### PR TITLE
[SPARK-3418] Sparse Matrix support (CCS) and additional native BLAS operations added

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
@@ -212,10 +212,8 @@ private[mllib] object BLAS extends Serializable with Logging {
 
   /**
    * C := alpha * A * B + beta * C
-   * @param transA specify whether to use matrix A, or the transpose of matrix A. Should be "N" or
-   *               "n" to use A, and "T" or "t" to use the transpose of A.
-   * @param transB specify whether to use matrix B, or the transpose of matrix B. Should be "N" or
-   *               "n" to use B, and "T" or "t" to use the transpose of B.
+   * @param transA whether to use the transpose of matrix A (true), or A itself (false).
+   * @param transB whether to use the transpose of matrix B (true), or B itself (false).
    * @param alpha a scalar to scale the multiplication A * B.
    * @param A the matrix A that will be left multiplied to B. Size of m x k.
    * @param B the matrix B that will be left multiplied by A. Size of k x n.
@@ -231,7 +229,7 @@ private[mllib] object BLAS extends Serializable with Logging {
       beta: Double,
       C: DenseMatrix): Unit = {
     if (alpha == 0.0) {
-      logWarning("gemm: alpha is equal to 0. Returning C.")
+      logDebug("gemm: alpha is equal to 0. Returning C.")
     } else {
       A match {
         case sparse: SparseMatrix =>
@@ -319,7 +317,7 @@ private[mllib] object BLAS extends Serializable with Logging {
     // Slicing is easy in this case. This is the optimal multiplication setting for sparse matrices
     if (transA){
       var colCounterForB = 0
-      if (!transB){ // Expensive to put the check inside the loop
+      if (!transB) { // Expensive to put the check inside the loop
         while (colCounterForB < nB) {
           var rowCounterForA = 0
           val Cstart = colCounterForB * mA
@@ -360,7 +358,7 @@ private[mllib] object BLAS extends Serializable with Logging {
     } else {
       // Scale matrix first if `beta` is not equal to 0.0
       if (beta != 0.0){
-        nativeBLAS.dscal(C.values.length, beta, C.values, 1)
+        f2jBLAS.dscal(C.values.length, beta, C.values, 1)
       }
       // Perform matrix multiplication and add to C. The rows of A are multiplied by the columns of
       // B, and added to C.
@@ -368,13 +366,14 @@ private[mllib] object BLAS extends Serializable with Logging {
       if (!transB) { // Expensive to put the check inside the loop
         while (colCounterForB < nB) {
           var colCounterForA = 0 // The column of A to multiply with the row of B
-          while (colCounterForA < kA){
+          val Bstart = colCounterForB * kB
+          val Cstart = colCounterForB * mA
+          while (colCounterForA < kA) {
             var i = Acols(colCounterForA)
             val indEnd = Acols(colCounterForA + 1)
-            val Bval = B(colCounterForA, colCounterForB)
-            val Cstart = colCounterForB * mA
+            val Bval = B.values(Bstart + colCounterForA) * alpha
             while (i < indEnd){
-              C.values(Cstart + Arows(i)) += Avals(i) * Bval * alpha
+              C.values(Cstart + Arows(i)) += Avals(i) * Bval
               i += 1
             }
             colCounterForA += 1
@@ -384,13 +383,13 @@ private[mllib] object BLAS extends Serializable with Logging {
       } else {
         while (colCounterForB < nB) {
           var colCounterForA = 0 // The column of A to multiply with the row of B
+          val Cstart = colCounterForB * mA
           while (colCounterForA < kA){
             var i = Acols(colCounterForA)
             val indEnd = Acols(colCounterForA + 1)
-            val Bval = B(colCounterForB, colCounterForA)
-            val Cstart = colCounterForB * mA
+            val Bval = B(colCounterForB, colCounterForA) * alpha
             while (i < indEnd){
-              C.values(Cstart + Arows(i)) += Avals(i) * Bval * alpha
+              C.values(Cstart + Arows(i)) += Avals(i) * Bval
               i += 1
             }
             colCounterForA += 1
@@ -403,8 +402,7 @@ private[mllib] object BLAS extends Serializable with Logging {
 
   /**
    * y := alpha * A * x + beta * y
-   * @param trans specify whether to use matrix A, or the transpose of matrix A. Should be "N" or
-   *               "n" to use A, and "T" or "t" to use the transpose of A.
+   * @param trans whether to use the transpose of matrix A (true), or A itself (false).
    * @param alpha a scalar to scale the multiplication A * x.
    * @param A the matrix A that will be left multiplied to x. Size of m x n.
    * @param x the vector x that will be left multiplied by A. Size of n x 1.
@@ -427,7 +425,7 @@ private[mllib] object BLAS extends Serializable with Logging {
     require(mA == y.size,
       s"The rows of A don't match the number of elements of y. A: $mA, y:${y.size}}")
     if (alpha == 0.0) {
-      logWarning("gemv: alpha is equal to 0. Returning y.")
+      logDebug("gemv: alpha is equal to 0. Returning y.")
     } else {
       A match {
         case sparse: SparseMatrix =>
@@ -457,47 +455,6 @@ private[mllib] object BLAS extends Serializable with Logging {
       y: DenseVector): Unit = {
     gemv(false, alpha, A, x, beta, y)
   }
-
-  /**
-   * y := alpha * A * x
-   *
-   * @param trans specify whether to use matrix A, or the transpose of matrix A. Should be "N" or
-   *               "n" to use A, and "T" or "t" to use the transpose of A.
-   * @param alpha a scalar to scale the multiplication A * x.
-   * @param A the matrix A that will be left multiplied to x. Size of m x n.
-   * @param x the vector x that will be left multiplied by A. Size of n x 1.
-   *
-   * @return `DenseVector` y, the result of the matrix-vector multiplication. Size of m x 1.
-   */
-  def gemv(
-            trans: Boolean,
-            alpha: Double,
-            A: Matrix,
-            x: DenseVector): DenseVector = {
-    val m = if(!trans) A.numRows else A.numCols
-
-    val y: DenseVector = new DenseVector(Array.fill(m)(0.0))
-    gemv(trans, alpha, A, x, 0.0, y)
-
-    y
-  }
-
-  /**
-   * y := alpha * A * x
-   *
-   * @param alpha a scalar to scale the multiplication A * x.
-   * @param A the matrix A that will be left multiplied to x. Size of m x n.
-   * @param x the vector x that will be left multiplied by A. Size of n x 1.
-   *
-   * @return `DenseVector` y, the result of the matrix-vector multiplication. Size of m x 1.
-   */
-  def gemv(
-      alpha: Double,
-      A: Matrix,
-      x: DenseVector): DenseVector = {
-    gemv(false, alpha, A, x)
-  }
-
 
   /**
    * y := alpha * A * x + beta * y
@@ -539,8 +496,9 @@ private[mllib] object BLAS extends Serializable with Logging {
       var rowCounter = 0
       while (rowCounter < mA){
         var i = Arows(rowCounter)
+        val indEnd = Arows(rowCounter + 1)
         var sum = 0.0
-        while(i < Arows(rowCounter + 1)){
+        while(i < indEnd){
           sum += Avals(i) * x.values(Acols(i))
           i += 1
         }
@@ -556,9 +514,11 @@ private[mllib] object BLAS extends Serializable with Logging {
       var colCounterForA = 0
       while (colCounterForA < nA){
         var i = Acols(colCounterForA)
-        while (i < Acols(colCounterForA + 1)){
+        val indEnd = Acols(colCounterForA + 1)
+        val xVal = x.values(colCounterForA) * alpha
+        while (i < indEnd){
           val rowIndex = Arows(i)
-          y.values(rowIndex) += Avals(i) * x.values(colCounterForA) * alpha
+          y.values(rowIndex) += Avals(i) * xVal
           i += 1
         }
         colCounterForA += 1

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
@@ -18,6 +18,9 @@
 package org.apache.spark.mllib.linalg
 
 import com.github.fommil.netlib.{BLAS => NetlibBLAS, F2jBLAS}
+import com.github.fommil.netlib.BLAS.{getInstance => NativeBLAS}
+
+import org.apache.commons.lang.StringEscapeUtils.escapeJava
 
 /**
  * BLAS routines for MLlib's vectors and matrices.
@@ -25,6 +28,7 @@ import com.github.fommil.netlib.{BLAS => NetlibBLAS, F2jBLAS}
 private[mllib] object BLAS extends Serializable {
 
   @transient private var _f2jBLAS: NetlibBLAS = _
+  @transient private var _nativeBLAS: NetlibBLAS = _
 
   // For level-1 routines, we use Java implementation.
   private def f2jBLAS: NetlibBLAS = {
@@ -197,4 +201,442 @@ private[mllib] object BLAS extends Serializable {
         throw new IllegalArgumentException(s"scal doesn't support vector type ${x.getClass}.")
     }
   }
+
+  // For level-3 routines, we use the native BLAS.
+  private def nativeBLAS: NetlibBLAS = {
+    if (_nativeBLAS == null) {
+      _nativeBLAS = NativeBLAS
+    }
+    _nativeBLAS
+  }
+
+  /**
+   * C := alpha * A * B + beta * C
+   * @param transA specify whether to use matrix A, or the transpose of matrix A. Should be "N" or
+   *               "n" to use A, and "T" or "t" to use the transpose of A.
+   * @param transB specify whether to use matrix B, or the transpose of matrix B. Should be "N" or
+   *               "n" to use B, and "T" or "t" to use the transpose of B.
+   * @param alpha a scalar to scale the multiplication A * B.
+   * @param A the matrix A that will be left multiplied to B. Size of m x k.
+   * @param B the matrix B that will be left multiplied by A. Size of k x n.
+   * @param beta a scalar that can be used to scale matrix C.
+   * @param C the resulting matrix C. Size of m x n.
+   */
+  def gemm(
+            transA: String,
+            transB: String,
+            alpha: Double,
+            A: Matrix,
+            B: DenseMatrix,
+            beta: Double,
+            C: DenseMatrix) {
+
+    var mA: Int = A.numRows
+    var nB: Int = B.numCols
+    var kA: Int = A.numCols
+    var kB: Int = B.numRows
+    var transposeA: Boolean = false
+    var transposeB: Boolean = false
+    if (transA == "T" || transA=="t"){
+      mA = A.numCols
+      kA = A.numRows
+      transposeA = true
+    }
+    require(transA == "T" || transA == "t" || transA == "N" || transA == "n",
+      s"Invalid argument used for transA: $transA. " +
+        escapeJava("Must be \"N\", \"n\", \"T\", or \"t\""))
+    if (transB == "T" || transB=="t"){
+      nB = B.numRows
+      kB = B.numCols
+      transposeB = true
+    }
+    require(transB == "T" || transB == "t" || transB == "N" || transB == "n",
+      s"Invalid argument used for transB: $transB. " +
+        escapeJava("Must be \"N\", \"n\", \"T\", or \"t\""))
+
+    require(kA == kB, s"The columns of A don't match the rows of B. A: $kA, B: $kB")
+    require(mA == C.numRows, s"The rows of C don't match the rows of A. C: ${C.numRows}, A: $mA")
+    require(nB == C.numCols,
+      s"The columns of C don't match the columns of B. C: ${C.numCols}, A: $nB")
+
+    A match {
+      case sparse: SparseMatrix =>
+        gemm(transA, transB, alpha, sparse, B, beta, C, transposeA, transposeB, mA, kA, nB)
+      case dense: DenseMatrix =>
+        gemm(transA, transB, alpha, dense, B, beta, C, mA, kA, nB)
+      case _ =>
+        throw new IllegalArgumentException(s"gemm doesn't support matrix type ${A.getClass}.")
+    }
+  }
+
+  /**
+   * C := alpha * A * B + beta * C
+   *
+   * @param alpha a scalar to scale the multiplication A * B.
+   * @param A the matrix A that will be left multiplied to B. Size of m x k.
+   * @param B the matrix B that will be left multiplied by A. Size of k x n.
+   * @param beta a scalar that can be used to scale matrix C.
+   * @param C the resulting matrix C. Size of m x n.
+   */
+  def gemm(
+            alpha: Double,
+            A: Matrix,
+            B: DenseMatrix,
+            beta: Double,
+            C: DenseMatrix) {
+
+    gemm("N", "N", alpha, A, B, beta, C)
+  }
+
+  /**
+   * C := alpha * A * B
+   *
+   * @param transA specify whether to use matrix A, or the transpose of matrix A. Should be "N" or
+   *               "n" to use A, and "T" or "t" to use the transpose of A.
+   * @param transB specify whether to use matrix B, or the transpose of matrix B. Should be "N" or
+   *               "n" to use B, and "T" or "t" to use the transpose of B.
+   * @param alpha a scalar to scale the multiplication A * B.
+   * @param A the matrix A that will be left multiplied to B. Size of m x k.
+   * @param B the matrix B that will be left multiplied by A. Size of k x n.
+   *
+   * @return The resulting matrix C. Size of m x n.
+   */
+  def gemm(transA: String,
+            transB: String,
+            alpha: Double,
+            A: Matrix,
+            B: DenseMatrix) : DenseMatrix = {
+
+    var mA: Int = A.numRows
+    var nB: Int = B.numCols
+    var kA: Int = A.numCols
+    var kB: Int = B.numRows
+
+    if (transA == "T" || transA=="T"){
+      mA = A.numCols
+      kA = A.numRows
+    }
+    if (transB == "T" || transB=="T"){
+      nB = B.numRows
+      kB = B.numCols
+    }
+
+    val C: DenseMatrix = DenseMatrix.zeros(mA, nB)
+
+    gemm(transA, transB, alpha, A, B, 0.0, C)
+
+    C
+  }
+
+  /**
+   * C := alpha * A * B
+   *
+   * @param alpha a scalar to scale the multiplication A * B.
+   * @param A the matrix A that will be left multiplied to B. Size of m x k.
+   * @param B the matrix B that will be left multiplied by A. Size of k x n.
+   *
+   * @return The resulting matrix C. Size of m x n.
+   */
+  def gemm(
+     alpha: Double,
+     A: Matrix,
+     B: DenseMatrix) : DenseMatrix = {
+
+    gemm("N", "N", alpha, A, B)
+  }
+
+  /**
+   * C := alpha * A * B + beta * C
+   * For `DenseMatrix` A.
+   */
+  private def gemm(
+      transA: String,
+      transB: String,
+      alpha: Double,
+      A: DenseMatrix,
+      B: DenseMatrix,
+      beta: Double,
+      C: DenseMatrix,
+      mA: Int,
+      kA: Int,
+      nB: Int) {
+
+    nativeBLAS.dgemm(transA,transB, mA, nB, kA, alpha, A.toArray, A.numRows, B.toArray, B.numRows,
+      beta, C.toArray, C.numRows)
+  }
+
+  /**
+   * C := alpha * A * B + beta * C
+   * For `SparseMatrix` A.
+   */
+  private def gemm(
+            transA: String,
+            transB: String,
+            alpha: Double,
+            A: SparseMatrix,
+            B: DenseMatrix,
+            beta: Double,
+            C: DenseMatrix,
+            transposeA: Boolean,
+            transposeB: Boolean,
+            mA: Int,
+            kA: Int,
+            nB: Int) {
+
+
+    val Avals = A.toArray
+    val Arows = if (!transposeA) A.rowIndices else A.colIndices
+    val Acols = if (!transposeA) A.colIndices else A.rowIndices
+
+    // Slicing is easy in this case. This is the optimal multiplication setting for sparse matrices
+    if (transposeA){
+      var colCounter = 0
+      while (colCounter < nB){ // Tests showed that the outer loop being columns was faster
+        var rowCounter = 0
+        while (rowCounter < mA){
+          val indStart = Arows(rowCounter)
+          val indEnd = Arows(rowCounter + 1)
+          var elementCount = 0 // Loop over non-zero entries in column (actually the row indices,
+                               // since this is a transposed multiplication
+          var sum = 0.0
+          while(indStart + elementCount < indEnd){
+            val AcolIndex = Acols(indStart + elementCount)
+            val Bval = if (!transposeB) B(AcolIndex, colCounter) else B(colCounter, AcolIndex)
+            sum += Avals(indStart + elementCount) * Bval
+            elementCount += 1
+          }
+          C.update(rowCounter, colCounter, beta * C(rowCounter, colCounter) + sum)
+          rowCounter += 1
+        }
+        colCounter += 1
+      }
+    } else {
+
+      // Scale matrix first if `beta` is not equal to 0.0
+      if (beta != 0.0){
+        var i = 0
+        val CLength = C.numCols * C.numRows
+        while ( i < CLength) {
+          C.values(i) *= beta
+          i += 1
+        }
+      }
+
+      // Perform matrix multiplication and add to C. The rows of A are multiplied by the columns of
+      // B, and added to C.
+      var colCounterForA = 0 // The column of A to multiply with the row of B
+      while (colCounterForA < kA){
+        val indStart = Acols(colCounterForA)
+        val indEnd = Acols(colCounterForA + 1)
+
+        var elementCount = 0 // Loop over non-zero entries in column
+        while (indStart + elementCount < indEnd){
+          var colCounterForB = 0 // the column to be updated in C
+          val rowIndex = Arows(indStart + elementCount) // the row to be updated in C
+          while (colCounterForB < nB){
+            val Bval =
+              if (!transposeB){
+                B(colCounterForA, colCounterForB)
+              } else {
+                B(colCounterForB, colCounterForA)
+              }
+
+            C.update(rowIndex, colCounterForB,
+              C(rowIndex, colCounterForB) + Avals(indStart + elementCount) * Bval)
+
+            colCounterForB += 1
+          }
+
+          elementCount += 1
+        }
+        colCounterForA += 1
+      }
+    }
+  }
+
+  /**
+   * y := alpha * A * x + beta * y
+   * @param trans specify whether to use matrix A, or the transpose of matrix A. Should be "N" or
+   *               "n" to use A, and "T" or "t" to use the transpose of A.
+   * @param alpha a scalar to scale the multiplication A * x.
+   * @param A the matrix A that will be left multiplied to x. Size of m x n.
+   * @param x the vector x that will be left multiplied by A. Size of n x 1.
+   * @param beta a scalar that can be used to scale vector y.
+   * @param y the resulting vector y. Size of m x 1.
+   */
+  def gemv(
+      trans: String,
+      alpha: Double,
+      A: Matrix,
+      x: DenseVector,
+      beta: Double,
+      y: DenseVector) {
+
+    var mA: Int = A.numRows
+    val nx: Int = x.size
+    var nA: Int = A.numCols
+    var transposeA: Boolean = false
+    if (trans == "T" || trans=="t"){
+      mA = A.numCols
+      nA = A.numRows
+      transposeA = true
+    }
+    require(trans == "T" || trans == "t" || trans == "N" || trans == "n",
+      s"Invalid argument used for trans: $trans. " +
+        escapeJava("Must be \"N\", \"n\", \"T\", or \"t\""))
+
+    require(nA == nx, s"The columns of A don't match the number of elements of x. A: $nA, x: $nx")
+    require(mA == y.size,
+      s"The rows of A don't match the number of elements of y. A: $mA, y:${y.size}}")
+
+    A match {
+      case sparse: SparseMatrix =>
+        gemv(trans, alpha, sparse, x, beta, y, mA, nA, transposeA)
+      case dense: DenseMatrix =>
+        gemv(trans, alpha, dense, x, beta, y)
+      case _ =>
+        throw new IllegalArgumentException(s"gemv doesn't support matrix type ${A.getClass}.")
+    }
+  }
+
+  /**
+   * y := alpha * A * x + beta * y
+   *
+   * @param alpha a scalar to scale the multiplication A * x.
+   * @param A the matrix A that will be left multiplied to x. Size of m x n.
+   * @param x the vector x that will be left multiplied by A. Size of n x 1.
+   * @param beta a scalar that can be used to scale vector y.
+   * @param y the resulting vector y. Size of m x 1.
+   */
+  def gemv(
+            alpha: Double,
+            A: Matrix,
+            x: DenseVector,
+            beta: Double,
+            y: DenseVector) {
+
+    gemv("N", alpha, A, x, beta, y)
+  }
+
+  /**
+   * y := alpha * A * x
+   *
+   * @param trans specify whether to use matrix A, or the transpose of matrix A. Should be "N" or
+   *               "n" to use A, and "T" or "t" to use the transpose of A.
+   * @param alpha a scalar to scale the multiplication A * x.
+   * @param A the matrix A that will be left multiplied to x. Size of m x n.
+   * @param x the vector x that will be left multiplied by A. Size of n x 1.
+   *
+   * @return `DenseVector` y, the result of the matrix-vector multiplication. Size of m x 1.
+   */
+  def gemv(
+            trans: String,
+            alpha: Double,
+            A: Matrix,
+            x: DenseVector): DenseVector = {
+
+    val m = if(trans == "N" || trans == "n") A.numRows else A.numCols
+
+    val y: DenseVector = new DenseVector(Array.fill(m)(0.0))
+    gemv(trans, alpha, A, x, 0.0, y)
+
+    y
+  }
+
+  /**
+   * y := alpha * A * x
+   *
+   * @param alpha a scalar to scale the multiplication A * x.
+   * @param A the matrix A that will be left multiplied to x. Size of m x n.
+   * @param x the vector x that will be left multiplied by A. Size of n x 1.
+   *
+   * @return `DenseVector` y, the result of the matrix-vector multiplication. Size of m x 1.
+   */
+  def gemv(
+            alpha: Double,
+            A: Matrix,
+            x: DenseVector): DenseVector = {
+
+    gemv("N", alpha, A, x)
+  }
+
+
+  /**
+   * y := alpha * A * x + beta * y
+   * For `DenseMatrix` A.
+   */
+  private def gemv(
+      trans: String,
+      alpha: Double,
+      A: DenseMatrix,
+      x: DenseVector,
+      beta: Double,
+      y: DenseVector) {
+
+    nativeBLAS.dgemv(trans, A.numRows, A.numCols, alpha, A.toArray, A.numRows, x.toArray, 1, beta,
+      y.toArray, 1)
+  }
+
+  /**
+   * y := alpha * A * x + beta * y
+   * For `SparseMatrix` A.
+   */
+  private def gemv(
+      trans: String,
+      alpha: Double,
+      A: SparseMatrix,
+      x: DenseVector,
+      beta: Double,
+      y: DenseVector,
+      mA: Int,
+      nA: Int,
+      transposeA: Boolean) {
+
+    val Avals = A.toArray
+    val Arows = if (!transposeA) A.rowIndices else A.colIndices
+    val Acols = if (!transposeA) A.colIndices else A.rowIndices
+
+    // Slicing is easy in this case. This is the optimal multiplication setting for sparse matrices
+    if (transposeA){
+      var rowCounter = 0
+      while (rowCounter < mA){
+        val indStart = Arows(rowCounter)
+        val indEnd = Arows(rowCounter + 1)
+        var elementCount = 0 // Number of elements already multiplied
+        var sum = 0.0
+        while(indStart + elementCount < indEnd){
+          sum += Avals(indStart + elementCount) * x.values(Acols(indStart + elementCount))
+          elementCount += 1
+        }
+        y.values(rowCounter) =  beta * y.values(rowCounter) + sum
+        rowCounter += 1
+      }
+    } else {
+      // Scale vector first if `beta` is not equal to 0.0
+      if (beta != 0.0){
+        var i = 0
+        val yLength = y.size
+        while (i < yLength) {
+          y.values(i) *= beta
+          i += 1
+        }
+      }
+
+      // Perform matrix-vector multiplication and add to y
+      var colCounterForA = 0
+      while (colCounterForA < nA){
+        val indStart = Acols(colCounterForA)
+        val indEnd = Acols(colCounterForA + 1)
+
+        var elementCount = 0 // Number of non-zero entries in column
+        while (indStart + elementCount < indEnd){
+          val rowIndex = Arows(indStart + elementCount)
+          y.values(rowIndex) += Avals(indStart + elementCount) * x.values(colCounterForA)
+          elementCount += 1
+        }
+        colCounterForA += 1
+      }
+    }
+  }
+
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
@@ -235,12 +235,10 @@ private[mllib] object BLAS extends Serializable {
     var nB: Int = B.numCols
     var kA: Int = A.numCols
     var kB: Int = B.numRows
-    var transposeA: Boolean = false
-    var transposeB: Boolean = false
+
     if (transA == "T" || transA=="t"){
       mA = A.numCols
       kA = A.numRows
-      transposeA = true
     }
     require(transA == "T" || transA == "t" || transA == "N" || transA == "n",
       s"Invalid argument used for transA: $transA. " +
@@ -248,7 +246,6 @@ private[mllib] object BLAS extends Serializable {
     if (transB == "T" || transB=="t"){
       nB = B.numRows
       kB = B.numCols
-      transposeB = true
     }
     require(transB == "T" || transB == "t" || transB == "N" || transB == "n",
       s"Invalid argument used for transB: $transB. " +
@@ -261,7 +258,7 @@ private[mllib] object BLAS extends Serializable {
 
     A match {
       case sparse: SparseMatrix =>
-        gemm(transA, transB, alpha, sparse, B, beta, C, transposeA, transposeB, mA, kA, nB)
+        gemm(transA, transB, alpha, sparse, B, beta, C, mA, kA, nB)
       case dense: DenseMatrix =>
         gemm(transA, transB, alpha, dense, B, beta, C, mA, kA, nB)
       case _ =>
@@ -370,19 +367,19 @@ private[mllib] object BLAS extends Serializable {
    * For `SparseMatrix` A.
    */
   private def gemm(
-            transA: String,
-            transB: String,
-            alpha: Double,
-            A: SparseMatrix,
-            B: DenseMatrix,
-            beta: Double,
-            C: DenseMatrix,
-            transposeA: Boolean,
-            transposeB: Boolean,
-            mA: Int,
-            kA: Int,
-            nB: Int) {
+      transA: String,
+      transB: String,
+      alpha: Double,
+      A: SparseMatrix,
+      B: DenseMatrix,
+      beta: Double,
+      C: DenseMatrix,
+      mA: Int,
+      kA: Int,
+      nB: Int) {
 
+    val transposeA = A.numCols == mA
+    val transposeB = B.numRows == nB
 
     val Avals = A.toArray
     val Arows = if (!transposeA) A.rowIndices else A.colIndices
@@ -446,7 +443,6 @@ private[mllib] object BLAS extends Serializable {
 
             colCounterForB += 1
           }
-
           elementCount += 1
         }
         colCounterForA += 1

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
@@ -205,7 +205,8 @@ class SparseMatrix(
 
   require(values.length == rowIndices.length, "The number of row indices and values don't match!")
   require(colPointers.length == numCols + 1, "The length of the column indices should be the " +
-    s"number of columns + 1. Currently, colPointers.length: ${colPointers.length}, numCols: $numCols")
+    s"number of columns + 1. Currently, colPointers.length: ${colPointers.length}, " +
+    s"numCols: $numCols")
 
   override def toArray: Array[Double] = values
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.mllib.linalg
 
-import breeze.linalg.{Matrix => BM, DenseMatrix => BDM}
+import breeze.linalg.{Matrix => BM, DenseMatrix => BDM, CSCMatrix => BSM}
 
 /**
  * Trait for a local matrix.
@@ -36,8 +36,20 @@ trait Matrix extends Serializable {
   /** Converts to a breeze matrix. */
   private[mllib] def toBreeze: BM[Double]
 
-  /** Gets the (i, j)-th element. */
-  private[mllib] def apply(i: Int, j: Int): Double = toBreeze(i, j)
+  /** Gets the (r, c)-th element. */
+  private[mllib] def apply(i: Int): Double
+  private[mllib] def apply(r: Int, c: Int): Double
+
+  // Update element at (r, c)
+  private[mllib] def update(r: Int, c: Int, v: Double)
+
+  def copy: Matrix // Deep Copy
+
+  // Matrix multiply operations for convenience
+  def times(y: DenseMatrix): DenseMatrix = BLAS.gemm(1.0, this, y)
+  def times(y: DenseVector): DenseVector = BLAS.gemv(1.0, this, y)
+  def transpose_times(y: DenseMatrix): DenseMatrix = BLAS.gemm("T", "N", 1.0, this, y)
+  def transpose_times(y: DenseVector): DenseVector = BLAS.gemv("T", 1.0, this, y)
 
   override def toString: String = toBreeze.toString()
 }
@@ -64,6 +76,121 @@ class DenseMatrix(val numRows: Int, val numCols: Int, val values: Array[Double])
   override def toArray: Array[Double] = values
 
   private[mllib] override def toBreeze: BM[Double] = new BDM[Double](numRows, numCols, values)
+
+  private[mllib] override def apply(i: Int): Double = values(i)
+  private[mllib] override def apply(r: Int, c: Int): Double = values(index(r,c))
+
+  private[mllib] def index(r: Int, c: Int): Int = r + numRows * c
+
+  private[mllib] override def update(r: Int, c: Int, v: Double){
+    values(index(r, c)) = v
+  }
+
+  def copy = new DenseMatrix(numRows, numCols, values.clone())
+}
+
+/**
+ * Factory methods for [[org.apache.spark.mllib.linalg.DenseMatrix]].
+ *
+ * These methods can be used to generate common matrix types such as the Identity matrix, any
+ * diagonal matrix, zero matrix, etc. Also provides methods to transform an `RDD[Vector]` into
+ * `RDD[DenseMatrix]`, which speeds up gradient updates for multi-model training.
+ */
+object DenseMatrix {
+
+  def zeros(rows: Int, cols: Int) = new DenseMatrix(rows, cols, Array.fill(rows*cols)(0.0))
+
+  def ones(rows: Int, cols: Int) = new DenseMatrix(rows, cols, Array.fill(rows*cols)(1.0))
+
+  def eye(n: Int) = {
+    val identity = DenseMatrix.zeros(n,n)
+    for (i <- 0 until n){
+      identity.update(i,i,1.0)
+    }
+    identity
+  }
+
+  def rand(rows: Int, cols: Int) = {
+    val rand = new scala.util.Random
+    new DenseMatrix(rows,cols, Array.fill(rows*cols)(rand.nextDouble()))
+  }
+
+  def randn(rows: Int, cols: Int) = {
+    val rand = new scala.util.Random
+    new DenseMatrix(rows,cols, Array.fill(rows*cols)(rand.nextGaussian()))
+  }
+
+  def diag(values: Array[Double]) = {
+    val n = values.length
+    val matrix = DenseMatrix.eye(n)
+    for (i <- 0 until n) matrix.update(i,i,values(i))
+    matrix
+  }
+}
+
+/**
+ * Column-majored sparse matrix.
+ * The entry values are stored in Compressed-Column Storage (CCS) format.
+ * For example, the following matrix
+ * {{{
+ *   1.0 0.0 4.0
+ *   0.0 3.0 5.0
+ *   2.0 0.0 6.0
+ * }}}
+ * is stored as `values: [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]`,
+ * `rowIndices=[0, 2, 1, 0, 1, 2]`, `colIndices=[0, 2, 3, 6]`.
+ *
+ * @param numRows number of rows
+ * @param numCols number of columns
+ * @param colIndices the index corresponding to the start of a new column
+ * @param rowIndices the row index of the entry
+ * @param values non-zero matrix entries in column major
+ */
+class SparseMatrix(val numRows: Int,
+                   val numCols: Int,
+                   val colIndices: Array[Int],
+                   val rowIndices: Array[Int],
+                   val values: Array[Double]) extends Matrix {
+
+  require(values.length == rowIndices.length, "The number of row indices and values don't match!")
+  require(colIndices.length == numCols + 1, "The length of the column indices should be the " +
+    s"number of columns + 1. Currently, colIndices.length: ${colIndices.length}, numCols: $numCols")
+
+  override def toArray: Array[Double] = values
+
+  private[mllib] override def toBreeze: BM[Double] =
+    new BSM[Double](values, numRows, numCols, colIndices, rowIndices)
+
+  private[mllib] override def apply(i: Int): Double = values(i)
+  private[mllib] override def apply(r: Int, c: Int): Double = {
+    val ind = index(r,c)
+    if (ind == -1) 0.0 else values(ind)
+  }
+
+  private[mllib] def index(r: Int, c: Int): Int = {
+    val regionStart = colIndices(c)
+    val regionEnd = colIndices(c+1)
+    val region = rowIndices.slice(regionStart, regionEnd)
+    if (region.contains(r)){
+      region.indexOf(r) + regionStart
+    } else {
+      -1 // return zero element
+    }
+  }
+
+  // TODO(Burak): Maybe convert to Breeze to update zero entries? I can't think of any MLlib
+  // TODO: algorithm that would use mutable Sparse Matrices
+  private[mllib] override def update(r: Int, c: Int, v: Double){
+    val ind = index(r,c)
+    if (ind == -1){
+      throw new IllegalArgumentException("The given row and column indices correspond to a zero " +
+        "value. Sparse Matrices are currently immutable.")
+    } else {
+      values(index(r, c)) = v
+    }
+  }
+
+  def copy = new SparseMatrix(numRows, numCols, colIndices, rowIndices, values.clone())
 }
 
 /**
@@ -83,6 +210,24 @@ object Matrices {
   }
 
   /**
+   * Creates a column-majored sparse matrix in Compressed Column Storage (CCS) format.
+   *
+   * @param numRows number of rows
+   * @param numCols number of columns
+   * @param colIndices the index corresponding to the start of a new column
+   * @param rowIndices the row index of the entry
+   * @param values non-zero matrix entries in column major
+   */
+  def sparse(
+     numRows: Int,
+     numCols: Int,
+     colIndices: Array[Int],
+     rowIndices: Array[Int],
+     values: Array[Double]): Matrix = {
+    new SparseMatrix(numRows, numCols, colIndices, rowIndices, values)
+  }
+
+  /**
    * Creates a Matrix instance from a breeze matrix.
    * @param breeze a breeze matrix
    * @return a Matrix instance
@@ -93,6 +238,8 @@ object Matrices {
         require(dm.majorStride == dm.rows,
           "Do not support stride size different from the number of rows.")
         new DenseMatrix(dm.rows, dm.cols, dm.data)
+      case sm: BSM[Double] =>
+        new SparseMatrix(sm.rows, sm.cols, sm.colPtrs, sm.rowIndices, sm.data)
       case _ =>
         throw new UnsupportedOperationException(
           s"Do not support conversion from type ${breeze.getClass.getName}.")

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
@@ -23,7 +23,7 @@ import org.apache.spark.util.random.XORShiftRandom
 /**
  * Trait for a local matrix.
  */
-trait Matrix extends Serializable {
+sealed trait Matrix extends Serializable {
 
   /** Number of rows. */
   def numRows: Int

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
@@ -78,7 +78,7 @@ class DenseMatrix(val numRows: Int, val numCols: Int, val values: Array[Double])
   private[mllib] override def toBreeze: BM[Double] = new BDM[Double](numRows, numCols, values)
 
   private[mllib] override def apply(i: Int): Double = values(i)
-  private[mllib] override def apply(r: Int, c: Int): Double = values(index(r,c))
+  private[mllib] override def apply(r: Int, c: Int): Double = values(index(r, c))
 
   private[mllib] def index(r: Int, c: Int): Int = r + numRows * c
 
@@ -98,32 +98,32 @@ class DenseMatrix(val numRows: Int, val numCols: Int, val values: Array[Double])
  */
 object DenseMatrix {
 
-  def zeros(rows: Int, cols: Int) = new DenseMatrix(rows, cols, Array.fill(rows*cols)(0.0))
+  def zeros(rows: Int, cols: Int) = new DenseMatrix(rows, cols, Array.fill(rows * cols)(0.0))
 
-  def ones(rows: Int, cols: Int) = new DenseMatrix(rows, cols, Array.fill(rows*cols)(1.0))
+  def ones(rows: Int, cols: Int) = new DenseMatrix(rows, cols, Array.fill(rows * cols)(1.0))
 
   def eye(n: Int) = {
     val identity = DenseMatrix.zeros(n,n)
     for (i <- 0 until n){
-      identity.update(i,i,1.0)
+      identity.update(i, i, 1.0)
     }
     identity
   }
 
   def rand(rows: Int, cols: Int) = {
     val rand = new scala.util.Random
-    new DenseMatrix(rows,cols, Array.fill(rows*cols)(rand.nextDouble()))
+    new DenseMatrix(rows,cols, Array.fill(rows * cols)(rand.nextDouble()))
   }
 
   def randn(rows: Int, cols: Int) = {
     val rand = new scala.util.Random
-    new DenseMatrix(rows,cols, Array.fill(rows*cols)(rand.nextGaussian()))
+    new DenseMatrix(rows,cols, Array.fill(rows * cols)(rand.nextGaussian()))
   }
 
   def diag(values: Array[Double]) = {
     val n = values.length
     val matrix = DenseMatrix.eye(n)
-    for (i <- 0 until n) matrix.update(i,i,values(i))
+    for (i <- 0 until n) matrix.update(i, i, values(i))
     matrix
   }
 }
@@ -169,7 +169,7 @@ class SparseMatrix(val numRows: Int,
 
   private[mllib] def index(r: Int, c: Int): Int = {
     val regionStart = colIndices(c)
-    val regionEnd = colIndices(c+1)
+    val regionEnd = colIndices(c + 1)
     val region = rowIndices.slice(regionStart, regionEnd)
     if (region.contains(r)){
       region.indexOf(r) + regionStart
@@ -181,7 +181,7 @@ class SparseMatrix(val numRows: Int,
   // TODO(Burak): Maybe convert to Breeze to update zero entries? I can't think of any MLlib
   // TODO: algorithm that would use mutable Sparse Matrices
   private[mllib] override def update(r: Int, c: Int, v: Double){
-    val ind = index(r,c)
+    val ind = index(r, c)
     if (ind == -1){
       throw new IllegalArgumentException("The given row and column indices correspond to a zero " +
         "value. Sparse Matrices are currently immutable.")

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
@@ -33,7 +33,7 @@ import org.apache.spark.SparkException
  *
  * Note: Users should not implement this interface.
  */
-trait Vector extends Serializable {
+sealed trait Vector extends Serializable {
 
   /**
    * Size of the vector.

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/BLASSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/BLASSuite.scala
@@ -143,12 +143,21 @@ class BLASSuite extends FunSuite {
     val C2 = C1.copy
     val C3 = C1.copy
     val C4 = C1.copy
+    val C5 = C1.copy
+    val C6 = C1.copy
+    val C7 = C1.copy
+    val C8 = C1.copy
     val expected2 = new DenseMatrix(4, 2, Array(2.0, 1.0, 4.0, 2.0, 4.0, 0.0, 4.0, 3.0))
+    val expected3 = new DenseMatrix(4, 2, Array(2.0, 2.0, 4.0, 2.0, 8.0, 0.0, 6.0, 6.0))
 
     gemm(1.0, dA, B, 2.0, C1)
     gemm(1.0, sA, B, 2.0, C2)
+    gemm(2.0, dA, B, 2.0, C3)
+    gemm(2.0, sA, B, 2.0, C4)
     assert(C1 ~== expected2 absTol 1e-15)
     assert(C2 ~== expected2 absTol 1e-15)
+    assert(C3 ~== expected3 absTol 1e-15)
+    assert(C4 ~== expected3 absTol 1e-15)
 
     withClue("columns of A don't match the rows of B") {
       intercept[Exception] {
@@ -164,10 +173,14 @@ class BLASSuite extends FunSuite {
     assert(dAT transposeTimes B ~== expected absTol 1e-15)
     assert(sAT transposeTimes B ~== expected absTol 1e-15)
 
-    gemm(true, false, 1.0, dAT, B, 2.0, C3)
-    gemm(true, false, 1.0, sAT, B, 2.0, C4)
-    assert(C3 ~== expected2 absTol 1e-15)
-    assert(C4 ~== expected2 absTol 1e-15)
+    gemm(true, false, 1.0, dAT, B, 2.0, C5)
+    gemm(true, false, 1.0, sAT, B, 2.0, C6)
+    gemm(true, false, 2.0, dAT, B, 2.0, C7)
+    gemm(true, false, 2.0, sAT, B, 2.0, C8)
+    assert(C5 ~== expected2 absTol 1e-15)
+    assert(C6 ~== expected2 absTol 1e-15)
+    assert(C7 ~== expected3 absTol 1e-15)
+    assert(C8 ~== expected3 absTol 1e-15)
 
   }
 
@@ -187,13 +200,21 @@ class BLASSuite extends FunSuite {
     val y2 = y1.copy
     val y3 = y1.copy
     val y4 = y1.copy
+    val y5 = y1.copy
+    val y6 = y1.copy
+    val y7 = y1.copy
+    val y8 = y1.copy
     val expected2 = new DenseVector(Array(6.0, 7.0, 4.0, 9.0))
+    val expected3 = new DenseVector(Array(10.0, 8.0, 6.0, 18.0))
 
     gemv(1.0, dA, x, 2.0, y1)
     gemv(1.0, sA, x, 2.0, y2)
+    gemv(2.0, dA, x, 2.0, y3)
+    gemv(2.0, sA, x, 2.0, y4)
     assert(y1 ~== expected2 absTol 1e-15)
     assert(y2 ~== expected2 absTol 1e-15)
-
+    assert(y3 ~== expected3 absTol 1e-15)
+    assert(y4 ~== expected3 absTol 1e-15)
     withClue("columns of A don't match the rows of B") {
       intercept[Exception] {
         gemv(true, 1.0, dA, x, 2.0, y1)
@@ -208,9 +229,13 @@ class BLASSuite extends FunSuite {
     assert(dAT transposeTimes x ~== expected absTol 1e-15)
     assert(sAT transposeTimes x ~== expected absTol 1e-15)
 
-    gemv(true, 1.0, dAT, x, 2.0, y3)
-    gemv(true, 1.0, sAT, x, 2.0, y4)
-    assert(y3 ~== expected2 absTol 1e-15)
-    assert(y4 ~== expected2 absTol 1e-15)
+    gemv(true, 1.0, dAT, x, 2.0, y5)
+    gemv(true, 1.0, sAT, x, 2.0, y6)
+    gemv(true, 2.0, dAT, x, 2.0, y7)
+    gemv(true, 2.0, sAT, x, 2.0, y8)
+    assert(y5 ~== expected2 absTol 1e-15)
+    assert(y6 ~== expected2 absTol 1e-15)
+    assert(y7 ~== expected3 absTol 1e-15)
+    assert(y8 ~== expected3 absTol 1e-15)
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/BLASSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/BLASSuite.scala
@@ -126,4 +126,91 @@ class BLASSuite extends FunSuite {
       }
     }
   }
+
+  test("gemm") {
+
+    val dA =
+      new DenseMatrix(4, 3, Array(0.0, 1.0, 0.0, 0.0, 2.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 3.0))
+    val sA = new SparseMatrix(4, 3, Array(0, 1, 3, 4), Array(1, 0, 2, 3), Array(1.0, 2.0, 1.0, 3.0))
+
+    val B = new DenseMatrix(3, 2, Array(1.0, 0.0, 0.0, 0.0, 2.0, 1.0))
+    val expected = new DenseMatrix(4, 2, Array(0.0, 1.0, 0.0, 0.0, 4.0, 0.0, 2.0, 3.0))
+
+    assert(dA times B ~== expected absTol 1e-15)
+    assert(sA times B ~== expected absTol 1e-15)
+
+    val C1 = new DenseMatrix(4, 2, Array(1.0, 0.0, 2.0, 1.0, 0.0, 0.0, 1.0, 0.0))
+    val C2 = C1.copy
+    val C3 = C1.copy
+    val C4 = C1.copy
+    val expected2 = new DenseMatrix(4, 2, Array(2.0, 1.0, 4.0, 2.0, 4.0, 0.0, 4.0, 3.0))
+
+    gemm(1.0, dA, B, 2.0, C1)
+    gemm(1.0, sA, B, 2.0, C2)
+    assert(C1 ~== expected2 absTol 1e-15)
+    assert(C2 ~== expected2 absTol 1e-15)
+
+    withClue("columns of A don't match the rows of B") {
+      intercept[Exception] {
+        gemm("T", "N", 1.0, dA, B, 2.0, C1)
+      }
+    }
+
+    val dAT =
+      new DenseMatrix(3, 4, Array(0.0, 2.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 3.0))
+    val sAT =
+      new SparseMatrix(3, 4, Array(0, 1, 2, 3, 4), Array(1, 0, 1, 2), Array(2.0, 1.0, 1.0, 3.0))
+
+    assert(dAT transpose_times B ~== expected absTol 1e-15)
+    assert(sAT transpose_times B ~== expected absTol 1e-15)
+
+    gemm("T", "N", 1.0, dAT, B, 2.0, C3)
+    gemm("T", "N", 1.0, sAT, B, 2.0, C4)
+    assert(C3 ~== expected2 absTol 1e-15)
+    assert(C4 ~== expected2 absTol 1e-15)
+
+  }
+
+  test("gemv") {
+
+    val dA =
+      new DenseMatrix(4, 3, Array(0.0, 1.0, 0.0, 0.0, 2.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 3.0))
+    val sA = new SparseMatrix(4, 3, Array(0, 1, 3, 4), Array(1, 0, 2, 3), Array(1.0, 2.0, 1.0, 3.0))
+
+    val x = new DenseVector(Array(1.0, 2.0, 3.0))
+    val expected = new DenseVector(Array(4.0, 1.0, 2.0, 9.0))
+
+    assert(dA times x ~== expected absTol 1e-15)
+    assert(sA times x ~== expected absTol 1e-15)
+
+    val y1 = new DenseVector(Array(1.0, 3.0, 1.0, 0.0))
+    val y2 = y1.copy
+    val y3 = y1.copy
+    val y4 = y1.copy
+    val expected2 = new DenseVector(Array(6.0, 7.0, 4.0, 9.0))
+
+    gemv(1.0, dA, x, 2.0, y1)
+    gemv(1.0, sA, x, 2.0, y2)
+    assert(y1 ~== expected2 absTol 1e-15)
+    assert(y2 ~== expected2 absTol 1e-15)
+
+    withClue("columns of A don't match the rows of B") {
+      intercept[Exception] {
+        gemv("T", 1.0, dA, x, 2.0, y1)
+      }
+    }
+
+    val dAT =
+      new DenseMatrix(3, 4, Array(0.0, 2.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 3.0))
+    val sAT =
+      new SparseMatrix(3, 4, Array(0, 1, 2, 3, 4), Array(1, 0, 1, 2), Array(2.0, 1.0, 1.0, 3.0))
+
+    assert(dAT transpose_times x ~== expected absTol 1e-15)
+    assert(sAT transpose_times x ~== expected absTol 1e-15)
+
+    gemv("T", 1.0, dAT, x, 2.0, y3)
+    gemv("T", 1.0, sAT, x, 2.0, y4)
+    assert(y3 ~== expected2 absTol 1e-15)
+    assert(y4 ~== expected2 absTol 1e-15)
+  }
 }

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/BLASSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/BLASSuite.scala
@@ -152,7 +152,7 @@ class BLASSuite extends FunSuite {
 
     withClue("columns of A don't match the rows of B") {
       intercept[Exception] {
-        gemm("T", "N", 1.0, dA, B, 2.0, C1)
+        gemm(true, false, 1.0, dA, B, 2.0, C1)
       }
     }
 
@@ -164,8 +164,8 @@ class BLASSuite extends FunSuite {
     assert(dAT transposeTimes B ~== expected absTol 1e-15)
     assert(sAT transposeTimes B ~== expected absTol 1e-15)
 
-    gemm("T", "N", 1.0, dAT, B, 2.0, C3)
-    gemm("T", "N", 1.0, sAT, B, 2.0, C4)
+    gemm(true, false, 1.0, dAT, B, 2.0, C3)
+    gemm(true, false, 1.0, sAT, B, 2.0, C4)
     assert(C3 ~== expected2 absTol 1e-15)
     assert(C4 ~== expected2 absTol 1e-15)
 
@@ -196,7 +196,7 @@ class BLASSuite extends FunSuite {
 
     withClue("columns of A don't match the rows of B") {
       intercept[Exception] {
-        gemv("T", 1.0, dA, x, 2.0, y1)
+        gemv(true, 1.0, dA, x, 2.0, y1)
       }
     }
 
@@ -208,8 +208,8 @@ class BLASSuite extends FunSuite {
     assert(dAT transposeTimes x ~== expected absTol 1e-15)
     assert(sAT transposeTimes x ~== expected absTol 1e-15)
 
-    gemv("T", 1.0, dAT, x, 2.0, y3)
-    gemv("T", 1.0, sAT, x, 2.0, y4)
+    gemv(true, 1.0, dAT, x, 2.0, y3)
+    gemv(true, 1.0, sAT, x, 2.0, y4)
     assert(y3 ~== expected2 absTol 1e-15)
     assert(y4 ~== expected2 absTol 1e-15)
   }

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/BLASSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/BLASSuite.scala
@@ -136,8 +136,8 @@ class BLASSuite extends FunSuite {
     val B = new DenseMatrix(3, 2, Array(1.0, 0.0, 0.0, 0.0, 2.0, 1.0))
     val expected = new DenseMatrix(4, 2, Array(0.0, 1.0, 0.0, 0.0, 4.0, 0.0, 2.0, 3.0))
 
-    assert(dA times B ~== expected absTol 1e-15)
-    assert(sA times B ~== expected absTol 1e-15)
+    assert(dA multiply B ~== expected absTol 1e-15)
+    assert(sA multiply B ~== expected absTol 1e-15)
 
     val C1 = new DenseMatrix(4, 2, Array(1.0, 0.0, 2.0, 1.0, 0.0, 0.0, 1.0, 0.0))
     val C2 = C1.copy
@@ -170,8 +170,8 @@ class BLASSuite extends FunSuite {
     val sAT =
       new SparseMatrix(3, 4, Array(0, 1, 2, 3, 4), Array(1, 0, 1, 2), Array(2.0, 1.0, 1.0, 3.0))
 
-    assert(dAT transposeTimes B ~== expected absTol 1e-15)
-    assert(sAT transposeTimes B ~== expected absTol 1e-15)
+    assert(dAT transposeMultiply B ~== expected absTol 1e-15)
+    assert(sAT transposeMultiply B ~== expected absTol 1e-15)
 
     gemm(true, false, 1.0, dAT, B, 2.0, C5)
     gemm(true, false, 1.0, sAT, B, 2.0, C6)
@@ -181,7 +181,6 @@ class BLASSuite extends FunSuite {
     assert(C6 ~== expected2 absTol 1e-15)
     assert(C7 ~== expected3 absTol 1e-15)
     assert(C8 ~== expected3 absTol 1e-15)
-
   }
 
   test("gemv") {
@@ -193,8 +192,8 @@ class BLASSuite extends FunSuite {
     val x = new DenseVector(Array(1.0, 2.0, 3.0))
     val expected = new DenseVector(Array(4.0, 1.0, 2.0, 9.0))
 
-    assert(dA times x ~== expected absTol 1e-15)
-    assert(sA times x ~== expected absTol 1e-15)
+    assert(dA multiply x ~== expected absTol 1e-15)
+    assert(sA multiply x ~== expected absTol 1e-15)
 
     val y1 = new DenseVector(Array(1.0, 3.0, 1.0, 0.0))
     val y2 = y1.copy
@@ -226,8 +225,8 @@ class BLASSuite extends FunSuite {
     val sAT =
       new SparseMatrix(3, 4, Array(0, 1, 2, 3, 4), Array(1, 0, 1, 2), Array(2.0, 1.0, 1.0, 3.0))
 
-    assert(dAT transposeTimes x ~== expected absTol 1e-15)
-    assert(sAT transposeTimes x ~== expected absTol 1e-15)
+    assert(dAT transposeMultiply x ~== expected absTol 1e-15)
+    assert(sAT transposeMultiply x ~== expected absTol 1e-15)
 
     gemv(true, 1.0, dAT, x, 2.0, y5)
     gemv(true, 1.0, sAT, x, 2.0, y6)

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/BLASSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/BLASSuite.scala
@@ -161,8 +161,8 @@ class BLASSuite extends FunSuite {
     val sAT =
       new SparseMatrix(3, 4, Array(0, 1, 2, 3, 4), Array(1, 0, 1, 2), Array(2.0, 1.0, 1.0, 3.0))
 
-    assert(dAT transpose_times B ~== expected absTol 1e-15)
-    assert(sAT transpose_times B ~== expected absTol 1e-15)
+    assert(dAT transposeTimes B ~== expected absTol 1e-15)
+    assert(sAT transposeTimes B ~== expected absTol 1e-15)
 
     gemm("T", "N", 1.0, dAT, B, 2.0, C3)
     gemm("T", "N", 1.0, sAT, B, 2.0, C4)
@@ -205,8 +205,8 @@ class BLASSuite extends FunSuite {
     val sAT =
       new SparseMatrix(3, 4, Array(0, 1, 2, 3, 4), Array(1, 0, 1, 2), Array(2.0, 1.0, 1.0, 3.0))
 
-    assert(dAT transpose_times x ~== expected absTol 1e-15)
-    assert(sAT transpose_times x ~== expected absTol 1e-15)
+    assert(dAT transposeTimes x ~== expected absTol 1e-15)
+    assert(sAT transposeTimes x ~== expected absTol 1e-15)
 
     gemv("T", 1.0, dAT, x, 2.0, y3)
     gemv("T", 1.0, sAT, x, 2.0, y4)

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/BreezeMatrixConversionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/BreezeMatrixConversionSuite.scala
@@ -40,9 +40,9 @@ class BreezeMatrixConversionSuite extends FunSuite {
 
   test("sparse matrix to breeze") {
     val values = Array(1.0, 2.0, 4.0, 5.0)
-    val colPointers = Array(0, 2, 4)
+    val colPtrs = Array(0, 2, 4)
     val rowIndices = Array(1, 2, 1, 2)
-    val mat = Matrices.sparse(3, 2, colPointers, rowIndices, values)
+    val mat = Matrices.sparse(3, 2, colPtrs, rowIndices, values)
     val breeze = mat.toBreeze.asInstanceOf[BSM[Double]]
     assert(breeze.rows === mat.numRows)
     assert(breeze.cols === mat.numCols)
@@ -51,9 +51,9 @@ class BreezeMatrixConversionSuite extends FunSuite {
 
   test("sparse breeze matrix to sparse matrix") {
     val values = Array(1.0, 2.0, 4.0, 5.0)
-    val colPointers = Array(0, 2, 4)
+    val colPtrs = Array(0, 2, 4)
     val rowIndices = Array(1, 2, 1, 2)
-    val breeze = new BSM[Double](values, 3, 2, colPointers, rowIndices)
+    val breeze = new BSM[Double](values, 3, 2, colPtrs, rowIndices)
     val mat = Matrices.fromBreeze(breeze).asInstanceOf[SparseMatrix]
     assert(mat.numRows === breeze.rows)
     assert(mat.numCols === breeze.cols)

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/BreezeMatrixConversionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/BreezeMatrixConversionSuite.scala
@@ -40,9 +40,9 @@ class BreezeMatrixConversionSuite extends FunSuite {
 
   test("sparse matrix to breeze") {
     val values = Array(1.0, 2.0, 4.0, 5.0)
-    val colIndices = Array(0, 2, 4)
+    val colPointers = Array(0, 2, 4)
     val rowIndices = Array(1, 2, 1, 2)
-    val mat = Matrices.sparse(3, 2, colIndices, rowIndices, values)
+    val mat = Matrices.sparse(3, 2, colPointers, rowIndices, values)
     val breeze = mat.toBreeze.asInstanceOf[BSM[Double]]
     assert(breeze.rows === mat.numRows)
     assert(breeze.cols === mat.numCols)
@@ -51,9 +51,9 @@ class BreezeMatrixConversionSuite extends FunSuite {
 
   test("sparse breeze matrix to sparse matrix") {
     val values = Array(1.0, 2.0, 4.0, 5.0)
-    val colIndices = Array(0, 2, 4)
+    val colPointers = Array(0, 2, 4)
     val rowIndices = Array(1, 2, 1, 2)
-    val breeze = new BSM[Double](values, 3, 2, colIndices, rowIndices)
+    val breeze = new BSM[Double](values, 3, 2, colPointers, rowIndices)
     val mat = Matrices.fromBreeze(breeze).asInstanceOf[SparseMatrix]
     assert(mat.numRows === breeze.rows)
     assert(mat.numCols === breeze.cols)

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/BreezeMatrixConversionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/BreezeMatrixConversionSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.mllib.linalg
 
 import org.scalatest.FunSuite
 
-import breeze.linalg.{DenseMatrix => BDM}
+import breeze.linalg.{DenseMatrix => BDM, CSCMatrix => BSM}
 
 class BreezeMatrixConversionSuite extends FunSuite {
   test("dense matrix to breeze") {
@@ -33,6 +33,28 @@ class BreezeMatrixConversionSuite extends FunSuite {
   test("dense breeze matrix to matrix") {
     val breeze = new BDM[Double](3, 2, Array(0.0, 1.0, 2.0, 3.0, 4.0, 5.0))
     val mat = Matrices.fromBreeze(breeze).asInstanceOf[DenseMatrix]
+    assert(mat.numRows === breeze.rows)
+    assert(mat.numCols === breeze.cols)
+    assert(mat.values.eq(breeze.data), "should not copy data")
+  }
+
+  test("sparse matrix to breeze") {
+    val values = Array(1.0, 2.0, 4.0, 5.0)
+    val colIndices = Array(0, 2, 4)
+    val rowIndices = Array(1, 2, 1, 2)
+    val mat = Matrices.sparse(3, 2, colIndices, rowIndices, values)
+    val breeze = mat.toBreeze.asInstanceOf[BSM[Double]]
+    assert(breeze.rows === mat.numRows)
+    assert(breeze.cols === mat.numCols)
+    assert(breeze.data.eq(mat.asInstanceOf[SparseMatrix].values), "should not copy data")
+  }
+
+  test("sparse breeze matrix to sparse matrix") {
+    val values = Array(1.0, 2.0, 4.0, 5.0)
+    val colIndices = Array(0, 2, 4)
+    val rowIndices = Array(1, 2, 1, 2)
+    val breeze = new BSM[Double](values, 3, 2, colIndices, rowIndices)
+    val mat = Matrices.fromBreeze(breeze).asInstanceOf[SparseMatrix]
     assert(mat.numRows === breeze.rows)
     assert(mat.numCols === breeze.cols)
     assert(mat.values.eq(breeze.data), "should not copy data")

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
@@ -41,20 +41,22 @@ class MatricesSuite extends FunSuite {
     val m = 3
     val n = 2
     val values = Array(1.0, 2.0, 4.0, 5.0)
-    val colIndices = Array(0, 2, 4)
+    val colPtrs = Array(0, 2, 4)
     val rowIndices = Array(1, 2, 1, 2)
-    val mat = Matrices.sparse(m, n, colIndices, rowIndices, values).asInstanceOf[SparseMatrix]
+    val mat = Matrices.sparse(m, n, colPtrs, rowIndices, values).asInstanceOf[SparseMatrix]
     assert(mat.numRows === m)
     assert(mat.numCols === n)
     assert(mat.values.eq(values), "should not copy data")
+    assert(mat.colPtrs.eq(colPtrs), "should not copy data")
+    assert(mat.rowIndices.eq(rowIndices), "should not copy data")
   }
 
   test("sparse matrix construction with wrong number of elements") {
-    intercept[RuntimeException] {
+    intercept[IllegalArgumentException] {
       Matrices.sparse(3, 2, Array(0, 1), Array(1, 2, 1), Array(0.0, 1.0, 2.0))
     }
 
-    intercept[RuntimeException] {
+    intercept[IllegalArgumentException] {
       Matrices.sparse(3, 2, Array(0, 1, 2), Array(1, 2), Array(0.0, 1.0, 2.0))
     }
   }
@@ -69,9 +71,9 @@ class MatricesSuite extends FunSuite {
     assert(!denseMat.toArray.eq(denseCopy.toArray))
 
     val values = Array(1.0, 2.0, 4.0, 5.0)
-    val colIndices = Array(0, 2, 4)
+    val colPtrs = Array(0, 2, 4)
     val rowIndices = Array(1, 2, 1, 2)
-    val sparseMat = Matrices.sparse(m, n, colIndices, rowIndices, values)
+    val sparseMat = Matrices.sparse(m, n, colPtrs, rowIndices, values)
     val sparseCopy = sparseMat.copy
 
     assert(!sparseMat.toArray.eq(sparseCopy.toArray))
@@ -84,31 +86,30 @@ class MatricesSuite extends FunSuite {
 
     val denseMat = new DenseMatrix(m, n, allValues)
 
-    assert(denseMat(0, 1) == 3.0)
-    assert(denseMat(0, 1) == denseMat.values(3))
-    assert(denseMat(0, 1) == denseMat(3))
-    assert(denseMat(0, 0) == 0.0)
+    assert(denseMat(0, 1) === 3.0)
+    assert(denseMat(0, 1) === denseMat.values(3))
+    assert(denseMat(0, 1) === denseMat(3))
+    assert(denseMat(0, 0) === 0.0)
 
     denseMat.update(0, 0, 10.0)
-    assert(denseMat(0, 0) == 10.0)
-    assert(denseMat.values(0) == 10.0)
+    assert(denseMat(0, 0) === 10.0)
+    assert(denseMat.values(0) === 10.0)
 
     val sparseValues = Array(1.0, 2.0, 3.0, 4.0)
-    val colIndices = Array(0, 2, 4)
+    val colPtrs = Array(0, 2, 4)
     val rowIndices = Array(1, 2, 0, 1)
-    val sparseMat = new SparseMatrix(m, n, colIndices, rowIndices, sparseValues)
+    val sparseMat = new SparseMatrix(m, n, colPtrs, rowIndices, sparseValues)
 
-    assert(sparseMat(0, 1) == 3.0)
-    assert(sparseMat(0, 1) == sparseMat.values(2))
-    assert(sparseMat(0, 1) == sparseMat(2))
-    assert(sparseMat(0, 0) == 0.0)
+    assert(sparseMat(0, 1) === 3.0)
+    assert(sparseMat(0, 1) === sparseMat.values(2))
+    assert(sparseMat(0, 0) === 0.0)
 
-    intercept[IllegalArgumentException] {
+    intercept[NoSuchElementException] {
       sparseMat.update(0, 0, 10.0)
     }
 
     sparseMat.update(0, 1, 10.0)
-    assert(sparseMat(0, 1) == 10.0)
-    assert(sparseMat.values(2) == 10.0)
+    assert(sparseMat(0, 1) === 10.0)
+    assert(sparseMat.values(2) === 10.0)
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
@@ -36,4 +36,45 @@ class MatricesSuite extends FunSuite {
       Matrices.dense(3, 2, Array(0.0, 1.0, 2.0))
     }
   }
+
+  test("sparse matrix construction") {
+    val m = 3
+    val n = 2
+    val values = Array(1.0, 2.0, 4.0, 5.0)
+    val colIndices = Array(0, 2, 4)
+    val rowIndices = Array(1, 2, 1, 2)
+    val mat = Matrices.sparse(m, n, colIndices, rowIndices, values).asInstanceOf[SparseMatrix]
+    assert(mat.numRows === m)
+    assert(mat.numCols === n)
+    assert(mat.values.eq(values), "should not copy data")
+    assert(mat.toArray.eq(values), "toArray should not copy data")
+  }
+
+  test("sparse matrix construction with wrong number of elements") {
+    intercept[RuntimeException] {
+      Matrices.sparse(3, 2, Array(0, 1), Array(1, 2, 1), Array(0.0, 1.0, 2.0))
+    }
+
+    intercept[RuntimeException] {
+      Matrices.sparse(3, 2, Array(0, 1, 2), Array(1, 2), Array(0.0, 1.0, 2.0))
+    }
+  }
+
+  test("matrix copies are deep copies") {
+    val m = 3
+    val n = 2
+
+    val denseMat = Matrices.dense(m, n, Array(0.0, 1.0, 2.0, 3.0, 4.0, 5.0))
+    val denseCopy = denseMat.copy
+
+    assert(!denseMat.toArray.eq(denseCopy.toArray))
+
+    val values = Array(1.0, 2.0, 4.0, 5.0)
+    val colIndices = Array(0, 2, 4)
+    val rowIndices = Array(1, 2, 1, 2)
+    val sparseMat = Matrices.sparse(m, n, colIndices, rowIndices, values)
+    val sparseCopy = sparseMat.copy
+
+    assert(!sparseMat.toArray.eq(sparseCopy.toArray))
+  }
 }

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
@@ -47,7 +47,6 @@ class MatricesSuite extends FunSuite {
     assert(mat.numRows === m)
     assert(mat.numCols === n)
     assert(mat.values.eq(values), "should not copy data")
-    assert(mat.toArray.eq(values), "toArray should not copy data")
   }
 
   test("sparse matrix construction with wrong number of elements") {

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
@@ -100,8 +100,8 @@ class MatricesSuite extends FunSuite {
     val sparseMat = new SparseMatrix(m, n, colIndices, rowIndices, sparseValues)
 
     assert(sparseMat(0, 1) == 3.0)
-    assert(sparseMat(0, 1) == denseMat.values(2))
-    assert(sparseMat(0, 1) == denseMat(2))
+    assert(sparseMat(0, 1) == sparseMat.values(2))
+    assert(sparseMat(0, 1) == sparseMat(2))
     assert(sparseMat(0, 0) == 0.0)
 
     intercept[IllegalArgumentException] {

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
@@ -77,4 +77,39 @@ class MatricesSuite extends FunSuite {
 
     assert(!sparseMat.toArray.eq(sparseCopy.toArray))
   }
+
+  test("matrix indexing and updating") {
+    val m = 3
+    val n = 2
+    val allValues = Array(0.0, 1.0, 2.0, 3.0, 4.0, 0.0)
+
+    val denseMat = new DenseMatrix(m, n, allValues)
+
+    assert(denseMat(0, 1) == 3.0)
+    assert(denseMat(0, 1) == denseMat.values(3))
+    assert(denseMat(0, 1) == denseMat(3))
+    assert(denseMat(0, 0) == 0.0)
+
+    denseMat.update(0, 0, 10.0)
+    assert(denseMat(0, 0) == 10.0)
+    assert(denseMat.values(0) == 10.0)
+
+    val sparseValues = Array(1.0, 2.0, 3.0, 4.0)
+    val colIndices = Array(0, 2, 4)
+    val rowIndices = Array(1, 2, 0, 1)
+    val sparseMat = new SparseMatrix(m, n, colIndices, rowIndices, sparseValues)
+
+    assert(sparseMat(0, 1) == 3.0)
+    assert(sparseMat(0, 1) == denseMat.values(2))
+    assert(sparseMat(0, 1) == denseMat(2))
+    assert(sparseMat(0, 0) == 0.0)
+
+    intercept[IllegalArgumentException] {
+      sparseMat.update(0, 0, 10.0)
+    }
+
+    sparseMat.update(0, 1, 10.0)
+    assert(sparseMat(0, 1) == 10.0)
+    assert(sparseMat.values(2) == 10.0)
+  }
 }

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -110,6 +110,14 @@ object MimaExcludes {
             ProblemFilters.exclude[IncompatibleMethTypeProblem](
               "org.apache.spark.mllib.recommendation.ALS.org$apache$spark$mllib$recommendation$ALS$^dateFeatures")
           ) ++
+          Seq( // Ignore new functions added to trait `Matrix`. They are sealed traits now.
+            ProblemFilters.exclude[MissingMethodProblem](
+              "org.apache.spark.mllib.linalg.Matrix.multiply"),
+            ProblemFilters.exclude[MissingMethodProblem](
+              "org.apache.spark.mllib.linalg.Matrix.transposeMultiply"),
+            ProblemFilters.exclude[MissingMethodProblem](
+              "org.apache.spark.mllib.linalg.Matrix.copy")
+          ) ++
           MimaBuild.excludeSparkClass("mllib.linalg.distributed.ColumnStatisticsAggregator") ++
           MimaBuild.excludeSparkClass("rdd.ZippedRDD") ++
           MimaBuild.excludeSparkClass("rdd.ZippedPartition") ++

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -110,14 +110,8 @@ object MimaExcludes {
             ProblemFilters.exclude[IncompatibleMethTypeProblem](
               "org.apache.spark.mllib.recommendation.ALS.org$apache$spark$mllib$recommendation$ALS$^dateFeatures")
           ) ++
-          Seq( // Ignore new functions added to trait `Matrix`. They are sealed traits now.
-            ProblemFilters.exclude[MissingMethodProblem](
-              "org.apache.spark.mllib.linalg.Matrix.multiply"),
-            ProblemFilters.exclude[MissingMethodProblem](
-              "org.apache.spark.mllib.linalg.Matrix.transposeMultiply"),
-            ProblemFilters.exclude[MissingMethodProblem](
-              "org.apache.spark.mllib.linalg.Matrix.copy")
-          ) ++
+          MimaBuild.excludeSparkClass("mllib.linalg.Matrix") ++
+          MimaBuild.excludeSparkClass("mllib.linalg.Vector") ++
           MimaBuild.excludeSparkClass("mllib.linalg.distributed.ColumnStatisticsAggregator") ++
           MimaBuild.excludeSparkClass("rdd.ZippedRDD") ++
           MimaBuild.excludeSparkClass("rdd.ZippedPartition") ++

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -37,7 +37,9 @@ object MimaExcludes {
           Seq(
             MimaBuild.excludeSparkPackage("deploy"),
             MimaBuild.excludeSparkPackage("graphx")
-          )
+          ) ++
+          MimaBuild.excludeSparkClass("mllib.linalg.Matrix") ++
+          MimaBuild.excludeSparkClass("mllib.linalg.Vector")
 
         case v if v.startsWith("1.1") =>
           Seq(
@@ -110,8 +112,6 @@ object MimaExcludes {
             ProblemFilters.exclude[IncompatibleMethTypeProblem](
               "org.apache.spark.mllib.recommendation.ALS.org$apache$spark$mllib$recommendation$ALS$^dateFeatures")
           ) ++
-          MimaBuild.excludeSparkClass("mllib.linalg.Matrix") ++
-          MimaBuild.excludeSparkClass("mllib.linalg.Vector") ++
           MimaBuild.excludeSparkClass("mllib.linalg.distributed.ColumnStatisticsAggregator") ++
           MimaBuild.excludeSparkClass("rdd.ZippedRDD") ++
           MimaBuild.excludeSparkClass("rdd.ZippedPartition") ++


### PR DESCRIPTION
Local `SparseMatrix` support added in Compressed Column Storage (CCS) format in addition to Level-2 and Level-3 BLAS operations such as dgemv and dgemm respectively.

BLAS doesn't support  sparse matrix operations, therefore support for `SparseMatrix`-`DenseMatrix` multiplication and `SparseMatrix`-`DenseVector` implementations have been added. I will post performance comparisons in the comments momentarily.
