### PR TITLE
SPARK-3648: Provide a script for fetching remote PR's for review

### DIFF
--- a/dev/fetch-pr
+++ b/dev/fetch-pr
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# A utility script for fetching local copies of a pull request.
+
+set -e
+set -o pipefail
+
+usage(){
+  echo "Utility for fetching a specific pull request into a temporary ref."
+  echo "Usage: ./dev/fetch-pr <pr-num>"
+  exit 1
+}
+
+case "$1" in
+  "") usage ;;
+  -h) usage ;;
+  h) usage ;;
+  --help) usage ;;
+  -help) usage ;;
+  help) usage ;;
+esac
+
+pr_num=$1
+# Find remote corresponding to github
+remote_name=$(git remote -v |grep apache/spark\.git | grep fetch | \
+  awk '{ print $1; }')
+echo "Detected Apache github remote '$remote_name'"
+
+remote_ref="pull/$pr_num/head"
+echo "Fetching remote ref '$remote_ref'"
+
+git fetch $remote_name $remote_ref
+git checkout FETCH_HEAD
+
+echo "To create a local branch for this pull request, run:"
+echo "$ git checkout -b pr-$pr_num"


### PR DESCRIPTION
This is a simple script I wrote for fetching remote pull requests.
I found this very useful during code reviews and I think other
developers would as well.

One nice thing is this allows you to avoid creating local refs for
all pull requests, which can be annoying since there is high churn
in PR activity.
