### PR TITLE
Remove extendedDebugInfo option in test build settings.

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -178,7 +178,6 @@ object SparkBuild extends Build {
     fork := true,
     javaOptions in Test += "-Dspark.home=" + sparkHome,
     javaOptions in Test += "-Dspark.testing=1",
-    javaOptions in Test += "-Dsun.io.serialization.extendedDebugInfo=true",
     javaOptions in Test ++= System.getProperties.filter(_._1 startsWith "spark").map { case (k,v) => s"-D$k=$v" }.toSeq,
     javaOptions += "-Xmx3g",
     // Show full stack trace and duration in test cases.


### PR DESCRIPTION
From this [commit](https://github.com/apache/spark/commit/accd0999f9cb6a449434d3fc5274dd469eeecab2), `SparkBuild.scala` add a new javaOptions `-Dsun.io.serialization.extendedDebugInfo=true` in Test. This make `org.apache.spark.streaming.InputStreamsSuite` failed.
