### PR TITLE
SPARK-2404: don't overwrite SPARK_HOME when it is set

### DIFF
--- a/bin/pyspark
+++ b/bin/pyspark
@@ -21,7 +21,9 @@
 FWDIR="$(cd `dirname $0`/..; pwd)"
 
 # Export this as SPARK_HOME
-export SPARK_HOME="$FWDIR"
+if [ -z $SPARK_HOME ]; then 
+  export SPARK_HOME="$FWDIR"
+fi
 
 SCALA_VERSION=2.10
 

--- a/bin/pyspark2.cmd
+++ b/bin/pyspark2.cmd
@@ -23,7 +23,7 @@ rem Figure out where the Spark framework is installed
 set FWDIR=%~dp0..\
 
 rem Export this as SPARK_HOME
-set SPARK_HOME=%FWDIR%
+if "x%SPARK_HOME%" == "x" set SPARK_HOME=%FWDIR%
 
 rem Test whether the user has built Spark
 if exist "%FWDIR%RELEASE" goto skip_build_test

--- a/bin/run-example
+++ b/bin/run-example
@@ -20,7 +20,11 @@
 SCALA_VERSION=2.10
 
 FWDIR="$(cd `dirname $0`/..; pwd)"
-export SPARK_HOME="$FWDIR"
+
+if [ -z $SPARK_HOME ]; then 
+  export SPARK_HOME="$FWDIR"
+fi
+
 EXAMPLES_DIR="$FWDIR"/examples
 
 if [ -n "$1" ]; then

--- a/bin/run-example2.cmd
+++ b/bin/run-example2.cmd
@@ -23,7 +23,7 @@ rem Figure out where the Spark framework is installed
 set FWDIR=%~dp0..\
 
 rem Export this as SPARK_HOME
-set SPARK_HOME=%FWDIR%
+if "x%SPARK_HOME%" == "x" set SPARK_HOME=%FWDIR%
 
 rem Load environment variables from conf\spark-env.cmd, if it exists
 if exist "%FWDIR%conf\spark-env.cmd" call "%FWDIR%conf\spark-env.cmd"

--- a/bin/spark-class
+++ b/bin/spark-class
@@ -27,8 +27,10 @@ SCALA_VERSION=2.10
 # Figure out where Spark is installed
 FWDIR="$(cd `dirname $0`/..; pwd)"
 
-# Export this as SPARK_HOME
-export SPARK_HOME="$FWDIR"
+if [ -z $SPARK_HOME ]; then
+  # Export this as SPARK_HOME
+  export SPARK_HOME="$FWDIR"
+fi
 
 . $FWDIR/bin/load-spark-env.sh
 

--- a/bin/spark-class2.cmd
+++ b/bin/spark-class2.cmd
@@ -25,7 +25,7 @@ rem Figure out where the Spark framework is installed
 set FWDIR=%~dp0..\
 
 rem Export this as SPARK_HOME
-set SPARK_HOME=%FWDIR%
+if "x%SPARK_HOME%" == "x" set SPARK_HOME=%FWDIR%
 
 rem Load environment variables from conf\spark-env.cmd, if it exists
 if exist "%FWDIR%conf\spark-env.cmd" call "%FWDIR%conf\spark-env.cmd"

--- a/bin/spark-shell.cmd
+++ b/bin/spark-shell.cmd
@@ -17,6 +17,6 @@ rem See the License for the specific language governing permissions and
 rem limitations under the License.
 rem
 
-set SPARK_HOME=%~dp0..
+if "x%SPARK_HOME%" == "x" set SPARK_HOME=%~dp0..
 
 cmd /V /E /C %SPARK_HOME%\bin\spark-submit.cmd spark-shell %* --class org.apache.spark.repl.Main

--- a/bin/spark-submit
+++ b/bin/spark-submit
@@ -17,7 +17,10 @@
 # limitations under the License.
 #
 
-export SPARK_HOME="$(cd `dirname $0`/..; pwd)"
+if [ -z $SPARK_HOME ]; then  
+  export SPARK_HOME="$(cd `dirname $0`/..; pwd)"
+fi
+
 ORIG_ARGS=("$@")
 
 while (($#)); do

--- a/bin/spark-submit.cmd
+++ b/bin/spark-submit.cmd
@@ -17,7 +17,7 @@ rem See the License for the specific language governing permissions and
 rem limitations under the License.
 rem
 
-set SPARK_HOME=%~dp0..
+if "x%SPARK_HOME%" == "x" set SPARK_HOME=%~dp0..
 set ORIG_ARGS=%*
 
 rem Clear the values of all variables used


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-2404

In spark-class and spark-submit, the SPARK_HOME is set to the present working directory, causing the value of already defined SPARK_HOME being overwritten

We should not overwrite that if SPARK_HOME has been defined

Our scenario:

We have a login portal for all the team members to use the spark-cluster, everyone gets an account and home directory. Spark-1.0 is copied in the root path "/", every account gets a soft link to the /spark-1.0 in it's home directory. 

Spark 1.0 is deployed in a cluster, where the user name is different with any accounts except one, say "CodingCat", we set a global SPARK_HOME to /home/CodingCat/spark-1.0 which is consistent with the remote cluster setup, but unfortunately, this is overwritten by the spark-class and spark-submit ....so in login portal, when the user runs spark-shell, it always tries to run /home/user_account/spark-1.0/bin/compute-class.sh, which does not exist.
