### PR TITLE
fixed dynamic pagerank vertex update computation

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
@@ -152,7 +152,7 @@ object PageRank extends Logging {
     // version of Pregel
     def vertexProgram(id: VertexId, attr: (Double, Double), msgSum: Double): (Double, Double) = {
       val (oldPR, lastDelta) = attr
-      val newPR = resetProb + (1.0 - resetProb) * msgSum
+      val newPR = oldPR + (1.0 - resetProb) * msgSum + resetProb
       (newPR, newPR - oldPR)
     }
 

--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
@@ -152,7 +152,7 @@ object PageRank extends Logging {
     // version of Pregel
     def vertexProgram(id: VertexId, attr: (Double, Double), msgSum: Double): (Double, Double) = {
       val (oldPR, lastDelta) = attr
-      val newPR = oldPR + (1.0 - resetProb) * msgSum
+      val newPR = resetProb + (1.0 - resetProb) * msgSum
       (newPR, newPR - oldPR)
     }
 


### PR DESCRIPTION
There seems to be a typo here when comparing to static version or to the usual pagerank algorithm. if we take a node in the graph, on each iteration, we add a random jump to any node in the graph with equal probability of resetProb/N. Then summing for all nodes in the graph yields the resetProb on line 155, which has nothing to do with the pagerank value for last iteration.
