### PR TITLE
[SPARK-3398] [EC2] Have spark-ec2 intelligently wait for specific cluster states

### DIFF
--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -649,7 +649,9 @@ def wait_for_cluster_state(cluster_instances, cluster_state, opts):
            'running', 'terminated', etc.
            (would be nice to replace this with a proper enum: http://stackoverflow.com/a/1695250)
     """
-    sys.stdout.write("Waiting for all instances in cluster to enter '{s}' state.".format(s=cluster_state))
+    sys.stdout.write(
+        "Waiting for all instances in cluster to enter '{s}' state.".format(s=cluster_state)
+    )
     sys.stdout.flush()
     while True:
         for i in cluster_instances:

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -643,7 +643,7 @@ def wait_for_cluster_state(cluster_instances, cluster_state, opts):
         sys.stdout.flush()
         time.sleep(3)
 
-    print ""  # so that next line of output starts on new line
+    sys.stdout.write("\n")
 
 
 # Get number of local disks available for a given EC2 instance type.

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -910,8 +910,6 @@ def real_main():
             (master_nodes, slave_nodes) = get_existing_cluster(conn, opts, cluster_name)
         else:
             (master_nodes, slave_nodes) = launch_cluster(conn, opts, cluster_name)
-        # NOTE: This next line means if we have a terminally broken cluster,
-        #       (e.g during a --resume) we'll keep waiting until the user exits.
         wait_for_cluster_state(
             cluster_instances=(master_nodes + slave_nodes),
             cluster_state='ssh-ready',


### PR DESCRIPTION
Instead of waiting arbitrary amounts of time for the cluster to reach a specific state, this patch lets `spark-ec2` explicitly wait for a cluster to reach a desired state.

This is useful in a couple of situations:
- The cluster is launching and you want to wait until SSH is available before installing stuff.
- The cluster is being terminated and you want to wait until all the instances are terminated before trying to delete security groups.

This patch removes the need for the `--wait` option and removes some of the time-based retry logic that was being used.
