### PR TITLE
[SPARK-2752]spark sql cli should not exit when exception

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -293,21 +293,20 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
             if (ret != 0) {
               driver.close()
               　return ret
-              　}
+            }
+            val res = new JArrayList[String]()
 
-            　val res = new JArrayList[String]()
-
-            　if (HiveConf.getBoolVar(conf, HiveConf.ConfVars.HIVE_CLI_PRINT_HEADER)) {
+            if (HiveConf.getBoolVar(conf, HiveConf.ConfVars.HIVE_CLI_PRINT_HEADER)) {
             　// Print the column names.
             　Option(driver.getSchema.getFieldSchemas).map { fields =>
               　out.println(fields.map(_.getName).mkString("\t"))
-              　}
             　}
+          　}
 
-          while (!out.checkError() && driver.getResults(res)) {
-            res.foreach(out.println)
-            res.clear()
-          }
+            while (!out.checkError() && driver.getResults(res)) {
+              res.foreach(out.println)
+              res.clear()
+            }
           } catch {
             case e:IOException =>
               console.printError(

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -292,16 +292,16 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
             ret = driver.run(cmd).getResponseCode
             if (ret != 0) {
               driver.close()
-              　return ret
+                return ret
             }
             val res = new JArrayList[String]()
 
             if (HiveConf.getBoolVar(conf, HiveConf.ConfVars.HIVE_CLI_PRINT_HEADER)) {
-            　// Print the column names.
-            　Option(driver.getSchema.getFieldSchemas).map { fields =>
-              　out.println(fields.map(_.getName).mkString("\t"))
-            　}
-          　}
+              // Print the column names.
+              Option(driver.getSchema.getFieldSchemas).map { fields =>
+                out.println(fields.map(_.getName).mkString("\t"))
+              }
+            }
 
             while (!out.checkError() && driver.getResults(res)) {
               res.foreach(out.println)

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -308,16 +308,12 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
               res.clear()
             }
           } catch {
-            case e: IOException =>
+            case e: Exception =>
               console.printError(
                 s"""Failed with exception ${e.getClass.getName}: ${e.getMessage}
                    |${org.apache.hadoop.util.StringUtils.stringifyException(e)}
                  """.stripMargin)
               ret = 1
-            case e: Exception =>
-              console.printError(s"Failed with exception ${e.getClass.getName}: ${e.getMessage}")
-              ret = 1
-
           }
 
           val cret = driver.close()

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -344,3 +344,4 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
     }
   }
 }
+

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -190,12 +190,12 @@ private[hive] object SparkSQLCLIDriver {
         reader.setHistory(new History(new File(historyFile)))
       } else {
         System.err.println("WARNING: Directory for Hive history file: " + historyDirectory +
-                           " does not exist.   History will not be available during this session.")
+          " does not exist.   History will not be available during this session.")
       }
     } catch {
       case e: Exception =>
         System.err.println("WARNING: Encountered an error while trying to initialize Hive's " +
-                           "history file.  History will not be available during this session.")
+          "history file.  History will not be available during this session.")
         System.err.println(e.getMessage)
     }
 
@@ -288,26 +288,26 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
             out.println(cmd)
           }
 
-          ret = driver.run(cmd).getResponseCode
-          if (ret != 0) {
-            driver.close()
-            return ret
-          }
-
-          val res = new JArrayList[String]()
-
-          if (HiveConf.getBoolVar(conf, HiveConf.ConfVars.HIVE_CLI_PRINT_HEADER)) {
-            // Print the column names.
-            Option(driver.getSchema.getFieldSchemas).map { fields =>
-              out.println(fields.map(_.getName).mkString("\t"))
-            }
-          }
-
           try {
-            while (!out.checkError() && driver.getResults(res)) {
-              res.foreach(out.println)
-              res.clear()
-            }
+            ret = driver.run(cmd).getResponseCode
+            if (ret != 0) {
+              driver.close()
+              　return ret
+              　}
+
+            　val res = new JArrayList[String]()
+
+            　if (HiveConf.getBoolVar(conf, HiveConf.ConfVars.HIVE_CLI_PRINT_HEADER)) {
+            　// Print the column names.
+            　Option(driver.getSchema.getFieldSchemas).map { fields =>
+              　out.println(fields.map(_.getName).mkString("\t"))
+              　}
+            　}
+
+          while (!out.checkError() && driver.getResults(res)) {
+            res.foreach(out.println)
+            res.clear()
+          }
           } catch {
             case e:IOException =>
               console.printError(
@@ -315,6 +315,11 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
                    |${org.apache.hadoop.util.StringUtils.stringifyException(e)}
                  """.stripMargin)
               ret = 1
+            case e:Exception =>
+              console.printError(
+                s"Failed with exception ${e.getClass.getName}: ${e.getMessage}")
+              ret = 1
+
           }
 
           val cret = driver.close()
@@ -341,4 +346,3 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
     }
   }
 }
-

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -190,12 +190,12 @@ private[hive] object SparkSQLCLIDriver {
         reader.setHistory(new History(new File(historyFile)))
       } else {
         System.err.println("WARNING: Directory for Hive history file: " + historyDirectory +
-          " does not exist.   History will not be available during this session.")
+                           " does not exist.   History will not be available during this session.")
       }
     } catch {
       case e: Exception =>
         System.err.println("WARNING: Encountered an error while trying to initialize Hive's " +
-          "history file.  History will not be available during this session.")
+                           "history file.  History will not be available during this session.")
         System.err.println(e.getMessage)
     }
 

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -308,15 +308,14 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
               res.clear()
             }
           } catch {
-            case e:IOException =>
+            case e: IOException =>
               console.printError(
                 s"""Failed with exception ${e.getClass.getName}: ${e.getMessage}
                    |${org.apache.hadoop.util.StringUtils.stringifyException(e)}
                  """.stripMargin)
               ret = 1
-            case e:Exception =>
-              console.printError(
-                s"Failed with exception ${e.getClass.getName}: ${e.getMessage}")
+            case e: Exception =>
+              console.printError(s"Failed with exception ${e.getClass.getName}: ${e.getMessage}")
               ret = 1
 
           }


### PR DESCRIPTION
Spark sql cli now will exit directly when we input a bad sql, fix it by catching the exception and print the error~
