### PR TITLE
[SPARK-3485][SQL] should check parameter type when look for constructors

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUdfs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUdfs.scala
@@ -128,7 +128,7 @@ private[hive] case class HiveSimpleUdf(functionClassName: String, children: Seq[
             c.getParameterTypes.head.getCanonicalName.equals(a.getClass.getCanonicalName)
           }.getOrElse(matchingConstructors.head)
           logDebug(
-            s"Wrapping $a of type ${if (a == null) "null" else a.getClass.getCanonicalName} $constructor.")
+            s"Wrapping $a of type ${a.getClass.getCanonicalName} $constructor.")
           // We must make sure that primitives get boxed java style.
           constructor.newInstance(a match {
             case i: Int => i: java.lang.Integer

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUdfs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUdfs.scala
@@ -118,19 +118,17 @@ private[hive] case class HiveSimpleUdf(functionClassName: String, children: Seq[
     }
 
     if (matchingConstructors.length == 0) {
-      (a: Any) => a match {
-        case wrapper => wrap(wrapper)
-      }
+      (a: Any) => wrap(a)
     } else {
       (a: Any) => {
         if (a == null) {
           null
         } else {
           val constructor = matchingConstructors.find { c =>
-            c.getParameterTypes.head.getName.equals(a.getClass.getName)
+            c.getParameterTypes.head.getCanonicalName.equals(a.getClass.getCanonicalName)
           }.getOrElse(matchingConstructors.head)
           logDebug(
-            s"Wrapping $a of type ${if (a == null) "null" else a.getClass.getName} $constructor.")
+            s"Wrapping $a of type ${if (a == null) "null" else a.getClass.getCanonicalName} $constructor.")
           // We must make sure that primitives get boxed java style.
           constructor.newInstance(a match {
             case i: Int => i: java.lang.Integer

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUdfs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUdfs.scala
@@ -123,15 +123,15 @@ private[hive] case class HiveSimpleUdf(functionClassName: String, children: Seq[
       }
     } else {
       (a: Any) => {
-        val constructor = matchingConstructors.find { c =>
-          c.getParameterTypes.head.getName.equals(a.getClass.getName)
-        }.getOrElse(matchingConstructors.head)
-        logDebug(
-          s"Wrapping $a of type ${if (a == null) "null" else a.getClass.getName} $constructor.")
-        // We must make sure that primitives get boxed java style.
         if (a == null) {
           null
         } else {
+          val constructor = matchingConstructors.find { c =>
+            c.getParameterTypes.head.getName.equals(a.getClass.getName)
+          }.getOrElse(matchingConstructors.head)
+          logDebug(
+            s"Wrapping $a of type ${if (a == null) "null" else a.getClass.getName} $constructor.")
+          // We must make sure that primitives get boxed java style.
           constructor.newInstance(a match {
             case i: Int => i: java.lang.Integer
             case bd: BigDecimal => new HiveDecimal(bd.underlying())

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUdfs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUdfs.scala
@@ -114,7 +114,8 @@ private[hive] case class HiveSimpleUdf(functionClassName: String, children: Seq[
       classOf[java.sql.Timestamp]
     )
     val matchingConstructor = argClass.getConstructors.find { c =>
-      c.getParameterTypes.size == 1 && primitiveClasses.contains(c.getParameterTypes.head)
+      c.getParameterTypes.size == 1 && primitiveClasses.contains(c.getParameterTypes.head) &&
+        c.getParameterTypes.head.getClass.getName.equals(argClass.getClass.getName)
     }
 
     matchingConstructor match {


### PR DESCRIPTION
In hiveUdfs, we get constructors of primitivetypes by find a constructor which takes only one parameter. This is very dangerous when more than one constructors match. When the sequence of primitiveTypes becomes larger, the problem would occur, causing a exception as 

java.lang.IllegalArgumentException: argument type mismatch
