### PR TITLE
SPARK-3265 Allow using custom ipython executable with pyspark

### DIFF
--- a/bin/pyspark
+++ b/bin/pyspark
@@ -104,7 +104,7 @@ if [[ "$1" =~ \.py$ ]]; then
 else
   # Only use ipython if no command line arguments were provided [SPARK-1134]
   if [[ "$IPYTHON" = "1" ]]; then
-    exec ipython $IPYTHON_OPTS
+    exec ${PYSPARK_PYTHON:-ipython} $IPYTHON_OPTS
   else
     exec "$PYSPARK_PYTHON"
   fi


### PR DESCRIPTION
Although you can make pyspark use ipython with `IPYTHON=1`, and also change the python executable with `PYSPARK_PYTHON=...`, you can't use both at the same time because it hardcodes the default ipython script.

This makes it use the `PYSPARK_PYTHON` variable if present and fall back to default python, similarly to how the default python executable is handled.

So you can use a custom ipython like so:
`PYSPARK_PYTHON=./anaconda/bin/ipython IPYTHON_OPTS="notebook" pyspark`
