### PR TITLE
SPARK-2058: Overriding config from SPARK_HOME with SPARK_CONF_DIR

### DIFF
--- a/bin/compute-classpath.cmd
+++ b/bin/compute-classpath.cmd
@@ -37,6 +37,13 @@ if exist "%FWDIR%conf\spark-env.cmd" call "%FWDIR%conf\spark-env.cmd"
 
 rem Build up classpath
 set CLASSPATH=%FWDIR%conf
+
+if "x%SPARK_CONF_DIR%"=="x" (
+  rem If SPARK_CONF_DIR is defined give it preference over default conf in spark home
+
+  set CLASSPATH=%SPARK_CONF_DIR%;%CLASSPATH%
+)
+
 if exist "%FWDIR%RELEASE" (
   for %%d in ("%FWDIR%lib\spark-assembly*.jar") do (
     set ASSEMBLY_JAR=%%d

--- a/bin/compute-classpath.cmd
+++ b/bin/compute-classpath.cmd
@@ -38,7 +38,7 @@ if exist "%FWDIR%conf\spark-env.cmd" call "%FWDIR%conf\spark-env.cmd"
 rem Build up classpath
 set CLASSPATH=%FWDIR%conf
 
-if "x%SPARK_CONF_DIR%"=="x" (
+if "x%SPARK_CONF_DIR%"!="x" (
   rem If SPARK_CONF_DIR is defined give it preference over default conf in spark home
 
   set CLASSPATH=%SPARK_CONF_DIR%;%CLASSPATH%

--- a/bin/compute-classpath.sh
+++ b/bin/compute-classpath.sh
@@ -30,6 +30,11 @@ FWDIR="$(cd `dirname $0`/..; pwd)"
 # Build up classpath
 CLASSPATH="$SPARK_CLASSPATH:$SPARK_SUBMIT_CLASSPATH:$FWDIR/conf"
 
+# If SPARK_CONF_DIR is defined give it preference over default conf in spark home
+if [ -n "${SPARK_CONF_DIR}" ]; then
+  CLASSPATH="$SPARK_CONF_DIR:$CLASSPATH"
+fi
+
 ASSEMBLY_DIR="$FWDIR/assembly/target/scala-$SCALA_VERSION"
 
 if [ -n "$JAVA_HOME" ]; then

--- a/bin/compute-classpath.sh
+++ b/bin/compute-classpath.sh
@@ -31,7 +31,7 @@ FWDIR="$(cd `dirname $0`/..; pwd)"
 CLASSPATH="$SPARK_CLASSPATH:$SPARK_SUBMIT_CLASSPATH:$FWDIR/conf"
 
 # If SPARK_CONF_DIR is defined give it preference over default conf in spark home
-if [ -n "${SPARK_CONF_DIR}" ]; then
+if [ -n "$SPARK_CONF_DIR" ]; then
   CLASSPATH="$SPARK_CONF_DIR:$CLASSPATH"
 fi
 

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -47,7 +47,7 @@ object SparkSubmit {
   private val PYSPARK_SHELL = "pyspark-shell"
 
   def main(args: Array[String]) {
-    val appArgs = new SparkSubmitArguments(args)
+    val appArgs = new SparkSubmitArguments(args, sys.env)
     if (appArgs.verbose) {
       printStream.println(appArgs)
     }

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -26,6 +26,7 @@ import org.apache.spark.deploy.SparkSubmit._
 import org.apache.spark.util.Utils
 import org.scalatest.FunSuite
 import org.scalatest.matchers.ShouldMatchers
+import java.nio.file.Files
 
 class SparkSubmitSuite extends FunSuite with ShouldMatchers {
   def beforeAll() {
@@ -289,20 +290,18 @@ class SparkSubmitSuite extends FunSuite with ShouldMatchers {
   }
 
   def forConfDir(defaults: Map[String, String]) (f: String => Unit) = {
-    val tmpDir = new File("TMP_SPARK_CONF_DIR")
-    tmpDir.mkdir()
+    val tmpDir = Files.createTempDirectory(null).toFile
 
     val defaultsConf = new File(tmpDir.getAbsolutePath, "spark-defaults.conf")
     val writer = new OutputStreamWriter(new FileOutputStream(defaultsConf))
-    for ((key, value) <- defaults) writer.write(key + " " + value)
-    writer.flush()
+    for ((key, value) <- defaults) writer.write(s"$key $value\n")
+
     writer.close()
 
     try {
       f(tmpDir.getAbsolutePath)
     } finally {
-      defaultsConf.delete()
-      tmpDir.delete()
+      Utils.deleteRecursively(tmpDir)
     }
   }
 }

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.deploy.SparkSubmit._
 import org.apache.spark.util.Utils
 import org.scalatest.FunSuite
 import org.scalatest.matchers.ShouldMatchers
-import java.nio.file.Files
+import com.google.common.io.Files
 
 class SparkSubmitSuite extends FunSuite with ShouldMatchers {
   def beforeAll() {
@@ -290,7 +290,7 @@ class SparkSubmitSuite extends FunSuite with ShouldMatchers {
   }
 
   def forConfDir(defaults: Map[String, String]) (f: String => Unit) = {
-    val tmpDir = Files.createTempDirectory(null).toFile
+    val tmpDir = Files.createTempDir()
 
     val defaultsConf = new File(tmpDir.getAbsolutePath, "spark-defaults.conf")
     val writer = new OutputStreamWriter(new FileOutputStream(defaultsConf))

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -839,3 +839,16 @@ compute `SPARK_LOCAL_IP` by looking up the IP of a specific network interface.
 Spark uses [log4j](http://logging.apache.org/log4j/) for logging. You can configure it by adding a
 `log4j.properties` file in the `conf` directory. One way to start is to copy the existing
 `log4j.properties.template` located there.
+
+# Overriding configuration
+
+In some cases you might want to provide all configuration from another place than the default SPARK_HOME/conf dir.
+For example if you are using the prepackaged version of Spark or if you are building it your self but want to be
+independent from your cluster configuration (managed by an automation tool).
+
+In that scenario you can define the SPARK_CONF_DIR variable pointing to an alternate directory containing you configuration.
+Spark will then use it for the following configurations:
+
+ * spark-defaults.conf and spark-env.sh will be loaded only from the SPARK_CONF_DIR
+ * log4j.properties, fairscheduler.xml and metrics.properties if present will be loaded from SPARK_CONF_DIR,
+ but if missing, the ones from SPARK_HOME/conf will be used.


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/SPARK-2058

The general idea is to use SPARK_CONF_DIR content instead of SPARK_HOME/conf when defined.
- When SPARK_CONF_DIR is defined, spark-defaults.conf will be loaded from there. 
- SPARK_CONF_DIR is added to the classpath, overriding the default conf from SPARK_HOME/conf
