### PR TITLE
[SPARK-3038] delete history server logs automatically when there are too many logs

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -34,7 +34,8 @@ private[history] class FsHistoryProvider(conf: SparkConf) extends ApplicationHis
   // Interval between each check for event log updates
   private val UPDATE_INTERVAL_MS = conf.getInt("spark.history.fs.updateInterval",
     conf.getInt("spark.history.updateInterval", 10)) * 1000
-
+  private val maxApplicationEnabled = conf.getBoolean("spark.history.deletelogs.enable", false)
+  private val maxSavedApplication = conf.getInt("spark.history.fs.maxsavedapplication", 50)
   private val logDir = conf.get("spark.history.fs.logDirectory", null)
   private val resolvedLogDir = Option(logDir)
     .map { d => Utils.resolveURI(d) }
@@ -116,7 +117,14 @@ private[history] class FsHistoryProvider(conf: SparkConf) extends ApplicationHis
     logDebug("Checking for logs. Time is now %d.".format(lastLogCheckTimeMs))
     try {
       val logStatus = fs.listStatus(new Path(resolvedLogDir))
-      val logDirs = if (logStatus != null) logStatus.filter(_.isDir).toSeq else Seq[FileStatus]()
+      var logDirs = if (logStatus != null) logStatus.filter(_.isDir).toSeq else Seq[FileStatus]()
+      if(maxApplicationEnabled && logDirs.size > maxSavedApplication) {
+        val apps = logDirs.sortBy(dir => -getModificationTime(dir))
+        val deleteApps = apps.takeRight(logDirs.size - maxSavedApplication);
+        deleteApps.foreach(x => fs.delete(x.getPath, true))
+        logDirs = fs.listStatus(new Path(logDir))
+      }
+
       val logInfos = logDirs.filter { dir =>
         fs.isFile(new Path(dir.getPath, EventLoggingListener.APPLICATION_COMPLETE))
       }

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -808,7 +808,6 @@ private[spark] object Utils extends Logging {
     }
     stdoutThread.start()
     val exitCode = process.waitFor()
-
     stdoutThread.join()   // Wait for it to finish reading output
     if (exitCode != 0) {
       throw new SparkException("Process " + command + " exited with code " + exitCode)

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -808,6 +808,7 @@ private[spark] object Utils extends Logging {
     }
     stdoutThread.start()
     val exitCode = process.waitFor()
+
     stdoutThread.join()   // Wait for it to finish reading output
     if (exitCode != 0) {
       throw new SparkException("Process " + command + " exited with code " + exitCode)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-3038
enhance history server to delete logs automatically
1 use spark.history.deletelogs.enable to enable this function
2 when app logs num is greater than spark.history.maxsavedapplication, delete the older logs
