### PR TITLE
[SPARK-2125] Add sort flag and move sort into shuffle implementations

### DIFF
--- a/core/src/main/scala/org/apache/spark/Dependency.scala
+++ b/core/src/main/scala/org/apache/spark/Dependency.scala
@@ -66,8 +66,6 @@ class ShuffleDependency[K, V, C](
     val ascending: Boolean = true)
   extends Dependency(rdd.asInstanceOf[RDD[Product2[K, V]]]) {
 
-  def isKeySorted = keyOrdering.isDefined
-
   val shuffleId: Int = rdd.context.newShuffleId()
 
   val shuffleHandle: ShuffleHandle = rdd.context.env.shuffleManager.registerShuffle(

--- a/core/src/main/scala/org/apache/spark/Dependency.scala
+++ b/core/src/main/scala/org/apache/spark/Dependency.scala
@@ -62,8 +62,11 @@ class ShuffleDependency[K, V, C](
     val serializer: Option[Serializer] = None,
     val keyOrdering: Option[Ordering[K]] = None,
     val aggregator: Option[Aggregator[K, V, C]] = None,
-    val mapSideCombine: Boolean = false)
+    val mapSideCombine: Boolean = false,
+    val ascending: Boolean = true)
   extends Dependency(rdd.asInstanceOf[RDD[Product2[K, V]]]) {
+
+  def isKeySorted = keyOrdering.isDefined
 
   val shuffleId: Int = rdd.context.newShuffleId()
 

--- a/core/src/main/scala/org/apache/spark/Dependency.scala
+++ b/core/src/main/scala/org/apache/spark/Dependency.scala
@@ -19,6 +19,7 @@ package org.apache.spark
 
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.rdd.RDD
+import org.apache.spark.rdd.SortOrder.SortOrder
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.ShuffleHandle
 
@@ -63,7 +64,7 @@ class ShuffleDependency[K, V, C](
     val keyOrdering: Option[Ordering[K]] = None,
     val aggregator: Option[Aggregator[K, V, C]] = None,
     val mapSideCombine: Boolean = false,
-    val ascending: Option[Boolean] = None)
+    val sortOrder: Option[SortOrder] = None)
   extends Dependency(rdd.asInstanceOf[RDD[Product2[K, V]]]) {
 
   val shuffleId: Int = rdd.context.newShuffleId()

--- a/core/src/main/scala/org/apache/spark/Dependency.scala
+++ b/core/src/main/scala/org/apache/spark/Dependency.scala
@@ -63,7 +63,7 @@ class ShuffleDependency[K, V, C](
     val keyOrdering: Option[Ordering[K]] = None,
     val aggregator: Option[Aggregator[K, V, C]] = None,
     val mapSideCombine: Boolean = false,
-    val ascending: Boolean = true)
+    val ascending: Option[Boolean] = None)
   extends Dependency(rdd.asInstanceOf[RDD[Product2[K, V]]]) {
 
   val shuffleId: Int = rdd.context.newShuffleId()

--- a/core/src/main/scala/org/apache/spark/rdd/OrderedRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/OrderedRDDFunctions.scala
@@ -59,6 +59,11 @@ class OrderedRDDFunctions[K : Ordering : ClassTag,
     val part = new RangePartitioner(numPartitions, self, ascending)
     new ShuffledRDD[K, V, V, P](self, part)
       .setKeyOrdering(ordering)
-      .setSortFlag(ascending)
+      .setSortOrder(if (ascending) SortOrder.ASCENDING else SortOrder.DESCENDING)
   }
+}
+
+object SortOrder extends Enumeration {
+  type SortOrder = Value
+  val ASCENDING, DESCENDING = Value
 }

--- a/core/src/main/scala/org/apache/spark/rdd/OrderedRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/OrderedRDDFunctions.scala
@@ -57,14 +57,8 @@ class OrderedRDDFunctions[K : Ordering : ClassTag,
    */
   def sortByKey(ascending: Boolean = true, numPartitions: Int = self.partitions.size): RDD[P] = {
     val part = new RangePartitioner(numPartitions, self, ascending)
-    val shuffled = new ShuffledRDD[K, V, V, P](self, part).setKeyOrdering(ordering)
-    shuffled.mapPartitions(iter => {
-      val buf = iter.toArray
-      if (ascending) {
-        buf.sortWith((x, y) => ordering.lt(x._1, y._1)).iterator
-      } else {
-        buf.sortWith((x, y) => ordering.gt(x._1, y._1)).iterator
-      }
-    }, preservesPartitioning = true)
+    new ShuffledRDD[K, V, V, P](self, part)
+      .setKeyOrdering(ordering)
+      .setAscendingFlag(ascending)
   }
 }

--- a/core/src/main/scala/org/apache/spark/rdd/OrderedRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/OrderedRDDFunctions.scala
@@ -59,6 +59,6 @@ class OrderedRDDFunctions[K : Ordering : ClassTag,
     val part = new RangePartitioner(numPartitions, self, ascending)
     new ShuffledRDD[K, V, V, P](self, part)
       .setKeyOrdering(ordering)
-      .setAscendingFlag(ascending)
+      .setSortFlag(ascending)
   }
 }

--- a/core/src/main/scala/org/apache/spark/rdd/OrderedRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/OrderedRDDFunctions.scala
@@ -63,7 +63,7 @@ class OrderedRDDFunctions[K : Ordering : ClassTag,
   }
 }
 
-object SortOrder extends Enumeration {
+private[spark] object SortOrder extends Enumeration {
   type SortOrder = Value
   val ASCENDING, DESCENDING = Value
 }

--- a/core/src/main/scala/org/apache/spark/rdd/ShuffledRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ShuffledRDD.scala
@@ -51,7 +51,7 @@ class ShuffledRDD[K, V, C, P <: Product2[K, C] : ClassTag](
 
   private var mapSideCombine: Boolean = false
 
-  private var ascending: Boolean = true
+  private var ascending: Option[Boolean] = None
 
   /** Set a serializer for this RDD's shuffle, or null to use the default (spark.serializer) */
   def setSerializer(serializer: Serializer): ShuffledRDD[K, V, C, P] = {
@@ -79,7 +79,7 @@ class ShuffledRDD[K, V, C, P <: Product2[K, C] : ClassTag](
 
   /** Set sort flag for RDD's sorting. */
   def setSortFlag(ascending: Boolean): ShuffledRDD[K, V, C, P] = {
-    this.ascending = ascending
+    this.ascending = Option(ascending)
     this
   }
 

--- a/core/src/main/scala/org/apache/spark/rdd/ShuffledRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ShuffledRDD.scala
@@ -65,11 +65,6 @@ class ShuffledRDD[K, V, C, P <: Product2[K, C] : ClassTag](
     this
   }
 
-  def setAscendingFlag(ascending: Boolean): ShuffledRDD[K, V, C, P] = {
-    this.ascending = ascending
-    this
-  }
-
   /** Set aggregator for RDD's shuffle. */
   def setAggregator(aggregator: Aggregator[K, V, C]): ShuffledRDD[K, V, C, P] = {
     this.aggregator = Option(aggregator)
@@ -79,6 +74,12 @@ class ShuffledRDD[K, V, C, P <: Product2[K, C] : ClassTag](
   /** Set mapSideCombine flag for RDD's shuffle. */
   def setMapSideCombine(mapSideCombine: Boolean): ShuffledRDD[K, V, C, P] = {
     this.mapSideCombine = mapSideCombine
+    this
+  }
+
+  /** Set sort flag for RDD's sorting. */
+  def setSortFlag(ascending: Boolean): ShuffledRDD[K, V, C, P] = {
+    this.ascending = ascending
     this
   }
 

--- a/core/src/main/scala/org/apache/spark/rdd/ShuffledRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ShuffledRDD.scala
@@ -21,6 +21,7 @@ import scala.reflect.ClassTag
 
 import org.apache.spark._
 import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.rdd.SortOrder.SortOrder
 import org.apache.spark.serializer.Serializer
 
 private[spark] class ShuffledRDDPartition(val idx: Int) extends Partition {
@@ -51,7 +52,7 @@ class ShuffledRDD[K, V, C, P <: Product2[K, C] : ClassTag](
 
   private var mapSideCombine: Boolean = false
 
-  private var ascending: Option[Boolean] = None
+  private var sortOrder: Option[SortOrder] = None
 
   /** Set a serializer for this RDD's shuffle, or null to use the default (spark.serializer) */
   def setSerializer(serializer: Serializer): ShuffledRDD[K, V, C, P] = {
@@ -77,15 +78,15 @@ class ShuffledRDD[K, V, C, P <: Product2[K, C] : ClassTag](
     this
   }
 
-  /** Set sort flag for RDD's sorting. */
-  def setSortFlag(ascending: Boolean): ShuffledRDD[K, V, C, P] = {
-    this.ascending = Option(ascending)
+  /** Set sort order for RDD's sorting. */
+  def setSortOrder(sortOrder: SortOrder): ShuffledRDD[K, V, C, P] = {
+    this.sortOrder = Option(sortOrder)
     this
   }
 
   override def getDependencies: Seq[Dependency[_]] = {
     List(new ShuffleDependency(prev, part, serializer,
-      keyOrdering, aggregator, mapSideCombine, ascending))
+      keyOrdering, aggregator, mapSideCombine, sortOrder))
   }
 
   override val partitioner = Some(part)

--- a/core/src/main/scala/org/apache/spark/rdd/ShuffledRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ShuffledRDD.scala
@@ -51,6 +51,8 @@ class ShuffledRDD[K, V, C, P <: Product2[K, C] : ClassTag](
 
   private var mapSideCombine: Boolean = false
 
+  private var ascending: Boolean = true
+
   /** Set a serializer for this RDD's shuffle, or null to use the default (spark.serializer) */
   def setSerializer(serializer: Serializer): ShuffledRDD[K, V, C, P] = {
     this.serializer = Option(serializer)
@@ -60,6 +62,11 @@ class ShuffledRDD[K, V, C, P <: Product2[K, C] : ClassTag](
   /** Set key ordering for RDD's shuffle. */
   def setKeyOrdering(keyOrdering: Ordering[K]): ShuffledRDD[K, V, C, P] = {
     this.keyOrdering = Option(keyOrdering)
+    this
+  }
+
+  def setAscendingFlag(ascending: Boolean): ShuffledRDD[K, V, C, P] = {
+    this.ascending = ascending
     this
   }
 
@@ -76,7 +83,8 @@ class ShuffledRDD[K, V, C, P <: Product2[K, C] : ClassTag](
   }
 
   override def getDependencies: Seq[Dependency[_]] = {
-    List(new ShuffleDependency(prev, part, serializer, keyOrdering, aggregator, mapSideCombine))
+    List(new ShuffleDependency(prev, part, serializer,
+      keyOrdering, aggregator, mapSideCombine, ascending))
   }
 
   override val partitioner = Some(part)

--- a/core/src/main/scala/org/apache/spark/shuffle/hash/HashShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/hash/HashShuffleReader.scala
@@ -50,16 +50,16 @@ class HashShuffleReader[K, C](
       iter
     }
 
-    dep.keyOrdering.map { ordering =>
+    val sortedIter = for (asc <- dep.ascending; ordering <- dep.keyOrdering) yield {
       val buf = aggregatedIter.toArray
-      if (dep.ascending) {
+      if (asc) {
         buf.sortWith((x, y) => ordering.lt(x._1, y._1)).iterator
       } else {
         buf.sortWith((x, y) => ordering.gt(x._1, y._1)).iterator
       }
-    }.getOrElse {
-      aggregatedIter
     }
+
+    sortedIter.getOrElse(aggregatedIter)
   }
 
   /** Close this reader */

--- a/core/src/main/scala/org/apache/spark/shuffle/hash/HashShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/hash/HashShuffleReader.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.shuffle.hash
 
 import org.apache.spark.{InterruptibleIterator, TaskContext}
+import org.apache.spark.rdd.SortOrder
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.{BaseShuffleHandle, ShuffleReader}
 
@@ -50,9 +51,9 @@ class HashShuffleReader[K, C](
       iter
     }
 
-    val sortedIter = for (asc <- dep.ascending; ordering <- dep.keyOrdering) yield {
+    val sortedIter = for (sortOrder <- dep.sortOrder; ordering <- dep.keyOrdering) yield {
       val buf = aggregatedIter.toArray
-      if (asc) {
+      if (sortOrder == SortOrder.ASCENDING) {
         buf.sortWith((x, y) => ordering.lt(x._1, y._1)).iterator
       } else {
         buf.sortWith((x, y) => ordering.gt(x._1, y._1)).iterator

--- a/core/src/main/scala/org/apache/spark/shuffle/hash/HashShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/hash/HashShuffleReader.scala
@@ -38,7 +38,7 @@ class HashShuffleReader[K, C](
     val iter = BlockStoreShuffleFetcher.fetch(handle.shuffleId, startPartition, context,
       Serializer.getSerializer(dep.serializer))
 
-    val aggregatedIter = if (dep.aggregator.isDefined) {
+    val aggregatedIter: Iterator[Product2[K, C]] = if (dep.aggregator.isDefined) {
       if (dep.mapSideCombine) {
         new InterruptibleIterator(context, dep.aggregator.get.combineCombinersByKey(iter, context))
       } else {

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -63,7 +63,10 @@ object MimaExcludes {
               "org.apache.spark.storage.MemoryStore.Entry")
           ) ++
           Seq(
-            ProblemFilters.exclude[MissingMethodProblem]("org.apache.spark.streaming.flume.FlumeReceiver.this")
+            ProblemFilters.exclude[MissingMethodProblem]("org.apache.spark.streaming.flume.FlumeReceiver.this"),
+            ProblemFilters.exclude[MissingMethodProblem](
+              "org.apache.spark.rdd.OrderedRDDFunctions.org$apache$spark$rdd$OrderedRDDFunctions$$"
+                + "ordering")
           ) ++
           Seq( // Ignore some private methods in ALS.
             ProblemFilters.exclude[MissingMethodProblem](

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -63,10 +63,7 @@ object MimaExcludes {
               "org.apache.spark.storage.MemoryStore.Entry")
           ) ++
           Seq(
-            ProblemFilters.exclude[MissingMethodProblem]("org.apache.spark.streaming.flume.FlumeReceiver.this"),
-            ProblemFilters.exclude[MissingMethodProblem](
-              "org.apache.spark.rdd.OrderedRDDFunctions.org$apache$spark$rdd$OrderedRDDFunctions$$"
-                + "ordering")
+            ProblemFilters.exclude[MissingMethodProblem]("org.apache.spark.streaming.flume.FlumeReceiver.this")
           ) ++
           Seq( // Ignore some private methods in ALS.
             ProblemFilters.exclude[MissingMethodProblem](


### PR DESCRIPTION
This patch adds a sort flag into ShuffleDependecy and moves sort into hash shuffle implementation.

Moving sort into shuffle implementation can give space for other shuffle implementations (like sort-based shuffle) to better optimize sort through shuffle. 
