### PR TITLE
SPARK-1488. Squash more language feature warnings in new commits by importing implicitConversion

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaInputDStream.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.streaming.api.java
 
+import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
 import org.apache.spark.streaming.dstream.InputDStream

--- a/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaPairInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaPairInputDStream.scala
@@ -18,6 +18,8 @@
 package org.apache.spark.streaming.api.java
 
 import org.apache.spark.streaming.dstream.InputDStream
+
+import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
 /**

--- a/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaPairReceiverInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaPairReceiverInputDStream.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.streaming.api.java
 
+import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
 import org.apache.spark.streaming.dstream.ReceiverInputDStream

--- a/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaReceiverInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaReceiverInputDStream.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.streaming.api.java
 
+import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
 import org.apache.spark.streaming.dstream.ReceiverInputDStream

--- a/streaming/src/test/scala/org/apache/spark/streaming/NetworkReceiverSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/NetworkReceiverSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.streaming
 import java.nio.ByteBuffer
 
 import scala.collection.mutable.ArrayBuffer
+import scala.language.postfixOps
 
 import org.apache.spark.SparkConf
 import org.apache.spark.storage.{StorageLevel, StreamBlockId}

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingListenerSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingListenerSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.streaming
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.language.postfixOps
 
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming.dstream.DStream


### PR DESCRIPTION
A recent commit reintroduced some of the same warnings that SPARK-1488 resolved. These are just a few more of the same changes to remove these warnings.
