### PR TITLE
[HOTFIX][SQL] Remove cleaning of UDFs

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUdf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUdf.scala
@@ -23,9 +23,6 @@ import org.apache.spark.util.ClosureCleaner
 case class ScalaUdf(function: AnyRef, dataType: DataType, children: Seq[Expression])
   extends Expression {
 
-  // Clean function when not called with default no-arg constructor.
-  if (function != null) { ClosureCleaner.clean(function) }
-
   type EvaluatedType = Any
 
   def nullable = true


### PR DESCRIPTION
It is not safe to run the closure cleaner on slaves.  #2153 introduced this which broke all UDF execution on slaves.  Will re-add cleaning of UDF closures in a follow-up PR.
