### PR TITLE
SPARK-1039: Set the upper bound for retry times of in-cluster drivers

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
@@ -55,7 +55,7 @@ private[deploy] object DeployMessages {
     extends DeployMessage
 
   case class DriverStateChanged(
-      driverId: String,
+      driverID: String,
       state: DriverState,
       exception: Option[Exception])
     extends DeployMessage

--- a/core/src/main/scala/org/apache/spark/deploy/master/DriverInfo.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/DriverInfo.scala
@@ -33,4 +33,9 @@ private[spark] class DriverInfo(
   @transient var exception: Option[Exception] = None
   /* Most recent worker assigned to this driver */
   @transient var worker: Option[WorkerInfo] = None
+
+  /**
+   * the retry times of starting a in-cluster driver
+   */
+  @transient var retriedcountOnMaster = 0
 }

--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -265,7 +265,7 @@ private[spark] class Worker(
 
     case LaunchDriver(driverId, driverDesc) => {
       logInfo(s"Asked to launch driver $driverId")
-      val driver = new DriverRunner(driverId, workDir, sparkHome, driverDesc, self, akkaUrl)
+      val driver = new DriverRunner(driverId, driverDesc, workDir, sparkHome, self, akkaUrl, conf)
       drivers(driverId) = driver
       driver.start()
 
@@ -286,11 +286,11 @@ private[spark] class Worker(
     case DriverStateChanged(driverId, state, exception) => {
       state match {
         case DriverState.ERROR =>
-          logWarning(s"Driver $driverId failed with unrecoverable exception: ${exception.get}")
+          logWarning(s"Driver ${driverId} failed with unrecoverable exception: ${exception.get}")
         case DriverState.FINISHED =>
-          logInfo(s"Driver $driverId exited successfully")
+          logInfo(s"Driver ${driverId} exited successfully")
         case DriverState.KILLED =>
-          logInfo(s"Driver $driverId was killed by user")
+          logInfo(s"Driver ${driverId} was killed by user")
       }
       masterLock.synchronized {
         master ! DriverStateChanged(driverId, state, exception)

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ui/IndexPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ui/IndexPage.scala
@@ -22,7 +22,7 @@ import scala.xml.Node
 
 import akka.pattern.ask
 import javax.servlet.http.HttpServletRequest
-import org.json4s.JValue
+import net.liftweb.json.JsonAST.JValue
 
 import org.apache.spark.deploy.JsonProtocol
 import org.apache.spark.deploy.DeployMessages.{RequestWorkerState, WorkerStateResponse}
@@ -144,7 +144,7 @@ private[spark] class IndexPage(parent: WorkerWebUI) {
 
   def driverRow(driver: DriverRunner): Seq[Node] = {
     <tr>
-      <td>{driver.driverId}</td>
+      <td>{driver.driverDesc}</td>
       <td>{driver.driverDesc.command.arguments(1)}</td>
       <td>{driver.finalState.getOrElse(DriverState.RUNNING)}</td>
       <td sorttable_customkey={driver.driverDesc.cores.toString}>

--- a/core/src/test/scala/org/apache/spark/deploy/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/JsonProtocolSuite.scala
@@ -119,8 +119,8 @@ class JsonProtocolSuite extends FunSuite {
       new File("sparkHome"), new File("workDir"), "akka://worker", ExecutorState.RUNNING)
   }
   def createDriverRunner(): DriverRunner = {
-    new DriverRunner("driverId", new File("workDir"), new File("sparkHome"), createDriverDesc(),
-      null, "akka://worker")
+    new DriverRunner("driverId", createDriverDesc(), new File("workDir"), new File("sparkHome"),
+      null, "akka://worker", null)
   }
 
   def assertValidJson(json: JValue) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -408,6 +408,13 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+  <td>spark.driver.maxRetry</td>
+  <td>0</td>
+  <td>
+    Maximum retry times for in-cluster driver. Default - 0, the driver will be retried on every worker before it is killed.
+  </td>
+</tr>
+<tr>
   <td>spark.cleaner.ttl</td>
   <td>(infinite)</td>
   <td>


### PR DESCRIPTION
The main change is to add a configurable parameter spark.driver.maxretrynum which limits the retry times when the in-cluster driver program fails to start,

in the current implementation, the in-cluster driver will fall into a dead loop when it fails to start unless the user kill it manually

in DriverRunner.scala: keepTrying = supervise && exitCode != 0 && !killed

With this PR

In the worker, if the driver has tried for spark.driver.maxretrynum times and still failed to run, the master will receive the notification (DriverStateChanged)

If the driver state is ERROR or FAILED, and the driver still has chance to run on another worker (i.e. if the retry number hasn't been over the number of workers or configured maxretrynum), the driver will be relaunched to the other worker

In this implementation, the updated retry number of the driver is not written to the file by persistenceEngine (to avoid too many IO operations). Also the structure recording which workers the driver has been assigned to is also ignored by persistenceEngine

The description of the implementation:

set two-level upper limit on retry number: master & worker, both of which are specified by spark.driver.maxRetry. The most obvious benefit of setting such a limit is to kill a failed driver earlier to save memory and cpu cores.

master-side limit is in driverInfo.retriedcountOnMaster, which is a transient variable. worker-side limit is a local variable in DriverRunner

in master-side, the default value of spark.driver.maxRetry is 0, in this case, the driver will be restarted in at most "workers.size" times, otherwise the driver will be restarted for MIN(maxRetry, workers.size) times; in worker-side, the default value of spark.driver.maxRetry is 0, in this case, the driver will be tried for ONLY ONCE (I changed the design to this because I think moving a driver to a new worker may have larger probability to run it successfully, e.g. some misconfigured env variable may be correct on other machines or memory may be larger there, etc.), otherwise, the driver will be restarted for maxRetry times

DriverInfo will not be serialized to worker, i.e. returning back to the before-PR implementation of the relevant DeployMessages
