### PR TITLE
[SPARK-1840] SparkListenerBus prints out scary error message when terminated normally

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1149,6 +1149,8 @@ private[spark] object Utils extends Logging {
     try {
       f
     } catch {
+      case ct: ControlThrowable =>
+        throw ct
       case t: Throwable =>
         logError(s"Uncaught exception in thread ${Thread.currentThread().getName}", t)
         throw t


### PR DESCRIPTION
Running SparkPi example gave this error.

```
Pi is roughly 3.14374
14/05/14 18:16:19 ERROR Utils: Uncaught exception in thread SparkListenerBus
scala.runtime.NonLocalReturnControl$mcV$sp
```

This is due to the catch-all in the SparkListenerBus, which logged control throwable used by scala system 
