### PR TITLE
[SPARK-2824/2825][SQL] Work towards separating data location from format

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -266,7 +266,8 @@ package object dsl {
 
   object plans {  // scalastyle:ignore
     implicit class DslLogicalPlan(val logicalPlan: LogicalPlan) extends LogicalPlanFunctions {
-      def writeToFile(path: String) = WriteToFile(path, logicalPlan)
+    // Writing to files doesn't make sense without Hadoop in scope (unless we assume local fs)
+//      def writeToFile(path: String) = WriteToFile(path, classOf[??], logicalPlan)
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicOperators.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.catalyst.plans.logical
 
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.catalyst.plans.physical.TableFormat
 import org.apache.spark.sql.catalyst.types._
 
 case class Project(projectList: Seq[NamedExpression], child: LogicalPlan) extends UnaryNode {
@@ -129,6 +130,7 @@ case class InsertIntoTable(
 case class InsertIntoCreatedTable(
     databaseName: Option[String],
     tableName: String,
+    format: Class[_ <: TableFormat],
     child: LogicalPlan) extends UnaryNode {
   override def references = Set.empty
   override def output = child.output
@@ -136,6 +138,7 @@ case class InsertIntoCreatedTable(
 
 case class WriteToFile(
     path: String,
+    format: Class[_ <: TableFormat],
     child: LogicalPlan) extends UnaryNode {
   override def references = Set.empty
   override def output = child.output

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/TableFormat.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/TableFormat.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.physical
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+
+/**
+ * A TableFormat enables the creation and loading of a logical table at a physical TableLocation.
+ *
+ * Concrete classes will be instantiated with a very simple form of dependency injection;
+ * a SQLContext (or HiveContext) and Hadoop Configuration are available. Only one constructor
+ * is allowed.
+ */
+private[sql] abstract class TableFormat {
+  /**
+   * Constructs a new, empty Relation with the given schema. It is the responsibility of
+   * the caller to ensure that the given location is either empty, or else that it is OK to
+   * overwrite any data already there.
+   * @param location Description of the physical location where the table data should be put
+   * @param schema Schema of the new relation
+   * @return Newly constructed Relation (e.g., a ParquetRelation)
+   */
+  def createEmptyRelation(location: TableLocation, schema: Seq[Attribute]): LogicalPlan
+
+  /**
+   * Loads an existing Relation from the given location. It is only valid to call this
+   * after calling createEmptyRelation() for the same location.
+   * @param location Description of the physical location of the table data
+   * @return Relation over the given data (e.g., a ParquetRelation)
+   */
+  def loadExistingRelation(location: TableLocation): LogicalPlan
+}
+
+/**
+ * Describes the physical location of a table.
+ */
+private[sql] trait TableLocation extends Serializable

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/TableFormat.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/TableFormat.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
  * a SQLContext (or HiveContext) and Hadoop Configuration are available. Only one constructor
  * is allowed.
  */
-private[sql] abstract class TableFormat {
+abstract class TableFormat {
   /**
    * Constructs a new, empty Relation with the given schema. It is the responsibility of
    * the caller to ensure that the given location is either empty, or else that it is OK to

--- a/sql/core/src/main/scala/org/apache/spark/sql/HadoopDirectory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/HadoopDirectory.scala
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import java.io.IOException
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.fs.permission.FsAction
+import org.apache.spark.sql.catalyst.plans.physical.TableLocation
+
+/**
+ * Represents the location of a table that exists within a single Hadoop directory.
+ */
+private[sql] class HadoopDirectory(path: String) extends TableLocation with HadoopDirectoryLike {
+  def this(path: Path) = this(path.toString)
+
+  def asString = path
+  def asPath = new Path(path)
+  def asHadoopDirectory = this
+
+  override def equals(other: Any) = other match {
+    case o: HadoopDirectory =>
+      o.asString == asString
+    case o: HadoopDirectoryLike =>
+      o.asHadoopDirectory.asString == asString
+    case _ => false
+  }
+
+  override def toString = asString
+}
+
+private[sql] object HadoopDirectory {
+
+  /**
+   * Creates a HadoopDirectory object that contains a fully-qualified path. This method also ensures
+   * that the given directory is writable by Spark, and, optionally, whether is already contains
+   * files.
+   */
+  def createChecked(
+      pathString: String,
+      conf: Configuration,
+      allowExisting: Boolean = false): HadoopDirectory = {
+    val path = new Path(pathString)
+    require(path != null, "Unable to create ParquetRelation: path is null")
+
+    val fs = path.getFileSystem(conf)
+    require(fs != null, s"Unable to create ParquetRelation: incorrectly formatted path $path")
+
+    if (!allowExisting && fs.exists(path) && fs.listStatus(path).nonEmpty) {
+      sys.error(s"File $path already exists and is not empty.")
+    }
+
+    if (fs.exists(path) &&
+      !fs.getFileStatus(path)
+        .getPermission
+        .getUserAction
+        .implies(FsAction.READ_WRITE)) {
+      throw new IOException(
+        s"Unable to create ParquetRelation: path $path not read-writable")
+    }
+    new HadoopDirectory(fs.makeQualified(path))
+  }
+}
+
+private[sql] trait HadoopDirectoryLike {
+  def asHadoopDirectory: HadoopDirectory
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -22,6 +22,7 @@ import scala.reflect.runtime.universe.TypeTag
 
 import org.apache.hadoop.conf.Configuration
 
+import org.apache.spark.SparkContext
 import org.apache.spark.annotation.{AlphaComponent, DeveloperApi, Experimental}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.ScalaReflection
@@ -30,13 +31,12 @@ import org.apache.spark.sql.catalyst.dsl.ExpressionConversions
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.optimizer.Optimizer
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.physical.TableFormat
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 import org.apache.spark.sql.columnar.InMemoryRelation
 import org.apache.spark.sql.execution._
-import org.apache.spark.sql.execution.SparkStrategies
 import org.apache.spark.sql.json._
-import org.apache.spark.sql.parquet.ParquetRelation
-import org.apache.spark.{Logging, SparkContext}
+import org.apache.spark.sql.parquet.ParquetFormat
 
 /**
  * :: AlphaComponent ::
@@ -74,6 +74,8 @@ class SQLContext(@transient val sparkContext: SparkContext)
   protected[sql] def executeSql(sql: String): this.QueryExecution = executePlan(parseSql(sql))
   protected[sql] def executePlan(plan: LogicalPlan): this.QueryExecution =
     new this.QueryExecution { val logical = plan }
+
+  protected[sql] def defaultTableFormat: Class[_ <: TableFormat] = classOf[ParquetFormat]
 
   /**
    * :: DeveloperApi ::
@@ -135,8 +137,10 @@ class SQLContext(@transient val sparkContext: SparkContext)
    *
    * @group userf
    */
-  def parquetFile(path: String): SchemaRDD =
-    new SchemaRDD(this, parquet.ParquetRelation(path, Some(sparkContext.hadoopConfiguration), this))
+  def parquetFile(path: String): SchemaRDD = {
+    val format = instantiateTableFormat(classOf[ParquetFormat])
+    new SchemaRDD(this, format.loadExistingRelation(new HadoopDirectory(path)))
+  }
 
   /**
    * Loads a JSON file (one object per line), returning the result as a [[SchemaRDD]].
@@ -230,11 +234,20 @@ class SQLContext(@transient val sparkContext: SparkContext)
   def createParquetFile[A <: Product : TypeTag](
       path: String,
       allowExisting: Boolean = true,
-      conf: Configuration = new Configuration()): SchemaRDD = {
-    new SchemaRDD(
-      this,
-      ParquetRelation.createEmpty(
-        path, ScalaReflection.attributesFor[A], allowExisting, conf, this))
+      conf: Configuration = sparkContext.hadoopConfiguration): SchemaRDD = {
+    createParquetFile(ScalaReflection.attributesFor[A], path, allowExisting, conf)
+  }
+
+  /** Creates an empty parquet file. Full documentation above. */
+  private[sql] def createParquetFile(
+      schema: Seq[Attribute],
+      path: String,
+      allowExisting: Boolean,
+      conf: Configuration): SchemaRDD = {
+    val dir = HadoopDirectory.createChecked(path, conf, allowExisting)
+    val format = instantiateTableFormat(classOf[ParquetFormat])
+    val relation = format.createEmptyRelation(dir, schema)
+    new SchemaRDD(this, relation)
   }
 
   /**
@@ -450,7 +463,7 @@ class SQLContext(@transient val sparkContext: SparkContext)
       rdd: RDD[Array[Any]],
       schema: StructType): SchemaRDD = {
     import scala.collection.JavaConversions._
-    import scala.collection.convert.Wrappers.{JListWrapper, JMapWrapper}
+    import scala.collection.convert.Wrappers.JListWrapper
 
     def needsConversion(dataType: DataType): Boolean = dataType match {
       case ByteType => true
@@ -511,5 +524,36 @@ class SQLContext(@transient val sparkContext: SparkContext)
     }
 
     new SchemaRDD(this, SparkLogicalPlan(ExistingRdd(schema.toAttributes, rowRdd))(self))
+  }
+
+  /**
+   * Constructs an instance of the given TableFormat class. A concrete TableFormat must have
+   * exactly one constructor. We will attempt to inject proper values for its constructor
+   * arguments based on a set of objects in our environment.
+   * Currently, we will inject this SQLContext, our SparkContext, and our Hadoop Configuration.
+   */
+  def instantiateTableFormat(cls: Class[_ <: TableFormat]): TableFormat = {
+    // Contains the environment of all objects that may be injected into the given TableFormat's
+    // constructor. Each object must have a different class in order to choose between them.
+    val environment = Seq[AnyRef](this, sparkContext, sparkContext.hadoopConfiguration)
+
+    // Only 1 constructor is allowed.
+    val ctors = cls.getConstructors
+    if (ctors.isEmpty) {
+      sys.error(s"No accessible constructors for TableFormat '$cls'.")
+    } else if (ctors.length > 1) {
+      sys.error(s"Cannot construct TableFormat '$cls' as it contains more than one constructor.")
+    }
+
+    val ctor = ctors.head
+    val parameterTypes = ctor.getParameterTypes
+
+    // Attempt to find a matching object in our environment for each parameter type.
+    val parameters = parameterTypes.map { case typ =>
+      environment.find(envObject => typ.isAssignableFrom(envObject.getClass)).getOrElse(
+        sys.error(s"Could not find parameter of type '$typ' while constructing '$cls'"))
+    }
+
+    ctor.newInstance(parameters: _*).asInstanceOf[TableFormat]
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -17,13 +17,14 @@
 
 package org.apache.spark.sql.execution
 
-import org.apache.spark.sql.{SQLContext, execution}
+import org.apache.spark.sql.{HadoopDirectory, SQLContext, execution}
+import org.apache.spark.sql.catalyst.analysis.UnresolvedException
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.planning._
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical._
-import org.apache.spark.sql.columnar.{InMemoryRelation, InMemoryColumnarTableScan}
+import org.apache.spark.sql.columnar.{InMemoryColumnarTableScan, InMemoryRelation}
 import org.apache.spark.sql.parquet._
 
 private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
@@ -192,11 +193,17 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
   object ParquetOperations extends Strategy {
     def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
       // TODO: need to support writing to other types of files.  Unify the below code paths.
-      case logical.WriteToFile(path, child) =>
-        val relation =
-          ParquetRelation.create(path, child, sparkContext.hadoopConfiguration, sqlContext)
+      case logical.WriteToFile(pathString, formatClass, child) =>
+        if (!child.resolved) {
+          throw new UnresolvedException[LogicalPlan](
+            child,
+            "Attempted to create relation with unresolved child (when schema is not available)")
+        }
+        val path = HadoopDirectory.createChecked(pathString, sparkContext.hadoopConfiguration)
+        val format = sqlContext.instantiateTableFormat(formatClass)
+        val relation = format.createEmptyRelation(path, child.output)
         // Note: overwrite=false because otherwise the metadata we just created will be deleted
-        InsertIntoParquetTable(relation, planLater(child), overwrite = false) :: Nil
+        planLater(logical.InsertIntoTable(relation, Map.empty, child, overwrite = false)) :: Nil
       case logical.InsertIntoTable(table: ParquetRelation, partition, child, overwrite) =>
         InsertIntoParquetTable(table, planLater(child), overwrite) :: Nil
       case PhysicalOperation(projectList, filters: Seq[Expression], relation: ParquetRelation) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetTestData.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetTestData.scala
@@ -104,7 +104,7 @@ private[sql] object ParquetTestData {
   val testDir = Utils.createTempDir()
   val testFilterDir = Utils.createTempDir()
 
-  lazy val testData = new ParquetRelation(testDir.toURI.toString, None, TestSQLContext)
+  lazy val testData = TestSQLContext.parquetFile(testDir.toURI.toString)
 
   val testNestedSchema1 =
     // based on blogpost example, source:
@@ -203,10 +203,8 @@ private[sql] object ParquetTestData {
   val testNestedDir3 = Utils.createTempDir()
   val testNestedDir4 = Utils.createTempDir()
 
-  lazy val testNestedData1 =
-    new ParquetRelation(testNestedDir1.toURI.toString, None, TestSQLContext)
-  lazy val testNestedData2 =
-    new ParquetRelation(testNestedDir2.toURI.toString, None, TestSQLContext)
+  lazy val testNestedData1 = TestSQLContext.parquetFile(testNestedDir1.toURI.toString)
+  lazy val testNestedData2 = TestSQLContext.parquetFile(testNestedDir2.toURI.toString)
 
   def writeFile() = {
     testDir.delete()

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -343,11 +343,11 @@ private[hive] case class MetastoreRelation
 }
 
 class MetastoreFormat(hiveContext: HiveContext) extends TableFormat {
-  override def createEmptyRelation(loc: TableLocation, schema: Seq[Attribute]): MetastoreRelation = {
-    new MetastoreRelation(loc.asInstanceOf[HiveTableLocation])(hiveContext)
+  override def createEmptyRelation(l: TableLocation, schema: Seq[Attribute]): MetastoreRelation = {
+    new MetastoreRelation(l.asInstanceOf[HiveTableLocation])(hiveContext)
   }
 
-  override def loadExistingRelation(loc: TableLocation): MetastoreRelation = {
-    new MetastoreRelation(loc.asInstanceOf[HiveTableLocation])(hiveContext)
+  override def loadExistingRelation(l: TableLocation): MetastoreRelation = {
+    new MetastoreRelation(l.asInstanceOf[HiveTableLocation])(hiveContext)
   }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -17,39 +17,37 @@
 
 package org.apache.spark.sql.hive
 
+import scala.collection.JavaConversions._
 import scala.util.parsing.combinator.RegexParsers
 
-import org.apache.hadoop.fs.Path
-import org.apache.hadoop.hive.conf.HiveConf
-import org.apache.hadoop.hive.metastore.api.{FieldSchema, StorageDescriptor, SerDeInfo}
-import org.apache.hadoop.hive.metastore.api.{Table => TTable, Partition => TPartition}
+import org.apache.hadoop.hive.metastore.api.{FieldSchema, SerDeInfo, StorageDescriptor}
 import org.apache.hadoop.hive.ql.metadata.{Hive, Partition, Table}
 import org.apache.hadoop.hive.ql.plan.TableDesc
 import org.apache.hadoop.hive.ql.stats.StatsSetupConst
 import org.apache.hadoop.hive.serde2.Deserializer
 
-import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.Logging
-import org.apache.spark.sql.SQLContext
-import org.apache.spark.sql.catalyst.analysis.{EliminateAnalysisOperators, Catalog}
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.sql.HadoopDirectoryLike
+import org.apache.spark.sql.catalyst.analysis.{Catalog, EliminateAnalysisOperators}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical
 import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.plans.physical.{TableFormat, TableLocation}
 import org.apache.spark.sql.catalyst.rules._
 import org.apache.spark.sql.catalyst.types._
 import org.apache.spark.sql.columnar.InMemoryRelation
 import org.apache.spark.sql.hive.execution.HiveTableScan
 
-/* Implicit conversions */
-import scala.collection.JavaConversions._
-
 private[hive] class HiveMetastoreCatalog(hive: HiveContext) extends Catalog with Logging {
-  import HiveMetastoreTypes._
+  import org.apache.spark.sql.hive.HiveMetastoreTypes._
 
   /** Connection to hive metastore.  Usages should lock on `this`. */
   protected[hive] val client = Hive.get(hive.hiveconf)
 
   val caseSensitive: Boolean = false
+
+  private val formatPropertyName = "spark.sql.format"
 
   def lookupRelation(
       db: Option[String],
@@ -65,32 +63,50 @@ private[hive] class HiveMetastoreCatalog(hive: HiveContext) extends Catalog with
         Nil
       }
 
-    // Since HiveQL is case insensitive for table names we make them all lowercase.
-    MetastoreRelation(
-      databaseName, tblName, alias)(
-      table.getTTable, partitions.map(part => part.getTPartition))(hive)
+    val location = new HiveTableLocation(databaseName, tblName, alias, table.getTTable,
+      partitions.map(part => part.getTPartition))
+
+    val formatClass =
+      Option(table.getTTable.getSd.getParameters.get(formatPropertyName)).map(Class.forName)
+        .getOrElse(classOf[MetastoreFormat])
+        .asInstanceOf[Class[_ <: TableFormat]]
+    logDebug(s"Using format $formatClass for table $tblName")
+    val format = hive.instantiateTableFormat(formatClass)
+    format.loadExistingRelation(location)
   }
 
+  /**
+   * Creates a new table in the Metastore, and returns a Relation based on the given format.
+   * If an existing location is specified, this call will act similarly to a Hive "CREATE EXTERNAL"
+   * and we will create our Relation based on the existing data. Otherwise, we will pick a new
+   * location within the Hive warehouse and create a new Relation for it.
+   *
+   * Note that this method cannot create partitioned tables, and only deals with tables that
+   * are backed by a single Hadoop directory (either within the Hive warehouse or without).
+   */
   def createTable(
       databaseName: String,
       tableName: String,
       schema: Seq[Attribute],
-      allowExisting: Boolean = false): Unit = {
+      formatClass: Class[_ <: TableFormat],
+      existingLocation: Option[HadoopDirectoryLike] = None,
+      allowExisting: Boolean = false): LogicalPlan = {
     val (dbName, tblName) = processDatabaseAndTableName(databaseName, tableName)
     val table = new Table(dbName, tblName)
     val hiveSchema =
       schema.map(attr => new FieldSchema(attr.name, toMetastoreType(attr.dataType), ""))
     table.setFields(hiveSchema)
 
-    val sd = new StorageDescriptor()
+    val sd = new StorageDescriptor
     table.getTTable.setSd(sd)
     sd.setCols(hiveSchema)
 
     // TODO: THESE ARE ALL DEFAULTS, WE NEED TO PARSE / UNDERSTAND the output specs.
     sd.setCompressed(false)
-    sd.setParameters(Map[String, String]())
+    sd.setParameters(Map[String, String](formatPropertyName -> formatClass.getCanonicalName))
     sd.setInputFormat("org.apache.hadoop.mapred.TextInputFormat")
     sd.setOutputFormat("org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat")
+    existingLocation.map(_.asHadoopDirectory.asString).foreach(sd.setLocation)
     val serDeInfo = new SerDeInfo()
     serDeInfo.setName(tblName)
     serDeInfo.setSerializationLib("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe")
@@ -102,6 +118,15 @@ private[hive] class HiveMetastoreCatalog(hive: HiveContext) extends Catalog with
         if e.getCause.isInstanceOf[org.apache.hadoop.hive.metastore.api.AlreadyExistsException] &&
            allowExisting => // Do nothing.
     }
+
+    val format = hive.instantiateTableFormat(formatClass)
+    val finalLocation = new HiveTableLocation(databaseName, tblName, None, table.getTTable, Nil)
+
+    // Either initialize a new Relation or load the existing one.
+    existingLocation match {
+      case None    => format.createEmptyRelation(finalLocation, schema)
+      case Some(_) => format.loadExistingRelation(finalLocation)
+    }
   }
 
   /**
@@ -110,15 +135,14 @@ private[hive] class HiveMetastoreCatalog(hive: HiveContext) extends Catalog with
    */
   object CreateTables extends Rule[LogicalPlan] {
     def apply(plan: LogicalPlan): LogicalPlan = plan transform {
-      case InsertIntoCreatedTable(db, tableName, child) =>
+      case InsertIntoCreatedTable(db, tableName, formatClass, child) =>
         val (dbName, tblName) = processDatabaseAndTableName(db, tableName)
         val databaseName = dbName.getOrElse(hive.sessionState.getCurrentDatabase)
 
-        createTable(databaseName, tblName, child.output)
+        val relation = createTable(databaseName, tblName, child.output, formatClass)
 
         InsertIntoTable(
-          EliminateAnalysisOperators(
-            lookupRelation(Some(databaseName), tblName, None)),
+          EliminateAnalysisOperators(relation),
           Map.empty,
           child,
           overwrite = false)
@@ -166,14 +190,14 @@ private[hive] class HiveMetastoreCatalog(hive: HiveContext) extends Catalog with
 
   /**
    * UNIMPLEMENTED: It needs to be decided how we will persist in-memory tables to the metastore.
-   * For now, if this functionality is desired mix in the in-memory [[OverrideCatalog]].
+   * For now, if this functionality is desired mix in the in-memory OverrideCatalog.
    */
   override def registerTable(
       databaseName: Option[String], tableName: String, plan: LogicalPlan): Unit = ???
 
   /**
    * UNIMPLEMENTED: It needs to be decided how we will persist in-memory tables to the metastore.
-   * For now, if this functionality is desired mix in the in-memory [[OverrideCatalog]].
+   * For now, if this functionality is desired mix in the in-memory OverrideCatalog.
    */
   override def unregisterTable(
       databaseName: Option[String], tableName: String): Unit = ???
@@ -253,9 +277,8 @@ object HiveMetastoreTypes extends RegexParsers {
 }
 
 private[hive] case class MetastoreRelation
-    (databaseName: String, tableName: String, alias: Option[String])
-    (val table: TTable, val partitions: Seq[TPartition])
-    (@transient sqlContext: SQLContext)
+    (location: HiveTableLocation)
+    (@transient hiveContext: HiveContext)
   extends LeafNode {
 
   self: Product =>
@@ -266,9 +289,9 @@ private[hive] case class MetastoreRelation
   // org.apache.hadoop.hive.ql.metadata.Partition will cause a NotSerializableException
   // which indicates the SerDe we used is not Serializable.
 
-  @transient lazy val hiveQlTable = new Table(table)
+  @transient lazy val hiveQlTable = new Table(location.table)
 
-  def hiveQlPartitions = partitions.map { p =>
+  def hiveQlPartitions = location.partitions.map { p =>
     new Partition(hiveQlTable, p)
   }
 
@@ -283,7 +306,7 @@ private[hive] case class MetastoreRelation
       BigInt(
         Option(hiveQlTable.getParameters.get(StatsSetupConst.TOTAL_SIZE))
           .map(_.toLong)
-          .getOrElse(sqlContext.defaultSizeInBytes))
+          .getOrElse(hiveContext.defaultSizeInBytes))
     }
   )
 
@@ -304,14 +327,24 @@ private[hive] case class MetastoreRelation
       HiveMetastoreTypes.toDataType(f.getType),
       // Since data can be dumped in randomly with no validation, everything is nullable.
       nullable = true
-    )(qualifiers = tableName +: alias.toSeq)
+    )(qualifiers = location.tableName +: location.alias.toSeq)
   }
 
   // Must be a stable value since new attributes are born here.
   val partitionKeys = hiveQlTable.getPartitionKeys.map(_.toAttribute)
 
   /** Non-partitionKey attributes */
-  val attributes = table.getSd.getCols.map(_.toAttribute)
+  val attributes = location.table.getSd.getCols.map(_.toAttribute)
 
   val output = attributes ++ partitionKeys
+}
+
+class MetastoreFormat(hiveContext: HiveContext) extends TableFormat {
+  override def createEmptyRelation(loc: TableLocation, schema: Seq[Attribute]): MetastoreRelation = {
+    new MetastoreRelation(loc.asInstanceOf[HiveTableLocation])(hiveContext)
+  }
+
+  override def loadExistingRelation(loc: TableLocation): MetastoreRelation = {
+    new MetastoreRelation(loc.asInstanceOf[HiveTableLocation])(hiveContext)
+  }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -39,8 +39,11 @@ import org.apache.spark.sql.catalyst.types._
 import org.apache.spark.sql.columnar.InMemoryRelation
 import org.apache.spark.sql.hive.execution.HiveTableScan
 
+/* Implicit conversions */
+import scala.collection.JavaConversions._
+
 private[hive] class HiveMetastoreCatalog(hive: HiveContext) extends Catalog with Logging {
-  import org.apache.spark.sql.hive.HiveMetastoreTypes._
+  import HiveMetastoreTypes._
 
   /** Connection to hive metastore.  Usages should lock on `this`. */
   protected[hive] val client = Hive.get(hive.hiveconf)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveTableLocation.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveTableLocation.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive
+
+import org.apache.hadoop.hive.metastore.api.{Partition => TPartition, Table => TTable}
+import org.apache.spark.sql.catalyst.plans.physical.TableLocation
+
+import org.apache.spark.sql.{HadoopDirectory, HadoopDirectoryLike}
+
+/**
+ * Describes a Hive table. Can be converted to a simple HadoopDirectory if the table is not
+ * partitioned.
+ */
+case class HiveTableLocation(
+    databaseName: String,
+    tableName: String,
+    alias: Option[String],
+    table: TTable,
+    partitions: Seq[TPartition])
+  extends TableLocation with HadoopDirectoryLike {
+
+  override def asHadoopDirectory: HadoopDirectory = {
+    require(partitions.isEmpty, "A partitioned table cannot be represented as a HadoopDirectory")
+    new HadoopDirectory(table.getSd.getLocation)
+  }
+}

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveTableLocation.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveTableLocation.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.{HadoopDirectory, HadoopDirectoryLike}
  * Describes a Hive table. Can be converted to a simple HadoopDirectory if the table is not
  * partitioned.
  */
-case class HiveTableLocation(
+private[sql] case class HiveTableLocation(
     databaseName: String,
     tableName: String,
     alias: Option[String],

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -214,7 +214,7 @@ case class InsertIntoHiveTable(
     // TODO: Handle dynamic partitioning.
     val outputPath = FileOutputFormat.getOutputPath(jobConf)
     // Have to construct the format of dbname.tablename.
-    val qualifiedTableName = s"${table.databaseName}.${table.tableName}"
+    val qualifiedTableName = s"${table.location.databaseName}.${table.location.tableName}"
     // TODO: Correctly set holdDDLTime.
     // In most of the time, we should have holdDDLTime = false.
     // holdDDLTime will be true when TOK_HOLD_DDLTIME presents in the query as a hint.


### PR DESCRIPTION
Currently, there is a fundamental assumption in SparkSQL that a Parquet
table is stored at a certain Hadoop path and that a Metastore table is
stored within the Hive warehouse. However, the fact that a table is
Parquet or serialized as an object file is independent of where the data
is actually located.

This patch attempts to work towards creating a cleaner separation between
where the data is located and the format the data is in by introducing
two concepts: a TableFormat and a TableLocation. This abstraction
enables code like the following:

``` scala
val myTable = // ...
myTable.saveAsTable("myTable", classOf[ParquetFormat])
hql("SELECT * FROM myTable").collect // reads from Parquet!

// Also allows expansion of file-writing later:
myTable.saveAsFile("/my/file", classOf[ParquetFormat])
```

Additionally, this allows us to trivially support external tables with arbitrary formats.

However, this PR doesn't attempt to make any radical changes. Parquet files still only
support being written to a single Hadoop directory, but this can be part of a Hive table or
a normal directory. The MetastoreRelation still requires living within the Metastore because
it relies heavily on the metadata there. The hope of this patch is that it enables the two linked
features ([SPARK-2824](https://issues.apache.org/jira/browse/SPARK-2824) and [SPARK-2825](https://issues.apache.org/jira/browse/SPARK-2825)) while adding a useful abstraction for the future.
