### PR TITLE
[WIP][SPARK-4351] RDD cached read logging + display RDD miss rates on web UI

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/MissRateListener.scala
+++ b/core/src/main/scala/org/apache/spark/storage/MissRateListener.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.storage
+
+import scala.collection.mutable
+
+import org.apache.spark.Logging
+
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.scheduler._
+import org.apache.spark.executor.{BlockAccess, BlockAccessType, DataReadMethod}
+
+/**
+ * :: DeveloperApi ::
+ * A SparkListener that maintains RDD and block hit and miss rates.
+ */
+class MissRateListener extends SparkListener {
+  // Hit/miss rates for reads
+  private[storage] val rddToHitMissCount = mutable.Map[Int, mutable.Map[BlockId, (Int, Int)]]()
+  private[storage] val nonRddToHitMissCount = mutable.Map[BlockId, (Int, Int)]()
+
+  def missRateFor(rddId: Int): Option[Double] = {
+    rddToHitMissCount.get(rddId).map { hitMissRates =>
+      hitMissRates.values.map { case (hitCount, missCount) => 
+        (hitCount, missCount - 1) // One compulsory miss.
+      }.reduce { (pair1: (Int, Int), pair2: (Int, Int)) => 
+        (pair1._1 + pair2._1, pair1._2 + pair2._2)
+      }
+    }.filter(_ != 0 -> 0).map {
+      case (hitCount, missCount) => missCount.asInstanceOf[Double] / (hitCount + missCount)
+    }
+  }
+
+  private def recordBlockAccess(blockId: BlockId, blockAccess: BlockAccess) {
+    if (blockAccess.accessType == BlockAccessType.Read) {
+      val hitMissMap = blockId match {
+        case RDDBlockId(rddId, split) => 
+          rddToHitMissCount.getOrElseUpdate(rddId, mutable.Map.empty[BlockId, (Int, Int)])
+        case _ => nonRddToHitMissCount
+      }
+      val oldHitMissRate = hitMissMap.getOrElse(blockId, (0, 0))
+      hitMissMap(blockId) = blockAccess.inputMetrics.map(_.readMethod) match {
+        case None => (oldHitMissRate._1, oldHitMissRate._2 + 1)
+        case Some(_) => (oldHitMissRate._1 + 1, oldHitMissRate._2)
+      }
+    }
+  }
+
+  override def onTaskEnd(taskEnd: SparkListenerTaskEnd) = synchronized {
+    val info = taskEnd.taskInfo
+    val metrics = taskEnd.taskMetrics
+    if (metrics != null) {
+      val accessedBlocks = metrics.accessedBlocks.getOrElse(Seq[(BlockId, BlockAccess)]())
+      accessedBlocks.foreach { case (id, access) => recordBlockAccess(id, access) }
+    }
+  }
+
+  override def onUnpersistRDD(unpersistRDD: SparkListenerUnpersistRDD) = synchronized {
+    rddToHitMissCount.remove(unpersistRDD.rddId)
+  }
+}

--- a/core/src/main/scala/org/apache/spark/storage/RDDInfo.scala
+++ b/core/src/main/scala/org/apache/spark/storage/RDDInfo.scala
@@ -33,6 +33,7 @@ class RDDInfo(
   var memSize = 0L
   var diskSize = 0L
   var tachyonSize = 0L
+  var missRate: Option[Double] = None
 
   def isCached: Boolean = (memSize + diskSize + tachyonSize > 0) && numCachedPartitions > 0
 

--- a/core/src/main/scala/org/apache/spark/storage/StorageUtils.scala
+++ b/core/src/main/scala/org/apache/spark/storage/StorageUtils.scala
@@ -238,7 +238,8 @@ private[spark] object StorageUtils {
    * Update the given list of RDDInfo with the given list of storage statuses.
    * This method overwrites the old values stored in the RDDInfo's.
    */
-  def updateRddInfo(rddInfos: Seq[RDDInfo], statuses: Seq[StorageStatus]): Unit = {
+  def updateRddInfo(rddInfos: Seq[RDDInfo], statuses: Seq[StorageStatus],
+                    missRateListener: Option[MissRateListener] = None): Unit = {
     rddInfos.foreach { rddInfo =>
       val rddId = rddInfo.id
       // Assume all blocks belonging to the same RDD have the same storage level
@@ -254,6 +255,7 @@ private[spark] object StorageUtils {
       rddInfo.memSize = memSize
       rddInfo.diskSize = diskSize
       rddInfo.tachyonSize = tachyonSize
+      rddInfo.missRate = missRateListener.flatMap(_.missRateFor(rddId))
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
@@ -19,7 +19,7 @@ package org.apache.spark.ui
 
 import org.apache.spark.{Logging, SecurityManager, SparkConf, SparkContext}
 import org.apache.spark.scheduler._
-import org.apache.spark.storage.StorageStatusListener
+import org.apache.spark.storage.{MissRateListener, StorageStatusListener}
 import org.apache.spark.ui.JettyUtils._
 import org.apache.spark.ui.env.{EnvironmentListener, EnvironmentTab}
 import org.apache.spark.ui.exec.{ExecutorsListener, ExecutorsTab}
@@ -35,6 +35,7 @@ private[spark] class SparkUI private (
     val securityManager: SecurityManager,
     val environmentListener: EnvironmentListener,
     val storageStatusListener: StorageStatusListener,
+    val missRateListener: MissRateListener,
     val executorsListener: ExecutorsListener,
     val jobProgressListener: JobProgressListener,
     val storageListener: StorageListener,
@@ -135,12 +136,13 @@ private[spark] object SparkUI {
       val listener = new JobProgressListener(conf)
       listenerBus.addListener(listener)
       listener
-    }
+   }
 
     val environmentListener = new EnvironmentListener
     val storageStatusListener = new StorageStatusListener
+    val missRateListener = new MissRateListener
     val executorsListener = new ExecutorsListener(storageStatusListener)
-    val storageListener = new StorageListener(storageStatusListener)
+    val storageListener = new StorageListener(storageStatusListener, missRateListener)
 
     listenerBus.addListener(environmentListener)
     listenerBus.addListener(storageStatusListener)
@@ -148,6 +150,6 @@ private[spark] object SparkUI {
     listenerBus.addListener(storageListener)
 
     new SparkUI(sc, conf, securityManager, environmentListener, storageStatusListener,
-      executorsListener, _jobProgressListener, storageListener, appName, basePath)
+      missRateListener, executorsListener, _jobProgressListener, storageListener, appName, basePath)
   }
 }

--- a/core/src/main/scala/org/apache/spark/ui/storage/RDDPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/storage/RDDPage.scala
@@ -77,6 +77,10 @@ private[ui] class RDDPage(parent: StorageTab) extends WebUIPage("rdd") {
               <strong>Disk Size:</strong>
               {Utils.bytesToString(rddInfo.diskSize)}
             </li>
+            <li>
+              <strong>Miss Rate:</strong>
+              {rddInfo.missRate.map(rate => "%0.f".format(rate * 100.0)).getOrElse("(no reads)")}
+            </li>
           </ul>
         </div>
       </div>

--- a/core/src/main/scala/org/apache/spark/ui/storage/StoragePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/storage/StoragePage.scala
@@ -43,7 +43,8 @@ private[ui] class StoragePage(parent: StorageTab) extends WebUIPage("") {
     "Fraction Cached",
     "Size in Memory",
     "Size in Tachyon",
-    "Size on Disk")
+    "Size on Disk",
+    "Miss Rate")
 
   /** Render an HTML row representing an RDD */
   private def rddRow(rdd: RDDInfo): Seq[Node] = {
@@ -61,6 +62,7 @@ private[ui] class StoragePage(parent: StorageTab) extends WebUIPage("") {
       <td sorttable_customkey={rdd.memSize.toString}>{Utils.bytesToString(rdd.memSize)}</td>
       <td sorttable_customkey={rdd.tachyonSize.toString}>{Utils.bytesToString(rdd.tachyonSize)}</td>
       <td sorttable_customkey={rdd.diskSize.toString} >{Utils.bytesToString(rdd.diskSize)}</td>
+      <td>{rdd.missRate.map(rate => "%.0f%%".format(rate * 100.0)).getOrElse("--")}</td>
     </tr>
     // scalastyle:on
   }

--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -239,6 +239,13 @@ private[spark] object JsonProtocol {
           ("Status" -> blockStatusToJson(status))
         })
       }.getOrElse(JNothing)
+    val accessedBlocks =
+      taskMetrics.accessedBlocks.map { blocks =>
+        JArray(blocks.toList.map { case (id, access) =>
+          ("Block ID" -> id.toString) ~
+          ("Access" -> blockAccessToJson(access))
+        })
+      }.getOrElse(JNothing)
     ("Host Name" -> taskMetrics.hostname) ~
     ("Executor Deserialize Time" -> taskMetrics.executorDeserializeTime) ~
     ("Executor Run Time" -> taskMetrics.executorRunTime) ~
@@ -251,7 +258,8 @@ private[spark] object JsonProtocol {
     ("Shuffle Write Metrics" -> shuffleWriteMetrics) ~
     ("Input Metrics" -> inputMetrics) ~
     ("Output Metrics" -> outputMetrics) ~
-    ("Updated Blocks" -> updatedBlocks)
+    ("Updated Blocks" -> updatedBlocks) ~
+    ("Accessed Blocks" -> accessedBlocks)
   }
 
   def shuffleReadMetricsToJson(shuffleReadMetrics: ShuffleReadMetrics): JValue = {
@@ -274,6 +282,11 @@ private[spark] object JsonProtocol {
   def outputMetricsToJson(outputMetrics: OutputMetrics): JValue = {
     ("Data Write Method" -> outputMetrics.writeMethod.toString) ~
     ("Bytes Written" -> outputMetrics.bytesWritten)
+  }
+  
+  def blockAccessToJson(blockAccess: BlockAccess): JValue = {
+    ("Access Type" -> blockAccess.accessType.toString) ~
+    ("Input Metrics" -> blockAccess.inputMetrics.map(inputMetricsToJson).getOrElse(JNothing))
   }
 
   def taskEndReasonToJson(taskEndReason: TaskEndReason): JValue = {
@@ -595,6 +608,14 @@ private[spark] object JsonProtocol {
           (id, status)
         }
       }
+    metrics.accessedBlocks =
+      Utils.jsonOption(json \ "Accessed Blocks").map { value =>
+        value.extract[List[JValue]].map { block =>
+          val id = BlockId((block \ "Block ID").extract[String])
+          val access = blockAccessFromJson(block \ "Access")
+          (id, access)
+        }
+      }
     metrics
   }
 
@@ -626,6 +647,14 @@ private[spark] object JsonProtocol {
       DataWriteMethod.withName((json \ "Data Write Method").extract[String]))
     metrics.bytesWritten = (json \ "Bytes Written").extract[Long]
     metrics
+  }
+  
+  def blockAccessFromJson(json: JValue): BlockAccess = {
+    val access = new BlockAccess(
+      BlockAccessType.withName((json \ "Access Type").extract[String]),
+      Utils.jsonOption(json \ "Input Metrics").map(inputMetricsFromJson)
+    )
+    access
   }
 
   def taskEndReasonFromJson(json: JValue): TaskEndReason = {

--- a/core/src/test/scala/org/apache/spark/storage/MissRateListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/MissRateListenerSuite.scala
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.storage
+
+import org.scalatest.{FunSuite, Matchers}
+import org.apache.spark.Success
+import org.apache.spark.executor.TaskMetrics
+import org.apache.spark.executor.{BlockAccess, BlockAccessType, InputMetrics, DataReadMethod}
+import org.apache.spark.scheduler._
+
+/**
+ * Test the behavior of MissRateListener in response to all relevant events.
+ */
+class MissRateListenerSuite extends FunSuite with Matchers {
+  private val bm1 = BlockManagerId("big", "dog", 1)
+  private val bm2 = BlockManagerId("fat", "duck", 2)
+  private val taskInfo1 = new TaskInfo(0, 0, 0, 0, "big", "dog", TaskLocality.ANY, false)
+  private val taskInfo2 = new TaskInfo(0, 0, 0, 0, "fat", "duck", TaskLocality.ANY, false)
+
+  test("task end without accessed blocks") {
+    val listener = new MissRateListener
+    val taskMetrics = new TaskMetrics
+
+    // Task end with no updated blocks
+    assert(listener.missRateFor(1).isEmpty)
+    listener.onTaskEnd(SparkListenerTaskEnd(1, 0, "obliteration", Success, taskInfo1, taskMetrics))
+    assert(listener.missRateFor(1).isEmpty)
+  }
+
+  test("task end with accessed blocks") {
+    val listener = new MissRateListener
+    assert(listener.missRateFor(1).isEmpty)
+    val taskMetrics1 = new TaskMetrics
+    val taskMetrics2 = new TaskMetrics
+    val missBlock1 = (RDDBlockId(1, 1), BlockAccess(BlockAccessType.Read, None))
+    val hitBlock1 = (RDDBlockId(1, 1), BlockAccess(BlockAccessType.Read, Some(InputMetrics(DataReadMethod.Memory))))
+    val writeBlock1 = (RDDBlockId(1, 1), BlockAccess(BlockAccessType.Write, None))
+    val missBlock2 = (RDDBlockId(1, 2), BlockAccess(BlockAccessType.Read, None))
+    val hitBlock2 = (RDDBlockId(1, 2), BlockAccess(BlockAccessType.Read, Some(InputMetrics(DataReadMethod.Memory))))
+    val writeBlock2 = (RDDBlockId(1, 2), BlockAccess(BlockAccessType.Write, None))
+    taskMetrics1.accessedBlocks = Some(Seq(missBlock1, writeBlock1))
+    taskMetrics2.accessedBlocks = Some(Seq(hitBlock1))
+    listener.onTaskEnd(SparkListenerTaskEnd(1, 0, "obliteration", Success, taskInfo1, taskMetrics1))
+    // 1 compulsory miss
+    assert(listener.missRateFor(1).isEmpty)
+    listener.onTaskEnd(SparkListenerTaskEnd(1, 0, "obliteration", Success, taskInfo1, taskMetrics1))
+    // 1 compulsory miss, 1 miss
+    assert(listener.missRateFor(1).isDefined)
+    assert(listener.missRateFor(1).get === 1.0 +- 0.01)
+    assert(listener.missRateFor(2).isEmpty) // irrelevant RDD
+    listener.onTaskEnd(SparkListenerTaskEnd(1, 0, "obliteration", Success, taskInfo2, taskMetrics2))
+    // 1 compulsory miss, 1 miss, 1 hit
+    assert(listener.missRateFor(1).get === ((1.0 / 2.0) +- 0.01))
+
+    listener.onTaskEnd(SparkListenerTaskEnd(1, 0, "obliteration", Success, taskInfo2, taskMetrics2))
+    // 1 compulsory miss, 1 miss, 2 hits
+    assert(listener.missRateFor(1).get === ((1.0 / 3.0) +- 0.01))
+    
+    taskMetrics1.accessedBlocks = Some(Seq(missBlock2, writeBlock2))
+    taskMetrics2.accessedBlocks = Some(Seq(hitBlock2))
+    listener.onTaskEnd(SparkListenerTaskEnd(1, 0, "obliteration", Success, taskInfo2, taskMetrics1))
+    // 2 compulsory miss, 1 miss, 2 hits
+    assert(listener.missRateFor(1).get === ((1.0 / 3.0) +- 0.01))
+
+    listener.onTaskEnd(SparkListenerTaskEnd(1, 0, "obliteration", Success, taskInfo2, taskMetrics2))
+    // 2 compulsory miss, 1 miss, 3 hits
+    assert(listener.missRateFor(1).get === ((1.0 / 4.0) +- 0.01))
+    
+    listener.onTaskEnd(SparkListenerTaskEnd(1, 0, "obliteration", Success, taskInfo2, taskMetrics1))
+    // 2 compulsory miss, 2 miss, 3 hits
+    assert(listener.missRateFor(1).get === ((2.0 / 5.0) +- 0.01))
+ 
+    listener.onTaskEnd(SparkListenerTaskEnd(1, 0, "obliteration", Success, taskInfo2, taskMetrics1))
+    // 2 compulsory miss, 3 miss, 3 hits
+    assert(listener.missRateFor(1).get === ((3.0 / 6.0) +- 0.01))
+  }
+
+  test("unpersist RDD") {
+    val listener = new MissRateListener
+    val taskMetrics1 = new TaskMetrics
+    val taskMetrics2 = new TaskMetrics
+    val missBlock1 = (RDDBlockId(1, 1), BlockAccess(BlockAccessType.Read, None))
+    val hitBlock1 = (RDDBlockId(1, 1), BlockAccess(BlockAccessType.Read, Some(InputMetrics(DataReadMethod.Memory))))
+    val writeBlock1 = (RDDBlockId(1, 1), BlockAccess(BlockAccessType.Write, None))
+    taskMetrics1.accessedBlocks = Some(Seq(missBlock1, writeBlock1))
+    taskMetrics2.accessedBlocks = Some(Seq(hitBlock1))
+    assert(!listener.missRateFor(1).isDefined)
+    listener.onTaskEnd(SparkListenerTaskEnd(1, 0, "obliteration", Success, taskInfo1, taskMetrics1))
+    assert(!listener.missRateFor(1).isDefined) // compulsory miss only
+    listener.onTaskEnd(SparkListenerTaskEnd(1, 0, "obliteration", Success, taskInfo1, taskMetrics1))
+    assert(listener.missRateFor(1).isDefined)
+    listener.onUnpersistRDD(SparkListenerUnpersistRDD(100))
+    assert(listener.missRateFor(1).isDefined)
+    listener.onUnpersistRDD(SparkListenerUnpersistRDD(1))
+    assert(!listener.missRateFor(1).isDefined)
+  }
+}

--- a/core/src/test/scala/org/apache/spark/ui/storage/StorageTabSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/storage/StorageTabSuite.scala
@@ -29,6 +29,7 @@ import org.apache.spark.storage._
 class StorageTabSuite extends FunSuite with BeforeAndAfter {
   private var bus: LiveListenerBus = _
   private var storageStatusListener: StorageStatusListener = _
+  private var missRateListener: MissRateListener = _
   private var storageListener: StorageListener = _
   private val memAndDisk = StorageLevel.MEMORY_AND_DISK
   private val memOnly = StorageLevel.MEMORY_ONLY
@@ -44,7 +45,8 @@ class StorageTabSuite extends FunSuite with BeforeAndAfter {
   before {
     bus = new LiveListenerBus
     storageStatusListener = new StorageStatusListener
-    storageListener = new StorageListener(storageStatusListener)
+    missRateListener = new MissRateListener
+    storageListener = new StorageListener(storageStatusListener, missRateListener)
     bus.addListener(storageStatusListener)
     bus.addListener(storageListener)
   }


### PR DESCRIPTION
This set of patches adds cached RDD block attempted read/write trace logging to TaskMetrics and therefore the event log, and uses this information to display/compute RDD miss rates on the Web UI.

This patch removes the elegance of the contents of the storage web UI being entirely from StorageStatuses (as RDD access records shouldn't go away when a block manager does for the purpose of tracking hit/miss rates); I'd appreciate comments on cleaner solutions.

This still needs some additions to the UI tests, and I'd like to make sure it doesn't do anything bad for perf.
