### PR TITLE
[SPARK-3836] [REPL] Spark REPL optionally propagate internal exceptions

### DIFF
--- a/repl/src/main/scala/org/apache/spark/repl/SparkIMain.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/SparkIMain.scala
@@ -84,7 +84,7 @@ import org.apache.spark.util.Utils
    *  @author Moez A. Abdel-Gawad
    *  @author Lex Spoon
    */
-  class SparkIMain(initialSettings: Settings, val out: JPrintWriter)
+  class SparkIMain(initialSettings: Settings, val out: JPrintWriter, propogateExceptions: Boolean = false)
       extends SparkImports with Logging {
     imain =>
 
@@ -816,6 +816,9 @@ import org.apache.spark.util.Utils
     val resultName  = FixedSessionNames.resultName
 
     def bindError(t: Throwable) = {
+      if (propogateExceptions) {
+       throw unwrap(t)
+      }
       if (!bindExceptions) // avoid looping if already binding
         throw t
 

--- a/repl/src/main/scala/org/apache/spark/repl/SparkIMain.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/SparkIMain.scala
@@ -84,7 +84,7 @@ import org.apache.spark.util.Utils
    *  @author Moez A. Abdel-Gawad
    *  @author Lex Spoon
    */
-  class SparkIMain(initialSettings: Settings, val out: JPrintWriter, propogateExceptions: Boolean = false)
+  class SparkIMain(initialSettings: Settings, val out: JPrintWriter, propagateExceptions: Boolean = false)
       extends SparkImports with Logging {
     imain =>
 
@@ -816,8 +816,9 @@ import org.apache.spark.util.Utils
     val resultName  = FixedSessionNames.resultName
 
     def bindError(t: Throwable) = {
-      if (propogateExceptions) {
-       throw unwrap(t)
+      // Immediately throw the exception if we are asked to propogate them
+      if (propagateExceptions) {
+        throw unwrap(t)
       }
       if (!bindExceptions) // avoid looping if already binding
         throw t

--- a/repl/src/main/scala/org/apache/spark/repl/SparkIMain.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/SparkIMain.scala
@@ -84,9 +84,11 @@ import org.apache.spark.util.Utils
    *  @author Moez A. Abdel-Gawad
    *  @author Lex Spoon
    */
-  class SparkIMain(initialSettings: Settings, val out: JPrintWriter, propagateExceptions: Boolean = false)
-      extends SparkImports with Logging {
-    imain =>
+  class SparkIMain(
+      initialSettings: Settings,
+      val out: JPrintWriter,
+      propagateExceptions: Boolean = false)
+    extends SparkImports with Logging { imain =>
 
     val conf = new SparkConf()
 
@@ -816,7 +818,7 @@ import org.apache.spark.util.Utils
     val resultName  = FixedSessionNames.resultName
 
     def bindError(t: Throwable) = {
-      // Immediately throw the exception if we are asked to propogate them
+      // Immediately throw the exception if we are asked to propagate them
       if (propagateExceptions) {
         throw unwrap(t)
       }


### PR DESCRIPTION
Optionally have the repl throw exceptions generated by interpreted code, instead of swallowing the exception and returning it as text output. This is useful when embedding the repl, otherwise it's not possible to know when user code threw an exception.
