### PR TITLE
[SPARK-4000][Build] Uploads HiveCompatibilitySuite logs

### DIFF
--- a/dev/run-tests-jenkins
+++ b/dev/run-tests-jenkins
@@ -101,7 +101,13 @@ function post_message () {
 function send_archived_logs () {
   echo "Archiving unit tests logs..."
 
-  local log_files=$(find . -name "unit-tests.log")
+  local log_files=$(
+    find .\
+      -name "unit-tests.log" -o\
+      -path "./sql/hive/target/HiveCompatibilitySuite.failed" -o\
+      -path "./sql/hive/target/HiveCompatibilitySuite.hiveFailed" -o\
+      -path "./sql/hive/target/HiveCompatibilitySuite.wrong"
+  )
 
   if [ -z "$log_files" ]; then
     echo "> No log files found." >&2


### PR DESCRIPTION
This is a follow up of #2845. In addition to unit-tests.log files, also upload failure output files generated by `HiveCompatibilitySuite` to Jenkins master. These files can be very helpful to debug Hive compatibility test failures.

/cc @pwendell @marmbrus
