### PR TITLE
[SPARK-3806][SQL]Minor fix for CliSuite

### DIFF
--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -62,9 +62,11 @@ class CliSuite extends FunSuite with BeforeAndAfterAll with Logging {
 
     def captureOutput(source: String)(line: String) {
       buffer += s"$source> $line"
-      if (line.contains(expectedAnswers(next.get()))) {
-        if (next.incrementAndGet() == expectedAnswers.size) {
-          foundAllExpectedAnswers.trySuccess(())
+      if (next.get() < expectedAnswers.size) {
+        if (line.startsWith(expectedAnswers(next.get()))) {
+          if (next.incrementAndGet() == expectedAnswers.size) {
+            foundAllExpectedAnswers.trySuccess(())
+          }
         }
       }
     }


### PR DESCRIPTION
To fix two issues in CliSuite
1 CliSuite throw IndexOutOfBoundsException:
Exception in thread "Thread-6" java.lang.IndexOutOfBoundsException: 6
    at scala.collection.mutable.ResizableArray$class.apply(ResizableArray.scala:43)
    at scala.collection.mutable.ArrayBuffer.apply(ArrayBuffer.scala:47)
    at org.apache.spark.sql.hive.thriftserver.CliSuite.org$apache$spark$sql$hive$thriftserver$CliSuite$$captureOutput$1(CliSuite.scala:67)
    at org.apache.spark.sql.hive.thriftserver.CliSuite$$anonfun$4.apply(CliSuite.scala:78)
    at org.apache.spark.sql.hive.thriftserver.CliSuite$$anonfun$4.apply(CliSuite.scala:78)
    at scala.sys.process.ProcessLogger$$anon$1.out(ProcessLogger.scala:96)
    at scala.sys.process.BasicIO$$anonfun$processOutFully$1.apply(BasicIO.scala:135)
    at scala.sys.process.BasicIO$$anonfun$processOutFully$1.apply(BasicIO.scala:135)
    at scala.sys.process.BasicIO$.readFully$1(BasicIO.scala:175)
    at scala.sys.process.BasicIO$.processLinesFully(BasicIO.scala:179)
    at scala.sys.process.BasicIO$$anonfun$processFully$1.apply(BasicIO.scala:164)
    at scala.sys.process.BasicIO$$anonfun$processFully$1.apply(BasicIO.scala:162)
    at scala.sys.process.ProcessBuilderImpl$Simple$$anonfun$3.apply$mcV$sp(ProcessBuilderImpl.scala:73)
    at scala.sys.process.ProcessImpl$Spawn$$anon$1.run(ProcessImpl.scala:22)

Actually, it is the Mutil-Threads lead to this problem.

2 Using `line.startsWith` instead `line.contains` to assert expected answer. This is a tiny bug in CliSuite, for test case "Simple commands", there is a expected answers "5", if we use `contains` that means output like "14/10/06 11:`5`4:36 INFO CliDriver: Time taken: 1.078 seconds" or "14/10/06 11:54:36 INFO StatsReportListener:  0%  `5`%    10% 25% 50% 75% 90% 95% 100%" will make the assert true.
