### PR TITLE
use Iterator#size in RDD#count

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -844,7 +844,7 @@ abstract class RDD[T: ClassTag](
   /**
    * Return the number of elements in the RDD.
    */
-  def count(): Long = sc.runJob(this, Utils.getIteratorSize _).sum
+  def count(): Long = sc.runJob(this, (_: Iterator[T]).size).sum
 
   /**
    * :: Experimental ::

--- a/core/src/main/scala/org/apache/spark/rdd/ZippedWithIndexRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ZippedWithIndexRDD.scala
@@ -49,7 +49,7 @@ class ZippedWithIndexRDD[T: ClassTag](@transient prev: RDD[T]) extends RDD[(T, L
       } else {
         prev.context.runJob(
           prev,
-          Utils.getIteratorSize _,
+          (_: Iterator[T]).size,
           0 until n - 1, // do not need to count the last partition
           false
         ).scanLeft(0L)(_ + _)

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -990,20 +990,6 @@ private[spark] object Utils extends Logging {
   }
 
   /**
-   * Counts the number of elements of an iterator using a while loop rather than calling
-   * [[scala.collection.Iterator#size]] because it uses a for loop, which is slightly slower
-   * in the current version of Scala.
-   */
-  def getIteratorSize[T](iterator: Iterator[T]): Long = {
-    var count = 0L
-    while (iterator.hasNext) {
-      count += 1L
-      iterator.next()
-    }
-    count
-  }
-
-  /**
    * Creates a symlink. Note jdk1.7 has Files.createSymbolicLink but not used here
    * for jdk1.6 support.  Supports windows by doing copy, everything else uses "ln -sf".
    * @param src absolute path to the source

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -148,13 +148,6 @@ class UtilsSuite extends FunSuite {
     assert(Utils.deserializeLongValue(bbuf.array) === testval)
   }
 
-  test("get iterator size") {
-    val empty = Seq[Int]()
-    assert(Utils.getIteratorSize(empty.toIterator) === 0L)
-    val iterator = Iterator.range(0, 5)
-    assert(Utils.getIteratorSize(iterator) === 5L)
-  }
-
   test("findOldFiles") {
     // create some temporary directories and files
     val parent: File = Utils.createTempDir()


### PR DESCRIPTION
in RDD#count, we used while loop to get the size of Iterator because that Iterator#size used a for loop, which was slightly slower in that version of Scala. But for now, the current version of scala will translate the for loop in Iterator#size into `foreach`, which uses while loop to iterate the Iterator. So we can use Iterator#size directly now.
