### PR TITLE
Fix sbt script

### DIFF
--- a/sbt/sbt
+++ b/sbt/sbt
@@ -20,7 +20,12 @@ realpath () {
 )
 }
 
-. $(dirname $(realpath $0))/sbt-launch-lib.bash
+DIR=$(dirname $(realpath $0))
+if [ ! -d $DIR ] || [ -z $DIR ]; then
+  DIR="./sbt/"
+fi
+echo $DIR
+. $DIR/sbt-launch-lib.bash
 
 
 declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy"

--- a/sbt/sbt
+++ b/sbt/sbt
@@ -24,7 +24,6 @@ DIR=$(dirname $(realpath $0))
 if [ ! -d $DIR ] || [ -z $DIR ]; then
   DIR="./sbt/"
 fi
-echo $DIR
 . $DIR/sbt-launch-lib.bash
 
 


### PR DESCRIPTION
When I ran ./sbt/sbt assembly I got the error no such file or directory: ./sbt/sbt in both zsh and bash.

I don't know what realpath is. It's not not anything on my machine. I changed the script to set DIR="./sbt/" in my case. 

With this change spark builds successfully on my machine. 
