### PR TITLE
[SQL] Fix path in HiveFromSpark

### DIFF
--- a/examples/src/main/scala/org/apache/spark/examples/sql/hive/HiveFromSpark.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/sql/hive/HiveFromSpark.scala
@@ -25,6 +25,14 @@ object HiveFromSpark {
   case class Record(key: Int, value: String)
 
   def main(args: Array[String]) {
+
+    if (args.length < 1) {
+      System.err.println("Usage: HiveFromSpark <file>")
+      System.exit(1)
+    }
+    // Data path for a table type of (Int, String)
+    val path = args(0)
+
     val sparkConf = new SparkConf().setAppName("HiveFromSpark")
     val sc = new SparkContext(sparkConf)
 
@@ -35,7 +43,7 @@ object HiveFromSpark {
     import hiveContext._
 
     sql("CREATE TABLE IF NOT EXISTS src (key INT, value STRING)")
-    sql("LOAD DATA LOCAL INPATH 'src/main/resources/kv1.txt' INTO TABLE src")
+    sql(s"LOAD DATA LOCAL INPATH '$path' INTO TABLE src")
 
     // Queries are expressed in HiveQL
     println("Result of 'SELECT *': ")

--- a/examples/src/main/scala/org/apache/spark/examples/sql/hive/HiveFromSpark.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/sql/hive/HiveFromSpark.scala
@@ -26,17 +26,11 @@ object HiveFromSpark {
 
   def main(args: Array[String]) {
 
-    if (args.length < 1) {
-      System.err.println("Usage: HiveFromSpark <file>")
-      System.exit(1)
-    }
-    // Data path for a table type of (Int, String)
-    val path = args(0)
-
     val sparkConf = new SparkConf().setAppName("HiveFromSpark")
     val sc = new SparkContext(sparkConf)
+    val path = s"${System.getenv("SPARK_HOME")}/examples/src/main/resources/kv1.txt"
 
-    // A local hive context creates an instance of the Hive Metastore in process, storing 
+    // A local hive context creates an instance of the Hive Metastore in process, storing
     // the warehouse data in the current directory.  This location can be overridden by
     // specifying a second parameter to the constructor.
     val hiveContext = new HiveContext(sc)

--- a/examples/src/main/scala/org/apache/spark/examples/sql/hive/HiveFromSpark.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/sql/hive/HiveFromSpark.scala
@@ -25,12 +25,11 @@ object HiveFromSpark {
   case class Record(key: Int, value: String)
 
   def main(args: Array[String]) {
-
     val sparkConf = new SparkConf().setAppName("HiveFromSpark")
     val sc = new SparkContext(sparkConf)
     val path = s"${System.getenv("SPARK_HOME")}/examples/src/main/resources/kv1.txt"
 
-    // A local hive context creates an instance of the Hive Metastore in process, storing
+    // A local hive context creates an instance of the Hive Metastore in process, storing 
     // the warehouse data in the current directory.  This location can be overridden by
     // specifying a second parameter to the constructor.
     val hiveContext = new HiveContext(sc)


### PR DESCRIPTION
It require us to run `HiveFromSpark` in specified dir because `HiveFromSpark` use relative path, this leads to `run-example` error(http://apache-spark-developers-list.1001551.n3.nabble.com/src-main-resources-kv1-txt-not-found-in-example-of-HiveFromSpark-td9100.html).  
