### PR TITLE
[HOTFIX] downgrade breeze version to 0.7

### DIFF
--- a/mllib/pom.xml
+++ b/mllib/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>org.scalanlp</groupId>
       <artifactId>breeze_${scala.binary.version}</artifactId>
-      <version>0.8.1</version>
+      <version>0.7</version>
       <exclusions>
         <!-- This is included as a compile-scoped dependency by jtransforms, which is
              a dependency of breeze. -->


### PR DESCRIPTION
breeze-0.8.1 causes dependency issues, as discussed in #940 .
