### PR TITLE
[SPARK-4137] [EC2] Don't change working dir on user

### DIFF
--- a/ec2/spark-ec2
+++ b/ec2/spark-ec2
@@ -18,5 +18,7 @@
 # limitations under the License.
 #
 
-cd "`dirname $0`"
-PYTHONPATH="./third_party/boto-2.4.1.zip/boto-2.4.1:$PYTHONPATH" python ./spark_ec2.py "$@"
+SPARK_EC2_DIR="$(dirname $0)"
+
+PYTHONPATH="${SPARK_EC2_DIR}/third_party/boto-2.4.1.zip/boto-2.4.1:$PYTHONPATH" \
+    python "${SPARK_EC2_DIR}/spark_ec2.py" "$@"

--- a/ec2/spark-ec2
+++ b/ec2/spark-ec2
@@ -18,6 +18,8 @@
 # limitations under the License.
 #
 
+# Preserve the user's CWD so that relative paths are passed corrently to 
+#+ the underlying Python script.
 SPARK_EC2_DIR="$(dirname $0)"
 
 PYTHONPATH="${SPARK_EC2_DIR}/third_party/boto-2.4.1.zip/boto-2.4.1:$PYTHONPATH" \

--- a/ec2/spark-ec2
+++ b/ec2/spark-ec2
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-# Preserve the user's CWD so that relative paths are passed corrently to 
+# Preserve the user's CWD so that relative paths are passed correctly to 
 #+ the underlying Python script.
 SPARK_EC2_DIR="$(dirname $0)"
 

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -731,7 +731,7 @@ def get_num_disks(instance_type):
 # cluster (e.g. lists of masters and slaves). Files are only deployed to
 # the first master instance in the cluster, and we expect the setup
 # script to be run on that instance to copy them to other nodes.
-# 
+#
 # root_dir should be an absolute path to the directory with the files we want to deploy.
 def deploy_files(conn, root_dir, opts, master_nodes, slave_nodes, modules):
     active_master = master_nodes[0].public_dns_name

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -726,16 +726,14 @@ def get_num_disks(instance_type):
         return 1
 
 
+# Deploy the configuration file templates in a given local directory to
+# a cluster, filling in any template parameters with information about the
+# cluster (e.g. lists of masters and slaves). Files are only deployed to
+# the first master instance in the cluster, and we expect the setup
+# script to be run on that instance to copy them to other nodes.
+# 
+# root_dir should be an absolute path to the directory with the files we want to deploy.
 def deploy_files(conn, root_dir, opts, master_nodes, slave_nodes, modules):
-    """
-    Deploy the configuration file templates in a given local directory to
-    a cluster, filling in any template parameters with information about the
-    cluster (e.g. lists of masters and slaves). Files are only deployed to
-    the first master instance in the cluster, and we expect the setup
-    script to be run on that instance to copy them to other nodes.
-
-    root_dir should be an absolute path to the directory with the files we want to deploy.
-    """
     active_master = master_nodes[0].public_dns_name
 
     num_disks = get_num_disks(opts.instance_type)

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -40,6 +40,7 @@ from boto.ec2.blockdevicemapping import BlockDeviceMapping, BlockDeviceType, EBS
 from boto import ec2
 
 DEFAULT_SPARK_VERSION = "1.1.0"
+SPARK_EC2_DIR = os.path.dirname(os.path.realpath(__file__))
 
 # A URL prefix from which to fetch AMI information
 AMI_PREFIX = "https://raw.github.com/mesos/spark-ec2/v2/ami-list"
@@ -586,7 +587,14 @@ def setup_cluster(conn, master_nodes, slave_nodes, opts, deploy_ssh_key):
     ssh(master, opts, "rm -rf spark-ec2 && git clone https://github.com/mesos/spark-ec2.git -b v4")
 
     print "Deploying files to master..."
-    deploy_files(conn, "deploy.generic", opts, master_nodes, slave_nodes, modules)
+    deploy_files(
+        conn=conn,
+        root_dir=SPARK_EC2_DIR + "/" + "deploy.generic",
+        opts=opts,
+        master_nodes=master_nodes,
+        slave_nodes=slave_nodes,
+        modules=modules
+    )
 
     print "Running setup on master..."
     setup_spark_cluster(master, opts)
@@ -718,12 +726,16 @@ def get_num_disks(instance_type):
         return 1
 
 
-# Deploy the configuration file templates in a given local directory to
-# a cluster, filling in any template parameters with information about the
-# cluster (e.g. lists of masters and slaves). Files are only deployed to
-# the first master instance in the cluster, and we expect the setup
-# script to be run on that instance to copy them to other nodes.
 def deploy_files(conn, root_dir, opts, master_nodes, slave_nodes, modules):
+    """
+    Deploy the configuration file templates in a given local directory to
+    a cluster, filling in any template parameters with information about the
+    cluster (e.g. lists of masters and slaves). Files are only deployed to
+    the first master instance in the cluster, and we expect the setup
+    script to be run on that instance to copy them to other nodes.
+
+    root_dir should be an absolute path to the directory with the files we want to deploy.
+    """
     active_master = master_nodes[0].public_dns_name
 
     num_disks = get_num_disks(opts.instance_type)


### PR DESCRIPTION
This issue was uncovered after [this discussion](https://issues.apache.org/jira/browse/SPARK-3398?focusedCommentId=14187471&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14187471).

Don't change the working directory on the user. This breaks relative paths the user may pass in, e.g., for the SSH identity file.

```
./ec2/spark-ec2 -i ../my.pem
```

This patch will preserve the user's current working directory and allow calls like the one above to work.
