### PR TITLE
Adds json api for stages, storage and executor pages

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/StageInfo.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/StageInfo.scala
@@ -32,12 +32,23 @@ class StageInfo(
     val taskInfos: mutable.Buffer[(TaskInfo, TaskMetrics)] = mutable.Buffer[(TaskInfo, TaskMetrics)]()
 ) {
   val stageId = stage.id
+  val jobId = stage.jobId
   /** When this stage was submitted from the DAGScheduler to a TaskScheduler. */
   var submissionTime: Option[Long] = None
   var completionTime: Option[Long] = None
   val rddName = stage.rdd.name
   val name = stage.name
-  val numPartitions = stage.numPartitions
-  val numTasks = stage.numTasks
   var emittedTaskSizeWarning = false
+  var description: Option[String] = None
+  var numPartitions = stage.numPartitions
+  var numTasks = stage.numTasks
+  var startedTasks: Int = 0
+  var completedTasks: Int = 0
+  var failedTasks: String = ""
+  var poolName: Option[String] = None
+  var shuffleRead = ""
+  var shuffleWrite = ""
+  val shuffleDep = stage.shuffleDep
+  val parents = stage.parents
+  var numStages: Int = 0
 }

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressUI.scala
@@ -55,6 +55,7 @@ private[spark] class JobProgressUI(val sc: SparkContext) {
   def getHandlers = Seq[(String, Handler)](
     ("/stages/stage", (request: HttpServletRequest) => stagePage.render(request)),
     ("/stages/pool", (request: HttpServletRequest) => poolPage.render(request)),
+    ("/stages/json", (request: HttpServletRequest) => indexPage.renderJson(request)),
     ("/stages", (request: HttpServletRequest) => indexPage.render(request))
   )
 }

--- a/core/src/main/scala/org/apache/spark/ui/storage/BlockManagerUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/storage/BlockManagerUI.scala
@@ -33,6 +33,7 @@ private[spark] class BlockManagerUI(val sc: SparkContext) extends Logging {
 
   def getHandlers = Seq[(String, Handler)](
     ("/storage/rdd", (request: HttpServletRequest) => rddPage.render(request)),
+    ("/storage/json", (request: HttpServletRequest) => indexPage.renderJson(request)),
     ("/storage", (request: HttpServletRequest) => indexPage.render(request))
   )
 }

--- a/core/src/main/scala/org/apache/spark/ui/storage/IndexPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/storage/IndexPage.scala
@@ -18,9 +18,11 @@
 package org.apache.spark.ui.storage
 
 import javax.servlet.http.HttpServletRequest
+import net.liftweb.json.JsonAST.JValue
 
 import scala.xml.Node
 
+import org.apache.spark.deploy.JsonProtocol
 import org.apache.spark.storage.{RDDInfo, StorageUtils}
 import org.apache.spark.ui.UIUtils._
 import org.apache.spark.ui.Page._
@@ -29,6 +31,22 @@ import org.apache.spark.util.Utils
 /** Page showing list of RDD's currently stored in the cluster */
 private[spark] class IndexPage(parent: BlockManagerUI) {
   val sc = parent.sc
+
+  def renderJson(request: HttpServletRequest): JValue = {
+    val storageStatusList = sc.getExecutorStorageStatus
+    // Calculate macro-level statistics
+
+    val rddHeaders = Seq(
+      "RDD Name",
+      "Storage Level",
+      "Cached Partitions",
+      "Fraction Cached",
+      "Size in Memory",
+      "Size on Disk")
+    val rdds = StorageUtils.rddInfoFromStorageStatus(storageStatusList, sc)
+
+    JsonProtocol.writeStorageInfo(rdds.toSeq)
+  }
 
   def render(request: HttpServletRequest): Seq[Node] = {
     val storageStatusList = sc.getExecutorStorageStatus


### PR DESCRIPTION
This is an early PR to discuss about the usefulness/interest in community towards having json api for spark application ui.

We have found following uses with the api:
1. Build query centric ui - combine stages of same job for easy understanding and analysis.
2. Automated tools could use the apis to alarm on stages fail or cache memory full etc.,
3. Generate timely reports on total stages run, least and highest response times etc.,

Would be happy to make any style changes, add other end points and re-send a pull request on the master branch.
