### PR TITLE
SPARK-1693: Most of the tests throw a java.lang.SecurityException when s...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -594,6 +594,10 @@
             <groupId>org.jboss.netty</groupId>
             <artifactId>netty</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 
@@ -613,6 +617,10 @@
           <exclusion>
             <groupId>org.jboss.netty</groupId>
             <artifactId>netty</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
...park built for hadoop 2.3.0 , 2.4.0
