### PR TITLE
[SPARK-1704][SQL] Fully support EXPLAIN commands as SchemaRDD.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.plans.logical
 import org.apache.spark.sql.catalyst.errors.TreeNodeException
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.QueryPlan
-import org.apache.spark.sql.catalyst.types.StructType
+import org.apache.spark.sql.catalyst.types.{StringType, StructType}
 import org.apache.spark.sql.catalyst.trees
 
 abstract class LogicalPlan extends QueryPlan[LogicalPlan] {
@@ -102,7 +102,7 @@ abstract class LeafNode extends LogicalPlan with trees.LeafNode[LogicalPlan] {
  */
 abstract class Command extends LeafNode {
   self: Product =>
-  def output = Seq.empty
+  def output: Seq[Attribute] = Seq.empty
 }
 
 /**
@@ -115,7 +115,9 @@ case class NativeCommand(cmd: String) extends Command
  * Returned by a parser when the users only wants to see what query plan would be executed, without
  * actually performing the execution.
  */
-case class ExplainCommand(plan: LogicalPlan) extends Command
+case class ExplainCommand(plan: LogicalPlan) extends Command {
+  override def output = Seq(AttributeReference("plan", StringType, nullable = false)())
+}
 
 /**
  * A logical plan node with single child.

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -191,6 +191,7 @@ class SQLContext(@transient val sparkContext: SparkContext)
     val sparkContext = self.sparkContext
 
     val strategies: Seq[Strategy] =
+      CommandStrategy(self) ::
       TakeOrdered ::
       PartialAggregation ::
       HashJoin ::
@@ -253,6 +254,11 @@ class SQLContext(@transient val sparkContext: SparkContext)
     val batches =
       Batch("Add exchange", Once, AddExchange) ::
       Batch("Prepare Expressions", Once, new BindReferences[SparkPlan]) :: Nil
+  }
+
+  // TODO: or should we make QueryExecution protected[sql]?
+  protected[sql] def mkQueryExecution(plan: LogicalPlan) = new QueryExecution {
+    val logical = plan
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -223,7 +223,7 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
     def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
       case logical.ExplainCommand(child) =>
         val qe = context.mkQueryExecution(child)
-        Seq(execution.ExplainCommandPhysical(qe.executedPlan)(context))
+        Seq(execution.ExplainCommandPhysical(qe.executedPlan, plan.output)(context))
       case _ => Nil
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -217,4 +217,15 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
       case _ => Nil
     }
   }
+
+  // TODO: this should be merged with SPARK-1508's SetCommandStrategy
+  case class CommandStrategy(context: SQLContext) extends Strategy {
+    def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
+      case logical.ExplainCommand(child) =>
+        val qe = context.mkQueryExecution(child)
+        Seq(execution.ExplainCommandPhysical(qe.executedPlan)(context))
+      case _ => Nil
+    }
+  }
+
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
@@ -17,45 +17,9 @@
 
 package org.apache.spark.sql.execution
 
-import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{SQLContext, Row}
 import org.apache.spark.sql.catalyst.expressions.{GenericRow, Attribute}
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-
-/**
- * :: DeveloperApi ::
- */
-//@DeveloperApi
-//case class SetCommandPhysical(
-//    key: Option[String],
-//    value: Option[String],
-//    context: SQLContext)
-//  extends LeafNode {
-//
-//  "hi".split("=", 2)
-//
-//   def execute(): RDD[Row] = (key, value) match {
-//     case (Some(k), Some(v)) => context.emptyResult
-//     case (Some(k), None) =>
-//       val resultString = context.sqlConf.getOption(k) match {
-//         case Some(v) => s"$k=$v"
-//         case None => s"$k is undefined"
-//       }
-//       context.sparkContext.parallelize(Seq(new GenericRow(Array[Any](resultString))), 1)
-//     case (None, None) =>
-//       val pairs = context.sqlConf.getAll
-//       val rows = pairs.map { case (k, v) =>
-//         new GenericRow(Array[Any](s"$k=$v"))
-//       }.toSeq
-//       // Assume config parameters can fit into one split (machine) ;)
-//       context.sparkContext.parallelize(rows, 1)
-//     case _ => context.emptyResult
-//   }
-//
-//   def output: Seq[Attribute] = Seq.empty // TODO: right thing?
-//}
-
 
 case class ExplainCommandPhysical(child: SparkPlan)
                                  (@transient context: SQLContext) extends UnaryNode {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{SQLContext, Row}
+import org.apache.spark.sql.catalyst.expressions.{GenericRow, Attribute}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+
+/**
+ * :: DeveloperApi ::
+ */
+//@DeveloperApi
+//case class SetCommandPhysical(
+//    key: Option[String],
+//    value: Option[String],
+//    context: SQLContext)
+//  extends LeafNode {
+//
+//  "hi".split("=", 2)
+//
+//   def execute(): RDD[Row] = (key, value) match {
+//     case (Some(k), Some(v)) => context.emptyResult
+//     case (Some(k), None) =>
+//       val resultString = context.sqlConf.getOption(k) match {
+//         case Some(v) => s"$k=$v"
+//         case None => s"$k is undefined"
+//       }
+//       context.sparkContext.parallelize(Seq(new GenericRow(Array[Any](resultString))), 1)
+//     case (None, None) =>
+//       val pairs = context.sqlConf.getAll
+//       val rows = pairs.map { case (k, v) =>
+//         new GenericRow(Array[Any](s"$k=$v"))
+//       }.toSeq
+//       // Assume config parameters can fit into one split (machine) ;)
+//       context.sparkContext.parallelize(rows, 1)
+//     case _ => context.emptyResult
+//   }
+//
+//   def output: Seq[Attribute] = Seq.empty // TODO: right thing?
+//}
+
+
+case class ExplainCommandPhysical(child: SparkPlan)
+                                 (@transient context: SQLContext) extends UnaryNode {
+  def execute(): RDD[Row] = {
+    val lines = child.toString.split("\n").map(s => new GenericRow(Array[Any](s)))
+    context.sparkContext.parallelize(lines)
+  }
+
+  def output: Seq[Attribute] = child.output // right thing to do?
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
@@ -29,4 +29,6 @@ case class ExplainCommandPhysical(child: SparkPlan)
   }
 
   def output: Seq[Attribute] = child.output // right thing to do?
+
+  override def otherCopyArgs = context :: Nil
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
@@ -21,14 +21,12 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{SQLContext, Row}
 import org.apache.spark.sql.catalyst.expressions.{GenericRow, Attribute}
 
-case class ExplainCommandPhysical(child: SparkPlan)
+case class ExplainCommandPhysical(child: SparkPlan, output: Seq[Attribute])
                                  (@transient context: SQLContext) extends UnaryNode {
   def execute(): RDD[Row] = {
     val planString = new GenericRow(Array[Any](child.toString))
     context.sparkContext.parallelize(Seq(planString))
   }
-
-  def output: Seq[Attribute] = child.output // right thing to do?
 
   override def otherCopyArgs = context :: Nil
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
@@ -24,8 +24,8 @@ import org.apache.spark.sql.catalyst.expressions.{GenericRow, Attribute}
 case class ExplainCommandPhysical(child: SparkPlan)
                                  (@transient context: SQLContext) extends UnaryNode {
   def execute(): RDD[Row] = {
-    val lines = child.toString.split("\n").map(s => new GenericRow(Array[Any](s)))
-    context.sparkContext.parallelize(lines)
+    val planString = new GenericRow(Array[Any](child.toString))
+    context.sparkContext.parallelize(Seq(planString))
   }
 
   def output: Seq[Attribute] = child.output // right thing to do?

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -218,6 +218,7 @@ class HiveContext(sc: SparkContext) extends SQLContext(sc) {
     val hiveContext = self
 
     override val strategies: Seq[Strategy] = Seq(
+      CommandStrategy(self),
       TakeOrdered,
       ParquetOperations,
       HiveTableScans,
@@ -303,7 +304,7 @@ class HiveContext(sc: SparkContext) extends SQLContext(sc) {
      */
     def stringResult(): Seq[String] = analyzed match {
       case NativeCommand(cmd) => runSqlHive(cmd)
-      case ExplainCommand(plan) => new QueryExecution { val logical = plan }.toString.split("\n")
+      case ExplainCommand(plan) => mkQueryExecution(plan).toString.split("\n")
       case query =>
         val result: Seq[Seq[Any]] = toRdd.collect().toSeq
         // We need the types so we can output struct field names

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.hive.execution
 
 import org.apache.spark.sql.hive.test.TestHive._
+import org.apache.spark.sql.hive.test.TestHive
 
 /**
  * A set of test cases expressed in Hive QL that are not covered by the tests included in the hive distribution.
@@ -158,6 +159,16 @@ class HiveQuerySuite extends HiveComparisonTest {
   test("SchemaRDD toString") {
     hql("SHOW TABLES").toString
     hql("SELECT * FROM src").toString
+  }
+
+  test("SPARK-1704: Explain commands as a SchemaRDD") {
+    hql("CREATE TABLE IF NOT EXISTS src (key INT, value STRING)")
+    val rdd = hql("explain select key, count(value) from src group by key")
+    assert(rdd.collect().size == 1)
+    assert(rdd.toString.contains("ExplainCommand"))
+    assert(rdd.filter(row => row.toString.contains("ExplainCommand")).collect().size == 0,
+      "actual contents of the result should be the plans of the query to be explained")
+    TestHive.reset()
   }
 
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -159,4 +159,5 @@ class HiveQuerySuite extends HiveComparisonTest {
     hql("SHOW TABLES").toString
     hql("SELECT * FROM src").toString
   }
+
 }


### PR DESCRIPTION
This PR attempts to resolve [SPARK-1704](https://issues.apache.org/jira/browse/SPARK-1704) by introducing a physical plan for EXPLAIN commands, which just prints out the debug string (containing various SparkSQL's plans) of the corresponding QueryExecution for the actual query.
