### PR TITLE
[Shuflle][SPARK-4641]file not found excepton in hash shuffle

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockObjectWriter.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockObjectWriter.scala
@@ -119,6 +119,14 @@ private[spark] class DiskBlockObjectWriter(
     * only call it every N writes */
   private var writesSinceMetricsUpdate = 0
 
+  /**
+   * In hash shuffle, if some keys are empty it will not create the shuffle file.
+   * But in shuffle fetch, it also will fetch this file and cause FileNotFoundException.
+   * So call the 'open' function in constructor to touch a empty file avoiding this problem.
+   * It seems only the hash shuffle manager can only be benefit from this modify.
+   */
+  open()
+
   override def open(): BlockObjectWriter = {
     fos = new FileOutputStream(file, true)
     ts = new TimeTrackingOutputStream(fos)


### PR DESCRIPTION
It's very hard to replay this problem but actually I have meet this.
Assuming that, some hash key bucket have no elems in it and in the code of HashShuffleWriter.write:
    for (elem <- iter) {
      val bucketId = dep.partitioner.getPartition(elem._1)
      shuffle.writers(bucketId).write(elem)
    }
The bucket will never call the 'write' funciton and will never create the file(create file in first writer and file.length never check file is exist or not).
But the shuffle fetch will also fetch the unexist file, and causes the problem.
I have tested the problem described in SPARK-4641.
Sort Shuffle will also throw "snappy (parsing_error(2))"  but can not be resolved by this modify.
