### PR TITLE
[HOTFIX] Fix broken Mima tests on the master branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,18 @@
         <enabled>false</enabled>
       </snapshots>
     </repository>
+    <!-- TODO: remove this as soon as 1.1.0 is published on Maven central -->
+    <repository>
+      <id>spark-staging-1030</id>
+      <name>Spark 1.1.0 Staging (1030)</name>
+      <url>https://repository.apache.org/content/repositories/orgapachespark-1030/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>

--- a/project/MimaBuild.scala
+++ b/project/MimaBuild.scala
@@ -85,7 +85,7 @@ object MimaBuild {
 
   def mimaSettings(sparkHome: File, projectRef: ProjectRef) = {
     val organization = "org.apache.spark"
-    val previousSparkVersion = "1.0.0"
+    val previousSparkVersion = "1.1.0"
     val fullId = "spark-" + projectRef.project + "_2.10"
     mimaDefaultSettings ++ 
     Seq(previousArtifact := Some(organization % fullId % previousSparkVersion),

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -37,6 +37,13 @@ object MimaExcludes {
           Seq(
             MimaBuild.excludeSparkPackage("deploy"),
             MimaBuild.excludeSparkPackage("graphx")
+          ) ++
+          // This is @DeveloperAPI, but Mima still gives false-positives:
+          MimaBuild.excludeSparkClass("scheduler.SparkListenerApplicationStart") ++
+          Seq(
+            // This is @Experimental, but Mima still gives false-positives:
+            ProblemFilters.exclude[MissingMethodProblem](
+              "org.apache.spark.api.java.JavaRDDLike.foreachAsync")
           )
         case v if v.startsWith("1.1") =>
           Seq(

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -33,6 +33,8 @@ import com.typesafe.tools.mima.core._
 object MimaExcludes {
     def excludes(version: String) =
       version match {
+        case v if v.startsWith("1.2") =>
+          Seq.empty
         case v if v.startsWith("1.1") =>
           Seq(
             MimaBuild.excludeSparkPackage("deploy"),

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -34,7 +34,10 @@ object MimaExcludes {
     def excludes(version: String) =
       version match {
         case v if v.startsWith("1.2") =>
-          Seq.empty
+          Seq(
+            MimaBuild.excludeSparkPackage("deploy"),
+            MimaBuild.excludeSparkPackage("graphx")
+          )
         case v if v.startsWith("1.1") =>
           Seq(
             MimaBuild.excludeSparkPackage("deploy"),


### PR DESCRIPTION
By merging #2268, which bumped the Spark version to 1.2.0-SNAPSHOT, I inadvertently broke the Mima binary compatibility tests.  The issue is that we were comparing 1.2.0-SNAPSHOT against Spark 1.0.0 without using any Mima excludes.  The right long-term fix for this is probably to publish nightly snapshots on Maven central and change the master branch to test binary compatibility against the current release candidate branch's snapshots until that release is finalized.

As a short-term fix until 1.1.0 is published on Maven central, I've configured the build to test the master branch for binary compatibility against the 1.1.0-RC4 jars.  I'll loop back and remove the Apache staging repo as soon as 1.1.0 final is available.
