### PR TITLE
Let pyspark execute files even when IPYTHON=1

### DIFF
--- a/bin/pyspark
+++ b/bin/pyspark
@@ -51,13 +51,9 @@ export PYTHONPATH=$SPARK_HOME/python/:$PYTHONPATH
 export OLD_PYTHONSTARTUP=$PYTHONSTARTUP
 export PYTHONSTARTUP=$FWDIR/python/pyspark/shell.py
 
-if [ -n "$IPYTHON_OPTS" ]; then
-  IPYTHON=1
-fi
 
-# Only use ipython if no command line arguments were provided [SPARK-1134]
-if [[ "$IPYTHON" = "1" && $# = 0 ]] ; then
-  exec ipython $IPYTHON_OPTS
+if [[ "$IPYTHON" = "1" ]] ; then
+  exec ipython "$@"
 else
   exec "$PYSPARK_PYTHON" "$@"
 fi


### PR DESCRIPTION
With the release of IPython 2.0 having the `PYTHONSTARTUP` environment variable and passing a file at the same time works as expected. So, we can just pass the commandline args straight to IPython.

Also remove `IPYTHON_OPTS`, as you can now just pass options to IPython directly

This puts the behavior of `IPYTHON=1` in line with the regular Python interpreter

Note that this won't work correctly when IPython version < 2.0
