### PR TITLE
Fixed typos in make-distribution.sh

### DIFF
--- a/make-distribution.sh
+++ b/make-distribution.sh
@@ -50,7 +50,7 @@ while (( "$#" )); do
   case $1 in
     --hadoop)
       echo "Error: '--hadoop' is no longer supported:"
-      echo "Error: use Maven options -Phadoop.version and -Pyarn.version"
+      echo "Error: use Maven options -Dhadoop.version and -Dyarn.version"
       exit_with_usage
       ;;
     --with-yarn)

--- a/make-distribution.sh
+++ b/make-distribution.sh
@@ -50,7 +50,8 @@ while (( "$#" )); do
   case $1 in
     --hadoop)
       echo "Error: '--hadoop' is no longer supported:"
-      echo "Error: use Maven options -Dhadoop.version and -Dyarn.version"
+      echo "Error: use Maven profiles and options -Dhadoop.version and -Dyarn.version instead."
+      echo "Error: Related profiles include hadoop-0.23, hdaoop-2.2, hadoop-2.3 and hadoop-2.4."
       exit_with_usage
       ;;
     --with-yarn)


### PR DESCRIPTION
`hadoop.version` and `yarn.version` are properties rather then profiles, should use `-D` instead of `-P`.

/cc @pwendell 
