### PR TITLE
SPARK-2881: Upgrade to Snappy 1.0.5.3 to avoid SPARK-2881.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -315,7 +315,7 @@
       <dependency>
         <groupId>org.xerial.snappy</groupId>
         <artifactId>snappy-java</artifactId>
-        <version>1.0.5</version>
+        <version>1.0.5.3</version>
       </dependency>
       <dependency>
         <groupId>net.jpountz.lz4</groupId>


### PR DESCRIPTION
This version of Snappy was released with a backported fix specifically
for Spark. This fixes an issue where names collide in the snappy .so
file when users are submitting jobs as different users on the same
cluster.
