### PR TITLE
[DEPLOY] SPARK-3759: Return the exit code of the driver process

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitDriverBootstrapper.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitDriverBootstrapper.scala
@@ -154,7 +154,8 @@ private[spark] object SparkSubmitDriverBootstrapper {
         process.destroy()
       }
     }
-    process.waitFor()
+    val returnCode = process.waitFor()
+    sys.exit(returnCode)
   }
 
 }


### PR DESCRIPTION
SparkSubmitDriverBootstrapper.scala now returns the exit code of the driver process, instead of always returning 0. 
