### PR TITLE
SPARK-1565 (Addendum): Replace `run-example` with `spark-submit`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,21 +39,22 @@ And run the following command, which should also return 1000:
 ## Example Programs
 
 Spark also comes with several sample programs in the `examples` directory.
-To run one of them, use the `./bin/spark-submit` script. For example:
+To run one of them, use `./bin/run-example <class> [<params>]`. For example:
 
-    ./bin/spark-submit \
-      --class org.apache.spark.examples.SparkLR \
-      --master local[2] \
-      lib/spark-examples*.jar
+    ./bin/run-example org.apache.spark.examples.SparkLR
 
-will run the Logistic Regression example locally on 2 CPUs.
+will run the Logistic Regression example locally.
+
+You can set the MASTER environment variable when running examples to submit
+examples to a cluster. This can be a mesos:// or spark:// URL, 
+"yarn-cluster" or "yarn-client" to run on YARN, and "local" to run 
+locally with one thread, or "local[N]" to run locally with N thread. You 
+can also use an abbreviated class name if the class is in the `examples`
+package. For instance:
+
+    MASTER=spark://host:7077 ./bin/run-example SparkPi
 
 Many of the example programs print usage help if no params are given.
-
-When running Spark examples you can pass `--master` parameter to the submission
-script. This can be a mesos:// or spark:// URL, "yarn-cluster" or "yarn-client"
-to run on YARN, and "local" to run locally with one thread, or "local[N]" to 
-run locally with N thread.
 
 ## Running Tests
 

--- a/README.md
+++ b/README.md
@@ -39,17 +39,21 @@ And run the following command, which should also return 1000:
 ## Example Programs
 
 Spark also comes with several sample programs in the `examples` directory.
-To run one of them, use `./bin/run-example <class> <params>`. For example:
+To run one of them, use the `./bin/spark-submit` script. For example:
 
-    ./bin/run-example org.apache.spark.examples.SparkLR local[2]
+    ./bin/spark-submit \
+      --class org.apache.spark.examples.SparkLR \
+      --master local[2] \
+      lib/spark-examples*.jar
 
 will run the Logistic Regression example locally on 2 CPUs.
 
-Each of the example programs prints usage help if no params are given.
+Many of the example programs print usage help if no params are given.
 
-All of the Spark samples take a `<master>` parameter that is the cluster URL
-to connect to. This can be a mesos:// or spark:// URL, or "local" to run
-locally with one thread, or "local[N]" to run locally with N threads.
+When running Spark examples you can pass `--master` parameter to the submission
+script. This can be a mesos:// or spark:// URL, "yarn-cluster" or "yarn-client"
+to run on YARN, and "local" to run locally with one thread, or "local[N]" to 
+run locally with N thread.
 
 ## Running Tests
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ And run the following command, which should also return 1000:
 ## Example Programs
 
 Spark also comes with several sample programs in the `examples` directory.
-To run one of them, use `./bin/run-example <class> [<params>]`. For example:
+To run one of them, use `./bin/run-example <class> [params]`. For example:
 
     ./bin/run-example org.apache.spark.examples.SparkLR
 
@@ -48,7 +48,7 @@ will run the Logistic Regression example locally.
 You can set the MASTER environment variable when running examples to submit
 examples to a cluster. This can be a mesos:// or spark:// URL, 
 "yarn-cluster" or "yarn-client" to run on YARN, and "local" to run 
-locally with one thread, or "local[N]" to run locally with N thread. You 
+locally with one thread, or "local[N]" to run locally with N threads. You 
 can also use an abbreviated class name if the class is in the `examples`
 package. For instance:
 

--- a/bin/pyspark
+++ b/bin/pyspark
@@ -31,7 +31,7 @@ if [ ! -f "$FWDIR/RELEASE" ]; then
   ls "$FWDIR"/assembly/target/scala-$SCALA_VERSION/spark-assembly*hadoop*.jar >& /dev/null
   if [[ $? != 0 ]]; then
     echo "Failed to find Spark assembly in $FWDIR/assembly/target" >&2
-    echo "You need to build Spark with sbt/sbt assembly before running this program" >&2
+    echo "You need to build Spark before running this program" >&2
     exit 1
   fi
 fi

--- a/bin/run-example
+++ b/bin/run-example
@@ -35,7 +35,7 @@ if [[ -z $SPARK_EXAMPLES_JAR ]]; then
   exit 1
 fi
 
-EXAMPLE_MASTER=${MASTER:-"local[2]"}
+EXAMPLE_MASTER=${MASTER:-"local[*]"}
 
 if [ -n "$1" ]; then
   EXAMPLE_CLASS="$1"
@@ -43,7 +43,7 @@ if [ -n "$1" ]; then
 else 
   echo "usage: ./bin/run-example <example-class> [<example-args>]" 
   echo "  - set MASTER=XX to use a specific master"
-  echo "  - can use abbreviated example class name (e.g. SparkPi)"
+  echo "  - can use abbreviated example class name (e.g. SparkPi, mllib.MovieLensALS)"
   echo
   exit -1
 fi

--- a/bin/run-example
+++ b/bin/run-example
@@ -17,28 +17,10 @@
 # limitations under the License.
 #
 
-cygwin=false
-case "`uname`" in
-    CYGWIN*) cygwin=true;;
-esac
-
 SCALA_VERSION=2.10
 
-# Figure out where the Scala framework is installed
 FWDIR="$(cd `dirname $0`/..; pwd)"
-
-# Export this as SPARK_HOME
 export SPARK_HOME="$FWDIR"
-
-. $FWDIR/bin/load-spark-env.sh
-
-if [ -z "$1" ]; then
-  echo "Usage: run-example <example-class> [<args>]" >&2
-  exit 1
-fi
-
-# Figure out the JAR file that our examples were packaged into. This includes a bit of a hack
-# to avoid the -sources and -doc packages that are built by publish-local.
 EXAMPLES_DIR="$FWDIR"/examples
 
 if [ -f "$FWDIR/RELEASE" ]; then
@@ -49,46 +31,31 @@ fi
 
 if [[ -z $SPARK_EXAMPLES_JAR ]]; then
   echo "Failed to find Spark examples assembly in $FWDIR/lib or $FWDIR/examples/target" >&2
-  echo "You need to build Spark with sbt/sbt assembly before running this program" >&2
+  echo "You need to build Spark before running this program" >&2
   exit 1
 fi
 
+SPARK_EXAMPLES_JAR_REL=${SPARK_EXAMPLES_JAR#$FWDIR/}
 
-# Since the examples JAR ideally shouldn't include spark-core (that dependency should be
-# "provided"), also add our standard Spark classpath, built using compute-classpath.sh.
-CLASSPATH=`$FWDIR/bin/compute-classpath.sh`
-CLASSPATH="$SPARK_EXAMPLES_JAR:$CLASSPATH"
+EXAMPLE_CLASS="<example-class>"
+EXAMPLE_ARGS="[<example args>]"
+EXAMPLE_MASTER=${MASTER:-"<master>"}
 
-if $cygwin; then
-    CLASSPATH=`cygpath -wp $CLASSPATH`
-    export SPARK_EXAMPLES_JAR=`cygpath -w $SPARK_EXAMPLES_JAR`
+if [ -n "$1" ]; then
+  EXAMPLE_CLASS="$1"
+  shift
 fi
 
-# Find java binary
-if [ -n "${JAVA_HOME}" ]; then
-  RUNNER="${JAVA_HOME}/bin/java"
-else
-  if [ `command -v java` ]; then
-    RUNNER="java"
-  else
-    echo "JAVA_HOME is not set" >&2
-    exit 1
-  fi
+if [ -n "$1" ]; then
+  EXAMPLE_ARGS="$@"
 fi
 
-# Set JAVA_OPTS to be able to load native libraries and to set heap size
-JAVA_OPTS="$SPARK_JAVA_OPTS"
-# Load extra JAVA_OPTS from conf/java-opts, if it exists
-if [ -e "$FWDIR/conf/java-opts" ] ; then
-  JAVA_OPTS="$JAVA_OPTS `cat $FWDIR/conf/java-opts`"
-fi
-export JAVA_OPTS
-
-if [ "$SPARK_PRINT_LAUNCH_COMMAND" == "1" ]; then
-  echo -n "Spark Command: "
-  echo "$RUNNER" -cp "$CLASSPATH" $JAVA_OPTS "$@"
-  echo "========================================"
-  echo
-fi
-
-exec "$RUNNER" -cp "$CLASSPATH" $JAVA_OPTS "$@"
+echo "NOTE: This script has been replaced with ./bin/spark-submit. Please run:" >&2
+echo
+echo "./bin/spark-submit \\" >&2
+echo "  --master $EXAMPLE_MASTER \\" >&2
+echo "  --class $EXAMPLE_CLASS \\" >&2
+echo "  $SPARK_EXAMPLES_JAR_REL \\" >&2
+echo "  $EXAMPLE_ARGS" >&2
+echo
+exit 1

--- a/bin/run-example
+++ b/bin/run-example
@@ -35,27 +35,25 @@ if [[ -z $SPARK_EXAMPLES_JAR ]]; then
   exit 1
 fi
 
-SPARK_EXAMPLES_JAR_REL=${SPARK_EXAMPLES_JAR#$FWDIR/}
-
-EXAMPLE_CLASS="<example-class>"
-EXAMPLE_ARGS="[<example args>]"
-EXAMPLE_MASTER=${MASTER:-"<master>"}
+EXAMPLE_MASTER=${MASTER:-"local[2]"}
 
 if [ -n "$1" ]; then
   EXAMPLE_CLASS="$1"
   shift
+else 
+  echo "usage: ./bin/run-example <example-class> [<example-args>]" 
+  echo "  - set MASTER=XX to use a specific master"
+  echo "  - can use abbreviated example class name (e.g. SparkPi)"
+  echo
+  exit -1
 fi
 
-if [ -n "$1" ]; then
-  EXAMPLE_ARGS="$@"
+if [[ ! $EXAMPLE_CLASS == org.apache.spark.examples* ]]; then
+  EXAMPLE_CLASS="org.apache.spark.examples.$EXAMPLE_CLASS"
 fi
 
-echo "NOTE: This script has been replaced with ./bin/spark-submit. Please run:" >&2
-echo
-echo "./bin/spark-submit \\" >&2
-echo "  --master $EXAMPLE_MASTER \\" >&2
-echo "  --class $EXAMPLE_CLASS \\" >&2
-echo "  $SPARK_EXAMPLES_JAR_REL \\" >&2
-echo "  $EXAMPLE_ARGS" >&2
-echo
-exit 1
+./bin/spark-submit \
+  --master $EXAMPLE_MASTER \
+  --class $EXAMPLE_CLASS \
+  $SPARK_EXAMPLES_JAR \
+  "$@"

--- a/bin/spark-class
+++ b/bin/spark-class
@@ -114,7 +114,7 @@ if [ ! -f "$FWDIR/RELEASE" ]; then
   jars_list=$(ls "$FWDIR"/assembly/target/scala-$SCALA_VERSION/ | grep "spark-assembly.*hadoop.*.jar")
   if [ "$num_jars" -eq "0" ]; then
     echo "Failed to find Spark assembly in $FWDIR/assembly/target/scala-$SCALA_VERSION/" >&2
-    echo "You need to build Spark with 'sbt/sbt assembly' before running this program." >&2
+    echo "You need to build Spark before running this program." >&2
     exit 1
   fi
   if [ "$num_jars" -gt "1" ]; then

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -53,7 +53,7 @@ For example:
         --driver-memory 4g \
         --executor-memory 2g \
         --executor-cores 1
-        examples/target/scala-{{site.SCALA_BINARY_VERSION}}/spark-examples-assembly-{{site.SPARK_VERSION}}.jar \
+        lib/spark-examples*.jar \
         yarn-cluster 5
 
 The above starts a YARN client program which starts the default Application Master. Then SparkPi will be run as a child thread of Application Master. The client will periodically poll the Application Master for status updates and display them in the console. The client will exit once your application has finished running.  Refer to the "Viewing Logs" section below for how to see driver and executor logs.

--- a/make-distribution.sh
+++ b/make-distribution.sh
@@ -40,6 +40,8 @@
 #
 
 set -o pipefail
+set -e
+
 # Figure out where the Spark framework is installed
 FWDIR="$(cd `dirname $0`; pwd)"
 DISTDIR="$FWDIR/dist"


### PR DESCRIPTION
Gives a nicely formatted message to the user when `run-example` is run to
tell them to use `spark-submit`.
