### PR TITLE
[SPARK-SQL] HiveTableScan operator Performance Improvement 

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveOperators.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveOperators.scala
@@ -163,33 +163,30 @@ case class HiveTableScan(
      *  each iteration inside the while loop.
      */
     val row = new GenericMutableRow(attributes.length)
-	
     boundPruningPred match {
       case None => partitions
       case Some(shouldKeep) => partitions.filter { part =>
         val castedValues = mutable.ArrayBuffer[Any]()
         var i = 0
-        var len = relation.partitionKeys.length	
+        var len = relation.partitionKeys.length
         val iter: Iterator[String] = part.getValues.iterator
         while (i < len) {
           castedValues += castFromString(iter.next,relation.partitionKeys(i).dataType)
           i += 1
         }
-
-        //Only partitioned values are needed here, since the predicate has already been bound to
-        //partition key attribute references.
-        //val row = new GenericRow(castedValues.toArray)
+        // Only partitioned values are needed here, since the predicate has already been bound to
+        // partition key attribute references.
         i = 0
         len = castedValues.length
- 	while (i < len) {
-        /** castedValues represents columns in the row */
+        while (i < len) {
+        //castedValues represents columns in the row */
           castedValues(i) match {
             case n: String if n.toLowerCase == "null" => row.setNullAt(i)
             case n: Boolean => row.setBoolean(i,n)
-            case n: Byte => row.setByte(i,n) 	
-            case n: Double => row.setDouble(i,n) 
-            case n: Float => row.setFloat(i,n) 
-            case n: Int => row.setInt(i,n) 
+            case n: Byte => row.setByte(i,n)
+            case n: Double => row.setDouble(i,n)
+            case n: Float => row.setFloat(i,n)
+            case n: Int => row.setInt(i,n)
             case n: Long => row.setLong(i,n)
             case n: String  => row.setString(i,n)
             case n: Short  => row.setShort(i,n)
@@ -228,7 +225,8 @@ case class HiveTableScan(
         while ( i < len ) {
           values(i) match {
             case n: String if n.toLowerCase == "null" => mutableRow.setNullAt(i)
-            case varchar: org.apache.hadoop.hive.common.`type`.HiveVarchar => mutableRow.update(i,varchar.getValue)
+            case varchar: org.apache.hadoop.hive.common.`type`.HiveVarchar => 
+              mutableRow.update(i,varchar.getValue)
             case decimal: org.apache.hadoop.hive.common.`type`.HiveDecimal =>
               mutableRow.update(i,BigDecimal(decimal.bigDecimalValue))
             case other => mutableRow.update(i,other)
@@ -239,9 +237,9 @@ case class HiveTableScan(
       }
       rddBuffer
     })
-    /** finalRdd ... equivelant to Rdd generated from inputRdd.map(...) */	
-    val finalRdd = inputRdd.context.makeRDD(res(0)) 
-    finalRdd 
+    /** finalRdd ... equivelant to Rdd generated from inputRdd.map(...) */
+    val finalRdd = inputRdd.context.makeRDD(res(0))
+    finalRdd
   }
   def output = attributes
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveOperators.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveOperators.scala
@@ -178,8 +178,8 @@ case class HiveTableScan(
         // partition key attribute references.
         i = 0
         len = castedValues.length
+        // castedValues represents columns in the row.
         while (i < len) {
-        //castedValues represents columns in the row */
           castedValues(i) match {
             case n: String if n.toLowerCase == "null" => row.setNullAt(i)
             case n: Boolean => row.setBoolean(i,n)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveOperators.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveOperators.scala
@@ -97,7 +97,7 @@ case class HiveTableScan(
     while(i < len) {
       for(a <- attributes) { 
         if(a.name == relation.attributes(i).name) {
-	   names.add(i)
+          names.add(i)
         }
       }
       i += 1 
@@ -111,7 +111,9 @@ case class HiveTableScan(
   @transient
   protected lazy val attributeFunctions: Seq[(Any, Array[String]) => Any] = {
     val len = attributes.length 
-    /** newList ArrayBuffer + while loop created to simulate functionality of attributes.map(...) .... performance reason */    
+    /** newList ArrayBuffer + while loop created to simulate functionality of
+     *  attributes.map(...) .... performance reason.    
+     */
     val newList = mutable.ArrayBuffer[(Any, Array[String]) => Any]()
     var i = 0
     while (i < len) {
@@ -122,7 +124,8 @@ case class HiveTableScan(
                        val value = partitionKeys(ordinal)
                        val dataType = relation.partitionKeys(ordinal).dataType
                        castFromString(value, dataType)
-                     })
+                     }
+                   )
       } else {
         val ref = objectInspector.getAllStructFieldRefs
           .find(_.getFieldName == a.name)
@@ -130,7 +133,8 @@ case class HiveTableScan(
           newList += ( (row: Any, _: Array[String]) => {
                          val data = objectInspector.getStructFieldData(row, ref)
                          unwrapData(data, ref.getFieldObjectInspector)
-                       })
+                       }
+                     )
       }
       i+=1
     }
@@ -155,8 +159,9 @@ case class HiveTableScan(
    * @return Partitions that are involved in the query plan.
    */
   private[hive] def prunePartitions(partitions: Seq[HivePartition]) = {
-    
-    /** mutable row implementation to avoid creating row instance at each iteration inside the while loop. */
+    /** mutable row implementation to avoid creating row instance at
+     *  each iteration inside the while loop.
+     */
     val row = new GenericMutableRow(attributes.length)
 	
     boundPruningPred match {
@@ -171,8 +176,8 @@ case class HiveTableScan(
           i += 1
         }
 
-        // Only partitioned values are needed here, since the predicate has already been bound to
-        // partition key attribute references.
+        //Only partitioned values are needed here, since the predicate has already been bound to
+        //partition key attribute references.
         //val row = new GenericRow(castedValues.toArray)
         i = 0
         len = castedValues.length
@@ -206,7 +211,9 @@ case class HiveTableScan(
     var i = 0
     
     var res = inputRdd.context.runJob(inputRdd,(iter: Iterator[_]) => {
-      /** rddBuffer keeps track of all the transformed rows ... needed later to create finalRdd */ 
+      /** rddBuffer keeps track of all the transformed rows.
+       *  needed later to create finalRdd 
+       */ 
       val rddBuffer = mutable.ArrayBuffer[Row]()
       while (iter.hasNext) {
         val row = iter.next()

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveOperators.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveOperators.scala
@@ -76,17 +76,19 @@ case class HiveTableScan(
 
   @transient
   val hadoopReader = new HadoopTableReader(relation.tableDesc, sc)
-  /* TODO:attempt to retrieve a list of column ids that is required
-  // require more work ...  
-  val hadoopReader = { 
-    val cNames: ArrayList[Integer] = getNeededColumnIDs()
-    if (cNames.size() != 0) {
-      ColumnProjectionUtils.appendReadColumnIDs(sc.hiveconf,cNames)
-    } else {
-      ColumnProjectionUtils.setFullyReadColumns(sc.hiveconf)
-    }
-    new HadoopTableReader(relation.tableDesc, sc)
-  }*/
+  /** 
+   * attempt to retrieve a list of column ids that is required
+   * TODO: require more work ...  
+   * val hadoopReader = { 
+   *   val cNames: ArrayList[Integer] = getNeededColumnIDs()
+   *   if (cNames.size() != 0) {
+   *     ColumnProjectionUtils.appendReadColumnIDs(sc.hiveconf,cNames)
+   *   } else {
+   *     ColumnProjectionUtils.setFullyReadColumns(sc.hiveconf)
+   *   }
+   *   new HadoopTableReader(relation.tableDesc, sc)
+   * }
+   */
  
   /**
    * The hive object inspector for this table, which can be used to extract values from the
@@ -183,7 +185,7 @@ case class HiveTableScan(
         len = castedValues.length
         // castedValues represents columns in the row.
         while (i < len) {
-	  val n = castedValues(i)
+          val n = castedValues(i)
           if (n.isInstanceOf[String]) {
             if (n.asInstanceOf[String].toLowerCase == "null") {
               row.setNullAt(i)
@@ -196,9 +198,10 @@ case class HiveTableScan(
           }
           i += 1
         }
-        if (shouldKeep.eval(row).asInstanceOf[Boolean])
+        if (shouldKeep.eval(row).asInstanceOf[Boolean]) {
           filterPartition += part
-	index += 1
+        }
+        index += 1
       }
       filterPartition
     }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveOperators.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveOperators.scala
@@ -31,8 +31,6 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.JavaHiveVarcharOb
 import org.apache.hadoop.io.Writable
 import org.apache.hadoop.mapred._
 
-import org.apache.spark._
-import org.apache.spark.rdd.ParallelCollectionRDD
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.types.{BooleanType, DataType}
@@ -258,7 +256,6 @@ case class InsertIntoHiveTable(
 
   private def newSerializer(tableDesc: TableDesc): Serializer = {
     val serializer = tableDesc.getDeserializerClass.newInstance().asInstanceOf[Serializer]
-
     serializer.initialize(null, tableDesc.getProperties)
     serializer
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveOperators.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveOperators.scala
@@ -22,6 +22,7 @@ import org.apache.hadoop.hive.metastore.MetaStoreUtils
 import org.apache.hadoop.hive.ql.Context
 import org.apache.hadoop.hive.ql.metadata.{Partition => HivePartition, Hive}
 import org.apache.hadoop.hive.ql.plan.{TableDesc, FileSinkDesc}
+import org.apache.hadoop.hive.serde2.ColumnProjectionUtils
 import org.apache.hadoop.hive.serde2.Serializer
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils.ObjectInspectorCopyOption
 import org.apache.hadoop.hive.serde2.objectinspector._
@@ -30,14 +31,18 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.JavaHiveVarcharOb
 import org.apache.hadoop.io.Writable
 import org.apache.hadoop.mapred._
 
+import org.apache.spark._
+import org.apache.spark.rdd.ParallelCollectionRDD
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.types.{BooleanType, DataType}
 import org.apache.spark.sql.execution._
 import org.apache.spark.{SparkHiveHadoopWriter, TaskContext, SparkException}
-
 /* Implicits */
 import scala.collection.JavaConversions._
+import scala.collection.mutable
+/* java library */ 
+import java.util.ArrayList
 
 /**
  * The Hive table scan operator.  Column and partition pruning are both handled.
@@ -69,8 +74,15 @@ case class HiveTableScan(
   }
 
   @transient
-  val hadoopReader = new HadoopTableReader(relation.tableDesc, sc)
-
+  val hadoopReader = { 
+    val cNames: ArrayList[Integer] = getNeededColumnIDs()
+    if (cNames.size() != 0) {
+      ColumnProjectionUtils.appendReadColumnIDs(sc.hiveconf,cNames)
+    } else {
+      ColumnProjectionUtils.setFullyReadColumns(sc.hiveconf)
+    }
+    new HadoopTableReader(relation.tableDesc, sc)
+  }
   /**
    * The hive object inspector for this table, which can be used to extract values from the
    * serialized row representation.
@@ -79,30 +91,55 @@ case class HiveTableScan(
   lazy val objectInspector =
     relation.tableDesc.getDeserializer.getObjectInspector.asInstanceOf[StructObjectInspector]
 
+  /** attempt to retrieve a list of column ids that is required ... used by ColumnProjectionUtils */
+  private def getNeededColumnIDs() : ArrayList[Integer] = { 
+    val names: ArrayList[Integer] = new ArrayList[Integer]()
+    var i = 0
+    val len = relation.attributes.length
+    while(i < len) {
+        for(a <- attributes) { 
+          if(a.name == relation.attributes(i).name) {
+	    names.add(i)
+            
+	  }
+	}
+	i += 1 
+    } 
+    names
+  }  
   /**
    * Functions that extract the requested attributes from the hive output.  Partitioned values are
    * casted from string to its declared data type.
    */
   @transient
   protected lazy val attributeFunctions: Seq[(Any, Array[String]) => Any] = {
-    attributes.map { a =>
+    val len = attributes.length 
+    /** newList ArrayBuffer + while loop created to simulate functionality of attributes.map(...) .... performance reason */    
+    val newList = mutable.ArrayBuffer[(Any, Array[String]) => Any]()
+    var i = 0
+    while (i < len) {
+      val a: Attribute = attributes(i)
       val ordinal = relation.partitionKeys.indexOf(a)
       if (ordinal >= 0) {
-        (_: Any, partitionKeys: Array[String]) => {
-          val value = partitionKeys(ordinal)
-          val dataType = relation.partitionKeys(ordinal).dataType
-          castFromString(value, dataType)
-        }
+        newList += ( (_: Any, partitionKeys: Array[String]) => {
+                       val value = partitionKeys(ordinal)
+                       val dataType = relation.partitionKeys(ordinal).dataType
+                       castFromString(value, dataType)
+                     })
       } else {
         val ref = objectInspector.getAllStructFieldRefs
           .find(_.getFieldName == a.name)
           .getOrElse(sys.error(s"Can't find attribute $a"))
-        (row: Any, _: Array[String]) => {
-          val data = objectInspector.getStructFieldData(row, ref)
-          unwrapData(data, ref.getFieldObjectInspector)
-        }
+          newList += ( (row: Any, _: Array[String]) => {
+                         val data = objectInspector.getStructFieldData(row, ref)
+                         unwrapData(data, ref.getFieldObjectInspector)
+                       })
       }
+      i+=1
     }
+
+    newList
+
   }
 
   private def castFromString(value: String, dataType: DataType) = {
@@ -123,40 +160,87 @@ case class HiveTableScan(
    * @return Partitions that are involved in the query plan.
    */
   private[hive] def prunePartitions(partitions: Seq[HivePartition]) = {
+    
+    /** mutable row implementation to avoid creating row instance at each iteration inside the while loop. */
+    val row = new GenericMutableRow(attributes.length)
+	
     boundPruningPred match {
       case None => partitions
       case Some(shouldKeep) => partitions.filter { part =>
-        val dataTypes = relation.partitionKeys.map(_.dataType)
-        val castedValues = for ((value, dataType) <- part.getValues.zip(dataTypes)) yield {
-          castFromString(value, dataType)
-        }
+        val castedValues = mutable.ArrayBuffer[Any]()
+	var i = 0
+        var len = relation.partitionKeys.length	
+        val iter: Iterator[String] = part.getValues.iterator
+	while (i < len) {
+	  castedValues += castFromString(iter.next,relation.partitionKeys(i).dataType)
+          i += 1
+	}
 
         // Only partitioned values are needed here, since the predicate has already been bound to
         // partition key attribute references.
-        val row = new GenericRow(castedValues.toArray)
-        shouldKeep.eval(row).asInstanceOf[Boolean]
+        //val row = new GenericRow(castedValues.toArray)
+        i = 0
+        len = castedValues.length
+	while (i < len) {
+          /** castedValues represents columns in the row */
+	  castedValues(i) match {
+	    case n: String if n.toLowerCase == "null" => row.setNullAt(i)
+	    case n: Boolean => row.setBoolean(i,n)
+            case n: Byte => row.setByte(i,n) 	
+            case n: Double => row.setDouble(i,n) 
+            case n: Float => row.setFloat(i,n) 
+            case n: Int => row.setInt(i,n) 
+            case n: Long => row.setLong(i,n) 
+	    case n: String  => row.setString(i,n)
+	    case n: Short  => row.setShort(i,n)  
+	    case other => row.update(i,other)
+	  }
+	  i += 1
+	}
+	shouldKeep.eval(row).asInstanceOf[Boolean]
       }
     }
   }
 
   def execute() = {
-    inputRdd.map { row =>
-      val values = row match {
-        case Array(deserializedRow: AnyRef, partitionKeys: Array[String]) =>
-          attributeFunctions.map(_(deserializedRow, partitionKeys))
-        case deserializedRow: AnyRef =>
-          attributeFunctions.map(_(deserializedRow, Array.empty))
+    /**
+     *  mutableRow is GenericMutableRow type and only created once.
+     *  mutableRow is upadted at each iteration inside the while loop. 
+     */ 
+    val mutableRow = new GenericMutableRow(attributes.length) 
+    var i = 0
+    
+    var res = inputRdd.context.runJob(inputRdd,(iter: Iterator[_]) => {
+      /** rddBuffer keeps track of all the transformed rows ... needed later to create finalRdd */ 
+      val rddBuffer = mutable.ArrayBuffer[Row]()
+      while (iter.hasNext) {
+        val row = iter.next()
+        val values = row match {
+          case Array(deserializedRow: AnyRef, partitionKeys: Array[String]) =>
+            attributeFunctions.map(_(deserializedRow, partitionKeys))
+          case deserializedRow: AnyRef =>
+            attributeFunctions.map(_(deserializedRow, Array.empty))
+        }
+        i = 0
+        val len = values.length
+        while ( i < len ) {
+          values(i) match {
+            case n: String if n.toLowerCase == "null" => mutableRow.setNullAt(i)
+	    case varchar: org.apache.hadoop.hive.common.`type`.HiveVarchar => mutableRow.update(i,varchar.getValue)
+            case decimal: org.apache.hadoop.hive.common.`type`.HiveDecimal =>
+              mutableRow.update(i,BigDecimal(decimal.bigDecimalValue))
+	    case other => mutableRow.update(i,other)
+	  }
+          i += 1
+        }
+        rddBuffer +=  mutableRow
       }
-      buildRow(values.map {
-        case n: String if n.toLowerCase == "null" => null
-        case varchar: org.apache.hadoop.hive.common.`type`.HiveVarchar => varchar.getValue
-        case decimal: org.apache.hadoop.hive.common.`type`.HiveDecimal =>
-          BigDecimal(decimal.bigDecimalValue)
-        case other => other
-      })
-    }
+      rddBuffer
+    } )
+    /** finalRdd ... equivelant to Rdd generated from inputRdd.map(...) */	
+    val finalRdd = inputRdd.context.makeRDD(res(0)) 
+    finalRdd 
   }
-
   def output = attributes
 }
 
@@ -174,6 +258,7 @@ case class InsertIntoHiveTable(
 
   private def newSerializer(tableDesc: TableDesc): Serializer = {
     val serializer = tableDesc.getDeserializerClass.newInstance().asInstanceOf[Serializer]
+
     serializer.initialize(null, tableDesc.getProperties)
     serializer
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveOperators.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveOperators.scala
@@ -95,13 +95,12 @@ case class HiveTableScan(
     var i = 0
     val len = relation.attributes.length
     while(i < len) {
-        for(a <- attributes) { 
-          if(a.name == relation.attributes(i).name) {
-	    names.add(i)
-            
-	  }
-	}
-	i += 1 
+      for(a <- attributes) { 
+        if(a.name == relation.attributes(i).name) {
+	   names.add(i)
+        }
+      }
+      i += 1 
     } 
     names
   }  
@@ -135,9 +134,7 @@ case class HiveTableScan(
       }
       i+=1
     }
-
     newList
-
   }
 
   private def castFromString(value: String, dataType: DataType) = {
@@ -166,36 +163,36 @@ case class HiveTableScan(
       case None => partitions
       case Some(shouldKeep) => partitions.filter { part =>
         val castedValues = mutable.ArrayBuffer[Any]()
-	var i = 0
+        var i = 0
         var len = relation.partitionKeys.length	
         val iter: Iterator[String] = part.getValues.iterator
-	while (i < len) {
-	  castedValues += castFromString(iter.next,relation.partitionKeys(i).dataType)
+        while (i < len) {
+          castedValues += castFromString(iter.next,relation.partitionKeys(i).dataType)
           i += 1
-	}
+        }
 
         // Only partitioned values are needed here, since the predicate has already been bound to
         // partition key attribute references.
         //val row = new GenericRow(castedValues.toArray)
         i = 0
         len = castedValues.length
-	while (i < len) {
-          /** castedValues represents columns in the row */
-	  castedValues(i) match {
-	    case n: String if n.toLowerCase == "null" => row.setNullAt(i)
-	    case n: Boolean => row.setBoolean(i,n)
+ 	while (i < len) {
+        /** castedValues represents columns in the row */
+          castedValues(i) match {
+            case n: String if n.toLowerCase == "null" => row.setNullAt(i)
+            case n: Boolean => row.setBoolean(i,n)
             case n: Byte => row.setByte(i,n) 	
             case n: Double => row.setDouble(i,n) 
             case n: Float => row.setFloat(i,n) 
             case n: Int => row.setInt(i,n) 
-            case n: Long => row.setLong(i,n) 
-	    case n: String  => row.setString(i,n)
-	    case n: Short  => row.setShort(i,n)  
-	    case other => row.update(i,other)
-	  }
-	  i += 1
-	}
-	shouldKeep.eval(row).asInstanceOf[Boolean]
+            case n: Long => row.setLong(i,n)
+            case n: String  => row.setString(i,n)
+            case n: Short  => row.setShort(i,n)
+            case other => row.update(i,other)
+          }
+          i += 1
+        }
+        shouldKeep.eval(row).asInstanceOf[Boolean]
       }
     }
   }
@@ -224,17 +221,17 @@ case class HiveTableScan(
         while ( i < len ) {
           values(i) match {
             case n: String if n.toLowerCase == "null" => mutableRow.setNullAt(i)
-	    case varchar: org.apache.hadoop.hive.common.`type`.HiveVarchar => mutableRow.update(i,varchar.getValue)
+            case varchar: org.apache.hadoop.hive.common.`type`.HiveVarchar => mutableRow.update(i,varchar.getValue)
             case decimal: org.apache.hadoop.hive.common.`type`.HiveDecimal =>
               mutableRow.update(i,BigDecimal(decimal.bigDecimalValue))
-	    case other => mutableRow.update(i,other)
-	  }
+            case other => mutableRow.update(i,other)
+          }
           i += 1
         }
         rddBuffer +=  mutableRow
       }
       rddBuffer
-    } )
+    })
     /** finalRdd ... equivelant to Rdd generated from inputRdd.map(...) */	
     val finalRdd = inputRdd.context.makeRDD(res(0)) 
     finalRdd 


### PR DESCRIPTION
The goal is to improve the performance of the HiveTableScan Operator:

As a quick benchmark run the following code in the scala interpreter:

scala> :paste

hql("CREATE TABLE IF NOT EXISTS sample (key1 INT, key2 INT,value STRING) ROW FORMAT DELIMITED FIELDS TERMINATED BY ','")
hql("LOAD DATA LOCAL INPATH 'examples/src/main/resources/sample2.txt' INTO TABLE sample")
println("Result of SELECT \* FROM sample:")
val start = System.nanoTime
val recs = hql("FROM sample SELECT key1,key2,value").collect()
val micros = (System.nanoTime - start) / 1000
println("%d microsecondss".format(micros))

scala> CTRL-D

you can download the test file from here: 
http://homes.cs.washington.edu/~soroush/sample2.txt

"sample2.txt contains about 3.6 million rows. The improved code scans the entire table in about 9 seconds while the original code scans the entire table in about 22 seconds.

Regarding the last item in the task: 
"Avoid Reading Unneeded Data - Some Hive Serializer/Deserializer (SerDe) interfaces support reading only the required columns from the underlying HDFS files.  We should use ColumnProjectionUtils to configure these correctly." 
The way to do it, should be similar to the following code: 

https://github.com/amplab/shark/blob/master/src/main/scala/shark/execution/TableScanOperator.scala

I tried to take a similar approach, but I am not sure columnar reading is working at hiveOperators.scala right now. Anyway, it requires more time for me to make sure that last feature is working. Please notice that it was the first time that I wrote code in scala and it took me some time to get comfortable with the language.  
