### PR TITLE
[Hot Fix][Streaming] Fix WriteAheadLogBackedBlockRDDSuite

### DIFF
--- a/streaming/src/test/scala/org/apache/spark/streaming/rdd/WriteAheadLogBackedBlockRDDSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/rdd/WriteAheadLogBackedBlockRDDSuite.scala
@@ -137,7 +137,8 @@ class WriteAheadLogBackedBlockRDDSuite extends FunSuite with BeforeAndAfterAll {
       blockIds: Seq[BlockId]
     ): Seq[WriteAheadLogFileSegment] = {
     require(blockData.size === blockIds.size)
-    val writer = new WriteAheadLogWriter(new File(dir, Random.nextString(10)).toString, hadoopConf)
+    val writer = new WriteAheadLogWriter(
+      new File(dir, Random.alphanumeric.take(10).mkString).toString, hadoopConf)
     val segments = blockData.zip(blockIds).map { case (data, id) =>
       writer.write(blockManager.dataSerialize(id, data.iterator))
     }


### PR DESCRIPTION
`WriteAheadLogBackedBlockRDDSuite` failed due to the same random file name(https://amplab.cs.berkeley.edu/jenkins/job/SparkPullRequestBuilder/24456/consoleFull)

```
/tmp/1418645532799-0/??????????
[info] - Read data available only in write ahead log, and test storing in block manager *** FAILED *** (2 milliseconds)
```

Using another way to produce random file name(http://alvinalexander.com/scala/creating-random-strings-in-scala).
