### PR TITLE
Suggest workarounds for partitionBy in Spark 1.0.0 due to SPARK-1931

### DIFF
--- a/docs/graphx-programming-guide.md
+++ b/docs/graphx-programming-guide.md
@@ -95,7 +95,7 @@ GraphX in Spark {{site.SPARK_VERSION}} contains one user-facing interface change
 ## Workaround for `Graph.partitionBy` in Spark 1.0.0
 <a name="partitionBy_workaround"></a>
 
-The [`Graph.partitionBy`][Graph.partitionBy] operator allows users to choose the graph partitioning strategy, but due to [SPARK-1931](https://issues.apache.org/jira/browse/SPARK-1931), this method is broken in Spark 1.0.0. We encourage users to build the latest version of Spark from the master branch, which contains a fix. Alternatively, a workaround is to partition the edges before constructing the graph, as follows:
+The [`Graph.partitionBy`][Graph.partitionBy] operator allows users to choose the graph partitioning strategy, but due to [SPARK-1931](https://issues.apache.org/jira/browse/SPARK-1931), this method is broken in Spark 1.0.0. We encourage users to build the latest version of Spark from [`branch-1.0`](https://github.com/apache/spark/tree/branch-1.0), which contains a fix. Alternatively, a workaround is to partition the edges before constructing the graph, as follows:
 
 {% highlight scala %}
 // Define our own version of partitionBy to work around SPARK-1931

--- a/graphx/src/main/scala/org/apache/spark/graphx/Graph.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/Graph.scala
@@ -103,8 +103,34 @@ abstract class Graph[VD: ClassTag, ED: ClassTag] protected () extends Serializab
    */
   def unpersistVertices(blocking: Boolean = true): Graph[VD, ED]
 
+  /** @define dot  */
   /**
-   * Repartitions the edges in the graph according to `partitionStrategy`.
+   * Repartitions the edges in the graph according to `partitionStrategy` (WARNING: broken in
+   * Spark 1\u20240\u20240).
+   *
+   * To use this function in Spark 1.0.0, either build the latest version of Spark from the master
+   * branch, or apply the following workaround:
+   * {{{
+   * // Define our own version of partitionBy to work around SPARK-1931
+   * import org.apache.spark.HashPartitioner
+   * def partitionBy[ED](
+   *     edges: RDD[Edge[ED]], partitionStrategy: PartitionStrategy): RDD[Edge[ED]] = {
+   *   val numPartitions = edges.partitions.size
+   *   edges.map(e => (partitionStrategy.getPartition(e.srcId, e.dstId, numPartitions), e))
+   *     .partitionBy(new HashPartitioner(numPartitions))
+   *     .mapPartitions(_.map(_._2), preservesPartitioning = true)
+   * }
+   *
+   * val vertices = ...
+   * val edges = ...
+   *
+   * // Instead of:
+   * val g = Graph(vertices, edges)
+   *   .partitionBy(PartitionStrategy.EdgePartition2D) // broken in Spark 1.0.0
+   *
+   * // Use:
+   * val g = Graph(vertices, partitionBy(edges, PartitionStrategy.EdgePartition2D))
+   * }}}
    */
   def partitionBy(partitionStrategy: PartitionStrategy): Graph[VD, ED]
 

--- a/graphx/src/main/scala/org/apache/spark/graphx/Graph.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/Graph.scala
@@ -107,8 +107,9 @@ abstract class Graph[VD: ClassTag, ED: ClassTag] protected () extends Serializab
    * Repartitions the edges in the graph according to `partitionStrategy` (WARNING: broken in
    * Spark 1\u20240\u20240).
    *
-   * To use this function in Spark 1.0.0, either build the latest version of Spark from the master
-   * branch, or apply the following workaround:
+   * To use this function in Spark 1.0.0, either build the latest version of Spark from
+   * [[https://github.com/apache/spark/tree/branch-1.0 branch-1.0]], or apply the following
+   * workaround:
    * {{{
    * // Define our own version of partitionBy to work around SPARK-1931
    * import org.apache.spark.HashPartitioner

--- a/graphx/src/main/scala/org/apache/spark/graphx/Graph.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/Graph.scala
@@ -103,7 +103,6 @@ abstract class Graph[VD: ClassTag, ED: ClassTag] protected () extends Serializab
    */
   def unpersistVertices(blocking: Boolean = true): Graph[VD, ED]
 
-  /** @define dot  */
   /**
    * Repartitions the edges in the graph according to `partitionStrategy` (WARNING: broken in
    * Spark 1\u20240\u20240).


### PR DESCRIPTION
The Graph.partitionBy operator allows users to choose the graph partitioning strategy, but due to SPARK-1931, this method is broken in Spark 1.0.0. This PR updates the GraphX docs for Spark 1.0.0 to encourage users to build the latest version of Spark from branch-1.0, which contains a fix. Alternatively, it suggests a workaround involving partitioning the edges before constructing the graph.
