### PR TITLE
[SPARK-2705][CORE] Fixed stage description in stage info page

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/jobs/StageTable.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StageTable.scala
@@ -119,14 +119,14 @@ private[ui] class StageTableBase(
       </div>
     }
 
-    val stageDataOption = listener.stageIdToData.get(s.stageId)
-    // Too many nested map/flatMaps with options are just annoying to read. Do this imperatively.
-    if (stageDataOption.isDefined && stageDataOption.get.description.isDefined) {
-      val desc = stageDataOption.get.description
-      <div><em>{desc}</em></div><div>{killLink} {nameLink} {details}</div>
-    } else {
-      <div>{killLink} {nameLink} {details}</div>
+    val stageDesc = for {
+      stageData <- listener.stageIdToData.get(s.stageId)
+      desc <- stageData.description
+    } yield {
+      <div><em>{desc}</em></div>
     }
+
+    <div>{stageDesc.getOrElse("")} {killLink} {nameLink} {details}</div>
   }
 
   protected def stageRow(s: StageInfo): Seq[Node] = {


### PR DESCRIPTION
Stage description should be a `String`, but was changed to an `Option[String]` by mistake:

![stage-desc-small](https://cloud.githubusercontent.com/assets/230655/3655611/f6d0b0f6-117b-11e4-83ed-71000dcd5009.png)
