### PR TITLE
[SPARK-3925][SQL] Do not consider the ordering of qualifiers during comparison

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
@@ -156,7 +156,7 @@ case class AttributeReference(name: String, dataType: DataType, nullable: Boolea
    * Returns a copy of this [[AttributeReference]] with new qualifiers.
    */
   override def withQualifiers(newQualifiers: Seq[String]) = {
-    if (newQualifiers == qualifiers) {
+    if (newQualifiers.filterNot(qualifiers.toSet).isEmpty && qualifiers.filterNot(newQualifiers.toSet).isEmpty) {
       this
     } else {
       AttributeReference(name, dataType, nullable)(exprId, newQualifiers)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
@@ -156,7 +156,7 @@ case class AttributeReference(name: String, dataType: DataType, nullable: Boolea
    * Returns a copy of this [[AttributeReference]] with new qualifiers.
    */
   override def withQualifiers(newQualifiers: Seq[String]) = {
-    if (newQualifiers.filterNot(qualifiers.toSet).isEmpty && qualifiers.filterNot(newQualifiers.toSet).isEmpty) {
+    if (newQualifiers.toSet == qualifiers.toSet) {
       this
     } else {
       AttributeReference(name, dataType, nullable)(exprId, newQualifiers)


### PR DESCRIPTION
The orderings should not be considered during the comparison between old qualifiers and new qualifiers. 
