### PR TITLE
SPARK-1299: making comments of RDD.doCheckpoint consistent with its usage

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -902,7 +902,6 @@ class SparkContext(
     dagScheduler.runJob(rdd, cleanedFunc, partitions, callSite, allowLocal,
       resultHandler, localProperties.get)
     logInfo("Job finished: " + callSite + ", took " + (System.nanoTime - start) / 1e9 + " s")
-    rdd.doCheckpoint()
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -459,7 +459,7 @@ class DAGScheduler(
   {
     val waiter = submitJob(rdd, func, partitions, callSite, allowLocal, resultHandler, properties)
     waiter.awaitResult() match {
-      case JobSucceeded => {}
+      case JobSucceeded => rdd.doCheckpoint()
       case JobFailed(exception: Exception, _) =>
         logInfo("Failed to run " + callSite)
         throw exception


### PR DESCRIPTION
https://spark-project.atlassian.net/browse/SPARK-1299

another thing I found occasionally, the comments of function is saying that

```
/**
Performs the checkpointing of this RDD by saving this. It is called by the DAGScheduler
after a job using this RDD has completed (therefore the RDD has been materialized and
potentially stored in memory). doCheckpoint() is called recursively on the parent RDDs.
*/

```

actually this function is called in SparkContext.runJob

we can either change the comments or call it in DAGScheduler, I personally prefer the later one, as this calling seems like an auto-checkpoint , better put it in a non-user-facing component
