### PR TITLE
[SPARK-2572] Delete the local dir on executor automatically when using spark on Mesos.

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -90,6 +90,7 @@ private[spark] class CoarseGrainedExecutorBackend(
       logInfo("Driver commanded a shutdown")
       context.stop(self)
       context.system.shutdown()
+      SparkEnv.get.blockManager.diskBlockManager.stop()
   }
 
   override def statusUpdate(taskId: Long, state: TaskState, data: ByteBuffer) {

--- a/core/src/main/scala/org/apache/spark/executor/MesosExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/MesosExecutorBackend.scala
@@ -87,7 +87,7 @@ private[spark] class MesosExecutorBackend
 
   override def frameworkMessage(d: ExecutorDriver, data: Array[Byte]) {}
 
-  override def shutdown(d: ExecutorDriver) {}
+  override def shutdown(d: ExecutorDriver) {SparkEnv.get.blockManager.diskBlockManager.stop()}
 }
 
 /**


### PR DESCRIPTION
When running spark over Mesos in “fine-grained” modes or “coarse-grained” mode. After the application finished.The local dir(/tmp/spark-local-20140718114058-834c) on executor can't not delete automatically.
