### PR TITLE
[SPARK-1429] Spark shell fails to start after "sbt clean assemble-deps package"

### DIFF
--- a/bin/compute-classpath.sh
+++ b/bin/compute-classpath.sh
@@ -47,7 +47,7 @@ else
 fi
 
 # First check if we have a dependencies jar. If so, include binary classes with the deps jar
-if [ -f "$ASSEMBLY_DIR"/spark-assembly*hadoop*-deps.jar ]; then
+if [ -f "$ASSEMBLY_DIR"/spark*-assembly*hadoop*-deps.jar ]; then
   CLASSPATH="$CLASSPATH:$FWDIR/core/target/scala-$SCALA_VERSION/classes"
   CLASSPATH="$CLASSPATH:$FWDIR/repl/target/scala-$SCALA_VERSION/classes"
   CLASSPATH="$CLASSPATH:$FWDIR/mllib/target/scala-$SCALA_VERSION/classes"


### PR DESCRIPTION
JIRA issue: [SPARK-1429](https://issues.apache.org/jira/browse/SPARK-1429)

Spark shell fails to start after `sbt clean assemble-deps package`. A `*` should be added in `compute-classpath.sh` line 55 to make sure both `spark-assembly-xxx-deps.jar` and `spark-hive-assembly-xxx-deps.jar` are taken into account.
