### PR TITLE
Sbt and Maven builds pass on Linux boxes with encrypted folder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -829,6 +829,8 @@
               <arg>-deprecation</arg>
               <arg>-feature</arg>
               <arg>-language:postfixOps</arg>
+              <arg>-Xmax-classfile-name</arg>
+              <arg>128</arg>
             </args>
             <jvmArgs>
               <jvmArg>-Xms1024m</jvmArg>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -116,6 +116,7 @@ object SparkBuild extends PomBuild {
     retrieveManaged := true,
     retrievePattern := "[type]s/[artifact](-[revision])(-[classifier]).[ext]",
     publishMavenStyle := true,
+    scalacOptions in Compile ++= Seq("-Xmax-classfile-name", "128"),
   
     resolvers += Resolver.mavenLocal,
     otherResolvers <<= SbtPomKeys.mvnLocalRepository(dotM2 => Seq(Resolver.file("dotM2", dotM2))),


### PR DESCRIPTION
The contribution is my original work.  I license the work to the project under the project's open source license.

Building on a Linux box with encrypted home folder results in a failure.

```
[error] == Expanded type of tree ==
[error] 
[error] ConstantType(value = Constant(Throwable))
[error] 
[error] uncaught exception during compilation: java.io.IOException
[error] File name too long
[error] two errors found
```

This pull request fixes the problem in both the sbt and maven builds. 

Few other people are experiencing the same problem and will be good to be fixed.

http://apache-spark-user-list.1001560.n3.nabble.com/compiling-spark-source-code-td13980.html

http://mail-archives.apache.org/mod_mbox/spark-user/201312.mbox/%3C35F52C98-1178-480C-8D84-619D8F341D3E@gmail.com%3E
