### PR TITLE
SPARK-2159: Add support for stopping SparkContent on exit() repl command

### DIFF
--- a/repl/src/main/scala/org/apache/spark/repl/SparkILoopInit.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/SparkILoopInit.scala
@@ -122,6 +122,13 @@ trait SparkILoopInit {
          @transient val sc = org.apache.spark.repl.Main.interp.createSparkContext();
         """)
       command("import org.apache.spark.SparkContext._")
+      command(
+        """def exit: Unit = {
+          |  import Predef.{exit => scalaDefaultExit}
+          |  org.apache.spark.repl.Main.interp.closeInterpreter()
+          |  scalaDefaultExit
+          |}
+        """.stripMargin)
     }
     echo("Spark context available as sc.")
   }

--- a/repl/src/test/scala/org/apache/spark/repl/ReplSuite.scala
+++ b/repl/src/test/scala/org/apache/spark/repl/ReplSuite.scala
@@ -269,4 +269,9 @@ class ReplSuite extends FunSuite {
     assertDoesNotContain("Exception", output)
     assertContains("ret: Array[Foo] = Array(Foo(1),", output)
   }
+
+  test("stop SparkContext on exit() command") {
+    val output = runInterpreter("local", "exit()")
+    assertContains("Stopping spark context.", output)
+  }
 }


### PR DESCRIPTION
#### Description

A patch that fixes issue [SPARK-2159](https://issues.apache.org/jira/browse/SPARK-2159) by offering the same stop behavior as when using Ctrl+D (EOF) but with the `exit` or `exit()` repl command.
#### Testing

Added test case in `ReplSuite`
