### PR TITLE
[SPARK-2737] Add retag() method for changing RDDs' ClassTags.

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1253,13 +1253,7 @@ abstract class RDD[T: ClassTag](
    * Used for internal Java <-> Scala API compatibility.
    */
   private[spark] def retag(implicit classTag: ClassTag[T]): RDD[T] = {
-    val oldRDD = this
-    new RDD[T](sc, Seq(new OneToOneDependency(this)))(classTag) {
-      override protected def getPartitions: Array[Partition] = oldRDD.getPartitions
-      override def compute(split: Partition, context: TaskContext): Iterator[T] =
-        oldRDD.compute(split, context)
-      @transient override val partitioner = oldRDD.partitioner
-    }
+    this.mapPartitions(identity, preservesPartitioning = true)(classTag)
   }
 
   // Avoid handling doCheckpoint multiple times to prevent excessive recursion

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1252,7 +1252,7 @@ abstract class RDD[T: ClassTag](
    * Private API for changing an RDD's ClassTag.
    * Used for internal Java <-> Scala API compatibility.
    */
-  private[spark] def retag(classTag: ClassTag[T]): RDD[T] = {
+  private[spark] def retag(implicit classTag: ClassTag[T]): RDD[T] = {
     val oldRDD = this
     new RDD[T](sc, Seq(new OneToOneDependency(this)))(classTag) {
       override protected def getPartitions: Array[Partition] = oldRDD.getPartitions

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1258,6 +1258,7 @@ abstract class RDD[T: ClassTag](
       override protected def getPartitions: Array[Partition] = oldRDD.getPartitions
       override def compute(split: Partition, context: TaskContext): Iterator[T] =
         oldRDD.compute(split, context)
+      @transient override val partitioner = oldRDD.partitioner
     }
   }
 

--- a/core/src/test/java/org/apache/spark/JavaAPISuite.java
+++ b/core/src/test/java/org/apache/spark/JavaAPISuite.java
@@ -1245,4 +1245,21 @@ public class JavaAPISuite implements Serializable {
     Assert.assertTrue(worExactCounts.get(0) == 2);
     Assert.assertTrue(worExactCounts.get(1) == 4);
   }
+
+  private static class SomeCustomClass implements Serializable {
+    public SomeCustomClass() {
+      // Intentionally left blank
+    }
+  }
+
+  @Test
+  public void collectUnderlyingScalaRDD() {
+    List<SomeCustomClass> data = new ArrayList<SomeCustomClass>();
+    for (int i = 0; i < 100; i++) {
+      data.add(new SomeCustomClass());
+    }
+    JavaRDD<SomeCustomClass> rdd = sc.parallelize(data);
+    SomeCustomClass[] collected = (SomeCustomClass[]) rdd.rdd().retag(SomeCustomClass.class).collect();
+    Assert.assertEquals(data.size(), collected.length);
+  }
 }

--- a/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.rdd
 
 import scala.collection.mutable.{ArrayBuffer, HashMap}
+import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 
 import org.scalatest.FunSuite
@@ -26,6 +27,7 @@ import org.apache.spark._
 import org.apache.spark.SparkContext._
 import org.apache.spark.util.Utils
 
+import org.apache.spark.api.java.{JavaRDD, JavaSparkContext}
 import org.apache.spark.rdd.RDDSuiteUtils._
 
 class RDDSuite extends FunSuite with SharedSparkContext {
@@ -705,6 +707,12 @@ class RDDSuite extends FunSuite with SharedSparkContext {
     val ranked = data.zipWithUniqueId()
     val ids = ranked.map(_._1).distinct().collect()
     assert(ids.length === n)
+  }
+
+  test("retag with implicit ClassTag") {
+    val jsc: JavaSparkContext = new JavaSparkContext(sc)
+    val jrdd: JavaRDD[String] = jsc.parallelize(Seq("A", "B", "C").asJava)
+    jrdd.rdd.retag.collect()
   }
 
   test("getNarrowAncestors") {


### PR DESCRIPTION
The Java API's use of fake ClassTags doesn't seem to cause any problems for Java users, but it can lead to issues when passing JavaRDDs' underlying RDDs to Scala code (e.g. in the MLlib Java API wrapper code). If we call collect() on a Scala RDD with an incorrect ClassTag, this causes ClassCastExceptions when we try to allocate an array of the wrong type (for example, see SPARK-2197).

There are a few possible fixes here. An API-breaking fix would be to completely remove the fake ClassTags and require Java API users to pass java.lang.Class instances to all parallelize() calls and add returnClass fields to all Function implementations. This would be extremely verbose.

Instead, this patch adds internal APIs to "repair" a Scala RDD with an incorrect ClassTag by wrapping it and overriding its ClassTag. This should be okay for cases where the Scala code that calls collect() knows what type of array should be allocated, which is the case in the MLlib wrappers.
