### PR TITLE
Clarify docstring for Pyspark's foreachPartition

### DIFF
--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -634,6 +634,11 @@ class RDD(object):
     def foreachPartition(self, f):
         """
         Applies a function to each partition of this RDD.
+        
+        
+        Note: Due to implementation, f must either return an iterable object
+        or be a generator function. However, foreachPartition always returns 
+        `None`.
 
         >>> def f(iterator):
         ...      for x in iterator:


### PR DESCRIPTION
Due to the underlying use of `mapPartitions` which requires a function that maps partitions to partitions, `foreachPartition` requires the function passed to be a generator function or return an iterable (although these results are discarded). 

This is currently not stated in the documentation except through the unexplained example. It would help users to understand that example and not waste time with this error:

```
TypeError: 'NoneType' object is not iterable
```
