### PR TITLE
make port of ConnectionManager configurable

### DIFF
--- a/core/src/main/scala/org/apache/spark/network/ConnectionManager.scala
+++ b/core/src/main/scala/org/apache/spark/network/ConnectionManager.scala
@@ -854,7 +854,7 @@ private[spark] object ConnectionManager {
 
   def main(args: Array[String]) {
     val conf = new SparkConf
-    val manager = new ConnectionManager(9999, conf, new SecurityManager(conf))
+    val manager = new ConnectionManager(conf.getInt("spark.network.connectionmanager.port",9999), conf, new SecurityManager(conf))
     manager.onReceiveMessage((msg: Message, id: ConnectionManagerId) => {
       println("Received [" + msg + "] from [" + id + "]")
       None

--- a/core/src/main/scala/org/apache/spark/network/ConnectionManager.scala
+++ b/core/src/main/scala/org/apache/spark/network/ConnectionManager.scala
@@ -854,7 +854,7 @@ private[spark] object ConnectionManager {
 
   def main(args: Array[String]) {
     val conf = new SparkConf
-    val manager = new ConnectionManager(conf.getInt("spark.network.connectionmanager.port",9999), conf, new SecurityManager(conf))
+    val manager = new ConnectionManager(conf.getInt("spark.network.connectionmanager.port", 9999), conf, new SecurityManager(conf))
     manager.onReceiveMessage((msg: Message, id: ConnectionManagerId) => {
       println("Received [" + msg + "] from [" + id + "]")
       None

--- a/core/src/main/scala/org/apache/spark/network/ConnectionManager.scala
+++ b/core/src/main/scala/org/apache/spark/network/ConnectionManager.scala
@@ -854,7 +854,8 @@ private[spark] object ConnectionManager {
 
   def main(args: Array[String]) {
     val conf = new SparkConf
-    val manager = new ConnectionManager(conf.getInt("spark.network.connectionmanager.port", 9999), conf, new SecurityManager(conf))
+    val manager = new ConnectionManager(conf.getInt("spark.network.connectionmanager.port", 9999),
+      conf, new SecurityManager(conf))
     manager.onReceiveMessage((msg: Message, id: ConnectionManagerId) => {
       println("Received [" + msg + "] from [" + id + "]")
       None

--- a/core/src/main/scala/org/apache/spark/network/ReceiverTest.scala
+++ b/core/src/main/scala/org/apache/spark/network/ReceiverTest.scala
@@ -23,7 +23,7 @@ import org.apache.spark.{SecurityManager, SparkConf}
 private[spark] object ReceiverTest {
   def main(args: Array[String]) {
     val conf = new SparkConf
-    val manager = new ConnectionManager(conf.getInt("spark.network.connectionmanager.port",9999), conf, new SecurityManager(conf))
+    val manager = new ConnectionManager(conf.getInt("spark.network.connectionmanager.port", 9999), conf, new SecurityManager(conf))
     println("Started connection manager with id = " + manager.id)
 
     manager.onReceiveMessage((msg: Message, id: ConnectionManagerId) => {

--- a/core/src/main/scala/org/apache/spark/network/ReceiverTest.scala
+++ b/core/src/main/scala/org/apache/spark/network/ReceiverTest.scala
@@ -23,7 +23,8 @@ import org.apache.spark.{SecurityManager, SparkConf}
 private[spark] object ReceiverTest {
   def main(args: Array[String]) {
     val conf = new SparkConf
-    val manager = new ConnectionManager(conf.getInt("spark.network.connectionmanager.port", 9999), conf, new SecurityManager(conf))
+    val manager = new ConnectionManager(conf.getInt("spark.network.connectionmanager.port", 9999),
+      conf, new SecurityManager(conf))
     println("Started connection manager with id = " + manager.id)
 
     manager.onReceiveMessage((msg: Message, id: ConnectionManagerId) => {

--- a/core/src/main/scala/org/apache/spark/network/ReceiverTest.scala
+++ b/core/src/main/scala/org/apache/spark/network/ReceiverTest.scala
@@ -23,7 +23,7 @@ import org.apache.spark.{SecurityManager, SparkConf}
 private[spark] object ReceiverTest {
   def main(args: Array[String]) {
     val conf = new SparkConf
-    val manager = new ConnectionManager(9999, conf, new SecurityManager(conf))
+    val manager = new ConnectionManager(conf.getInt("spark.network.connectionmanager.port",9999), conf, new SecurityManager(conf))
     println("Started connection manager with id = " + manager.id)
 
     manager.onReceiveMessage((msg: Message, id: ConnectionManagerId) => {


### PR DESCRIPTION
I encountered a port confliction problem due to ConnectionManager which is really annoying .
So I make the ConnectionManager port configurable with default port 9999 still.
I added a new configuration called `spark.network.connectionmanager.port` , and I'm not sure whether the name is OK or not : )
