### PR TITLE
SPARK-1652: Set driver memory correctly in spark-submit.

### DIFF
--- a/bin/spark-submit
+++ b/bin/spark-submit
@@ -35,8 +35,8 @@ while (($#)); do
   shift
 done
 
-if [ ! -z $DRIVER_MEMORY ] && [ ! -z $DEPLOY_MODE ] && [ $DEPLOY_MODE = "client" ]; then
-  export SPARK_MEM=$DRIVER_MEMORY
+if [ ! -z $DRIVER_MEMORY ] && [ ! "$DEPLOY_MODE" == "cluster" ]; then
+  export SPARK_DRIVER_MEMORY=$DRIVER_MEMORY
 fi
 
 $SPARK_HOME/bin/spark-class org.apache.spark.deploy.SparkSubmit "${ORIG_ARGS[@]}"

--- a/bin/spark-submit
+++ b/bin/spark-submit
@@ -35,7 +35,9 @@ while (($#)); do
   shift
 done
 
-if [ ! -z $DRIVER_MEMORY ] && [ ! "$DEPLOY_MODE" == "cluster" ]; then
+DEPLOY_MODE=${DEPLOY_MODE:-"client"}
+
+if [ ! -z $DRIVER_MEMORY ] && [ ! $DEPLOY_MODE == "cluster" ]; then
   export SPARK_DRIVER_MEMORY=$DRIVER_MEMORY
 fi
 

--- a/bin/spark-submit
+++ b/bin/spark-submit
@@ -37,7 +37,7 @@ done
 
 DEPLOY_MODE=${DEPLOY_MODE:-"client"}
 
-if [ ! -z $DRIVER_MEMORY ] && [ ! $DEPLOY_MODE == "cluster" ]; then
+if [ -n "$DRIVER_MEMORY" ] && [ $DEPLOY_MODE == "client" ]; then
   export SPARK_DRIVER_MEMORY=$DRIVER_MEMORY
 fi
 


### PR DESCRIPTION
The previous check didn't account for the fact that the default
deploy mode is "client" unless otherwise specified. Also, this
sets the more narrowly defined SPARK_DRIVER_MEMORY instead of setting
SPARK_MEM.
