### PR TITLE
HOTFIX: clear() configs in SQLConf-related unit tests.

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLConfSuite.scala
@@ -28,6 +28,7 @@ class SQLConfSuite extends QueryTest {
   val testVal = "test.val.0"
 
   test("programmatic ways of basic setting and getting") {
+    clear()
     assert(getOption(testKey).isEmpty)
     assert(getAll.toSet === Set())
 
@@ -48,6 +49,7 @@ class SQLConfSuite extends QueryTest {
   }
 
   test("parse SQL set commands") {
+    clear()
     sql(s"set $testKey=$testVal")
     assert(get(testKey, testVal + "_") == testVal)
     assert(TestSQLContext.get(testKey, testVal + "_") == testVal)

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -402,6 +402,7 @@ class SQLQuerySuite extends QueryTest {
       sql(s"SET $nonexistentKey"),
       Seq(Seq(s"$nonexistentKey is undefined"))
     )
+    clear()
   }
 
 }


### PR DESCRIPTION
Thanks goes to @liancheng, who pointed out that `sql/test-only *.SQLConfSuite *.SQLQuerySuite` passed but `sql/test-only *.SQLQuerySuite *.SQLConfSuite` failed. The reason is that some tests use the same test keys and without clear()'ing, they get carried over to other tests. This hotfix simply adds some `clear()` calls.

This problem was not evident on Jenkins before probably because `parallelExecution` is not set to `false` for `sqlCoreSettings`.
