### PR TITLE
[SPARK-3763] The example of building with sbt should be "sbt assembly" instead of "sbt compile"

### DIFF
--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -169,7 +169,7 @@ compilation. More advanced developers may wish to use SBT.
 The SBT build is derived from the Maven POM files, and so the same Maven profiles and variables
 can be set to control the SBT build. For example:
 
-    sbt/sbt -Pyarn -Phadoop-2.3 compile
+    sbt/sbt -Pyarn -Phadoop-2.3 assembly
 
 # Speeding up Compilation with Zinc
 


### PR DESCRIPTION
In building-spark.md, there are some examples for making assembled package with maven but the example for building with sbt is only about for compiling.
