### PR TITLE
Add hadoop-2.5 profile with upgraded jets3t

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1294,6 +1294,17 @@
     </profile>
 
     <profile>
+      <id>hadoop-2.5</id>
+      <properties>
+        <hadoop.version>2.5.0</hadoop.version>
+        <protobuf.version>2.5.0</protobuf.version>
+        <jets3t.version>0.9.2</jets3t.version>
+        <commons.math3.version>3.1.1</commons.math3.version>
+        <avro.mapred.classifier>hadoop2</avro.mapred.classifier>
+      </properties>
+    </profile>
+
+    <profile>
       <id>yarn</id>
       <modules>
         <module>yarn</module>


### PR DESCRIPTION
This contribution is my original work and I license the work to the project under the project's open source license.

Adding support for hadoop-2.5.

Also bumped the jets3t version because there are conflicts with the java-aws-sdk under version 0.9.0. 

JIRA: https://issues.apache.org/jira/browse/SPARK-4807
