### PR TITLE
[SPARK-1889] [SQL] Apply splitConjunctivePredicates to join condition while finding join ke...

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -129,11 +129,12 @@ object HashFilteredJoin extends Logging with PredicateHelper {
   // as join keys.
   def splitPredicates(allPredicates: Seq[Expression], join: Join): Option[ReturnType] = {
     val Join(left, right, joinType, _) = join
-    val (joinPredicates, otherPredicates) = allPredicates.partition {
-      case Equals(l, r) if (canEvaluate(l, left) && canEvaluate(r, right)) ||
-        (canEvaluate(l, right) && canEvaluate(r, left)) => true
-      case _ => false
-    }
+    val (joinPredicates, otherPredicates) =
+      allPredicates.flatMap(splitConjunctivePredicates).partition {
+        case Equals(l, r) if (canEvaluate(l, left) && canEvaluate(r, right)) ||
+          (canEvaluate(l, right) && canEvaluate(r, left)) => true
+        case _ => false
+      }
 
     val joinKeys = joinPredicates.map {
       case Equals(l, r) if canEvaluate(l, left) && canEvaluate(r, right) => (l, r)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -21,7 +21,7 @@ import org.scalatest.FunSuite
 
 import org.apache.spark.sql.TestData._
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.plans.logical
+import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.execution
 import org.apache.spark.sql.test.TestSQLContext._
 import org.apache.spark.sql.test.TestSQLContext.planner._
@@ -56,5 +56,22 @@ class PlannerSuite extends FunSuite {
       testData.groupBy('value)(Count('value), CountDistinct('key :: Nil)).queryExecution.analyzed
     val planned = PartialAggregation(query)
     assert(planned.isEmpty)
+  }
+
+  test("equi-join is hash-join") {
+    val x = testData2.as('x)
+    val y = testData2.as('y)
+    val join = x.join(y, Inner, Some("x.a".attr === "y.a".attr)).queryExecution.analyzed
+    val planned = planner.HashJoin(join)
+    assert(planned.size === 1)
+  }
+
+  test("multiple-key equi-join is hash-join") {
+    val x = testData2.as('x)
+    val y = testData2.as('y)
+    val join = x.join(y, Inner,
+      Some("x.a".attr === "y.a".attr && "x.b".attr === "y.b".attr)).queryExecution.analyzed
+    val planned = planner.HashJoin(join)
+    assert(planned.size === 1)
   }
 }


### PR DESCRIPTION
...ys.

When tables are equi-joined by multiple-keys `HashJoin` should be used, but `CartesianProduct` and then `Filter` are used.
The join keys are paired by `And` expression so we need to apply `splitConjunctivePredicates` to join condition while finding join keys.
