### PR TITLE
[SPARK-3793][SQL]use HiveConf/Context when parse hive ql

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -95,7 +95,7 @@ class HiveContext(sc: SparkContext) extends SQLContext(sc) {
     if (dialect == "sql") {
       super.sql(sqlText)
     } else if (dialect == "hiveql") {
-      new SchemaRDD(this, HiveQl.parseSql(sqlText))
+      new SchemaRDD(this, HiveQl.parseSql(sqlText, hiveconf))
     }  else {
       sys.error(s"Unsupported SQL dialect: $dialect.  Try 'sql' or 'hiveql'")
     }
@@ -103,7 +103,7 @@ class HiveContext(sc: SparkContext) extends SQLContext(sc) {
 
   @deprecated("hiveql() is deprecated as the sql function now parses using HiveQL by default. " +
              s"The SQL dialect for parsing can be set using ${SQLConf.DIALECT}", "1.1")
-  def hiveql(hqlQuery: String): SchemaRDD = new SchemaRDD(this, HiveQl.parseSql(hqlQuery))
+  def hiveql(hqlQuery: String): SchemaRDD = new SchemaRDD(this, HiveQl.parseSql(hqlQuery, hiveconf))
 
   @deprecated("hql() is deprecated as the sql function now parses using HiveQL by default. " +
              s"The SQL dialect for parsing can be set using ${SQLConf.DIALECT}", "1.1")

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TestHive.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TestHive.scala
@@ -142,7 +142,7 @@ class TestHiveContext(sc: SparkContext) extends HiveContext(sc) {
   val describedTable = "DESCRIBE (\\w+)".r
 
   protected[hive] class HiveQLQueryExecution(hql: String) extends this.QueryExecution {
-    lazy val logical = HiveQl.parseSql(hql)
+    lazy val logical = HiveQl.parseSql(hql, hiveconf)
     def hiveExec() = runSqlHive(hql)
     override def toString = hql + "\n" + super.toString
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/api/java/JavaHiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/api/java/JavaHiveContext.scala
@@ -34,7 +34,7 @@ class JavaHiveContext(sparkContext: JavaSparkContext) extends JavaSQLContext(spa
     if (sqlContext.dialect == "sql") {
       super.sql(sqlText)
     } else if (sqlContext.dialect == "hiveql") {
-      new JavaSchemaRDD(sqlContext, HiveQl.parseSql(sqlText))
+      new JavaSchemaRDD(sqlContext, HiveQl.parseSql(sqlText, sqlContext.hiveconf))
     }  else {
       sys.error(s"Unsupported SQL dialect: ${sqlContext.dialect}.  Try 'sql' or 'hiveql'")
     }
@@ -45,5 +45,5 @@ class JavaHiveContext(sparkContext: JavaSparkContext) extends JavaSQLContext(spa
     */
   @Deprecated
   def hql(hqlQuery: String): JavaSchemaRDD =
-    new JavaSchemaRDD(sqlContext, HiveQl.parseSql(hqlQuery))
+    new JavaSchemaRDD(sqlContext, HiveQl.parseSql(hqlQuery, sqlContext.hiveconf))
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
@@ -34,7 +34,7 @@ class StatisticsSuite extends QueryTest with BeforeAndAfterAll {
 
   test("parse analyze commands") {
     def assertAnalyzeCommand(analyzeCommand: String, c: Class[_]) {
-      val parsed = HiveQl.parseSql(analyzeCommand)
+      val parsed = HiveQl.parseSql(analyzeCommand, TestHive.hiveconf)
       val operators = parsed.collect {
         case a: AnalyzeTable => a
         case o => o


### PR DESCRIPTION
This PR is to make hive ql parser more general and compatible with both hive-0.12 and hive-0.13. In hive-0.13 we may need hiveconf(Context) when parsing a sql(quoted sql). For example, runing sql as follow without hiveconf will get NPE exception:

createQueryTest("quoted alias.attr",
    "SELECT `a`.`key` FROM src a ORDER BY key LIMIT 1")
[info] - quoted alias.attr **\* FAILED ***
[info]   org.apache.spark.sql.hive.HiveQl$ParseException: Failed to parse: SELECT `a`.`key` FROM src a ORDER BY key LIMIT 1
[info]   at org.apache.spark.sql.hive.HiveQl$.parseSql(HiveQl.scala:221)
[info]   at org.apache.spark.sql.hive.test.TestHiveContext$HiveQLQueryExecution.logical$lzycompute(TestHive.scala:143)
[info]   at org.apache.spark.sql.hive.test.TestHiveContext$HiveQLQueryExecution.logical(TestHive.scala:143)
[info]   at org.apache.spark.sql.hive.test.TestHiveContext$QueryExecution.analyzed$lzycompute(TestHive.scala:153)
[info]   at org.apache.spark.sql.hive.test.TestHiveContext$QueryExecution.analyzed(TestHive.scala:152)
[info]   at org.apache.spark.sql.SQLContext$QueryExecution.optimizedPlan$lzycompute(SQLContext.scala:403)
[info]   at org.apache.spark.sql.SQLContext$QueryExecution.optimizedPlan(SQLContext.scala:403)
[info]   at org.apache.spark.sql.SQLContext$QueryExecution.sparkPlan$lzycompute(SQLContext.scala:407)
[info]   at org.apache.spark.sql.SQLContext$QueryExecution.sparkPlan(SQLContext.scala:405)
[info]   at org.apache.spark.sql.SQLContext$QueryExecution.executedPlan$lzycompute(SQLContext.scala:411)
[info]   ...
[info]   Cause: java.lang.NullPointerException:
[info]   at org.apache.hadoop.hive.conf.HiveConf.getVar(HiveConf.java:1295)
[info]   at org.apache.hadoop.hive.ql.parse.HiveLexer.allowQuotedId(HiveLexer.java:342)
[info]   at org.apache.hadoop.hive.ql.parse.HiveLexer$DFA21.specialStateTransition(HiveLexer.java:10945)
[info]   at org.antlr.runtime.DFA.predict(DFA.java:80)
[info]   at org.apache.hadoop.hive.ql.parse.HiveLexer.mIdentifier(HiveLexer.java:7925)
[info]   at org.apache.hadoop.hive.ql.parse.HiveLexer.mTokens(HiveLexer.java:10818)
[info]   at org.antlr.runtime.Lexer.nextToken(Lexer.java:89)
[info]   at org.antlr.runtime.BufferedTokenStream.fetch(BufferedTokenStream.java:133)
[info]   at org.antlr.runtime.BufferedTokenStream.sync(BufferedTokenStream.java:127)
[info]   at org.antlr.runtime.CommonTokenStream.consume(CommonTokenStream.java:70)
