### PR TITLE
Optionally parallelize the Spark build.

### DIFF
--- a/make-distribution.sh
+++ b/make-distribution.sh
@@ -154,7 +154,19 @@ cd "$FWDIR"
 
 export MAVEN_OPTS="-Xmx2g -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=512m"
 
-BUILD_COMMAND="mvn clean package -DskipTests $@"
+# Maven 3 allows for parallel builds, though the Scala plugins are not
+# marked as threadsafe. To enable this, set the environment variable
+# `SPARK_BUILD_THREADS` to the number of jobs to create. You can also
+# say `1.5C` to indicate 1.5 times the number of cores on the host. (The
+# coefficient can be any number.)
+if [ "x$SPARK_BUILD_THREADS" != 'x' ]; then
+    echo "Parallel Maven build enabled for $SPARK_BUILD_THREADS threads (experimental)"
+    PAR_BUILD_OPTS="-T $SPARK_BUILD_THREADS"
+else
+    PAR_BUILD_OPTS=''
+fi
+
+BUILD_COMMAND="mvn $PAR_BUILD_OPTS clean package -DskipTests $@"
 
 # Actually build the jar
 echo -e "\nBuilding with..."


### PR DESCRIPTION
This introduces a new environment variable, `SPARK_BUILD_THREADS`,
that controls the level of Maven parallelization (if set). This uses
Maven 3's syntax for the number of threads: either a simple integer or
something like `1.5C` to indicate 1.5 times the number of cores on the
build server.

On my hardware, (Intel Xeon E5-1620 v2, roughly equivalent to a fast
i7), a setting of `1.5C` speeds up the build by about 15%.

This will trigger some warnings that the Scala plugins are not marked as
threadsafe. Several repeated builds show no differences in the compiled
distribution (save timestamps), but this isn't proof that it can never
fail.
