### PR TITLE
[SPARK-2806] core - upgrade to json4s-jackson 3.2.10

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -150,7 +150,7 @@
     <dependency>
       <groupId>org.json4s</groupId>
       <artifactId>json4s-jackson_${scala.binary.version}</artifactId>
-      <version>3.2.6</version>
+      <version>3.2.10</version>
     </dependency>
     <dependency>
       <groupId>colt</groupId>


### PR DESCRIPTION
Scala 2.11 packages not available for the current version (3.2.6)

Signed-off-by: Anand Avati avati@redhat.com
