### PR TITLE
[SPARK-3061] Fix Maven build under Windows

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -318,7 +318,7 @@
         </executions>
         <configuration>
           <tasks>
-            <unzip src="../python/lib/py4j-0.8.2.1-src.zip" dest="build" />
+            <unzip src="../python/lib/py4j-0.8.2.1-src.zip" dest="../python/build" />
           </tasks>
         </configuration>
       </plugin>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -306,26 +306,20 @@
       </plugin>
       <!-- Unzip py4j so we can include its files in the jar -->
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>1.2.1</version>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
         <executions>
           <execution>
             <phase>generate-resources</phase>
             <goals>
-              <goal>exec</goal>
+              <goal>run</goal>
             </goals>
           </execution>
         </executions>
         <configuration>
-          <executable>unzip</executable>
-          <workingDirectory>../python</workingDirectory>
-          <arguments>
-            <argument>-o</argument>
-            <argument>lib/py4j*.zip</argument>
-            <argument>-d</argument>
-            <argument>build</argument>
-          </arguments>
+          <tasks>
+              <unzip src="../python/lib/py4j-0.8.2.1-src.zip" dest="build" />
+          </tasks>
         </configuration>
       </plugin>
       <plugin>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -318,7 +318,7 @@
         </executions>
         <configuration>
           <tasks>
-              <unzip src="../python/lib/py4j-0.8.2.1-src.zip" dest="build" />
+            <unzip src="../python/lib/py4j-0.8.2.1-src.zip" dest="build" />
           </tasks>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -880,7 +880,7 @@
           <configuration>
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
             <junitxml>.</junitxml>
-            <filereports>${project.build.directory}/SparkTestSuite.txt</filereports>
+            <filereports>SparkTestSuite.txt</filereports>
             <argLine>-Xmx3g -XX:MaxPermSize=${MaxPermGen} -XX:ReservedCodeCacheSize=512m</argLine>
             <stderr/>
             <systemProperties>


### PR DESCRIPTION
The Maven build was failing on Windows because it tried to call the unix `unzip` utility to extract the Py4J files into core's build directory.  I've fixed this issue by using the `maven-antrun-plugin` to perform the unzipping.

I also fixed an issue that prevented tests from running under Windows:

In the Maven ScalaTest plugin, the filename listed in <filereports> is placed under the <reportsDirectory>; the current code places it in a subdirectory of reportsDirectory, e.g.

```
${project.build.directory}/surefire-reports/${project.build.directory}/SparkTestSuite.txt
```

This caused problems under Windows because it would try to create a subdirectory named "c:\".

Note that the tests still fail under Windows (for other reasons); this PR just allows them to run and fail rather than crash when trying to create the test reports directory.
