### PR TITLE
[SPARK-2594][SQL] Support CACHE TABLE <name> AS SELECT ...

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
@@ -183,10 +183,10 @@ class SqlParser extends StandardTokenParsers with PackratParsers {
     }
 
   protected lazy val cache: Parser[LogicalPlan] =
-    CACHE ~ TABLE ~> ident ~ opt(AS ~ select) <~ opt(";") ^^ {
+    CACHE ~ TABLE ~> ident ~ opt(AS ~> select) <~ opt(";") ^^ {
       case tableName ~ None => 
         CacheCommand(tableName, true)
-      case tableName ~ Some(as ~ plan) =>
+      case tableName ~ Some(plan) =>
         CacheTableAsSelectCommand(tableName, plan)
     }
     

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
@@ -182,18 +182,12 @@ class SqlParser extends StandardTokenParsers with PackratParsers {
         val overwrite: Boolean = o.getOrElse("") == "OVERWRITE"
         InsertIntoTable(r, Map[String, Option[String]](), s, overwrite)
     }
-    
-  protected lazy val addCache: Parser[LogicalPlan] =
-    ADD ~ CACHE ~ TABLE ~> ident ~ AS ~ select <~ opt(";") ^^ {
-     case tableName ~ as ~ s =>
-       CacheTableAsSelectCommand(tableName,s)
-    }        
 
   protected lazy val cache: Parser[LogicalPlan] =
-    CACHE ~ TABLE ~> ident ~ opt(AS) ~ opt(select) <~ opt(";") ^^ {
-      case tableName ~ None ~ None => 
+    CACHE ~ TABLE ~> ident ~ opt(AS ~ select) <~ opt(";") ^^ {
+      case tableName ~ None => 
         CacheCommand(tableName, true)
-      case tableName ~ as ~ Some(plan) => 
+      case tableName ~ Some(as ~ plan) =>
         CacheTableAsSelectCommand(tableName,plan)
     }
     

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
@@ -188,7 +188,7 @@ class SqlParser extends StandardTokenParsers with PackratParsers {
       case tableName ~ None => 
         CacheCommand(tableName, true)
       case tableName ~ Some(as ~ plan) =>
-        CacheTableAsSelectCommand(tableName,plan)
+        CacheTableAsSelectCommand(tableName, plan)
     }
     
   protected lazy val unCache: Parser[LogicalPlan] =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
@@ -152,7 +152,7 @@ class SqlParser extends StandardTokenParsers with PackratParsers {
         EXCEPT ^^^ { (q1: LogicalPlan, q2: LogicalPlan) => Except(q1, q2)} |
         UNION ~ opt(DISTINCT) ^^^ { (q1: LogicalPlan, q2: LogicalPlan) => Distinct(Union(q1, q2)) }
       )
-    | insert | cache | addCache
+    | insert | cache | unCache
   )
 
   protected lazy val select: Parser[LogicalPlan] =
@@ -182,17 +182,19 @@ class SqlParser extends StandardTokenParsers with PackratParsers {
         val overwrite: Boolean = o.getOrElse("") == "OVERWRITE"
         InsertIntoTable(r, Map[String, Option[String]](), s, overwrite)
     }
-    
-  protected lazy val addCache: Parser[LogicalPlan] =
-    ADD ~ CACHE ~ TABLE ~> ident ~ AS ~ select <~ opt(";") ^^ {
-     case tableName ~ as ~ s =>
-       CacheTableAsSelectCommand(tableName,s)
-    }        
 
   protected lazy val cache: Parser[LogicalPlan] =
-    (CACHE ^^^ true | UNCACHE ^^^ false) ~ TABLE ~ ident ^^ {
-      case doCache ~ _ ~ tableName => CacheCommand(tableName, doCache)
+    CACHE ~ TABLE ~> ident ~ opt(AS) ~ opt(select) <~ opt(";") ^^ {
+      case tableName ~ None ~ None => 
+        CacheCommand(tableName, true)
+      case tableName ~ as ~ Some(plan) => 
+        CacheTableAsSelectCommand(tableName,plan)
     }
+    
+  protected lazy val unCache: Parser[LogicalPlan] =
+    UNCACHE ~ TABLE ~> ident <~ opt(";") ^^ {
+      case tableName => CacheCommand(tableName, false)
+    }    
 
   protected lazy val projections: Parser[Seq[Expression]] = repsep(projection, ",")
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
@@ -127,7 +127,6 @@ class SqlParser extends StandardTokenParsers with PackratParsers {
   protected val SUBSTRING = Keyword("SUBSTRING")
   protected val SQRT = Keyword("SQRT")
   protected val ABS = Keyword("ABS")
-  protected val ADD = Keyword("ADD")
 
   // Use reflection to find the reserved words defined in this class.
   protected val reservedWords =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/commands.scala
@@ -75,3 +75,8 @@ case class DescribeCommand(
     AttributeReference("data_type", StringType, nullable = false)(),
     AttributeReference("comment", StringType, nullable = false)())
 }
+
+/**
+ * Returned for the "ADD CACHE TABLE tableName AS SELECT .." command.
+ */
+case class CacheTableAsSelectCommand(tableName: String, plan: LogicalPlan) extends Command

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/commands.scala
@@ -77,6 +77,6 @@ case class DescribeCommand(
 }
 
 /**
- * Returned for the "ADD CACHE TABLE tableName AS SELECT .." command.
+ * Returned for the "CACHE TABLE tableName AS SELECT .." command.
  */
 case class CacheTableAsSelectCommand(tableName: String, plan: LogicalPlan) extends Command

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -306,7 +306,7 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
       case logical.CacheCommand(tableName, cache) =>
         Seq(execution.CacheCommand(tableName, cache)(context))
       case logical.CacheTableAsSelectCommand(tableName,plan) =>
-        Seq(execution.CacheTableAsSelectCommand(tableName, plan)(context))
+        Seq(execution.CacheTableAsSelectCommand(tableName, plan))
       case _ => Nil
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -305,6 +305,8 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         Seq(execution.ExplainCommand(logicalPlan, plan.output, extended)(context))
       case logical.CacheCommand(tableName, cache) =>
         Seq(execution.CacheCommand(tableName, cache)(context))
+      case logical.CacheTableAsSelectCommand(tableName,plan) =>
+        Seq(execution.CacheTableAsSelectCommand(tableName, plan)(context))
       case _ => Nil
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -305,7 +305,7 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         Seq(execution.ExplainCommand(logicalPlan, plan.output, extended)(context))
       case logical.CacheCommand(tableName, cache) =>
         Seq(execution.CacheCommand(tableName, cache)(context))
-      case logical.CacheTableAsSelectCommand(tableName,plan) =>
+      case logical.CacheTableAsSelectCommand(tableName, plan) =>
         Seq(execution.CacheTableAsSelectCommand(tableName, plan))
       case _ => Nil
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
@@ -171,16 +171,14 @@ case class DescribeCommand(child: SparkPlan, output: Seq[Attribute])(
  * :: DeveloperApi ::
  */
 @DeveloperApi
-case class CacheTableAsSelectCommand(tableName: String,plan: LogicalPlan)(
-    @transient context: SQLContext)
+case class CacheTableAsSelectCommand(tableName: String, plan: LogicalPlan)
   extends LeafNode with Command {
   
   override protected[sql] lazy val sideEffectResult = {
-    context.catalog.registerTable(None, tableName,  sqlContext.executePlan(plan).analyzed)
-    context.cacheTable(tableName)
-    //It does the caching eager.
-    //TODO : Does it really require to collect?
-    context.table(tableName).collect
+    sqlContext.catalog.registerTable(None, tableName,  sqlContext.executePlan(plan).analyzed)
+    sqlContext.cacheTable(tableName)
+    // It does the caching eager.
+    sqlContext.table(tableName).count
     Seq.empty[Row]
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
@@ -171,12 +171,13 @@ case class DescribeCommand(child: SparkPlan, output: Seq[Attribute])(
  * :: DeveloperApi ::
  */
 @DeveloperApi
-case class CacheTableAsSelectCommand(tableName: String, plan: LogicalPlan)
+case class CacheTableAsSelectCommand(tableName: String, logicalPlan: LogicalPlan)
   extends LeafNode with Command {
   
   override protected[sql] lazy val sideEffectResult = {
-    sqlContext.catalog.registerTable(None, tableName,  sqlContext.executePlan(plan).analyzed)
-    sqlContext.cacheTable(tableName)
+    import sqlContext._
+    logicalPlan.registerTempTable(tableName)
+    cacheTable(tableName) 
     Seq.empty[Row]
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
@@ -177,8 +177,6 @@ case class CacheTableAsSelectCommand(tableName: String, plan: LogicalPlan)
   override protected[sql] lazy val sideEffectResult = {
     sqlContext.catalog.registerTable(None, tableName,  sqlContext.executePlan(plan).analyzed)
     sqlContext.cacheTable(tableName)
-    // It does the caching eager.
-    sqlContext.table(tableName).count
     Seq.empty[Row]
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -120,18 +120,14 @@ class CachedTableSuite extends QueryTest {
     assert(!TestSQLContext.isCached("testData"), "Table 'testData' should not be cached")
   }
   
-  test("ADD CACHE TABLE tableName AS SELECT Star Table") {
-    TestSQLContext.sql("ADD CACHE TABLE testCacheTable AS SELECT * FROM testData")
+  test("CACHE TABLE tableName AS SELECT Star Table") {
+    TestSQLContext.sql("CACHE TABLE testCacheTable AS SELECT * FROM testData")
     TestSQLContext.sql("SELECT * FROM testCacheTable WHERE key = 1").collect()
     TestSQLContext.uncacheTable("testCacheTable")
   }
   
-  test("'ADD CACHE TABLE tableName AS SELECT ..'") {
-    TestSQLContext.sql("ADD CACHE TABLE testCacheTable AS SELECT * FROM testData")
-    TestSQLContext.table("testCacheTable").queryExecution.executedPlan match {
-      case _: InMemoryColumnarTableScan => // Found evidence of caching
-      case _ => fail(s"Table 'testCacheTable' should be cached")
-    }
+  test("'CACHE TABLE tableName AS SELECT ..'") {
+    TestSQLContext.sql("CACHE TABLE testCacheTable AS SELECT * FROM testData")
     assert(TestSQLContext.isCached("testCacheTable"), "Table 'testCacheTable' should be cached")
     TestSQLContext.uncacheTable("testCacheTable")
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -119,4 +119,20 @@ class CachedTableSuite extends QueryTest {
     }
     assert(!TestSQLContext.isCached("testData"), "Table 'testData' should not be cached")
   }
+  
+  test("ADD CACHE TABLE tableName AS SELECT Star Table") {
+    TestSQLContext.sql("ADD CACHE TABLE testCacheTable AS SELECT * FROM testData")
+    TestSQLContext.sql("SELECT * FROM testCacheTable WHERE key = 1").collect()
+    TestSQLContext.uncacheTable("testCacheTable")
+  }
+  
+  test("'ADD CACHE TABLE tableName AS SELECT ..'") {
+    TestSQLContext.sql("ADD CACHE TABLE testCacheTable AS SELECT * FROM testData")
+    TestSQLContext.table("testCacheTable").queryExecution.executedPlan match {
+      case _: InMemoryColumnarTableScan => // Found evidence of caching
+      case _ => fail(s"Table 'testCacheTable' should be cached")
+    }
+    assert(TestSQLContext.isCached("testCacheTable"), "Table 'testCacheTable' should be cached")
+    TestSQLContext.uncacheTable("testCacheTable")
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -123,6 +123,7 @@ class CachedTableSuite extends QueryTest {
   test("CACHE TABLE tableName AS SELECT Star Table") {
     TestSQLContext.sql("CACHE TABLE testCacheTable AS SELECT * FROM testData")
     TestSQLContext.sql("SELECT * FROM testCacheTable WHERE key = 1").collect()
+    assert(TestSQLContext.isCached("testCacheTable"), "Table 'testCacheTable' should be cached")
     TestSQLContext.uncacheTable("testCacheTable")
   }
   

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
@@ -232,9 +232,8 @@ private[hive] object HiveQl {
         sql.trim.drop(12).trim.split(" ").toSeq match {
           case Seq(tableName) => 
             CacheCommand(tableName, true)
-          case Seq(tableName,as, select@_*) => 
-            CacheTableAsSelectCommand(tableName,
-                createPlan(sql.trim.drop(12 + tableName.length() + as.length() + 2)))
+          case Seq(tableName, _, select @ _*) => 
+            CacheTableAsSelectCommand(tableName, createPlan(select.mkString(" ").trim))
         }
       } else if (sql.trim.toLowerCase.startsWith("uncache table")) {
         CacheCommand(sql.trim.drop(14).trim, false)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
@@ -216,7 +216,7 @@ private[hive] object HiveQl {
 
  
   /** Returns a LogicalPlan for a given HiveQL string. */
-  def parseSql(sql : String): LogicalPlan = {
+  def parseSql(sql: String): LogicalPlan = {
     try {
       if (sql.trim.toLowerCase.startsWith("set")) {
         // Split in two parts since we treat the part before the first "="

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
@@ -213,7 +213,7 @@ private[hive] object HiveQl {
    * Returns the AST for the given SQL string.
    */
   def getAst(sql: String): ASTNode = ParseUtils.findRootNonNullToken((new ParseDriver).parse(sql))
- 
+
   /** Returns a LogicalPlan for a given HiveQL string. */
   def parseSql(sql: String): LogicalPlan = {
     try {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
@@ -213,7 +213,6 @@ private[hive] object HiveQl {
    * Returns the AST for the given SQL string.
    */
   def getAst(sql: String): ASTNode = ParseUtils.findRootNonNullToken((new ParseDriver).parse(sql))
-
  
   /** Returns a LogicalPlan for a given HiveQL string. */
   def parseSql(sql: String): LogicalPlan = {
@@ -240,7 +239,7 @@ private[hive] object HiveQl {
       } else if (sql.trim.toLowerCase.startsWith("uncache table")) {
         CacheCommand(sql.trim.drop(14).trim, false)
       } else if (sql.trim.toLowerCase.startsWith("add jar")) {
-        NativeCommand(sql)
+        AddJar(sql.trim.drop(8).trim)
       } else if (sql.trim.toLowerCase.startsWith("add file")) {
         AddFile(sql.trim.drop(9))
       } else if (sql.trim.toLowerCase.startsWith("dfs")) {
@@ -1109,7 +1108,7 @@ private[hive] object HiveQl {
 
       case Token("TOK_FUNCTION", Token(functionName, Nil) :: children) =>
         HiveGenericUdtf(functionName, attributes, children.map(nodeToExpr))
-        
+
       case a: ASTNode =>
         throw new NotImplementedError(
           s"""No parse rules for ASTNode type: ${a.getType}, text: ${a.getText}, tree:

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
@@ -216,7 +216,7 @@ private[hive] object HiveQl {
 
  
   /** Returns a LogicalPlan for a given HiveQL string. */
-  def parseSql(sql : String) = {
+  def parseSql(sql : String): LogicalPlan = {
     try {
       if (sql.trim.toLowerCase.startsWith("set")) {
         // Split in two parts since we treat the part before the first "="

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
@@ -262,6 +262,7 @@ private[hive] object HiveQl {
     }
   }
 
+  /** Creates LogicalPlan for a given HiveQL string. */
   def createPlan(sql: String) ={
     val tree = getAst(sql)
     if (nativeCommands contains tree.getText) {


### PR DESCRIPTION
This feature allows user to add cache table from the select query.
Example : `CACHE TABLE testCacheTable AS SELECT * FROM TEST_TABLE`
Spark takes this type of SQL as command and it does lazy caching just like `SQLContext.cacheTable`, `CACHE TABLE <name>` does.
It can be executed from both SQLContext and HiveContext.

Recreated the pull request after rebasing with master.And fixed all the comments raised in previous pull requests.
https://github.com/apache/spark/pull/2381
https://github.com/apache/spark/pull/2390

Author : ravipesala ravindra.pesala@huawei.com
