### PR TITLE
SPARK-1935: Explicitly add commons-codec 1.5 as a dependency (for branch-0.9).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,11 @@
         <version>14.0.1</version>
       </dependency>
       <dependency>
+        <groupId>commons-codec</groupId>
+        <artifactId>commons-codec</artifactId>
+        <version>1.5</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
         <version>1.3.9</version>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -279,6 +279,7 @@ object SparkBuild extends Build {
         "colt"                     % "colt"             % "1.2.0",
         "org.apache.mesos"         % "mesos"            % "0.13.0",
         "net.java.dev.jets3t"      % "jets3t"           % "0.7.1",
+        "commons-codec"            % "commons-codec"    % "1.5", // Prevent jets3t from including the older version of commons-codec
         "org.apache.derby"         % "derby"            % "10.4.2.0"                     % "test",
         "org.apache.hadoop"        % hadoopClient       % hadoopVersion excludeAll(excludeJackson, excludeNetty, excludeAsm, excludeCglib),
         "org.apache.avro"          % "avro"             % "1.7.4",


### PR DESCRIPTION
This is for branch 0.9.
