### PR TITLE
[SPARK-4859][Core][Streaming] Improve LiveListenerBus and StreamingListenerBus

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/LiveListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/LiveListenerBus.scala
@@ -28,7 +28,8 @@ import org.apache.spark.util.Utils
  *
  * Until start() is called, all posted events are only buffered. Only after this listener bus
  * has started will events be actually propagated to all attached listeners. This listener bus
- * is stopped when it receives a SparkListenerShutdown event, which is posted using stop().
+ * will be stopped when stop() is called. After `stop()` is called, it won't accept new events.
+ * However, for the events in the bufer, it will still process them before it exits.
  */
 private[spark] class LiveListenerBus extends SparkListenerBus with Logging {
 

--- a/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
@@ -102,9 +102,6 @@ case class SparkListenerApplicationStart(appName: String, appId: Option[String],
 @DeveloperApi
 case class SparkListenerApplicationEnd(time: Long) extends SparkListenerEvent
 
-/** An event used in the listener to shutdown the listener daemon thread. */
-private[spark] case object SparkListenerShutdown extends SparkListenerEvent
-
 
 /**
  * :: DeveloperApi ::

--- a/core/src/main/scala/org/apache/spark/scheduler/SparkListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SparkListenerBus.scala
@@ -70,7 +70,6 @@ private[spark] trait SparkListenerBus extends Logging {
         foreachListener(_.onApplicationEnd(applicationEnd))
       case metricsUpdate: SparkListenerExecutorMetricsUpdate =>
         foreachListener(_.onExecutorMetricsUpdate(metricsUpdate))
-      case SparkListenerShutdown =>
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -85,7 +85,6 @@ private[spark] object JsonProtocol {
         applicationEndToJson(applicationEnd)
 
       // These aren't used, but keeps compiler happy
-      case SparkListenerShutdown => JNothing
       case SparkListenerExecutorMetricsUpdate(_, _) => JNothing
     }
   }

--- a/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
@@ -350,7 +350,6 @@ class JsonProtocolSuite extends FunSuite {
         assert(e1.sparkUser == e2.sparkUser)
       case (e1: SparkListenerApplicationEnd, e2: SparkListenerApplicationEnd) =>
         assert(e1.time == e2.time)
-      case (SparkListenerShutdown, SparkListenerShutdown) =>
       case _ => fail("Events don't match in types!")
     }
   }

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/StreamingListenerBus.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/StreamingListenerBus.scala
@@ -96,7 +96,9 @@ private[spark] class StreamingListenerBus() extends Logging {
   }
 
   private def foreachListener(f: StreamingListener => Unit): Unit = {
-    listeners.foreach { listener =>
+    val iter = listeners.iterator
+    while (iter.hasNext) {
+      val listener = iter.next()
       try {
         f(listener)
       } catch {

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/StreamingListenerBus.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/StreamingListenerBus.scala
@@ -28,7 +28,7 @@ import org.apache.spark.util.Utils
 /** Asynchronously passes StreamingListenerEvents to registered StreamingListeners. */
 private[spark] class StreamingListenerBus() extends Logging {
   // `listeners` will be set up during the initialization of the whole system and the number of
-  // listeners are small. The copying cost of CopyOnWriteArrayList will be little. With the help of
+  // listeners is small, so the copying cost of CopyOnWriteArrayList will be little. With the help of
   // CopyOnWriteArrayList, we can eliminate a lock during processing every event comparing to
   // SynchronizedBuffer.
   private val listeners = new CopyOnWriteArrayList[StreamingListener]()

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/StreamingListenerBus.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/StreamingListenerBus.scala
@@ -28,8 +28,8 @@ import org.apache.spark.util.Utils
 /** Asynchronously passes StreamingListenerEvents to registered StreamingListeners. */
 private[spark] class StreamingListenerBus() extends Logging {
   // `listeners` will be set up during the initialization of the whole system and the number of
-  // listeners is small, so the copying cost of CopyOnWriteArrayList will be little. With the help of
-  // CopyOnWriteArrayList, we can eliminate a lock during processing every event comparing to
+  // listeners is small, so the copying cost of CopyOnWriteArrayList will be little. With the help
+  // of CopyOnWriteArrayList, we can eliminate a lock during processing every event comparing to
   // SynchronizedBuffer.
   private val listeners = new CopyOnWriteArrayList[StreamingListener]()
 


### PR DESCRIPTION
Changes to LiveListenerBus and StreamingListenerBus:
- Fix the race condition of `queueFullErrorMessageLogged`.
- Make sure the SHUTDOWN message will be delivered to `listenerThread`.

Changes only to StreamingListenerBus:
- Log the error from listener rather than crashing `listenerThread`.
