### PR TITLE
[SPARK-3371][SQL] Renaming a function expression with group by gives error

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
@@ -149,6 +149,7 @@ class SqlParser extends StandardTokenParsers with PackratParsers {
       grpExprs: Seq[Expression], 
       projExprs: Seq[Expression]): Seq[NamedExpression] = {
     grpExprs.zipWithIndex.map {
+      case (ne: NamedExpression, _) => ne
       case (e, i) => 
         var aliasForGrp:NamedExpression = null
         projExprs.foreach {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
@@ -143,6 +143,25 @@ class SqlParser extends StandardTokenParsers with PackratParsers {
       case (e, i) => Alias(e, s"c$i")()
     }
   }
+  
+  /** Creates the aliases to the grouping expressions */
+  protected def assignAliasesForGroups(
+      grpExprs: Seq[Expression], 
+      projExprs: Seq[Expression]): Seq[NamedExpression] = {
+    grpExprs.zipWithIndex.map {
+      case (e, i) => 
+        var aliasForGrp:NamedExpression = null
+        projExprs.foreach {
+          case Alias(pe,pi) if pe.fastEquals(e) =>  aliasForGrp = Alias(e, pi)()
+          case _ =>
+        }
+        if (aliasForGrp == null) {
+          Alias(e, s"c$i")()
+        } else {
+          aliasForGrp
+        }
+    }
+  }  
 
   protected lazy val query: Parser[LogicalPlan] = (
     select * (
@@ -166,7 +185,7 @@ class SqlParser extends StandardTokenParsers with PackratParsers {
         val withFilter = f.map(f => Filter(f, base)).getOrElse(base)
         val withProjection =
           g.map {g =>
-            Aggregate(assignAliases(g), assignAliases(p), withFilter)
+            Aggregate(assignAliasesForGroups(g,p), assignAliases(p), withFilter)
           }.getOrElse(Project(assignAliases(p), withFilter))
         val withDistinct = d.map(_ => Distinct(withProjection)).getOrElse(withProjection)
         val withHaving = h.map(h => Filter(h, withDistinct)).getOrElse(withDistinct)

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -676,7 +676,5 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll {
   test("SPARK-3371 Renaming a function expression with group by gives error") {
     registerFunction("len", (s: String) => s.length)
     checkAnswer(
-      sql("SELECT len(value) as temp FROM testData WHERE key = 1 group by len(value)"),
-      Seq(Seq("1")))
-  }    
+      sql("SELECT len(value) as temp FROM testData WHERE key = 1 group by len(value)"), 1)}    
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -672,4 +672,11 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll {
       sql("SELECT CAST(TRUE AS STRING), CAST(FALSE AS STRING) FROM testData LIMIT 1"),
       ("true", "false") :: Nil)
   }
+  
+  test("SPARK-3371 Renaming a function expression with group by gives error") {
+    registerFunction("len", (s: String) => s.length)
+    checkAnswer(
+      sql("SELECT len(value) as temp FROM testData WHERE key = 1 group by len(value)"),
+      Seq(Seq("1")))
+  }    
 }


### PR DESCRIPTION
The following code gives error.

```
sqlContext.registerFunction("len", (s: String) => s.length)
sqlContext.sql("select len(foo) as a, count(1) from t1 group by len(foo)").collect() 
```

Because SQl parser creates the aliases to the functions in grouping expressions with generated alias names. So if user gives the alias names to the functions inside projection then it does not match the generated alias name of grouping expression.
This kind of queries are working in Hive.
So the fix I have given that if user provides alias to the function in projection then don't generate alias in grouping expression,use the same alias.
