### PR TITLE
SPARK-2863: [SQL] Add facilities for function-argument coercion

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -245,3 +245,29 @@ abstract class UnaryExpression extends Expression with trees.UnaryNode[Expressio
 
 
 }
+
+/**
+ * Trait representing a fixed-arity function whose arguments should be casted to particular types.
+ * Expression classes extending SignedFunction must provide `formalTypes`, a List of expected 
+ * types for formal parameters, `actualParams`, a list of Expressions corresponding to actual
+ * parameters, and create, which creates an instance of that expression class from a list of
+ * expressions corresponding to actuals.  The type parameter for SignedFunction should be the
+ * expression class extending it.
+ *
+ * See the Sqrt class for a concrete example.
+ *
+ * This trait (or abstract classes extending this trait) could be exposed to code outside `sql`
+ * in the future.
+ */
+private[sql] trait SignedFunction[E <: Expression] {
+  self: E =>
+  type exprType = E
+  def formalTypes: List[DataType]
+  def actualParams: List[Expression]
+  def actualsProperlyTyped = actualParams.map(_.dataType)
+    .zip(formalTypes)
+    .forall(x => x._1 == x._2)
+  
+  def create(actuals: List[Expression]): E
+
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -34,7 +34,7 @@ case class UnaryMinus(child: Expression) extends UnaryExpression {
   }
 }
 
-case class Sqrt(child: Expression) extends UnaryExpression {
+case class Sqrt(child: Expression) extends UnaryExpression with SignedFunction[Sqrt] {
   type EvaluatedType = Any
   
   def dataType = DoubleType
@@ -44,6 +44,12 @@ case class Sqrt(child: Expression) extends UnaryExpression {
 
   override def eval(input: Row): Any = {
     n1(child, input, ((na,a) => math.sqrt(na.toDouble(a))))
+  }
+  
+  val formalTypes = List(DoubleType)
+  val actualParams = List(child)
+  def create(al: List[Expression]) = al match {
+    case exp::Nil => Sqrt(exp)
   }
 }
 


### PR DESCRIPTION
This commit adds the `SignedFunction` trait and modifies the `Sqrt` expression
class to use it for coercing its argument to `DoubleType`.

`SignedFunction` represents a fixed-arity function whose arguments should be
casted to particular types. Expression classes extending SignedFunction
must provide `formalTypes`, a List of expected types for formal parameters,
`actualParams`, a list of Expressions corresponding to actual parameters,
and create, which creates an instance of that expression class from a list
of expressions corresponding to actuals. The type parameter for
SignedFunction should be the expression class extending it.

See the `Sqrt` class for a concrete example.

This trait (or one or several abstract classes extending this trait) could
be exposed to code outside `sql` in the future.
