### PR TITLE
[SPARK-4799] Use IP address instead of local hostname in ConnectionManager

### DIFF
--- a/core/src/main/scala/org/apache/spark/network/nio/ConnectionManager.scala
+++ b/core/src/main/scala/org/apache/spark/network/nio/ConnectionManager.scala
@@ -167,7 +167,7 @@ private[nio] class ConnectionManager(
   Utils.startServiceOnPort[ServerSocketChannel](port, startService, name)
   serverChannel.register(selector, SelectionKey.OP_ACCEPT)
 
-  val id = new ConnectionManagerId(Utils.localHostName, serverChannel.socket.getLocalPort)
+  val id = new ConnectionManagerId(Utils.localIpAddress, serverChannel.socket.getLocalPort)
   logInfo("Bound socket to port " + serverChannel.socket.getLocalPort() + " with id = " + id)
 
   // used in combination with the ConnectionManagerId to create unique Connection ids


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/SPARK-4799

Spark fails when a node hostname is not resolvable by other nodes.

See an example trace:

```
14/12/09 17:02:41 ERROR SendingConnection: Error connecting to 27e434cf36ac:35093
java.nio.channels.UnresolvedAddressException
    at sun.nio.ch.Net.checkAddress(Net.java:127)
    at sun.nio.ch.SocketChannelImpl.connect(SocketChannelImpl.java:644)
    at org.apache.spark.network.SendingConnection.connect(Connection.scala:299)
    at org.apache.spark.network.ConnectionManager.run(ConnectionManager.scala:278)
    at org.apache.spark.network.ConnectionManager$$anon$4.run(ConnectionManager.scala:139)
```

The relevant code is here:
https://github.com/apache/spark/blob/bcb5cdad614d4fce43725dfec3ce88172d2f8c11/core/src/main/scala/org/apache/spark/network/nio/ConnectionManager.scala#L170

```
val id = new ConnectionManagerId(Utils.localHostName, serverChannel.socket.getLocalPort)
```

This piece of code should use the host IP with Utils.localIpAddress or a method that acknowleges user settings (e.g. `SPARK_LOCAL_IP`). Since I cannot think about a use case for using hostname here, I'm creating a PR with the former solution, but if you think the later is better, I'm willing to create a new PR with a more elaborate fix.
