### PR TITLE
[SPARK-4342] [Core]connection ack timeout improvement, replace Timer with ScheudledExecutor...

### DIFF
--- a/core/src/main/scala/org/apache/spark/network/nio/ConnectionManager.scala
+++ b/core/src/main/scala/org/apache/spark/network/nio/ConnectionManager.scala
@@ -916,7 +916,6 @@ private[nio] class ConnectionManager(
       }
     }
 
-//    ackTimeoutMonitor.schedule(timeoutTask, ackTimeout * 1000)
     val timeoutTaskFuture = ackTimeoutMonitor.schedule(timeoutTask, ackTimeout, TimeUnit.SECONDS)
     val status = new MessageStatus(message, connectionManagerId, s => {
       timeoutTaskFuture.cancel(true)


### PR DESCRIPTION
- replace java.util.Timer with ScheduledExectorService
- avoid reference to the whole message, use message id only.
