### PR TITLE
[SQL] Fix Performance Issue in data type casting

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -182,7 +182,7 @@ case class Cast(child: Expression, dataType: DataType) extends UnaryExpression {
     case x: NumericType => b => x.numeric.asInstanceOf[Numeric[Any]].toFloat(b)
   }
 
-  def cast: Any => Any = dataType match {
+  private lazy val cast: Any => Any = dataType match {
     case StringType => castToString
     case BinaryType => castToBinary
     case DecimalType => castToDecimal


### PR DESCRIPTION
Using lazy val object instead of function in the class Cast, which improved the performance nearly by 2X in my local micro-benchmark.
