### PR TITLE
[SPARK-3448][SQL] Check for null in SpecificMutableRow.update

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SpecificRow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SpecificRow.scala
@@ -227,7 +227,9 @@ final class SpecificMutableRow(val values: Array[MutableValue]) extends MutableR
     new SpecificMutableRow(newValues)
   }
 
-  override def update(ordinal: Int, value: Any): Unit = values(ordinal).update(value)
+  override def update(ordinal: Int, value: Any): Unit = {
+    if (value == null) setNullAt(ordinal) else values(ordinal).update(value)
+  }
 
   override def iterator: Iterator[Any] = values.map(_.boxed).iterator
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/RowSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/RowSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql
 
 import org.scalatest.FunSuite
 
-import org.apache.spark.sql.catalyst.expressions.GenericMutableRow
+import org.apache.spark.sql.catalyst.expressions.{GenericMutableRow, SpecificMutableRow}
 
 class RowSuite extends FunSuite {
 
@@ -42,5 +42,11 @@ class RowSuite extends FunSuite {
     assert(expected.getString(1) === actual2.getString(1))
     assert(expected.getBoolean(2) === actual2.getBoolean(2))
     assert(expected(3) === actual2(3))
+  }
+
+  test("SpecificMutableRow.update with null") {
+    val row = new SpecificMutableRow(Seq(IntegerType))
+    row(0) = null
+    assert(row.isNullAt(0))
   }
 }


### PR DESCRIPTION
`SpecificMutableRow.update` doesn't check for null, and breaks existing `MutableRow` contract.

The tricky part here is that for performance considerations, the `update` method of all subclasses of `MutableValue` doesn't check for null and sets the null bit to false.
