### PR TITLE
[SPARK-3609][SQL] Adds sizeInBytes statistics for Limit operator when all output attributes are of native data types

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/dataTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/dataTypes.scala
@@ -122,6 +122,16 @@ object NativeType {
     IntegerType, BooleanType, LongType, DoubleType, FloatType, ShortType, ByteType, StringType)
 
   def unapply(dt: DataType): Boolean = all.contains(dt)
+
+  val defaultSizeOf: Map[NativeType, Int] = Map(
+    IntegerType -> 4,
+    BooleanType -> 1,
+    LongType -> 8,
+    DoubleType -> 8,
+    FloatType -> 4,
+    ShortType -> 2,
+    ByteType -> 1,
+    StringType -> 4096)
 }
 
 trait PrimitiveType extends DataType {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -686,8 +686,6 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll {
     val broadcastHashJoin = query.collect { case join: BroadcastHashJoin => join }
     val shuffledHashJoin = query.collect { case join: ShuffledHashJoin => join }
 
-    println(query)
-
     assert(shuffledHashJoin.isEmpty, "Should not use shuffled hash join")
     assert(broadcastHashJoin.nonEmpty, "Should use broadcast hash join")
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -674,19 +674,4 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll {
       sql("SELECT CAST(TRUE AS STRING), CAST(FALSE AS STRING) FROM testData LIMIT 1"),
       ("true", "false") :: Nil)
   }
-
-  test("Limit sizeInBytes estimation") {
-    // Using a threshold that is guaranteed greater than the tiny table used below
-    setConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD, 8192.toString)
-
-    table("testData").limit(1).registerTempTable("tiny")
-    val query = sql("SELECT a.key, b.value FROM testData a INNER JOIN tiny b ON a.key = b.key")
-      .queryExecution.executedPlan
-
-    val broadcastHashJoin = query.collect { case join: BroadcastHashJoin => join }
-    val shuffledHashJoin = query.collect { case join: ShuffledHashJoin => join }
-
-    assert(shuffledHashJoin.isEmpty, "Should not use shuffled hash join")
-    assert(broadcastHashJoin.nonEmpty, "Should use broadcast hash join")
-  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -22,7 +22,7 @@ import org.scalatest.FunSuite
 import org.apache.spark.sql.TestData._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans._
-import org.apache.spark.sql.execution
+import org.apache.spark.sql.{SQLConf, execution}
 import org.apache.spark.sql.test.TestSQLContext._
 import org.apache.spark.sql.test.TestSQLContext.planner._
 
@@ -56,5 +56,23 @@ class PlannerSuite extends FunSuite {
       testData.groupBy('value)(Count('value), CountDistinct('key :: Nil)).queryExecution.analyzed
     val planned = HashAggregation(query)
     assert(planned.nonEmpty)
+  }
+
+  test("sizeInBytes estimation of limit operator for broadcast hash join optimization") {
+    val origThreshold = autoBroadcastJoinThreshold
+    setConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD, 81920.toString)
+
+    // Using a threshold that is definitely larger than the small testing table (b) below
+    val a = testData.as('a)
+    val b = testData.limit(3).as('b)
+    val planned = a.join(b, Inner, Some("a.key".attr === "b.key".attr)).queryExecution.executedPlan
+
+    val broadcastHashJoins = planned.collect { case join: BroadcastHashJoin => join }
+    val shuffledHashJoins = planned.collect { case join: ShuffledHashJoin => join }
+
+    assert(broadcastHashJoins.size === 1, "Should use broadcast hash join")
+    assert(shuffledHashJoins.isEmpty, "Should not use shuffled hash join")
+
+    setConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD, origThreshold.toString)
   }
 }


### PR DESCRIPTION
This helps to replace shuffled hash joins with broadcast hash joins in some cases.
