### PR TITLE
Add SSDs to block device mapping

### DIFF
--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -34,7 +34,7 @@ import urllib2
 from optparse import OptionParser
 from sys import stderr
 import boto
-from boto.ec2.blockdevicemapping import BlockDeviceMapping, EBSBlockDeviceType
+from boto.ec2.blockdevicemapping import BlockDeviceMapping, BlockDeviceType, EBSBlockDeviceType
 from boto import ec2
 
 # A URL prefix from which to fetch AMI information
@@ -341,6 +341,13 @@ def launch_cluster(conn, opts, cluster_name):
         device.size = opts.ebs_vol_size
         device.delete_on_termination = True
         block_map["/dev/sdv"] = device
+
+    sdb = BlockDeviceType()
+    sdb.ephemeral_name = 'ephemeral0'
+    block_map['/dev/sdb'] = sdb
+    sdc = BlockDeviceType()
+    sdc.ephemeral_name = 'ephemeral1'
+    block_map['/dev/sdc'] = sdc
 
     # Launch slaves
     if opts.spot_price is not None:

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -343,13 +343,14 @@ def launch_cluster(conn, opts, cluster_name):
         device.delete_on_termination = True
         block_map["/dev/sdv"] = device
 
-    # Add ephemeral drives to device mapping.
-    for i in range(get_num_disks(opts.instance_type)):
-        dev = BlockDeviceType()
-        dev.ephemeral_name = 'ephemeral{}'.format(i)
-        # The first ephemeral drive is /dev/sdb.
-        name = '/dev/sd' + string.letters[i + 1]
-        block_map[name] = dev
+    # AWS ignores the AMI-specified block device mapping for M3.
+    if opts.instance_type.startswith('m3.'):
+        for i in range(get_num_disks(opts.instance_type)):
+            dev = BlockDeviceType()
+            dev.ephemeral_name = 'ephemeral{}'.format(i)
+            # The first ephemeral drive is /dev/sdb.
+            name = '/dev/sd' + string.letters[i + 1]
+            block_map[name] = dev
 
     # Launch slaves
     if opts.spot_price is not None:

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -347,7 +347,7 @@ def launch_cluster(conn, opts, cluster_name):
     if opts.instance_type.startswith('m3.'):
         for i in range(get_num_disks(opts.instance_type)):
             dev = BlockDeviceType()
-            dev.ephemeral_name = 'ephemeral{}'.format(i)
+            dev.ephemeral_name = 'ephemeral%d' % i
             # The first ephemeral drive is /dev/sdb.
             name = '/dev/sd' + string.letters[i + 1]
             block_map[name] = dev

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -26,6 +26,7 @@ import os
 import pipes
 import random
 import shutil
+import string
 import subprocess
 import sys
 import tempfile
@@ -342,12 +343,13 @@ def launch_cluster(conn, opts, cluster_name):
         device.delete_on_termination = True
         block_map["/dev/sdv"] = device
 
-    sdb = BlockDeviceType()
-    sdb.ephemeral_name = 'ephemeral0'
-    block_map['/dev/sdb'] = sdb
-    sdc = BlockDeviceType()
-    sdc.ephemeral_name = 'ephemeral1'
-    block_map['/dev/sdc'] = sdc
+    # Add ephemeral drives to device mapping.
+    for i in range(get_num_disks(opts.instance_type)):
+        dev = BlockDeviceType()
+        dev.ephemeral_name = 'ephemeral{}'.format(i)
+        # The first ephemeral drive is /dev/sdb.
+        name = '/dev/sd' + string.letters[i + 1]
+        block_map[name] = dev
 
     # Launch slaves
     if opts.spot_price is not None:


### PR DESCRIPTION
On `m3.2xlarge` instances the 2x80GB SSDs are inaccessible if not added to the block device mapping when the instance is created. They work when added with this patch. I have not tested this with other instance types, and I do not know much about this script and EC2 deployment in general. Maybe this code needs to depend on the instance type.

The requirement for this mapping is described in the AWS docs at:
http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#InstanceStore_UsageScenarios
