### PR TITLE
SPARK-2587: Fix error message in make-distribution.sh

### DIFF
--- a/make-distribution.sh
+++ b/make-distribution.sh
@@ -58,7 +58,7 @@ while (( "$#" )); do
       exit_with_usage
       ;;
     --with-hive)
-      echo "Error: '--with-hive' is no longer supported, use Maven option -Pyarn"
+      echo "Error: '--with-hive' is no longer supported, use Maven option -Phive"
       exit_with_usage
       ;;
     --skip-java-test)


### PR DESCRIPTION
make-distribution.sh gives a slightly off error message when using --with-hive.
