### PR TITLE
[SPARK-4616][Core] - SPARK_CONF_DIR is not effective in spark-submit

### DIFF
--- a/bin/spark-class
+++ b/bin/spark-class
@@ -30,7 +30,7 @@ FWDIR="$(cd "`dirname "$0"`"/..; pwd)"
 # Export this as SPARK_HOME
 export SPARK_HOME="$FWDIR"
 
-. "$FWDIR"/bin/load-spark-env.sh
+. "$SPARK_HOME"/bin/load-spark-env.sh
 
 if [ -z "$1" ]; then
   echo "Usage: spark-class <class> [<args>]" 1>&2

--- a/bin/spark-submit
+++ b/bin/spark-submit
@@ -30,6 +30,8 @@ while (($#)); do
     SPARK_SUBMIT_DEPLOY_MODE=$2
   elif [ "$1" = "--properties-file" ]; then
     SPARK_SUBMIT_PROPERTIES_FILE=$2
+  elif [ "$1" = "--environment-file" ]; then
+    SPARK_SUBMIT_ENVIRONMENT_FILE=$2
   elif [ "$1" = "--driver-memory" ]; then
     export SPARK_SUBMIT_DRIVER_MEMORY=$2
   elif [ "$1" = "--driver-library-path" ]; then
@@ -42,9 +44,19 @@ while (($#)); do
   shift
 done
 
-DEFAULT_PROPERTIES_FILE="$SPARK_HOME/conf/spark-defaults.conf"
-export SPARK_SUBMIT_DEPLOY_MODE=${SPARK_SUBMIT_DEPLOY_MODE:-"client"}
+# SPARK-4616 - Add environment file to source in possible configuration options
+DEFAULT_ENVIRONMENT_FILE="$SPARK_HOME/conf/spark-env.sh"
+export SPARK_SUBMIT_ENVIRONMENT_FILE=${SPARK_SUBMIT_ENVIRONMENT_FILE:-"$DEFAULT_ENVIRONMENT_FILE"}
+
+# Source in the environment specifically to ensure whether SPARK_CONF_DIR has been set or not
+. "$SPARK_HOME"/bin/load-spark-env.sh
+
+# If the SPARK_CONF_DIR wasn't set from spark-env.sh then provide healthy defaults
+SPARK_CONF_DIR=${SPARK_CONF_DIR:-"$SPARK_HOME/conf"}
+DEFAULT_PROPERTIES_FILE="$SPARK_CONF_DIR/spark-defaults.conf"
 export SPARK_SUBMIT_PROPERTIES_FILE=${SPARK_SUBMIT_PROPERTIES_FILE:-"$DEFAULT_PROPERTIES_FILE"}
+
+export SPARK_SUBMIT_DEPLOY_MODE=${SPARK_SUBMIT_DEPLOY_MODE:-"client"}
 
 # For client mode, the driver will be launched in the same JVM that launches
 # SparkSubmit, so we may need to read the properties file for any extra class

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -35,7 +35,8 @@ function gatherSparkSubmitOpts() {
       --master | --deploy-mode | --class | --name | --jars | --py-files | --files | \
       --conf | --properties-file | --driver-memory | --driver-java-options | \
       --driver-library-path | --driver-class-path | --executor-memory | --driver-cores | \
-      --total-executor-cores | --executor-cores | --queue | --num-executors | --archives)
+      --total-executor-cores | --executor-cores | --queue | --num-executors | \
+      --archives | --environment-file )
         if [[ $# -lt 2 ]]; then
           "$SUBMIT_USAGE_FUNCTION"
           exit 1;

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -34,6 +34,7 @@ private[spark] class SparkSubmitArguments(args: Seq[String], env: Map[String, St
   var executorCores: String = null
   var totalExecutorCores: String = null
   var propertiesFile: String = null
+  var environmentFile: String = null
   var driverMemory: String = null
   var driverExtraClassPath: String = null
   var driverExtraLibraryPath: String = null
@@ -188,6 +189,7 @@ private[spark] class SparkSubmitArguments(args: Seq[String], env: Map[String, St
     |  executorCores           $executorCores
     |  totalExecutorCores      $totalExecutorCores
     |  propertiesFile          $propertiesFile
+    |  environmentFile         $environmentFile
     |  driverMemory            $driverMemory
     |  driverCores             $driverCores
     |  driverExtraClassPath    $driverExtraClassPath
@@ -283,6 +285,10 @@ private[spark] class SparkSubmitArguments(args: Seq[String], env: Map[String, St
         propertiesFile = value
         parse(tail)
 
+      case ("--environment-file") :: value :: tail =>
+        environmentFile = value
+        parse(tail)
+
       case ("--supervise") :: tail =>
         supervise = true
         parse(tail)
@@ -365,6 +371,9 @@ private[spark] class SparkSubmitArguments(args: Seq[String], env: Map[String, St
         |  --conf PROP=VALUE           Arbitrary Spark configuration property.
         |  --properties-file FILE      Path to a file from which to load extra properties. If not
         |                              specified, this will look for conf/spark-defaults.conf.
+        |  --environment-file FILE     Path to a file from which to load various Spark environment
+        |                              options (e.g. SPARK_CONF_DIR, etc.). If not specified, this
+        |                              will look for conf/spark-env.sh.
         |
         |  --driver-memory MEM         Memory for driver (e.g. 1000M, 2G) (Default: 512M).
         |  --driver-java-options       Extra Java options to pass to the driver.


### PR DESCRIPTION
By default the `SPARK_CONF_DIR` is not capable of being set from the `spark-submit` script, but a spark properties file is. After diving through the code it turned out that the `SPARK_CONF_DIR` is actually a cyclic reference as it is referenced within the `load-spark-env.sh` script and can also then be reset within the loaded `spark-env.sh` file. What's worse is that, if the `spark-env.sh` defined a `SPARK_CONF_DIR` it wouldn't be picked up and used to grab the default `spark-defaults.conf` if no `--properties-file` flag was present. As such, it seemed best to provide a `--environment-file` flag that can be used to present an arbitrary bash file to the system which would preload any necessary environment configuration options (including `SPARK_CONF_DIR`). This then solves the original problem that the `SPARK_CONF_DIR` wasn't effective within `spark-submit`, but also removes the cyclic dependency on where and when the `SPARK_CONF_DIR` is loaded.
