### PR TITLE
Fix UISuite unit test that fails under Jenkins contention

### DIFF
--- a/core/src/test/scala/org/apache/spark/ui/UISuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISuite.scala
@@ -94,7 +94,7 @@ class UISuite extends FunSuite {
     }
   }
 
-  test("jetty port increases under contention") {
+  test("jetty selects different port under contention") {
     val startPort = 4040
     val server = new Server(startPort)
 
@@ -110,8 +110,9 @@ class UISuite extends FunSuite {
     // Allow some wiggle room in case ports on the machine are under contention
     val boundPort1 = serverInfo1.boundPort
     val boundPort2 = serverInfo2.boundPort
-    assert(boundPort1 > startPort && boundPort1 < startPort + 10)
-    assert(boundPort2 > boundPort1 && boundPort2 < boundPort1 + 10)
+    assert(boundPort1 != startPort)
+    assert(boundPort2 != startPort)
+    assert(boundPort1 != boundPort2)
   }
 
   test("jetty binds to port 0 correctly") {


### PR DESCRIPTION
Due to perhaps zombie processes on Jenkins, it seems that at least 10
Spark ports are in use. It also doesn't matter that the port increases
when used, it could in fact go down -- the only part that matters is
that it selects a different port rather than failing to bind.
Changed test to match this.

Thanks to @andrewor14 for helping diagnose this.
