### PR TITLE
[SPARK-2402] Update the initial position when reusing DiskBlockObjectWriter

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockObjectWriter.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockObjectWriter.scala
@@ -107,8 +107,8 @@ private[spark] class DiskBlockObjectWriter(
   private var fos: FileOutputStream = null
   private var ts: TimeTrackingOutputStream = null
   private var objOut: SerializationStream = null
-  private val initialPosition = file.length()
-  private var lastValidPosition = initialPosition
+  private var initialPosition: Long = 0L
+  private var lastValidPosition: Long = 0L
   private var initialized = false
   private var _timeWriting = 0L
 
@@ -116,6 +116,7 @@ private[spark] class DiskBlockObjectWriter(
     fos = new FileOutputStream(file, true)
     ts = new TimeTrackingOutputStream(fos)
     channel = fos.getChannel()
+    initialPosition = file.length()
     lastValidPosition = initialPosition
     bs = compressStream(new BufferedOutputStream(ts, bufferSize))
     objOut = serializer.newInstance().serializeStream(bs)


### PR DESCRIPTION
Minor fix, `initialPosition` can not be updated after `close()` and re`open()`, which will lead to error when reusing this object. Details can be seen in [SPARK-2402](https://issues.apache.org/jira/browse/SPARK-2402).
