### PR TITLE
[WIP]SPARK-1706: Allow multiple executors per worker in Standalone mode

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/ApplicationDescription.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/ApplicationDescription.scala
@@ -20,7 +20,7 @@ package org.apache.spark.deploy
 private[spark] class ApplicationDescription(
     val name: String,
     val maxCores: Option[Int],
-    val memoryPerSlave: Int,
+    val memoryPerExecutor: Int,
     val command: Command,
     val sparkHome: Option[String],
     var appUiUrl: String,

--- a/core/src/main/scala/org/apache/spark/deploy/ApplicationDescription.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/ApplicationDescription.scala
@@ -20,7 +20,7 @@ package org.apache.spark.deploy
 private[spark] class ApplicationDescription(
     val name: String,
     val maxCores: Option[Int],
-    val memoryPerExecutor: Int,
+    val memoryPerExecutor: Int, // in Mb
     val command: Command,
     val sparkHome: Option[String],
     var appUiUrl: String,
@@ -28,6 +28,7 @@ private[spark] class ApplicationDescription(
   extends Serializable {
 
   val user = System.getProperty("user.name", "<unknown>")
-
+  // only valid when spark.executor.multiPerWorker is set to true
+  var maxCorePerExecutor = maxCores
   override def toString: String = "ApplicationDescription(" + name + ")"
 }

--- a/core/src/main/scala/org/apache/spark/deploy/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/JsonProtocol.scala
@@ -45,7 +45,7 @@ private[spark] object JsonProtocol {
     ("name" -> obj.desc.name) ~
     ("cores" -> obj.desc.maxCores) ~
     ("user" ->  obj.desc.user) ~
-    ("memoryperslave" -> obj.desc.memoryPerSlave) ~
+    ("memoryperslave" -> obj.desc.memoryPerExecutor) ~
     ("submitdate" -> obj.submitDate.toString) ~
     ("state" -> obj.state.toString) ~
     ("duration" -> obj.duration)
@@ -54,7 +54,7 @@ private[spark] object JsonProtocol {
   def writeApplicationDescription(obj: ApplicationDescription) = {
     ("name" -> obj.name) ~
     ("cores" -> obj.maxCores) ~
-    ("memoryperslave" -> obj.memoryPerSlave) ~
+    ("memoryperslave" -> obj.memoryPerExecutor) ~
     ("user" -> obj.user) ~
     ("sparkhome" -> obj.sparkHome) ~
     ("command" -> obj.command.toString)

--- a/core/src/main/scala/org/apache/spark/deploy/master/ApplicationInfo.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ApplicationInfo.scala
@@ -66,7 +66,7 @@ private[spark] class ApplicationInfo(
   }
 
   def addExecutor(worker: WorkerInfo, cores: Int, useID: Option[Int] = None): ExecutorInfo = {
-    val exec = new ExecutorInfo(newExecutorId(useID), this, worker, cores, desc.memoryPerSlave)
+    val exec = new ExecutorInfo(newExecutorId(useID), this, worker, cores, desc.memoryPerExecutor)
     executors(exec.id) = exec
     coresGranted += cores
     exec

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -531,8 +531,9 @@ private[spark] class Master(
             usableWorkers(pos).memoryFree >=
               app.desc.memoryPerExecutor * (assigned(pos).length + 1)) {
             mostFreeCoreWorkerPos = pos
-            maxPossibleCore = usableWorkers(pos).coresFree - assignedSum(pos)
           }
+          maxPossibleCore = usableWorkers(mostFreeCoreWorkerPos).coresFree -
+            assignedSum(mostFreeCoreWorkerPos)
           val coreToAssign = math.min(math.min(maxCoreNumPerExecutor, maxPossibleCore),
             leftCoreToAssign)
           if (usableWorkers(pos).coresFree - assignedSum(pos) >= coreToAssign) {

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -520,9 +520,9 @@ private[spark] class Master(
         val memoryNotEnoughFlags = new Array[Boolean](numUsable)
         while (leftCoreToAssign > 0 && memoryNotEnoughFlags.contains(false)) {
           val coreToAssign = math.min(coreNumPerExecutor, leftCoreToAssign)
-          if (usableWorkers(pos).coresFree - assigned(pos).sum > coreToAssign &&
+          if (usableWorkers(pos).coresFree - assigned(pos).sum >= coreToAssign &&
             !memoryNotEnoughFlags(pos)) {
-            if (usableWorkers(pos).memoryFree >
+            if (usableWorkers(pos).memoryFree >=
               app.desc.memoryPerExecutor * (assigned(pos).length + 1)) {
               leftCoreToAssign -= coreToAssign
               assigned(pos) += coreToAssign

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -515,7 +515,9 @@ private[spark] class Master(
           app.desc.memoryPerExecutor).sortBy(_.coresFree).reverse
         val maxCoreNumPerExecutor = app.desc.maxCorePerExecutor.get
         var mostFreeCoreWorkerPos = 0
-        var leftCoreToAssign = math.min(app.coresLeft, usableWorkers.map(_.coresFree).sum)
+        val maxAvailableSlots = usableWorkers.map(worker => math.min(worker.coresFree,
+          worker.memoryFree / app.desc.memoryPerExecutor)).sum
+        var leftCoreToAssign = math.min(app.coresLeft, maxAvailableSlots)
         val numUsable = usableWorkers.length
         // Number of cores of each executor assigned to each worker
         val assigned = Array.fill[ListBuffer[Int]](numUsable)(new ListBuffer[Int])

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -511,8 +511,8 @@ private[spark] class Master(
     if (spreadOutApps) {
       for (app <- waitingApps if app.coresLeft > 0) {
         var usableWorkers = workers.toArray.filter(_.state == WorkerState.ALIVE)
-          .filter(worker => worker.coresFree > 0 && worker.memoryFree >= app.desc.memoryPerExecutor).
-          sortBy(_.coresFree).reverse
+          .filter(worker => worker.coresFree > 0 && worker.memoryFree >=
+          app.desc.memoryPerExecutor).sortBy(_.coresFree).reverse
         val maxCoreNumPerExecutor = app.desc.maxCorePerExecutor.get
         var mostFreeCoreWorkerPos = 0
         var leftCoreToAssign = math.min(app.coresLeft, usableWorkers.map(_.coresFree).sum)

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/ApplicationPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/ApplicationPage.scala
@@ -79,7 +79,7 @@ private[spark] class ApplicationPage(parent: MasterWebUI) extends WebUIPage("app
               </li>
               <li>
                 <strong>Executor Memory:</strong>
-                {Utils.megabytesToString(app.desc.memoryPerSlave)}
+                {Utils.megabytesToString(app.desc.memoryPerExecutor)}
               </li>
               <li><strong>Submit Date:</strong> {app.submitDate}</li>
               <li><strong>State:</strong> {app.state}</li>

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
@@ -165,8 +165,8 @@ private[spark] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
       <td>
         {app.coresGranted}
       </td>
-      <td sorttable_customkey={app.desc.memoryPerSlave.toString}>
-        {Utils.megabytesToString(app.desc.memoryPerSlave)}
+      <td sorttable_customkey={app.desc.memoryPerExecutor.toString}>
+        {Utils.megabytesToString(app.desc.memoryPerExecutor)}
       </td>
       <td>{UIUtils.formatDate(app.submitDate)}</td>
       <td>{app.desc.user}</td>

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
@@ -59,7 +59,9 @@ private[spark] class SparkDeploySchedulerBackend(
     val sparkHome = sc.getSparkHome()
     val appDesc = new ApplicationDescription(sc.appName, maxCores, sc.executorMemory, command,
       sparkHome, sc.ui.appUIAddress, sc.eventLogger.map(_.logDir))
-
+    if (conf.getBoolean("spark.executor.multiPerWorker", false)) {
+      appDesc.maxCorePerExecutor = Some(conf.getInt("spark.executor.maxCoreNumPerExecutor", 1))
+    }
     client = new AppClient(sc.env.actorSystem, masters, appDesc, this, conf)
     client.start()
   }

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
@@ -59,7 +59,7 @@ private[spark] class SparkDeploySchedulerBackend(
     val sparkHome = sc.getSparkHome()
     val appDesc = new ApplicationDescription(sc.appName, maxCores, sc.executorMemory, command,
       sparkHome, sc.ui.appUIAddress, sc.eventLogger.map(_.logDir))
-    if (conf.getBoolean("spark.executor.multiPerWorker", false)) {
+    if (conf.getBoolean("spark.executor.multiPerWorker", true)) {
       appDesc.maxCorePerExecutor = Some(conf.getInt("spark.executor.maxCoreNumPerExecutor", 1))
     }
     client = new AppClient(sc.env.actorSystem, masters, appDesc, this, conf)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -675,6 +675,21 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+  <td>spark.executor.multiPerWorker</td>
+  <td>false</td>
+  <td>
+    enable user to run multiple executors in the same worker.
+  </td>
+</tr>
+<tr>
+  <td>spark.executor.coreNumPerExecutor</td>
+  <td>1</td>
+  <td>
+    set the number of cores assigned to each executor; this property is only valid when
+    <code>spark.executor.multiPerWorker</code> is set to true.
+  </td>
+</tr>
+<tr>
   <td>spark.executor.extraClassPath</td>
   <td>(none)</td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -682,10 +682,10 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
-  <td>spark.executor.coreNumPerExecutor</td>
+  <td>spark.executor.maxCoreNumPerExecutor</td>
   <td>1</td>
   <td>
-    set the number of cores assigned to each executor; this property is only valid when
+    set the max number of cores assigned to each executor; this property is only valid when
     <code>spark.executor.multiPerWorker</code> is set to true.
   </td>
 </tr>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-1706

In current implementation, the user has to start multiple workers in a server for starting multiple executors in a server, which introduces additional overhead due to the more JVM processes...

In this patch, I changed the scheduling logic in master to enable the user to start multiple executor processes within the same JVM process. 

Other small changes include
1. change  memoryPerSlave in ApplicationDescription to memoryPerExecutor, as "Slave" is overrided  to represent both worker and executor in the documents... (we have some discussion on this before?)

@pwendell, I think we don't need to change anything in scheduler part, as we indexed the executor by executorId instead of host IP address?
