### PR TITLE
[SPARK-2237][CORE]Add ZLIBCompressionCodec code

### DIFF
--- a/core/src/main/scala/org/apache/spark/io/CompressionCodec.scala
+++ b/core/src/main/scala/org/apache/spark/io/CompressionCodec.scala
@@ -97,3 +97,24 @@ class SnappyCompressionCodec(conf: SparkConf) extends CompressionCodec {
 
   override def compressedInputStream(s: InputStream): InputStream = new SnappyInputStream(s)
 }
+
+
+/**
+ * :: DeveloperApi ::
+ * ZLIB implementation of [[org.apache.spark.io.CompressionCodec]].
+ * 
+ *
+ * Note: The wire protocol for this codec is not guaranteed to be compatible across versions
+ *       of Spark. This is intended for use as an internal compression utility within a single Spark
+ *       application.
+ */
+import com.jcraft.jzlib._
+@DeveloperApi
+class ZLIBCompressionCodec(conf: SparkConf) extends CompressionCodec {
+
+  override def compressedOutputStream(s: OutputStream): OutputStream = {
+ //  val blockSize = conf.getInt("spark.io.compression.snappy.block.size", 32768)
+    //new SnappyOutputStream(s, blockSize)
+   val zOut = new ZOutputStream(s, JZlib.Z_BEST_COMPRESSION)
+         zOut
+  }

--- a/core/src/test/scala/org/apache/spark/io/CompressionCodecSuite.scala
+++ b/core/src/test/scala/org/apache/spark/io/CompressionCodecSuite.scala
@@ -62,3 +62,33 @@ class CompressionCodecSuite extends FunSuite {
     testCodec(codec)
   }
 }
+
+class CompressionCodecSuite extends FunSuite {
+  val conf = new SparkConf(false)
+
+  def testCodec(codec: CompressionCodec) {
+    // Write 1000 integers to the output stream, compressed.
+    val outputStream = new ByteArrayOutputStream()
+    val out = codec.compressedOutputStream(outputStream)
+    for (i <- 1 until 1000) {
+      out.write(i % 256)
+    }
+    out.close()
+
+    // Read the 1000 integers back.
+    val inputStream = new ByteArrayInputStream(outputStream.toByteArray)
+    val in = codec.compressedInputStream(inputStream)
+    for (i <- 1 until 1000) {
+      assert(in.read() === i % 256)
+    }
+    in.close()
+  }
+
+  test("zlib compression codec") {
+    val codec = CompressionCodec.createCodec(conf, classOf[ZLIBCompressionCodec].getName)
+    assert(codec.getClass === classOf[ZLIBCompressionCodec])
+    testCodec(codec)
+  }
+}
+
+


### PR DESCRIPTION
Hi ,ALL,I try to add Spark ZLIBCompressionCodec
the code is here and the jzlib lib is from http://www.jcraft.com/jzlib/
The code can run on Spark source code ,and the test can pass.
I want to add a new API to support ZLIB compress
