### PR TITLE
SPARK-1607. HOTFIX: Fix syntax adapting Int result to Short

### DIFF
--- a/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/ClientBase.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/ClientBase.scala
@@ -60,10 +60,10 @@ trait ClientBase extends Logging {
 
   // Staging directory is private! -> rwx--------
   val STAGING_DIR_PERMISSION: FsPermission =
-    FsPermission.createImmutable(Integer.parseInt("700", 8): Short)
+    FsPermission.createImmutable(Integer.parseInt("700", 8).toShort)
   // App files are world-wide readable and owner writable -> rw-r--r--
   val APP_FILE_PERMISSION: FsPermission =
-    FsPermission.createImmutable(Integer.parseInt("644", 8): Short)
+    FsPermission.createImmutable(Integer.parseInt("644", 8).toShort)
 
   // TODO(harvey): This could just go in ClientArguments.
   def validateArgs() = {


### PR DESCRIPTION
Sorry folks. This should make the change for SPARK-1607 compile again. Verified this time with the yarn build enabled.
