### PR TITLE
[GraphX] Fixed backward-incompatible change to logNormalGraph API 

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/util/GraphGenerators.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/util/GraphGenerators.scala
@@ -50,13 +50,17 @@ object GraphGenerators {
    *
    * @param sc
    * @param numVertices
+   * @param numEParts
    * @param mu
    * @param sigma
    * @return
    */
-  def logNormalGraph(sc: SparkContext, numVertices: Int, numEParts: Int,
+  def logNormalGraph(sc: SparkContext, numVertices: Int, numEParts: Int = 0,
                      mu: Double = 4.0, sigma: Double = 1.3): Graph[Long, Int] = {
-    val vertices = sc.parallelize(0 until numVertices, numEParts).map { src =>
+
+    val evalNumEParts = if (numEParts == 0) sc.defaultParallelism else numEParts		         
+
+    val vertices = sc.parallelize(0 until numVertices, evalNumEParts).map { src =>
       // Initialize the random number generator with the source vertex id
       val rand = new Random(src)
       val degree = math.min(numVertices.toLong, math.exp(rand.nextGaussian() * sigma + mu).toLong)


### PR DESCRIPTION
PR #720 added a required parameter to logNormalGraph(), breaking backwards compatibility.  PR did not update function docs and GraphX programming guide, either.  This new PR makes the parameter optional so that both versions of the API are supported, maintaining backwards compatibility
