### PR TITLE
HOTFIX: Add no-arg SparkContext constructor in Java

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
@@ -42,6 +42,12 @@ import org.apache.spark.rdd.RDD
  */
 class JavaSparkContext(val sc: SparkContext) extends JavaSparkContextVarargsWorkaround {
   /**
+   * Create a JavaSparkContext that loads settings from system properties (for instance, when
+   * launching with ./bin/spark-submit).
+   */
+  def this() = this(new SparkContext())
+
+  /**
    * @param conf a [[org.apache.spark.SparkConf]] object specifying Spark parameters
    */
   def this(conf: SparkConf) = this(new SparkContext(conf))


### PR DESCRIPTION
Self explanatory.
