### PR TITLE
[SPARK-732][SPARK-3628][CORE][RESUBMIT] eliminate duplicate update on accmulator

### DIFF
--- a/core/src/main/scala/org/apache/spark/Accumulators.scala
+++ b/core/src/main/scala/org/apache/spark/Accumulators.scala
@@ -254,9 +254,10 @@ private object Accumulators {
   val localAccums = Map[Thread, Map[Long, Accumulable[_, _]]]()
   var lastId: Long = 0
 
-  private val nextAccumID = new AtomicLong(0)
-
-  def newId(): Long = nextAccumID.getAndIncrement
+  def newId(): Long = synchronized {
+    lastId += 1
+    lastId
+  }
 
   def register(a: Accumulable[_, _], original: Boolean): Unit = synchronized {
     if (original) {

--- a/core/src/main/scala/org/apache/spark/Accumulators.scala
+++ b/core/src/main/scala/org/apache/spark/Accumulators.scala
@@ -252,11 +252,10 @@ private object Accumulators {
   // TODO: Use soft references? => need to make readObject work properly then
   val originals = Map[Long, Accumulable[_, _]]()
   val localAccums = Map[Thread, Map[Long, Accumulable[_, _]]]()
-  var lastId: Long = 0
 
   private val nextAccumID = new AtomicLong(0)
 
-  def newId: Long = nextAccumID.getAndIncrement
+  def newId(): Long = nextAccumID.getAndIncrement
 
   def register(a: Accumulable[_, _], original: Boolean): Unit = synchronized {
     if (original) {

--- a/core/src/main/scala/org/apache/spark/Accumulators.scala
+++ b/core/src/main/scala/org/apache/spark/Accumulators.scala
@@ -252,6 +252,7 @@ private object Accumulators {
   // TODO: Use soft references? => need to make readObject work properly then
   val originals = Map[Long, Accumulable[_, _]]()
   val localAccums = Map[Thread, Map[Long, Accumulable[_, _]]]()
+  var lastId: Long = 0
 
   private val nextAccumID = new AtomicLong(0)
 

--- a/core/src/main/scala/org/apache/spark/Accumulators.scala
+++ b/core/src/main/scala/org/apache/spark/Accumulators.scala
@@ -45,15 +45,11 @@ import org.apache.spark.util.Utils
 class Accumulable[R, T] (
     @transient initialValue: R,
     param: AccumulableParam[R, T],
-    val name: Option[String],
-    val allowDuplicate: Boolean)
+    val name: Option[String])
   extends Serializable {
 
-  def this(@transient initialValue: R, param: AccumulableParam[R, T], name: Option[String]) =
-    this(initialValue, param, name, true)
-
   def this(@transient initialValue: R, param: AccumulableParam[R, T]) =
-    this(initialValue, param, None, true)
+    this(initialValue, param, None)
 
   val id: Long = Accumulators.newId
 
@@ -232,16 +228,11 @@ GrowableAccumulableParam[R <% Growable[T] with TraversableOnce[T] with Serializa
  * @tparam T result type
  */
 class Accumulator[T](@transient initialValue: T, param: AccumulatorParam[T],
-                     name: Option[String], allowDuplicate: Boolean)
-    extends Accumulable[T,T](initialValue, param, name, allowDuplicate) {
+                     name: Option[String])
+    extends Accumulable[T,T](initialValue, param, name) {
 
-  def this(initialValue: T, param: AccumulatorParam[T], name: Option[String]) =
-    this(initialValue, param, None, true)
-
-  def this(initialValue: T, param: AccumulatorParam[T]) = this(initialValue, param, None)
-
-  def this(initialValue: T, param: AccumulatorParam[T], allowDuplicate: Boolean) =
-    this(initialValue, param, None, allowDuplicate)
+  def this(initialValue: T, param: AccumulatorParam[T]) =
+    this(initialValue, param, None)
 }
 
 /**
@@ -278,8 +269,6 @@ private object Accumulators {
     }
   }
 
-  def isAllowDuplicate(id: Long) = originals(id).allowDuplicate
-
   // Clear the local (non-original) accumulators for the current thread
   def clear() {
     synchronized {
@@ -301,13 +290,6 @@ private object Accumulators {
       if (originals.contains(id)) {
         originals(id).asInstanceOf[Accumulable[Any, Any]] ++= value
       }
-    }
-  }
-
-  // Add values to the original accumulators with some given IDs
-  def add(value: (Long, Any)): Unit = synchronized {
-    if (originals.contains(value._1)) {
-      originals(value._1).asInstanceOf[Accumulable[Any, Any]] ++= value._2
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/Accumulators.scala
+++ b/core/src/main/scala/org/apache/spark/Accumulators.scala
@@ -227,12 +227,10 @@ GrowableAccumulableParam[R <% Growable[T] with TraversableOnce[T] with Serializa
  * @param param helper object defining how to add elements of type `T`
  * @tparam T result type
  */
-class Accumulator[T](@transient initialValue: T, param: AccumulatorParam[T],
-                     name: Option[String])
+class Accumulator[T](@transient initialValue: T, param: AccumulatorParam[T], name: Option[String])
     extends Accumulable[T,T](initialValue, param, name) {
 
-  def this(initialValue: T, param: AccumulatorParam[T]) =
-    this(initialValue, param, None)
+  def this(initialValue: T, param: AccumulatorParam[T]) = this(initialValue, param, None)
 }
 
 /**
@@ -285,6 +283,7 @@ private object Accumulators {
     return ret
   }
 
+  // Add values to the original accumulators with some given IDs
   def add(values: Map[Long, Any]): Unit = synchronized {
     for ((id, value) <- values) {
       if (originals.contains(id)) {

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -893,9 +893,8 @@ class SparkContext(config: SparkConf) extends Logging {
    * Create an [[org.apache.spark.Accumulator]] variable of a given type, which tasks can "add"
    * values to using the `+=` method. Only the driver can access the accumulator's `value`.
    */
-  def accumulator[T](initialValue: T)
-                    (implicit param: AccumulatorParam[T]) =
-    new Accumulator(initialValue, param, None)
+  def accumulator[T](initialValue: T)(implicit param: AccumulatorParam[T]) =
+    new Accumulator(initialValue, param)
 
   /**
    * Create an [[org.apache.spark.Accumulator]] variable of a given type, with a name for display
@@ -934,7 +933,7 @@ class SparkContext(config: SparkConf) extends Logging {
   def accumulableCollection[R <% Growable[T] with TraversableOnce[T] with Serializable: ClassTag, T]
       (initialValue: R): Accumulable[R, T] = {
     val param = new GrowableAccumulableParam[R,T]
-    new Accumulable(initialValue, param, None)
+    new Accumulable(initialValue, param)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -895,17 +895,7 @@ class SparkContext(config: SparkConf) extends Logging {
    */
   def accumulator[T](initialValue: T)
                     (implicit param: AccumulatorParam[T]) =
-    new Accumulator(initialValue, param, None, true)
-
-  /**
-   * Create an [[org.apache.spark.Accumulator]] variable of a given type, which tasks can "add"
-   * values to using the `+=` method. Only the driver can access the accumulator's `value`.
-   *
-   * NOTE: allows user to specify if the accumulator allows duplicate update
-   */
-  def accumulator[T](initialValue: T, name: String, allowDuplicate: Boolean)
-                    (implicit param: AccumulatorParam[T]) =
-    new Accumulator(initialValue, param, None, allowDuplicate)
+    new Accumulator(initialValue, param, None)
 
   /**
    * Create an [[org.apache.spark.Accumulator]] variable of a given type, with a name for display
@@ -924,7 +914,6 @@ class SparkContext(config: SparkConf) extends Logging {
    */
   def accumulable[R, T](initialValue: R)(implicit param: AccumulableParam[R, T]) =
     new Accumulable(initialValue, param)
-
 
   /**
    * Create an [[org.apache.spark.Accumulable]] shared variable, with a name for display in the
@@ -945,21 +934,7 @@ class SparkContext(config: SparkConf) extends Logging {
   def accumulableCollection[R <% Growable[T] with TraversableOnce[T] with Serializable: ClassTag, T]
       (initialValue: R): Accumulable[R, T] = {
     val param = new GrowableAccumulableParam[R,T]
-    new Accumulable(initialValue, param, None, true)
-  }
-
-  /**
-   * Create an accumulator from a "mutable collection" type.
-   *
-   * Growable and TraversableOnce are the standard APIs that guarantee += and ++=, implemented by
-   * standard mutable collections. So you can use this with mutable Map, Set, etc.
-   *
-   * NOTE: this allows user to define if the Accumulable allows duplciate update
-   */
-  def accumulableCollection[R <% Growable[T] with TraversableOnce[T] with Serializable: ClassTag, T]
-  (initialValue: R, allowDuplciate: Boolean): Accumulable[R, T] = {
-    val param = new GrowableAccumulableParam[R,T]
-    new Accumulable(initialValue, param, None, allowDuplciate)
+    new Accumulable(initialValue, param, None)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -893,8 +893,9 @@ class SparkContext(config: SparkConf) extends Logging {
    * Create an [[org.apache.spark.Accumulator]] variable of a given type, which tasks can "add"
    * values to using the `+=` method. Only the driver can access the accumulator's `value`.
    */
-  def accumulator[T](initialValue: T)(implicit param: AccumulatorParam[T]) =
-    new Accumulator(initialValue, param)
+  def accumulator[T](initialValue: T, allowDuplicate: Boolean = true)
+                    (implicit param: AccumulatorParam[T]) =
+    new Accumulator(initialValue, param, None, allowDuplicate)
 
   /**
    * Create an [[org.apache.spark.Accumulator]] variable of a given type, with a name for display
@@ -931,9 +932,9 @@ class SparkContext(config: SparkConf) extends Logging {
    * standard mutable collections. So you can use this with mutable Map, Set, etc.
    */
   def accumulableCollection[R <% Growable[T] with TraversableOnce[T] with Serializable: ClassTag, T]
-      (initialValue: R): Accumulable[R, T] = {
+      (initialValue: R, allowDuplicate: Boolean = true): Accumulable[R, T] = {
     val param = new GrowableAccumulableParam[R,T]
-    new Accumulable(initialValue, param)
+    new Accumulable(initialValue, param, allowDuplicate)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -940,8 +940,6 @@ class DAGScheduler(
     }
     event.reason match {
       case Success =>
-        // only save AccumulatorValue when it's the first successfully finished
-        // task
         if (event.accumUpdates != null) {
           try {
             event.accumUpdates.foreach { case (id, partialValue) =>
@@ -970,7 +968,9 @@ class DAGScheduler(
             stage.resultOfJob match {
               case Some(job) =>
                 if (!job.finished(rt.outputId)) {
-                  Accumulators.add(event.accumUpdates)
+                  if (event.accumUpdates != null) {
+                    Accumulators.add(event.accumUpdates)
+                  }
                   job.finished(rt.outputId) = true
                   job.numFinished += 1
                   // If the whole job has finished, remove it

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -409,31 +409,6 @@ class DAGScheduler(
     updateJobIdStageIdMapsList(List(stage))
   }
 
-  def removeStage(stageId: Int) {
-    // data structures based on Stage
-    for (stage <- stageIdToStage.get(stageId)) {
-      if (runningStages.contains(stage)) {
-        logDebug("Removing running stage %d".format(stageId))
-        runningStages -= stage
-      }
-      for ((k, v) <- shuffleToMapStage.find(_._2 == stage)) {
-        shuffleToMapStage.remove(k)
-      }
-      if (waitingStages.contains(stage)) {
-        logDebug("Removing stage %d from waiting set.".format(stageId))
-        waitingStages -= stage
-      }
-      if (failedStages.contains(stage)) {
-        logDebug("Removing stage %d from failed set.".format(stageId))
-        failedStages -= stage
-      }
-    }
-    // data structures based on StageId
-    stageIdToStage -= stageId
-    logDebug("After removal of stage %d, remaining stages = %d"
-      .format(stageId, stageIdToStage.size))
-  }
-
   /**
    * Removes state for job and any stages that are not needed by any other job.  Does not
    * handle cancelling tasks or notifying the SparkListener about finished jobs/stages/tasks.
@@ -453,6 +428,31 @@ class DAGScheduler(
               "Job %d not registered for stage %d even though that stage was registered for the job"
               .format(job.jobId, stageId))
           } else {
+            def removeStage(stageId: Int) {
+              // data structures based on Stage
+              for (stage <- stageIdToStage.get(stageId)) {
+                if (runningStages.contains(stage)) {
+                  logDebug("Removing running stage %d".format(stageId))
+                  runningStages -= stage
+                }
+                for ((k, v) <- shuffleToMapStage.find(_._2 == stage)) {
+                  shuffleToMapStage.remove(k)
+                }
+                if (waitingStages.contains(stage)) {
+                  logDebug("Removing stage %d from waiting set.".format(stageId))
+                  waitingStages -= stage
+                }
+                if (failedStages.contains(stage)) {
+                  logDebug("Removing stage %d from failed set.".format(stageId))
+                  failedStages -= stage
+                }
+              }
+              // data structures based on StageId
+              stageIdToStage -= stageId
+              logDebug("After removal of stage %d, remaining stages = %d"
+                .format(stageId, stageIdToStage.size))
+            }
+
             jobSet -= job.jobId
             if (jobSet.isEmpty) { // no other job needs this stage
               removeStage(stageId)

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -964,7 +964,8 @@ class DAGScheduler(
                         }
                       }
                     } catch {
-                      // If we see an exception during accumulator update, just log the error and move on.
+                      // If we see an exception during accumulator update, just log the
+                      // error and move on.
                       case e: Exception =>
                         logError(s"Failed to update accumulators for $task", e)
                     }

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -900,6 +900,33 @@ class DAGScheduler(
     }
   }
 
+  private def updateAccumulator(event: CompletionEvent): Unit = {
+    val task = event.task
+    val stage = stageIdToStage(task.stageId)
+    if (event.accumUpdates != null) {
+      try {
+        Accumulators.add(event.accumUpdates)
+        event.accumUpdates.foreach { case (id, partialValue) =>
+          val acc = Accumulators.originals(id).asInstanceOf[Accumulable[Any, Any]]
+          // To avoid UI cruft, ignore cases where value wasn't updated
+          if (acc.name.isDefined && partialValue != acc.zero) {
+            val name = acc.name.get
+            val stringPartialValue = Accumulators.stringifyPartialValue(partialValue)
+            val stringValue = Accumulators.stringifyValue(acc.value)
+            stage.latestInfo.accumulables(id) = AccumulableInfo(id, name, stringValue)
+            event.taskInfo.accumulables +=
+              AccumulableInfo(id, name, Some(stringPartialValue), stringValue)
+          }
+        }
+      } catch {
+        // If we see an exception during accumulator update, just log the
+        // error and move on.
+        case e: Exception =>
+          logError(s"Failed to update accumulators for $task", e)
+      }
+    }
+  }
+
   /**
    * Responds to a task finishing. This is called inside the event loop so it assumes that it can
    * modify the scheduler's internal state. Use taskEnded() to post a task end event from outside.
@@ -948,28 +975,7 @@ class DAGScheduler(
             stage.resultOfJob match {
               case Some(job) =>
                 if (!job.finished(rt.outputId)) {
-                  if (event.accumUpdates != null) {
-                    try {
-                      Accumulators.add(event.accumUpdates)
-                      event.accumUpdates.foreach { case (id, partialValue) =>
-                        val acc = Accumulators.originals(id).asInstanceOf[Accumulable[Any, Any]]
-                        // To avoid UI cruft, ignore cases where value wasn't updated
-                        if (acc.name.isDefined && partialValue != acc.zero) {
-                          val name = acc.name.get
-                          val stringPartialValue = Accumulators.stringifyPartialValue(partialValue)
-                          val stringValue = Accumulators.stringifyValue(acc.value)
-                          stage.latestInfo.accumulables(id) = AccumulableInfo(id, name, stringValue)
-                          event.taskInfo.accumulables +=
-                            AccumulableInfo(id, name, Some(stringPartialValue), stringValue)
-                        }
-                      }
-                    } catch {
-                      // If we see an exception during accumulator update, just log the
-                      // error and move on.
-                      case e: Exception =>
-                        logError(s"Failed to update accumulators for $task", e)
-                    }
-                  }
+                  updateAccumulator(event)
                   job.finished(rt.outputId) = true
                   job.numFinished += 1
                   // If the whole job has finished, remove it
@@ -994,6 +1000,7 @@ class DAGScheduler(
             }
 
           case smt: ShuffleMapTask =>
+            updateAccumulator(event)
             val status = event.result.asInstanceOf[MapStatus]
             val execId = status.location.executorId
             logDebug("ShuffleMapTask finished on " + execId)

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -207,7 +207,18 @@ class DAGSchedulerSuite extends TestKit(ActorSystem("DAGSchedulerSuite")) with F
     assert(taskSet.tasks.size >= results.size)
     for ((result, i) <- results.zipWithIndex) {
       if (i < taskSet.tasks.size) {
-        runEvent(CompletionEvent(taskSet.tasks(i), result._1, result._2, Map[Long, Any](), null, null))
+        runEvent(CompletionEvent(taskSet.tasks(i), result._1, result._2, null, null, null))
+      }
+    }
+  }
+
+  private def completeWithAccumulator(accumId: Long, taskSet: TaskSet,
+                                      results: Seq[(TaskEndReason, Any)]) {
+    assert(taskSet.tasks.size >= results.size)
+    for ((result, i) <- results.zipWithIndex) {
+      if (i < taskSet.tasks.size) {
+        runEvent(CompletionEvent(taskSet.tasks(i), result._1, result._2,
+          Map[Long, Any]((accumId, 1)), null, null))
       }
     }
   }
@@ -493,17 +504,16 @@ class DAGSchedulerSuite extends TestKit(ActorSystem("DAGSchedulerSuite")) with F
     runEvent(ExecutorLost("exec-hostA"))
     val newEpoch = mapOutputTracker.getEpoch
     assert(newEpoch > oldEpoch)
-    val noAccum = Map[Long, Any]()
     val taskSet = taskSets(0)
     // should be ignored for being too old
-    runEvent(CompletionEvent(taskSet.tasks(0), Success, makeMapStatus("hostA", 1), noAccum, null, null))
+    runEvent(CompletionEvent(taskSet.tasks(0), Success, makeMapStatus("hostA", 1), null, null, null))
     // should work because it's a non-failed host
-    runEvent(CompletionEvent(taskSet.tasks(0), Success, makeMapStatus("hostB", 1), noAccum, null, null))
+    runEvent(CompletionEvent(taskSet.tasks(0), Success, makeMapStatus("hostB", 1), null, null, null))
     // should be ignored for being too old
-    runEvent(CompletionEvent(taskSet.tasks(0), Success, makeMapStatus("hostA", 1), noAccum, null, null))
+    runEvent(CompletionEvent(taskSet.tasks(0), Success, makeMapStatus("hostA", 1), null, null, null))
     // should work because it's a new epoch
     taskSet.tasks(1).epoch = newEpoch
-    runEvent(CompletionEvent(taskSet.tasks(1), Success, makeMapStatus("hostA", 1), noAccum, null, null))
+    runEvent(CompletionEvent(taskSet.tasks(1), Success, makeMapStatus("hostA", 1), null, null, null))
     assert(mapOutputTracker.getServerStatuses(shuffleId, 0).map(_._1) ===
            Array(makeBlockManagerId("hostB"), makeBlockManagerId("hostA")))
     complete(taskSets(1), Seq((Success, 42), (Success, 43)))
@@ -728,6 +738,72 @@ class DAGSchedulerSuite extends TestKit(ActorSystem("DAGSchedulerSuite")) with F
     assert(scheduler.sc.dagScheduler === null)
   }
 
+  test("accumulator allowing duplication can be calculated correctly") {
+    val accum = new Accumulator[Int](0, SparkContext.IntAccumulatorParam)
+    val shuffleOneRdd = new MyRDD(sc, 2, Nil)
+    val shuffleDepOne = new ShuffleDependency(shuffleOneRdd, null)
+    val shuffleTwoRdd = new MyRDD(sc, 2, List(shuffleDepOne))
+    val shuffleDepTwo = new ShuffleDependency(shuffleTwoRdd, null)
+    val finalRdd = new MyRDD(sc, 1, List(shuffleDepTwo))
+    submit(finalRdd, Array(0))
+    // have the first stage complete normally
+    completeWithAccumulator(accum.id, taskSets(0), Seq(
+      (Success, makeMapStatus("hostA", 2)),
+      (Success, makeMapStatus("hostB", 2))))
+    // have the second stage complete normally
+    completeWithAccumulator(accum.id, taskSets(1), Seq(
+      (Success, makeMapStatus("hostA", 1)),
+      (Success, makeMapStatus("hostC", 1))))
+    // fail the third stage because hostA went down
+    completeWithAccumulator(accum.id, taskSets(2), Seq(
+      (FetchFailed(makeBlockManagerId("hostA"), shuffleDepTwo.shuffleId, 0, 0), null)))
+    scheduler.resubmitFailedStages()
+    completeWithAccumulator(accum.id, taskSets(3), Seq((Success, makeMapStatus("hostA", 2))))
+    completeWithAccumulator(accum.id, taskSets(4), Seq((Success, makeMapStatus("hostA", 1))))
+    completeWithAccumulator(accum.id, taskSets(5), Seq((Success, 42)))
+    assert(results === Map(0 -> 42))
+    assert(Accumulators.originals(accum.id).value === 7)
+    assertDataStructuresEmpty
+  }
+
+  test("accumulator not allowing duplication is not calculated for resubmitted stage") {
+    //just for register
+    val accum = new Accumulator[Int](0, SparkContext.IntAccumulatorParam, false)
+    val shuffleOneRdd = new MyRDD(sc, 2, Nil)
+    val shuffleDepOne = new ShuffleDependency(shuffleOneRdd, null)
+    val shuffleTwoRdd = new MyRDD(sc, 2, List(shuffleDepOne))
+    val shuffleDepTwo = new ShuffleDependency(shuffleTwoRdd, null)
+    val finalRdd = new MyRDD(sc, 1, List(shuffleDepTwo))
+    submit(finalRdd, Array(0))
+    // have the first stage complete normally
+    completeWithAccumulator(accum.id, taskSets(0), Seq(
+      (Success, makeMapStatus("hostA", 2)),
+      (Success, makeMapStatus("hostB", 2))))
+    // have the second stage complete normally
+    completeWithAccumulator(accum.id, taskSets(1), Seq(
+      (Success, makeMapStatus("hostA", 1)),
+      (Success, makeMapStatus("hostC", 1))))
+    // fail the third stage because hostA went down
+    completeWithAccumulator(accum.id, taskSets(2), Seq(
+      (FetchFailed(makeBlockManagerId("hostA"), shuffleDepTwo.shuffleId, 0, 0), null)))
+    scheduler.resubmitFailedStages()
+    completeWithAccumulator(accum.id, taskSets(3), Seq((Success, makeMapStatus("hostA", 2))))
+    completeWithAccumulator(accum.id, taskSets(4), Seq((Success, makeMapStatus("hostA", 1))))
+    completeWithAccumulator(accum.id, taskSets(5), Seq((Success, 42)))
+    assert(results === Map(0 -> 42))
+    assert(Accumulators.originals(accum.id).value === 5)
+    assertDataStructuresEmpty
+  }
+
+  test("accumulator is cleared for aborted stages") {
+    //just for register
+    new Accumulator[Int](0, SparkContext.IntAccumulatorParam)
+    val rdd = new MyRDD(sc, 2, Nil)
+    submit(rdd, Array(0))
+    failed(taskSets(0), "tastset failed")
+    assertDataStructuresEmpty
+  }
+
   /**
    * Assert that the supplied TaskSet has exactly the given hosts as its preferred locations.
    * Note that this checks only the host and not the executor ID.
@@ -754,6 +830,7 @@ class DAGSchedulerSuite extends TestKit(ActorSystem("DAGSchedulerSuite")) with F
     assert(scheduler.runningStages.isEmpty)
     assert(scheduler.shuffleToMapStage.isEmpty)
     assert(scheduler.waitingStages.isEmpty)
+    assert(scheduler.stageIdToAccumulators.isEmpty)
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -738,7 +738,7 @@ class DAGSchedulerSuite extends TestKit(ActorSystem("DAGSchedulerSuite")) with F
     assert(scheduler.sc.dagScheduler === null)
   }
 
-  test("accumulator not allowing duplication is not calculated for resubmitted stage") {
+  test("accumulator not calculated for resubmitted shuffle stage") {
     //just for register
     val accum = new Accumulator[Int](0, SparkContext.IntAccumulatorParam)
     val shuffleOneRdd = new MyRDD(sc, 2, Nil)
@@ -764,6 +764,18 @@ class DAGSchedulerSuite extends TestKit(ActorSystem("DAGSchedulerSuite")) with F
     completeWithAccumulator(accum.id, taskSets(5), Seq((Success, 42)))
     assert(results === Map(0 -> 42))
     assert(Accumulators.originals(accum.id).value === 5)
+    assertDataStructuresEmpty
+  }
+
+  test("accumulator not calculated for resubmitted result stage") {
+    //just for register
+    val accum = new Accumulator[Int](0, SparkContext.IntAccumulatorParam)
+    val finalRdd = new MyRDD(sc, 1, Nil)
+    submit(finalRdd, Array(0))
+    completeWithAccumulator(accum.id, taskSets(0), Seq((Success, 42)))
+    completeWithAccumulator(accum.id, taskSets(0), Seq((Success, 42)))
+    assert(results === Map(0 -> 42))
+    assert(Accumulators.originals(accum.id).value === 1)
     assertDataStructuresEmpty
   }
 

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -757,7 +757,7 @@ class DAGSchedulerSuite extends TestKit(ActorSystem("DAGSchedulerSuite")) with F
       (Success, makeMapStatus("hostC", 1))))
     // fail the third stage because hostA went down
     completeWithAccumulator(accum.id, taskSets(2), Seq(
-      (FetchFailed(makeBlockManagerId("hostA"), shuffleDepTwo.shuffleId, 0, 0), null)))
+      (FetchFailed(makeBlockManagerId("hostA"), shuffleDepTwo.shuffleId, 0, 0, ""), null)))
     scheduler.resubmitFailedStages()
     completeWithAccumulator(accum.id, taskSets(3), Seq((Success, makeMapStatus("hostA", 2))))
     completeWithAccumulator(accum.id, taskSets(4), Seq((Success, makeMapStatus("hostA", 1))))

--- a/docs/programming-guide.md
+++ b/docs/programming-guide.md
@@ -1228,6 +1228,11 @@ interface to accumulate data where the resulting type is not the same as the ele
 a list by collecting together elements), and the `SparkContext.accumulableCollection` method for accumulating
 common Scala collection types.
 
+<b>Only when the accumulator operation is executed within an 
+action</b>, Spark guarantees that the operation will only be applied when the task is successfully finished for 
+the first time, i.e. the restarted task will not update the value. In transformations, users should be aware of that 
+the accumulator value would be updated as long as the task is executed.
+
 </div>
 
 <div data-lang="java"  markdown="1">

--- a/docs/programming-guide.md
+++ b/docs/programming-guide.md
@@ -1228,11 +1228,6 @@ interface to accumulate data where the resulting type is not the same as the ele
 a list by collecting together elements), and the `SparkContext.accumulableCollection` method for accumulating
 common Scala collection types.
 
-<b>Only when the accumulator operation is executed within an 
-action</b>, Spark guarantees that the operation will only be applied when the task is successfully finished for 
-the first time, i.e. the restarted task will not update the value. In transformations, users should be aware of that 
-the accumulator value would be updated as long as the task is executed.
-
 </div>
 
 <div data-lang="java"  markdown="1">
@@ -1310,6 +1305,12 @@ vecAccum = sc.accumulator(Vector(...), VectorAccumulatorParam())
 </div>
 
 </div>
+
+For accumulator updates performed inside <b>actions only</b>, Spark guarantees that each task's update to the accumulator 
+will only be applied once, i.e. restarted tasks will not update the value. In transformations, users should be aware 
+of that each task's update may be applied more than once if tasks or job stages are re-executed.
+
+
 
 # Deploying to a Cluster
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-3628

In current implementation, the accumulator will be updated for every successfully finished task, even the task is from a resubmitted stage, which makes the accumulator counter-intuitive

In this patch, I changed the way for the DAGScheduler to update the accumulator,

DAGScheduler maintains a HashTable, mapping the stage id to the received <accumulator_id , value> pairs. Only when the stage becomes independent, (no job needs it any more), we accumulate the values of the <accumulator_id , value> pairs, when a task finished, we check if the HashTable has contained such stageId, it saves the accumulator_id, value only when the task is the first finished task of a new stage or the stage is running for the first attempt...
