### PR TITLE
SPARK-1628 follow up: Improve RangePartitioner's documentation.

### DIFF
--- a/core/src/main/scala/org/apache/spark/Partitioner.scala
+++ b/core/src/main/scala/org/apache/spark/Partitioner.scala
@@ -90,6 +90,10 @@ class HashPartitioner(partitions: Int) extends Partitioner {
 /**
  * A [[org.apache.spark.Partitioner]] that partitions sortable records by range into roughly
  * equal ranges. The ranges are determined by sampling the content of the RDD passed in.
+ *
+ * Note that the actual number of partitions created by the RangePartitioner might not be the same
+ * as the `partitions` parameter, in the case where the number of sampled records is less than
+ * the value of `partitions`.
  */
 class RangePartitioner[K : Ordering : ClassTag, V](
     partitions: Int,
@@ -157,7 +161,6 @@ class RangePartitioner[K : Ordering : ClassTag, V](
     case _ =>
       false
   }
-
 
   override def hashCode(): Int = {
     val prime = 31


### PR DESCRIPTION
Adding a paragraph clarifying a weird behavior in RangePartitioner. 

See also #549.
