### PR TITLE
[SPARK-3300][SQL] No need to call clear() and shorten build()

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/columnar/ColumnBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/columnar/ColumnBuilder.scala
@@ -75,8 +75,7 @@ private[sql] class BasicColumnBuilder[T <: DataType, JvmType](
   }
 
   override def build() = {
-    buffer.limit(buffer.position()).rewind()
-    buffer
+    buffer.flip().asInstanceOf[ByteBuffer]
   }
 }
 
@@ -133,9 +132,6 @@ private[sql] object ColumnBuilder {
         .allocate(newSize)
         .order(ByteOrder.nativeOrder())
         .put(orig.array(), 0, pos)
-
-      // should clear old buffer after copying its content
-      orig.clear()
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/columnar/ColumnBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/columnar/ColumnBuilder.scala
@@ -129,11 +129,13 @@ private[sql] object ColumnBuilder {
       val newSize = capacity + size.max(capacity / 8 + 1)
       val pos = orig.position()
 
-      orig.clear()
       ByteBuffer
         .allocate(newSize)
         .order(ByteOrder.nativeOrder())
         .put(orig.array(), 0, pos)
+
+      // should clear old buffer after copying its content
+      orig.clear()
     }
   }
 


### PR DESCRIPTION
The function `ensureFreeSpace` in object `ColumnBuilder` clears old buffer before copying its content to new buffer. This PR fixes it.
