### PR TITLE
SPARK-2486: Utils.getCallSite is now resilient to bogus frames

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -811,9 +811,9 @@ private[spark] object Utils extends Logging {
     val trace = Thread.currentThread.getStackTrace()
       .filterNot((ste:StackTraceElement) => 
         // When running under some profilers, the current stack trace might contain some bogus 
-        // frames. This Try is intended to ensure that we don't crash in these situations by
+        // frames. This is intended to ensure that we don't crash in these situations by
         // ignoring any frames that we can't examine.
-        Try(ste.getMethodName.contains("getStackTrace")).getOrElse(true))
+        (ste == null || ste.getMethodName == null || ste.getMethodName.contains("getStackTrace")))
 
     // Keep crawling up the stack trace until we find the first function not inside of the spark
     // package. We track the last (shallowest) contiguous Spark method. This might be an RDD

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -809,7 +809,11 @@ private[spark] object Utils extends Logging {
    */
   def getCallSite: CallSite = {
     val trace = Thread.currentThread.getStackTrace()
-      .filterNot(_.getMethodName.contains("getStackTrace"))
+      .filterNot((ste:StackTraceElement) => 
+        // When running under some profilers, the current stack trace might contain some bogus 
+        // frames. This Try is intended to ensure that we don't crash in these situations by
+        // ignoring any frames that we can't examine.
+        Try(ste.getMethodName.contains("getStackTrace")).getOrElse(true))
 
     // Keep crawling up the stack trace until we find the first function not inside of the spark
     // package. We track the last (shallowest) contiguous Spark method. This might be an RDD


### PR DESCRIPTION
When running Spark under certain instrumenting profilers,
Utils.getCallSite could crash with an NPE.  This commit
makes it more resilient to failures occurring while inspecting
stack frames.
