### PR TITLE
[SPARK-1667] Jobs never finish successfully once bucket file missing occurred

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/AkkaUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/AkkaUtils.scala
@@ -99,8 +99,6 @@ private[spark] object AkkaUtils extends Logging {
       |akka.remote.log-remote-lifecycle-events = $lifecycleEvents
       |akka.log-dead-letters = $lifecycleEvents
       |akka.log-dead-letters-during-shutdown = $lifecycleEvents
-      |akka.actor.debug.recieve on
-      |akka.loglevel "DEBUG"
       """.stripMargin))
 
     val actorSystem = ActorSystem(name, akkaConf)

--- a/core/src/main/scala/org/apache/spark/util/AkkaUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/AkkaUtils.scala
@@ -99,6 +99,8 @@ private[spark] object AkkaUtils extends Logging {
       |akka.remote.log-remote-lifecycle-events = $lifecycleEvents
       |akka.log-dead-letters = $lifecycleEvents
       |akka.log-dead-letters-during-shutdown = $lifecycleEvents
+      |akka.actor.debug.recieve on
+      |akka.loglevel "DEBUG"
       """.stripMargin))
 
     val actorSystem = ActorSystem(name, akkaConf)

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1223,6 +1223,8 @@ private[spark] object Utils extends Logging {
   /** Returns true if the given exception was fatal. See docs for scala.util.control.NonFatal. */
   def isFatalError(e: Throwable): Boolean = {
     e match {
+      case _: IOException =>
+        true
       case NonFatal(_) | _: InterruptedException | _: NotImplementedError | _: ControlThrowable =>
         false
       case _ =>


### PR DESCRIPTION
If jobs execute shuffle, bucket files are created in a temporary directory (named like spark-local-*).
When the bucket files are missing cased by disk failure or any reasons, jobs cannot execute shuffle which has same shuffle id for the bucket files.

I think when Executors cannot read bucket files from their local directory (spark-local-*), they should abort and marked as lost.
In this case, Executor which has bucket files throw FileNotFoundException, so I think, we should handle IOException as fatal in Utils.scala to abort.

After I modified the code as follows, an Executor which fetches bucket files from failed Executor could retry to fetch from another Executor.

```
def isFatalError(e: Throwable): Boolean = {                                                                                                                 
  e match {                                                                                                                                                 
    case _: IOException =>                                                                                                                                  
      true                                                                                                                                                  
    case NonFatal(_) | _: InterruptedException | _: NotImplementedError | _: ControlThrowable =>                                                            
      false                                                                                                                                                 
    case _ =>                                                                                                                                               
      true                                                                                                                                                  
  }                                                                                                                                                           
}  
```
