### PR TITLE
[SPARK-3965] Ensure that Spark assembly for hadoop2 contains avro-mapred for hadoop2

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -196,6 +196,20 @@
           <groupId>org.apache.spark</groupId>
           <artifactId>spark-hive_${scala.binary.version}</artifactId>
           <version>${project.version}</version>
+          <exclusions>
+            <exclusion>
+              <groupId>org.apache.avro</groupId>
+              <artifactId>avro-mapred</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+        <!-- spark-hive already depends on avro-mapred but classifier is not applied
+         on transitive dependency so assembly always contains the default version, hadoop1. -->
+        <dependency>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>avro-mapred</artifactId>
+          <version>${avro.version}</version>
+          <classifier>${avro.mapred.classifier}</classifier>
         </dependency>
         <dependency>
           <groupId>org.apache.spark</groupId>


### PR DESCRIPTION
When building current Spark assembly for hadoop2, the wrong version of avro-mapred is picked. This patch adds org.apache.avro:avro-mapred as direct dependency of the assembly to ensure that the correct version is added to it.
