### PR TITLE
[SPARK-3713][SQL] Uses JSON to serialize DataType objects

### DIFF
--- a/python/pyspark/sql.py
+++ b/python/pyspark/sql.py
@@ -68,7 +68,7 @@ class DataType(object):
         return cls.__name__[:-4].lower()
 
     def jsonValue(self):
-        return {"type": self.typeName()}
+        return self.typeName()
 
     def json(self):
         return json.dumps(self.jsonValue(),
@@ -360,11 +360,11 @@ class StructType(DataType):
 
     def jsonValue(self):
         return {"type": self.typeName(),
-                "fields": map(lambda f: f.jsonValue(), self.fields)}
+                "fields": [f.jsonValue() for f in self.fields]}
 
     @classmethod
     def fromJson(cls, json):
-        return StructType(map(StructField.fromJson, json["fields"]))
+        return StructType([StructField.fromJson(f) for f in json["fields"]])
 
 
 _all_primitive_types = dict((v.typeName(), v)
@@ -423,8 +423,8 @@ def _parse_datatype_json_string(json_string):
 
 
 def _parse_datatype_json_value(json_value):
-    if json_value["type"] in _all_primitive_types.keys():
-        return _all_primitive_types[json_value["type"]]()
+    if type(json_value) is unicode and json_value in _all_primitive_types.keys():
+        return _all_primitive_types[json_value]()
     else:
         return _all_complex_types[json_value["type"]].fromJson(json_value)
 

--- a/python/pyspark/sql.py
+++ b/python/pyspark/sql.py
@@ -67,7 +67,8 @@ class DataType(object):
         return self.simpleString
 
     def jsonString(self):
-        return json.dumps(self.jsonValue(), separators=(',',':'), sort_keys=True)
+        return json.dumps(self.jsonValue(), separators=(',', ':'), sort_keys=True)
+
 
 class PrimitiveTypeSingleton(type):
 
@@ -242,6 +243,7 @@ class ArrayType(DataType):
                 'containsNull': self.containsNull
             }
         }
+
 
 class MapType(DataType):
 
@@ -444,13 +446,13 @@ def _parse_datatype_json_value(json_value):
         value_type = _parse_datatype_json_value(map_type['value'])
         value_contains_null = map_type['valueContainsNull']
         return MapType(key_type, value_type, value_contains_null)
-    elif 'field' in json_value: 
+    elif 'field' in json_value:
         field = json_value['field']
         name = field['name']
         datatype = _parse_datatype_json_value(field['type'])
         nullable = field['nullable']
         return StructField(name, datatype, nullable)
-    elif 'struct' in json_value: 
+    elif 'struct' in json_value:
         struct_type = json_value['struct']
         fields = map(_parse_datatype_json_value, struct_type['fields'])
         return StructType(fields)

--- a/python/pyspark/sql.py
+++ b/python/pyspark/sql.py
@@ -39,11 +39,11 @@ from py4j.protocol import Py4JError
 from py4j.java_collections import ListConverter, MapConverter
 
 
-#__all__ = [
-#    "StringType", "BinaryType", "BooleanType", "TimestampType", "DecimalType",
-#    "DoubleType", "FloatType", "ByteType", "IntegerType", "LongType",
-#    "ShortType", "ArrayType", "MapType", "StructField", "StructType",
-#    "SQLContext", "HiveContext", "SchemaRDD", "Row"]
+__all__ = [
+    "StringType", "BinaryType", "BooleanType", "TimestampType", "DecimalType",
+    "DoubleType", "FloatType", "ByteType", "IntegerType", "LongType",
+    "ShortType", "ArrayType", "MapType", "StructField", "StructType",
+    "SQLContext", "HiveContext", "SchemaRDD", "Row"]
 
 
 def _get_simple_string(clz):
@@ -353,10 +353,6 @@ _all_primitive_types = dict((_get_simple_string(v), v)
                             if type(v) is PrimitiveTypeSingleton and
                             v.__base__ == PrimitiveType)
 
-all_primitive_types = _all_primitive_types
-
-def parse_datatype_json_string(json_string):
-    return _parse_datatype_json_string(json_string)
 
 def _parse_datatype_json_string(json_string):
     """Parses the given data type JSON string.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/WrapDynamic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/WrapDynamic.scala
@@ -24,9 +24,7 @@ import org.apache.spark.sql.catalyst.types.DataType
 /**
  * The data type representing [[DynamicRow]] values.
  */
-case object DynamicType extends DataType {
-  def simpleString: String = "dynamic"
-}
+case object DynamicType extends DataType
 
 /**
  * Wrap a [[Row]] as a [[DynamicRow]].

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/WrapDynamic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/WrapDynamic.scala
@@ -19,8 +19,6 @@ package org.apache.spark.sql.catalyst.expressions
 
 import scala.language.dynamics
 
-import org.json4s.JsonDSL._
-
 import org.apache.spark.sql.catalyst.types.DataType
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/WrapDynamic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/WrapDynamic.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.catalyst.expressions
 
 import scala.language.dynamics
 
+import org.json4s.JsonDSL._
+
 import org.apache.spark.sql.catalyst.types.DataType
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/dataTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/dataTypes.scala
@@ -46,7 +46,7 @@ object DataType {
 
   // NOTE: Map fields must be sorted in alphabetical order to keep consistent with the Python side.
   private def parseDataType(json: JValue): DataType = json match {
-    case JObject(("type", JString(name)) :: Nil) =>
+    case JString(name) =>
       PrimitiveType.nameToType(name)
 
     case JSortedObject(
@@ -167,7 +167,7 @@ abstract class DataType {
 
   def typeName: String = this.getClass.getSimpleName.stripSuffix("$").dropRight(4).toLowerCase
 
-  private[sql] def jsonValue: JValue = "type" -> typeName
+  private[sql] def jsonValue: JValue = typeName
 
   def json: String = compact(render(jsonValue))
 
@@ -229,7 +229,7 @@ case object BinaryType extends NativeType with PrimitiveType {
         val res = x(i).compareTo(y(i))
         if (res != 0) return res
       }
-      return x.length - y.length
+      x.length - y.length
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/dataTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/dataTypes.scala
@@ -78,10 +78,7 @@ object DataType {
   @deprecated("Use DataType.fromJson instead")
   def fromCaseClassString(string: String): DataType = CaseClassStringParser(string)
 
-  /**
-   * Utility functions for working with DataTypes.
-   */
-  private[sql] object CaseClassStringParser extends RegexParsers {
+  private object CaseClassStringParser extends RegexParsers {
     protected lazy val primitiveType: Parser[DataType] =
       ( "StringType" ^^^ StringType
       | "FloatType" ^^^ FloatType

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/dataTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/dataTypes.scala
@@ -44,34 +44,35 @@ object DataType {
     }
   }
 
-  private def parseDataType(asJValue: JValue): DataType = asJValue match {
-    case JString("boolean") => BooleanType
-    case JString("byte") => ByteType
-    case JString("short") => ShortType
-    case JString("integer") => IntegerType
-    case JString("long") => LongType
-    case JString("float") => FloatType
-    case JString("double") => DoubleType
-    case JString("decimal") => DecimalType
-    case JString("string") => StringType
-    case JString("binary") => BinaryType
-    case JString("timestamp") => TimestampType
-    case JString("null") => NullType
-    case JObject(List(("array", JSortedObject(
-        ("containsNull", JBool(n)), ("type", t: JValue))))) =>
+  // NOTE: Map fields must be sorted in alphabetical order to keep consistent with the Python side.
+  private def parseDataType(json: JValue): DataType = json match {
+    case JObject(("type", JString(name)) :: Nil) =>
+      PrimitiveType.nameToType(name)
+
+    case JSortedObject(
+        ("containsNull", JBool(n)),
+        ("elementType", t: JValue),
+        ("type", JString("array"))) =>
       ArrayType(parseDataType(t), n)
-    case JObject(List(("struct", JObject(List(("fields", JArray(fields))))))) =>
-      StructType(fields.map(parseStructField))
-    case JObject(List(("map", JSortedObject(
-        ("key", k: JValue), ("value", v: JValue), ("valueContainsNull", JBool(n)))))) =>
+
+    case JSortedObject(
+        ("keyType", k: JValue),
+        ("type", JString("map")),
+        ("valueContainsNull", JBool(n)),
+        ("valueType", v: JValue)) =>
       MapType(parseDataType(k), parseDataType(v), n)
+
+    case JSortedObject(
+        ("fields", JArray(fields)),
+        ("type", JString("struct"))) =>
+      StructType(fields.map(parseStructField))
   }
 
-  private def parseStructField(asJValue: JValue): StructField = asJValue match {
-    case JObject(Seq(("field", JSortedObject(
+  private def parseStructField(json: JValue): StructField = json match {
+    case JSortedObject(
         ("name", JString(name)),
         ("nullable", JBool(nullable)),
-        ("type", dataType: JValue))))) =>
+        ("type", dataType: JValue)) =>
       StructField(name, parseDataType(dataType), nullable)
   }
 
@@ -164,21 +165,19 @@ abstract class DataType {
 
   def isPrimitive: Boolean = false
 
-  def simpleString: String
+  def typeName: String = this.getClass.getSimpleName.stripSuffix("$").dropRight(4).toLowerCase
 
-  private[sql] def jsonValue: JValue = simpleString
+  private[sql] def jsonValue: JValue = "type" -> typeName
 
-  def jsonString: String = compact(render(jsonValue))
+  def json: String = compact(render(jsonValue))
 
-  def prettyJsonString: String = pretty(render(jsonValue))
+  def prettyJson: String = pretty(render(jsonValue))
 }
 
-case object NullType extends DataType {
-  def simpleString: String = "null"
-}
+case object NullType extends DataType
 
 object NativeType {
-  def all = Seq(
+  val all = Seq(
     IntegerType, BooleanType, LongType, DoubleType, FloatType, ShortType, ByteType, StringType)
 
   def unapply(dt: DataType): Boolean = all.contains(dt)
@@ -198,6 +197,12 @@ trait PrimitiveType extends DataType {
   override def isPrimitive = true
 }
 
+object PrimitiveType {
+  private[sql] val all = Seq(DecimalType, TimestampType, BinaryType) ++ NativeType.all
+
+  private[sql] val nameToType = all.map(t => t.typeName -> t).toMap
+}
+
 abstract class NativeType extends DataType {
   private[sql] type JvmType
   @transient private[sql] val tag: TypeTag[JvmType]
@@ -213,7 +218,6 @@ case object StringType extends NativeType with PrimitiveType {
   private[sql] type JvmType = String
   @transient private[sql] lazy val tag = ScalaReflectionLock.synchronized { typeTag[JvmType] }
   private[sql] val ordering = implicitly[Ordering[JvmType]]
-  def simpleString: String = "string"
 }
 
 case object BinaryType extends NativeType with PrimitiveType {
@@ -228,14 +232,12 @@ case object BinaryType extends NativeType with PrimitiveType {
       return x.length - y.length
     }
   }
-  def simpleString: String = "binary"
 }
 
 case object BooleanType extends NativeType with PrimitiveType {
   private[sql] type JvmType = Boolean
   @transient private[sql] lazy val tag = ScalaReflectionLock.synchronized { typeTag[JvmType] }
   private[sql] val ordering = implicitly[Ordering[JvmType]]
-  def simpleString: String = "boolean"
 }
 
 case object TimestampType extends NativeType {
@@ -246,8 +248,6 @@ case object TimestampType extends NativeType {
   private[sql] val ordering = new Ordering[JvmType] {
     def compare(x: Timestamp, y: Timestamp) = x.compareTo(y)
   }
-
-  def simpleString: String = "timestamp"
 }
 
 abstract class NumericType extends NativeType with PrimitiveType {
@@ -281,7 +281,6 @@ case object LongType extends IntegralType {
   private[sql] val numeric = implicitly[Numeric[Long]]
   private[sql] val integral = implicitly[Integral[Long]]
   private[sql] val ordering = implicitly[Ordering[JvmType]]
-  def simpleString: String = "long"
 }
 
 case object IntegerType extends IntegralType {
@@ -290,7 +289,6 @@ case object IntegerType extends IntegralType {
   private[sql] val numeric = implicitly[Numeric[Int]]
   private[sql] val integral = implicitly[Integral[Int]]
   private[sql] val ordering = implicitly[Ordering[JvmType]]
-  def simpleString: String = "integer"
 }
 
 case object ShortType extends IntegralType {
@@ -299,7 +297,6 @@ case object ShortType extends IntegralType {
   private[sql] val numeric = implicitly[Numeric[Short]]
   private[sql] val integral = implicitly[Integral[Short]]
   private[sql] val ordering = implicitly[Ordering[JvmType]]
-  def simpleString: String = "short"
 }
 
 case object ByteType extends IntegralType {
@@ -308,7 +305,6 @@ case object ByteType extends IntegralType {
   private[sql] val numeric = implicitly[Numeric[Byte]]
   private[sql] val integral = implicitly[Integral[Byte]]
   private[sql] val ordering = implicitly[Ordering[JvmType]]
-  def simpleString: String = "byte"
 }
 
 /** Matcher for any expressions that evaluate to [[FractionalType]]s */
@@ -330,7 +326,6 @@ case object DecimalType extends FractionalType {
   private[sql] val fractional = implicitly[Fractional[BigDecimal]]
   private[sql] val ordering = implicitly[Ordering[JvmType]]
   private[sql] val asIntegral = BigDecimalAsIfIntegral
-  def simpleString: String = "decimal"
 }
 
 case object DoubleType extends FractionalType {
@@ -340,7 +335,6 @@ case object DoubleType extends FractionalType {
   private[sql] val fractional = implicitly[Fractional[Double]]
   private[sql] val ordering = implicitly[Ordering[JvmType]]
   private[sql] val asIntegral = DoubleAsIfIntegral
-  def simpleString: String = "double"
 }
 
 case object FloatType extends FractionalType {
@@ -350,13 +344,12 @@ case object FloatType extends FractionalType {
   private[sql] val fractional = implicitly[Fractional[Float]]
   private[sql] val ordering = implicitly[Ordering[JvmType]]
   private[sql] val asIntegral = FloatAsIfIntegral
-  def simpleString: String = "float"
 }
 
 object ArrayType {
   /** Construct a [[ArrayType]] object with the given element type. The `containsNull` is true. */
   def apply(elementType: DataType): ArrayType = ArrayType(elementType, true)
-  def simpleString: String = "array"
+  def typeName: String = "array"
 }
 
 /**
@@ -369,15 +362,13 @@ object ArrayType {
 case class ArrayType(elementType: DataType, containsNull: Boolean) extends DataType {
   private[sql] def buildFormattedString(prefix: String, builder: StringBuilder): Unit = {
     builder.append(
-      s"$prefix-- element: ${elementType.simpleString} (containsNull = $containsNull)\n")
+      s"$prefix-- element: ${elementType.typeName} (containsNull = $containsNull)\n")
     DataType.buildFormattedString(elementType, s"$prefix    |", builder)
   }
 
-  def simpleString: String = ArrayType.simpleString
-
   override private[sql] def jsonValue =
-    simpleString ->
-      ("type" -> elementType.jsonValue) ~
+    ("type" -> typeName) ~
+      ("elementType" -> elementType.jsonValue) ~
       ("containsNull" -> containsNull)
 }
 
@@ -390,13 +381,12 @@ case class ArrayType(elementType: DataType, containsNull: Boolean) extends DataT
 case class StructField(name: String, dataType: DataType, nullable: Boolean) {
 
   private[sql] def buildFormattedString(prefix: String, builder: StringBuilder): Unit = {
-    builder.append(s"$prefix-- $name: ${dataType.simpleString} (nullable = $nullable)\n")
+    builder.append(s"$prefix-- $name: ${dataType.typeName} (nullable = $nullable)\n")
     DataType.buildFormattedString(dataType, s"$prefix    |", builder)
   }
 
   private[sql] def jsonValue: JValue = {
-    "field" ->
-      ("name" -> name) ~
+    ("name" -> name) ~
       ("type" -> dataType.jsonValue) ~
       ("nullable" -> nullable)
   }
@@ -406,7 +396,7 @@ object StructType {
   protected[sql] def fromAttributes(attributes: Seq[Attribute]): StructType =
     StructType(attributes.map(a => StructField(a.name, a.dataType, a.nullable)))
 
-  def simpleName = "struct"
+  def typeName = "struct"
 }
 
 case class StructType(fields: Seq[StructField]) extends DataType {
@@ -457,9 +447,9 @@ case class StructType(fields: Seq[StructField]) extends DataType {
     fields.foreach(field => field.buildFormattedString(prefix, builder))
   }
 
-  def simpleString: String = StructType.simpleName
-
-  override private[sql] def jsonValue = simpleString -> ("fields" -> fields.map(_.jsonValue))
+  override private[sql] def jsonValue =
+    ("type" -> typeName) ~
+      ("fields" -> fields.map(_.jsonValue))
 }
 
 object MapType {
@@ -484,18 +474,16 @@ case class MapType(
     valueType: DataType,
     valueContainsNull: Boolean) extends DataType {
   private[sql] def buildFormattedString(prefix: String, builder: StringBuilder): Unit = {
-    builder.append(s"$prefix-- key: ${keyType.simpleString}\n")
-    builder.append(s"$prefix-- value: ${valueType.simpleString} " +
+    builder.append(s"$prefix-- key: ${keyType.typeName}\n")
+    builder.append(s"$prefix-- value: ${valueType.typeName} " +
       s"(valueContainsNull = $valueContainsNull)\n")
     DataType.buildFormattedString(keyType, s"$prefix    |", builder)
     DataType.buildFormattedString(valueType, s"$prefix    |", builder)
   }
 
-  def simpleString: String = MapType.simpleName
-
   override private[sql] def jsonValue: JValue =
-    simpleString ->
-      ("key" -> keyType.jsonValue) ~
-      ("value" -> valueType.jsonValue) ~
+    ("type" -> typeName) ~
+      ("keyType" -> keyType.jsonValue) ~
+      ("valueType" -> valueType.jsonValue) ~
       ("valueContainsNull" -> valueContainsNull)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -22,6 +22,7 @@ import scala.reflect.runtime.universe.TypeTag
 
 import org.apache.hadoop.conf.Configuration
 
+import org.apache.spark.SparkContext
 import org.apache.spark.annotation.{AlphaComponent, DeveloperApi, Experimental}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.ScalaReflection
@@ -31,12 +32,11 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.optimizer.Optimizer
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
+import org.apache.spark.sql.catalyst.types.DataType
 import org.apache.spark.sql.columnar.InMemoryRelation
-import org.apache.spark.sql.execution._
-import org.apache.spark.sql.execution.SparkStrategies
+import org.apache.spark.sql.execution.{SparkStrategies, _}
 import org.apache.spark.sql.json._
 import org.apache.spark.sql.parquet.ParquetRelation
-import org.apache.spark.{Logging, SparkContext}
 
 /**
  * :: AlphaComponent ::
@@ -409,8 +409,7 @@ class SQLContext(@transient val sparkContext: SparkContext)
    * It is only used by PySpark.
    */
   private[sql] def parseDataType(dataTypeString: String): DataType = {
-    val parser = org.apache.spark.sql.catalyst.types.DataType
-    parser(dataTypeString)
+    DataType.fromJson(dataTypeString)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetTypes.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetTypes.scala
@@ -332,7 +332,7 @@ private[parquet] object ParquetTypesConverter extends Logging {
   }
 
   def convertToString(schema: Seq[Attribute]): String = {
-    StructType.fromAttributes(schema).jsonString
+    StructType.fromAttributes(schema).json
   }
 
   def writeMetaData(attributes: Seq[Attribute], origPath: Path, conf: Configuration): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetTypes.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetTypes.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.parquet
 
 import java.io.IOException
 
+import scala.util.Try
+
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.mapreduce.Job
@@ -323,14 +325,14 @@ private[parquet] object ParquetTypesConverter extends Logging {
   }
 
   def convertFromString(string: String): Seq[Attribute] = {
-    DataType(string) match {
+    Try(DataType.fromJson(string)).getOrElse(DataType.fromCaseClassString(string)) match {
       case s: StructType => s.toAttributes
       case other => sys.error(s"Can convert $string to row")
     }
   }
 
   def convertToString(schema: Seq[Attribute]): String = {
-    StructType.fromAttributes(schema).toString
+    StructType.fromAttributes(schema).jsonString
   }
 
   def writeMetaData(attributes: Seq[Attribute], origPath: Path, conf: Configuration): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataTypeSuite.scala
@@ -60,7 +60,7 @@ class DataTypeSuite extends FunSuite {
 
   def checkDataTypeJsonRepr(dataType: DataType): Unit = {
     test(s"JSON - $dataType") {
-      assert(DataType.fromJson(dataType.jsonString) === dataType)
+      assert(DataType.fromJson(dataType.json) === dataType)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataTypeSuite.scala
@@ -73,6 +73,8 @@ class DataTypeSuite extends FunSuite {
   checkDataTypeJsonRepr(DoubleType)
   checkDataTypeJsonRepr(DecimalType)
   checkDataTypeJsonRepr(TimestampType)
+  checkDataTypeJsonRepr(StringType)
+  checkDataTypeJsonRepr(BinaryType)
   checkDataTypeJsonRepr(ArrayType(DoubleType, true))
   checkDataTypeJsonRepr(ArrayType(StringType, false))
   checkDataTypeJsonRepr(MapType(IntegerType, StringType, true))

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataTypeSuite.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql
 
 import org.scalatest.FunSuite
 
+import org.apache.spark.sql.catalyst.types.DataType
+
 class DataTypeSuite extends FunSuite {
 
   test("construct an ArrayType") {
@@ -55,4 +57,28 @@ class DataTypeSuite extends FunSuite {
       struct(Set("b", "d", "e", "f"))
     }
   }
+
+  def checkDataTypeJsonRepr(dataType: DataType): Unit = {
+    test(s"JSON - $dataType") {
+      assert(DataType.fromJson(dataType.jsonString) === dataType)
+    }
+  }
+
+  checkDataTypeJsonRepr(BooleanType)
+  checkDataTypeJsonRepr(ByteType)
+  checkDataTypeJsonRepr(ShortType)
+  checkDataTypeJsonRepr(IntegerType)
+  checkDataTypeJsonRepr(LongType)
+  checkDataTypeJsonRepr(FloatType)
+  checkDataTypeJsonRepr(DoubleType)
+  checkDataTypeJsonRepr(DecimalType)
+  checkDataTypeJsonRepr(TimestampType)
+  checkDataTypeJsonRepr(ArrayType(DoubleType, true))
+  checkDataTypeJsonRepr(ArrayType(StringType, false))
+  checkDataTypeJsonRepr(MapType(IntegerType, StringType, true))
+  checkDataTypeJsonRepr(MapType(IntegerType, ArrayType(DoubleType), false))
+  checkDataTypeJsonRepr(
+    StructType(Seq(
+      StructField("a", IntegerType, nullable = true),
+      StructField("b", ArrayType(DoubleType), nullable = false))))
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/parquet/ParquetQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/parquet/ParquetQuerySuite.scala
@@ -805,7 +805,7 @@ class ParquetQuerySuite extends QueryTest with FunSuiteLike with BeforeAndAfterA
       StructField("c2", BinaryType, false)))
 
     val fromCaseClassString = ParquetTypesConverter.convertFromString(schema.toString)
-    val fromJson = ParquetTypesConverter.convertFromString(schema.jsonString)
+    val fromJson = ParquetTypesConverter.convertFromString(schema.json)
 
     (fromCaseClassString, fromJson).zipped.foreach { (a, b) =>
       assert(a.name == b.name)

--- a/sql/core/src/test/scala/org/apache/spark/sql/parquet/ParquetQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/parquet/ParquetQuerySuite.scala
@@ -789,7 +789,7 @@ class ParquetQuerySuite extends QueryTest with FunSuiteLike with BeforeAndAfterA
     assert(result3(0)(1) === "the answer")
     Utils.deleteRecursively(tmpdir)
   }
-  
+
   test("Querying on empty parquet throws exception (SPARK-3536)") {
     val tmpdir = Utils.createTempDir()
     Utils.deleteRecursively(tmpdir)
@@ -797,5 +797,19 @@ class ParquetQuerySuite extends QueryTest with FunSuiteLike with BeforeAndAfterA
     val result1 = sql("SELECT * FROM tmpemptytable").collect()
     assert(result1.size === 0)
     Utils.deleteRecursively(tmpdir)
+  }
+
+  test("DataType string parser compatibility") {
+    val schema = StructType(List(
+      StructField("c1", IntegerType, false),
+      StructField("c2", BinaryType, false)))
+
+    val fromCaseClassString = ParquetTypesConverter.convertFromString(schema.toString)
+    val fromJson = ParquetTypesConverter.convertFromString(schema.jsonString)
+
+    (fromCaseClassString, fromJson).zipped.foreach { (a, b) =>
+      assert(a.name == b.name)
+      assert(a.dataType === b.dataType)
+    }
   }
 }


### PR DESCRIPTION
This PR uses JSON instead of `toString` to serialize `DataType`s. The latter is not only hard to parse but also flaky in many cases.

Since we already write schema information to Parquet metadata in the old style, we have to reserve the old `DataType` parser and ensure downward compatibility. The old parser is now renamed to `CaseClassStringParser` and moved into `object DataType`.

@JoshRosen @davies Please help review PySpark related changes, thanks!
