### PR TITLE
EC2 script should exit with non-zero code on UsageError

### DIFF
--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -814,6 +814,7 @@ def main():
     real_main()
   except UsageError, e:
     print >> stderr, "\nError:\n", e
+    sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is specially import because some ssh errors are raised as UsageError, preventing an automated usage of the script from detecting the failure.
