### PR TITLE
[SPARK-3022] [mllib] FindBinsForLevel in decision tree should call findBin only once for each feature

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/DecisionTree.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/DecisionTree.scala
@@ -652,11 +652,11 @@ object DecisionTree extends Serializable with Logging {
      *             Indexed by (node, feature, bin, label) where label is the least significant bit.
      */
     def updateBinForOrderedFeature(
-                                    arr: Array[Double],
-                                    agg: Array[Double],
-                                    nodeIndex: Int,
-                                    label: Double,
-                                    featureIndex: Int): Unit = {
+        arr: Array[Double],
+        agg: Array[Double],
+        nodeIndex: Int,
+        label: Double,
+        featureIndex: Int): Unit = {
       // Find the bin index for this feature.
       val arrShift = 1 + numNodes
       val arrIndex = arrShift + featureIndex
@@ -695,8 +695,8 @@ object DecisionTree extends Serializable with Logging {
       // Update the left or right count for one bin.
       val aggShift =
         numClasses * numBins * numFeatures * nodeIndex +
-          numClasses * numBins * featureIndex +
-          label.toInt
+        numClasses * numBins * featureIndex +
+        label.toInt
       // Find all matching bins and increment their values
       val featureCategories = strategy.categoricalFeaturesInfo(featureIndex)
       val numCategoricalBins = math.pow(2.0, featureCategories - 1).toInt - 1
@@ -1064,7 +1064,7 @@ object DecisionTree extends Serializable with Logging {
           while (innerClassIndex < numClasses) {
             leftNodeAgg(featureIndex)(splitIndex)(innerClassIndex)
               = binData(shift + numClasses * splitIndex + innerClassIndex) +
-              leftNodeAgg(featureIndex)(splitIndex - 1)(innerClassIndex)
+                leftNodeAgg(featureIndex)(splitIndex - 1)(innerClassIndex)
             rightNodeAgg(featureIndex)(numBins - 2 - splitIndex)(innerClassIndex) =
               binData(shift + (numClasses * (numBins - 1 - splitIndex) + innerClassIndex)) +
                 rightNodeAgg(featureIndex)(numBins - 1 - splitIndex)(innerClassIndex)

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/DecisionTree.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/DecisionTree.scala
@@ -160,10 +160,10 @@ class DecisionTree (private val strategy: Strategy) extends Serializable with Lo
    * Extract the decision tree node information for the given tree level and node index
    */
   private def extractNodeInfo(
-                               nodeSplitStats: (Split, InformationGainStats),
-                               level: Int,
-                               index: Int,
-                               nodes: Array[Node]): Unit = {
+      nodeSplitStats: (Split, InformationGainStats),
+      level: Int,
+      index: Int,
+      nodes: Array[Node]): Unit = {
     val split = nodeSplitStats._1
     val stats = nodeSplitStats._2
     val nodeIndex = math.pow(2, level).toInt - 1 + index
@@ -177,12 +177,12 @@ class DecisionTree (private val strategy: Strategy) extends Serializable with Lo
    *  Extract the decision tree node information for the children of the node
    */
   private def extractInfoForLowerLevels(
-                                         level: Int,
-                                         index: Int,
-                                         maxDepth: Int,
-                                         nodeSplitStats: (Split, InformationGainStats),
-                                         parentImpurities: Array[Double],
-                                         filters: Array[List[Filter]]): Unit = {
+      level: Int,
+      index: Int,
+      maxDepth: Int,
+      nodeSplitStats: (Split, InformationGainStats),
+      parentImpurities: Array[Double],
+      filters: Array[List[Filter]]): Unit = {
     // 0 corresponds to the left child node and 1 corresponds to the right child node.
     var i = 0
     while (i <= 1) {
@@ -207,9 +207,6 @@ class DecisionTree (private val strategy: Strategy) extends Serializable with Lo
       i += 1
     }
   }
-
-
-
 }
 
 object DecisionTree extends Serializable with Logging {
@@ -252,10 +249,10 @@ object DecisionTree extends Serializable with Logging {
    * @return DecisionTreeModel that can be used for prediction
    */
   def train(
-             input: RDD[LabeledPoint],
-             algo: Algo,
-             impurity: Impurity,
-             maxDepth: Int): DecisionTreeModel = {
+      input: RDD[LabeledPoint],
+      algo: Algo,
+      impurity: Impurity,
+      maxDepth: Int): DecisionTreeModel = {
     val strategy = new Strategy(algo, impurity, maxDepth)
     new DecisionTree(strategy).train(input)
   }
@@ -279,11 +276,11 @@ object DecisionTree extends Serializable with Logging {
    * @return DecisionTreeModel that can be used for prediction
    */
   def train(
-             input: RDD[LabeledPoint],
-             algo: Algo,
-             impurity: Impurity,
-             maxDepth: Int,
-             numClassesForClassification: Int): DecisionTreeModel = {
+      input: RDD[LabeledPoint],
+      algo: Algo,
+      impurity: Impurity,
+      maxDepth: Int,
+      numClassesForClassification: Int): DecisionTreeModel = {
     val strategy = new Strategy(algo, impurity, maxDepth, numClassesForClassification)
     new DecisionTree(strategy).train(input)
   }
@@ -312,14 +309,14 @@ object DecisionTree extends Serializable with Logging {
    * @return DecisionTreeModel that can be used for prediction
    */
   def train(
-             input: RDD[LabeledPoint],
-             algo: Algo,
-             impurity: Impurity,
-             maxDepth: Int,
-             numClassesForClassification: Int,
-             maxBins: Int,
-             quantileCalculationStrategy: QuantileStrategy,
-             categoricalFeaturesInfo: Map[Int,Int]): DecisionTreeModel = {
+      input: RDD[LabeledPoint],
+      algo: Algo,
+      impurity: Impurity,
+      maxDepth: Int,
+      numClassesForClassification: Int,
+      maxBins: Int,
+      quantileCalculationStrategy: QuantileStrategy,
+      categoricalFeaturesInfo: Map[Int,Int]): DecisionTreeModel = {
     val strategy = new Strategy(algo, impurity, maxDepth, numClassesForClassification, maxBins,
       quantileCalculationStrategy, categoricalFeaturesInfo)
     new DecisionTree(strategy).train(input)
@@ -344,12 +341,12 @@ object DecisionTree extends Serializable with Logging {
    * @return DecisionTreeModel that can be used for prediction
    */
   def trainClassifier(
-                       input: RDD[LabeledPoint],
-                       numClassesForClassification: Int,
-                       categoricalFeaturesInfo: Map[Int, Int],
-                       impurity: String,
-                       maxDepth: Int,
-                       maxBins: Int): DecisionTreeModel = {
+      input: RDD[LabeledPoint],
+      numClassesForClassification: Int,
+      categoricalFeaturesInfo: Map[Int, Int],
+      impurity: String,
+      maxDepth: Int,
+      maxBins: Int): DecisionTreeModel = {
     val impurityType = Impurities.fromString(impurity)
     train(input, Classification, impurityType, maxDepth, numClassesForClassification, maxBins, Sort,
       categoricalFeaturesInfo)
@@ -359,12 +356,12 @@ object DecisionTree extends Serializable with Logging {
    * Java-friendly API for [[org.apache.spark.mllib.tree.DecisionTree$#trainClassifier]]
    */
   def trainClassifier(
-                       input: JavaRDD[LabeledPoint],
-                       numClassesForClassification: Int,
-                       categoricalFeaturesInfo: java.util.Map[java.lang.Integer, java.lang.Integer],
-                       impurity: String,
-                       maxDepth: Int,
-                       maxBins: Int): DecisionTreeModel = {
+      input: JavaRDD[LabeledPoint],
+      numClassesForClassification: Int,
+      categoricalFeaturesInfo: java.util.Map[java.lang.Integer, java.lang.Integer],
+      impurity: String,
+      maxDepth: Int,
+      maxBins: Int): DecisionTreeModel = {
     trainClassifier(input.rdd, numClassesForClassification,
       categoricalFeaturesInfo.asInstanceOf[java.util.Map[Int, Int]].asScala.toMap,
       impurity, maxDepth, maxBins)
@@ -388,11 +385,11 @@ object DecisionTree extends Serializable with Logging {
    * @return DecisionTreeModel that can be used for prediction
    */
   def trainRegressor(
-                      input: RDD[LabeledPoint],
-                      categoricalFeaturesInfo: Map[Int, Int],
-                      impurity: String,
-                      maxDepth: Int,
-                      maxBins: Int): DecisionTreeModel = {
+      input: RDD[LabeledPoint],
+      categoricalFeaturesInfo: Map[Int, Int],
+      impurity: String,
+      maxDepth: Int,
+      maxBins: Int): DecisionTreeModel = {
     val impurityType = Impurities.fromString(impurity)
     train(input, Regression, impurityType, maxDepth, 0, maxBins, Sort, categoricalFeaturesInfo)
   }
@@ -401,11 +398,11 @@ object DecisionTree extends Serializable with Logging {
    * Java-friendly API for [[org.apache.spark.mllib.tree.DecisionTree$#trainRegressor]]
    */
   def trainRegressor(
-                      input: JavaRDD[LabeledPoint],
-                      categoricalFeaturesInfo: java.util.Map[java.lang.Integer, java.lang.Integer],
-                      impurity: String,
-                      maxDepth: Int,
-                      maxBins: Int): DecisionTreeModel = {
+      input: JavaRDD[LabeledPoint],
+      categoricalFeaturesInfo: java.util.Map[java.lang.Integer, java.lang.Integer],
+      impurity: String,
+      maxDepth: Int,
+      maxBins: Int): DecisionTreeModel = {
     trainRegressor(input.rdd,
       categoricalFeaturesInfo.asInstanceOf[java.util.Map[Int, Int]].asScala.toMap,
       impurity, maxDepth, maxBins)
@@ -432,14 +429,14 @@ object DecisionTree extends Serializable with Logging {
    * @return array of splits with best splits for all nodes at a given level.
    */
   protected[tree] def findBestSplits(
-    inputWithFeatures2bin: RDD[(LabeledPoint, Array[Int])],
-    parentImpurities: Array[Double],
-    strategy: Strategy,
-    level: Int,
-    filters: Array[List[Filter]],
-    splits: Array[Array[Split]],
-    bins: Array[Array[Bin]],
-    maxLevelForSingleGroup: Int): Array[(Split, InformationGainStats)] = {
+      inputWithFeatures2bin: RDD[(LabeledPoint, Array[Int])],
+      parentImpurities: Array[Double],
+      strategy: Strategy,
+      level: Int,
+      filters: Array[List[Filter]],
+      splits: Array[Array[Split]],
+      bins: Array[Array[Bin]],
+      maxLevelForSingleGroup: Int): Array[(Split, InformationGainStats)] = {
     // split into groups to avoid memory overflow during aggregation
     if (level > maxLevelForSingleGroup) {
       // When information for all nodes at a given level cannot be stored in memory,
@@ -482,15 +479,15 @@ object DecisionTree extends Serializable with Logging {
    * @return array of splits with best splits for all nodes at a given level.
    */
   private def findBestSplitsPerGroup(
-    inputWithFeatures2bin: RDD[(LabeledPoint, Array[Int])],
-    parentImpurities: Array[Double],
-    strategy: Strategy,
-    level: Int,
-    filters: Array[List[Filter]],
-    splits: Array[Array[Split]],
-    bins: Array[Array[Bin]],
-    numGroups: Int = 1,
-    groupIndex: Int = 0): Array[(Split, InformationGainStats)] = {
+      inputWithFeatures2bin: RDD[(LabeledPoint, Array[Int])],
+      parentImpurities: Array[Double],
+      strategy: Strategy,
+      level: Int,
+      filters: Array[List[Filter]],
+      splits: Array[Array[Split]],
+      bins: Array[Array[Bin]],
+      numGroups: Int = 1,
+      groupIndex: Int = 0): Array[(Split, InformationGainStats)] = {
 
     /*
      * The high-level descriptions of the best split optimizations are noted here.
@@ -538,7 +535,7 @@ object DecisionTree extends Serializable with Logging {
     logDebug("isMulticlassClassification = " + isMulticlassClassification)
 
     val isMulticlassClassificationWithCategoricalFeatures
-    = strategy.isMulticlassWithCategoricalFeatures
+      = strategy.isMulticlassWithCategoricalFeatures
     logDebug("isMultiClassWithCategoricalFeatures = " +
       isMulticlassClassificationWithCategoricalFeatures)
 
@@ -666,9 +663,9 @@ object DecisionTree extends Serializable with Logging {
       // Update the left or right count for one bin.
       val aggIndex =
         numClasses * numBins * numFeatures * nodeIndex +
-          numClasses * numBins * featureIndex +
-          numClasses * arr(arrIndex).toInt +
-          label.toInt
+        numClasses * numBins * featureIndex +
+        numClasses * arr(arrIndex).toInt +
+        label.toInt
       agg(aggIndex) += 1
     }
 
@@ -686,12 +683,12 @@ object DecisionTree extends Serializable with Logging {
      * @param rightChildShift Offset for right side of agg.
      */
     def updateBinForUnorderedFeature(
-                                      nodeIndex: Int,
-                                      featureIndex: Int,
-                                      arr: Array[Double],
-                                      label: Double,
-                                      agg: Array[Double],
-                                      rightChildShift: Int): Unit = {
+        nodeIndex: Int,
+        featureIndex: Int,
+        arr: Array[Double],
+        label: Double,
+        agg: Array[Double],
+        rightChildShift: Int): Unit = {
       // Find the bin index for this feature.
       val arrIndex = 1 + numNodes + featureIndex
       val featureValue = arr(arrIndex).toInt
@@ -780,7 +777,7 @@ object DecisionTree extends Serializable with Logging {
             } else {
               val featureCategories = strategy.categoricalFeaturesInfo(featureIndex)
               val isSpaceSufficientForAllCategoricalSplits
-              = numBins > math.pow(2, featureCategories.toInt - 1) - 1
+                = numBins > math.pow(2, featureCategories.toInt - 1) - 1
               if (isSpaceSufficientForAllCategoricalSplits) {
                 updateBinForUnorderedFeature(nodeIndex, featureIndex, arr, label, agg,
                   rightChildShift)
@@ -869,7 +866,7 @@ object DecisionTree extends Serializable with Logging {
 
     // Calculate bin aggregate length for classification or regression.
     val binAggregateLength = numNodes * getElementsPerNode(numFeatures, numBins, numClasses,
-      isMulticlassClassificationWithCategoricalFeatures, strategy.algo)
+        isMulticlassClassificationWithCategoricalFeatures, strategy.algo)
     logDebug("binAggregateLength = " + binAggregateLength)
 
     /**
@@ -904,11 +901,11 @@ object DecisionTree extends Serializable with Logging {
      * @return information gain and statistics for all splits
      */
     def calculateGainForSplit(
-                               leftNodeAgg: Array[Array[Array[Double]]],
-                               featureIndex: Int,
-                               splitIndex: Int,
-                               rightNodeAgg: Array[Array[Array[Double]]],
-                               topImpurity: Double): InformationGainStats = {
+        leftNodeAgg: Array[Array[Array[Double]]],
+        featureIndex: Int,
+        splitIndex: Int,
+        rightNodeAgg: Array[Array[Array[Double]]],
+        topImpurity: Double): InformationGainStats = {
       strategy.algo match {
         case Classification =>
           val leftCounts: Array[Double] = leftNodeAgg(featureIndex)(splitIndex)
@@ -1037,13 +1034,13 @@ object DecisionTree extends Serializable with Logging {
      *
      */
     def extractLeftRightNodeAggregates(
-      binData: Array[Double]): (Array[Array[Array[Double]]], Array[Array[Array[Double]]]) = {
+        binData: Array[Double]): (Array[Array[Array[Double]]], Array[Array[Array[Double]]]) = {
 
 
       def findAggForOrderedFeatureClassification(
-                                                  leftNodeAgg: Array[Array[Array[Double]]],
-                                                  rightNodeAgg: Array[Array[Array[Double]]],
-                                                  featureIndex: Int) {
+          leftNodeAgg: Array[Array[Array[Double]]],
+          rightNodeAgg: Array[Array[Array[Double]]],
+          featureIndex: Int) {
 
         // shift for this featureIndex
         val shift = numClasses * featureIndex * numBins
@@ -1083,9 +1080,9 @@ object DecisionTree extends Serializable with Logging {
        * @param leftNodeAgg   leftNodeAgg(featureIndex)(splitIndex)(classIndex) = aggregate value
        */
       def findAggForUnorderedFeatureClassification(
-                                                    leftNodeAgg: Array[Array[Array[Double]]],
-                                                    rightNodeAgg: Array[Array[Array[Double]]],
-                                                    featureIndex: Int) {
+          leftNodeAgg: Array[Array[Array[Double]]],
+          rightNodeAgg: Array[Array[Array[Double]]],
+          featureIndex: Int) {
 
         val rightChildShift = numClasses * numBins * numFeatures
         var splitIndex = 0
@@ -1105,9 +1102,9 @@ object DecisionTree extends Serializable with Logging {
       }
 
       def findAggForRegression(
-                                leftNodeAgg: Array[Array[Array[Double]]],
-                                rightNodeAgg: Array[Array[Array[Double]]],
-                                featureIndex: Int) {
+          leftNodeAgg: Array[Array[Array[Double]]],
+          rightNodeAgg: Array[Array[Array[Double]]],
+          featureIndex: Int) {
 
         // shift for this featureIndex
         val shift = 3 * featureIndex * numBins
@@ -1158,7 +1155,7 @@ object DecisionTree extends Serializable with Logging {
               } else {
                 val featureCategories = strategy.categoricalFeaturesInfo(featureIndex)
                 val isSpaceSufficientForAllCategoricalSplits
-                = numBins > math.pow(2, featureCategories.toInt - 1) - 1
+                  = numBins > math.pow(2, featureCategories.toInt - 1) - 1
                 if (isSpaceSufficientForAllCategoricalSplits) {
                   findAggForUnorderedFeatureClassification(leftNodeAgg, rightNodeAgg, featureIndex)
                 } else {
@@ -1211,8 +1208,8 @@ object DecisionTree extends Serializable with Logging {
      * @return tuple of split and information gain
      */
     def binsToBestSplit(
-         binData: Array[Double],
-         nodeImpurity: Double): (Split, InformationGainStats) = {
+        binData: Array[Double],
+        nodeImpurity: Double): (Split, InformationGainStats) = {
 
       logDebug("node impurity = " + nodeImpurity)
 
@@ -1237,9 +1234,9 @@ object DecisionTree extends Serializable with Logging {
             if (isFeatureContinuous) {
               numBins - 1
             } else { // Categorical feature
-            val featureCategories = strategy.categoricalFeaturesInfo(featureIndex)
+              val featureCategories = strategy.categoricalFeaturesInfo(featureIndex)
               val isSpaceSufficientForAllCategoricalSplits
-              = numBins > math.pow(2, featureCategories.toInt - 1) - 1
+                = numBins > math.pow(2, featureCategories.toInt - 1) - 1
               if (isMulticlassClassification && isSpaceSufficientForAllCategoricalSplits) {
                 math.pow(2.0, featureCategories - 1).toInt - 1
               } else { // Binary classification
@@ -1278,9 +1275,9 @@ object DecisionTree extends Serializable with Logging {
             val rightChildShift = numClasses * numBins * numFeatures * numNodes
             val binsForNode = {
               val leftChildData
-              = binAggregates.slice(shift, shift + numClasses * numBins * numFeatures)
+                = binAggregates.slice(shift, shift + numClasses * numBins * numFeatures)
               val rightChildData
-              = binAggregates.slice(rightChildShift + shift,
+                = binAggregates.slice(rightChildShift + shift,
                 rightChildShift + shift + numClasses * numBins * numFeatures)
               leftChildData ++ rightChildData
             }
@@ -1435,9 +1432,9 @@ object DecisionTree extends Serializable with Logging {
               splits(featureIndex)(index) = split
             }
           } else { // Categorical feature
-          val featureCategories = strategy.categoricalFeaturesInfo(featureIndex)
+            val featureCategories = strategy.categoricalFeaturesInfo(featureIndex)
             val isSpaceSufficientForAllCategoricalSplits
-            = numBins > math.pow(2, featureCategories.toInt - 1) - 1
+              = numBins > math.pow(2, featureCategories.toInt - 1) - 1
 
             // Use different bin/split calculation strategy for categorical features in multiclass
             // classification that satisfy the space constraint.
@@ -1448,7 +1445,7 @@ object DecisionTree extends Serializable with Logging {
               var index = 0
               while (index < math.pow(2.0, featureCategories - 1).toInt - 1) {
                 val categories: List[Double]
-                = extractMultiClassCategories(index + 1, featureCategories)
+                  = extractMultiClassCategories(index + 1, featureCategories)
                 splits(featureIndex)(index)
                   = new Split(featureIndex, Double.MinValue, Categorical, categories)
                 bins(featureIndex)(index) = {
@@ -1469,31 +1466,31 @@ object DecisionTree extends Serializable with Logging {
                 index += 1
               }
             } else { // ordered feature
-            /* For a given categorical feature, use a subsample of the data
-             * to choose how to arrange possible splits.
-             * This examines each category and computes a centroid.
-             * These centroids are later used to sort the possible splits.
-             * centroidForCategories is a mapping: category (for the given feature) --> centroid
-             */
-            val centroidForCategories = {
-              if (isMulticlassClassification) {
-                // For categorical variables in multiclass classification,
-                // each bin is a category. The bins are sorted and they
-                // are ordered by calculating the impurity of their corresponding labels.
-                sampledInput.map(lp => (lp.features(featureIndex), lp.label))
-                  .groupBy(_._1)
-                  .mapValues(x => x.groupBy(_._2).mapValues(x => x.size.toDouble))
-                  .map(x => (x._1, x._2.values.toArray))
-                  .map(x => (x._1, strategy.impurity.calculate(x._2, x._2.sum)))
-              } else { // regression or binary classification
-                // For categorical variables in regression and binary classification,
-                // each bin is a category. The bins are sorted and they
-                // are ordered by calculating the centroid of their corresponding labels.
-                sampledInput.map(lp => (lp.features(featureIndex), lp.label))
-                  .groupBy(_._1)
-                  .mapValues(x => x.map(_._2).sum / x.map(_._1).length)
+              /* For a given categorical feature, use a subsample of the data
+               * to choose how to arrange possible splits.
+               * This examines each category and computes a centroid.
+               * These centroids are later used to sort the possible splits.
+               * centroidForCategories is a mapping: category (for the given feature) --> centroid
+               */
+              val centroidForCategories = {
+                if (isMulticlassClassification) {
+                  // For categorical variables in multiclass classification,
+                  // each bin is a category. The bins are sorted and they
+                  // are ordered by calculating the impurity of their corresponding labels.
+                  sampledInput.map(lp => (lp.features(featureIndex), lp.label))
+                    .groupBy(_._1)
+                    .mapValues(x => x.groupBy(_._2).mapValues(x => x.size.toDouble))
+                    .map(x => (x._1, x._2.values.toArray))
+                    .map(x => (x._1, strategy.impurity.calculate(x._2, x._2.sum)))
+                } else { // regression or binary classification
+                  // For categorical variables in regression and binary classification,
+                  // each bin is a category. The bins are sorted and they
+                  // are ordered by calculating the centroid of their corresponding labels.
+                  sampledInput.map(lp => (lp.features(featureIndex), lp.label))
+                    .groupBy(_._1)
+                    .mapValues(x => x.map(_._2).sum / x.map(_._1).length)
+                }
               }
-            }
 
               logDebug("centroid for categories = " + centroidForCategories.mkString(","))
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/DecisionTree.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/DecisionTree.scala
@@ -84,7 +84,8 @@ class DecisionTree (private val strategy: Strategy) extends Serializable with Lo
     val numFeatures = retaggedInput.take(1)(0).features.size
 
     // compute features to bins array
-    val inputWithFeatures2bin = retaggedInput.map(DecisionTree.findFeature2Bin(numFeatures, numBins, bins, strategy)).cache()
+    val inputWithFeatures2bin = retaggedInput.map(
+      DecisionTree.findFeature2Bin(numFeatures, numBins, bins, strategy)).cache()
 
     // Calculate level for single group construction
 
@@ -430,14 +431,14 @@ object DecisionTree extends Serializable with Logging {
    * @return array of splits with best splits for all nodes at a given level.
    */
   protected[tree] def findBestSplits(
-                                      inputWithFeatures2bin: RDD[(LabeledPoint, Array[Int])],
-                                      parentImpurities: Array[Double],
-                                      strategy: Strategy,
-                                      level: Int,
-                                      filters: Array[List[Filter]],
-                                      splits: Array[Array[Split]],
-                                      bins: Array[Array[Bin]],
-                                      maxLevelForSingleGroup: Int): Array[(Split, InformationGainStats)] = {
+    inputWithFeatures2bin: RDD[(LabeledPoint, Array[Int])],
+    parentImpurities: Array[Double],
+    strategy: Strategy,
+    level: Int,
+    filters: Array[List[Filter]],
+    splits: Array[Array[Split]],
+    bins: Array[Array[Bin]],
+    maxLevelForSingleGroup: Int): Array[(Split, InformationGainStats)] = {
     // split into groups to avoid memory overflow during aggregation
     if (level > maxLevelForSingleGroup) {
       // When information for all nodes at a given level cannot be stored in memory,
@@ -450,14 +451,16 @@ object DecisionTree extends Serializable with Logging {
       // Iterate over each group of nodes at a level.
       var groupIndex = 0
       while (groupIndex < numGroups) {
-        val bestSplitsForGroup = findBestSplitsPerGroup(inputWithFeatures2bin, parentImpurities, strategy, level,
+        val bestSplitsForGroup = findBestSplitsPerGroup(
+          inputWithFeatures2bin,parentImpurities, strategy, level,
           filters, splits, bins, numGroups, groupIndex)
         bestSplits = Array.concat(bestSplits, bestSplitsForGroup)
         groupIndex += 1
       }
       bestSplits
     } else {
-      findBestSplitsPerGroup(inputWithFeatures2bin, parentImpurities, strategy, level, filters, splits, bins)
+      findBestSplitsPerGroup(inputWithFeatures2bin, parentImpurities,
+        strategy, level, filters, splits, bins)
     }
   }
 
@@ -477,15 +480,15 @@ object DecisionTree extends Serializable with Logging {
    * @return array of splits with best splits for all nodes at a given level.
    */
   private def findBestSplitsPerGroup(
-                                      inputWithFeatures2bin: RDD[(LabeledPoint, Array[Int])],
-                                      parentImpurities: Array[Double],
-                                      strategy: Strategy,
-                                      level: Int,
-                                      filters: Array[List[Filter]],
-                                      splits: Array[Array[Split]],
-                                      bins: Array[Array[Bin]],
-                                      numGroups: Int = 1,
-                                      groupIndex: Int = 0): Array[(Split, InformationGainStats)] = {
+    inputWithFeatures2bin: RDD[(LabeledPoint, Array[Int])],
+    parentImpurities: Array[Double],
+    strategy: Strategy,
+    level: Int,
+    filters: Array[List[Filter]],
+    splits: Array[Array[Split]],
+    bins: Array[Array[Bin]],
+    numGroups: Int = 1,
+    groupIndex: Int = 0): Array[(Split, InformationGainStats)] = {
 
     /*
      * The high-level descriptions of the best split optimizations are noted here.
@@ -1034,7 +1037,7 @@ object DecisionTree extends Serializable with Logging {
      *
      */
     def extractLeftRightNodeAggregates(
-                                        binData: Array[Double]): (Array[Array[Array[Double]]], Array[Array[Array[Double]]]) = {
+      binData: Array[Double]): (Array[Array[Array[Double]]], Array[Array[Array[Double]]]) = {
 
 
       def findAggForOrderedFeatureClassification(
@@ -1187,9 +1190,9 @@ object DecisionTree extends Serializable with Logging {
      * Calculates information gain for all nodes splits.
      */
     def calculateGainsForAllNodeSplits(
-                                        leftNodeAgg: Array[Array[Array[Double]]],
-                                        rightNodeAgg: Array[Array[Array[Double]]],
-                                        nodeImpurity: Double): Array[Array[InformationGainStats]] = {
+        leftNodeAgg: Array[Array[Array[Double]]],
+        rightNodeAgg: Array[Array[Array[Double]]],
+        nodeImpurity: Double): Array[Array[InformationGainStats]] = {
       val gains = Array.ofDim[InformationGainStats](numFeatures, numBins - 1)
 
       for (featureIndex <- 0 until numFeatures) {
@@ -1208,8 +1211,8 @@ object DecisionTree extends Serializable with Logging {
      * @return tuple of split and information gain
      */
     def binsToBestSplit(
-                         binData: Array[Double],
-                         nodeImpurity: Double): (Split, InformationGainStats) = {
+         binData: Array[Double],
+         nodeImpurity: Double): (Split, InformationGainStats) = {
 
       logDebug("node impurity = " + nodeImpurity)
 
@@ -1316,11 +1319,11 @@ object DecisionTree extends Serializable with Logging {
    * @param numBins  Number of bins = 1 + number of possible splits.
    */
   private def getElementsPerNode(
-                                  numFeatures: Int,
-                                  numBins: Int,
-                                  numClasses: Int,
-                                  isMulticlassClassificationWithCategoricalFeatures: Boolean,
-                                  algo: Algo): Int = {
+      numFeatures: Int,
+      numBins: Int,
+      numClasses: Int,
+      isMulticlassClassificationWithCategoricalFeatures: Boolean,
+      algo: Algo): Int = {
     algo match {
       case Classification =>
         if (isMulticlassClassificationWithCategoricalFeatures) {
@@ -1363,8 +1366,8 @@ object DecisionTree extends Serializable with Logging {
    *          of size (numFeatures, numBins).
    */
   protected[tree] def findSplitsBins(
-                                      input: RDD[LabeledPoint],
-                                      strategy: Strategy): (Array[Array[Split]], Array[Array[Bin]]) = {
+      input: RDD[LabeledPoint],
+      strategy: Strategy): (Array[Array[Split]], Array[Array[Bin]]) = {
 
     val count = input.count()
 
@@ -1563,7 +1566,8 @@ object DecisionTree extends Serializable with Logging {
       val featureInfo = strategy.categoricalFeaturesInfo.get(featureIndex)
       val isFeatureContinuous = featureInfo.isEmpty
       if (isFeatureContinuous) {
-        feature2bin(featureIndex) = findBin(strategy, bins, featureIndex, labeledPoint, isFeatureContinuous, false)
+        feature2bin(featureIndex) = findBin(strategy, bins,
+          featureIndex, labeledPoint, isFeatureContinuous, false)
       } else {
         val featureCategories = featureInfo.get
         val isSpaceSufficientForAllCategoricalSplits

--- a/mllib/src/test/scala/org/apache/spark/mllib/tree/DecisionTreeSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/tree/DecisionTreeSuite.scala
@@ -427,7 +427,10 @@ class DecisionTreeSuite extends FunSuite with LocalSparkContext {
       maxBins = 100,
       categoricalFeaturesInfo = Map(0 -> 3, 1-> 3))
     val (splits, bins) = DecisionTree.findSplitsBins(rdd, strategy)
-    val bestSplits = DecisionTree.findBestSplits(rdd, new Array(7), strategy, 0,
+    val numBins = bins(0).length
+    val numFeatures = rdd.take(1)(0).features.size
+    val inputWithFeatures2bin = rdd.map(DecisionTree.findFeature2Bin(numFeatures, numBins, bins, strategy))
+    val bestSplits = DecisionTree.findBestSplits(inputWithFeatures2bin, new Array(7), strategy, 0,
       Array[List[Filter]](), splits, bins, 10)
 
     val split = bestSplits(0)._1
@@ -454,7 +457,10 @@ class DecisionTreeSuite extends FunSuite with LocalSparkContext {
       maxBins = 100,
       categoricalFeaturesInfo = Map(0 -> 3, 1-> 3))
     val (splits, bins) = DecisionTree.findSplitsBins(rdd,strategy)
-    val bestSplits = DecisionTree.findBestSplits(rdd, new Array(7), strategy, 0,
+    val numBins = bins(0).length
+    val numFeatures = rdd.take(1)(0).features.size
+    val inputWithFeatures2bin = rdd.map(DecisionTree.findFeature2Bin(numFeatures, numBins, bins, strategy))
+    val bestSplits = DecisionTree.findBestSplits(inputWithFeatures2bin, new Array(7), strategy, 0,
       Array[List[Filter]](), splits, bins, 10)
 
     val split = bestSplits(0)._1
@@ -499,7 +505,10 @@ class DecisionTreeSuite extends FunSuite with LocalSparkContext {
     assert(splits(0).length === 99)
     assert(bins(0).length === 100)
 
-    val bestSplits = DecisionTree.findBestSplits(rdd, new Array(7), strategy, 0,
+    val numBins = bins(0).length
+    val numFeatures = rdd.take(1)(0).features.size
+    val inputWithFeatures2bin = rdd.map(DecisionTree.findFeature2Bin(numFeatures, numBins, bins, strategy))
+    val bestSplits = DecisionTree.findBestSplits(inputWithFeatures2bin, new Array(7), strategy, 0,
       Array[List[Filter]](), splits, bins, 10)
     assert(bestSplits.length === 1)
     assert(bestSplits(0)._1.feature === 0)
@@ -521,7 +530,10 @@ class DecisionTreeSuite extends FunSuite with LocalSparkContext {
     assert(splits(0).length === 99)
     assert(bins(0).length === 100)
 
-    val bestSplits = DecisionTree.findBestSplits(rdd, Array(0.0), strategy, 0,
+    val numBins = bins(0).length
+    val numFeatures = rdd.take(1)(0).features.size
+    val inputWithFeatures2bin = rdd.map(DecisionTree.findFeature2Bin(numFeatures, numBins, bins, strategy))
+    val bestSplits = DecisionTree.findBestSplits(inputWithFeatures2bin, Array(0.0), strategy, 0,
       Array[List[Filter]](), splits, bins, 10)
     assert(bestSplits.length === 1)
     assert(bestSplits(0)._1.feature === 0)
@@ -544,7 +556,10 @@ class DecisionTreeSuite extends FunSuite with LocalSparkContext {
     assert(splits(0).length === 99)
     assert(bins(0).length === 100)
 
-    val bestSplits = DecisionTree.findBestSplits(rdd, Array(0.0), strategy, 0,
+    val numBins = bins(0).length
+    val numFeatures = rdd.take(1)(0).features.size
+    val inputWithFeatures2bin = rdd.map(DecisionTree.findFeature2Bin(numFeatures, numBins, bins, strategy))
+    val bestSplits = DecisionTree.findBestSplits(inputWithFeatures2bin, Array(0.0), strategy, 0,
       Array[List[Filter]](), splits, bins, 10)
     assert(bestSplits.length === 1)
     assert(bestSplits(0)._1.feature === 0)
@@ -567,7 +582,10 @@ class DecisionTreeSuite extends FunSuite with LocalSparkContext {
     assert(splits(0).length === 99)
     assert(bins(0).length === 100)
 
-    val bestSplits = DecisionTree.findBestSplits(rdd, Array(0.0), strategy, 0,
+    val numBins = bins(0).length
+    val numFeatures = rdd.take(1)(0).features.size
+    val inputWithFeatures2bin = rdd.map(DecisionTree.findFeature2Bin(numFeatures, numBins, bins, strategy))
+    val bestSplits = DecisionTree.findBestSplits(inputWithFeatures2bin, Array(0.0), strategy, 0,
       Array[List[Filter]](), splits, bins, 10)
     assert(bestSplits.length === 1)
     assert(bestSplits(0)._1.feature === 0)
@@ -596,7 +614,10 @@ class DecisionTreeSuite extends FunSuite with LocalSparkContext {
     val parentImpurities = Array(0.5, 0.5, 0.5)
 
     // Single group second level tree construction.
-    val bestSplits = DecisionTree.findBestSplits(rdd, parentImpurities, strategy, 1, filters,
+    val numBins = bins(0).length
+    val numFeatures = rdd.take(1)(0).features.size
+    val inputWithFeatures2bin = rdd.map(DecisionTree.findFeature2Bin(numFeatures, numBins, bins, strategy))
+    val bestSplits = DecisionTree.findBestSplits(inputWithFeatures2bin, parentImpurities, strategy, 1, filters,
       splits, bins, 10)
     assert(bestSplits.length === 2)
     assert(bestSplits(0)._2.gain > 0)
@@ -604,7 +625,7 @@ class DecisionTreeSuite extends FunSuite with LocalSparkContext {
 
     // maxLevelForSingleGroup parameter is set to 0 to force splitting into groups for second
     // level tree construction.
-    val bestSplitsWithGroups = DecisionTree.findBestSplits(rdd, parentImpurities, strategy, 1,
+    val bestSplitsWithGroups = DecisionTree.findBestSplits(inputWithFeatures2bin, parentImpurities, strategy, 1,
       filters, splits, bins, 0)
     assert(bestSplitsWithGroups.length === 2)
     assert(bestSplitsWithGroups(0)._2.gain > 0)
@@ -630,7 +651,10 @@ class DecisionTreeSuite extends FunSuite with LocalSparkContext {
       numClassesForClassification = 3, categoricalFeaturesInfo = Map(0 -> 3, 1 -> 3))
     assert(strategy.isMulticlassClassification)
     val (splits, bins) = DecisionTree.findSplitsBins(input, strategy)
-    val bestSplits = DecisionTree.findBestSplits(input, new Array(31), strategy, 0,
+    val numBins = bins(0).length
+    val numFeatures = input.take(1)(0).features.size
+    val inputWithFeatures2bin = input.map(DecisionTree.findFeature2Bin(numFeatures, numBins, bins, strategy))
+    val bestSplits = DecisionTree.findBestSplits(inputWithFeatures2bin, new Array(31), strategy, 0,
       Array[List[Filter]](), splits, bins, 10)
 
     assert(bestSplits.length === 1)
@@ -689,7 +713,10 @@ class DecisionTreeSuite extends FunSuite with LocalSparkContext {
     assert(model.depth === 1)
 
     val (splits, bins) = DecisionTree.findSplitsBins(input, strategy)
-    val bestSplits = DecisionTree.findBestSplits(input, new Array(31), strategy, 0,
+    val numBins = bins(0).length
+    val numFeatures = input.take(1)(0).features.size
+    val inputWithFeatures2bin = input.map(DecisionTree.findFeature2Bin(numFeatures, numBins, bins, strategy))
+    val bestSplits = DecisionTree.findBestSplits(inputWithFeatures2bin, new Array(31), strategy, 0,
       Array[List[Filter]](), splits, bins, 10)
 
     assert(bestSplits.length === 1)
@@ -714,7 +741,10 @@ class DecisionTreeSuite extends FunSuite with LocalSparkContext {
     validateClassifier(model, arr, 0.9)
 
     val (splits, bins) = DecisionTree.findSplitsBins(input, strategy)
-    val bestSplits = DecisionTree.findBestSplits(input, new Array(31), strategy, 0,
+    val numBins = bins(0).length
+    val numFeatures = input.take(1)(0).features.size
+    val inputWithFeatures2bin = input.map(DecisionTree.findFeature2Bin(numFeatures, numBins, bins, strategy))
+    val bestSplits = DecisionTree.findBestSplits(inputWithFeatures2bin, new Array(31), strategy, 0,
       Array[List[Filter]](), splits, bins, 10)
 
     assert(bestSplits.length === 1)
@@ -738,7 +768,10 @@ class DecisionTreeSuite extends FunSuite with LocalSparkContext {
     validateClassifier(model, arr, 0.9)
 
     val (splits, bins) = DecisionTree.findSplitsBins(input, strategy)
-    val bestSplits = DecisionTree.findBestSplits(input, new Array(31), strategy, 0,
+    val numBins = bins(0).length
+    val numFeatures = input.take(1)(0).features.size
+    val inputWithFeatures2bin = input.map(DecisionTree.findFeature2Bin(numFeatures, numBins, bins, strategy))
+    val bestSplits = DecisionTree.findBestSplits(inputWithFeatures2bin, new Array(31), strategy, 0,
       Array[List[Filter]](), splits, bins, 10)
 
     assert(bestSplits.length === 1)
@@ -757,7 +790,10 @@ class DecisionTreeSuite extends FunSuite with LocalSparkContext {
       numClassesForClassification = 3, categoricalFeaturesInfo = Map(0 -> 10, 1 -> 10))
     assert(strategy.isMulticlassClassification)
     val (splits, bins) = DecisionTree.findSplitsBins(input, strategy)
-    val bestSplits = DecisionTree.findBestSplits(input, new Array(31), strategy, 0,
+    val numBins = bins(0).length
+    val numFeatures = input.take(1)(0).features.size
+    val inputWithFeatures2bin = input.map(DecisionTree.findFeature2Bin(numFeatures, numBins, bins, strategy))
+    val bestSplits = DecisionTree.findBestSplits(inputWithFeatures2bin, new Array(31), strategy, 0,
       Array[List[Filter]](), splits, bins, 10)
 
     assert(bestSplits.length === 1)


### PR DESCRIPTION
`findbinsForLevel` is applied to every `LabeledPoint` to find bins for all nodes at a given level. Given a specific `LabeledPoint` and a specific feature, the bin to put this labeled point should always be same.But in current implementation, `findBin` on a (labeledpoint, feature) pair is called for all nodes and all levels, which is a waste of computation.

In my implementation, `findBin` for each (labeledpoint, feature) pair is executed only once before the start of level-wise training of decision tree. Then, at each level, this `feature2bin` array can be reused.

What's more, `findbinsForLevel` now return a array of smaller size, all the nodes on which this labeledPoint is valid share the same `feature2bin` array, instead of each node having a copy of it.

CC: @mengxr @manishamde @jkbradley,  Please have a look at this, thanks.
