### PR TITLE
[SPARK-4845][Core] Adding a parallelismRatio to control the partitions num of shuffledRDD

### DIFF
--- a/core/src/main/scala/org/apache/spark/Partitioner.scala
+++ b/core/src/main/scala/org/apache/spark/Partitioner.scala
@@ -49,8 +49,8 @@ object Partitioner {
    * defaultParallelism, otherwise we'll use the max number of upstream partitions.
    *
    * Unless spark.default.parallelism is set, the number of partitions will be the
-   * same as the number of partitions in the largest upstream RDD, as this should
-   * be least likely to cause out-of-memory errors.
+   * same as { number of partitions in the largest upstream RDD * spark.default.parallelismRatio },
+   * as this should be least likely to cause out-of-memory errors.
    *
    * We use two method parameters (rdd, others) to enforce callers passing at least 1 RDD.
    */
@@ -62,7 +62,10 @@ object Partitioner {
     if (rdd.context.conf.contains("spark.default.parallelism")) {
       new HashPartitioner(rdd.context.defaultParallelism)
     } else {
-      new HashPartitioner(bySize.head.partitions.size)
+      val numPartitons: Int =
+        rdd.context.conf
+          .getDouble("spark.default.parallelismRatio", 1) * bySize.head.partitions.size
+      new HashPartitioner(Math.max(1, numPartitons))
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/Partitioner.scala
+++ b/core/src/main/scala/org/apache/spark/Partitioner.scala
@@ -62,10 +62,10 @@ object Partitioner {
     if (rdd.context.conf.contains("spark.default.parallelism")) {
       new HashPartitioner(rdd.context.defaultParallelism)
     } else {
-      val numPartitons =
-        rdd.context.conf
-          .getDouble("spark.default.parallelismRatio", 1) * bySize.head.partitions.size
-      new HashPartitioner(Math.max(1, numPartitons.toInt))
+      val ratio = rdd.context.conf.getDouble("spark.default.parallelismRatio", 1)
+      require(ratio > 0, "spark.default.parallelismRatio must be greater than 0!")
+      val numPartitons = (ratio * bySize.head.partitions.size).toInt
+      new HashPartitioner(Math.max(1, numPartitons))
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/Partitioner.scala
+++ b/core/src/main/scala/org/apache/spark/Partitioner.scala
@@ -62,10 +62,10 @@ object Partitioner {
     if (rdd.context.conf.contains("spark.default.parallelism")) {
       new HashPartitioner(rdd.context.defaultParallelism)
     } else {
-      val numPartitons: Int =
+      val numPartitons =
         rdd.context.conf
           .getDouble("spark.default.parallelismRatio", 1) * bySize.head.partitions.size
-      new HashPartitioner(Math.max(1, numPartitons))
+      new HashPartitioner(Math.max(1, numPartitons.toInt))
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/Partitioner.scala
+++ b/core/src/main/scala/org/apache/spark/Partitioner.scala
@@ -49,7 +49,7 @@ object Partitioner {
    * defaultParallelism, otherwise we'll use the max number of upstream partitions.
    *
    * Unless spark.default.parallelism is set, the number of partitions will be the
-   * same as { number of partitions in the largest upstream RDD * spark.default.parallelismRatio },
+   * same as {number of partitions in the largest upstream RDD * spark.default.parallelismRatio},
    * as this should be least likely to cause out-of-memory errors.
    *
    * We use two method parameters (rdd, others) to enforce callers passing at least 1 RDD.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -618,6 +618,17 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+  <td><code>spark.default.parallelismRatio</code></td>
+  <td>1.0</td>
+  <td>
+    Default ratio to control the number of partitions in RDDs returned by transformations like
+    <code>join</code>, <code>reduceByKey</code>, and <code>parallelize</code> when not set by user,
+    which has lower priority than <code>spark.default.parallelism</code>. If it is set as 0.5,
+    it means the number of partitions in these RDDs will be
+    Max(1, 0.5 * number of partitions in the largest upstream RDD).
+  </td>
+</tr>
+<tr>
   <td><code>spark.broadcast.factory</code></td>
   <td>org.apache.spark.broadcast.<br />TorrentBroadcastFactory</td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -623,8 +623,8 @@ Apart from these, the following properties are also available, and may be useful
   <td>
     Default ratio to control the number of partitions in RDDs returned by transformations like
     <code>join</code>, <code>reduceByKey</code>, and <code>parallelize</code> when not set by user,
-    which has lower priority than <code>spark.default.parallelism</code>. If it is set as 0.5,
-    it means the number of partitions in these RDDs will be
+    which has lower priority than <code>spark.default.parallelism</code>. For examples, if it is
+    configured as 0.5, it means the number of partitions in these RDDs will be
     Max(1, 0.5 * number of partitions in the largest upstream RDD).
   </td>
 </tr>


### PR DESCRIPTION
Adding parallelismRatio to control the partitions num of shuffledRDD, the rule is:

```
 Math.max(1, parallelismRatio * number of partitions of the largest upstream RDD)
```

The ratio is 1.0 by default to make it compatible with the old version. When we have a good experience on it, we can change this.  
