### PR TITLE
[SPARK-1754] [SQL] Add missing arithmetic DSL operations.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -58,6 +58,7 @@ package object dsl {
     def expr: Expression
 
     def unary_- = UnaryMinus(expr)
+    def unary_! = Not(expr)
 
     def + (other: Expression) = Add(expr, other)
     def - (other: Expression) = Subtract(expr, other)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -57,10 +57,13 @@ package object dsl {
   trait ImplicitOperators {
     def expr: Expression
 
+    def unary_- = UnaryMinus(expr)
+
     def + (other: Expression) = Add(expr, other)
     def - (other: Expression) = Subtract(expr, other)
     def * (other: Expression) = Multiply(expr, other)
     def / (other: Expression) = Divide(expr, other)
+    def % (other: Expression) = Remainder(expr, other)
 
     def && (other: Expression) = And(expr, other)
     def || (other: Expression) = Or(expr, other)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvaluationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvaluationSuite.scala
@@ -61,7 +61,7 @@ class ExpressionEvaluationSuite extends FunSuite {
   test("3VL Not") {
     notTrueTable.foreach {
       case (v, answer) =>
-        val expr = Not(Literal(v, BooleanType))
+        val expr = ! Literal(v, BooleanType)
         val result = expr.eval(null)
         if (result != answer)
           fail(s"$expr should not evaluate to $result, expected: $answer")    }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvaluationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvaluationSuite.scala
@@ -381,6 +381,30 @@ class ExpressionEvaluationSuite extends FunSuite {
     checkEvaluation(Add(c1, Literal(null, IntegerType)), null, row)
     checkEvaluation(Add(Literal(null, IntegerType), c2), null, row)
     checkEvaluation(Add(Literal(null, IntegerType), Literal(null, IntegerType)), null, row)
+
+    checkEvaluation(-c1, -1, row)
+    checkEvaluation(c1 + c2, 3, row)
+    checkEvaluation(c1 - c2, -1, row)
+    checkEvaluation(c1 * c2, 2, row)
+    checkEvaluation(c1 / c2, 0, row)
+    checkEvaluation(c1 % c2, 1, row)
+  }
+
+  test("BinaryPredicate") {
+    val row = new GenericRow(Array[Any](true, false, null))
+    val c1 = 'a.boolean.at(0)
+    val c2 = 'a.boolean.at(1)
+    val c3 = 'a.boolean.at(2)
+
+    checkEvaluation(And(c1, c1), true, row)
+    checkEvaluation(And(c1, c2), false, row)
+    checkEvaluation(And(c1, c3), null, row)
+    checkEvaluation(And(c1, Literal(null, BooleanType)), null, row)
+    checkEvaluation(And(Literal(null, BooleanType), c2), false, row)
+    checkEvaluation(And(Literal(null, BooleanType), Literal(null, BooleanType)), null, row)
+
+    checkEvaluation(c1 && c2, false, row)
+    checkEvaluation(c1 || c2, true, row)
   }
 
   test("BinaryComparison") {
@@ -395,6 +419,13 @@ class ExpressionEvaluationSuite extends FunSuite {
     checkEvaluation(LessThan(c1, Literal(null, IntegerType)), null, row)
     checkEvaluation(LessThan(Literal(null, IntegerType), c2), null, row)
     checkEvaluation(LessThan(Literal(null, IntegerType), Literal(null, IntegerType)), null, row)
+
+    checkEvaluation(c1 < c2, true, row)
+    checkEvaluation(c1 <= c2, true, row)
+    checkEvaluation(c1 > c2, false, row)
+    checkEvaluation(c1 >= c2, false, row)
+    checkEvaluation(c1 === c2, false, row)
+    checkEvaluation(c1 !== c2, true, row)
   }
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvaluationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvaluationSuite.scala
@@ -390,23 +390,6 @@ class ExpressionEvaluationSuite extends FunSuite {
     checkEvaluation(c1 % c2, 1, row)
   }
 
-  test("BinaryPredicate") {
-    val row = new GenericRow(Array[Any](true, false, null))
-    val c1 = 'a.boolean.at(0)
-    val c2 = 'a.boolean.at(1)
-    val c3 = 'a.boolean.at(2)
-
-    checkEvaluation(And(c1, c1), true, row)
-    checkEvaluation(And(c1, c2), false, row)
-    checkEvaluation(And(c1, c3), null, row)
-    checkEvaluation(And(c1, Literal(null, BooleanType)), null, row)
-    checkEvaluation(And(Literal(null, BooleanType), c2), false, row)
-    checkEvaluation(And(Literal(null, BooleanType), Literal(null, BooleanType)), null, row)
-
-    checkEvaluation(c1 && c2, false, row)
-    checkEvaluation(c1 || c2, true, row)
-  }
-
   test("BinaryComparison") {
     val row = new GenericRow(Array[Any](1, 2, 3, null))
     val c1 = 'a.int.at(0)


### PR DESCRIPTION
Add missing arithmetic DSL operations: `unary_-`, `%`.
