### PR TITLE
[FIX] do not load defaults when testing SparkConf in pyspark

### DIFF
--- a/python/pyspark/conf.py
+++ b/python/pyspark/conf.py
@@ -33,7 +33,7 @@ u'My app'
 >>> sc.sparkHome == None
 True
 
->>> conf = SparkConf()
+>>> conf = SparkConf(loadDefaults=False)
 >>> conf.setSparkHome("/path")
 <pyspark.conf.SparkConf object at ...>
 >>> conf.get("spark.home")


### PR DESCRIPTION
The default constructor loads default properties, which can fail the test.
