### PR TITLE
[SPARK-2177][SQL] describe table result contains only one column

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/commands.scala
@@ -60,3 +60,16 @@ case class ExplainCommand(plan: LogicalPlan) extends Command {
  * Returned for the "CACHE TABLE tableName" and "UNCACHE TABLE tableName" command.
  */
 case class CacheCommand(tableName: String, doCache: Boolean) extends Command
+
+/**
+ * Returned for the "Describe tableName" command. [Extended|Formatted|Pretty] is not handled.
+ */
+case class DescribeCommand(
+    table: LogicalPlan,
+    isFormatted: Boolean,
+    isExtended: Boolean) extends Command {
+  override def output = Seq(
+    BoundReference(0, AttributeReference("name", StringType, nullable = false)()),
+    BoundReference(1, AttributeReference("type", StringType, nullable = false)()),
+    BoundReference(2, AttributeReference("comment", StringType, nullable = false)()))
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/commands.scala
@@ -62,11 +62,7 @@ case class ExplainCommand(plan: LogicalPlan) extends Command {
 case class CacheCommand(tableName: String, doCache: Boolean) extends Command
 
 /**
- * Returned for the "DESCRIBE tableName" command.
- */
-
-/**
- * Returned for the "DESCRIBE tableName" command.
+ * Returned for the "DESCRIBE [EXTENDED] [dbName.]tableName" command.
  * @param table The table to be described.
  * @param isExtended True if "DESCRIBE EXTENDED" is used. Otherwise, false.
  *                   It is effective only when the table is a Hive table.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/commands.scala
@@ -62,7 +62,16 @@ case class ExplainCommand(plan: LogicalPlan) extends Command {
 case class CacheCommand(tableName: String, doCache: Boolean) extends Command
 
 /**
- * Returned for the "Describe tableName" command.
+ * Returned for the "DESCRIBE tableName" command.
+ */
+
+/**
+ * Returned for the "DESCRIBE tableName" command.
+ * @param table The table to be described.
+ * @param isFormatted True if "DESCRIBE FORMATTED" is used. Otherwise, false.
+ *                    It is effective only when the table is a Hive table.
+ * @param isExtended True if "DESCRIBE EXTENDED" is used. Otherwise, false.
+ *                   It is effective only when the table is a Hive table.
  */
 case class DescribeCommand(
     table: LogicalPlan,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/commands.scala
@@ -62,7 +62,7 @@ case class ExplainCommand(plan: LogicalPlan) extends Command {
 case class CacheCommand(tableName: String, doCache: Boolean) extends Command
 
 /**
- * Returned for the "Describe tableName" command. [Extended|Formatted|Pretty] is not handled.
+ * Returned for the "Describe tableName" command.
  */
 case class DescribeCommand(
     table: LogicalPlan,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/commands.scala
@@ -68,17 +68,15 @@ case class CacheCommand(tableName: String, doCache: Boolean) extends Command
 /**
  * Returned for the "DESCRIBE tableName" command.
  * @param table The table to be described.
- * @param isFormatted True if "DESCRIBE FORMATTED" is used. Otherwise, false.
- *                    It is effective only when the table is a Hive table.
  * @param isExtended True if "DESCRIBE EXTENDED" is used. Otherwise, false.
  *                   It is effective only when the table is a Hive table.
  */
 case class DescribeCommand(
     table: LogicalPlan,
-    isFormatted: Boolean,
     isExtended: Boolean) extends Command {
   override def output = Seq(
-    BoundReference(0, AttributeReference("name", StringType, nullable = false)()),
-    BoundReference(1, AttributeReference("type", StringType, nullable = false)()),
+    // Column names are based on Hive.
+    BoundReference(0, AttributeReference("col_name", StringType, nullable = false)()),
+    BoundReference(1, AttributeReference("data_type", StringType, nullable = false)()),
     BoundReference(2, AttributeReference("comment", StringType, nullable = false)()))
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
@@ -130,8 +130,10 @@ case class DescribeCommand(child: SparkPlan, output: Seq[Attribute])(
     @transient context: SQLContext)
   extends LeafNode with Command {
 
-  override protected[sql] lazy val sideEffectResult: Seq[(String, String, String)] =
-    child.output.map(field => (field.name, field.dataType.toString, None.toString))
+  override protected[sql] lazy val sideEffectResult: Seq[(String, String, String)] = {
+    Seq(("# Registered as a temporary table", null, null)) ++
+      child.output.map(field => (field.name, field.dataType.toString, null))
+  }
 
   override def execute(): RDD[Row] = {
     val rows = sideEffectResult.map {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -38,6 +38,7 @@ import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.types._
 import org.apache.spark.sql.execution.QueryExecutionException
 import org.apache.spark.sql.execution.{Command => PhysicalCommand}
+import org.apache.spark.sql.hive.execution.DescribeHiveTableCommand
 
 /**
  * Starts up an instance of hive where metadata is stored locally. An in-process metadata data is
@@ -291,6 +292,10 @@ class HiveContext(sc: SparkContext) extends SQLContext(sc) {
      * execution is simply passed back to Hive.
      */
     def stringResult(): Seq[String] = executedPlan match {
+      case describeHiveTableCommand: DescribeHiveTableCommand =>
+        // If it is a describe command for a Hive table, we want to have the output format
+        // be similar with Hive.
+        describeHiveTableCommand.hiveString
       case command: PhysicalCommand =>
         command.sideEffectResult.map(_.toString)
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
@@ -403,6 +403,7 @@ private[hive] object HiveQl {
             nameParts.head match {
               case Token(".", dbName :: tableName :: Nil) =>
                 // It is describing a table with the format like "describe db.table".
+                // TODO: Actually, a user may mean tableName.columnName. Need to resolve this issue.
                 val (db, tableName) = extractDbNameTableName(nameParts.head)
                 DescribeCommand(
                   UnresolvedRelation(db, tableName, None), extended.isDefined)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
@@ -369,7 +369,7 @@ private[hive] object HiveQl {
 
   protected def extractDbNameTableName(tableNameParts: Node): (Option[String], String) = {
     val (db, tableName) =
-      tableNameParts.getChildren.map{ case Token(part, Nil) => cleanIdentifier(part)} match {
+      tableNameParts.getChildren.map { case Token(part, Nil) => cleanIdentifier(part) } match {
         case Seq(tableOnly) => (None, tableOnly)
         case Seq(databaseName, table) => (Some(databaseName), table)
       }
@@ -379,7 +379,8 @@ private[hive] object HiveQl {
 
   protected def nodeToPlan(node: Node): LogicalPlan = node match {
     // Just fake explain for any of the native commands.
-    case Token("TOK_EXPLAIN", explainArgs) if noExplainCommands contains explainArgs.head.getText =>
+    case Token("TOK_EXPLAIN", explainArgs)
+      if noExplainCommands.contains(explainArgs.head.getText) =>
       ExplainCommand(NoRelation)
     case Token("TOK_EXPLAIN", explainArgs) =>
       // Ignore FORMATTED if present.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
@@ -52,7 +52,6 @@ private[hive] case class AddFile(filePath: String) extends Command
 private[hive] object HiveQl {
   protected val nativeCommands = Seq(
     "TOK_DESCFUNCTION",
-    "TOK_DESCTABLE",
     "TOK_DESCDATABASE",
     "TOK_SHOW_TABLESTATUS",
     "TOK_SHOWDATABASES",
@@ -119,6 +118,12 @@ private[hive] object HiveQl {
 
     "TOK_SWITCHDATABASE"
   )
+
+  // Commands that we do not need to explain.
+  protected val noExplainCommands = Seq(
+    "TOK_CREATETABLE",
+    "TOK_DESCTABLE"
+  ) ++ nativeCommands
 
   /**
    * A set of implicit transformations that allow Hive ASTNodes to be rewritten by transformations
@@ -362,13 +367,19 @@ private[hive] object HiveQl {
     }
   }
 
+  protected def extractDbNameTableName(tableNameParts: Node): (Option[String], String) = {
+    val (db, tableName) =
+      tableNameParts.getChildren.map{ case Token(part, Nil) => cleanIdentifier(part)} match {
+        case Seq(tableOnly) => (None, tableOnly)
+        case Seq(databaseName, table) => (Some(databaseName), table)
+      }
+
+    (db, tableName)
+  }
+
   protected def nodeToPlan(node: Node): LogicalPlan = node match {
     // Just fake explain for any of the native commands.
-    case Token("TOK_EXPLAIN", explainArgs) if nativeCommands contains explainArgs.head.getText =>
-      ExplainCommand(NoRelation)
-    // Create tables aren't native commands due to CTAS queries, but we still don't need to
-    // explain them.
-    case Token("TOK_EXPLAIN", explainArgs) if explainArgs.head.getText == "TOK_CREATETABLE" =>
+    case Token("TOK_EXPLAIN", explainArgs) if noExplainCommands contains explainArgs.head.getText =>
       ExplainCommand(NoRelation)
     case Token("TOK_EXPLAIN", explainArgs) =>
       // Ignore FORMATTED if present.
@@ -376,6 +387,34 @@ private[hive] object HiveQl {
         getClauses(Seq("TOK_QUERY", "FORMATTED", "EXTENDED"), explainArgs)
       // TODO: support EXTENDED?
       ExplainCommand(nodeToPlan(query))
+
+    case Token("TOK_DESCTABLE", describeArgs) =>
+      // Reference: https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL
+      val Some(tableType) :: formatted :: extended :: _ :: Nil =
+        getClauses(Seq("TOK_TABTYPE", "FORMATTED", "EXTENDED", "PRETTY"), describeArgs)
+      // TODO: support PRETTY?
+      tableType match {
+        case Token("TOK_TABTYPE", nameParts) if nameParts.size == 1 => {
+          nameParts.head match {
+            case Token(".", dbName :: tableName :: Nil) =>
+              // It is describing a table with the format like "describe db.table".
+              val (db, tableName) = extractDbNameTableName(nameParts.head)
+              DescribeCommand(
+                UnresolvedRelation(db, tableName, None), formatted.isDefined, extended.isDefined)
+            case Token(".", dbName :: tableName :: colName :: Nil) =>
+              // It is describing a column with the format like "describe db.table column".
+              NativePlaceholder
+            case tableName =>
+              // It is describing a table with the format like "describe table".
+              DescribeCommand(
+                UnresolvedRelation(None, tableName.getText, None),
+                formatted.isDefined,
+                extended.isDefined)
+          }
+        }
+        // All other cases.
+        case _ => NativePlaceholder
+      }
 
     case Token("TOK_CREATETABLE", children)
         if children.collect { case t@Token("TOK_QUERY", _) => t }.nonEmpty =>
@@ -414,11 +453,8 @@ private[hive] object HiveQl {
           s"Unhandled clauses: ${notImplemented.flatten.map(dumpTree(_)).mkString("\n")}")
       }
 
-      val (db, tableName) =
-        tableNameParts.getChildren.map{ case Token(part, Nil) => cleanIdentifier(part)} match {
-          case Seq(tableOnly) => (None, tableOnly)
-          case Seq(databaseName, table) => (Some(databaseName), table)
-        }
+      val (db, tableName) = extractDbNameTableName(tableNameParts)
+
       InsertIntoCreatedTable(db, tableName, nodeToPlan(query))
 
     // If its not a "CREATE TABLE AS" like above then just pass it back to hive as a native command.
@@ -736,11 +772,7 @@ private[hive] object HiveQl {
       val Some(tableNameParts) :: partitionClause :: Nil =
         getClauses(Seq("TOK_TABNAME", "TOK_PARTSPEC"), tableArgs)
 
-      val (db, tableName) =
-        tableNameParts.getChildren.map{ case Token(part, Nil) => cleanIdentifier(part)} match {
-          case Seq(tableOnly) => (None, tableOnly)
-          case Seq(databaseName, table) => (Some(databaseName), table)
-        }
+      val (db, tableName) = extractDbNameTableName(tableNameParts)
 
       val partitionKeys = partitionClause.map(_.getChildren.map {
         // Parse partitions. We also make keys case insensitive.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.hive
 
-import org.apache.spark.sql.{SQLContext}
+import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.planning._
 import org.apache.spark.sql.catalyst.plans._
@@ -88,10 +88,6 @@ private[hive] trait HiveStrategies {
             Seq(DescribeHiveTableCommand(
               t, describe.output, describe.isFormatted, describe.isExtended)(context))
           case o: LogicalPlan =>
-            if (describe.isFormatted)
-              logger.info("Formatted is ignored because it is not defined for non-Hive tables.")
-            if (describe.isExtended)
-              logger.info("Extended is ignored because it is not defined for non-Hive tables.")
             Seq(DescribeCommand(planLater(o), describe.output)(context))
         }
       }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -86,7 +86,7 @@ private[hive] trait HiveStrategies {
         resolvedTable match {
           case t: MetastoreRelation =>
             Seq(DescribeHiveTableCommand(
-              t, describe.output, describe.isFormatted, describe.isExtended)(context))
+              t, describe.output, describe.isExtended)(context))
           case o: LogicalPlan =>
             Seq(DescribeCommand(planLater(o), describe.output)(context))
         }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/hiveOperators.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/hiveOperators.scala
@@ -454,7 +454,7 @@ case class NativeCommand(
         // This method is introduced by https://issues.apache.org/jira/browse/HIVE-4545.
         // Right now, we split every string by any number of consecutive spaces.
         sideEffectResult.map(
-          r => r.split("\\s+")).map(r => new GenericRow(r.asInstanceOf[Array[Any]]))
+          r => r.trim.split("\\s+", 3)).map(r => new GenericRow(r.asInstanceOf[Array[Any]]))
       } else {
         sideEffectResult.map(r => new GenericRow(Array[Any](r)))
       }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/hiveOperators.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/hiveOperators.scala
@@ -19,11 +19,11 @@ package org.apache.spark.sql.hive.execution
 
 import org.apache.hadoop.hive.common.`type`.{HiveDecimal, HiveVarchar}
 import org.apache.hadoop.hive.conf.HiveConf
-import org.apache.hadoop.hive.metastore.api.FieldSchema
 import org.apache.hadoop.hive.metastore.MetaStoreUtils
+import org.apache.hadoop.hive.metastore.api.FieldSchema
 import org.apache.hadoop.hive.ql.Context
-import org.apache.hadoop.hive.ql.metadata.formatting.MetaDataFormatUtils
 import org.apache.hadoop.hive.ql.metadata.{Partition => HivePartition, Hive}
+import org.apache.hadoop.hive.ql.metadata.formatting.MetaDataFormatUtils
 import org.apache.hadoop.hive.ql.plan.{TableDesc, FileSinkDesc}
 import org.apache.hadoop.hive.serde.serdeConstants
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils.ObjectInspectorCopyOption

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/hiveOperators.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/hiveOperators.scala
@@ -490,8 +490,10 @@ case class DescribeHiveTableCommand(
       val partColumnInfo =
         partitionColumns.map(field => (field.getName, field.getType, field.getComment))
       results ++=
-        partColumnInfo ++ Seq(("# Partition Information", "", "")) ++
-          Seq((s"# ${output.get(0).name}", output.get(1).name, output.get(2).name)) ++ partColumnInfo
+        partColumnInfo ++
+        Seq(("# Partition Information", "", "")) ++
+        Seq((s"# ${output.get(0).name}", output.get(1).name, output.get(2).name)) ++
+        partColumnInfo
     }
 
     if (isExtended) {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveComparisonTest.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveComparisonTest.scala
@@ -145,9 +145,11 @@ abstract class HiveComparisonTest
       case _: LogicalNativeCommand => answer.filterNot(nonDeterministicLine).filterNot(_ == "")
       case _: ExplainCommand => answer
       case _: DescribeCommand =>
+        // Filter out non-deterministic lines and lines which do not have actual results but
+        // can introduce problems because of the way Hive formats these lines.
+        // Then, remove empty lines. Do not sort the results.
         answer.filterNot(
-          r => nonDeterministicLine(r) || ignoredLine(r)).map(_.trim).filterNot(
-            r => r == "" || r == "\n")
+          r => nonDeterministicLine(r) || ignoredLine(r)).map(_.trim).filterNot(_ == "")
       case plan => if (isSorted(plan)) answer else answer.sorted
     }
     orderedAnswer.map(cleanPaths)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveComparisonTest.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveComparisonTest.scala
@@ -144,6 +144,10 @@ abstract class HiveComparisonTest
       case _: SetCommand => Seq("0")
       case _: LogicalNativeCommand => answer.filterNot(nonDeterministicLine).filterNot(_ == "")
       case _: ExplainCommand => answer
+      case _: DescribeCommand =>
+        answer.filterNot(
+          r => nonDeterministicLine(r) || ignoredLine(r)).map(_.trim).filterNot(
+            r => r == "" || r == "\n")
       case plan => if (isSorted(plan)) answer else answer.sorted
     }
     orderedAnswer.map(cleanPaths)
@@ -168,6 +172,16 @@ abstract class HiveComparisonTest
   )
   protected def nonDeterministicLine(line: String) =
     nonDeterministicLineIndicators.exists(line contains _)
+
+  // This list contains indicators for those lines which do not have actual results and we
+  // want to ignore.
+  lazy val ignoredLineIndicators = Seq(
+    "# Partition Information",
+    "# col_name"
+  )
+
+  protected def ignoredLine(line: String) =
+    ignoredLineIndicators.exists(line contains _)
 
   /**
    * Removes non-deterministic paths from `str` so cached answers will compare correctly.
@@ -329,10 +343,16 @@ abstract class HiveComparisonTest
 
             if ((!hiveQuery.logical.isInstanceOf[ExplainCommand]) && preparedHive != catalyst) {
 
-              val hivePrintOut = s"== HIVE - ${hive.size} row(s) ==" +: preparedHive
+              val hivePrintOut = s"== HIVE - ${preparedHive.size} row(s) ==" +: preparedHive
               val catalystPrintOut = s"== CATALYST - ${catalyst.size} row(s) ==" +: catalyst
 
               val resultComparison = sideBySide(hivePrintOut, catalystPrintOut).mkString("\n")
+
+              println("hive output")
+              hive.foreach(println)
+
+              println("catalyst printout")
+              catalyst.foreach(println)
 
               if (recomputeCache) {
                 logger.warn(s"Clearing cache files for failed test $testCaseName")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCompatibilitySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCompatibilitySuite.scala
@@ -78,7 +78,7 @@ class HiveCompatibilitySuite extends HiveQueryFileTest with BeforeAndAfter {
     "alter_merge",
     "alter_concatenate_indexed_table",
     "protectmode2",
-    "describe_table",
+    //"describe_table",
     "describe_comment_nonascii",
     "udf5",
     "udf_java_method",
@@ -185,7 +185,7 @@ class HiveCompatibilitySuite extends HiveQueryFileTest with BeforeAndAfter {
     "describe_formatted_view_partitioned_json",
 
     // Hive returns the results of describe as plain text. Comments with multiple lines
-    // introduce extra in the Hive results, which make the result comparison fail.
+    // introduce extra lines in the Hive results, which make the result comparison fail.
     "describe_comment_indent"
   )
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCompatibilitySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCompatibilitySuite.scala
@@ -177,7 +177,16 @@ class HiveCompatibilitySuite extends HiveQueryFileTest with BeforeAndAfter {
     // After stop taking the `stringOrError` route, exceptions are thrown from these cases.
     // See SPARK-2129 for details.
     "join_view",
-    "mergejoins_mixed"
+    "mergejoins_mixed",
+
+    // Returning the result of a describe state as a JSON object is not supported.
+    "describe_table_json",
+    "describe_database_json",
+    "describe_formatted_view_partitioned_json",
+
+    // Hive returns the results of describe as plain text. Comments with multiple lines
+    // introduce extra in the Hive results, which make the result comparison fail.
+    "describe_comment_indent"
   )
 
   /**
@@ -292,11 +301,7 @@ class HiveCompatibilitySuite extends HiveQueryFileTest with BeforeAndAfter {
     "default_partition_name",
     "delimiter",
     "desc_non_existent_tbl",
-    "describe_comment_indent",
-    "describe_database_json",
     "describe_formatted_view_partitioned",
-    "describe_formatted_view_partitioned_json",
-    "describe_table_json",
     "diff_part_input_formats",
     "disable_file_format_check",
     "drop_function",

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -270,7 +270,7 @@ class HiveQuerySuite extends HiveComparisonTest {
         Array("dt", "string", null))
     ) {
       hql("DESCRIBE test_describe_commands1")
-        .select('name, 'type, 'comment)
+        .select('col_name, 'data_type, 'comment)
         .collect()
     }
 
@@ -295,7 +295,7 @@ class HiveQuerySuite extends HiveComparisonTest {
         Array("dt", "string", null))
     ) {
       hql("DESCRIBE default.test_describe_commands1")
-        .select('name, 'type, 'comment)
+        .select('col_name, 'data_type, 'comment)
         .collect()
     }
 
@@ -347,7 +347,7 @@ class HiveQuerySuite extends HiveComparisonTest {
         Array("b", "StringType", null))
     ) {
       hql("DESCRIBE test_describe_commands2")
-        .select('name, 'type, 'comment)
+        .select('col_name, 'data_type, 'comment)
         .collect()
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -266,23 +266,13 @@ class HiveQuerySuite extends HiveComparisonTest {
         Array("key", "int", null),
         Array("value", "string", null),
         Array("dt", "string", null),
-        Array("# Partition Information", null, null),
+        Array("# Partition Information", "", ""),
+        Array("# col_name", "data_type", "comment"),
         Array("dt", "string", null))
     ) {
       hql("DESCRIBE test_describe_commands1")
         .select('col_name, 'data_type, 'comment)
         .collect()
-    }
-
-    // Describe a table with keyword FORMATTED
-    // We only
-    assertResult(6) {
-      hql("DESCRIBE FORMATTED test_describe_commands1").count()
-    }
-
-    // Describe a table
-    assertResult(6) {
-      hql("DESCRIBE EXTENDED test_describe_commands1").count()
     }
 
     // Describe a table with a fully qualified table name
@@ -291,7 +281,8 @@ class HiveQuerySuite extends HiveComparisonTest {
         Array("key", "int", null),
         Array("value", "string", null),
         Array("dt", "string", null),
-        Array("# Partition Information", null, null),
+        Array("# Partition Information", "", ""),
+        Array("# col_name", "data_type", "comment"),
         Array("dt", "string", null))
     ) {
       hql("DESCRIBE default.test_describe_commands1")


### PR DESCRIPTION
```
scala> hql("describe src").collect().foreach(println)

[key                    string                  None                ]
[value                  string                  None                ]
```

The result should contain 3 columns instead of one. This screws up JDBC or even the downstream consumer of the Scala/Java/Python APIs.

I am providing a workaround. We handle a subset of describe commands in Spark SQL, which are defined by ...

```
DESCRIBE [EXTENDED] [db_name.]table_name
```

All other cases are treated as Hive native commands.

Also, if we upgrade Hive to 0.13, we need to check the results of context.sessionState.isHiveServerQuery() to determine how to split the result. This method is introduced by https://issues.apache.org/jira/browse/HIVE-4545. We may want to set Hive to use JsonMetaDataFormatter for the output of a DDL statement (`set hive.ddl.output.format=json` introduced by https://issues.apache.org/jira/browse/HIVE-2822).

The link to JIRA: https://issues.apache.org/jira/browse/SPARK-2177
