### PR TITLE
[Spark-1461] Deferred Expression Evaluation (short-circuit evaluation)

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -98,16 +98,18 @@ case class And(left: Expression, right: Expression) extends BinaryPredicate {
 
   override def eval(input: Row): Any = {
     val l = left.eval(input)
-    if(l == null) {
-       null
-    } else if(l == false) {
-      false
+    if(l == false) {
+       false
     } else {
       val r = right.eval(input)
-      if(r == null) {
-        null
+      if(r == false) {
+        false
       } else {
-        r
+        if(l != null && r != null) {
+          true
+        } else {
+          null
+        }
       }
     }
   }
@@ -118,16 +120,18 @@ case class Or(left: Expression, right: Expression) extends BinaryPredicate {
 
   override def eval(input: Row): Any = {
     val l = left.eval(input)
-    if(l == null) {
-      null
-    } else if(l == true) {
+    if(l == true) {
       true
     } else {
       val r = right.eval(input)
-      if(r == null) {
-        null
+      if(r == true) {
+        true
       } else {
-        r
+        if(l != null && r != null) {
+          false
+        } else {
+          null
+        }
       }
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -174,7 +174,7 @@ case class If(predicate: Expression, trueValue: Expression, falseValue: Expressi
     extends Expression {
 
   def children = predicate :: trueValue :: falseValue :: Nil
-  override def nullable = predicate.nullable || (trueValue.nullable && falseValue.nullable)
+  override def nullable = trueValue.nullable || falseValue.nullable
   def references = children.flatMap(_.references).toSet
   override lazy val resolved = childrenResolved && trueValue.dataType == falseValue.dataType
   def dataType = {
@@ -189,10 +189,7 @@ case class If(predicate: Expression, trueValue: Expression, falseValue: Expressi
   type EvaluatedType = Any
 
   override def eval(input: Row): Any = {
-    val condition = predicate.eval(input)
-    if (null == condition) {
-      null
-    } else if(condition == true) {
+    if (true == predicate.eval(input)) {
       trueValue.eval(input)
     } else {
       falseValue.eval(input)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -98,14 +98,14 @@ case class And(left: Expression, right: Expression) extends BinaryPredicate {
 
   override def eval(input: Row): Any = {
     val l = left.eval(input)
-    if(l == false) {
+    if (l == false) {
        false
     } else {
       val r = right.eval(input)
-      if(r == false) {
+      if (r == false) {
         false
       } else {
-        if(l != null && r != null) {
+        if (l != null && r != null) {
           true
         } else {
           null
@@ -120,14 +120,14 @@ case class Or(left: Expression, right: Expression) extends BinaryPredicate {
 
   override def eval(input: Row): Any = {
     val l = left.eval(input)
-    if(l == true) {
+    if (l == true) {
       true
     } else {
       val r = right.eval(input)
-      if(r == true) {
+      if (r == true) {
         true
       } else {
-        if(l != null && r != null) {
+        if (l != null && r != null) {
           false
         } else {
           null
@@ -149,7 +149,7 @@ case class Equals(left: Expression, right: Expression) extends BinaryComparison 
       null
     } else {
       val r = right.eval(input)
-      if(r == null) null else l == r
+      if (r == null) null else l == r
     }
   }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUdfs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUdfs.scala
@@ -267,7 +267,7 @@ private[hive] case class HiveGenericUdf(name: String, children: Seq[Expression])
   override def eval(input: Row): Any = {
     returnInspector // Make sure initialized.
     var i = 0
-    while(i < children.length) {
+    while (i < children.length) {
       val idx = i
       deferedObjects(i).asInstanceOf[DeferredObjectAdapter].set(() => {children(idx).eval(input)})
       i += 1

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUdfs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUdfs.scala
@@ -248,17 +248,31 @@ private[hive] case class HiveGenericUdf(name: String, children: Seq[Expression])
     isUDFDeterministic && children.foldLeft(true)((prev, n) => prev && n.foldable)
   }
 
+  protected lazy val deferedObjects = Array.fill[DeferredObject](children.length)({
+    new DeferredObjectAdapter
+  })
+
+  // Adapter from Catalyst ExpressionResult to Hive DeferredObject
+  class DeferredObjectAdapter extends DeferredObject {
+    private var func: () => Any = _
+    def set(func: () => Any) {
+      this.func = func
+    }
+    override def prepare(i: Int) = {}
+    override def get(): AnyRef = wrap(func())
+  }
+
   val dataType: DataType = inspectorToDataType(returnInspector)
 
   override def eval(input: Row): Any = {
     returnInspector // Make sure initialized.
-    val args = children.map { v =>
-      new DeferredObject {
-        override def prepare(i: Int) = {}
-        override def get(): AnyRef = wrap(v.eval(input))
-      }
-    }.toArray
-    unwrap(function.evaluate(args))
+    var i = 0
+    while(i < children.length) {
+      val idx = i
+      deferedObjects(i).asInstanceOf[DeferredObjectAdapter].set(() => {children(idx).eval(input)})
+      i += 1
+    }
+    unwrap(function.evaluate(deferedObjects))
   }
 }
 


### PR DESCRIPTION
This patch unify the foldable & nullable interface for Expression. 
1) Deterministic-less UDF (like Rand()) can not be folded.
2) Short-circut will significantly improves the performance in Expression Evaluation, however, the stateful UDF should not be ignored in a short-circuit evaluation(e.g. in expression: col1 > 0 and row_sequence() < 1000, row_sequence() can not be ignored even if col1 > 0 is false)

I brought an concept of DeferredObject from Hive, which has 2 kinds of children classes (EagerResult / DeferredResult), the former requires triggering the evaluation before it's created, while the later trigger the evaluation when first called its get() method.
