### PR TITLE
[SPARK-2387][Core]Remove Stage's barrier

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -935,7 +935,8 @@ class DAGScheduler(
           logInfo("Pre-start stage " + preStartStage.id)
           // Register map output finished so far
           mapOutputTracker.registerMapOutputs(stage.shuffleDep.get.shuffleId,
-            stage.outputLocs.map(list => if (list.isEmpty) null else list.head).toArray, changeEpoch = false)
+            stage.outputLocs.map(list => if (list.isEmpty) null else list.head).toArray,
+            changeEpoch = false)
           waitingStages -= preStartStage
           runningStages += preStartStage
           // Inform parent stages that the dependant stage has been pre-started

--- a/core/src/main/scala/org/apache/spark/scheduler/SchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SchedulerBackend.scala
@@ -34,6 +34,8 @@ private[spark] trait SchedulerBackend {
     throw new UnsupportedOperationException
   def isReady(): Boolean = true
 
+  def freeSlotAvail(numPendingTask: Int): Boolean = false
+
   /**
    * Get an application ID associated with the job.
    *

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -348,6 +348,10 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val actorSyste
    */
   protected def doKillExecutors(executorIds: Seq[String]): Boolean = false
 
+  override def freeSlotAvail(numPendingTask: Int): Boolean = {
+    numPendingTask * scheduler.CPUS_PER_TASK < totalCoreCount.get()
+  }
+
 }
 
 private[spark] object CoarseGrainedSchedulerBackend {

--- a/core/src/main/scala/org/apache/spark/shuffle/hash/BlockStoreShuffleFetcher.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/hash/BlockStoreShuffleFetcher.scala
@@ -40,7 +40,8 @@ private[hash] object BlockStoreShuffleFetcher extends Logging {
 
     val startTime = System.currentTimeMillis
     var statuses: Array[(BlockManagerId, Long)] = null
-    val blockFetcherItr = if (blockManager.conf.getBoolean("spark.scheduler.removeStageBarrier", false)) {
+    val blockFetcherItr = if (blockManager.conf.getBoolean("spark.scheduler.removeStageBarrier",
+      false)) {
       statuses = SparkEnv.get.mapOutputTracker.getUpdatedStatus(shuffleId, reduceId)
       logDebug("Fetching partial output for shuffle %d, reduce %d took %d ms".format(
         shuffleId, reduceId, System.currentTimeMillis - startTime))
@@ -60,7 +61,6 @@ private[hash] object BlockStoreShuffleFetcher extends Logging {
       for (((address, size), index) <- statuses.zipWithIndex) {
         splitsByAddress.getOrElseUpdate(address, ArrayBuffer()) += ((index, size))
       }
-
       val blocksByAddress: Seq[(BlockManagerId, Seq[(BlockId, Long)])] = splitsByAddress.toSeq.map {
         case (address, splits) =>
           (address, splits.map(s => (ShuffleBlockId(shuffleId, s._1, reduceId), s._2)))

--- a/core/src/main/scala/org/apache/spark/storage/PartialBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/PartialBlockFetcherIterator.scala
@@ -1,0 +1,97 @@
+package org.apache.spark.storage
+
+import java.util.concurrent.LinkedBlockingQueue
+
+import scala.collection.mutable.{ArrayBuffer, HashSet, HashMap}
+import scala.util.Try
+
+import org.apache.spark.{SparkEnv, MapOutputTracker, Logging, TaskContext}
+import org.apache.spark.network.shuffle. ShuffleClient
+import org.apache.spark.serializer.Serializer
+
+private[spark]
+class PartialBlockFetcherIterator(
+    context: TaskContext,
+    shuffleClient: ShuffleClient,
+    blockManager: BlockManager,
+    var statuses: Array[(BlockManagerId, Long)],
+    serializer: Serializer,
+    shuffleId: Int,
+    reduceId: Int)
+  extends Iterator[(BlockId, Try[Iterator[Any]])] with Logging {
+
+  private val mapOutputFetchInterval = SparkEnv.get.conf.getInt("spark.reducer.mapOutput.fetchInterval", 1000)
+
+  private var iterator:Iterator[(BlockId, Try[Iterator[Any]])] = null
+
+  // Track the map outputs we've delegated
+  private val delegatedStatuses = new HashSet[Int]()
+
+  private var fetchTime:Int = 1
+
+  initialize()
+
+  // Get the updated map output
+  private def updateStatuses() {
+    fetchTime += 1
+    logDebug("Still missing " + statuses.filter(_ == null).size +
+      " map outputs for reduce " + reduceId + " of shuffle " + shuffleId +" next fetchTime="+ fetchTime)
+    val update = SparkEnv.get.mapOutputTracker.getUpdatedStatus(shuffleId, reduceId)
+    statuses = update
+  }
+
+  private def readyStatuses = (0 until statuses.size).filter(statuses(_) != null)
+
+  // Check if there's new map outputs available
+  private def newStatusesReady = readyStatuses.exists(!delegatedStatuses.contains(_))
+
+  private def getIterator() = {
+    while (!newStatusesReady) {
+      Thread.sleep(mapOutputFetchInterval)
+      updateStatuses()
+    }
+    val splitsByAddress = new HashMap[BlockManagerId, ArrayBuffer[(Int, Long)]]
+    for (index <- readyStatuses if !delegatedStatuses.contains(index)) {
+      splitsByAddress.getOrElseUpdate(statuses(index)._1, ArrayBuffer()) += ((index, statuses(index)._2))
+      delegatedStatuses += index
+    }
+    val blocksByAddress: Seq[(BlockManagerId, Seq[(BlockId, Long)])] = splitsByAddress.toSeq.map {
+      case (address, splits) =>
+        (address, splits.map(s => (ShuffleBlockId(shuffleId, s._1, reduceId), s._2)))
+    }
+    logDebug("Delegating " + blocksByAddress.map(_._2.size).sum +
+      " blocks to a new iterator for reduce " + reduceId + " of shuffle " + shuffleId)
+    val blockFetcherItr = new ShuffleBlockFetcherIterator(
+      context,
+      SparkEnv.get.blockManager.shuffleClient,
+      blockManager,
+      blocksByAddress,
+      serializer,
+      SparkEnv.get.conf.getLong("spark.reducer.maxMbInFlight", 48) * 1024 * 1024)
+    blockFetcherItr
+  }
+
+  private[this] def initialize(){
+    iterator = getIterator()
+  }
+
+  override def hasNext: Boolean = {
+    // Firstly see if the delegated iterators have more blocks for us
+    if (iterator.hasNext) {
+      return true
+    }
+    // If we have blocks not delegated yet, try to delegate them to a new iterator
+    // and depend on the iterator to tell us if there are valid blocks.
+    while (delegatedStatuses.size < statuses.size) {
+      iterator = getIterator()
+      if (iterator.hasNext) {
+        return true
+      }
+    }
+    false
+  }
+
+  override def next(): (BlockId, Try[Iterator[Any]]) = {
+    return iterator.next()
+  }
+}

--- a/core/src/main/scala/org/apache/spark/storage/PartialBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/PartialBlockFetcherIterator.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.storage
 
 import java.util.concurrent.LinkedBlockingQueue

--- a/core/src/main/scala/org/apache/spark/storage/PartialBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/PartialBlockFetcherIterator.scala
@@ -52,7 +52,7 @@ class PartialBlockFetcherIterator(
   // Get the updated map output
   private def updateStatuses() {
     fetchTime += 1
-    logDebug("Still missing " + statuses.filter(_ == null).size +" map outputs for reduce "
+    logDebug("Still missing " + statuses.filter(_ == null).size + " map outputs for reduce "
       + reduceId + " of shuffle " + shuffleId + " next fetchTime=" + fetchTime)
     val update = SparkEnv.get.mapOutputTracker.getUpdatedStatus(shuffleId, reduceId)
     statuses = update

--- a/core/src/main/scala/org/apache/spark/storage/PartialBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/PartialBlockFetcherIterator.scala
@@ -37,7 +37,8 @@ class PartialBlockFetcherIterator(
     reduceId: Int)
   extends Iterator[(BlockId, Try[Iterator[Any]])] with Logging {
 
-  private val mapOutputFetchInterval = SparkEnv.get.conf.getInt("spark.reducer.mapOutput.fetchInterval", 1000)
+  private val mapOutputFetchInterval =
+    SparkEnv.get.conf.getInt("spark.reducer.mapOutput.fetchInterval", 1000)
 
   private var iterator:Iterator[(BlockId, Try[Iterator[Any]])] = null
 
@@ -51,8 +52,8 @@ class PartialBlockFetcherIterator(
   // Get the updated map output
   private def updateStatuses() {
     fetchTime += 1
-    logDebug("Still missing " + statuses.filter(_ == null).size +
-      " map outputs for reduce " + reduceId + " of shuffle " + shuffleId +" next fetchTime="+ fetchTime)
+    logDebug("Still missing " + statuses.filter(_ == null).size +" map outputs for reduce "
+      + reduceId + " of shuffle " + shuffleId + " next fetchTime=" + fetchTime)
     val update = SparkEnv.get.mapOutputTracker.getUpdatedStatus(shuffleId, reduceId)
     statuses = update
   }
@@ -69,7 +70,8 @@ class PartialBlockFetcherIterator(
     }
     val splitsByAddress = new HashMap[BlockManagerId, ArrayBuffer[(Int, Long)]]
     for (index <- readyStatuses if !delegatedStatuses.contains(index)) {
-      splitsByAddress.getOrElseUpdate(statuses(index)._1, ArrayBuffer()) += ((index, statuses(index)._2))
+      splitsByAddress.getOrElseUpdate(statuses(index)._1, ArrayBuffer()) +=
+        ((index, statuses(index)._2))
       delegatedStatuses += index
     }
     val blocksByAddress: Seq[(BlockManagerId, Seq[(BlockId, Long)])] = splitsByAddress.toSeq.map {


### PR DESCRIPTION
based on https://github.com/apache/spark/pull/1328.
when one task of parent stage is not finished, so other executors is idle. we can pre-start the reduce stage to make good use of these idle executors.
This can achieve better resource utilization and improve the overall job performance, especially when there're lots of executors granted to the application.in my no-cache application's test, it improves the job by about 10%.
@lirui-intel @sryza @rxin 
