### PR TITLE
[SPARK-3814][SQL] Bitwise & does not work in Hive

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
@@ -308,7 +308,8 @@ class SqlParser extends StandardTokenParsers with PackratParsers {
     baseExpression * (
       "*" ^^^ { (e1: Expression, e2: Expression) => Multiply(e1,e2) } |
       "/" ^^^ { (e1: Expression, e2: Expression) => Divide(e1,e2) } |
-      "%" ^^^ { (e1: Expression, e2: Expression) => Remainder(e1,e2) }
+      "%" ^^^ { (e1: Expression, e2: Expression) => Remainder(e1,e2) } |
+      "&" ^^^ { (e1: Expression, e2: Expression) => BitwiseAND(e1,e2) }
     )
 
   protected lazy val function: Parser[Expression] =
@@ -396,7 +397,7 @@ class SqlLexical(val keywords: Seq[String]) extends StdLexical {
 
   delimiters += (
       "@", "*", "+", "-", "<", "=", "<>", "!=", "<=", ">=", ">", "/", "(", ")",
-      ",", ";", "%", "{", "}", ":", "[", "]", "."
+      ",", ";", "%", "{", "}", ":", "[", "]", ".", "&"
   )
 
   override lazy val token: Parser[Token] = (

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -100,6 +100,14 @@ case class Remainder(left: Expression, right: Expression) extends BinaryArithmet
   override def eval(input: Row): Any = i2(input, left, right, _.rem(_, _))
 }
 
+case class BitwiseAND(left: Expression, right: Expression) extends BinaryArithmetic {
+  def symbol = "&"
+
+  override def eval(input: Row): Any = dataType match {
+    case _: IntegralType => b2(input, left , right, _.bitwiseAND(_, _))
+  }
+}
+
 case class MaxOf(left: Expression, right: Expression) extends Expression {
   type EvaluatedType = Any
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/dataTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/dataTypes.scala
@@ -216,40 +216,49 @@ abstract class IntegralType extends NumericType {
   private[sql] val integral: Integral[JvmType]
 }
 
-case object LongType extends IntegralType {
+/** Matcher for any expressions that evaluate which do bitwise operations */
+trait BitwiseOpsType[T] {
+  def bitwiseAND(x: T, y: T): T
+}
+
+case object LongType extends IntegralType with BitwiseOpsType[Long] {
   private[sql] type JvmType = Long
   @transient private[sql] lazy val tag = ScalaReflectionLock.synchronized { typeTag[JvmType] }
   private[sql] val numeric = implicitly[Numeric[Long]]
   private[sql] val integral = implicitly[Integral[Long]]
   private[sql] val ordering = implicitly[Ordering[JvmType]]
   def simpleString: String = "long"
+  def bitwiseAND(x: JvmType, y: JvmType): JvmType = x & y
 }
 
-case object IntegerType extends IntegralType {
+case object IntegerType extends IntegralType with BitwiseOpsType[Int] {
   private[sql] type JvmType = Int
   @transient private[sql] lazy val tag = ScalaReflectionLock.synchronized { typeTag[JvmType] }
   private[sql] val numeric = implicitly[Numeric[Int]]
   private[sql] val integral = implicitly[Integral[Int]]
   private[sql] val ordering = implicitly[Ordering[JvmType]]
   def simpleString: String = "integer"
+  def bitwiseAND(x: JvmType, y: JvmType): JvmType = x & y
 }
 
-case object ShortType extends IntegralType {
+case object ShortType extends IntegralType with BitwiseOpsType[Short] {
   private[sql] type JvmType = Short
   @transient private[sql] lazy val tag = ScalaReflectionLock.synchronized { typeTag[JvmType] }
   private[sql] val numeric = implicitly[Numeric[Short]]
   private[sql] val integral = implicitly[Integral[Short]]
   private[sql] val ordering = implicitly[Ordering[JvmType]]
   def simpleString: String = "short"
+  def bitwiseAND(x: JvmType, y: JvmType): JvmType = (x & y).toShort
 }
 
-case object ByteType extends IntegralType {
+case object ByteType extends IntegralType with BitwiseOpsType[Byte] {
   private[sql] type JvmType = Byte
   @transient private[sql] lazy val tag = ScalaReflectionLock.synchronized { typeTag[JvmType] }
   private[sql] val numeric = implicitly[Numeric[Byte]]
   private[sql] val integral = implicitly[Integral[Byte]]
   private[sql] val ordering = implicitly[Ordering[JvmType]]
   def simpleString: String = "byte"
+  def bitwiseAND(x: JvmType, y: JvmType): JvmType = (x & y).toByte
 }
 
 /** Matcher for any expressions that evaluate to [[FractionalType]]s */

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -680,9 +680,14 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll {
       sql("SELECT CAST(TRUE AS STRING), CAST(FALSE AS STRING) FROM testData LIMIT 1"),
       ("true", "false") :: Nil)
   }
-  
+
   test("SPARK-3371 Renaming a function expression with group by gives error") {
     registerFunction("len", (s: String) => s.length)
     checkAnswer(
-      sql("SELECT len(value) as temp FROM testData WHERE key = 1 group by len(value)"), 1)}    
+      sql("SELECT len(value) as temp FROM testData WHERE key = 1 group by len(value)"), 1)
+  }
+
+  test("SPARK-3814 Support Bitwise & operator") {
+    checkAnswer(sql("SELECT key&1 FROM testData WHERE key = 1 "), 1)
+  }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
@@ -935,6 +935,7 @@ private[hive] object HiveQl {
     case Token(DIV(), left :: right:: Nil) =>
       Cast(Divide(nodeToExpr(left), nodeToExpr(right)), LongType)
     case Token("%", left :: right:: Nil) => Remainder(nodeToExpr(left), nodeToExpr(right))
+    case Token("&", left :: right:: Nil) => BitwiseAND(nodeToExpr(left), nodeToExpr(right))
     case Token("TOK_FUNCTION", Token(SQRT(), Nil) :: arg :: Nil) => Sqrt(nodeToExpr(arg))
 
     /* Comparisons */

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -68,5 +68,11 @@ class SQLQuerySuite extends QueryTest {
     checkAnswer(
       sql("SELECT k FROM (SELECT `key` AS `k` FROM src) a"),
       sql("SELECT `key` FROM src").collect().toSeq)
-  }  
+  }
+
+  test("SPARK-3814 Support Bitwise & operator") {
+    checkAnswer(
+      sql("SELECT case when 1&1=1 then 1 else 0 end FROM src"),
+      sql("SELECT 1 FROM src").collect().toSeq)
+  }
 }


### PR DESCRIPTION
Currently there is no support of Bitwise & in Spark HiveQl and Spark SQL as well. So this PR support the same.

Author : ravipesala ravindra.pesala@huawei.com
