### PR TITLE
[SPARK-4762][SQL]: Add support for tuples in 'where in' clause query

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -290,6 +290,9 @@ object OptimizeIn extends Rule[LogicalPlan] {
       case In(v, list) if !list.exists(!_.isInstanceOf[Literal]) =>
           val hSet = list.map(e => e.eval(null))
           InSet(v, HashSet() ++ hSet)
+      case InTuple(v, list) if !list.flatten.exists(!_.isInstanceOf[Literal]) =>
+          val hSet = list.map(e => e.map(k => k.eval(null)))
+          InTupleSet(v, HashSet() ++ hSet)
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -184,6 +184,17 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] {
           } else {
             arg
           }
+        case subargs: Traversable[_] => subargs.map {
+         case sarg: TreeNode[_] if children contains sarg =>
+          val newChild = sarg.asInstanceOf[BaseType].transformDown(rule)
+          if (!(newChild fastEquals sarg)) {
+            changed = true
+            newChild
+          } else {
+            sarg
+          }
+         case other => other
+        }
         case other => other
       }
       case nonChild: AnyRef => nonChild

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvaluationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvaluationSuite.scala
@@ -197,6 +197,24 @@ class ExpressionEvaluationSuite extends FunSuite {
     checkEvaluation(InSet(one, hS) && InSet(two, hS), true)
   }
 
+  test("INTUPLESET") {
+    val hS = HashSet[Any]() + Seq(1,2) + Seq(3,4)
+    val nS = HashSet[Any]() + Seq(1,2) + Seq(3,null)
+    val one = Seq(Literal(1),Literal(2))
+    val two = Seq(Literal(3),Literal(4))
+    val three = Seq(Literal(4), Literal(3))
+    val nl = Seq(Literal(3),Literal(null))
+    val s = Seq(one, two)
+    val nullS = Seq(one, two, null)
+    checkEvaluation(InTupleSet(one, hS), true)
+    checkEvaluation(InTupleSet(two, hS), true)
+    checkEvaluation(InTupleSet(one, nS), true)
+    checkEvaluation(InTupleSet(nl, nS), true)
+    checkEvaluation(InTupleSet(three, hS), false)
+    checkEvaluation(InTupleSet(three, nS), false)
+    checkEvaluation(InTupleSet(one, hS) && InTupleSet(two, hS), true)
+  }
+
   test("MaxOf") {
     checkEvaluation(MaxOf(1, 2), 2)
     checkEvaluation(MaxOf(2, 1), 2)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeInSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeInSuite.scala
@@ -72,4 +72,39 @@ class OptimizeInSuite extends PlanTest {
 
     comparePlans(optimized, correctAnswer)
   }
+
+  test("OptimizedIn test: InTuple clause optimized to InTupleSet") {
+    val originalQuery =
+      testRelation
+        .where(InTuple(Seq(UnresolvedAttribute("a"), UnresolvedAttribute("b")), 
+          Seq(Seq(Literal(1),Literal(2)), Seq(Literal(3),Literal(4)))))
+        .analyze
+
+    val optimized = Optimize(originalQuery.analyze)
+    val correctAnswer =
+      testRelation
+        .where(InTupleSet(Seq(UnresolvedAttribute("a"), UnresolvedAttribute("b")),
+          HashSet[Any]()+Seq(1,2)+Seq(3,4)))
+        .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+  
+  test("OptimizedIn test: InTuple clause not optimized in case filter has attributes") {
+    val originalQuery =
+      testRelation
+        .where(InTuple(Seq(UnresolvedAttribute("a"), UnresolvedAttribute("b")), 
+          Seq(Seq(Literal(1),Literal(2)), Seq(UnresolvedAttribute("c"), Literal(3)))))
+        .analyze
+
+    val optimized = Optimize(originalQuery.analyze)
+    val correctAnswer =
+      testRelation
+        .where(InTuple(Seq(UnresolvedAttribute("a"), UnresolvedAttribute("b")), 
+          Seq(Seq(Literal(1),Literal(2)), Seq(UnresolvedAttribute("c"), Literal(3)))))
+        .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
@@ -1002,7 +1002,8 @@ private[hive] object HiveQl {
       IsNotNull(nodeToExpr(child))
     case Token("TOK_FUNCTION", Token("TOK_ISNULL", Nil) :: child :: Nil) =>
       IsNull(nodeToExpr(child))
-    case Token("TOK_FUNCTION", Token(IN(), Nil) :: Token("TOK_TABLE_OR_COLLIST", value) :: list) =>
+    case Token("TOK_FUNCTION", Token(IN(), Nil) :: Token("TOK_TABLE_OR_COLLIST", value) :: 
+      Token("TOK_EXPLIST_LIST", list) :: Nil) =>
       val values = value.map { 
          case Token(name, Nil) => UnresolvedAttribute(cleanIdentifier(name)) 
       }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
@@ -1002,6 +1002,14 @@ private[hive] object HiveQl {
       IsNotNull(nodeToExpr(child))
     case Token("TOK_FUNCTION", Token("TOK_ISNULL", Nil) :: child :: Nil) =>
       IsNull(nodeToExpr(child))
+    case Token("TOK_FUNCTION", Token(IN(), Nil) :: Token("TOK_TABLE_OR_COLLIST", value) :: list) =>
+      val values = value.map { 
+         case Token(name, Nil) => UnresolvedAttribute(cleanIdentifier(name)) 
+      }
+      val lists = list.map { 
+        case Token("TOK_EXPLIST", sublist) => sublist.map(nodeToExpr)
+      }
+      InTuple(values, lists)
     case Token("TOK_FUNCTION", Token(IN(), Nil) :: value :: list) =>
       In(nodeToExpr(value), list.map(nodeToExpr))
     case Token("TOK_FUNCTION",

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
@@ -1006,9 +1006,13 @@ private[hive] object HiveQl {
       val values = value.map { 
          case Token(name, Nil) => UnresolvedAttribute(cleanIdentifier(name)) 
       }
+      val vSize = values.size()
       val lists = list.map { 
         case Token("TOK_EXPLIST", sublist) => sublist.map(nodeToExpr)
       }
+      if (lists.exists(list => list.size() != vSize)) {
+        throw new RuntimeException(s"Failed to parse : ${lists.toString}, size mismatch")
+      } 
       InTuple(values, lists)
     case Token("TOK_FUNCTION", Token(IN(), Nil) :: value :: list) =>
       In(nodeToExpr(value), list.map(nodeToExpr))


### PR DESCRIPTION
 Currently, in the where in clause the filter is applied only on a single column. We can enhance it to accept filter on multiple columns.
So current support is for queries like :
Select \* from table where c1 in (value1,value2,...value n);

This added  support for queries like :
Select \* from table where (c1,c2,... cn) in ((value1,value2...value n), (value1' , value2' ... ,value n').... )
Also, added optimized version of where in clause of tuples , where we create a hashset of the filter tuples for matching rows.

This also requires a change in the hive parser since currently there is no support for multiple columns in IN clause.
