### PR TITLE
[HOT FIX] [YARN] Check whether `/lib` exists before listing its files

### DIFF
--- a/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/ClientBase.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/ClientBase.scala
@@ -243,18 +243,21 @@ private[spark] trait ClientBase extends Logging {
       val libsURI = new URI(libsDir)
       val jarLinks = ListBuffer.empty[String]
       if (libsURI.getScheme != LOCAL_SCHEME) {
-        val localURI = getQualifiedLocalPath(libsURI).toUri()
-        val jars = FileSystem.get(localURI, hadoopConf).listFiles(new Path(localURI.getPath), false)
-        while (jars.hasNext) {
-          val jar = jars.next()
-          val name = jar.getPath.getName
-          if (name.startsWith("datanucleus-")) {
-            // copy to remote and add to classpath
-            val src = jar.getPath
-            val destPath = copyFileToRemote(dst, src, replication)
-            distCacheMgr.addResource(fs, hadoopConf, destPath,
-              localResources, LocalResourceType.FILE, name, statCache)
-            jarLinks += name
+        val localPath = getQualifiedLocalPath(libsURI)
+        val localFs = FileSystem.get(localPath.toUri, hadoopConf)
+        if (localFs.exists(localPath)) {
+          val jars = localFs.listFiles(localPath, /* recursive */ false)
+          while (jars.hasNext) {
+            val jar = jars.next()
+            val name = jar.getPath.getName
+            if (name.startsWith("datanucleus-")) {
+              // copy to remote and add to classpath
+              val src = jar.getPath
+              val destPath = copyFileToRemote(dst, src, replication)
+              distCacheMgr.addResource(localFs, hadoopConf, destPath,
+                localResources, LocalResourceType.FILE, name, statCache)
+              jarLinks += name
+            }
           }
         }
       } else {


### PR DESCRIPTION
This is caused by a975dc32799bb8a14f9e1c76defaaa7cfbaf8b53
