### PR TITLE
[SPARK-3415] [PySpark] removes SerializingAdapter code

### DIFF
--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -180,6 +180,7 @@ class PySparkTestCase(unittest.TestCase):
         self.sc.stop()
         sys.path = self._old_sys_path
 
+
 # Regression test for SPARK-3415
 class CloudPickleTestCase(PySparkTestCase):
     def test_pickling_file_handles(self):
@@ -190,6 +191,7 @@ class CloudPickleTestCase(PySparkTestCase):
         self.cp = CloudPickler(file)
         r = self.cp.save_file(out)
         self.assertEquals(None, r)
+
 
 class TestCheckpoint(PySparkTestCase):
 

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -169,6 +169,17 @@ class SerializationTestCase(unittest.TestCase):
         self.assertEquals(p1, p2)
 
 
+# Regression test for SPARK-3415
+class CloudPickleTest(unittest.TestCase):
+    def test_pickling_file_handles(self):
+        from pyspark.cloudpickle import dumps
+        from StringIO import StringIO
+        from pickle import load
+        out1 = sys.stderr
+        out2 = load(StringIO(dumps(out1)))
+        self.assertEquals(out1, out2)
+
+
 class PySparkTestCase(unittest.TestCase):
 
     def setUp(self):
@@ -179,17 +190,6 @@ class PySparkTestCase(unittest.TestCase):
     def tearDown(self):
         self.sc.stop()
         sys.path = self._old_sys_path
-
-
-# Regression test for SPARK-3415
-class CloudPickleTest(unittest.TestCase):
-    def test_pickling_file_handles(self):
-        from pyspark.cloudpickle import dumps
-        out = sys.stderr
-        r = dumps(out)
-        exp = ('\x80\x02c__builtin__\ngetattr\nq\x00cpyspark.cloudpickle\n'
-               'subimport\nq\x01U\x03sysq\x02\x85q\x03Rq\x04U\x06stderrq\x05\x86q\x06Rq\x07.')
-        self.assertEquals(exp, r)
 
 
 class TestCheckpoint(PySparkTestCase):

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -180,22 +180,16 @@ class PySparkTestCase(unittest.TestCase):
         self.sc.stop()
         sys.path = self._old_sys_path
 
+# Regression test for SPARK-3415
 class CloudPickleTestCase(PySparkTestCase):
-    def SetUp(self):
-        PySparkTestCase.setUp(self)
-    def tearDown(self):
-        PySparkTestCase.tearDown(self)
-    def test_CloudPickle(self):
-        self.t = self.CloudPickleTestClass()
-        a = [ 1 , 2, 3, 4, 5 ]
-        b = self.sc.parallelize(a)
-        c = b.map(self.t.getOk)
-        self.assertEquals('ok', c.first())
-    class CloudPickleTestClass(object):
-        def __init__(self, out = sys.stderr):
-            self.out = out
-        def getOk(self, args):
-            return 'ok'
+    def test_pickling_file_handles(self):
+        from pyspark.cloudpickle import CloudPickler
+        from StringIO import StringIO
+        file = StringIO()
+        out = sys.stderr
+        self.cp = CloudPickler(file)
+        r = self.cp.save_file(out)
+        self.assertEquals(None, r)
 
 class TestCheckpoint(PySparkTestCase):
 
@@ -1119,6 +1113,7 @@ class TestWorker(PySparkTestCase):
         N = 1100  # fd limit is 1024 by default
         rdd = self.sc.parallelize(range(N), N)
         self.assertEquals(N, rdd.count())
+
 
 class TestSparkSubmit(unittest.TestCase):
 

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -180,6 +180,22 @@ class PySparkTestCase(unittest.TestCase):
         self.sc.stop()
         sys.path = self._old_sys_path
 
+class CloudPickleTestCase(PySparkTestCase):
+    def SetUp(self):
+        PySparkTestCase.setUp(self)
+    def tearDown(self):
+        PySparkTestCase.tearDown(self)
+    def test_CloudPickle(self):
+        self.t = self.CloudPickleTestClass()
+        a = [ 1 , 2, 3, 4, 5 ]
+        b = self.sc.parallelize(a)
+        c = b.map(self.t.getOk)
+        self.assertEquals('ok', c.first())
+    class CloudPickleTestClass(object):
+        def __init__(self, out = sys.stderr):
+            self.out = out
+        def getOk(self, args):
+            return 'ok'
 
 class TestCheckpoint(PySparkTestCase):
 
@@ -1104,6 +1120,24 @@ class TestWorker(PySparkTestCase):
         rdd = self.sc.parallelize(range(N), N)
         self.assertEquals(N, rdd.count())
 
+class TestCloudPickle(unittest.TestCase):
+    class TestClass(object):
+        def __init__(self, out = sys.stderr):
+            self.out = out
+        def getOk(self):
+            return 'ok'
+    def SetUp(self):
+        ok = 'ok'
+        PySparkTestCase.setUp(self)
+        t = TestClass()
+        a = [ 1 , 2, 3, 4, 5 ]
+        b = self.sc.parallelize(a)
+        c = b.map(lambda x: f())
+        self.assertEquals(ok, c.first())
+    def tearDown(self):
+        PySparkTestCase.tearDown(self)
+    def f():
+        return t.getOk()
 
 class TestSparkSubmit(unittest.TestCase):
 

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -182,15 +182,14 @@ class PySparkTestCase(unittest.TestCase):
 
 
 # Regression test for SPARK-3415
-class CloudPickleTestCase(PySparkTestCase):
+class CloudPickleTest(unittest.TestCase):
     def test_pickling_file_handles(self):
-        from pyspark.cloudpickle import CloudPickler
-        from StringIO import StringIO
-        file = StringIO()
+        from pyspark.cloudpickle import dumps
         out = sys.stderr
-        self.cp = CloudPickler(file)
-        r = self.cp.save_file(out)
-        self.assertEquals(None, r)
+        r = dumps(out)
+        exp = ('\x80\x02c__builtin__\ngetattr\nq\x00cpyspark.cloudpickle\n'
+               'subimport\nq\x01U\x03sysq\x02\x85q\x03Rq\x04U\x06stderrq\x05\x86q\x06Rq\x07.')
+        self.assertEquals(exp, r)
 
 
 class TestCheckpoint(PySparkTestCase):

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -1120,25 +1120,6 @@ class TestWorker(PySparkTestCase):
         rdd = self.sc.parallelize(range(N), N)
         self.assertEquals(N, rdd.count())
 
-class TestCloudPickle(unittest.TestCase):
-    class TestClass(object):
-        def __init__(self, out = sys.stderr):
-            self.out = out
-        def getOk(self):
-            return 'ok'
-    def SetUp(self):
-        ok = 'ok'
-        PySparkTestCase.setUp(self)
-        t = TestClass()
-        a = [ 1 , 2, 3, 4, 5 ]
-        b = self.sc.parallelize(a)
-        c = b.map(lambda x: f())
-        self.assertEquals(ok, c.first())
-    def tearDown(self):
-        PySparkTestCase.tearDown(self)
-    def f():
-        return t.getOk()
-
 class TestSparkSubmit(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
This code removes the SerializingAdapter code that was copied from PiCloud
