### PR TITLE
[SAPRK-4967] [SQL] File name with comma will cause exception for SQLContext.parquetFile

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetTableOperations.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetTableOperations.scala
@@ -86,7 +86,7 @@ case class ParquetTableScan(
 
     val conf: Configuration = ContextUtil.getConfiguration(job)
 
-    relation.path.split(",").foreach { curPath =>
+    ParquetRelation.splitPartitionPath(relation.path).foreach { curPath =>
       val qualifiedPath = {
         val path = new Path(curPath)
         path.getFileSystem(conf).makeQualified(path)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -133,7 +133,7 @@ private[hive] trait HiveStrategies {
             }
 
             hiveContext
-              .parquetFile(partitions.map(_.getLocation).mkString(","))
+              .parquetFile(ParquetRelation.makePartitionPath(partitions.map(_.getLocation)))
               .addPartitioningAttributes(relation.partitionKeys)
               .lowerCase
               .where(unresolvedOtherPredicates)


### PR DESCRIPTION
This is a workaround solution to support the `,` in the parquet file name, however, we need to update the API `SQLContext.parquetFile` to support multiple parquet files as input.
