### PR TITLE
[SQL][DOC] Wrong package name "scala.math.sql" in sql-programming-guide.md

### DIFF
--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -1215,7 +1215,7 @@ import  org.apache.spark.sql._
 </tr>
 <tr>
   <td> <b>DecimalType</b> </td>
-  <td> scala.math.sql.BigDecimal </td>
+  <td> scala.math.BigDecimal </td>
   <td>
   DecimalType
   </td>


### PR DESCRIPTION
In sql-programming-guide.md, there is a wrong package name "scala.math.sql".
