### PR TITLE
SPARK-3211 .take() is OOM-prone with empty partitions

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1064,9 +1064,8 @@ abstract class RDD[T: ClassTag](
       // greater than totalParts because we actually cap it at totalParts in runJob.
       var numPartsToTry = 1
       if (partsScanned > 0) {
-        // If we didn't find any rows after the first iteration, just try all partitions next.
-        // Otherwise, interpolate the number of partitions we need to try, but overestimate it
-        // by 50%.
+        // If we didn't find any rows after the previous iteration, double and retry.  Otherwise,
+        // interpolate the number of partitions we need to try, but overestimate it by 50%.
         if (buf.size == 0) {
           numPartsToTry = partsScanned * 2
         } else {

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1068,7 +1068,7 @@ abstract class RDD[T: ClassTag](
         // Otherwise, interpolate the number of partitions we need to try, but overestimate it
         // by 50%.
         if (buf.size == 0) {
-          numPartsToTry = totalParts - 1
+          numPartsToTry = partsScanned * 2
         } else {
           numPartsToTry = (1.5 * num * partsScanned / buf.size).toInt
         }

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1064,10 +1064,10 @@ abstract class RDD[T: ClassTag](
       // greater than totalParts because we actually cap it at totalParts in runJob.
       var numPartsToTry = 1
       if (partsScanned > 0) {
-        // If we didn't find any rows after the previous iteration, double and retry.  Otherwise,
+        // If we didn't find any rows after the previous iteration, quadruple and retry.  Otherwise,
         // interpolate the number of partitions we need to try, but overestimate it by 50%.
         if (buf.size == 0) {
-          numPartsToTry = partsScanned * 2
+          numPartsToTry = partsScanned * 4
         } else {
           numPartsToTry = (1.5 * num * partsScanned / buf.size).toInt
         }

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -1031,9 +1031,9 @@ class RDD(object):
             # we actually cap it at totalParts in runJob.
             numPartsToTry = 1
             if partsScanned > 0:
-                # If we didn't find any rows after the first iteration, just
-                # try all partitions next. Otherwise, interpolate the number
-                # of partitions we need to try, but overestimate it by 50%.
+                # If we didn't find any rows after the previous iteration,
+                # double and retry.  Otherwise, interpolate the number of
+                # partitions we need to try, but overestimate it by 50%.
                 if len(items) == 0:
                     numPartsToTry = partsScanned * 2
                 else:

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -1032,10 +1032,10 @@ class RDD(object):
             numPartsToTry = 1
             if partsScanned > 0:
                 # If we didn't find any rows after the previous iteration,
-                # double and retry.  Otherwise, interpolate the number of
+                # quadruple and retry.  Otherwise, interpolate the number of
                 # partitions we need to try, but overestimate it by 50%.
                 if len(items) == 0:
-                    numPartsToTry = partsScanned * 2
+                    numPartsToTry = partsScanned * 4
                 else:
                     numPartsToTry = int(1.5 * num * partsScanned / len(items))
 

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -1035,7 +1035,7 @@ class RDD(object):
                 # try all partitions next. Otherwise, interpolate the number
                 # of partitions we need to try, but overestimate it by 50%.
                 if len(items) == 0:
-                    numPartsToTry = totalParts - 1
+                    numPartsToTry = partsScanned * 2
                 else:
                     numPartsToTry = int(1.5 * num * partsScanned / len(items))
 


### PR DESCRIPTION
Instead of jumping straight from 1 partition to all partitions, do exponential
growth and double the number of partitions to attempt each time instead.

Fix proposed by Paul Nepywoda
