### PR TITLE
[SPARK-1237, 1238] Improve the computation of YtY for implicit ALS

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
@@ -237,9 +237,8 @@ class ALS private (
   }
 
   /**
-   * Adding x * x.t to a matrix, the same as BLAS's DSPR.
+   * Adds alpha * x * x.t to a matrix in-place. This is the same as BLAS's DSPR.
    *
-   * @param x a vector of length n
    * @param L the lower triangular part of the matrix packed in an array (row major)
    */
   private def dspr(alpha: Double, x: DoubleMatrix, L: DoubleMatrix) = {

--- a/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
@@ -137,6 +137,7 @@ class ALS private (
     this
   }
 
+  /** Sets a random seed to have deterministic results. */
   def setSeed(seed: Long): ALS = {
     this.seed = seed
     this
@@ -419,14 +420,12 @@ class ALS private (
           implicitPrefs match {
             case false =>
               userXtX(us(i)).addi(tempXtX)
-              // dspr(1.0, x, userXtX(us(i)))
               SimpleBlas.axpy(rs(i), x, userXy(us(i)))
             case true =>
               // Extension to the original paper to handle rs(i) < 0. confidence is a function
               // of |rs(i)| instead so that it is never negative:
               val confidence = 1 + alpha * abs(rs(i))
               SimpleBlas.axpy(confidence - 1.0, tempXtX, userXtX(us(i)))
-              // dspr(confidence - 1.0, x, userXtX(us(i)))
               // For rs(i) < 0, the corresponding entry in P is 0 now, not 1 -- negative rs(i)
               // means we try to reconstruct 0. We add terms only where P = 1, so, term below
               // is now only added for rs(i) > 0:

--- a/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
@@ -438,15 +438,15 @@ class ALS private (
     }
 
     // Solve the least-squares problem for each user and return the new feature vectors
-    userXtX.zip(userXy).map { case (triangularXtX, rhs) =>
+    Array.range(0, numUsers).map { index =>
       // Compute the full XtX matrix from the lower-triangular part we got above
-      fillFullMatrix(triangularXtX, fullXtX)
+      fillFullMatrix(userXtX(index), fullXtX)
       // Add regularization
       (0 until rank).foreach(i => fullXtX.data(i*rank + i) += lambda)
       // Solve the resulting matrix, which is symmetric and positive-definite
       implicitPrefs match {
-        case false => Solve.solvePositive(fullXtX, rhs).data
-        case true => Solve.solvePositive(fullXtX.addi(YtY.value.get), rhs).data
+        case false => Solve.solvePositive(fullXtX, userXy(index)).data
+        case true => Solve.solvePositive(fullXtX.addi(YtY.value.get), userXy(index)).data
       }
     }
   }

--- a/mllib/src/test/scala/org/apache/spark/mllib/recommendation/ALSSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/recommendation/ALSSuite.scala
@@ -25,6 +25,7 @@ import org.scalatest.FunSuite
 
 import org.jblas._
 
+import org.apache.spark.SparkContext._
 import org.apache.spark.mllib.util.LocalSparkContext
 
 object ALSSuite {
@@ -113,6 +114,18 @@ class ALSSuite extends FunSuite with LocalSparkContext {
 
   test("rank-2 matrices implicit negative") {
     testALS(100, 200, 2, 15, 0.7, 0.4, true, false, true)
+  }
+
+  test("pseudorandomness") {
+    val ratings = sc.parallelize(ALSSuite.generateRatings(10, 20, 5, 0.5, false, false)._1, 2)
+    val model11 = ALS.train(ratings, 5, 1, 1.0, 2, 1)
+    val model12 = ALS.train(ratings, 5, 1, 1.0, 2, 1)
+    val u11 = model11.userFeatures.values.flatMap(_.toList).collect().toList
+    val u12 = model12.userFeatures.values.flatMap(_.toList).collect().toList
+    val model2 = ALS.train(ratings, 5, 1, 1.0, 2, 2)
+    val u2 = model2.userFeatures.values.flatMap(_.toList).collect().toList
+    assert(u11 == u12)
+    assert(u11 != u2)
   }
 
   /**

--- a/mllib/src/test/scala/org/apache/spark/mllib/recommendation/ALSSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/recommendation/ALSSuite.scala
@@ -23,10 +23,10 @@ import scala.util.Random
 
 import org.scalatest.FunSuite
 
-import org.jblas._
+import org.jblas.DoubleMatrix
 
-import org.apache.spark.SparkContext._
 import org.apache.spark.mllib.util.LocalSparkContext
+import org.apache.spark.SparkContext._
 
 object ALSSuite {
 


### PR DESCRIPTION
Computing YtY can be implemented using BLAS's DSPR operations instead of generating y_i y_i^T and then combining them. The latter generates many k-by-k matrices. On the movielens data, this change improves the performance by 10-20%. The algorithm remains the same, verified by computing RMSE on the movielens data.

To compare the results, I also added an option to set a random seed in ALS.

JIRA:
1. https://spark-project.atlassian.net/browse/SPARK-1237
2. https://spark-project.atlassian.net/browse/SPARK-1238
