### PR TITLE
SPARK-4507: PR merge script should support closing multiple JIRA tickets

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -215,36 +215,12 @@ def fix_version_from_branch(branch, versions):
 
 
 def resolve_jira(title, merge_branches, comment):
+
+    def get_version_json(version_str):
+        return filter(lambda v: v.name == version_str, versions)[0].raw
+
     asf_jira = jira.client.JIRA({'server': JIRA_API_BASE},
                                 basic_auth=(JIRA_USERNAME, JIRA_PASSWORD))
-
-    default_jira_id = ""
-    search = re.findall("SPARK-[0-9]{4,5}", title)
-    if len(search) > 0:
-        default_jira_id = search[0]
-
-    jira_id = raw_input("Enter a JIRA id [%s]: " % default_jira_id)
-    if jira_id == "":
-        jira_id = default_jira_id
-
-    try:
-        issue = asf_jira.issue(jira_id)
-    except Exception as e:
-        fail("ASF JIRA could not find %s\n%s" % (jira_id, e))
-
-    cur_status = issue.fields.status.name
-    cur_summary = issue.fields.summary
-    cur_assignee = issue.fields.assignee
-    if cur_assignee is None:
-        cur_assignee = "NOT ASSIGNED!!!"
-    else:
-        cur_assignee = cur_assignee.displayName
-
-    if cur_status == "Resolved" or cur_status == "Closed":
-        fail("JIRA issue %s already has status '%s'" % (jira_id, cur_status))
-    print ("=== JIRA %s ===" % jira_id)
-    print ("summary\t\t%s\nassignee\t%s\nstatus\t\t%s\nurl\t\t%s/%s\n" % (
-        cur_summary, cur_assignee, cur_status, JIRA_BASE, jira_id))
 
     versions = asf_jira.project_versions("SPARK")
     versions = sorted(versions, key=lambda x: x.name, reverse=True)
@@ -263,21 +239,44 @@ def resolve_jira(title, merge_branches, comment):
                 default_fix_versions = filter(lambda x: x != v, default_fix_versions)
     default_fix_versions = ",".join(default_fix_versions)
 
-    fix_versions = raw_input("Enter comma-separated fix version(s) [%s]: " % default_fix_versions)
-    if fix_versions == "":
-        fix_versions = default_fix_versions
-    fix_versions = fix_versions.replace(" ", "").split(",")
+    search_jira_ids = re.findall("SPARK-[0-9]{4,5}", title)
 
-    def get_version_json(version_str):
-        return filter(lambda v: v.name == version_str, versions)[0].raw
+    for search_jira_id in search_jira_ids:
+        jira_id = raw_input("Enter a JIRA id [%s]: " % search_jira_id)
+        if jira_id == "":
+            jira_id = search_jira_id
 
-    jira_fix_versions = map(lambda v: get_version_json(v), fix_versions)
+        try:
+            issue = asf_jira.issue(jira_id)
+        except Exception as e:
+            fail("ASF JIRA could not find %s\n%s" % (jira_id, e))
 
-    resolve = filter(lambda a: a['name'] == "Resolve Issue", asf_jira.transitions(jira_id))[0]
-    asf_jira.transition_issue(
-        jira_id, resolve["id"], fixVersions=jira_fix_versions, comment=comment)
+        cur_status = issue.fields.status.name
+        cur_summary = issue.fields.summary
+        cur_assignee = issue.fields.assignee
+        if cur_assignee is None:
+            cur_assignee = "NOT ASSIGNED!!!"
+        else:
+            cur_assignee = cur_assignee.displayName
 
-    print "Succesfully resolved %s with fixVersions=%s!" % (jira_id, fix_versions)
+        if cur_status == "Resolved" or cur_status == "Closed":
+            fail("JIRA issue %s already has status '%s'" % (jira_id, cur_status))
+        print ("=== JIRA %s ===" % jira_id)
+        print ("summary\t\t%s\nassignee\t%s\nstatus\t\t%s\nurl\t\t%s/%s\n" % (
+            cur_summary, cur_assignee, cur_status, JIRA_BASE, jira_id))
+
+        fix_versions = raw_input("Enter comma-separated fix version(s) [%s]: " % default_fix_versions)
+        if fix_versions == "":
+            fix_versions = default_fix_versions
+        fix_versions = fix_versions.replace(" ", "").split(",")
+
+        jira_fix_versions = map(lambda v: get_version_json(v), fix_versions)
+
+        resolve = filter(lambda a: a['name'] == "Resolve Issue", asf_jira.transitions(jira_id))[0]
+        asf_jira.transition_issue(
+            jira_id, resolve["id"], fixVersions=jira_fix_versions, comment=comment)
+
+        print "Succesfully resolved %s with fixVersions=%s!" % (jira_id, fix_versions)
 
 
 branches = get_json("%s/branches" % GITHUB_API_BASE)

--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -214,13 +214,32 @@ def fix_version_from_branch(branch, versions):
         return filter(lambda x: x.name.startswith(branch_ver), versions)[-1]
 
 
-def resolve_jira(title, merge_branches, comment):
-
-    def get_version_json(version_str):
-        return filter(lambda v: v.name == version_str, versions)[0].raw
-
+def resolve_jira_issue(merge_branches, comment, default_jira_id=""):
     asf_jira = jira.client.JIRA({'server': JIRA_API_BASE},
                                 basic_auth=(JIRA_USERNAME, JIRA_PASSWORD))
+
+    jira_id = raw_input("Enter a JIRA id [%s]: " % default_jira_id)
+    if jira_id == "":
+        jira_id = default_jira_id
+
+    try:
+        issue = asf_jira.issue(jira_id)
+    except Exception as e:
+        fail("ASF JIRA could not find %s\n%s" % (jira_id, e))
+
+    cur_status = issue.fields.status.name
+    cur_summary = issue.fields.summary
+    cur_assignee = issue.fields.assignee
+    if cur_assignee is None:
+        cur_assignee = "NOT ASSIGNED!!!"
+    else:
+        cur_assignee = cur_assignee.displayName
+
+    if cur_status == "Resolved" or cur_status == "Closed":
+        fail("JIRA issue %s already has status '%s'" % (jira_id, cur_status))
+    print ("=== JIRA %s ===" % jira_id)
+    print ("summary\t\t%s\nassignee\t%s\nstatus\t\t%s\nurl\t\t%s/%s\n" % (
+        cur_summary, cur_assignee, cur_status, JIRA_BASE, jira_id))
 
     versions = asf_jira.project_versions("SPARK")
     versions = sorted(versions, key=lambda x: x.name, reverse=True)
@@ -239,44 +258,28 @@ def resolve_jira(title, merge_branches, comment):
                 default_fix_versions = filter(lambda x: x != v, default_fix_versions)
     default_fix_versions = ",".join(default_fix_versions)
 
-    search_jira_ids = re.findall("SPARK-[0-9]{4,5}", title)
+    fix_versions = raw_input("Enter comma-separated fix version(s) [%s]: " % default_fix_versions)
+    if fix_versions == "":
+        fix_versions = default_fix_versions
+    fix_versions = fix_versions.replace(" ", "").split(",")
 
-    for search_jira_id in search_jira_ids:
-        jira_id = raw_input("Enter a JIRA id [%s]: " % search_jira_id)
-        if jira_id == "":
-            jira_id = search_jira_id
+    def get_version_json(version_str):
+        return filter(lambda v: v.name == version_str, versions)[0].raw
 
-        try:
-            issue = asf_jira.issue(jira_id)
-        except Exception as e:
-            fail("ASF JIRA could not find %s\n%s" % (jira_id, e))
+    jira_fix_versions = map(lambda v: get_version_json(v), fix_versions)
 
-        cur_status = issue.fields.status.name
-        cur_summary = issue.fields.summary
-        cur_assignee = issue.fields.assignee
-        if cur_assignee is None:
-            cur_assignee = "NOT ASSIGNED!!!"
-        else:
-            cur_assignee = cur_assignee.displayName
+    resolve = filter(lambda a: a['name'] == "Resolve Issue", asf_jira.transitions(jira_id))[0]
+    asf_jira.transition_issue(
+        jira_id, resolve["id"], fixVersions=jira_fix_versions, comment=comment)
 
-        if cur_status == "Resolved" or cur_status == "Closed":
-            fail("JIRA issue %s already has status '%s'" % (jira_id, cur_status))
-        print ("=== JIRA %s ===" % jira_id)
-        print ("summary\t\t%s\nassignee\t%s\nstatus\t\t%s\nurl\t\t%s/%s\n" % (
-            cur_summary, cur_assignee, cur_status, JIRA_BASE, jira_id))
+    print "Succesfully resolved %s with fixVersions=%s!" % (jira_id, fix_versions)
 
-        fix_versions = raw_input("Enter comma-separated fix version(s) [%s]: " % default_fix_versions)
-        if fix_versions == "":
-            fix_versions = default_fix_versions
-        fix_versions = fix_versions.replace(" ", "").split(",")
 
-        jira_fix_versions = map(lambda v: get_version_json(v), fix_versions)
+def resolve_jira_issues(title, merge_branches, comment):
+    jira_ids = re.findall("SPARK-[0-9]{4,5}", title)
 
-        resolve = filter(lambda a: a['name'] == "Resolve Issue", asf_jira.transitions(jira_id))[0]
-        asf_jira.transition_issue(
-            jira_id, resolve["id"], fixVersions=jira_fix_versions, comment=comment)
-
-        print "Succesfully resolved %s with fixVersions=%s!" % (jira_id, fix_versions)
+    for jira_id in jira_ids:
+        resolve_jira_issue(merge_branches, comment, jira_id)
 
 
 branches = get_json("%s/branches" % GITHUB_API_BASE)
@@ -337,7 +340,7 @@ if JIRA_IMPORTED:
     if JIRA_USERNAME and JIRA_PASSWORD:
         continue_maybe("Would you like to update an associated JIRA?")
         jira_comment = "Issue resolved by pull request %s\n[%s/%s]" % (pr_num, GITHUB_BASE, pr_num)
-        resolve_jira(title, merged_refs, jira_comment)
+        resolve_jira_issues(title, merged_refs, jira_comment)
     else:
         print "JIRA_USERNAME and JIRA_PASSWORD not set"
         print "Exiting without trying to close the associated JIRA."

--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -278,6 +278,8 @@ def resolve_jira_issue(merge_branches, comment, default_jira_id=""):
 def resolve_jira_issues(title, merge_branches, comment):
     jira_ids = re.findall("SPARK-[0-9]{4,5}", title)
 
+    if len(jira_ids) == 0:
+        resolve_jira_issue(merge_branches, comment)
     for jira_id in jira_ids:
         resolve_jira_issue(merge_branches, comment, jira_id)
 


### PR DESCRIPTION
This will fix SPARK-4507.

For pull requests that reference multiple JIRAs in their titles, it would be helpful if the PR merge script offered to close all of them.
