### PR TITLE
[SPARK-3534] Add hive-thriftserver to SQL tests

### DIFF
--- a/dev/run-tests
+++ b/dev/run-tests
@@ -149,7 +149,7 @@ echo "========================================================================="
   if [ -n "$_SQL_TESTS_ONLY" ]; then
     # This must be an array of individual arguments. Otherwise, having one long string
     #+ will be interpreted as a single test, which doesn't work.
-    SBT_MAVEN_TEST_ARGS=("catalyst/test" "sql/test" "hive/test")
+    SBT_MAVEN_TEST_ARGS=("catalyst/test" "sql/test" "hive/test" "hive-thriftserver/test")
   else
     SBT_MAVEN_TEST_ARGS=("test")
   fi


### PR DESCRIPTION
Addresses the problem pointed out in [this comment](https://github.com/apache/spark/pull/2441#issuecomment-55990116).
