### PR TITLE
[SPARK-2434][MLlib]: Warning messages that point users to original MLlib implementations added to Examples

### DIFF
--- a/examples/src/main/python/als.py
+++ b/examples/src/main/python/als.py
@@ -16,9 +16,10 @@
 #
 
 """
-This example requires numpy (http://www.numpy.org/)
 This is an example implementation of ALS for learning how to use Spark. Please refer to
 ALS in pyspark.mllib.recommendation for more conventional use.
+
+This example requires numpy (http://www.numpy.org/)
 """
 from os.path import realpath
 import sys
@@ -51,12 +52,15 @@ def update(i, vec, mat, ratings):
 
 
 if __name__ == "__main__":
-    
-    print """WARNING: THIS IS A NAIVE IMPLEMENTATION OF ALS AND IS GIVEN AS AN EXAMPLE!
-      PLEASE USE THE ALS METHOD FOUND IN pyspark.mllib.recommendation FOR MORE CONVENTIONAL USE"""
+
     """
     Usage: als [M] [U] [F] [iterations] [slices]"
     """
+
+    print >> sys.stderr, """WARN: This is a naive implementation of ALS and is given as an
+      example. Please use the ALS method found in pyspark.mllib.recommendation for more
+      conventional use."""
+
     sc = SparkContext(appName="PythonALS")
     M = int(sys.argv[1]) if len(sys.argv) > 1 else 100
     U = int(sys.argv[2]) if len(sys.argv) > 2 else 500

--- a/examples/src/main/python/als.py
+++ b/examples/src/main/python/als.py
@@ -17,6 +17,8 @@
 
 """
 This example requires numpy (http://www.numpy.org/)
+This is an example implementation of ALS for learning how to use Spark. Please refer to
+ALS in pyspark.mllib.recommendation for more conventional use.
 """
 from os.path import realpath
 import sys
@@ -49,6 +51,9 @@ def update(i, vec, mat, ratings):
 
 
 if __name__ == "__main__":
+    
+    print """WARNING: THIS IS A NAIVE IMPLEMENTATION OF ALS AND IS GIVEN AS AN EXAMPLE!
+      PLEASE USE THE ALS METHOD FOUND IN pyspark.mllib.recommendation FOR MORE CONVENTIONAL USE"""
     """
     Usage: als [M] [U] [F] [iterations] [slices]"
     """

--- a/examples/src/main/python/kmeans.py
+++ b/examples/src/main/python/kmeans.py
@@ -45,6 +45,10 @@ def closestPoint(p, centers):
 
 
 if __name__ == "__main__":
+
+    print """WARNING: THIS IS A NAIVE IMPLEMENTATION OF K-MEANS CLUSTERING AND IS GIVEN AS AN EXAMPLE!
+      PLEASE REFER TO examples/src/main/python/mllib/kmeans.py FOR AN EXAMPLE ON HOW TO USE MLlib's KMEANS
+      IMPLEMENTATION."""
     if len(sys.argv) != 4:
         print >> sys.stderr, "Usage: kmeans <file> <k> <convergeDist>"
         exit(-1)

--- a/examples/src/main/python/kmeans.py
+++ b/examples/src/main/python/kmeans.py
@@ -46,12 +46,14 @@ def closestPoint(p, centers):
 
 if __name__ == "__main__":
 
-    print """WARNING: THIS IS A NAIVE IMPLEMENTATION OF K-MEANS CLUSTERING AND IS GIVEN AS AN EXAMPLE!
-      PLEASE REFER TO examples/src/main/python/mllib/kmeans.py FOR AN EXAMPLE ON HOW TO USE MLlib's KMEANS
-      IMPLEMENTATION."""
     if len(sys.argv) != 4:
         print >> sys.stderr, "Usage: kmeans <file> <k> <convergeDist>"
         exit(-1)
+
+    print >> sys.stderr, """WARN: This is a naive implementation of KMeans Clustering and is given
+       as an example! Please refer to examples/src/main/python/mllib/kmeans.py for an example on
+       how to use MLlib's KMeans implementation."""
+
     sc = SparkContext(appName="PythonKMeans")
     lines = sc.textFile(sys.argv[1])
     data = lines.map(parseVector).cache()

--- a/examples/src/main/python/logistic_regression.py
+++ b/examples/src/main/python/logistic_regression.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
 
     print >> sys.stderr,  """WARN: This is a naive implementation of Logistic Regression and is
       given as an example! Please refer to examples/src/main/python/mllib/logistic_regression.py
-      to see how MLlib's implementation is used"""
+      to see how MLlib's implementation is used."""
 
     sc = SparkContext(appName="PythonLR")
     points = sc.textFile(sys.argv[1]).mapPartitions(readPointBatch).cache()

--- a/examples/src/main/python/logistic_regression.py
+++ b/examples/src/main/python/logistic_regression.py
@@ -47,13 +47,15 @@ def readPointBatch(iterator):
     return [matrix]
 
 if __name__ == "__main__":
-    
-    print """WARNING: THIS IS A NAIVE IMPLEMENTATION OF LOGISTIC REGRESSION AND IS GIVEN AS AN EXAMPLE!
-        PLEASE REFER TO examples/src/main/python/mllib/logistic_regression.py TO SEE HOW MLlib's IMPLEMENTATION
-        IS USED"""
+
     if len(sys.argv) != 3:
         print >> sys.stderr, "Usage: logistic_regression <file> <iterations>"
         exit(-1)
+
+    print >> sys.stderr,  """WARN: This is a naive implementation of Logistic Regression and is
+      given as an example! Please refer to examples/src/main/python/mllib/logistic_regression.py
+      to see how MLlib's implementation is used"""
+
     sc = SparkContext(appName="PythonLR")
     points = sc.textFile(sys.argv[1]).mapPartitions(readPointBatch).cache()
     iterations = int(sys.argv[2])

--- a/examples/src/main/python/logistic_regression.py
+++ b/examples/src/main/python/logistic_regression.py
@@ -47,6 +47,10 @@ def readPointBatch(iterator):
     return [matrix]
 
 if __name__ == "__main__":
+    
+    print """WARNING: THIS IS A NAIVE IMPLEMENTATION OF LOGISTIC REGRESSION AND IS GIVEN AS AN EXAMPLE!
+        PLEASE REFER TO examples/src/main/python/mllib/logistic_regression.py TO SEE HOW MLlib's IMPLEMENTATION
+        IS USED"""
     if len(sys.argv) != 3:
         print >> sys.stderr, "Usage: logistic_regression <file> <iterations>"
         exit(-1)

--- a/examples/src/main/scala/org/apache/spark/examples/LocalALS.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/LocalALS.scala
@@ -24,8 +24,10 @@ import cern.colt.matrix.linalg._
 import cern.jet.math._
 
 /**
- * Alternating least squares matrix factorization. This is an example implementation for learning how to use Spark.
- * For more conventional use, please refer to org.apache.spark.mllib.recommendation.ALS
+ * Alternating least squares matrix factorization.
+ *
+ * This is an example implementation for learning how to use Spark. For more conventional use,
+ * please refer to org.apache.spark.mllib.recommendation.ALS
  */
 object LocalALS {
   // Parameters set through command line arguments
@@ -110,16 +112,14 @@ object LocalALS {
 
   def showWarning() {
     System.err.println(
-      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF ALS AND IS GIVEN AS AN EXAMPLE!
-        |PLEASE USE THE ALS METHOD FOUND IN org.apache.spark.mllib.recommendation FOR
-        |MORE CONVENTIONAL USE
+      """WARN: This is a naive implementation of ALS and is given as an example!
+        |Please use the ALS method found in org.apache.spark.mllib.recommendation
+        |for more conventional use
       """.stripMargin)
-    System.exit(1)
   }
 
   def main(args: Array[String]) {
 
-    showWarning()
     args match {
       case Array(m, u, f, iters) => {
         M = m.toInt
@@ -129,9 +129,12 @@ object LocalALS {
       }
       case _ => {
         System.err.println("Usage: LocalALS <M> <U> <F> <iters>")
-
+        System.exit(1)
       }
     }
+
+    showWarning()
+
     printf("Running with M=%d, U=%d, F=%d, iters=%d\n", M, U, F, ITERATIONS)
 
     val R = generateR()

--- a/examples/src/main/scala/org/apache/spark/examples/LocalALS.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/LocalALS.scala
@@ -107,6 +107,15 @@ object LocalALS {
     solved2D.viewColumn(0)
   }
 
+  def showWarning() {
+    System.err.println(
+      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF ALS AND IS GIVEN AS AN EXAMPLE!
+        |PLEASE USE THE ALS METHOD FOUND IN org.apache.spark.mllib.recommendation FOR
+        |MORE CONVENTIONAL USE
+      """.stripMargin)
+    System.exit(1)
+  }
+
   def main(args: Array[String]) {
     args match {
       case Array(m, u, f, iters) => {
@@ -117,20 +126,11 @@ object LocalALS {
       }
       case _ => {
         System.err.println("Usage: LocalALS <M> <U> <F> <iters>")
-        System.err.println(
-          """WARNING: THIS IS A NAIVE IMPLEMENTATION OF ALS AND IS GIVEN AS AN EXAMPLE!
-            |PLEASE USE THE ALS METHOD FOUND IN org.apache.spark.mllib.recommendation FOR
-            |MORE CONVENTIONAL USE
-          """.stripMargin)
-        System.exit(1)
+        showWarning()
       }
     }
     printf("Running with M=%d, U=%d, F=%d, iters=%d\n", M, U, F, ITERATIONS)
-    System.err.println(
-      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF ALS AND IS GIVEN AS AN EXAMPLE!
-        |PLEASE USE THE ALS METHOD FOUND IN org.apache.spark.mllib.recommendation FOR
-        |MORE CONVENTIONAL USE
-      """.stripMargin)
+    showWarning()
     val R = generateR()
 
     // Initialize m and u randomly
@@ -145,10 +145,6 @@ object LocalALS {
       println("RMSE = " + rmse(R, ms, us))
       println()
     }
-    System.err.println(
-      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF ALS AND IS GIVEN AS AN EXAMPLE!
-        |PLEASE USE THE ALS METHOD FOUND IN org.apache.spark.mllib.recommendation FOR
-        |MORE CONVENTIONAL USE
-      """.stripMargin)
+    showWarning()
   }
 }

--- a/examples/src/main/scala/org/apache/spark/examples/LocalALS.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/LocalALS.scala
@@ -117,11 +117,20 @@ object LocalALS {
       }
       case _ => {
         System.err.println("Usage: LocalALS <M> <U> <F> <iters>")
+        System.err.println(
+          """WARNING: THIS IS A NAIVE IMPLEMENTATION OF ALS AND IS GIVEN AS AN EXAMPLE!
+            |PLEASE USE THE ALS METHOD FOUND IN org.apache.spark.mllib.recommendation FOR
+            |MORE CONVENTIONAL USE
+          """.stripMargin)
         System.exit(1)
       }
     }
     printf("Running with M=%d, U=%d, F=%d, iters=%d\n", M, U, F, ITERATIONS)
-
+    System.err.println(
+      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF ALS AND IS GIVEN AS AN EXAMPLE!
+        |PLEASE USE THE ALS METHOD FOUND IN org.apache.spark.mllib.recommendation FOR
+        |MORE CONVENTIONAL USE
+      """.stripMargin)
     val R = generateR()
 
     // Initialize m and u randomly
@@ -136,5 +145,10 @@ object LocalALS {
       println("RMSE = " + rmse(R, ms, us))
       println()
     }
+    System.err.println(
+      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF ALS AND IS GIVEN AS AN EXAMPLE!
+        |PLEASE USE THE ALS METHOD FOUND IN org.apache.spark.mllib.recommendation FOR
+        |MORE CONVENTIONAL USE
+      """.stripMargin)
   }
 }

--- a/examples/src/main/scala/org/apache/spark/examples/LocalALS.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/LocalALS.scala
@@ -24,7 +24,8 @@ import cern.colt.matrix.linalg._
 import cern.jet.math._
 
 /**
- * Alternating least squares matrix factorization.
+ * Alternating least squares matrix factorization. This is an example implementation for learning how to use Spark.
+ * For more conventional use, please refer to org.apache.spark.mllib.recommendation.ALS
  */
 object LocalALS {
   // Parameters set through command line arguments
@@ -117,6 +118,8 @@ object LocalALS {
   }
 
   def main(args: Array[String]) {
+
+    showWarning()
     args match {
       case Array(m, u, f, iters) => {
         M = m.toInt
@@ -126,11 +129,11 @@ object LocalALS {
       }
       case _ => {
         System.err.println("Usage: LocalALS <M> <U> <F> <iters>")
-        showWarning()
+
       }
     }
     printf("Running with M=%d, U=%d, F=%d, iters=%d\n", M, U, F, ITERATIONS)
-    showWarning()
+
     val R = generateR()
 
     // Initialize m and u randomly
@@ -145,6 +148,5 @@ object LocalALS {
       println("RMSE = " + rmse(R, ms, us))
       println()
     }
-    showWarning()
   }
 }

--- a/examples/src/main/scala/org/apache/spark/examples/LocalALS.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/LocalALS.scala
@@ -114,7 +114,7 @@ object LocalALS {
     System.err.println(
       """WARN: This is a naive implementation of ALS and is given as an example!
         |Please use the ALS method found in org.apache.spark.mllib.recommendation
-        |for more conventional use
+        |for more conventional use.
       """.stripMargin)
   }
 

--- a/examples/src/main/scala/org/apache/spark/examples/LocalFileLR.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/LocalFileLR.scala
@@ -32,15 +32,19 @@ object LocalFileLR {
     DataPoint(new DenseVector(nums.slice(1, D + 1)), nums(0))
   }
 
-  def main(args: Array[String]) {
-    val lines = scala.io.Source.fromFile(args(0)).getLines().toArray
-    val points = lines.map(parsePoint _)
-    val ITERATIONS = args(1).toInt
+  def showWarning() {
     System.err.println(
       """WARNING: THIS IS A NAIVE IMPLEMENTATION OF LOGISTIC REGRESSION AND IS GIVEN AS AN EXAMPLE!
         |PLEASE USE THE LogisticRegression METHOD FOUND IN org.apache.spark.mllib.classification FOR
         |MORE CONVENTIONAL USE
       """.stripMargin)
+  }
+
+  def main(args: Array[String]) {
+    val lines = scala.io.Source.fromFile(args(0)).getLines().toArray
+    val points = lines.map(parsePoint _)
+    val ITERATIONS = args(1).toInt
+    showWarning()
     // Initialize w to a random value
     var w = DenseVector.fill(D){2 * rand.nextDouble - 1}
     println("Initial w: " + w)
@@ -56,10 +60,6 @@ object LocalFileLR {
     }
 
     println("Final w: " + w)
-    System.err.println(
-      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF LOGISTIC REGRESSION AND IS GIVEN AS AN EXAMPLE!
-        |PLEASE USE THE LogisticRegression METHOD FOUND IN org.apache.spark.mllib.classification FOR
-        |MORE CONVENTIONAL USE
-      """.stripMargin)
+    showWarning()
   }
 }

--- a/examples/src/main/scala/org/apache/spark/examples/LocalFileLR.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/LocalFileLR.scala
@@ -21,6 +21,10 @@ import java.util.Random
 
 import breeze.linalg.{Vector, DenseVector}
 
+/**
+ * Logistic regression based classification. This is an example implementation for learning how to use Spark.
+ * For more conventional use, please refer to org.apache.spark.mllib.classification.LogisticRegression
+ */
 object LocalFileLR {
   val D = 10   // Numer of dimensions
   val rand = new Random(42)
@@ -41,10 +45,13 @@ object LocalFileLR {
   }
 
   def main(args: Array[String]) {
+
+    showWarning()
+
     val lines = scala.io.Source.fromFile(args(0)).getLines().toArray
     val points = lines.map(parsePoint _)
     val ITERATIONS = args(1).toInt
-    showWarning()
+
     // Initialize w to a random value
     var w = DenseVector.fill(D){2 * rand.nextDouble - 1}
     println("Initial w: " + w)
@@ -60,6 +67,5 @@ object LocalFileLR {
     }
 
     println("Final w: " + w)
-    showWarning()
   }
 }

--- a/examples/src/main/scala/org/apache/spark/examples/LocalFileLR.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/LocalFileLR.scala
@@ -22,8 +22,10 @@ import java.util.Random
 import breeze.linalg.{Vector, DenseVector}
 
 /**
- * Logistic regression based classification. This is an example implementation for learning how to use Spark.
- * For more conventional use, please refer to org.apache.spark.mllib.classification.LogisticRegression
+ * Logistic regression based classification.
+ *
+ * This is an example implementation for learning how to use Spark. For more conventional use,
+ * please refer to org.apache.spark.mllib.classification.LogisticRegression
  */
 object LocalFileLR {
   val D = 10   // Numer of dimensions
@@ -38,9 +40,9 @@ object LocalFileLR {
 
   def showWarning() {
     System.err.println(
-      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF LOGISTIC REGRESSION AND IS GIVEN AS AN EXAMPLE!
-        |PLEASE USE THE LogisticRegression METHOD FOUND IN org.apache.spark.mllib.classification FOR
-        |MORE CONVENTIONAL USE
+      """WARN: This is a naive implementation of Logistic Regression and is given as an example!
+        |Please use the LogisticRegression method found in org.apache.spark.mllib.classification
+        |for more conventional use
       """.stripMargin)
   }
 

--- a/examples/src/main/scala/org/apache/spark/examples/LocalFileLR.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/LocalFileLR.scala
@@ -36,7 +36,11 @@ object LocalFileLR {
     val lines = scala.io.Source.fromFile(args(0)).getLines().toArray
     val points = lines.map(parsePoint _)
     val ITERATIONS = args(1).toInt
-
+    System.err.println(
+      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF LOGISTIC REGRESSION AND IS GIVEN AS AN EXAMPLE!
+        |PLEASE USE THE LogisticRegression METHOD FOUND IN org.apache.spark.mllib.classification FOR
+        |MORE CONVENTIONAL USE
+      """.stripMargin)
     // Initialize w to a random value
     var w = DenseVector.fill(D){2 * rand.nextDouble - 1}
     println("Initial w: " + w)
@@ -52,5 +56,10 @@ object LocalFileLR {
     }
 
     println("Final w: " + w)
+    System.err.println(
+      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF LOGISTIC REGRESSION AND IS GIVEN AS AN EXAMPLE!
+        |PLEASE USE THE LogisticRegression METHOD FOUND IN org.apache.spark.mllib.classification FOR
+        |MORE CONVENTIONAL USE
+      """.stripMargin)
   }
 }

--- a/examples/src/main/scala/org/apache/spark/examples/LocalFileLR.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/LocalFileLR.scala
@@ -42,7 +42,7 @@ object LocalFileLR {
     System.err.println(
       """WARN: This is a naive implementation of Logistic Regression and is given as an example!
         |Please use the LogisticRegression method found in org.apache.spark.mllib.classification
-        |for more conventional use
+        |for more conventional use.
       """.stripMargin)
   }
 

--- a/examples/src/main/scala/org/apache/spark/examples/LocalKMeans.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/LocalKMeans.scala
@@ -68,7 +68,7 @@ object LocalKMeans {
     System.err.println(
       """WARN: This is a naive implementation of KMeans Clustering and is given as an example!
         |Please use the KMeans method found in org.apache.spark.mllib.clustering
-        |for more conventional use
+        |for more conventional use.
       """.stripMargin)
   }
 

--- a/examples/src/main/scala/org/apache/spark/examples/LocalKMeans.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/LocalKMeans.scala
@@ -61,6 +61,14 @@ object LocalKMeans {
     bestIndex
   }
 
+  def showWarning() {
+    System.err.println(
+      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF K-MEANS CLUSTERING AND IS GIVEN AS AN EXAMPLE!
+        |PLEASE USE THE KMeans METHOD FOUND IN org.apache.spark.mllib.clustering FOR
+        |MORE CONVENTIONAL USE
+      """.stripMargin)
+  }
+
   def main(args: Array[String]) {
     val data = generateData
     var points = new HashSet[Vector[Double]]
@@ -70,12 +78,8 @@ object LocalKMeans {
     while (points.size < K) {
       points.add(data(rand.nextInt(N)))
     }
+    showWarning()
 
-    System.err.println(
-      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF K-MEANS CLUSTERING AND IS GIVEN AS AN EXAMPLE!
-        |PLEASE USE THE KMeans METHOD FOUND IN org.apache.spark.mllib.clustering FOR
-        |MORE CONVENTIONAL USE
-      """.stripMargin)
     val iter = points.iterator
     for (i <- 1 to points.size) {
       kPoints.put(i, iter.next())
@@ -108,10 +112,6 @@ object LocalKMeans {
     }
 
     println("Final centers: " + kPoints)
-    System.err.println(
-      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF K-MEANS CLUSTERING AND IS GIVEN AS AN EXAMPLE!
-        |PLEASE USE THE KMeans METHOD FOUND IN org.apache.spark.mllib.clustering FOR
-        |MORE CONVENTIONAL USE
-      """.stripMargin)
+    showWarning()
   }
 }

--- a/examples/src/main/scala/org/apache/spark/examples/LocalKMeans.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/LocalKMeans.scala
@@ -27,7 +27,8 @@ import breeze.linalg.{Vector, DenseVector, squaredDistance}
 import org.apache.spark.SparkContext._
 
 /**
- * K-means clustering.
+ * K-means clustering. This is an example implementation for learning how to use Spark.
+ * For more conventional use, please refer to org.apache.spark.mllib.clustering.KMeans
  */
 object LocalKMeans {
   val N = 1000
@@ -70,6 +71,9 @@ object LocalKMeans {
   }
 
   def main(args: Array[String]) {
+
+    showWarning()
+
     val data = generateData
     var points = new HashSet[Vector[Double]]
     var kPoints = new HashMap[Int, Vector[Double]]
@@ -78,7 +82,6 @@ object LocalKMeans {
     while (points.size < K) {
       points.add(data(rand.nextInt(N)))
     }
-    showWarning()
 
     val iter = points.iterator
     for (i <- 1 to points.size) {
@@ -112,6 +115,5 @@ object LocalKMeans {
     }
 
     println("Final centers: " + kPoints)
-    showWarning()
   }
 }

--- a/examples/src/main/scala/org/apache/spark/examples/LocalKMeans.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/LocalKMeans.scala
@@ -27,8 +27,10 @@ import breeze.linalg.{Vector, DenseVector, squaredDistance}
 import org.apache.spark.SparkContext._
 
 /**
- * K-means clustering. This is an example implementation for learning how to use Spark.
- * For more conventional use, please refer to org.apache.spark.mllib.clustering.KMeans
+ * K-means clustering.
+ *
+ * This is an example implementation for learning how to use Spark. For more conventional use,
+ * please refer to org.apache.spark.mllib.clustering.KMeans
  */
 object LocalKMeans {
   val N = 1000
@@ -64,9 +66,9 @@ object LocalKMeans {
 
   def showWarning() {
     System.err.println(
-      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF K-MEANS CLUSTERING AND IS GIVEN AS AN EXAMPLE!
-        |PLEASE USE THE KMeans METHOD FOUND IN org.apache.spark.mllib.clustering FOR
-        |MORE CONVENTIONAL USE
+      """WARN: This is a naive implementation of KMeans Clustering and is given as an example!
+        |Please use the KMeans method found in org.apache.spark.mllib.clustering
+        |for more conventional use
       """.stripMargin)
   }
 

--- a/examples/src/main/scala/org/apache/spark/examples/LocalKMeans.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/LocalKMeans.scala
@@ -71,6 +71,11 @@ object LocalKMeans {
       points.add(data(rand.nextInt(N)))
     }
 
+    System.err.println(
+      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF K-MEANS CLUSTERING AND IS GIVEN AS AN EXAMPLE!
+        |PLEASE USE THE KMeans METHOD FOUND IN org.apache.spark.mllib.clustering FOR
+        |MORE CONVENTIONAL USE
+      """.stripMargin)
     val iter = points.iterator
     for (i <- 1 to points.size) {
       kPoints.put(i, iter.next())
@@ -103,5 +108,10 @@ object LocalKMeans {
     }
 
     println("Final centers: " + kPoints)
+    System.err.println(
+      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF K-MEANS CLUSTERING AND IS GIVEN AS AN EXAMPLE!
+        |PLEASE USE THE KMeans METHOD FOUND IN org.apache.spark.mllib.clustering FOR
+        |MORE CONVENTIONAL USE
+      """.stripMargin)
   }
 }

--- a/examples/src/main/scala/org/apache/spark/examples/LocalLR.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/LocalLR.scala
@@ -22,8 +22,10 @@ import java.util.Random
 import breeze.linalg.{Vector, DenseVector}
 
 /**
- * Logistic regression based classification. This is an example implementation for learning how to use Spark.
- * For more conventional use, please refer to org.apache.spark.mllib.classification.LogisticRegression
+ * Logistic regression based classification.
+ *
+ * This is an example implementation for learning how to use Spark. For more conventional use,
+ * please refer to org.apache.spark.mllib.classification.LogisticRegression
  */
 object LocalLR {
   val N = 10000  // Number of data points
@@ -45,9 +47,9 @@ object LocalLR {
 
   def showWarning() {
     System.err.println(
-      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF LOGISTIC REGRESSION AND IS GIVEN AS AN EXAMPLE!
-        |PLEASE USE THE LogisticRegression METHOD FOUND IN org.apache.spark.mllib.classification FOR
-        |MORE CONVENTIONAL USE
+      """WARN: This is a naive implementation of Logistic Regression and is given as an example!
+        |Please use the LogisticRegression method found in org.apache.spark.mllib.classification
+        |for more conventional use
       """.stripMargin)
   }
 

--- a/examples/src/main/scala/org/apache/spark/examples/LocalLR.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/LocalLR.scala
@@ -49,7 +49,7 @@ object LocalLR {
     System.err.println(
       """WARN: This is a naive implementation of Logistic Regression and is given as an example!
         |Please use the LogisticRegression method found in org.apache.spark.mllib.classification
-        |for more conventional use
+        |for more conventional use.
       """.stripMargin)
   }
 

--- a/examples/src/main/scala/org/apache/spark/examples/LocalLR.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/LocalLR.scala
@@ -42,13 +42,17 @@ object LocalLR {
     Array.tabulate(N)(generatePoint)
   }
 
-  def main(args: Array[String]) {
-    val data = generateData
+  def showWarning() {
     System.err.println(
       """WARNING: THIS IS A NAIVE IMPLEMENTATION OF LOGISTIC REGRESSION AND IS GIVEN AS AN EXAMPLE!
         |PLEASE USE THE LogisticRegression METHOD FOUND IN org.apache.spark.mllib.classification FOR
         |MORE CONVENTIONAL USE
       """.stripMargin)
+  }
+
+  def main(args: Array[String]) {
+    val data = generateData
+    showWarning()
     // Initialize w to a random value
     var w = DenseVector.fill(D){2 * rand.nextDouble - 1}
     println("Initial w: " + w)
@@ -64,10 +68,6 @@ object LocalLR {
     }
 
     println("Final w: " + w)
-    System.err.println(
-      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF LOGISTIC REGRESSION AND IS GIVEN AS AN EXAMPLE!
-      |PLEASE USE THE LogisticRegression METHOD FOUND IN org.apache.spark.mllib.classification FOR
-      |MORE CONVENTIONAL USE
-    """.stripMargin)
+    showWarning()
   }
 }

--- a/examples/src/main/scala/org/apache/spark/examples/LocalLR.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/LocalLR.scala
@@ -22,7 +22,8 @@ import java.util.Random
 import breeze.linalg.{Vector, DenseVector}
 
 /**
- * Logistic regression based classification.
+ * Logistic regression based classification. This is an example implementation for learning how to use Spark.
+ * For more conventional use, please refer to org.apache.spark.mllib.classification.LogisticRegression
  */
 object LocalLR {
   val N = 10000  // Number of data points
@@ -51,8 +52,10 @@ object LocalLR {
   }
 
   def main(args: Array[String]) {
-    val data = generateData
+
     showWarning()
+
+    val data = generateData
     // Initialize w to a random value
     var w = DenseVector.fill(D){2 * rand.nextDouble - 1}
     println("Initial w: " + w)
@@ -68,6 +71,5 @@ object LocalLR {
     }
 
     println("Final w: " + w)
-    showWarning()
   }
 }

--- a/examples/src/main/scala/org/apache/spark/examples/LocalLR.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/LocalLR.scala
@@ -44,7 +44,11 @@ object LocalLR {
 
   def main(args: Array[String]) {
     val data = generateData
-
+    System.err.println(
+      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF LOGISTIC REGRESSION AND IS GIVEN AS AN EXAMPLE!
+        |PLEASE USE THE LogisticRegression METHOD FOUND IN org.apache.spark.mllib.classification FOR
+        |MORE CONVENTIONAL USE
+      """.stripMargin)
     // Initialize w to a random value
     var w = DenseVector.fill(D){2 * rand.nextDouble - 1}
     println("Initial w: " + w)
@@ -60,5 +64,10 @@ object LocalLR {
     }
 
     println("Final w: " + w)
+    System.err.println(
+      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF LOGISTIC REGRESSION AND IS GIVEN AS AN EXAMPLE!
+      |PLEASE USE THE LogisticRegression METHOD FOUND IN org.apache.spark.mllib.classification FOR
+      |MORE CONVENTIONAL USE
+    """.stripMargin)
   }
 }

--- a/examples/src/main/scala/org/apache/spark/examples/SparkALS.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/SparkALS.scala
@@ -26,7 +26,8 @@ import cern.jet.math._
 import org.apache.spark._
 
 /**
- * Alternating least squares matrix factorization.
+ * Alternating least squares matrix factorization. This is an example implementation for learning how to use Spark.
+ * For more conventional use, please refer to org.apache.spark.mllib.recommendation.ALS
  */
 object SparkALS {
   // Parameters set through command line arguments
@@ -96,6 +97,9 @@ object SparkALS {
   }
 
   def main(args: Array[String]) {
+
+    showWarning()
+
     var slices = 0
 
     val options = (0 to 4).map(i => if (i < args.length) Some(args(i)) else None)
@@ -109,11 +113,10 @@ object SparkALS {
         slices = slices_.getOrElse("2").toInt
       case _ =>
         System.err.println("Usage: SparkALS [M] [U] [F] [iters] [slices]")
-        showWarning()
         System.exit(1)
     }
     printf("Running with M=%d, U=%d, F=%d, iters=%d\n", M, U, F, ITERATIONS)
-    showWarning()
+
     val sparkConf = new SparkConf().setAppName("SparkALS")
     val sc = new SparkContext(sparkConf)
 
@@ -140,7 +143,7 @@ object SparkALS {
       println("RMSE = " + rmse(R, ms, us))
       println()
     }
-    showWarning()
+
     sc.stop()
   }
 }

--- a/examples/src/main/scala/org/apache/spark/examples/SparkALS.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/SparkALS.scala
@@ -94,7 +94,7 @@ object SparkALS {
     System.err.println(
       """WARN: This is a naive implementation of ALS and is given as an example!
         |Please use the ALS method found in org.apache.spark.mllib.recommendation
-        |for more conventional use
+        |for more conventional use.
       """.stripMargin)
   }
 

--- a/examples/src/main/scala/org/apache/spark/examples/SparkALS.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/SparkALS.scala
@@ -26,8 +26,10 @@ import cern.jet.math._
 import org.apache.spark._
 
 /**
- * Alternating least squares matrix factorization. This is an example implementation for learning how to use Spark.
- * For more conventional use, please refer to org.apache.spark.mllib.recommendation.ALS
+ * Alternating least squares matrix factorization.
+ *
+ * This is an example implementation for learning how to use Spark. For more conventional use,
+ * please refer to org.apache.spark.mllib.recommendation.ALS
  */
 object SparkALS {
   // Parameters set through command line arguments
@@ -90,15 +92,13 @@ object SparkALS {
 
   def showWarning() {
     System.err.println(
-      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF ALS AND IS GIVEN AS AN EXAMPLE!
-        |PLEASE USE THE ALS METHOD FOUND IN org.apache.spark.mllib.recommendation FOR
-        |MORE CONVENTIONAL USE
+      """WARN: This is a naive implementation of ALS and is given as an example!
+        |Please use the ALS method found in org.apache.spark.mllib.recommendation
+        |for more conventional use
       """.stripMargin)
   }
 
   def main(args: Array[String]) {
-
-    showWarning()
 
     var slices = 0
 
@@ -115,6 +115,9 @@ object SparkALS {
         System.err.println("Usage: SparkALS [M] [U] [F] [iters] [slices]")
         System.exit(1)
     }
+
+    showWarning()
+
     printf("Running with M=%d, U=%d, F=%d, iters=%d\n", M, U, F, ITERATIONS)
 
     val sparkConf = new SparkConf().setAppName("SparkALS")

--- a/examples/src/main/scala/org/apache/spark/examples/SparkALS.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/SparkALS.scala
@@ -101,9 +101,19 @@ object SparkALS {
         slices = slices_.getOrElse("2").toInt
       case _ =>
         System.err.println("Usage: SparkALS [M] [U] [F] [iters] [slices]")
+        System.err.println(
+          """WARNING: THIS IS A NAIVE IMPLEMENTATION OF ALS AND IS GIVEN AS AN EXAMPLE!
+            |PLEASE USE THE ALS METHOD FOUND IN org.apache.spark.mllib.recommendation FOR
+            |MORE CONVENTIONAL USE
+          """.stripMargin)
         System.exit(1)
     }
     printf("Running with M=%d, U=%d, F=%d, iters=%d\n", M, U, F, ITERATIONS)
+    System.err.println(
+      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF ALS AND IS GIVEN AS AN EXAMPLE!
+        |PLEASE USE THE ALS METHOD FOUND IN org.apache.spark.mllib.recommendation FOR
+        |MORE CONVENTIONAL USE
+      """.stripMargin)
     val sparkConf = new SparkConf().setAppName("SparkALS")
     val sc = new SparkContext(sparkConf)
 
@@ -130,7 +140,11 @@ object SparkALS {
       println("RMSE = " + rmse(R, ms, us))
       println()
     }
-
+    System.err.println(
+      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF ALS AND IS GIVEN AS AN EXAMPLE!
+        |PLEASE USE THE ALS METHOD FOUND IN org.apache.spark.mllib.recommendation FOR
+        |MORE CONVENTIONAL USE
+      """.stripMargin)
     sc.stop()
   }
 }

--- a/examples/src/main/scala/org/apache/spark/examples/SparkALS.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/SparkALS.scala
@@ -87,6 +87,14 @@ object SparkALS {
     solved2D.viewColumn(0)
   }
 
+  def showWarning() {
+    System.err.println(
+      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF ALS AND IS GIVEN AS AN EXAMPLE!
+        |PLEASE USE THE ALS METHOD FOUND IN org.apache.spark.mllib.recommendation FOR
+        |MORE CONVENTIONAL USE
+      """.stripMargin)
+  }
+
   def main(args: Array[String]) {
     var slices = 0
 
@@ -101,19 +109,11 @@ object SparkALS {
         slices = slices_.getOrElse("2").toInt
       case _ =>
         System.err.println("Usage: SparkALS [M] [U] [F] [iters] [slices]")
-        System.err.println(
-          """WARNING: THIS IS A NAIVE IMPLEMENTATION OF ALS AND IS GIVEN AS AN EXAMPLE!
-            |PLEASE USE THE ALS METHOD FOUND IN org.apache.spark.mllib.recommendation FOR
-            |MORE CONVENTIONAL USE
-          """.stripMargin)
+        showWarning()
         System.exit(1)
     }
     printf("Running with M=%d, U=%d, F=%d, iters=%d\n", M, U, F, ITERATIONS)
-    System.err.println(
-      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF ALS AND IS GIVEN AS AN EXAMPLE!
-        |PLEASE USE THE ALS METHOD FOUND IN org.apache.spark.mllib.recommendation FOR
-        |MORE CONVENTIONAL USE
-      """.stripMargin)
+    showWarning()
     val sparkConf = new SparkConf().setAppName("SparkALS")
     val sc = new SparkContext(sparkConf)
 
@@ -140,11 +140,7 @@ object SparkALS {
       println("RMSE = " + rmse(R, ms, us))
       println()
     }
-    System.err.println(
-      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF ALS AND IS GIVEN AS AN EXAMPLE!
-        |PLEASE USE THE ALS METHOD FOUND IN org.apache.spark.mllib.recommendation FOR
-        |MORE CONVENTIONAL USE
-      """.stripMargin)
+    showWarning()
     sc.stop()
   }
 }

--- a/examples/src/main/scala/org/apache/spark/examples/SparkHdfsLR.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/SparkHdfsLR.scala
@@ -29,8 +29,10 @@ import org.apache.spark.scheduler.InputFormatInfo
 
 
 /**
- * Logistic regression based classification. This is an example implementation for learning how to use Spark.
- * For more conventional use, please refer to org.apache.spark.mllib.classification.LogisticRegression
+ * Logistic regression based classification.
+ *
+ * This is an example implementation for learning how to use Spark. For more conventional use,
+ * please refer to org.apache.spark.mllib.classification.LogisticRegression
  */
 object SparkHdfsLR {
   val D = 10   // Numer of dimensions
@@ -51,21 +53,21 @@ object SparkHdfsLR {
 
   def showWarning() {
     System.err.println(
-      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF LOGISTIC REGRESSION AND IS GIVEN AS AN EXAMPLE!
-        |PLEASE USE THE LogisticRegression METHOD FOUND IN org.apache.spark.mllib.classification FOR
-        |MORE CONVENTIONAL USE
+      """WARN: This is a naive implementation of Logistic Regression and is given as an example!
+        |Please use the LogisticRegression method found in org.apache.spark.mllib.classification
+        |for more conventional use
       """.stripMargin)
   }
 
   def main(args: Array[String]) {
 
-    showWarning()
-
     if (args.length < 2) {
       System.err.println("Usage: SparkHdfsLR <file> <iters>")
-      showWarning()
       System.exit(1)
     }
+
+    showWarning()
+
     val sparkConf = new SparkConf().setAppName("SparkHdfsLR")
     val inputPath = args(0)
     val conf = SparkHadoopUtil.get.newConfiguration()

--- a/examples/src/main/scala/org/apache/spark/examples/SparkHdfsLR.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/SparkHdfsLR.scala
@@ -29,7 +29,8 @@ import org.apache.spark.scheduler.InputFormatInfo
 
 
 /**
- * Logistic regression based classification.
+ * Logistic regression based classification. This is an example implementation for learning how to use Spark.
+ * For more conventional use, please refer to org.apache.spark.mllib.classification.LogisticRegression
  */
 object SparkHdfsLR {
   val D = 10   // Numer of dimensions
@@ -57,12 +58,14 @@ object SparkHdfsLR {
   }
 
   def main(args: Array[String]) {
+
+    showWarning()
+
     if (args.length < 2) {
       System.err.println("Usage: SparkHdfsLR <file> <iters>")
       showWarning()
       System.exit(1)
     }
-    showWarning()
     val sparkConf = new SparkConf().setAppName("SparkHdfsLR")
     val inputPath = args(0)
     val conf = SparkHadoopUtil.get.newConfiguration()
@@ -87,7 +90,6 @@ object SparkHdfsLR {
     }
 
     println("Final w: " + w)
-    showWarning()
     sc.stop()
   }
 }

--- a/examples/src/main/scala/org/apache/spark/examples/SparkHdfsLR.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/SparkHdfsLR.scala
@@ -48,21 +48,21 @@ object SparkHdfsLR {
     DataPoint(new DenseVector(x), y)
   }
 
-  def main(args: Array[String]) {
-    if (args.length < 2) {
-      System.err.println("Usage: SparkHdfsLR <file> <iters>")
-      System.err.println(
-        """WARNING: THIS IS A NAIVE IMPLEMENTATION OF LOGISTIC REGRESSION AND IS GIVEN AS AN EXAMPLE!
-          |PLEASE USE THE LogisticRegression METHOD FOUND IN org.apache.spark.mllib.classification FOR
-          |MORE CONVENTIONAL USE
-        """.stripMargin)
-      System.exit(1)
-    }
+  def showWarning() {
     System.err.println(
       """WARNING: THIS IS A NAIVE IMPLEMENTATION OF LOGISTIC REGRESSION AND IS GIVEN AS AN EXAMPLE!
         |PLEASE USE THE LogisticRegression METHOD FOUND IN org.apache.spark.mllib.classification FOR
         |MORE CONVENTIONAL USE
       """.stripMargin)
+  }
+
+  def main(args: Array[String]) {
+    if (args.length < 2) {
+      System.err.println("Usage: SparkHdfsLR <file> <iters>")
+      showWarning()
+      System.exit(1)
+    }
+    showWarning()
     val sparkConf = new SparkConf().setAppName("SparkHdfsLR")
     val inputPath = args(0)
     val conf = SparkHadoopUtil.get.newConfiguration()
@@ -87,11 +87,7 @@ object SparkHdfsLR {
     }
 
     println("Final w: " + w)
-    System.err.println(
-      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF LOGISTIC REGRESSION AND IS GIVEN AS AN EXAMPLE!
-        |PLEASE USE THE LogisticRegression METHOD FOUND IN org.apache.spark.mllib.classification FOR
-        |MORE CONVENTIONAL USE
-      """.stripMargin)
+    showWarning()
     sc.stop()
   }
 }

--- a/examples/src/main/scala/org/apache/spark/examples/SparkHdfsLR.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/SparkHdfsLR.scala
@@ -51,9 +51,18 @@ object SparkHdfsLR {
   def main(args: Array[String]) {
     if (args.length < 2) {
       System.err.println("Usage: SparkHdfsLR <file> <iters>")
+      System.err.println(
+        """WARNING: THIS IS A NAIVE IMPLEMENTATION OF LOGISTIC REGRESSION AND IS GIVEN AS AN EXAMPLE!
+          |PLEASE USE THE LogisticRegression METHOD FOUND IN org.apache.spark.mllib.classification FOR
+          |MORE CONVENTIONAL USE
+        """.stripMargin)
       System.exit(1)
     }
-
+    System.err.println(
+      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF LOGISTIC REGRESSION AND IS GIVEN AS AN EXAMPLE!
+        |PLEASE USE THE LogisticRegression METHOD FOUND IN org.apache.spark.mllib.classification FOR
+        |MORE CONVENTIONAL USE
+      """.stripMargin)
     val sparkConf = new SparkConf().setAppName("SparkHdfsLR")
     val inputPath = args(0)
     val conf = SparkHadoopUtil.get.newConfiguration()
@@ -78,6 +87,11 @@ object SparkHdfsLR {
     }
 
     println("Final w: " + w)
+    System.err.println(
+      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF LOGISTIC REGRESSION AND IS GIVEN AS AN EXAMPLE!
+        |PLEASE USE THE LogisticRegression METHOD FOUND IN org.apache.spark.mllib.classification FOR
+        |MORE CONVENTIONAL USE
+      """.stripMargin)
     sc.stop()
   }
 }

--- a/examples/src/main/scala/org/apache/spark/examples/SparkHdfsLR.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/SparkHdfsLR.scala
@@ -55,7 +55,7 @@ object SparkHdfsLR {
     System.err.println(
       """WARN: This is a naive implementation of Logistic Regression and is given as an example!
         |Please use the LogisticRegression method found in org.apache.spark.mllib.classification
-        |for more conventional use
+        |for more conventional use.
       """.stripMargin)
   }
 

--- a/examples/src/main/scala/org/apache/spark/examples/SparkKMeans.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/SparkKMeans.scala
@@ -23,7 +23,8 @@ import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.SparkContext._
 
 /**
- * K-means clustering.
+ * K-means clustering. This is an example implementation for learning how to use Spark.
+ * For more conventional use, please refer to org.apache.spark.mllib.clustering.KMeans
  */
 object SparkKMeans {
 
@@ -55,9 +56,10 @@ object SparkKMeans {
   }
 
   def main(args: Array[String]) {
+
+    showWarning()
     if (args.length < 3) {
       System.err.println("Usage: SparkKMeans <file> <k> <convergeDist>")
-      showWarning()
       System.exit(1)
     }
 
@@ -92,7 +94,6 @@ object SparkKMeans {
 
     println("Final centers:")
     kPoints.foreach(println)
-    showWarning()
     sc.stop()
   }
 }

--- a/examples/src/main/scala/org/apache/spark/examples/SparkKMeans.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/SparkKMeans.scala
@@ -46,21 +46,21 @@ object SparkKMeans {
     bestIndex
   }
 
-  def main(args: Array[String]) {
-    if (args.length < 3) {
-      System.err.println("Usage: SparkKMeans <file> <k> <convergeDist>"
-        System.err.println(
-          """WARNING: THIS IS A NAIVE IMPLEMENTATION OF K-MEANS CLUSTERING AND IS GIVEN AS AN EXAMPLE!
-            |PLEASE USE THE KMeans METHOD FOUND IN org.apache.spark.mllib.clustering FOR
-            |MORE CONVENTIONAL USE
-          """.stripMargin)
-      System.exit(1)
-    }
+  def showWarning() {
     System.err.println(
       """WARNING: THIS IS A NAIVE IMPLEMENTATION OF K-MEANS CLUSTERING AND IS GIVEN AS AN EXAMPLE!
         |PLEASE USE THE KMeans METHOD FOUND IN org.apache.spark.mllib.clustering FOR
         |MORE CONVENTIONAL USE
       """.stripMargin)
+  }
+
+  def main(args: Array[String]) {
+    if (args.length < 3) {
+      System.err.println("Usage: SparkKMeans <file> <k> <convergeDist>")
+      showWarning()
+      System.exit(1)
+    }
+
     val sparkConf = new SparkConf().setAppName("SparkKMeans")
     val sc = new SparkContext(sparkConf)
     val lines = sc.textFile(args(0))
@@ -92,11 +92,7 @@ object SparkKMeans {
 
     println("Final centers:")
     kPoints.foreach(println)
-    System.err.println(
-      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF K-MEANS CLUSTERING AND IS GIVEN AS AN EXAMPLE!
-        |PLEASE USE THE KMeans METHOD FOUND IN org.apache.spark.mllib.clustering FOR
-        |MORE CONVENTIONAL USE
-      """.stripMargin)
+    showWarning()
     sc.stop()
   }
 }

--- a/examples/src/main/scala/org/apache/spark/examples/SparkKMeans.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/SparkKMeans.scala
@@ -23,8 +23,10 @@ import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.SparkContext._
 
 /**
- * K-means clustering. This is an example implementation for learning how to use Spark.
- * For more conventional use, please refer to org.apache.spark.mllib.clustering.KMeans
+ * K-means clustering.
+ *
+ * This is an example implementation for learning how to use Spark. For more conventional use,
+ * please refer to org.apache.spark.mllib.clustering.KMeans
  */
 object SparkKMeans {
 
@@ -49,19 +51,20 @@ object SparkKMeans {
 
   def showWarning() {
     System.err.println(
-      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF K-MEANS CLUSTERING AND IS GIVEN AS AN EXAMPLE!
-        |PLEASE USE THE KMeans METHOD FOUND IN org.apache.spark.mllib.clustering FOR
-        |MORE CONVENTIONAL USE
+      """WARN: This is a naive implementation of KMeans Clustering and is given as an example!
+        |Please use the KMeans method found in org.apache.spark.mllib.clustering
+        |for more conventional use
       """.stripMargin)
   }
 
   def main(args: Array[String]) {
 
-    showWarning()
     if (args.length < 3) {
       System.err.println("Usage: SparkKMeans <file> <k> <convergeDist>")
       System.exit(1)
     }
+
+    showWarning()
 
     val sparkConf = new SparkConf().setAppName("SparkKMeans")
     val sc = new SparkContext(sparkConf)

--- a/examples/src/main/scala/org/apache/spark/examples/SparkKMeans.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/SparkKMeans.scala
@@ -48,9 +48,19 @@ object SparkKMeans {
 
   def main(args: Array[String]) {
     if (args.length < 3) {
-      System.err.println("Usage: SparkKMeans <file> <k> <convergeDist>")
+      System.err.println("Usage: SparkKMeans <file> <k> <convergeDist>"
+        System.err.println(
+          """WARNING: THIS IS A NAIVE IMPLEMENTATION OF K-MEANS CLUSTERING AND IS GIVEN AS AN EXAMPLE!
+            |PLEASE USE THE KMeans METHOD FOUND IN org.apache.spark.mllib.clustering FOR
+            |MORE CONVENTIONAL USE
+          """.stripMargin)
       System.exit(1)
     }
+    System.err.println(
+      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF K-MEANS CLUSTERING AND IS GIVEN AS AN EXAMPLE!
+        |PLEASE USE THE KMeans METHOD FOUND IN org.apache.spark.mllib.clustering FOR
+        |MORE CONVENTIONAL USE
+      """.stripMargin)
     val sparkConf = new SparkConf().setAppName("SparkKMeans")
     val sc = new SparkContext(sparkConf)
     val lines = sc.textFile(args(0))
@@ -82,6 +92,11 @@ object SparkKMeans {
 
     println("Final centers:")
     kPoints.foreach(println)
+    System.err.println(
+      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF K-MEANS CLUSTERING AND IS GIVEN AS AN EXAMPLE!
+        |PLEASE USE THE KMeans METHOD FOUND IN org.apache.spark.mllib.clustering FOR
+        |MORE CONVENTIONAL USE
+      """.stripMargin)
     sc.stop()
   }
 }

--- a/examples/src/main/scala/org/apache/spark/examples/SparkKMeans.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/SparkKMeans.scala
@@ -53,7 +53,7 @@ object SparkKMeans {
     System.err.println(
       """WARN: This is a naive implementation of KMeans Clustering and is given as an example!
         |Please use the KMeans method found in org.apache.spark.mllib.clustering
-        |for more conventional use
+        |for more conventional use.
       """.stripMargin)
   }
 

--- a/examples/src/main/scala/org/apache/spark/examples/SparkLR.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/SparkLR.scala
@@ -27,7 +27,8 @@ import org.apache.spark._
 
 /**
  * Logistic regression based classification.
- * Usage: SparkLR [slices]
+ * Usage: SparkLR [slices] This is an example implementation for learning how to use Spark.
+ * For more conventional use, please refer to org.apache.spark.mllib.classification.LogisticRegression
  */
 object SparkLR {
   val N = 10000  // Number of data points
@@ -56,12 +57,14 @@ object SparkLR {
   }
 
   def main(args: Array[String]) {
+    showWarning()
+
     val sparkConf = new SparkConf().setAppName("SparkLR")
     val sc = new SparkContext(sparkConf)
     val numSlices = if (args.length > 0) args(0).toInt else 2
     val points = sc.parallelize(generateData, numSlices).cache()
 
-    showWarning()
+
     // Initialize w to a random value
     var w = DenseVector.fill(D){2 * rand.nextDouble - 1}
     println("Initial w: " + w)
@@ -75,7 +78,6 @@ object SparkLR {
     }
 
     println("Final w: " + w)
-    showWarning()
 
     sc.stop()
   }

--- a/examples/src/main/scala/org/apache/spark/examples/SparkLR.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/SparkLR.scala
@@ -47,16 +47,21 @@ object SparkLR {
     Array.tabulate(N)(generatePoint)
   }
 
-  def main(args: Array[String]) {
-    val sparkConf = new SparkConf().setAppName("SparkLR")
-    val sc = new SparkContext(sparkConf)
-    val numSlices = if (args.length > 0) args(0).toInt else 2
-    val points = sc.parallelize(generateData, numSlices).cache()
+  def showWarning() {
     System.err.println(
       """WARNING: THIS IS A NAIVE IMPLEMENTATION OF LOGISTIC REGRESSION AND IS GIVEN AS AN EXAMPLE!
         |PLEASE USE THE LogisticRegression METHOD FOUND IN org.apache.spark.mllib.classification FOR
         |MORE CONVENTIONAL USE
       """.stripMargin)
+  }
+
+  def main(args: Array[String]) {
+    val sparkConf = new SparkConf().setAppName("SparkLR")
+    val sc = new SparkContext(sparkConf)
+    val numSlices = if (args.length > 0) args(0).toInt else 2
+    val points = sc.parallelize(generateData, numSlices).cache()
+
+    showWarning()
     // Initialize w to a random value
     var w = DenseVector.fill(D){2 * rand.nextDouble - 1}
     println("Initial w: " + w)
@@ -70,11 +75,8 @@ object SparkLR {
     }
 
     println("Final w: " + w)
-    System.err.println(
-      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF LOGISTIC REGRESSION AND IS GIVEN AS AN EXAMPLE!
-        |PLEASE USE THE LogisticRegression METHOD FOUND IN org.apache.spark.mllib.classification FOR
-        |MORE CONVENTIONAL USE
-      """.stripMargin)
+    showWarning()
+
     sc.stop()
   }
 }

--- a/examples/src/main/scala/org/apache/spark/examples/SparkLR.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/SparkLR.scala
@@ -27,8 +27,10 @@ import org.apache.spark._
 
 /**
  * Logistic regression based classification.
- * Usage: SparkLR [slices] This is an example implementation for learning how to use Spark.
- * For more conventional use, please refer to org.apache.spark.mllib.classification.LogisticRegression
+ * Usage: SparkLR [slices]
+ *
+ * This is an example implementation for learning how to use Spark. For more conventional use,
+ * please refer to org.apache.spark.mllib.classification.LogisticRegression
  */
 object SparkLR {
   val N = 10000  // Number of data points
@@ -50,20 +52,20 @@ object SparkLR {
 
   def showWarning() {
     System.err.println(
-      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF LOGISTIC REGRESSION AND IS GIVEN AS AN EXAMPLE!
-        |PLEASE USE THE LogisticRegression METHOD FOUND IN org.apache.spark.mllib.classification FOR
-        |MORE CONVENTIONAL USE
+      """WARN: This is a naive implementation of Logistic Regression and is given as an example!
+        |Please use the LogisticRegression method found in org.apache.spark.mllib.classification
+        |for more conventional use
       """.stripMargin)
   }
 
   def main(args: Array[String]) {
+
     showWarning()
 
     val sparkConf = new SparkConf().setAppName("SparkLR")
     val sc = new SparkContext(sparkConf)
     val numSlices = if (args.length > 0) args(0).toInt else 2
     val points = sc.parallelize(generateData, numSlices).cache()
-
 
     // Initialize w to a random value
     var w = DenseVector.fill(D){2 * rand.nextDouble - 1}

--- a/examples/src/main/scala/org/apache/spark/examples/SparkLR.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/SparkLR.scala
@@ -52,7 +52,11 @@ object SparkLR {
     val sc = new SparkContext(sparkConf)
     val numSlices = if (args.length > 0) args(0).toInt else 2
     val points = sc.parallelize(generateData, numSlices).cache()
-
+    System.err.println(
+      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF LOGISTIC REGRESSION AND IS GIVEN AS AN EXAMPLE!
+        |PLEASE USE THE LogisticRegression METHOD FOUND IN org.apache.spark.mllib.classification FOR
+        |MORE CONVENTIONAL USE
+      """.stripMargin)
     // Initialize w to a random value
     var w = DenseVector.fill(D){2 * rand.nextDouble - 1}
     println("Initial w: " + w)
@@ -66,6 +70,11 @@ object SparkLR {
     }
 
     println("Final w: " + w)
+    System.err.println(
+      """WARNING: THIS IS A NAIVE IMPLEMENTATION OF LOGISTIC REGRESSION AND IS GIVEN AS AN EXAMPLE!
+        |PLEASE USE THE LogisticRegression METHOD FOUND IN org.apache.spark.mllib.classification FOR
+        |MORE CONVENTIONAL USE
+      """.stripMargin)
     sc.stop()
   }
 }

--- a/examples/src/main/scala/org/apache/spark/examples/SparkLR.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/SparkLR.scala
@@ -54,7 +54,7 @@ object SparkLR {
     System.err.println(
       """WARN: This is a naive implementation of Logistic Regression and is given as an example!
         |Please use the LogisticRegression method found in org.apache.spark.mllib.classification
-        |for more conventional use
+        |for more conventional use.
       """.stripMargin)
   }
 


### PR DESCRIPTION
[SPARK-2434][MLlib]: Warning messages that refer users to the original MLlib implementations of some popular example machine learning algorithms added both in the comments and the code. The following examples have been modified:
Scala:
- LocalALS
- LocalFileLR
- LocalKMeans
- LocalLP
- SparkALS
- SparkHdfsLR
- SparkKMeans
- SparkLR
  Python:
  - kmeans.py
  - als.py
  - logistic_regression.py
