### PR TITLE
[SPARK-4483][SQL]Optimization about reduce memory costs during the HashOuterJoin

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashOuterJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashOuterJoin.scala
@@ -75,7 +75,6 @@ case class HashOuterJoin(
 
   private[this] def leftOuterIterator(
       key: Row, leftRow: Row, rightIter: Iterable[Row]): Iterator[Row] = {
-    //val joinedRow = new JoinedRow()
     val rightNullRow = new GenericRow(right.output.length)
     val boundCondition =
       condition.map(newPredicate(_, left.output ++ right.output)).getOrElse((row: Row) => true)
@@ -100,7 +99,6 @@ case class HashOuterJoin(
 
   private[this] def rightOuterIterator(
       key: Row, leftIter: Iterable[Row], rightRow: Row): Iterator[Row] = {
-    //val joinedRow = new JoinedRow()
     val leftNullRow = new GenericRow(right.output.length)
     val boundCondition =
       condition.map(newPredicate(_, left.output ++ right.output)).getOrElse((row: Row) => true)
@@ -125,7 +123,6 @@ case class HashOuterJoin(
 
   private[this] def fullOuterIterator(
       key: Row, leftIter: Iterable[Row], rightIter: Iterable[Row]): Iterator[Row] = {
-    //val joinedRow = new JoinedRow()
     val leftNullRow = new GenericRow(left.output.length)
     val rightNullRow = new GenericRow(right.output.length)
     val boundCondition =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashOuterJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashOuterJoin.scala
@@ -99,7 +99,7 @@ case class HashOuterJoin(
 
   private[this] def rightOuterIterator(
       key: Row, leftIter: Iterable[Row], rightRow: Row): Iterator[Row] = {
-    val leftNullRow = new GenericRow(right.output.length)
+    val leftNullRow = new GenericRow(left.output.length)
     val boundCondition =
       condition.map(newPredicate(_, left.output ++ right.output)).getOrElse((row: Row) => true)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashOuterJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashOuterJoin.scala
@@ -196,28 +196,6 @@ case class HashOuterJoin(
   override def execute() = {
     left.execute().zipPartitions(right.execute()) { (leftIter, rightIter) =>
       // TODO this probably can be replaced by external sort (sort merged join?)
-      /*
-      val leftHashTable = buildHashTable(leftIter, newProjection(leftKeys, left.output))
-      val rightHashTable = buildHashTable(rightIter, newProjection(rightKeys, right.output))
-
-      joinType match {
-        case LeftOuter => leftHashTable.keysIterator.flatMap { key =>
-          leftOuterIterator(key, leftHashTable.getOrElse(key, EMPTY_LIST),
-            rightHashTable.getOrElse(key, EMPTY_LIST))
-        }
-        case RightOuter => rightHashTable.keysIterator.flatMap { key =>
-          rightOuterIterator(key, leftHashTable.getOrElse(key, EMPTY_LIST),
-            rightHashTable.getOrElse(key, EMPTY_LIST))
-        }
-        case FullOuter => (leftHashTable.keySet ++ rightHashTable.keySet).iterator.flatMap { key =>
-          fullOuterIterator(key,
-            leftHashTable.getOrElse(key, EMPTY_LIST),
-            rightHashTable.getOrElse(key, EMPTY_LIST))
-        }
-        case x => throw new Exception(s"HashOuterJoin should not take $x as the JoinType")
-      }
-      */
-
 
       joinType match {
         case LeftOuter => {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashOuterJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashOuterJoin.scala
@@ -91,7 +91,7 @@ case class HashOuterJoin(
           temp
         }
       } else {
-        Nil
+        List(joinedRow.withRight(rightNullRow).copy)
       }
     )
     ret.iterator
@@ -115,7 +115,7 @@ case class HashOuterJoin(
           temp
         }
       } else {
-        Nil
+        List(joinedRow.withLeft(leftNullRow).copy)
       }
     )
     ret.iterator


### PR DESCRIPTION
In `HashOuterJoin.scala`, spark read data from both side of join operation before zip them together. It is a waste for memory. We are trying to read data from only one side, put them into a hashmap, and then generate the `JoinedRow` with data from other side one by one.
Currently, we could only do this optimization for `left outer join` and `right outer join`. For `full outer join`, we will do something in another issue.

for 
table test_csv contains 1 million records
table dim_csv contains 10 thousand records

SQL:
`select * from test_csv a left outer join dim_csv b on a.key = b.key`

the result is:
master:

```
CSV: 12671 ms
CSV: 9021 ms
CSV: 9200 ms
Current Mem Usage:787788984
```

after patch：

```
CSV: 10382 ms
CSV: 7543 ms
CSV: 7469 ms
Current Mem Usage:208145728
```
