### PR TITLE
[SPARK-2189][SQL] Adds dropTempTable API

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/CacheManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/CacheManager.scala
@@ -104,7 +104,9 @@ private[sql] trait CacheManager {
   }
 
   /** Tries to remove the data for the given SchemaRDD from the cache if it's cached */
-  private[sql] def tryUncacheQuery(query: SchemaRDD, blocking: Boolean = true): Boolean = writeLock {
+  private[sql] def tryUncacheQuery(
+      query: SchemaRDD,
+      blocking: Boolean = true): Boolean = writeLock {
     val planToCache = query.queryExecution.analyzed
     val dataIndex = cachedData.indexWhere(cd => planToCache.sameResult(cd.plan))
     val found = dataIndex >= 0

--- a/sql/core/src/main/scala/org/apache/spark/sql/CacheManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/CacheManager.scala
@@ -103,6 +103,17 @@ private[sql] trait CacheManager {
     cachedData.remove(dataIndex)
   }
 
+  /** Tries to remove the data for the given SchemaRDD from the cache if it's cached */
+  private[sql] def tryUncacheQuery(query: SchemaRDD, blocking: Boolean = true): Boolean = writeLock {
+    val planToCache = query.queryExecution.analyzed
+    val dataIndex = cachedData.indexWhere(cd => planToCache.sameResult(cd.plan))
+    val found = dataIndex >= 0
+    if (found) {
+      cachedData(dataIndex).cachedRepresentation.cachedColumnBuffers.unpersist(blocking)
+      cachedData.remove(dataIndex)
+    }
+    found
+  }
 
   /** Optionally returns cached data for the given SchemaRDD */
   private[sql] def lookupCachedData(query: SchemaRDD): Option[CachedData] = readLock {

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -267,6 +267,23 @@ class SQLContext(@transient val sparkContext: SparkContext)
   }
 
   /**
+   * Unregisters the temporary table with the given table name in the catalog. If the table has been
+   * cached/persisted before, it can be unpersisted if required.
+   *
+   * @param tableName the name of the table to be unregistered.
+   * @param unpersist whether to unpersist the table if it has been cached/persisted before.
+   *
+   * @group userf
+   */
+  def unregisterTempTable(tableName: String, unpersist: Boolean = false): Unit = {
+    val schemaRDD = table(tableName)
+    if (unpersist && lookupCachedData(schemaRDD).nonEmpty) {
+      uncacheQuery(schemaRDD)
+    }
+    catalog.unregisterTable(None, tableName)
+  }
+
+  /**
    * Executes a SQL query using Spark, returning the result as a SchemaRDD.  The dialect that is
    * used for SQL parsing can be configured with 'spark.sql.dialect'.
    *

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -277,8 +277,8 @@ class SQLContext(@transient val sparkContext: SparkContext)
    */
   def unregisterTempTable(tableName: String, unpersist: Boolean = false): Unit = {
     val schemaRDD = table(tableName)
-    if (unpersist && lookupCachedData(schemaRDD).nonEmpty) {
-      uncacheQuery(schemaRDD)
+    if (unpersist) {
+      tryUncacheQuery(schemaRDD)
     }
     catalog.unregisterTable(None, tableName)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -267,19 +267,15 @@ class SQLContext(@transient val sparkContext: SparkContext)
   }
 
   /**
-   * Unregisters the temporary table with the given table name in the catalog. If the table has been
-   * cached/persisted before, it can be unpersisted if required.
+   * Drops the temporary table with the given table name in the catalog. If the table has been
+   * cached/persisted before, it's also unpersisted.
    *
    * @param tableName the name of the table to be unregistered.
-   * @param unpersist whether to unpersist the table if it has been cached/persisted before.
    *
    * @group userf
    */
-  def unregisterTempTable(tableName: String, unpersist: Boolean = false): Unit = {
-    val schemaRDD = table(tableName)
-    if (unpersist) {
-      tryUncacheQuery(schemaRDD)
-    }
+  def dropTempTable(tableName: String): Unit = {
+    tryUncacheQuery(table(tableName))
     catalog.unregisterTable(None, tableName)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -244,14 +244,14 @@ class CachedTableSuite extends QueryTest {
     }
   }
 
-  test("Unregister temp table") {
+  test("Drops temporary table") {
     testData.select('key).registerTempTable("t1")
     table("t1")
-    unregisterTempTable("t1")
-    intercept[RuntimeException](table("t1"))
+    dropTempTable("t1")
+    assert(intercept[RuntimeException](table("t1")).getMessage.startsWith("Table Not Found"))
   }
 
-  test("Unregister but don't unpersist temp table") {
+  test("Drops cached temporary table") {
     testData.select('key).registerTempTable("t1")
     testData.select('key).registerTempTable("t2")
     cacheTable("t1")
@@ -259,21 +259,8 @@ class CachedTableSuite extends QueryTest {
     assert(isCached("t1"))
     assert(isCached("t2"))
 
-    unregisterTempTable("t1", unpersist = false)
-
-    assert(isCached("t2"))
-  }
-
-  test("Unregister and unpersist temp table") {
-    testData.select('key).registerTempTable("t1")
-    testData.select('key).registerTempTable("t2")
-    cacheTable("t1")
-
-    assert(isCached("t1"))
-    assert(isCached("t2"))
-
-    unregisterTempTable("t1", unpersist = true)
-
+    dropTempTable("t1")
+    assert(intercept[RuntimeException](table("t1")).getMessage.startsWith("Table Not Found"))
     assert(!isCached("t2"))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -243,4 +243,37 @@ class CachedTableSuite extends QueryTest {
         assert(cached.statistics.sizeInBytes === actualSizeInBytes)
     }
   }
+
+  test("Unregister temp table") {
+    testData.select('key).registerTempTable("t1")
+    table("t1")
+    unregisterTempTable("t1")
+    intercept[RuntimeException](table("t1"))
+  }
+
+  test("Unregister but don't unpersist temp table") {
+    testData.select('key).registerTempTable("t1")
+    testData.select('key).registerTempTable("t2")
+    cacheTable("t1")
+
+    assert(isCached("t1"))
+    assert(isCached("t2"))
+
+    unregisterTempTable("t1", unpersist = false)
+
+    assert(isCached("t2"))
+  }
+
+  test("Unregister and unpersist temp table") {
+    testData.select('key).registerTempTable("t1")
+    testData.select('key).registerTempTable("t2")
+    cacheTable("t1")
+
+    assert(isCached("t1"))
+    assert(isCached("t2"))
+
+    unregisterTempTable("t1", unpersist = true)
+
+    assert(!isCached("t2"))
+  }
 }


### PR DESCRIPTION
This PR adds an API for unregistering temporary tables. If a temporary table has been cached before, it's unpersisted as well.
