### PR TITLE
[SPARK-3945]Properties of hive-site.xml is invalid in running the Thrift JDBC server

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnv.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnv.scala
@@ -39,7 +39,11 @@ private[hive] object SparkSQLEnv extends Logging {
       sparkContext.addSparkListener(new StatsReportListener())
 
       hiveContext = new HiveContext(sparkContext) {
-        @transient override lazy val sessionState = SessionState.get()
+        @transient override lazy val sessionState = {
+          val state = SessionState.get()
+          setConf(state.getConf.getAllProperties)
+          state
+        }
         @transient override lazy val hiveconf = sessionState.getConf
       }
     }


### PR DESCRIPTION
Write properties of hive-site.xml to HiveContext when initilize session state in SparkSQLEnv.scala.

The method of SparkSQLEnv.init() in HiveThriftServer2.scala can not write the properties of hive-site.xml to HiveContext. Such as: add configuration property spark.sql.shuffle.partititions in the hive-site.xml.
