### PR TITLE
[SPARK-1997] update breeze to version 0.8.1

### DIFF
--- a/mllib/pom.xml
+++ b/mllib/pom.xml
@@ -52,13 +52,17 @@
     <dependency>
       <groupId>org.scalanlp</groupId>
       <artifactId>breeze_${scala.binary.version}</artifactId>
-      <version>0.7</version>
+      <version>0.8.1</version>
       <exclusions>
         <!-- This is included as a compile-scoped dependency by jtransforms, which is
              a dependency of breeze. -->
         <exclusion>
           <groupId>junit</groupId>
           <artifactId>junit</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-math3</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
`breeze 0.8.1`  dependent on  `scala-logging-slf4j 2.1.1` The relevant code on #1369
