### PR TITLE
SPARK-1737: Warn rather than fail when Java 7+ is used to create distributions

### DIFF
--- a/make-distribution.sh
+++ b/make-distribution.sh
@@ -39,17 +39,10 @@
 # 5) ./bin/spark-shell --master spark://my-master-ip:7077
 #
 
+set -o pipefail
 # Figure out where the Spark framework is installed
 FWDIR="$(cd `dirname $0`; pwd)"
 DISTDIR="$FWDIR/dist"
-
-set -o pipefail
-VERSION=$(mvn help:evaluate -Dexpression=project.version 2>/dev/null | grep -v "INFO" | tail -n 1)
-if [ $? != 0 ]; then
-    echo -e "You need Maven installed to build Spark."
-    echo -e "Download Maven from https://maven.apache.org/"
-    exit -1;
-fi
 
 if [ -z "$JAVA_HOME" ]; then
   echo "Error: JAVA_HOME is not set, cannot proceed."
@@ -59,10 +52,17 @@ fi
 JAVA_CMD="$JAVA_HOME"/bin/java
 JAVA_VERSION=$("$JAVA_CMD" -version 2>&1)
 if ! [[ "$JAVA_VERSION" =~ "1.6" ]]; then
-  echo "Error: JAVA_HOME must point to a JDK 6 installation (see SPARK-1703)."
+  echo "***NOTE***: JAVA_HOME is not set to a JDK 6 installation. The resulting"
+  echo "***NOTE***: distribution will not support Java 6. See SPARK-1703."
   echo "Output from 'java -version' was:"
   echo "$JAVA_VERSION"
-  exit -1
+fi
+
+VERSION=$(mvn help:evaluate -Dexpression=project.version 2>/dev/null | grep -v "INFO" | tail -n 1)
+if [ $? != 0 ]; then
+    echo -e "You need Maven installed to build Spark."
+    echo -e "Download Maven from https://maven.apache.org/"
+    exit -1;
 fi
 
 # Initialize defaults

--- a/make-distribution.sh
+++ b/make-distribution.sh
@@ -53,7 +53,7 @@ JAVA_CMD="$JAVA_HOME"/bin/java
 JAVA_VERSION=$("$JAVA_CMD" -version 2>&1)
 if ! [[ "$JAVA_VERSION" =~ "1.6" ]]; then
   echo "***NOTE***: JAVA_HOME is not set to a JDK 6 installation. The resulting"
-  echo "***NOTE***: distribution will not support Java 6. See SPARK-1703."
+  echo "            distribution will not support Java 6. See SPARK-1703."
   echo "Output from 'java -version' was:"
   echo "$JAVA_VERSION"
 fi


### PR DESCRIPTION
Also moves a few lines of code around in make-distribution.sh.
