### PR TITLE
fix the "Building Spark" url

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To build Spark and its example programs, run:
 
 (You do not need to do this if you downloaded a pre-built package.)
 More detailed documentation is available from the project site, at
-["Building Spark"](http://spark.apache.org/docs/latest/building-spark-maven.html).
+["Building Spark"](http://spark.apache.org/docs/latest/building-with-maven.html).
 
 ## Interactive Scala Shell
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To build Spark and its example programs, run:
 
 (You do not need to do this if you downloaded a pre-built package.)
 More detailed documentation is available from the project site, at
-["Building Spark"](http://spark.apache.org/docs/latest/building-spark.html).
+["Building Spark"](http://spark.apache.org/docs/latest/building-spark-maven.html).
 
 ## Interactive Scala Shell
 


### PR DESCRIPTION
the "Building Spark" url now should http://spark.apache.org/docs/latest/building-with-maven.html
