### PR TITLE
[SPARK-1753] Warn about PySpark on YARN on Red Hat

### DIFF
--- a/docs/building-with-maven.md
+++ b/docs/building-with-maven.md
@@ -98,7 +98,6 @@ The ScalaTest plugin also supports running only a specific test suite as follows
 
     $ mvn -Dhadoop.version=... -Dsuites=org.apache.spark.repl.ReplSuite test
 
-
 ## Continuous Compilation ##
 
 We use the scala-maven-plugin which supports incremental and continuous compilation. E.g.
@@ -128,6 +127,10 @@ Running only java 8 tests and nothing else.
 Java 8 tests are run when -Pjava8-tests profile is enabled, they will run in spite of -DskipTests. 
 For these tests to run your system must have a JDK 8 installation. 
 If you have JDK 8 installed but it is not the system default, you can set JAVA_HOME to point to JDK 8 before running the tests.
+
+## Building for PySpark on YARN ##
+
+There is a known problem with building an assembly jar for running PySpark on YARN on Red Hat based operating systems. If you wish to run PySpark on a YARN cluster with Red Hat installed, we recommend that you build the jar elsewhere, then ship it over to the cluster. We are investigating the exact cause for this.
 
 ## Packaging without Hadoop dependencies for deployment on YARN ##
 

--- a/docs/building-with-maven.md
+++ b/docs/building-with-maven.md
@@ -130,7 +130,7 @@ If you have JDK 8 installed but it is not the system default, you can set JAVA_H
 
 ## Building for PySpark on YARN ##
 
-There is a known problem with building an assembly jar for running PySpark on YARN on Red Hat based operating systems. If you wish to run PySpark on a YARN cluster with Red Hat installed, we recommend that you build the jar elsewhere, then ship it over to the cluster. We are investigating the exact cause for this.
+PySpark on YARN is only supported if the jar is built with maven. Further, there is a known problem with building this assembly jar on Red Hat based operating systems (see SPARK-1753). If you wish to run PySpark on a YARN cluster with Red Hat installed, we recommend that you build the jar elsewhere, then ship it over to the cluster. We are investigating the exact cause for this.
 
 ## Packaging without Hadoop dependencies for deployment on YARN ##
 


### PR DESCRIPTION
In #30, both @tgraves and I ran into the issue of building the assembly jar on a Red Hat system: the resulting jar does not load the python files properly, which were needed for running PySpark on YARN.

In the medium term, we should figure out what the issue is, since Red Hat is used quite commonly. For now, we should at the very least document it so people don't run into the same headaches that plagued us for days.
