### PR TITLE
[WIP] [SPARK-4198] [Core] Refactor some BlockManager internals

### DIFF
--- a/core/src/main/scala/org/apache/spark/CacheManager.scala
+++ b/core/src/main/scala/org/apache/spark/CacheManager.scala
@@ -45,7 +45,7 @@ private[spark] class CacheManager(blockManager: BlockManager) extends Logging {
       case Some(blockResult) =>
         // Partition is already materialized, so just return its values
         context.taskMetrics.inputMetrics = Some(blockResult.inputMetrics)
-        new InterruptibleIterator(context, blockResult.data.asInstanceOf[Iterator[T]])
+        new InterruptibleIterator(context, blockResult.dataAsIterator().asInstanceOf[Iterator[T]])
 
       case None =>
         // Acquire a lock for loading this partition
@@ -114,7 +114,7 @@ private[spark] class CacheManager(blockManager: BlockManager) extends Logging {
           logInfo(s"Whoever was loading $id failed; we'll try it ourselves")
           loading.add(id)
         }
-        values.map(_.data.asInstanceOf[Iterator[T]])
+        values.map(_.dataAsIterator().asInstanceOf[Iterator[T]])
       }
     }
   }
@@ -144,7 +144,7 @@ private[spark] class CacheManager(blockManager: BlockManager) extends Logging {
       updatedBlocks ++=
         blockManager.putIterator(key, values, level, tellMaster = true, effectiveStorageLevel)
       blockManager.get(key) match {
-        case Some(v) => v.data.asInstanceOf[Iterator[T]]
+        case Some(v) => v.dataAsIterator().asInstanceOf[Iterator[T]]
         case None =>
           logInfo(s"Failure to store $key")
           throw new BlockException(key, s"Block manager failed to return cached value for $key!")

--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -129,7 +129,15 @@ class KryoSerializationStream(kryo: Kryo, outStream: OutputStream) extends Seria
     this
   }
 
-  override def flush() { output.flush() }
+  override def flush() {
+    output.flush()
+    // Kryo does not flush its underlying stream, so let's do that manually to preserve the expected
+    // semantics.
+    val underlyingStream = output.getOutputStream
+    if (underlyingStream != null) {
+      underlyingStream.flush()
+    }
+  }
   override def close() { output.close() }
 }
 

--- a/core/src/main/scala/org/apache/spark/shuffle/hash/BlockStoreShuffleFetcher.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/hash/BlockStoreShuffleFetcher.scala
@@ -23,7 +23,7 @@ import scala.collection.mutable.HashMap
 import org.apache.spark._
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.FetchFailedException
-import org.apache.spark.storage.{BlockId, BlockManagerId, ShuffleBlockFetcherIterator, ShuffleBlockId}
+import org.apache.spark.storage._
 import org.apache.spark.util.CompletionIterator
 
 private[hash] object BlockStoreShuffleFetcher extends Logging {
@@ -77,7 +77,7 @@ private[hash] object BlockStoreShuffleFetcher extends Logging {
       SparkEnv.get.blockManager.shuffleClient,
       blockManager,
       blocksByAddress,
-      serializer,
+      new BlockSerializer(SparkEnv.get.conf, serializer),
       SparkEnv.get.conf.getLong("spark.reducer.maxMbInFlight", 48) * 1024 * 1024)
     val itr = blockFetcherItr.flatMap(unpackBlock)
 

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.storage
 
-import java.io.{BufferedOutputStream, ByteArrayOutputStream, File, InputStream, OutputStream}
+import java.io.{File, OutputStream}
 import java.nio.{ByteBuffer, MappedByteBuffer}
 
 import scala.collection.mutable.{ArrayBuffer, HashMap}
@@ -31,7 +31,6 @@ import sun.nio.ch.DirectBuffer
 
 import org.apache.spark._
 import org.apache.spark.executor._
-import org.apache.spark.io.CompressionCodec
 import org.apache.spark.network._
 import org.apache.spark.network.buffer.{ManagedBuffer, NioManagedBuffer}
 import org.apache.spark.network.netty.{SparkTransportConf, NettyBlockTransferService}
@@ -42,20 +41,6 @@ import org.apache.spark.shuffle.ShuffleManager
 import org.apache.spark.shuffle.hash.HashShuffleManager
 import org.apache.spark.shuffle.sort.SortShuffleManager
 import org.apache.spark.util._
-
-private[spark] sealed trait BlockValues
-private[spark] case class ByteBufferValues(buffer: ByteBuffer) extends BlockValues
-private[spark] case class IteratorValues(iterator: Iterator[Any]) extends BlockValues
-private[spark] case class ArrayValues(buffer: Array[Any]) extends BlockValues
-
-/* Class for returning a fetched block and associated metrics. */
-private[spark] class BlockResult(
-    val data: Iterator[Any],
-    readMethod: DataReadMethod.Value,
-    bytes: Long) {
-  val inputMetrics = new InputMetrics(readMethod)
-  inputMetrics.bytesRead = bytes
-}
 
 private[spark] class BlockManager(
     executorId: String,
@@ -69,6 +54,8 @@ private[spark] class BlockManager(
     blockTransferService: BlockTransferService)
   extends BlockDataManager with Logging {
 
+  val blockSerde = new BlockSerializer(conf, defaultSerializer)
+
   blockTransferService.init(this)
 
   val diskBlockManager = new DiskBlockManager(this, conf)
@@ -77,8 +64,8 @@ private[spark] class BlockManager(
 
   // Actual storage of where blocks are kept
   private var tachyonInitialized = false
-  private[spark] val memoryStore = new MemoryStore(this, maxMemory)
-  private[spark] val diskStore = new DiskStore(this, diskBlockManager)
+  private[spark] val memoryStore = new MemoryStore(conf, blockSerde, this, maxMemory)
+  private[spark] val diskStore = new DiskStore(conf, blockSerde, diskBlockManager)
   private[spark] lazy val tachyonStore: TachyonStore = {
     val storeDir = conf.get("spark.tachyonStore.baseDir", "/tmp_spark_tachyon")
     val appFolderName = conf.get("spark.tachyonStore.folderName")
@@ -87,7 +74,7 @@ private[spark] class BlockManager(
     val tachyonBlockManager =
       new TachyonBlockManager(this, tachyonStorePath, tachyonMaster)
     tachyonInitialized = true
-    new TachyonStore(this, tachyonBlockManager)
+    new TachyonStore(blockSerde, tachyonBlockManager)
   }
 
   private[spark]
@@ -122,15 +109,6 @@ private[spark] class BlockManager(
     blockTransferService
   }
 
-  // Whether to compress broadcast variables that are stored
-  private val compressBroadcast = conf.getBoolean("spark.broadcast.compress", true)
-  // Whether to compress shuffle output that are stored
-  private val compressShuffle = conf.getBoolean("spark.shuffle.compress", true)
-  // Whether to compress RDD partitions that are stored serialized
-  private val compressRdds = conf.getBoolean("spark.rdd.compress", false)
-  // Whether to compress shuffle output temporarily spilled to disk
-  private val compressShuffleSpill = conf.getBoolean("spark.shuffle.spill.compress", true)
-
   private val slaveActor = actorSystem.actorOf(
     Props(new BlockManagerSlaveActor(this, mapOutputTracker)),
     name = "BlockManagerActor" + BlockManager.ID_GENERATOR.next)
@@ -151,13 +129,6 @@ private[spark] class BlockManager(
   private var lastPeerFetchTime = 0L
 
   initialize()
-
-  /* The compression codec to use. Note that the "lazy" val is necessary because we want to delay
-   * the initialization of the compression codec until it is first used. The reason is that a Spark
-   * program could be using a user-defined codec in a third party jar, which is loaded in
-   * Executor.updateDependencies. When the BlockManager is initialized, user level jars hasn't been
-   * loaded yet. */
-  private lazy val compressionCodec: CompressionCodec = CompressionCodec.createCodec(conf)
 
   /**
    * Construct a BlockManager with a memory limit set based on system properties.
@@ -282,14 +253,8 @@ private[spark] class BlockManager(
     if (blockId.isShuffle) {
       shuffleManager.shuffleBlockManager.getBlockData(blockId.asInstanceOf[ShuffleBlockId])
     } else {
-      val blockBytesOpt = doGetLocal(blockId, asBlockResult = false)
-        .asInstanceOf[Option[ByteBuffer]]
-      if (blockBytesOpt.isDefined) {
-        val buffer = blockBytesOpt.get
-        new NioManagedBuffer(buffer)
-      } else {
-        throw new BlockNotFoundException(blockId.toString)
-      }
+      getLocal(blockId).map(block => new NioManagedBuffer(block.dataAsBytes()))
+        .getOrElse(throw new BlockNotFoundException(blockId.toString))
     }
   }
 
@@ -407,31 +372,6 @@ private[spark] class BlockManager(
    */
   def getLocal(blockId: BlockId): Option[BlockResult] = {
     logDebug(s"Getting local block $blockId")
-    doGetLocal(blockId, asBlockResult = true).asInstanceOf[Option[BlockResult]]
-  }
-
-  /**
-   * Get block from the local block manager as serialized bytes.
-   */
-  def getLocalBytes(blockId: BlockId): Option[ByteBuffer] = {
-    logDebug(s"Getting local block $blockId as bytes")
-    // As an optimization for map output fetches, if the block is for a shuffle, return it
-    // without acquiring a lock; the disk store never deletes (recent) items so this should work
-    if (blockId.isShuffle) {
-      val shuffleBlockManager = shuffleManager.shuffleBlockManager
-      shuffleBlockManager.getBytes(blockId.asInstanceOf[ShuffleBlockId]) match {
-        case Some(bytes) =>
-          Some(bytes)
-        case None =>
-          throw new BlockException(
-            blockId, s"Block $blockId not found on disk, though it should be")
-      }
-    } else {
-      doGetLocal(blockId, asBlockResult = false).asInstanceOf[Option[ByteBuffer]]
-    }
-  }
-
-  private def doGetLocal(blockId: BlockId, asBlockResult: Boolean): Option[Any] = {
     val info = blockInfo.get(blockId).orNull
     if (info != null) {
       info.synchronized {
@@ -458,14 +398,11 @@ private[spark] class BlockManager(
         // Look for the block in memory
         if (level.useMemory) {
           logDebug(s"Getting block $blockId from memory")
-          val result = if (asBlockResult) {
-            memoryStore.getValues(blockId).map(new BlockResult(_, DataReadMethod.Memory, info.size))
-          } else {
-            memoryStore.getBytes(blockId)
-          }
-          result match {
+          val block = memoryStore.get(blockId)
+          block match {
             case Some(values) =>
-              return result
+              return Some(BlockResult(blockId, values, blockSerde, DataReadMethod.Memory,
+                info.size))
             case None =>
               logDebug(s"Block $blockId not found in memory")
           }
@@ -475,14 +412,10 @@ private[spark] class BlockManager(
         if (level.useOffHeap) {
           logDebug(s"Getting block $blockId from tachyon")
           if (tachyonStore.contains(blockId)) {
-            tachyonStore.getBytes(blockId) match {
-              case Some(bytes) =>
-                if (!asBlockResult) {
-                  return Some(bytes)
-                } else {
-                  return Some(new BlockResult(
-                    dataDeserialize(blockId, bytes), DataReadMethod.Memory, info.size))
-                }
+            tachyonStore.get(blockId) match {
+              case Some(block) =>
+                return Some(BlockResult(blockId, block, blockSerde, DataReadMethod.Memory,
+                  info.size))
               case None =>
                 logDebug(s"Block $blockId not found in tachyon")
             }
@@ -492,52 +425,40 @@ private[spark] class BlockManager(
         // Look for block on disk, potentially storing it back in memory if required
         if (level.useDisk) {
           logDebug(s"Getting block $blockId from disk")
-          val bytes: ByteBuffer = diskStore.getBytes(blockId) match {
-            case Some(b) => b
-            case None =>
-              throw new BlockException(
-                blockId, s"Block $blockId not found on disk, though it should be")
-          }
-          assert(0 == bytes.position())
+          val block: BlockValue = diskStore.get(blockId).getOrElse(
+            throw new BlockException(blockId, s"Block $blockId not found on disk"))
 
           if (!level.useMemory) {
             // If the block shouldn't be stored in memory, we can just return it
-            if (asBlockResult) {
-              return Some(new BlockResult(dataDeserialize(blockId, bytes), DataReadMethod.Disk,
-                info.size))
-            } else {
-              return Some(bytes)
-            }
+            return Some(BlockResult(blockId, block, blockSerde, DataReadMethod.Disk, info.size))
           } else {
             // Otherwise, we also have to store something in the memory store
-            if (!level.deserialized || !asBlockResult) {
+            if (!level.deserialized) {
               /* We'll store the bytes in memory if the block's storage level includes
                * "memory serialized", or if it should be cached as objects in memory
                * but we only requested its serialized bytes. */
-              val copyForMemory = ByteBuffer.allocate(bytes.limit)
-              copyForMemory.put(bytes)
-              memoryStore.putBytes(blockId, copyForMemory, level)
-              bytes.rewind()
-            }
-            if (!asBlockResult) {
-              return Some(bytes)
+              // Why do this copy?
+//              val copyForMemory = ByteBuffer.allocate(bytes.limit)
+//              copyForMemory.put(bytes)
+              memoryStore.put(blockId, block, level)
+              return Some(BlockResult(blockId, block, blockSerde, DataReadMethod.Disk, info.size))
             } else {
-              val values = dataDeserialize(blockId, bytes)
-              if (level.deserialized) {
-                // Cache the values before returning them
-                val putResult = memoryStore.putIterator(
-                  blockId, values, level, returnValues = true, allowPersistToDisk = false)
-                // The put may or may not have succeeded, depending on whether there was enough
-                // space to unroll the block. Either way, the put here should return an iterator.
-                putResult.data match {
-                  case Left(it) =>
-                    return Some(new BlockResult(it, DataReadMethod.Disk, info.size))
-                  case _ =>
-                    // This only happens if we dropped the values back to disk (which is never)
-                    throw new SparkException("Memory store did not return an iterator!")
-                }
-              } else {
-                return Some(new BlockResult(values, DataReadMethod.Disk, info.size))
+              val values = block.asIterator(blockId, blockSerde)
+              // Cache the values before returning them
+              val putResult = memoryStore.putIterator(
+                blockId, values, level, pin = true, allowPersistToDisk = false)
+              // The put may or may not have succeeded, depending on whether there was enough
+              // space to unroll the block. Either way, the put here should return an iterator.
+              putResult match {
+                case SuccessfulPut(stats) =>
+                  val block = memoryStore.getPinned(blockId, unpin = true)
+                  return Some(BlockResult(blockId, block, blockSerde, DataReadMethod.Disk,
+                    info.size))
+
+                case OutOfSpaceFailure(it, stats) =>
+                  val block = IteratorValue(it)
+                  return Some(BlockResult(blockId, block, blockSerde, DataReadMethod.Disk,
+                    info.size))
               }
             }
           }
@@ -554,18 +475,6 @@ private[spark] class BlockManager(
    */
   def getRemote(blockId: BlockId): Option[BlockResult] = {
     logDebug(s"Getting remote block $blockId")
-    doGetRemote(blockId, asBlockResult = true).asInstanceOf[Option[BlockResult]]
-  }
-
-  /**
-   * Get block from remote block managers as serialized bytes.
-   */
-  def getRemoteBytes(blockId: BlockId): Option[ByteBuffer] = {
-    logDebug(s"Getting remote block $blockId as bytes")
-    doGetRemote(blockId, asBlockResult = false).asInstanceOf[Option[ByteBuffer]]
-  }
-
-  private def doGetRemote(blockId: BlockId, asBlockResult: Boolean): Option[Any] = {
     require(blockId != null, "BlockId is null")
     val locations = Random.shuffle(master.getLocations(blockId))
     for (loc <- locations) {
@@ -574,14 +483,8 @@ private[spark] class BlockManager(
         loc.host, loc.port, loc.executorId, blockId.toString).nioByteBuffer()
 
       if (data != null) {
-        if (asBlockResult) {
-          return Some(new BlockResult(
-            dataDeserialize(blockId, data),
-            DataReadMethod.Network,
-            data.limit()))
-        } else {
-          return Some(data)
-        }
+        return Some(BlockResult(blockId, ByteBufferValue(data), blockSerde, DataReadMethod.Network,
+          data.limit()))
       }
       logDebug(s"The value of block $blockId is null")
     }
@@ -613,24 +516,7 @@ private[spark] class BlockManager(
       tellMaster: Boolean = true,
       effectiveStorageLevel: Option[StorageLevel] = None): Seq[(BlockId, BlockStatus)] = {
     require(values != null, "Values is null")
-    doPut(blockId, IteratorValues(values), level, tellMaster, effectiveStorageLevel)
-  }
-
-  /**
-   * A short circuited method to get a block writer that can write data directly to disk.
-   * The Block will be appended to the File specified by filename. Callers should handle error
-   * cases.
-   */
-  def getDiskWriter(
-      blockId: BlockId,
-      file: File,
-      serializer: Serializer,
-      bufferSize: Int,
-      writeMetrics: ShuffleWriteMetrics): BlockObjectWriter = {
-    val compressStream: OutputStream => OutputStream = wrapForCompression(blockId, _)
-    val syncWrites = conf.getBoolean("spark.shuffle.sync", false)
-    new DiskBlockObjectWriter(blockId, file, serializer, bufferSize, compressStream, syncWrites,
-      writeMetrics)
+    doPut(blockId, IteratorValue(values), level, tellMaster, effectiveStorageLevel)
   }
 
   /**
@@ -644,7 +530,7 @@ private[spark] class BlockManager(
       tellMaster: Boolean = true,
       effectiveStorageLevel: Option[StorageLevel] = None): Seq[(BlockId, BlockStatus)] = {
     require(values != null, "Values is null")
-    doPut(blockId, ArrayValues(values), level, tellMaster, effectiveStorageLevel)
+    doPut(blockId, ArrayValue(values), level, tellMaster, effectiveStorageLevel)
   }
 
   /**
@@ -658,8 +544,10 @@ private[spark] class BlockManager(
       tellMaster: Boolean = true,
       effectiveStorageLevel: Option[StorageLevel] = None): Seq[(BlockId, BlockStatus)] = {
     require(bytes != null, "Bytes is null")
-    doPut(blockId, ByteBufferValues(bytes), level, tellMaster, effectiveStorageLevel)
+    bytes.rewind()
+    doPut(blockId, ByteBufferValue(bytes), level, tellMaster, effectiveStorageLevel)
   }
+
 
   /**
    * Put the given block according to the given level in one of the block stores, replicating
@@ -671,11 +559,10 @@ private[spark] class BlockManager(
    */
   private def doPut(
       blockId: BlockId,
-      data: BlockValues,
+      data: BlockValue,
       level: StorageLevel,
       tellMaster: Boolean = true,
-      effectiveStorageLevel: Option[StorageLevel] = None)
-    : Seq[(BlockId, BlockStatus)] = {
+      effectiveStorageLevel: Option[StorageLevel] = None): Seq[(BlockId, BlockStatus)] = {
 
     require(blockId != null, "BlockId is null")
     require(level != null && level.isValid, "StorageLevel is null or invalid")
@@ -683,109 +570,90 @@ private[spark] class BlockManager(
       require(level != null && level.isValid, "Effective StorageLevel is null or invalid")
     }
 
-    // Return value
-    val updatedBlocks = new ArrayBuffer[(BlockId, BlockStatus)]
+    val startTimeMs = System.currentTimeMillis
 
     /* Remember the block's storage level so that we can correctly drop it to disk if it needs
      * to be dropped right after it got put into memory. Note, however, that other threads will
      * not be able to get() this block until we call markReady on its BlockInfo. */
-    val putBlockInfo = {
-      val tinfo = new BlockInfo(level, tellMaster)
-      // Do atomically !
-      val oldBlockOpt = blockInfo.putIfAbsent(blockId, tinfo)
-      if (oldBlockOpt.isDefined) {
-        if (oldBlockOpt.get.waitForReady()) {
-          logWarning(s"Block $blockId already exists on this machine; not re-adding it")
-          return updatedBlocks
-        }
-        // TODO: So the block info exists - but previous attempt to load it (?) failed.
-        // What do we do now ? Retry on it ?
-        oldBlockOpt.get
-      } else {
-        tinfo
-      }
+    val putBlockInfo = obtainBlockInfoLock(blockId, new BlockInfo(level, tellMaster)) match {
+      case None =>
+        logWarning(s"Block $blockId already exists on this machine; not re-adding it")
+        return Seq.empty
+      case Some(info) =>
+        info
     }
-
-    val startTimeMs = System.currentTimeMillis
-
-    /* If we're storing values and we need to replicate the data, we'll want access to the values,
-     * but because our put will read the whole iterator, there will be no values left. For the
-     * case where the put serializes data, we'll remember the bytes, above; but for the case where
-     * it doesn't, such as deserialized storage, let's rely on the put returning an Iterator. */
-    var valuesAfterPut: Iterator[Any] = null
-
-    // Ditto for the bytes after the put
-    var bytesAfterPut: ByteBuffer = null
-
-    // Size of the block in bytes
-    var size = 0L
 
     // The level we actually use to put the block
     val putLevel = effectiveStorageLevel.getOrElse(level)
 
-    // If we're storing bytes, then initiate the replication before storing them locally.
-    // This is faster as data is already serialized and ready to send.
-    val replicationFuture = data match {
-      case b: ByteBufferValues if putLevel.replication > 1 =>
-        // Duplicate doesn't copy the bytes, but just creates a wrapper
-        val bufferView = b.buffer.duplicate()
-        Future { replicate(blockId, bufferView, putLevel) }
-      case _ => null
+    val blockStore: BlockStore = getStoreForLevel(putLevel)
+
+    val shouldReplicate = putLevel.replication > 1
+
+    def doPut(pinBlock: Boolean): UpdatedBlocks = {
+      doPutLocal(blockStore, putBlockInfo, blockId, data, putLevel, tellMaster, pinBlock)
     }
+
+    val updatedBlocks: UpdatedBlocks = if (shouldReplicate) {
+      doReplicateAndPut(blockId, data, blockStore, putLevel, doPut)
+    } else {
+      doPut(pinBlock = false)
+    }
+
+    logDebug("Putting block %s with%s replication took %s"
+      .format(blockId, if (shouldReplicate) "" else "out", Utils.getUsedTimeMs(startTimeMs)))
+
+    updatedBlocks
+  }
+
+  /** Type for a sequence of blocks that were dropped/inserted. */
+  type UpdatedBlocks = Seq[(BlockId, BlockStatus)]
+
+  /**
+   * Performs the actual insertion of the given BlockValue into the local BlockStore. After a
+   * successful put, this will mark the BlockInfo as "ready" so that others may start reading.
+   *
+   * @param tellMaster If true, we will send a message back to the BlockManagerMaster about this
+   *                   block. Typically should be true unless there's a good reason not to be.
+   * @param pinBlock A pinned block is guaranteed not to be evicted until getPinned(unpin = true)
+   *                 is called on the associated BlockStore.
+   * @return Returns the blocks that have been dropped and the single block inserted by this put.
+   */
+  private def doPutLocal(
+      blockStore: BlockStore,
+      putBlockInfo: BlockInfo,
+      blockId: BlockId,
+      data: BlockValue,
+      putLevel: StorageLevel,
+      tellMaster: Boolean,
+      pinBlock: Boolean): UpdatedBlocks = {
+
+    val startTimeMs = System.currentTimeMillis
+
+    // Size of the block in bytes
+    var size = 0L
+
+    val updatedBlocks = new ArrayBuffer[(BlockId, BlockStatus)]
 
     putBlockInfo.synchronized {
       logTrace("Put for block %s took %s to get into synchronized block"
         .format(blockId, Utils.getUsedTimeMs(startTimeMs)))
 
-      var marked = false
+      var success = false
+      var result: PutResult = null
       try {
-        // returnValues - Whether to return the values put
-        // blockStore - The type of storage to put these values into
-        val (returnValues, blockStore: BlockStore) = {
-          if (putLevel.useMemory) {
-            // Put it in memory first, even if it also has useDisk set to true;
-            // We will drop it to disk later if the memory store can't hold it.
-            (true, memoryStore)
-          } else if (putLevel.useOffHeap) {
-            // Use tachyon for off-heap storage
-            (false, tachyonStore)
-          } else if (putLevel.useDisk) {
-            // Don't get back the bytes from put unless we replicate them
-            (putLevel.replication > 1, diskStore)
-          } else {
-            assert(putLevel == StorageLevel.NONE)
-            throw new BlockException(
-              blockId, s"Attempted to put block $blockId without specifying storage level!")
-          }
-        }
-
         // Actually put the values
-        val result = data match {
-          case IteratorValues(iterator) =>
-            blockStore.putIterator(blockId, iterator, putLevel, returnValues)
-          case ArrayValues(array) =>
-            blockStore.putArray(blockId, array, putLevel, returnValues)
-          case ByteBufferValues(bytes) =>
-            bytes.rewind()
-            blockStore.putBytes(blockId, bytes, putLevel)
-        }
-        size = result.size
-        result.data match {
-          case Left (newIterator) if putLevel.useMemory => valuesAfterPut = newIterator
-          case Right (newBytes) => bytesAfterPut = newBytes
-          case _ =>
-        }
+        result = blockStore.put(blockId, data, putLevel, pin = pinBlock)
+        size = result.statistics.size
 
-        // Keep track of which blocks are dropped from memory
-        if (putLevel.useMemory) {
-          result.droppedBlocks.foreach { updatedBlocks += _ }
-        }
+        // Keep track of which blocks are dropped
+        result.statistics.droppedBlocks.foreach { updatedBlocks += _ }
 
         val putBlockStatus = getCurrentBlockStatus(blockId, putBlockInfo)
         if (putBlockStatus.storageLevel != StorageLevel.NONE) {
-          // Now that the block is in either the memory, tachyon, or disk store,
+          // Now that the block is in either the memory, disk, or tachyon store,
           // let other threads read it, and tell the master about it.
-          marked = true
+          success = true
           putBlockInfo.markReady(size)
           if (tellMaster) {
             reportBlockStatus(blockId, putBlockInfo, putBlockStatus)
@@ -795,52 +663,100 @@ private[spark] class BlockManager(
       } finally {
         // If we failed in putting the block to memory/disk, notify other possible readers
         // that it has failed, and then remove it from the block info map.
-        if (!marked) {
+        if (!success) {
           // Note that the remove must happen before markFailure otherwise another thread
           // could've inserted a new BlockInfo before we remove it.
           blockInfo.remove(blockId)
           putBlockInfo.markFailure()
-          logWarning(s"Putting block $blockId failed")
+          logWarning(s"Putting block $blockId failed, put result was: $result")
         }
       }
     }
     logDebug("Put block %s locally took %s".format(blockId, Utils.getUsedTimeMs(startTimeMs)))
+    updatedBlocks
+  }
+
+  /**
+   * Responsible for performing replication of the BlockValue, while invoking the putBlock method.
+   * This method will start replication early if the data starts out as ByteBuffer, or else will
+   * perform replication after storing the block locally.
+   */
+  private def doReplicateAndPut(
+      blockId: BlockId,
+      data: BlockValue,
+      blockStore: BlockStore,
+      putLevel: StorageLevel,
+      putBlock: (Boolean) => UpdatedBlocks): UpdatedBlocks = {
+    // If we're storing bytes, then initiate the replication before storing them locally.
+    // This is faster as data is already serialized and ready to send.
+    val replicationFuture = data match {
+      case b: ByteBufferValue =>
+        // Duplicate doesn't copy the bytes, but just creates a wrapper
+        val bufferView = b.buffer.duplicate()
+        Future { replicate(blockId, bufferView, putLevel) }
+      case _ => null
+    }
+
+    val shouldPin = replicationFuture == null
+    val updatedBlocks = putBlock(shouldPin)
 
     // Either we're storing bytes and we asynchronously started replication, or we're storing
     // values and need to serialize and replicate them now:
-    if (putLevel.replication > 1) {
-      data match {
-        case ByteBufferValues(bytes) =>
-          if (replicationFuture != null) {
-            Await.ready(replicationFuture, Duration.Inf)
-          }
-        case _ =>
-          val remoteStartTime = System.currentTimeMillis
-          // Serialize the block if not already done
-          if (bytesAfterPut == null) {
-            if (valuesAfterPut == null) {
-              throw new SparkException(
-                "Underlying put returned neither an Iterator nor bytes! This shouldn't happen.")
-            }
-            bytesAfterPut = dataSerialize(blockId, valuesAfterPut)
-          }
-          replicate(blockId, bytesAfterPut, putLevel)
-          logDebug("Put block %s remotely took %s"
-            .format(blockId, Utils.getUsedTimeMs(remoteStartTime)))
-      }
-    }
-
-    BlockManager.dispose(bytesAfterPut)
-
-    if (putLevel.replication > 1) {
-      logDebug("Putting block %s with replication took %s"
-        .format(blockId, Utils.getUsedTimeMs(startTimeMs)))
+    if (replicationFuture != null) {
+      Await.ready(replicationFuture, Duration.Inf)
     } else {
-      logDebug("Putting block %s without replication took %s"
-        .format(blockId, Utils.getUsedTimeMs(startTimeMs)))
+      val remoteStartTime = System.currentTimeMillis()
+      blockStore.getPinned(blockId, unpin = true) match {
+        case ByteBufferValue(buffer) =>
+          replicate(blockId, buffer, putLevel)
+        case block =>
+          // If the block was not stored as bytes inherently, turn into a ByteBuffer and dispose
+          // of it afterwards.
+          val buffer = block.asBytes(blockId, blockSerde)
+          replicate(blockId, buffer, putLevel)
+          BlockManager.dispose(buffer)
+      }
+      logDebug(s"Put block $blockId remotely took ${Utils.getUsedTimeMs(remoteStartTime)}")
     }
-
     updatedBlocks
+  }
+
+  /**
+   * Returns an appropriate BlockStore for the given level, which will be the first store we'll try.
+   */
+  private def getStoreForLevel(level: StorageLevel): BlockStore = {
+    if (level.useMemory) {
+      memoryStore
+    } else if (level.useOffHeap) {
+      tachyonStore
+    } else if (level.useDisk) {
+      diskStore
+    } else {
+      assert(level == StorageLevel.NONE)
+      null
+    }
+  }
+
+  /**
+   * Attempts to lock the "BlockInfo" for this block, which would allow us to have uncontested
+   * access for inserting the block's data. The BlockInfo must be eventually released by calling
+   * markReady() so that others may read and write it.
+   * @return Returns None if the BlockInfo already exists, meaning the block is already locked, or
+   *         Some(tinfo) if the caller successfully got the lock.
+   */
+  private def obtainBlockInfoLock(blockId: BlockId, tinfo: BlockInfo): Option[BlockInfo] = {
+    // Do atomically !
+    val oldBlockOpt = blockInfo.putIfAbsent(blockId, tinfo)
+    if (oldBlockOpt.isDefined) {
+      if (oldBlockOpt.get.waitForReady()) {
+        return None
+      }
+      // TODO: So the block info exists - but previous attempt to load it (?) failed.
+      // What do we do now ? Retry on it ?
+      oldBlockOpt
+    } else {
+      Some(tinfo)
+    }
   }
 
   /**
@@ -956,7 +872,7 @@ private[spark] class BlockManager(
    * Read a block consisting of a single object.
    */
   def getSingle(blockId: BlockId): Option[Any] = {
-    get(blockId).map(_.data.next())
+    get(blockId).map(_.dataAsIterator().next())
   }
 
   /**
@@ -978,7 +894,7 @@ private[spark] class BlockManager(
    */
   def dropFromMemory(
       blockId: BlockId,
-      data: Either[Array[Any], ByteBuffer]): Option[BlockStatus] = {
+      data: BlockValue): Option[BlockStatus] = {
 
     logInfo(s"Dropping block $blockId from memory")
     val info = blockInfo.get(blockId).orNull
@@ -1000,12 +916,7 @@ private[spark] class BlockManager(
         // Drop to disk, if storage level requires
         if (level.useDisk && !diskStore.contains(blockId)) {
           logInfo(s"Writing block $blockId to disk")
-          data match {
-            case Left(elements) =>
-              diskStore.putArray(blockId, elements, level, returnValues = false)
-            case Right(bytes) =>
-              diskStore.putBytes(blockId, bytes, level)
-          }
+          diskStore.put(blockId, data, level)
           blockIsUpdated = true
         }
 
@@ -1115,65 +1026,6 @@ private[spark] class BlockManager(
         reportBlockStatus(id, info, status)
       }
     }
-  }
-
-  private def shouldCompress(blockId: BlockId): Boolean = {
-    blockId match {
-      case _: ShuffleBlockId => compressShuffle
-      case _: BroadcastBlockId => compressBroadcast
-      case _: RDDBlockId => compressRdds
-      case _: TempLocalBlockId => compressShuffleSpill
-      case _: TempShuffleBlockId => compressShuffle
-      case _ => false
-    }
-  }
-
-  /**
-   * Wrap an output stream for compression if block compression is enabled for its block type
-   */
-  def wrapForCompression(blockId: BlockId, s: OutputStream): OutputStream = {
-    if (shouldCompress(blockId)) compressionCodec.compressedOutputStream(s) else s
-  }
-
-  /**
-   * Wrap an input stream for compression if block compression is enabled for its block type
-   */
-  def wrapForCompression(blockId: BlockId, s: InputStream): InputStream = {
-    if (shouldCompress(blockId)) compressionCodec.compressedInputStream(s) else s
-  }
-
-  /** Serializes into a stream. */
-  def dataSerializeStream(
-      blockId: BlockId,
-      outputStream: OutputStream,
-      values: Iterator[Any],
-      serializer: Serializer = defaultSerializer): Unit = {
-    val byteStream = new BufferedOutputStream(outputStream)
-    val ser = serializer.newInstance()
-    ser.serializeStream(wrapForCompression(blockId, byteStream)).writeAll(values).close()
-  }
-
-  /** Serializes into a byte buffer. */
-  def dataSerialize(
-      blockId: BlockId,
-      values: Iterator[Any],
-      serializer: Serializer = defaultSerializer): ByteBuffer = {
-    val byteStream = new ByteArrayOutputStream(4096)
-    dataSerializeStream(blockId, byteStream, values, serializer)
-    ByteBuffer.wrap(byteStream.toByteArray)
-  }
-
-  /**
-   * Deserializes a ByteBuffer into an iterator of values and disposes of it when the end of
-   * the iterator is reached.
-   */
-  def dataDeserialize(
-      blockId: BlockId,
-      bytes: ByteBuffer,
-      serializer: Serializer = defaultSerializer): Iterator[Any] = {
-    bytes.rewind()
-    val stream = wrapForCompression(blockId, new ByteBufferInputStream(bytes, true))
-    serializer.newInstance().deserializeStream(stream).asIterator
   }
 
   def stop(): Unit = {

--- a/core/src/main/scala/org/apache/spark/storage/BlockSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockSerializer.scala
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.storage
+
+import java.io.{ByteArrayOutputStream, BufferedOutputStream, InputStream, OutputStream}
+import java.nio.ByteBuffer
+
+import org.apache.spark.SparkConf
+import org.apache.spark.io.CompressionCodec
+import org.apache.spark.serializer.{SerializationStream, DeserializationStream, Serializer}
+import org.apache.spark.util.ByteBufferInputStream
+
+class BlockSerializer(conf: SparkConf, serializer: Serializer) {
+  // Whether to compress broadcast variables that are stored
+  private val compressBroadcast = conf.getBoolean("spark.broadcast.compress", true)
+  // Whether to compress shuffle output that are stored
+  private val compressShuffle = conf.getBoolean("spark.shuffle.compress", true)
+  // Whether to compress RDD partitions that are stored serialized
+  private val compressRdds = conf.getBoolean("spark.rdd.compress", false)
+  // Whether to compress shuffle output temporarily spilled to disk
+  private val compressShuffleSpill = conf.getBoolean("spark.shuffle.spill.compress", true)
+
+  /* The compression codec to use. Note that the "lazy" val is necessary because we want to delay
+   * the initialization of the compression codec until it is first used. The reason is that a Spark
+   * program could be using a user-defined codec in a third party jar, which is loaded in
+   * Executor.updateDependencies. When the BlockManager is initialized, user level jars hasn't been
+   * loaded yet. */
+  private lazy val compressionCodec: CompressionCodec = CompressionCodec.createCodec(conf)
+
+  private def shouldCompress(blockId: BlockId): Boolean = {
+    blockId match {
+      case _: ShuffleBlockId => compressShuffle
+      case _: BroadcastBlockId => compressBroadcast
+      case _: RDDBlockId => compressRdds
+      case _: TempLocalBlockId => compressShuffleSpill
+      case _: TempShuffleBlockId => compressShuffle
+      case _ => false
+    }
+  }
+
+  /**
+   * Wrap an output stream for compression if block compression is enabled for its block type
+   */
+  private def wrapForCompression(blockId: BlockId, s: OutputStream): OutputStream = {
+    if (shouldCompress(blockId)) compressionCodec.compressedOutputStream(s) else s
+  }
+
+  /**
+   * Wrap an input stream for compression if block compression is enabled for its block type
+   */
+  private def wrapForCompression(blockId: BlockId, s: InputStream): InputStream = {
+    if (shouldCompress(blockId)) compressionCodec.compressedInputStream(s) else s
+  }
+
+  /** Serializes into a stream. */
+  def dataSerializeStream(
+                           blockId: BlockId,
+                           outputStream: OutputStream,
+                           values: Iterator[Any]): Unit = {
+    val byteStream = new BufferedOutputStream(outputStream)
+    val ser = serializer.newInstance()
+    ser.serializeStream(wrapForCompression(blockId, byteStream)).writeAll(values).close()
+  }
+
+  /** Serializes into a stream. */
+  def dataSerializeStream(
+                           blockId: BlockId,
+                           outputStream: OutputStream): SerializationStream = {
+    val byteStream = new BufferedOutputStream(outputStream)
+    val ser = serializer.newInstance()
+    ser.serializeStream(wrapForCompression(blockId, byteStream))
+  }
+
+  /** Serializes into a byte buffer. */
+  def dataSerialize(
+                     blockId: BlockId,
+                     values: Iterator[Any]): ByteBuffer = {
+    val byteStream = new ByteArrayOutputStream(4096)
+    dataSerializeStream(blockId, byteStream, values)
+    ByteBuffer.wrap(byteStream.toByteArray)
+  }
+
+  /**
+   * Deserializes a ByteBuffer into an iterator of values and disposes of it when the end of
+   * the iterator is reached.
+   */
+  def dataDeserialize(
+                       blockId: BlockId,
+                       bytes: ByteBuffer): Iterator[Any] = {
+    bytes.rewind()
+    val stream = wrapForCompression(blockId, new ByteBufferInputStream(bytes, true))
+    serializer.newInstance().deserializeStream(stream).asIterator
+  }
+
+  // TODO: Need the default??
+  def dataDeserializeStream(
+                             blockId: BlockId,
+                             inputStream: InputStream): DeserializationStream = {
+    serializer.newInstance().deserializeStream(wrapForCompression(blockId, inputStream))
+  }
+}

--- a/core/src/main/scala/org/apache/spark/storage/BlockStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockStore.scala
@@ -26,37 +26,26 @@ import org.apache.spark.Logging
 /**
  * Abstract class to store blocks.
  */
-private[spark] abstract class BlockStore(val blockManager: BlockManager) extends Logging {
+private[spark] abstract class BlockStore() extends Logging {
 
-  def putBytes(blockId: BlockId, bytes: ByteBuffer, level: StorageLevel): PutResult
-
-  /**
-   * Put in a block and, possibly, also return its content as either bytes or another Iterator.
-   * This is used to efficiently write the values to multiple locations (e.g. for replication).
-   *
-   * @return a PutResult that contains the size of the data, as well as the values put if
-   *         returnValues is true (if not, the result's data field can be null)
-   */
-  def putIterator(
+  def put(
     blockId: BlockId,
-    values: Iterator[Any],
+    value: BlockValue,
     level: StorageLevel,
-    returnValues: Boolean): PutResult
-
-  def putArray(
-    blockId: BlockId,
-    values: Array[Any],
-    level: StorageLevel,
-    returnValues: Boolean): PutResult
+    pin: Boolean = false): PutResult
 
   /**
    * Return the size of a block in bytes.
    */
   def getSize(blockId: BlockId): Long
 
-  def getBytes(blockId: BlockId): Option[ByteBuffer]
+  def get(blockId: BlockId): Option[BlockValue]
 
-  def getValues(blockId: BlockId): Option[Iterator[Any]]
+  def getPinned(blockId: BlockId, unpin: Boolean): BlockValue = {
+    val result = get(blockId).getOrElse(
+      throw new IllegalStateException("Block should have been pinned: " + blockId))
+    result
+  }
 
   /**
    * Remove a block, if it exists.

--- a/core/src/main/scala/org/apache/spark/storage/BlockValue.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockValue.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.storage
+
+import java.nio.ByteBuffer
+
+private[spark] sealed trait BlockValue {
+  def asIterator(blockId: BlockId, blockSerde: BlockSerializer): Iterator[Any]
+  def asBytes(blockId: BlockId, blockSerde: BlockSerializer): ByteBuffer
+}
+
+private[spark] case class ByteBufferValue(buffer: ByteBuffer) extends BlockValue {
+  def asIterator(blockId: BlockId, blockSerde: BlockSerializer): Iterator[Any] = {
+    blockSerde.dataDeserialize(blockId, buffer)
+  }
+  def asBytes(blockId: BlockId, blockSerde: BlockSerializer): ByteBuffer = {
+    buffer
+  }
+}
+
+private[spark] case class IteratorValue(iterator: Iterator[Any]) extends BlockValue {
+  override def asIterator(blockId: BlockId, blockSerde: BlockSerializer): Iterator[Any] = {
+    iterator
+  }
+  override def asBytes(blockId: BlockId, blockSerde: BlockSerializer): ByteBuffer = {
+    blockSerde.dataSerialize(blockId, iterator)
+  }
+}
+
+private[spark] case class ArrayValue(values: Array[Any]) extends BlockValue {
+  override def asIterator(blockId: BlockId, blockSerde: BlockSerializer): Iterator[Any] = {
+    values.iterator
+  }
+  override def asBytes(blockId: BlockId, blockSerde: BlockSerializer): ByteBuffer = {
+    blockSerde.dataSerialize(blockId, values.iterator)
+  }
+}

--- a/core/src/test/scala/org/apache/spark/DistributedSuite.scala
+++ b/core/src/test/scala/org/apache/spark/DistributedSuite.scala
@@ -204,7 +204,7 @@ class DistributedSuite extends FunSuite with Matchers with BeforeAndAfter
     blockManager.master.getLocations(blockId).foreach { cmId =>
       val bytes = blockTransfer.fetchBlockSync(cmId.host, cmId.port, cmId.executorId,
         blockId.toString)
-      val deserialized = blockManager.dataDeserialize(blockId, bytes.nioByteBuffer())
+      val deserialized = blockManager.blockSerde.dataDeserialize(blockId, bytes.nioByteBuffer())
         .asInstanceOf[Iterator[Int]].toList
       assert(deserialized === (1 to 100).toList)
     }

--- a/core/src/test/scala/org/apache/spark/storage/BlockObjectWriterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockObjectWriterSuite.scala
@@ -26,9 +26,11 @@ class BlockObjectWriterSuite extends FunSuite {
   test("verify write metrics") {
     val file = new File("somefile")
     file.deleteOnExit()
+
+    val conf = new SparkConf().set("spark.shuffle.sync", "true")
     val writeMetrics = new ShuffleWriteMetrics()
-    val writer = new DiskBlockObjectWriter(new TestBlockId("0"), file,
-      new JavaSerializer(new SparkConf()), 1024, os => os, true, writeMetrics)
+    val writer = new DiskBlockObjectWriter(conf, new TestBlockId("0"), file,
+      1024, new BlockSerializer(conf, new JavaSerializer(conf)), writeMetrics)
 
     writer.write(Long.box(20))
     // Metrics don't update on every write
@@ -46,10 +48,11 @@ class BlockObjectWriterSuite extends FunSuite {
   test("verify write metrics on revert") {
     val file = new File("somefile")
     file.deleteOnExit()
-    val writeMetrics = new ShuffleWriteMetrics()
-    val writer = new DiskBlockObjectWriter(new TestBlockId("0"), file,
-      new JavaSerializer(new SparkConf()), 1024, os => os, true, writeMetrics)
 
+    val conf = new SparkConf().set("spark.shuffle.sync", "true")
+    val writeMetrics = new ShuffleWriteMetrics()
+    val writer = new DiskBlockObjectWriter(conf, new TestBlockId("0"), file,
+      1024, new BlockSerializer(conf, new JavaSerializer(conf)), writeMetrics)
     writer.write(Long.box(20))
     // Metrics don't update on every write
     assert(writeMetrics.shuffleBytesWritten == 0)

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -93,7 +93,7 @@ class ShuffleBlockFetcherIteratorSuite extends FunSuite {
       transfer,
       blockManager,
       blocksByAddress,
-      new TestSerializer,
+      new BlockSerializer(conf, new TestSerializer),
       48 * 1024 * 1024)
 
     // 3 local blocks fetched in initialization
@@ -160,7 +160,7 @@ class ShuffleBlockFetcherIteratorSuite extends FunSuite {
       transfer,
       blockManager,
       blocksByAddress,
-      new TestSerializer,
+      new BlockSerializer(conf, new TestSerializer),
       48 * 1024 * 1024)
 
     // Exhaust the first block, and then it should be released.
@@ -223,7 +223,7 @@ class ShuffleBlockFetcherIteratorSuite extends FunSuite {
       transfer,
       blockManager,
       blocksByAddress,
-      new TestSerializer,
+      new BlockSerializer(conf, new TestSerializer),
       48 * 1024 * 1024)
 
     // Continue only after the mock calls onBlockFetchFailure

--- a/streaming/src/main/scala/org/apache/spark/streaming/rdd/WriteAheadLogBackedBlockRDD.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/rdd/WriteAheadLogBackedBlockRDD.scala
@@ -93,7 +93,7 @@ class WriteAheadLogBackedBlockRDD[T: ClassTag](
     val blockId = partition.blockId
     blockManager.get(blockId) match {
       case Some(block) => // Data is in Block Manager
-        val iterator = block.data.asInstanceOf[Iterator[T]]
+        val iterator = block.dataAsIterator().asInstanceOf[Iterator[T]]
         logDebug(s"Read partition data of $this from block manager, block $blockId")
         iterator
       case None => // Data not found in Block Manager, grab it from write ahead log file
@@ -106,7 +106,7 @@ class WriteAheadLogBackedBlockRDD[T: ClassTag](
           logDebug(s"Stored partition data of $this into block manager with level $storageLevel")
           dataRead.rewind()
         }
-        blockManager.dataDeserialize(blockId, dataRead).asInstanceOf[Iterator[T]]
+        blockManager.blockSerde.dataDeserialize(blockId, dataRead).asInstanceOf[Iterator[T]]
     }
   }
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/ReceivedBlockHandler.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/ReceivedBlockHandler.scala
@@ -144,9 +144,9 @@ private[streaming] class WriteAheadLogBasedBlockHandler(
     // Serialize the block so that it can be inserted into both
     val serializedBlock = block match {
       case ArrayBufferBlock(arrayBuffer) =>
-        blockManager.dataSerialize(blockId, arrayBuffer.iterator)
+        blockManager.blockSerde.dataSerialize(blockId, arrayBuffer.iterator)
       case IteratorBlock(iterator) =>
-        blockManager.dataSerialize(blockId, iterator)
+        blockManager.blockSerde.dataSerialize(blockId, iterator)
       case ByteBufferBlock(byteBuffer) =>
         byteBuffer
       case _ =>

--- a/streaming/src/test/scala/org/apache/spark/streaming/rdd/WriteAheadLogBackedBlockRDDSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/rdd/WriteAheadLogBackedBlockRDDSuite.scala
@@ -139,7 +139,7 @@ class WriteAheadLogBackedBlockRDDSuite extends FunSuite with BeforeAndAfterAll {
     require(blockData.size === blockIds.size)
     val writer = new WriteAheadLogWriter(new File(dir, Random.nextString(10)).toString, hadoopConf)
     val segments = blockData.zip(blockIds).map { case (data, id) =>
-      writer.write(blockManager.dataSerialize(id, data.iterator))
+      writer.write(blockManager.blockSerde.dataSerialize(id, data.iterator))
     }
     writer.close()
     segments


### PR DESCRIPTION
Main goals of this PR:
- Break up doPut and doGetLocal into component methods which are individually more readable.
- Remove the weird "return bytes or value depending on parameter" in BlockManager.
- Move the block-related Serialization logic out of BlockManager.

Not quite finished and tested, just wanted to get what I have so far up.
