### PR TITLE
[SPARK-4648][SQL] Support COALESCE function in Spark SQL and Hive QL

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
@@ -51,6 +51,7 @@ class SqlParser extends AbstractSparkSQLParser {
   protected val CACHE = Keyword("CACHE")
   protected val CASE = Keyword("CASE")
   protected val CAST = Keyword("CAST")
+  protected val COALESCE = Keyword("COALESCE")
   protected val COUNT = Keyword("COUNT")
   protected val DECIMAL = Keyword("DECIMAL")
   protected val DESC = Keyword("DESC")
@@ -305,6 +306,7 @@ class SqlParser extends AbstractSparkSQLParser {
       { case s ~ p ~ l => Substring(s, p, l) }
     | SQRT  ~ "(" ~> expression <~ ")" ^^ { case exp => Sqrt(exp) }
     | ABS   ~ "(" ~> expression <~ ")" ^^ { case exp => Abs(exp) }
+    | COALESCE   ~ "(" ~> repsep(expression, ",") <~ ")" ^^ { case exps => Coalesce(exps) }
     | ident ~ ("(" ~> repsep(expression, ",")) <~ ")" ^^
       { case udfName ~ exprs => UnresolvedFunction(udfName, exprs) }
     )

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
@@ -51,7 +51,6 @@ class SqlParser extends AbstractSparkSQLParser {
   protected val CACHE = Keyword("CACHE")
   protected val CASE = Keyword("CASE")
   protected val CAST = Keyword("CAST")
-  protected val COALESCE = Keyword("COALESCE")
   protected val COUNT = Keyword("COUNT")
   protected val DECIMAL = Keyword("DECIMAL")
   protected val DESC = Keyword("DESC")
@@ -306,7 +305,6 @@ class SqlParser extends AbstractSparkSQLParser {
       { case s ~ p ~ l => Substring(s, p, l) }
     | SQRT  ~ "(" ~> expression <~ ")" ^^ { case exp => Sqrt(exp) }
     | ABS   ~ "(" ~> expression <~ ")" ^^ { case exp => Abs(exp) }
-    | COALESCE   ~ "(" ~> repsep(expression, ",") <~ ")" ^^ { case exps => Coalesce(exps) }
     | ident ~ ("(" ~> repsep(expression, ",")) <~ ")" ^^
       { case udfName ~ exprs => UnresolvedFunction(udfName, exprs) }
     )

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -992,17 +992,4 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll {
       "nulldata2 on nulldata1.value <=> nulldata2.value"),
         (1 to 2).map(i => Seq(i)))
   }
-
-  test("Supporting Coalesce function in Spark SQL") {
-    val nullCheckData1 = TestData(1,"1") :: TestData(2,null) :: Nil
-    val rdd1 = sparkContext.parallelize((0 to 1).map(i => nullCheckData1(i)))
-    rdd1.registerTempTable("nulldata1")
-    val nullCheckData2 = TestData(1,"1") :: TestData(2,"2") :: Nil
-    val rdd2 = sparkContext.parallelize((0 to 1).map(i => nullCheckData2(i)))
-    rdd2.registerTempTable("nulldata2")
-
-    checkAnswer(sql("SELECT Coalesce(nulldata2.value,nulldata1.value) FROM nulldata1 join " +
-      "nulldata2 on nulldata1.key = nulldata2.key"),
-        (1 to 2).map(i => Seq(i.toString)))
-  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -992,4 +992,17 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll {
       "nulldata2 on nulldata1.value <=> nulldata2.value"),
         (1 to 2).map(i => Seq(i)))
   }
+
+  test("Supporting Coalesce function in Spark SQL") {
+    val nullCheckData1 = TestData(1,"1") :: TestData(2,null) :: Nil
+    val rdd1 = sparkContext.parallelize((0 to 1).map(i => nullCheckData1(i)))
+    rdd1.registerTempTable("nulldata1")
+    val nullCheckData2 = TestData(1,"1") :: TestData(2,"2") :: Nil
+    val rdd2 = sparkContext.parallelize((0 to 1).map(i => nullCheckData2(i)))
+    rdd2.registerTempTable("nulldata2")
+
+    checkAnswer(sql("SELECT Coalesce(nulldata2.value,nulldata1.value) FROM nulldata1 join " +
+      "nulldata2 on nulldata1.key = nulldata2.key"),
+        (1 to 2).map(i => Seq(i.toString)))
+  }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
@@ -902,6 +902,7 @@ private[hive] object HiveQl {
   val CASE = "(?i)CASE".r
   val SUBSTR = "(?i)SUBSTR(?:ING)?".r
   val SQRT = "(?i)SQRT".r
+  val COALESCE = "(?i)COALESCE".r
 
   protected def nodeToExpr(node: Node): Expression = node match {
     /* Attribute References */
@@ -1053,6 +1054,7 @@ private[hive] object HiveQl {
       Substring(nodeToExpr(string), nodeToExpr(pos), Literal(Integer.MAX_VALUE, IntegerType))
     case Token("TOK_FUNCTION", Token(SUBSTR(), Nil) :: string :: pos :: length :: Nil) =>
       Substring(nodeToExpr(string), nodeToExpr(pos), nodeToExpr(length))
+    case Token("TOK_FUNCTION", Token(COALESCE(), Nil) :: args) => Coalesce(args.map(nodeToExpr))
 
     /* UDFs - Must be last otherwise will preempt built in functions */
     case Token("TOK_FUNCTION", Token(name, Nil) :: args) =>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
@@ -902,7 +902,6 @@ private[hive] object HiveQl {
   val CASE = "(?i)CASE".r
   val SUBSTR = "(?i)SUBSTR(?:ING)?".r
   val SQRT = "(?i)SQRT".r
-  val COALESCE = "(?i)COALESCE".r
 
   protected def nodeToExpr(node: Node): Expression = node match {
     /* Attribute References */
@@ -1054,7 +1053,6 @@ private[hive] object HiveQl {
       Substring(nodeToExpr(string), nodeToExpr(pos), Literal(Integer.MAX_VALUE, IntegerType))
     case Token("TOK_FUNCTION", Token(SUBSTR(), Nil) :: string :: pos :: length :: Nil) =>
       Substring(nodeToExpr(string), nodeToExpr(pos), nodeToExpr(length))
-    case Token("TOK_FUNCTION", Token(COALESCE(), Nil) :: args) => Coalesce(args.map(nodeToExpr))
 
     /* UDFs - Must be last otherwise will preempt built in functions */
     case Token("TOK_FUNCTION", Token(name, Nil) :: args) =>

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -168,4 +168,11 @@ class SQLQuerySuite extends QueryTest {
     checkAnswer(sql("SELECT key FROM src WHERE key not between 0 and 10 order by key"), 
         sql("SELECT key FROM src WHERE key between 11 and 500 order by key").collect().toSeq)
   }
+
+ test("Supporting Coalesce function in Spark SQL") {
+   sql("SELECT * FROM src where key=477").registerTempTable("src1")
+   checkAnswer(sql("SELECT COALESCE(src1.key,src.key) FROM src left outer join src1 "
+       +"on src.key=src1.key order by src.key,src1.key"), 
+       sql("SELECT key FROM src order by key").collect().toSeq)
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -163,16 +163,9 @@ class SQLQuerySuite extends QueryTest {
       sql("SELECT case when ~1=-2 then 1 else 0 end FROM src"),
       sql("SELECT 1 FROM src").collect().toSeq)
   }
-
+ 
  test("SPARK-4154 Query does not work if it has 'not between' in Spark SQL and HQL") {
     checkAnswer(sql("SELECT key FROM src WHERE key not between 0 and 10 order by key"), 
         sql("SELECT key FROM src WHERE key between 11 and 500 order by key").collect().toSeq)
-  }
-
- test("Supporting Coalesce function in Spark SQL") {
-   sql("SELECT * FROM src where key=477").registerTempTable("src1")
-   checkAnswer(sql("SELECT COALESCE(src1.key,src.key) FROM src left outer join src1 "
-       +"on src.key=src1.key order by src.key,src1.key"), 
-       sql("SELECT key FROM src order by key").collect().toSeq)
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -163,7 +163,7 @@ class SQLQuerySuite extends QueryTest {
       sql("SELECT case when ~1=-2 then 1 else 0 end FROM src"),
       sql("SELECT 1 FROM src").collect().toSeq)
   }
- 
+  
  test("SPARK-4154 Query does not work if it has 'not between' in Spark SQL and HQL") {
     checkAnswer(sql("SELECT key FROM src WHERE key not between 0 and 10 order by key"), 
         sql("SELECT key FROM src WHERE key between 11 and 500 order by key").collect().toSeq)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -163,16 +163,9 @@ class SQLQuerySuite extends QueryTest {
       sql("SELECT case when ~1=-2 then 1 else 0 end FROM src"),
       sql("SELECT 1 FROM src").collect().toSeq)
   }
-
+  
  test("SPARK-4154 Query does not work if it has 'not between' in Spark SQL and HQL") {
     checkAnswer(sql("SELECT key FROM src WHERE key not between 0 and 10 order by key"), 
         sql("SELECT key FROM src WHERE key between 11 and 500 order by key").collect().toSeq)
-  }
-
- test("Supporting Coalesce function in Spark SQL") {
-   sql("SELECT * FROM src where key=477").registerTempTable("src1")
-   checkAnswer(sql("SELECT COALESCE(src1.key,src.key) FROM src left outer join src1 "
-       +"on src.key=src1.key order by src.key,src1.key"), 
-       sql("SELECT key FROM src order by key").collect().toSeq)
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -163,9 +163,16 @@ class SQLQuerySuite extends QueryTest {
       sql("SELECT case when ~1=-2 then 1 else 0 end FROM src"),
       sql("SELECT 1 FROM src").collect().toSeq)
   }
-  
+
  test("SPARK-4154 Query does not work if it has 'not between' in Spark SQL and HQL") {
     checkAnswer(sql("SELECT key FROM src WHERE key not between 0 and 10 order by key"), 
         sql("SELECT key FROM src WHERE key between 11 and 500 order by key").collect().toSeq)
+  }
+
+ test("Supporting Coalesce function in Spark SQL") {
+   sql("SELECT * FROM src where key=477").registerTempTable("src1")
+   checkAnswer(sql("SELECT COALESCE(src1.key,src.key) FROM src left outer join src1 "
+       +"on src.key=src1.key order by src.key,src1.key"), 
+       sql("SELECT key FROM src order by key").collect().toSeq)
   }
 }


### PR DESCRIPTION
Support Coalesce function in Spark SQL.
Support type widening in Coalesce function.
And replace Coalesce UDF in Spark Hive with local Coalesce function since it is memory efficient and faster.
