### PR TITLE
add spark.driver.memory to config docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -107,7 +107,7 @@ of the most common options to set are:
   <td><code>spark.driver.memory</code></td>
   <td>512m</td>
   <td>
-    Amount of memory to use for the driver process, i.e. where spark context is initialized.
+    Amount of memory to use for the driver process, i.e. where SparkContext is initialized.
     (e.g. <code>512m</code>, <code>2g</code>).
   </td>
 </tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,6 +104,14 @@ of the most common options to set are:
   </td>
 </tr>
 <tr>
+  <td><code>spark.driver.memory</code></td>
+  <td>512m</td>
+  <td>
+    Amount of memory to use for the driver process, i.e. where spark context is initialized.
+    (e.g. <code>512m</code>, <code>2g</code>).
+  </td>
+</tr>
+<tr>
   <td><code>spark.serializer</code></td>
   <td>org.apache.spark.serializer.<br />JavaSerializer</td>
   <td>


### PR DESCRIPTION
It took me a minute to track this down, so I thought it could be useful to have it in the docs.

I'm unsure if 512mb is the default for spark.driver.memory? Also - there could be a better value for the 'description' to differentiate it from spark.executor.memory.
