### PR TITLE
[SQL] Make Hive Metastore conversion functions publicly visible.

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -26,6 +26,7 @@ import org.apache.hadoop.hive.ql.plan.TableDesc
 import org.apache.hadoop.hive.ql.session.SessionState
 import org.apache.hadoop.hive.serde2.Deserializer
 
+import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.sql.Logging
 import org.apache.spark.sql.catalyst.analysis.{EliminateAnalysisOperators, Catalog}
 import org.apache.spark.sql.catalyst.expressions._
@@ -172,7 +173,12 @@ private[hive] class HiveMetastoreCatalog(hive: HiveContext) extends Catalog with
   override def unregisterAllTables() = {}
 }
 
-private[hive] object HiveMetastoreTypes extends RegexParsers {
+/**
+ * :: DeveloperApi ::
+ * Provides conversions between Spark SQL data types and Hive Metastore types.
+ */
+@DeveloperApi
+object HiveMetastoreTypes extends RegexParsers {
   protected lazy val primitiveType: Parser[DataType] =
     "string" ^^^ StringType |
     "float" ^^^ FloatType |


### PR DESCRIPTION
I need this to be public for the implementation of SharkServer2.  However, I think this functionality is generally useful and should be pretty stable.
