### PR TITLE
[SPARK-3411] Improve load-balancing of concurrently-submitted drivers across workers

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -482,7 +482,7 @@ private[spark] class Master(
 
     // First schedule drivers, they take strict precedence over applications
     // Randomization helps balance drivers
-    val shuffledAliveWorkers = Random.shuffle(workers.filter(_.state == WorkerState.ALIVE))
+    val shuffledAliveWorkers = Random.shuffle(workers).toArray
     val aliveWorkerNum = shuffledAliveWorkers.size
     var curPos = aliveWorkerNum - 1
     for (driver <- List(waitingDrivers: _*)) {
@@ -491,7 +491,8 @@ private[spark] class Master(
       var launched = false
       while (curPos != startFlag && !launched) {
         val worker = shuffledAliveWorkers(curPos)
-        if (worker.memoryFree >= driver.desc.mem && worker.coresFree >= driver.desc.cores) {
+        if (worker.state == WorkerState.ALIVE
+          && worker.memoryFree >= driver.desc.mem && worker.coresFree >= driver.desc.cores) {
           launchDriver(worker, driver)
           waitingDrivers -= driver
           launched = true

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -481,7 +481,8 @@ private[spark] class Master(
     if (state != RecoveryState.ALIVE) { return }
 
     // First schedule drivers, they take strict precedence over applications
-    val shuffledAliveWorkers = Random.shuffle(workers.filter(_.state == WorkerState.ALIVE)) // Randomization helps balance drivers
+    // Randomization helps balance drivers
+    val shuffledAliveWorkers = Random.shuffle(workers.filter(_.state == WorkerState.ALIVE))
     val aliveWorkerNum = shuffledAliveWorkers.size
     var curPos = aliveWorkerNum - 1
     for (driver <- List(waitingDrivers: _*)) {


### PR DESCRIPTION
If the waiting driver array is too big, the drivers in it will be dispatched to the first worker we get(if it has enough resources), with or without the Randomization.

We should do randomization every time we dispatch a driver, in order to better balance drivers.
