### PR TITLE
[STREAMING] Add redis pub/sub streaming support

### DIFF
--- a/dev/audit-release/audit_release.py
+++ b/dev/audit-release/audit_release.py
@@ -105,7 +105,8 @@ modules = [
     "spark-core", "spark-bagel", "spark-mllib", "spark-streaming", "spark-repl",
     "spark-graphx", "spark-streaming-flume", "spark-streaming-kafka",
     "spark-streaming-mqtt", "spark-streaming-twitter", "spark-streaming-zeromq",
-    "spark-catalyst", "spark-sql", "spark-hive", "spark-streaming-kinesis-asl"
+    "spark-catalyst", "spark-sql", "spark-hive", "spark-streaming-kinesis-asl",
+    "spark-streaming-redis"
 ]
 modules = map(lambda m: "%s_%s" % (m, SCALA_BINARY_VERSION), modules)
 

--- a/docs/streaming-programming-guide.md
+++ b/docs/streaming-programming-guide.md
@@ -316,6 +316,7 @@ some of the common ones are as follows.
 <tr><td> Twitter </td><td> spark-streaming-twitter_{{site.SCALA_BINARY_VERSION}} </td></tr>
 <tr><td> ZeroMQ </td><td> spark-streaming-zeromq_{{site.SCALA_BINARY_VERSION}} </td></tr>
 <tr><td> MQTT </td><td> spark-streaming-mqtt_{{site.SCALA_BINARY_VERSION}} </td></tr>
+<tr><td> Redis </td><td> spark-streaming-redis_{{site.SCALA_BINARY_VERSION}} </td></tr>
 <tr><td></td><td></td></tr>
 </table>
 
@@ -1562,6 +1563,7 @@ package and renamed for better clarity.
     [TwitterUtils](api/scala/index.html#org.apache.spark.streaming.twitter.TwitterUtils$),
     [ZeroMQUtils](api/scala/index.html#org.apache.spark.streaming.zeromq.ZeroMQUtils$), and
     [MQTTUtils](api/scala/index.html#org.apache.spark.streaming.mqtt.MQTTUtils$)
+    [RedisUtils](api/scala/index.html#org.apache.spark.streaming.redis.RedisUtils$)
   - Java docs
     * [JavaStreamingContext](api/java/index.html?org/apache/spark/streaming/api/java/JavaStreamingContext.html),
     [JavaDStream](api/java/index.html?org/apache/spark/streaming/api/java/JavaDStream.html) and
@@ -1572,6 +1574,7 @@ package and renamed for better clarity.
     [TwitterUtils](api/java/index.html?org/apache/spark/streaming/twitter/TwitterUtils.html),
     [ZeroMQUtils](api/java/index.html?org/apache/spark/streaming/zeromq/ZeroMQUtils.html), and
     [MQTTUtils](api/java/index.html?org/apache/spark/streaming/mqtt/MQTTUtils.html)
+    [RedisUtils](api/java/index.html?org/apache/spark/streaming/redis/RedisUtils.html)
 
 * More examples in [Scala]({{site.SPARK_GITHUB_URL}}/tree/master/examples/src/main/scala/org/apache/spark/examples/streaming)
   and [Java]({{site.SPARK_GITHUB_URL}}/tree/master/examples/src/main/java/org/apache/spark/examples/streaming)

--- a/external/redis/pom.xml
+++ b/external/redis/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.spark</groupId>
+    <artifactId>spark-parent</artifactId>
+    <version>1.0.2</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <groupId>org.apache.spark</groupId>
+  <artifactId>spark-streaming-redis_2.10</artifactId>
+  <properties>
+    <sbt.project.name>streaming-redis</sbt.project.name>
+  </properties>
+  <packaging>jar</packaging>
+  <name>Spark Project External Redis</name>
+  <url>http://spark.apache.org/</url>
+
+  <repositories>
+    <repository>
+        <id>rediscala</id>
+        <url>https://raw.github.com/etaty/rediscala-mvn/master/releases/</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.etaty.rediscala</groupId>
+      <artifactId>rediscala_${scala.binary.version}</artifactId>
+       <version>1.3</version>
+    </dependency>
+    <dependency>
+      <groupId>${akka.group}</groupId>
+      <artifactId>akka-zeromq_${scala.binary.version}</artifactId>
+      <version>${akka.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.scalatest</groupId>
+      <artifactId>scalatest_${scala.binary.version}</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.scalacheck</groupId>
+      <artifactId>scalacheck_${scala.binary.version}</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.novocode</groupId>
+      <artifactId>junit-interface</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
+    <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
+    <plugins>
+      <plugin>
+        <groupId>org.scalatest</groupId>
+        <artifactId>scalatest-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/external/redis/src/main/scala/org/apache/spark/streaming/redis/RedisInputDStream.scala
+++ b/external/redis/src/main/scala/org/apache/spark/streaming/redis/RedisInputDStream.scala
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.streaming.redis
+
+import scala.collection.Map
+import scala.collection.mutable.HashMap
+import scala.collection.JavaConversions._
+import scala.reflect.ClassTag
+
+import java.util.Properties
+import java.util.concurrent.Executors
+import java.io.IOException
+import java.net.URI
+
+import redis.RedisPubSub
+import redis.api.pubsub._
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import org.apache.spark.Logging
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.streaming.StreamingContext
+import org.apache.spark.streaming.dstream._
+import org.apache.spark.streaming.receiver.Receiver
+
+/**
+ * Input stream that subscribe messages from a Redis server.
+ * Uses com.livestream as Redis client https://github.com/Livestream/scredis
+ * @param redisUrl Url of remote redis server (e.g. redis://host:port/db)
+ * @param channel channel name to subscribe to
+ * @param storageLevel RDD storage level.
+ */
+
+private[streaming]
+class RedisInputDStream(
+    @transient ssc_ : StreamingContext,
+    redisUrl: String,
+    channels: Seq[String],
+    patterns: Seq[String],
+    storageLevel: StorageLevel
+  ) extends ReceiverInputDStream[String](ssc_) with Logging {
+  
+  def getReceiver(): Receiver[String] = {
+    new RedisReceiver(redisUrl, channels, patterns, storageLevel)
+  }
+}
+
+private[streaming] 
+class RedisReceiver(
+    redisUrl: String,
+    channels: Seq[String],
+    patterns: Seq[String],
+    storageLevel: StorageLevel
+  ) extends Receiver[String](storageLevel) {
+
+  def onStop() {
+    // redis.quit()
+  }
+  
+  def onStart() {
+    implicit val akkaSystem = akka.actor.ActorSystem()
+
+    // This will fail if given a bad URL
+    val parsedUrl = new java.net.URI(redisUrl)
+
+    // Initializing Redis Client specifying redisUrl
+    val redisPubSub = RedisPubSub(
+      host = parsedUrl.getHost,
+      port = parsedUrl.getPort,
+      channels = channels,
+      patterns = patterns,
+      onMessage = (m: Message) => {
+        // info(s"got message: ${m.data}")
+        store(m.data)
+      }
+    )
+
+  }
+}

--- a/external/redis/src/main/scala/org/apache/spark/streaming/redis/RedisUtils.scala
+++ b/external/redis/src/main/scala/org/apache/spark/streaming/redis/RedisUtils.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.streaming.redis
+
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.streaming.StreamingContext
+import org.apache.spark.streaming.api.java.{JavaReceiverInputDStream, JavaStreamingContext, JavaDStream}
+import scala.reflect.ClassTag
+import org.apache.spark.streaming.dstream.{ReceiverInputDStream, DStream}
+
+object RedisUtils {
+  /**
+   * Create an input stream that receives messages from a Redis Pub/Sub channel.
+   * @param ssc           StreamingContext object
+   * @param redisUrl      Url of remote Redis server
+   * @param channel       Channel to subscribe to
+   * @param storageLevel  RDD storage level. Defaults to StorageLevel.MEMORY_AND_DISK_SER_2.
+   */
+  def createStream(
+      ssc: StreamingContext,
+      redisUrl: String,
+      channels: Seq[String],
+      patterns: Seq[String],
+      storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK_SER_2
+    ): ReceiverInputDStream[String] = {
+    new RedisInputDStream(ssc, redisUrl, channels, patterns, storageLevel)
+  }
+
+  /**
+   * Create an input stream that receives messages from a Redis Pub/Sub channel.
+   * Storage level of the data will be the default StorageLevel.MEMORY_AND_DISK_SER_2.
+   * @param jssc      JavaStreamingContext object
+   * @param redisUrl  Url of remote Redis server
+   * @param channel   Channel name to subscribe to
+   */
+  def createStream(
+      jssc: JavaStreamingContext,
+      redisUrl: String,
+      channels: Seq[String],
+      patterns: Seq[String]
+    ): JavaReceiverInputDStream[String] = {
+    implicitly[ClassTag[AnyRef]].asInstanceOf[ClassTag[String]]
+    createStream(jssc.ssc, redisUrl, channels, patterns)
+  }
+
+  /**
+   * Create an input stream that receives messages from a Redis Pub/Sub channel.
+   * @param jssc          JavaStreamingContext object
+   * @param redisUrl      Url of remote Redis server
+   * @param channel       Channel to subscribe to
+   * @param storageLevel  RDD storage level.
+   */
+  def createStream(
+      jssc: JavaStreamingContext,
+      redisUrl: String,
+      channels: Seq[String],
+      patterns: Seq[String],
+      storageLevel: StorageLevel
+    ): JavaReceiverInputDStream[String] = {
+    implicitly[ClassTag[AnyRef]].asInstanceOf[ClassTag[String]]
+    createStream(jssc.ssc, redisUrl, channels, patterns, storageLevel)
+  }
+}

--- a/external/redis/src/main/scala/org/apache/spark/streaming/redis/package-info.java
+++ b/external/redis/src/main/scala/org/apache/spark/streaming/redis/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Redis receiver for Spark Streaming.
+ */
+package org.apache.spark.streaming.redis;

--- a/external/redis/src/main/scala/org/apache/spark/streaming/redis/package.scala
+++ b/external/redis/src/main/scala/org/apache/spark/streaming/redis/package.scala
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.streaming
+
+/**
+ * Redis receiver for Spark Streaming.
+ */
+package object redis

--- a/external/redis/src/test/java/org/apache/spark/streaming/redis/JavaRedisStreamSuite.java
+++ b/external/redis/src/test/java/org/apache/spark/streaming/redis/JavaRedisStreamSuite.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.streaming.redis;
+
+import org.apache.spark.storage.StorageLevel;
+import org.apache.spark.streaming.api.java.JavaReceiverInputDStream;
+import org.junit.Test;
+
+import org.apache.spark.streaming.LocalJavaStreamingContext;
+
+import scala.collection.JavaConversions;
+import java.util.ArrayList;
+import java.util.List;
+
+
+public class JavaRedisStreamSuite extends LocalJavaStreamingContext {
+  @Test
+  public void testRedisStream() {
+    String redisUrl = "abc";
+    List<String> channels = new ArrayList<String>();
+    
+    channels.add("abc");
+
+    List<String> patterns = new ArrayList<String>();
+
+    // tests the API, does not actually test data receiving
+    JavaReceiverInputDStream<String> test1 = RedisUtils.createStream(ssc, redisUrl, JavaConversions.asScalaBuffer(channels), JavaConversions.asScalaBuffer(patterns));
+    JavaReceiverInputDStream<String> test2 = RedisUtils.createStream(ssc, redisUrl, JavaConversions.asScalaBuffer(channels), JavaConversions.asScalaBuffer(patterns),
+      StorageLevel.MEMORY_AND_DISK_SER_2());
+  }
+}

--- a/external/redis/src/test/resources/log4j.properties
+++ b/external/redis/src/test/resources/log4j.properties
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set everything to be logged to the file streaming/target/unit-tests.log
+log4j.rootCategory=INFO, file
+# log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.append=false
+log4j.appender.file.file=target/unit-tests.log
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS} %p %c{1}: %m%n
+
+# Ignore messages below warning level from Jetty, because it's a bit verbose
+log4j.logger.org.eclipse.jetty=WARN
+

--- a/external/redis/src/test/scala/org/apache/spark/streaming/redis/RedisStreamSuite.scala
+++ b/external/redis/src/test/scala/org/apache/spark/streaming/redis/RedisStreamSuite.scala
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.streaming.redis
+
+import scala.collection.mutable.{ArrayBuffer, SynchronizedBuffer}
+
+import org.apache.spark.streaming.{TestOutputStream, StreamingContext, TestSuiteBase}
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.streaming.dstream.ReceiverInputDStream
+
+import org.apache.spark.streaming.api.java.JavaReceiverInputDStream
+
+import redis.RedisClient
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class RedisStreamSuite extends TestSuiteBase {
+
+  // Note, this test case requires a redis-server to be running
+  // We will silently fail if no such server is running
+  test("redis input stream") {
+
+    implicit val akkaSystem = akka.actor.ActorSystem()
+
+    try {
+      val redisUrl = "redis://localhost:6379"
+      val channel = "def"
+      val channels = Seq(channel)
+      val patterns = Seq()
+
+      val input = Seq(1, 2, 3, 4, 5)
+
+      // We'll create a new redis topic and check for events in the stream
+      val redis = new RedisClient("localhost", 6379)
+
+      // We will fail silently if we're unable to connect to a running redis server
+      try {
+        Await.ready(redis.ping, 1 second)
+      } catch {
+        // If we cannot connect to redis, simply skip this test
+        case redis.actors.NoConnectionException => return
+      }
+
+      // Create streaming context
+      val ssc = new StreamingContext(master, framework, batchDuration)
+      val redisStream: JavaReceiverInputDStream[String] =
+        RedisUtils.createStream(ssc, redisUrl, channels, patterns, StorageLevel.MEMORY_AND_DISK)
+
+      val outputBuffer = new ArrayBuffer[Seq[String]]
+        with SynchronizedBuffer[Seq[String]]
+      val outputStream = new TestOutputStream(redisStream.receiverInputDStream, outputBuffer)
+
+      outputStream.register()
+
+      ssc.start()
+
+      // Wait to sync
+      Thread.sleep(1000)
+
+      // Publish test data
+      input.foreach(key => {
+        // publishes "key is $key" to the channel
+        redis.publish(channel, s"key is $key")
+      })
+
+      // Wait to sync
+      Thread.sleep(1000)
+
+      ssc.stop()
+
+      logInfo(s"Got $outputBuffer")
+      assert(outputBuffer.flatten.toList === input.map(k => s"key is $k"))
+    } finally {
+      // Ensure we shut down
+      akkaSystem.shutdown()  
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,7 @@
     <module>external/flume-sink</module>
     <module>external/zeromq</module>
     <module>external/mqtt</module>
+    <module>external/redis</module>
     <module>examples</module>
   </modules>
 
@@ -187,6 +188,10 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
+    </repository>
+    <repository>
+        <id>rediscala</id>
+        <url>https://raw.github.com/etaty/rediscala-mvn/master/releases/</url>
     </repository>
     <repository>
       <id>cloudera-repo</id>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -32,10 +32,10 @@ object BuildCommons {
 
   val allProjects@Seq(bagel, catalyst, core, graphx, hive, hiveThriftServer, mllib, repl,
   sql, streaming, streamingFlumeSink, streamingFlume, streamingKafka, streamingMqtt,
-  streamingTwitter, streamingZeromq) =
+  streamingTwitter, streamingZeromq, streamingRedis) =
     Seq("bagel", "catalyst", "core", "graphx", "hive", "hive-thriftserver", "mllib", "repl",
       "sql", "streaming", "streaming-flume-sink", "streaming-flume", "streaming-kafka",
-      "streaming-mqtt", "streaming-twitter", "streaming-zeromq").map(ProjectRef(buildLocation, _))
+      "streaming-mqtt", "streaming-twitter", "streaming-zeromq", "streaming-redis").map(ProjectRef(buildLocation, _))
 
   val optionallyEnabledProjects@Seq(yarn, yarnStable, yarnAlpha, java8Tests, sparkGangliaLgpl, sparkKinesisAsl) =
     Seq("yarn", "yarn-stable", "yarn-alpha", "java8-tests", "ganglia-lgpl", "kinesis-asl")
@@ -194,8 +194,8 @@ object OldDeps {
     retrievePattern := "[type]s/[artifact](-[revision])(-[classifier]).[ext]",
     libraryDependencies := Seq("spark-streaming-mqtt", "spark-streaming-zeromq",
       "spark-streaming-flume", "spark-streaming-kafka", "spark-streaming-twitter",
-      "spark-streaming", "spark-mllib", "spark-bagel", "spark-graphx",
-      "spark-core").map(versionArtifact(_).get intransitive())
+      "spark-streaming-redis", "spark-streaming", "spark-mllib", "spark-bagel",
+      "spark-graphx", "spark-core").map(versionArtifact(_).get intransitive())
   )
 }
 
@@ -314,7 +314,8 @@ object Unidoc {
       "-group", "Core Java API", packageList("api.java", "api.java.function"),
       "-group", "Spark Streaming", packageList(
         "streaming.api.java", "streaming.flume", "streaming.kafka",
-        "streaming.mqtt", "streaming.twitter", "streaming.zeromq", "streaming.kinesis"
+        "streaming.mqtt", "streaming.twitter", "streaming.zeromq", "streaming.kinesis",
+        "streaming.redis"
       ),
       "-group", "MLlib", packageList(
         "mllib.classification", "mllib.clustering", "mllib.evaluation.binary", "mllib.linalg",


### PR DESCRIPTION
This patch adds native streaming support for [redis](http://redis.io) through the [Pub/Sub](http://redis.io/topics/pubsub) system.  When creating the streaming interface, the user specifies `channels` and `patterns` to watch.  The streaming RDD then receives all messages which match those channels and patterns in the redis database.

I have attempted to match the process used by the other external streaming plugins.  I have added test cases to verify correctness of this plugin.  I would appreciate any feedback required to have this merged into master.

Note, this patch uses the [rediscala](https://github.com/etaty/rediscala) library to communicate with redis, and thus uses the "akka 2.2" branch to match spark's Akka version and reduce conflict.

Additionally, I own all source code included in this patch and release all of the source code under the license of Apache Spark (Apache 2.0).
