### PR TITLE
Update DecisionTree.scala

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/DecisionTree.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/DecisionTree.scala
@@ -985,6 +985,7 @@ object DecisionTree extends Serializable with Logging {
         1.0
       }
       logDebug("fraction of data used for calculating quantiles = " + fraction)
+      // To discuss: being able to set the seed via train method, or in Strategy of constructor.
       input.sample(withReplacement = false, fraction, new XORShiftRandom().nextInt()).collect()
     } else {
       new Array[LabeledPoint](0)


### PR DESCRIPTION
Hello,

Hope you are well.  We've been using DecisionTree at Samsung and hope to help in some small way.  I was interested in setting the seed for the sampling i.e. in line 988.    We're in the process of creating tests for our code being able to set the seed is helpful.  

To that end, I think also the sample method here depends on a PartitionwiseSampledRDD.  In there the 'compute' method think uses a different seed from the one that can be passed to the  constructor of PartitionSampledRDD, it uses split.seed (below).  Well hope we can discuss more! Thank you..   Best Wishes -Ed 

override def compute(splitIn: Partition, context: TaskContext): Iterator[U] = {
    val split = splitIn.asInstanceOf[PartitionwiseSampledRDDPartition]
    val thisSampler = sampler.clone
    thisSampler.setSeed(split.seed)
    thisSampler.sample(firstParent[T].iterator(split.prev, context))
  }
