### PR TITLE
SPARK-2768 [MLLIB] Add product, user recommend method to MatrixFactorizationModel

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/recommendation/MatrixFactorizationModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/recommendation/MatrixFactorizationModel.scala
@@ -70,9 +70,11 @@ class MatrixFactorizationModel private[mllib] (
    *
    * @param user the user to recommend products to
    * @param num how many products to return. The number returned may be less than this.
-   * @return product ID and score tuples, sorted descending by score. The first product returned
-   *  is the one predicted to be most strongly recommended to the user. The score is an opaque
-   *  value that indicates how strongly recommended the product is.
+   * @return [[Rating]] objects, each of which contains the given user ID, a product ID, and a
+   *  "score" in the rating field. Each represents one recommended product, and they are sorted
+   *  by score, decreasing. The first returned is the one predicted to be most strongly
+   *  recommended to the user. The score is an opaque value that indicates how strongly
+   *  recommended the product is.
    */
   def recommendProducts(user: Int, num: Int): Array[Rating] =
     recommend(userFeatures.lookup(user).head, productFeatures, num)
@@ -84,9 +86,11 @@ class MatrixFactorizationModel private[mllib] (
    *
    * @param product the product to recommend users to
    * @param num how many users to return. The number returned may be less than this.
-   * @return user ID and score tuples, sorted descending by score. The first user returned
-   *  is the one predicted to be most strongly interested in the product. The score is an opaque
-   *  value that indicates how strongly interested the user is.
+   * @return [[Rating]] objects, each of which contains a user ID, the given product ID, and a
+   *  "score" in the rating field. Each represents one recommended user, and they are sorted
+   *  by score, decreasing. The first returned is the one predicted to be most strongly
+   *  recommended to the product. The score is an opaque value that indicates how strongly
+   *  recommended the user is.
    */
   def recommendUsers(product: Int, num: Int): Array[Rating] =
     recommend(productFeatures.lookup(product).head, userFeatures, num)

--- a/mllib/src/test/java/org/apache/spark/mllib/recommendation/JavaALSSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/recommendation/JavaALSSuite.java
@@ -20,6 +20,11 @@ package org.apache.spark.mllib.recommendation;
 import java.io.Serializable;
 import java.util.List;
 
+import scala.Tuple2;
+import scala.Tuple3;
+
+import org.jblas.DoubleMatrix;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -27,10 +32,6 @@ import org.junit.Test;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
-
-import scala.Tuple2;
-import scala.Tuple3;
-import org.jblas.DoubleMatrix;
 
 public class JavaALSSuite implements Serializable {
   private transient JavaSparkContext sc;
@@ -130,8 +131,8 @@ public class JavaALSSuite implements Serializable {
     JavaRDD<Rating> data = sc.parallelize(testData._1());
 
     MatrixFactorizationModel model = new ALS().setRank(features)
-                                              .setIterations(iterations)
-                                              .run(data.rdd());
+      .setIterations(iterations)
+      .run(data.rdd());
     validatePrediction(model, users, products, features, testData._2(), 0.3, false, testData._3());
   }
 
@@ -178,10 +179,10 @@ public class JavaALSSuite implements Serializable {
 
     JavaRDD<Rating> data = sc.parallelize(testData._1());
     MatrixFactorizationModel model = new ALS().setRank(features)
-        .setIterations(iterations)
-        .setImplicitPrefs(true)
-        .setSeed(8675309L)
-        .run(data.rdd());
+      .setIterations(iterations)
+      .setImplicitPrefs(true)
+      .setSeed(8675309L)
+      .run(data.rdd());
     validatePrediction(model, users, products, features, testData._2(), 0.4, true, testData._3());
   }
 
@@ -195,10 +196,10 @@ public class JavaALSSuite implements Serializable {
         users, products, features, 0.7, true, false);
     JavaRDD<Rating> data = sc.parallelize(testData._1());
     MatrixFactorizationModel model = new ALS().setRank(features)
-        .setIterations(iterations)
-        .setImplicitPrefs(true)
-        .setSeed(8675309L)
-        .run(data.rdd());
+      .setIterations(iterations)
+      .setImplicitPrefs(true)
+      .setSeed(8675309L)
+      .run(data.rdd());
     validateRecommendations(model.recommendProducts(1, 10), 10);
     validateRecommendations(model.recommendUsers(1, 20), 20);
   }


### PR DESCRIPTION
Right now, `MatrixFactorizationModel` can only predict a score for one or more `(user,product)` tuples. As a comment in the file notes, it would be more useful to expose a recommend method, that computes top N scoring products for a user (or vice versa – users for a product).

(This also corrects some long lines in the Java ALS test suite.)

As you can see, it's a little messy to access the class from Java. Should there be a Java-friendly wrapper for it? with a pointer about where that should go, I could add that.
