### PR TITLE
[SPARK-1089] fix the regression problem on ADD_JARS in 0.9

### DIFF
--- a/repl/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -183,7 +183,7 @@ class SparkILoop(in0: Option[BufferedReader], protected val out: JPrintWriter,
   /** Create a new interpreter. */
   def createInterpreter() {
     if (settings != null) {
-      if (addedClasspath != "") settings.classpath append addedClasspath
+      if (addedClasspath != "") settings.classpath.append(addedClasspath)
 
       // work around for Scala bug
       val totalClassPath = SparkILoop.getAddedJars.foldLeft(

--- a/repl/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -183,8 +183,7 @@ class SparkILoop(in0: Option[BufferedReader], protected val out: JPrintWriter,
   /** Create a new interpreter. */
   def createInterpreter() {
     if (settings != null) {
-      if (addedClasspath != "")
-        settings.classpath append addedClasspath
+      if (addedClasspath != "") settings.classpath append addedClasspath
 
       // work around for Scala bug
       val totalClassPath = SparkILoop.getAddedJars.foldLeft(

--- a/repl/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -182,10 +182,17 @@ class SparkILoop(in0: Option[BufferedReader], protected val out: JPrintWriter,
 
   /** Create a new interpreter. */
   def createInterpreter() {
-    if (addedClasspath != "")
-      settings.classpath append addedClasspath
+    if (settings != null) {
+      if (addedClasspath != "")
+        settings.classpath append addedClasspath
 
-    intp = new SparkILoopInterpreter
+      // work around for Scala bug
+      val totalClassPath = SparkILoop.getAddedJars.foldLeft(
+        settings.classpath.value)((l, r) => ClassPath.join(l, r))
+      this.settings.classpath.value = totalClassPath
+
+      intp = new SparkILoopInterpreter
+    }
   }
 
   /** print a friendly help message */

--- a/repl/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -182,16 +182,15 @@ class SparkILoop(in0: Option[BufferedReader], protected val out: JPrintWriter,
 
   /** Create a new interpreter. */
   def createInterpreter() {
-    if (settings != null) {
-      if (addedClasspath != "") settings.classpath.append(addedClasspath)
+    require(settings != null)
 
-      // work around for Scala bug
-      val totalClassPath = SparkILoop.getAddedJars.foldLeft(
-        settings.classpath.value)((l, r) => ClassPath.join(l, r))
-      this.settings.classpath.value = totalClassPath
+    if (addedClasspath != "") settings.classpath.append(addedClasspath)
+    // work around for Scala bug
+    val totalClassPath = SparkILoop.getAddedJars.foldLeft(
+      settings.classpath.value)((l, r) => ClassPath.join(l, r))
+    this.settings.classpath.value = totalClassPath
 
-      intp = new SparkILoopInterpreter
-    }
+    intp = new SparkILoopInterpreter
   }
 
   /** print a friendly help message */


### PR DESCRIPTION
https://spark-project.atlassian.net/browse/SPARK-1089

copied from JIRA, reported by @ash211

"Using the ADD_JARS environment variable with spark-shell used to add the jar to both the shell and the various workers. Now it only adds to the workers and importing a custom class in the shell is broken.
The workaround is to add custom jars to both ADD_JARS and SPARK_CLASSPATH.
We should fix ADD_JARS so it works properly again.
See various threads on the user list:
https://mail-archives.apache.org/mod_mbox/incubator-spark-user/201402.mbox/%3CCAJbo4neMLiTrnm1XbyqomWmp0m+EUcg4yE-txuRGSVKOb5KLeA@mail.gmail.com%3E
(another one that doesn't appear in the archives yet titled "ADD_JARS not working on 0.9")"

The reason of this bug is two-folds

in the current implementation of SparkILoop.scala, the settings.classpath is not set properly when the process() method is invoked

the weird behaviour of Scala 2.10, (I personally thought it is a bug)

if we simply set value of a PathSettings object (like settings.classpath), the isDefault is not set to true (this is a flag showing if the variable is modified), so it makes the PathResolver loads the default CLASSPATH environment variable value to calculated the path (see https://github.com/scala/scala/blob/2.10.x/src/compiler/scala/tools/util/PathResolver.scala#L215)

what we have to do is to manually make this flag set, (https://github.com/CodingCat/incubator-spark/blob/e3991d97ddc33e77645e4559b13bf78b9e68239a/repl/src/main/scala/org/apache/spark/repl/SparkILoop.scala#L884)
