### PR TITLE
[https://issues.apache.org/jira/browse/SPARK-4392] Event proration based on event timestamps.

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/binning/BinStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/binning/BinStream.scala
@@ -21,6 +21,7 @@ import scala.reflect.ClassTag
 
 import org.apache.spark.streaming.dstream.DStream
 
-class BinStream[T: ClassTag](@transient ds: DStream[T], sizeInNumBatches: Int, delayInNumBatches: Int) {
+class BinStream[T: ClassTag](
+  @transient ds: DStream[T], sizeInNumBatches: Int, delayInNumBatches: Int) {
   def getDStream = ds
 }

--- a/streaming/src/main/scala/org/apache/spark/streaming/binning/BinStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/binning/BinStream.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.streaming.binning
 
 import scala.reflect.ClassTag

--- a/streaming/src/main/scala/org/apache/spark/streaming/binning/BinStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/binning/BinStream.scala
@@ -1,0 +1,9 @@
+package org.apache.spark.streaming.binning
+
+import scala.reflect.ClassTag
+
+import org.apache.spark.streaming.dstream.DStream
+
+class BinStream[T: ClassTag](@transient ds: DStream[T], sizeInNumBatches: Int, delayInNumBatches: Int) {
+  def getDStream = ds
+}

--- a/streaming/src/main/scala/org/apache/spark/streaming/binning/BinStreamer.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/binning/BinStreamer.scala
@@ -1,0 +1,86 @@
+package org.apache.spark.streaming.binning
+
+import org.apache.spark.streaming.dstream.{DStream, ProratedEventDStream, BinAlignedWindowDStream, PulsatingWindowDStream}
+import org.apache.spark.streaming.Time
+import scala.reflect.ClassTag
+
+
+class BinStreamer[T: ClassTag](@transient ds: DStream[T], getStartTime: (T) => Time, getEndTime: (T) => Time) extends Serializable {
+
+  def prorate(binStart: Time, binEnd: Time)(x: T) = {
+
+      val sx = getStartTime(x)
+      val ex = getEndTime(x)
+
+      if (ex == sx) {
+        (x, 1.0)
+      }
+      else {
+
+        // Even though binStart is not inclusive, setting s = binStart  implies limit s as x approaches binStart+
+        val s = if (sx > binStart) sx else binStart
+
+        val e = if (ex < binEnd) ex else binEnd
+
+        (x, (e - s) / (ex - sx))
+      }
+  }
+
+  def filter(binStart: Time, binEnd: Time)(x: T) = {
+
+    // The flow is starting in the subsequent bin
+    if (getStartTime(x) > binEnd) false
+
+    // The flow ended in the prior bin
+    else if (getEndTime(x) <= binStart) false
+
+    // s approaches from binEnd+
+    else if (getStartTime(x) == binEnd && getEndTime(x) > binEnd) false
+
+    // defensive check
+    else if (getStartTime(x) > getEndTime(x)) false
+
+    else true
+
+  }
+
+  def numStreams(sz: Int, delay: Int) = (sz + delay - 1)/sz + 1
+
+  def incrementalStreams(sizeInNumBatches: Int, delayInNumBatches: Int) = {
+
+    val num = numStreams(sizeInNumBatches, delayInNumBatches)
+
+    Array.tabulate(num)(
+      delayNumBins =>
+        new BinStream(
+          new ProratedEventDStream[T](ds, filter, prorate, sizeInNumBatches, delayNumBins),
+          sizeInNumBatches, delayNumBins)
+      )
+  }
+
+  def finalStream(sizeInNumBatches: Int, delayInNumBatches: Int) = {
+
+    val num = numStreams(sizeInNumBatches, delayInNumBatches)
+
+    new BinStream(
+      new ProratedEventDStream[T](
+        new BinAlignedWindowDStream(ds, sizeInNumBatches, num - 1),
+        filter, prorate, sizeInNumBatches, num - 1),
+      sizeInNumBatches, num - 1
+    )
+  }
+
+  def updatedStreams(sizeInNumBatches: Int, delayInNumBatches: Int) = {
+
+    val num = numStreams(sizeInNumBatches, delayInNumBatches)
+
+    Array.tabulate(num)(
+      delayNumBins => new BinStream(
+        new ProratedEventDStream(
+          new PulsatingWindowDStream(ds, sizeInNumBatches, delayNumBins),
+          filter, prorate, sizeInNumBatches, delayNumBins),
+        sizeInNumBatches, delayNumBins)
+    )
+  }
+
+}

--- a/streaming/src/main/scala/org/apache/spark/streaming/binning/BinStreamer.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/binning/BinStreamer.scala
@@ -22,7 +22,9 @@ import org.apache.spark.streaming.Time
 import scala.reflect.ClassTag
 
 
-class BinStreamer[T: ClassTag](@transient ds: DStream[T], getStartTime: (T) => Time, getEndTime: (T) => Time) extends Serializable {
+class BinStreamer[T: ClassTag](
+    @transient ds: DStream[T], getStartTime: (T) => Time, getEndTime: (T) => Time
+  ) extends Serializable {
 
   def prorate(binStart: Time, binEnd: Time)(x: T) = {
 
@@ -34,7 +36,8 @@ class BinStreamer[T: ClassTag](@transient ds: DStream[T], getStartTime: (T) => T
       }
       else {
 
-        // Even though binStart is not inclusive, setting s = binStart  implies limit s as x approaches binStart+
+        // Even though binStart is not inclusive, 
+        // setting s = binStart  implies limit s as x approaches binStart+
         val s = if (sx > binStart) sx else binStart
 
         val e = if (ex < binEnd) ex else binEnd

--- a/streaming/src/main/scala/org/apache/spark/streaming/binning/BinStreamer.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/binning/BinStreamer.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.streaming.binning
 
 import org.apache.spark.streaming.dstream.{DStream, ProratedEventDStream, BinAlignedWindowDStream, PulsatingWindowDStream}

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/BinAlignedWindowDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/BinAlignedWindowDStream.scala
@@ -36,11 +36,14 @@ class BinAlignedWindowDStream[T: ClassTag](
 
   override def slideDuration: Duration = parent.slideDuration
 
-  override def parentRememberDuration: Duration = rememberDuration + parent.slideDuration * sizeNumBatches * (delayNumBins + 1)
+  override def parentRememberDuration: Duration = 
+    rememberDuration + parent.slideDuration * sizeNumBatches * (delayNumBins + 1)
 
   override def compute(validTime: Time): Option[RDD[T]] = {
 
-    val binStart = (validTime - Duration(1)).floor(slideDuration * sizeNumBatches) - slideDuration * sizeNumBatches * delayNumBins
+    val binStart = 
+      (validTime - Duration(1)).floor(slideDuration * sizeNumBatches) - 
+      slideDuration * sizeNumBatches * delayNumBins
 
     if ((validTime - binStart).isMultipleOf(slideDuration * sizeNumBatches)) {
       val currentWindow = new Interval(binStart + slideDuration, validTime)

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/BinAlignedWindowDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/BinAlignedWindowDStream.scala
@@ -1,0 +1,36 @@
+package org.apache.spark.streaming.dstream
+
+import org.apache.spark.rdd.{UnionRDD, RDD}
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.streaming.{Time, Duration, Interval}
+import scala.reflect.ClassTag
+
+
+private[streaming]
+class BinAlignedWindowDStream[T: ClassTag](
+                                                parent: DStream[T],
+                                                sizeNumBatches: Int,
+                                                delayNumBins: Int)
+  extends DStream[T](parent.ssc) {
+
+  parent.persist(StorageLevel.MEMORY_ONLY_SER)
+
+  override def dependencies = List(parent)
+
+  override def slideDuration: Duration = parent.slideDuration
+
+  override def parentRememberDuration: Duration = rememberDuration + parent.slideDuration * sizeNumBatches * (delayNumBins + 1)
+
+  override def compute(validTime: Time): Option[RDD[T]] = {
+
+    val binStart = (validTime - Duration(1)).floor(slideDuration * sizeNumBatches) - slideDuration * sizeNumBatches * delayNumBins
+
+    if ((validTime - binStart).isMultipleOf(slideDuration * sizeNumBatches)) {
+      val currentWindow = new Interval(binStart + slideDuration, validTime)
+      Some(new UnionRDD(ssc.sc, parent.slice(currentWindow)))
+    }
+    else {
+      None
+    }
+  }
+}

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/BinAlignedWindowDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/BinAlignedWindowDStream.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.streaming.dstream
 
 import org.apache.spark.rdd.{UnionRDD, RDD}

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/ProratedEventDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/ProratedEventDStream.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.streaming.dstream
 
 import org.apache.spark.streaming.{Time, Duration}

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/ProratedEventDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/ProratedEventDStream.scala
@@ -44,7 +44,8 @@ class ProratedEventDStream[T: ClassTag](parent: DStream[T],
     // Assumption: start(x) <= end(x) <= boundaryEnd
     //
 
-    def binStart = (validTime - Duration(1)).floor(slideDuration * sizeNumBatches) - slideDuration * sizeNumBatches * delayNumBins
+    def binStart = (validTime - Duration(1)).floor(slideDuration * sizeNumBatches) - 
+      slideDuration * sizeNumBatches * delayNumBins
     def binEnd = binStart + slideDuration * sizeNumBatches
 
     parent.getOrCompute(validTime).map(

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/ProratedEventDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/ProratedEventDStream.scala
@@ -1,0 +1,43 @@
+package org.apache.spark.streaming.dstream
+
+import org.apache.spark.streaming.{Time, Duration}
+import org.apache.spark.rdd.RDD
+import scala.reflect.ClassTag
+
+
+
+private[streaming]
+class ProratedEventDStream[T: ClassTag](parent: DStream[T],
+                                             filterFunc: (Time,Time) => T => Boolean,
+                                             prorateFunc: (Time,Time) => T => (T,Double),
+                                             sizeNumBatches: Int,
+
+                                             delayNumBins: Int
+
+                                             )
+  extends DStream[(T, Double)](parent.ssc) {
+
+  override def dependencies = List(parent)
+
+  override def slideDuration: Duration = parent.slideDuration
+
+  override def compute(validTime: Time) = {
+
+    //
+    // Assumption: start(x) <= end(x) <= boundaryEnd
+    //
+
+    def binStart = (validTime - Duration(1)).floor(slideDuration * sizeNumBatches) - slideDuration * sizeNumBatches * delayNumBins
+    def binEnd = binStart + slideDuration * sizeNumBatches
+
+    parent.getOrCompute(validTime).map(
+
+      _.filter(
+        filterFunc(binStart, binEnd)
+      ).map(
+        prorateFunc(binStart, binEnd)
+      )
+    )
+  }
+}
+

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/PulsatingWindowDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/PulsatingWindowDStream.scala
@@ -35,11 +35,13 @@ class PulsatingWindowDStream[T: ClassTag](parent: DStream[T],
 
   override def slideDuration: Duration = parent.slideDuration
 
-  override def parentRememberDuration: Duration = rememberDuration + parent.slideDuration * sizeNumBatches * (delayNumBins + 1)
+  override def parentRememberDuration: Duration = 
+    rememberDuration + parent.slideDuration * sizeNumBatches * (delayNumBins + 1)
 
   override def compute(validTime: Time): Option[RDD[T]] = {
 
-    val binStart = (validTime - Duration(1)).floor(slideDuration * sizeNumBatches) - slideDuration * sizeNumBatches * delayNumBins
+    val binStart = (validTime - Duration(1)).floor(slideDuration * sizeNumBatches) - 
+      slideDuration * sizeNumBatches * delayNumBins
 
     val currentWindow = new Interval(binStart + slideDuration, validTime)
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/PulsatingWindowDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/PulsatingWindowDStream.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.streaming.dstream
 
 import org.apache.spark.storage.StorageLevel

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/PulsatingWindowDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/PulsatingWindowDStream.scala
@@ -1,0 +1,34 @@
+package org.apache.spark.streaming.dstream
+
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.rdd.{UnionRDD, RDD}
+import org.apache.spark.streaming.{Time, Duration, Interval}
+import scala.reflect.ClassTag
+
+
+private[streaming]
+class PulsatingWindowDStream[T: ClassTag](parent: DStream[T],
+                                               sizeNumBatches: Int,
+                                               delayNumBins: Int)
+  extends DStream[T](parent.ssc) {
+
+  parent.persist(StorageLevel.MEMORY_ONLY_SER)
+
+  override def dependencies = List(parent)
+
+  override def slideDuration: Duration = parent.slideDuration
+
+  override def parentRememberDuration: Duration = rememberDuration + parent.slideDuration * sizeNumBatches * (delayNumBins + 1)
+
+  override def compute(validTime: Time): Option[RDD[T]] = {
+
+    val binStart = (validTime - Duration(1)).floor(slideDuration * sizeNumBatches) - slideDuration * sizeNumBatches * delayNumBins
+
+    val currentWindow = new Interval(binStart + slideDuration, validTime)
+
+    Some(new UnionRDD(parent.ssc.sc, parent.slice(currentWindow)))
+  }
+}
+
+
+

--- a/streaming/src/test/scala/org/apache/spark/streaming/BinStreamerTestSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/BinStreamerTestSuite.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.streaming.binning
 
 import scala.Array

--- a/streaming/src/test/scala/org/apache/spark/streaming/BinStreamerTestSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/BinStreamerTestSuite.scala
@@ -1,0 +1,374 @@
+package org.apache.spark.streaming.binning
+
+import scala.Array
+import org.apache.spark.streaming.binning._
+import org.apache.spark.streaming._
+import org.apache.spark.streaming.dstream._
+import scala.language.reflectiveCalls
+import scala.language.existentials
+import scala.language.implicitConversions
+
+case class ProrateGenerator(bStart: Int, bEnd: Int) {
+
+  type Tuple = (Int, Int)
+
+  //
+  // binStart is not inclusive for a bin, hence ensuring that for a binSize 1 i.e from x to x+1 inBin maps a time to x+1
+  //
+  private def inBin(dur: Int) = (dur - 1) / 2 + 1
+
+  // Event starts before BinStart
+  private val evStart1 = bStart - 2
+  // Event starts at BinStart
+  private val evStart2 = bStart
+  // Event starts in Bin
+  private val evStart3 = inBin(bStart + bEnd)
+  // Event starts at BinEnd
+  private val evStart4 = bEnd
+  // Event starts after BinEnd. No output case
+  private val evStart5 = bEnd + 2
+
+  private def _input(evStart: Int) =
+    Seq(
+      // No output case
+      (evStart, bStart - 2),
+      // No output case
+      (evStart, bStart - 1),
+      // No output case
+      (evStart, bStart),
+      (evStart, inBin(bStart + inBin(bStart + bEnd))),
+      (evStart, inBin(bStart + bEnd)),
+      (evStart, inBin(inBin(bStart + bEnd) + bEnd)),
+      (evStart, bEnd),
+      (evStart, bEnd + 1),
+      (evStart, bEnd + 2),
+      (evStart, bEnd + 3)
+    )
+
+  private def prorate(eDuration: Int, eRelevant: Int) =
+    if (eDuration == 0)
+      1.0
+    else
+      (eRelevant.toDouble) / eDuration
+
+  private def valid(evStart: Int, evEnd: Int) =
+    if (evStart > evEnd)
+      None
+    else
+      Some((evStart, evEnd))
+
+  private def inside(evStart: Int, evEnd: Int) =
+    if (evStart == bEnd)
+      None
+    else
+      Some((evStart, evEnd))
+
+  val input = Seq(_input(evStart1) ++ _input(evStart2) ++ _input(evStart3) ++ _input(evStart4) ++ _input(evStart5))
+
+  case class EvStart() {
+    var v: Int = 0
+
+    def set(value: Int) = {
+      v = value;
+      v
+    }
+  }
+
+  val evStart = EvStart()
+
+  val output =
+    Seq(Seq(
+      // bStart - 2
+      Some(evStart.set(bStart - 2), inBin(bStart + inBin(bStart + bEnd))).map(x => (x, prorate(x._2 - x._1, x._2 - bStart))),
+      Some(evStart.v, inBin(bStart + bEnd)).map(x => (x, prorate(x._2 - x._1, x._2 - bStart))),
+      Some(evStart.v, inBin(inBin(bStart + bEnd) + bEnd)).map(x => (x, prorate(x._2 - x._1, x._2 - bStart))),
+      Some(evStart.v, bEnd).map(x => (x, prorate(x._2 - x._1, bEnd - bStart))),
+      Some(evStart.v, bEnd + 1).map(x => (x, prorate(x._2 - x._1, bEnd - bStart))),
+      Some(evStart.v, bEnd + 2).map(x => (x, prorate(x._2 - x._1, bEnd - bStart))),
+      Some(evStart.v, bEnd + 3).map(x => (x, prorate(x._2 - x._1, bEnd - bStart))),
+
+      // bStart
+      Some(evStart.set(bStart), inBin(bStart + inBin(bStart + bEnd))).map(x => (x, prorate(x._2 - x._1, x._2 - bStart))),
+      Some(evStart.v, inBin(bStart + bEnd)).map(x => (x, prorate(x._2 - x._1, x._2 - bStart))),
+      Some(evStart.v, inBin(inBin(bStart + bEnd) + bEnd)).map(x => (x, prorate(x._2 - x._1, x._2 - bStart))),
+      Some(evStart.v, bEnd).map(x => (x, prorate(x._2 - x._1, bEnd - bStart))),
+      Some(evStart.v, bEnd + 1).map(x => (x, prorate(x._2 - x._1, bEnd - bStart))),
+      Some(evStart.v, bEnd + 2).map(x => (x, prorate(x._2 - x._1, bEnd - bStart))),
+      Some(evStart.v, bEnd + 3).map(x => (x, prorate(x._2 - x._1, bEnd - bStart))),
+
+      // inBin
+      valid(evStart.set(inBin(bStart + bEnd)), inBin(bStart + inBin(bStart + bEnd))).map(x => (x, prorate(x._2 - x._1, x._2 - x._1))),
+      Some(evStart.v, inBin(bStart + bEnd)).map((_, 1.0)),
+      Some(evStart.v, inBin(inBin(bStart + bEnd) + bEnd)).map((_, 1.0)),
+      Some(evStart.v, bEnd).map(x => (x, prorate(x._2 - x._1, bEnd - x._1))),
+      inside(evStart.v, bEnd + 1).map(x => (x, prorate(x._2 - x._1, bEnd - x._1))),
+      inside(evStart.v, bEnd + 2).map(x => (x, prorate(x._2 - x._1, bEnd - x._1))),
+      inside(evStart.v, bEnd + 3).map(x => (x, prorate(x._2 - x._1, bEnd - x._1))),
+
+      // bEnd
+      valid(evStart.set(bEnd), inBin(bStart + inBin(bStart + bEnd))).map((_, 1.0)),
+      valid(evStart.v, inBin(bStart + bEnd)).map((_, 1.0)),
+      valid(evStart.v, inBin(inBin(bStart + bEnd) + bEnd)).map((_, 1.0)),
+      Some(evStart.v, bEnd).map((_, 1.0))
+
+      // bEnd + 2
+
+    ).filter({
+      case Some(x) => true
+      case None => false
+    }).map(_.get))
+
+  def getStartTime(x: Tuple) = Time(x._1 * 1000)
+
+  def getEndTime(x: Tuple) = Time(x._2 * 1000)
+
+  def proratedStream(in: DStream[Tuple]) = {
+
+    val b = new BinStreamer[Tuple](in, getStartTime, getEndTime)
+
+    b.incrementalStreams(bEnd - bStart, 0)(0).getDStream
+  }
+}
+
+case class DataGenerator(seed: Seq[Seq[Int]], batchSize: Int, binSize: Int) {
+
+  type Tuple = (Int, Int, Int, Int)
+
+  def getBin(batch: Int, _delay: Int): Option[Tuple] = {
+
+    val start = ((batch * batchSize) / (binSize * batchSize)) * (binSize * batchSize) + _delay * binSize * batchSize
+
+    if (start < 0)
+      None
+    else
+      Some((start, batch * batchSize + _delay * binSize * batchSize + batchSize, batch, _delay))
+
+  }
+
+  val batches = seed.size
+
+  val input = Array.tabulate(seed.size)(
+    batchId => seed(batchId).map(
+      _relBin => getBin(batchId, _relBin)
+    ).filter({
+      case Some(x) => true
+      case None => false
+    }).map(
+      _.get
+    )
+  ).toSeq
+
+  val delay = {
+    var d: Int = 0
+    Array.tabulate(seed.size)({
+      batchId => seed(batchId).map(
+        _relBin => {
+          val c = (batchId * batchSize) % (binSize * batchSize) / batchSize + 1 - ((1 + _relBin) * (binSize * batchSize) / batchSize);
+          d = if (c > d) c else d
+        }
+      )
+    })
+    d
+  }
+
+  val numStreams = ((binSize + delay) * batchSize - 1) / (binSize * batchSize) + 1
+
+  val output = Array.tabulate(numStreams)(
+    delayNumBins => Array.tabulate(seed.size)(
+      batchId => seed(batchId).filter(
+        _relBin => if (_relBin == -delayNumBins) true else false
+      ).map(
+        _relBin => getBin(batchId, _relBin)
+      ).filter({
+        case Some(x) => true;
+        case None => false
+      }).map(
+        _.get
+      ).map(
+        (_, 1.0)
+      )
+    ).toSeq
+  )
+
+  val incrementalStreamOutput = output
+
+  val updatedStreamOutput = for (u <- 0 until numStreams) yield {
+
+    for (batchId <- 0 until seed.size) yield {
+
+      var ud: Seq[(Tuple, Double)] = Seq()
+
+      for (i <- 0 to u) {
+
+        val floor = (batchId / binSize) * binSize
+
+        for (l <- floor - binSize * (u - i) until {
+          if (u == i) batchId + 1 else floor - binSize * (u - i - 1)
+        } by 1) {
+          if (l >= 0)
+            ud ++= output(i)(l)
+          else
+            Nil
+        }
+      }
+
+      ud
+    }
+  }
+
+  val finalStreamOutput = updatedStreamOutput(numStreams - 1).zipWithIndex.filter(x => (x._2 + 1) % binSize == 0).unzip._1
+
+  def getStartTime(x: Tuple) = Time(x._1 * 1000)
+
+  def getEndTime(x: Tuple) = Time(x._2 * 1000)
+
+  def incrementalStream(in: DStream[Tuple], delayNumBins: Int) = {
+
+    val b = new BinStreamer[Tuple](in, getStartTime, getEndTime)
+
+    b.incrementalStreams(binSize, delay)(delayNumBins).getDStream
+  }
+
+  def finalStream(in: DStream[Tuple]) = {
+
+    val b = new BinStreamer[Tuple](in, getStartTime, getEndTime)
+
+    b.finalStream(binSize, delay).getDStream
+  }
+
+  def updatedStream(in: DStream[Tuple], delayNumBins: Int) = {
+
+    val b = new BinStreamer[Tuple](in, getStartTime, getEndTime)
+
+    b.updatedStreams(binSize, delay)(delayNumBins).getDStream
+  }
+
+}
+
+
+class BinStreamerTestSuite extends TestSuiteBase {
+
+  implicit def toDataGenerator(seq: Seq[Seq[Int]]) = {
+    new {
+      var batchSz: Int = _
+      var binSz: Int = _
+
+      def batchSize(batchSz: Int) = {
+        this.batchSz = batchSz;
+        this
+      }
+
+      def binSize(binSz: Int) = {
+        this.binSz = binSz;
+        this
+      }
+
+      def generator = DataGenerator(seq, batchSz, binSz)
+    }
+  }
+
+  override def framework() = "BinStreamerTestSuite"
+
+  System.setProperty("testing.batch.duration", "1")
+  
+  override def batchDuration = Seconds(System.getProperty("testing.batch.duration").toLong)
+
+  def testProrate(data: ProrateGenerator) = testOperation(
+    data.input,
+    (r: DStream[data.Tuple]) => data.proratedStream(r),
+    data.output
+  )
+
+
+  test("Prorate events for bin starting at 0 and ending at 1") {
+
+    testProrate(ProrateGenerator(0, 1))
+  }
+
+  test("Prorate events for bin starting at 0 and ending at 2") {
+
+    testProrate(ProrateGenerator(0, 2))
+  }
+
+  test("Prorate events for bin starting at 0 and ending at 3") {
+
+    testProrate(ProrateGenerator(0, 3))
+  }
+
+
+  /*
+   This data set represents a streaming data. Where the sequence elements represents the batches.
+   Each batch is a sequence of numbers which represents records pertaining to the
+   bin relative to this batch. So 0 represents data belonging to bin corresponding to this batch.
+   -1 represents the bin prior to the bin belonging to this batch. And so on ...
+
+   This data set is an input to a DataGenerator which provides the input and the output, which is
+   can then tested for the various binning cases.
+
+   The data set generates records which fit the complete bin. The tuple generated is (start,end)
+   where start is the binStart in Seconds and the end is the binStart + relative batch number for a bin.
+   In addition it also has a record which identifies batch in with it was generated.
+   */
+
+  val dataSet = Seq(
+    Seq(),
+    Seq(0, -1),
+    Seq(0, -1),
+    Seq(0, -1),
+    Seq(0, -1),
+    Seq(0, -1),
+    Seq(0, -2),
+    Seq(),
+    Seq(),
+    Seq(),
+    Seq(),
+    Seq(),
+    Seq()
+  )
+
+  for (binSize <- 1 to 4; batchSize <- 1 to 3) {
+
+    val dataGenerator = dataSet.batchSize(batchSize).binSize(binSize).generator
+
+    for (delayNumBins <- 0 until dataGenerator.numStreams) {
+
+      test("Incremental BinStream(" + delayNumBins + "), for batchSize(" + batchSize + "), binSize(" + binSize + ")") {
+
+        System.setProperty("testing.batch.duration", dataGenerator.batchSize.toString())
+
+        testOperation(
+          dataGenerator.input,
+          (r: DStream[dataGenerator.Tuple]) => dataGenerator.incrementalStream(r, delayNumBins),
+          dataGenerator.incrementalStreamOutput(delayNumBins)
+        )
+      }
+
+      test("Updated BinStream(" + delayNumBins + "),     for batchSize(" + batchSize + "), binSize(" + binSize + ")") {
+
+        System.setProperty("testing.batch.duration", dataGenerator.batchSize.toString())
+
+        testOperation(
+          dataGenerator.input,
+          (r: DStream[dataGenerator.Tuple]) => dataGenerator.updatedStream(r, delayNumBins),
+          dataGenerator.updatedStreamOutput(delayNumBins)
+        )
+      }
+
+    }
+    test("Final BinStream,          for batchSize(" + batchSize + "), binSize(" + binSize + ")") {
+
+      System.setProperty("testing.batch.duration", dataGenerator.batchSize.toString())
+
+      testOperation(
+        dataGenerator.input,
+        (r: DStream[dataGenerator.Tuple]) => dataGenerator.finalStream(r),
+        dataGenerator.finalStreamOutput,
+        dataGenerator.batches,
+        false
+      )
+    }
+
+  }
+
+}
+


### PR DESCRIPTION
Topic: Spark Streaming using Event TimeStamps

Spark streaming creates a batch (RDD) of events every T duration. The batch is based on a schedule and the timestamp associated with the batch is the time at which it was scheduled by Spark. Spark applied timestamp may be less relevant than the timestamp for which the event was originally meant to be.

The fundamental reason for the event timestamp to differ from the spark stamp is the delay in event generation in the upstream system and delay in transporting the event to spark after the event generation. The problem is compounded in case of events having a start and an end with both the timestamps packed in a single event generated after the event ends as illustrated in the following diagram.

(upstream) -------s--------e----g---------------->
(spark   ) ------------------------r------------->

Horizontal axis is time. Event starts at s ends at e and the event record is generated at g, which is then received by spark at r.

So there is a need to create batches which only contain the relevant events or the relevant proportion of the events according to the original timestamp passed to Spark as a part of the received tuples.  Lets refer to a batch which has all the events occurring in the time window it represents as a bin. So a bin from T1 - T2 will 'only have events' which occurred in the period T1 - T2. The definition of the bin can be extended to include ‘all the events’ which occurred in a given period, however second constraint is harder to satisfy in practice, because events can be arbitrarily delayed. 

For the rest of the discussion the definition of the batch and the bin shall be as per the previous paragraph.

Bin sizes determine time series time granularity and is an independent consideration in itself i.e independent of the batch/event/delay.

Lets say that batch size is T and the bin size is n_T and an event is delayed (for reception) at a maximum by d_T. So in order to generate a bin, n + d batches of size T are required.

Conversely every batch is going to contribute to current up till the last ceiling((n + d)/ n) bins.

For for batch @ t. The contents can be seen as T1 @ t (where the notation T1 @ t implies events corresponding to bin T1 from batch t), T1 - 1 @t, T1 - 2 @t ... T1 - m @ t (where T1 - 1, represents the bin previous to T1 and m = ceiling(n + d)/ n))).

We can then de-multiplex the contributions from batch @ t into bins T1, T1 - 1, T1 - 2, T1 -3, resulting into streams which represent partial bins relative to the batch stream. So a stream i represents partial bin T1 - i received at t. This way the spark application can deliver incremental bins to the downstream in the most real time possible. Now depending on how the downstream application can handle the partial bins, the definition and the generation of the streams needs to be controlled.

Cases:
1. The downstream application can handle incremental updates to the bin (i.e. a partial bin = current partial bin + latest partial bin). For this what is required is m streams  which send the updates every T interval where

Stream 1: T1 @ t
Stream 2: T1 - 1 @ t
…
Stream m: T1 - m @ t.
1. The downstream application can only handle full updates to the bin ( i.e. partial bin = latest partial bin). For this what is required is m streams  which send the updates every T interval where

Stream 1: T1         @ t
Stream 2: T1 - 1    @ t +  @ t - 1
...
Stream m: T1 - m @ t +  … +  @ t - m 

i.e a bin is getting updated at every T until the bin is final. The first stream represents the most current bin with the latest cumulative update. The next stream represents the previous bin with the latest cumulative update and so on. Until the last stream which represents a final bin.
1. The downstream application cannot handle updates to a bin. This is basically the last stream from case 2 (highlighted in bold) with the exception that it slides by nT and not T. Note that the next bin after T1 @ t is  T1 + 1 @ t + n_T, because the size of the bin is n_T.

Typically each stream needs to treated similarly because it represents that same kind of content, however there can be use cases where the stream may be required to be treated differently. A consideration for the API.

Implementation:

In order to transform a batch stream to a partial bin stream, we can filter the events and put the prorated events in a bin streams representing T @ t, T-1 @ t and so on.

For this we can define a new DStream which generates a DStream by prorating the data from batch to a bin corresponding to the stream. 

For the use case 2 which requires progressively accumulating all the events for a bin. A new DStream is required which generates a pulsating window which goes from (s_n + 1) to (s_n + n) where s is the partial stream index. A stream index 0 implies that it is the most current partial bin stream.
## APIs

BinStreamer[T](DStream[T], start: T=>Time, end: T=>Time)
This will return a BinStreamer object.

The BinStreamer object can be used to generate incremental bin streams (case 1)/ final bin (case 3) stream/ updated bin streams (case 2) using the following APIs.

BinStreamer.incrementalStreams(sizeInNumBatches: Int, delayIndex: Int, numStreams: Int) : Seq[BinStream[(T,percentage)]] 

BinStreamer.finalStream(sizeInNumBatches: Int, delayIndex: Int) : BinStream[(T,percentage)]

BinStreamer.updatedStreams(sizeInNumBatches: Int, delayIndex: Int, numStreams: Int) : Seq[BinStream[(T,percentage)]]

```
    DStream[T] : This is the batch stream.
        start : Closure to get the start time from the record.
end : Closure to get the end time from the record.
sizeInNumBatches : The size of bin as a multiple of batch size.
delayIndex : The maximum delay between the event relevance and event reception.
```

numStreams: This is the number of bin streams. Even though it is fixed by batch size, bin size and the delayIndex. This is an  optional parameter to control the number of output Streams and it does so by delaying the most current bin.

Each BinStream will wrap a DStream.


  def prorate(binStart: Time, binEnd: Time)(x: T) = {

```
  val sx = startFunc(x)
  val ex = endFunc(x)

  // Even though binStart is not inclusive, binStart here implies limit x as x approaches binStart+
  val s = if (sx > binStart) sx else binStart

  val e = if (ex < binEnd) ex else binEnd

  if (ex == sx) {
    (x, 1.0)
  }
  else {
    (x, (e - s) / (ex - sx))
  }
```

  }

  def filter(binStart: Time, binEnd: Time)(x: T) = {

```
// The flow is starting in the subsequent bin
if (startFunc(x) > binEnd) false

// The flow ended in the prior bin
else if (endFunc(x) <= binStart) false

// start(x) approaches from binEnd+
else if (startFunc(x) == binEnd && endFunc(x) > binEnd) false

else true
```

  }
