### PR TITLE
[SPARK-2563] Make connection retries configurable

### DIFF
--- a/core/src/main/scala/org/apache/spark/network/Connection.scala
+++ b/core/src/main/scala/org/apache/spark/network/Connection.scala
@@ -325,8 +325,14 @@ class SendingConnection(val address: InetSocketAddress, selector_ : Selector,
       logInfo("Connected to [" + address + "], " + outbox.messages.size + " messages pending")
     } catch {
       case e: Exception => {
-        logWarning("Error finishing connection to " + address, e)
-        callOnExceptionCallback(e)
+        if (!force) {
+          logWarning("finish connect failed [" + address + "], " + outbox.messages.size +
+            " messages pending", e)
+          return false
+        } else {
+          logWarning("Error finishing connection to " + address, e)
+          callOnExceptionCallback(e)
+        }
       }
     }
     true

--- a/core/src/main/scala/org/apache/spark/network/ConnectionManager.scala
+++ b/core/src/main/scala/org/apache/spark/network/ConnectionManager.scala
@@ -55,6 +55,8 @@ private[spark] class ConnectionManager(port: Int, conf: SparkConf,
 
   private val selector = SelectorProvider.provider.openSelector()
 
+  private val connectionRetries = conf.getInt("spark.core.connection.retries", 10)
+
   // default to 30 second timeout waiting for authentication
   private val authTimeout = conf.getInt("spark.core.connection.auth.wait.timeout", 30)
 
@@ -198,7 +200,7 @@ private[spark] class ConnectionManager(port: Int, conf: SparkConf,
     handleConnectExecutor.execute(new Runnable {
       override def run() {
 
-        var tries: Int = 10
+        var tries: Int = connectionRetries
         while (tries >= 0) {
           if (conn.finishConnect(false)) return
           // Sleep ?

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -755,6 +755,13 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+  <td><code>spark.core.connection.retries</code></td>
+  <td>10</td>
+  <td>
+    Number of connection attempts to make before timing out.
+  </td>
+</tr>
+<tr>
   <td><code>spark.ui.filters</code></td>
   <td>None</td>
   <td>


### PR DESCRIPTION
In a large EC2 cluster, I often see the first shuffle stage in a job fail due to connection timeout exceptions. This patch makes the number of connection retries configurable to handle these cases.
