### PR TITLE
SPARK-1623. Broadcast cleaner should use getCanonicalPath when deleting files by name

### DIFF
--- a/core/src/main/scala/org/apache/spark/broadcast/HttpBroadcast.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/HttpBroadcast.scala
@@ -213,7 +213,7 @@ private[spark] object HttpBroadcast extends Logging {
     SparkEnv.get.blockManager.master.removeBroadcast(id, removeFromDriver, blocking)
     if (removeFromDriver) {
       val file = getFile(id)
-      files.remove(file.toString)
+      files.remove(file.getCanonicalPath)
       deleteBroadcastFile(file)
     }
   }
@@ -229,7 +229,7 @@ private[spark] object HttpBroadcast extends Logging {
       val (file, time) = (entry.getKey, entry.getValue)
       if (time < cleanupTime) {
         iterator.remove()
-        deleteBroadcastFile(new File(file.toString))
+        deleteBroadcastFile(new File(file.getCanonicalPath))
       }
     }
   }

--- a/core/src/main/scala/org/apache/spark/broadcast/HttpBroadcast.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/HttpBroadcast.scala
@@ -229,7 +229,7 @@ private[spark] object HttpBroadcast extends Logging {
       val (file, time) = (entry.getKey, entry.getValue)
       if (time < cleanupTime) {
         iterator.remove()
-        deleteBroadcastFile(new File(file.getCanonicalPath))
+        deleteBroadcastFile(new File(file))
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
@@ -26,6 +26,7 @@ import com.google.common.io.Files
 import org.scalatest.{BeforeAndAfterEach, FunSuite}
 
 import org.apache.spark.SparkConf
+import java.nio.file.Files
 
 class DiskBlockManagerSuite extends FunSuite with BeforeAndAfterEach {
   private val testConf = new SparkConf(false)
@@ -33,7 +34,7 @@ class DiskBlockManagerSuite extends FunSuite with BeforeAndAfterEach {
   rootDir0.deleteOnExit()
   val rootDir1 = Files.createTempDir()
   rootDir1.deleteOnExit()
-  val rootDirs = rootDir0.getName + "," + rootDir1.getName
+  val rootDirs = rootDir0.getCanonicalPath + "," + rootDir1.getCanonicalPath
   println("Created root dirs: " + rootDirs)
 
   // This suite focuses primarily on consolidation features,

--- a/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
@@ -26,7 +26,7 @@ import com.google.common.io.Files
 import org.scalatest.{BeforeAndAfterEach, FunSuite}
 
 import org.apache.spark.SparkConf
-import java.nio.file.Files
+
 
 class DiskBlockManagerSuite extends FunSuite with BeforeAndAfterEach {
   private val testConf = new SparkConf(false)


### PR DESCRIPTION
Getting absloute path instead of relative path. : Its a same bug as Jira 1527
