### PR TITLE
[SPARK-2687] [yarn]amClient should remove ContainerRequest

### DIFF
--- a/yarn/alpha/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocationHandler.scala
+++ b/yarn/alpha/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocationHandler.scala
@@ -125,6 +125,9 @@ private[yarn] class YarnAllocationHandler(
     releaseList.add(container.getId())
   }
 
+  override protected def removeContainerRequest() = {
+  }
+
   private def createRackResourceRequests(hostContainers: List[ResourceRequest]):
     List[ResourceRequest] = {
     // First generate modified racks and new set of hosts under it : then issue requests

--- a/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -301,6 +301,7 @@ private[yarn] abstract class YarnAllocator(
 
         val executorMemoryOverhead = (executorMemory + memoryOverhead)
         assert(container.getResource.getMemory >= executorMemoryOverhead)
+        removeContainerRequest()
 
         if (numExecutorsRunningNow > maxExecutors) {
           logInfo("""Ignoring container %s at host %s, since we already have the required number of
@@ -505,6 +506,9 @@ private[yarn] abstract class YarnAllocator(
 
   /** Called to release a previously allocated container. */
   protected def releaseContainer(container: Container): Unit
+
+  /** Called to remove container request. */
+  protected def removeContainerRequest(): Unit
 
   /**
    * Defines the interface for an allocate response from the RM. This is needed since the alpha


### PR DESCRIPTION
in https://issues.apache.org/jira/browse/YARN-1902, after receving allocated containers,if amClient donot remove ContainerRequest,RM will continually allocate container for spark AppMaster.@tgravescs
