### PR TITLE
SPARK-1949. Servlet 2.5 vs 3.0 conflict in SBT build

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -326,6 +326,7 @@ object SparkBuild extends Build {
   val excludeJBossNetty = ExclusionRule(organization = "org.jboss.netty")
   val excludeIONetty = ExclusionRule(organization = "io.netty")
   val excludeEclipseJetty = ExclusionRule(organization = "org.eclipse.jetty")
+  val excludeMortbayJetty = ExclusionRule(organization = "org.mortbay.jetty")
   val excludeAsm = ExclusionRule(organization = "org.ow2.asm")
   val excludeOldAsm = ExclusionRule(organization = "asm")
   val excludeCommonsLogging = ExclusionRule(organization = "commons-logging")
@@ -371,7 +372,7 @@ object SparkBuild extends Build {
         "net.java.dev.jets3t"        % "jets3t"           % jets3tVersion excludeAll(excludeCommonsLogging),
         "commons-codec"              % "commons-codec"    % "1.5", // Prevent jets3t from including the older version of commons-codec
         "org.apache.derby"           % "derby"            % "10.4.2.0"                     % "test",
-        "org.apache.hadoop"          % hadoopClient       % hadoopVersion excludeAll(excludeJBossNetty, excludeAsm, excludeCommonsLogging, excludeSLF4J, excludeOldAsm, excludeServletApi),
+        "org.apache.hadoop"          % hadoopClient       % hadoopVersion excludeAll(excludeJBossNetty, excludeMortbayJetty, excludeAsm, excludeCommonsLogging, excludeSLF4J, excludeOldAsm, excludeServletApi),
         "org.apache.curator"         % "curator-recipes"  % "2.4.0" excludeAll(excludeJBossNetty),
         "com.codahale.metrics"       % "metrics-core"     % codahaleMetricsVersion,
         "com.codahale.metrics"       % "metrics-jvm"      % codahaleMetricsVersion,
@@ -528,9 +529,9 @@ object SparkBuild extends Build {
     name := "spark-hive",
     javaOptions += "-XX:MaxPermSize=1g",
     libraryDependencies ++= Seq(
-      "org.spark-project.hive" % "hive-metastore" % hiveVersion,
-      "org.spark-project.hive" % "hive-exec"      % hiveVersion excludeAll(excludeCommonsLogging),
-      "org.spark-project.hive" % "hive-serde"     % hiveVersion
+      "org.spark-project.hive" % "hive-metastore" % hiveVersion excludeAll(excludeJBossNetty, excludeMortbayJetty, excludeCommonsLogging, excludeSLF4J),
+      "org.spark-project.hive" % "hive-exec"      % hiveVersion excludeAll(excludeJBossNetty, excludeMortbayJetty, excludeCommonsLogging, excludeSLF4J),
+      "org.spark-project.hive" % "hive-serde"     % hiveVersion excludeAll(excludeJBossNetty, excludeMortbayJetty, excludeCommonsLogging, excludeSLF4J)
     ),
     // Multiple queries rely on the TestHive singleton.  See comments there for more details.
     parallelExecution in Test := false,


### PR DESCRIPTION
Kay Ousterhout mentioned that:

```
I had some trouble compiling an application (Shark) against Spark 1.0,
where Shark had a runtime exception (at the bottom of this message) because
it couldn't find the javax.servlet classes. SBT seemed to have trouble
downloading the servlet APIs that are dependencies of Jetty (used by the
Spark web UI), so I had to manually add them to the application's build
file:

libraryDependencies += "org.mortbay.jetty" % "servlet-api" % "3.0.20100224"

Not exactly sure why this happens but thought it might be useful in case
others run into the same problem.
```

This is a symptom of Servlet API conflict which we battled in the Maven build. The resolution is to nix Servlet 2.5 and odd old Jetty / Netty 3.x dependencies. It looks like the Hive part of the assembly in the SBT build doesn't exclude all these entirely.
