### PR TITLE
[SPARK-3097][MLlib] Word2Vec performance improvement

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/Word2Vec.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/Word2Vec.scala
@@ -321,8 +321,8 @@ class Word2Vec extends Serializable with Logging {
                     // Hierarchical softmax
                     var d = 0
                     while (d < bcVocab.value(word).codeLen) {
-                      val ind = bcVocab.value(word).point(d)
-                      val l2 = ind * vectorSize
+                      val inner = bcVocab.value(word).point(d)
+                      val l2 = inner * vectorSize
                       // Propagate hidden -> output
                       var f = blas.sdot(vectorSize, syn, l1, 1, syn, l2, 1)
                       if (f > -MAX_EXP && f < MAX_EXP) {
@@ -331,7 +331,7 @@ class Word2Vec extends Serializable with Logging {
                         val g = ((1 - bcVocab.value(word).code(d) - f) * alpha).toFloat
                         blas.saxpy(vectorSize, g, syn, l2, 1, neu1e, 0, 1)
                         blas.saxpy(vectorSize, g, syn, l1, 1, syn, l2, 1)
-                        synModify(ind) += 1
+                        synModify(inner) += 1
                       }
                       d += 1
                     }


### PR DESCRIPTION
@mengxr Please review the code. Adding weights in reduceByKey soon. 

Only output model entry for words appeared in the partition before merging and use reduceByKey to combine model. In general, this implementation is 30s or so faster than implementation using big array.  
