### PR TITLE
Spark 1857 improve error message when trying perform a spark operation inside another spark operation

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/CoGroupedRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/CoGroupedRDD.scala
@@ -110,7 +110,7 @@ class CoGroupedRDD[K](@transient var rdds: Seq[RDD[_ <: Product2[K, _]]], part: 
     array
   }
 
-  @transient override val partitioner: Some[Partitioner] = Some(part)
+  @transient override val getPartitioner: Some[Partitioner] = Some(part)
 
   override def compute(s: Partition, context: TaskContext): Iterator[(K, CoGroupCombiner)] = {
     val sparkConf = SparkEnv.get.conf

--- a/core/src/main/scala/org/apache/spark/rdd/CoGroupedRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/CoGroupedRDD.scala
@@ -83,7 +83,7 @@ class CoGroupedRDD[K](@transient var rdds: Seq[RDD[_ <: Product2[K, _]]], part: 
 
   override def getDependencies: Seq[Dependency[_]] = {
     rdds.map { rdd: RDD[_ <: Product2[K, _]] =>
-      if (rdd.getPartitioner == Some(part)) {
+      if (rdd.partitioner == Some(part)) {
         logDebug("Adding one-to-one dependency with " + rdd)
         new OneToOneDependency(rdd)
       } else {
@@ -110,7 +110,7 @@ class CoGroupedRDD[K](@transient var rdds: Seq[RDD[_ <: Product2[K, _]]], part: 
     array
   }
 
-  override val partitioner: Some[Partitioner] = Some(part)
+  @transient override val partitioner: Some[Partitioner] = Some(part)
 
   override def compute(s: Partition, context: TaskContext): Iterator[(K, CoGroupCombiner)] = {
     val sparkConf = SparkEnv.get.conf

--- a/core/src/main/scala/org/apache/spark/rdd/CoGroupedRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/CoGroupedRDD.scala
@@ -110,7 +110,7 @@ class CoGroupedRDD[K](@transient var rdds: Seq[RDD[_ <: Product2[K, _]]], part: 
     array
   }
 
-  @transient override val getPartitioner: Some[Partitioner] = Some(part)
+  @transient override val partitioner: Some[Partitioner] = Some(part)
 
   override def compute(s: Partition, context: TaskContext): Iterator[(K, CoGroupCombiner)] = {
     val sparkConf = SparkEnv.get.conf

--- a/core/src/main/scala/org/apache/spark/rdd/CoGroupedRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/CoGroupedRDD.scala
@@ -83,7 +83,7 @@ class CoGroupedRDD[K](@transient var rdds: Seq[RDD[_ <: Product2[K, _]]], part: 
 
   override def getDependencies: Seq[Dependency[_]] = {
     rdds.map { rdd: RDD[_ <: Product2[K, _]] =>
-      if (rdd.partitioner == Some(part)) {
+      if (rdd.getPartitioner == Some(part)) {
         logDebug("Adding one-to-one dependency with " + rdd)
         new OneToOneDependency(rdd)
       } else {

--- a/core/src/main/scala/org/apache/spark/rdd/FilteredRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/FilteredRDD.scala
@@ -28,7 +28,7 @@ private[spark] class FilteredRDD[T: ClassTag](
 
   override def getPartitions: Array[Partition] = firstParent[T].partitions
 
-  override val partitioner = prev.partitioner    // Since filter cannot change a partition's keys
+  @transient override val partitioner = prev.partitioner    // Since filter cannot change a partition's keys
 
   override def compute(split: Partition, context: TaskContext) =
     firstParent[T].iterator(split, context).filter(f)

--- a/core/src/main/scala/org/apache/spark/rdd/FilteredRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/FilteredRDD.scala
@@ -28,7 +28,7 @@ private[spark] class FilteredRDD[T: ClassTag](
 
   override def getPartitions: Array[Partition] = firstParent[T].partitions
 
-  @transient override val partitioner = prev.partitioner    // Since filter cannot change a partition's keys
+  @transient override val getPartitioner = prev.partitioner    // Since filter cannot change a partition's keys
 
   override def compute(split: Partition, context: TaskContext) =
     firstParent[T].iterator(split, context).filter(f)

--- a/core/src/main/scala/org/apache/spark/rdd/FilteredRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/FilteredRDD.scala
@@ -28,7 +28,7 @@ private[spark] class FilteredRDD[T: ClassTag](
 
   override def getPartitions: Array[Partition] = firstParent[T].partitions
 
-  @transient override val getPartitioner = prev.partitioner    // Since filter cannot change a partition's keys
+  @transient override val partitioner = prev.partitioner    // Since filter cannot change a partition's keys
 
   override def compute(split: Partition, context: TaskContext) =
     firstParent[T].iterator(split, context).filter(f)

--- a/core/src/main/scala/org/apache/spark/rdd/FlatMappedValuesRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/FlatMappedValuesRDD.scala
@@ -25,7 +25,7 @@ class FlatMappedValuesRDD[K, V, U](prev: RDD[_ <: Product2[K, V]], f: V => Trave
 
   override def getPartitions = firstParent[Product2[K, V]].partitions
 
-  override val partitioner = firstParent[Product2[K, V]].partitioner
+  @transient override val partitioner = firstParent[Product2[K, V]].partitioner
 
   override def compute(split: Partition, context: TaskContext) = {
     firstParent[Product2[K, V]].iterator(split, context).flatMap { case Product2(k, v) =>

--- a/core/src/main/scala/org/apache/spark/rdd/FlatMappedValuesRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/FlatMappedValuesRDD.scala
@@ -25,7 +25,7 @@ class FlatMappedValuesRDD[K, V, U](prev: RDD[_ <: Product2[K, V]], f: V => Trave
 
   override def getPartitions = firstParent[Product2[K, V]].partitions
 
-  @transient override val partitioner = firstParent[Product2[K, V]].partitioner
+  override def getPartitioner = firstParent[Product2[K, V]].partitioner
 
   override def compute(split: Partition, context: TaskContext) = {
     firstParent[Product2[K, V]].iterator(split, context).flatMap { case Product2(k, v) =>

--- a/core/src/main/scala/org/apache/spark/rdd/FlatMappedValuesRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/FlatMappedValuesRDD.scala
@@ -25,7 +25,7 @@ class FlatMappedValuesRDD[K, V, U](prev: RDD[_ <: Product2[K, V]], f: V => Trave
 
   override def getPartitions = firstParent[Product2[K, V]].partitions
 
-  override def getPartitioner = firstParent[Product2[K, V]].partitioner
+  @transient override val partitioner = firstParent[Product2[K, V]].partitioner
 
   override def compute(split: Partition, context: TaskContext) = {
     firstParent[Product2[K, V]].iterator(split, context).flatMap { case Product2(k, v) =>

--- a/core/src/main/scala/org/apache/spark/rdd/MapPartitionsRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/MapPartitionsRDD.scala
@@ -27,7 +27,7 @@ private[spark] class MapPartitionsRDD[U: ClassTag, T: ClassTag](
     preservesPartitioning: Boolean = false)
   extends RDD[U](prev) {
 
-  @transient override val partitioner = if (preservesPartitioning) firstParent[T].partitioner else None
+  @transient override val getPartitioner = if (preservesPartitioning) firstParent[T].partitioner else None
 
   override def getPartitions: Array[Partition] = firstParent[T].partitions
 

--- a/core/src/main/scala/org/apache/spark/rdd/MapPartitionsRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/MapPartitionsRDD.scala
@@ -27,7 +27,7 @@ private[spark] class MapPartitionsRDD[U: ClassTag, T: ClassTag](
     preservesPartitioning: Boolean = false)
   extends RDD[U](prev) {
 
-  override val partitioner = if (preservesPartitioning) firstParent[T].partitioner else None
+  @transient override val partitioner = if (preservesPartitioning) firstParent[T].partitioner else None
 
   override def getPartitions: Array[Partition] = firstParent[T].partitions
 

--- a/core/src/main/scala/org/apache/spark/rdd/MapPartitionsRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/MapPartitionsRDD.scala
@@ -27,7 +27,7 @@ private[spark] class MapPartitionsRDD[U: ClassTag, T: ClassTag](
     preservesPartitioning: Boolean = false)
   extends RDD[U](prev) {
 
-  @transient override val getPartitioner = if (preservesPartitioning) firstParent[T].partitioner else None
+  @transient override val partitioner = if (preservesPartitioning) firstParent[T].partitioner else None
 
   override def getPartitions: Array[Partition] = firstParent[T].partitions
 

--- a/core/src/main/scala/org/apache/spark/rdd/MappedValuesRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/MappedValuesRDD.scala
@@ -25,7 +25,7 @@ class MappedValuesRDD[K, V, U](prev: RDD[_ <: Product2[K, V]], f: V => U)
 
   override def getPartitions = firstParent[Product2[K, U]].partitions
 
-  override val partitioner = firstParent[Product2[K, U]].partitioner
+  override val getPartitioner = firstParent[Product2[K, U]].partitioner
 
   override def compute(split: Partition, context: TaskContext): Iterator[(K, U)] = {
     firstParent[Product2[K, V]].iterator(split, context).map { case Product2(k ,v) => (k, f(v)) }

--- a/core/src/main/scala/org/apache/spark/rdd/MappedValuesRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/MappedValuesRDD.scala
@@ -25,7 +25,7 @@ class MappedValuesRDD[K, V, U](prev: RDD[_ <: Product2[K, V]], f: V => U)
 
   override def getPartitions = firstParent[Product2[K, U]].partitions
 
-  override val getPartitioner = firstParent[Product2[K, U]].partitioner
+  @transient override val partitioner = firstParent[Product2[K, U]].partitioner
 
   override def compute(split: Partition, context: TaskContext): Iterator[(K, U)] = {
     firstParent[Product2[K, V]].iterator(split, context).map { case Product2(k ,v) => (k, f(v)) }

--- a/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
@@ -569,6 +569,8 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
    */
   def lookup(key: K): Seq[V] = {
     self.partitioner match {
+      case null => throw new SparkException("Actions on RDDs inside of another RDD operation are " +
+          "not supported")
       case Some(p) =>
         val index = p.getPartition(key)
         def process(it: Iterator[(K, V)]): Seq[V] = {

--- a/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
@@ -87,7 +87,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
       }
     }
     val aggregator = new Aggregator[K, V, C](createCombiner, mergeValue, mergeCombiners)
-    if (self.getPartitioner == Some(partitioner)) {
+    if (self.partitioner == Some(partitioner)) {
       self.mapPartitionsWithContext((context, iter) => {
         new InterruptibleIterator(context, aggregator.combineValuesByKey(iter, context))
       }, preservesPartitioning = true)
@@ -300,7 +300,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
     if (keyClass.isArray && partitioner.isInstanceOf[HashPartitioner]) {
       throw new SparkException("Default partitioner cannot partition array keys.")
     }
-    if (self.getPartitioner == Some(partitioner)) {
+    if (self.partitioner == Some(partitioner)) {
       self
     } else {
       new ShuffledRDD[K, V, (K, V)](self, partitioner)
@@ -553,7 +553,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
    * RDD will be <= us.
    */
   def subtractByKey[W: ClassTag](other: RDD[(K, W)]): RDD[(K, V)] =
-    subtractByKey(other, self.getPartitioner.getOrElse(new HashPartitioner(self.partitions.size)))
+    subtractByKey(other, self.partitioner.getOrElse(new HashPartitioner(self.partitions.size)))
 
   /** Return an RDD with the pairs from `this` whose keys are not in `other`. */
   def subtractByKey[W: ClassTag](other: RDD[(K, W)], numPartitions: Int): RDD[(K, V)] =
@@ -568,7 +568,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
    * RDD has a known partitioner by only searching the partition that the key maps to.
    */
   def lookup(key: K): Seq[V] = {
-    self.getPartitioner match {
+    self.partitioner match {
       case Some(p) =>
         val index = p.getPartition(key)
         def process(it: Iterator[(K, V)]): Seq[V] = {

--- a/core/src/main/scala/org/apache/spark/rdd/PartitionerAwareUnionRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PartitionerAwareUnionRDD.scala
@@ -59,10 +59,10 @@ class PartitionerAwareUnionRDD[T: ClassTag](
     var rdds: Seq[RDD[T]]
   ) extends RDD[T](sc, rdds.map(x => new OneToOneDependency(x))) {
   require(rdds.length > 0)
-  require(rdds.flatMap(_.getPartitioner).toSet.size == 1,
+  require(rdds.flatMap(_.partitioner).toSet.size == 1,
     "Parent RDDs have different partitioners: " + rdds.flatMap(_.partitioner))
 
-  override val partitioner = rdds.head.getPartitioner
+  override val partitioner = rdds.head.partitioner
 
   override def getPartitions: Array[Partition] = {
     val numPartitions = partitioner.get.numPartitions

--- a/core/src/main/scala/org/apache/spark/rdd/PartitionerAwareUnionRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PartitionerAwareUnionRDD.scala
@@ -62,7 +62,7 @@ class PartitionerAwareUnionRDD[T: ClassTag](
   require(rdds.flatMap(_.partitioner).toSet.size == 1,
     "Parent RDDs have different partitioners: " + rdds.flatMap(_.partitioner))
 
-  override val partitioner = rdds.head.partitioner
+  override val getPartitioner = rdds.head.partitioner
 
   override def getPartitions: Array[Partition] = {
     val numPartitions = partitioner.get.numPartitions

--- a/core/src/main/scala/org/apache/spark/rdd/PartitionerAwareUnionRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PartitionerAwareUnionRDD.scala
@@ -59,10 +59,10 @@ class PartitionerAwareUnionRDD[T: ClassTag](
     var rdds: Seq[RDD[T]]
   ) extends RDD[T](sc, rdds.map(x => new OneToOneDependency(x))) {
   require(rdds.length > 0)
-  require(rdds.flatMap(_.partitioner).toSet.size == 1,
+  require(rdds.flatMap(_.getPartitioner).toSet.size == 1,
     "Parent RDDs have different partitioners: " + rdds.flatMap(_.partitioner))
 
-  override val partitioner = rdds.head.partitioner
+  override val partitioner = rdds.head.getPartitioner
 
   override def getPartitions: Array[Partition] = {
     val numPartitions = partitioner.get.numPartitions

--- a/core/src/main/scala/org/apache/spark/rdd/PartitionerAwareUnionRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PartitionerAwareUnionRDD.scala
@@ -62,7 +62,7 @@ class PartitionerAwareUnionRDD[T: ClassTag](
   require(rdds.flatMap(_.partitioner).toSet.size == 1,
     "Parent RDDs have different partitioners: " + rdds.flatMap(_.partitioner))
 
-  override val getPartitioner = rdds.head.partitioner
+  override val partitioner = rdds.head.partitioner
 
   override def getPartitions: Array[Partition] = {
     val numPartitions = partitioner.get.numPartitions

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -123,7 +123,8 @@ abstract class RDD[T: ClassTag](
     a parallel operation as the partitioner is marked as transient */
   def getPartitioner: Option[Partitioner] = {
     partitioner match {
-      case null => throw new SparkException("Actions on RDDs inside of another RDD operation are not supported")
+      case null => throw new SparkException("Actions on RDDs inside of another RDD operation are " +
+          "not supported")
       case _ => partitioner
     }
   }
@@ -131,7 +132,8 @@ abstract class RDD[T: ClassTag](
   /** The SparkContext that created this RDD. */
   def sparkContext: SparkContext = {
     sc match {
-      case null => throw new SparkException("Actions on RDDs inside of another RDD operation are not supported")
+      case null => throw new SparkException("Actions on RDDs inside of another RDD operation are " +
+          "not supported")
       case _ => sc
     }
   }
@@ -701,7 +703,8 @@ abstract class RDD[T: ClassTag](
   def zipPartitions[B: ClassTag, C: ClassTag, D: ClassTag, V: ClassTag]
       (rdd2: RDD[B], rdd3: RDD[C], rdd4: RDD[D], preservesPartitioning: Boolean)
       (f: (Iterator[T], Iterator[B], Iterator[C], Iterator[D]) => Iterator[V]): RDD[V] =
-    new ZippedPartitionsRDD4(sc, sparkContext.clean(f), this, rdd2, rdd3, rdd4, preservesPartitioning)
+    new ZippedPartitionsRDD4(sc, sparkContext.clean(f), this, rdd2, rdd3, rdd4,
+      preservesPartitioning)
 
   def zipPartitions[B: ClassTag, C: ClassTag, D: ClassTag, V: ClassTag]
       (rdd2: RDD[B], rdd3: RDD[C], rdd4: RDD[D])
@@ -740,7 +743,8 @@ abstract class RDD[T: ClassTag](
    */
   def toLocalIterator: Iterator[T] = {
     def collectPartition(p: Int): Array[T] = {
-      sparkContext.runJob(this, (iter: Iterator[T]) => iter.toArray, Seq(p), allowLocal = false).head
+      sparkContext.runJob(this, (iter: Iterator[T]) => iter.toArray, Seq(p),
+        allowLocal = false).head
     }
     (0 until partitions.length).iterator.flatMap(i => collectPartition(i))
   }
@@ -1001,7 +1005,8 @@ abstract class RDD[T: ClassTag](
 
       val left = num - buf.size
       val p = partsScanned until math.min(partsScanned + numPartsToTry, totalParts)
-      val res = sparkContext.runJob(this, (it: Iterator[T]) => it.take(left).toArray, p, allowLocal = true)
+      val res = sparkContext.runJob(this, (it: Iterator[T]) => it.take(left).toArray, p,
+        allowLocal = true)
 
       res.foreach(buf ++= _.take(num - buf.size))
       partsScanned += numPartsToTry

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -112,22 +112,12 @@ abstract class RDD[T: ClassTag](
   protected def getPreferredLocations(split: Partition): Seq[String] = Nil
 
   /** Optionally overridden by subclasses to specify how they are partitioned.
-   * Please override getPartitioner instead.
    */
-  def partitioner: Option[Partitioner] = {
-    Option(getPartitioner).getOrElse(throw new SparkException("Actions on RDDs inside of another " +
-      "RDD operation are not supported"))
-    }
+  @transient val partitioner: Option[Partitioner] = None
 
   // =======================================================================
   // Methods and fields available on all RDDs
   // =======================================================================
-
-  /** Accessor method which throws a runtime exception if null. This lets us have
-   * a clearer error method when attempting to perform operations on an RDD inside of
-   * a parallel operation as the partitioner is marked as transient.
-   */
-  protected def getPartitioner: Option[Partitioner] = None
 
   /** The SparkContext that created this RDD. */
   def sparkContext: SparkContext = {

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -112,7 +112,7 @@ abstract class RDD[T: ClassTag](
   protected def getPreferredLocations(split: Partition): Seq[String] = Nil
 
   /** Optionally overridden by subclasses to specify how they are partitioned. */
-  @transient val partitioner: Option[Partitioner] = None
+  def partitioner: Option[Partitioner] = getPartitioner
 
   // =======================================================================
   // Methods and fields available on all RDDs
@@ -126,7 +126,7 @@ abstract class RDD[T: ClassTag](
     partitioner match {
       case null => throw new SparkException("Actions on RDDs inside of another RDD operation are " +
           "not supported")
-      case _ => partitioner
+      case _ => partitioner_
     }
   }
 
@@ -195,6 +195,8 @@ abstract class RDD[T: ClassTag](
   // be overwritten when we're checkpointed
   private var dependencies_ : Seq[Dependency[_]] = null
   @transient private var partitions_ : Array[Partition] = null
+  @transient val partitioner_ : Option[Partitioner] = None
+
 
   /** An Option holding our checkpoint RDD, if we are checkpointed */
   private def checkpointRDD: Option[RDD[T]] = checkpointData.flatMap(_.checkpointRDD)

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1167,7 +1167,7 @@ abstract class RDD[T: ClassTag](
   }
 
   /** The [[org.apache.spark.SparkContext]] that this RDD was created on. */
-  def context = sc
+  def context = sparkContext
 
   // Avoid handling doCheckpoint multiple times to prevent excessive recursion
   @transient private var doCheckpointCalled = false

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -119,9 +119,10 @@ abstract class RDD[T: ClassTag](
   // =======================================================================
 
   /** Accessor method which throws a runtime exception if null. This lets us have
-    a clearer error method when attempting to perform operations on an RDD inside of
-    a parallel operation as the partitioner is marked as transient */
-  def getPartitioner: Option[Partitioner] = {
+   * a clearer error method when attempting to perform operations on an RDD inside of
+   * a parallel operation as the partitioner is marked as transient.
+   */
+  protected def getPartitioner: Option[Partitioner] = {
     partitioner match {
       case null => throw new SparkException("Actions on RDDs inside of another RDD operation are " +
           "not supported")

--- a/core/src/main/scala/org/apache/spark/rdd/ShuffledRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ShuffledRDD.scala
@@ -53,7 +53,7 @@ class ShuffledRDD[K, V, P <: Product2[K, V] : ClassTag](
     List(new ShuffleDependency(prev, part, serializer))
   }
 
-  @transient override val getPartitioner = Some(part)
+  @transient override val partitioner = Some(part)
 
   override def getPartitions: Array[Partition] = {
     Array.tabulate[Partition](part.numPartitions)(i => new ShuffledRDDPartition(i))

--- a/core/src/main/scala/org/apache/spark/rdd/ShuffledRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ShuffledRDD.scala
@@ -53,7 +53,7 @@ class ShuffledRDD[K, V, P <: Product2[K, V] : ClassTag](
     List(new ShuffleDependency(prev, part, serializer))
   }
 
-  @transient override val partitioner = Some(part)
+  @transient override val getPartitioner = Some(part)
 
   override def getPartitions: Array[Partition] = {
     Array.tabulate[Partition](part.numPartitions)(i => new ShuffledRDDPartition(i))

--- a/core/src/main/scala/org/apache/spark/rdd/ShuffledRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ShuffledRDD.scala
@@ -53,7 +53,7 @@ class ShuffledRDD[K, V, P <: Product2[K, V] : ClassTag](
     List(new ShuffleDependency(prev, part, serializer))
   }
 
-  override val partitioner = Some(part)
+  @transient override val partitioner = Some(part)
 
   override def getPartitions: Array[Partition] = {
     Array.tabulate[Partition](part.numPartitions)(i => new ShuffledRDDPartition(i))

--- a/core/src/main/scala/org/apache/spark/rdd/SubtractedRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/SubtractedRDD.scala
@@ -51,7 +51,7 @@ import org.apache.spark.serializer.Serializer
 private[spark] class SubtractedRDD[K: ClassTag, V: ClassTag, W: ClassTag](
     @transient var rdd1: RDD[_ <: Product2[K, V]],
     @transient var rdd2: RDD[_ <: Product2[K, W]],
-    part: Partitioner)
+    @transient part: Partitioner)
   extends RDD[(K, V)](rdd1.context, Nil) {
 
   private var serializer: Serializer = null
@@ -89,7 +89,7 @@ private[spark] class SubtractedRDD[K: ClassTag, V: ClassTag, W: ClassTag](
     array
   }
 
-  override val partitioner = Some(part)
+  @transient override val partitioner = Some(part)
 
   override def compute(p: Partition, context: TaskContext): Iterator[(K, V)] = {
     val partition = p.asInstanceOf[CoGroupPartition]

--- a/core/src/main/scala/org/apache/spark/rdd/SubtractedRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/SubtractedRDD.scala
@@ -89,7 +89,7 @@ private[spark] class SubtractedRDD[K: ClassTag, V: ClassTag, W: ClassTag](
     array
   }
 
-  @transient override val partitioner = Some(part)
+  @transient override val getPartitioner = Some(part)
 
   override def compute(p: Partition, context: TaskContext): Iterator[(K, V)] = {
     val partition = p.asInstanceOf[CoGroupPartition]

--- a/core/src/main/scala/org/apache/spark/rdd/SubtractedRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/SubtractedRDD.scala
@@ -89,7 +89,7 @@ private[spark] class SubtractedRDD[K: ClassTag, V: ClassTag, W: ClassTag](
     array
   }
 
-  @transient override val getPartitioner = Some(part)
+  @transient override val partitioner = Some(part)
 
   override def compute(p: Partition, context: TaskContext): Iterator[(K, V)] = {
     val partition = p.asInstanceOf[CoGroupPartition]

--- a/core/src/main/scala/org/apache/spark/rdd/ZippedPartitionsRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ZippedPartitionsRDD.scala
@@ -47,7 +47,7 @@ private[spark] abstract class ZippedPartitionsBaseRDD[V: ClassTag](
     preservesPartitioning: Boolean = false)
   extends RDD[V](sc, rdds.map(x => new OneToOneDependency(x))) {
 
-  @transient override val partitioner =
+  @transient override val getPartitioner =
     if (preservesPartitioning) firstParent[Any].partitioner else None
 
   override def getPartitions: Array[Partition] = {

--- a/core/src/main/scala/org/apache/spark/rdd/ZippedPartitionsRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ZippedPartitionsRDD.scala
@@ -47,7 +47,7 @@ private[spark] abstract class ZippedPartitionsBaseRDD[V: ClassTag](
     preservesPartitioning: Boolean = false)
   extends RDD[V](sc, rdds.map(x => new OneToOneDependency(x))) {
 
-  override val partitioner =
+  @transient override val partitioner =
     if (preservesPartitioning) firstParent[Any].partitioner else None
 
   override def getPartitions: Array[Partition] = {

--- a/core/src/main/scala/org/apache/spark/rdd/ZippedPartitionsRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ZippedPartitionsRDD.scala
@@ -47,7 +47,7 @@ private[spark] abstract class ZippedPartitionsBaseRDD[V: ClassTag](
     preservesPartitioning: Boolean = false)
   extends RDD[V](sc, rdds.map(x => new OneToOneDependency(x))) {
 
-  @transient override val getPartitioner =
+  @transient override val partitioner =
     if (preservesPartitioning) firstParent[Any].partitioner else None
 
   override def getPartitions: Array[Partition] = {

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1140,7 +1140,7 @@ private[spark] object Utils extends Logging {
     }
   }
 
-  /** 
+  /**
    * Execute the given block, logging and re-throwing any uncaught exception.
    * This is particularly useful for wrapping code that runs in a thread, to ensure
    * that exceptions are printed, and to avoid having to catch Throwable.

--- a/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
@@ -496,7 +496,7 @@ class RDDSuite extends FunSuite with SharedSparkContext {
 
   test("takeSample") {
     val data = sc.parallelize(1 to 100, 2)
-    
+
     for (num <- List(5, 20, 100)) {
       val sample = data.takeSample(withReplacement=false, num=num)
       assert(sample.size === num)        // Got exactly num elements
@@ -758,4 +758,26 @@ class RDDSuite extends FunSuite with SharedSparkContext {
       mutableDependencies += dep
     }
   }
+
+  test("RDD operations inside of another RDD operation should fail with a SparkException") {
+    val rdd1 = sc.makeRDD(List(1, 2))
+    val rdd2 = sc.makeRDD(List((1, 2)))
+
+    intercept[SparkException] {
+      rdd1.map(rdd2.lookup(_)).collect()
+    }
+
+    intercept[SparkException] {
+      rdd1.map(x => rdd1.map(y => x * y)).collect()
+    }
+
+    intercept[SparkException] {
+      rdd1.map(x => rdd1.count()).collect()
+    }
+
+    intercept[SparkException] {
+      rdd1.map(x => rdd2.count()).collect()
+    }
+  }
+
 }


### PR DESCRIPTION
This is a quick little PR that should improve error message when trying perform a spark operation inside another spark operation. Its implemented by adding a getPartitioner function to check if the partitioner is null and adding the same check to the existing sparkContext function on RDDs.
