### PR TITLE
Updated doc for spark.closure.serializer to indicate only Java serializer work.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -289,7 +289,7 @@ Apart from these, the following properties are also available, and may be useful
   <td>spark.closure.serializer</td>
   <td>org.apache.spark.serializer.<br />JavaSerializer</td>
   <td>
-    Serializer class to use for closures. Currently only the default serializer is supported.
+    Serializer class to use for closures. Currently only the Java serializer is supported.
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -289,8 +289,7 @@ Apart from these, the following properties are also available, and may be useful
   <td>spark.closure.serializer</td>
   <td>org.apache.spark.serializer.<br />JavaSerializer</td>
   <td>
-    Serializer class to use for closures. Generally Java is fine unless your distributed functions
-    (e.g. map functions) reference large objects in the driver program.
+    Serializer class to use for closures. Currently only the default serializer is supported.
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
See discussion from http://apache-spark-developers-list.1001551.n3.nabble.com/bug-using-kryo-as-closure-serializer-td6473.html
