### PR TITLE
[SPARK-3890][Docs]remove redundant spark.executor.memory in doc

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -162,14 +162,6 @@ Apart from these, the following properties are also available, and may be useful
 <table class="table">
 <tr><th>Property Name</th><th>Default</th><th>Meaning</th></tr>
 <tr>
-  <td><code>spark.executor.memory</code></td>
-  <td>512m</td>
-  <td>
-    Amount of memory to use per executor process, in the same format as JVM memory strings
-    (e.g. <code>512m</code>, <code>2g</code>).
-  </td>
-</tr>
-<tr>
   <td><code>spark.executor.extraJavaOptions</code></td>
   <td>(none)</td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -872,7 +872,8 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.scheduler.revive.interval</code></td>
   <td>1000</td>
   <td>
-    The interval length for the scheduler to revive the worker resource offers to run tasks (in milliseconds).
+    The interval length for the scheduler to revive the worker resource offers to run tasks
+    (in milliseconds).
   </td>
 </tr>
 </tr>
@@ -950,7 +951,7 @@ Apart from these, the following properties are also available, and may be useful
     standard <a href="http://docs.oracle.com/javaee/6/api/javax/servlet/Filter.html">
     javax servlet Filter</a>. Parameters to each filter can also be specified by setting a
     java system property of: <br />
-    <code>spark.&lt;class name of filter&gt;.params='param1=value1,param2=value2'</code>.<br />
+    <code>spark.&lt;class name of filter&gt;.params='param1=value1,param2=value2'</code><br />
     For example: <br />
     <code>-Dspark.ui.filters=com.test.filter1</code> <br />
     <code>-Dspark.com.test.filter1.params='param1=foo,param2=testing'</code>.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -357,7 +357,7 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.ui.port</code></td>
   <td>4040</td>
   <td>
-    Port for your application's dashboard, which shows memory and workload data
+    Port for your application's dashboard, which shows memory and workload data.
   </td>
 </tr>
 <tr>
@@ -872,8 +872,7 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.scheduler.revive.interval</code></td>
   <td>1000</td>
   <td>
-    The interval length for the scheduler to revive the worker resource offers to run tasks.
-    (in milliseconds)
+    The interval length for the scheduler to revive the worker resource offers to run tasks (in milliseconds).
   </td>
 </tr>
 </tr>
@@ -885,7 +884,7 @@ Apart from these, the following properties are also available, and may be useful
     to wait for before scheduling begins. Specified as a double between 0 and 1.
     Regardless of whether the minimum ratio of resources has been reached,
     the maximum amount of time it will wait before scheduling begins is controlled by config 
-    <code>spark.scheduler.maxRegisteredResourcesWaitingTime</code> 
+    <code>spark.scheduler.maxRegisteredResourcesWaitingTime</code>.
   </td>
 </tr>
 <tr>
@@ -951,10 +950,10 @@ Apart from these, the following properties are also available, and may be useful
     standard <a href="http://docs.oracle.com/javaee/6/api/javax/servlet/Filter.html">
     javax servlet Filter</a>. Parameters to each filter can also be specified by setting a
     java system property of: <br />
-    <code>spark.&lt;class name of filter&gt;.params='param1=value1,param2=value2'</code><br />
+    <code>spark.&lt;class name of filter&gt;.params='param1=value1,param2=value2'</code>.<br />
     For example: <br />
     <code>-Dspark.ui.filters=com.test.filter1</code> <br />
-    <code>-Dspark.com.test.filter1.params='param1=foo,param2=testing'</code>
+    <code>-Dspark.com.test.filter1.params='param1=foo,param2=testing'</code>.
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
Introduced in https://github.com/pwendell/spark/commit/f7e79bc42c1635686c3af01eef147dae92de2529, I'm not sure why we need two spark.executor.memory here.
