### PR TITLE
[WIP] SPARK-2157 Ability to write tight firewall rules for Spark

### DIFF
--- a/core/src/main/scala/org/apache/spark/HttpFileServer.scala
+++ b/core/src/main/scala/org/apache/spark/HttpFileServer.scala
@@ -31,14 +31,18 @@ private[spark] class HttpFileServer(securityManager: SecurityManager) extends Lo
   var httpServer : HttpServer = null
   var serverUri : String = null
 
-  def initialize() {
+  def initialize(port: Option[Int]) {
     baseDir = Utils.createTempDir()
     fileDir = new File(baseDir, "files")
     jarDir = new File(baseDir, "jars")
     fileDir.mkdir()
     jarDir.mkdir()
     logInfo("HTTP File server directory is " + baseDir)
-    httpServer = new HttpServer(baseDir, securityManager)
+    httpServer = if (port.isEmpty) {
+      new HttpServer(baseDir, securityManager)
+    } else {
+      new HttpServer(baseDir, securityManager, port.get)
+    }
     httpServer.start()
     serverUri = httpServer.uri
     logDebug("HTTP file server started at: " + serverUri)

--- a/core/src/main/scala/org/apache/spark/HttpServer.scala
+++ b/core/src/main/scala/org/apache/spark/HttpServer.scala
@@ -48,7 +48,7 @@ private[spark] class HttpServer(resourceBase: File,
   private var server: Server = null
   private var port: Int = localPort
 
-  private def startOnPort(startPort: Int): Server = {
+  private def startOnPort(startPort: Int): (Server, Int) = {
     val server = new Server()
     val connector = new SocketConnector
     connector.setMaxIdleTime(60*1000)
@@ -79,7 +79,7 @@ private[spark] class HttpServer(resourceBase: File,
     server.start()
     val actualPort = server.getConnectors()(0).getLocalPort()
 
-    server
+    (server, actualPort)
   }
 
   def start() {

--- a/core/src/main/scala/org/apache/spark/HttpServer.scala
+++ b/core/src/main/scala/org/apache/spark/HttpServer.scala
@@ -41,10 +41,11 @@ private[spark] class ServerStateException(message: String) extends Exception(mes
  * as well as classes created by the interpreter when the user types in code. This is just a wrapper
  * around a Jetty server.
  */
-private[spark] class HttpServer(resourceBase: File, securityManager: SecurityManager)
-    extends Logging {
+private[spark] class HttpServer(resourceBase: File,
+                                securityManager: SecurityManager,
+                                localPort: Int = 0) extends Logging {
   private var server: Server = null
-  private var port: Int = -1
+  private var port: Int = localPort
 
   def start() {
     if (server != null) {
@@ -55,7 +56,7 @@ private[spark] class HttpServer(resourceBase: File, securityManager: SecurityMan
       val connector = new SocketConnector
       connector.setMaxIdleTime(60*1000)
       connector.setSoLingerTime(-1)
-      connector.setPort(0)
+      connector.setPort(localPort)
       server.addConnector(connector)
 
       val threadPool = new QueuedThreadPool

--- a/core/src/main/scala/org/apache/spark/HttpServer.scala
+++ b/core/src/main/scala/org/apache/spark/HttpServer.scala
@@ -84,7 +84,7 @@ private[spark] class HttpServer(resourceBase: File,
   private def startWithIncrements(startPort: Int, maxRetries: Int): Tuple2[Server,Int] = {
     for( offset <- 0 to maxRetries) {
       try {
-        val (server, actualPort) = startOnPort(startPort+offset)
+        val (server, actualPort) = startOnPort(startPort + offset)
         return (server, actualPort)
       } catch {
         case e: java.net.BindException => {
@@ -92,7 +92,7 @@ private[spark] class HttpServer(resourceBase: File,
             offset == (maxRetries-1)) {
             throw e
           }
-          logInfo("Could not bind on port: " + (startPort+offset))
+          logInfo("Could not bind on port: " + (startPort + offset))
         }
         case e: Exception => throw e
       }

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -231,7 +231,7 @@ object SparkEnv extends Logging {
     val httpFileServer =
       if (isDriver) {
         val server = new HttpFileServer(securityManager)
-        server.initialize()
+        server.initialize(conf.getOption("spark.fileserver.port").map(_.toInt))
         conf.set("spark.fileserver.uri",  server.serverUri)
         server
       } else {

--- a/core/src/main/scala/org/apache/spark/broadcast/HttpBroadcast.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/HttpBroadcast.scala
@@ -152,7 +152,8 @@ private[broadcast] object HttpBroadcast extends Logging {
 
   private def createServer(conf: SparkConf) {
     broadcastDir = Utils.createTempDir(Utils.getLocalDir(conf))
-    server = new HttpServer(broadcastDir, securityManager)
+    val broadcastListenPort: Int = conf.getInt("spark.broadcast.port", 0)
+    server = new HttpServer(broadcastDir, securityManager, broadcastListenPort)
     server.start()
     serverUri = server.uri
     logInfo("Broadcast server started at " + serverUri)

--- a/core/src/main/scala/org/apache/spark/network/ConnectionManager.scala
+++ b/core/src/main/scala/org/apache/spark/network/ConnectionManager.scala
@@ -104,7 +104,7 @@ private[spark] class ConnectionManager(port: Int, conf: SparkConf,
 
   private def startService(port: Int) = {
     serverChannel.socket.bind(new InetSocketAddress(port))
-    serverChannel
+    (serverChannel, port)
   }
   PortManager.startWithIncrements(port, 3, startService)
   serverChannel.register(selector, SelectionKey.OP_ACCEPT)

--- a/core/src/main/scala/org/apache/spark/network/ConnectionManager.scala
+++ b/core/src/main/scala/org/apache/spark/network/ConnectionManager.scala
@@ -102,24 +102,11 @@ private[spark] class ConnectionManager(port: Int, conf: SparkConf,
   serverChannel.socket.setReuseAddress(true)
   serverChannel.socket.setReceiveBufferSize(256 * 1024)
 
-  def bindWithIncrement(port: Int, maxTries: Int = 3) {
-    for( offset <- 0 until maxTries ) {
-      try {
-        serverChannel.socket.bind(new InetSocketAddress(port + offset))
-        return
-      } catch {
-        case e: java.net.BindException => {
-          if(!e.getMessage.contains("Address already in use") ||
-             offset == maxTries) {
-            throw e
-          }
-          logInfo("Could not bind on port: " + (port + offset))
-        }
-        case e: Exception => throw e
-      }
-    }
+  private def startService(port: Int) = {
+    serverChannel.socket.bind(new InetSocketAddress(port))
+    serverChannel
   }
-  bindWithIncrement(port, 3)
+  PortManager.startWithIncrements(port, 3, startService)
   serverChannel.register(selector, SelectionKey.OP_ACCEPT)
 
   val id = new ConnectionManagerId(Utils.localHostName, serverChannel.socket.getLocalPort)

--- a/core/src/main/scala/org/apache/spark/network/ConnectionManager.scala
+++ b/core/src/main/scala/org/apache/spark/network/ConnectionManager.scala
@@ -113,7 +113,7 @@ private[spark] class ConnectionManager(port: Int, conf: SparkConf,
              offset == maxTries) {
             throw e
           }
-          logInfo("Could not bind on port: " + (port+offset))
+          logInfo("Could not bind on port: " + (port + offset))
         }
         case e: Exception => throw e
       }

--- a/core/src/main/scala/org/apache/spark/network/PortManager.scala
+++ b/core/src/main/scala/org/apache/spark/network/PortManager.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network
+
+import java.net.InetSocketAddress
+
+import org.apache.spark.{Logging, SparkException}
+import org.eclipse.jetty.server.Server
+
+private[spark] object PortManager extends Logging
+{
+
+  /**
+   * Start service on given port, or attempt to fall back to the n+1 port for a certain number of
+   * retries
+   *
+   * @param startPort
+   * @param maxRetries Maximum number of retries to attempt.  A value of e.g. 3 will cause 4
+   *                   total attempts, on ports n, n+1, n+2, and n+3
+   * @param startService Function to start service on a given port.  Expected to throw a java.net
+   *                     .BindException if the port is already in use
+   * @tparam T
+   * @throws SparkException When unable to start service in the given number of attempts
+   * @return
+   */
+  def startWithIncrements[T](startPort: Int, maxRetries: Int, startService: Int => T):
+      (T, Int) = {
+    for( offset <- 0 to maxRetries) {
+      val tryPort = startPort + offset
+      try {
+        val service: T = startService(tryPort)
+        return (service, tryPort)
+      } catch {
+        case e: java.net.BindException => {
+          if (!e.getMessage.contains("Address already in use") ||
+            offset == (maxRetries-1)) {
+            throw e
+          }
+          logInfo("Could not bind on port: " + tryPort + ". Attempting port " + (tryPort+1))
+        }
+        case e: Exception => throw e
+      }
+    }
+    throw new SparkException(s"Couldn't start service on port $startPort")
+  }
+}

--- a/core/src/main/scala/org/apache/spark/network/PortManager.scala
+++ b/core/src/main/scala/org/apache/spark/network/PortManager.scala
@@ -51,7 +51,7 @@ private[spark] object PortManager extends Logging
             offset == (maxRetries-1)) {
             throw e
           }
-          logInfo("Could not bind on port: " + tryPort + ". Attempting port " + (tryPort+1))
+          logInfo("Could not bind on port: " + tryPort + ". Attempting port " + (tryPort + 1))
         }
         case e: Exception => throw e
       }

--- a/core/src/main/scala/org/apache/spark/network/PortManager.scala
+++ b/core/src/main/scala/org/apache/spark/network/PortManager.scala
@@ -38,13 +38,12 @@ private[spark] object PortManager extends Logging
    * @throws SparkException When unable to start service in the given number of attempts
    * @return
    */
-  def startWithIncrements[T](startPort: Int, maxRetries: Int, startService: Int => T):
+  def startWithIncrements[T](startPort: Int, maxRetries: Int, startService: Int => (T, Int)):
       (T, Int) = {
     for( offset <- 0 to maxRetries) {
       val tryPort = startPort + offset
       try {
-        val service: T = startService(tryPort)
-        return (service, tryPort)
+        return startService(tryPort)
       } catch {
         case e: java.net.BindException => {
           if (!e.getMessage.contains("Address already in use") ||

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -63,7 +63,8 @@ private[spark] class BlockManager(
   val shuffleBlockManager = new ShuffleBlockManager(this)
   val diskBlockManager = new DiskBlockManager(shuffleBlockManager,
     conf.get("spark.local.dir", System.getProperty("java.io.tmpdir")))
-  val connectionManager = new ConnectionManager(0, conf, securityManager)
+  val connectionManager = new ConnectionManager(conf.getInt("spark.blockManager.port", 0), conf,
+    securityManager)
 
   implicit val futureExecContext = connectionManager.futureExecContext
 

--- a/docs/spark-standalone.md
+++ b/docs/spark-standalone.md
@@ -322,7 +322,7 @@ configure those ports.
   </tr>
   <tr>
     <td>Browser</td>
-    <td>Driver</td>
+    <td>Application</td>
     <td>4040</td>
     <td>Web UI</td>
     <td><code>spark.ui.port</code></td>
@@ -372,18 +372,37 @@ configure those ports.
 
   <!-- Other misc stuff -->
   <tr>
-    <td>Driver and other Workers</td>
     <td>Worker</td>
+    <td>Application</td>
     <td>(random)</td>
-    <td>
-      <ul>
-        <li>File server for file and jars</li>
-        <li>Http Broadcast</li>
-        <li>Class file server (Spark Shell only)</li>
-      </ul>
-    </td>
-    <td>None</td>
-    <td>Jetty-based.  Each of these services starts on a random port that cannot be configured</td>
+    <td>File server for files and jars</td>
+    <td><code>spark.fileserver.port</code></td>
+    <td>Jetty-based</td>
+  </tr>
+  <tr>
+    <td>Worker</td>
+    <td>Application</td>
+    <td>(random)</td>
+    <td>HTTP Broadcast</td>
+    <td><code>spark.broadcast.port</code></td>
+    <td>Jetty-based.  Not used by TorrentBroadcast, which sends data through the block manager
+    instead</td>
+  </tr>
+  <tr>
+    <td>Worker</td>
+    <td>Spark Shell</td>
+    <td>(random)</td>
+    <td>Class file server (Spark Shell only)</td>
+    <td><code>spark.replClassServer.port</code></td>
+    <td>Jetty-based</td>
+  </tr>
+  <tr>
+    <td>Worker</td>
+    <td>Other Workers</td>
+    <td>(random)</td>
+    <td>Block Manager port</td>
+    <td><code>spark.blockManager.port</code></td>
+    <td>Raw socket via ServerSocketChannel</td>
   </tr>
 
 </table>

--- a/repl/src/main/scala/org/apache/spark/repl/SparkIMain.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/SparkIMain.scala
@@ -102,7 +102,8 @@ import org.apache.spark.util.Utils
 
     val virtualDirectory                              = new PlainFile(outputDir) // "directory" for classfiles
     /** Jetty server that will serve our classes to worker nodes */
-    val classServer                                   = new HttpServer(outputDir, new SecurityManager(conf))
+    val classServerListenPort: Int                    = conf.getInt("spark.replClassServer.port", 0)
+    val classServer                                   = new HttpServer(outputDir, new SecurityManager(conf), classServerListenPort)
     private var currentSettings: Settings             = initialSettings
     var printResults                                  = true      // whether to print result lines
     var totalSilence                                  = false     // whether to print anything

--- a/repl/src/main/scala/org/apache/spark/repl/SparkIMain.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/SparkIMain.scala
@@ -102,7 +102,7 @@ import org.apache.spark.util.Utils
 
     val virtualDirectory                              = new PlainFile(outputDir) // "directory" for classfiles
     /** Jetty server that will serve our classes to worker nodes */
-    val classServerListenPort: Int                    = conf.getInt("spark.replClassServer.port", 0)
+    val classServerListenPort                         = conf.getInt("spark.replClassServer.port", 0)
     val classServer                                   = new HttpServer(outputDir, new SecurityManager(conf), classServerListenPort)
     private var currentSettings: Settings             = initialSettings
     var printResults                                  = true      // whether to print result lines


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-2157

This pull request adds the ability to specify every port opened by Spark that I could find to configure.  Specifically, it adds the following four configuration options:
- `spark.fileserver.port`
- `spark.broadcast.port`
- `spark.replClassServer.port`
- `spark.blockManager.port`

Of those options, most will attempt to fall back to the n+1 incremental port if the port is currently in use.  This incremental fallback logic is done for :
- `spark.broadcast.port`
- `spark.blockManager.port`
- `spark.replClassServer.port`

But not for `spark.fileserver.port`

Things still thinking about for this PR:
- I'm still observing instances of `CoarseGrainedExecutorBackend` listening on ephemeral ports
- In earlier documentation `spark.driver.port` is described as being the way to configure :7077 on Spark Master, and I'm not sure this is the case.  If so the same config item is used for multiple things, as it's also the port on which the applications starts listening on Akka.

Many thanks to @epahomov whose work this is based off of. 
