### PR TITLE
SPARK-3033:java.math.BigDecimal cannot be cast to org.apache.hadoop.hive.common.type.HiveDecimal

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
@@ -184,6 +184,7 @@ private[hive] trait HiveInspectors {
         case l: Byte => l: java.lang.Byte
         case b: BigDecimal => HiveShim.createDecimal(b.underlying())
         case d: Decimal => HiveShim.createDecimal(d.toBigDecimal.underlying())
+        case d: org.apache.hadoop.hive.common.`type`.HiveDecimal => d
         case b: Array[Byte] => b
         case d: java.sql.Date => d
         case t: java.sql.Timestamp => t

--- a/yarn/alpha/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocationHandler.scala
+++ b/yarn/alpha/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocationHandler.scala
@@ -19,18 +19,16 @@ package org.apache.spark.deploy.yarn
 
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicInteger
-
 import scala.collection.JavaConversions._
 import scala.collection.mutable.{ArrayBuffer, HashMap}
-
 import org.apache.spark.{SecurityManager, SparkConf}
 import org.apache.spark.scheduler.SplitInfo
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.yarn.api.AMRMProtocol
 import org.apache.hadoop.yarn.api.records._
 import org.apache.hadoop.yarn.api.protocolrecords.AllocateRequest
 import org.apache.hadoop.yarn.util.Records
+import org.apache.hadoop.yarn.api.protocolrecords.AllocateResponse
 
 /**
  * Acquires resources for executors from a ResourceManager and launches executors in new containers.
@@ -118,7 +116,7 @@ private[yarn] class YarnAllocationHandler(
           request.getPriority,
           request.getCapability))
     }
-    new AlphaAllocateResponse(resourceManager.allocate(req).getAMResponse())
+    new AlphaAllocateResponse(resourceManager.allocate(req))
   }
 
   override protected def releaseContainer(container: Container) = {
@@ -220,7 +218,7 @@ private[yarn] class YarnAllocationHandler(
     retval
   }
 
-  private class AlphaAllocateResponse(response: AMResponse) extends YarnAllocateResponse {
+  private class AlphaAllocateResponse(response: AllocateResponse) extends YarnAllocateResponse {
     override def getAllocatedContainers() = response.getAllocatedContainers()
     override def getAvailableResources() = response.getAvailableResources()
     override def getCompletedContainersStatuses() = response.getCompletedContainersStatuses()


### PR DESCRIPTION
fix bug SPARK-3033:
"if" expression In the Select clause of  hive query as below:
    IF(
      d.lost_order_amt IS NULL ,
      0.0 ,
      d.lost_order_amt
    ) AS lost_order_amt
throw exception: java.math.BigDecimal cannot be cast to org.apache.hadoop.hive.common.type.HiveDecimal
