### PR TITLE
[SPARK-3707] [SQL] Fix bug of type coercion in DIV

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
@@ -351,8 +351,9 @@ trait HiveTypeCoercion {
       case d: Divide if d.resolved && d.dataType == DoubleType => d
       case d: Divide if d.resolved && d.dataType == DecimalType => d
 
-      case Divide(l, r) if l.dataType == DecimalType || r.dataType == DecimalType =>
-        Divide(Cast(l, DecimalType), Cast(r, DecimalType))
+      case Divide(l, r) if l.dataType == DecimalType => Divide(l, Cast(r, DecimalType))
+      case Divide(l, r) if r.dataType == DecimalType => Divide(Cast(l, DecimalType), r)
+
       case Divide(l, r) => Divide(Cast(l, DoubleType), Cast(r, DoubleType))
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
@@ -348,9 +348,11 @@ trait HiveTypeCoercion {
       case e if !e.childrenResolved => e
 
       // Decimal and Double remain the same
-      case d: Divide if d.dataType == DoubleType => d
-      case d: Divide if d.dataType == DecimalType => d
+      case d: Divide if d.resolved && d.dataType == DoubleType => d
+      case d: Divide if d.resolved && d.dataType == DecimalType => d
 
+      case Divide(l, r) if l.dataType == DecimalType || r.dataType == DecimalType =>
+        Divide(Cast(l, DecimalType), Cast(r, DecimalType))
       case Divide(l, r) => Divide(Cast(l, DoubleType), Cast(r, DoubleType))
     }
   }


### PR DESCRIPTION
Calling `BinaryArithmetic.dataType` will throws exception until it's resolved, but in type coercion rule `Division`, seems doesn't follow this.
