### PR TITLE
[SPARK-4129][MLlib] Performance tuning in MultivariateOnlineSummarizer

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/stat/MultivariateOnlineSummarizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/stat/MultivariateOnlineSummarizer.scala
@@ -17,10 +17,10 @@
 
 package org.apache.spark.mllib.stat
 
-import breeze.linalg.{DenseVector => BDV, SparseVector => BSV}
+import breeze.linalg.{DenseVector => BDV}
 
 import org.apache.spark.annotation.DeveloperApi
-import org.apache.spark.mllib.linalg.{Vectors, Vector}
+import org.apache.spark.mllib.linalg.{DenseVector, SparseVector, Vectors, Vector}
 
 /**
  * :: DeveloperApi ::
@@ -91,18 +91,18 @@ class MultivariateOnlineSummarizer extends MultivariateStatisticalSummary with S
       }
     }
 
-    sample.toBreeze match {
-      case dv: BDV[Double] => {
+    sample match {
+      case dv: DenseVector => {
         var j = 0
-        while (j < dv.length) {
-          update(j, dv(j))
+        while (j < dv.size) {
+          update(j, dv.values(j))
           j += 1
         }
       }
-      case sv: BSV[Double] =>
+      case sv: SparseVector =>
         var j = 0
-        while (j < sv.data.length) {
-          update(sv.index(j), sv.data(j))
+        while (j < sv.size) {
+          update(sv.indices(j), sv.values(j))
           j += 1
         }
       case v => throw new IllegalArgumentException("Do not support vector type " + v.getClass)

--- a/mllib/src/main/scala/org/apache/spark/mllib/stat/MultivariateOnlineSummarizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/stat/MultivariateOnlineSummarizer.scala
@@ -101,7 +101,7 @@ class MultivariateOnlineSummarizer extends MultivariateStatisticalSummary with S
       }
       case sv: SparseVector =>
         var j = 0
-        while (j < sv.size) {
+        while (j < sv.indices.size) {
           update(sv.indices(j), sv.values(j))
           j += 1
         }


### PR DESCRIPTION
In MultivariateOnlineSummarizer, breeze's activeIterator is used 
to loop through the nonZero elements in the vector. However, 
activeIterator doesn't perform well due to lots of overhead. 
In this PR, native while loop is used for both DenseVector and SparseVector.

The benchmark result with 20 executors using mnist8m dataset:
Before:
DenseVector: 48.2 seconds
SparseVector: 16.3 seconds

After:
DenseVector: 17.8 seconds
SparseVector: 11.2 seconds

Since MultivariateOnlineSummarizer is used in several places, 
the overall performance gain in mllib library will be significant with this PR.
