### PR TITLE
Ignore RateLimitedOutputStreamSuite for now.

### DIFF
--- a/streaming/src/test/scala/org/apache/spark/streaming/util/RateLimitedOutputStreamSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/util/RateLimitedOutputStreamSuite.scala
@@ -29,7 +29,7 @@ class RateLimitedOutputStreamSuite extends FunSuite {
     System.nanoTime - start
   }
 
-  test("write") {
+  ignore("write") {
     val underlying = new ByteArrayOutputStream
     val data = "X" * 41000
     val stream = new RateLimitedOutputStream(underlying, 10000)


### PR DESCRIPTION
This test has been flaky. We can re-enable it after @tdas has a chance to look at it.
