### PR TITLE
[SPARK-2242] HOTFIX: pyspark shell hangs on simple job

### DIFF
--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -54,8 +54,10 @@ def launch_gateway():
             gateway_port = int(gateway_port)
         except ValueError:
             (stdout, _) = proc.communicate()
-            error_msg = "Launching GatewayServer failed because of stdout interference. "
-            error_msg += "Silence the following and try again:\n\n"
+            exit_code = proc.poll()
+            error_msg = "Launching GatewayServer failed"
+            error_msg += " with exit code %d!" % exit_code if exit_code else "! "
+            error_msg += "(Warning: unexpected output detected.)\n\n"
             error_msg += gateway_port + stdout
             raise Exception(error_msg)
 

--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -53,14 +53,11 @@ def launch_gateway():
             gateway_port = proc.stdout.readline()
             gateway_port = int(gateway_port)
         except ValueError:
+            (stdout, _) = proc.communicate()
             error_msg = "Launching GatewayServer failed because of stdout interference. "
             error_msg += "Silence the following and try again:\n\n"
-            error_msg += "  %s" % gateway_port
+            error_msg += gateway_port + stdout
             raise Exception(error_msg)
-        except Exception as e:
-            exit_code = proc.poll()
-            exit_code_msg = " Exit code was %d." % exit_code if exit_code else ""
-            raise Exception("Launching GatewayServer failed!" + exit_code_msg, e)
 
         # Create a thread to echo output from the GatewayServer, which is required
         # for Java log output to show up:

--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -43,10 +43,10 @@ def launch_gateway():
             # Don't send ctrl-c / SIGINT to the Java gateway:
             def preexec_func():
                 signal.signal(signal.SIGINT, signal.SIG_IGN)
-            proc = Popen(command, stdout=PIPE, stdin=PIPE, stderr=PIPE, preexec_fn=preexec_func)
+            proc = Popen(command, stdout=PIPE, stdin=PIPE, preexec_fn=preexec_func)
         else:
             # preexec_fn not supported on Windows
-            proc = Popen(command, stdout=PIPE, stdin=PIPE, stderr=PIPE)
+            proc = Popen(command, stdout=PIPE, stdin=PIPE)
         
         try:
             # Determine which ephemeral port the server started on:

--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -57,10 +57,10 @@ def launch_gateway():
             error_msg += "Silence the following and try again:\n\n"
             error_msg += "  %s" % gateway_port
             raise Exception(error_msg)
-        except:
+        except Exception as e:
             exit_code = proc.poll()
             exit_code_msg = " Exit code was %d." % exit_code if exit_code else ""
-            raise Exception("Launching GatewayServer failed!" + exit_code_msg)
+            raise Exception("Launching GatewayServer failed!" + exit_code_msg, e)
 
         # Create a thread to echo output from the GatewayServer, which is required
         # for Java log output to show up:

--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -47,14 +47,20 @@ def launch_gateway():
         else:
             # preexec_fn not supported on Windows
             proc = Popen(command, stdout=PIPE, stdin=PIPE)
-        
+
         try:
             # Determine which ephemeral port the server started on:
-            gateway_port = int(proc.stdout.readline())
+            gateway_port = proc.stdout.readline()
+            gateway_port = int(gateway_port)
+        except ValueError:
+            error_msg = "Launching GatewayServer failed because of stdout interference. "
+            error_msg += "Silence the following and try again:\n\n"
+            error_msg += "  %s" % gateway_port
+            raise Exception(error_msg)
         except:
-            error_code = proc.poll()
-            raise Exception("Launching GatewayServer failed with exit code %d: %s" %
-                (error_code, "".join(proc.stderr.readlines())))
+            exit_code = proc.poll()
+            exit_code_msg = " Exit code was %d." % exit_code if exit_code else ""
+            raise Exception("Launching GatewayServer failed!" + exit_code_msg)
 
         # Create a thread to echo output from the GatewayServer, which is required
         # for Java log output to show up:


### PR DESCRIPTION
This reverts a change introduced in 3870248740d83b0292ccca88a494ce19783847f0, which redirected all stderr to the OS pipe instead of directly to the `bin/pyspark` shell output. This causes a simple job to hang in two ways:
1. If the cluster is not configured correctly or does not have enough resources, the job hangs without producing any output, because the relevant warning messages are masked.
2. If the stderr volume is large, this could lead to a deadlock if we redirect everything to the OS pipe. From the [python docs](https://docs.python.org/2/library/subprocess.html):

```
Note Do not use stdout=PIPE or stderr=PIPE with this function as that can deadlock
based on the child process output volume. Use Popen with the communicate() method
when you need pipes.
```

Note that we cannot remove `stdout=PIPE` in a similar way, because we currently use it to communicate the py4j port. However, it should be fine (as it has been for a long time) because we do not produce a ton of traffic through `stdout`.

That commit was not merged in branch-1.0, so this fix is for master only.
