### PR TITLE
[SPARK-1696][MLLIB] use alpha in dense dspr

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/RowMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/RowMatrix.scala
@@ -440,7 +440,7 @@ object RowMatrix {
     val n = v.size
     v match {
       case dv: DenseVector =>
-        blas.dspr("U", n, 1.0, dv.values, 1, U)
+        blas.dspr("U", n, alpha, dv.values, 1, U)
       case sv: SparseVector =>
         val indices = sv.indices
         val values = sv.values


### PR DESCRIPTION
It doesn't affect existing code because only `alpha = 1.0` is used in the code.
