### PR TITLE
Avoid numerical instability

### DIFF
--- a/python/pyspark/mllib/classification.py
+++ b/python/pyspark/mllib/classification.py
@@ -66,7 +66,8 @@ class LogisticRegressionModel(LinearModel):
         if margin > 0:
             prob = 1 / (1 + exp(-margin))
         else:
-            prob = 1 - 1 / (1 + exp(margin))
+            exp_margin = exp(margin)
+            prob = exp_margin / (1 + exp_margin)
         return 1 if prob > 0.5 else 0
 
 


### PR DESCRIPTION
This avoids basically doing 1 - 1, for example:

``` python
>>> from math import exp
>>> margin = -40
>>> 1 - 1 / (1 + exp(margin))
0.0
>>> exp(margin) / (1 + exp(margin))
4.248354255291589e-18
>>>
```
