### PR TITLE
[WIP] Remove many uses of Thread.sleep() from streaming tests

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -709,7 +709,9 @@ Apart from these, the following properties are also available, and may be useful
     <td>If set to true, validates the output specification (e.g. checking if the output directory already exists)
     used in saveAsHadoopFile and other variants. This can be disabled to silence exceptions due to pre-existing
     output directories. We recommend that users do not disable this except if trying to achieve compatibility with
-    previous versions of Spark. Simply use Hadoop's FileSystem API to delete output directories by hand.</td>
+    previous versions of Spark. Simply use Hadoop's FileSystem API to delete output directories by hand.
+    This setting is ignored for jobs launched by the Spark Streaming scheduler, since data may need
+    to be written to a pre-existing output directory during checkpoint recovery.</td>
 </tr>
 <tr>
     <td><code>spark.hadoop.cloneConf</code></td>

--- a/external/flume/src/test/scala/org/apache/spark/streaming/flume/FlumeStreamSuite.scala
+++ b/external/flume/src/test/scala/org/apache/spark/streaming/flume/FlumeStreamSuite.scala
@@ -19,13 +19,13 @@ package org.apache.spark.streaming.flume
 
 import java.net.{InetSocketAddress, ServerSocket}
 import java.nio.ByteBuffer
-import java.nio.charset.Charset
 
 import scala.collection.JavaConversions._
 import scala.collection.mutable.{ArrayBuffer, SynchronizedBuffer}
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
+import com.google.common.base.Charsets
 import org.apache.avro.ipc.NettyTransceiver
 import org.apache.avro.ipc.specific.SpecificRequestor
 import org.apache.flume.source.avro
@@ -138,7 +138,7 @@ class FlumeStreamSuite extends FunSuite with BeforeAndAfter with Matchers with L
       status should be (avro.Status.OK)
     }
     
-    val decoder = Charset.forName("UTF-8").newDecoder()    
+    val decoder = Charsets.UTF_8.newDecoder()
     eventually(timeout(10 seconds), interval(100 milliseconds)) {
       val outputEvents = outputBuffer.flatten.map { _.event }
       outputEvents.foreach {

--- a/streaming/src/main/scala/org/apache/spark/streaming/Interval.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/Interval.scala
@@ -47,14 +47,3 @@ class Interval(val beginTime: Time, val endTime: Time) {
 
   override def toString = "[" + beginTime + ", " + endTime + "]"
 }
-
-private[streaming]
-object Interval {
-  def currentInterval(duration: Duration): Interval  = {
-    val time = new Time(System.currentTimeMillis)
-    val intervalBegin = time.floor(duration)
-    new Interval(intervalBegin, intervalBegin + duration)
-  }
-}
-
-

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
@@ -74,12 +74,14 @@ class FileInputDStream[K: ClassTag, V: ClassTag, F <: NewInputFormat[K,V] : Clas
     newFilesOnly: Boolean = true)
   extends InputDStream[(K, V)](ssc_) {
 
+  @transient private val clock = ssc.scheduler.clock
+
   // Data to be saved as part of the streaming checkpoints
   protected[streaming] override val checkpointData = new FileInputDStreamCheckpointData
 
   // Initial ignore threshold based on which old, existing files in the directory (at the time of
   // starting the streaming application) will be ignored or considered
-  private val initialModTimeIgnoreThreshold = if (newFilesOnly) System.currentTimeMillis() else 0L
+  private val initialModTimeIgnoreThreshold = if (newFilesOnly) clock.currentTime() else 0L
 
   /*
    * Make sure that the information of files selected in the last few batches are remembered.
@@ -151,7 +153,7 @@ class FileInputDStream[K: ClassTag, V: ClassTag, F <: NewInputFormat[K,V] : Clas
    */
   private def findNewFiles(currentTime: Long): Array[String] = {
     try {
-      lastNewFileFindingTime = System.currentTimeMillis
+      lastNewFileFindingTime = clock.currentTime()
 
       // Calculate ignore threshold
       val modTimeIgnoreThreshold = math.max(
@@ -164,7 +166,7 @@ class FileInputDStream[K: ClassTag, V: ClassTag, F <: NewInputFormat[K,V] : Clas
         def accept(path: Path): Boolean = isNewFile(path, currentTime, modTimeIgnoreThreshold)
       }
       val newFiles = fs.listStatus(directoryPath, filter).map(_.getPath.toString)
-      val timeTaken = System.currentTimeMillis - lastNewFileFindingTime
+      val timeTaken = clock.currentTime() - lastNewFileFindingTime
       logInfo("Finding new files took " + timeTaken + " ms")
       logDebug("# cached file times = " + fileToModTime.size)
       if (timeTaken > slideDuration.milliseconds) {

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
@@ -74,7 +74,8 @@ class FileInputDStream[K: ClassTag, V: ClassTag, F <: NewInputFormat[K,V] : Clas
     newFilesOnly: Boolean = true)
   extends InputDStream[(K, V)](ssc_) {
 
-  @transient private val clock = ssc.scheduler.clock
+  // This is a def so that it works during checkpoint recovery:
+  private def clock = ssc.scheduler.clock
 
   // Data to be saved as part of the streaming checkpoints
   protected[streaming] override val checkpointData = new FileInputDStreamCheckpointData

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
@@ -22,6 +22,7 @@ import scala.collection.JavaConversions._
 import java.util.concurrent.{TimeUnit, ConcurrentHashMap, Executors}
 import akka.actor.{ActorRef, Actor, Props}
 import org.apache.spark.{SparkException, Logging, SparkEnv}
+import org.apache.spark.rdd.PairRDDFunctions
 import org.apache.spark.streaming._
 
 
@@ -168,7 +169,12 @@ class JobScheduler(val ssc: StreamingContext) extends Logging {
   private class JobHandler(job: Job) extends Runnable {
     def run() {
       eventActor ! JobStarted(job)
-      job.run()
+      // Disable checks for existing output directories in jobs launched by the streaming scheduler,
+      // since we may need to write output to an existing directory during checkpoint recovery;
+      // see SPARK-4835 for more details.
+      PairRDDFunctions.disableOutputSpecValidation.withValue(true) {
+        job.run()
+      }
       eventActor ! JobCompleted(job)
     }
   }

--- a/streaming/src/main/scala/org/apache/spark/streaming/util/Clock.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/util/Clock.scala
@@ -59,9 +59,11 @@ class SystemClock() extends Clock {
 private[streaming]
 class ManualClock() extends Clock {
 
-  var time = 0L
+  private var time = 0L
 
-  def currentTime() = time
+  def currentTime() = this.synchronized {
+    time
+  }
 
   def setTime(timeToSet: Long) = {
     this.synchronized {

--- a/streaming/src/test/scala/org/apache/spark/streaming/BasicOperationsSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/BasicOperationsSuite.scala
@@ -639,7 +639,7 @@ class BasicOperationsSuite extends TestSuiteBase {
       if (rememberDuration != null) ssc.remember(rememberDuration)
       val output = runStreams[(Int, Int)](ssc, cleanupTestInput.size, numExpectedOutput)
       val clock = ssc.scheduler.clock.asInstanceOf[ManualClock]
-      assert(clock.time === Seconds(10).milliseconds)
+      assert(clock.currentTime() === Seconds(10).milliseconds)
       assert(output.size === numExpectedOutput)
       operatedStream
     }

--- a/streaming/src/test/scala/org/apache/spark/streaming/CheckpointSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/CheckpointSuite.scala
@@ -449,12 +449,12 @@ class CheckpointSuite extends TestSuiteBase {
   def advanceTimeWithRealDelay[V: ClassTag](ssc: StreamingContext, numBatches: Int): Seq[Seq[V]] = {
     val clock = ssc.scheduler.clock.asInstanceOf[ManualClock]
     val waiter = new StreamingTestWaiter(ssc)
-    logInfo("Manual clock before advancing = " + clock.time)
+    logInfo("Manual clock before advancing = " + clock.currentTime())
     for (i <- 1 to numBatches) {
       clock.addToTime(batchDuration.milliseconds)
       waiter.waitForTotalBatchesCompleted(i, timeout = Durations.seconds(10))
     }
-    logInfo("Manual clock after advancing = " + clock.time)
+    logInfo("Manual clock after advancing = " + clock.currentTime())
 
     val outputStream = ssc.graph.getOutputStreams.filter { dstream =>
       dstream.isInstanceOf[TestOutputStreamWithPartitions[V]]

--- a/streaming/src/test/scala/org/apache/spark/streaming/CheckpointSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/CheckpointSuite.scala
@@ -276,7 +276,7 @@ class CheckpointSuite extends TestSuiteBase {
   // the master failure and uses them again to process a large window operation.
   // It also tests whether batches, whose processing was incomplete due to the
   // failure, are re-processed or not.
-  test("recovery with file input ztream") {
+  test("recovery with file input stream") {
     // Set up the streaming context and input streams
     val batchDuration = Seconds(2)  // Due to 1-second resolution of setLastModified() on some OS's.
     val testDir = Utils.createTempDir()

--- a/streaming/src/test/scala/org/apache/spark/streaming/CheckpointSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/CheckpointSuite.scala
@@ -21,8 +21,6 @@ import java.io.File
 import java.nio.charset.Charset
 
 import scala.collection.mutable.ArrayBuffer
-import scala.concurrent.duration._
-import scala.language.postfixOps
 import scala.reflect.ClassTag
 
 import com.google.common.io.Files
@@ -423,7 +421,7 @@ class CheckpointSuite extends TestSuiteBase {
     val waiter = new StreamingTestWaiter(ssc)
     ssc.start()
     // Wait for the last batch before restart to be re-processed:
-    waiter.waitForTotalBatchesCompleted(1, timeout = 10 seconds)
+    waiter.waitForTotalBatchesCompleted(1, timeout = Durations.seconds(10))
     val outputNew = advanceTimeWithRealDelay[V](ssc, nextNumBatches)
     // the first element will be re-processed data of the last batch before restart
     verifyOutput(outputNew, expectedOutput.takeRight(nextNumExpectedOutputs), useSet = true)
@@ -441,7 +439,7 @@ class CheckpointSuite extends TestSuiteBase {
     logInfo("Manual clock before advancing = " + clock.time)
     for (i <- 1 to numBatches) {
       clock.addToTime(batchDuration.milliseconds)
-      waiter.waitForTotalBatchesCompleted(i, timeout = 10 seconds)
+      waiter.waitForTotalBatchesCompleted(i, timeout = Durations.seconds(10))
     }
     logInfo("Manual clock after advancing = " + clock.time)
 

--- a/streaming/src/test/scala/org/apache/spark/streaming/CheckpointSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/CheckpointSuite.scala
@@ -18,11 +18,11 @@
 package org.apache.spark.streaming
 
 import java.io.File
-import java.nio.charset.Charset
 
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
 
+import com.google.common.base.Charsets
 import com.google.common.io.Files
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
@@ -305,7 +305,7 @@ class CheckpointSuite extends TestSuiteBase {
     // var clock = ssc.scheduler.clock.asInstanceOf[ManualClock]
     Thread.sleep(1000)
     for (i <- Seq(1, 2, 3)) {
-      Files.write(i + "\n", new File(testDir, i.toString), Charset.forName("UTF-8"))
+      Files.write(i + "\n", new File(testDir, i.toString), Charsets.UTF_8)
       // wait to make sure that the file is written such that it gets shown in the file listings
       Thread.sleep(1000)
     }
@@ -322,7 +322,7 @@ class CheckpointSuite extends TestSuiteBase {
 
     // Create files while the master is down
     for (i <- Seq(4, 5, 6)) {
-      Files.write(i + "\n", new File(testDir, i.toString), Charset.forName("UTF-8"))
+      Files.write(i + "\n", new File(testDir, i.toString), Charsets.UTF_8)
       Thread.sleep(1000)
     }
 
@@ -338,7 +338,7 @@ class CheckpointSuite extends TestSuiteBase {
     // Restart stream computation
     ssc.start()
     for (i <- Seq(7, 8, 9)) {
-      Files.write(i + "\n", new File(testDir, i.toString), Charset.forName("UTF-8"))
+      Files.write(i + "\n", new File(testDir, i.toString), Charsets.UTF_8)
       Thread.sleep(1000)
     }
     Thread.sleep(1000)

--- a/streaming/src/test/scala/org/apache/spark/streaming/InputStreamsSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/InputStreamsSuite.scala
@@ -19,7 +19,6 @@ package org.apache.spark.streaming
 
 import java.io.{File, BufferedWriter, OutputStreamWriter}
 import java.net.{InetSocketAddress, SocketException, ServerSocket}
-import java.nio.charset.Charset
 import java.util.concurrent.{Executors, TimeUnit, ArrayBlockingQueue}
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -27,6 +26,7 @@ import scala.collection.mutable.{SynchronizedBuffer, ArrayBuffer, SynchronizedQu
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
+import com.google.common.base.Charsets
 import com.google.common.io.Files
 import org.scalatest.BeforeAndAfter
 import org.scalatest.concurrent.Eventually._
@@ -193,7 +193,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
     try {
       val testDir = Utils.createTempDir()
       val existingFile = new File(testDir, "0")
-      Files.write("0\n", existingFile, Charset.forName("UTF-8"))
+      Files.write("0\n", existingFile, Charsets.UTF_8)
 
       Thread.sleep(1000)
       // Set up the streaming context and input streams
@@ -212,7 +212,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
       input.foreach { i =>
         Thread.sleep(batchDuration.milliseconds)
         val file = new File(testDir, i.toString)
-        Files.write(i + "\n", file, Charset.forName("UTF-8"))
+        Files.write(i + "\n", file, Charsets.UTF_8)
         logInfo("Created file " + file)
       }
 

--- a/streaming/src/test/scala/org/apache/spark/streaming/InputStreamsSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/InputStreamsSuite.scala
@@ -67,7 +67,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
       Thread.sleep(500)  // This call is to allow time for the testServer to send the data to Spark
       clock.addToTime(batchDuration.milliseconds)
     }
-    waiter.waitForTotalBatchesCompleted(input.size, timeout = 10 seconds)
+    waiter.waitForTotalBatchesCompleted(input.size, timeout = Durations.seconds(10))
     logInfo("Stopping server")
     testServer.stop()
     logInfo("Stopping context")
@@ -146,7 +146,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
       inputIterator.take(2).foreach(i => queue += ssc.sparkContext.makeRDD(Seq(i)))
       clock.addToTime(batchDuration.milliseconds)
     }
-    waiter.waitForTotalBatchesCompleted(input.size, timeout = 10 seconds)
+    waiter.waitForTotalBatchesCompleted(input.size, timeout = Durations.seconds(10))
 
     logInfo("Stopping context")
     ssc.stop()
@@ -175,12 +175,12 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
     val inputIterator = input.toIterator
     inputIterator.take(3).foreach(i => queue += ssc.sparkContext.makeRDD(Seq(i)))
     clock.addToTime(batchDuration.milliseconds)
-    waiter.waitForTotalBatchesCompleted(1, timeout = 10 seconds)
+    waiter.waitForTotalBatchesCompleted(1, timeout = Durations.seconds(10))
 
     // Enqueue the remaining items (again one by one), merged in the final batch
     inputIterator.foreach(i => queue += ssc.sparkContext.makeRDD(Seq(i)))
     clock.addToTime(batchDuration.milliseconds)
-    waiter.waitForTotalBatchesCompleted(2, timeout = 10 seconds)
+    waiter.waitForTotalBatchesCompleted(2, timeout = Durations.seconds(10))
     logInfo("Stopping context")
     ssc.stop()
 

--- a/streaming/src/test/scala/org/apache/spark/streaming/InputStreamsSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/InputStreamsSuite.scala
@@ -17,10 +17,6 @@
 
 package org.apache.spark.streaming
 
-import akka.actor.Actor
-import akka.actor.Props
-import akka.util.ByteString
-
 import java.io.{File, BufferedWriter, OutputStreamWriter}
 import java.net.{InetSocketAddress, SocketException, ServerSocket}
 import java.nio.charset.Charset
@@ -54,6 +50,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
 
     // Set up the streaming context and input streams
     val ssc = new StreamingContext(conf, batchDuration)
+    val waiter = new StreamingTestWaiter(ssc)
     val networkStream = ssc.socketTextStream(
       "localhost", testServer.port, StorageLevel.MEMORY_AND_DISK)
     val outputBuffer = new ArrayBuffer[Seq[String]] with SynchronizedBuffer[Seq[String]]
@@ -66,13 +63,12 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
     val clock = ssc.scheduler.clock.asInstanceOf[ManualClock]
     val input = Seq(1, 2, 3, 4, 5)
     val expectedOutput = input.map(_.toString)
-    Thread.sleep(1000)
     for (i <- 0 until input.size) {
       testServer.send(input(i).toString + "\n")
-      Thread.sleep(500)
+      Thread.sleep(500)  // This sleep is to wait for `testServer` to send the data to Spark
       clock.addToTime(batchDuration.milliseconds)
+      waiter.waitForBatchToComplete()
     }
-    Thread.sleep(1000)
     logInfo("Stopping server")
     testServer.stop()
     logInfo("Stopping context")

--- a/streaming/src/test/scala/org/apache/spark/streaming/InputStreamsSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/InputStreamsSuite.scala
@@ -55,14 +55,13 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
       "localhost", testServer.port, StorageLevel.MEMORY_AND_DISK)
     val outputBuffer = new ArrayBuffer[Seq[String]] with SynchronizedBuffer[Seq[String]]
     val outputStream = new TestOutputStream(networkStream, outputBuffer)
-    def output = outputBuffer.flatMap(x => x)
     outputStream.register()
     ssc.start()
 
     // Feed data to the server to send to the network receiver
     val clock = ssc.scheduler.clock.asInstanceOf[ManualClock]
     val input = Seq(1, 2, 3, 4, 5)
-    val expectedOutput = input.map(_.toString)
+    val expectedOutput: Seq[Seq[String]] = input.map(i => Seq(i.toString))
     for (i <- 0 until input.size) {
       testServer.send(input(i).toString + "\n")
       Thread.sleep(500)  // This sleep is to wait for `testServer` to send the data to Spark
@@ -74,22 +73,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
     logInfo("Stopping context")
     ssc.stop()
 
-    // Verify whether data received was as expected
-    logInfo("--------------------------------")
-    logInfo("output.size = " + outputBuffer.size)
-    logInfo("output")
-    outputBuffer.foreach(x => logInfo("[" + x.mkString(",") + "]"))
-    logInfo("expected output.size = " + expectedOutput.size)
-    logInfo("expected output")
-    expectedOutput.foreach(x => logInfo("[" + x.mkString(",") + "]"))
-    logInfo("--------------------------------")
-
-    // Verify whether all the elements received are as expected
-    // (whether the elements were received one in each interval is not verified)
-    assert(output.size === expectedOutput.size)
-    for (i <- 0 until output.size) {
-      assert(output(i) === expectedOutput(i))
-    }
+    verifyOutput(outputBuffer, expectedOutput, useSet = false)
   }
 
 
@@ -166,21 +150,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
     logInfo("Stopping context")
     ssc.stop()
 
-    // Verify whether data received was as expected
-    logInfo("--------------------------------")
-    logInfo("output.size = " + outputBuffer.size)
-    logInfo("output")
-    outputBuffer.foreach(x => logInfo("[" + x.mkString(",") + "]"))
-    logInfo("expected output.size = " + expectedOutput.size)
-    logInfo("expected output")
-    expectedOutput.foreach(x => logInfo("[" + x.mkString(",") + "]"))
-    logInfo("--------------------------------")
-
-    // Verify whether all the elements received are as expected
-    assert(output.size === expectedOutput.size)
-    for (i <- 0 until output.size) {
-      assert(output(i) === expectedOutput(i))
-    }
+    verifyOutput(outputBuffer, expectedOutput, useSet = false)
   }
 
   test("queue input stream - oneAtATime = false") {
@@ -212,21 +182,7 @@ class InputStreamsSuite extends TestSuiteBase with BeforeAndAfter {
     logInfo("Stopping context")
     ssc.stop()
 
-    // Verify whether data received was as expected
-    logInfo("--------------------------------")
-    logInfo("output.size = " + outputBuffer.size)
-    logInfo("output")
-    outputBuffer.foreach(x => logInfo("[" + x.mkString(",") + "]"))
-    logInfo("expected output.size = " + expectedOutput.size)
-    logInfo("expected output")
-    expectedOutput.foreach(x => logInfo("[" + x.mkString(",") + "]"))
-    logInfo("--------------------------------")
-
-    // Verify whether all the elements received are as expected
-    assert(output.size === expectedOutput.size)
-    for (i <- 0 until output.size) {
-      assert(output(i) === expectedOutput(i))
-    }
+    verifyOutput(outputBuffer, expectedOutput, useSet = false)
   }
 
   def testFileStream(newFilesOnly: Boolean) {

--- a/streaming/src/test/scala/org/apache/spark/streaming/MasterFailureTest.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/MasterFailureTest.scala
@@ -27,9 +27,9 @@ import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
 
 import java.io.{File, IOException}
-import java.nio.charset.Charset
 import java.util.UUID
 
+import com.google.common.base.Charsets
 import com.google.common.io.Files
 
 import org.apache.hadoop.fs.Path
@@ -362,7 +362,7 @@ class FileGeneratingThread(input: Seq[String], testDir: Path, interval: Long)
         val localFile = new File(localTestDir, (i + 1).toString)
         val hadoopFile = new Path(testDir, (i + 1).toString)
         val tempHadoopFile = new Path(testDir, ".tmp_" + (i + 1).toString)
-        Files.write(input(i) + "\n", localFile, Charset.forName("UTF-8"))
+        Files.write(input(i) + "\n", localFile, Charsets.UTF_8)
         var tries = 0
         var done = false
             while (!done && tries < maxTries) {

--- a/streaming/src/test/scala/org/apache/spark/streaming/MasterFailureTest.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/MasterFailureTest.scala
@@ -34,10 +34,10 @@ import com.google.common.io.Files
 
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.conf.Configuration
-
+import org.scalatest.Assertions
 
 private[streaming]
-object MasterFailureTest extends Logging {
+object MasterFailureTest extends Logging with Assertions {
 
   @volatile var killed = false
   @volatile var killCount = 0
@@ -81,7 +81,7 @@ object MasterFailureTest extends Logging {
 
     // Verify whether all the values of the expected output is present
     // in the output
-    assert(output.distinct.toSet == expectedOutput.toSet)
+    assert(output.distinct.toSet === expectedOutput.toSet)
   }
 
 
@@ -114,7 +114,7 @@ object MasterFailureTest extends Logging {
 
     // Verify whether the last expected output value has been generated, there by
     // confirming that none of the inputs have been missed
-    assert(output.last == expectedOutput.last)
+    assert(output.last === expectedOutput.last)
   }
 
   /**
@@ -130,7 +130,7 @@ object MasterFailureTest extends Logging {
   ): Seq[T] = {
 
     // Just making sure that the expected output does not have duplicates
-    assert(expectedOutput.distinct.toSet == expectedOutput.toSet)
+    assert(expectedOutput.distinct.toSet === expectedOutput.toSet)
 
     // Reset all state
     reset()

--- a/streaming/src/test/scala/org/apache/spark/streaming/TestSuiteBase.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/TestSuiteBase.scala
@@ -111,7 +111,7 @@ class TestOutputStreamWithPartitions[T: ClassTag](parent: DStream[T],
  * Internally, this is implemented using a StreamingListener.  Constructing a new instance of this
  * class automatically registers a StreamingListener on the given StreamingContext.
  */
-  class StreamingTestWaiter(ssc: StreamingContext) {
+class StreamingTestWaiter(ssc: StreamingContext) {
 
   // All access to this state should be guarded by `StreamingListener.this.synchronized`
   private var numCompletedBatches = 0
@@ -143,7 +143,7 @@ class TestOutputStreamWithPartitions[T: ClassTag](parent: DStream[T],
     }
     if (!successful && timedOut) {
       throw new TimeoutException(s"Waited for $targetNumBatches completed batches, but only" +
-      s" $numCompletedBatches have completed after $timeout")
+        s" $numCompletedBatches have completed after $timeout")
     }
   }
 }

--- a/streaming/src/test/scala/org/apache/spark/streaming/TestSuiteBase.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/TestSuiteBase.scala
@@ -365,7 +365,7 @@ trait TestSuiteBase extends FunSuite with BeforeAndAfter with Logging {
 
       // Advance manual clock
       val clock = ssc.scheduler.clock.asInstanceOf[ManualClock]
-      logInfo("Manual clock before advancing = " + clock.time)
+      logInfo("Manual clock before advancing = " + clock.currentTime())
       if (actuallyWait) {
         for (i <- 1 to numBatches) {
           logInfo("Actually waiting for " + batchDuration)
@@ -375,7 +375,7 @@ trait TestSuiteBase extends FunSuite with BeforeAndAfter with Logging {
       } else {
         clock.addToTime(numBatches * batchDuration.milliseconds)
       }
-      logInfo("Manual clock after advancing = " + clock.time)
+      logInfo("Manual clock after advancing = " + clock.currentTime())
 
       // Wait until expected number of output items have been generated
       val startTime = System.currentTimeMillis()

--- a/streaming/src/test/scala/org/apache/spark/streaming/TestSuiteBase.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/TestSuiteBase.scala
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeoutException
 
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.mutable.SynchronizedBuffer
-import scala.concurrent.duration.{Duration => SDuration}
+import scala.concurrent.duration.FiniteDuration
 import scala.reflect.ClassTag
 
 import org.scalatest.{BeforeAndAfter, FunSuite}
@@ -135,10 +135,10 @@ class TestOutputStreamWithPartitions[T: ClassTag](parent: DStream[T],
    */
   def waitForTotalBatchesCompleted(
       targetNumBatches: Int,
-      timeout: SDuration = SDuration.Inf): Unit = this.synchronized {
+      timeout: FiniteDuration): Unit = this.synchronized {
     val startTime = System.nanoTime
-    def timedOut = timeout < SDuration.Inf && (System.nanoTime - startTime) >= timeout.toNanos
     def successful = getNumCompletedBatches >= targetNumBatches
+    def timedOut = (System.nanoTime - startTime) >= timeout.toNanos
     while (!timedOut && !successful) {
       this.wait(timeout.toMillis)
     }


### PR DESCRIPTION
**Update:** we have decided to split this into a series of smaller PRs: #3801 and #3832.

This is a work-in-progress PR towards removing many of the `Thread.sleep()` calls from Spark Streaming's test suite, since I think that these calls make these tests race-prone and flaky.

**Running list of the JIRAs that this patch addresses / intends to address**:
- [SPARK-4835](https://issues.apache.org/jira/browse/SPARK-4835): "Streaming saveAs*HadoopFiles() methods may throw FileAlreadyExistsException during checkpoint recovery"
- [SPARK-1600](https://issues.apache.org/jira/browse/SPARK-1600): "Flaky "recovery with file input stream" test in streaming.CheckpointSuite"

**TODOS**:
- [x] Fix SPARK-1600 by removing the `Thread.sleep` calls from the `recovery with file input stream` test.  There are several uses of `Thread.sleep` here which seem to serve several different purposes, so this will require some care.
- [x] Remove the sleep calls in `InputStreamSuite`.  Most of these cases look simple to replace with the new StreamingTestWaiter, but the `testFileStream` case looks like it could be tricky.  Going to defer removing the sleeps from `multi-thread receiver` since that looks like a bit of work and we can do it later if we observe flakiness.
- [ ] Investigate the uses in `ReceiverSuite`.  There are a few `Thread.sleep(0)` cases which seem confusing; if they're still necessary, they should be commented.
- [ ] Might be able to remove one or two low-hanging fruit calls in `MasterFailureTest`, since these seem to be blocking on events like the StreamingContext starting and we have waiters for this.
- [ ] Determine whether the fix for SPARK-4835 should be done differently (see discussion on JIRA).
