### PR TITLE
[SPARK-2111] Print SPARK_PRINT_LAUNCH_COMMAND to stderr

### DIFF
--- a/bin/spark-class
+++ b/bin/spark-class
@@ -147,10 +147,10 @@ fi
 export CLASSPATH
 
 if [ "$SPARK_PRINT_LAUNCH_COMMAND" == "1" ]; then
-  echo -n "Spark Command: "
-  echo "$RUNNER" -cp "$CLASSPATH" $JAVA_OPTS "$@"
-  echo "========================================"
-  echo
+  echo -n "Spark Command: " 1>&2
+  echo "$RUNNER" -cp "$CLASSPATH" $JAVA_OPTS "$@" 1>&2
+  echo "========================================" 1>&2
+  echo 1>&2
 fi
 
 exec "$RUNNER" -cp "$CLASSPATH" $JAVA_OPTS "$@"


### PR DESCRIPTION
Printing to stdout breaks the contract with java_gateway.py that
stdout should only be a port number.
