### PR TITLE
[SPARK-4055][MLlib] Inconsistent spelling 'MLlib' and 'MLLib'

### DIFF
--- a/docs/mllib-feature-extraction.md
+++ b/docs/mllib-feature-extraction.md
@@ -83,7 +83,7 @@ val idf = new IDF().fit(tf)
 val tfidf: RDD[Vector] = idf.transform(tf)
 {% endhighlight %}
 
-MLLib's IDF implementation provides an option for ignoring terms which occur in less than a
+MLlib's IDF implementation provides an option for ignoring terms which occur in less than a
 minimum number of documents.  In such cases, the IDF for these terms is set to 0.  This feature
 can be used by passing the `minDocFreq` value to the IDF constructor.
 

--- a/docs/mllib-statistics.md
+++ b/docs/mllib-statistics.md
@@ -197,7 +197,7 @@ print Statistics.corr(data, method="pearson")
 
 ## Stratified sampling
 
-Unlike the other statistics functions, which reside in MLLib, stratified sampling methods, 
+Unlike the other statistics functions, which reside in MLlib, stratified sampling methods,
 `sampleByKey` and `sampleByKeyExact`, can be performed on RDD's of key-value pairs. For stratified
 sampling, the keys can be thought of as a label and the value as a specific attribute. For example 
 the key can be man or woman, or document ids, and the respective values can be the list of ages 

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaALS.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaALS.java
@@ -32,7 +32,7 @@ import java.util.regex.Pattern;
 import scala.Tuple2;
 
 /**
- * Example using MLLib ALS from Java.
+ * Example using MLlib ALS from Java.
  */
 public final class JavaALS {
 

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaKMeans.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaKMeans.java
@@ -30,7 +30,7 @@ import org.apache.spark.mllib.linalg.Vector;
 import org.apache.spark.mllib.linalg.Vectors;
 
 /**
- * Example using MLLib KMeans from Java.
+ * Example using MLlib KMeans from Java.
  */
 public final class JavaKMeans {
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/package.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/package.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.mllib.api
 
 /**
- * Internal support for MLLib Python API.
+ * Internal support for MLlib Python API.
  *
  * @see [[org.apache.spark.mllib.api.python.PythonMLLibAPI]]
  */


### PR DESCRIPTION
Thare are some inconsistent spellings 'MLlib' and 'MLLib' in some documents and source codes.
