### PR TITLE
[SPARK-4084] Reuse sort key in Sorter

### DIFF
--- a/core/src/main/java/org/apache/spark/util/collection/Sorter.java
+++ b/core/src/main/java/org/apache/spark/util/collection/Sorter.java
@@ -24,12 +24,16 @@ import java.util.Comparator;
  * See the method comment on sort() for more details.
  *
  * This has been kept in Java with the original style in order to match very closely with the
- * Anroid source code, and thus be easy to verify correctness.
+ * Android source code, and thus be easy to verify correctness.
  *
  * The purpose of the port is to generalize the interface to the sort to accept input data formats
  * besides simple arrays where every element is sorted individually. For instance, the AppendOnlyMap
  * uses this to sort an Array with alternating elements of the form [key, value, key, value].
  * This generalization comes with minimal overhead -- see SortDataFormat for more information.
+ *
+ * We allow key reuse to prevent creating many key objects -- see SortDataFormat.
+ *
+ * @see org.apache.spark.util.collection.SortDataFormat
  */
 class Sorter<K, Buffer> {
 

--- a/core/src/main/java/org/apache/spark/util/collection/Sorter.java
+++ b/core/src/main/java/org/apache/spark/util/collection/Sorter.java
@@ -162,13 +162,13 @@ class Sorter<K, Buffer> {
     if (start == lo)
       start++;
 
-    K mutableThiny1 = s.createNewMutableThingy();
-    K mutableThiny2 = s.createNewMutableThingy();
+    K key0 = s.newKey();
+    K key1 = s.newKey();
 
     Buffer pivotStore = s.allocate(1);
     for ( ; start < hi; start++) {
       s.copyElement(a, start, pivotStore, 0);
-      K pivot = s.getKey(pivotStore, 0, mutableThiny1);
+      K pivot = s.getKey(pivotStore, 0, key0);
 
       // Set left (and right) to the index where a[start] (pivot) belongs
       int left = lo;
@@ -181,7 +181,7 @@ class Sorter<K, Buffer> {
        */
       while (left < right) {
         int mid = (left + right) >>> 1;
-        if (c.compare(pivot, s.getKey(a, mid, mutableThiny2)) < 0)
+        if (c.compare(pivot, s.getKey(a, mid, key1)) < 0)
           right = mid;
         else
           left = mid + 1;
@@ -238,16 +238,16 @@ class Sorter<K, Buffer> {
     if (runHi == hi)
       return 1;
 
-    K mutableThiny1 = s.createNewMutableThingy();
-    K mutableThiny2 = s.createNewMutableThingy();
+    K key1 = s.newKey();
+    K key2 = s.newKey();
 
     // Find end of run, and reverse range if descending
-    if (c.compare(s.getKey(a, runHi++, mutableThiny1), s.getKey(a, lo, mutableThiny2)) < 0) { // Descending
-      while (runHi < hi && c.compare(s.getKey(a, runHi, mutableThiny1), s.getKey(a, runHi - 1, mutableThiny2)) < 0)
+    if (c.compare(s.getKey(a, runHi++, key1), s.getKey(a, lo, key2)) < 0) { // Descending
+      while (runHi < hi && c.compare(s.getKey(a, runHi, key1), s.getKey(a, runHi - 1, key2)) < 0)
         runHi++;
       reverseRange(a, lo, runHi);
     } else {                              // Ascending
-      while (runHi < hi && c.compare(s.getKey(a, runHi, mutableThiny1), s.getKey(a, runHi - 1, mutableThiny2)) >= 0)
+      while (runHi < hi && c.compare(s.getKey(a, runHi, key1), s.getKey(a, runHi - 1, key2)) >= 0)
         runHi++;
     }
 
@@ -474,14 +474,13 @@ class Sorter<K, Buffer> {
       }
       stackSize--;
 
-
-      K mutableThiny1 = s.createNewMutableThingy();
+      K key0 = s.newKey();
 
       /*
        * Find where the first element of run2 goes in run1. Prior elements
        * in run1 can be ignored (because they're already in place).
        */
-      int k = gallopRight(s.getKey(a, base2, mutableThiny1), a, base1, len1, 0, c);
+      int k = gallopRight(s.getKey(a, base2, key0), a, base1, len1, 0, c);
       assert k >= 0;
       base1 += k;
       len1 -= k;
@@ -492,7 +491,7 @@ class Sorter<K, Buffer> {
        * Find where the last element of run1 goes in run2. Subsequent elements
        * in run2 can be ignored (because they're already in place).
        */
-      len2 = gallopLeft(s.getKey(a, base1 + len1 - 1, mutableThiny1), a, base2, len2, len2 - 1, c);
+      len2 = gallopLeft(s.getKey(a, base1 + len1 - 1, key0), a, base2, len2, len2 - 1, c);
       assert len2 >= 0;
       if (len2 == 0)
         return;
@@ -526,12 +525,12 @@ class Sorter<K, Buffer> {
       assert len > 0 && hint >= 0 && hint < len;
       int lastOfs = 0;
       int ofs = 1;
-      K mutableThiny1 = s.createNewMutableThingy();
+      K key0 = s.newKey();
 
-      if (c.compare(key, s.getKey(a, base + hint, mutableThiny1)) > 0) {
+      if (c.compare(key, s.getKey(a, base + hint, key0)) > 0) {
         // Gallop right until a[base+hint+lastOfs] < key <= a[base+hint+ofs]
         int maxOfs = len - hint;
-        while (ofs < maxOfs && c.compare(key, s.getKey(a, base + hint + ofs, mutableThiny1)) > 0) {
+        while (ofs < maxOfs && c.compare(key, s.getKey(a, base + hint + ofs, key0)) > 0) {
           lastOfs = ofs;
           ofs = (ofs << 1) + 1;
           if (ofs <= 0)   // int overflow
@@ -546,7 +545,7 @@ class Sorter<K, Buffer> {
       } else { // key <= a[base + hint]
         // Gallop left until a[base+hint-ofs] < key <= a[base+hint-lastOfs]
         final int maxOfs = hint + 1;
-        while (ofs < maxOfs && c.compare(key, s.getKey(a, base + hint - ofs, mutableThiny1)) <= 0) {
+        while (ofs < maxOfs && c.compare(key, s.getKey(a, base + hint - ofs, key0)) <= 0) {
           lastOfs = ofs;
           ofs = (ofs << 1) + 1;
           if (ofs <= 0)   // int overflow
@@ -571,7 +570,7 @@ class Sorter<K, Buffer> {
       while (lastOfs < ofs) {
         int m = lastOfs + ((ofs - lastOfs) >>> 1);
 
-        if (c.compare(key, s.getKey(a, base + m, mutableThiny1)) > 0)
+        if (c.compare(key, s.getKey(a, base + m, key0)) > 0)
           lastOfs = m + 1;  // a[base + m] < key
         else
           ofs = m;          // key <= a[base + m]
@@ -598,12 +597,12 @@ class Sorter<K, Buffer> {
 
       int ofs = 1;
       int lastOfs = 0;
-      K mutableThiny1 = s.createNewMutableThingy();
+      K key1 = s.newKey();
 
-      if (c.compare(key, s.getKey(a, base + hint, mutableThiny1)) < 0) {
+      if (c.compare(key, s.getKey(a, base + hint, key1)) < 0) {
         // Gallop left until a[b+hint - ofs] <= key < a[b+hint - lastOfs]
         int maxOfs = hint + 1;
-        while (ofs < maxOfs && c.compare(key, s.getKey(a, base + hint - ofs, mutableThiny1)) < 0) {
+        while (ofs < maxOfs && c.compare(key, s.getKey(a, base + hint - ofs, key1)) < 0) {
           lastOfs = ofs;
           ofs = (ofs << 1) + 1;
           if (ofs <= 0)   // int overflow
@@ -619,7 +618,7 @@ class Sorter<K, Buffer> {
       } else { // a[b + hint] <= key
         // Gallop right until a[b+hint + lastOfs] <= key < a[b+hint + ofs]
         int maxOfs = len - hint;
-        while (ofs < maxOfs && c.compare(key, s.getKey(a, base + hint + ofs, mutableThiny1)) >= 0) {
+        while (ofs < maxOfs && c.compare(key, s.getKey(a, base + hint + ofs, key1)) >= 0) {
           lastOfs = ofs;
           ofs = (ofs << 1) + 1;
           if (ofs <= 0)   // int overflow
@@ -643,7 +642,7 @@ class Sorter<K, Buffer> {
       while (lastOfs < ofs) {
         int m = lastOfs + ((ofs - lastOfs) >>> 1);
 
-        if (c.compare(key, s.getKey(a, base + m, mutableThiny1)) < 0)
+        if (c.compare(key, s.getKey(a, base + m, key1)) < 0)
           ofs = m;          // key < a[b + m]
         else
           lastOfs = m + 1;  // a[b + m] <= key
@@ -692,8 +691,8 @@ class Sorter<K, Buffer> {
         return;
       }
 
-      K mutableThiny1 = s.createNewMutableThingy();
-      K mutableThiny2 = s.createNewMutableThingy();
+      K key0 = s.newKey();
+      K key1 = s.newKey();
 
       Comparator<? super K> c = this.c;  // Use local variable for performance
       int minGallop = this.minGallop;    //  "    "       "     "      "
@@ -708,7 +707,7 @@ class Sorter<K, Buffer> {
          */
         do {
           assert len1 > 1 && len2 > 0;
-          if (c.compare(s.getKey(a, cursor2, mutableThiny1), s.getKey(tmp, cursor1, mutableThiny2)) < 0) {
+          if (c.compare(s.getKey(a, cursor2, key0), s.getKey(tmp, cursor1, key1)) < 0) {
             s.copyElement(a, cursor2++, a, dest++);
             count2++;
             count1 = 0;
@@ -730,7 +729,7 @@ class Sorter<K, Buffer> {
          */
         do {
           assert len1 > 1 && len2 > 0;
-          count1 = gallopRight(s.getKey(a, cursor2, mutableThiny1), tmp, cursor1, len1, 0, c);
+          count1 = gallopRight(s.getKey(a, cursor2, key0), tmp, cursor1, len1, 0, c);
           if (count1 != 0) {
             s.copyRange(tmp, cursor1, a, dest, count1);
             dest += count1;
@@ -743,7 +742,7 @@ class Sorter<K, Buffer> {
           if (--len2 == 0)
             break outer;
 
-          count2 = gallopLeft(s.getKey(tmp, cursor1, mutableThiny1), a, cursor2, len2, 0, c);
+          count2 = gallopLeft(s.getKey(tmp, cursor1, key0), a, cursor2, len2, 0, c);
           if (count2 != 0) {
             s.copyRange(a, cursor2, a, dest, count2);
             dest += count2;
@@ -800,9 +799,8 @@ class Sorter<K, Buffer> {
       int cursor2 = len2 - 1;          // Indexes into tmp array
       int dest = base2 + len2 - 1;     // Indexes into a
 
-      K mutableThiny1 = s.createNewMutableThingy();
-      K mutableThiny2 = s.createNewMutableThingy();
-
+      K key0 = s.newKey();
+      K key1 = s.newKey();
 
       // Move last element of first run and deal with degenerate cases
       s.copyElement(a, cursor1--, a, dest--);
@@ -831,7 +829,7 @@ class Sorter<K, Buffer> {
          */
         do {
           assert len1 > 0 && len2 > 1;
-          if (c.compare(s.getKey(tmp, cursor2, mutableThiny1), s.getKey(a, cursor1, mutableThiny2)) < 0) {
+          if (c.compare(s.getKey(tmp, cursor2, key0), s.getKey(a, cursor1, key1)) < 0) {
             s.copyElement(a, cursor1--, a, dest--);
             count1++;
             count2 = 0;
@@ -853,7 +851,7 @@ class Sorter<K, Buffer> {
          */
         do {
           assert len1 > 0 && len2 > 1;
-          count1 = len1 - gallopRight(s.getKey(tmp, cursor2, mutableThiny1), a, base1, len1, len1 - 1, c);
+          count1 = len1 - gallopRight(s.getKey(tmp, cursor2, key0), a, base1, len1, len1 - 1, c);
           if (count1 != 0) {
             dest -= count1;
             cursor1 -= count1;
@@ -866,7 +864,7 @@ class Sorter<K, Buffer> {
           if (--len2 == 1)
             break outer;
 
-          count2 = len2 - gallopLeft(s.getKey(a, cursor1, mutableThiny1), tmp, 0, len2, len2 - 1, c);
+          count2 = len2 - gallopLeft(s.getKey(a, cursor1, key0), tmp, 0, len2, len2 - 1, c);
           if (count2 != 0) {
             dest -= count2;
             cursor2 -= count2;

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1238,8 +1238,9 @@ private[spark] object Utils extends Logging {
    * Timing method based on iterations that permit JVM JIT optimization.
    * @param numIters number of iterations
    * @param f function to be executed
+   * @param prepare function to be executed before each call to f. Its running time doesn't count.
    */
-  def timeIt(numIters: Int)(f: => Unit, prepare: => Unit = ()): Long = {
+  def timeIt(numIters: Int)(f: => Unit, prepare: => Unit = {}): Long = {
     var i = 0
     var sum = 0L
     while (i < numIters) {

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1238,9 +1238,21 @@ private[spark] object Utils extends Logging {
    * Timing method based on iterations that permit JVM JIT optimization.
    * @param numIters number of iterations
    * @param f function to be executed
+   */
+  def timeIt(numIters: Int)(f: => Unit): Long = {
+    val start = System.currentTimeMillis
+    times(numIters)(f)
+    System.currentTimeMillis - start
+  }
+
+  /**
+   * Timing method based on iterations that permit JVM JIT optimization.
+   * @param numIters number of iterations
+   * @param f function to be executed. For accurate timing, the execution time for each run must be
+   *          an order of magnitude longer than one millisecond.
    * @param prepare function to be executed before each call to f. Its running time doesn't count.
    */
-  def timeIt(numIters: Int)(f: => Unit, prepare: => Unit = {}): Long = {
+  def timeIt(numIters: Int)(f: => Unit, prepare: => Unit): Long = {
     var i = 0
     var sum = 0L
     while (i < numIters) {

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1240,6 +1240,7 @@ private[spark] object Utils extends Logging {
    * @param f function to be executed. If prepare is not None, the running time of each call to f
    *          must be an order of magnitude longer than one millisecond for accurate timing.
    * @param prepare function to be executed before each call to f. Its running time doesn't count.
+   * @return the total time across all iterations (not couting preparation time)
    */
   def timeIt(numIters: Int)(f: => Unit, prepare: Option[() => Unit] = None): Long = {
     if (prepare.isEmpty) {

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1239,10 +1239,17 @@ private[spark] object Utils extends Logging {
    * @param numIters number of iterations
    * @param f function to be executed
    */
-  def timeIt(numIters: Int)(f: => Unit): Long = {
-    val start = System.currentTimeMillis
-    times(numIters)(f)
-    System.currentTimeMillis - start
+  def timeIt(numIters: Int)(f: => Unit, prepare: => Unit = ()): Long = {
+    var i = 0
+    var sum = 0L
+    while (i < numIters) {
+      prepare
+      val start = System.currentTimeMillis
+      f
+      sum += System.currentTimeMillis - start
+      i += 1
+    }
+    sum
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/util/collection/SortDataFormat.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/SortDataFormat.scala
@@ -37,6 +37,12 @@ private[spark] trait SortDataFormat[K, Buffer] extends Any {
   /** Return the sort key for the element at the given index. */
   protected def getKey(data: Buffer, pos: Int): K
 
+  protected def createNewMutableThingy(): K = null.asInstanceOf[K]
+
+  protected def getKey(data: Buffer, pos: Int, mutableThingy: K): K = {
+    getKey(data, pos)
+  }
+
   /** Swap two elements. */
   protected def swap(data: Buffer, pos0: Int, pos1: Int): Unit
 

--- a/core/src/main/scala/org/apache/spark/util/collection/SortDataFormat.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/SortDataFormat.scala
@@ -40,7 +40,7 @@ trait SortDataFormat[K, Buffer] extends Any {
    * Creates a new mutable key for reuse. This should be implemented if you want to override
    * [[getKey(Buffer, Int, K)]].
    */
-  protected def newKey(): K = null.asInstanceOf[K]
+  def newKey(): K = null.asInstanceOf[K]
 
   /** Return the sort key for the element at the given index. */
   protected def getKey(data: Buffer, pos: Int): K
@@ -50,27 +50,27 @@ trait SortDataFormat[K, Buffer] extends Any {
    * The default implementation ignores the reuse parameter and invokes [[getKey(Buffer, Int]].
    * If you want to override this method, you must implement [[newKey()]].
    */
-  protected def getKey(data: Buffer, pos: Int, reuse: K): K = {
+  def getKey(data: Buffer, pos: Int, reuse: K): K = {
     getKey(data, pos)
   }
 
   /** Swap two elements. */
-  protected def swap(data: Buffer, pos0: Int, pos1: Int): Unit
+  def swap(data: Buffer, pos0: Int, pos1: Int): Unit
 
   /** Copy a single element from src(srcPos) to dst(dstPos). */
-  protected def copyElement(src: Buffer, srcPos: Int, dst: Buffer, dstPos: Int): Unit
+  def copyElement(src: Buffer, srcPos: Int, dst: Buffer, dstPos: Int): Unit
 
   /**
    * Copy a range of elements starting at src(srcPos) to dst, starting at dstPos.
    * Overlapping ranges are allowed.
    */
-  protected def copyRange(src: Buffer, srcPos: Int, dst: Buffer, dstPos: Int, length: Int): Unit
+  def copyRange(src: Buffer, srcPos: Int, dst: Buffer, dstPos: Int, length: Int): Unit
 
   /**
    * Allocates a Buffer that can hold up to 'length' elements.
    * All elements of the buffer should be considered invalid until data is explicitly copied in.
    */
-  protected def allocate(length: Int): Buffer
+  def allocate(length: Int): Buffer
 }
 
 /**
@@ -84,9 +84,9 @@ trait SortDataFormat[K, Buffer] extends Any {
 private[spark]
 class KVArraySortDataFormat[K, T <: AnyRef : ClassTag] extends SortDataFormat[K, Array[T]] {
 
-  override protected def getKey(data: Array[T], pos: Int): K = data(2 * pos).asInstanceOf[K]
+  override def getKey(data: Array[T], pos: Int): K = data(2 * pos).asInstanceOf[K]
 
-  override protected def swap(data: Array[T], pos0: Int, pos1: Int) {
+  override def swap(data: Array[T], pos0: Int, pos1: Int) {
     val tmpKey = data(2 * pos0)
     val tmpVal = data(2 * pos0 + 1)
     data(2 * pos0)     = data(2 * pos1)
@@ -95,17 +95,16 @@ class KVArraySortDataFormat[K, T <: AnyRef : ClassTag] extends SortDataFormat[K,
     data(2 * pos1 + 1) = tmpVal
   }
 
-  override protected def copyElement(src: Array[T], srcPos: Int, dst: Array[T], dstPos: Int) {
+  override def copyElement(src: Array[T], srcPos: Int, dst: Array[T], dstPos: Int) {
     dst(2 * dstPos) = src(2 * srcPos)
     dst(2 * dstPos + 1) = src(2 * srcPos + 1)
   }
 
-  override protected def copyRange(src: Array[T], srcPos: Int,
-                                   dst: Array[T], dstPos: Int, length: Int) {
+  override def copyRange(src: Array[T], srcPos: Int, dst: Array[T], dstPos: Int, length: Int) {
     System.arraycopy(src, 2 * srcPos, dst, 2 * dstPos, 2 * length)
   }
 
-  override protected def allocate(length: Int): Array[T] = {
+  override def allocate(length: Int): Array[T] = {
     new Array[T](2 * length)
   }
 }

--- a/core/src/main/scala/org/apache/spark/util/collection/SortDataFormat.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/SortDataFormat.scala
@@ -34,12 +34,17 @@ import scala.reflect.ClassTag
  */
 // TODO: Making Buffer a real trait would be a better abstraction, but adds some complexity.
 private[spark] trait SortDataFormat[K, Buffer] extends Any {
+
+  /** Creates a new mutable key for reuse. */
+  protected def newKey(): K = null.asInstanceOf[K]
+
   /** Return the sort key for the element at the given index. */
   protected def getKey(data: Buffer, pos: Int): K
 
-  protected def createNewMutableThingy(): K = null.asInstanceOf[K]
-
-  protected def getKey(data: Buffer, pos: Int, mutableThingy: K): K = {
+  /**
+   * Returns the sort key for the element at the given index and reuse the input key if possible.
+   */
+  protected def getKey(data: Buffer, pos: Int, reuse: K): K = {
     getKey(data, pos)
   }
 

--- a/core/src/main/scala/org/apache/spark/util/collection/SortDataFormat.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/SortDataFormat.scala
@@ -27,14 +27,15 @@ import scala.reflect.ClassTag
  * Example format: an array of numbers, where each element is also the key.
  * See [[KVArraySortDataFormat]] for a more exciting format.
  *
- * This trait extends Any to ensure it is universal (and thus compiled to a Java interface).
+ * Declaring and instantiating multiple subclasses of this class would prevent JIT inlining
+ * overridden methods and hence decrease the shuffle performance.
  *
  * @tparam K Type of the sort key of each element
  * @tparam Buffer Internal data structure used by a particular format (e.g., Array[Int]).
  */
 // TODO: Making Buffer a real trait would be a better abstraction, but adds some complexity.
 private[spark]
-trait SortDataFormat[K, Buffer] extends Any {
+abstract class SortDataFormat[K, Buffer] extends Any {
 
   /**
    * Creates a new mutable key for reuse. This should be implemented if you want to override

--- a/core/src/main/scala/org/apache/spark/util/collection/SortDataFormat.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/SortDataFormat.scala
@@ -35,7 +35,7 @@ import scala.reflect.ClassTag
  */
 // TODO: Making Buffer a real trait would be a better abstraction, but adds some complexity.
 private[spark]
-abstract class SortDataFormat[K, Buffer] extends Any {
+abstract class SortDataFormat[K, Buffer] {
 
   /**
    * Creates a new mutable key for reuse. This should be implemented if you want to override

--- a/core/src/main/scala/org/apache/spark/util/collection/SortDataFormat.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/SortDataFormat.scala
@@ -27,7 +27,7 @@ import scala.reflect.ClassTag
  * Example format: an array of numbers, where each element is also the key.
  * See [[KVArraySortDataFormat]] for a more exciting format.
  *
- * Declaring and instantiating multiple subclasses of this class would prevent JIT inlining
+ * Note: Declaring and instantiating multiple subclasses of this class would prevent JIT inlining
  * overridden methods and hence decrease the shuffle performance.
  *
  * @tparam K Type of the sort key of each element

--- a/core/src/main/scala/org/apache/spark/util/collection/SortDataFormat.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/SortDataFormat.scala
@@ -33,9 +33,13 @@ import scala.reflect.ClassTag
  * @tparam Buffer Internal data structure used by a particular format (e.g., Array[Int]).
  */
 // TODO: Making Buffer a real trait would be a better abstraction, but adds some complexity.
-private[spark] trait SortDataFormat[K, Buffer] extends Any {
+private[spark]
+trait SortDataFormat[K, Buffer] extends Any {
 
-  /** Creates a new mutable key for reuse. */
+  /**
+   * Creates a new mutable key for reuse. This should be implemented if you want to override
+   * [[getKey(Buffer, Int, K)]].
+   */
   protected def newKey(): K = null.asInstanceOf[K]
 
   /** Return the sort key for the element at the given index. */
@@ -43,6 +47,8 @@ private[spark] trait SortDataFormat[K, Buffer] extends Any {
 
   /**
    * Returns the sort key for the element at the given index and reuse the input key if possible.
+   * The default implementation ignores the reuse parameter and invokes [[getKey(Buffer, Int]].
+   * If you want to override this method, you must implement [[newKey()]].
    */
   protected def getKey(data: Buffer, pos: Int, reuse: K): K = {
     getKey(data, pos)

--- a/core/src/main/scala/org/apache/spark/util/collection/Sorter.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/Sorter.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util.collection
+
+import java.util.Comparator
+
+/**
+ * A simpler wrapper over the Java implementation [[TimSort]].
+ *
+ * The Java implementation is package private, and hence it cannot be called outside package
+ * org.apache.spark.util.collection. This is a simple wrapper of it that is available to spark.
+ */
+private[spark]
+class Sorter[K, Buffer](private val s: SortDataFormat[K, Buffer]) {
+
+  private val timSort = new TimSort(s)
+
+  /**
+   * Sorts the input buffer within range [lo, hi).
+   */
+  def sort(a: Buffer, lo: Int, hi: Int, c: Comparator[_ >: K]): Unit = {
+    timSort.sort(a, lo, hi, c)
+  }
+}

--- a/core/src/main/scala/org/apache/spark/util/collection/Sorter.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/Sorter.scala
@@ -20,7 +20,7 @@ package org.apache.spark.util.collection
 import java.util.Comparator
 
 /**
- * A simpler wrapper over the Java implementation [[TimSort]].
+ * A simple wrapper over the Java implementation [[TimSort]].
  *
  * The Java implementation is package private, and hence it cannot be called outside package
  * org.apache.spark.util.collection. This is a simple wrapper of it that is available to spark.

--- a/core/src/main/scala/org/apache/spark/util/random/XORShiftRandom.scala
+++ b/core/src/main/scala/org/apache/spark/util/random/XORShiftRandom.scala
@@ -96,7 +96,7 @@ private[spark] object XORShiftRandom {
       xorRand.nextInt()
     }
 
-    val iters: (=> Unit) => Unit = (f) => timeIt(numIters)(f)
+    val iters = timeIt(numIters)(_)
 
     /* Return results as a map instead of just printing to screen
     in case the user wants to do something with them */

--- a/core/src/main/scala/org/apache/spark/util/random/XORShiftRandom.scala
+++ b/core/src/main/scala/org/apache/spark/util/random/XORShiftRandom.scala
@@ -96,7 +96,7 @@ private[spark] object XORShiftRandom {
       xorRand.nextInt()
     }
 
-    val iters = timeIt(numIters)(_)
+    val iters: (=> Unit) => Unit = (f) => timeIt(numIters)(f)
 
     /* Return results as a map instead of just printing to screen
     in case the user wants to do something with them */

--- a/core/src/main/scala/org/apache/spark/util/random/XORShiftRandom.scala
+++ b/core/src/main/scala/org/apache/spark/util/random/XORShiftRandom.scala
@@ -96,7 +96,7 @@ private[spark] object XORShiftRandom {
       xorRand.nextInt()
     }
 
-    val iters = timeIt(numIters)(_)
+    val iters: (=> Unit) => Unit = (x) => timeIt(numIters)(x)
 
     /* Return results as a map instead of just printing to screen
     in case the user wants to do something with them */

--- a/core/src/main/scala/org/apache/spark/util/random/XORShiftRandom.scala
+++ b/core/src/main/scala/org/apache/spark/util/random/XORShiftRandom.scala
@@ -96,13 +96,9 @@ private[spark] object XORShiftRandom {
       xorRand.nextInt()
     }
 
-    val iters: (=> Unit) => Unit = (x) => timeIt(numIters)(x)
-
     /* Return results as a map instead of just printing to screen
     in case the user wants to do something with them */
-    Map("javaTime" -> iters {javaRand.nextInt()},
-        "xorTime" -> iters {xorRand.nextInt()})
-
+    Map("javaTime" -> timeIt(numIters) { javaRand.nextInt() },
+        "xorTime" -> timeIt(numIters) { xorRand.nextInt() })
   }
-
 }

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -351,4 +351,15 @@ class UtilsSuite extends FunSuite {
       outFile.delete()
     }
   }
+
+  test("timeIt with prepare") {
+    var cnt = 0
+    val prepare = () => {
+      cnt += 1
+      Thread.sleep(1000)
+    }
+    val time = Utils.timeIt(2)({}, prepare())
+    require(cnt === 2, "prepare should be called twice")
+    require(time < 500, "preparation time should not count")
+  }
 }

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -358,7 +358,7 @@ class UtilsSuite extends FunSuite {
       cnt += 1
       Thread.sleep(1000)
     }
-    val time = Utils.timeIt(2)({}, prepare())
+    val time = Utils.timeIt(2)({}, Some(prepare))
     require(cnt === 2, "prepare should be called twice")
     require(time < 500, "preparation time should not count")
   }

--- a/core/src/test/scala/org/apache/spark/util/collection/SorterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/SorterSuite.scala
@@ -90,7 +90,8 @@ class SorterSuite extends FunSuite {
   /**
    * This provides a simple benchmark for comparing the Sorter with Java internal sorting.
    * Ideally these would be executed one at a time, each in their own JVM, so their listing
-   * here is mainly to have the code.
+   * here is mainly to have the code. Running multiple tests within the same JVM session would
+   * prevent JIT inlining overridden methods and hence hurt the performance.
    *
    * The goal of this code is to sort an array of key-value pairs, where the array physically
    * has the keys and values alternating. The basic Java sorts work only on the keys, so the
@@ -151,6 +152,10 @@ class SorterSuite extends FunSuite {
    * Tests for sorting with primitive keys with/without key reuse. Java's Arrays.sort is used as
    * reference, which is expected to be faster but it can only sort a single array. Sorter can be
    * used to sort parallel arrays.
+   *
+   * Ideally these would be executed one at a time, each in their own JVM, so their listing
+   * here is mainly to have the code. Running multiple tests within the same JVM session would
+   * prevent JIT inlining overridden methods and hence hurt the performance.
    */
   ignore("Sorter benchmark for primitive int array") {
     val numElements = 25000000 // 25 mil

--- a/core/src/test/scala/org/apache/spark/util/collection/SorterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/SorterSuite.scala
@@ -143,24 +143,24 @@ class SorterSuite extends FunSuite {
 
 abstract class AbstractIntArraySortDataFormat[K] extends SortDataFormat[K, Array[Int]] {
 
-  override protected def swap(data: Array[Int], pos0: Int, pos1: Int): Unit = {
+  override def swap(data: Array[Int], pos0: Int, pos1: Int): Unit = {
     val tmp = data(pos0)
     data(pos0) = data(pos1)
     data(pos1) = tmp
   }
 
-  override protected def copyElement(src: Array[Int], srcPos: Int, dst: Array[Int], dstPos: Int) {
+  override def copyElement(src: Array[Int], srcPos: Int, dst: Array[Int], dstPos: Int) {
     dst(dstPos) = src(srcPos)
   }
 
   /** Copy a range of elements starting at src(srcPos) to dest, starting at destPos. */
-  override protected def copyRange(src: Array[Int], srcPos: Int,
+  override def copyRange(src: Array[Int], srcPos: Int,
                                    dst: Array[Int], dstPos: Int, length: Int) {
     System.arraycopy(src, srcPos, dst, dstPos, length)
   }
 
   /** Allocates a new structure that can hold up to 'length' elements. */
-  override protected def allocate(length: Int): Array[Int] = {
+  override def allocate(length: Int): Array[Int] = {
     new Array[Int](length)
   }
 }
@@ -183,11 +183,11 @@ class IntWrapper(var key: Int = 0) extends Ordered[IntWrapper] {
 /** SortDataFormat for Array[Int] with reused keys. */
 class KeyReuseIntArraySortDataFormat extends AbstractIntArraySortDataFormat[IntWrapper] {
 
-  override protected def newKey(): IntWrapper = {
+  override def newKey(): IntWrapper = {
     new IntWrapper()
   }
 
-  override protected def getKey(data: Array[Int], pos: Int, reuse: IntWrapper): IntWrapper = {
+  override def getKey(data: Array[Int], pos: Int, reuse: IntWrapper): IntWrapper = {
     if (reuse == null) {
       new IntWrapper(data(pos))
     } else {

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -53,7 +53,9 @@ object MimaExcludes {
               "org.apache.spark.scheduler.MapStatus"),
             // TaskContext was promoted to Abstract class
             ProblemFilters.exclude[AbstractClassProblem](
-              "org.apache.spark.TaskContext")
+              "org.apache.spark.TaskContext"),
+            ProblemFilters.exclude[IncompatibleTemplateDefProblem](
+              "org.apache.spark.util.collection.SortDataFormat")
           ) ++ Seq(
             // Adding new methods to the JavaRDDLike trait:
             ProblemFilters.exclude[MissingMethodProblem](


### PR DESCRIPTION
Sorter uses generic-typed key for sorting. When data is large, it creates lots of key objects, which is not efficient. We should reuse the key in Sorter for memory efficiency. This change is part of the petabyte sort implementation from @rxin .

The `Sorter` class was written in Java and marked package private. So it is only available to `org.apache.spark.util.collection`. I renamed it to `TimSort` and add a simple wrapper of it, still called `Sorter`, in Scala, which is `private[spark]`.

The benchmark code is updated, which now resets the array before each run. Here is the result on sorting primitive Int arrays of size 25 million using Sorter:

```
[info] - Sorter benchmark for key-value pairs !!! IGNORED !!!
Java Arrays.sort() on non-primitive int array: Took 13237 ms
Java Arrays.sort() on non-primitive int array: Took 13320 ms
Java Arrays.sort() on non-primitive int array: Took 15718 ms
Java Arrays.sort() on non-primitive int array: Took 13283 ms
Java Arrays.sort() on non-primitive int array: Took 13267 ms
Java Arrays.sort() on non-primitive int array: Took 15122 ms
Java Arrays.sort() on non-primitive int array: Took 15495 ms
Java Arrays.sort() on non-primitive int array: Took 14877 ms
Java Arrays.sort() on non-primitive int array: Took 16429 ms
Java Arrays.sort() on non-primitive int array: Took 14250 ms
Java Arrays.sort() on non-primitive int array: (13878 ms first try, 14499 ms average)
Java Arrays.sort() on primitive int array: Took 2683 ms
Java Arrays.sort() on primitive int array: Took 2683 ms
Java Arrays.sort() on primitive int array: Took 2701 ms
Java Arrays.sort() on primitive int array: Took 2746 ms
Java Arrays.sort() on primitive int array: Took 2685 ms
Java Arrays.sort() on primitive int array: Took 2735 ms
Java Arrays.sort() on primitive int array: Took 2669 ms
Java Arrays.sort() on primitive int array: Took 2693 ms
Java Arrays.sort() on primitive int array: Took 2680 ms
Java Arrays.sort() on primitive int array: Took 2642 ms
Java Arrays.sort() on primitive int array: (2948 ms first try, 2691 ms average)
Sorter without key reuse on primitive int array: Took 10732 ms
Sorter without key reuse on primitive int array: Took 12482 ms
Sorter without key reuse on primitive int array: Took 10718 ms
Sorter without key reuse on primitive int array: Took 12650 ms
Sorter without key reuse on primitive int array: Took 10747 ms
Sorter without key reuse on primitive int array: Took 10783 ms
Sorter without key reuse on primitive int array: Took 12721 ms
Sorter without key reuse on primitive int array: Took 10604 ms
Sorter without key reuse on primitive int array: Took 10622 ms
Sorter without key reuse on primitive int array: Took 11843 ms
Sorter without key reuse on primitive int array: (11089 ms first try, 11390 ms average)
Sorter with key reuse on primitive int array: Took 5141 ms
Sorter with key reuse on primitive int array: Took 5298 ms
Sorter with key reuse on primitive int array: Took 5066 ms
Sorter with key reuse on primitive int array: Took 5164 ms
Sorter with key reuse on primitive int array: Took 5203 ms
Sorter with key reuse on primitive int array: Took 5274 ms
Sorter with key reuse on primitive int array: Took 5186 ms
Sorter with key reuse on primitive int array: Took 5159 ms
Sorter with key reuse on primitive int array: Took 5164 ms
Sorter with key reuse on primitive int array: Took 5078 ms
Sorter with key reuse on primitive int array: (5311 ms first try, 5173 ms average)
```

So with key reuse, it is faster and less likely to trigger GC.
