### PR TITLE
[WIP][SPARK-1771] fault tolerance when the driver actor restarts

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -82,9 +82,8 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val actorSyste
       context.system.scheduler.schedule(0.millis, reviveInterval.millis, self, ReviveOffers)
     }
 
-    override def preRestart(reason: Throwable, message: Option[Any]): Unit = {
+    override def postStop(): Unit = {
       stopAllExecutors
-      postStop()
     }
 
     private def stopAllExecutors = {

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -83,12 +83,12 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val actorSyste
     }
 
     override def postStop(): Unit = {
-      stopAllExecutors
+      stopAllExecutors("driver actor stopped")
     }
 
-    private def stopAllExecutors = {
-      for ((_, executorData) <- executorDataMap) {
-        executorData.executorActor ! StopExecutor
+    private def stopAllExecutors(reason: String) = {
+      for ((executorId, _) <- executorDataMap) {
+        removeExecutor(executorId, reason)
       }
     }
 
@@ -144,7 +144,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val actorSyste
 
       case StopExecutors =>
         logInfo("Asking each executor to shut down")
-        stopAllExecutors
+        stopAllExecutors("Asking each executor to shut down")
         sender ! true
 
       case RemoveExecutor(executorId, reason) =>


### PR DESCRIPTION
In current implementation, when driverActor restarts due to some error, it will clean the executorDataMap but without explicitly sending the stop instructions to the executors, causing some messes....

In this patch, I explicitly stop the executors in the postStop method of driver Actor

https://issues.apache.org/jira/browse/SPARK-1771
