### PR TITLE
[SPARK-4056] Upgrade snappy-java to 1.1.1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -342,7 +342,7 @@
       <dependency>
         <groupId>org.xerial.snappy</groupId>
         <artifactId>snappy-java</artifactId>
-        <version>1.1.1.4</version>
+        <version>1.1.1.5</version>
       </dependency>
       <dependency>
         <groupId>net.jpountz.lz4</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -342,7 +342,7 @@
       <dependency>
         <groupId>org.xerial.snappy</groupId>
         <artifactId>snappy-java</artifactId>
-        <version>1.1.1.3</version>
+        <version>1.1.1.4</version>
       </dependency>
       <dependency>
         <groupId>net.jpountz.lz4</groupId>


### PR DESCRIPTION
This upgrades snappy-java to 1.1.1.5, which improves error messages when attempting to deserialize empty inputs using SnappyInputStream (see https://github.com/xerial/snappy-java/issues/89).
