### PR TITLE
bash can't `die`

### DIFF
--- a/sbt/sbt-launch-lib.bash
+++ b/sbt/sbt-launch-lib.bash
@@ -124,7 +124,8 @@ require_arg () {
   local opt="$2"
   local arg="$3"
   if [[ -z "$arg" ]] || [[ "${arg:0:1}" == "-" ]]; then
-    die "$opt requires <$type> argument"
+    echo "$opt requires <$type> argument" 1>&2
+    exit 1
   fi
 }
 


### PR DESCRIPTION
This PR fixes the bug that `sbt/sbt` enters an infinite loop when a required argument is omitted:

```
jey@kallisti:~/proj/spark$ sbt/sbt -mem 2>&1 | head -n 10
/home/jey/proj/spark/sbt/sbt-launch-lib.bash: line 127: die: command not found
/home/jey/proj/spark/sbt/sbt-launch-lib.bash: line 127: die: command not found
/home/jey/proj/spark/sbt/sbt-launch-lib.bash: line 127: die: command not found
/home/jey/proj/spark/sbt/sbt-launch-lib.bash: line 127: die: command not found
/home/jey/proj/spark/sbt/sbt-launch-lib.bash: line 127: die: command not found
/home/jey/proj/spark/sbt/sbt-launch-lib.bash: line 127: die: command not found
/home/jey/proj/spark/sbt/sbt-launch-lib.bash: line 127: die: command not found
/home/jey/proj/spark/sbt/sbt-launch-lib.bash: line 127: die: command not found
/home/jey/proj/spark/sbt/sbt-launch-lib.bash: line 127: die: command not found
/home/jey/proj/spark/sbt/sbt-launch-lib.bash: line 127: die: command not found
[...]
```
