### PR TITLE
Error in Page Rank Computation in PageRank.scala

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
@@ -139,7 +139,7 @@ object PageRank extends Logging {
     // version of Pregel
     def vertexProgram(id: VertexId, attr: (Double, Double), msgSum: Double): (Double, Double) = {
       val (oldPR, lastDelta) = attr
-      # Equation: resetProb * (1-resetProb)*msgSum
+      // Equation: resetProb * (1-resetProb)*msgSum
       val newPR = resetProb + (1.0 - resetProb) * msgSum
       (newPR, newPR - oldPR)
     }

--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
@@ -139,7 +139,8 @@ object PageRank extends Logging {
     // version of Pregel
     def vertexProgram(id: VertexId, attr: (Double, Double), msgSum: Double): (Double, Double) = {
       val (oldPR, lastDelta) = attr
-      val newPR = oldPR + (1.0 - resetProb) * msgSum
+      # Equation: resetProb * (1-resetProb)*msgSum
+      val newPR = resetProb + (1.0 - resetProb) * msgSum
       (newPR, newPR - oldPR)
     }
 


### PR DESCRIPTION
I saw something strange in the Page Rank computation for runUntilConverge() in PageRank.scala. It uses the oldPR instead of the resetProb. Note that the run() Method in PageRank.scala uses resetProb as my correction does here (see Lines 95–96 of PageRank.scala).

Here is the diff that I see (in case it is hidden later):

``` scala
-      val newPR = oldPR + (1.0 - resetProb) * msgSum
+      // Equation: resetProb * (1-resetProb)*msgSum
+      val newPR = resetProb + (1.0 - resetProb) * msgSum
```

This might not be the right correction, but I brought a pull request to see if I have found an error or not. If it is not correct, just deny the pull request.

Best Wishes
