### PR TITLE
SPARK-2465. Use long as user / item ID for ALS

### DIFF
--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaALS.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaALS.java
@@ -42,8 +42,8 @@ public final class JavaALS {
     @Override
     public Rating call(String line) {
       String[] tok = COMMA.split(line);
-      int x = Integer.parseInt(tok[0]);
-      int y = Integer.parseInt(tok[1]);
+      long x = Long.parseLong(tok[0]);
+      long y = Long.parseLong(tok[1]);
       double rating = Double.parseDouble(tok[2]);
       return new Rating(x, y, rating);
     }

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/MovieLensALS.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/MovieLensALS.scala
@@ -187,7 +187,7 @@ object MovieLensALS {
 
     def mapPredictedRating(r: Double) = if (implicitPrefs) math.max(math.min(r, 1.0), 0.0) else r
 
-    val predictions: RDD[Rating] = model.predict(data.map(x => (x.user, x.product)))
+    val predictions: RDD[Rating] = model.predictRDD(data.map(x => (x.user, x.product)))
     val predictionsAndRatings = predictions.map{ x =>
       ((x.user, x.product), mapPredictedRating(x.rating))
     }.join(data.map(x => ((x.user, x.product), x.rating))).values

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/MovieLensALS.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/MovieLensALS.scala
@@ -133,9 +133,9 @@ object MovieLensALS {
          * The semantics of 0 in this expanded world of non-positive weights
          * are "the same as never having interacted at all".
          */
-        Rating(fields(0).toInt, fields(1).toInt, fields(2).toDouble - 2.5)
+        Rating(fields(0).toLong, fields(1).toLong, fields(2).toDouble - 2.5)
       } else {
-        Rating(fields(0).toInt, fields(1).toInt, fields(2).toDouble)
+        Rating(fields(0).toLong, fields(1).toLong, fields(2).toDouble)
       }
     }.cache()
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
@@ -363,18 +363,18 @@ class PythonMLLibAPI extends Serializable {
   private def unpackRating(ratingBytes: Array[Byte]): Rating = {
     val bb = ByteBuffer.wrap(ratingBytes)
     bb.order(ByteOrder.nativeOrder())
-    val user = bb.getInt()
-    val product = bb.getInt()
+    val user = bb.getLong()
+    val product = bb.getLong()
     val rating = bb.getDouble()
     new Rating(user, product, rating)
   }
 
-  /** Unpack a tuple of Ints from an array of bytes */
-  private[spark] def unpackTuple(tupleBytes: Array[Byte]): (Int, Int) = {
+  /** Unpack a tuple of Longs from an array of bytes */
+  private[spark] def unpackTuple(tupleBytes: Array[Byte]): (Long, Long) = {
     val bb = ByteBuffer.wrap(tupleBytes)
     bb.order(ByteOrder.nativeOrder())
-    val v1 = bb.getInt()
-    val v2 = bb.getInt()
+    val v1 = bb.getLong()
+    val v2 = bb.getLong()
     (v1, v2)
   }
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/recommendation/MatrixFactorizationModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/recommendation/MatrixFactorizationModel.scala
@@ -36,10 +36,10 @@ import org.apache.spark.mllib.api.python.PythonMLLibAPI
  */
 class MatrixFactorizationModel private[mllib] (
     val rank: Int,
-    val userFeatures: RDD[(Int, Array[Double])],
-    val productFeatures: RDD[(Int, Array[Double])]) extends Serializable {
+    val userFeatures: RDD[(Long, Array[Double])],
+    val productFeatures: RDD[(Long, Array[Double])]) extends Serializable {
   /** Predict the rating of one user for one product. */
-  def predict(user: Int, product: Int): Double = {
+  def predict(user: Long, product: Long): Double = {
     val userVector = new DoubleMatrix(userFeatures.lookup(user).head)
     val productVector = new DoubleMatrix(productFeatures.lookup(product).head)
     userVector.dot(productVector)
@@ -53,7 +53,7 @@ class MatrixFactorizationModel private[mllib] (
     * @param usersProducts  RDD of (user, product) pairs.
     * @return RDD of Ratings.
     */
-  def predict(usersProducts: RDD[(Int, Int)]): RDD[Rating] = {
+  def predict(usersProducts: RDD[(Long, Long)]): RDD[Rating] = {
     val users = userFeatures.join(usersProducts).map{
       case (user, (uFeatures, product)) => (product, (user, uFeatures))
     }

--- a/mllib/src/test/java/org/apache/spark/mllib/recommendation/JavaALSSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/recommendation/JavaALSSuite.java
@@ -50,7 +50,7 @@ public class JavaALSSuite implements Serializable {
     List<scala.Tuple2<Object, double[]>> userFeatures = model.userFeatures().toJavaRDD().collect();
     for (int i = 0; i < features; ++i) {
       for (scala.Tuple2<Object, double[]> userFeature : userFeatures) {
-        predictedU.put((Integer)userFeature._1(), i, userFeature._2()[i]);
+        predictedU.put(((Number) userFeature._1()).intValue(), i, userFeature._2()[i]);
       }
     }
     DoubleMatrix predictedP = new DoubleMatrix(products, features);
@@ -59,7 +59,7 @@ public class JavaALSSuite implements Serializable {
       model.productFeatures().toJavaRDD().collect();
     for (int i = 0; i < features; ++i) {
       for (scala.Tuple2<Object, double[]> productFeature : productFeatures) {
-        predictedP.put((Integer)productFeature._1(), i, productFeature._2()[i]);
+        predictedP.put(((Number) productFeature._1()).intValue(), i, productFeature._2()[i]);
       }
     }
 

--- a/mllib/src/test/scala/org/apache/spark/mllib/recommendation/ALSSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/recommendation/ALSSuite.scala
@@ -146,7 +146,7 @@ class ALSSuite extends FunSuite with LocalSparkContext {
     val model = ALS.train(ratings, 5, 15)
 
     val pairs = Array.tabulate(50, 50)((u, p) => (u - 25L, p - 25L)).flatten
-    val ans = model.predict(sc.parallelize(pairs)).collect()
+    val ans = model.predictRDD(sc.parallelize(pairs)).collect()
     ans.foreach { r =>
       val u = r.user + 25
       val p = r.product + 25
@@ -219,7 +219,7 @@ class ALSSuite extends FunSuite with LocalSparkContext {
         val usersProducts =
           for (u <- 0 until users; p <- 0 until products) yield (u.toLong, p.toLong)
         val userProductsRDD = sc.parallelize(usersProducts)
-        model.predict(userProductsRDD).collect().foreach { elem =>
+        model.predictRDD(userProductsRDD).collect().foreach { elem =>
           allRatings.put(elem.user.toInt, elem.product.toInt, elem.rating)
         }
         allRatings

--- a/mllib/src/test/scala/org/apache/spark/mllib/recommendation/ALSSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/recommendation/ALSSuite.scala
@@ -145,13 +145,13 @@ class ALSSuite extends FunSuite with LocalSparkContext {
     val correct = data._2
     val model = ALS.train(ratings, 5, 15)
 
-    val pairs = Array.tabulate(50, 50)((u, p) => (u - 25, p - 25)).flatten
+    val pairs = Array.tabulate(50, 50)((u, p) => (u - 25L, p - 25L)).flatten
     val ans = model.predict(sc.parallelize(pairs)).collect()
     ans.foreach { r =>
       val u = r.user + 25
       val p = r.product + 25
       val v = r.rating
-      val error = v - correct.get(u, p)
+      val error = v - correct.get(u.toInt, p.toInt)
       assert(math.abs(error) < 0.4)
     }
   }
@@ -170,7 +170,7 @@ class ALSSuite extends FunSuite with LocalSparkContext {
    * @param samplingRate what fraction of the user-product pairs are known
    * @param matchThreshold max difference allowed to consider a predicted rating correct
    * @param implicitPrefs flag to test implicit feedback
-   * @param bulkPredict flag to test bulk prediciton
+   * @param bulkPredict flag to test bulk prediction
    * @param negativeWeights whether the generated data can contain negative values
    * @param numUserBlocks number of user blocks to partition users into
    * @param numProductBlocks number of product blocks to partition products into
@@ -206,20 +206,21 @@ class ALSSuite extends FunSuite with LocalSparkContext {
 
     val predictedU = new DoubleMatrix(users, features)
     for ((u, vec) <- model.userFeatures.collect(); i <- 0 until features) {
-      predictedU.put(u, i, vec(i))
+      predictedU.put(u.toInt, i, vec(i))
     }
     val predictedP = new DoubleMatrix(products, features)
     for ((p, vec) <- model.productFeatures.collect(); i <- 0 until features) {
-      predictedP.put(p, i, vec(i))
+      predictedP.put(p.toInt, i, vec(i))
     }
     val predictedRatings = bulkPredict match {
       case false => predictedU.mmul(predictedP.transpose)
       case true =>
         val allRatings = new DoubleMatrix(users, products)
-        val usersProducts = for (u <- 0 until users; p <- 0 until products) yield (u, p)
+        val usersProducts =
+          for (u <- 0 until users; p <- 0 until products) yield (u.toLong, p.toLong)
         val userProductsRDD = sc.parallelize(usersProducts)
         model.predict(userProductsRDD).collect().foreach { elem =>
-          allRatings.put(elem.user, elem.product, elem.rating)
+          allRatings.put(elem.user.toInt, elem.product.toInt, elem.rating)
         }
         allRatings
     }
@@ -248,8 +249,11 @@ class ALSSuite extends FunSuite with LocalSparkContext {
       }
       val rmse = math.sqrt(sqErr / denom)
       if (rmse > matchThreshold) {
-        fail("Model failed to predict RMSE: %f\ncorr: %s\npred: %s\nU: %s\n P: %s".format(
-          rmse, truePrefs, predictedRatings, predictedU, predictedP))
+        fail(s"""Model failed to predict RMSE: $rmse\n
+                 |corr: $truePrefs\n
+                 |pred: $predictedRatings\n
+                 |U: $predictedU\n
+                 |P: $predictedP""".stripMargin)
       }
     }
   }

--- a/python/pyspark/mllib/_common.py
+++ b/python/pyspark/mllib/_common.py
@@ -374,10 +374,10 @@ def _regression_train_wrapper(sc, train_func, klass, data, initial_weights):
 # Functions for serializing ALS Rating objects and tuples
 
 def _serialize_rating(r):
-    ba = bytearray(16)
-    intpart = ndarray(shape=[2], buffer=ba, dtype=int32)
-    doublepart = ndarray(shape=[1], buffer=ba, dtype=float64, offset=8)
-    intpart[0], intpart[1], doublepart[0] = r
+    ba = bytearray(24)
+    longpart = ndarray(shape=[2], buffer=ba, dtype=int64)
+    doublepart = ndarray(shape=[1], buffer=ba, dtype=float64, offset=16)
+    longpart[0], longpart[1], doublepart[0] = r
     return ba
 
 
@@ -399,9 +399,9 @@ class RatingDeserializer(Serializer):
 
 
 def _serialize_tuple(t):
-    ba = bytearray(8)
-    intpart = ndarray(shape=[2], buffer=ba, dtype=int32)
-    intpart[0], intpart[1] = t
+    ba = bytearray(16)
+    longpart = ndarray(shape=[2], buffer=ba, dtype=int64)
+    longpart[0], longpart[1] = t
     return ba
 
 


### PR DESCRIPTION
I'd like to float this for consideration: use longs instead of ints for user and product IDs in the ALS implementation.

The main reason for is that identifiers are not generally numeric at all, and will be hashed to an integer. (This is a separate issue.) Hashing to 32 bits means collisions are likely after hundreds of thousands of users and items, which is not unrealistic. Hashing to 64 bits pushes this back to billions.

It would also mean numeric IDs that happen to be larger than the largest int can be used directly as identifiers.

On the downside of course: 8 bytes instead of 4 bytes of memory used per Rating.

Thoughts?
