### PR TITLE
Fixed small running on YARN docs typo

### DIFF
--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -119,7 +119,7 @@ For example:
         --num-executors 3 \
         --driver-memory 4g \
         --executor-memory 2g \
-        --executor-cores 1
+        --executor-cores 1 \
         lib/spark-examples*.jar \
         10
 


### PR DESCRIPTION
The backslash is needed for multiline command
