### PR TITLE
[SPARK-4518][SPARK-4519][Streaming] Refactored file stream to prevent files from being processed multiple times

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
@@ -254,7 +254,7 @@ abstract class DStream[T: ClassTag] (
   }
 
   private[streaming] def remember(duration: Duration) {
-    if (duration != null && duration > rememberDuration) {
+    if (duration != null && (rememberDuration == null || duration > rememberDuration)) {
       rememberDuration = duration
       logInfo("Duration for remembering RDDs set to " + rememberDuration + " for " + this)
     }

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
@@ -17,18 +17,50 @@
 
 package org.apache.spark.streaming.dstream
 
-import java.io.{ObjectInputStream, IOException}
-import scala.collection.mutable.{HashSet, HashMap}
+import java.io.{IOException, ObjectInputStream}
+
+import scala.Some
+import scala.collection.mutable
+import scala.collection.mutable.HashMap
 import scala.reflect.ClassTag
+
 import org.apache.hadoop.fs.{FileSystem, Path, PathFilter}
-import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.mapreduce.{InputFormat => NewInputFormat}
-import org.apache.spark.rdd.RDD
-import org.apache.spark.rdd.UnionRDD
-import org.apache.spark.streaming.{StreamingContext, Time}
+import org.apache.spark.rdd.{RDD, UnionRDD}
+import org.apache.spark.streaming._
 import org.apache.spark.util.{TimeStampedHashMap, Utils}
 
-
+/**
+ * This class represents an input stream that monitors a Hadoop-compatible filesystem for new
+ * files and creates a stream out of them. The way it works as follows.
+ *
+ * This class remembers the information about the files selected in past batches for
+ * a certain duration (say, "remember window") as shown in the figure below.
+ *
+ *
+ * ignore threshold --->|                              |<--- current batch time
+ *                      |<------ remember window ----->|
+ *                      |                              |
+ * --------------------------------------------------------------------------------> Time
+ *
+ * The trailing end of the window is the "ignore threshold" and all files whose mod time
+ * are less than this threshold are assumed to have already been processed and therefore ignored.
+ * Files whose mode times are within the "remember window" are checked against files that have
+ * already been selected and processed. This is how new files are identified in each batch -
+ * files whose mod times are greater than the ignore threshold and have not been considered
+ * within the remember window.
+ *
+ * This makes some assumptions from the underlying file system that the system is monitoring.
+ * - If a file is to be visible in the file listings, it must be visible within a certain
+ *   duration of the mod time of the file. This duration is the "remember window", which is set to
+ *   1 minute (see `FileInputDStream.MIN_REMEMBER_DURATION`). Otherwise, the file will not be
+ *   selected as the mod time will be less than the ignore threshold when it become visible.
+ * - Once a file is visible, the mod time cannot change. If it does due to appends, then the
+ *   processing semantics is undefined.
+ * - The time of the file system does not need to be synchronized with the time of the system
+ *   running Spark Streaming. The mod time is used to ignore old files based on the threshold,
+ *   and we use the mod times of selected files to define that threshold.
+ */
 private[streaming]
 class FileInputDStream[K: ClassTag, V: ClassTag, F <: NewInputFormat[K,V] : ClassTag](
     @transient ssc_ : StreamingContext,
@@ -37,22 +69,24 @@ class FileInputDStream[K: ClassTag, V: ClassTag, F <: NewInputFormat[K,V] : Clas
     newFilesOnly: Boolean = true)
   extends InputDStream[(K, V)](ssc_) {
 
+  protected[streaming] case class SelectedFileInfo(files: Array[String], minModTime: Long)
+
   protected[streaming] override val checkpointData = new FileInputDStreamCheckpointData
 
-  // files found in the last interval
-  private val lastFoundFiles = new HashSet[String]
+  @transient private[streaming] var timeToSelectedFileInfo = new HashMap[Time, SelectedFileInfo]
+  @transient private var allFoundFiles = new mutable.HashSet[String]()
+  @transient private var fileToModTimes = new TimeStampedHashMap[String, Long](true)
+  @transient private var lastNewFileFindingTime = 0L
 
-  // Files with mod time earlier than this is ignored. This is updated every interval
-  // such that in the current interval, files older than any file found in the
-  // previous interval will be ignored. Obviously this time keeps moving forward.
-  private var ignoreTime = if (newFilesOnly) System.currentTimeMillis() else 0L
-
-  // Latest file mod time seen till any point of time
   @transient private var path_ : Path = null
   @transient private var fs_ : FileSystem = null
-  @transient private[streaming] var files = new HashMap[Time, Array[String]]
-  @transient private var fileModTimes = new TimeStampedHashMap[String, Long](true)
-  @transient private var lastNewFileFindingTime = 0L
+
+  /*
+   * Make sure that the information of files selected in the last few batches are remembered.
+   * This would allow us to filter away not-too-old files which have already been recently
+   * selected and processed.
+   */
+  remember(FileInputDStream.calculateRememberDuration(slideDuration))
 
   override def start() { }
 
@@ -68,59 +102,61 @@ class FileInputDStream[K: ClassTag, V: ClassTag, F <: NewInputFormat[K,V] : Clas
    * the previous call.
    */
   override def compute(validTime: Time): Option[RDD[(K, V)]] = {
-    assert(validTime.milliseconds >= ignoreTime,
-      "Trying to get new files for a really old time [" + validTime + " < " + ignoreTime + "]")
-
-    // Find new files
-    val (newFiles, minNewFileModTime) = findNewFiles(validTime.milliseconds)
-    logInfo("New files at time " + validTime + ":\n" + newFiles.mkString("\n"))
-    if (!newFiles.isEmpty) {
-      lastFoundFiles.clear()
-      lastFoundFiles ++= newFiles
-      ignoreTime = minNewFileModTime
-    }
-    files += ((validTime, newFiles.toArray))
-    Some(filesToRDD(newFiles))
+    val selectedFileInfo = findNewFiles(validTime.milliseconds)
+    logInfo(s"New files at time $validTime :\n${selectedFileInfo.files.mkString("\n")}")
+    timeToSelectedFileInfo += ((validTime, selectedFileInfo))
+    allFoundFiles ++= selectedFileInfo.files
+    Some(filesToRDD(selectedFileInfo.files))
   }
 
   /** Clear the old time-to-files mappings along with old RDDs */
   protected[streaming] override def clearMetadata(time: Time) {
     super.clearMetadata(time)
-    val oldFiles = files.filter(_._1 < (time - rememberDuration))
-    files --= oldFiles.keys
+    val oldFiles = timeToSelectedFileInfo.filter(_._1 < (time - rememberDuration))
+    timeToSelectedFileInfo --= oldFiles.keys
+    allFoundFiles --= oldFiles.values.map { _.files }.flatten
     logInfo("Cleared " + oldFiles.size + " old files that were older than " +
       (time - rememberDuration) + ": " + oldFiles.keys.mkString(", "))
     logDebug("Cleared files are:\n" +
-      oldFiles.map(p => (p._1, p._2.mkString(", "))).mkString("\n"))
+      oldFiles.map(p => (p._1, p._2.files.mkString(", "))).mkString("\n"))
     // Delete file mod times that weren't accessed in the last round of getting new files
-    fileModTimes.clearOldValues(lastNewFileFindingTime - 1)
+    fileToModTimes.clearOldValues(lastNewFileFindingTime - 1)
   }
 
   /**
-   * Find files which have modification timestamp <= current time and return a 3-tuple of
-   * (new files found, latest modification time among them, files with latest modification time)
+   * Find new files using a custom filter which selects files whose mod time is within the
+   * remember window (not before it) but have not been selected yet.
    */
-  private def findNewFiles(currentTime: Long): (Seq[String], Long) = {
-    logDebug("Trying to get new files for time " + currentTime)
+  private def findNewFiles(currentTime: Long): SelectedFileInfo = {
     lastNewFileFindingTime = System.currentTimeMillis
-    val filter = new CustomPathFilter(currentTime)
+
+    // Find the minimum mod time of the batches we are remembering and use that
+    // the threshold time for ignoring old files
+    val modTimeIgnoreThreshold = if (timeToSelectedFileInfo.nonEmpty) {
+      timeToSelectedFileInfo.values.map { _.minModTime }.min
+    } else {
+      0
+    }
+
+    logDebug(s"Getting new files for time $currentTime with ignore time $modTimeIgnoreThreshold")
+    val filter = new CustomPathFilter(modTimeIgnoreThreshold)
     val newFiles = fs.listStatus(directoryPath, filter).map(_.getPath.toString)
     val timeTaken = System.currentTimeMillis - lastNewFileFindingTime
-    logInfo("Finding new files took " + timeTaken + " ms")
-    logDebug("# cached file times = " + fileModTimes.size)
+    logInfo(s"Finding new files took $timeTaken ms")
+    logDebug(s"# cached file times = ${fileToModTimes.size}")
     if (timeTaken > slideDuration.milliseconds) {
       logWarning(
         "Time taken to find new files exceeds the batch size. " +
-          "Consider increasing the batch size or reduceing the number of " +
+          "Consider increasing the batch size or reducing the number of " +
           "files in the monitored directory."
       )
     }
-    (newFiles, filter.minNewFileModTime)
+    SelectedFileInfo(newFiles, filter.minNewFileModTime)
   }
 
   /** Generate one RDD from an array of files */
   private def filesToRDD(files: Seq[String]): RDD[(K, V)] = {
-    val fileRDDs = files.map(file =>{
+    val fileRDDs = files.map(file => {
       val rdd = context.sparkContext.newAPIHadoopFile[K, V, F](file)
       if (rdd.partitions.size == 0) {
         logError("File " + file + " has no data in it. Spark Streaming can only ingest " +
@@ -138,13 +174,8 @@ class FileInputDStream[K: ClassTag, V: ClassTag, F <: NewInputFormat[K,V] : Clas
   }
 
   private def fs: FileSystem = {
-    if (fs_ == null) fs_ = directoryPath.getFileSystem(new Configuration())
+    if (fs_ == null) fs_ = directoryPath.getFileSystem(ssc.sparkContext.hadoopConfiguration)
     fs_
-  }
-
-  private def getFileModTime(path: Path) = {
-    // Get file mod time from cache or fetch it from the file system
-    fileModTimes.getOrElseUpdate(path.toString, fs.getFileStatus(path).getModificationTime())
   }
 
   private def reset()  {
@@ -155,83 +186,81 @@ class FileInputDStream[K: ClassTag, V: ClassTag, F <: NewInputFormat[K,V] : Clas
   private def readObject(ois: ObjectInputStream): Unit = Utils.tryOrIOException {
     logDebug(this.getClass().getSimpleName + ".readObject used")
     ois.defaultReadObject()
+    allFoundFiles = new mutable.HashSet[String]()
     generatedRDDs = new HashMap[Time, RDD[(K,V)]] ()
-    files = new HashMap[Time, Array[String]]
-    fileModTimes = new TimeStampedHashMap[String, Long](true)
+    timeToSelectedFileInfo = new HashMap[Time, SelectedFileInfo]
+    fileToModTimes = new TimeStampedHashMap[String, Long](updateTimeStampOnGet = true)
   }
 
   /**
-   * A custom version of the DStreamCheckpointData that stores names of
-   * Hadoop files as checkpoint data.
+   * A custom version of the DStreamCheckpointData that stores the information about the
+   * files selected in every batch. This is necessary so that the files selected for the past
+   * batches (that have already been defined) can be recovered correctly upon driver failure and
+   * the input data of the batches are exactly the same.
    */
   private[streaming]
   class FileInputDStreamCheckpointData extends DStreamCheckpointData(this) {
 
-    def hadoopFiles = data.asInstanceOf[HashMap[Time, Array[String]]]
+    def checkpointedFileInfo = data.asInstanceOf[HashMap[Time, SelectedFileInfo]]
 
     override def update(time: Time) {
-      hadoopFiles.clear()
-      hadoopFiles ++= files
+      checkpointedFileInfo.clear()
+      checkpointedFileInfo ++= timeToSelectedFileInfo
     }
 
     override def cleanup(time: Time) { }
 
     override def restore() {
-      hadoopFiles.toSeq.sortBy(_._1)(Time.ordering).foreach {
+      checkpointedFileInfo.toSeq.sortBy(_._1)(Time.ordering).foreach {
         case (t, f) => {
           // Restore the metadata in both files and generatedRDDs
-          logInfo("Restoring files for time " + t + " - " +
-            f.mkString("[", ", ", "]") )
-          files += ((t, f))
-          generatedRDDs += ((t, filesToRDD(f)))
+          logInfo(s"Restoring files for time $t - ${f.files.mkString(", ")}")
+          timeToSelectedFileInfo += ((t, f))
+          allFoundFiles ++= f.files
+          generatedRDDs += ((t, filesToRDD(f.files)))
         }
       }
     }
 
     override def toString() = {
-      "[\n" + hadoopFiles.size + " file sets\n" +
-        hadoopFiles.map(p => (p._1, p._2.mkString(", "))).mkString("\n") + "\n]"
+      "[\n" + checkpointedFileInfo.size + " file sets\n" +
+        checkpointedFileInfo.map(p => (p._1, p._2.files.mkString(", "))).mkString("\n") + "\n]"
     }
   }
 
   /**
-   * Custom PathFilter class to find new files that
-   * ... have modification time more than ignore time
-   * ... have not been seen in the last interval
-   * ... have modification time less than maxModTime
+   * Custom PathFilter class to find new files that have modification time within the
+   * remember window (that is mod time > ignore threshold) and have not been selected in that
+   * window.
    */
-  private[streaming]
-  class CustomPathFilter(maxModTime: Long) extends PathFilter {
 
+  private class CustomPathFilter(modTimeIgnoreThreshold: Long) extends PathFilter {
     // Minimum of the mod times of new files found in the current interval
     var minNewFileModTime = -1L
 
     def accept(path: Path): Boolean = {
       try {
+        val pathStr = path.toString
         if (!filter(path)) {  // Reject file if it does not satisfy filter
-          logDebug("Rejected by filter " + path)
+          logDebug(s"$pathStr rejected by filter")
           return false
         }
-        // Reject file if it was found in the last interval
-        if (lastFoundFiles.contains(path.toString)) {
-          logDebug("Mod time equal to last mod time, but file considered already")
+        // Reject file if it was considered earlier
+        if (allFoundFiles.contains(pathStr)) {
+          logDebug(s"$pathStr already considered")
           return false
         }
-        val modTime = getFileModTime(path)
-        logDebug("Mod time for " + path + " is " + modTime)
-        if (modTime < ignoreTime) {
-          // Reject file if it was created before the ignore time (or, before last interval)
-          logDebug("Mod time " + modTime + " less than ignore time " + ignoreTime)
-          return false
-        } else if (modTime > maxModTime) {
-          // Reject file if it is too new that considering it may give errors
-          logDebug("Mod time more than ")
+        val modTime = fileToModTimes.getOrElseUpdate(pathStr,
+          fs.getFileStatus(path).getModificationTime())
+        if (modTime <= modTimeIgnoreThreshold) {
+          // Reject file if it was created before the ignore time
+          logDebug(s"$pathStr ignored as mod time $modTime < ignore time $modTimeIgnoreThreshold")
           return false
         }
         if (minNewFileModTime < 0 || modTime < minNewFileModTime) {
           minNewFileModTime = modTime
         }
-        logDebug("Accepted " + path)
+        logDebug(s"$pathStr accepted with mod time $modTime")
       } catch {
         case fnfe: java.io.FileNotFoundException =>
           logWarning("Error finding new files", fnfe)
@@ -245,5 +274,22 @@ class FileInputDStream[K: ClassTag, V: ClassTag, F <: NewInputFormat[K,V] : Clas
 
 private[streaming]
 object FileInputDStream {
+  /**
+   * Minimum duration of remembering the information of selected files. Files with mod times
+   * older than this "window" of remembering will be ignored. So if new files are visible
+   * within this window, then the file will get selected in the next batch.  
+   */
+  private val MIN_REMEMBER_DURATION = Minutes(1)
+
   def defaultFilter(path: Path): Boolean = !path.getName().startsWith(".")
+
+  /**
+   * Calculate the duration to remember. This duration must be a multiple of the batch duration
+   * while not being less than MIN_REMEMBER_DURATION.
+   */
+  def calculateRememberDuration(batchDuration: Duration): Duration = {
+    val numMinBatches = math.ceil(
+      MIN_REMEMBER_DURATION.milliseconds.toDouble / batchDuration.milliseconds).toLong
+    Milliseconds(numMinBatches * batchDuration.milliseconds)
+  }
 }

--- a/streaming/src/test/scala/org/apache/spark/streaming/CheckpointSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/CheckpointSuite.scala
@@ -265,7 +265,7 @@ class CheckpointSuite extends TestSuiteBase {
 
     // Verify whether files created have been recorded correctly or not
     var fileInputDStream = ssc.graph.getInputStreams().head.asInstanceOf[FileInputDStream[_, _, _]]
-    def recordedFiles = fileInputDStream.files.values.flatMap(x => x)
+    def recordedFiles = fileInputDStream.timeToSelectedFileInfo.values.flatMap(x => x.files)
     assert(!recordedFiles.filter(_.endsWith("1")).isEmpty)
     assert(!recordedFiles.filter(_.endsWith("2")).isEmpty)
     assert(!recordedFiles.filter(_.endsWith("3")).isEmpty)

--- a/streaming/src/test/scala/org/apache/spark/streaming/InputStreamsSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/InputStreamsSuite.scala
@@ -41,7 +41,7 @@ import org.apache.spark.rdd.RDD
 
 class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
 
-  test("socket input stream") {
+  ignore("socket input stream") {
     // Start the server
     val testServer = new TestServer()
     testServer.start()
@@ -141,7 +141,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
     conf.set("spark.streaming.clock", "org.apache.spark.streaming.util.ManualClock")
   }
 
-  test("multi-thread receiver") {
+  ignore("multi-thread receiver") {
     // set up the test receiver
     val numThreads = 10
     val numRecordsPerThread = 1000
@@ -180,7 +180,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
     assert(output.sum === numTotalRecords)
   }
 
-  test("queue input stream - oneAtATime=true") {
+  ignore("queue input stream - oneAtATime=true") {
     // Set up the streaming context and input streams
     val ssc = new StreamingContext(conf, batchDuration)
     val queue = new SynchronizedQueue[RDD[String]]()
@@ -223,7 +223,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
     }
   }
 
-  test("queue input stream - oneAtATime=false") {
+  ignore("queue input stream - oneAtATime=false") {
     // Set up the streaming context and input streams
     val ssc = new StreamingContext(conf, batchDuration)
     val queue = new SynchronizedQueue[RDD[String]]()

--- a/streaming/src/test/scala/org/apache/spark/streaming/InputStreamsSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/InputStreamsSuite.scala
@@ -41,7 +41,7 @@ import org.apache.spark.rdd.RDD
 
 class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
 
-  ignore("socket input stream") {
+  test("socket input stream") {
     // Start the server
     val testServer = new TestServer()
     testServer.start()
@@ -141,7 +141,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
     conf.set("spark.streaming.clock", "org.apache.spark.streaming.util.ManualClock")
   }
 
-  ignore("multi-thread receiver") {
+  test("multi-thread receiver") {
     // set up the test receiver
     val numThreads = 10
     val numRecordsPerThread = 1000
@@ -180,7 +180,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
     assert(output.sum === numTotalRecords)
   }
 
-  ignore("queue input stream - oneAtATime=true") {
+  test("queue input stream - oneAtATime=true") {
     // Set up the streaming context and input streams
     val ssc = new StreamingContext(conf, batchDuration)
     val queue = new SynchronizedQueue[RDD[String]]()
@@ -223,7 +223,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
     }
   }
 
-  ignore("queue input stream - oneAtATime=false") {
+  test("queue input stream - oneAtATime=false") {
     // Set up the streaming context and input streams
     val ssc = new StreamingContext(conf, batchDuration)
     val queue = new SynchronizedQueue[RDD[String]]()


### PR DESCRIPTION
Because of a corner case, a file already selected for batch t can get considered again for batch t+2. This refactoring fixes it by remembering all the files selected in the last 1 minute, so that this corner case does not arise. Also uses spark context's hadoop configuration to access the file system API for listing directories.
