### PR TITLE
Fixed the number of worker thread

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -101,8 +101,9 @@ private[spark] class Executor(
   // to send the result back.
   private val akkaFrameSize = AkkaUtils.maxFrameSizeBytes(conf)
 
+  private val nThreads = env.conf.getInt("spark.worker.threads.max", Runtime.getRuntime.availableProcessors())
   // Start worker thread pool
-  val threadPool = Utils.newDaemonCachedThreadPool("Executor task launch worker")
+  val threadPool = Utils.newDaemonFixedThreadPool(nThreads, "Executor task launch worker")
 
   // Maintains the list of running tasks.
   private val runningTasks = new ConcurrentHashMap[Long, TaskRunner]


### PR DESCRIPTION
There are a lot of input Block cause too many Worker threads and will
load all data.So it should be to control the number of Worker threads
