### PR TITLE
[Spark] RDD take() method: overestimate too much

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/AsyncRDDActions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/AsyncRDDActions.scala
@@ -85,7 +85,8 @@ class AsyncRDDActions[T: ClassTag](self: RDD[T]) extends Serializable with Loggi
             numPartsToTry = partsScanned * 4
           } else {
             // the left side of max is >=1 whenever partsScanned >= 2
-            numPartsToTry = Math.max((1.5 * num * partsScanned / results.size).toInt - partsScanned, 1)
+            numPartsToTry = Math.max(1, 
+              (1.5 * num * partsScanned / results.size).toInt - partsScanned)
             numPartsToTry = Math.min(numPartsToTry, partsScanned * 4) 
           }
         }

--- a/core/src/main/scala/org/apache/spark/rdd/AsyncRDDActions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/AsyncRDDActions.scala
@@ -84,7 +84,8 @@ class AsyncRDDActions[T: ClassTag](self: RDD[T]) extends Serializable with Loggi
           if (results.size == 0) {
             numPartsToTry = totalParts - 1
           } else {
-            numPartsToTry = ((1.5 * num * partsScanned / results.size).toInt - partsScanned) max 1   // the left side of max is >=1 whenever partsScanned >= 2
+            // the left side of max is >=1 whenever partsScanned >= 2
+            numPartsToTry = ((1.5 * num * partsScanned / results.size).toInt - partsScanned) max 1
           }
         }
 

--- a/core/src/main/scala/org/apache/spark/rdd/AsyncRDDActions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/AsyncRDDActions.scala
@@ -82,11 +82,11 @@ class AsyncRDDActions[T: ClassTag](self: RDD[T]) extends Serializable with Loggi
           // Otherwise, interpolate the number of partitions we need to try, but overestimate it
           // by 50%. We also cap the estimation in the end.
           if (results.size == 0) {
-            numPartsToTry = totalParts * 4
+            numPartsToTry = partsScanned * 4
           } else {
             // the left side of max is >=1 whenever partsScanned >= 2
             numPartsToTry = ((1.5 * num * partsScanned / results.size).toInt - partsScanned) max 1
-            numPartsToTry = numPartsToTry min (totalParts * 4) 
+            numPartsToTry = numPartsToTry min (partsScanned * 4) 
           }
         }
 

--- a/core/src/main/scala/org/apache/spark/rdd/AsyncRDDActions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/AsyncRDDActions.scala
@@ -85,8 +85,8 @@ class AsyncRDDActions[T: ClassTag](self: RDD[T]) extends Serializable with Loggi
             numPartsToTry = partsScanned * 4
           } else {
             // the left side of max is >=1 whenever partsScanned >= 2
-            numPartsToTry = ((1.5 * num * partsScanned / results.size).toInt - partsScanned) max 1
-            numPartsToTry = numPartsToTry min (partsScanned * 4) 
+            numPartsToTry = Math.max((1.5 * num * partsScanned / results.size).toInt - partsScanned, 1)
+            numPartsToTry = Math.min(numPartsToTry, partsScanned * 4) 
           }
         }
 

--- a/core/src/main/scala/org/apache/spark/rdd/AsyncRDDActions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/AsyncRDDActions.scala
@@ -84,10 +84,9 @@ class AsyncRDDActions[T: ClassTag](self: RDD[T]) extends Serializable with Loggi
           if (results.size == 0) {
             numPartsToTry = totalParts - 1
           } else {
-            numPartsToTry = (1.5 * num * partsScanned / results.size).toInt
+            numPartsToTry = ((1.5 * num * partsScanned / results.size).toInt - partsScanned) max 1   // the left side of max is >=1 whenever partsScanned >= 2
           }
         }
-        numPartsToTry = math.max(0, numPartsToTry)  // guard against negative num of partitions
 
         val left = num - results.size
         val p = partsScanned until math.min(partsScanned + numPartsToTry, totalParts)

--- a/core/src/main/scala/org/apache/spark/rdd/AsyncRDDActions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/AsyncRDDActions.scala
@@ -78,14 +78,15 @@ class AsyncRDDActions[T: ClassTag](self: RDD[T]) extends Serializable with Loggi
         // greater than totalParts because we actually cap it at totalParts in runJob.
         var numPartsToTry = 1
         if (partsScanned > 0) {
-          // If we didn't find any rows after the first iteration, just try all partitions next.
+          // If we didn't find any rows after the previous iteration, quadruple and retry.
           // Otherwise, interpolate the number of partitions we need to try, but overestimate it
-          // by 50%.
+          // by 50%. We also cap the estimation in the end.
           if (results.size == 0) {
-            numPartsToTry = totalParts - 1
+            numPartsToTry = totalParts * 4
           } else {
             // the left side of max is >=1 whenever partsScanned >= 2
             numPartsToTry = ((1.5 * num * partsScanned / results.size).toInt - partsScanned) max 1
+            numPartsToTry = numPartsToTry min (totalParts * 4) 
           }
         }
 

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1086,8 +1086,8 @@ abstract class RDD[T: ClassTag](
           numPartsToTry = partsScanned * 4
         } else {
           // the left side of max is >=1 whenever partsScanned >= 2
-          numPartsToTry = ((1.5 * num * partsScanned / buf.size).toInt - partsScanned) max 1
-          numPartsToTry = numPartsToTry min (partsScanned * 4) 
+          numPartsToTry = Math.max((1.5 * num * partsScanned / buf.size).toInt - partsScanned, 1)
+          numPartsToTry = Math.min(numPartsToTry, partsScanned * 4) 
         }
       }
 

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1079,13 +1079,15 @@ abstract class RDD[T: ClassTag](
       // greater than totalParts because we actually cap it at totalParts in runJob.
       var numPartsToTry = 1
       if (partsScanned > 0) {
-        // If we didn't find any rows after the previous iteration, quadruple and retry.  Otherwise,
+        // If we didn't find any rows after the previous iteration, quadruple and retry. Otherwise,
         // interpolate the number of partitions we need to try, but overestimate it by 50%.
+        // We also cap the estimation in the end.
         if (buf.size == 0) {
           numPartsToTry = partsScanned * 4
         } else {
           // the left side of max is >=1 whenever partsScanned >= 2
           numPartsToTry = ((1.5 * num * partsScanned / buf.size).toInt - partsScanned) max 1
+          numPartsToTry = numPartsToTry min (partsScanned * 4) 
         }
       }
 

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1084,7 +1084,7 @@ abstract class RDD[T: ClassTag](
         if (buf.size == 0) {
           numPartsToTry = partsScanned * 4
         } else {
-          numPartsToTry = (1.5 * num * partsScanned / buf.size).toInt - partsScanned
+          numPartsToTry = ((1.5 * num * partsScanned / buf.size).toInt - partsScanned) max 1   // the left side of max is >=1 whenever partsScanned >= 2
         }
       }
 

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1084,7 +1084,8 @@ abstract class RDD[T: ClassTag](
         if (buf.size == 0) {
           numPartsToTry = partsScanned * 4
         } else {
-          numPartsToTry = ((1.5 * num * partsScanned / buf.size).toInt - partsScanned) max 1   // the left side of max is >=1 whenever partsScanned >= 2
+          // the left side of max is >=1 whenever partsScanned >= 2
+          numPartsToTry = ((1.5 * num * partsScanned / buf.size).toInt - partsScanned) max 1
         }
       }
 

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1084,10 +1084,9 @@ abstract class RDD[T: ClassTag](
         if (buf.size == 0) {
           numPartsToTry = partsScanned * 4
         } else {
-          numPartsToTry = (1.5 * num * partsScanned / buf.size).toInt
+          numPartsToTry = (1.5 * num * partsScanned / buf.size).toInt - partsScanned
         }
       }
-      numPartsToTry = math.max(0, numPartsToTry)  // guard against negative num of partitions
 
       val left = num - buf.size
       val p = partsScanned until math.min(partsScanned + numPartsToTry, totalParts)

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -1070,11 +1070,13 @@ class RDD(object):
                 # If we didn't find any rows after the previous iteration,
                 # quadruple and retry.  Otherwise, interpolate the number of
                 # partitions we need to try, but overestimate it by 50%.
+                # We also cap the estimation in the end.
                 if len(items) == 0:
                     numPartsToTry = partsScanned * 4
                 else:
                     #the first paramter of max is >=1 whenever partsScanned >= 2
                     numPartsToTry = max(int(1.5 * num * partsScanned / len(items)) - partsScanned, 1)
+                    numPartsToTry = min(numPartsToTry, partsScanned * 4)
 
             left = num - len(items)
 

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -1073,7 +1073,8 @@ class RDD(object):
                 if len(items) == 0:
                     numPartsToTry = partsScanned * 4
                 else:
-                    numPartsToTry = int(1.5 * num * partsScanned / len(items))
+                    #the first paramter of max is >=1 whenever partsScanned >= 2
+                    numPartsToTry = max(int(1.5 * num * partsScanned / len(items)) - partsScanned, 1)
 
             left = num - len(items)
 

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -1074,9 +1074,9 @@ class RDD(object):
                 if len(items) == 0:
                     numPartsToTry = partsScanned * 4
                 else:
-                    #the first paramter of max is >=1 whenever partsScanned >= 2
-                    numPartsToTry = max(int(1.5 * num * partsScanned / len(items)) - partsScanned, 1)
-                    numPartsToTry = min(numPartsToTry, partsScanned * 4)
+                    # the first paramter of max is >=1 whenever partsScanned >= 2
+                    numPartsToTry = int(1.5 * num * partsScanned / len(items)) - partsScanned
+                    numPartsToTry = min(max(numPartsToTry, 1), partsScanned * 4)
 
             left = num - len(items)
 


### PR DESCRIPTION
In the comment (Line 1083), it says: "Otherwise, interpolate the number of partitions we need to try, but overestimate it by 50%."

`(1.5 * num * partsScanned / buf.size).toInt` is the guess of "num of total partitions needed". In every iteration, we should consider the increment `(1.5 * num * partsScanned / buf.size).toInt - partsScanned`
Existing implementation 'exponentially' grows `partsScanned` ( roughly: `x_{n+1} >= (1.5 + 1) x_n`)

This could be a performance problem. (unless this is the intended behavior)
