### PR TITLE
[SPARK-1852] prevents queries with sorts submitting jobs prematurely

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -28,8 +28,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.optimizer.Optimizer
-import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoTable, InsertIntoCreatedTable}
-import org.apache.spark.sql.catalyst.plans.logical.{Command, LogicalPlan, WriteToFile}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 import org.apache.spark.sql.catalyst.types._
 import org.apache.spark.sql.catalyst.{ScalaReflection, dsl}

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -28,6 +28,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.optimizer.Optimizer
+import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoTable, InsertIntoCreatedTable}
 import org.apache.spark.sql.catalyst.plans.logical.{Command, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 import org.apache.spark.sql.catalyst.types._
@@ -147,7 +148,8 @@ class SQLContext(@transient val sparkContext: SparkContext)
       // We force query optimization to happen right away instead of letting it happen lazily like
       // when using the query DSL.  This is so DDL commands behave as expected.  This is only
       // generates the RDD lineage for DML queries, but do not perform any execution.
-      case _: Command => result.queryExecution.toRdd
+      case _: Command | _: InsertIntoTable | _: InsertIntoCreatedTable =>
+        result.queryExecution.toRdd
       case _ =>
     }
     result

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -25,20 +25,15 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.spark.SparkContext
 import org.apache.spark.annotation.{AlphaComponent, DeveloperApi, Experimental}
 import org.apache.spark.rdd.RDD
-
 import org.apache.spark.sql.catalyst.analysis._
-import org.apache.spark.sql.catalyst.{ScalaReflection, dsl}
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.types._
 import org.apache.spark.sql.catalyst.optimizer.Optimizer
-import org.apache.spark.sql.catalyst.plans.logical.{Subquery, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.{Command, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
-
+import org.apache.spark.sql.catalyst.types._
+import org.apache.spark.sql.catalyst.{ScalaReflection, dsl}
 import org.apache.spark.sql.columnar.InMemoryColumnarTableScan
-
 import org.apache.spark.sql.execution._
-import org.apache.spark.sql.execution.SparkStrategies
-
 import org.apache.spark.sql.parquet.ParquetRelation
 
 /**
@@ -148,10 +143,13 @@ class SQLContext(@transient val sparkContext: SparkContext)
    */
   def sql(sqlText: String): SchemaRDD = {
     val result = new SchemaRDD(this, parseSql(sqlText))
-    // We force query optimization to happen right away instead of letting it happen lazily like
-    // when using the query DSL.  This is so DDL commands behave as expected.  This is only
-    // generates the RDD lineage for DML queries, but do not perform any execution.
-    result.queryExecution.toRdd
+    result.logicalPlan match {
+      // We force query optimization to happen right away instead of letting it happen lazily like
+      // when using the query DSL.  This is so DDL commands behave as expected.  This is only
+      // generates the RDD lineage for DML queries, but do not perform any execution.
+      case _: Command => result.queryExecution.toRdd
+      case _ =>
+    }
     result
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.optimizer.Optimizer
 import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoTable, InsertIntoCreatedTable}
-import org.apache.spark.sql.catalyst.plans.logical.{Command, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.{Command, LogicalPlan, WriteToFile}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 import org.apache.spark.sql.catalyst.types._
 import org.apache.spark.sql.catalyst.{ScalaReflection, dsl}
@@ -148,7 +148,7 @@ class SQLContext(@transient val sparkContext: SparkContext)
       // We force query optimization to happen right away instead of letting it happen lazily like
       // when using the query DSL.  This is so DDL commands behave as expected.  This is only
       // generates the RDD lineage for DML queries, but do not perform any execution.
-      case _: Command | _: InsertIntoTable | _: InsertIntoCreatedTable =>
+      case _: Command | _: InsertIntoTable | _: InsertIntoCreatedTable | _: WriteToFile =>
         result.queryExecution.toRdd
       case _ =>
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -142,18 +142,7 @@ class SQLContext(@transient val sparkContext: SparkContext)
    *
    * @group userf
    */
-  def sql(sqlText: String): SchemaRDD = {
-    val result = new SchemaRDD(this, parseSql(sqlText))
-    result.logicalPlan match {
-      // We force query optimization to happen right away instead of letting it happen lazily like
-      // when using the query DSL.  This is so DDL commands behave as expected.  This is only
-      // generates the RDD lineage for DML queries, but do not perform any execution.
-      case _: Command | _: InsertIntoTable | _: InsertIntoCreatedTable | _: WriteToFile =>
-        result.queryExecution.toRdd
-      case _ =>
-    }
-    result
-  }
+  def sql(sqlText: String): SchemaRDD = new SchemaRDD(this, parseSql(sqlText))
 
   /** Returns the specified table as a SchemaRDD */
   def table(tableName: String): SchemaRDD =

--- a/sql/core/src/main/scala/org/apache/spark/sql/SchemaRDDLike.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SchemaRDDLike.scala
@@ -50,6 +50,15 @@ private[sql] trait SchemaRDDLike {
   @DeveloperApi
   lazy val queryExecution = sqlContext.executePlan(logicalPlan)
 
+  logicalPlan match {
+    // We force query optimization to happen right away instead of letting it happen lazily like
+    // when using the query DSL.  This is so DDL commands behave as expected.  This is only
+    // generates the RDD lineage for DML queries, but do not perform any execution.
+    case _: Command | _: InsertIntoTable | _: InsertIntoCreatedTable | _: WriteToFile =>
+      queryExecution.toRdd
+    case _ =>
+  }
+
   override def toString =
     s"""${super.toString}
        |== Query Plan ==

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -75,18 +75,7 @@ class HiveContext(sc: SparkContext) extends SQLContext(sc) {
   /**
    * Executes a query expressed in HiveQL using Spark, returning the result as a SchemaRDD.
    */
-  def hiveql(hqlQuery: String): SchemaRDD = {
-    val result = new SchemaRDD(this, HiveQl.parseSql(hqlQuery))
-    result.logicalPlan match {
-      // We force query optimization to happen right away instead of letting it happen lazily like
-      // when using the query DSL.  This is so DDL commands behave as expected.  This is only
-      // generates the RDD lineage for DML queries, but do not perform any execution.
-      case _: Command | _: InsertIntoTable | _: InsertIntoCreatedTable | _: WriteToFile =>
-        result.queryExecution.toRdd
-      case _ =>
-    }
-    result
-  }
+  def hiveql(hqlQuery: String): SchemaRDD = new SchemaRDD(this, HiveQl.parseSql(hqlQuery))
 
   /** An alias for `hiveql`. */
   def hql(hqlQuery: String): SchemaRDD = hiveql(hqlQuery)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -81,7 +81,8 @@ class HiveContext(sc: SparkContext) extends SQLContext(sc) {
       // We force query optimization to happen right away instead of letting it happen lazily like
       // when using the query DSL.  This is so DDL commands behave as expected.  This is only
       // generates the RDD lineage for DML queries, but do not perform any execution.
-      case _: Command => result.queryExecution.toRdd
+      case _: Command | _: InsertIntoTable | _: InsertIntoCreatedTable =>
+        result.queryExecution.toRdd
       case _ =>
     }
     result

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -81,7 +81,7 @@ class HiveContext(sc: SparkContext) extends SQLContext(sc) {
       // We force query optimization to happen right away instead of letting it happen lazily like
       // when using the query DSL.  This is so DDL commands behave as expected.  This is only
       // generates the RDD lineage for DML queries, but do not perform any execution.
-      case _: Command | _: InsertIntoTable | _: InsertIntoCreatedTable =>
+      case _: Command | _: InsertIntoTable | _: InsertIntoCreatedTable | _: WriteToFile =>
         result.queryExecution.toRdd
       case _ =>
     }


### PR DESCRIPTION
JIRA issue: [SPARK-1852](https://issues.apache.org/jira/browse/SPARK-1852)

This issue is related to [SPARK-1021](https://issues.apache.org/jira/browse/SPARK-1021), but this PR doesn't try to solve that one. Worked around by only forcing query planning when running DDL and other native commands.
