### PR TITLE
remove "sbt/" prefix in $JAR variable make the script pass if test

### DIFF
--- a/sbt/sbt
+++ b/sbt/sbt
@@ -23,7 +23,7 @@
 SBT_VERSION=`awk -F "=" '/sbt\\.version/ {print $2}' ./project/build.properties`
 URL1=http://typesafe.artifactoryonline.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch.jar
 URL2=http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch.jar
-JAR=sbt/sbt-launch-${SBT_VERSION}.jar
+JAR=sbt-launch-${SBT_VERSION}.jar
 
 # Download sbt launch jar if it hasn't been downloaded yet
 if [ ! -f ${JAR} ]; then


### PR DESCRIPTION
There is no sbt/ dir under sbt/sbt. "if" test on line 29 can not pass.

remove "sbt/" prefix in $JAR variable make the script pass if test
