### PR TITLE
HOTFIX: Ignore python metastore files in RAT checks.

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -40,3 +40,5 @@ work
 golden
 test.out/*
 .*iml
+python/metastore/service.properties
+python/metastore/db.lck


### PR DESCRIPTION
This was causing some errors with pull request tests.
