### PR TITLE
SPARK-3561 - Pluggable strategy to facilitate access to native Hadoop/YARN resources

### DIFF
--- a/bin/spark-class
+++ b/bin/spark-class
@@ -18,7 +18,6 @@
 #
 
 # NOTE: Any changes to this file must be reflected in SparkSubmitDriverBootstrapper.scala!
-
 cygwin=false
 case "`uname`" in
     CYGWIN*) cygwin=true;;
@@ -140,7 +139,20 @@ if [[ "$?" != "0" ]]; then
   echo "$classpath_output"
   exit 1
 else
-  CLASSPATH="$classpath_output"
+  if [[ $@ == *execution-context:* ]]; then
+    if [ -z "$EXECUTION_CONTEXT_HOME" ]; then
+      echo "Need to set EXECUTION_CONTEXT_HOME"
+      exit 1
+    fi  
+    CLASSPATH=$EXECUTION_CONTEXT_HOME/conf
+    for i in `ls -a $EXECUTION_CONTEXT_HOME/lib/*.jar`  
+       do  
+       CLASSPATH=$CLASSPATH":"$i
+    done  
+    echo STARK CLASSPATH: $CLASSPATH
+  else
+    CLASSPATH="$classpath_output"
+  fi
 fi
 
 if [[ "$1" =~ org.apache.spark.tools.* ]]; then

--- a/core/src/main/scala/org/apache/spark/DefaultExecutionContext.scala
+++ b/core/src/main/scala/org/apache/spark/DefaultExecutionContext.scala
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.mapred.{ FileInputFormat, InputFormat, JobConf }
+import org.apache.hadoop.mapreduce.{ InputFormat => NewInputFormat, Job => NewHadoopJob }
+import org.apache.hadoop.mapreduce.lib.input.{ FileInputFormat => NewFileInputFormat }
+import scala.reflect.ClassTag
+import org.apache.spark.rdd.RDD
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.rdd.HadoopRDD
+import org.apache.spark.rdd.NewHadoopRDD
+import org.apache.spark.rdd.UnionRDD
+/**
+ * Default implementation of JobExecutionContext which delegates to native Spark execution
+ */
+class DefaultExecutionContext extends JobExecutionContext with Logging {
+  
+  def hadoopFile[K, V](
+    sc:SparkContext,
+    path: String,
+    inputFormatClass: Class[_ <: InputFormat[K, V]],
+    keyClass: Class[K],
+    valueClass: Class[V],
+    minPartitions: Int = 1): RDD[(K, V)] = {
+    // A Hadoop configuration can be about 10 KB, which is pretty big, so broadcast it.
+    val confBroadcast = broadcast(sc, new SerializableWritable(sc.hadoopConfiguration))
+    val setInputPathsFunc = (jobConf: JobConf) => FileInputFormat.setInputPaths(jobConf, path)
+    new HadoopRDD(
+      sc,
+      confBroadcast,
+      Some(setInputPathsFunc),
+      inputFormatClass,
+      keyClass,
+      valueClass,
+      minPartitions).setName(path)
+  }
+
+  def newAPIHadoopFile[K, V, F <: NewInputFormat[K, V]](
+    sc:SparkContext,
+    path: String,
+    fClass: Class[F],
+    kClass: Class[K],
+    vClass: Class[V],
+    conf: Configuration = new Configuration): RDD[(K, V)] = {
+    
+    val job = new NewHadoopJob(conf)
+    NewFileInputFormat.addInputPath(job, new Path(path))
+    val updatedConf = job.getConfiguration
+    new NewHadoopRDD(sc, fClass, kClass, vClass, updatedConf).setName(path)
+  }
+
+  def broadcast[T: ClassTag](sc:SparkContext, value: T): Broadcast[T] = {
+    val bc = sc.env.broadcastManager.newBroadcast[T](value, sc.isLocal)
+    sc.cleaner.foreach(_.registerBroadcastForCleanup(bc))
+    bc
+  }
+
+  /**
+   * Run a function on a given set of partitions in an RDD and pass the results to the given
+   * handler function. This is the main entry point for all actions in Spark. The allowLocal
+   * flag allows you to manage scheduler's computation. Keep in mind that it is implementation
+   * specific and may simply be ignored by some implementations.
+   */
+  def runJob[T, U: ClassTag](
+    sc:SparkContext,
+    rdd: RDD[T],
+    func: (TaskContext, Iterator[T]) => U,
+    partitions: Seq[Int],
+    allowLocal: Boolean,
+    resultHandler: (Int, U) => Unit) = {
+    
+    if (sc.dagScheduler == null) {
+      throw new SparkException("SparkContext has been shutdown")
+    }
+    val callSite = sc.getCallSite
+    val cleanedFunc = sc.clean(func)
+    logInfo("Starting job: " + callSite.shortForm)
+    sc.dagScheduler.runJob(rdd, cleanedFunc, partitions, callSite, allowLocal,
+      resultHandler, sc.getLocalProperties)
+    rdd.doCheckpoint()
+  }
+}

--- a/core/src/main/scala/org/apache/spark/JobExecutionContext.scala
+++ b/core/src/main/scala/org/apache/spark/JobExecutionContext.scala
@@ -24,7 +24,7 @@ import org.apache.hadoop.mapreduce.lib.input.{FileInputFormat => NewFileInputFor
 import scala.reflect.ClassTag
 import org.apache.spark.rdd.RDD
 import org.apache.spark.broadcast.Broadcast
-import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.annotation.Experimental
 
 /** 
  * Execution strategy which allows customizations around execution environment of Spark job.
@@ -36,7 +36,7 @@ import org.apache.spark.annotation.DeveloperApi
  * 
  * Implementation must provide default no-arg constructor
  */
-@DeveloperApi
+@Experimental
 trait JobExecutionContext {
 
 
@@ -47,7 +47,7 @@ trait JobExecutionContext {
     * If you plan to directly cache Hadoop writable objects, you should first copy them using
     * a `map` function.
     */
-  @DeveloperApi
+  @Experimental
   def hadoopFile[K, V](
     sc:SparkContext,
     path: String,
@@ -65,7 +65,7 @@ trait JobExecutionContext {
    * If you plan to directly cache Hadoop writable objects, you should first copy them using
    * a `map` function.
    */
-  @DeveloperApi
+  @Experimental
   def newAPIHadoopFile[K, V, F <: NewInputFormat[K, V]](
     sc:SparkContext,
     path: String,
@@ -79,7 +79,7 @@ trait JobExecutionContext {
    * [[org.apache.spark.broadcast.Broadcast]] object for reading it in distributed functions.
    * The variable will be sent to each cluster only once.
    */
-  @DeveloperApi
+  @Experimental
   def broadcast[T: ClassTag](sc:SparkContext, value: T): Broadcast[T]
 
   /**
@@ -88,7 +88,7 @@ trait JobExecutionContext {
    * flag allows you to manage scheduler's computation. Keep in mind that it is implementation 
    * specific and may simply be ignored by some implementations. 
    */
-  @DeveloperApi
+  @Experimental
   def runJob[T, U: ClassTag](
     sc:SparkContext,
     rdd: RDD[T],

--- a/core/src/main/scala/org/apache/spark/JobExecutionContext.scala
+++ b/core/src/main/scala/org/apache/spark/JobExecutionContext.scala
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.mapred.{FileInputFormat, InputFormat, JobConf}
+import org.apache.hadoop.mapreduce.{InputFormat => NewInputFormat, Job => NewHadoopJob}
+import org.apache.hadoop.mapreduce.lib.input.{FileInputFormat => NewFileInputFormat}
+import scala.reflect.ClassTag
+import org.apache.spark.rdd.RDD
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.annotation.DeveloperApi
+
+/** 
+ * Execution strategy which allows customizations around execution environment of Spark job.
+ * Primarily used to facilitate the use of native features of Hadoop related to large scale
+ * batch and ETL jobs.
+ *
+ * To enable it specify your implementation via master URL (e.g., "execution-context:foo.bar.MyImplementation").
+ * 
+ * Implementation must provide default no-arg constructor
+ */
+@DeveloperApi
+trait JobExecutionContext {
+
+
+   /** Get an RDD for a Hadoop file with an arbitrary InputFormat
+    *
+    * '''Note:''' Because Hadoop's RecordReader class re-uses the same Writable object for each
+    * record, directly caching the returned RDD will create many references to the same object.
+    * If you plan to directly cache Hadoop writable objects, you should first copy them using
+    * a `map` function.
+    */
+  @DeveloperApi
+  def hadoopFile[K, V](
+    sc:SparkContext,
+    path: String,
+    inputFormatClass: Class[_ <: InputFormat[K, V]],
+    keyClass: Class[K],
+    valueClass: Class[V],
+    minPartitions: Int = 1): RDD[(K, V)]
+
+  /**
+   * Get an RDD for a given Hadoop file with an arbitrary new API InputFormat
+   * and extra configuration options to pass to the input format.
+   *
+   * '''Note:''' Because Hadoop's RecordReader class re-uses the same Writable object for each
+   * record, directly caching the returned RDD will create many references to the same object.
+   * If you plan to directly cache Hadoop writable objects, you should first copy them using
+   * a `map` function.
+   */
+  @DeveloperApi
+  def newAPIHadoopFile[K, V, F <: NewInputFormat[K, V]](
+    sc:SparkContext,
+    path: String,
+    fClass: Class[F],
+    kClass: Class[K],
+    vClass: Class[V],
+    conf: Configuration = new Configuration): RDD[(K, V)]
+
+  /**
+   * Broadcast a read-only variable to the cluster, returning a
+   * [[org.apache.spark.broadcast.Broadcast]] object for reading it in distributed functions.
+   * The variable will be sent to each cluster only once.
+   */
+  @DeveloperApi
+  def broadcast[T: ClassTag](sc:SparkContext, value: T): Broadcast[T]
+
+  /**
+   * Run a function on a given set of partitions in an RDD and pass the results to the given
+   * handler function. This is the main entry point for all actions in Spark. The allowLocal
+   * flag allows you to manage scheduler's computation. Keep in mind that it is implementation 
+   * specific and may simply be ignored by some implementations. 
+   */
+  @DeveloperApi
+  def runJob[T, U: ClassTag](
+    sc:SparkContext,
+    rdd: RDD[T],
+    func: (TaskContext, Iterator[T]) => U,
+    partitions: Seq[Int],
+    allowLocal: Boolean,
+    resultHandler: (Int, U) => Unit)
+}

--- a/core/src/main/scala/org/apache/spark/JobExecutionContext.scala
+++ b/core/src/main/scala/org/apache/spark/JobExecutionContext.scala
@@ -31,7 +31,8 @@ import org.apache.spark.annotation.DeveloperApi
  * Primarily used to facilitate the use of native features of Hadoop related to large scale
  * batch and ETL jobs.
  *
- * To enable it specify your implementation via master URL (e.g., "execution-context:foo.bar.MyImplementation").
+ * To enable it specify your implementation via master URL 
+ * (e.g., "execution-context:foo.bar.MyImplementation").
  * 
  * Implementation must provide default no-arg constructor
  */

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1277,7 +1277,7 @@ class SparkContext(config: SparkConf) extends Logging {
   private def postApplicationStart() {
     // Note: this code assumes that the task scheduler has been initialized and has contacted
     // the cluster manager to get an application ID (in case the cluster manager provides one).
-    listenerBus.post(SparkListenerApplicationStart(appName, taskScheduler.applicationId(),
+    listenerBus.post(SparkListenerApplicationStart(appName, Some(applicationId),
       startTime, sparkUser))
   }
 

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -245,8 +245,8 @@ class SparkContext(config: SparkConf) extends Logging {
 
   val startTime = System.currentTimeMillis()
 
-  // Add each JAR given through the constructor
-  if (jars != null) {
+  // Add each JAR given through the constructor only if execution is managed by SPARK
+  if (jars != null && !master.startsWith("execution-context:")) {
     jars.foreach(addJar)
   }
 

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -39,7 +39,8 @@ object SparkSubmit {
   private val STANDALONE = 2
   private val MESOS = 4
   private val LOCAL = 8
-  private val ALL_CLUSTER_MGRS = YARN | STANDALONE | MESOS | LOCAL
+  private val EXTERNAL = 16
+  private val ALL_CLUSTER_MGRS = YARN | STANDALONE | MESOS | LOCAL | EXTERNAL
 
   // Deploy modes
   private val CLIENT = 1
@@ -97,6 +98,7 @@ object SparkSubmit {
       case m if m.startsWith("spark") => STANDALONE
       case m if m.startsWith("mesos") => MESOS
       case m if m.startsWith("local") => LOCAL
+      case m if m.startsWith("execution-context:") => EXTERNAL
       case _ => printErrorAndExit("Master must start with yarn, spark, mesos, or local"); -1
     }
 

--- a/core/src/test/scala/org/apache/spark/JobExecutionContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/JobExecutionContextSuite.scala
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.mapred.{ FileInputFormat, InputFormat, JobConf }
+import org.apache.hadoop.mapreduce.{ InputFormat => NewInputFormat, Job => NewHadoopJob }
+import org.apache.hadoop.mapreduce.lib.input.{ FileInputFormat => NewFileInputFormat }
+import scala.reflect.ClassTag
+import org.apache.spark.rdd.RDD
+import org.apache.spark.broadcast.Broadcast
+import org.scalatest.FunSuite
+
+class JobExecutionContextSuite extends FunSuite {
+
+  test("nonCompleteExecutionContextURL") {
+    try {
+      new SparkContext("execution-context", "foo")
+    } catch {
+      case e: Exception => assert(e.isInstanceOf[SparkException])
+    }
+  }
+
+  test("classNotFound1") {
+    try {
+      new SparkContext("execution-context:", "foo")
+    } catch {
+      case e: Exception => assert(e.isInstanceOf[ClassNotFoundException])
+    }
+  }
+
+  test("classNotFound2") {
+    try {
+      new SparkContext("execution-context:foo.bar.Baz", "foo")
+    } catch {
+      case e: Exception => assert(e.isInstanceOf[ClassNotFoundException])
+    }
+  }
+
+  test("invalidContextClass") {
+    try {
+      new SparkContext("execution-context:org.apache.spark.InvalidJobExecutionContext", "foo")
+    } catch {
+      case e: Exception => assert(e.isInstanceOf[InstantiationException])
+    }
+  }
+
+  test("validURLandClass") {
+    val sc = new SparkContext("execution-context:org.apache.spark.ValidJobExecutionContext", "foo")
+    val f = sc.getClass.getDeclaredField("executionContext")
+    f.setAccessible(true)
+    assert(f.get(sc).isInstanceOf[ValidJobExecutionContext])
+  }
+  
+  test("defaultExecutionContext") {
+    val sc = new SparkContext("local", "foo")
+    val f = sc.getClass.getDeclaredField("executionContext")
+    f.setAccessible(true)
+    assert(f.get(sc).isInstanceOf[DefaultExecutionContext])
+  }
+}
+
+private class InvalidJobExecutionContext(s: String) extends JobExecutionContext {
+  def hadoopFile[K, V](
+    sc: SparkContext,
+    path: String,
+    inputFormatClass: Class[_ <: InputFormat[K, V]],
+    keyClass: Class[K],
+    valueClass: Class[V],
+    minPartitions: Int = 1): RDD[(K, V)] = {
+    null
+  }
+
+  def newAPIHadoopFile[K, V, F <: NewInputFormat[K, V]](
+    sc: SparkContext,
+    path: String,
+    fClass: Class[F],
+    kClass: Class[K],
+    vClass: Class[V],
+    conf: Configuration = new Configuration): RDD[(K, V)] = {
+    null
+  }
+
+  def broadcast[T: ClassTag](sc: SparkContext, value: T): Broadcast[T] = {
+    null
+  }
+
+  def runJob[T, U: ClassTag](
+    sc: SparkContext,
+    rdd: RDD[T],
+    func: (TaskContext, Iterator[T]) => U,
+    partitions: Seq[Int],
+    allowLocal: Boolean,
+    resultHandler: (Int, U) => Unit) = {
+
+  }
+}
+
+private class ValidJobExecutionContext extends JobExecutionContext {
+  def hadoopFile[K, V](
+    sc: SparkContext,
+    path: String,
+    inputFormatClass: Class[_ <: InputFormat[K, V]],
+    keyClass: Class[K],
+    valueClass: Class[V],
+    minPartitions: Int = 1): RDD[(K, V)] = {
+    null
+  }
+
+  def newAPIHadoopFile[K, V, F <: NewInputFormat[K, V]](
+    sc: SparkContext,
+    path: String,
+    fClass: Class[F],
+    kClass: Class[K],
+    vClass: Class[V],
+    conf: Configuration = new Configuration): RDD[(K, V)] = {
+    null
+  }
+
+  def broadcast[T: ClassTag](sc: SparkContext, value: T): Broadcast[T] = {
+    null
+  }
+
+  def runJob[T, U: ClassTag](
+    sc: SparkContext,
+    rdd: RDD[T],
+    func: (TaskContext, Iterator[T]) => U,
+    partitions: Seq[Int],
+    allowLocal: Boolean,
+    resultHandler: (Int, U) => Unit) = {
+
+  }
+}

--- a/docs/submitting-applications.md
+++ b/docs/submitting-applications.md
@@ -122,6 +122,9 @@ client mode. The cluster location will be found based on the HADOOP_CONF_DIR var
 <tr><td> yarn-cluster </td><td> Connect to a <a href="running-on-yarn.html"> YARN </a> cluster in
 cluster mode. The cluster location will be found based on HADOOP_CONF_DIR.
 </td></tr>
+<tr><td> execution-context:[org.apache.spark.JobExecutionContext implementation] </td><td> Allows one to specify custom implementation of JobExecutionContext.
+Primarily used within the context of Hadoop/YARN to provide access to its native features related to batch/ETL processing.
+</td></tr>
 </table>
 
 


### PR DESCRIPTION
Added HadoopExecutionContext trait and its default implementation DefaultHadoopExecutionContext
Modified SparkContext to instantiate and delegate to the instance of HadoopExecutionContext where appropriate

Changed HadoopExecutionContext to JobExecutionContext
Changed DefaultHadoopExecutionContext to DefaultExecutionContext
Name changes are due to the fact that when Spark executes outside of Hadoop having Hadoop in the name woudl be confusing
Added initial documentation and tests
