### PR TITLE
SPARK-1869: 'spark-shell --help' fails if called from outside spark home

### DIFF
--- a/bin/spark-shell
+++ b/bin/spark-shell
@@ -28,14 +28,14 @@ esac
 # Enter posix mode for bash
 set -o posix
 
-if [[ "$@" = *--help ]] || [[ "$@" = *-h ]]; then
-  echo "Usage: ./bin/spark-shell [options]"
-  ./bin/spark-submit --help 2>&1 | grep -v Usage 1>&2
-  exit 0
-fi
-
 ## Global script variables
 FWDIR="$(cd `dirname $0`/..; pwd)"
+
+if [[ "$@" = *--help ]] || [[ "$@" = *-h ]]; then
+  echo "Usage: ./bin/spark-shell [options]"
+  $FWDIR/bin/spark-submit --help 2>&1 | grep -v Usage 1>&2
+  exit 0
+fi
 
 function main(){
     if $cygwin; then
@@ -88,4 +88,3 @@ main "$@"
 # then reenable echo and propagate the code.
 exit_status=$?
 onExit
-


### PR DESCRIPTION
The fix is simple, we just use the full path as in other places where we invoke the shell.
