### PR TITLE
[SPARK-1812] mllib - upgrade to breeze 0.8.1

### DIFF
--- a/mllib/pom.xml
+++ b/mllib/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>org.scalanlp</groupId>
       <artifactId>breeze_${scala.binary.version}</artifactId>
-      <version>0.7</version>
+      <version>0.8.1</version>
       <exclusions>
         <!-- This is included as a compile-scoped dependency by jtransforms, which is
              a dependency of breeze. -->


### PR DESCRIPTION
Scala 2.11 packages not available for the current version (0.7)

Signed-off-by: Anand Avati avati@redhat.com
