### PR TITLE
SPARK-3096: Include parquet hive serde by default in build

### DIFF
--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -37,6 +37,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.twitter</groupId>
+      <artifactId>parquet-hive-bundle</artifactId>
+      <version>1.5.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
       <version>${project.version}</version>


### PR DESCRIPTION
A small change - we should just add this dependency. It doesn't have any recursive deps and it's needed for reading have parquet tables.
