### PR TITLE
SPARK-1629. Addendum: Depend on commons lang3 (already used by tachyon) as it's used in ReplSuite, and return to use lang3 utility in Utils.scala

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -70,6 +70,10 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
     </dependency>

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -32,6 +32,7 @@ import scala.util.Try
 
 import com.google.common.io.Files
 import com.google.common.util.concurrent.ThreadFactoryBuilder
+import org.apache.commons.lang3.SystemUtils
 import org.apache.hadoop.fs.{FileSystem, FileUtil, Path}
 import org.json4s._
 import tachyon.client.{TachyonFile,TachyonFS}
@@ -1073,9 +1074,7 @@ private[spark] object Utils extends Logging {
   /**
    * Return true if this is Windows.
    */
-  def isWindows = {
-    Option(System.getProperty("os.name")).exists(_.startsWith("Windows"))
-  }
+  def isWindows = SystemUtils.IS_OS_WINDOWS;
 
   /**
    * Indicates whether Spark is currently running unit tests.

--- a/pom.xml
+++ b/pom.xml
@@ -222,6 +222,11 @@
         <version>14.0.1</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.3.2</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
         <version>1.3.9</version>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -326,6 +326,7 @@ object SparkBuild extends Build {
     name := "spark-core",
     libraryDependencies ++= Seq(
         "com.google.guava"           % "guava"            % "14.0.1",
+        "org.apache.commons"         % "commons-lang3"    % "3.3.2",
         "com.google.code.findbugs"   % "jsr305"           % "1.3.9",
         "log4j"                      % "log4j"            % "1.2.17",
         "org.slf4j"                  % "slf4j-api"        % slf4jVersion,


### PR DESCRIPTION
For consideration. This was proposed in related discussion: https://github.com/apache/spark/pull/569
