### PR TITLE
[SPARK-1912] fix compress memory issue during reduce

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -335,11 +335,8 @@ private[spark] class BlockManager(
     // initialization, etc.). Reducer read shuffle blocks one by one so we could do the
     // wrapping lazily to save memory.
     class LazyProxyIterator(f: => Iterator[Any]) extends Iterator[Any] {
-
       lazy val proxy = f
-
       override def hasNext: Boolean = proxy.hasNext
-
       override def next(): Any = proxy.next()
     }
 


### PR DESCRIPTION
When we need to read a compressed block, we will first create a compress stream instance(LZF or Snappy) and use it to wrap that block.
Let's say a reducer task need to read 1000 local shuffle blocks, it will first prepare to read that 1000 blocks, which means create 1000 compression stream instance to wrap them. But the initialization of compression instance will allocate some memory and when we have many compression instance at the same time, it is a problem.
Actually reducer reads the shuffle blocks one by one, so we can do the compression instance initialization lazily.
