### PR TITLE
[SPARK-4387][PySpark] Refactoring python profiling code to make it extensible

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,8 +23,8 @@ application. These properties can be set directly on a
 (e.g. master URL and application name), as well as arbitrary key-value pairs through the
 `set()` method. For example, we could initialize an application with two threads as follows:
 
-Note that we run with local[2], meaning two threads - which represents "minimal" parallelism,
-which can help detect bugs that only exist when we run in a distributed context.
+Note that we run with local[2], meaning two threads - which represents "minimal" parallelism, 
+which can help detect bugs that only exist when we run in a distributed context. 
 
 {% highlight scala %}
 val conf = new SparkConf()
@@ -35,7 +35,7 @@ val sc = new SparkContext(conf)
 {% endhighlight %}
 
 Note that we can have more than 1 thread in local mode, and in cases like spark streaming, we may actually
-require one to prevent any sort of starvation issues.
+require one to prevent any sort of starvation issues.  
 
 ## Dynamically Loading Spark Properties
 In some cases, you may want to avoid hard-coding certain configurations in a `SparkConf`. For
@@ -48,8 +48,8 @@ val sc = new SparkContext(new SparkConf())
 
 Then, you can supply configuration values at runtime:
 {% highlight bash %}
-./bin/spark-submit --name "My app" --master local[4] --conf spark.shuffle.spill=false
-  --conf "spark.executor.extraJavaOptions=-XX:+PrintGCDetails -XX:+PrintGCTimeStamps" myApp.jar
+./bin/spark-submit --name "My app" --master local[4] --conf spark.shuffle.spill=false 
+  --conf "spark.executor.extraJavaOptions=-XX:+PrintGCDetails -XX:+PrintGCTimeStamps" myApp.jar 
 {% endhighlight %}
 
 The Spark shell and [`spark-submit`](cluster-overview.html#launching-applications-with-spark-submit)
@@ -123,7 +123,7 @@ of the most common options to set are:
   <td>
     Limit of total size of serialized results of all partitions for each Spark action (e.g. collect).
     Should be at least 1M, or 0 for unlimited. Jobs will be aborted if the total size
-    is above this limit.
+    is above this limit. 
     Having a high limit may cause out-of-memory errors in driver (depends on spark.driver.memory
     and memory overhead of objects in JVM). Setting a proper limit can protect the driver from
     out-of-memory errors.
@@ -244,7 +244,7 @@ Apart from these, the following properties are also available, and may be useful
     `sc.dump_profiles(path)`. If some of the profile results had been displayed maually,
     they will not be displayed automatically before driver exiting.
 
-    By default the `pyspark.pyprofiler.BasicProfiler` will be used, but this can be overridden by
+    By default the `pyspark.profiler.BasicProfiler` will be used, but this can be overridden by
     passing a profiler class in as a parameter to the `SparkContext` constructor.
   </td>
 </tr>
@@ -252,7 +252,7 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.python.profile.dump</code></td>
   <td>(none)</td>
   <td>
-    The directory which is used to dump the profile result before driver exiting.
+    The directory which is used to dump the profile result before driver exiting. 
     The results will be dumped as separated file for each RDD. They can be loaded
     by ptats.Stats(). If this is specified, the profile result will not be displayed
     automatically.
@@ -271,8 +271,8 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.executorEnv.[EnvironmentVariableName]</code></td>
   <td>(none)</td>
   <td>
-    Add the environment variable specified by <code>EnvironmentVariableName</code> to the Executor
-    process. The user can specify multiple of these and to set multiple environment variables.
+    Add the environment variable specified by <code>EnvironmentVariableName</code> to the Executor 
+    process. The user can specify multiple of these and to set multiple environment variables. 
   </td>
 </tr>
 <tr>
@@ -477,9 +477,9 @@ Apart from these, the following properties are also available, and may be useful
   <td>
     The codec used to compress internal data such as RDD partitions, broadcast variables and
     shuffle outputs. By default, Spark provides three codecs: <code>lz4</code>, <code>lzf</code>,
-    and <code>snappy</code>. You can also use fully qualified class names to specify the codec,
-    e.g.
-    <code>org.apache.spark.io.LZ4CompressionCodec</code>,
+    and <code>snappy</code>. You can also use fully qualified class names to specify the codec, 
+    e.g. 
+    <code>org.apache.spark.io.LZ4CompressionCodec</code>,    
     <code>org.apache.spark.io.LZFCompressionCodec</code>,
     and <code>org.apache.spark.io.SnappyCompressionCodec</code>.
   </td>
@@ -947,7 +947,7 @@ Apart from these, the following properties are also available, and may be useful
     (resources are executors in yarn mode, CPU cores in standalone mode)
     to wait for before scheduling begins. Specified as a double between 0 and 1.
     Regardless of whether the minimum ratio of resources has been reached,
-    the maximum amount of time it will wait before scheduling begins is controlled by config
+    the maximum amount of time it will wait before scheduling begins is controlled by config 
     <code>spark.scheduler.maxRegisteredResourcesWaitingTime</code>.
   </td>
 </tr>
@@ -956,7 +956,7 @@ Apart from these, the following properties are also available, and may be useful
   <td>30000</td>
   <td>
     Maximum amount of time to wait for resources to register before scheduling begins
-    (in milliseconds).
+    (in milliseconds).  
   </td>
 </tr>
 <tr>
@@ -1025,7 +1025,7 @@ Apart from these, the following properties are also available, and may be useful
   <td>false</td>
   <td>
     Whether Spark acls should are enabled. If enabled, this checks to see if the user has
-    access permissions to view or modify the job.  Note this requires the user to be known,
+    access permissions to view or modify the job.  Note this requires the user to be known, 
     so if the user comes across as null no checks are done. Filters can be used with the UI
     to authenticate and set the user.
   </td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,8 +23,8 @@ application. These properties can be set directly on a
 (e.g. master URL and application name), as well as arbitrary key-value pairs through the
 `set()` method. For example, we could initialize an application with two threads as follows:
 
-Note that we run with local[2], meaning two threads - which represents "minimal" parallelism, 
-which can help detect bugs that only exist when we run in a distributed context. 
+Note that we run with local[2], meaning two threads - which represents "minimal" parallelism,
+which can help detect bugs that only exist when we run in a distributed context.
 
 {% highlight scala %}
 val conf = new SparkConf()
@@ -35,7 +35,7 @@ val sc = new SparkContext(conf)
 {% endhighlight %}
 
 Note that we can have more than 1 thread in local mode, and in cases like spark streaming, we may actually
-require one to prevent any sort of starvation issues.  
+require one to prevent any sort of starvation issues.
 
 ## Dynamically Loading Spark Properties
 In some cases, you may want to avoid hard-coding certain configurations in a `SparkConf`. For
@@ -48,8 +48,8 @@ val sc = new SparkContext(new SparkConf())
 
 Then, you can supply configuration values at runtime:
 {% highlight bash %}
-./bin/spark-submit --name "My app" --master local[4] --conf spark.shuffle.spill=false 
-  --conf "spark.executor.extraJavaOptions=-XX:+PrintGCDetails -XX:+PrintGCTimeStamps" myApp.jar 
+./bin/spark-submit --name "My app" --master local[4] --conf spark.shuffle.spill=false
+  --conf "spark.executor.extraJavaOptions=-XX:+PrintGCDetails -XX:+PrintGCTimeStamps" myApp.jar
 {% endhighlight %}
 
 The Spark shell and [`spark-submit`](cluster-overview.html#launching-applications-with-spark-submit)
@@ -123,7 +123,7 @@ of the most common options to set are:
   <td>
     Limit of total size of serialized results of all partitions for each Spark action (e.g. collect).
     Should be at least 1M, or 0 for unlimited. Jobs will be aborted if the total size
-    is above this limit. 
+    is above this limit.
     Having a high limit may cause out-of-memory errors in driver (depends on spark.driver.memory
     and memory overhead of objects in JVM). Setting a proper limit can protect the driver from
     out-of-memory errors.
@@ -243,13 +243,16 @@ Apart from these, the following properties are also available, and may be useful
     or it will be displayed before the driver exiting. It also can be dumped into disk by
     `sc.dump_profiles(path)`. If some of the profile results had been displayed maually,
     they will not be displayed automatically before driver exiting.
+
+    By default the `pyspark.pyprofiler.BasicProfiler` will be used, but this can be overridden by
+    passing a profiler class in as a parameter to the `SparkContext` constructor.
   </td>
 </tr>
 <tr>
   <td><code>spark.python.profile.dump</code></td>
   <td>(none)</td>
   <td>
-    The directory which is used to dump the profile result before driver exiting. 
+    The directory which is used to dump the profile result before driver exiting.
     The results will be dumped as separated file for each RDD. They can be loaded
     by ptats.Stats(). If this is specified, the profile result will not be displayed
     automatically.
@@ -268,8 +271,8 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.executorEnv.[EnvironmentVariableName]</code></td>
   <td>(none)</td>
   <td>
-    Add the environment variable specified by <code>EnvironmentVariableName</code> to the Executor 
-    process. The user can specify multiple of these and to set multiple environment variables. 
+    Add the environment variable specified by <code>EnvironmentVariableName</code> to the Executor
+    process. The user can specify multiple of these and to set multiple environment variables.
   </td>
 </tr>
 <tr>
@@ -474,9 +477,9 @@ Apart from these, the following properties are also available, and may be useful
   <td>
     The codec used to compress internal data such as RDD partitions, broadcast variables and
     shuffle outputs. By default, Spark provides three codecs: <code>lz4</code>, <code>lzf</code>,
-    and <code>snappy</code>. You can also use fully qualified class names to specify the codec, 
-    e.g. 
-    <code>org.apache.spark.io.LZ4CompressionCodec</code>,    
+    and <code>snappy</code>. You can also use fully qualified class names to specify the codec,
+    e.g.
+    <code>org.apache.spark.io.LZ4CompressionCodec</code>,
     <code>org.apache.spark.io.LZFCompressionCodec</code>,
     and <code>org.apache.spark.io.SnappyCompressionCodec</code>.
   </td>
@@ -944,7 +947,7 @@ Apart from these, the following properties are also available, and may be useful
     (resources are executors in yarn mode, CPU cores in standalone mode)
     to wait for before scheduling begins. Specified as a double between 0 and 1.
     Regardless of whether the minimum ratio of resources has been reached,
-    the maximum amount of time it will wait before scheduling begins is controlled by config 
+    the maximum amount of time it will wait before scheduling begins is controlled by config
     <code>spark.scheduler.maxRegisteredResourcesWaitingTime</code>.
   </td>
 </tr>
@@ -953,7 +956,7 @@ Apart from these, the following properties are also available, and may be useful
   <td>30000</td>
   <td>
     Maximum amount of time to wait for resources to register before scheduling begins
-    (in milliseconds).  
+    (in milliseconds).
   </td>
 </tr>
 <tr>
@@ -1022,7 +1025,7 @@ Apart from these, the following properties are also available, and may be useful
   <td>false</td>
   <td>
     Whether Spark acls should are enabled. If enabled, this checks to see if the user has
-    access permissions to view or modify the job.  Note this requires the user to be known, 
+    access permissions to view or modify the job.  Note this requires the user to be known,
     so if the user comes across as null no checks are done. Filters can be used with the UI
     to authenticate and set the user.
   </td>

--- a/python/pyspark/__init__.py
+++ b/python/pyspark/__init__.py
@@ -45,6 +45,7 @@ from pyspark.storagelevel import StorageLevel
 from pyspark.accumulators import Accumulator, AccumulatorParam
 from pyspark.broadcast import Broadcast
 from pyspark.serializers import MarshalSerializer, PickleSerializer
+from pyspark.profiler import BasicProfiler
 
 # for back compatibility
 from pyspark.sql import SQLContext, HiveContext, SchemaRDD, Row
@@ -52,4 +53,5 @@ from pyspark.sql import SQLContext, HiveContext, SchemaRDD, Row
 __all__ = [
     "SparkConf", "SparkContext", "SparkFiles", "RDD", "StorageLevel", "Broadcast",
     "Accumulator", "AccumulatorParam", "MarshalSerializer", "PickleSerializer",
+    "BasicProfiler",
 ]

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -33,7 +33,7 @@ from pyspark.serializers import PickleSerializer, BatchedSerializer, UTF8Deseria
 from pyspark.storagelevel import StorageLevel
 from pyspark.rdd import RDD
 from pyspark.traceback_utils import CallSite, first_spark_call
-from pyspark.pyprofiler import BasicProfiler
+from pyspark.profiler import BasicProfiler
 
 from py4j.java_collections import ListConverter
 

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -826,10 +826,17 @@ class SparkContext(object):
         self._profile_stats.append([id, profiler, False])
 
     def show_profiles(self):
-        self.profiler.show_profiles(self._profile_stats)
+        """ Print the profile stats to stdout """
+        for i, (id, profiler, showed) in enumerate(self._profile_stats):
+            if not showed and profiler:
+                profiler.show(id)
+                # mark it as showed
+                self._profile_stats[i][2] = True
+
 
     def dump_profiles(self, path):
-        self.profiler.dump_profiles(path, self._profile_stats)
+        for id, profiler, _ in self._profile_stats:
+            profiler.dump(id, path)
         self._profile_stats = []
 
 

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -20,7 +20,6 @@ import shutil
 import sys
 from threading import Lock
 from tempfile import NamedTemporaryFile
-import atexit
 
 from pyspark import accumulators
 from pyspark.accumulators import Accumulator
@@ -812,16 +811,6 @@ class SparkContext(object):
         mappedRDD = rdd.mapPartitions(partitionFunc)
         it = self._jvm.PythonRDD.runJob(self._jsc.sc(), mappedRDD._jrdd, javaPartitions, allowLocal)
         return list(mappedRDD._collect_iterator_through_file(it))
-
-    def _add_profiler(self, id, profiler):
-        if not self._profile_stats:
-            dump_path = self._conf.get("spark.python.profile.dump")
-            if dump_path:
-                atexit.register(self.dump_profiles, dump_path)
-            else:
-                atexit.register(self.show_profiles)
-
-        self._profile_stats.append([id, profiler, False])
 
     def show_profiles(self):
         self.profiler_collector.show_profiles()

--- a/python/pyspark/profiler.py
+++ b/python/pyspark/profiler.py
@@ -30,14 +30,10 @@ class BasicProfiler(object):
     be used as well as outputting to different formats than what is provided in the
     BasicProfiler.
 
-    A custom profiler has to define the following static methods:
+    A custom profiler has to define or inherit the following methods:
         profile - will produce a system profile of some sort.
-        show_profiles - shows all collected profiles in a readable format
-        dump_profiles - dumps the provided profiles to a path
-
-    and the following instance methods:
-        new_profile_accumulator - produces a new accumulator that can be used to combine the
-            profiles of partitions on a per stage basis
+        show - shows collected profiles for this profiler in a readable format
+        dump - dumps the profiles to a path
         add - adds a profile to the existing accumulated profile
 
     The profiler class is chosen when creating a SparkContext

--- a/python/pyspark/pyprofiler.py
+++ b/python/pyspark/pyprofiler.py
@@ -1,0 +1,81 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+PySpark supports custom profilers, this is to allow for different profilers to
+be used as well as outputting to different formats than what is provided in the
+BasicProfiler.
+
+The profiler class is chosen when creating L{SparkContext}:
+NOTE: This has no effect if `spark.python.profile` is not set.
+>>> from pyspark.context import SparkContext
+>>> from pyspark.serializers import MarshalSerializer
+>>> sc = SparkContext('local', 'test', profiler=MyCustomProfiler)
+>>> sc.parallelize(list(range(1000))).map(lambda x: 2 * x).take(10)
+[0, 2, 4, 6, 8, 10, 12, 14, 16, 18]
+>>> sc.show_profiles()
+>>> sc.stop()
+
+"""
+
+
+import cProfile
+import pstats
+import os
+from pyspark.accumulators import PStatsParam
+
+
+class BasicProfiler(object):
+
+    @staticmethod
+    def profile(to_profile):
+        pr = cProfile.Profile()
+        pr.runcall(to_profile)
+        st = pstats.Stats(pr)
+        st.stream = None  # make it picklable
+        st.strip_dirs()
+        return st
+
+    @staticmethod
+    def show_profiles(profilers):
+        """ Print the profile stats to stdout """
+        for i, (id, profiler, showed) in enumerate(profilers):
+            stats = profiler._accumulator.value
+            if not showed and stats:
+                print "=" * 60
+                print "Profile of RDD<id=%d>" % id
+                print "=" * 60
+                stats.sort_stats("time", "cumulative").print_stats()
+                # mark it as showed
+                profilers[i][2] = True
+
+    @staticmethod
+    def dump_profiles(path, profilers):
+        """ Dump the profilers stats into directory `path` """
+        if not os.path.exists(path):
+            os.makedirs(path)
+        for id, profiler, _ in profilers:
+            stats = profiler._accumulator.value
+            if stats:
+                p = os.path.join(path, "rdd_%d.pstats" % id)
+                stats.dump_stats(p)
+
+    def new_profile_accumulator(self, ctx):
+        self._accumulator = ctx.accumulator(None, PStatsParam)
+
+    def add(self, accum_value):
+        self._accumulator.add(accum_value)

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -2073,8 +2073,7 @@ class PipelinedRDD(RDD):
             self._jrdd_deserializer = NoOpSerializer()
 
         if self.ctx.profiler:
-            profiler = self.ctx.profiler()
-            profiler.new_profile_accumulator(self.ctx)
+            profiler = self.ctx.profiler(self.ctx)
         else:
             profiler = None
 

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -2072,8 +2072,8 @@ class PipelinedRDD(RDD):
         if self._bypass_serializer:
             self._jrdd_deserializer = NoOpSerializer()
 
-        if self.ctx.profiler:
-            profiler = self.ctx.profiler(self.ctx)
+        if self.ctx.profiler_collector:
+            profiler = self.ctx.profiler_collector.new_profiler(self.ctx)
         else:
             profiler = None
 
@@ -2102,7 +2102,7 @@ class PipelinedRDD(RDD):
 
         if profiler:
             self._id = self._jrdd_val.id()
-            self.ctx._add_profiler(self._id, profiler)
+            self.ctx.profiler_collector.add_profiler(self._id, profiler)
         return self._jrdd_val
 
     def id(self):

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -681,7 +681,7 @@ class ProfilerTests(PySparkTestCase):
     def test_profiler(self):
         self.do_computation()
 
-        profilers = self.sc._profile_stats
+        profilers = self.sc.profiler_collector.profilers
         self.assertEqual(1, len(profilers))
         id, acc, _ = profilers[0]
         stats = acc.value
@@ -700,11 +700,11 @@ class ProfilerTests(PySparkTestCase):
             def show_profiles(self, profilers):
                 return "Custom formatting"
 
-        self.sc.profiler = TestCustomProfiler
+        self.sc.profiler_collector.profiler = TestCustomProfiler
 
         self.do_computation()
 
-        profilers = self.sc._profile_stats
+        profilers = self.sc.profiler_collector.profilers
         self.assertEqual(1, len(profilers))
         id, profiler, _ = profilers[0]
         self.assertTrue(isinstance(profiler, TestCustomProfiler))

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -52,6 +52,7 @@ from pyspark.shuffle import Aggregator, InMemoryMerger, ExternalMerger, External
 from pyspark.sql import SQLContext, IntegerType, Row, ArrayType, StructType, StructField, \
     UserDefinedType, DoubleType
 from pyspark import shuffle
+from pyspark.pyprofiler import BasicProfiler
 
 _have_scipy = False
 _have_numpy = False
@@ -670,22 +671,17 @@ class RDDTests(ReusedPySparkTestCase):
 
 class ProfilerTests(PySparkTestCase):
 
-    def setUp(self):
+    def test_profiler(self):
         self._old_sys_path = list(sys.path)
         class_name = self.__class__.__name__
         conf = SparkConf().set("spark.python.profile", "true")
         self.sc = SparkContext('local[4]', class_name, conf=conf)
 
-    def test_profiler(self):
+        self.do_computation()
 
-        def heavy_foo(x):
-            for i in range(1 << 20):
-                x = 1
-        rdd = self.sc.parallelize(range(100))
-        rdd.foreach(heavy_foo)
-        profiles = self.sc._profile_stats
-        self.assertEqual(1, len(profiles))
-        id, acc, _ = profiles[0]
+        profilers = self.sc._profile_stats
+        self.assertEqual(1, len(profilers))
+        id, acc, _ = profilers[0]
         stats = acc.value
         self.assertTrue(stats is not None)
         width, stat_list = stats.get_print_list([])
@@ -696,6 +692,35 @@ class ProfilerTests(PySparkTestCase):
         d = tempfile.gettempdir()
         self.sc.dump_profiles(d)
         self.assertTrue("rdd_%d.pstats" % id in os.listdir(d))
+
+    def test_custom_profiler(self):
+        class TestCustomProfiler(BasicProfiler):
+            def show_profiles(self, profilers):
+                return "Custom formatting"
+
+
+        self._old_sys_path = list(sys.path)
+        class_name = self.__class__.__name__
+        conf = SparkConf().set("spark.python.profile", "true")
+        self.sc = SparkContext('local[4]', class_name, conf=conf, profiler=TestCustomProfiler)
+
+        self.do_computation()
+
+        profilers = self.sc._profile_stats
+        self.assertEqual(1, len(profilers))
+        id, profiler, _ = profilers[0]
+        self.assertTrue(isinstance(profiler, TestCustomProfiler))
+
+        self.assertEqual("Custom formatting", self.sc.show_profiles())
+
+
+        def do_computation(self):
+            def heavy_foo(x):
+                for i in range(1 << 20):
+                    x = 1
+
+            rdd = self.sc.parallelize(range(100))
+            rdd.foreach(heavy_foo)
 
 
 class ExamplePointUDT(UserDefinedType):

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -23,8 +23,6 @@ import sys
 import time
 import socket
 import traceback
-import cProfile
-import pstats
 
 from pyspark.accumulators import _accumulatorRegistry
 from pyspark.broadcast import Broadcast, _broadcastRegistry
@@ -92,19 +90,16 @@ def main(infile, outfile):
         command = pickleSer._read_with_length(infile)
         if isinstance(command, Broadcast):
             command = pickleSer.loads(command.value)
-        (func, stats, deserializer, serializer) = command
+        (func, profiler, deserializer, serializer) = command
         init_time = time.time()
 
         def process():
             iterator = deserializer.load_stream(infile)
             serializer.dump_stream(func(split_index, iterator), outfile)
 
-        if stats:
-            p = cProfile.Profile()
-            p.runcall(process)
-            st = pstats.Stats(p)
-            st.stream = None  # make it picklable
-            stats.add(st.strip_dirs())
+        if profiler:
+            st = profiler.profile(process)
+            profiler.add(st)
         else:
             process()
     except Exception:

--- a/python/run-tests
+++ b/python/run-tests
@@ -57,6 +57,7 @@ function run_core_tests() {
     PYSPARK_DOC_TEST=1 run_test "pyspark/broadcast.py"
     PYSPARK_DOC_TEST=1 run_test "pyspark/accumulators.py"
     PYSPARK_DOC_TEST=1 run_test "pyspark/serializers.py"
+    PYSPARK_DOC_TEST=1 run_test "pyspark/profiler.py" 
     run_test "pyspark/shuffle.py"
     run_test "pyspark/tests.py"
 }


### PR DESCRIPTION
This is a refactor of the [profiling feature](https://github.com/apache/spark/commit/c5414b681868a0a11cc5a94184116e66e8d3e9c0) done by @davies 

This will allow us to hook in custom profilers and output sinks more easily. 
