### PR TITLE
[SPARK-4666] Improve YarnAllocator's parsing of "memory overhead" param

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -206,7 +206,24 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging {
 
   // Limit of bytes for total size of results (default is 1GB)
   def getMaxResultSize: Long = {
-    Utils.memoryStringToMb(get("spark.driver.maxResultSize", "1g")).toLong << 20
+    getMemory("spark.driver.maxResultSize", "1g", outputScale = 'b')
+  }
+
+  private def getMemory(
+      key: String,
+      defaultValue: String,
+      defaultInputScale: Char = 'b',
+      outputScale: Char = 'm'): Long = {
+    Utils.parseMemoryString(getOption(key).getOrElse(defaultValue), defaultInputScale, outputScale)
+  }
+
+  def getMB(
+      key: String,
+      defaultValue: Int): Int = {
+    getOption(key)
+        .map(Utils.memoryStringToMb(_, defaultInputScale = 'm'))
+        .map(_.toInt)
+        .getOrElse(defaultValue)
   }
 
   /** Get all executor environment variables set on this SparkConf */

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -204,6 +204,11 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging {
     getOption(key).map(_.toBoolean).getOrElse(defaultValue)
   }
 
+  // Limit of bytes for total size of results (default is 1GB)
+  def getMaxResultSize: Long = {
+    Utils.memoryStringToMb(get("spark.driver.maxResultSize", "1g")).toLong << 20
+  }
+
   /** Get all executor environment variables set on this SparkConf */
   def getExecutorEnv: Seq[(String, String)] = {
     val prefix = "spark.executorEnv."

--- a/core/src/main/scala/org/apache/spark/deploy/Client.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/Client.scala
@@ -74,7 +74,7 @@ private class ClientActor(driverArgs: ClientArguments, conf: SparkConf)
 
         val driverDescription = new DriverDescription(
           driverArgs.jarUrl,
-          driverArgs.memory,
+          driverArgs.memoryMB,
           driverArgs.cores,
           driverArgs.supervise,
           command)

--- a/core/src/main/scala/org/apache/spark/deploy/ClientArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/ClientArguments.scala
@@ -39,7 +39,7 @@ private[spark] class ClientArguments(args: Array[String]) {
   var jarUrl: String = ""
   var mainClass: String = ""
   var supervise: Boolean = DEFAULT_SUPERVISE
-  var memory: Int = DEFAULT_MEMORY
+  var memory: Int = DEFAULT_MEMORY_MB
   var cores: Int = DEFAULT_CORES
   private var _driverOptions = ListBuffer[String]()
   def driverOptions = _driverOptions.toSeq
@@ -106,7 +106,7 @@ private[spark] class ClientArguments(args: Array[String]) {
       |
       |Options:
       |   -c CORES, --cores CORES        Number of cores to request (default: $DEFAULT_CORES)
-      |   -m MEMORY, --memory MEMORY     Megabytes of memory to request (default: $DEFAULT_MEMORY)
+      |   -m MEMORY, --memory MEMORY     Megabytes of memory to request (default: $DEFAULT_MEMORY_MB)
       |   -s, --supervise                Whether to restart the driver on failure
       |                                  (default: $DEFAULT_SUPERVISE)
       |   -v, --verbose                  Print more debugging output
@@ -118,7 +118,7 @@ private[spark] class ClientArguments(args: Array[String]) {
 
 object ClientArguments {
   private[spark] val DEFAULT_CORES = 1
-  private[spark] val DEFAULT_MEMORY = 512 // MB
+  private[spark] val DEFAULT_MEMORY_MB = 512
   private[spark] val DEFAULT_SUPERVISE = false
 
   def isValidJarUrl(s: String): Boolean = {

--- a/core/src/main/scala/org/apache/spark/deploy/ClientArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/ClientArguments.scala
@@ -39,7 +39,7 @@ private[spark] class ClientArguments(args: Array[String]) {
   var jarUrl: String = ""
   var mainClass: String = ""
   var supervise: Boolean = DEFAULT_SUPERVISE
-  var memory: Int = DEFAULT_MEMORY_MB
+  var memoryMB: Int = DEFAULT_MEMORY_MB
   var cores: Int = DEFAULT_CORES
   private var _driverOptions = ListBuffer[String]()
   def driverOptions = _driverOptions.toSeq
@@ -55,7 +55,7 @@ private[spark] class ClientArguments(args: Array[String]) {
       parse(tail)
 
     case ("--memory" | "-m") :: MemoryParam(value) :: tail =>
-      memory = value
+      memoryMB = value
       parse(tail)
 
     case ("--supervise" | "-s") :: tail =>

--- a/core/src/main/scala/org/apache/spark/deploy/DriverDescription.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DriverDescription.scala
@@ -19,7 +19,7 @@ package org.apache.spark.deploy
 
 private[spark] class DriverDescription(
     val jarUrl: String,
-    val mem: Int,
+    val memMB: Int,
     val cores: Int,
     val supervise: Boolean,
     val command: Command)
@@ -27,11 +27,11 @@ private[spark] class DriverDescription(
 
   def copy(
       jarUrl: String = jarUrl,
-      mem: Int = mem,
+      memMB: Int = memMB,
       cores: Int = cores,
       supervise: Boolean = supervise,
       command: Command = command): DriverDescription =
-    new DriverDescription(jarUrl, mem, cores, supervise, command)
+    new DriverDescription(jarUrl, memMB, cores, supervise, command)
 
   override def toString: String = s"DriverDescription (${command.mainClass})"
 }

--- a/core/src/main/scala/org/apache/spark/deploy/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/JsonProtocol.scala
@@ -71,7 +71,7 @@ private[spark] object JsonProtocol {
     ("starttime" -> obj.startTime.toString) ~
     ("state" -> obj.state.toString) ~
     ("cores" -> obj.desc.cores) ~
-    ("memory" -> obj.desc.mem)
+    ("memory" -> obj.desc.memMB)
   }
 
   def writeMasterState(obj: MasterStateResponse) = {

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -543,7 +543,7 @@ private[spark] class Master(
       while (numWorkersVisited < numWorkersAlive && !launched) {
         val worker = shuffledAliveWorkers(curPos)
         numWorkersVisited += 1
-        if (worker.memoryFree >= driver.desc.mem && worker.coresFree >= driver.desc.cores) {
+        if (worker.memoryFree >= driver.desc.memMB && worker.coresFree >= driver.desc.cores) {
           launchDriver(worker, driver)
           waitingDrivers -= driver
           launched = true

--- a/core/src/main/scala/org/apache/spark/deploy/master/WorkerInfo.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/WorkerInfo.scala
@@ -90,13 +90,13 @@ private[spark] class WorkerInfo(
 
   def addDriver(driver: DriverInfo) {
     drivers(driver.id) = driver
-    memoryUsed += driver.desc.mem
+    memoryUsed += driver.desc.memMB
     coresUsed += driver.desc.cores
   }
 
   def removeDriver(driver: DriverInfo) {
     drivers -= driver.id
-    memoryUsed -= driver.desc.mem
+    memoryUsed -= driver.desc.memMB
     coresUsed -= driver.desc.cores
   }
 

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
@@ -193,8 +193,8 @@ private[spark] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
       <td sorttable_customkey={driver.desc.cores.toString}>
         {driver.desc.cores}
       </td>
-      <td sorttable_customkey={driver.desc.mem.toString}>
-        {Utils.megabytesToString(driver.desc.mem.toLong)}
+      <td sorttable_customkey={driver.desc.memMB.toString}>
+        {Utils.megabytesToString(driver.desc.memMB.toLong)}
       </td>
       <td>{driver.desc.command.arguments(2)}</td>
     </tr>

--- a/core/src/main/scala/org/apache/spark/deploy/rest/StandaloneRestServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/rest/StandaloneRestServer.scala
@@ -394,7 +394,7 @@ private class SubmitRequestServlet(
       "org.apache.spark.deploy.worker.DriverWrapper",
       Seq("{{WORKER_URL}}", "{{USER_JAR}}", mainClass) ++ appArgs, // args to the DriverWrapper
       environmentVariables, extraClassPath, extraLibraryPath, javaOpts)
-    val actualDriverMemory = driverMemory.map(Utils.memoryStringToMb).getOrElse(DEFAULT_MEMORY)
+    val actualDriverMemory = driverMemory.map(Utils.memoryStringToMb).getOrElse(DEFAULT_MEMORY_MB)
     val actualDriverCores = driverCores.map(_.toInt).getOrElse(DEFAULT_CORES)
     val actualSuperviseDriver = superviseDriver.map(_.toBoolean).getOrElse(DEFAULT_SUPERVISE)
     new DriverDescription(

--- a/core/src/main/scala/org/apache/spark/deploy/worker/DriverRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/DriverRunner.scala
@@ -81,7 +81,7 @@ private[spark] class DriverRunner(
           }
 
           // TODO: If we add ability to submit multiple jars they should also be added here
-          val builder = CommandUtils.buildProcessBuilder(driverDesc.command, driverDesc.mem,
+          val builder = CommandUtils.buildProcessBuilder(driverDesc.command, driverDesc.memMB,
             sparkHome.getAbsolutePath, substituteVariables)
           launchDriver(builder, driverDir, driverDesc.supervise)
         }

--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -435,7 +435,7 @@ private[spark] class Worker(
       driver.start()
 
       coresUsed += driverDesc.cores
-      memoryUsed += driverDesc.mem
+      memoryUsed += driverDesc.memMB
     }
 
     case KillDriver(driverId) => {
@@ -464,7 +464,7 @@ private[spark] class Worker(
       master ! DriverStateChanged(driverId, state, exception)
       val driver = drivers.remove(driverId).get
       finishedDrivers(driverId) = driver
-      memoryUsed -= driver.driverDesc.mem
+      memoryUsed -= driver.driverDesc.memMB
       coresUsed -= driver.driverDesc.cores
     }
 

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ui/WorkerPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ui/WorkerPage.scala
@@ -139,8 +139,8 @@ private[spark] class WorkerPage(parent: WorkerWebUI) extends WebUIPage("") {
       <td sorttable_customkey={driver.driverDesc.cores.toString}>
         {driver.driverDesc.cores.toString}
       </td>
-      <td sorttable_customkey={driver.driverDesc.mem.toString}>
-        {Utils.megabytesToString(driver.driverDesc.mem)}
+      <td sorttable_customkey={driver.driverDesc.memMB.toString}>
+        {Utils.megabytesToString(driver.driverDesc.memMB)}
       </td>
       <td>
         <a href={s"logPage?driverId=${driver.driverId}&logType=stdout"}>stdout</a>

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -105,7 +105,7 @@ private[spark] class Executor(
   private val akkaFrameSize = AkkaUtils.maxFrameSizeBytes(conf)
 
   // Limit of bytes for total size of results (default is 1GB)
-  private val maxResultSize = Utils.getMaxResultSize(conf)
+  private val maxResultSize = conf.getMaxResultSize
 
   // Maintains the list of running tasks.
   private val runningTasks = new ConcurrentHashMap[Long, TaskRunner]

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -70,7 +70,7 @@ private[spark] class TaskSetManager(
   val SPECULATION_MULTIPLIER = conf.getDouble("spark.speculation.multiplier", 1.5)
 
   // Limit of bytes for total size of results (default is 1GB)
-  val maxResultSize = Utils.getMaxResultSize(conf)
+  val maxResultSize = conf.getMaxResultSize
 
   // Serializer for closures and tasks.
   val env = SparkEnv.get

--- a/core/src/main/scala/org/apache/spark/scheduler/local/LocalBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/local/LocalBackend.scala
@@ -20,6 +20,7 @@ package org.apache.spark.scheduler.local
 import java.nio.ByteBuffer
 
 import scala.concurrent.duration._
+import scala.language.postfixOps
 
 import akka.actor.{Actor, ActorRef, Props}
 

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -983,18 +983,28 @@ private[spark] object Utils extends Logging {
   /**
    * Convert a Java memory parameter passed to -Xmx (such as 300m or 1g) to a number of megabytes.
    */
-  def memoryStringToMb(str: String): Int = {
+  def memoryStringToMb(str: String): Int = memoryStringToMb(str, 'b')
+  def memoryStringToMb(str: String, defaultScale: Char): Int = {
     val lower = str.toLowerCase
-    if (lower.endsWith("k")) {
+    val lastChar = lower(lower.length - 1)
+    val scale =
+      if (lastChar.isDigit)
+        defaultScale
+      else
+        lastChar
+
+    if (scale == 'k') {
       (lower.substring(0, lower.length-1).toLong / 1024).toInt
-    } else if (lower.endsWith("m")) {
+    } else if (scale == 'm') {
       lower.substring(0, lower.length-1).toInt
-    } else if (lower.endsWith("g")) {
+    } else if (scale == 'g') {
       lower.substring(0, lower.length-1).toInt * 1024
-    } else if (lower.endsWith("t")) {
+    } else if (scale == 't') {
       lower.substring(0, lower.length-1).toInt * 1024 * 1024
-    } else {// no suffix, so it's just a number in bytes
+    } else if (scale == 'b') {// no suffix, so it's just a number in bytes
       (lower.toLong / 1024 / 1024).toInt
+    } else {
+      throw new IllegalArgumentException("Invalid memory string: %s".format(str))
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -986,33 +986,66 @@ private[spark] object Utils extends Logging {
   private val MB = 1L << 20
   private val KB = 1L << 10
 
+  private val scaleCharToFactor: Map[Char, Long] = Map(
+    'b' -> 1L,
+    'k' -> KB,
+    'm' -> MB,
+    'g' -> GB,
+    't' -> TB
+  )
+
   /**
-   * Convert a Java memory parameter passed to -Xmx (such as 300m or 1g) to a number of megabytes.
+   * Convert a Java memory parameter passed to -Xmx (such as "300m" or "1g") to a number of
+   * megabytes (or other byte-scale denominations as specified by @outputScaleChar).
+   *
+   * For @defaultInputScaleChar and @outputScaleChar, valid values are: 'b' (bytes), 'k'
+   * (kilobytes), 'm' (megabytes), 'g' (gigabytes), and 't' (terabytes).
+   *
+   * @param str String to parse an amount of memory out of
+   * @param defaultInputScaleChar if no "scale" is provided on the end of @str (i.e. @str is a
+   *                              plain numeric value), assume this scale (default: 'b' for
+   *                              'bytes')
+   * @param outputScaleChar express the output in this scale, i.e. number of bytes, kilobytes,
+   *                        megabytes, or gigabytes.
    */
-  def memoryStringToMb(str: String): Int = memoryStringToMb(str, 'b')
-  def memoryStringToMb(str: String, defaultScale: Char): Int = {
+  def parseMemoryString(
+      str: String,
+      defaultInputScaleChar: Char = 'b',
+      outputScaleChar: Char = 'm'): Long = {
+
     val lower = str.toLowerCase
     val lastChar = lower(lower.length - 1)
-    val scale =
-      if (lastChar.isDigit)
-        defaultScale
-      else
-        lastChar
+    val (num, inputScaleChar) =
+      if (lastChar.isDigit) {
+        (lower.toLong, defaultInputScaleChar)
+      } else {
+        (lower.substring(0, lower.length - 1).toLong, lastChar)
+      }
 
-    if (scale == 'k') {
-      (lower.substring(0, lower.length-1).toLong / 1024).toInt
-    } else if (scale == 'm') {
-      lower.substring(0, lower.length-1).toInt
-    } else if (scale == 'g') {
-      lower.substring(0, lower.length-1).toInt * 1024
-    } else if (scale == 't') {
-      lower.substring(0, lower.length-1).toInt * 1024 * 1024
-    } else if (scale == 'b') {// no suffix, so it's just a number in bytes
-      (lower.toLong / 1024 / 1024).toInt
-    } else {
-      throw new IllegalArgumentException("Invalid memory string: %s".format(str))
-    }
+    (for {
+      inputScale <- scaleCharToFactor.get(inputScaleChar)
+      outputScale <- scaleCharToFactor.get(outputScaleChar)
+      scale = inputScale * num / outputScale
+    } yield {
+      scale
+    }).getOrElse(
+        throw new IllegalArgumentException(
+          "Invalid memory string or scale: %s, %s, %s".format(
+            str,
+            defaultInputScaleChar,
+            outputScaleChar
+          )
+        )
+      )
   }
+
+  /**
+   * Wrapper for @parseMemoryString taking default arguments and returning an int, which is safe
+   * since we are converting to a number of megabytes.
+   */
+  def memoryStringToMb(str: String): Int = memoryStringToMb(str, defaultInputScale = 'b')
+  def memoryStringToMb(str: String, defaultInputScale: Char = 'b'): Int =
+    parseMemoryString(str, defaultInputScale, 'm').toInt
 
   /**
    * Convert a quantity in bytes to a human-readable string such as "4.0 MB".

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -980,6 +980,12 @@ private[spark] object Utils extends Logging {
     )
   }
 
+
+  private val TB = 1L << 40
+  private val GB = 1L << 30
+  private val MB = 1L << 20
+  private val KB = 1L << 10
+
   /**
    * Convert a Java memory parameter passed to -Xmx (such as 300m or 1g) to a number of megabytes.
    */
@@ -1012,11 +1018,6 @@ private[spark] object Utils extends Logging {
    * Convert a quantity in bytes to a human-readable string such as "4.0 MB".
    */
   def bytesToString(size: Long): String = {
-    val TB = 1L << 40
-    val GB = 1L << 30
-    val MB = 1L << 20
-    val KB = 1L << 10
-
     val (value, unit) = {
       if (size >= 2*TB) {
         (size.asInstanceOf[Double] / TB, "TB")
@@ -1057,7 +1058,7 @@ private[spark] object Utils extends Logging {
    * Convert a quantity in megabytes to a human-readable string such as "4.0 MB".
    */
   def megabytesToString(megabytes: Long): String = {
-    bytesToString(megabytes * 1024L * 1024L)
+    bytesToString(megabytes * MB)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1915,11 +1915,6 @@ private[spark] object Utils extends Logging {
     method.invoke(obj, values.toSeq: _*)
   }
 
-  // Limit of bytes for total size of results (default is 1GB)
-  def getMaxResultSize(conf: SparkConf): Long = {
-    memoryStringToMb(conf.get("spark.driver.maxResultSize", "1g")).toLong << 20
-  }
-
   /**
    * Return the current system LD_LIBRARY_PATH name
    */

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1025,9 +1025,8 @@ private[spark] object Utils extends Logging {
     (for {
       inputScale <- scaleCharToFactor.get(inputScaleChar)
       outputScale <- scaleCharToFactor.get(outputScaleChar)
-      scale = inputScale * num / outputScale
     } yield {
-      scale
+      inputScale * num / outputScale
     }).getOrElse(
         throw new IllegalArgumentException(
           "Invalid memory string or scale: %s, %s, %s".format(

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -113,23 +113,23 @@ Most of the configs are the same for Spark on YARN as for other deployment modes
 </tr>
 <tr>
  <td><code>spark.yarn.executor.memoryOverhead</code></td>
-  <td>executorMemory * 0.07, with minimum of 384 megabytes </td>
+  <td>executorMemory * 0.07, with a minimum of 384 megabytes </td>
   <td>
     The amount of off heap memory to be allocated per executor. This is memory that accounts for things like VM overheads, interned strings, other native overheads, etc. This tends to grow with the executor size (typically 6-10%), but is specified here as an absolute amount of memory, e.g. "1g" or "384m".
   </td>
 </tr>
 <tr>
   <td><code>spark.yarn.driver.memoryOverhead</code></td>
-  <td>driverMemory * 0.07, with minimum of 384 </td>
+  <td>driverMemory * 0.07, with a minimum of 384 megabytes </td>
   <td>
-    The amount of off heap memory (in megabytes) to be allocated per driver in cluster mode. This is memory that accounts for things like VM overheads, interned strings, other native overheads, etc. This tends to grow with the container size (typically 6-10%).
+    Same as <code>spark.yarn.executor.memoryOverhead</code>, but for the driver in cluster mode.
   </td>
 </tr>
 <tr>
   <td><code>spark.yarn.am.memoryOverhead</code></td>
-  <td>AM memory * 0.07, with minimum of 384 </td>
+  <td>AM memory * 0.07, with a minimum of 384 megabytes </td>
   <td>
-    Same as <code>spark.yarn.driver.memoryOverhead</code>, but for the Application Master in client mode.
+    Same as <code>spark.yarn.executor.memoryOverhead</code>, but for the Application Master in client mode.
   </td>
 </tr>
 <tr>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -113,9 +113,9 @@ Most of the configs are the same for Spark on YARN as for other deployment modes
 </tr>
 <tr>
  <td><code>spark.yarn.executor.memoryOverhead</code></td>
-  <td>executorMemory * 0.07, with minimum of 384 </td>
+  <td>executorMemory * 0.07, with minimum of 384 megabytes </td>
   <td>
-    The amount of off heap memory (in megabytes) to be allocated per executor. This is memory that accounts for things like VM overheads, interned strings, other native overheads, etc. This tends to grow with the executor size (typically 6-10%).
+    The amount of off heap memory to be allocated per executor. This is memory that accounts for things like VM overheads, interned strings, other native overheads, etc. This tends to grow with the executor size (typically 6-10%), but is specified here as an absolute amount of memory, e.g. "1g" or "384m".
   </td>
 </tr>
 <tr>

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMasterArguments.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMasterArguments.scala
@@ -27,7 +27,7 @@ class ApplicationMasterArguments(val args: Array[String]) {
   var primaryPyFile: String = null
   var pyFiles: String = null
   var userArgs: Seq[String] = Seq[String]()
-  var executorMemory = 1024
+  var executorMemoryMB = 1024
   var executorCores = 1
   var numExecutors = DEFAULT_NUMBER_EXECUTORS
 
@@ -67,7 +67,7 @@ class ApplicationMasterArguments(val args: Array[String]) {
           args = tail
 
         case ("--worker-memory" | "--executor-memory") :: MemoryParam(value) :: tail =>
-          executorMemory = value
+          executorMemoryMB = value
           args = tail
 
         case ("--worker-cores" | "--executor-cores") :: IntParam(value) :: tail =>

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -63,7 +63,7 @@ private[spark] class Client(
   private val yarnConf = new YarnConfiguration(hadoopConf)
   private val credentials = UserGroupInformation.getCurrentUser.getCredentials
   private val amMemoryOverheadMB = args.amMemoryOverhead
-  private val executorMemoryOverhead = args.executorMemoryOverhead // MB
+  private val executorMemoryOverheadMB = args.executorMemoryOverhead
   private val distCacheMgr = new ClientDistributedCacheManager()
   private val isClusterMode = args.isClusterMode
 
@@ -157,10 +157,10 @@ private[spark] class Client(
     val maxMem = newAppResponse.getMaximumResourceCapability().getMemory()
     logInfo("Verifying our application has not requested more than the maximum " +
       s"memory capability of the cluster ($maxMem MB per container)")
-    val executorMem = args.executorMemoryMB + executorMemoryOverhead
+    val executorMem = args.executorMemoryMB + executorMemoryOverheadMB
     if (executorMem > maxMem) {
       throw new IllegalArgumentException(s"Required executor memory (${args.executorMemoryMB}" +
-        s"+$executorMemoryOverhead MB) is above the max threshold ($maxMem MB) of this cluster!")
+        s"+$executorMemoryOverheadMB MB) is above the max threshold ($maxMem MB) of this cluster!")
     }
     val amMem = args.amMemoryMB + amMemoryOverheadMB
     if (amMem > maxMem) {

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -62,7 +62,7 @@ private[spark] class Client(
   private val yarnClient = YarnClient.createYarnClient
   private val yarnConf = new YarnConfiguration(hadoopConf)
   private val credentials = UserGroupInformation.getCurrentUser.getCredentials
-  private val amMemoryOverhead = args.amMemoryOverhead // MB
+  private val amMemoryOverheadMB = args.amMemoryOverhead
   private val executorMemoryOverhead = args.executorMemoryOverhead // MB
   private val distCacheMgr = new ClientDistributedCacheManager()
   private val isClusterMode = args.isClusterMode
@@ -126,7 +126,7 @@ private[spark] class Client(
           "Cluster's default value will be used.")
     }
     val capability = Records.newRecord(classOf[Resource])
-    capability.setMemory(args.amMemoryMB + amMemoryOverhead)
+    capability.setMemory(args.amMemoryMB + amMemoryOverheadMB)
     capability.setVirtualCores(args.amCores)
     appContext.setResource(capability)
     appContext
@@ -162,14 +162,14 @@ private[spark] class Client(
       throw new IllegalArgumentException(s"Required executor memory (${args.executorMemoryMB}" +
         s"+$executorMemoryOverhead MB) is above the max threshold ($maxMem MB) of this cluster!")
     }
-    val amMem = args.amMemoryMB + amMemoryOverhead
+    val amMem = args.amMemoryMB + amMemoryOverheadMB
     if (amMem > maxMem) {
       throw new IllegalArgumentException(s"Required AM memory (${args.amMemoryMB}" +
-        s"+$amMemoryOverhead MB) is above the max threshold ($maxMem MB) of this cluster!")
+        s"+$amMemoryOverheadMB MB) is above the max threshold ($maxMem MB) of this cluster!")
     }
     logInfo("Will allocate AM container, with %d MB memory including %d MB overhead".format(
       amMem,
-      amMemoryOverhead))
+      amMemoryOverheadMB))
 
     // We could add checks to make sure the entire cluster has enough resources but that involves
     // getting all the node reports and computing ourselves.

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -157,9 +157,9 @@ private[spark] class Client(
     val maxMem = newAppResponse.getMaximumResourceCapability().getMemory()
     logInfo("Verifying our application has not requested more than the maximum " +
       s"memory capability of the cluster ($maxMem MB per container)")
-    val executorMem = args.executorMemory + executorMemoryOverhead
+    val executorMem = args.executorMemoryMB + executorMemoryOverhead
     if (executorMem > maxMem) {
-      throw new IllegalArgumentException(s"Required executor memory (${args.executorMemory}" +
+      throw new IllegalArgumentException(s"Required executor memory (${args.executorMemoryMB}" +
         s"+$executorMemoryOverhead MB) is above the max threshold ($maxMem MB) of this cluster!")
     }
     val amMem = args.amMemory + amMemoryOverhead
@@ -503,7 +503,7 @@ private[spark] class Client(
     val amArgs =
       Seq(amClass) ++ userClass ++ userJar ++ primaryPyFile ++ pyFiles ++ userArgs ++
         Seq(
-          "--executor-memory", args.executorMemory.toString + "m",
+          "--executor-memory", args.executorMemoryMB.toString + "m",
           "--executor-cores", args.executorCores.toString,
           "--num-executors ", args.numExecutors.toString)
 

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -63,7 +63,7 @@ private[spark] class Client(
   private val yarnConf = new YarnConfiguration(hadoopConf)
   private val credentials = UserGroupInformation.getCurrentUser.getCredentials
   private val amMemoryOverheadMB = args.amMemoryOverheadMB
-  private val executorMemoryOverheadMB = args.executorMemoryOverhead
+  private val executorMemoryOverheadMB = args.executorMemoryOverheadMB
   private val distCacheMgr = new ClientDistributedCacheManager()
   private val isClusterMode = args.isClusterMode
 

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -62,7 +62,7 @@ private[spark] class Client(
   private val yarnClient = YarnClient.createYarnClient
   private val yarnConf = new YarnConfiguration(hadoopConf)
   private val credentials = UserGroupInformation.getCurrentUser.getCredentials
-  private val amMemoryOverheadMB = args.amMemoryOverhead
+  private val amMemoryOverheadMB = args.amMemoryOverheadMB
   private val executorMemoryOverheadMB = args.executorMemoryOverhead
   private val distCacheMgr = new ClientDistributedCacheManager()
   private val isClusterMode = args.isClusterMode

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -126,7 +126,7 @@ private[spark] class Client(
           "Cluster's default value will be used.")
     }
     val capability = Records.newRecord(classOf[Resource])
-    capability.setMemory(args.amMemory + amMemoryOverhead)
+    capability.setMemory(args.amMemoryMB + amMemoryOverhead)
     capability.setVirtualCores(args.amCores)
     appContext.setResource(capability)
     appContext
@@ -162,9 +162,9 @@ private[spark] class Client(
       throw new IllegalArgumentException(s"Required executor memory (${args.executorMemoryMB}" +
         s"+$executorMemoryOverhead MB) is above the max threshold ($maxMem MB) of this cluster!")
     }
-    val amMem = args.amMemory + amMemoryOverhead
+    val amMem = args.amMemoryMB + amMemoryOverhead
     if (amMem > maxMem) {
-      throw new IllegalArgumentException(s"Required AM memory (${args.amMemory}" +
+      throw new IllegalArgumentException(s"Required AM memory (${args.amMemoryMB}" +
         s"+$amMemoryOverhead MB) is above the max threshold ($maxMem MB) of this cluster!")
     }
     logInfo("Will allocate AM container, with %d MB memory including %d MB overhead".format(
@@ -394,7 +394,7 @@ private[spark] class Client(
     var prefixEnv: Option[String] = None
 
     // Add Xmx for AM memory
-    javaOpts += "-Xmx" + args.amMemory + "m"
+    javaOpts += "-Xmx" + args.amMemoryMB + "m"
 
     val tmpDir = new Path(
       YarnSparkHadoopUtil.expandEnvironment(Environment.PWD),

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
@@ -62,7 +62,7 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
   val amMemoryOverheadMB = sparkConf.getInt(amMemoryOverheadConf,
     math.max((MEMORY_OVERHEAD_FACTOR * amMemoryMB).toInt, MEMORY_OVERHEAD_MIN))
 
-  val executorMemoryOverhead = sparkConf.getInt("spark.yarn.executor.memoryOverhead",
+  val executorMemoryOverheadMB = sparkConf.getInt("spark.yarn.executor.memoryOverhead",
     math.max((MEMORY_OVERHEAD_FACTOR * executorMemoryMB).toInt, MEMORY_OVERHEAD_MIN))
 
   /** Load any default arguments provided through environment variables and Spark properties. */

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
@@ -43,7 +43,7 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
   var priority = 0
   def isClusterMode: Boolean = userClass != null
 
-  private var driverMemory: Int = 512 // MB
+  private var driverMemoryMB: Int = 512
   private var driverCores: Int = 1
   private val driverMemOverheadKey = "spark.yarn.driver.memoryOverhead"
   private val amMemKey = "spark.yarn.am.memory"
@@ -116,7 +116,7 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
           println(s"$key is set but does not apply in cluster mode.")
         }
       }
-      amMemoryMB = driverMemory
+      amMemoryMB = driverMemoryMB
       amCores = driverCores
     } else {
       for (key <- Seq(driverMemOverheadKey, driverCoresKey)) {
@@ -165,7 +165,7 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
           if (args(0) == "--master-memory") {
             println("--master-memory is deprecated. Use --driver-memory instead.")
           }
-          driverMemory = value
+          driverMemoryMB = value
           args = tail
 
         case ("--driver-cores") :: IntParam(value) :: tail =>

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
@@ -33,7 +33,7 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
   var pyFiles: String = null
   var primaryPyFile: String = null
   var userArgs: ArrayBuffer[String] = new ArrayBuffer[String]()
-  var executorMemory = 1024 // MB
+  var executorMemoryMB = 1024
   var executorCores = 1
   var numExecutors = DEFAULT_NUMBER_EXECUTORS
   var amQueue = sparkConf.get("spark.yarn.queue", "default")
@@ -63,7 +63,7 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
     math.max((MEMORY_OVERHEAD_FACTOR * amMemory).toInt, MEMORY_OVERHEAD_MIN))
 
   val executorMemoryOverhead = sparkConf.getInt("spark.yarn.executor.memoryOverhead",
-    math.max((MEMORY_OVERHEAD_FACTOR * executorMemory).toInt, MEMORY_OVERHEAD_MIN))
+    math.max((MEMORY_OVERHEAD_FACTOR * executorMemoryMB).toInt, MEMORY_OVERHEAD_MIN))
 
   /** Load any default arguments provided through environment variables and Spark properties. */
   private def loadEnvironmentArgs(): Unit = {
@@ -188,7 +188,7 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
           if (args(0) == "--worker-memory") {
             println("--worker-memory is deprecated. Use --executor-memory instead.")
           }
-          executorMemory = value
+          executorMemoryMB = value
           args = tail
 
         case ("--worker-cores" | "--executor-cores") :: IntParam(value) :: tail =>

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
@@ -59,10 +59,10 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
 
   // Additional memory to allocate to containers
   private val amMemoryOverheadConf = if (isClusterMode) driverMemOverheadKey else amMemOverheadKey
-  val amMemoryOverheadMB = sparkConf.getInt(amMemoryOverheadConf,
+  val amMemoryOverheadMB = sparkConf.getMB(amMemoryOverheadConf,
     math.max((MEMORY_OVERHEAD_FACTOR * amMemoryMB).toInt, MEMORY_OVERHEAD_MIN_MB))
 
-  val executorMemoryOverheadMB = sparkConf.getInt("spark.yarn.executor.memoryOverhead",
+  val executorMemoryOverheadMB = sparkConf.getMB("spark.yarn.executor.memoryOverhead",
     math.max((MEMORY_OVERHEAD_FACTOR * executorMemoryMB).toInt, MEMORY_OVERHEAD_MIN_MB))
 
   /** Load any default arguments provided through environment variables and Spark properties. */

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
@@ -60,10 +60,10 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
   // Additional memory to allocate to containers
   val amMemoryOverheadConf = if (isClusterMode) driverMemOverheadKey else amMemOverheadKey
   val amMemoryOverheadMB = sparkConf.getInt(amMemoryOverheadConf,
-    math.max((MEMORY_OVERHEAD_FACTOR * amMemoryMB).toInt, MEMORY_OVERHEAD_MIN))
+    math.max((MEMORY_OVERHEAD_FACTOR * amMemoryMB).toInt, MEMORY_OVERHEAD_MIN_MB))
 
   val executorMemoryOverheadMB = sparkConf.getInt("spark.yarn.executor.memoryOverhead",
-    math.max((MEMORY_OVERHEAD_FACTOR * executorMemoryMB).toInt, MEMORY_OVERHEAD_MIN))
+    math.max((MEMORY_OVERHEAD_FACTOR * executorMemoryMB).toInt, MEMORY_OVERHEAD_MIN_MB))
 
   /** Load any default arguments provided through environment variables and Spark properties. */
   private def loadEnvironmentArgs(): Unit = {

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
@@ -37,7 +37,7 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
   var executorCores = 1
   var numExecutors = DEFAULT_NUMBER_EXECUTORS
   var amQueue = sparkConf.get("spark.yarn.queue", "default")
-  var amMemory: Int = 512 // MB
+  var amMemoryMB: Int = 512
   var amCores: Int = 1
   var appName: String = "Spark"
   var priority = 0
@@ -60,7 +60,7 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
   // Additional memory to allocate to containers
   val amMemoryOverheadConf = if (isClusterMode) driverMemOverheadKey else amMemOverheadKey
   val amMemoryOverhead = sparkConf.getInt(amMemoryOverheadConf,
-    math.max((MEMORY_OVERHEAD_FACTOR * amMemory).toInt, MEMORY_OVERHEAD_MIN))
+    math.max((MEMORY_OVERHEAD_FACTOR * amMemoryMB).toInt, MEMORY_OVERHEAD_MIN))
 
   val executorMemoryOverhead = sparkConf.getInt("spark.yarn.executor.memoryOverhead",
     math.max((MEMORY_OVERHEAD_FACTOR * executorMemoryMB).toInt, MEMORY_OVERHEAD_MIN))
@@ -116,7 +116,7 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
           println(s"$key is set but does not apply in cluster mode.")
         }
       }
-      amMemory = driverMemory
+      amMemoryMB = driverMemory
       amCores = driverCores
     } else {
       for (key <- Seq(driverMemOverheadKey, driverCoresKey)) {
@@ -126,7 +126,7 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
       }
       sparkConf.getOption(amMemKey)
         .map(Utils.memoryStringToMb)
-        .foreach { mem => amMemory = mem }
+        .foreach { mem => amMemoryMB = mem }
       sparkConf.getOption(amCoresKey)
         .map(_.toInt)
         .foreach { cores => amCores = cores }

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
@@ -59,7 +59,7 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
 
   // Additional memory to allocate to containers
   val amMemoryOverheadConf = if (isClusterMode) driverMemOverheadKey else amMemOverheadKey
-  val amMemoryOverhead = sparkConf.getInt(amMemoryOverheadConf,
+  val amMemoryOverheadMB = sparkConf.getInt(amMemoryOverheadConf,
     math.max((MEMORY_OVERHEAD_FACTOR * amMemoryMB).toInt, MEMORY_OVERHEAD_MIN))
 
   val executorMemoryOverhead = sparkConf.getInt("spark.yarn.executor.memoryOverhead",

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
@@ -58,7 +58,7 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
   validateArgs()
 
   // Additional memory to allocate to containers
-  val amMemoryOverheadConf = if (isClusterMode) driverMemOverheadKey else amMemOverheadKey
+  private val amMemoryOverheadConf = if (isClusterMode) driverMemOverheadKey else amMemOverheadKey
   val amMemoryOverheadMB = sparkConf.getInt(amMemoryOverheadConf,
     math.max((MEMORY_OVERHEAD_FACTOR * amMemoryMB).toInt, MEMORY_OVERHEAD_MIN_MB))
 

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -91,8 +91,9 @@ private[yarn] class YarnAllocator(
   // Executor memory in MB.
   protected val executorMemoryMB = args.executorMemoryMB
   // Additional memory overhead.
-  protected val memoryOverheadMB: Int = sparkConf.getInt("spark.yarn.executor.memoryOverhead",
+  protected val memoryOverheadMB: Int = sparkConf.getMB("spark.yarn.executor.memoryOverhead",
     math.max((MEMORY_OVERHEAD_FACTOR * executorMemoryMB).toInt, MEMORY_OVERHEAD_MIN_MB))
+
   // Number of cores per executor.
   protected val executorCores = args.executorCores
   // Resource capability requested for each executors

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -89,14 +89,14 @@ private[yarn] class YarnAllocator(
   private val executorIdToContainer = new HashMap[String, Container]
 
   // Executor memory in MB.
-  protected val executorMemory = args.executorMemoryMB
+  protected val executorMemoryMB = args.executorMemoryMB
   // Additional memory overhead.
   protected val memoryOverhead: Int = sparkConf.getInt("spark.yarn.executor.memoryOverhead",
-    math.max((MEMORY_OVERHEAD_FACTOR * executorMemory).toInt, MEMORY_OVERHEAD_MIN_MB))
+    math.max((MEMORY_OVERHEAD_FACTOR * executorMemoryMB).toInt, MEMORY_OVERHEAD_MIN_MB))
   // Number of cores per executor.
   protected val executorCores = args.executorCores
   // Resource capability requested for each executors
-  private val resource = Resource.newInstance(executorMemory + memoryOverhead, executorCores)
+  private val resource = Resource.newInstance(executorMemoryMB + memoryOverhead, executorCores)
 
   private val launcherPool = new ThreadPoolExecutor(
     // max pool size of Integer.MAX_VALUE is ignored because we use an unbounded queue
@@ -333,7 +333,7 @@ private[yarn] class YarnAllocator(
         driverUrl,
         executorId,
         executorHostname,
-        executorMemory,
+        executorMemoryMB,
         executorCores,
         appAttemptId.getApplicationId.toString,
         securityMgr)

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -89,7 +89,7 @@ private[yarn] class YarnAllocator(
   private val executorIdToContainer = new HashMap[String, Container]
 
   // Executor memory in MB.
-  protected val executorMemory = args.executorMemory
+  protected val executorMemory = args.executorMemoryMB
   // Additional memory overhead.
   protected val memoryOverhead: Int = sparkConf.getInt("spark.yarn.executor.memoryOverhead",
     math.max((MEMORY_OVERHEAD_FACTOR * executorMemory).toInt, MEMORY_OVERHEAD_MIN_MB))

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -91,12 +91,12 @@ private[yarn] class YarnAllocator(
   // Executor memory in MB.
   protected val executorMemoryMB = args.executorMemoryMB
   // Additional memory overhead.
-  protected val memoryOverhead: Int = sparkConf.getInt("spark.yarn.executor.memoryOverhead",
+  protected val memoryOverheadMB: Int = sparkConf.getInt("spark.yarn.executor.memoryOverhead",
     math.max((MEMORY_OVERHEAD_FACTOR * executorMemoryMB).toInt, MEMORY_OVERHEAD_MIN_MB))
   // Number of cores per executor.
   protected val executorCores = args.executorCores
   // Resource capability requested for each executors
-  private val resource = Resource.newInstance(executorMemoryMB + memoryOverhead, executorCores)
+  private val resource = Resource.newInstance(executorMemoryMB + memoryOverheadMB, executorCores)
 
   private val launcherPool = new ThreadPoolExecutor(
     // max pool size of Integer.MAX_VALUE is ignored because we use an unbounded queue
@@ -206,7 +206,7 @@ private[yarn] class YarnAllocator(
 
     if (missing > 0) {
       logInfo(s"Will request $missing executor containers, each with ${resource.getVirtualCores} " +
-        s"cores and ${resource.getMemory} MB memory including $memoryOverhead MB overhead")
+        s"cores and ${resource.getMemory} MB memory including $memoryOverheadMB MB overhead")
 
       for (i <- 0 until missing) {
         val request = new ContainerRequest(resource, null, null, RM_REQUEST_PRIORITY)

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -92,7 +92,7 @@ private[yarn] class YarnAllocator(
   protected val executorMemory = args.executorMemory
   // Additional memory overhead.
   protected val memoryOverhead: Int = sparkConf.getInt("spark.yarn.executor.memoryOverhead",
-    math.max((MEMORY_OVERHEAD_FACTOR * executorMemory).toInt, MEMORY_OVERHEAD_MIN))
+    math.max((MEMORY_OVERHEAD_FACTOR * executorMemory).toInt, MEMORY_OVERHEAD_MIN_MB))
   // Number of cores per executor.
   protected val executorCores = args.executorCores
   // Resource capability requested for each executors

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -90,7 +90,7 @@ object YarnSparkHadoopUtil {
   // the common cases. Memory overhead tends to grow with container size. 
 
   val MEMORY_OVERHEAD_FACTOR = 0.07
-  val MEMORY_OVERHEAD_MIN = 384
+  val MEMORY_OVERHEAD_MIN_MB = 384
 
   val ANY_HOST = "*"
 


### PR DESCRIPTION
- let it be specified as a fraction of the executor memory
- add/generalize some utilities for parsing "memory strings" that are found around the Spark codebase.

fixes SPARK-4665 and SPARK-4666.
