### PR TITLE
[SPARK-4930][SQL][DOCS]Update SQL programming guide, CACHE TABLE is eager

### DIFF
--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -1012,6 +1012,10 @@ let user control table caching explicitly:
 
 **NOTE:** `CACHE TABLE tbl` is now __eager__ by default not __lazy__. Don’t need to trigger cache materialization manually anymore.
 
+Spark SQL newly introduced a statement to let user control table caching whether or not lazy since Spark 1.2.0:
+
+	CACHE [LAZY] TABLE [AS SELECT] ...
+
 Several caching related features are not supported yet:
 
 * User defined partition level cache eviction policy

--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -1010,12 +1010,7 @@ let user control table caching explicitly:
     CACHE TABLE logs_last_month;
     UNCACHE TABLE logs_last_month;
 
-**NOTE:** `CACHE TABLE tbl` is lazy, similar to `.cache` on an RDD. This command only marks `tbl` to ensure that
-partitions are cached when calculated but doesn't actually cache it until a query that touches `tbl` is executed.
-To force the table to be cached, you may simply count the table immediately after executing `CACHE TABLE`:
-
-    CACHE TABLE logs_last_month;
-    SELECT COUNT(1) FROM logs_last_month;
+**NOTE:** `CACHE TABLE tbl` is now __eager__ by default not __lazy__. Don’t need to trigger cache materialization manually anymore.
 
 Several caching related features are not supported yet:
 


### PR DESCRIPTION
`CACHE TABLE tbl` is now **eager** by default not **lazy**
