### PR TITLE
implement secondary sort: sorting by values in addition to keys

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
@@ -460,6 +460,57 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
   }
 
   /**
+   * Group the values for each key in the RDD and apply a binary operator to a start value and all 
+   * ordered values for a key, going left to right.
+   * 
+   * Note: this operation may be expensive, since there is no map-side combine, so all values are
+   * send through the shuffle.
+   */
+  def foldLeftByKey[U: ClassTag](valueOrdering: Ordering[V], zeroValue: U,
+    partitioner: Partitioner)(func: (U, V) => U): RDD[(K, U)] = {
+    val shuffled = new ShuffledRDD[K, V, V](self, partitioner)
+      .setCombinerOrdering(valueOrdering)
+
+    val zeroBuffer = SparkEnv.get.closureSerializer.newInstance().serialize(zeroValue)
+    val zeroArray = new Array[Byte](zeroBuffer.limit)
+    zeroBuffer.get(zeroArray)
+    lazy val cachedSerializer = SparkEnv.get.closureSerializer.newInstance()
+    val createZero = () => cachedSerializer.deserialize[U](ByteBuffer.wrap(zeroArray))
+
+    new RDD[(K, U)](shuffled) {
+      def compute(split: Partition, context: TaskContext): Iterator[(K, U)] = new Iterator[(K, U)] {
+        private val iter = shuffled.compute(split, context).buffered
+
+        override def hasNext: Boolean = iter.hasNext
+
+        override def next(): (K, U) = {
+          val key = iter.head._1
+          var u = createZero()
+          while (iter.hasNext && iter.head._1 == key)
+            u = func(u, iter.next()._2)
+          (key, u)
+        }
+      }
+
+      protected def getPartitions: Array[Partition] = shuffled.getPartitions
+    }
+  }
+
+  /**
+   * Simplified version of foldLeftByKey that hash-partitions the output RDD.
+   */
+  def foldLeftByKey[U: ClassTag](valueOrdering: Ordering[V], zeroValue: U, numPartitions: Int)(
+    func: (U, V) => U): RDD[(K, U)] =
+    foldLeftByKey(valueOrdering, zeroValue, new HashPartitioner(numPartitions))(func)
+
+  /**
+   * Simplified version of foldLeftByKey that uses the default partitioner.
+   */
+  def foldLeftByKey[U: ClassTag](valueOrdering: Ordering[V], zeroValue: U)(
+    func: (U, V) => U): RDD[(K, U)] =
+    foldLeftByKey(valueOrdering, zeroValue, defaultPartitioner(self))(func)
+
+  /**
    * Return a copy of the RDD partitioned using the specified partitioner.
    */
   def partitionBy(partitioner: Partitioner): RDD[(K, V)] = {

--- a/core/src/main/scala/org/apache/spark/rdd/ShuffledRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ShuffledRDD.scala
@@ -48,6 +48,8 @@ class ShuffledRDD[K, V, C](
 
   private var keyOrdering: Option[Ordering[K]] = None
 
+  private var combinerOrdering: Option[Ordering[C]] = None
+
   private var aggregator: Option[Aggregator[K, V, C]] = None
 
   private var mapSideCombine: Boolean = false
@@ -64,6 +66,12 @@ class ShuffledRDD[K, V, C](
     this
   }
 
+  /** Set combiner ordering for RDD's shuffle. */
+  def setCombinerOrdering(combinerOrdering: Ordering[C]): ShuffledRDD[K, V, C] = {
+    this.combinerOrdering = Option(combinerOrdering)
+    this
+  }
+
   /** Set aggregator for RDD's shuffle. */
   def setAggregator(aggregator: Aggregator[K, V, C]): ShuffledRDD[K, V, C] = {
     this.aggregator = Option(aggregator)
@@ -77,7 +85,9 @@ class ShuffledRDD[K, V, C](
   }
 
   override def getDependencies: Seq[Dependency[_]] = {
-    List(new ShuffleDependency(prev, part, serializer, keyOrdering, aggregator, mapSideCombine))
+    List(new ShuffleDependency(
+      prev, part, serializer, keyOrdering, combinerOrdering, aggregator, mapSideCombine
+    ))
   }
 
   override val partitioner = Some(part)

--- a/core/src/main/scala/org/apache/spark/shuffle/hash/HashShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/hash/HashShuffleReader.scala
@@ -53,11 +53,13 @@ private[spark] class HashShuffleReader[K, C](
     }
 
     // Sort the output if there is a sort ordering defined.
-    dep.keyOrdering match {
-      case Some(keyOrd: Ordering[K]) =>
+    dep.keyCombinerOrdering match {
+      case Some(keyCombinerOrd: Ordering[Product2[K, C]]) =>
         // Create an ExternalSorter to sort the data. Note that if spark.shuffle.spill is disabled,
         // the ExternalSorter won't spill to disk.
-        val sorter = new ExternalSorter[K, C, C](ordering = Some(keyOrd), serializer = Some(ser))
+        val sorter = new ExternalSorter[K, C, C](
+          ordering = Some(keyCombinerOrd),
+          serializer = Some(ser))
         sorter.insertAll(aggregatedIter)
         context.taskMetrics.memoryBytesSpilled += sorter.memoryBytesSpilled
         context.taskMetrics.diskBytesSpilled += sorter.diskBytesSpilled

--- a/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleWriter.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleWriter.scala
@@ -54,7 +54,7 @@ private[spark] class SortShuffleWriter[K, V, C](
         throw new IllegalStateException("Aggregator is empty for map-side combine")
       }
       sorter = new ExternalSorter[K, V, C](
-        dep.aggregator, Some(dep.partitioner), dep.keyOrdering, dep.serializer)
+        dep.aggregator, Some(dep.partitioner), dep.keyCombinerOrdering, dep.serializer)
       sorter.insertAll(records)
     } else {
       // In this case we pass neither an aggregator nor an ordering to the sorter, because we don't

--- a/core/src/main/scala/org/apache/spark/util/Ordering.scala
+++ b/core/src/main/scala/org/apache/spark/util/Ordering.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util
+
+private[spark] class HashOrdering[A] extends Ordering[A] {
+  override def compare(x: A, y: A): Int = {
+    val h1 = if (x == null) 0 else x.hashCode()
+    val h2 = if (y == null) 0 else y.hashCode()
+    if (h1 < h2) -1 else if (h1 == h2) 0 else 1
+  }
+}
+
+private[spark] class NoOrdering[A] extends Ordering[A] {
+  override def compare(x: A, y: A): Int = 0
+}
+
+private [spark] object KeyValueOrdering {
+  implicit def keyValueImplicitOrdering[A, B](
+    implicit ord1: Ordering[A], ord2: Ordering[B]
+  ): KeyValueOrdering[A, B] = new KeyValueOrdering(Some(ord1), Some(ord2))
+}
+
+private[spark] class KeyValueOrdering[A, B](
+  ordering1: Option[Ordering[A]], ordering2: Option[Ordering[B]]
+) extends Ordering[Product2[A, B]] {
+  private val ord1 = ordering1.getOrElse(new HashOrdering[A])
+  private val ord2 = ordering2.getOrElse(new NoOrdering[B])
+
+  override def compare(x: Product2[A, B], y: Product2[A, B]): Int = {
+    val c1 = ord1.compare(x._1, y._1)
+    if (c1 != 0) c1 else ord2.compare(x._2, y._2)
+  }
+}

--- a/core/src/main/scala/org/apache/spark/util/collection/AppendOnlyMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/AppendOnlyMap.scala
@@ -254,7 +254,7 @@ class AppendOnlyMap[K, V](initialCapacity: Int = 64)
    * Return an iterator of the map in sorted order. This provides a way to sort the map without
    * using additional memory, at the expense of destroying the validity of the map.
    */
-  def destructiveSortedIterator(keyComparator: Comparator[K]): Iterator[(K, V)] = {
+  def destructiveSortedIterator(keyValueComparator: Comparator[(K, V)]): Iterator[(K, V)] = {
     destroyed = true
     // Pack KV pairs into the front of the underlying array
     var keyIndex, newIndex = 0
@@ -268,7 +268,8 @@ class AppendOnlyMap[K, V](initialCapacity: Int = 64)
     }
     assert(curSize == newIndex + (if (haveNullValue) 1 else 0))
 
-    new Sorter(new KVArraySortDataFormat[K, AnyRef]).sort(data, 0, newIndex, keyComparator)
+    new Sorter(new KVArraySortDataFormat[(K, V), AnyRef])
+      .sort(data, 0, newIndex, keyValueComparator)
 
     new Iterator[(K, V)] {
       var i = 0

--- a/core/src/main/scala/org/apache/spark/util/collection/SizeTrackingPairBuffer.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/SizeTrackingPairBuffer.scala
@@ -79,8 +79,9 @@ private[spark] class SizeTrackingPairBuffer[K, V](initialCapacity: Int = 64)
   }
 
   /** Iterate through the data in a given order. For this class this is not really destructive. */
-  override def destructiveSortedIterator(keyComparator: Comparator[K]): Iterator[(K, V)] = {
-    new Sorter(new KVArraySortDataFormat[K, AnyRef]).sort(data, 0, curSize, keyComparator)
+  override def destructiveSortedIterator(keyValueComparator: Comparator[(K, V)]): Iterator[(K, V)] =
+  {
+    new Sorter(new KVArraySortDataFormat[(K, V), AnyRef]).sort(data, 0, curSize, keyValueComparator)
     iterator
   }
 }

--- a/core/src/main/scala/org/apache/spark/util/collection/SizeTrackingPairCollection.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/SizeTrackingPairCollection.scala
@@ -30,5 +30,5 @@ private[spark] trait SizeTrackingPairCollection[K, V] extends Iterable[(K, V)] {
   def estimateSize(): Long
 
   /** Iterate through the data in a given key order. This may destroy the underlying collection. */
-  def destructiveSortedIterator(keyComparator: Comparator[K]): Iterator[(K, V)]
+  def destructiveSortedIterator(keyComparator: Comparator[(K, V)]): Iterator[(K, V)]
 }

--- a/core/src/main/scala/org/apache/spark/util/collection/SortDataFormat.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/SortDataFormat.scala
@@ -67,7 +67,8 @@ private[spark] trait SortDataFormat[K, Buffer] extends Any {
 private[spark]
 class KVArraySortDataFormat[K, T <: AnyRef : ClassTag] extends SortDataFormat[K, Array[T]] {
 
-  override protected def getKey(data: Array[T], pos: Int): K = data(2 * pos).asInstanceOf[K]
+  override protected def getKey(data: Array[T], pos: Int): K = 
+    (data(2 * pos), data(2 * pos + 1)).asInstanceOf[K]
 
   override protected def swap(data: Array[T], pos0: Int, pos1: Int) {
     val tmpKey = data(2 * pos0)

--- a/core/src/test/scala/org/apache/spark/rdd/PairRDDFunctionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/PairRDDFunctionsSuite.scala
@@ -552,6 +552,12 @@ class PairRDDFunctionsSuite extends FunSuite with SharedSparkContext {
     intercept[IllegalArgumentException] {shuffled.lookup(-1)}
   }
 
+  test("foldLeftByKey") {
+    val pairs = sc.parallelize(Array((5, (2, 0.5)), (1, (1, 1.2)), (5, (1, 1.0)), (1, (2, 2.0)), (1, (3, 3.0))))
+    val emas = pairs.foldLeftByKey(Ordering.by[(Int, Double), Int](_._1), 0.0){ case (acc, (time, value)) => 0.8 * acc + 0.2 * value }
+    assert(emas.collect.toSet === Set((1,1.0736), (5,0.26)))
+  }
+
   private object StratifiedAuxiliary {
     def stratifier (fractionPositive: Double) = {
       (x: Int) => if (x % 10 < (10 * fractionPositive).toInt) "1" else "0"

--- a/core/src/test/scala/org/apache/spark/util/collection/AppendOnlyMapSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/AppendOnlyMapSuite.scala
@@ -170,10 +170,10 @@ class AppendOnlyMapSuite extends FunSuite {
       case e: IllegalStateException => fail()
     }
 
-    val it = map.destructiveSortedIterator(new Comparator[String] {
-      def compare(key1: String, key2: String): Int = {
-        val x = if (key1 != null) key1.toInt else Int.MinValue
-        val y = if (key2 != null) key2.toInt else Int.MinValue
+    val it = map.destructiveSortedIterator(new Comparator[(String, String)] {
+      def compare(key1: (String, String), key2: (String, String)): Int = {
+        val x = if (key1._1 != null) key1._1.toInt else Int.MinValue
+        val y = if (key2._1 != null) key2._1.toInt else Int.MinValue
         x.compareTo(y)
       }
     })

--- a/core/src/test/scala/org/apache/spark/util/collection/SorterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/SorterSuite.scala
@@ -23,6 +23,7 @@ import java.util.{Arrays, Comparator}
 import org.scalatest.FunSuite
 
 import org.apache.spark.util.random.XORShiftRandom
+import org.apache.spark.util.KeyValueOrdering._
 
 class SorterSuite extends FunSuite {
 
@@ -52,8 +53,8 @@ class SorterSuite extends FunSuite {
       keyValueArray.grouped(2).map { case Array(k, v) => k.doubleValue() -> v.intValue() }.toMap
 
     Arrays.sort(keys)
-    new Sorter(new KVArraySortDataFormat[Double, Number])
-      .sort(keyValueArray, 0, keys.length, Ordering.Double)
+    new Sorter(new KVArraySortDataFormat[Product2[Double, Int], Number])
+      .sort(keyValueArray, 0, keys.length, implicitly[Ordering[Product2[Double, Int]]])
 
     keys.zipWithIndex.foreach { case (k, i) =>
       assert(k === keyValueArray(2 * i))


### PR DESCRIPTION
see:
https://issues.apache.org/jira/browse/SPARK-3655

this is the first of 2 competing pullreqs that try to address this issue. this one does so by modifying spark internal sort routines to support sorting by (key, value) pairs in general, instead of just by key. this is the most "invasive" solution, in that it makes (small) changes to many core functions. but if we think there are other parts of spark that can also benefit of this new sorting capability (besides PairRDDFunctions.PairsfoldLeft which is part of this pullreq) then this could be the appropriate change.
