### PR TITLE
SPARK-3175 : Branch-1.1 SBT build failed for Yarn-Alpha ( TRY AGAIN)

### DIFF
--- a/yarn/alpha/pom.xml
+++ b/yarn/alpha/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>yarn-parent_2.10</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>


### PR DESCRIPTION
The issue is that the yarn/alpha/pom.xml using 1.1.0 instead of 1.1.1-SNAPSHOT version.

update the pom.xml to 1.1.1-SNAPSHOT (same as yarn/stable/pom.xml)
