### PR TITLE
[SPARK-2678][Core] Prevents `spark-submit` from shadowing application options

### DIFF
--- a/bin/beeline
+++ b/bin/beeline
@@ -20,26 +20,5 @@
 # Figure out where Spark is installed
 FWDIR="$(cd `dirname $0`/..; pwd)"
 
-# Find the java binary
-if [ -n "${JAVA_HOME}" ]; then
-  RUNNER="${JAVA_HOME}/bin/java"
-else
-  if [ `command -v java` ]; then
-    RUNNER="java"
-  else
-    echo "JAVA_HOME is not set" >&2
-    exit 1
-  fi
-fi
-
-# Compute classpath using external script
-classpath_output=$($FWDIR/bin/compute-classpath.sh)
-if [[ "$?" != "0" ]]; then
-  echo "$classpath_output"
-  exit 1
-else
-  CLASSPATH=$classpath_output
-fi
-
 CLASS="org.apache.hive.beeline.BeeLine"
-exec "$RUNNER" -cp "$CLASSPATH" $CLASS "$@"
+exec "$FWDIR/bin/spark-class" $CLASS "$@"

--- a/bin/run-example
+++ b/bin/run-example
@@ -55,4 +55,4 @@ fi
   --master $EXAMPLE_MASTER \
   --class $EXAMPLE_CLASS \
   "$SPARK_EXAMPLES_JAR" \
-  "$@"
+  -- "$@"

--- a/bin/run-example.cmd
+++ b/bin/run-example.cmd
@@ -20,4 +20,4 @@ rem
 rem This is the entry point for running a Spark example. To avoid polluting
 rem the environment, it just launches a new cmd to do the real work.
 
-cmd /V /E /C %~dp0run-example2.cmd %*
+cmd /V /E /C %~dp0run-example2.cmd -- %*

--- a/bin/run-example2.cmd
+++ b/bin/run-example2.cmd
@@ -83,6 +83,6 @@ if defined ARGS set ARGS=%ARGS:~1%
 call "%FWDIR%bin\spark-submit.cmd" ^
   --master %EXAMPLE_MASTER% ^
   --class %EXAMPLE_CLASS% ^
-  "%SPARK_EXAMPLES_JAR%" %ARGS%
+  "%SPARK_EXAMPLES_JAR%" -- %ARGS%
 
 :exit

--- a/bin/spark-shell
+++ b/bin/spark-shell
@@ -46,11 +46,11 @@ function main(){
         # (see https://github.com/sbt/sbt/issues/562).
         stty -icanon min 1 -echo > /dev/null 2>&1
         export SPARK_SUBMIT_OPTS="$SPARK_SUBMIT_OPTS -Djline.terminal=unix"
-        $FWDIR/bin/spark-submit --class org.apache.spark.repl.Main spark-shell "$@"
+        $FWDIR/bin/spark-submit spark-shell --class org.apache.spark.repl.Main "$@"
         stty icanon echo > /dev/null 2>&1
     else
         export SPARK_SUBMIT_OPTS
-        $FWDIR/bin/spark-submit --class org.apache.spark.repl.Main spark-shell "$@"
+        $FWDIR/bin/spark-submit spark-shell --class org.apache.spark.repl.Main "$@"
     fi
 }
 

--- a/bin/spark-sql
+++ b/bin/spark-sql
@@ -26,11 +26,15 @@ set -o posix
 # Figure out where Spark is installed
 FWDIR="$(cd `dirname $0`/..; pwd)"
 
-if [[ "$@" = *--help ]] || [[ "$@" = *-h ]]; then
-  echo "Usage: ./sbin/spark-sql [options]"
-  $FWDIR/bin/spark-submit --help 2>&1 | grep -v Usage 1>&2
+CLASS="org.apache.spark.sql.hive.thriftserver.SparkSQLCLIDriver"
+
+if [[ "$@" = --help ]] || [[ "$@" = -H ]]; then
+  echo "Usage: ./sbin/spark-sql [options] [-- application options]"
+  exec "$FWDIR"/bin/spark-submit --help 2>&1 | grep -v Usage 1>&2
+  echo
+  echo "Applicaion options:"
+  exec "$FWDIR"/bin/spark-submit spark-internal --class $CLASS -- -H 2>&1 | tail -n +3
   exit 0
 fi
 
-CLASS="org.apache.spark.sql.hive.thriftserver.SparkSQLCLIDriver"
-exec "$FWDIR"/bin/spark-submit --class $CLASS spark-internal $@
+exec "$FWDIR"/bin/spark-submit spark-internal --class $CLASS $@

--- a/bin/spark-submit
+++ b/bin/spark-submit
@@ -42,4 +42,3 @@ if [ -n "$DRIVER_MEMORY" ] && [ $DEPLOY_MODE == "client" ]; then
 fi
 
 exec $SPARK_HOME/bin/spark-class org.apache.spark.deploy.SparkSubmit "${ORIG_ARGS[@]}"
-

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -259,7 +259,7 @@ object SparkSubmit {
     // In yarn-cluster mode, use yarn.Client as a wrapper around the user class
     if (clusterManager == YARN && deployMode == CLUSTER) {
       childMainClass = "org.apache.spark.deploy.yarn.Client"
-      if (args.primaryResource != SPARK_INTERNAL) {
+      if (isUserJar(args.primaryResource)) {
         childArgs += ("--jar", args.primaryResource)
       }
       childArgs += ("--class", args.mainClass)

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -100,9 +100,26 @@ class SparkSubmitSuite extends FunSuite with Matchers {
       "--name", "myApp",
       "--class", "Foo",
       "userjar.jar",
+      "--",
       "some",
       "--weird", "args")
     val appArgs = new SparkSubmitArguments(clArgs)
+    appArgs.childArgs should be (Seq("some", "--weird", "args"))
+  }
+
+  test("handles extra spark options after user program options") {
+    val clArgs = Seq(
+      "--name", "myApp",
+      "--master", "local",
+      "userjar.jar",
+      "--class", "Foo",
+      "--",
+      "some",
+      "--weird", "args")
+    val appArgs = new SparkSubmitArguments(clArgs)
+    appArgs.master should be ("local")
+    appArgs.name should be ("myApp")
+    appArgs.mainClass should be ("Foo")
     appArgs.childArgs should be (Seq("some", "--weird", "args"))
   }
 
@@ -122,6 +139,7 @@ class SparkSubmitSuite extends FunSuite with Matchers {
       "--name", "beauty",
       "--conf", "spark.shuffle.spill=false",
       "thejar.jar",
+      "--",
       "arg1", "arg2")
     val appArgs = new SparkSubmitArguments(clArgs)
     val (childArgs, classpath, sysProps, mainClass) = createLaunchEnv(appArgs)
@@ -160,6 +178,7 @@ class SparkSubmitSuite extends FunSuite with Matchers {
       "--name", "trill",
       "--conf", "spark.shuffle.spill=false",
       "thejar.jar",
+      "--",
       "arg1", "arg2")
     val appArgs = new SparkSubmitArguments(clArgs)
     val (childArgs, classpath, sysProps, mainClass) = createLaunchEnv(appArgs)
@@ -192,6 +211,7 @@ class SparkSubmitSuite extends FunSuite with Matchers {
       "--driver-cores", "5",
       "--conf", "spark.shuffle.spill=false",
       "thejar.jar",
+      "--",
       "arg1", "arg2")
     val appArgs = new SparkSubmitArguments(clArgs)
     val (childArgs, classpath, sysProps, mainClass) = createLaunchEnv(appArgs)
@@ -219,6 +239,7 @@ class SparkSubmitSuite extends FunSuite with Matchers {
       "--driver-memory", "4g",
       "--conf", "spark.shuffle.spill=false",
       "thejar.jar",
+      "--",
       "arg1", "arg2")
     val appArgs = new SparkSubmitArguments(clArgs)
     val (childArgs, classpath, sysProps, mainClass) = createLaunchEnv(appArgs)
@@ -241,6 +262,7 @@ class SparkSubmitSuite extends FunSuite with Matchers {
       "--driver-memory", "4g",
       "--conf", "spark.shuffle.spill=false",
       "thejar.jar",
+      "--",
       "arg1", "arg2")
     val appArgs = new SparkSubmitArguments(clArgs)
     val (childArgs, classpath, sysProps, mainClass) = createLaunchEnv(appArgs)

--- a/sbin/start-thriftserver.sh
+++ b/sbin/start-thriftserver.sh
@@ -26,11 +26,15 @@ set -o posix
 # Figure out where Spark is installed
 FWDIR="$(cd `dirname $0`/..; pwd)"
 
-if [[ "$@" = *--help ]] || [[ "$@" = *-h ]]; then
-  echo "Usage: ./sbin/start-thriftserver [options]"
-  $FWDIR/bin/spark-submit --help 2>&1 | grep -v Usage 1>&2
+CLASS="org.apache.spark.sql.hive.thriftserver.HiveThriftServer2"
+
+if [[ "$1" = --help ]] || [[ "$1" = -h ]]; then
+  echo "Usage: ./sbin/start-thriftserver.sh [options] [-- application options]"
+  exec "$FWDIR"/bin/spark-submit --help 2>&1 | grep -v Usage 1>&2
+  echo
+  echo "Applicaion options:"
+  exec "$FWDIR"/bin/spark-submit spark-internal --class $CLASS -- -H 2>&1 | tail -n +3
   exit 0
 fi
 
-CLASS="org.apache.spark.sql.hive.thriftserver.HiveThriftServer2"
-exec "$FWDIR"/bin/spark-submit --class $CLASS spark-internal $@
+exec "$FWDIR"/bin/spark-submit spark-internal --class $CLASS $@

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
@@ -40,7 +40,6 @@ private[hive] object HiveThriftServer2 extends Logging {
     val optionsProcessor = new ServerOptionsProcessor("HiveThriftServer2")
 
     if (!optionsProcessor.process(args)) {
-      logger.warn("Error starting HiveThriftServer2 with given arguments")
       System.exit(-1)
     }
 


### PR DESCRIPTION
JIRA issue: [SPARK-2678](https://issues.apache.org/jira/browse/SPARK-2678)

Currently, `spark-submit` shadows user application options. Namely, options like `--help` are always captured by `spark-submit` and won't be passed to the user application. A negative impact of this is that, every time we add a new option to `spark-submit`, we may potentially break some existing user scripts if the new option name happens to shadow an existing option in the application.

This PR introduced an **incompatible** change to fix this issue: `--` is used as a separator between `spark-submit` options and user application options. All arguments after `--` are passed to the application as is. Thus,

``` bash
./bin/spark-submit --class Foo user.jar arg1 -arg2 --arg3 x
# or
./bin/spark-submit user.jar --class Foo arg1 -arg2 --arg3 x
```

must be rewritten to

``` bash
./bin/spark-submit --class Foo user.jar -- arg1 -arg2 --arg3 x
# or
./bin/spark-submit user.jar --class Foo -- arg1 -arg2 --arg3 x
```

@pwendell Please help review, thanks. Especially, maybe we need a vote here to decide whether fixing this issue worth an incompatible change.
