### PR TITLE
[SPARK-4045][SQL] BinaryArithmetic cannot implicitly cast StringType to DoubleType

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
@@ -212,9 +212,9 @@ trait HiveTypeCoercion {
       case e if !e.childrenResolved => e
 
       case a: BinaryArithmetic if a.left.dataType == StringType =>
-        a.makeCopy(Array(Cast(a.left, DoubleType), a.right))
+        a.makeCopy(Array(Cast(a.left, a.right.dataType), a.right))
       case a: BinaryArithmetic if a.right.dataType == StringType =>
-        a.makeCopy(Array(a.left, Cast(a.right, DoubleType)))
+        a.makeCopy(Array(a.left, Cast(a.right, a.left.dataType)))
 
       case p: BinaryPredicate if p.left.dataType == StringType && p.right.dataType != StringType =>
         p.makeCopy(Array(Cast(p.left, DoubleType), p.right))


### PR DESCRIPTION
If we use StringType for a operand for BinaryArithmetic, the operand is coerced to be DoubleType.
I think, the operand should be coerced to be the type of another operand.
