### PR TITLE
[SPARK-2283][SQL] Reset test environment before running PruningSuite

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/PruningSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/PruningSuite.scala
@@ -26,6 +26,11 @@ import scala.collection.JavaConversions._
  * A set of test cases that validate partition and column pruning.
  */
 class PruningSuite extends HiveComparisonTest {
+  // Column/partition pruning is not implemented for `InMemoryColumnarTableScan` yet, need to reset
+  // the environment to ensure all referenced tables in this suites are not cached in-memory.
+  // Refer to https://issues.apache.org/jira/browse/SPARK-2283 for details.
+  TestHive.reset()
+
   // Column pruning tests
 
   createPruningTest("Column pruning - with partitioned table",


### PR DESCRIPTION
JIRA issue: [SPARK-2283](https://issues.apache.org/jira/browse/SPARK-2283)

If `PruningSuite` is run right after `HiveCompatibilitySuite`, the first test case fails because `srcpart` table is cached in-memory by `HiveCompatibilitySuite`, but column pruning is not implemented for `InMemoryColumnarTableScan` operator yet.
