### PR TITLE
Consistency for function naming in Duration

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/Duration.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/Duration.scala
@@ -46,9 +46,9 @@ case class Duration (private val millis: Long) {
 
   def isZero: Boolean = (this.millis == 0)
 
-  override def toString: String = (millis.toString + " ms")
+  override def toString: String = millis.toString
 
-  def toFormattedString: String = millis.toString
+  def toFormattedString: String =  (millis.toString + " ms")
 
   def milliseconds: Long = millis
 


### PR DESCRIPTION
toFormattedString should represent formatted millisecond like "10 ms" not simply give back "10"
toString should represent string of duration. It should simply give back string of millisecond.

Currently like this. 

```
duration = Duration(10)
duration.toString()
>> "10 ms"
duration.toFormattedString()
>> "10"
```

Should be 

```
duration = Duration(10)
duration.toString()
>> "10"
duration.toFormattedString()
>> "10 ms"
```

Please explain what does "formatted" mean? Why does it simply give millisecond with string?
