### PR TITLE
[SPARK-1535] ALS: Avoid the garbage-creating ctor of DoubleMatrix

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
@@ -267,7 +267,7 @@ class ALS private (
   private def computeYtY(factors: RDD[(Int, Array[Array[Double]])]) = {
     val n = rank * (rank + 1) / 2
     val LYtY = factors.values.aggregate(new DoubleMatrix(n))( seqOp = (L, Y) => {
-      Y.foreach(y => dspr(1.0, new DoubleMatrix(y), L))
+      Y.foreach(y => dspr(1.0, wrapDoubleArray(y), L))
       L
     }, combOp = (L1, L2) => {
       L1.addi(L2)
@@ -300,6 +300,13 @@ class ALS private (
       }
       i += 1
     }
+  }
+
+  /**
+   * Wrap a double array in a DoubleMatrix without creating garbage.
+   */
+  private def wrapDoubleArray(v: Array[Double]): DoubleMatrix = {
+    new DoubleMatrix(v.length, 1, v:_*)
   }
 
   /**
@@ -455,7 +462,7 @@ class ALS private (
     // block
     for (productBlock <- 0 until numBlocks) {
       for (p <- 0 until blockFactors(productBlock).length) {
-        val x = new DoubleMatrix(blockFactors(productBlock)(p))
+        val x = wrapDoubleArray(blockFactors(productBlock)(p))
         tempXtX.fill(0.0)
         dspr(1.0, x, tempXtX)
         val (us, rs) = inLinkBlock.ratingsForBlock(productBlock)(p)

--- a/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
@@ -304,9 +304,11 @@ class ALS private (
 
   /**
    * Wrap a double array in a DoubleMatrix without creating garbage.
+   * This is a temporary fix for jblas 1.2.3; it should be safe to move back to the
+   * DoubleMatrix(double[]) constructor come jblas 1.2.4.
    */
   private def wrapDoubleArray(v: Array[Double]): DoubleMatrix = {
-    new DoubleMatrix(v.length, 1, v:_*)
+    new DoubleMatrix(v.length, 1, v: _*)
   }
 
   /**


### PR DESCRIPTION
`new DoubleMatrix(double[])` creates a garbage `double[]` of the same length as its argument and immediately throws it away.  This pull request avoids that constructor in the ALS code.
