### PR TITLE
[SPARK-3592] [SQL] [PySpark] support applySchema to RDD of Row

### DIFF
--- a/python/pyspark/sql.py
+++ b/python/pyspark/sql.py
@@ -687,19 +687,19 @@ def _infer_schema_type(obj, dataType):
 
 
 _acceptable_types = {
-    BooleanType: bool,
+    BooleanType: (bool,),
     ByteType: (int, long),
     ShortType: (int, long),
     IntegerType: (int, long),
     LongType: (int, long),
-    FloatType: float,
-    DoubleType: float,
-    DecimalType: decimal.Decimal,
+    FloatType: (float,),
+    DoubleType: (float,),
+    DecimalType: (decimal.Decimal,),
     StringType: (str, unicode),
-    BinaryType: bytearray,
-    TimestampType: datetime.datetime,
+    BinaryType: (bytearray,),
+    TimestampType: (datetime.datetime,),
     ArrayType: (list, tuple, array),
-    MapType: dict,
+    MapType: (dict,),
     StructType: (tuple, list),
 }
 

--- a/python/pyspark/sql.py
+++ b/python/pyspark/sql.py
@@ -440,6 +440,7 @@ _type_mappings = {
     float: DoubleType,
     str: StringType,
     unicode: StringType,
+    bytearray: BinaryType,
     decimal.Decimal: DecimalType,
     datetime.datetime: TimestampType,
     datetime.date: TimestampType,
@@ -685,19 +686,21 @@ def _infer_schema_type(obj, dataType):
         raise ValueError("Unexpected dataType: %s" % dataType)
 
 
+# including subclasses
 _acceptable_types = {
-    BooleanType: (bool,),
+    BooleanType: bool,
     ByteType: (int, long),
     ShortType: (int, long),
     IntegerType: (int, long),
-    LongType: (long,),
-    FloatType: (float,),
-    DoubleType: (float,),
-    DecimalType: (decimal.Decimal,),
+    LongType: (int, long),
+    FloatType: float,
+    DoubleType: float,
+    DecimalType: decimal.Decimal,
     StringType: (str, unicode),
-    TimestampType: (datetime.datetime,),
+    BinaryType: bytearray,
+    TimestampType: datetime.datetime,
     ArrayType: (list, tuple, array),
-    MapType: (dict,),
+    MapType: dict,
     StructType: (tuple, list),
 }
 
@@ -728,10 +731,9 @@ def _verify_type(obj, dataType):
         return
 
     _type = type(dataType)
-    if _type not in _acceptable_types:
-        return
+    assert _type in _acceptable_types, "unkown datatype: %s" % dataType
 
-    if type(obj) not in _acceptable_types[_type]:
+    if not isinstance(obj, _acceptable_types[_type]):
         raise TypeError("%s can not accept abject in type %s"
                         % (dataType, type(obj)))
 

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -45,7 +45,7 @@ from pyspark.files import SparkFiles
 from pyspark.serializers import read_int, BatchedSerializer, MarshalSerializer, PickleSerializer, \
     CloudPickleSerializer
 from pyspark.shuffle import Aggregator, InMemoryMerger, ExternalMerger, ExternalSorter
-from pyspark.sql import SQLContext, IntegerType
+from pyspark.sql import SQLContext, IntegerType, Row
 from pyspark import shuffle
 
 _have_scipy = False
@@ -657,6 +657,10 @@ class TestSQL(PySparkTestCase):
         srdd = self.sqlCtx.jsonRDD(self.sc.parallelize(["""{"a":2}"""]))
         srdd2 = self.sqlCtx.applySchema(srdd.map(lambda x: x), srdd.schema())
         self.assertEqual(srdd.collect(), srdd2.collect())
+
+        rdd = self.sc.parallelize(range(10)).map(lambda x: Row(a=x))
+        srdd3 = self.sqlCtx.applySchema(rdd, srdd.schema())
+        self.assertEqual(10, srdd3.count())
 
 
 class TestIO(PySparkTestCase):

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -653,6 +653,11 @@ class TestSQL(PySparkTestCase):
         self.assertEquals(result.getNumPartitions(), 5)
         self.assertEquals(result.count(), 3)
 
+    def test_apply_schema_to_row(self):
+        srdd = self.sqlCtx.jsonRDD(self.sc.parallelize(["""{"a":2}"""]))
+        srdd2 = self.sqlCtx.applySchema(srdd.map(lambda x: x), srdd.schema())
+        self.assertEqual(srdd.collect(), srdd2.collect())
+
 
 class TestIO(PySparkTestCase):
 


### PR DESCRIPTION
Fix the issue when applySchema() to an RDD of Row.

Also add type mapping for BinaryType.
