### PR TITLE
[HOTFIX][SQL] Temporarily turn of hive-server tests.

### DIFF
--- a/dev/run-tests
+++ b/dev/run-tests
@@ -173,7 +173,7 @@ CURRENT_BLOCK=$BLOCK_SPARK_UNIT_TESTS
   if [ -n "$_SQL_TESTS_ONLY" ]; then
     # This must be an array of individual arguments. Otherwise, having one long string
     #+ will be interpreted as a single test, which doesn't work.
-    SBT_MAVEN_TEST_ARGS=("catalyst/test" "sql/test" "hive/test" "hive-thriftserver/test")
+    SBT_MAVEN_TEST_ARGS=("catalyst/test" "sql/test" "hive/test")
   else
     SBT_MAVEN_TEST_ARGS=("test")
   fi


### PR DESCRIPTION
The thirift server is not available in the default (hive13) profile yet which is breaking all SQL only PRs.  This turns off these test until #2685 is merged.
