### PR TITLE
[SPARK-4058] [PySpark] Log file name is hard coded even though there is a variable '$LOG_FILE '

### DIFF
--- a/python/run-tests
+++ b/python/run-tests
@@ -41,7 +41,7 @@ function run_test() {
 
     # Fail and exit on the first test failure.
     if [[ $FAILED != 0 ]]; then
-        cat unit-tests.log | grep -v "^[0-9][0-9]*" # filter all lines starting with a number.
+        cat $LOG_FILE | grep -v "^[0-9][0-9]*" # filter all lines starting with a number.
         echo -en "\033[31m"  # Red
         echo "Had test failures; see logs."
         echo -en "\033[0m"  # No color
@@ -87,7 +87,7 @@ function run_streaming_tests() {
     run_test "pyspark/streaming/tests.py"
 }
 
-echo "Running PySpark tests. Output is in python/unit-tests.log."
+echo "Running PySpark tests. Output is in python/$LOG_FILE."
 
 export PYSPARK_PYTHON="python"
 


### PR DESCRIPTION
In a script 'python/run-tests', log file name is represented by a variable 'LOG_FILE' and it is used in run-tests. But, there are some hard-coded log file name in the script.
