### PR TITLE
SPARK-3200, SPARK-4165 [REPL] Classes defined with reference to external variables, should not crash REPL.

### DIFF
--- a/examples/src/main/scala/org/apache/spark/examples/SparkPi.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/SparkPi.scala
@@ -20,6 +20,7 @@ package org.apache.spark.examples
 import scala.math.random
 
 import org.apache.spark._
+import org.apache.spark.SparkContext._
 
 /** Computes an approximation to pi */
 object SparkPi {

--- a/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkImports.scala
+++ b/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkImports.scala
@@ -57,7 +57,8 @@ trait SparkImports {
     importHandlers filter (_.importsWildcard) map (_.targetType) distinct
   }
   def wildcardTypes = languageWildcards ++ sessionWildcards
-
+  def mapReqHandlers    = allReqAndHandlers.filter(x => x._1.definedNames.nonEmpty)
+    .map(x => x._1.definedNames.head -> x._2).toMap
   def languageSymbols        = languageWildcardSyms flatMap membersAtPickler
   def sessionImportedSymbols = importHandlers flatMap (_.importedSymbols)
   def importedSymbols        = languageSymbols ++ sessionImportedSymbols
@@ -150,6 +151,7 @@ trait SparkImports {
     }
 
     val code, trailingBraces, accessPath = new StringBuilder
+    var importMap = mutable.LinkedHashMap[String, String]()
     val currentImps = mutable.HashSet[Name]()
 
     // add code for a new object to hold some imports
@@ -160,11 +162,6 @@ trait SparkImports {
       accessPath append ("." + impname)
 
       currentImps.clear
-      // code append "object %s {\n".format(impname)
-      // trailingBraces append "}\n"
-      // accessPath append ("." + impname)
-
-      // currentImps.clear
     }
 
     addWrapper()
@@ -178,7 +175,8 @@ trait SparkImports {
           if (x.importsWildcard || currentImps.exists(x.importedNames contains _))
             addWrapper()
 
-          code append (x.member + "\n")
+          // code append (x.member + "\n")
+          importMap += (x.importString -> (x.member + "\n"))
 
           // give wildcard imports a import wrapper all to their own
           if (x.importsWildcard) addWrapper()
@@ -190,33 +188,47 @@ trait SparkImports {
         // the name of the variable, so that we don't need to
         // handle quoting keywords separately.
         case x: ClassHandler if !fallback =>
-        // I am trying to guess if the import is a defined class
-        // This is an ugly hack, I am not 100% sure of the consequences.
-        // Here we, let everything but "defined classes" use the import with val.
-        // The reason for this is, otherwise the remote executor tries to pull the
-        // classes involved and may fail.
+          // If its a defined class and does not refers a val outside, then we can import it
+          // directly, however if it refers an outside val we have to use a different import
+          // strategy.
+
+          // Checks whether this class referred an outside val.
+          val refersVal = x.referencedNames.exists(y => mapReqHandlers.getOrElse(y, x).isInstanceOf[ValHandler])
           for (imv <- x.definedNames) {
+            if (importMap.contains(imv.decoded)) {
+              importMap.remove(imv.decoded)
+            }
             val objName = req.lineRep.readPath
-            code.append("import " + objName + ".INSTANCE" + req.accessPath + ".`" + imv + "`\n")
+            if (!refersVal) {
+              importMap += (imv.decoded -> s"""
+                   |import $objName.INSTANCE${req.accessPath}.`$imv`
+                 """.stripMargin)
+            } else {
+              val valName = "$VAL" + newValId()
+              importMap += (imv.decoded -> s"""
+                  |val $valName = $objName.INSTANCE
+                  |import $valName${req.accessPath}.`$imv`
+                  |""".stripMargin)
+            }
+            currentImps += imv
           }
 
         case x =>
           for (imv <- x.definedNames) {
-            if (currentImps contains imv) addWrapper()
+            if (importMap.contains(imv.decoded)) {
+              importMap.remove(imv.decoded)
+            }
             val objName = req.lineRep.readPath
             val valName = "$VAL" + newValId()
-
-            if(!code.toString.endsWith(".`" + imv + "`;\n")) { // Which means already imported
-                code.append("val " + valName + " = " + objName + ".INSTANCE;\n")
-                code.append("import " + valName + req.accessPath + ".`" + imv + "`;\n")
-            }
-            // code.append("val " + valName + " = " + objName + ".INSTANCE;\n")
-            // code.append("import " + valName + req.accessPath + ".`" + imv + "`;\n")
-            // code append ("import " + (req fullPath imv) + "\n")
+            importMap.put(imv.decoded, s"""
+                  |val $valName = $objName.INSTANCE
+                  |import $valName${req.accessPath}.`$imv`
+                  |""".stripMargin)
             currentImps += imv
           }
       }
     }
+    for ((_, c) <- importMap) yield code.append(c)
     // add one extra wrapper, to prevent warnings in the common case of
     // redefining the value bound in the last interpreter request.
     addWrapper()

--- a/repl/scala-2.10/src/test/scala/org/apache/spark/repl/ReplSuite.scala
+++ b/repl/scala-2.10/src/test/scala/org/apache/spark/repl/ReplSuite.scala
@@ -281,6 +281,17 @@ class ReplSuite extends FunSuite {
     assertDoesNotContain("Exception", output)
   }
 
+  test("SPARK-3200 Class defined with reference to external variables") {
+    val output = runInterpreter("local",
+      """
+        |val a = sc.parallelize(1 to 100).count
+        |case class A(i: Int) { val j = a}
+        |sc.parallelize(1 to 10).map(A(_)).collect()
+      """.stripMargin)
+    assertDoesNotContain("error:", output)
+    assertDoesNotContain("Exception", output)
+  }
+
   if (System.getenv("MESOS_NATIVE_LIBRARY") != null) {
     test("running on Mesos") {
       val output = runInterpreter("localquiet",


### PR DESCRIPTION
This might not be a critical bug fix. But this patch will make things more predictable. 

In this patch, I have introduced another condition. Where if a class refers to an external variable then we just fallback to our old style of importing.

For example,  
When class does not refers any outside variable.

``` scala

scala> case class A()
case class A()
defined class A

scala> A() // show
A() // show
class $read extends Serializable {
  def <init>() = {
    super.<init>;
    ()
  };
  class $iwC extends Serializable {
    def <init>() = {
      super.<init>;
      ()
    };
    class $iwC extends Serializable {
      def <init>() = {
        super.<init>;
        ()
      };
      class $iwC extends Serializable {
        def <init>() = {
          super.<init>;
          ()
        };
        import org.apache.spark.SparkContext._;
        import $line11.$read.INSTANCE.$iw.$iw.A; // <--- place of interest. 
        class $iwC extends Serializable {
          def <init>() = {
            super.<init>;
            ()
          };
          val res1 = A
        };
        val $iw = new $iwC.<init>
      };
      val $iw = new $iwC.<init>
    };
    val $iw = new $iwC.<init>
  };
  val $iw = new $iwC.<init>
}
object $read extends scala.AnyRef {
  def <init>() = {
    super.<init>;
    ()
  };
  val INSTANCE = new $read.<init>
}
res1: A = A()

```

And when it does refer outside variable.

``` scala
scala> val c = 10
val c = 10
c: Int = 10

scala> case class A() { val q = c }
case class A() { val q = c }
defined class A

scala> A() // show
A() // show
class $read extends Serializable {
  def <init>() = {
    super.<init>;
    ()
  };
  class $iwC extends Serializable {
    def <init>() = {
      super.<init>;
      ()
    };
    class $iwC extends Serializable {
      def <init>() = {
        super.<init>;
        ()
      };
      class $iwC extends Serializable {
        def <init>() = {
          super.<init>;
          ()
        };
        import org.apache.spark.SparkContext._;
        val $VAL2 = $line13.$read.INSTANCE;
        import $VAL2.$iw.$iw.$iw.$iw.c;  // <--- place of interest. 
        val $VAL4 = $line14.$read.INSTANCE;
        import $VAL4.$iw.$iw.A;  // <--- place of interest. 
        class $iwC extends Serializable {
          def <init>() = {
            super.<init>;
            ()
          };
          val res2 = A
        };
        val $iw = new $iwC.<init>
      };
      val $iw = new $iwC.<init>
    };
    val $iw = new $iwC.<init>
  };
  val $iw = new $iwC.<init>
}
object $read extends scala.AnyRef {
  def <init>() = {
    super.<init>;
    ()
  };
  val INSTANCE = new $read.<init>
}
res2: A = A()

```

Note the difference in how `A` is imported in both cases. 
[EDIT]
With this patch few other non-regression/never reported and non critical bug like if you import [exp.scala](https://gist.github.com/ScrapCodes/d6dc6efd7b0e24e638b3) twice will break things is also solved. 

However I have consciously chosen to "retain" a bug that two instances of classes that refer external variables will not be of same type. I can explain why this is so.   
