### PR TITLE
Add getListenerBus() in SparkContext.

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -135,6 +135,11 @@ class SparkContext(
   // An asynchronous listener bus for Spark events
   private[spark] val listenerBus = new LiveListenerBus
 
+  /**
+   * Return the listener bus held by the driver.
+   */
+  def getListenerBus: SparkListenerBus = listenerBus
+
   // Create the Spark execution environment (cache, map output tracker, etc)
   private[spark] val env = SparkEnv.create(
     conf,


### PR DESCRIPTION
Motivation:

We had a job that analyzes statistics collected by a custom SparkListener. What we realized was that it was possible for our main job to finish first, when the listener event poster thread was still processing events. (In our particular case -- a small job consisting of linear algebra operations -- an average of ~43ms is needed for the event queue to drain.) A simple solution to this seems to be gaining access to the listener bus, and thus do something like `sc.getListenerBus().waitUntilEmpty(10000)`.
