### PR TITLE
SPARK-4628: Put all external projects behind a build flag

### DIFF
--- a/dev/create-release/create-release.sh
+++ b/dev/create-release/create-release.sh
@@ -94,13 +94,13 @@ if [[ ! "$@" =~ --package-only ]]; then
   rm -rf $SPARK_REPO
 
   mvn -DskipTests -Dhadoop.version=2.2.0 -Dyarn.version=2.2.0 \
-    -Pyarn -Phive -Phadoop-2.2 -Pspark-ganglia-lgpl -Pkinesis-asl \
+    -Pyarn -Phive -Phadoop-2.2 -Pspark-ganglia-lgpl -Pkinesis-asl -Pexternal-projects \
     clean install
 
   ./dev/change-version-to-2.11.sh
   
   mvn -DskipTests -Dhadoop.version=2.2.0 -Dyarn.version=2.2.0 \
-    -Dscala-2.11 -Pyarn -Phive -Phadoop-2.2 -Pspark-ganglia-lgpl -Pkinesis-asl \
+    -Dscala-2.11 -Pyarn -Phive -Phadoop-2.2 -Pspark-ganglia-lgpl -Pkinesis-asl -Pexternal-projects \
     clean install
 
   ./dev/change-version-to-2.10.sh

--- a/dev/run-tests
+++ b/dev/run-tests
@@ -53,7 +53,8 @@ function handle_error () {
   fi
 }
 
-export SBT_MAVEN_PROFILES_ARGS="$SBT_MAVEN_PROFILES_ARGS -Pkinesis-asl"
+# Add non-default build components
+export SBT_MAVEN_PROFILES_ARGS="$SBT_MAVEN_PROFILES_ARGS -Pkinesis-asl -Pexternal-projects"
 
 # Determine Java path and version.
 {

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -124,6 +124,12 @@ Scala 2.11 support in Spark is experimental and does not support a few features.
 Specifically, Spark's external Kafka library and JDBC component are not yet
 supported in Scala 2.11 builds.
 
+# Building External Connectors
+Spark's external connectors such as Flume integration can be enabled with the `-Pexternal-projects` flag.
+    mvn -Pexternal-projects -DskipTests clean package
+
+Scala 2.11 support in Spark is experimental and does not support a few features.
+
 # Spark Tests in Maven
 
 Tests are run by default via the [ScalaTest Maven plugin](http://www.scalatest.org/user_guide/using_the_scalatest_maven_plugin). 

--- a/pom.xml
+++ b/pom.xml
@@ -98,11 +98,6 @@
     <module>sql/core</module>
     <module>sql/hive</module>
     <module>assembly</module>
-    <module>external/twitter</module>
-    <module>external/flume</module>
-    <module>external/flume-sink</module>
-    <module>external/mqtt</module>
-    <module>external/zeromq</module>
     <module>examples</module>
     <module>repl</module>
   </modules>
@@ -1199,6 +1194,18 @@
           <scope>compile</scope>
         </dependency>
       </dependencies>
+    </profile>
+
+    <!-- External projects are not built in less this flag is enabled. -->
+    <profile>
+      <id>external-projects</id>
+      <modules>
+        <module>external/twitter</module>
+        <module>external/flume</module>
+        <module>external/flume-sink</module>
+        <module>external/mqtt</module>
+        <module>external/zeromq</module>
+      </modules>
     </profile>
 
     <!-- Ganglia integration is not included by default due to LGPL-licensed code -->


### PR DESCRIPTION
This is important since we don't want breaks in the dependency
graphs of external projects to break the default Spark build.
