### PR TITLE
[Build] SPARK-2619: Configurable filemode for the spark/bin folder in debian package

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -39,6 +39,7 @@
     <deb.pkg.name>spark</deb.pkg.name>
     <deb.install.path>/usr/share/spark</deb.install.path>
     <deb.user>root</deb.user>
+    <deb.bin.filemode>744</deb.bin.filemode>
   </properties>
 
   <dependencies>
@@ -276,7 +277,7 @@
                         <user>${deb.user}</user>
                         <group>${deb.user}</group>
                         <prefix>${deb.install.path}/bin</prefix>
-                        <filemode>744</filemode>
+                        <filemode>${deb.bin.filemode}</filemode>
                       </mapper>
                     </data>
                     <data>


### PR DESCRIPTION
Add  a `<deb.bin.filemode>744</deb.bin.filemode>` property to the `assembly/pom.xml` that defaults to `744`.  
Use this property for ../bin folder <filemode>. 

This patch doesn't change the current default modes but allows one override the modes at build time: 
`-Ddeb.bin.filemode=<new mode>`
