### PR TITLE
Strip '@' symbols when merging pull requests.

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -130,7 +130,9 @@ def merge_pr(pr_num, target_ref):
 
     merge_message_flags += ["-m", title]
     if body != None:
-        merge_message_flags += ["-m", body]
+        # We remove @ symbols from the body to avoid triggering e-mails
+        # to people every time someone creates a public fork of Spark.
+        merge_message_flags += ["-m", body.replace("@", "")]
 
     authors = "\n".join(["Author: %s" % a for a in distinct_authors])
 


### PR DESCRIPTION
Currently all of the commits with '@X' in them cause person X to
receive e-mails every time someone makes a public fork of Spark.

@marmbrus who requested this.
