### PR TITLE
[SPARK-2675]LiveListenerBus Queue Overflow

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -65,7 +65,8 @@ class SparkEnv (
     val httpFileServer: HttpFileServer,
     val sparkFilesDir: String,
     val metricsSystem: MetricsSystem,
-    val conf: SparkConf) extends Logging {
+    val conf: SparkConf,
+    val isDriver: Boolean = false) extends Logging {
 
   // A mapping of thread ID to amount of memory used for shuffle in bytes
   // All accesses should be manually synchronized
@@ -78,14 +79,17 @@ class SparkEnv (
   private[spark] val hadoopJobMetadata = new MapMaker().softValues().makeMap[String, Any]()
 
   private[spark] def stop() {
-    pythonWorkers.foreach { case(key, worker) => worker.stop() }
-    Option(httpFileServer).foreach(_.stop())
-    mapOutputTracker.stop()
-    shuffleManager.stop()
-    broadcastManager.stop()
+    if(isDriver) {
+      pythonWorkers.foreach { case(key, worker) => worker.stop() }
+      Option(httpFileServer).foreach(_.stop())
+      mapOutputTracker.stop()
+      shuffleManager.stop()
+      broadcastManager.stop()
+      blockManager.master.stop()
+      metricsSystem.stop()
+      actorSystem.shutdown()
+    }
     blockManager.stop()
-    blockManager.master.stop()
-    metricsSystem.stop()
     actorSystem.shutdown()
     // Unfortunately Akka's awaitTermination doesn't actually wait for the Netty server to shut
     // down, but let's call it anyway in case it gets fixed in a later release
@@ -278,7 +282,8 @@ object SparkEnv extends Logging {
       httpFileServer,
       sparkFilesDir,
       metricsSystem,
-      conf)
+      conf,
+      isDriver)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -88,6 +88,7 @@ private[spark] class CoarseGrainedExecutorBackend(
 
     case StopExecutor =>
       logInfo("Driver commanded a shutdown")
+      executor.stop()
       context.stop(self)
       context.system.shutdown()
   }

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -341,4 +341,8 @@ private[spark] class Executor(
       }
     }
   }
+
+  def stop() {
+    this.env.stop()
+  }
 }

--- a/core/src/main/scala/org/apache/spark/storage/BlockId.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockId.scala
@@ -65,6 +65,11 @@ case class BroadcastBlockId(broadcastId: Long, field: String = "") extends Block
 }
 
 @DeveloperApi
+case class EventBlockId(eventId: Long) extends BlockId {
+  def name = "eventblock_" + eventId
+}
+
+@DeveloperApi
 case class TaskResultBlockId(taskId: Long) extends BlockId {
   def name = "taskresult_" + taskId
 }
@@ -91,6 +96,7 @@ object BlockId {
   val BROADCAST = "broadcast_([0-9]+)([_A-Za-z0-9]*)".r
   val TASKRESULT = "taskresult_([0-9]+)".r
   val STREAM = "input-([0-9]+)-([0-9]+)".r
+  val EVENT = "eventblock_([0-9]+)".r
   val TEST = "test_(.*)".r
 
   /** Converts a BlockId "name" String back into a BlockId. */
@@ -103,6 +109,8 @@ object BlockId {
       BroadcastBlockId(broadcastId.toLong, field.stripPrefix("_"))
     case TASKRESULT(taskId) =>
       TaskResultBlockId(taskId.toLong)
+    case EVENT(eventId) =>
+      EventBlockId(eventId.toLong)
     case STREAM(streamId, uniqueId) =>
       StreamBlockId(streamId.toInt, uniqueId.toLong)
     case TEST(value) =>

--- a/yarn/alpha/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocationHandler.scala
+++ b/yarn/alpha/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocationHandler.scala
@@ -22,7 +22,7 @@ import java.util.{Collections, Set => JSet}
 import java.util.concurrent.{CopyOnWriteArrayList, ConcurrentHashMap}
 import java.util.concurrent.atomic.AtomicInteger
 
-import scala.collection
+import scala.{Int, collection}
 import scala.collection.JavaConversions._
 import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet}
 
@@ -93,12 +93,15 @@ private[yarn] class YarnAllocationHandler(
     YarnAllocationHandler.MEMORY_OVERHEAD)
 
   private val numExecutorsRunning = new AtomicInteger()
+  private val numExecutorsFinished = new AtomicInteger()
   // Used to generate a unique id per executor
   private val executorIdCounter = new AtomicInteger()
   private val lastResponseId = new AtomicInteger()
   private val numExecutorsFailed = new AtomicInteger()
 
   def getNumExecutorsRunning: Int = numExecutorsRunning.intValue
+
+  def getNumExecutorsFinished: Int = numExecutorsFinished.intValue
 
   def getNumExecutorsFailed: Int = numExecutorsFailed.intValue
 
@@ -308,6 +311,9 @@ private[yarn] class YarnAllocationHandler(
           if (completedContainer.getExitStatus() != 0) {
             logInfo("Container marked as failed: " + containerId)
             numExecutorsFailed.incrementAndGet()
+          } else {
+            logInfo("Container marked as finised successfully: " + containerId)
+            numExecutorsFinished.incrementAndGet()
           }
         }
 

--- a/yarn/stable/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/stable/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -269,7 +269,7 @@ class ApplicationMaster(args: ApplicationMasterArguments, conf: Configuration,
 
   private def allocateMissingExecutor() {
     val missingExecutorCount = args.numExecutors - yarnAllocator.getNumExecutorsRunning -
-      yarnAllocator.getNumPendingAllocate
+      yarnAllocator.getNumPendingAllocate - yarnAllocator.getNumExecutorsFinished
     if (missingExecutorCount > 0) {
       logInfo("Allocating %d containers to make up for (potentially) lost containers".
         format(missingExecutorCount))


### PR DESCRIPTION
As we know, the size of  "eventQueue" is fixed. When event comes faster than consume speed of listener, overflow events will be thrown away with throwing an "logQueueFullErrorMessage'. As a result, we find spark UI in chaotic state. In my Strategy, those overflow events are "cached" in "blockManager" first , and replayed by "replayThread" when "eventQueue" is free. The unique drawback is some display delay in Spark UI. But it is better than event loss. This delay will disappear when event stress alleviates.
