### PR TITLE
[spark-3940][sql]SQL console prints error messages three times

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLDriver.scala
@@ -62,7 +62,7 @@ private[hive] class SparkSQLDriver(val context: HiveContext = SparkSQLEnv.hiveCo
     } catch {
       case cause: Throwable =>
         logError(s"Failed in [$command]", cause)
-        new CommandProcessorResponse(-3, ExceptionUtils.getFullStackTrace(cause), null)
+        new CommandProcessorResponse(0, ExceptionUtils.getFullStackTrace(cause), null)
     }
   }
 


### PR DESCRIPTION
If  wrong sql,the console print error one times。
eg：

<pre>
spark-sql> show tabless;   
show tabless;
14/10/13 21:03:48 INFO ParseDriver: Parsing command: show tabless
............
    at org.apache.spark.sql.hive.thriftserver.SparkSQLCLIDriver.processCmd(SparkSQLCLIDriver.scala:274)
    at org.apache.hadoop.hive.cli.CliDriver.processLine(CliDriver.java:413)
    at org.apache.spark.sql.hive.thriftserver.SparkSQLCLIDriver$.main(SparkSQLCLIDriver.scala:209)
    at org.apache.spark.sql.hive.thriftserver.SparkSQLCLIDriver.main(SparkSQLCLIDriver.scala)
Caused by: org.apache.hadoop.hive.ql.parse.ParseException: line 1:5 cannot recognize input near 'show' 'tabless' '<EOF>' in ddl statement

    at org.apache.hadoop.hive.ql.parse.ParseDriver.parse(ParseDriver.java:193)
    at org.apache.hadoop.hive.ql.parse.ParseDriver.parse(ParseDriver.java:161)
    at org.apache.spark.sql.hive.HiveQl$.getAst(HiveQl.scala:218)
    at org.apache.spark.sql.hive.HiveQl$.createPlan(HiveQl.scala:226)
    ... 47 more
Time taken: 4.35 seconds
14/10/13 21:03:51 INFO CliDriver: Time taken: 4.35 seconds
</pre>
