### PR TITLE
[SPARK-4458][Build] Eliminate compilation of test classes in make distribution.

### DIFF
--- a/make-distribution.sh
+++ b/make-distribution.sh
@@ -165,7 +165,7 @@ cd "$FWDIR"
 
 export MAVEN_OPTS="-Xmx2g -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=512m"
 
-BUILD_COMMAND="mvn clean package -DskipTests $@"
+BUILD_COMMAND="mvn clean package -DskipTests -Dmaven.test.skip $@"
 
 # Actually build the jar
 echo -e "\nBuilding with..."


### PR DESCRIPTION
The make-distribution generates Spark distributions, and therefore does not require building of test classes. Maven -DskipTests only eliminates running of tests, but does not eliminate compilation of tests (see [Maven docs](http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#skipTests)). To prevent compilation of tests (reduces compilation time), we need to add -Dmaven.test.skip (again see [Maven docs](http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#skip)). 
