### PR TITLE
[SPARK-4436][SPARK-3624][BUILD] Debian packaging fixes

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -289,7 +289,7 @@
                         <type>perm</type>
                         <user>${deb.user}</user>
                         <group>${deb.user}</group>
-                        <prefix>${deb.install.path}/jars</prefix>
+                        <prefix>${deb.install.path}/lib</prefix>
                       </mapper>
                     </data>
                     <data>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -293,6 +293,16 @@
                       </mapper>
                     </data>
                     <data>
+                      <src>${basedir}/../lib_managed/jars</src>
+                      <type>directory</type>
+                      <mapper>
+                        <type>perm</type>
+                        <user>${deb.user}</user>
+                        <group>${deb.user}</group>
+                        <prefix>${deb.install.path}/lib</prefix>
+                      </mapper>
+                    </data>
+                    <data>
                       <src>${basedir}/src/deb/RELEASE</src>
                       <type>file</type>
                       <mapper>


### PR DESCRIPTION
This makes the Spark jar as well as the datanucleus jars (and anything else in lib_managed/jars) available in the debian package at spark/lib.  In addition to allowing HiveContext to work with a deb package built using -Phive, this incorporates the clean&simple-but-not-backward-compatible fix for SPARK-3624, which has been needed since Spark 1.0.0.

@JoshRosen @tzolov @pwendell @andrewor14
