### PR TITLE
[SPARK-3611] Show number of cores for each executor in application web UI

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/StorageUtils.scala
+++ b/core/src/main/scala/org/apache/spark/storage/StorageUtils.scala
@@ -168,6 +168,9 @@ class StorageStatus(val blockManagerId: BlockManagerId, val maxMem: Long) {
    */
   def numRddBlocksById(rddId: Int): Int = _rddBlocks.get(rddId).map(_.size).getOrElse(0)
 
+  /** Return the number of CPU cores in this block manager. */
+  def numCoresUsed: Int = Runtime.getRuntime.availableProcessors();
+
   /** Return the memory remaining in this block manager. */
   def memRemaining: Long = maxMem - memUsed
 

--- a/core/src/main/scala/org/apache/spark/storage/StorageUtils.scala
+++ b/core/src/main/scala/org/apache/spark/storage/StorageUtils.scala
@@ -169,7 +169,7 @@ class StorageStatus(val blockManagerId: BlockManagerId, val maxMem: Long) {
   def numRddBlocksById(rddId: Int): Int = _rddBlocks.get(rddId).map(_.size).getOrElse(0)
 
   /** Return the number of CPU cores in this block manager. */
-  def numCoresUsed: Int = Runtime.getRuntime.availableProcessors();
+  def numCoresUsed: Int = Runtime.getRuntime.availableProcessors()
 
   /** Return the memory remaining in this block manager. */
   def memRemaining: Long = maxMem - memUsed

--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsPage.scala
@@ -40,7 +40,7 @@ private case class ExecutorSummaryInfo(
     totalShuffleRead: Long,
     totalShuffleWrite: Long,
     maxMemory: Long,
-    numCores:Integer)
+    numCores: Int)
 
 private[ui] class ExecutorsPage(parent: ExecutorsTab) extends WebUIPage("") {
   private val listener = parent.listener
@@ -57,7 +57,7 @@ private[ui] class ExecutorsPage(parent: ExecutorsTab) extends WebUIPage("") {
       <table class={UIUtils.TABLE_CLASS}>
         <thead>
           <th>Executor ID</th>
-          <th>Number of CPU Cores</th>
+          <th>Cores</th>
           <th>Address</th>
           <th>RDD Blocks</th>
           <th>Memory Used</th>
@@ -148,7 +148,7 @@ private[ui] class ExecutorsPage(parent: ExecutorsTab) extends WebUIPage("") {
     val memUsed = status.memUsed
     val maxMem = status.maxMem
     val diskUsed = status.diskUsed
-    val numCores=status.numCoresUsed
+    val numCores = status.numCoresUsed
     val activeTasks = listener.executorToTasksActive.getOrElse(execId, 0)
     val failedTasks = listener.executorToTasksFailed.getOrElse(execId, 0)
     val completedTasks = listener.executorToTasksComplete.getOrElse(execId, 0)

--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsPage.scala
@@ -39,7 +39,8 @@ private case class ExecutorSummaryInfo(
     totalInputBytes: Long,
     totalShuffleRead: Long,
     totalShuffleWrite: Long,
-    maxMemory: Long)
+    maxMemory: Long,
+    numCores:Integer)
 
 private[ui] class ExecutorsPage(parent: ExecutorsTab) extends WebUIPage("") {
   private val listener = parent.listener
@@ -56,6 +57,7 @@ private[ui] class ExecutorsPage(parent: ExecutorsTab) extends WebUIPage("") {
       <table class={UIUtils.TABLE_CLASS}>
         <thead>
           <th>Executor ID</th>
+          <th>Number of CPU Cores</th>
           <th>Address</th>
           <th>RDD Blocks</th>
           <th>Memory Used</th>
@@ -108,6 +110,7 @@ private[ui] class ExecutorsPage(parent: ExecutorsTab) extends WebUIPage("") {
     val diskUsed = info.diskUsed
     <tr>
       <td>{info.id}</td>
+      <td>{info.numCores}</td>
       <td>{info.hostPort}</td>
       <td>{info.rddBlocks}</td>
       <td sorttable_customkey={memoryUsed.toString}>
@@ -145,6 +148,7 @@ private[ui] class ExecutorsPage(parent: ExecutorsTab) extends WebUIPage("") {
     val memUsed = status.memUsed
     val maxMem = status.maxMem
     val diskUsed = status.diskUsed
+    val numCores=status.numCoresUsed
     val activeTasks = listener.executorToTasksActive.getOrElse(execId, 0)
     val failedTasks = listener.executorToTasksFailed.getOrElse(execId, 0)
     val completedTasks = listener.executorToTasksComplete.getOrElse(execId, 0)
@@ -168,7 +172,8 @@ private[ui] class ExecutorsPage(parent: ExecutorsTab) extends WebUIPage("") {
       totalInputBytes,
       totalShuffleRead,
       totalShuffleWrite,
-      maxMem
+      maxMem,
+      numCores
     )
   }
 }


### PR DESCRIPTION
Initial approach to determine total number of cores on the ExecutorsPage. Extends the information recorded by the storage utils.
