### PR TITLE
[SPARK-3614][MLLIB] Add minimumOccurence filtering to IDF

### DIFF
--- a/docs/mllib-feature-extraction.md
+++ b/docs/mllib-feature-extraction.md
@@ -85,14 +85,14 @@ val tfidf: RDD[Vector] = idf.transform(tf)
 
 MLLib's IDF implementation provides an option for ignoring terms which occur in less than a
 minimum number of documents.  In such cases, the IDF for these terms is set to 0.  This feature
-can be used by passing the `minimumOccurence` value to the IDF constructor.
+can be used by passing the `minDocFreq` value to the IDF constructor.
 
 {% highlight scala %}
 import org.apache.spark.mllib.feature.IDF
 
 // ... continue from the previous example
 tf.cache()
-val idf = new IDF(minimumOccurence=2).fit(tf)
+val idf = new IDF(minDocFreq=2).fit(tf)
 val tfidf: RDD[Vector] = idf.transform(tf)
 {% endhighlight %}
 

--- a/docs/mllib-feature-extraction.md
+++ b/docs/mllib-feature-extraction.md
@@ -82,6 +82,21 @@ tf.cache()
 val idf = new IDF().fit(tf)
 val tfidf: RDD[Vector] = idf.transform(tf)
 {% endhighlight %}
+
+MLLib's IDF implementation provides an option for ignoring terms which occur in less than a
+minimum number of documents.  In such cases, the IDF for these terms is set to 0.  This feature
+can be used by passing the `minimumOccurence` value to the IDF constructor.
+
+{% highlight scala %}
+import org.apache.spark.mllib.feature.IDF
+
+// ... continue from the previous example
+tf.cache()
+val idf = new IDF(minimumOccurence=2).fit(tf)
+val tfidf: RDD[Vector] = idf.transform(tf)
+{% endhighlight %}
+
+
 </div>
 </div>
 

--- a/docs/mllib-feature-extraction.md
+++ b/docs/mllib-feature-extraction.md
@@ -92,7 +92,7 @@ import org.apache.spark.mllib.feature.IDF
 
 // ... continue from the previous example
 tf.cache()
-val idf = new IDF(minDocFreq=2).fit(tf)
+val idf = new IDF(minDocFreq = 2).fit(tf)
 val tfidf: RDD[Vector] = idf.transform(tf)
 {% endhighlight %}
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
@@ -78,7 +78,7 @@ private object IDF {
     private var df: BDV[Long] = _
 
 
-   def this() = this(0);
+   def this() = this(0)
 
     /** Adds a new document. */
     def add(doc: Vector): this.type = {

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
@@ -79,6 +79,9 @@ private object IDF {
     /** document frequency vector */
     private var df: BDV[Long] = _
 
+
+   def this() = this(0L);
+
     /** Adds a new document. */
     def add(doc: Vector): this.type = {
       if (isEmpty) {

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
@@ -139,11 +139,12 @@ private object IDF {
          * number of documents, set IDF to 0. This
          * will cause multiplication in IDFModel to
          * set TF-IDF to 0.
+         *
+         * Since arrays are initialized to 0 by default,
+         * we just omit changing those entries.
          */
         if(df(j) >= minimumOccurence) {
           inv(j) = math.log((m + 1.0)/ (df(j) + 1.0))
-        } else {
-          inv(j) = 0.0
         }
         j += 1
       }

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
@@ -37,8 +37,6 @@ import org.apache.spark.rdd.RDD
  *
  * @param minimumOccurence minimum of documents in which a term
  *                         should appear for filtering
- *
- *
  */
 @Experimental
 class IDF(val minimumOccurence: Long) {

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
@@ -41,7 +41,7 @@ import org.apache.spark.rdd.RDD
  *
  */
 @Experimental
-class IDF(minimumOccurence: Long) {
+class IDF(val minimumOccurence: Long) {
 
   def this() = this(0L)
 
@@ -71,7 +71,7 @@ class IDF(minimumOccurence: Long) {
 private object IDF {
 
   /** Document frequency aggregator. */
-  class DocumentFrequencyAggregator(minimumOccurence: Long) extends Serializable {
+  class DocumentFrequencyAggregator(val minimumOccurence: Long) extends Serializable {
 
     /** number of documents */
     private var m = 0L

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
@@ -52,7 +52,8 @@ class IDF(val minimumOccurence: Long) {
    * @param dataset an RDD of term frequency vectors
    */
   def fit(dataset: RDD[Vector]): IDFModel = {
-    val idf = dataset.treeAggregate(new IDF.DocumentFrequencyAggregator(minimumOccurence=minimumOccurence))(
+    val idf = dataset.treeAggregate(new IDF.DocumentFrequencyAggregator(
+          minimumOccurence=minimumOccurence))(
       seqOp = (df, v) => df.add(v),
       combOp = (df1, df2) => df1.merge(df2)
     ).idf()

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
@@ -39,9 +39,9 @@ import org.apache.spark.rdd.RDD
  *                         should appear for filtering
  */
 @Experimental
-class IDF(val minimumOccurence: Long) {
+class IDF(val minimumOccurence: Int) {
 
-  def this() = this(0L)
+  def this() = this(0)
 
   // TODO: Allow different IDF formulations.
 
@@ -70,7 +70,7 @@ class IDF(val minimumOccurence: Long) {
 private object IDF {
 
   /** Document frequency aggregator. */
-  class DocumentFrequencyAggregator(val minimumOccurence: Long) extends Serializable {
+  class DocumentFrequencyAggregator(val minimumOccurence: Int) extends Serializable {
 
     /** number of documents */
     private var m = 0L
@@ -78,7 +78,7 @@ private object IDF {
     private var df: BDV[Long] = _
 
 
-   def this() = this(0L);
+   def this() = this(0);
 
     /** Adds a new document. */
     def add(doc: Vector): this.type = {

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
@@ -78,7 +78,7 @@ private object IDF {
     private var df: BDV[Long] = _
 
 
-   def this() = this(0)
+    def this() = this(0)
 
     /** Adds a new document. */
     def add(doc: Vector): this.type = {

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
@@ -146,7 +146,7 @@ private object IDF {
          * we just omit changing those entries.
          */
         if(df(j) >= minDocFreq) {
-          inv(j) = math.log((m + 1.0)/ (df(j) + 1.0))
+          inv(j) = math.log((m + 1.0) / (df(j) + 1.0))
         }
         j += 1
       }

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
@@ -51,7 +51,7 @@ class IDF(val minDocFreq: Int) {
    */
   def fit(dataset: RDD[Vector]): IDFModel = {
     val idf = dataset.treeAggregate(new IDF.DocumentFrequencyAggregator(
-          minDocFreq=minDocFreq))(
+          minDocFreq = minDocFreq))(
       seqOp = (df, v) => df.add(v),
       combOp = (df1, df2) => df1.merge(df2)
     ).idf()

--- a/mllib/src/test/java/org/apache/spark/mllib/feature/JavaTfIdfSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/feature/JavaTfIdfSuite.java
@@ -27,6 +27,8 @@ import org.junit.Before;
 import org.junit.Test;
 import com.google.common.collect.Lists;
 
+import java.lang.reflect.Method;
+
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.mllib.linalg.Vector;
@@ -63,4 +65,24 @@ public class JavaTfIdfSuite implements Serializable {
       Assert.assertEquals(0.0, v.apply(indexOfThis), 1e-15);
     }
   }
+
+  @Test
+  public void tfIdfMinimumOccurence() {
+    // The tests are to check Java compatibility.
+    HashingTF tf = new HashingTF();
+    JavaRDD<ArrayList<String>> documents = sc.parallelize(Lists.newArrayList(
+      Lists.newArrayList("this is a sentence".split(" ")),
+      Lists.newArrayList("this is another sentence".split(" ")),
+      Lists.newArrayList("this is still a sentence".split(" "))), 2);
+    JavaRDD<Vector> termFreqs = tf.transform(documents);
+    termFreqs.collect();
+    IDF idf = new IDF(2);
+    JavaRDD<Vector> tfIdfs = idf.fit(termFreqs).transform(termFreqs);
+    List<Vector> localTfIdfs = tfIdfs.collect();
+    int indexOfThis = tf.indexOf("this");
+    for (Vector v: localTfIdfs) {
+      Assert.assertEquals(0.0, v.apply(indexOfThis), 1e-15);
+    }
+  }
+
 }

--- a/mllib/src/test/java/org/apache/spark/mllib/feature/JavaTfIdfSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/feature/JavaTfIdfSuite.java
@@ -27,8 +27,6 @@ import org.junit.Before;
 import org.junit.Test;
 import com.google.common.collect.Lists;
 
-import java.lang.reflect.Method;
-
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.mllib.linalg.Vector;

--- a/mllib/src/test/java/org/apache/spark/mllib/feature/JavaTfIdfSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/feature/JavaTfIdfSuite.java
@@ -65,7 +65,7 @@ public class JavaTfIdfSuite implements Serializable {
   }
 
   @Test
-  public void tfIdfMinimumOccurence() {
+  public void tfIdfMinimumDocumentFrequency() {
     // The tests are to check Java compatibility.
     HashingTF tf = new HashingTF();
     JavaRDD<ArrayList<String>> documents = sc.parallelize(Lists.newArrayList(

--- a/mllib/src/test/scala/org/apache/spark/mllib/feature/IDFSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/feature/IDFSuite.scala
@@ -54,4 +54,38 @@ class IDFSuite extends FunSuite with LocalSparkContext {
     assert(tfidf2.indices === Array(1))
     assert(tfidf2.values(0) ~== (1.0 * expected(1)) absTol 1e-12)
   }
+
+  test("idf minimum occurence filtering") {
+    val n = 4
+    val localTermFrequencies = Seq(
+      Vectors.sparse(n, Array(1, 3), Array(1.0, 2.0)),
+      Vectors.dense(0.0, 1.0, 2.0, 3.0),
+      Vectors.sparse(n, Array(1), Array(1.0))
+    )
+    val m = localTermFrequencies.size
+    val termFrequencies = sc.parallelize(localTermFrequencies, 2)
+    val idf = new IDF(minimumOccurence=1L)
+    val model = idf.fit(termFrequencies)
+    val expected = Vectors.dense(Array(0, 3, 1, 2).map { x =>
+      if(x > 0) {
+        math.log((m.toDouble + 1.0) / (x + 1.0))
+      } else {
+        0
+      }
+    })
+    assert(model.idf ~== expected absTol 1e-12)
+    val tfidf = model.transform(termFrequencies).cache().zipWithIndex().map(_.swap).collectAsMap()
+    assert(tfidf.size === 3)
+    val tfidf0 = tfidf(0L).asInstanceOf[SparseVector]
+    assert(tfidf0.indices === Array(1, 3))
+    assert(Vectors.dense(tfidf0.values) ~==
+      Vectors.dense(1.0 * expected(1), 2.0 * expected(3)) absTol 1e-12)
+    val tfidf1 = tfidf(1L).asInstanceOf[DenseVector]
+    assert(Vectors.dense(tfidf1.values) ~==
+      Vectors.dense(0.0, 1.0 * expected(1), 2.0 * expected(2), 3.0 * expected(3)) absTol 1e-12)
+    val tfidf2 = tfidf(2L).asInstanceOf[SparseVector]
+    assert(tfidf2.indices === Array(1))
+    assert(tfidf2.values(0) ~== (1.0 * expected(1)) absTol 1e-12)
+  }
+
 }

--- a/mllib/src/test/scala/org/apache/spark/mllib/feature/IDFSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/feature/IDFSuite.scala
@@ -64,7 +64,7 @@ class IDFSuite extends FunSuite with LocalSparkContext {
     )
     val m = localTermFrequencies.size
     val termFrequencies = sc.parallelize(localTermFrequencies, 2)
-    val idf = new IDF(minimumOccurence=1L)
+    val idf = new IDF(minimumOccurence=1)
     val model = idf.fit(termFrequencies)
     val expected = Vectors.dense(Array(0, 3, 1, 2).map { x =>
       if(x > 0) {

--- a/mllib/src/test/scala/org/apache/spark/mllib/feature/IDFSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/feature/IDFSuite.scala
@@ -38,7 +38,7 @@ class IDFSuite extends FunSuite with LocalSparkContext {
     val idf = new IDF
     val model = idf.fit(termFrequencies)
     val expected = Vectors.dense(Array(0, 3, 1, 2).map { x =>
-      math.log((m.toDouble + 1.0) / (x + 1.0))
+      math.log((m + 1.0) / (x + 1.0))
     })
     assert(model.idf ~== expected absTol 1e-12)
     val tfidf = model.transform(termFrequencies).cache().zipWithIndex().map(_.swap).collectAsMap()
@@ -68,7 +68,7 @@ class IDFSuite extends FunSuite with LocalSparkContext {
     val model = idf.fit(termFrequencies)
     val expected = Vectors.dense(Array(0, 3, 1, 2).map { x =>
       if (x > 0) {
-        math.log((m.toDouble + 1.0) / (x + 1.0))
+        math.log((m + 1.0) / (x + 1.0))
       } else {
         0
       }

--- a/mllib/src/test/scala/org/apache/spark/mllib/feature/IDFSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/feature/IDFSuite.scala
@@ -64,7 +64,7 @@ class IDFSuite extends FunSuite with LocalSparkContext {
     )
     val m = localTermFrequencies.size
     val termFrequencies = sc.parallelize(localTermFrequencies, 2)
-    val idf = new IDF(minDocFreq=1)
+    val idf = new IDF(minDocFreq = 1)
     val model = idf.fit(termFrequencies)
     val expected = Vectors.dense(Array(0, 3, 1, 2).map { x =>
       if(x > 0) {

--- a/mllib/src/test/scala/org/apache/spark/mllib/feature/IDFSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/feature/IDFSuite.scala
@@ -67,7 +67,7 @@ class IDFSuite extends FunSuite with LocalSparkContext {
     val idf = new IDF(minDocFreq = 1)
     val model = idf.fit(termFrequencies)
     val expected = Vectors.dense(Array(0, 3, 1, 2).map { x =>
-      if(x > 0) {
+      if (x > 0) {
         math.log((m.toDouble + 1.0) / (x + 1.0))
       } else {
         0

--- a/mllib/src/test/scala/org/apache/spark/mllib/feature/IDFSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/feature/IDFSuite.scala
@@ -55,7 +55,7 @@ class IDFSuite extends FunSuite with LocalSparkContext {
     assert(tfidf2.values(0) ~== (1.0 * expected(1)) absTol 1e-12)
   }
 
-  test("idf minimum occurence filtering") {
+  test("idf minimum document frequency filtering") {
     val n = 4
     val localTermFrequencies = Seq(
       Vectors.sparse(n, Array(1, 3), Array(1.0, 2.0)),
@@ -64,7 +64,7 @@ class IDFSuite extends FunSuite with LocalSparkContext {
     )
     val m = localTermFrequencies.size
     val termFrequencies = sc.parallelize(localTermFrequencies, 2)
-    val idf = new IDF(minimumOccurence=1)
+    val idf = new IDF(minDocFreq=1)
     val model = idf.fit(termFrequencies)
     val expected = Vectors.dense(Array(0, 3, 1, 2).map { x =>
       if(x > 0) {


### PR DESCRIPTION
This PR for [SPARK-3614](https://issues.apache.org/jira/browse/SPARK-3614) adds functionality for filtering out terms which do not appear in at least a minimum number of documents.

This is implemented using a minimumOccurence parameter (default 0).  When terms' document frequencies are less than minimumOccurence, their IDFs are set to 0, just like when the DF is 0.  As a result, the TF-IDFs for the terms are found to be 0, as if the terms were not present in the documents.

This PR makes the following changes:
- Add a minimumOccurence parameter to the IDF and DocumentFrequencyAggregator classes.
- Create a parameter-less constructor for IDF with a default minimumOccurence value of 0 to remain backwards-compatibility with the original IDF API.
- Sets the IDFs to 0 for terms which DFs are less than minimumOccurence
- Add tests to the Spark IDFSuite and Java JavaTfIdfSuite test suites
- Updated the MLLib Feature Extraction programming guide to describe the new feature
