### PR TITLE
[SPARK-3083] fix unnecessarily removing sendingConnection when closing connections

### DIFF
--- a/core/src/main/scala/org/apache/spark/network/Connection.scala
+++ b/core/src/main/scala/org/apache/spark/network/Connection.scala
@@ -118,6 +118,7 @@ abstract class Connection(val channel: SocketChannel, val selector: Selector,
   }
 
   def close() {
+    callOnCloseCallback()
     closed = true
     val k = key()
     if (k != null) {
@@ -125,7 +126,6 @@ abstract class Connection(val channel: SocketChannel, val selector: Selector,
     }
     channel.close()
     disposeSasl()
-    callOnCloseCallback()
   }
 
   protected def isClosed: Boolean = closed

--- a/core/src/main/scala/org/apache/spark/network/ConnectionManager.scala
+++ b/core/src/main/scala/org/apache/spark/network/ConnectionManager.scala
@@ -466,29 +466,16 @@ private[spark] class ConnectionManager(
 
           val sendingConnectionOpt = connectionsById.get(remoteConnectionManagerId)
           if (!sendingConnectionOpt.isDefined) {
-            logError("Corresponding SendingConnectionManagerId not found")
+            logWarning("Corresponding SendingConnectionManagerId not found, maybe removed in advance")
             return
           }
 
           val sendingConnection = sendingConnectionOpt.get
-          connectionsById -= remoteConnectionManagerId
-          sendingConnection.close()
-
           val sendingConnectionManagerId = sendingConnection.getRemoteConnectionManagerId()
 
           assert(sendingConnectionManagerId == remoteConnectionManagerId)
 
-          messageStatuses.synchronized {
-            for (s <- messageStatuses.values
-                 if s.connectionManagerId == sendingConnectionManagerId) {
-              logInfo("Notifying " + s)
-              s.markDone(None)
-            }
-
-            messageStatuses.retain((i, status) => {
-              status.connectionManagerId != sendingConnectionManagerId
-            })
-          }
+          sendingConnection.close()
         case _ => logError("Unsupported type of connection.")
       }
     } finally {


### PR DESCRIPTION
Currently in `ConnectionManager`, when a `ReceivingConnection` is closing, the corresponding `SendingConnection` would be removed twice. It causes unnecessary errors when removing `sendingConnectionManagerId` from `connectionsById`. There are also redundant codes in the implementation.
