### PR TITLE
[SPARK-986]: Job cancelation for PySpark

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -97,6 +97,17 @@ class SparkEnv (
       pythonWorkers.getOrElseUpdate(key, new PythonWorkerFactory(pythonExec, envVars)).create()
     }
   }
+
+  private[spark]
+  def destroyPythonWorker(pythonExec: String, envVars: Map[String, String]) {
+    synchronized {
+      val key = (pythonExec, envVars)
+      pythonWorkers.get(key) match {
+        case Some(worker) => worker.stop()
+        case _ =>
+      }
+    }
+  }
 }
 
 object SparkEnv extends Logging {

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -102,10 +102,7 @@ class SparkEnv (
   def destroyPythonWorker(pythonExec: String, envVars: Map[String, String]) {
     synchronized {
       val key = (pythonExec, envVars)
-      pythonWorkers.get(key) match {
-        case Some(worker) => worker.stop()
-        case _ =>
-      }
+      pythonWorkers(key).stop()
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -119,11 +119,12 @@ private[spark] class PythonRDD[T: ClassTag](
     // threads can block indefinetly.
     new Thread(s"Worker Monitor for $pythonExec") {
       override def run() {
-        Thread.sleep(2000)
-        if (context.interrupted) {
-          Try(worker.shutdownOutput())
-          return
+        // Kill the worker if it is interrupted or completed
+        // When a python task completes, the context is always set to interupted
+        while (!context.interrupted) {
+          Thread.sleep(2000)
         }
+        Try(worker.shutdownOutput())
       }
     }.start()
 

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -119,14 +119,10 @@ private[spark] class PythonRDD[T: ClassTag](
     // threads can block indefinetly.
     new Thread(s"Worker Monitor for $pythonExec") {
       override def run() {
-        while (writer.isAlive || reader.isAlive) {
-          Thread.sleep(1000)
-          if (context.interrupted) {
-            writer.interrupt()
-            reader.interrupt()
-            Try(worker.shutdownOutput())
-            return
-          }
+        Thread.sleep(2000)
+        if (context.interrupted) {
+          Try(worker.shutdownOutput())
+          return
         }
       }
     }.start()

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -120,7 +120,7 @@ private[spark] class PythonRDD[T: ClassTag](
         while (!context.interrupted) {
           Thread.sleep(2000)
         }
-        Try(worker.shutdownOutput())
+        Try(env.destroyPythonWorker(pythonExec, envVars.toMap))
       }
     }.start()
 

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -59,7 +59,7 @@ private[spark] class PythonRDD[T: ClassTag](
     @volatile var readerException: Exception = null
 
     // Start a thread to feed the process input from our parent's iterator
-    new Thread("stdin writer for " + pythonExec) {
+    val writer = new Thread("stdin writer for " + pythonExec) {
       override def run() {
         try {
           SparkEnv.set(env)
@@ -109,6 +109,10 @@ private[spark] class PythonRDD[T: ClassTag](
         }
       }
     }
+
+    writer.start()
+
+    val reader = Thread.currentThread
 
     // It is necessary to have a monitor thread for python workers if the user cancel's with
     // interrupts disabled. In that case we will need to explicitly kill the worker, otherwise the

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -59,7 +59,7 @@ private[spark] class PythonRDD[T: ClassTag](
     @volatile var readerException: Exception = null
 
     // Start a thread to feed the process input from our parent's iterator
-    val writer = new Thread("stdin writer for " + pythonExec) {
+    new Thread("stdin writer for " + pythonExec) {
       override def run() {
         try {
           SparkEnv.set(env)
@@ -109,10 +109,6 @@ private[spark] class PythonRDD[T: ClassTag](
         }
       }
     }
-
-    writer.start()
-
-    val reader = Thread.currentThread
 
     // It is necessary to have a monitor thread for python workers if the user cancel's with
     // interrupts disabled. In that case we will need to explicitly kill the worker, otherwise the

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -108,7 +108,7 @@ private[spark] class PythonRDD[T: ClassTag](
             Try(worker.shutdownOutput()) // kill Python worker process
         }
       }
-    }
+    }.start()
 
     // It is necessary to have a monitor thread for python workers if the user cancel's with
     // interrupts disabled. In that case we will need to explicitly kill the worker, otherwise the

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -454,16 +454,15 @@ class SparkContext(object):
         ...         sc.setJobGroup("job_to_cancel", "some description")
         ...         result = sc.parallelize(range(x)).map(map_func).collect()
         ...     except Exception as e:
-        ...         print e
         ...         result = "Cancelled"
         ...     lock.release()
         >>> def stop_job():
         ...     sleep(5)
         ...     sc.cancelJobGroup("job_to_cancel")
-        >>> lock.acquire()
-        >>> thread.start_new_thread(start_job, (10,))
-        >>> thread.start_new_thread(stop_job, tuple())
-        >>> lock.acquire()
+        >>> supress = lock.acquire()
+        >>> supress = thread.start_new_thread(start_job, (10,))
+        >>> supress = thread.start_new_thread(stop_job, tuple())
+        >>> supress = lock.acquire()
         >>> print result
         Cancelled
 

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -429,7 +429,7 @@ class SparkContext(object):
                                storageLevel.deserialized,
                                storageLevel.replication)
 
-    def setJobGroup(self, groupId, description):
+    def setJobGroup(self, groupId, description, interruptOnCancel=False):
         """
         Assigns a group ID to all the jobs started by this thread until the group ID is set to a
         different value or cleared.
@@ -437,8 +437,42 @@ class SparkContext(object):
         Often, a unit of execution in an application consists of multiple Spark actions or jobs.
         Application programmers can use this method to group all those jobs together and give a
         group description. Once set, the Spark web UI will associate such jobs with this group.
+
+        The application can use L{SparkContext.cancelJobGroup} to cancel all
+        running jobs in this group.
+
+        >>> import thread, threading
+        >>> from time import sleep
+        >>> result = "Not Set"
+        >>> lock = threading.Lock()
+        >>> def map_func(x):
+        ...     sleep(100)
+        ...     return x * x
+        >>> def start_job(x):
+        ...     global result
+        ...     try:
+        ...         sc.setJobGroup("job_to_cancel", "some description")
+        ...         result = sc.parallelize(range(x)).map(map_func).collect()
+        ...     except Exception as e:
+        ...         print e
+        ...         result = "Cancelled"
+        ...     lock.release()
+        >>> def stop_job():
+        ...     sleep(5)
+        ...     sc.cancelJobGroup("job_to_cancel")
+        >>> lock.acquire()
+        >>> thread.start_new_thread(start_job, (10,))
+        >>> thread.start_new_thread(stop_job, tuple())
+        >>> lock.acquire()
+        >>> print result
+        Cancelled
+
+        If interruptOnCancel is set to true for the job group, then job cancellation will result
+        in Thread.interrupt() being called on the job's executor threads. This is useful to help ensure
+        that the tasks are actually stopped in a timely manner, but is off by default due to HDFS-1208,
+        where HDFS may respond to Thread.interrupt() by marking nodes as dead.
         """
-        self._jsc.setJobGroup(groupId, description)
+        self._jsc.setJobGroup(groupId, description, interruptOnCancel)
 
     def setLocalProperty(self, key, value):
         """
@@ -459,6 +493,19 @@ class SparkContext(object):
         Get SPARK_USER for user who is running SparkContext.
         """
         return self._jsc.sc().sparkUser()
+
+    def cancelJobGroup(self, groupId):
+        """
+        Cancel active jobs for the specified group. See L{SparkContext.setJobGroup}
+        for more information.
+        """
+        self._jsc.sc().cancelJobGroup(groupId)
+
+    def cancelAllJobs(self):
+        """
+        Cancel all jobs that have been scheduled or are running.
+        """
+        self._jsc.sc().cancelAllJobs()
 
 def _test():
     import atexit


### PR DESCRIPTION
- Additions to the PySpark API to cancel jobs
- Monitor Thread in PythonRDD to kill Python workers if a task is interrupted
