### PR TITLE
[SPARK-4721][CORE] Improve logic while first thread put block failed

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -1012,7 +1012,7 @@ private[spark] class BlockManager(
       info.synchronized {
         // required ? As of now, this will be invoked only for blocks which are ready
         // But in case this changes in future, adding for consistency sake.
-        if (!info.waitForReady()) {
+        if (!info.waitForReady(info.waitTypes.DROP)) {
           // If we get here, the block write failed.
           logWarning(s"Block $blockId was marked as failure. Nothing to drop")
           return None

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -468,7 +468,7 @@ private[spark] class BlockManager(
         }
 
         // If another thread is writing the block, wait for it to become ready.
-        if (!info.waitForReady()) {
+        if (!info.waitForReady(info.waitTypes.GET)) {
           // If we get here, the block write failed.
           logWarning(s"Block $blockId was marked as failure.")
           return None
@@ -716,13 +716,15 @@ private[spark] class BlockManager(
       // Do atomically !
       val oldBlockOpt = blockInfo.putIfAbsent(blockId, tinfo)
       if (oldBlockOpt.isDefined) {
-        if (oldBlockOpt.get.waitForReady()) {
+        val oldInfo = oldBlockOpt.get
+        if (oldInfo.waitForReady(oldInfo.waitTypes.PUT)) {
           logWarning(s"Block $blockId already exists on this machine; not re-adding it")
           return updatedBlocks
         }
-        // TODO: So the block info exists - but previous attempt to load it (?) failed.
-        // What do we do now ? Retry on it ?
-        oldBlockOpt.get
+        if (oldInfo.removed) {
+          return doPut(blockId, data, level, tellMaster, effectiveStorageLevel)
+        }
+        oldInfo
       } else {
         tinfo
       }
@@ -759,6 +761,7 @@ private[spark] class BlockManager(
       logTrace("Put for block %s took %s to get into synchronized block"
         .format(blockId, Utils.getUsedTimeMs(startTimeMs)))
 
+      putBlockInfo.resetStatus()
       var marked = false
       try {
         // returnValues - Whether to return the values put
@@ -820,8 +823,7 @@ private[spark] class BlockManager(
         if (!marked) {
           // Note that the remove must happen before markFailure otherwise another thread
           // could've inserted a new BlockInfo before we remove it.
-          blockInfo.remove(blockId)
-          putBlockInfo.markFailure()
+          if (putBlockInfo.markFailureOrWithRemove()) { blockInfo.remove(blockId) }
           logWarning(s"Putting block $blockId failed")
         }
       }

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -468,7 +468,7 @@ private[spark] class BlockManager(
         }
 
         // If another thread is writing the block, wait for it to become ready.
-        if (!info.waitForReady(info.waitTypes.GET)) {
+        if (!info.waitForReady("GET")) {
           // If we get here, the block write failed.
           logWarning(s"Block $blockId was marked as failure.")
           return None
@@ -717,11 +717,11 @@ private[spark] class BlockManager(
       val oldBlockOpt = blockInfo.putIfAbsent(blockId, tinfo)
       if (oldBlockOpt.isDefined) {
         val oldInfo = oldBlockOpt.get
-        if (oldInfo.waitForReady(oldInfo.waitTypes.PUT)) {
+        if (oldInfo.waitForReady("PUT")) {
           logWarning(s"Block $blockId already exists on this machine; not re-adding it")
           return updatedBlocks
         }
-        if (oldInfo.removed) {
+        if (oldInfo.isRemoved) {
           return doPut(blockId, data, level, tellMaster, effectiveStorageLevel)
         }
         oldInfo
@@ -1012,7 +1012,7 @@ private[spark] class BlockManager(
       info.synchronized {
         // required ? As of now, this will be invoked only for blocks which are ready
         // But in case this changes in future, adding for consistency sake.
-        if (!info.waitForReady(info.waitTypes.DROP)) {
+        if (!info.waitForReady("DROP")) {
           // If we get here, the block write failed.
           logWarning(s"Block $blockId was marked as failure. Nothing to drop")
           return None

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -1230,4 +1230,56 @@ class BlockManagerSuite extends FunSuite with Matchers with BeforeAndAfter
     assert(unrollMemoryAfterB6 === unrollMemoryAfterB4)
     assert(unrollMemoryAfterB7 === unrollMemoryAfterB4)
   }
+
+  test("test BlockWaitCondition") {
+    val info1 = new BlockInfo(StorageLevel.MEMORY_ONLY, true)
+    val t1 = new Thread {
+      override def run() {
+        assert(!info1.waitForReady("PUT"))
+        info1.resetStatus()
+        Thread.sleep(2000)
+        info1.markFailureOrWithRemove()
+      }
+    }
+    t1.setName("t1")
+    val t2 = new Thread {
+      override def run() {
+        assert(!info1.waitForReady("PUT"))
+        info1.resetStatus()
+        Thread.sleep(2000)
+        info1.markFailureOrWithRemove()
+      }
+    }
+    t2.setName("t2")
+
+    val info2 = new BlockInfo(StorageLevel.MEMORY_ONLY, true)
+    val t3 = new Thread {
+      override def run() { assert(info2.waitForReady("PUT")) }
+    }
+    t3.setName("t3")
+    val t4 = new Thread {
+      override def run() { assert(info2.waitForReady("PUT")) }
+    }
+    t4.setName("t4")
+
+    //info1: Failed, reput one by one
+    t1.start()
+    t2.start()
+    Thread.sleep(100)
+    assert(!info1.isRemoved)
+    info1.markFailureOrWithRemove()
+    assert(!info1.isRemoved)
+    Thread.sleep(5000)
+    assert(info1.isRemoved)
+    t1.join()
+    t2.join()
+
+    //info2: Succeed, notify all wait thread
+    t3.start()
+    t4.start()
+    Thread.sleep(1000)
+    info2.markReady(1024)
+    t3.join()
+    t4.join()
+  }
 }


### PR DESCRIPTION
1. make thread which wait old block info try one by one while the first thread which created that block failed.
2. use reentrantLock instead of this.syn{} in block info.
