### PR TITLE
[SPARK-4089][Doc][Minor] The version number of Spark in _config.yaml is wrong.

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -11,10 +11,10 @@ kramdown:
 include:
   - _static
 
-# These allow the documentation to be updated with nerw releases
+# These allow the documentation to be updated with newer releases
 # of Spark, Scala, and Mesos.
-SPARK_VERSION: 1.0.0-SNAPSHOT
-SPARK_VERSION_SHORT: 1.0.0
+SPARK_VERSION: 1.2.0-SNAPSHOT
+SPARK_VERSION_SHORT: 1.2.0
 SCALA_BINARY_VERSION: "2.10"
 SCALA_VERSION: "2.10.4"
 MESOS_VERSION: 0.18.1


### PR DESCRIPTION
The version number of Spark in docs/_config.yaml for master branch should be 1.2.0 for now.
