### PR TITLE
SPARK-3638 | Forced a compatible version of http client in kinesis-asl profile

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -347,5 +347,15 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>kinesis-asl</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+          <version>${commons.httpclient.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 </project>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -43,6 +43,11 @@
           <artifactId>spark-streaming-kinesis-asl_${scala.binary.version}</artifactId>
           <version>${project.version}</version>
         </dependency>
+        <dependency>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+          <version>${commons.httpclient.version}</version>
+       </dependency>
       </dependencies>
     </profile>
   </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,7 @@
     <jets3t.version>0.7.1</jets3t.version>
     <aws.java.sdk.version>1.8.3</aws.java.sdk.version>
     <aws.kinesis.client.version>1.1.0</aws.kinesis.client.version>
+    <commons.httpclient.version>4.2</commons.httpclient.version>
 
     <PermGen>64m</PermGen>
     <MaxPermGen>512m</MaxPermGen>


### PR DESCRIPTION
Note that this is a temporary fix and will work until AWS releases a newer version of SDK that uses a newer version of httpclient
