### PR TITLE
[SPARK-2162] Double check in doGetLocal to avoid read on removed block.

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -363,6 +363,12 @@ private[spark] class BlockManager(
     val info = blockInfo.get(blockId).orNull
     if (info != null) {
       info.synchronized {
+        // Double check to make sure the block is still there, since it
+        // might has been removed when we actually come here.
+        if (blockInfo.get(blockId).isEmpty) {
+          logDebug(s"Block $blockId had been removed")
+          return None
+        }
 
         // If another thread is writing the block, wait for it to become ready.
         if (!info.waitForReady()) {

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -363,8 +363,9 @@ private[spark] class BlockManager(
     val info = blockInfo.get(blockId).orNull
     if (info != null) {
       info.synchronized {
-        // Double check to make sure the block is still there, since it
-        // might has been removed when we actually come here.
+        // Double check to make sure the block is still there, since removeBlock
+        // method also synchronizes on BlockInfo object, so the block might have
+        // been removed when we actually come here.
         if (blockInfo.get(blockId).isEmpty) {
           logDebug(s"Block $blockId had been removed")
           return None


### PR DESCRIPTION
other wise, it will either read in vain in memory level case, or throw exception in disk level case when it believe the block is there while actually it had been removed.
