### PR TITLE
SPARK-1829 Sub-second durations shouldn't round to "0 s"

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -36,7 +36,13 @@ private[spark] object UIUtils extends Logging {
   def formatDate(timestamp: Long): String = dateFormat.get.format(new Date(timestamp))
 
   def formatDuration(milliseconds: Long): String = {
+    if (milliseconds < 100) {
+      return "%d ms".format(milliseconds)
+    }
     val seconds = milliseconds.toDouble / 1000
+    if (seconds < 1) {
+      return "%.1f s".format(seconds)
+    }
     if (seconds < 60) {
       return "%.0f s".format(seconds)
     }


### PR DESCRIPTION
As "99 ms" up to 99 ms
As "0.1 s" from 0.1 s up to 0.9 s

https://issues.apache.org/jira/browse/SPARK-1829

Compare the first image to the second here: http://imgur.com/RaLEsSZ,7VTlgfo#0
