### PR TITLE
[SPARK-4070] [WIP] Add WebUITableBuilder to simplify table-building code

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryPage.scala
@@ -28,19 +28,18 @@ private[spark] class HistoryPage(parent: HistoryServer) extends WebUIPage("") {
   private val pageSize = 20
 
   val appTable: UITable[ApplicationHistoryInfo] = {
-    val builder = new UITableBuilder[ApplicationHistoryInfo]()
-    import builder._
-    customCol("App ID") { info =>
+    val t = new UITableBuilder[ApplicationHistoryInfo]()
+    t.customCol("App ID") { info =>
       val uiAddress = HistoryServer.UI_PATH_PREFIX + s"/${info.id}"
       <a href={uiAddress}>{info.id}</a>
     }
-    col("App Name") { _.name }
-    epochDateCol("Started") { _.startTime }
-    epochDateCol("Completed") { _.endTime }
-    durationCol("Duration") { info => info.endTime - info.startTime }
-    col("Spark User") { _.sparkUser }
-    epochDateCol("Last Updated") { _.lastUpdated }
-    build
+    t.col("App Name") { _.name }
+    t.epochDateCol("Started") { _.startTime }
+    t.epochDateCol("Completed") { _.endTime }
+    t.durationCol("Duration") { info => info.endTime - info.startTime }
+    t.col("Spark User") { _.sparkUser }
+    t.epochDateCol("Last Updated") { _.lastUpdated }
+    t.build()
   }
 
   def render(request: HttpServletRequest): Seq[Node] = {

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryPage.scala
@@ -21,11 +21,27 @@ import javax.servlet.http.HttpServletRequest
 
 import scala.xml.Node
 
-import org.apache.spark.ui.{WebUIPage, UIUtils}
+import org.apache.spark.ui.{UITableBuilder, UITable, WebUIPage, UIUtils}
 
 private[spark] class HistoryPage(parent: HistoryServer) extends WebUIPage("") {
 
   private val pageSize = 20
+
+  val appTable: UITable[ApplicationHistoryInfo] = {
+    val builder = new UITableBuilder[ApplicationHistoryInfo]()
+    import builder._
+    customCol("App ID") { info =>
+      val uiAddress = HistoryServer.UI_PATH_PREFIX + s"/${info.id}"
+      <a href={uiAddress}>{info.id}</a>
+    }
+    col("App Name") { _.name }
+    epochDateCol("Started") { _.startTime }
+    epochDateCol("Completed") { _.endTime }
+    durationCol("Duration") { info => info.endTime - info.startTime }
+    col("Spark User") { _.sparkUser }
+    epochDateCol("Last Updated") { _.lastUpdated }
+    build
+  }
 
   def render(request: HttpServletRequest): Seq[Node] = {
     val requestedPage = Option(request.getParameter("page")).getOrElse("1").toInt
@@ -39,7 +55,7 @@ private[spark] class HistoryPage(parent: HistoryServer) extends WebUIPage("") {
     val last = Math.min(actualFirst + pageSize, allApps.size) - 1
     val pageCount = allApps.size / pageSize + (if (allApps.size % pageSize > 0) 1 else 0)
 
-    val appTable = UIUtils.listingTable(appHeader, appRow, apps)
+    val appTable = this.appTable.render(apps)
     val providerConfig = parent.getProviderConfig()
     val content =
       <div class="row-fluid">
@@ -64,31 +80,5 @@ private[spark] class HistoryPage(parent: HistoryServer) extends WebUIPage("") {
         </div>
       </div>
     UIUtils.basicSparkPage(content, "History Server")
-  }
-
-  private val appHeader = Seq(
-    "App ID",
-    "App Name",
-    "Started",
-    "Completed",
-    "Duration",
-    "Spark User",
-    "Last Updated")
-
-  private def appRow(info: ApplicationHistoryInfo): Seq[Node] = {
-    val uiAddress = HistoryServer.UI_PATH_PREFIX + s"/${info.id}"
-    val startTime = UIUtils.formatDate(info.startTime)
-    val endTime = UIUtils.formatDate(info.endTime)
-    val duration = UIUtils.formatDuration(info.endTime - info.startTime)
-    val lastUpdated = UIUtils.formatDate(info.lastUpdated)
-    <tr>
-      <td><a href={uiAddress}>{info.id}</a></td>
-      <td>{info.name}</td>
-      <td>{startTime}</td>
-      <td>{endTime}</td>
-      <td>{duration}</td>
-      <td>{info.sparkUser}</td>
-      <td>{lastUpdated}</td>
-    </tr>
   }
 }

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryPage.scala
@@ -29,7 +29,7 @@ private[spark] class HistoryPage(parent: HistoryServer) extends WebUIPage("") {
 
   val appTable: UITable[ApplicationHistoryInfo] = {
     val t = new UITableBuilder[ApplicationHistoryInfo]()
-    t.customCol("App ID") { info =>
+    t.col("App ID") (identity) withMarkup { info =>
       val uiAddress = HistoryServer.UI_PATH_PREFIX + s"/${info.id}"
       <a href={uiAddress}>{info.id}</a>
     }

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/ApplicationPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/ApplicationPage.scala
@@ -50,18 +50,18 @@ private[spark] class ApplicationPage(parent: MasterWebUI) extends WebUIPage("app
   private val executorsTable: UITable[ExecutorInfo] = {
     val t = new UITableBuilder[ExecutorInfo]()
     t.col("ExecutorID") { _.id.toString }
-    t.customCol("Worker") { executor =>
+    t.col("Worker") (identity) withMarkup { executor =>
       <a href={executor.worker.webUiAddress}>{executor.worker.id}</a>
     }
-    t.intCol("Cores") { _.cores }
+    t.col("Cores") { _.cores }
     t.sizeCol("Memory") { _.memory }
     t.col("State") { _.state.toString }
-    t.customCol("Logs") { executor =>
+    t.col("Logs") (identity) withMarkup { executor =>
       <a href={"%s/logPage?appId=%s&executorId=%s&logType=stdout"
         .format(executor.worker.webUiAddress, executor.application.id, executor.id)}>stdout</a>
         <a href={"%s/logPage?appId=%s&executorId=%s&logType=stderr"
           .format(executor.worker.webUiAddress, executor.application.id, executor.id)}>stderr</a>
-    }
+    } isUnsortable()
     t.build()
   }
 

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/ApplicationPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/ApplicationPage.scala
@@ -48,22 +48,21 @@ private[spark] class ApplicationPage(parent: MasterWebUI) extends WebUIPage("app
   }
 
   private val executorsTable: UITable[ExecutorInfo] = {
-    val builder = new UITableBuilder[ExecutorInfo]()
-    import builder._
-    col("ExecutorID") { _.id.toString }
-    customCol("Worker") { executor =>
+    val t = new UITableBuilder[ExecutorInfo]()
+    t.col("ExecutorID") { _.id.toString }
+    t.customCol("Worker") { executor =>
       <a href={executor.worker.webUiAddress}>{executor.worker.id}</a>
     }
-    intCol("Cores") { _.cores }
-    memCol("Memory") { _.memory }
-    col("State") { _.state.toString }
-    customCol("Logs") { executor =>
+    t.intCol("Cores") { _.cores }
+    t.memCol("Memory") { _.memory }
+    t.col("State") { _.state.toString }
+    t.customCol("Logs") { executor =>
       <a href={"%s/logPage?appId=%s&executorId=%s&logType=stdout"
         .format(executor.worker.webUiAddress, executor.application.id, executor.id)}>stdout</a>
         <a href={"%s/logPage?appId=%s&executorId=%s&logType=stderr"
           .format(executor.worker.webUiAddress, executor.application.id, executor.id)}>stderr</a>
     }
-    build
+    t.build()
   }
 
   /** Executor details for a particular application */

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/ApplicationPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/ApplicationPage.scala
@@ -54,7 +54,7 @@ private[spark] class ApplicationPage(parent: MasterWebUI) extends WebUIPage("app
       <a href={executor.worker.webUiAddress}>{executor.worker.id}</a>
     }
     t.intCol("Cores") { _.cores }
-    t.memCol("Memory") { _.memory }
+    t.sizeCol("Memory") { _.memory }
     t.col("State") { _.state.toString }
     t.customCol("Logs") { executor =>
       <a href={"%s/logPage?appId=%s&executorId=%s&logType=stdout"

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
@@ -64,7 +64,7 @@ private[spark] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
     }
     t.col("Name") { _.id }
     t.intCol("Cores") { _.coresGranted }
-    t.memCol("Memory per Node") { _.desc.memoryPerSlave }
+    t.sizeCol("Memory per Node") { _.desc.memoryPerSlave }
     t.dateCol("Submitted Time") { _.submitDate }
     t.col("User") { _.desc.user }
     t.col("State") { _.state.toString }
@@ -81,7 +81,7 @@ private[spark] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
     }
     t.col("State") { _.state.toString }
     t.intCol("Cores") { _.desc.cores }
-    t.memCol("Memory") { _.desc.mem.toLong }
+    t.sizeCol("Memory") { _.desc.mem.toLong }
     t.col("Main Class") { _.desc.command.arguments(1) }
     t.build()
   }

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
@@ -42,51 +42,48 @@ private[spark] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
   }
 
   private val workerTable: UITable[WorkerInfo] = {
-    val builder = new UITableBuilder[WorkerInfo]()
-    import builder._
-    customCol("ID") { worker =>
+    val t = new UITableBuilder[WorkerInfo]()
+    t.customCol("ID") { worker =>
       <a href={worker.webUiAddress}>{worker.id}</a>
     }
-    col("Address") { worker => s"${worker.host}:${worker.port}"}
-    col("State") { _.state.toString }
-    intCol("Cores", formatter = c => s"$c Used") { _.coresUsed }
-    customCol("Memory",
+    t.col("Address") { worker => s"${worker.host}:${worker.port}"}
+    t.col("State") { _.state.toString }
+    t.intCol("Cores", formatter = c => s"$c Used") { _.coresUsed }
+    t.customCol("Memory",
       sortKey = Some({worker: WorkerInfo => s"${worker.memory}:${worker.memoryUsed}"})) { worker =>
         Text(Utils.megabytesToString(worker.memory)) ++
         Text(Utils.megabytesToString(worker.memoryUsed))
     }
-    build
+    t.build()
   }
 
   private val appTable: UITable[ApplicationInfo] = {
-    val builder = new UITableBuilder[ApplicationInfo]()
-    import builder._
-    customCol("ID") { app =>
+    val t = new UITableBuilder[ApplicationInfo]()
+    t.customCol("ID") { app =>
       <a href={"app?appId=" + app.id}>{app.id}</a>
     }
-    col("Name") { _.id }
-    intCol("Cores") { _.coresGranted }
-    memCol("Memory per Node") { _.desc.memoryPerSlave }
-    dateCol("Submitted Time") { _.submitDate }
-    col("User") { _.desc.user }
-    col("State") { _.state.toString }
-    durationCol("Duration") { _.duration }
-    build
+    t.col("Name") { _.id }
+    t.intCol("Cores") { _.coresGranted }
+    t.memCol("Memory per Node") { _.desc.memoryPerSlave }
+    t.dateCol("Submitted Time") { _.submitDate }
+    t.col("User") { _.desc.user }
+    t.col("State") { _.state.toString }
+    t.durationCol("Duration") { _.duration }
+    t.build()
   }
 
   private val driverTable: UITable[DriverInfo] = {
-    val builder = new UITableBuilder[DriverInfo]()
-    import builder._
-    col("ID") { _.id }
-    dateCol("Submitted Time") { _.submitDate }
-    customCol("Worker") { driver =>
+    val t = new UITableBuilder[DriverInfo]()
+    t.col("ID") { _.id }
+    t.dateCol("Submitted Time") { _.submitDate }
+    t.customCol("Worker") { driver =>
       driver.worker.map(w => <a href={w.webUiAddress}>{w.id.toString}</a>).getOrElse(Text("None"))
     }
-    col("State") { _.state.toString }
-    intCol("Cores") { _.desc.cores }
-    memCol("Memory") { _.desc.mem.toLong }
-    col("Main Class") { _.desc.command.arguments(1) }
-    build
+    t.col("State") { _.state.toString }
+    t.intCol("Cores") { _.desc.cores }
+    t.memCol("Memory") { _.desc.mem.toLong }
+    t.col("Main Class") { _.desc.command.arguments(1) }
+    t.build()
   }
 
   /** Index view listing applications and executors */

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ui/WorkerPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ui/WorkerPage.scala
@@ -47,7 +47,7 @@ private[spark] class WorkerPage(parent: WorkerWebUI) extends WebUIPage("") {
     t.intCol("Executor ID") { _.execId }
     t.intCol("Cores") { _.cores }
     t.col("State") { _.state.toString }
-    t.memCol("Memory") { _.memory }
+    t.sizeCol("Memory") { _.memory }
     t.customCol("Job Details") { executor =>
       <ul class="unstyled">
         <li><strong>ID:</strong> {executor.appId}</li>
@@ -70,7 +70,7 @@ private[spark] class WorkerPage(parent: WorkerWebUI) extends WebUIPage("") {
     t.col("Main Class") { _.driverDesc.command.arguments(1) }
     t.col("State") { _.finalState.getOrElse(DriverState.RUNNING).toString }
     t.intCol("Cores") { _.driverDesc.cores }
-    t.memCol("Memory") { _.driverDesc.mem }
+    t.sizeCol("Memory") { _.driverDesc.mem }
     t.customCol("Logs") { driver =>
       <a href={s"logPage?driverId=${driver.driverId}&logType=stdout"}>stdout</a>
       <a href={s"logPage?driverId=${driver.driverId}&logType=stderr"}>stderr</a>

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ui/WorkerPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ui/WorkerPage.scala
@@ -48,14 +48,14 @@ private[spark] class WorkerPage(parent: WorkerWebUI) extends WebUIPage("") {
     t.intCol("Cores") { _.cores }
     t.col("State") { _.state.toString }
     t.sizeCol("Memory") { _.memory }
-    t.customCol("Job Details") { executor =>
+    t.customCol("Job Details", sortable = false) { executor =>
       <ul class="unstyled">
         <li><strong>ID:</strong> {executor.appId}</li>
         <li><strong>Name:</strong> {executor.appDesc.name}</li>
         <li><strong>User:</strong> {executor.appDesc.user}</li>
       </ul>
     }
-    t.customCol("Logs") { executor =>
+    t.customCol("Logs", sortable = false) { executor =>
       <a href={"logPage?appId=%s&executorId=%s&logType=stdout"
         .format(executor.appId, executor.execId)}>stdout</a>
       <a href={"logPage?appId=%s&executorId=%s&logType=stderr"
@@ -71,7 +71,7 @@ private[spark] class WorkerPage(parent: WorkerWebUI) extends WebUIPage("") {
     t.col("State") { _.finalState.getOrElse(DriverState.RUNNING).toString }
     t.intCol("Cores") { _.driverDesc.cores }
     t.sizeCol("Memory") { _.driverDesc.mem }
-    t.customCol("Logs") { driver =>
+    t.customCol("Logs", sortable = false) { driver =>
       <a href={s"logPage?driverId=${driver.driverId}&logType=stdout"}>stdout</a>
       <a href={s"logPage?driverId=${driver.driverId}&logType=stderr"}>stderr</a>
     }

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ui/WorkerPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ui/WorkerPage.scala
@@ -44,23 +44,23 @@ private[spark] class WorkerPage(parent: WorkerWebUI) extends WebUIPage("") {
 
   private val executorTable: UITable[ExecutorRunner] = {
     val t = new UITableBuilder[ExecutorRunner]()
-    t.intCol("Executor ID") { _.execId }
-    t.intCol("Cores") { _.cores }
+    t.col("Executor ID") { _.execId }
+    t.col("Cores") { _.cores }
     t.col("State") { _.state.toString }
     t.sizeCol("Memory") { _.memory }
-    t.customCol("Job Details", sortable = false) { executor =>
+    t.col("Job Details") (identity) withMarkup  { executor =>
       <ul class="unstyled">
         <li><strong>ID:</strong> {executor.appId}</li>
         <li><strong>Name:</strong> {executor.appDesc.name}</li>
         <li><strong>User:</strong> {executor.appDesc.user}</li>
       </ul>
-    }
-    t.customCol("Logs", sortable = false) { executor =>
+    } isUnsortable()
+    t.col("Logs") (identity) withMarkup { executor =>
       <a href={"logPage?appId=%s&executorId=%s&logType=stdout"
         .format(executor.appId, executor.execId)}>stdout</a>
       <a href={"logPage?appId=%s&executorId=%s&logType=stderr"
         .format(executor.appId, executor.execId)}>stderr</a>
-    }
+    } isUnsortable()
     t.build()
   }
 
@@ -69,12 +69,12 @@ private[spark] class WorkerPage(parent: WorkerWebUI) extends WebUIPage("") {
     t.col("Driver ID") { _.driverId }
     t.col("Main Class") { _.driverDesc.command.arguments(1) }
     t.col("State") { _.finalState.getOrElse(DriverState.RUNNING).toString }
-    t.intCol("Cores") { _.driverDesc.cores }
+    t.col("Cores") { _.driverDesc.cores }
     t.sizeCol("Memory") { _.driverDesc.mem }
-    t.customCol("Logs", sortable = false) { driver =>
+    t.col("Logs") (identity) withMarkup { driver =>
       <a href={s"logPage?driverId=${driver.driverId}&logType=stdout"}>stdout</a>
       <a href={s"logPage?driverId=${driver.driverId}&logType=stderr"}>stderr</a>
-    }
+    } isUnsortable()
     t.col("Notes") { _.finalException.getOrElse("").toString }
     t.build()
   }

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ui/WorkerPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ui/WorkerPage.scala
@@ -43,42 +43,40 @@ private[spark] class WorkerPage(parent: WorkerWebUI) extends WebUIPage("") {
   }
 
   private val executorTable: UITable[ExecutorRunner] = {
-    val builder = new UITableBuilder[ExecutorRunner]()
-    import builder._
-    intCol("Executor ID") { _.execId }
-    intCol("Cores") { _.cores }
-    col("State") { _.state.toString }
-    memCol("Memory") { _.memory }
-    customCol("Job Details") { executor =>
+    val t = new UITableBuilder[ExecutorRunner]()
+    t.intCol("Executor ID") { _.execId }
+    t.intCol("Cores") { _.cores }
+    t.col("State") { _.state.toString }
+    t.memCol("Memory") { _.memory }
+    t.customCol("Job Details") { executor =>
       <ul class="unstyled">
         <li><strong>ID:</strong> {executor.appId}</li>
         <li><strong>Name:</strong> {executor.appDesc.name}</li>
         <li><strong>User:</strong> {executor.appDesc.user}</li>
       </ul>
     }
-    customCol("Logs") { executor =>
+    t.customCol("Logs") { executor =>
       <a href={"logPage?appId=%s&executorId=%s&logType=stdout"
         .format(executor.appId, executor.execId)}>stdout</a>
       <a href={"logPage?appId=%s&executorId=%s&logType=stderr"
         .format(executor.appId, executor.execId)}>stderr</a>
     }
-    build
+    t.build()
   }
 
   private val driverTable: UITable[DriverRunner] = {
-    val builder = new UITableBuilder[DriverRunner]()
-    import builder._
-    col("Driver ID") { _.driverId }
-    col("Main Class") { _.driverDesc.command.arguments(1) }
-    col("State") { _.finalState.getOrElse(DriverState.RUNNING).toString }
-    intCol("Cores") { _.driverDesc.cores }
-    memCol("Memory") { _.driverDesc.mem }
-    customCol("Logs") { driver =>
+    val t = new UITableBuilder[DriverRunner]()
+    t.col("Driver ID") { _.driverId }
+    t.col("Main Class") { _.driverDesc.command.arguments(1) }
+    t.col("State") { _.finalState.getOrElse(DriverState.RUNNING).toString }
+    t.intCol("Cores") { _.driverDesc.cores }
+    t.memCol("Memory") { _.driverDesc.mem }
+    t.customCol("Logs") { driver =>
       <a href={s"logPage?driverId=${driver.driverId}&logType=stdout"}>stdout</a>
       <a href={s"logPage?driverId=${driver.driverId}&logType=stderr"}>stderr</a>
     }
-    col("Notes") { _.finalException.getOrElse("").toString }
-    build
+    t.col("Notes") { _.finalException.getOrElse("").toString }
+    t.build()
   }
 
   def render(request: HttpServletRequest): Seq[Node] = {

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ui/WorkerPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ui/WorkerPage.scala
@@ -28,7 +28,7 @@ import org.apache.spark.deploy.JsonProtocol
 import org.apache.spark.deploy.DeployMessages.{RequestWorkerState, WorkerStateResponse}
 import org.apache.spark.deploy.master.DriverState
 import org.apache.spark.deploy.worker.{DriverRunner, ExecutorRunner}
-import org.apache.spark.ui.{WebUIPage, UIUtils}
+import org.apache.spark.ui.{UITable, UITableBuilder, WebUIPage, UIUtils}
 import org.apache.spark.util.Utils
 
 private[spark] class WorkerPage(parent: WorkerWebUI) extends WebUIPage("") {
@@ -42,23 +42,58 @@ private[spark] class WorkerPage(parent: WorkerWebUI) extends WebUIPage("") {
     JsonProtocol.writeWorkerState(workerState)
   }
 
+  private val executorTable: UITable[ExecutorRunner] = {
+    val builder = new UITableBuilder[ExecutorRunner]()
+    import builder._
+    intCol("Executor ID") { _.execId }
+    intCol("Cores") { _.cores }
+    col("State") { _.state.toString }
+    memCol("Memory") { _.memory }
+    customCol("Job Details") { executor =>
+      <ul class="unstyled">
+        <li><strong>ID:</strong> {executor.appId}</li>
+        <li><strong>Name:</strong> {executor.appDesc.name}</li>
+        <li><strong>User:</strong> {executor.appDesc.user}</li>
+      </ul>
+    }
+    customCol("Logs") { executor =>
+      <a href={"logPage?appId=%s&executorId=%s&logType=stdout"
+        .format(executor.appId, executor.execId)}>stdout</a>
+      <a href={"logPage?appId=%s&executorId=%s&logType=stderr"
+        .format(executor.appId, executor.execId)}>stderr</a>
+    }
+    build
+  }
+
+  private val driverTable: UITable[DriverRunner] = {
+    val builder = new UITableBuilder[DriverRunner]()
+    import builder._
+    col("Driver ID") { _.driverId }
+    col("Main Class") { _.driverDesc.command.arguments(1) }
+    col("State") { _.finalState.getOrElse(DriverState.RUNNING).toString }
+    intCol("Cores") { _.driverDesc.cores }
+    memCol("Memory") { _.driverDesc.mem }
+    customCol("Logs") { driver =>
+      <a href={s"logPage?driverId=${driver.driverId}&logType=stdout"}>stdout</a>
+      <a href={s"logPage?driverId=${driver.driverId}&logType=stderr"}>stderr</a>
+    }
+    col("Notes") { _.finalException.getOrElse("").toString }
+    build
+  }
+
   def render(request: HttpServletRequest): Seq[Node] = {
     val stateFuture = (workerActor ? RequestWorkerState)(timeout).mapTo[WorkerStateResponse]
     val workerState = Await.result(stateFuture, timeout)
 
-    val executorHeaders = Seq("ExecutorID", "Cores", "State", "Memory", "Job Details", "Logs")
     val runningExecutors = workerState.executors
-    val runningExecutorTable =
-      UIUtils.listingTable(executorHeaders, executorRow, runningExecutors)
+    val runningExecutorTable = executorTable.render(runningExecutors)
     val finishedExecutors = workerState.finishedExecutors
-    val finishedExecutorTable =
-      UIUtils.listingTable(executorHeaders, executorRow, finishedExecutors)
+    val finishedExecutorTable = executorTable.render(finishedExecutors)
 
-    val driverHeaders = Seq("DriverID", "Main Class", "State", "Cores", "Memory", "Logs", "Notes")
     val runningDrivers = workerState.drivers.sortBy(_.driverId).reverse
-    val runningDriverTable = UIUtils.listingTable(driverHeaders, driverRow, runningDrivers)
+    val runningDriverTable = driverTable.render(runningDrivers)
     val finishedDrivers = workerState.finishedDrivers.sortBy(_.driverId).reverse
-    val finishedDriverTable = UIUtils.listingTable(driverHeaders, driverRow, finishedDrivers)
+    val finishedDriverTable = driverTable.render(finishedDrivers)
 
     // For now we only show driver information if the user has submitted drivers to the cluster.
     // This is until we integrate the notion of drivers and applications in the UI.
@@ -104,51 +139,5 @@ private[spark] class WorkerPage(parent: WorkerWebUI) extends WebUIPage("") {
       </div>;
     UIUtils.basicSparkPage(content, "Spark Worker at %s:%s".format(
       workerState.host, workerState.port))
-  }
-
-  def executorRow(executor: ExecutorRunner): Seq[Node] = {
-    <tr>
-      <td>{executor.execId}</td>
-      <td>{executor.cores}</td>
-      <td>{executor.state}</td>
-      <td sorttable_customkey={executor.memory.toString}>
-        {Utils.megabytesToString(executor.memory)}
-      </td>
-      <td>
-        <ul class="unstyled">
-          <li><strong>ID:</strong> {executor.appId}</li>
-          <li><strong>Name:</strong> {executor.appDesc.name}</li>
-          <li><strong>User:</strong> {executor.appDesc.user}</li>
-        </ul>
-      </td>
-      <td>
-     <a href={"logPage?appId=%s&executorId=%s&logType=stdout"
-        .format(executor.appId, executor.execId)}>stdout</a>
-     <a href={"logPage?appId=%s&executorId=%s&logType=stderr"
-        .format(executor.appId, executor.execId)}>stderr</a>
-      </td>
-    </tr>
-
-  }
-
-  def driverRow(driver: DriverRunner): Seq[Node] = {
-    <tr>
-      <td>{driver.driverId}</td>
-      <td>{driver.driverDesc.command.arguments(1)}</td>
-      <td>{driver.finalState.getOrElse(DriverState.RUNNING)}</td>
-      <td sorttable_customkey={driver.driverDesc.cores.toString}>
-        {driver.driverDesc.cores.toString}
-      </td>
-      <td sorttable_customkey={driver.driverDesc.mem.toString}>
-        {Utils.megabytesToString(driver.driverDesc.mem)}
-      </td>
-      <td>
-        <a href={s"logPage?driverId=${driver.driverId}&logType=stdout"}>stdout</a>
-        <a href={s"logPage?driverId=${driver.driverId}&logType=stderr"}>stderr</a>
-      </td>
-      <td>
-        {driver.finalException.getOrElse("")}
-      </td>
-    </tr>
   }
 }

--- a/core/src/main/scala/org/apache/spark/ui/UITables.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UITables.scala
@@ -20,7 +20,7 @@ package org.apache.spark.ui
 import java.util.Date
 
 import scala.collection.mutable
-import scala.xml.{Text, Node}
+import scala.xml.{Node, Text}
 
 import org.apache.spark.util.Utils
 
@@ -142,17 +142,7 @@ private[spark] class UITable[T] (cols: Seq[UITableColumn[T, _]], fixedWidth: Boo
  *    Columns have additional options, such as controlling their sort keys; see the individual
  *    methods' documentation for more details.
  *
- *  - Call `build` to construct an immutable object which can be used to render tables.
- *   *
- * To remove some of the boilerplate here, you can statically import the `col` methods; for example:
- *
- *    val myTable: UITable[MyRowDataType] = {
- *      val builder = new UITableBuilder[MyRowDataType]()
- *      import builder._
- *      col("Name") { _.name }
- *      [...]
- *      build
- *    }
+ *  - Call `build()` to construct an immutable object which can be used to render tables.
  *
  * There are many other features, including support for arbitrary markup in custom column types;
  * see the actual uses in the web UI code for more details.
@@ -168,9 +158,9 @@ private[spark] class UITableBuilder[T](fixedWidth: Boolean = false) {
    * render the contents of the TD tag, not the TD tag itself.
    */
   def customCol[V](
-    name: String,
-    sortable: Boolean = true,
-    sortKey: Option[T => String] = None)(renderer: T => Seq[Node]): UITableBuilder[T] = {
+      name: String,
+      sortable: Boolean = true,
+      sortKey: Option[T => String] = None)(renderer: T => Seq[Node]): UITableBuilder[T] = {
     val customColumn = new UITableColumn[T, T](name, null, sortable, sortKey, identity) {
       override def renderCellContents(row: T) = renderer(row)
     }
@@ -179,32 +169,32 @@ private[spark] class UITableBuilder[T](fixedWidth: Boolean = false) {
   }
 
   def col[V](
-    name: String,
-    formatter: V => String,
-    sortable: Boolean = true,
-    sortKey: Option[V => String] = None)(fieldExtractor: T => V): UITableBuilder[T] = {
+      name: String,
+      formatter: V => String,
+      sortable: Boolean = true,
+      sortKey: Option[V => String] = None)(fieldExtractor: T => V): UITableBuilder[T] = {
     cols.append(UITableColumn(name, formatter, sortable, sortKey, fieldExtractor))
     this
   }
 
   def col(
-    name: String,
-    sortable: Boolean = true,
-    sortKey: Option[String => String] = None)(fieldExtractor: T => String): UITableBuilder[T] = {
+      name: String,
+      sortable: Boolean = true,
+      sortKey: Option[String => String] = None)(fieldExtractor: T => String): UITableBuilder[T] = {
     col[String](name, {x: String => x}, sortable, sortKey)(fieldExtractor)
   }
 
   def intCol(
-    name: String,
-    formatter: Int => String = { x: Int => x.toString },
-    sortable: Boolean = true)(fieldExtractor: T => Int): UITableBuilder[T] = {
+      name: String,
+      formatter: Int => String = { x: Int => x.toString },
+      sortable: Boolean = true)(fieldExtractor: T => Int): UITableBuilder[T] = {
     col[Int](name, formatter, sortable = sortable)(fieldExtractor)
   }
 
   /**
-   * Display a column of memory sizes, in megabytes, as human-readable strings, such as "4.0 MB".
+   * Display a column of sizes, in megabytes, as human-readable strings, such as "4.0 MB".
    */
-  def memCol(name: String)(fieldExtractor: T => Long): UITableBuilder[T] = {
+  def sizeCol(name: String)(fieldExtractor: T => Long): UITableBuilder[T] = {
     col[Long](
       name,
       formatter = Utils.megabytesToString,

--- a/core/src/main/scala/org/apache/spark/ui/UITables.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UITables.scala
@@ -98,7 +98,7 @@ private[spark] class UITable[T] (cols: Seq[UITableColumn[T, _]], fixedWidth: Boo
   }
 
   /** Render the table with the given data */
-  def render(data: Seq[T]): Seq[Node] = {
+  def render(data: Iterable[T]): Seq[Node] = {
     val rows = data.map(renderRow)
     <table class={tableClass}>
       <thead>{headerRow}</thead>
@@ -216,6 +216,13 @@ private[spark] class UITableBuilder[T](fixedWidth: Boolean = false) {
    */
   def dateCol(name: String)(fieldExtractor: T => Date): UITableBuilder[T] = {
     col[Date](name, formatter = UIUtils.formatDate)(fieldExtractor)
+  }
+
+  /**
+   * Display a column of dates as yyyy/MM/dd HH:mm:ss format.
+   */
+  def epochDateCol(name: String)(fieldExtractor: T => Long): UITableBuilder[T] = {
+    col[Long](name, formatter = UIUtils.formatDate)(fieldExtractor)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/ui/UITables.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UITables.scala
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ui
+
+import java.util.Date
+
+import scala.collection.mutable
+import scala.xml.{Text, Node}
+
+import org.apache.spark.util.Utils
+
+
+/**
+ * Describes how to render a column of values in a web UI table.
+ *
+ * @param name the name / title of this column
+ * @param formatter function that formats values for display in the table
+ * @param sortable if false, this column will not be sortable
+ * @param sortKey optional function for sorting by a key other than `formatter(value)`
+ * @param fieldExtractor function for extracting this field's value from the table's row data type
+ * @tparam T the table's row data type
+ * @tparam V this column's value type
+ */
+private case class UITableColumn[T, V](
+  name: String,
+  formatter: V => String,
+  sortable: Boolean,
+  sortKey: Option[V => String],
+  fieldExtractor: T => V) {
+
+  /** Render the TD tag for this row */
+  def renderCell(row: T): Seq[Node] =  {
+    val data = fieldExtractor(row)
+    val cellContents = renderCellContents(data)
+    <td sorttable_customkey={sortKey.map(k => Text(k(data)))}>
+      {cellContents}
+    </td>
+  }
+
+  /** Render the contents of the TD tag for this row.  The contents may be a string or HTML */
+  def renderCellContents(data: V): Seq[Node] = {
+    Text(formatter(data))
+  }
+}
+
+/**
+ * Describes how to render a table to display rows of type `T`.
+ * @param cols a sequence of UITableColumns that describe how each column should be rendered
+ * @param fixedWidth if true, all columns of this table will be displayed with the same width
+ * @tparam T the row data type
+ */
+private[spark] class UITable[T] (cols: Seq[UITableColumn[T, _]], fixedWidth: Boolean) {
+
+  private val tableClass = if (fixedWidth) {
+    UIUtils.TABLE_CLASS + " table-fixed"
+  } else {
+    UIUtils.TABLE_CLASS
+  }
+
+  private val colWidthAttr = if (fixedWidth) Some(Text((100.toDouble / cols.size) + "%")) else None
+
+  private val headerRow: Seq[Node] = {
+    val headers = cols.map(_.name)
+    // if none of the headers have "\n" in them
+    if (headers.forall(!_.contains("\n"))) {
+      // represent header as simple text
+      headers.map(h => <th width={colWidthAttr}>{h}</th>)
+    } else {
+      // represent header text as list while respecting "\n"
+      headers.map { case h =>
+        <th width={colWidthAttr}>
+          <ul class="unstyled">
+            { h.split("\n").map { case t => <li> {t} </li> } }
+          </ul>
+        </th>
+      }
+    }
+  }
+
+  private def renderRow(row: T): Seq[Node] = {
+    val tds = cols.map(_.renderCell(row))
+    <tr>{ tds }</tr>
+  }
+
+  /** Render the table with the given data */
+  def render(data: Seq[T]): Seq[Node] = {
+    val rows = data.map(renderRow)
+    <table class={tableClass}>
+      <thead>{headerRow}</thead>
+      <tbody>
+        {rows}
+      </tbody>
+    </table>
+  }
+}
+
+/**
+ * Builder for constructing web UI tables.  This builder offers several advantages over constructing
+ * tables by hand using raw XML:
+ *
+ *  - All of the table's data and formatting logic can live in one place; the table headers and
+ *    rows aren't described in separate code.  This prevents several common errors, like changing
+ *    the ordering of two column headers but forgetting to re-order the corresponding TD tags.
+ *
+ *  - No repetition of code for type-specific display rules: common column types like "memory",
+ *    "duration", and "time" have convenience methods that implement the right formatting logic.
+ *
+ *  - Details of our specific markup are generally abstracted away.  For example, the markup for
+ *    setting a custom sort key on a column now lives in one place, rather than being repeated
+ *    in each table.
+ *
+ * The recommended way of using this class:
+ *
+ *  - Create a new builder that is parametrized by the type (`T`) of data that you want to render.
+ *    In many cases, there may be some record type like `WorkerInfo` that holds all of the
+ *    information needed to render a particular row.  If the data for each table row comes from
+ *    several objects, you can combine those objects into a tuple or case-class.
+ *
+ *  - Use the `col` methods to add columns to this builder.  The final argument of each `col` method
+ *    is a function that extracts the column's field from a row object of type `T`.  Columns are
+ *    displayed in the order that they are added to the builder.  For most columns, you can write
+ *    code like
+ *
+ *      builder.col("Id") { _.id }
+ *      builder.memCol("Memory" { _.memory }
+ *
+ *    Columns have additional options, such as controlling their sort keys; see the individual
+ *    methods' documentation for more details.
+ *
+ *  - Call `build` to construct an immutable object which can be used to render tables.
+ *   *
+ * To remove some of the boilerplate here, you can statically import the `col` methods; for example:
+ *
+ *    val myTable: UITable[MyRowDataType] = {
+ *      val builder = new UITableBuilder[MyRowDataType]()
+ *      import builder._
+ *      col("Name") { _.name }
+ *      [...]
+ *      build
+ *    }
+ *
+ * There are many other features, including support for arbitrary markup in custom column types;
+ * see the actual uses in the web UI code for more details.
+ *
+ * @param fixedWidth if true, all columns will be rendered with the same width
+ * @tparam T the type of the data items that will be used to render individual rows
+ */
+private[spark] class UITableBuilder[T](fixedWidth: Boolean = false) {
+  private val cols = mutable.Buffer[UITableColumn[T, _]]()
+
+  /**
+   * Display a column with custom HTML markup.  The markup should only describe how to
+   * render the contents of the TD tag, not the TD tag itself.
+   */
+  def customCol[V](
+    name: String,
+    sortable: Boolean = true,
+    sortKey: Option[T => String] = None)(renderer: T => Seq[Node]): UITableBuilder[T] = {
+    val customColumn = new UITableColumn[T, T](name, null, sortable, sortKey, identity) {
+      override def renderCellContents(row: T) = renderer(row)
+    }
+    cols.append(customColumn)
+    this
+  }
+
+  def col[V](
+    name: String,
+    formatter: V => String,
+    sortable: Boolean = true,
+    sortKey: Option[V => String] = None)(fieldExtractor: T => V): UITableBuilder[T] = {
+    cols.append(UITableColumn(name, formatter, sortable, sortKey, fieldExtractor))
+    this
+  }
+
+  def col(
+    name: String,
+    sortable: Boolean = true,
+    sortKey: Option[String => String] = None)(fieldExtractor: T => String): UITableBuilder[T] = {
+    col[String](name, {x: String => x}, sortable, sortKey)(fieldExtractor)
+  }
+
+  def intCol(
+    name: String,
+    formatter: Int => String = { x: Int => x.toString },
+    sortable: Boolean = true)(fieldExtractor: T => Int): UITableBuilder[T] = {
+    col[Int](name, formatter, sortable = sortable)(fieldExtractor)
+  }
+
+  /**
+   * Display a column of memory sizes, in megabytes, as human-readable strings, such as "4.0 MB".
+   */
+  def memCol(name: String)(fieldExtractor: T => Long): UITableBuilder[T] = {
+    col[Long](
+      name,
+      formatter = Utils.megabytesToString,
+      sortKey = Some(x => x.toString))(fieldExtractor)
+  }
+
+  /**
+   * Display a column of dates as yyyy/MM/dd HH:mm:ss format.
+   */
+  def dateCol(name: String)(fieldExtractor: T => Date): UITableBuilder[T] = {
+    col[Date](name, formatter = UIUtils.formatDate)(fieldExtractor)
+  }
+
+  /**
+   * Display a column of durations, in milliseconds, as human-readable strings, such as "12 s".
+   */
+  def durationCol(name: String)(fieldExtractor: T => Long): UITableBuilder[T] = {
+    col[Long](name, formatter = UIUtils.formatDuration)(fieldExtractor)
+  }
+
+  def build: UITable[T] = {
+    val immutableCols: Seq[UITableColumn[T, _]] = cols.toSeq
+    new UITable[T](immutableCols, fixedWidth)
+  }
+}

--- a/core/src/main/scala/org/apache/spark/ui/UITables.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UITables.scala
@@ -47,7 +47,8 @@ private case class UITableColumn[T, V](
   def renderCell(row: T): Seq[Node] =  {
     val data = fieldExtractor(row)
     val cellContents = renderCellContents(data)
-    <td sorttable_customkey={sortKey.map(k => Text(k(data)))}>
+    val cls = if (sortable) None else Some(Text("sorttable_nosort"))
+    <td sorttable_customkey={sortKey.map(k => Text(k(data)))} class={cls}>
       {cellContents}
     </td>
   }

--- a/core/src/main/scala/org/apache/spark/ui/UITables.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UITables.scala
@@ -229,7 +229,19 @@ private[spark] class UITableBuilder[T](fixedWidth: Boolean = false) {
    * Display a column of durations, in milliseconds, as human-readable strings, such as "12 s".
    */
   def durationCol(name: String)(fieldExtractor: T => Long): UITableBuilder[T] = {
-    col[Long](name, formatter = UIUtils.formatDuration)(fieldExtractor)
+    col[Long](name, formatter = UIUtils.formatDuration, sortKey = Some(_.toString))(fieldExtractor)
+  }
+
+  /**
+   * Display a column of optional durations, in milliseconds, as human-readable strings,
+   * such as "12 s".  If the duration is None, then '-' will be displayed.
+   */
+  def optDurationCol(name: String)(fieldExtractor: T => Option[Long]): UITableBuilder[T] = {
+    col[Option[Long]](
+      name,
+      formatter = { _.map(UIUtils.formatDuration).getOrElse("-")},
+      sortKey = Some(_.getOrElse("-").toString)
+    )(fieldExtractor)
   }
 
   def build: UITable[T] = {

--- a/core/src/main/scala/org/apache/spark/ui/UITables.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UITables.scala
@@ -244,7 +244,7 @@ private[spark] class UITableBuilder[T](fixedWidth: Boolean = false) {
     )(fieldExtractor)
   }
 
-  def build: UITable[T] = {
+  def build(): UITable[T] = {
     val immutableCols: Seq[UITableColumn[T, _]] = cols.toSeq
     new UITable[T](immutableCols, fixedWidth)
   }

--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -234,6 +234,14 @@ private[spark] object UIUtils extends Logging {
     </html>
   }
 
+  /** Render key-value pairs as a table */
+  def stringPairTable(col1Name: String, col2Name: String): UITable[(Any, Any)] = {
+    val t = new UITableBuilder[(Any, Any)](fixedWidth = true)
+    t.col(col1Name) { _._1.toString }
+    t.col(col2Name) { _._2.toString }
+    t.build()
+  }
+
   /** Returns an HTML table constructed by generating a row for each object in a sequence. */
   def listingTable[T](
       headers: Seq[String],

--- a/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
@@ -21,20 +21,13 @@ import javax.servlet.http.HttpServletRequest
 
 import scala.xml.Node
 
-import org.apache.spark.ui.{UITableBuilder, UITable, UIUtils, WebUIPage}
+import org.apache.spark.ui.{UIUtils, WebUIPage}
 
 private[ui] class EnvironmentPage(parent: EnvironmentTab) extends WebUIPage("") {
   private val listener = parent.listener
 
-  private def stringPairTable(col1Name: String, col2Name: String): UITable[(Any, Any)] = {
-    val t = new UITableBuilder[(Any, Any)](fixedWidth = true)
-    t.col(col1Name) { _._1.toString }
-    t.col(col2Name) { _._2.toString }
-    t.build()
-  }
-
-  private val propertyTable = stringPairTable("Name", "Value")
-  private val classpathTable = stringPairTable("Resource", "Source")
+  private val propertyTable = UIUtils.stringPairTable("Name", "Value")
+  private val classpathTable = UIUtils.stringPairTable("Resource", "Source")
 
   def render(request: HttpServletRequest): Seq[Node] = {
     val content =

--- a/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
@@ -27,11 +27,10 @@ private[ui] class EnvironmentPage(parent: EnvironmentTab) extends WebUIPage("") 
   private val listener = parent.listener
 
   private def stringPairTable(col1Name: String, col2Name: String): UITable[(Any, Any)] = {
-    val builder = new UITableBuilder[(Any, Any)](fixedWidth = true)
-    import builder._
-    col(col1Name) { _._1.toString }
-    col(col2Name) { _._2.toString }
-    build
+    val t = new UITableBuilder[(Any, Any)](fixedWidth = true)
+    t.col(col1Name) { _._1.toString }
+    t.col(col2Name) { _._2.toString }
+    t.build()
   }
 
   private val propertyTable = stringPairTable("Name", "Value")

--- a/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/env/EnvironmentPage.scala
@@ -21,34 +21,31 @@ import javax.servlet.http.HttpServletRequest
 
 import scala.xml.Node
 
-import org.apache.spark.ui.{UIUtils, WebUIPage}
+import org.apache.spark.ui.{UITableBuilder, UITable, UIUtils, WebUIPage}
 
 private[ui] class EnvironmentPage(parent: EnvironmentTab) extends WebUIPage("") {
   private val listener = parent.listener
 
+  private def stringPairTable(col1Name: String, col2Name: String): UITable[(Any, Any)] = {
+    val builder = new UITableBuilder[(Any, Any)](fixedWidth = true)
+    import builder._
+    col(col1Name) { _._1.toString }
+    col(col2Name) { _._2.toString }
+    build
+  }
+
+  private val propertyTable = stringPairTable("Name", "Value")
+  private val classpathTable = stringPairTable("Resource", "Source")
+
   def render(request: HttpServletRequest): Seq[Node] = {
-    val runtimeInformationTable = UIUtils.listingTable(
-      propertyHeader, jvmRow, listener.jvmInformation, fixedWidth = true)
-    val sparkPropertiesTable = UIUtils.listingTable(
-      propertyHeader, propertyRow, listener.sparkProperties, fixedWidth = true)
-    val systemPropertiesTable = UIUtils.listingTable(
-      propertyHeader, propertyRow, listener.systemProperties, fixedWidth = true)
-    val classpathEntriesTable = UIUtils.listingTable(
-      classPathHeaders, classPathRow, listener.classpathEntries, fixedWidth = true)
     val content =
       <span>
-        <h4>Runtime Information</h4> {runtimeInformationTable}
-        <h4>Spark Properties</h4> {sparkPropertiesTable}
-        <h4>System Properties</h4> {systemPropertiesTable}
-        <h4>Classpath Entries</h4> {classpathEntriesTable}
+        <h4>Runtime Information</h4> {propertyTable.render(listener.jvmInformation)}
+        <h4>Spark Properties</h4> {propertyTable.render(listener.sparkProperties)}
+        <h4>System Properties</h4> {propertyTable.render(listener.systemProperties)}
+        <h4>Classpath Entries</h4> {classpathTable.render(listener.classpathEntries)}
       </span>
 
     UIUtils.headerSparkPage("Environment", content, parent)
   }
-
-  private def propertyHeader = Seq("Name", "Value")
-  private def classPathHeaders = Seq("Resource", "Source")
-  private def jvmRow(kv: (String, String)) = <tr><td>{kv._1}</td><td>{kv._2}</td></tr>
-  private def propertyRow(kv: (String, String)) = <tr><td>{kv._1}</td><td>{kv._2}</td></tr>
-  private def classPathRow(data: (String, String)) = <tr><td>{data._1}</td><td>{data._2}</td></tr>
 }

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -31,6 +31,8 @@ import org.apache.spark.scheduler.AccumulableInfo
 private[ui] class StagePage(parent: JobProgressTab) extends WebUIPage("stage") {
   private val listener = parent.listener
 
+  private val accumulableTable = UIUtils.stringPairTable("Accumulable", "Value")
+
   def render(request: HttpServletRequest): Seq[Node] = {
     listener.synchronized {
       val stageId = request.getParameter("id").toInt
@@ -96,10 +98,8 @@ private[ui] class StagePage(parent: JobProgressTab) extends WebUIPage("stage") {
           </ul>
         </div>
         // scalastyle:on
-      val accumulableHeaders: Seq[String] = Seq("Accumulable", "Value")
-      def accumulableRow(acc: AccumulableInfo) = <tr><td>{acc.name}</td><td>{acc.value}</td></tr>
-      val accumulableTable = UIUtils.listingTable(accumulableHeaders, accumulableRow,
-        accumulables.values.toSeq)
+      val accumulableTable =
+        this.accumulableTable.render(accumulables.values.map(a => (a.name, a.value)))
 
       val taskHeaders: Seq[String] =
         Seq(

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -20,12 +20,11 @@ package org.apache.spark.ui.jobs
 import java.util.Date
 import javax.servlet.http.HttpServletRequest
 
-import scala.xml.{Node, Unparsed}
+import scala.xml.{Text, Node, Unparsed}
 
-import org.apache.spark.ui.{ToolTips, WebUIPage, UIUtils}
+import org.apache.spark.ui._
 import org.apache.spark.ui.jobs.UIData._
 import org.apache.spark.util.{Utils, Distribution}
-import org.apache.spark.scheduler.AccumulableInfo
 
 /** Page showing statistics and task list for a given stage */
 private[ui] class StagePage(parent: JobProgressTab) extends WebUIPage("stage") {
@@ -58,6 +57,101 @@ private[ui] class StagePage(parent: JobProgressTab) extends WebUIPage("stage") {
       val hasShuffleRead = stageData.shuffleReadBytes > 0
       val hasShuffleWrite = stageData.shuffleWriteBytes > 0
       val hasBytesSpilled = stageData.memoryBytesSpilled > 0 && stageData.diskBytesSpilled > 0
+
+      val taskTableRenderer: UITable[TaskUIData] = {
+        val t = new UITableBuilder[TaskUIData]()
+        t.col("Index") { _.taskInfo.index }
+        t.col("Id") { _.taskInfo.taskId }
+        t.col("Attempt") { _.taskInfo } formatWith { info =>
+          if (info.speculative) s"${info.attempt} (speculative)" else info.attempt.toString
+        } sortBy { info =>
+          info.taskId.toString
+        }
+        t.col("Status") { _.taskInfo.status }
+        t.col("Locality level") { _.taskInfo.taskLocality }
+        t.col("Executor ID / Host") { case TaskUIData(info, _, _) =>
+          s"${info.executorId} / ${info.host}"
+        }
+        t.dateCol("Launch Time") { case TaskUIData(info, _, _) =>
+          new Date(info.launchTime)
+        }
+        t.col("Duration") { case TaskUIData(info, metrics, _) =>
+          val duration =
+            if (info.status == "RUNNING") info.timeRunning(System.currentTimeMillis())
+            else metrics.map(_.executorRunTime).getOrElse(1L)
+          (info, metrics, duration)
+        } formatWith { case (info, metrics, duration) =>
+          if (info.status == "RUNNING") UIUtils.formatDuration(duration)
+          else metrics.map(m => UIUtils.formatDuration(m.executorRunTime)).getOrElse("")
+        } sortBy { case (info, metrics, duration) =>
+          duration.toString
+        }
+
+        t.durationCol("GC Time") { _.taskMetrics.map(_.jvmGCTime).getOrElse(0L)}
+        t.durationCol("Serialization Time") {
+          _.taskMetrics.map(_.resultSerializationTime).getOrElse(0L)
+        }
+        t.col("Accumulators")(identity) withMarkup { case TaskUIData(info, _, _) =>
+          Unparsed(
+            info.accumulables.map{acc => s"${acc.name}: ${acc.update.get}"}.mkString("<br/>")
+          )
+        }
+        if (hasInput) {
+          t.col("Input") {
+            _.taskMetrics.flatMap(_.inputMetrics)
+          } sortBy {
+            _.map(_.bytesRead.toString).getOrElse("")
+          } formatWith { _.map(
+            m => s"${Utils.bytesToString(m.bytesRead)} (${m.readMethod.toString.toLowerCase})")
+              .getOrElse("")
+          }
+        }
+        if (hasShuffleRead) {
+          t.col("Shuffle Read") {
+            _.taskMetrics.flatMap(_.shuffleReadMetrics).map(_.remoteBytesRead)
+          } sortBy {
+            _.map(_.toString).getOrElse("")
+          } formatWith {
+            _.map(Utils.bytesToString).getOrElse("")
+          }
+        }
+        if (hasShuffleWrite) {
+          t.col("Write Time") {
+            _.taskMetrics.flatMap(_.shuffleWriteMetrics).map(_.shuffleWriteTime)
+          } sortBy {
+            _.map(_.toString).getOrElse("")
+          } formatWith {
+            _.map(t => t / (1000 * 1000)).map { ms =>
+              if (ms == 0) "" else UIUtils.formatDuration(ms)
+            }.getOrElse("")
+          }
+
+          t.col("Shuffle Write") {
+            _.taskMetrics.flatMap(_.shuffleWriteMetrics).map(_.shuffleBytesWritten)
+          } sortBy {
+            _.map(_.toString).getOrElse("")
+          } formatWith {
+            _.map(Utils.bytesToString).getOrElse("")
+          }
+        }
+        if (hasBytesSpilled) {
+          t.col("Shuffle Spill (Memory)") { _.taskMetrics.map(_.memoryBytesSpilled) } sortBy {
+            _.map(_.toString).getOrElse("")
+          } formatWith {
+            _.map(Utils.bytesToString).getOrElse("")
+          }
+
+          t.col("Shuffle Spill (Disk)") { _.taskMetrics.map(_.diskBytesSpilled) } sortBy {
+            _.map(_.toString).getOrElse("")
+          } formatWith {
+            _.map(Utils.bytesToString).getOrElse("")
+          }
+        }
+        t.col("Errors")(identity) withMarkup { case TaskUIData(_, _, errorMessage) =>
+          errorMessage.map { e => <pre>{e}</pre> }.getOrElse(Text(""))
+        }
+        t.build()
+      }
 
       // scalastyle:off
       val summary =
@@ -101,18 +195,7 @@ private[ui] class StagePage(parent: JobProgressTab) extends WebUIPage("stage") {
       val accumulableTable =
         this.accumulableTable.render(accumulables.values.map(a => (a.name, a.value)))
 
-      val taskHeaders: Seq[String] =
-        Seq(
-          "Index", "ID", "Attempt", "Status", "Locality Level", "Executor ID / Host",
-          "Launch Time", "Duration", "GC Time", "Accumulators") ++
-        {if (hasInput) Seq("Input") else Nil} ++
-        {if (hasShuffleRead) Seq("Shuffle Read")  else Nil} ++
-        {if (hasShuffleWrite) Seq("Write Time", "Shuffle Write") else Nil} ++
-        {if (hasBytesSpilled) Seq("Shuffle Spill (Memory)", "Shuffle Spill (Disk)") else Nil} ++
-        Seq("Errors")
-
-      val taskTable = UIUtils.listingTable(
-        taskHeaders, taskRow(hasInput, hasShuffleRead, hasShuffleWrite, hasBytesSpilled), tasks)
+      val taskTable = taskTableRenderer.render(tasks)
 
       // Excludes tasks which failed and have incomplete metrics
       val validTasks = tasks.filter(t => t.taskInfo.status == "SUCCESS" && t.taskMetrics.isDefined)
@@ -228,109 +311,6 @@ private[ui] class StagePage(parent: JobProgressTab) extends WebUIPage("stage") {
         <h4>Tasks</h4> ++ taskTable
 
       UIUtils.headerSparkPage("Details for Stage %d".format(stageId), content, parent)
-    }
-  }
-
-  def taskRow(
-      hasInput: Boolean,
-      hasShuffleRead: Boolean,
-      hasShuffleWrite: Boolean,
-      hasBytesSpilled: Boolean)(taskData: TaskUIData): Seq[Node] = {
-    taskData match { case TaskUIData(info, metrics, errorMessage) =>
-      val duration = if (info.status == "RUNNING") info.timeRunning(System.currentTimeMillis())
-        else metrics.map(_.executorRunTime).getOrElse(1L)
-      val formatDuration = if (info.status == "RUNNING") UIUtils.formatDuration(duration)
-        else metrics.map(m => UIUtils.formatDuration(m.executorRunTime)).getOrElse("")
-      val gcTime = metrics.map(_.jvmGCTime).getOrElse(0L)
-      val serializationTime = metrics.map(_.resultSerializationTime).getOrElse(0L)
-
-      val maybeInput = metrics.flatMap(_.inputMetrics)
-      val inputSortable = maybeInput.map(_.bytesRead.toString).getOrElse("")
-      val inputReadable = maybeInput
-        .map(m => s"${Utils.bytesToString(m.bytesRead)} (${m.readMethod.toString.toLowerCase()})")
-        .getOrElse("")
-
-      val maybeShuffleRead = metrics.flatMap(_.shuffleReadMetrics).map(_.remoteBytesRead)
-      val shuffleReadSortable = maybeShuffleRead.map(_.toString).getOrElse("")
-      val shuffleReadReadable = maybeShuffleRead.map(Utils.bytesToString).getOrElse("")
-
-      val maybeShuffleWrite =
-        metrics.flatMap(_.shuffleWriteMetrics).map(_.shuffleBytesWritten)
-      val shuffleWriteSortable = maybeShuffleWrite.map(_.toString).getOrElse("")
-      val shuffleWriteReadable = maybeShuffleWrite.map(Utils.bytesToString).getOrElse("")
-
-      val maybeWriteTime = metrics.flatMap(_.shuffleWriteMetrics).map(_.shuffleWriteTime)
-      val writeTimeSortable = maybeWriteTime.map(_.toString).getOrElse("")
-      val writeTimeReadable = maybeWriteTime.map(t => t / (1000 * 1000)).map { ms =>
-        if (ms == 0) "" else UIUtils.formatDuration(ms)
-      }.getOrElse("")
-
-      val maybeMemoryBytesSpilled = metrics.map(_.memoryBytesSpilled)
-      val memoryBytesSpilledSortable = maybeMemoryBytesSpilled.map(_.toString).getOrElse("")
-      val memoryBytesSpilledReadable =
-        maybeMemoryBytesSpilled.map(Utils.bytesToString).getOrElse("")
-
-      val maybeDiskBytesSpilled = metrics.map(_.diskBytesSpilled)
-      val diskBytesSpilledSortable = maybeDiskBytesSpilled.map(_.toString).getOrElse("")
-      val diskBytesSpilledReadable = maybeDiskBytesSpilled.map(Utils.bytesToString).getOrElse("")
-
-      <tr>
-        <td>{info.index}</td>
-        <td>{info.taskId}</td>
-        <td sorttable_customkey={info.attempt.toString}>{
-          if (info.speculative) s"${info.attempt} (speculative)" else info.attempt.toString
-        }</td>
-        <td>{info.status}</td>
-        <td>{info.taskLocality}</td>
-        <td>{info.executorId} / {info.host}</td>
-        <td>{UIUtils.formatDate(new Date(info.launchTime))}</td>
-        <td sorttable_customkey={duration.toString}>
-          {formatDuration}
-        </td>
-        <td sorttable_customkey={gcTime.toString}>
-          {if (gcTime > 0) UIUtils.formatDuration(gcTime) else ""}
-        </td>
-        <td>
-          {Unparsed(
-            info.accumulables.map{acc => s"${acc.name}: ${acc.update.get}"}.mkString("<br/>")
-          )}
-        </td>
-        <!--
-        TODO: Add this back after we add support to hide certain columns.
-        <td sorttable_customkey={serializationTime.toString}>
-          {if (serializationTime > 0) UIUtils.formatDuration(serializationTime) else ""}
-        </td>
-        -->
-        {if (hasInput) {
-          <td sorttable_customkey={inputSortable}>
-            {inputReadable}
-          </td>
-        }}
-        {if (hasShuffleRead) {
-           <td sorttable_customkey={shuffleReadSortable}>
-             {shuffleReadReadable}
-           </td>
-        }}
-        {if (hasShuffleWrite) {
-           <td sorttable_customkey={writeTimeSortable}>
-             {writeTimeReadable}
-           </td>
-           <td sorttable_customkey={shuffleWriteSortable}>
-             {shuffleWriteReadable}
-           </td>
-        }}
-        {if (hasBytesSpilled) {
-          <td sorttable_customkey={memoryBytesSpilledSortable}>
-            {memoryBytesSpilledReadable}
-          </td>
-          <td sorttable_customkey={diskBytesSpilledSortable}>
-            {diskBytesSpilledReadable}
-          </td>
-        }}
-        <td>
-          {errorMessage.map { e => <pre>{e}</pre> }.getOrElse("")}
-        </td>
-      </tr>
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/ui/storage/RDDPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/storage/RDDPage.scala
@@ -19,15 +19,46 @@ package org.apache.spark.ui.storage
 
 import javax.servlet.http.HttpServletRequest
 
-import scala.xml.Node
+import scala.xml.{Text, Node}
 
 import org.apache.spark.storage.{BlockId, BlockStatus, StorageStatus, StorageUtils}
-import org.apache.spark.ui.{WebUIPage, UIUtils}
+import org.apache.spark.ui.{UITableBuilder, UITable, WebUIPage, UIUtils}
 import org.apache.spark.util.Utils
 
 /** Page showing storage details for a given RDD */
 private[ui] class RDDPage(parent: StorageTab) extends WebUIPage("rdd") {
   private val listener = parent.listener
+
+  private val workerTable: UITable[(Int, StorageStatus)] = {
+    val builder = new UITableBuilder[(Int, StorageStatus)]()
+    import builder._
+    col("Host") { case (_, status) =>
+      s"${status.blockManagerId.host}:${status.blockManagerId.port}"
+    }
+    def getMemUsed(x: (Int, StorageStatus)): String = x._2.memUsedByRdd(x._1).toString
+    customCol(
+      "Memory usage",
+      sortKey = Some(getMemUsed)) { case (rddId, status) =>
+        val used = Utils.bytesToString(status.memUsedByRdd(rddId))
+        val remaining = Utils.bytesToString(status.memRemaining)
+        Text(s"$used ($remaining Remaining)")
+      }
+    memCol("Disk Usage") { case (rddId, status) => status.diskUsedByRdd(rddId) }
+    build
+  }
+
+  val blockTable: UITable[(BlockId, BlockStatus, Seq[String])] = {
+    val builder = new UITableBuilder[(BlockId, BlockStatus, Seq[String])]()
+    import builder._
+    col("Block Name") { case (id, block, locations) => id.toString }
+    col("Storage Level") { case (id, block, locations) => block.storageLevel.description }
+    memCol("Size in Memory") { case (id, block, locations) => block.memSize }
+    memCol("Size on Disk") { case (id, block, locations) => block.diskSize }
+    customCol("Executors") { case (id, block, locations) =>
+      locations.map(l => <span>{l}<br/></span>)
+    }
+    build
+  }
 
   def render(request: HttpServletRequest): Seq[Node] = {
     val rddId = request.getParameter("id").toInt
@@ -39,7 +70,7 @@ private[ui] class RDDPage(parent: StorageTab) extends WebUIPage("rdd") {
 
     // Worker table
     val workers = storageStatusList.map((rddId, _))
-    val workerTable = UIUtils.listingTable(workerHeader, workerRow, workers)
+    val workerTable = this.workerTable.render(workers)
 
     // Block table
     val blockLocations = StorageUtils.getRddBlockLocations(rddId, storageStatusList)
@@ -49,7 +80,7 @@ private[ui] class RDDPage(parent: StorageTab) extends WebUIPage("rdd") {
       .map { case (blockId, status) =>
         (blockId, status, blockLocations.get(blockId).getOrElse(Seq[String]("Unknown")))
       }
-    val blockTable = UIUtils.listingTable(blockHeader, blockRow, blocks)
+    val blockTable = this.blockTable.render(blocks)
 
     val content =
       <div class="row-fluid">
@@ -94,52 +125,5 @@ private[ui] class RDDPage(parent: StorageTab) extends WebUIPage("rdd") {
       </div>;
 
     UIUtils.headerSparkPage("RDD Storage Info for " + rddInfo.name, content, parent)
-  }
-
-  /** Header fields for the worker table */
-  private def workerHeader = Seq(
-    "Host",
-    "Memory Usage",
-    "Disk Usage")
-
-  /** Header fields for the block table */
-  private def blockHeader = Seq(
-    "Block Name",
-    "Storage Level",
-    "Size in Memory",
-    "Size on Disk",
-    "Executors")
-
-  /** Render an HTML row representing a worker */
-  private def workerRow(worker: (Int, StorageStatus)): Seq[Node] = {
-    val (rddId, status) = worker
-    <tr>
-      <td>{status.blockManagerId.host + ":" + status.blockManagerId.port}</td>
-      <td>
-        {Utils.bytesToString(status.memUsedByRdd(rddId))}
-        ({Utils.bytesToString(status.memRemaining)} Remaining)
-      </td>
-      <td>{Utils.bytesToString(status.diskUsedByRdd(rddId))}</td>
-    </tr>
-  }
-
-  /** Render an HTML row representing a block */
-  private def blockRow(row: (BlockId, BlockStatus, Seq[String])): Seq[Node] = {
-    val (id, block, locations) = row
-    <tr>
-      <td>{id}</td>
-      <td>
-        {block.storageLevel.description}
-      </td>
-      <td sorttable_customkey={block.memSize.toString}>
-        {Utils.bytesToString(block.memSize)}
-      </td>
-      <td sorttable_customkey={block.diskSize.toString}>
-        {Utils.bytesToString(block.diskSize)}
-      </td>
-      <td>
-        {locations.map(l => <span>{l}<br/></span>)}
-      </td>
-    </tr>
   }
 }

--- a/core/src/main/scala/org/apache/spark/ui/storage/RDDPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/storage/RDDPage.scala
@@ -30,34 +30,32 @@ private[ui] class RDDPage(parent: StorageTab) extends WebUIPage("rdd") {
   private val listener = parent.listener
 
   private val workerTable: UITable[(Int, StorageStatus)] = {
-    val builder = new UITableBuilder[(Int, StorageStatus)]()
-    import builder._
-    col("Host") { case (_, status) =>
+    val t = new UITableBuilder[(Int, StorageStatus)]()
+    t.col("Host") { case (_, status) =>
       s"${status.blockManagerId.host}:${status.blockManagerId.port}"
     }
     def getMemUsed(x: (Int, StorageStatus)): String = x._2.memUsedByRdd(x._1).toString
-    customCol(
+    t.customCol(
       "Memory usage",
       sortKey = Some(getMemUsed)) { case (rddId, status) =>
         val used = Utils.bytesToString(status.memUsedByRdd(rddId))
         val remaining = Utils.bytesToString(status.memRemaining)
         Text(s"$used ($remaining Remaining)")
       }
-    memCol("Disk Usage") { case (rddId, status) => status.diskUsedByRdd(rddId) }
-    build
+    t.memCol("Disk Usage") { case (rddId, status) => status.diskUsedByRdd(rddId) }
+    t.build()
   }
 
   val blockTable: UITable[(BlockId, BlockStatus, Seq[String])] = {
-    val builder = new UITableBuilder[(BlockId, BlockStatus, Seq[String])]()
-    import builder._
-    col("Block Name") { case (id, block, locations) => id.toString }
-    col("Storage Level") { case (id, block, locations) => block.storageLevel.description }
-    memCol("Size in Memory") { case (id, block, locations) => block.memSize }
-    memCol("Size on Disk") { case (id, block, locations) => block.diskSize }
-    customCol("Executors") { case (id, block, locations) =>
+    val t = new UITableBuilder[(BlockId, BlockStatus, Seq[String])]()
+    t.col("Block Name") { case (id, block, locations) => id.toString }
+    t.col("Storage Level") { case (id, block, locations) => block.storageLevel.description }
+    t. memCol("Size in Memory") { case (id, block, locations) => block.memSize }
+    t.memCol("Size on Disk") { case (id, block, locations) => block.diskSize }
+    t.customCol("Executors") { case (id, block, locations) =>
       locations.map(l => <span>{l}<br/></span>)
     }
-    build
+    t.build()
   }
 
   def render(request: HttpServletRequest): Seq[Node] = {

--- a/core/src/main/scala/org/apache/spark/ui/storage/RDDPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/storage/RDDPage.scala
@@ -42,16 +42,16 @@ private[ui] class RDDPage(parent: StorageTab) extends WebUIPage("rdd") {
         val remaining = Utils.bytesToString(status.memRemaining)
         Text(s"$used ($remaining Remaining)")
       }
-    t.memCol("Disk Usage") { case (rddId, status) => status.diskUsedByRdd(rddId) }
+    t.sizeCol("Disk Usage") { case (rddId, status) => status.diskUsedByRdd(rddId) }
     t.build()
   }
 
-  val blockTable: UITable[(BlockId, BlockStatus, Seq[String])] = {
+  private val blockTable: UITable[(BlockId, BlockStatus, Seq[String])] = {
     val t = new UITableBuilder[(BlockId, BlockStatus, Seq[String])]()
     t.col("Block Name") { case (id, block, locations) => id.toString }
     t.col("Storage Level") { case (id, block, locations) => block.storageLevel.description }
-    t. memCol("Size in Memory") { case (id, block, locations) => block.memSize }
-    t.memCol("Size on Disk") { case (id, block, locations) => block.diskSize }
+    t. sizeCol("Size in Memory") { case (id, block, locations) => block.memSize }
+    t.sizeCol("Size on Disk") { case (id, block, locations) => block.diskSize }
     t.customCol("Executors") { case (id, block, locations) =>
       locations.map(l => <span>{l}<br/></span>)
     }

--- a/core/src/main/scala/org/apache/spark/ui/storage/RDDPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/storage/RDDPage.scala
@@ -35,13 +35,13 @@ private[ui] class RDDPage(parent: StorageTab) extends WebUIPage("rdd") {
       s"${status.blockManagerId.host}:${status.blockManagerId.port}"
     }
     def getMemUsed(x: (Int, StorageStatus)): String = x._2.memUsedByRdd(x._1).toString
-    t.customCol(
-      "Memory usage",
-      sortKey = Some(getMemUsed)) { case (rddId, status) =>
-        val used = Utils.bytesToString(status.memUsedByRdd(rddId))
-        val remaining = Utils.bytesToString(status.memRemaining)
-        Text(s"$used ($remaining Remaining)")
-      }
+    t.col("Memory Usage") (identity) sortBy {
+      getMemUsed
+    } withMarkup { case (rddId, status) =>
+      val used = Utils.bytesToString(status.memUsedByRdd(rddId))
+      val remaining = Utils.bytesToString(status.memRemaining)
+      Text(s"$used ($remaining Remaining)")
+    }
     t.sizeCol("Disk Usage") { case (rddId, status) => status.diskUsedByRdd(rddId) }
     t.build()
   }
@@ -52,7 +52,7 @@ private[ui] class RDDPage(parent: StorageTab) extends WebUIPage("rdd") {
     t.col("Storage Level") { case (id, block, locations) => block.storageLevel.description }
     t. sizeCol("Size in Memory") { case (id, block, locations) => block.memSize }
     t.sizeCol("Size on Disk") { case (id, block, locations) => block.diskSize }
-    t.customCol("Executors") { case (id, block, locations) =>
+    t.col("Executors") (identity) withMarkup { case (id, block, locations) =>
       locations.map(l => <span>{l}<br/></span>)
     }
     t.build()

--- a/core/src/main/scala/org/apache/spark/ui/storage/StoragePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/storage/StoragePage.scala
@@ -40,9 +40,9 @@ private[ui] class StoragePage(parent: StorageTab) extends WebUIPage("") {
     t. col("Fraction Cached") { rdd =>
       "%.0f%%".format(rdd.numCachedPartitions * 100.0 / rdd.numPartitions)
     }
-    t.memCol("Size in Memory") { _.memSize }
-    t.memCol("Size in Tachyon") { _.tachyonSize }
-    t.memCol("Size on Disk") { _.diskSize }
+    t.sizeCol("Size in Memory") { _.memSize }
+    t.sizeCol("Size in Tachyon") { _.tachyonSize }
+    t.sizeCol("Size on Disk") { _.diskSize }
     t.build()
   }
 

--- a/core/src/main/scala/org/apache/spark/ui/storage/StoragePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/storage/StoragePage.scala
@@ -29,22 +29,21 @@ private[ui] class StoragePage(parent: StorageTab) extends WebUIPage("") {
   private val listener = parent.listener
 
   val rddTable: UITable[RDDInfo] = {
-    val builder = new UITableBuilder[RDDInfo]()
-    import builder._
-    customCol("RDD Name") { rdd =>
+    val t = new UITableBuilder[RDDInfo]()
+    t.customCol("RDD Name") { rdd =>
       <a href={"%s/storage/rdd?id=%s".format(UIUtils.prependBaseUri(parent.basePath), rdd.id)}>
         {rdd.name}
       </a>
     }
-    col("Storage Level") { _.storageLevel.description }
-    intCol("Cached Partitions") { _.numCachedPartitions }
-    col("Fraction Cached") { rdd =>
+    t.col("Storage Level") { _.storageLevel.description }
+    t.intCol("Cached Partitions") { _.numCachedPartitions }
+    t. col("Fraction Cached") { rdd =>
       "%.0f%%".format(rdd.numCachedPartitions * 100.0 / rdd.numPartitions)
     }
-    memCol("Size in Memory") { _.memSize }
-    memCol("Size in Tachyon") { _.tachyonSize }
-    memCol("Size on Disk") { _.diskSize }
-    build
+    t.memCol("Size in Memory") { _.memSize }
+    t.memCol("Size in Tachyon") { _.tachyonSize }
+    t.memCol("Size on Disk") { _.diskSize }
+    t.build()
   }
 
   def render(request: HttpServletRequest): Seq[Node] = {

--- a/core/src/main/scala/org/apache/spark/ui/storage/StoragePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/storage/StoragePage.scala
@@ -30,14 +30,14 @@ private[ui] class StoragePage(parent: StorageTab) extends WebUIPage("") {
 
   val rddTable: UITable[RDDInfo] = {
     val t = new UITableBuilder[RDDInfo]()
-    t.customCol("RDD Name") { rdd =>
+    t.col("RDD Name") (identity) withMarkup { rdd =>
       <a href={"%s/storage/rdd?id=%s".format(UIUtils.prependBaseUri(parent.basePath), rdd.id)}>
         {rdd.name}
       </a>
     }
     t.col("Storage Level") { _.storageLevel.description }
-    t.intCol("Cached Partitions") { _.numCachedPartitions }
-    t. col("Fraction Cached") { rdd =>
+    t.col("Cached Partitions") { _.numCachedPartitions }
+    t.col("Fraction Cached") { rdd =>
       "%.0f%%".format(rdd.numCachedPartitions * 100.0 / rdd.numPartitions)
     }
     t.sizeCol("Size in Memory") { _.memSize }

--- a/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingPage.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingPage.scala
@@ -100,23 +100,23 @@ private[ui] class StreamingPage(parent: StreamingTab)
         t.col("Records in last batch\n[" + formatDate(Calendar.getInstance().getTime()) + "]") {
           case (receiverId, _) => formatNumber(lastBatchReceivedRecord(receiverId))
         }
-        t.col("Minimum rate\n[records/sec]") {
-          case (receiverId, _) => receivedRecordDistributions(receiverId).map {
+        t.col("Minimum rate\n[records/sec]") { case (receiverId, _) =>
+          receivedRecordDistributions(receiverId).map {
             _.getQuantiles(Seq(0.0)).map(formatNumber).head
           }.getOrElse(empty)
         }
-        t.col("Median rate\n[records/sec]") {
-          case (receiverId, _) => receivedRecordDistributions(receiverId).map {
+        t.col("Median rate\n[records/sec]") { case (receiverId, _) =>
+          receivedRecordDistributions(receiverId).map {
             _.getQuantiles(Seq(0.5)).map(formatNumber).head
           }.getOrElse(empty)
         }
-        t.col("Maximum rate\n[records/sec]") {
-          case (receiverId, _) => receivedRecordDistributions(receiverId).map {
+        t.col("Maximum rate\n[records/sec]") { case (receiverId, _) =>
+          receivedRecordDistributions(receiverId).map {
             _.getQuantiles(Seq(1.0)).map(formatNumber).head
           }.getOrElse(empty)
         }
-        t.col("Last Error") {
-          case (_, receiverInfo) => receiverInfo.map { info =>
+        t.col("Last Error") { case (_, receiverInfo) =>
+          receiverInfo.map { info =>
             val msg = s"${info.lastErrorMessage} - ${info.lastError}"
             if (msg.size > 100) msg.take(97) + "..." else msg
           }.getOrElse(empty)

--- a/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingPage.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingPage.scala
@@ -47,16 +47,15 @@ private[ui] class StreamingPage(parent: StreamingTab)
   }
 
   private val batchStatsTable: UITable[(String, Option[Long], Option[Seq[Double]])] = {
-    val builder = new UITableBuilder[(String, Option[Long], Option[Seq[Double]])]()
-    import builder._
-    col("Metric") { _._1 }
-    optDurationCol("Last batch") { _._2 }
-    optDurationCol("Minimum") { _._3.map(_(0).toLong) }
-    optDurationCol("25th percentile") { _._3.map(_(1).toLong) }
-    optDurationCol("Median") { _._3.map(_(2).toLong) }
-    optDurationCol("75th percentile") { _._3.map(_(3).toLong) }
-    optDurationCol("Maximum") { _._3.map(_(4).toLong) }
-    build
+    val t = new UITableBuilder[(String, Option[Long], Option[Seq[Double]])]()
+    t.col("Metric") { _._1 }
+    t.optDurationCol("Last batch") { _._2 }
+    t.optDurationCol("Minimum") { _._3.map(_(0).toLong) }
+    t.optDurationCol("25th percentile") { _._3.map(_(1).toLong) }
+    t.optDurationCol("Median") { _._3.map(_(2).toLong) }
+    t.optDurationCol("75th percentile") { _._3.map(_(3).toLong) }
+    t.optDurationCol("Maximum") { _._3.map(_(4).toLong) }
+    t.build()
   }
 
   /** Generate basic stats of the streaming program */
@@ -90,40 +89,39 @@ private[ui] class StreamingPage(parent: StreamingTab)
     val lastBatchReceivedRecord = listener.lastReceivedBatchRecords
     val table = if (receivedRecordDistributions.size > 0) {
       val tableRenderer: UITable[(Int, Option[ReceiverInfo])] = {
-        val builder = new UITableBuilder[(Int, Option[ReceiverInfo])]()
-        import builder._
-        col("Receiver") { case (receiverId, receiverInfo) =>
+        val t = new UITableBuilder[(Int, Option[ReceiverInfo])]()
+        t.col("Receiver") { case (receiverId, receiverInfo) =>
           receiverInfo.map(_.name).getOrElse(s"Receiver-$receiverId")
         }
-        col("Status") { case (_, receiverInfo) =>
+        t.col("Status") { case (_, receiverInfo) =>
           receiverInfo.map { info => if (info.active) "ACTIVE" else "INACTIVE" }.getOrElse(empty)
         }
-        col("Location") { case (_, receiverInfo) => receiverInfo.map(_.location).getOrElse(empty) }
-        col("Records in last batch\n[" + formatDate(Calendar.getInstance().getTime()) + "]") {
+        t.col("Location") { case (_, receiverInfo) => receiverInfo.map(_.location).getOrElse(empty) }
+        t.col("Records in last batch\n[" + formatDate(Calendar.getInstance().getTime()) + "]") {
           case (receiverId, _) => formatNumber(lastBatchReceivedRecord(receiverId))
         }
-        col("Minimum rate\n[records/sec]") {
+        t.col("Minimum rate\n[records/sec]") {
           case (receiverId, _) => receivedRecordDistributions(receiverId).map {
             _.getQuantiles(Seq(0.0)).map(formatNumber).head
           }.getOrElse(empty)
         }
-        col("Median rate\n[records/sec]") {
+        t.col("Median rate\n[records/sec]") {
           case (receiverId, _) => receivedRecordDistributions(receiverId).map {
             _.getQuantiles(Seq(0.5)).map(formatNumber).head
           }.getOrElse(empty)
         }
-        col("Maximum rate\n[records/sec]") {
+        t.col("Maximum rate\n[records/sec]") {
           case (receiverId, _) => receivedRecordDistributions(receiverId).map {
             _.getQuantiles(Seq(1.0)).map(formatNumber).head
           }.getOrElse(empty)
         }
-        col("Last Error") {
+        t.col("Last Error") {
           case (_, receiverInfo) => receiverInfo.map { info =>
             val msg = s"${info.lastErrorMessage} - ${info.lastError}"
             if (msg.size > 100) msg.take(97) + "..." else msg
           }.getOrElse(empty)
         }
-        build
+        t.build()
       }
 
       val dataRows = (0 until listener.numReceivers).map { id => (id, listener.receiverInfo(id)) }

--- a/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingPage.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingPage.scala
@@ -46,15 +46,23 @@ private[ui] class StreamingPage(parent: StreamingTab)
     UIUtils.headerSparkPage("Streaming", content, parent, Some(5000))
   }
 
-  private val batchStatsTable: UITable[(String, Option[Long], Option[Seq[Double]])] = {
-    val t = new UITableBuilder[(String, Option[Long], Option[Seq[Double]])]()
+  private type BatchStatsRowType = (String, Option[Long], Option[Seq[Double]])
+  private val batchStatsTable: UITable[BatchStatsRowType] = {
+    val t = new UITableBuilder[BatchStatsRowType]()
     t.col("Metric") { _._1 }
-    t.optDurationCol("Last batch") { _._2 }
-    t.optDurationCol("Minimum") { _._3.map(_(0).toLong) }
-    t.optDurationCol("25th percentile") { _._3.map(_(1).toLong) }
-    t.optDurationCol("Median") { _._3.map(_(2).toLong) }
-    t.optDurationCol("75th percentile") { _._3.map(_(3).toLong) }
-    t.optDurationCol("Maximum") { _._3.map(_(4).toLong) }
+    t.col("Last batch") { _._2 }
+    def optDurationCol(name: String)(fieldExtractor: BatchStatsRowType => Option[Long]) {
+      t.col(name)(fieldExtractor) sortBy {
+        _.getOrElse("").toString
+      } formatWith {
+        _.map(UIUtils.formatDuration).getOrElse("-")
+      }
+    }
+    t.col("Minimum") { _._3.map(_(0).toLong) }
+    optDurationCol("25th percentile") { _._3.map(_(1).toLong) }
+    optDurationCol("Median") { _._3.map(_(2).toLong) }
+    optDurationCol("75th percentile") { _._3.map(_(3).toLong) }
+    optDurationCol("Maximum") { _._3.map(_(4).toLong) }
     t.build()
   }
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingPage.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingPage.scala
@@ -96,7 +96,9 @@ private[ui] class StreamingPage(parent: StreamingTab)
         t.col("Status") { case (_, receiverInfo) =>
           receiverInfo.map { info => if (info.active) "ACTIVE" else "INACTIVE" }.getOrElse(empty)
         }
-        t.col("Location") { case (_, receiverInfo) => receiverInfo.map(_.location).getOrElse(empty) }
+        t.col("Location") { case (_, receiverInfo) =>
+          receiverInfo.map(_.location).getOrElse(empty)
+        }
         t.col("Records in last batch\n[" + formatDate(Calendar.getInstance().getTime()) + "]") {
           case (receiverId, _) => formatNumber(lastBatchReceivedRecord(receiverId))
         }


### PR DESCRIPTION
This work-in-progress commit illustrates a weekend hack project that I came up with for significantly simplifying the web UI's table rendering code.  See the huge block comment in `WebUITableBuilder` for more details.  This isn't ready to merge yet; I wanted to get some feedback before converting the rest of the table construction code to use this (I know that I should open a JIRA for this, too; I'll do it tomorrow).

Essentially, this commit adds a small builder class for constructing objects that know how to render web UI tables.  This builder helps us to avoid several sources of errors / maintenance headaches, such as duplicate/boilerplate markup, inconsistent formatting of columns in different tables (e.g. durations or memory being displayed differently), separation of column names from column data values, etc.  This is best illustrated by some sample code; this new framework lets you write

``` scala
  private val appTable: UITable[ApplicationInfo] = {
    val t = new UITableBuilder[ApplicationInfo]()
    t.col("ID") (identity) withMarkup { app =>
      <a href={"app?appId=" + app.id}>{app.id}</a>
    }
    t.col("Name") { _.id }
    t.col("Cores") { _.coresGranted }
    t.sizeCol("Memory per Node") { _.desc.memoryPerSlave }
    t.dateCol("Submitted Time") { _.submitDate }
    t.col("User") { _.desc.user }
    t.col("State") { _.state.toString }
    t.durationCol("Duration") { _.duration }
    t.build()
  }
```

to render the "applications" table in the standalone Master UI.  I find this significantly easier to understand and maintain than the old code.  For example, this makes it trivial to re-order columns.
#### TODO:
- [ ] Update Stages page to use this
- [ ] Tests of disabling sorting; audit current tables to figure out which columns should not be sortable.
- [ ] Tooltip support.
