### PR TITLE
[SPARK-3110][YARN] Add a "ha" mode in YARN mode to keep executors in bet...

### DIFF
--- a/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
@@ -41,6 +41,7 @@ class ClientArguments(val args: Array[String], val sparkConf: SparkConf) {
   var appName: String = "Spark"
   var inputFormatInfo: List[InputFormatInfo] = null
   var priority = 0
+  var ha: Boolean = false
 
   parseArgs(args.toList)
 
@@ -132,6 +133,10 @@ class ClientArguments(val args: Array[String], val sparkConf: SparkConf) {
 
         case ("--archives") :: value :: tail =>
           archives = value
+          args = tail
+
+        case ("--ha") :: value :: tail =>
+          ha = true
           args = tail
 
         case Nil =>

--- a/yarn/stable/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/stable/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -49,6 +49,8 @@ class Client(clientArgs: ClientArguments, hadoopConf: Configuration, spConf: Spa
   val sparkConf = spConf
   var rpc: YarnRPC = YarnRPC.create(conf)
   val yarnConf: YarnConfiguration = new YarnConfiguration(conf)
+  val maxAppAttempts = conf.getInt(
+    YarnConfiguration.RM_AM_MAX_ATTEMPTS, YarnConfiguration.DEFAULT_RM_AM_MAX_ATTEMPTS)
 
   def runApp(): ApplicationId = {
     validateArgs()
@@ -81,6 +83,10 @@ class Client(clientArgs: ClientArguments, hadoopConf: Configuration, spConf: Spa
     appContext.setQueue(args.amQueue)
     appContext.setAMContainerSpec(amContainer)
     appContext.setApplicationType("SPARK")
+    if (args.ha) {
+      appContext.setMaxAppAttempts(maxAppAttempts) // Set to max app attempts
+      appContext.setKeepContainersAcrossApplicationAttempts(true)
+    }
 
     // Memory for the ApplicationMaster.
     val memoryResource = Records.newRecord(classOf[Resource]).asInstanceOf[Resource]

--- a/yarn/stable/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/stable/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -88,9 +88,9 @@ class Client(clientArgs: ClientArguments, hadoopConf: Configuration, spConf: Spa
     if (args.ha) {
       Try {
         appContext.getClass.getMethod("setMaxAppAttempts", Integer.TYPE)
-          .invoke(appContext, maxAppAttempts)
+          .invoke(appContext, new Object{maxAppAttempts})
         appContext.getClass.getMethod("setKeepContainersAcrossApplicationAttempts",
-          java.lang.Boolean.TYPE).invoke(appContext, true)
+          java.lang.Boolean.TYPE).invoke(appContext, new Object{true})
       }.recover {
         case e: Exception =>
           logWarning("setMaxAttempts and setKeepContainersAcrossApplicationAttempts is not " +

--- a/yarn/stable/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/stable/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -88,9 +88,9 @@ class Client(clientArgs: ClientArguments, hadoopConf: Configuration, spConf: Spa
     if (args.ha) {
       Try {
         appContext.getClass.getMethod("setMaxAppAttempts", Integer.TYPE)
-          .invoke(appContext, new Object{maxAppAttempts})
+          .invoke(appContext, maxAppAttempts: java.lang.Integer)
         appContext.getClass.getMethod("setKeepContainersAcrossApplicationAttempts",
-          java.lang.Boolean.TYPE).invoke(appContext, new Object{true})
+          java.lang.Boolean.TYPE).invoke(appContext, true: java.lang.Boolean)
       }.recover {
         case e: Exception =>
           logWarning("setMaxAttempts and setKeepContainersAcrossApplicationAttempts is not " +


### PR DESCRIPTION
...ween restarts.

This patch takes an additional argument from the user and tells YARN to restart the AM if it dies and
also keep the same executors around for the restart attempts.
