### PR TITLE
[SPARK-1919] Fix Windows spark-shell --jars

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -325,7 +325,14 @@ private[spark] object Utils extends Logging {
     val targetFile = new File(targetDir, filename)
     val uri = new URI(url)
     val fileOverwrite = conf.getBoolean("spark.files.overwrite", false)
-    uri.getScheme match {
+    // In Windows, the URL may be the raw path starting with a root drive (e.g. C:/)
+    // We need to format this correctly so that the drive is not interpreted as a URI scheme
+    val formattedURI =
+      uri.getScheme match {
+        case windowsDrive(d) if isWindows => new URI("file:/" + uri)
+        case _ => uri
+      }
+    formattedURI.getScheme match {
       case "http" | "https" | "ftp" =>
         logInfo("Fetching " + url + " to " + tempFile)
 

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -325,14 +325,7 @@ private[spark] object Utils extends Logging {
     val targetFile = new File(targetDir, filename)
     val uri = new URI(url)
     val fileOverwrite = conf.getBoolean("spark.files.overwrite", false)
-    // In Windows, the URL may be the raw path starting with a root drive (e.g. C:/)
-    // We need to format this correctly so that the drive is not interpreted as a URI scheme
-    val formattedURI =
-      uri.getScheme match {
-        case windowsDrive(d) if isWindows => new URI("file:/" + uri)
-        case _ => uri
-      }
-    formattedURI.getScheme match {
+    uri.getScheme match {
       case "http" | "https" | "ftp" =>
         logInfo("Fetching " + url + " to " + tempFile)
 

--- a/repl/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -176,7 +176,7 @@ class SparkILoop(in0: Option[BufferedReader], protected val out: JPrintWriter,
     }
   }
 
-  class SparkILoopInterpreter extends SparkIMain(settings, out) with Logging {
+  class SparkILoopInterpreter extends SparkIMain(settings, out) {
     outer =>
 
     override lazy val formatting = new Formatting {
@@ -194,9 +194,6 @@ class SparkILoop(in0: Option[BufferedReader], protected val out: JPrintWriter,
     val totalClassPath = SparkILoop.getAddedJars.foldLeft(
       settings.classpath.value)((l, r) => ClassPath.join(l, r))
     this.settings.classpath.value = totalClassPath
-
-    logError("HELLO")
-    logError("MY CLASSPATH = " + settings.classpath.value)
 
     intp = new SparkILoopInterpreter
   }


### PR DESCRIPTION
We were trying to add `file:/C:/path/to/my.jar` to the class path. We should add `C:/path/to/my.jar` instead. Tested on Windows 8.1.
