### PR TITLE
[SPARK-2918] [SQL] [WIP] Support the extended & native command for EXPLAIN

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -414,7 +414,7 @@ class SQLContext(@transient val sparkContext: SparkContext)
     def simpleString: String =
       s"""== Physical Plan ==
          |${stringOrError(executedPlan)}
-      """
+      """.stripMargin.trim
 
     override def toString: String =
       // TODO previously will output RDD details by run (${stringOrError(toRdd.toDebugString)})

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveExplainSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveExplainSuite.scala
@@ -51,4 +51,12 @@ class HiveExplainSuite extends QueryTest {
           "== Physical Plan ==", 
           "Code Generation", "== RDD ==")
   }
+
+  test("explain native command") {
+    check("explain set a=123", true, "== Physical Plan ==", "SetCommand", "a", "123")
+    check("explain show tables", true, "== Physical Plan ==", "NativeCommand", "show tables")
+    check("  Explain   show tables  ", true, "== Physical Plan ==", "NativeCommand", "show tables")
+    check(" Explain   create table temp__B as select * from src", true,
+          "== Physical Plan ==", "HiveTableScan")
+  }
 }


### PR DESCRIPTION
Currently, EXPLAIN doesn't support the SQL native command, or printing the logical plan. This PR will solve this.
For examples:

```
spark-sql> explain create table temp__ as select * from src;
Physical execution plan:InsertIntoHiveTable (MetastoreRelation default, temp__, None), Map(), false
 HiveTableScan [key#6,value#7], (MetastoreRelation default, src, None), None

spark-sql> explain  Extended create table temp__a as select * from src;
Logical execution plan (Parsed):InsertIntoCreatedTable None, temp__a
 Project [*]
  UnresolvedRelation None, src, None

Logical execution plan (Analyzed):InsertIntoCreatedTable None, temp__a
 Project [key#1,value#2]
  MetastoreRelation default, src, None

Logical execution plan (Optimized):InsertIntoTable Map(), false
 MetastoreRelation default, temp__a, None
 MetastoreRelation default, src, None

Physical execution plan:InsertIntoHiveTable (MetastoreRelation default, temp__a, None), Map(), false
 HiveTableScan [key#1,value#2], (MetastoreRelation default, src, None), None

spark-sql> explain extended select key+3>2+3 as b from src;
Logical execution plan (Parsed):Project [(('key + 3) > (2 + 3)) AS b#10]
 UnresolvedRelation None, src, None

Logical execution plan (Analyzed):Project [((CAST(key#13, DoubleType) + CAST(3, DoubleType)) > CAST((2 + 3), DoubleType)) AS b#10]
 MetastoreRelation default, src, None

Logical execution plan (Optimized):Project [((CAST(key#13, DoubleType) + 3.0) > 5.0) AS b#10]
 MetastoreRelation default, src, None

Physical execution plan:Project [((CAST(key#13, DoubleType) + 3.0) > 5.0) AS b#10]
 HiveTableScan [key#13], (MetastoreRelation default, src, None), None
```

BTW, this PR depends on https://github.com/apache/spark/pull/1846, it will keep failure before #1846 merged.
