### PR TITLE
[SPARK-3373][GraphX]: Filtering operations should optionally rebuild routing tables

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/Graph.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/Graph.scala
@@ -285,8 +285,8 @@ abstract class Graph[VD: ClassTag, ED: ClassTag] protected () extends Serializab
    * satisfy the predicates
    */
   def subgraph(
-      epred: EdgeTriplet[VD,ED] => Boolean = (x => true),
-      vpred: (VertexId, VD) => Boolean = ((v, d) => true),
+      epred: EdgeTriplet[VD,ED] => Boolean,
+      vpred: (VertexId, VD) => Boolean,
       updateRoutingTable: Boolean)
   : Graph[VD, ED]
 

--- a/graphx/src/main/scala/org/apache/spark/graphx/Graph.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/Graph.scala
@@ -253,22 +253,34 @@ abstract class Graph[VD: ClassTag, ED: ClassTag] protected () extends Serializab
    * @param vpred the vertex predicate, which takes a vertex object and
    * evaluates to true if the vertex is to be included in the subgraph
    *
+   * @param trim Whether to update the routingTable in VertexRDD with less size.
+   * If set to true, the negative effects is the new VertexRDD can not used to
+   * update original graph
+   *
    * @return the subgraph containing only the vertices and edges that
    * satisfy the predicates
    */
   def subgraph(
       epred: EdgeTriplet[VD,ED] => Boolean = (x => true),
-      vpred: (VertexId, VD) => Boolean = ((v, d) => true))
+      vpred: (VertexId, VD) => Boolean = ((v, d) => true),
+      trim: Boolean = false)
     : Graph[VD, ED]
 
   /**
    * Restricts the graph to only the vertices and edges that are also in `other`, but keeps the
    * attributes from this graph.
    * @param other the graph to project this graph onto
+   *
+   * @param trim Whether to update the routingTable in VertexRDD  with less size. If set to true,
+   * the negative effects is the new VertexRDD can not used to update original graph
+   *
    * @return a graph with vertices and edges that exist in both the current graph and `other`,
    * with vertex and edge data from the current graph
    */
-  def mask[VD2: ClassTag, ED2: ClassTag](other: Graph[VD2, ED2]): Graph[VD, ED]
+  def mask[VD2: ClassTag, ED2: ClassTag](
+      other: Graph[VD2, ED2],
+      trim: Boolean = false)
+    : Graph[VD, ED]
 
   /**
    * Merges multiple edges between two vertices into a single edge. For correct results, the graph
@@ -277,9 +289,12 @@ abstract class Graph[VD: ClassTag, ED: ClassTag] protected () extends Serializab
    * @param merge the user-supplied commutative associative function to merge edge attributes
    *              for duplicate edges.
    *
+   * @param trim Whether to update the routingTable in VertexRDD with less size. If set to true,
+   * the negative effects is the new VertexRDD can not used to update original graph
+   *
    * @return The resulting graph with a single edge for each (source, dest) vertex pair.
    */
-  def groupEdges(merge: (ED, ED) => ED): Graph[VD, ED]
+  def groupEdges(merge: (ED, ED) => ED, trim: Boolean = false): Graph[VD, ED]
 
   /**
    * Aggregates values from the neighboring edges and vertices of each vertex.  The user supplied

--- a/graphx/src/main/scala/org/apache/spark/graphx/Graph.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/Graph.scala
@@ -253,9 +253,33 @@ abstract class Graph[VD: ClassTag, ED: ClassTag] protected () extends Serializab
    * @param vpred the vertex predicate, which takes a vertex object and
    * evaluates to true if the vertex is to be included in the subgraph
    *
-   * @param trim Whether to update the routingTable in VertexRDD with less size.
-   * If set to true, the negative effects is the new VertexRDD can not used to
-   * update original graph
+   * @return the subgraph containing only the vertices and edges that
+   * satisfy the predicates
+   */
+  def subgraph(
+      epred: EdgeTriplet[VD,ED] => Boolean = (x => true),
+      vpred: (VertexId, VD) => Boolean = ((v, d) => true))
+    : Graph[VD, ED]
+
+  /**
+   * Restricts the graph to only the vertices and edges satisfying the predicates. The resulting
+   * subgraph satisifies
+   *
+   * {{{
+   * V' = {v : for all v in V where vpred(v)}
+   * E' = {(u,v): for all (u,v) in E where epred((u,v)) && vpred(u) && vpred(v)}
+   * }}}
+   *
+   * @param epred the edge predicate, which takes a triplet and
+   * evaluates to true if the edge is to remain in the subgraph.  Note
+   * that only edges where both vertices satisfy the vertex
+   * predicate are considered.
+   *
+   * @param vpred the vertex predicate, which takes a vertex object and
+   * evaluates to true if the vertex is to be included in the subgraph
+   *
+   * @param updateRoutingTable whether to rebuild the routingTable in
+   * VertexRDD to reduce the shuffle when shipping VertexAttributes.
    *
    * @return the subgraph containing only the vertices and edges that
    * satisfy the predicates
@@ -263,7 +287,19 @@ abstract class Graph[VD: ClassTag, ED: ClassTag] protected () extends Serializab
   def subgraph(
       epred: EdgeTriplet[VD,ED] => Boolean = (x => true),
       vpred: (VertexId, VD) => Boolean = ((v, d) => true),
-      trim: Boolean = false)
+      updateRoutingTable: Boolean)
+  : Graph[VD, ED]
+
+  /**
+   * Restricts the graph to only the vertices and edges that are also in `other`, but keeps the
+   * attributes from this graph.
+   * @param other the graph to project this graph onto
+   *
+   * @return a graph with vertices and edges that exist in both the current graph and `other`,
+   * with vertex and edge data from the current graph
+   */
+  def mask[VD2: ClassTag, ED2: ClassTag](
+      other: Graph[VD2, ED2])
     : Graph[VD, ED]
 
   /**
@@ -271,16 +307,16 @@ abstract class Graph[VD: ClassTag, ED: ClassTag] protected () extends Serializab
    * attributes from this graph.
    * @param other the graph to project this graph onto
    *
-   * @param trim Whether to update the routingTable in VertexRDD  with less size. If set to true,
-   * the negative effects is the new VertexRDD can not used to update original graph
+   * @param updateRoutingTable whether to rebuild the routingTable in VertexRDD to reduce the
+   * shuffle when shipping VertexAttributes.
    *
    * @return a graph with vertices and edges that exist in both the current graph and `other`,
    * with vertex and edge data from the current graph
    */
   def mask[VD2: ClassTag, ED2: ClassTag](
       other: Graph[VD2, ED2],
-      trim: Boolean = false)
-    : Graph[VD, ED]
+      updateRoutingTable: Boolean)
+  : Graph[VD, ED]
 
   /**
    * Merges multiple edges between two vertices into a single edge. For correct results, the graph
@@ -289,12 +325,23 @@ abstract class Graph[VD: ClassTag, ED: ClassTag] protected () extends Serializab
    * @param merge the user-supplied commutative associative function to merge edge attributes
    *              for duplicate edges.
    *
-   * @param trim Whether to update the routingTable in VertexRDD with less size. If set to true,
-   * the negative effects is the new VertexRDD can not used to update original graph
+   * @return The resulting graph with a single edge for each (source, dest) vertex pair.
+   */
+  def groupEdges(merge: (ED, ED) => ED): Graph[VD, ED]
+
+  /**
+   * Merges multiple edges between two vertices into a single edge. For correct results, the graph
+   * must have been partitioned using [[partitionBy]].
+   *
+   * @param merge the user-supplied commutative associative function to merge edge attributes
+   *              for duplicate edges.
+   *
+   * @param updateRoutingTable whether to rebuild the routingTable in VertexRDD to reduce the
+   * shuffle when shipping VertexAttributes.
    *
    * @return The resulting graph with a single edge for each (source, dest) vertex pair.
    */
-  def groupEdges(merge: (ED, ED) => ED, trim: Boolean = false): Graph[VD, ED]
+  def groupEdges(merge: (ED, ED) => ED, updateRoutingTable: Boolean): Graph[VD, ED]
 
   /**
    * Aggregates values from the neighboring edges and vertices of each vertex.  The user supplied

--- a/graphx/src/main/scala/org/apache/spark/graphx/impl/GraphImpl.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/impl/GraphImpl.scala
@@ -139,9 +139,16 @@ class GraphImpl[VD: ClassTag, ED: ClassTag] protected (
   }
 
   override def subgraph(
+      epred: EdgeTriplet[VD,ED] => Boolean = (x => true),
+      vpred: (VertexId, VD) => Boolean = ((v, d) => true))
+    : Graph[VD, ED] = {
+    subgraph(epred, vpred, false)
+  }
+
+  override def subgraph(
       epred: EdgeTriplet[VD, ED] => Boolean = x => true,
       vpred: (VertexId, VD) => Boolean = (a, b) => true,
-      trim: Boolean = false): Graph[VD, ED] = {
+      updateRoutingTable: Boolean): Graph[VD, ED] = {
     vertices.cache()
     // Filter the vertices, reusing the partitioner and the index from this graph
     val newVerts = vertices.mapVertexPartitions(_.filter(vpred))
@@ -149,36 +156,30 @@ class GraphImpl[VD: ClassTag, ED: ClassTag] protected (
     // on both src and dst vertices
     replicatedVertexView.upgrade(vertices, true, true)
     val newEdges = replicatedVertexView.edges.filter(epred, vpred)
-    if(trim) {
-      val trimmedVertex = newVerts.withEdges(newEdges)
-      new GraphImpl(trimmedVertex, replicatedVertexView.withEdges(newEdges))
-    } else {
-      new GraphImpl(newVerts, replicatedVertexView.withEdges(newEdges))
-    }
+    rebuildRoutingTable(newVerts, newEdges, updateRoutingTable)
+  }
+
+  override def mask[VD2: ClassTag, ED2: ClassTag](
+      other: Graph[VD2, ED2]) : Graph[VD, ED] = {
+    mask(other, false)
   }
 
   override def mask[VD2: ClassTag, ED2: ClassTag] (
       other: Graph[VD2, ED2],
-      trim: Boolean = false): Graph[VD, ED] = {
+      updateRoutingTable: Boolean): Graph[VD, ED] = {
     val newVerts = vertices.innerJoin(other.vertices) { (vid, v, w) => v }
     val newEdges = replicatedVertexView.edges.innerJoin(other.edges) { (src, dst, v, w) => v }
-    if(trim) {
-      val trimmedVertex = newVerts.withEdges(newEdges)
-      new GraphImpl(trimmedVertex, replicatedVertexView.withEdges(newEdges))
-    } else {
-      new GraphImpl(newVerts, replicatedVertexView.withEdges(newEdges))
-    }
+    rebuildRoutingTable(newVerts, newEdges, updateRoutingTable)
   }
 
-  override def groupEdges(merge: (ED, ED) => ED, trim: Boolean = false): Graph[VD, ED] = {
+  override def groupEdges(merge: (ED, ED) => ED): Graph[VD, ED] = {
+    groupEdges(merge, false)
+  }
+
+  override def groupEdges(merge: (ED, ED) => ED, updateRoutingTable: Boolean): Graph[VD, ED] = {
     val newEdges = replicatedVertexView.edges.mapEdgePartitions(
       (pid, part) => part.groupEdges(merge))
-    if(trim) {
-      val trimmedVertex = vertices.withEdges(newEdges)
-      new GraphImpl(trimmedVertex, replicatedVertexView.withEdges(newEdges))
-    } else {
-      new GraphImpl(vertices, replicatedVertexView.withEdges(newEdges))
-    }
+    rebuildRoutingTable(vertices, newEdges, updateRoutingTable)
   }
 
   // ///////////////////////////////////////////////////////////////////////////////////////////////
@@ -276,6 +277,19 @@ class GraphImpl[VD: ClassTag, ED: ClassTag] protected (
       case _: ClassNotFoundException => true // if we don't know, be conservative
     }
   }
+
+  private def rebuildRoutingTable(
+      vertices: VertexRDD[VD],
+      edges: EdgeRDD[ED, VD],
+      updateRoutingTable: Boolean): Graph[VD, ED] = {
+    if(updateRoutingTable) {
+      val newVertex = vertices.withEdges(edges)
+      new GraphImpl(newVertex, replicatedVertexView.withEdges(edges))
+    } else {
+      new GraphImpl(vertices, replicatedVertexView.withEdges(edges))
+    }
+  }
+
 } // end of class GraphImpl
 
 

--- a/graphx/src/main/scala/org/apache/spark/graphx/impl/GraphImpl.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/impl/GraphImpl.scala
@@ -146,9 +146,10 @@ class GraphImpl[VD: ClassTag, ED: ClassTag] protected (
   }
 
   override def subgraph(
-      epred: EdgeTriplet[VD, ED] => Boolean = x => true,
-      vpred: (VertexId, VD) => Boolean = (a, b) => true,
-      updateRoutingTable: Boolean): Graph[VD, ED] = {
+      epred: EdgeTriplet[VD, ED] => Boolean,
+      vpred: (VertexId, VD) => Boolean,
+      updateRoutingTable: Boolean)
+    : Graph[VD, ED] = {
     vertices.cache()
     // Filter the vertices, reusing the partitioner and the index from this graph
     val newVerts = vertices.mapVertexPartitions(_.filter(vpred))


### PR DESCRIPTION
Graph operations that filter the edges (subgraph, mask, groupEdges) currently reuse the existing routing table to avoid the shuffle which would be required to build a new one. However, this may be inefficient when the filtering is highly selective. Vertices will be sent to more partitions than necessary, and the extra routing information may take up excessive space.
