### PR TITLE
SPARK-782. Shade ASM

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -269,6 +269,37 @@
                     </environmentVariables>
                 </configuration>
             </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-shade-plugin</artifactId>
+              <version>2.0</version>
+              <executions>
+                <execution>
+                  <phase>package</phase>
+                  <goals>
+                    <goal>shade</goal>
+                  </goals>
+                  <configuration>
+                    <relocations>
+                      <relocation>
+                        <pattern>org.objectweb.asm</pattern>
+                        <shadedPattern>shaded.org.objectweb.asm</shadedPattern>
+                      </relocation>
+                    </relocations>
+                    <filters>
+                      <filter>
+                        <artifact>*:*</artifact>
+                        <excludes>
+                          <exclude>META-INF/*.SF</exclude>
+                          <exclude>META-INF/*.DSA</exclude>
+                          <exclude>META-INF/*.RSA</exclude>
+                        </excludes>
+                      </filter>
+                    </filters>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -283,7 +283,7 @@
                     <relocations>
                       <relocation>
                         <pattern>org.objectweb.asm</pattern>
-                        <shadedPattern>shaded.org.objectweb.asm</shadedPattern>
+                        <shadedPattern>org.apache.spark.shaded.org.objectweb.asm</shadedPattern>
                       </relocation>
                     </relocations>
                     <filters>

--- a/core/src/main/scala/org/apache/spark/util/BytecodeUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/BytecodeUtils.scala
@@ -15,13 +15,11 @@
  * limitations under the License.
  */
 
-package org.apache.spark.graphx.util
+package org.apache.spark.util
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 
 import scala.collection.mutable.HashSet
-
-import org.apache.spark.util.Utils
 
 import org.objectweb.asm.{ClassReader, ClassVisitor, MethodVisitor}
 import org.objectweb.asm.Opcodes._
@@ -31,7 +29,7 @@ import org.objectweb.asm.Opcodes._
  * Includes an utility function to test whether a function accesses a specific attribute
  * of an object.
  */
-private[graphx] object BytecodeUtils {
+private[spark] object BytecodeUtils {
 
   /**
    * Test whether the given closure invokes the specified method in the specified class.

--- a/core/src/test/scala/org/apache/spark/util/BytecodeUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/BytecodeUtilsSuite.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.spark.graphx.util
+package org.apache.spark.util
 
 import org.scalatest.FunSuite
 

--- a/graphx/pom.xml
+++ b/graphx/pom.xml
@@ -70,6 +70,10 @@
       <artifactId>scalacheck_${scala.binary.version}</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
@@ -78,6 +82,37 @@
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <relocations>
+                <relocation>
+                  <pattern>org.objectweb.asm</pattern>
+                  <shadedPattern>shaded.org.objectweb.asm</shadedPattern>
+                </relocation>
+              </relocations>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/graphx/pom.xml
+++ b/graphx/pom.xml
@@ -70,10 +70,6 @@
       <artifactId>scalacheck_${scala.binary.version}</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.ow2.asm</groupId>
-      <artifactId>asm</artifactId>
-    </dependency>
   </dependencies>
   <build>
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
@@ -82,37 +78,6 @@
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>2.0</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <relocations>
-                <relocation>
-                  <pattern>org.objectweb.asm</pattern>
-                  <shadedPattern>shaded.org.objectweb.asm</shadedPattern>
-                </relocation>
-              </relocations>
-              <filters>
-                <filter>
-                  <artifact>*:*</artifact>
-                  <excludes>
-                    <exclude>META-INF/*.SF</exclude>
-                    <exclude>META-INF/*.DSA</exclude>
-                    <exclude>META-INF/*.RSA</exclude>
-                  </excludes>
-                </filter>
-              </filters>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/graphx/src/main/scala/org/apache/spark/graphx/impl/GraphImpl.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/impl/GraphImpl.scala
@@ -25,7 +25,7 @@ import org.apache.spark.SparkContext._
 import org.apache.spark.graphx._
 import org.apache.spark.graphx.impl.GraphImpl._
 import org.apache.spark.graphx.impl.MsgRDDFunctions._
-import org.apache.spark.graphx.util.BytecodeUtils
+import org.apache.spark.util.BytecodeUtils
 import org.apache.spark.rdd.{ShuffledRDD, RDD}
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util.ClosureCleaner

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -158,7 +158,7 @@
               <relocations>
                 <relocation>
                   <pattern>org.objectweb.asm</pattern>
-                  <shadedPattern>shaded.org.objectweb.asm</shadedPattern>
+                  <shadedPattern>org.apache.spark.shaded.org.objectweb.asm</shadedPattern>
                 </relocation>
               </relocations>
               <filters>

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -96,6 +96,10 @@
       <artifactId>scalacheck_${scala.binary.version}</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
@@ -139,6 +143,37 @@
             <SPARK_TESTING>1</SPARK_TESTING>
           </environmentVariables>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <relocations>
+                <relocation>
+                  <pattern>org.objectweb.asm</pattern>
+                  <shadedPattern>shaded.org.objectweb.asm</shadedPattern>
+                </relocation>
+              </relocations>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
This solves the issue of Spark's version of ASM conflicting with the ASM versions of its transitive dependencies (e.g. Hadoop).  The ASM packages, with their package names modified (shaded), become included in jars of the submodules that rely on ASM.  This also occurs for the assembly jar. 

I couldn't figure out a way to do this with sbt.  I considered adding this as a profile, but couldn't think of a situation where it would be beneficial to turn it off. 
