### PR TITLE
[SPARK-4581][MLlib] Refactorize StandardScaler to improve the transformation performance

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/StandardScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/StandardScaler.scala
@@ -101,15 +101,16 @@ class StandardScalerModel private[mllib] (
       vector match {
         case dv: DenseVector =>
           val values = dv.values.clone()
+          val size = values.size
           var i = 0
           if (withStd) {
             val localFactor = factor
-            while (i < values.length) {
+            while (i < size) {
               values(i) = (values(i) - localShift(i)) * localFactor(i)
               i += 1
             }
           } else {
-            while (i < values.length) {
+            while (i < size) {
               values(i) -= localShift(i)
               i += 1
             }
@@ -122,8 +123,9 @@ class StandardScalerModel private[mllib] (
       vector match {
         case dv: DenseVector =>
           val values = dv.values.clone()
+          val size = values.size
           var i = 0
-          while(i < values.length) {
+          while(i < size) {
             values(i) *= localFactor(i)
             i += 1
           }
@@ -133,8 +135,9 @@ class StandardScalerModel private[mllib] (
           // so we can re-use it to save memory.
           val indices = sv.indices
           val values = sv.values.clone()
+          val size = values.size
           var i = 0
-          while (i < indices.length) {
+          while (i < size) {
             values(i) *= localFactor(indices(i))
             i += 1
           }

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/StandardScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/StandardScaler.scala
@@ -85,7 +85,10 @@ class StandardScalerModel private[mllib] (
     f
   }
 
-  private val shift: Array[Double] = mean.toArray
+  // Since `shift` will be only used in `withMean` branch, we have it as
+  // `lazy val` so it will be evaluated in that branch. Note that we don't
+  // want to create this array multiple times in `transform` function.
+  private lazy val shift: Array[Double] = mean.toArray
 
   /**
    * Applies standardization transformation on a vector.

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/StandardScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/StandardScaler.scala
@@ -102,7 +102,7 @@ class StandardScalerModel private[mllib] (
         case dv: DenseVector =>
           val values = dv.values.clone()
           var i = 0
-          if(withStd) {
+          if (withStd) {
             val localFactor = factor
             while (i < values.length) {
               values(i) = (values(i) - localShift(i)) * localFactor(i)

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/StandardScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/StandardScaler.scala
@@ -96,7 +96,6 @@ class StandardScalerModel private[mllib] (
    */
   override def transform(vector: Vector): Vector = {
     require(mean.size == vector.size)
-    val localFactor = factor
     if (withMean) {
       val localShift = shift
       vector match {
@@ -104,6 +103,7 @@ class StandardScalerModel private[mllib] (
           val values = dv.values.clone()
           var i = 0
           if(withStd) {
+            val localFactor = factor
             while (i < values.length) {
               values(i) = (values(i) - localShift(i)) * localFactor(i)
               i += 1
@@ -118,6 +118,7 @@ class StandardScalerModel private[mllib] (
         case v => throw new IllegalArgumentException("Do not support vector type " + v.getClass)
       }
     } else if (withStd) {
+      val localFactor = factor
       vector match {
         case dv: DenseVector =>
           val values = dv.values.clone()


### PR DESCRIPTION
The following optimizations are done to improve the StandardScaler model 
transformation performance.

1) Covert Breeze dense vector to primitive vector to reduce the overhead.
2) Since mean can be potentially a sparse vector, we explicitly convert it to dense primitive vector.
3) Have a local reference to `shift` and `factor` array so JVM can locate the value with one operation call.
4) In pattern matching part, we use the mllib SparseVector/DenseVector instead of breeze's vector to 
make the codebase cleaner.

Benchmark with mnist8m dataset:

Before,
DenseVector withMean and withStd: 50.97secs
DenseVector withMean and withoutStd: 42.11secs
DenseVector withoutMean and withStd: 8.75secs
SparseVector withoutMean and withStd: 5.437secs

With this PR,
DenseVector withMean and withStd: 5.76secs
DenseVector withMean and withoutStd: 5.28secs
DenseVector withoutMean and withStd: 5.30secs
SparseVector withoutMean and withStd: 1.27secs

Note that without the local reference copy of `factor` and `shift` arrays, 
the runtime is almost three time slower. 

DenseVector withMean and withStd: 18.15secs
DenseVector withMean and withoutStd: 18.05secs
DenseVector withoutMean and withStd: 18.54secs
SparseVector withoutMean and withStd: 2.01secs

The following code,

``` scala
while (i < size) {
   values(i) = (values(i) - shift(i)) * factor(i)
   i += 1
}
```

will generate the bytecode

```
   L13
    LINENUMBER 106 L13
   FRAME FULL [org/apache/spark/mllib/feature/StandardScalerModel org/apache/spark/mllib/linalg/Vector org/apache/spark/mllib/linalg/Vector org/apache/spark/mllib/linalg/DenseVector T [D I I] []
    ILOAD 7
    ILOAD 6
    IF_ICMPGE L14
   L15
    LINENUMBER 107 L15
    ALOAD 5
    ILOAD 7
    ALOAD 5
    ILOAD 7
    DALOAD
    ALOAD 0
    INVOKESPECIAL org/apache/spark/mllib/feature/StandardScalerModel.shift ()[D
    ILOAD 7
    DALOAD
    DSUB
    ALOAD 0
    INVOKESPECIAL org/apache/spark/mllib/feature/StandardScalerModel.factor ()[D
    ILOAD 7
    DALOAD
    DMUL
    DASTORE
   L16
    LINENUMBER 108 L16
    ILOAD 7
    ICONST_1
    IADD
    ISTORE 7
    GOTO L13
```

, while with the local reference of the `shift` and `factor` arrays, the bytecode will be

```
   L14
    LINENUMBER 107 L14
    ALOAD 0
    INVOKESPECIAL org/apache/spark/mllib/feature/StandardScalerModel.factor ()[D
    ASTORE 9
   L15
    LINENUMBER 108 L15
   FRAME FULL [org/apache/spark/mllib/feature/StandardScalerModel org/apache/spark/mllib/linalg/Vector [D org/apache/spark/mllib/linalg/Vector org/apache/spark/mllib/linalg/DenseVector T [D I I [D] []
    ILOAD 8
    ILOAD 7
    IF_ICMPGE L16
   L17
    LINENUMBER 109 L17
    ALOAD 6
    ILOAD 8
    ALOAD 6
    ILOAD 8
    DALOAD
    ALOAD 2
    ILOAD 8
    DALOAD
    DSUB
    ALOAD 9
    ILOAD 8
    DALOAD
    DMUL
    DASTORE
   L18
    LINENUMBER 110 L18
    ILOAD 8
    ICONST_1
    IADD
    ISTORE 8
    GOTO L15
```

You can see that with local reference, the both of the arrays will be in the stack, so JVM can access the value without calling `INVOKESPECIAL`.
