### PR TITLE
[BUILD FIX] Fix compilation of Spark SQL Java API.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/api/java/JavaSQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api/java/JavaSQLContext.scala
@@ -87,7 +87,7 @@ class JavaSQLContext(sparkContext: JavaSparkContext) {
    * Loads a parquet file, returning the result as a [[JavaSchemaRDD]].
    */
   def parquetFile(path: String): JavaSchemaRDD =
-    new JavaSchemaRDD(sqlContext, ParquetRelation("ParquetFile", path))
+    new JavaSchemaRDD(sqlContext, ParquetRelation(path))
 
 
   /**


### PR DESCRIPTION
The JavaAPI and the Parquet improvements PRs didn't conflict, but broke the build.
