### PR TITLE
SPARK-1125: The maven build error for Spark Examples

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -33,6 +33,17 @@
 
   <repositories>
     <repository>
+      <id>mqtt-repo</id>
+      <name>MQTT Repository</name>
+      <url>https://repo.eclipse.org/content/repositories/paho-releases</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+    <repository>
       <id>apache-repo</id>
       <name>Apache Repository</name>
       <url>https://repository.apache.org/content/repositories/releases</url>


### PR DESCRIPTION
building with maven, throw Failure to find org.eclipse.paho:mqtt-client:jar:0.4.0 in https://repository.apache.org/content/repositories/releases was cached in the local repository, resolution will not be reattempted until the update interval of apache-repo has elapsed or updates are forced
