### PR TITLE
[SPARK-2925] [sql]fix spark-sql and start-thriftserver shell bugs when set --driver-java-options

### DIFF
--- a/bin/spark-sql
+++ b/bin/spark-sql
@@ -65,35 +65,30 @@ while (($#)); do
   case $1 in
     -d | --define | --database | -f | -h | --hiveconf | --hivevar | -i | -p)
       ensure_arg_number $# 2
-      CLI_ARGS+=($1); shift
-      CLI_ARGS+=($1); shift
+      CLI_ARGS+=("$1"); shift
+      CLI_ARGS+=("$1"); shift
       ;;
 
     -e)
       ensure_arg_number $# 2
-      CLI_ARGS+=($1); shift
-      CLI_ARGS+=(\"$1\"); shift
+      CLI_ARGS+=("$1"); shift
+      CLI_ARGS+=("$1"); shift
       ;;
 
     -s | --silent)
-      CLI_ARGS+=($1); shift
+      CLI_ARGS+=("$1"); shift
       ;;
 
     -v | --verbose)
       # Both SparkSubmit and SparkSQLCLIDriver recognizes -v | --verbose
-      CLI_ARGS+=($1)
-      SUBMISSION_ARGS+=($1); shift
-      ;;
-      
-    --driver-java-options)
-      shift;
-      export SPARK_SUBMIT_OPTS=$1; shift
+      CLI_ARGS+=("$1")
+      SUBMISSION_ARGS+=("$1"); shift
       ;;
 
     *)
-      SUBMISSION_ARGS+=($1); shift
+      SUBMISSION_ARGS+=("$1"); shift
       ;;
   esac
 done
 
-eval exec "$FWDIR"/bin/spark-submit --class $CLASS ${SUBMISSION_ARGS[*]} spark-internal ${CLI_ARGS[*]}
+exec "$FWDIR"/bin/spark-submit --class $CLASS "${SUBMISSION_ARGS[@]}" spark-internal "${CLI_ARGS[@]}"

--- a/bin/spark-sql
+++ b/bin/spark-sql
@@ -84,6 +84,11 @@ while (($#)); do
       CLI_ARGS+=($1)
       SUBMISSION_ARGS+=($1); shift
       ;;
+      
+    --driver-java-options)
+      shift;
+      export SPARK_SUBMIT_OPTS=$1; shift
+      ;;
 
     *)
       SUBMISSION_ARGS+=($1); shift

--- a/sbin/start-thriftserver.sh
+++ b/sbin/start-thriftserver.sh
@@ -68,6 +68,11 @@ while (($#)); do
       THRIFT_SERVER_ARGS+=($1); shift
       THRIFT_SERVER_ARGS+=($1); shift
       ;;
+      
+    --driver-java-options)
+      shift;
+      export SPARK_SUBMIT_OPTS=$1; shift
+      ;;
 
     *)
       SUBMISSION_ARGS+=($1); shift

--- a/sbin/start-thriftserver.sh
+++ b/sbin/start-thriftserver.sh
@@ -65,19 +65,14 @@ while (($#)); do
   case $1 in
     --hiveconf)
       ensure_arg_number $# 2
-      THRIFT_SERVER_ARGS+=($1); shift
-      THRIFT_SERVER_ARGS+=($1); shift
-      ;;
-      
-    --driver-java-options)
-      shift;
-      export SPARK_SUBMIT_OPTS=$1; shift
+      THRIFT_SERVER_ARGS+=("$1"); shift
+      THRIFT_SERVER_ARGS+=("$1"); shift
       ;;
 
     *)
-      SUBMISSION_ARGS+=($1); shift
+      SUBMISSION_ARGS+=("$1"); shift
       ;;
   esac
 done
 
-eval exec "$FWDIR"/bin/spark-submit --class $CLASS ${SUBMISSION_ARGS[*]} spark-internal ${THRIFT_SERVER_ARGS[*]}
+exec "$FWDIR"/bin/spark-submit --class $CLASS "${SUBMISSION_ARGS[@]}" spark-internal "${THRIFT_SERVER_ARGS[@]}"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-2925

Run cmd like this will get the error
bin/spark-sql --driver-java-options '-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,address=8788,server=y,suspend=y'

Error: Unrecognized option '-Xnoagent'.
Run with --help for usage help or --verbose for debug output
