### PR TITLE
[SPARK-2687] [yarn]amClient should remove ContainerRequest

### DIFF
--- a/yarn/stable/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocationHandler.scala
+++ b/yarn/stable/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocationHandler.scala
@@ -89,6 +89,8 @@ private[yarn] class YarnAllocationHandler(
   private val releasedContainerList = new CopyOnWriteArrayList[ContainerId]()
   // Containers to be released in next request to RM
   private val pendingReleaseContainers = new ConcurrentHashMap[ContainerId, Boolean]
+  // ContainerRequests which have been added to AMRMClient.
+  private val containerRequestList = new CopyOnWriteArrayList[ContainerRequest]()
 
   // Additional memory overhead - in mb.
   private def memoryOverhead: Int = sparkConf.getInt("spark.yarn.executor.memoryOverhead",
@@ -254,6 +256,7 @@ private[yarn] class YarnAllocationHandler(
 
         val executorMemoryOverhead = (executorMemory + memoryOverhead)
         assert(container.getResource.getMemory >= executorMemoryOverhead)
+        amClient.removeContainerRequest(containerRequestList.remove(1))
 
         if (numExecutorsRunningNow > maxExecutors) {
           logInfo("""Ignoring container %s at host %s, since we already have the required number of
@@ -474,6 +477,7 @@ private[yarn] class YarnAllocationHandler(
       }
 
     for (request <- containerRequests) {
+      containerRequestList += request
       amClient.addContainerRequest(request)
     }
 


### PR DESCRIPTION
in https://issues.apache.org/jira/browse/YARN-1902, after receving allocated containers,if amClient donot remove ContainerRequest,RM will continually allocate container for spark AppMaster. 
