### PR TITLE
Update FsHistoryProvider.scala

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -153,13 +153,18 @@ private[history] class FsHistoryProvider(conf: SparkConf) extends ApplicationHis
       // later than the last known log directory will be loaded.
       var newLastModifiedTime = lastModifiedTime
       val logInfos = logDirs
-        .filter { dir =>
-          if (fs.isFile(new Path(dir.getPath(), EventLoggingListener.APPLICATION_COMPLETE))) {
-            val modTime = getModificationTime(dir)
-            newLastModifiedTime = math.max(newLastModifiedTime, modTime)
-            modTime > lastModifiedTime
-          } else {
-            false
+          .filter { dir =>
+          try {
+            if (fs.isFile(new Path(dir.getPath(), EventLoggingListener.APPLICATION_COMPLETE))) {
+              val modTime = getModificationTime(dir)
+              newLastModifiedTime = math.max(newLastModifiedTime, modTime)
+              modTime > lastModifiedTime
+            } else {
+              false
+            }
+          } catch {
+            case t: Exception => logError("Exception in checking for event log updates", t)
+              false
           }
         }
         .flatMap { dir =>


### PR DESCRIPTION
As describe In SPARK-3697 HistoryServer cann't list event Log on WEB UI when there was a no permissions directory in the $spark.eventLog.dir. eg, The following files list is in the $spark.eventLog.dir
Because the HistoryServer don't have permission to read the directory(/spark-logs/eventLog/simple-application-1411720159090). and lead the HistoryServer cann't show other event log file on the WEB UI. but show "No Completed Applications Found"! I think the HistoryServer can ignore the incorrect directory(eg: /spark-logs/eventLog/simple-application-1411720159090 as mentioned above).
