### PR TITLE
[SPARK-4562] [MLlib] speedup vector

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
@@ -828,9 +828,11 @@ private[spark] object SerDe extends Serializable {
       val n = bytes.length / 12
       val indices = new Array[Int](n)
       val values = new Array[Double](n)
-      val order = ByteOrder.nativeOrder()
-      ByteBuffer.wrap(bytes, 0, n * 4).order(order).asIntBuffer().get(indices)
-      ByteBuffer.wrap(bytes, n * 4, n * 8).order(order).asDoubleBuffer().get(values)
+      if (n > 0) {
+        val order = ByteOrder.nativeOrder()
+        ByteBuffer.wrap(bytes, 0, n * 4).order(order).asIntBuffer().get(indices)
+        ByteBuffer.wrap(bytes, n * 4, n * 8).order(order).asDoubleBuffer().get(values)
+      }
       new SparseVector(args(0).asInstanceOf[Int], indices, values)
     }
   }

--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
@@ -691,6 +691,7 @@ class PythonMLLibAPI extends Serializable {
 private[spark] object SerDe extends Serializable {
 
   val PYSPARK_PACKAGE = "pyspark.mllib"
+  val LATIN1 = "ISO-8859-1"
 
   /**
    * Base class used for pickle
@@ -712,7 +713,7 @@ private[spark] object SerDe extends Serializable {
     def pickle(obj: Object, out: OutputStream, pickler: Pickler): Unit = {
       if (obj == this) {
         out.write(Opcodes.GLOBAL)
-        out.write((module + "\n" + name + "\n").getBytes())
+        out.write((module + "\n" + name + "\n").getBytes)
       } else {
         pickler.save(this)  // it will be memorized by Pickler
         saveState(obj, out, pickler)
@@ -759,7 +760,7 @@ private[spark] object SerDe extends Serializable {
       if (args.length != 1) {
         throw new PickleException("should be 1")
       }
-      val bytes = args(0).asInstanceOf[String].getBytes("ISO-8859-1")
+      val bytes = args(0).asInstanceOf[String].getBytes(LATIN1)
       val bb = ByteBuffer.wrap(bytes, 0, bytes.length)
       bb.order(ByteOrder.nativeOrder())
       val db = bb.asDoubleBuffer()
@@ -792,7 +793,7 @@ private[spark] object SerDe extends Serializable {
       if (args.length != 3) {
         throw new PickleException("should be 3")
       }
-      val bytes = args(2).asInstanceOf[String].getBytes("ISO-8859-1")
+      val bytes = args(2).asInstanceOf[String].getBytes(LATIN1)
       val n = bytes.length / 8
       val values = new Array[Double](n)
       val order = ByteOrder.nativeOrder()
@@ -829,8 +830,8 @@ private[spark] object SerDe extends Serializable {
         throw new PickleException("should be 3")
       }
       val size = args(0).asInstanceOf[Int]
-      val indiceBytes = args(1).asInstanceOf[String].getBytes("ISO-8859-1")
-      val valueBytes = args(2).asInstanceOf[String].getBytes("ISO-8859-1")
+      val indiceBytes = args(1).asInstanceOf[String].getBytes(LATIN1)
+      val valueBytes = args(2).asInstanceOf[String].getBytes(LATIN1)
       val n = indiceBytes.length / 4
       val indices = new Array[Int](n)
       val values = new Array[Double](n)

--- a/python/pyspark/mllib/linalg.py
+++ b/python/pyspark/mllib/linalg.py
@@ -319,8 +319,12 @@ class SparseVector(Vector):
             if isinstance(pairs, basestring):
                 l = len(pairs) / (4 + 8)
                 assert len(pairs) == l * 12, "unexpected length: %d" % len(pairs)
-                self.indices = np.frombuffer(pairs[:l * 4], np.uint32)
-                self.values = np.frombuffer(pairs[l * 4:], np.float64)
+                if l:
+                    self.indices = np.frombuffer(pairs[:l * 4], np.uint32)
+                    self.values = np.frombuffer(pairs[l * 4:], np.float64)
+                else:
+                    self.indices = np.array([], dtype=np.uint32)
+                    self.values = np.array([], dtype=np.float64)
             else:
                 if type(pairs) == dict:
                     pairs = pairs.items()

--- a/python/pyspark/mllib/linalg.py
+++ b/python/pyspark/mllib/linalg.py
@@ -318,8 +318,9 @@ class SparseVector(Vector):
             pairs = args[0]
             if isinstance(pairs, basestring):
                 l = len(pairs) / (4 + 8)
-                self.indices = np.frombuffer(pairs, np.uint32, count=l)
-                self.values = np.frombuffer(pairs, np.float64, count=l, offset=l * 4)
+                assert len(pairs) == l * 12, "unexpected length: %d" % len(pairs)
+                self.indices = np.frombuffer(pairs[:l * 4], np.uint32)
+                self.values = np.frombuffer(pairs[l * 4:], np.float64)
             else:
                 if type(pairs) == dict:
                     pairs = pairs.items()

--- a/python/pyspark/mllib/linalg.py
+++ b/python/pyspark/mllib/linalg.py
@@ -26,12 +26,11 @@ SciPy is available in their environment.
 import sys
 import array
 import copy_reg
-import itertools
 
 import numpy as np
 
 from pyspark.sql import UserDefinedType, StructField, StructType, ArrayType, DoubleType, \
-    IntegerType, ByteType, Row
+    IntegerType, ByteType
 
 
 __all__ = ['Vector', 'DenseVector', 'SparseVector', 'Vectors', 'DenseMatrix', 'Matrices']
@@ -472,8 +471,7 @@ class SparseVector(Vector):
         Returns a copy of this SparseVector as a 1-dimensional NumPy array.
         """
         arr = np.zeros((self.size,), dtype=np.float64)
-        for i, v in itertools.izip(self.indices, self.values):
-            arr[i] = v
+        arr[self.indices] = self.values
         return arr
 
     def __len__(self):

--- a/python/pyspark/mllib/linalg.py
+++ b/python/pyspark/mllib/linalg.py
@@ -324,8 +324,13 @@ class SparseVector(Vector):
         else:
             if isinstance(args[0], basestring):
                 assert isinstance(args[1], str), "values should be string too"
-                self.indices = np.frombuffer(args[0], np.int32)
-                self.values = np.frombuffer(args[1], np.float64)
+                if args[0]:
+                    self.indices = np.frombuffer(args[0], np.int32)
+                    self.values = np.frombuffer(args[1], np.float64)
+                else:
+                    # np.frombuffer() doesn't work well with empty string in older version
+                    self.indices = np.array([], dtype=np.int32)
+                    self.values = np.array([], dtype=np.float64)
             else:
                 self.indices = np.array(args[0], dtype=np.int32)
                 self.values = np.array(args[1], dtype=np.float64)

--- a/python/pyspark/mllib/linalg.py
+++ b/python/pyspark/mllib/linalg.py
@@ -587,25 +587,35 @@ class DenseMatrix(Matrix):
     """
     def __init__(self, numRows, numCols, values):
         Matrix.__init__(self, numRows, numCols)
+        if isinstance(values, basestring):
+            values = np.frombuffer(values, dtype=np.float64)
+        elif not isinstance(values, np.ndarray):
+            values = np.array(values, dtype=np.float64)
         assert len(values) == numRows * numCols
-        if not isinstance(values, array.array):
-            values = array.array('d', values)
+        if values.dtype != np.float64:
+            values.astype(np.float64)
         self.values = values
 
     def __reduce__(self):
-        return DenseMatrix, (self.numRows, self.numCols, self.values)
+        return DenseMatrix, (self.numRows, self.numCols, self.values.tostring())
 
     def toArray(self):
         """
         Return an numpy.ndarray
 
-        >>> arr = array.array('d', [float(i) for i in range(4)])
+        >>> arr = np.array([float(i) for i in range(4)])
         >>> m = DenseMatrix(2, 2, arr)
         >>> m.toArray()
         array([[ 0.,  2.],
                [ 1.,  3.]])
         """
-        return np.reshape(self.values, (self.numRows, self.numCols), order='F')
+        return self.values.reshape((self.numRows, self.numCols), order='F')
+
+    def __eq__(self, other):
+        return (isinstance(other, DenseMatrix) and
+                self.numRows == other.numRows and
+                self.numCols == other.numCols and
+                all(self.values == other.values))
 
 
 class Matrices(object):

--- a/python/pyspark/mllib/linalg.py
+++ b/python/pyspark/mllib/linalg.py
@@ -173,7 +173,7 @@ class DenseVector(Vector):
     A dense vector represented by a value array.
     """
     def __init__(self, ar):
-        if isinstance(ar, (bytearray, basestring)):
+        if isinstance(ar, basestring):
             ar = np.frombuffer(ar, dtype=np.float64)
         elif not isinstance(ar, np.ndarray):
             ar = np.array(ar, dtype=np.float64)
@@ -319,7 +319,7 @@ class SparseVector(Vector):
             if isinstance(pairs, basestring):
                 l = len(pairs) / (4 + 8)
                 self.indices = np.frombuffer(pairs, np.uint32, count=l)
-                self.values = np.frombuffer(pairs, np.float64, l, offset=l * 4)
+                self.values = np.frombuffer(pairs, np.float64, count=l, offset=l * 4)
             else:
                 if type(pairs) == dict:
                     pairs = pairs.items()

--- a/python/pyspark/mllib/tests.py
+++ b/python/pyspark/mllib/tests.py
@@ -77,6 +77,7 @@ class VectorTests(PySparkTestCase):
         self._test_serialize(DenseVector(array([1., 2., 3., 4.])))
         self._test_serialize(DenseVector(pyarray.array('d', range(10))))
         self._test_serialize(SparseVector(4, {1: 1, 3: 2}))
+        self._test_serialize(SparseVector(3, {}))
         self._test_serialize(DenseMatrix(2, 3, range(6)))
 
     def test_dot(self):

--- a/python/pyspark/mllib/tests.py
+++ b/python/pyspark/mllib/tests.py
@@ -33,7 +33,8 @@ if sys.version_info[:2] <= (2, 6):
 else:
     import unittest
 
-from pyspark.mllib.linalg import Vector, SparseVector, DenseVector, VectorUDT, _convert_to_vector
+from pyspark.mllib.linalg import Vector, SparseVector, DenseVector, VectorUDT, _convert_to_vector,\
+    DenseMatrix
 from pyspark.mllib.regression import LabeledPoint
 from pyspark.mllib.random import RandomRDDs
 from pyspark.mllib.stat import Statistics
@@ -76,6 +77,7 @@ class VectorTests(PySparkTestCase):
         self._test_serialize(DenseVector(array([1., 2., 3., 4.])))
         self._test_serialize(DenseVector(pyarray.array('d', range(10))))
         self._test_serialize(SparseVector(4, {1: 1, 3: 2}))
+        self._test_serialize(DenseMatrix(2, 3, range(6)))
 
     def test_dot(self):
         sv = SparseVector(4, {1: 1, 3: 2})

--- a/python/pyspark/mllib/tests.py
+++ b/python/pyspark/mllib/tests.py
@@ -62,6 +62,7 @@ def _squared_distance(a, b):
 class VectorTests(PySparkTestCase):
 
     def _test_serialize(self, v):
+        self.assertEqual(v, ser.loads(ser.dumps(v)))
         jvec = self.sc._jvm.SerDe.loads(bytearray(ser.dumps(v)))
         nv = ser.loads(str(self.sc._jvm.SerDe.dumps(jvec)))
         self.assertEqual(v, nv)


### PR DESCRIPTION
This PR change the underline array of DenseVector to numpy.ndarray to avoid the conversion, because most of the users will using numpy.array.

It also improve the serialization of DenseVector.

Before this change:

| trial | trainingTime | testTime |
| --- | --- | --- |
| 0 | 5.126 | 1.786 |
| 1 | 2.698 | 1.693 |

After the change:

| trial | trainingTime | testTime |
| --- | --- | --- |
| 0 | 4.692 | 0.554 |
| 1 | 2.307 | 0.525 |

This could partially fix the performance regression during test.
