### PR TITLE
[SPARK-3760] [STREAMING] Add Twitter4j FilterQuery to spark streaming twitter API

### DIFF
--- a/external/twitter/src/main/scala/org/apache/spark/streaming/twitter/TwitterUtils.scala
+++ b/external/twitter/src/main/scala/org/apache/spark/streaming/twitter/TwitterUtils.scala
@@ -32,26 +32,6 @@ object TwitterUtils {
    *        authorization; this uses the system properties twitter4j.oauth.consumerKey,
    *        twitter4j.oauth.consumerSecret, twitter4j.oauth.accessToken and
    *        twitter4j.oauth.accessTokenSecret
-   * @param query Twitter4j filter query, or None to return a stream of random sample
-   *              of all public statuses
-   * @param storageLevel Storage level to use for storing the received objects
-   */
-  def createQueryStream(
-      ssc: StreamingContext,
-      twitterAuth: Option[Authorization],
-      query: Option[FilterQuery] = None,
-      storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK_SER_2
-    ): ReceiverInputDStream[Status] = {
-    new TwitterInputDStream(ssc, twitterAuth, query, storageLevel)
-  }
-
-  /**
-   * Create a input stream that returns tweets received from Twitter.
-   * @param ssc         StreamingContext object
-   * @param twitterAuth Twitter4J authentication, or None to use Twitter4J's default OAuth
-   *        authorization; this uses the system properties twitter4j.oauth.consumerKey,
-   *        twitter4j.oauth.consumerSecret, twitter4j.oauth.accessToken and
-   *        twitter4j.oauth.accessTokenSecret
    * @param filters Set of filter strings to get only those tweets that match them
    * @param storageLevel Storage level to use for storing the received objects
    */
@@ -64,6 +44,93 @@ object TwitterUtils {
     val query = if (filters.isEmpty) None else Some(new FilterQuery().track(filters.toArray))
     new TwitterInputDStream(ssc, twitterAuth, query, storageLevel)
   }
+
+  // Scala allows only one version of createStream method with default parameters
+  // To emulate default parameters list, java method-copy pattern used here
+
+  /**
+   * Create a input stream that returns tweets received from Twitter.
+   * @param ssc         StreamingContext object
+   * @param twitterAuth Twitter4J authentication, or None to use Twitter4J's default OAuth
+   *        authorization; this uses the system properties twitter4j.oauth.consumerKey,
+   *        twitter4j.oauth.consumerSecret, twitter4j.oauth.accessToken and
+   *        twitter4j.oauth.accessTokenSecret
+   * @param query Twitter4j filter query, or None to return a stream of random sample
+   *              of all public statuses
+   * @param storageLevel Storage level to use for storing the received objects
+   */
+  private def createFilterQueryStream(
+      ssc: StreamingContext,
+      twitterAuth: Option[Authorization],
+      query: Option[FilterQuery] = None,
+      storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK_SER_2
+    ): ReceiverInputDStream[Status] = {
+    new TwitterInputDStream(ssc, twitterAuth, query, storageLevel)
+  }
+
+  /**
+   * Create a input stream that returns tweets received from Twitter using Twitter4J's default
+   * OAuth authentication; this requires the system properties twitter4j.oauth.consumerKey,
+   * twitter4j.oauth.consumerSecret, twitter4j.oauth.accessToken and
+   * twitter4j.oauth.accessTokenSecret.
+   * Storage level of the data will be the default StorageLevel.MEMORY_AND_DISK_SER_2.
+   * @param ssc    StreamingContext object
+   * @param query  Twitter4j filter query
+   */
+  def createStream(ssc: StreamingContext, query: FilterQuery
+      ): ReceiverInputDStream[Status] = {
+    createFilterQueryStream(ssc, None, Some(query))
+  }
+
+  /**
+   * Create a input stream that returns tweets received from Twitter using Twitter4J's default
+   * OAuth authentication; this requires the system properties twitter4j.oauth.consumerKey,
+   * twitter4j.oauth.consumerSecret, twitter4j.oauth.accessToken and
+   * twitter4j.oauth.accessTokenSecret.
+   * @param ssc          StreamingContext object
+   * @param query        Twitter4j filter query
+   * @param storageLevel Storage level to use for storing the received objects
+   */
+  def createStream(
+      ssc: StreamingContext,
+      query: FilterQuery,
+      storageLevel: StorageLevel
+    ): ReceiverInputDStream[Status] = {
+    createFilterQueryStream(ssc, None, Some(query), storageLevel)
+  }
+
+  /**
+   * Create a input stream that returns tweets received from Twitter.
+   * Storage level of the data will be the default StorageLevel.MEMORY_AND_DISK_SER_2.
+   * @param ssc         StreamingContext object
+   * @param twitterAuth Twitter4J Authorization
+   * @param query       Twitter4j filter query
+   */
+  def createStream(
+      ssc: StreamingContext,
+      twitterAuth: Authorization,
+      query: FilterQuery
+    ): ReceiverInputDStream[Status] = {
+    createFilterQueryStream(ssc, Some(twitterAuth), Some(query))
+  }
+
+  /**
+   * Create a input stream that returns tweets received from Twitter.
+   * @param ssc          StreamingContext object
+   * @param twitterAuth  Twitter4J Authorization object
+   * @param query        Twitter4j filter query
+   * @param storageLevel Storage level to use for storing the received objects
+   */
+  def createStream(
+      ssc: StreamingContext,
+      twitterAuth: Authorization,
+      query: FilterQuery,
+      storageLevel: StorageLevel
+    ): ReceiverInputDStream[Status] = {
+    createFilterQueryStream(ssc, Some(twitterAuth), Some(query), storageLevel)
+  }
+
+  // Create Twitter Stream from JavaStreamingContext
 
   /**
    * Create a input stream that returns tweets received from Twitter using Twitter4J's default
@@ -102,7 +169,7 @@ object TwitterUtils {
    */
   def createStream(jssc: JavaStreamingContext, query: FilterQuery
       ): JavaReceiverInputDStream[Status] = {
-    createQueryStream(jssc.ssc, None, Some(query))
+    createFilterQueryStream(jssc.ssc, None, Some(query))
   }
 
   /**
@@ -136,7 +203,7 @@ object TwitterUtils {
       query: FilterQuery,
       storageLevel: StorageLevel
     ): JavaReceiverInputDStream[Status] = {
-    createQueryStream(jssc.ssc, None, Some(query), storageLevel)
+    createFilterQueryStream(jssc.ssc, None, Some(query), storageLevel)
   }
 
 
@@ -178,7 +245,7 @@ object TwitterUtils {
       twitterAuth: Authorization,
       query: FilterQuery
     ): JavaReceiverInputDStream[Status] = {
-    createQueryStream(jssc.ssc, Some(twitterAuth), Some(query))
+    createFilterQueryStream(jssc.ssc, Some(twitterAuth), Some(query))
   }
 
   /**
@@ -210,6 +277,6 @@ object TwitterUtils {
       query: FilterQuery,
       storageLevel: StorageLevel
     ): JavaReceiverInputDStream[Status] = {
-    createQueryStream(jssc.ssc, Some(twitterAuth), Some(query), storageLevel)
+    createFilterQueryStream(jssc.ssc, Some(twitterAuth), Some(query), storageLevel)
   }
 }

--- a/external/twitter/src/test/java/org/apache/spark/streaming/twitter/JavaTwitterStreamSuite.java
+++ b/external/twitter/src/test/java/org/apache/spark/streaming/twitter/JavaTwitterStreamSuite.java
@@ -36,15 +36,25 @@ public class JavaTwitterStreamSuite extends LocalJavaStreamingContext {
     Authorization auth = NullAuthorization.getInstance();
 
     // tests the API, does not actually test data receiving
+
+    // Create stream with empty filter restrictions
     JavaDStream<Status> test1 = TwitterUtils.createStream(ssc);
-    JavaDStream<Status> test2 = TwitterUtils.createStream(ssc, filters);
-    JavaDStream<Status> test3 = TwitterUtils.createStream(
+    JavaDStream<Status> test2 = TwitterUtils.createStream(ssc, auth);
+
+    // Create stream filtered by keywords
+    JavaDStream<Status> test3 = TwitterUtils.createStream(ssc, filters);
+    JavaDStream<Status> test4 = TwitterUtils.createStream(
       ssc, filters, StorageLevel.MEMORY_AND_DISK_SER_2());
-    JavaDStream<Status> test4 = TwitterUtils.createStream(ssc, auth);
     JavaDStream<Status> test5 = TwitterUtils.createStream(ssc, auth, filters);
     JavaDStream<Status> test6 = TwitterUtils.createStream(ssc,
       auth, filters, StorageLevel.MEMORY_AND_DISK_SER_2());
+
+    // Create stream from FilterQuery
     JavaDStream<Status> test7 = TwitterUtils.createStream(ssc, query);
-    JavaDStream<Status> test8 = TwitterUtils.createStream(ssc, auth, query);
+    JavaDStream<Status> test8 = TwitterUtils.createStream(
+      ssc, query, StorageLevel.MEMORY_AND_DISK_SER_2());
+    JavaDStream<Status> test9 = TwitterUtils.createStream(ssc, auth, query);
+    JavaDStream<Status> test10 = TwitterUtils.createStream(ssc,
+      auth, query, StorageLevel.MEMORY_AND_DISK_SER_2());
   }
 }

--- a/external/twitter/src/test/java/org/apache/spark/streaming/twitter/JavaTwitterStreamSuite.java
+++ b/external/twitter/src/test/java/org/apache/spark/streaming/twitter/JavaTwitterStreamSuite.java
@@ -20,6 +20,7 @@ package org.apache.spark.streaming.twitter;
 import java.util.Arrays;
 
 import org.junit.Test;
+import twitter4j.FilterQuery;
 import twitter4j.Status;
 import twitter4j.auth.Authorization;
 import twitter4j.auth.NullAuthorization;
@@ -31,6 +32,7 @@ public class JavaTwitterStreamSuite extends LocalJavaStreamingContext {
   @Test
   public void testTwitterStream() {
     String[] filters = (String[])Arrays.<String>asList("filter1", "filter2").toArray();
+    FilterQuery query = new FilterQuery().track(filters);
     Authorization auth = NullAuthorization.getInstance();
 
     // tests the API, does not actually test data receiving
@@ -42,5 +44,7 @@ public class JavaTwitterStreamSuite extends LocalJavaStreamingContext {
     JavaDStream<Status> test5 = TwitterUtils.createStream(ssc, auth, filters);
     JavaDStream<Status> test6 = TwitterUtils.createStream(ssc,
       auth, filters, StorageLevel.MEMORY_AND_DISK_SER_2());
+    JavaDStream<Status> test7 = TwitterUtils.createStream(ssc, query);
+    JavaDStream<Status> test8 = TwitterUtils.createStream(ssc, auth, query);
   }
 }

--- a/external/twitter/src/test/scala/org/apache/spark/streaming/twitter/TwitterStreamSuite.scala
+++ b/external/twitter/src/test/scala/org/apache/spark/streaming/twitter/TwitterStreamSuite.scala
@@ -21,27 +21,37 @@ import org.apache.spark.streaming.{StreamingContext, TestSuiteBase}
 import org.apache.spark.storage.StorageLevel
 import twitter4j.auth.{NullAuthorization, Authorization}
 import org.apache.spark.streaming.dstream.ReceiverInputDStream
-import twitter4j.Status
+import twitter4j.{FilterQuery, Status}
 
 class TwitterStreamSuite extends TestSuiteBase {
 
   test("twitter input stream") {
     val ssc = new StreamingContext(master, framework, batchDuration)
     val filters = Seq("filter1", "filter2")
+    val query = Some(new FilterQuery().track(filters.toArray))
     val authorization: Authorization = NullAuthorization.getInstance()
 
     // tests the API, does not actually test data receiving
-    val test1: ReceiverInputDStream[Status] = TwitterUtils.createStream(ssc, None)
+    val test1: ReceiverInputDStream[Status] = TwitterUtils.createQueryStream(ssc, None)
     val test2: ReceiverInputDStream[Status] =
       TwitterUtils.createStream(ssc, None, filters)
     val test3: ReceiverInputDStream[Status] =
       TwitterUtils.createStream(ssc, None, filters, StorageLevel.MEMORY_AND_DISK_SER_2)
     val test4: ReceiverInputDStream[Status] =
-      TwitterUtils.createStream(ssc, Some(authorization))
+      TwitterUtils.createQueryStream(ssc, Some(authorization))
     val test5: ReceiverInputDStream[Status] =
       TwitterUtils.createStream(ssc, Some(authorization), filters)
     val test6: ReceiverInputDStream[Status] = TwitterUtils.createStream(
       ssc, Some(authorization), filters, StorageLevel.MEMORY_AND_DISK_SER_2)
+    TwitterUtils.createStream(ssc, None, filters)
+    val test7: ReceiverInputDStream[Status] =
+      TwitterUtils.createQueryStream(ssc, None, query)
+    val test8: ReceiverInputDStream[Status] =
+      TwitterUtils.createQueryStream(ssc, None, query, StorageLevel.MEMORY_AND_DISK_SER_2)
+    val test9: ReceiverInputDStream[Status] =
+      TwitterUtils.createQueryStream(ssc, Some(authorization), query)
+    val test10: ReceiverInputDStream[Status] = TwitterUtils.createQueryStream(
+      ssc, Some(authorization), query, StorageLevel.MEMORY_AND_DISK_SER_2)
 
     // Note that actually testing the data receiving is hard as authentication keys are
     // necessary for accessing Twitter live stream

--- a/external/twitter/src/test/scala/org/apache/spark/streaming/twitter/TwitterStreamSuite.scala
+++ b/external/twitter/src/test/scala/org/apache/spark/streaming/twitter/TwitterStreamSuite.scala
@@ -28,30 +28,35 @@ class TwitterStreamSuite extends TestSuiteBase {
   test("twitter input stream") {
     val ssc = new StreamingContext(master, framework, batchDuration)
     val filters = Seq("filter1", "filter2")
-    val query = Some(new FilterQuery().track(filters.toArray))
+    val query = new FilterQuery().track(filters.toArray)
     val authorization: Authorization = NullAuthorization.getInstance()
 
     // tests the API, does not actually test data receiving
-    val test1: ReceiverInputDStream[Status] = TwitterUtils.createQueryStream(ssc, None)
+
+    // Create stream with empty filter restrictions
+    val test1: ReceiverInputDStream[Status] = TwitterUtils.createStream(ssc, None)
     val test2: ReceiverInputDStream[Status] =
-      TwitterUtils.createStream(ssc, None, filters)
+      TwitterUtils.createStream(ssc, Some(authorization))
+
+    // Create stream restricted by keywords
     val test3: ReceiverInputDStream[Status] =
-      TwitterUtils.createStream(ssc, None, filters, StorageLevel.MEMORY_AND_DISK_SER_2)
+      TwitterUtils.createStream(ssc, None, filters)
     val test4: ReceiverInputDStream[Status] =
-      TwitterUtils.createQueryStream(ssc, Some(authorization))
+      TwitterUtils.createStream(ssc, None, filters, StorageLevel.MEMORY_AND_DISK_SER_2)
     val test5: ReceiverInputDStream[Status] =
       TwitterUtils.createStream(ssc, Some(authorization), filters)
     val test6: ReceiverInputDStream[Status] = TwitterUtils.createStream(
       ssc, Some(authorization), filters, StorageLevel.MEMORY_AND_DISK_SER_2)
-    TwitterUtils.createStream(ssc, None, filters)
+
+    // Create stream from FilterQuery
     val test7: ReceiverInputDStream[Status] =
-      TwitterUtils.createQueryStream(ssc, None, query)
+      TwitterUtils.createStream(ssc, query)
     val test8: ReceiverInputDStream[Status] =
-      TwitterUtils.createQueryStream(ssc, None, query, StorageLevel.MEMORY_AND_DISK_SER_2)
+      TwitterUtils.createStream(ssc,  query, StorageLevel.MEMORY_AND_DISK_SER_2)
     val test9: ReceiverInputDStream[Status] =
-      TwitterUtils.createQueryStream(ssc, Some(authorization), query)
-    val test10: ReceiverInputDStream[Status] = TwitterUtils.createQueryStream(
-      ssc, Some(authorization), query, StorageLevel.MEMORY_AND_DISK_SER_2)
+      TwitterUtils.createStream(ssc, authorization, query)
+    val test10: ReceiverInputDStream[Status] = TwitterUtils.createStream(
+      ssc, authorization, query, StorageLevel.MEMORY_AND_DISK_SER_2)
 
     // Note that actually testing the data receiving is hard as authentication keys are
     // necessary for accessing Twitter live stream


### PR DESCRIPTION
TwitterUtils.createStream(...) allows users to specify keywords that restrict the tweets that are returned. However FilterQuery from Twitter4j has a bunch of other options including location that was asked in SPARK-2788. Best solution will be add alternative createStream method with FilterQuery as argument instead of keywords.

This PR is a replacement for #1717 and #2098

For new method I can't use "createStream" name, I want to keep public API stable & binary compatible and introducing new method with same name cause scalac compilation issue: multiple overloaded alternatives of createStream define default arguments
