### PR TITLE
[SPARK-3133] Piggyback control message to fetch small broadcasts in TorrentBroadcast

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -198,7 +198,7 @@ object SparkEnv extends Logging {
       }
     }
 
-    val mapOutputTracker =  if (isDriver) {
+    val mapOutputTracker = if (isDriver) {
       new MapOutputTrackerMaster(conf)
     } else {
       new MapOutputTrackerWorker(conf)
@@ -220,12 +220,14 @@ object SparkEnv extends Logging {
 
     val shuffleMemoryManager = new ShuffleMemoryManager(conf)
 
+    val blockManager = new BlockManager(executorId, actorSystem,
+      serializer, conf, securityManager, mapOutputTracker, shuffleManager)
+
     val blockManagerMaster = new BlockManagerMaster(registerOrLookup(
       "BlockManagerMaster",
-      new BlockManagerMasterActor(isLocal, conf, listenerBus)), conf)
+      new BlockManagerMasterActor(isLocal, conf, listenerBus, Some(blockManager))), conf)
 
-    val blockManager = new BlockManager(executorId, actorSystem, blockManagerMaster,
-      serializer, conf, securityManager, mapOutputTracker, shuffleManager)
+    blockManager.initialize(blockManagerMaster)
 
     val connectionManager = blockManager.connectionManager
 

--- a/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
@@ -108,25 +108,42 @@ private[spark] class TorrentBroadcast[T: ClassTag](
       // broadcast blocks have already fetched some of the blocks. In that case, some blocks
       // would be available locally (on this executor).
       var blockOpt = bm.getLocalBytes(pieceId)
+
       if (!blockOpt.isDefined) {
-        blockOpt = bm.getRemoteBytes(pieceId)
-        blockOpt match {
+        // For the first block, try to piggyback on the control message to get the block.
+        val (replicate, blockOpt0) = if (pid == 0) {
+          bm.getRemoteBytesPiggybackControl(pieceId)
+        } else {
+          (true, bm.getRemoteBytes(pieceId))
+        }
+
+        // replicate is only false if there is only one block and the block is small enough.
+        if (!replicate) {
+          assert(numBlocks == 1)
+        }
+
+        blockOpt0 match {
           case Some(block) =>
-            // If we found the block from remote executors/driver's BlockManager, put the block
-            // in this executor's BlockManager.
-            SparkEnv.get.blockManager.putBytes(
-              pieceId,
-              block,
-              StorageLevel.MEMORY_AND_DISK_SER,
-              tellMaster = true)
+            if (replicate) {
+              // If we found the block from remote executors/driver's BlockManager, put the block
+              // in this executor's BlockManager.
+              bm.putBytes(
+                pieceId,
+                block,
+                StorageLevel.MEMORY_AND_DISK_SER,
+                tellMaster = true)
+            }
 
           case None =>
             throw new SparkException("Failed to get " + pieceId + " of " + broadcastId)
         }
+
+        blockOpt = blockOpt0
       }
       // If we get here, the option is defined.
       blocks(pid) = blockOpt.get
     }
+
     blocks
   }
 

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMessages.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMessages.scala
@@ -88,6 +88,12 @@ private[spark] object BlockManagerMessages {
 
   case class GetLocationsMultipleBlockIds(blockIds: Array[BlockId]) extends ToBlockManagerMaster
 
+  /**
+   * Similar to [[GetLocations]], but optionally just return the block data itself if it is small
+   * and available on the driver.
+   */
+  case class GetBlockOrLocations(blockId: BlockId) extends ToBlockManagerMaster
+
   case class GetPeers(blockManagerId: BlockManagerId, size: Int) extends ToBlockManagerMaster
 
   case class RemoveExecutor(execId: String) extends ToBlockManagerMaster

--- a/core/src/test/scala/org/apache/spark/broadcast/BroadcastSuite.scala
+++ b/core/src/test/scala/org/apache/spark/broadcast/BroadcastSuite.scala
@@ -257,7 +257,7 @@ class BroadcastSuite extends FunSuite with LocalSparkContext {
       new SparkContext("local", "test", broadcastConf)
     }
     val blockManagerMaster = sc.env.blockManager.master
-    val list = List[Int](1, 2, 3, 4)
+    val list = scala.util.Random.shuffle(1 to 1024 * 1024)
 
     // Create broadcast variable
     val broadcast = sc.broadcast(list)

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -73,8 +73,10 @@ class BlockManagerSuite extends FunSuite with Matchers with BeforeAndAfter
   def rdd(rddId: Int, splitId: Int) = RDDBlockId(rddId, splitId)
 
   private def makeBlockManager(maxMem: Long, name: String = "<driver>"): BlockManager = {
-    new BlockManager(name, actorSystem, master, serializer, maxMem, conf, securityMgr,
+    val bm = new BlockManager(name, actorSystem, serializer, maxMem, conf, securityMgr,
       mapOutputTracker, shuffleManager)
+    bm.initialize(master)
+    bm
   }
 
   before {


### PR DESCRIPTION
This reduces the number of network calls from 3 to 1 for small broadcasts, which should improve small task scheduling latency.

Slightly ugly.

TODO:
- [ ] Add unit tests
