### PR TITLE
[SPARK-4951][Core] Fix the issue that a busy executor may be killed

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
@@ -101,8 +101,8 @@ private[spark] abstract class YarnSchedulerBackend(
   private class YarnSchedulerActor extends Actor {
     private var amActor: Option[ActorRef] = None
 
-    implicit val askAmActorExecutor =
-      ExecutionContext.fromExecutor(Utils.newDaemonCachedThreadPool("yarn-scheduler-ask-executor"))
+    implicit val askAmActorExecutor = ExecutionContext.fromExecutor(
+      Utils.newDaemonCachedThreadPool("yarn-scheduler-ask-am-executor"))
 
     override def preStart(): Unit = {
       // Listen for disassociation events
@@ -121,7 +121,7 @@ private[spark] abstract class YarnSchedulerBackend(
             Future {
               driverActor ! AkkaUtils.askWithReply[Boolean](r, actor, askTimeout)
             } onFailure {
-              case NonFatal(e) => logError(s"Ask ${r} unsuccessfully", e)
+              case NonFatal(e) => logError(s"Sending $r to AM was unsuccessful", e)
             }
           case None =>
             logWarning("Attempted to request executors before the AM has registered!")
@@ -135,7 +135,7 @@ private[spark] abstract class YarnSchedulerBackend(
             Future {
               driverActor ! AkkaUtils.askWithReply[Boolean](k, actor, askTimeout)
             } onFailure {
-              case NonFatal(e) => logError(s"Ask ${k} unsuccessfully", e)
+              case NonFatal(e) => logError(s"Sending $k to AM was unsuccessful", e)
             }
           case None =>
             logWarning("Attempted to kill executors before the AM has registered!")

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.scheduler.cluster
 
+import scala.concurrent.{Future, ExecutionContext}
+
 import akka.actor.{Actor, ActorRef, Props}
 import akka.remote.{DisassociatedEvent, RemotingLifecycleEvent}
 
@@ -24,7 +26,9 @@ import org.apache.spark.SparkContext
 import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages._
 import org.apache.spark.scheduler.TaskSchedulerImpl
 import org.apache.spark.ui.JettyUtils
-import org.apache.spark.util.AkkaUtils
+import org.apache.spark.util.{AkkaUtils, Utils}
+
+import scala.util.control.NonFatal
 
 /**
  * Abstract Yarn scheduler backend that contains common logic
@@ -97,6 +101,9 @@ private[spark] abstract class YarnSchedulerBackend(
   private class YarnSchedulerActor extends Actor {
     private var amActor: Option[ActorRef] = None
 
+    implicit val askAmActorExecutor =
+      ExecutionContext.fromExecutor(Utils.newDaemonCachedThreadPool("yarn-scheduler-ask-executor"))
+
     override def preStart(): Unit = {
       // Listen for disassociation events
       context.system.eventStream.subscribe(self, classOf[RemotingLifecycleEvent])
@@ -110,7 +117,12 @@ private[spark] abstract class YarnSchedulerBackend(
       case r: RequestExecutors =>
         amActor match {
           case Some(actor) =>
-            sender ! AkkaUtils.askWithReply[Boolean](r, actor, askTimeout)
+            val driverActor = sender
+            Future {
+              driverActor ! AkkaUtils.askWithReply[Boolean](r, actor, askTimeout)
+            } onFailure {
+              case NonFatal(e) => logError(s"Ask ${r} unsuccessfully", e)
+            }
           case None =>
             logWarning("Attempted to request executors before the AM has registered!")
             sender ! false
@@ -119,7 +131,12 @@ private[spark] abstract class YarnSchedulerBackend(
       case k: KillExecutors =>
         amActor match {
           case Some(actor) =>
-            sender ! AkkaUtils.askWithReply[Boolean](k, actor, askTimeout)
+            val driverActor = sender
+            Future {
+              driverActor ! AkkaUtils.askWithReply[Boolean](k, actor, askTimeout)
+            } onFailure {
+              case NonFatal(e) => logError(s"Ask ${k} unsuccessfully", e)
+            }
           case None =>
             logWarning("Attempted to kill executors before the AM has registered!")
             sender ! false

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -607,7 +607,7 @@ class ExecutorAllocationManagerSuite extends FunSuite with LocalSparkContext {
     assert(removeTimes(manager).size === 1)
   }
 
-  test("call onTaskStart before onBlockManagerAdded") {
+  test("SPARK-4951: call onTaskStart before onBlockManagerAdded") {
     sc = createSparkContext(2, 10)
     val manager = sc.executorAllocationManager.get
     assert(executorIds(manager).isEmpty)
@@ -621,7 +621,7 @@ class ExecutorAllocationManagerSuite extends FunSuite with LocalSparkContext {
     assert(removeTimes(manager).size === 0)
   }
 
-  test("onExecutorAdded should not add a busy executor to removeTimes") {
+  test("SPARK-4951: onExecutorAdded should not add a busy executor to removeTimes") {
     sc = createSparkContext(2, 10)
     val manager = sc.executorAllocationManager.get
     assert(executorIds(manager).isEmpty)

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -468,7 +468,7 @@ class ExecutorAllocationManagerSuite extends FunSuite with LocalSparkContext {
     assert(executorsPendingToRemove(manager).isEmpty)
     clock.tick(executorIdleTimeout * 1000)
     schedule(manager)
-    assert(removeTimes(manager).size === 1) // idle threshold exceeded (1 executor remaining)
+    assert(removeTimes(manager).isEmpty) // idle threshold exceeded
     assert(executorsPendingToRemove(manager).size === 2) // limit reached (1 executor remaining)
 
     // Mark a subset as busy - only idle executors should be removed
@@ -482,13 +482,11 @@ class ExecutorAllocationManagerSuite extends FunSuite with LocalSparkContext {
     onExecutorBusy(manager, "executor-5")
     onExecutorBusy(manager, "executor-6") // 3 busy and 2 idle (of the 5 active ones)
     schedule(manager)
-    // remove one idle executor (one of "executor-1", "executor-2", "executor-3") because
-    // its idle threshold is exceeded
-    assert(removeTimes(manager).size === 1)
+    assert(removeTimes(manager).size === 2) // remove only idle executors
     assert(!removeTimes(manager).contains("executor-4"))
     assert(!removeTimes(manager).contains("executor-5"))
     assert(!removeTimes(manager).contains("executor-6"))
-    assert(executorsPendingToRemove(manager).size === 3)
+    assert(executorsPendingToRemove(manager).size === 2)
     clock.tick(executorIdleTimeout * 1000)
     schedule(manager)
     assert(removeTimes(manager).isEmpty) // idle executors are removed
@@ -509,7 +507,7 @@ class ExecutorAllocationManagerSuite extends FunSuite with LocalSparkContext {
     assert(executorsPendingToRemove(manager).size === 4)
     clock.tick(executorIdleTimeout * 1000)
     schedule(manager)
-    assert(removeTimes(manager).size === 1) // idle threshold exceeded (1 executor remaining)
+    assert(removeTimes(manager).isEmpty)
     assert(executorsPendingToRemove(manager).size === 6) // limit reached (1 executor remaining)
   }
 


### PR DESCRIPTION
A few changes to fix this issue:
1. Handle the case that receiving `SparkListenerTaskStart` before `SparkListenerBlockManagerAdded`.
2. Don't add `executorId` to `removeTimes` when the executor is busy.
3. Use `HashMap.retain` to safely traverse the HashMap and remove items.
4. Use the same lock in ExecutorAllocationManager and ExecutorAllocationListener to fix the race condition in `totalPendingTasks`.
5. Move the blocking codes out of the message processing code in YarnSchedulerActor.
