### PR TITLE
[SPARK-2552][MLLIB] stabilize logistic function in pyspark

### DIFF
--- a/python/pyspark/mllib/classification.py
+++ b/python/pyspark/mllib/classification.py
@@ -63,7 +63,10 @@ class LogisticRegressionModel(LinearModel):
     def predict(self, x):
         _linear_predictor_typecheck(x, self._coeff)
         margin = _dot(x, self._coeff) + self._intercept
-        prob = 1/(1 + exp(-margin))
+        if margin > 0:
+            prob = 1 / (1 + exp(-margin))
+        else:
+            prob = 1 - 1 / (1 + exp(margin))
         return 1 if prob > 0.5 else 0
 
 


### PR DESCRIPTION
to avoid overflow in `exp(x)` if `x` is large.
