### PR TITLE
[SPARK-4933][CORE] eventlog file not found 

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/ApplicationDescription.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/ApplicationDescription.scala
@@ -23,7 +23,7 @@ private[spark] class ApplicationDescription(
     val memoryPerSlave: Int,
     val command: Command,
     var appUiUrl: String,
-    val eventLogFile: Option[String] = None)
+    val eventLogDir: Option[String] = None)
   extends Serializable {
 
   val user = System.getProperty("user.name", "<unknown>")


### PR DESCRIPTION
enent log file not found exception will be thrown after making eventLog into a single file. And web ui will show "No event logs found for application xxx in xxx". Main cause is the wrong argument when getting log file.
