### PR TITLE
[SPARK-2648] through shuffling blocksByAddress avoid much reducers to fetch data from a executor at a time

### DIFF
--- a/core/src/main/scala/org/apache/spark/shuffle/hash/BlockStoreShuffleFetcher.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/hash/BlockStoreShuffleFetcher.scala
@@ -19,7 +19,7 @@ package org.apache.spark.shuffle.hash
 
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.mutable.HashMap
-import scala.util.Random
+import org.apache.spark.util.Utils
 
 import org.apache.spark._
 import org.apache.spark.executor.ShuffleReadMetrics
@@ -74,7 +74,7 @@ private[hash] object BlockStoreShuffleFetcher extends Logging {
       }
     }
 
-    val shuffledBlocksByAddress = Random.shuffle(blocksByAddress)
+    val shuffledBlocksByAddress = Utils.randomize(blocksByAddress)
     val blockFetcherItr = blockManager.getMultiple(shuffledBlocksByAddress, serializer)
     val itr = blockFetcherItr.flatMap(unpackBlock)
 

--- a/core/src/main/scala/org/apache/spark/shuffle/hash/BlockStoreShuffleFetcher.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/hash/BlockStoreShuffleFetcher.scala
@@ -19,6 +19,7 @@ package org.apache.spark.shuffle.hash
 
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.mutable.HashMap
+import scala.util.Random
 
 import org.apache.spark._
 import org.apache.spark.executor.ShuffleReadMetrics
@@ -73,7 +74,8 @@ private[hash] object BlockStoreShuffleFetcher extends Logging {
       }
     }
 
-    val blockFetcherItr = blockManager.getMultiple(blocksByAddress, serializer)
+    val shuffledBlocksByAddress = Random.shuffle(blocksByAddress)
+    val blockFetcherItr = blockManager.getMultiple(shuffledBlocksByAddress, serializer)
     val itr = blockFetcherItr.flatMap(unpackBlock)
 
     val completionIter = CompletionIterator[T, Iterator[T]](itr, {

--- a/core/src/main/scala/org/apache/spark/storage/BlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockFetcherIterator.scala
@@ -217,7 +217,7 @@ object BlockFetcherIterator {
       // Split local and remote blocks.
       val remoteRequests = splitLocalRemoteBlocks()
       // Add the remote requests into our queue in a random order
-      fetchRequests ++= Utils.randomize(remoteRequests)
+      fetchRequests ++= remoteRequests
 
       // Send out initial requests for blocks, up to our maxBytesInFlight
       while (!fetchRequests.isEmpty &&
@@ -320,7 +320,7 @@ object BlockFetcherIterator {
       // Split Local Remote Blocks and set numBlocksToFetch
       val remoteRequests = splitLocalRemoteBlocks()
       // Add the remote requests into our queue in a random order
-      for (request <- Utils.randomize(remoteRequests)) {
+      for (request <- remoteRequests) {
         fetchRequestsSync.put(request)
       }
 


### PR DESCRIPTION
like mapreduce we need to shuffle blocksByAddress.it can avoid many reducers to connect a executor at a time.when a map has many paritions, at a time there has so much reduces connecting to this map.so it maybe make network's connect to timeout.
