### PR TITLE
SPARK-2624 add datanucleus jars to the container in yarn-cluster

### DIFF
--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -132,6 +132,18 @@ Most of the configs are the same for Spark on YARN as for other deployment modes
     The maximum number of threads to use in the application master for launching executor containers.
   </td>
 </tr>
+<tr>
+  <td><code>spark.yarn.datanucleus.dir</code></td>
+  <td>(none)</td>
+  <td>
+     The location of the DataNucleus jars, in case overriding the default location is desired.
+     By default, Spark on YARN will use the DataNucleus jars installed at
+     <code>{sparkHome}/lib</code>, but the jars can also be in a world-readable location on HDFS.
+     This allows YARN to cache it on nodes so that it doesn't need to be distributed each time an
+     application runs. To point to a directory on HDFS, for example, set this configuration to
+     "hdfs:///some/path".
+  </td>
+</tr>
 </table>
 
 # Launching Spark on YARN

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -138,10 +138,13 @@ Most of the configs are the same for Spark on YARN as for other deployment modes
   <td>
      The location of the DataNucleus jars, in case overriding the default location is desired.
      By default, Spark on YARN will use the DataNucleus jars installed at
-     <code>{sparkHome}/lib</code>, but the jars can also be in a world-readable location on HDFS.
+     <code>$SPARK_HOME/lib</code>, but the jars can also be in a world-readable location on HDFS.
      This allows YARN to cache it on nodes so that it doesn't need to be distributed each time an
      application runs. To point to a directory on HDFS, for example, set this configuration to
      "hdfs:///some/path".
+
+     This is required because the datanucleus jars cannot be packaged into the
+     assembly jar due to metadata conflicts (involving <code>plugin.xml</code>.)
   </td>
 </tr>
 </table>

--- a/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/ClientBase.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/ClientBase.scala
@@ -18,11 +18,11 @@
 package org.apache.spark.deploy.yarn
 
 import java.net.{InetAddress, UnknownHostException, URI, URISyntaxException}
+import java.io.{File, FilenameFilter}
 
 import scala.collection.JavaConversions._
 import scala.collection.mutable.{HashMap, ListBuffer, Map}
 import scala.util.{Try, Success, Failure}
-import java.io.{File, FilenameFilter}
 
 import com.google.common.base.Objects
 import org.apache.hadoop.conf.Configuration


### PR DESCRIPTION
If `spark-submit` finds the datanucleus jars, it adds them to the driver's classpath, but does not add it to the container.

This patch modifies the yarn deployment class to copy all `datanucleus-*` jars found in `[spark-home]/libs` to the container.
