### PR TITLE
[SPARK-2006] Spark Sql example throws ClassCastException: Long -> Int

### DIFF
--- a/examples/src/main/scala/org/apache/spark/examples/sql/RDDRelation.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/sql/RDDRelation.scala
@@ -43,7 +43,7 @@ object RDDRelation {
     sql("SELECT * FROM records").collect().foreach(println)
 
     // Aggregation queries are also supported.
-    val count = sql("SELECT COUNT(*) FROM records").collect().head.getInt(0)
+    val count = sql("SELECT COUNT(*) FROM records").collect().head.getLong(0)
     println(s"COUNT(*): $count")
 
     // The results of SQL queries are themselves RDDs and support all normal RDD functions.  The
@@ -51,7 +51,7 @@ object RDDRelation {
     val rddFromSql = sql("SELECT key, value FROM records WHERE key < 10")
 
     println("Result of RDD.map:")
-    rddFromSql.map(row => s"Key: ${row(0)}, Value: ${row(1)}").collect.foreach(println)
+    rddFromSql.map(row => s"Key: ${row(0)}, Value: ${row(1)}").collect().foreach(println)
 
     // Queries can also be written using a LINQ-like Scala DSL.
     rdd.where('key === 1).orderBy('value.asc).select('key).collect().foreach(println)
@@ -59,10 +59,10 @@ object RDDRelation {
     // Write out an RDD as a parquet file.
     rdd.saveAsParquetFile("pair.parquet")
 
-    // Read in parquet file.  Parquet files are self-describing so the schmema is preserved.
+    // Read in parquet file.  Parquet files are self-describing so the schema is preserved.
     val parquetFile = sqlContext.parquetFile("pair.parquet")
 
-    // Queries can be run using the DSL on parequet files just like the original RDD.
+    // Queries can be run using the DSL on parquet files just like the original RDD.
     parquetFile.where('key === 1).select('value as 'a).collect().foreach(println)
 
     // These files can also be registered as tables.


### PR DESCRIPTION
This fixes an example spark sql program which failed at the getInt() call.
getInt() was called on a COUNT query whose output datatype is of type Long and casting a Long to Int is an illegal operation

In this commit:
- use getLong(0) instead of getInt(0)
- Fix typos in comments
- add call parens to collect() call for consistency

For the future, I think it would be good to have all the example programs be automatically run and checked for successful exit codes as part of the CI run so that something like this doesn't slip through
