### PR TITLE
[SPARK-2342] Evaluation helper's output type doesn't conform to input ty...

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -111,7 +111,7 @@ abstract class Expression extends TreeNode[Expression] {
       } else {
         e1.dataType match {
           case n: NumericType =>
-            f.asInstanceOf[(Numeric[n.JvmType], n.JvmType, n.JvmType) => Int](
+            f.asInstanceOf[(Numeric[n.JvmType], n.JvmType, n.JvmType) => n.JvmType](
               n.numeric, evalE1.asInstanceOf[n.JvmType], evalE2.asInstanceOf[n.JvmType])
           case other => sys.error(s"Type $other does not support numeric operations")
         }


### PR DESCRIPTION
The function cast doesn't conform to the intention of "Those expressions are supposed to be in the same data type, and also the return type." comment
