### PR TITLE
[SPARK-3809][SQL]fix HiveThriftServer2Suite to make it work correctly

### DIFF
--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suite.scala
@@ -82,9 +82,8 @@ class HiveThriftServer2Suite extends FunSuite with BeforeAndAfterAll  with Loggi
       if (line.contains(startString)) {
         val logFile = new File(line.substring(startString.length))
         var tryNum = 0
-        // This is a hack to wait logFile is ready
+        // This is a hack to wait logFile ready
         Thread.sleep(5000)
-
         // logFile may have not finished, try every second
         while (!logFile.exists() || (!fileToString(logFile).contains(
           "ThriftBinaryCLIService listening on") && tryNum < maxTries)) {

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suite.scala
@@ -21,6 +21,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future, Promise}
+import scala.io.Source
 import scala.sys.process.{Process, ProcessLogger}
 
 import java.io.File
@@ -30,19 +31,19 @@ import java.util.concurrent.TimeoutException
 
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars
 import org.apache.hive.jdbc.HiveDriver
-import org.scalatest.FunSuite
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
 
 import org.apache.spark.Logging
-import org.apache.spark.sql.catalyst.util.getTempFilePath
+import org.apache.spark.sql.catalyst.util._
 
 /**
  * Tests for the HiveThriftServer2 using JDBC.
  */
-class HiveThriftServer2Suite extends FunSuite with Logging {
+class HiveThriftServer2Suite extends FunSuite with BeforeAndAfterAll  with Logging {
   Class.forName(classOf[HiveDriver].getCanonicalName)
 
   private val listeningHost = "localhost"
-  private val listeningPort =  {
+  private val listeningPort = {
     // Let the system to choose a random available port to avoid collision with other parallel
     // builds.
     val socket = new ServerSocket(0)
@@ -54,10 +55,12 @@ class HiveThriftServer2Suite extends FunSuite with Logging {
   private val warehousePath = getTempFilePath("warehouse")
   private val metastorePath = getTempFilePath("metastore")
   private val metastoreJdbcUri = s"jdbc:derby:;databaseName=$metastorePath;create=true"
+  val jdbcUri = s"jdbc:hive2://$listeningHost:$listeningPort/"
+  val user = System.getProperty("user.name")
 
-  def startThriftServerWithin(timeout: FiniteDuration = 30.seconds)(f: Statement => Unit) {
+  override def beforeAll(): Unit = {
+    val timeout: FiniteDuration = 30.seconds
     val serverScript = "../../sbin/start-thriftserver.sh".split("/").mkString(File.separator)
-
     val command =
       s"""$serverScript
          |  --master local
@@ -70,37 +73,40 @@ class HiveThriftServer2Suite extends FunSuite with Logging {
 
     val serverStarted = Promise[Unit]()
     val buffer = new ArrayBuffer[String]()
+    val startString =
+      "starting org.apache.spark.sql.hive.thriftserver.HiveThriftServer2, logging to "
+    val maxTries = 30
 
     def captureOutput(source: String)(line: String) {
       buffer += s"$source> $line"
-      if (line.contains("ThriftBinaryCLIService listening on")) {
-        serverStarted.success(())
+      if (line.contains(startString)) {
+        val logFile = new File(line.substring(startString.length))
+        var tryNum = 0
+        // This is a hack to wait logFile is ready
+        Thread.sleep(5000)
+
+        // logFile may have not finished, try every second
+        while (!logFile.exists() || (!fileToString(logFile).contains(
+          "ThriftBinaryCLIService listening on") && tryNum < maxTries)) {
+          Thread.sleep(1000)
+        }
+        if (fileToString(logFile).contains("ThriftBinaryCLIService listening on")) {
+          serverStarted.success(())
+        } else {
+          throw new TimeoutException()
+        }
       }
     }
-
     val process = Process(command).run(
       ProcessLogger(captureOutput("stdout"), captureOutput("stderr")))
 
     Future {
       val exitValue = process.exitValue()
-      logInfo(s"Spark SQL Thrift server process exit value: $exitValue")
+      logInfo(s"Start Spark SQL Thrift server process exit value: $exitValue")
     }
-
-    val jdbcUri = s"jdbc:hive2://$listeningHost:$listeningPort/"
-    val user = System.getProperty("user.name")
 
     try {
       Await.result(serverStarted.future, timeout)
-
-      val connection = DriverManager.getConnection(jdbcUri, user, "")
-      val statement = connection.createStatement()
-
-      try {
-        f(statement)
-      } finally {
-        statement.close()
-        connection.close()
-      }
     } catch {
       case cause: Exception =>
         cause match {
@@ -123,14 +129,45 @@ class HiveThriftServer2Suite extends FunSuite with Logging {
              |=========================================
            """.stripMargin, cause)
     } finally {
-      warehousePath.delete()
-      metastorePath.delete()
       process.destroy()
     }
   }
 
+  override def afterAll() {
+    warehousePath.delete()
+    metastorePath.delete()
+    stopThriftserver
+  }
+
+  def stopThriftserver: Unit = {
+    val stopScript = "../../sbin/stop-thriftserver.sh".split("/").mkString(File.separator)
+    val builder = new ProcessBuilder(stopScript)
+    val process = builder.start()
+    new Thread("read stderr") {
+      override def run() {
+        for (line <- Source.fromInputStream(process.getErrorStream).getLines()) {
+          System.err.println(line)
+        }
+      }
+    }.start()
+    val output = new StringBuffer
+    val stdoutThread = new Thread("read stdout") {
+      override def run() {
+        for (line <- Source.fromInputStream(process.getInputStream).getLines()) {
+          output.append(line)
+        }
+      }
+    }
+    stdoutThread.start()
+    val exitValue = process.waitFor()
+    logInfo(s"Stop Spark SQL Thrift server process exit value: $exitValue")
+  }
+
   test("Test JDBC query execution") {
-    startThriftServerWithin() { statement =>
+    val connection = DriverManager.getConnection(jdbcUri, user, "")
+    val statement = connection.createStatement()
+
+    try {
       val dataFilePath =
         Thread.currentThread().getContextClassLoader.getResource("data/files/small_kv.txt")
 
@@ -146,11 +183,17 @@ class HiveThriftServer2Suite extends FunSuite with Logging {
         resultSet.next()
         resultSet.getInt(1)
       }
+    } finally {
+      statement.close()
+      connection.close()
     }
   }
 
   test("SPARK-3004 regression: result set containing NULL") {
-    startThriftServerWithin() { statement =>
+    val connection = DriverManager.getConnection(jdbcUri, user, "")
+    val statement = connection.createStatement()
+
+    try {
       val dataFilePath =
         Thread.currentThread().getContextClassLoader.getResource(
           "data/files/small_kv_with_null.txt")
@@ -169,8 +212,10 @@ class HiveThriftServer2Suite extends FunSuite with Logging {
         assert(resultSet.getInt(1) === 0)
         assert(resultSet.wasNull())
       }
-
       assert(!resultSet.next())
+    } finally {
+      statement.close()
+      connection.close()
     }
   }
 }


### PR DESCRIPTION
Currently HiveThriftServer2Suite is a fake one, actually HiveThriftServer not even started there. Issues here:
1 Thriftserver not started. Testing will get this error ---
ERROR HiveThriftServer2Suite: Failed to start Hive Thrift server within 30 seconds
java.util.concurrent.TimeoutException: Futures timed out after [30 seconds]
2 Thriftserver not stoped. After test finished the process of thriftserver did not exit.

This patch fix this problems as follows:
1 Since thriftserver started as a daemon in  https://github.com/apache/spark/pull/2509, output of the`start-thriftserver.sh` has be redirect to a log file such as `spark-kf-org.apache.spark.sql.hive.thriftserver.HiveThriftServer2-1-kf.out`, so to see whether this file contain "ThriftBinaryCLIService listening on" ` to assert server started successfully

2 Start server in `beforeAll`

3 stop server in `afterAll`
