### PR TITLE
[SPARK-3913] Spark Yarn Client API change to expose Yarn Resource Capacity, Yarn Application Listener and KillApplication APIs

### DIFF
--- a/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/YarnAppInfo.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/YarnAppInfo.scala
@@ -1,0 +1,14 @@
+package org.apache.spark.deploy.yarn
+
+import org.apache.hadoop.yarn.api.records.ApplicationId
+
+case class YarnAppInfo(appId: ApplicationId,
+                       user: String,
+                       queue: String,
+                       name: String,
+                       masterHost: String,
+                       masterRpcPort: Int,
+                       state: String,
+                       diagnostics: String,
+                       trackingUrl: String,
+                       startTime: Long)

--- a/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/YarnAppListener.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/YarnAppListener.scala
@@ -1,0 +1,21 @@
+package org.apache.spark.deploy.yarn
+
+
+import org.apache.hadoop.yarn.api.records.ApplicationId
+import org.apache.spark.deploy.yarn.{YarnAppInfo, YarnAppProgress}
+
+sealed trait YarnApplicationEvent
+
+case class YarnApplicationStart(time: Long) extends YarnApplicationEvent
+case class YarnApplicationProgress(time: Long, progress: YarnAppProgress) extends YarnApplicationEvent
+case class YarnApplicationEnd(time: Long) extends YarnApplicationEvent
+
+trait YarnApplicationListener {
+  def onApplicationInit(time:Long, appId: ApplicationId)
+  def onApplicationStart(time:Long, info: YarnAppInfo)
+  def onApplicationProgress(time:Long, progress: YarnAppProgress)
+  def onApplicationEnd(time:Long, progress: YarnAppProgress)
+  def onApplicationFailed(time:Long, progress: YarnAppProgress)
+  def onApplicationKilled(time:Long, progress: YarnAppProgress)
+
+}

--- a/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/YarnAppProgress.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/YarnAppProgress.scala
@@ -1,0 +1,16 @@
+package org.apache.spark.deploy.yarn
+
+import org.apache.hadoop.yarn.api.records.ApplicationId
+import org.apache.spark.deploy.yarn.YarnResourceUsage
+
+/**
+ *
+ * @param appId -- application Id
+ * @param trackingUrl -- tracking URL
+ * @param usage  -- Yarn Resource Usage
+ * @param progress -- note: for Yarn-Alpha, no progress is reported, so the value will be always default value.
+ * */
+ case class YarnAppProgress(appId: ApplicationId,
+                           trackingUrl: String,
+                           usage: YarnResourceUsage,
+                           progress: Float = 0)

--- a/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/YarnResourceCapacity.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/YarnResourceCapacity.scala
@@ -1,0 +1,9 @@
+package org.apache.spark.deploy.yarn
+
+
+case class YarnAppResource(memory: Int, virtualCores: Int)
+
+case class YarnResourceCapacity(resource: YarnAppResource,
+                                ammMemOverHead: Int,
+                                executorMemOverhead: Int)
+

--- a/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/YarnResourceUsage.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/YarnResourceUsage.scala
@@ -1,0 +1,7 @@
+package org.apache.spark.deploy.yarn
+
+case class YarnResourceUsage(numUsedContainers     : Int,
+                             numReservedContainers : Int,
+                             usedResource     : YarnAppResource,
+                             reservedResource : YarnAppResource,
+                             neededResource   : YarnAppResource)

--- a/yarn/common/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
@@ -19,7 +19,7 @@ package org.apache.spark.scheduler.cluster
 
 import org.apache.hadoop.yarn.api.records.{ApplicationId, YarnApplicationState}
 import org.apache.spark.{SparkException, Logging, SparkContext}
-import org.apache.spark.deploy.yarn.{Client, ClientArguments}
+import org.apache.spark.deploy.yarn.{YarnResourceCapacity, Client, ClientArguments}
 import org.apache.spark.scheduler.TaskSchedulerImpl
 
 import scala.collection.mutable.ArrayBuffer
@@ -55,10 +55,13 @@ private[spark] class YarnClientSchedulerBackend(
     argsArrayBuf ++= getExtraClientArguments
 
     logDebug("ClientArguments called with: " + argsArrayBuf.mkString(" "))
-    val args = new ClientArguments(argsArrayBuf.toArray, conf)
+
+    def toArgs (capacity: YarnResourceCapacity) = new ClientArguments(argsArrayBuf.toArray, conf)
+    //val args = new ClientArguments(argsArrayBuf.toArray, conf)
+    client = new Client(toArgs, conf)
+    val (applicationId, args) = client.submitApplication()
+    appId = applicationId
     totalExpectedExecutors = args.numExecutors
-    client = new Client(args, conf)
-    appId = client.submitApplication()
     waitForApplication()
     asyncMonitorApplication()
   }

--- a/yarn/common/src/test/scala/org/apache/spark/deploy/yarn/ClientBaseSuite.scala
+++ b/yarn/common/src/test/scala/org/apache/spark/deploy/yarn/ClientBaseSuite.scala
@@ -116,7 +116,7 @@ class ClientBaseSuite extends FunSuite with Matchers {
 
     val tempDir = Utils.createTempDir()
     try {
-      client.prepareLocalResources(tempDir.getAbsolutePath())
+      client.prepareLocalResources(args,tempDir.getAbsolutePath())
       sparkConf.getOption(ClientBase.CONF_SPARK_USER_JAR) should be (Some(USER))
 
       // The non-local path should be propagated by name only, since it will end up in the app's
@@ -248,9 +248,11 @@ class ClientBaseSuite extends FunSuite with Matchers {
       val sparkConf: SparkConf,
       val yarnConf: YarnConfiguration) extends ClientBase {
     override def setupSecurityToken(amContainer: ContainerLaunchContext): Unit = ???
-    override def submitApplication(): ApplicationId = ???
+    override def submitApplication(): (ApplicationId, ClientArguments) = ???
     override def getApplicationReport(appId: ApplicationId): ApplicationReport = ???
     override def getClientToken(report: ApplicationReport): String = ???
+    override def killApplication(appId: ApplicationId): Unit = ???
+    override protected def getAppProgress(report: ApplicationReport): YarnAppProgress = ???
   }
 
 }


### PR DESCRIPTION
Spark Yarn Client API change to expose Yarn Resource Capacity, Yarn Application Listener and KillApplication APIs

When working with Spark with Yarn cluster mode, we have following issues:
1) We don't know how much yarn max capacity ( memory and cores) before we specify the number of executor and memories for spark drivers and executors. We we set a big number, the job can potentially exceeds the limit and got killed.
It would be better we let the application know that the yarn resource capacity a head of time and the spark config can adjusted dynamically.
2) Once job started, we would like some feedback from yarn application. Currently, the spark client basically block the call and returns when the job is finished or failed or killed.
If the job runs for few hours, we have no idea how far it has gone, the progress and resource usage, tracking URL etc. This Pull Request will not complete solve the issue #2, but it will allow expose Yarn Application status: such as when the job is started, killed, finished, the tracking URL etc, some limited progress reporting ( for CDH5 we found the progress only reports 0, 10 and 100%)

I will have another Pull Request to address the Yarn Application and Spark Job communication issue, that's not covered here.

3) If we decide to stop the spark job, the Spark Yarn Client expose a stop method. But the stop method, in many cases, does not stop the yarn application.

  So we need to expose the yarn client's killApplication() API to spark client.

The proposed change is to change Client Constructor, change the first argument from ClientArguments to
 YarnResourceCapacity => ClientArguments

 Were YarnResourceCapacity contains yarn's max memory and virtual cores as well as overheads.

This allows application to adjust the memory and core settings accordingly.

For existing application that ignore the YarnResourceCapacity the

def toArgs (capacity: YarnResourceCapacity) = new ClientArguments(...)

 We also defined the YarnApplicationListener interface that expose some of the information about YarnApplicationReport.

  Client.addYarnApplicaitonListener(listerner)
  will allow them to get call back at different state of the application, so they can react accordingly.

  For example, onApplicationInit() the callback will invoked when the AppId is available but application is not yet started. Once can use this AppId to kill the application if the run is not longer desired.
