### PR TITLE
SPARK-1022 [BUILD] Depend on Zookeeper from Kafka tests

### DIFF
--- a/external/kafka/pom.xml
+++ b/external/kafka/pom.xml
@@ -68,11 +68,13 @@
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-simple</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>org.apache.zookeeper</groupId>
-          <artifactId>zookeeper</artifactId>
-        </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.zookeeper</groupId>
+      <artifactId>zookeeper</artifactId>
+      <version>3.4.5</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>net.sf.jopt-simple</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,6 @@
     <protobuf.version>2.4.1</protobuf.version>
     <yarn.version>${hadoop.version}</yarn.version>
     <hbase.version>0.94.6</hbase.version>
-    <zookeeper.version>3.4.5</zookeeper.version>
     <hive.version>0.12.0</hive.version>
     <parquet.version>1.4.3</parquet.version>
     <jblas.version>1.2.3</jblas.version>
@@ -1139,7 +1138,6 @@
         <hadoop.version>1.0.3-mapr-3.0.3</hadoop.version>
         <yarn.version>2.3.0-mapr-4.0.0-FCS</yarn.version>
         <hbase.version>0.94.17-mapr-1405</hbase.version>
-        <zookeeper.version>3.4.5-mapr-1406</zookeeper.version>
       </properties>
     </profile>
 
@@ -1152,7 +1150,6 @@
         <hadoop.version>2.3.0-mapr-4.0.0-FCS</hadoop.version>
         <yarn.version>2.3.0-mapr-4.0.0-FCS</yarn.version>
         <hbase.version>0.94.17-mapr-1405-4.0.0-FCS</hbase.version>
-        <zookeeper.version>3.4.5-mapr-1406</zookeeper.version>
       </properties>
       <dependencies>
         <dependency>
@@ -1219,7 +1216,6 @@
         <dependency>
           <groupId>org.apache.zookeeper</groupId>
           <artifactId>zookeeper</artifactId>
-          <version>${zookeeper.version}</version>
           <scope>provided</scope>
         </dependency>
       </dependencies>


### PR DESCRIPTION
Per discussion at https://github.com/apache/spark/pull/1751 I suggest that the more correct thing to do is to depend on Zookeeper from Kafka tests. The first commit does this.

The second commit reflects the explicit dependency on ZK in core, in order to make `zookeeper.version` do something. Another reasonable change would be to simply remove `zookeeper.version` to reflect that otherwise it does nothing.
