### PR TITLE
[SPARK-3026][SQL] Report better error message when running JDBC/CLI without hive profile enabled

### DIFF
--- a/bin/spark-sql
+++ b/bin/spark-sql
@@ -76,7 +76,7 @@ while (($#)); do
       CLI_ARGS+=("$1"); shift
       ;;
 
-    -s | --silent)
+    -S | --silent)
       CLI_ARGS+=("$1"); shift
       ;;
 

--- a/bin/spark-sql
+++ b/bin/spark-sql
@@ -92,7 +92,7 @@ while (($#)); do
   esac
 done
 
-eval "$FWDIR"/bin/spark-submit --class $CLASS ${SUBMISSION_ARGS[*]} spark-internal ${CLI_ARGS[*]}
+"$FWDIR"/bin/spark-submit --class $CLASS "${SUBMISSION_ARGS[@]}" spark-internal "${CLI_ARGS[@]}"
 exit_status=$?
 
 if [[ exit_status -eq CLASS_NOT_FOUND_EXIT_STATUS ]]; then

--- a/bin/spark-sql
+++ b/bin/spark-sql
@@ -24,6 +24,7 @@
 set -o posix
 
 CLASS="org.apache.spark.sql.hive.thriftserver.SparkSQLCLIDriver"
+CLASS_NOT_FOUND_EXIT_STATUS=1
 
 # Figure out where Spark is installed
 FWDIR="$(cd `dirname $0`/..; pwd)"
@@ -91,4 +92,13 @@ while (($#)); do
   esac
 done
 
-exec "$FWDIR"/bin/spark-submit --class $CLASS "${SUBMISSION_ARGS[@]}" spark-internal "${CLI_ARGS[@]}"
+eval "$FWDIR"/bin/spark-submit --class $CLASS ${SUBMISSION_ARGS[*]} spark-internal ${CLI_ARGS[*]}
+exit_status=$?
+
+if [[ exit_status -eq CLASS_NOT_FOUND_EXIT_STATUS ]]; then
+  echo
+  echo "Failed to load Spark SQL CLI main class $CLASS."
+  echo "You need to build Spark with -Phive."
+fi
+
+exit $exit_status

--- a/sbin/start-thriftserver.sh
+++ b/sbin/start-thriftserver.sh
@@ -27,6 +27,7 @@ set -o posix
 FWDIR="$(cd `dirname $0`/..; pwd)"
 
 CLASS="org.apache.spark.sql.hive.thriftserver.HiveThriftServer2"
+CLASS_NOT_FOUND_EXIT_STATUS=1
 
 function usage {
   echo "Usage: ./sbin/start-thriftserver [options] [thrift server options]"
@@ -75,4 +76,13 @@ while (($#)); do
   esac
 done
 
-exec "$FWDIR"/bin/spark-submit --class $CLASS "${SUBMISSION_ARGS[@]}" spark-internal "${THRIFT_SERVER_ARGS[@]}"
+eval "$FWDIR"/bin/spark-submit --class $CLASS ${SUBMISSION_ARGS[*]} spark-internal ${THRIFT_SERVER_ARGS[*]}
+exit_status=$?
+
+if [[ exit_status -eq CLASS_NOT_FOUND_EXIT_STATUS ]]; then
+  echo
+  echo "Failed to load Hive Thrift server main class $CLASS."
+  echo "You need to build Spark with -Phive."
+fi
+
+exit $exit_status

--- a/sbin/start-thriftserver.sh
+++ b/sbin/start-thriftserver.sh
@@ -76,7 +76,7 @@ while (($#)); do
   esac
 done
 
-eval "$FWDIR"/bin/spark-submit --class $CLASS ${SUBMISSION_ARGS[*]} spark-internal ${THRIFT_SERVER_ARGS[*]}
+"$FWDIR"/bin/spark-submit --class $CLASS "${SUBMISSION_ARGS[@]}" spark-internal "${THRIFT_SERVER_ARGS[@]}"
 exit_status=$?
 
 if [[ exit_status -eq CLASS_NOT_FOUND_EXIT_STATUS ]]; then

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suite.scala
@@ -72,11 +72,10 @@ class HiveThriftServer2Suite extends FunSuite with BeforeAndAfterAll with TestUt
        """.stripMargin.split("\\s+")
 
     val pb = new ProcessBuilder(command ++ args: _*)
-    val environment = pb.environment()
     process = pb.start()
     inputReader = new BufferedReader(new InputStreamReader(process.getInputStream))
     errorReader = new BufferedReader(new InputStreamReader(process.getErrorStream))
-    waitForOutput(inputReader, "ThriftBinaryCLIService listening on", 300000)
+    waitForOutput(inputReader, "ThriftBinaryCLIService listening on", 30000)
 
     // Spawn a thread to read the output from the forked process.
     // Note that this is necessary since in some configurations, log4j could be blocked


### PR DESCRIPTION
This PR tries to catch `ClassNotFoundException` within `SparkSubmit` and exit with a special status code. Then we check the exit status within scripts to provide more friendly error message.
