### PR TITLE
[EC2] Update default Spark version to 1.2.0

### DIFF
--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -39,7 +39,7 @@ from datetime import datetime
 from optparse import OptionParser
 from sys import stderr
 
-DEFAULT_SPARK_VERSION = "1.1.0"
+DEFAULT_SPARK_VERSION = "1.2.0"
 SPARK_EC2_DIR = os.path.dirname(os.path.realpath(__file__))
 
 MESOS_SPARK_EC2_BRANCH = "v4"

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -255,6 +255,7 @@ def get_spark_shark_version(opts):
         "1.0.1": "1.0.1",
         "1.0.2": "1.0.2",
         "1.1.0": "1.1.0",
+        "1.2.0": "1.2.0",
     }
     version = opts.spark_version.replace("v", "")
     if version not in spark_shark_map:


### PR DESCRIPTION
Now that 1.2.0 is out, let's update the default Spark version.
