### PR TITLE
[SPARK-2251] fix concurrency issues in random sampler (branch-1.0)

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/random/RandomSampler.scala
+++ b/core/src/main/scala/org/apache/spark/util/random/RandomSampler.scala
@@ -72,9 +72,10 @@ class BernoulliSampler[T](lb: Double, ub: Double, complement: Boolean = false)
   /**
    *  Return a sampler with is the complement of the range specified of the current sampler.
    */
-  def cloneComplement():  BernoulliSampler[T] = new BernoulliSampler[T](lb, ub, !complement)
+  def cloneComplement():  BernoulliSampler[T] =
+    new BernoulliSampler[T](lb, ub, !complement)(new XORShiftRandom)
 
-  override def clone = new BernoulliSampler[T](lb, ub, complement)
+  override def clone = new BernoulliSampler[T](lb, ub, complement)(new XORShiftRandom)
 }
 
 /**
@@ -104,5 +105,5 @@ class PoissonSampler[T](mean: Double)
     }
   }
 
-  override def clone = new PoissonSampler[T](mean)
+  override def clone = new PoissonSampler[T](mean)(new Poisson(mean, new DRand))
 }


### PR DESCRIPTION
The following code is very likely to throw an exception:

```
val rdd = sc.parallelize(0 until 111, 10).sample(false, 0.1)
rdd.zip(rdd).count()
```

because the same random number generator is used in compute partitions. This fix doesn't change the type signature.

@pwendell
