### PR TITLE
[SPARK-3124] Fix the jar version conflict in uber-jar

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -42,6 +42,10 @@
           <groupId>javax.servlet</groupId>
           <artifactId>servlet-api</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.jboss.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1222,6 +1222,12 @@
           <artifactId>zookeeper</artifactId>
           <version>${zookeeper.version}</version>
           <scope>provided</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>org.jboss.netty</groupId>
+              <artifactId>netty</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
       </dependencies>
     </profile>

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suite.scala
@@ -108,6 +108,7 @@ class HiveThriftServer2Suite extends FunSuite with Logging {
             logError(s"Failed to start Hive Thrift server within $timeout", cause)
           case _ =>
         }
+
         logError(
           s"""
              |=====================================


### PR DESCRIPTION
Both netty-3.2.2.Final.jar and netty-3.6.6.Final.jar are flatten into the assembly package, however, the class(NioWorker) signature difference leads to the failure in launching sparksql CLI/ThriftServer.

And also a tiny bug found in `CLISuite` & `HiveThriftServer2Suite` after fixing the duplicated netty jar.
