### PR TITLE
[DOCS][BUILD] Add instruction to use change-version-to-2.11.sh in 'Building for Scala 2.11'.

### DIFF
--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -115,6 +115,7 @@ mvn -Pyarn -Phive -Phive-thriftserver-0.12.0 -Phadoop-2.4 -Dhadoop.version=2.4.0
 # Building for Scala 2.11
 To produce a Spark package compiled with Scala 2.11, use the `-Dscala-2.11` property:
 
+    dev/change-version-to-2.11.sh
     mvn -Pyarn -Phadoop-2.4 -Dscala-2.11 -DskipTests clean package
 
 Scala 2.11 support in Spark is experimental and does not support a few features.


### PR DESCRIPTION
To build with Scala 2.11, we have to execute `change-version-to-2.11.sh` before Maven execute, otherwise inter-module dependencies are broken.
