### PR TITLE
Fix wrong file name pattern in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,7 @@ dependency-reduced-pom.xml
 checkpoint
 derby.log
 dist/
-spark-*-bin.tar.gz
+spark-*-bin-*.tgz
 unit-tests.log
 /lib/
 rat-results.txt


### PR DESCRIPTION
In .gitignore, there is an entry for spark-_-bin.tar.gz but considering make-distribution.sh, the name pattern should be spark-_-bin-*.tgz.

This change is really small so I don't open issue in JIRA. If it's needed, please let me know.
