### PR TITLE
[SPARK-4418][SQL] Remove restriction of binary arithmetic operations for fixed-precision decimal.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -56,8 +56,7 @@ abstract class BinaryArithmetic extends BinaryExpression {
 
   override lazy val resolved =
     left.resolved && right.resolved &&
-    left.dataType == right.dataType &&
-    !DecimalType.isFixed(left.dataType)
+    left.dataType == right.dataType
 
   def dataType = {
     if (!resolved) {


### PR DESCRIPTION
Binary arithmetic operations for fixed-precision decimal should not be restricted.
