### PR TITLE
[SPARK-2871] [PySpark] add histgram() API

### DIFF
--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -871,7 +871,7 @@ class RDD(object):
         Buckets must be sorted and not contain any duplicates, must be
         at least two elements.
 
-        If `buckets` is a number, it will generates buckets which is
+        If `buckets` is a number, it will generates buckets which are
         evenly spaced between the minimum and maximum of the RDD. For
         example, if the min value is 0 and the max is 100, given buckets
         as 2, the resulting buckets will be [0,50) [50,100]. buckets must
@@ -892,7 +892,7 @@ class RDD(object):
 
         if isinstance(buckets, (int, long)):
             if buckets < 1:
-                raise ValueError("buckets should not less than 1")
+                raise ValueError("number of buckets must be >= 1")
 
             # filter out non-comparable elements
             self = self.filter(lambda x: x is not None and not isnan(x))

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -913,7 +913,7 @@ class RDD(object):
             try:
                 minv, maxv = filtered.map(lambda x: (x, x)).reduce(minmax)
             except TypeError as e:
-                if " empty " in e.message:
+                if " empty " in str(e):
                     raise ValueError("can not generate buckets from empty RDD")
                 raise
 

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -364,6 +364,98 @@ class TestRDDFunctions(PySparkTestCase):
         self.assertEquals(a.count(), b.count())
         self.assertRaises(Exception, lambda: a.zip(b).count())
 
+    def test_histogram(self):
+        # empty
+        rdd = self.sc.parallelize([])
+        self.assertEquals([0], rdd.histogram([0, 10])[1])
+        self.assertEquals([0], rdd.histogram([0, 10], True)[1])
+
+        # out of range
+        rdd = self.sc.parallelize([10.01, -0.01])
+        self.assertEquals([0], rdd.histogram([0, 10])[1])
+        self.assertEquals([0], rdd.histogram([0, 10], True)[1])
+
+        # in range with one bucket
+        rdd = self.sc.parallelize(range(1, 5))
+        self.assertEquals([4], rdd.histogram([0, 10])[1])
+        self.assertEquals([4], rdd.histogram([0, 10], True)[1])
+
+        # in range with one bucket exact match
+        self.assertEquals([4], rdd.histogram([1, 4])[1])
+        self.assertEquals([4], rdd.histogram([1, 4], True)[1])
+
+        # out of range with two buckets
+        rdd = self.sc.parallelize([10.01, -0.01])
+        self.assertEquals([0, 0], rdd.histogram([0, 5, 10])[1])
+        self.assertEquals([0, 0], rdd.histogram([0, 5, 10], True)[1])
+
+        # out of range with two uneven buckets
+        rdd = self.sc.parallelize([10.01, -0.01])
+        self.assertEquals([0, 0], rdd.histogram([0, 4, 10])[1])
+
+        # in range with two buckets
+        rdd = self.sc.parallelize([1, 2, 3, 5, 6])
+        self.assertEquals([3, 2], rdd.histogram([0, 5, 10])[1])
+        self.assertEquals([3, 2], rdd.histogram([0, 5, 10], True)[1])
+
+        # in range with two bucket and None
+        rdd = self.sc.parallelize([1, 2, 3, 5, 6, None, float('nan')])
+        self.assertEquals([3, 2], rdd.histogram([0, 5, 10])[1])
+        self.assertEquals([3, 2], rdd.histogram([0, 5, 10], True)[1])
+
+        # in range with two uneven buckets
+        rdd = self.sc.parallelize([1, 2, 3, 5, 6])
+        self.assertEquals([3, 2], rdd.histogram([0, 5, 11])[1])
+
+        # mixed range with two uneven buckets
+        rdd = self.sc.parallelize([-0.01, 0.0, 1, 2, 3, 5, 6, 11.0, 11.01])
+        self.assertEquals([4, 3], rdd.histogram([0, 5, 11])[1])
+
+        # mixed range with four uneven buckets
+        rdd = self.sc.parallelize([-0.01, 0.0, 1, 2, 3, 5, 6, 11.01, 12.0, 199.0, 200.0, 200.1])
+        self.assertEquals([4, 2, 1, 3], rdd.histogram([0.0, 5.0, 11.0, 12.0, 200.0])[1])
+
+        # mixed range with uneven buckets and NaN
+        rdd = self.sc.parallelize([-0.01, 0.0, 1, 2, 3, 5, 6, 11.01, 12.0,
+                                   199.0, 200.0, 200.1, None, float('nan')])
+        self.assertEquals([4, 2, 1, 3], rdd.histogram([0.0, 5.0, 11.0, 12.0, 200.0])[1])
+
+        # out of range with infinite buckets
+        rdd = self.sc.parallelize([10.01, -0.01, float('nan')])
+        self.assertEquals([1, 1], rdd.histogram([float('-inf'), 0, float('inf')])[1])
+
+        # invalid buckets
+        self.assertRaises(ValueError, lambda: rdd.histogram([]))
+        self.assertRaises(ValueError, lambda: rdd.histogram([1]))
+
+        # without buckets
+        rdd = self.sc.parallelize(range(1, 5))
+        self.assertEquals(([1, 4], [4]), rdd.histogram(1))
+
+        # without buckets single element
+        rdd = self.sc.parallelize([1])
+        self.assertEquals(([1, 1], [1]), rdd.histogram(1))
+
+        # without bucket no range
+        rdd = self.sc.parallelize([1] * 4)
+        self.assertEquals(([1, 1], [4]), rdd.histogram(1))
+
+        # without buckets basic two
+        rdd = self.sc.parallelize(range(1, 5))
+        self.assertEquals(([1, 2.5, 4], [2, 2]), rdd.histogram(2))
+
+        # without buckets with more requested than elements
+        rdd = self.sc.parallelize([1, 2])
+        buckets = [1 + 0.2 * i for i in range(6)]
+        hist = [1, 0, 0, 0, 1]
+        self.assertEquals((buckets, hist), rdd.histogram(5))
+
+        # invalid RDDs
+        rdd = self.sc.parallelize([1, float('inf')])
+        self.assertRaises(ValueError, lambda: rdd.histogram(2))
+        rdd = self.sc.parallelize([float('nan')])
+        self.assertRaises(ValueError, lambda: rdd.histogram(2))
+
 
 class TestIO(PySparkTestCase):
 


### PR DESCRIPTION
RDD.histogram(buckets)

```
    Compute a histogram using the provided buckets. The buckets
    are all open to the right except for the last which is closed.
    e.g. [1,10,20,50] means the buckets are [1,10) [10,20) [20,50],
    which means 1<=x<10, 10<=x<20, 20<=x<=50. And on the input of 1
    and 50 we would have a histogram of 1,0,1.

    If your histogram is evenly spaced (e.g. [0, 10, 20, 30]),
    this can be switched from an O(log n) inseration to O(1) per
    element(where n = # buckets).

    Buckets must be sorted and not contain any duplicates, must be
    at least two elements.

    If `buckets` is a number, it will generates buckets which is
    evenly spaced between the minimum and maximum of the RDD. For
    example, if the min value is 0 and the max is 100, given buckets
    as 2, the resulting buckets will be [0,50) [50,100]. buckets must
    be at least 1 If the RDD contains infinity, NaN throws an exception
    If the elements in RDD do not vary (max == min) always returns
    a single bucket.

    It will return an tuple of buckets and histogram.

    >>> rdd = sc.parallelize(range(51))
    >>> rdd.histogram(2)
    ([0, 25, 50], [25, 26])
    >>> rdd.histogram([0, 5, 25, 50])
    ([0, 5, 25, 50], [5, 20, 26])
    >>> rdd.histogram([0, 15, 30, 45, 60], True)
    ([0, 15, 30, 45, 60], [15, 15, 15, 6])
    >>> rdd = sc.parallelize(["ab", "ac", "b", "bd", "ef"])
    >>> rdd.histogram(("a", "b", "c"))
    (('a', 'b', 'c'), [2, 2])
```

closes #122, it's duplicated.
