### PR TITLE
[SPARK-1987] EdgePartitionBuilder: More memory-efficient graph construction

### DIFF
--- a/graphx/build.sbt
+++ b/graphx/build.sbt
@@ -1,1 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 libraryDependencies += "org.mockito" % "mockito-all" % "1.9.5"

--- a/graphx/build.sbt
+++ b/graphx/build.sbt
@@ -1,18 +1,18 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 
 libraryDependencies += "org.mockito" % "mockito-all" % "1.9.5"

--- a/graphx/build.sbt
+++ b/graphx/build.sbt
@@ -1,0 +1,1 @@
+libraryDependencies += "org.mockito" % "mockito-all" % "1.9.5"

--- a/graphx/pom.xml
+++ b/graphx/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>1.9.0</version>
+      <version>1.9.5</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/graphx/pom.xml
+++ b/graphx/pom.xml
@@ -59,6 +59,12 @@
       <artifactId>scalacheck_${scala.binary.version}</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.9.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>

--- a/graphx/src/main/scala/org/apache/spark/graphx/impl/EdgePartitionBuilder.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/impl/EdgePartitionBuilder.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.graphx.impl
 
 import scala.reflect.ClassTag
-// import scala.util.Sorting
+
 import org.mockito.cglib.util.ParallelSorter
 
 import org.apache.spark.util.collection.{BitSet, OpenHashSet, PrimitiveVector}
@@ -44,12 +44,13 @@ class EdgePartitionBuilder[@specialized(Long, Int, Double) ED: ClassTag, VD: Cla
     val srcIdsTrim = srcIds.trim().array
     val dstIdsTrim = dstIds.trim().array
     val dataTrim = data.trim().array
-    val edgeArray = Array(srcIdsTrim, dstIdsTrim, dataTrim)
-    // TODO: sort three arrays simultaneously based on srcIds
-    val sorter = ParallelSorter.create(edgeArray)
-    sorter.mergeSort(0)
-    //val sorter = Sorting.quickSort(edgeArray)
-    // Sorting.quickSort(edgeArray)(Edge.lexicographicOrdering)
+
+    // Sort the three arrays in parallel by (srcId, dstId)
+    val arrays = Array[Object](srcIdsTrim, dstIdsTrim, dataTrim)
+    val sorter = ParallelSorter.create(arrays)
+    sorter.quickSort(1, 0, srcIdsTrim.length)
+    sorter.mergeSort(0, 0, srcIdsTrim.length)
+
     val index = new GraphXPrimitiveKeyOpenHashMap[VertexId, Int]
     // Copy edges into columnar structures, tracking the beginnings of source vertex id clusters and
     // adding them to the index

--- a/graphx/src/main/scala/org/apache/spark/graphx/impl/EdgePartitionBuilder.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/impl/EdgePartitionBuilder.scala
@@ -46,7 +46,7 @@ class EdgePartitionBuilder[@specialized(Long, Int, Double) ED: ClassTag, VD: Cla
     val dataTrim = data.trim().array
     val edgeArray = Array(srcIdsTrim, dstIdsTrim, dataTrim)
     // TODO: sort three arrays simultaneously based on srcIds
-    val sorter = ParallelSorter(edgeArray)
+    val sorter = ParallelSorter.create(edgeArray)
     sorter.mergeSort(0)
     //val sorter = Sorting.quickSort(edgeArray)
     // Sorting.quickSort(edgeArray)(Edge.lexicographicOrdering)

--- a/graphx/src/main/scala/org/apache/spark/graphx/impl/EdgePartitionBuilder.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/impl/EdgePartitionBuilder.scala
@@ -48,8 +48,8 @@ class EdgePartitionBuilder[@specialized(Long, Int, Double) ED: ClassTag, VD: Cla
     // Sort the three arrays in parallel by (srcId, dstId)
     val arrays = Array[Object](srcIdsTrim, dstIdsTrim, dataTrim)
     val sorter = ParallelSorter.create(arrays)
-    sorter.quickSort(1, 0, srcIdsTrim.length)
-    sorter.mergeSort(0, 0, srcIdsTrim.length)
+    sorter.quickSort(1, 0, srcIdsTrim.length) // necessary for groupEdges
+    sorter.mergeSort(0, 0, srcIdsTrim.length) // preserves dstId sort order
 
     val index = new GraphXPrimitiveKeyOpenHashMap[VertexId, Int]
     // Copy edges into columnar structures, tracking the beginnings of source vertex id clusters and

--- a/graphx/src/main/scala/org/apache/spark/graphx/impl/EdgePartitionBuilder.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/impl/EdgePartitionBuilder.scala
@@ -18,7 +18,8 @@
 package org.apache.spark.graphx.impl
 
 import scala.reflect.ClassTag
-import scala.util.Sorting
+// import scala.util.Sorting
+import org.mockito.cglib.util.ParallelSorter
 
 import org.apache.spark.util.collection.{BitSet, OpenHashSet, PrimitiveVector}
 
@@ -28,32 +29,37 @@ import org.apache.spark.graphx.util.collection.GraphXPrimitiveKeyOpenHashMap
 private[graphx]
 class EdgePartitionBuilder[@specialized(Long, Int, Double) ED: ClassTag, VD: ClassTag](
     size: Int = 64) {
-  var edges = new PrimitiveVector[Edge[ED]](size)
+  var srcIds = new PrimitiveVector[VertexId](size)
+  var dstIds = new PrimitiveVector[VertexId](size)
+  var data = new PrimitiveVector[ED](size)
 
   /** Add a new edge to the partition. */
   def add(src: VertexId, dst: VertexId, d: ED) {
-    edges += Edge(src, dst, d)
+    srcIds += src
+    dstIds += dst
+    data += d
   }
 
   def toEdgePartition: EdgePartition[ED, VD] = {
-    val edgeArray = edges.trim().array
-    Sorting.quickSort(edgeArray)(Edge.lexicographicOrdering)
-    val srcIds = new Array[VertexId](edgeArray.size)
-    val dstIds = new Array[VertexId](edgeArray.size)
-    val data = new Array[ED](edgeArray.size)
+    val srcIdsTrim = srcIds.trim().array
+    val dstIdsTrim = dstIds.trim().array
+    val dataTrim = data.trim().array
+    val edgeArray = Array(srcIdsTrim, dstIdsTrim, dataTrim)
+    // TODO: sort three arrays simultaneously based on srcIds
+    val sorter = ParallelSorter(edgeArray)
+    sorter.mergeSort(0)
+    //val sorter = Sorting.quickSort(edgeArray)
+    // Sorting.quickSort(edgeArray)(Edge.lexicographicOrdering)
     val index = new GraphXPrimitiveKeyOpenHashMap[VertexId, Int]
     // Copy edges into columnar structures, tracking the beginnings of source vertex id clusters and
     // adding them to the index
-    if (edgeArray.length > 0) {
+    if (srcIdsTrim.length > 0) {
       index.update(srcIds(0), 0)
       var currSrcId: VertexId = srcIds(0)
       var i = 0
-      while (i < edgeArray.size) {
-        srcIds(i) = edgeArray(i).srcId
-        dstIds(i) = edgeArray(i).dstId
-        data(i) = edgeArray(i).attr
-        if (edgeArray(i).srcId != currSrcId) {
-          currSrcId = edgeArray(i).srcId
+      while (i < srcIdsTrim.size) {
+        if (srcIdsTrim(i) != currSrcId) {
+          currSrcId = srcIdsTrim(i)
           index.update(currSrcId, i)
         }
         i += 1
@@ -61,12 +67,12 @@ class EdgePartitionBuilder[@specialized(Long, Int, Double) ED: ClassTag, VD: Cla
     }
 
     // Create and populate a VertexPartition with vids from the edges, but no attributes
-    val vidsIter = srcIds.iterator ++ dstIds.iterator
+    val vidsIter = srcIdsTrim.iterator ++ dstIdsTrim.iterator
     val vertexIds = new OpenHashSet[VertexId]
     vidsIter.foreach(vid => vertexIds.add(vid))
     val vertices = new VertexPartition(
       vertexIds, new Array[VD](vertexIds.capacity), vertexIds.getBitSet)
 
-    new EdgePartition(srcIds, dstIds, data, index, vertices)
+    new EdgePartition(srcIdsTrim, dstIdsTrim, dataTrim, index, vertices)
   }
 }

--- a/graphx/src/test/scala/org/apache/spark/graphx/impl/EdgePartitionSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/impl/EdgePartitionSuite.scala
@@ -72,8 +72,9 @@ class EdgePartitionSuite extends FunSuite {
 
   test("groupEdges") {
     val edges = List(
-      Edge(0, 1, 1), Edge(1, 2, 2), Edge(2, 0, 4), Edge(0, 1, 8), Edge(1, 2, 16), Edge(2, 0, 32))
-    val groupedEdges = List(Edge(0, 1, 9), Edge(1, 2, 18), Edge(2, 0, 36))
+      Edge(0, 1, 1), Edge(1, 2, 2), Edge(1, 3, 1), Edge(2, 0, 4), Edge(0, 1, 8), Edge(1, 2, 16),
+      Edge(2, 0, 32))
+    val groupedEdges = List(Edge(0, 1, 9), Edge(1, 2, 18), Edge(1, 3, 1), Edge(2, 0, 36))
     val builder = new EdgePartitionBuilder[Int, Nothing]
     for (e <- edges) {
       builder.add(e.srcId, e.dstId, e.attr)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-1987
To save overhead of Edge objects, separate an array of Edge objects into three arrays of srdId, dstId and data, for later EdgePartition(srcIdsTrim, dstIdsTrim, dataTrim, index, vertices).
To sort arrays directly, I use [ParallelSorter](http://cglib.sourceforge.net/apidocs/net/sf/cglib/ParallelSorter.html) from mockito.cglib 

Can't compile at the moment and I don't really know to solve.

```
[info] Compiling 8 Scala sources to /home/xd/Developer/spark/graphx/target/scala-2.10/classes...
[error] /home/xd/Developer/spark/graphx/src/main/scala/org/apache/spark/graphx/impl/EdgePartitionBuilder.scala:49: type mismatch;
[error]  found   : Array[Array[_ >: ED with Long]]
[error]  required: Array[Object]
[error] Note: Array[_ >: ED with Long] <: Object, but class Array is invariant in type T.
[error] You may wish to investigate a wildcard type such as `_ <: Object`. (SLS 3.2.10)
[error]     val sorter = ParallelSorter.create(edgeArray)
[error]                                        ^
[error] one error found
[error] (graphx/compile:compile) Compilation failed
[error] Total time: 5 s, completed Sep 18, 2014 9:01:14 PM
```
