### PR TITLE
[SPARK-3393] [SQL] Align the log4j configuration for Spark & SparkSQLCLI

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -73,18 +73,6 @@ private[hive] object SparkSQLCLIDriver {
       System.exit(1)
     }
 
-    // NOTE: It is critical to do this here so that log4j is reinitialized
-    // before any of the other core hive classes are loaded
-    var logInitFailed = false
-    var logInitDetailMessage: String = null
-    try {
-      logInitDetailMessage = LogUtils.initHiveLog4j()
-    } catch {
-      case e: LogInitializationException =>
-        logInitFailed = true
-        logInitDetailMessage = e.getMessage
-    }
-
     val sessionState = new CliSessionState(new HiveConf(classOf[SessionState]))
 
     sessionState.in = System.in
@@ -98,11 +86,6 @@ private[hive] object SparkSQLCLIDriver {
 
     if (!oproc.process_stage2(sessionState)) {
       System.exit(2)
-    }
-
-    if (!sessionState.getIsSilent) {
-      if (logInitFailed) System.err.println(logInitDetailMessage)
-      else SessionState.getConsole.printInfo(logInitDetailMessage)
     }
 
     // Set all properties specified via command line.


### PR DESCRIPTION
User may be confused for the HQL logging & configurations, we'd better provide a default templates.

Both files are copied from Hive.
