### PR TITLE
[SPARK-2873] [SQL] using ExternalAppendOnlyMap to resolve OOM when aggregating

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/AggregatesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/AggregatesSuite.scala
@@ -1,0 +1,86 @@
+package org.apache.spark.sql.catalyst.expressions
+
+import org.scalatest.FunSuite
+import org.apache.spark.sql.catalyst.types._
+import org.apache.spark.sql.catalyst.dsl.expressions._
+
+
+class AggregatesSuite extends FunSuite {
+
+  val testRows = Seq(1, 1, 2, 2, 3, 3, 4, 4).map(x => {
+    val row = new GenericMutableRow(1)
+    row(0) = x
+    row
+  })
+
+  val dataType: DataType = IntegerType
+  val exp = BoundReference(0, dataType, true)
+
+  /**
+   * ensure whether all merge functions in aggregates have correct output
+   * according to the output between update and merge
+   */
+  def checkMethod(f: AggregateExpression) = {
+    val combiner = f.newInstance()
+    val combiner1 = f.newInstance()
+    val combiner2 = f.newInstance()
+
+    //merge each row of testRow twice into combiner
+    testRows.map(combiner.update(_))
+    testRows.map(combiner.update(_))
+
+    //merge each row of testRow into combiner1
+    testRows.map(combiner1.update(_))
+
+    //merge each row of testRow into combiner2
+    testRows.map(combiner2.update(_))
+
+    //merge combiner1 and combiner2 into combiner1
+    combiner1.merge(combiner2)
+
+    val r1 = combiner.eval(EmptyRow)
+    val r2 = combiner1.eval(EmptyRow)
+
+    //check the output between the up two ways
+    assert(r1 == r2, "test suite failed")
+  }
+
+  test("max merge test") {
+    checkMethod(max(exp))
+  }
+
+  test("min merge test") {
+    checkMethod(min(exp))
+  }
+
+  test("sum merge test") {
+    checkMethod(sum(exp))
+  }
+
+  test("count merge test") {
+    checkMethod(count(exp))
+  }
+
+  test("avg merge test") {
+    checkMethod(avg(exp))
+  }
+
+  test("sum distinct merge test") {
+    checkMethod(sumDistinct(exp))
+  }
+
+  test("count distinct merge test") {
+    checkMethod(countDistinct(exp))
+  }
+
+  test("first merge test") {
+    checkMethod(first(exp))
+  }
+
+  //this test case seems wrong
+  //it does not check ApproxCountDistinctPartitionFunction and ApproxCountDistinctMergeFunction
+  test("approx count distinct merge test") {
+    checkMethod(approxCountDistinct(exp))
+  }
+
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
@@ -29,6 +29,7 @@ private[spark] object SQLConf {
   val AUTO_BROADCASTJOIN_THRESHOLD = "spark.sql.autoBroadcastJoinThreshold"
   val DEFAULT_SIZE_IN_BYTES = "spark.sql.defaultSizeInBytes"
   val SHUFFLE_PARTITIONS = "spark.sql.shuffle.partitions"
+  val EXTERNAL_AGGREGATE = "spark.sql.aggregate.external"
   val CODEGEN_ENABLED = "spark.sql.codegen"
   val DIALECT = "spark.sql.dialect"
   val PARQUET_BINARY_AS_STRING = "spark.sql.parquet.binaryAsString"
@@ -82,6 +83,13 @@ trait SQLConf {
 
   /** Number of partitions to use for shuffle operators. */
   private[spark] def numShufflePartitions: Int = getConf(SHUFFLE_PARTITIONS, "200").toInt
+
+  /**
+   * When set to true, Spark SQL will use ExternalAggregation.
+   * Defaults to false will use OnHeapAggregation
+   */
+  private[spark] def externalAggregate: Boolean =
+    if (getConf(EXTERNAL_AGGREGATE, "false") == "true") true else false
 
   /**
    * When set to true, Spark SQL will use the Scala compiler at runtime to generate custom bytecode

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/Aggregate.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/Aggregate.scala
@@ -25,25 +25,30 @@ import org.apache.spark.sql.catalyst.errors._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.SQLContext
+import org.apache.spark.util.collection.{CompactBuffer, ExternalAppendOnlyMap}
 
 /**
- * :: DeveloperApi ::
  * Groups input data by `groupingExpressions` and computes the `aggregateExpressions` for each
  * group.
  *
- * @param partial if true then aggregation is done partially on local data without shuffling to
- *                ensure all values where `groupingExpressions` are equal are present.
- * @param groupingExpressions expressions that are evaluated to determine grouping.
- * @param aggregateExpressions expressions that are computed for each group.
- * @param child the input data source.
+ *  - If true then aggregation is done partially on local data without shuffling to
+ *    ensure all values where `groupingExpressions` are equal are present.
+ *  - Expressions that are evaluated to determine grouping.
+ *  - Expressions that are computed for each group.
+ *  - The input data source.
  */
-@DeveloperApi
-case class Aggregate(
-    partial: Boolean,
-    groupingExpressions: Seq[Expression],
-    aggregateExpressions: Seq[NamedExpression],
-    child: SparkPlan)
-  extends UnaryNode {
+trait Aggregate{
+
+  self: SparkPlan =>
+
+  /** If true then aggregation is done partially on local data without shuffling to */
+  val partial: Boolean
+  /** Expressions that are evaluated to determine grouping */
+  val groupingExpressions: Seq[Expression]
+  /** Expressions that are computed for each group */
+  val aggregateExpressions: Seq[NamedExpression]
+  /** The input data source */
+  val child: SparkPlan
 
   override def requiredChildDistribution =
     if (partial) {
@@ -58,7 +63,7 @@ case class Aggregate(
 
   // HACK: Generators don't correctly preserve their output through serializations so we grab
   // out child's output attributes statically here.
-  private[this] val childOutput = child.output
+  protected[this] val childOutput = child.output
 
   override def output = aggregateExpressions.map(_.toAttribute)
 
@@ -76,7 +81,7 @@ case class Aggregate(
       resultAttribute: AttributeReference)
 
   /** A list of aggregates that need to be computed for each group. */
-  private[this] val computedAggregates = aggregateExpressions.flatMap { agg =>
+  protected[this] val computedAggregates = aggregateExpressions.flatMap { agg =>
     agg.collect {
       case a: AggregateExpression =>
         ComputedAggregate(
@@ -87,21 +92,21 @@ case class Aggregate(
   }.toArray
 
   /** The schema of the result of all aggregate evaluations */
-  private[this] val computedSchema = computedAggregates.map(_.resultAttribute)
+  protected[this] val computedSchema = computedAggregates.map(_.resultAttribute)
 
   /** Creates a new aggregate buffer for a group. */
-  private[this] def newAggregateBuffer(): Array[AggregateFunction] = {
-    val buffer = new Array[AggregateFunction](computedAggregates.length)
+  protected[this] def newAggregateBuffer(): CompactBuffer[AggregateFunction] = {
+    val buffer = new CompactBuffer[AggregateFunction]
     var i = 0
     while (i < computedAggregates.length) {
-      buffer(i) = computedAggregates(i).aggregate.newInstance()
+      buffer += computedAggregates(i).aggregate.newInstance()
       i += 1
     }
     buffer
   }
 
   /** Named attributes used to substitute grouping attributes into the final result. */
-  private[this] val namedGroups = groupingExpressions.map {
+  protected[this] val namedGroups = groupingExpressions.map {
     case ne: NamedExpression => ne -> ne.toAttribute
     case e => e -> Alias(e, s"groupingExpr:$e")().toAttribute
   }
@@ -117,40 +122,52 @@ case class Aggregate(
    * Substituted version of aggregateExpressions expressions which are used to compute final
    * output rows given a group and the result of all aggregate computations.
    */
-  private[this] val resultExpressions = aggregateExpressions.map { agg =>
+  protected[this] val resultExpressions = aggregateExpressions.map { agg =>
     agg.transform {
       case e: Expression if resultMap.contains(e) => resultMap(e)
     }
   }
 
-  override def execute() = attachTree(this, "execute") {
-    if (groupingExpressions.isEmpty) {
-      child.execute().mapPartitions { iter =>
-        val buffer = newAggregateBuffer()
-        var currentRow: Row = null
-        while (iter.hasNext) {
-          currentRow = iter.next()
-          var i = 0
-          while (i < buffer.length) {
-            buffer(i).update(currentRow)
-            i += 1
-          }
-        }
-        val resultProjection = new InterpretedProjection(resultExpressions, computedSchema)
-        val aggregateResults = new GenericMutableRow(computedAggregates.length)
-
+  protected[this] def aggregateNoGrouping() = {
+    child.execute().mapPartitions { iter =>
+      val buffer = newAggregateBuffer()
+      var currentRow: Row = null
+      while (iter.hasNext) {
+        currentRow = iter.next()
         var i = 0
         while (i < buffer.length) {
-          aggregateResults(i) = buffer(i).eval(EmptyRow)
+          buffer(i).update(currentRow)
           i += 1
         }
-
-        Iterator(resultProjection(aggregateResults))
       }
+      val resultProjection = new InterpretedProjection(resultExpressions, computedSchema)
+      val aggregateResults = new GenericMutableRow(computedAggregates.length)
+
+      var i = 0
+      while (i < buffer.length) {
+        aggregateResults(i) = buffer(i).eval(EmptyRow)
+        i += 1
+      }
+
+      Iterator(resultProjection(aggregateResults))
+    }
+  }
+}
+
+case class OnHeapAggregate(
+    partial: Boolean,
+    groupingExpressions: Seq[Expression],
+    aggregateExpressions: Seq[NamedExpression],
+    child: SparkPlan) extends UnaryNode with Aggregate{
+
+  override def execute() = attachTree(this, "execute") {
+    if (groupingExpressions.isEmpty) {
+      aggregateNoGrouping()
     } else {
       child.execute().mapPartitions { iter =>
-        val hashTable = new HashMap[Row, Array[AggregateFunction]]
-        val groupingProjection = new InterpretedMutableProjection(groupingExpressions, childOutput)
+        val hashTable = new HashMap[Row, CompactBuffer[AggregateFunction]]
+        val groupingProjection =
+          new InterpretedMutableProjection(groupingExpressions, childOutput)
 
         var currentRow: Row = null
         while (iter.hasNext) {
@@ -183,6 +200,81 @@ case class Aggregate(
             val currentEntry = hashTableIter.next()
             val currentGroup = currentEntry.getKey
             val currentBuffer = currentEntry.getValue
+
+            var i = 0
+            while (i < currentBuffer.length) {
+              // Evaluating an aggregate buffer returns the result.  No row is required since we
+              // already added all rows in the group using update.
+              aggregateResults(i) = currentBuffer(i).eval(EmptyRow)
+              i += 1
+            }
+            resultProjection(joinedRow(aggregateResults, currentGroup))
+          }
+        }
+      }
+    }
+  }
+
+}
+
+case class ExternalAggregate(
+    partial: Boolean,
+    groupingExpressions: Seq[Expression],
+    aggregateExpressions: Seq[NamedExpression],
+    child: SparkPlan) extends UnaryNode with Aggregate{
+
+  override def execute() = attachTree(this, "execute") {
+    if (groupingExpressions.isEmpty) {
+      aggregateNoGrouping()
+    } else {
+      child.execute().mapPartitions { iter =>
+        val groupingProjection =
+          new InterpretedMutableProjection(groupingExpressions, childOutput)
+
+        val createCombiner = (v: Row) =>{
+          val c = newAggregateBuffer()
+          var i = 0
+          while (i < c.length) {
+            c(i).update(v)
+            i += 1
+          }
+          c
+        }
+        val mergeValue = (c: CompactBuffer[AggregateFunction], v: Row) => {
+          var i = 0
+          while (i < c.length) {
+            c(i).update(v)
+            i += 1
+          }
+          c
+        }
+        val mergeCombiners = (c1: CompactBuffer[AggregateFunction], c2: CompactBuffer[AggregateFunction]) => {
+          var i = 0
+          while (i < c1.length) {
+            c1(i).merge(c2(i))
+            i += 1
+          }
+          c1
+        }
+        val combiners = new ExternalAppendOnlyMap[Row, Row, CompactBuffer[AggregateFunction]](
+          createCombiner, mergeValue, mergeCombiners)
+        while (iter.hasNext) {
+          val row = iter.next()
+          combiners.insert(groupingProjection(row).copy(), row)
+        }
+        new Iterator[Row] {
+          private[this] val externalIter = combiners.iterator
+          private[this] val aggregateResults = new GenericMutableRow(computedAggregates.length)
+          private[this] val resultProjection =
+            new InterpretedMutableProjection(
+              resultExpressions, computedSchema ++ namedGroups.map(_._2))
+          private[this] val joinedRow = new JoinedRow
+
+          override final def hasNext: Boolean = externalIter.hasNext
+          override final def next(): Row = {
+            val currentEntry = externalIter.next()
+            val currentGroup = currentEntry._1
+            val currentBuffer = currentEntry._2
 
             var i = 0
             while (i < currentBuffer.length) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -134,15 +134,26 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
              groupingExpressions,
              partialComputation,
              child) =>
-        execution.Aggregate(
-          partial = false,
-          namedGroupingAttributes,
-          rewrittenAggregateExpressions,
-          execution.Aggregate(
-            partial = true,
-            groupingExpressions,
-            partialComputation,
-            planLater(child))) :: Nil
+
+        val preAggregate = execution.OnHeapAggregate(
+          partial = true,
+          groupingExpressions,
+          partialComputation,
+          planLater(child))
+
+        if (self.sqlContext.externalAggregate) {
+          execution.ExternalAggregate(
+            partial = false,
+            namedGroupingAttributes,
+            rewrittenAggregateExpressions,
+            preAggregate) :: Nil
+        } else {
+          execution.OnHeapAggregate(
+            partial = false,
+            namedGroupingAttributes,
+            rewrittenAggregateExpressions,
+            preAggregate) :: Nil
+        }
 
       case _ => Nil
     }
@@ -265,7 +276,11 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
       case logical.Filter(condition, child) =>
         execution.Filter(condition, planLater(child)) :: Nil
       case logical.Aggregate(group, agg, child) =>
-        execution.Aggregate(partial = false, group, agg, planLater(child)) :: Nil
+        if (self.sqlContext.externalAggregate) {
+          execution.ExternalAggregate(partial = false, group, agg, planLater(child)) :: Nil
+        } else {
+          execution.OnHeapAggregate(partial = false, group, agg, planLater(child)) :: Nil
+        }
       case logical.Sample(fraction, withReplacement, seed, child) =>
         execution.Sample(fraction, withReplacement, seed, planLater(child)) :: Nil
       case logical.LocalRelation(output, data) =>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUdfs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUdfs.scala
@@ -347,4 +347,10 @@ private[hive] case class HiveUdafFunction(
     val inputs = inputProjection(input).asInstanceOf[Seq[AnyRef]].toArray
     function.iterate(buffer, inputs)
   }
+
+  //hiveUdaf does not support external aggregate, for HiveUdafFunction need to spill to disk,
+  //and all the vals above need Serializable
+  override def merge(input: AggregateFunction): Unit = {
+    throw new NotImplementedError(s"HiveUdaf does not support external aggregate")
+  }
 }


### PR DESCRIPTION
A new PR clone from PR 1822

Fix numbers of problems

Reuse the CompactBuffer from Spark Core to save memory and pointer dereferences as PR 1993

Hive UDAF not support external aggregate, for hive AggregationBuffer need  serializable and hive GenericUDAFEvaluator has no method implement to merge two evaluators
