### PR TITLE
SPARK-571: forbid return statements in cleaned closures

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/ClosureCleaner.scala
+++ b/core/src/main/scala/org/apache/spark/util/ClosureCleaner.scala
@@ -188,15 +188,17 @@ private[spark]
 class ReturnStatementFinder extends ClassVisitor(ASM4) {
   override def visitMethod(access: Int, name: String, desc: String,
       sig: String, exceptions: Array[String]): MethodVisitor = {
-    if(name.contains("apply"))
+    if(name.contains("apply")) {
       new MethodVisitor(ASM4) {
         override def visitTypeInsn(op: Int, tp: String) {
-          if(op == NEW && tp.contains("scala/runtime/NonLocalReturnControl"))
+          if(op == NEW && tp.contains("scala/runtime/NonLocalReturnControl")) {
             throw new SparkException("Return statements aren't allowed in Spark closures")
+          }
         }
       }
-    else
+    } else {
       new MethodVisitor(ASM4) {}
+    }
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/util/ClosureCleaner.scala
+++ b/core/src/main/scala/org/apache/spark/util/ClosureCleaner.scala
@@ -25,8 +25,7 @@ import scala.collection.mutable.Set
 import com.esotericsoftware.reflectasm.shaded.org.objectweb.asm.{ClassReader, ClassVisitor, MethodVisitor, Type}
 import com.esotericsoftware.reflectasm.shaded.org.objectweb.asm.Opcodes._
 
-import org.apache.spark.Logging
-import org.apache.spark.SparkException
+import org.apache.spark.{Logging, SparkException}
 
 private[spark] object ClosureCleaner extends Logging {
   // Get an ASM class reader for a given class from the JAR that loaded it

--- a/core/src/main/scala/org/apache/spark/util/ClosureCleaner.scala
+++ b/core/src/main/scala/org/apache/spark/util/ClosureCleaner.scala
@@ -187,10 +187,10 @@ private[spark]
 class ReturnStatementFinder extends ClassVisitor(ASM4) {
   override def visitMethod(access: Int, name: String, desc: String,
       sig: String, exceptions: Array[String]): MethodVisitor = {
-    if(name.contains("apply")) {
+    if (name.contains("apply")) {
       new MethodVisitor(ASM4) {
         override def visitTypeInsn(op: Int, tp: String) {
-          if(op == NEW && tp.contains("scala/runtime/NonLocalReturnControl")) {
+          if (op == NEW && tp.contains("scala/runtime/NonLocalReturnControl")) {
             throw new SparkException("Return statements aren't allowed in Spark closures")
           }
         }
@@ -200,8 +200,6 @@ class ReturnStatementFinder extends ClassVisitor(ASM4) {
     }
   }
 }
-
-
 
 private[spark]
 class FieldAccessFinder(output: Map[Class[_], Set[String]]) extends ClassVisitor(ASM4) {

--- a/core/src/test/scala/org/apache/spark/util/ClosureCleanerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/ClosureCleanerSuite.scala
@@ -51,12 +51,17 @@ class ClosureCleanerSuite extends FunSuite {
     assert(obj.run() === 96) // 4 * (1+2+3+4) + 4 * (1+2+3+4) + 16 * 1
   }
   
-  test("return statements in closures are identified at cleaning time") {
+  test("toplevel return statements in closures are identified at cleaning time") {
     val ex = intercept[SparkException] {
       TestObjectWithBogusReturns.run()
     }
     
     assert(ex.getMessage.contains("Return statements aren't allowed in Spark closures"))
+  }
+
+  test("return statements from named functions nested in closures don't raise exceptions") {
+    val result = TestObjectWithNestedReturns.run()
+    assert(result == 1)
   }
 }
 
@@ -120,12 +125,26 @@ object TestObjectWithBogusReturns {
   def run(): Int = {
     withSpark(new SparkContext("local", "test")) { sc =>
       val nums = sc.parallelize(Array(1, 2, 3, 4))
+      // this return is invalid since it will transfer control outside the closure
       nums.map {x => return 1 ; x * 2}
       1
     }
   }
 }
 
+object TestObjectWithNestedReturns {
+  def run(): Int = {
+    withSpark(new SparkContext("local", "test")) { sc =>
+      val nums = sc.parallelize(Array(1, 2, 3, 4))
+      nums.map {x => 
+        // this return is fine since it will not transfer control outside the closure
+        def foo(): Int = { return 5; 1 }
+        foo()
+      }
+      1
+    }
+  }
+}
 
 object TestObjectWithNesting {
   def run(): Int = {

--- a/core/src/test/scala/org/apache/spark/util/ClosureCleanerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/ClosureCleanerSuite.scala
@@ -20,8 +20,7 @@ package org.apache.spark.util
 import org.scalatest.FunSuite
 
 import org.apache.spark.LocalSparkContext._
-import org.apache.spark.SparkContext
-import org.apache.spark.SparkException
+import org.apache.spark.{SparkContext, SparkException}
 
 class ClosureCleanerSuite extends FunSuite {
   test("closures inside an object") {
@@ -118,15 +117,11 @@ class TestClassWithoutFieldAccess {
 }
 
 object TestObjectWithBogusReturns {
-  def badClosureWithReturn(v: org.apache.spark.rdd.RDD[Int]): Int = {
-     v.map {x => return 1 ; x * 2}
-     1
-  }
-  
   def run(): Int = {
     withSpark(new SparkContext("local", "test")) { sc =>
       val nums = sc.parallelize(Array(1, 2, 3, 4))
-      badClosureWithReturn(nums)
+      nums.map {x => return 1 ; x * 2}
+      1
     }
   }
 }

--- a/core/src/test/scala/org/apache/spark/util/ClosureCleanerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/ClosureCleanerSuite.scala
@@ -21,6 +21,7 @@ import org.scalatest.FunSuite
 
 import org.apache.spark.LocalSparkContext._
 import org.apache.spark.SparkContext
+import org.apache.spark.SparkException
 
 class ClosureCleanerSuite extends FunSuite {
   test("closures inside an object") {
@@ -49,6 +50,14 @@ class ClosureCleanerSuite extends FunSuite {
   test("nested closures inside a class") {
     val obj = new TestClassWithNesting(1)
     assert(obj.run() === 96) // 4 * (1+2+3+4) + 4 * (1+2+3+4) + 16 * 1
+  }
+  
+  test("return statements in closures are identified at cleaning time") {
+    val ex = intercept[SparkException] {
+      TestObjectWithBogusReturns.run()
+    }
+    
+    assert(ex.getMessage.contains("Return statements aren't allowed in Spark closures"))
   }
 }
 
@@ -104,6 +113,20 @@ class TestClassWithoutFieldAccess {
     withSpark(new SparkContext("local", "test")) { sc =>
       val nums = sc.parallelize(Array(1, 2, 3, 4))
       nums.map(_ + x).reduce(_ + _)
+    }
+  }
+}
+
+object TestObjectWithBogusReturns {
+  def badClosureWithReturn(v: org.apache.spark.rdd.RDD[Int]): Int = {
+     v.map {x => return 1 ; x * 2}
+     1
+  }
+  
+  def run(): Int = {
+    withSpark(new SparkContext("local", "test")) { sc =>
+      val nums = sc.parallelize(Array(1, 2, 3, 4))
+      badClosureWithReturn(nums)
     }
   }
 }


### PR DESCRIPTION
This patch checks top-level closure arguments to `ClosureCleaner.clean` for `return` statements and raises an exception if it finds any.  This is mainly a user-friendliness addition, since programs with return statements in closure arguments will currently fail upon RDD actions with a less-than-intuitive error message.
