### PR TITLE
SPARK-1583: Fix a bug that using java.util.HashMap by mistake

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterActor.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterActor.scala
@@ -203,7 +203,7 @@ class BlockManagerMasterActor(val isLocal: Boolean, conf: SparkConf, listenerBus
       val locations = blockLocations.get(blockId)
       locations -= blockManagerId
       if (locations.size == 0) {
-        blockLocations.remove(locations)
+        blockLocations.remove(blockId)
       }
     }
     listenerBus.post(SparkListenerBlockManagerRemoved(blockManagerId))


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-1583

Does anyone know why using `java.util.HashMap` rather than `mutable.HashMap`? Some methods of `java.util.HashMap` are not generics and compiler can not help us find similar problems.
