### PR TITLE
fix flaky tests

### DIFF
--- a/python/pyspark/sql.py
+++ b/python/pyspark/sql.py
@@ -1092,7 +1092,7 @@ class SQLContext:
         ...   "SELECT byte1 - 1 AS byte1, byte2 + 1 AS byte2, " +
         ...     "short1 + 1 AS short1, short2 - 1 AS short2, int - 1 AS int, " +
         ...     "float + 1.1 as float FROM table2").collect()
-        [Row(byte1=126, byte2=-127, short1=-32767, short2=32766, int=2147483646, float=2.1)]
+        [Row(byte1=126, byte2=-127, short1=-32767, short2=32766, int=2147483646, float=2.1...)]
 
         >>> rdd = sc.parallelize([(127, -32768, 1.0,
         ...     datetime(2010, 1, 1, 1, 1, 1),


### PR DESCRIPTION
Python 2.6 does not handle float error well as 2.7+
