### PR TITLE
[GraphX][SPARK-2245] add a materialize method to materialize VertexRDD by calling RDD's count

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/VertexRDD.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/VertexRDD.scala
@@ -111,6 +111,11 @@ class VertexRDD[@specialized VD: ClassTag](
     partitionsRDD.map(_.size).reduce(_ + _)
   }
 
+  /** Materialize vertices by calling RDD's count method */
+  def materialize(): Long = {
+    super.count()
+  }
+
   /**
    * Provides the `RDD[(VertexId, VD)]` equivalent output.
    */

--- a/graphx/src/main/scala/org/apache/spark/graphx/VertexRDD.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/VertexRDD.scala
@@ -111,9 +111,16 @@ class VertexRDD[@specialized VD: ClassTag](
     partitionsRDD.map(_.size).reduce(_ + _)
   }
 
-  /** Materialize vertices by calling RDD's count method */
-  def materialize(): Long = {
-    super.count()
+  override def checkpoint() {
+    partitionsRDD.checkpoint()
+  }
+
+  override def getCheckpointFile: Option[String] = {
+    partitionsRDD.getCheckpointFile
+  }
+
+  override def isCheckpointed: Boolean = {
+    partitionsRDD.isCheckpointed
   }
 
   /**


### PR DESCRIPTION
Seems one can not materialize VertexRDD by simply calling count method, which is overridden by VertexRDD. But if you call RDD's count, it could materialize it. 

Is this a feature that designed to get the count without materialize VertexRDD? If so, do you guys think it is necessary to add a materialize method to VertexRDD? 

By the way, does count() is the cheapest way to materialize a RDD? Or it just cost the same resources like other actions? 

Best,
