### PR TITLE
[SPARK-1334] Allow the setting of a Pyspark RDD's name attribute

### DIFF
--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -122,6 +122,20 @@ class RDD(object):
         """
         return self.ctx
 
+    @property
+    def name(self):
+        """
+        A friendly name for this RDD
+        """
+        return self._jrdd.name()
+
+    @name.setter
+    def name(self, name):
+        """
+        Sets the friendly name for this RDD
+        """
+        return self._jrdd.setName(name)
+
     def cache(self):
         """
         Persist this RDD with the default storage level (C{MEMORY_ONLY}).


### PR DESCRIPTION
This allows the setting of the underlying Java RDD's name attribute from python land.

```
In [2]: rdd = sc.parallelize(range(0, 10000))

In [3]: rdd.name = "cool"

In [4]: rdd.name
Out[4]: u'cool'
```

And after persisting:

![screen shot 2014-03-27 at 12 10 57 am](https://cloud.githubusercontent.com/assets/158950/2533730/6a8235e6-b566-11e3-8be9-841bb0d341a5.png)
