### PR TITLE
SPARK-1603: use auto-generated name in JobScheduler Actor

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
@@ -58,7 +58,7 @@ class JobScheduler(val ssc: StreamingContext) extends Logging {
       def receive = {
         case event: JobSchedulerEvent => processEvent(event)
       }
-    }), "JobScheduler")
+    }))
 
     listenerBus.start()
     receiverTracker = new ReceiverTracker(ssc)


### PR DESCRIPTION
When Jenkins is pretty busy, the test of the "stop gracefully" case in StreamingContextSuite sometimes failed with an unrelated change, the reason is that "JobScheduler" (the actor name) is not unique, so it fails to start a new actor. 

The reason of this bug is that we assign a fixed name to the JobScheduler Actor, and we assume that the actor should be stopped when StreamingContext is stopped (https://github.com/apache/spark/blob/master/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala#L98), actually, "nearly everything related to akka is asynchronous", we call the stop() but get no guarantee on when the actor is really stopped

so there is a possibility to have two "JobScheduler" in akka's namespace

in this patch, I go with a pretty easy fix, use auto-generated name in the actor
