### PR TITLE
SPARK-1630: Make PythonRDD handle NULL elements and strings gracefully

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -301,22 +301,20 @@ private[spark] object PythonRDD extends Logging {
               throw new SparkException("Unexpected Tuple2 element type " + pair._1.getClass)
           }
         case other =>
-          Option(other) match {
-            case None =>
-              logDebug("Encountered NULL element from iterator. We skip writing NULL to stream.")
-            case Some(x) =>
-              throw new SparkException("Unexpected element type " + first.getClass)
+          if (other == null) {
+            logDebug("Encountered NULL element from iterator. We skip writing NULL to stream.")
+          } else {
+            throw new SparkException("Unexpected element type " + first.getClass)
           }
       }
     }
   }
 
   def writeUTF(str: String, dataOut: DataOutputStream) {
-    Option(str) match {
-      case None =>
-        logDebug("Encountered NULL string. We skip writing NULL to stream.")
-      case Some(x) =>
-        val bytes = x.getBytes(UTF8)
+    if (str == null) {
+      logDebug("Encountered NULL string. We skip writing NULL to stream.")
+    } else {
+        val bytes = str.getBytes(UTF8)
         dataOut.writeInt(bytes.length)
         dataOut.write(bytes)
     }

--- a/core/src/test/scala/org/apache/spark/api/python/PythonRDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/api/python/PythonRDDSuite.scala
@@ -23,16 +23,16 @@ import org.scalatest.FunSuite
 
 class PythonRDDSuite extends FunSuite {
 
-    test("Writing large strings to the worker") {
-        val input: List[String] = List("a"*100000)
-        val buffer = new DataOutputStream(new ByteArrayOutputStream)
-        PythonRDD.writeIteratorToStream(input.iterator, buffer)
-    }
+  test("Writing large strings to the worker") {
+    val input: List[String] = List("a"*100000)
+    val buffer = new DataOutputStream(new ByteArrayOutputStream)
+    PythonRDD.writeIteratorToStream(input.iterator, buffer)
+  }
 
-    test("Handle nulls gracefully") {
-        val input: List[String] = List("a", null)
-        val buffer = new DataOutputStream(new ByteArrayOutputStream)
-        PythonRDD.writeIteratorToStream(input.iterator, buffer)
-    }
+  test("Handle nulls gracefully") {
+    val input: List[String] = List("a", null)
+    val buffer = new DataOutputStream(new ByteArrayOutputStream)
+    PythonRDD.writeIteratorToStream(input.iterator, buffer)
+  }
 }
 

--- a/core/src/test/scala/org/apache/spark/api/python/PythonRDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/api/python/PythonRDDSuite.scala
@@ -29,5 +29,10 @@ class PythonRDDSuite extends FunSuite {
         PythonRDD.writeIteratorToStream(input.iterator, buffer)
     }
 
+    test("Handle nulls gracefully") {
+        val input: List[String] = List("a",null)
+        val buffer = new DataOutputStream(new ByteArrayOutputStream)
+        PythonRDD.writeIteratorToStream(input.iterator, buffer)
+    }
 }
 

--- a/core/src/test/scala/org/apache/spark/api/python/PythonRDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/api/python/PythonRDDSuite.scala
@@ -30,7 +30,7 @@ class PythonRDDSuite extends FunSuite {
     }
 
     test("Handle nulls gracefully") {
-        val input: List[String] = List("a",null)
+        val input: List[String] = List("a", null)
         val buffer = new DataOutputStream(new ByteArrayOutputStream)
         PythonRDD.writeIteratorToStream(input.iterator, buffer)
     }


### PR DESCRIPTION
Have added a unit test that validates the fix. We no longer NPE.
