### PR TITLE
Provide a default PYSPARK_PYTHON for python/run_tests

### DIFF
--- a/python/run-tests
+++ b/python/run-tests
@@ -48,6 +48,8 @@ function run_test() {
 
 echo "Running PySpark tests. Output is in python/unit-tests.log."
 
+export PYSPARK_PYTHON="python"
+
 # Try to test with Python 2.6, since that's the minimum version that we support:
 if [ $(which python2.6) ]; then
     export PYSPARK_PYTHON="python2.6"


### PR DESCRIPTION
Without this the version of python used in the test is not
recorded. The error is,

   Testing with Python version:
   ./run-tests: line 57: --version: command not found
