### PR TITLE
remove staging dir when app quiting for yarn-cluster mode

### DIFF
--- a/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/ClientBase.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/ClientBase.scala
@@ -273,7 +273,7 @@ trait ClientBase extends Logging {
 
     ClientBase.populateClasspath(yarnConf, sparkConf, log4jConfLocalRes != null, env)
     env("SPARK_YARN_MODE") = "true"
-    env("SPARK_YARN_STAGING_DIR") = stagingDir
+    env("SPARK_YARN_STAGING_DIR") = FileSystem.get(conf).getHomeDirectory() + Path.SEPARATOR + stagingDir
     env("SPARK_USER") = UserGroupInformation.getCurrentUser().getShortUserName()
 
     // Set the environment variables to be passed on to the executors.


### PR DESCRIPTION
In yarn-cluster, the driver is actually running as 'yarn' user. When
posting jobs from other users, we need give stagingDir a full path, so
the driver could remove the correct directory if needed.
