### PR TITLE
[SPARK-3935][Core] log the number of records that has been written

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
@@ -1031,17 +1031,14 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
 
       writer.setup(context.getStageId, context.getPartitionId, attemptNumber)
       writer.open()
-      var count = 0
       try {
         while (iter.hasNext) {
           val record = iter.next()
-          count += 1
           writer.write(record._1.asInstanceOf[AnyRef], record._2.asInstanceOf[AnyRef])
         }
       } finally {
         writer.close()
       }
-      logInfo(s"$count records are written")
       writer.commit()
     }
 

--- a/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
@@ -1031,8 +1031,8 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
 
       writer.setup(context.getStageId, context.getPartitionId, attemptNumber)
       writer.open()
+      var count = 0
       try {
-        var count = 0
         while (iter.hasNext) {
           val record = iter.next()
           count += 1
@@ -1041,6 +1041,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
       } finally {
         writer.close()
       }
+      logInfo(s"$count records are written")
       writer.commit()
     }
 


### PR DESCRIPTION
There is a unused variable(count) in saveAsHadoopDataset in PairRDDFunctions.scala. The initial idea of this variable seems to count the number of records, so I am adding a log statement to log the number of records that has been written to the writer.
