### PR TITLE
SPARK-1349: spark-shell gets its own command history

### DIFF
--- a/repl/src/main/scala/org/apache/spark/repl/SparkJLineReader.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/SparkJLineReader.scala
@@ -7,8 +7,10 @@
 
 package org.apache.spark.repl
 
+import scala.reflect.io.{Path, File}
 import scala.tools.nsc._
 import scala.tools.nsc.interpreter._
+import scala.tools.nsc.interpreter.session.JLineHistory.JLineFileHistory
 
 import scala.tools.jline.console.ConsoleReader
 import scala.tools.jline.console.completer._
@@ -25,7 +27,7 @@ class SparkJLineReader(_completion: => Completion) extends InteractiveReader {
   val consoleReader = new JLineConsoleReader()
 
   lazy val completion = _completion
-  lazy val history: JLineHistory = JLineHistory()
+  lazy val history: JLineHistory = new SparkJLineHistory
 
   private def term = consoleReader.getTerminal()
   def reset() = term.reset()
@@ -77,4 +79,12 @@ class SparkJLineReader(_completion: => Completion) extends InteractiveReader {
   // def eraseLine() = while (consoleReader.delete()) { }
   def readOneLine(prompt: String) = consoleReader readLine prompt
   def readOneKey(prompt: String)  = consoleReader readOneKey prompt
+}
+
+/** Changes the default history file to not collide with the scala repl's. */
+class SparkJLineHistory extends JLineFileHistory {
+  import Properties.userHome
+
+  def defaultFileName = ".spark_history"
+  override protected lazy val historyFile = File(Path(userHome) / defaultFileName)
 }


### PR DESCRIPTION
Currently, spark-shell shares its command history with scala repl.

This fix is simply a modification of the default FileBackedHistory file setting:
https://github.com/scala/scala/blob/master/src/repl/scala/tools/nsc/interpreter/session/FileBackedHistory.scala#L77
