### PR TITLE
[SPARK-3437][BUILD] Support crossbuilding in maven.

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-assembly_2.10</artifactId>
+  <artifactId>spark-assembly</artifactId>
   <name>Spark Project Assembly</name>
   <url>http://spark.apache.org/</url>
   <packaging>pom</packaging>
@@ -51,37 +51,37 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <artifactId>spark-core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-bagel_${scala.binary.version}</artifactId>
+      <artifactId>spark-bagel</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-mllib_${scala.binary.version}</artifactId>
+      <artifactId>spark-mllib</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-repl_${scala.binary.version}</artifactId>
+      <artifactId>spark-repl</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+      <artifactId>spark-streaming</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-graphx_${scala.binary.version}</artifactId>
+      <artifactId>spark-graphx</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_${scala.binary.version}</artifactId>
+      <artifactId>spark-sql</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>
@@ -158,7 +158,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.spark</groupId>
-          <artifactId>spark-yarn-alpha_${scala.binary.version}</artifactId>
+          <artifactId>spark-yarn-alpha</artifactId>
           <version>${project.version}</version>
         </dependency>
       </dependencies>
@@ -168,7 +168,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.spark</groupId>
-          <artifactId>spark-yarn_${scala.binary.version}</artifactId>
+          <artifactId>spark-yarn</artifactId>
           <version>${project.version}</version>
         </dependency>
       </dependencies>
@@ -178,12 +178,12 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.spark</groupId>
-          <artifactId>spark-hive_${scala.binary.version}</artifactId>
+          <artifactId>spark-hive</artifactId>
           <version>${project.version}</version>
         </dependency>
         <dependency>
           <groupId>org.apache.spark</groupId>
-          <artifactId>spark-hive-thriftserver_${scala.binary.version}</artifactId>
+          <artifactId>spark-hive-thriftserver</artifactId>
           <version>${project.version}</version>
         </dependency>
       </dependencies>
@@ -193,7 +193,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.spark</groupId>
-          <artifactId>spark-ganglia-lgpl_${scala.binary.version}</artifactId>
+          <artifactId>spark-ganglia-lgpl</artifactId>
           <version>${project.version}</version>
         </dependency>
       </dependencies>

--- a/bagel/pom.xml
+++ b/bagel/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-bagel_2.10</artifactId>
+  <artifactId>spark-bagel</artifactId>
   <properties>
     <sbt.project.name>bagel</sbt.project.name>
   </properties>
@@ -37,7 +37,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <artifactId>spark-core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -59,6 +59,53 @@
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
     <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+        <executions>
+          <execution>
+            <id>1</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <file>${project.build.directory}/${project.build.finalName}.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+            </configuration>
+          </execution>
+          <execution>
+            <id>2</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-sources.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>sources</classifier>
+            </configuration>
+          </execution>
+          <execution>
+            <id>3</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-javadoc.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>javadoc</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-core_2.10</artifactId>
+  <artifactId>spark-core</artifactId>
   <properties>
     <sbt.project.name>core</sbt.project.name>
   </properties>
@@ -351,6 +351,54 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.5.2</version>
+          <executions>
+            <execution>
+              <id>1</id>
+              <goals>
+                <goal>install-file</goal>
+              </goals>
+              <phase>install</phase>
+              <configuration>
+                <file>${project.build.directory}/${project.build.finalName}.jar</file>
+                <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              </configuration>
+            </execution>
+            <execution>
+              <id>2</id>
+              <goals>
+                <goal>install-file</goal>
+              </goals>
+              <phase>install</phase>
+              <configuration>
+                <generatePom>false</generatePom>
+                <pomFile>pom.xml</pomFile>
+                <file>${project.build.directory}/${project.build.finalName}-sources.jar</file>
+                <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+                <classifier>sources</classifier>
+              </configuration>
+            </execution>
+            <execution>
+              <id>3</id>
+              <goals>
+                <goal>install-file</goal>
+              </goals>
+              <phase>install</phase>
+              <configuration>
+                <generatePom>false</generatePom>
+                <pomFile>pom.xml</pomFile>
+                <file>${project.build.directory}/${project.build.finalName}-javadoc.jar</file>
+                <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+                <classifier>javadoc</classifier>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+
     </plugins>
 
     <resources>

--- a/dev/audit-release/maven_app_core/pom.xml
+++ b/dev/audit-release/maven_app_core/pom.xml
@@ -36,7 +36,7 @@
   <dependencies>
     <dependency> <!-- Spark dependency -->
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <artifactId>spark-core</artifactId>
       <version>${spark.version}</version>
     </dependency>
   </dependencies>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-examples_2.10</artifactId>
+  <artifactId>spark-examples</artifactId>
   <properties>
     <sbt.project.name>examples</sbt.project.name>
   </properties>
@@ -40,7 +40,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.spark</groupId>
-          <artifactId>spark-streaming-kinesis-asl_${scala.binary.version}</artifactId>
+          <artifactId>spark-streaming-kinesis-asl</artifactId>
           <version>${project.version}</version>
         </dependency>
       </dependencies>
@@ -56,63 +56,63 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <artifactId>spark-core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+      <artifactId>spark-streaming</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-mllib_${scala.binary.version}</artifactId>
+      <artifactId>spark-mllib</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-bagel_${scala.binary.version}</artifactId>
+      <artifactId>spark-bagel</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-hive_${scala.binary.version}</artifactId>
+      <artifactId>spark-hive</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-graphx_${scala.binary.version}</artifactId>
+      <artifactId>spark-graphx</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming-twitter_${scala.binary.version}</artifactId>
+      <artifactId>spark-streaming-twitter</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming-kafka_${scala.binary.version}</artifactId>
+      <artifactId>spark-streaming-kafka</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming-flume_${scala.binary.version}</artifactId>
+      <artifactId>spark-streaming-flume</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming-zeromq_${scala.binary.version}</artifactId>
+      <artifactId>spark-streaming-zeromq</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming-mqtt_${scala.binary.version}</artifactId>
+      <artifactId>spark-streaming-mqtt</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -203,6 +203,53 @@
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
     <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+        <executions>
+          <execution>
+            <id>1</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <file>${project.build.directory}/${project.build.finalName}.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+            </configuration>
+          </execution>
+          <execution>
+            <id>2</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-sources.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>sources</classifier>
+            </configuration>
+          </execution>
+          <execution>
+            <id>3</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-javadoc.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>javadoc</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>

--- a/external/flume-sink/pom.xml
+++ b/external/flume-sink/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-streaming-flume-sink_2.10</artifactId>
+  <artifactId>spark-streaming-flume-sink</artifactId>
   <properties>
     <sbt.project.name>streaming-flume-sink</sbt.project.name>
   </properties>
@@ -91,6 +91,52 @@
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
     <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+        <executions>
+          <execution>
+            <id>1</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <file>${project.build.directory}/${project.build.finalName}.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+            </configuration>
+          </execution>
+          <execution>
+            <id>2</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-sources.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>sources</classifier>
+            </configuration>
+          </execution>
+          <execution>
+            <id>3</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-javadoc.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>javadoc</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>

--- a/external/flume/pom.xml
+++ b/external/flume/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-streaming-flume_2.10</artifactId>
+  <artifactId>spark-streaming-flume</artifactId>
   <properties>
     <sbt.project.name>streaming-flume</sbt.project.name>
   </properties>
@@ -37,17 +37,17 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+      <artifactId>spark-streaming</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming-flume-sink_${scala.binary.version}</artifactId>
+      <artifactId>spark-streaming-flume-sink</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+      <artifactId>spark-streaming</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
@@ -92,6 +92,52 @@
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
     <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+        <executions>
+          <execution>
+            <id>1</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <file>${project.build.directory}/${project.build.finalName}.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+            </configuration>
+          </execution>
+          <execution>
+            <id>2</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-sources.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>sources</classifier>
+            </configuration>
+          </execution>
+          <execution>
+            <id>3</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-javadoc.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>javadoc</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>

--- a/external/kafka/pom.xml
+++ b/external/kafka/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-streaming-kafka_2.10</artifactId>
+  <artifactId>spark-streaming-kafka</artifactId>
   <properties>
     <sbt.project.name>streaming-kafka</sbt.project.name>
   </properties>
@@ -37,12 +37,12 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+      <artifactId>spark-streaming</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+      <artifactId>spark-streaming</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
@@ -105,6 +105,52 @@
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
     <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+        <executions>
+          <execution>
+            <id>1</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <file>${project.build.directory}/${project.build.finalName}.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+            </configuration>
+          </execution>
+          <execution>
+            <id>2</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-sources.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>sources</classifier>
+            </configuration>
+          </execution>
+          <execution>
+            <id>3</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-javadoc.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>javadoc</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>

--- a/external/mqtt/pom.xml
+++ b/external/mqtt/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-streaming-mqtt_2.10</artifactId>
+  <artifactId>spark-streaming-mqtt</artifactId>
   <properties>
     <sbt.project.name>streaming-mqtt</sbt.project.name>
   </properties>
@@ -37,12 +37,12 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+      <artifactId>spark-streaming</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+      <artifactId>spark-streaming</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
@@ -82,6 +82,52 @@
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
     <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+        <executions>
+          <execution>
+            <id>1</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <file>${project.build.directory}/${project.build.finalName}.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+            </configuration>
+          </execution>
+          <execution>
+            <id>2</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-sources.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>sources</classifier>
+            </configuration>
+          </execution>
+          <execution>
+            <id>3</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-javadoc.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>javadoc</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>

--- a/external/twitter/pom.xml
+++ b/external/twitter/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-streaming-twitter_2.10</artifactId>
+  <artifactId>spark-streaming-twitter</artifactId>
   <properties>
     <sbt.project.name>streaming-twitter</sbt.project.name>
   </properties>
@@ -37,12 +37,12 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+      <artifactId>spark-streaming</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+      <artifactId>spark-streaming</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
@@ -77,6 +77,52 @@
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
     <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+        <executions>
+          <execution>
+            <id>1</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <file>${project.build.directory}/${project.build.finalName}.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+            </configuration>
+          </execution>
+          <execution>
+            <id>2</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-sources.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>sources</classifier>
+            </configuration>
+          </execution>
+          <execution>
+            <id>3</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-javadoc.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>javadoc</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>

--- a/external/zeromq/pom.xml
+++ b/external/zeromq/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-streaming-zeromq_2.10</artifactId>
+  <artifactId>spark-streaming-zeromq</artifactId>
   <properties>
     <sbt.project.name>streaming-zeromq</sbt.project.name>
   </properties>
@@ -37,12 +37,12 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+      <artifactId>spark-streaming</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+      <artifactId>spark-streaming</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
@@ -77,6 +77,52 @@
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
     <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+        <executions>
+          <execution>
+            <id>1</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <file>${project.build.directory}/${project.build.finalName}.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+            </configuration>
+          </execution>
+          <execution>
+            <id>2</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-sources.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>sources</classifier>
+            </configuration>
+          </execution>
+          <execution>
+            <id>3</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-javadoc.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>javadoc</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>

--- a/extras/java8-tests/pom.xml
+++ b/extras/java8-tests/pom.xml
@@ -25,7 +25,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>java8-tests_2.10</artifactId>
+  <artifactId>java8-tests</artifactId>
   <packaging>pom</packaging>
   <name>Spark Project Java8 Tests POM</name>
 
@@ -36,17 +36,17 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <artifactId>spark-core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+      <artifactId>spark-streaming</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+      <artifactId>spark-streaming</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
     </dependency>
@@ -66,7 +66,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
   <profiles>
     <profile>
       <id>java8-tests</id>

--- a/extras/kinesis-asl/pom.xml
+++ b/extras/kinesis-asl/pom.xml
@@ -26,7 +26,7 @@
 
   <!-- Kinesis integration is not included by default due to ASL-licensed code. -->
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-streaming-kinesis-asl_2.10</artifactId>
+  <artifactId>spark-streaming-kinesis-asl</artifactId>
   <packaging>jar</packaging>
   <name>Spark Kinesis Integration</name>
 
@@ -37,12 +37,12 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+      <artifactId>spark-streaming</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+      <artifactId>spark-streaming</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
@@ -87,6 +87,52 @@
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
     <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+        <executions>
+          <execution>
+            <id>1</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <file>${project.build.directory}/${project.build.finalName}.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+            </configuration>
+          </execution>
+          <execution>
+            <id>2</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-sources.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>sources</classifier>
+            </configuration>
+          </execution>
+          <execution>
+            <id>3</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-javadoc.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>javadoc</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>

--- a/extras/spark-ganglia-lgpl/pom.xml
+++ b/extras/spark-ganglia-lgpl/pom.xml
@@ -26,7 +26,7 @@
 
   <!-- Ganglia integration is not included by default due to LGPL-licensed code -->
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-ganglia-lgpl_2.10</artifactId>
+  <artifactId>spark-ganglia-lgpl</artifactId>
   <packaging>jar</packaging>
   <name>Spark Ganglia Integration</name>
 
@@ -37,7 +37,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <artifactId>spark-core</artifactId>
       <version>${project.version}</version>
     </dependency>
 
@@ -46,4 +46,54 @@
       <artifactId>metrics-ganglia</artifactId>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>      
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+        <executions>
+          <execution>
+            <id>1</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <file>${project.build.directory}/${project.build.finalName}.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+            </configuration>
+          </execution>
+          <execution>
+            <id>2</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-sources.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>sources</classifier>
+            </configuration>
+          </execution>
+          <execution>
+            <id>3</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-javadoc.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>javadoc</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/graphx/pom.xml
+++ b/graphx/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-graphx_2.10</artifactId>
+  <artifactId>spark-graphx</artifactId>
   <properties>
     <sbt.project.name>graphx</sbt.project.name>
   </properties>
@@ -37,7 +37,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <artifactId>spark-core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -64,6 +64,53 @@
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
     <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+        <executions>
+          <execution>
+            <id>1</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <file>${project.build.directory}/${project.build.finalName}.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+            </configuration>
+          </execution>
+          <execution>
+            <id>2</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-sources.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>sources</classifier>
+            </configuration>
+          </execution>
+          <execution>
+            <id>3</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-javadoc.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>javadoc</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>

--- a/mllib/pom.xml
+++ b/mllib/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-mllib_2.10</artifactId>
+  <artifactId>spark-mllib</artifactId>
   <properties>
     <sbt.project.name>mllib</sbt.project.name>
   </properties>  
@@ -37,12 +37,12 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <artifactId>spark-core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+      <artifactId>spark-streaming</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -93,7 +93,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+      <artifactId>spark-streaming</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
@@ -116,6 +116,52 @@
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
     <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+        <executions>
+          <execution>
+            <id>1</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <file>${project.build.directory}/${project.build.finalName}.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+            </configuration>
+          </execution>
+          <execution>
+            <id>2</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-sources.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>sources</classifier>
+            </configuration>
+          </execution>
+          <execution>
+            <id>3</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-javadoc.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>javadoc</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -774,8 +774,28 @@
   </dependencyManagement>
 
   <build>
+    <finalName>
+      ${project.artifactId}-${project.version}_${scala.binary.version}
+    </finalName>
+
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>2.4</version>
+          <configuration>
+            <finalName>${project.build.finalName}</finalName>                   
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.5.2</version>
+          <configuration>
+            <skip>true</skip>
+          </configuration>
+        </plugin>        
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
@@ -909,11 +929,6 @@
               </goals>
             </execution>
           </executions>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-jar-plugin</artifactId>
-          <version>2.4</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-repl_2.10</artifactId>
+  <artifactId>spark-repl</artifactId>
   <packaging>jar</packaging>
   <name>Spark Project REPL</name>
   <url>http://spark.apache.org/</url>
@@ -40,24 +40,24 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <artifactId>spark-core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-bagel_${scala.binary.version}</artifactId>
-      <version>${project.version}</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-mllib_${scala.binary.version}</artifactId>
+      <artifactId>spark-bagel</artifactId>
       <version>${project.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_${scala.binary.version}</artifactId>
+      <artifactId>spark-mllib</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
@@ -99,6 +99,53 @@
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
     <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+        <executions>
+          <execution>
+            <id>1</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <file>${project.build.directory}/${project.build.finalName}.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+            </configuration>
+          </execution>
+          <execution>
+            <id>2</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-sources.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>sources</classifier>
+            </configuration>
+          </execution>
+          <execution>
+            <id>3</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-javadoc.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>javadoc</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>

--- a/sql/catalyst/pom.xml
+++ b/sql/catalyst/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-catalyst_2.10</artifactId>
+  <artifactId>spark-catalyst</artifactId>
   <packaging>jar</packaging>
   <name>Spark Project Catalyst</name>
   <url>http://spark.apache.org/</url>
@@ -51,7 +51,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <artifactId>spark-core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -69,6 +69,52 @@
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
     <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+        <executions>
+          <execution>
+            <id>1</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <file>${project.build.directory}/${project.build.finalName}.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+            </configuration>
+          </execution>
+          <execution>
+            <id>2</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-sources.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>sources</classifier>
+            </configuration>
+          </execution>
+          <execution>
+            <id>3</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-javadoc.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>javadoc</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-sql_2.10</artifactId>
+  <artifactId>spark-sql</artifactId>
   <packaging>jar</packaging>
   <name>Spark Project SQL</name>
   <url>http://spark.apache.org/</url>
@@ -38,17 +38,17 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <artifactId>spark-core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
+      <artifactId>spark-catalyst</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
+      <artifactId>spark-catalyst</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
@@ -88,6 +88,53 @@
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
     <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+        <executions>
+          <execution>
+            <id>1</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <file>${project.build.directory}/${project.build.finalName}.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+            </configuration>
+          </execution>
+          <execution>
+            <id>2</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-sources.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>sources</classifier>
+            </configuration>
+          </execution>
+          <execution>
+            <id>3</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-javadoc.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>javadoc</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>

--- a/sql/hive-thriftserver/pom.xml
+++ b/sql/hive-thriftserver/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-hive-thriftserver_2.10</artifactId>
+  <artifactId>spark-hive-thriftserver</artifactId>
   <packaging>jar</packaging>
   <name>Spark Project Hive Thrift Server</name>
   <url>http://spark.apache.org/</url>
@@ -38,7 +38,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-hive_${scala.binary.version}</artifactId>
+      <artifactId>spark-hive</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -66,6 +66,53 @@
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
     <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+        <executions>
+          <execution>
+            <id>1</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <file>${project.build.directory}/${project.build.finalName}.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+            </configuration>
+          </execution>
+          <execution>
+            <id>2</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-sources.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>sources</classifier>
+            </configuration>
+          </execution>
+          <execution>
+            <id>3</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-javadoc.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>javadoc</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>

--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-hive_2.10</artifactId>
+  <artifactId>spark-hive</artifactId>
   <packaging>jar</packaging>
   <name>Spark Project Hive</name>
   <url>http://spark.apache.org/</url>
@@ -43,12 +43,12 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <artifactId>spark-core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_${scala.binary.version}</artifactId>
+      <artifactId>spark-sql</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -141,6 +141,52 @@
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
     <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+        <executions>
+          <execution>
+            <id>1</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <file>${project.build.directory}/${project.build.finalName}.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+            </configuration>
+          </execution>
+          <execution>
+            <id>2</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-sources.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>sources</classifier>
+            </configuration>
+          </execution>
+          <execution>
+            <id>3</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-javadoc.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>javadoc</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>

--- a/streaming/pom.xml
+++ b/streaming/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-streaming_2.10</artifactId>
+  <artifactId>spark-streaming</artifactId>
   <properties>
     <sbt.project.name>streaming</sbt.project.name>
   </properties>
@@ -37,7 +37,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <artifactId>spark-core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -72,8 +72,54 @@
   <build>
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
     <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
-    <plugins>
+    <plugins>      
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+        <executions>
+          <execution>
+            <id>1</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <file>${project.build.directory}/${project.build.finalName}.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+            </configuration>
+          </execution>
+          <execution>
+            <id>2</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-sources.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>sources</classifier>
+            </configuration>
+          </execution>
+          <execution>
+            <id>3</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-javadoc.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>javadoc</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+     <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>
       </plugin>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -25,7 +25,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-tools_2.10</artifactId>
+  <artifactId>spark-tools</artifactId>
   <properties>
     <sbt.project.name>tools</sbt.project.name>
   </properties>
@@ -36,12 +36,12 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <artifactId>spark-core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+      <artifactId>spark-streaming</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -63,6 +63,52 @@
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
     <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+        <executions>
+          <execution>
+            <id>1</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <file>${project.build.directory}/${project.build.finalName}.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+            </configuration>
+          </execution>
+          <execution>
+            <id>2</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-sources.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>sources</classifier>
+            </configuration>
+          </execution>
+          <execution>
+            <id>3</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-javadoc.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>javadoc</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>

--- a/yarn/alpha/pom.xml
+++ b/yarn/alpha/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.spark</groupId>
-    <artifactId>yarn-parent_2.10</artifactId>
+    <artifactId>yarn-parent</artifactId>
     <version>1.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
@@ -28,7 +28,7 @@
   </properties>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-yarn-alpha_2.10</artifactId>
+  <artifactId>spark-yarn-alpha</artifactId>
   <packaging>jar</packaging>
   <name>Spark Project YARN Alpha API</name>
 

--- a/yarn/pom.xml
+++ b/yarn/pom.xml
@@ -25,7 +25,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>yarn-parent_2.10</artifactId>
+  <artifactId>yarn-parent</artifactId>
   <packaging>pom</packaging>
   <name>Spark Project YARN Parent POM</name>
   <properties>
@@ -35,7 +35,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <artifactId>spark-core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -88,6 +88,52 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+        <executions>
+          <execution>
+            <id>1</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <file>${project.build.directory}/${project.build.finalName}.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+            </configuration>
+          </execution>
+          <execution>
+            <id>2</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-sources.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>sources</classifier>
+            </configuration>
+          </execution>
+          <execution>
+            <id>3</id>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <generatePom>false</generatePom>
+              <pomFile>pom.xml</pomFile>
+              <file>${project.build.directory}/${project.build.finalName}-javadoc.jar</file>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+              <classifier>javadoc</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/yarn/stable/pom.xml
+++ b/yarn/stable/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.spark</groupId>
-    <artifactId>yarn-parent_2.10</artifactId>
+    <artifactId>yarn-parent</artifactId>
     <version>1.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
@@ -28,7 +28,7 @@
   </properties>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-yarn_2.10</artifactId>
+  <artifactId>spark-yarn</artifactId>
   <packaging>jar</packaging>
   <name>Spark Project YARN Stable API</name>
 


### PR DESCRIPTION
This patch get rid of _2.10 in the artifact ids and adapts the install plugin to include it instead.
This will make it easy to cross build for scala 2.10 and 2.11.

There was no way(I know) to avoid copying the same code everywhere. (Maven oddities... )
