### PR TITLE
[SPARK-3091] [SQL] Add support for caching metadata on Parquet files

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
@@ -32,6 +32,7 @@ private[spark] object SQLConf {
   val CODEGEN_ENABLED = "spark.sql.codegen"
   val DIALECT = "spark.sql.dialect"
   val PARQUET_BINARY_AS_STRING = "spark.sql.parquet.binaryAsString"
+  val PARQUET_CACHE_METADATA = "spark.sql.parquet.cacheMetadata"
 
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"

--- a/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetTableOperations.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetTableOperations.scala
@@ -330,7 +330,7 @@ private[parquet] class FilteringParquetRowInputFormat
       val toFetch = new ArrayList[FileStatus]
       footerCache.synchronized {
         for (status <- statuses) {
-          if (!footerCache.contains(status)) {
+          if (footerCache.contains(status)) {
             footers.add(footerCache(status))
           } else {
             footers.add(null)
@@ -348,7 +348,7 @@ private[parquet] class FilteringParquetRowInputFormat
         var i = 0
         var j = 0
         while (i < toFetch.size) {
-          while (statuses(j) ne toFetch.get(i)) {
+          while (statuses.get(j) ne toFetch.get(i)) {
             j += 1
           }
           footers(j) = fetched(i)

--- a/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetTableOperations.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetTableOperations.scala
@@ -353,10 +353,10 @@ private[parquet] class FilteringParquetRowInputFormat
         val newFooters = new mutable.HashMap[FileStatus, Footer]
         if (toFetch.size > 0) {
           val fetched = getFooters(conf, toFetch)
-          for ((footer, i) <- fetched.zipWithIndex) {
-            newFooters(statuses.get(i)) = footer
-            footerCache.putAll(newFooters)
+          for ((status, i) <- toFetch.zipWithIndex) {
+            newFooters(status) = fetched.get(i)
           }
+          footerCache.putAll(newFooters)
         }
         footers = new ArrayList[Footer](statuses.size)
         for (status <- statuses) {


### PR DESCRIPTION
For larger Parquet files, reading the file footers (which is done in parallel on up to 5 threads) and HDFS block locations (which is serial) can take multiple seconds. We can add an option to cache this data within FilteringParquetInputFormat. Unfortunately ParquetInputFormat only caches footers within each instance of ParquetInputFormat, not across them.

Note: this PR leaves this turned off by default for 1.1, but I believe it's safe to turn it on after. The keys in the hash maps are FileStatus objects that include a modification time, so this will work fine if files are modified. The location cache could become invalid if files have moved within HDFS, but that's rare so I just made it invalidate entries every 15 minutes.
