### PR TITLE
[SPARK-3201][YARN-Stable] Make the yarn-client support the extraJavaOptions

### DIFF
--- a/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/ClientBase.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/ClientBase.scala
@@ -388,11 +388,14 @@ trait ClientBase extends Logging {
     for ((k, v) <- sparkConf.getAll) {
       javaOpts += YarnSparkHadoopUtil.escapeForShell(s"-D$k=$v")
     }
-
+    
+    // Set the extra(like "-X") java opts in "spark.driver.extraJavaOptions" or "SPARK_JAVA_OPTS".
+    sparkConf.getOption("spark.driver.extraJavaOptions")
+      .orElse(sys.env.get("SPARK_JAVA_OPTS"))
+      .foreach(opts => javaOpts += opts)
+      
+    // No need to set the "spark.driver.libraryPath" in yarn-client mode.
     if (args.amClass == classOf[ApplicationMaster].getName) {
-      sparkConf.getOption("spark.driver.extraJavaOptions")
-        .orElse(sys.env.get("SPARK_JAVA_OPTS"))
-        .foreach(opts => javaOpts += opts)
       sparkConf.getOption("spark.driver.libraryPath")
         .foreach(p => javaOpts += s"-Djava.library.path=$p")
     }

--- a/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/ClientBase.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/ClientBase.scala
@@ -389,9 +389,8 @@ trait ClientBase extends Logging {
       javaOpts += YarnSparkHadoopUtil.escapeForShell(s"-D$k=$v")
     }
     
-    // Set the extra(like "-X") java opts in "spark.driver.extraJavaOptions" or "SPARK_JAVA_OPTS".
-    sparkConf.getOption("spark.driver.extraJavaOptions")
-      .orElse(sys.env.get("SPARK_JAVA_OPTS"))
+    // Set the extra java opts(like "-X") in "spark.driver.extraJavaOptions" or "SPARK_JAVA_OPTS".
+    sparkConf.getOption("spark.driver.extraJavaOptions").orElse(sys.env.get("SPARK_JAVA_OPTS"))
       .foreach(opts => javaOpts += opts)
       
     // No need to set the "spark.driver.libraryPath" in yarn-client mode.


### PR DESCRIPTION
it's very inconvenient if we want to set the "-X" java opts in the process of "ExecutorLauncher".
So I add it in yarn-client mode.
