### PR TITLE
[SPARK-4848] Stand-alone cluster: Allow differences between workers with multiple instances

### DIFF
--- a/sbin/start-slaves.sh
+++ b/sbin/start-slaves.sh
@@ -57,13 +57,4 @@ if [ "$START_TACHYON" == "true" ]; then
 fi
 
 # Launch the slaves
-if [ "$SPARK_WORKER_INSTANCES" = "" ]; then
-  exec "$sbin/slaves.sh" cd "$SPARK_HOME" \; "$sbin/start-slave.sh" 1 "spark://$SPARK_MASTER_IP:$SPARK_MASTER_PORT"
-else
-  if [ "$SPARK_WORKER_WEBUI_PORT" = "" ]; then
-    SPARK_WORKER_WEBUI_PORT=8081
-  fi
-  for ((i=0; i<$SPARK_WORKER_INSTANCES; i++)); do
-    "$sbin/slaves.sh" cd "$SPARK_HOME" \; "$sbin/start-slave.sh" $(( $i + 1 ))  "spark://$SPARK_MASTER_IP:$SPARK_MASTER_PORT" --webui-port $(( $SPARK_WORKER_WEBUI_PORT + $i ))
-  done
-fi
+"$sbin/slaves.sh" cd "$SPARK_HOME" \; "$sbin/start-slave.sh" "spark://$SPARK_MASTER_IP:$SPARK_MASTER_PORT"

--- a/sbin/stop-slave.sh
+++ b/sbin/stop-slave.sh
@@ -27,40 +27,10 @@ sbin="`cd "$sbin"; pwd`"
 
 . "$SPARK_PREFIX/bin/load-spark-env.sh"
 
-
-# First argument should be the master; we need to store it aside because we may
-# need to insert arguments between it and the other arguments
-MASTER=$1
-shift
-
-
-# Determine desired worker port
-
-# Start up the appropriate number of workers on this machine.
-if [ "$SPARK_WORKER_WEBUI_PORT" = "" ]; then
-  SPARK_WORKER_WEBUI_PORT=8081
-fi
-
 if [ "$SPARK_WORKER_INSTANCES" = "" ]; then
-  if [ "$SPARK_WORKER_PORT" = "" ]; then
-    PORT_FLAG=
-    PORT_NUM=
-  else
-    PORT_FLAG="--port"
-    PORT_NUM="$SPARK_WORKER_PORT"
-  fi
-
-  "$sbin"/spark-daemon.sh start org.apache.spark.deploy.worker.Worker 1 $MASTER --webui-port "$SPARK_WORKER_WEBUI_PORT" "$PORT_FLAG" "$PORT_NUM" "$@"
+  "$sbin"/spark-daemon.sh stop org.apache.spark.deploy.worker.Worker 1
 else
   for ((i=0; i<$SPARK_WORKER_INSTANCES; i++)); do
-    if [ "$SPARK_WORKER_PORT" = "" ]; then
-      PORT_FLAG=
-      PORT_NUM=
-    else
-      PORT_FLAG="--port"
-      PORT_NUM=$(( $SPARK_WORKER_PORT + $i ))
-    fi
-
-    "$sbin"/spark-daemon.sh start org.apache.spark.deploy.worker.Worker $(( 1 + $i )) $MASTER --webui-port $(( $SPARK_WORKER_WEBUI_PORT + $i )) "$PORT_FLAG" "$PORT_NUM" "$@"
+    "$sbin"/spark-daemon.sh stop org.apache.spark.deploy.worker.Worker $(( $i + 1 ))
   done
 fi

--- a/sbin/stop-slaves.sh
+++ b/sbin/stop-slaves.sh
@@ -17,8 +17,8 @@
 # limitations under the License.
 #
 
-sbin=`dirname "$0"`
-sbin=`cd "$sbin"; pwd`
+sbin="`dirname "$0"`"
+sbin="`cd "$sbin"; pwd`"
 
 . "$sbin/spark-config.sh"
 
@@ -29,10 +29,4 @@ if [ -e "$sbin"/../tachyon/bin/tachyon ]; then
   "$sbin/slaves.sh" cd "$SPARK_HOME" \; "$sbin"/../tachyon/bin/tachyon killAll tachyon.worker.Worker
 fi
 
-if [ "$SPARK_WORKER_INSTANCES" = "" ]; then
-  "$sbin"/spark-daemons.sh stop org.apache.spark.deploy.worker.Worker 1
-else
-  for ((i=0; i<$SPARK_WORKER_INSTANCES; i++)); do
-    "$sbin"/spark-daemons.sh stop org.apache.spark.deploy.worker.Worker $(( $i + 1 ))
-  done
-fi
+"$sbin/slaves.sh" cd "$SPARK_HOME" \; "$sbin"/stop-slave.sh


### PR DESCRIPTION
I've changed the stand-alone cluster run scripts to allow different workers to have different numbers of instances, and base webui ports.

I did this by moving the loop over instances from start-slaves to start-slave.

In order to stop things properly, I had to make similar changes in stop-slaves (and introduce stop-slave).

While I was at it, I changed SPARK_WORKER_PORT to work the same way as SPARK_WORKER_UI_PORT, since the new methods works fine for both.
