### PR TITLE
[SPARK-1371] fix computePreferredLocations signature to not depend on underlying implementation

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/InputFormatInfo.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/InputFormatInfo.scala
@@ -164,8 +164,7 @@ object InputFormatInfo {
 
     PS: I know the wording here is weird, hopefully it makes some sense !
   */
-  def computePreferredLocations(formats: Seq[InputFormatInfo]): Map[String, Set[SplitInfo]]
-  = {
+  def computePreferredLocations(formats: Seq[InputFormatInfo]): Map[String, Set[SplitInfo]] = {
 
     val nodeToSplit = new HashMap[String, HashSet[SplitInfo]]
     for (inputSplit <- formats) {
@@ -178,6 +177,6 @@ object InputFormatInfo {
       }
     }
 
-    nodeToSplit.map(entry => entry._1 -> entry._2.toSet).toMap
+    nodeToSplit.mapValues(_.toSet).toMap
   }
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/InputFormatInfo.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/InputFormatInfo.scala
@@ -164,7 +164,7 @@ object InputFormatInfo {
 
     PS: I know the wording here is weird, hopefully it makes some sense !
   */
-  def computePreferredLocations(formats: Seq[InputFormatInfo]): HashMap[String, HashSet[SplitInfo]]
+  def computePreferredLocations(formats: Seq[InputFormatInfo]): Map[String, Set[SplitInfo]]
   = {
 
     val nodeToSplit = new HashMap[String, HashSet[SplitInfo]]
@@ -178,6 +178,6 @@ object InputFormatInfo {
       }
     }
 
-    nodeToSplit
+    nodeToSplit.map(entry => entry._1 -> entry._2.toSet).toMap
   }
 }


### PR DESCRIPTION
Change to Map and Set - not mutable HashMap and HashSet
