### PR TITLE
[YARN][SPARK-4929] Bug fix: fix the yarn-client code to support HA

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -60,7 +60,7 @@ private[spark] class ApplicationMaster(args: ApplicationMasterArguments,
   @volatile private var exitCode = 0
   @volatile private var unregistered = false
   @volatile private var finished = false
-  @volatile private var finalStatus = FinalApplicationStatus.SUCCEEDED
+  @volatile private var finalStatus = getDefaultFinalStatus
   @volatile private var finalMsg: String = ""
   @volatile private var userClassThread: Thread = _
 
@@ -150,6 +150,19 @@ private[spark] class ApplicationMaster(args: ApplicationMasterArguments,
           "Uncaught exception: " + e.getMessage())
     }
     exitCode
+  }
+
+  /**
+   * we should distinct the default final status between client and cluster,
+   * because the SUCCEEDED status may cause the HA failed in client mode and
+   * UNDEFINED may cause the error reporter in cluster when using sys.exit.
+   */
+  final def getDefaultFinalStatus() = {
+    if (isDriver) {
+      FinalApplicationStatus.SUCCEEDED
+    } else {
+      FinalApplicationStatus.UNDEFINED
+    }
   }
 
   /**

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -153,9 +153,10 @@ private[spark] class ApplicationMaster(args: ApplicationMasterArguments,
   }
 
   /**
-   * we should distinct the default final status between client and cluster,
-   * because the SUCCEEDED status may cause the HA failed in client mode and
-   * UNDEFINED may cause the error reporter in cluster when using sys.exit.
+   * Set the default final application status for client mode to UNDEFINED to handle
+   * if YARN HA restarts the application so that it properly retries. Set the final
+   * status to SUCCEEDED in cluster mode to handle if the user calls System.exit
+   * from the application code.
    */
   final def getDefaultFinalStatus() = {
     if (isDriver) {


### PR DESCRIPTION
Nowadays, yarn-client will exit directly when the HA change happens no matter how many times the am should retry.
The reason may be that the default final status only considerred the sys.exit, and the yarn-client HA cann't benefit from this.
So we should distinct the default final status between client and cluster, because the SUCCEEDED status may cause the HA failed in client mode and UNDEFINED may cause the error reporter in cluster when using sys.exit.
