### PR TITLE
SPARK-4910 [CORE] build failed (use of FileStatus.isFile in Hadoop 1.x)

### DIFF
--- a/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
@@ -65,11 +65,11 @@ class EventLoggingListenerSuite extends FunSuite with BeforeAndAfter with Loggin
     val logPath = new Path(eventLogger.logPath + EventLoggingListener.IN_PROGRESS)
     assert(fileSystem.exists(logPath))
     val logStatus = fileSystem.getFileStatus(logPath)
-    assert(logStatus.isFile)
+    assert(!logStatus.isDir)
 
     // Verify log is renamed after stop()
     eventLogger.stop()
-    assert(fileSystem.getFileStatus(new Path(eventLogger.logPath)).isFile())
+    assert(!fileSystem.getFileStatus(new Path(eventLogger.logPath)).isDir)
   }
 
   test("Basic event logging") {

--- a/core/src/test/scala/org/apache/spark/scheduler/ReplayListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/ReplayListenerSuite.scala
@@ -112,7 +112,7 @@ class ReplayListenerSuite extends FunSuite with BeforeAndAfter {
     val applications = fileSystem.listStatus(logDirPath)
     assert(applications != null && applications.size > 0)
     val eventLog = applications.sortBy(_.getModificationTime).last
-    assert(eventLog.isFile)
+    assert(!eventLog.isDir)
 
     // Replay events
     val (logData, version) = EventLoggingListener.openEventLog(eventLog.getPath(), fileSystem)


### PR DESCRIPTION
Fix small Hadoop 1 compile error from SPARK-2261. In Hadoop 1.x, all we have is FileStatus.isDir, so these "is file" assertions are changed to "is not a dir". This is how similar checks are done so far in the code base.
