### PR TITLE
Ability to initialize Spark-Shell with command script

### DIFF
--- a/repl/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -910,6 +910,7 @@ class SparkILoop(in0: Option[BufferedReader], protected val out: JPrintWriter,
 
     addThunk(printWelcome())
     addThunk(initializeSpark())
+    addThunk(runShellRC())
 
     // it is broken on startup; go ahead and exit
     if (intp.reporter.hasErrors)
@@ -956,6 +957,17 @@ class SparkILoop(in0: Option[BufferedReader], protected val out: JPrintWriter,
     sparkContext = new SparkContext(conf)
     logInfo("Created spark context..")
     sparkContext
+  }
+
+  def runShellRC() {
+    if (System.getenv("SPARKSHELL_RC") != null) {
+      loadCommand(System.getenv("SPARKSHELL_RC"))
+    } else {
+      val rc_file = File(System.getProperty("user.home"))/".spark_shell_rc"
+      if (rc_file.exists) {
+        loadCommand(rc_file.toString())
+      }
+    }
   }
 
   private def getMaster(): String = {

--- a/repl/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -960,8 +960,8 @@ class SparkILoop(in0: Option[BufferedReader], protected val out: JPrintWriter,
   }
 
   def runShellRC() {
-    if (System.getenv("SPARKSHELL_RC") != null) {
-      loadCommand(System.getenv("SPARKSHELL_RC"))
+    if (System.getenv("SPARK_SHELL_RC") != null) {
+      loadCommand(System.getenv("SPARK_SHELL_RC"))
     } else {
       val rc_file = File(System.getProperty("user.home"))/".spark_shell_rc"
       if (rc_file.exists) {


### PR DESCRIPTION
This script allows a user to define a script file with code that will be executed when then spark-shell starts up.
This initialization script file can be set either by setting the SPARK_SHELL_RC environmental variable to the path, or by placing a file at $HOME/.spark_shell_rc (the environmental variable takes precedence over the home directory file)

There are two main usage scenarios:
1) The user has a set of commands they want run automatically whenever they open spark-shell
2) Other software packages that depend on spark, and want to provide easy access to their code in a way similar to spark-shell, can provide a wrapper shell for spark-shell that adds the tool jars with ADD_JARS and then executes an initialization with SPARK_SHELL_RC to do all the import calls and variable initialization. 
