### PR TITLE
[SPARK-4594][SQL] Improvement the broadcast for HiveConf

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -42,6 +42,8 @@ import org.apache.spark.sql.catalyst.types.decimal.Decimal
 import org.apache.spark.sql.execution.{ExtractPythonUdfs, QueryExecutionException, Command => PhysicalCommand}
 import org.apache.spark.sql.hive.execution.DescribeHiveTableCommand
 import org.apache.spark.sql.sources.DataSourceStrategy
+import org.apache.spark.SerializableWritable
+import org.apache.spark.broadcast.Broadcast
 
 /**
  * DEPRECATED: Use HiveContext instead.
@@ -242,6 +244,8 @@ class HiveContext(sc: SparkContext) extends SQLContext(sc) {
         (state.getConf, state)
       }
       .get
+
+  protected[hive] var hiveConfBroadcast: Option[Broadcast[SerializableWritable[HiveConf]]] = None
 
   override def setConf(key: String, value: String): Unit = {
     super.setConf(key, value)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -65,7 +65,14 @@ class HadoopTableReader(
   // TODO: set aws s3 credentials.
 
   private val _broadcastedHiveConf =
-    sc.sparkContext.broadcast(new SerializableWritable(hiveExtraConf))
+    sc.hiveConfBroadcast match {
+      case Some(hc) => hc
+      case None => {
+        val bc = sc.sparkContext.broadcast(new SerializableWritable(sc.hiveconf))
+        sc.hiveConfBroadcast = Some(bc)
+        bc
+      }
+    }
 
   override def makeRDDForTable(hiveTable: HiveTable): RDD[Row] =
     makeRDDForTable(


### PR DESCRIPTION
Every time we need to get a table from hive , HadoopTableReader will broadcast HiveConf to clustor . Acturally In one application the hiveconf is single, so I think we can keep it in HiveContext for every query . Although it just 50kb , it's useful for JDBC user and streaming+sql app .
