### PR TITLE
[SPARK-4594][SQL] Improvement the broadcast for HiveConf

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/MetadataCleaner.scala
+++ b/core/src/main/scala/org/apache/spark/util/MetadataCleaner.scala
@@ -52,7 +52,7 @@ private[spark] class MetadataCleaner(
     logDebug(
       "Starting metadata cleaner for " + name + " with delay of " + delaySeconds + " seconds " +
       "and period of " + periodSeconds + " secs")
-    timer.schedule(task, periodSeconds * 1000, periodSeconds * 1000)
+    timer.schedule(task, delaySeconds * 1000, periodSeconds * 1000)
   }
 
   def cancel() {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-4594
Every time we need to get a table from hive , HadoopTableReader will broadcast HiveConf to clustor . Acturally In one application the hiveconf is single, so I think we can keep it in HiveContext for every query . Although it just 50kb , it's useful for JDBC user and streaming+sql app .
