### PR TITLE
SPARK-2180:  support HAVING clauses in Hive queries

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
@@ -205,7 +205,7 @@ private[hive] object HiveQl {
     extends Exception(s"Failed to parse: $sql", cause)
 
   class SemanticException(msg: String)
-    extends Exception(msg)
+    extends Exception(s"Error in semantic analysis: $msg")
 
   /**
    * Returns the AST for the given SQL string.
@@ -584,7 +584,7 @@ private[hive] object HiveQl {
         val withHaving = havingClause.map { h => 
 
           if (groupByClause == None) {
-            throw new SemanticException("Error in semantic analysis: HAVING specified without GROUP BY")
+            throw new SemanticException("HAVING specified without GROUP BY")
           }
 
           val Seq(havingExpr) = h.getChildren.toSeq

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
@@ -587,8 +587,11 @@ private[hive] object HiveQl {
             throw new SemanticException("HAVING specified without GROUP BY")
           }
 
-          val Seq(havingExpr) = h.getChildren.toSeq
-          Filter(nodeToExpr(havingExpr), withDistinct)
+          val havingExpr = h.getChildren.toSeq match {
+            case Seq(hexpr) => nodeToExpr(hexpr)
+          }
+          
+          Filter(Cast(havingExpr, BooleanType), withDistinct)
         }.getOrElse(withDistinct)
 
         val withSort =

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -224,6 +224,21 @@ class HiveQuerySuite extends HiveComparisonTest {
     TestHive.reset()
   }
 
+  test("SPARK-2180: HAVING support in GROUP BY clauses") {
+    val fixture = List(("foo", 2), ("bar", 1), ("foo", 4), ("bar", 3))
+      .zipWithIndex.map {case Pair(Pair(value, attr), key) => HavingRow(key, value, attr)}
+    
+    TestHive.sparkContext.parallelize(fixture).registerAsTable("having_test")
+    
+    val results = hql("SELECT value, max(attr) AS attr FROM having_test GROUP BY value HAVING attr > 3")
+      .collect()
+      .map(x => Pair(x.getString(0), x.getInt(1)))
+    
+    assert(results === Array(Pair("foo", 4)))
+    
+    TestHive.reset()
+  }
+
   test("Query Hive native command execution result") {
     val tableName = "test_native_commands"
 
@@ -441,3 +456,6 @@ class HiveQuerySuite extends HiveComparisonTest {
   // since they modify /clear stuff.
 
 }
+
+// for SPARK-2180 test
+case class HavingRow(key: Int, value: String, attr: Int)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -230,7 +230,8 @@ class HiveQuerySuite extends HiveComparisonTest {
     
     TestHive.sparkContext.parallelize(fixture).registerAsTable("having_test")
     
-    val results = hql("SELECT value, max(attr) AS attr FROM having_test GROUP BY value HAVING attr > 3")
+    val results = 
+      hql("SELECT value, max(attr) AS attr FROM having_test GROUP BY value HAVING attr > 3")
       .collect()
       .map(x => Pair(x.getString(0), x.getInt(1)))
     
@@ -243,6 +244,10 @@ class HiveQuerySuite extends HiveComparisonTest {
     intercept[Exception] {
       hql("SELECT value, attr FROM having_test HAVING attr > 3")
     }
+  }
+  
+  test("SPARK-2180:  HAVING with non-boolean clause raises no exceptions") {
+    val results = hql("select key, count(*) c from src group by key having c").collect()
   }
 
   test("Query Hive native command execution result") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -224,7 +224,7 @@ class HiveQuerySuite extends HiveComparisonTest {
     TestHive.reset()
   }
 
-  test("SPARK-2180: HAVING support in GROUP BY clauses") {
+  test("SPARK-2180: HAVING support in GROUP BY clauses (positive)") {
     val fixture = List(("foo", 2), ("bar", 1), ("foo", 4), ("bar", 3))
       .zipWithIndex.map {case Pair(Pair(value, attr), key) => HavingRow(key, value, attr)}
     
@@ -237,6 +237,12 @@ class HiveQuerySuite extends HiveComparisonTest {
     assert(results === Array(Pair("foo", 4)))
     
     TestHive.reset()
+  }
+
+  test("SPARK-2180:  HAVING without GROUP BY raises exception") {
+    intercept[Exception] {
+      hql("SELECT value, attr FROM having_test HAVING attr > 3")
+    }
   }
 
   test("Query Hive native command execution result") {


### PR DESCRIPTION
This PR extends Spark's HiveQL support to handle HAVING clauses in aggregations.  The HAVING test from the Hive compatibility suite doesn't appear to be runnable from within Spark, so I added a simple comparable test to `HiveQuerySuite`.
