### PR TITLE
Supporting elasticsearch API in this page in pyspark

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -301,6 +301,11 @@
       <artifactId>py4j</artifactId>
       <version>0.8.2.1</version>
     </dependency>
+    <dependency>
+      <groupId>org.elasticsearch</groupId>
+      <artifactId>elasticsearch-spark_2.10</artifactId>
+      <version>2.1.0.Beta2</version>
+  </dependency>
   </dependencies>
   <build>
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>

--- a/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
@@ -39,8 +39,6 @@ import org.apache.spark.api.java.JavaSparkContext.fakeClassTag
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.{EmptyRDD, HadoopRDD, NewHadoopRDD, RDD}
 
-import org.elasticsearch.spark._
-
 /**
  * A Java-friendly version of [[org.apache.spark.SparkContext]] that returns
  * [[org.apache.spark.api.java.JavaRDD]]s and works with Java collections instead of Scala ones.
@@ -205,7 +203,6 @@ class JavaSparkContext(val sc: SparkContext)
    */
   def textFile(path: String, minPartitions: Int): JavaRDD[String] =
     sc.textFile(path, minPartitions)
-
 
 
   /**

--- a/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
@@ -39,6 +39,8 @@ import org.apache.spark.api.java.JavaSparkContext.fakeClassTag
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.{EmptyRDD, HadoopRDD, NewHadoopRDD, RDD}
 
+import org.elasticsearch.spark._
+
 /**
  * A Java-friendly version of [[org.apache.spark.SparkContext]] that returns
  * [[org.apache.spark.api.java.JavaRDD]]s and works with Java collections instead of Scala ones.

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -40,6 +40,8 @@ import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.util.Utils
 
+import org.elasticsearch.spark.rdd.api.java.JavaEsSpark
+
 private[spark] class PythonRDD(
     @transient parent: RDD[_],
     command: Array[Byte],
@@ -429,6 +431,11 @@ private[spark] object PythonRDD extends Logging {
           throw new SparkException("Unexpected element type " + first.getClass)
       }
     }
+  }
+
+  def esRDD(sc: JavaSparkContext, resource: String, query: String) = {
+    val rdd = JavaEsSpark.esRDD(sc, resource, query).rdd
+    JavaRDD.fromRDD(SerDeUtil.pairRDDToPython(rdd))
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -435,7 +435,7 @@ private[spark] object PythonRDD extends Logging {
 
   def esRDD(sc: JavaSparkContext, resource: String, query: String) = {
     val rdd = JavaEsSpark.esRDD(sc, resource, query).rdd
-    JavaRDD.fromRDD(SerDeUtil.pairRDDToPython(rdd))
+    JavaRDD.fromRDD(SerDeUtil.pairRDDToPython(rdd.asInstanceOf[RDD[(Any, Any)]], 0))
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/api/python/SerDeUtil.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/SerDeUtil.scala
@@ -216,19 +216,6 @@ private[spark] object SerDeUtil extends Logging {
     }
   }
 
-  def pairRDDToPython(rdd: RDD[(String, java.util.Map[String,Object])]): RDD[Array[Byte]] = {
-    val (keyFailed, valueFailed) = checkPickle(rdd.first())
-
-    rdd.mapPartitions { iter =>
-      val cleaned = iter.map { case (k, v) =>
-        val key = if (keyFailed) k.toString else k
-        val value = if (valueFailed) v.toString else v
-        Array[Any](key, value)
-      }
-      new AutoBatchedPickler(cleaned)
-    }
-  }
-
   /**
    * Convert an RDD of serialized Python tuple (K, V) to RDD[(K, V)].
    */

--- a/core/src/main/scala/org/apache/spark/api/python/SerDeUtil.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/SerDeUtil.scala
@@ -216,6 +216,19 @@ private[spark] object SerDeUtil extends Logging {
     }
   }
 
+  def pairRDDToPython(rdd: RDD[(String, java.util.Map[String,Object])]): RDD[Array[Byte]] = {
+    val (keyFailed, valueFailed) = checkPickle(rdd.first())
+
+    rdd.mapPartitions { iter =>
+      val cleaned = iter.map { case (k, v) =>
+        val key = if (keyFailed) k.toString else k
+        val value = if (valueFailed) v.toString else v
+        Array[Any](key, value)
+      }
+      new AutoBatchedPickler(cleaned)
+    }
+  }
+
   /**
    * Convert an RDD of serialized Python tuple (K, V) to RDD[(K, V)].
    */

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -45,6 +45,8 @@ __all__ = ['SparkContext']
 DEFAULT_CONFIGS = {
     "spark.serializer.objectStreamReset": 100,
     "spark.rdd.compress": True,
+    # added for ES
+    'es.nodes': '104.131.165.122:9200'
 }
 
 
@@ -569,6 +571,10 @@ class SparkContext(object):
                                              valueClass, keyConverter, valueConverter,
                                              jconf, batchSize)
         return RDD(jrdd, self)
+
+    def esRDD(self, resource, query):
+        es_rdd = self._jvm.PythonRDD.esRDD(self._jsc, resource, query)
+        return RDD(es_rdd, self)
 
     def _checkpointFile(self, name, input_deserializer):
         jrdd = self._jsc.checkpointFile(name)

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -44,9 +44,7 @@ __all__ = ['SparkContext']
 # the default ones for Spark if they are not configured by user.
 DEFAULT_CONFIGS = {
     "spark.serializer.objectStreamReset": 100,
-    "spark.rdd.compress": True,
-    # added for ES
-    'es.nodes': '104.131.165.122:9200'
+    "spark.rdd.compress": True
 }
 
 


### PR DESCRIPTION
I am trying to support elasticsearch API in this page in pyspark:
https://github.com/elasticsearch/elasticsearch-hadoop/blob/master/spark/src/main/scala/org/elasticsearch/spark/rdd/api/java/JavaEsSpark.scala

The POC code is committed into this pull request for `def esRDD(self, resource, query)`. It's working well. I can come up with the rest functions too. 

However, I understand that introduction of a new dependency is not generally accepted:

> Introduction of dependencies: Due to the complex nature of Spark, we are conservative about introducing new dependencies. If patches add new dependencies to Spark, they may not be merged.

I will be happy to listen to a 3-rd party way to do it from the community too.
