### PR TITLE
[SPARK-4667] fix spillable memory acquisition request

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/collection/Spillable.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/Spillable.scala
@@ -75,8 +75,7 @@ private[spark] trait Spillable[C] extends Logging {
     if (elementsRead > trackMemoryThreshold && elementsRead % 32 == 0 &&
         currentMemory >= myMemoryThreshold) {
       // Claim up to double our current memory from the shuffle memory pool
-      val amountToRequest = 2 * currentMemory - myMemoryThreshold
-      val granted = shuffleMemoryManager.tryToAcquire(amountToRequest)
+      val granted = shuffleMemoryManager.tryToAcquire(currentMemory)
       myMemoryThreshold += granted
       if (myMemoryThreshold <= currentMemory) {
         // We were granted too little memory to grow further (either tryToAcquire returned 0,


### PR DESCRIPTION
comment says we should request enough memory to potentially double our
memory-pool footprint, but the code was actually requesting more than
that:

```
currentMemory >= myMemoryThreshold (L66) implies
2*currentMemory - myMemoryThreshold >= currentMemory
```

(strict inequality in the former implies it in the latter, as well). We
were effectively trying to bump our memory footprint to:

```
3*currentMemory - myMemoryThreshold
```

I’m assuming that the comment reflects the true intent, not that it was
mistaken and we actually want (3*cM - mMT).
