### PR TITLE
add jackson-core-asl 1.8.8 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -860,6 +860,11 @@
         <artifactId>jackson-mapper-asl</artifactId>
         <version>1.8.8</version>
       </dependency>
+      <dependency>
+        <groupId>org.codehaus.jackson</groupId>
+        <artifactId>jackson-core-asl</artifactId>
+        <version>1.8.8</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
When I use jackson lib on spark app. to parse json string, jackson-mapper-asl 1.8.8 conflicts with jackson-core-asl (1.9.x) 
jackson-mapper-asl 1.8.8 dependency doesn't affect jackson-core-asl version.
So, I add jackson-core-asl 1.8.8 dependency to match the version of jackson-mapper-asl.
My app. is working well after fix it.
