### PR TITLE
[SQL] Refactors data type pattern matching

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
@@ -126,14 +126,14 @@ trait HiveTypeCoercion {
           b.makeCopy(Array(r, Literal(Double.NaN)))
         case b @ BinaryExpression(DoubleType(l), StringNaN) =>
           b.makeCopy(Array(Literal(Double.NaN), l))
-        case b @ BinaryExpression(l @ StringNaN, StringNaN) =>
-          b.makeCopy(Array(Literal(Double.NaN), l))
 
         /* Float Conversions */
         case b @ BinaryExpression(StringNaN, FloatType(r)) =>
           b.makeCopy(Array(r, Literal(Float.NaN)))
         case b @ BinaryExpression(FloatType(l), StringNaN) =>
           b.makeCopy(Array(Literal(Float.NaN), l))
+
+        /* Use float NaN by default to avoid unnecessary type widening */
         case b @ BinaryExpression(l @ StringNaN, StringNaN) =>
           b.makeCopy(Array(Literal(Float.NaN), l))
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -227,6 +227,10 @@ abstract class Expression extends TreeNode[Expression] {
   }
 }
 
+object BinaryExpression {
+  def unapply(a: BinaryExpression): Option[(Expression, Expression)] = Some((a.left, a.right))
+}
+
 abstract class BinaryExpression extends Expression with trees.BinaryNode[Expression] {
   self: Product =>
 
@@ -243,6 +247,4 @@ abstract class LeafExpression extends Expression with trees.LeafNode[Expression]
 
 abstract class UnaryExpression extends Expression with trees.UnaryNode[Expression] {
   self: Product =>
-
-
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.sql.catalyst.analysis.UnresolvedException
 import org.apache.spark.sql.catalyst.types._
-import scala.math.pow
 
 case class UnaryMinus(child: Expression) extends UnaryExpression {
   type EvaluatedType = Any
@@ -43,8 +42,12 @@ case class Sqrt(child: Expression) extends UnaryExpression {
   override def toString = s"SQRT($child)"
 
   override def eval(input: Row): Any = {
-    n1(child, input, ((na,a) => math.sqrt(na.toDouble(a))))
+    n1(child, input, (na, a) => math.sqrt(na.toDouble(a)))
   }
+}
+
+object BinaryArithmetic {
+  def unapply(a: BinaryArithmetic): Option[(Expression, Expression)] = Some((a.left, a.right))
 }
 
 abstract class BinaryArithmetic extends BinaryExpression {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -235,7 +235,7 @@ abstract class CodeGenerator[InType <: AnyRef, OutType <: AnyRef] extends Loggin
           val $primitiveTerm: ${termForType(dataType)} = $value
          """.children
 
-      case Cast(e @ BinaryType(), StringType) =>
+      case Cast(BinaryType(e), StringType) =>
         val eval = expressionEvaluator(e)
         eval.code ++
         q"""
@@ -247,16 +247,16 @@ abstract class CodeGenerator[InType <: AnyRef, OutType <: AnyRef] extends Loggin
               new String(${eval.primitiveTerm}.asInstanceOf[Array[Byte]])
         """.children
 
-      case Cast(child @ NumericType(), IntegerType) =>
+      case Cast(NumericType(child), IntegerType) =>
         child.castOrNull(c => q"$c.toInt", IntegerType)
 
-      case Cast(child @ NumericType(), LongType) =>
+      case Cast(NumericType(child), LongType) =>
         child.castOrNull(c => q"$c.toLong", LongType)
 
-      case Cast(child @ NumericType(), DoubleType) =>
+      case Cast(NumericType(child), DoubleType) =>
         child.castOrNull(c => q"$c.toDouble", DoubleType)
 
-      case Cast(child @ NumericType(), FloatType) =>
+      case Cast(NumericType(child), FloatType) =>
         child.castOrNull(c => q"$c.toFloat", IntegerType)
 
       // Special handling required for timestamps in hive test cases since the toString function
@@ -301,13 +301,13 @@ abstract class CodeGenerator[InType <: AnyRef, OutType <: AnyRef] extends Loggin
         """.children
       */
 
-      case GreaterThan(e1 @ NumericType(), e2 @ NumericType()) =>
+      case GreaterThan(NumericType(e1), NumericType(e2)) =>
         (e1, e2).evaluateAs (BooleanType) { case (eval1, eval2) => q"$eval1 > $eval2" }
-      case GreaterThanOrEqual(e1 @ NumericType(), e2 @ NumericType()) =>
+      case GreaterThanOrEqual(NumericType(e1), NumericType(e2)) =>
         (e1, e2).evaluateAs (BooleanType) { case (eval1, eval2) => q"$eval1 >= $eval2" }
-      case LessThan(e1 @ NumericType(), e2 @ NumericType()) =>
+      case LessThan(NumericType(e1), NumericType(e2)) =>
         (e1, e2).evaluateAs (BooleanType) { case (eval1, eval2) => q"$eval1 < $eval2" }
-      case LessThanOrEqual(e1 @ NumericType(), e2 @ NumericType()) =>
+      case LessThanOrEqual(NumericType(e1), NumericType(e2)) =>
         (e1, e2).evaluateAs (BooleanType) { case (eval1, eval2) => q"$eval1 <= $eval2" }
 
       case And(e1, e2) =>
@@ -546,7 +546,7 @@ abstract class CodeGenerator[InType <: AnyRef, OutType <: AnyRef] extends Loggin
 
   protected def getColumn(inputRow: TermName, dataType: DataType, ordinal: Int) = {
     dataType match {
-      case dt @ NativeType() => q"$inputRow.${accessorForType(dt)}($ordinal)"
+      case NativeType(dt) => q"$inputRow.${accessorForType(dt)}($ordinal)"
       case _ => q"$inputRow.apply($ordinal).asInstanceOf[${termForType(dataType)}]"
     }
   }
@@ -557,7 +557,7 @@ abstract class CodeGenerator[InType <: AnyRef, OutType <: AnyRef] extends Loggin
       ordinal: Int,
       value: TermName) = {
     dataType match {
-      case dt @ NativeType() => q"$destinationRow.${mutatorForType(dt)}($ordinal, $value)"
+      case NativeType(dt) => q"$destinationRow.${mutatorForType(dt)}($ordinal, $value)"
       case _ => q"$destinationRow.update($ordinal, $value)"
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -62,6 +62,10 @@ trait PredicateHelper {
     expr.references.subsetOf(plan.outputSet)
 }
 
+object BinaryPredicate {
+  def unapply(a: BinaryPredicate): Option[(Expression, Expression)] = Some((a.left, a.right))
+}
+
 abstract class BinaryPredicate extends BinaryExpression with Predicate {
   self: Product =>
   def nullable = left.nullable || right.nullable
@@ -99,7 +103,7 @@ case class In(value: Expression, list: Seq[Expression]) extends Predicate {
  * Optimized version of In clause, when all filter values of In clause are
  * static.
  */
-case class InSet(value: Expression, hset: HashSet[Any], child: Seq[Expression]) 
+case class InSet(value: Expression, hset: HashSet[Any], child: Seq[Expression])
   extends Predicate {
 
   def children = child
@@ -154,6 +158,10 @@ case class Or(left: Expression, right: Expression) extends BinaryPredicate {
       }
     }
   }
+}
+
+object BinaryComparison {
+  def unapply(a: BinaryComparison): Option[(Expression, Expression)] = Some((a.left, a.right))
 }
 
 abstract class BinaryComparison extends BinaryPredicate {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/dataTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/dataTypes.scala
@@ -167,10 +167,7 @@ object DataType {
 
 abstract class DataType {
   /** Matches any expression that evaluates to this DataType */
-  def unapply(a: Expression): Boolean = a match {
-    case e: Expression if e.dataType == this => true
-    case _ => false
-  }
+  def unapply[T <: Expression](a: T): Option[T] = if (a.dataType == this) Some(a) else None
 
   def isPrimitive: Boolean = false
 
@@ -189,7 +186,7 @@ object NativeType {
   val all = Seq(
     IntegerType, BooleanType, LongType, DoubleType, FloatType, ShortType, ByteType, StringType)
 
-  def unapply(dt: DataType): Boolean = all.contains(dt)
+  def unapply[T <: DataType](dt: T): Option[T] = if (all.contains(dt)) Some(dt) else None
 
   val defaultSizeOf: Map[NativeType, Int] = Map(
     IntegerType -> 4,
@@ -288,15 +285,14 @@ abstract class NumericType extends NativeType with PrimitiveType {
 }
 
 object NumericType {
-  def unapply(e: Expression): Boolean = e.dataType.isInstanceOf[NumericType]
+  def unapply[T <: Expression](e: T): Option[T] =
+    if (e.dataType.isInstanceOf[NumericType]) Some(e) else None
 }
 
 /** Matcher for any expressions that evaluate to [[IntegralType]]s */
 object IntegralType {
-  def unapply(a: Expression): Boolean = a match {
-    case e: Expression if e.dataType.isInstanceOf[IntegralType] => true
-    case _ => false
-  }
+  def unapply[T <: Expression](a: T): Option[T] =
+    if (a.dataType.isInstanceOf[IntegralType]) Some(a) else None
 }
 
 abstract class IntegralType extends NumericType {
@@ -337,10 +333,8 @@ case object ByteType extends IntegralType {
 
 /** Matcher for any expressions that evaluate to [[FractionalType]]s */
 object FractionalType {
-  def unapply(a: Expression): Boolean = a match {
-    case e: Expression if e.dataType.isInstanceOf[FractionalType] => true
-    case _ => false
-  }
+  def unapply[T <: Expression](a: T): Option[T] =
+    if (a.dataType.isInstanceOf[FractionalType]) Some(a) else None
 }
 abstract class FractionalType extends NumericType {
   private[sql] val fractional: Fractional[JvmType]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/dataTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/dataTypes.scala
@@ -333,7 +333,7 @@ case object ByteType extends IntegralType {
 
 /** Matcher for any expressions that evaluate to [[FractionalType]]s */
 object FractionalType {
-  def unapply[T <: Expression](a: T): Option[T] =
+  def unapply(a: Expression): Option[Expression] =
     if (a.dataType.isInstanceOf[FractionalType]) Some(a) else None
 }
 abstract class FractionalType extends NumericType {


### PR DESCRIPTION
Refactors/adds extractors for `DataType` and `Binary*` types to ease and simplify data type related (nested) pattern matching.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/apache/spark/2764)

<!-- Reviewable:end -->
