### PR TITLE
SPARK-2604: Incorporating memory overhead of executor during the verifcation of cluster resources, before starting the application

### DIFF
--- a/yarn/alpha/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/alpha/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -71,7 +71,7 @@ class Client(clientArgs: ClientArguments, hadoopConf: Configuration, spConf: Spa
 
     val capability = Records.newRecord(classOf[Resource]).asInstanceOf[Resource]
     // Memory for the ApplicationMaster.
-    capability.setMemory(args.amMemory + memoryOverhead)
+    capability.setMemory(args.amMemory + amMemoryOverhead)
     amContainer.setResource(capability)
 
     appContext.setQueue(args.amQueue)

--- a/yarn/stable/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/stable/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -84,7 +84,7 @@ class Client(clientArgs: ClientArguments, hadoopConf: Configuration, spConf: Spa
 
     // Memory for the ApplicationMaster.
     val memoryResource = Records.newRecord(classOf[Resource]).asInstanceOf[Resource]
-    memoryResource.setMemory(args.amMemory + memoryOverhead)
+    memoryResource.setMemory(args.amMemory + amMemoryOverhead)
     appContext.setResource(memoryResource)
 
     // Finally, submit and monitor the application.


### PR DESCRIPTION
While doing the validation for resources of application master and executor resources with cluster resources, corrected the comparison for executor resources, to keep it in sync with allocation handler, where we add and check the memory overhead too. 
please see discussion https://issues.apache.org/jira/browse/SPARK-2604, to get more idea
