### PR TITLE
[SPARK-2735][Documentation] Remove deprecation warning in 'jekyll build' for pygments

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-pygments: true
+highlighter: pygments
 markdown: kramdown
 
 # These allow the documentation to be updated with nerw releases


### PR DESCRIPTION
The following warning was corrected which shows up when one does 'jekyll build' in the docs folder
    "Deprecation: The 'pygments' configuration option has been renamed to 'highlighter'. Please update your config file accordingly. The allowed values are 'rouge', 'pygments' or null."

```
Reference:https://github.com/mmistakes/hpstr-jekyll-theme/issues/25
```
