### PR TITLE
added compatibility for python 2.6 for ssh_read command

### DIFF
--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -670,6 +670,11 @@ def ssh(host, opts, command):
 
 
 def ssh_read(host, opts, command):
+    if sys.version_info < (2, 7):
+        return subprocess.Popen(
+            ssh_command(opts) + ['%s@%s' %
+                                 (opts.user, host), stringify_command(command)],
+        stdout=subprocess.PIPE).stdout
     return subprocess.check_output(
         ssh_command(opts) + ['%s@%s' % (opts.user, host), stringify_command(command)])
 

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -669,13 +669,22 @@ def ssh(host, opts, command):
             tries = tries + 1
 
 
+def _check_output(*popenargs, **kwargs):
+    if 'stdout' in kwargs:
+        raise ValueError('stdout argument not allowed, it will be overridden.')
+    process = subprocess.Popen(stdout=PIPE, *popenargs, **kwargs)
+    output, unused_err = process.communicate()
+    retcode = process.poll()
+    if retcode:
+        cmd = kwargs.get("args")
+        if cmd is None:
+            cmd = popenargs[0]
+        raise subprocess.CalledProcessError(retcode, cmd, output=output)
+    return output
+
+
 def ssh_read(host, opts, command):
-    if sys.version_info < (2, 7):
-        return subprocess.Popen(
-            ssh_command(opts) + ['%s@%s' %
-                                 (opts.user, host), stringify_command(command)],
-        stdout=subprocess.PIPE).stdout
-    return subprocess.check_output(
+    return _check_output(
         ssh_command(opts) + ['%s@%s' % (opts.user, host), stringify_command(command)])
 
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-1990

There were some posts on the lists that spark-ec2 does not work with Python 2.6. In addition, we should check the Python version at the top of the script and exit if it's too old
