### PR TITLE
[SPARK-2506]: In yarn-cluster mode, ApplicationMaster does not clean up corre...

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -65,7 +65,8 @@ class SparkEnv (
     val httpFileServer: HttpFileServer,
     val sparkFilesDir: String,
     val metricsSystem: MetricsSystem,
-    val conf: SparkConf) extends Logging {
+    val conf: SparkConf,
+    val isDriver: Boolean = false) extends Logging {
 
   // A mapping of thread ID to amount of memory used for shuffle in bytes
   // All accesses should be manually synchronized
@@ -78,14 +79,16 @@ class SparkEnv (
   private[spark] val hadoopJobMetadata = new MapMaker().softValues().makeMap[String, Any]()
 
   private[spark] def stop() {
-    pythonWorkers.foreach { case(key, worker) => worker.stop() }
-    Option(httpFileServer).foreach(_.stop())
-    mapOutputTracker.stop()
-    shuffleManager.stop()
-    broadcastManager.stop()
+    if(isDriver) {
+      pythonWorkers.foreach { case(key, worker) => worker.stop() }
+      Option(httpFileServer).foreach(_.stop())
+      mapOutputTracker.stop()
+      shuffleManager.stop()
+      broadcastManager.stop()
+      blockManager.master.stop()
+      metricsSystem.stop()
+    }
     blockManager.stop()
-    blockManager.master.stop()
-    metricsSystem.stop()
     actorSystem.shutdown()
     // Unfortunately Akka's awaitTermination doesn't actually wait for the Netty server to shut
     // down, but let's call it anyway in case it gets fixed in a later release
@@ -278,7 +281,8 @@ object SparkEnv extends Logging {
       httpFileServer,
       sparkFilesDir,
       metricsSystem,
-      conf)
+      conf,
+      isDriver)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -88,6 +88,7 @@ private[spark] class CoarseGrainedExecutorBackend(
 
     case StopExecutor =>
       logInfo("Driver commanded a shutdown")
+      executor.stop()
       context.stop(self)
       context.system.shutdown()
   }

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -341,4 +341,8 @@ private[spark] class Executor(
       }
     }
   }
+
+  def stop() {
+    this.env.stop()
+  }
 }

--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
@@ -135,9 +135,9 @@ class ExternalAppendOnlyMap[K, V, C](
           (shuffleMemoryMap.values.sum - previouslyOccupiedMemory.getOrElse(0L))
 
         // Assume map growth factor is 2x
-        shouldSpill = availableMemory < mapSize * 2
+        shouldSpill = availableMemory < mapSize * SparkEnv.get.conf.get("spark.executor.cores").toInt
         if (!shouldSpill) {
-          shuffleMemoryMap(threadId) = mapSize * 2
+          shuffleMemoryMap(threadId) = mapSize
         }
       }
       // Do not synchronize spills

--- a/yarn/alpha/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocationHandler.scala
+++ b/yarn/alpha/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocationHandler.scala
@@ -22,7 +22,7 @@ import java.util.{Collections, Set => JSet}
 import java.util.concurrent.{CopyOnWriteArrayList, ConcurrentHashMap}
 import java.util.concurrent.atomic.AtomicInteger
 
-import scala.collection
+import scala.{Int, collection}
 import scala.collection.JavaConversions._
 import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet}
 
@@ -93,13 +93,14 @@ private[yarn] class YarnAllocationHandler(
     YarnAllocationHandler.MEMORY_OVERHEAD)
 
   private val numExecutorsRunning = new AtomicInteger()
+  private val numExecutorsFinished = new AtomicInteger()
   // Used to generate a unique id per executor
   private val executorIdCounter = new AtomicInteger()
   private val lastResponseId = new AtomicInteger()
   private val numExecutorsFailed = new AtomicInteger()
 
   def getNumExecutorsRunning: Int = numExecutorsRunning.intValue
-
+  def getNumExecutorsFinished: Int = numExecutorsFinished.intValue
   def getNumExecutorsFailed: Int = numExecutorsFailed.intValue
 
   def isResourceConstraintSatisfied(container: Container): Boolean = {
@@ -308,6 +309,9 @@ private[yarn] class YarnAllocationHandler(
           if (completedContainer.getExitStatus() != 0) {
             logInfo("Container marked as failed: " + containerId)
             numExecutorsFailed.incrementAndGet()
+          } else {
+            logInfo("Container marked as finised successfully: " + containerId)
+            numExecutorsFinished.incrementAndGet()
           }
         }
 

--- a/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnableUtil.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnableUtil.scala
@@ -73,6 +73,8 @@ trait ExecutorRunnableUtil extends Logging {
     sparkConf.getAkkaConf.
       foreach { case (k, v) => javaOpts += "-D" + k + "=" + "\\\"" + v + "\\\"" }
 
+    JAVA_OPTS += "-Dspark.executor.cores" + "=" + "\\\"" + executorCores + "\\\""
+
     // Commenting it out for now - so that people can refer to the properties if required. Remove
     // it once cpuset version is pushed out.
     // The context is, default gc for server class machines end up using all cores to do gc - hence

--- a/yarn/stable/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/stable/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -269,7 +269,7 @@ class ApplicationMaster(args: ApplicationMasterArguments, conf: Configuration,
 
   private def allocateMissingExecutor() {
     val missingExecutorCount = args.numExecutors - yarnAllocator.getNumExecutorsRunning -
-      yarnAllocator.getNumPendingAllocate
+      yarnAllocator.getNumPendingAllocate - yarnAllocator.getNumExecutorsFinished
     if (missingExecutorCount > 0) {
       logInfo("Allocating %d containers to make up for (potentially) lost containers".
         format(missingExecutorCount))

--- a/yarn/stable/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocationHandler.scala
+++ b/yarn/stable/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocationHandler.scala
@@ -98,15 +98,15 @@ private[yarn] class YarnAllocationHandler(
   // ApplicationMaster.
   private val numPendingAllocate = new AtomicInteger()
   private val numExecutorsRunning = new AtomicInteger()
+  private val numExecutorsFinished = new AtomicInteger()
   // Used to generate a unique id per executor
   private val executorIdCounter = new AtomicInteger()
   private val lastResponseId = new AtomicInteger()
   private val numExecutorsFailed = new AtomicInteger()
 
   def getNumPendingAllocate: Int = numPendingAllocate.intValue
-
+  def getNumExecutorsFinished: Int = numExecutorsFinished.intValue
   def getNumExecutorsRunning: Int = numExecutorsRunning.intValue
-
   def getNumExecutorsFailed: Int = numExecutorsFailed.intValue
 
   def isResourceConstraintSatisfied(container: Container): Boolean = {
@@ -336,6 +336,9 @@ private[yarn] class YarnAllocationHandler(
           if (completedContainer.getExitStatus() != 0) {
             logInfo("Container marked as failed: " + containerId)
             numExecutorsFailed.incrementAndGet()
+          } else {
+            logInfo("Container marked as finised successfully: " + containerId)
+            numExecutorsFinished.incrementAndGet()
           }
         }
 


### PR DESCRIPTION
...ctly at the end of the job if users call sc.stop manually. There are two minor bugs:
1. At the end of a job, "ApplicationMaster" will ask for resources and launch containers repeatedly. These newly launched containers keep trying to contact with the already-stopped driver and fianally fail. When the container failure number reaches the max value, this job's FinalStatus wil be marked as FAILED.
2.  After the driver asks to stop executors, "BlockManager" of executors will try to contact  the already-stoppped "BlockManagerMasterActor" of the driver. Unfortunately, all the connecting attempts will fail, and then the executor process will crash with a non-zero Exit Code.
