### PR TITLE
[SPARK-1112, 2156] use min akka frame size to decide how to send task results

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -214,7 +214,8 @@ private[spark] class Executor(
           // TODO: the task result or block manager. Since this is via the backend, whose actor
           // TODO: system is initialized before receiving the Spark conf, and hence it does not know
           // TODO: `spark.akka.frameSize`. A temporary solution is using the min frame size.
-          if (serializedDirectResult.limit >= AkkaUtils.minFrameSizeBytes - 1024) {
+          // [SPARK-2156] We subtract 200K to leave some space for other data in the Akka message.
+          if (serializedDirectResult.limit >= AkkaUtils.minFrameSizeBytes - 200 * 1024) {
             logInfo("Storing result for " + taskId + " in local BlockManager")
             val blockId = TaskResultBlockId(taskId)
             env.blockManager.putBytes(

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -208,12 +208,10 @@ private[spark] class Executor(
         val serializedDirectResult = ser.serialize(directResult)
         logInfo("Serialized size of result for " + taskId + " is " + serializedDirectResult.limit)
         val serializedResult = {
-          // Akka's message frame size. If task result is bigger than this, we use the block manager
-          // to send the result back.
           // TODO: [SPARK-1112] We use the min frame size to determine whether to use Akka to send
-          // TODO: the task result or block manager. Since this is via the backend, whose actor
-          // TODO: system is initialized before receiving the Spark conf, and hence it does not know
-          // TODO: `spark.akka.frameSize`. A temporary solution is using the min frame size.
+          // the task result or block manager. Since this is via the backend, whose actor system is
+          // initialized before receiving the Spark conf, and hence it does not know
+          // `spark.akka.frameSize`. A temporary solution is using the min frame size.
           // [SPARK-2156] We subtract 200K to leave some space for other data in the Akka message.
           if (serializedDirectResult.limit >= AkkaUtils.minFrameSizeBytes - 200 * 1024) {
             logInfo("Storing result for " + taskId + " in local BlockManager")

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -99,7 +99,10 @@ private[spark] class Executor(
 
   // Akka's message frame size. If task result is bigger than this, we use the block manager
   // to send the result back.
-  private val akkaFrameSize = AkkaUtils.maxFrameSizeBytes(conf)
+  // TODO: [SPARK-1112] We use the min frame size to determine whether to use Akka to send the
+  // TODO: task result or block manager. Since this is via the backend, whose actor system is
+  // TODO: initialized before receiving the Spark conf, the safe bet is using the min frame size.
+  private val akkaFrameSize = AkkaUtils.minFrameSizeBytes
 
   // Start worker thread pool
   val threadPool = Utils.newDaemonCachedThreadPool("Executor task launch worker")

--- a/core/src/main/scala/org/apache/spark/util/AkkaUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/AkkaUtils.scala
@@ -122,6 +122,6 @@ private[spark] object AkkaUtils extends Logging {
     math.max(conf.getInt("spark.akka.frameSize", 0) * 1024 * 1024, minFrameSizeBytes)
   }
 
-  /** The min frame size for Akka messages in bytes. */
+  /** The minimum value of the max frame size for Akka messages in bytes. */
   val minFrameSizeBytes = 10 * 1024 * 1024
 }

--- a/core/src/main/scala/org/apache/spark/util/AkkaUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/AkkaUtils.scala
@@ -119,6 +119,9 @@ private[spark] object AkkaUtils extends Logging {
 
   /** Returns the configured max frame size for Akka messages in bytes. */
   def maxFrameSizeBytes(conf: SparkConf): Int = {
-    conf.getInt("spark.akka.frameSize", 10) * 1024 * 1024
+    math.max(conf.getInt("spark.akka.frameSize", 0) * 1024 * 1024, minFrameSizeBytes)
   }
+
+  /** The min frame size for Akka messages in bytes. */
+  val minFrameSizeBytes = 10 * 1024 * 1024
 }

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -179,7 +179,6 @@ class MapOutputTrackerSuite extends FunSuite with LocalSparkContext {
 
   test("remote fetch exceeds akka frame size") {
     val newConf = new SparkConf
-    newConf.set("spark.akka.frameSize", "1")
     newConf.set("spark.akka.askTimeout", "1") // Fail fast
 
     val masterTracker = new MapOutputTrackerMaster(conf)
@@ -188,14 +187,18 @@ class MapOutputTrackerSuite extends FunSuite with LocalSparkContext {
       new MapOutputTrackerMasterActor(masterTracker, newConf))(actorSystem)
     val masterActor = actorRef.underlyingActor
 
-    // Frame size should be ~1.1MB, and MapOutputTrackerMasterActor should throw exception.
-    // Note that the size is hand-selected here because map output statuses are compressed before
-    // being sent.
-    masterTracker.registerShuffle(20, 100)
-    (0 until 100).foreach { i =>
-      masterTracker.registerMapOutput(20, i, new MapStatus(
-        BlockManagerId("999", "mps", 1000, 0), Array.fill[Byte](4000000)(0)))
+    // Frame size should be 2 * AkkaUtils.minFrameSizeBytes, and MapOutputTrackerMasterActor should
+    // throw exception.
+    val shuffleId = 20
+    val numMaps = 2
+    val data = new Array[Byte](AkkaUtils.minFrameSizeBytes)
+    val random = new java.util.Random(0)
+    random.nextBytes(data) // Make it hard to compress.
+    masterTracker.registerShuffle(shuffleId, numMaps)
+    (0 until numMaps).foreach { i =>
+      masterTracker.registerMapOutput(shuffleId, i, new MapStatus(
+        BlockManagerId("999", "mps", 1000, 0), data))
     }
-    intercept[SparkException] { masterActor.receive(GetMapOutputStatuses(20)) }
+    intercept[SparkException] { masterActor.receive(GetMapOutputStatuses(shuffleId)) }
   }
 }


### PR DESCRIPTION
Task results are sent either via akka directly or block manager indirectly, based on whether the size of the serialized task is smaller than spark.akka.frameSize. However, the result is actually sent back to the driver via the backend actor, which is initialized before receiving the SparkConf and hence it doesn't know the spark.akka.frameSize. That is the root cause of SPARK-1112.

A quick fix is using the min frame size to decide which route to go.

This PR also fixes SPARK-2156.
