### PR TITLE
[SPARK-2764] Simplify daemon.py process structure

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.api.python
 
 import java.io.{DataInputStream, InputStream, OutputStreamWriter}
-import java.net._
+import java.net.{InetAddress, ServerSocket, Socket, SocketException}
 
 import scala.collection.JavaConversions._
 
@@ -67,7 +67,7 @@ private[spark] class PythonWorkerFactory(pythonExec: String, envVars: Map[String
         val socket = new Socket(daemonHost, daemonPort)
         val launchStatus = new DataInputStream(socket.getInputStream).readInt()
         if (launchStatus != 0) {
-          logWarning("Python daemon failed to launch worker")
+          throw new IllegalStateException("Python daemon failed to launch worker")
         }
         socket
       } catch {

--- a/python/pyspark/daemon.py
+++ b/python/pyspark/daemon.py
@@ -120,7 +120,7 @@ def manager():
             try:
                 ready_fds = select.select([0, listen_sock], [], [])[0]
             except select.error as ex:
-                if ex[0] == 4:
+                if ex[0] == EINTR:
                     continue
                 else:
                     raise


### PR DESCRIPTION
Curently, daemon.py forks a pool of numProcessors subprocesses, and those processes fork themselves again to create the actual Python worker processes that handle data.

I think that this extra layer of indirection is unnecessary and adds a lot of complexity.  This commit attempts to remove this middle layer of subprocesses by launching the workers directly from daemon.py.

See https://github.com/mesos/spark/pull/563 for the original PR that added daemon.py, where I raise some issues with the current design.
