### PR TITLE
spark-ec2: quote command line args

### DIFF
--- a/ec2/spark-ec2
+++ b/ec2/spark-ec2
@@ -19,4 +19,4 @@
 #
 
 cd "`dirname $0`"
-PYTHONPATH="./third_party/boto-2.4.1.zip/boto-2.4.1:$PYTHONPATH" python ./spark_ec2.py $@
+PYTHONPATH="./third_party/boto-2.4.1.zip/boto-2.4.1:$PYTHONPATH" python ./spark_ec2.py "$@"


### PR DESCRIPTION
To preserve quoted command line args (in case options have space in them).
