### PR TITLE
Fix for PR #195 for Java 6

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetRelation.scala
@@ -103,7 +103,7 @@ private[sql] object ParquetRelation {
     SLF4JBridgeHandler.install()
     for(name <- loggerNames) {
       val logger = Logger.getLogger(name)
-      logger.setParent(Logger.getGlobal)
+      logger.setParent(Logger.getLogger(Logger.GLOBAL_LOGGER_NAME))
       logger.setUseParentHandlers(true)
     }
   }


### PR DESCRIPTION
Use Java 6's recommended equivalent of Java 7's Logger.getGlobal() to retain Java 6 compatibility. See PR #195
