### PR TITLE
[SPARK-2312] Logging Unhandled messages

### DIFF
--- a/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
@@ -45,5 +45,9 @@ private[spark] class HeartbeatReceiver(scheduler: TaskScheduler)
       val response = HeartbeatResponse(
         !scheduler.executorHeartbeatReceived(executorId, taskMetrics, blockManagerId))
       sender ! response
+
+    case _@message =>
+      logWarning(s"Received unexpected actor system event: $message")
+
   }
 }

--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -64,6 +64,10 @@ private[spark] class MapOutputTrackerMasterActor(tracker: MapOutputTrackerMaster
       logInfo("MapOutputTrackerActor stopped!")
       sender ! true
       context.stop(self)
+
+    case _@message =>
+      logWarning(s"Received unexpected actor system event: $message")
+
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/deploy/Client.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/Client.scala
@@ -134,6 +134,10 @@ private class ClientActor(driverArgs: ClientArguments, conf: SparkConf)
       println(s"Error connecting to master ${driverArgs.master} ($remoteAddress), exiting.")
       println(s"Cause was: $cause")
       System.exit(-1)
+
+    case _@message =>
+      logWarning(s"Received unexpected actor system event: $message")
+
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/deploy/client/AppClient.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/client/AppClient.scala
@@ -161,6 +161,10 @@ private[spark] class AppClient(
         markDead("Application has been stopped.")
         sender ! true
         context.stop(self)
+
+      case _@message =>
+        logWarning(s"Received unexpected actor system event: $message")
+
     }
 
     /**

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -398,6 +398,9 @@ private[spark] class Master(
     case RequestWebUIPort => {
       sender ! WebUIPortResponse(webUi.boundPort)
     }
+
+    case _@message =>
+      logWarning(s"Received unexpected actor system event: $message")
   }
 
   def canCompleteRecovery =

--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -349,6 +349,9 @@ private[spark] class Worker(
         finishedDrivers.values.toList, activeMasterUrl, cores, memory,
         coresUsed, memoryUsed, activeMasterWebUiUrl)
     }
+
+    case _@message =>
+      logWarning(s"Received unexpected actor system event: $message")
   }
 
   def masterDisconnected() {

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -92,6 +92,9 @@ private[spark] class CoarseGrainedExecutorBackend(
       executor.stop()
       context.stop(self)
       context.system.shutdown()
+
+    case _@message =>
+      logWarning(s"Received unexpected actor system event: $message")
   }
 
   override def statusUpdate(taskId: Long, state: TaskState, data: ByteBuffer) {

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1365,6 +1365,9 @@ private[scheduler] class DAGSchedulerEventProcessActor(dagScheduler: DAGSchedule
 
     case ResubmitFailedStages =>
       dagScheduler.resubmitFailedStages()
+
+    case _@message =>
+      logWarning(s"Received unexpected actor system event: $message")
   }
 
   override def postStop() {

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -144,6 +144,9 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, actorSystem: A
 
       case RetrieveSparkProps =>
         sender ! sparkProperties
+
+      case _@message =>
+        logWarning(s"Received unexpected actor system event: $message")
     }
 
     // Make fake resource offers on all executors

--- a/core/src/main/scala/org/apache/spark/scheduler/local/LocalBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/local/LocalBackend.scala
@@ -69,6 +69,9 @@ private[spark] class LocalActor(
 
     case StopExecutor =>
       executor.stop()
+
+    case _@message =>
+      logWarning(s"Received unexpected actor system event: $message")
   }
 
   def reviveOffers() {

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerSlaveActor.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerSlaveActor.scala
@@ -68,6 +68,9 @@ class BlockManagerSlaveActor(
 
     case GetMatchingBlockIds(filter, _) =>
       sender ! blockManager.getMatchingBlockIds(filter)
+
+    case _@message =>
+      logWarning(s"Received unexpected actor system event: $message")
   }
 
   private def doAsync[T](actionMessage: String, responseActor: ActorRef)(body: => T) {


### PR DESCRIPTION
Note about tests: The best way to write tests for Log is use the TestEventListener and EventFilter of Akka, but the current Actors aren't using default ActorLogging and the current configuration are outputting results to a file instead STDOUT.
