### PR TITLE
[SPARK-4463] Add (de)select all button for add'l metrics.

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/additional-metrics.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/additional-metrics.js
@@ -26,13 +26,6 @@ $(function() {
         // Switch the class of the arrow from open to closed.
         $(this).find('.expand-additional-metrics-arrow').toggleClass('arrow-open');
         $(this).find('.expand-additional-metrics-arrow').toggleClass('arrow-closed');
-
-        // If clicking caused the metrics to expand, automatically check all options for additional
-        // metrics (don't trigger a click when collapsing metrics, because it leads to weird
-        // toggling behavior).
-        if (!$(additionalMetricsDiv).hasClass('collapsed')) {
-            $(this).parent().find('input:checkbox:not(:checked)').trigger('click');
-        }
     });
 
     $("input:checkbox:not(:checked)").each(function() {
@@ -46,6 +39,16 @@ $(function() {
         var column = "table ." + $(this).attr("name");
         $(column).toggle();
         stripeTables();
+    });
+
+    $("#select-all-metrics").click(function() {
+       if (this.checked) {
+          // Toggle all un-checked options.
+          $('input:checkbox:not(:checked)').trigger('click');
+       } else {
+          // Toggle all checked options.
+          $('input:checkbox:checked').trigger('click');
+       }
     });
 
     // Trigger a click on the checkbox if a user clicks the label next to it.

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -116,7 +116,7 @@ private[ui] class StagePage(parent: JobProgressTab) extends WebUIPage("stage") {
             <ul style="list-style-type:none">
               <li>
                   <input type="checkbox" id="select-all-metrics"/>
-                  <span class="additional-metric-title">(De)select All</span>
+                  <span class="additional-metric-title"><em>(De)select All</em></span>
               </li>
               <li>
                 <span data-toggle="tooltip"

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -115,6 +115,10 @@ private[ui] class StagePage(parent: JobProgressTab) extends WebUIPage("stage") {
           <div class="additional-metrics collapsed">
             <ul style="list-style-type:none">
               <li>
+                  <input type="checkbox" id="select-all-metrics"/>
+                  <span class="additional-metric-title">(De)select All</span>
+              </li>
+              <li>
                 <span data-toggle="tooltip"
                       title={ToolTips.SCHEDULER_DELAY} data-placement="right">
                   <input type="checkbox" name={TaskDetailsClassNames.SCHEDULER_DELAY}/>


### PR DESCRIPTION
This commit removes the behavior where when a user clicks
"Show additional metrics" on the stage page, all of the additional
metrics are automatically selected; now, collapsing and expanding
the additional metrics has no effect on which options are selected.
Instead, there's a "(De)select All" box at the top; checking this box
checks all additional metrics (and similarly, unchecking it unchecks
all additional metrics).

This commit is intended to be backported to 1.2, so that the additional
metrics behavior is not confusing to users.

Now when a user clicks the "Show additional metrics" menu, this is what
it looks like:
![image](https://cloud.githubusercontent.com/assets/1108612/5094347/1541ead6-6f15-11e4-8e8c-25a65ddbdfb2.png)
