### PR TITLE
[SPARK-1361] DAGScheduler throws NullPointerException occasionally

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -274,10 +274,10 @@ class SparkContext(config: SparkConf) extends Logging {
 
   // Create and start the scheduler
   private[spark] var taskScheduler = SparkContext.createTaskScheduler(this, master)
-  taskScheduler.start()
-
   @volatile private[spark] var dagScheduler = new DAGScheduler(this)
+  
   dagScheduler.start()
+  taskScheduler.start()
 
   private[spark] val cleaner: Option[ContextCleaner] = {
     if (conf.getBoolean("spark.cleaner.referenceTracking", true)) {


### PR DESCRIPTION
this is an order issue of construction and starting of the taskScheduler and the dagScheduler in SparkContext. now taskScheduler start before dagScheduler, so executor backend may register executor even before dagScheduler(or the eventProcessActor) has not initialized. in this situation it will throw NPE
