### PR TITLE
[SPARK-2457] Inconsistent description in README about build option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ versions without YARN, use:
     $ sbt/sbt -Dhadoop.version=2.0.0-mr1-cdh4.2.0 assembly
 
 For Apache Hadoop 2.2.X, 2.1.X, 2.0.X, 0.23.x, Cloudera CDH MRv2, and other Hadoop versions
-with YARN, also set `SPARK_YARN=true`:
+with YARN, also set `-Pyarn`:
 
     # Apache Hadoop 2.0.5-alpha
     $ sbt/sbt -Dhadoop.version=2.0.5-alpha -Pyarn assembly


### PR DESCRIPTION
Now, we should use -Pyarn instead of SPARK_YARN when building but README says as follows.

```
For Apache Hadoop 2.2.X, 2.1.X, 2.0.X, 0.23.x, Cloudera CDH MRv2, and other Hadoop versions
with YARN, also set `SPARK_YARN=true`:

  # Apache Hadoop 2.0.5-alpha
  $ sbt/sbt -Dhadoop.version=2.0.5-alpha -Pyarn assembly

  # Cloudera CDH 4.2.0 with MapReduce v2
  $ sbt/sbt -Dhadoop.version=2.0.0-cdh4.2.0 -Pyarn assembly

  # Apache Hadoop 2.2.X and newer
  $ sbt/sbt -Dhadoop.version=2.2.0 -Pyarn assembly
```
