### PR TITLE
SPARK-1621 Upgrade Chill to 0.3.6

### DIFF
--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -58,7 +58,9 @@ class KryoSerializer(conf: SparkConf)
     // Do this before we invoke the user registrator so the user registrator can override this.
     kryo.setReferences(referenceTracking)
 
-    for (cls <- KryoSerializer.toRegister) kryo.register(cls)
+    for (cls <- KryoSerializer.toRegister) {
+      kryo.register(cls)
+    }
 
     // Allow sending SerializableWritable
     kryo.register(classOf[SerializableWritable[_]], new KryoJavaSerializer())
@@ -77,7 +79,7 @@ class KryoSerializer(conf: SparkConf)
     }
 
     // Register Chill's classes; we do this after our ranges and the user's own classes to let
-    // our code override the generic serialziers in Chill for things like Seq
+    // our code override the generic serializers in Chill for things like Seq
     new AllScalaRegistrar().apply(kryo)
 
     kryo.setClassLoader(classLoader)
@@ -176,10 +178,6 @@ private[serializer] object KryoSerializer {
     classOf[GetBlock],
     classOf[MapStatus],
     classOf[BlockManagerId],
-    classOf[Array[Byte]],
-    (1 to 10).getClass,
-    (1 until 10).getClass,
-    (1L to 10L).getClass,
-    (1L until 10L).getClass
+    classOf[Array[Byte]]
   )
 }

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <parquet.version>1.3.2</parquet.version>
     <jblas.version>1.2.3</jblas.version>
     <jetty.version>8.1.14.v20131031</jetty.version>
-    <chill.version>0.3.1</chill.version>
+    <chill.version>0.3.6</chill.version>
     <codahale.metrics.version>3.0.0</codahale.metrics.version>
 
     <PermGen>64m</PermGen>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -294,7 +294,7 @@ object SparkBuild extends Build {
   ) ++ net.virtualvoid.sbt.graph.Plugin.graphSettings ++ ScalaStyleSettings ++ genjavadocSettings
 
   val akkaVersion = "2.2.3-shaded-protobuf"
-  val chillVersion = "0.3.1"
+  val chillVersion = "0.3.6"
   val codahaleMetricsVersion = "3.0.0"
   val jblasVersion = "1.2.3"
   val jettyVersion = "8.1.14.v20131031"
@@ -411,8 +411,8 @@ object SparkBuild extends Build {
   )
 
   def examplesSettings = sharedSettings ++ Seq(
-    name := "spark-examples",  
-    jarName in assembly <<= version map { 
+    name := "spark-examples",
+    jarName in assembly <<= version map {
       v => "spark-examples-" + v + "-hadoop" + hadoopVersion + ".jar" },
     libraryDependencies ++= Seq(
       "com.twitter"          %% "algebird-core"   % "0.1.11",


### PR DESCRIPTION
It registers more Scala classes, including things like Ranges that we had to register manually before. See https://github.com/twitter/chill/releases for Chill's change log.
