### PR TITLE
[SPARK-4669]Allow users to set arbitrary akka configurations via property file

### DIFF
--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -51,7 +51,7 @@ private[spark] class MapOutputTrackerMasterActor(tracker: MapOutputTrackerMaster
       val serializedSize = mapOutputStatuses.size
       if (serializedSize > maxAkkaFrameSize) {
         val msg = s"Map output statuses were $serializedSize bytes which " +
-          s"exceeds spark.akka.frameSize ($maxAkkaFrameSize bytes)."
+          s"exceeds spark.akka.remote.netty.tcp.maximum-frame-size ($maxAkkaFrameSize bytes)."
 
         /* For SPARK-1244 we'll opt for just logging an error and then throwing an exception.
          * Note that on exception the actor will just restart. A bigger refactoring (SPARK-1239)

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -216,6 +216,7 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging {
      *   E.g. spark.akka.option.x.y.x = "value"
      */
     getAll.filter { case (k, _) => isAkkaConf(k) }
+        .map { case (k, v) => (k.substring(k.indexOf("akka")), v) }
 
   /**
    * Returns the Spark application id, valid in the Driver after TaskScheduler registration and
@@ -354,7 +355,7 @@ private[spark] object SparkConf {
    * Return whether the given config is an akka config (e.g. akka.actor.provider).
    * Note that this does not include spark-specific akka configs (e.g. spark.akka.timeout).
    */
-  def isAkkaConf(name: String): Boolean = name.startsWith("akka.")
+  def isAkkaConf(name: String): Boolean = name.startsWith("spark.akka.")
 
   /**
    * Return whether the given config should be passed to an executor on start-up.
@@ -364,7 +365,6 @@ private[spark] object SparkConf {
    */
   def isExecutorStartupConf(name: String): Boolean = {
     isAkkaConf(name) ||
-    name.startsWith("spark.akka") ||
     name.startsWith("spark.auth") ||
     isSparkPortConf(name)
   }

--- a/core/src/main/scala/org/apache/spark/deploy/Client.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/Client.scala
@@ -151,10 +151,10 @@ object Client {
     val driverArgs = new ClientArguments(args)
 
     if (!driverArgs.logLevel.isGreaterOrEqual(Level.WARN)) {
-      conf.set("spark.akka.logLifecycleEvents", "true")
+      conf.set("spark.akka.remote.log-remote-lifecycle-events", "true")
     }
-    conf.set("spark.akka.askTimeout", "10")
-    conf.set("akka.loglevel", driverArgs.logLevel.toString.replace("WARN", "WARNING"))
+    conf.set("spark.internal.akka.askTimeout", "10")
+    conf.set("spark.akka.loglevel", driverArgs.logLevel.toString.replace("WARN", "WARNING"))
     Logger.getRootLogger.setLevel(driverArgs.logLevel)
 
     val (actorSystem, _) = AkkaUtils.createActorSystem(

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -182,8 +182,9 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val actorSyste
           scheduler.activeTaskSets.get(taskSetId).foreach { taskSet =>
             try {
               var msg = "Serialized task %s:%d was %d bytes, which exceeds max allowed: " +
-                "spark.akka.frameSize (%d bytes) - reserved (%d bytes). Consider increasing " +
-                "spark.akka.frameSize or using broadcast variables for large values."
+                "spark.akka.remote.netty.tcp.maximum-frame-size (%d bytes) - reserved (%d bytes). " +
+                "Consider increasing spark.akka.remote.netty.tcp.maximum-frame-size " +
+                "or using broadcast variables for large values."
               msg = msg.format(task.taskId, task.index, serializedTask.limit, akkaFrameSize,
                 AkkaUtils.reservedSizeBytes)
               taskSet.abort(msg)

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -182,8 +182,8 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val actorSyste
           scheduler.activeTaskSets.get(taskSetId).foreach { taskSet =>
             try {
               var msg = "Serialized task %s:%d was %d bytes, which exceeds max allowed: " +
-                "spark.akka.remote.netty.tcp.maximum-frame-size (%d bytes) - reserved (%d bytes). " +
-                "Consider increasing spark.akka.remote.netty.tcp.maximum-frame-size " +
+                "spark.akka.remote.netty.tcp.maximum-frame-size (%d bytes) - reserved (%d bytes)." +
+                " Consider increasing spark.akka.remote.netty.tcp.maximum-frame-size " +
                 "or using broadcast variables for large values."
               msg = msg.format(task.taskId, task.index, serializedTask.limit, akkaFrameSize,
                 AkkaUtils.reservedSizeBytes)

--- a/core/src/main/scala/org/apache/spark/util/AkkaUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/AkkaUtils.scala
@@ -130,6 +130,7 @@ private[spark] object AkkaUtils extends Logging {
       throw new IllegalArgumentException("spark.akka.remote.netty.tcp.maximum-frame-size " +
           "should not be greater than " + Int.MaxValue + "B")
     }
+    ret
   }
 
   /** Space reserved for extra data in an Akka message besides serialized task or task result. */

--- a/core/src/main/scala/org/apache/spark/util/AkkaUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/AkkaUtils.scala
@@ -63,8 +63,8 @@ private[spark] object AkkaUtils extends Logging {
       conf: SparkConf,
       securityManager: SecurityManager): (ActorSystem, Int) = {
 
-    val akkaLogLifecycleEvents = conf.getBoolean("spark.akka.remote.log-remote-lifecycle-events", false)
-    if (!akkaLogLifecycleEvents) {
+    val akkaLogLifecycleEvents = conf.get("spark.akka.remote.log-remote-lifecycle-events", "off")
+    if (akkaLogLifecycleEvents == "on") {
       // As a workaround for Akka issue #3787, we coerce the "EndpointWriter" log to be silent.
       // See: https://www.assembla.com/spaces/akka/tickets/3787#/
       Option(Logger.getLogger("akka.remote.EndpointWriter")).map(l => l.setLevel(Level.FATAL))

--- a/core/src/main/scala/org/apache/spark/util/AkkaUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/AkkaUtils.scala
@@ -103,7 +103,7 @@ private[spark] object AkkaUtils extends Logging {
       |akka.remote.log-remote-lifecycle-events = off
       |akka.log-dead-letters = off
       |akka.log-dead-letters-during-shutdown = off
-      """.stripMargin).withFallback(conf.getAkkaConf.toMap[String, String])
+      """.stripMargin).withFallback(ConfigFactory.parseMap(conf.getAkkaConf.toMap[String, String]))
 
     val actorSystem = ActorSystem(name, akkaConf)
     val provider = actorSystem.asInstanceOf[ExtendedActorSystem].provider

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -153,8 +153,8 @@ class MapOutputTrackerSuite extends FunSuite {
 
   test("remote fetch below akka frame size") {
     val newConf = new SparkConf
-    newConf.set("spark.akka.frameSize", "1")
-    newConf.set("spark.akka.askTimeout", "1") // Fail fast
+    newConf.set("spark.akka.remote.netty.tcp.maximum-frame-size", "1048576b")
+    newConf.set("spark.internal.akka.askTimeout", "1") // Fail fast
 
     val masterTracker = new MapOutputTrackerMaster(conf)
     val actorSystem = ActorSystem("test")
@@ -174,8 +174,8 @@ class MapOutputTrackerSuite extends FunSuite {
 
   test("remote fetch exceeds akka frame size") {
     val newConf = new SparkConf
-    newConf.set("spark.akka.frameSize", "1")
-    newConf.set("spark.akka.askTimeout", "1") // Fail fast
+    newConf.set("spark.akka.remote.netty.tcp.maximum-frame-size", "1048576b")
+    newConf.set("spark.internal.akka.askTimeout", "1") // Fail fast
 
     val masterTracker = new MapOutputTrackerMaster(conf)
     val actorSystem = ActorSystem("test")

--- a/core/src/test/scala/org/apache/spark/scheduler/CoarseGrainedSchedulerBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/CoarseGrainedSchedulerBackendSuite.scala
@@ -26,7 +26,7 @@ class CoarseGrainedSchedulerBackendSuite extends FunSuite with LocalSparkContext
 
   test("serialized task larger than akka frame size") {
     val conf = new SparkConf
-    conf.set("spark.akka.frameSize","1")
+    conf.set("spark.akka.remote.netty.tcp.maximum-frame-size","1048576b")
     conf.set("spark.default.parallelism","1")
     sc = new SparkContext("local-cluster[2 , 1 , 512]", "test", conf)
     val frameSize = AkkaUtils.maxFrameSizeBytes(sc.conf)

--- a/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
@@ -39,7 +39,7 @@ class SparkListenerSuite extends FunSuite with LocalSparkContext with Matchers
   }
 
   override def afterAll() {
-    System.clearProperty("spark.akka.frameSize")
+    System.clearProperty("spark.akka.remote.netty.tcp.maximum-frame-size")
   }
 
   test("basic creation and shutdown of LiveListenerBus") {
@@ -273,7 +273,7 @@ class SparkListenerSuite extends FunSuite with LocalSparkContext with Matchers
     sc.addSparkListener(listener)
 
     // Make a task whose result is larger than the akka frame size
-    System.setProperty("spark.akka.frameSize", "1")
+    System.setProperty("spark.akka.remote.netty.tcp.maximum-frame-size", "1048576b")
     val akkaFrameSize =
       sc.env.actorSystem.settings.config.getBytes("akka.remote.netty.tcp.maximum-frame-size").toInt
     val result = sc.parallelize(Seq(1), 1)

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskResultGetterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskResultGetterSuite.scala
@@ -61,11 +61,11 @@ class TaskResultGetterSuite extends FunSuite with BeforeAndAfter with BeforeAndA
   override def beforeAll {
     // Set the Akka frame size to be as small as possible (it must be an integer, so 1 is as small
     // as we can make it) so the tests don't take too long.
-    System.setProperty("spark.akka.frameSize", "1")
+    System.setProperty("spark.akka.remote.netty.tcp.maximum-frame-size", "1048576b")
   }
 
   override def afterAll {
-    System.clearProperty("spark.akka.frameSize")
+    System.clearProperty("spark.akka.remote.netty.tcp.maximum-frame-size")
   }
 
   test("handling results smaller than Akka frame size") {

--- a/mllib/src/test/scala/org/apache/spark/mllib/util/LocalClusterSparkContext.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/util/LocalClusterSparkContext.scala
@@ -28,7 +28,8 @@ trait LocalClusterSparkContext extends BeforeAndAfterAll { self: Suite =>
     val conf = new SparkConf()
       .setMaster("local-cluster[2, 1, 512]")
       .setAppName("test-cluster")
-      .set("spark.akka.frameSize", "1") // set to 1MB to detect direct serialization of data
+      // set to 1MB to detect direct serialization of data
+      .set("spark.akka.remote.netty.tcp.maximum-frame-size", "1048576b")
     sc = new SparkContext(conf)
     super.beforeAll()
   }


### PR DESCRIPTION
Now user can set arbitrary akka configurations via property file or Spark Conf using spark.akka.x.y.. to represent akka.x.y.. in akka properties.
Spark's own akka options is setted in spark.internal.akka.x.y form, for instance, "spark.internal.akka.askTimeout".
