### PR TITLE
[SPARK-2325] Utils.getLocalDir had better check the directory and choose a good one instead of choosing the first one directly

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/DiskChecker.scala
+++ b/core/src/main/scala/org/apache/spark/util/DiskChecker.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util
+
+import java.io._
+
+import org.apache.spark.Logging
+
+/**
+ * Various utility methods used by Spark for checking disks.
+ */
+private[spark] object DiskChecker extends Logging {
+
+  def mkdirsWithExistsCheck(dir: File): Boolean = {
+    if (dir.mkdir() || dir.exists()) {
+      return true
+    }
+    var canonDir: File = null
+    try {
+      canonDir = dir.getCanonicalFile()
+    } catch {
+      case ie: IOException => return false
+    }
+    val parent = canonDir.getParent()
+    (parent != null) && (mkdirsWithExistsCheck(new File(parent)) && (canonDir.mkdir() || canonDir.exists()))
+  }
+
+  def checkDir(dir: File): Boolean = {
+    mkdirsWithExistsCheck(dir) && dir.isDirectory() && dir.canRead() && dir.canWrite()
+  }
+}

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -430,7 +430,14 @@ private[spark] object Utils extends Logging {
    * multiple paths.
    */
   def getLocalDir(conf: SparkConf): String = {
-    conf.get("spark.local.dir",  System.getProperty("java.io.tmpdir")).split(',')(0)
+    val localDirs = conf.get("spark.local.dir",  System.getProperty("java.io.tmpdir")).split(',')
+    for (localDir <- localDirs) {
+      if (DiskChecker.checkDir(new File(localDir))) {
+        return localDir
+      }
+    }
+    logWarning("No local dir is good by checked, the first one will be choosed.")
+    localDirs(0)
   }
 
   /**


### PR DESCRIPTION
If the first directory of spark.local.dir is bad, application will exit with the exception:
Exception in thread "main" java.io.IOException: Failed to create a temp directory (under /data1/sparkenv/local) after 10 attempts!
at org.apache.spark.util.Utils$.createTempDir(Utils.scala:258)
at org.apache.spark.broadcast.HttpBroadcast$.createServer(HttpBroadcast.scala:154)
at org.apache.spark.broadcast.HttpBroadcast$.initialize(HttpBroadcast.scala:127)
at org.apache.spark.broadcast.HttpBroadcastFactory.initialize(HttpBroadcastFactory.scala:31)
at org.apache.spark.broadcast.BroadcastManager.initialize(BroadcastManager.scala:48)
at org.apache.spark.broadcast.BroadcastManager.<init>(BroadcastManager.scala:35)
at org.apache.spark.SparkEnv$.create(SparkEnv.scala:218)
at org.apache.spark.SparkContext.<init>(SparkContext.scala:202)
at JobTaskJoin$.main(JobTaskJoin.scala:9)
at JobTaskJoin.main(JobTaskJoin.scala)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.lang.reflect.Method.invoke(Method.java:601)
at org.apache.spark.deploy.SparkSubmit$.launch(SparkSubmit.scala:292)
at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:55)
at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
Utils.getLocalDir had better check the directory and choose a good one instead of choosing the first one directly. For example, spark.local.dir is /data1/sparkenv/local,/data2/sparkenv/local. The disk data1 is bad while the disk data2 is good, we could choose the data2 not data1.
