### PR TITLE
SPARK-1494 Don't initialize classes loaded by MIMA excludes, attempt 2

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -27,6 +27,8 @@ import org.apache.spark.sql.catalyst.plans.{QueryPlan, logical}
 import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.columnar.InMemoryColumnarTableScan
 
+/* CHANGE */
+
 /**
  * :: DeveloperApi ::
  */

--- a/tools/src/main/scala/org/apache/spark/tools/GenerateMIMAIgnore.scala
+++ b/tools/src/main/scala/org/apache/spark/tools/GenerateMIMAIgnore.scala
@@ -50,7 +50,7 @@ object GenerateMIMAIgnore {
            is a module or class. */
 
         val privateAsClass = mirror
-          .staticClass(className)
+          .classSymbol(Class.forName(className, false, classLoader))
           .privateWithin
           .fullName
           .startsWith(packageName)


### PR DESCRIPTION
[WIP]

Looks like scala reflection was invoking the static initializer:

```
...
    at org.apache.spark.sql.test.TestSQLContext$.<init>(TestSQLContext.scala:25)
    at org.apache.spark.sql.test.TestSQLContext$.<clinit>(TestSQLContext.scala)
    at java.lang.Class.forName0(Native Method)
    at java.lang.Class.forName(Class.java:270)
    at scala.reflect.runtime.JavaMirrors$JavaMirror.javaClass(JavaMirrors.scala:500)
    at scala.reflect.runtime.JavaMirrors$JavaMirror.tryJavaClass(JavaMirrors.scala:505)
    at scala.reflect.runtime.SymbolLoaders$PackageScope.lookupEntry(SymbolLoaders.scala:109)
...
```

Need to make sure that this doesn't change the exclusion semantics before merging.
