### PR TITLE
[SPARK-3170][CORE]: Bug Fix in Storage UI

### DIFF
--- a/core/src/main/scala/org/apache/spark/CacheManager.scala
+++ b/core/src/main/scala/org/apache/spark/CacheManager.scala
@@ -68,7 +68,8 @@ private[spark] class CacheManager(blockManager: BlockManager) extends Logging {
           // Otherwise, cache the values and keep track of any updates in block statuses
           val updatedBlocks = new ArrayBuffer[(BlockId, BlockStatus)]
           val cachedValues = putInBlockManager(key, computedValues, storageLevel, updatedBlocks)
-          context.taskMetrics.updatedBlocks = Some(updatedBlocks)
+          val metrics = context.taskMetrics
+          metrics.updatedBlocks = Some(metrics.updatedBlocks.getOrElse(Seq[(BlockId, BlockStatus)]()) ++ updatedBlocks)
           new InterruptibleIterator(context, cachedValues)
 
         } finally {

--- a/core/src/main/scala/org/apache/spark/ui/storage/StorageTab.scala
+++ b/core/src/main/scala/org/apache/spark/ui/storage/StorageTab.scala
@@ -74,8 +74,8 @@ class StorageListener(storageStatusListener: StorageStatusListener) extends Spar
 
   override def onStageCompleted(stageCompleted: SparkListenerStageCompleted) = synchronized {
     // Remove all partitions that are no longer cached in current competed stage
-    val currentComletedRddInfoIds = Set[Int]() ++ stageCompleted.stageInfo.rddInfos.map(r => r.id)
-    _rddInfoMap.retain { case (id, info) => !currentComletedRddInfoIds.contains(id) || info.numCachedPartitions > 0 }
+    val comletedRddIds = Set(stageCompleted.stageInfo.rddInfos.map(r => r.id))
+    _rddInfoMap.retain { case (id, info) => !comletedRddIds.contains(id) || info.numCachedPartitions > 0 }
   }
 
   override def onUnpersistRDD(unpersistRDD: SparkListenerUnpersistRDD) = synchronized {

--- a/core/src/main/scala/org/apache/spark/ui/storage/StorageTab.scala
+++ b/core/src/main/scala/org/apache/spark/ui/storage/StorageTab.scala
@@ -73,7 +73,7 @@ class StorageListener(storageStatusListener: StorageStatusListener) extends Spar
   }
 
   override def onStageCompleted(stageCompleted: SparkListenerStageCompleted) = synchronized {
-    // Remove all partitions that are no longer cached in current competed stage
+    // Remove all partitions that are no longer cached in current completed stage
     val comletedRddIds = Set(stageCompleted.stageInfo.rddInfos.map(r => r.id))
     _rddInfoMap.retain { case (id, info) => !comletedRddIds.contains(id) || info.numCachedPartitions > 0 }
   }

--- a/core/src/main/scala/org/apache/spark/ui/storage/StorageTab.scala
+++ b/core/src/main/scala/org/apache/spark/ui/storage/StorageTab.scala
@@ -73,8 +73,9 @@ class StorageListener(storageStatusListener: StorageStatusListener) extends Spar
   }
 
   override def onStageCompleted(stageCompleted: SparkListenerStageCompleted) = synchronized {
-    // Remove all partitions that are no longer cached
-    _rddInfoMap.retain { case (_, info) => info.numCachedPartitions > 0 }
+    // Remove all partitions that are no longer cached in current competed stage
+    val currentComletedRddInfoIds = Set[Int]() ++ stageCompleted.stageInfo.rddInfos.map(r => r.id)
+    _rddInfoMap.retain { case (id, info) => !currentComletedRddInfoIds.contains(id) || info.numCachedPartitions > 0 }
   }
 
   override def onUnpersistRDD(unpersistRDD: SparkListenerUnpersistRDD) = synchronized {


### PR DESCRIPTION
current compeleted stage only need to remove its own partitions that are no longer cached. Currently, "Storage" in Spark UI may lost some rdds which are cached actually.
