### PR TITLE
[SPARK-4088] [PySpark] Python worker should exit after socket is closed by JVM

### DIFF
--- a/python/pyspark/daemon.py
+++ b/python/pyspark/daemon.py
@@ -62,8 +62,7 @@ def worker(sock):
         exit_code = compute_real_exit_code(exc.code)
     finally:
         outfile.flush()
-        if exit_code:
-            os._exit(exit_code)
+    return exit_code
 
 
 # Cleanup zombie children
@@ -160,10 +159,13 @@ def manager():
                         outfile.flush()
                         outfile.close()
                         while True:
-                            worker(sock)
-                            if not reuse:
+                            code = worker(sock)
+                            if not reuse or code:
                                 # wait for closing
-                                while sock.recv(1024):
+                                try:
+                                    while sock.recv(1024):
+                                        pass
+                                except Exception:
                                     pass
                                 break
                             gc.collect()


### PR DESCRIPTION
In case of take() or exception in Python, python worker may exit before JVM read() all the response, then the write thread may raise "Connection reset" exception.

Python should always wait JVM to close the socket first.

cc @JoshRosen This is a warm fix, or the tests will be flaky, sorry for that.
