### PR TITLE
[SPARK-1527] change rootDir*.getName to rootDir*.getAbsolutePath 

### DIFF
--- a/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
@@ -33,7 +33,7 @@ class DiskBlockManagerSuite extends FunSuite with BeforeAndAfterEach {
   rootDir0.deleteOnExit()
   val rootDir1 = Files.createTempDir()
   rootDir1.deleteOnExit()
-  val rootDirs = rootDir0.getName + "," + rootDir1.getName
+  val rootDirs = rootDir0.getAbsolutePath + "," + rootDir1.getAbsolutePath
   println("Created root dirs: " + rootDirs)
 
   // This suite focuses primarily on consolidation features,


### PR DESCRIPTION
JIRA issue: [SPARK-1527](https://issues.apache.org/jira/browse/SPARK-1527)

getName() only gets the last component of the file path. When deleting test-generated directories,
we should pass the generated directory's absolute path to DiskBlockManager.
