### PR TITLE
[SPARK-4005][CORE] handle message replies in receive instead of in the individual private methods

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterActor.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterActor.scala
@@ -74,7 +74,7 @@ class BlockManagerMasterActor(val isLocal: Boolean, conf: SparkConf, listenerBus
     case UpdateBlockInfo(
       blockManagerId, blockId, storageLevel, deserializedSize, size, tachyonSize) =>
       sender ! updateBlockInfo(
-          blockManagerId, blockId, storageLevel, deserializedSize, size, tachyonSize)
+        blockManagerId, blockId, storageLevel, deserializedSize, size, tachyonSize)
 
     case GetLocations(blockId) =>
       sender ! getLocations(blockId)

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterActor.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterActor.scala
@@ -352,21 +352,20 @@ class BlockManagerMasterActor(val isLocal: Boolean, conf: SparkConf, listenerBus
       diskSize: Long,
       tachyonSize: Long): Boolean = {
 
-    var updated = true
     if (!blockManagerInfo.contains(blockManagerId)) {
       if (blockManagerId.isDriver && !isLocal) {
         // We intentionally do not register the master (except in local mode),
         // so we should not indicate failure.
-        // do nothing here, "updated == true".
+        return true
       } else {
-        updated = false
+        return false
       }
-      return updated
+      return true
     }
 
     if (blockId == null) {
       blockManagerInfo(blockManagerId).updateLastSeenMs()
-      return updated
+      return true
     }
 
     blockManagerInfo(blockManagerId).updateBlockInfo(
@@ -390,7 +389,7 @@ class BlockManagerMasterActor(val isLocal: Boolean, conf: SparkConf, listenerBus
     if (locations.size == 0) {
       blockLocations.remove(blockId)
     }
-    updated
+    true
   }
 
   private def getLocations(blockId: BlockId): Seq[BlockManagerId] = {

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterActor.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterActor.scala
@@ -360,7 +360,6 @@ class BlockManagerMasterActor(val isLocal: Boolean, conf: SparkConf, listenerBus
       } else {
         return false
       }
-      return true
     }
 
     if (blockId == null) {


### PR DESCRIPTION
In BlockManagermasterActor, when handling message type UpdateBlockInfo, the message replies is in handled in individual private methods, should handle it in receive of Akka.
