### PR TITLE
[SPARK-2334] fix rdd.id() Attribute Error

### DIFF
--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -181,7 +181,7 @@ class RDD(object):
         """
         A unique ID for this RDD (within its SparkContext).
         """
-        return self._id
+        return self._jrdd.id()
 
     def __repr__(self):
         return self._jrdd.toString()


### PR DESCRIPTION
rdd.id() was returning an Attribute Error in some cases because self._id is not getting set.  So instead of returning the _id attribute, return the value of id() from the jrdd.  Fixes bug SPARK-2334.
Test with: sc.parallelize([1,2,3]).map(lambda x: x+1).id()
