### PR TITLE
[SPARK-2471] remove runtime scope for jets3t

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -609,7 +609,6 @@
         <groupId>net.java.dev.jets3t</groupId>
         <artifactId>jets3t</artifactId>
         <version>${jets3t.version}</version>
-        <scope>runtime</scope>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>


### PR DESCRIPTION
The assembly jar (built by sbt) doesn't include jets3t if we set it to runtime only, but I don't know whether it was set this way for a particular reason.

CC: @srowen @ScrapCodes
