### PR TITLE
SPARK-2641: Passing num executors to spark arguments from properties file

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -105,6 +105,8 @@ private[spark] class SparkSubmitArguments(args: Seq[String]) {
       .getOrElse(defaultProperties.get("spark.cores.max").orNull)
     name = Option(name).getOrElse(defaultProperties.get("spark.app.name").orNull)
     jars = Option(jars).getOrElse(defaultProperties.get("spark.jars").orNull)
+    numExecutors = Option(numExecutors)
+      .getOrElse(defaultProperties.get("spark.executor.instances").orNull)
 
     // This supports env vars in older versions of Spark
     master = Option(master).getOrElse(System.getenv("MASTER"))


### PR DESCRIPTION
Since we can set spark executor memory and executor cores using property file, we must also be allowed to set the executor instances.
