### PR TITLE
[SPARK-3251][MLLIB]: Clarify learning interfaces

### DIFF
--- a/examples/src/main/scala/org/apache/spark/examples/mllib/BinaryClassification.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/BinaryClassification.scala
@@ -131,7 +131,7 @@ object BinaryClassification {
           .setNumIterations(params.numIterations)
           .setUpdater(updater)
           .setRegParam(params.regParam)
-        algorithm.run(training).clearThreshold()
+        algorithm.run(training)
       case SVM =>
         val algorithm = new SVMWithSGD()
         algorithm.optimizer
@@ -139,10 +139,10 @@ object BinaryClassification {
           .setStepSize(params.stepSize)
           .setUpdater(updater)
           .setRegParam(params.regParam)
-        algorithm.run(training).clearThreshold()
+        algorithm.run(training)
     }
 
-    val prediction = model.predict(test.map(_.features))
+    val prediction = model.predictClass(test.map(_.features))
     val predictionAndLabel = prediction.zip(test.map(_.label))
 
     val metrics = new BinaryClassificationMetrics(predictionAndLabel)

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/LinearRegression.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/LinearRegression.scala
@@ -118,7 +118,7 @@ object LinearRegression extends App {
 
     val model = algorithm.run(training)
 
-    val prediction = model.predict(test.map(_.features))
+    val prediction = model.predictScore(test.map(_.features))
     val predictionAndLabel = prediction.zip(test.map(_.label))
 
     val loss = predictionAndLabel.map { case (p, l) =>

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/SparseNaiveBayes.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/SparseNaiveBayes.scala
@@ -91,7 +91,7 @@ object SparseNaiveBayes {
 
     val model = new NaiveBayes().setLambda(params.lambda).run(training)
 
-    val prediction = model.predict(test.map(_.features))
+    val prediction = model.predictClass(test.map(_.features))
     val predictionAndLabel = prediction.zip(test.map(_.label))
     val accuracy = predictionAndLabel.filter(x => x._1 == x._2).count().toDouble / numTest
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/classification/BinaryClassificationModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/classification/BinaryClassificationModel.scala
@@ -21,7 +21,6 @@ import org.apache.spark.mllib.linalg.Vector
 import org.apache.spark.rdd.RDD
 import org.apache.spark.mllib.regression.GeneralizedLinearModel
 import org.apache.spark.api.java.JavaRDD
-import scala.deprecated
 
 /**
  * Represents a classification model that predicts to which of a set of categories an example
@@ -33,7 +32,8 @@ class BinaryClassificationModel (
   extends GeneralizedLinearModel(weights, intercept) with ClassificationModel with Serializable {
 
   protected var threshold: Double = 0.0
-  @deprecated
+
+  // this is only used to ensure prior behaviour of deprecated `predict``
   protected var useThreshold: Boolean = true
 
   /**
@@ -61,7 +61,7 @@ class BinaryClassificationModel (
   }
 
   /**
-   * :: Deprecated ::
+   * DEPRECATED: Use predictScore(...) or predictClass(...) instead
    * Clears the threshold so that `predict` will output raw prediction scores.
    */
   @Deprecated
@@ -71,38 +71,50 @@ class BinaryClassificationModel (
   }
 
   /**
-   * :: Deprecated ::
+   * DEPRECATED: Use predictScore(...) or predictClass(...) instead
+   */
+  @Deprecated
+  override protected def predictPoint(
+                                       dataMatrix: Vector,
+                                       weightMatrix: Vector,
+                                       intercept: Double) = {
+    if (useThreshold) predictClass(dataMatrix)
+    else predictScore(dataMatrix)
+  }
+
+  /**
+   * DEPRECATED: Use predictScore(...) or predictClass(...) instead
    * Predict values for the given data set using the model trained.
    *
    * @param testData RDD representing data points to be predicted
    * @return an RDD[Double] where each entry contains the corresponding prediction
    */
-  @deprecated
+  @Deprecated
   override def predict(testData: RDD[Vector]): RDD[Double] = {
     if (useThreshold) predictClass(testData)
     else predictScore(testData)
   }
 
   /**
-   * :: Deprecated ::
+   * DEPRECATED: Use predictScore(...) or predictClass(...) instead
    * Predict values for a single data point using the model trained.
    *
    * @param testData array representing a single data point
    * @return predicted category from the trained model
    */
-  @deprecated
-  def predict(testData: Vector): Double = {
+  @Deprecated
+  override def predict(testData: Vector): Double = {
     if (useThreshold) predictClass(testData)
     else predictScore(testData)
   }
 
   /**
-   * :: Deprecated ::
+   * DEPRECATED: Use predictScore(...) or predictClass(...) instead
    * Predict values for examples stored in a JavaRDD.
    * @param testData JavaRDD representing data points to be predicted
    * @return a JavaRDD[java.lang.Double] where each entry contains the corresponding prediction
    */
-  @deprecated
+  @Deprecated
   def predict(testData: JavaRDD[Vector]): JavaRDD[java.lang.Double] =
     predict(testData.rdd).toJavaRDD().asInstanceOf[JavaRDD[java.lang.Double]]
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/classification/BinaryClassificationModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/classification/BinaryClassificationModel.scala
@@ -107,14 +107,4 @@ class BinaryClassificationModel (
     if (useThreshold) predictClass(testData)
     else predictScore(testData)
   }
-
-  /**
-   * DEPRECATED: Use predictScore(...) or predictClass(...) instead
-   * Predict values for examples stored in a JavaRDD.
-   * @param testData JavaRDD representing data points to be predicted
-   * @return a JavaRDD[java.lang.Double] where each entry contains the corresponding prediction
-   */
-  @Deprecated
-  def predict(testData: JavaRDD[Vector]): JavaRDD[java.lang.Double] =
-    predict(testData.rdd).toJavaRDD().asInstanceOf[JavaRDD[java.lang.Double]]
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/classification/BinaryClassificationModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/classification/BinaryClassificationModel.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.mllib.classification
+
+import org.apache.spark.annotation.Experimental
+import org.apache.spark.mllib.linalg.Vector
+import org.apache.spark.rdd.RDD
+import org.apache.spark.mllib.regression.GeneralizedLinearModel
+
+/**
+ * :: Experimental ::
+ * Represents a classification model that predicts to which of a set of categories an example
+ * belongs. The categories are represented by double values: 0.0, 1.0
+ */
+@Experimental
+class BinaryClassificationModel (
+     override val weights: Vector,
+     override val intercept: Double)
+  extends GeneralizedLinearModel(weights, intercept) with ClassificationModel[Double] with Serializable {
+
+  protected var threshold: Double = 0.0
+
+  /**
+   * :: Experimental ::
+   * Setter and getter for the threshold. The threshold separates positive predictions from
+   * negative predictions. An example with prediction score greater than or equal to this
+   * threshold is identified as an positive, and negative otherwise. The default value is 0.5.
+   */
+  @Experimental
+  def setThreshold(threshold: Double): this.type = {
+    this.threshold = threshold
+    this
+  }
+
+  def getThreshold = threshold
+
+  private def compareWithThreshold(value: Double): Double =
+    if (value < threshold) 0.0 else 1.0
+
+  def predictClass(testData: RDD[Vector]): RDD[Double] = {
+    predictScore(testData).map(compareWithThreshold)
+  }
+
+  def predictClass(testData: Vector): Double = {
+    compareWithThreshold(predictScore(testData))
+  }
+}

--- a/mllib/src/main/scala/org/apache/spark/mllib/classification/ClassificationModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/classification/ClassificationModel.scala
@@ -43,13 +43,13 @@ trait ClassificationModel extends Serializable {
    * @param testData array representing a single data point
    * @return predicted category from the trained model
    */
-  def predict(testData: Vector): Double
+  def predictClass(testData: Vector): Double
 
   /**
    * Predict values for examples stored in a JavaRDD.
    * @param testData JavaRDD representing data points to be predicted
    * @return a JavaRDD[java.lang.Double] where each entry contains the corresponding prediction
    */
-  def predict(testData: JavaRDD[Vector]): JavaRDD[java.lang.Double] =
-    predict(testData.rdd).toJavaRDD().asInstanceOf[JavaRDD[java.lang.Double]]
+  def predictClass(testData: JavaRDD[Vector]): JavaRDD[java.lang.Double] =
+    predictClass(testData.rdd).toJavaRDD().asInstanceOf[JavaRDD[java.lang.Double]]
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/classification/ClassificationModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/classification/ClassificationModel.scala
@@ -30,15 +30,15 @@ import org.apache.spark.rdd.RDD
 @Experimental
 trait ClassificationModel extends Serializable {
   /**
-   * Predict values for the given data set using the model trained.
+   * Classify the given data set using the model trained.
    *
-   * @param testData RDD representing data points to be predicted
+   * @param testData RDD representing data points to be classified
    * @return an RDD[Double] where each entry contains the corresponding prediction
    */
-  def predict(testData: RDD[Vector]): RDD[Double]
+  def predictClass(testData: RDD[Vector]): RDD[Double]
 
   /**
-   * Predict values for a single data point using the model trained.
+   * Classify a single data point using the model trained.
    *
    * @param testData array representing a single data point
    * @return predicted category from the trained model

--- a/mllib/src/main/scala/org/apache/spark/mllib/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/classification/LogisticRegression.scala
@@ -45,13 +45,21 @@ class LogisticRegressionModel (
   def predictProbability(testData: Vector): Double = {
     computeProbability(predictScore(testData))
   }
+
+  @deprecated
+  override protected def predictPoint(dataMatrix: Vector, weightMatrix: Vector,
+                                      intercept: Double) = {
+    if (useThreshold) predictClass(dataMatrix)
+    else predictProbability(dataMatrix)
+  }
 }
 
 /**
- * Train a classification model for Logistic Regression using limited-memory Broyden–Fletcher–Goldfarb–Shanno algorithm.
+ * Train a classification model for Logistic Regression using limited-memory
+ * Broyden–Fletcher–Goldfarb–Shanno algorithm.
  * NOTE: Labels used in Logistic Regression should be {0, 1}
  *
- * Using [[LogisticRegressionWithLBFGS]] is recommended over this.
+ * Using [[org.apache.spark.mllib.classification.LogisticRegressionWithLBFGS]] is recommended over this.
  */
 class LogisticRegressionWithSGD private (
     private var stepSize: Double,

--- a/mllib/src/main/scala/org/apache/spark/mllib/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/classification/LogisticRegression.scala
@@ -46,7 +46,10 @@ class LogisticRegressionModel (
     computeProbability(predictScore(testData))
   }
 
-  @deprecated
+  /**
+   * DEPRECATED: Use predictProbability(...) or predictClass(...) instead
+   */
+  @Deprecated
   override protected def predictPoint(dataMatrix: Vector, weightMatrix: Vector,
                                       intercept: Double) = {
     if (useThreshold) predictClass(dataMatrix)

--- a/mllib/src/main/scala/org/apache/spark/mllib/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/classification/LogisticRegression.scala
@@ -59,7 +59,7 @@ class LogisticRegressionModel (
  * Broyden–Fletcher–Goldfarb–Shanno algorithm.
  * NOTE: Labels used in Logistic Regression should be {0, 1}
  *
- * Using [[org.apache.spark.mllib.classification.LogisticRegressionWithLBFGS]] is recommended over this.
+ * Using [[LogisticRegressionWithLBFGS]] is recommended over this.
  */
 class LogisticRegressionWithSGD private (
     private var stepSize: Double,

--- a/mllib/src/main/scala/org/apache/spark/mllib/classification/NaiveBayes.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/classification/NaiveBayes.scala
@@ -65,6 +65,11 @@ class NaiveBayesModel private[mllib] (
   override def predictClass(testData: Vector): Double = {
     labels(brzArgmax(brzPi + brzTheta * testData.toBreeze))
   }
+
+  @deprecated
+  def predict(testData: RDD[Vector]): RDD[Double] = predictClass(testData)
+  @deprecated
+  def predict(testData: Vector): Double = predictClass(testData)
 }
 
 /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/classification/NaiveBayes.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/classification/NaiveBayes.scala
@@ -54,15 +54,15 @@ class NaiveBayesModel private[mllib] (
     }
   }
 
-  override def predict(testData: RDD[Vector]): RDD[Double] = {
+  override def predictClass(testData: RDD[Vector]): RDD[Double] = {
     val bcModel = testData.context.broadcast(this)
     testData.mapPartitions { iter =>
       val model = bcModel.value
-      iter.map(model.predict)
+      iter.map(model.predictClass)
     }
   }
 
-  override def predict(testData: Vector): Double = {
+  override def predictClass(testData: Vector): Double = {
     labels(brzArgmax(brzPi + brzTheta * testData.toBreeze))
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/classification/NaiveBayes.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/classification/NaiveBayes.scala
@@ -66,8 +66,15 @@ class NaiveBayesModel private[mllib] (
     labels(brzArgmax(brzPi + brzTheta * testData.toBreeze))
   }
 
-  @deprecated
+  /**
+   * DEPRECATED: Use predictClass(...) instead
+   */
+  @Deprecated
   def predict(testData: RDD[Vector]): RDD[Double] = predictClass(testData)
+
+  /**
+   * DEPRECATED: Use predictClass(...) instead
+   */
   @deprecated
   def predict(testData: Vector): Double = predictClass(testData)
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/classification/NaiveBayes.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/classification/NaiveBayes.scala
@@ -24,6 +24,7 @@ import org.apache.spark.SparkContext._
 import org.apache.spark.mllib.linalg.{DenseVector, SparseVector, Vector}
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.rdd.RDD
+import org.apache.spark.api.java.JavaRDD
 
 /**
  * Model for Naive Bayes Classifiers.
@@ -77,6 +78,13 @@ class NaiveBayesModel private[mllib] (
    */
   @deprecated
   def predict(testData: Vector): Double = predictClass(testData)
+
+  /**
+   * DEPRECATED: Use predictClass(...) instead
+   */
+  @Deprecated
+  def predict(testData: JavaRDD[Vector]): JavaRDD[java.lang.Double] =
+    predict(testData.rdd).toJavaRDD().asInstanceOf[JavaRDD[java.lang.Double]]
 }
 
 /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/classification/ProbabilisticClassificationModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/classification/ProbabilisticClassificationModel.scala
@@ -15,36 +15,32 @@
  * limitations under the License.
  */
 
-package org.apache.spark.mllib.regression
+package org.apache.spark.mllib.classification
 
 import org.apache.spark.annotation.Experimental
-import org.apache.spark.api.java.JavaRDD
-import org.apache.spark.rdd.RDD
 import org.apache.spark.mllib.linalg.Vector
+import org.apache.spark.rdd.RDD
 
+/**
+ * :: Experimental ::
+ * Represents a probabilistic classification model that provides a probability
+ * distribution over a set of classes, rather than only predicting a class.
+ */
 @Experimental
-trait RegressionModel extends Serializable {
+trait ProbabilisticClassificationModel extends ClassificationModel {
   /**
-   * Predict values for the given data set using the model trained.
+   * Return probability for the prediction of the given data set using the model trained.
    *
-   * @param testData RDD representing data points to be predicted
-   * @return RDD[Double] where each entry contains the corresponding prediction
+   * @param testData RDD representing data points to be classified
+   * @return an RDD[Double] where each entry contains the corresponding prediction
    */
-  def predictScore(testData: RDD[Vector]): RDD[Double]
+  def predictProbability(testData: RDD[Vector]): RDD[Double]
 
   /**
-   * Predict values for a single data point using the model trained.
+   * Return probability for a single data point prediction using the model trained.
    *
    * @param testData array representing a single data point
-   * @return Double prediction from the trained model
+   * @return predicted category from the trained model
    */
-  def predictScore(testData: Vector): Double
-
-  /**
-   * Predict values for examples stored in a JavaRDD.
-   * @param testData JavaRDD representing data points to be predicted
-   * @return a JavaRDD[java.lang.Double] where each entry contains the corresponding prediction
-   */
-  def predictScore(testData: JavaRDD[Vector]): JavaRDD[java.lang.Double] =
-    predictScore(testData.rdd).toJavaRDD().asInstanceOf[JavaRDD[java.lang.Double]]
+  def predictProbability(testData: Vector): Double
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/classification/SVM.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/classification/SVM.scala
@@ -33,15 +33,6 @@ class SVMModel (
                  override val weights: Vector,
                  override val intercept: Double)
   extends BinaryClassificationModel(weights, intercept) {
-
-  @deprecated
-  override protected def predictPoint(
-                                       dataMatrix: Vector,
-                                       weightMatrix: Vector,
-                                       intercept: Double) = {
-    if (useThreshold) predictClass(dataMatrix)
-    else predictScore(dataMatrix)
-  }
 }
 
 /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/GeneralizedLinearAlgorithm.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/GeneralizedLinearAlgorithm.scala
@@ -86,7 +86,7 @@ abstract class GeneralizedLinearModel(val weights: Vector, val intercept: Double
    * @param weightMatrix Column vector containing the weights of the model
    * @param intercept Intercept of the model.
    */
-  @deprecated
+  @Deprecated
   protected def predictPoint(dataMatrix: Vector, weightMatrix: Vector, intercept: Double): Double
 
   /**
@@ -96,7 +96,7 @@ abstract class GeneralizedLinearModel(val weights: Vector, val intercept: Double
    * @param testData RDD representing data points to be predicted
    * @return RDD[Double] where each entry contains the corresponding prediction
    */
-  @deprecated
+  @Deprecated
   def predict(testData: RDD[Vector]): RDD[Double] = {
     // A small optimization to avoid serializing the entire model. Only the weightsMatrix
     // and intercept is needed.
@@ -116,7 +116,7 @@ abstract class GeneralizedLinearModel(val weights: Vector, val intercept: Double
    * @param testData array representing a single data point
    * @return Double prediction from the trained model
    */
-  @deprecated
+  @Deprecated
   def predict(testData: Vector): Double = {
     predictPoint(testData, weights, intercept)
   }

--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/GeneralizedLinearAlgorithm.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/GeneralizedLinearAlgorithm.scala
@@ -24,6 +24,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.mllib.optimization._
 import org.apache.spark.mllib.linalg.{Vectors, Vector}
 import org.apache.spark.mllib.util.MLUtils._
+import org.apache.spark.api.java.JavaRDD
 
 /**
  * :: DeveloperApi ::
@@ -120,6 +121,13 @@ abstract class GeneralizedLinearModel(val weights: Vector, val intercept: Double
   def predict(testData: Vector): Double = {
     predictPoint(testData, weights, intercept)
   }
+
+  /**
+   * DEPRECATED: Use predictScore(...) instead
+   */
+  @Deprecated
+  def predict(testData: JavaRDD[Vector]): JavaRDD[java.lang.Double] =
+    predict(testData.rdd).toJavaRDD().asInstanceOf[JavaRDD[java.lang.Double]]
 }
 
 /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/GeneralizedLinearAlgorithm.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/GeneralizedLinearAlgorithm.scala
@@ -45,7 +45,9 @@ abstract class GeneralizedLinearModel(val weights: Vector, val intercept: Double
    * @param weightMatrix Column vector containing the weights of the model
    * @param intercept Intercept of the model.
    */
-  protected def predictPoint(dataMatrix: Vector, weightMatrix: Vector, intercept: Double): Double
+  protected def computeScore(dataMatrix: Vector, weightMatrix: Vector, intercept: Double): Double = {
+    weightMatrix.toBreeze.dot(dataMatrix.toBreeze) + intercept
+  }
 
   /**
    * Predict values for the given data set using the model trained.
@@ -53,7 +55,7 @@ abstract class GeneralizedLinearModel(val weights: Vector, val intercept: Double
    * @param testData RDD representing data points to be predicted
    * @return RDD[Double] where each entry contains the corresponding prediction
    */
-  def predict(testData: RDD[Vector]): RDD[Double] = {
+  def predictScore(testData: RDD[Vector]): RDD[Double] = {
     // A small optimization to avoid serializing the entire model. Only the weightsMatrix
     // and intercept is needed.
     val localWeights = weights
@@ -61,7 +63,7 @@ abstract class GeneralizedLinearModel(val weights: Vector, val intercept: Double
     val localIntercept = intercept
     testData.mapPartitions { iter =>
       val w = bcWeights.value
-      iter.map(v => predictPoint(v, w, localIntercept))
+      iter.map(v => computeScore(v, w, localIntercept))
     }
   }
 
@@ -71,8 +73,8 @@ abstract class GeneralizedLinearModel(val weights: Vector, val intercept: Double
    * @param testData array representing a single data point
    * @return Double prediction from the trained model
    */
-  def predict(testData: Vector): Double = {
-    predictPoint(testData, weights, intercept)
+  def predictScore(testData: Vector): Double = {
+    computeScore(testData, weights, intercept)
   }
 }
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/Lasso.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/Lasso.scala
@@ -34,7 +34,7 @@ class LassoModel (
   extends GeneralizedLinearModel(weights, intercept)
   with RegressionModel with Serializable {
 
-  override protected def predictPoint(
+  override protected def computeScore(
       dataMatrix: Vector,
       weightMatrix: Vector,
       intercept: Double): Double = {

--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/Lasso.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/Lasso.scala
@@ -34,12 +34,16 @@ class LassoModel (
   extends GeneralizedLinearModel(weights, intercept)
   with RegressionModel with Serializable {
 
-  override protected def computeScore(
-      dataMatrix: Vector,
-      weightMatrix: Vector,
-      intercept: Double): Double = {
-    weightMatrix.toBreeze.dot(dataMatrix.toBreeze) + intercept
-  }
+  /**
+   * DEPRECATED: Use predictScore(...) instead
+   */
+  @Deprecated
+  override protected def predictPoint(
+                                       dataMatrix: Vector,
+                                       weightMatrix: Vector,
+                                       intercept: Double): Double =
+    predictScore(dataMatrix)
+
 }
 
 /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/LinearRegression.scala
@@ -32,7 +32,7 @@ class LinearRegressionModel (
     override val intercept: Double)
   extends GeneralizedLinearModel(weights, intercept) with RegressionModel with Serializable {
 
-  override protected def predictPoint(
+  override protected def computeScore(
       dataMatrix: Vector,
       weightMatrix: Vector,
       intercept: Double): Double = {

--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/LinearRegression.scala
@@ -32,7 +32,11 @@ class LinearRegressionModel (
     override val intercept: Double)
   extends GeneralizedLinearModel(weights, intercept) with RegressionModel with Serializable {
 
-  @deprecated
+
+  /**
+   * DEPRECATED: Use predictScore(...) instead
+   */
+  @Deprecated
   override protected def predictPoint(
                                        dataMatrix: Vector,
                                        weightMatrix: Vector,

--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/LinearRegression.scala
@@ -32,12 +32,12 @@ class LinearRegressionModel (
     override val intercept: Double)
   extends GeneralizedLinearModel(weights, intercept) with RegressionModel with Serializable {
 
-  override protected def computeScore(
-      dataMatrix: Vector,
-      weightMatrix: Vector,
-      intercept: Double): Double = {
-    weightMatrix.toBreeze.dot(dataMatrix.toBreeze) + intercept
-  }
+  @deprecated
+  override protected def predictPoint(
+                                       dataMatrix: Vector,
+                                       weightMatrix: Vector,
+                                       intercept: Double) =
+    predictScore(dataMatrix)
 }
 
 /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/RidgeRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/RidgeRegression.scala
@@ -34,7 +34,7 @@ class RidgeRegressionModel (
   extends GeneralizedLinearModel(weights, intercept)
   with RegressionModel with Serializable {
 
-  override protected def predictPoint(
+  override protected def computeScore(
       dataMatrix: Vector,
       weightMatrix: Vector,
       intercept: Double): Double = {

--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/RidgeRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/RidgeRegression.scala
@@ -33,11 +33,14 @@ class RidgeRegressionModel (
   extends GeneralizedLinearModel(weights, intercept)
   with RegressionModel with Serializable {
 
-  @deprecated
+  /**
+   * DEPRECATED: Use predictScore(...) instead
+   */
+  @Deprecated
   override protected def predictPoint(
                                        dataMatrix: Vector,
                                        weightMatrix: Vector,
-                                       intercept: Double) =
+                                       intercept: Double): Double =
     predictScore(dataMatrix)
 
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/RidgeRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/RidgeRegression.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.mllib.regression
 
-import org.apache.spark.annotation.Experimental
 import org.apache.spark.rdd.RDD
 import org.apache.spark.mllib.optimization._
 import org.apache.spark.mllib.linalg.Vector
@@ -34,12 +33,13 @@ class RidgeRegressionModel (
   extends GeneralizedLinearModel(weights, intercept)
   with RegressionModel with Serializable {
 
-  override protected def computeScore(
-      dataMatrix: Vector,
-      weightMatrix: Vector,
-      intercept: Double): Double = {
-    weightMatrix.toBreeze.dot(dataMatrix.toBreeze) + intercept
-  }
+  @deprecated
+  override protected def predictPoint(
+                                       dataMatrix: Vector,
+                                       weightMatrix: Vector,
+                                       intercept: Double) =
+    predictScore(dataMatrix)
+
 }
 
 /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/StreamingLinearAlgorithm.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/StreamingLinearAlgorithm.scala
@@ -105,7 +105,7 @@ abstract class StreamingLinearAlgorithm[
       logError(msg)
       throw new IllegalArgumentException(msg)
     }
-    data.map(model.predict)
+    data.map(model.predictScore)
   }
 
   /**
@@ -120,6 +120,6 @@ abstract class StreamingLinearAlgorithm[
       logError(msg)
       throw new IllegalArgumentException(msg)
     }
-    data.mapValues(model.predict)
+    data.mapValues(model.predictScore)
   }
 }

--- a/mllib/src/test/java/org/apache/spark/mllib/classification/JavaLogisticRegressionSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/classification/JavaLogisticRegressionSuite.java
@@ -47,7 +47,7 @@ public class JavaLogisticRegressionSuite implements Serializable {
   int validatePrediction(List<LabeledPoint> validationData, LogisticRegressionModel model) {
     int numAccurate = 0;
     for (LabeledPoint point: validationData) {
-      Double prediction = model.predict(point.features());
+      Double prediction = model.predictScore(point.features());
       if (prediction == point.label()) {
         numAccurate++;
       }

--- a/mllib/src/test/java/org/apache/spark/mllib/classification/JavaLogisticRegressionSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/classification/JavaLogisticRegressionSuite.java
@@ -47,7 +47,7 @@ public class JavaLogisticRegressionSuite implements Serializable {
   int validatePrediction(List<LabeledPoint> validationData, LogisticRegressionModel model) {
     int numAccurate = 0;
     for (LabeledPoint point: validationData) {
-      Double prediction = model.predictScore(point.features());
+      Double prediction = model.predictClass(point.features());
       if (prediction == point.label()) {
         numAccurate++;
       }

--- a/mllib/src/test/java/org/apache/spark/mllib/classification/JavaNaiveBayesSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/classification/JavaNaiveBayesSuite.java
@@ -58,7 +58,7 @@ public class JavaNaiveBayesSuite implements Serializable {
   private int validatePrediction(List<LabeledPoint> points, NaiveBayesModel model) {
     int correct = 0;
     for (LabeledPoint p: points) {
-      if (model.predict(p.features()) == p.label()) {
+      if (model.predictClass(p.features()) == p.label()) {
         correct += 1;
       }
     }
@@ -98,7 +98,7 @@ public class JavaNaiveBayesSuite implements Serializable {
       public Vector call(LabeledPoint v) throws Exception {
         return v.features();
       }});
-    JavaRDD<Double> predictions = model.predict(vectors);
+    JavaRDD<Double> predictions = model.predictClass(vectors);
     // Should be able to get the first prediction.
     predictions.first();
   }

--- a/mllib/src/test/java/org/apache/spark/mllib/classification/JavaSVMSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/classification/JavaSVMSuite.java
@@ -43,10 +43,10 @@ public class JavaSVMSuite implements Serializable {
     sc = null;
   }
 
-  int validatePrediction(List<LabeledPoint> validationData, SVMModel model) {
+  int validatePrediction(List<LabeledPoint> validationData, BinaryClassificationModel model) {
     int numAccurate = 0;
     for (LabeledPoint point: validationData) {
-      Double prediction = model.predict(point.features());
+      Double prediction = model.predictClass(point.features());
       if (prediction == point.label()) {
         numAccurate++;
       }
@@ -70,7 +70,7 @@ public class JavaSVMSuite implements Serializable {
     svmSGDImpl.optimizer().setStepSize(1.0)
                           .setRegParam(1.0)
                           .setNumIterations(100);
-    SVMModel model = svmSGDImpl.run(testRDD.rdd());
+    BinaryClassificationModel model = svmSGDImpl.run(testRDD.rdd());
 
     int numAccurate = validatePrediction(validationData, model);
     Assert.assertTrue(numAccurate > nPoints * 4.0 / 5.0);
@@ -87,7 +87,7 @@ public class JavaSVMSuite implements Serializable {
     List<LabeledPoint> validationData =
         SVMSuite.generateSVMInputAsList(A, weights, nPoints, 17);
 
-    SVMModel model = SVMWithSGD.train(testRDD.rdd(), 100, 1.0, 1.0, 1.0);
+    BinaryClassificationModel model = SVMWithSGD.train(testRDD.rdd(), 100, 1.0, 1.0, 1.0);
 
     int numAccurate = validatePrediction(validationData, model);
     Assert.assertTrue(numAccurate > nPoints * 4.0 / 5.0);

--- a/mllib/src/test/java/org/apache/spark/mllib/regression/JavaLassoSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/regression/JavaLassoSuite.java
@@ -46,7 +46,7 @@ public class JavaLassoSuite implements Serializable {
   int validatePrediction(List<LabeledPoint> validationData, LassoModel model) {
     int numAccurate = 0;
     for (LabeledPoint point: validationData) {
-      Double prediction = model.predict(point.features());
+      Double prediction = model.predictScore(point.features());
       // A prediction is off if the prediction is more than 0.5 away from expected value.
       if (Math.abs(prediction - point.label()) <= 0.5) {
         numAccurate++;

--- a/mllib/src/test/java/org/apache/spark/mllib/regression/JavaLinearRegressionSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/regression/JavaLinearRegressionSuite.java
@@ -48,7 +48,7 @@ public class JavaLinearRegressionSuite implements Serializable {
   int validatePrediction(List<LabeledPoint> validationData, LinearRegressionModel model) {
     int numAccurate = 0;
     for (LabeledPoint point: validationData) {
-        Double prediction = model.predict(point.features());
+        Double prediction = model.predictScore(point.features());
         // A prediction is off if the prediction is more than 0.5 away from expected value.
         if (Math.abs(prediction - point.label()) <= 0.5) {
             numAccurate++;
@@ -108,7 +108,7 @@ public class JavaLinearRegressionSuite implements Serializable {
         return v.features();
       }
     });
-    JavaRDD<Double> predictions = model.predict(vectors);
+    JavaRDD<Double> predictions = model.predictScore(vectors);
     // Should be able to get the first prediction.
     predictions.first();
   }

--- a/mllib/src/test/java/org/apache/spark/mllib/regression/JavaRidgeRegressionSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/regression/JavaRidgeRegressionSuite.java
@@ -48,7 +48,7 @@ public class JavaRidgeRegressionSuite implements Serializable {
   double predictionError(List<LabeledPoint> validationData, RidgeRegressionModel model) {
     double errorSum = 0;
     for (LabeledPoint point: validationData) {
-      Double prediction = model.predict(point.features());
+      Double prediction = model.predictScore(point.features());
       errorSum += (prediction - point.label()) * (prediction - point.label());
     }
     return errorSum / validationData.size();

--- a/mllib/src/test/scala/org/apache/spark/mllib/classification/NaiveBayesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/classification/NaiveBayesSuite.scala
@@ -91,10 +91,10 @@ class NaiveBayesSuite extends FunSuite with LocalSparkContext {
     val validationRDD = sc.parallelize(validationData, 2)
 
     // Test prediction on RDD.
-    validatePrediction(model.predict(validationRDD.map(_.features)).collect(), validationData)
+    validatePrediction(model.predictClass(validationRDD.map(_.features)).collect(), validationData)
 
     // Test prediction on Array.
-    validatePrediction(validationData.map(row => model.predict(row.features)), validationData)
+    validatePrediction(validationData.map(row => model.predictClass(row.features)), validationData)
   }
 
   test("detect negative values") {
@@ -139,6 +139,6 @@ class NaiveBayesClusterSuite extends FunSuite with LocalClusterSparkContext {
     // If we serialize data directly in the task closure, the size of the serialized task would be
     // greater than 1MB and hence Spark would throw an error.
     val model = NaiveBayes.train(examples)
-    val predictions = model.predict(examples.map(_.features))
+    val predictions = model.predictClass(examples.map(_.features))
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/mllib/classification/SVMSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/classification/SVMSuite.scala
@@ -91,17 +91,17 @@ class SVMSuite extends FunSuite with LocalSparkContext {
 
     // Test prediction on RDD.
 
-    var predictions = model.predict(validationRDD.map(_.features)).collect()
+    var predictions = model.predictClass(validationRDD.map(_.features)).collect()
     assert(predictions.count(_ == 0.0) != predictions.length)
 
     // High threshold makes all the predictions 0.0
     model.setThreshold(10000.0)
-    predictions = model.predict(validationRDD.map(_.features)).collect()
+    predictions = model.predictClass(validationRDD.map(_.features)).collect()
     assert(predictions.count(_ == 0.0) == predictions.length)
 
     // Low threshold makes all the predictions 1.0
     model.setThreshold(-10000.0)
-    predictions = model.predict(validationRDD.map(_.features)).collect()
+    predictions = model.predictClass(validationRDD.map(_.features)).collect()
     assert(predictions.count(_ == 1.0) == predictions.length)
   }
 
@@ -127,10 +127,10 @@ class SVMSuite extends FunSuite with LocalSparkContext {
     val validationRDD  = sc.parallelize(validationData, 2)
 
     // Test prediction on RDD.
-    validatePrediction(model.predict(validationRDD.map(_.features)).collect(), validationData)
+    validatePrediction(model.predictClass(validationRDD.map(_.features)).collect(), validationData)
 
     // Test prediction on Array.
-    validatePrediction(validationData.map(row => model.predict(row.features)), validationData)
+    validatePrediction(validationData.map(row => model.predictClass(row.features)), validationData)
   }
 
   test("SVM local random SGD with initial weights") {
@@ -159,10 +159,10 @@ class SVMSuite extends FunSuite with LocalSparkContext {
     val validationRDD  = sc.parallelize(validationData,2)
 
     // Test prediction on RDD.
-    validatePrediction(model.predict(validationRDD.map(_.features)).collect(), validationData)
+    validatePrediction(model.predictClass(validationRDD.map(_.features)).collect(), validationData)
 
     // Test prediction on Array.
-    validatePrediction(validationData.map(row => model.predict(row.features)), validationData)
+    validatePrediction(validationData.map(row => model.predictClass(row.features)), validationData)
   }
 
   test("SVM with invalid labels") {
@@ -205,6 +205,6 @@ class SVMClusterSuite extends FunSuite with LocalClusterSparkContext {
     // If we serialize data directly in the task closure, the size of the serialized task would be
     // greater than 1MB and hence Spark would throw an error.
     val model = SVMWithSGD.train(points, 2)
-    val predictions = model.predict(points.map(_.features))
+    val predictions = model.predictClass(points.map(_.features))
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/mllib/regression/LassoSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/regression/LassoSuite.scala
@@ -67,10 +67,10 @@ class LassoSuite extends FunSuite with LocalSparkContext {
     val validationRDD  = sc.parallelize(validationData, 2)
 
     // Test prediction on RDD.
-    validatePrediction(model.predict(validationRDD.map(_.features)).collect(), validationData)
+    validatePrediction(model.predictScore(validationRDD.map(_.features)).collect(), validationData)
 
     // Test prediction on Array.
-    validatePrediction(validationData.map(row => model.predict(row.features)), validationData)
+    validatePrediction(validationData.map(row => model.predictScore(row.features)), validationData)
   }
 
   test("Lasso local random SGD with initial weights") {
@@ -110,10 +110,10 @@ class LassoSuite extends FunSuite with LocalSparkContext {
     val validationRDD  = sc.parallelize(validationData,2)
 
     // Test prediction on RDD.
-    validatePrediction(model.predict(validationRDD.map(_.features)).collect(), validationData)
+    validatePrediction(model.predictScore(validationRDD.map(_.features)).collect(), validationData)
 
     // Test prediction on Array.
-    validatePrediction(validationData.map(row => model.predict(row.features)), validationData)
+    validatePrediction(validationData.map(row => model.predictScore(row.features)), validationData)
   }
 }
 
@@ -129,6 +129,6 @@ class LassoClusterSuite extends FunSuite with LocalClusterSparkContext {
     // If we serialize data directly in the task closure, the size of the serialized task would be
     // greater than 1MB and hence Spark would throw an error.
     val model = LassoWithSGD.train(points, 2)
-    val predictions = model.predict(points.map(_.features))
+    val predictions = model.predictScore(points.map(_.features))
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/mllib/regression/LinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/regression/LinearRegressionSuite.scala
@@ -56,10 +56,10 @@ class LinearRegressionSuite extends FunSuite with LocalSparkContext {
     val validationRDD = sc.parallelize(validationData, 2).cache()
 
     // Test prediction on RDD.
-    validatePrediction(model.predict(validationRDD.map(_.features)).collect(), validationData)
+    validatePrediction(model.predictScore(validationRDD.map(_.features)).collect(), validationData)
 
     // Test prediction on Array.
-    validatePrediction(validationData.map(row => model.predict(row.features)), validationData)
+    validatePrediction(validationData.map(row => model.predictScore(row.features)), validationData)
   }
 
   // Test if we can correctly learn Y = 10*X1 + 10*X2
@@ -83,10 +83,10 @@ class LinearRegressionSuite extends FunSuite with LocalSparkContext {
     val validationRDD = sc.parallelize(validationData, 2).cache()
 
     // Test prediction on RDD.
-    validatePrediction(model.predict(validationRDD.map(_.features)).collect(), validationData)
+    validatePrediction(model.predictScore(validationRDD.map(_.features)).collect(), validationData)
 
     // Test prediction on Array.
-    validatePrediction(validationData.map(row => model.predict(row.features)), validationData)
+    validatePrediction(validationData.map(row => model.predictScore(row.features)), validationData)
   }
 
   // Test if we can correctly learn Y = 10*X1 + 10*X10000
@@ -118,11 +118,11 @@ class LinearRegressionSuite extends FunSuite with LocalSparkContext {
 
       // Test prediction on RDD.
     validatePrediction(
-      model.predict(sparseValidationRDD.map(_.features)).collect(), sparseValidationData)
+      model.predictScore(sparseValidationRDD.map(_.features)).collect(), sparseValidationData)
 
     // Test prediction on Array.
     validatePrediction(
-      sparseValidationData.map(row => model.predict(row.features)), sparseValidationData)
+      sparseValidationData.map(row => model.predictScore(row.features)), sparseValidationData)
   }
 }
 
@@ -138,6 +138,6 @@ class LinearRegressionClusterSuite extends FunSuite with LocalClusterSparkContex
     // If we serialize data directly in the task closure, the size of the serialized task would be
     // greater than 1MB and hence Spark would throw an error.
     val model = LinearRegressionWithSGD.train(points, 2)
-    val predictions = model.predict(points.map(_.features))
+    val predictions = model.predictScore(points.map(_.features))
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/mllib/regression/RidgeRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/regression/RidgeRegressionSuite.scala
@@ -61,7 +61,7 @@ class RidgeRegressionSuite extends FunSuite with LocalSparkContext {
 
     val linearModel = linearReg.run(testRDD)
     val linearErr = predictionError(
-        linearModel.predict(validationRDD.map(_.features)).collect(), validationData)
+        linearModel.predictScore(validationRDD.map(_.features)).collect(), validationData)
 
     val ridgeReg = new RidgeRegressionWithSGD()
     ridgeReg.optimizer.setNumIterations(200)
@@ -69,7 +69,7 @@ class RidgeRegressionSuite extends FunSuite with LocalSparkContext {
                       .setStepSize(1.0)
     val ridgeModel = ridgeReg.run(testRDD)
     val ridgeErr = predictionError(
-        ridgeModel.predict(validationRDD.map(_.features)).collect(), validationData)
+        ridgeModel.predictScore(validationRDD.map(_.features)).collect(), validationData)
 
     // Ridge validation error should be lower than linear regression.
     assert(ridgeErr < linearErr,
@@ -89,6 +89,6 @@ class RidgeRegressionClusterSuite extends FunSuite with LocalClusterSparkContext
     // If we serialize data directly in the task closure, the size of the serialized task would be
     // greater than 1MB and hence Spark would throw an error.
     val model = RidgeRegressionWithSGD.train(points, 2)
-    val predictions = model.predict(points.map(_.features))
+    val predictions = model.predictScore(points.map(_.features))
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/mllib/regression/StreamingLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/regression/StreamingLinearRegressionSuite.scala
@@ -75,7 +75,7 @@ class StreamingLinearRegressionSuite extends FunSuite with TestSuiteBase {
 
     // check accuracy of predictions
     val validationData = LinearDataGenerator.generateLinearInput(0.0, Array(10.0, 10.0), 100, 17)
-    validatePrediction(validationData.map(row => model.latestModel().predict(row.features)),
+    validatePrediction(validationData.map(row => model.latestModel().predictScore(row.features)),
       validationData)
   }
 


### PR DESCRIPTION
*\* Make threshold mandatory **
Currently, the output of `predict` for an example is either the score
or the class. This side-effect is caused by `clearThreshold`. To
clarify that behaviour three different types of predict (predictScore,
predictClass, predictProbabilty) were introduced; the threshold is not
longer optional.

*\* Clarify classification interfaces
Currently, some functionality is spreaded over multiple models.
In order to clarify the structure and simplify the implementation of
more complex models (like multinomial logistic regression), two new
classes are introduced:
- BinaryClassificationModel: for all models that derives a binary
  classification from a single weight vector. Comprises the tresholding
  functionality to derive a prediction from a score. It basically captures
  SVMModel and LogisticRegressionModel.
- ProbabilitistClassificaitonModel: This trait defines the interface for
  models that return a calibrated confidence score (aka probability).

*\* Misc
- some renaming
- add test for probabilistic output
