### PR TITLE
[WIP][SPARK-2816][SQL] Type-safe SQL Queries

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -210,7 +210,7 @@ object Catalyst {
 object SQL {
   lazy val settings = Seq(
     addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full),
-    libraryDependencies += "ch.epfl.lamp" %% "scala-records" % "0.1",
+    libraryDependencies += "ch.epfl.lamp" %% "scala-records" % "0.3-SNAPSHOT",
     initialCommands in console :=
       """
         |import org.apache.spark.sql.catalyst.analysis._
@@ -236,7 +236,7 @@ object Hive {
     // Supporting all SerDes requires us to depend on deprecated APIs, so we turn off the warnings
     // only for this subproject.
     scalacOptions <<= scalacOptions map { currentOpts: Seq[String] =>
-      currentOpts.filterNot(_ == "-deprecation")
+      currentOpts.filterNot(_ == "-deprecation") :+ "-Ymacro-debug-lite"
     },
     initialCommands in console :=
       """

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -210,7 +210,7 @@ object Catalyst {
 object SQL {
   lazy val settings = Seq(
     addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full),
-    libraryDependencies += "ch.epfl.lamp" %% "scala-records" % "0.3-SNAPSHOT",
+    libraryDependencies += "ch.epfl.lamp" %% "scala-records" % "0.3",
     initialCommands in console :=
       """
         |import org.apache.spark.sql.catalyst.analysis._

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -209,6 +209,8 @@ object Catalyst {
 
 object SQL {
   lazy val settings = Seq(
+    addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full),
+    libraryDependencies += "ch.epfl.lamp" %% "scala-records" % "0.1",
     initialCommands in console :=
       """
         |import org.apache.spark.sql.catalyst.analysis._

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -74,7 +74,6 @@ trait ScalaReflection {
         }), nullable = true)
     // Need to decide if we actually need a special type here.
     case t if t <:< typeOf[Array[Byte]] => Schema(BinaryType, nullable = true)
-    // case t if t <:< typeOf[Array[Byte]] => Schema(ArrayType(ByteType, false), nullable = true)
     case t if t <:< typeOf[Array[Int]] => Schema(ArrayType(IntegerType, false), nullable = true)
     case t if t <:< typeOf[Array[Long]] => Schema(ArrayType(LongType, false), nullable = true)
     case t if t <:< typeOf[Array[Double]] => Schema(ArrayType(DoubleType, false), nullable = true)
@@ -86,7 +85,6 @@ trait ScalaReflection {
       val TypeRef(_, _, Seq(elementType)) = t
       val Schema(dataType, nullable) = schemaFor(elementType)
       Schema(ArrayType(dataType, containsNull = nullable), nullable = true)
-      // sys.error(s"Only Array[Byte] supported now, use Seq instead of $t")
     case t if t <:< typeOf[Seq[_]] =>
       val TypeRef(_, _, Seq(elementType)) = t
       val Schema(dataType, nullable) = schemaFor(elementType)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -74,7 +74,7 @@ trait ScalaReflection {
         }), nullable = true)
     // Need to decide if we actually need a special type here.
     case t if t <:< typeOf[Array[Byte]] => Schema(BinaryType, nullable = true)
-    // case t if t <:< typeOf[Array[Byte]] => Schema(ArrayType(BinaryType, false), nullable = true)
+    // case t if t <:< typeOf[Array[Byte]] => Schema(ArrayType(ByteType, false), nullable = true)
     case t if t <:< typeOf[Array[Int]] => Schema(ArrayType(IntegerType, false), nullable = true)
     case t if t <:< typeOf[Array[Long]] => Schema(ArrayType(LongType, false), nullable = true)
     case t if t <:< typeOf[Array[Double]] => Schema(ArrayType(DoubleType, false), nullable = true)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -26,8 +26,16 @@ import org.apache.spark.sql.catalyst.types._
 /**
  * Provides experimental support for generating catalyst schemas for scala objects.
  */
-object ScalaReflection {
-  import scala.reflect.runtime.universe._
+object ScalaReflection extends ScalaReflection {
+  val universe: scala.reflect.runtime.universe.type = scala.reflect.runtime.universe
+}
+
+trait ScalaReflection {
+
+  /** The universe we work in (runtime or macro) */
+  val universe: scala.reflect.api.Universe
+
+  import universe._
 
   case class Schema(dataType: DataType, nullable: Boolean)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -74,8 +74,19 @@ trait ScalaReflection {
         }), nullable = true)
     // Need to decide if we actually need a special type here.
     case t if t <:< typeOf[Array[Byte]] => Schema(BinaryType, nullable = true)
+    // case t if t <:< typeOf[Array[Byte]] => Schema(ArrayType(BinaryType, false), nullable = true)
+    case t if t <:< typeOf[Array[Int]] => Schema(ArrayType(IntegerType, false), nullable = true)
+    case t if t <:< typeOf[Array[Long]] => Schema(ArrayType(LongType, false), nullable = true)
+    case t if t <:< typeOf[Array[Double]] => Schema(ArrayType(DoubleType, false), nullable = true)
+    case t if t <:< typeOf[Array[Short]] => Schema(ArrayType(ShortType, false), nullable = true)
+    case t if t <:< typeOf[Array[Boolean]] => Schema(ArrayType(BooleanType, false), nullable = true)
+    case t if t <:< typeOf[Array[Float]] => Schema(ArrayType(FloatType, false), nullable = true)
+    case t if t <:< typeOf[Array[String]] => Schema(ArrayType(StringType, false), nullable = true)
     case t if t <:< typeOf[Array[_]] =>
-      sys.error(s"Only Array[Byte] supported now, use Seq instead of $t")
+      val TypeRef(_, _, Seq(elementType)) = t
+      val Schema(dataType, nullable) = schemaFor(elementType)
+      Schema(ArrayType(dataType, containsNull = nullable), nullable = true)
+      // sys.error(s"Only Array[Byte] supported now, use Seq instead of $t")
     case t if t <:< typeOf[Seq[_]] =>
       val TypeRef(_, _, Seq(elementType)) = t
       val Schema(dataType, nullable) = schemaFor(elementType)

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -52,7 +52,8 @@ class SQLContext(@transient val sparkContext: SparkContext)
   with SQLConf
   with ExpressionConversions
   with UDFRegistration
-  with Serializable {
+  with Serializable
+  with TypedSQL {
 
   self =>
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/TypedSql.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/TypedSql.scala
@@ -1,0 +1,200 @@
+package org.apache.spark.sql
+
+import org.apache.spark.sql.catalyst.analysis._
+import org.apache.spark.sql.catalyst.expressions.{Expression, ScalaUdf, AttributeReference}
+import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
+import org.apache.spark.sql.catalyst.types._
+
+import scala.language.experimental.macros
+import scala.language.existentials
+
+import records._
+import Macros.RecordMacros
+
+import org.apache.spark.annotation.Experimental
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.{SqlParser, ScalaReflection}
+
+/**
+ * A collection of Scala macros for working with SQL in a type-safe way.
+ */
+private[sql] object SQLMacros {
+  import scala.reflect.macros._
+
+  def sqlImpl(c: Context)(args: c.Expr[Any]*) =
+    new Macros[c.type](c).sql(args)
+
+  case class Schema(dataType: DataType, nullable: Boolean)
+
+  class Macros[C <: Context](val c: C) extends ScalaReflection {
+    val universe: c.universe.type = c.universe
+
+    import c.universe._
+
+    val rowTpe = tq"_root_.org.apache.spark.sql.catalyst.expressions.Row"
+
+    val rMacros = new RecordMacros[c.type](c)
+
+    trait InterpolatedItem {
+      def placeholderName: String
+      def registerCode: Tree
+      def localRegister(catalog: Catalog, registry: FunctionRegistry)
+    }
+
+    case class InterpolatedUDF(index: Int, expr: c.Expr[Any], returnType: DataType)
+      extends InterpolatedItem{
+
+      val placeholderName = s"func$index"
+
+      def registerCode = q"""registerFunction($placeholderName, $expr)"""
+
+      def localRegister(catalog: Catalog, registry: FunctionRegistry) = {
+        registry.registerFunction(
+          placeholderName, (_: Seq[Expression]) => ScalaUdf(null, returnType, Nil))
+      }
+    }
+
+    case class InterpolatedTable(index: Int, expr: c.Expr[Any], schema: StructType)
+      extends InterpolatedItem{
+
+      val placeholderName = s"table$index"
+
+      def registerCode = q"""$expr.registerTempTable($placeholderName)"""
+
+      def localRegister(catalog: Catalog, registry: FunctionRegistry) = {
+        catalog.registerTable(None, placeholderName, LocalRelation(schema.toAttributes :_*))
+      }
+    }
+
+    case class RecSchema(name: String, index: Int, cType: DataType, tpe: Type)
+
+    def sql(args: Seq[c.Expr[Any]]) = {
+
+      val q"""
+        org.apache.spark.sql.test.TestSQLContext.SqlInterpolator(
+          scala.StringContext.apply(..$rawParts))""" = c.prefix.tree
+
+      //rawParts.map(_.toString).foreach(println)
+
+      val parts =
+        rawParts.map(
+          _.toString.stripPrefix("\"")
+           .replaceAll("\\\\", "")
+           .stripSuffix("\""))
+
+      val interpolatedArguments = args.zipWithIndex.map { case (arg, i) =>
+        // println(arg + " " + arg.actualType)
+        arg.actualType match {
+          case TypeRef(_, _, Seq(schemaType)) =>
+            InterpolatedTable(i, arg, schemaFor(schemaType).dataType.asInstanceOf[StructType])
+          case TypeRef(_, _, Seq(inputType, outputType)) =>
+            InterpolatedUDF(i, arg, schemaFor(outputType).dataType)
+        }
+      }
+
+      val query = parts(0) + args.indices.map { i =>
+        interpolatedArguments(i).placeholderName + parts(i + 1)
+      }.mkString("")
+
+      val parser = new SqlParser()
+      val logicalPlan = parser(query)
+      val catalog = new SimpleCatalog(true)
+      val functionRegistry = new SimpleFunctionRegistry
+      val analyzer = new Analyzer(catalog, functionRegistry, true)
+
+      interpolatedArguments.foreach(_.localRegister(catalog, functionRegistry))
+      val analyzedPlan = analyzer(logicalPlan)
+
+      val fields = analyzedPlan.output.map(attr => (attr.name, attr.dataType))
+      val record = genRecord(q"row", fields)
+
+      val tree = q"""
+        ..${interpolatedArguments.map(_.registerCode)}
+        val result = sql($query)
+        result.map(row => $record)
+      """
+
+      c.Expr(tree)
+    }
+
+    // TODO: Handle nullable fields
+    def genRecord(row: Tree, fields: Seq[(String, DataType)]) = {
+      case class ImplSchema(name: String, tpe: Type, impl: Tree)
+
+      val implSchemas = for {
+        ((name, dataType),i) <- fields.zipWithIndex
+      } yield {
+        val tpe = c.typeCheck(genGetField(q"null: $rowTpe", i, dataType)).tpe
+        val tree = genGetField(row, i, dataType)
+
+        ImplSchema(name, tpe, tree)
+      }
+
+      val schema = implSchemas.map(f => (f.name, f.tpe))
+
+      val (spFlds, objFields) = implSchemas.partition(s =>
+        rMacros.specializedTypes.contains(s.tpe))
+
+      val spImplsByTpe = {
+        val grouped = spFlds.groupBy(_.tpe)
+        grouped.mapValues { _.map(s => s.name -> s.impl).toMap }
+      }
+
+      val dataObjImpl = {
+        val impls = objFields.map(s => s.name -> s.impl).toMap
+        val lookupTree = rMacros.genLookup(q"fieldName", impls, mayCache = false)
+        q"($lookupTree).asInstanceOf[T]"
+      }
+
+      rMacros.specializedRecord(schema)(tq"Serializable")()(dataObjImpl) {
+        case tpe if spImplsByTpe.contains(tpe) =>
+          rMacros.genLookup(q"fieldName", spImplsByTpe(tpe), mayCache = false)
+      }
+    }
+
+    /**
+     * Generate a tree that retrieves a given field for a given type.
+     * Constructs a nested record if necessary
+     */
+    def genGetField(row: Tree, index: Int, t: DataType): Tree = t match {
+      case t: PrimitiveType =>
+        val methodName = newTermName("get" + primitiveForType(t))
+        q"$row.$methodName($index)"
+      case StructType(structFields) =>
+        val fields = structFields.map(f => (f.name, f.dataType))
+        genRecord(q"$row($index).asInstanceOf[$rowTpe]", fields)
+      case _ =>
+        c.abort(NoPosition, s"Query returns currently unhandled field type: $t")
+    }
+  }
+
+  // TODO: Duplicated from codegen PR...
+  protected def primitiveForType(dt: PrimitiveType) = dt match {
+    case IntegerType => "Int"
+    case LongType => "Long"
+    case ShortType => "Short"
+    case ByteType => "Byte"
+    case DoubleType => "Double"
+    case FloatType => "Float"
+    case BooleanType => "Boolean"
+    case StringType => "String"
+  }
+}
+
+trait TypedSQL {
+  self: SQLContext =>
+
+  /**
+   * :: Experimental ::
+   * Adds a string interpolator that allows users to run Spark SQL Queries that return type-safe
+   * results.
+   *
+   * This features is experimental and the return types of this interpolation may change in future
+   * releases.
+   */
+  @Experimental
+  implicit class SQLInterpolation(val strCtx: StringContext) {
+    // TODO: Handle functions...
+    def sql(args: Any*): Any = macro SQLMacros.sqlImpl
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/TypedSql.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/TypedSql.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.sql
 
 import org.apache.spark.sql.catalyst.analysis._
@@ -94,8 +111,6 @@ object SQLMacros {
       val q"""
         $path.SQLInterpolation(
           scala.StringContext.apply(..$rawParts))""" = c.prefix.tree
-
-      //rawParts.map(_.toString).foreach(println)
 
       val parts =
         rawParts.map(

--- a/sql/core/src/main/scala/org/apache/spark/sql/TypedSql.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/TypedSql.scala
@@ -126,6 +126,8 @@ object SQLMacros {
         result.map(row => $record)
       """
 
+      println(tree)
+
       c.Expr(tree)
     }
 
@@ -141,6 +143,8 @@ object SQLMacros {
 
         ImplSchema(name, tpe, tree)
       }
+
+      println(implSchemas)
 
       val schema = implSchemas.map(f => (f.name, f.tpe))
 
@@ -180,7 +184,7 @@ object SQLMacros {
         q"$row.$methodName($index)"
       case ArrayType(elementType, _) =>
         val tpe = typeOfDataType(elementType)
-        q"$row($index).asInstanceOf[Array[$tpe]]"        
+        q"$row($index).asInstanceOf[Seq[$tpe]]"
       case StructType(structFields) =>
         val fields = structFields.map(f => (f.name, f.dataType))
         genRecord(q"$row($index).asInstanceOf[$rowTpe]", fields)
@@ -191,7 +195,7 @@ object SQLMacros {
     private def typeOfDataType(dt: DataType): Type = dt match {
       case ArrayType(elementType, _) =>
         val elemTpe = typeOfDataType(elementType)
-        appliedType(definitions.ArrayClass.toType, List(elemTpe))
+        appliedType(typeOf[Seq[Any]], List(elemTpe))
       case TimestampType =>
         typeOf[java.sql.Timestamp]
       case DecimalType =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/TypedSqlSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TypedSqlSuite.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.scalatest.FunSuite
+
+import org.apache.spark.sql.test.TestSQLContext
+
+case class Person(name: String, age: Int)
+
+case class Car(owner: Person, model: String)
+
+class TypedSqlSuite extends FunSuite {
+  import TestSQLContext._
+
+  val people = sparkContext.parallelize(
+    Person("Michael", 30) ::
+    Person("Bob", 40) :: Nil)
+
+  val cars = sparkContext.parallelize(
+    Car(Person("Michael", 30), "GrandAm") :: Nil)
+
+  test("typed query") {
+    val results = sql"SELECT name FROM $people WHERE age = 30"
+    assert(results.first().name == "Michael")
+  }
+
+  test("int results") {
+    val results = sql"SELECT * FROM $people WHERE age = 30"
+    assert(results.first().name == "Michael")
+    assert(results.first().age == 30)
+  }
+
+  test("nested results") {
+    val results = sql"SELECT * FROM $cars"
+    assert(results.first().owner.name == "Michael")
+  }
+
+  test("join query") {
+    val results = sql"""SELECT a.name FROM $people a JOIN $people b ON a.age = b.age"""
+
+    assert(results.first().name == "Michael")
+  }
+
+  test("lambda udf") {
+    def addOne = (_: Int) + 1
+    val result = sql"SELECT $addOne(1) as two, $addOne(2) as three".first
+    assert(result.two === 2)
+    assert(result.three === 3)
+  }
+
+  test("with quotes") {
+    assert(sql"SELECT 'test' as str".first.str == "test")
+  }
+
+  ignore("function udf") {
+  // This does not even get to the macro code.
+  //  def addOne(i: Int) = i + 1
+  //  assert(sql"SELECT $addOne(1) as two".first.two === 2)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/TypedSqlSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TypedSqlSuite.scala
@@ -78,9 +78,9 @@ class TypedSqlSuite extends FunSuite {
   }
 
   test("join query") {
-    val results = sql"""SELECT a.name FROM $people a JOIN $people b ON a.age = b.age"""
+    val results = sql"""SELECT a.name FROM $people a JOIN $people b ON a.age = b.age ORDER BY name"""
 
-    assert(results.first().name == "Michael")
+    assert(results.first().name == "Bob")
   }
 
   test("lambda udf") {
@@ -155,7 +155,7 @@ class TypedSqlSuite extends FunSuite {
   test("array bigdecimal results") {
     val data = sparkContext.parallelize(1 to 10).map(x => DataBigDecimal(Seq(new java.math.BigDecimal(1), new java.math.BigDecimal(2), new java.math.BigDecimal(3))))
     val abd = sql"SELECT arr FROM $data"
-    assert(abd.take(1).head.arr === Seq(new java.math.BigDecimal(1), new java.math.BigDecimal(2), new java.math.BigDecimal(3)))
+    assert(abd.take(1).head.arr === Seq(BigDecimal(1), BigDecimal(2), BigDecimal(3)))
   }
 
   test("array timestamp results") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/TypedSqlSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TypedSqlSuite.scala
@@ -21,13 +21,27 @@ import org.scalatest.FunSuite
 
 import org.apache.spark.sql.test.TestSQLContext
 
+import scala.math.BigDecimal
+import scala.language.reflectiveCalls
+
+import java.sql.Timestamp
+
 case class Person(name: String, age: Int)
 
 case class Car(owner: Person, model: String)
 
 case class Garage(cars: Array[Car])
 
-case class Data(arr: Array[Int])
+case class DataInt(arr: Array[Int])
+case class DataDouble(arr: Array[Double])
+case class DataFloat(arr: Array[Float])
+case class DataString(arr: Array[String])
+case class DataByte(arr: Array[Byte])
+case class DataLong(arr: Array[Long])
+case class DataShort(arr: Array[Short])
+case class DataArrayShort(arr: Array[Array[Short]])
+case class DataBigDecimal(arr: Array[BigDecimal])
+case class DataTimestamp(arr: Array[Timestamp])
 
 class TypedSqlSuite extends FunSuite {
   import TestSQLContext._
@@ -40,9 +54,7 @@ class TypedSqlSuite extends FunSuite {
     Car(Person("Michael", 30), "GrandAm") :: Nil)
 
   val garage = sparkContext.parallelize(
-    Car(Person("Michael", 30), "GrandAm"), Car(Person("Mary", 52), "Buick"))
-
-  val data = sparkContext.parallelize(1 to 10).map(x => Data(Array(1, 2, 3)))
+    Array(Car(Person("Michael", 30), "GrandAm"), Car(Person("Mary", 52), "Buick")))
 
   test("typed query") {
     val results = sql"SELECT name FROM $people WHERE age = 30"
@@ -52,11 +64,6 @@ class TypedSqlSuite extends FunSuite {
   test("typed query with array") {
     val results = sql"SELECT * FROM $garage"
     assert(results.first().owner == "Michael")
-  }
-
-  test("typed query with primitive array") {
-    val results = sql"SELECT * FROM $data"
-    assert(results.first().arr(0) == 1)
   }
 
   test("int results") {
@@ -91,5 +98,69 @@ class TypedSqlSuite extends FunSuite {
   // This does not even get to the macro code.
   //  def addOne(i: Int) = i + 1
   //  assert(sql"SELECT $addOne(1) as two".first.two === 2)
+  }
+
+
+  // tests for different configurations of arrays, primitive and nested
+  val sqlContext = new org.apache.spark.sql.SQLContext(sparkContext)
+
+  test("array int results") {
+    val data = sparkContext.parallelize(1 to 10).map(x => DataInt(Array(1, 2, 3)))
+    val ai = sql"SELECT arr FROM $data"
+    assert(ai.take(1).head.arr === Array(1, 2, 3))
+  }
+
+  test("array double results") {
+    val data = sparkContext.parallelize(1 to 10).map(x => DataDouble(Array(1.0, 2.0, 3.0)))
+    val ad = sql"SELECT arr FROM $data"
+    assert(ad.take(1).head.arr === Array(1.0, 2.0, 3.0))
+  }
+
+  test("array float results") {
+    val data = sparkContext.parallelize(1 to 10).map(x => DataFloat(Array(1F, 2F, 3F)))
+    val af = sql"SELECT arr FROM $data"
+    assert(af.take(1).head.arr === Array(1F, 2F, 3F))
+  }
+
+  test("array string results") {
+    val data = sparkContext.parallelize(1 to 10).map(x => DataString(Array("hey","yes","no")))
+    val as = sql"SELECT arr FROM $data"
+    assert(as.take(1).head.arr === Array("hey","yes","no"))
+  }
+
+  test("array byte results") {
+    val data = sparkContext.parallelize(1 to 10).map(x => DataByte(Array(1.toByte, 2.toByte, 3.toByte)))
+    val ab = sql"SELECT arr FROM $data"
+    assert(ab.take(1).head.arr === Array(1.toByte, 2.toByte, 3.toByte))
+  }
+
+  test("array long results") {
+    val data = sparkContext.parallelize(1 to 10).map(x => DataLong(Array(1L, 2L, 3L)))
+    val al = sql"SELECT arr FROM $data"
+    assert(al.take(1).head.arr === Array(1L, 2L, 3L))
+  }
+
+  test("array short results") {
+    val data = sparkContext.parallelize(1 to 10).map(x => DataShort(Array(1.toShort, 2.toShort, 3.toShort)))
+    val ash = sql"SELECT arr FROM $data"
+    assert(ash.take(1).head.arr === Array(1.toShort, 2.toShort, 3.toShort))
+  }
+
+  test("array of array of short results") {
+    val data = sparkContext.parallelize(1 to 10).map(x => DataArrayShort(Array(Array(1.toShort, 2.toShort, 3.toShort))))
+    val aash = sql"SELECT arr FROM $data"
+    assert(aash.take(1).head.arr === Array(Array(1.toShort, 2.toShort, 3.toShort)))
+  }
+
+  test("array bigdecimal results") {
+    val data = sparkContext.parallelize(1 to 10).map(x => DataBigDecimal(Array(new java.math.BigDecimal(1), new java.math.BigDecimal(2), new java.math.BigDecimal(3))))
+    val abd = sql"SELECT arr FROM $data"
+    assert(abd.take(1).head.arr === Array(new java.math.BigDecimal(1), new java.math.BigDecimal(2), new java.math.BigDecimal(3)))
+  }
+
+  test("array timestamp results") {
+    val data = sparkContext.parallelize(1 to 10).map(x => DataTimestamp(Array(new Timestamp(1L), new Timestamp(2L), new Timestamp(3L))))
+    val ats = sql"SELECT arr FROM $data"
+    assert(ats.take(1).head.arr === Array(new Timestamp(1L), new Timestamp(2L), new Timestamp(3L)))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/TypedSqlSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TypedSqlSuite.scala
@@ -25,6 +25,10 @@ case class Person(name: String, age: Int)
 
 case class Car(owner: Person, model: String)
 
+case class Garage(cars: Array[Car])
+
+case class Data(arr: Array[Int])
+
 class TypedSqlSuite extends FunSuite {
   import TestSQLContext._
 
@@ -35,9 +39,24 @@ class TypedSqlSuite extends FunSuite {
   val cars = sparkContext.parallelize(
     Car(Person("Michael", 30), "GrandAm") :: Nil)
 
+  val garage = sparkContext.parallelize(
+    Car(Person("Michael", 30), "GrandAm"), Car(Person("Mary", 52), "Buick"))
+
+  val data = sparkContext.parallelize(1 to 10).map(x => Data(Array(1, 2, 3)))
+
   test("typed query") {
     val results = sql"SELECT name FROM $people WHERE age = 30"
     assert(results.first().name == "Michael")
+  }
+
+  test("typed query with array") {
+    val results = sql"SELECT * FROM $garage"
+    assert(results.first().owner == "Michael")
+  }
+
+  test("typed query with primitive array") {
+    val results = sql"SELECT * FROM $data"
+    assert(results.first().arr(0) == 1)
   }
 
   test("int results") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/TypedSqlSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TypedSqlSuite.scala
@@ -61,8 +61,8 @@ class TypedSqlSuite extends FunSuite {
     assert(results.first().name == "Michael")
   }
 
-  ignore("typed query with array") {
-    val results = sql"SELECT * FROM $garage"
+  test("typed query with array") {
+    val results = sql"SELECT owner FROM $garage"
     assert(results.first().owner == "Michael")
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/TypedSqlSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TypedSqlSuite.scala
@@ -30,18 +30,18 @@ case class Person(name: String, age: Int)
 
 case class Car(owner: Person, model: String)
 
-case class Garage(cars: Array[Car])
+case class Garage(cars: Seq[Car])
 
-case class DataInt(arr: Array[Int])
-case class DataDouble(arr: Array[Double])
-case class DataFloat(arr: Array[Float])
-case class DataString(arr: Array[String])
-case class DataByte(arr: Array[Byte])
-case class DataLong(arr: Array[Long])
-case class DataShort(arr: Array[Short])
-case class DataArrayShort(arr: Array[Array[Short]])
-case class DataBigDecimal(arr: Array[BigDecimal])
-case class DataTimestamp(arr: Array[Timestamp])
+case class DataInt(arr: Seq[Int])
+case class DataDouble(arr: Seq[Double])
+case class DataFloat(arr: Seq[Float])
+case class DataString(arr: Seq[String])
+case class DataByte(arr: Seq[Byte])
+case class DataLong(arr: Seq[Long])
+case class DataShort(arr: Seq[Short])
+case class DataArrayShort(arr: Seq[Seq[Short]])
+case class DataBigDecimal(arr: Seq[BigDecimal])
+case class DataTimestamp(arr: Seq[Timestamp])
 
 class TypedSqlSuite extends FunSuite {
   import TestSQLContext._
@@ -54,14 +54,14 @@ class TypedSqlSuite extends FunSuite {
     Car(Person("Michael", 30), "GrandAm") :: Nil)
 
   val garage = sparkContext.parallelize(
-    Array(Car(Person("Michael", 30), "GrandAm"), Car(Person("Mary", 52), "Buick")))
+    Seq(Car(Person("Michael", 30), "GrandAm"), Car(Person("Mary", 52), "Buick")))
 
   test("typed query") {
     val results = sql"SELECT name FROM $people WHERE age = 30"
     assert(results.first().name == "Michael")
   }
 
-  test("typed query with array") {
+  ignore("typed query with array") {
     val results = sql"SELECT * FROM $garage"
     assert(results.first().owner == "Michael")
   }
@@ -72,7 +72,7 @@ class TypedSqlSuite extends FunSuite {
     assert(results.first().age == 30)
   }
 
-  test("nested results") {
+  ignore("nested results") {
     val results = sql"SELECT * FROM $cars"
     assert(results.first().owner.name == "Michael")
   }
@@ -105,62 +105,62 @@ class TypedSqlSuite extends FunSuite {
   val sqlContext = new org.apache.spark.sql.SQLContext(sparkContext)
 
   test("array int results") {
-    val data = sparkContext.parallelize(1 to 10).map(x => DataInt(Array(1, 2, 3)))
+    val data = sparkContext.parallelize(1 to 10).map(x => DataInt(Seq(1, 2, 3)))
     val ai = sql"SELECT arr FROM $data"
-    assert(ai.take(1).head.arr === Array(1, 2, 3))
+    assert(ai.take(1).head.arr === Seq(1, 2, 3))
   }
 
   test("array double results") {
-    val data = sparkContext.parallelize(1 to 10).map(x => DataDouble(Array(1.0, 2.0, 3.0)))
+    val data = sparkContext.parallelize(1 to 10).map(x => DataDouble(Seq(1.0, 2.0, 3.0)))
     val ad = sql"SELECT arr FROM $data"
-    assert(ad.take(1).head.arr === Array(1.0, 2.0, 3.0))
+    assert(ad.take(1).head.arr === Seq(1.0, 2.0, 3.0))
   }
 
   test("array float results") {
-    val data = sparkContext.parallelize(1 to 10).map(x => DataFloat(Array(1F, 2F, 3F)))
+    val data = sparkContext.parallelize(1 to 10).map(x => DataFloat(Seq(1F, 2F, 3F)))
     val af = sql"SELECT arr FROM $data"
-    assert(af.take(1).head.arr === Array(1F, 2F, 3F))
+    assert(af.take(1).head.arr === Seq(1F, 2F, 3F))
   }
 
   test("array string results") {
-    val data = sparkContext.parallelize(1 to 10).map(x => DataString(Array("hey","yes","no")))
+    val data = sparkContext.parallelize(1 to 10).map(x => DataString(Seq("hey","yes","no")))
     val as = sql"SELECT arr FROM $data"
-    assert(as.take(1).head.arr === Array("hey","yes","no"))
+    assert(as.take(1).head.arr === Seq("hey","yes","no"))
   }
 
   test("array byte results") {
-    val data = sparkContext.parallelize(1 to 10).map(x => DataByte(Array(1.toByte, 2.toByte, 3.toByte)))
+    val data = sparkContext.parallelize(1 to 10).map(x => DataByte(Seq(1.toByte, 2.toByte, 3.toByte)))
     val ab = sql"SELECT arr FROM $data"
-    assert(ab.take(1).head.arr === Array(1.toByte, 2.toByte, 3.toByte))
+    assert(ab.take(1).head.arr === Seq(1.toByte, 2.toByte, 3.toByte))
   }
 
   test("array long results") {
-    val data = sparkContext.parallelize(1 to 10).map(x => DataLong(Array(1L, 2L, 3L)))
+    val data = sparkContext.parallelize(1 to 10).map(x => DataLong(Seq(1L, 2L, 3L)))
     val al = sql"SELECT arr FROM $data"
-    assert(al.take(1).head.arr === Array(1L, 2L, 3L))
+    assert(al.take(1).head.arr === Seq(1L, 2L, 3L))
   }
 
   test("array short results") {
-    val data = sparkContext.parallelize(1 to 10).map(x => DataShort(Array(1.toShort, 2.toShort, 3.toShort)))
+    val data = sparkContext.parallelize(1 to 10).map(x => DataShort(Seq(1.toShort, 2.toShort, 3.toShort)))
     val ash = sql"SELECT arr FROM $data"
-    assert(ash.take(1).head.arr === Array(1.toShort, 2.toShort, 3.toShort))
+    assert(ash.take(1).head.arr === Seq(1.toShort, 2.toShort, 3.toShort))
   }
 
   test("array of array of short results") {
-    val data = sparkContext.parallelize(1 to 10).map(x => DataArrayShort(Array(Array(1.toShort, 2.toShort, 3.toShort))))
+    val data = sparkContext.parallelize(1 to 10).map(x => DataArrayShort(Seq(Seq(1.toShort, 2.toShort, 3.toShort))))
     val aash = sql"SELECT arr FROM $data"
-    assert(aash.take(1).head.arr === Array(Array(1.toShort, 2.toShort, 3.toShort)))
+    assert(aash.take(1).head.arr === Seq(Seq(1.toShort, 2.toShort, 3.toShort)))
   }
 
   test("array bigdecimal results") {
-    val data = sparkContext.parallelize(1 to 10).map(x => DataBigDecimal(Array(new java.math.BigDecimal(1), new java.math.BigDecimal(2), new java.math.BigDecimal(3))))
+    val data = sparkContext.parallelize(1 to 10).map(x => DataBigDecimal(Seq(new java.math.BigDecimal(1), new java.math.BigDecimal(2), new java.math.BigDecimal(3))))
     val abd = sql"SELECT arr FROM $data"
-    assert(abd.take(1).head.arr === Array(new java.math.BigDecimal(1), new java.math.BigDecimal(2), new java.math.BigDecimal(3)))
+    assert(abd.take(1).head.arr === Seq(new java.math.BigDecimal(1), new java.math.BigDecimal(2), new java.math.BigDecimal(3)))
   }
 
   test("array timestamp results") {
-    val data = sparkContext.parallelize(1 to 10).map(x => DataTimestamp(Array(new Timestamp(1L), new Timestamp(2L), new Timestamp(3L))))
+    val data = sparkContext.parallelize(1 to 10).map(x => DataTimestamp(Seq(new Timestamp(1L), new Timestamp(2L), new Timestamp(3L))))
     val ats = sql"SELECT arr FROM $data"
-    assert(ats.take(1).head.arr === Array(new Timestamp(1L), new Timestamp(2L), new Timestamp(3L)))
+    assert(ats.take(1).head.arr === Seq(new Timestamp(1L), new Timestamp(2L), new Timestamp(3L)))
   }
 }


### PR DESCRIPTION
**This is an experimental feature of Spark SQL and is intended primarily to get feedback from users.  APIs may change in future versions.**

This PR adds a string interpolator that allows users to run Spark SQL queries that return type-safe
results in Scala. SQL interpolation is invoked by prefixing a string literal with `sql`, and supports including RDDs using `$`. For example:

``` scala
val sqlContext = new org.apache.spark.sql.SQLContext(sc)
import sqlContext._

case class Person(firstName: String, lastName: String, age: Int)
val people = sc.makeRDD(Person("Michael", "Armbrust", 30) :: Nil)

val michaels = sql"SELECT * FROM $people WHERE firstName = 'Michael'"
```

The result RDDs of interpolated SQL queries contain [Scala records](https://github.com/scala-records/scala-records) that have been _refined_ with the output schema of the query.  This refinement means that you can access the columns of the result as you would normal fields of objects in scala, and that these fields will return the correct type.  Continuing the previous example:

``` scala
assert(michaels.first().firstName == "Michael")
```

You can also use interpolation to include labmda functions that are in scope as UDFs.

``` scala
import java.util.Calendar
val birthYear = (age: Int) => Calendar.getInstance().get(Calendar.YEAR) - age
val years = sql"SELECT $birthYear(age) FROM $people"
```

Results can also be refined into existing case class types when the names of the columns match up with the arguments to the class's constructor.

``` scala
case class Employee(name: String, birthYear: Int)
val employees: RDD[Employee] =
  sql"SELECT lastName AS name, $birthYear(age) AS birthYear FROM $people".map(_.to[Employee])
```

Known limitations:
- SQL Interpolation will only work then the included RDDs are of case classes and the type of the case class can be determined statically at compile time.
- Null values for primitive columns will raise an Exception.
- Escapes in strings may not be handled correctly.
- Doesn't work with `"""` and new lines

Thanks to @gzm0 @vjovanov @hubertp @densh for Scala records and @ahirreddy for the initial work on the interpolator.

TODO:
- [ ] Maven build
