### PR TITLE
[SPARK-3270] Spark API for Application Extensions

### DIFF
--- a/core/src/main/scala/org/apache/spark/PlatformExtension.scala
+++ b/core/src/main/scala/org/apache/spark/PlatformExtension.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark
+
+import org.apache.spark.ExtensionState.ExtensionState
+import org.apache.spark.InterceptionPoints.InterceptionPoints
+
+
+/** Notion of Spark application platform extension. */
+trait PlatformExtension extends Serializable {
+
+  /** Method to start extension */
+  def start(conf: SparkConf):Unit
+  /** Method to stop extension */
+  def stop (conf: SparkConf):Unit
+
+  /** Method to query actual state of extension */
+  def state : ExtensionState = ExtensionState.STOPPED
+
+  /* Point in Spark infrastructure which will be intercepted by this extension. */
+  def intercept: InterceptionPoints = InterceptionPoints.EXECUTOR_LC
+
+  /* User-friendly description of extension */
+  def desc:String
+
+  override def toString = s"$desc@$intercept"
+}
+
+/** Supported interception points.
+  *
+  * Currently only Executor life cycle is supported. */
+object InterceptionPoints extends Enumeration {
+  type InterceptionPoints = Value
+  val EXECUTOR_LC /* Inject into executor lifecycle */
+      = Value
+}
+/** Possible state of extension.
+  */
+object ExtensionState extends Enumeration {
+  type ExtensionState = Value
+  val STOPPED, STARTED, STARTING, STOPPING = Value
+}

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -18,7 +18,8 @@
 package org.apache.spark
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable.HashMap
+import scala.collection.mutable.{ArrayBuffer, HashMap}
+import scala.reflect.ClassTag
 
 /**
  * Configuration for a Spark application. Used to set various Spark parameters as key-value pairs.
@@ -304,6 +305,21 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging {
         }
       }
     }
+  }
+
+  /* Register a new platform extension */
+  def addExtension[T <: PlatformExtension : ClassTag]: SparkConf = {
+    val name = implicitly[ClassTag[T]].runtimeClass.getCanonicalName
+    addExtension(name)
+  }
+  /* Register a new platform extension */
+  def addExtension(fullName : String): SparkConf = {
+    val exts = settings.get("spark.extensions") match {
+      case Some(v) => s"${v},${fullName}"
+      case None    => fullName
+    }
+    settings.update("spark.extensions", exts)
+    this
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/TestUtils.scala
+++ b/core/src/main/scala/org/apache/spark/TestUtils.scala
@@ -21,10 +21,14 @@ import java.io.{File, FileInputStream, FileOutputStream}
 import java.net.{URI, URL}
 import java.util.jar.{JarEntry, JarOutputStream}
 
+import org.apache.commons.io.FilenameUtils
+
 import scala.collection.JavaConversions._
 
 import javax.tools.{JavaFileObject, SimpleJavaFileObject, ToolProvider}
-import com.google.common.io.Files
+import com.google.common.io.{ByteStreams, ByteSource, InputSupplier, Files}
+
+import scala.collection.mutable
 
 /**
  * Utilities for tests. Included in main codebase since it's used by multiple
@@ -51,25 +55,38 @@ private[spark] object TestUtils {
 
 
   /**
-   * Create a jar file that contains this set of files. All files will be located at the root
-   * of the jar.
+   * Create a jar file that contains this set of files.
+   *
    */
-  def createJar(files: Seq[File], jarFile: File): URL = {
+  def createJar(files: Seq[File],
+                jarFile: File,
+                flat:Boolean = true,
+                stripPath: String = ""): URL = {
     val jarFileStream = new FileOutputStream(jarFile)
     val jarStream = new JarOutputStream(jarFileStream, new java.util.jar.Manifest())
+    val fprefix = if (!stripPath.isEmpty && !stripPath.endsWith("/")) stripPath + "/" else ""
 
     for (file <- files) {
-      val jarEntry = new JarEntry(file.getName)
-      jarStream.putNextEntry(jarEntry)
+      if (file.isDirectory && !flat) { // Skip directories in flat mode
+        val name = file.getPath.stripPrefix(fprefix)
+        val jarEntry = new JarEntry(name)
+        jarEntry.setTime(file.lastModified())
+        jarStream.putNextEntry(jarEntry)
+        jarStream.closeEntry()
+      } else if (file.isFile) { // Put file into jar file
+        val name = if (flat) file.getName else file.getPath.stripPrefix(fprefix)
+        val jarEntry = new JarEntry(name)
+        jarStream.putNextEntry(jarEntry)
 
-      val in = new FileInputStream(file)
-      val buffer = new Array[Byte](10240)
-      var nRead = 0
-      while (nRead <= 0) {
-        nRead = in.read(buffer, 0, buffer.length)
-        jarStream.write(buffer, 0, nRead)
+        val in = new FileInputStream(file)
+        val buffer = new Array[Byte](10240)
+        var nRead = 0
+        while (nRead <= 0) {
+          nRead = in.read(buffer, 0, buffer.length)
+          jarStream.write(buffer, 0, nRead)
+        }
+        in.close()
       }
-      in.close()
     }
     jarStream.close()
     jarFileStream.close()
@@ -110,5 +127,40 @@ private[spark] object TestUtils {
 
     assert(out.exists(), "Destination file not moved: " + out.getAbsolutePath())
     out
+  }
+
+  /** Create a jar containing given classes.
+    *
+    * @param klazzes list of classes which will be in resulting jar
+    * @param cl  classloader to access given classes
+    */
+  def createJarWithExistingClasses(klazzes: Seq[String], cl: ClassLoader): URL = {
+    val tempDir = Files.createTempDir()
+    tempDir.deleteOnExit()
+    val files = for (klazz <- klazzes) yield createExistingClass(klazz, cl, tempDir)
+    val jarFile = new File(tempDir, "testJar-%s.jar".format(System.currentTimeMillis()))
+    createJar(files, jarFile, false, tempDir.getAbsolutePath)
+  }
+
+  /** Save an existing class loadable by given classloader into a file in destination directory
+    *
+    * @param klazz  name of class to save
+    * @param cl  classloader for loading given class
+    * @param destDir  directory where a class file will be saved
+    * @return  return a reference to saved class file
+    */
+  def createExistingClass(klazz: String, cl: ClassLoader, destDir: File): File = {
+    val klazzName = klazz.replace('.', '/') + ".class"
+
+    val is = cl.getResourceAsStream(klazzName)
+    val kDir  = new File(destDir, FilenameUtils.getPath(klazzName))
+    val kFile = new File(kDir, FilenameUtils.getName(klazzName))
+    kDir.mkdirs()
+    // Copy content
+    val os = Files.asByteSink(kFile).openStream()
+    ByteStreams.copy(is, os)
+    os.close()
+    assert(kFile.exists(), "Destination file not created: " + kFile.getAbsolutePath())
+    kFile
   }
 }

--- a/core/src/test/scala/org/apache/spark/PlatformExtensionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/PlatformExtensionSuite.scala
@@ -1,0 +1,83 @@
+package org.apache.spark
+
+import org.scalatest.FunSuite
+
+/**
+ * Test if platform extension was initialized.
+ */
+class PlatformExtensionSuite extends FunSuite with LocalSparkContext {
+
+  test("extension is started on all executors in cluster") {
+    val conf = new SparkConf()
+    conf.setMaster("local-cluster[3,2,512]")
+    conf.setAppName("test")
+    conf.addExtension("org.apache.spark.TestPlatformExt")
+
+    // Create a jar containing extension classes
+    val jar = createJarWithExtension()
+    conf.setJars(List(jar.getPath))
+
+    // Create spark context based on constructed configuration
+    sc = new SparkContext(conf)
+    // Create dataset distributed over cluster of 3 workers
+    // and verify that Status singleton is initialized
+    val executorStatus = sc.parallelize(1 to 3, 3).map(_ => {
+      val statusKlazz = Class.forName("org.apache.spark.ExtStatus")
+      val method = statusKlazz.getMethod("initialized")
+      method.invoke(null)
+    }).collect()
+
+    assert(executorStatus === Array(true, true, true))
+    // Status singleton should not be initialized inside driver
+    assert(!ExtStatus.initialized, "Status singleton should not be initialized inside driver!")
+    // Terminate Spark context
+    resetSparkContext()
+  }
+
+  test("extension is not started on executors if not specified by Spark config") {
+    val conf = new SparkConf()
+    conf.setMaster("local-cluster[3,2,512]")
+    conf.setAppName("test")
+
+    // Create a jar containing extension classes
+    val jar = createJarWithExtension()
+    conf.setJars(List(jar.getPath))
+
+    // Create spark context based on constructed configuration
+    sc = new SparkContext(conf)
+    // Create dataset distributed over cluster of 3 workers
+    val executorStatus = sc.parallelize(1 to 3, 3).map(_ => {
+      val statusKlazz = Class.forName("org.apache.spark.ExtStatus")
+      val method = statusKlazz.getMethod("initialized")
+      method.invoke(null)
+    }).collect()
+
+    // Status should not be initialized on executors
+    assert(executorStatus === Array(false, false, false))
+    // Neither locally
+    assert(!ExtStatus.initialized, "Status singleton should not be initialized inside driver!")
+    // Terminate Spark context
+    resetSparkContext()
+  }
+
+  def createJarWithExtension() =
+    TestUtils.createJarWithExistingClasses(
+      List(
+        "org.apache.spark.TestPlatformExt",
+        "org.apache.spark.ExtStatus", "org.apache.spark.ExtStatus$"),
+      this.getClass.getClassLoader)
+}
+
+/** Simple platform extension flipping flag in ExtStatus singleton */
+class TestPlatformExt extends PlatformExtension {
+  override def start(conf: SparkConf): Unit = ExtStatus.init()
+  override def stop(conf: SparkConf): Unit = { }
+  override def desc: String = "test"
+}
+
+/** Flag singleton exposing status of extension */
+object ExtStatus {
+  private var flag = false
+  def init(): Unit = { println("A"); flag = true }
+  def initialized = flag
+}


### PR DESCRIPTION
SPARK-3270: Initial proposal of application extensions.

The change set introduces:
- Spark extension API to implement
- hook into Executor to handle extension lifecycle
  - a method to specify extension via SparkConf
  - a 'spark.extensions' configuration variable to pass extension
    list to spark context
  - a test verifying that extension is correctly started inside executor lifecycle

For more details please folow SPARK-3270 or design document
    https://docs.google.com/document/d/1dHF9zi7GzFbYnbV2PwaOQ2eLPoTeiN9IogUe4PAOtrQ/edit?usp=sharing
