### PR TITLE
Fix jenkins from giving the green light to builds that don't compile.

### DIFF
--- a/dev/run-tests
+++ b/dev/run-tests
@@ -49,7 +49,7 @@ dev/scalastyle
 echo "========================================================================="
 echo "Running Spark unit tests"
 echo "========================================================================="
-sbt/sbt assembly test | grep -v -e "info.*Resolving" -e "warn.*Merging" -e "info.*Including"
+sbt/sbt assembly test
 
 echo "========================================================================="
 echo "Running PySpark tests"

--- a/sql/core/src/main/scala/org/apache/spark/sql/api/java/JavaSQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api/java/JavaSQLContext.scala
@@ -87,7 +87,7 @@ class JavaSQLContext(sparkContext: JavaSparkContext) {
    * Loads a parquet file, returning the result as a [[JavaSchemaRDD]].
    */
   def parquetFile(path: String): JavaSchemaRDD =
-    new JavaSchemaRDD(sqlContext, ParquetRelation("ParquetFile", path))
+    new JavaSchemaRDD(sqlContext, ParquetRelation(path))
 
 
   /**


### PR DESCRIPTION
 Adding `| grep` swallows the non-zero return code from sbt failures. See [here](https://amplab.cs.berkeley.edu/jenkins/job/SparkPullRequestBuilder/13735/consoleFull) for a Jenkins run that fails to compile, but still gets a green light.

Note the [BUILD FIX] commit isn't actually part of this PR, but github is out of date.
