### PR TITLE
[SPARK-4654] Clean up DAGScheduler getMissingParentStages / stageDependsOn methods

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -370,8 +370,7 @@ class DAGScheduler(
         val s = stages.head
         s.jobIds += jobId
         jobIdToStageIds.getOrElseUpdate(jobId, new HashSet[Int]()) += s.id
-        val parents: List[Stage] = stage.parents
-        val parentsWithoutThisJobId = parents.filter { ! _.jobIds.contains(jobId) }
+        val parentsWithoutThisJobId = stage.parents.filter { ! _.jobIds.contains(jobId) }
         updateJobIdStageIdMapsList(parentsWithoutThisJobId ++ stages.tail)
       }
     }

--- a/core/src/main/scala/org/apache/spark/scheduler/Stage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Stage.scala
@@ -85,6 +85,17 @@ private[spark] class Stage(
     }
   }
 
+  def missingParents: List[Stage] = {
+    parents.filterNot(_.isAvailable)
+  }
+
+  /**
+   * Returns true if one of this stage's ancestors is `otherStage`.
+   */
+  def dependsOn(otherStage: Stage): Boolean = {
+    parents.exists(_.rdd == otherStage.rdd)
+  }
+
   def addOutputLoc(partition: Int, status: MapStatus) {
     val prevList = outputLocs(partition)
     outputLocs(partition) = status :: prevList


### PR DESCRIPTION
DAGScheduler has getMissingParentStages() and stageDependsOn() methods which are suspiciously similar to getParentStages().

Both of these methods perform traversals of the RDD / Stage graph to inspect parent stages. We can remove both of these methods, though: the set of parent stages is known when a Stage instance is constructed and is stored in Stage.parents, so we can just check for missing stages by looking for unavailable stages in Stage.parents. Similarly, we can determine whether one stage depends on another by searching Stage.parents rather than performing a graph traversal from scratch.
