### PR TITLE
SPARK-3526 Add section about data locality to the tuning guide

### DIFF
--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -275,8 +275,8 @@ server, or b) immediately start a new task in a farther away place that requires
 
 What Spark typically does is wait a bit in the hopes that a busy CPU frees up.  Once that timeout
 expires, it starts moving the data from far away to the free CPU.  The wait timeout for fallback
-between each level can be configured individually via `spark.locality.wait.process` and
-`spark.locality.wait.node` and `spark.locality.wait.rack`, or all together via `spark.locality.wait`
+between each level can be configured individually or all together in one parameter; see the
+`spark.locality` parameters on the [configuration page](configuration.html#scheduling) for details.
 You should increase these settings if your tasks are long and see poor locality, but the default
 usually works well.
 

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -249,11 +249,11 @@ worth optimizing.
 
 ## Data Locality
 
-One of the most important principles of distributed computing is data locality.  If data and the
-code that operates on it are together than computation tends to be fast.  But if code and data are
-separated, one must move to the other.  Typically it is faster to ship serialized code from place to
-place than a chunk of data because code size is much smaller than data.  Spark builds its scheduling
-around this general principle of data locality.
+Data locality can have a major impact on the performance of Spark jobs.  If data and the code that
+operates on it are together than computation tends to be fast.  But if code and data are separated,
+one must move to the other.  Typically it is faster to ship serialized code from place to place than
+a chunk of data because code size is much smaller than data.  Spark builds its scheduling around
+this general principle of data locality.
 
 Data locality is how close data is to the code processing it.  There are several levels of
 locality based on the data's current location.  In order from closest to farthest:


### PR DESCRIPTION
cc @kayousterhout

I have a few outstanding questions from compiling this documentation:
- What's the difference between NO_PREF and ANY?  I understand the implications of the ordering but don't know what an example of each would be
- Why is NO_PREF ahead of RACK_LOCAL?  I would think it'd be better to schedule rack-local tasks ahead of no preference if you could only do one or the other.  Is the idea to wait longer and hope for the rack-local tasks to turn into node-local or better?
- Will there be a datacenter-local locality level in the future?  Apache Cassandra for example has this level
