### PR TITLE
SPARK-2400 : fix spark.yarn.max.executor.failures explaination

### DIFF
--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -56,7 +56,7 @@ Most of the configs are the same for Spark on YARN as for other deployment modes
 <tr>
   <td><code>spark.yarn.max.executor.failures</code></td>
   <td>
-    2*numExecutors or 3, whichever is larger
+    numExecutors * 2, with minimum of 3
   </td>
   <td>
     It's the same to <code>spark.yarn.max.worker.failures</code>,

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -60,7 +60,7 @@ Most of the configs are the same for Spark on YARN as for other deployment modes
   </td>
   <td>
     It's the same to `spark.yarn.max.worker.failures`,
-    The maximum number of executor failures before failing the application.
+    the maximum number of executor failures before failing the application.
   </td>
 </tr>
 <tr>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -57,8 +57,7 @@ Most of the configs are the same for Spark on YARN as for other deployment modes
   <td><code>spark.yarn.max.executor.failures</code></td>
   <td>numExecutors * 2, with minimum of 3</td>
   <td>
-    It's the same to <code>spark.yarn.max.worker.failures</code>,
-    the maximum number of executor failures before failing the application.
+    The maximum number of executor failures before failing the application.
   </td>
 </tr>
 <tr>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -55,9 +55,7 @@ Most of the configs are the same for Spark on YARN as for other deployment modes
 </tr>
 <tr>
   <td><code>spark.yarn.max.executor.failures</code></td>
-  <td>
-    numExecutors * 2, with minimum of 3
-  </td>
+  <td>numExecutors * 2, with minimum of 3</td>
   <td>
     It's the same to <code>spark.yarn.max.worker.failures</code>,
     the maximum number of executor failures before failing the application.

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -59,7 +59,7 @@ Most of the configs are the same for Spark on YARN as for other deployment modes
     2*numExecutors or 3, whichever is larger
   </td>
   <td>
-    It's the same to `spark.yarn.max.worker.failures`,
+    It's the same to <code>spark.yarn.max.worker.failures</code>,
     the maximum number of executor failures before failing the application.
   </td>
 </tr>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -55,8 +55,11 @@ Most of the configs are the same for Spark on YARN as for other deployment modes
 </tr>
 <tr>
   <td><code>spark.yarn.max.executor.failures</code></td>
-  <td>2*numExecutors</td>
   <td>
+    2*numExecutors or 3, whichever is larger
+  </td>
+  <td>
+    It's the same to `spark.yarn.max.worker.failures`,
     The maximum number of executor failures before failing the application.
   </td>
 </tr>


### PR DESCRIPTION
According to 

``` scala
  private val maxNumExecutorFailures = sparkConf.getInt("spark.yarn.max.executor.failures",
    sparkConf.getInt("spark.yarn.max.worker.failures", math.max(args.numExecutors * 2, 3)))
```

default value should be numExecutors \* 2, with minimum of 3,  and it's same to the config 
`spark.yarn.max.worker.failures`
