### PR TITLE
[PySpark]addPyFile parameter can be a singular string

### DIFF
--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -639,7 +639,25 @@ class SparkContext(object):
         SparkContext in the future.  The C{path} passed can be either a local
         file, a file in HDFS (or other Hadoop-supported filesystems), or an
         HTTP, HTTPS or FTP URI.
+        
+        >>> from pyspark import SparkContext
+        >>> modules = []
+        >>> modules.append(os.path.join(CURRENT_DIRECTORY, "my_spark_module.py"))
+        >>> modules.append(os.path.join(CURRENT_DIRECTORY, "my_spark_module2.py"))
+        >>> sc = SparkContext("local", "app_name_here", pyFiles=module_path)
+        .
+        . (later)
+        .
+        >>> sc.addPyFile(os.path.join(CURRENT_DIRECTORY + "my_mod_3.py"))
+        .
+        . (later)
+        .
+        >>> import my_mod_3.py
+        >>> rdd_I_made.map(my_mod_3.custom_transformation)
         """
+        if type(path) == str:
+            # if only one module at a time is added in
+            path = [path]
         self.addFile(path)
         (dirname, filename) = os.path.split(path)  # dirname may be directory or HDFS/S3 prefix
 


### PR DESCRIPTION
The "path" parameter of addPyFile(self, path) would imply that the input is a singular path. However, it currently only accepts a list of paths. This is slightly misleading to the user and so just catch it and type cast it. Not the best type of patch, but it does the job.

This is rather odd because in the tests the parameter to addPyFile is a simple string. But when I execute this code on my machine:
https://gist.github.com/abhikalakuntla/e9d39ebe4062ad463780

It throws a:

```
py4j.protocol.Py4JJavaError: An error occurred while calling o11.addFile.
: java.lang.IllegalArgumentException: / cannot be a directory.
    at org.apache.spark.HttpFileServer.addFileToDir(HttpFileServer.scala:67)
    at org.apache.spark.HttpFileServer.addFile(HttpFileServer.scala:52)
    at org.apache.spark.SparkContext.addFile(SparkContext.scala:790)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:231)
    at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:379)
    at py4j.Gateway.invoke(Gateway.java:259)
    at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
    at py4j.commands.CallCommand.execute(CallCommand.java:79)
    at py4j.GatewayConnection.run(GatewayConnection.java:207)
    at java.lang.Thread.run(Thread.java:695)
```

However, this totally works:
https://gist.github.com/abhikalakuntla/a0c3d1a46bca0af5a8b7
