### PR TITLE
[SPARK-3709] Fix the flaky test in BroadcastSuite.

### DIFF
--- a/core/src/main/scala/org/apache/spark/network/nio/NioBlockTransferService.scala
+++ b/core/src/main/scala/org/apache/spark/network/nio/NioBlockTransferService.scala
@@ -200,6 +200,6 @@ final class NioBlockTransferService(conf: SparkConf, securityManager: SecurityMa
     val buffer = blockDataManager.getBlockData(blockId).orNull
     logDebug("GetBlock " + blockId + " used " + Utils.getUsedTimeMs(startTimeMs)
       + " and got buffer " + buffer)
-    buffer.nioByteBuffer()
+    if (buffer != null) buffer.nioByteBuffer() else null
   }
 }


### PR DESCRIPTION
The problem was introduced when I refactored the network module. Previously ConnectionManager / BlockManagerWorker silently ignores blocks that don't exist, whereas the new code throws an exception.
