### PR TITLE
SPARK-1254. Supplemental fix for HTTPS on Maven Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,8 @@
     <repository>
       <id>maven-repo</id> <!-- This should be at top, it makes maven try the central repo first and then others and hence faster dep resolution -->
       <name>Maven Repository</name>
-      <url>https://repo.maven.apache.org/maven2</url>
+      <!-- HTTPS is unavailable for Maven Central -->
+      <url>http://repo.maven.apache.org/maven2</url>
       <releases>
         <enabled>true</enabled>
       </releases>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -182,7 +182,8 @@ object SparkBuild extends Build {
     concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),
 
     resolvers ++= Seq(
-      "Maven Repository"     at "https://repo.maven.apache.org/maven2",
+      // HTTPS is unavailable for Maven Central
+      "Maven Repository"     at "http://repo.maven.apache.org/maven2",
       "Apache Repository"    at "https://repository.apache.org/content/repositories/releases",
       "JBoss Repository"     at "https://repository.jboss.org/nexus/content/repositories/releases/",
       "MQTT Repository"      at "https://repo.eclipse.org/content/repositories/paho-releases/",


### PR DESCRIPTION
It seems that HTTPS does not necessarily work on Maven Central, as it does not today at least. Back to HTTP. Both builds works from a clean repo.
