### PR TITLE
[SPARK-2730][SQL] When retrieving a value from a Map, GetItem evaluates key twice

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypes.scala
@@ -61,7 +61,6 @@ case class GetItem(child: Expression, ordinal: Expression) extends Expression {
           }
         } else {
           val baseValue = value.asInstanceOf[Map[Any, _]]
-          val key = ordinal.eval(input)
           baseValue.get(key).orNull
         }
       }


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-2730
