### PR TITLE
[SPARK-1959] String "NULL" shouldn't be interpreted as null value

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveOperators.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveOperators.scala
@@ -113,7 +113,6 @@ case class HiveTableScan(
   }
 
   private def unwrapHiveData(value: Any) = value match {
-    case maybeNull: String if maybeNull.toLowerCase == "null" => null
     case varchar: HiveVarchar => varchar.getValue
     case decimal: HiveDecimal => BigDecimal(decimal.bigDecimalValue)
     case other => other


### PR DESCRIPTION
JIRA issue: [SPARK-1959](https://issues.apache.org/jira/browse/SPARK-1959)
