### PR TITLE
[SPARK-4633] Support GZIPOutputStream in spark.io.compression.codec

### DIFF
--- a/core/src/test/scala/org/apache/spark/io/CompressionCodecSuite.scala
+++ b/core/src/test/scala/org/apache/spark/io/CompressionCodecSuite.scala
@@ -50,6 +50,18 @@ class CompressionCodecSuite extends FunSuite {
     testCodec(codec)
   }
 
+  test("gzip compression codec") {
+    val codec = CompressionCodec.createCodec(conf, classOf[GzipCompressionCodec].getName)
+    assert(codec.getClass === classOf[GzipCompressionCodec])
+    testCodec(codec)
+  }
+
+  test("gzip compression codec short form") {
+    val codec = CompressionCodec.createCodec(conf, "gzip")
+    assert(codec.getClass === classOf[GzipCompressionCodec])
+    testCodec(codec)
+  }
+
   test("lz4 compression codec") {
     val codec = CompressionCodec.createCodec(conf, classOf[LZ4CompressionCodec].getName)
     assert(codec.getClass === classOf[LZ4CompressionCodec])

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -474,9 +474,11 @@ Apart from these, the following properties are also available, and may be useful
   <td>snappy</td>
   <td>
     The codec used to compress internal data such as RDD partitions, broadcast variables and
-    shuffle outputs. By default, Spark provides three codecs: <code>lz4</code>, <code>lzf</code>,
-    and <code>snappy</code>. You can also use fully qualified class names to specify the codec, 
+    shuffle outputs. By default, Spark provides three codecs: <code>gzip</code>, <code>lz4</code>,
+    <code>lzf</code>, and <code>snappy</code>. You can also use fully qualified class names
+    to specify the codec, 
     e.g. 
+    <code>org.apache.spark.io.GzipCompresssionCodec</code>,    
     <code>org.apache.spark.io.LZ4CompressionCodec</code>,    
     <code>org.apache.spark.io.LZFCompressionCodec</code>,
     and <code>org.apache.spark.io.SnappyCompressionCodec</code>.
@@ -496,6 +498,14 @@ Apart from these, the following properties are also available, and may be useful
   <td>
     Block size (in bytes) used in LZ4 compression, in the case when LZ4 compression codec
     is used. Lowering this block size will also lower shuffle memory usage when LZ4 is used.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.io.compression.gzip.block.size</code></td>
+  <td>32768</td>
+  <td>
+    Block size (in bytes) used in Gzip compression, in the case when Gzip compression codec
+    is used. Lowering this block size will also lower shuffle memory usage when Gzip is used.
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
gzip is widely used in other frameworks such as hadoop mapreduce and tez, and also
I think that gizip is more stable than other codecs in terms of both performance
and space overheads.

I have one open question; current spark configurations have a block size option
for each codec (spark.io.compression.[gzip|lz4|snappy].block.size).
As # of codecs increases, the configurations have more options and
I think that it is sort of complicated for non-expert users.

To mitigate it, my thought follows;
the three configurations are replaced with a single option for block size
(spark.io.compression.block.size). Then, 'Meaning' in configurations
will describe "This option makes an effect on gzip, lz4, and snappy. 
Block size (in bytes) used in compression, in the case when these compression
codecs are used. Lowering...".

Thought?
