### PR TITLE
SPARK-3330 [BUILD] Successive test runs with different profiles fail SparkSubmitSuite

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -948,6 +948,23 @@
     </pluginManagement>
 
     <plugins>
+      <!--
+      Additionally clean assembly/target when parent is cleaned. Many assemblies can
+      build up here when different profiles are built, and these are not otherwise cleaned
+      with "mvn clean" since the assembly module is not declared as a submodule
+      -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>2.5</version>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>assembly/target</directory>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>


### PR DESCRIPTION
Maven-based Jenkins builds have been failing for a while:
https://amplab.cs.berkeley.edu/jenkins/view/Spark/job/Spark-Master-Maven-with-YARN/480/HADOOP_PROFILE=hadoop-2.4,label=centos/console

One common cause is that on the second and subsequent runs of "mvn clean test", at least two assembly JARs will exist in assembly/target. Because assembly is not a submodule of parent, "mvn clean" is not invoked for assembly. The presence of two assembly jars causes spark-submit to fail.
