### PR TITLE
SPARK-1577: Enabling reference tracking by default in GraphX KryoRegistrator.

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/GraphKryoRegistrator.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/GraphKryoRegistrator.scala
@@ -26,6 +26,12 @@ import org.apache.spark.util.BoundedPriorityQueue
 
 /**
  * Registers GraphX classes with Kryo for improved performance.
+ *
+ * If possible disable Reference tracking in Kryo (not safe in the Spark-Shell).
+ * Reference tracking can be disabled by following the instructions here:
+ *
+ *   http://spark.apache.org/docs/latest/configuration.html
+ *
  */
 class GraphKryoRegistrator extends KryoRegistrator {
 
@@ -41,8 +47,5 @@ class GraphKryoRegistrator extends KryoRegistrator {
     kryo.register(classOf[PartitionStrategy])
     kryo.register(classOf[BoundedPriorityQueue[Object]])
     kryo.register(classOf[EdgeDirection])
-
-    // This avoids a large number of hash table lookups.
-    kryo.setReferences(false)
   }
 }


### PR DESCRIPTION
We had originally disabled reference tracking by default. However,this creates serious issues in the spark-shell.  For example the following code will fail:

``` scala
class A(a: String) extends Serializable
val x = sc.parallelize(Array.fill(10)(new A("hello")))
x.collect
```
