### PR TITLE
[SQL] add note of use synchronizedMap in SQLConf

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
@@ -50,8 +50,9 @@ private[spark] object SQLConf {
 trait SQLConf {
   import SQLConf._
 
-  @transient protected[spark] val settings =
-    new java.util.concurrent.ConcurrentHashMap[String, String]
+  /** Only low degree of contention is expected for conf, thus NOT using ConcurrentHashMap. */
+  @transient protected[spark] val settings = java.util.Collections.synchronizedMap(
+    new java.util.HashMap[String, String]())
 
   /** ************************ Spark SQL Params/Hints ******************* */
   // TODO: refactor so that these hints accessors don't pollute the name space of SQLContext?

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
@@ -50,8 +50,8 @@ private[spark] object SQLConf {
 trait SQLConf {
   import SQLConf._
 
-  @transient protected[spark] val settings = java.util.Collections.synchronizedMap(
-    new java.util.HashMap[String, String]())
+  @transient protected[spark] val settings =
+    new java.util.concurrent.ConcurrentHashMap[String, String]
 
   /** ************************ Spark SQL Params/Hints ******************* */
   // TODO: refactor so that these hints accessors don't pollute the name space of SQLContext?

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -473,7 +473,7 @@ class HiveQuerySuite extends HiveComparisonTest {
 
     sql(s"SET ${testKey + testKey}=${testVal + testVal}")
     assert(hiveconf.get(testKey + testKey, "") == testVal + testVal)
-    assertResult(Array(s"${testKey + testKey}=${testVal + testVal}", s"$testKey=$testVal")) {
+    assertResult(Array(s"$testKey=$testVal", s"${testKey + testKey}=${testVal + testVal}")) {
       sql(s"SET").collect().map(_.getString(0))
     }
 
@@ -501,7 +501,7 @@ class HiveQuerySuite extends HiveComparisonTest {
 
     sql(s"SET ${testKey + testKey}=${testVal + testVal}")
     assert(hiveconf.get(testKey + testKey, "") == testVal + testVal)
-    assertResult(Array(s"${testKey + testKey}=${testVal + testVal}", s"$testKey=$testVal")) {
+    assertResult(Array(s"$testKey=$testVal", s"${testKey + testKey}=${testVal + testVal}")) {
       sql("SET").collect().map(_.getString(0))
     }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -473,7 +473,7 @@ class HiveQuerySuite extends HiveComparisonTest {
 
     sql(s"SET ${testKey + testKey}=${testVal + testVal}")
     assert(hiveconf.get(testKey + testKey, "") == testVal + testVal)
-    assertResult(Array( s"${testKey + testKey}=${testVal + testVal}", s"$testKey=$testVal")) {
+    assertResult(Array(s"${testKey + testKey}=${testVal + testVal}", s"$testKey=$testVal")) {
       sql(s"SET").collect().map(_.getString(0))
     }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -473,7 +473,7 @@ class HiveQuerySuite extends HiveComparisonTest {
 
     sql(s"SET ${testKey + testKey}=${testVal + testVal}")
     assert(hiveconf.get(testKey + testKey, "") == testVal + testVal)
-    assertResult(Array(s"$testKey=$testVal", s"${testKey + testKey}=${testVal + testVal}")) {
+    assertResult(Array( s"${testKey + testKey}=${testVal + testVal}", s"$testKey=$testVal")) {
       sql(s"SET").collect().map(_.getString(0))
     }
 
@@ -501,7 +501,7 @@ class HiveQuerySuite extends HiveComparisonTest {
 
     sql(s"SET ${testKey + testKey}=${testVal + testVal}")
     assert(hiveconf.get(testKey + testKey, "") == testVal + testVal)
-    assertResult(Array(s"$testKey=$testVal", s"${testKey + testKey}=${testVal + testVal}")) {
+    assertResult(Array(s"${testKey + testKey}=${testVal + testVal}", s"$testKey=$testVal")) {
       sql("SET").collect().map(_.getString(0))
     }
 


### PR DESCRIPTION
Refer to:
http://stackoverflow.com/questions/510632/whats-the-difference-between-concurrenthashmap-and-collections-synchronizedmap
Collections.synchronizedMap(map) creates a blocking Map which will degrade performance, albeit ensure consistency. So use ConcurrentHashMap(a more effective thread-safe hashmap) instead.

also update HiveQuerySuite to fix test error when changed to ConcurrentHashMap.
