### PR TITLE
Update run-example

### DIFF
--- a/bin/run-example
+++ b/bin/run-example
@@ -51,7 +51,7 @@ if [[ ! $EXAMPLE_CLASS == org.apache.spark.examples* ]]; then
   EXAMPLE_CLASS="org.apache.spark.examples.$EXAMPLE_CLASS"
 fi
 
-./bin/spark-submit \
+$FWDIR/bin/spark-submit \
   --master $EXAMPLE_MASTER \
   --class $EXAMPLE_CLASS \
   "$SPARK_EXAMPLES_JAR" \


### PR DESCRIPTION
Old code can only be ran under spark_home and use "bin/run-example".
Error "./run-example: line 55: ./bin/spark-submit: No such file or directory" appears when running in other place. So change this
