### PR TITLE
Include the sbin/spark-config.sh in spark-executor

### DIFF
--- a/sbin/spark-executor
+++ b/sbin/spark-executor
@@ -19,10 +19,8 @@
 
 FWDIR="$(cd `dirname $0`/..; pwd)"
 
-sbin=`dirname "$0"`
-sbin=`cd "$sbin"; pwd`
-
-. "$sbin/spark-config.sh"
+export PYTHONPATH=$FWDIR/python:$PYTHONPATH
+export PYTHONPATH=$FWDIR/python/lib/py4j-0.8.1-src.zip:$PYTHONPATH
 
 echo "Running spark-executor with framework dir = $FWDIR"
 exec $FWDIR/bin/spark-class org.apache.spark.executor.MesosExecutorBackend

--- a/sbin/spark-executor
+++ b/sbin/spark-executor
@@ -19,5 +19,10 @@
 
 FWDIR="$(cd `dirname $0`/..; pwd)"
 
+sbin=`dirname "$0"`
+sbin=`cd "$sbin"; pwd`
+
+. "$sbin/spark-config.sh"
+
 echo "Running spark-executor with framework dir = $FWDIR"
 exec $FWDIR/bin/spark-class org.apache.spark.executor.MesosExecutorBackend


### PR DESCRIPTION
This is needed because broadcast values are broken on pyspark on Mesos, it tries to import pyspark but can't, as the PYTHONPATH is not set due to changes in ff5be9a4

https://issues.apache.org/jira/browse/SPARK-1725
