### PR TITLE
[bugfix] wrong client arg, should use executor-cores

### DIFF
--- a/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
@@ -95,7 +95,7 @@ class ClientArguments(val args: Array[String], val sparkConf: SparkConf) {
           executorMemory = value
           args = tail
 
-        case ("--worker-cores" | "--executor-memory") :: IntParam(value) :: tail =>
+        case ("--worker-cores" | "--executor-cores") :: IntParam(value) :: tail =>
           if (args(0) == "--worker-cores") {
             println("--worker-cores is deprecated. Use --executor-cores instead.")
           }


### PR DESCRIPTION
client arg is wrong, it should be executor-cores. it causes executor fail to start when executor-cores is specified
