### PR TITLE
method getAllPools in SC throws NPE

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -159,7 +159,7 @@ class SparkContext(
   // Initialize the Spark UI, registering all associated listeners
   private[spark] val ui = new SparkUI(this)
   ui.bind()
-  ui.start()
+
 
   // Optionally log Spark events
   private[spark] val eventLogger: Option[EventLoggingListener] = {
@@ -228,6 +228,7 @@ class SparkContext(
   @volatile private[spark] var dagScheduler = new DAGScheduler(this)
   dagScheduler.start()
 
+  ui.start()
   postEnvironmentUpdate()
 
   /** A default Hadoop Configuration for the Hadoop code (e.g. file systems) that we reuse. */

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -96,7 +96,7 @@ private[spark] class TaskSchedulerImpl(
   val mapOutputTracker = SparkEnv.get.mapOutputTracker
 
   var schedulableBuilder: SchedulableBuilder = null
-  var rootPool: Pool = null
+  var rootPool_ : Pool = null
   // default scheduler is FIFO
   val schedulingMode: SchedulingMode = SchedulingMode.withName(
     conf.get("spark.scheduler.mode", "FIFO"))
@@ -110,14 +110,14 @@ private[spark] class TaskSchedulerImpl(
 
   def initialize(backend: SchedulerBackend) {
     this.backend = backend
-    // temporarily set rootPool name to empty
-    rootPool = new Pool("", schedulingMode, 0, 0)
+    // temporarily set rootPool_ name to empty
+    rootPool_ = new Pool("", schedulingMode, 0, 0)
     schedulableBuilder = {
       schedulingMode match {
         case SchedulingMode.FIFO =>
-          new FIFOSchedulableBuilder(rootPool)
+          new FIFOSchedulableBuilder(rootPool_)
         case SchedulingMode.FAIR =>
-          new FairSchedulableBuilder(rootPool, conf)
+          new FairSchedulableBuilder(rootPool_, conf)
       }
     }
     schedulableBuilder.buildPools()
@@ -137,6 +137,7 @@ private[spark] class TaskSchedulerImpl(
       }
     }
   }
+  override def rootPool = rootPool_
 
   override def submitTasks(taskSet: TaskSet) {
     val tasks = taskSet.tasks


### PR DESCRIPTION
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/home/wangfei/spark0403/spark-master/examples/target/scala-2.10/spark-examples_2.10-assembly-1.0.0-SNAPSHOT.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/home/wangfei/spark0403/spark-master/assembly/target/scala-2.10/spark-assembly_2.10-1.0.0-SNAPSHOT-hadoop2.3.0.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.impl.Log4jLoggerFactory]
14/04/03 16:43:19 INFO SecurityManager: SecurityManager, is authentication enabled: false are ui acls enabled: false users with view permissions: Set(root)
14/04/03 16:43:19 INFO Slf4jLogger: Slf4jLogger started
14/04/03 16:43:19 INFO Remoting: Starting remoting
14/04/03 16:43:20 INFO Remoting: Remoting started; listening on addresses :[akka.tcp://spark@VM-13:55231]
14/04/03 16:43:20 INFO Remoting: Remoting now listens on addresses: [akka.tcp://spark@VM-13:55231]
14/04/03 16:43:20 INFO SparkEnv: Registering BlockManagerMaster
14/04/03 16:43:20 INFO DiskBlockManager: Created local directory at /tmp/spark-local-20140403164320-b637
14/04/03 16:43:20 INFO MemoryStore: MemoryStore started with capacity 1141.5 MB.
14/04/03 16:43:20 INFO ConnectionManager: Bound socket to port 33813 with id = ConnectionManagerId(VM-13,33813)
14/04/03 16:43:20 INFO BlockManagerMaster: Trying to register BlockManager
14/04/03 16:43:20 INFO BlockManagerInfo: Registering block manager VM-13:33813 with 1141.5 MB RAM
14/04/03 16:43:20 INFO BlockManagerMaster: Registered BlockManager
14/04/03 16:43:20 INFO HttpServer: Starting HTTP Server
14/04/03 16:43:21 INFO HttpBroadcast: Broadcast server started at http://9.91.11.32:58746
14/04/03 16:43:21 INFO SparkEnv: Registering MapOutputTracker
14/04/03 16:43:21 INFO HttpFileServer: HTTP File server directory is /tmp/spark-34b290f1-ca2f-489e-93c5-1c3e860874b0
14/04/03 16:43:21 INFO HttpServer: Starting HTTP Server
14/04/03 16:43:22 INFO SparkUI: Started Spark Web UI at http://VM-13:4040
14/04/03 16:43:22 WARN ServletHandler: /stages/
java.lang.NullPointerException
        at org.apache.spark.SparkContext.getAllPools(SparkContext.scala:712)
        at org.apache.spark.ui.jobs.IndexPage.render(IndexPage.scala:50)
        at org.apache.spark.ui.jobs.JobProgressUI$$anonfun$getHandlers$3.apply(JobProgressUI.scala:58)
        at org.apache.spark.ui.jobs.JobProgressUI$$anonfun$getHandlers$3.apply(JobProgressUI.scala:58)
        at org.apache.spark.ui.JettyUtils$$anon$1.doGet(JettyUtils.scala:68)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:707)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:820)
        at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:684)
        at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:501)
        at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1086)
        at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:428)
        at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1020)
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:135)
        at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:255)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:116)
        at org.eclipse.jetty.server.Server.handle(Server.java:370)
        at org.eclipse.jetty.server.AbstractHttpConnection.handleRequest(AbstractHttpConnection.java:494)
        at org.eclipse.jetty.server.AbstractHttpConnection.headerComplete(AbstractHttpConnection.java:971)
        at org.eclipse.jetty.server.AbstractHttpConnection$RequestHandler.headerComplete(AbstractHttpConnection.java:1033)
        at org.eclipse.jetty.http.HttpParser.parseNext(HttpParser.java:644)
        at org.eclipse.jetty.http.HttpParser.parseAvailable(HttpParser.java:235)
        at org.eclipse.jetty.server.AsyncHttpConnection.handle(AsyncHttpConnection.java:82)
        at org.eclipse.jetty.io.nio.SelectChannelEndPoint.handle(SelectChannelEndPoint.java:667)
        at org.eclipse.jetty.io.nio.SelectChannelEndPoint$1.run(SelectChannelEndPoint.java:52)
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:608)
        at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:543)
        at java.lang.Thread.run(Thread.java:662)

this is because rootPool method is not implemented in TaskSchedulerImpl
