### PR TITLE
[SPARK-4054] Dead link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To build Spark and its example programs, run:
 
 (You do not need to do this if you downloaded a pre-built package.)
 More detailed documentation is available from the project site, at
-["Building Spark with Maven"](http://spark.apache.org/docs/latest/building-with-maven.html).
+["Building Spark"](http://spark.apache.org/docs/latest/building-spark.html).
 
 ## Interactive Scala Shell
 


### PR DESCRIPTION
In 1.2.0, building-with-maven.html is no longer here but README still points that.
