### PR TITLE
[SPARK-3578] Fix upper bound in GraphGenerators.sampleLogNormal

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/util/GraphGenerators.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/util/GraphGenerators.scala
@@ -118,7 +118,7 @@ object GraphGenerators {
       val Z = rand.nextGaussian()
       X = math.exp(mu + sigma*Z)
     }
-    math.round(X.toFloat)
+    math.floor(X).toInt
   }
 
   /**

--- a/graphx/src/main/scala/org/apache/spark/graphx/util/GraphGenerators.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/util/GraphGenerators.scala
@@ -114,14 +114,12 @@ object GraphGenerators {
     // Z ~ N(0, 1)
     var X: Double = maxVal
 
-    while (round(X) >= maxVal) {
+    while (X >= maxVal) {
       val Z = rand.nextGaussian()
       X = math.exp(mu + sigma*Z)
     }
-    round(X)
+    math.floor(X).toInt
   }
-
-  private def round(x: Double): Int = math.round(x.toFloat)
 
   /**
    * A random graph generator using the R-MAT model, proposed in

--- a/graphx/src/main/scala/org/apache/spark/graphx/util/GraphGenerators.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/util/GraphGenerators.scala
@@ -114,12 +114,14 @@ object GraphGenerators {
     // Z ~ N(0, 1)
     var X: Double = maxVal
 
-    while (X >= maxVal) {
+    while (round(X) >= maxVal) {
       val Z = rand.nextGaussian()
       X = math.exp(mu + sigma*Z)
     }
-    math.floor(X).toInt
+    round(X)
   }
+
+  private def round(x: Double): Int = math.round(x.toFloat)
 
   /**
    * A random graph generator using the R-MAT model, proposed in

--- a/graphx/src/test/scala/org/apache/spark/graphx/util/GraphGeneratorsSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/util/GraphGeneratorsSuite.scala
@@ -64,8 +64,11 @@ class GraphGeneratorsSuite extends FunSuite with LocalSparkContext {
     val sigma = 1.3
     val maxVal = 100
 
-    val dstId = GraphGenerators.sampleLogNormal(mu, sigma, maxVal)
-    assert(dstId < maxVal)
+    val trials = 1000
+    for (i <- 1 to trials) {
+      val dstId = GraphGenerators.sampleLogNormal(mu, sigma, maxVal)
+      assert(dstId < maxVal)
+    }
 
     val dstId_round1 = GraphGenerators.sampleLogNormal(mu, sigma, maxVal, 12345)
     val dstId_round2 = GraphGenerators.sampleLogNormal(mu, sigma, maxVal, 12345)


### PR DESCRIPTION
GraphGenerators.sampleLogNormal is supposed to return an integer strictly less than maxVal. However, it violates this guarantee. It generates its return value as follows:

``` scala
var X: Double = maxVal

while (X >= maxVal) {
  val Z = rand.nextGaussian()
  X = math.exp(mu + sigma*Z)
}
math.round(X.toFloat)
```

When X is sampled to be close to (but less than) maxVal, then it will pass the while loop condition, but the rounded result will be equal to maxVal, which will violate the guarantee. For example, if maxVal is 5 and X is 4.9, then X < maxVal, but `math.round(X.toFloat)` is 5.

This PR instead rounds X before checking the loop condition, guaranteeing that the condition will hold for the return value.
