### PR TITLE
Remove unnecessary Code from spark-shell.cmd

### DIFF
--- a/bin/spark-shell.cmd
+++ b/bin/spark-shell.cmd
@@ -17,7 +17,4 @@ rem See the License for the specific language governing permissions and
 rem limitations under the License.
 rem
 
-rem Find the path of sbin
-set BIN=%~dp0..\bin\
-
-cmd /V /E /C %BIN%spark-class2.cmd org.apache.spark.repl.Main %*
+cmd /V /E /C %~dp0spark-class2.cmd org.apache.spark.repl.Main %*


### PR DESCRIPTION
I don't see a reason to find path of bin directory.
