### PR TITLE
[SPARK-2492][Streaming] kafkaReceiver minor changes to align with Kafka 0.8

### DIFF
--- a/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaInputDStream.scala
+++ b/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaInputDStream.scala
@@ -95,7 +95,7 @@ class KafkaReceiver[
     consumerConnector = Consumer.create(consumerConfig)
     logInfo("Connected to " + zkConnect)
 
-    val keyDecoder = manifest[U].runtimeClass.getConstructor(classOf[VerifiableProperties])
+    val keyDecoder = classTag[U].runtimeClass.getConstructor(classOf[VerifiableProperties])
       .newInstance(consumerConfig.props)
       .asInstanceOf[Decoder[K]]
     val valueDecoder = classTag[T].runtimeClass.getConstructor(classOf[VerifiableProperties])

--- a/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaUtils.scala
+++ b/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaUtils.scala
@@ -17,21 +17,18 @@
 
 package org.apache.spark.streaming.kafka
 
+import java.lang.{Integer => JInt}
+import java.util.{Map => JMap}
 
 import scala.reflect.ClassTag
 import scala.collection.JavaConversions._
 
-import java.lang.{Integer => JInt}
-import java.util.{Map => JMap}
-
 import kafka.serializer.{Decoder, StringDecoder}
-import kafka.utils.ZkUtils
 
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming.StreamingContext
 import org.apache.spark.streaming.api.java.{JavaPairReceiverInputDStream, JavaStreamingContext}
 import org.apache.spark.streaming.dstream.ReceiverInputDStream
-
 
 object KafkaUtils {
   /**
@@ -146,24 +143,5 @@ object KafkaUtils {
 
     createStream[K, V, U, T](
       jssc.ssc, kafkaParams.toMap, Map(topics.mapValues(_.intValue()).toSeq: _*), storageLevel)
-  }
-
-  /**
-   * Delete the consumer group related Zookeeper metadata immediately,
-   * force consumer to ignore previous consumer offset and directly read data from the beginning
-   * or end of the partition. The behavior of reading data from the beginning or end of the
-   * partition also relies on kafka parameter 'auto.offset.reset':
-   * When 'auto.offset.reset' = 'smallest', directly read data from beginning,
-   * will re-read the whole partition.
-   * When 'auto.offset.reset' = 'largest', directly read data from end, ignore old, unwanted data.
-   * This is default in Kafka 0.8.
-   *
-   * To avoid deleting existing Zookeeper metadata in each Receiver when multiple consumers are
-   * launched, this should be called be createStream().
-   * @param zkQuorum Zookeeper quorum (hostname:port,hostname:port,..).
-   * @param groupId The group id for this consumer.
-   */
-  def resetOffset(zkQuorum: String, groupId: String) {
-    ZkUtils.maybeDeletePath(zkQuorum, s"/consumers/$groupId")
   }
 }

--- a/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaUtils.scala
+++ b/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaUtils.scala
@@ -158,8 +158,8 @@ object KafkaUtils {
    * When 'auto.offset.reset' = 'largest', directly read data from end, ignore old, unwanted data.
    * This is default in Kafka 0.8.
    *
-   * To avoid concurrent deleting Zookeeper metadata in each Receiver when multiple consumers are
-   * launched, this should be call be createStream().
+   * To avoid deleting existing Zookeeper metadata in each Receiver when multiple consumers are
+   * launched, this should be called be createStream().
    * @param zkQuorum Zookeeper quorum (hostname:port,hostname:port,..).
    * @param groupId The group id for this consumer.
    */


### PR DESCRIPTION
Update the KafkaReceiver's behavior when auto.offset.reset is set. 

In Kafka 0.8, `auto.offset.reset` is a hint for out-range offset to seek to the beginning or end of the partition. While in the previous code `auto.offset.reset` is a enforcement to seek to the beginning or end immediately, this is different from Kafka 0.8 defined behavior. 

Also deleting extesting ZK metadata in Receiver when multiple consumers are launched will introduce issue as mentioned in [SPARK-2383](https://issues.apache.org/jira/browse/SPARK-2383).

So Here we change to offer user to API to explicitly reset offset before create Kafka stream, while in the meantime keep the same behavior as Kafka 0.8 for parameter `auto.offset.reset`.

@tdas, would you please review this PR? Thanks a lot.
