### PR TITLE
Update RoaringBitmap to 0.4.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -445,7 +445,7 @@
       <dependency>
         <groupId>org.roaringbitmap</groupId>
         <artifactId>RoaringBitmap</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.3</version>
       </dependency>
       <dependency>
         <groupId>commons-net</groupId>


### PR DESCRIPTION
Roaring has been updated to version 0.4.3. We fixed a rarely occurring bug with serialization. No API or format changes were made.
