### PR TITLE
SPARK-2903 [BUILD] [SQL] Spark SQL tests fail to compile due to dependency structure, misplaced test class

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -17,10 +17,12 @@
 
 package org.apache.spark.sql
 
+import org.scalatest.FunSuite
+
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.util._
 
-class QueryTest extends PlanTest {
+class QueryTest extends FunSuite {
   /**
    * Runs the plan and makes sure the answer matches the expected result.
    * @param rdd the [[SchemaRDD]] to be executed


### PR DESCRIPTION
Since recently, I find that the SQL modules' test code fails to compile with a simple `mvn clean compile test-compile`. `sql/core` fails with a large number of errors, beginning like so:

```
[error] /Users/srowen/Documents/spark/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala:23: not found: type PlanTest
[error] class QueryTest extends PlanTest {
[error]                         ^
[error] /Users/srowen/Documents/spark/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala:28: package org.apache.spark.sql.test is not a value
[error]   test("SPARK-1669: cacheTable should be idempotent") {
...
```

I think a couple files and dependencies are in the wrong place, and it is resolved with the following:
- Move `org.apache.spark.sql.test.TestSQLContext` from under `sql/core/src/main/scala`, to `sql/core/src/test/scala` , which seems like where it belongs as test code
- Move `org.apache.spark.sql.parquet.ParquetTestData` likewise from main to test
- QueryTest in sql/core depends on `PlanTest`, which appears to be catalyst-specific, instead of `FunSuite`. It shouldn't, and isn't needed.
- Remove dependency from `sql/core` tests on `sql/catalyst` tests, which seems reversed
- Introduce dependency from `sql/hive` tests on `sql/core` tests to restore access to the files moved above

What I'm still not clear on is why it has only started failing to compile in the last week or so. But, these seem like the right changes to make. It compiles and tests pass.
