### PR TITLE
[SPARK-1812] streaming - fix parameters to StreamingContext constructor

### DIFF
--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -60,7 +60,7 @@ class StreamingContextSuite extends FunSuite with BeforeAndAfter with Timeouts w
   }
 
   test("from no conf + spark home") {
-    ssc = new StreamingContext(master, appName, batchDuration, sparkHome, Nil)
+    ssc = new StreamingContext(master, appName, batchDuration, sparkHome, Nil, Map(envPair))
     assert(ssc.conf.get("spark.home") === sparkHome)
   }
 


### PR DESCRIPTION
Encountered while compiling against Scala 2.11, possibly unrelated to Scala version (and is an existing issue)

Signed-off-by: Anand Avati avati@redhat.com
