### PR TITLE
Fix the default akka.timeout

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/AkkaUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/AkkaUtils.scala
@@ -126,7 +126,7 @@ private[spark] object AkkaUtils extends Logging {
 
   /** Returns the default Spark timeout to use for Akka ask operations. */
   def askTimeout(conf: SparkConf): FiniteDuration = {
-    Duration.create(conf.getLong("spark.akka.askTimeout", 30), "seconds")
+    Duration.create(conf.getLong("spark.akka.askTimeout", 100), "seconds")
   }
 
   /** Returns the default Spark timeout to use for Akka remote actor lookup. */


### PR DESCRIPTION
According to the docs at https://spark.apache.org/docs/1.1.0/configuration.html and line 68 of this file, the default value for akka.timeout is 100
