### PR TITLE
[SQL] set spark.sql.hive.convertMetastoreParquet false by default

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -81,7 +81,7 @@ class HiveContext(sc: SparkContext) extends SQLContext(sc) {
    * SerDe.
    */
   private[spark] def convertMetastoreParquet: Boolean =
-    getConf("spark.sql.hive.convertMetastoreParquet", "true") == "true"
+    getConf("spark.sql.hive.convertMetastoreParquet", "false") == "true"
 
   override protected[sql] def executePlan(plan: LogicalPlan): this.QueryExecution =
     new this.QueryExecution { val logical = plan }


### PR DESCRIPTION
Set `spark.sql.hive.convertMetastoreParquet` true now leads to
1 run
`create table test_parquet(key int, value string) stored as parquet;`
`select * from test_parquet;`
get error as follow

java.lang.IllegalArgumentException: Could not find Parquet metadata at path file:/user/hive/warehouse/test_parquet
        at org.apache.spark.sql.parquet.ParquetTypesConverter$$anonfun$readMetaData$4.apply(ParquetTypes.scala:459)
        at org.apache.spark.sql.parquet.ParquetTypesConverter$$anonfun$readMetaData$4.apply(ParquetTypes.scala:459)
        at scala.Option.getOrElse(Option.scala:120)
        at org.apache.spark.sql.parquet.ParquetTypesConverter$.readMetaData(ParquetTypes.sc

2 run 
`create table test_parquet(key int, value string) stored as parquet;`
`insert into table test_parquet select * from src;`
`select * from test_parquet;`
get result as follow

...
282     [B@38fda3b8
138     [B@1407a243
238     [B@12de6fb
419     [B@6c976957
15      [B@48850673
118     [B@156a8d37
72      [B@65d20dd
90      [B@4c18906e
307     [B@60b24cc9
19      [B@59cf51b7
435     [B@39fdf371
10      [B@4f799d75
277     [B@39509516
273     [B@596bf4bf
306     [B@3e915576
224     [B@3781d611
309     [B@2d0d128f
