### PR TITLE
[SPARK-2773]use growth rate to predict if need to spill

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockId.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockId.scala
@@ -54,18 +54,19 @@ case class RDDBlockId(rddId: Int, splitIndex: Int) extends BlockId {
 }
 
 @DeveloperApi
-case class ShuffleBlockId(shuffleId: Int, mapId: Int, reduceId: Int) extends BlockId {
+case class ShuffleBlockId(shuffleId: Int, mapId: Int, reduceId: Int)
+  extends BlockId {
   def name = "shuffle_" + shuffleId + "_" + mapId + "_" + reduceId
-}
-
-@DeveloperApi
-case class ShuffleIndexBlockId(shuffleId: Int, mapId: Int, reduceId: Int) extends BlockId {
-  def name = "shuffle_" + shuffleId + "_" + mapId + "_" + reduceId + ".index"
 }
 
 @DeveloperApi
 case class BroadcastBlockId(broadcastId: Long, field: String = "") extends BlockId {
   def name = "broadcast_" + broadcastId + (if (field == "") "" else "_" + field)
+}
+
+@DeveloperApi
+case class EventBlockId(eventId: Long) extends BlockId {
+  def name = "eventblock_" + eventId
 }
 
 @DeveloperApi
@@ -92,10 +93,10 @@ private[spark] case class TestBlockId(id: String) extends BlockId {
 object BlockId {
   val RDD = "rdd_([0-9]+)_([0-9]+)".r
   val SHUFFLE = "shuffle_([0-9]+)_([0-9]+)_([0-9]+)".r
-  val SHUFFLE_INDEX = "shuffle_([0-9]+)_([0-9]+)_([0-9]+).index".r
   val BROADCAST = "broadcast_([0-9]+)([_A-Za-z0-9]*)".r
   val TASKRESULT = "taskresult_([0-9]+)".r
   val STREAM = "input-([0-9]+)-([0-9]+)".r
+  val EVENT = "eventblock_([0-9]+)".r
   val TEST = "test_(.*)".r
 
   /** Converts a BlockId "name" String back into a BlockId. */
@@ -104,12 +105,12 @@ object BlockId {
       RDDBlockId(rddId.toInt, splitIndex.toInt)
     case SHUFFLE(shuffleId, mapId, reduceId) =>
       ShuffleBlockId(shuffleId.toInt, mapId.toInt, reduceId.toInt)
-    case SHUFFLE_INDEX(shuffleId, mapId, reduceId) =>
-      ShuffleIndexBlockId(shuffleId.toInt, mapId.toInt, reduceId.toInt)
     case BROADCAST(broadcastId, field) =>
       BroadcastBlockId(broadcastId.toLong, field.stripPrefix("_"))
     case TASKRESULT(taskId) =>
       TaskResultBlockId(taskId.toLong)
+    case EVENT(eventId) =>
+      EventBlockId(eventId.toLong)
     case STREAM(streamId, uniqueId) =>
       StreamBlockId(streamId.toInt, uniqueId.toLong)
     case TEST(value) =>

--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
@@ -157,13 +157,12 @@ class ExternalAppendOnlyMap[K, V, C](
             myMemoryThreshold = currentSize * 2
           }
         }
+        lastSize = currentSize
         // Do not synchronize spills
         if (shouldSpill) {
           spill(currentSize)
           lastSize = 0L
         }
-        
-        lastSize = currentSize
       }
       currentMap.changeValue(curEntry._1, update)
       elementsRead += 1

--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
@@ -151,7 +151,7 @@ class ExternalAppendOnlyMap[K, V, C](
           val availableMemory = maxMemoryThreshold - shuffleMemoryMap.values.sum
 
           // Use growth rate to predict if need to spill
-          shouldSpill = availableMemory < （currentSize - lastSize) * SparkEnv.get.conf.get("spark.executor.cores").toInt
+          shouldSpill = availableMemory < (currentSize - lastSize) * SparkEnv.get.conf.get("spark.executor.cores").toInt * 2
           if (!shouldSpill) {
             shuffleMemoryMap(threadId) = currentSize * 2
             myMemoryThreshold = currentSize * 2

--- a/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnableUtil.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnableUtil.scala
@@ -72,6 +72,8 @@ trait ExecutorRunnableUtil extends Logging {
 
     sparkConf.getAkkaConf.
       foreach { case (k, v) => javaOpts += "-D" + k + "=" + "\\\"" + v + "\\\"" }
+      
+    JAVA_OPTS += "-Dspark.executor.cores" + "=" + "\\\"" + executorCores + "\\\""  
 
     // Commenting it out for now - so that people can refer to the properties if required. Remove
     // it once cpuset version is pushed out.


### PR DESCRIPTION
Right now, Spark uses the total usage of "shuffle" memory of each thread to predict if need to spill. I think it is not very reasonable. For example, there are two threads pulling "shuffle" data. The total memory used to buffer data is 21G. The first time to trigger spilling it when one thread has used 7G memory to buffer "shuffle" data, here I assume another one has used the same size. Unfortunately, I still have remaining 7G to use. So, I think current prediction mode is too conservative, and can not maximize the usage of "shuffle" memory. In my solution, I use the growth rate of "shuffle" memory. Again, the growth of each time is limited, maybe 10K \* 1024(my assumption), then the first time to trigger spilling is when the remaining "shuffle" memory is less than threads \* growth \* 2, i.e. 2 \* 10M \* 2. I think it can maximize the usage of "shuffle" memory. In my solution, there is also a conservative assumption, i.e. all of threads is pulling shuffle data in one executor. However it dose not have much effect, the grow is limited after all. Any suggestion?
