### PR TITLE
SPARK-1714. Take advantage of AMRMClient APIs to simplify logic in YarnA...

### DIFF
--- a/yarn/common/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientClusterScheduler.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientClusterScheduler.scala
@@ -19,6 +19,7 @@ package org.apache.spark.scheduler.cluster
 
 import org.apache.spark._
 import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.yarn.util.RackResolver
 import org.apache.spark.deploy.yarn.YarnAllocationHandler
 import org.apache.spark.scheduler.TaskSchedulerImpl
 import org.apache.spark.util.Utils
@@ -34,7 +35,7 @@ private[spark] class YarnClientClusterScheduler(sc: SparkContext, conf: Configur
   // By default, rack is unknown
   override def getRackForHost(hostPort: String): Option[String] = {
     val host = Utils.parseHostPort(hostPort)._1
-    val retval = YarnAllocationHandler.lookupRack(conf, host)
+    val retval = RackResolver.resolve(conf, host).getNetworkLocation
     if (retval != null) Some(retval) else None
   }
 

--- a/yarn/common/src/main/scala/org/apache/spark/scheduler/cluster/YarnClusterScheduler.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/scheduler/cluster/YarnClusterScheduler.scala
@@ -22,6 +22,7 @@ import org.apache.spark.deploy.yarn.{ApplicationMaster, YarnAllocationHandler}
 import org.apache.spark.scheduler.TaskSchedulerImpl
 import org.apache.spark.util.Utils
 import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.yarn.util.RackResolver
 
 /**
  *
@@ -41,7 +42,7 @@ private[spark] class YarnClusterScheduler(sc: SparkContext, conf: Configuration)
   // By default, rack is unknown
   override def getRackForHost(hostPort: String): Option[String] = {
     val host = Utils.parseHostPort(hostPort)._1
-    val retval = YarnAllocationHandler.lookupRack(conf, host)
+    val retval = RackResolver.resolve(conf, host).getNetworkLocation
     if (retval != null) Some(retval) else None
   }
 

--- a/yarn/stable/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocationHandler.scala
+++ b/yarn/stable/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocationHandler.scala
@@ -17,8 +17,7 @@
 
 package org.apache.spark.deploy.yarn
 
-import java.lang.{Boolean => JBoolean}
-import java.util.{Collections, Set => JSet}
+import java.util.{Set => JSet}
 import java.util.concurrent.{CopyOnWriteArrayList, ConcurrentHashMap}
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -27,19 +26,16 @@ import scala.collection.JavaConversions._
 import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet}
 
 import org.apache.spark.{Logging, SparkConf}
-import org.apache.spark.scheduler.{SplitInfo,TaskSchedulerImpl}
+import org.apache.spark.scheduler.SplitInfo
 import org.apache.spark.scheduler.cluster.CoarseGrainedSchedulerBackend
-import org.apache.spark.util.Utils
 
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.yarn.api.ApplicationMasterProtocol
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId
 import org.apache.hadoop.yarn.api.records.{Container, ContainerId, ContainerStatus}
-import org.apache.hadoop.yarn.api.records.{Priority, Resource, ResourceRequest}
-import org.apache.hadoop.yarn.api.protocolrecords.{AllocateRequest, AllocateResponse}
+import org.apache.hadoop.yarn.api.records.{Priority, Resource}
 import org.apache.hadoop.yarn.client.api.AMRMClient
 import org.apache.hadoop.yarn.client.api.AMRMClient.ContainerRequest
-import org.apache.hadoop.yarn.util.{RackResolver, Records}
+import org.apache.hadoop.yarn.util.RackResolver
 
 
 object AllocationType extends Enumeration {
@@ -71,24 +67,20 @@ private[yarn] class YarnAllocationHandler(
     val preferredRackToCount: Map[String, Int],
     val sparkConf: SparkConf)
   extends Logging {
+
   // These three are locked on allocatedHostToContainersMap. Complementary data structures
   // allocatedHostToContainersMap : containers which are running : host, Set<containerid>
   // allocatedContainerToHostMap: container to host mapping.
-  private val allocatedHostToContainersMap =
+  private[yarn] val allocatedHostToContainersMap =
     new HashMap[String, collection.mutable.Set[ContainerId]]()
 
-  private val allocatedContainerToHostMap = new HashMap[ContainerId, String]()
+  private[yarn] val allocatedContainerToHostMap = new HashMap[ContainerId, String]()
 
-  // allocatedRackCount is populated ONLY if allocation happens (or decremented if this is an
-  // allocated node)
-  // As with the two data structures above, tightly coupled with them, and to be locked on
-  // allocatedHostToContainersMap
-  private val allocatedRackCount = new HashMap[String, Int]()
+  // Mapping of rack names to # of executors allocated on them
+  private[yarn] val allocatedRackCount = new HashMap[String, Int]()
 
   // Containers which have been released.
   private val releasedContainerList = new CopyOnWriteArrayList[ContainerId]()
-  // Containers to be released in next request to RM
-  private val pendingReleaseContainers = new ConcurrentHashMap[ContainerId, Boolean]
 
   // Number of container requests that have been sent to, but not yet allocated by the
   // ApplicationMaster.
@@ -96,7 +88,6 @@ private[yarn] class YarnAllocationHandler(
   private val numExecutorsRunning = new AtomicInteger()
   // Used to generate a unique id per executor
   private val executorIdCounter = new AtomicInteger()
-  private val lastResponseId = new AtomicInteger()
   private val numExecutorsFailed = new AtomicInteger()
 
   def getNumPendingAllocate: Int = numPendingAllocate.intValue
@@ -105,278 +96,222 @@ private[yarn] class YarnAllocationHandler(
 
   def getNumExecutorsFailed: Int = numExecutorsFailed.intValue
 
-  def isResourceConstraintSatisfied(container: Container): Boolean = {
-    container.getResource.getMemory >= (executorMemory + YarnAllocationHandler.MEMORY_OVERHEAD)
-  }
-
   def releaseContainer(container: Container) {
     val containerId = container.getId
-    pendingReleaseContainers.put(containerId, true)
     amClient.releaseAssignedContainer(containerId)
   }
 
+  /**
+   * Heartbeat to the ResourceManager. Passes along any ContainerRequests we've added to the
+   * AMRMClient. If there are no pending requests, lets the ResourceManager know we're still alive.
+   */
   def allocateResources() {
-    // We have already set the container request. Poll the ResourceManager for a response.
-    // This doubles as a heartbeat if there are no pending container requests.
     val progressIndicator = 0.1f
     val allocateResponse = amClient.allocate(progressIndicator)
 
     val allocatedContainers = allocateResponse.getAllocatedContainers()
     if (allocatedContainers.size > 0) {
-      var numPendingAllocateNow = numPendingAllocate.addAndGet(-1 * allocatedContainers.size)
-
-      if (numPendingAllocateNow < 0) {
-        numPendingAllocateNow = numPendingAllocate.addAndGet(-1 * numPendingAllocateNow)
-      }
-
       logDebug("""
         Allocated containers: %d
         Current executor count: %d
         Containers released: %s
-        Containers to-be-released: %s
         Cluster resources: %s
-        """.format(
-          allocatedContainers.size,
-          numExecutorsRunning.get(),
-          releasedContainerList,
-          pendingReleaseContainers,
-          allocateResponse.getAvailableResources))
+               """.format(
+        allocatedContainers.size,
+        numExecutorsRunning.get(),
+        releasedContainerList,
+        allocateResponse.getAvailableResources))
 
-      val hostToContainers = new HashMap[String, ArrayBuffer[Container]]()
-
-      for (container <- allocatedContainers) {
-        if (isResourceConstraintSatisfied(container)) {
-          // Add the accepted `container` to the host's list of already accepted,
-          // allocated containers
-          val host = container.getNodeId.getHost
-          val containersForHost = hostToContainers.getOrElseUpdate(host,
-            new ArrayBuffer[Container]())
-          containersForHost += container
-        } else {
-          // Release container, since it doesn't satisfy resource constraints.
-          releaseContainer(container)
-        }
-      }
-
-       // Find the appropriate containers to use.
-      // TODO: Cleanup this group-by...
-      val dataLocalContainers = new HashMap[String, ArrayBuffer[Container]]()
-      val rackLocalContainers = new HashMap[String, ArrayBuffer[Container]]()
-      val offRackContainers = new HashMap[String, ArrayBuffer[Container]]()
-
-      for (candidateHost <- hostToContainers.keySet) {
-        val maxExpectedHostCount = preferredHostToCount.getOrElse(candidateHost, 0)
-        val requiredHostCount = maxExpectedHostCount - allocatedContainersOnHost(candidateHost)
-
-        val remainingContainersOpt = hostToContainers.get(candidateHost)
-        assert(remainingContainersOpt.isDefined)
-        var remainingContainers = remainingContainersOpt.get
-
-        if (requiredHostCount >= remainingContainers.size) {
-          // Since we have <= required containers, add all remaining containers to
-          // `dataLocalContainers`.
-          dataLocalContainers.put(candidateHost, remainingContainers)
-          // There are no more free containers remaining.
-          remainingContainers = null
-        } else if (requiredHostCount > 0) {
-          // Container list has more containers than we need for data locality.
-          // Split the list into two: one based on the data local container count,
-          // (`remainingContainers.size` - `requiredHostCount`), and the other to hold remaining
-          // containers.
-          val (dataLocal, remaining) = remainingContainers.splitAt(
-            remainingContainers.size - requiredHostCount)
-          dataLocalContainers.put(candidateHost, dataLocal)
-
-          // Invariant: remainingContainers == remaining
-
-          // YARN has a nasty habit of allocating a ton of containers on a host - discourage this.
-          // Add each container in `remaining` to list of containers to release. If we have an
-          // insufficient number of containers, then the next allocation cycle will reallocate
-          // (but won't treat it as data local).
-          // TODO(harvey): Rephrase this comment some more.
-          for (container <- remaining) releaseContainer(container)
-          remainingContainers = null
-        }
-
-        // For rack local containers
-        if (remainingContainers != null) {
-          val rack = YarnAllocationHandler.lookupRack(conf, candidateHost)
-          if (rack != null) {
-            val maxExpectedRackCount = preferredRackToCount.getOrElse(rack, 0)
-            val requiredRackCount = maxExpectedRackCount - allocatedContainersOnRack(rack) -
-              rackLocalContainers.getOrElse(rack, List()).size
-
-            if (requiredRackCount >= remainingContainers.size) {
-              // Add all remaining containers to to `dataLocalContainers`.
-              dataLocalContainers.put(rack, remainingContainers)
-              remainingContainers = null
-            } else if (requiredRackCount > 0) {
-              // Container list has more containers that we need for data locality.
-              // Split the list into two: one based on the data local container count,
-              // (`remainingContainers.size` - `requiredHostCount`), and the other to hold remaining
-              // containers.
-              val (rackLocal, remaining) = remainingContainers.splitAt(
-                remainingContainers.size - requiredRackCount)
-              val existingRackLocal = rackLocalContainers.getOrElseUpdate(rack,
-                new ArrayBuffer[Container]())
-
-              existingRackLocal ++= rackLocal
-
-              remainingContainers = remaining
-            }
-          }
-        }
-
-        if (remainingContainers != null) {
-          // Not all containers have been consumed - add them to the list of off-rack containers.
-          offRackContainers.put(candidateHost, remainingContainers)
-        }
-      }
-
-      // Now that we have split the containers into various groups, go through them in order:
-      // first host-local, then rack-local, and finally off-rack.
-      // Note that the list we create below tries to ensure that not all containers end up within
-      // a host if there is a sufficiently large number of hosts/containers.
-      val allocatedContainersToProcess = new ArrayBuffer[Container](allocatedContainers.size)
-      allocatedContainersToProcess ++= TaskSchedulerImpl.prioritizeContainers(dataLocalContainers)
-      allocatedContainersToProcess ++= TaskSchedulerImpl.prioritizeContainers(rackLocalContainers)
-      allocatedContainersToProcess ++= TaskSchedulerImpl.prioritizeContainers(offRackContainers)
-
-      // Run each of the allocated containers.
-      for (container <- allocatedContainersToProcess) {
-        val numExecutorsRunningNow = numExecutorsRunning.incrementAndGet()
-        val executorHostname = container.getNodeId.getHost
-        val containerId = container.getId
-
-        val executorMemoryOverhead = (executorMemory + YarnAllocationHandler.MEMORY_OVERHEAD)
-        assert(container.getResource.getMemory >= executorMemoryOverhead)
-
-        if (numExecutorsRunningNow > maxExecutors) {
-          logInfo("""Ignoring container %s at host %s, since we already have the required number of
-            containers for it.""".format(containerId, executorHostname))
-          releaseContainer(container)
-          numExecutorsRunning.decrementAndGet()
-        } else {
-          val executorId = executorIdCounter.incrementAndGet().toString
-          val driverUrl = "akka.tcp://spark@%s:%s/user/%s".format(
-            sparkConf.get("spark.driver.host"),
-            sparkConf.get("spark.driver.port"),
-            CoarseGrainedSchedulerBackend.ACTOR_NAME)
-
-          logInfo("Launching container %s for on host %s".format(containerId, executorHostname))
-
-          // To be safe, remove the container from `pendingReleaseContainers`.
-          pendingReleaseContainers.remove(containerId)
-
-          val rack = YarnAllocationHandler.lookupRack(conf, executorHostname)
-          allocatedHostToContainersMap.synchronized {
-            val containerSet = allocatedHostToContainersMap.getOrElseUpdate(executorHostname,
-              new HashSet[ContainerId]())
-
-            containerSet += containerId
-            allocatedContainerToHostMap.put(containerId, executorHostname)
-
-            if (rack != null) {
-              allocatedRackCount.put(rack, allocatedRackCount.getOrElse(rack, 0) + 1)
-            }
-          }
-          logInfo("Launching ExecutorRunnable. driverUrl: %s,  executorHostname: %s".format(
-            driverUrl, executorHostname))
-          val executorRunnable = new ExecutorRunnable(
-            container,
-            conf,
-            sparkConf,
-            driverUrl,
-            executorId,
-            executorHostname,
-            executorMemory,
-            executorCores)
-          new Thread(executorRunnable).start()
-        }
-      }
-      logDebug("""
-        Finished allocating %s containers (from %s originally).
-        Current number of executors running: %d,
-        releasedContainerList: %s,
-        pendingReleaseContainers: %s
-        """.format(
-          allocatedContainersToProcess,
-          allocatedContainers,
-          numExecutorsRunning.get(),
-          releasedContainerList,
-          pendingReleaseContainers))
+      handleAllocatedContainers(allocatedContainers)
     }
 
     val completedContainers = allocateResponse.getCompletedContainersStatuses()
     if (completedContainers.size > 0) {
       logDebug("Completed %d containers".format(completedContainers.size))
 
-      for (completedContainer <- completedContainers) {
-        val containerId = completedContainer.getContainerId
+      processCompletedContainers(completedContainers)
 
-        if (pendingReleaseContainers.containsKey(containerId)) {
-          // YarnAllocationHandler already marked the container for release, so remove it from
-          // `pendingReleaseContainers`.
-          pendingReleaseContainers.remove(containerId)
-        } else {
-          // Decrement the number of executors running. The next iteration of
-          // the ApplicationMaster's reporting thread will take care of allocating.
-          numExecutorsRunning.decrementAndGet()
-          logInfo("Completed container %s (state: %s, exit status: %s)".format(
-            containerId,
-            completedContainer.getState,
-            completedContainer.getExitStatus()))
-          // Hadoop 2.2.X added a ContainerExitStatus we should switch to use
-          // there are some exit status' we shouldn't necessarily count against us, but for
-          // now I think its ok as none of the containers are expected to exit
-          if (completedContainer.getExitStatus() != 0) {
-            logInfo("Container marked as failed: " + containerId)
-            numExecutorsFailed.incrementAndGet()
-          }
-        }
-
-        allocatedHostToContainersMap.synchronized {
-          if (allocatedContainerToHostMap.containsKey(containerId)) {
-            val hostOpt = allocatedContainerToHostMap.get(containerId)
-            assert(hostOpt.isDefined)
-            val host = hostOpt.get
-
-            val containerSetOpt = allocatedHostToContainersMap.get(host)
-            assert(containerSetOpt.isDefined)
-            val containerSet = containerSetOpt.get
-
-            containerSet.remove(containerId)
-            if (containerSet.isEmpty) {
-              allocatedHostToContainersMap.remove(host)
-            } else {
-              allocatedHostToContainersMap.update(host, containerSet)
-            }
-
-            allocatedContainerToHostMap.remove(containerId)
-
-            // TODO: Move this part outside the synchronized block?
-            val rack = YarnAllocationHandler.lookupRack(conf, host)
-            if (rack != null) {
-              val rackCount = allocatedRackCount.getOrElse(rack, 0) - 1
-              if (rackCount > 0) {
-                allocatedRackCount.put(rack, rackCount)
-              } else {
-                allocatedRackCount.remove(rack)
-              }
-            }
-          }
-        }
-      }
       logDebug("""
         Finished processing %d completed containers.
         Current number of executors running: %d,
         releasedContainerList: %s,
-        pendingReleaseContainers: %s
         """.format(
           completedContainers.size,
           numExecutorsRunning.get(),
-          releasedContainerList,
-          pendingReleaseContainers))
+          releasedContainerList))
+    }
+  }
+
+  def handleAllocatedContainers(allocatedContainers: Seq[Container]) {
+    val numPendingAllocateNow = numPendingAllocate.addAndGet(-allocatedContainers.size)
+
+    if (numPendingAllocateNow < 0) {
+      numPendingAllocate.addAndGet(-numPendingAllocateNow)
+    }
+
+    val containersToUse = new ArrayBuffer[Container](allocatedContainers.size)
+
+    // Match incoming requests by host
+    val remainingAfterHostMatches = new ArrayBuffer[Container]()
+    for (allocatedContainer <- allocatedContainers) {
+      matchContainerToRequest(allocatedContainer, allocatedContainer.getNodeId.getHost,
+        containersToUse, remainingAfterHostMatches)
+    }
+
+    // Match remaining by rack
+    val remainingAfterRackMatches = new ArrayBuffer[Container]()
+    for (allocatedContainer <- remainingAfterHostMatches) {
+      val rack = RackResolver.resolve(conf, allocatedContainer.getNodeId.getHost).getNetworkLocation
+      matchContainerToRequest(allocatedContainer, rack, containersToUse,
+        remainingAfterRackMatches)
+    }
+
+    // Assign remaining that are neither node-local nor rack-local
+    val remainingAfterOffRackMatches = new ArrayBuffer[Container]()
+    for (allocatedContainer <- remainingAfterRackMatches) {
+      matchContainerToRequest(allocatedContainer, "*", containersToUse,
+        remainingAfterOffRackMatches)
+    }
+
+    if (!remainingAfterOffRackMatches.isEmpty) {
+      logWarning("Received containers that did not satisfy resource constraints: "
+        + remainingAfterOffRackMatches)
+      for (container <- remainingAfterOffRackMatches) {
+        amClient.releaseAssignedContainer(container.getId)
+      }
+    }
+
+    runAllocatedContainers(containersToUse)
+
+    logDebug("""
+        Finished allocating %s containers (from %s originally).
+        Current number of executors running: %d,
+        releasedContainerList: %s,
+             """.format(
+      containersToUse,
+      allocatedContainers,
+      numExecutorsRunning.get(),
+      releasedContainerList))
+  }
+
+  def runAllocatedContainers(containersToUse: ArrayBuffer[Container]) {
+    for (container <- containersToUse) {
+      val numExecutorsRunningNow = numExecutorsRunning.incrementAndGet()
+      val executorHostname = container.getNodeId.getHost
+      val containerId = container.getId
+
+      val executorMemoryWithOverhead = (executorMemory + YarnAllocationHandler.MEMORY_OVERHEAD)
+      assert(container.getResource.getMemory >= executorMemoryWithOverhead)
+
+      if (numExecutorsRunningNow > maxExecutors) {
+        logInfo("""Ignoring container %s at host %s, since we already have the required number of
+            containers.""".format(containerId, executorHostname))
+        amClient.releaseAssignedContainer(container.getId)
+        numExecutorsRunning.decrementAndGet()
+      } else {
+        val executorId = executorIdCounter.incrementAndGet().toString
+        val driverUrl = "akka.tcp://spark@%s:%s/user/%s".format(
+          sparkConf.get("spark.driver.host"),
+          sparkConf.get("spark.driver.port"),
+          CoarseGrainedSchedulerBackend.ACTOR_NAME)
+
+        logInfo("Launching container %s for on host %s".format(containerId, executorHostname))
+
+        val rack = RackResolver.resolve(conf, executorHostname).getNetworkLocation
+        allocatedHostToContainersMap.synchronized {
+          val containerSet = allocatedHostToContainersMap.getOrElseUpdate(executorHostname,
+            new HashSet[ContainerId]())
+
+          containerSet += containerId
+          allocatedContainerToHostMap.put(containerId, executorHostname)
+
+          if (rack != null) {
+            allocatedRackCount.put(rack, allocatedRackCount.getOrElse(rack, 0) + 1)
+          }
+        }
+        logInfo("Launching ExecutorRunnable. driverUrl: %s,  executorHostname: %s".format(
+          driverUrl, executorHostname))
+        val executorRunnable = new ExecutorRunnable(
+          container,
+          conf,
+          sparkConf,
+          driverUrl,
+          executorId,
+          executorHostname,
+          executorMemory,
+          executorCores)
+        new Thread(executorRunnable).start()
+      }
+    }
+  }
+
+  def processCompletedContainers(completedContainers: Seq[ContainerStatus]) {
+    for (completedContainer <- completedContainers) {
+      val containerId = completedContainer.getContainerId
+
+      if (allocatedContainerToHostMap.containsKey(containerId)) {
+        // Decrement the number of executors running. The next iteration of
+        // the ApplicationMaster's reporting thread will take care of allocating.
+        numExecutorsRunning.decrementAndGet()
+        logInfo("Completed container %s (state: %s, exit status: %s)".format(
+          containerId,
+          completedContainer.getState,
+          completedContainer.getExitStatus()))
+        // Hadoop 2.2.X added a ContainerExitStatus we should switch to use
+        // there are some exit status' we shouldn't necessarily count against us, but for
+        // now I think its ok as none of the containers are expected to exit
+        if (completedContainer.getExitStatus() != 0) {
+          logInfo("Container marked as failed: " + containerId)
+          numExecutorsFailed.incrementAndGet()
+        }
+      }
+
+      allocatedHostToContainersMap.synchronized {
+        if (allocatedContainerToHostMap.containsKey(containerId)) {
+          val host = allocatedContainerToHostMap.get(containerId).get
+          val containerSet = allocatedHostToContainersMap.get(host).get
+
+          containerSet.remove(containerId)
+          if (containerSet.isEmpty) {
+            allocatedHostToContainersMap.remove(host)
+          } else {
+            allocatedHostToContainersMap.update(host, containerSet)
+          }
+
+          allocatedContainerToHostMap.remove(containerId)
+
+          // TODO: Move this part outside the synchronized block?
+          val rack = RackResolver.resolve(conf, host).getNetworkLocation
+          if (rack != null) {
+            val rackCount = allocatedRackCount.getOrElse(rack, 0) - 1
+            if (rackCount > 0) {
+              allocatedRackCount.put(rack, rackCount)
+            } else {
+              allocatedRackCount.remove(rack)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Looks for requests for the given location that match the given container allocation. If it
+   * finds one, removes the request so that it won't be submitted again. Places the container into
+   * containersToUse or remaining.
+   */
+  def matchContainerToRequest(allocatedContainer: Container, location: String,
+      containersToUse: ArrayBuffer[Container], remaining: ArrayBuffer[Container]) {
+    val matchingRequests = amClient.getMatchingRequests(allocatedContainer.getPriority,
+      location, allocatedContainer.getResource)
+
+    // Match the allocation to a request
+    if (!matchingRequests.isEmpty) {
+      val containerRequest = matchingRequests.get(0).iterator.next
+      amClient.removeContainerRequest(containerRequest)
+      containersToUse += allocatedContainer
+    } else {
+      remaining += allocatedContainer
     }
   }
 
@@ -390,7 +325,7 @@ private[yarn] class YarnAllocationHandler(
       val candidateHost = container.getNodes.last
       assert(YarnAllocationHandler.ANY_HOST != candidateHost)
 
-      val rack = YarnAllocationHandler.lookupRack(conf, candidateHost)
+      val rack = RackResolver.resolve(conf, candidateHost).getNetworkLocation
       if (rack != null) {
         var count = rackToCounts.getOrElse(rack, 0)
         count += 1
@@ -411,19 +346,9 @@ private[yarn] class YarnAllocationHandler(
   }
 
   def allocatedContainersOnHost(host: String): Int = {
-    var retval = 0
     allocatedHostToContainersMap.synchronized {
-      retval = allocatedHostToContainersMap.getOrElse(host, Set()).size
+      allocatedHostToContainersMap.getOrElse(host, Set()).size
     }
-    retval
-  }
-
-  def allocatedContainersOnRack(rack: String): Int = {
-    var retval = 0
-    allocatedHostToContainersMap.synchronized {
-      retval = allocatedRackCount.getOrElse(rack, 0)
-    }
-    retval
   }
 
   def addResourceRequests(numExecutors: Int) {
@@ -437,7 +362,7 @@ private[yarn] class YarnAllocationHandler(
           numExecutors,
           YarnAllocationHandler.PRIORITY).toList
       } else {
-        // Request for all hosts in preferred nodes and for numExecutors - 
+        // Requests for all hosts in preferred nodes and for numExecutors -
         // candidates.size, request by default allocation policy.
         val hostContainerRequests = new ArrayBuffer[ContainerRequest](preferredHostToCount.size)
         for ((candidateHost, candidateCount) <- preferredHostToCount) {
@@ -461,7 +386,7 @@ private[yarn] class YarnAllocationHandler(
           YarnAllocationHandler.PRIORITY)
 
         val containerRequestBuffer = new ArrayBuffer[ContainerRequest](
-          hostContainerRequests.size + rackContainerRequests.size() + anyContainerRequests.size)
+          hostContainerRequests.size + rackContainerRequests.size + anyContainerRequests.size)
 
         containerRequestBuffer ++= hostContainerRequests
         containerRequestBuffer ++= rackContainerRequests
@@ -484,7 +409,7 @@ private[yarn] class YarnAllocationHandler(
 
     for (request <- containerRequests) {
       val nodes = request.getNodes
-      var hostStr = if (nodes == null || nodes.isEmpty) {
+      val hostStr = if (nodes == null || nodes.isEmpty) {
         "Any"
       } else {
         nodes.last
@@ -503,28 +428,13 @@ private[yarn] class YarnAllocationHandler(
       priority: Int
     ): ArrayBuffer[ContainerRequest] = {
 
-    // If hostname is specified, then we need at least two requests - node local and rack local.
-    // There must be a third request, which is ANY. That will be specially handled.
     requestType match {
-      case AllocationType.HOST => {
-        assert(YarnAllocationHandler.ANY_HOST != resource)
-        val hostname = resource
-        val nodeLocal = constructContainerRequests(
-          Array(hostname),
-          racks = null,
-          numExecutors,
-          priority)
-
-        // Add `hostname` to the global (singleton) host->rack mapping in YarnAllocationHandler.
-        YarnAllocationHandler.populateRackInfo(conf, hostname)
-        nodeLocal
-      }
-      case AllocationType.RACK => {
-        val rack = resource
-        constructContainerRequests(hosts = null, Array(rack), numExecutors, priority)
-      }
+      case AllocationType.HOST => constructContainerRequests(
+        Array(resource), null, numExecutors, priority)
+      case AllocationType.RACK => constructContainerRequests(
+        null, Array(resource), numExecutors, priority)
       case AllocationType.ANY => constructContainerRequests(
-        hosts = null, racks = null, numExecutors, priority)
+        null, null, numExecutors, priority)
       case _ => throw new IllegalArgumentException(
         "Unexpected/unsupported request type: " + requestType)
     }
@@ -540,8 +450,7 @@ private[yarn] class YarnAllocationHandler(
     val memoryRequest = executorMemory + YarnAllocationHandler.MEMORY_OVERHEAD
     val resource = Resource.newInstance(memoryRequest, executorCores)
 
-    val prioritySetting = Records.newRecord(classOf[Priority])
-    prioritySetting.setPriority(priority)
+    val prioritySetting = Priority.newInstance(priority)
 
     val requests = new ArrayBuffer[ContainerRequest]()
     for (i <- 0 until numExecutors) {
@@ -562,11 +471,10 @@ object YarnAllocationHandler {
   val MEMORY_OVERHEAD = 384
 
   // Host to rack map - saved from allocation requests. We are expecting this not to change.
-  // Note that it is possible for this to change : and ResurceManager will indicate that to us via
+  // Note that it is possible for this to change : and ResourceManager will indicate that to us via
   // update response to allocate. But we are punting on handling that for now.
   private val hostToRack = new ConcurrentHashMap[String, String]()
   private val rackToHostSet = new ConcurrentHashMap[String, JSet[String]]()
-
 
   def newAllocator(
       conf: Configuration,
@@ -649,7 +557,7 @@ object YarnAllocationHandler {
       val hostCount = hostToCount.getOrElse(host, 0)
       hostToCount.put(host, hostCount + splits.size)
 
-      val rack = lookupRack(conf, host)
+      val rack = RackResolver.resolve(conf, host).getNetworkLocation
       if (rack != null){
         val rackCount = rackToCount.getOrElse(host, 0)
         rackToCount.put(host, rackCount + splits.size)
@@ -657,44 +565,5 @@ object YarnAllocationHandler {
     }
 
     (hostToCount.toMap, rackToCount.toMap)
-  }
-
-  def lookupRack(conf: Configuration, host: String): String = {
-    if (!hostToRack.contains(host)) {
-      populateRackInfo(conf, host)
-    }
-    hostToRack.get(host)
-  }
-
-  def fetchCachedHostsForRack(rack: String): Option[Set[String]] = {
-    Option(rackToHostSet.get(rack)).map { set =>
-      val convertedSet: collection.mutable.Set[String] = set
-      // TODO: Better way to get a Set[String] from JSet.
-      convertedSet.toSet
-    }
-  }
-
-  def populateRackInfo(conf: Configuration, hostname: String) {
-    Utils.checkHost(hostname)
-
-    if (!hostToRack.containsKey(hostname)) {
-      // If there are repeated failures to resolve, all to an ignore list.
-      val rackInfo = RackResolver.resolve(conf, hostname)
-      if (rackInfo != null && rackInfo.getNetworkLocation != null) {
-        val rack = rackInfo.getNetworkLocation
-        hostToRack.put(hostname, rack)
-        if (! rackToHostSet.containsKey(rack)) {
-          rackToHostSet.putIfAbsent(rack,
-            Collections.newSetFromMap(new ConcurrentHashMap[String, JBoolean]()))
-        }
-        rackToHostSet.get(rack).add(hostname)
-
-        // TODO(harvey): Figure out what this comment means...
-        // Since RackResolver caches, we are disabling this for now ...
-      } /* else {
-        // right ? Else we will keep calling rack resolver in case we cant resolve rack info ...
-        hostToRack.put(hostname, null)
-      } */
-    }
   }
 }

--- a/yarn/stable/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocationHandlerSuite.scala
+++ b/yarn/stable/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocationHandlerSuite.scala
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.yarn
+
+import org.scalatest.FunSuite
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.ShouldMatchers
+
+import org.apache.hadoop.yarn.client.api.AMRMClient
+import org.apache.hadoop.yarn.client.api.AMRMClient.ContainerRequest
+import org.apache.hadoop.conf.Configuration
+
+import org.apache.spark.SparkConf
+import org.apache.hadoop.net.DNSToSwitchMapping
+
+import java.util.{List => JList}
+import java.util.Arrays
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic
+import org.apache.hadoop.yarn.api.records._
+
+class MyResolver extends DNSToSwitchMapping {
+
+  override def resolve(names: JList[String]): JList[String] = {
+    if (names.size > 0 && names.get(0) == "host3") Arrays.asList("/rack2")
+    else Arrays.asList("/rack1")
+  }
+
+  override def reloadCachedMappings() {}
+
+  def reloadCachedMappings(names: JList[String]) {}
+}
+
+class YarnAllocationHandlerSuite extends FunSuite with ShouldMatchers with BeforeAndAfterEach {
+  val conf = new Configuration()
+  conf.setClass(
+    CommonConfigurationKeysPublic.NET_TOPOLOGY_NODE_SWITCH_MAPPING_IMPL_KEY,
+    classOf[MyResolver], classOf[DNSToSwitchMapping])
+
+  val sparkConf = new SparkConf()
+  sparkConf.set("spark.driver.host", "localhost")
+  sparkConf.set("spark.driver.port", "4040")
+
+  var rmClient: AMRMClient[ContainerRequest] = _
+
+  var containerNum = 0
+
+  val CONTAINER_RESOURCE = Resource.newInstance(2048 + YarnAllocationHandler.MEMORY_OVERHEAD, 6)
+
+  override def beforeEach() {
+    rmClient = AMRMClient.createAMRMClient()
+    rmClient.init(conf)
+    rmClient.start()
+
+    // rmClient.registerApplicationMaster("Host", 10000, "")
+  }
+
+  override def afterEach() {
+    rmClient.stop()
+  }
+
+  def createHandler(preferredHosts: Seq[String] = new Array[String](0),
+      maxExecutors: Int = 5): YarnAllocationHandler = {
+    val preferredHostToCount = preferredHosts.groupBy(identity).map(x => (x._1, x._2.size))
+    new YarnAllocationHandler(conf,
+      rmClient,
+      null,
+      maxExecutors,
+      2048,
+      5,
+      preferredHostToCount,
+      null,
+      sparkConf)
+  }
+
+  def createContainer(host: String): Container = {
+    val appId = ApplicationId.newInstance(0, 0)
+    val appAttemptId = ApplicationAttemptId.newInstance(appId, 0)
+    val containerId = ContainerId.newInstance(appAttemptId, containerNum)
+    containerNum += 1
+    val nodeId = NodeId.newInstance(host, 1000)
+    // YARN can give larger containers than requested, so give 6 cores instead of the 5 requested
+    Container.newInstance(containerId, nodeId, "",
+      CONTAINER_RESOURCE,
+      Priority.newInstance(YarnAllocationHandler.PRIORITY), null)
+  }
+
+  test("single container allocated") {
+    // request a single container and receive it
+    val handler = createHandler()
+    handler.addResourceRequests(1)
+    handler.getNumExecutorsRunning should be (0)
+    handler.getNumPendingAllocate should be (1)
+
+    val container = createContainer("host1")
+    handler.handleAllocatedContainers(Array(container))
+
+    handler.getNumExecutorsRunning should be (1)
+    handler.allocatedContainerToHostMap.get(container.getId).get should be ("host1")
+    handler.allocatedHostToContainersMap.get("host1").get should contain (container.getId)
+    handler.allocatedRackCount.get("/rack1").get should be (1)
+    rmClient.getMatchingRequests(container.getPriority, "host1", CONTAINER_RESOURCE).size should be (0)
+  }
+
+  test("some containers allocated") {
+    // request a few containers and receive some of them
+    val handler = createHandler()
+    handler.addResourceRequests(4)
+    handler.getNumExecutorsRunning should be (0)
+    handler.getNumPendingAllocate should be (4)
+
+    val container1 = createContainer("host1")
+    val container2 = createContainer("host1")
+    val container3 = createContainer("host2")
+    handler.handleAllocatedContainers(Array(container1, container2, container3))
+
+    handler.getNumExecutorsRunning should be (3)
+    handler.allocatedContainerToHostMap.get(container1.getId).get should be ("host1")
+    handler.allocatedContainerToHostMap.get(container2.getId).get should be ("host1")
+    handler.allocatedContainerToHostMap.get(container3.getId).get should be ("host2")
+    handler.allocatedHostToContainersMap.get("host1").get should contain (container1.getId)
+    handler.allocatedHostToContainersMap.get("host1").get should contain (container2.getId)
+    handler.allocatedHostToContainersMap.get("host2").get should contain (container3.getId)
+    handler.allocatedRackCount.get("/rack1").get should be (3)
+  }
+
+  test("some containers with locality preferences") {
+    val handler = createHandler(Array("host1", "host1", "host2", "host3"))
+    handler.addResourceRequests(4)
+    handler.getNumExecutorsRunning should be (0)
+    handler.getNumPendingAllocate should be (4)
+
+    val container1 = createContainer("host1")
+    val container2 = createContainer("host3")
+    val container3 = createContainer("host4")
+    handler.handleAllocatedContainers(Array(container1, container2, container3))
+
+    handler.getNumExecutorsRunning should be (3)
+    handler.allocatedContainerToHostMap.get(container1.getId).get should be ("host1")
+    handler.allocatedContainerToHostMap.get(container2.getId).get should be ("host3")
+    handler.allocatedContainerToHostMap.get(container3.getId).get should be ("host4")
+    handler.allocatedHostToContainersMap.get("host1").get should contain (container1.getId)
+    handler.allocatedHostToContainersMap.get("host3").get should contain (container2.getId)
+    handler.allocatedHostToContainersMap.get("host4").get should contain (container3.getId)
+    handler.allocatedRackCount.get("/rack1").get should be (2)
+    handler.allocatedRackCount.get("/rack2").get should be (1)
+  }
+
+  test("receive more containers than requested") {
+    val handler = createHandler(Array("host1", "host2"), 2)
+    handler.addResourceRequests(2)
+    handler.getNumExecutorsRunning should be (0)
+    handler.getNumPendingAllocate should be (2)
+
+    val container1 = createContainer("host1")
+    val container2 = createContainer("host2")
+    val container3 = createContainer("host4")
+    handler.handleAllocatedContainers(Array(container1, container2, container3))
+
+    handler.getNumExecutorsRunning should be (2)
+    handler.allocatedContainerToHostMap.get(container1.getId).get should be ("host1")
+    handler.allocatedContainerToHostMap.get(container2.getId).get should be ("host2")
+    handler.allocatedContainerToHostMap.contains(container3.getId) should be (false)
+    handler.allocatedHostToContainersMap.get("host1").get should contain (container1.getId)
+    handler.allocatedHostToContainersMap.get("host2").get should contain (container2.getId)
+    handler.allocatedHostToContainersMap.contains("host4") should be (false)
+    handler.allocatedRackCount.get("/rack1").get should be (2)
+  }
+}

--- a/yarn/stable/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocationHandlerSuite.scala
+++ b/yarn/stable/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocationHandlerSuite.scala
@@ -65,8 +65,6 @@ class YarnAllocationHandlerSuite extends FunSuite with ShouldMatchers with Befor
     rmClient = AMRMClient.createAMRMClient()
     rmClient.init(conf)
     rmClient.start()
-
-    // rmClient.registerApplicationMaster("Host", 10000, "")
   }
 
   override def afterEach() {


### PR DESCRIPTION
...llocationHandler

This patch does a few things:
- Uses AMRMClient APIs for matching containers to requests.
- Calls AMRMClient.removeContainerRequest so that, when we use a container, we don't end up requesting it again.
- Removes YarnAllocationHandler's host->rack cache.  YARN's RackResolver already does this caching, so this is redundant.
- Adds tests for basic YarnAllocationHandler functionality.
- Breaks up allocateResources.
- A little bit of stylistic cleanup.

The patch is lossy.  In particular, it loses the logic for trying to avoid containers bunching up on nodes.  As I understand it, the logic that's gone is two-part:
- If, in a single response from the RM, we receive a set of containers on a node, and prefer some number of containers on that node greater than 0 but less than the number we received, give back the delta between what we preferred and what we received.

This seems like a weird way to avoid bunching  E.g. it does nothing to avoid bunching when we don't request containers on particular nodes.  I think we can come up with something better.
- If we receive more containers than the number of executors we desire, make sure that the containers we use are distributed as evenly as possible among the available nodes.

It's rare for YARN to allocate more containers than requested, and when it does, it's only a small number.  In fact, with the current code, because we call allocate() and handle allocations in the same thread, it should never happen.  Having a bunch of logic to deal with this seems unnecessary.
