### PR TITLE
fixed typo in docstring for min()

### DIFF
--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -695,7 +695,7 @@ class RDD(object):
 
     def min(self):
         """
-        Find the maximum item in this RDD.
+        Find the minimum item in this RDD.
 
         >>> sc.parallelize([1.0, 5.0, 43.0, 10.0]).min()
         1.0


### PR DESCRIPTION
Hi, I found this typo while learning spark and thought I'd do a pull request.  
