### PR TITLE
[SPARK-3437][BUILD] Support crossbuilding in maven. With new scala-install-plugin.

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-assembly_2.10</artifactId>
+  <artifactId>spark-assembly</artifactId>
   <name>Spark Project Assembly</name>
   <url>http://spark.apache.org/</url>
   <packaging>pom</packaging>

--- a/bagel/pom.xml
+++ b/bagel/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-bagel_2.10</artifactId>
+  <artifactId>spark-bagel</artifactId>
   <properties>
     <sbt.project.name>bagel</sbt.project.name>
   </properties>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-core_2.10</artifactId>
+  <artifactId>spark-core</artifactId>
   <properties>
     <sbt.project.name>core</sbt.project.name>
   </properties>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-examples_2.10</artifactId>
+  <artifactId>spark-examples</artifactId>
   <properties>
     <sbt.project.name>examples</sbt.project.name>
   </properties>

--- a/external/flume-sink/pom.xml
+++ b/external/flume-sink/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-streaming-flume-sink_2.10</artifactId>
+  <artifactId>spark-streaming-flume-sink</artifactId>
   <properties>
     <sbt.project.name>streaming-flume-sink</sbt.project.name>
   </properties>

--- a/external/flume/pom.xml
+++ b/external/flume/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-streaming-flume_2.10</artifactId>
+  <artifactId>spark-streaming-flume</artifactId>
   <properties>
     <sbt.project.name>streaming-flume</sbt.project.name>
   </properties>

--- a/external/kafka/pom.xml
+++ b/external/kafka/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-streaming-kafka_2.10</artifactId>
+  <artifactId>spark-streaming-kafka</artifactId>
   <properties>
     <sbt.project.name>streaming-kafka</sbt.project.name>
   </properties>

--- a/external/mqtt/pom.xml
+++ b/external/mqtt/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-streaming-mqtt_2.10</artifactId>
+  <artifactId>spark-streaming-mqtt</artifactId>
   <properties>
     <sbt.project.name>streaming-mqtt</sbt.project.name>
   </properties>

--- a/external/twitter/pom.xml
+++ b/external/twitter/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-streaming-twitter_2.10</artifactId>
+  <artifactId>spark-streaming-twitter</artifactId>
   <properties>
     <sbt.project.name>streaming-twitter</sbt.project.name>
   </properties>

--- a/external/zeromq/pom.xml
+++ b/external/zeromq/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-streaming-zeromq_2.10</artifactId>
+  <artifactId>spark-streaming-zeromq</artifactId>
   <properties>
     <sbt.project.name>streaming-zeromq</sbt.project.name>
   </properties>

--- a/extras/java8-tests/pom.xml
+++ b/extras/java8-tests/pom.xml
@@ -25,7 +25,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>java8-tests_2.10</artifactId>
+  <artifactId>java8-tests</artifactId>
   <packaging>pom</packaging>
   <name>Spark Project Java8 Tests POM</name>
 

--- a/extras/kinesis-asl/pom.xml
+++ b/extras/kinesis-asl/pom.xml
@@ -26,7 +26,7 @@
 
   <!-- Kinesis integration is not included by default due to ASL-licensed code. -->
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-streaming-kinesis-asl_2.10</artifactId>
+  <artifactId>spark-streaming-kinesis-asl</artifactId>
   <packaging>jar</packaging>
   <name>Spark Kinesis Integration</name>
 

--- a/extras/spark-ganglia-lgpl/pom.xml
+++ b/extras/spark-ganglia-lgpl/pom.xml
@@ -26,7 +26,7 @@
 
   <!-- Ganglia integration is not included by default due to LGPL-licensed code -->
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-ganglia-lgpl_2.10</artifactId>
+  <artifactId>spark-ganglia-lgpl</artifactId>
   <packaging>jar</packaging>
   <name>Spark Ganglia Integration</name>
 

--- a/graphx/pom.xml
+++ b/graphx/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-graphx_2.10</artifactId>
+  <artifactId>spark-graphx</artifactId>
   <properties>
     <sbt.project.name>graphx</sbt.project.name>
   </properties>

--- a/mllib/pom.xml
+++ b/mllib/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-mllib_2.10</artifactId>
+  <artifactId>spark-mllib</artifactId>
   <properties>
     <sbt.project.name>mllib</sbt.project.name>
   </properties>  

--- a/pom.xml
+++ b/pom.xml
@@ -89,9 +89,9 @@
     <module>core</module>
     <module>bagel</module>
     <module>graphx</module>
+    <module>streaming</module>
     <module>mllib</module>
     <module>tools</module>
-    <module>streaming</module>
     <module>sql/catalyst</module>
     <module>sql/core</module>
     <module>sql/hive</module>
@@ -99,8 +99,8 @@
     <module>assembly</module>
     <module>external/twitter</module>
     <module>external/kafka</module>
-    <module>external/flume</module>
     <module>external/flume-sink</module>
+    <module>external/flume</module>
     <module>external/zeromq</module>
     <module>external/mqtt</module>
     <module>examples</module>
@@ -774,9 +774,20 @@
   </dependencyManagement>
 
   <build>
+    <finalName>
+      ${project.artifactId}_${scala.binary.version}-${project.version}
+    </finalName>
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.5.2</version>
+          <configuration>
+            <skip>true</skip>
+          </configuration>
+        </plugin>
+        <plugin>          
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
           <version>1.3.1</version>
@@ -961,6 +972,30 @@
     </pluginManagement>
 
     <plugins>
+      <plugin>
+        <groupId>org.apache.spark</groupId>
+        <artifactId>scala-install-plugin</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <executions>
+          <execution>
+            <id>install</id>
+            <goals>
+              <goal>install</goal>
+            </goals>
+            <phase>install</phase>
+            <configuration>
+              <artifactId>${project.artifactId}_${scala.binary.version}</artifactId>
+            </configuration>
+          </execution>
+          <execution>
+            <id>load</id>
+            <goals>
+              <goal>init-scala</goal>
+            </goals>
+            <phase>initialize</phase>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>

--- a/project/project/SparkPluginBuild.scala
+++ b/project/project/SparkPluginBuild.scala
@@ -26,7 +26,7 @@ import sbt.Keys._
 object SparkPluginDef extends Build {
   lazy val root = Project("plugins", file(".")) dependsOn(sparkStyle, sbtPomReader)
   lazy val sparkStyle = Project("spark-style", file("spark-style"), settings = styleSettings)
-  lazy val sbtPomReader = uri("https://github.com/ScrapCodes/sbt-pom-reader.git")
+  lazy val sbtPomReader = uri("https://github.com/ScrapCodes/sbt-pom-reader.git#wip-cross-build")
 
   // There is actually no need to publish this artifact.
   def styleSettings = Defaults.defaultSettings ++ Seq (

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-repl_2.10</artifactId>
+  <artifactId>spark-repl</artifactId>
   <packaging>jar</packaging>
   <name>Spark Project REPL</name>
   <url>http://spark.apache.org/</url>

--- a/sql/catalyst/pom.xml
+++ b/sql/catalyst/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-catalyst_2.10</artifactId>
+  <artifactId>spark-catalyst</artifactId>
   <packaging>jar</packaging>
   <name>Spark Project Catalyst</name>
   <url>http://spark.apache.org/</url>

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-sql_2.10</artifactId>
+  <artifactId>spark-sql</artifactId>
   <packaging>jar</packaging>
   <name>Spark Project SQL</name>
   <url>http://spark.apache.org/</url>

--- a/sql/hive-thriftserver/pom.xml
+++ b/sql/hive-thriftserver/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-hive-thriftserver_2.10</artifactId>
+  <artifactId>spark-hive-thriftserver</artifactId>
   <packaging>jar</packaging>
   <name>Spark Project Hive Thrift Server</name>
   <url>http://spark.apache.org/</url>

--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-hive_2.10</artifactId>
+  <artifactId>spark-hive</artifactId>
   <packaging>jar</packaging>
   <name>Spark Project Hive</name>
   <url>http://spark.apache.org/</url>

--- a/streaming/pom.xml
+++ b/streaming/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-streaming_2.10</artifactId>
+  <artifactId>spark-streaming</artifactId>
   <properties>
     <sbt.project.name>streaming</sbt.project.name>
   </properties>
@@ -77,7 +77,7 @@
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>
       </plugin>
-      
+
       <!-- 
            This plugin forces the generation of jar containing streaming test classes, 
            so that the tests classes of external modules can use them. The two execution profiles

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -25,7 +25,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-tools_2.10</artifactId>
+  <artifactId>spark-tools</artifactId>
   <properties>
     <sbt.project.name>tools</sbt.project.name>
   </properties>

--- a/yarn/alpha/pom.xml
+++ b/yarn/alpha/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.spark</groupId>
-    <artifactId>yarn-parent_2.10</artifactId>
+    <artifactId>yarn-parent</artifactId>
     <version>1.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
@@ -28,7 +28,7 @@
   </properties>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-yarn-alpha_2.10</artifactId>
+  <artifactId>spark-yarn-alpha</artifactId>
   <packaging>jar</packaging>
   <name>Spark Project YARN Alpha API</name>
 

--- a/yarn/pom.xml
+++ b/yarn/pom.xml
@@ -25,7 +25,7 @@
   </parent>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>yarn-parent_2.10</artifactId>
+  <artifactId>yarn-parent</artifactId>
   <packaging>pom</packaging>
   <name>Spark Project YARN Parent POM</name>
   <properties>

--- a/yarn/stable/pom.xml
+++ b/yarn/stable/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.spark</groupId>
-    <artifactId>yarn-parent_2.10</artifactId>
+    <artifactId>yarn-parent</artifactId>
     <version>1.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
@@ -28,7 +28,7 @@
   </properties>
 
   <groupId>org.apache.spark</groupId>
-  <artifactId>spark-yarn_2.10</artifactId>
+  <artifactId>spark-yarn</artifactId>
   <packaging>jar</packaging>
   <name>Spark Project YARN Stable API</name>
 


### PR DESCRIPTION
Since this plugin is not deployed anywhere, for anyone trying this patch has to publish it locally by cloning the following repo https://github.com/ScrapCodes/scala-install-plugin.  And then running `mvn install`. 
