### PR TITLE
[SPARK-4740] Create multiple concurrent connections between two peer nodes in Netty.

### DIFF
--- a/network/common/src/main/java/org/apache/spark/network/client/TransportClientFactory.java
+++ b/network/common/src/main/java/org/apache/spark/network/client/TransportClientFactory.java
@@ -66,6 +66,9 @@ public class TransportClientFactory implements Closeable {
     public ClientPool() {
       clients = new TransportClient[numConnectionsPerPeer];
       locks = new Object[numConnectionsPerPeer];
+      for (int i = 0; i < numConnectionsPerPeer; i++) {
+        locks[i] = new Object();
+      }
     }
   }
 
@@ -120,7 +123,8 @@ public class TransportClientFactory implements Closeable {
     // Create the ClientPool if we don't have it yet.
     ClientPool clientPool = connectionPool.get(address);
     if (clientPool == null) {
-      clientPool = connectionPool.putIfAbsent(address, new ClientPool());
+      connectionPool.putIfAbsent(address, new ClientPool());
+      clientPool = connectionPool.get(address);
     }
 
     int clientIndex = rand.nextInt(numConnectionsPerPeer);

--- a/network/common/src/main/java/org/apache/spark/network/client/TransportClientFactory.java
+++ b/network/common/src/main/java/org/apache/spark/network/client/TransportClientFactory.java
@@ -58,6 +58,7 @@ import org.apache.spark.network.util.TransportConf;
  */
 public class TransportClientFactory implements Closeable {
 
+  /** A simple data structure to track the pool of clients between two peer nodes. */
   private class ClientPool {
     TransportClient[] clients;
     Object[] locks;
@@ -152,12 +153,12 @@ public class TransportClientFactory implements Closeable {
 
     Bootstrap bootstrap = new Bootstrap();
     bootstrap.group(workerGroup)
-        .channel(socketChannelClass)
-            // Disable Nagle's Algorithm since we don't want packets to wait
-        .option(ChannelOption.TCP_NODELAY, true)
-        .option(ChannelOption.SO_KEEPALIVE, true)
-        .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, conf.connectionTimeoutMs())
-        .option(ChannelOption.ALLOCATOR, pooledAllocator);
+      .channel(socketChannelClass)
+      // Disable Nagle's Algorithm since we don't want packets to wait
+      .option(ChannelOption.TCP_NODELAY, true)
+      .option(ChannelOption.SO_KEEPALIVE, true)
+      .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, conf.connectionTimeoutMs())
+      .option(ChannelOption.ALLOCATOR, pooledAllocator);
 
     final AtomicReference<TransportClient> clientRef = new AtomicReference<TransportClient>();
 
@@ -174,7 +175,7 @@ public class TransportClientFactory implements Closeable {
     ChannelFuture cf = bootstrap.connect(address);
     if (!cf.awaitUninterruptibly(conf.connectionTimeoutMs())) {
       throw new IOException(
-          String.format("Connecting to %s timed out (%s ms)", address, conf.connectionTimeoutMs()));
+        String.format("Connecting to %s timed out (%s ms)", address, conf.connectionTimeoutMs()));
     } else if (cf.cause() != null) {
       throw new IOException(String.format("Failed to connect to %s", address), cf.cause());
     }

--- a/network/common/src/main/java/org/apache/spark/network/client/TransportClientFactory.java
+++ b/network/common/src/main/java/org/apache/spark/network/client/TransportClientFactory.java
@@ -107,10 +107,14 @@ public class TransportClientFactory implements Closeable {
   }
 
   /**
-   * Create a new {@link TransportClient} connecting to the given remote host / port. This will
-   * reuse TransportClients if they are still active and are for the same remote address. Prior
-   * to the creation of a new TransportClient, we will execute all {@link TransportClientBootstrap}s
-   * that are registered with this factory.
+   * Create a {@link TransportClient} connecting to the given remote host / port.
+   *
+   * We maintains an array of clients (size determined by spark.shuffle.io.numConnectionsPerPeer)
+   * and randomly picks one to use. If no client was previously created in the randomly selected
+   * spot, this function creates a new client and places it there.
+   *
+   * Prior to the creation of a new TransportClient, we will execute all
+   * {@link TransportClientBootstrap}s that are registered with this factory.
    *
    * This blocks until a connection is successfully established and fully bootstrapped.
    *

--- a/network/common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/network/common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -40,6 +40,11 @@ public class TransportConf {
     return conf.getInt("spark.shuffle.io.connectionTimeout", 120) * 1000;
   }
 
+  /** Number of concurrent connections between two nodes for fetching data. **/
+  public int numConnectionsPerPeer() {
+    return conf.getInt("spark.shuffle.io.numConnectionsPerPeer", 2);
+  }
+
   /** Requested maximum length of the queue of incoming connections. Default -1 for no backlog. */
   public int backLog() { return conf.getInt("spark.shuffle.io.backLog", -1); }
 


### PR DESCRIPTION
It's been reported that when the number of disks is large and the number of nodes is small, Netty network throughput is low compared with NIO. We suspect the problem is that only a small number of disks are utilized to serve shuffle files at any given point, due to connection reuse. This patch adds a new config parameter to specify the number of concurrent connections between two peer nodes, default to 2.
