### PR TITLE
Add support for clock offset

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/PairDStreamFunctions.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/PairDStreamFunctions.scala
@@ -396,6 +396,26 @@ class PairDStreamFunctions[K, V](self: DStream[(K,V)])
 
   /**
    * Return a new "state" DStream where the state for each key is updated by applying
+   * the given function on the previous state of the key and the new values of the key.
+   * org.apache.spark.Partitioner is used to control the partitioning of each RDD.
+   * @param updateFunc State update function. If `this` function returns None, then
+   *                   corresponding state key-value pair will be eliminated.
+   * @param partitioner Partitioner for controlling the partitioning of each RDD in the new
+   *                    DStream.
+   * @tparam S State type
+   */
+  def updateStateByKey[S: ClassTag](
+      updateFunc: (Time, K, Seq[V], Option[S]) => Option[S],
+      partitioner: Partitioner
+    ): DStream[(K, S)] = {
+    val newUpdateFunc = (time: Time, iterator: Iterator[(K, Seq[V], Option[S])]) => {
+      iterator.flatMap(t => updateFunc(time, t._1, t._2, t._3).map(s => (t._1, s)))
+    }
+    updateStateByKey(newUpdateFunc, partitioner, true)
+  }
+
+  /**
+   * Return a new "state" DStream where the state for each key is updated by applying
    * the given function on the previous state of the key and the new values of each key.
    * org.apache.spark.Partitioner is used to control the partitioning of each RDD.
    * @param updateFunc State update function. If `this` function returns None, then

--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/BlockGenerator.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/BlockGenerator.scala
@@ -48,7 +48,8 @@ private[streaming] class BlockGenerator(
 
   private case class Block(id: StreamBlockId, buffer: ArrayBuffer[Any])
 
-  private val clock = new SystemClock()
+  private val clockStartTimeMs = conf.getOption("spark.streaming.clockStartMs").map(_.toLong)
+  private val clock = new SystemClock(clockStartTimeMs)
   private val blockInterval = conf.getLong("spark.streaming.blockInterval", 200)
   private val blockIntervalTimer =
     new RecurringTimer(clock, blockInterval, updateCurrentBuffer, "BlockGenerator")

--- a/streaming/src/main/scala/org/apache/spark/streaming/util/Clock.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/util/Clock.scala
@@ -24,21 +24,22 @@ trait Clock {
 }
 
 private[streaming]
-class SystemClock() extends Clock {
+class SystemClock(val startTimeMs: Option[Long] = None) extends Clock {
 
   val minPollTime = 25L
+  val deltaTimeMs = startTimeMs.map(_ - System.currentTimeMillis()).getOrElse(0L)
 
   def currentTime(): Long = {
-    System.currentTimeMillis()
+    System.currentTimeMillis() + deltaTimeMs
   }
 
   def waitTillTime(targetTime: Long): Long = {
-    var currentTime = 0L
-    currentTime = System.currentTimeMillis()
+    var currTime = 0L
+    currTime = currentTime()
 
-    var waitTime = targetTime - currentTime
+    var waitTime = targetTime - currTime
     if (waitTime <= 0) {
-      return currentTime
+      return currTime
     }
 
     val pollTime = {
@@ -50,10 +51,10 @@ class SystemClock() extends Clock {
     }
 
     while (true) {
-      currentTime = System.currentTimeMillis()
-      waitTime = targetTime - currentTime
+      currTime = currentTime()
+      waitTime = targetTime - currTime
       if (waitTime <= 0) {
-        return currentTime
+        return currTime
       }
       val sleepTime =
         if (waitTime < pollTime) {

--- a/streaming/src/test/scala/org/apache/spark/streaming/util/ClockSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/util/ClockSuite.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.streaming.util
+
+import org.scalatest.FunSuite
+
+class ClockSuite extends FunSuite {
+
+  def checkClockWait(clock: Clock, targetTimeMs: Long) {
+    clock.waitTillTime(targetTimeMs)
+    assert(clock.currentTime() >= targetTimeMs)
+    assert(clock.currentTime() <= targetTimeMs + 2000)
+  }
+
+  test("SystemClock without offset") {
+    val clock = new SystemClock()
+
+    assert(clock.deltaTimeMs === 0)
+
+    val currTimeMs = System.currentTimeMillis()
+    val waitTimeMs = currTimeMs + 500
+
+    checkClockWait(clock, waitTimeMs)
+  }
+
+  test("SystemClock with a start time") {
+    val clock = new SystemClock(Option(100))
+    checkClockWait(clock, 600)
+  }
+}


### PR DESCRIPTION
We need to reset the clock to run streaming spark on old data for testing, debugging, etc.
