### PR TITLE
[SPARK-4890] Ignore downloaded EC2 libs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ dev/create-release/*final
 spark-*-bin-*.tgz
 unit-tests.log
 /lib/
+ec2/lib/
 rat-results.txt
 scalastyle.txt
 scalastyle-output.xml


### PR DESCRIPTION
PR #3737 changed `spark-ec2` to automatically download boto from PyPI. This PR tell git to ignore those downloaded library files.
