### PR TITLE
spark-submit with accept multiple properties-files and merge the values

### DIFF
--- a/bin/spark-submit
+++ b/bin/spark-submit
@@ -25,11 +25,12 @@ ORIG_ARGS=("$@")
 # Set COLUMNS for progress bar
 export COLUMNS=`tput cols`
 
+SPARK_SUBMIT_PROPERTIES_FILES=${SPARK_SUBMIT_PROPERTIES_FILE}
 while (($#)); do
   if [ "$1" = "--deploy-mode" ]; then
     SPARK_SUBMIT_DEPLOY_MODE=$2
   elif [ "$1" = "--properties-file" ]; then
-    SPARK_SUBMIT_PROPERTIES_FILE=$2
+    SPARK_SUBMIT_PROPERTIES_FILES=${SPARK_SUBMIT_PROPERTIES_FILES}:$2
   elif [ "$1" = "--driver-memory" ]; then
     export SPARK_SUBMIT_DRIVER_MEMORY=$2
   elif [ "$1" = "--driver-library-path" ]; then
@@ -44,22 +45,25 @@ done
 
 DEFAULT_PROPERTIES_FILE="$SPARK_HOME/conf/spark-defaults.conf"
 export SPARK_SUBMIT_DEPLOY_MODE=${SPARK_SUBMIT_DEPLOY_MODE:-"client"}
-export SPARK_SUBMIT_PROPERTIES_FILE=${SPARK_SUBMIT_PROPERTIES_FILE:-"$DEFAULT_PROPERTIES_FILE"}
+export SPARK_SUBMIT_PROPERTIES_FILES=${DEFAULT_PROPERTIES_FILE}:${SPARK_SUBMIT_PROPERTIES_FILES}
 
 # For client mode, the driver will be launched in the same JVM that launches
 # SparkSubmit, so we may need to read the properties file for any extra class
 # paths, library paths, java options and memory early on. Otherwise, it will
 # be too late by the time the driver JVM has started.
 
-if [[ "$SPARK_SUBMIT_DEPLOY_MODE" == "client" && -f "$SPARK_SUBMIT_PROPERTIES_FILE" ]]; then
-  # Parse the properties file only if the special configs exist
-  contains_special_configs=$(
-    grep -e "spark.driver.extra*\|spark.driver.memory" "$SPARK_SUBMIT_PROPERTIES_FILE" | \
-    grep -v "^[[:space:]]*#"
-  )
-  if [ -n "$contains_special_configs" ]; then
-    export SPARK_SUBMIT_BOOTSTRAP_DRIVER=1
-  fi
+for prop_file in "${!SPARK_SUBMIT_PROPERTIES_FILES[:]}" do
+  if [[ "$SPARK_SUBMIT_DEPLOY_MODE" == "client" && -f "$prop_file" ]]; then
+    # Parse the properties file only if the special configs exist
+    contains_special_configs=$(
+      grep -e "spark.driver.extra*\|spark.driver.memory" "$prop_file" | \
+      grep -v "^[[:space:]]*#"
+    )
+    if [ -n "$contains_special_configs" ]; then
+      export SPARK_SUBMIT_BOOTSTRAP_DRIVER=1
+      break
+    fi
+  done
 fi
 
 exec "$SPARK_HOME"/bin/spark-class org.apache.spark.deploy.SparkSubmit "${ORIG_ARGS[@]}"

--- a/bin/spark-submit
+++ b/bin/spark-submit
@@ -30,7 +30,11 @@ while (($#)); do
   if [ "$1" = "--deploy-mode" ]; then
     SPARK_SUBMIT_DEPLOY_MODE=$2
   elif [ "$1" = "--properties-file" ]; then
-    SPARK_SUBMIT_PROPERTIES_FILES=${SPARK_SUBMIT_PROPERTIES_FILES}:$2
+    if [ -n "$SPARK_SUBMIT_PROPERTIES_FILES" ] ; then
+        SPARK_SUBMIT_PROPERTIES_FILES=${SPARK_SUBMIT_PROPERTIES_FILES},$2
+    else
+        SPARK_SUBMIT_PROPERTIES_FILES=$2
+    fi
   elif [ "$1" = "--driver-memory" ]; then
     export SPARK_SUBMIT_DRIVER_MEMORY=$2
   elif [ "$1" = "--driver-library-path" ]; then
@@ -45,14 +49,14 @@ done
 
 DEFAULT_PROPERTIES_FILE="$SPARK_HOME/conf/spark-defaults.conf"
 export SPARK_SUBMIT_DEPLOY_MODE=${SPARK_SUBMIT_DEPLOY_MODE:-"client"}
-export SPARK_SUBMIT_PROPERTIES_FILES=${DEFAULT_PROPERTIES_FILE}:${SPARK_SUBMIT_PROPERTIES_FILES}
+export SPARK_SUBMIT_PROPERTIES_FILES=${DEFAULT_PROPERTIES_FILE},${SPARK_SUBMIT_PROPERTIES_FILES}
 
 # For client mode, the driver will be launched in the same JVM that launches
 # SparkSubmit, so we may need to read the properties file for any extra class
 # paths, library paths, java options and memory early on. Otherwise, it will
 # be too late by the time the driver JVM has started.
 
-for prop_file in "${!SPARK_SUBMIT_PROPERTIES_FILES[:]}" do
+for prop_file in `echo ${SPARK_SUBMIT_PROPERTIES_FILES} | tr , \  `; do
   if [[ "$SPARK_SUBMIT_DEPLOY_MODE" == "client" && -f "$prop_file" ]]; then
     # Parse the properties file only if the special configs exist
     contains_special_configs=$(
@@ -63,8 +67,8 @@ for prop_file in "${!SPARK_SUBMIT_PROPERTIES_FILES[:]}" do
       export SPARK_SUBMIT_BOOTSTRAP_DRIVER=1
       break
     fi
-  done
-fi
+  fi
+done
 
 exec "$SPARK_HOME"/bin/spark-class org.apache.spark.deploy.SparkSubmit "${ORIG_ARGS[@]}"
 

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -33,7 +33,7 @@ private[spark] class SparkSubmitArguments(args: Seq[String], env: Map[String, St
   var executorMemory: String = null
   var executorCores: String = null
   var totalExecutorCores: String = null
-  var propertiesFile: String = null
+  var propertiesFiles: String = null
   var driverMemory: String = null
   var driverExtraClassPath: String = null
   var driverExtraLibraryPath: String = null
@@ -57,14 +57,16 @@ private[spark] class SparkSubmitArguments(args: Seq[String], env: Map[String, St
   /** Default properties present in the currently defined defaults file. */
   lazy val defaultSparkProperties: HashMap[String, String] = {
     val defaultProperties = new HashMap[String, String]()
-    if (verbose) SparkSubmit.printStream.println(s"Using properties file: $propertiesFile")
-    Option(propertiesFile).foreach { filename =>
-      Utils.getPropertiesFromFile(filename).foreach { case (k, v) =>
-        if (k.startsWith("spark.")) {
-          defaultProperties(k) = v
-          if (verbose) SparkSubmit.printStream.println(s"Adding default property: $k=$v")
-        } else {
-          SparkSubmit.printWarning(s"Ignoring non-spark config property: $k=$v")
+    if (verbose) SparkSubmit.printStream.println(s"Using properties file: $propertiesFiles")
+    Option(propertiesFiles).foreach { filenames =>
+      filenames.split(",").foreach { filename =>
+        Utils.getPropertiesFromFile(filename).foreach { case (k, v) =>
+          if (k.startsWith("spark.")) {
+            defaultProperties(k) = v
+            if (verbose) SparkSubmit.printStream.println(s"Adding default property: $k=$v")
+          } else {
+            SparkSubmit.printWarning(s"Ignoring non-spark config property: $k=$v")
+          }
         }
       }
     }
@@ -86,7 +88,7 @@ private[spark] class SparkSubmitArguments(args: Seq[String], env: Map[String, St
    */
   private def mergeDefaultSparkProperties(): Unit = {
     // Use common defaults file, if not specified by user
-    propertiesFile = Option(propertiesFile).getOrElse(Utils.getDefaultPropertiesFile(env))
+    propertiesFiles = Option(propertiesFiles).getOrElse(Utils.getDefaultPropertiesFile(env))
     // Honor --conf before the defaults file
     defaultSparkProperties.foreach { case (k, v) =>
       if (!sparkProperties.contains(k)) {
@@ -187,7 +189,7 @@ private[spark] class SparkSubmitArguments(args: Seq[String], env: Map[String, St
     |  executorMemory          $executorMemory
     |  executorCores           $executorCores
     |  totalExecutorCores      $totalExecutorCores
-    |  propertiesFile          $propertiesFile
+    |  propertiesFile          $propertiesFiles
     |  driverMemory            $driverMemory
     |  driverCores             $driverCores
     |  driverExtraClassPath    $driverExtraClassPath
@@ -207,7 +209,7 @@ private[spark] class SparkSubmitArguments(args: Seq[String], env: Map[String, St
     |  verbose                 $verbose
     |
     |Spark properties used, including those specified through
-    | --conf and those from the properties file $propertiesFile:
+    | --conf and those from the properties file $propertiesFiles:
     |${sparkProperties.mkString("  ", "\n  ", "\n")}
     """.stripMargin
   }
@@ -280,7 +282,7 @@ private[spark] class SparkSubmitArguments(args: Seq[String], env: Map[String, St
         parse(tail)
 
       case ("--properties-file") :: value :: tail =>
-        propertiesFile = value
+        propertiesFiles = if (propertiesFiles == null) value else s"$propertiesFiles,$value"
         parse(tail)
 
       case ("--supervise") :: tail =>
@@ -365,6 +367,7 @@ private[spark] class SparkSubmitArguments(args: Seq[String], env: Map[String, St
         |  --conf PROP=VALUE           Arbitrary Spark configuration property.
         |  --properties-file FILE      Path to a file from which to load extra properties. If not
         |                              specified, this will look for conf/spark-defaults.conf.
+        |                              Multiple properties files will be merged sequentially.
         |
         |  --driver-memory MEM         Memory for driver (e.g. 1000M, 2G) (Default: 512M).
         |  --driver-java-options       Extra Java options to pass to the driver.

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitDriverBootstrapper.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitDriverBootstrapper.scala
@@ -37,12 +37,12 @@ private[spark] object SparkSubmitDriverBootstrapper {
   // Any changes made there must be reflected in this file.
 
   def main(args: Array[String]): Unit = {
-
     // This should be called only from `bin/spark-class`
     if (!sys.env.contains("SPARK_CLASS")) {
       System.err.println("SparkSubmitDriverBootstrapper must be called from `bin/spark-class`!")
       System.exit(1)
     }
+
 
     val submitArgs = args
     val runner = sys.env("RUNNER")
@@ -68,7 +68,7 @@ private[spark] object SparkSubmitDriverBootstrapper {
     assume(bootstrapDriver != null, "SPARK_SUBMIT_BOOTSTRAP_DRIVER must be set")
 
     // Parse the properties file for the equivalent spark.driver.* configs
-    val properties = Utils.getPropertiesFromFiles(propertiesFiles.split(":"))
+    val properties = Utils.getPropertiesFromFiles(propertiesFiles.split(","))
     val confDriverMemory = properties.get("spark.driver.memory")
     val confLibraryPath = properties.get("spark.driver.extraLibraryPath")
     val confClasspath = properties.get("spark.driver.extraClassPath")

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitDriverBootstrapper.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitDriverBootstrapper.scala
@@ -52,7 +52,7 @@ private[spark] object SparkSubmitDriverBootstrapper {
 
     // Spark submit specific environment variables
     val deployMode = sys.env("SPARK_SUBMIT_DEPLOY_MODE")
-    val propertiesFile = sys.env("SPARK_SUBMIT_PROPERTIES_FILE")
+    val propertiesFiles = sys.env("SPARK_SUBMIT_PROPERTIES_FILES")
     val bootstrapDriver = sys.env("SPARK_SUBMIT_BOOTSTRAP_DRIVER")
     val submitDriverMemory = sys.env.get("SPARK_SUBMIT_DRIVER_MEMORY")
     val submitLibraryPath = sys.env.get("SPARK_SUBMIT_LIBRARY_PATH")
@@ -64,11 +64,11 @@ private[spark] object SparkSubmitDriverBootstrapper {
     assume(javaOpts != null, "JAVA_OPTS must be set")
     assume(defaultDriverMemory != null, "OUR_JAVA_MEM must be set")
     assume(deployMode == "client", "SPARK_SUBMIT_DEPLOY_MODE must be \"client\"!")
-    assume(propertiesFile != null, "SPARK_SUBMIT_PROPERTIES_FILE must be set")
+    assume(propertiesFiles != null, "SPARK_SUBMIT_PROPERTIES_FILE must be set")
     assume(bootstrapDriver != null, "SPARK_SUBMIT_BOOTSTRAP_DRIVER must be set")
 
     // Parse the properties file for the equivalent spark.driver.* configs
-    val properties = Utils.getPropertiesFromFile(propertiesFile)
+    val properties = Utils.getPropertiesFromFiles(propertiesFiles.split(":"))
     val confDriverMemory = properties.get("spark.driver.memory")
     val confLibraryPath = properties.get("spark.driver.extraLibraryPath")
     val confClasspath = properties.get("spark.driver.extraClassPath")

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1589,7 +1589,7 @@ private[spark] object Utils extends Logging {
 
   /** Load properties in the given filenames. */
   def getPropertiesFromFiles(filenames: Array[String]): Map[String, String] = {
-    filenames.map{name => getPropertiesFromFile(name)}.foldLeft[Map[String, String](Map())(_ ++ _)
+    filenames.map{name => getPropertiesFromFile(name)}.foldLeft[Map[String, String]](Map())(_ ++ _)
   }
 
   /** Return the path of the default Spark properties file. */

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1587,6 +1587,11 @@ private[spark] object Utils extends Logging {
     }
   }
 
+  /** Load properties in the given filenames. */
+  def getPropertiesFromFiles(filenames: Array[String]): Map[String, String] = {
+    filenames.map{name => getPropertiesFromFile(name)}.foldLeft[Map[String, String](Map())(_ ++ _)
+  }
+
   /** Return the path of the default Spark properties file. */
   def getDefaultPropertiesFile(env: Map[String, String] = sys.env): String = {
     env.get("SPARK_CONF_DIR")


### PR DESCRIPTION
Current `spark-submit` accepts only one properties-file, and use `spark-defaults.conf` if unspecified.
A more nature approach is patching the properties-files sequentially against `spark-defaults.conf`.

This PR affairs:
1. spark-submit script: join multiple `--properties-file` with comma and stored as `SPARK_SUBMIT_PROPERTIES_FILES` environment variable. Peek each properties-file to set `SPARK_SUBMIT_BOOTSTRAP_DRIVER` flag.
2. SparkSubmitArguments.scala: similar with 1.
3. SparkSubmitDriverBootstrapper.scala: accept `SPARK_SUBMIT_PROPERTIES_FILES` and call `getPropertiesFromFiles` for parsing.
4. Utils.scala: add `getPropertiesFromFiles` for the parsing of multiple properties-files.
