### PR TITLE
[SPARK-2130] End-user friendly String repr for StorageLevel in Python

### DIFF
--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -1448,6 +1448,7 @@ class RDD(object):
     def getStorageLevel(self):
         """
         Get the RDD's current storage level.
+
         >>> rdd1 = sc.parallelize([1,2])
         >>> rdd1.getStorageLevel()
         StorageLevel(False, False, False, False, 1)

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -1451,6 +1451,8 @@ class RDD(object):
         >>> rdd1 = sc.parallelize([1,2])
         >>> rdd1.getStorageLevel()
         StorageLevel(False, False, False, False, 1)
+        >>> print(rdd1.getStorageLevel())
+        Serialized 1x Replicated
         """
         java_storage_level = self._jrdd.getStorageLevel()
         storage_level = StorageLevel(java_storage_level.useDisk(),

--- a/python/pyspark/storagelevel.py
+++ b/python/pyspark/storagelevel.py
@@ -36,6 +36,15 @@ class StorageLevel:
         return "StorageLevel(%s, %s, %s, %s, %s)" % (
             self.useDisk, self.useMemory, self.useOffHeap, self.deserialized, self.replication)
 
+    def __str__(self):
+        result = ""
+        result += "Disk " if self.useDisk else ""
+        result += "Memory " if self.useMemory else ""
+        result += "Tachyon " if self.useOffHeap else ""
+        result += "Deserialized " if self.deserialized else "Serialized "
+        result += "%sx Replicated" % self.replication
+        return result
+
 StorageLevel.DISK_ONLY = StorageLevel(True, False, False, False)
 StorageLevel.DISK_ONLY_2 = StorageLevel(True, False, False, False, 2)
 StorageLevel.MEMORY_ONLY = StorageLevel(False, True, False, True)


### PR DESCRIPTION
JIRA issue https://issues.apache.org/jira/browse/SPARK-2130

This PR adds an end-user friendly String representation for StorageLevel 
in Python, similar to `StorageLevel.description` in Scala.

```
>>> rdd = sc.parallelize([1,2])
>>> storage_level = rdd.getStorageLevel()
>>> storage_level
StorageLevel(False, False, False, False, 1)
>>> print(storage_level)
Serialized 1x Replicated
```
