### PR TITLE
add yarn.version for profile yarn and yarn-alpha

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -845,7 +845,8 @@
         <hadoop.major.version>2</hadoop.major.version>
         <!-- 0.23.* is same as 2.0.* - except hardened to run production jobs -->
         <hadoop.version>0.23.7</hadoop.version>
-        <!--<hadoop.version>2.0.5-alpha</hadoop.version> -->
+        <yarn.version>0.23.7</yarn.version>
+          <!--<hadoop.version>2.0.5-alpha</hadoop.version> -->
       </properties>
       <modules>
         <module>yarn</module>
@@ -896,6 +897,7 @@
       <properties>
         <hadoop.major.version>2</hadoop.major.version>
         <hadoop.version>2.2.0</hadoop.version>
+        <yarn.version>2.2.0</yarn.version>
         <protobuf.version>2.5.0</protobuf.version>
       </properties>
       <modules>


### PR DESCRIPTION
Now use "mvn -Pyarn -DskipTests clean package" to build will get error because of the yarn.version default value 0.23.7. So add the yarn.version for profile yarn and yarn-alpha, then "mvn -Pyarn -DskipTests clean package" and "mvn -Pyarn-alpha -DskipTests clean package" build both success. 
