### PR TITLE
[SPARK-2062][GraphX] VertexRDD.apply does not use the mergeFunc

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/VertexRDD.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/VertexRDD.scala
@@ -392,7 +392,7 @@ object VertexRDD {
    */
   def apply[VD: ClassTag](
       vertices: RDD[(VertexId, VD)], edges: EdgeRDD[_, _], defaultVal: VD): VertexRDD[VD] = {
-    VertexRDD(vertices, edges, defaultVal, (a, b) => b)
+    VertexRDD(vertices, edges, defaultVal, (a, b) => a)
   }
 
   /**

--- a/graphx/src/main/scala/org/apache/spark/graphx/VertexRDD.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/VertexRDD.scala
@@ -406,8 +406,6 @@ object VertexRDD {
    * @param edges the [[EdgeRDD]] that these vertices may be joined with
    * @param defaultVal the vertex attribute to use when creating missing vertices
    * @param mergeFunc the commutative, associative duplicate vertex attribute merge function
-   * note that all vertices with default value created upon construction in VertexPartition
-   * so it will appear as b in (a, b) pair for mergeFunc.
    */
   def apply[VD: ClassTag](
       vertices: RDD[(VertexId, VD)], edges: EdgeRDD[_, _], defaultVal: VD, mergeFunc: (VD, VD) => VD

--- a/graphx/src/main/scala/org/apache/spark/graphx/VertexRDD.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/VertexRDD.scala
@@ -419,7 +419,7 @@ object VertexRDD {
       (vertexIter, routingTableIter) =>
         val routingTable =
           if (routingTableIter.hasNext) routingTableIter.next() else RoutingTablePartition.empty
-        Iterator(ShippableVertexPartition(vertexIter, routingTable, defaultVal))
+        Iterator(ShippableVertexPartition(vertexIter, routingTable, defaultVal, mergeFunc))
     }
     new VertexRDD(vertexPartitions)
   }

--- a/graphx/src/main/scala/org/apache/spark/graphx/VertexRDD.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/VertexRDD.scala
@@ -410,10 +410,9 @@ object VertexRDD {
   def apply[VD: ClassTag](
       vertices: RDD[(VertexId, VD)], edges: EdgeRDD[_, _], defaultVal: VD, mergeFunc: (VD, VD) => VD
     ): VertexRDD[VD] = {
-    val verticesDedup = vertices.reduceByKey((VD1, VD2) => mergeFunc(VD1, VD2))
-    val vPartitioned: RDD[(VertexId, VD)] = verticesDedup.partitioner match {
-      case Some(p) => verticesDedup
-      case None => verticesDedup.copartitionWithVertices(new HashPartitioner(verticesDedup.partitions.size))
+    val vPartitioned: RDD[(VertexId, VD)] = vertices.partitioner match {
+      case Some(p) => vertices
+      case None => vertices.copartitionWithVertices(new HashPartitioner(vertices.partitions.size))
     }
     val routingTables = createRoutingTables(edges, vPartitioned.partitioner.get)
     val vertexPartitions = vPartitioned.zipPartitions(routingTables, preservesPartitioning = true) {

--- a/graphx/src/main/scala/org/apache/spark/graphx/VertexRDD.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/VertexRDD.scala
@@ -406,6 +406,8 @@ object VertexRDD {
    * @param edges the [[EdgeRDD]] that these vertices may be joined with
    * @param defaultVal the vertex attribute to use when creating missing vertices
    * @param mergeFunc the commutative, associative duplicate vertex attribute merge function
+   * note that all vertices with default value created upon construction in VertexPartition
+   * so it will appear as b in (a, b) pair for mergeFunc.
    */
   def apply[VD: ClassTag](
       vertices: RDD[(VertexId, VD)], edges: EdgeRDD[_, _], defaultVal: VD, mergeFunc: (VD, VD) => VD

--- a/graphx/src/main/scala/org/apache/spark/graphx/impl/ShippableVertexPartition.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/impl/ShippableVertexPartition.scala
@@ -43,7 +43,7 @@ object ShippableVertexPartition {
    * table, filling in missing vertices mentioned in the routing table using `defaultVal`.
    */
   def apply[VD: ClassTag](
-    iter: Iterator[(VertexId, VD)], routingTable: RoutingTablePartition, defaultVal: VD)
+      iter: Iterator[(VertexId, VD)], routingTable: RoutingTablePartition, defaultVal: VD)
     : ShippableVertexPartition[VD] = 
     apply(iter, routingTable, defaultVal, (a, b) => a)
 
@@ -53,7 +53,9 @@ object ShippableVertexPartition {
    * and merging duplicate vertex atrribute with mergeFunc.
    */
   def apply[VD: ClassTag](
-    iter: Iterator[(VertexId, VD)], routingTable: RoutingTablePartition, defaultVal: VD, mergeFunc: (VD, VD) => VD)
+      iter: Iterator[(VertexId, VD)], routingTable: RoutingTablePartition, defaultVal: VD,
+      mergeFunc: (VD, VD) => VD
+  )
     : ShippableVertexPartition[VD] = {
     val fullIter = iter ++ routingTable.iterator.map(vid => (vid, defaultVal))
     val (index, values, mask) = VertexPartitionBase.initFrom(fullIter, mergeFunc)

--- a/graphx/src/main/scala/org/apache/spark/graphx/impl/ShippableVertexPartition.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/impl/ShippableVertexPartition.scala
@@ -36,7 +36,16 @@ private[graphx]
 object ShippableVertexPartition {
   /** Construct a `ShippableVertexPartition` from the given vertices without any routing table. */
   def apply[VD: ClassTag](iter: Iterator[(VertexId, VD)]): ShippableVertexPartition[VD] =
-    apply(iter, RoutingTablePartition.empty, null.asInstanceOf[VD])
+    apply(iter, RoutingTablePartition.empty, null.asInstanceOf[VD], (a, b) => a)
+
+  /**
+   * Construct a `ShippableVertexPartition` from the given vertices with the specified routing
+   * table, filling in missing vertices mentioned in the routing table using `defaultVal`.
+   */
+  def apply[VD: ClassTag](
+    iter: Iterator[(VertexId, VD)], routingTable: RoutingTablePartition, defaultVal: VD)
+    : ShippableVertexPartition[VD] = 
+    apply(iter, routingTable, defaultVal, (a, b) => a)
 
   /**
    * Construct a `ShippableVertexPartition` from the given vertices with the specified routing

--- a/graphx/src/main/scala/org/apache/spark/graphx/impl/ShippableVertexPartition.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/impl/ShippableVertexPartition.scala
@@ -40,13 +40,14 @@ object ShippableVertexPartition {
 
   /**
    * Construct a `ShippableVertexPartition` from the given vertices with the specified routing
-   * table, filling in missing vertices mentioned in the routing table using `defaultVal`.
+   * table, filling in missing vertices mentioned in the routing table using `defaultVal`,
+   * and merging duplicate vertex atrribute with mergeFunc.
    */
   def apply[VD: ClassTag](
-      iter: Iterator[(VertexId, VD)], routingTable: RoutingTablePartition, defaultVal: VD)
+    iter: Iterator[(VertexId, VD)], routingTable: RoutingTablePartition, defaultVal: VD, mergeFunc: (VD, VD) => VD)
     : ShippableVertexPartition[VD] = {
     val fullIter = iter ++ routingTable.iterator.map(vid => (vid, defaultVal))
-    val (index, values, mask) = VertexPartitionBase.initFrom(fullIter, (a: VD, b: VD) => a)
+    val (index, values, mask) = VertexPartitionBase.initFrom(fullIter, mergeFunc)
     new ShippableVertexPartition(index, values, mask, routingTable)
   }
 

--- a/graphx/src/test/scala/org/apache/spark/graphx/VertexRDDSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/VertexRDDSuite.scala
@@ -102,17 +102,11 @@ class VertexRDDSuite extends FunSuite with LocalSparkContext {
   test("mergeFunc") {
     // test to see if the mergeFunc is working correctly
     withSpark { sc =>
-      // VertexRDD default constructor: Duplicate entries are removed arbitrarily.
-      // val verts = VertexRDD(sc.parallelize(List((0L, 1), (0L, 2), (1L, 3), (1L, 3), (1L, 3))))
-      // ensure constructor preserve duplicate vertex
-      // assert(verts.collect.toSet == Set((0L, 1), (0L, 2), (1L, 3), (1L, 3), (1L, 3)))
-      // won't pass
-
-      val verts = sc.parallelize(List((0L, 1), (0L, 2), (1L, 3), (1L, 3), (1L, 3)))
+      val verts = sc.parallelize(List((0L, 0), (1L, 1), (1L, 2), (2L, 3), (2L, 3), (2L, 3)))
       val edges = EdgeRDD.fromEdges(sc.parallelize(List.empty[Edge[Int]]))
       val rdd = VertexRDD(verts, edges, 0, (a: Int, b: Int) => a + b)
       // test merge function
-      assert(rdd.collect.toSet == Set((0L, 3), (1L, 9)))
+      assert(rdd.collect.toSet == Set((0L, 0), (1L, 3), (2L, 9)))
     }
   }
 

--- a/graphx/src/test/scala/org/apache/spark/graphx/VertexRDDSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/VertexRDDSuite.scala
@@ -99,4 +99,21 @@ class VertexRDDSuite extends FunSuite with LocalSparkContext {
     }
   }
 
+  test("mergeFunc") {
+    // test to see if the mergeFunc is working correctly
+    withSpark { sc =>
+      // VertexRDD default constructor: Duplicate entries are removed arbitrarily.
+      // val verts = VertexRDD(sc.parallelize(List((0L, 1), (0L, 2), (1L, 3), (1L, 3), (1L, 3))))
+      // ensure constructor preserve duplicate vertex
+      // assert(verts.collect.toSet == Set((0L, 1), (0L, 2), (1L, 3), (1L, 3), (1L, 3)))
+      // won't pass
+
+      val verts = sc.parallelize(List((0L, 1), (0L, 2), (1L, 3), (1L, 3), (1L, 3)))
+      val edges = EdgeRDD.fromEdges(sc.parallelize(List.empty[Edge[Int]]))
+      val rdd = VertexRDD(verts, edges, 0, (a: Int, b: Int) => a + b)
+      // test merge function
+      assert(rdd.collect.toSet == Set((0L, 3), (1L, 9)))
+    }
+  }
+
 }

--- a/graphx/src/test/scala/org/apache/spark/graphx/VertexRDDSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/VertexRDDSuite.scala
@@ -29,10 +29,6 @@ class VertexRDDSuite extends FunSuite with LocalSparkContext {
     VertexRDD(sc.parallelize((0 to n).map(x => (x.toLong, x)), 5))
   }
 
-  def verticesDup(sc: SparkContext, n: Int) = {
-    VertexRDD(sc.parallelize((-n to n).map(x => (math.abs(x.toLong), x)), 5)
-  }
-
   test("filter") {
     withSpark { sc =>
       val n = 100
@@ -103,14 +99,4 @@ class VertexRDDSuite extends FunSuite with LocalSparkContext {
     }
   }
 
-  // TODO:
-  // need edges in apply function
-  test("apply.mergeFunc") {
-    withSpark { sc =>
-      val n = 100
-      val verts = vertices(sc, n)
-      val evens = verts.filter(q => ((q._2 % 2) == 0))
-      assert(evens.count === (0 to n).filter(_ % 2 == 0).size)
-    }
-  }
 }

--- a/graphx/src/test/scala/org/apache/spark/graphx/VertexRDDSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/VertexRDDSuite.scala
@@ -29,6 +29,10 @@ class VertexRDDSuite extends FunSuite with LocalSparkContext {
     VertexRDD(sc.parallelize((0 to n).map(x => (x.toLong, x)), 5))
   }
 
+  def verticesDup(sc: SparkContext, n: Int) = {
+    VertexRDD(sc.parallelize((-n to n).map(x => (math.abs(x.toLong), x)), 5)
+  }
+
   test("filter") {
     withSpark { sc =>
       val n = 100
@@ -99,4 +103,14 @@ class VertexRDDSuite extends FunSuite with LocalSparkContext {
     }
   }
 
+  // TODO:
+  // need edges in apply function
+  test("apply.mergeFunc") {
+    withSpark { sc =>
+      val n = 100
+      val verts = vertices(sc, n)
+      val evens = verts.filter(q => ((q._2 % 2) == 0))
+      assert(evens.count === (0 to n).filter(_ % 2 == 0).size)
+    }
+  }
 }


### PR DESCRIPTION
create verticesDeduplicate with reduceByKey, using mergeFunc
then proceed with verticesDedup

But this is not tested and I want to add a test on VertexRDD.apply, 
because it need Edges, should I place it in VertexRDDSuite or else?
