### PR TITLE
Fix for SPARK-2228

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
@@ -75,7 +75,9 @@ class JobProgressListener(conf: SparkConf) extends SparkListener {
     val stage = stageCompleted.stageInfo
     val stageId = stage.stageId
     // Remove by stageId, rather than by StageInfo, in case the StageInfo is from storage
-    poolToActiveStages(stageIdToPool(stageId)).remove(stageId)
+    if (stageIdToPool.contains(stageId)) {
+      poolToActiveStages(stageIdToPool(stageId)).remove(stageId)
+    }
     activeStages.remove(stageId)
     if (stage.failureReason.isEmpty) {
       completedStages += stage


### PR DESCRIPTION
Add check to see if stageId exists in stageIdToPool before attempting to remove it from poolToActiveStages.
