### PR TITLE
[SPARK-4097] Fix the race condition of 'thread'

### DIFF
--- a/core/src/main/scala/org/apache/spark/FutureAction.scala
+++ b/core/src/main/scala/org/apache/spark/FutureAction.scala
@@ -210,7 +210,9 @@ class ComplexFutureAction[T] extends FutureAction[T] {
       } catch {
         case e: Exception => p.failure(e)
       } finally {
-        thread = null
+        ComplexFutureAction.this.synchronized {
+          thread = null
+        }
       }
     }
     this

--- a/core/src/main/scala/org/apache/spark/FutureAction.scala
+++ b/core/src/main/scala/org/apache/spark/FutureAction.scala
@@ -210,6 +210,8 @@ class ComplexFutureAction[T] extends FutureAction[T] {
       } catch {
         case e: Exception => p.failure(e)
       } finally {
+        // This lock guarantees when calling `thread.interrupt()` in `cancel`,
+        // thread won't be set to null.
         ComplexFutureAction.this.synchronized {
           thread = null
         }


### PR DESCRIPTION
There is a chance that `thread` is null when calling `thread.interrupt()`.

``` Scala
  override def cancel(): Unit = this.synchronized {
    _cancelled = true
    if (thread != null) {
      thread.interrupt()
    }
  }
```

Should put `thread = null` into a `synchronized` block to fix the race condition.
