### PR TITLE
[STREAMING] SPARK-2009 Key not found exception when slow receiver starts

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/ReceiverInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/ReceiverInputDStream.scala
@@ -74,7 +74,7 @@ abstract class ReceiverInputDStream[T: ClassTag](@transient ssc_ : StreamingCont
 
   /** Get information on received blocks. */
   private[streaming] def getReceivedBlockInfo(time: Time) = {
-     receivedBlockInfo.get(time).getOrElse(Array.empty[ReceivedBlockInfo])
+    receivedBlockInfo.get(time).getOrElse(Array.empty[ReceivedBlockInfo])
   }
 
   /**

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/ReceiverInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/ReceiverInputDStream.scala
@@ -74,7 +74,7 @@ abstract class ReceiverInputDStream[T: ClassTag](@transient ssc_ : StreamingCont
 
   /** Get information on received blocks. */
   private[streaming] def getReceivedBlockInfo(time: Time) = {
-    receivedBlockInfo(time)
+     receivedBlockInfo.get(time).getOrElse(Array.empty[ReceivedBlockInfo])
   }
 
   /**


### PR DESCRIPTION
I got "java.util.NoSuchElementException: key not found: 1401756085000 ms" exception when using kafka stream and 1 sec batchPeriod.

Investigation showed that the reason is that ReceiverLauncher.startReceivers is asynchronous (started in a thread).
https://github.com/vchekan/spark/blob/master/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceiverTracker.scala#L206

In case of slow starting receiver, such as Kafka, it easily takes more than 2sec to start. In result, no single "compute" will be called on ReceiverInputDStream before first batch job is executed and receivedBlockInfo remains empty (obviously). Batch job will cause ReceiverInputDStream.getReceivedBlockInfo call and "key not found" exception.

The patch makes getReceivedBlockInfo more robust by tolerating missing values.
