### PR TITLE
SPARK-4817[STREAMING]Print the specified number of data and handle all of the elements in RDD

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -788,6 +788,18 @@ abstract class RDD[T: ClassTag](
   }
 
   /**
+   * Take all of the elements in this RDD, and print the first num elements of the RDD.
+   */
+  def printTop (num: Int): Array[T] = {
+    val buf = new ArrayBuffer[T]
+    val results = sc.runJob(this, (iter: Iterator[T]) => iter.toArray)
+    for (partition <- results; data <- partition if buf.size <= num){
+      buf += data
+    }
+    buf.toArray
+  }
+
+  /**
    * Return an array that contains all of the elements in this RDD.
    */
   def collect(): Array[T] = {

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -788,9 +788,9 @@ abstract class RDD[T: ClassTag](
   }
 
   /**
-   * Take all of the elements in this RDD, and print the first num elements of the RDD.
+   * Process all of the elements in this RDD, and take the first num elements of the RDD.
    */
-  def printTop (num: Int): Array[T] = {
+  def processAllAndTake (num: Int): Array[T] = {
     val buf = new ArrayBuffer[T]
     val results = sc.runJob(this, (iter: Iterator[T]) => iter.toArray)
     for (partition <- results; data <- partition if buf.size <= num){

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
@@ -621,9 +621,9 @@ abstract class DStream[T: ClassTag] (
   /**
    * Print the first specified number elements of each RDD in this DStream.
    */
-  def printTop(num: Int) {
+  def processAllAndPrintFirst(num: Int) {
     def foreachFunc = (rdd: RDD[T], time: Time) => {
-      val first11 = rdd.printTop(num)
+      val first11 = rdd.processAllAndTake(num)
       println ("-------------------------------------------")
       println ("Time: " + time)
       println ("-------------------------------------------")

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
@@ -619,6 +619,20 @@ abstract class DStream[T: ClassTag] (
   }
 
   /**
+   * Print the first specified number elements of each RDD in this DStream.
+   */
+  def printTop(num: Int) {
+    def foreachFunc = (rdd: RDD[T], time: Time) => {
+      val first11 = rdd.printTop(num)
+      println ("-------------------------------------------")
+      println ("Time: " + time)
+      println ("-------------------------------------------")
+      first11.take(num).foreach(println)
+    }
+    new ForEachDStream(this, context.sparkContext.clean(foreachFunc)).register()
+  }
+
+  /**
    * Return a new DStream in which each RDD contains all the elements in seen in a
    * sliding window of time over this DStream. The new DStream generates RDDs with
    * the same interval as this DStream.


### PR DESCRIPTION
Dstream.print function:Print 10 elements and handle 11 elements.
A new function based on Dstream.print function is presented:
the new function:
Print the specified number of data and handle all of the elements in RDD.
there is a work scene:
val dstream = stream.map->filter->mapPartitions->print
the data after filter need update database in mapPartitions,but don't need print each data,only need to print the top 20 for view the data processing.
