### PR TITLE
SPARK-1539: RDDPage.scala contains RddPage class

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/storage/RDDPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/storage/RDDPage.scala
@@ -26,7 +26,7 @@ import org.apache.spark.ui.{WebUIPage, UIUtils}
 import org.apache.spark.util.Utils
 
 /** Page showing storage details for a given RDD */
-private[ui] class RddPage(parent: StorageTab) extends WebUIPage("rdd") {
+private[ui] class RDDPage(parent: StorageTab) extends WebUIPage("rdd") {
   private val appName = parent.appName
   private val basePath = parent.basePath
   private val listener = parent.listener

--- a/core/src/main/scala/org/apache/spark/ui/storage/StorageTab.scala
+++ b/core/src/main/scala/org/apache/spark/ui/storage/StorageTab.scala
@@ -30,7 +30,7 @@ private[ui] class StorageTab(parent: SparkUI) extends WebUITab(parent, "storage"
   val listener = new StorageListener(parent.storageStatusListener)
 
   attachPage(new StoragePage(this))
-  attachPage(new RddPage(this))
+  attachPage(new RDDPage(this))
   parent.registerListener(listener)
 }
 


### PR DESCRIPTION
SPARK-1386 changed RDDPage to RddPage but didn't change the filename. I tried sbt/sbt publish-local. Inside the spark-core jar, the unit name is RDDPage.class and hence I got the following error:

```
[error] (run-main) java.lang.NoClassDefFoundError: org/apache/spark/ui/storage/RddPage
java.lang.NoClassDefFoundError: org/apache/spark/ui/storage/RddPage
    at org.apache.spark.ui.SparkUI.initialize(SparkUI.scala:59)
    at org.apache.spark.ui.SparkUI.<init>(SparkUI.scala:52)
    at org.apache.spark.ui.SparkUI.<init>(SparkUI.scala:42)
    at org.apache.spark.SparkContext.<init>(SparkContext.scala:215)
    at MovieLensALS$.main(MovieLensALS.scala:38)
    at MovieLensALS.main(MovieLensALS.scala)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
Caused by: java.lang.ClassNotFoundException: org.apache.spark.ui.storage.RddPage
    at java.net.URLClassLoader$1.run(URLClassLoader.java:366)
    at java.net.URLClassLoader$1.run(URLClassLoader.java:355)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.net.URLClassLoader.findClass(URLClassLoader.java:354)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:425)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:358)
    at org.apache.spark.ui.SparkUI.initialize(SparkUI.scala:59)
    at org.apache.spark.ui.SparkUI.<init>(SparkUI.scala:52)
    at org.apache.spark.ui.SparkUI.<init>(SparkUI.scala:42)
    at org.apache.spark.SparkContext.<init>(SparkContext.scala:215)
    at MovieLensALS$.main(MovieLensALS.scala:38)
    at MovieLensALS.main(MovieLensALS.scala)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
```

This can be fixed after renaming RddPage to RDDPage, or renaming RDDPage.scala to RddPage.scala. I chose the former since the name `RDD` is common in Spark code. 
