### PR TITLE
Remove jruby

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -121,6 +121,14 @@
           <artifactId>netty</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>org.jruby</groupId>
+          <artifactId>jruby-complete</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jmon</groupId>
+          <artifactId>jamon-runtime</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>


### PR DESCRIPTION
This is needed for the HBase shell, which we don't use, and adds 10+MB (compressed) to the examples jar.

I'm just removing this in maven which we use for the release packaging.
