### PR TITLE
SPARK-1465: Spark compilation is broken with the latest hadoop-2.4.0 release

### DIFF
--- a/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnableUtil.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnableUtil.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.deploy.yarn
 
+import java.io.File
 import java.net.URI
 import java.nio.ByteBuffer
 import java.security.PrivilegedExceptionAction
@@ -167,7 +168,8 @@ trait ExecutorRunnableUtil extends Logging {
     ClientBase.populateClasspath(yarnConf, sparkConf, System.getenv("SPARK_YARN_LOG4J_PATH") != null, env)
 
     // Allow users to specify some environment variables
-    Apps.setEnvFromInputString(env, System.getenv("SPARK_YARN_USER_ENV"))
+    YarnSparkHadoopUtil.setEnvFromInputString(env, System.getenv("SPARK_YARN_USER_ENV"),
+      File.pathSeparator)
 
     System.getenv().filterKeys(_.startsWith("SPARK")).foreach { case (k,v) => env(k) = v }
     env

--- a/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -17,10 +17,19 @@
 
 package org.apache.spark.deploy.yarn
 
+import java.util.Map
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+import scala.collection.mutable.HashMap
+import scala.collection.mutable.Map
+
 import org.apache.hadoop.io.Text
 import org.apache.hadoop.mapred.JobConf
 import org.apache.hadoop.security.Credentials
 import org.apache.hadoop.security.UserGroupInformation
+import org.apache.hadoop.util.Shell
+import org.apache.hadoop.util.StringInterner
 import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.apache.hadoop.yarn.api.ApplicationConstants
 import org.apache.hadoop.conf.Configuration
@@ -73,4 +82,52 @@ object YarnSparkHadoopUtil {
   def getLoggingArgsForContainerCommandLine(): String = {
     "-Dlog4j.configuration=log4j-spark-container.properties"
   }
+
+  def addToEnvironment(
+      env: HashMap[String, String],
+      variable: String,
+      value: String,
+      classPathSeparator: String) = {
+    var envVariable = ""
+    if (env.get(variable) == None) {
+      envVariable = value
+    } else {
+      envVariable = env.get(variable).get + classPathSeparator + value
+    }
+    env put (StringInterner.weakIntern(variable), StringInterner.weakIntern(envVariable))
+  }
+
+  def setEnvFromInputString(
+      env: HashMap[String, String],
+      envString: String,
+      classPathSeparator: String) = {
+    if (envString != null && envString.length() > 0) {
+      var childEnvs = envString.split(",")
+      var p = Pattern.compile(Shell.getEnvironmentVariableRegex())
+      for (cEnv <- childEnvs) {
+        var parts = cEnv.split("=") // split on '='
+        var m = p.matcher(parts(1))
+        val sb = new StringBuffer
+        while (m.find()) {
+          val variable = m.group(1)
+          var replace = ""
+          if (env.get(variable) != None) {
+            replace = env.get(variable).get
+          } else {
+            // if this key is not configured for the child .. get it
+            // from the env
+            replace = System.getenv(variable)
+            if (replace == null) {
+            // the env key is note present anywhere .. simply set it
+              replace = ""
+            }
+          }
+          m.appendReplacement(sb, Matcher.quoteReplacement(replace))
+        }
+        m.appendTail(sb)
+        addToEnvironment(env, parts(0), sb.toString(), classPathSeparator)
+      }
+    }
+  }
+
 }

--- a/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -28,7 +28,6 @@ import org.apache.hadoop.io.Text
 import org.apache.hadoop.mapred.JobConf
 import org.apache.hadoop.security.Credentials
 import org.apache.hadoop.security.UserGroupInformation
-import org.apache.hadoop.util.Shell
 import org.apache.hadoop.util.StringInterner
 import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.apache.hadoop.yarn.api.ApplicationConstants
@@ -103,7 +102,7 @@ object YarnSparkHadoopUtil {
       classPathSeparator: String) = {
     if (envString != null && envString.length() > 0) {
       var childEnvs = envString.split(",")
-      var p = Pattern.compile(Shell.getEnvironmentVariableRegex())
+      var p = Pattern.compile(getEnvironmentVariableRegex())
       for (cEnv <- childEnvs) {
         var parts = cEnv.split("=") // split on '='
         var m = p.matcher(parts(1))
@@ -127,6 +126,15 @@ object YarnSparkHadoopUtil {
         m.appendTail(sb)
         addToEnvironment(env, parts(0), sb.toString(), classPathSeparator)
       }
+    }
+  }
+
+  private def getEnvironmentVariableRegex() : String = {
+    val osName = System.getProperty("os.name")
+    if (osName startsWith "Windows") {
+      "%([A-Za-z_][A-Za-z0-9_]*?)%"
+    } else {
+      "\\$([A-Za-z_][A-Za-z0-9_]*)"
     }
   }
 

--- a/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -17,12 +17,10 @@
 
 package org.apache.spark.deploy.yarn
 
-import java.util.Map
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
 import scala.collection.mutable.HashMap
-import scala.collection.mutable.Map
 
 import org.apache.hadoop.io.Text
 import org.apache.hadoop.mapred.JobConf


### PR DESCRIPTION
YARN-1824 changes the APIs (addToEnvironment, setEnvFromInputString) in Apps, which causes the spark build to break if built against a version 2.4.0. To fix this, create the spark own function to do that functionality which will not break compiling against 2.3 and other 2.x versions.
