### PR TITLE
[SPARK-3088] fix noisy messages when run tests

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -794,7 +794,6 @@ private[spark] object Utils extends Logging {
     new Thread("read stderr for " + command(0)) {
       override def run() {
         for (line <- Source.fromInputStream(process.getErrorStream).getLines) {
-          System.err.println(line)
         }
       }
     }.start()


### PR DESCRIPTION
There are quite noisy messages when jekins run tests with maven or sbt. For example , see from this link:
https://amplab.cs.berkeley.edu/jenkins/job/SparkPullRequestBuilder/18688/consoleFull

It print flowing messages repeatedly， really noisy
"Spark assembly has been built with Hive, including Datanucleus jars on classpath
Spark assembly has been built with Hive, including Datanucleus jars on classpath
Spark assembly has been built with Hive, including Datanucleus jars on classpath"
