### PR TITLE
[HOTFIX] Fix compilation error for Yarn 2.0.*-alpha

### DIFF
--- a/yarn/alpha/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/alpha/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -122,7 +122,7 @@ private[spark] class Client(
    * ApplicationReport#getClientToken is renamed `getClientToAMToken` in the stable API.
    */
   override def getClientToken(report: ApplicationReport): String =
-    Option(report.getClientToken).getOrElse("")
+    Option(report.getClientToken).map(_.toString).getOrElse("")
 }
 
 object Client {


### PR DESCRIPTION
This was reported in https://issues.apache.org/jira/browse/SPARK-3445. There are API differences between the 0.23.\* and the 2.0.*-alpha branches that are not accounted for when this code was introduced.
