### PR TITLE
[SPARK-1250] Fixed misleading comments in bin/pyspark, bin/spark-class

### DIFF
--- a/bin/pyspark
+++ b/bin/pyspark
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-# Figure out where the Scala framework is installed
+# Figure out where Spark is installed
 FWDIR="$(cd `dirname $0`/..; pwd)"
 
 # Export this as SPARK_HOME

--- a/bin/spark-class
+++ b/bin/spark-class
@@ -24,7 +24,7 @@ esac
 
 SCALA_VERSION=2.10
 
-# Figure out where the Scala framework is installed
+# Figure out where Spark is installed
 FWDIR="$(cd `dirname $0`/..; pwd)"
 
 # Export this as SPARK_HOME


### PR DESCRIPTION
Fixed a couple of misleading comments in bin/pyspark and bin/spark-class. The comments make it seem like the script is looking for the Scala installation when in fact it is looking for Spark. 
