### PR TITLE
SPARK-4305 [BUILD] yarn-alpha profile won't build due to network/yarn module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1229,7 +1229,6 @@
       <id>yarn-alpha</id>
       <modules>
         <module>yarn</module>
-        <module>network/yarn</module>
       </modules>
     </profile>
 


### PR DESCRIPTION
SPARK-3797 introduced the `network/yarn` module, but its YARN code depends on YARN APIs not present in older versions covered by the `yarn-alpha` profile. As a result builds like `mvn -Pyarn-alpha -Phadoop-0.23 -Dhadoop.version=0.23.7 -DskipTests clean package` fail.

The solution is just to not build `network/yarn` with profile `yarn-alpha`.
