### PR TITLE
[SPARK-1986][GraphX]move lib.Analytics to org.apache.spark.examples

### DIFF
--- a/examples/src/main/scala/org/apache/spark/examples/graphx/Analytics.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/graphx/Analytics.scala
@@ -15,12 +15,13 @@
  * limitations under the License.
  */
 
-package org.apache.spark.graphx.lib
+package org.apache.spark.examples.graphx
 
 import scala.collection.mutable
 import org.apache.spark._
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.graphx._
+import org.apache.spark.graphx.lib._
 import org.apache.spark.graphx.PartitionStrategy._
 
 /**

--- a/examples/src/main/scala/org/apache/spark/examples/graphx/LiveJournalPageRank.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/graphx/LiveJournalPageRank.scala
@@ -20,7 +20,7 @@ package org.apache.spark.examples.graphx
 import org.apache.spark.SparkContext._
 import org.apache.spark._
 import org.apache.spark.graphx._
-import org.apache.spark.graphx.lib.Analytics
+import org.apache.spark.examples.graphx.Analytics
 
 /**
  * Uses GraphX to run PageRank on a LiveJournal social network graph. Download the dataset from


### PR DESCRIPTION
to support ~/spark/bin/run-example GraphXAnalytics triangles
/soc-LiveJournal1.txt --numEPart=256
