### PR TITLE
[SPARK-2608] fix executor backend launch commond over mesos mode

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
@@ -27,11 +27,13 @@ import org.apache.mesos.{Scheduler => MScheduler}
 import org.apache.mesos._
 import org.apache.mesos.Protos.{TaskInfo => MesosTaskInfo, TaskState => MesosTaskState, _}
 
-import org.apache.spark.{Logging, SparkContext, SparkException}
+import org.apache.spark.{SparkConf, Logging, SparkContext, SparkException}
 import org.apache.spark.scheduler.TaskSchedulerImpl
 import org.apache.spark.scheduler.cluster.CoarseGrainedSchedulerBackend
 import org.apache.spark.deploy.Command
 import org.apache.spark.deploy.worker.CommandUtils
+import org.apache.spark.util.Utils
+
 
 /**
  * A SchedulerBackend that runs tasks on Mesos, but uses "coarse-grained" tasks, where it holds

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
@@ -34,7 +34,6 @@ import org.apache.spark.deploy.Command
 import org.apache.spark.deploy.worker.CommandUtils
 import org.apache.spark.util.Utils
 
-
 /**
  * A SchedulerBackend that runs tasks on Mesos, but uses "coarse-grained" tasks, where it holds
  * onto each Mesos node for the duration of the Spark job instead of relinquishing cores whenever

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
@@ -151,8 +151,6 @@ private[spark] class CoarseMesosSchedulerBackend(
     mesosCommand.build()
   }
 
-
-
   override def offerRescinded(d: SchedulerDriver, o: OfferID) {}
 
   override def registered(d: SchedulerDriver, frameworkId: FrameworkID, masterInfo: MasterInfo) {

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
@@ -44,9 +44,9 @@ import org.apache.spark.deploy.worker.CommandUtils
  * remove this.
  */
 private[spark] class CoarseMesosSchedulerBackend(
-                                                  scheduler: TaskSchedulerImpl,
-                                                  sc: SparkContext,
-                                                  master: String)
+    scheduler: TaskSchedulerImpl,
+    sc: SparkContext,
+    master: String)
   extends CoarseGrainedSchedulerBackend(scheduler, sc.env.actorSystem)
   with MScheduler
   with Logging {

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
@@ -29,7 +29,7 @@ import org.apache.mesos._
 import org.apache.mesos.Protos.{TaskInfo => MesosTaskInfo, TaskState => MesosTaskState, _}
 
 import org.apache.spark.{SparkConf, Logging, SparkContext, TaskState, SparkException}
-import org.apache.spark.scheduler.{ExecutorLossReason, SchedulerBackend, TaskDescription, TaskSchedulerImpl}
+import org.apache.spark.scheduler.{ExecutorExited, ExecutorLossReason, SchedulerBackend, SlaveLost, TaskDescription, TaskSchedulerImpl, WorkerOffer}
 import org.apache.spark.util.Utils
 import org.apache.spark.deploy.Command
 import org.apache.spark.deploy.worker.CommandUtils

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
@@ -29,7 +29,7 @@ import org.apache.mesos._
 import org.apache.mesos.Protos.{TaskInfo => MesosTaskInfo, TaskState => MesosTaskState, _}
 
 import org.apache.spark.{SparkConf, Logging, SparkContext, TaskState, SparkException}
-import org.apache.spark.scheduler.{ExecutorExited, ExecutorLossReason, SchedulerBackend, SlaveLost, TaskDescription, TaskSchedulerImpl, WorkerOffer}
+import org.apache.spark.scheduler.{ExecutorLossReason, SchedulerBackend, TaskDescription, TaskSchedulerImpl}
 import org.apache.spark.util.Utils
 import org.apache.spark.deploy.Command
 import org.apache.spark.deploy.worker.CommandUtils

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
@@ -28,11 +28,13 @@ import org.apache.mesos.{Scheduler => MScheduler}
 import org.apache.mesos._
 import org.apache.mesos.Protos.{TaskInfo => MesosTaskInfo, TaskState => MesosTaskState, _}
 
-import org.apache.spark.{Logging, SparkContext, SparkException, TaskState}
+import org.apache.spark.{SparkConf, Logging, SparkContext, SparkException}
 import org.apache.spark.scheduler.{ExecutorExited, ExecutorLossReason, SchedulerBackend, SlaveLost, TaskDescription, TaskSchedulerImpl, WorkerOffer}
 import org.apache.spark.util.Utils
 import org.apache.spark.deploy.Command
 import org.apache.spark.deploy.worker.CommandUtils
+import org.apache.spark.util.Utils
+
 
 /**
  * A SchedulerBackend for running fine-grained tasks on Mesos. Each Spark task is mapped to a

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
@@ -35,7 +35,6 @@ import org.apache.spark.deploy.Command
 import org.apache.spark.deploy.worker.CommandUtils
 import org.apache.spark.util.Utils
 
-
 /**
  * A SchedulerBackend for running fine-grained tasks on Mesos. Each Spark task is mapped to a
  * separate Mesos task, allowing multiple applications to share cluster nodes both in space (tasks

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
@@ -28,7 +28,7 @@ import org.apache.mesos.{Scheduler => MScheduler}
 import org.apache.mesos._
 import org.apache.mesos.Protos.{TaskInfo => MesosTaskInfo, TaskState => MesosTaskState, _}
 
-import org.apache.spark.{SparkConf, Logging, SparkContext, SparkException}
+import org.apache.spark.{SparkConf, Logging, SparkContext, TaskState, SparkException}
 import org.apache.spark.scheduler.{ExecutorExited, ExecutorLossReason, SchedulerBackend, SlaveLost, TaskDescription, TaskSchedulerImpl, WorkerOffer}
 import org.apache.spark.util.Utils
 import org.apache.spark.deploy.Command

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
@@ -142,7 +142,6 @@ private[spark] class MesosSchedulerBackend(
       .setData(ByteString.copyFrom(createExecArg()))
       .addResources(memory)
       .build()
-
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
@@ -40,9 +40,9 @@ import org.apache.spark.deploy.worker.CommandUtils
  * from multiple apps can run on different cores) and in time (a core can switch ownership).
  */
 private[spark] class MesosSchedulerBackend(
-                                            scheduler: TaskSchedulerImpl,
-                                            sc: SparkContext,
-                                            master: String)
+    scheduler: TaskSchedulerImpl,
+    sc: SparkContext,
+    master: String)
   extends SchedulerBackend
   with MScheduler
   with Logging {
@@ -345,7 +345,7 @@ private[spark] class MesosSchedulerBackend(
   override def executorLost(d: SchedulerDriver, executorId: ExecutorID,
                             slaveId: SlaveID, status: Int) {
     logInfo("Executor lost: %s, marking slave %s as lost".format(executorId.getValue,
-      slaveId.getValue))
+                                                                         slaveId.getValue))
     recordSlaveLost(d, slaveId, ExecutorExited(status))
   }
 


### PR DESCRIPTION
mesos scheduler backend use spark-class/spark-executor to launch executor backend, this will lead to problems:
1 when set spark.executor.extraJavaOptions CoarseMesosSchedulerBackend will throw errors because of the launch command "./bin/spark-class org.apache.spark.executor.CoarseGrainedExecutorBackend %s %s %s %s %d").format(basename, extraOpts, driverUrl, offer.getSlaveId.getValue,offer.getHostname, numCores))

2 spark.executor.extraJavaOptions and spark.executor.extraLibraryPath set in sparkconf will not be valid
