### PR TITLE
[Build] SPARK-3624: Failed to find Spark assembly in /usr/share/spark/lib...

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -263,7 +263,7 @@
           <plugin>
             <groupId>org.vafer</groupId>
             <artifactId>jdeb</artifactId>
-            <version>0.11</version>
+            <version>1.3</version>
             <executions>
               <execution>
                 <phase>package</phase>
@@ -274,6 +274,7 @@
                   <deb>${project.build.directory}/${deb.pkg.name}_${project.version}-${buildNumber}_all.deb</deb>
                   <attach>false</attach>
                   <compression>gzip</compression>
+                  <skipPOMs>false</skipPOMs>
                   <dataSet>
                     <data>
                       <src>${spark.jar}</src>
@@ -294,6 +295,12 @@
                         <group>${deb.user}</group>
                         <prefix>${deb.install.path}</prefix>
                       </mapper>
+                    </data>
+                    <data>
+                      <type>link</type>
+                      <symlink>true</symlink>
+                      <linkName>${deb.install.path}/lib</linkName>
+                      <linkTarget>${deb.install.path}/jars</linkTarget>
                     </data>
                     <data>
                       <src>${basedir}/../conf</src>


### PR DESCRIPTION
Define a 'lib' symlink like this:

```
lib -> /usr/share/spark/jars
```

This required jdeb maven plugin update from version 0.11 to 1.3
