### PR TITLE
[SPARK-3626] [WIP] Replace AsyncRDDActions with a more general runAsync() mechanism

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1144,6 +1144,38 @@ class SparkContext(config: SparkConf) extends Logging {
   }
 
   /**
+   * Start an asynchronous computation that may launch Spark jobs.
+   * Returns a `FutureAction` object that contains the result of the computation and allows the
+   * computation to be cancelled.
+   *
+   * @tparam T            the type of the result
+   * @param jobGroupId    the job group for Spark jobs launched by this computation
+   * @param description   a description of the job group
+   * @param body          the asynchronous computation
+   * @return              the `FutureAction` holding the result of the computation
+   */
+  def runAsync[T](jobGroupId: String,
+                  description: String)
+                 (body: => T): FutureAction[T] = {
+    new RunAsyncResult[T](jobGroupId, description, this, body)
+  }
+
+  /**
+   * Start an asynchronous computation that may launch Spark jobs.
+   * Returns a `FutureAction` object that contains the result of the computation and allows the
+   * computation to be cancelled.
+   *
+   * All Spark jobs launched by this computation will be created in the same (anonymous) job group.
+   *
+   * @tparam T            the type of the result
+   * @param body          the asynchronous computation
+   * @return              the `FutureAction` holding the result of the computation
+   */
+  def runAsync[T](body: => T): FutureAction[T] = {
+    runAsync(s"RunAsync${UUID.randomUUID().toString}", "Anonymous runAsync job")(body)
+  }
+
+  /**
    * :: DeveloperApi ::
    * Run a job that can return approximate results.
    */

--- a/core/src/main/scala/org/apache/spark/rdd/AsyncRDDActions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/AsyncRDDActions.scala
@@ -17,13 +17,9 @@
 
 package org.apache.spark.rdd
 
-import java.util.concurrent.atomic.AtomicLong
-
-import scala.collection.mutable.ArrayBuffer
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.reflect.ClassTag
 
-import org.apache.spark.{ComplexFutureAction, FutureAction, Logging}
+import org.apache.spark.{FutureAction, Logging}
 import org.apache.spark.annotation.Experimental
 
 /**
@@ -38,90 +34,44 @@ class AsyncRDDActions[T: ClassTag](self: RDD[T]) extends Serializable with Loggi
    * Returns a future for counting the number of elements in the RDD.
    */
   def countAsync(): FutureAction[Long] = {
-    val totalCount = new AtomicLong
-    self.context.submitJob(
-      self,
-      (iter: Iterator[T]) => {
-        var result = 0L
-        while (iter.hasNext) {
-          result += 1L
-          iter.next()
-        }
-        result
-      },
-      Range(0, self.partitions.size),
-      (index: Int, data: Long) => totalCount.addAndGet(data),
-      totalCount.get())
+    self.sparkContext.runAsync {
+      self.count()
+    }
   }
 
   /**
    * Returns a future for retrieving all elements of this RDD.
    */
   def collectAsync(): FutureAction[Seq[T]] = {
-    val results = new Array[Array[T]](self.partitions.size)
-    self.context.submitJob[T, Array[T], Seq[T]](self, _.toArray, Range(0, self.partitions.size),
-      (index, data) => results(index) = data, results.flatten.toSeq)
+    self.sparkContext.runAsync {
+      self.collect()
+    }
   }
 
   /**
    * Returns a future for retrieving the first num elements of the RDD.
    */
   def takeAsync(num: Int): FutureAction[Seq[T]] = {
-    val f = new ComplexFutureAction[Seq[T]]
-
-    f.run {
-      val results = new ArrayBuffer[T](num)
-      val totalParts = self.partitions.length
-      var partsScanned = 0
-      while (results.size < num && partsScanned < totalParts) {
-        // The number of partitions to try in this iteration. It is ok for this number to be
-        // greater than totalParts because we actually cap it at totalParts in runJob.
-        var numPartsToTry = 1
-        if (partsScanned > 0) {
-          // If we didn't find any rows after the first iteration, just try all partitions next.
-          // Otherwise, interpolate the number of partitions we need to try, but overestimate it
-          // by 50%.
-          if (results.size == 0) {
-            numPartsToTry = totalParts - 1
-          } else {
-            numPartsToTry = (1.5 * num * partsScanned / results.size).toInt
-          }
-        }
-        numPartsToTry = math.max(0, numPartsToTry)  // guard against negative num of partitions
-
-        val left = num - results.size
-        val p = partsScanned until math.min(partsScanned + numPartsToTry, totalParts)
-
-        val buf = new Array[Array[T]](p.size)
-        f.runJob(self,
-          (it: Iterator[T]) => it.take(left).toArray,
-          p,
-          (index: Int, data: Array[T]) => buf(index) = data,
-          Unit)
-
-        buf.foreach(results ++= _.take(num - results.size))
-        partsScanned += numPartsToTry
-      }
-      results.toSeq
+    self.sparkContext.runAsync {
+      self.take(num)
     }
-
-    f
   }
 
   /**
    * Applies a function f to all elements of this RDD.
    */
   def foreachAsync(f: T => Unit): FutureAction[Unit] = {
-    val cleanF = self.context.clean(f)
-    self.context.submitJob[T, Unit, Unit](self, _.foreach(cleanF), Range(0, self.partitions.size),
-      (index, data) => Unit, Unit)
+    self.sparkContext.runAsync {
+      self.foreach(f)
+    }
   }
 
   /**
    * Applies a function f to each partition of this RDD.
    */
   def foreachPartitionAsync(f: Iterator[T] => Unit): FutureAction[Unit] = {
-    self.context.submitJob[T, Unit, Unit](self, f, Range(0, self.partitions.size),
-      (index, data) => Unit, Unit)
+    self.sparkContext.runAsync {
+      self.foreachPartition(f)
+    }
   }
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -477,6 +477,10 @@ class DAGScheduler(
       resultHandler: (Int, U) => Unit,
       properties: Properties = null): JobWaiter[U] =
   {
+    if (Thread.currentThread().isInterrupted) {
+      throw new SparkException(
+        "Shouldn't submit jobs from interrupted threads (was the job cancelled?)")
+    }
     // Check to make sure we are not launching a task on a partition that does not exist.
     val maxPartitions = rdd.partitions.length
     partitions.find(p => p >= maxPartitions || p < 0).foreach { p =>
@@ -493,8 +497,11 @@ class DAGScheduler(
     assert(partitions.size > 0)
     val func2 = func.asInstanceOf[(TaskContext, Iterator[_]) => _]
     val waiter = new JobWaiter(this, jobId, partitions.size, resultHandler)
+    // Make a defensive copy of the mutable properties object (this fixes a race condition that
+    // could occur during cancellation).
+    val propertiesCopy = Option(properties).map(_.clone().asInstanceOf[Properties]).orNull
     eventProcessActor ! JobSubmitted(
-      jobId, rdd, func2, partitions.toArray, allowLocal, callSite, waiter, properties)
+      jobId, rdd, func2, partitions.toArray, allowLocal, callSite, waiter, propertiesCopy)
     waiter
   }
 
@@ -675,7 +682,7 @@ class DAGScheduler(
     // Cancel all jobs belonging to this job group.
     // First finds all active jobs with this group id, and then kill stages for them.
     val activeInGroup = activeJobs.filter(activeJob =>
-      groupId == activeJob.properties.get(SparkContext.SPARK_JOB_GROUP_ID))
+      groupId == Option(activeJob.properties).map(_.get(SparkContext.SPARK_JOB_GROUP_ID)).orNull)
     val jobIds = activeInGroup.map(_.jobId)
     jobIds.foreach(handleJobCancellation(_, "part of cancelled job group %s".format(groupId)))
     submitWaitingStages()

--- a/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
@@ -308,7 +308,9 @@ class SparkListenerSuite extends FunSuite with LocalSparkContext with Matchers
     sc.addSparkListener(listener)
 
     val numTasks = 10
-    val f = sc.parallelize(1 to 10000, numTasks).map { i => Thread.sleep(10); i }.countAsync()
+    val f = sc.runAsync {
+      sc.parallelize(1 to 10000, numTasks).map { i => Thread.sleep(10); i }.count()
+    }
     // Wait until one task has started (because we want to make sure that any tasks that are started
     // have corresponding end events sent to the listener).
     var finishTime = System.currentTimeMillis + WAIT_TIMEOUT_MILLIS


### PR DESCRIPTION
### Background

The `AsyncRDDActions` methods were introduced in e33b1839e27249e232a2126cec67a38109e03243, the first pull request to add support for job cancelation.  A follow pull request, 599dcb0ddf740e028cc8faac163303be8f9400a6, added cancelation on a per-job-group basis.  Quoting from that PR:

> This PR adds a simple API to group together a set of jobs belonging to a thread and threads spawned from it. It also allows the cancellation of all jobs in this group.
> 
> ```
> An example:
> 
>     sc.setJobDescription("this_is_the_group_id", "some job description")
>     sc.parallelize(1 to 10000, 2).map { i => Thread.sleep(10); i }.count()
> 
> In a separate thread:
> 
>     sc.cancelJobGroup("this_is_the_group_id")
> ```

In its current form, `AsyncRDDActions` seems to serve no purpose other than to enable job cancelation.  `AsyncRDDActions` is marked as `@Experimental`, so users may be reluctant to depend on it.  If we add new actions, then we also have to add asynchronous versions of those actions, creating a maintenance burden.
### Proposal

I propose that we remove `AsyncRDDActions` and use job groups as the only user-facing API for job cancelation.  To make job groups more convenient for users, this pull request adds a `runAsync` method to SparkContext that makes it easy to run an asynchronous computation in a particular Spark job group.  For example:

``` scala
// Instead of countAsync(), we call the regular actions from a runAsync block:
val futureCount: RunAsyncResult[Long] = sc.runAsync {
   sc.parallelize(...).map(...).count()
}

// This returns a Future:
futureCount.onSuccess(c => println(s"Got count $c!"))

// The future also supports cancellation
futureCount.cancel()

// This also works with blocks that call multiple actions (e.g. an iterative ML algorithm)
val futureResult = sc.runAsync {
   val rdd = sc.parallelize(...)
   val count = rdd.count()
   val first = rdd.first()
   first  // this is the result of the block
} 
```

I refactored `JobCancellationSuite` to use this new API instead of AsyncRDDActions; see that file for more examples.
### TODOS / tasks to finish before merging:

This is marked as [WIP] since there are still a number of tasks that need to be finished before this is merge-worthy:
- [ ] Add a Java interface for this; it can probably be an extension of `Runnable`.
- [ ] Extend `RunAsyncResult` to expose the job ids of jobs launched from its computation (see [SPARK-3446](https://issues.apache.org/jira/browse/SPARK-3446) / #2337).
- [ ] The thread-safety concerns here are somewhat complicated; add more comments.
- [ ] Explain the caveats with job-group-based cancellation:
  - Having multiple threads submitting jobs in the same job group may lead to confusing behavior.
  - Recursive runAsync() calls may have undefined / confusing behavior.
- [ ] Look through AsyncRDDActionsSuite to see whether there are any tests that need to be re-added for these APIs.
- [ ] Add example uses in the Spark examples subproject, since it may not be obvious how to use this.
- [ ] Fix the tests in CancellationSuite to fail for more subtly-incorrect cases.  While working on this PR, I found a few cases where this test suite could still pass despite cancellation being broken.  I need to extend this suite to ensure that the jobs that are cancelled never actually complete and that jobs scheduled after cancellations launch in a short period of time.  If the cancellation doesn't work, then the current test suite will run very slowly but still pass.
- [ ] Currently we run computations in new threads; should we use execution contexts for this?  How does this interact with thread locals?  We don't want to accidentally leave thread locals set on threads that will be re-used, since this could lead to the wrong job groups being set.
