### PR TITLE
SPARK-1937: fix issue with task locality

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -238,7 +238,7 @@ private[spark] class TaskSchedulerImpl(
     // Take each TaskSet in our scheduling order, and then offer it each node in increasing order
     // of locality levels so that it gets a chance to launch local tasks on all of them.
     var launchedTask = false
-    for (taskSet <- sortedTaskSets; maxLocality <- TaskLocality.values) {
+    for (taskSet <- sortedTaskSets; maxLocality <- taskSet.myLocalityLevels) {
       do {
         launchedTask = false
         for (i <- 0 until shuffledOffers.size) {

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -212,7 +212,7 @@ private[spark] class TaskSchedulerImpl(
     SparkEnv.set(sc.env)
 
     // Mark each slave as alive and remember its hostname
-    //also track if new executor is added
+    // Also track if new executor is added
     var newExecAvail = false
     for (o <- offers) {
       executorIdToHost(o.executorId) = o.host
@@ -232,15 +232,15 @@ private[spark] class TaskSchedulerImpl(
     for (taskSet <- sortedTaskSets) {
       logDebug("parentName: %s, name: %s, runningTasks: %s".format(
         taskSet.parent.name, taskSet.name, taskSet.runningTasks))
+      if (delaySchedule && newExecAvail) {
+        taskSet.reAddPendingTasks()
+      }
     }
 
     // Take each TaskSet in our scheduling order, and then offer it each node in increasing order
     // of locality levels so that it gets a chance to launch local tasks on all of them.
     var launchedTask = false
     for (taskSet <- sortedTaskSets; maxLocality <- TaskLocality.values) {
-      if (delaySchedule && newExecAvail) {
-        taskSet.reAddPendingTasks()
-      }
       do {
         launchedTask = false
         for (i <- 0 until shuffledOffers.size) {

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -111,7 +111,6 @@ private[spark] class TaskSchedulerImpl(
   // This is a var so that we can reset it for testing purposes.
   private[spark] var taskResultGetter = new TaskResultGetter(sc.env, this)
 
-
   override def setDAGScheduler(dagScheduler: DAGScheduler) {
     this.dagScheduler = dagScheduler
   }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -111,7 +111,6 @@ private[spark] class TaskSchedulerImpl(
   // This is a var so that we can reset it for testing purposes.
   private[spark] var taskResultGetter = new TaskResultGetter(sc.env, this)
 
-  private val delaySchedule = conf.getBoolean("spark.schedule.delaySchedule", true)
 
   override def setDAGScheduler(dagScheduler: DAGScheduler) {
     this.dagScheduler = dagScheduler
@@ -211,15 +210,16 @@ private[spark] class TaskSchedulerImpl(
   def resourceOffers(offers: Seq[WorkerOffer]): Seq[Seq[TaskDescription]] = synchronized {
     SparkEnv.set(sc.env)
 
+    val sortedTaskSets = rootPool.getSortedTaskSetQueue
     // Mark each slave as alive and remember its hostname
-    // Also track if new executor is added
-    var newExecAvail = false
     for (o <- offers) {
       executorIdToHost(o.executorId) = o.host
       if (!executorsByHost.contains(o.host)) {
         executorsByHost(o.host) = new HashSet[String]()
         executorAdded(o.executorId, o.host)
-        newExecAvail = true
+        for (taskSet <- sortedTaskSets) {
+          taskSet.executorAdded(o.executorId, o.host)
+        }
       }
     }
 
@@ -228,13 +228,9 @@ private[spark] class TaskSchedulerImpl(
     // Build a list of tasks to assign to each worker.
     val tasks = shuffledOffers.map(o => new ArrayBuffer[TaskDescription](o.cores))
     val availableCpus = shuffledOffers.map(o => o.cores).toArray
-    val sortedTaskSets = rootPool.getSortedTaskSetQueue
     for (taskSet <- sortedTaskSets) {
       logDebug("parentName: %s, name: %s, runningTasks: %s".format(
         taskSet.parent.name, taskSet.name, taskSet.runningTasks))
-      if (delaySchedule && newExecAvail) {
-        taskSet.reAddPendingTasks()
-      }
     }
 
     // Take each TaskSet in our scheduling order, and then offer it each node in increasing order

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -386,7 +386,7 @@ private[spark] class TaskSetManager(
       val curTime = clock.getTime()
 
       var allowedLocality = getAllowedLocalityLevel(curTime)
-      if (allowedLocality > maxLocality && myLocalityLevels.contains(maxLocality)) {
+      if (allowedLocality > maxLocality) {
         allowedLocality = maxLocality   // We're not allowed to search for farther-away tasks
       }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -740,7 +740,7 @@ private[spark] class TaskSetManager(
     levels.toArray
   }
 
-  //Re-compute the pending lists. This should be called when new executor is added
+  // Re-compute the pending lists. This should be called when new executor is added
   def reAddPendingTasks() {
     logInfo("Re-computing pending task lists.")
     for (i <- (0 until numTasks).reverse.filter(index => copiesRunning(index) == 0

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -154,7 +154,7 @@ private[spark] class TaskSetManager(
 
   // Figure out which locality levels we have in our TaskSet, so we can do delay scheduling
   var myLocalityLevels = computeValidLocalityLevels()
-  val localityWaits = myLocalityLevels.map(getLocalityWait) // Time to wait at each level
+  var localityWaits = myLocalityLevels.map(getLocalityWait) // Time to wait at each level
 
   // Delay scheduling variables: we keep track of our current locality level and the time we
   // last launched a task at that level, and move up a level when localityWaits[curLevel] expires.
@@ -753,5 +753,6 @@ private[spark] class TaskSetManager(
     logInfo("Re-computing pending task lists.")
     pendingTasksWithNoPrefs = pendingTasksWithNoPrefs.filter(!newLocAvail(_))
     myLocalityLevels = computeValidLocalityLevels()
+    localityWaits = myLocalityLevels.map(getLocalityWait)
   }
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -196,8 +196,7 @@ private[spark] class TaskSetManager(
       }
     }
 
-    if (tasks(index).preferredLocations.isEmpty ||
-      (!delaySchedule && !hadAliveLocations)) {
+    if (tasks(index).preferredLocations.isEmpty || (!delaySchedule && !hadAliveLocations)) {
       // Even though the task might've had preferred locations, all of those hosts or executors
       // are dead; put it in the no-prefs list so we can schedule it elsewhere right away.
       addTo(pendingTasksWithNoPrefs)
@@ -744,7 +743,8 @@ private[spark] class TaskSetManager(
   //Re-compute the pending lists. This should be called when new executor is added
   def reAddPendingTasks() {
     logInfo("Re-computing pending task lists.")
-    for (i <- (0 until numTasks).reverse.filter(index => copiesRunning(index) == 0 && !successful(index))) {
+    for (i <- (0 until numTasks).reverse.filter(index => copiesRunning(index) == 0
+      && !successful(index))) {
       addPendingTask(i, readding = true)
     }
   }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -188,9 +188,6 @@ private[spark] class TaskSetManager(
     var hadAliveLocations = false
     for (loc <- tasks(index).preferredLocations) {
       for (execId <- loc.executorId) {
-        if (sched.isExecutorAlive(execId)) {
-          hadAliveLocations = true
-        }
         addTo(pendingTasksForExecutor.getOrElseUpdate(execId, new ArrayBuffer))
       }
       if (sched.hasExecutorsAliveOnHost(loc.host)) {
@@ -756,7 +753,6 @@ private[spark] class TaskSetManager(
     def newLocAvail(index: Int): Boolean = {
       for (loc <- tasks(index).preferredLocations) {
         if (sched.hasExecutorsAliveOnHost(loc.host) ||
-          (loc.executorId.isDefined && sched.isExecutorAlive(loc.executorId.get)) ||
           sched.getRackForHost(loc.host).isDefined) {
           return true
         }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -752,15 +752,12 @@ private[spark] class TaskSetManager(
   }
 
   // Re-compute pendingTasksWithNoPrefs since new preferred locations may become available
-  def executorAdded(execId: String, host: String) {
+  def executorAdded() {
     def newLocAvail(index: Int): Boolean = {
       for (loc <- tasks(index).preferredLocations) {
-        if (execId.equals(loc.executorId.getOrElse(null)) || host.equals(loc.host)) {
-          return true
-        }
-        val availRack = sched.getRackForHost(host)
-        val prefRack = sched.getRackForHost(loc.host)
-        if (prefRack.isDefined && prefRack.get.equals(availRack.getOrElse(null))) {
+        if (sched.hasExecutorsAliveOnHost(loc.host) ||
+          (loc.executorId.isDefined && sched.isExecutorAlive(loc.executorId.get)) ||
+          sched.getRackForHost(loc.host).isDefined) {
           return true
         }
       }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -148,8 +148,10 @@ private[spark] class TaskSetManager(
 
   // Add all our tasks to the pending lists. We do this in reverse order
   // of task index so that tasks with low indices get launched first.
+  val delaySchedule = conf.getBoolean("spark.schedule.delaySchedule", true)
   for (i <- (0 until numTasks).reverse) {
-    addPendingTask(i)
+    //if delay schedule is set, we shouldn't enforce check since executors may haven't registered yet
+    addPendingTask(i, enforceCheck = !delaySchedule)
   }
 
   // Figure out which locality levels we have in our TaskSet, so we can do delay scheduling
@@ -169,8 +171,10 @@ private[spark] class TaskSetManager(
   /**
    * Add a task to all the pending-task lists that it should be on. If readding is set, we are
    * re-adding the task so only include it in each list if it's not already there.
+   * If enforceCheck is set, we'll check the availability of executors/hosts before adding a task
+   * to the pending list, otherwise, we simply add the task according to its preference.
    */
-  private def addPendingTask(index: Int, readding: Boolean = false) {
+  private def addPendingTask(index: Int, readding: Boolean = false, enforceCheck: Boolean = true) {
     // Utility method that adds `index` to a list only if readding=false or it's not already there
     def addTo(list: ArrayBuffer[Int]) {
       if (!readding || !list.contains(index)) {
@@ -181,12 +185,12 @@ private[spark] class TaskSetManager(
     var hadAliveLocations = false
     for (loc <- tasks(index).preferredLocations) {
       for (execId <- loc.executorId) {
-        if (sched.isExecutorAlive(execId)) {
+        if (!enforceCheck || sched.isExecutorAlive(execId)) {
           addTo(pendingTasksForExecutor.getOrElseUpdate(execId, new ArrayBuffer))
           hadAliveLocations = true
         }
       }
-      if (sched.hasExecutorsAliveOnHost(loc.host)) {
+      if (!enforceCheck || sched.hasExecutorsAliveOnHost(loc.host)) {
         addTo(pendingTasksForHost.getOrElseUpdate(loc.host, new ArrayBuffer))
         for (rack <- sched.getRackForHost(loc.host)) {
           addTo(pendingTasksForRack.getOrElseUpdate(rack, new ArrayBuffer))

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -724,11 +724,11 @@ private[spark] class TaskSetManager(
     import TaskLocality.{PROCESS_LOCAL, NODE_LOCAL, RACK_LOCAL, ANY}
     val levels = new ArrayBuffer[TaskLocality.TaskLocality]
     if (!pendingTasksForExecutor.isEmpty && getLocalityWait(PROCESS_LOCAL) != 0 &&
-      pendingTasksForExecutor.keySet.exists(sched.isExecutorAlive(_))) {
+        pendingTasksForExecutor.keySet.exists(sched.isExecutorAlive(_))) {
       levels += PROCESS_LOCAL
     }
     if (!pendingTasksForHost.isEmpty && getLocalityWait(NODE_LOCAL) != 0 &&
-      pendingTasksForHost.keySet.exists(sched.hasExecutorsAliveOnHost(_))) {
+        pendingTasksForHost.keySet.exists(sched.hasExecutorsAliveOnHost(_))) {
       levels += NODE_LOCAL
     }
     if (!pendingTasksForRack.isEmpty && getLocalityWait(RACK_LOCAL) != 0) {
@@ -744,7 +744,7 @@ private[spark] class TaskSetManager(
     def newLocAvail(index: Int): Boolean = {
       for (loc <- tasks(index).preferredLocations) {
         if (sched.hasExecutorsAliveOnHost(loc.host) ||
-          sched.getRackForHost(loc.host).isDefined) {
+            sched.getRackForHost(loc.host).isDefined) {
           return true
         }
       }

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -401,14 +401,14 @@ class TaskSetManagerSuite extends FunSuite with LocalSparkContext with Logging {
     // All tasks added to no-pref list since no preferred location is available
     assert(manager.pendingTasksWithNoPrefs.size === 4)
     // Only ANY is valid
-    assert(manager.myLocalityLevels.size === 1)
+    assert(manager.myLocalityLevels.sameElements(Array(ANY)))
     // Add a new executor
     sched.addExecutor(("execD", "host1"))
     manager.executorAdded()
     // Task 0 and 1 should be removed from no-pref list
     assert(manager.pendingTasksWithNoPrefs.size === 2)
     // Valid locality should contain NODE_LOCAL and ANY
-    assert(manager.myLocalityLevels.size === 2)
+    assert(manager.myLocalityLevels.sameElements(Array(NODE_LOCAL, ANY)))
     // Offer host1, execD, at PROCESS_LOCAL level: task 0 should be chosen
     // because PROCESS_LOCAL is not valid at the moment
     assert(manager.resourceOffer("execD", "host1", PROCESS_LOCAL).get.index === 0)
@@ -418,7 +418,7 @@ class TaskSetManagerSuite extends FunSuite with LocalSparkContext with Logging {
     // No-pref list now only contains task 3
     assert(manager.pendingTasksWithNoPrefs.size === 1)
     // Valid locality should contain PROCESS_LOCAL, NODE_LOCAL and ANY
-    assert(manager.myLocalityLevels.size === 3)
+    assert(manager.myLocalityLevels.sameElements(Array(PROCESS_LOCAL, NODE_LOCAL, ANY)))
     // Offer host2, execC, at PROCESS_LOCAL level: task 2 should be chosen
     assert(manager.resourceOffer("execC", "host2", PROCESS_LOCAL).get.index === 2)
     // Offer host1, execD again at PROCESS_LOCAL level: task 3 should be chosen

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -409,9 +409,6 @@ class TaskSetManagerSuite extends FunSuite with LocalSparkContext with Logging {
     assert(manager.pendingTasksWithNoPrefs.size === 2)
     // Valid locality should contain NODE_LOCAL and ANY
     assert(manager.myLocalityLevels.sameElements(Array(NODE_LOCAL, ANY)))
-    // Offer host1, execD, at PROCESS_LOCAL level: task 0 should be chosen
-    // because PROCESS_LOCAL is not valid at the moment
-    assert(manager.resourceOffer("execD", "host1", PROCESS_LOCAL).get.index === 0)
     // Add another executor
     sched.addExecutor(("execC", "host2"))
     manager.executorAdded()
@@ -419,10 +416,6 @@ class TaskSetManagerSuite extends FunSuite with LocalSparkContext with Logging {
     assert(manager.pendingTasksWithNoPrefs.size === 1)
     // Valid locality should contain PROCESS_LOCAL, NODE_LOCAL and ANY
     assert(manager.myLocalityLevels.sameElements(Array(PROCESS_LOCAL, NODE_LOCAL, ANY)))
-    // Offer host2, execC, at PROCESS_LOCAL level: task 2 should be chosen
-    assert(manager.resourceOffer("execC", "host2", PROCESS_LOCAL).get.index === 2)
-    // Offer host1, execD again at PROCESS_LOCAL level: task 3 should be chosen
-    assert(manager.resourceOffer("execD", "host1", PROCESS_LOCAL).get.index === 3)
   }
 
   def createTaskResult(id: Int): DirectTaskResult[Int] = {

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -78,8 +78,8 @@ class FakeTaskScheduler(sc: SparkContext, liveExecutors: (String, String)* /* ex
 
   override def hasExecutorsAliveOnHost(host: String): Boolean = executors.values.exists(_ == host)
 
-  def addExecutor(newExecutors: (String, String)*) {
-    executors ++= newExecutors
+  def addExecutor(execId: String, host: String) {
+    executors.put(execId, host)
   }
 }
 
@@ -403,14 +403,14 @@ class TaskSetManagerSuite extends FunSuite with LocalSparkContext with Logging {
     // Only ANY is valid
     assert(manager.myLocalityLevels.sameElements(Array(ANY)))
     // Add a new executor
-    sched.addExecutor(("execD", "host1"))
+    sched.addExecutor("execD", "host1")
     manager.executorAdded()
     // Task 0 and 1 should be removed from no-pref list
     assert(manager.pendingTasksWithNoPrefs.size === 2)
     // Valid locality should contain NODE_LOCAL and ANY
     assert(manager.myLocalityLevels.sameElements(Array(NODE_LOCAL, ANY)))
     // Add another executor
-    sched.addExecutor(("execC", "host2"))
+    sched.addExecutor("execC", "host2")
     manager.executorAdded()
     // No-pref list now only contains task 3
     assert(manager.pendingTasksWithNoPrefs.size === 1)


### PR DESCRIPTION
Don't check executor/host availability when creating a TaskSetManager. Because the executors may haven't been registered when the TaskSetManager is created, in which case all tasks will be considered "has no preferred locations", and thus losing data locality in later scheduling.
