### PR TITLE
SPARK-2882: Spark build now checks local maven cache for dependencies

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -115,7 +115,8 @@ object SparkBuild extends PomBuild {
     retrieveManaged := true,
     retrievePattern := "[type]s/[artifact](-[revision])(-[classifier]).[ext]",
     publishMavenStyle := true,
-
+  
+    resolvers += Resolver.mavenLocal,
     otherResolvers <<= SbtPomKeys.mvnLocalRepository(dotM2 => Seq(Resolver.file("dotM2", dotM2))),
     publishLocalConfiguration in MavenCompile <<= (packagedArtifacts, deliverLocal, ivyLoggingLevel) map {
       (arts, _, level) => new PublishConfiguration(None, "dotM2", arts, Seq(), level)


### PR DESCRIPTION
Fixes [SPARK-2882](https://issues.apache.org/jira/browse/SPARK-2882)
