### PR TITLE
SPARK-1706: Allow multiple executors per worker in Standalone mode

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/ApplicationDescription.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/ApplicationDescription.scala
@@ -22,7 +22,7 @@ import java.net.URI
 private[spark] class ApplicationDescription(
     val name: String,
     val maxCores: Option[Int],
-    val memoryPerSlave: Int,
+    val memoryPerExecutorMB: Int,
     val command: Command,
     var appUiUrl: String,
     val eventLogDir: Option[URI] = None,
@@ -35,13 +35,16 @@ private[spark] class ApplicationDescription(
   def copy(
       name: String = name,
       maxCores: Option[Int] = maxCores,
-      memoryPerSlave: Int = memoryPerSlave,
+      memoryPerSlave: Int = memoryPerExecutorMB,
       command: Command = command,
       appUiUrl: String = appUiUrl,
       eventLogDir: Option[URI] = eventLogDir,
       eventLogCodec: Option[String] = eventLogCodec): ApplicationDescription =
     new ApplicationDescription(
       name, maxCores, memoryPerSlave, command, appUiUrl, eventLogDir, eventLogCodec)
+
+  // only valid when spark.executor.multiPerWorker is set to true
+  var maxCorePerExecutor = maxCores
 
   override def toString: String = "ApplicationDescription(" + name + ")"
 }

--- a/core/src/main/scala/org/apache/spark/deploy/ApplicationDescription.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/ApplicationDescription.scala
@@ -27,7 +27,8 @@ private[spark] class ApplicationDescription(
     var appUiUrl: String,
     val eventLogDir: Option[URI] = None,
     // short name of compression codec used when writing event logs, if any (e.g. lzf)
-    val eventLogCodec: Option[String] = None)
+    val eventLogCodec: Option[String] = None,
+    val maxCorePerExecutor: Option[Int] = None)
   extends Serializable {
 
   val user = System.getProperty("user.name", "<unknown>")
@@ -42,9 +43,6 @@ private[spark] class ApplicationDescription(
       eventLogCodec: Option[String] = eventLogCodec): ApplicationDescription =
     new ApplicationDescription(
       name, maxCores, memoryPerSlave, command, appUiUrl, eventLogDir, eventLogCodec)
-
-  // only valid when spark.executor.multiPerWorker is set to true
-  var maxCorePerExecutor: Option[Int] = None
 
   override def toString: String = "ApplicationDescription(" + name + ")"
 }

--- a/core/src/main/scala/org/apache/spark/deploy/ApplicationDescription.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/ApplicationDescription.scala
@@ -44,7 +44,7 @@ private[spark] class ApplicationDescription(
       name, maxCores, memoryPerSlave, command, appUiUrl, eventLogDir, eventLogCodec)
 
   // only valid when spark.executor.multiPerWorker is set to true
-  var maxCorePerExecutor = None
+  var maxCorePerExecutor: Option[Int] = None
 
   override def toString: String = "ApplicationDescription(" + name + ")"
 }

--- a/core/src/main/scala/org/apache/spark/deploy/ApplicationDescription.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/ApplicationDescription.scala
@@ -28,7 +28,7 @@ private[spark] class ApplicationDescription(
     val eventLogDir: Option[URI] = None,
     // short name of compression codec used when writing event logs, if any (e.g. lzf)
     val eventLogCodec: Option[String] = None,
-    val maxCorePerExecutor: Option[Int] = None)
+    val coresPerExecutor: Option[Int] = None)
   extends Serializable {
 
   val user = System.getProperty("user.name", "<unknown>")
@@ -36,13 +36,13 @@ private[spark] class ApplicationDescription(
   def copy(
       name: String = name,
       maxCores: Option[Int] = maxCores,
-      memoryPerSlave: Int = memoryPerExecutorMB,
+      memoryPerExecutorMB: Int = memoryPerExecutorMB,
       command: Command = command,
       appUiUrl: String = appUiUrl,
       eventLogDir: Option[URI] = eventLogDir,
       eventLogCodec: Option[String] = eventLogCodec): ApplicationDescription =
     new ApplicationDescription(
-      name, maxCores, memoryPerSlave, command, appUiUrl, eventLogDir, eventLogCodec)
+      name, maxCores, memoryPerExecutorMB, command, appUiUrl, eventLogDir, eventLogCodec)
 
   override def toString: String = "ApplicationDescription(" + name + ")"
 }

--- a/core/src/main/scala/org/apache/spark/deploy/ApplicationDescription.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/ApplicationDescription.scala
@@ -44,7 +44,7 @@ private[spark] class ApplicationDescription(
       name, maxCores, memoryPerSlave, command, appUiUrl, eventLogDir, eventLogCodec)
 
   // only valid when spark.executor.multiPerWorker is set to true
-  var maxCorePerExecutor = maxCores
+  var maxCorePerExecutor = None
 
   override def toString: String = "ApplicationDescription(" + name + ")"
 }

--- a/core/src/main/scala/org/apache/spark/deploy/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/JsonProtocol.scala
@@ -46,7 +46,7 @@ private[deploy] object JsonProtocol {
     ("name" -> obj.desc.name) ~
     ("cores" -> obj.desc.maxCores) ~
     ("user" ->  obj.desc.user) ~
-    ("memoryperslave" -> obj.desc.memoryPerSlave) ~
+    ("memoryperslave" -> obj.desc.memoryPerExecutorMB) ~
     ("submitdate" -> obj.submitDate.toString) ~
     ("state" -> obj.state.toString) ~
     ("duration" -> obj.duration)
@@ -55,7 +55,7 @@ private[deploy] object JsonProtocol {
   def writeApplicationDescription(obj: ApplicationDescription): JObject = {
     ("name" -> obj.name) ~
     ("cores" -> obj.maxCores) ~
-    ("memoryperslave" -> obj.memoryPerSlave) ~
+    ("memoryperslave" -> obj.memoryPerExecutorMB) ~
     ("user" -> obj.user) ~
     ("command" -> obj.command.toString)
   }

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -383,6 +383,8 @@ object SparkSubmit {
       OptionAssigner(args.ivyRepoPath, STANDALONE, CLUSTER, sysProp = "spark.jars.ivy"),
       OptionAssigner(args.driverMemory, STANDALONE, CLUSTER, sysProp = "spark.driver.memory"),
       OptionAssigner(args.driverCores, STANDALONE, CLUSTER, sysProp = "spark.driver.cores"),
+      OptionAssigner(args.executorCores, STANDALONE, ALL_DEPLOY_MODES, 
+        sysProp = "spark.executor.cores"),
       OptionAssigner(args.supervise.toString, STANDALONE, CLUSTER,
         sysProp = "spark.driver.supervise"),
 

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -407,7 +407,7 @@ object SparkSubmit {
 
       // Other options
       OptionAssigner(args.executorCores, STANDALONE, ALL_DEPLOY_MODES,
-        sysProp = "spark.deploy.maxCoresPerExecutor"),
+        sysProp = "spark.executor.cores"),
       OptionAssigner(args.executorMemory, STANDALONE | MESOS | YARN, ALL_DEPLOY_MODES,
         sysProp = "spark.executor.memory"),
       OptionAssigner(args.totalExecutorCores, STANDALONE | MESOS, ALL_DEPLOY_MODES,

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -383,8 +383,6 @@ object SparkSubmit {
       OptionAssigner(args.ivyRepoPath, STANDALONE, CLUSTER, sysProp = "spark.jars.ivy"),
       OptionAssigner(args.driverMemory, STANDALONE, CLUSTER, sysProp = "spark.driver.memory"),
       OptionAssigner(args.driverCores, STANDALONE, CLUSTER, sysProp = "spark.driver.cores"),
-      OptionAssigner(args.executorCores, STANDALONE, ALL_DEPLOY_MODES, 
-        sysProp = "spark.executor.cores"),
       OptionAssigner(args.supervise.toString, STANDALONE, CLUSTER,
         sysProp = "spark.driver.supervise"),
 
@@ -408,6 +406,8 @@ object SparkSubmit {
       OptionAssigner(args.jars, YARN, CLUSTER, clOption = "--addJars"),
 
       // Other options
+      OptionAssigner(args.executorCores, STANDALONE, ALL_DEPLOY_MODES,
+        sysProp = "spark.deploy.maxCoresPerExecutor"),
       OptionAssigner(args.executorMemory, STANDALONE | MESOS | YARN, ALL_DEPLOY_MODES,
         sysProp = "spark.executor.memory"),
       OptionAssigner(args.totalExecutorCores, STANDALONE | MESOS, ALL_DEPLOY_MODES,

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -483,12 +483,10 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
         |  --total-executor-cores NUM  Total cores for all executors.
         | 
         | Spark standalone and YARN only:
-        |  --executor-cores NUM        Number of cores per executor. Default value: 1 (YARN), 0 (
-        |                              Standalone). In Standalone mode, Spark will try to run more
-        |                              than 1 executors on each worker in standalone mode; 
-        |                              otherwise, only one executor on each executor is allowed 
-        |                              (the executor will take all available cores of the worker at 
-        |                              the moment.
+        |  --executor-cores NUM        Number of cores to use on each executor. In standalone mode,
+        |                              the executor will use all available cores on the worker if
+        |                              this is not specified. (Default: 1 in YARN mode, all
+        |                              available cores in standalone mode).
         |          
         | YARN-only:
         |  --driver-cores NUM          Number of cores used by the driver, only in cluster mode

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -481,13 +481,14 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
         |
         | Spark standalone and Mesos only:
         |  --total-executor-cores NUM  Total cores for all executors.
-        | 
+        |
         | Spark standalone and YARN only:
-        |  --executor-cores NUM        Number of cores to use on each executor. In standalone mode,
-        |                              the executor will use all available cores on the worker if
-        |                              this is not specified. (Default: 1 in YARN mode, all
-        |                              available cores in standalone mode).
-        |          
+        |  --executor-cores NUM        Number of cores to use on each executor. Default:
+        |                              1 in YARN mode; in standalone mode, all available cores
+        |                              (non-spreadApp mode) or ranging from 1 to
+        |                              total-executor-cores / availableNumOfWorkers at the moment
+        |                              of scheduling.
+        |
         | YARN-only:
         |  --driver-cores NUM          Number of cores used by the driver, only in cluster mode
         |                              (Default: 1).

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -484,10 +484,9 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
         |
         | Spark standalone and YARN only:
         |  --executor-cores NUM        Number of cores to use on each executor. Default:
-        |                              1 in YARN mode; in standalone mode, all available cores
-        |                              (non-spreadApp mode) or ranging from 1 to
-        |                              total-executor-cores / availableNumOfWorkers at the moment
-        |                              of scheduling.
+        |                              1 in YARN mode; in standalone mode, all cores in a worker
+        |                              allocated to an application will be assigned to a single
+        |                              executor.
         |
         | YARN-only:
         |  --driver-cores NUM          Number of cores used by the driver, only in cluster mode

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -483,10 +483,8 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
         |  --total-executor-cores NUM  Total cores for all executors.
         |
         | Spark standalone and YARN only:
-        |  --executor-cores NUM        Number of cores to use on each executor. Default:
-        |                              1 in YARN mode; in standalone mode, all cores in a worker
-        |                              allocated to an application will be assigned to a single
-        |                              executor.
+        |  --executor-cores NUM        Number of cores per executor. (Default: 1 in YARN mode,
+        |                              or all available cores on the worker in standalone mode)
         |
         | YARN-only:
         |  --driver-cores NUM          Number of cores used by the driver, only in cluster mode

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -481,11 +481,18 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
         |
         | Spark standalone and Mesos only:
         |  --total-executor-cores NUM  Total cores for all executors.
-        |
+        | 
+        | Spark standalone and YARN only:
+        |  --executor-cores NUM        Number of cores per executor. Default value: 1 (YARN), 0 (
+        |                              Standalone). In Standalone mode, Spark will try to run more
+        |                              than 1 executors on each worker in standalone mode; 
+        |                              otherwise, only one executor on each executor is allowed 
+        |                              (the executor will take all available cores of the worker at 
+        |                              the moment.
+        |          
         | YARN-only:
         |  --driver-cores NUM          Number of cores used by the driver, only in cluster mode
         |                              (Default: 1).
-        |  --executor-cores NUM        Number of cores per executor (Default: 1).
         |  --queue QUEUE_NAME          The YARN queue to submit to (Default: "default").
         |  --num-executors NUM         Number of executors to launch (Default: 2).
         |  --archives ARCHIVES         Comma separated list of archives to be extracted into the

--- a/core/src/main/scala/org/apache/spark/deploy/master/ApplicationInfo.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ApplicationInfo.scala
@@ -75,8 +75,10 @@ private[deploy] class ApplicationInfo(
     }
   }
 
-  private[master] def addExecutor(worker: WorkerInfo, cores: Int, useID: Option[Int] = None):
-      ExecutorDesc = {
+  private[master] def addExecutor(
+      worker: WorkerInfo,
+      cores: Int,
+      useID: Option[Int] = None): ExecutorDesc = {
     val exec = new ExecutorDesc(newExecutorId(useID), this, worker, cores, desc.memoryPerExecutorMB)
     executors(exec.id) = exec
     coresGranted += cores

--- a/core/src/main/scala/org/apache/spark/deploy/master/ApplicationInfo.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ApplicationInfo.scala
@@ -75,9 +75,8 @@ private[deploy] class ApplicationInfo(
     }
   }
 
-  private[master] def addExecutor(worker: WorkerInfo, cores: Int, useID: Option[Int] = None): 
-  ExecutorDesc = {
-    val exec = new ExecutorDesc(newExecutorId(useID), this, worker, cores, desc.memoryPerSlave)
+  def addExecutor(worker: WorkerInfo, cores: Int, useID: Option[Int] = None): ExecutorDesc = {
+    val exec = new ExecutorDesc(newExecutorId(useID), this, worker, cores, desc.memoryPerExecutorMB)
     executors(exec.id) = exec
     coresGranted += cores
     exec

--- a/core/src/main/scala/org/apache/spark/deploy/master/ApplicationInfo.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ApplicationInfo.scala
@@ -75,7 +75,8 @@ private[deploy] class ApplicationInfo(
     }
   }
 
-  def addExecutor(worker: WorkerInfo, cores: Int, useID: Option[Int] = None): ExecutorDesc = {
+  private[master] def addExecutor(worker: WorkerInfo, cores: Int, useID: Option[Int] = None):
+      ExecutorDesc = {
     val exec = new ExecutorDesc(newExecutorId(useID), this, worker, cores, desc.memoryPerExecutorMB)
     executors(exec.id) = exec
     coresGranted += cores

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -544,7 +544,7 @@ private[master] class Master(
       for (app <- waitingApps if app.coresLeft > 0) {
         val usableWorkers = workers.toArray.filter(_.state == WorkerState.ALIVE)
           .filter(worker => worker.memoryFree >= app.desc.memoryPerExecutorMB &&
-            worker.coresFree >= app.desc.coresPerExecutor.getOrElse(0))
+            worker.coresFree >= app.desc.coresPerExecutor.getOrElse(1))
           .sortBy(_.coresFree).reverse
         val numUsable = usableWorkers.length
         val assigned = new Array[Int](numUsable) // Number of cores to give on each node

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -677,7 +677,7 @@ private[master] class Master(
       }
     }
 
-    if (!conf.getBoolean("spark.executor.multiPerWorker", false)) {
+    if (!conf.getBoolean("spark.executor.multiPerWorker", true)) {
       startSingleExecutorPerWorker()
     } else {
       startMultiExecutorsPerWorker()

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -524,15 +524,6 @@ private[master] class Master(
   }
 
   /**
-   * Can an app use the given worker?
-   */
-  private def canUse(app: ApplicationInfo, worker: WorkerInfo): Boolean = {
-    val enoughResources = worker.memoryFree >= app.desc.memoryPerExecutorMB && worker.coresFree > 0
-    val allowToExecute = app.desc.coresPerExecutor.isDefined || !worker.hasExecutor(app)
-    allowToExecute && enoughResources
-  }
-
-  /**
    * Schedule executors to be launched on the workers.There are two modes of launching executors.
    * The first attempts to spread out an application's executors on as many workers as possible,
    * while the second does the opposite (i.e. launch them on as few workers as possible). The former

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -609,7 +609,9 @@ private[master] class Master(
         var leftExecutorNumToAssign = usableWorkers.map(_.memoryFree / memoryPerExecutor).sum
         var maxCoresLeft = app.coresLeft
         val numUsable = usableWorkers.length
-        // 2D array to track the number of cores of each executor assigned to each worker
+        // A 2D array that tracks the number of cores used by each executor launched on
+        // each worker. The first index refers to the usable worker, and the second index
+        // refers to the executor launched on that worker.
         val assigned = Array.fill[ListBuffer[Int]](numUsable)(new ListBuffer[Int])
         val assignedSum = Array.fill[Int](numUsable)(0)
         var pos = 0

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -581,14 +581,14 @@ private[master] class Master(
   /**
    * This functions starts multiple executors on each worker.
    * It first calculates the maximum number of executors we can allocate to the application in this 
-   * scheduling moment according to the free memory space on each worker, then tries to allocate executors
-   * on each worker according to the user-specified spark.executor.maxCoreNumPerExecutor.
+   * scheduling moment according to the free memory space on each worker, then tries to allocate 
+   * executors on each worker according to the user-specified spark.executor.maxCoreNumPerExecutor.
    * 
    * It traverses the available worker list. In spreadOutApps mode, it allocates at most
-   * spark.executor.maxCoreNumPerExecutor cores (can be less than it when the worker does not have enough 
-   * cores or the demand is less than it) and app.desc.memoryPerExecutorMB megabytes memory and tracks the 
-   * resource allocation in a 2d array for each visit; Otherwise, it uses up all available resources of a worker 
-   * for each visit.
+   * spark.executor.maxCoreNumPerExecutor cores (can be less than it when the worker does not have 
+   * enough cores or the demand is less than it) and app.desc.memoryPerExecutorMB megabytes memory 
+   * and tracks the resource allocation in a 2d array for each visit; Otherwise, it uses up all 
+   * available resources of a worker for each visit.
    */
   private def startMultiExecutorsPerWorker() {
     if (spreadOutApps) {

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -555,7 +555,7 @@ private[master] class Master(
           pos = (pos + 1) % numUsable
         }
         // Now that we've decided how many cores to give on each node, let's actually give them
-        for (pos <- 0 until numUsable) {
+        for (pos <- 0 until numUsable if assigned(pos) > 0) {
           allocateWorkerResourceToExecutors(app, assigned(pos), usableWorkers(pos))
         }
       }

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -611,7 +611,7 @@ private[master] class Master(
     startExecutorsOnWorkers()
   }
 
-  def launchExecutor(worker: WorkerInfo, exec: ExecutorDesc): Unit = {
+  private def launchExecutor(worker: WorkerInfo, exec: ExecutorDesc): Unit = {
     logInfo("Launching executor " + exec.fullId + " on worker " + worker.id)
     worker.addExecutor(exec)
     worker.actor ! LaunchExecutor(masterUrl,

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -524,9 +524,7 @@ private[master] class Master(
   }
 
   /**
-   * Can an app use the given worker? True if the worker has enough memory and we haven't already
-   * launched an executor for the app on it (right now the standalone backend doesn't like having
-   * two executors on the same worker).
+   * Can an app use the given worker?
    */
   private def canUse(app: ApplicationInfo, worker: WorkerInfo): Boolean = {
     val enoughResources = worker.memoryFree >= app.desc.memoryPerExecutorMB && worker.coresFree > 0

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -615,9 +615,9 @@ private[master] class Master(
    */
   private def schedule(): Unit = {
     if (state != RecoveryState.ALIVE) { return }
-    //start in-cluster drivers, they take strict precedence over applications
+    // start in-cluster drivers, they take strict precedence over applications
     startDriversOnWorkers()
-    //start executors
+    // start executors
     startExecutorsOnWorkers()
   }
 

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -545,7 +545,6 @@ private[master] class Master(
     if (spreadOutApps) {
       // Try to spread out each app among all the workers, until it has all its cores
       for (app <- waitingApps if app.coresLeft > 0) {
-        val maxCoresPerExecutor = app.desc.maxCorePerExecutor.getOrElse(Int.MaxValue)
         val usableWorkers = workers.toArray.filter(_.state == WorkerState.ALIVE)
           .filter(canUse(app, _)).sortBy(_.coresFree).reverse
         val numUsable = usableWorkers.length

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -570,7 +570,7 @@ private[master] class Master(
         while (maxCoresLeft > 0) {
           val memoryDemand = {
             if (app.desc.maxCorePerExecutor.isDefined) {
-              executorNumberOnWorker(pos) + 1
+              (executorNumberOnWorker(pos) + 1) * memoryPerExecutor
             } else {
               memoryPerExecutor  
             }  

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -22,7 +22,7 @@ import java.net.URLEncoder
 import java.text.SimpleDateFormat
 import java.util.Date
 
-import scala.collection.mutable.{ListBuffer, ArrayBuffer, HashMap, HashSet}
+import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet}
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.language.postfixOps

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -623,7 +623,7 @@ private[master] class Master(
    * Schedule the currently available resources among waiting apps. This method will be called
    * every time a new app joins or resource availability changes.
    */
-  def schedule() {
+  private def schedule(): Unit = {
     if (state != RecoveryState.ALIVE) { return }
 
     // First schedule drivers, they take strict precedence over applications

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/ApplicationPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/ApplicationPage.scala
@@ -83,14 +83,14 @@ private[ui] class ApplicationPage(parent: MasterWebUI) extends WebUIPage("app") 
             <li><strong>Name:</strong> {app.desc.name}</li>
             <li><strong>User:</strong> {app.desc.user}</li>
             <li><strong>Cores:</strong>
-              {
+            {
               if (app.desc.maxCores.isEmpty) {
                 "Unlimited (%s granted)".format(app.coresGranted)
               } else {
                 "%s (%s granted, %s left)".format(
                   app.desc.maxCores.get, app.coresGranted, app.coresLeft)
               }
-              }
+            }
             </li>
             <li>
               <strong>Executor Memory:</strong>

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/ApplicationPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/ApplicationPage.scala
@@ -83,18 +83,18 @@ private[ui] class ApplicationPage(parent: MasterWebUI) extends WebUIPage("app") 
             <li><strong>Name:</strong> {app.desc.name}</li>
             <li><strong>User:</strong> {app.desc.user}</li>
             <li><strong>Cores:</strong>
-            {
+              {
               if (app.desc.maxCores.isEmpty) {
                 "Unlimited (%s granted)".format(app.coresGranted)
               } else {
                 "%s (%s granted, %s left)".format(
                   app.desc.maxCores.get, app.coresGranted, app.coresLeft)
               }
-            }
+              }
             </li>
             <li>
               <strong>Executor Memory:</strong>
-              {Utils.megabytesToString(app.desc.memoryPerSlave)}
+              {Utils.megabytesToString(app.desc.memoryPerExecutorMB)}
             </li>
             <li><strong>Submit Date:</strong> {app.submitDate}</li>
             <li><strong>State:</strong> {app.state}</li>

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
@@ -208,8 +208,8 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
       <td>
         {app.coresGranted}
       </td>
-      <td sorttable_customkey={app.desc.memoryPerSlave.toString}>
-        {Utils.megabytesToString(app.desc.memoryPerSlave)}
+      <td sorttable_customkey={app.desc.memoryPerExecutorMB.toString}>
+        {Utils.megabytesToString(app.desc.memoryPerExecutorMB)}
       </td>
       <td>{UIUtils.formatDate(app.submitDate)}</td>
       <td>{app.desc.user}</td>

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
@@ -82,9 +82,9 @@ private[spark] class SparkDeploySchedulerBackend(
     val command = Command("org.apache.spark.executor.CoarseGrainedExecutorBackend",
       args, sc.executorEnvs, classPathEntries ++ testingClassPath, libraryPathEntries, javaOpts)
     val appUIAddress = sc.ui.map(_.appUIAddress).getOrElse("")
-    val appDesc = new ApplicationDescription(sc.appName, maxCores, sc.executorMemory, command,
-      appUIAddress, sc.eventLogDir, sc.eventLogCodec,
-      conf.getOption("spark.deploy.maxCoresPerExecutor").map(_.toInt))
+    val appDesc = new ApplicationDescription(sc.appName, maxCores, sc.executorMemory,
+      command, appUIAddress, sc.eventLogDir, sc.eventLogCodec,
+      conf.getOption("spark.executor.cores").map(_.toInt))
     client = new AppClient(sc.env.actorSystem, masters, appDesc, this, conf)
     client.start()
     waitForRegistration()

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
@@ -84,13 +84,9 @@ private[spark] class SparkDeploySchedulerBackend(
     val appUIAddress = sc.ui.map(_.appUIAddress).getOrElse("")
     val appDesc = new ApplicationDescription(sc.appName, maxCores, sc.executorMemory, command,
       appUIAddress, sc.eventLogDir, sc.eventLogCodec)
-
-    if (conf.getBoolean("spark.executor.multiPerWorker", true)) {
-      appDesc.maxCorePerExecutor = Some(conf.getInt("spark.executor.maxCoreNumPerExecutor", 1))
-    }
+    appDesc.maxCorePerExecutor = conf.getOption("spark.executor.cores").map(_.toInt)
     client = new AppClient(sc.env.actorSystem, masters, appDesc, this, conf)
     client.start()
-
     waitForRegistration()
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
@@ -82,9 +82,9 @@ private[spark] class SparkDeploySchedulerBackend(
     val command = Command("org.apache.spark.executor.CoarseGrainedExecutorBackend",
       args, sc.executorEnvs, classPathEntries ++ testingClassPath, libraryPathEntries, javaOpts)
     val appUIAddress = sc.ui.map(_.appUIAddress).getOrElse("")
+    val coresPerExecutor = conf.getOption("spark.executor.cores").map(_.toInt)
     val appDesc = new ApplicationDescription(sc.appName, maxCores, sc.executorMemory,
-      command, appUIAddress, sc.eventLogDir, sc.eventLogCodec,
-      conf.getOption("spark.executor.cores").map(_.toInt))
+      command, appUIAddress, sc.eventLogDir, sc.eventLogCodec, coresPerExecutor)
     client = new AppClient(sc.env.actorSystem, masters, appDesc, this, conf)
     client.start()
     waitForRegistration()

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
@@ -85,6 +85,9 @@ private[spark] class SparkDeploySchedulerBackend(
     val appDesc = new ApplicationDescription(sc.appName, maxCores, sc.executorMemory, command,
       appUIAddress, sc.eventLogDir, sc.eventLogCodec)
 
+    if (conf.getBoolean("spark.executor.multiPerWorker", true)) {
+      appDesc.maxCorePerExecutor = Some(conf.getInt("spark.executor.maxCoreNumPerExecutor", 1))
+    }
     client = new AppClient(sc.env.actorSystem, masters, appDesc, this, conf)
     client.start()
 

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
@@ -83,8 +83,8 @@ private[spark] class SparkDeploySchedulerBackend(
       args, sc.executorEnvs, classPathEntries ++ testingClassPath, libraryPathEntries, javaOpts)
     val appUIAddress = sc.ui.map(_.appUIAddress).getOrElse("")
     val appDesc = new ApplicationDescription(sc.appName, maxCores, sc.executorMemory, command,
-      appUIAddress, sc.eventLogDir, sc.eventLogCodec)
-    appDesc.maxCorePerExecutor = conf.getOption("spark.executor.cores").map(_.toInt)
+      appUIAddress, sc.eventLogDir, sc.eventLogCodec,
+      conf.getOption("spark.deploy.maxCoresPerExecutor").map(_.toInt))
     client = new AppClient(sc.env.actorSystem, masters, appDesc, this, conf)
     client.start()
     waitForRegistration()

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,15 +128,6 @@ of the most common options to set are:
   </td>
 </tr>
 <tr>
-  <td><code>spark.executor.cores</code></td>
-  <td>None (Standalone), 1 (YARN)</td>
-  <td>
-    Number of cores per executor. In Standalone mode, Spark will try to run more
-    than 1 executors on each worker in standalone mode; otherwise, only one executor on each executor
-    is allowed (the executor will take all available cores of the worker at the moment.
-  </td>
-</tr>
-<tr>
   <td><code>spark.executor.memory</code></td>
   <td>512m</td>
   <td>
@@ -720,6 +711,15 @@ Apart from these, the following properties are also available, and may be useful
     forgotten. This is useful for running Spark for many hours / days (for example, running 24/7 in
     case of Spark Streaming applications). Note that any RDD that persists in memory for more than
     this duration will be cleared as well.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.deploy.maxCoresPerExecutor</code></td>
+  <td>(infinite)</td>
+  <td>
+    The maximum number of cores given to the executor. When this parameter is set, Spark will try to 
+    run more than 1 executors on each worker in standalone mode; otherwise, only one executor is 
+    launched on each worker.
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -714,12 +714,16 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
-  <td><code>spark.deploy.maxCoresPerExecutor</code></td>
+  <td><code>spark.executor.cores</code></td>
   <td>(infinite)</td>
   <td>
-    The maximum number of cores given to the executor. When this parameter is set, Spark will try to 
-    run more than 1 executors on each worker in standalone mode; otherwise, only one executor is 
-    launched on each worker.
+    Default: 1 in YARN mode, all the available cores on the worker in standalone mode.
+    
+    The number of cores to use on each executor. For YARN and standalone mode only.
+    
+    In standalone mode, setting this parameter allows an application to run multiple executors on 
+    the same worker, provided that there are enough cores on that worker. Otherwise, only one 
+    executor per application will run on each worker.
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,7 +103,6 @@ of the most common options to set are:
     Number of cores to use for the driver process, only in cluster mode.
   </td>
 </tr>
-<tr>
   <td><code>spark.driver.maxResultSize</code></td>
   <td>1g</td>
   <td>
@@ -129,11 +128,12 @@ of the most common options to set are:
   </td>
 </tr>
 <tr>
-  <td>spark.executor.maxCoreNumPerExecutor</td>
-  <td>1</td>
+  <td><code>spark.executor.cores</code></td>
+  <td>None (Standalone), 1 (YARN)</td>
   <td>
-    set the max number of cores assigned to each executor; this property is only valid when
-    <code>spark.executor.multiPerWorker</code> is set to true.
+    Number of cores per executor. In Standalone mode, Spark will try to run more
+    than 1 executors on each worker in standalone mode; otherwise, only one executor on each executor
+    is allowed (the executor will take all available cores of the worker at the moment.
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1255,6 +1255,25 @@ Apart from these, the following properties are also available, and may be useful
 <tr>
   <td><code>spark.ui.view.acls</code></td>
   <td>Empty</td>
+</tr>
+<tr>
+  <td>spark.executor.multiPerWorker</td>
+  <td>false</td>
+  <td>
+    enable user to run multiple executors in the same worker.
+  </td>
+</tr>
+<tr>
+  <td>spark.executor.maxCoreNumPerExecutor</td>
+  <td>1</td>
+  <td>
+    set the max number of cores assigned to each executor; this property is only valid when
+    <code>spark.executor.multiPerWorker</code> is set to true.
+  </td>
+</tr>
+<tr>
+  <td>spark.executor.extraClassPath</td>
+  <td>(none)</td>
   <td>
     Comma separated list of users that have view access to the Spark web ui. By default only the
     user that started the Spark job has view access.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -715,10 +715,8 @@ Apart from these, the following properties are also available, and may be useful
 </tr>
 <tr>
   <td><code>spark.executor.cores</code></td>
-  <td>(infinite)</td>
+  <td>1 in YARN mode, all the available cores on the worker in standalone mode.</td>
   <td>
-    Default: 1 in YARN mode, all the available cores on the worker in standalone mode.
-    
     The number of cores to use on each executor. For YARN and standalone mode only.
     
     In standalone mode, setting this parameter allows an application to run multiple executors on 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,6 +103,7 @@ of the most common options to set are:
     Number of cores to use for the driver process, only in cluster mode.
   </td>
 </tr>
+<tr>
   <td><code>spark.driver.maxResultSize</code></td>
   <td>1g</td>
   <td>
@@ -125,6 +126,14 @@ of the most common options to set are:
     directly in your application, because the driver JVM has already started at that point.
     Instead, please set this through the <code>--driver-memory</code> command line option
     or in your default properties file.
+  </td>
+</tr>
+<tr>
+  <td>spark.executor.maxCoreNumPerExecutor</td>
+  <td>1</td>
+  <td>
+    set the max number of cores assigned to each executor; this property is only valid when
+    <code>spark.executor.multiPerWorker</code> is set to true.
   </td>
 </tr>
 <tr>
@@ -1255,25 +1264,6 @@ Apart from these, the following properties are also available, and may be useful
 <tr>
   <td><code>spark.ui.view.acls</code></td>
   <td>Empty</td>
-</tr>
-<tr>
-  <td>spark.executor.multiPerWorker</td>
-  <td>false</td>
-  <td>
-    enable user to run multiple executors in the same worker.
-  </td>
-</tr>
-<tr>
-  <td>spark.executor.maxCoreNumPerExecutor</td>
-  <td>1</td>
-  <td>
-    set the max number of cores assigned to each executor; this property is only valid when
-    <code>spark.executor.multiPerWorker</code> is set to true.
-  </td>
-</tr>
-<tr>
-  <td>spark.executor.extraClassPath</td>
-  <td>(none)</td>
   <td>
     Comma separated list of users that have view access to the Spark web ui. By default only the
     user that started the Spark job has view access.


### PR DESCRIPTION
resubmit of https://github.com/apache/spark/pull/636  for a totally different algorithm

https://issues.apache.org/jira/browse/SPARK-1706

In current implementation, the user has to start multiple workers in a server for starting multiple executors in a server, which introduces additional overhead due to the more JVM processes...

In this patch, I changed the scheduling logic in master to enable the user to start multiple executor processes within the same JVM process.
1. user configure spark.executor.maxCoreNumPerExecutor to suggest the maximum core he/she would like to allocate to each executor
2. Master assigns the executors to the workers with the major consideration on the memoryPerExecutor and the worker.freeMemory, and tries to allocate as many as possible cores to the executor `min(min(memoryPerExecutor, worker.freeCore), maxLeftCoreToAssign)` where `maxLeftCoreToAssign = maxExecutorCanAssign * maxCoreNumPerExecutor`

---

Other small changes include

change memoryPerSlave in ApplicationDescription to memoryPerExecutor, as "Slave" is overrided to represent both worker and executor in the documents... (we have some discussion on this before?)
