### PR TITLE
SPARK-2143 [WEB UI] Add Spark version to UI footer

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -206,6 +206,11 @@ private[spark] object UIUtils extends Logging {
           </div>
           {content}
         </div>
+        <div id="footer">
+          <div class="container-fluid">
+            <p class="muted credit">Spark {org.apache.spark.SPARK_VERSION}</p>
+          </div>
+        </div>
       </body>
     </html>
   }
@@ -231,6 +236,11 @@ private[spark] object UIUtils extends Logging {
             </div>
           </div>
           {content}
+        </div>
+        <div id="footer">
+          <div class="container-fluid">
+            <p class="muted credit">Spark {org.apache.spark.SPARK_VERSION}</p>
+          </div>
         </div>
       </body>
     </html>


### PR DESCRIPTION
I took a very basic stab at adding the Spark version number to the UI header / footer. This is the simplest place I could think to stick it without getting into the CSS much, and this is how it looks:

![screen shot 2014-11-21 at 22 58 40](https://cloud.githubusercontent.com/assets/822522/5151133/2ff0522c-71d2-11e4-9814-e630f7f80f71.png)

Thoughts? I think it's nice to have in the UI but might need to look a little different.
