### PR TITLE
[SPARK-2210] cast to boolean on boolean value gets turned into NOT((boolean_condition) = 0)

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
@@ -251,7 +251,9 @@ trait HiveTypeCoercion {
     def apply(plan: LogicalPlan): LogicalPlan = plan transformAllExpressions {
       // Skip nodes who's children have not been resolved yet.
       case e if !e.childrenResolved => e
-
+      // Skip if the type is boolean type already. Note that this extra cast should be removed
+      // by optimizer.SimplifyCasts.
+      case Cast(e, BooleanType) if e.dataType == BooleanType => e
       case Cast(e, BooleanType) => Not(Equals(e, Literal(0)))
       case Cast(e, dataType) if e.dataType == BooleanType =>
         Cast(If(e, Literal(1), Literal(0)), dataType)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveTypeCoercionSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveTypeCoercionSuite.scala
@@ -17,8 +17,12 @@
 
 package org.apache.spark.sql.hive.execution
 
+import org.apache.spark.sql.catalyst.expressions.{Cast, Equals}
+import org.apache.spark.sql.execution.Project
+import org.apache.spark.sql.hive.test.TestHive
+
 /**
- * A set of tests that validate type promotion rules.
+ * A set of tests that validate type promotion and coercion rules.
  */
 class HiveTypeCoercionSuite extends HiveComparisonTest {
   val baseTypes = Seq("1", "1.0", "1L", "1S", "1Y", "'1'")
@@ -27,5 +31,24 @@ class HiveTypeCoercionSuite extends HiveComparisonTest {
     baseTypes.foreach { j =>
       createQueryTest(s"$i + $j", s"SELECT $i + $j FROM src LIMIT 1")
     }
+  }
+
+  test("[SPARK-2210] boolean cast on boolean value should be removed") {
+    val q = "select cast(cast(key=0 as boolean) as boolean) from src"
+    val project = TestHive.hql(q).queryExecution.executedPlan.collect { case e: Project => e }.head
+
+    // No cast expression introduced
+    project.transformAllExpressions { case c: Cast =>
+      assert(false, "unexpected cast " + c)
+      c
+    }
+
+    // Only one Equals
+    var numEquals = 0
+    project.transformAllExpressions { case e: Equals =>
+      numEquals += 1
+      e
+    }
+    assert(numEquals === 1)
   }
 }


### PR DESCRIPTION
```
explain select cast(cast(key=0 as boolean) as boolean) aaa from src
```

should be

```
[Physical execution plan:]
[Project [(key#10:0 = 0) AS aaa#7]]
[ HiveTableScan [key#10], (MetastoreRelation default, src, None), None]
```

However, it is currently

```
[Physical execution plan:]
[Project [NOT((key#10=0) = 0) AS aaa#7]]
[ HiveTableScan [key#10], (MetastoreRelation default, src, None), None]
```
