### PR TITLE
[SPARK-3891][SQL] Add array support to percentile, percentile_approx and constant inspectors support

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypes.scala
@@ -107,7 +107,9 @@ case class GetField(child: Expression, fieldName: String) extends UnaryExpressio
  */
 case class CreateArray(children: Seq[Expression]) extends Expression {
   override type EvaluatedType = Any
-
+  
+  override def foldable = !children.exists(!_.foldable)
+  
   lazy val childTypes = children.map(_.dataType).distinct
 
   override lazy val resolved =

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUdfs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUdfs.scala
@@ -341,11 +341,8 @@ private[hive] case class HiveUdafFunction(
     } else {
       createFunction[AbstractGenericUDAFResolver]()
     }
-
   
-  private val inspectors = 
-    if(isUDAFBridgeRequired) exprs.map(ex => toInspector(ex.dataType)).toArray
-    else exprs.map(toInspector).toArray
+  private val inspectors = exprs.map(toInspector).toArray
     
   private val function = { 
     val parameterInfo = new SimpleGenericUDAFParameterInfo(inspectors,false,false)
@@ -368,6 +365,6 @@ private[hive] case class HiveUdafFunction(
   
   def update(input: Row): Unit = {
     val inputs = inputProjection(input).asInstanceOf[Seq[AnyRef]].toArray
-    function.iterate(buffer, wrap(inputs,inspectors,cached))
+    function.iterate(buffer, wrap(inputs, inspectors, cached))
   }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUdfs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUdfs.scala
@@ -198,7 +198,7 @@ private[hive] case class HiveGenericUdaf(
 
   @transient
   protected lazy val objectInspector  = {
-    val parameterInfo = new SimpleGenericUDAFParameterInfo(inspectors.toArray,false,false)
+    val parameterInfo = new SimpleGenericUDAFParameterInfo(inspectors.toArray, false, false)
     resolver.getEvaluator(parameterInfo)
       .init(GenericUDAFEvaluator.Mode.COMPLETE, inspectors.toArray)
   }
@@ -229,12 +229,13 @@ private[hive] case class HiveUdaf(
 
   @transient
   protected lazy val objectInspector  = {
-    resolver.getEvaluator(children.map(_.dataType.toTypeInfo).toArray)
+    val parameterInfo = new SimpleGenericUDAFParameterInfo(inspectors.toArray, false, false)
+    resolver.getEvaluator(parameterInfo)
       .init(GenericUDAFEvaluator.Mode.COMPLETE, inspectors.toArray)
   }
 
   @transient
-  protected lazy val inspectors = children.map(ex => toInspector(ex.dataType))
+  protected lazy val inspectors = children.map(toInspector)
 
   def dataType: DataType = inspectorToDataType(objectInspector)
 
@@ -267,7 +268,7 @@ private[hive] case class HiveGenericUdtf(
   protected lazy val function: GenericUDTF = createFunction()
 
   @transient
-  protected lazy val inputInspectors = children.map( ex => toInspector(ex.dataType))
+  protected lazy val inputInspectors = children.map(toInspector)
 
   @transient
   protected lazy val outputInspector = function.initialize(inputInspectors.toArray)
@@ -345,7 +346,7 @@ private[hive] case class HiveUdafFunction(
   private val inspectors = exprs.map(toInspector).toArray
     
   private val function = { 
-    val parameterInfo = new SimpleGenericUDAFParameterInfo(inspectors,false,false)
+    val parameterInfo = new SimpleGenericUDAFParameterInfo(inspectors, false, false)
     resolver.getEvaluator(parameterInfo) 
   }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUdfs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUdfs.scala
@@ -165,7 +165,7 @@ private[hive] case class HiveGenericUdf(functionClassName: String, children: Seq
     isUDFDeterministic && returnInspector.isInstanceOf[ConstantObjectInspector]
 
   @transient
-  protected lazy val constantReturnValue = unwrap(
+  protected def constantReturnValue = unwrap(
     returnInspector.asInstanceOf[ConstantObjectInspector].getWritableConstantValue(),
     returnInspector)
   

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUdfSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUdfSuite.scala
@@ -90,8 +90,6 @@ class HiveUdfSuite extends QueryTest {
       
     checkAnswer(sql("SELECT percentile(key, array(1, 1)) FROM src LIMIT 1"),
       sql("SELECT array(max(key), max(key)) FROM src").collect().toSeq)
-      
-    TestHive.reset()
   }
 
   test("Generic UDAF aggregates") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUdfSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUdfSuite.scala
@@ -87,8 +87,19 @@ class HiveUdfSuite extends QueryTest {
   test("SPARK-2693 udaf aggregates test") {
     checkAnswer(sql("SELECT percentile(key,1) FROM src LIMIT 1"),
       sql("SELECT max(key) FROM src").collect().toSeq)
+      
+    checkAnswer(sql("SELECT percentile(key,array(1,1)) FROM src LIMIT 1"),
+      sql("SELECT array(max(key),max(key)) FROM src").collect().toSeq)
   }
 
+  test("Generic UDAF aggregates") {
+    checkAnswer(sql("SELECT ceiling(percentile_approx(key,0.99999)) FROM src LIMIT 1"),
+      sql("SELECT max(key) FROM src LIMIT 1").collect().toSeq)
+      
+    checkAnswer(sql("SELECT percentile_approx(100.0, array(0.9,0.9)) FROM src LIMIT 1"),
+      sql("SELECT array(100,100) FROM src LIMIT 1").collect().toSeq)
+   }	
+  
   test("UDFIntegerToString") {
     val testData = TestHive.sparkContext.parallelize(
       IntegerCaseClass(1) :: IntegerCaseClass(2) :: Nil)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUdfSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUdfSuite.scala
@@ -85,22 +85,22 @@ class HiveUdfSuite extends QueryTest {
   }
 
   test("SPARK-2693 udaf aggregates test") {
-    checkAnswer(sql("SELECT percentile(key,1) FROM src LIMIT 1"),
+    checkAnswer(sql("SELECT percentile(key, 1) FROM src LIMIT 1"),
       sql("SELECT max(key) FROM src").collect().toSeq)
       
-    checkAnswer(sql("SELECT percentile(key,array(1,1)) FROM src LIMIT 1"),
-      sql("SELECT array(max(key),max(key)) FROM src").collect().toSeq)
+    checkAnswer(sql("SELECT percentile(key, array(1, 1)) FROM src LIMIT 1"),
+      sql("SELECT array(max(key), max(key)) FROM src").collect().toSeq)
       
     TestHive.reset()
   }
 
   test("Generic UDAF aggregates") {
-    checkAnswer(sql("SELECT ceiling(percentile_approx(key,0.99999)) FROM src LIMIT 1"),
+    checkAnswer(sql("SELECT ceiling(percentile_approx(key, 0.99999)) FROM src LIMIT 1"),
       sql("SELECT max(key) FROM src LIMIT 1").collect().toSeq)
       
-    checkAnswer(sql("SELECT percentile_approx(100.0, array(0.9,0.9)) FROM src LIMIT 1"),
-      sql("SELECT array(100,100) FROM src LIMIT 1").collect().toSeq)
-   }	
+    checkAnswer(sql("SELECT percentile_approx(100.0, array(0.9, 0.9)) FROM src LIMIT 1"),
+      sql("SELECT array(100, 100) FROM src LIMIT 1").collect().toSeq)
+   }
   
   test("UDFIntegerToString") {
     val testData = TestHive.sparkContext.parallelize(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUdfSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUdfSuite.scala
@@ -100,8 +100,6 @@ class HiveUdfSuite extends QueryTest {
       
     checkAnswer(sql("SELECT percentile_approx(100.0, array(0.9,0.9)) FROM src LIMIT 1"),
       sql("SELECT array(100,100) FROM src LIMIT 1").collect().toSeq)
-    
-    TestHive.reset()
    }	
   
   test("UDFIntegerToString") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUdfSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUdfSuite.scala
@@ -90,6 +90,8 @@ class HiveUdfSuite extends QueryTest {
       
     checkAnswer(sql("SELECT percentile(key,array(1,1)) FROM src LIMIT 1"),
       sql("SELECT array(max(key),max(key)) FROM src").collect().toSeq)
+      
+    TestHive.reset()
   }
 
   test("Generic UDAF aggregates") {
@@ -98,6 +100,8 @@ class HiveUdfSuite extends QueryTest {
       
     checkAnswer(sql("SELECT percentile_approx(100.0, array(0.9,0.9)) FROM src LIMIT 1"),
       sql("SELECT array(100,100) FROM src LIMIT 1").collect().toSeq)
+    
+    TestHive.reset()
    }	
   
   test("UDFIntegerToString") {


### PR DESCRIPTION
Supported passing array to percentile and percentile_approx UDAFs
To support percentile_approx,  constant inspectors are supported for GenericUDAF
Constant folding support added to CreateArray expression
Avoided constant udf expression re-evaluation

Author: Venkata Ramana G ramana.gollamudi@huawei.com
