### PR TITLE
[SPARK-4741] Do not destroy FileInputStream and recreate it every time

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
@@ -400,15 +400,10 @@ class ExternalAppendOnlyMap[K, V, C](
       // Note that batchOffsets.length = numBatches + 1 since we did a scan above; check whether
       // we're still in a valid batch.
       if (batchIndex < batchOffsets.length - 1) {
-        if (deserializeStream != null) {
-          deserializeStream.close()
-          fileStream.close()
-          deserializeStream = null
-          fileStream = null
-        }
-
         val start = batchOffsets(batchIndex)
-        fileStream = new FileInputStream(file)
+        if (fileStream == null) {
+          fileStream = new FileInputStream(file)
+        }
         fileStream.getChannel.position(start)
         batchIndex += 1
 


### PR DESCRIPTION
The `FileInputStream` in `DiskMapIterator` is destroyed and recreate after each batch reading. However, since we can change the reading position on that stream, it is not needed and inefficient to destroy and recreate it every time. 
