### PR TITLE
[SPARK-1194] Fix the same-RDD rule for cache replacement

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/MemoryStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/MemoryStore.scala
@@ -236,14 +236,6 @@ private class MemoryStore(blockManager: BlockManager, maxMemory: Long)
         while (maxMemory - (currentMemory - selectedMemory) < space && iterator.hasNext) {
           val pair = iterator.next()
           val blockId = pair.getKey
-          // Apply the same-RDD rule for cache replacement. Quoted from the
-          // original RDD paper:
-          //
-          //    When a new RDD partition is computed but there is not enough
-          //    space to store it, we evict a partition from the least recently
-          //    accessed RDD, unless this is the same RDD as the one with the
-          //    new partition. In that case, we keep the old partition in memory
-          //    to prevent cycling partitions from the same RDD in and out.
           if (rddToAdd.isEmpty || rddToAdd != getRddId(blockId)) {
             selectedBlocks += blockId
             selectedMemory += pair.getValue.size

--- a/core/src/main/scala/org/apache/spark/storage/MemoryStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/MemoryStore.scala
@@ -244,14 +244,9 @@ private class MemoryStore(blockManager: BlockManager, maxMemory: Long)
           //    accessed RDD, unless this is the same RDD as the one with the
           //    new partition. In that case, we keep the old partition in memory
           //    to prevent cycling partitions from the same RDD in and out.
-          //
-          // TODO implement LRU eviction
-          rddToAdd match {
-            case Some(rddId) if rddId == getRddId(blockId) =>
-              // no-op
-            case _ =>
-              selectedBlocks += blockId
-              selectedMemory += pair.getValue.size
+          if (rddToAdd.isEmpty || rddToAdd != getRddId(blockId)) {
+            selectedBlocks += blockId
+            selectedMemory += pair.getValue.size
           }
         }
       }
@@ -274,6 +269,8 @@ private class MemoryStore(blockManager: BlockManager, maxMemory: Long)
         }
         return true
       } else {
+        logInfo(s"Will not store $blockIdToAdd as it would require dropping another block " +
+          "from the same RDD")
         return false
       }
     }

--- a/core/src/main/scala/org/apache/spark/storage/MemoryStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/MemoryStore.scala
@@ -236,13 +236,23 @@ private class MemoryStore(blockManager: BlockManager, maxMemory: Long)
         while (maxMemory - (currentMemory - selectedMemory) < space && iterator.hasNext) {
           val pair = iterator.next()
           val blockId = pair.getKey
-          if (rddToAdd.isDefined && rddToAdd == getRddId(blockId)) {
-            logInfo("Will not store " + blockIdToAdd + " as it would require dropping another " +
-              "block from the same RDD")
-            return false
+          // Apply the same-RDD rule for cache replacement. Quoted from the
+          // original RDD paper:
+          //
+          //    When a new RDD partition is computed but there is not enough
+          //    space to store it, we evict a partition from the least recently
+          //    accessed RDD, unless this is the same RDD as the one with the
+          //    new partition. In that case, we keep the old partition in memory
+          //    to prevent cycling partitions from the same RDD in and out.
+          //
+          // TODO implement LRU eviction
+          rddToAdd match {
+            case Some(rddId) if rddId == getRddId(blockId) =>
+              // no-op
+            case _ =>
+              selectedBlocks += blockId
+              selectedMemory += pair.getValue.size
           }
-          selectedBlocks += blockId
-          selectedMemory += pair.getValue.size
         }
       }
 


### PR DESCRIPTION
SPARK-1194: https://spark-project.atlassian.net/browse/SPARK-1194

In the current implementation, when selecting candidate blocks to be swapped out, once we find a block from the same RDD that the block to be stored belongs to, cache eviction fails  and aborts.

In this PR, we keep selecting blocks _not_ from the RDD that the block to be stored belongs to until either enough free space can be ensured (cache eviction succeeds) or all such blocks are checked (cache eviction fails).
