### PR TITLE
[SPARK-4498][SPARK-2424] [WIP] Add driver -> master heartbeat to detect exited applications and fix executor failure detection logic

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/ApplicationDescription.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/ApplicationDescription.scala
@@ -23,6 +23,7 @@ private[spark] class ApplicationDescription(
     val memoryPerSlave: Int,
     val command: Command,
     var appUiUrl: String,
+    val heartbeatInterval: Int,
     val eventLogDir: Option[String] = None)
   extends Serializable {
 

--- a/core/src/main/scala/org/apache/spark/deploy/ApplicationDescription.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/ApplicationDescription.scala
@@ -24,6 +24,7 @@ private[spark] class ApplicationDescription(
     val command: Command,
     var appUiUrl: String,
     val heartbeatInterval: Int,
+    val consecutiveExecutorFailuresThreshold: Int,
     val eventLogDir: Option[String] = None)
   extends Serializable {
 

--- a/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
@@ -146,6 +146,12 @@ private[deploy] object DeployMessages {
 
   case object StopAppClient
 
+  /**
+    * Message sent from the heartbeat timer thread to trigger the sending of a heartbeat to the
+    * Master. This is necessary for proper thread-safety
+    */
+  case object TriggerHeartbeat
+
   // Master to Worker & AppClient
 
   case class MasterChanged(masterUrl: String, masterWebUiUrl: String)

--- a/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
@@ -104,10 +104,12 @@ private[deploy] object DeployMessages {
   /**
    * Periodic heartbeat from the app client to the master, used to detect driver death and to
    * detect drivers that have not obtained any usable executors.
+   *
    * @param appId the application id.
-   * @param hasExecutors true if the app client has at least one running executor, false otherwise.
+   * @param hasRegisteredExecutors true if the app client has at least one registered executor,
+   *                               false otherwise.
    */
-  case class AppClientHeartbeat(appId: String, hasExecutors: Boolean)
+  case class AppClientHeartbeat(appId: String, hasRegisteredExecutors: Boolean)
 
   // Master to AppClient
 

--- a/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
@@ -101,6 +101,14 @@ private[deploy] object DeployMessages {
 
   case class MasterChangeAcknowledged(appId: String)
 
+  /**
+   * Periodic heartbeat from the app client to the master, used to detect driver death and to
+   * detect drivers that have not obtained any usable executors.
+   * @param appId the application id.
+   * @param hasExecutors true if the app client has at least one running executor, false otherwise.
+   */
+  case class AppClientHeartbeat(appId: String, hasExecutors: Boolean)
+
   // Master to AppClient
 
   case class RegisteredApplication(appId: String, masterUrl: String) extends DeployMessage

--- a/core/src/main/scala/org/apache/spark/deploy/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/JsonProtocol.scala
@@ -48,7 +48,8 @@ private[spark] object JsonProtocol {
     ("memoryperslave" -> obj.desc.memoryPerSlave) ~
     ("submitdate" -> obj.submitDate.toString) ~
     ("state" -> obj.state.toString) ~
-    ("duration" -> obj.duration)
+    ("duration" -> obj.duration) ~
+    ("lastheartbeat" -> obj.lastHeartbeat)
   }
 
   def writeApplicationDescription(obj: ApplicationDescription) = {
@@ -56,7 +57,8 @@ private[spark] object JsonProtocol {
     ("cores" -> obj.maxCores) ~
     ("memoryperslave" -> obj.memoryPerSlave) ~
     ("user" -> obj.user) ~
-    ("command" -> obj.command.toString)
+    ("command" -> obj.command.toString) ~
+    ("heartbeatinterval" -> obj.heartbeatInterval)
   }
 
   def writeExecutorRunner(obj: ExecutorRunner) = {

--- a/core/src/main/scala/org/apache/spark/deploy/client/AppClient.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/client/AppClient.scala
@@ -130,10 +130,10 @@ private[spark] class AppClient(
       heartbeatTimer = Some(
         context.system.scheduler.schedule(heartbeatInterval, heartbeatInterval) {
           if (master != null) {  // guard against race condition while switching masters
-            val hasExecutors = runningExecutors.synchronized {
+            val hasRegisteredExecutors = runningExecutors.synchronized {
               runningExecutors.nonEmpty
             }
-            master ! AppClientHeartbeat(appId, hasExecutors)
+            master ! AppClientHeartbeat(appId, hasRegisteredExecutors)
           }
         }
       )

--- a/core/src/main/scala/org/apache/spark/deploy/client/AppClient.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/client/AppClient.scala
@@ -59,7 +59,7 @@ private[spark] class AppClient(
   var registered = false
   var activeMasterUrl: String = null
 
-  /** Tracks the set of executors currently assigned to this application. */
+  /** Tracks the set of executors currently registered with this application. */
   private val runningExecutors = mutable.BitSet()
 
   class ClientActor extends Actor with ActorLogReceive with Logging {
@@ -147,9 +147,7 @@ private[spark] class AppClient(
         val fullId = appId + "/" + id
         logInfo("Executor added: %s on %s (%s) with %d cores".format(fullId, workerId, hostPort,
           cores))
-        runningExecutors.synchronized {
-          runningExecutors += id
-        }
+        runningExecutors += id
         listener.executorAdded(fullId, workerId, hostPort, cores, memory)
 
       case ExecutorUpdated(id, state, message, exitStatus) =>
@@ -157,9 +155,7 @@ private[spark] class AppClient(
         val messageText = message.map(s => " (" + s + ")").getOrElse("")
         logInfo("Executor updated: %s is now %s%s".format(fullId, state, messageText))
         if (ExecutorState.isFinished(state)) {
-          runningExecutors.synchronized {
-            runningExecutors -= id
-          }
+          runningExecutors -= id
           listener.executorRemoved(fullId, message.getOrElse(""), exitStatus)
         }
 

--- a/core/src/main/scala/org/apache/spark/deploy/client/TestClient.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/client/TestClient.scala
@@ -49,7 +49,8 @@ private[spark] object TestClient {
     val (actorSystem, _) = AkkaUtils.createActorSystem("spark", Utils.localIpAddress, 0,
       conf = conf, securityManager = new SecurityManager(conf))
     val desc = new ApplicationDescription("TestClient", Some(1), 512,
-      Command("spark.deploy.client.TestExecutor", Seq(), Map(), Seq(), Seq(), Seq()), "ignored")
+      Command("spark.deploy.client.TestExecutor", Seq(), Map(), Seq(), Seq(), Seq()), "ignored",
+      10000)
     val listener = new TestListener
     val client = new AppClient(actorSystem, Array(url), desc, listener, new SparkConf)
     client.start()

--- a/core/src/main/scala/org/apache/spark/deploy/client/TestClient.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/client/TestClient.scala
@@ -50,7 +50,7 @@ private[spark] object TestClient {
       conf = conf, securityManager = new SecurityManager(conf))
     val desc = new ApplicationDescription("TestClient", Some(1), 512,
       Command("spark.deploy.client.TestExecutor", Seq(), Map(), Seq(), Seq(), Seq()), "ignored",
-      10000)
+      10000, 10)
     val listener = new TestListener
     val client = new AppClient(actorSystem, Array(url), desc, listener, new SparkConf)
     client.start()

--- a/core/src/main/scala/org/apache/spark/deploy/master/ApplicationFailureDetector.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ApplicationFailureDetector.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.master
+
+import org.apache.spark.Logging
+
+/**
+ * This class encapsulates the Worker's logic for deciding whether to kill a Spark application
+ * based on executor failures.  The goal of this logic is to ensure that buggy applications are
+ * killed in a prompt manner, while preventing applications from being killed due to buggy
+ * machines / executors.
+ *
+ * Thread-safety: this class is not thread-safe because it is only intended to be called
+ * from the Master actor.
+ */
+private[master] class ApplicationFailureDetector(
+    appName: String,
+    appId: String)
+  extends Logging with Serializable {
+
+  private val MAX_RETRIES = 10
+
+  private var retryCount = 0
+
+  /**
+   * Called when an executor enters the RUNNING state.
+   */
+  def onExecutorRunning(execId: Int): Unit = {
+    retryCount = 0
+  }
+
+  /**
+   * Called when an executor exits due to a failure.
+   */
+  def onFailedExecutorExit(execId: Int): Unit = {
+    retryCount += 1
+  }
+
+  /**
+   * Ask the failure detector whether the application should be marked as failed.
+   *
+   * @param someExecutorIsRunning true if _some_ executor is in the RUNNING state, false otherwise.
+   * @return true if the application has failed, false otherwise.
+   */
+  def isFailed(someExecutorIsRunning: Boolean): Boolean = {
+    if (retryCount >= MAX_RETRIES && !someExecutorIsRunning) {
+      logError(s"Application $appName with ID $appId is failed " +
+        s"because executors failed $retryCount times")
+      true
+    } else {
+      false
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/deploy/master/ApplicationFailureDetector.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ApplicationFailureDetector.scala
@@ -38,16 +38,16 @@ private[master] class ApplicationFailureDetector(
   private var consecutiveExecutorFailures = 0
 
   /**
-   * True if the driver has reported that it has at least one running executor, false otherwise.
+   * True if the driver has reported that it has at least one registered executor, false otherwise.
    */
-  private var hasRunningExecutors: Boolean = false
+  private var hasRegisteredExecutors: Boolean = false
 
   /**
    * Called when an application's executor status might have changed.
    */
-  def updateExecutorStatus(_hasRunningExecutors: Boolean): Unit = {
-    hasRunningExecutors = _hasRunningExecutors
-    if (hasRunningExecutors) {
+  def updateExecutorStatus(hasRegisteredExecutors: Boolean): Unit = {
+    this.hasRegisteredExecutors = hasRegisteredExecutors
+    if (hasRegisteredExecutors) {
       consecutiveExecutorFailures = 0
     }
   }
@@ -65,7 +65,7 @@ private[master] class ApplicationFailureDetector(
    * @return true if the application has failed, false otherwise.
    */
   def isFailed: Boolean = {
-    if (consecutiveExecutorFailures >= MAX_CONSECUTIVE_FAILURES && !hasRunningExecutors) {
+    if (consecutiveExecutorFailures >= MAX_CONSECUTIVE_FAILURES && !hasRegisteredExecutors) {
       logError(s"Application $appName with ID $appId is failed because it has no executors and " +
         s"there were $consecutiveExecutorFailures consecutive executor failures")
       true

--- a/core/src/main/scala/org/apache/spark/deploy/master/ApplicationInfo.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ApplicationInfo.scala
@@ -47,7 +47,8 @@ private[spark] class ApplicationInfo(
 
   @transient private var nextExecutorId: Int = _
 
-  val failureDetector = new ApplicationFailureDetector(desc.name, id)
+  val failureDetector =
+    new ApplicationFailureDetector(desc.name, id, desc.consecutiveExecutorFailuresThreshold)
 
   init()
 

--- a/core/src/main/scala/org/apache/spark/deploy/master/ApplicationInfo.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ApplicationInfo.scala
@@ -43,6 +43,7 @@ private[spark] class ApplicationInfo(
   @transient var coresGranted: Int = _
   @transient var endTime: Long = _
   @transient var appSource: ApplicationSource = _
+  @transient var lastHeartbeat: Long = _
 
   @transient private var nextExecutorId: Int = _
 
@@ -63,6 +64,7 @@ private[spark] class ApplicationInfo(
     appSource = new ApplicationSource(this)
     nextExecutorId = 0
     removedExecutors = new ArrayBuffer[ExecutorInfo]
+    lastHeartbeat = System.currentTimeMillis()
   }
 
   private def newExecutorId(useID: Option[Int] = None): Int = {

--- a/core/src/main/scala/org/apache/spark/deploy/master/ApplicationInfo.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ApplicationInfo.scala
@@ -46,6 +46,8 @@ private[spark] class ApplicationInfo(
 
   @transient private var nextExecutorId: Int = _
 
+  val failureDetector = new ApplicationFailureDetector(desc.name, id)
+
   init()
 
   private def readObject(in: java.io.ObjectInputStream): Unit = Utils.tryOrIOException {
@@ -93,17 +95,6 @@ private[spark] class ApplicationInfo(
   private val myMaxCores = desc.maxCores.getOrElse(defaultCores)
 
   def coresLeft: Int = myMaxCores - coresGranted
-
-  private var _retryCount = 0
-
-  def retryCount = _retryCount
-
-  def incrementRetryCount() = {
-    _retryCount += 1
-    _retryCount
-  }
-
-  def resetRetryCount() = _retryCount = 0
 
   def markFinished(endState: ApplicationState.Value) {
     state = endState

--- a/core/src/main/scala/org/apache/spark/deploy/master/ApplicationState.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ApplicationState.scala
@@ -22,6 +22,4 @@ private[spark] object ApplicationState extends Enumeration {
   type ApplicationState = Value
 
   val WAITING, RUNNING, FINISHED, FAILED, UNKNOWN = Value
-
-  val MAX_NUM_RETRY = 10
 }

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -360,12 +360,13 @@ private[spark] class Master(
       }
     }
 
-    case AppClientHeartbeat(appId, hasExecutors) => {
+    case AppClientHeartbeat(appId, hasRegisteredExecutors) => {
       idToApp.get(appId) match {
         case Some(app) =>
           app.lastHeartbeat = System.currentTimeMillis()
-          app.failureDetector.updateExecutorStatus(hasExecutors)
-          logDebug(s"Got heartbeat from app $appId (hasExecutors = $hasExecutors)")
+          app.failureDetector.updateExecutorStatus(hasRegisteredExecutors)
+          logDebug(s"Got heartbeat from app $appId " +
+            s"(hasRegisteredExecutors = $hasRegisteredExecutors)")
         case None =>
           logWarning(s"Got heartbeat from unknown app $appId")
       }

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -770,8 +770,8 @@ private[spark] class Master(
     appId
   }
 
-  /** Check for, and remove, and dead applications */
-  def timeOutDeadApplications() {
+  /** Check for, and remove, any dead applications */
+  def timeOutDeadApplications(): Unit = {
     val currentTime = System.currentTimeMillis()
     // Copy the applications into an array so we don't modify the hashset while iterating through it
     val toRemove =
@@ -784,7 +784,7 @@ private[spark] class Master(
   }
 
   /** Check for, and remove, any timed-out workers */
-  def timeOutDeadWorkers() {
+  def timeOutDeadWorkers(): Unit = {
     // Copy the workers into an array so we don't modify the hashset while iterating through it
     val currentTime = System.currentTimeMillis()
     val toRemove = workers.filter(_.lastHeartbeat < currentTime - WORKER_TIMEOUT).toArray

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -415,7 +415,7 @@ private[spark] class Master(
       // The disconnected client could've been either a worker or an app; remove whichever it was
       logInfo(s"$address got disassociated, removing it.")
       addressToWorker.get(address).foreach(removeWorker)
-      //addressToApp.get(address).foreach(finishApplication)
+      addressToApp.get(address).foreach(finishApplication)
       if (state == RecoveryState.RECOVERING && canCompleteRecovery) { completeRecovery() }
     }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
@@ -69,7 +69,7 @@ private[spark] class SparkDeploySchedulerBackend(
     val command = Command("org.apache.spark.executor.CoarseGrainedExecutorBackend",
       args, sc.executorEnvs, classPathEntries, libraryPathEntries, javaOpts)
     val appUIAddress = sc.ui.map(_.appUIAddress).getOrElse("")
-    val heartbeatInterval = conf.getInt("spark.app.heartbeatInterval", 10000)
+    val heartbeatInterval = conf.getInt("spark.app.heartbeatInterval", 60000)
     val appDesc = new ApplicationDescription(sc.appName, maxCores, sc.executorMemory, command,
       appUIAddress, heartbeatInterval, sc.eventLogDir)
 

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
@@ -69,8 +69,9 @@ private[spark] class SparkDeploySchedulerBackend(
     val command = Command("org.apache.spark.executor.CoarseGrainedExecutorBackend",
       args, sc.executorEnvs, classPathEntries, libraryPathEntries, javaOpts)
     val appUIAddress = sc.ui.map(_.appUIAddress).getOrElse("")
+    val heartbeatInterval = conf.getInt("spark.app.heartbeatInterval", 10000)
     val appDesc = new ApplicationDescription(sc.appName, maxCores, sc.executorMemory, command,
-      appUIAddress, sc.eventLogDir)
+      appUIAddress, heartbeatInterval, sc.eventLogDir)
 
     client = new AppClient(sc.env.actorSystem, masters, appDesc, this, conf)
     client.start()

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
@@ -70,8 +70,11 @@ private[spark] class SparkDeploySchedulerBackend(
       args, sc.executorEnvs, classPathEntries, libraryPathEntries, javaOpts)
     val appUIAddress = sc.ui.map(_.appUIAddress).getOrElse("")
     val heartbeatInterval = conf.getInt("spark.app.heartbeatInterval", 60000)
+    val consecutiveExecutorFailuresThreshold =
+      conf.getInt("spark.app.consecutiveExecutorFailuresThreshold", 10)
     val appDesc = new ApplicationDescription(sc.appName, maxCores, sc.executorMemory, command,
-      appUIAddress, heartbeatInterval, sc.eventLogDir)
+      appUIAddress, heartbeatInterval = heartbeatInterval,
+      consecutiveExecutorFailuresThreshold = consecutiveExecutorFailuresThreshold, sc.eventLogDir)
 
     client = new AppClient(sc.env.actorSystem, masters, appDesc, this, conf)
     client.start()

--- a/core/src/test/scala/org/apache/spark/deploy/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/JsonProtocolSuite.scala
@@ -89,7 +89,7 @@ class JsonProtocolSuite extends FunSuite {
 
   def createAppDesc(): ApplicationDescription = {
     val cmd = new Command("mainClass", List("arg1", "arg2"), Map(), Seq(), Seq(), Seq())
-    new ApplicationDescription("name", Some(4), 1234, cmd, "appUiUrl", 10000)
+    new ApplicationDescription("name", Some(4), 1234, cmd, "appUiUrl", 10000, 10)
   }
 
   def createAppInfo() : ApplicationInfo = {

--- a/core/src/test/scala/org/apache/spark/deploy/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/JsonProtocolSuite.scala
@@ -89,13 +89,14 @@ class JsonProtocolSuite extends FunSuite {
 
   def createAppDesc(): ApplicationDescription = {
     val cmd = new Command("mainClass", List("arg1", "arg2"), Map(), Seq(), Seq(), Seq())
-    new ApplicationDescription("name", Some(4), 1234, cmd, "appUiUrl")
+    new ApplicationDescription("name", Some(4), 1234, cmd, "appUiUrl", 10000)
   }
 
   def createAppInfo() : ApplicationInfo = {
     val appInfo = new ApplicationInfo(JsonConstants.appInfoStartTime,
       "id", createAppDesc(), JsonConstants.submitDate, null, Int.MaxValue)
     appInfo.endTime = JsonConstants.currTimeInMillis
+    appInfo.lastHeartbeat = JsonConstants.currTimeInMillis
     appInfo
   }
 
@@ -155,9 +156,9 @@ object JsonConstants {
       |{"starttime":3,"id":"id","name":"name",
       |"cores":4,"user":"%s",
       |"memoryperslave":1234,"submitdate":"%s",
-      |"state":"WAITING","duration":%d}
+      |"state":"WAITING","duration":%d,"lastheartbeat":%d}
     """.format(System.getProperty("user.name", "<unknown>"),
-        submitDate.toString, currTimeInMillis - appInfoStartTime).stripMargin
+        submitDate.toString, currTimeInMillis - appInfoStartTime, currTimeInMillis).stripMargin
 
   val workerInfoJsonStr =
     """
@@ -171,7 +172,8 @@ object JsonConstants {
   val appDescJsonStr =
     """
       |{"name":"name","cores":4,"memoryperslave":1234,
-      |"user":"%s","command":"Command(mainClass,List(arg1, arg2),Map(),List(),List(),List())"}
+      |"user":"%s","command":"Command(mainClass,List(arg1, arg2),Map(),List(),List(),List())",
+      |"heartbeatinterval": 10000}
     """.format(System.getProperty("user.name", "<unknown>")).stripMargin
 
   val executorRunnerJsonStr =

--- a/core/src/test/scala/org/apache/spark/deploy/master/ApplicationFailureDetectorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/master/ApplicationFailureDetectorSuite.scala
@@ -19,16 +19,15 @@ package org.apache.spark.deploy.master
 
 import org.scalatest.{FunSuite, Matchers}
 
-
 class ApplicationFailureDetectorSuite extends FunSuite with Matchers {
 
   test("initially, the application should not be failed") {
-    val failureDetector = new ApplicationFailureDetector("testApp", "testAppId")
+    val failureDetector = new ApplicationFailureDetector("testApp", "testAppId", 10)
     assert(!failureDetector.isFailed)
   }
 
   test("normal operation (no executor failures)") {
-    val failureDetector = new ApplicationFailureDetector("testApp", "testAppId")
+    val failureDetector = new ApplicationFailureDetector("testApp", "testAppId", 10)
     for (execId <- 1 to 100) {
       failureDetector.updateExecutorStatus(hasRegisteredExecutors = true)
       assert(!failureDetector.isFailed)
@@ -37,7 +36,7 @@ class ApplicationFailureDetectorSuite extends FunSuite with Matchers {
   }
 
   test("every other executor launch fails") {
-    val failureDetector = new ApplicationFailureDetector("testApp", "testAppId")
+    val failureDetector = new ApplicationFailureDetector("testApp", "testAppId", 10)
     for (execId <- 1 to 100) {
       failureDetector.updateExecutorStatus(hasRegisteredExecutors = true)
       assert(!failureDetector.isFailed)
@@ -50,7 +49,7 @@ class ApplicationFailureDetectorSuite extends FunSuite with Matchers {
   }
 
   test("every executor fails after launch") {
-    val failureDetector = new ApplicationFailureDetector("testApp", "testAppId")
+    val failureDetector = new ApplicationFailureDetector("testApp", "testAppId", 10)
     var failed: Boolean = false
     for (execId <- 1 to 100) {
       failureDetector.updateExecutorStatus(hasRegisteredExecutors = false)

--- a/core/src/test/scala/org/apache/spark/deploy/master/ApplicationFailureDetectorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/master/ApplicationFailureDetectorSuite.scala
@@ -30,16 +30,16 @@ class ApplicationFailureDetectorSuite extends FunSuite with Matchers {
   test("normal operation (no executor failures)") {
     val failureDetector = new ApplicationFailureDetector("testApp", "testAppId")
     for (execId <- 1 to 100) {
-      failureDetector.updateExecutorStatus(_hasRunningExecutors = true)
+      failureDetector.updateExecutorStatus(hasRegisteredExecutors = true)
       assert(!failureDetector.isFailed)
     }
     assert(!failureDetector.isFailed)
   }
 
-  test("some executor failures") {
+  test("every other executor launch fails") {
     val failureDetector = new ApplicationFailureDetector("testApp", "testAppId")
     for (execId <- 1 to 100) {
-      failureDetector.updateExecutorStatus(_hasRunningExecutors = true)
+      failureDetector.updateExecutorStatus(hasRegisteredExecutors = true)
       assert(!failureDetector.isFailed)
       if (execId % 2 == 0) {
         failureDetector.onFailedExecutorExit(execId)
@@ -53,7 +53,7 @@ class ApplicationFailureDetectorSuite extends FunSuite with Matchers {
     val failureDetector = new ApplicationFailureDetector("testApp", "testAppId")
     var failed: Boolean = false
     for (execId <- 1 to 100) {
-      failureDetector.updateExecutorStatus(_hasRunningExecutors = false)
+      failureDetector.updateExecutorStatus(hasRegisteredExecutors = false)
       failureDetector.onFailedExecutorExit(execId)
       if (failureDetector.isFailed) {
         failed = true

--- a/core/src/test/scala/org/apache/spark/deploy/worker/ExecutorRunnerTest.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/worker/ExecutorRunnerTest.scala
@@ -31,7 +31,7 @@ class ExecutorRunnerTest extends FunSuite {
     val appId = "12345-worker321-9876"
     val sparkHome = sys.props.getOrElse("spark.test.home", fail("spark.test.home is not set!"))
     val appDesc = new ApplicationDescription("app name", Some(8), 500,
-      Command("foo", Seq(appId), Map(), Seq(), Seq(), Seq()), "appUiUrl", 10000)
+      Command("foo", Seq(appId), Map(), Seq(), Seq(), Seq()), "appUiUrl", 10000, 10)
     val er = new ExecutorRunner(appId, 1, appDesc, 8, 500, null, "blah", "worker321",
       new File(sparkHome), new File("ooga"), "blah", new SparkConf, ExecutorState.RUNNING)
     val builder = CommandUtils.buildProcessBuilder(appDesc.command, 512, sparkHome, er.substituteVariables)

--- a/core/src/test/scala/org/apache/spark/deploy/worker/ExecutorRunnerTest.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/worker/ExecutorRunnerTest.scala
@@ -31,7 +31,7 @@ class ExecutorRunnerTest extends FunSuite {
     val appId = "12345-worker321-9876"
     val sparkHome = sys.props.getOrElse("spark.test.home", fail("spark.test.home is not set!"))
     val appDesc = new ApplicationDescription("app name", Some(8), 500,
-      Command("foo", Seq(appId), Map(), Seq(), Seq(), Seq()), "appUiUrl")
+      Command("foo", Seq(appId), Map(), Seq(), Seq(), Seq()), "appUiUrl", 10000)
     val er = new ExecutorRunner(appId, 1, appDesc, 8, 500, null, "blah", "worker321",
       new File(sparkHome), new File("ooga"), "blah", new SparkConf, ExecutorState.RUNNING)
     val builder = CommandUtils.buildProcessBuilder(appDesc.command, 512, sparkHome, er.substituteVariables)


### PR DESCRIPTION
This is a WIP fix for SPARK-4498; this isn't the final fix that I want to merge in, but I'm submitting this now to get early feedback from Jenkins and reviewers.  The main idea here is to add a periodic driver -> master heartbeat that both signals driver liveness and carries information on whether it the driver has received executors, which allows us to implement proper "don't kill an application due to failed executors as long as it has some running executors" logic in the master.

See discussion at https://issues.apache.org/jira/browse/SPARK-4498 for context.

Before merging, this needs more comments and tests.  Specifically, I need tests to check that the heartbeat's information actually corresponds to the right notion of application progress / liveness.  There's also open questions about heartbeat interval configuration and failure thresholds.  I'll edit this description to accurately reflect the PR before I remove the `[WIP]` tag.

/cc @markhamstra @aarondav @andrewor14 @pwendell @airhorns
