### PR TITLE
[SPARK-4695][SQL] Get result using executeCollect

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -377,7 +377,7 @@ class HiveContext(sc: SparkContext) extends SQLContext(sc) {
         command.executeCollect().map(_.head.toString)
 
       case other =>
-        val result: Seq[Seq[Any]] = toRdd.map(_.copy()).collect().toSeq
+        val result: Seq[Seq[Any]] = other.executeCollect().toSeq
         // We need the types so we can output struct field names
         val types = analyzed.output.map(_.dataType)
         // Reformat to match hive tab delimited output.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -416,6 +416,8 @@ object HiveContext {
     case (bin: Array[Byte], BinaryType) => new String(bin, "UTF-8")
     case (decimal: Decimal, DecimalType()) =>  // Hive strips trailing zeros so use its toString
       HiveShim.createDecimal(decimal.toBigDecimal.underlying()).toString
+    case (decimal: BigDecimal, DecimalType()) =>
+      HiveShim.createDecimal(decimal.underlying()).toString
     case (other, tpe) if primitiveTypes contains tpe => other.toString
     case (a, b) => println(a.getClass); println(b.getClass);
       println(a.toString + " " + b.toString);

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -419,9 +419,6 @@ object HiveContext {
     case (decimal: BigDecimal, DecimalType()) =>
       HiveShim.createDecimal(decimal.underlying()).toString
     case (other, tpe) if primitiveTypes contains tpe => other.toString
-    case (a, b) => println(a.getClass); println(b.getClass);
-      println(a.toString + " " + b.toString);
-      a.toString + " " + b.toString;
   }
 
   /** Hive outputs fields of structs slightly differently than top level attributes. */

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -417,6 +417,9 @@ object HiveContext {
     case (decimal: Decimal, DecimalType()) =>  // Hive strips trailing zeros so use its toString
       HiveShim.createDecimal(decimal.toBigDecimal.underlying()).toString
     case (other, tpe) if primitiveTypes contains tpe => other.toString
+    case (a, b) => println(a.getClass); println(b.getClass);
+      println(a.toString + " " + b.toString);
+      a.toString + " " + b.toString;
   }
 
   /** Hive outputs fields of structs slightly differently than top level attributes. */


### PR DESCRIPTION
Using `executeCollect` to collect the result, because executeCollect is a custom implementation of collect in spark sql which better than rdd's collect
