### PR TITLE
[SPARK-2355][MLlib] Add checker for the number of clusters

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeans.scala
@@ -117,6 +117,11 @@ class KMeans private (
    * performance, because this is an iterative algorithm.
    */
   def run(data: RDD[Vector]): KMeansModel = {
+
+    if (data.count() < k) {
+      throw new IllegalArgumentException("Number of clusters must not be greater than data number")
+    }
+
     // Compute squared norms and cache them.
     val norms = data.map(v => breezeNorm(v.toBreeze, 2.0))
     norms.persist()


### PR DESCRIPTION
When the number of clusters given to perform with org.apache.spark.mllib.clustering.KMeans under parallel initial mode is greater than data number, it will throw ArrayIndexOutOfBoundsException.

This PR adds checker for the number of clusters and throws IllegalArgumentException when that number is greater than data number.
