### PR TITLE
SPARK-1135: fix broken anchors in docs

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -1,26 +1,3 @@
-
-// From docs.scala-lang.org
-function styleCode() {
-  if (typeof disableStyleCode != "undefined") {
-    return;
-  }
-  $(".codetabs pre code").parent().each(function() {
-    if (!$(this).hasClass("prettyprint")) {
-      var lang = $(this).parent().data("lang");
-      if (lang == "python") {
-        lang = "py"
-      }
-      if (lang == "bash") {
-        lang = "bsh"
-      }
-      $(this).addClass("prettyprint lang-"+lang+" linenums");
-    }
-  });
-  console.log("runningPrettyPrint()")
-  prettyPrint();
-}
-
-
 function codeTabs() {
   var counter = 0;
   var langImages = {
@@ -97,11 +74,7 @@ function viewSolution() {
 }
 
 
-$(document).ready(function() {
+$(function() {
   codeTabs();
   viewSolution();
-  $('#chapter-toc').toc({exclude: '', context: '.container'});
-  $('#chapter-toc').prepend('<p class="chapter-toc-header">In This Chapter</p>');
-  makeCollapsable($('#global-toc'), "", "global-toc", "Show Table of Contents");
-  //styleCode();
 });


### PR DESCRIPTION
A recent PR that added Java vs Scala tabs for streaming also
inadvertently added some bad code to a document.ready handler, breaking
our other handler that manages scrolling to anchors correctly with the
floating top bar. As a result the section title ended up always being
hidden below the top bar. This removes the unnecessary JavaScript code.
