### PR TITLE
[SPARK-3140] Clarify confusing PySpark exception message

### DIFF
--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -54,12 +54,18 @@ def launch_gateway():
             gateway_port = proc.stdout.readline()
             gateway_port = int(gateway_port)
         except ValueError:
+            # Grab the remaining lines of stdout
             (stdout, _) = proc.communicate()
             exit_code = proc.poll()
             error_msg = "Launching GatewayServer failed"
             error_msg += " with exit code %d! " % exit_code if exit_code else "! "
-            error_msg += "(Warning: unexpected output detected.)\n\n"
-            error_msg += gateway_port + stdout
+            if gateway_port == "" and stdout == "":
+                error_msg += "(Warning: no output detected.)\n"
+            else:
+                error_msg += "(Warning: unexpected output detected.)\n\n"
+                error_msg += "--------------------------------------------------------------\n"
+                error_msg += gateway_port + stdout
+                error_msg += "--------------------------------------------------------------\n"
             raise Exception(error_msg)
 
         # Create a thread to echo output from the GatewayServer, which is required

--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -58,11 +58,12 @@ def launch_gateway():
             (stdout, _) = proc.communicate()
             exit_code = proc.poll()
             error_msg = "Launching GatewayServer failed"
-            error_msg += " with exit code %d! " % exit_code if exit_code else "! "
+            error_msg += " with exit code %d!\n" % exit_code if exit_code else "!\n"
+            error_msg += "Warning: Expected GatewayServer to output a port, but found "
             if gateway_port == "" and stdout == "":
-                error_msg += "(Warning: no output detected.)\n"
+                error_msg += "no output.\n"
             else:
-                error_msg += "(Warning: unexpected output detected.)\n\n"
+                error_msg += "the following:\n\n"
                 error_msg += "--------------------------------------------------------------\n"
                 error_msg += gateway_port + stdout
                 error_msg += "--------------------------------------------------------------\n"


### PR DESCRIPTION
We read the py4j port from the stdout of the `bin/spark-submit` subprocess. If there is interference in stdout (e.g. a random echo in `spark-submit`), we throw an exception with a warning message. We do not, however, distinguish between this case from the case where no stdout is produced at all.

I wasted a non-trivial amount of time being baffled by this exception in search of places where I print random whitespace (in vain, of course). A clearer exception message that distinguishes between these cases will prevent similar headaches that I have gone through.
