### PR TITLE
[EC2] Update mesos/spark-ec2 branch to branch-1.3

### DIFF
--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -42,7 +42,7 @@ from sys import stderr
 DEFAULT_SPARK_VERSION = "1.1.0"
 SPARK_EC2_DIR = os.path.dirname(os.path.realpath(__file__))
 
-MESOS_SPARK_EC2_BRANCH = "v4"
+MESOS_SPARK_EC2_BRANCH = "branch-1.3"
 # A URL prefix from which to fetch AMI information
 AMI_PREFIX = "https://raw.github.com/mesos/spark-ec2/{b}/ami-list".format(b=MESOS_SPARK_EC2_BRANCH)
 


### PR DESCRIPTION
Going forward, we'll use matching branch names across the mesos/spark-ec2 and apache/spark repositories, per [the discussion here](https://github.com/mesos/spark-ec2/pull/85#issuecomment-68069589).
