### PR TITLE
Delete unnecessary function.

### DIFF
--- a/sbt/sbt-launch-lib.bash
+++ b/sbt/sbt-launch-lib.bash
@@ -186,9 +186,3 @@ run() {
     "${residual_args[@]}"
 }
 
-runAlternateBoot() {
-  local bootpropsfile="$1"
-  shift
-  addJava "-Dsbt.boot.properties=$bootpropsfile"
-  run $@
-}


### PR DESCRIPTION
when building spark by sbt, the function “runAlternateBoot" in  sbt/sbt-launch-lib.bash is not used. And this function is not used by spark code. So I think this function is not necessary. And the option of "sbt.boot.properties" can be configured in the command line when building spark, eg: 
sbt/sbt  assembly -Dsbt.boot.properties=$bootpropsfile.
