### PR TITLE
[WIP] [SPARK-2655] Change logging level from INFO to DEBUG

### DIFF
--- a/conf/log4j.properties.template
+++ b/conf/log4j.properties.template
@@ -1,5 +1,5 @@
 # Set everything to be logged to the console
-log4j.rootCategory=INFO, console
+log4j.rootCategory=WARN, console
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.target=System.err
 log4j.appender.console.layout=org.apache.log4j.PatternLayout

--- a/conf/log4j.properties.template
+++ b/conf/log4j.properties.template
@@ -1,11 +1,12 @@
 # Set everything to be logged to the console
-log4j.rootCategory=WARN, console
+log4j.rootCategory=INFO, console
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.target=System.err
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
 
 # Settings to quiet third party logs that are too verbose
+log4j.logger.org.apache.hadoop=WARN
 log4j.logger.org.eclipse.jetty=WARN
 log4j.logger.org.eclipse.jetty.util.component.AbstractLifeCycle=ERROR
 log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO

--- a/core/src/main/scala/org/apache/spark/ContextCleaner.scala
+++ b/core/src/main/scala/org/apache/spark/ContextCleaner.scala
@@ -140,7 +140,7 @@ private[spark] class ContextCleaner(sc: SparkContext) extends Logging {
       logDebug("Cleaning RDD " + rddId)
       sc.unpersistRDD(rddId, blocking)
       listeners.foreach(_.rddCleaned(rddId))
-      logInfo("Cleaned RDD " + rddId)
+      logDebug("Cleaned RDD " + rddId)
     } catch {
       case e: Exception => logError("Error cleaning RDD " + rddId, e)
     }
@@ -153,7 +153,7 @@ private[spark] class ContextCleaner(sc: SparkContext) extends Logging {
       mapOutputTrackerMaster.unregisterShuffle(shuffleId)
       blockManagerMaster.removeShuffle(shuffleId, blocking)
       listeners.foreach(_.shuffleCleaned(shuffleId))
-      logInfo("Cleaned shuffle " + shuffleId)
+      logDebug("Cleaned shuffle " + shuffleId)
     } catch {
       case e: Exception => logError("Error cleaning shuffle " + shuffleId, e)
     }
@@ -165,7 +165,7 @@ private[spark] class ContextCleaner(sc: SparkContext) extends Logging {
       logDebug("Cleaning broadcast " + broadcastId)
       broadcastManager.unbroadcast(broadcastId, true, blocking)
       listeners.foreach(_.broadcastCleaned(broadcastId))
-      logInfo("Cleaned broadcast " + broadcastId)
+      logDebug("Cleaned broadcast " + broadcastId)
     } catch {
       case e: Exception => logError("Error cleaning broadcast " + broadcastId, e)
     }

--- a/core/src/main/scala/org/apache/spark/HttpFileServer.scala
+++ b/core/src/main/scala/org/apache/spark/HttpFileServer.scala
@@ -37,7 +37,7 @@ private[spark] class HttpFileServer(securityManager: SecurityManager) extends Lo
     jarDir = new File(baseDir, "jars")
     fileDir.mkdir()
     jarDir.mkdir()
-    logInfo("HTTP File server directory is " + baseDir)
+    logDebug("HTTP File server directory is " + baseDir)
     httpServer = new HttpServer(baseDir, securityManager)
     httpServer.start()
     serverUri = httpServer.uri

--- a/core/src/main/scala/org/apache/spark/HttpServer.scala
+++ b/core/src/main/scala/org/apache/spark/HttpServer.scala
@@ -50,7 +50,7 @@ private[spark] class HttpServer(resourceBase: File, securityManager: SecurityMan
     if (server != null) {
       throw new ServerStateException("Server is already started")
     } else {
-      logInfo("Starting HTTP Server")
+      logDebug("Starting HTTP Server")
       server = new Server()
       val connector = new SocketConnector
       connector.setMaxIdleTime(60*1000)

--- a/core/src/main/scala/org/apache/spark/SecurityManager.scala
+++ b/core/src/main/scala/org/apache/spark/SecurityManager.scala
@@ -146,7 +146,7 @@ private[spark] class SecurityManager(sparkConf: SparkConf) extends Logging {
   setViewAcls(defaultAclUsers, sparkConf.get("spark.ui.view.acls", ""))
 
   private val secretKey = generateSecretKey()
-  logInfo("SecurityManager: authentication " + (if (authOn) "enabled" else "disabled") +
+  logDebug("SecurityManager: authentication " + (if (authOn) "enabled" else "disabled") +
     "; ui acls " + (if (uiAclsOn) "enabled" else "disabled") +
     "; users with view permissions: " + viewAcls.toString())
 
@@ -170,8 +170,8 @@ private[spark] class SecurityManager(sparkConf: SparkConf) extends Logging {
   }
 
   private[spark] def setViewAcls(defaultUsers: Seq[String], allowedUsers: String) {
-    viewAcls = (defaultUsers ++ allowedUsers.split(',')).map(_.trim()).filter(!_.isEmpty).toSet 
-    logInfo("Changing view acls to: " + viewAcls.mkString(","))
+    viewAcls = (defaultUsers ++ allowedUsers.split(',')).map(_.trim()).filter(!_.isEmpty).toSet
+    logDebug("Changing view acls to: " + viewAcls.mkString(","))
   }
 
   private[spark] def setViewAcls(defaultUser: String, allowedUsers: String) {
@@ -179,8 +179,8 @@ private[spark] class SecurityManager(sparkConf: SparkConf) extends Logging {
   }
 
   private[spark] def setUIAcls(aclSetting: Boolean) { 
-    uiAclsOn = aclSetting 
-    logInfo("Changing acls enabled to: " + uiAclsOn)
+    uiAclsOn = aclSetting
+    logDebug("Changing acls enabled to: " + uiAclsOn)
   }
 
   /**
@@ -207,7 +207,7 @@ private[spark] class SecurityManager(sparkConf: SparkConf) extends Logging {
       // if we generated the secret then we must be the first so lets set it so t
       // gets used by everyone else
       SparkHadoopUtil.get.addSecretKeyToUserCredentials(sparkSecretLookupKey, cookie)
-      logInfo("adding secret to credentials in yarn mode")
+      logDebug("adding secret to credentials in yarn mode")
       cookie
     } else {
       // user must have set spark.authenticate.secret config

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1068,8 +1068,7 @@ class SparkContext(config: SparkConf) extends Logging {
     val start = System.nanoTime
     dagScheduler.runJob(rdd, cleanedFunc, partitions, callSite, allowLocal,
       resultHandler, localProperties.get)
-    logInfo(
-      "Job finished: " + callSite.shortForm + ", took " + (System.nanoTime - start) / 1e9 + " s")
+    logInfo("Job finished: %s, took %.3f s".format(callSite.shortForm, (System.nanoTime - start) / 1e9))
     rdd.doCheckpoint()
   }
 

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -810,7 +810,7 @@ class SparkContext(config: SparkConf) extends Logging {
     // Fetch the file locally in case a job is executed using DAGScheduler.runLocally().
     Utils.fetchFile(path, new File(SparkFiles.getRootDirectory()), conf, env.securityManager)
 
-    logInfo("Added file " + path + " at " + key + " with timestamp " + addedFiles(key))
+    logDebug("Added file " + path + " at " + key + " with timestamp " + addedFiles(key))
     postEnvironmentUpdate()
   }
 
@@ -971,7 +971,7 @@ class SparkContext(config: SparkConf) extends Logging {
       }
       if (key != null) {
         addedJars(key) = System.currentTimeMillis
-        logInfo("Added JAR " + path + " at " + key + " with timestamp " + addedJars(key))
+        logDebug("Added JAR " + path + " at " + key + " with timestamp " + addedJars(key))
       }
     }
     postEnvironmentUpdate()
@@ -1006,9 +1006,9 @@ class SparkContext(config: SparkConf) extends Logging {
       SparkEnv.set(null)
       listenerBus.stop()
       eventLogger.foreach(_.stop())
-      logInfo("Successfully stopped SparkContext")
+      logDebug("Successfully stopped SparkContext")
     } else {
-      logInfo("SparkContext already stopped")
+      logDebug("SparkContext already stopped")
     }
   }
 
@@ -1064,7 +1064,7 @@ class SparkContext(config: SparkConf) extends Logging {
     }
     val callSite = getCallSite
     val cleanedFunc = clean(func)
-    logInfo("Starting job: " + callSite.shortForm)
+    logDebug("Starting job: " + callSite.shortForm)
     val start = System.nanoTime
     dagScheduler.runJob(rdd, cleanedFunc, partitions, callSite, allowLocal,
       resultHandler, localProperties.get)
@@ -1150,7 +1150,7 @@ class SparkContext(config: SparkConf) extends Logging {
       evaluator: ApproximateEvaluator[U, R],
       timeout: Long): PartialResult[R] = {
     val callSite = getCallSite
-    logInfo("Starting job: " + callSite.shortForm)
+    logDebug("Starting job: " + callSite.shortForm)
     val start = System.nanoTime
     val result = dagScheduler.runApproximateJob(rdd, func, evaluator, callSite, timeout,
       localProperties.get)

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1068,7 +1068,8 @@ class SparkContext(config: SparkConf) extends Logging {
     val start = System.nanoTime
     dagScheduler.runJob(rdd, cleanedFunc, partitions, callSite, allowLocal,
       resultHandler, localProperties.get)
-    logInfo("Job finished: %s, took %.3f s".format(callSite.shortForm, (System.nanoTime - start) / 1e9))
+    logInfo("Job finished: %s, took %.3f s".format(
+      callSite.shortForm, (System.nanoTime - start) / 1e9))
     rdd.doCheckpoint()
   }
 

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -191,7 +191,7 @@ object SparkEnv extends Logging {
 
     def registerOrLookup(name: String, newActor: => Actor): ActorRef = {
       if (isDriver) {
-        logInfo("Registering " + name)
+        logDebug("Registering " + name)
         actorSystem.actorOf(Props(newActor), name = name)
       } else {
         AkkaUtils.makeDriverRef(name, conf, actorSystem)

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -113,7 +113,7 @@ private[spark] class PythonRDD(
               val init = initTime - bootTime
               val finish = finishTime - initTime
               val total = finishTime - startTime
-              logInfo("Times: total = %s, boot = %s, init = %s, finish = %s".format(total, boot,
+              logDebug("Times: total = %s, boot = %s, init = %s, finish = %s".format(total, boot,
                 init, finish))
               read()
             case SpecialLengths.PYTHON_EXCEPTION_THROWN =>

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -167,7 +167,7 @@ private[spark] class Executor(
       SparkEnv.set(env)
       Thread.currentThread.setContextClassLoader(replClassLoader)
       val ser = SparkEnv.get.closureSerializer.newInstance()
-      logInfo(s"Running $taskName (TID $taskId)")
+      logDebug(s"Running $taskName (TID $taskId)")
       execBackend.statusUpdate(taskId, TaskState.RUNNING, EMPTY_BYTE_BUFFER)
       var taskStart: Long = 0
       def gcTime = ManagementFactory.getGarbageCollectorMXBeans.map(_.getCollectionTime).sum
@@ -237,9 +237,9 @@ private[spark] class Executor(
         execBackend.statusUpdate(taskId, TaskState.FINISHED, serializedResult)
 
         if (directSend) {
-          logInfo(s"Finished $taskName (TID $taskId). $resultSize bytes result sent to driver")
+          logDebug(s"Finished $taskName (TID $taskId). $resultSize bytes result sent to driver")
         } else {
-          logInfo(
+          logDebug(
             s"Finished $taskName (TID $taskId). $resultSize bytes result sent via BlockManager)")
         }
       } catch {

--- a/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
@@ -188,7 +188,7 @@ class HadoopRDD[K, V](
     val iter = new NextIterator[(K, V)] {
 
       val split = theSplit.asInstanceOf[HadoopPartition]
-      logInfo("Input split: " + split.inputSplit)
+      logDebug("Input split: " + split.inputSplit)
       var reader: RecordReader[K, V] = null
       val jobConf = getJobConf()
       val inputFormat = getInputFormat(jobConf)

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -271,7 +271,7 @@ class DAGScheduler(
     } else {
       // Kind of ugly: need to register RDDs with the cache and map output tracker here
       // since we can't do it in the RDD constructor because # of partitions is unknown
-      logInfo("Registering RDD " + rdd.id + " (" + rdd.getCreationSite + ")")
+      logDebug("Registering RDD " + rdd.id + " (" + rdd.getCreationSite + ")")
       mapOutputTracker.registerShuffle(shuffleDep.shuffleId, rdd.partitions.size)
     }
     stage
@@ -535,12 +535,12 @@ class DAGScheduler(
    * Cancel a job that is running or waiting in the queue.
    */
   def cancelJob(jobId: Int) {
-    logInfo("Asked to cancel job " + jobId)
+    logDebug("Asked to cancel job " + jobId)
     eventProcessActor ! JobCancelled(jobId)
   }
 
   def cancelJobGroup(groupId: String) {
-    logInfo("Asked to cancel job group " + groupId)
+    logDebug("Asked to cancel job group " + groupId)
     eventProcessActor ! JobGroupCancelled(groupId)
   }
 
@@ -610,7 +610,7 @@ class DAGScheduler(
    * don't block the DAGScheduler event loop or other concurrent jobs.
    */
   protected def runLocally(job: ActiveJob) {
-    logInfo("Computing the requested partition locally")
+    logDebug("Computing the requested partition locally")
     new Thread("Local computation of job " + job.jobId) {
       override def run() {
         runLocallyWithinThread(job)
@@ -729,9 +729,9 @@ class DAGScheduler(
       clearCacheLocs()
       logInfo("Got job %s (%s) with %d output partitions (allowLocal=%s)".format(
         job.jobId, callSite.shortForm, partitions.length, allowLocal))
-      logInfo("Final stage: " + finalStage + "(" + finalStage.name + ")")
-      logInfo("Parents of final stage: " + finalStage.parents)
-      logInfo("Missing parents: " + getMissingParentStages(finalStage))
+      logDebug("Final stage: " + finalStage + "(" + finalStage.name + ")")
+      logDebug("Parents of final stage: " + finalStage.parents)
+      logDebug("Missing parents: " + getMissingParentStages(finalStage))
       if (allowLocal && finalStage.parents.size == 0 && partitions.length == 1) {
         // Compute very short actions like first() or take() with no parent stages locally.
         listenerBus.post(SparkListenerJobStart(job.jobId, Array[Int](), properties))
@@ -859,7 +859,7 @@ class DAGScheduler(
           return
       }
 
-      logInfo("Submitting " + tasks.size + " missing tasks from " + stage + " (" + stage.rdd + ")")
+      logDebug("Submitting " + tasks.size + " missing tasks from " + stage + " (" + stage.rdd + ")")
       stage.pendingTasks ++= tasks
       logDebug("New pending tasks: " + stage.pendingTasks)
       taskScheduler.submitTasks(
@@ -947,10 +947,10 @@ class DAGScheduler(
             }
             if (runningStages.contains(stage) && stage.pendingTasks.isEmpty) {
               markStageAsFinished(stage)
-              logInfo("looking for newly runnable stages")
-              logInfo("running: " + runningStages)
-              logInfo("waiting: " + waitingStages)
-              logInfo("failed: " + failedStages)
+              logDebug("looking for newly runnable stages")
+              logDebug("running: " + runningStages)
+              logDebug("waiting: " + waitingStages)
+              logDebug("failed: " + failedStages)
               if (stage.shuffleDep.isDefined) {
                 // We supply true to increment the epoch number here in case this is a
                 // recomputation of the map outputs. In that case, some nodes may have cached
@@ -1072,7 +1072,7 @@ class DAGScheduler(
   private[scheduler] def handleExecutorAdded(execId: String, host: String) {
     // remove from failedEpoch(execId) ?
     if (failedEpoch.contains(execId)) {
-      logInfo("Host added was in lost list earlier: " + host)
+      logDebug("Host added was in lost list earlier: " + host)
       failedEpoch -= execId
     }
     submitWaitingStages()
@@ -1086,7 +1086,7 @@ class DAGScheduler(
           handleJobCancellation(jobId, s"because Stage $stageId was cancelled")
         }
       case None =>
-        logInfo("No active jobs to kill for Stage " + stageId)
+        logDebug("No active jobs to kill for Stage " + stageId)
     }
     submitWaitingStages()
   }
@@ -1117,7 +1117,7 @@ class DAGScheduler(
       failJobAndIndependentStages(job, s"Job aborted due to stage failure: $reason")
     }
     if (dependentJobs.isEmpty) {
-      logInfo("Ignoring failure of " + failedStage + " because all jobs depending on it are done")
+      logDebug("Ignoring failure of " + failedStage + " because all jobs depending on it are done")
     }
   }
 
@@ -1258,7 +1258,7 @@ class DAGScheduler(
   }
 
   def stop() {
-    logInfo("Stopping DAGScheduler")
+    logDebug("Stopping DAGScheduler")
     dagSchedulerActorSupervisor ! PoisonPill
     taskScheduler.stop()
   }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -141,7 +141,7 @@ private[spark] class TaskSchedulerImpl(
     backend.start()
 
     if (!isLocal && conf.getBoolean("spark.speculation", false)) {
-      logInfo("Starting speculative execution thread")
+      logDebug("Starting speculative execution thread")
       import sc.env.actorSystem.dispatcher
       sc.env.actorSystem.scheduler.schedule(SPECULATION_INTERVAL milliseconds,
             SPECULATION_INTERVAL milliseconds) {
@@ -156,7 +156,7 @@ private[spark] class TaskSchedulerImpl(
 
   override def submitTasks(taskSet: TaskSet) {
     val tasks = taskSet.tasks
-    logInfo("Adding task set " + taskSet.id + " with " + tasks.length + " tasks")
+    logDebug("Adding task set " + taskSet.id + " with " + tasks.length + " tasks")
     this.synchronized {
       val manager = new TaskSetManager(this, taskSet, maxTaskFailures)
       activeTaskSets(taskSet.id) = manager
@@ -181,7 +181,7 @@ private[spark] class TaskSchedulerImpl(
   }
 
   override def cancelTasks(stageId: Int, interruptThread: Boolean): Unit = synchronized {
-    logInfo("Cancelling stage " + stageId)
+    logDebug("Cancelling stage " + stageId)
     activeTaskSets.find(_._2.stageId == stageId).foreach { case (_, tsm) =>
       // There are two possible cases here:
       // 1. The task set manager has been created and some tasks have been scheduled.
@@ -194,7 +194,7 @@ private[spark] class TaskSchedulerImpl(
         backend.killTask(tid, execId, interruptThread)
       }
       tsm.abort("Stage %s cancelled".format(stageId))
-      logInfo("Stage %d was cancelled".format(stageId))
+      logDebug("Stage %d was cancelled".format(stageId))
     }
   }
 
@@ -206,7 +206,7 @@ private[spark] class TaskSchedulerImpl(
   def taskSetFinished(manager: TaskSetManager): Unit = synchronized {
     activeTaskSets -= manager.taskSet.id
     manager.parent.removeSchedulable(manager)
-    logInfo("Removed TaskSet %s, whose tasks have all completed, from pool %s"
+    logDebug("Removed TaskSet %s, whose tasks have all completed, from pool %s"
       .format(manager.taskSet.id, manager.parent.name))
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -431,7 +431,7 @@ private[spark] class TaskSetManager(
           // a good proxy to task serialization time.
           // val timeTaken = clock.getTime() - startTime
           val taskName = s"task ${info.id} in stage ${taskSet.id}"
-          logInfo("Starting %s (TID %d, %s, %s, %d bytes)".format(
+          logDebug("Starting %s (TID %d, %s, %s, %d bytes)".format(
               taskName, taskId, host, taskLocality, serializedTask.limit))
 
           sched.dagScheduler.taskStarted(task, info)
@@ -503,7 +503,7 @@ private[spark] class TaskSetManager(
         isZombie = true
       }
     } else {
-      logInfo("Ignoring task-finished event for " + info.id + " in stage " + taskSet.id +
+      logDebug("Ignoring task-finished event for " + info.id + " in stage " + taskSet.id +
         " because task " + index + " has already completed successfully")
     }
     failedExecutors.remove(index)
@@ -763,7 +763,7 @@ private[spark] class TaskSetManager(
       }
       false
     }
-    logInfo("Re-computing pending task lists.")
+    logDebug("Re-computing pending task lists.")
     pendingTasksWithNoPrefs = pendingTasksWithNoPrefs.filter(!newLocAvail(_))
     myLocalityLevels = computeValidLocalityLevels()
     localityWaits = myLocalityLevels.map(getLocalityWait)

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMaster.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMaster.scala
@@ -38,14 +38,14 @@ class BlockManagerMaster(var driverActor: ActorRef, conf: SparkConf) extends Log
   /** Remove a dead executor from the driver actor. This is only called on the driver side. */
   def removeExecutor(execId: String) {
     tell(RemoveExecutor(execId))
-    logInfo("Removed " + execId + " successfully in removeExecutor")
+    logDebug("Removed " + execId + " successfully in removeExecutor")
   }
 
   /** Register the BlockManager's id with the driver. */
   def registerBlockManager(blockManagerId: BlockManagerId, maxMemSize: Long, slaveActor: ActorRef) {
-    logInfo("Trying to register BlockManager")
+    logDebug("Trying to register BlockManager")
     tell(RegisterBlockManager(blockManagerId, maxMemSize, slaveActor))
-    logInfo("Registered BlockManager")
+    logDebug("Registered BlockManager")
   }
 
   def updateBlockInfo(
@@ -57,7 +57,7 @@ class BlockManagerMaster(var driverActor: ActorRef, conf: SparkConf) extends Log
       tachyonSize: Long): Boolean = {
     val res = askDriverWithReply[Boolean](
       UpdateBlockInfo(blockManagerId, blockId, storageLevel, memSize, diskSize, tachyonSize))
-    logInfo("Updated info of block " + blockId)
+    logDebug("Updated info of block " + blockId)
     res
   }
 
@@ -197,7 +197,7 @@ class BlockManagerMaster(var driverActor: ActorRef, conf: SparkConf) extends Log
     if (driverActor != null) {
       tell(StopBlockManagerMaster)
       driverActor = null
-      logInfo("BlockManagerMaster stopped")
+      logDebug("BlockManagerMaster stopped")
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterActor.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterActor.scala
@@ -69,7 +69,7 @@ class BlockManagerMasterActor(val isLocal: Boolean, conf: SparkConf, listenerBus
 
   def receive = {
     case RegisterBlockManager(blockManagerId, maxMemSize, slaveActor) =>
-      logInfo("received a register")
+      logDebug("received a register")
       register(blockManagerId, maxMemSize, slaveActor)
       sender ! true
 
@@ -118,7 +118,7 @@ class BlockManagerMasterActor(val isLocal: Boolean, conf: SparkConf, listenerBus
       sender ! true
 
     case StopBlockManagerMaster =>
-      logInfo("Stopping BlockManagerMaster")
+      logDebug("Stopping BlockManagerMaster")
       sender ! true
       if (timeoutCheckingTask != null) {
         timeoutCheckingTask.cancel()
@@ -225,7 +225,7 @@ class BlockManagerMasterActor(val isLocal: Boolean, conf: SparkConf, listenerBus
   }
 
   private def removeExecutor(execId: String) {
-    logInfo("Trying to remove executor " + execId + " from BlockManagerMaster.")
+    logDebug("Trying to remove executor " + execId + " from BlockManagerMaster.")
     blockManagerIdByExecutor.get(execId).foreach(removeBlockManager)
   }
 
@@ -339,7 +339,7 @@ class BlockManagerMasterActor(val isLocal: Boolean, conf: SparkConf, listenerBus
           blockManagerIdByExecutor(id.executorId) = id
       }
 
-      logInfo("Registering block manager %s with %s RAM".format(
+      logDebug("Registering block manager %s with %s RAM".format(
         id.hostPort, Utils.bytesToString(maxMemSize)))
 
       blockManagerInfo(id) =
@@ -479,18 +479,18 @@ private[spark] class BlockManagerInfo(
       if (storageLevel.useMemory) {
         _blocks.put(blockId, BlockStatus(storageLevel, memSize, 0, 0))
         _remainingMem -= memSize
-        logInfo("Added %s in memory on %s (size: %s, free: %s)".format(
+        logDebug("Added %s in memory on %s (size: %s, free: %s)".format(
           blockId, blockManagerId.hostPort, Utils.bytesToString(memSize),
           Utils.bytesToString(_remainingMem)))
       }
       if (storageLevel.useDisk) {
         _blocks.put(blockId, BlockStatus(storageLevel, 0, diskSize, 0))
-        logInfo("Added %s on disk on %s (size: %s)".format(
+        logDebug("Added %s on disk on %s (size: %s)".format(
           blockId, blockManagerId.hostPort, Utils.bytesToString(diskSize)))
       }
       if (storageLevel.useOffHeap) {
         _blocks.put(blockId, BlockStatus(storageLevel, 0, 0, tachyonSize))
-        logInfo("Added %s on tachyon on %s (size: %s)".format(
+        logDebug("Added %s on tachyon on %s (size: %s)".format(
           blockId, blockManagerId.hostPort, Utils.bytesToString(tachyonSize)))
       }
     } else if (_blocks.containsKey(blockId)) {
@@ -499,16 +499,16 @@ private[spark] class BlockManagerInfo(
       _blocks.remove(blockId)
       if (blockStatus.storageLevel.useMemory) {
         _remainingMem += blockStatus.memSize
-        logInfo("Removed %s on %s in memory (size: %s, free: %s)".format(
+        logDebug("Removed %s on %s in memory (size: %s, free: %s)".format(
           blockId, blockManagerId.hostPort, Utils.bytesToString(blockStatus.memSize),
           Utils.bytesToString(_remainingMem)))
       }
       if (blockStatus.storageLevel.useDisk) {
-        logInfo("Removed %s on %s on disk (size: %s)".format(
+        logDebug("Removed %s on %s on disk (size: %s)".format(
           blockId, blockManagerId.hostPort, Utils.bytesToString(blockStatus.diskSize)))
       }
       if (blockStatus.storageLevel.useOffHeap) {
-        logInfo("Removed %s on %s on tachyon (size: %s)".format(
+        logDebug("Removed %s on %s on tachyon (size: %s)".format(
           blockId, blockManagerId.hostPort, Utils.bytesToString(blockStatus.tachyonSize)))
       }
     }

--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
@@ -158,7 +158,7 @@ private[spark] class DiskBlockManager(shuffleBlockManager: ShuffleBlockManager, 
                   " Ignoring this directory.")
         None
       } else {
-        logInfo(s"Created local directory at $localDir")
+        logDebug(s"Created local directory at $localDir")
         Some(localDir)
       }
     }
@@ -194,7 +194,7 @@ private[spark] class DiskBlockManager(shuffleBlockManager: ShuffleBlockManager, 
 
   private[storage] def startShuffleBlockSender(port: Int): Int = {
     shuffleSender = new ShuffleSender(port, this)
-    logInfo(s"Created ShuffleSender binding to port: ${shuffleSender.port}")
+    logDebug(s"Created ShuffleSender binding to port: ${shuffleSender.port}")
     shuffleSender.port
   }
 }

--- a/core/src/main/scala/org/apache/spark/storage/MemoryStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/MemoryStore.scala
@@ -56,7 +56,7 @@ private[spark] class MemoryStore(blockManager: BlockManager, maxMemory: Long)
     (maxMemory * unrollFraction).toLong
   }
 
-  logInfo("MemoryStore started with capacity %s".format(Utils.bytesToString(maxMemory)))
+  logDebug("MemoryStore started with capacity %s".format(Utils.bytesToString(maxMemory)))
 
   /** Free memory not occupied by existing blocks. Note that this does not include unroll memory. */
   def freeMemory: Long = maxMemory - currentMemory
@@ -176,7 +176,7 @@ private[spark] class MemoryStore(blockManager: BlockManager, maxMemory: Long)
       val entry = entries.remove(blockId)
       if (entry != null) {
         currentMemory -= entry.size
-        logInfo(s"Block $blockId of size ${entry.size} dropped from memory (free $freeMemory)")
+        logDebug(s"Block $blockId of size ${entry.size} dropped from memory (free $freeMemory)")
         true
       } else {
         false
@@ -189,7 +189,7 @@ private[spark] class MemoryStore(blockManager: BlockManager, maxMemory: Long)
       entries.clear()
       currentMemory = 0
     }
-    logInfo("MemoryStore cleared")
+    logDebug("MemoryStore cleared")
   }
 
   /**
@@ -325,7 +325,7 @@ private[spark] class MemoryStore(blockManager: BlockManager, maxMemory: Long)
           currentMemory += size
         }
         val valuesOrBytes = if (deserialized) "values" else "bytes"
-        logInfo("Block %s stored as %s in memory (estimated size %s, free %s)".format(
+        logDebug("Block %s stored as %s in memory (estimated size %s, free %s)".format(
           blockId, valuesOrBytes, Utils.bytesToString(size), Utils.bytesToString(freeMemory)))
         putSuccess = true
       } else {
@@ -357,12 +357,12 @@ private[spark] class MemoryStore(blockManager: BlockManager, maxMemory: Long)
   private def ensureFreeSpace(
       blockIdToAdd: BlockId,
       space: Long): ResultWithDroppedBlocks = {
-    logInfo(s"ensureFreeSpace($space) called with curMem=$currentMemory, maxMem=$maxMemory")
+    logDebug(s"ensureFreeSpace($space) called with curMem=$currentMemory, maxMem=$maxMemory")
 
     val droppedBlocks = new ArrayBuffer[(BlockId, BlockStatus)]
 
     if (space > maxMemory) {
-      logInfo(s"Will not store $blockIdToAdd as it is larger than our memory limit")
+      logDebug(s"Will not store $blockIdToAdd as it is larger than our memory limit")
       return ResultWithDroppedBlocks(success = false, droppedBlocks)
     }
 

--- a/core/src/main/scala/org/apache/spark/util/AkkaUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/AkkaUtils.scala
@@ -183,7 +183,7 @@ private[spark] object AkkaUtils extends Logging {
     Utils.checkHost(driverHost, "Expected hostname")
     val url = s"akka.tcp://spark@$driverHost:$driverPort/user/$name"
     val timeout = AkkaUtils.lookupTimeout(conf)
-    logInfo(s"Connecting to $name: $url")
+    logDebug(s"Connecting to $name: $url")
     Await.result(actorSystem.actorSelection(url).resolveOne(timeout), timeout)
   }
 }


### PR DESCRIPTION
Currently, it's too noisy at the default level INFO, so it's better to put the logging about runtime details into DEBUG level.

Basic rule is that, DEBUG is used for developer or debugging, INFO is used for user (who does not know much of the details). So if some loggings do not provide helpful messages for users, it should be put in DEBUG level.

The progress of Job/stage/task is helpful for user, should be keep in INFO level. (It will be better to put all messages of task completeness into one line, not addressed in this PR)

The logging level in third-parties should be set to WARN by default.
