### PR TITLE
[SPARK-2147] Show exited executors on the Master UI

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/ApplicationInfo.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ApplicationInfo.scala
@@ -20,10 +20,11 @@ package org.apache.spark.deploy.master
 import java.util.Date
 
 import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
 
 import akka.actor.ActorRef
 
-import org.apache.spark.deploy.ApplicationDescription
+import org.apache.spark.deploy.{ApplicationDescription, ExecutorState}
 
 private[spark] class ApplicationInfo(
     val startTime: Long,
@@ -41,6 +42,7 @@ private[spark] class ApplicationInfo(
   @transient var appSource: ApplicationSource = _
 
   @transient private var nextExecutorId: Int = _
+  @transient private var exitedExecutors: ArrayBuffer[ExecutorInfo] = _
 
   init()
 
@@ -51,6 +53,7 @@ private[spark] class ApplicationInfo(
     endTime = -1L
     appSource = new ApplicationSource(this)
     nextExecutorId = 0
+    exitedExecutors = new ArrayBuffer[ExecutorInfo]
   }
 
   private def newExecutorId(useID: Option[Int] = None): Int = {
@@ -74,10 +77,16 @@ private[spark] class ApplicationInfo(
 
   def removeExecutor(exec: ExecutorInfo) {
     if (executors.contains(exec.id)) {
+      if (exec.state == ExecutorState.EXITED) {
+        exitedExecutors += executors(exec.id)
+      }
       executors -= exec.id
       coresGranted -= exec.cores
     }
   }
+
+  /** Return the information for all live and exited executors. */
+  def executorInfo: Seq[ExecutorInfo] = (executors.values ++ exitedExecutors).toSet.toSeq
 
   private val myMaxCores = desc.maxCores.getOrElse(defaultCores)
 

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/ApplicationPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/ApplicationPage.scala
@@ -57,7 +57,7 @@ private[spark] class ApplicationPage(parent: MasterWebUI) extends WebUIPage("app
     })
 
     val executorHeaders = Seq("ExecutorID", "Worker", "Cores", "Memory", "State", "Logs")
-    val executors = app.executors.values.toSeq
+    val executors = app.executorInfo
     val executorTable = UIUtils.listingTable(executorHeaders, executorRow, executors)
 
     val content =
@@ -68,14 +68,14 @@ private[spark] class ApplicationPage(parent: MasterWebUI) extends WebUIPage("app
               <li><strong>Name:</strong> {app.desc.name}</li>
               <li><strong>User:</strong> {app.desc.user}</li>
               <li><strong>Cores:</strong>
-                {
+              {
                 if (app.desc.maxCores.isEmpty) {
                   "Unlimited (%s granted)".format(app.coresGranted)
                 } else {
                   "%s (%s granted, %s left)".format(
                     app.desc.maxCores.get, app.coresGranted, app.coresLeft)
                 }
-                }
+              }
               </li>
               <li>
                 <strong>Executor Memory:</strong>


### PR DESCRIPTION
If an application exits cleanly (i.e. `sc.stop()` is called), then the executors disappear from the applications page on the Master UI. This PR keeps the information associated with the exited executors around to display them on the UI.
