### PR TITLE
[SPARK-3946] gitignore in /python includes wrong directory

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,5 +1,5 @@
 *.pyc
-docs/
+docs/_build/
 pyspark.egg-info
 build/
 dist/


### PR DESCRIPTION
Modified to ignore not the docs/ directory, but only the docs/_build/ which is the output directory of sphinx build.
