### PR TITLE
SPARK-4271

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -192,6 +192,10 @@ private[spark] object JettyUtils extends Logging {
         server.start()
         (server, server.getConnectors.head.getLocalPort)
       } catch {
+        case e: java.net.BindException =>
+          server.stop()
+          pool.stop()
+          throw new java.net.BindException("Address already in use")
         case e: Exception =>
           server.stop()
           pool.stop()


### PR DESCRIPTION
if operating system language is not Englisth, occur org.apache.spark.util.Util.isBindCollision can't contains BingException message. so jetty Server can't tryport+1
