### PR TITLE
[SPARK-2193] Improve tasks preferrd locality by sorting tasks partial or...

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -152,6 +152,28 @@ private[spark] class TaskSetManager(
     addPendingTask(i)
   }
 
+  sortPendingTasksForHosts(pendingTasksForHost)
+
+  // Improve tasks preferrd locality by sorting tasks partial ordering.
+  private def sortPendingTasksForHosts(tasksMap: HashMap[String, ArrayBuffer[Int]]) {
+    tasksMap.foreach(pair => {
+      val host = pair._1
+      var v = pair._2
+      var map = new HashMap[Int, ArrayBuffer[Int]]()
+      v.foreach(index => {
+        for (loc <- tasks(index).preferredLocations) {
+          var i = 0
+          if (loc.host == host) {
+            map.getOrElseUpdate(i, new ArrayBuffer) += index
+          }
+          i += 1
+        }
+      })
+      v.clear
+      map.foreach(kv => v ++= kv._2)
+    })
+  }
+
   // Figure out which locality levels we have in our TaskSet, so we can do delay scheduling
   val myLocalityLevels = computeValidLocalityLevels()
   val localityWaits = myLocalityLevels.map(getLocalityWait) // Time to wait at each level


### PR DESCRIPTION
Now, the last executor(s) maybe not get it’s preferred task(s), although these tasks have build in pendingTasksForHosts map. Because executers pick up tasks sequential, their preferred task(s) maybe picked up by other executors.
This appearance can be eliminated by sorting tasks partial ordering. Executor pick up task by host’s order of task’s preferredLocation, that mean, executor firstly pick up all tasks which task.preferredLocations.1 = executor.hostName, then secondly…
