### PR TITLE
[SPARK-4298][Core] - The spark-submit cannot read Main-Class from Manifest.

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -126,19 +126,21 @@ private[spark] class SparkSubmitArguments(args: Seq[String], env: Map[String, St
     if (mainClass == null && !isPython && primaryResource != null) {
       val uri = new URI(primaryResource)
       val uriScheme = uri.getScheme()
-      // Note that this might still return null if no main-class is set; we catch that later
+
       uriScheme match {
         case "file" =>
           try {
             val jar = new JarFile(uri.getPath)
+            // Note that this might still return null if no main-class is set; we catch that later
             mainClass = jar.getManifest.getMainAttributes.getValue("Main-Class")
           } catch {
             case e: Exception =>
-              SparkSubmit.printErrorAndExit("Cannot load main class from JAR: " + primaryResource)
+              SparkSubmit.printErrorAndExit(s"Cannot load main class from JAR $primaryResource")
           }
         case _ =>
-          SparkSubmit.printErrorAndExit("Cannot load main class from JAR: " + primaryResource +
-                                        " with URI: " + uriScheme)
+          SparkSubmit.printErrorAndExit(
+            s"Cannot load main class from JAR $primaryResource with URI $uriScheme. " +
+            "Please specify a class through --class.")
       }
     }
 

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -125,7 +125,8 @@ private[spark] class SparkSubmitArguments(args: Seq[String], env: Map[String, St
     // Try to set main class from JAR if no --class argument is given
     if (mainClass == null && !isPython && primaryResource != null) {
       try {
-        val jar = new JarFile(new URI(primaryResource).getPath)
+        val uri = new URI(primaryResource)
+        val jar = new JarFile(uri.getPath)
         // Note that this might still return null if no main-class is set; we catch that later
         mainClass = jar.getManifest.getMainAttributes.getValue("Main-Class")
       } catch {

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -131,8 +131,7 @@ private[spark] class SparkSubmitArguments(args: Seq[String], env: Map[String, St
         mainClass = jar.getManifest.getMainAttributes.getValue("Main-Class")
       } catch {
         case e: Exception =>
-          SparkSubmit.printErrorAndExit("Cannot main: " + primaryResource)
-          //SparkSubmit.printErrorAndExit("Cannot load main class from JAR: " + primaryResource)
+          SparkSubmit.printErrorAndExit("Cannot load main class from JAR: " + primaryResource)
           return
       }
     }

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.deploy
 
+import java.net.URI
 import java.util.jar.JarFile
 
 import scala.collection.mutable.{ArrayBuffer, HashMap}
@@ -124,12 +125,13 @@ private[spark] class SparkSubmitArguments(args: Seq[String], env: Map[String, St
     // Try to set main class from JAR if no --class argument is given
     if (mainClass == null && !isPython && primaryResource != null) {
       try {
-        val jar = new JarFile(primaryResource)
+        val jar = new JarFile(new URI(primaryResource).getPath)
         // Note that this might still return null if no main-class is set; we catch that later
         mainClass = jar.getManifest.getMainAttributes.getValue("Main-Class")
       } catch {
         case e: Exception =>
-          SparkSubmit.printErrorAndExit("Cannot load main class from JAR: " + primaryResource)
+          SparkSubmit.printErrorAndExit("Cannot main: " + primaryResource)
+          //SparkSubmit.printErrorAndExit("Cannot load main class from JAR: " + primaryResource)
           return
       }
     }

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -127,22 +127,18 @@ private[spark] class SparkSubmitArguments(args: Seq[String], env: Map[String, St
       val uri = new URI(primaryResource)
       val uriScheme = uri.getScheme()
       // Note that this might still return null if no main-class is set; we catch that later
-      mainClass = uriScheme match {
-        case "file" => {
+      uriScheme match {
+        case "file" =>
           try {
             val jar = new JarFile(uri.getPath)
-            jar.getManifest.getMainAttributes.getValue("Main-Class")
+            mainClass = jar.getManifest.getMainAttributes.getValue("Main-Class")
           } catch {
             case e: Exception =>
               SparkSubmit.printErrorAndExit("Cannot load main class from JAR: " + primaryResource)
-              return
           }
-        }
-        case _      => {
+        case _ =>
           SparkSubmit.printErrorAndExit("Cannot load main class from JAR: " + primaryResource +
                                         " with URI: " + uriScheme)
-          return
-        }
       }
     }
 


### PR DESCRIPTION
Resolves a bug where the `Main-Class` from a .jar file wasn't being read in properly. This was caused by the fact that the `primaryResource` object was a URI and needed to be normalized through a call to `.getPath` before it could be passed into the `JarFile` object.
