### PR TITLE
[SPARK-2691][Mesos] Support for Mesos DockerInfo

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -15,6 +15,7 @@ TAGS
 RELEASE
 control
 docs
+docker.properties.template
 fairscheduler.xml.template
 spark-defaults.conf.template
 log4j.properties

--- a/.rat-excludes
+++ b/.rat-excludes
@@ -15,6 +15,7 @@ TAGS
 RELEASE
 control
 docs
+docker/spark-mesos
 docker.properties.template
 fairscheduler.xml.template
 spark-defaults.conf.template

--- a/.rat-excludes
+++ b/.rat-excludes
@@ -15,7 +15,6 @@ TAGS
 RELEASE
 control
 docs
-docker/spark-mesos/Dockerfile
 docker.properties.template
 fairscheduler.xml.template
 spark-defaults.conf.template

--- a/.rat-excludes
+++ b/.rat-excludes
@@ -15,7 +15,7 @@ TAGS
 RELEASE
 control
 docs
-docker/spark-mesos
+docker/spark-mesos/*
 docker.properties.template
 fairscheduler.xml.template
 spark-defaults.conf.template

--- a/.rat-excludes
+++ b/.rat-excludes
@@ -15,7 +15,7 @@ TAGS
 RELEASE
 control
 docs
-docker/spark-mesos/*
+docker/spark-mesos/Dockerfile
 docker.properties.template
 fairscheduler.xml.template
 spark-defaults.conf.template

--- a/conf/docker.properties.template
+++ b/conf/docker.properties.template
@@ -1,3 +1,3 @@
-spark.executor.docker.image: amplab/spark-1.1.0
+spark.mesos.executor.docker.image: amplab/spark-1.1.0
 spark.executorEnv.MESOS_NATIVE_LIBRARY: /usr/lib/libmesos.so
 spark.mesos.executor.home: /tmp/spark-1.1.0-bin-hadoop1

--- a/conf/docker.properties.template
+++ b/conf/docker.properties.template
@@ -1,3 +1,3 @@
-spark.mesos.executor.docker.image: amplab/spark-1.1.0
-spark.executorEnv.MESOS_NATIVE_LIBRARY: /usr/lib/libmesos.so
-spark.mesos.executor.home: /tmp/spark-1.1.0-bin-hadoop1
+spark.mesos.executor.docker.image: <image built from `../docker/spark-mesos/Dockerfile`>
+spark.mesos.executor.docker.volumes: /usr/local/lib:/host/usr/local/lib:ro
+spark.mesos.executor.home: /opt/spark

--- a/conf/docker.properties.template
+++ b/conf/docker.properties.template
@@ -1,0 +1,3 @@
+spark.executor.docker.image: amplab/spark-1.1.0
+spark.executorEnv.MESOS_NATIVE_LIBRARY: /usr/lib/libmesos.so
+spark.mesos.executor.home: /tmp/spark-1.1.0-bin-hadoop1

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
@@ -197,16 +197,9 @@ private[spark] class CoarseMesosSchedulerBackend(
             .addResources(createResource("mem",
               MemoryUtils.calculateTotalMemory(sc)))
 
-          sc.conf.getOption("spark.mesos.executor.docker.image").map { image =>
-            val container = task.getContainerBuilder()
-            val volumes = sc.conf
-              .getOption("spark.mesos.executor.docker.volumes")
-              .map(MesosSchedulerBackendUtil.parseVolumesSpec)
-            val portmaps = sc.conf
-              .getOption("spark.mesos.executor.docker.portmaps")
-              .map(MesosSchedulerBackendUtil.parsePortMappingsSpec)
-            MesosSchedulerBackendUtil.withDockerInfo(
-              container, image, volumes = volumes, portmaps = portmaps)
+          sc.conf.getOption("spark.mesos.executor.docker.image").foreach { image =>
+            MesosSchedulerBackendUtil
+              .setupContainerBuilderDockerInfo(image, sc.conf, task.getContainerBuilder())
           }
 
           d.launchTasks(

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
@@ -197,7 +197,7 @@ private[spark] class CoarseMesosSchedulerBackend(
             .addResources(createResource("mem",
               MemoryUtils.calculateTotalMemory(sc)))
 
-          sc.conf.getOption("spark.executor.docker.image").foreach { image =>
+          sc.conf.getOption("spark.executor.docker.image").map { image =>
             val container = task.getContainerBuilder()
             val volumes = sc.conf
               .getOption("spark.executor.docker.volumes")

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
@@ -200,11 +200,11 @@ private[spark] class CoarseMesosSchedulerBackend(
           sc.conf.getOption("spark.executor.docker.image").map { image:String =>
             val container = task.getContainerBuilder()
             val volumes = sc.conf
-                          .getOption("spark.executor.docker.volumes")
-                          .map (MesosSchedulerBackendUtil.parseVolumesSpec _)
+              .getOption("spark.executor.docker.volumes")
+              .map(MesosSchedulerBackendUtil.parseVolumesSpec _)
             val portmaps = sc.conf
-                           .getOption("spark.executor.docker.portmaps")
-                           .map (MesosSchedulerBackendUtil.parsePortMappingsSpec _)
+              .getOption("spark.executor.docker.portmaps")
+              .map(MesosSchedulerBackendUtil.parsePortMappingsSpec _)
             MesosSchedulerBackendUtil.withDockerInfo(container, image,
                                                      volumes  = volumes,
                                                      portmaps = portmaps)

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
@@ -197,21 +197,20 @@ private[spark] class CoarseMesosSchedulerBackend(
             .addResources(createResource("mem",
               MemoryUtils.calculateTotalMemory(sc)))
 
-          sc.conf.getOption("spark.executor.docker.image").map { image:String =>
+          sc.conf.getOption("spark.executor.docker.image").foreach { image =>
             val container = task.getContainerBuilder()
             val volumes = sc.conf
               .getOption("spark.executor.docker.volumes")
-              .map(MesosSchedulerBackendUtil.parseVolumesSpec _)
+              .map(MesosSchedulerBackendUtil.parseVolumesSpec)
             val portmaps = sc.conf
               .getOption("spark.executor.docker.portmaps")
-              .map(MesosSchedulerBackendUtil.parsePortMappingsSpec _)
-            MesosSchedulerBackendUtil.withDockerInfo(container, image,
-                                                     volumes  = volumes,
-                                                     portmaps = portmaps)
+              .map(MesosSchedulerBackendUtil.parsePortMappingsSpec)
+            MesosSchedulerBackendUtil.withDockerInfo(
+              container, image, volumes = volumes, portmaps = portmaps)
           }
 
           d.launchTasks(
-            Collections.singleton(offer.getId),  Collections.singletonList(task.build()), filters)
+            Collections.singleton(offer.getId), Collections.singletonList(task.build()), filters)
         } else {
           // Filter it out
           d.launchTasks(

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
@@ -197,13 +197,13 @@ private[spark] class CoarseMesosSchedulerBackend(
             .addResources(createResource("mem",
               MemoryUtils.calculateTotalMemory(sc)))
 
-          sc.conf.getOption("spark.executor.docker.image").map { image =>
+          sc.conf.getOption("spark.mesos.executor.docker.image").map { image =>
             val container = task.getContainerBuilder()
             val volumes = sc.conf
-              .getOption("spark.executor.docker.volumes")
+              .getOption("spark.mesos.executor.docker.volumes")
               .map(MesosSchedulerBackendUtil.parseVolumesSpec)
             val portmaps = sc.conf
-              .getOption("spark.executor.docker.portmaps")
+              .getOption("spark.mesos.executor.docker.portmaps")
               .map(MesosSchedulerBackendUtil.parsePortMappingsSpec)
             MesosSchedulerBackendUtil.withDockerInfo(
               container, image, volumes = volumes, portmaps = portmaps)

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
@@ -199,8 +199,15 @@ private[spark] class CoarseMesosSchedulerBackend(
 
           sc.conf.getOption("spark.executor.docker.image").map { image:String =>
             val container = task.getContainerBuilder()
-            val volumes = sc.conf.getOption("spark.executor.docker.volumes")
-            MesosSchedulerBackendUtil.withDockerInfo(container, image, volumes)
+            val volumes = sc.conf
+                          .getOption("spark.executor.docker.volumes")
+                          .map (MesosSchedulerBackendUtil.parseVolumesSpec _)
+            val portmaps = sc.conf
+                           .getOption("spark.executor.docker.portmaps")
+                           .map (MesosSchedulerBackendUtil.parsePortMappingsSpec _)
+            MesosSchedulerBackendUtil.withDockerInfo(container, image,
+                                                     volumes  = volumes,
+                                                     portmaps = portmaps)
           }
 
           d.launchTasks(

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
@@ -133,8 +133,15 @@ private[spark] class MesosSchedulerBackend(
 
     sc.conf.getOption("spark.executor.docker.image").map { image:String =>
       val container = executorInfo.getContainerBuilder()
-      val volumes = sc.conf.getOption("spark.executor.docker.volumes")
-      MesosSchedulerBackendUtil.withDockerInfo(container, image, volumes)
+      val volumes = sc.conf
+                    .getOption("spark.executor.docker.volumes")
+                    .map (MesosSchedulerBackendUtil.parseVolumesSpec _)
+      val portmaps = sc.conf
+                     .getOption("spark.executor.docker.portmaps")
+                     .map (MesosSchedulerBackendUtil.parsePortMappingsSpec _)
+      MesosSchedulerBackendUtil.withDockerInfo(container, image,
+                                               volumes  = volumes,
+                                               portmaps = portmaps)
     }
 
     executorInfo.build()

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
@@ -131,13 +131,13 @@ private[spark] class MesosSchedulerBackend(
       .addResources(cpus)
       .addResources(memory)
 
-    sc.conf.getOption("spark.executor.docker.image").map { image:String =>
+    sc.conf.getOption("spark.mesos.executor.docker.image").map { image:String =>
       val container = executorInfo.getContainerBuilder()
       val volumes = sc.conf
-        .getOption("spark.executor.docker.volumes")
+        .getOption("spark.mesos.executor.docker.volumes")
         .map(MesosSchedulerBackendUtil.parseVolumesSpec)
       val portmaps = sc.conf
-        .getOption("spark.executor.docker.portmaps")
+        .getOption("spark.mesos.executor.docker.portmaps")
         .map(MesosSchedulerBackendUtil.parsePortMappingsSpec)
       MesosSchedulerBackendUtil.withDockerInfo(
         container, image, volumes = volumes, portmaps = portmaps)

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
@@ -124,13 +124,63 @@ private[spark] class MesosSchedulerBackend(
         Value.Scalar.newBuilder()
           .setValue(MemoryUtils.calculateTotalMemory(sc)).build())
       .build()
-    MesosExecutorInfo.newBuilder()
+    val executorInfo = ExecutorInfo.newBuilder()
       .setExecutorId(ExecutorID.newBuilder().setValue(execId).build())
       .setCommand(command)
       .setData(ByteString.copyFrom(createExecArg()))
       .addResources(cpus)
       .addResources(memory)
       .build()
+
+    maybeDockerize(executorInfo)
+  }
+
+  private def maybeDockerize(executorInfo: ExecutorInfo): ExecutorInfo = {
+    import org.apache.mesos.Protos.{ContainerInfo, Volume}
+    val image = sc.conf.get("spark.executor.docker.image", null)
+    if(image == null) {
+      return executorInfo
+    } else {
+      val builder = executorInfo.toBuilder()
+      val container = builder.getContainerBuilder()
+        .setType(ContainerInfo.Type.DOCKER)
+      container.setDocker(ContainerInfo.DockerInfo.newBuilder()
+                                                  .setImage(image)
+                                                  .build())
+      def mkVol(p:String,m:Volume.Mode) { 
+        logInfo("ExecutorInfo adding docker volume: " + p 
+               + " with mode " + m)
+        container.addVolumesBuilder().setContainerPath(p).setMode(m) 
+      }
+      def mkMnt(s:String,d:String,m:Volume.Mode) { 
+        logInfo("ExecutorInfo mounting docker container path: " + d 
+               + " from host path: " + s 
+               + " with mode " + m)
+        container.addVolumesBuilder().setContainerPath(d).setHostPath(s).setMode(m)
+      }
+      sc.conf.getOption("spark.executor.docker.volumes").map { 
+        _.split(",").map(_.split(":")).map { 
+          _ match {
+            case Array(container_path) =>
+              mkVol(container_path, Volume.Mode.RW)
+            case Array(container_path, "rw") =>
+              mkVol(container_path, Volume.Mode.RO)
+            case Array(container_path, "ro") =>
+              mkVol(container_path, Volume.Mode.RO)
+            case Array(host_path,container_path) =>
+              mkMnt(host_path, container_path, Volume.Mode.RW)
+            case Array(host_path,container_path,"rw") =>
+              mkMnt(host_path, container_path, Volume.Mode.RW)
+            case Array(host_path,container_path,"ro") =>
+              mkMnt(host_path, container_path, Volume.Mode.RO)
+            case _ => ()
+          }
+        }
+      }
+      logInfo("ExecutorInfo using docker image: " + image)
+      return builder.build()
+    }
+
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
@@ -134,11 +134,11 @@ private[spark] class MesosSchedulerBackend(
     sc.conf.getOption("spark.executor.docker.image").map { image:String =>
       val container = executorInfo.getContainerBuilder()
       val volumes = sc.conf
-                    .getOption("spark.executor.docker.volumes")
-                    .map (MesosSchedulerBackendUtil.parseVolumesSpec _)
+        .getOption("spark.executor.docker.volumes")
+        .map(MesosSchedulerBackendUtil.parseVolumesSpec _)
       val portmaps = sc.conf
-                     .getOption("spark.executor.docker.portmaps")
-                     .map (MesosSchedulerBackendUtil.parsePortMappingsSpec _)
+        .getOption("spark.executor.docker.portmaps")
+        .map(MesosSchedulerBackendUtil.parsePortMappingsSpec _)
       MesosSchedulerBackendUtil.withDockerInfo(container, image,
                                                volumes  = volumes,
                                                portmaps = portmaps)

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
@@ -124,7 +124,7 @@ private[spark] class MesosSchedulerBackend(
         Value.Scalar.newBuilder()
           .setValue(MemoryUtils.calculateTotalMemory(sc)).build())
       .build()
-    val executorInfo = ExecutorInfo.newBuilder()
+    val executorInfo = MesosExecutorInfo.newBuilder()
       .setExecutorId(ExecutorID.newBuilder().setValue(execId).build())
       .setCommand(command)
       .setData(ByteString.copyFrom(createExecArg()))
@@ -135,13 +135,12 @@ private[spark] class MesosSchedulerBackend(
       val container = executorInfo.getContainerBuilder()
       val volumes = sc.conf
         .getOption("spark.executor.docker.volumes")
-        .map(MesosSchedulerBackendUtil.parseVolumesSpec _)
+        .map(MesosSchedulerBackendUtil.parseVolumesSpec)
       val portmaps = sc.conf
         .getOption("spark.executor.docker.portmaps")
-        .map(MesosSchedulerBackendUtil.parsePortMappingsSpec _)
-      MesosSchedulerBackendUtil.withDockerInfo(container, image,
-                                               volumes  = volumes,
-                                               portmaps = portmaps)
+        .map(MesosSchedulerBackendUtil.parsePortMappingsSpec)
+      MesosSchedulerBackendUtil.withDockerInfo(
+        container, image, volumes = volumes, portmaps = portmaps)
     }
 
     executorInfo.build()

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
@@ -131,16 +131,9 @@ private[spark] class MesosSchedulerBackend(
       .addResources(cpus)
       .addResources(memory)
 
-    sc.conf.getOption("spark.mesos.executor.docker.image").map { image:String =>
-      val container = executorInfo.getContainerBuilder()
-      val volumes = sc.conf
-        .getOption("spark.mesos.executor.docker.volumes")
-        .map(MesosSchedulerBackendUtil.parseVolumesSpec)
-      val portmaps = sc.conf
-        .getOption("spark.mesos.executor.docker.portmaps")
-        .map(MesosSchedulerBackendUtil.parsePortMappingsSpec)
-      MesosSchedulerBackendUtil.withDockerInfo(
-        container, image, volumes = volumes, portmaps = portmaps)
+    sc.conf.getOption("spark.mesos.executor.docker.image").foreach { image =>
+      MesosSchedulerBackendUtil
+        .setupContainerBuilderDockerInfo(image, sc.conf, executorInfo.getContainerBuilder())
     }
 
     executorInfo.build()

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtil.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtil.scala
@@ -79,6 +79,7 @@ private[spark] object MesosSchedulerBackendUtil extends Logging {
     portmaps.split(",").map(_.split(":")).map({ spec: Array[String] =>
       val portmap: DockerInfo.PortMapping.Builder = DockerInfo.PortMapping
         .newBuilder()
+        .setProtocol("tcp")
       spec match {
         case Array(host_port, container_port) =>
           Some(portmap.setHostPort(host_port.toInt)

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtil.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtil.scala
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler.cluster.mesos
+
+import org.apache.mesos.Protos.{ContainerInfo, Volume}
+import org.apache.mesos.Protos.ContainerInfo.Builder
+
+/**
+ * A collection of utility functions which can be used by both the
+ * MesosSchedulerBackend and the CoarseMesosSchedulerBackend.
+ */
+private[spark] object MesosSchedulerBackendUtil {
+  def withDockerInfo(container: ContainerInfo.Builder, image: String, volumes: Option[String]) = {
+    container.setType(ContainerInfo.Type.DOCKER)
+    container.setDocker(ContainerInfo.DockerInfo.newBuilder().setImage(image).build())
+
+    def mkVol(p: String, m:Volume.Mode) {
+      container.addVolumesBuilder().setContainerPath(p).setMode(m)
+    }
+
+    def mkMnt(s: String, d: String, m: Volume.Mode) {
+      container.addVolumesBuilder().setContainerPath(d).setHostPath(s).setMode(m)
+    }
+
+    volumes.map {
+      _.split(",").map(_.split(":")).map {
+        _ match {
+          case Array(container_path) =>
+            mkVol(container_path, Volume.Mode.RW)
+          case Array(container_path, "rw") =>
+            mkVol(container_path, Volume.Mode.RW)
+          case Array(container_path, "ro") =>
+            mkVol(container_path, Volume.Mode.RO)
+          case Array(host_path, container_path) =>
+            mkMnt(host_path, container_path, Volume.Mode.RW)
+          case Array(host_path, container_path, "rw") =>
+            mkMnt(host_path, container_path, Volume.Mode.RW)
+          case Array(host_path, container_path, "ro") =>
+            mkMnt(host_path, container_path, Volume.Mode.RO)
+          case _ => ()
+        }
+      }
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtil.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtil.scala
@@ -31,11 +31,11 @@ private[spark] object MesosSchedulerBackendUtil extends Logging {
    * Parse a volume spec in the form passed to 'docker run -v'
    * which is [host-dir:][container-dir][:rw|ro]
    */
-  def parseVolumesSpec(volumes:String):List[Volume] = {
-    volumes.split(",").map(_.split(":")).map({ spec:Array[String] =>
-        val vol:Volume.Builder = Volume
-                                .newBuilder()
-                                .setMode(Volume.Mode.RW)
+  def parseVolumesSpec(volumes: String): List[Volume] = {
+    volumes.split(",").map(_.split(":")).map({ spec: Array[String] =>
+        val vol: Volume.Builder = Volume
+          .newBuilder()
+          .setMode(Volume.Mode.RW)
         spec match {
           case Array(container_path) => 
             Some(vol.setContainerPath(container_path))
@@ -75,10 +75,10 @@ private[spark] object MesosSchedulerBackendUtil extends Logging {
    * anticipates the expansion of the docker form to allow for a protocol
    * and leaves open the chance for mesos to begin to accept an 'ip' field
    */
-  def parsePortMappingsSpec(portmaps:String):List[DockerInfo.PortMapping] = {
-    portmaps.split(",").map(_.split(":")).map({ spec:Array[String] =>
-      val portmap:DockerInfo.PortMapping.Builder = DockerInfo.PortMapping
-                                                   .newBuilder()
+  def parsePortMappingsSpec(portmaps: String): List[DockerInfo.PortMapping] = {
+    portmaps.split(",").map(_.split(":")).map({ spec: Array[String] =>
+      val portmap: DockerInfo.PortMapping.Builder = DockerInfo.PortMapping
+        .newBuilder()
       spec match {
         case Array(host_port, container_port) =>
           Some(portmap.setHostPort(host_port.toInt)

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtil.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtil.scala
@@ -18,43 +18,101 @@
 package org.apache.spark.scheduler.cluster.mesos
 
 import org.apache.mesos.Protos.{ContainerInfo, Volume}
-import org.apache.mesos.Protos.ContainerInfo.Builder
+import org.apache.mesos.Protos.ContainerInfo.DockerInfo
+
+import org.apache.spark.Logging
 
 /**
  * A collection of utility functions which can be used by both the
  * MesosSchedulerBackend and the CoarseMesosSchedulerBackend.
  */
-private[spark] object MesosSchedulerBackendUtil {
-  def withDockerInfo(container: ContainerInfo.Builder, image: String, volumes: Option[String]) = {
-    container.setType(ContainerInfo.Type.DOCKER)
-    container.setDocker(ContainerInfo.DockerInfo.newBuilder().setImage(image).build())
-
-    def mkVol(p: String, m:Volume.Mode) {
-      container.addVolumesBuilder().setContainerPath(p).setMode(m)
-    }
-
-    def mkMnt(s: String, d: String, m: Volume.Mode) {
-      container.addVolumesBuilder().setContainerPath(d).setHostPath(s).setMode(m)
-    }
-
-    volumes.map {
-      _.split(",").map(_.split(":")).map {
-        _ match {
-          case Array(container_path) =>
-            mkVol(container_path, Volume.Mode.RW)
+private[spark] object MesosSchedulerBackendUtil extends Logging {
+  /**
+   * Parse a volume spec in the form passed to 'docker run -v'
+   * which is [host-dir:][container-dir][:rw|ro]
+   */
+  def parseVolumesSpec(volumes:String):List[Volume] = {
+    volumes.split(",").map(_.split(":")).map({ spec:Array[String] =>
+        val vol:Volume.Builder = Volume
+                                .newBuilder()
+                                .setMode(Volume.Mode.RW)
+        spec match {
+          case Array(container_path) => 
+            Some(vol.setContainerPath(container_path))
           case Array(container_path, "rw") =>
-            mkVol(container_path, Volume.Mode.RW)
+            Some(vol.setContainerPath(container_path))
           case Array(container_path, "ro") =>
-            mkVol(container_path, Volume.Mode.RO)
-          case Array(host_path, container_path) =>
-            mkMnt(host_path, container_path, Volume.Mode.RW)
+            Some(vol.setContainerPath(container_path)
+                    .setMode(Volume.Mode.RO))
+          case Array(host_path, container_path) => 
+            Some(vol.setContainerPath(container_path)
+                    .setHostPath(host_path))
           case Array(host_path, container_path, "rw") =>
-            mkMnt(host_path, container_path, Volume.Mode.RW)
+            Some(vol.setContainerPath(container_path)
+                    .setHostPath(host_path))
           case Array(host_path, container_path, "ro") =>
-            mkMnt(host_path, container_path, Volume.Mode.RO)
-          case _ => ()
+            Some(vol.setContainerPath(container_path)
+                    .setHostPath(host_path)
+                    .setMode(Volume.Mode.RO))
+          case spec => {
+            logWarning("parseVolumeSpec: unparseable: " + spec.mkString(":"))
+            None
+          }
+      }
+    })
+    .filter { _.isDefined }
+    .map { _.head.build() }
+    .toList
+  }
+
+  /**
+   * Parse a portmap spec, simmilar to the form passed to 'docker run -p'
+   * the form accepted is host_port:container_port[:proto]
+   * Note:
+   * the docker form is [ip:]host_port:container_port, but the DockerInfo
+   * message has no field for 'ip', and instead has a 'protocol' field.
+   * Docker itself only appears to support TCP, so this alternative form
+   * anticipates the expansion of the docker form to allow for a protocol
+   * and leaves open the chance for mesos to begin to accept an 'ip' field
+   */
+  def parsePortMappingsSpec(portmaps:String):List[DockerInfo.PortMapping] = {
+    portmaps.split(",").map(_.split(":")).map({ spec:Array[String] =>
+      val portmap:DockerInfo.PortMapping.Builder = DockerInfo.PortMapping
+                                                   .newBuilder()
+      spec match {
+        case Array(host_port, container_port) =>
+          Some(portmap.setHostPort(host_port.toInt)
+                      .setContainerPort(container_port.toInt))
+        case Array(host_port, container_port, protocol) =>
+          Some(portmap.setHostPort(host_port.toInt)
+                      .setContainerPort(container_port.toInt)
+                      .setProtocol(protocol))
+        case spec => {
+          logWarning("parsePortMappingSpec: unparseable: " + spec.mkString(":"))
+          None
         }
       }
-    }
+    })
+    .filter { _.isDefined }
+    .map { _.head.build() }
+    .toList
+  }
+
+  def withDockerInfo(
+      container: ContainerInfo.Builder,
+      image: String,
+      volumes: Option[List[Volume]] = None,
+      network: Option[ContainerInfo.DockerInfo.Network] = None,
+      portmaps: Option[List[ContainerInfo.DockerInfo.PortMapping]] = None) = {
+
+    val docker = ContainerInfo.DockerInfo.newBuilder().setImage(image)
+    network.map(docker.setNetwork _)
+    portmaps.map(_.map(docker.addPortMappings _))
+
+    container.setType(ContainerInfo.Type.DOCKER)
+    container.setDocker(docker.build())
+    volumes.map(_.map(container.addVolumes _))
+
+    logInfo("withDockerInfo: using docker image: " + image)
   }
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtil.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtil.scala
@@ -32,7 +32,7 @@ private[spark] object MesosSchedulerBackendUtil extends Logging {
    * which is [host-dir:][container-dir][:rw|ro]
    */
   def parseVolumesSpec(volumes: String): List[Volume] = {
-    volumes.split(",").map(_.split(":")).map({ spec: Array[String] =>
+    volumes.split(",").map(_.split(":")).map { spec: Array[String] =>
         val vol: Volume.Builder = Volume
           .newBuilder()
           .setMode(Volume.Mode.RW)
@@ -59,9 +59,8 @@ private[spark] object MesosSchedulerBackendUtil extends Logging {
             None
           }
       }
-    })
-    .filter { _.isDefined }
-    .map { _.head.build() }
+    }
+    .flatMap { _.map(_.build) }
     .toList
   }
 
@@ -76,7 +75,7 @@ private[spark] object MesosSchedulerBackendUtil extends Logging {
    * and leaves open the chance for mesos to begin to accept an 'ip' field
    */
   def parsePortMappingsSpec(portmaps: String): List[DockerInfo.PortMapping] = {
-    portmaps.split(",").map(_.split(":")).map({ spec: Array[String] =>
+    portmaps.split(",").map(_.split(":")).map { spec: Array[String] =>
       val portmap: DockerInfo.PortMapping.Builder = DockerInfo.PortMapping
         .newBuilder()
         .setProtocol("tcp")
@@ -93,9 +92,8 @@ private[spark] object MesosSchedulerBackendUtil extends Logging {
           None
         }
       }
-    })
-    .filter { _.isDefined }
-    .map { _.head.build() }
+    }
+    .flatMap { _.map(_.build) }
     .toList
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtil.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtil.scala
@@ -32,7 +32,7 @@ private[mesos] object MesosSchedulerBackendUtil extends Logging {
    * which is [host-dir:][container-dir][:rw|ro]
    */
   def parseVolumesSpec(volumes: String): List[Volume] = {
-    volumes.split(",").map(_.split(":")).map { spec =>
+    volumes.split(",").map(_.split(":")).flatMap { spec =>
         val vol: Volume.Builder = Volume
           .newBuilder()
           .setMode(Volume.Mode.RW)
@@ -43,24 +43,24 @@ private[mesos] object MesosSchedulerBackendUtil extends Logging {
             Some(vol.setContainerPath(container_path))
           case Array(container_path, "ro") =>
             Some(vol.setContainerPath(container_path)
-                    .setMode(Volume.Mode.RO))
+              .setMode(Volume.Mode.RO))
           case Array(host_path, container_path) => 
             Some(vol.setContainerPath(container_path)
-                    .setHostPath(host_path))
+              .setHostPath(host_path))
           case Array(host_path, container_path, "rw") =>
             Some(vol.setContainerPath(container_path)
-                    .setHostPath(host_path))
+              .setHostPath(host_path))
           case Array(host_path, container_path, "ro") =>
             Some(vol.setContainerPath(container_path)
-                    .setHostPath(host_path)
-                    .setMode(Volume.Mode.RO))
+              .setHostPath(host_path)
+              .setMode(Volume.Mode.RO))
           case spec => {
             logWarning("parseVolumeSpec: unparseable: " + spec.mkString(":"))
             None
           }
       }
     }
-    .flatMap { _.map(_.build) }
+    .map { _.build() }
     .toList
   }
 
@@ -75,25 +75,25 @@ private[mesos] object MesosSchedulerBackendUtil extends Logging {
    * and leaves open the chance for mesos to begin to accept an 'ip' field
    */
   def parsePortMappingsSpec(portmaps: String): List[DockerInfo.PortMapping] = {
-    portmaps.split(",").map(_.split(":")).map { spec: Array[String] =>
+    portmaps.split(",").map(_.split(":")).flatMap { spec: Array[String] =>
       val portmap: DockerInfo.PortMapping.Builder = DockerInfo.PortMapping
         .newBuilder()
         .setProtocol("tcp")
       spec match {
         case Array(host_port, container_port) =>
           Some(portmap.setHostPort(host_port.toInt)
-                      .setContainerPort(container_port.toInt))
+            .setContainerPort(container_port.toInt))
         case Array(host_port, container_port, protocol) =>
           Some(portmap.setHostPort(host_port.toInt)
-                      .setContainerPort(container_port.toInt)
-                      .setProtocol(protocol))
+            .setContainerPort(container_port.toInt)
+            .setProtocol(protocol))
         case spec => {
           logWarning("parsePortMappingSpec: unparseable: " + spec.mkString(":"))
           None
         }
       }
     }
-    .flatMap { _.map(_.build) }
+    .map { _.build() }
     .toList
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtil.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtil.scala
@@ -28,8 +28,8 @@ import org.apache.spark.{Logging, SparkConf}
  */
 private[mesos] object MesosSchedulerBackendUtil extends Logging {
   /**
-   * Parse a volume spec in the form passed to 'docker run -v'
-   * which is [host-dir:][container-dir][:rw|ro]
+   * Parse a comma-delimited list of volume specs, each of which
+   * takes the form [host-dir:]container-dir[:rw|:ro].
    */
   def parseVolumesSpec(volumes: String): List[Volume] = {
     volumes.split(",").map(_.split(":")).flatMap { spec =>
@@ -55,7 +55,8 @@ private[mesos] object MesosSchedulerBackendUtil extends Logging {
               .setHostPath(host_path)
               .setMode(Volume.Mode.RO))
           case spec => {
-            logWarning("parseVolumeSpec: unparseable: " + spec.mkString(":"))
+            logWarning(s"Unable to parse volume specs: $volumes. "
+              + "Expected form: \"[host-dir:]container-dir[:rw|:ro](, ...)\"")
             None
           }
       }
@@ -65,8 +66,9 @@ private[mesos] object MesosSchedulerBackendUtil extends Logging {
   }
 
   /**
-   * Parse a portmap spec, similar to the form passed to 'docker run -p'
-   * the form accepted is host_port:container_port[:proto]
+   * Parse a comma-delimited list of port mapping specs, each of which
+   * takes the form host_port:container_port[:udp|:tcp]
+   *
    * Note:
    * the docker form is [ip:]host_port:container_port, but the DockerInfo
    * message has no field for 'ip', and instead has a 'protocol' field.
@@ -88,7 +90,8 @@ private[mesos] object MesosSchedulerBackendUtil extends Logging {
             .setContainerPort(container_port.toInt)
             .setProtocol(protocol))
         case spec => {
-          logWarning("parsePortMappingSpec: unparseable: " + spec.mkString(":"))
+          logWarning(s"Unable to parse port mapping specs: $portmaps. "
+            + "Expected form: \"host_port:container_port[:udp|:tcp](, ...)\"")
           None
         }
       }

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtil.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendUtil.scala
@@ -32,7 +32,7 @@ private[spark] object MesosSchedulerBackendUtil extends Logging {
    * which is [host-dir:][container-dir][:rw|ro]
    */
   def parseVolumesSpec(volumes: String): List[Volume] = {
-    volumes.split(",").map(_.split(":")).map { spec: Array[String] =>
+    volumes.split(",").map(_.split(":")).map { spec =>
         val vol: Volume.Builder = Volume
           .newBuilder()
           .setMode(Volume.Mode.RW)
@@ -65,7 +65,7 @@ private[spark] object MesosSchedulerBackendUtil extends Logging {
   }
 
   /**
-   * Parse a portmap spec, simmilar to the form passed to 'docker run -p'
+   * Parse a portmap spec, similar to the form passed to 'docker run -p'
    * the form accepted is host_port:container_port[:proto]
    * Note:
    * the docker form is [ip:]host_port:container_port, but the DockerInfo
@@ -102,7 +102,7 @@ private[spark] object MesosSchedulerBackendUtil extends Logging {
       image: String,
       volumes: Option[List[Volume]] = None,
       network: Option[ContainerInfo.DockerInfo.Network] = None,
-      portmaps: Option[List[ContainerInfo.DockerInfo.PortMapping]] = None) = {
+      portmaps: Option[List[ContainerInfo.DockerInfo.PortMapping]] = None):Unit = {
 
     val docker = ContainerInfo.DockerInfo.newBuilder().setImage(image)
     network.map(docker.setNetwork _)

--- a/core/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendSuite.scala
@@ -86,6 +86,7 @@ class MesosSchedulerBackendSuite extends FunSuite with LocalSparkContext with Mo
     EasyMock.expect(sc.getSparkHome()).andReturn(Option("/path")).anyTimes()
     EasyMock.expect(sc.executorEnvs).andReturn(new mutable.HashMap).anyTimes()
     EasyMock.expect(sc.conf).andReturn(conf).anyTimes()
+    EasyMock.expect(sc.listenerBus).andReturn(listenerBus)
     EasyMock.replay(sc)
 
     val backend = new MesosSchedulerBackend(taskScheduler, sc, "master")

--- a/core/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendSuite.scala
@@ -73,6 +73,43 @@ class MesosSchedulerBackendSuite extends FunSuite with LocalSparkContext with Mo
       s"cd test-app-1*;  ./bin/spark-class ${classOf[MesosExecutorBackend].getName}")
   }
 
+  test("spark docker properties correctly populate the DockerInfo message") {
+    val taskScheduler = EasyMock.createMock(classOf[TaskSchedulerImpl])
+
+    val conf = EasyMock.createMock(classOf[SparkConf])
+    EasyMock.expect(conf.getOption("spark.executor.docker.image")).andReturn(Option("spark/mock")).anyTimes()
+    EasyMock.expect(conf.getOption("spark.executor.docker.volumes")).andReturn(Option("/a,/b:/b,/c:/c:rw,/d:/d:ro")).anyTimes()
+    EasyMock.expect(conf.getOption("spark.executor.docker.portmaps")).andReturn(Option("80:8080,53:53:tcp")).anyTimes()
+    EasyMock.replay(conf)
+
+    val sc = EasyMock.createMock(classOf[SparkContext])
+    EasyMock.expect(sc.executorMemory).andReturn(100).anyTimes()
+    EasyMock.expect(sc.getSparkHome()).andReturn(Option("/path")).anyTimes()
+    EasyMock.expect(sc.executorEnvs).andReturn(new mutable.HashMap).anyTimes()
+    EasyMock.expect(sc.conf).andReturn(conf).anyTimes()
+    EasyMock.replay(sc)
+
+    val backend = new MesosSchedulerBackend(taskScheduler, sc, "master")
+
+    val capture = new Capture[util.Collection[ExecutorInfo]]
+    EasyMock.expect(
+      backend.createExecutorInfo("mockExecutor")
+    ).andReturn(Status.valueOf(1)).once
+    EasyMock.replay(taskScheduler)
+
+    EasyMock.verify(taskScheduler)
+    assert(capture.getValue.size() == 1)
+    val execInfo = capture.getValue.iterator().next()
+    assert(execInfo.getContainer.getDocker.getImage.equals("spark/mock"))
+    val portmaps = execInfo.getContainer.getDocker.getPortMappingsList
+    assert(portmaps.get(0).getHostPort.equals(80))
+    assert(portmaps.get(0).getContainerPort.equals(8080))
+    assert(portmaps.get(0).getProtocol.equals("tcp"))
+    assert(portmaps.get(1).getHostPort.equals(53))
+    assert(portmaps.get(1).getContainerPort.equals(53))
+    assert(portmaps.get(1).getProtocol.equals("tcp"))
+  }
+
   test("mesos resource offers result in launching tasks") {
     def createOffer(id: Int, mem: Int, cpu: Int): Offer = {
       val builder = Offer.newBuilder()

--- a/core/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendSuite.scala
@@ -77,10 +77,14 @@ class MesosSchedulerBackendSuite extends FunSuite with LocalSparkContext with Mo
     val taskScheduler = EasyMock.createNiceMock(classOf[TaskSchedulerImpl])
 
     val conf = new SparkConf()
-      .set("spark.executor.docker.image", "spark/mock")
-      .set("spark.executor.docker.volumes", "/a,/b:/b,/c:/c:rw,/d:ro,/e:/e:ro")
-      .set("spark.executor.docker.portmaps", "80:8080,53:53:tcp")
-                              
+      .set("spark.mesos.executor.docker.image", "spark/mock")
+      .set("spark.mesos.executor.docker.volumes", "/a,/b:/b,/c:/c:rw,/d:ro,/e:/e:ro")
+      .set("spark.mesos.executor.docker.portmaps", "80:8080,53:53:tcp")
+     
+    val listenerBus = EasyMock.createMock(classOf[LiveListenerBus])
+    listenerBus.post(SparkListenerExecutorAdded(EasyMock.anyLong, "s1", new ExecutorInfo("host1", 2)))
+    EasyMock.replay(listenerBus)
+                         
     val sc = EasyMock.createMock(classOf[SparkContext])
     EasyMock.expect(sc.executorMemory).andReturn(100).anyTimes()
     EasyMock.expect(sc.getSparkHome()).andReturn(Option("/path")).anyTimes()

--- a/core/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendSuite.scala
@@ -82,7 +82,8 @@ class MesosSchedulerBackendSuite extends FunSuite with LocalSparkContext with Mo
       .set("spark.mesos.executor.docker.portmaps", "80:8080,53:53:tcp")
      
     val listenerBus = mock[LiveListenerBus]
-    listenerBus.post(SparkListenerExecutorAdded(anyLong, "s1", new ExecutorInfo("host1", 2, Map.empty)))
+    val execInfo = new ExecutorInfo("host1", 2, Map.empty)
+    listenerBus.post(SparkListenerExecutorAdded(anyLong, "s1", execInfo))
                          
     val sc = mock[SparkContext]
     when(sc.executorMemory).thenReturn(100)

--- a/core/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendSuite.scala
@@ -82,8 +82,8 @@ class MesosSchedulerBackendSuite extends FunSuite with LocalSparkContext with Mo
       .set("spark.mesos.executor.docker.portmaps", "80:8080,53:53:tcp")
      
     val listenerBus = mock[LiveListenerBus]
-    val execInfo = new ExecutorInfo("host1", 2, Map.empty)
-    listenerBus.post(SparkListenerExecutorAdded(anyLong, "s1", execInfo))
+    listenerBus.post(
+      SparkListenerExecutorAdded(anyLong, "s1", new ExecutorInfo("host1", 2, Map.empty)))
                          
     val sc = mock[SparkContext]
     when(sc.executorMemory).thenReturn(100)

--- a/docker/spark-mesos/Dockerfile
+++ b/docker/spark-mesos/Dockerfile
@@ -1,0 +1,21 @@
+# This is an example Dockerfile for creating a Spark image which can be
+# references by the Spark property 'spark.mesos.executor.docker.image'
+
+FROM ubuntu
+
+# Update the base ubuntu image with dependencies needed for Spark and Mesos
+RUN apt-get update && \
+    apt-get install -y python libnss3 openjdk-7-jre-headless
+
+# A Spark distribution tarball is needed, one can be built from the root
+# of the Spark source repository with `make-distribution.sh --tgz`
+ADD spark-1.3.0.tar.gz /opt
+RUN ln -s /opt/spark-1.3.0 /opt/spark
+ENV SPARK_HOME /opt/spark
+
+# The correct version of the Mesos shared library will be needed by this image
+# One simple way to ensure you always have the correct version is to mount the
+# system shared library into the image.
+# In this example the shared library has been mounted to the volume:
+# /host/usr/local/lib
+ENV MESOS_NATIVE_JAVA_LIBRARY /host/usr/local/lib/libmesos.so

--- a/docker/spark-mesos/Dockerfile
+++ b/docker/spark-mesos/Dockerfile
@@ -1,5 +1,21 @@
 # This is an example Dockerfile for creating a Spark image which can be
 # references by the Spark property 'spark.mesos.executor.docker.image'
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 FROM ubuntu
 

--- a/docker/spark-mesos/Dockerfile
+++ b/docker/spark-mesos/Dockerfile
@@ -17,21 +17,14 @@
 # limitations under the License.
 #
 
-FROM ubuntu
+FROM mesosphere/mesos:0.20.1
 
-# Update the base ubuntu image with dependencies needed for Spark and Mesos
+# Update the base ubuntu image with dependencies needed for Spark
 RUN apt-get update && \
-    apt-get install -y python libnss3 openjdk-7-jre-headless
+    apt-get install -y python libnss3 openjdk-7-jre-headless curl
 
-# A Spark distribution tarball is needed, one can be built from the root
-# of the Spark source repository with `make-distribution.sh --tgz`
-ADD spark-1.3.0.tar.gz /opt
-RUN ln -s /opt/spark-1.3.0 /opt/spark
+RUN mkdir /opt/spark && \
+    curl http://www.apache.org/dyn/closer.cgi/spark/spark-1.4.0/spark-1.4.0-bin-hadoop2.4.tgz \
+    | tar -xzC /opt
 ENV SPARK_HOME /opt/spark
-
-# The correct version of the Mesos shared library will be needed by this image
-# One simple way to ensure you always have the correct version is to mount the
-# system shared library into the image.
-# In this example the shared library has been mounted to the volume:
-# /host/usr/local/lib
-ENV MESOS_NATIVE_JAVA_LIBRARY /host/usr/local/lib/libmesos.so
+ENV MESOS_NATIVE_JAVA_LIBRARY /usr/local/lib/libmesos.so

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -245,7 +245,7 @@ See the [configuration page](configuration.html) for information on Spark config
     image must have Spark installed, as well as a compatible version of the Mesos library.
     The installed path of Spark in the image can be specified with <code>spark.mesos.executor.home</code>;
     the installed path of the Mesos library can be specified with <code>spark.executorEnv.MESOS_NATIVE_LIBRARY</code>.
-    Mesos Docker support requires Mesos version 0.20.0 or later.
+    Mesos Docker support requires Mesos version 0.20.1 or later.
   </td>
 </tr>
 <tr>
@@ -258,7 +258,7 @@ See the [configuration page](configuration.html) for information on Spark config
 
     <pre>[host_path:]container_path[:ro|:rw]</pre>
 
-    Mesos Docker volume support requires Mesos version 0.20.0 or later.
+    Mesos Docker volume support requires Mesos version 0.20.1 or later.
   </td>
 </tr>
 <tr>
@@ -271,7 +271,7 @@ See the [configuration page](configuration.html) for information on Spark config
 
     <pre>host_port:container_port[:tcp|:udp]</pre>
 
-    Mesos Docker portmap support requires Mesos version 0.20.0 or later.
+    Mesos Docker portmap support requires Mesos version 0.20.1 or later.
   </td>
 </tr>
 <tr>

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -238,6 +238,43 @@ See the [configuration page](configuration.html) for information on Spark config
   </td>
 </tr>
 <tr>
+  <td><code>spark.executor.docker.image</code></td>
+  <td>(none)</td>
+  <td>
+    Set the docker image in which the Spark executors will run when using Mesos. The selected
+    image must have Spark installed, as well as a compatible version of the Mesos library.
+    The installed path of Spark in the image can be specified with <code>spark.mesos.executor.home</code>;
+    the installed path of the Mesos library can be specified with <code>spark.executorEnv.MESOS_NATIVE_LIBRARY</code>.
+    Mesos Docker support requires Mesos version 0.20.0 or later.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.executor.docker.volumes</code></td>
+  <td>(none)</td>
+  <td>
+    Set the list of volumes which will be mounted into the Docker image, which was set using
+    <code>spark.executor.docker.image</code>. The format of this property is a comma-separated list of
+    mappings following the form passed to <tt>docker run -v</tt>. That is they take the form:
+
+    <pre>[host_path:]container_path[:ro|:rw]</pre>
+
+    Mesos Docker volume support requires Mesos version 0.20.0 or later.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.executor.docker.portmaps</code></td>
+  <td>(none)</td>
+  <td>
+    Set the list of incoming ports exposed by the Docker image, which was set using
+    <code>spark.executor.docker.image</code>. The format of this property is a comma-separated list of
+    mappings which take the form:
+
+    <pre>host_port:container_port[:tcp|:udp]</pre>
+
+    Mesos Docker portmap support requires Mesos version 0.20.0 or later.
+  </td>
+</tr>
+<tr>
   <td><code>spark.mesos.executor.home</code></td>
   <td>driver side <code>SPARK_HOME</code></td>
   <td>

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -187,10 +187,12 @@ using `conf.set("spark.cores.max", "10")` (for example).
 # Mesos Docker Support
 
 Spark can make use of a Mesos Docker containerizer by setting the property `spark.mesos.executor.docker.image`
-in your [SparkConf](configuration.html#spark-properties)
+in your [SparkConf](configuration.html#spark-properties).
 
-The Docker Image used must have an appropriate version of Spark already part of the image, or you can
+The Docker image used must have an appropriate version of Spark already part of the image, or you can
 have Mesos download Spark via the usual methods.
+
+Requires Mesos version 0.20.1 or later.
 
 # Running Alongside Hadoop
 
@@ -249,11 +251,10 @@ See the [configuration page](configuration.html) for information on Spark config
   <td><code>spark.mesos.executor.docker.image</code></td>
   <td>(none)</td>
   <td>
-    Set the docker image in which the Spark executors will run when using Mesos. The selected
+    Set the name of the docker image that the Spark executors will run in. The selected
     image must have Spark installed, as well as a compatible version of the Mesos library.
     The installed path of Spark in the image can be specified with <code>spark.mesos.executor.home</code>;
     the installed path of the Mesos library can be specified with <code>spark.executorEnv.MESOS_NATIVE_LIBRARY</code>.
-    Mesos Docker support requires Mesos version 0.20.1 or later.
   </td>
 </tr>
 <tr>
@@ -265,8 +266,6 @@ See the [configuration page](configuration.html) for information on Spark config
     mappings following the form passed to <tt>docker run -v</tt>. That is they take the form:
 
     <pre>[host_path:]container_path[:ro|:rw]</pre>
-
-    Mesos Docker volume support requires Mesos version 0.20.1 or later.
   </td>
 </tr>
 <tr>
@@ -278,8 +277,6 @@ See the [configuration page](configuration.html) for information on Spark config
     mappings which take the form:
 
     <pre>host_port:container_port[:tcp|:udp]</pre>
-
-    Mesos Docker portmap support requires Mesos version 0.20.1 or later.
   </td>
 </tr>
 <tr>

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -184,6 +184,14 @@ acquire. By default, it will acquire *all* cores in the cluster (that get offere
 only makes sense if you run just one application at a time. You can cap the maximum number of cores
 using `conf.set("spark.cores.max", "10")` (for example).
 
+# Mesos Docker Support
+
+Spark can make use of a Mesos Docker containerizer by setting the property `spark.mesos.executor.docker.image`
+in your [SparkConf](configuration.html#spark-properties)
+
+The Docker Image used must have an appropriate version of Spark already part of the image, or you can
+have Mesos download Spark via the usual methods.
+
 # Running Alongside Hadoop
 
 You can run Spark and Mesos alongside your existing Hadoop cluster by just launching them as a
@@ -238,7 +246,7 @@ See the [configuration page](configuration.html) for information on Spark config
   </td>
 </tr>
 <tr>
-  <td><code>spark.executor.docker.image</code></td>
+  <td><code>spark.mesos.executor.docker.image</code></td>
   <td>(none)</td>
   <td>
     Set the docker image in which the Spark executors will run when using Mesos. The selected
@@ -249,11 +257,11 @@ See the [configuration page](configuration.html) for information on Spark config
   </td>
 </tr>
 <tr>
-  <td><code>spark.executor.docker.volumes</code></td>
+  <td><code>spark.mesos.executor.docker.volumes</code></td>
   <td>(none)</td>
   <td>
     Set the list of volumes which will be mounted into the Docker image, which was set using
-    <code>spark.executor.docker.image</code>. The format of this property is a comma-separated list of
+    <code>spark.mesos.executor.docker.image</code>. The format of this property is a comma-separated list of
     mappings following the form passed to <tt>docker run -v</tt>. That is they take the form:
 
     <pre>[host_path:]container_path[:ro|:rw]</pre>
@@ -262,11 +270,11 @@ See the [configuration page](configuration.html) for information on Spark config
   </td>
 </tr>
 <tr>
-  <td><code>spark.executor.docker.portmaps</code></td>
+  <td><code>spark.mesos.executor.docker.portmaps</code></td>
   <td>(none)</td>
   <td>
     Set the list of incoming ports exposed by the Docker image, which was set using
-    <code>spark.executor.docker.image</code>. The format of this property is a comma-separated list of
+    <code>spark.mesos.executor.docker.image</code>. The format of this property is a comma-separated list of
     mappings which take the form:
 
     <pre>host_port:container_port[:tcp|:udp]</pre>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <java.version>1.6</java.version>
     <sbt.project.name>spark</sbt.project.name>
     <scala.macros.version>2.0.1</scala.macros.version>
-    <mesos.version>0.21.0</mesos.version>
+    <mesos.version>0.20.1</mesos.version>
     <mesos.classifier>shaded-protobuf</mesos.classifier>
     <slf4j.version>1.7.10</slf4j.version>
     <log4j.version>1.2.17</log4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <java.version>1.6</java.version>
     <sbt.project.name>spark</sbt.project.name>
     <scala.macros.version>2.0.1</scala.macros.version>
-    <mesos.version>0.20.1</mesos.version>
+    <mesos.version>0.21.1</mesos.version>
     <mesos.classifier>shaded-protobuf</mesos.classifier>
     <slf4j.version>1.7.10</slf4j.version>
     <log4j.version>1.2.17</log4j.version>


### PR DESCRIPTION
This patch adds partial support for running spark on mesos inside of a docker container. Only fine-grained mode is presently supported, and there is no checking done to ensure that the version of libmesos is recent enough to have a DockerInfo structure in the protobuf (other than pinning a mesos version in the pom.xml).
