### PR TITLE
[SPARK-3228][Streaming]

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
@@ -771,8 +771,10 @@ abstract class DStream[T: ClassTag] (
    */
   def saveAsObjectFiles(prefix: String, suffix: String = "") {
     val saveFunc = (rdd: RDD[T], time: Time) => {
-      val file = rddToFileName(prefix, suffix, time)
-      rdd.saveAsObjectFile(file)
+      if(rdd.partitions.size>0) {
+        val file = rddToFileName(prefix, suffix, time)
+        rdd.saveAsObjectFile(file)
+      }
     }
     this.foreachRDD(saveFunc)
   }
@@ -784,8 +786,10 @@ abstract class DStream[T: ClassTag] (
    */
   def saveAsTextFiles(prefix: String, suffix: String = "") {
     val saveFunc = (rdd: RDD[T], time: Time) => {
-      val file = rddToFileName(prefix, suffix, time)
-      rdd.saveAsTextFile(file)
+      if(rdd.partitions.size>0){
+        val file = rddToFileName(prefix, suffix, time)
+        rdd.saveAsTextFile(file)
+      }
     }
     this.foreachRDD(saveFunc)
   }

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
@@ -771,7 +771,7 @@ abstract class DStream[T: ClassTag] (
    */
   def saveAsObjectFiles(prefix: String, suffix: String = "") {
     val saveFunc = (rdd: RDD[T], time: Time) => {
-      if(rdd.partitions.size>0) {
+      if (rdd.partitions.size > 0) {
         val file = rddToFileName(prefix, suffix, time)
         rdd.saveAsObjectFile(file)
       }
@@ -786,7 +786,7 @@ abstract class DStream[T: ClassTag] (
    */
   def saveAsTextFiles(prefix: String, suffix: String = "") {
     val saveFunc = (rdd: RDD[T], time: Time) => {
-      if(rdd.partitions.size>0){
+      if (rdd.partitions.size > 0){
         val file = rddToFileName(prefix, suffix, time)
         rdd.saveAsTextFile(file)
       }


### PR DESCRIPTION
When I use DStream to save files to hdfs, it will create a directory and a empty file named "_SUCCESS" for each job which made in the batch duration.
But if there are no data from source for a long time , and the duration is very short(e.g. 10s), it will create so many directory and empty files in hdfs.
I don't think it is necessary. So I want to modify class DStream's method saveAsObjectFiles and saveAsTextFiles , it creates directory and files just when the RDD's partitions size > 0 .
