### PR TITLE
[SPARK-4880] remove spark.locality.wait in Analytics

### DIFF
--- a/examples/src/main/scala/org/apache/spark/examples/graphx/Analytics.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/graphx/Analytics.scala
@@ -46,7 +46,7 @@ object Analytics extends Logging {
     }
     val options = mutable.Map(optionsList: _*)
 
-    val conf = new SparkConf().set("spark.locality.wait", "100000")
+    val conf = new SparkConf()
     GraphXUtils.registerKryoClasses(conf)
 
     val numEPart = options.remove("numEPart").map(_.toInt).getOrElse {


### PR DESCRIPTION
spark.locality.wait set to 100000 in examples/graphx/Analytics.scala.
Should be left to the user.
