### PR TITLE
[Build] Post commit hash with timeout messages

### DIFF
--- a/dev/run-tests-jenkins
+++ b/dev/run-tests-jenkins
@@ -141,8 +141,10 @@ function post_message () {
   test_result="$?"
 
   if [ "$test_result" -eq "124" ]; then
-    fail_message="**[Tests timed out](${BUILD_URL}consoleFull)** after \
-    a configured wait of \`${TESTS_TIMEOUT}\`."
+    fail_message="**[Tests timed out](${BUILD_URL}consoleFull)** \
+    for PR $ghprbPullId at commit [\`${SHORT_COMMIT_HASH}\`](${COMMIT_URL}) \
+    after a configured wait of \`${TESTS_TIMEOUT}\`."
+
     post_message "$fail_message"
     exit $test_result
   else

--- a/dev/run-tests-jenkins
+++ b/dev/run-tests-jenkins
@@ -33,7 +33,7 @@ COMMIT_URL="https://github.com/apache/spark/commit/${ghprbActualCommit}"
 # GitHub doesn't auto-link short hashes when submitted via the API, unfortunately. :(
 SHORT_COMMIT_HASH="${ghprbActualCommit:0:7}"
 
-TESTS_TIMEOUT="1m" # format: http://linux.die.net/man/1/timeout
+TESTS_TIMEOUT="120m" # format: http://linux.die.net/man/1/timeout
 
 function post_message () {
   local message=$1

--- a/dev/run-tests-jenkins
+++ b/dev/run-tests-jenkins
@@ -33,7 +33,7 @@ COMMIT_URL="https://github.com/apache/spark/commit/${ghprbActualCommit}"
 # GitHub doesn't auto-link short hashes when submitted via the API, unfortunately. :(
 SHORT_COMMIT_HASH="${ghprbActualCommit:0:7}"
 
-TESTS_TIMEOUT="120m" # format: http://linux.die.net/man/1/timeout
+TESTS_TIMEOUT="1m" # format: http://linux.die.net/man/1/timeout
 
 function post_message () {
   local message=$1


### PR DESCRIPTION
[By request](https://github.com/apache/spark/pull/2588#issuecomment-57266871), and because it also makes sense.
