### PR TITLE
[SPARK-1192][RESUBMIT]Missing document of some parameters in Spark Core

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -376,6 +376,15 @@ Apart from these, the following properties are also available, and may be useful
     discarded.
   </td>
 </tr>
+<tr>
+  <td>spark.dead.worker.persistence</td>
+  <td>15</td>
+  <td>
+    This parameter controls when Spark will remove the worker information from the UI if it is dead.
+        If it has been longer than (<code>spark.dead.worker.persistence</code> + 1) * <code> spark.worker.timeout
+        </code> seconds since the worker is dead, Spark will remove it from UI.
+  </td>
+</tr>
 </table>
 
 #### Compression and Serialization

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -274,6 +274,15 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+  <td><code>spark.shuffle.safetyFraction</code></td>
+  <td>0.8</td>
+  <td>
+    Specify the safety margin of the memory space used by shuffle. The total size of memory size used by 
+    Shuffle is (Runtime.getRuntime.maxMemory * <code>spark.shuffle.memoryFraction</code> * 
+    <code>spark.shuffle.safetyFraction</code>)
+  </td>
+</tr>
+<tr>
   <td><code>spark.shuffle.compress</code></td>
   <td>true</td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -586,6 +586,15 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+  <td><code>spark.storage.safetyFraction</code></td>
+  <td>0.9</td>
+  <td>
+    Specify the safety margin of the memory space used by storage. The total size of memory size used by 
+        Shuffle is (Runtime.getRuntime.maxMemory * <code>spark.storage.memoryFraction</code> * 
+        <code>spark.storage.safetyFraction</code>)
+  </td>
+</tr>
+<tr>
   <td><code>spark.storage.unrollFraction</code></td>
   <td>0.2</td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -900,6 +900,13 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+  <td><code>spark.scheduler.executorTaskBlacklistTime</code></td>
+  <td>0</td>
+  <td>
+    The allowed failure number of a task before the executor is put into black list. 
+  </td>
+</tr>
+<tr>
   <td><code>spark.localExecution.enabled</code></td>
   <td>false</td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -224,31 +224,6 @@ Apart from these, the following properties are also available, and may be useful
     <code>spark.executor.uri</code>.
   </td>
 </tr>
-<tr>
-  <td><code>spark.deploy.recoveryDirectory</code></td>
-  <td>""</td>
-  <td>
-    The user can specify the directory for the master recovery file when using FileSystemPersistenceEngine.
-  </td>
-</tr>
-<tr>
-  <td><code>spark.deploy.spreadOut</code></td>
-  <td>true</td>
-  <td>
-    Whether the standalone cluster manager should spread applications out across nodes or try
-       to consolidate them onto as few nodes as possible. Spreading out is usually better for
-      data locality in HDFS, but consolidating is more efficient for compute-intensive workloads. <br/>
-       <b>Note:</b> this setting needs to be configured in the standalone cluster master, not in individual
-      applications; you can set it through <code>SPARK_JAVA_OPTS</code> in <code>spark-env.sh</code>.
-  </td>
-</tr>
-<tr>
-  <td><code>spark.worker.timeout</code></td>
-  <td>60s</td>
-  <td>
-    Communication timeout before the master takes a worker as dead
-  </td>
-</tr>
 </table>
 
 #### Shuffle Behavior
@@ -383,31 +358,6 @@ Apart from these, the following properties are also available, and may be useful
     Within this base directory, Spark creates a sub-directory for each application, and logs the
     events specific to the application in this directory. Users may want to set this to
     a unified location like an HDFS directory so history files can be read by the history server.
-  </td>
-</tr>
-<tr>
-  <td>spark.deploy.retainedApplications</td>
-  <td>200</td>
-  <td>
-    The maximum number of records on completed applications kept in the Master node. When the completed
-    application number exceeds the threshold, the first Max(spark.deploy.retainedApplications, 1) will be
-    discarded.
-  </td>
-</tr>
-<tr>
-  <td>spark.dead.worker.persistence</td>
-  <td>15</td>
-  <td>
-    This parameter controls when Spark will remove the worker information from the UI if it is dead.
-        If it has been longer than (<code>spark.dead.worker.persistence</code> + 1) * <code> spark.worker.timeout
-        </code> seconds since the worker is dead, Spark will remove it from UI.
-  </td>
-</tr>
-<tr>
-  <td>spark.master.ui.port</td>
-  <td>8080</td>
-  <td>
-    The port number of the web UI of Master.  
   </td>
 </tr>
 </table>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -224,6 +224,13 @@ Apart from these, the following properties are also available, and may be useful
     <code>spark.executor.uri</code>.
   </td>
 </tr>
+<tr>
+  <td><code>spark.worker.timeout</code></td>
+  <td>60s</td>
+  <td>
+    Communication timeout before the master takes a worker as dead
+  </td>
+</tr>
 </table>
 
 #### Shuffle Behavior

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -309,6 +309,27 @@ Apart from these, the following properties are also available, and may be useful
     map-side aggregation and there are at most this many reduce partitions.
   </td>
 </tr>
+<tr>
+  <td><code>spark.shuffle.io.port</code></td>
+  <td>Random</td>
+  <td>
+    Port the Netty-based BlockServer listens on.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.shuffle.io.mode</code></td>
+  <td>nio</td>
+  <td>
+    IO mode of the Netty-based BlockServer, nio, oio, epoll, or auto.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.shuffle.io.connectionTimeout</code></td>
+  <td>60s</td>
+  <td>
+    Connect timeout of Netty-based BlockServer.
+  </td>
+</tr>
 </table>
 
 #### Spark UI

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -622,6 +622,13 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+  <td><code>spark.storage.blockManagerSlaveTimeoutMs</code></td>
+  <td><code>max(<code>spark.executor.heartbeatInterval</code>, 10000) * 3, 45000)</code></td>
+  <td>
+    Communication timeout between BlockManagerMaster and BlockManagerSlave.
+  </td>
+</tr>
+<tr>
   <td><code>spark.tachyonStore.url</code></td>
   <td>tachyon://localhost:19998</td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -387,6 +387,13 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+  <td><code>spark.eventLog.overwrite</code></td>
+  <td>false</td>
+  <td>
+    Whether to overwrite the log directory if it already exists.
+  </td>
+</tr>
+<tr>
   <td><code>spark.eventLog.dir</code></td>
   <td>file:///tmp/spark-events</td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -367,6 +367,15 @@ Apart from these, the following properties are also available, and may be useful
     a unified location like an HDFS directory so history files can be read by the history server.
   </td>
 </tr>
+<tr>
+  <td>spark.deploy.retainedApplications</td>
+  <td>200</td>
+  <td>
+    The maximum number of records on completed applications kept in the Master node. When the completed
+    application number exceeds the threshold, the first Max(spark.deploy.retainedApplications, 1) will be
+    discarded.
+  </td>
+</tr>
 </table>
 
 #### Compression and Serialization

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -403,6 +403,13 @@ Apart from these, the following properties are also available, and may be useful
         </code> seconds since the worker is dead, Spark will remove it from UI.
   </td>
 </tr>
+<tr>
+  <td>spark.master.ui.port</td>
+  <td>8080</td>
+  <td>
+    The port number of the web UI of Master.  
+  </td>
+</tr>
 </table>
 
 #### Compression and Serialization

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -225,6 +225,13 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+  <td><code>spark.deploy.recoveryDirectory</code></td>
+  <td>""</td>
+  <td>
+    The user can specify the directory for the master recovery file when using FileSystemPersistenceEngine.
+  </td>
+</tr>
+<tr>
   <td><code>spark.worker.timeout</code></td>
   <td>60s</td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -232,6 +232,17 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+  <td><code>spark.deploy.spreadOut</code></td>
+  <td>true</td>
+  <td>
+    Whether the standalone cluster manager should spread applications out across nodes or try
+       to consolidate them onto as few nodes as possible. Spreading out is usually better for
+      data locality in HDFS, but consolidating is more efficient for compute-intensive workloads. <br/>
+       <b>Note:</b> this setting needs to be configured in the standalone cluster master, not in individual
+      applications; you can set it through <code>SPARK_JAVA_OPTS</code> in <code>spark-env.sh</code>.
+  </td>
+</tr>
+<tr>
   <td><code>spark.worker.timeout</code></td>
   <td>60s</td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -622,6 +622,13 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+  <td><code>spark.storage.blockManagerTimeoutIntervalMs</code></td>
+  <td>60000ms</code></td>
+  <td>
+    The interval length between two checking of timeout BlockManagerSlaves.
+  </td>
+</tr>
+<tr>
   <td><code>spark.storage.blockManagerSlaveTimeoutMs</code></td>
   <td><code>max(<code>spark.executor.heartbeatInterval</code>, 10000) * 3, 45000)</code></td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,6 +104,13 @@ of the most common options to set are:
   </td>
 </tr>
 <tr>
+  <td><code>spark.logging.exceptionPrintInterval</code></td>
+  <td>10000</td>
+  <td>
+    Frequency to reprint duplicate exceptions in full, in milliseconds
+  </td>
+</tr>
+<tr>
   <td><code>spark.serializer</code></td>
   <td>org.apache.spark.serializer.<br />JavaSerializer</td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -330,6 +330,21 @@ Apart from these, the following properties are also available, and may be useful
     Connect timeout of Netty-based BlockServer.
   </td>
 </tr>
+<tr>
+  <td><code>spark.shuffle.io.netty.ioRatio</code></td>
+  <td>80</td>
+  <td>
+    Percentage of the desired amount of time spent for I/O in the child event loops. Only applicable in nio and epoll of 
+    Netty-based BlockServer
+  </td>
+</tr>
+<tr>
+  <td><code>spark.shuffle.io.backLog</code></td>
+  <td>50</td>
+  <td>
+    Requested maximum length of the queue of incoming connections (for Netty-based BlockServer).
+  </td>
+</tr>
 </table>
 
 #### Spark UI

--- a/docs/spark-standalone.md
+++ b/docs/spark-standalone.md
@@ -191,6 +191,15 @@ SPARK_MASTER_OPTS supports the following system properties:
   </td>
 </tr>
 <tr>
+  <td><code>spark.dead.worker.persistence</code></td>
+  <td>15</td>
+  <td>
+    This parameter controls when Spark will remove the worker information from the UI if it is dead.
+            If it has been longer than (<code>spark.dead.worker.persistence</code> + 1) * <code> spark.worker.timeout
+            </code> seconds since the worker is dead, Spark will remove it from UI.
+  </td>
+</tr>
+<tr>
   <td><code>spark.worker.timeout</code></td>
   <td>60</td>
   <td>


### PR DESCRIPTION
It's a resubmission of https://github.com/apache/spark/pull/85 according to @mateiz 's suggestion

---

Hi, @mateiz and @pwendell 

I found that nearly all parameters in constructing actor system (AkkaUtil) are not documented...

IIRC, there was a PR which proposes that we should leave space for the user to configure the Akka system, is that still valid?
