### PR TITLE
[SPARK-4226][SQL] SparkSQL - Add support for subqueries in predicates('in' clause)

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
@@ -247,6 +247,9 @@ class SqlParser extends AbstractSparkSQLParser {
     | termExpression ~ (REGEXP ~> termExpression) ^^ { case e1 ~ e2 => RLike(e1, e2) }
     | termExpression ~ (LIKE   ~> termExpression) ^^ { case e1 ~ e2 => Like(e1, e2) }
     | termExpression ~ (NOT ~ LIKE ~> termExpression) ^^ { case e1 ~ e2 => Not(Like(e1, e2)) }
+    | termExpression ~ (IN ~ "(" ~> start <~ ")") ^^ {
+        case e1 ~ e2 => SubqueryExpression(e1, e2)
+      }
     | termExpression ~ (IN ~ "(" ~> rep1sep(termExpression, ",")) <~ ")" ^^ {
         case e1 ~ e2 => In(e1, e2)
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
@@ -248,7 +248,7 @@ class SqlParser extends AbstractSparkSQLParser {
     | termExpression ~ (LIKE   ~> termExpression) ^^ { case e1 ~ e2 => Like(e1, e2) }
     | termExpression ~ (NOT ~ LIKE ~> termExpression) ^^ { case e1 ~ e2 => Not(Like(e1, e2)) }
     | termExpression ~ (IN ~ "(" ~> start <~ ")") ^^ {
-        case e1 ~ e2 => SubqueryExpression(e1, e2)
+        case e1 ~ e2 => In(e1, Seq(SubqueryExpression(e2)))
       }
     | termExpression ~ (IN ~ "(" ~> rep1sep(termExpression, ",")) <~ ")" ^^ {
         case e1 ~ e2 => In(e1, e2)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -60,7 +60,7 @@ class Analyzer(catalog: Catalog,
       ResolveGroupingAnalytics ::
       ResolveSortReferences ::
       ImplicitGenerate ::
-//      SubQueryExpressions ::      
+      SubQueryExpressions ::
       ResolveFunctions ::
       GlobalAggregates ::
       UnresolvedHavingClauseAttributes ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -507,7 +507,7 @@ class Analyzer(catalog: Catalog,
           // Replace the condition column names with alias names.
           val transformedConds = condition.transform{
             case a: Attribute if resolvedChild.resolve(a.name, resolver) != None =>
-              UnresolvedAttribute("subquery."+cache.get(a.name).get)
+              UnresolvedAttribute("subquery." + cache.get(a.name).get)
           }
           // Join the first projection column of subquery to the main query and add as condition
           // TODO : We can avoid if the parent condition already has this condition.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -60,7 +60,7 @@ class Analyzer(catalog: Catalog,
       ResolveGroupingAnalytics ::
       ResolveSortReferences ::
       ImplicitGenerate ::
-      SubQueryExpressions ::      
+//      SubQueryExpressions ::      
       ResolveFunctions ::
       GlobalAggregates ::
       UnresolvedHavingClauseAttributes ::
@@ -433,53 +433,97 @@ class Analyzer(catalog: Catalog,
   object SubQueryExpressions extends Rule[LogicalPlan] {
 
     def apply(plan: LogicalPlan): LogicalPlan = plan transform {
+      case p: LogicalPlan if !p.childrenResolved => p
       case filter @ Filter(conditions, child) =>
-        val subqueryExprs = new scala.collection.mutable.ArrayBuffer[SubqueryExpression]()
-        val nonSubQueryConds = new scala.collection.mutable.ArrayBuffer[Expression]()
-        val transformedConds = conditions.transform{
-          // Replace with dummy
-          case s @ SubqueryExpression(exp,subquery) =>
-            subqueryExprs += s
-            Literal(true)
+        val subqueryExprs = conditions.collect {
+          case In(exp, Seq(SubqueryExpression(subquery))) => (exp, subquery)
         }
-        if(subqueryExprs.size > 0) {
-          val subqueryExpr = subqueryExprs.remove(0)
-          val firstJoin = createLeftSemiJoin(
-                child, subqueryExpr.exp, subqueryExpr.child, transformedConds)
-          subqueryExprs.foldLeft(firstJoin){case(fj, sq) =>
-            createLeftSemiJoin(fj, sq.exp, sq.child)}
-        } else {
-          filter
+        // Replace subqueries with a dummy true literal since they are evaluated separately now.
+        val transformedConds = conditions.transform {
+          case In(_, Seq(SubqueryExpression(_))) => Literal(true)
+        }
+        subqueryExprs match {
+          case Seq() => filter // No subqueries.
+          case Seq((exp, subquery)) =>
+            createLeftSemiJoin(
+              child,
+              exp,
+              subquery,
+              transformedConds)
+          case _ =>
+            throw new TreeNodeException(filter, "Only one SubQuery expression is supported.")
         }
     }
 
+    /**
+     * Create LeftSemi join with parent query to the subquery which is mentioned in 'IN' predicate
+     * And combine the subquery conditions and parent query conditions.
+     */ 
     def createLeftSemiJoin(left: LogicalPlan,
-        expression: Expression, subquery: LogicalPlan,
-        parentConds: Expression = null) : LogicalPlan = {
-      val (transformedPlan, subqueryConds) = transformAndGetConditions(
-          expression, subquery)
-      // Unify the parent query conditions and subquery conditions and add these as j0in conditions
-      val unifyConds = if (parentConds != null) And(parentConds, subqueryConds) else subqueryConds
-      Join(left, transformedPlan, LeftSemi, Some(unifyConds))
+        value: Expression,
+        subquery: LogicalPlan,
+        parentConds: Expression) : LogicalPlan = {
+      val (transformedPlan, subqueryConds) = transformAndGetConditions(value, subquery)
+      // Add both parent query conditions and subquery conditions as join conditions
+      val allPredicates = And(parentConds, subqueryConds)
+      Join(left, transformedPlan, LeftSemi, Some(allPredicates))
     }
 
-    def transformAndGetConditions(expression: Expression,
-          plan: LogicalPlan): (LogicalPlan, Expression) = {
+    /**
+     * Transform the subquery LogicalPlan and add the expressions which are used as filters to the
+     * projection. And also return filter conditions used in subquery
+     */
+    def transformAndGetConditions(value: Expression,
+          subquery: LogicalPlan): (LogicalPlan, Expression) = {
       val expr = new scala.collection.mutable.ArrayBuffer[Expression]()
-      val transformedPlan = plan transform {
-      case project @ Project(projectList, f @ Filter(condition, child)) =>
-         expr += EqualTo(expression, projectList(0).asInstanceOf[Expression])
-         expr += condition
-         val resolvedChild = ResolveRelations(child)
-         // Add the expressions to the projections which are used as filters in subquery
-         val toBeAddedExprs = f.references.filter(
-             a=>resolvedChild.resolve(a.name, resolver) != None && !projectList.contains(a))
-         Project(projectList ++ toBeAddedExprs, child)
-      case project @ Project(projectList, child) =>
-         expr += EqualTo(expression, projectList(0).asInstanceOf[Expression])
-         project
+      // TODO : we only decorelate subqueries in very specific cases like the cases mentioned above
+      // in documentation. The more complex queries like using of subqueries inside subqueries can 
+      // be supported in future.
+      val transformedPlan = subquery transform {
+        case project @ Project(projectList, f @ Filter(condition, child)) =>
+          // Don't support more than one item in select list of subquery
+          if(projectList.size > 1) {
+            throw new TreeNodeException(
+                project,
+                "SubQuery can contain only one item in Select List")
+          }
+          val resolvedChild = ResolveRelations(child)
+          // Add the expressions to the projections which are used as filters in subquery
+          val toBeAddedExprs = f.references.filter{a =>
+            resolvedChild.resolve(a.name, resolver) != None && !project.outputSet.contains(a)}
+          val nameToExprMap = collection.mutable.Map[String, Alias]()
+          // Create aliases for all projection expressions.
+          val witAliases = (projectList ++ toBeAddedExprs).zipWithIndex.map {
+            case (exp, index) => 
+              nameToExprMap.put(exp.name, Alias(exp, s"sqc$index")())
+              Alias(exp, s"sqc$index")()
+          }
+          // Replace the condition column names with alias names.
+          val transformedConds = condition.transform {
+            case a: Attribute if resolvedChild.resolve(a.name, resolver) != None =>
+              nameToExprMap.get(a.name).get.toAttribute
+          }
+          // Join the first projection column of subquery to the main query and add as condition
+          // TODO : We can avoid if the parent condition already has this condition.
+          expr += EqualTo(value, witAliases(0).toAttribute)
+          expr += transformedConds
+          Project(witAliases, child)
+        case project @ Project(projectList, child) =>
+          // Don't support more than one item in select list of subquery
+          if(projectList.size > 1) {
+            throw new TreeNodeException(
+                project,
+                "SubQuery can contain only one item in Select List")
+          }
+          // Case 1  Uncorelated queries
+          // Create aliases for all projection expressions.
+          val witAliases = projectList.zipWithIndex.map{case (x,y) => Alias(x, s"sqc$y")()}
+          // Take the first projection expression as join condition.
+          expr += EqualTo(value, witAliases(0).toAttribute)
+          Project(witAliases, child)
       }
-      (transformedPlan, expr.reduce(And(_, _)))
+      // Add alias to Subquery as 'subquery'
+      (transformedPlan, expr.reduce(And))
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -425,9 +425,21 @@ class Analyzer(catalog: Catalog,
   }
 
   /**
-   * Transforms the query which has subquery expressions in where clause to left semi join.
-   * select T1.x from T1 where T1.x in (select T2.y from T2) transformed to
-   * select T1.x from T1 left semi join T2 on T1.x = T2.y.
+   * Transforms the query which has subquery expressions in where clause to join queries.
+   * Case 1 Uncorelated queries
+   * -- original query
+   * select C from R1 where R1.A in (Select B from R2)
+   * -- rewritten query
+   * Select C from R1 left semi join (select B as sqc0 from R2) subquery on R1.A = subquery.sqc0
+   *
+   * Case 2 Corelated queries
+   * -- original query
+   * select C from R1 where R1.A in (Select B from R2 where R1.X = R2.Y)
+   * -- rewritten query
+   * select C from R1 left semi join (select B as sqc0, R2.Y as sqc1 from R2) subquery
+   *   on R1.X = subquery.sqc1 and R1.A = subquery.sqc0
+   * 
+   * Refer: https://issues.apache.org/jira/secure/attachment/12614003/SubQuerySpec.pdf
    */
   object SubQueryExpressions extends Rule[LogicalPlan] {
 
@@ -441,49 +453,81 @@ class Analyzer(catalog: Catalog,
             subqueryExprs += s
             Literal(true)
         }
-        if(subqueryExprs.size > 0) {
+        if (subqueryExprs.size == 1) {
           val subqueryExpr = subqueryExprs.remove(0)
-          val firstJoin = createLeftSemiJoin(
-                child, subqueryExpr.value, subqueryExpr.subquery, transformedConds)
-          subqueryExprs.foldLeft(firstJoin){case(fj, sq) =>
-            createLeftSemiJoin(fj, sq.value, sq.subquery)}
+          createLeftSemiJoin(
+            child, subqueryExpr.value,
+            subqueryExpr.subquery, transformedConds)
+        } else if (subqueryExprs.size > 1) {
+          // Only one subquery expression is supported.
+          throw new TreeNodeException(filter, "Only 1 SubQuery expression is supported.")
         } else {
           filter
         }
     }
 
-    // Create LeftSemi join with parent query to the subquery which is mentioned in 'IN' predicate
-    // And combine the subquery conditions and parent query conditions.
+    /**
+     * Create LeftSemi join with parent query to the subquery which is mentioned in 'IN' predicate
+     * And combine the subquery conditions and parent query conditions.
+     */ 
     def createLeftSemiJoin(left: LogicalPlan,
         value: Expression, subquery: LogicalPlan,
-        parentConds: Expression = null) : LogicalPlan = {
+        parentConds: Expression) : LogicalPlan = {
       val (transformedPlan, subqueryConds) = transformAndGetConditions(
           value, subquery)
       // Unify the parent query conditions and subquery conditions and add these as join conditions
-      val unifyConds = if (parentConds != null) And(parentConds, subqueryConds) else subqueryConds
+      val unifyConds = And(parentConds, subqueryConds)
       Join(left, transformedPlan, LeftSemi, Some(unifyConds))
     }
 
-    // Transform the subquery LogicalPlan and add the expressions which are used as filters to the 
-    // projection. And also return filter conditions used in subquery.
+    /**
+     * Transform the subquery LogicalPlan and add the expressions which are used as filters to the
+     * projection. And also return filter conditions used in subquery
+     */
     def transformAndGetConditions(value: Expression,
           subquery: LogicalPlan): (LogicalPlan, Expression) = {
       val expr = new scala.collection.mutable.ArrayBuffer[Expression]()
       val transformedPlan = subquery transform {
         case project @ Project(projectList, f @ Filter(condition, child)) =>
-          expr += EqualTo(value, projectList(0).asInstanceOf[Expression])
-          expr += condition
+          // Don't support more than 1 item in select list of subquery
+          if(projectList.size > 1) {
+            throw new TreeNodeException(project, "SubQuery can contain only 1 item in Select List")
+          }
           val resolvedChild = ResolveRelations(child)
           // Add the expressions to the projections which are used as filters in subquery
           val toBeAddedExprs = f.references.filter(
               a=>resolvedChild.resolve(a.name, resolver) != None && !projectList.contains(a))
-          Project(projectList ++ toBeAddedExprs, child)
+          val cache = collection.mutable.Map[String, String]()
+          // Create aliases for all projection expressions.
+          val witAliases = (projectList ++ toBeAddedExprs).zipWithIndex.map {
+            case (exp, index) => 
+              cache.put(exp.name, s"sqc$index")
+              Alias(exp, s"sqc$index")()
+          }
+          // Replace the condition column names with alias names.
+          val transformedConds = condition.transform{
+            case a: Attribute if resolvedChild.resolve(a.name, resolver) != None =>
+              UnresolvedAttribute("subquery."+cache.get(a.name).get)
+          }
+          // Join the first projection column of subquery to the main query and add as condition
+          // TODO : We can avoid if the parent condition already has this condition.
+          expr += EqualTo(value, UnresolvedAttribute("subquery.sqc0"))
+          expr += transformedConds
+          Project(witAliases, child)
         case project @ Project(projectList, child) =>
+          // Don't support more than 1 item in select list of subquery
+          if(projectList.size > 1) {
+            throw new TreeNodeException(project, "SubQuery can contain only 1 item in Select List")
+          }
+          // Case 1  Uncorelated queries
+          // Create aliases for all projection expressions.
+          val witAliases = projectList.zipWithIndex.map{case (x,y) => Alias(x, s"sqc$y")()}
           // Take the first projection expression as join condition.
-          expr += EqualTo(value, projectList(0).asInstanceOf[Expression])
-          project
+          expr += EqualTo(value, UnresolvedAttribute("subquery.sqc0"))
+          Project(witAliases, child)
       }
-      (transformedPlan, expr.reduce(And(_, _)))
+      // Add alias to Subquery as 'subquery'
+      (Subquery("subquery", transformedPlan), expr.reduce(And(_, _)))
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -504,7 +504,7 @@ class Analyzer(catalog: Catalog,
           val resolvedChild = ResolveRelations(child)
           // Add the expressions to the projections which are used as filters in subquery
           val toBeAddedExprs = f.references.filter{a =>
-            resolvedChild.resolve(a.name, resolver) != None && !project.output.contains(a)}
+            resolvedChild.resolve(a.name, resolver) != None && !project.outputSet.contains(a)}
           val nameToExprMap = collection.mutable.Map[String, Alias]()
           // Create aliases for all projection expressions.
           val witAliases = (projectList ++ toBeAddedExprs).zipWithIndex.map {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SubqueryExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SubqueryExpression.scala
@@ -22,18 +22,17 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 /**
  * Evaluates whether `subquery` result contains `value`. 
  * For example : 'SELECT * FROM src a WHERE a.key in (SELECT b.key FROM src b)'
- * @param value   In the above example 'a.key' is 'value'
  * @param subquery  In the above example 'SELECT b.key FROM src b' is 'subquery'
  */
-case class SubqueryExpression(value: Expression, subquery: LogicalPlan) extends Expression {
+case class SubqueryExpression(subquery: LogicalPlan) extends Expression {
 
   type EvaluatedType = Any
-  def dataType = value.dataType
-  override def foldable = value.foldable
-  def nullable = value.nullable
-  override def toString = s"SubqueryExpression($value, $subquery)"
-  override lazy val resolved = childrenResolved
-  def children = value :: Nil
+  def dataType = subquery.output.head.dataType
+  override def foldable = false
+  def nullable = true
+  override def toString = s"SubqueryExpression($subquery)"
+  override lazy val resolved = false
+  def children = Nil
   override def eval(input: Row): Any =
     sys.error(s"SubqueryExpression eval should not be called since it will be converted"
         + " to join query")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SubqueryExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SubqueryExpression.scala
@@ -19,14 +19,22 @@ package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 
-case class SubqueryExpression(exp: Expression, child: LogicalPlan) extends Expression {
+/**
+ * Evaluates whether `subquery` result contains `value`. 
+ * For example : 'SELECT * FROM src a WHERE a.key in (SELECT b.key FROM src b)'
+ * @param value   In the above example 'a.key' is 'value'
+ * @param subquery  In the above example 'SELECT b.key FROM src b' is 'subquery'
+ */
+case class SubqueryExpression(value: Expression, subquery: LogicalPlan) extends Expression {
 
   type EvaluatedType = Any
-  def dataType = exp.dataType
-  override def foldable = exp.foldable
-  def nullable = exp.nullable
-  override def toString = s"SubqueryExpression($exp, $child)"
+  def dataType = value.dataType
+  override def foldable = value.foldable
+  def nullable = value.nullable
+  override def toString = s"SubqueryExpression($value, $subquery)"
   override lazy val resolved = childrenResolved
-  def children = exp :: Nil
-  override def eval(input: Row): Any = ???
+  def children = value :: Nil
+  override def eval(input: Row): Any =
+    sys.error(s"SubqueryExpression eval should not be called since it will be converted"
+        +" to LeftSemiJoin query")
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SubqueryExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SubqueryExpression.scala
@@ -30,7 +30,7 @@ case class SubqueryExpression(subquery: LogicalPlan) extends Expression {
   def dataType = subquery.output.head.dataType
   override def foldable = false
   def nullable = true
-  override def toString = s"SubqueryExpression($subquery)"
+  override def toString = s"SubqueryExpression(${subquery.output.mkString(",")})"
   override lazy val resolved = false
   def children = Nil
   override def eval(input: Row): Any =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SubqueryExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SubqueryExpression.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+
+case class SubqueryExpression(exp: Expression, child: LogicalPlan) extends Expression {
+
+  type EvaluatedType = Any
+  def dataType = exp.dataType
+  override def foldable = exp.foldable
+  def nullable = exp.nullable
+  override def toString = s"SubqueryExpression($exp, $child)"
+  override lazy val resolved = childrenResolved
+  def children = exp :: Nil
+  override def eval(input: Row): Any = ???
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SubqueryExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SubqueryExpression.scala
@@ -36,5 +36,5 @@ case class SubqueryExpression(value: Expression, subquery: LogicalPlan) extends 
   def children = value :: Nil
   override def eval(input: Row): Any =
     sys.error(s"SubqueryExpression eval should not be called since it will be converted"
-        +" to LeftSemiJoin query")
+        + " to join query")
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -1055,6 +1055,6 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll {
         sql(
           """SELECT a.key FROM testData a 
             |WHERE a.key in
-            |(SELECT b.key FROM testData b WHERE b.key in (1))""".stripMargin), 1)
+            |(SELECT b.key FROM testData b WHERE b.key in (1))""".stripMargin), Row(1))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -1049,4 +1049,12 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll {
     rdd.toDF().registerTempTable("distinctData")
     checkAnswer(sql("SELECT COUNT(DISTINCT key,value) FROM distinctData"), Row(2))
   }
+
+  test("SPARK-4226 Add support for subqueries in predicates") {
+    checkAnswer(
+        sql(
+          """SELECT a.key FROM testData a 
+            |WHERE a.key in
+            |(SELECT b.key FROM testData b WHERE b.key in (1))""".stripMargin), 1)
+  }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
@@ -1206,6 +1206,12 @@ https://cwiki.apache.org/confluence/display/Hive/Enhanced+Aggregation%2C+Cube%2C
     case Token("TOK_STRINGLITERALSEQUENCE", strings) =>
       Literal(strings.map(s => BaseSemanticAnalyzer.unescapeSQLString(s.getText)).mkString)
 
+    /* Subquery expressions in where condition */
+    case Token("TOK_SUBQUERY_EXPR",
+                   Token("TOK_SUBQUERY_OP",
+                       Token("in", Nil) :: Nil) ::
+                       query :: exprsn :: Nil) =>
+      SubqueryExpression(nodeToExpr(exprsn),nodeToPlan(query))
     // This code is adapted from
     // /ql/src/java/org/apache/hadoop/hive/ql/parse/TypeCheckProcFactory.java#L223
     case ast: ASTNode if numericAstTypes contains ast.getType =>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
@@ -1211,7 +1211,7 @@ https://cwiki.apache.org/confluence/display/Hive/Enhanced+Aggregation%2C+Cube%2C
                    Token("TOK_SUBQUERY_OP",
                        Token("in", Nil) :: Nil) ::
                        query :: exprsn :: Nil) =>
-      SubqueryExpression(nodeToExpr(exprsn),nodeToPlan(query))
+      In(nodeToExpr(exprsn), Seq(SubqueryExpression(nodeToPlan(query))))
     // This code is adapted from
     // /ql/src/java/org/apache/hadoop/hive/ql/parse/TypeCheckProcFactory.java#L223
     case ast: ASTNode if numericAstTypes contains ast.getType =>

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -416,4 +416,23 @@ class SQLQuerySuite extends QueryTest {
     dropTempTable("data")
     setConf("spark.sql.hive.convertCTAS", originalConf)
   }
+
+  test("SPARK-4226 Add support for subqueries in predicates- Uncorelated queries") {
+    checkAnswer(
+        sql(
+          """SELECT a.key FROM src a 
+            |WHERE a.key in
+            |(SELECT b.key FROM src b WHERE b.key in (230))""".stripMargin),
+            sql("SELECT key FROM src WHERE key in (230)").collect().toSeq)
+  }
+
+  test("SPARK-4226 Add support for subqueries in predicates- corelated queries") {
+    checkAnswer(
+        sql(
+          """SELECT a.key FROM src a 
+            |WHERE a.key in
+            |(SELECT b.key FROM src b WHERE b.key in (230)and a.value=b.value)""".stripMargin),
+            sql("SELECT key FROM src WHERE key in (230)").collect().toSeq)
+  }
+
 }


### PR DESCRIPTION
This PR supports subqueries in preicates 'in' clause. The queries will be transformed to the LeftSemi join as mentioned below.

Case 1 Uncorelated queries

-- original query
select C
from R1
where R1.A in (Select B from R2)
-- rewritten query
Select C
from R1 left semijoin R2 on R1.A = R2.B

Case 2 Corelated queries

-- original query
select C
from R1
where R1.A in (Select B from R2 where R1.X = R2.Y)
-- rewritten query
select C
from R1 left semi join
(select B, R2.Y as sq1_col0 from R2) sq1
on R1.X = sq1.sq1_col0 and R1.A = sq1.B

Restriction : Alias need to be used as we convert it into join queries.
Complete specification is available in https://issues.apache.org/jira/secure/attachment/12614003/SubQuerySpec.pdf
