### PR TITLE
Fix maven jenkins: Add explicit init for required tables in SQLQuerySuite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -31,6 +31,9 @@ import TestSQLContext._
 import TestData._
 
 class SQLQuerySuite extends QueryTest {
+  // Make sure the tables are loaded.
+  TestData
+
   test("agg") {
     checkAnswer(
       sql("SELECT a, SUM(b) FROM testData2 GROUP BY a"),


### PR DESCRIPTION
Sorry! I added this test at the last minute and failed to run it in maven as well.

Note that, this will probably not be sufficient to actually fix the maven jenkins build, as that does not use the dev/run-tests scripts.  We will need to configure it to also run dev/download-hive-tests.sh.  The other option would be to check in the tests as I suggested in the original PR. (I can do this if we agree its the right thing to do).

Long term it would probably be a good idea to also have maven run some sort of test env setup script so that we can decouple the test environment from the jenkins configuration.
