### PR TITLE
HOTFIX: Remove generated-mima-excludes file after runing MIMA.

### DIFF
--- a/dev/mima
+++ b/dev/mima
@@ -31,4 +31,5 @@ if [ $ret_val != 0 ]; then
   echo "NOTE: Exceptions to binary compatibility can be added in project/MimaExcludes.scala"
 fi
 
+rm -f .generated-mima-excludes
 exit $ret_val


### PR DESCRIPTION
This has been causing some false failures on PR's that don't merge
correctly.
