### PR TITLE
StatCounter on NumPy arrays [PYSPARK][SPARK-2012]

### DIFF
--- a/python/pyspark/statcounter.py
+++ b/python/pyspark/statcounter.py
@@ -28,6 +28,7 @@ except:
     # no NumPy, so fall back on scalar operators
     pass
 
+
 class StatCounter(object):
 
     def __init__(self, values=[]):

--- a/python/pyspark/statcounter.py
+++ b/python/pyspark/statcounter.py
@@ -22,7 +22,7 @@ import math
 
 _have_numpy = False
 try:
-    import numpy as np
+    from numpy import maximum, minimum, sqrt
     _have_numpy = True
 except:
     # no NumPy, so fall back on scalar operators
@@ -53,8 +53,8 @@ class StatCounter(object):
             if self.minValue > value:
                 self.minValue = value
         else:
-            self.maxValue = np.maximum(self.maxValue, value)
-            self.minValue = np.minimum(self.minValue, value)
+            self.maxValue = maximum(self.maxValue, value)
+            self.minValue = minimum(self.minValue, value)
 
         return self
 
@@ -86,8 +86,8 @@ class StatCounter(object):
                     self.maxValue = max(self.maxValue, other.maxValue)
                     self.minValue = min(self.minValue, other.minValue)
                 else:
-                    self.maxValue = np.maximum(self.maxValue, other.maxValue)
-                    self.minValue = np.minimum(self.minValue, other.minValue)
+                    self.maxValue = maximum(self.maxValue, other.maxValue)
+                    self.minValue = minimum(self.minValue, other.minValue)
 
                 self.m2 += other.m2 + (delta * delta * self.n * other.n) / (self.n + other.n)
                 self.n += other.n
@@ -134,7 +134,7 @@ class StatCounter(object):
         if not _have_numpy:
             return math.sqrt(self.variance())
         else:
-            return np.sqrt(self.variance())
+            return sqrt(self.variance())
 
     #
     # Return the sample standard deviation of the values, which corrects for bias in estimating the
@@ -144,7 +144,7 @@ class StatCounter(object):
         if not _have_numpy:
             return math.sqrt(self.sampleVariance())
         else:
-            return np.sqrt(self.sampleVariance())
+            return sqrt(self.sampleVariance())
 
     def __repr__(self):
         return ("(count: %s, mean: %s, stdev: %s, max: %s, min: %s)" %

--- a/python/pyspark/statcounter.py
+++ b/python/pyspark/statcounter.py
@@ -20,13 +20,12 @@
 import copy
 import math
 
-_have_numpy = False
 try:
     from numpy import maximum, minimum, sqrt
-    _have_numpy = True
-except:
-    # no NumPy, so fall back on scalar operators
-    pass
+except ImportError:
+    maximum = max
+    minimum = min
+    sqrt = math.sqrt
 
 
 class StatCounter(object):
@@ -47,14 +46,8 @@ class StatCounter(object):
         self.n += 1
         self.mu += delta / self.n
         self.m2 += delta * (value - self.mu)
-        if not _have_numpy:
-            if self.maxValue < value:
-                self.maxValue = value
-            if self.minValue > value:
-                self.minValue = value
-        else:
-            self.maxValue = maximum(self.maxValue, value)
-            self.minValue = minimum(self.minValue, value)
+        self.maxValue = maximum(self.maxValue, value)
+        self.minValue = minimum(self.minValue, value)
 
         return self
 
@@ -82,12 +75,8 @@ class StatCounter(object):
                 else:
                     self.mu = (self.mu * self.n + other.mu * other.n) / (self.n + other.n)
 
-                if not _have_numpy:
-                    self.maxValue = max(self.maxValue, other.maxValue)
-                    self.minValue = min(self.minValue, other.minValue)
-                else:
-                    self.maxValue = maximum(self.maxValue, other.maxValue)
-                    self.minValue = minimum(self.minValue, other.minValue)
+                self.maxValue = maximum(self.maxValue, other.maxValue)
+                self.minValue = minimum(self.minValue, other.minValue)
 
                 self.m2 += other.m2 + (delta * delta * self.n * other.n) / (self.n + other.n)
                 self.n += other.n
@@ -131,20 +120,14 @@ class StatCounter(object):
 
     # Return the standard deviation of the values.
     def stdev(self):
-        if not _have_numpy:
-            return math.sqrt(self.variance())
-        else:
-            return sqrt(self.variance())
+        return sqrt(self.variance())
 
     #
     # Return the sample standard deviation of the values, which corrects for bias in estimating the
     # variance by dividing by N-1 instead of N.
     #
     def sampleStdev(self):
-        if not _have_numpy:
-            return math.sqrt(self.sampleVariance())
-        else:
-            return sqrt(self.sampleVariance())
+        return sqrt(self.sampleVariance())
 
     def __repr__(self):
         return ("(count: %s, mean: %s, stdev: %s, max: %s, min: %s)" %

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -38,11 +38,18 @@ from pyspark.serializers import read_int
 from pyspark.shuffle import Aggregator, InMemoryMerger, ExternalMerger
 
 _have_scipy = False
+_have_numpy = False
 try:
     import scipy.sparse
     _have_scipy = True
 except:
     # No SciPy, but that's okay, we'll skip those tests
+    pass
+try:
+    from numpy import array
+    _have_numpy = True
+except:
+    # No NumPy, but that's okay, we'll skip those tests
     pass
 
 
@@ -914,9 +921,27 @@ class SciPyTests(PySparkTestCase):
         self.assertEqual(expected, observed)
 
 
+@unittest.skipIf(not _have_numpy, "NumPy not installed")
+class NumPyTests(PySparkTestCase):
+    """General PySpark tests that depend on numpy """
+
+    def test_statcounter_array(self):
+        from numpy import array
+        x = self.sc.parallelize([array([1.0,1.0]), array([2.0,2.0]), array([3.0,3.0])])
+        s = x.stats()
+        self.assertSequenceEqual([2.0,2.0], s.mean().tolist())
+        self.assertSequenceEqual([1.0,1.0], s.min().tolist())
+        self.assertSequenceEqual([3.0,3.0], s.max().tolist())
+        self.assertSequenceEqual([1.0,1.0], s.sampleStdev().tolist())
+
+
 if __name__ == "__main__":
     if not _have_scipy:
         print "NOTE: Skipping SciPy tests as it does not seem to be installed"
+    if not _have_numpy:
+            print "NOTE: Skipping NumPy tests as it does not seem to be installed"
     unittest.main()
     if not _have_scipy:
         print "NOTE: SciPy tests were skipped as it does not seem to be installed"
+    if not _have_numpy:
+            print "NOTE: NumPy tests were skipped as it does not seem to be installed"

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -46,7 +46,7 @@ except:
     # No SciPy, but that's okay, we'll skip those tests
     pass
 try:
-    from numpy import array
+    import numpy as np
     _have_numpy = True
 except:
     # No NumPy, but that's okay, we'll skip those tests
@@ -926,8 +926,7 @@ class NumPyTests(PySparkTestCase):
     """General PySpark tests that depend on numpy """
 
     def test_statcounter_array(self):
-        from numpy import array
-        x = self.sc.parallelize([array([1.0,1.0]), array([2.0,2.0]), array([3.0,3.0])])
+        x = self.sc.parallelize([np.array([1.0,1.0]), np.array([2.0,2.0]), np.array([3.0,3.0])])
         s = x.stats()
         self.assertSequenceEqual([2.0,2.0], s.mean().tolist())
         self.assertSequenceEqual([1.0,1.0], s.min().tolist())

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -939,9 +939,9 @@ if __name__ == "__main__":
     if not _have_scipy:
         print "NOTE: Skipping SciPy tests as it does not seem to be installed"
     if not _have_numpy:
-            print "NOTE: Skipping NumPy tests as it does not seem to be installed"
+        print "NOTE: Skipping NumPy tests as it does not seem to be installed"
     unittest.main()
     if not _have_scipy:
         print "NOTE: SciPy tests were skipped as it does not seem to be installed"
     if not _have_numpy:
-            print "NOTE: NumPy tests were skipped as it does not seem to be installed"
+        print "NOTE: NumPy tests were skipped as it does not seem to be installed"


### PR DESCRIPTION
These changes allow StatCounters to work properly on NumPy arrays, to fix the issue reported here  (https://issues.apache.org/jira/browse/SPARK-2012). 

If NumPy is installed, the NumPy functions `maximum`, `minimum`, and `sqrt`, which work on arrays, are used to merge statistics. If not, we fall back on scalar operators, so it will work on arrays with NumPy, but will also work without NumPy.

New unit tests added, along with a check for NumPy in the tests.
