### PR TITLE
[SPARK-2857] Correct properties to set Master / Worker ports

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/MasterArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/MasterArguments.scala
@@ -38,8 +38,8 @@ private[spark] class MasterArguments(args: Array[String], conf: SparkConf) {
   if (System.getenv("SPARK_MASTER_WEBUI_PORT") != null) {
     webUiPort = System.getenv("SPARK_MASTER_WEBUI_PORT").toInt
   }
-  if (conf.contains("master.ui.port")) {
-    webUiPort = conf.get("master.ui.port").toInt
+  if (conf.contains("spark.master.ui.port")) {
+    webUiPort = conf.get("spark.master.ui.port").toInt
   }
 
   parse(args.toList)

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ui/WorkerWebUI.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ui/WorkerWebUI.scala
@@ -58,6 +58,6 @@ private[spark] object WorkerWebUI {
   val STATIC_RESOURCE_BASE = SparkUI.STATIC_RESOURCE_DIR
 
   def getUIPort(requestedPort: Option[Int], conf: SparkConf): Int = {
-    requestedPort.getOrElse(conf.getInt("worker.ui.port", WorkerWebUI.DEFAULT_PORT))
+    requestedPort.getOrElse(conf.getInt("spark.worker.ui.port", WorkerWebUI.DEFAULT_PORT))
   }
 }

--- a/docs/spark-standalone.md
+++ b/docs/spark-standalone.md
@@ -314,7 +314,7 @@ configure those ports.
     <td>Standalone Cluster Master</td>
     <td>8080</td>
     <td>Web UI</td>
-    <td><code>master.ui.port</code></td>
+    <td><code>spark.master.ui.port</code></td>
     <td>Jetty-based</td>
   </tr>
   <tr>
@@ -338,7 +338,7 @@ configure those ports.
     <td>Worker</td>
     <td>8081</td>
     <td>Web UI</td>
-    <td><code>worker.ui.port</code></td>
+    <td><code>spark.worker.ui.port</code></td>
     <td>Jetty-based</td>
   </tr>
   <!-- Cluster interactions -->


### PR DESCRIPTION
`master.ui.port` and `worker.ui.port` were never picked up by SparkConf, simply because they are not prefixed with "spark." Unfortunately, this is also currently the documented way of setting these values.
