### PR TITLE
[SPARK-3847] Prohibit Java enums from being used as partitioning keys; strengthen prohibitions on array keys in PairRDDFuncions

### DIFF
--- a/core/src/main/scala/org/apache/spark/Partitioner.scala
+++ b/core/src/main/scala/org/apache/spark/Partitioner.scala
@@ -70,10 +70,10 @@ object Partitioner {
    * Check whether the given partitioner can correctly partition keys of the given class.  This is
    * used to prevent Java arrays (SPARK-597) or enumerations (SPARK-3847) from being used with
    * HashPartitioner, since that will lead to incorrect results.  Since partitioning is an expensive
-   * operation, this method lets perform these checks once per transformation rather than once per
-   * record.
+   * operation, this method lets us perform these checks once per transformation rather than once
+   * per record.
    *
-   * @throws SparkException if the partitioner will behave incorrectly for keys of the given class.
+   * @throws SparkException if the partitioner does not support keys of the given class.
    */
   private[spark] def assertPartitionerSupportsKeyClass(
       partitioner: Partitioner,
@@ -82,7 +82,7 @@ object Partitioner {
       if (keyClass.isArray) {
         throw new SparkException("HashPartitioner cannot partition array keys (see SPARK-597)")
       } else if (classOf[Enum[_]].isAssignableFrom(keyClass)) {
-        throw new SparkException("HashPartitioner cannot partition Java enums (see SPARK-3847)")
+        throw new SparkException("HashPartitioner cannot partition Java enum keys (see SPARK-3847)")
       }
     }
   }
@@ -96,8 +96,8 @@ object Partitioner {
  * so attempting to partition an RDD[Array[_]] or RDD[(Array[_], _)] using a HashPartitioner will
  * produce an unexpected or incorrect result.  See SPARK-597 for more details.
  *
- * Similarly, Java Enums have hash hashCodes are JVM-dependent, so it is unsafe to compare the
- * hashCodes of Java Enums in different JVMs.  To work around this, you can either call toString()
+ * Similarly, Java Enums have hash hashCodes are JVM-dependent, so it is unsafe to compare enum
+ * hashCodes that were generated in different JVMs.  To work around this, you can call toString()
  * on the Enums and work with string values, or use Scala sealed traits and case objects to emulate
  * Java Enums.  See SPARK-3847 for more details.
  */

--- a/core/src/main/scala/org/apache/spark/Partitioner.scala
+++ b/core/src/main/scala/org/apache/spark/Partitioner.scala
@@ -78,6 +78,7 @@ object Partitioner {
   private[spark] def assertPartitionerSupportsKeyClass(
       partitioner: Partitioner,
       keyClass: Class[_]): Unit = {
+    // If you update this method, consider also updating the warnings at the top of PairRDDFunctions
     if (partitioner.isInstanceOf[HashPartitioner]) {
       if (keyClass.isArray) {
         throw new SparkException("HashPartitioner cannot partition array keys (see SPARK-597)")

--- a/core/src/main/scala/org/apache/spark/rdd/OrderedRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/OrderedRDDFunctions.scala
@@ -72,6 +72,8 @@ class OrderedRDDFunctions[K : Ordering : ClassTag,
    * because it can push the sorting down into the shuffle machinery.
    */
   def repartitionAndSortWithinPartitions(partitioner: Partitioner): RDD[(K, V)] = {
+    val keyClass = implicitly[ClassTag[K]].runtimeClass
+    Partitioner.assertPartitionerSupportsKeyClass(partitioner, keyClass)
     new ShuffledRDD[K, V, V](self, partitioner).setKeyOrdering(ordering)
   }
 

--- a/core/src/main/scala/org/apache/spark/rdd/OrderedRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/OrderedRDDFunctions.scala
@@ -73,7 +73,7 @@ class OrderedRDDFunctions[K : Ordering : ClassTag,
    */
   def repartitionAndSortWithinPartitions(partitioner: Partitioner): RDD[(K, V)] = {
     val keyClass = implicitly[ClassTag[K]].runtimeClass
-    Partitioner.assertPartitionerSupportsKeyClass(partitioner, keyClass)
+    Partitioner.assertHashCodeIsWellBehaved(keyClass)
     new ShuffledRDD[K, V, V](self, partitioner).setKeyOrdering(ordering)
   }
 

--- a/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
@@ -57,10 +57,6 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
   with Serializable
 {
 
-  if (keyClass.isArray) {
-    logWarning("Using arrays as keys may lead to incorrect results (see SPARK-597)")
-  }
-
   /**
    * Generic function to combine the elements for each key using a custom set of aggregation
    * functions. Turns an RDD[(K, V)] into a result of type RDD[(K, C)], for a "combined type" C
@@ -81,12 +77,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
       mapSideCombine: Boolean = true,
       serializer: Serializer = null): RDD[(K, C)] = {
     require(mergeCombiners != null, "mergeCombiners must be defined") // required as of Spark 0.9.0
-    if (mapSideCombine && keyClass.isArray) {
-      // Map-side combining with array keys won't lead to incorrect results, but it's ineffective
-      // because the arrays' hashcodes will be based on object identity rather than their contents
-      throw new SparkException("Map-side combining is not supported for array keys (see SPARK-597)")
-    }
-    Partitioner.assertPartitionerSupportsKeyClass(partitioner, keyClass)
+    Partitioner.assertHashCodeIsWellBehaved(keyClass)
     val aggregator = new Aggregator[K, V, C](
       self.context.clean(createCombiner),
       self.context.clean(mergeValue),
@@ -292,10 +283,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
    * before sending results to a reducer, similarly to a "combiner" in MapReduce.
    */
   def reduceByKeyLocally(func: (V, V) => V): Map[K, V] = {
-
-    if (keyClass.isArray) {
-      throw new SparkException("reduceByKeyLocally() does not support array keys (see SPARK-597)")
-    }
+    Partitioner.assertHashCodeIsWellBehaved(keyClass)
 
     val reducePartition = (iter: Iterator[(K, V)]) => {
       val map = new JHashMap[K, V]
@@ -469,7 +457,9 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
    * Return a copy of the RDD partitioned using the specified partitioner.
    */
   def partitionBy(partitioner: Partitioner): RDD[(K, V)] = {
-    Partitioner.assertPartitionerSupportsKeyClass(partitioner, keyClass)
+    if (partitioner.isInstanceOf[HashPartitioner]) {
+      Partitioner.assertHashCodeIsWellBehaved(keyClass)
+    }
     if (self.partitioner == Some(partitioner)) {
       self
     } else {
@@ -692,7 +682,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
       other3: RDD[(K, W3)],
       partitioner: Partitioner)
       : RDD[(K, (Iterable[V], Iterable[W1], Iterable[W2], Iterable[W3]))] = {
-    Partitioner.assertPartitionerSupportsKeyClass(partitioner, keyClass)
+    Partitioner.assertHashCodeIsWellBehaved(keyClass)
     val cg = new CoGroupedRDD[K](Seq(self, other1, other2, other3), partitioner)
     cg.mapValues { case Array(vs, w1s, w2s, w3s) =>
        (vs.asInstanceOf[Iterable[V]],
@@ -708,7 +698,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
    */
   def cogroup[W](other: RDD[(K, W)], partitioner: Partitioner)
       : RDD[(K, (Iterable[V], Iterable[W]))]  = {
-    Partitioner.assertPartitionerSupportsKeyClass(partitioner, keyClass)
+    Partitioner.assertHashCodeIsWellBehaved(keyClass)
     val cg = new CoGroupedRDD[K](Seq(self, other), partitioner)
     cg.mapValues { case Array(vs, w1s) =>
       (vs.asInstanceOf[Iterable[V]], w1s.asInstanceOf[Iterable[W]])
@@ -721,7 +711,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
    */
   def cogroup[W1, W2](other1: RDD[(K, W1)], other2: RDD[(K, W2)], partitioner: Partitioner)
       : RDD[(K, (Iterable[V], Iterable[W1], Iterable[W2]))] = {
-    Partitioner.assertPartitionerSupportsKeyClass(partitioner, keyClass)
+    Partitioner.assertHashCodeIsWellBehaved(keyClass)
     val cg = new CoGroupedRDD[K](Seq(self, other1, other2), partitioner)
     cg.mapValues { case Array(vs, w1s, w2s) =>
       (vs.asInstanceOf[Iterable[V]],

--- a/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
@@ -56,6 +56,13 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
   with SparkHadoopMapReduceUtil
   with Serializable
 {
+
+  if (keyClass.isArray) {
+    logWarning("Using arrays as keys may lead to incorrect results (see SPARK-597)")
+  } else if (classOf[Enum[_]].isAssignableFrom(keyClass)) {
+    logWarning("Using Java enums as keys may lead to incorrect results (see SPARK-3847)")
+  }
+
   /**
    * Generic function to combine the elements for each key using a custom set of aggregation
    * functions. Turns an RDD[(K, V)] into a result of type RDD[(K, C)], for a "combined type" C

--- a/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
@@ -59,8 +59,6 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
 
   if (keyClass.isArray) {
     logWarning("Using arrays as keys may lead to incorrect results (see SPARK-597)")
-  } else if (classOf[Enum[_]].isAssignableFrom(keyClass)) {
-    logWarning("Using Java enums as keys may lead to incorrect results (see SPARK-3847)")
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
@@ -78,7 +78,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
     require(mergeCombiners != null, "mergeCombiners must be defined") // required as of Spark 0.9.0
     if (mapSideCombine && keyClass.isArray) {
       // Map-side combining with array keys won't lead to incorrect results, but it's ineffective
-      // because the arrays' hashcodes will be based on object identity rather than their contents;
+      // because the arrays' hashcodes will be based on object identity rather than their contents
       throw new SparkException("Map-side combining is not supported for array keys (see SPARK-597)")
     }
     Partitioner.assertPartitionerSupportsKeyClass(partitioner, keyClass)
@@ -289,7 +289,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
   def reduceByKeyLocally(func: (V, V) => V): Map[K, V] = {
 
     if (keyClass.isArray) {
-      throw new SparkException("reduceByKeyLocally() does not support array keys")
+      throw new SparkException("reduceByKeyLocally() does not support array keys (see SPARK-597)")
     }
 
     val reducePartition = (iter: Iterator[(K, V)]) => {

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -964,7 +964,7 @@ abstract class RDD[T: ClassTag](
       : PartialResult[Map[T, BoundedDouble]] =
   {
     if (elementClassTag.runtimeClass.isArray) {
-      throw new SparkException("countByValueApprox() does not support arrays")
+      throw new SparkException("countByValueApprox() does not support arrays (see SPARK-597)")
     }
     val countPartition: (TaskContext, Iterator[T]) => OpenHashMap[T,Long] = { (ctx, iter) =>
       val map = new OpenHashMap[T,Long]

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -963,9 +963,7 @@ abstract class RDD[T: ClassTag](
       (implicit ord: Ordering[T] = null)
       : PartialResult[Map[T, BoundedDouble]] =
   {
-    if (elementClassTag.runtimeClass.isArray) {
-      throw new SparkException("countByValueApprox() does not support arrays (see SPARK-597)")
-    }
+    Partitioner.assertHashCodeIsWellBehaved(elementClassTag.runtimeClass)
     val countPartition: (TaskContext, Iterator[T]) => OpenHashMap[T,Long] = { (ctx, iter) =>
       val map = new OpenHashMap[T,Long]
       iter.foreach {

--- a/core/src/test/scala/org/apache/spark/PartitioningSuite.scala
+++ b/core/src/test/scala/org/apache/spark/PartitioningSuite.scala
@@ -230,6 +230,10 @@ class PartitioningSuite extends FunSuite with SharedSparkContext with PrivateMet
     assert(intercept[SparkException]{ arrPairs.reduceByKeyLocally(_ + _) }.getMessage.contains("array"))
     assert(intercept[SparkException]{ arrPairs.reduceByKey(_ + _) }.getMessage.contains("array"))
     assert(intercept[SparkException]{ arrPairs.map(x => x).reduceByKey(_ + _) }.getMessage.contains("array"))
+    implicit object ArrayIntOrdering extends Ordering[Array[Int]] {
+      override def compare(x: Array[Int], y: Array[Int]) = 0
+    }
+    assert(intercept[SparkException]{ arrPairs.repartitionAndSortWithinPartitions(new HashPartitioner(2)) }.getMessage.contains("array"))
   }
 
   test("partitioning Java enums should fail") {
@@ -252,6 +256,7 @@ class PartitioningSuite extends FunSuite with SharedSparkContext with PrivateMet
     enumPairs.reduceByKeyLocally(_ + _)
     assert(intercept[SparkException]{ enumPairs.reduceByKey(_ + _) }.getMessage.contains("enum"))
     assert(intercept[SparkException]{ enumPairs.map(x => x).reduceByKey(_ + _) }.getMessage.contains("enum"))
+    assert(intercept[SparkException]{ enumPairs.repartitionAndSortWithinPartitions(new HashPartitioner(2)) }.getMessage.contains("enum"))
   }
 
   test("zero-length partitions should be correctly handled") {

--- a/core/src/test/scala/org/apache/spark/PartitioningSuite.scala
+++ b/core/src/test/scala/org/apache/spark/PartitioningSuite.scala
@@ -212,28 +212,28 @@ class PartitioningSuite extends FunSuite with SharedSparkContext with PrivateMet
   test("partitioning Java arrays should fail") {
     // See SPARK-597
     val arrs: RDD[Array[Int]] = sc.parallelize(Array(1, 2, 3, 4), 2).map(x => Array(x))
-    assert(intercept[SparkException]{ arrs.distinct() }.getMessage.contains("array"))
+    assert(intercept[SparkException]{ arrs.distinct() }.getMessage.contains("Arrays"))
 
     val arrPairs: RDD[(Array[Int], Int)] =
       sc.parallelize(Array(1, 2, 3, 4), 2).map(x => (Array(x), x))
     // We can't catch all usages of arrays, since they might occur inside other collections:
     // assert(fails { arrPairs.distinct() })
-    assert(intercept[SparkException]{ arrPairs.partitionBy(new HashPartitioner(2)) }.getMessage.contains("array"))
-    assert(intercept[SparkException]{ arrPairs.join(arrPairs) }.getMessage.contains("array"))
-    assert(intercept[SparkException]{ arrPairs.leftOuterJoin(arrPairs) }.getMessage.contains("array"))
-    assert(intercept[SparkException]{ arrPairs.rightOuterJoin(arrPairs) }.getMessage.contains("array"))
-    assert(intercept[SparkException]{ arrPairs.fullOuterJoin(arrPairs) }.getMessage.contains("array"))
-    assert(intercept[SparkException]{ arrPairs.groupByKey() }.getMessage.contains("array"))
-    assert(intercept[SparkException]{ arrPairs.countByKey() }.getMessage.contains("array"))
-    assert(intercept[SparkException]{ arrPairs.countByKeyApprox(1) }.getMessage.contains("array"))
-    assert(intercept[SparkException]{ arrPairs.cogroup(arrPairs) }.getMessage.contains("array"))
-    assert(intercept[SparkException]{ arrPairs.reduceByKeyLocally(_ + _) }.getMessage.contains("array"))
-    assert(intercept[SparkException]{ arrPairs.reduceByKey(_ + _) }.getMessage.contains("array"))
-    assert(intercept[SparkException]{ arrPairs.map(x => x).reduceByKey(_ + _) }.getMessage.contains("array"))
+    assert(intercept[SparkException]{ arrPairs.partitionBy(new HashPartitioner(2)) }.getMessage.contains("Arrays"))
+    assert(intercept[SparkException]{ arrPairs.join(arrPairs) }.getMessage.contains("Arrays"))
+    assert(intercept[SparkException]{ arrPairs.leftOuterJoin(arrPairs) }.getMessage.contains("Arrays"))
+    assert(intercept[SparkException]{ arrPairs.rightOuterJoin(arrPairs) }.getMessage.contains("Arrays"))
+    assert(intercept[SparkException]{ arrPairs.fullOuterJoin(arrPairs) }.getMessage.contains("Arrays"))
+    assert(intercept[SparkException]{ arrPairs.groupByKey() }.getMessage.contains("Arrays"))
+    assert(intercept[SparkException]{ arrPairs.countByKey() }.getMessage.contains("Arrays"))
+    assert(intercept[SparkException]{ arrPairs.countByKeyApprox(1) }.getMessage.contains("Arrays"))
+    assert(intercept[SparkException]{ arrPairs.cogroup(arrPairs) }.getMessage.contains("Arrays"))
+    assert(intercept[SparkException]{ arrPairs.reduceByKeyLocally(_ + _) }.getMessage.contains("Arrays"))
+    assert(intercept[SparkException]{ arrPairs.reduceByKey(_ + _) }.getMessage.contains("Arrays"))
+    assert(intercept[SparkException]{ arrPairs.map(x => x).reduceByKey(_ + _) }.getMessage.contains("Arrays"))
     implicit object ArrayIntOrdering extends Ordering[Array[Int]] {
       override def compare(x: Array[Int], y: Array[Int]) = 0
     }
-    assert(intercept[SparkException]{ arrPairs.repartitionAndSortWithinPartitions(new HashPartitioner(2)) }.getMessage.contains("array"))
+    assert(intercept[SparkException]{ arrPairs.repartitionAndSortWithinPartitions(new HashPartitioner(2)) }.getMessage.contains("Arrays"))
   }
 
   test("HashPartitioner should partition Java enums based on their ordinals") {


### PR DESCRIPTION
This patch prevents Java enums from being used as keys for PairRDD partitioning operations.  Java enums' hashCodes are based on the enumerations' ordinal() values rather than the default Enum.hashCode, which produces machine-dependent values that cannot safely be compared across machines.  We could add some special-case logic to HashPartitioner for handling this case, but I've chosen not to do that because it may give users the false impression that it's safe to use Java enums as components of a partitioning key, e.g. `PairRDD[(Enum, Enum), T]`.

In addition, this patch strengthens some of the existing error-checking which prohibits arrays from being used as keys for the PairRDDFunctions transformations.  [Previously](https://github.com/mesos/spark/pull/348), I added logic to throw exceptions if the default HashPartitioner was being used with array keys, since Java arrays' hashCodes are based on the arrays' object identities and not their contents.  However, this still permitted arrays to be used as keys if a custom partitioner was supplied.  This could still lead to errors, though, since we might call the default array hashCode when using arrays as keys in aggregation maps.  Therefore, I've strengthened the error-checking to always throw exceptions if arrays are being used in most PairRDDFunctions methods.

In case we have to add similar error checks in the future, I've factored the logic into a helper function in the `Partitioner` object.  I also improved the warning messages to reference the relevant JIRA issues.
