### PR TITLE
[SPARK-1819] [SQL] Fix GetField.nullable.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypes.scala
@@ -74,7 +74,7 @@ case class GetField(child: Expression, fieldName: String) extends UnaryExpressio
   type EvaluatedType = Any
 
   def dataType = field.dataType
-  override def nullable = field.nullable
+  override def nullable = child.nullable || field.nullable
   override def foldable = child.foldable
 
   protected def structType = child.dataType match {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvaluationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvaluationSuite.scala
@@ -364,6 +364,18 @@ class ExpressionEvaluationSuite extends FunSuite {
 
     checkEvaluation(GetField(BoundReference(2, AttributeReference("c", typeS)()), "a"), "aa", row)
     checkEvaluation(GetField(Literal(null, typeS), "a"), null, row)
+
+    val typeS_notNullable = StructType(
+      StructField("a", StringType, false) :: StructField("b", StringType, false) :: Nil
+    )
+
+    assert(GetField(BoundReference(2,
+      AttributeReference("c", typeS)()), "a").nullable === true)
+    assert(GetField(BoundReference(2,
+      AttributeReference("c", typeS_notNullable, false)()), "a").nullable === false)
+
+    assert(GetField(Literal(null, typeS), "a").nullable === true)
+    assert(GetField(Literal(null, typeS_notNullable), "a").nullable === true)
   }
 
   test("arithmetic") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvaluationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvaluationSuite.scala
@@ -366,13 +366,14 @@ class ExpressionEvaluationSuite extends FunSuite {
     checkEvaluation(GetField(Literal(null, typeS), "a"), null, row)
 
     val typeS_notNullable = StructType(
-      StructField("a", StringType, false) :: StructField("b", StringType, false) :: Nil
+      StructField("a", StringType, nullable = false)
+        :: StructField("b", StringType, nullable = false) :: Nil
     )
 
     assert(GetField(BoundReference(2,
       AttributeReference("c", typeS)()), "a").nullable === true)
     assert(GetField(BoundReference(2,
-      AttributeReference("c", typeS_notNullable, false)()), "a").nullable === false)
+      AttributeReference("c", typeS_notNullable, nullable = false)()), "a").nullable === false)
 
     assert(GetField(Literal(null, typeS), "a").nullable === true)
     assert(GetField(Literal(null, typeS_notNullable), "a").nullable === true)


### PR DESCRIPTION
`GetField.nullable` should be `true` not only when `field.nullable` is `true` but also when `child.nullable` is `true`.
