### PR TITLE
[SPARK-4091][Core] Don't delete spark local directories twice

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
@@ -140,7 +140,6 @@ private[spark] class DiskBlockManager(blockManager: BlockManager, conf: SparkCon
   }
 
   private def addShutdownHook() {
-    localDirs.foreach(localDir => Utils.registerShutdownDeleteDir(localDir))
     Runtime.getRuntime.addShutdownHook(new Thread("delete Spark local dirs") {
       override def run(): Unit = Utils.logUncaughtExceptions {
         logDebug("Shutdown hook called")


### PR DESCRIPTION
(This PR should fix the flaky `CliSuite` which frequently fails Jenkins builds recently.)

Temporary local directories created by `DiskBlockManager` are asked to be deleted at two places:
1. in `DiskBlockManager.addShutdownHook()`
2. in `DiskBlockManager.stop()`

Both of them are executed as shutdown hooks in parallel, and may cause subtle race conditions that makes the 2nd deletion fail. In most cases, this failure is harmless, but when it happens on Jenkins builds that run Spark SQL tests, it fails `CliSuite`.

This PR fixes this issue by only deleting these temporary directories in `DiskBlockManager.stop()`.
