### PR TITLE
[MLLIB] [PYTHON] SPARK-4221: Expose nonnegative ALS in the python API

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
@@ -279,8 +279,8 @@ class PythonMLLibAPI extends Serializable {
       iterations: Int,
       lambda: Double,
       blocks: Int,
-      seed: java.lang.Long,
-      nonnegative: Boolean): MatrixFactorizationModel = {
+      nonnegative: Boolean,
+      seed: java.lang.Long): MatrixFactorizationModel = {
     if (seed == null) {
       new MatrixFactorizationModelWrapper(
         // if the seed coming from python is None/null, let ALS use the
@@ -305,8 +305,8 @@ class PythonMLLibAPI extends Serializable {
       lambda: Double,
       blocks: Int,
       alpha: Double,
-      seed: java.lang.Long,
-      nonnegative: Boolean): MatrixFactorizationModel = {
+      nonnegative: Boolean,
+      seed: java.lang.Long): MatrixFactorizationModel = {
     if (seed == null) {
       // if the seed coming from python is None/null, let ALS use the
       // default, which is to use System.nanoTime

--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
@@ -278,8 +278,10 @@ class PythonMLLibAPI extends Serializable {
       rank: Int,
       iterations: Int,
       lambda: Double,
-      blocks: Int): MatrixFactorizationModel = {
-    new MatrixFactorizationModelWrapper(ALS.train(ratings.rdd, rank, iterations, lambda, blocks))
+      blocks: Int,
+      nonnegative: Boolean): MatrixFactorizationModel = {
+    new MatrixFactorizationModelWrapper(
+      ALS.train(ratings.rdd, rank, iterations, lambda, blocks, nonnegative))
   }
 
   /**
@@ -294,9 +296,10 @@ class PythonMLLibAPI extends Serializable {
       iterations: Int,
       lambda: Double,
       blocks: Int,
-      alpha: Double): MatrixFactorizationModel = {
+      alpha: Double,
+      nonnegative: Boolean): MatrixFactorizationModel = {
     new MatrixFactorizationModelWrapper(
-      ALS.trainImplicit(ratingsJRDD.rdd, rank, iterations, lambda, blocks, alpha))
+      ALS.trainImplicit(ratingsJRDD.rdd, rank, iterations, lambda, blocks, alpha, nonnegative))
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
@@ -279,27 +279,17 @@ class PythonMLLibAPI extends Serializable {
       iterations: Int,
       lambda: Double,
       blocks: Int,
-      seed: Long,
+      seed: java.lang.Long,
       nonnegative: Boolean): MatrixFactorizationModel = {
-    new MatrixFactorizationModelWrapper(
-      ALS.train(ratings.rdd, rank, iterations, lambda, blocks, seed, nonnegative))
-  }
-
-  /**
-   * Java stub for Python mllib ALS.train().  This stub returns a handle
-   * to the Java object instead of the content of the Java object.  Extra care
-   * needs to be taken in the Python code to ensure it gets freed on exit; see
-   * the Py4J documentation.  This version does not specify a seed.
-   */
-  def trainALSModel(
-      ratings: JavaRDD[Rating],
-      rank: Int,
-      iterations: Int,
-      lambda: Double,
-      blocks: Int,
-      nonnegative: Boolean): MatrixFactorizationModel = {
-    new MatrixFactorizationModelWrapper(
-      ALS.train(ratings.rdd, rank, iterations, lambda, blocks, nonnegative))
+    if (seed == null) {
+      new MatrixFactorizationModelWrapper(
+        // if the seed coming from python is None/null, let ALS use the
+        // default, which is to use System.nanoTime
+        ALS.train(ratings.rdd, rank, iterations, lambda, blocks, nonnegative))
+    } else {
+      new MatrixFactorizationModelWrapper(
+        ALS.train(ratings.rdd, rank, iterations, lambda, blocks, seed, nonnegative))
+    }
   }
 
   /**
@@ -315,30 +305,19 @@ class PythonMLLibAPI extends Serializable {
       lambda: Double,
       blocks: Int,
       alpha: Double,
-      seed: Long,
+      seed: java.lang.Long,
       nonnegative: Boolean): MatrixFactorizationModel = {
-    new MatrixFactorizationModelWrapper(
-      ALS.trainImplicit(ratingsJRDD.rdd, rank, iterations, lambda, blocks, alpha, 
-        seed, nonnegative))
-  }
-
-  /**
-   * Java stub for Python mllib ALS.trainImplicit().  This stub returns a
-   * handle to the Java object instead of the content of the Java object.
-   * Extra care needs to be taken in the Python code to ensure it gets freed on
-   * exit; see the Py4J documentation.  This version does not specify a seed.
-   */
-  def trainImplicitALSModel(
-      ratingsJRDD: JavaRDD[Rating],
-      rank: Int,
-      iterations: Int,
-      lambda: Double,
-      blocks: Int,
-      alpha: Double,
-      nonnegative: Boolean): MatrixFactorizationModel = {
-    new MatrixFactorizationModelWrapper(
-      ALS.trainImplicit(ratingsJRDD.rdd, rank, iterations, lambda, blocks, alpha, 
-        nonnegative))
+    if (seed == null) {
+      // if the seed coming from python is None/null, let ALS use the
+      // default, which is to use System.nanoTime
+      new MatrixFactorizationModelWrapper(
+        ALS.trainImplicit(ratingsJRDD.rdd, rank, iterations, lambda, blocks, alpha,
+          nonnegative))
+    } else {
+      new MatrixFactorizationModelWrapper(
+        ALS.trainImplicit(ratingsJRDD.rdd, rank, iterations, lambda, blocks, alpha,
+          seed, nonnegative))
+    }
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
@@ -274,22 +274,25 @@ class PythonMLLibAPI extends Serializable {
    * the Py4J documentation.
    */
   def trainALSModel(
-      ratings: JavaRDD[Rating],
+      ratingsJRDD: JavaRDD[Rating],
       rank: Int,
       iterations: Int,
       lambda: Double,
       blocks: Int,
       nonnegative: Boolean,
       seed: java.lang.Long): MatrixFactorizationModel = {
-    if (seed == null) {
-      new MatrixFactorizationModelWrapper(
-        // if the seed coming from python is None/null, let ALS use the
-        // default, which is to use System.nanoTime
-        ALS.train(ratings.rdd, rank, iterations, lambda, blocks, nonnegative))
-    } else {
-      new MatrixFactorizationModelWrapper(
-        ALS.train(ratings.rdd, rank, iterations, lambda, blocks, seed, nonnegative))
-    }
+
+    val als = new ALS()
+      .setRank(rank)
+      .setIterations(iterations)
+      .setLambda(lambda)
+      .setBlocks(blocks)
+      .setNonnegative(nonnegative)
+
+    if (seed != null) als.setSeed(seed)
+
+    val model =  als.run(ratingsJRDD.rdd)
+    new MatrixFactorizationModelWrapper(model)
   }
 
   /**
@@ -307,17 +310,20 @@ class PythonMLLibAPI extends Serializable {
       alpha: Double,
       nonnegative: Boolean,
       seed: java.lang.Long): MatrixFactorizationModel = {
-    if (seed == null) {
-      // if the seed coming from python is None/null, let ALS use the
-      // default, which is to use System.nanoTime
-      new MatrixFactorizationModelWrapper(
-        ALS.trainImplicit(ratingsJRDD.rdd, rank, iterations, lambda, blocks, alpha,
-          nonnegative))
-    } else {
-      new MatrixFactorizationModelWrapper(
-        ALS.trainImplicit(ratingsJRDD.rdd, rank, iterations, lambda, blocks, alpha,
-          seed, nonnegative))
-    }
+
+    val als = new ALS()
+      .setImplicitPrefs(true)
+      .setRank(rank)
+      .setIterations(iterations)
+      .setLambda(lambda)
+      .setBlocks(blocks)
+      .setAlpha(alpha)
+      .setNonnegative(nonnegative)
+
+    if (seed != null) als.setSeed(seed)
+
+    val model =  als.run(ratingsJRDD.rdd)
+    new MatrixFactorizationModelWrapper(model)
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
@@ -279,6 +279,24 @@ class PythonMLLibAPI extends Serializable {
       iterations: Int,
       lambda: Double,
       blocks: Int,
+      seed: Long,
+      nonnegative: Boolean): MatrixFactorizationModel = {
+    new MatrixFactorizationModelWrapper(
+      ALS.train(ratings.rdd, rank, iterations, lambda, blocks, seed, nonnegative))
+  }
+
+  /**
+   * Java stub for Python mllib ALS.train().  This stub returns a handle
+   * to the Java object instead of the content of the Java object.  Extra care
+   * needs to be taken in the Python code to ensure it gets freed on exit; see
+   * the Py4J documentation.  This version does not specify a seed.
+   */
+  def trainALSModel(
+      ratings: JavaRDD[Rating],
+      rank: Int,
+      iterations: Int,
+      lambda: Double,
+      blocks: Int,
       nonnegative: Boolean): MatrixFactorizationModel = {
     new MatrixFactorizationModelWrapper(
       ALS.train(ratings.rdd, rank, iterations, lambda, blocks, nonnegative))
@@ -297,9 +315,30 @@ class PythonMLLibAPI extends Serializable {
       lambda: Double,
       blocks: Int,
       alpha: Double,
+      seed: Long,
       nonnegative: Boolean): MatrixFactorizationModel = {
     new MatrixFactorizationModelWrapper(
-      ALS.trainImplicit(ratingsJRDD.rdd, rank, iterations, lambda, blocks, alpha, nonnegative))
+      ALS.trainImplicit(ratingsJRDD.rdd, rank, iterations, lambda, blocks, alpha, 
+        seed, nonnegative))
+  }
+
+  /**
+   * Java stub for Python mllib ALS.trainImplicit().  This stub returns a
+   * handle to the Java object instead of the content of the Java object.
+   * Extra care needs to be taken in the Python code to ensure it gets freed on
+   * exit; see the Py4J documentation.  This version does not specify a seed.
+   */
+  def trainImplicitALSModel(
+      ratingsJRDD: JavaRDD[Rating],
+      rank: Int,
+      iterations: Int,
+      lambda: Double,
+      blocks: Int,
+      alpha: Double,
+      nonnegative: Boolean): MatrixFactorizationModel = {
+    new MatrixFactorizationModelWrapper(
+      ALS.trainImplicit(ratingsJRDD.rdd, rank, iterations, lambda, blocks, alpha, 
+        nonnegative))
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
@@ -700,6 +700,32 @@ object ALS {
    * Train a matrix factorization model given an RDD of ratings given by users to some products,
    * in the form of (userID, productID, rating) pairs. We approximate the ratings matrix as the
    * product of two lower-rank matrices of a given rank (number of features). To solve for these
+   * features, we run a given number of iterations of ALS. This is done using a level of
+   * parallelism given by `blocks`.
+   *
+   * @param ratings     RDD of (userID, productID, rating) pairs
+   * @param rank        number of features to use
+   * @param iterations  number of iterations of ALS (recommended: 10-20)
+   * @param lambda      regularization factor (recommended: 0.01)
+   * @param blocks      level of parallelism to split computation into
+   * @param nonnegative whether to enforce nonnegativity
+   */
+  def train(
+      ratings: RDD[Rating],
+      rank: Int,
+      iterations: Int,
+      lambda: Double,
+      blocks: Int,
+      nonnegative: Boolean
+    ): MatrixFactorizationModel = {
+    (new ALS(blocks, blocks, rank, iterations, lambda, false, 1.0)
+      .setNonnegative(nonnegative).run(ratings))
+  }
+
+  /**
+   * Train a matrix factorization model given an RDD of ratings given by users to some products,
+   * in the form of (userID, productID, rating) pairs. We approximate the ratings matrix as the
+   * product of two lower-rank matrices of a given rank (number of features). To solve for these
    * features, we run a given number of iterations of ALS. The level of parallelism is determined
    * automatically based on the number of partitions in `ratings`.
    *
@@ -779,6 +805,34 @@ object ALS {
       alpha: Double
     ): MatrixFactorizationModel = {
     new ALS(blocks, blocks, rank, iterations, lambda, true, alpha).run(ratings)
+  }
+
+  /**
+   * Train a matrix factorization model given an RDD of 'implicit preferences' given by users
+   * to some products, in the form of (userID, productID, preference) pairs. We approximate the
+   * ratings matrix as the product of two lower-rank matrices of a given rank (number of features).
+   * To solve for these features, we run a given number of iterations of ALS. This is done using
+   * a level of parallelism given by `blocks`.
+   *
+   * @param ratings     RDD of (userID, productID, rating) pairs
+   * @param rank        number of features to use
+   * @param iterations  number of iterations of ALS (recommended: 10-20)
+   * @param lambda      regularization factor (recommended: 0.01)
+   * @param blocks      level of parallelism to split computation into
+   * @param alpha       confidence parameter (only applies when immplicitPrefs = true)
+   * @param nonnegative whether to enforce nonnegativity
+   */
+  def trainImplicit(
+      ratings: RDD[Rating],
+      rank: Int,
+      iterations: Int,
+      lambda: Double,
+      blocks: Int,
+      alpha: Double,
+      nonnegative: Boolean
+    ): MatrixFactorizationModel = {
+    (new ALS(blocks, blocks, rank, iterations, lambda, true, alpha)
+      .setNonnegative(nonnegative).run(ratings))
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
@@ -685,6 +685,34 @@ object ALS {
    * @param iterations number of iterations of ALS (recommended: 10-20)
    * @param lambda     regularization factor (recommended: 0.01)
    * @param blocks     level of parallelism to split computation into
+   * @param seed       random seed
+   * @param nonnegative whether to enforce nonnegativity
+   */
+  def train(
+      ratings: RDD[Rating],
+      rank: Int,
+      iterations: Int,
+      lambda: Double,
+      blocks: Int,
+      seed: Long,
+      nonnegative: Boolean
+    ): MatrixFactorizationModel = {
+    (new ALS(blocks, blocks, rank, iterations, lambda, false, 1.0, seed)
+      .setNonnegative(nonnegative).run(ratings))
+  }
+
+  /**
+   * Train a matrix factorization model given an RDD of ratings given by users to some products,
+   * in the form of (userID, productID, rating) pairs. We approximate the ratings matrix as the
+   * product of two lower-rank matrices of a given rank (number of features). To solve for these
+   * features, we run a given number of iterations of ALS. This is done using a level of
+   * parallelism given by `blocks`.
+   *
+   * @param ratings    RDD of (userID, productID, rating) pairs
+   * @param rank       number of features to use
+   * @param iterations number of iterations of ALS (recommended: 10-20)
+   * @param lambda     regularization factor (recommended: 0.01)
+   * @param blocks     level of parallelism to split computation into
    */
   def train(
       ratings: RDD[Rating],
@@ -780,6 +808,36 @@ object ALS {
       seed: Long
     ): MatrixFactorizationModel = {
     new ALS(blocks, blocks, rank, iterations, lambda, true, alpha, seed).run(ratings)
+  }
+
+  /**
+   * Train a matrix factorization model given an RDD of 'implicit preferences' given by users
+   * to some products, in the form of (userID, productID, preference) pairs. We approximate the
+   * ratings matrix as the product of two lower-rank matrices of a given rank (number of features).
+   * To solve for these features, we run a given number of iterations of ALS. This is done using
+   * a level of parallelism given by `blocks`.
+   *
+   * @param ratings    RDD of (userID, productID, rating) pairs
+   * @param rank       number of features to use
+   * @param iterations number of iterations of ALS (recommended: 10-20)
+   * @param lambda     regularization factor (recommended: 0.01)
+   * @param blocks     level of parallelism to split computation into
+   * @param alpha      confidence parameter (only applies when immplicitPrefs = true)
+   * @param seed       random seed
+   * @param nonnegative whether to enforce nonnegativity
+   */
+  def trainImplicit(
+      ratings: RDD[Rating],
+      rank: Int,
+      iterations: Int,
+      lambda: Double,
+      blocks: Int,
+      alpha: Double,
+      seed: Long,
+      nonnegative: Boolean
+    ): MatrixFactorizationModel = {
+    (new ALS(blocks, blocks, rank, iterations, lambda, true, alpha, seed)
+      .setNonnegative(nonnegative).run(ratings))
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/recommendation/ALS.scala
@@ -685,34 +685,6 @@ object ALS {
    * @param iterations number of iterations of ALS (recommended: 10-20)
    * @param lambda     regularization factor (recommended: 0.01)
    * @param blocks     level of parallelism to split computation into
-   * @param seed       random seed
-   * @param nonnegative whether to enforce nonnegativity
-   */
-  def train(
-      ratings: RDD[Rating],
-      rank: Int,
-      iterations: Int,
-      lambda: Double,
-      blocks: Int,
-      seed: Long,
-      nonnegative: Boolean
-    ): MatrixFactorizationModel = {
-    (new ALS(blocks, blocks, rank, iterations, lambda, false, 1.0, seed)
-      .setNonnegative(nonnegative).run(ratings))
-  }
-
-  /**
-   * Train a matrix factorization model given an RDD of ratings given by users to some products,
-   * in the form of (userID, productID, rating) pairs. We approximate the ratings matrix as the
-   * product of two lower-rank matrices of a given rank (number of features). To solve for these
-   * features, we run a given number of iterations of ALS. This is done using a level of
-   * parallelism given by `blocks`.
-   *
-   * @param ratings    RDD of (userID, productID, rating) pairs
-   * @param rank       number of features to use
-   * @param iterations number of iterations of ALS (recommended: 10-20)
-   * @param lambda     regularization factor (recommended: 0.01)
-   * @param blocks     level of parallelism to split computation into
    */
   def train(
       ratings: RDD[Rating],
@@ -722,32 +694,6 @@ object ALS {
       blocks: Int
     ): MatrixFactorizationModel = {
     new ALS(blocks, blocks, rank, iterations, lambda, false, 1.0).run(ratings)
-  }
-
-  /**
-   * Train a matrix factorization model given an RDD of ratings given by users to some products,
-   * in the form of (userID, productID, rating) pairs. We approximate the ratings matrix as the
-   * product of two lower-rank matrices of a given rank (number of features). To solve for these
-   * features, we run a given number of iterations of ALS. This is done using a level of
-   * parallelism given by `blocks`.
-   *
-   * @param ratings     RDD of (userID, productID, rating) pairs
-   * @param rank        number of features to use
-   * @param iterations  number of iterations of ALS (recommended: 10-20)
-   * @param lambda      regularization factor (recommended: 0.01)
-   * @param blocks      level of parallelism to split computation into
-   * @param nonnegative whether to enforce nonnegativity
-   */
-  def train(
-      ratings: RDD[Rating],
-      rank: Int,
-      iterations: Int,
-      lambda: Double,
-      blocks: Int,
-      nonnegative: Boolean
-    ): MatrixFactorizationModel = {
-    (new ALS(blocks, blocks, rank, iterations, lambda, false, 1.0)
-      .setNonnegative(nonnegative).run(ratings))
   }
 
   /**
@@ -823,36 +769,6 @@ object ALS {
    * @param lambda     regularization factor (recommended: 0.01)
    * @param blocks     level of parallelism to split computation into
    * @param alpha      confidence parameter (only applies when immplicitPrefs = true)
-   * @param seed       random seed
-   * @param nonnegative whether to enforce nonnegativity
-   */
-  def trainImplicit(
-      ratings: RDD[Rating],
-      rank: Int,
-      iterations: Int,
-      lambda: Double,
-      blocks: Int,
-      alpha: Double,
-      seed: Long,
-      nonnegative: Boolean
-    ): MatrixFactorizationModel = {
-    (new ALS(blocks, blocks, rank, iterations, lambda, true, alpha, seed)
-      .setNonnegative(nonnegative).run(ratings))
-  }
-
-  /**
-   * Train a matrix factorization model given an RDD of 'implicit preferences' given by users
-   * to some products, in the form of (userID, productID, preference) pairs. We approximate the
-   * ratings matrix as the product of two lower-rank matrices of a given rank (number of features).
-   * To solve for these features, we run a given number of iterations of ALS. This is done using
-   * a level of parallelism given by `blocks`.
-   *
-   * @param ratings    RDD of (userID, productID, rating) pairs
-   * @param rank       number of features to use
-   * @param iterations number of iterations of ALS (recommended: 10-20)
-   * @param lambda     regularization factor (recommended: 0.01)
-   * @param blocks     level of parallelism to split computation into
-   * @param alpha      confidence parameter (only applies when immplicitPrefs = true)
    */
   def trainImplicit(
       ratings: RDD[Rating],
@@ -863,34 +779,6 @@ object ALS {
       alpha: Double
     ): MatrixFactorizationModel = {
     new ALS(blocks, blocks, rank, iterations, lambda, true, alpha).run(ratings)
-  }
-
-  /**
-   * Train a matrix factorization model given an RDD of 'implicit preferences' given by users
-   * to some products, in the form of (userID, productID, preference) pairs. We approximate the
-   * ratings matrix as the product of two lower-rank matrices of a given rank (number of features).
-   * To solve for these features, we run a given number of iterations of ALS. This is done using
-   * a level of parallelism given by `blocks`.
-   *
-   * @param ratings     RDD of (userID, productID, rating) pairs
-   * @param rank        number of features to use
-   * @param iterations  number of iterations of ALS (recommended: 10-20)
-   * @param lambda      regularization factor (recommended: 0.01)
-   * @param blocks      level of parallelism to split computation into
-   * @param alpha       confidence parameter (only applies when immplicitPrefs = true)
-   * @param nonnegative whether to enforce nonnegativity
-   */
-  def trainImplicit(
-      ratings: RDD[Rating],
-      rank: Int,
-      iterations: Int,
-      lambda: Double,
-      blocks: Int,
-      alpha: Double,
-      nonnegative: Boolean
-    ): MatrixFactorizationModel = {
-    (new ALS(blocks, blocks, rank, iterations, lambda, true, alpha)
-      .setNonnegative(nonnegative).run(ratings))
   }
 
   /**

--- a/python/pyspark/mllib/recommendation.py
+++ b/python/pyspark/mllib/recommendation.py
@@ -120,14 +120,14 @@ class ALS(object):
     def train(cls, ratings, rank, iterations=5, lambda_=0.01, blocks=-1, nonnegative=False,
               seed=None):
         model = callMLlibFunc("trainALSModel", cls._prepare(ratings), rank, iterations,
-                              lambda_, blocks, seed, nonnegative)
+                              lambda_, blocks, nonnegative, seed)
         return MatrixFactorizationModel(model)
 
     @classmethod
     def trainImplicit(cls, ratings, rank, iterations=5, lambda_=0.01, blocks=-1, alpha=0.01,
                       nonnegative=False, seed=None):
         model = callMLlibFunc("trainImplicitALSModel", cls._prepare(ratings), rank,
-                              iterations, lambda_, blocks, alpha, seed, nonnegative)
+                              iterations, lambda_, blocks, alpha, nonnegative, seed)
         return MatrixFactorizationModel(model)
 
 

--- a/python/pyspark/mllib/recommendation.py
+++ b/python/pyspark/mllib/recommendation.py
@@ -44,16 +44,16 @@ class MatrixFactorizationModel(JavaModelWrapper):
     >>> r2 = (1, 2, 2.0)
     >>> r3 = (2, 1, 2.0)
     >>> ratings = sc.parallelize([r1, r2, r3])
-    >>> model = ALS.trainImplicit(ratings, 1)
+    >>> model = ALS.trainImplicit(ratings, 1, seed=10)
     >>> model.predict(2,2)
     0.4473...
 
     >>> testset = sc.parallelize([(1, 2), (1, 1)])
-    >>> model = ALS.train(ratings, 1)
+    >>> model = ALS.train(ratings, 1, seed=10)
     >>> model.predictAll(testset).collect()
     [Rating(1, 1, 1), Rating(1, 2, 1)]
 
-    >>> model = ALS.train(ratings, 4)
+    >>> model = ALS.train(ratings, 4, seed=10)
     >>> model.userFeatures().collect()
     [(2, array('d', [...])), (1, array('d', [...]))]
 
@@ -69,14 +69,6 @@ class MatrixFactorizationModel(JavaModelWrapper):
     >>> latents = first_product[1]
     >>> len(latents) == 4
     True
-
-    >>> model = ALS.train(ratings, 1, nonnegative=True)
-    >>> model.predict(2,2)
-    3.735...
-
-    >>> model = ALS.trainImplicit(ratings, 1, nonnegative=True)
-    >>> model.predict(2,2)
-    0.4473...
 
     >>> model = ALS.train(ratings, 1, nonnegative=True, seed=10)
     >>> model.predict(2,2)

--- a/python/pyspark/mllib/recommendation.py
+++ b/python/pyspark/mllib/recommendation.py
@@ -45,25 +45,25 @@ class MatrixFactorizationModel(JavaModelWrapper):
     >>> r3 = (2, 1, 2.0)
     >>> ratings = sc.parallelize([r1, r2, r3])
     >>> model = ALS.trainImplicit(ratings, 1)
-    >>> model.predict(2,2) is not None
-    True
+    >>> model.predict(2,2)
+    0.4473...
 
     >>> testset = sc.parallelize([(1, 2), (1, 1)])
     >>> model = ALS.train(ratings, 1)
-    >>> model.predictAll(testset).count() == 2
-    True
+    >>> model.predictAll(testset).collect()
+    [Rating(1, 1, 1), Rating(1, 2, 1)]
 
     >>> model = ALS.train(ratings, 4)
-    >>> model.userFeatures().count() == 2
-    True
+    >>> model.userFeatures().collect()
+    [(2, array('d', [...])), (1, array('d', [...]))]
 
     >>> first_user = model.userFeatures().take(1)[0]
     >>> latents = first_user[1]
     >>> len(latents) == 4
     True
 
-    >>> model.productFeatures().count() == 2
-    True
+    >>> model.productFeatures().collect()
+    [(2, array('d', [...])), (1, array('d', [...]))]
 
     >>> first_product = model.productFeatures().take(1)[0]
     >>> latents = first_product[1]
@@ -71,12 +71,20 @@ class MatrixFactorizationModel(JavaModelWrapper):
     True
 
     >>> model = ALS.train(ratings, 1, nonnegative=True)
-    >>> model.predict(2,2) is not None
-    True
+    >>> model.predict(2,2)
+    3.735...
 
     >>> model = ALS.trainImplicit(ratings, 1, nonnegative=True)
-    >>> model.predict(2,2) is not None
-    True
+    >>> model.predict(2,2)
+    0.4473...
+
+    >>> model = ALS.train(ratings, 1, seed=10, nonnegative=True)
+    >>> model.predict(2,2)
+    3.735...
+
+    >>> model = ALS.trainImplicit(ratings, 1, seed=10, nonnegative=True)
+    >>> model.predict(2,2)
+    0.4473...
     """
     def predict(self, user, product):
         return self._java_model.predict(user, product)
@@ -109,16 +117,25 @@ class ALS(object):
         return _to_java_object_rdd(ratings, True)
 
     @classmethod
-    def train(cls, ratings, rank, iterations=5, lambda_=0.01, blocks=-1, nonnegative=False):
-        model = callMLlibFunc("trainALSModel", cls._prepare(ratings), rank, iterations,
-                              lambda_, blocks, nonnegative)
+    def train(cls, ratings, rank, iterations=5, lambda_=0.01, blocks=-1, seed=None,
+              nonnegative=False):
+        if seed:
+            model = callMLlibFunc("trainALSModel", cls._prepare(ratings), rank, iterations,
+                                  lambda_, blocks, seed, nonnegative)
+        else:
+            model = callMLlibFunc("trainALSModel", cls._prepare(ratings), rank, iterations,
+                                  lambda_, blocks, nonnegative)
         return MatrixFactorizationModel(model)
 
     @classmethod
     def trainImplicit(cls, ratings, rank, iterations=5, lambda_=0.01, blocks=-1, alpha=0.01,
-                      nonnegative=False):
-        model = callMLlibFunc("trainImplicitALSModel", cls._prepare(ratings), rank,
-                              iterations, lambda_, blocks, alpha, nonnegative)
+                      seed=None, nonnegative=False):
+        if seed:
+            model = callMLlibFunc("trainImplicitALSModel", cls._prepare(ratings), rank,
+                                  iterations, lambda_, blocks, alpha, seed, nonnegative)
+        else:
+            model = callMLlibFunc("trainImplicitALSModel", cls._prepare(ratings), rank,
+                                  iterations, lambda_, blocks, alpha, nonnegative)
         return MatrixFactorizationModel(model)
 
 

--- a/python/pyspark/mllib/recommendation.py
+++ b/python/pyspark/mllib/recommendation.py
@@ -69,6 +69,14 @@ class MatrixFactorizationModel(JavaModelWrapper):
     >>> latents = first_product[1]
     >>> len(latents) == 4
     True
+
+    >>> model = ALS.train(ratings, 1, nonnegative=True)
+    >>> model.predict(2,2) is not None
+    True
+
+    >>> model = ALS.trainImplicit(ratings, 1, nonnegative=True)
+    >>> model.predict(2,2) is not None
+    True
     """
     def predict(self, user, product):
         return self._java_model.predict(user, product)
@@ -101,15 +109,16 @@ class ALS(object):
         return _to_java_object_rdd(ratings, True)
 
     @classmethod
-    def train(cls, ratings, rank, iterations=5, lambda_=0.01, blocks=-1):
+    def train(cls, ratings, rank, iterations=5, lambda_=0.01, blocks=-1, nonnegative=False):
         model = callMLlibFunc("trainALSModel", cls._prepare(ratings), rank, iterations,
-                              lambda_, blocks)
+                              lambda_, blocks, nonnegative)
         return MatrixFactorizationModel(model)
 
     @classmethod
-    def trainImplicit(cls, ratings, rank, iterations=5, lambda_=0.01, blocks=-1, alpha=0.01):
+    def trainImplicit(cls, ratings, rank, iterations=5, lambda_=0.01, blocks=-1, alpha=0.01,
+                      nonnegative=False):
         model = callMLlibFunc("trainImplicitALSModel", cls._prepare(ratings), rank,
-                              iterations, lambda_, blocks, alpha)
+                              iterations, lambda_, blocks, alpha, nonnegative)
         return MatrixFactorizationModel(model)
 
 

--- a/python/pyspark/mllib/recommendation.py
+++ b/python/pyspark/mllib/recommendation.py
@@ -78,11 +78,11 @@ class MatrixFactorizationModel(JavaModelWrapper):
     >>> model.predict(2,2)
     0.4473...
 
-    >>> model = ALS.train(ratings, 1, seed=10, nonnegative=True)
+    >>> model = ALS.train(ratings, 1, nonnegative=True, seed=10)
     >>> model.predict(2,2)
     3.735...
 
-    >>> model = ALS.trainImplicit(ratings, 1, seed=10, nonnegative=True)
+    >>> model = ALS.trainImplicit(ratings, 1, nonnegative=True, seed=10)
     >>> model.predict(2,2)
     0.4473...
     """
@@ -117,15 +117,15 @@ class ALS(object):
         return _to_java_object_rdd(ratings, True)
 
     @classmethod
-    def train(cls, ratings, rank, iterations=5, lambda_=0.01, blocks=-1, seed=None,
-              nonnegative=False):
+    def train(cls, ratings, rank, iterations=5, lambda_=0.01, blocks=-1, nonnegative=False,
+              seed=None):
         model = callMLlibFunc("trainALSModel", cls._prepare(ratings), rank, iterations,
                               lambda_, blocks, seed, nonnegative)
         return MatrixFactorizationModel(model)
 
     @classmethod
     def trainImplicit(cls, ratings, rank, iterations=5, lambda_=0.01, blocks=-1, alpha=0.01,
-                      seed=None, nonnegative=False):
+                      nonnegative=False, seed=None):
         model = callMLlibFunc("trainImplicitALSModel", cls._prepare(ratings), rank,
                               iterations, lambda_, blocks, alpha, seed, nonnegative)
         return MatrixFactorizationModel(model)

--- a/python/pyspark/mllib/recommendation.py
+++ b/python/pyspark/mllib/recommendation.py
@@ -119,23 +119,15 @@ class ALS(object):
     @classmethod
     def train(cls, ratings, rank, iterations=5, lambda_=0.01, blocks=-1, seed=None,
               nonnegative=False):
-        if seed:
-            model = callMLlibFunc("trainALSModel", cls._prepare(ratings), rank, iterations,
-                                  lambda_, blocks, seed, nonnegative)
-        else:
-            model = callMLlibFunc("trainALSModel", cls._prepare(ratings), rank, iterations,
-                                  lambda_, blocks, nonnegative)
+        model = callMLlibFunc("trainALSModel", cls._prepare(ratings), rank, iterations,
+                              lambda_, blocks, seed, nonnegative)
         return MatrixFactorizationModel(model)
 
     @classmethod
     def trainImplicit(cls, ratings, rank, iterations=5, lambda_=0.01, blocks=-1, alpha=0.01,
                       seed=None, nonnegative=False):
-        if seed:
-            model = callMLlibFunc("trainImplicitALSModel", cls._prepare(ratings), rank,
-                                  iterations, lambda_, blocks, alpha, seed, nonnegative)
-        else:
-            model = callMLlibFunc("trainImplicitALSModel", cls._prepare(ratings), rank,
-                                  iterations, lambda_, blocks, alpha, nonnegative)
+        model = callMLlibFunc("trainImplicitALSModel", cls._prepare(ratings), rank,
+                              iterations, lambda_, blocks, alpha, seed, nonnegative)
         return MatrixFactorizationModel(model)
 
 


### PR DESCRIPTION
SPARK-1553 added alternating nonnegative least squares to MLLib, however it's not possible to access it via the python API.  This pull request resolves that.
