### PR TITLE
[HOTFIX] Patching maven build after #6 (SPARK-1121).

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -47,14 +47,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.avro</groupId>
-            <artifactId>avro</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.avro</groupId>
-            <artifactId>avro-ipc</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-recipes</artifactId>
         </dependency>


### PR DESCRIPTION
That patch removed the Maven avro declaration but didn't remove the
actual dependency in core. /cc @scrapcodes
