### PR TITLE
[WIP] SPARK-1430: Support sparse data in Python MLlib

### DIFF
--- a/docs/mllib-clustering.md
+++ b/docs/mllib-clustering.md
@@ -48,14 +48,15 @@ optimal *k* is usually one where there is an "elbow" in the WSSSE graph.
 
 {% highlight scala %}
 import org.apache.spark.mllib.clustering.KMeans
+import org.apache.spark.mllib.linalg.Vectors
 
 // Load and parse the data
-val data = sc.textFile("kmeans_data.txt")
-val parsedData = data.map( _.split(' ').map(_.toDouble))
+val data = sc.textFile("data/kmeans_data.txt")
+val parsedData = data.map(s => Vectors.dense(s.split(' ').map(_.toDouble)))
 
 // Cluster the data into two classes using KMeans
-val numIterations = 20
 val numClusters = 2
+val numIterations = 20
 val clusters = KMeans.train(parsedData, numClusters, numIterations)
 
 // Evaluate clustering by computing Within Set Sum of Squared Errors
@@ -85,12 +86,12 @@ from numpy import array
 from math import sqrt
 
 # Load and parse the data
-data = sc.textFile("kmeans_data.txt")
+data = sc.textFile("data/kmeans_data.txt")
 parsedData = data.map(lambda line: array([float(x) for x in line.split(' ')]))
 
 # Build the model (cluster the data)
 clusters = KMeans.train(parsedData, 2, maxIterations=10,
-        runs=30, initialization_mode="random")
+        runs=10, initialization_mode="random")
 
 # Evaluate clustering by computing Within Set Sum of Squared Errors
 def error(point):

--- a/docs/mllib-guide.md
+++ b/docs/mllib-guide.md
@@ -7,8 +7,9 @@ title: Machine Learning Library (MLlib)
 MLlib is a Spark implementation of some common machine learning (ML)
 functionality, as well associated tests and data generators.  MLlib
 currently supports four common types of machine learning problem settings,
-namely, binary classification, regression, clustering and collaborative
-filtering, as well as an underlying gradient descent optimization primitive.
+namely classification, regression, clustering and collaborative filtering,
+as well as an underlying gradient descent optimization primitive and several
+linear algebra methods.
 
 # Available Methods
 The following links provide a detailed explanation of the methods and usage examples for each of them:
@@ -31,6 +32,28 @@ The following links provide a detailed explanation of the methods and usage exam
 * <a href="mllib-linear-algebra.html">Linear Algebra</a>
   * Singular Value Decomposition
   * Principal Component Analysis
+
+# Data Types
+
+Most MLlib algorithms operate on RDDs containing vectors. In Java and Scala, the
+[Vector](api/mllib/index.html#org.apache.spark.mllib.linalg.Vector) class is used to
+represent vectors. You can create either dense or sparse vectors using the
+[Vectors](api/mllib/index.html#org.apache.spark.mllib.linalg.Vectors$) factory.
+
+In Python, MLlib can take the following vector types:
+
+* [NumPy](http://www.numpy.org) arrays
+* Standard Python lists (e.g. `[1, 2, 3]`)
+* The MLlib [SparseVector](api/pyspark/pyspark.mllib.linalg.SparseVector-class.html) class
+* [SciPy sparse matrices](http://docs.scipy.org/doc/scipy/reference/sparse.html)
+
+For efficiency, we recommend using NumPy arrays over lists, and using the
+[CSC format](http://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csc_matrix.html#scipy.sparse.csc_matrix)
+for SciPy matrices, or MLlib's own SparseVector class.
+
+Several other simple data types are used throughout the library, e.g. the LabeledPoint
+class ([Java/Scala](api/mllib/index.html#org.apache.spark.mllib.regression.LabeledPoint),
+[Python](api/pyspark/pyspark.mllib.regression.LabeledPoint-class.html)) for labeled data.
 
 # Dependencies
 MLlib uses the [jblas](https://github.com/mikiobraun/jblas) linear algebra library, which itself

--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
@@ -32,7 +32,7 @@ import org.apache.spark.rdd.RDD
  * :: DeveloperApi ::
  * The Java stubs necessary for the Python mllib bindings.
  *
- * See mllib/python/pyspark._common.py for the mutually agreed upon data format.
+ * See python/pyspark/mllib/_common.py for the mutually agreed upon data format.
  */
 @DeveloperApi
 class PythonMLLibAPI extends Serializable {

--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
@@ -36,6 +36,10 @@ import org.apache.spark.rdd.RDD
  */
 @DeveloperApi
 class PythonMLLibAPI extends Serializable {
+  private val DENSE_VECTOR_MAGIC = 1
+  private val SPARSE_VECTOR_MAGIC = 2
+  private val DENSE_MATRIX_MAGIC = 3
+  
   private def deserializeDoubleVector(bytes: Array[Byte]): Array[Double] = {
     val packetLength = bytes.length
     if (packetLength < 5) {
@@ -44,7 +48,7 @@ class PythonMLLibAPI extends Serializable {
     val bb = ByteBuffer.wrap(bytes)
     bb.order(ByteOrder.nativeOrder())
     val magic = bb.get()
-    if (magic != 1) {
+    if (magic != DENSE_VECTOR_MAGIC) {
       throw new IllegalArgumentException("Magic " + magic + " is wrong.")
     }
     val length = bb.getInt()
@@ -77,7 +81,7 @@ class PythonMLLibAPI extends Serializable {
     val bb = ByteBuffer.wrap(bytes)
     bb.order(ByteOrder.nativeOrder())
     val magic = bb.get()
-    if (magic != 2) {
+    if (magic != DENSE_MATRIX_MAGIC) {
       throw new IllegalArgumentException("Magic " + magic + " is wrong.")
     }
     val rows = bb.getInt()

--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
@@ -171,8 +171,8 @@ class PythonMLLibAPI extends Serializable {
       dataBytesJRDD: JavaRDD[Array[Byte]],
       initialWeightsBA: Array[Byte]): java.util.LinkedList[java.lang.Object] = {
     val data = dataBytesJRDD.rdd.map(xBytes => {
-        val x = deserializeDoubleVector(xBytes).toArray  // TODO: deal with sparse vectors here!
-        LabeledPoint(x(0), Vectors.dense(x.slice(1, x.length)))
+        val x = deserializeDoubleVector(xBytes)
+        LabeledPoint(x(0), x.slice(1, x.size))
     })
     val initialWeights = deserializeDoubleVector(initialWeightsBA)
     val model = trainFunc(data, initialWeights)
@@ -300,8 +300,8 @@ class PythonMLLibAPI extends Serializable {
       dataBytesJRDD: JavaRDD[Array[Byte]],
       lambda: Double): java.util.List[java.lang.Object] = {
     val data = dataBytesJRDD.rdd.map(xBytes => {
-      val x = deserializeDoubleVector(xBytes).toArray // TODO: make this efficient for sparse vecs
-      LabeledPoint(x(0), Vectors.dense(x.slice(1, x.length)))
+      val x = deserializeDoubleVector(xBytes)
+      LabeledPoint(x(0), x.slice(1, x.size))
     })
     val model = NaiveBayes.train(data, lambda)
     val ret = new java.util.LinkedList[java.lang.Object]()

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
@@ -100,24 +100,4 @@ class VectorsSuite extends FunSuite {
     assert(vec2(6) === 4.0)
     assert(vec2(7) === 0.0)
   }
-
-  test("slicing dense vectors") {
-    val vec = Vectors.dense(1.0, 2.0, 3.0, 4.0)
-    val slice = vec.slice(1, 3)
-    assert(slice === Vectors.dense(2.0, 3.0))
-    assert(slice.isInstanceOf[DenseVector], "slice was not DenseVector")
-  }
-
-  test("slicing sparse vectors") {
-    val vec = Vectors.sparse(7, Array(0, 2, 4, 6), Array(1.0, 2.0, 3.0, 4.0))
-    val slice = vec.slice(1, 5)
-    assert(slice === Vectors.sparse(4, Array(1,3), Array(2.0, 3.0)))
-    assert(slice.isInstanceOf[SparseVector], "slice was not SparseVector")
-    val slice2 = vec.slice(1, 2)
-    assert(slice2 === Vectors.sparse(1, Array(), Array()))
-    assert(slice2.isInstanceOf[SparseVector], "slice was not SparseVector")
-    val slice3 = vec.slice(6, 7)
-    assert(slice3 === Vectors.sparse(1, Array(0), Array(4.0)))
-    assert(slice3.isInstanceOf[SparseVector], "slice was not SparseVector")
-  }
 }

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
@@ -82,4 +82,42 @@ class VectorsSuite extends FunSuite {
       assert(v.## != another.##)
     }
   }
+
+  test("indexing dense vectors") {
+    val vec = Vectors.dense(1.0, 2.0, 3.0, 4.0)
+    assert(vec(0) === 1.0)
+    assert(vec(3) === 4.0)
+  }
+
+  test("indexing sparse vectors") {
+    val vec = Vectors.sparse(7, Array(0, 2, 4, 6), Array(1.0, 2.0, 3.0, 4.0))
+    assert(vec(0) === 1.0)
+    assert(vec(1) === 0.0)
+    assert(vec(2) === 2.0)
+    assert(vec(3) === 0.0)
+    assert(vec(6) === 4.0)
+    val vec2 = Vectors.sparse(8, Array(0, 2, 4, 6), Array(1.0, 2.0, 3.0, 4.0))
+    assert(vec2(6) === 4.0)
+    assert(vec2(7) === 0.0)
+  }
+
+  test("slicing dense vectors") {
+    val vec = Vectors.dense(1.0, 2.0, 3.0, 4.0)
+    val slice = vec.slice(1, 3)
+    assert(slice === Vectors.dense(2.0, 3.0))
+    assert(slice.isInstanceOf[DenseVector], "slice was not DenseVector")
+  }
+
+  test("slicing sparse vectors") {
+    val vec = Vectors.sparse(7, Array(0, 2, 4, 6), Array(1.0, 2.0, 3.0, 4.0))
+    val slice = vec.slice(1, 5)
+    assert(slice === Vectors.sparse(4, Array(1,3), Array(2.0, 3.0)))
+    assert(slice.isInstanceOf[SparseVector], "slice was not SparseVector")
+    val slice2 = vec.slice(1, 2)
+    assert(slice2 === Vectors.sparse(1, Array(), Array()))
+    assert(slice2.isInstanceOf[SparseVector], "slice was not SparseVector")
+    val slice3 = vec.slice(6, 7)
+    assert(slice3 === Vectors.sparse(1, Array(0), Array(4.0)))
+    assert(slice3.isInstanceOf[SparseVector], "slice was not SparseVector")
+  }
 }

--- a/python/epydoc.conf
+++ b/python/epydoc.conf
@@ -33,5 +33,6 @@ target: docs/
 private: no
 
 exclude: pyspark.cloudpickle pyspark.worker pyspark.join
-         pyspark.java_gateway pyspark.examples pyspark.shell pyspark.test
+         pyspark.java_gateway pyspark.examples pyspark.shell pyspark.tests
          pyspark.rddsampler pyspark.daemon pyspark.mllib._common
+         pyspark.mllib.tests

--- a/python/examples/kmeans.py
+++ b/python/examples/kmeans.py
@@ -16,8 +16,12 @@
 #
 
 """
-This example requires numpy (http://www.numpy.org/)
+The K-means algorithm written from scratch against PySpark. In practice, one
+may prefer to use the KMeans algorithm in MLlib, as shown in mllib_kmeans.py.
+
+This example requires NumPy (http://www.numpy.org/).
 """
+
 import sys
 
 import numpy as np
@@ -49,9 +53,7 @@ if __name__ == "__main__":
     K = int(sys.argv[3])
     convergeDist = float(sys.argv[4])
 
-    # TODO: change this after we port takeSample()
-    #kPoints = data.takeSample(False, K, 34)
-    kPoints = data.take(K)
+    kPoints = data.takeSample(False, K, 1)
     tempDist = 1.0
 
     while tempDist > convergeDist:

--- a/python/examples/kmeans.py
+++ b/python/examples/kmeans.py
@@ -16,8 +16,9 @@
 #
 
 """
-The K-means algorithm written from scratch against PySpark. In practice, one
-may prefer to use the KMeans algorithm in MLlib, as shown in mllib_kmeans.py.
+The K-means algorithm written from scratch against PySpark. In practice,
+one may prefer to use the KMeans algorithm in MLlib, as shown in
+python/examples/mllib/kmeans.py.
 
 This example requires NumPy (http://www.numpy.org/).
 """

--- a/python/examples/logistic_regression.py
+++ b/python/examples/logistic_regression.py
@@ -16,9 +16,13 @@
 #
 
 """
-A logistic regression implementation that uses NumPy (http://www.numpy.org) to act on batches
-of input data using efficient matrix operations.
+A logistic regression implementation that uses NumPy (http://www.numpy.org)
+to act on batches of input data using efficient matrix operations.
+
+In practice, one may prefer to use the LogisticRegression algorithm in
+MLlib, as shown in python/examples/mllib/logistic_regression.py.
 """
+
 from collections import namedtuple
 from math import exp
 from os.path import realpath

--- a/python/examples/mllib/kmeans.py
+++ b/python/examples/mllib/kmeans.py
@@ -18,7 +18,7 @@
 """
 A K-means clustering program using MLlib.
 
-This example requires NuMpy (http://www.numpy.org/).
+This example requires NumPy (http://www.numpy.org/).
 """
 
 import sys

--- a/python/examples/mllib/logistic_regression.py
+++ b/python/examples/mllib/logistic_regression.py
@@ -1,0 +1,50 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Logistic regression using MLlib.
+
+This example requires NumPy (http://www.numpy.org/).
+"""
+
+from math import exp
+import sys
+
+import numpy as np
+from pyspark import SparkContext
+from pyspark.mllib.regression import LabeledPoint
+from pyspark.mllib.classification import LogisticRegressionWithSGD
+
+
+# Parse a line of text into an MLlib LabeledPoint object
+def parsePoint(line):
+    values = [float(s) for s in line.split(' ')]
+    if values[0] == -1:   # Convert -1 labels to 0 for MLlib
+        values[0] = 0
+    return LabeledPoint(values[0], values[1:])
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 4:
+        print >> sys.stderr, "Usage: logistic_regression <master> <file> <iters>"
+        exit(-1)
+    sc = SparkContext(sys.argv[1], "PythonLR")
+    points = sc.textFile(sys.argv[2]).map(parsePoint)
+    iterations = int(sys.argv[3])
+    model = LogisticRegressionWithSGD.train(points, iterations)
+    print "Final weights: " + str(model.weights)
+    print "Final intercept: " + str(model.intercept)

--- a/python/examples/mllib_kmeans.py
+++ b/python/examples/mllib_kmeans.py
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+A K-means clustering program using MLlib.
+
+This example requires NuMpy (http://www.numpy.org/).
+"""
+
+import sys
+
+import numpy as np
+from pyspark import SparkContext
+from pyspark.mllib.clustering import KMeans
+
+
+def parseVector(line):
+    return np.array([float(x) for x in line.split(' ')])
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 4:
+        print >> sys.stderr, "Usage: kmeans <master> <file> <k>"
+        exit(-1)
+    sc = SparkContext(sys.argv[1], "KMeans")
+    lines = sc.textFile(sys.argv[2])
+    data = lines.map(parseVector)
+    k = int(sys.argv[3])
+    model = KMeans.train(data, k)
+    print "Final centers: " + str(model.clusterCenters)

--- a/python/pyspark/mllib/_common.py
+++ b/python/pyspark/mllib/_common.py
@@ -299,27 +299,6 @@ def _linear_predictor_typecheck(x, coeffs):
         raise TypeError("Argument of type " + type(x).__name__ + " unsupported")
 
 
-class LinearModel(object):
-    """Something that has a vector of coefficients and an intercept."""
-    def __init__(self, coeff, intercept):
-        self._coeff = coeff
-        self._intercept = intercept
-
-
-class LinearRegressionModelBase(LinearModel):
-    """A linear regression model.
-
-    >>> lrmb = LinearRegressionModelBase(array([1.0, 2.0]), 0.1)
-    >>> abs(lrmb.predict(array([-1.03, 7.777])) - 14.624) < 1e-6
-    True
-    """
-    def predict(self, x):
-        """Predict the value of the dependent variable given a vector x"""
-        """containing values for the independent variables."""
-        _linear_predictor_typecheck(x, self._coeff)
-        return _dot(x, self._coeff) + self._intercept
-
-
 # If we weren't given initial weights, take a zero vector of the appropriate
 # length.
 def _get_initial_weights(initial_weights, data):

--- a/python/pyspark/mllib/_common.py
+++ b/python/pyspark/mllib/_common.py
@@ -329,9 +329,9 @@ def _get_initial_weights(initial_weights, data):
             if initial_weights.ndim != 1:
                 raise TypeError("At least one data element has "
                         + initial_weights.ndim + " dimensions, which is not 1")
-            initial_weights = numpy.ones([initial_weights.shape[0] - 1])
+            initial_weights = numpy.ones([initial_weights.shape[0]])
         elif type(initial_weights) == SparseVector:
-            initial_weights = numpy.ones([initial_weights.size - 1])
+            initial_weights = numpy.ones([initial_weights.size])
     return initial_weights
 
 

--- a/python/pyspark/mllib/_common.py
+++ b/python/pyspark/mllib/_common.py
@@ -258,7 +258,7 @@ def _get_initial_weights(initial_weights, data):
                         + initial_weights.ndim + " dimensions, which is not 1")
             initial_weights = numpy.ones([initial_weights.shape[0] - 1])
         elif type(initial_weights) == SparseVector:
-            initial_weights = numpy.ones(initial_weights.size - 1)
+            initial_weights = numpy.ones([initial_weights.size - 1])
         else:
             raise TypeError("At least one data element has type "
                     + type(initial_weights).__name__ + " which is not a vector")
@@ -309,6 +309,31 @@ def _serialize_tuple(t):
     intpart = ndarray(shape=[2], buffer=ba, dtype=int32)
     intpart[0], intpart[1] = t
     return ba
+
+def _squared_distance(v1, v2):
+    """
+    Squared distance of two NumPy or sparse vectors.
+
+    >>> dense1 = array([1., 2.])
+    >>> sparse1 = SparseVector(2, [0, 1], [1., 2.])
+    >>> dense2 = array([2., 1.])
+    >>> sparse2 = SparseVector(2, [0, 1], [2., 1.])
+    >>> _squared_distance(dense1, dense2)
+    2.0
+    >>> _squared_distance(dense1, sparse2)
+    2.0
+    >>> _squared_distance(sparse1, dense2)
+    2.0
+    >>> _squared_distance(sparse1, sparse2)
+    2.0
+    """
+    if type(v1) == ndarray and type(v2) == ndarray:
+        diff = v1 - v2
+        return diff.dot(diff)
+    elif type(v1) == ndarray:
+        return v2.squared_distance(v1)
+    else:
+        return v1.squared_distance(v2)
 
 def _test():
     import doctest

--- a/python/pyspark/mllib/_common.py
+++ b/python/pyspark/mllib/_common.py
@@ -17,7 +17,7 @@
 
 import struct
 import numpy
-from numpy import ndarray, float64, int64, int32, ones, array_equal, array, dot, shape, complex, issubdtype
+from numpy import ndarray, float64, int64, int32, array_equal, array
 from pyspark import SparkContext, RDD
 from pyspark.mllib.linalg import SparseVector
 from pyspark.serializers import Serializer
@@ -243,8 +243,6 @@ def _deserialize_double_matrix(ba):
 
 def _serialize_labeled_point(p):
     """Serialize a LabeledPoint with a features vector of any type."""
-    #from pyspark.mllib.regression import LabeledPoint
-    #assert type(p) == LabeledPoint, "Expected a LabeledPoint object"
     from pyspark.mllib.regression import LabeledPoint
     serialized_features = _serialize_double_vector(p.features)
     header = bytearray(9)
@@ -318,9 +316,9 @@ def _get_initial_weights(initial_weights, data):
             if initial_weights.ndim != 1:
                 raise TypeError("At least one data element has "
                         + initial_weights.ndim + " dimensions, which is not 1")
-            initial_weights = numpy.ones([initial_weights.shape[0]])
+            initial_weights = numpy.zeros([initial_weights.shape[0]])
         elif type(initial_weights) == SparseVector:
-            initial_weights = numpy.ones([initial_weights.size])
+            initial_weights = numpy.zeros([initial_weights.size])
     return initial_weights
 
 

--- a/python/pyspark/mllib/classification.py
+++ b/python/pyspark/mllib/classification.py
@@ -24,9 +24,9 @@ from pyspark.mllib._common import \
     _serialize_double_matrix, _deserialize_double_matrix, \
     _serialize_double_vector, _deserialize_double_vector, \
     _get_initial_weights, _serialize_rating, _regression_train_wrapper, \
-    LinearModel, _linear_predictor_typecheck, _get_unmangled_labeled_point_rdd
+    _linear_predictor_typecheck, _get_unmangled_labeled_point_rdd
 from pyspark.mllib.linalg import SparseVector
-from pyspark.mllib.regression import LabeledPoint
+from pyspark.mllib.regression import LabeledPoint, LinearModel
 from math import exp, log
 
 class LogisticRegressionModel(LinearModel):
@@ -64,6 +64,7 @@ class LogisticRegressionModel(LinearModel):
         margin = _dot(x, self._coeff) + self._intercept
         prob = 1/(1 + exp(-margin))
         return 1 if prob > 0.5 else 0
+
 
 class LogisticRegressionWithSGD(object):
     @classmethod

--- a/python/pyspark/mllib/classification.py
+++ b/python/pyspark/mllib/classification.py
@@ -20,7 +20,7 @@ import numpy
 from numpy import array, shape
 from pyspark import SparkContext
 from pyspark.mllib._common import \
-    _get_unmangled_rdd, _get_unmangled_double_vector_rdd, \
+    _dot, _get_unmangled_rdd, _get_unmangled_double_vector_rdd, \
     _serialize_double_matrix, _deserialize_double_matrix, \
     _serialize_double_vector, _deserialize_double_vector, \
     _get_initial_weights, _serialize_rating, _regression_train_wrapper, \
@@ -55,7 +55,7 @@ class LogisticRegressionModel(LinearModel):
     """
     def predict(self, x):
         _linear_predictor_typecheck(x, self._coeff)
-        margin = x.dot(self._coeff) + self._intercept
+        margin = _dot(x, self._coeff) + self._intercept
         prob = 1/(1 + exp(-margin))
         return 1 if prob > 0.5 else 0
 
@@ -91,7 +91,7 @@ class SVMModel(LinearModel):
     """
     def predict(self, x):
         _linear_predictor_typecheck(x, self._coeff)
-        margin = x.dot(self._coeff) + self._intercept
+        margin = _dot(x, self._coeff) + self._intercept
         return 1 if margin >= 0 else 0
 
 class SVMWithSGD(object):
@@ -138,7 +138,7 @@ class NaiveBayesModel(object):
 
     def predict(self, x):
         """Return the most likely class for a data vector x"""
-        return self.labels[numpy.argmax(self.pi + x.dot(self.theta))]
+        return self.labels[numpy.argmax(self.pi + _dot(x, self.theta))]
 
 class NaiveBayes(object):
     @classmethod

--- a/python/pyspark/mllib/classification.py
+++ b/python/pyspark/mllib/classification.py
@@ -50,6 +50,8 @@ class LogisticRegressionModel(LinearModel):
     True
     >>> lrm.predict(SparseVector(2, [1], [1.0])) > 0
     True
+    >>> lrm.predict(SparseVector(2, [1], [0.0])) <= 0
+    True
     """
     def predict(self, x):
         _linear_predictor_typecheck(x, self._coeff)
@@ -74,6 +76,17 @@ class SVMModel(LinearModel):
     >>> data = array([0.0, 0.0, 1.0, 1.0, 1.0, 2.0, 1.0, 3.0]).reshape(4,2)
     >>> svm = SVMWithSGD.train(sc.parallelize(data))
     >>> svm.predict(array([1.0])) > 0
+    True
+    >>> sparse_data = [
+    ...     SparseVector(3, [0, 1], [0.0, 0.0]),
+    ...     SparseVector(3, [0, 2], [1.0, 1.0]),
+    ...     SparseVector(3, [0, 1], [0.0, 0.0]),
+    ...     SparseVector(3, [0, 2], [1.0, 2.0])
+    ... ]
+    >>> svm = SVMWithSGD.train(sc.parallelize(sparse_data))
+    >>> svm.predict(SparseVector(2, [1], [1.0])) > 0
+    True
+    >>> svm.predict(SparseVector(2, [1], [0.0])) <= 0
     True
     """
     def predict(self, x):
@@ -105,6 +118,16 @@ class NaiveBayesModel(object):
     >>> model.predict(array([0.0, 1.0]))
     0.0
     >>> model.predict(array([1.0, 0.0]))
+    1.0
+    >>> sparse_data = [
+    ...     SparseVector(3, [0, 2], [0.0, 1.0]),
+    ...     SparseVector(3, [0, 2], [0.0, 2.0]),
+    ...     SparseVector(3, [0, 1], [1.0, 1.0])
+    ... ]
+    >>> model = NaiveBayes.train(sc.parallelize(sparse_data))
+    >>> model.predict(SparseVector(2, [1], [1.0]))
+    0.0
+    >>> model.predict(SparseVector(2, [0], [1.0]))
     1.0
     """
 

--- a/python/pyspark/mllib/classification.py
+++ b/python/pyspark/mllib/classification.py
@@ -24,7 +24,7 @@ from pyspark.mllib._common import \
     _serialize_double_matrix, _deserialize_double_matrix, \
     _serialize_double_vector, _deserialize_double_vector, \
     _get_initial_weights, _serialize_rating, _regression_train_wrapper, \
-    LinearModel, _linear_predictor_typecheck
+    LinearModel, _linear_predictor_typecheck, _get_unmangled_labeled_point_rdd
 from pyspark.mllib.linalg import SparseVector
 from pyspark.mllib.regression import LabeledPoint
 from math import exp, log
@@ -135,9 +135,9 @@ class NaiveBayesModel(object):
     >>> model.predict(array([1.0, 0.0]))
     1.0
     >>> sparse_data = [
-    ...     LabeledPoint(0.0, SparseVector(2, {1: 0.0}),
-    ...     LabeledPoint(0.0, SparseVector(2, {1: 1.0}),
-    ...     LabeledPoint(1.0, SparseVector(2, {0: 1.0})
+    ...     LabeledPoint(0.0, SparseVector(2, {1: 0.0})),
+    ...     LabeledPoint(0.0, SparseVector(2, {1: 1.0})),
+    ...     LabeledPoint(1.0, SparseVector(2, {0: 1.0}))
     ... ]
     >>> model = NaiveBayes.train(sc.parallelize(sparse_data))
     >>> model.predict(SparseVector(2, {1: 1.0}))
@@ -173,7 +173,7 @@ class NaiveBayes(object):
         @param lambda_: The smoothing parameter
         """
         sc = data.context
-        dataBytes = _get_unmangled_double_vector_rdd(data)
+        dataBytes = _get_unmangled_labeled_point_rdd(data)
         ans = sc._jvm.PythonMLLibAPI().trainNaiveBayes(dataBytes._jrdd, lambda_)
         return NaiveBayesModel(
             _deserialize_double_vector(ans[0]),

--- a/python/pyspark/mllib/classification.py
+++ b/python/pyspark/mllib/classification.py
@@ -26,31 +26,37 @@ from pyspark.mllib._common import \
     _get_initial_weights, _serialize_rating, _regression_train_wrapper, \
     LinearModel, _linear_predictor_typecheck
 from pyspark.mllib.linalg import SparseVector
+from pyspark.mllib.regression import LabeledPoint
 from math import exp, log
 
 class LogisticRegressionModel(LinearModel):
     """A linear binary classification model derived from logistic regression.
 
-    >>> data = array([0.0, 0.0, 1.0, 1.0, 1.0, 2.0, 1.0, 3.0]).reshape(4,2)
+    >>> data = [
+    ...     LabeledPoint(0.0, [0.0]),
+    ...     LabeledPoint(1.0, [1.0]),
+    ...     LabeledPoint(1.0, [2.0]),
+    ...     LabeledPoint(1.0, [3.0])
+    ... ]
     >>> lrm = LogisticRegressionWithSGD.train(sc.parallelize(data))
     >>> lrm.predict(array([1.0])) > 0
     True
     >>> lrm.predict(array([0.0])) <= 0
     True
     >>> sparse_data = [
-    ...     SparseVector(3, [0, 1], [0.0, 0.0]),
-    ...     SparseVector(3, [0, 2], [1.0, 1.0]),
-    ...     SparseVector(3, [0, 1], [0.0, 0.0]),
-    ...     SparseVector(3, [0, 2], [1.0, 2.0])
+    ...     LabeledPoint(0.0, SparseVector(2, {0: 0.0})),
+    ...     LabeledPoint(1.0, SparseVector(2, {1: 1.0})),
+    ...     LabeledPoint(0.0, SparseVector(2, {0: 0.0})),
+    ...     LabeledPoint(1.0, SparseVector(2, {1: 2.0}))
     ... ]
     >>> lrm = LogisticRegressionWithSGD.train(sc.parallelize(sparse_data))
     >>> lrm.predict(array([0.0, 1.0])) > 0
     True
     >>> lrm.predict(array([0.0, 0.0])) <= 0
     True
-    >>> lrm.predict(SparseVector(2, [1], [1.0])) > 0
+    >>> lrm.predict(SparseVector(2, {1: 1.0})) > 0
     True
-    >>> lrm.predict(SparseVector(2, [1], [0.0])) <= 0
+    >>> lrm.predict(SparseVector(2, {1: 0.0})) <= 0
     True
     """
     def predict(self, x):
@@ -73,20 +79,25 @@ class LogisticRegressionWithSGD(object):
 class SVMModel(LinearModel):
     """A support vector machine.
 
-    >>> data = array([0.0, 0.0, 1.0, 1.0, 1.0, 2.0, 1.0, 3.0]).reshape(4,2)
+    >>> data = [
+    ...     LabeledPoint(0.0, [0.0]),
+    ...     LabeledPoint(1.0, [1.0]),
+    ...     LabeledPoint(1.0, [2.0]),
+    ...     LabeledPoint(1.0, [3.0])
+    ... ]
     >>> svm = SVMWithSGD.train(sc.parallelize(data))
     >>> svm.predict(array([1.0])) > 0
     True
     >>> sparse_data = [
-    ...     SparseVector(3, [0, 1], [0.0, 0.0]),
-    ...     SparseVector(3, [0, 2], [1.0, 1.0]),
-    ...     SparseVector(3, [0, 1], [0.0, 0.0]),
-    ...     SparseVector(3, [0, 2], [1.0, 2.0])
+    ...     LabeledPoint(0.0, SparseVector(2, {0: 0.0})),
+    ...     LabeledPoint(1.0, SparseVector(2, {1: 1.0})),
+    ...     LabeledPoint(0.0, SparseVector(2, {0: 0.0})),
+    ...     LabeledPoint(1.0, SparseVector(2, {1: 2.0}))
     ... ]
     >>> svm = SVMWithSGD.train(sc.parallelize(sparse_data))
-    >>> svm.predict(SparseVector(2, [1], [1.0])) > 0
+    >>> svm.predict(SparseVector(2, {1: 1.0})) > 0
     True
-    >>> svm.predict(SparseVector(2, [1], [0.0])) <= 0
+    >>> svm.predict(SparseVector(2, {1: 0.0})) <= 0
     True
     """
     def predict(self, x):
@@ -113,21 +124,25 @@ class NaiveBayesModel(object):
     - pi: vector of logs of class priors (dimension C)
     - theta: matrix of logs of class conditional probabilities (CxD)
 
-    >>> data = array([0.0, 0.0, 1.0, 0.0, 0.0, 2.0, 1.0, 1.0, 0.0]).reshape(3,3)
+    >>> data = [
+    ...     LabeledPoint(0.0, [0.0, 0.0]),
+    ...     LabeledPoint(0.0, [0.0, 1.0]),
+    ...     LabeledPoint(1.0, [1.0, 0.0]),
+    ... ]
     >>> model = NaiveBayes.train(sc.parallelize(data))
     >>> model.predict(array([0.0, 1.0]))
     0.0
     >>> model.predict(array([1.0, 0.0]))
     1.0
     >>> sparse_data = [
-    ...     SparseVector(3, [0, 2], [0.0, 1.0]),
-    ...     SparseVector(3, [0, 2], [0.0, 2.0]),
-    ...     SparseVector(3, [0, 1], [1.0, 1.0])
+    ...     LabeledPoint(0.0, SparseVector(2, {1: 0.0}),
+    ...     LabeledPoint(0.0, SparseVector(2, {1: 1.0}),
+    ...     LabeledPoint(1.0, SparseVector(2, {0: 1.0})
     ... ]
     >>> model = NaiveBayes.train(sc.parallelize(sparse_data))
-    >>> model.predict(SparseVector(2, [1], [1.0]))
+    >>> model.predict(SparseVector(2, {1: 1.0}))
     0.0
-    >>> model.predict(SparseVector(2, [0], [1.0]))
+    >>> model.predict(SparseVector(2, {0: 1.0}))
     1.0
     """
 

--- a/python/pyspark/mllib/clustering.py
+++ b/python/pyspark/mllib/clustering.py
@@ -36,10 +36,10 @@ class KMeansModel(object):
     True
     >>> clusters = KMeans.train(sc.parallelize(data), 2)
     >>> sparse_data = [
-    ...     SparseVector(3, [0, 1], [0.0, 1.0]),
-    ...     SparseVector(3, [0, 1], [0.0, 1.1]),
-    ...     SparseVector(3, [0, 2], [0.0, 1.0]),
-    ...     SparseVector(3, [0, 2], [0.0, 1.1])
+    ...     SparseVector(3, {1: 1.0}),
+    ...     SparseVector(3, {1: 1.1}),
+    ...     SparseVector(3, {2: 1.0}),
+    ...     SparseVector(3, {2: 1.1})
     ... ]
     >>> clusters = KMeans.train(sc.parallelize(sparse_data), 2, initializationMode="k-means||")
     >>> clusters.predict(array([0., 1., 0.])) == clusters.predict(array([0, 1.1, 0.]))

--- a/python/pyspark/mllib/clustering.py
+++ b/python/pyspark/mllib/clustering.py
@@ -52,7 +52,7 @@ class KMeansModel(object):
     >>> model.predict(sparse_data[2]) == model.predict(sparse_data[3])
     True
     >>> type(model.clusterCenters)
-    list
+    <type 'list'>
     """
     def __init__(self, centers):
         self.centers = centers

--- a/python/pyspark/mllib/clustering.py
+++ b/python/pyspark/mllib/clustering.py
@@ -57,7 +57,7 @@ class KMeansModel(object):
     def predict(self, x):
         """Find the cluster to which x belongs in this model."""
         best = 0
-        best_distance = 1e75
+        best_distance = float("inf")
         for i in range(0, self.centers.shape[0]):
             distance = _squared_distance(x, self.centers[i])
             if distance < best_distance:

--- a/python/pyspark/mllib/linalg.py
+++ b/python/pyspark/mllib/linalg.py
@@ -23,7 +23,7 @@ object from MLlib or pass SciPy C{scipy.sparse} column vectors if
 SciPy is available in their environment.
 """
 
-from numpy import array
+from numpy import array, array_equal, ndarray
 
 
 class SparseVector(object):
@@ -35,23 +35,57 @@ class SparseVector(object):
     def __init__(self, size, *args):
         """
         Create a sparse vector, using either an array of (index, value) pairs
-        or two separate arrays of indices and values.
+        or two separate arrays of indices and values (sorted by index).
 
         >>> print SparseVector(4, [(1, 1.0), (3, 5.5)])
         [1: 1.0, 3: 5.5]
         >>> print SparseVector(4, [1, 3], [1.0, 5.5])
         [1: 1.0, 3: 5.5]
         """
+        assert type(size) == int, "first argument must be an int"
         self.size = size
         assert 1 <= len(args) <= 2, "must pass either 1 or 2 arguments"
         if len(args) == 1:
-            pairs = args[0]
+            pairs = sorted(args[0])
             self.indices = array([p[0] for p in pairs], dtype='int32')
             self.values = array([p[1] for p in pairs], dtype='float64')
         else:
             assert len(args[0]) == len(args[1]), "index and value arrays not same length"
             self.indices = array(args[0], dtype='int32')
             self.values = array(args[1], dtype='float64')
+            for i in xrange(len(self.indices) - 1):
+                if self.indices[i] >= self.indices[i + 1]:
+                    raise TypeError("indices array must be sorted")
+
+    def dot(self, other):
+        """
+        Dot product with another SparseVector or NumPy array.
+
+        >>> a = SparseVector(4, [1, 3], [3.0, 4.0])
+        >>> a.dot(a)
+        25.0
+        >>> a.dot(array([1., 2., 3., 4.]))
+        22.0
+        >>> b = SparseVector(4, [2, 4], [1.0, 2.0])
+        >>> a.dot(b)
+        0.0
+        """
+        result = 0.0
+        if type(other) == ndarray:
+            for i in xrange(len(self.indices)):
+                result += self.values[i] * other[self.indices[i]]
+        else:
+            i, j = 0, 0
+            while i < len(self.indices) and j < len(other.indices):
+                if self.indices[i] == other.indices[j]:
+                    result += self.values[i] * other.values[j]
+                    i += 1
+                    j += 1
+                elif self.indices[i] < other.indices[j]:
+                    i += 1
+                else:
+                    j += 1
+        return result
 
     def __str__(self):
         inds = self.indices
@@ -64,6 +98,26 @@ class SparseVector(object):
         vals = self.values
         entries = ", ".join(["({0}, {1})".format(inds[i], vals[i]) for i in xrange(len(inds))])
         return "SparseVector({0}, [{1}])".format(self.size, entries)
+
+    def __eq__(self, other):
+        """
+        Test SparseVectors for equality.
+
+        >>> v1 = SparseVector(4, [(1, 1.0), (3, 5.5)])
+        >>> v2 = SparseVector(4, [(1, 1.0), (3, 5.5)])
+        >>> v1 == v2
+        True
+        >>> v1 != v2
+        False
+        """
+
+        return (isinstance(other, self.__class__)
+            and other.size == self.size
+            and array_equal(other.indices, self.indices)
+            and array_equal(other.values, self.values))
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 
 
@@ -80,7 +134,7 @@ class Vectors(object):
     def sparse(size, *args):
         """
         Create a sparse vector, using either an array of (index, value) pairs
-        or two separate arrays of indices and values.
+        or two separate arrays of indices and values (sorted by index).
 
         >>> print Vectors.sparse(4, [(1, 1.0), (3, 5.5)])
         [1: 1.0, 3: 5.5]

--- a/python/pyspark/mllib/linalg.py
+++ b/python/pyspark/mllib/linalg.py
@@ -34,9 +34,16 @@ class SparseVector(object):
 
     def __init__(self, size, *args):
         """
-        Create a sparse vector, using either an array of (index, value) pairs
-        or two separate arrays of indices and values (sorted by index).
+        Create a sparse vector, using either a dictionary, a list of
+        (index, value) pairs, or two separate arrays of indices and
+        values (sorted by index).
 
+        @param size: Size of the vector.
+        @param args: Non-zero entries, as a dictionary, list of tupes,
+                     or two sorted lists containing indices and values.
+
+        >>> print SparseVector(4, {1: 1.0, 3: 5.5})
+        [1: 1.0, 3: 5.5]
         >>> print SparseVector(4, [(1, 1.0), (3, 5.5)])
         [1: 1.0, 3: 5.5]
         >>> print SparseVector(4, [1, 3], [1.0, 5.5])
@@ -44,9 +51,12 @@ class SparseVector(object):
         """
         assert type(size) == int, "first argument must be an int"
         self.size = size
-        assert 1 <= len(args) <= 2, "must pass either 1 or 2 arguments"
+        assert 1 <= len(args) <= 2, "must pass either 2 or 3 arguments"
         if len(args) == 1:
-            pairs = sorted(args[0])
+            pairs = args[0]
+            if type(pairs) == dict:
+               pairs = pairs.items()
+            pairs = sorted(pairs)
             self.indices = array([p[0] for p in pairs], dtype='int32')
             self.values = array([p[1] for p in pairs], dtype='float64')
         else:
@@ -154,8 +164,8 @@ class SparseVector(object):
     def __repr__(self):
         inds = self.indices
         vals = self.values
-        entries = ", ".join(["({0}, {1})".format(inds[i], vals[i]) for i in xrange(len(inds))])
-        return "SparseVector({0}, [{1}])".format(self.size, entries)
+        entries = ", ".join(["{0}: {1}".format(inds[i], vals[i]) for i in xrange(len(inds))])
+        return "SparseVector({0}, {{{1}}})".format(self.size, entries)
 
     def __eq__(self, other):
         """
@@ -191,9 +201,16 @@ class Vectors(object):
     @staticmethod
     def sparse(size, *args):
         """
-        Create a sparse vector, using either an array of (index, value) pairs
-        or two separate arrays of indices and values (sorted by index).
+        Create a sparse vector, using either a dictionary, a list of
+        (index, value) pairs, or two separate arrays of indices and
+        values (sorted by index).
 
+        @param size: Size of the vector.
+        @param args: Non-zero entries, as a dictionary, list of tupes,
+                     or two sorted lists containing indices and values.
+
+        >>> print Vectors.sparse(4, {1: 1.0, 3: 5.5})
+        [1: 1.0, 3: 5.5]
         >>> print Vectors.sparse(4, [(1, 1.0), (3, 5.5)])
         [1: 1.0, 3: 5.5]
         >>> print Vectors.sparse(4, [1, 3], [1.0, 5.5])

--- a/python/pyspark/mllib/linalg.py
+++ b/python/pyspark/mllib/linalg.py
@@ -23,7 +23,7 @@ object from MLlib or pass SciPy C{scipy.sparse} column vectors if
 SciPy is available in their environment.
 """
 
-from numpy import array, array_equal, ndarray
+from numpy import array, array_equal, ndarray, float64, int32
 
 
 class SparseVector(object):
@@ -57,12 +57,12 @@ class SparseVector(object):
             if type(pairs) == dict:
                pairs = pairs.items()
             pairs = sorted(pairs)
-            self.indices = array([p[0] for p in pairs], dtype='int32')
-            self.values = array([p[1] for p in pairs], dtype='float64')
+            self.indices = array([p[0] for p in pairs], dtype=int32)
+            self.values = array([p[1] for p in pairs], dtype=float64)
         else:
             assert len(args[0]) == len(args[1]), "index and value arrays not same length"
-            self.indices = array(args[0], dtype='int32')
-            self.values = array(args[1], dtype='float64')
+            self.indices = array(args[0], dtype=int32)
+            self.values = array(args[1], dtype=float64)
             for i in xrange(len(self.indices) - 1):
                 if self.indices[i] >= self.indices[i + 1]:
                     raise TypeError("indices array must be sorted")
@@ -232,7 +232,7 @@ class Vectors(object):
         >>> Vectors.dense([1, 2, 3])
         array([ 1.,  2.,  3.])
         """
-        return array(elements, dtype='float64')
+        return array(elements, dtype=float64)
 
 
 def _test():

--- a/python/pyspark/mllib/linalg.py
+++ b/python/pyspark/mllib/linalg.py
@@ -16,7 +16,7 @@
 #
 
 """
-MLlib utilities for working with vectors. For dense vectors, MLlib
+MLlib utilities for linear algebra. For dense vectors, MLlib
 uses the NumPy C{array} type, so you can simply pass NumPy arrays
 around. For sparse vectors, users can construct a L{SparseVector}
 object from MLlib or pass SciPy C{scipy.sparse} column vectors if
@@ -29,7 +29,7 @@ from numpy import array, array_equal, ndarray
 class SparseVector(object):
     """
     A simple sparse vector class for passing data to MLlib. Users may
-    alternatively pass use SciPy's {scipy.sparse} data types.
+    alternatively pass SciPy's {scipy.sparse} data types.
     """
 
     def __init__(self, size, *args):
@@ -40,7 +40,7 @@ class SparseVector(object):
 
         @param size: Size of the vector.
         @param args: Non-zero entries, as a dictionary, list of tupes,
-                     or two sorted lists containing indices and values.
+               or two sorted lists containing indices and values.
 
         >>> print SparseVector(4, {1: 1.0, 3: 5.5})
         [1: 1.0, 3: 5.5]
@@ -115,7 +115,7 @@ class SparseVector(object):
         >>> a.squared_distance(a)
         0.0
         >>> a.squared_distance(array([1., 2., 3., 4.]))
-        1.0
+        11.0
         >>> b = SparseVector(4, [2, 4], [1.0, 2.0])
         >>> a.squared_distance(b)
         30.0
@@ -125,9 +125,14 @@ class SparseVector(object):
         if type(other) == ndarray:
             if other.ndim == 1:
                 result = 0.0
-                for i in xrange(len(self.indices)):
-                    diff = self.values[i] - other[self.indices[i]]
-                    result += diff * diff
+                j = 0   # index into our own array
+                for i in xrange(other.shape[0]):
+                    if j < len(self.indices) and self.indices[j] == i:
+                        diff = self.values[j] - other[i]
+                        result += diff * diff
+                        j += 1
+                    else:
+                        result += other[i] * other[i]
                 return result
             else:
                 raise Exception("Cannot call squared_distance with %d-dimensional array" %
@@ -191,7 +196,7 @@ class SparseVector(object):
 
 class Vectors(object):
     """
-    Factory methods to create MLlib vectors. Note that dense vectors
+    Factory methods for working with vectors. Note that dense vectors
     are simply represented as NumPy array objects, so there is no need
     to covert them for use in MLlib. For sparse vectors, the factory
     methods in this class create an MLlib-compatible type, or users

--- a/python/pyspark/mllib/linalg.py
+++ b/python/pyspark/mllib/linalg.py
@@ -1,0 +1,111 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+MLlib utilities for working with vectors. For dense vectors, MLlib
+uses the NumPy C{array} type, so you can simply pass NumPy arrays
+around. For sparse vectors, users can construct a L{SparseVector}
+object from MLlib or pass SciPy C{scipy.sparse} column vectors if
+SciPy is available in their environment.
+"""
+
+from numpy import array
+
+
+class SparseVector(object):
+    """
+    A simple sparse vector class for passing data to MLlib. Users may
+    alternatively pass use SciPy's {scipy.sparse} data types.
+    """
+
+    def __init__(self, size, *args):
+        """
+        Create a sparse vector, using either an array of (index, value) pairs
+        or two separate arrays of indices and values.
+
+        >>> print SparseVector(4, [(1, 1.0), (3, 5.5)])
+        [1: 1.0, 3: 5.5]
+        >>> print SparseVector(4, [1, 3], [1.0, 5.5])
+        [1: 1.0, 3: 5.5]
+        """
+        self.size = size
+        assert 1 <= len(args) <= 2, "must pass either 1 or 2 arguments"
+        if len(args) == 1:
+            pairs = args[0]
+            self.indices = array([p[0] for p in pairs], dtype='int32')
+            self.values = array([p[1] for p in pairs], dtype='float64')
+        else:
+            assert len(args[0]) == len(args[1]), "index and value arrays not same length"
+            self.indices = array(args[0], dtype='int32')
+            self.values = array(args[1], dtype='float64')
+
+    def __str__(self):
+        inds = self.indices
+        vals = self.values
+        entries = ", ".join(["{0}: {1}".format(inds[i], vals[i]) for i in xrange(len(inds))])
+        return "[" + entries + "]"
+
+    def __repr__(self):
+        inds = self.indices
+        vals = self.values
+        entries = ", ".join(["({0}, {1})".format(inds[i], vals[i]) for i in xrange(len(inds))])
+        return "SparseVector({0}, [{1}])".format(self.size, entries)
+
+
+
+class Vectors(object):
+    """
+    Factory methods to create MLlib vectors. Note that dense vectors
+    are simply represented as NumPy array objects, so there is no need
+    to covert them for use in MLlib. For sparse vectors, the factory
+    methods in this class create an MLlib-compatible type, or users
+    can pass in SciPy's C{scipy.sparse} column vectors.
+    """
+
+    @staticmethod
+    def sparse(size, *args):
+        """
+        Create a sparse vector, using either an array of (index, value) pairs
+        or two separate arrays of indices and values.
+
+        >>> print Vectors.sparse(4, [(1, 1.0), (3, 5.5)])
+        [1: 1.0, 3: 5.5]
+        >>> print Vectors.sparse(4, [1, 3], [1.0, 5.5])
+        [1: 1.0, 3: 5.5]
+        """
+        return SparseVector(size, *args)
+
+    @staticmethod
+    def dense(elements):
+        """
+        Create a dense vector of 64-bit floats from a Python list. Always
+        returns a NumPy array.
+
+        >>> Vectors.dense([1, 2, 3])
+        array([ 1.,  2.,  3.])
+        """
+        return array(elements, dtype='float64')
+
+
+def _test():
+    import doctest
+    (failure_count, test_count) = doctest.testmod(optionflags=doctest.ELLIPSIS)
+    if failure_count:
+        exit(-1)
+
+if __name__ == "__main__":
+    _test()

--- a/python/pyspark/mllib/regression.py
+++ b/python/pyspark/mllib/regression.py
@@ -15,15 +15,35 @@
 # limitations under the License.
 #
 
-from numpy import array, dot
+from numpy import array, ndarray
 from pyspark import SparkContext
 from pyspark.mllib._common import \
     _dot, _get_unmangled_rdd, _get_unmangled_double_vector_rdd, \
     _serialize_double_matrix, _deserialize_double_matrix, \
     _serialize_double_vector, _deserialize_double_vector, \
     _get_initial_weights, _serialize_rating, _regression_train_wrapper, \
-    _linear_predictor_typecheck
+    _linear_predictor_typecheck, _have_scipy, _scipy_issparse
 from pyspark.mllib.linalg import SparseVector
+
+
+class LabeledPoint(object):
+    """
+    The features and labels of a data point.
+
+    @param label: Label for this data point.
+    @param features: Vector of features for this point (NumPy array, list,
+        pyspark.mllib.linalg.SparseVector, or scipy.sparse column matrix)
+    """
+    def __init__(self, label, features):
+        self.label = label
+        if (type(features) == ndarray or type(features) == SparseVector
+                or (_have_scipy and _scipy_issparse(features))):
+            self.features = features
+        elif type(features) == list:
+            self.features = array(features)
+        else:
+            raise TypeError("Expected NumPy array, list, SparseVector, or scipy.sparse matrix")
+
 
 class LinearModel(object):
     """Something that has a vector of coefficients and an intercept."""
@@ -31,13 +51,14 @@ class LinearModel(object):
         self._coeff = coeff
         self._intercept = intercept
 
+
 class LinearRegressionModelBase(LinearModel):
     """A linear regression model.
 
     >>> lrmb = LinearRegressionModelBase(array([1.0, 2.0]), 0.1)
     >>> abs(lrmb.predict(array([-1.03, 7.777])) - 14.624) < 1e-6
     True
-    >>> abs(lrmb.predict(SparseVector(2, [0, 1], [-1.03, 7.777])) - 14.624) < 1e-6
+    >>> abs(lrmb.predict(SparseVector(2, {0: -1.03, 1: 7.777})) - 14.624) < 1e-6
     True
     """
     def predict(self, x):
@@ -46,29 +67,37 @@ class LinearRegressionModelBase(LinearModel):
         _linear_predictor_typecheck(x, self._coeff)
         return _dot(x, self._coeff) + self._intercept
 
+
 class LinearRegressionModel(LinearRegressionModelBase):
     """A linear regression model derived from a least-squares fit.
 
-    >>> data = array([0.0, 0.0, 1.0, 1.0, 3.0, 2.0, 2.0, 3.0]).reshape(4,2)
+    >>> from pyspark.mllib.regression import LabeledPoint
+    >>> data = [
+    ...     LabeledPoint(0.0, [0.0]),
+    ...     LabeledPoint(1.0, [1.0]),
+    ...     LabeledPoint(3.0, [2.0]),
+    ...     LabeledPoint(2.0, [3.0])
+    ... ]
     >>> lrm = LinearRegressionWithSGD.train(sc.parallelize(data), initialWeights=array([1.0]))
     >>> abs(lrm.predict(array([0.0])) - 0) < 0.5
     True
     >>> abs(lrm.predict(array([1.0])) - 1) < 0.5
     True
-    >>> abs(lrm.predict(SparseVector(1, [0], [1.0])) - 1) < 0.5
+    >>> abs(lrm.predict(SparseVector(1, {0: 1.0})) - 1) < 0.5
     True
     >>> data = [
-    ...     SparseVector(2, [0, 1], [0.0, 0.0]),
-    ...     SparseVector(2, [0, 1], [1.0, 1.0]),
-    ...     SparseVector(2, [0, 1], [3.0, 2.0]),
-    ...     SparseVector(2, [0, 1], [2.0, 3.0])
+    ...     LabeledPoint(0.0, SparseVector(1, {0: 0.0})),
+    ...     LabeledPoint(1.0, SparseVector(1, {0: 1.0})),
+    ...     LabeledPoint(3.0, SparseVector(1, {0: 2.0})),
+    ...     LabeledPoint(2.0, SparseVector(1, {0: 3.0}))
     ... ]
     >>> lrm = LinearRegressionWithSGD.train(sc.parallelize(data), initialWeights=array([1.0]))
     >>> abs(lrm.predict(array([0.0])) - 0) < 0.5
     True
-    >>> abs(lrm.predict(SparseVector(1, [0], [1.0])) - 1) < 0.5
+    >>> abs(lrm.predict(SparseVector(1, {0: 1.0})) - 1) < 0.5
     True
     """
+
 
 class LinearRegressionWithSGD(object):
     @classmethod
@@ -81,30 +110,38 @@ class LinearRegressionWithSGD(object):
                         d._jrdd, iterations, step, miniBatchFraction, i),
                 LinearRegressionModel, data, initialWeights)
 
+
 class LassoModel(LinearRegressionModelBase):
     """A linear regression model derived from a least-squares fit with an
     l_1 penalty term.
 
-    >>> data = array([0.0, 0.0, 1.0, 1.0, 3.0, 2.0, 2.0, 3.0]).reshape(4,2)
+    >>> from pyspark.mllib.regression import LabeledPoint
+    >>> data = [
+    ...     LabeledPoint(0.0, [0.0]),
+    ...     LabeledPoint(1.0, [1.0]),
+    ...     LabeledPoint(3.0, [2.0]),
+    ...     LabeledPoint(2.0, [3.0])
+    ... ]
     >>> lrm = LassoWithSGD.train(sc.parallelize(data), initialWeights=array([1.0]))
     >>> abs(lrm.predict(array([0.0])) - 0) < 0.5
     True
     >>> abs(lrm.predict(array([1.0])) - 1) < 0.5
     True
-    >>> abs(lrm.predict(SparseVector(1, [0], [1.0])) - 1) < 0.5
+    >>> abs(lrm.predict(SparseVector(1, {0: 1.0})) - 1) < 0.5
     True
     >>> data = [
-    ...     SparseVector(2, [0, 1], [0.0, 0.0]),
-    ...     SparseVector(2, [0, 1], [1.0, 1.0]),
-    ...     SparseVector(2, [0, 1], [3.0, 2.0]),
-    ...     SparseVector(2, [0, 1], [2.0, 3.0])
+    ...     LabeledPoint(0.0, SparseVector(1, {0: 0.0})),
+    ...     LabeledPoint(1.0, SparseVector(1, {0: 1.0})),
+    ...     LabeledPoint(3.0, SparseVector(1, {0: 2.0})),
+    ...     LabeledPoint(2.0, SparseVector(1, {0: 3.0}))
     ... ]
     >>> lrm = LinearRegressionWithSGD.train(sc.parallelize(data), initialWeights=array([1.0]))
     >>> abs(lrm.predict(array([0.0])) - 0) < 0.5
     True
-    >>> abs(lrm.predict(SparseVector(1, [0], [1.0])) - 1) < 0.5
+    >>> abs(lrm.predict(SparseVector(1, {0: 1.0})) - 1) < 0.5
     True
     """
+
 
 class LassoWithSGD(object):
     @classmethod
@@ -117,30 +154,38 @@ class LassoWithSGD(object):
                         iterations, step, regParam, miniBatchFraction, i),
                 LassoModel, data, initialWeights)
 
+
 class RidgeRegressionModel(LinearRegressionModelBase):
     """A linear regression model derived from a least-squares fit with an
     l_2 penalty term.
 
-    >>> data = array([0.0, 0.0, 1.0, 1.0, 3.0, 2.0, 2.0, 3.0]).reshape(4,2)
+    >>> from pyspark.mllib.regression import LabeledPoint
+    >>> data = [
+    ...     LabeledPoint(0.0, [0.0]),
+    ...     LabeledPoint(1.0, [1.0]),
+    ...     LabeledPoint(3.0, [2.0]),
+    ...     LabeledPoint(2.0, [3.0])
+    ... ]
     >>> lrm = RidgeRegressionWithSGD.train(sc.parallelize(data), initialWeights=array([1.0]))
     >>> abs(lrm.predict(array([0.0])) - 0) < 0.5
     True
     >>> abs(lrm.predict(array([1.0])) - 1) < 0.5
     True
-    >>> abs(lrm.predict(SparseVector(1, [0], [1.0])) - 1) < 0.5
+    >>> abs(lrm.predict(SparseVector(1, {0: 1.0})) - 1) < 0.5
     True
     >>> data = [
-    ...     SparseVector(2, [0, 1], [0.0, 0.0]),
-    ...     SparseVector(2, [0, 1], [1.0, 1.0]),
-    ...     SparseVector(2, [0, 1], [3.0, 2.0]),
-    ...     SparseVector(2, [0, 1], [2.0, 3.0])
+    ...     LabeledPoint(0.0, SparseVector(1, {0: 0.0})),
+    ...     LabeledPoint(1.0, SparseVector(1, {0: 1.0})),
+    ...     LabeledPoint(3.0, SparseVector(1, {0: 2.0})),
+    ...     LabeledPoint(2.0, SparseVector(1, {0: 3.0}))
     ... ]
     >>> lrm = LinearRegressionWithSGD.train(sc.parallelize(data), initialWeights=array([1.0]))
     >>> abs(lrm.predict(array([0.0])) - 0) < 0.5
     True
-    >>> abs(lrm.predict(SparseVector(1, [0], [1.0])) - 1) < 0.5
+    >>> abs(lrm.predict(SparseVector(1, {0: 1.0})) - 1) < 0.5
     True
     """
+
 
 class RidgeRegressionWithSGD(object):
     @classmethod
@@ -152,6 +197,7 @@ class RidgeRegressionWithSGD(object):
                 sc._jvm.PythonMLLibAPI().trainRidgeModelWithSGD(d._jrdd,
                         iterations, step, regParam, miniBatchFraction, i),
                 RidgeRegressionModel, data, initialWeights)
+
 
 def _test():
     import doctest

--- a/python/pyspark/mllib/regression.py
+++ b/python/pyspark/mllib/regression.py
@@ -18,7 +18,7 @@
 from numpy import array, dot
 from pyspark import SparkContext
 from pyspark.mllib._common import \
-    _get_unmangled_rdd, _get_unmangled_double_vector_rdd, \
+    _dot, _get_unmangled_rdd, _get_unmangled_double_vector_rdd, \
     _serialize_double_matrix, _deserialize_double_matrix, \
     _serialize_double_vector, _deserialize_double_vector, \
     _get_initial_weights, _serialize_rating, _regression_train_wrapper, \
@@ -44,7 +44,7 @@ class LinearRegressionModelBase(LinearModel):
         """Predict the value of the dependent variable given a vector x"""
         """containing values for the independent variables."""
         _linear_predictor_typecheck(x, self._coeff)
-        return x.dot(self._coeff) + self._intercept
+        return _dot(x, self._coeff) + self._intercept
 
 class LinearRegressionModel(LinearRegressionModelBase):
     """A linear regression model derived from a least-squares fit.

--- a/python/pyspark/mllib/regression.py
+++ b/python/pyspark/mllib/regression.py
@@ -46,10 +46,18 @@ class LabeledPoint(object):
 
 
 class LinearModel(object):
-    """Something that has a vector of coefficients and an intercept."""
-    def __init__(self, coeff, intercept):
-        self._coeff = coeff
+    """A linear model that has a vector of coefficients and an intercept."""
+    def __init__(self, weights, intercept):
+        self._coeff = weights
         self._intercept = intercept
+
+    @property
+    def weights(self):
+        return self._coeff
+
+    @property
+    def intercept(self):
+        return self._intercept
 
 
 class LinearRegressionModelBase(LinearModel):

--- a/python/pyspark/mllib/regression.py
+++ b/python/pyspark/mllib/regression.py
@@ -23,6 +23,7 @@ from pyspark.mllib._common import \
     _serialize_double_vector, _deserialize_double_vector, \
     _get_initial_weights, _serialize_rating, _regression_train_wrapper, \
     _linear_predictor_typecheck
+from pyspark.mllib.linalg import SparseVector
 
 class LinearModel(object):
     """Something that has a vector of coefficients and an intercept."""
@@ -36,18 +37,37 @@ class LinearRegressionModelBase(LinearModel):
     >>> lrmb = LinearRegressionModelBase(array([1.0, 2.0]), 0.1)
     >>> abs(lrmb.predict(array([-1.03, 7.777])) - 14.624) < 1e-6
     True
+    >>> abs(lrmb.predict(SparseVector(2, [0, 1], [-1.03, 7.777])) - 14.624) < 1e-6
+    True
     """
     def predict(self, x):
         """Predict the value of the dependent variable given a vector x"""
         """containing values for the independent variables."""
         _linear_predictor_typecheck(x, self._coeff)
-        return dot(self._coeff, x) + self._intercept
+        return x.dot(self._coeff) + self._intercept
 
 class LinearRegressionModel(LinearRegressionModelBase):
     """A linear regression model derived from a least-squares fit.
 
     >>> data = array([0.0, 0.0, 1.0, 1.0, 3.0, 2.0, 2.0, 3.0]).reshape(4,2)
     >>> lrm = LinearRegressionWithSGD.train(sc.parallelize(data), initialWeights=array([1.0]))
+    >>> abs(lrm.predict(array([0.0])) - 0) < 0.5
+    True
+    >>> abs(lrm.predict(array([1.0])) - 1) < 0.5
+    True
+    >>> abs(lrm.predict(SparseVector(1, [0], [1.0])) - 1) < 0.5
+    True
+    >>> data = [
+    ...     SparseVector(2, [0, 1], [0.0, 0.0]),
+    ...     SparseVector(2, [0, 1], [1.0, 1.0]),
+    ...     SparseVector(2, [0, 1], [3.0, 2.0]),
+    ...     SparseVector(2, [0, 1], [2.0, 3.0])
+    ... ]
+    >>> lrm = LinearRegressionWithSGD.train(sc.parallelize(data), initialWeights=array([1.0]))
+    >>> abs(lrm.predict(array([0.0])) - 0) < 0.5
+    True
+    >>> abs(lrm.predict(SparseVector(1, [0], [1.0])) - 1) < 0.5
+    True
     """
 
 class LinearRegressionWithSGD(object):
@@ -67,6 +87,23 @@ class LassoModel(LinearRegressionModelBase):
 
     >>> data = array([0.0, 0.0, 1.0, 1.0, 3.0, 2.0, 2.0, 3.0]).reshape(4,2)
     >>> lrm = LassoWithSGD.train(sc.parallelize(data), initialWeights=array([1.0]))
+    >>> abs(lrm.predict(array([0.0])) - 0) < 0.5
+    True
+    >>> abs(lrm.predict(array([1.0])) - 1) < 0.5
+    True
+    >>> abs(lrm.predict(SparseVector(1, [0], [1.0])) - 1) < 0.5
+    True
+    >>> data = [
+    ...     SparseVector(2, [0, 1], [0.0, 0.0]),
+    ...     SparseVector(2, [0, 1], [1.0, 1.0]),
+    ...     SparseVector(2, [0, 1], [3.0, 2.0]),
+    ...     SparseVector(2, [0, 1], [2.0, 3.0])
+    ... ]
+    >>> lrm = LinearRegressionWithSGD.train(sc.parallelize(data), initialWeights=array([1.0]))
+    >>> abs(lrm.predict(array([0.0])) - 0) < 0.5
+    True
+    >>> abs(lrm.predict(SparseVector(1, [0], [1.0])) - 1) < 0.5
+    True
     """
 
 class LassoWithSGD(object):
@@ -86,6 +123,23 @@ class RidgeRegressionModel(LinearRegressionModelBase):
 
     >>> data = array([0.0, 0.0, 1.0, 1.0, 3.0, 2.0, 2.0, 3.0]).reshape(4,2)
     >>> lrm = RidgeRegressionWithSGD.train(sc.parallelize(data), initialWeights=array([1.0]))
+    >>> abs(lrm.predict(array([0.0])) - 0) < 0.5
+    True
+    >>> abs(lrm.predict(array([1.0])) - 1) < 0.5
+    True
+    >>> abs(lrm.predict(SparseVector(1, [0], [1.0])) - 1) < 0.5
+    True
+    >>> data = [
+    ...     SparseVector(2, [0, 1], [0.0, 0.0]),
+    ...     SparseVector(2, [0, 1], [1.0, 1.0]),
+    ...     SparseVector(2, [0, 1], [3.0, 2.0]),
+    ...     SparseVector(2, [0, 1], [2.0, 3.0])
+    ... ]
+    >>> lrm = LinearRegressionWithSGD.train(sc.parallelize(data), initialWeights=array([1.0]))
+    >>> abs(lrm.predict(array([0.0])) - 0) < 0.5
+    True
+    >>> abs(lrm.predict(SparseVector(1, [0], [1.0])) - 1) < 0.5
+    True
     """
 
 class RidgeRegressionWithSGD(object):

--- a/python/pyspark/mllib/tests.py
+++ b/python/pyspark/mllib/tests.py
@@ -1,0 +1,199 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Fuller unit tests for Python MLlib.
+"""
+
+from numpy import array, array_equal
+import unittest
+
+from pyspark.mllib._common import _convert_vector, _serialize_double_vector, \
+        _deserialize_double_vector, _dot, _squared_distance
+from pyspark.mllib.linalg import SparseVector
+from pyspark.tests import PySparkTestCase
+
+
+_have_scipy = False
+try:
+    import scipy.sparse
+    _have_scipy = True
+except:
+    # No SciPy, but that's okay, we'll skip those tests
+    pass
+
+
+class VectorTests(unittest.TestCase):
+    def test_serialize(self):
+        sv = SparseVector(4, {1: 1, 3: 2})
+        dv = array([1., 2., 3., 4.])
+        self.assertTrue(sv is _convert_vector(sv))
+        self.assertTrue(dv is _convert_vector(dv))
+        self.assertEquals(sv,
+                _deserialize_double_vector(_serialize_double_vector(sv)))
+        self.assertTrue(array_equal(dv,
+                _deserialize_double_vector(_serialize_double_vector(dv))))
+
+    def test_dot(self):
+        sv = SparseVector(4, {1: 1, 3: 2})
+        dv = array([1., 2., 3., 4.])
+        mat = array([[1., 2., 3., 4.],
+                     [1., 2., 3., 4.],
+                     [1., 2., 3., 4.],
+                     [1., 2., 3., 4.]])
+        self.assertEquals(10.0, _dot(sv, dv))
+        self.assertTrue(array_equal(array([3., 6., 9., 12.]), _dot(sv, mat)))
+        self.assertEquals(30.0, _dot(dv, dv))
+        self.assertTrue(array_equal(array([10., 20., 30., 40.]), _dot(dv, mat)))
+
+
+@unittest.skipIf(not _have_scipy, "SciPy not installed")
+class SciPyTests(PySparkTestCase):
+    def test_serialize(self):
+        from scipy.sparse import lil_matrix
+        lil = lil_matrix((4, 1))
+        lil[1, 0] = 1
+        lil[3, 0] = 2
+        sv = SparseVector(4, {1: 1, 3: 2})
+        self.assertEquals(sv, _convert_vector(lil))
+        self.assertEquals(sv, _convert_vector(lil.tocsc()))
+        self.assertEquals(sv, _convert_vector(lil.tocoo()))
+        self.assertEquals(sv, _convert_vector(lil.tocsr()))
+        self.assertEquals(sv, _convert_vector(lil.todok()))
+        self.assertEquals(sv,
+                _deserialize_double_vector(_serialize_double_vector(lil)))
+        self.assertEquals(sv,
+                _deserialize_double_vector(_serialize_double_vector(lil.tocsc())))
+        self.assertEquals(sv,
+                _deserialize_double_vector(_serialize_double_vector(lil.tocsr())))
+        self.assertEquals(sv,
+                _deserialize_double_vector(_serialize_double_vector(lil.todok())))
+
+    def test_dot(self):
+        from scipy.sparse import lil_matrix
+        lil = lil_matrix((4, 1))
+        lil[1, 0] = 1
+        lil[3, 0] = 2
+        dv = array([1., 2., 3., 4.])
+        sv = SparseVector(4, {0: 1, 1: 2, 2: 3, 3: 4})
+        mat = array([[1., 2., 3., 4.],
+                     [1., 2., 3., 4.],
+                     [1., 2., 3., 4.],
+                     [1., 2., 3., 4.]])
+        self.assertEquals(10.0, _dot(lil, dv))
+        self.assertTrue(array_equal(array([3., 6., 9., 12.]), _dot(lil, mat)))
+
+    def test_squared_distance(self):
+        from scipy.sparse import lil_matrix
+        lil = lil_matrix((4, 1))
+        lil[1, 0] = 3
+        lil[3, 0] = 2
+        dv = array([1., 2., 3., 4.])
+        sv = SparseVector(4, {0: 1, 1: 2, 2: 3, 3: 4})
+        self.assertEquals(15.0, _squared_distance(lil, dv))
+        self.assertEquals(15.0, _squared_distance(lil, sv))
+        self.assertEquals(15.0, _squared_distance(dv, lil))
+        self.assertEquals(15.0, _squared_distance(sv, lil))
+
+    def scipy_matrix(self, size, values):
+        """Create a column SciPy matrix from a dictionary of values"""
+        from scipy.sparse import lil_matrix
+        lil = lil_matrix((size, 1))
+        for key, value in values.items():
+            lil[key, 0] = value
+        return lil
+
+    def test_clustering(self):
+        from pyspark.mllib.clustering import KMeans
+        data = [
+            self.scipy_matrix(3, {1: 1.0}),
+            self.scipy_matrix(3, {1: 1.1}),
+            self.scipy_matrix(3, {2: 1.0}),
+            self.scipy_matrix(3, {2: 1.1})
+        ]
+        clusters = KMeans.train(self.sc.parallelize(data), 2, initializationMode="k-means||")
+        self.assertEquals(clusters.predict(data[0]), clusters.predict(data[1]))
+        self.assertEquals(clusters.predict(data[2]), clusters.predict(data[3]))
+
+    def test_classification(self):
+        from pyspark.mllib.classification import LogisticRegressionWithSGD, SVMWithSGD, NaiveBayes
+        data = [
+            self.scipy_matrix(3, {0: 0.0, 2: 0.0}),
+            self.scipy_matrix(3, {0: 1.0, 2: 1.0}),
+            self.scipy_matrix(3, {0: 0.0, 2: 0.0}),
+            self.scipy_matrix(3, {0: 1.0, 2: 2.0})
+        ]
+        rdd = self.sc.parallelize(data)
+        features = [
+            self.scipy_matrix(2, {1: 0.0}),
+            self.scipy_matrix(2, {1: 1.0}),
+            self.scipy_matrix(2, {1: 2.0}),
+        ]
+
+        lr_model = LogisticRegressionWithSGD.train(rdd)
+        self.assertTrue(lr_model.predict(features[0]) <= 0)
+        self.assertTrue(lr_model.predict(features[1]) > 0)
+        self.assertTrue(lr_model.predict(features[2]) > 0)
+
+        svm_model = SVMWithSGD.train(rdd)
+        self.assertTrue(svm_model.predict(features[0]) <= 0)
+        self.assertTrue(svm_model.predict(features[1]) > 0)
+        self.assertTrue(svm_model.predict(features[2]) > 0)
+
+        nb_model = NaiveBayes.train(rdd)
+        self.assertTrue(nb_model.predict(features[0]) <= 0)
+        self.assertTrue(nb_model.predict(features[1]) > 0)
+        self.assertTrue(nb_model.predict(features[2]) > 0)
+
+    def test_regression(self):
+        from pyspark.mllib.regression import LinearRegressionWithSGD, LassoWithSGD, \
+                RidgeRegressionWithSGD
+        data = [
+            self.scipy_matrix(3, {0: -1.0, 2: -1.0}),
+            self.scipy_matrix(3, {0: 1.0, 2: 1.0}),
+            self.scipy_matrix(3, {0: -1.0, 2: -2.0}),
+            self.scipy_matrix(3, {0: 1.0, 2: 2.0})
+        ]
+        rdd = self.sc.parallelize(data)
+        features = [
+            self.scipy_matrix(2, {1: -1.0}),
+            self.scipy_matrix(2, {1: 1.0}),
+            self.scipy_matrix(2, {1: 2.0}),
+        ]
+
+        lr_model = LinearRegressionWithSGD.train(rdd)
+        self.assertTrue(lr_model.predict(features[0]) <= 0)
+        self.assertTrue(lr_model.predict(features[1]) > 0)
+        self.assertTrue(lr_model.predict(features[2]) > 0)
+
+        lasso_model = LassoWithSGD.train(rdd)
+        self.assertTrue(lasso_model.predict(features[0]) <= 0)
+        self.assertTrue(lasso_model.predict(features[1]) > 0)
+        self.assertTrue(lasso_model.predict(features[2]) > 0)
+
+        rr_model = RidgeRegressionWithSGD.train(rdd)
+        self.assertTrue(rr_model.predict(features[0]) <= 0)
+        self.assertTrue(rr_model.predict(features[1]) > 0)
+        self.assertTrue(rr_model.predict(features[2]) > 0)
+
+
+if __name__ == "__main__":
+    if not _have_scipy:
+        print "NOTE: Skipping SciPy tests as it does not seem to be installed"
+    unittest.main()
+    if not _have_scipy:
+        print "NOTE: SciPy tests were skipped as it does not seem to be installed"

--- a/python/run-tests
+++ b/python/run-tests
@@ -60,6 +60,7 @@ run_test "pyspark/mllib/clustering.py"
 run_test "pyspark/mllib/linalg.py"
 run_test "pyspark/mllib/recommendation.py"
 run_test "pyspark/mllib/regression.py"
+run_test "pyspark/mllib/tests.py"
 
 if [[ $FAILED == 0 ]]; then
     echo -en "\033[32m"  # Green

--- a/python/run-tests
+++ b/python/run-tests
@@ -34,7 +34,7 @@ rm -rf metastore warehouse
 function run_test() {
     SPARK_TESTING=0 $FWDIR/bin/pyspark $1 2>&1 | tee -a > unit-tests.log
     FAILED=$((PIPESTATUS[0]||$FAILED))
-    
+
     # Fail and exit on the first test failure.
     if [[ $FAILED != 0 ]]; then
         cat unit-tests.log | grep -v "^[0-9][0-9]*" # filter all lines starting with a number.
@@ -57,6 +57,7 @@ run_test "pyspark/tests.py"
 run_test "pyspark/mllib/_common.py"
 run_test "pyspark/mllib/classification.py"
 run_test "pyspark/mllib/clustering.py"
+run_test "pyspark/mllib/linalg.py"
 run_test "pyspark/mllib/recommendation.py"
 run_test "pyspark/mllib/regression.py"
 


### PR DESCRIPTION
This PR adds a SparseVector class in PySpark and updates all the regression, classification and clustering algorithms and models to support sparse data, similar to MLlib. I chose to add this class because SciPy is quite difficult to install in many environments (more so than NumPy), but I plan to add support for SciPy sparse vectors later too, and make the methods work transparently on objects of either type.

On the Scala side, we keep Python sparse vectors sparse and pass them to MLlib. We always return dense vectors from our models.

Some to-do items left:
- [x] Support SciPy's scipy.sparse matrix objects when SciPy is available. We can easily add a function to convert these to our own SparseVector.
- [x] MLlib currently uses a vector with one extra column on the left to represent what we call LabeledPoint in Scala. Do we really want this? It may get annoying once you deal with sparse data since you must add/subtract 1 to each feature index when training. We can remove this API in 1.0 and use tuples for labeling.
- [x] Explain how to use these in the Python MLlib docs.

CC @mengxr, @joshrosen
