### PR TITLE
Delete jetty 6.1.26 from spark package

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -119,6 +119,7 @@
               <artifact>*:*</artifact>
               <excludes>
                 <exclude>org/datanucleus/**</exclude>
+                <exclude>org/mortbay/**</exclude>
                 <exclude>META-INF/*.SF</exclude>
                 <exclude>META-INF/*.DSA</exclude>
                 <exclude>META-INF/*.RSA</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -604,6 +604,10 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.mortbay.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -786,6 +790,10 @@
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.mortbay.jetty</groupId>
+            <artifactId>jetty</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -812,6 +820,10 @@
           <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.mortbay.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
In spark code, jetty version is 8.1.14.v20131031 (see ./pom.xml). But when building, the jetty-6.1.26 and jetty-util-6.1.26 is packaged in spark-assembly_.jar. So the version 8.1.14.v20131031 and 6.1.26 of jetty are existed in spark-assembly_.jar. I think jetty 6.1.26 is unnecessary.
