### PR TITLE
[SPARK-1880] [SQL] Eliminate unnecessary job executions.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins.scala
@@ -211,28 +211,28 @@ case class BroadcastNestedLoopJoin(
       Iterator((matchedRows, includedBroadcastTuples))
     }
 
-    val includedBroadcastTuples = streamedPlusMatches.map(_._2)
-    val allIncludedBroadcastTuples =
-      if (includedBroadcastTuples.count == 0) {
-        new scala.collection.mutable.BitSet(broadcastedRelation.value.size)
-      } else {
-        streamedPlusMatches.map(_._2).reduce(_ ++ _)
-      }
+    if (joinType == RightOuter || joinType == FullOuter) {
+      val includedBroadcastTuples = streamedPlusMatches.map(_._2)
+      val allIncludedBroadcastTuples =
+        if (includedBroadcastTuples.count == 0) {
+          new scala.collection.mutable.BitSet(broadcastedRelation.value.size)
+        } else {
+          streamedPlusMatches.map(_._2).reduce(_ ++ _)
+        }
 
-    val rightOuterMatches: Seq[Row] =
-      if (joinType == RightOuter || joinType == FullOuter) {
+      val rightOuterMatches: Seq[Row] =
         broadcastedRelation.value.zipWithIndex.filter {
           case (row, i) => !allIncludedBroadcastTuples.contains(i)
         }.map {
           // TODO: Use projection.
           case (row, _) => buildRow(Vector.fill(left.output.size)(null) ++ row)
         }
-      } else {
-        Vector()
-      }
 
-    // TODO: Breaks lineage.
-    sc.union(
-      streamedPlusMatches.flatMap(_._1), sc.makeRDD(rightOuterMatches))
+      // TODO: Breaks lineage.
+      sc.union(
+        streamedPlusMatches.flatMap(_._1), sc.makeRDD(rightOuterMatches))
+    } else {
+      streamedPlusMatches.flatMap(_._1)
+    }
   }
 }


### PR DESCRIPTION
There are unnecessary job executions in `BroadcastNestedLoopJoin`.

When `Innner` or `LeftOuter` join, preparation of `rightOuterMatches` for `RightOuter` or `FullOuter` join is not neccessary.
And when `RightOuter` or `FullOuter`, it should use not `count` and then `reduce` but `fold`.
