### PR TITLE
add foldLeftByKey to PairRDDFunctions for reduce algorithms that by key ...

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Ordering.scala
+++ b/core/src/main/scala/org/apache/spark/util/Ordering.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util
+
+private[spark] class HashOrdering[A] extends Ordering[A] {
+  override def compare(x: A, y: A): Int = {
+    val h1 = if (x == null) 0 else x.hashCode()
+    val h2 = if (y == null) 0 else y.hashCode()
+    if (h1 < h2) -1 else if (h1 == h2) 0 else 1
+  }
+}
+
+private[spark] class NoOrdering[A] extends Ordering[A] {
+  override def compare(x: A, y: A): Int = 0
+}
+
+private[spark] class KeyValueOrdering[A, B](
+  ordering1: Option[Ordering[A]], ordering2: Option[Ordering[B]]
+) extends Ordering[(A, B)] {
+  private val ord1 = ordering1.getOrElse(new HashOrdering[A])
+  private val ord2 = ordering2.getOrElse(new NoOrdering[B])
+
+  override def compare(x: (A, B), y: (A, B)): Int = {
+    val c1 = ord1.compare(x._1, y._1)
+    if (c1 != 0) c1 else ord2.compare(x._2, y._2)
+  }
+}

--- a/core/src/test/scala/org/apache/spark/rdd/PairRDDFunctionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/PairRDDFunctionsSuite.scala
@@ -552,6 +552,12 @@ class PairRDDFunctionsSuite extends FunSuite with SharedSparkContext {
     intercept[IllegalArgumentException] {shuffled.lookup(-1)}
   }
 
+  test("foldLeftByKey") {
+    val pairs = sc.parallelize(Array((5, (2, 0.5)), (1, (1, 1.2)), (5, (1, 1.0)), (1, (2, 2.0)), (1, (3, 3.0))))
+    val emas = pairs.foldLeftByKey(Ordering.by[(Int, Double), Int](_._1), 0.0){ case (acc, (time, value)) => 0.8 * acc + 0.2 * value }
+    assert(emas.collect.toSet === Set((1,1.0736), (5,0.26)))
+  }
+
   private object StratifiedAuxiliary {
     def stratifier (fractionPositive: Double) = {
       (x: Int) => if (x % 10 < (10 * fractionPositive).toInt) "1" else "0"

--- a/core/src/test/scala/org/apache/spark/rdd/PairRDDFunctionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/PairRDDFunctionsSuite.scala
@@ -552,6 +552,14 @@ class PairRDDFunctionsSuite extends FunSuite with SharedSparkContext {
     intercept[IllegalArgumentException] {shuffled.lookup(-1)}
   }
 
+  test("groupByKeyAndSortValues") {
+    val pairs = sc.parallelize(Array((5, (2, 0.5)), (1, (1, 1.2)), (5, (1, 1.0)), (1, (2, 2.0)), (1, (3, 3.0))))
+    val emas = pairs.groupByKeyAndSortValues(Ordering.by[(Int, Double), Int](_._1), 2).mapValues{ it => 
+      it.foldLeft(0.0){ case (acc, (time, value)) => 0.8 * acc + 0.2 * value }
+    }
+    assert(emas.collect.toSet === Set((1,1.0736), (5,0.26)))
+  }
+
   test("foldLeftByKey") {
     val pairs = sc.parallelize(Array((5, (2, 0.5)), (1, (1, 1.2)), (5, (1, 1.0)), (1, (2, 2.0)), (1, (3, 3.0))))
     val emas = pairs.foldLeftByKey(Ordering.by[(Int, Double), Int](_._1), 0.0){ case (acc, (time, value)) => 0.8 * acc + 0.2 * value }


### PR DESCRIPTION
...need to process values in a particular order

see:
https://issues.apache.org/jira/browse/SPARK-3655

this is the second of 2 competing pullreqs that try to address this issue. this one does so without making changes to core spark sorting routines. it is based on this suggestion by patrick wendell:
1. Map your RDD[(K, V)] to an RDD[((K, V), null)]
2. Write a custom partitioner that partitions based only on the K component of the key.
3. Call repartitionAndSortWithinPartition with your custom partitioner
4. Map the RDD back into RDD[(K, V)]

the downsides of this approach are that 
1) a little more data goes through the shuffle (one extra object per row), i am not sure if this matters at all
2) the sorting by value is not generalized

the upside is that it's a much simpler and more self-contained change than the other pullreq.
