### PR TITLE
[Spark-3822] Ability to add/delete executors from Spark Context. Works in both yarn-client and yarn-cluster mode

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -52,6 +52,7 @@ import org.apache.spark.scheduler.local.LocalBackend
 import org.apache.spark.storage._
 import org.apache.spark.ui.SparkUI
 import org.apache.spark.util.{CallSite, ClosureCleaner, MetadataCleaner, MetadataCleanerType, TimeStampedWeakValueHashMap, Utils}
+import org.apache.spark.autoscale.AutoscaleClient
 
 /**
  * Main entry point for Spark functionality. A SparkContext represents the connection to a Spark
@@ -290,7 +291,17 @@ class SparkContext(config: SparkConf) extends Logging {
     SparkContext.SPARK_UNKNOWN_USER
   }
   executorEnvs("SPARK_USER") = sparkUser
-
+  //start Autoscale client
+  private[spark] var autoscaleClient = new AutoscaleClient(env.actorSystem)
+  
+  def addExecutors(count: Int) {
+    autoscaleClient.addExecutors(count)
+  }
+  
+  def deleteExecutors(execIds: List[String]) {
+    autoscaleClient.deleteExecutors(execIds)
+  }
+  
   // Create and start the scheduler
   private[spark] var taskScheduler = SparkContext.createTaskScheduler(this, master)
   private val heartbeatReceiver = env.actorSystem.actorOf(

--- a/core/src/main/scala/org/apache/spark/autoscale/AutoscaleClient.scala
+++ b/core/src/main/scala/org/apache/spark/autoscale/AutoscaleClient.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.autoscale
 
 import org.apache.spark.SparkEnv
@@ -25,16 +42,12 @@ class AutoscaleClient(actorSystem: ActorSystem) extends Logging {
     }
   }
   def addExecutors(count: Int) {
-    if (server != null)
-      server ! AddExecutors(count)
-    else
-      logInfo("Autoscale Server not registered")
+    if (server != null) server ! AddExecutors(count)
+    else logInfo("Autoscale Server not registered")
   }
   def deleteExecutors(execIds: List[String]) {
-    if (server!= null)
-      server ! DeleteExecutors(execIds)
-    else
-      logInfo("Autoscale Server not registered")
+    if (server!= null) server ! DeleteExecutors(execIds)
+    else logInfo("Autoscale Server not registered")
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/autoscale/AutoscaleClient.scala
+++ b/core/src/main/scala/org/apache/spark/autoscale/AutoscaleClient.scala
@@ -1,0 +1,40 @@
+package org.apache.spark.autoscale
+
+import org.apache.spark.SparkEnv
+import akka.actor.ActorRef
+import akka.actor.Actor
+import akka.actor.Props
+import akka.actor.ActorSelection
+import akka.actor.ActorSystem
+import org.apache.spark.Logging
+import org.apache.spark.autoscale.AutoscaleMessages._
+
+class AutoscaleClient(actorSystem: ActorSystem) extends Logging {
+  var server : ActorRef = _
+  actorSystem.actorOf(Props(new AutoscaleClientActor()), "AutoscaleClient")
+  
+  private class AutoscaleClientActor extends Actor {
+    override def preStart = {
+      logInfo("Starting Autoscale Client Actor")
+    }
+    override def receive = {
+      case RegisterAutoscaleServer =>
+        logInfo("Registering Autoscale Server Actor")
+         server = sender
+         sender ! true
+    }
+  }
+  def addExecutors(count: Int) {
+    if (server != null)
+      server ! AddExecutors(count)
+    else
+      logInfo("Autoscale Server not registered")
+  }
+  def deleteExecutors(execIds: List[String]) {
+    if (server!= null)
+      server ! DeleteExecutors(execIds)
+    else
+      logInfo("Autoscale Server not registered")
+  }
+}
+

--- a/core/src/main/scala/org/apache/spark/autoscale/AutoscaleMessage.scala
+++ b/core/src/main/scala/org/apache/spark/autoscale/AutoscaleMessage.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.autoscale
 
 private[spark] sealed trait AutoscaleMessage extends Serializable

--- a/core/src/main/scala/org/apache/spark/autoscale/AutoscaleMessage.scala
+++ b/core/src/main/scala/org/apache/spark/autoscale/AutoscaleMessage.scala
@@ -1,0 +1,11 @@
+package org.apache.spark.autoscale
+
+private[spark] sealed trait AutoscaleMessage extends Serializable
+
+private[spark] object AutoscaleMessages {
+  case class AddExecutors(count: Int) extends AutoscaleMessage
+  case class DeleteExecutors(execId: List[String]) extends AutoscaleMessage
+  case object DeleteFreeExecutors extends AutoscaleMessage
+  case object RegisterAutoscaleServer extends AutoscaleMessage
+  case object RegisteredAutoscaleServer extends AutoscaleMessage
+}

--- a/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -227,6 +227,7 @@ private[spark] class ApplicationMaster(args: ApplicationMasterArguments,
         "Timed out waiting for SparkContext.")
     } else {
       registerAM(sc.ui.map(_.appUIAddress).getOrElse(""), securityMgr)
+      var as = new AutoscaleServer(allocator, sparkConf, sc.env.actorSystem, false).start()
       userClassThread.join()
     }
   }
@@ -236,7 +237,9 @@ private[spark] class ApplicationMaster(args: ApplicationMasterArguments,
       conf = sparkConf, securityManager = securityMgr)._1
     actor = waitForSparkDriver()
     addAmIpFilter()
+
     registerAM(sparkConf.get("spark.driver.appUIAddress", ""), securityMgr)
+    var as = new AutoscaleServer(allocator, sparkConf, actorSystem).start()
 
     // In client mode the actor will stop the reporter thread.
     reporterThread.join()

--- a/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/AutoscaleServer.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/AutoscaleServer.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.deploy.yarn
 
 import org.apache.spark.SparkEnv
@@ -47,12 +64,12 @@ private[spark] class AutoscaleServer(allocator: YarnAllocator, sparkConf: SparkC
         logInfo(s"Driver terminated or disconnected! Shutting down. $x")
         //finish(FinalApplicationStatus.SUCCEEDED)
       case RegisteredAutoscaleServer =>
-        logInfo("Autoscaler registered successfully")
+        logInfo("Autoscale Server registered successfully")
       case AddExecutors(count: Int) =>
-        logInfo("Autoscaler : request to add " + count + "executors")
+        logInfo("Request to add " + count + "executors")
         allocator.addExecutors(count)
       case DeleteExecutors(execIds: List[String]) =>
-        logInfo("Autoscaler: request to delete executor : " + execIds)
+        logInfo("Request to delete executors : " + execIds)
         allocator.deleteExecutors(execIds)
     }
 

--- a/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/AutoscaleServer.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/AutoscaleServer.scala
@@ -1,0 +1,61 @@
+package org.apache.spark.deploy.yarn
+
+import org.apache.spark.SparkEnv
+import org.apache.spark.SparkConf
+import akka.actor.ActorSystem
+import akka.actor.ActorSelection
+import akka.actor.Props
+import org.apache.spark.Logging
+import akka.actor.Actor
+import akka.remote.RemotingLifecycleEvent
+import akka.remote.DisassociatedEvent
+import org.apache.spark.autoscale.AutoscaleMessages._
+
+private[spark] class AutoscaleServer(allocator: YarnAllocator, sparkConf: SparkConf, actorSystem: ActorSystem, isClientRemote : Boolean = true) extends Logging {
+  
+  def start() {
+    var driverUrl = if (isClientRemote) {
+      "akka.tcp://%s@%s:%s/user/%s".format(
+      SparkEnv.driverActorSystemName,
+      sparkConf.get("spark.driver.host"),
+      sparkConf.get("spark.driver.port"),
+      "AutoscaleClient")
+    } else {
+        "akka://%s/user/%s".format(
+        SparkEnv.driverActorSystemName,
+        "AutoscaleClient")
+    }
+    actorSystem.actorOf(Props(new AutoscaleServerActor(driverUrl)), name = "AutoscaleServerActor")
+  }
+  
+  private class AutoscaleServerActor(driverUrl: String) extends Actor {
+
+    var driver: ActorSelection = _
+
+    override def preStart() = {
+      logInfo("Listen to driver: " + driverUrl)
+      driver = context.actorSelection(driverUrl)
+      // Send a hello message to establish the connection, after which
+      // we can monitor Lifecycle Events.
+      driver ! "Hello"
+      driver ! RegisterAutoscaleServer
+      context.system.eventStream.subscribe(self, classOf[RemotingLifecycleEvent])
+    }
+
+    override def receive = {
+      case x: DisassociatedEvent =>
+        logInfo(s"Driver terminated or disconnected! Shutting down. $x")
+        //finish(FinalApplicationStatus.SUCCEEDED)
+      case RegisteredAutoscaleServer =>
+        logInfo("Autoscaler registered successfully")
+      case AddExecutors(count: Int) =>
+        logInfo("Autoscaler : request to add " + count + "executors")
+        allocator.addExecutors(count)
+      case DeleteExecutors(execIds: List[String]) =>
+        logInfo("Autoscaler: request to delete executor : " + execIds)
+        allocator.deleteExecutors(execIds)
+    }
+
+  }
+
+}


### PR DESCRIPTION
sc.addExecutors(count : Int)
sc.deleteExecutors(List[String])
![image](https://cloud.githubusercontent.com/assets/5339198/4628165/8f281bd8-5393-11e4-8f28-f5cc3d7b0795.png)
Diagram : add/deleteExecutors in Yarn-Client mode

In Yarn-Cluster mode, driver program and Yarn allocator threads are in the same JVM. But, in client mode, they live in different JVM’s. To make this work in both client and cluster mode,  we need a way for the driver and Yarn Allocator to communicate and hence uses Actors.

At high level, this works as follows, 
- AutoscaleClientActor is created by SparkContext and AutoscaleServerActor is created by Yarn Application Master code flow. 
- Once AutoscaleServerActor comes up, it registers itself to the AutoscaleClientActor.
- SparkContext forwards the add/deleteExecutors call through AutoScaleClient -> AutoscaleServerActor.
- AutoscaleServer has a reference of YarnAllocator. On receiving addExecutors, it just increments the maxExecutor count in YarnAllocator. And, reporter thread will allocate the respective containers. Note that Yarn Allocator now has both numExecutors (initial count of executors) and maxExecutors and reporter thread will request based on maxExecutors
- YarnAllocator also maintains a map between (executor_id,container_id). Hence to delete executors, we could just call sc.deleteExecutors(List("1","2")) where "1" and "2" are executor id's. We can get the executorId and its storage status from this API - sc.getExecutorStorageStatus.foreach(x=> println(x.blockManagerId.executorId))

Difference when compared to what is proposed
- This creates separate AutoscaleClient whereas the current design proposed(https://issues.apache.org/jira/secure/attachment/12673181/dynamic-scaling-executors-10-6-14.pdf) was to add these new messages in CoarseGrainedSchedulerBackend itself. One minor advantage of doing this way is, the dynamic scaling itself lives as a separate module in Spark and none of the other Spark Core code is affected much. Also, we could add more messages going forward. If you think, its not required, let me know - I can move it to CoarseGrainedSchedulerBackend itself.
