### PR TITLE
Use user defined $SPARK_HOME in spark-submit if possible

### DIFF
--- a/bin/run-example
+++ b/bin/run-example
@@ -20,7 +20,7 @@
 SCALA_VERSION=2.10
 
 FWDIR="$(cd `dirname $0`/..; pwd)"
-export SPARK_HOME="$FWDIR"
+export SPARK_HOME=${SPARK_HOME:-"$FWDIR"}
 EXAMPLES_DIR="$FWDIR"/examples
 
 if [ -n "$1" ]; then

--- a/bin/spark-submit
+++ b/bin/spark-submit
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-export SPARK_HOME="$(cd `dirname $0`/..; pwd)"
+export SPARK_HOME=${SPARK_HOME:-"$(cd `dirname $0`/..; pwd)"}
 ORIG_ARGS=("$@")
 
 while (($#)); do


### PR DESCRIPTION
This is useful when $SPARK_HOME of the submission machine is not the same as the slave machinese, eg. when running with Mesos.
