### PR TITLE
[SPARK-3755][Core] avoid trying privileged port when request a non-privileged port

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1437,7 +1437,7 @@ private[spark] object Utils extends Logging {
     val serviceString = if (serviceName.isEmpty) "" else s" '$serviceName'"
     for (offset <- 0 to maxRetries) {
       // Do not increment port if startPort is 0, which is treated as a special port
-      val tryPort = if (startPort == 0) startPort else (startPort + offset) % 65536
+      val tryPort = if (startPort == 0) startPort else (startPort + offset) % (65536 - 1024) + 1024
       try {
         val (service, port) = startService(tryPort)
         logInfo(s"Successfully started service$serviceString on port $port.")

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1437,12 +1437,10 @@ private[spark] object Utils extends Logging {
     val serviceString = if (serviceName.isEmpty) "" else s" '$serviceName'"
     for (offset <- 0 to maxRetries) {
       // Do not increment port if startPort is 0, which is treated as a special port
-      val _tryPort = if (startPort == 0) startPort else (startPort + offset) % 65536
-      // Do not bind to port 1-1024
-      val tryPort = if (_tryPort > 0 && _tryPort <= 1024) {
-        _tryPort + 1024
+      val tryPort = if (startPort == 0) {
+        startPort
       } else {
-        _tryPort
+        ((startPort + offset - 1024) % (65536 - 1024)) + 1024
       }
       try {
         val (service, port) = startService(tryPort)

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1437,7 +1437,13 @@ private[spark] object Utils extends Logging {
     val serviceString = if (serviceName.isEmpty) "" else s" '$serviceName'"
     for (offset <- 0 to maxRetries) {
       // Do not increment port if startPort is 0, which is treated as a special port
-      val tryPort = if (startPort == 0) startPort else (startPort + offset) % (65536 - 1024) + 1024
+      val _tryPort = if (startPort == 0) startPort else (startPort + offset) % 65536
+      // Do not bind to port 1-1024
+      val tryPort = if (_tryPort > 0 && _tryPort <= 1024) {
+        _tryPort + 1024
+      } else {
+        _tryPort
+      }
       try {
         val (service, port) = startService(tryPort)
         logInfo(s"Successfully started service$serviceString on port $port.")

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1440,6 +1440,7 @@ private[spark] object Utils extends Logging {
       val tryPort = if (startPort == 0) {
         startPort
       } else {
+        // If the new port wraps around, do not try a privilege port
         ((startPort + offset - 1024) % (65536 - 1024)) + 1024
       }
       try {


### PR DESCRIPTION
@pwendell, `tryPort` is not compatible with old code in last PR, this is to fix it.
And after discuss with @srowen renamed the title to "avoid trying privileged port when request a non-privileged port". Plz refer to the discuss for detail.
