### PR TITLE
SPARK-2168 [Spark core] Use relative URIs for the app links in the History Server.

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryPage.scala
@@ -61,7 +61,7 @@ private[spark] class HistoryPage(parent: HistoryServer) extends WebUIPage("") {
 
   private def appRow(info: ApplicationHistoryInfo): Seq[Node] = {
     val appName = if (info.started) info.name else info.logDirPath.getName
-    val uiAddress = parent.getAddress + info.ui.basePath
+    val uiAddress = info.ui.basePath
     val startTime = if (info.started) UIUtils.formatDate(info.startTime) else "Not started"
     val endTime = if (info.completed) UIUtils.formatDate(info.endTime) else "Not completed"
     val difference = if (info.started && info.completed) info.endTime - info.startTime else -1L

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.history
+
+import org.scalatest.FunSuite
+import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.mock.MockitoSugar
+import javax.servlet.http.HttpServletRequest
+import org.mockito.Mockito.{when}
+import org.apache.hadoop.fs.Path
+import org.apache.spark.ui.SparkUI
+import scala.collection.mutable
+
+class HistoryServerSuite extends FunSuite with ShouldMatchers with MockitoSugar {
+	
+  val historyServer = mock[HistoryServer]
+  val request = mock[HttpServletRequest]
+  
+  test("generate history page with relative links") { 
+    val ui = mock[SparkUI]
+    val link = "/history/app1.html"
+    val info = new ApplicationHistoryInfo("1", "app1", 0, 2, 1, "xxx", new Path("/tmp"), ui )
+    val sampleHistory = mutable.HashMap("app1" -> info)
+    when(historyServer.appIdToInfo).thenReturn(sampleHistory)
+    when(ui.basePath).thenReturn(link)
+    when(historyServer.getAddress).thenReturn("http://localhost:123")
+    val page = new HistoryPage(historyServer)
+    
+    //when
+    val response = page.render(request)
+    
+    //then
+   val expectedLink = response \\ "a"
+   expectedLink.size should equal(1)
+   val hrefAttr = expectedLink(0).attribute("href")
+   hrefAttr.get.toString should equal(link)
+  }
+}


### PR DESCRIPTION
Removing full URI leaving only relative path in link to the completed application plus unit test
