### PR TITLE
configuration for spark.cleaner.referenceTracking

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -551,6 +551,13 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+  <td><code>spark.cleaner.referenceTracking</code></td>
+  <td>true</td>
+  <td>
+    Switch of the periodical metadata cleaner. 
+  </td>
+</tr>
+<tr>
   <td><code>spark.cleaner.ttl</code></td>
   <td>(infinite)</td>
   <td>


### PR DESCRIPTION
missing document about the switch of ContextCleaner
