### PR TITLE
[SPARK-3327] Make broadcasted value mutable for caching useful information

### DIFF
--- a/core/src/main/scala/org/apache/spark/broadcast/Broadcast.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/Broadcast.scala
@@ -109,6 +109,14 @@ abstract class Broadcast[T: ClassTag](val id: Long) extends Serializable {
   protected def getValue(): T
 
   /**
+   * Actually set the broadcasted value. Concrete implementations of Broadcast class must
+   * define their own way to set the value.
+   * @param setter The function computes and returns new broadcasted value based on current value
+   */
+
+  def setValue(setter: (T) => T): Unit
+
+  /**
    * Actually unpersist the broadcasted value on the executors. Concrete implementations of
    * Broadcast class must define their own logic to unpersist their own data.
    */

--- a/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
@@ -65,9 +65,27 @@ private[spark] class TorrentBroadcast[T: ClassTag](
   private val broadcastId = BroadcastBlockId(id)
 
   /** Total number of blocks this broadcast variable contains. */
-  private val numBlocks: Int = writeBlocks()
+  private var numBlocks: Int = writeBlocks()
 
   override protected def getValue() = _value
+
+  override def setValue(setter: (T) => T) = {
+    TorrentBroadcast.synchronized {
+
+      // Obtain latest value from blockManager
+
+      SparkEnv.get.blockManager.getLocal(broadcastId).map(_.data.next()) match {
+        case Some(x) =>
+          _value = setter(x.asInstanceOf[T])
+
+        case None =>
+          throw new SparkException("Failed to get value of " + broadcastId)
+      }
+
+      doDestroy(true)
+      numBlocks = writeBlocks()
+    }
+  }
 
   /**
    * Divide the object into multiple blocks and put those blocks in the block manager.

--- a/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
@@ -82,7 +82,7 @@ private[spark] class TorrentBroadcast[T: ClassTag](
           throw new SparkException("Failed to get value of " + broadcastId)
       }
 
-      doDestroy(true)
+      SparkEnv.get.blockManager.removeBroadcast(id, false)
       numBlocks = writeBlocks()
     }
   }


### PR DESCRIPTION
This PR makes broadcasted value mutable for caching useful information when implementing some algorithms that iteratively run with those information.

Some algorithms can be implemented more efficiently if we can update broadcasted variables and use them in later iterations.

Specifically, we would like to perform operation "A" on each partition of data. Some variables are updated. Then we want to run operation "B" on the data too. "B" operation uses the variables updated by operation "A".

One of the examples is the Liblinear on Spark from Dr. Lin. They discuss the problem in Section IV.D of the paper "Large-scale Logistic Regression and Linear Support Vector Machines Using Spark." I have successfully applied this PR to Dr.Lin's Linlinear Spark implementation.

This implementation can make sure that updated broadcasted variables are consistent after parallel data operations (such as map) are done on the broadcasted variables at same node.
