### PR TITLE
[WIP] SPARK-2450: Add YARN executor log links to UI executors page

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
@@ -57,7 +57,8 @@ private[spark] class SparkUI(
   // Maintain executor storage status through Spark events
   val storageStatusListener = new StorageStatusListener
 
-  var executorsTab : ExecutorsTab = null
+  // The executors tab created during initialize()
+  private var executorsTab : ExecutorsTab = null
 
   initialize()
 
@@ -89,6 +90,7 @@ private[spark] class SparkUI(
     listenerBus.addListener(listener)
   }
 
+  /** Update the location of an executor's logs reported in the executors tab. */
   def updateExecutorLogLocation(executorId: String, logs: String) {
     executorsTab.updateExecutorLogLocation(executorId, logs)
   }

--- a/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
@@ -57,6 +57,8 @@ private[spark] class SparkUI(
   // Maintain executor storage status through Spark events
   val storageStatusListener = new StorageStatusListener
 
+  var executorsTab : ExecutorsTab = null
+
   initialize()
 
   /** Initialize all components of the server. */
@@ -66,7 +68,8 @@ private[spark] class SparkUI(
     attachTab(jobProgressTab)
     attachTab(new StorageTab(this))
     attachTab(new EnvironmentTab(this))
-    attachTab(new ExecutorsTab(this))
+    executorsTab = new ExecutorsTab(this)
+    attachTab(executorsTab)
     attachHandler(createStaticHandler(SparkUI.STATIC_RESOURCE_DIR, "/static"))
     attachHandler(createRedirectHandler("/", "/stages", basePath = basePath))
     attachHandler(
@@ -84,6 +87,10 @@ private[spark] class SparkUI(
   /** Register the given listener with the listener bus. */
   def registerListener(listener: SparkListener) {
     listenerBus.addListener(listener)
+  }
+
+  def updateExecutorLogLocation(executorId: String, logs: String) {
+    executorsTab.updateExecutorLogLocation(executorId, logs)
   }
 
   /** Stop the server behind this web interface. Only valid after bind(). */

--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsPage.scala
@@ -21,6 +21,7 @@ import javax.servlet.http.HttpServletRequest
 
 import scala.xml.Node
 
+import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.ui.{ToolTips, UIUtils, WebUIPage}
 import org.apache.spark.util.Utils
@@ -40,7 +41,8 @@ private case class ExecutorSummaryInfo(
     totalInputBytes: Long,
     totalShuffleRead: Long,
     totalShuffleWrite: Long,
-    maxMemory: Long)
+    maxMemory: Long,
+    logLocation: String)
 
 private[ui] class ExecutorsPage(parent: ExecutorsTab) extends WebUIPage("") {
   private val appName = parent.appName
@@ -70,14 +72,10 @@ private[ui] class ExecutorsPage(parent: ExecutorsTab) extends WebUIPage("") {
           <th>Task Time</th>
           <th><span data-toggle="tooltip" title={ToolTips.INPUT}>Input</span></th>
           <th><span data-toggle="tooltip" title={ToolTips.SHUFFLE_READ}>Shuffle Read</span></th>
-          <th>
-            <!-- Place the shuffle write tooltip on the left (rather than the default position
-              of on top) because the shuffle write column is the last column on the right side and
-              the tooltip is wider than the column, so it doesn't fit on top. -->
-            <span data-toggle="tooltip" data-placement="left" title={ToolTips.SHUFFLE_WRITE}>
-              Shuffle Write
-            </span>
-          </th>
+          <th><span data-toggle="tooltip" title={ToolTips.SHUFFLE_WRITE}>Shuffle Write</span></th>
+          {if (SparkHadoopUtil.get.isYarnMode)
+            <th>Logs</th>
+          }
         </thead>
         <tbody>
           {execInfoSorted.map(execRow(_))}
@@ -104,6 +102,8 @@ private[ui] class ExecutorsPage(parent: ExecutorsTab) extends WebUIPage("") {
     UIUtils.headerSparkPage(content, basePath, appName, "Executors (" + execInfo.size + ")",
       parent.headerTabs, parent)
   }
+
+  private val NoLogs = "-none-"
 
   /** Render an HTML row representing an executor */
   private def execRow(info: ExecutorSummaryInfo): Seq[Node] = {
@@ -137,6 +137,13 @@ private[ui] class ExecutorsPage(parent: ExecutorsTab) extends WebUIPage("") {
       <td sorttable_customkey={info.totalShuffleWrite.toString}>
         {Utils.bytesToString(info.totalShuffleWrite)}
       </td>
+      {if (SparkHadoopUtil.get.isYarnMode) <td>
+        {if (info.logLocation == NoLogs)
+          <span>&#9940;</span>
+        else
+          <a href={info.logLocation}>&#9654;</a>
+        }
+      </td>}
     </tr>
   }
 
@@ -157,6 +164,7 @@ private[ui] class ExecutorsPage(parent: ExecutorsTab) extends WebUIPage("") {
     val totalInputBytes = listener.executorToInputBytes.getOrElse(execId, 0L)
     val totalShuffleRead = listener.executorToShuffleRead.getOrElse(execId, 0L)
     val totalShuffleWrite = listener.executorToShuffleWrite.getOrElse(execId, 0L)
+    val logLocation = parent.executorToLogLocation.getOrElse(execId, NoLogs)
 
     new ExecutorSummaryInfo(
       execId,
@@ -172,7 +180,8 @@ private[ui] class ExecutorsPage(parent: ExecutorsTab) extends WebUIPage("") {
       totalInputBytes,
       totalShuffleRead,
       totalShuffleWrite,
-      maxMem
+      maxMem,
+      logLocation
     )
   }
 }

--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsPage.scala
@@ -72,7 +72,14 @@ private[ui] class ExecutorsPage(parent: ExecutorsTab) extends WebUIPage("") {
           <th>Task Time</th>
           <th><span data-toggle="tooltip" title={ToolTips.INPUT}>Input</span></th>
           <th><span data-toggle="tooltip" title={ToolTips.SHUFFLE_READ}>Shuffle Read</span></th>
-          <th><span data-toggle="tooltip" title={ToolTips.SHUFFLE_WRITE}>Shuffle Write</span></th>
+          <th>
+            <!-- Place the shuffle write tooltip on the left (rather than the default position
+              of on top) because the shuffle write column is the last column on the right side and
+              the tooltip is wider than the column, so it doesn't fit on top. -->
+            <span data-toggle="tooltip" data-placement="left" title={ToolTips.SHUFFLE_WRITE}>
+              Shuffle Write
+            </span>
+          </th>
           {if (SparkHadoopUtil.get.isYarnMode)
             <th>Logs</th>
           }
@@ -103,6 +110,7 @@ private[ui] class ExecutorsPage(parent: ExecutorsTab) extends WebUIPage("") {
       parent.headerTabs, parent)
   }
 
+  // The log location string used when the log location is unknown
   private val NoLogs = "-none-"
 
   /** Render an HTML row representing an executor */
@@ -139,9 +147,9 @@ private[ui] class ExecutorsPage(parent: ExecutorsTab) extends WebUIPage("") {
       </td>
       {if (SparkHadoopUtil.get.isYarnMode) <td>
         {if (info.logLocation == NoLogs)
-          <span>&#9940;</span>
+          <span>&#9940;</span>  // Unicode "do not enter" sign
         else
-          <a href={info.logLocation}>&#9654;</a>
+          <a href={info.logLocation}>&#9654;</a>  // Unicode right black triangle
         }
       </td>}
     </tr>

--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsTab.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsTab.scala
@@ -25,7 +25,7 @@ import org.apache.spark.scheduler._
 import org.apache.spark.storage.StorageStatusListener
 import org.apache.spark.ui.{SparkUI, WebUITab}
 
-class ExecutorsTab(parent: SparkUI) extends WebUITab(parent, "executors") {
+private[ui] class ExecutorsTab(parent: SparkUI) extends WebUITab(parent, "executors") {
   val appName = parent.appName
   val basePath = parent.basePath
   val listener = new ExecutorsListener(parent.storageStatusListener)

--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsTab.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsTab.scala
@@ -35,6 +35,7 @@ private[ui] class ExecutorsTab(parent: SparkUI) extends WebUITab(parent, "execut
   attachPage(new ExecutorsPage(this))
   parent.registerListener(listener)
 
+  /** Update the location of an executor's logs. */
   def updateExecutorLogLocation(executorId: String, logs: String) = synchronized {
     val eid = parent.storageStatusListener.formatExecutorId(executorId)
     executorToLogLocation(eid) = logs

--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsTab.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsTab.scala
@@ -25,13 +25,20 @@ import org.apache.spark.scheduler._
 import org.apache.spark.storage.StorageStatusListener
 import org.apache.spark.ui.{SparkUI, WebUITab}
 
-private[ui] class ExecutorsTab(parent: SparkUI) extends WebUITab(parent, "executors") {
+class ExecutorsTab(parent: SparkUI) extends WebUITab(parent, "executors") {
   val appName = parent.appName
   val basePath = parent.basePath
   val listener = new ExecutorsListener(parent.storageStatusListener)
 
+  val executorToLogLocation = HashMap[String, String]()
+
   attachPage(new ExecutorsPage(this))
   parent.registerListener(listener)
+
+  def updateExecutorLogLocation(executorId: String, logs: String) = synchronized {
+    val eid = parent.storageStatusListener.formatExecutorId(executorId)
+    executorToLogLocation(eid) = logs
+  }
 }
 
 /**

--- a/yarn/stable/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/stable/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -221,7 +221,8 @@ class ApplicationMaster(args: ApplicationMasterArguments, conf: Configuration,
             appAttemptId,
             args,
             sparkContext.preferredNodeLocationData,
-            sparkContext.getConf)
+            sparkContext.getConf,
+            sparkContext.ui)
         } else {
           logWarning("Unable to retrieve SparkContext in spite of waiting for %d, maxNumTries = %d".
             format(numTries * waitTime, maxNumTries))
@@ -230,7 +231,8 @@ class ApplicationMaster(args: ApplicationMasterArguments, conf: Configuration,
             amClient,
             appAttemptId,
             args,
-            sparkContext.getConf)
+            sparkContext.getConf,
+            sparkContext.ui)
         }
       }
     } finally {

--- a/yarn/stable/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/stable/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -222,6 +222,7 @@ class ApplicationMaster(args: ApplicationMasterArguments, conf: Configuration,
             args,
             sparkContext.preferredNodeLocationData,
             sparkContext.getConf,
+            sparkContext.sparkUser,
             sparkContext.ui)
         } else {
           logWarning("Unable to retrieve SparkContext in spite of waiting for %d, maxNumTries = %d".
@@ -232,6 +233,7 @@ class ApplicationMaster(args: ApplicationMasterArguments, conf: Configuration,
             appAttemptId,
             args,
             sparkContext.getConf,
+            sparkContext.sparkUser,
             sparkContext.ui)
         }
       }

--- a/yarn/stable/src/main/scala/org/apache/spark/deploy/yarn/ExecutorLauncher.scala
+++ b/yarn/stable/src/main/scala/org/apache/spark/deploy/yarn/ExecutorLauncher.scala
@@ -187,6 +187,7 @@ class ExecutorLauncher(args: ApplicationMasterArguments, conf: Configuration, sp
       args,
       preferredNodeLocationData,
       sparkConf,
+      "tbd",
       null)
 
     logInfo("Requesting " + args.numExecutors + " executors.")

--- a/yarn/stable/src/main/scala/org/apache/spark/deploy/yarn/ExecutorLauncher.scala
+++ b/yarn/stable/src/main/scala/org/apache/spark/deploy/yarn/ExecutorLauncher.scala
@@ -186,7 +186,8 @@ class ExecutorLauncher(args: ApplicationMasterArguments, conf: Configuration, sp
       appAttemptId,
       args,
       preferredNodeLocationData,
-      sparkConf)
+      sparkConf,
+      null)
 
     logInfo("Requesting " + args.numExecutors + " executors.")
     // Wait until all containers have launched

--- a/yarn/stable/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocationHandler.scala
+++ b/yarn/stable/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocationHandler.scala
@@ -122,6 +122,7 @@ private[yarn] class YarnAllocationHandler(
     amClient.releaseAssignedContainer(containerId)
   }
 
+  /** Build the URL for a container's log location. */
   def buildLogLocation(container: Container) =
     "http://%s/node/containerlogs/%s/%s".format(container.getNodeHttpAddress(),
                                                 ConverterUtils.toString(container.getId()),
@@ -293,6 +294,7 @@ private[yarn] class YarnAllocationHandler(
             }
           }
 
+          // If a UI is available, update it with this container's log location.
           if (sparkUi != null) {
             val logLocation = buildLogLocation(container)
             logInfo("Updating log location for %s to %s".format(


### PR DESCRIPTION
This adds a new column in the Executors page of the Spark UI called "Logs", visible only when running under YARN. After getting a container for an executor, the YarnAllocationHandler informs the UI of where its logs reside, so that a link can be presented in the Logs column for it.

Current issues / limitations:
- This only works running with yarn-cluster, not yarn-client.
- The mechanism for getting the log URL through to the UI is different than the usual way information gets there (via SparkListeners). There may be a better, more decoupled way to do it.

![screen shot 2014-07-10 at 4 36 28 pm](https://cloud.githubusercontent.com/assets/1541206/3557128/006f6ea2-092c-11e4-8125-5c2c3a158068.png)
