### PR TITLE
Update CommandUtils.scala

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/worker/CommandUtils.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/CommandUtils.scala
@@ -60,7 +60,14 @@ object CommandUtils extends Logging {
       Seq(sparkHome + "/bin/compute-classpath" + ext),
       extraEnvironment=command.environment)
 
-    Seq("-cp", classPath) ++ libraryOpts ++ workerLocalOpts ++ userOpts ++ memoryOpts
+    val debugflage = System.getProperty("spark.excutor.debug", "0").toInt
+    if (debugflage==0) {
+      Seq("-cp", classPath) ++ libraryOpts ++ workerLocalOpts ++ userOpts ++ memoryOpts
+    }
+    else {
+      val debugInfo = "-Xrunjdwp:transport=dt_socket,address=" +System.getProperty("spark.excutor.debug.port", "18000") +",server=y,suspend=y"
+      Seq("-Xdebug",debugInfo, "-cp", classPath) ++ libraryOpts ++ workerLocalOpts ++ userOpts ++ memoryOpts
+    }
   }
 
   /** Spawn a thread that will redirect a given stream to a file */

--- a/core/src/main/scala/org/apache/spark/deploy/worker/CommandUtils.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/CommandUtils.scala
@@ -60,8 +60,8 @@ object CommandUtils extends Logging {
       Seq(sparkHome + "/bin/compute-classpath" + ext),
       extraEnvironment=command.environment)
 
-    val debugflage = System.getProperty("spark.excutor.debug", "0").toInt
-    if (debugflage==0) {
+    val debugflag = System.getProperty("spark.excutor.debug", "0").toInt
+    if (debugflag==0) {
       Seq("-cp", classPath) ++ libraryOpts ++ workerLocalOpts ++ userOpts ++ memoryOpts
     }
     else {

--- a/core/src/main/scala/org/apache/spark/deploy/worker/CommandUtils.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/CommandUtils.scala
@@ -60,8 +60,8 @@ object CommandUtils extends Logging {
       Seq(sparkHome + "/bin/compute-classpath" + ext),
       extraEnvironment=command.environment)
 
-    val debugflag = System.getProperty("spark.excutor.debug", "0").toInt
-    if (debugflag==0) {
+    val debugflag = System.getProperty("spark.excutor.debug", "0").toBoolean
+    if (!debugflag) {
       Seq("-cp", classPath) ++ libraryOpts ++ workerLocalOpts ++ userOpts ++ memoryOpts
     }
     else {

--- a/core/src/main/scala/org/apache/spark/deploy/worker/CommandUtils.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/CommandUtils.scala
@@ -60,7 +60,7 @@ object CommandUtils extends Logging {
       Seq(sparkHome + "/bin/compute-classpath" + ext),
       extraEnvironment=command.environment)
 
-    val debugflag = System.getProperty("spark.excutor.debug", "0").toBoolean
+    val debugflag = System.getProperty("spark.excutor.debug", "false").toBoolean
     if (!debugflag) {
       Seq("-cp", classPath) ++ libraryOpts ++ workerLocalOpts ++ userOpts ++ memoryOpts
     }

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -81,3 +81,7 @@ can provide fine-grained profiling on individual nodes.
 * JVM utilities such as `jstack` for providing stack traces, `jmap` for creating heap-dumps, 
 `jstat` for reporting time-series statistics and `jconsole` for visually exploring various JVM 
 properties are useful for those comfortable with JVM internals.
+
+#debug the Excutor process
+
+Since the excutor process is started by ProcessBuilder, if we wang to trace the code, we can modify the CommandUtils.scala, add the option for remote-debugging. please refer https://github.com/apache/spark/pull/157

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -84,4 +84,4 @@ properties are useful for those comfortable with JVM internals.
 
 #debug the Excutor process
 
-Since the excutor process is started by ProcessBuilder, if we wang to trace the code, we can modify the CommandUtils.scala, and rebuild the package. How to add the option for remote-debugging. please refer https://github.com/apache/spark/pull/157
+Since the excutor process is started by ProcessBuilder, if we wang to trace the code, we can modify the CommandUtils.scala, and rebuild the package. We can set spark.excutor.debug=true(default is false) to turn on this function and set spark.excutor.debug.port=xxxx （default is 18000）to specify the port for remote-debugging . The both option are set as jvm arguments when we start one worker process. please refer https://github.com/apache/spark/pull/157 for detail

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -84,4 +84,4 @@ properties are useful for those comfortable with JVM internals.
 
 #debug the Excutor process
 
-Since the excutor process is started by ProcessBuilder, if we wang to trace the code, we can modify the CommandUtils.scala, add the option for remote-debugging. please refer https://github.com/apache/spark/pull/157
+Since the excutor process is started by ProcessBuilder, if we wang to trace the code, we can modify the CommandUtils.scala, and rebuild the package. How to add the option for remote-debugging. please refer https://github.com/apache/spark/pull/157


### PR DESCRIPTION
enable the user can do remote-debugging on the ExcutorRunner Process. we need one flag to enable this function: spark.excutor.debug=true(default is false), an other flag spark.excutor.debug.port to set the port（default is 18000）. at normal time, the function is off
if we want do remote-debuggging，we should use -Dspark.excutor.debug=1 as jvm arguments when we start worker process
