### PR TITLE
Use numpy directly for matrix multiply.

### DIFF
--- a/examples/src/main/python/als.py
+++ b/examples/src/main/python/als.py
@@ -36,13 +36,10 @@ def rmse(R, ms, us):
 def update(i, vec, mat, ratings):
     uu = mat.shape[0]
     ff = mat.shape[1]
-    XtX = matrix(np.zeros((ff, ff)))
-    Xty = np.zeros((ff, 1))
-
-    for j in range(uu):
-        v = mat[j, :]
-        XtX += v.T * v
-        Xty += v.T * ratings[i, j]
+    
+    XtX = mat.T * mat
+    XtY = mat.T * ratings[i, :].T
+    
     XtX += np.eye(ff, ff) * LAMBDA * uu
     return np.linalg.solve(XtX, Xty)
 

--- a/examples/src/main/python/als.py
+++ b/examples/src/main/python/als.py
@@ -40,7 +40,9 @@ def update(i, vec, mat, ratings):
     XtX = mat.T * mat
     XtY = mat.T * ratings[i, :].T
     
-    XtX += np.eye(ff, ff) * LAMBDA * uu
+    for j in range(ff):
+        XtX[j,j] += LAMBDA * uu
+    
     return np.linalg.solve(XtX, Xty)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Using matrix multiply to compute XtX and XtY yields a 5-20x speedup depending on problem size.

For example - the following takes 19s locally after this change vs. 5m21s before the change. (16x speedup).
bin/pyspark examples/src/main/python/als.py local[8] 1000 1000 50 10 10
