### PR TITLE
SPARK-4276 fix for two working thread

### DIFF
--- a/examples/src/main/scala/org/apache/spark/examples/streaming/NetworkWordCount.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/streaming/NetworkWordCount.scala
@@ -42,8 +42,8 @@ object NetworkWordCount {
 
     StreamingExamples.setStreamingLogLevels()
 
-    // Create the context with a 1 second batch size
-    val sparkConf = new SparkConf().setAppName("NetworkWordCount")
+    // Create a local StreamingContext with two working thread and batch interval of 1 second
+    val sparkConf = new SparkConf().setMaster("local[2]").setAppName("NetworkWordCount")
     val ssc = new StreamingContext(sparkConf, Seconds(1))
 
     // Create a socket stream on target ip:port and count the


### PR DESCRIPTION
Spark streaming requires at least two working threads.But example in spark/examples/src/main/scala/org/apache/spark/examples/streaming/NetworkWordCount.scala 
has
// Create the context with a 1 second batch size
val sparkConf = new SparkConf().setAppName("NetworkWordCount")
val ssc = new StreamingContext(sparkConf, Seconds(1))
which creates only 1 thread.
It should have atleast 2 threads:
http://spark.apache.org/docs/latest/streaming-programming-guide.html
