### PR TITLE
SPARK-1298: remove duplicate partitionID checking

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -894,9 +894,6 @@ class SparkContext(
       partitions: Seq[Int],
       allowLocal: Boolean,
       resultHandler: (Int, U) => Unit) {
-    partitions.foreach{ p =>
-      require(p >= 0 && p < rdd.partitions.size, s"Invalid partition requested: $p")
-    }
     val callSite = getCallSite
     val cleanedFunc = clean(func)
     logInfo("Starting job: " + callSite)
@@ -1000,9 +997,6 @@ class SparkContext(
       resultHandler: (Int, U) => Unit,
       resultFunc: => R): SimpleFutureAction[R] =
   {
-    partitions.foreach{ p =>
-      require(p >= 0 && p < rdd.partitions.size, s"Invalid partition requested: $p")
-    }
     val cleanF = clean(processPartition)
     val callSite = getCallSite
     val waiter = dagScheduler.submitJob(

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -429,7 +429,7 @@ class DAGScheduler(
   {
     // Check to make sure we are not launching a task on a partition that does not exist.
     val maxPartitions = rdd.partitions.length
-    partitions.find(p => p >= maxPartitions).foreach { p =>
+    partitions.find(p => p < 0 || p >= maxPartitions).foreach { p =>
       throw new IllegalArgumentException(
         "Attempting to access a non-existent partition: " + p + ". " +
           "Total number of partitions: " + maxPartitions)


### PR DESCRIPTION
https://spark-project.atlassian.net/browse/SPARK-1298

In the current implementation, we check whether partitionIDs is >=0 & < maxPartitionNum in SparkContext.runJob()

https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/SparkContext.scala#L896

However, immediately following, in DAGScheduler (calling path SparkContext.runJob -> DAGScheduler.runJob -> DAGScheduler.submitJob)

we check it again, (just missing a < 0 condition),

https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala#L432

I propose to remove the SparkContext one and check it in DAGScheduler (which makes more sense, from my view, as DAGScheduler handles everything about job, it should check whether the input of the job is valid before running it. But SparkContext is something more like a user-facing interface)

at least we should check it in only one place....

---

the other calling path is in AsyncRDDActions.submitJob -> SparkContext.submitJob -> DAGScheduler.submitJob, 

since we have to run the job through DAGScheduler.submitJob in the end, we shall check it there, 

Just found it when working on another PR....
