### PR TITLE
bugfix: Wrong "Duration" in "Active Stages" in stages page

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/jobs/StageTable.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StageTable.scala
@@ -106,13 +106,8 @@ private[spark] class StageTable(val stages: Seq[StageInfo], val parent: JobProgr
     val description = listener.stageIdToDescription.get(s.stageId)
       .map(d => <div><em>{d}</em></div><div>{nameLink}</div>).getOrElse(nameLink)
     val finishTime = s.completionTime.getOrElse(System.currentTimeMillis())
-    val duration = s.submissionTime.map {
-      case t =>
-        if (finishTime > t) {
-          finishTime - t
-        } else {
-          System.currentTimeMillis() - t
-        }
+    val duration = s.submissionTime.map { t =>
+        if (finishTime > t) finishTime - t else System.currentTimeMillis - t
     }
 
     <tr>

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StageTable.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StageTable.scala
@@ -106,7 +106,14 @@ private[spark] class StageTable(val stages: Seq[StageInfo], val parent: JobProgr
     val description = listener.stageIdToDescription.get(s.stageId)
       .map(d => <div><em>{d}</em></div><div>{nameLink}</div>).getOrElse(nameLink)
     val finishTime = s.completionTime.getOrElse(System.currentTimeMillis())
-    val duration =  s.submissionTime.map(t => if(finishTime > t) finishTime - t else System.currentTimeMillis() - t)
+    val duration = s.submissionTime.map {
+      case t =>
+        if (finishTime > t) {
+          finishTime - t
+        } else {
+          System.currentTimeMillis() - t
+        }
+    }
 
     <tr>
       <td>{s.stageId}</td>

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StageTable.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StageTable.scala
@@ -106,7 +106,7 @@ private[spark] class StageTable(val stages: Seq[StageInfo], val parent: JobProgr
     val description = listener.stageIdToDescription.get(s.stageId)
       .map(d => <div><em>{d}</em></div><div>{nameLink}</div>).getOrElse(nameLink)
     val finishTime = s.completionTime.getOrElse(System.currentTimeMillis())
-    val duration =  s.submissionTime.map(t => finishTime - t)
+    val duration =  s.submissionTime.map(t => if(finishTime > t) finishTime - t else System.currentTimeMillis() - t)
 
     <tr>
       <td>{s.stageId}</td>

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StageTable.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StageTable.scala
@@ -107,7 +107,7 @@ private[spark] class StageTable(val stages: Seq[StageInfo], val parent: JobProgr
       .map(d => <div><em>{d}</em></div><div>{nameLink}</div>).getOrElse(nameLink)
     val finishTime = s.completionTime.getOrElse(System.currentTimeMillis())
     val duration = s.submissionTime.map { t =>
-        if (finishTime > t) finishTime - t else System.currentTimeMillis - t
+      if (finishTime > t) finishTime - t else System.currentTimeMillis - t
     }
 
     <tr>


### PR DESCRIPTION
If a stage which has completed once loss parts of data, it will be resubmitted. At this time, it appears that stage.completionTime > stage.submissionTime.
