### PR TITLE
[SPARK-3469] Make sure all TaskCompletionListener are called even with failures

### DIFF
--- a/core/src/main/scala/org/apache/spark/TaskContext.scala
+++ b/core/src/main/scala/org/apache/spark/TaskContext.scala
@@ -77,8 +77,6 @@ class TaskContext(
   /**
    * Add a listener in the form of a Scala closure to be executed on task completion.
    * This will be called in all situation - success, failure, or cancellation.
-   * Exceptions in callbacks are however not thrown back upstream, i.e. tasks won't marked as
-   * failed even if completion callbacks fail to execute.
    *
    * An example use is for HadoopRDD to register a callback to close the input stream.
    */

--- a/core/src/main/scala/org/apache/spark/TaskContext.scala
+++ b/core/src/main/scala/org/apache/spark/TaskContext.scala
@@ -41,7 +41,7 @@ class TaskContext(
     val attemptId: Long,
     val runningLocally: Boolean = false,
     private[spark] val taskMetrics: TaskMetrics = TaskMetrics.empty)
-  extends Serializable {
+  extends Serializable with Logging {
 
   @deprecated("use partitionId", "0.8.1")
   def splitId = partitionId

--- a/core/src/main/scala/org/apache/spark/util/TaskCompletionListenerException.scala
+++ b/core/src/main/scala/org/apache/spark/util/TaskCompletionListenerException.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util
+
+/**
+ * Exception thrown when there is an exception in
+ * executing the callback in TaskCompletionListener.
+ */
+class TaskCompletionListenerException(errorMessages: Seq[String]) extends Exception {
+
+  override def getMessage: String = {
+    if (errorMessages.size == 1) {
+      errorMessages.head
+    } else {
+      errorMessages.zipWithIndex.map { case (msg, i) => s"Exception $i: $msg" }.mkString("\n")
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/util/TaskCompletionListenerException.scala
+++ b/core/src/main/scala/org/apache/spark/util/TaskCompletionListenerException.scala
@@ -21,6 +21,7 @@ package org.apache.spark.util
  * Exception thrown when there is an exception in
  * executing the callback in TaskCompletionListener.
  */
+private[spark]
 class TaskCompletionListenerException(errorMessages: Seq[String]) extends Exception {
 
   override def getMessage: String = {


### PR DESCRIPTION
This is necessary because we rely on this callback interface to clean resources up. The old behavior would lead to resource leaks.

Note that this also changes the fault semantics of TaskCompletionListener. Previously failures in TaskCompletionListeners would result in the task being reported immediately. With this change, we report the exception at the end, and the reported exception is a TaskCompletionListenerException that contains all the exception messages.
