### PR TITLE
[SPARK-2913] Place our log4j.properties at the head of the classpath.

### DIFF
--- a/bin/compute-classpath.sh
+++ b/bin/compute-classpath.sh
@@ -28,7 +28,7 @@ FWDIR="$(cd `dirname $0`/..; pwd)"
 . $FWDIR/bin/load-spark-env.sh
 
 # Build up classpath
-CLASSPATH="$SPARK_CLASSPATH:$SPARK_SUBMIT_CLASSPATH:$FWDIR/conf"
+CLASSPATH="$FWDIR/conf/log4j.properties:$SPARK_CLASSPATH:$SPARK_SUBMIT_CLASSPATH:$FWDIR/conf"
 
 ASSEMBLY_DIR="$FWDIR/assembly/target/scala-$SCALA_VERSION"
 


### PR DESCRIPTION
This addresses SPARK-2913, an issue where changes to log4j.properties didn't take effect in our default Spark EC2 configuration because Hadoop's configuration directory would end up ahead of Spark's on the computed CLASSPATH.
