### PR TITLE
SPARK-2368 Making FileServerHandler sends gracefully to prevent OOM

### DIFF
--- a/core/src/main/java/org/apache/spark/network/netty/FileClient.java
+++ b/core/src/main/java/org/apache/spark/network/netty/FileClient.java
@@ -20,6 +20,7 @@ package org.apache.spark.network.netty;
 import java.util.concurrent.TimeUnit;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
@@ -53,6 +54,9 @@ class FileClient {
       .option(ChannelOption.SO_KEEPALIVE, true)
       .option(ChannelOption.TCP_NODELAY, true)
       .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeout)
+      .option(ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK, 32 * 1024)
+      .option(ChannelOption.WRITE_BUFFER_LOW_WATER_MARK, 8 * 1024)
+      .option(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
       .handler(new FileClientChannelInitializer(handler));
   }
 

--- a/core/src/main/java/org/apache/spark/network/netty/FileClientHandler.java
+++ b/core/src/main/java/org/apache/spark/network/netty/FileClientHandler.java
@@ -44,10 +44,13 @@ abstract class FileClientHandler extends SimpleChannelInboundHandler<ByteBuf> {
     }
     // get file
     if(in.readableBytes() >= currentHeader.fileLen()) {
-      handle(ctx, in, currentHeader);
-      handlerCalled = true;
-      currentHeader = null;
-      ctx.close();
+      try {
+        handle(ctx, in, currentHeader);
+      } finally {
+        handlerCalled = true;
+        currentHeader = null;
+        ctx.close();
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/spark/network/netty/FileServer.java
+++ b/core/src/main/java/org/apache/spark/network/netty/FileServer.java
@@ -20,6 +20,7 @@ package org.apache.spark.network.netty;
 import java.net.InetSocketAddress;
 
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
@@ -52,7 +53,10 @@ class FileServer {
         .channel(OioServerSocketChannel.class)
         .option(ChannelOption.SO_BACKLOG, 100)
         .option(ChannelOption.SO_RCVBUF, 1500)
-        .childHandler(new FileServerChannelInitializer(pResolver));
+        .childHandler(new FileServerChannelInitializer(pResolver))
+        .childOption(ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK, 32 * 1024)
+        .childOption(ChannelOption.WRITE_BUFFER_LOW_WATER_MARK, 8 * 1024)
+        .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);
     // Start the server.
     channelFuture = bootstrap.bind(addr);
     try {

--- a/core/src/main/java/org/apache/spark/network/netty/FileServer.java
+++ b/core/src/main/java/org/apache/spark/network/netty/FileServer.java
@@ -26,6 +26,7 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.oio.OioEventLoopGroup;
 import io.netty.channel.socket.oio.OioServerSocketChannel;
+import org.apache.spark.SparkConf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +42,7 @@ class FileServer {
   private ChannelFuture channelFuture = null;
   private int port = 0;
 
-  FileServer(PathResolver pResolver, int port) {
+  FileServer(PathResolver pResolver, int port, SparkConf conf) {
     InetSocketAddress addr = new InetSocketAddress(port);
 
     // Configure the server.
@@ -49,13 +50,14 @@ class FileServer {
     workerGroup = new OioEventLoopGroup();
 
     ServerBootstrap bootstrap = new ServerBootstrap();
+
     bootstrap.group(bossGroup, workerGroup)
         .channel(OioServerSocketChannel.class)
-        .option(ChannelOption.SO_BACKLOG, 100)
-        .option(ChannelOption.SO_RCVBUF, 1500)
+        .option(ChannelOption.SO_BACKLOG, conf.getInt("spark.shuffle.fileserver.backlog", 100))
+        .option(ChannelOption.SO_RCVBUF, conf.getInt("spark.shuffle.fileserver.receivebuf", 1536))
         .childHandler(new FileServerChannelInitializer(pResolver))
-        .childOption(ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK, 32 * 1024)
-        .childOption(ChannelOption.WRITE_BUFFER_LOW_WATER_MARK, 8 * 1024)
+        .childOption(ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK, conf.getInt("spark.shuffle.fileserver.watermark.high", 1024) * 1024)
+        .childOption(ChannelOption.WRITE_BUFFER_LOW_WATER_MARK, conf.getInt("spark.shuffle.fileserver.watermark.low", 256) * 1024)
         .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);
     // Start the server.
     channelFuture = bootstrap.bind(addr);

--- a/core/src/main/java/org/apache/spark/network/netty/FileServerHandler.java
+++ b/core/src/main/java/org/apache/spark/network/netty/FileServerHandler.java
@@ -81,8 +81,11 @@ class FileServerHandler extends SimpleChannelInboundHandler<String> {
 
   // We want to send right away without over  loading the channel so the busy wait is needed.
   private void writeIfPossible(Channel channel, Object object) {
-    while (!channel.isWritable()) {
-      channel.writeAndFlush(object);
+    while (true) {
+      if (channel.isWritable()) {
+        channel.writeAndFlush(object);
+        return;
+      }
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/network/netty/ShuffleCopier.scala
+++ b/core/src/main/scala/org/apache/spark/network/netty/ShuffleCopier.scala
@@ -35,8 +35,7 @@ private[spark] class ShuffleCopier(conf: SparkConf) extends Logging {
       resultCollectCallback: (BlockId, Long, ByteBuf) => Unit) {
 
     val handler = new ShuffleCopier.ShuffleClientHandler(resultCollectCallback)
-    val connectTimeout = conf.getInt("spark.shuffle.netty.connect.timeout", 60000)
-    val fc = new FileClient(handler, connectTimeout)
+    val fc = new FileClient(handler, conf)
 
     try {
       fc.init()

--- a/core/src/main/scala/org/apache/spark/network/netty/ShuffleSender.scala
+++ b/core/src/main/scala/org/apache/spark/network/netty/ShuffleSender.scala
@@ -19,13 +19,13 @@ package org.apache.spark.network.netty
 
 import java.io.File
 
-import org.apache.spark.Logging
+import org.apache.spark.{SparkConf, Logging}
 import org.apache.spark.util.Utils
 import org.apache.spark.storage.{BlockId, FileSegment}
 
-private[spark] class ShuffleSender(portIn: Int, val pResolver: PathResolver) extends Logging {
+private[spark] class ShuffleSender(portIn: Int, val pResolver: PathResolver, val conf: SparkConf) extends Logging {
 
-  val server = new FileServer(pResolver, portIn)
+  val server = new FileServer(pResolver, portIn, conf)
   server.start()
 
   def stop() {
@@ -66,6 +66,6 @@ private[spark] object ShuffleSender {
         new FileSegment(file, 0, file.length())
       }
     }
-    val sender = new ShuffleSender(port, pResovler)
+    val sender = new ShuffleSender(port, pResovler, new SparkConf)
   }
 }

--- a/core/src/main/scala/org/apache/spark/network/netty/ShuffleSender.scala
+++ b/core/src/main/scala/org/apache/spark/network/netty/ShuffleSender.scala
@@ -23,7 +23,8 @@ import org.apache.spark.{SparkConf, Logging}
 import org.apache.spark.util.Utils
 import org.apache.spark.storage.{BlockId, FileSegment}
 
-private[spark] class ShuffleSender(portIn: Int, val pResolver: PathResolver, val conf: SparkConf) extends Logging {
+private[spark] class ShuffleSender(portIn: Int, val pResolver: PathResolver,
+                                   val conf: SparkConf) extends Logging {
 
   val server = new FileServer(pResolver, portIn, conf)
   server.start()

--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
@@ -179,7 +179,7 @@ private[spark] class DiskBlockManager(shuffleManager: ShuffleBlockManager, rootD
   }
 
   private[storage] def startShuffleBlockSender(port: Int): Int = {
-    shuffleSender = new ShuffleSender(port, this)
+    shuffleSender = new ShuffleSender(port, this, shuffleManager.conf)
     logInfo(s"Created ShuffleSender binding to port: ${shuffleSender.port}")
     shuffleSender.port
   }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -574,6 +574,62 @@ Apart from these, the following properties are also available, and may be useful
     between nodes leading to flooding the network with those.
   </td>
 </tr>
+<tr>
+  <td><code>spark.shuffle.fileclient.connect.timeout</code></td>
+  <td>60000</td>
+  <td>
+    The maximum allowed time in milliseconds for FileClient to connect to FileServer.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.shuffle.fileclient.send.timeout</code></td>
+  <td>60</td>
+  <td>
+    The maximum allowed wait time in milliseconds for FileClient to send a request to FileServer after the connection has been established.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.shuffle.fileclient.watermark.high</code></td>
+  <td>512</td>
+  <td>
+    The high watermark for FileClient in kbytes. If the number of bytes queued in the write buffer exceeds this value, Netty <code> Channel.isWritable() </code> will start to return false.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.shuffle.fileclient.watermark.low</code></td>
+  <td>128</td>
+  <td>
+    The low watermark for FileClient in kbytes. Once the number of bytes queued in the write buffer exceeded the high water mark and then dropped down below this value, Netty <code>Channel.isWritable()</code> will start to return true again.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.shuffle.fileserver.watermark.high</code></td>
+  <td>1024</td>
+  <td>
+    The high watermark for FileServer in kbytes. If the number of bytes queued in the write buffer exceeds this value, Netty <code> Channel.isWritable() </code> will start to return false.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.shuffle.fileserver.watermark.low</code></td>
+  <td>256</td>
+  <td>
+    The low watermark for FileServer in kbytes. Once the number of bytes queued in the write buffer exceeded the high water mark and then dropped down below this value, Netty <code>Channel.isWritable()</code> will start to return true again.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.shuffle.fileserver.receivebuf</code></td>
+  <td>1536</td>
+  <td>
+    Set SO_RCVBUF of the FileSever socket. It specifies the size of the buffer the kernel allocates to hold the data arriving into the given socket during the time between it arrives over the network and when it is read by the program that owns this socket. With TCP, if data arrives and you are not reading it, the buffer will fill up, and the sender will be told to slow down.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.shuffle.fileserver.backlog</code></td>
+  <td>100</td>
+  <td>
+    Set SO_BACKLOG of the FileServer socket. It indicates the maximum queue length for incoming connection indications (a request to connect) is set to the backlog parameter. If a connection indication arrives when the queue is full, the connection is refused.
+  </td>
+</tr>
 </table>
 
 #### Scheduling


### PR DESCRIPTION
Busy wait for the channel to be ready before writing to it to prevent
the buffer from exploding.

Also making some small code changes to improve clarity.
