### PR TITLE
[SPARK-4382] Add locations parameter to Twitter Stream

### DIFF
--- a/external/twitter/src/main/scala/org/apache/spark/streaming/twitter/TwitterInputDStream.scala
+++ b/external/twitter/src/main/scala/org/apache/spark/streaming/twitter/TwitterInputDStream.scala
@@ -93,12 +93,12 @@ class TwitterReceiver(
         }
       })
 
-      if (filters.size > 0 || locations.size > 0) {
+      if (filters.nonEmpty || locations.nonEmpty) {
         val query = new FilterQuery
-        if (filters.size > 0) {
+        if (filters.nonEmpty) {
           query.track(filters.toArray)
         }
-        if (locations.size > 0) {
+        if (locations.nonEmpty) {
           query.locations(locations.map(l => Array(l._1, l._2)).toArray)
         }
         newTwitterStream.filter(query)

--- a/external/twitter/src/main/scala/org/apache/spark/streaming/twitter/TwitterInputDStream.scala
+++ b/external/twitter/src/main/scala/org/apache/spark/streaming/twitter/TwitterInputDStream.scala
@@ -42,6 +42,7 @@ class TwitterInputDStream(
     @transient ssc_ : StreamingContext,
     twitterAuth: Option[Authorization],
     filters: Seq[String],
+    locations: Seq[Seq[Double]],
     storageLevel: StorageLevel
   ) extends ReceiverInputDStream[Status](ssc_)  {
 
@@ -52,7 +53,7 @@ class TwitterInputDStream(
   private val authorization = twitterAuth.getOrElse(createOAuthAuthorization())
 
   override def getReceiver(): Receiver[Status] = {
-    new TwitterReceiver(authorization, filters, storageLevel)
+    new TwitterReceiver(authorization, filters, locations, storageLevel)
   }
 }
 
@@ -60,6 +61,7 @@ private[streaming]
 class TwitterReceiver(
     twitterAuth: Authorization,
     filters: Seq[String],
+    locations: Seq[Seq[Double]],
     storageLevel: StorageLevel
   ) extends Receiver[Status](storageLevel) with Logging {
 
@@ -88,6 +90,11 @@ class TwitterReceiver(
       val query = new FilterQuery
       if (filters.size > 0) {
         query.track(filters.toArray)
+      }
+      if (locations.size > 0) {
+        query.locations(locations.map(_.toArray).toArray)
+      }
+      if (filters.size > 0 || locations.size > 0) {
         newTwitterStream.filter(query)
       } else {
         newTwitterStream.sample()

--- a/external/twitter/src/main/scala/org/apache/spark/streaming/twitter/TwitterUtils.scala
+++ b/external/twitter/src/main/scala/org/apache/spark/streaming/twitter/TwitterUtils.scala
@@ -25,16 +25,6 @@ import org.apache.spark.streaming.api.java.{JavaReceiverInputDStream, JavaDStrea
 import org.apache.spark.streaming.dstream.{ReceiverInputDStream, DStream}
 
 object TwitterUtils {
-
-  // For implicit parameter used to avoid to have same type after erasure
-  case class Ignore(value: String ) {
-    override def toString = value
-  }
-
-  implicit def stringToIgnore(value: String) = Ignore(value)
-
-  implicit val ignore: Ignore = ""
-
  
   /**
    * Create a input stream that returns tweets received from Twitter.
@@ -44,94 +34,30 @@ object TwitterUtils {
    *        twitter4j.oauth.consumerSecret, twitter4j.oauth.accessToken and
    *        twitter4j.oauth.accessTokenSecret
    * @param filters Set of filter strings to get only those tweets that match them
-   */
-  def createStream(
-      ssc: StreamingContext,
-      twitterAuth: Option[Authorization],
-      filters: Seq[String]
-    ): ReceiverInputDStream[Status] = {
-    createStream(ssc, twitterAuth, filters, Nil, StorageLevel.MEMORY_AND_DISK_SER_2) 
-  }
- 
-  /**
-   * Create a input stream that returns tweets received from Twitter.
-   * @param ssc         StreamingContext object
-   * @param twitterAuth Twitter4J authentication, or None to use Twitter4J's default OAuth
-   *        authorization; this uses the system properties twitter4j.oauth.consumerKey,
-   *        twitter4j.oauth.consumerSecret, twitter4j.oauth.accessToken and
-   *        twitter4j.oauth.accessTokenSecret
-   * @param locations Set of longitude, latitude pairs to get only those tweets
-   *        that falling within the requested bounding boxes  
-   */
-  def createStream(
-      ssc: StreamingContext,
-      twitterAuth: Option[Authorization],
-      locations: Seq[Seq[Double]]
-    )(implicit ignore: Ignore): ReceiverInputDStream[Status] = {
-    createStream(ssc, twitterAuth, Nil, locations, StorageLevel.MEMORY_AND_DISK_SER_2)
-  }
- 
-  /**
-   * Create a input stream that returns tweets received from Twitter.
-   * @param ssc         StreamingContext object
-   * @param twitterAuth Twitter4J authentication, or None to use Twitter4J's default OAuth
-   *        authorization; this uses the system properties twitter4j.oauth.consumerKey,
-   *        twitter4j.oauth.consumerSecret, twitter4j.oauth.accessToken and
-   *        twitter4j.oauth.accessTokenSecret
-   * @param filters Set of filter strings to get only those tweets that match them
-   * @param storageLevel Storage level to use for storing the received objects
-   */
-  def createStream(
-      ssc: StreamingContext,
-      twitterAuth: Option[Authorization],
-      filters: Seq[String],
-      storageLevel: StorageLevel
-    ): ReceiverInputDStream[Status] = {
-    createStream(ssc, twitterAuth, filters, Nil, storageLevel)
-  }
- 
-  /**
-   * Create a input stream that returns tweets received from Twitter.
-   * @param ssc         StreamingContext object
-   * @param twitterAuth Twitter4J authentication, or None to use Twitter4J's default OAuth
-   *        authorization; this uses the system properties twitter4j.oauth.consumerKey,
-   *        twitter4j.oauth.consumerSecret, twitter4j.oauth.accessToken and
-   *        twitter4j.oauth.accessTokenSecret
-   * @param locations Set of longitude, latitude pairs to get only those tweets
-   *        that falling within the requested bounding boxes  
-   * @param storageLevel Storage level to use for storing the received objects
-   */
-  def createStream(
-      ssc: StreamingContext,
-      twitterAuth: Option[Authorization],
-      locations: Seq[Seq[Double]],
-      storageLevel: StorageLevel
-    )(implicit ignore: Ignore): ReceiverInputDStream[Status] = {
-    createStream(ssc, twitterAuth, Nil, locations, storageLevel)
-  }
- 
-  /**
-   * Create a input stream that returns tweets received from Twitter.
-   * @param ssc         StreamingContext object
-   * @param twitterAuth Twitter4J authentication, or None to use Twitter4J's default OAuth
-   *        authorization; this uses the system properties twitter4j.oauth.consumerKey,
-   *        twitter4j.oauth.consumerSecret, twitter4j.oauth.accessToken and
-   *        twitter4j.oauth.accessTokenSecret
-   * @param filters Set of filter strings to get only those tweets that match them
-   * @param locations Set of longitude, latitude pairs to get only those tweets
-   *        that falling within the requested bounding boxes  
    * @param storageLevel Storage level to use for storing the received objects
    */
   def createStream(
       ssc: StreamingContext,
       twitterAuth: Option[Authorization],
       filters: Seq[String] = Nil,
-      locations: Seq[Seq[Double]] = Nil,
       storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK_SER_2
     ): ReceiverInputDStream[Status] = {
-    new TwitterInputDStream(ssc, twitterAuth, filters, locations, storageLevel)
+    new TwitterInputDStream(ssc, twitterAuth, filters, storageLevel)
   }
  
+  /**
+   * Set location filter for a input stream.
+   * @param locations Set of longitude, latitude pairs to get only those tweets
+   *        that falling within the requested bounding boxes
+   * @param storageLevel Storage level to use for storing the received objects
+   */
+  def setLocations(
+      stream: ReceiverInputDStream[Status],
+      locations: Seq[(Double, Double)]
+    ): ReceiverInputDStream[Status] = {
+    stream.asInstanceOf[TwitterInputDStream].setLocations(locations)
+  }
+
   /**
    * Create a input stream that returns tweets received from Twitter using Twitter4J's default
    * OAuth authentication; this requires the system properties twitter4j.oauth.consumerKey,
@@ -141,7 +67,7 @@ object TwitterUtils {
    * @param jssc   JavaStreamingContext object
    */
   def createStream(jssc: JavaStreamingContext): JavaReceiverInputDStream[Status] = {
-    createStream(jssc.ssc, None, Nil, Nil)
+    createStream(jssc.ssc, None) 
   }
 
   /**
@@ -155,38 +81,7 @@ object TwitterUtils {
    */
   def createStream(jssc: JavaStreamingContext, filters: Array[String]
       ): JavaReceiverInputDStream[Status] = {
-    createStream(jssc.ssc, None, filters.toSeq, Nil, StorageLevel.MEMORY_AND_DISK_SER_2)
-  }
- 
-  /**
-   * Create a input stream that returns tweets received from Twitter using Twitter4J's default
-   * OAuth authentication; this requires the system properties twitter4j.oauth.consumerKey,
-   * twitter4j.oauth.consumerSecret, twitter4j.oauth.accessToken and
-   * twitter4j.oauth.accessTokenSecret.
-   * Storage level of the data will be the default StorageLevel.MEMORY_AND_DISK_SER_2.
-   * @param jssc    JavaStreamingContext object
-   * @param filters Set of filter strings to get only those tweets that match them
-   * @param locations Set of longitude, latitude pairs to get only those tweets
-   *        that falling within the requested bounding boxes
-   */
-  def createStream(jssc: JavaStreamingContext, filters: Array[String],
-      locations: Array[Array[Double]]): JavaReceiverInputDStream[Status] = {
-    createStream(jssc.ssc, None, filters, locations.map(_.toSeq).toSeq)
-  }
- 
-  /**
-   * Create a input stream that returns tweets received from Twitter using Twitter4J's default
-   * OAuth authentication; this requires the system properties twitter4j.oauth.consumerKey,
-   * twitter4j.oauth.consumerSecret, twitter4j.oauth.accessToken and
-   * twitter4j.oauth.accessTokenSecret.
-   * Storage level of the data will be the default StorageLevel.MEMORY_AND_DISK_SER_2.
-   * @param jssc    JavaStreamingContext object
-   * @param locations Set of longitude, latitude pairs to get only those tweets
-   *        that falling within the requested bounding boxes
-   */
-  def createStream(jssc: JavaStreamingContext, locations: Array[Array[Double]]
-      ): JavaReceiverInputDStream[Status] = {
-    createStream(jssc.ssc, None, Nil, locations.map(_.toSeq).toSeq)
+    createStream(jssc.ssc, None, filters)
   }
  
   /**
@@ -203,47 +98,9 @@ object TwitterUtils {
       filters: Array[String],
       storageLevel: StorageLevel
     ): JavaReceiverInputDStream[Status] = {
-    createStream(jssc.ssc, None, filters, Nil, storageLevel)
+    createStream(jssc.ssc, None, filters, storageLevel)
   }
- 
-  /**
-   * Create a input stream that returns tweets received from Twitter using Twitter4J's default
-   * OAuth authentication; this requires the system properties twitter4j.oauth.consumerKey,
-   * twitter4j.oauth.consumerSecret, twitter4j.oauth.accessToken and
-   * twitter4j.oauth.accessTokenSecret.
-   * @param jssc         JavaStreamingContext object
-   * @param filters      Set of filter strings to get only those tweets that match them
-   * @param locations Set of longitude, latitude pairs to get only those tweets
-   *        that falling within the requested bounding boxes
-   * @param storageLevel Storage level to use for storing the received objects
-   */
-  def createStream(
-      jssc: JavaStreamingContext,
-      filters: Array[String],
-      locations: Array[Array[Double]],
-      storageLevel: StorageLevel
-    ): JavaReceiverInputDStream[Status] = {
-    createStream(jssc.ssc, None, filters, locations.map(_.toSeq).toSeq, storageLevel)
-  }
- 
-  /**
-   * Create a input stream that returns tweets received from Twitter using Twitter4J's default
-   * OAuth authentication; this requires the system properties twitter4j.oauth.consumerKey,
-   * twitter4j.oauth.consumerSecret, twitter4j.oauth.accessToken and
-   * twitter4j.oauth.accessTokenSecret.
-   * @param jssc         JavaStreamingContext object
-   * @param locations Set of longitude, latitude pairs to get only those tweets
-   *        that falling within the requested bounding boxes
-   * @param storageLevel Storage level to use for storing the received objects
-   */
-  def createStream(
-      jssc: JavaStreamingContext,
-      locations: Array[Array[Double]],
-      storageLevel: StorageLevel
-    ): JavaReceiverInputDStream[Status] = {
-    createStream(jssc.ssc, None, Nil, locations.map(_.toSeq).toSeq, storageLevel)
-  }
- 
+
   /**
    * Create a input stream that returns tweets received from Twitter.
    * Storage level of the data will be the default StorageLevel.MEMORY_AND_DISK_SER_2.
@@ -269,41 +126,7 @@ object TwitterUtils {
     ): JavaReceiverInputDStream[Status] = {
     createStream(jssc.ssc, Some(twitterAuth), filters)
   }
- 
-  /**
-   * Create a input stream that returns tweets received from Twitter.
-   * Storage level of the data will be the default StorageLevel.MEMORY_AND_DISK_SER_2.
-   * @param jssc        JavaStreamingContext object
-   * @param twitterAuth Twitter4J Authorization
-   * @param filters     Set of filter strings to get only those tweets that match them
-   * @param locations Set of longitude, latitude pairs to get only those tweets
-   *        that falling within the requested bounding boxes
-   */
-  def createStream(
-      jssc: JavaStreamingContext,
-      twitterAuth: Authorization,
-      filters: Array[String],
-      locations: Array[Array[Double]]
-    ): JavaReceiverInputDStream[Status] = {
-    createStream(jssc.ssc, Some(twitterAuth), filters, locations.map(_.toSeq).toSeq)
-  }
- 
-  /**
-   * Create a input stream that returns tweets received from Twitter.
-   * Storage level of the data will be the default StorageLevel.MEMORY_AND_DISK_SER_2.
-   * @param jssc        JavaStreamingContext object
-   * @param twitterAuth Twitter4J Authorization
-   * @param locations Set of longitude, latitude pairs to get only those tweets
-   *        that falling within the requested bounding boxes
-   */
-  def createStream(
-      jssc: JavaStreamingContext,
-      twitterAuth: Authorization,
-      locations: Array[Array[Double]]
-    ): JavaReceiverInputDStream[Status] = {
-    createStream(jssc.ssc, Some(twitterAuth), Nil, locations.map(_.toSeq).toSeq)
-  }
- 
+
   /**
    * Create a input stream that returns tweets received from Twitter.
    * @param jssc         JavaStreamingContext object
@@ -317,43 +140,22 @@ object TwitterUtils {
       filters: Array[String],
       storageLevel: StorageLevel
     ): JavaReceiverInputDStream[Status] = {
-    createStream(jssc.ssc, Some(twitterAuth), filters, Nil, storageLevel)
+    createStream(jssc.ssc, Some(twitterAuth), filters, storageLevel)
   }
  
   /**
-   * Create a input stream that returns tweets received from Twitter.
-   * @param jssc         JavaStreamingContext object
-   * @param twitterAuth  Twitter4J Authorization object
-   * @param filters      Set of filter strings to get only those tweets that match them
+   * Set location filter for a input stream.
    * @param locations Set of longitude, latitude pairs to get only those tweets
    *        that falling within the requested bounding boxes
    * @param storageLevel Storage level to use for storing the received objects
    */
-  def createStream(
-      jssc: JavaStreamingContext,
-      twitterAuth: Authorization,
-      filters: Array[String],
-      locations: Array[Array[Double]],
-      storageLevel: StorageLevel
+  def setLocations(
+      jstream: JavaReceiverInputDStream[Status],
+      locations: Array[Array[Double]]
     ): JavaReceiverInputDStream[Status] = {
-    createStream(jssc.ssc, Some(twitterAuth), filters, locations.map(_.toSeq).toSeq, storageLevel)
+    val locationTuples = locations.collect{ case Array(x: Double, y: Double, _*) =>
+      (x, y)
+    }
+    jstream.receiverInputDStream.asInstanceOf[TwitterInputDStream].setLocations(locationTuples)
   }
- 
-  /**
-   * Create a input stream that returns tweets received from Twitter.
-   * @param jssc         JavaStreamingContext object
-   * @param twitterAuth  Twitter4J Authorization object
-   * @param locations Set of longitude, latitude pairs to get only those tweets
-   *        that falling within the requested bounding boxes
-   * @param storageLevel Storage level to use for storing the received objects
-   */
-  def createStream(
-      jssc: JavaStreamingContext,
-      twitterAuth: Authorization,
-      locations: Array[Array[Double]],
-      storageLevel: StorageLevel
-    ): JavaReceiverInputDStream[Status] = {
-    createStream(jssc.ssc, Some(twitterAuth), Nil, locations.map(_.toSeq).toSeq, storageLevel)
-  }
- 
 }

--- a/external/twitter/src/main/scala/org/apache/spark/streaming/twitter/TwitterUtils.scala
+++ b/external/twitter/src/main/scala/org/apache/spark/streaming/twitter/TwitterUtils.scala
@@ -25,7 +25,6 @@ import org.apache.spark.streaming.api.java.{JavaReceiverInputDStream, JavaDStrea
 import org.apache.spark.streaming.dstream.{ReceiverInputDStream, DStream}
 
 object TwitterUtils {
- 
   /**
    * Create a input stream that returns tweets received from Twitter.
    * @param ssc         StreamingContext object
@@ -67,7 +66,7 @@ object TwitterUtils {
    * @param jssc   JavaStreamingContext object
    */
   def createStream(jssc: JavaStreamingContext): JavaReceiverInputDStream[Status] = {
-    createStream(jssc.ssc, None) 
+    createStream(jssc.ssc, None)
   }
 
   /**
@@ -83,7 +82,7 @@ object TwitterUtils {
       ): JavaReceiverInputDStream[Status] = {
     createStream(jssc.ssc, None, filters)
   }
- 
+
   /**
    * Create a input stream that returns tweets received from Twitter using Twitter4J's default
    * OAuth authentication; this requires the system properties twitter4j.oauth.consumerKey,

--- a/external/twitter/src/main/scala/org/apache/spark/streaming/twitter/TwitterUtils.scala
+++ b/external/twitter/src/main/scala/org/apache/spark/streaming/twitter/TwitterUtils.scala
@@ -25,6 +25,52 @@ import org.apache.spark.streaming.api.java.{JavaReceiverInputDStream, JavaDStrea
 import org.apache.spark.streaming.dstream.{ReceiverInputDStream, DStream}
 
 object TwitterUtils {
+
+  // For implicit parameter used to avoid to have same type after erasure
+  case class Ignore(value: String ) {
+    override def toString = value
+  }
+
+  implicit def stringToIgnore(value: String) = Ignore(value)
+
+  implicit val ignore: Ignore = ""
+
+ 
+  /**
+   * Create a input stream that returns tweets received from Twitter.
+   * @param ssc         StreamingContext object
+   * @param twitterAuth Twitter4J authentication, or None to use Twitter4J's default OAuth
+   *        authorization; this uses the system properties twitter4j.oauth.consumerKey,
+   *        twitter4j.oauth.consumerSecret, twitter4j.oauth.accessToken and
+   *        twitter4j.oauth.accessTokenSecret
+   * @param filters Set of filter strings to get only those tweets that match them
+   */
+  def createStream(
+      ssc: StreamingContext,
+      twitterAuth: Option[Authorization],
+      filters: Seq[String]
+    ): ReceiverInputDStream[Status] = {
+    createStream(ssc, twitterAuth, filters, Nil, StorageLevel.MEMORY_AND_DISK_SER_2) 
+  }
+ 
+  /**
+   * Create a input stream that returns tweets received from Twitter.
+   * @param ssc         StreamingContext object
+   * @param twitterAuth Twitter4J authentication, or None to use Twitter4J's default OAuth
+   *        authorization; this uses the system properties twitter4j.oauth.consumerKey,
+   *        twitter4j.oauth.consumerSecret, twitter4j.oauth.accessToken and
+   *        twitter4j.oauth.accessTokenSecret
+   * @param locations Set of longitude, latitude pairs to get only those tweets
+   *        that falling within the requested bounding boxes  
+   */
+  def createStream(
+      ssc: StreamingContext,
+      twitterAuth: Option[Authorization],
+      locations: Seq[Seq[Double]]
+    )(implicit ignore: Ignore): ReceiverInputDStream[Status] = {
+    createStream(ssc, twitterAuth, Nil, locations, StorageLevel.MEMORY_AND_DISK_SER_2)
+  }
+ 
   /**
    * Create a input stream that returns tweets received from Twitter.
    * @param ssc         StreamingContext object
@@ -38,12 +84,54 @@ object TwitterUtils {
   def createStream(
       ssc: StreamingContext,
       twitterAuth: Option[Authorization],
+      filters: Seq[String],
+      storageLevel: StorageLevel
+    ): ReceiverInputDStream[Status] = {
+    createStream(ssc, twitterAuth, filters, Nil, storageLevel)
+  }
+ 
+  /**
+   * Create a input stream that returns tweets received from Twitter.
+   * @param ssc         StreamingContext object
+   * @param twitterAuth Twitter4J authentication, or None to use Twitter4J's default OAuth
+   *        authorization; this uses the system properties twitter4j.oauth.consumerKey,
+   *        twitter4j.oauth.consumerSecret, twitter4j.oauth.accessToken and
+   *        twitter4j.oauth.accessTokenSecret
+   * @param locations Set of longitude, latitude pairs to get only those tweets
+   *        that falling within the requested bounding boxes  
+   * @param storageLevel Storage level to use for storing the received objects
+   */
+  def createStream(
+      ssc: StreamingContext,
+      twitterAuth: Option[Authorization],
+      locations: Seq[Seq[Double]],
+      storageLevel: StorageLevel
+    )(implicit ignore: Ignore): ReceiverInputDStream[Status] = {
+    createStream(ssc, twitterAuth, Nil, locations, storageLevel)
+  }
+ 
+  /**
+   * Create a input stream that returns tweets received from Twitter.
+   * @param ssc         StreamingContext object
+   * @param twitterAuth Twitter4J authentication, or None to use Twitter4J's default OAuth
+   *        authorization; this uses the system properties twitter4j.oauth.consumerKey,
+   *        twitter4j.oauth.consumerSecret, twitter4j.oauth.accessToken and
+   *        twitter4j.oauth.accessTokenSecret
+   * @param filters Set of filter strings to get only those tweets that match them
+   * @param locations Set of longitude, latitude pairs to get only those tweets
+   *        that falling within the requested bounding boxes  
+   * @param storageLevel Storage level to use for storing the received objects
+   */
+  def createStream(
+      ssc: StreamingContext,
+      twitterAuth: Option[Authorization],
       filters: Seq[String] = Nil,
+      locations: Seq[Seq[Double]] = Nil,
       storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK_SER_2
     ): ReceiverInputDStream[Status] = {
-    new TwitterInputDStream(ssc, twitterAuth, filters, storageLevel)
+    new TwitterInputDStream(ssc, twitterAuth, filters, locations, storageLevel)
   }
-
+ 
   /**
    * Create a input stream that returns tweets received from Twitter using Twitter4J's default
    * OAuth authentication; this requires the system properties twitter4j.oauth.consumerKey,
@@ -53,7 +141,7 @@ object TwitterUtils {
    * @param jssc   JavaStreamingContext object
    */
   def createStream(jssc: JavaStreamingContext): JavaReceiverInputDStream[Status] = {
-    createStream(jssc.ssc, None)
+    createStream(jssc.ssc, None, Nil, Nil)
   }
 
   /**
@@ -67,9 +155,40 @@ object TwitterUtils {
    */
   def createStream(jssc: JavaStreamingContext, filters: Array[String]
       ): JavaReceiverInputDStream[Status] = {
-    createStream(jssc.ssc, None, filters)
+    createStream(jssc.ssc, None, filters.toSeq, Nil, StorageLevel.MEMORY_AND_DISK_SER_2)
   }
-
+ 
+  /**
+   * Create a input stream that returns tweets received from Twitter using Twitter4J's default
+   * OAuth authentication; this requires the system properties twitter4j.oauth.consumerKey,
+   * twitter4j.oauth.consumerSecret, twitter4j.oauth.accessToken and
+   * twitter4j.oauth.accessTokenSecret.
+   * Storage level of the data will be the default StorageLevel.MEMORY_AND_DISK_SER_2.
+   * @param jssc    JavaStreamingContext object
+   * @param filters Set of filter strings to get only those tweets that match them
+   * @param locations Set of longitude, latitude pairs to get only those tweets
+   *        that falling within the requested bounding boxes
+   */
+  def createStream(jssc: JavaStreamingContext, filters: Array[String],
+      locations: Array[Array[Double]]): JavaReceiverInputDStream[Status] = {
+    createStream(jssc.ssc, None, filters, locations.map(_.toSeq).toSeq)
+  }
+ 
+  /**
+   * Create a input stream that returns tweets received from Twitter using Twitter4J's default
+   * OAuth authentication; this requires the system properties twitter4j.oauth.consumerKey,
+   * twitter4j.oauth.consumerSecret, twitter4j.oauth.accessToken and
+   * twitter4j.oauth.accessTokenSecret.
+   * Storage level of the data will be the default StorageLevel.MEMORY_AND_DISK_SER_2.
+   * @param jssc    JavaStreamingContext object
+   * @param locations Set of longitude, latitude pairs to get only those tweets
+   *        that falling within the requested bounding boxes
+   */
+  def createStream(jssc: JavaStreamingContext, locations: Array[Array[Double]]
+      ): JavaReceiverInputDStream[Status] = {
+    createStream(jssc.ssc, None, Nil, locations.map(_.toSeq).toSeq)
+  }
+ 
   /**
    * Create a input stream that returns tweets received from Twitter using Twitter4J's default
    * OAuth authentication; this requires the system properties twitter4j.oauth.consumerKey,
@@ -84,9 +203,47 @@ object TwitterUtils {
       filters: Array[String],
       storageLevel: StorageLevel
     ): JavaReceiverInputDStream[Status] = {
-    createStream(jssc.ssc, None, filters, storageLevel)
+    createStream(jssc.ssc, None, filters, Nil, storageLevel)
   }
-
+ 
+  /**
+   * Create a input stream that returns tweets received from Twitter using Twitter4J's default
+   * OAuth authentication; this requires the system properties twitter4j.oauth.consumerKey,
+   * twitter4j.oauth.consumerSecret, twitter4j.oauth.accessToken and
+   * twitter4j.oauth.accessTokenSecret.
+   * @param jssc         JavaStreamingContext object
+   * @param filters      Set of filter strings to get only those tweets that match them
+   * @param locations Set of longitude, latitude pairs to get only those tweets
+   *        that falling within the requested bounding boxes
+   * @param storageLevel Storage level to use for storing the received objects
+   */
+  def createStream(
+      jssc: JavaStreamingContext,
+      filters: Array[String],
+      locations: Array[Array[Double]],
+      storageLevel: StorageLevel
+    ): JavaReceiverInputDStream[Status] = {
+    createStream(jssc.ssc, None, filters, locations.map(_.toSeq).toSeq, storageLevel)
+  }
+ 
+  /**
+   * Create a input stream that returns tweets received from Twitter using Twitter4J's default
+   * OAuth authentication; this requires the system properties twitter4j.oauth.consumerKey,
+   * twitter4j.oauth.consumerSecret, twitter4j.oauth.accessToken and
+   * twitter4j.oauth.accessTokenSecret.
+   * @param jssc         JavaStreamingContext object
+   * @param locations Set of longitude, latitude pairs to get only those tweets
+   *        that falling within the requested bounding boxes
+   * @param storageLevel Storage level to use for storing the received objects
+   */
+  def createStream(
+      jssc: JavaStreamingContext,
+      locations: Array[Array[Double]],
+      storageLevel: StorageLevel
+    ): JavaReceiverInputDStream[Status] = {
+    createStream(jssc.ssc, None, Nil, locations.map(_.toSeq).toSeq, storageLevel)
+  }
+ 
   /**
    * Create a input stream that returns tweets received from Twitter.
    * Storage level of the data will be the default StorageLevel.MEMORY_AND_DISK_SER_2.
@@ -112,7 +269,41 @@ object TwitterUtils {
     ): JavaReceiverInputDStream[Status] = {
     createStream(jssc.ssc, Some(twitterAuth), filters)
   }
-
+ 
+  /**
+   * Create a input stream that returns tweets received from Twitter.
+   * Storage level of the data will be the default StorageLevel.MEMORY_AND_DISK_SER_2.
+   * @param jssc        JavaStreamingContext object
+   * @param twitterAuth Twitter4J Authorization
+   * @param filters     Set of filter strings to get only those tweets that match them
+   * @param locations Set of longitude, latitude pairs to get only those tweets
+   *        that falling within the requested bounding boxes
+   */
+  def createStream(
+      jssc: JavaStreamingContext,
+      twitterAuth: Authorization,
+      filters: Array[String],
+      locations: Array[Array[Double]]
+    ): JavaReceiverInputDStream[Status] = {
+    createStream(jssc.ssc, Some(twitterAuth), filters, locations.map(_.toSeq).toSeq)
+  }
+ 
+  /**
+   * Create a input stream that returns tweets received from Twitter.
+   * Storage level of the data will be the default StorageLevel.MEMORY_AND_DISK_SER_2.
+   * @param jssc        JavaStreamingContext object
+   * @param twitterAuth Twitter4J Authorization
+   * @param locations Set of longitude, latitude pairs to get only those tweets
+   *        that falling within the requested bounding boxes
+   */
+  def createStream(
+      jssc: JavaStreamingContext,
+      twitterAuth: Authorization,
+      locations: Array[Array[Double]]
+    ): JavaReceiverInputDStream[Status] = {
+    createStream(jssc.ssc, Some(twitterAuth), Nil, locations.map(_.toSeq).toSeq)
+  }
+ 
   /**
    * Create a input stream that returns tweets received from Twitter.
    * @param jssc         JavaStreamingContext object
@@ -126,6 +317,43 @@ object TwitterUtils {
       filters: Array[String],
       storageLevel: StorageLevel
     ): JavaReceiverInputDStream[Status] = {
-    createStream(jssc.ssc, Some(twitterAuth), filters, storageLevel)
+    createStream(jssc.ssc, Some(twitterAuth), filters, Nil, storageLevel)
   }
+ 
+  /**
+   * Create a input stream that returns tweets received from Twitter.
+   * @param jssc         JavaStreamingContext object
+   * @param twitterAuth  Twitter4J Authorization object
+   * @param filters      Set of filter strings to get only those tweets that match them
+   * @param locations Set of longitude, latitude pairs to get only those tweets
+   *        that falling within the requested bounding boxes
+   * @param storageLevel Storage level to use for storing the received objects
+   */
+  def createStream(
+      jssc: JavaStreamingContext,
+      twitterAuth: Authorization,
+      filters: Array[String],
+      locations: Array[Array[Double]],
+      storageLevel: StorageLevel
+    ): JavaReceiverInputDStream[Status] = {
+    createStream(jssc.ssc, Some(twitterAuth), filters, locations.map(_.toSeq).toSeq, storageLevel)
+  }
+ 
+  /**
+   * Create a input stream that returns tweets received from Twitter.
+   * @param jssc         JavaStreamingContext object
+   * @param twitterAuth  Twitter4J Authorization object
+   * @param locations Set of longitude, latitude pairs to get only those tweets
+   *        that falling within the requested bounding boxes
+   * @param storageLevel Storage level to use for storing the received objects
+   */
+  def createStream(
+      jssc: JavaStreamingContext,
+      twitterAuth: Authorization,
+      locations: Array[Array[Double]],
+      storageLevel: StorageLevel
+    ): JavaReceiverInputDStream[Status] = {
+    createStream(jssc.ssc, Some(twitterAuth), Nil, locations.map(_.toSeq).toSeq, storageLevel)
+  }
+ 
 }

--- a/external/twitter/src/test/java/org/apache/spark/streaming/twitter/JavaTwitterStreamSuite.java
+++ b/external/twitter/src/test/java/org/apache/spark/streaming/twitter/JavaTwitterStreamSuite.java
@@ -37,27 +37,28 @@ public class JavaTwitterStreamSuite extends LocalJavaStreamingContext {
     // tests the API, does not actually test data receiving
     JavaDStream<Status> test1 = TwitterUtils.createStream(ssc);
     JavaDStream<Status> test2 = TwitterUtils.createStream(ssc, filters);
-    JavaDStream<Status> test3 = TwitterUtils.createStream(ssc, locations);
-    JavaDStream<Status> test4 = TwitterUtils.createStream(ssc, filters, locations);
-  
-    JavaDStream<Status> test5 = TwitterUtils.createStream(
+
+    JavaDStream<Status> test3 = TwitterUtils.setLocations(
+      TwitterUtils.createStream(ssc, filters), locations);
+
+    JavaDStream<Status> test4 = TwitterUtils.createStream(
       ssc, filters, StorageLevel.MEMORY_AND_DISK_SER_2());
-    JavaDStream<Status> test6 = TwitterUtils.createStream(
-      ssc, locations, StorageLevel.MEMORY_AND_DISK_SER_2());
-    JavaDStream<Status> test7 = TwitterUtils.createStream(
-      ssc, filters, locations, StorageLevel.MEMORY_AND_DISK_SER_2());
+
+    JavaDStream<Status> test5 = TwitterUtils.setLocations(
+      TwitterUtils.createStream(ssc, filters, StorageLevel.MEMORY_AND_DISK_SER_2()),
+      locations);
  
-    JavaDStream<Status> test8 = TwitterUtils.createStream(ssc, auth);
-    JavaDStream<Status> test9 = TwitterUtils.createStream(ssc, auth, filters);
-    JavaDStream<Status> test10 = TwitterUtils.createStream(ssc, auth, locations);
-    JavaDStream<Status> test11 = TwitterUtils.createStream(ssc, auth, filters, locations);
- 
-    JavaDStream<Status> test12 = TwitterUtils.createStream(ssc,
+    JavaDStream<Status> test6 = TwitterUtils.createStream(ssc, auth);
+    JavaDStream<Status> test7 = TwitterUtils.createStream(ssc, auth, filters);
+
+    JavaDStream<Status> test8 = TwitterUtils.setLocations(
+      TwitterUtils.createStream(ssc, auth, filters), locations);
+
+    JavaDStream<Status> test9 = TwitterUtils.createStream(ssc,
       auth, filters, StorageLevel.MEMORY_AND_DISK_SER_2());
-    JavaDStream<Status> test13 = TwitterUtils.createStream(ssc,
-      auth, locations, StorageLevel.MEMORY_AND_DISK_SER_2());
-    JavaDStream<Status> test14 = TwitterUtils.createStream(ssc,
-      auth, filters, locations, StorageLevel.MEMORY_AND_DISK_SER_2());
- 
+
+    JavaDStream<Status> test10 = TwitterUtils.setLocations(
+      TwitterUtils.createStream(ssc, auth, filters, StorageLevel.MEMORY_AND_DISK_SER_2()),
+      locations);
   }
 }

--- a/external/twitter/src/test/java/org/apache/spark/streaming/twitter/JavaTwitterStreamSuite.java
+++ b/external/twitter/src/test/java/org/apache/spark/streaming/twitter/JavaTwitterStreamSuite.java
@@ -31,16 +31,33 @@ public class JavaTwitterStreamSuite extends LocalJavaStreamingContext {
   @Test
   public void testTwitterStream() {
     String[] filters = (String[])Arrays.<String>asList("filter1", "filter2").toArray();
+    double[][] locations = { {-180.0, -90.0}, {180.0, 90.0} };
     Authorization auth = NullAuthorization.getInstance();
 
     // tests the API, does not actually test data receiving
     JavaDStream<Status> test1 = TwitterUtils.createStream(ssc);
     JavaDStream<Status> test2 = TwitterUtils.createStream(ssc, filters);
-    JavaDStream<Status> test3 = TwitterUtils.createStream(
+    JavaDStream<Status> test3 = TwitterUtils.createStream(ssc, locations);
+    JavaDStream<Status> test4 = TwitterUtils.createStream(ssc, filters, locations);
+  
+    JavaDStream<Status> test5 = TwitterUtils.createStream(
       ssc, filters, StorageLevel.MEMORY_AND_DISK_SER_2());
-    JavaDStream<Status> test4 = TwitterUtils.createStream(ssc, auth);
-    JavaDStream<Status> test5 = TwitterUtils.createStream(ssc, auth, filters);
-    JavaDStream<Status> test6 = TwitterUtils.createStream(ssc,
+    JavaDStream<Status> test6 = TwitterUtils.createStream(
+      ssc, locations, StorageLevel.MEMORY_AND_DISK_SER_2());
+    JavaDStream<Status> test7 = TwitterUtils.createStream(
+      ssc, filters, locations, StorageLevel.MEMORY_AND_DISK_SER_2());
+ 
+    JavaDStream<Status> test8 = TwitterUtils.createStream(ssc, auth);
+    JavaDStream<Status> test9 = TwitterUtils.createStream(ssc, auth, filters);
+    JavaDStream<Status> test10 = TwitterUtils.createStream(ssc, auth, locations);
+    JavaDStream<Status> test11 = TwitterUtils.createStream(ssc, auth, filters, locations);
+ 
+    JavaDStream<Status> test12 = TwitterUtils.createStream(ssc,
       auth, filters, StorageLevel.MEMORY_AND_DISK_SER_2());
+    JavaDStream<Status> test13 = TwitterUtils.createStream(ssc,
+      auth, locations, StorageLevel.MEMORY_AND_DISK_SER_2());
+    JavaDStream<Status> test14 = TwitterUtils.createStream(ssc,
+      auth, filters, locations, StorageLevel.MEMORY_AND_DISK_SER_2());
+ 
   }
 }

--- a/external/twitter/src/test/scala/org/apache/spark/streaming/twitter/TwitterStreamSuite.scala
+++ b/external/twitter/src/test/scala/org/apache/spark/streaming/twitter/TwitterStreamSuite.scala
@@ -17,51 +17,69 @@
 
 package org.apache.spark.streaming.twitter
 
-import org.apache.spark.streaming.{StreamingContext, TestSuiteBase}
-import org.apache.spark.storage.StorageLevel
-import twitter4j.auth.{NullAuthorization, Authorization}
-import org.apache.spark.streaming.dstream.ReceiverInputDStream
-import twitter4j.Status
 
-class TwitterStreamSuite extends TestSuiteBase {
+import org.scalatest.{BeforeAndAfter, FunSuite}
+import twitter4j.Status
+import twitter4j.auth.{NullAuthorization, Authorization}
+
+import org.apache.spark.Logging
+import org.apache.spark.streaming.{Seconds, StreamingContext}
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.streaming.dstream.ReceiverInputDStream
+
+class TwitterStreamSuite extends FunSuite with BeforeAndAfter with Logging {
+
+  val batchDuration = Seconds(1)
+
+  private val master: String = "local[2]"
+
+  private val framework: String = this.getClass.getSimpleName
 
   test("twitter input stream") {
     val ssc = new StreamingContext(master, framework, batchDuration)
     val filters = Seq("filter1", "filter2")
-    val locations: Seq[Seq[Double]] = Seq(Seq(-180, -90), Seq(180, 90))
+    val locations: Seq[(Double, Double)] = Seq((-180, -90), (180, 90))
     val authorization: Authorization = NullAuthorization.getInstance()
 
     // tests the API, does not actually test data receiving
     val test1: ReceiverInputDStream[Status] = TwitterUtils.createStream(ssc, None)
     val test2: ReceiverInputDStream[Status] =
       TwitterUtils.createStream(ssc, None, filters)
+
     val test3: ReceiverInputDStream[Status] =
-      TwitterUtils.createStream(ssc, None, locations)
+      TwitterUtils.createStream(ssc, None)
+    TwitterUtils.setLocations(test3, locations)
+
     val test4: ReceiverInputDStream[Status] =
-      TwitterUtils.createStream(ssc, None, filters, locations)
+      TwitterUtils.createStream(ssc, None, filters)
+    TwitterUtils.setLocations(test4, locations)
  
     val test5: ReceiverInputDStream[Status] =
       TwitterUtils.createStream(ssc, None, filters, StorageLevel.MEMORY_AND_DISK_SER_2)
+
     val test6: ReceiverInputDStream[Status] =
-      TwitterUtils.createStream(ssc, None, locations, StorageLevel.MEMORY_AND_DISK_SER_2)
+      TwitterUtils.createStream(ssc, None, filters, StorageLevel.MEMORY_AND_DISK_SER_2)
+    TwitterUtils.setLocations(test6, locations)
+
     val test7: ReceiverInputDStream[Status] =
-      TwitterUtils.createStream(ssc, None, filters, locations, StorageLevel.MEMORY_AND_DISK_SER_2)
- 
-    val test8: ReceiverInputDStream[Status] =
       TwitterUtils.createStream(ssc, Some(authorization))
-    val test9: ReceiverInputDStream[Status] =
+    val test8: ReceiverInputDStream[Status] =
       TwitterUtils.createStream(ssc, Some(authorization), filters)
+
+    val test9: ReceiverInputDStream[Status] =
+      TwitterUtils.createStream(ssc, Some(authorization))
+    TwitterUtils.setLocations(test9, locations)
+
     val test10: ReceiverInputDStream[Status] =
-      TwitterUtils.createStream(ssc, Some(authorization), locations)
-    val test11: ReceiverInputDStream[Status] =
-      TwitterUtils.createStream(ssc, Some(authorization), filters, locations)
+      TwitterUtils.createStream(ssc, Some(authorization), filters)
+    TwitterUtils.setLocations(test10, locations)
  
+    val test11: ReceiverInputDStream[Status] = TwitterUtils.createStream(
+      ssc, Some(authorization), filters, StorageLevel.MEMORY_AND_DISK_SER_2)
+
     val test12: ReceiverInputDStream[Status] = TwitterUtils.createStream(
       ssc, Some(authorization), filters, StorageLevel.MEMORY_AND_DISK_SER_2)
-    val test13: ReceiverInputDStream[Status] = TwitterUtils.createStream(
-      ssc, Some(authorization), locations, StorageLevel.MEMORY_AND_DISK_SER_2)
-    val test14: ReceiverInputDStream[Status] = TwitterUtils.createStream(
-      ssc, Some(authorization), filters, locations, StorageLevel.MEMORY_AND_DISK_SER_2)
+    TwitterUtils.setLocations(test12, locations)
  
     // Note that actually testing the data receiving is hard as authentication keys are
     // necessary for accessing Twitter live stream

--- a/external/twitter/src/test/scala/org/apache/spark/streaming/twitter/TwitterStreamSuite.scala
+++ b/external/twitter/src/test/scala/org/apache/spark/streaming/twitter/TwitterStreamSuite.scala
@@ -28,6 +28,7 @@ class TwitterStreamSuite extends TestSuiteBase {
   test("twitter input stream") {
     val ssc = new StreamingContext(master, framework, batchDuration)
     val filters = Seq("filter1", "filter2")
+    val locations: Seq[Seq[Double]] = Seq(Seq(-180, -90), Seq(180, 90))
     val authorization: Authorization = NullAuthorization.getInstance()
 
     // tests the API, does not actually test data receiving
@@ -35,14 +36,33 @@ class TwitterStreamSuite extends TestSuiteBase {
     val test2: ReceiverInputDStream[Status] =
       TwitterUtils.createStream(ssc, None, filters)
     val test3: ReceiverInputDStream[Status] =
-      TwitterUtils.createStream(ssc, None, filters, StorageLevel.MEMORY_AND_DISK_SER_2)
+      TwitterUtils.createStream(ssc, None, locations)
     val test4: ReceiverInputDStream[Status] =
-      TwitterUtils.createStream(ssc, Some(authorization))
+      TwitterUtils.createStream(ssc, None, filters, locations)
+ 
     val test5: ReceiverInputDStream[Status] =
+      TwitterUtils.createStream(ssc, None, filters, StorageLevel.MEMORY_AND_DISK_SER_2)
+    val test6: ReceiverInputDStream[Status] =
+      TwitterUtils.createStream(ssc, None, locations, StorageLevel.MEMORY_AND_DISK_SER_2)
+    val test7: ReceiverInputDStream[Status] =
+      TwitterUtils.createStream(ssc, None, filters, locations, StorageLevel.MEMORY_AND_DISK_SER_2)
+ 
+    val test8: ReceiverInputDStream[Status] =
+      TwitterUtils.createStream(ssc, Some(authorization))
+    val test9: ReceiverInputDStream[Status] =
       TwitterUtils.createStream(ssc, Some(authorization), filters)
-    val test6: ReceiverInputDStream[Status] = TwitterUtils.createStream(
+    val test10: ReceiverInputDStream[Status] =
+      TwitterUtils.createStream(ssc, Some(authorization), locations)
+    val test11: ReceiverInputDStream[Status] =
+      TwitterUtils.createStream(ssc, Some(authorization), filters, locations)
+ 
+    val test12: ReceiverInputDStream[Status] = TwitterUtils.createStream(
       ssc, Some(authorization), filters, StorageLevel.MEMORY_AND_DISK_SER_2)
-
+    val test13: ReceiverInputDStream[Status] = TwitterUtils.createStream(
+      ssc, Some(authorization), locations, StorageLevel.MEMORY_AND_DISK_SER_2)
+    val test14: ReceiverInputDStream[Status] = TwitterUtils.createStream(
+      ssc, Some(authorization), filters, locations, StorageLevel.MEMORY_AND_DISK_SER_2)
+ 
     // Note that actually testing the data receiving is hard as authentication keys are
     // necessary for accessing Twitter live stream
     ssc.stop()


### PR DESCRIPTION
When we request Tweet stream, geo-location is one of the most important parameters. In addition to the track parameter, the locations parameter is widely used to ask for the Tweets falling within the requested bounding boxes. This PR adds the locations parameter to existing APIs.
