### PR TITLE
SPARK-1215 [MLLIB]: Clustering: Index out of bounds error (2)

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LocalKMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LocalKMeans.scala
@@ -59,6 +59,11 @@ private[mllib] object LocalKMeans extends Logging {
         cumulativeScore += weights(j) * KMeans.pointCost(curCenters, points(j))
         j += 1
       }
+      if (j == 0) {
+        logWarning("kMeansPlusPlus initialization ran out of distinct points for centers." +
+          s" Using duplicate point for center k = $i.")
+        j = 1
+      }
       centers(i) = points(j-1).toDense
     }
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LocalKMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LocalKMeans.scala
@@ -62,9 +62,10 @@ private[mllib] object LocalKMeans extends Logging {
       if (j == 0) {
         logWarning("kMeansPlusPlus initialization ran out of distinct points for centers." +
           s" Using duplicate point for center k = $i.")
-        j = 1
+        centers(i) = points(0).toDense
+      } else {
+        centers(i) = points(j - 1).toDense
       }
-      centers(i) = points(j-1).toDense
     }
 
     // Run up to maxIterations iterations of Lloyd's algorithm

--- a/mllib/src/test/scala/org/apache/spark/mllib/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/clustering/KMeansSuite.scala
@@ -61,6 +61,30 @@ class KMeansSuite extends FunSuite with LocalSparkContext {
     assert(model.clusterCenters.head === center)
   }
 
+  test("no distinct points") {
+    val data = sc.parallelize(Array(
+      Vectors.dense(1.0, 2.0, 3.0),
+      Vectors.dense(1.0, 2.0, 3.0),
+      Vectors.dense(1.0, 2.0, 3.0)
+    ))
+    val center = Vectors.dense(1.0, 2.0, 3.0)
+
+    // Make sure code runs.
+    var model = KMeans.train(data, k=2, maxIterations=1)
+    assert(model.clusterCenters.size === 2)
+  }
+
+  test("more clusters than points") {
+    val data = sc.parallelize(Array(
+      Vectors.dense(1.0, 2.0, 3.0),
+      Vectors.dense(1.0, 3.0, 4.0)
+    ))
+
+    // Make sure code runs.
+    var model = KMeans.train(data, k=3, maxIterations=1)
+    assert(model.clusterCenters.size === 3)
+  }
+
   test("single cluster with big dataset") {
     val smallData = Array(
       Vectors.dense(1.0, 2.0, 6.0),

--- a/mllib/src/test/scala/org/apache/spark/mllib/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/clustering/KMeansSuite.scala
@@ -62,11 +62,12 @@ class KMeansSuite extends FunSuite with LocalSparkContext {
   }
 
   test("no distinct points") {
-    val data = sc.parallelize(Array(
-      Vectors.dense(1.0, 2.0, 3.0),
-      Vectors.dense(1.0, 2.0, 3.0),
-      Vectors.dense(1.0, 2.0, 3.0)
-    ))
+    val data = sc.parallelize(
+      Array(
+        Vectors.dense(1.0, 2.0, 3.0),
+        Vectors.dense(1.0, 2.0, 3.0),
+        Vectors.dense(1.0, 2.0, 3.0)),
+      2)
     val center = Vectors.dense(1.0, 2.0, 3.0)
 
     // Make sure code runs.
@@ -75,10 +76,11 @@ class KMeansSuite extends FunSuite with LocalSparkContext {
   }
 
   test("more clusters than points") {
-    val data = sc.parallelize(Array(
-      Vectors.dense(1.0, 2.0, 3.0),
-      Vectors.dense(1.0, 3.0, 4.0)
-    ))
+    val data = sc.parallelize(
+      Array(
+        Vectors.dense(1.0, 2.0, 3.0),
+        Vectors.dense(1.0, 3.0, 4.0)),
+      2)
 
     // Make sure code runs.
     var model = KMeans.train(data, k=3, maxIterations=1)


### PR DESCRIPTION
Added check to LocalKMeans.scala: kMeansPlusPlus initialization to handle case with fewer distinct data points than clusters k.  Added two related unit tests to KMeansSuite.  (Re-submitting PR after tangling commits in PR 1407 https://github.com/apache/spark/pull/1407 )
