### PR TITLE
[SPARK-4745] Fix get_existing_cluster() function with multiple security groups

### DIFF
--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -504,9 +504,9 @@ def get_existing_cluster(conn, opts, cluster_name, die_on_error=True):
         active = [i for i in res.instances if is_active(i)]
         for inst in active:
             group_names = [g.name for g in inst.groups]
-            if group_names == [cluster_name + "-master"]:
+            if cluster_name + "-master" in group_names:
                 master_nodes.append(inst)
-            elif group_names == [cluster_name + "-slaves"]:
+            elif cluster_name + "-slaves" in group_names:
                 slave_nodes.append(inst)
     if any((master_nodes, slave_nodes)):
         print "Found %d master(s), %d slaves" % (len(master_nodes), len(slave_nodes))


### PR DESCRIPTION
The current get_existing_cluster() function would only find an instance belonged to a cluster if the instance's security groups == cluster_name + "-master" (or "-slaves"). This fix allows for multiple security groups by checking if the cluster_name + "-master" security group is in the list of groups for a particular instance.
