### PR TITLE
[SPARK-4404]SparkSubmitDriverBootstrapper should stop after its SparkSubmit sub-proc...

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitDriverBootstrapper.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitDriverBootstrapper.scala
@@ -129,7 +129,8 @@ private[spark] object SparkSubmitDriverBootstrapper {
 
     val process = builder.start()
 
-    Runtime.getRuntime().addShutdownHook(new Thread("Kill SparkSubmit process") {
+    // If we kill an app while it's running, its sub-process should be killed too.
+    Runtime.getRuntime().addShutdownHook(new Thread() {
       override def run() = {
         if (process != null) {
           process.destroy()

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitDriverBootstrapper.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitDriverBootstrapper.scala
@@ -129,6 +129,15 @@ private[spark] object SparkSubmitDriverBootstrapper {
 
     val process = builder.start()
 
+    Runtime.getRuntime().addShutdownHook(new Thread("Kill SparkSubmit process") {
+      override def run() = {
+        if (process != null) {
+          process.destroy()
+          sys.exit(process.waitFor())
+        }
+      }
+    })
+
     // Redirect stdout and stderr from the child JVM
     val stdoutThread = new RedirectThread(process.getInputStream, System.out, "redirect stdout")
     val stderrThread = new RedirectThread(process.getErrorStream, System.err, "redirect stderr")


### PR DESCRIPTION
...ess ends

https://issues.apache.org/jira/browse/SPARK-4404

When we have spark.driver.extra\* or spark.driver.memory in SPARK_SUBMIT_PROPERTIES_FILE, spark-class will use SparkSubmitDriverBootstrapper to launch driver.
If we get process id of SparkSubmitDriverBootstrapper and wanna kill it during its running, we expect its SparkSubmit sub-process stop also.
