### PR TITLE
[SPARK-4161]Spark shell class path is not correctly set if "spark.driver.extraClassPath" is set in defaults.conf.(branch-1.1 backport)

### DIFF
--- a/bin/spark-class
+++ b/bin/spark-class
@@ -107,8 +107,7 @@ else
 fi
 
 # Set JAVA_OPTS to be able to load native libraries and to set heap size
-# SPARK-3936: scala does not assume use of the java classpath, so we need to add the "-Dscala.usejavacp=true"
-JAVA_OPTS="-Dscala.usejavacp=true -XX:MaxPermSize=128m $OUR_JAVA_OPTS"
+JAVA_OPTS="-XX:MaxPermSize=128m $OUR_JAVA_OPTS"
 JAVA_OPTS="$JAVA_OPTS -Xms$OUR_JAVA_MEM -Xmx$OUR_JAVA_MEM"
 
 # Load extra JAVA_OPTS from conf/java-opts, if it exists

--- a/bin/spark-class
+++ b/bin/spark-class
@@ -107,7 +107,7 @@ else
 fi
 
 # Set JAVA_OPTS to be able to load native libraries and to set heap size
-JAVA_OPTS="-XX:MaxPermSize=128m $OUR_JAVA_OPTS"
+JAVA_OPTS="-Dscala.usejavacp=true -XX:MaxPermSize=128m $OUR_JAVA_OPTS"
 JAVA_OPTS="$JAVA_OPTS -Xms$OUR_JAVA_MEM -Xmx$OUR_JAVA_MEM"
 
 # Load extra JAVA_OPTS from conf/java-opts, if it exists

--- a/bin/spark-class
+++ b/bin/spark-class
@@ -107,6 +107,7 @@ else
 fi
 
 # Set JAVA_OPTS to be able to load native libraries and to set heap size
+# SPARK-3936: scala does not assume use of the java classpath, so we need to add the "-Dscala.usejavacp=true"
 JAVA_OPTS="-Dscala.usejavacp=true -XX:MaxPermSize=128m $OUR_JAVA_OPTS"
 JAVA_OPTS="$JAVA_OPTS -Xms$OUR_JAVA_MEM -Xmx$OUR_JAVA_MEM"
 

--- a/bin/spark-shell
+++ b/bin/spark-shell
@@ -45,6 +45,9 @@ source $FWDIR/bin/utils.sh
 SUBMIT_USAGE_FUNCTION=usage
 gatherSparkSubmitOpts "$@"
 
+# SPARK-4161: scala does not assume use of the java classpath, so we need to add the "-Dscala.usejavacp=true"
+SPARK_SUBMIT_OPTS="$SPARK_SUBMIT_OPTS -Dscala.usejavacp=true"
+
 function main() {
   if $cygwin; then
     # Workaround for issue involving JLine and Cygwin


### PR DESCRIPTION
...ath" is set in defaults.conf.(branch-1.1 backport)
