### PR TITLE
[SPARK-2713] Executors of same application in same host should only download files & jars once

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -809,7 +809,7 @@ class SparkContext(config: SparkConf) extends Logging {
     addedFiles(key) = timestamp
 
     // Fetch the file locally in case a job is executed using DAGScheduler.runLocally().
-    Utils.fetchCachedFile(path, new File(SparkFiles.getRootDirectory()), conf, env.securityManager,
+    Utils.fetchFile(path, new File(SparkFiles.getRootDirectory()), conf, env.securityManager,
       hadoopConfiguration, timestamp, useCache = false)
 
     logInfo("Added file " + path + " at " + key + " with timestamp " + addedFiles(key))

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -805,11 +805,12 @@ class SparkContext(config: SparkConf) extends Logging {
       case "local"       => "file:" + uri.getPath
       case _             => path
     }
-    addedFiles(key) = System.currentTimeMillis
+    val timestamp = System.currentTimeMillis
+    addedFiles(key) = timestamp
 
     // Fetch the file locally in case a job is executed using DAGScheduler.runLocally().
-    Utils.fetchFile(path, new File(SparkFiles.getRootDirectory()), conf, env.securityManager,
-      hadoopConfiguration)
+    Utils.fetchCachedFile(path, new File(SparkFiles.getRootDirectory()), conf, env.securityManager,
+      timestamp, hadoopConfiguration, false)
 
     logInfo("Added file " + path + " at " + key + " with timestamp " + addedFiles(key))
     postEnvironmentUpdate()

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -810,7 +810,7 @@ class SparkContext(config: SparkConf) extends Logging {
 
     // Fetch the file locally in case a job is executed using DAGScheduler.runLocally().
     Utils.fetchCachedFile(path, new File(SparkFiles.getRootDirectory()), conf, env.securityManager,
-      timestamp, hadoopConfiguration, false)
+      hadoopConfiguration, timestamp, useCache = false)
 
     logInfo("Added file " + path + " at " + key + " with timestamp " + addedFiles(key))
     postEnvironmentUpdate()

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -322,14 +322,16 @@ private[spark] class Executor(
       // Fetch missing dependencies
       for ((name, timestamp) <- newFiles if currentFiles.getOrElse(name, -1L) < timestamp) {
         logInfo("Fetching " + name + " with timestamp " + timestamp)
+        // Fetch file with useCache mode, close cache for local mode.
         Utils.fetchFile(name, new File(SparkFiles.getRootDirectory), conf,
-          env.securityManager, hadoopConf, timestamp, useCache = true)
+          env.securityManager, hadoopConf, timestamp, useCache = !isLocal)
         currentFiles(name) = timestamp
       }
       for ((name, timestamp) <- newJars if currentJars.getOrElse(name, -1L) < timestamp) {
         logInfo("Fetching " + name + " with timestamp " + timestamp)
+        // Fetch file with useCache mode, close cache for local mode.
         Utils.fetchFile(name, new File(SparkFiles.getRootDirectory), conf,
-          env.securityManager, hadoopConf, timestamp, useCache = true)
+          env.securityManager, hadoopConf, timestamp, useCache = !isLocal)
         currentJars(name) = timestamp
         // Add it to our class loader
         val localName = name.split("/").last

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -322,13 +322,13 @@ private[spark] class Executor(
       // Fetch missing dependencies
       for ((name, timestamp) <- newFiles if currentFiles.getOrElse(name, -1L) < timestamp) {
         logInfo("Fetching " + name + " with timestamp " + timestamp)
-        Utils.fetchCachedFile(name, new File(SparkFiles.getRootDirectory), conf,
+        Utils.fetchFile(name, new File(SparkFiles.getRootDirectory), conf,
           env.securityManager, hadoopConf, timestamp, true)
         currentFiles(name) = timestamp
       }
       for ((name, timestamp) <- newJars if currentJars.getOrElse(name, -1L) < timestamp) {
         logInfo("Fetching " + name + " with timestamp " + timestamp)
-        Utils.fetchCachedFile(name, new File(SparkFiles.getRootDirectory), conf,
+        Utils.fetchFile(name, new File(SparkFiles.getRootDirectory), conf,
           env.securityManager, hadoopConf, timestamp, true)
         currentJars(name) = timestamp
         // Add it to our class loader

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -323,13 +323,13 @@ private[spark] class Executor(
       for ((name, timestamp) <- newFiles if currentFiles.getOrElse(name, -1L) < timestamp) {
         logInfo("Fetching " + name + " with timestamp " + timestamp)
         Utils.fetchFile(name, new File(SparkFiles.getRootDirectory), conf,
-          env.securityManager, hadoopConf, timestamp, true)
+          env.securityManager, hadoopConf, timestamp, useCache = true)
         currentFiles(name) = timestamp
       }
       for ((name, timestamp) <- newJars if currentJars.getOrElse(name, -1L) < timestamp) {
         logInfo("Fetching " + name + " with timestamp " + timestamp)
         Utils.fetchFile(name, new File(SparkFiles.getRootDirectory), conf,
-          env.securityManager, hadoopConf, timestamp, true)
+          env.securityManager, hadoopConf, timestamp, useCache = true)
         currentJars(name) = timestamp
         // Add it to our class loader
         val localName = name.split("/").last

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -323,12 +323,13 @@ private[spark] class Executor(
       for ((name, timestamp) <- newFiles if currentFiles.getOrElse(name, -1L) < timestamp) {
         logInfo("Fetching " + name + " with timestamp " + timestamp)
         Utils.fetchCachedFile(name, new File(SparkFiles.getRootDirectory), conf,
-          env.securityManager, hadoopConf, timestamp)
+          env.securityManager, hadoopConf, timestamp, true)
+        currentFiles(name) = timestamp
       }
       for ((name, timestamp) <- newJars if currentJars.getOrElse(name, -1L) < timestamp) {
         logInfo("Fetching " + name + " with timestamp " + timestamp)
         Utils.fetchCachedFile(name, new File(SparkFiles.getRootDirectory), conf,
-          env.securityManager, hadoopConf, timestamp)
+          env.securityManager, hadoopConf, timestamp, true)
         currentJars(name) = timestamp
         // Add it to our class loader
         val localName = name.split("/").last

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -322,14 +322,13 @@ private[spark] class Executor(
       // Fetch missing dependencies
       for ((name, timestamp) <- newFiles if currentFiles.getOrElse(name, -1L) < timestamp) {
         logInfo("Fetching " + name + " with timestamp " + timestamp)
-        Utils.fetchFile(name, new File(SparkFiles.getRootDirectory), conf, env.securityManager,
-          hadoopConf)
-        currentFiles(name) = timestamp
+        Utils.fetchCachedFile(name, new File(SparkFiles.getRootDirectory), conf,
+          env.securityManager, hadoopConf, timestamp)
       }
       for ((name, timestamp) <- newJars if currentJars.getOrElse(name, -1L) < timestamp) {
         logInfo("Fetching " + name + " with timestamp " + timestamp)
-        Utils.fetchFile(name, new File(SparkFiles.getRootDirectory), conf, env.securityManager,
-          hadoopConf)
+        Utils.fetchCachedFile(name, new File(SparkFiles.getRootDirectory), conf,
+          env.securityManager, hadoopConf, timestamp)
         currentJars(name) = timestamp
         // Add it to our class loader
         val localName = name.split("/").last

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -318,7 +318,7 @@ private[spark] object Utils extends Logging {
    *
    * If `useCache` is true, first attempts to fetch the file to a local cache that's shared 
    * across executors running the same application. `useCache` is used mainly for 
-   * the the executors, not in local mode.
+   * the executors, and not in local mode.
    *
    * Throws SparkException if the target file already exists and has different contents than
    * the requested file.
@@ -341,7 +341,7 @@ private[spark] object Utils extends Logging {
       val raf = new RandomAccessFile(lockFile, "rw")
       // Only one executor entry.
       // The FileLock is only used to control synchronization for executors download file,
-      // it's always safe regardless of lock type(mandatory or advisory).
+      // it's always safe regardless of lock type (mandatory or advisory).
       val lock = raf.getChannel().lock()
       val cachedFile = new File(localDir, cachedFileName)
       try {
@@ -354,8 +354,8 @@ private[spark] object Utils extends Logging {
       if (targetFile.exists && !Files.equal(cachedFile, targetFile)) {
         if (conf.getBoolean("spark.files.overwrite", false)) {
           targetFile.delete()
-          logInfo(("File %s exists and does not match contents of %s, " +
-            "replacing it with %s").format(targetFile, url, url))
+          logInfo((s"File $targetFile exists and does not match contents of $url, " +
+            s"replacing it with $url"))
         } else {
           throw new SparkException(s"File $targetFile exists and does not match contents of $url")
         }

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -330,8 +330,8 @@ private[spark] object Utils extends Logging {
       fetchFile(url, localDir, conf, securityMgr)
       Files.move(new File(localDir, fileName), cachedFile)
     }
-    Files.copy(cachedFile, targetFile)
     lock.release()
+    Files.copy(cachedFile, targetFile)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -324,7 +324,10 @@ private[spark] object Utils extends Logging {
     val localDir = new File(getLocalDir(conf))
     val lockFile = new File(localDir, lockFileName)
     val raf = new RandomAccessFile(lockFile, "rw")
-    val lock = raf.getChannel().lock() // only one executor entry
+    // Only one executor entry.
+    // The FileLock is only used to control synchronization for executors download file,
+    // it's always safe regardless of lock type(mandatory or advisory).
+    val lock = raf.getChannel().lock()
     val cachedFile = new File(localDir, cachedFileName)
     try {
       if (!cachedFile.exists()) {

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -333,7 +333,7 @@ private[spark] object Utils extends Logging {
     val fileName = url.split("/").last
     val targetFile = new File(targetDir, fileName)
     if (useCache) {
-      val cachedFileName = url.hashCode + timestamp + "_cach"
+      val cachedFileName = url.hashCode + timestamp + "_cache"
       val lockFileName = url.hashCode + timestamp + "_lock"
       val localDir = new File(getLocalDir(conf))
       val lockFile = new File(localDir, lockFileName)

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -313,11 +313,12 @@ private[spark] object Utils extends Logging {
   }
 
   /**
-   * Download a file requested by the executor . Supports fetching the file in a variety of ways,
+   * Download a file to target directory. Supports fetching the file in a variety of ways,
    * including HTTP, HDFS and files on a standard filesystem, based on the URL parameter.
    *
-   * If `useCache` is true, first attempts to fetch the file from a local cache that's shared across
-   * executors running the same application.
+   * If `useCache` is true, first attempts to fetch the file to a local cache that's shared 
+   * across executors running the same application. `useCache` is used mainly for 
+   * the the executors, not in local mode.
    *
    * Throws SparkException if the target file already exists and has different contents than
    * the requested file.
@@ -377,7 +378,7 @@ private[spark] object Utils extends Logging {
   }
 
   /**
-   * Download a file requested by the executor. Supports fetching the file in a variety of ways,
+   * Download a file to target directory. Supports fetching the file in a variety of ways,
    * including HTTP, HDFS and files on a standard filesystem, based on the URL parameter.
    *
    * Throws SparkException if the target file already exists and has different contents than

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -356,8 +356,7 @@ private[spark] object Utils extends Logging {
           logInfo(("File %s exists and does not match contents of %s, " +
             "replacing it with %s").format(targetFile, url, url))
         } else {
-          throw new SparkException(
-            "File " + targetFile + " exists and does not match contents of" + " " + url)
+          throw new SparkException(s"File $targetFile exists and does not match contents of $url")
         }
       }
       Files.copy(cachedFile, targetFile)


### PR DESCRIPTION
If Spark lunched multiple executors in one host for one application, every executor would download it dependent files and jars (if not using local: url) independently. It maybe result in huge latency. In my case, it result in 20 seconds latency to download dependent jars(size about 17M) when I lunched 32 executors in every host(total 4 hosts).

This patch will cache downloaded files and jars for executors to reduce network throughput and download latency. In my case, the latency was reduced from 20 seconds to less than 1 second.
