### PR TITLE
HOTFIX: bug caused by #941

### DIFF
--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -693,7 +693,7 @@ def ssh(host, opts, command):
 def _check_output(*popenargs, **kwargs):
     if 'stdout' in kwargs:
         raise ValueError('stdout argument not allowed, it will be overridden.')
-    process = subprocess.Popen(stdout=PIPE, *popenargs, **kwargs)
+    process = subprocess.Popen(stdout=subprocess.PIPE, *popenargs, **kwargs)
     output, unused_err = process.communicate()
     retcode = process.poll()
     if retcode:


### PR DESCRIPTION
This patch should have qualified the use of PIPE. This needs to be back ported into 0.9 and 1.0.
