### PR TITLE
[SPARK-2308][MLLIB] Add Mini-Batch KMeans Clustering method

### DIFF
--- a/docs/mllib-clustering.md
+++ b/docs/mllib-clustering.md
@@ -21,8 +21,11 @@ MLlib supports
 the most commonly used clustering algorithms that clusters the data points into
 predefined number of clusters. The MLlib implementation includes a parallelized
 variant of the [k-means++](http://en.wikipedia.org/wiki/K-means%2B%2B) method
-called [kmeans||](http://theory.stanford.edu/~sergei/papers/vldb12-kmpar.pdf).
-The implementation in MLlib has the following parameters:  
+called [kmeans||](http://theory.stanford.edu/~sergei/papers/vldb12-kmpar.pdf)
+as well as a higher-performance [mini-batch](http://dl.acm.org/citation.cfm?id=1772862)
+version that uses a randomly-sampled subset of the data points in each iteration
+instead of the full set of data points. The implementation in MLlib has the
+following parameters:  
 
 * *k* is the number of desired clusters.
 * *maxIterations* is the maximum number of iterations to run.
@@ -33,6 +36,10 @@ guaranteed to find a globally optimal solution, and when run multiple times on
 a given dataset, the algorithm returns the best clustering result).
 * *initializationSteps* determines the number of steps in the k-means\|\| algorithm.
 * *epsilon* determines the distance threshold within which we consider k-means to have converged. 
+
+The mini-batch version takes an additional paramater:
+
+* *batchSize* is the number of points to randomly sample in each iteration.
 
 ## Examples
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeans.scala
@@ -138,9 +138,7 @@ class KMeans private (
     val initStartTime = System.nanoTime()
 
     val centers = if (initializationMode == KMeans.RANDOM) {
-      val flatCenters = initRandom(data, k * runs)
-      
-      Array.tabulate(runs)(r => flatCenters.slice(r * k, (r + 1) * k).toArray)
+      Array.tabulate(runs)(r => initRandom(data, k))
     } else {
       Array.tabulate(runs)(r => initParallel(data, k, initializationSteps))
     }

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeans.scala
@@ -305,7 +305,7 @@ class KMeans private (
 /**
  * Top-level methods for calling K-means clustering.
  */
-object KMeans {
+object KMeans extends KMeansObjectCommons {
 
   // Initialization mode names
   val RANDOM = "random"
@@ -353,66 +353,4 @@ object KMeans {
       runs: Int): KMeansModel = {
     train(data, k, maxIterations, runs, K_MEANS_PARALLEL)
   }
-
-  /**
-   * Returns the index of the closest center to the given point, as well as the squared distance.
-   */
-  private[mllib] def findClosest(
-      centers: TraversableOnce[BreezeVectorWithNorm],
-      point: BreezeVectorWithNorm): (Int, Double) = {
-    var bestDistance = Double.PositiveInfinity
-    var bestIndex = 0
-    var i = 0
-    centers.foreach { center =>
-      // Since `\|a - b\| \geq |\|a\| - \|b\||`, we can use this lower bound to avoid unnecessary
-      // distance computation.
-      var lowerBoundOfSqDist = center.norm - point.norm
-      lowerBoundOfSqDist = lowerBoundOfSqDist * lowerBoundOfSqDist
-      if (lowerBoundOfSqDist < bestDistance) {
-        val distance: Double = fastSquaredDistance(center, point)
-        if (distance < bestDistance) {
-          bestDistance = distance
-          bestIndex = i
-        }
-      }
-      i += 1
-    }
-    (bestIndex, bestDistance)
-  }
-
-  /**
-   * Returns the K-means cost of a given point against the given cluster centers.
-   */
-  private[mllib] def pointCost(
-      centers: TraversableOnce[BreezeVectorWithNorm],
-      point: BreezeVectorWithNorm): Double =
-    findClosest(centers, point)._2
-
-  /**
-   * Returns the squared Euclidean distance between two vectors computed by
-   * [[org.apache.spark.mllib.util.MLUtils#fastSquaredDistance]].
-   */
-  private[clustering] def fastSquaredDistance(
-      v1: BreezeVectorWithNorm,
-      v2: BreezeVectorWithNorm): Double = {
-    MLUtils.fastSquaredDistance(v1.vector, v1.norm, v2.vector, v2.norm)
-  }
-}
-
-/**
- * A breeze vector with its norm for fast distance computation.
- *
- * @see [[org.apache.spark.mllib.clustering.KMeans#fastSquaredDistance]]
- */
-private[clustering]
-class BreezeVectorWithNorm(val vector: BV[Double], val norm: Double) extends Serializable {
-
-  def this(vector: BV[Double]) = this(vector, breezeNorm(vector, 2.0))
-
-  def this(array: Array[Double]) = this(new BDV[Double](array))
-
-  def this(v: Vector) = this(v.toBreeze)
-
-  /** Converts the vector to a dense vector. */
-  def toDense = new BreezeVectorWithNorm(vector.toDenseVector, norm)
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeansCommons.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeansCommons.scala
@@ -12,7 +12,7 @@ import org.apache.spark.util.random.XORShiftRandom
 
 trait KMeansCommons {
     /**
-   * Initialize `runs` sets of cluster centers at random.
+   * Initialize cluster centers for one run at random.
    */
   protected def initRandom(data: RDD[BreezeVectorWithNorm], k: Int)
   : Array[BreezeVectorWithNorm] = {
@@ -24,7 +24,7 @@ trait KMeansCommons {
   }
 
   /**
-   * Initialize `runs` sets of cluster centers using the k-means|| algorithm by Bahmani et al.
+   * Initialize cluster centers for one run using the k-means|| algorithm by Bahmani et al.
    * (Bahmani et al., Scalable K-Means++, VLDB 2012). This is a variant of k-means++ that tries
    * to find with dissimilar cluster centers by starting with a random center and then doing
    * passes where more centers are chosen with probability proportional to their squared distance

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeansCommons.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeansCommons.scala
@@ -32,7 +32,7 @@ trait KMeansCommons {
    *
    * The original paper can be found at http://theory.stanford.edu/~sergei/papers/vldb12-kmpar.pdf.
    */
-  protected def initKMeansMiniBatchParallel(data: RDD[BreezeVectorWithNorm],
+  protected def initParallel(data: RDD[BreezeVectorWithNorm],
       k: Int,
       initializationSteps: Int)
   : Array[BreezeVectorWithNorm] = {

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeansCommons.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeansCommons.scala
@@ -1,0 +1,72 @@
+package org.apache.spark.mllib.clustering
+
+import breeze.linalg.{DenseVector => BDV, Vector => BV, norm => breezeNorm}
+
+import org.apache.spark.mllib.linalg.Vector
+import org.apache.spark.mllib.util.MLUtils
+
+trait KMeansObjectCommons {
+  
+    /**
+   * Returns the index of the closest center to the given point, as well as the squared distance.
+   */
+  private[mllib] def findClosest(
+      centers: TraversableOnce[BreezeVectorWithNorm],
+      point: BreezeVectorWithNorm): (Int, Double) = {
+    var bestDistance = Double.PositiveInfinity
+    var bestIndex = 0
+    var i = 0
+    centers.foreach { center =>
+      // Since `\|a - b\| \geq |\|a\| - \|b\||`, we can use this lower bound to avoid unnecessary
+      // distance computation.
+      var lowerBoundOfSqDist = center.norm - point.norm
+      lowerBoundOfSqDist = lowerBoundOfSqDist * lowerBoundOfSqDist
+      if (lowerBoundOfSqDist < bestDistance) {
+        val distance: Double = fastSquaredDistance(center, point)
+        if (distance < bestDistance) {
+          bestDistance = distance
+          bestIndex = i
+        }
+      }
+      i += 1
+    }
+    (bestIndex, bestDistance)
+  }
+
+  /**
+   * Returns the K-means cost of a given point against the given cluster centers.
+   */
+  private[mllib] def pointCost(
+      centers: TraversableOnce[BreezeVectorWithNorm],
+      point: BreezeVectorWithNorm): Double =
+    findClosest(centers, point)._2
+
+  /**
+   * Returns the squared Euclidean distance between two vectors computed by
+   * [[org.apache.spark.mllib.util.MLUtils#fastSquaredDistance]].
+   */
+  private[clustering] def fastSquaredDistance(
+      v1: BreezeVectorWithNorm,
+      v2: BreezeVectorWithNorm): Double = {
+    MLUtils.fastSquaredDistance(v1.vector, v1.norm, v2.vector, v2.norm)
+  }
+  
+}
+
+/**
+ * A breeze vector with its norm for fast distance computation.
+ *
+ * @see [[org.apache.spark.mllib.clustering.KMeans#fastSquaredDistance]]
+ */
+private[clustering]
+class BreezeVectorWithNorm(val vector: BV[Double], val norm: Double) extends Serializable {
+
+  def this(vector: BV[Double]) = this(vector, breezeNorm(vector, 2.0))
+
+  def this(array: Array[Double]) = this(new BDV[Double](array))
+
+  def this(v: Vector) = this(v.toBreeze)
+
+  /** Converts the vector to a dense vector. */
+  def toDense = new BreezeVectorWithNorm(vector.toDenseVector, norm)
+}

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeansCommons.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeansCommons.scala
@@ -1,9 +1,81 @@
 package org.apache.spark.mllib.clustering
 
+import scala.collection.mutable.ArrayBuffer
+
 import breeze.linalg.{DenseVector => BDV, Vector => BV, norm => breezeNorm}
 
+import org.apache.spark.SparkContext._
 import org.apache.spark.mllib.linalg.Vector
 import org.apache.spark.mllib.util.MLUtils
+import org.apache.spark.rdd.RDD
+import org.apache.spark.util.random.XORShiftRandom
+
+trait KMeansCommons {
+    /**
+   * Initialize `runs` sets of cluster centers at random.
+   */
+  protected def initRandom(data: RDD[BreezeVectorWithNorm], k: Int)
+  : Array[BreezeVectorWithNorm] = {
+    // Sample all the cluster centers in one pass to avoid repeated scans
+    val sample = data.takeSample(true, k, new XORShiftRandom().nextInt()).toSeq
+    sample.map { v =>
+      new BreezeVectorWithNorm(v.vector.toDenseVector, v.norm)
+    }.toArray
+  }
+
+  /**
+   * Initialize `runs` sets of cluster centers using the k-means|| algorithm by Bahmani et al.
+   * (Bahmani et al., Scalable K-Means++, VLDB 2012). This is a variant of k-means++ that tries
+   * to find with dissimilar cluster centers by starting with a random center and then doing
+   * passes where more centers are chosen with probability proportional to their squared distance
+   * to the current cluster set. It results in a provable approximation to an optimal clustering.
+   *
+   * The original paper can be found at http://theory.stanford.edu/~sergei/papers/vldb12-kmpar.pdf.
+   */
+  protected def initKMeansMiniBatchParallel(data: RDD[BreezeVectorWithNorm],
+      k: Int,
+      initializationSteps: Int)
+  : Array[BreezeVectorWithNorm] = {
+    // Initialize each run's center to a random point
+    val seed = new XORShiftRandom().nextInt()
+    val sample = data.takeSample(true, 1, seed).toSeq
+    val centers = ArrayBuffer() ++ sample
+
+    // On each step, sample 2 * k points on average for each run with probability proportional
+    // to their squared distance from that run's current centers
+    var step = 0
+    while (step < initializationSteps) {
+      val sumCosts = data.map { point =>
+      		KMeansMiniBatch.pointCost(centers, point)
+      }.reduce(_ + _)
+      val chosen = data.mapPartitionsWithIndex { (index, points) =>
+        val rand = new XORShiftRandom(seed ^ (step << 16) ^ index)
+        
+        // accept / reject each point
+        val sampledCenters = points.filter { p =>
+          rand.nextDouble() < 2.0 * KMeansMiniBatch.pointCost(centers, p) * k / sumCosts
+        }
+        
+        sampledCenters
+      }.collect()
+      
+      
+      centers ++= chosen
+      step += 1
+    }
+    
+    // Finally, we might have a set of more than k candidate centers for each run; weigh each
+    // candidate by the number of points in the dataset mapping to it and run a local k-means++
+    // on the weighted centers to pick just k of them
+    val weightMap = data.map { p =>
+        (KMeansMiniBatch.findClosest(centers, p)._1, 1.0)
+      }.reduceByKey(_ + _).collectAsMap()
+    val weights = (0 until centers.length).map(i => weightMap.getOrElse(i, 0.0)).toArray
+    val finalCenters = LocalKMeans.kMeansPlusPlus(seed, centers.toArray, weights, k, 30)
+
+    finalCenters.toArray
+  }
+}
 
 trait KMeansObjectCommons {
   

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeansMiniBatch.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeansMiniBatch.scala
@@ -336,6 +336,18 @@ object KMeansMiniBatch {
       runs: Int): KMeansModel = {
     train(data, k, 1000, maxIterations, runs, K_MEANS_PARALLEL)
   }
+  
+    /**
+   * Trains a k-means model using specified parameters and the default values for unspecified.
+   */
+  def train(
+      data: RDD[Vector],
+      k: Int,
+      maxIterations: Int,
+      runs: Int,
+      initializationMode: String): KMeansModel = {
+    train(data, k, 1000, maxIterations, runs, initializationMode)
+  }
 
   /**
    * Returns the index of the closest center to the given point, as well as the squared distance.

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeansMiniBatch.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeansMiniBatch.scala
@@ -152,7 +152,7 @@ class KMeansMiniBatch private (
     val centers = if (initializationMode == KMeansMiniBatch.RANDOM) {
       initRandom(data, k)
     } else {
-      initKMeansMiniBatchParallel(data, k, initializationSteps)
+      initParallel(data, k, initializationSteps)
     }
 
     val initTimeInSeconds = (System.nanoTime() - initStartTime) / 1e9

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeansMiniBatch.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeansMiniBatch.scala
@@ -1,0 +1,383 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.mllib.clustering
+
+import scala.collection.mutable.ArrayBuffer
+
+import breeze.linalg.{DenseVector => BDV, Vector => BV, norm => breezeNorm}
+
+import org.apache.spark.annotation.Experimental
+import org.apache.spark.Logging
+import org.apache.spark.SparkContext._
+import org.apache.spark.mllib.linalg.{Vector, Vectors}
+import org.apache.spark.mllib.util.MLUtils
+import org.apache.spark.rdd.RDD
+import org.apache.spark.util.random.XORShiftRandom
+
+/**
+ * K-means clustering with support for multiple parallel runs and a k-means++ like initialization
+ * mode (the k-means|| algorithm by Bahmani et al). When multiple concurrent runs are requested,
+ * they are executed together with joint passes over the data for efficiency.
+ *
+ * This is an iterative algorithm that will make multiple passes over the data, so any RDDs given
+ * to it should be cached by the user.
+ */
+class KMeansMiniBatch private (
+    private var k: Int,
+    private var maxIterations: Int,
+    private var batchSize: Int,
+    private var runs: Int,
+    private var initializationMode: String,
+    private var initializationSteps: Int,
+    private var epsilon: Double) extends Serializable with Logging {
+
+  /**
+   * Constructs a KMeans instance with default parameters: {k: 2, maxIterations: 20, runs: 1,
+   * batchSize: 1000, initializationMode: "k-means||", initializationSteps: 5, epsilon: 1e-4}.
+   */
+  def this() = this(2, 20, 1, 1000, KMeansMiniBatch.K_MEANS_PARALLEL, 5, 1e-4)
+
+  def setBatchSize(batchSize: Int): KMeansMiniBatch = {
+    this.batchSize = batchSize
+    this
+  }
+  
+  /** Set the number of clusters to create (k). Default: 2. */
+  def setK(k: Int): KMeansMiniBatch = {
+    this.k = k
+    this
+  }
+
+  /** Set maximum number of iterations to run. Default: 20. */
+  def setMaxIterations(maxIterations: Int): KMeansMiniBatch = {
+    this.maxIterations = maxIterations
+    this
+  }
+
+  /**
+   * Set the initialization algorithm. This can be either "random" to choose random points as
+   * initial cluster centers, or "k-means||" to use a parallel variant of k-means++
+   * (Bahmani et al., Scalable K-Means++, VLDB 2012). Default: k-means||.
+   */
+  def setInitializationMode(initializationMode: String): KMeansMiniBatch = {
+    if (initializationMode != KMeansMiniBatch.RANDOM && initializationMode != KMeansMiniBatch.K_MEANS_PARALLEL) {
+      throw new IllegalArgumentException("Invalid initialization mode: " + initializationMode)
+    }
+    this.initializationMode = initializationMode
+    this
+  }
+
+  /**
+   * :: Experimental ::
+   * Set the number of runs of the algorithm to execute in parallel. We initialize the algorithm
+   * this many times with random starting conditions (configured by the initialization mode), then
+   * return the best clustering found over any run. Default: 1.
+   */
+  @Experimental
+  def setRuns(runs: Int): KMeansMiniBatch = {
+    if (runs <= 0) {
+      throw new IllegalArgumentException("Number of runs must be positive")
+    }
+    this.runs = runs
+    this
+  }
+
+  /**
+   * Set the number of steps for the k-means|| initialization mode. This is an advanced
+   * setting -- the default of 5 is almost always enough. Default: 5.
+   */
+  def setInitializationSteps(initializationSteps: Int): KMeansMiniBatch = {
+    if (initializationSteps <= 0) {
+      throw new IllegalArgumentException("Number of initialization steps must be positive")
+    }
+    this.initializationSteps = initializationSteps
+    this
+  }
+
+  /**
+   * Set the distance threshold within which we've consider centers to have converged.
+   * If all centers move less than this Euclidean distance, we stop iterating one run.
+   */
+  def setEpsilon(epsilon: Double): KMeansMiniBatch = {
+    this.epsilon = epsilon
+    this
+  }
+
+  /**
+   * Train a K-means model on the given set of points; `data` should be cached for high
+   * performance, because this is an iterative algorithm.
+   */
+  def run(data: RDD[Vector]): KMeansModel = {
+    // Compute squared norms and cache them.
+    val norms = data.map(v => breezeNorm(v.toBreeze, 2.0))
+    norms.persist()
+    val breezeData = data.map(_.toBreeze).zip(norms).map { case (v, norm) =>
+      new BreezeVectorWithNorm(v, norm)
+    }
+    
+    val runModels = (0 until runs).map { _ =>
+      runBreeze(breezeData)
+    }
+    
+    val bestModel = runModels.minBy(t => t._2)._1
+    
+    norms.unpersist()
+    bestModel
+  }
+
+  /**
+   * Implementation of K-Means using breeze.
+   */
+  private def runBreeze(data: RDD[BreezeVectorWithNorm]): (KMeansModel, Double) = {
+
+    val sc = data.sparkContext
+
+    val initStartTime = System.nanoTime()
+
+    val centers = if (initializationMode == KMeansMiniBatch.RANDOM) {
+      initRandom(data)
+    } else {
+      initKMeansMiniBatchParallel(data)
+    }
+
+    val initTimeInSeconds = (System.nanoTime() - initStartTime) / 1e9
+    logInfo(s"Initialization with $initializationMode took " + "%.3f".format(initTimeInSeconds) +
+      " seconds.")
+
+    var costs = 0.0
+    var iteration = 0
+    val iterationStartTime = System.nanoTime()
+
+    // Execute iterations of Lloyd's algorithm until all runs have converged
+    while (iteration < maxIterations) {
+      type WeightedPoint = (BV[Double], Long)
+      def mergeContribs(p1: WeightedPoint, p2: WeightedPoint): WeightedPoint = {
+        (p1._1 += p2._1, p1._2 + p2._2)
+      }
+
+      val costAccums = sc.accumulator(0.0)
+
+      // Find the sum and count of points mapping to each center
+      val totalContribs = data.mapPartitions { points =>
+        val k = centers.length
+        val dims = centers(0).vector.length
+
+        val sums = Array.fill(k)(BDV.zeros[Double](dims).asInstanceOf[BV[Double]])
+        val counts = Array.fill(k)(0L)
+
+        points.foreach { point =>
+          val (bestCenter, cost) = KMeansMiniBatch.findClosest(centers, point)
+          costAccums += cost
+          sums(bestCenter) += point.vector
+          counts(bestCenter) += 1
+        }
+
+        val contribs = for (j <- 0 until k) yield {
+          (j, (sums(j), counts(j)))
+        }
+        contribs.iterator
+      }.reduceByKey(mergeContribs).collectAsMap()
+
+      // Update the cluster centers and costs
+	  var j = 0
+	  while (j < k) {
+	    val (sum, count) = totalContribs(j)
+	    if (count != 0) {
+	      sum /= count.toDouble
+	      val newCenter = new BreezeVectorWithNorm(sum)
+	      centers(j) = newCenter
+	    }
+	    j += 1
+  	  }
+        
+      costs = costAccums.value
+      iteration += 1
+    }
+
+    val iterationTimeInSeconds = (System.nanoTime() - iterationStartTime) / 1e9
+    logInfo(s"Iterations took " + "%.3f".format(iterationTimeInSeconds) + " seconds.")
+ 
+    logInfo(s"The cost for the run is $costs.")
+
+    new Tuple2(new KMeansModel(centers.map(c => Vectors.fromBreeze(c.vector))), costs)
+  }
+
+  /**
+   * Initialize `runs` sets of cluster centers at random.
+   */
+  private def initRandom(data: RDD[BreezeVectorWithNorm])
+  : Array[BreezeVectorWithNorm] = {
+    // Sample all the cluster centers in one pass to avoid repeated scans
+    val sample = data.takeSample(true, k, new XORShiftRandom().nextInt()).toSeq
+    sample.map { v =>
+      new BreezeVectorWithNorm(v.vector.toDenseVector, v.norm)
+    }.toArray
+  }
+
+  /**
+   * Initialize `runs` sets of cluster centers using the k-means|| algorithm by Bahmani et al.
+   * (Bahmani et al., Scalable K-Means++, VLDB 2012). This is a variant of k-means++ that tries
+   * to find with dissimilar cluster centers by starting with a random center and then doing
+   * passes where more centers are chosen with probability proportional to their squared distance
+   * to the current cluster set. It results in a provable approximation to an optimal clustering.
+   *
+   * The original paper can be found at http://theory.stanford.edu/~sergei/papers/vldb12-kmpar.pdf.
+   */
+  private def initKMeansMiniBatchParallel(data: RDD[BreezeVectorWithNorm])
+  : Array[BreezeVectorWithNorm] = {
+    // Initialize each run's center to a random point
+    val seed = new XORShiftRandom().nextInt()
+    val sample = data.takeSample(true, 1, seed).toSeq
+    val centers = ArrayBuffer() ++ sample
+
+    // On each step, sample 2 * k points on average for each run with probability proportional
+    // to their squared distance from that run's current centers
+    var step = 0
+    while (step < initializationSteps) {
+      val sumCosts = data.map { point =>
+      		KMeansMiniBatch.pointCost(centers, point)
+      }.reduce(_ + _)
+      val chosen = data.mapPartitionsWithIndex { (index, points) =>
+        val rand = new XORShiftRandom(seed ^ (step << 16) ^ index)
+        
+        // accept / reject each point
+        val sampledCenters = points.filter { p =>
+          rand.nextDouble() < 2.0 * KMeansMiniBatch.pointCost(centers, p) * k / sumCosts
+        }
+        
+        sampledCenters
+      }.collect()
+      
+      
+      centers ++= chosen
+      step += 1
+    }
+    
+    // Finally, we might have a set of more than k candidate centers for each run; weigh each
+    // candidate by the number of points in the dataset mapping to it and run a local k-means++
+    // on the weighted centers to pick just k of them
+    val weightMap = data.map { p =>
+        (KMeansMiniBatch.findClosest(centers, p)._1, 1.0)
+      }.reduceByKey(_ + _).collectAsMap()
+    val weights = (0 until centers.length).map(i => weightMap.getOrElse(i, 0.0)).toArray
+    val finalCenters = LocalKMeans.kMeansPlusPlus(seed, centers.toArray, weights, k, 30)
+
+    finalCenters.toArray
+  }
+}
+
+
+/**
+ * Top-level methods for calling K-means clustering.
+ */
+object KMeansMiniBatch {
+
+  // Initialization mode names
+  val RANDOM = "random"
+  val K_MEANS_PARALLEL = "k-means||"
+
+  /**
+   * Trains a k-means model using the given set of parameters.
+   *
+   * @param data training points stored as `RDD[Array[Double]]`
+   * @param k number of clusters
+   * @param batchSize number of points in each batch
+   * @param maxIterations max number of iterations
+   * @param runs number of parallel runs, defaults to 1. The best model is returned.
+   * @param initializationMode initialization model, either "random" or "k-means||" (default).
+   */
+  def train(
+      data: RDD[Vector],
+      k: Int,
+      batchSize: Int,
+      maxIterations: Int,
+      runs: Int,
+      initializationMode: String): KMeansModel = {
+    new KMeansMiniBatch().setK(k)
+      .setBatchSize(batchSize)
+      .setMaxIterations(maxIterations)
+      .setRuns(runs)
+      .setInitializationMode(initializationMode)
+      .run(data)
+  }
+
+  /**
+   * Trains a k-means model using specified parameters and the default values for unspecified.
+   */
+  def train(
+      data: RDD[Vector],
+      k: Int,
+      maxIterations: Int): KMeansModel = {
+    train(data, k, 1000, maxIterations, 1, K_MEANS_PARALLEL)
+  }
+
+  /**
+   * Trains a k-means model using specified parameters and the default values for unspecified.
+   */
+  def train(
+      data: RDD[Vector],
+      k: Int,
+      maxIterations: Int,
+      runs: Int): KMeansModel = {
+    train(data, k, 1000, maxIterations, runs, K_MEANS_PARALLEL)
+  }
+
+  /**
+   * Returns the index of the closest center to the given point, as well as the squared distance.
+   */
+  private[mllib] def findClosest(
+      centers: TraversableOnce[BreezeVectorWithNorm],
+      point: BreezeVectorWithNorm): (Int, Double) = {
+    var bestDistance = Double.PositiveInfinity
+    var bestIndex = 0
+    var i = 0
+    centers.foreach { center =>
+      // Since `\|a - b\| \geq |\|a\| - \|b\||`, we can use this lower bound to avoid unnecessary
+      // distance computation.
+      var lowerBoundOfSqDist = center.norm - point.norm
+      lowerBoundOfSqDist = lowerBoundOfSqDist * lowerBoundOfSqDist
+      if (lowerBoundOfSqDist < bestDistance) {
+        val distance: Double = fastSquaredDistance(center, point)
+        if (distance < bestDistance) {
+          bestDistance = distance
+          bestIndex = i
+        }
+      }
+      i += 1
+    }
+    (bestIndex, bestDistance)
+  }
+
+  /**
+   * Returns the K-means cost of a given point against the given cluster centers.
+   */
+  private[mllib] def pointCost(
+      centers: TraversableOnce[BreezeVectorWithNorm],
+      point: BreezeVectorWithNorm): Double =
+    findClosest(centers, point)._2
+
+  /**
+   * Returns the squared Euclidean distance between two vectors computed by
+   * [[org.apache.spark.mllib.util.MLUtils#fastSquaredDistance]].
+   */
+  private[clustering] def fastSquaredDistance(
+      v1: BreezeVectorWithNorm,
+      v2: BreezeVectorWithNorm): Double = {
+    MLUtils.fastSquaredDistance(v1.vector, v1.norm, v2.vector, v2.norm)
+  }
+}

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeansMiniBatch.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeansMiniBatch.scala
@@ -285,7 +285,7 @@ class KMeansMiniBatch private (
 /**
  * Top-level methods for calling K-means clustering.
  */
-object KMeansMiniBatch {
+object KMeansMiniBatch extends KMeansObjectCommons {
 
   // Initialization mode names
   val RANDOM = "random"
@@ -347,49 +347,5 @@ object KMeansMiniBatch {
       runs: Int,
       initializationMode: String): KMeansModel = {
     train(data, k, 1000, maxIterations, runs, initializationMode)
-  }
-
-  /**
-   * Returns the index of the closest center to the given point, as well as the squared distance.
-   */
-  private[mllib] def findClosest(
-      centers: TraversableOnce[BreezeVectorWithNorm],
-      point: BreezeVectorWithNorm): (Int, Double) = {
-    var bestDistance = Double.PositiveInfinity
-    var bestIndex = 0
-    var i = 0
-    centers.foreach { center =>
-      // Since `\|a - b\| \geq |\|a\| - \|b\||`, we can use this lower bound to avoid unnecessary
-      // distance computation.
-      var lowerBoundOfSqDist = center.norm - point.norm
-      lowerBoundOfSqDist = lowerBoundOfSqDist * lowerBoundOfSqDist
-      if (lowerBoundOfSqDist < bestDistance) {
-        val distance: Double = fastSquaredDistance(center, point)
-        if (distance < bestDistance) {
-          bestDistance = distance
-          bestIndex = i
-        }
-      }
-      i += 1
-    }
-    (bestIndex, bestDistance)
-  }
-
-  /**
-   * Returns the K-means cost of a given point against the given cluster centers.
-   */
-  private[mllib] def pointCost(
-      centers: TraversableOnce[BreezeVectorWithNorm],
-      point: BreezeVectorWithNorm): Double =
-    findClosest(centers, point)._2
-
-  /**
-   * Returns the squared Euclidean distance between two vectors computed by
-   * [[org.apache.spark.mllib.util.MLUtils#fastSquaredDistance]].
-   */
-  private[clustering] def fastSquaredDistance(
-      v1: BreezeVectorWithNorm,
-      v2: BreezeVectorWithNorm): Double = {
-    MLUtils.fastSquaredDistance(v1.vector, v1.norm, v2.vector, v2.norm)
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeansMiniBatch.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeansMiniBatch.scala
@@ -30,10 +30,10 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.util.random.XORShiftRandom
 
 /**
- * K-means clustering with support for multiple parallel runs and a k-means++ like initialization
- * mode (the k-means|| algorithm by Bahmani et al). When multiple concurrent runs are requested,
- * they are executed together with joint passes over the data for efficiency.
- *
+ * K-means clustering with support for multiple parallel runs, a k-means++ like initialization
+ * mode (the k-means|| algorithm by Bahmani et al), and randomly-sampled mini-batches of points
+ * in each iteration instead of all points for speed (Web-Scale K-Means Clustering by Sculley).
+ * 
  * This is an iterative algorithm that will make multiple passes over the data, so any RDDs given
  * to it should be cached by the user.
  */

--- a/mllib/src/test/scala/org/apache/spark/mllib/clustering/KMeansMiniBatchSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/clustering/KMeansMiniBatchSuite.scala
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.mllib.clustering
+
+import org.scalatest.FunSuite
+
+import org.apache.spark.mllib.util.LocalSparkContext
+import org.apache.spark.mllib.linalg.Vectors
+
+class KMeansMiniBatchSuite extends FunSuite with LocalSparkContext {
+
+  import KMeans.{RANDOM, K_MEANS_PARALLEL}
+
+  test("single cluster") {
+    val data = sc.parallelize(Array(
+      Vectors.dense(1.0, 2.0, 6.0),
+      Vectors.dense(1.0, 3.0, 0.0),
+      Vectors.dense(1.0, 4.0, 6.0)
+    ))
+
+    val center = Vectors.dense(1.0, 3.0, 4.0)
+
+    // No matter how many runs or iterations we use, we should get one cluster,
+    // centered at the mean of the points
+
+    var model = KMeansMiniBatch.train(data, k=1, maxIterations=1)
+    assert(model.clusterCenters.head === center)
+
+    model = KMeansMiniBatch.train(data, k=1, maxIterations=2)
+    assert(model.clusterCenters.head === center)
+
+    model = KMeansMiniBatch.train(data, k=1, maxIterations=5)
+    assert(model.clusterCenters.head === center)
+
+    model = KMeansMiniBatch.train(data, k=1, maxIterations=1, runs=5)
+    assert(model.clusterCenters.head === center)
+
+    model = KMeansMiniBatch.train(data, k=1, maxIterations=1, runs=5)
+    assert(model.clusterCenters.head === center)
+
+    model = KMeansMiniBatch.train(data, k=1, maxIterations=1, runs=1, initializationMode=RANDOM)
+    assert(model.clusterCenters.head === center)
+
+    model = KMeansMiniBatch.train(
+      data, k=1, maxIterations=1, runs=1, initializationMode=K_MEANS_PARALLEL)
+    assert(model.clusterCenters.head === center)
+  }
+
+  test("single cluster with big dataset") {
+    val smallData = Array(
+      Vectors.dense(1.0, 2.0, 6.0),
+      Vectors.dense(1.0, 3.0, 0.0),
+      Vectors.dense(1.0, 4.0, 6.0)
+    )
+    val data = sc.parallelize((1 to 100).flatMap(_ => smallData), 4)
+
+    // No matter how many runs or iterations we use, we should get one cluster,
+    // centered at the mean of the points
+
+    val center = Vectors.dense(1.0, 3.0, 4.0)
+
+    var model = KMeansMiniBatch.train(data, k=1, maxIterations=1)
+    assert(model.clusterCenters.size === 1)
+    assert(model.clusterCenters.head === center)
+
+    model = KMeansMiniBatch.train(data, k=1, maxIterations=2)
+    assert(model.clusterCenters.head === center)
+
+    model = KMeansMiniBatch.train(data, k=1, maxIterations=5)
+    assert(model.clusterCenters.head === center)
+
+    model = KMeansMiniBatch.train(data, k=1, maxIterations=1, runs=5)
+    assert(model.clusterCenters.head === center)
+
+    model = KMeansMiniBatch.train(data, k=1, maxIterations=1, runs=5)
+    assert(model.clusterCenters.head === center)
+
+    model = KMeansMiniBatch.train(data, k=1, maxIterations=1, runs=1, initializationMode=RANDOM)
+    assert(model.clusterCenters.head === center)
+
+    model = KMeansMiniBatch.train(data, k=1, maxIterations=1, runs=1, initializationMode=K_MEANS_PARALLEL)
+    assert(model.clusterCenters.head === center)
+  }
+
+  test("single cluster with sparse data") {
+
+    val n = 10000
+    val data = sc.parallelize((1 to 100).flatMap { i =>
+      val x = i / 1000.0
+      Array(
+        Vectors.sparse(n, Seq((0, 1.0 + x), (1, 2.0), (2, 6.0))),
+        Vectors.sparse(n, Seq((0, 1.0 - x), (1, 2.0), (2, 6.0))),
+        Vectors.sparse(n, Seq((0, 1.0), (1, 3.0 + x))),
+        Vectors.sparse(n, Seq((0, 1.0), (1, 3.0 - x))),
+        Vectors.sparse(n, Seq((0, 1.0), (1, 4.0), (2, 6.0 + x))),
+        Vectors.sparse(n, Seq((0, 1.0), (1, 4.0), (2, 6.0 - x)))
+      )
+    }, 4)
+
+    data.persist()
+
+    // No matter how many runs or iterations we use, we should get one cluster,
+    // centered at the mean of the points
+
+    val center = Vectors.sparse(n, Seq((0, 1.0), (1, 3.0), (2, 4.0)))
+
+    var model = KMeansMiniBatch.train(data, k=1, maxIterations=1)
+    assert(model.clusterCenters.head === center)
+
+    model = KMeansMiniBatch.train(data, k=1, maxIterations=2)
+    assert(model.clusterCenters.head === center)
+
+    model = KMeansMiniBatch.train(data, k=1, maxIterations=5)
+    assert(model.clusterCenters.head === center)
+
+    model = KMeansMiniBatch.train(data, k=1, maxIterations=1, runs=5)
+    assert(model.clusterCenters.head === center)
+
+    model = KMeansMiniBatch.train(data, k=1, maxIterations=1, runs=5)
+    assert(model.clusterCenters.head === center)
+
+    model = KMeansMiniBatch.train(data, k=1, maxIterations=1, runs=1, initializationMode=RANDOM)
+    assert(model.clusterCenters.head === center)
+
+    model = KMeansMiniBatch.train(data, k=1, maxIterations=1, runs=1, initializationMode=K_MEANS_PARALLEL)
+    assert(model.clusterCenters.head === center)
+
+    data.unpersist()
+  }
+
+  test("k-means|| initialization") {
+    val points = Seq(
+      Vectors.dense(1.0, 2.0, 6.0),
+      Vectors.dense(1.0, 3.0, 0.0),
+      Vectors.dense(1.0, 4.0, 6.0),
+      Vectors.dense(1.0, 0.0, 1.0),
+      Vectors.dense(1.0, 1.0, 1.0)
+    )
+    val rdd = sc.parallelize(points)
+
+    // K-means|| initialization should place all clusters into distinct centers because
+    // it will make at least five passes, and it will give non-zero probability to each
+    // unselected point as long as it hasn't yet selected all of them
+
+    var model = KMeansMiniBatch.train(rdd, k=5, maxIterations=1)
+    assert(Set(model.clusterCenters: _*) === Set(points: _*))
+
+    // Iterations of Lloyd's should not change the answer either
+    model = KMeansMiniBatch.train(rdd, k=5, maxIterations=10)
+    assert(Set(model.clusterCenters: _*) === Set(points: _*))
+
+    // Neither should more runs
+    model = KMeansMiniBatch.train(rdd, k=5, maxIterations=10, runs=5)
+    assert(Set(model.clusterCenters: _*) === Set(points: _*))
+  }
+
+  test("two clusters") {
+    val points = Seq(
+      Vectors.dense(0.0, 0.0),
+      Vectors.dense(0.0, 0.1),
+      Vectors.dense(0.1, 0.0),
+      Vectors.dense(9.0, 0.0),
+      Vectors.dense(9.0, 0.2),
+      Vectors.dense(9.2, 0.0)
+    )
+    val rdd = sc.parallelize(points, 3)
+
+    for (initMode <- Seq(RANDOM, K_MEANS_PARALLEL)) {
+      // Two iterations are sufficient no matter where the initial centers are.
+      val model = KMeansMiniBatch.train(rdd, k = 2, maxIterations = 2, runs = 1, initMode)
+
+      val predicts = model.predict(rdd).collect()
+
+      assert(predicts(0) === predicts(1))
+      assert(predicts(0) === predicts(2))
+      assert(predicts(3) === predicts(4))
+      assert(predicts(3) === predicts(5))
+      assert(predicts(0) != predicts(3))
+    }
+  }
+}


### PR DESCRIPTION
Mini-batch is a version of KMeans that uses a randomly-sampled subset of the data points in each iteration instead of the full set of data points, improving performance (and in some cases, accuracy). The mini-batch version is compatible with the KMeans|| initialization algorithm currently implemented in MLlib.

This PR adds the KMeansMiniBatch clustering algorithm, tests, and updates docs.

Discussed in [SPARK-2308](https://issues.apache.org/jira/browse/SPARK-2308)
