### PR TITLE
[SPARK-4035] Fix a wrong format specifier

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -870,7 +870,7 @@ private[spark] class BlockManager(
             logTrace(s"Trying to replicate $blockId of ${data.limit()} bytes to $peer")
             blockTransferService.uploadBlockSync(
               peer.host, peer.port, blockId.toString, new NioByteBufferManagedBuffer(data), tLevel)
-            logTrace(s"Replicated $blockId of ${data.limit()} bytes to $peer in %f ms"
+            logTrace(s"Replicated $blockId of ${data.limit()} bytes to $peer in %d ms"
               .format((System.currentTimeMillis - onePeerStartTime)))
             peersReplicatedTo += peer
             peersForReplication -= peer


### PR DESCRIPTION
Just found a typo. Should not use "%f" for Long.
