### PR TITLE
[SPARK-1820] Make GenerateMimaIgnore @DeveloperApi annotation aware.

### DIFF
--- a/tools/src/main/scala/org/apache/spark/tools/GenerateMIMAIgnore.scala
+++ b/tools/src/main/scala/org/apache/spark/tools/GenerateMIMAIgnore.scala
@@ -43,7 +43,7 @@ object GenerateMIMAIgnore {
   private def classesPrivateWithin(packageName: String): Set[String] = {
 
     val classes = getClasses(packageName)
-    val privateClasses = mutable.HashSet[String]()
+    val ignoredClasses = mutable.HashSet[String]()
 
     def isPackagePrivate(className: String) = {
       try {
@@ -98,10 +98,10 @@ object GenerateMIMAIgnore {
         }
       }
       if (directlyPrivateSpark || indirectlyPrivateSpark || developerApi) {
-        privateClasses += className
+        ignoredClasses += className
       }
     }
-    privateClasses.flatMap(c => Seq(c, c.replace("$", "#"))).toSet
+    ignoredClasses.flatMap(c => Seq(c, c.replace("$", "#"))).toSet
   }
 
   def main(args: Array[String]) {

--- a/tools/src/main/scala/org/apache/spark/tools/GenerateMIMAIgnore.scala
+++ b/tools/src/main/scala/org/apache/spark/tools/GenerateMIMAIgnore.scala
@@ -74,7 +74,6 @@ object GenerateMIMAIgnore {
     def isDeveloperApi(className: String) = {
       try {
         val clazz = mirror.classSymbol(Class.forName(className, false, classLoader))
-
         clazz.annotations.exists(_.tpe =:= unv.typeOf[org.apache.spark.annotation.DeveloperApi])
       } catch {
         case _: Throwable => {
@@ -98,8 +97,9 @@ object GenerateMIMAIgnore {
           false
         }
       }
-      if (directlyPrivateSpark || indirectlyPrivateSpark || developerApi) privateClasses +=
-        className
+      if (directlyPrivateSpark || indirectlyPrivateSpark || developerApi) {
+        privateClasses += className
+      }
     }
     privateClasses.flatMap(c => Seq(c, c.replace("$", "#"))).toSet
   }
@@ -114,10 +114,10 @@ object GenerateMIMAIgnore {
   private def shouldExclude(name: String) = {
     // Heuristic to remove JVM classes that do not correspond to user-facing classes in Scala
     name.contains("anon") ||
-      name.endsWith("$class") ||
-      name.contains("$sp") ||
-      name.contains("hive") ||
-      name.contains("Hive")
+    name.endsWith("$class") ||
+    name.contains("$sp") ||
+    name.contains("hive") ||
+    name.contains("Hive")
   }
 
   /**
@@ -143,7 +143,7 @@ object GenerateMIMAIgnore {
     val jar = new JarFile(new File(jarPath))
     val enums = jar.entries().map(_.getName).filter(_.startsWith(packageName))
     val classes = for (entry <- enums if entry.endsWith(".class"))
-    yield Class.forName(entry.replace('/', '.').stripSuffix(".class"), false, classLoader)
+      yield Class.forName(entry.replace('/', '.').stripSuffix(".class"), false, classLoader)
     classes
   }
 }


### PR DESCRIPTION
We add all the classes annotated as `DeveloperApi` to `~/.mima-excludes`.
