### PR TITLE
SPARK-1952 removed slf4j Pig conflicts

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -335,8 +335,6 @@ object SparkBuild extends Build {
         "log4j"                      % "log4j"            % "1.2.17",
         "org.slf4j"                  % "slf4j-api"        % slf4jVersion,
         "org.slf4j"                  % "slf4j-log4j12"    % slf4jVersion,
-        "org.slf4j"                  % "jul-to-slf4j"     % slf4jVersion,
-        "org.slf4j"                  % "jcl-over-slf4j"   % slf4jVersion,
         "commons-daemon"             % "commons-daemon"   % "1.0.10", // workaround for bug HADOOP-9407
         "com.ning"                   % "compress-lzf"     % "1.0.0",
         "org.xerial.snappy"          % "snappy-java"      % "1.0.5",


### PR DESCRIPTION
Removed jul-to-slf4j and jcl-over-slf4j to allow Pig scripts to register jars containing the Spark-1.0 assembly, cf https://issues.apache.org/jira/browse/SPARK-1952
