### PR TITLE
SPARK-2741 - Publish version of spark assembly which does not contain Hive

### DIFF
--- a/dev/create-release/create-release.sh
+++ b/dev/create-release/create-release.sh
@@ -115,6 +115,8 @@ make_binary_release "hadoop1" "-Phive -Phive-thriftserver -Dhadoop.version=1.0.4
 make_binary_release "cdh4" "-Phive -Phive-thriftserver -Dhadoop.version=2.0.0-mr1-cdh4.2.0"
 make_binary_release "hadoop2" \
   "-Phive -Phive-thriftserver -Pyarn -Phadoop-2.2 -Dhadoop.version=2.2.0 -Pyarn.version=2.2.0"
+make_binary_release "hadoop2-without-hive" \
+  "-Pyarn -Phadoop-2.2 -Dhadoop.version=2.2.0 -Pyarn.version=2.2.0"
 
 # Copy data
 echo "Copying release tarballs"


### PR DESCRIPTION
Provide a version of the Spark tarball which does not package Hive. This is meant for HIve + Spark users.
