### PR TITLE
[SPARK-2678] Follow-up commit for #1715 #1801, spark-shell is broken

### DIFF
--- a/bin/spark-shell
+++ b/bin/spark-shell
@@ -46,11 +46,11 @@ function main(){
         # (see https://github.com/sbt/sbt/issues/562).
         stty -icanon min 1 -echo > /dev/null 2>&1
         export SPARK_SUBMIT_OPTS="$SPARK_SUBMIT_OPTS -Djline.terminal=unix"
-        $FWDIR/bin/spark-submit --class org.apache.spark.repl.Main spark-shell "$@"
+        $FWDIR/bin/spark-submit "$@" --class org.apache.spark.repl.Main spark-shell
         stty icanon echo > /dev/null 2>&1
     else
         export SPARK_SUBMIT_OPTS
-        $FWDIR/bin/spark-submit --class org.apache.spark.repl.Main spark-shell "$@"
+        $FWDIR/bin/spark-submit "$@" --class org.apache.spark.repl.Main spark-shell
     fi
 }
 

--- a/bin/spark-shell.cmd
+++ b/bin/spark-shell.cmd
@@ -19,4 +19,4 @@ rem
 
 set SPARK_HOME=%~dp0..
 
-cmd /V /E /C %SPARK_HOME%\bin\spark-submit.cmd spark-shell --class org.apache.spark.repl.Main %*
+cmd /V /E /C %SPARK_HOME%\bin\spark-submit.cmd %* --class org.apache.spark.repl.Main spark-shell


### PR DESCRIPTION
all options are not working...
just run spark-shell with any options, such as --master
`./bin/spark-shell --master local[2]`
will get error message
`bad option: '--master'`

then oevr!...

more detail: https://github.com/apache/spark/pull/1801#issuecomment-51545117
