### PR TITLE
[SQL] Correct a variable name in JavaApplySchemaSuite.applySchemaToJSON

### DIFF
--- a/sql/core/src/test/java/org/apache/spark/sql/api/java/JavaApplySchemaSuite.java
+++ b/sql/core/src/test/java/org/apache/spark/sql/api/java/JavaApplySchemaSuite.java
@@ -156,7 +156,7 @@ public class JavaApplySchemaSuite implements Serializable {
     JavaSchemaRDD schemaRDD2 = javaSqlCtx.jsonRDD(jsonRDD, expectedSchema);
     StructType actualSchema2 = schemaRDD2.schema();
     Assert.assertEquals(expectedSchema, actualSchema2);
-    schemaRDD1.registerTempTable("jsonTable2");
+    schemaRDD2.registerTempTable("jsonTable2");
     List<Row> actual2 = javaSqlCtx.sql("select * from jsonTable2").collect();
     Assert.assertEquals(expectedResult, actual2);
   }


### PR DESCRIPTION
`schemaRDD2` is not tested because `schemaRDD1` is registered again.
