### PR TITLE
[SPARK-4314][Streaming] Exception throws when textFileStream attempts to read deleted _COPYING_ file

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
@@ -318,7 +318,8 @@ object FileInputDStream {
    */
   private val MIN_REMEMBER_DURATION = Minutes(1)
 
-  def defaultFilter(path: Path): Boolean = !path.getName().startsWith(".")
+  def defaultFilter(path: Path): Boolean = 
+    !path.getName.startsWith(".") && !path.getName.endsWith("_COPYING_")
 
   /**
    * Calculate the number of last batches to remember, such that all the files selected in


### PR DESCRIPTION
The ephemeral file(_COPYING_) is caught by FileInputDStream interface.
Exception appears when textFileStream attempts to read deleted _COPYING_ file if _COPYING_ is deleted when spark handle this file.
Therefore, add filter for intermediate partly written state 
