### PR TITLE
[SPARK-3146][Streaming] Improve the flexibility of Spark Streaming Kafka API

### DIFF
--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -87,7 +87,11 @@ object MimaExcludes {
             ProblemFilters.exclude[IncompatibleMethTypeProblem](
               "org.apache.spark.streaming.kafka.KafkaUtils.createStream"),
             ProblemFilters.exclude[IncompatibleMethTypeProblem](
-              "org.apache.spark.streaming.kafka.KafkaReceiver.this")
+              "org.apache.spark.streaming.kafka.KafkaReceiver.this"),
+            ProblemFilters.exclude[MissingMethodProblem](
+              "org.apache.spark.streaming.kafka.KafkaReceiver.this"),
+            ProblemFilters.exclude[MissingClassProblem](
+              "org.apache.spark.streaming.kafka.KafkaReceiver$MessageHandler")
           ) ++
           Seq( // Ignore some private methods in ALS.
             ProblemFilters.exclude[MissingMethodProblem](


### PR DESCRIPTION
Improve the flexibility of Spark Streaming Kafka API to offer user the ability to pre-process message before stored into BlockGenerator, this will potential bring some benefits, details can be seen in [SPARK-3146](https://issues.apache.org/jira/browse/SPARK-3146).
