### PR TITLE
Update the import package name for TestHive in sbt shell

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -506,7 +506,7 @@ object SparkBuild extends Build {
         |import org.apache.spark.sql.catalyst.util._
         |import org.apache.spark.sql.execution
         |import org.apache.spark.sql.hive._
-        |import org.apache.spark.sql.hive.TestHive._
+        |import org.apache.spark.sql.hive.test.TestHive._
         |import org.apache.spark.sql.parquet.ParquetTestData""".stripMargin
   )
 


### PR DESCRIPTION
sbt/sbt hive/console will fail as TestHive changed its package from "org.apache.spark.sql.hive" to "org.apache.spark.sql.hive.test".
