### PR TITLE
Use commons-lang3 in SignalLogger rather than commons-lang

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/SignalLogger.scala
+++ b/core/src/main/scala/org/apache/spark/util/SignalLogger.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.util
 
-import org.apache.commons.lang.SystemUtils
+import org.apache.commons.lang3.SystemUtils
 import org.slf4j.Logger
 import sun.misc.{Signal, SignalHandler}
 


### PR DESCRIPTION
Spark only transitively depends on the latter, based on the Hadoop version.
