### PR TITLE
[SPARK-3051] Support looking-up named accumulators in a registry

### DIFF
--- a/core/src/main/scala/org/apache/spark/Accumulators.scala
+++ b/core/src/main/scala/org/apache/spark/Accumulators.scala
@@ -37,17 +37,19 @@ import org.apache.spark.serializer.JavaSerializer
  * @param initialValue initial value of accumulator
  * @param param helper object defining how to add elements of type `R` and `T`
  * @param name human-readable name for use in Spark's web UI
+ * @param sc the [[SparkContext]] that created this accumulable
  * @tparam R the full accumulated data (result type)
  * @tparam T partial data that can be added in
  */
 class Accumulable[R, T] (
     @transient initialValue: R,
     param: AccumulableParam[R, T],
-    val name: Option[String])
+    val name: Option[String],
+    @transient val sc: SparkContext)
   extends Serializable {
 
-  def this(@transient initialValue: R, param: AccumulableParam[R, T]) =
-    this(initialValue, param, None)
+  def this(@transient initialValue: R, param: AccumulableParam[R, T], sc: SparkContext) =
+    this(initialValue, param, None, sc)
 
   val id: Long = Accumulators.newId
 
@@ -223,11 +225,13 @@ GrowableAccumulableParam[R <% Growable[T] with TraversableOnce[T] with Serializa
  *
  * @param initialValue initial value of accumulator
  * @param param helper object defining how to add elements of type `T`
+ * @param sc the [[SparkContext]] that created this accumulable
  * @tparam T result type
  */
-class Accumulator[T](@transient initialValue: T, param: AccumulatorParam[T], name: Option[String])
-    extends Accumulable[T,T](initialValue, param, name) {
-  def this(initialValue: T, param: AccumulatorParam[T]) = this(initialValue, param, None)
+class Accumulator[T](@transient initialValue: T, param: AccumulatorParam[T], name: Option[String],
+    @transient sc: SparkContext) extends Accumulable[T,T](initialValue, param, name, sc) {
+  def this(initialValue: T, param: AccumulatorParam[T], sc: SparkContext) = this(initialValue,
+      param, None, sc)
 }
 
 /**
@@ -243,7 +247,27 @@ trait AccumulatorParam[T] extends AccumulableParam[T, T] {
   }
 }
 
+/**
+ * Provides the ability to look-up [[Accumulable]]s by name when performing operations on RDDs.
+ *
+ * For the correct Accumulable to be returned, the RDD used must have been created
+ * by the same [[SparkContext]] as the Accumulable. It is not possible to create Accumulables
+ * using one [[SparkContext]] and look them up when performing operations on an RDD created by
+ * a different [[SparkContext]].
+ *
+ * Note that named Accumulables cannot be looked-up in the driver program; they can only be
+ * obtained while an operation is being performed on an RDD (a task is executing).
+ *
+ * If multiple Accumulables have been created with the same name using the same [[SparkContext]]
+ * then the one that was created most recently is returned.
+ */
 object AccumulableRegistry {
+  /**
+   * Returns the [[Accumulable]] with the specified name, if it exists.
+   * @param name The name of the [[Accumulable]]
+   * @return The accumulable with the specified name, or [[None]] if one does not exist,
+   *         or if there is not a currently-executing task
+   */
   def get(name: String): Option[Accumulable[_, _]] = {
     Accumulators.getLocalAccumulable(name)
   }
@@ -258,6 +282,9 @@ private object Accumulators {
   var lastId: Long = 0
 
   def newId: Long = synchronized {
+    // Note that we currently rely on the current ID generation scheme (accumulables that are
+    // created later have higher IDs) to ensure that we always get the most recently-created
+    // accumulable when we look them up by name.
     lastId += 1
     lastId
   }
@@ -266,9 +293,8 @@ private object Accumulators {
     if (original) {
       originals(a.id) = a
     } else {
-      val accums = localAccums.getOrElseUpdate(Thread.currentThread, LocalAccumulables())
-      accums.byId(a.id) = a
-      a.name.foreach(accums.byName(_) = a)
+      val accums = localAccums.getOrElseUpdate(Thread.currentThread, new LocalAccumulables())
+      accums.add(a)
     }
   }
 
@@ -282,14 +308,15 @@ private object Accumulators {
   // Get the values of the local accumulators for the current thread (by ID)
   def values: Map[Long, Any] = synchronized {
     val ret = Map[Long, Any]()
-    for ((id, accum) <- localAccums.getOrElse(Thread.currentThread, LocalAccumulables()).byId) {
+    for ((id, accum) <- localAccums.getOrElse(Thread.currentThread, new LocalAccumulables()).byId) {
       ret(id) = accum.localValue
     }
     return ret
   }
 
+  // Get the local accumulable with the specified name
   def getLocalAccumulable(name: String): Option[Accumulable[_, _]] = {
-    val accums = localAccums.getOrElseUpdate(Thread.currentThread, LocalAccumulables())
+    val accums = localAccums.getOrElseUpdate(Thread.currentThread, new LocalAccumulables())
     accums.byName.get(name)
   }
 
@@ -306,5 +333,25 @@ private object Accumulators {
   def stringifyValue(value: Any) = "%s".format(value)
 }
 
-private case class LocalAccumulables(byId: Map[Long, Accumulable[_, _]] = Map(),
-                                     byName: Map[String, Accumulable[_, _]] = Map())
+private class LocalAccumulables(val byId: Map[Long, Accumulable[_, _]] = Map(),
+                                val byName: Map[String, Accumulable[_, _]] = Map()) {
+  def add(accumulable: Accumulable[_, _]) {
+    // It is possible to have two accumulables with the same ID. This is caused when
+    // a named accumulable is broadcast, but is also explicitly passed-in to a task.
+    // In this case we want the explicitly passed-in version to replace the broadcast version,
+    // since this is the version that the function references. Since explicitly passed accumulables
+    // are deserialized after broadcast ones, we always replace accumulables with the same ID here.
+    byId(accumulable.id) = accumulable
+    accumulable.name.foreach(name => {
+      val existing = byName.get(name)
+      // If there are two accumulables with the same name, we want to use the one that was
+      // defined later, which we assume is the one with the higher ID. Note that this relies
+      // on the implementation of the ID generation for accumulables. We also need to make sure to
+      // replace existing any accumulables with the same ID.
+      if (!existing.isDefined || existing.get.id <= accumulable.id) {
+        byName(name) = accumulable
+      }
+    })
+  }
+
+}

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -745,15 +745,19 @@ class SparkContext(config: SparkConf) extends Logging {
    * values to using the `+=` method. Only the driver can access the accumulator's `value`.
    */
   def accumulator[T](initialValue: T)(implicit param: AccumulatorParam[T]) =
-    new Accumulator(initialValue, param)
+    new Accumulator(initialValue, param, this)
 
   /**
-   * Create an [[org.apache.spark.Accumulator]] variable of a given type, with a name for display
-   * in the Spark UI. Tasks can "add" values to the accumulator using the `+=` method. Only the
+   * Create an [[org.apache.spark.Accumulator]] variable of a given type, with the specified name.
+   * Tasks can "add" values to the accumulator using the `+=` method. Only the
    * driver can access the accumulator's `value`.
+   *
+   * The accumulator's name is used in the Spark UI, as well as permitting accumulators to be
+   * looked-up by name from the [[AccumulableRegistry]]. Note that named accumulators are broadcast
+   * to all executors, so this imposes a (small) cost in terms of serialization and network traffic.
    */
   def accumulator[T](initialValue: T, name: String)(implicit param: AccumulatorParam[T]) = {
-    new Accumulator(initialValue, param, Some(name))
+    new Accumulator(initialValue, param, Some(name), this)
   }
 
   /**
@@ -763,17 +767,22 @@ class SparkContext(config: SparkConf) extends Logging {
    * @tparam R type that can be added to the accumulator
    */
   def accumulable[T, R](initialValue: T)(implicit param: AccumulableParam[T, R]) =
-    new Accumulable(initialValue, param)
+    new Accumulable(initialValue, param, this)
 
   /**
-   * Create an [[org.apache.spark.Accumulable]] shared variable, with a name for display in the
-   * Spark UI. Tasks can add values to the accumuable using the `+=` operator. Only the driver can
+   * Create an [[org.apache.spark.Accumulable]] shared variable, with the specified name.
+   * Tasks can add values to the accumuable using the `+=` operator. Only the driver can
    * access the accumuable's `value`.
+   *
+   * The accumulator's name is used in the Spark UI, as well as permitting accumulators to be
+   * looked-up by name from the [[AccumulableRegistry]]. Note that named accumulators are broadcast
+   * to all executors, so this imposes a (small) cost in terms of serialization and network traffic.
+   *
    * @tparam T accumulator type
    * @tparam R type that can be added to the accumulator
    */
   def accumulable[T, R](initialValue: T, name: String)(implicit param: AccumulableParam[T, R]) =
-    new Accumulable(initialValue, param, Some(name))
+    new Accumulable(initialValue, param, Some(name), this)
 
   /**
    * Create an accumulator from a "mutable collection" type.
@@ -784,7 +793,7 @@ class SparkContext(config: SparkConf) extends Logging {
   def accumulableCollection[R <% Growable[T] with TraversableOnce[T] with Serializable: ClassTag, T]
       (initialValue: R): Accumulable[R, T] = {
     val param = new GrowableAccumulableParam[R,T]
-    new Accumulable(initialValue, param)
+    new Accumulable(initialValue, param, this)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -774,8 +774,8 @@ class SparkContext(config: SparkConf) extends Logging {
    * Tasks can add values to the accumuable using the `+=` operator. Only the driver can
    * access the accumuable's `value`.
    *
-   * The accumulator's name is used in the Spark UI, as well as permitting accumulators to be
-   * looked-up by name from the [[AccumulableRegistry]]. Note that named accumulators are broadcast
+   * The accumulable's name is used in the Spark UI, as well as permitting accumulables to be
+   * looked-up by name from the [[AccumulableRegistry]]. Note that named accumulables are broadcast
    * to all executors, so this imposes a (small) cost in terms of serialization and network traffic.
    *
    * @tparam T accumulator type

--- a/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
@@ -529,8 +529,8 @@ class JavaSparkContext(val sc: SparkContext)
    * Create an [[org.apache.spark.Accumulable]] shared variable of the given type, to which tasks
    * can "add" values with `add`. Only the master can access the accumuable's `value`.
    *
-   * The accumulator's name is used in the Spark UI, as well as permitting accumulators to be
-   * looked-up by name from the [[AccumulableRegistry]]. Note that named accumulators are broadcast
+   * The accumulable's name is used in the Spark UI, as well as permitting accumulables to be
+   * looked-up by name from the [[AccumulableRegistry]]. Note that named accumulables are broadcast
    * to all executors, so this imposes a (small) cost in terms of serialization and network traffic.
    */
   def accumulable[T, R](initialValue: T, name: String, param: AccumulableParam[T, R])

--- a/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
@@ -436,7 +436,9 @@ class JavaSparkContext(val sc: SparkContext)
    * Create an [[org.apache.spark.Accumulator]] integer variable, which tasks can "add" values
    * to using the `add` method. Only the master can access the accumulator's `value`.
    *
-   * This version supports naming the accumulator for display in Spark's web UI.
+   * The accumulator's name is used in the Spark UI, as well as permitting accumulators to be
+   * looked-up by name from the [[AccumulableRegistry]]. Note that named accumulators are broadcast
+   * to all executors, so this imposes a (small) cost in terms of serialization and network traffic.
    */
   def intAccumulator(initialValue: Int, name: String): Accumulator[java.lang.Integer] =
     sc.accumulator(initialValue, name)(IntAccumulatorParam)
@@ -453,7 +455,9 @@ class JavaSparkContext(val sc: SparkContext)
    * Create an [[org.apache.spark.Accumulator]] double variable, which tasks can "add" values
    * to using the `add` method. Only the master can access the accumulator's `value`.
    *
-   * This version supports naming the accumulator for display in Spark's web UI.
+   * The accumulator's name is used in the Spark UI, as well as permitting accumulators to be
+   * looked-up by name from the [[AccumulableRegistry]]. Note that named accumulators are broadcast
+   * to all executors, so this imposes a (small) cost in terms of serialization and network traffic.
    */
   def doubleAccumulator(initialValue: Double, name: String): Accumulator[java.lang.Double] =
     sc.accumulator(initialValue, name)(DoubleAccumulatorParam)
@@ -469,7 +473,9 @@ class JavaSparkContext(val sc: SparkContext)
    * Create an [[org.apache.spark.Accumulator]] integer variable, which tasks can "add" values
    * to using the `add` method. Only the master can access the accumulator's `value`.
    *
-   * This version supports naming the accumulator for display in Spark's web UI.
+   * The accumulator's name is used in the Spark UI, as well as permitting accumulators to be
+   * looked-up by name from the [[AccumulableRegistry]]. Note that named accumulators are broadcast
+   * to all executors, so this imposes a (small) cost in terms of serialization and network traffic.
    */
   def accumulator(initialValue: Int, name: String): Accumulator[java.lang.Integer] =
     intAccumulator(initialValue, name)
@@ -486,7 +492,9 @@ class JavaSparkContext(val sc: SparkContext)
    * Create an [[org.apache.spark.Accumulator]] double variable, which tasks can "add" values
    * to using the `add` method. Only the master can access the accumulator's `value`.
    *
-   * This version supports naming the accumulator for display in Spark's web UI.
+   * The accumulator's name is used in the Spark UI, as well as permitting accumulators to be
+   * looked-up by name from the [[AccumulableRegistry]]. Note that named accumulators are broadcast
+   * to all executors, so this imposes a (small) cost in terms of serialization and network traffic.
    */
   def accumulator(initialValue: Double, name: String): Accumulator[java.lang.Double] =
     doubleAccumulator(initialValue, name)
@@ -502,7 +510,9 @@ class JavaSparkContext(val sc: SparkContext)
    * Create an [[org.apache.spark.Accumulator]] variable of a given type, which tasks can "add"
    * values to using the `add` method. Only the master can access the accumulator's `value`.
    *
-   * This version supports naming the accumulator for display in Spark's web UI.
+   * The accumulator's name is used in the Spark UI, as well as permitting accumulators to be
+   * looked-up by name from the [[AccumulableRegistry]]. Note that named accumulators are broadcast
+   * to all executors, so this imposes a (small) cost in terms of serialization and network traffic.
    */
   def accumulator[T](initialValue: T, name: String, accumulatorParam: AccumulatorParam[T])
       : Accumulator[T] =
@@ -519,7 +529,9 @@ class JavaSparkContext(val sc: SparkContext)
    * Create an [[org.apache.spark.Accumulable]] shared variable of the given type, to which tasks
    * can "add" values with `add`. Only the master can access the accumuable's `value`.
    *
-   * This version supports naming the accumulator for display in Spark's web UI.
+   * The accumulator's name is used in the Spark UI, as well as permitting accumulators to be
+   * looked-up by name from the [[AccumulableRegistry]]. Note that named accumulators are broadcast
+   * to all executors, so this imposes a (small) cost in terms of serialization and network traffic.
    */
   def accumulable[T, R](initialValue: T, name: String, param: AccumulableParam[T, R])
       : Accumulable[T, R] =

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -163,7 +163,7 @@ private[spark] class Executor(
         task = ser.deserialize[Task[Any]](taskBytes, Thread.currentThread.getContextClassLoader)
 
         // We don't actually need to do anything with the result of the deserialization as it
-        // is the deserialization itself that registers the accumulables in the Accumulators object
+        // is the deserialization itself that registers the accumulables in the Accumulators object.
         // It is important that we do this before we deserialize any accumulators that are
         // explicitly passed with the task (this happens when the task is run) as we want
         // those accumulators to replace these ones if they have the same ID.

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -161,6 +161,11 @@ private[spark] class Executor(
         val (taskFiles, taskJars, taskBytes) = Task.deserializeWithDependencies(serializedTask)
         updateDependencies(taskFiles, taskJars)
         task = ser.deserialize[Task[Any]](taskBytes, Thread.currentThread.getContextClassLoader)
+        val accumulablesBinary = task.accumulablesBinary
+        // We don't actually need to do anything with the result of the deserialization as it
+        // is the deserialization itself that registers the accumulables in the Accumulators object
+        ser.deserialize[Seq[Accumulable[_, _]]](ByteBuffer.wrap(accumulablesBinary.value),
+          Thread.currentThread.getContextClassLoader)
 
         // If this task has been killed before we deserialized it, let's quit now. Otherwise,
         // continue executing the task.

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -161,9 +161,13 @@ private[spark] class Executor(
         val (taskFiles, taskJars, taskBytes) = Task.deserializeWithDependencies(serializedTask)
         updateDependencies(taskFiles, taskJars)
         task = ser.deserialize[Task[Any]](taskBytes, Thread.currentThread.getContextClassLoader)
-        val accumulablesBinary = task.accumulablesBinary
+
         // We don't actually need to do anything with the result of the deserialization as it
         // is the deserialization itself that registers the accumulables in the Accumulators object
+        // It is important that we do this before we deserialize any accumulators that are
+        // explicitly passed with the task (this happens when the task is run) as we want
+        // those accumulators to replace these ones if they have the same ID.
+        val accumulablesBinary = task.accumulablesBinary
         ser.deserialize[Seq[Accumulable[_, _]]](ByteBuffer.wrap(accumulablesBinary.value),
           Thread.currentThread.getContextClassLoader)
 

--- a/core/src/main/scala/org/apache/spark/scheduler/ResultTask.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ResultTask.scala
@@ -44,8 +44,9 @@ private[spark] class ResultTask[T, U](
     taskBinary: Broadcast[Array[Byte]],
     partition: Partition,
     @transient locs: Seq[TaskLocation],
-    val outputId: Int)
-  extends Task[U](stageId, partition.index) with Serializable {
+    val outputId: Int,
+    accumulablesBinary: Broadcast[Array[Byte]])
+  extends Task[U](stageId, partition.index, accumulablesBinary) with Serializable {
 
   @transient private[this] val preferredLocs: Seq[TaskLocation] = {
     if (locs == null) Nil else locs.toSet.toSeq

--- a/core/src/main/scala/org/apache/spark/scheduler/ResultTask.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ResultTask.scala
@@ -36,6 +36,7 @@ import org.apache.spark.rdd.RDD
  *                   (RDD[T], (TaskContext, Iterator[T]) => U).
  * @param partition partition of the RDD this task is associated with
  * @param locs preferred task execution locations for locality scheduling
+ * @param accumulablesBinary serialized version of the set of named accumulables for this job
  * @param outputId index of the task in this job (a job can launch tasks on only a subset of the
  *                 input RDD's partitions).
  */

--- a/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapTask.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapTask.scala
@@ -42,12 +42,13 @@ private[spark] class ShuffleMapTask(
     stageId: Int,
     taskBinary: Broadcast[Array[Byte]],
     partition: Partition,
-    @transient private var locs: Seq[TaskLocation])
-  extends Task[MapStatus](stageId, partition.index) with Logging {
+    @transient private var locs: Seq[TaskLocation],
+    accumulablesBinary: Broadcast[Array[Byte]])
+  extends Task[MapStatus](stageId, partition.index, accumulablesBinary) with Logging {
 
   /** A constructor used only in test suites. This does not require passing in an RDD. */
   def this(partitionId: Int) {
-    this(0, null, new Partition { override def index = 0 }, null)
+    this(0, null, new Partition { override def index = 0 }, null, null)
   }
 
   @transient private val preferredLocs: Seq[TaskLocation] = {

--- a/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapTask.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapTask.scala
@@ -37,6 +37,7 @@ import org.apache.spark.shuffle.ShuffleWriter
  *                   the type should be (RDD[_], ShuffleDependency[_, _, _]).
  * @param partition partition of the RDD this task is associated with
  * @param locs preferred task execution locations for locality scheduling
+ * @param accumulablesBinary serialized version of the set of named accumulables for this job
  */
 private[spark] class ShuffleMapTask(
     stageId: Int,

--- a/core/src/main/scala/org/apache/spark/scheduler/Task.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Task.scala
@@ -26,6 +26,7 @@ import org.apache.spark.TaskContext
 import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.serializer.SerializerInstance
 import org.apache.spark.util.ByteBufferInputStream
+import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.util.Utils
 
 
@@ -42,7 +43,8 @@ import org.apache.spark.util.Utils
  * @param stageId id of the stage this task belongs to
  * @param partitionId index of the number in the RDD
  */
-private[spark] abstract class Task[T](val stageId: Int, var partitionId: Int) extends Serializable {
+private[spark] abstract class Task[T](val stageId: Int, var partitionId: Int,
+  val accumulablesBinary: Broadcast[Array[Byte]]) extends Serializable {
 
   final def run(attemptId: Long): T = {
     context = new TaskContext(stageId, partitionId, attemptId, runningLocally = false)

--- a/core/src/main/scala/org/apache/spark/scheduler/Task.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Task.scala
@@ -42,9 +42,10 @@ import org.apache.spark.util.Utils
  *
  * @param stageId id of the stage this task belongs to
  * @param partitionId index of the number in the RDD
+ * @param accumulablesBinary serialized version of the set of named accumulables for this job
  */
 private[spark] abstract class Task[T](val stageId: Int, var partitionId: Int,
-  val accumulablesBinary: Broadcast[Array[Byte]]) extends Serializable {
+    val accumulablesBinary: Broadcast[Array[Byte]]) extends Serializable {
 
   final def run(attemptId: Long): T = {
     context = new TaskContext(stageId, partitionId, attemptId, runningLocally = false)

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -675,7 +675,7 @@ class DAGSchedulerSuite extends TestKit(ActorSystem("DAGSchedulerSuite")) with F
       override def addInPlace(r1: Int, r2: Int): Int = {
         throw new DAGSchedulerSuiteDummyException
       }
-    })
+    }, sc)
 
     // Run this on executors
     sc.parallelize(1 to 10, 2).foreach { item => acc.add(1) }

--- a/core/src/test/scala/org/apache/spark/scheduler/FakeTask.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/FakeTask.scala
@@ -19,7 +19,7 @@ package org.apache.spark.scheduler
 
 import org.apache.spark.TaskContext
 
-class FakeTask(stageId: Int, prefLocs: Seq[TaskLocation] = Nil) extends Task[Int](stageId, 0) {
+class FakeTask(stageId: Int, prefLocs: Seq[TaskLocation] = Nil) extends Task[Int](stageId, 0, null) {
   override def runTask(context: TaskContext): Int = 0
 
   override def preferredLocations: Seq[TaskLocation] = prefLocs

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskContextSuite.scala
@@ -43,7 +43,8 @@ class TaskContextSuite extends FunSuite with BeforeAndAfter with LocalSparkConte
     val closureSerializer = SparkEnv.get.closureSerializer.newInstance()
     val func = (c: TaskContext, i: Iterator[String]) => i.next()
     val task = new ResultTask[String, String](
-      0, sc.broadcast(closureSerializer.serialize((rdd, func)).array), rdd.partitions(0), Seq(), 0)
+      0, sc.broadcast(closureSerializer.serialize((rdd, func)).array), rdd.partitions(0), Seq(), 0,
+      sc.broadcast(Array()))
     intercept[RuntimeException] {
       task.run(0)
     }

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -137,7 +137,7 @@ class FakeTaskScheduler(sc: SparkContext, liveExecutors: (String, String)* /* ex
 /**
  * A Task implementation that results in a large serialized task.
  */
-class LargeTask(stageId: Int) extends Task[Array[Byte]](stageId, 0) {
+class LargeTask(stageId: Int) extends Task[Array[Byte]](stageId, 0, null) {
   val randomBuffer = new Array[Byte](TaskSetManager.TASK_SIZE_TO_WARN_KB * 1024)
   val random = new Random(0)
   random.nextBytes(randomBuffer)


### PR DESCRIPTION
This proposal builds on SPARK-2380 (Support displaying accumulator values in the web UI) to allow 
named accumulables to be looked-up in a "registry", as opposed to having to be passed to every 
method that need to access them. See the JIRA ticket (SPARK-3051) for some more details, including 
an example use case.

An AccumulableRegistry object is provided to allow accumulables to be looked-up by name at task 
execution time. This requires named accumulables to be broadcast to the executors before the task 
is executed. This is taken care of in the DAGScheduler in much the same way as for Tasks.

Accumulables were already stored in thread-local variables in the Accumulators object, so exposing 
these in the registry was simply a matter of wrapping this object, and keying the accumulables by 
name (they were previously keyed only by ID).

Note that Accumulables cannot be looked-up from the registry in the driver program; they can only be
obtained while an operation is being performed on an RDD (a task is executing).

One important thing to note in the implementation is that it is important that we we deserialize 
any named accumulators that have been broadcast before those that are explicitly passed with the task 
as we want the explicitly-passed ones to override the broadcast ones (otherwise the explicitly passed
ones would not work). This may be a little brittle, but there are tests (in AccumulatorSuite) that will break
if this is ever changed.
