### PR TITLE
[SPARK-4304] [PySpark] Fix sort on empty RDD (1.0 branch)

### DIFF
--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -496,6 +496,8 @@ class RDD(object):
         # number of (key, value) pairs falling into them
         if numPartitions > 1:
             rddSize = self.count()
+            if not rddSize:
+                return self
             maxSampleSize = numPartitions * 20.0 # constant from Spark's RangePartitioner
             fraction = min(maxSampleSize / max(rddSize, 1), 1.0)
 

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -198,6 +198,9 @@ class TestRDDFunctions(PySparkTestCase):
         os.unlink(tempFile.name)
         self.assertRaises(Exception, lambda: filtered_data.count())
 
+    def test_sort_on_empty_rdd(self):
+        self.assertEqual([], self.sc.parallelize(zip([], [])).sortByKey().collect())
+
     def test_itemgetter(self):
         rdd = self.sc.parallelize([range(10)])
         from operator import itemgetter


### PR DESCRIPTION
This PR fix sortBy()/sortByKey() on empty RDD.

This should be back ported into 1.0
