### PR TITLE
[SPARK-3580] add 'partitions' property to PySpark RDD

### DIFF
--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -120,6 +120,10 @@ class RDD(object):
     operated on in parallel.
     """
 
+    @property
+    def partitions(self):
+        return self._jrdd.partitions()
+
     def __init__(self, jrdd, ctx, jrdd_deserializer):
         self._jrdd = jrdd
         self.is_cached = False
@@ -287,7 +291,7 @@ class RDD(object):
         >>> rdd.getNumPartitions()
         2
         """
-        return self._jrdd.partitions().size()
+        return self.partitions.size()
 
     def filter(self, f):
         """

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -601,6 +601,12 @@ class TestRDDFunctions(PySparkTestCase):
         self.assertEquals(result.getNumPartitions(), 5)
         self.assertEquals(result.count(), 3)
 
+    def test_partitions_property(self):
+        rdd = self.sc.parallelize([], 80)
+        self.assertEquals(rdd.getNumPartitions(), 80)
+        self.assertEquals(rdd.partitions.size(), 80)
+        self.assertEquals(len(rdd.partitions), 80)
+
 
 class TestSQL(PySparkTestCase):
 


### PR DESCRIPTION
'rdd.partitions' is available in scala&java, primarily used for its
size() method to get the number of partitions. pyspark instead has a
getNumPartitions() call and no access to 'partitions'

this change adds 'partitions' to pyspark's rdd, allowing for
len(rdd.partitions) to get the number of partitions in a way familiar
to python developers
