### PR TITLE
[SPARK-1268] Adding XOR and AND-NOT operations to spark.util.collection.BitSet

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/collection/BitSet.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/BitSet.scala
@@ -64,7 +64,7 @@ class BitSet(numBits: Int) extends Serializable {
   }
 
   /**
-   * Compute the bit-wise OR of the two sets  returning the
+   * Compute the bit-wise OR of the two sets returning the
    * result.
    */
   def |(other: BitSet): BitSet = {

--- a/core/src/main/scala/org/apache/spark/util/collection/BitSet.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/BitSet.scala
@@ -95,21 +95,17 @@ class BitSet(numBits: Int) extends Serializable {
    */
   def ^(other: BitSet): BitSet = {
     val newBS = new BitSet(math.max(capacity, other.capacity))
-    assert(newBS.numWords >= numWords)
-    assert(newBS.numWords >= other.numWords)
     val smaller = math.min(numWords, other.numWords)
     var ind = 0
-    while( ind < smaller ) {
+    while ( ind < smaller ) {
       newBS.words(ind) = words(ind) ^ other.words(ind)
       ind += 1
     }
-    while( ind < numWords ) {
-      newBS.words(ind) = words(ind)
-      ind += 1
+    if ( ind < numWords ) {
+      Array.copy( words, ind, newBS.words, ind, numWords - ind )
     }
-    while( ind < other.numWords ) {
-      newBS.words(ind) = other.words(ind)
-      ind += 1
+    if ( ind < other.numWords ) {
+      Array.copy( other.words, ind, newBS.words, ind, other.numWords - ind )
     }
     newBS
   }
@@ -118,19 +114,16 @@ class BitSet(numBits: Int) extends Serializable {
    * Compute the difference of the two sets by performing bit-wise AND-NOT returning the
    * result.
    */
-  def &~(other: BitSet): BitSet = {
-    val newBS = new BitSet(math.max(capacity, other.capacity))
-    assert(newBS.numWords >= numWords)
-    assert(newBS.numWords >= other.numWords)
+  def andNot(other: BitSet): BitSet = {
+    val newBS = new BitSet(capacity)
     val smaller = math.min(numWords, other.numWords)
     var ind = 0
-    while( ind < smaller ) {
+    while ( ind < smaller ) {
       newBS.words(ind) = words(ind) & ~other.words(ind)
       ind += 1
     }
-    while( ind < numWords ) {
-      newBS.words(ind) = words(ind)
-      ind += 1
+    if ( ind < numWords ) {
+      Array.copy( words, ind, newBS.words, ind, numWords - ind )
     }
     newBS
   }

--- a/core/src/main/scala/org/apache/spark/util/collection/BitSet.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/BitSet.scala
@@ -64,7 +64,7 @@ class BitSet(numBits: Int) extends Serializable {
   }
 
   /**
-   * Compute the bit-wise OR of the two sets returning the
+   * Compute the bit-wise OR of the two sets  returning the
    * result.
    */
   def |(other: BitSet): BitSet = {
@@ -83,6 +83,53 @@ class BitSet(numBits: Int) extends Serializable {
     }
     while( ind < other.numWords ) {
       newBS.words(ind) = other.words(ind)
+      ind += 1
+    }
+    newBS
+  }
+
+
+  /**
+   * Compute the symmetric difference by performing bit-wise XOR of the two sets returning the
+   * result.
+   */
+  def ^(other: BitSet): BitSet = {
+    val newBS = new BitSet(math.max(capacity, other.capacity))
+    assert(newBS.numWords >= numWords)
+    assert(newBS.numWords >= other.numWords)
+    val smaller = math.min(numWords, other.numWords)
+    var ind = 0
+    while( ind < smaller ) {
+      newBS.words(ind) = words(ind) ^ other.words(ind)
+      ind += 1
+    }
+    while( ind < numWords ) {
+      newBS.words(ind) = words(ind)
+      ind += 1
+    }
+    while( ind < other.numWords ) {
+      newBS.words(ind) = other.words(ind)
+      ind += 1
+    }
+    newBS
+  }
+
+  /**
+   * Compute the difference of the two sets by performing bit-wise AND-NOT returning the
+   * result.
+   */
+  def &~(other: BitSet): BitSet = {
+    val newBS = new BitSet(math.max(capacity, other.capacity))
+    assert(newBS.numWords >= numWords)
+    assert(newBS.numWords >= other.numWords)
+    val smaller = math.min(numWords, other.numWords)
+    var ind = 0
+    while( ind < smaller ) {
+      newBS.words(ind) = words(ind) & ~other.words(ind)
+      ind += 1
+    }
+    while( ind < numWords ) {
+      newBS.words(ind) = words(ind)
       ind += 1
     }
     newBS

--- a/core/src/main/scala/org/apache/spark/util/collection/BitSet.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/BitSet.scala
@@ -88,7 +88,6 @@ class BitSet(numBits: Int) extends Serializable {
     newBS
   }
 
-
   /**
    * Compute the symmetric difference by performing bit-wise XOR of the two sets returning the
    * result.
@@ -97,14 +96,14 @@ class BitSet(numBits: Int) extends Serializable {
     val newBS = new BitSet(math.max(capacity, other.capacity))
     val smaller = math.min(numWords, other.numWords)
     var ind = 0
-    while ( ind < smaller ) {
+    while (ind < smaller) {
       newBS.words(ind) = words(ind) ^ other.words(ind)
       ind += 1
     }
-    if ( ind < numWords ) {
+    if (ind < numWords) {
       Array.copy( words, ind, newBS.words, ind, numWords - ind )
     }
-    if ( ind < other.numWords ) {
+    if (ind < other.numWords) {
       Array.copy( other.words, ind, newBS.words, ind, other.numWords - ind )
     }
     newBS
@@ -118,11 +117,11 @@ class BitSet(numBits: Int) extends Serializable {
     val newBS = new BitSet(capacity)
     val smaller = math.min(numWords, other.numWords)
     var ind = 0
-    while ( ind < smaller ) {
+    while (ind < smaller) {
       newBS.words(ind) = words(ind) & ~other.words(ind)
       ind += 1
     }
-    if ( ind < numWords ) {
+    if (ind < numWords) {
       Array.copy( words, ind, newBS.words, ind, numWords - ind )
     }
     newBS

--- a/core/src/test/scala/org/apache/spark/util/collection/BitSetSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/BitSetSuite.scala
@@ -134,8 +134,6 @@ class BitSetSuite extends FunSuite {
   }
 
   test( "andNot len(bitsetX) > len(bitsetY)" ) {
-    for( i <- 0 until 10000 ) {
-
     val setBitsX = Seq( 0, 1, 3, 37, 38, 41, 85)
     val setBitsY = Seq( 0, 2, 3, 37, 41, 48 )
     val bitsetX = new BitSet(100)
@@ -153,6 +151,5 @@ class BitSetSuite extends FunSuite {
     assert(bitsetDiff.nextSetBit(39) === 85)
     assert(bitsetDiff.nextSetBit(85) === 85)
     assert(bitsetDiff.nextSetBit(86) === -1)
-    }
   }
 }

--- a/core/src/test/scala/org/apache/spark/util/collection/BitSetSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/BitSetSuite.scala
@@ -70,7 +70,7 @@ class BitSetSuite extends FunSuite {
     assert(bitset.nextSetBit(97) === -1)
   }
 
-  test( "xor" ) {
+  test( "xor len(bitsetX) < len(bitsetY)" ) {
     val setBitsX = Seq( 0, 2, 3, 37, 41 )
     val setBitsY = Seq( 0, 1, 3, 37, 38, 41, 85)
     val bitsetX = new BitSet(60)
@@ -92,7 +92,29 @@ class BitSetSuite extends FunSuite {
 
   }
 
-  test( "and-not" ) {
+  test( "xor len(bitsetX) > len(bitsetY)" ) {
+    val setBitsX = Seq( 0, 1, 3, 37, 38, 41, 85)
+    val setBitsY   = Seq( 0, 2, 3, 37, 41 )
+    val bitsetX = new BitSet(100)
+    setBitsX.foreach( i => bitsetX.set(i))
+    val bitsetY = new BitSet(60)
+    setBitsY.foreach( i => bitsetY.set(i))
+
+    val bitsetXor = bitsetX ^ bitsetY
+
+    assert(bitsetXor.nextSetBit(0) === 1)
+    assert(bitsetXor.nextSetBit(1) === 1)
+    assert(bitsetXor.nextSetBit(2) === 2)
+    assert(bitsetXor.nextSetBit(3) === 38)
+    assert(bitsetXor.nextSetBit(38) === 38)
+    assert(bitsetXor.nextSetBit(39) === 85)
+    assert(bitsetXor.nextSetBit(42) === 85)
+    assert(bitsetXor.nextSetBit(85) === 85)
+    assert(bitsetXor.nextSetBit(86) === -1)
+
+  }
+
+  test( "andNot len(bitsetX) < len(bitsetY)" ) {
     val setBitsX = Seq( 0, 2, 3, 37, 41, 48 )
     val setBitsY = Seq( 0, 1, 3, 37, 38, 41, 85)
     val bitsetX = new BitSet(60)
@@ -100,7 +122,7 @@ class BitSetSuite extends FunSuite {
     val bitsetY = new BitSet(100)
     setBitsY.foreach( i => bitsetY.set(i))
 
-    val bitsetDiff = bitsetX &~ bitsetY
+    val bitsetDiff = bitsetX.andNot( bitsetY )
 
     assert(bitsetDiff.nextSetBit(0) === 2)
     assert(bitsetDiff.nextSetBit(1) === 2)
@@ -109,5 +131,28 @@ class BitSetSuite extends FunSuite {
     assert(bitsetDiff.nextSetBit(48) === 48)
     assert(bitsetDiff.nextSetBit(49) === -1)
     assert(bitsetDiff.nextSetBit(65) === -1)
+  }
+
+  test( "andNot len(bitsetX) > len(bitsetY)" ) {
+    for( i <- 0 until 10000 ) {
+
+    val setBitsX = Seq( 0, 1, 3, 37, 38, 41, 85)
+    val setBitsY = Seq( 0, 2, 3, 37, 41, 48 )
+    val bitsetX = new BitSet(100)
+    setBitsX.foreach( i => bitsetX.set(i))
+    val bitsetY = new BitSet(60)
+    setBitsY.foreach( i => bitsetY.set(i))
+
+    val bitsetDiff = bitsetX.andNot( bitsetY )
+
+    assert(bitsetDiff.nextSetBit(0) === 1)
+    assert(bitsetDiff.nextSetBit(1) === 1)
+    assert(bitsetDiff.nextSetBit(2) === 38)
+    assert(bitsetDiff.nextSetBit(3) === 38)
+    assert(bitsetDiff.nextSetBit(38) === 38)
+    assert(bitsetDiff.nextSetBit(39) === 85)
+    assert(bitsetDiff.nextSetBit(85) === 85)
+    assert(bitsetDiff.nextSetBit(86) === -1)
+    }
   }
 }

--- a/core/src/test/scala/org/apache/spark/util/collection/BitSetSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/BitSetSuite.scala
@@ -69,4 +69,45 @@ class BitSetSuite extends FunSuite {
     assert(bitset.nextSetBit(96) === 96)
     assert(bitset.nextSetBit(97) === -1)
   }
+
+  test( "xor" ) {
+    val setBitsX = Seq( 0, 2, 3, 37, 41 )
+    val setBitsY = Seq( 0, 1, 3, 37, 38, 41, 85)
+    val bitsetX = new BitSet(60)
+    setBitsX.foreach( i => bitsetX.set(i))
+    val bitsetY = new BitSet(100)
+    setBitsY.foreach( i => bitsetY.set(i))
+
+    val bitsetXor = bitsetX ^ bitsetY
+
+    assert(bitsetXor.nextSetBit(0) === 1)
+    assert(bitsetXor.nextSetBit(1) === 1)
+    assert(bitsetXor.nextSetBit(2) === 2)
+    assert(bitsetXor.nextSetBit(3) === 38)
+    assert(bitsetXor.nextSetBit(38) === 38)
+    assert(bitsetXor.nextSetBit(39) === 85)
+    assert(bitsetXor.nextSetBit(42) === 85)
+    assert(bitsetXor.nextSetBit(85) === 85)
+    assert(bitsetXor.nextSetBit(86) === -1)
+
+  }
+
+  test( "and-not" ) {
+    val setBitsX = Seq( 0, 2, 3, 37, 41, 48 )
+    val setBitsY = Seq( 0, 1, 3, 37, 38, 41, 85)
+    val bitsetX = new BitSet(60)
+    setBitsX.foreach( i => bitsetX.set(i))
+    val bitsetY = new BitSet(100)
+    setBitsY.foreach( i => bitsetY.set(i))
+
+    val bitsetDiff = bitsetX &~ bitsetY
+
+    assert(bitsetDiff.nextSetBit(0) === 2)
+    assert(bitsetDiff.nextSetBit(1) === 2)
+    assert(bitsetDiff.nextSetBit(2) === 2)
+    assert(bitsetDiff.nextSetBit(3) === 48)
+    assert(bitsetDiff.nextSetBit(48) === 48)
+    assert(bitsetDiff.nextSetBit(49) === -1)
+    assert(bitsetDiff.nextSetBit(65) === -1)
+  }
 }


### PR DESCRIPTION
Symmetric difference (xor) in particular is useful for computing some distance metrics (e.g. Hamming). Unit tests added.
