### PR TITLE
SPARK-2170: Fix for global name 'PIPE' is not defined

### DIFF
--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -693,7 +693,7 @@ def ssh(host, opts, command):
 def _check_output(*popenargs, **kwargs):
     if 'stdout' in kwargs:
         raise ValueError('stdout argument not allowed, it will be overridden.')
-    process = subprocess.Popen(stdout=PIPE, *popenargs, **kwargs)
+    process = subprocess.Popen(stdout=subprocess.PIPE, *popenargs, **kwargs)
     output, unused_err = process.communicate()
     retcode = process.poll()
     if retcode:


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-2170

Before this fix, when running ./spark-ec2 script:

```
    Traceback (most recent call last):
      File "./spark_ec2.py", line 894, in <module>
        main()
      File "./spark_ec2.py", line 886, in main
        real_main()
      File "./spark_ec2.py", line 770, in real_main
        setup_cluster(conn, master_nodes, slave_nodes, opts, True)
      File "./spark_ec2.py", line 475, in setup_cluster
        dot_ssh_tar = ssh_read(master, opts, ['tar', 'c', '.ssh'])
      File "./spark_ec2.py", line 709, in ssh_read
        ssh_command(opts) + ['%s@%s' % (opts.user, host), stringify_command(command)])
      File "./spark_ec2.py", line 696, in _check_output
        process = subprocess.Popen(stdout=PIPE, *popenargs, **kwargs)
    NameError: global name 'PIPE' is not defined
```
