### PR TITLE
Fix maven test bug

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -243,6 +243,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+	    <groupId>cglib</groupId>
+	    <artifactId>cglib</artifactId>
+	    <version>3.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+	    <groupId>org.objenesis</groupId>
+	    <artifactId>objenesis</artifactId>
+	    <version>2.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -243,15 +243,15 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-	    <groupId>cglib</groupId>
-	    <artifactId>cglib</artifactId>
-	    <version>3.1</version>
+      <groupId>cglib</groupId>
+      <artifactId>cglib</artifactId>
+      <version>3.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-	    <groupId>org.objenesis</groupId>
-	    <artifactId>objenesis</artifactId>
-	    <version>2.1</version>
+      <groupId>org.objenesis</groupId>
+      <artifactId>objenesis</artifactId>
+      <version>2.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
When running the mvn test, it will throw such exception in core module--"Class mocking requires to have cglib and objenesis librairies in the classpath"
So adding cglib and objenesis in pom.xml at core module can avoid such problem.
