### PR TITLE
SPARK-2192 [BUILD] Examples Data Not in Binary Distribution

### DIFF
--- a/make-distribution.sh
+++ b/make-distribution.sh
@@ -201,6 +201,9 @@ if [ -e "$FWDIR"/CHANGES.txt ]; then
   cp "$FWDIR/CHANGES.txt" "$DISTDIR"
 fi
 
+# Copy data files
+cp -r "$FWDIR/data" "$DISTDIR"
+
 # Copy other things
 mkdir "$DISTDIR"/conf
 cp "$FWDIR"/conf/*.template "$DISTDIR"/conf


### PR DESCRIPTION
Simply, add data/ to distributions. This adds about 291KB (compressed) to the tarball, FYI.
