### PR TITLE
[SPARK-2258 / 2266] Fix a few worker UI bugs

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
@@ -60,8 +60,11 @@ private[deploy] object DeployMessages {
       exception: Option[Exception])
     extends DeployMessage
 
-  case class WorkerSchedulerStateResponse(id: String, executors: List[ExecutorDescription],
-     driverIds: Seq[String])
+  case class WorkerSchedulerStateResponse(
+      id: String,
+      executors: List[ExecutorDescription],
+      driverIds: Seq[String])
+    extends DeployMessage
 
   case class Heartbeat(workerId: String) extends DeployMessage
 
@@ -88,28 +91,38 @@ private[deploy] object DeployMessages {
 
   // Worker internal
 
-  case object WorkDirCleanup      // Sent to Worker actor periodically for cleaning up app folders
+  // Sent to Worker actor periodically for cleaning up app folders
+  case object WorkDirCleanup extends DeployMessage
 
   // AppClient to Master
 
-  case class RegisterApplication(appDescription: ApplicationDescription)
-    extends DeployMessage
+  case class RegisterApplication(appDescription: ApplicationDescription) extends DeployMessage
 
-  case class MasterChangeAcknowledged(appId: String)
+  case class MasterChangeAcknowledged(appId: String) extends DeployMessage
 
   // Master to AppClient
 
   case class RegisteredApplication(appId: String, masterUrl: String) extends DeployMessage
 
   // TODO(matei): replace hostPort with host
-  case class ExecutorAdded(id: Int, workerId: String, hostPort: String, cores: Int, memory: Int) {
+  case class ExecutorAdded(
+      id: Int,
+      workerId: String,
+      hostPort: String,
+      cores: Int,
+      memory: Int)
+    extends DeployMessage {
     Utils.checkHostPort(hostPort, "Required hostport")
   }
 
-  case class ExecutorUpdated(id: Int, state: ExecutorState, message: Option[String],
-    exitStatus: Option[Int])
+  case class ExecutorUpdated(
+      id: Int,
+      state: ExecutorState,
+      message: Option[String],
+      exitStatus: Option[Int])
+    extends DeployMessage
 
-  case class ApplicationRemoved(message: String)
+  case class ApplicationRemoved(message: String) extends DeployMessage
 
   // DriverClient <-> Master
 
@@ -125,50 +138,69 @@ private[deploy] object DeployMessages {
 
   case class RequestDriverStatus(driverId: String) extends DeployMessage
 
-  case class DriverStatusResponse(found: Boolean, state: Option[DriverState],
-    workerId: Option[String], workerHostPort: Option[String], exception: Option[Exception])
+  case class DriverStatusResponse(
+      found: Boolean,
+      state: Option[DriverState],
+      workerId: Option[String],
+      workerHostPort: Option[String],
+      exception: Option[Exception])
+    extends DeployMessage
 
   // Internal message in AppClient
 
-  case object StopAppClient
+  case object StopAppClient extends DeployMessage
 
   // Master to Worker & AppClient
 
-  case class MasterChanged(masterUrl: String, masterWebUiUrl: String)
+  case class MasterChanged(masterUrl: String, masterWebUiUrl: String) extends DeployMessage
 
   // MasterWebUI To Master
 
-  case object RequestMasterState
+  case object RequestMasterState extends DeployMessage
 
   // Master to MasterWebUI
 
-  case class MasterStateResponse(host: String, port: Int, workers: Array[WorkerInfo],
-    activeApps: Array[ApplicationInfo], completedApps: Array[ApplicationInfo],
-    activeDrivers: Array[DriverInfo], completedDrivers: Array[DriverInfo],
-    status: MasterState) {
-
+  case class MasterStateResponse(
+      host: String,
+      port: Int,
+      workers: Array[WorkerInfo],
+      activeApps: Array[ApplicationInfo],
+      completedApps: Array[ApplicationInfo],
+      activeDrivers: Array[DriverInfo],
+      completedDrivers: Array[DriverInfo],
+      status: MasterState)
+    extends DeployMessage {
     Utils.checkHost(host, "Required hostname")
     assert (port > 0)
-
     def uri = "spark://" + host + ":" + port
   }
 
   //  WorkerWebUI to Worker
 
-  case object RequestWorkerState
+  case object RequestWorkerState extends DeployMessage
 
   // Worker to WorkerWebUI
 
-  case class WorkerStateResponse(host: String, port: Int, workerId: String,
-    executors: List[ExecutorRunner], finishedExecutors: List[ExecutorRunner],
-    drivers: List[DriverRunner], finishedDrivers: List[DriverRunner], masterUrl: String,
-    cores: Int, memory: Int, coresUsed: Int, memoryUsed: Int, masterWebUiUrl: String) {
-
+  case class WorkerStateResponse(
+      host: String,
+      port: Int,
+      workerId: String,
+      executors: List[ExecutorRunner],
+      finishedExecutors: List[ExecutorRunner],
+      drivers: List[DriverRunner],
+      finishedDrivers: List[DriverRunner],
+      masterUrl: String,
+      cores: Int,
+      memory: Int,
+      coresUsed: Int,
+      memoryUsed: Int,
+      masterWebUiUrl: String)
+    extends DeployMessage {
     Utils.checkHost(host, "Required hostname")
     assert (port > 0)
   }
 
   // Liveness checks in various places
 
-  case object SendHeartbeat
+  case object SendHeartbeat extends DeployMessage
 }

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ExecutorRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ExecutorRunner.scala
@@ -77,6 +77,7 @@ private[spark] class ExecutorRunner(
    * @param message the exception message which caused the executor's death 
    */
   private def killProcess(message: Option[String]) {
+    var exitCode: Option[Int] = None
     if (process != null) {
       logInfo("Killing process!")
       process.destroy()
@@ -87,9 +88,9 @@ private[spark] class ExecutorRunner(
       if (stderrAppender != null) {
         stderrAppender.stop()
       }
-      val exitCode = process.waitFor()
-      worker ! ExecutorStateChanged(appId, execId, state, message, Some(exitCode))
+      exitCode = Some(process.waitFor())
     }
+    worker ! ExecutorStateChanged(appId, execId, state, message, exitCode)
   }
 
   /** Stop this executor runner, including killing the process it launched */

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ExecutorRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ExecutorRunner.scala
@@ -113,9 +113,12 @@ private[spark] class ExecutorRunner(
   }
 
   def getCommandSeq = {
-    val command = Command(appDesc.command.mainClass,
-      appDesc.command.arguments.map(substituteVariables) ++ Seq(appId), appDesc.command.environment,
-      appDesc.command.classPathEntries, appDesc.command.libraryPathEntries,
+    val command = Command(
+      appDesc.command.mainClass,
+      appDesc.command.arguments.map(substituteVariables) ++ Seq(appId),
+      appDesc.command.environment,
+      appDesc.command.classPathEntries,
+      appDesc.command.libraryPathEntries,
       appDesc.command.extraJavaOptions)
     CommandUtils.buildCommandSeq(command, memory, sparkHome.getAbsolutePath)
   }
@@ -161,16 +164,14 @@ private[spark] class ExecutorRunner(
       val message = "Command exited with code " + exitCode
       worker ! ExecutorStateChanged(appId, execId, state, Some(message), Some(exitCode))
     } catch {
-      case interrupted: InterruptedException => {
+      case interrupted: InterruptedException =>
         logInfo("Runner thread for executor " + fullId + " interrupted")
         state = ExecutorState.KILLED
         killProcess(None)
-      }
-      case e: Exception => {
+      case e: Exception =>
         logError("Error running executor", e)
         state = ExecutorState.FAILED
         killProcess(Some(e.toString))
-      }
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ui/LogPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ui/LogPage.scala
@@ -120,7 +120,7 @@ private[spark] class LogPage(parent: WorkerWebUI) extends WebUIPage("logPage") w
           </div>
         </body>
       </html>
-    UIUtils.basicSparkPage(content, logType + " log page for " + appId)
+    UIUtils.basicSparkPage(content, logType + " log page for " + appId.getOrElse("unknown app"))
   }
 
   /** Get the part of the log files given the offset and desired length of bytes */


### PR DESCRIPTION
**SPARK-2258.** Worker UI displays zombie processes if the executor throws an exception before a process is launched. This is because we only inform the Worker of the change if the process is already launched, which in this case it isn't.

**SPARK-2266.** We expose "Some(app-id)" on the log page. This is fairly minor.

I commented in the diff where these two fixes are added. The rest involves mainly style fixes.
