### PR TITLE
SPARK-1357 (addendum). More Experimental items in MLlib

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/classification/ClassificationModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/classification/ClassificationModel.scala
@@ -19,11 +19,15 @@ package org.apache.spark.mllib.classification
 
 import org.apache.spark.mllib.linalg.Vector
 import org.apache.spark.rdd.RDD
+import org.apache.spark.annotation.Experimental
 
 /**
+ * :: Experimental ::
+ *
  * Represents a classification model that predicts to which of a set of categories an example
  * belongs. The categories are represented by double values: 0.0, 1.0, 2.0, etc.
  */
+@Experimental
 trait ClassificationModel extends Serializable {
   /**
    * Predict values for the given data set using the model trained.

--- a/mllib/src/main/scala/org/apache/spark/mllib/classification/ClassificationModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/classification/ClassificationModel.scala
@@ -23,7 +23,6 @@ import org.apache.spark.annotation.Experimental
 
 /**
  * :: Experimental ::
- *
  * Represents a classification model that predicts to which of a set of categories an example
  * belongs. The categories are represented by double values: 0.0, 1.0, 2.0, etc.
  */

--- a/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
@@ -143,7 +143,6 @@ class ALS private (
 
   /**
    * :: Experimental ::
-   *
    * Sets the constant used in computing confidence in implicit ALS. Default: 1.0.
    */
   @Experimental

--- a/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
@@ -57,7 +57,6 @@ private[recommendation] case class InLinkBlock(
 
 /**
  * :: Experimental ::
- *
  * A more compact class to represent a rating than Tuple3[Int, Int, Double].
  */
 @Experimental

--- a/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
@@ -56,8 +56,11 @@ private[recommendation] case class InLinkBlock(
 
 
 /**
+ * :: Experimental ::
+ *
  * A more compact class to represent a rating than Tuple3[Int, Int, Double].
  */
+@Experimental
 case class Rating(val user: Int, val product: Int, val rating: Double)
 
 /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/RegressionModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/RegressionModel.scala
@@ -19,7 +19,12 @@ package org.apache.spark.mllib.regression
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.mllib.linalg.Vector
+import org.apache.spark.annotation.Experimental
 
+/**
+ * :: Experimental ::
+ */
+@Experimental
 trait RegressionModel extends Serializable {
   /**
    * Predict values for the given data set using the model trained.


### PR DESCRIPTION
Per discussion, this is my suggestion to make ALS Rating, ClassificationModel, RegressionModel experimental for now, to reserve the right to possibly change after 1.0. See what you think of this much.
