### PR TITLE
SPARK-3331 [BUILD] PEP8 tests fail because they check unzipped py4j code

### DIFF
--- a/dev/lint-python
+++ b/dev/lint-python
@@ -44,7 +44,7 @@ fi
 #+ first, but we do so so that the check status can
 #+ be output before the report, like with the
 #+ scalastyle and RAT checks.
-python $PEP8_SCRIPT_PATH ./python > "$PEP8_REPORT_PATH"
+python $PEP8_SCRIPT_PATH ./python/pyspark > "$PEP8_REPORT_PATH"
 pep8_status=${PIPESTATUS[0]} #$?
 
 if [ $pep8_status -ne 0 ]; then


### PR DESCRIPTION
PEP8 tests run on files under "./python", but unzipped py4j code is found at "./python/build/py4j". Py4J code fails style checks and can fail ./dev/run-tests if this code is present locally.
