### PR TITLE
[SPARK-1394] Remove SIGCHLD handler in worker subprocess

### DIFF
--- a/python/pyspark/daemon.py
+++ b/python/pyspark/daemon.py
@@ -103,6 +103,7 @@ def worker(listen_sock):
             if os.fork() == 0:
                 # Leave the worker pool
                 signal.signal(SIGHUP, SIG_DFL)
+                signal.signal(SIGCHLD, SIG_DFL)
                 listen_sock.close()
                 # Read the socket using fdopen instead of socket.makefile() because the latter
                 # seems to be very slow; note that we need to dup() the file descriptor because


### PR DESCRIPTION
It should not be the responsibility of the worker subprocess, which
does not intentionally fork, to try and cleanup child processes. Doing
so is complex and interferes with operations such as
platform.system().

If it is desirable to have tighter control over subprocesses, then
namespaces should be used and it should be the manager's resposibility
to handle cleanup.
