### PR TITLE
update spark.default.parallelism

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,9 +98,9 @@ Apart from these, the following properties are also available, and may be useful
   <td>spark.default.parallelism</td>
   <td>
     <ul>
-      <li>Mesos fine grained mode: 8
-      <li>Local mode: core number of the local machine
-      <li>Others: total core number of all executor nodes or 2, whichever is larger
+      <li>Mesos fine grained mode: 8</li>
+      <li>Local mode: core number of the local machine</li>
+      <li>Others: total core number of all executor nodes or 2, whichever is larger</li>
     </ul>
   </td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,7 +96,11 @@ Apart from these, the following properties are also available, and may be useful
 <tr><th>Property Name</th><th>Default</th><th>Meaning</th></tr>
 <tr>
   <td>spark.default.parallelism</td>
-  <td>8</td>
+  <td>
+    · Mesos fine grained mode: 8<br/>
+    · Local mode: core number of the local machine<br/>
+    · Others: total core number of all executor nodes or 2, whichever is larger
+  </td>
   <td>
     Default number of tasks to use across the cluster for distributed shuffle operations (<code>groupByKey</code>,
     <code>reduceByKey</code>, etc) when not set by user.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,9 +97,11 @@ Apart from these, the following properties are also available, and may be useful
 <tr>
   <td>spark.default.parallelism</td>
   <td>
-    · Mesos fine grained mode: 8<br/>
-    · Local mode: core number of the local machine<br/>
-    · Others: total core number of all executor nodes or 2, whichever is larger
+    <ul>
+      <li>Mesos fine grained mode: 8
+      <li>Local mode: core number of the local machine
+      <li>Others: total core number of all executor nodes or 2, whichever is larger
+    </ul>
   </td>
   <td>
     Default number of tasks to use across the cluster for distributed shuffle operations (<code>groupByKey</code>,


### PR DESCRIPTION
actually, the value 8 is only valid in mesos fine-grained mode :
<code>
  override def defaultParallelism() = sc.conf.getInt("spark.default.parallelism", 8)
</code>

while in coarse-grained model including mesos coares-grained, the value of the property depending on core numbers!
<code> 
override def defaultParallelism(): Int = {
   conf.getInt("spark.default.parallelism", math.max(totalCoreCount.get(), 2))
  }
</code>
