### PR TITLE
[SPARK-4733] Add missing prameter comments in ShuffleDependency

### DIFF
--- a/core/src/main/scala/org/apache/spark/Dependency.scala
+++ b/core/src/main/scala/org/apache/spark/Dependency.scala
@@ -61,8 +61,8 @@ abstract class NarrowDependency[T](_rdd: RDD[T]) extends Dependency[T] {
  *                   the default serializer, as specified by `spark.serializer` config option, will
  *                   be used.
  * @param keyOrdering key ordering for RDD's shuffles
- * @param aggregator map-side aggregator for RDD's shuffle
- * @param mapSideCombine map-side aggregation flag
+ * @param aggregator map/reduce-side aggregator for RDD's shuffle
+ * @param mapSideCombine whether to perform partial aggregation (also known as map-side combine)
  */
 @DeveloperApi
 class ShuffleDependency[K, V, C](

--- a/core/src/main/scala/org/apache/spark/Dependency.scala
+++ b/core/src/main/scala/org/apache/spark/Dependency.scala
@@ -60,6 +60,9 @@ abstract class NarrowDependency[T](_rdd: RDD[T]) extends Dependency[T] {
  * @param serializer [[org.apache.spark.serializer.Serializer Serializer]] to use. If set to None,
  *                   the default serializer, as specified by `spark.serializer` config option, will
  *                   be used.
+ * @param keyOrdering key ordering for RDD's shuffles
+ * @param aggregator map-side aggregator for RDD's shuffle
+ * @param mapSideCombine map-side aggregation flag
  */
 @DeveloperApi
 class ShuffleDependency[K, V, C](


### PR DESCRIPTION
Add missing Javadoc comments in ShuffleDependency.
