### PR TITLE
SPARK-4770. [DOC] [YARN] spark.scheduler.minRegisteredResourcesRatio doc...

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -939,11 +939,11 @@ Apart from these, the following properties are also available, and may be useful
 </tr>
 </tr>
   <td><code>spark.scheduler.minRegisteredResourcesRatio</code></td>
-  <td>0</td>
+  <td>0.0 for Mesos and Standalone mode, 0.8 for YARN</td>
   <td>
     The minimum ratio of registered resources (registered resources / total expected resources)
     (resources are executors in yarn mode, CPU cores in standalone mode)
-    to wait for before scheduling begins. Specified as a double between 0 and 1.
+    to wait for before scheduling begins. Specified as a double between 0.0 and 1.0.
     Regardless of whether the minimum ratio of resources has been reached,
     the maximum amount of time it will wait before scheduling begins is controlled by config 
     <code>spark.scheduler.maxRegisteredResourcesWaitingTime</code>.


### PR DESCRIPTION
...umented default is incorrect for YARN
