### PR TITLE
Fix .deb package permissions

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -39,7 +39,7 @@
     <deb.pkg.name>spark</deb.pkg.name>
     <deb.install.path>/usr/share/spark</deb.install.path>
     <deb.user>root</deb.user>
-    <deb.bin.filemode>744</deb.bin.filemode>
+    <deb.bin.filemode>755</deb.bin.filemode>
   </properties>
 
   <dependencies>
@@ -289,7 +289,7 @@
                         <type>perm</type>
                         <user>${deb.user}</user>
                         <group>${deb.user}</group>
-                        <prefix>${deb.install.path}/jars</prefix>
+                        <prefix>${deb.install.path}/lib</prefix>
                       </mapper>
                     </data>
                     <data>


### PR DESCRIPTION
Small fix to .deb package
1) permissions for all binaries in bin/sbin so it would be possible to run from user account
2) rename "jars" to "lib" ( why was it named jars in a first place? )
