### PR TITLE
fix native library path

### DIFF
--- a/bin/spark-class
+++ b/bin/spark-class
@@ -99,7 +99,7 @@ else
 fi
 
 # Set JAVA_OPTS to be able to load native libraries and to set heap size
-JAVA_OPTS="-XX:MaxPermSize=128m $OUR_JAVA_OPTS"
+JAVA_OPTS="-XX:MaxPermSize=128m $OUR_JAVA_OPTS -Djava.library.path=$SPARK_LIBRARY_PATH"
 JAVA_OPTS="$JAVA_OPTS -Xms$OUR_JAVA_MEM -Xmx$OUR_JAVA_MEM"
 # Load extra JAVA_OPTS from conf/java-opts, if it exists
 if [ -e "$FWDIR/conf/java-opts" ] ; then


### PR DESCRIPTION
bug fix:
the spark-class did not read the SPARK_LIBRARY_PATH env variable, it was causing not able to load native library
