### PR TITLE
[SPARK-979] a LRU scheduler for load balancing in TaskSchedulerImpl

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/WorkerOffer.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/WorkerOffer.scala
@@ -21,4 +21,4 @@ package org.apache.spark.scheduler
  * Represents free resources available on an executor.
  */
 private[spark]
-class WorkerOffer(val executorId: String, val host: String, val cores: Int)
+class WorkerOffer(val executorId: String, val host: String, var cores: Int)

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
@@ -202,10 +202,9 @@ private[spark] class MesosSchedulerBackend(
             offer.getHostname,
             getResource(offer.getResourcesList, "cpus").toInt)
         }
-
-        // Call into the TaskSchedulerImpl
-        val taskLists = scheduler.resourceOffers(offerableWorkers)
-
+        // Call into the ClusterScheduler
+        val taskLists = scheduler.resourceOffers(
+          TaskSchedulerImpl.buildMapFromWorkerOffers(scheduler, offerableWorkers))
         // Build a list of Mesos tasks for each slave
         val mesosTasks = offers.map(o => Collections.emptyList[MesosTaskInfo]())
         for ((taskList, index) <- taskLists.zipWithIndex) {

--- a/core/src/main/scala/org/apache/spark/scheduler/local/LocalBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/local/LocalBackend.scala
@@ -67,7 +67,8 @@ private[spark] class LocalActor(
 
   def reviveOffers() {
     val offers = Seq(new WorkerOffer(localExecutorId, localExecutorHostname, freeCores))
-    for (task <- scheduler.resourceOffers(offers).flatten) {
+    for (task <- scheduler.resourceOffers(
+      TaskSchedulerImpl.buildMapFromWorkerOffers(scheduler, offers)).flatten) {
       freeCores -= 1
       executor.launchTask(executorBackend, task.taskId, task.serializedTask)
     }

--- a/core/src/main/scala/org/apache/spark/util/collection/LRUMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/LRUMap.scala
@@ -1,0 +1,15 @@
+package org.apache.spark.util.collection
+
+import scala.collection.mutable
+import java.util
+import scala.collection.convert.Wrappers
+import org.apache.commons.collections.map.{LRUMap => JLRUMap}
+
+class LRUMap[K, V](maxSize: Int, underlying: util.Map[K, V]) extends Wrappers.JMapWrapper(underlying) {
+
+  def this(maxSize: Int) = this(maxSize, new JLRUMap(maxSize).asInstanceOf[util.Map[K, V]])
+}
+
+
+class LRUSyncMap[K, V](maxSize: Int, underlying: util.Map[K, V])
+  extends LRUMap[K, V](maxSize, underlying: util.Map[K, V]) with mutable.SynchronizedMap[K, V]

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -25,6 +25,7 @@ import org.scalatest.FunSuite
 import org.apache.spark._
 import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.util.FakeClock
+import org.apache.spark.util.collection.LRUMap
 
 class FakeDAGScheduler(taskScheduler: FakeTaskScheduler) extends DAGScheduler(taskScheduler) {
   override def taskStarted(task: Task[_], taskInfo: TaskInfo) {
@@ -296,6 +297,32 @@ class TaskSetManagerSuite extends FunSuite with LocalSparkContext with Logging {
         assert(sched.taskSetsFailed.contains(taskSet.id))
       }
     }
+  }
+
+  test ("executors should be scheduled with LRU order when the feature is enabled") {
+    sc = new SparkContext("local", "test")
+    val sched = new FakeClusterScheduler(sc,
+      ("exec1", "host1"), ("exec2", "host2"), ("exec3", "host3"))
+    sched.rootPool = new Pool("", sched.schedulingMode, 0, 0)
+    sched.schedulableBuilder = new FIFOSchedulableBuilder(sched.rootPool)
+    val executorWorkerOffer = new LRUMap[String, WorkerOffer](3)
+    executorWorkerOffer += "exec1" -> new WorkerOffer("exec1", "host1", 8)
+    executorWorkerOffer += "exec2" -> new WorkerOffer("exec2", "host2", 8)
+    executorWorkerOffer += "exec3" -> new WorkerOffer("exec3", "host3", 8)
+    val taskSet1 = createTaskSet(1)
+    val taskSet2 = createTaskSet(1)
+    val taskSet3 = createTaskSet(1)
+    val clock = new FakeClock
+    val manager1 = new TaskSetManager(sched, taskSet1, MAX_TASK_FAILURES, clock)
+    val manager2 = new TaskSetManager(sched, taskSet2, MAX_TASK_FAILURES, clock)
+    val manager3 = new TaskSetManager(sched, taskSet3, MAX_TASK_FAILURES, clock)
+    sched.schedulableBuilder.addTaskSetManager(manager1, manager1.taskSet.properties)
+    sched.schedulableBuilder.addTaskSetManager(manager2, manager2.taskSet.properties)
+    sched.schedulableBuilder.addTaskSetManager(manager3, manager3.taskSet.properties)
+    sched.resourceOffers(executorWorkerOffer)
+    assert(sched.taskIdToExecutorId.values.toList(0) == "exec3")
+    assert(sched.taskIdToExecutorId.values.toList(1) == "exec2")
+    assert(sched.taskIdToExecutorId.values.toList(2) == "exec1")
   }
 
 

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -301,7 +301,7 @@ class TaskSetManagerSuite extends FunSuite with LocalSparkContext with Logging {
 
   test ("executors should be scheduled with LRU order when the feature is enabled") {
     sc = new SparkContext("local", "test")
-    val sched = new FakeClusterScheduler(sc,
+    val sched = new FakeTaskScheduler(sc,
       ("exec1", "host1"), ("exec2", "host2"), ("exec3", "host3"))
     sched.rootPool = new Pool("", sched.schedulingMode, 0, 0)
     sched.schedulableBuilder = new FIFOSchedulableBuilder(sched.rootPool)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -200,6 +200,14 @@ Apart from these, the following properties are also available, and may be useful
     to use fair sharing instead of queueing jobs one after another. Useful for
     multi-user services.
   </td>
+  </tr>
+<tr>
+  <td>spark.scheduler.lruOffer</td>
+  <td>false</td>
+  <td>
+    offer resources to the application in LRU order. If set to false, the tasks may be padded into just a few
+    nodes, if true, then the executors will be scheduled in LRU order
+  </td>
 </tr>
 <tr>
   <td>spark.reducer.maxMbInFlight</td>


### PR DESCRIPTION
this PR is for SPARK-979(https://spark-project.atlassian.net/browse/SPARK-979), where @rxin pointed out that the Spark Scheduler is very deterministic.

the main changes include

Add a LRUMap in util package (based on org.apache.commons.collections.map.LRUMap , its implementation is pretty neat, it implements LRU with a double linked list, and it does not need to really move data, but just changes the pointers)

remove freeCores in CoarseGrainedSchedulerBackend.scala and save WorkerOffer in a LRUMap/HashMap(Configurable) to avoid new operation everytime

change the implementation of resourceOffers in TaskSchedulerImpl. Now it takes a Map as input and balances the load with LRU principle (LRU scheduling is configurable, if user does not want this feature (by default), then we will pass a HashMap to resourceOffers, otherwise, we will pass a LRUMap)

For clarification, in the code, I give an initial size 1000 to LRUMap, which will not impose the limitation on the max number of executors each application can use. I double checked the implementation of commons.collections, it turns out that when the map is full, the implementation will automatically double-size the original map until there are 1<<30 elements (in practice, we will not have so many executors to use)
