### PR TITLE
[SPARK-2567] Resubmitted stage sometimes remains as active stage in the web UI

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -753,10 +753,6 @@ class DAGScheduler(
       null
     }
 
-    // must be run listener before possible NotSerializableException
-    // should be "StageSubmitted" first and then "JobEnded"
-    listenerBus.post(SparkListenerStageSubmitted(stageToInfos(stage), properties))
-
     if (tasks.size > 0) {
       // Preemptively serialize a task to make sure it can be serialized. We are catching this
       // exception here because it would be fairly hard to catch the non-serializable exception
@@ -774,6 +770,10 @@ class DAGScheduler(
           runningStages -= stage
           return
       }
+
+      // must be run listener before possible NotSerializableException
+      // should be "StageSubmitted" first and then "JobEnded"
+      listenerBus.post(SparkListenerStageSubmitted(stageToInfos(stage), properties))
 
       logInfo("Submitting " + tasks.size + " missing tasks from " + stage + " (" + stage.rdd + ")")
       myPending ++= tasks


### PR DESCRIPTION
Moved the line which post SparkListenerStageSubmitted to the back of check of tasks size and serializability.
