### PR TITLE
[SPARK-4528][SQL] add comment support for Spark SQL CLI 

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SQLCommentUtils.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SQLCommentUtils.scala
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive.thriftserver
+
+private[hive] object SQLCommentUtils {
+
+  /**
+   * Filter Comments in inputed line and return a commultive string without any comments.
+   * This can be used for **comment support**.
+   * Three comment styles supported:
+   * 1. From a '#' character to the end of the line.
+   * 2. From a '--' sequence to the end of the line
+   * 3. From a /* sequence to the following */ sequence, as in the C programming language.
+   * This syntax allows a comment to extend over multiple lines because the beginning
+   * and closing sequences need not be on the same line.
+   * @param line string inputed from console
+   * @param filterCommentResult the case class that encapsulates the result of filterComment
+   * for making code more concise
+   * @return  the case class representing result after filter comments,
+   * including (cmd, isCmdEnded, commentStack)
+   */
+  def filterComment(line: String,
+                    filterCommentResult: FilterCommentResult
+                    = FilterCommentResult("", false, new scala.collection.mutable.Stack[String])
+                     ): FilterCommentResult = {
+    filterCommentResult.isCmdEnded = false
+
+    if (line == null || line.trim.isEmpty) return filterCommentResult
+
+    // define some regexes for match
+    val commentMarkSeq = scala.collection.immutable.Seq(
+      CommentMark("SINGLE_LINE_COMMENT_DASH", " -- ", """(.*?)--(.*)""".r),
+      CommentMark("SINGLE_LINE_COMMENT_POUND", " # ", """(.*?)#(.*)""".r),
+      CommentMark("MULTI_LINE_COMMENT_START", " /* ", """(.*?)/\*(.*)""".r),
+      CommentMark("MULTI_LINE_COMMENT_END", " */ ", """(.*?)\*/(.*)""".r),
+      CommentMark("SINGLE_QUOTATION_MARK", "'", """(.*?)'(.*)""".r),
+      CommentMark("DOUBLE_QUOTATION_MARK", "\"", """(.*?)"(.*)""".r),
+      CommentMark("CMD_END_MARK", ";", """(.*?);(.*)""".r)
+    )
+
+    val commentMarkMap = (for (c <- commentMarkSeq) yield (c.name -> c)).toMap
+
+    // to get the first match in the line
+    var filterMatchName = ""
+    var filterMatchRegex: scala.util.matching.Regex = null
+    var filterMatchIdx = -1
+
+    commentMarkSeq.foreach(commentMark => {
+      val findFirstMatch = commentMark.regex.findFirstMatchIn(line)
+      if (findFirstMatch != None) {
+        val matchPositonIdx = findFirstMatch.get.group(1).length
+        if (matchPositonIdx < filterMatchIdx || filterMatchIdx == -1) {
+          filterMatchName = commentMark.name
+          filterMatchRegex = commentMark.regex
+          filterMatchIdx = matchPositonIdx
+        }
+      }
+    })
+
+    // process the comments one by one based on head eliment in commentStack and
+    // first match regex.
+    val currentCommentMark = filterCommentResult.commentStack.headOption.getOrElse(null)
+
+    if (filterMatchRegex != null) {
+      val filterMatch = filterMatchRegex.findFirstMatchIn(line)
+      val Array(part1, part2) = filterMatch.get.subgroups.toArray
+
+      if (currentCommentMark == null) {
+        filterMatchName match {
+          case "CMD_END_MARK" =>
+            filterCommentResult.cmd += part1 + commentMarkMap(filterMatchName).marker
+            filterComment(part2, filterCommentResult)
+            if (filterCommentResult.cmd.trim.endsWith(";")) {
+              filterCommentResult.isCmdEnded = true
+            }
+          case "SINGLE_QUOTATION_MARK" | "DOUBLE_QUOTATION_MARK" =>
+            filterCommentResult.commentStack.push(filterMatchName)
+            filterCommentResult.cmd += part1 + commentMarkMap(filterMatchName).marker
+            filterComment(part2, filterCommentResult)
+          case "SINGLE_LINE_COMMENT_DASH" | "SINGLE_LINE_COMMENT_POUND" =>
+            filterCommentResult.cmd += part1
+          case "MULTI_LINE_COMMENT_START" =>
+            filterCommentResult.commentStack.push(filterMatchName)
+            filterCommentResult.cmd += part1
+            filterComment(part2, filterCommentResult)
+          case "MULTI_LINE_COMMENT_END" =>
+            println(
+              """WARN: found "*/", but not found matched multi line comment start marker "/*".
+                |Reset your input.
+              """.stripMargin)
+            return FilterCommentResult("", false, new scala.collection.mutable.Stack[String])
+          case _ =>
+        }
+      } else {
+        currentCommentMark match {
+          case "SINGLE_QUOTATION_MARK" | "DOUBLE_QUOTATION_MARK" =>
+            filterCommentResult.cmd += part1 + commentMarkMap(filterMatchName).marker
+            if (filterMatchName == currentCommentMark) {
+              filterCommentResult.commentStack.pop()
+            } else {
+              filterCommentResult.commentStack.push(filterMatchName)
+            }
+            filterComment(part2, filterCommentResult)
+          case "MULTI_LINE_COMMENT_START" =>
+            if (filterMatchName == "MULTI_LINE_COMMENT_END") filterCommentResult.commentStack.pop()
+            filterComment(part2, filterCommentResult)
+        }
+      }
+    } else {
+      // filterMatchRegex == null (not found match mark in the line)
+      if (currentCommentMark == null) {
+        filterCommentResult.cmd += line
+      } else {
+        if (currentCommentMark == "SINGLE_QUOTATION_MARK"
+          || currentCommentMark == "DOUBLE_QUOTATION_MARK") {
+          filterCommentResult.cmd += line
+        }
+      }
+    }
+    filterCommentResult
+  }
+}
+
+/**
+ * Represents result of filterComment.
+ * @param cmd The commulative string for generating one cmd from multi inputs
+ * @param isCmdEnded  Whether the cmd is ended.
+ * @param commentStack  the context used in filterComment, stores elements that should
+ *                      be considered while filtering comments, like ', ", or the begin
+ *                      flag of multi line comments
+ */
+private[hive] case class FilterCommentResult(var cmd: String,
+                               var isCmdEnded: Boolean,
+                               var commentStack: scala.collection.mutable.Stack[String])
+
+/**
+ * Represents comment mark.
+ * @param name the name of comment mark
+ * @param marker the marker of comment mark
+ * @param regex the regular expression of comment mark
+ */
+private[hive] case class CommentMark(name: String, marker: String, regex: scala.util.matching.Regex)

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -186,7 +186,6 @@ private[hive] object SparkSQLCLIDriver {
     transport = clientTransportTSocketField.get(sessionState).asInstanceOf[TSocket]
 
     var ret = 0
-    var prefix = ""
     val currentDB = ReflectionUtils.invokeStatic(classOf[CliDriver], "getFormattedDb",
       classOf[HiveConf] -> conf, classOf[CliSessionState] -> sessionState)
 
@@ -201,12 +200,9 @@ private[hive] object SparkSQLCLIDriver {
       new scala.collection.mutable.Stack[String])
 
     while (line != null) {
-      if (prefix.nonEmpty) {
-        prefix += '\n'
-      }
 
       // filter the comments in the line
-      cli.filterComment(line, filterCommentResult)
+      SQLCommentUtils.filterComment(line, filterCommentResult)
 
       if (filterCommentResult.isCmdEnded) {
         ret = cli.processLine(filterCommentResult.cmd, true)
@@ -216,11 +212,14 @@ private[hive] object SparkSQLCLIDriver {
         currentPrompt = continuedPromptWithDBSpaces
       }
 
+      if (filterCommentResult.cmd.trim.nonEmpty) {
+        filterCommentResult.cmd += "\n"
+      }
+
       line = reader.readLine(currentPrompt + "> ")
     }
 
     sessionState.close()
-
     System.exit(ret)
   }
 }
@@ -325,142 +324,38 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
     }
   }
 
-  /**
-   * Filter Comments in inputed line and return a commultive string without any comments.
-   * This can be used for **comment support**.
-   * Three comment styles supported:
-   * 1. From a '#' character to the end of the line.
-   * 2. From a '--' sequence to the end of the line
-   * 3. From a /* sequence to the following */ sequence, as in the C programming language.
-   * This syntax allows a comment to extend over multiple lines because the beginning
-   * and closing sequences need not be on the same line.
-   * @param line string inputed from console
-   * @param filterCommentResult the case class that encapsulates the result of filterComment
-   * for making code more concise
-   * @return  the case class representing result after filter comments,
-   * including (cmd, isCmdEnded, commentStack)
-   */
-  def filterComment(line: String,
-                    filterCommentResult: FilterCommentResult
-                    = FilterCommentResult("", false, new scala.collection.mutable.Stack[String])
-                     ): FilterCommentResult = {
-    filterCommentResult.isCmdEnded = false
+  // override for comment support when using spark-sql with CLI option -f
+  override def processReader(r: BufferedReader): Int = {
 
-    if (line == null || line.trim.isEmpty) return filterCommentResult
+    var line = r.readLine()
+    val filterCommentResult = FilterCommentResult("", false,
+      new scala.collection.mutable.Stack[String])
 
-    // define some regexes for match
-    val commentMarkSeq = scala.collection.immutable.Seq(
-      CommentMark("SINGLE_LINE_COMMENT_DASH", " -- ", """(.*?)--(.*)""".r),
-      CommentMark("SINGLE_LINE_COMMENT_POUND", " # ", """(.*?)#(.*)""".r),
-      CommentMark("MULTI_LINE_COMMENT_START", " /* ", """(.*?)/\*(.*)""".r),
-      CommentMark("MULTI_LINE_COMMENT_END", " */ ", """(.*?)\*/(.*)""".r),
-      CommentMark("SINGLE_QUOTATION_MARK", "'", """(.*?)'(.*)""".r),
-      CommentMark("DOUBLE_QUOTATION_MARK", "\"", """(.*?)"(.*)""".r),
-      CommentMark("CMD_END_MARK", ";", """(.*?);(.*)""".r)
-    )
+    while (line != null) {
+      // filter the comments in the line
+      SQLCommentUtils.filterComment(line, filterCommentResult)
+      LOG.debug("filterCommentResult=" + filterCommentResult)
 
-    val commentMarkMap = (for (c <- commentMarkSeq) yield (c.name -> c)).toMap
-
-    // to get the first match in the line
-    var filterMatchName = ""
-    var filterMatchRegex: scala.util.matching.Regex = null
-    var filterMatchIdx = -1
-
-    commentMarkSeq.foreach(commentMark => {
-      val findFirstMatch = commentMark.regex.findFirstMatchIn(line)
-      if (findFirstMatch != None) {
-        val matchPositonIdx = findFirstMatch.get.group(1).length
-        if (matchPositonIdx < filterMatchIdx || filterMatchIdx == -1) {
-          filterMatchName = commentMark.name
-          filterMatchRegex = commentMark.regex
-          filterMatchIdx = matchPositonIdx
-        }
+      if (filterCommentResult.cmd.trim.nonEmpty) {
+        filterCommentResult.cmd += "\n"
       }
-    })
 
-    // process the comments one by one based on head eliment in commentStack and
-    // first match regex.
-    val currentCommentMark = filterCommentResult.commentStack.headOption.getOrElse(null)
+      line = r.readLine()
+    }
 
-    if (filterMatchRegex != null) {
-      val filterMatch = filterMatchRegex.findFirstMatchIn(line)
-      val Array(part1, part2) = filterMatch.get.subgroups.toArray
-
-      if (currentCommentMark == null) {
-        filterMatchName match {
-          case "CMD_END_MARK" =>
-            filterCommentResult.cmd += part1 + commentMarkMap(filterMatchName).marker
-            filterComment(part2, filterCommentResult)
-            if (filterCommentResult.cmd.trim.endsWith(";")) {
-              filterCommentResult.isCmdEnded = true
-              filterCommentResult.cmd = filterCommentResult.cmd.
-                replaceAll( """\n+\s*\n*""", "\n").trim
-            }
-          case "SINGLE_QUOTATION_MARK" | "DOUBLE_QUOTATION_MARK" =>
-            filterCommentResult.commentStack.push(filterMatchName)
-            filterCommentResult.cmd += part1 + commentMarkMap(filterMatchName).marker
-            filterComment(part2, filterCommentResult)
-          case "SINGLE_LINE_COMMENT_DASH" | "SINGLE_LINE_COMMENT_POUND" =>
-            filterCommentResult.cmd += part1
-          case "MULTI_LINE_COMMENT_START" =>
-            filterCommentResult.commentStack.push(filterMatchName)
-            filterCommentResult.cmd += part1
-            filterComment(part2, filterCommentResult)
-          case "MULTI_LINE_COMMENT_END" =>
-            println(
-              """WARN: found "*/", but not found matched multi line comment start marker "/*".
-                |Reset your input.
-              """.stripMargin)
-            return FilterCommentResult("", false, new scala.collection.mutable.Stack[String])
-          case _ =>
-        }
-
+    if (!filterCommentResult.isCmdEnded) {
+      if (filterCommentResult.commentStack.nonEmpty
+        || !filterCommentResult.cmd.trim.endsWith(";")) {
+        val filename = sessionState.fileName
+        throw new Exception(s"WARN: sqls in $filename is not completed.")
       } else {
-        currentCommentMark match {
-          case "SINGLE_QUOTATION_MARK" | "DOUBLE_QUOTATION_MARK" =>
-            filterCommentResult.cmd += part1 + commentMarkMap(filterMatchName).marker
-            if (filterMatchName == currentCommentMark) {
-              filterCommentResult.commentStack.pop()
-            } else {
-              filterCommentResult.commentStack.push(filterMatchName)
-            }
-            filterComment(part2, filterCommentResult)
-          case "MULTI_LINE_COMMENT_START" =>
-            if (filterMatchName == "MULTI_LINE_COMMENT_END") filterCommentResult.commentStack.pop()
-            filterComment(part2, filterCommentResult)
-        }
-      }
-    } else {
-      // filterMatchRegex == null (not found match mark in the line)
-      if (currentCommentMark == null) {
-        filterCommentResult.cmd += line
-      } else {
-        if (currentCommentMark == "SINGLE_QUOTATION_MARK"
-          || currentCommentMark == "DOUBLE_QUOTATION_MARK") {
-          filterCommentResult.cmd += line
-        }
+        filterCommentResult.isCmdEnded = true
       }
     }
-    filterCommentResult
+
+    LOG.debug("filterCommentResult.cmd=" + filterCommentResult.cmd)
+    val ret = processLine(filterCommentResult.cmd)
+    return (ret);
   }
+
 }
-
-/**
- * Represents result of filterComment.
- * @param cmd The commulative string for generating one cmd from multi inputs
- * @param isCmdEnded  Whether the cmd is ended.
- * @param commentStack  the context used in filterComment, stores elements that should
- *                      be considered while filtering comments, like ', ", or the begin
- *                      flag of multi line comments
- */
-case class FilterCommentResult(var cmd: String,
-                               var isCmdEnded: Boolean,
-                               var commentStack: scala.collection.mutable.Stack[String])
-
-/**
- * Represents comment mark.
- * @param name the name of comment mark
- * @param marker the marker of comment mark
- * @param regex the regular expression of comment mark
- */
-case class CommentMark(name: String, marker: String, regex: scala.util.matching.Regex)

--- a/sql/hive-thriftserver/src/test/resources/data/files/sqlfile.sql
+++ b/sql/hive-thriftserver/src/test/resources/data/files/sqlfile.sql
@@ -1,0 +1,21 @@
+SHOW DATABASES; #
+SHOW TABLES ; --
+CREATE TABLE t(id int, name string, tag string)
+ROW FORMAT DELIMITED FIELDS TERMINATED by '\t'
+;
+SELECT id, 1+1 FROM t; --test;
+SELECT id, 1+1 FROM t; #test;
+SELECT id, 1 + 1 FROM t;# This comment continues to the end of line;
+SELECT id, 1 + 1 FROM t;-- This comment continues to the end of line;
+SELECT id, 1/* this is an in-line comment */  + 1 FROM t;
+SELECT id, 1 +
+/*
+this is a
+multiple-line comment
+*/
+1 FROM t;
+
+SHOW DATABASES; /* test */ SHOW
+TABLES; --end;
+--end1
+#end2

--- a/sql/hive-thriftserver/src/test/resources/data/files/sqlfile.sql
+++ b/sql/hive-thriftserver/src/test/resources/data/files/sqlfile.sql
@@ -19,3 +19,4 @@ SHOW DATABASES; /* test */ SHOW
 TABLES; --end;
 --end1
 #end2
+

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -123,6 +123,7 @@ class CliSuite extends FunSuite with BeforeAndAfterAll with Logging {
     runCliWithin(1.minute, Seq("-e", "SHOW TABLES;"))("" -> "OK")
   }
 
+  // test comment support feature for spark-sql
   test("Test single line commond support using --"){
     runCliWithin(1.minute, Seq("-e", "SHOW TABLES;--test single line commond support;"))("" -> "OK")
   }
@@ -162,5 +163,13 @@ class CliSuite extends FunSuite with BeforeAndAfterAll with Logging {
         |SHOW DATABASES;/*test multi sql commonds in one line */ SHOW
         |TABLES; --end
       """.stripMargin))("" -> "OK")
+  }
+
+  test("Test input from a file") {
+    val sqlFilePath =
+      Thread.currentThread().getContextClassLoader.getResource("data/files/sqlfile.sql")
+
+    runCliWithin(3.minute, Seq("-f", sqlFilePath.getPath))("" -> "OK")
+
   }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -155,4 +155,12 @@ class CliSuite extends FunSuite with BeforeAndAfterAll with Logging {
         -> "Time taken: "
     )
   }
+
+  test("Test input multi sql commonds as a whole at one time"){
+    runCliWithin(1.minute, Seq("-e",
+      """
+        |SHOW DATABASES;/*test multi sql commonds in one line */ SHOW
+        |TABLES; --end
+      """.stripMargin))("" -> "OK")
+  }
 }


### PR DESCRIPTION
The relative JIRA: https://issues.apache.org/jira/browse/SPARK-4528?filter=-2

While using _spark-sql_, found it does not support comment while write sqls.
**Comment support** is widely using in many projects, it is a necessary to add this feature.
Added one function _filterComment()_ in the source org.apache.spark.sql.hive.thriftserver.SparkSQLCLIDriver.scala.
##### three comment styles supported:
1. From a '#' character to the end of the line.
2. From a '--' sequence to the end of the line
3. From a /\* sequence to the following */ sequence, as in the C programming language. 
   This syntax allows a comment to extend over multiple lines because the beginning and closing sequences need not be on the same line.
