### PR TITLE
SPARK-1667 re-fetch fails occasionally

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
@@ -71,13 +71,13 @@ private[spark] class DiskBlockManager(shuffleManager: ShuffleBlockManager, rootD
 
     // Create the subdirectory if it doesn't already exist
     var subDir = subDirs(dirId)(subDirId)
-    if (subDir == null) {
+    val newDir = new File(localDirs(dirId), "%02x".format(subDirId))
+    if (subDir == null || !newDir.exists) {
       subDir = subDirs(dirId).synchronized {
         val old = subDirs(dirId)(subDirId)
-        if (old != null) {
+        if (old != null && newDir.exists) {
           old
         } else {
-          val newDir = new File(localDirs(dirId), "%02x".format(subDirId))
           newDir.mkdir()
           subDirs(dirId)(subDirId) = newDir
           newDir


### PR DESCRIPTION
I think, when an Executor which has block(s) to be fetched is lost, fetch from the Executor will be fail and re-fetch from another Executor will occur.
When an Executor process is dead, re-fetch will be done successfully, but an Executor process is alive but can't read its own block(s), re-fetch wouldn't occur.
I think the behavior is not expected and tried to modify.

I pull-request my first modification and how does this look?
