### PR TITLE
spark-core - [SPARK-4787] - Stop sparkcontext properly if a DAGScheduler init error occurs

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -330,9 +330,11 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
     dagScheduler = new DAGScheduler(this)
   } catch {
     case e: Exception => {
-      stop()
-      throw
-        new SparkException("DAGScheduler cannot be initialized due to %s".format(e.getMessage))
+      try {
+        stop()
+      } finally {
+        throw new SparkException("Error while constructing DAGScheduler", e)
+      }
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -329,8 +329,11 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
   try {
     dagScheduler = new DAGScheduler(this)
   } catch {
-    case e: Exception => throw
-      new SparkException("DAGScheduler cannot be initialized due to %s".format(e.getMessage))
+    case e: Exception => {
+      stop()
+      throw
+        new SparkException("DAGScheduler cannot be initialized due to %s".format(e.getMessage))
+    }
   }
 
   // start TaskScheduler after taskScheduler sets DAGScheduler reference in DAGScheduler's


### PR DESCRIPTION
[SPARK-4787] Stop SparkContext properly if an exception occurs during DAGscheduler initialization.
