### PR TITLE
[SPARK-3421][SQL] Allows arbitrary character in StructField.name

### DIFF
--- a/python/pyspark/sql.py
+++ b/python/pyspark/sql.py
@@ -278,8 +278,23 @@ class StructField(DataType):
         self.nullable = nullable
 
     def __repr__(self):
-        return "StructField(%s,%s,%s)" % (self.name, self.dataType,
-                                          str(self.nullable).lower())
+        """
+        >>> 'StructField("f1",StringType,True)'
+        ...      == StructField("f1", StringType, True)
+        True
+        >>> 'StructField("f 1",StringType,True)'
+        ...      == StructField("f 1", StringType, True)
+        True
+        >>> 'StructField("f \\"1\\"",StringType,True)'
+        ...      == StructField('f "1"', StringType, True)
+        True
+        >>> 'StructField("f \\\\1",StringType,True)'
+        ...      == StructField('f \\1', StringType, True)
+        True
+        """
+        escapedName = self.name.replace('\\', '\\\\').replace('"', '\\"')
+        return 'StructField("%s",%s,%s)' % (escapedName, self.dataType,
+                                            str(self.nullable).lower())
 
 
 class StructType(DataType):

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/dataTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/dataTypes.scala
@@ -72,7 +72,7 @@ object DataType extends RegexParsers {
     "false" ^^^ false
 
   protected lazy val structType: Parser[DataType] =
-    "StructType\\([A-Za-z]*\\(".r ~> repsep(structField, ",") <~ "))" ^^ {
+    "StructType(List(" ~> repsep(structField, ",") <~ "))" ^^ {
       case fields => new StructType(fields)
     }
 
@@ -375,6 +375,8 @@ case class StructType(fields: Seq[StructField]) extends DataType {
   }
 
   def simpleString: String = "struct"
+
+  override def toString = s"StructType(List(${fields.map(_.toString).mkString(",")}))"
 }
 
 object MapType {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/dataTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/dataTypes.scala
@@ -31,6 +31,8 @@ import org.apache.spark.util.Utils
  * Utility functions for working with DataTypes.
  */
 object DataType extends RegexParsers {
+  override def skipWhitespace: Boolean = false
+
   protected lazy val primitiveType: Parser[DataType] =
     "StringType" ^^^ StringType |
     "FloatType" ^^^ FloatType |

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataTypeSuite.scala
@@ -55,4 +55,38 @@ class DataTypeSuite extends FunSuite {
       struct(Set("b", "d", "e", "f"))
     }
   }
+
+  test("StructField.toString") {
+    def structFieldWithName(name: String) = StructField(name, StringType, nullable = true)
+
+    assertResult("""StructField("a",StringType,true)""") {
+      structFieldWithName("a").toString
+    }
+
+    assertResult("""StructField("(a)",StringType,true)""") {
+      structFieldWithName("(a)").toString
+    }
+
+    assertResult("""StructField("a\\b\"",StringType,true)""") {
+      structFieldWithName("""a\b"""").toString
+    }
+  }
+
+  test("parsing StructField string") {
+    val expected = StructType(
+      StructField("a", StringType, true) ::
+      StructField("\"b\"", StringType, true) ::
+      StructField("\"c\\", StringType, true) ::
+      Nil)
+
+    val structTypeString = Seq(
+      """StructType(List(""",
+      """StructField("a",StringType,true),""",
+      """StructField("\"b\"",StringType,true),""",
+      """StructField("\"c\\",StringType,true)""",
+      """))"""
+    ).mkString
+
+    assert(catalyst.types.DataType(structTypeString) === expected)
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.hive.execution
 
 import scala.util.Try
 
-import org.apache.spark.sql.{SchemaRDD, Row}
 import org.apache.spark.sql.hive._
 import org.apache.spark.sql.hive.test.TestHive
 import org.apache.spark.sql.hive.test.TestHive._
@@ -313,7 +312,7 @@ class HiveQuerySuite extends HiveComparisonTest {
     "SELECT srcalias.KEY, SRCALIAS.value FROM sRc SrCAlias WHERE SrCAlias.kEy < 15")
 
   test("case sensitivity: registered table") {
-    val testData: SchemaRDD =
+    val testData =
       TestHive.sparkContext.parallelize(
         TestData(1, "str1") ::
         TestData(2, "str2") :: Nil)
@@ -327,7 +326,7 @@ class HiveQuerySuite extends HiveComparisonTest {
 
   def isExplanation(result: SchemaRDD) = {
     val explanation = result.select('plan).collect().map { case Row(plan: String) => plan }
-    explanation.exists(_ == "== Physical Plan ==")
+    explanation.contains("== Physical Plan ==")
   }
 
   test("SPARK-1704: Explain commands as a SchemaRDD") {
@@ -467,7 +466,7 @@ class HiveQuerySuite extends HiveComparisonTest {
     }
 
     // Describe a registered temporary table.
-    val testData: SchemaRDD =
+    val testData =
       TestHive.sparkContext.parallelize(
         TestData(1, "str1") ::
         TestData(1, "str2") :: Nil)


### PR DESCRIPTION
`StructField.toString` now quotes the `name` field and escapes backslashes and double quotes within the string. The `DataType` parser is also updated to parse double quoted string as `StructField` name.

**UPDATE** Spark SQL Python binding is also updated.
