### PR TITLE
Loads test tables when running "sbt hive/console" without HIVE_DEV_HOME

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TestHive.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TestHive.scala
@@ -99,7 +99,12 @@ class TestHiveContext(sc: SparkContext) extends LocalHiveContext(sc) {
   hiveFilesTemp.delete()
   hiveFilesTemp.mkdir()
 
-  val inRepoTests = new File("src/test/resources/")
+  val inRepoTests = if (System.getProperty("user.dir").endsWith("sql/hive")) {
+    new File("src/test/resources/")
+  } else {
+    new File("sql/hive/src/test/resources")
+  }
+
   def getHiveFile(path: String): File = {
     val stripped = path.replaceAll("""\.\.\/""", "")
     hiveDevHome


### PR DESCRIPTION
When running Hive tests, the working directory is `$SPARK_HOME/sql/hive`, while when running `sbt hive/console`, it becomes `$SPARK_HOME`, and test tables are not loaded if `HIVE_DEV_HOME` is not defined.
