### PR TITLE
[Spark QA] Link to console output on test time out

### DIFF
--- a/dev/run-tests-jenkins
+++ b/dev/run-tests-jenkins
@@ -138,7 +138,7 @@ function post_message () {
   test_result="$?"
 
   if [ "$test_result" -eq "124" ]; then
-    fail_message="**Tests timed out** after a configured wait of \`${TESTS_TIMEOUT}\`."
+    fail_message="**[Tests timed out](${BUILD_URL}consoleFull)** after a configured wait of \`${TESTS_TIMEOUT}\`."
     post_message "$fail_message"
     exit $test_result
   else


### PR DESCRIPTION
When tests time out we should link to the Jenkins console output for easy review. We already do this for when tests start or complete normally.

Here's [a recent example](https://github.com/apache/spark/pull/2109#issuecomment-53374032) of where this would be helpful.
