### PR TITLE
[SPARK-3010] fix redundant conditional in spark

### DIFF
--- a/core/src/main/scala/org/apache/spark/SecurityManager.scala
+++ b/core/src/main/scala/org/apache/spark/SecurityManager.scala
@@ -294,7 +294,7 @@ private[spark] class SecurityManager(sparkConf: SparkConf) extends Logging {
   def checkUIViewPermissions(user: String): Boolean = {
     logDebug("user=" + user + " aclsEnabled=" + aclsEnabled() + " viewAcls=" +
       viewAcls.mkString(","))
-    if (aclsEnabled() && (user != null) && (!viewAcls.contains(user))) false else true
+    (aclsEnabled() && (user != null) && (!viewAcls.contains(user))) == false
   }
 
   /**
@@ -309,7 +309,7 @@ private[spark] class SecurityManager(sparkConf: SparkConf) extends Logging {
   def checkModifyPermissions(user: String): Boolean = {
     logDebug("user=" + user + " aclsEnabled=" + aclsEnabled() + " modifyAcls=" +
       modifyAcls.mkString(","))
-    if (aclsEnabled() && (user != null) && (!modifyAcls.contains(user))) false else true
+    (aclsEnabled() && (user != null) && (!modifyAcls.contains(user))) == false
   }
 
 

--- a/core/src/test/scala/org/apache/spark/rdd/PartitionPruningRDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/PartitionPruningRDDSuite.scala
@@ -39,7 +39,7 @@ class PartitionPruningRDDSuite extends FunSuite with SharedSparkContext {
       }
     }
     val prunedRDD = PartitionPruningRDD.create(rdd, {
-      x => if (x == 2) true else false
+      x => (x == 2)
     })
     assert(prunedRDD.partitions.length == 1)
     val p = prunedRDD.partitions(0)
@@ -63,11 +63,11 @@ class PartitionPruningRDDSuite extends FunSuite with SharedSparkContext {
       }
     }
     val prunedRDD1 = PartitionPruningRDD.create(rdd, {
-      x => if (x == 0) true else false
+      x => (x == 0)
     })
 
     val prunedRDD2 = PartitionPruningRDD.create(rdd, {
-      x => if (x == 2) true else false
+      x => (x == 2)
     })
 
     val merged = prunedRDD1 ++ prunedRDD2

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
@@ -87,8 +87,7 @@ trait SQLConf {
    *
    * Defaults to false as this feature is currently experimental.
    */
-  private[spark] def codegenEnabled: Boolean =
-    if (getConf(CODEGEN_ENABLED, "false") == "true") true else false
+  private[spark] def codegenEnabled: Boolean = getConf(CODEGEN_ENABLED, "false") == "true"
 
   /**
    * Upper bound on the sizes (in bytes) of the tables qualified for the auto conversion to

--- a/sql/core/src/main/scala/org/apache/spark/sql/columnar/ColumnType.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/columnar/ColumnType.scala
@@ -158,9 +158,7 @@ private[sql] object BOOLEAN extends NativeColumnType(BooleanType, 4, 1) {
     buffer.put(if (v) 1.toByte else 0.toByte)
   }
 
-  override def extract(buffer: ByteBuffer) = {
-    if (buffer.get() == 1) true else false
-  }
+  override def extract(buffer: ByteBuffer) = buffer.get() == 1
 
   override def setField(row: MutableRow, ordinal: Int, value: Boolean) {
     row.setBoolean(ordinal, value)

--- a/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/ClientBase.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/ClientBase.scala
@@ -218,7 +218,7 @@ trait ClientBase extends Logging {
       if (! localPath.isEmpty()) {
         val localURI = new URI(localPath)
         if (!ClientBase.LOCAL_SCHEME.equals(localURI.getScheme())) {
-          val setPermissions = if (destName.equals(ClientBase.APP_JAR)) true else false
+          val setPermissions = destName.equals(ClientBase.APP_JAR)
           val destPath = copyRemoteFile(dst, qualifyForLocal(localURI), replication, setPermissions)
           val destFs = FileSystem.get(destPath.toUri(), conf)
           distCacheMgr.addResource(destFs, conf, destPath, localResources, LocalResourceType.FILE,


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-3010

there are some redundant conditional in spark, such as
1.
private[spark] def codegenEnabled: Boolean =
if (getConf(CODEGEN_ENABLED, "false") == "true") true else false
2.
x => if (x == 2) true else false
... 

this pr is to fix this
