### PR TITLE
[WIP] SPARK-2126: Move MapOutputTracker behind ShuffleManager interface to 

### DIFF
--- a/core/src/main/scala/org/apache/spark/ContextCleaner.scala
+++ b/core/src/main/scala/org/apache/spark/ContextCleaner.scala
@@ -19,8 +19,6 @@ package org.apache.spark
 
 import java.lang.ref.{ReferenceQueue, WeakReference}
 
-import org.apache.spark.shuffle.MapOutputTrackerMaster
-
 import scala.collection.mutable.{ArrayBuffer, SynchronizedBuffer}
 
 import org.apache.spark.broadcast.Broadcast

--- a/core/src/main/scala/org/apache/spark/ContextCleaner.scala
+++ b/core/src/main/scala/org/apache/spark/ContextCleaner.scala
@@ -19,6 +19,8 @@ package org.apache.spark
 
 import java.lang.ref.{ReferenceQueue, WeakReference}
 
+import org.apache.spark.shuffle.MapOutputTrackerMaster
+
 import scala.collection.mutable.{ArrayBuffer, SynchronizedBuffer}
 
 import org.apache.spark.broadcast.Broadcast
@@ -150,7 +152,7 @@ private[spark] class ContextCleaner(sc: SparkContext) extends Logging {
   def doCleanupShuffle(shuffleId: Int, blocking: Boolean) {
     try {
       logDebug("Cleaning shuffle " + shuffleId)
-      mapOutputTrackerMaster.unregisterShuffle(shuffleId)
+      shuffleManager.unregisterShuffle(shuffleId)
       blockManagerMaster.removeShuffle(shuffleId, blocking)
       listeners.foreach(_.shuffleCleaned(shuffleId))
       logInfo("Cleaned shuffle " + shuffleId)
@@ -173,7 +175,7 @@ private[spark] class ContextCleaner(sc: SparkContext) extends Logging {
 
   private def blockManagerMaster = sc.env.blockManager.master
   private def broadcastManager = sc.env.broadcastManager
-  private def mapOutputTrackerMaster = sc.env.mapOutputTracker.asInstanceOf[MapOutputTrackerMaster]
+  private def shuffleManager = sc.env.shuffleManager
 
   // Used for testing. These methods explicitly blocks until cleanup is completed
   // to ensure that more reliable testing.

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -180,7 +180,7 @@ private[spark] class Executor(
 
         attemptedTask = Some(task)
         logDebug("Task " + taskId + "'s epoch is " + task.epoch)
-        env.mapOutputTracker.updateEpoch(task.epoch)
+        env.shuffleManager.updateEpoch(task.epoch)
 
         // Run the actual task and measure its runtime.
         taskStart = System.currentTimeMillis()

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -180,7 +180,7 @@ private[spark] class Executor(
 
         attemptedTask = Some(task)
         logDebug("Task " + taskId + "'s epoch is " + task.epoch)
-        env.shuffleManager.updateEpoch(task.epoch)
+        env.shuffleManager.mapOutputTracker.updateEpoch(task.epoch)
 
         // Run the actual task and measure its runtime.
         taskStart = System.currentTimeMillis()

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -17,9 +17,11 @@
 
 package org.apache.spark.scheduler
 
-import java.io.{NotSerializableException, PrintWriter, StringWriter}
+import java.io.{NotSerializableException}
 import java.util.Properties
 import java.util.concurrent.atomic.AtomicInteger
+
+import org.apache.spark.shuffle.{ShuffleManager}
 
 import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet, Map}
 import scala.concurrent.Await
@@ -59,7 +61,7 @@ class DAGScheduler(
     private[scheduler] val sc: SparkContext,
     private[scheduler] val taskScheduler: TaskScheduler,
     listenerBus: LiveListenerBus,
-    mapOutputTracker: MapOutputTrackerMaster,
+    shuffleManager: ShuffleManager,
     blockManagerMaster: BlockManagerMaster,
     env: SparkEnv,
     clock: Clock = SystemClock)
@@ -72,7 +74,7 @@ class DAGScheduler(
       sc,
       taskScheduler,
       sc.listenerBus,
-      sc.env.mapOutputTracker.asInstanceOf[MapOutputTrackerMaster],
+      sc.env.shuffleManager,
       sc.env.blockManager.master,
       sc.env)
   }
@@ -241,18 +243,17 @@ class DAGScheduler(
     : Stage =
   {
     val stage = newStage(rdd, numTasks, Some(shuffleDep), jobId, callSite)
-    if (mapOutputTracker.containsShuffle(shuffleDep.shuffleId)) {
-      val serLocs = mapOutputTracker.getSerializedMapOutputStatuses(shuffleDep.shuffleId)
-      val locs = MapOutputTracker.deserializeMapStatuses(serLocs)
-      for (i <- 0 until locs.size) {
-        stage.outputLocs(i) = Option(locs(i)).toList   // locs(i) will be null if missing
+    if (shuffleManager.containsShuffle(shuffleDep.shuffleId)) {
+      val mapStatusArray = shuffleManager.getShuffleMetadata(shuffleDep.shuffleId)
+      for (i <- 0 until mapStatusArray.size) {
+        stage.outputLocs(i) = Option(mapStatusArray(i)).toList   // locs(i) will be null if missing
       }
-      stage.numAvailableOutputs = locs.count(_ != null)
+      stage.numAvailableOutputs = mapStatusArray.count(_ != null)
     } else {
-      // Kind of ugly: need to register RDDs with the cache and map output tracker here
+      // Kind of ugly: need to register RDDs with the cache and shuffleManager here
       // since we can't do it in the RDD constructor because # of partitions is unknown
       logInfo("Registering RDD " + rdd.id + " (" + rdd.getCreationSite + ")")
-      mapOutputTracker.registerShuffle(shuffleDep.shuffleId, rdd.partitions.size)
+      shuffleManager.registerShuffle(shuffleDep.shuffleId, rdd.partitions.size, shuffleDep)
     }
     stage
   }
@@ -866,7 +867,7 @@ class DAGScheduler(
                 // epoch incremented to refetch them.
                 // TODO: Only increment the epoch number if this is not the first time
                 //       we registered these map outputs.
-                mapOutputTracker.registerMapOutputs(
+                shuffleManager.registerMapOutputs(
                   stage.shuffleDep.get.shuffleId,
                   stage.outputLocs.map(list => if (list.isEmpty) null else list.head).toArray,
                   changeEpoch = true)
@@ -915,7 +916,7 @@ class DAGScheduler(
         val mapStage = shuffleToMapStage(shuffleId)
         if (mapId != -1) {
           mapStage.removeOutputLoc(mapId, bmAddress)
-          mapOutputTracker.unregisterMapOutput(shuffleId, mapId, bmAddress)
+          shuffleManager.unregisterMapOutput(shuffleId, mapId, bmAddress)
         }
         logInfo("The failed fetch was from " + mapStage + " (" + mapStage.name +
           "); marking it for resubmission")
@@ -955,7 +956,7 @@ class DAGScheduler(
    * stray fetch failures from possibly retriggering the detection of a node as lost.
    */
   private[scheduler] def handleExecutorLost(execId: String, maybeEpoch: Option[Long] = None) {
-    val currentEpoch = maybeEpoch.getOrElse(mapOutputTracker.getEpoch)
+    val currentEpoch = maybeEpoch.getOrElse(shuffleManager.getEpoch)
     if (!failedEpoch.contains(execId) || failedEpoch(execId) < currentEpoch) {
       failedEpoch(execId) = currentEpoch
       logInfo("Executor lost: %s (epoch %d)".format(execId, currentEpoch))
@@ -964,10 +965,10 @@ class DAGScheduler(
       for ((shuffleId, stage) <- shuffleToMapStage) {
         stage.removeOutputsOnExecutor(execId)
         val locs = stage.outputLocs.map(list => if (list.isEmpty) null else list.head).toArray
-        mapOutputTracker.registerMapOutputs(shuffleId, locs, changeEpoch = true)
+        shuffleManager.registerMapOutputs(shuffleId, locs, changeEpoch = true)
       }
       if (shuffleToMapStage.isEmpty) {
-        mapOutputTracker.incrementEpoch()
+        shuffleManager.incrementEpoch()
       }
       clearCacheLocs()
     } else {

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -955,7 +955,7 @@ class DAGScheduler(
    * stray fetch failures from possibly retriggering the detection of a node as lost.
    */
   private[scheduler] def handleExecutorLost(execId: String, maybeEpoch: Option[Long] = None) {
-    val currentEpoch = maybeEpoch.getOrElse(shuffleManager.getEpoch)
+    val currentEpoch = maybeEpoch.getOrElse(shuffleManager.mapOutputTracker.getEpoch)
     if (!failedEpoch.contains(execId) || failedEpoch(execId) < currentEpoch) {
       failedEpoch(execId) = currentEpoch
       logInfo("Executor lost: %s (epoch %d)".format(execId, currentEpoch))
@@ -967,7 +967,7 @@ class DAGScheduler(
         shuffleManager.registerMapOutputs(shuffleId, locs, changeEpoch = true)
       }
       if (shuffleToMapStage.isEmpty) {
-        shuffleManager.incrementEpoch()
+        shuffleManager.mapOutputTracker.incrementEpoch()
       }
       clearCacheLocs()
     } else {

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -21,8 +21,6 @@ import java.io.{NotSerializableException}
 import java.util.Properties
 import java.util.concurrent.atomic.AtomicInteger
 
-import org.apache.spark.shuffle.{ShuffleManager}
-
 import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet, Map}
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -39,6 +37,7 @@ import org.apache.spark._
 import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.partial.{ApproximateActionListener, ApproximateEvaluator, PartialResult}
 import org.apache.spark.rdd.RDD
+import org.apache.spark.shuffle.ShuffleManager
 import org.apache.spark.storage.{BlockId, BlockManager, BlockManagerMaster, RDDBlockId}
 import org.apache.spark.util.{CallSite, SystemClock, Clock, Utils}
 

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -37,7 +37,7 @@ import org.apache.spark._
 import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.partial.{ApproximateActionListener, ApproximateEvaluator, PartialResult}
 import org.apache.spark.rdd.RDD
-import org.apache.spark.shuffle.ShuffleManager
+import org.apache.spark.shuffle.{MapStatus, ShuffleManager}
 import org.apache.spark.storage.{BlockId, BlockManager, BlockManagerMaster, RDDBlockId}
 import org.apache.spark.util.{CallSite, SystemClock, Clock, Utils}
 

--- a/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapTask.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapTask.scala
@@ -26,7 +26,7 @@ import scala.collection.mutable.HashMap
 
 import org.apache.spark._
 import org.apache.spark.rdd.{RDD, RDDCheckpointData}
-import org.apache.spark.shuffle.ShuffleWriter
+import org.apache.spark.shuffle.{ShuffleWriter, MapStatus}
 
 private[spark] object ShuffleMapTask {
 

--- a/core/src/main/scala/org/apache/spark/scheduler/Stage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Stage.scala
@@ -19,6 +19,7 @@ package org.apache.spark.scheduler
 
 import org.apache.spark._
 import org.apache.spark.rdd.RDD
+import org.apache.spark.shuffle.MapStatus
 import org.apache.spark.storage.BlockManagerId
 import org.apache.spark.util.CallSite
 

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -95,7 +95,7 @@ private[spark] class TaskSchedulerImpl(
 
   var backend: SchedulerBackend = null
 
-  val mapOutputTracker = SparkEnv.get.mapOutputTracker
+  val shuffleManager = SparkEnv.get.shuffleManager
 
   var schedulableBuilder: SchedulableBuilder = null
   var rootPool: Pool = null

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -140,7 +140,7 @@ private[spark] class TaskSetManager(
   val recentExceptions = HashMap[String, (Int, Long)]()
 
   // Figure out the current map output tracker epoch and set it on all tasks
-  val epoch = sched.mapOutputTracker.getEpoch
+  val epoch = sched.shuffleManager.getEpoch
   logDebug("Epoch for " + taskSet + ": " + epoch)
   for (t <- tasks) {
     t.epoch = epoch

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -140,7 +140,7 @@ private[spark] class TaskSetManager(
   val recentExceptions = HashMap[String, (Int, Long)]()
 
   // Figure out the current map output tracker epoch and set it on all tasks
-  val epoch = sched.shuffleManager.getEpoch
+  val epoch = sched.shuffleManager.mapOutputTracker.getEpoch
   logDebug("Epoch for " + taskSet + ": " + epoch)
   for (t <- tasks) {
     t.epoch = epoch

--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -27,7 +27,7 @@ import com.twitter.chill.{AllScalaRegistrar, EmptyScalaKryoInstantiator}
 
 import org.apache.spark._
 import org.apache.spark.broadcast.HttpBroadcast
-import org.apache.spark.scheduler.MapStatus
+import org.apache.spark.shuffle.MapStatus
 import org.apache.spark.storage._
 import org.apache.spark.storage.{GetBlock, GotBlock, PutBlock}
 

--- a/core/src/main/scala/org/apache/spark/shuffle/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/MapOutputTracker.scala
@@ -20,13 +20,18 @@ package org.apache.spark.shuffle
 import java.io._
 import java.util.zip.{GZIPInputStream, GZIPOutputStream}
 
+import scala.collection.mutable.{HashMap, HashSet, Map}
+import scala.concurrent.Await
+
 import akka.actor._
 import akka.pattern.ask
 
+import org.apache.spark.{SparkException, Logging, SparkConf}
 import org.apache.spark.util._
-import org.apache.spark.scheduler.MapStatus
-import org.apache.spark.shuffle.MetadataFetchFailedException
 import org.apache.spark.storage.BlockManagerId
+
+import scala.collection.mutable
+import scala.concurrent.Await
 
 private[spark] sealed trait MapOutputTrackerMessage
 private[spark] case class GetMapOutputStatuses(shuffleId: Int)

--- a/core/src/main/scala/org/apache/spark/shuffle/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/MapOutputTracker.scala
@@ -184,6 +184,13 @@ private[spark] abstract class MapOutputTracker(conf: SparkConf) extends Logging 
     }
   }
 
+  def incrementEpoch() {
+    epochLock.synchronized {
+      epoch += 1
+      logDebug("Increasing epoch to " + epoch)
+    }
+  }
+
   /**
    * Called from executors to update the epoch number, potentially clearing old outputs
    * because of a fetch failure. Each worker task calls this with the latest epoch
@@ -276,13 +283,6 @@ private[spark] class MapOutputTrackerMaster(conf: SparkConf)
   /** Check if the given shuffle is being tracked */
   def containsShuffle(shuffleId: Int): Boolean = {
     cachedSerializedStatuses.contains(shuffleId) || mapStatuses.contains(shuffleId)
-  }
-
-  def incrementEpoch() {
-    epochLock.synchronized {
-      epoch += 1
-      logDebug("Increasing epoch to " + epoch)
-    }
   }
 
   def getSerializedMapOutputStatuses(shuffleId: Int): Array[Byte] = {

--- a/core/src/main/scala/org/apache/spark/shuffle/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/MapOutputTracker.scala
@@ -15,13 +15,10 @@
  * limitations under the License.
  */
 
-package org.apache.spark
+package org.apache.spark.shuffle
 
 import java.io._
 import java.util.zip.{GZIPInputStream, GZIPOutputStream}
-
-import scala.collection.mutable.{HashSet, HashMap, Map}
-import scala.concurrent.Await
 
 import akka.actor._
 import akka.pattern.ask

--- a/core/src/main/scala/org/apache/spark/shuffle/MapStatus.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/MapStatus.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.spark.scheduler
+package org.apache.spark.shuffle
 
 import java.io.{Externalizable, ObjectInput, ObjectOutput}
 

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleManager.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleManager.scala
@@ -35,7 +35,7 @@ import org.apache.spark.util.{AkkaUtils, Utils}
 private[spark] trait ShuffleManager {
 
   protected var isDriver: Boolean = true
-  protected var mapOutputTracker: MapOutputTracker = _
+  protected[spark] var mapOutputTracker: MapOutputTracker = _
 
   /**
    * initialize the mapOutputTracker
@@ -139,7 +139,7 @@ private[spark] trait ShuffleManager {
   // TODO: disassociate Epoch with ShuffleManager?
   def incrementEpoch() {
     if (isDriver) {
-      mapOutputTracker.asInstanceOf[MapOutputTrackerMaster].incrementEpoch()
+      mapOutputTracker.incrementEpoch()
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleManager.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleManager.scala
@@ -17,13 +17,13 @@
 
 package org.apache.spark.shuffle
 
-import org.apache.spark.scheduler.MapStatus
-import org.apache.spark.storage.BlockManagerId
-
 import scala.concurrent.Await
 
 import akka.actor.{Props, ActorSystem}
+
 import org.apache.spark._
+import org.apache.spark.scheduler.MapStatus
+import org.apache.spark.storage.BlockManagerId
 import org.apache.spark.util.{AkkaUtils, Utils}
 
 

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleManager.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleManager.scala
@@ -22,7 +22,6 @@ import scala.concurrent.Await
 import akka.actor.{Props, ActorSystem}
 
 import org.apache.spark._
-import org.apache.spark.scheduler.MapStatus
 import org.apache.spark.storage.BlockManagerId
 import org.apache.spark.util.{AkkaUtils, Utils}
 

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleManager.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleManager.scala
@@ -137,23 +137,6 @@ private[spark] trait ShuffleManager {
       endPartition: Int,
       context: TaskContext): ShuffleReader[K, C]
 
-  def getEpoch = mapOutputTracker.getEpoch
-
-  // TODO: disassociate Epoch with ShuffleManager?
-  def incrementEpoch() {
-    if (isDriver) {
-      mapOutputTracker.incrementEpoch()
-    }
-  }
-
-  def updateEpoch(newEpoch: Long) {
-    mapOutputTracker.updateEpoch(newEpoch)
-  }
-
-  def getServerStatuses(shuffleId: Int, reduceId: Int) = {
-    mapOutputTracker.getServerStatuses(shuffleId, reduceId)
-  }
-
   /** Shut down this ShuffleManager. */
   def stop() {
     mapOutputTracker.stop()

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleManager.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleManager.scala
@@ -59,7 +59,8 @@ private[spark] trait ShuffleManager {
       Utils.checkHost(driverHost, "Expected hostname")
       val url = s"akka.tcp://spark@$driverHost:$driverPort/user/MapOutputTracker"
       val timeout = AkkaUtils.lookupTimeout(conf)
-      Await.result(actorSystem.actorSelection(url).resolveOne(timeout), timeout)
+      mapOutputTracker.trackerActor = Await.result(
+        actorSystem.actorSelection(url).resolveOne(timeout), timeout)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleManager.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleManager.scala
@@ -17,24 +17,107 @@
 
 package org.apache.spark.shuffle
 
-import org.apache.spark.{TaskContext, ShuffleDependency}
+import org.apache.spark.scheduler.MapStatus
+import org.apache.spark.storage.BlockManagerId
+
+import scala.concurrent.Await
+
+import akka.actor.{Props, ActorSystem}
+import org.apache.spark._
+import org.apache.spark.util.{AkkaUtils, Utils}
+
 
 /**
  * Pluggable interface for shuffle systems. A ShuffleManager is created in SparkEnv on both the
  * driver and executors, based on the spark.shuffle.manager setting. The driver registers shuffles
  * with it, and executors (or tasks running locally in the driver) can ask to read and write data.
- *
- * NOTE: this will be instantiated by SparkEnv so its constructor can take a SparkConf and
- * boolean isDriver as parameters.
  */
 private[spark] trait ShuffleManager {
+
+  protected var mapOutputTracker: MapOutputTracker = _
+
+  /**
+   * initialize the mapOutputTracker
+   *
+   * Basic implementation here, the users can implement customized MapOutputTracker and override
+   * this method for customized approach to keep track the map output
+   */
+  def initMapOutputTracker(conf: SparkConf, isDriver: Boolean, actorSystem: ActorSystem) {
+    if (isDriver) {
+      mapOutputTracker = new MapOutputTrackerMaster(conf)
+      mapOutputTracker.trackerActor = actorSystem.actorOf(
+        Props(new MapOutputTrackerMasterActor(mapOutputTracker.asInstanceOf[MapOutputTrackerMaster],
+          conf)), "MapOutputTracker")
+    } else {
+      mapOutputTracker = new MapOutputTrackerWorker(conf)
+      val driverHost: String = conf.get("spark.driver.host", "localhost")
+      val driverPort: Int = conf.getInt("spark.driver.port", 7077)
+      Utils.checkHost(driverHost, "Expected hostname")
+      val url = s"akka.tcp://spark@$driverHost:$driverPort/user/MapOutputTracker"
+      val timeout = AkkaUtils.lookupTimeout(conf)
+      Await.result(actorSystem.actorSelection(url).resolveOne(timeout), timeout)
+    }
+  }
+
   /**
    * Register a shuffle with the manager and obtain a handle for it to pass to tasks.
    */
   def registerShuffle[K, V, C](
       shuffleId: Int,
       numMaps: Int,
-      dependency: ShuffleDependency[K, V, C]): ShuffleHandle
+      dependency: ShuffleDependency[K, V, C]): ShuffleHandle = {
+    if (mapOutputTracker.isInstanceOf[MapOutputTrackerMaster]) {
+      mapOutputTracker.asInstanceOf[MapOutputTrackerMaster].registerShuffle(shuffleId, numMaps)
+    }
+    new BaseShuffleHandle(shuffleId, numMaps, dependency)
+  }
+
+  /** Remove a shuffle's metadata from the ShuffleManager. */
+  def unregisterShuffle(shuffleId: Int) {
+    mapOutputTracker.unregisterShuffle(shuffleId)
+  }
+
+  def registerMapOutput(shuffleId: Int, mapId: Int, status: MapStatus) {
+    if (mapOutputTracker.isInstanceOf[MapOutputTrackerMaster]) {
+      mapOutputTracker.asInstanceOf[MapOutputTrackerMaster].registerMapOutput(shuffleId, mapId,
+        status)
+    }
+  }
+
+  /** Register multiple map output information for the given shuffle */
+  def registerMapOutputs(shuffleId: Int, statuses: Array[MapStatus], changeEpoch: Boolean = false) {
+    if (mapOutputTracker.isInstanceOf[MapOutputTrackerMaster]) {
+      mapOutputTracker.asInstanceOf[MapOutputTrackerMaster].registerMapOutputs(
+        shuffleId, statuses, changeEpoch)
+    }
+  }
+
+  def unregisterMapOutput(shuffleId: Int, mapId: Int, bmAddress: BlockManagerId) {
+    if (mapOutputTracker.isInstanceOf[MapOutputTrackerMaster]) {
+      mapOutputTracker.asInstanceOf[MapOutputTrackerMaster].unregisterMapOutput(shuffleId, mapId,
+        bmAddress)
+    }
+  }
+
+  def containsShuffle(shuffleId: Int): Boolean =  {
+    if (mapOutputTracker.isInstanceOf[MapOutputTrackerMaster]) {
+      mapOutputTracker.asInstanceOf[MapOutputTrackerMaster].containsShuffle(shuffleId)
+    } else {
+      false
+    }
+  }
+
+  // TODO: MapStatus should be customizable
+  def getShuffleMetadata(shuffleId: Int): Array[MapStatus] = {
+    if (mapOutputTracker.isInstanceOf[MapOutputTrackerMaster]) {
+      val serLocs = mapOutputTracker.asInstanceOf[MapOutputTrackerMaster].
+        getSerializedMapOutputStatuses(shuffleId)
+      MapOutputTracker.deserializeMapStatuses(serLocs)
+    } else {
+      null
+    }
+  }
+
 
   /** Get a writer for a given partition. Called on executors by map tasks. */
   def getWriter[K, V](handle: ShuffleHandle, mapId: Int, context: TaskContext): ShuffleWriter[K, V]
@@ -49,9 +132,25 @@ private[spark] trait ShuffleManager {
       endPartition: Int,
       context: TaskContext): ShuffleReader[K, C]
 
-  /** Remove a shuffle's metadata from the ShuffleManager. */
-  def unregisterShuffle(shuffleId: Int)
+  def getEpoch = mapOutputTracker.getEpoch
+
+  // TODO: disassociate Epoch with ShuffleManager?
+  def incrementEpoch() {
+    if (mapOutputTracker.isInstanceOf[MapOutputTrackerMaster]) {
+      mapOutputTracker.asInstanceOf[MapOutputTrackerMaster].incrementEpoch()
+    }
+  }
+
+  def updateEpoch(newEpoch: Long) {
+    mapOutputTracker.updateEpoch(newEpoch)
+  }
+
+  def getServerStatuses(shuffleId: Int, reduceId: Int) = {
+    mapOutputTracker.getServerStatuses(shuffleId, reduceId)
+  }
 
   /** Shut down this ShuffleManager. */
-  def stop(): Unit
+  def stop() {
+    mapOutputTracker.stop()
+  }
 }

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleWriter.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleWriter.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.shuffle
 
-import org.apache.spark.scheduler.MapStatus
-
 /**
  * Obtained inside a map task to write out records to the shuffle system.
  */

--- a/core/src/main/scala/org/apache/spark/shuffle/hash/BlockStoreShuffleFetcher.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/hash/BlockStoreShuffleFetcher.scala
@@ -39,7 +39,8 @@ private[hash] object BlockStoreShuffleFetcher extends Logging {
     val blockManager = SparkEnv.get.blockManager
 
     val startTime = System.currentTimeMillis
-    val statuses = SparkEnv.get.shuffleManager.getServerStatuses(shuffleId, reduceId)
+    val statuses = SparkEnv.get.shuffleManager.mapOutputTracker.getServerStatuses(shuffleId,
+      reduceId)
     logDebug("Fetching map output location for shuffle %d, reduce %d took %d ms".format(
       shuffleId, reduceId, System.currentTimeMillis - startTime))
 

--- a/core/src/main/scala/org/apache/spark/shuffle/hash/BlockStoreShuffleFetcher.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/hash/BlockStoreShuffleFetcher.scala
@@ -39,7 +39,7 @@ private[hash] object BlockStoreShuffleFetcher extends Logging {
     val blockManager = SparkEnv.get.blockManager
 
     val startTime = System.currentTimeMillis
-    val statuses = SparkEnv.get.mapOutputTracker.getServerStatuses(shuffleId, reduceId)
+    val statuses = SparkEnv.get.shuffleManager.getServerStatuses(shuffleId, reduceId)
     logDebug("Fetching map output location for shuffle %d, reduce %d took %d ms".format(
       shuffleId, reduceId, System.currentTimeMillis - startTime))
 

--- a/core/src/main/scala/org/apache/spark/shuffle/hash/HashShuffleManager.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/hash/HashShuffleManager.scala
@@ -25,13 +25,6 @@ import org.apache.spark.shuffle._
  * mapper (possibly reusing these across waves of tasks).
  */
 class HashShuffleManager(conf: SparkConf) extends ShuffleManager {
-  /* Register a shuffle with the manager and obtain a handle for it to pass to tasks. */
-  override def registerShuffle[K, V, C](
-      shuffleId: Int,
-      numMaps: Int,
-      dependency: ShuffleDependency[K, V, C]): ShuffleHandle = {
-    new BaseShuffleHandle(shuffleId, numMaps, dependency)
-  }
 
   /**
    * Get a reader for a range of reduce partitions (startPartition to endPartition-1, inclusive).
@@ -51,10 +44,4 @@ class HashShuffleManager(conf: SparkConf) extends ShuffleManager {
       : ShuffleWriter[K, V] = {
     new HashShuffleWriter(handle.asInstanceOf[BaseShuffleHandle[K, V, _]], mapId, context)
   }
-
-  /** Remove a shuffle's metadata from the ShuffleManager. */
-  override def unregisterShuffle(shuffleId: Int): Unit = {}
-
-  /** Shut down this ShuffleManager. */
-  override def stop(): Unit = {}
 }

--- a/core/src/main/scala/org/apache/spark/shuffle/hash/HashShuffleWriter.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/hash/HashShuffleWriter.scala
@@ -17,12 +17,11 @@
 
 package org.apache.spark.shuffle.hash
 
-import org.apache.spark.shuffle.{MapOutputTracker, BaseShuffleHandle, ShuffleWriter}
+import org.apache.spark.shuffle.{MapStatus, MapOutputTracker, BaseShuffleHandle, ShuffleWriter}
 import org.apache.spark.{Logging, SparkEnv, TaskContext}
 import org.apache.spark.storage.{BlockObjectWriter}
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.executor.ShuffleWriteMetrics
-import org.apache.spark.scheduler.MapStatus
 
 class HashShuffleWriter[K, V](
     handle: BaseShuffleHandle[K, V, _],

--- a/core/src/main/scala/org/apache/spark/shuffle/hash/HashShuffleWriter.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/hash/HashShuffleWriter.scala
@@ -17,8 +17,8 @@
 
 package org.apache.spark.shuffle.hash
 
-import org.apache.spark.shuffle.{BaseShuffleHandle, ShuffleWriter}
-import org.apache.spark.{Logging, MapOutputTracker, SparkEnv, TaskContext}
+import org.apache.spark.shuffle.{MapOutputTracker, BaseShuffleHandle, ShuffleWriter}
+import org.apache.spark.{Logging, SparkEnv, TaskContext}
 import org.apache.spark.storage.{BlockObjectWriter}
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.executor.ShuffleWriteMetrics
@@ -37,7 +37,7 @@ class HashShuffleWriter[K, V](
 
   private val blockManager = SparkEnv.get.blockManager
   private val shuffleBlockManager = blockManager.shuffleBlockManager
-  private val ser = Serializer.getSerializer(dep.serializer.getOrElse(null))
+  private val ser = Serializer.getSerializer(dep.serializer.orNull)
   private val shuffle = shuffleBlockManager.forMapTask(dep.shuffleId, mapId, numOutputSplits, ser)
 
   /** Write a bunch of records to this task's output */
@@ -69,7 +69,7 @@ class HashShuffleWriter[K, V](
       stopping = true
       if (success) {
         try {
-          return Some(commitWritesAndBuildStatus())
+          Some(commitWritesAndBuildStatus())
         } catch {
           case e: Exception =>
             revertWrites()
@@ -77,7 +77,7 @@ class HashShuffleWriter[K, V](
         }
       } else {
         revertWrites()
-        return None
+        None
       }
     } finally {
       // Release the writers back to the shuffle block manager.

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -20,8 +20,6 @@ package org.apache.spark.storage
 import java.io.{File, InputStream, OutputStream, BufferedOutputStream, ByteArrayOutputStream}
 import java.nio.{ByteBuffer, MappedByteBuffer}
 
-import org.apache.spark.shuffle.{ShuffleManager}
-
 import scala.collection.mutable.{ArrayBuffer, HashMap}
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
@@ -32,6 +30,7 @@ import sun.nio.ch.DirectBuffer
 
 import org.apache.spark._
 import org.apache.spark.io.CompressionCodec
+import org.apache.spark.shuffle.{ShuffleManager}
 import org.apache.spark.network._
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.util._

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerSlaveActor.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerSlaveActor.scala
@@ -17,11 +17,13 @@
 
 package org.apache.spark.storage
 
+import org.apache.spark.shuffle.{ShuffleManager}
+
 import scala.concurrent.Future
 
 import akka.actor.{ActorRef, Actor}
 
-import org.apache.spark.{Logging, MapOutputTracker}
+import org.apache.spark.Logging
 import org.apache.spark.storage.BlockManagerMessages._
 
 /**
@@ -31,7 +33,7 @@ import org.apache.spark.storage.BlockManagerMessages._
 private[storage]
 class BlockManagerSlaveActor(
     blockManager: BlockManager,
-    mapOutputTracker: MapOutputTracker)
+    shuffleManager: ShuffleManager)
   extends Actor with Logging {
 
   import context.dispatcher
@@ -51,8 +53,8 @@ class BlockManagerSlaveActor(
 
     case RemoveShuffle(shuffleId) =>
       doAsync[Boolean]("removing shuffle " + shuffleId, sender) {
-        if (mapOutputTracker != null) {
-          mapOutputTracker.unregisterShuffle(shuffleId)
+        if (shuffleManager != null) {
+          shuffleManager.unregisterShuffle(shuffleId)
         }
         blockManager.shuffleBlockManager.removeShuffle(shuffleId)
       }

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerSlaveActor.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerSlaveActor.scala
@@ -17,14 +17,13 @@
 
 package org.apache.spark.storage
 
-import org.apache.spark.shuffle.{ShuffleManager}
-
 import scala.concurrent.Future
 
 import akka.actor.{ActorRef, Actor}
 
 import org.apache.spark.Logging
 import org.apache.spark.storage.BlockManagerMessages._
+import org.apache.spark.shuffle.ShuffleManager
 
 /**
  * An actor to take commands from the master to execute options. For example,

--- a/core/src/main/scala/org/apache/spark/storage/ThreadingTest.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ThreadingTest.scala
@@ -20,9 +20,11 @@ package org.apache.spark.storage
 import java.util.concurrent.ArrayBlockingQueue
 
 import akka.actor._
+import org.apache.spark.shuffle.hash.HashShuffleManager
+import org.apache.spark.shuffle.{ShuffleManager, MapOutputTrackerMaster}
 import util.Random
 
-import org.apache.spark.{MapOutputTrackerMaster, SecurityManager, SparkConf}
+import org.apache.spark.{SecurityManager, SparkConf}
 import org.apache.spark.scheduler.LiveListenerBus
 import org.apache.spark.serializer.KryoSerializer
 
@@ -99,9 +101,10 @@ private[spark] object ThreadingTest {
     val blockManagerMaster = new BlockManagerMaster(
       actorSystem.actorOf(Props(new BlockManagerMasterActor(true, conf, new LiveListenerBus))),
       conf)
+    val shuffleManager = new HashShuffleManager(conf)
     val blockManager = new BlockManager(
       "<driver>", actorSystem, blockManagerMaster, serializer, 1024 * 1024, conf,
-      new SecurityManager(conf), new MapOutputTrackerMaster(conf))
+      new SecurityManager(conf), shuffleManager)
     val producers = (1 to numProducers).map(i => new ProducerThread(blockManager, i))
     val consumers = producers.map(p => new ConsumerThread(blockManager, p.queue))
     producers.foreach(_.start)

--- a/core/src/main/scala/org/apache/spark/storage/ThreadingTest.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ThreadingTest.scala
@@ -20,13 +20,12 @@ package org.apache.spark.storage
 import java.util.concurrent.ArrayBlockingQueue
 
 import akka.actor._
-import org.apache.spark.shuffle.hash.HashShuffleManager
-import org.apache.spark.shuffle.{ShuffleManager, MapOutputTrackerMaster}
 import util.Random
 
 import org.apache.spark.{SecurityManager, SparkConf}
 import org.apache.spark.scheduler.LiveListenerBus
 import org.apache.spark.serializer.KryoSerializer
+import org.apache.spark.shuffle.hash.HashShuffleManager
 
 /**
  * This class tests the BlockManager and MemoryStore for thread safety and

--- a/core/src/test/scala/org/apache/spark/AkkaUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/AkkaUtilsSuite.scala
@@ -17,14 +17,17 @@
 
 package org.apache.spark
 
-import org.apache.spark.shuffle.{MapOutputTracker, MapOutputTrackerWorker, MapOutputTrackerMaster, MapOutputTrackerMasterActor}
-import org.scalatest.FunSuite
+import scala.concurrent.Await
 
 import akka.actor._
+import org.scalatest.FunSuite
+
 import org.apache.spark.scheduler.MapStatus
 import org.apache.spark.storage.BlockManagerId
 import org.apache.spark.util.AkkaUtils
-import scala.concurrent.Await
+import org.apache.spark.shuffle.{MapOutputTracker, MapOutputTrackerWorker, MapOutputTrackerMaster,
+MapOutputTrackerMasterActor}
+
 
 /**
   * Test the AkkaUtils with various security settings.

--- a/core/src/test/scala/org/apache/spark/AkkaUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/AkkaUtilsSuite.scala
@@ -21,12 +21,9 @@ import scala.concurrent.Await
 
 import akka.actor._
 import org.scalatest.FunSuite
-
-import org.apache.spark.scheduler.MapStatus
 import org.apache.spark.storage.BlockManagerId
 import org.apache.spark.util.AkkaUtils
-import org.apache.spark.shuffle.{MapOutputTracker, MapOutputTrackerWorker, MapOutputTrackerMaster,
-MapOutputTrackerMasterActor}
+import org.apache.spark.shuffle._
 
 
 /**

--- a/core/src/test/scala/org/apache/spark/AkkaUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/AkkaUtilsSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark
 
+import org.apache.spark.shuffle.{MapOutputTracker, MapOutputTrackerWorker, MapOutputTrackerMaster, MapOutputTrackerMasterActor}
 import org.scalatest.FunSuite
 
 import akka.actor._

--- a/core/src/test/scala/org/apache/spark/ContextCleanerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ContextCleanerSuite.scala
@@ -19,8 +19,6 @@ package org.apache.spark
 
 import java.lang.ref.WeakReference
 
-import org.apache.spark.shuffle.MapOutputTrackerMaster
-
 import scala.collection.mutable.{HashSet, SynchronizedSet}
 import scala.language.existentials
 import scala.language.postfixOps
@@ -34,6 +32,7 @@ import org.scalatest.time.SpanSugar._
 import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.{BlockId, BroadcastBlockId, RDDBlockId, ShuffleBlockId}
+import org.apache.spark.shuffle.MapOutputTrackerMaster
 
 class ContextCleanerSuite extends FunSuite with BeforeAndAfter with LocalSparkContext {
 

--- a/core/src/test/scala/org/apache/spark/ContextCleanerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ContextCleanerSuite.scala
@@ -414,5 +414,6 @@ class CleanerTester(
   }
 
   private def blockManager = sc.env.blockManager
-  private def mapOutputTrackerMaster = sc.env.mapOutputTracker.asInstanceOf[MapOutputTrackerMaster]
+  private def mapOutputTrackerMaster = sc.env.shuffleManager.mapOutputTracker.
+    asInstanceOf[MapOutputTrackerMaster]
 }

--- a/core/src/test/scala/org/apache/spark/ContextCleanerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ContextCleanerSuite.scala
@@ -19,6 +19,8 @@ package org.apache.spark
 
 import java.lang.ref.WeakReference
 
+import org.apache.spark.shuffle.MapOutputTrackerMaster
+
 import scala.collection.mutable.{HashSet, SynchronizedSet}
 import scala.language.existentials
 import scala.language.postfixOps

--- a/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
@@ -67,7 +67,7 @@ class ShuffleSuite extends FunSuite with Matchers with LocalSparkContext {
 
     // All blocks must have non-zero size
     (0 until NUM_BLOCKS).foreach { id =>
-      val statuses = SparkEnv.get.shuffleManager.getServerStatuses(shuffleId, id)
+      val statuses = SparkEnv.get.shuffleManager.mapOutputTracker.getServerStatuses(shuffleId, id)
       assert(statuses.forall(s => s._2 > 0))
     }
   }
@@ -107,7 +107,7 @@ class ShuffleSuite extends FunSuite with Matchers with LocalSparkContext {
     assert(c.count === 4)
 
     val blockSizes = (0 until NUM_BLOCKS).flatMap { id =>
-      val statuses = SparkEnv.get.shuffleManager.getServerStatuses(shuffleId, id)
+      val statuses = SparkEnv.get.shuffleManager.mapOutputTracker.getServerStatuses(shuffleId, id)
       statuses.map(x => x._2)
     }
     val nonEmptyBlocks = blockSizes.filter(x => x > 0)
@@ -132,7 +132,7 @@ class ShuffleSuite extends FunSuite with Matchers with LocalSparkContext {
     assert(c.count === 4)
 
     val blockSizes = (0 until NUM_BLOCKS).flatMap { id =>
-      val statuses = SparkEnv.get.shuffleManager.getServerStatuses(shuffleId, id)
+      val statuses = SparkEnv.get.shuffleManager.mapOutputTracker.getServerStatuses(shuffleId, id)
       statuses.map(x => x._2)
     }
     val nonEmptyBlocks = blockSizes.filter(x => x > 0)

--- a/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
@@ -67,7 +67,7 @@ class ShuffleSuite extends FunSuite with Matchers with LocalSparkContext {
 
     // All blocks must have non-zero size
     (0 until NUM_BLOCKS).foreach { id =>
-      val statuses = SparkEnv.get.mapOutputTracker.getServerStatuses(shuffleId, id)
+      val statuses = SparkEnv.get.shuffleManager.getServerStatuses(shuffleId, id)
       assert(statuses.forall(s => s._2 > 0))
     }
   }
@@ -107,7 +107,7 @@ class ShuffleSuite extends FunSuite with Matchers with LocalSparkContext {
     assert(c.count === 4)
 
     val blockSizes = (0 until NUM_BLOCKS).flatMap { id =>
-      val statuses = SparkEnv.get.mapOutputTracker.getServerStatuses(shuffleId, id)
+      val statuses = SparkEnv.get.shuffleManager.getServerStatuses(shuffleId, id)
       statuses.map(x => x._2)
     }
     val nonEmptyBlocks = blockSizes.filter(x => x > 0)
@@ -132,7 +132,7 @@ class ShuffleSuite extends FunSuite with Matchers with LocalSparkContext {
     assert(c.count === 4)
 
     val blockSizes = (0 until NUM_BLOCKS).flatMap { id =>
-      val statuses = SparkEnv.get.mapOutputTracker.getServerStatuses(shuffleId, id)
+      val statuses = SparkEnv.get.shuffleManager.getServerStatuses(shuffleId, id)
       statuses.map(x => x._2)
     }
     val nonEmptyBlocks = blockSizes.filter(x => x > 0)

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.scheduler
 
-import org.apache.spark.shuffle.MapOutputTrackerMaster
-
 import scala.Tuple2
 import scala.collection.mutable.{HashSet, HashMap, Map}
 import scala.language.reflectiveCalls
@@ -30,6 +28,7 @@ import org.scalatest.{BeforeAndAfter, FunSuiteLike}
 import org.apache.spark._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.scheduler.SchedulingMode.SchedulingMode
+import org.apache.spark.shuffle.MapOutputTrackerMaster
 import org.apache.spark.storage.{BlockId, BlockManagerId, BlockManagerMaster}
 import org.apache.spark.util.CallSite
 

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.scheduler
 
+import org.apache.spark.shuffle.MapOutputTrackerMaster
+
 import scala.Tuple2
 import scala.collection.mutable.{HashSet, HashMap, Map}
 import scala.language.reflectiveCalls

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -124,7 +124,7 @@ class DAGSchedulerSuite extends TestKit(ActorSystem("DAGSchedulerSuite")) with F
     cancelledStages.clear()
     cacheLocations.clear()
     results.clear()
-    shuffleManager = new HashShuffleManager(conf)
+    shuffleManager = sc.env.shuffleManager
     scheduler = new DAGScheduler(
         sc,
         taskScheduler,

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -30,7 +30,7 @@ import org.scalatest.{BeforeAndAfter, FunSuiteLike}
 import org.apache.spark._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.scheduler.SchedulingMode.SchedulingMode
-import org.apache.spark.shuffle.{ShuffleManager, MapOutputTrackerMaster}
+import org.apache.spark.shuffle.{MapStatus, ShuffleManager, MapOutputTrackerMaster}
 import org.apache.spark.storage.{BlockId, BlockManagerId, BlockManagerMaster}
 import org.apache.spark.util.CallSite
 
@@ -339,7 +339,7 @@ class DAGSchedulerSuite extends TestKit(ActorSystem("DAGSchedulerSuite")) with F
       sc,
       noKillTaskScheduler,
       sc.listenerBus,
-      mapOutputTracker,
+      shuffleManager,
       blockManagerMaster,
       sc.env) {
       override def runLocally(job: ActiveJob) {
@@ -374,7 +374,7 @@ class DAGSchedulerSuite extends TestKit(ActorSystem("DAGSchedulerSuite")) with F
     complete(taskSets(0), Seq(
         (Success, makeMapStatus("hostA", 1)),
         (Success, makeMapStatus("hostB", 1))))
-    assert(shuffleManager.getServerStatuses(shuffleId, 0).map(_._1) ===
+    assert(shuffleManager.mapOutputTracker.getServerStatuses(shuffleId, 0).map(_._1) ===
            Array(makeBlockManagerId("hostA"), makeBlockManagerId("hostB")))
     complete(taskSets(1), Seq((Success, 42)))
     assert(results === Map(0 -> 42))

--- a/core/src/test/scala/org/apache/spark/shuffle/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/MapOutputTrackerSuite.scala
@@ -15,18 +15,18 @@
  * limitations under the License.
  */
 
-package org.apache.spark
-
-import scala.concurrent.Await
+package org.apache.spark.shuffle
 
 import akka.actor._
 import akka.testkit.TestActorRef
-import org.scalatest.FunSuite
-
+import org.apache.spark._
 import org.apache.spark.scheduler.MapStatus
 import org.apache.spark.shuffle.FetchFailedException
 import org.apache.spark.storage.BlockManagerId
 import org.apache.spark.util.AkkaUtils
+import org.scalatest.FunSuite
+
+import scala.concurrent.Await
 
 class MapOutputTrackerSuite extends FunSuite with LocalSparkContext {
   private val conf = new SparkConf

--- a/core/src/test/scala/org/apache/spark/shuffle/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/MapOutputTrackerSuite.scala
@@ -17,16 +17,17 @@
 
 package org.apache.spark.shuffle
 
+import scala.concurrent.Await
+
 import akka.actor._
 import akka.testkit.TestActorRef
+import org.scalatest.FunSuite
+
 import org.apache.spark._
 import org.apache.spark.scheduler.MapStatus
 import org.apache.spark.shuffle.FetchFailedException
 import org.apache.spark.storage.BlockManagerId
 import org.apache.spark.util.AkkaUtils
-import org.scalatest.FunSuite
-
-import scala.concurrent.Await
 
 class MapOutputTrackerSuite extends FunSuite with LocalSparkContext {
   private val conf = new SparkConf

--- a/core/src/test/scala/org/apache/spark/shuffle/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/MapOutputTrackerSuite.scala
@@ -24,8 +24,6 @@ import akka.testkit.TestActorRef
 import org.scalatest.FunSuite
 
 import org.apache.spark._
-import org.apache.spark.scheduler.MapStatus
-import org.apache.spark.shuffle.FetchFailedException
 import org.apache.spark.storage.BlockManagerId
 import org.apache.spark.util.AkkaUtils
 

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -23,6 +23,7 @@ import java.util.Arrays
 import akka.actor._
 import org.apache.spark.SparkConf
 import org.apache.spark.serializer.{JavaSerializer, KryoSerializer}
+import org.apache.spark.shuffle.MapOutputTrackerMaster
 import org.apache.spark.util.{AkkaUtils, ByteBufferInputStream, SizeEstimator, Utils}
 import org.mockito.Mockito.{mock, when}
 import org.scalatest.{BeforeAndAfter, FunSuite, PrivateMethodTester}
@@ -31,7 +32,7 @@ import org.scalatest.concurrent.Timeouts._
 import org.scalatest.Matchers
 import org.scalatest.time.SpanSugar._
 
-import org.apache.spark.{MapOutputTrackerMaster, SecurityManager, SparkConf}
+import org.apache.spark.{SecurityManager, SparkConf}
 import org.apache.spark.scheduler.LiveListenerBus
 import org.apache.spark.serializer.{JavaSerializer, KryoSerializer}
 import org.apache.spark.util.{AkkaUtils, ByteBufferInputStream, SizeEstimator, Utils}

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -20,20 +20,21 @@ package org.apache.spark.storage
 import java.nio.{ByteBuffer, MappedByteBuffer}
 import java.util.Arrays
 
+import scala.language.{implicitConversions, postfixOps}
+
 import akka.actor._
+import org.mockito.Mockito.{mock, when}
+import org.scalatest.concurrent.Eventually._
+import org.scalatest.concurrent.Timeouts._
+import org.scalatest.Matchers
+import org.scalatest.time.SpanSugar._
+import org.scalatest.{BeforeAndAfter, FunSuite, PrivateMethodTester}
+
 import org.apache.spark.shuffle.hash.HashShuffleManager
 import org.apache.spark.{SecurityManager, SparkConf}
 import org.apache.spark.scheduler.LiveListenerBus
 import org.apache.spark.serializer.{JavaSerializer, KryoSerializer}
-import org.apache.spark.shuffle.{ShuffleManager, MapOutputTrackerMaster}
 import org.apache.spark.util.{AkkaUtils, ByteBufferInputStream, SizeEstimator, Utils}
-import org.mockito.Mockito.{mock, when}
-import org.scalatest.concurrent.Eventually._
-import org.scalatest.concurrent.Timeouts._
-import org.scalatest.time.SpanSugar._
-import org.scalatest.{BeforeAndAfter, FunSuite, PrivateMethodTester}
-
-import scala.language.{implicitConversions, postfixOps}
 
 class BlockManagerSuite extends FunSuite with Matchers with BeforeAndAfter
   with PrivateMethodTester {

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -20,25 +20,19 @@ package org.apache.spark.storage
 import java.nio.{ByteBuffer, MappedByteBuffer}
 import java.util.Arrays
 
-import scala.language.implicitConversions
-import scala.language.postfixOps
-
 import akka.actor._
-import org.mockito.Mockito.{mock, when}
-import org.scalatest.{BeforeAndAfter, FunSuite, PrivateMethodTester}
-import org.scalatest.concurrent.Eventually._
-import org.scalatest.concurrent.Timeouts._
-import org.scalatest.Matchers
-import org.scalatest.time.SpanSugar._
-
 import org.apache.spark.{SecurityManager, SparkConf}
 import org.apache.spark.scheduler.LiveListenerBus
 import org.apache.spark.serializer.{JavaSerializer, KryoSerializer}
-import org.apache.spark.util.{AkkaUtils, ByteBufferInputStream, SizeEstimator, Utils}
-import org.apache.spark.SparkConf
-import org.apache.spark.serializer.{JavaSerializer, KryoSerializer}
 import org.apache.spark.shuffle.MapOutputTrackerMaster
 import org.apache.spark.util.{AkkaUtils, ByteBufferInputStream, SizeEstimator, Utils}
+import org.mockito.Mockito.{mock, when}
+import org.scalatest.concurrent.Eventually._
+import org.scalatest.concurrent.Timeouts._
+import org.scalatest.time.SpanSugar._
+import org.scalatest.{BeforeAndAfter, FunSuite, PrivateMethodTester}
+
+import scala.language.{implicitConversions, postfixOps}
 
 class BlockManagerSuite extends FunSuite with Matchers with BeforeAndAfter
   with PrivateMethodTester {

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -20,11 +20,10 @@ package org.apache.spark.storage
 import java.nio.{ByteBuffer, MappedByteBuffer}
 import java.util.Arrays
 
+import scala.language.implicitConversions
+import scala.language.postfixOps
+
 import akka.actor._
-import org.apache.spark.SparkConf
-import org.apache.spark.serializer.{JavaSerializer, KryoSerializer}
-import org.apache.spark.shuffle.MapOutputTrackerMaster
-import org.apache.spark.util.{AkkaUtils, ByteBufferInputStream, SizeEstimator, Utils}
 import org.mockito.Mockito.{mock, when}
 import org.scalatest.{BeforeAndAfter, FunSuite, PrivateMethodTester}
 import org.scalatest.concurrent.Eventually._
@@ -36,9 +35,10 @@ import org.apache.spark.{SecurityManager, SparkConf}
 import org.apache.spark.scheduler.LiveListenerBus
 import org.apache.spark.serializer.{JavaSerializer, KryoSerializer}
 import org.apache.spark.util.{AkkaUtils, ByteBufferInputStream, SizeEstimator, Utils}
-
-import scala.language.implicitConversions
-import scala.language.postfixOps
+import org.apache.spark.SparkConf
+import org.apache.spark.serializer.{JavaSerializer, KryoSerializer}
+import org.apache.spark.shuffle.MapOutputTrackerMaster
+import org.apache.spark.util.{AkkaUtils, ByteBufferInputStream, SizeEstimator, Utils}
 
 class BlockManagerSuite extends FunSuite with Matchers with BeforeAndAfter
   with PrivateMethodTester {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -238,6 +238,32 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+  <td><code>spark.shuffle.manager</code></td>
+  <td>org.apache.spark.shuffle.hash.HashShuffleManager</td>
+  <td>
+    Specify the ShuffleManager class in SparkEnv. The default HashShuffleManager uses hashing and creates 
+    one output file per reduce partition on each mapper.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.shuffle.mapOutputTrackerMasterClass</code></td>
+  <td>org.apache.spark.shuffle.MapOutputTrackerMaster</td>
+  <td>
+    Specify the MapOutputTrackerMaster initialized in ShuffleManager. The default MapOutputTrackerMaster runs on the 
+    driver and uses TimeStampedHashMap to keep track of map output information (includes the block manager address that 
+    the task ran on as well as the sizes of outputs for each reducer), which allows old output information based on 
+    a TTL.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.shuffle.mapOutputTrackerWorkerClass</code></td>
+  <td>org.apache.spark.shuffle.MapOutputTrackerWorker</td>
+  <td>
+    Specify the MapOutputTrackerWorker initialized in ShuffleManager. The default MapOutputTrackerWorker runs on workers
+     and fetches map output information from the driver's MapOutputTrackerMaster.
+  </td>
+</tr>
+<tr>
   <td><code>spark.shuffle.compress</code></td>
   <td>true</td>
   <td>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-2126

Move MapOutputTracker behind ShuffleManager interface to enable customized MapOutputTracker implementation
