### PR TITLE
SPARK-2462.  Make Vector.apply public.

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
@@ -62,7 +62,7 @@ trait Vector extends Serializable {
    * Gets the value of the ith element.
    * @param i index
    */
-  private[mllib] def apply(i: Int): Double = toBreeze(i)
+  def apply(i: Int): Double = toBreeze(i)
 }
 
 /**


### PR DESCRIPTION
Apologies if there's an already-discussed reason I missed for why this doesn't make sense.
