### PR TITLE
[SPARK-4076] Parameter expansion in spark-config is wrong

### DIFF
--- a/sbin/spark-config.sh
+++ b/sbin/spark-config.sh
@@ -20,7 +20,7 @@
 # also should not be passed any arguments, since we need original $*
 
 # resolve links - $0 may be a softlink
-this="${BASH_SOURCE-$0}"
+this="${BASH_SOURCE:-$0}"
 common_bin="$(cd -P -- "$(dirname -- "$this")" && pwd -P)"
 script="$(basename -- "$this")"
 this="$common_bin/$script"


### PR DESCRIPTION
In sbin/spark-config.sh, parameter expansion is used to extract source root as follows.

```
this="${BASH_SOURCE-$0}"
```

I think, the parameter expansion should be ":" instead of "".
If we use "-" and BASH_SOURCE="", (empty character is set, not unset),
"" (empty character) is set to $this.
