### PR TITLE
[SPARK-2172] PySpark cannot import mllib modules in YARN-client mode

### DIFF
--- a/mllib/pom.xml
+++ b/mllib/pom.xml
@@ -76,5 +76,16 @@
         <artifactId>scalatest-maven-plugin</artifactId>
       </plugin>
     </plugins>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+      <resource>
+        <directory>../python</directory>
+        <includes>
+          <include>pyspark/mllib/*.py</include>
+        </includes>
+      </resource>
+    </resources>
   </build>
 </project>

--- a/mllib/pom.xml
+++ b/mllib/pom.xml
@@ -78,9 +78,6 @@
     </plugins>
     <resources>
       <resource>
-        <directory>src/main/resources</directory>
-      </resource>
-      <resource>
         <directory>../python</directory>
         <includes>
           <include>pyspark/mllib/*.py</include>


### PR DESCRIPTION
Include pyspark/mllib python sources as resources in the mllib.jar.
This way they will be included in the final assembly
