### PR TITLE
SPARK-1715: Ensure actor is self-contained in DAGScheduler

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -293,8 +293,6 @@ class SparkContext(config: SparkConf) extends Logging {
   private val heartbeatReceiver = env.actorSystem.actorOf(
     Props(new HeartbeatReceiver(taskScheduler)), "HeartbeatReceiver")
 
-  @volatile private[spark] var dagSchedulerStopped = false
-
   @volatile private[spark] var dagScheduler: DAGScheduler = _
 
   // for work around the current MIMA issue
@@ -1027,8 +1025,7 @@ class SparkContext(config: SparkConf) extends Logging {
       metadataCleaner.cancel()
       env.actorSystem.stop(heartbeatReceiver)
       cleaner.foreach(_.stop())
-      dagSchedulerStopped = true
-      dagScheduler.stop()
+      dagSchedulerCopy.stop()
       taskScheduler = null
       // TODO: Cache.stop()?
       env.stop()

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -725,7 +725,7 @@ class DAGSchedulerSuite extends TestKit(ActorSystem("DAGSchedulerSuite")) with F
     watch(child)
     child ! "hi"
     expectMsgPF(){ case Terminated(child) => () }
-    assert(scheduler.sc.dagScheduler === null)
+    assert(scheduler.sc.dagSchedulerStopped === true)
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -725,7 +725,7 @@ class DAGSchedulerSuite extends TestKit(ActorSystem("DAGSchedulerSuite")) with F
     watch(child)
     child ! "hi"
     expectMsgPF(){ case Terminated(child) => () }
-    assert(scheduler.sc.dagSchedulerStopped === true)
+    assert(scheduler.sc.dagScheduler === null)
   }
 
   /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-1715

Though the current supervisor-child structure works fine for fault-tolerance, it violates the rule that the actor is better to be self-contained

We should forward the message from supervisor to the child actor, so that we can eliminate the hard-coded timeout threshold for starting the DAGScheduler and provide more convenient interface for future development like parallel DAGScheduler, or new changes to the DAGScheduler
