### PR TITLE
[Bugfix] Tachyon file cleanup logical error

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -215,9 +215,9 @@ private[spark] object Utils extends Logging {
   def hasRootAsShutdownDeleteDir(file: File): Boolean = {
     val absolutePath = file.getAbsolutePath()
     val retval = shutdownDeletePaths.synchronized {
-      shutdownDeletePaths.find { path =>
+      shutdownDeletePaths.exists { path =>
         !absolutePath.equals(path) && absolutePath.startsWith(path)
-      }.isDefined
+      }
     }
     if (retval) {
       logInfo("path = " + file + ", already present as root for deletion.")
@@ -230,10 +230,10 @@ private[spark] object Utils extends Logging {
   // paths - resulting in Exception and incomplete cleanup.
   def hasRootAsShutdownDeleteDir(file: TachyonFile): Boolean = {
     val absolutePath = file.getPath()
-    val retval = shutdownDeletePaths.synchronized {
-      shutdownDeletePaths.find { path =>
+    val retval = shutdownDeleteTachyonPaths.synchronized {
+      shutdownDeleteTachyonPaths.exists { path =>
         !absolutePath.equals(path) && absolutePath.startsWith(path)
-      }.isDefined
+      }
     }
     if (retval) {
       logInfo("path = " + file + ", already present as root for deletion.")


### PR DESCRIPTION
Should lookup `shutdownDeleteTachyonPaths` instead of `shutdownDeletePaths`. Together with a minor style clean up: `find {...}.isDefined` to `exists {...}`.
