### PR TITLE
[Spark-4432]close InStream after the block is accessed

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/TachyonStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/TachyonStore.scala
@@ -116,6 +116,8 @@ private[spark] class TachyonStore(
       case ioe: IOException =>
         logWarning(s"Failed to fetch the block $blockId from Tachyon", ioe)
         None
+    } finally {
+      is.close()
     }
   }
 


### PR DESCRIPTION
InStream is not closed after data is read from Tachyon. which makes the blocks in Tachyon locked after accessed.
