### PR TITLE
[SPARK-2666] when task failed with FetchFailed it need to cancel running tasks of failedStage

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -913,7 +913,11 @@ class DAGScheduler(
         // Mark the stage that the reducer was in as unrunnable
         val failedStage = stageIdToStage(task.stageId)
         runningStages -= failedStage
-        // TODO: Cancel running tasks in the stage
+        val job = jobIdToActiveJob(failedStage.jobId)
+        val shouldInterruptThread =
+          if (job.properties == null) false
+          else job.properties.getProperty(SparkContext.SPARK_JOB_INTERRUPT_ON_CANCEL, "false").toBoolean
+        taskScheduler.cancelTasks(task.stageId, shouldInterruptThread)
         logInfo("Marking " + failedStage + " (" + failedStage.name +
           ") for resubmision due to a fetch failure")
         // Mark the map whose fetch failed as broken in the map stage


### PR DESCRIPTION
in DAGScheduler's handleTaskCompletion,when task failed with FetchFailed reason, it need to cancel running tasks of failedStage before add failedStage to failedStages queue.
