### PR TITLE
[SPARK-4592] Avoid duplicate worker registrations in standalone mode

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
@@ -92,6 +92,8 @@ private[deploy] object DeployMessages {
 
   case object WorkDirCleanup      // Sent to Worker actor periodically for cleaning up app folders
 
+  case object ReregisterWithMaster // used when a worker attempts to reconnect to a master
+
   // AppClient to Master
 
   case class RegisterApplication(appDescription: ApplicationDescription)

--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -205,8 +205,9 @@ private[spark] class Worker(
    * another master has taken over, then we can avoid registering with the same master twice.
    */
   private def reregisterWithActiveMaster(): Unit = {
-    assert(master != null, "Attempted to re-register with an active Master that is null")
-    master ! RegisterWorker(workerId, host, port, cores, memory, webUi.boundPort, publicAddress)
+    if (master != null) {
+      master ! RegisterWorker(workerId, host, port, cores, memory, webUi.boundPort, publicAddress)
+    }
   }
 
   private def retryConnectToMaster() {

--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -201,7 +201,7 @@ private[spark] class Worker(
    *   (4) Meanwhile, Worker's previous reconnection attempt reaches Master B,
    *       causing the same Worker to register with Master B twice
    *
-   * Instead, if we only register with the known active master, which must be dead because
+   * Instead, if we only register with the known active master, which must have died because
    * another master has taken over, then we can avoid registering with the same master twice.
    */
   private def reregisterWithActiveMaster(): Unit = {


### PR DESCRIPTION
**Summary.** On failover, the Master may receive duplicate registrations from the same worker, causing the worker to exit. This is caused by this commit https://github.com/apache/spark/commit/4afe9a4852ebeb4cc77322a14225cd3dec165f3f, which adds logic for the worker to re-register with the master in case of failures. However, the following race condition may occur:

(1) Master A fails and Worker attempts to reconnect to all masters
(2) Master B takes over and notifies Worker
(3) Worker responds by registering with Master B
(4) Meanwhile, Worker's previous reconnection attempt reaches Master B, causing the same Worker to register with Master B twice

**Fix.** Instead of attempting to register with all known masters, the worker should re-register with only the one that it has been communicating with. This is safe because the fact that a failover has occurred means the old master must have died. Then, when the worker is finally notified of a new master, it gives up on the old one in favor of the new one.

**Caveat.** Even this fix is subject to more obscure race conditions. For instance, if Master B fails and Master A recovers immediately, then Master A may still observe duplicate worker registrations. However, this and other potential race conditions summarized in [SPARK-4592](https://issues.apache.org/jira/browse/SPARK-4592), are much, much less likely than the one described above, which is deterministically reproducible.
