### PR TITLE
SPARK-2101: import unittest2 when using Python 2.6

### DIFF
--- a/python/pyspark/mllib/tests.py
+++ b/python/pyspark/mllib/tests.py
@@ -19,8 +19,13 @@
 Fuller unit tests for Python MLlib.
 """
 
+import sys
 from numpy import array, array_equal
-import unittest
+
+if sys.version_info[:2] <= (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
 
 from pyspark.mllib._common import _convert_vector, _serialize_double_vector, \
     _deserialize_double_vector, _dot, _squared_distance

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -28,8 +28,12 @@ import subprocess
 import sys
 import tempfile
 import time
-import unittest
 import zipfile
+
+if sys.version_info[:2] <= (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
 
 from pyspark.context import SparkContext
 from pyspark.files import SparkFiles


### PR DESCRIPTION
The PySpark tests depend on `unittest.skipIf`, which was only added in Python 2.7.  This should remedy the build failures on Python 2.6.  The only remaining piece is that it may be necessary to install `unittest2` with Python 2.6, if it's not provided automatically.
