### PR TITLE
[BRANCH-1.1][SPARK-2652] change the default spark.serializer in pyspark back to Kryo

### DIFF
--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -40,6 +40,7 @@ from py4j.java_collections import ListConverter
 # These are special default configs for PySpark, they will overwrite
 # the default ones for Spark if they are not configured by user.
 DEFAULT_CONFIGS = {
+    "spark.serializer": "org.apache.spark.serializer.KryoSerializer",
     "spark.serializer.objectStreamReset": 100,
     "spark.rdd.compress": True,
 }


### PR DESCRIPTION
This reverts #2916 . We shouldn't change the default settings in a minor release. @JoshRosen @davies
