### PR TITLE
Delete the useless import

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -266,7 +266,7 @@ object HistoryServer {
 
   def main(argStrings: Array[String]) {
     initSecurity()
-    val args = new HistoryServerArguments(argStrings)
+    new HistoryServerArguments(argStrings)
     val securityManager = new SecurityManager(conf)
     val server = new HistoryServer(args.logDir, securityManager, conf)
     server.bind()

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -26,7 +26,6 @@ import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.scheduler._
 import org.apache.spark.ui.{WebUI, SparkUI}
 import org.apache.spark.ui.JettyUtils._
-import org.apache.spark.util.Utils
 
 /**
  * A web server that renders SparkUIs of completed applications.


### PR DESCRIPTION
"import org.apache.spark.util.Utils" is never used in HistoryServer.scala
