### PR TITLE
[SPARK-3550][MLLIB] Disable automatic rdd caching for relevant learners.

### DIFF
--- a/python/pyspark/mllib/classification.py
+++ b/python/pyspark/mllib/classification.py
@@ -242,7 +242,7 @@ class NaiveBayes(object):
         @param lambda_: The smoothing parameter
         """
         sc = data.context
-        dataBytes = _get_unmangled_labeled_point_rdd(data)
+        dataBytes = _get_unmangled_labeled_point_rdd(data, cache=False)
         ans = sc._jvm.PythonMLLibAPI().trainNaiveBayes(dataBytes._jrdd, lambda_)
         return NaiveBayesModel(
             _deserialize_double_vector(ans[0]),

--- a/python/pyspark/mllib/clustering.py
+++ b/python/pyspark/mllib/clustering.py
@@ -22,7 +22,7 @@ from pyspark.mllib._common import \
     _get_unmangled_rdd, _get_unmangled_double_vector_rdd, _squared_distance, \
     _serialize_double_matrix, _deserialize_double_matrix, \
     _serialize_double_vector, _deserialize_double_vector, \
-    _get_initial_weights, _serialize_rating, _regression_train_wrapper
+    _get_initial_weights, _serialize_rating
 from pyspark.mllib.linalg import SparseVector
 
 __all__ = ['KMeansModel', 'KMeans']

--- a/python/pyspark/mllib/recommendation.py
+++ b/python/pyspark/mllib/recommendation.py
@@ -20,8 +20,8 @@ from pyspark.mllib._common import \
     _get_unmangled_rdd, _get_unmangled_double_vector_rdd, \
     _serialize_double_matrix, _deserialize_double_matrix, \
     _serialize_double_vector, _deserialize_double_vector, \
-    _get_initial_weights, _serialize_rating, _regression_train_wrapper, \
-    _serialize_tuple, RatingDeserializer
+    _get_initial_weights, _serialize_rating, _serialize_tuple, \
+    RatingDeserializer
 from pyspark.rdd import RDD
 
 __all__ = ['MatrixFactorizationModel', 'ALS']
@@ -65,7 +65,7 @@ class ALS(object):
     @classmethod
     def train(cls, ratings, rank, iterations=5, lambda_=0.01, blocks=-1):
         sc = ratings.context
-        ratingBytes = _get_unmangled_rdd(ratings, _serialize_rating)
+        ratingBytes = _get_unmangled_rdd(ratings, _serialize_rating, cache=False)
         mod = sc._jvm.PythonMLLibAPI().trainALSModel(
             ratingBytes._jrdd, rank, iterations, lambda_, blocks)
         return MatrixFactorizationModel(sc, mod)
@@ -73,7 +73,7 @@ class ALS(object):
     @classmethod
     def trainImplicit(cls, ratings, rank, iterations=5, lambda_=0.01, blocks=-1, alpha=0.01):
         sc = ratings.context
-        ratingBytes = _get_unmangled_rdd(ratings, _serialize_rating)
+        ratingBytes = _get_unmangled_rdd(ratings, _serialize_rating, cache=False)
         mod = sc._jvm.PythonMLLibAPI().trainImplicitALSModel(
             ratingBytes._jrdd, rank, iterations, lambda_, blocks, alpha)
         return MatrixFactorizationModel(sc, mod)

--- a/python/pyspark/mllib/tree.py
+++ b/python/pyspark/mllib/tree.py
@@ -161,7 +161,7 @@ class DecisionTree(object):
         :return: DecisionTreeModel
         """
         sc = data.context
-        dataBytes = _get_unmangled_labeled_point_rdd(data)
+        dataBytes = _get_unmangled_labeled_point_rdd(data, cache=False)
         categoricalFeaturesInfoJMap = \
             MapConverter().convert(categoricalFeaturesInfo,
                                    sc._gateway._gateway_client)
@@ -169,7 +169,6 @@ class DecisionTree(object):
             dataBytes._jrdd, "classification",
             numClasses, categoricalFeaturesInfoJMap,
             impurity, maxDepth, maxBins, minInstancesPerNode, minInfoGain)
-        dataBytes.unpersist()
         return DecisionTreeModel(sc, model)
 
     @staticmethod
@@ -196,7 +195,7 @@ class DecisionTree(object):
         :return: DecisionTreeModel
         """
         sc = data.context
-        dataBytes = _get_unmangled_labeled_point_rdd(data)
+        dataBytes = _get_unmangled_labeled_point_rdd(data, cache=False)
         categoricalFeaturesInfoJMap = \
             MapConverter().convert(categoricalFeaturesInfo,
                                    sc._gateway._gateway_client)
@@ -204,7 +203,6 @@ class DecisionTree(object):
             dataBytes._jrdd, "regression",
             0, categoricalFeaturesInfoJMap,
             impurity, maxDepth, maxBins, minInstancesPerNode, minInfoGain)
-        dataBytes.unpersist()
         return DecisionTreeModel(sc, model)
 
 


### PR DESCRIPTION
The NaiveBayes, ALS, and DecisionTree learners do not require external caching to prevent repeated RDD re-evaluation during learning iterations. NaiveBayes only evaluates its input RDD once, while ALS and DecisionTree internally persist transformations of their input RDDs.
