### PR TITLE
[SPARK-3047] [PySpark] add an option to use str in textFileRDD

### DIFF
--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -320,6 +320,10 @@ class SparkContext(object):
         nodes), or any Hadoop-supported file system URI, and return it as an
         RDD of Strings.
 
+        If use_unicode is False, the strings will be kept as `str` (encoding
+        as `utf-8`), which is faster and smaller than unicode. (Added in
+        Spark 1.1)
+
         >>> path = os.path.join(tempdir, "sample-text.txt")
         >>> with open(path, "w") as testFile:
         ...    testFile.write("Hello world!")
@@ -338,6 +342,10 @@ class SparkContext(object):
         URI. Each file is read as a single record and returned in a
         key-value pair, where the key is the path of each file, the
         value is the content of each file.
+
+        If use_unicode is False, the strings will be kept as `str` (encoding
+        as `utf-8`), which is faster and smaller than unicode. (Added in
+        Spark 1.1)
 
         For example, if you have the following files::
 

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -314,7 +314,7 @@ class SparkContext(object):
         return RDD(self._jsc.objectFile(name, minPartitions), self,
                    BatchedSerializer(PickleSerializer()))
 
-    def textFile(self, name, minPartitions=None):
+    def textFile(self, name, minPartitions=None, use_unicode=True):
         """
         Read a text file from HDFS, a local file system (available on all
         nodes), or any Hadoop-supported file system URI, and return it as an
@@ -329,9 +329,9 @@ class SparkContext(object):
         """
         minPartitions = minPartitions or min(self.defaultParallelism, 2)
         return RDD(self._jsc.textFile(name, minPartitions), self,
-                   UTF8Deserializer())
+                   UTF8Deserializer(use_unicode))
 
-    def wholeTextFiles(self, path, minPartitions=None):
+    def wholeTextFiles(self, path, minPartitions=None, use_unicode=True):
         """
         Read a directory of text files from HDFS, a local file system
         (available on all nodes), or any  Hadoop-supported file system
@@ -369,7 +369,7 @@ class SparkContext(object):
         """
         minPartitions = minPartitions or self.defaultMinPartitions
         return RDD(self._jsc.wholeTextFiles(path, minPartitions), self,
-                   PairDeserializer(UTF8Deserializer(), UTF8Deserializer()))
+                   PairDeserializer(UTF8Deserializer(use_unicode), UTF8Deserializer(use_unicode)))
 
     def _dictToJavaMap(self, d):
         jm = self._jvm.java.util.HashMap()

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -322,7 +322,7 @@ class SparkContext(object):
 
         If use_unicode is False, the strings will be kept as `str` (encoding
         as `utf-8`), which is faster and smaller than unicode. (Added in
-        Spark 1.1)
+        Spark 1.2)
 
         >>> path = os.path.join(tempdir, "sample-text.txt")
         >>> with open(path, "w") as testFile:
@@ -345,7 +345,7 @@ class SparkContext(object):
 
         If use_unicode is False, the strings will be kept as `str` (encoding
         as `utf-8`), which is faster and smaller than unicode. (Added in
-        Spark 1.1)
+        Spark 1.2)
 
         For example, if you have the following files::
 

--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -412,15 +412,15 @@ class UTF8Deserializer(Serializer):
     def __init__(self, use_unicode=False):
         self.use_unicode = use_unicode
 
+    def loads(self, stream):
+        length = read_int(stream)
+        s = stream.read(length)
+        return s.decode("utf-8") if self.use_unicode else s
+
     def load_stream(self, stream):
         try:
-            _read_int = read_int  # faster than global lookup
-            if self.use_unicode:
-                while True:
-                    yield stream.read(_read_int(stream)).decode("utf-8")
-            else:
-                while True:
-                    yield stream.read(_read_int(stream))
+            while True:
+                yield self.loads(stream)
         except struct.error:
             return
         except EOFError:

--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -409,18 +409,25 @@ class UTF8Deserializer(Serializer):
     Deserializes streams written by String.getBytes.
     """
 
+    def __init__(self, use_unicode=False):
+        self.use_unicode = use_unicode
+
     def loads(self, stream):
         length = read_int(stream)
-        return stream.read(length).decode('utf8')
+        return stream.read(length)
 
     def load_stream(self, stream):
-        while True:
-            try:
-                yield self.loads(stream)
-            except struct.error:
-                return
-            except EOFError:
-                return
+        try:
+            if self.use_unicode:
+                while True:
+                    yield self.loads(stream).decode("utf-8")
+            else:
+                while True:
+                    yield self.loads(stream)
+        except struct.error:
+            return
+        except EOFError:
+            return
 
 
 def read_long(stream):

--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -412,18 +412,15 @@ class UTF8Deserializer(Serializer):
     def __init__(self, use_unicode=False):
         self.use_unicode = use_unicode
 
-    def loads(self, stream):
-        length = read_int(stream)
-        return stream.read(length)
-
     def load_stream(self, stream):
         try:
+            _read_int = read_int  # faster than global lookup
             if self.use_unicode:
                 while True:
-                    yield self.loads(stream).decode("utf-8")
+                    yield stream.read(_read_int(stream)).decode("utf-8")
             else:
                 while True:
-                    yield self.loads(stream)
+                    yield stream.read(_read_int(stream))
         except struct.error:
             return
         except EOFError:


### PR DESCRIPTION
str is much efficient than unicode (both CPU and memory), it'e better to use str in textFileRDD. In order to keep compatibility, use unicode by default. (Maybe change it in the future).

use_unicode=True:

daviesliu@dm:~/work/spark$ time python wc.py
(u'./universe/spark/sql/core/target/java/org/apache/spark/sql/execution/ExplainCommand$.java', 7776)

real    2m8.298s
user    0m0.185s
sys 0m0.064s

use_unicode=False

daviesliu@dm:~/work/spark$ time python wc.py
('./universe/spark/sql/core/target/java/org/apache/spark/sql/execution/ExplainCommand$.java', 7776)

real    1m26.402s
user    0m0.182s
sys 0m0.062s

We can see that it got 32% improvement!
