### PR TITLE
SPARK-1523: improve the readability of code in AkkaUtil

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/AkkaUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/AkkaUtils.scala
@@ -119,7 +119,7 @@ private[spark] object AkkaUtils extends Logging {
 
   /** Returns the default Spark timeout to use for Akka remote actor lookup. */
   def lookupTimeout(conf: SparkConf): FiniteDuration = {
-    Duration.create(conf.get("spark.akka.lookupTimeout", "30").toLong, "seconds")
+    Duration.create(conf.getLong("spark.akka.lookupTimeout", 30), "seconds")
   }
 
   /** Returns the configured max frame size for Akka messages in bytes. */


### PR DESCRIPTION
Actually it is separated from https://github.com/apache/spark/pull/85 as suggested by @rxin

compare 

https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/util/AkkaUtils.scala#L122 

and 

https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/util/AkkaUtils.scala#L117

the first one use get and then toLong, the second one getLong....better to make them consistent

very very small fix........
