### PR TITLE
[SPARK-3712][STREAMING]: add a new UpdateDStream to update a rdd dynamically

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
@@ -602,6 +602,18 @@ abstract class DStream[T: ClassTag] (
   }
 
   /**
+   * Return a new UpdateDStream in which each RDD is used to update the original rdd by
+   * applying a function on each RDD of 'this' DStream.
+   */
+  def updateRDD[U: ClassTag, V: ClassTag](
+      rdd: RDD[V],
+      updateFunc: (Option[RDD[T]], RDD[V]) => RDD[U]
+    ): DStream[T] = {
+    val cleanF = ssc.sparkContext.clean(updateFunc)
+    new UpdateDStream[U, T, V](this, cleanF, rdd).register()
+  }
+
+  /**
    * Print the first ten elements of each RDD generated in this DStream. This is an output
    * operator, so this DStream will be registered as an output stream and there materialized.
    */

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/UpdateDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/UpdateDStream.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.streaming.dstream
+
+import org.apache.spark.streaming.{Duration, Time}
+import org.apache.spark.rdd.RDD
+import scala.reflect.ClassTag
+
+class UpdateDStream[U: ClassTag, T: ClassTag, V: ClassTag](
+    parent: DStream[T],
+    updateFunc: (Option[RDD[T]], RDD[V]) => RDD[U],
+    val basicRdd: RDD[V]
+  ) extends DStream[T](parent.ssc) {
+
+  var updatedRDD: RDD[U] = updateFunc(None, basicRdd)
+
+  override def dependencies = List(parent)
+
+  override def slideDuration: Duration = parent.slideDuration
+
+  override def compute(validTime: Time): Option[RDD[T]] = {
+    val rdd = parent.getOrCompute(validTime)
+    updatedRDD = updateFunc(rdd, basicRdd)
+    rdd
+  }
+
+  def getUpdatedRDD: RDD[U] = this.updatedRDD
+}

--- a/streaming/src/test/scala/org/apache/spark/streaming/BasicOperationsSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/BasicOperationsSuite.scala
@@ -191,7 +191,7 @@ class BasicOperationsSuite extends TestSuiteBase {
     val input = Seq(1 to 4, 101 to 104, 201 to 204)
     val output = Seq(1 to 12, 101 to 112, 201 to 212)
     // union over 3 DStreams
-    testOperation(4
+    testOperation(
       input,
       (s: DStream[Int]) => s.context.union(Seq(s, s.map(_ + 4), s.map(_ + 8))),
       output

--- a/streaming/src/test/scala/org/apache/spark/streaming/BasicOperationsSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/BasicOperationsSuite.scala
@@ -191,7 +191,7 @@ class BasicOperationsSuite extends TestSuiteBase {
     val input = Seq(1 to 4, 101 to 104, 201 to 204)
     val output = Seq(1 to 12, 101 to 112, 201 to 212)
     // union over 3 DStreams
-    testOperation(
+    testOperation(4
       input,
       (s: DStream[Int]) => s.context.union(Seq(s, s.map(_ + 4), s.map(_ + 8))),
       output
@@ -228,6 +228,7 @@ class BasicOperationsSuite extends TestSuiteBase {
   }
 
   test("update rdd within dstream") {
+    val conf = new SparkConf().setMaster("local[4]").setAppName("BasicOperationsSuite")
     val ssc = new StreamingContext(conf, Seconds(3))
     val data = ssc.sparkContext.makeRDD(1 to 2, 1)
     val input = Seq(Seq(1, 2), Seq(3, 4), Seq(5, 6), Seq(7, 8))

--- a/streaming/src/test/scala/org/apache/spark/streaming/BasicOperationsSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/BasicOperationsSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.SparkContext._
 
 import util.ManualClock
 import org.apache.spark.{SparkException, SparkConf}
-import org.apache.spark.streaming.dstream.{WindowedDStream, DStream}
+import org.apache.spark.streaming.dstream.{UpdateDStream, WindowedDStream, DStream}
 import scala.collection.mutable.{SynchronizedBuffer, ArrayBuffer}
 import scala.reflect.ClassTag
 import org.apache.spark.storage.StorageLevel
@@ -225,6 +225,47 @@ class BasicOperationsSuite extends TestSuiteBase {
       )
     }
     testOperation(inputData1, inputData2, operation, outputData, true)
+  }
+
+  test("update rdd within dstream") {
+    val ssc = new StreamingContext(conf, Seconds(3))
+    val data = ssc.sparkContext.makeRDD(1 to 2, 1)
+    val input = Seq(Seq(1, 2), Seq(3, 4), Seq(5, 6), Seq(7, 8))
+    val stream = new TestInputStream[Int](ssc, input, 1)
+
+    val updateFunc = (rdd1: Option[RDD[Int]], rdd2: RDD[Int]) => {
+      rdd1 match {
+        case Some(rdd) =>
+          val r = rdd.repartition(rdd2.partitions.length)
+          rdd2.zipPartitions(r, true) {
+            (first, second) =>
+              first.zip(second)
+          }
+        case None => rdd2.map(e => (e, -1))
+      }
+    }
+
+    val updateStream = stream.updateRDD(data, updateFunc).asInstanceOf[UpdateDStream[(Int, Int), Int, Int]]
+    ssc.start()
+    Thread.sleep(4000)
+    var updatedData = updateStream.getUpdatedRDD.collect()
+    assert(updatedData(0) === (1, 1))
+    assert(updatedData(1) === (2, 2))
+
+    Thread.sleep(3000)
+    updatedData = updateStream.getUpdatedRDD.collect()
+    assert(updatedData(0) === (1, 3))
+    assert(updatedData(1) === (2, 4))
+
+    Thread.sleep(3000)
+    updatedData = updateStream.getUpdatedRDD.collect()
+    assert(updatedData(0) === (1, 5))
+    assert(updatedData(1) === (2, 6))
+
+    Thread.sleep(3000)
+    updatedData = updateStream.getUpdatedRDD.collect()
+    assert(updatedData(0) === (1, 7))
+    assert(updatedData(1) === (2, 8))
   }
 
   test("StreamingContext.transform") {


### PR DESCRIPTION
Maybe, we can achieve the aim by using "forEachRdd"  function. But it is weird in this way, because I need to pass a closure, like this:

```
val baseRdd = ...
var updatedRDD = ...
val inputStream = ...

val func = (rdd: RDD[T], t: Time) => {
     updatedRDD = baseRDD.op(rdd)
}

inputStream.foreachRDD(func _)
```

In my PR, we can update a rdd like:

```
val updateStream = inputStream.updateRDD(baseRDD, func).asInstanceOf[U, V, T]
```

and obtain the updatedRDD like this:

```
val updatedRDD = updateStream.getUpdatedRDD
```
