### PR TITLE
[SPARK-2555] Support configuration spark.scheduler.minRegisteredResourcesRatio in Mesos mode.

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
@@ -63,6 +63,8 @@ private[spark] class CoarseMesosSchedulerBackend(
   // Maximum number of cores to acquire (TODO: we'll need more flexible controls here)
   val maxCores = conf.get("spark.cores.max",  Int.MaxValue.toString).toInt
 
+  val totalExpectedCores = conf.getInt("spark.cores.max", 0)
+
   // Cores we have acquired with each Mesos task ID
   val coresByTaskId = new HashMap[Int, Int]
   var totalCoresAcquired = 0
@@ -333,4 +335,7 @@ private[spark] class CoarseMesosSchedulerBackend(
       super.applicationId
     }
 
+  override def sufficientResourcesRegistered(): Boolean = {
+    totalCoreCount.get() >= totalExpectedCores * minRegisteredRatio
+  }
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
@@ -69,6 +69,11 @@ private[spark] class MesosSchedulerBackend(
   val listenerBus = sc.listenerBus
 
   @volatile var appId: String = _
+  
+  if (!sc.getConf.getOption("spark.scheduler.minRegisteredResourcesRatio").isEmpty) {
+    logWarning("spark.scheduler.minRegisteredResourcesRatio is set, "
+      + "but it will be ignored in mesos fine-grained mode.")
+  }
 
   override def start() {
     synchronized {

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
@@ -70,7 +70,7 @@ private[spark] class MesosSchedulerBackend(
 
   @volatile var appId: String = _
   
-  if (!sc.getConf.getOption("spark.scheduler.minRegisteredResourcesRatio").isEmpty) {
+  if (sc.conf.contains("spark.scheduler.minRegisteredResourcesRatio")) {
     logWarning("spark.scheduler.minRegisteredResourcesRatio is set, "
       + "but it will be ignored in mesos fine-grained mode.")
   }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1021,7 +1021,7 @@ Apart from these, the following properties are also available, and may be useful
   <td>0.0 for Mesos and Standalone mode, 0.8 for YARN</td>
   <td>
     The minimum ratio of registered resources (registered resources / total expected resources)
-    (resources are executors in yarn mode, CPU cores in standalone mode)
+    (resources are executors in yarn mode, CPU cores in standalone mode and coarse-grained mesos mode)
     to wait for before scheduling begins. Specified as a double between 0.0 and 1.0.
     Regardless of whether the minimum ratio of resources has been reached,
     the maximum amount of time it will wait before scheduling begins is controlled by config

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1018,7 +1018,7 @@ Apart from these, the following properties are also available, and may be useful
 </tr>
 <tr>
   <td><code>spark.scheduler.minRegisteredResourcesRatio</code></td>
-  <td>0.0 for Mesos and Standalone mode, 0.8 for YARN</td>
+  <td>0.0 for coarse-grained Mesos and Standalone mode, 0.8 for YARN</td>
   <td>
     The minimum ratio of registered resources (registered resources / total expected resources)
     (resources are executors in yarn mode, CPU cores in standalone mode and coarse-grained mesos mode)


### PR DESCRIPTION
In SPARK-1946(PR #900), configuration <code>spark.scheduler.minRegisteredExecutorsRatio</code> was introduced(and it was renamed <code>spark.scheduler.minRegisteredResourcesRatio</code> in PR #1525), but it only support Standalone and Yarn mode.
This PR try to introduce the configuration to Mesos mode.

In Mesos coarse-grained mode, the configuration is work well.
In Mesos fine-grained mode, the configuration is ignored because executors are dynamic, and SchedulerBackend will print a warning log if the configuration is set.
