### PR TITLE
SPARK-3332 - Tags shouldn't be the main strategy for machine membership on clusters

### DIFF
--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -508,10 +508,16 @@ def get_existing_cluster(conn, opts, cluster_name, die_on_error=True):
     for res in reservations:
         active = [i for i in res.instances if is_active(i)]
         for inst in active:
+            group_names = [g.name for g in inst.groups]
             name = inst.tags.get(u'Name', "")
-            if name.startswith(cluster_name + "-master"):
+            master_name = cluster_name + "-master"
+            slave_name = cluster_name + "-slave"
+            # Check by tag name is required when --security-group-prefix flag is used
+            # but it's not failsafe, so also check by group name
+            # which is a more solid strategy in the general case
+            if name.startswith(master_name) or master_name in group_names:
                 master_nodes.append(inst)
-            elif name.startswith(cluster_name + "-slave"):
+            elif name.startswith(slave_name) or slave_name + 's' in group_names:
                 slave_nodes.append(inst)
     if any((master_nodes, slave_nodes)):
         print ("Found %d master(s), %d slaves" % (len(master_nodes), len(slave_nodes)))
@@ -597,7 +603,6 @@ def get_num_disks(instance_type):
         "m1.medium":   1,
         "m1.large":    2,
         "m1.xlarge":   4,
-        "t1.micro":    1,
         "c1.medium":   1,
         "c1.xlarge":   4,
         "m2.xlarge":   1,


### PR DESCRIPTION
See the issue for more information. This PR is related to #1899.

Also removed a redundant entry for t1.micro.
