### PR TITLE
[SPARK-2547]:The clustering documentaion example provided for spark 0.9....

### DIFF
--- a/docs/mllib-guide.md
+++ b/docs/mllib-guide.md
@@ -392,7 +392,7 @@ parsedData = data.map(lambda line: array([float(x) for x in line.split(' ')]))
 
 # Build the model (cluster the data)
 clusters = KMeans.train(parsedData, 2, maxIterations=10,
-        runs=30, initialization_mode="random")
+        runs=30, initializationMode="random")
 
 # Evaluate clustering by computing Within Set Sum of Squared Errors
 def error(point):


### PR DESCRIPTION
I modified a trivial mistake in the MLlib documentation.
I checked that the python sample code for a k-means clustering can correctly run on a EC2 instance.
