### PR TITLE
[Core]Remove duplicated code in DAGScheduler

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1037,7 +1037,6 @@ class DAGScheduler(
                   newlyRunnable += stage
                 }
                 waitingStages --= newlyRunnable
-                runningStages ++= newlyRunnable
                 for {
                   stage <- newlyRunnable.sortBy(_.id)
                   jobId <- activeJobForStage(stage)


### PR DESCRIPTION
A simple code optimization. 

After the DAGScheduler figures out new runnable stages, it adds them to the runningStages twice: one (line 1040) before calling submitMissingTasks() and one inside the submitMissingTasks() (line 814).
We can just remove the first one.
