### PR TITLE
Add init script to the debian packaging

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -39,6 +39,7 @@
     <deb.pkg.name>apache-spark</deb.pkg.name>
     <deb.install.path>/usr/share/apache-spark</deb.install.path>
     <deb.user>root</deb.user>
+    <deb.group>root</deb.group>
   </properties>
 
   <dependencies>
@@ -243,8 +244,8 @@
                       <mapper>
                         <type>perm</type>
                         <user>${deb.user}</user>
-                        <group>${deb.user}</group>
-                        <prefix>${deb.install.path}/jars</prefix>
+                        <group>${deb.group}</group>
+                        <prefix>${deb.install.path}/lib</prefix>
                       </mapper>
                     </data>
                     <data>
@@ -253,17 +254,18 @@
                       <mapper>
                         <type>perm</type>
                         <user>${deb.user}</user>
-                        <group>${deb.user}</group>
+                        <group>${deb.group}</group>
                         <prefix>${deb.install.path}</prefix>
                       </mapper>
                     </data>
                     <data>
                       <src>${basedir}/../conf</src>
                       <type>directory</type>
+                      <excludes>.DS_Store</excludes>
                       <mapper>
                         <type>perm</type>
                         <user>${deb.user}</user>
-                        <group>${deb.user}</group>
+                        <group>${deb.group}</group>
                         <prefix>${deb.install.path}/conf</prefix>
                         <filemode>744</filemode>
                       </mapper>
@@ -271,10 +273,11 @@
                     <data>
                       <src>${basedir}/../bin</src>
                       <type>directory</type>
+                      <excludes>.DS_Store</excludes>
                       <mapper>
                         <type>perm</type>
                         <user>${deb.user}</user>
-                        <group>${deb.user}</group>
+                        <group>${deb.group}</group>
                         <prefix>${deb.install.path}/bin</prefix>
                         <filemode>744</filemode>
                       </mapper>
@@ -282,10 +285,11 @@
                     <data>
                       <src>${basedir}/../sbin</src>
                       <type>directory</type>
+                      <excludes>.DS_Store</excludes>
                       <mapper>
                         <type>perm</type>
                         <user>${deb.user}</user>
-                        <group>${deb.user}</group>
+                        <group>${deb.group}</group>
                         <prefix>${deb.install.path}/sbin</prefix>
                         <filemode>744</filemode>
                       </mapper>
@@ -293,12 +297,47 @@
                     <data>
                       <src>${basedir}/../python</src>
                       <type>directory</type>
+                      <excludes>.DS_Store</excludes>
                       <mapper>
                         <type>perm</type>
                         <user>${deb.user}</user>
-                        <group>${deb.user}</group>
+                        <group>${deb.group}</group>
                         <prefix>${deb.install.path}/python</prefix>
                         <filemode>744</filemode>
+                      </mapper>
+                    </data>
+                    <data>
+                      <src>${basedir}/src/deb/default/</src>
+                      <type>directory</type>
+                      <excludes>.DS_Store</excludes>
+                      <mapper>
+                        <type>perm</type>
+                        <prefix>/etc/default</prefix>
+                        <user>${deb.user}</user>
+                        <group>${deb.group}</group>
+                      </mapper>
+                    </data>
+                    <data>
+                      <src>${basedir}/src/deb/init.d/</src>
+                      <type>directory</type>
+                      <excludes>.DS_Store</excludes>
+                      <mapper>
+                        <type>perm</type>
+                        <prefix>/etc/init.d</prefix>
+                        <filemode>755</filemode>
+                        <user>${deb.user}</user>
+                        <group>${deb.group}</group>
+                      </mapper>
+                    </data>
+                    <data>
+                      <src>${basedir}/src/deb/etc/</src>
+                      <type>directory</type>
+                      <excludes>.DS_Store</excludes>
+                      <mapper>
+                        <type>perm</type>
+                        <prefix>/etc/apache-spark</prefix>
+                        <user>${deb.user}</user>
+                        <group>${deb.group}</group>
                       </mapper>
                     </data>
                   </dataSet>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -36,8 +36,8 @@
     <spark.jar.dir>scala-${scala.binary.version}</spark.jar.dir>
     <spark.jar.basename>spark-assembly-${project.version}-hadoop${hadoop.version}.jar</spark.jar.basename>
     <spark.jar>${project.build.directory}/${spark.jar.dir}/${spark.jar.basename}</spark.jar>
-    <deb.pkg.name>spark</deb.pkg.name>
-    <deb.install.path>/usr/share/spark</deb.install.path>
+    <deb.pkg.name>apache-spark</deb.pkg.name>
+    <deb.install.path>/usr/share/apache-spark</deb.install.path>
     <deb.user>root</deb.user>
   </properties>
 

--- a/assembly/src/deb/control/conffiles
+++ b/assembly/src/deb/control/conffiles
@@ -1,0 +1,2 @@
+/etc/default/apache-spark
+/etc/apache-spark/log4j.properties

--- a/assembly/src/deb/control/postinst
+++ b/assembly/src/deb/control/postinst
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -e
+
+SPARK_HOME=/usr/share/apache-spark
+SPARK_LOG_DIR=/var/log/apache-spark
+SPARK_USER=apache-spark
+SPARK_GROUP=apache-spark
+
+[ -f /etc/default/apache-spark ] && . /etc/default/apache-spark
+
+case "$1" in
+	configure)
+	if ! getent group "$SPARK_GROUP" > /dev/null 2>&1 ; then
+	    addgroup --system "$SPARK_GROUP" --quiet
+	fi
+	if ! id $SPARK_USER > /dev/null 2>&1 ; then
+	    adduser --system --home "$SPARK_HOME" --no-create-home \
+		--ingroup "$SPARK_GROUP" --disabled-password --shell /bin/false \
+		"$SPARK_USER"
+	fi
+
+	# Set user permissions on /var/log/spark
+	mkdir -p $SPARK_LOG_DIR
+	chown -R $SPARK_USER:$SPARK_GROUP $SPARK_LOG_DIR
+	chmod 755 $SPARK_LOG_DIR
+
+	# this is a fresh installation
+	if [ -z $2 ] ; then
+        echo "### To start a Spark master by default on bootup, please execute"
+        echo " sudo update-rc.d spark-master defaults 95 10"
+        echo "### To start a Spark slave by default on bootup, please execute"
+        echo " sudo update-rc.d spark-slave defaults 95 10"
+        echo "### In order to start a Spark master, execute"
+        echo " sudo /etc/init.d/spark-master start"
+        echo "### In order to start a Spark slave, execute"
+        echo " sudo /etc/init.d/spark-slave start"
+	fi
+	;;
+esac
+

--- a/assembly/src/deb/control/postrm
+++ b/assembly/src/deb/control/postrm
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -e
+
+SPARK_LOG_DIR=/var/log/apache-spark
+SPARK_WORKER_DIR=/tmp/apache-spark-worker
+SPARK_USER=apache-spark
+SPARK_GROUP=apache-spark
+
+[ -f /etc/default/apache-spark ] && . /etc/default/apache-spark
+
+case "$1" in
+    remove)
+        # Remove logs
+        rm -rf $SPARK_LOG_DIR
+    ;;
+
+    purge)
+    	# Remove service
+        update-rc.d apache-spark-master remove >/dev/null || true
+        update-rc.d apache-spark-slave remove >/dev/null || true
+
+        # Remove logs
+        rm -rf $SPARK_LOG_DIR
+        # Remove worker dir
+        rm -rf $SPARK_WORKER_DIR
+
+        # Remove user/group
+        deluser $SPARK_USER || true
+        delgroup $SPARK_GROUP || true
+    ;;
+
+    upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+        # Nothing to do here
+    ;;
+
+    *)
+        echo "$0 called with unknown argument \`$1'" >&2
+        exit 1
+    ;;
+esac

--- a/assembly/src/deb/control/prerm
+++ b/assembly/src/deb/control/prerm
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+stopSpark() {
+	if [ -x "/etc/init.d/apache-spark-slave" ]; then
+		if [ -x "`which invoke-rc.d 2>/dev/null`" ]; then
+			invoke-rc.d apache-spark-slave stop || true
+		else
+			/etc/init.d/apache-spark-slave stop || true
+		fi
+	fi
+	if [ -x "/etc/init.d/apache-spark-master" ]; then
+		if [ -x "`which invoke-rc.d 2>/dev/null`" ]; then
+			invoke-rc.d apache-spark-master stop || true
+		else
+			/etc/init.d/apache-spark-master stop || true
+		fi
+	fi
+}
+
+case "$1" in
+	upgrade)
+	# since we don't know which service to restart, don't stop anything
+	#stopSpark
+	;;
+	remove)
+	stopSpark
+	;;
+esac

--- a/assembly/src/deb/default/apache-spark
+++ b/assembly/src/deb/default/apache-spark
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -17,30 +15,9 @@
 # limitations under the License.
 #
 
-# This script loads spark-env.sh if it exists, and ensures it is only loaded once.
-# spark-env.sh is loaded from SPARK_CONF_DIR if set, or within the current directory's
-# conf/ subdirectory.
+# This is the user editable configuration for spark master and slave
 
-if [ -z "$SPARK_ENV_LOADED" ]; then
-  export SPARK_ENV_LOADED=1
-
-  # Returns the parent of the directory this script lives in.
-  parent_dir="$(cd `dirname $0`/..; pwd)"
-
-  use_conf_dir=${SPARK_CONF_DIR:-"$parent_dir/conf"}
-
-  if [ -f "${use_conf_dir}/spark-env.sh" ]; then
-    # Promote all variable declarations to environment (exported) variables
-    set -a
-    . "${use_conf_dir}/spark-env.sh"
-    set +a
-  fi
-
-  # load the debian default conf, if any
-  if [ -f "/etc/default/spark" ]; then
-    set -a
-    . "/etc/default/spark"
-    set +a
-  fi
-
-fi
+# For any insight of which environment variable is useful, see
+# - /usr/share/apache-spark/conf/spark-env.sh.template
+# - /usr/share/apache-spark/bin/*.sh
+# - /usr/share/apache-spark/sbin/*.sh

--- a/assembly/src/deb/etc/README
+++ b/assembly/src/deb/etc/README
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -17,30 +15,6 @@
 # limitations under the License.
 #
 
-# This script loads spark-env.sh if it exists, and ensures it is only loaded once.
-# spark-env.sh is loaded from SPARK_CONF_DIR if set, or within the current directory's
-# conf/ subdirectory.
+This folder is the "conf" folder for Spark when launch via the init debian scripts.
 
-if [ -z "$SPARK_ENV_LOADED" ]; then
-  export SPARK_ENV_LOADED=1
-
-  # Returns the parent of the directory this script lives in.
-  parent_dir="$(cd `dirname $0`/..; pwd)"
-
-  use_conf_dir=${SPARK_CONF_DIR:-"$parent_dir/conf"}
-
-  if [ -f "${use_conf_dir}/spark-env.sh" ]; then
-    # Promote all variable declarations to environment (exported) variables
-    set -a
-    . "${use_conf_dir}/spark-env.sh"
-    set +a
-  fi
-
-  # load the debian default conf, if any
-  if [ -f "/etc/default/spark" ]; then
-    set -a
-    . "/etc/default/spark"
-    set +a
-  fi
-
-fi
+Some template files can be found in /usr/share/apache-spark/conf/

--- a/assembly/src/deb/etc/log4j.properties
+++ b/assembly/src/deb/etc/log4j.properties
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -17,30 +15,14 @@
 # limitations under the License.
 #
 
-# This script loads spark-env.sh if it exists, and ensures it is only loaded once.
-# spark-env.sh is loaded from SPARK_CONF_DIR if set, or within the current directory's
-# conf/ subdirectory.
+# Set everything to be logged to the console
+log4j.rootCategory=INFO, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
 
-if [ -z "$SPARK_ENV_LOADED" ]; then
-  export SPARK_ENV_LOADED=1
-
-  # Returns the parent of the directory this script lives in.
-  parent_dir="$(cd `dirname $0`/..; pwd)"
-
-  use_conf_dir=${SPARK_CONF_DIR:-"$parent_dir/conf"}
-
-  if [ -f "${use_conf_dir}/spark-env.sh" ]; then
-    # Promote all variable declarations to environment (exported) variables
-    set -a
-    . "${use_conf_dir}/spark-env.sh"
-    set +a
-  fi
-
-  # load the debian default conf, if any
-  if [ -f "/etc/default/spark" ]; then
-    set -a
-    . "/etc/default/spark"
-    set +a
-  fi
-
-fi
+# Settings to quiet third party logs that are too verbose
+log4j.logger.org.eclipse.jetty=WARN
+log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO
+log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO

--- a/assembly/src/deb/init.d/apache-spark-master
+++ b/assembly/src/deb/init.d/apache-spark-master
@@ -1,0 +1,89 @@
+#!/bin/sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# /etc/init.d/apache-spark-master -- startup script for the Spark master
+#
+### BEGIN INIT INFO
+# Provides:          apache-spark-master
+# Required-Start:    $network $named
+# Required-Stop:     $network $named
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Starts Apache Spark master
+# Description:       Starts Apache Spark matser
+### END INIT INFO
+
+DESC="Apache Spark master"
+NAME=apache-spark-master
+
+export SPARK_HOME=/usr/share/apache-spark
+export SPARK_PREFIX=$SPARK_HOME
+export SPARK_CONF_DIR=/etc/apache-spark
+export SPARK_LOG_DIR=/var/log/apache-spark
+export SPARK_PID_DIR=/var/run/
+export SPARK_USER=apache-spark
+export SPARK_IDENT_STRING=$SPARK_USER
+
+# ensure we don't try compute incorrect path
+export SPARK_CONFIG_LOADED=1
+
+if [ `id -u` -ne 0 ]; then
+	echo "You need root privileges to run this script"
+	exit 1
+fi
+
+. /lib/lsb/init-functions
+
+if [ -r /etc/default/rcS ]; then
+	. /etc/default/rcS
+fi
+
+. "$SPARK_HOME/bin/load-spark-env.sh"
+
+set -a
+[ -f /etc/default/apache-spark ] && . /etc/default/apache-spark
+set -a
+
+if [ "$SPARK_MASTER_PORT" = "" ]; then
+  SPARK_MASTER_PORT=7077
+fi
+if [ "$SPARK_MASTER_IP" = "" ]; then
+  SPARK_MASTER_IP=`hostname`
+fi
+if [ "$SPARK_MASTER_WEBUI_PORT" = "" ]; then
+  SPARK_MASTER_WEBUI_PORT=8080
+fi
+
+case "$1" in
+  start)
+	log_daemon_msg "Starting Spark master"
+	"$SPARK_HOME/sbin/spark-daemon.sh" start org.apache.spark.deploy.master.Master 1 --ip $SPARK_MASTER_IP --port $SPARK_MASTER_PORT --webui-port $SPARK_MASTER_WEBUI_PORT
+	log_end_msg $?
+	;;
+  stop)
+	log_daemon_msg "Stopping Spark master"
+	"$SPARK_HOME/sbin/spark-daemon.sh" stop org.apache.spark.deploy.master.Master 1
+	log_end_msg 0
+	;;
+  *)
+	log_success_msg "Usage: $0 {start|stop}"
+	exit 1
+	;;
+esac
+
+exit 0

--- a/assembly/src/deb/init.d/apache-spark-slave
+++ b/assembly/src/deb/init.d/apache-spark-slave
@@ -1,0 +1,110 @@
+#!/bin/sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# /etc/init.d/apache-spark-slave -- startup script for a Spark slave
+#
+### BEGIN INIT INFO
+# Provides:          apache-spark-slave
+# Required-Start:    $network $named
+# Required-Stop:     $network $named
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Starts a Apache Spark slave
+# Description:       Starts a Apache Spark slave
+### END INIT INFO
+
+DESC="Apache Spark slave"
+NAME=apache-spark-slave
+
+export SPARK_HOME=/usr/share/apache-spark
+export SPARK_PREFIX=$SPARK_HOME
+export SPARK_CONF_DIR=/etc/apache-spark
+export SPARK_LOG_DIR=/var/log/apache-spark
+export SPARK_PID_DIR=/var/run/
+export SPARK_WORKER_DIR=/tmp/apache-spark-worker
+export SPARK_USER=apache-spark
+export SPARK_GROUP=apache-spark
+export SPARK_IDENT_STRING=$SPARK_USER
+
+# ensure we don't try compute incorrect path
+export SPARK_CONFIG_LOADED=1
+
+if [ `id -u` -ne 0 ]; then
+	echo "You need root privileges to run this script"
+	exit 1
+fi
+
+. /lib/lsb/init-functions
+
+if [ -r /etc/default/rcS ]; then
+	. /etc/default/rcS
+fi
+
+. "$SPARK_HOME/bin/load-spark-env.sh"
+
+set -a
+[ -f /etc/default/apache-spark ] && . /etc/default/apache-spark
+set -a
+
+if [ "$SPARK_MASTER_PORT" = "" ]; then
+  SPARK_MASTER_PORT=7077
+fi
+if [ "$SPARK_MASTER_IP" = "" ]; then
+  SPARK_MASTER_IP=`hostname`
+fi
+
+case "$1" in
+  start)
+    #make sure the worker dir exists and has the proper rights
+    mkdir $SPARK_WORKER_DIR
+    chown -R $SPARK_USER:$SPARK_GROUP $SPARK_WORKER_DIR
+
+    if [ "$SPARK_WORKER_INSTANCES" = "" ]; then
+	  log_daemon_msg "Starting Spark slave"
+      "$SPARK_HOME/sbin/spark-daemon.sh" start org.apache.spark.deploy.worker.Worker 1 spark://$SPARK_MASTER_IP:$SPARK_MASTER_PORT
+    else
+      i=0
+      while [ $i -lt $SPARK_WORKER_INSTANCES ]; do
+        i=`expr $i + 1`
+      	log_daemon_msg "Starting Spark slave $i"
+        "$SPARK_HOME/sbin/spark-daemon.sh" start org.apache.spark.deploy.worker.Worker $i spark://$SPARK_MASTER_IP:$SPARK_MASTER_PORT
+      done
+    fi
+	log_end_msg $?
+	;;
+  stop)
+    if [ "$SPARK_WORKER_INSTANCES" = "" ]; then
+	  log_daemon_msg "Stopping Spark slave"
+      "$SPARK_HOME/sbin/spark-daemon.sh" stop org.apache.spark.deploy.worker.Worker 1
+    else
+      i=0
+      while [ $i -lt $SPARK_WORKER_INSTANCES ]; do
+        i=`expr $i + 1`
+        log_daemon_msg "Stopping Spark slave $i"
+        "$SPARK_HOME/sbin/spark-daemon.sh" stop org.apache.spark.deploy.worker.Worker $i
+      done
+    fi
+	log_end_msg 0
+	;;
+  *)
+	log_success_msg "Usage: $0 {start|stop}"
+	exit 1
+	;;
+esac
+
+exit 0

--- a/bin/compute-classpath.sh
+++ b/bin/compute-classpath.sh
@@ -27,8 +27,12 @@ FWDIR="$(cd `dirname $0`/..; pwd)"
 
 . $FWDIR/bin/load-spark-env.sh
 
+if [ "$SPARK_CONF_DIR" = "" ]; then
+  export SPARK_CONF_DIR="$FWDIR/conf"
+fi
+
 # Build up classpath
-CLASSPATH="$SPARK_CLASSPATH:$SPARK_SUBMIT_CLASSPATH:$FWDIR/conf"
+CLASSPATH="$SPARK_CLASSPATH:$SPARK_SUBMIT_CLASSPATH:$SPARK_CONF_DIR"
 
 ASSEMBLY_DIR="$FWDIR/assembly/target/scala-$SCALA_VERSION"
 

--- a/bin/spark-class
+++ b/bin/spark-class
@@ -42,6 +42,10 @@ if [ -n "$SPARK_MEM" ]; then
   echo -e "(e.g., spark.executor.memory or SPARK_DRIVER_MEMORY)." 1>&2
 fi
 
+if [ "$SPARK_CONF_DIR" = "" ]; then
+  export SPARK_CONF_DIR="$FWDIR/conf"
+fi
+
 # Use SPARK_MEM or 512m as the default memory, to be overridden by specific options
 DEFAULT_MEM=${SPARK_MEM:-512m}
 
@@ -102,8 +106,8 @@ fi
 JAVA_OPTS="-XX:MaxPermSize=128m $OUR_JAVA_OPTS"
 JAVA_OPTS="$JAVA_OPTS -Xms$OUR_JAVA_MEM -Xmx$OUR_JAVA_MEM"
 # Load extra JAVA_OPTS from conf/java-opts, if it exists
-if [ -e "$FWDIR/conf/java-opts" ] ; then
-  JAVA_OPTS="$JAVA_OPTS `cat $FWDIR/conf/java-opts`"
+if [ -e "$SPARK_CONF_DIR/java-opts" ] ; then
+  JAVA_OPTS="$JAVA_OPTS `cat $SPARK_CONF_DIR/java-opts`"
 fi
 export JAVA_OPTS
 # Attention: when changing the way the JAVA_OPTS are assembled, the change must be reflected in CommandUtils.scala!
@@ -152,4 +156,8 @@ if [ "$SPARK_PRINT_LAUNCH_COMMAND" == "1" ]; then
   echo -e "========================================\n" 1>&2
 fi
 
-exec "$RUNNER" -cp "$CLASSPATH" $JAVA_OPTS "$@"
+if [ "$SPARK_USER" = "" ]; then
+  exec "$RUNNER" -cp "$CLASSPATH" $JAVA_OPTS "$@"
+else
+  exec sudo -E -u $SPARK_USER "$RUNNER" -cp "$CLASSPATH" $JAVA_OPTS "$@"
+fi

--- a/sbin/spark-config.sh
+++ b/sbin/spark-config.sh
@@ -19,21 +19,25 @@
 # should not be executable directly
 # also should not be passed any arguments, since we need original $*
 
-# resolve links - $0 may be a softlink
-this="${BASH_SOURCE-$0}"
-common_bin=$(cd -P -- "$(dirname -- "$this")" && pwd -P)
-script="$(basename -- "$this")"
-this="$common_bin/$script"
+if [ -z "$SPARK_CONFIG_LOADED" ]; then
+    export SPARK_CONFIG_LOADED=1
 
-# convert relative path to absolute path
-config_bin=`dirname "$this"`
-script=`basename "$this"`
-config_bin=`cd "$config_bin"; pwd`
-this="$config_bin/$script"
+    # resolve links - $0 may be a softlink
+    this="${BASH_SOURCE-$0}"
+    common_bin=$(cd -P -- "$(dirname -- "$this")" && pwd -P)
+    script="$(basename -- "$this")"
+    this="$common_bin/$script"
 
-export SPARK_PREFIX=`dirname "$this"`/..
-export SPARK_HOME=${SPARK_PREFIX}
-export SPARK_CONF_DIR="$SPARK_HOME/conf"
-# Add the PySpark classes to the PYTHONPATH:
-export PYTHONPATH=$SPARK_HOME/python:$PYTHONPATH
-export PYTHONPATH=$SPARK_HOME/python/lib/py4j-0.8.1-src.zip:$PYTHONPATH
+    # convert relative path to absolute path
+    config_bin=`dirname "$this"`
+    script=`basename "$this"`
+    config_bin=`cd "$config_bin"; pwd`
+    this="$config_bin/$script"
+
+    export SPARK_PREFIX=`dirname "$this"`/..
+    export SPARK_HOME=${SPARK_PREFIX}
+    export SPARK_CONF_DIR="$SPARK_HOME/conf"
+    # Add the PySpark classes to the PYTHONPATH:
+    export PYTHONPATH=$SPARK_HOME/python:$PYTHONPATH
+    export PYTHONPATH=$SPARK_HOME/python/lib/py4j-0.8.1-src.zip:$PYTHONPATH
+fi

--- a/sbin/spark-daemon.sh
+++ b/sbin/spark-daemon.sh
@@ -123,6 +123,10 @@ if [ "$SPARK_NICENESS" = "" ]; then
     export SPARK_NICENESS=0
 fi
 
+sudoUser=""
+if [ "$SPARK_USER" = "" ]; then
+    sudoUser = "sudo -u $SPARK_USER"
+fi
 
 case $startStop in
 
@@ -145,7 +149,7 @@ case $startStop in
     spark_rotate_log "$log"
     echo starting $command, logging to $log
     cd "$SPARK_PREFIX"
-    nohup nice -n $SPARK_NICENESS "$SPARK_PREFIX"/bin/spark-class $command "$@" >> "$log" 2>&1 < /dev/null &
+    nohup nice -n $SPARK_NICENESS $sudoUser "$SPARK_PREFIX"/bin/spark-class $command "$@" >> "$log" 2>&1 < /dev/null &
     newpid=$!
     echo $newpid > $pid
     sleep 2


### PR DESCRIPTION
This patch add init scripts to the debian packaging

The debian package has been renamed to apache-spark because a package spark already exists:
http://packages.ubuntu.com/trusty/spark

I'm not an expert in init script, most of the code has been inspired by the ones for elasticsearch and cassandra.

It seems that usual init script relies on a predefined function start-stop-daemon. Since the daemonization is already handled by spark's scripts, in order to avoid a refactoring, I tried to make the best of not modifying much spark scripts.
