### PR TITLE
Proposal: clarify Scala programming guide on caching ...

### DIFF
--- a/docs/scala-programming-guide.md
+++ b/docs/scala-programming-guide.md
@@ -278,10 +278,13 @@ iterative algorithms with Spark and for interactive use from the interpreter.
 You can mark an RDD to be persisted using the `persist()` or `cache()` methods on it. The first time
 it is computed in an action, it will be kept in memory on the nodes. The cache is fault-tolerant --
 if any partition of an RDD is lost, it will automatically be recomputed using the transformations
-that originally created it.
+that originally created it. Note: in a multi-stage job, Spark saves the map output files from map
+stages to the filesystem, so it only needs to rerun the last reduce stage. This means that multi-stage
+jobs that are rerun will often not recompute the full dependency graph. The lack of recomputation,
+in this case, does not indicate that RDDs are cached.
 
-In addition, each RDD can be stored using a different *storage level*, allowing you, for example, to
-persist the dataset on disk, or persist it in memory but as serialized Java objects (to save space),
+In addition, each cached RDD can be stored using a different *storage level*, allowing you, for example,
+to persist the dataset on disk, or persist it in memory but as serialized Java objects (to save space),
 or replicate it across nodes, or store the data in off-heap memory in [Tachyon](http://tachyon-project.org/).
 These levels are chosen by passing a
 [`org.apache.spark.storage.StorageLevel`](api/scala/index.html#org.apache.spark.storage.StorageLevel)

--- a/docs/scala-programming-guide.md
+++ b/docs/scala-programming-guide.md
@@ -146,7 +146,7 @@ RDDs support two types of operations: *transformations*, which create a new data
 
 All transformations in Spark are <i>lazy</i>, in that they do not compute their results right away. Instead, they just remember the transformations applied to some base dataset (e.g. a file). The transformations are only computed when an action requires a result to be returned to the driver program. This design enables Spark to run more efficiently -- for example, we can realize that a dataset created through `map` will be used in a `reduce` and return only the result of the `reduce` to the driver, rather than the larger mapped dataset.
 
-By default, each transformed RDD is recomputed each time you run an action on it. However, you may also *persist* an RDD in memory using the `persist` (or `cache`) method, in which case Spark will keep the elements around on the cluster for much faster access the next time you query it. There is also support for persisting datasets on disk, or replicated across the cluster. The next section in this document describes these options.
+By default, each transformed RDD may be recomputed each time you run an action on it. However, you may also *persist* an RDD in memory using the `persist` (or `cache`) method, in which case Spark will keep the elements around on the cluster for much faster access the next time you query it. There is also support for persisting datasets on disk, or replicated across the cluster. The next section in this document describes these options.
 
 The following tables list the transformations and actions currently supported (see also the [RDD API doc](api/scala/index.html#org.apache.spark.rdd.RDD) for details):
 
@@ -278,12 +278,9 @@ iterative algorithms with Spark and for interactive use from the interpreter.
 You can mark an RDD to be persisted using the `persist()` or `cache()` methods on it. The first time
 it is computed in an action, it will be kept in memory on the nodes. The cache is fault-tolerant --
 if any partition of an RDD is lost, it will automatically be recomputed using the transformations
-that originally created it. Note: in a multi-stage job, Spark saves the map output files from map
-stages to the filesystem, so it only needs to rerun the last reduce stage. This means that multi-stage
-jobs that are rerun will often not recompute the full dependency graph. The lack of recomputation,
-in this case, does not indicate that RDDs are cached.
+that originally created it.
 
-In addition, each cached RDD can be stored using a different *storage level*, allowing you, for example,
+In addition, each persisted RDD can be stored using a different *storage level*, allowing you, for example,
 to persist the dataset on disk, or persist it in memory but as serialized Java objects (to save space),
 or replicate it across nodes, or store the data in off-heap memory in [Tachyon](http://tachyon-project.org/).
 These levels are chosen by passing a
@@ -333,6 +330,8 @@ available storage levels is:
   <td> Same as the levels above, but replicate each partition on two cluster nodes. </td>
 </tr>
 </table>
+
+Spark sometimes automatically persists intermediate state from RDD operations, even without users calling persist() or cache(). In particular, if a shuffle happens when computing an RDD, Spark will keep the outputs from the map side of the shuffle on disk to avoid re-computing the entire dependency graph if an RDD is re-used. We still recommend users call persist() if they plan to re-use an RDD iteratively.
 
 ### Which Storage Level to Choose?
 


### PR DESCRIPTION
... with regards to saved map output. Wording taken partially from Matei Zaharia's email to the Spark user list. http://apache-spark-user-list.1001560.n3.nabble.com/performance-improvement-on-second-operation-without-caching-td5227.html
