### PR TITLE
[SPARK-3801] More efficient app dir cleanup

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -719,8 +719,7 @@ private[spark] object Utils extends Logging {
     } else {
       val files = FileUtils.listFilesAndDirs(dir, TrueFileFilter.TRUE, TrueFileFilter.TRUE)
       val cutoffTimeInMillis = (currentTimeMillis - (cutoff * 1000))
-      val newFiles = files.filter { _.lastModified > cutoffTimeInMillis }
-      newFiles.nonEmpty
+      files.exists { _.lastModified > cutoffTimeInMillis }
     }
   }
 


### PR DESCRIPTION
The newly merged more conservative app directory cleanup can be more efficient. Since it is not needed to store newer files, using `exists` to check if newer files are there can be more efficient because redundant items are skipped.
