### PR TITLE
SPARK-2602 [BUILD] Tests steal focus under Java 6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -871,6 +871,7 @@
             <argLine>-Xmx3g -XX:MaxPermSize=${MaxPermGen} -XX:ReservedCodeCacheSize=512m</argLine>
             <stderr/>
             <systemProperties>
+              <java.awt.headless>true</java.awt.headless>
               <spark.test.home>${session.executionRootDirectory}</spark.test.home>
               <spark.testing>1</spark.testing>
             </systemProperties>


### PR DESCRIPTION
As per https://issues.apache.org/jira/browse/SPARK-2602 , this may be resolved for Java 6 with the java.awt.headless system property, which never hurt anyone running a command line app. I tested it and seemed to get rid of focus stealing.
