### PR TITLE
[SPARK-1511] use Files.move instead of renameTo in TestUtils.scala

### DIFF
--- a/core/src/main/scala/org/apache/spark/TestUtils.scala
+++ b/core/src/main/scala/org/apache/spark/TestUtils.scala
@@ -102,7 +102,12 @@ private[spark] object TestUtils {
     val result = new File(fileName)
     if (!result.exists()) throw new Exception("Compiled file not found: " + fileName)
     val out = new File(destDir, fileName)
-    result.renameTo(out)
+
+    // renameTo cannot handle in and out files in different filesystems
+    // use google's Files.move instead
+    Files.move(result, out)
+
+    if (!out.exists()) throw new Exception("Destination file not moved: " + out)
     out
   }
 }

--- a/core/src/main/scala/org/apache/spark/TestUtils.scala
+++ b/core/src/main/scala/org/apache/spark/TestUtils.scala
@@ -100,14 +100,14 @@ private[spark] object TestUtils {
 
     val fileName = className + ".class"
     val result = new File(fileName)
-    if (!result.exists()) throw new Exception("Compiled file not found: " + fileName)
+    assert(result.exists(), "Compiled file not found: " + result.getAbsolutePath())
     val out = new File(destDir, fileName)
 
     // renameTo cannot handle in and out files in different filesystems
     // use google's Files.move instead
     Files.move(result, out)
 
-    if (!out.exists()) throw new Exception("Destination file not moved: " + out)
+    assert(out.exists(), "Destination file not moved: " + out.getAbsolutePath())
     out
   }
 }


### PR DESCRIPTION
JIRA issue:[SPARK-1511](https://issues.apache.org/jira/browse/SPARK-1511)

TestUtils.createCompiledClass method use renameTo() to move files which fails when the src and dest files are in different disks or partitions. This pr uses Files.move() instead. The move method will try to use renameTo() and then fall back to copy() and delete(). I think this should handle this issue.

I didn't found a test suite for this file, so I add file existence detection after file moving.
