### PR TITLE
Add range join support to spark-sql

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
@@ -104,6 +104,9 @@ class SqlParser extends AbstractSparkSQLParser {
   protected val WHEN = Keyword("WHEN")
   protected val WHERE = Keyword("WHERE")
 
+  protected val RANGEJOIN = Keyword("RANGEJOIN")
+  protected val OVERLAPS = Keyword("OVERLAPS")
+
   // Use reflection to find the reserved words defined in this class.
   protected val reservedWords =
     this
@@ -171,7 +174,7 @@ class SqlParser extends AbstractSparkSQLParser {
     )
 
   protected lazy val relation: Parser[LogicalPlan] =
-    joinedRelation | relationFactor
+    joinedRelation | rangeJoinedRelation  | relationFactor
 
   protected lazy val relationFactor: Parser[LogicalPlan] =
     ( ident ~ (opt(AS) ~> opt(ident)) ^^ {
@@ -188,8 +191,18 @@ class SqlParser extends AbstractSparkSQLParser {
         }
     }
 
-  protected lazy val joinConditions: Parser[Expression] =
-    ON ~> expression
+  protected lazy val rangeJoinedRelation: Parser[LogicalPlan] =
+    relationFactor ~ RANGEJOIN ~ relationFactor ~ ON ~ OVERLAPS ~
+      "(" ~ "(" ~ expression ~ "," ~ expression ~ ")" ~ "," ~
+      "(" ~ expression ~ "," ~ expression ~ ")" ~ ")" ^^ {
+      case r1 ~ _ ~ r2 ~ _ ~ _ ~ _ ~ _ ~ e1 ~ _ ~ e2 ~ _ ~ _ ~ _ ~ e3 ~ _ ~ e4 ~ _ ~ _ =>
+        RangeJoin(r1, r2, Seq(e1,e2,e3,e4))
+    }
+
+   protected lazy val joinConditions: Parser[Expression] =
+     ON ~> expression
+
+  protected lazy val rangeJoinConditions: Parser[Seq[Expression]] = repN(4, projection)
 
   protected lazy val joinType: Parser[JoinType] =
     ( INNER           ^^^ Inner
@@ -291,7 +304,8 @@ class SqlParser extends AbstractSparkSQLParser {
         }
     | (SUBSTR | SUBSTRING) ~ "(" ~> expression ~ ("," ~> expression) <~ ")" ^^
       { case s ~ p => Substring(s, p, Literal(Integer.MAX_VALUE)) }
-    | (SUBSTR | SUBSTRING) ~ "(" ~> expression ~ ("," ~> expression) ~ ("," ~> expression) <~ ")" ^^
+    | (SUBSTR | SUBSTRING) ~ "(" ~> expression ~ ("," ~> expression) ~
+      ("," ~> expression) <~ ")" ^^
       { case s ~ p ~ l => Substring(s, p, l) }
     | SQRT  ~ "(" ~> expression <~ ")" ^^ { case exp => Sqrt(exp) }
     | ABS   ~ "(" ~> expression <~ ")" ^^ { case exp => Abs(exp) }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicOperators.scala
@@ -95,6 +95,16 @@ case class Join(
   }
 }
 
+case class RangeJoin(
+  left: LogicalPlan,
+  right: LogicalPlan,
+  condition: Seq[Expression]) extends BinaryNode{
+
+  override def output = {
+    left.output ++ right.output
+  }
+}
+
 case class Except(left: LogicalPlan, right: LogicalPlan) extends BinaryNode {
   def output = left.output
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -303,6 +303,7 @@ class SQLContext(@transient val sparkContext: SparkContext)
       ParquetOperations ::
       BasicOperators ::
       CartesianProduct ::
+      RangeJoin ::
       BroadcastNestedLoopJoin :: Nil
 
     /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/IntervalTree.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/IntervalTree.scala
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+class IntervalTree[T](allRegions: List[(Interval[Long], T)]) extends Serializable {
+
+  val root = new Node(allRegions)
+
+  def getAllOverlappings(r: Interval[Long]) = allOverlappingRegions(r, root)
+
+  private def allOverlappingRegions(r: Interval[Long], rt: Node): List[(Interval[Long], T)] = {
+    if (rt == null) {
+      return Nil
+    }
+    val resultFromThisNode = r match {
+      case x if (rt.inclusiveIntervals == Nil) => Nil // Sometimes a node can have zero intervals
+      // Save unnecessary filtering
+      case x if (x.end < rt.minPointOfCollection || x.start > rt.maxPointOfCollection) => Nil
+      case _ => rt.inclusiveIntervals.filter(t => r.overlaps(t._1))
+    }
+    if (r.overlaps(Interval[Long](rt.centerPoint, rt.centerPoint + 1))) {
+      return resultFromThisNode ++ allOverlappingRegions(r, rt.leftChild) ++
+        allOverlappingRegions(r, rt.rightChild)
+    }
+    else if (r.end <= rt.centerPoint) {
+      return resultFromThisNode ++ allOverlappingRegions(r, rt.leftChild)
+    }
+    else if (r.start > rt.centerPoint) {
+      return resultFromThisNode ++ allOverlappingRegions(r, rt.rightChild)
+    }
+    else throw new NoSuchElementException("Interval Tree Exception. Illegal " +
+      "comparison for centerpoint " + rt.centerPoint + " " + r.toString + " cmp: " +
+      r.overlaps(Interval[Long](rt.centerPoint, rt.centerPoint + 1)))
+  }
+
+  class Node(allRegions: List[(Interval[Long], T)]) extends Serializable {
+    private val largestPoint = allRegions.maxBy(_._1.end)._1.end
+    private val smallestPoint = allRegions.minBy(_._1.start)._1.start
+    val centerPoint = smallestPoint + (largestPoint - smallestPoint) / 2
+    val (inclusiveIntervals, leftChild, rightChild) = distributeRegions()
+    val minPointOfCollection: Long = inclusiveIntervals match {
+      case Nil => -1
+      case _ => inclusiveIntervals.minBy(_._1.start)._1.start
+    }
+    val maxPointOfCollection: Long = inclusiveIntervals match {
+      case Nil => -1
+      case _ => inclusiveIntervals.maxBy(_._1.end)._1.end
+    }
+
+    def distributeRegions() = {
+      var leftRegions: List[(Interval[Long], T)] = Nil
+      var rightRegions: List[(Interval[Long], T)] = Nil
+      var centerRegions: List[(Interval[Long], T)] = Nil
+      allRegions.foreach(x => {
+        if (x._1.end < centerPoint) leftRegions ::= x
+        else if (x._1.start > centerPoint) rightRegions ::= x
+        else centerRegions ::= x
+      } )
+      val leftChild: Node = leftRegions match {
+        case Nil => null
+        case _ => new Node(leftRegions)
+      }
+      val rightChild: Node = rightRegions match {
+        case Nil => null
+        case _ => new Node(rightRegions)
+      }
+      (centerRegions, leftChild, rightChild)
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/RangeJoinImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/RangeJoinImpl.scala
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.{sql, SparkContext}
+import org.apache.spark.SparkContext._
+
+object RangeJoinImpl extends Serializable {
+
+  /**
+   * Multi-joins together two RDDs that contain objects that map to reference regions.
+   * The elements from the first RDD become the key of the output RDD, and the value
+   * contains all elements from the second RDD which overlap the region of the key.
+   * This is a multi-join, so it preserves n-to-m relationships between regions.
+   *
+   * @param sc A spark context from the cluster that will perform the join
+   * @param rdd1 RDD of values on which we build an interval tree. Assume |rdd1| < |rdd2|
+   */
+  def overlapJoin(sc: SparkContext,
+                  rdd1: RDD[(Interval[Long], sql.Row)],
+                  rdd2: RDD[(Interval[Long], sql.Row)]): RDD[(sql.Row, Iterable[sql.Row])] = {
+
+    val indexedRdd1 = rdd1.zipWithIndex().map(_.swap)
+
+    /* Collect only Reference regions and the index of indexedRdd1 */
+    val localIntervals = indexedRdd1.map(x => (x._2._1, x._1)).collect()
+    /* Create and broadcast an interval tree */
+    val intervalTree = sc.broadcast(new IntervalTree[Long](localIntervals.toList))
+
+    val kvrdd2: RDD[(Long, Iterable[sql.Row])] = rdd2
+      // join entry with the intervals returned from the interval tree
+      .map(x => (intervalTree.value.getAllOverlappings(x._1), x._2))
+      .filter(x => x._1 != Nil) // filter out entries that do not join anywhere
+      .flatMap(t => t._1.map(s => (s._2, t._2))) // create pairs of (index1, rdd2Elem)
+      .groupByKey
+
+    val ret = indexedRdd1 // this is RDD[(Long, (Interval[Long], Row))]
+      .map(x => (x._1, x._2._2)) // convert it to (Long, Row)
+      .join(kvrdd2) // join produces RDD[(Long, (Row, Iterable[Row]))]
+      .map(_._2) // end up with RDD[(Row, Iterable[Row])]
+    ret
+  }
+
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/RangeJoins.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/RangeJoins.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.SQLContext
+
+@DeveloperApi
+case class RangeJoin(left: SparkPlan,
+                     right: SparkPlan,
+                     condition: Seq[Expression],
+                     context: SQLContext) extends BinaryNode with Serializable {
+  def output = left.output ++ right.output
+
+  lazy val (buildPlan, streamedPlan) = (left, right)
+
+  lazy val (buildKeys, streamedKeys) = (List(condition(0), condition(1)),
+    List(condition(2), condition(3)))
+
+  @transient lazy val buildKeyGenerator = new InterpretedProjection(buildKeys, buildPlan.output)
+  @transient lazy val streamKeyGenerator = new InterpretedProjection(streamedKeys,
+    streamedPlan.output)
+
+  def execute() = {
+    val v1 = left.execute()
+    val v1kv = v1.map(x => {
+      val v1Key = buildKeyGenerator(x)
+      (new Interval[Long](v1Key.apply(0).asInstanceOf[Long], v1Key.apply(1).asInstanceOf[Long]),
+        x.copy())
+    } )
+    val v2 = right.execute()
+    val v2kv = v2.map(x => {
+      val v2Key = streamKeyGenerator(x)
+      (new Interval[Long](v2Key.apply(0).asInstanceOf[Long], v2Key.apply(1).asInstanceOf[Long]),
+        x.copy())
+    } )
+    /* As we are going to collect v1 and build an interval tree on its intervals,
+    make sure that its size is the smaller one. */
+    assert(v1.count <= v2.count)
+    val v3 = RangeJoinImpl.overlapJoin(context.sparkContext, v1kv, v2kv)
+      .flatMap(l => l._2.map(r => (l._1, r)))
+    val v4 = v3.map {
+      case (l: Row, r: Row) => new JoinedRow(l, r).withLeft(l)
+    }
+    v4
+  }
+}
+
+case class Interval[T <% Long](start: T, end: T) {
+  def overlaps(other: Interval[T]): Boolean = {
+    (end >= start) && (other.end >= other.start) &&
+      (end > other.start && start < other.end)
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -102,6 +102,13 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
     }
   }
 
+  object RangeJoin extends Strategy {
+    def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
+      case logical.RangeJoin(left, right, condition) =>
+        execution.RangeJoin(planLater(left), planLater(right), condition, sqlContext) :: Nil
+    }
+  }
+
   object HashAggregation extends Strategy {
     def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
       // Aggregations that can be performed in two phases, before and after the shuffle.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLRangeJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLRangeJoinSuite.scala
@@ -1,0 +1,67 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution
+
+import org.apache.spark.sql.{SQLContext, QueryTest}
+import org.apache.spark.sql.test._
+
+case class RecordData1(start1: Long, end1: Long) extends Serializable
+case class RecordData2(start2: Long, end2: Long) extends Serializable
+
+class SQLRangeJoinSuite extends QueryTest {
+  val sc = TestSQLContext.sparkContext
+  val sqlContext = new SQLContext(sc)
+  import sqlContext._
+
+  test("joining non overlappings results into no entries") {
+    val rdd1 = sc.parallelize(Seq((1L, 5L), (2L, 7L))).map(i => RecordData1(i._1, i._2))
+    val rdd2 = sc.parallelize(Seq((11L, 44L), (23L, 45L))).map(i => RecordData2(i._1, i._2))
+    rdd1.registerTempTable("t1")
+    rdd2.registerTempTable("t2")
+    checkAnswer(
+      sql("select * from t1 RANGEJOIN t2 on OVERLAPS( (start1, end1), (start2, end2))"),
+      Nil
+    )
+  }
+
+  test("basic range join") {
+    val rdd1 = sc.parallelize(Seq((100L, 199L),
+      (200L, 299L),
+      (400L, 600L),
+      (10000L, 20000L)))
+      .map(i => RecordData1(i._1, i._2))
+    val rdd2 = sc.parallelize(Seq((150L, 250L),
+      (300L, 500L),
+      (500L, 700L),
+      (22000L, 22300L)))
+      .map(i => RecordData2(i._1, i._2))
+    rdd1.registerTempTable("s1")
+    rdd2.registerTempTable("s2")
+    checkAnswer(
+      sql("select start1, end1, start2, end2 from s1 RANGEJOIN s2 on OVERLAPS( (start1, end1), (start2, end2))"),
+      (100L, 199L, 150L, 250L) ::
+        (200L, 299L, 150L, 250L) ::
+        (400L, 600L, 300L, 500L) ::
+        (400L, 600L, 500L, 700L) :: Nil
+    )
+    checkAnswer(
+      sql("select end1 from s1 RANGEJOIN s2 on OVERLAPS( (start1, end1), (start2, end2))"),
+      Seq(199L) :: Seq(299L) :: Seq(600L) :: Seq(600L) :: Nil
+    )
+  }
+}


### PR DESCRIPTION
This PR enables spark-sql to join two tables based on the interval overlapping between their columns. This is a very useful feature to add as you can see here: https://issues.apache.org/jira/browse/HIVE-556

Syntax:
select \* from table1 RANGEJOIN table2 on OVERLAPS( (t1Attribute1, t1Attribute2), (t2Attribute1, t2Attribute2))

Example:
Table1 (id : String, start1: Int, end1: Int) = (  ("i1", 10,20), ("i2", 50, 60) )
Table2(start2: Int, end2: Int) = (  (15,70), (80, 90) )
select \* from Table1 RANGEJOIN Table2 on OVERLAPS( (start1, end1), (start2, end2) ) produces the following entries:
("i1", 10, 20, 15, 70), ("i2", 50, 60, 15, 70)

Method:
Assuming rdd1 corresponds to the smaller table and rdd2 to the bigger one, I create an interval tree from all regions of rdd1 which I broadcast to all nodes and I query the tree with all entries of rdd2.

Note that the interval tree uses metadata only, not all contents of rdd1. I keep track of the correspondence between the contents of interval tree and rdd1 through a collection of keys that I zipped with rdd1.
