### PR TITLE
make spark-class to work with openjdk

### DIFF
--- a/bin/spark-class
+++ b/bin/spark-class
@@ -105,7 +105,7 @@ else
     exit 1
   fi
 fi
-JAVA_VERSION=$("$RUNNER" -version 2>&1 | sed 's/java version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q')
+JAVA_VERSION=$("$RUNNER" -version 2>&1 | sed 's/openjdk/java/' | sed 's/java version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q')
 
 # Set JAVA_OPTS to be able to load native libraries and to set heap size
 if [ "$JAVA_VERSION" -ge 18 ]; then


### PR DESCRIPTION
fix for  SPARK-3520 - java version check in spark-class fails with openjdk
