### PR TITLE
Fixed bug for Jira Issue# 1527

### DIFF
--- a/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
@@ -26,6 +26,7 @@ import com.google.common.io.Files
 import org.scalatest.{BeforeAndAfterEach, FunSuite}
 
 import org.apache.spark.SparkConf
+import java.nio.file.Files
 
 class DiskBlockManagerSuite extends FunSuite with BeforeAndAfterEach {
   private val testConf = new SparkConf(false)
@@ -33,7 +34,7 @@ class DiskBlockManagerSuite extends FunSuite with BeforeAndAfterEach {
   rootDir0.deleteOnExit()
   val rootDir1 = Files.createTempDir()
   rootDir1.deleteOnExit()
-  val rootDirs = rootDir0.getName + "," + rootDir1.getName
+  val rootDirs = rootDir0.getCanonicalPath + "," + rootDir1.getCanonicalPath
   println("Created root dirs: " + rootDirs)
 
   // This suite focuses primarily on consolidation features,

--- a/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
@@ -26,7 +26,7 @@ import com.google.common.io.Files
 import org.scalatest.{BeforeAndAfterEach, FunSuite}
 
 import org.apache.spark.SparkConf
-import java.nio.file.Files
+
 
 class DiskBlockManagerSuite extends FunSuite with BeforeAndAfterEach {
   private val testConf = new SparkConf(false)


### PR DESCRIPTION
Details: rootDirs in DiskBlockManagerSuite doesn't get full path from rootDir0, rootDir1
