### PR TITLE
[SPARK-3705][SQL]add case for VoidObjectInspector to cover NullType

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
@@ -213,6 +213,8 @@ private[hive] trait HiveInspectors {
     case _: JavaHiveDecimalObjectInspector => DecimalType
     case _: WritableTimestampObjectInspector => TimestampType
     case _: JavaTimestampObjectInspector => TimestampType
+    case _: WritableVoidObjectInspector => NullType
+    case _: JavaVoidObjectInspector => NullType
   }
 
   implicit class typeInfoConversions(dt: DataType) {


### PR DESCRIPTION
add case for VoidObjectInspector in `inspectorToDataType`
