### PR TITLE
[SPARK-2403] Catch all errors during serialization in DAGScheduler

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -770,7 +770,7 @@ class DAGScheduler(
           runningStages -= stage
           return
         case NonFatal(e) => // Other exceptions, such as IllegalArgumentException from Kryo.
-          abortStage(stage, "Task serialization failed: " + e.toString)
+          abortStage(stage, s"Task serialization failed: $e\n${e.getStackTraceString}")
           runningStages -= stage
           return
       }

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -26,6 +26,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.reflect.ClassTag
+import scala.util.control.NonFatal
 
 import akka.actor._
 import akka.actor.OneForOneStrategy
@@ -768,7 +769,7 @@ class DAGScheduler(
           abortStage(stage, "Task not serializable: " + e.toString)
           runningStages -= stage
           return
-        case e: Throwable => // Other exceptions, such as IllegalArgumentException from Kryo.
+        case NonFatal(e) => // Other exceptions, such as IllegalArgumentException from Kryo.
           abortStage(stage, "Task serialization failed: " + e.toString)
           runningStages -= stage
           return

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -768,6 +768,10 @@ class DAGScheduler(
           abortStage(stage, "Task not serializable: " + e.toString)
           runningStages -= stage
           return
+        case e: Throwable => // Other exceptions, such as IllegalArgumentException from Kryo.
+          abortStage(stage, "Task serialization failed: " + e.toString)
+          runningStages -= stage
+          return
       }
 
       logInfo("Submitting " + tasks.size + " missing tasks from " + stage + " (" + stage.rdd + ")")


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-2403

Spark hangs for us whenever we forget to register a class with Kryo. This should be a simple fix for that. But let me know if you have a better suggestion.

I did not write a new test for this. It would be pretty complicated and I'm not sure it's worthwhile for such a simple change. Let me know if you disagree.
