### PR TITLE
[SPARK-4736][mllib] [random forest] functions returning the category with weights

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/treeEnsembleModels.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/treeEnsembleModels.scala
@@ -94,14 +94,14 @@ private[tree] sealed class TreeEnsembleModel(
    * Classifies a single data point based on (weighted) majority votes.
    */
   private def predictByVoting(features: Vector): Double = {
-    predictByVotingWithWeight(features)._1
+    predictRawByVoting(features)._1
   }
   
   /**
    * Classifies a single data point based on (weighted) majority votes.
    * @return predicted category and number of votes as weight
    */
-  private def predictByVotingWithWeight(features: Vector): (Double, Double) = {
+  private def predictRawByVoting(features: Vector): (Double, Double) = {
     val votes = mutable.Map.empty[Int, Double]
     trees.view.zip(treeWeights).foreach { case (tree, weight) =>
       val prediction = tree.predict(features).toInt
@@ -142,10 +142,10 @@ private[tree] sealed class TreeEnsembleModel(
    * @param features array representing a single data point
    * @return predicted category from the trained model and the number of votes as weight
    */
-  def predictWithWeight(features: Vector): (Double, Double) = {
+  def predictRaw(features: Vector): (Double, Double) = {
     (algo, combiningStrategy) match {
       case (Classification, Vote) =>
-        predictByVotingWithWeight(features)
+        predictRawByVoting(features)
       case _ =>
         throw new IllegalArgumentException(
           "TreeEnsembleModel given unsupported (algo, combiningStrategy) combination: " +


### PR DESCRIPTION
In this version, we add two functions: 1) predictByVotingWithWeight(features: Vector) and 2) predictWithWeight(features: Vector). And we also modify the function: predictByVoting(features: Vector).

There are at least two reasons why we make such improvement:

1 ) In our practice, we want to find the top N samples from one category. However in 1.3.0 version, the function of predict can only give the predicted category but without weights.

2) What's more, in our practice, the numbers of positive and negative samples are very unbalance. There are much less positive samples than negative samples. According to the results of votes, there are very few samples predicted as positive sample. If the weights are also given, users can make a proper threshold to modify the results so that the performance can be improved.
