### PR TITLE
[Minor] Fix outdated Spark version

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1294,7 +1294,7 @@ class SparkContext(config: SparkConf) extends Logging {
  */
 object SparkContext extends Logging {
 
-  private[spark] val SPARK_VERSION = "1.1.0"
+  private[spark] val SPARK_VERSION = "1.2.0"
 
   private[spark] val SPARK_JOB_DESCRIPTION = "spark.job.description"
 

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1294,7 +1294,7 @@ class SparkContext(config: SparkConf) extends Logging {
  */
 object SparkContext extends Logging {
 
-  private[spark] val SPARK_VERSION = "1.0.0"
+  private[spark] val SPARK_VERSION = "1.1.0"
 
   private[spark] val SPARK_JOB_DESCRIPTION = "spark.job.description"
 

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1294,7 +1294,7 @@ class SparkContext(config: SparkConf) extends Logging {
  */
 object SparkContext extends Logging {
 
-  private[spark] val SPARK_VERSION = "1.2.0"
+  private[spark] val SPARK_VERSION = "1.2.0-SNAPSHOT"
 
   private[spark] val SPARK_JOB_DESCRIPTION = "spark.job.description"
 


### PR DESCRIPTION
This is causing the event logs to include a file called SPARK_VERSION_1.0.0, which is not accurate.
