### PR TITLE
[SPARK-4632][Streaming] Upgrade MQTT dependency to latest version

### DIFF
--- a/external/mqtt/pom.xml
+++ b/external/mqtt/pom.xml
@@ -43,8 +43,8 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.paho</groupId>
-      <artifactId>mqtt-client</artifactId>
-       <version>0.4.0</version>
+      <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
+       <version>1.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>

--- a/external/mqtt/pom.xml
+++ b/external/mqtt/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>org.eclipse.paho</groupId>
       <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-       <version>1.0.1</version>
+      <version>1.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>


### PR DESCRIPTION
MQTT client 0.4.0 was removed from the Eclipse Paho repository, and hence is breaking Spark build. This upgrades the version of MQTT client. This is an alternative approach to https://github.com/apache/spark/pull/3485 for unblocking Spark 1.2 release.

Note that whether the MQTT functionality is still working after this upgrade is not really being tested as the unit test does not actually transfer data. So only API compatibility is ensured. Adding a real unit test has been noted as another JIRA (https://issues.apache.org/jira/browse/SPARK-4631). For the purpose of unblocking Spark 1.2 release, I am ready to make this upgrade even with the slight risk of breaking MQTT functionality.
