### PR TITLE
[MLlib]Vectors.sparse() add support to unsorted indices

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
@@ -173,12 +173,13 @@ object Vectors {
    * Creates a sparse vector providing its index array and value array.
    *
    * @param size vector size.
-   * @param indices index array.
-   * @param values value array.
+   * @param indices index array, must be strictly increasing.
+   * @param values value array, must have the same length as indices.
    */
   def sparse(size: Int, indices: Array[Int], values: Array[Double]): Vector = {
-    val (newIndices, newValues) = indices.zip(values).sortBy(_._1).unzip
-    new SparseVector(size, newIndices, newValues)
+    require((1 until indices.length).forall(i => indices(i-1) <= indices(i)), 
+      "indices is not strictly increasing.")
+    new SparseVector(size, indices, values)
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
@@ -173,11 +173,13 @@ object Vectors {
    * Creates a sparse vector providing its index array and value array.
    *
    * @param size vector size.
-   * @param indices index array, must be strictly increasing.
-   * @param values value array, must have the same length as indices.
+   * @param indices index array.
+   * @param values value array.
    */
-  def sparse(size: Int, indices: Array[Int], values: Array[Double]): Vector =
-    new SparseVector(size, indices, values)
+  def sparse(size: Int, indices: Array[Int], values: Array[Double]): Vector = {
+    val (newIndices, newValues) = indices.zip(values).sortBy(_._1).unzip
+    new SparseVector(size, newIndices, newValues)
+  }
 
   /**
    * Creates a sparse vector using unordered (index, value) pairs.


### PR DESCRIPTION
For original method, when the indices is not strictly increasing, the sparse vector can be created without any warning or error. But when use apply() method, only zero will be returned.
