### PR TITLE
[SPARK-2375][SQL] JSON schema inference may not resolve type conflicts correctly for a field inside an array of structs

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/json/JsonRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/json/JsonRDD.scala
@@ -198,11 +198,12 @@ private[sql] object JsonRDD extends Logging {
    * in this JSON object can appear in other JSON objects.
    */
   private def allKeysWithValueTypes(m: Map[String, Any]): Set[(String, DataType)] = {
-    m.map{
+    val keyValuePairs = m.map {
       // Quote the key with backticks to handle cases which have dots
       // in the field name.
-      case (key, dataType) => (s"`$key`", dataType)
-    }.flatMap {
+      case (key, value) => (s"`$key`", value)
+    }.toSet
+    keyValuePairs.flatMap {
       case (key: String, struct: Map[String, Any]) => {
         // The value associted with the key is an JSON object.
         allKeysWithValueTypes(struct).map {
@@ -224,7 +225,7 @@ private[sql] object JsonRDD extends Logging {
         }
       }
       case (key: String, value) => (key, typeOfPrimitiveValue(value)) :: Nil
-    }.toSet
+    }
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/json/JsonSuite.scala
@@ -448,9 +448,9 @@ class JsonSuite extends QueryTest {
   }
 
   test("Type conflict in array elements") {
-    val jsonSchemaRDD = jsonRDD(arrayElementTypeConflict)
+    var jsonSchemaRDD = jsonRDD(arrayElementTypeConflict1)
 
-    val expectedSchema =
+    var expectedSchema =
       AttributeReference("array", ArrayType(StringType), true)() :: Nil
 
     comparePlans(Schema(expectedSchema), Schema(jsonSchemaRDD.logicalPlan.output))
@@ -468,6 +468,14 @@ class JsonSuite extends QueryTest {
       sql("select array[0] + 1 from jsonTable"),
       2
     )
+
+    jsonSchemaRDD = jsonRDD(arrayElementTypeConflict2)
+
+    expectedSchema =
+      AttributeReference("array",
+        ArrayType(StructType(StructField("field", LongType, true) :: Nil)), true)() :: Nil
+
+    comparePlans(Schema(expectedSchema), Schema(jsonSchemaRDD.logicalPlan.output))
   }
 
   test("Handling missing fields") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/json/TestJsonData.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/json/TestJsonData.scala
@@ -70,9 +70,13 @@ object TestJsonData {
       """{"num_struct":{}, "str_array":["str1", "str2", 33],
           "array":[7], "struct_array":{"field": true}, "struct": {"field": "str"}}""" :: Nil)
 
-  val arrayElementTypeConflict =
+  val arrayElementTypeConflict1 =
     TestSQLContext.sparkContext.parallelize(
       """{"array": [1, 1.1, true, null, [], {}, [2,3,4], {"field":"str"}]}""" :: Nil)
+
+  val arrayElementTypeConflict2 =
+    TestSQLContext.sparkContext.parallelize(
+      """{"array": [{"field":214748364700}, {"field":1}]}""" :: Nil)
 
   val missingFields =
     TestSQLContext.sparkContext.parallelize(

--- a/sql/core/src/test/scala/org/apache/spark/sql/json/TestJsonData.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/json/TestJsonData.scala
@@ -70,13 +70,10 @@ object TestJsonData {
       """{"num_struct":{}, "str_array":["str1", "str2", 33],
           "array":[7], "struct_array":{"field": true}, "struct": {"field": "str"}}""" :: Nil)
 
-  val arrayElementTypeConflict1 =
+  val arrayElementTypeConflict =
     TestSQLContext.sparkContext.parallelize(
-      """{"array": [1, 1.1, true, null, [], {}, [2,3,4], {"field":"str"}]}""" :: Nil)
-
-  val arrayElementTypeConflict2 =
-    TestSQLContext.sparkContext.parallelize(
-      """{"array": [{"field":214748364700}, {"field":1}]}""" :: Nil)
+      """{"array1": [1, 1.1, true, null, [], {}, [2,3,4], {"field":"str"}],
+          "array2": [{"field":214748364700}, {"field":1}]}""" :: Nil)
 
   val missingFields =
     TestSQLContext.sparkContext.parallelize(


### PR DESCRIPTION
For example, for

```
{"array": [{"field":214748364700}, {"field":1}]}
```

the type of field is resolved as IntType. While, for

```
{"array": [{"field":1}, {"field":214748364700}]}
```

the type of field is resolved as LongType.

JIRA: https://issues.apache.org/jira/browse/SPARK-2375
