### PR TITLE
Modify a typo in monitoring.md

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -156,7 +156,7 @@ Each instance can report to zero or more _sinks_. Sinks are contained in the
 
 * `ConsoleSink`: Logs metrics information to the console.
 * `CSVSink`: Exports metrics data to CSV files at regular intervals.
-* `JmxSink`: Registers metrics for viewing in a JXM console.
+* `JmxSink`: Registers metrics for viewing in a JMX console.
 * `MetricsServlet`: Adds a servlet within the existing Spark UI to serve metrics data as JSON data.
 * `GraphiteSink`: Sends metrics to a Graphite node.
 


### PR DESCRIPTION
As I mentioned in SPARK-1765, there is a word 'JXM' in monitoring.md.
I think it's typo for 'JMX'.
