### PR TITLE
[SPARK-2505][MLlib] Weighted Regularizer for Generalized Linear Model 

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/classification/LogisticRegression.scala
@@ -77,23 +77,21 @@ class LogisticRegressionModel private[mllib] (
 class LogisticRegressionWithSGD private (
     private var stepSize: Double,
     private var numIterations: Int,
-    private var regParam: Double,
     private var miniBatchFraction: Double)
   extends GeneralizedLinearAlgorithm[LogisticRegressionModel] with Serializable {
 
   private val gradient = new LogisticGradient()
-  private val updater = new SimpleUpdater()
-  override val optimizer = new GradientDescent(gradient, updater)
+  private val regularizer = new SimpleRegularizer()
+  override val optimizer = new GradientDescent(gradient, regularizer)
     .setStepSize(stepSize)
     .setNumIterations(numIterations)
-    .setRegParam(regParam)
     .setMiniBatchFraction(miniBatchFraction)
   override protected val validators = List(DataValidators.binaryLabelValidator)
 
   /**
    * Construct a LogisticRegression object with default parameters
    */
-  def this() = this(1.0, 100, 0.0, 1.0)
+  def this() = this(1.0, 100, 1.0)
 
   override protected def createModel(weights: Vector, intercept: Double) = {
     new LogisticRegressionModel(weights, intercept)
@@ -128,7 +126,7 @@ object LogisticRegressionWithSGD {
       stepSize: Double,
       miniBatchFraction: Double,
       initialWeights: Vector): LogisticRegressionModel = {
-    new LogisticRegressionWithSGD(stepSize, numIterations, 0.0, miniBatchFraction)
+    new LogisticRegressionWithSGD(stepSize, numIterations, miniBatchFraction)
       .run(input, initialWeights)
   }
 
@@ -149,7 +147,7 @@ object LogisticRegressionWithSGD {
       numIterations: Int,
       stepSize: Double,
       miniBatchFraction: Double): LogisticRegressionModel = {
-    new LogisticRegressionWithSGD(stepSize, numIterations, 0.0, miniBatchFraction)
+    new LogisticRegressionWithSGD(stepSize, numIterations, miniBatchFraction)
       .run(input)
   }
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/classification/SVM.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/classification/SVM.scala
@@ -83,11 +83,10 @@ class SVMWithSGD private (
   extends GeneralizedLinearAlgorithm[SVMModel] with Serializable {
 
   private val gradient = new HingeGradient()
-  private val updater = new SquaredL2Updater()
-  override val optimizer = new GradientDescent(gradient, updater)
+  private val regularizer = new L2Regularizer(regParam)
+  override val optimizer = new GradientDescent(gradient, regularizer)
     .setStepSize(stepSize)
     .setNumIterations(numIterations)
-    .setRegParam(regParam)
     .setMiniBatchFraction(miniBatchFraction)
   override protected val validators = List(DataValidators.binaryLabelValidator)
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/optimization/Regularizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/optimization/Regularizer.scala
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.mllib.optimization
+
+import scala.collection.mutable.ListBuffer
+import scala.math._
+
+import breeze.linalg.{DenseVector => BDV, Vector => BV}
+
+import org.apache.spark.mllib.linalg.{Vectors, Vector}
+
+abstract class Regularizer extends Serializable {
+  var isSmooth: Boolean = true
+
+  def add(that: Regularizer): CompositeRegularizer = {
+    (new CompositeRegularizer).add(this).add(that)
+  }
+
+  def compute(weights: Vector, cumGradient: Vector): Double
+}
+
+class SimpleRegularizer extends Regularizer {
+    isSmooth = true
+
+  override def compute(weights: Vector, cumGradient: Vector): Double = 0
+}
+
+class CompositeRegularizer extends Regularizer {
+   isSmooth = true
+
+  protected val regularizers = ListBuffer[Regularizer]()
+
+  override def add(that: Regularizer): this.type = {
+    if (this.isSmooth && !that.isSmooth) isSmooth = false
+    regularizers.append(that)
+    this
+  }
+
+  override def compute(weights: Vector, cumGradient: Vector): Double = {
+    if (regularizers.isEmpty) {
+      0.0
+    } else {
+      regularizers.foldLeft(0.0)((loss: Double, x: Regularizer) =>
+        loss + x.compute(weights, cumGradient)
+      )
+    }
+  }
+}
+
+class L1Regularizer(private val regParam: BV[Double]) extends Regularizer {
+   isSmooth = false
+
+  def this(regParam: Double) = this(new BDV[Double](Array[Double](regParam)))
+
+  def this(regParam: Vector) = this(regParam.toBreeze)
+
+  def compute(weights: Vector, cumGradient: Vector): Double = {
+    val brzWeights = weights.toBreeze
+    val brzCumGradient = cumGradient.toBreeze
+
+    if (regParam.length > 1) require(brzWeights.length == regParam.length)
+
+    if (regParam.length == 1 && regParam(0) == 0.0) {
+      0.0
+    }
+    else {
+      var loss: Double = 0.0
+      brzWeights.activeIterator.foreach {
+        case (_, 0.0) => // Skip explicit zero elements.
+        case (i, value) => {
+          val lambda = if (regParam.length > 1) regParam(i) else regParam(0)
+          loss += lambda * Math.abs(value)
+          brzCumGradient(i) += lambda * signum(value)
+        }
+      }
+      loss
+    }
+  }
+}
+
+class L2Regularizer(private val regParam: BV[Double]) extends Regularizer {
+   isSmooth = true
+
+  def this(regParam: Double) = this(new BDV[Double](Array[Double](regParam)))
+
+  def this(regParam: Vector) = this(regParam.toBreeze)
+
+  def compute(weights: Vector, cumGradient: Vector): Double = {
+    val brzWeights = weights.toBreeze
+    val brzCumGradient = cumGradient.toBreeze
+
+    if (regParam.length > 1) require(brzWeights.length == regParam.length)
+
+    if (regParam.length == 1 && regParam(0) == 0) {
+      0.0
+    }
+    else {
+      var loss: Double = 0.0
+      brzWeights.activeIterator.foreach {
+        case (_, 0.0) => // Skip explicit zero elements.
+        case (i, value) => {
+          val lambda = if (regParam.length > 1) regParam(i) else regParam(0)
+          loss += lambda * value * value / 2.0
+          brzCumGradient(i) += lambda * value
+        }
+      }
+      loss
+    }
+  }
+}
+
+class ElasticNetRegularizer(private val regParam: BV[Double], private val alpha: Double)
+  extends CompositeRegularizer {
+
+  def this(regParam: Double, alpha: Double) = this(new BDV[Double](Array[Double](regParam)), alpha)
+
+  def this(regParam: Vector, alpha: Double) = this(regParam.toBreeze, alpha)
+
+  if (alpha != 0.0) {
+    this.add(new L2Regularizer(Vectors.fromBreeze(this.regParam * alpha)))
+  }
+  if (alpha != 1.0) {
+    this.add(new L1Regularizer(Vectors.fromBreeze(this.regParam * (1.0 - alpha))))
+  }
+}

--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/Lasso.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/Lasso.scala
@@ -58,11 +58,10 @@ class LassoWithSGD private (
   extends GeneralizedLinearAlgorithm[LassoModel] with Serializable {
 
   private val gradient = new LeastSquaresGradient()
-  private val updater = new L1Updater()
-  override val optimizer = new GradientDescent(gradient, updater)
+  private val regularizer = new L1Regularizer(regParam)
+  override val optimizer = new GradientDescent(gradient, regularizer)
     .setStepSize(stepSize)
     .setNumIterations(numIterations)
-    .setRegParam(regParam)
     .setMiniBatchFraction(miniBatchFraction)
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/LinearRegression.scala
@@ -56,8 +56,8 @@ class LinearRegressionWithSGD private (
   extends GeneralizedLinearAlgorithm[LinearRegressionModel] with Serializable {
 
   private val gradient = new LeastSquaresGradient()
-  private val updater = new SimpleUpdater()
-  override val optimizer = new GradientDescent(gradient, updater)
+  private val regularizer = new SimpleRegularizer()
+  override val optimizer = new GradientDescent(gradient, regularizer)
     .setStepSize(stepSize)
     .setNumIterations(numIterations)
     .setMiniBatchFraction(miniBatchFraction)

--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/RidgeRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/RidgeRegression.scala
@@ -58,12 +58,11 @@ class RidgeRegressionWithSGD private (
   extends GeneralizedLinearAlgorithm[RidgeRegressionModel] with Serializable {
 
   private val gradient = new LeastSquaresGradient()
-  private val updater = new SquaredL2Updater()
+  private val regularizer = new L2Regularizer(regParam)
 
-  override val optimizer = new GradientDescent(gradient, updater)
+  override val optimizer = new GradientDescent(gradient, regularizer)
     .setStepSize(stepSize)
     .setNumIterations(numIterations)
-    .setRegParam(regParam)
     .setMiniBatchFraction(miniBatchFraction)
 
   /**

--- a/mllib/src/test/scala/org/apache/spark/mllib/optimization/GradientDescentSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/optimization/GradientDescentSuite.scala
@@ -72,10 +72,9 @@ class GradientDescentSuite extends FunSuite with LocalSparkContext with Matchers
     val initialWeights = Array(initialB)
 
     val gradient = new LogisticGradient()
-    val updater = new SimpleUpdater()
+    val regularizer = new SimpleRegularizer()
     val stepSize = 1.0
     val numIterations = 10
-    val regParam = 0
     val miniBatchFrac = 1.0
 
     // Add a extra variable consisting of all 1.0's for the intercept.
@@ -90,10 +89,9 @@ class GradientDescentSuite extends FunSuite with LocalSparkContext with Matchers
     val (_, loss) = GradientDescent.runMiniBatchSGD(
       dataRDD,
       gradient,
-      updater,
+      regularizer,
       stepSize,
       numIterations,
-      regParam,
       miniBatchFrac,
       initialWeightsWithIntercept)
 
@@ -106,7 +104,6 @@ class GradientDescentSuite extends FunSuite with LocalSparkContext with Matchers
   test("Test the loss and gradient of first iteration with regularization.") {
 
     val gradient = new LogisticGradient()
-    val updater = new SquaredL2Updater()
 
     // Add a extra variable consisting of all 1.0's for the intercept.
     val testData = GradientDescentSuite.generateGDInput(2.0, -1.5, 10000, 42)
@@ -119,13 +116,13 @@ class GradientDescentSuite extends FunSuite with LocalSparkContext with Matchers
     // Prepare non-zero weights
     val initialWeightsWithIntercept = Vectors.dense(1.0, 0.5)
 
-    val regParam0 = 0
+    val regularizer0 = new L2Regularizer(0.0)
     val (newWeights0, loss0) = GradientDescent.runMiniBatchSGD(
-      dataRDD, gradient, updater, 1, 1, regParam0, 1.0, initialWeightsWithIntercept)
+      dataRDD, gradient, regularizer0, 1, 1, 1.0, initialWeightsWithIntercept)
 
-    val regParam1 = 1
+    val regularizer1 = new L2Regularizer(1.0)
     val (newWeights1, loss1) = GradientDescent.runMiniBatchSGD(
-      dataRDD, gradient, updater, 1, 1, regParam1, 1.0, initialWeightsWithIntercept)
+      dataRDD, gradient, regularizer1, 1, 1, 1.0, initialWeightsWithIntercept)
 
     def compareDouble(x: Double, y: Double, tol: Double = 1E-3): Boolean = {
       math.abs(x - y) / (math.abs(y) + 1e-15) < tol

--- a/mllib/src/test/scala/org/apache/spark/mllib/optimization/LBFGSSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/optimization/LBFGSSuite.scala
@@ -62,11 +62,10 @@ class LBFGSSuite extends FunSuite with LocalSparkContext with Matchers {
     val (_, loss) = LBFGS.runLBFGS(
       dataRDD,
       gradient,
-      simpleUpdater,
+      new SimpleRegularizer(),
       numCorrections,
       convergenceTol,
       maxNumIterations,
-      regParam,
       initialWeightsWithIntercept)
 
     // Since the cost function is convex, the loss is guaranteed to be monotonically decreasing
@@ -80,10 +79,9 @@ class LBFGSSuite extends FunSuite with LocalSparkContext with Matchers {
     val (_, lossGD) = GradientDescent.runMiniBatchSGD(
       dataRDD,
       gradient,
-      simpleUpdater,
+      new SimpleRegularizer(),
       stepSize,
       numGDIterations,
-      regParam,
       miniBatchFrac,
       initialWeightsWithIntercept)
 
@@ -106,11 +104,10 @@ class LBFGSSuite extends FunSuite with LocalSparkContext with Matchers {
     val (weightLBFGS, lossLBFGS) = LBFGS.runLBFGS(
       dataRDD,
       gradient,
-      squaredL2Updater,
+      new L2Regularizer(regParam),
       numCorrections,
       convergenceTol,
       maxNumIterations,
-      regParam,
       initialWeightsWithIntercept)
 
     val numGDIterations = 50
@@ -118,10 +115,9 @@ class LBFGSSuite extends FunSuite with LocalSparkContext with Matchers {
     val (weightGD, lossGD) = GradientDescent.runMiniBatchSGD(
       dataRDD,
       gradient,
-      squaredL2Updater,
+      new L2Regularizer(regParam),
       stepSize,
       numGDIterations,
-      regParam,
       miniBatchFrac,
       initialWeightsWithIntercept)
 
@@ -151,11 +147,10 @@ class LBFGSSuite extends FunSuite with LocalSparkContext with Matchers {
     val (_, lossLBFGS1) = LBFGS.runLBFGS(
       dataRDD,
       gradient,
-      squaredL2Updater,
+      new L2Regularizer(regParam),
       numCorrections,
       convergenceTol,
       maxNumIterations,
-      regParam,
       initialWeightsWithIntercept)
 
     // Note that the first loss is computed with initial weights,
@@ -166,11 +161,10 @@ class LBFGSSuite extends FunSuite with LocalSparkContext with Matchers {
     val (_, lossLBFGS2) = LBFGS.runLBFGS(
       dataRDD,
       gradient,
-      squaredL2Updater,
+      new L2Regularizer(regParam),
       numCorrections,
       convergenceTol,
       maxNumIterations,
-      regParam,
       initialWeightsWithIntercept)
 
     // Based on observation, lossLBFGS2 runs 3 iterations, no theoretically guaranteed.
@@ -181,11 +175,10 @@ class LBFGSSuite extends FunSuite with LocalSparkContext with Matchers {
     val (_, lossLBFGS3) = LBFGS.runLBFGS(
       dataRDD,
       gradient,
-      squaredL2Updater,
+      new L2Regularizer(regParam),
       numCorrections,
       convergenceTol,
       maxNumIterations,
-      regParam,
       initialWeightsWithIntercept)
 
     // With smaller convergenceTol, it takes more steps.
@@ -204,11 +197,10 @@ class LBFGSSuite extends FunSuite with LocalSparkContext with Matchers {
     val convergenceTol = 1e-12
     val maxNumIterations = 10
 
-    val lbfgsOptimizer = new LBFGS(gradient, squaredL2Updater)
+    val lbfgsOptimizer = new LBFGS(gradient, new L2Regularizer(regParam))
       .setNumCorrections(numCorrections)
       .setConvergenceTol(convergenceTol)
       .setMaxNumIterations(maxNumIterations)
-      .setRegParam(regParam)
 
     val weightLBFGS = lbfgsOptimizer.optimize(dataRDD, initialWeightsWithIntercept)
 
@@ -217,10 +209,9 @@ class LBFGSSuite extends FunSuite with LocalSparkContext with Matchers {
     val (weightGD, _) = GradientDescent.runMiniBatchSGD(
       dataRDD,
       gradient,
-      squaredL2Updater,
+      new L2Regularizer(regParam),
       stepSize,
       numGDIterations,
-      regParam,
       miniBatchFrac,
       initialWeightsWithIntercept)
 


### PR DESCRIPTION
(Note: This is not ready to be merged. Need documentation, and make sure it's backforwad compatible with Spark 1.0 apis). 

The current implementation of regularization in linear model is using `Updater`, and this design has couple issues as the following.
1) It will penalize all the weights including intercept. In machine learning training process, typically, people don't penalize the intercept. 
2) The `Updater` has the logic of adaptive step size for gradient decent, and we would like to clean it up by separating the logic of regularization out from updater to regularizer so in LBFGS optimizer, we don't need the trick for getting the loss and gradient of objective function.
In this work, a weighted regularizer will be implemented, and users can exclude the intercept or any weight from regularization by setting that term with zero weighted penalty. Since the regularizer will return a tuple of loss and gradient, the adaptive step size logic, and soft thresholding for L1 in Updater will be moved to SGD optimizer.
