### PR TITLE
Minimize the scope of runAsUser to support Hadoop token passing

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -173,7 +173,7 @@ private[spark] class Executor(
       }
     }
 
-    override def run(): Unit = SparkHadoopUtil.get.runAsUser(sparkUser) { () =>
+    override def run(): Unit = {
       val startTime = System.currentTimeMillis()
       SparkEnv.set(env)
       Thread.currentThread.setContextClassLoader(replClassLoader)
@@ -208,7 +208,7 @@ private[spark] class Executor(
 
         // Run the actual task and measure its runtime.
         taskStart = System.currentTimeMillis()
-        val value = task.run(taskId.toInt)
+        val value = SparkHadoopUtil.get.runAsUser(sparkUser)(() => task.run(taskId.toInt))
         val taskFinish = System.currentTimeMillis()
 
         // If the task has been killed, let's fail it.


### PR DESCRIPTION
To support accessing a secure HDFS installation from Mesos executed Spark jobs, the resources attached to the `SparkContext` should be fetched before invoking `UserGroupInformation.doAs`. Or at least the credentials should be fetched before `doAs`. This allows us to set the `HADOOP_TOKEN_FILE_LOCATION` environment variable on the executor to a token cache file generated for each job.

`UserGroupInformation.doAs` fails to execute if the environment variable is set but the file does not exist, and trying to stuff the credentials back in later via some other mechanism is problematic. This approach is similar to how credentials are passed for YARN executed jobs.
