### PR TITLE
[SPARK-2141] Adding getPersistentRddIds and unpersistRDD to Java/Python

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
@@ -559,6 +559,19 @@ class JavaSparkContext(val sc: SparkContext) extends JavaSparkContextVarargsWork
   def getLocalProperty(key: String): String = sc.getLocalProperty(key)
 
   /**
+   * Get a set of RDD IDs that have marked themselves as persistent via cache() call.
+   * Note that this does not necessarily mean the caching or computation was successful.
+   */
+  def getPersistentRddIds(): java.util.Set[Int] =
+    setAsJavaSet(sc.getPersistentRDDs.keySet)
+
+  /**
+   * Unpersist an RDD from memory and/or disk storage
+   */
+  def unpersistRDD(rddId: Int, blocking: Boolean): Unit =
+    sc.unpersistRDD(rddId, blocking)
+
+  /**
    * Assigns a group ID to all the jobs started by this thread until the group ID is set to a
    * different value or cleared.
    *

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -674,16 +674,13 @@ class SparkContext(object):
         Get a set of RDD IDs that have marked themselves as persistent via cache() call.
         Note that this does not necessarily mean the caching or computation was successful.
 
-        >>> existing = len(sc.getPersistentRddIds())
         >>> rdd = sc.parallelize(range(4)).cache()
         >>> c = rdd.count()
         >>> rdd.id() in sc.getPersistentRddIds()
         True
-        >>> len(sc.getPersistentRddIds()) - existing
-        1
         >>> sc.unpersistRDD(rdd.id())
-        >>> len(sc.getPersistentRddIds()) - existing
-        0
+        >>> rdd.id() in sc.getPersistentRddIds()
+        False
         """
         return self._jsc.getPersistentRddIds()
 

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -677,6 +677,8 @@ class SparkContext(object):
         >>> existing = len(sc.getPersistentRddIds())
         >>> rdd = sc.parallelize(range(4)).cache()
         >>> c = rdd.count()
+        >>> rdd.id() in sc.getPersistentRddIds()
+        True
         >>> len(sc.getPersistentRddIds()) - existing
         1
         >>> sc.unpersistRDD(rdd.id())

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -669,6 +669,28 @@ class SparkContext(object):
         """
         return self._jsc.getLocalProperty(key)
 
+    def getPersistentRddIds(self):
+        """
+        Get a set of RDD IDs that have marked themselves as persistent via cache() call.
+        Note that this does not necessarily mean the caching or computation was successful.
+
+        >>> existing = len(sc.getPersistentRddIds())
+        >>> rdd = sc.parallelize(range(4)).cache()
+        >>> c = rdd.count()
+        >>> len(sc.getPersistentRddIds()) - existing
+        1
+        >>> sc.unpersistRDD(rdd.id())
+        >>> len(sc.getPersistentRddIds()) - existing
+        0
+        """
+        return self._jsc.getPersistentRddIds()
+
+    def unpersistRDD(self, rddId):
+        """
+        Unpersist an RDD from memory and/or disk storage
+        """
+        self._jsc.unpersistRDD(rddId, True)
+
     def sparkUser(self):
         """
         Get SPARK_USER for user who is running SparkContext.


### PR DESCRIPTION
JIRA issue: https://issues.apache.org/jira/browse/SPARK-2141

This PR exposes `sc.getPersistentRddIds()` and `sc.unpersistRDD()` in 
Java and Python APIs. Example,

```
>>> rdd = sc.parallelize(range(4)).cache()
>>> rdd.count()
4
>>> rdd.id() in sc.getPersistentRddIds()
True
>>> sc.unpersistRDD(rdd.id())
>>> rdd.id() in sc.getPersistentRddIds()
False
```
