### PR TITLE
Add project-build-information to package

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -29,6 +29,8 @@
   <artifactId>spark-core_2.10</artifactId>
   <properties>
     <sbt.project.name>core</sbt.project.name>
+    <timestamp>${maven.build.timestamp}</timestamp>
+    <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
   </properties>
   <packaging>jar</packaging>
   <name>Spark Project Core</name>
@@ -431,6 +433,17 @@
     <resources>
       <resource>
         <directory>src/main/resources</directory>
+        <excludes>
+          <exclude>spark-version.properties</exclude>
+        </excludes>
+        <filtering>false</filtering>
+      </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+        <includes>
+          <include>spark-version.properties</include>
+        </includes>
+        <filtering>true</filtering>
       </resource>
       <resource>
         <directory>../python</directory>

--- a/core/src/main/resources/spark-version.properties
+++ b/core/src/main/resources/spark-version.properties
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version=${project.version}
+date=${timestamp}


### PR DESCRIPTION
When building spark,  add a file about version and build-time of project to package. 
