### PR TITLE
[SPARK-3953][SQL][Minor] Confusable variable name.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
@@ -142,7 +142,7 @@ class SqlParser extends AbstractSparkSQLParser {
       (LIMIT  ~> expression).? ^^ {
         case d ~ p ~ r ~ f ~ g ~ h ~ o ~ l  =>
           val base = r.getOrElse(NoRelation)
-          val withFilter = f.map(f => Filter(f, base)).getOrElse(base)
+          val withFilter = f.map(Filter(_, base)).getOrElse(base)
           val withProjection = g
             .map(Aggregate(_, assignAliases(p), withFilter))
             .getOrElse(Project(assignAliases(p), withFilter))


### PR DESCRIPTION
In SqlParser.scala, there is following code.

```
case d ~ p ~ r ~ f ~ g ~ h ~ o ~ l  =>
  val base = r.getOrElse(NoRelation)
  val withFilter = f.map(f => Filter(f, base)).getOrElse(base)
```

In the code above, there are 2 variables which have same name "f" in near place. 
One is receiver "f" and other is bound variable "f".
