### PR TITLE
[Spark QA] only check code files for new classes

### DIFF
--- a/dev/run-tests-jenkins
+++ b/dev/run-tests-jenkins
@@ -33,9 +33,7 @@ COMMIT_URL="https://github.com/apache/spark/commit/${ghprbActualCommit}"
 # GitHub doesn't auto-link short hashes when submitted via the API, unfortunately. :(
 SHORT_COMMIT_HASH="${ghprbActualCommit:0:7}"
 
-# NOTE: Jenkins will kill the whole build after 120 minutes.
-#       Tests are a large part of that, but not all of it.
-TESTS_TIMEOUT="120m"
+TESTS_TIMEOUT="120m" # format: http://linux.die.net/man/1/timeout
 
 function post_message () {
   local message=$1
@@ -93,7 +91,12 @@ function post_message () {
   else
     merge_note=" * This patch merges cleanly."
 
-    non_test_files=$(git diff master --name-only | grep -v "\/test" | tr "\n" " ")
+    non_test_files=$(
+        git diff master --name-only \
+      | grep -v -e "\/test"                         `# ignore files in test directories` \
+      | grep -e "\.py$" -e "\.java$" -e "\.scala$"  `# include only code files` \
+      | tr "\n" " "
+    )
     new_public_classes=$(
         git diff master ${non_test_files}       `# diff this patch against master and...` \
       | grep "^\+"                              `# filter in only added lines` \

--- a/dev/run-tests-jenkins
+++ b/dev/run-tests-jenkins
@@ -141,7 +141,8 @@ function post_message () {
   test_result="$?"
 
   if [ "$test_result" -eq "124" ]; then
-    fail_message="**[Tests timed out](${BUILD_URL}consoleFull)** after a configured wait of \`${TESTS_TIMEOUT}\`."
+    fail_message="**[Tests timed out](${BUILD_URL}consoleFull)** after \
+    a configured wait of \`${TESTS_TIMEOUT}\`."
     post_message "$fail_message"
     exit $test_result
   else

--- a/dev/run-tests-jenkins
+++ b/dev/run-tests-jenkins
@@ -91,14 +91,14 @@ function post_message () {
   else
     merge_note=" * This patch merges cleanly."
 
-    non_test_files=$(
+    source_files=$(
         git diff master --name-only \
       | grep -v -e "\/test"                         `# ignore files in test directories` \
       | grep -e "\.py$" -e "\.java$" -e "\.scala$"  `# include only code files` \
       | tr "\n" " "
     )
     new_public_classes=$(
-        git diff master ${non_test_files}       `# diff this patch against master and...` \
+        git diff master ${source_files}         `# diff this patch against master and...` \
       | grep "^\+"                              `# filter in only added lines` \
       | sed -r -e "s/^\+//g"                    `# remove the leading +` \
       | grep -e "trait " -e "class "            `# filter in lines with these key words` \


### PR DESCRIPTION
Look only at code files (`.py`, `.java`, and `.scala`) for new classes.

Should get rid of false alarms like [the one reported here](https://github.com/apache/spark/pull/2014#issuecomment-52912040).
