### PR TITLE
[SPARK-3417] -Use new-style classes in PySpark

### DIFF
--- a/python/pyspark/mllib/random.py
+++ b/python/pyspark/mllib/random.py
@@ -28,7 +28,7 @@ from pyspark.serializers import NoOpSerializer
 __all__ = ['RandomRDDs', ]
 
 
-class RandomRDDs:
+class RandomRDDs(object):
     """
     Generator methods for creating RDDs comprised of i.i.d samples from
     some distribution.

--- a/python/pyspark/mllib/util.py
+++ b/python/pyspark/mllib/util.py
@@ -25,7 +25,7 @@ from pyspark.rdd import RDD
 from pyspark.serializers import NoOpSerializer
 
 
-class MLUtils:
+class MLUtils(object):
 
     """
     Helper methods to load, save and pre-process data used in MLlib.

--- a/python/pyspark/sql.py
+++ b/python/pyspark/sql.py
@@ -898,7 +898,7 @@ def _create_cls(dataType):
     return Row
 
 
-class SQLContext:
+class SQLContext(object):
 
     """Main entry point for SparkSQL functionality.
 

--- a/python/pyspark/storagelevel.py
+++ b/python/pyspark/storagelevel.py
@@ -18,7 +18,7 @@
 __all__ = ["StorageLevel"]
 
 
-class StorageLevel:
+class StorageLevel(object):
 
     """
     Flags for controlling the storage of an RDD. Each StorageLevel records whether to use memory,


### PR DESCRIPTION
Tiny PR making SQLContext a new-style class.  This allows various type logic to work more effectively

``` Python
In [1]: import pyspark

In [2]: pyspark.sql.SQLContext.mro()
Out[2]: [pyspark.sql.SQLContext, object]
```
