### PR TITLE
SPARK-2881. Upgrade snappy-java to 1.1.1.3.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@
       <dependency>
         <groupId>org.xerial.snappy</groupId>
         <artifactId>snappy-java</artifactId>
-        <version>1.0.5</version>
+        <version>1.1.1.3</version>
       </dependency>
       <dependency>
         <groupId>net.jpountz.lz4</groupId>


### PR DESCRIPTION
This upgrades snappy-java which fixes the issue reported in SPARK-2881.
This is the master branch equivalent to #1994 which provides a different
work-around for the 1.1 branch.
