### PR TITLE
[Spark-4976] [MLlib] trust region Newton method optimizer based on breeze

### DIFF
--- a/docs/mllib-guide.md
+++ b/docs/mllib-guide.md
@@ -30,6 +30,7 @@ filtering, dimensionality reduction, as well as underlying optimization primitiv
 * [Optimization (developer)](mllib-optimization.html)
   * stochastic gradient descent
   * limited-memory BFGS (L-BFGS)
+  * trust region Newton method (TRON)
 
 MLlib is under active development.
 The APIs marked `Experimental`/`DeveloperApi` may change in future releases, 

--- a/docs/mllib-linear-methods.md
+++ b/docs/mllib-linear-methods.md
@@ -112,7 +112,7 @@ especially when the number of training examples is small.
 
 ### Optimization
 
-Under the hood, linear methods use convex optimization methods to optimize the objective functions.  MLlib uses two methods, SGD and L-BFGS, described in the [optimization section](mllib-optimization.html).  Currently, most algorithm APIs support Stochastic Gradient Descent (SGD), and a few support L-BFGS. Refer to [this optimization section](mllib-optimization.html#Choosing-an-Optimization-Method) for guidelines on choosing between optimization methods.
+Under the hood, linear methods use convex optimization methods to optimize the objective functions.  MLlib uses three methods, SGD, L-BFGS, and TRON, described in the [optimization section](mllib-optimization.html).  Currently, most algorithm APIs support Stochastic Gradient Descent (SGD), and a few support L-BFGS or TRON. Refer to [this optimization section](mllib-optimization.html#Choosing-an-Optimization-Method) for guidelines on choosing between optimization methods.
 
 ## Binary classification
 

--- a/docs/mllib-optimization.md
+++ b/docs/mllib-optimization.md
@@ -138,11 +138,30 @@ vertical scalability issue (the number of training features) when computing the 
 explicitly in Newton's method. As a result, L-BFGS often achieves rapider convergence compared with 
 other first-order optimization. 
 
+### Trust region Newton method (TRON)
+[TRON](http://www.csie.ntu.edu.tw/~cjlin/papers/spark-liblinear/spark-liblinear.pdf)
+is an optimization algorithm in the family of truncated Newton methods to solve 
+twice-differentiable, unconstrained convex optimization problems.
+It approximates the objective function locally as a quadratic function by using the exact Hessian.
+To avoid vertical scalability issue (the number of training features) when computing the
+Hessian matrix,
+TRON uses the [conjugate gradient method](http://en.wikipedia.org/wiki/Conjugate_gradient_method)
+that only requires the result of the Hessian-vector products instead of explicitly computing the
+Hessian matrix in solving the quadratic sub-problem.
+With careful implementation of the Hessian-vector product function, the scalability issue can be
+avoided.
+As a result of using more accurate approximation, TRON enjoys faster theoretical and practical
+convergence in comparison with quasi-Newton methods and first-order optimization methods.
+However, the applicability of TRON is more restrictive due to the requirement of
+twice-differentiability.
+Note that due to this requirement, L2-regularization is directly built in the optimization
+procedure, and other regularizers are not supported.
+
 ### Choosing an Optimization Method
 
-[Linear methods](mllib-linear-methods.html) use optimization internally, and some linear methods in MLlib support both SGD and L-BFGS.
+[Linear methods](mllib-linear-methods.html) use optimization internally, and some linear methods in MLlib support SGD, L-BFGS and TRON.
 Different optimization methods can have different convergence guarantees depending on the properties of the objective function, and we cannot cover the literature here.
-In general, when L-BFGS is available, we recommend using it instead of SGD since L-BFGS tends to converge faster (in fewer iterations).
+In general, when TRON or L-BFGS is available, we recommend using them instead of SGD since they tend to converge faster (in fewer iterations).
 
 ## Implementation in MLlib
 
@@ -376,3 +395,100 @@ loss of objective function of regularization for L-BFGS by ignoring the part of 
 only for gradient decent such as adaptive step size stuff. We will refactorize
 this into regularizer to replace updater to separate the logic between 
 regularization and step update later. 
+
+### TRON
+TRON is currently only a low-level optimization primitive in `MLlib`. If you want to use TRON in various 
+ML algorithms such as Linear Regression, and Logistic Regression, you have to pass the gradient and the Hessian of the objective
+function into optimizer yourself instead of using the training APIs like 
+[LogisticRegressionWithSGD](api/scala/index.html#org.apache.spark.mllib.classification.LogisticRegressionWithSGD).
+See the example below.
+
+TRON does not require a parameter of the regularization updater since the L2 regularizer is built
+in the optimization procedure.
+This is due to the restriction that TRON can only solve twice-differentiable convex optimization problems.
+
+The TRON method
+[TRON.runTRON](api/scala/index.html#org.apache.spark.mllib.optimization.TRON)
+has the following parameters:
+
+* `Gradient` is a class that computes the gradient of the objective function
+being optimized, i.e., with respect to a single training example, at the
+current parameter value. MLlib includes gradient classes for common loss
+functions, e.g., hinge, logistic, least-squares.  The gradient class takes as
+input a training example, its label, and the current parameter value. 
+* `Hessian` is a class that computes the Hessian-vector products of the objective function
+being optimized with any given vector, i.e., with respect to a single training example, at the
+current parameter value. MLlib includes Hessian classes for logistic loss
+function.  The hessian class takes as
+input a training example, its label, the current parameter value, and the vector for the product.
+* `maxNumIterations` is the maximal number of iterations that TRON can be run.
+* `regParam` is the regularization parameter for L2 regularization.
+
+The `return` is a tuple containing two elements. The first element is a column matrix
+containing weights for every feature, and the second element is an array containing 
+the loss computed for every iteration.
+
+Here is an example to train binary logistic regression with L2 regularization using
+TRON optimizer.
+
+<div class="codetabs">
+
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+import org.apache.spark.SparkContext
+import org.apache.spark.mllib.evaluation.BinaryClassificationMetrics
+import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.mllib.util.MLUtils
+import org.apache.spark.mllib.classification.LogisticRegressionModel
+import org.apache.spark.mllib.optimization.{TRON, LogisticGradient, LogisticHessian}
+
+val data = MLUtils.loadLibSVMFile(sc, "data/mllib/sample_libsvm_data.txt")
+val numFeatures = data.take(1)(0).features.size
+
+// Split data into training (60%) and test (40%).
+val splits = data.randomSplit(Array(0.6, 0.4), seed = 11L)
+
+// Append 1 into the training data as intercept.
+val training = splits(0).map(x => (x.label, MLUtils.appendBias(x.features))).cache()
+
+val test = splits(1)
+
+// Run training algorithm to build the model
+val convergenceTol = 1e-4
+val maxNumIterations = 20
+val regParam = 0.1
+val initialWeightsWithIntercept = Vectors.dense(new Array[Double](numFeatures + 1))
+
+val (weightsWithIntercept, loss) = TRON.runTRON(
+  training,
+  new LogisticGradient(),
+  new LogisticHessian(),
+  convergenceTol,
+  maxNumIterations,
+  regParam,
+  initialWeightsWithIntercept)
+
+val model = new LogisticRegressionModel(
+  Vectors.dense(weightsWithIntercept.toArray.slice(0, weightsWithIntercept.size - 1)),
+  weightsWithIntercept(weightsWithIntercept.size - 1))
+
+// Clear the default threshold.
+model.clearThreshold()
+
+// Compute raw scores on the test set.
+val scoreAndLabels = test.map { point =>
+  val score = model.predict(point.features)
+  (score, point.label)
+}
+
+// Get evaluation metrics.
+val metrics = new BinaryClassificationMetrics(scoreAndLabels)
+val auROC = metrics.areaUnderROC()
+
+println("Loss of each step in training process")
+loss.foreach(println)
+println("Area under ROC = " + auROC)
+{% endhighlight %}
+</div>
+
+</div>

--- a/mllib/src/main/scala/org/apache/spark/mllib/optimization/Hessian.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/optimization/Hessian.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.mllib.optimization
+
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.mllib.linalg.Vector
+import org.apache.spark.mllib.linalg.BLAS.{dot, scal}
+
+/**
+ * :: DeveloperApi ::
+ * Class used to compute the Hessian-vector product for a twice-differentiable loss function,
+ * given a single data point.
+ */
+@DeveloperApi
+abstract class HessianVector extends Serializable {
+  def compute(data: Vector, label: Double, weights: Vector, direction: Vector): Vector
+}
+
+@DeveloperApi
+class LogisticHessian extends HessianVector {
+  override def compute(data: Vector, label: Double, weights: Vector, direction: Vector) = {
+    val sigma = 1.0 / (1.0 + math.exp(- dot(weights, data) * (label * 2.0 - 1.0)))
+    val hessianMultiplier = sigma * (1.0 - sigma) * dot(direction, data)
+    val hv = data.copy
+    scal(hessianMultiplier, hv)
+    hv
+  }
+}

--- a/mllib/src/main/scala/org/apache/spark/mllib/optimization/Tron.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/optimization/Tron.scala
@@ -1,0 +1,252 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.mllib.optimization
+
+import scala.collection.mutable.ArrayBuffer
+
+import breeze.linalg.{DenseVector => BDV}
+import breeze.linalg.operators.{OpMulMatrix, BinaryOp}
+import breeze.optimize.{CachedDiffFunction, SecondOrderFunction, TruncatedNewtonMinimizer => BreezeTRON}
+import breeze.util.Implicits._
+
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.Logging
+import org.apache.spark.mllib.classification._
+import org.apache.spark.mllib.linalg.{Vector, Vectors}
+import org.apache.spark.mllib.linalg.BLAS.{axpy,dot,scal}
+import org.apache.spark.mllib.rdd.RDDFunctions._
+import org.apache.spark.mllib.regression._
+import org.apache.spark.mllib.util.DataValidators
+import org.apache.spark.rdd.RDD
+
+
+/**
+ * :: DeveloperApi ::
+ * Class used to solve an optimization problem using trust region truncated Newton method (TRON)
+ * Reference: [[http://www.csie.ntu.edu.tw/~cjlin/papers/logistic.pdf]]
+ * @param gradient Gradient function to be used.
+ * @param hessian Hessian-vector function to be used.
+ */
+@DeveloperApi
+class TRON(private var gradient: Gradient, private var hessian: HessianVector)
+  extends Optimizer with Logging {
+  private var convergenceTol = 1E-2
+  private var maxNumIterations = 1000
+  private var regParam = 0.0
+  /**
+   * Set the convergence tolerance of iterations for TRON. Default 1E-2.
+   * Smaller value will lead to higher accuracy with the cost of more iterations.
+   */
+  def setConvergenceTol(tolerance: Double): this.type = {
+    this.convergenceTol = tolerance
+    this
+  }
+
+  /**
+   * Set the maximal number of iterations for TRON. Default 1000.
+   */
+  def setNumIterations(iters: Int): this.type = {
+    this.maxNumIterations = iters
+    this
+  }
+  /**
+   * Set the regularization parameter. Default 0.0.
+   */
+  def setRegParam(regParam: Double): this.type = {
+    this.regParam = regParam
+    this
+  }
+  /**
+   * Set the gradient function (of the loss function of one single data example)
+   * to be used for TRON.
+   */
+  def setGradient(gradient: Gradient): this.type = {
+    this.gradient = gradient
+    this
+  }
+  /**
+   * Set the Hessian-vector function (of the loss function of one single data example)
+   * to be used for TRON.
+   */
+  def setHessian(hessian: HessianVector): this.type = {
+    this.hessian = hessian
+    this
+  }
+
+  override def optimize(data: RDD[(Double, Vector)], initialWeights: Vector): Vector = {
+    val (weights, _) = TRON.runTRON(
+      data,
+      gradient,
+      hessian,
+      convergenceTol,
+      maxNumIterations,
+      regParam,
+      initialWeights)
+    weights
+  }
+
+}
+/**
+ * :: DeveloperApi ::
+ * Top-level method to run TRON.
+ */
+@DeveloperApi
+object TRON extends Logging {
+  /**
+   * Run TRON in parallel.
+   * summing the gradient and summing the hessian vector product over different partitions is
+   * performed using one standard
+   * spark map-reduce in each iteration.
+   *
+   * @param data - Input data for TRON. RDD of the set of data examples, each of
+   *               the form (label, [feature values]).
+   * @param gradient - Gradient object (used to compute the gradient of the loss function of
+   *                   one single data example)
+   * @param hessian - HessianVector object (used to compute the hessian-vector product of the loss
+   * function of one single data example)
+   * @param convergenceTol - The convergence tolerance of iterations for TRON
+   * @param maxNumIterations - Maximal number of iterations that TRON can be run.
+   * @param regParam - Regularization parameter
+   *
+   * @return A tuple containing two elements. The first element is a column matrix containing
+   *         weights for every feature, and the second element is an array containing the loss
+   *         computed for every iteration.
+   */
+  def runTRON(
+      data: RDD[(Double, Vector)],
+      gradient: Gradient,
+      hessian: HessianVector,
+      convergenceTol: Double,
+      maxNumIterations: Int,
+      regParam: Double,
+      initialWeights: Vector): (Vector, Array[Double]) = {
+
+    val lossHistory = new ArrayBuffer[Double](maxNumIterations)
+
+    val numExamples = data.count()
+    val H = new HessianMatrix
+    H.setHv(hessian)
+    H.setdata(data)
+
+    val costFun =
+      new SecondOrderCostFun(data, gradient, H, numExamples)
+
+    val tron =
+      new BreezeTRON[BDV[Double], HessianMatrix](maxNumIterations, convergenceTol, regParam)
+
+    val states =
+      tron.iterations(costFun, initialWeights.toBreeze.toDenseVector).takeUpToWhere(_.converged)
+
+    var state = states.next()
+    while(states.hasNext) {
+      lossHistory.append(state.adjFval)
+      state = states.next()
+    }
+    lossHistory.append(state.fval)
+    val weights = Vectors.fromBreeze(state.x)
+
+    logInfo("TRON.runTRON finished. Last 10 losses %s".format(
+      lossHistory.takeRight(10).mkString(", ")))
+
+    (weights, lossHistory.toArray)
+  }
+}
+  /**
+   * SecondOrderCostFun implements Breeze's SecondOrderFunction[T, H], which returns the loss,
+   * gradient and the Hessian
+   * at a particular point (weights). It's used in Breeze's convex optimization routines.
+   * In this implementation, the Hessian is an object that only implements the matrix-vector
+   * product, but the values of the matrix are not directly accessible.
+   */
+
+class SecondOrderCostFun(
+    data: RDD[(Double, Vector)],
+    gradient: Gradient,
+    hessian: HessianMatrix,
+    numExamples: Long) extends SecondOrderFunction[BDV[Double], HessianMatrix] {
+  override def calculate2(weights: BDV[Double]): (Double, BDV[Double], HessianMatrix) = {
+      val w = Vectors.fromBreeze(weights)
+      val n = w.size
+      val bcW = data.context.broadcast(w)
+      val localGradient = gradient
+
+      val (gradientSum, lossSum) = data.treeAggregate((Vectors.zeros(n), 0.0))(
+          seqOp = (c, v) => (c, v) match { case ((grad, loss), (label, features)) =>
+            val l = localGradient.compute(features, label, bcW.value, grad)
+            (grad, loss + l)
+          },
+          combOp = (c1, c2) => (c1, c2) match { case ((grad1, loss1), (grad2, loss2)) =>
+            axpy(1.0, grad2, grad1)
+            (grad1, loss1 + loss2)
+          })
+      hessian.setw(bcW)
+      (lossSum, gradientSum.toBreeze.toDenseVector, hessian)
+  }
+}
+
+class HessianMatrix extends Serializable{
+  private var data: RDD[(Double, Vector)] = null
+  private var w: Broadcast[Vector] = null
+  private var Hv: HessianVector = null
+
+  def setHv(Hv: HessianVector) = {
+    this.Hv = Hv
+    this
+  }
+
+  def setw(w: Broadcast[Vector]) = {
+    this.w = w
+    this
+  }
+
+  def setdata(data: RDD[(Double, Vector)]) = {
+    this.data = data
+    this
+  }
+
+  def *(direction: BDV[Double]): BDV[Double] = {
+    val n = data.first()._2.size
+    val sc = data.sparkContext
+    val d = Vectors.fromBreeze(direction)
+    val bcD = sc.broadcast(d)
+    var hv = data.treeAggregate(Vectors.zeros(n))(
+    seqOp = (c, v) => (c, v) match { case (hv, (label, features)) =>
+      val hv1 = Hv.compute(features, label, w.value, bcD.value)
+      axpy(1.0, hv1, hv)
+      hv
+    },
+    combOp = (c1, c2) => (c1, c2) match { case (hv1, hv2) =>
+      axpy(1.0, hv2, hv1)
+      hv1
+    })
+    bcD.unpersist()
+    hv.toBreeze.toDenseVector
+  }
+}
+
+object HessianMatrix {
+  implicit def mult: OpMulMatrix.Impl2[HessianMatrix, BDV[Double], BDV[Double]] = {
+    new OpMulMatrix.Impl2[HessianMatrix, BDV[Double], BDV[Double]] {
+      def apply (a: HessianMatrix, b: BDV[Double]): BDV[Double] = {
+        a * b
+      }
+    }
+  }
+}
+

--- a/mllib/src/test/scala/org/apache/spark/mllib/optimization/TronSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/optimization/TronSuite.scala
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.mllib.optimization
+
+import scala.util.Random
+
+import org.scalatest.{FunSuite, Matchers}
+
+import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.mllib.regression.LabeledPoint
+import org.apache.spark.mllib.util.{LocalClusterSparkContext, MLlibTestSparkContext}
+import org.apache.spark.mllib.util.TestingUtils._
+
+class TronSSuite extends FunSuite with MLlibTestSparkContext with Matchers {
+
+  val nPoints = 10000
+  val A = 2.0
+  val B = -1.5
+
+  val initialB = -1.0
+  val initialWeights = Array(initialB)
+
+  val gradient = new LogisticGradient()
+  val hessian = new LogisticHessian()
+  val numCorrections = 10
+
+  val simpleUpdater = new SimpleUpdater()
+  val squaredL2Updater = new SquaredL2Updater()
+
+  // Add an extra variable consisting of all 1.0's for the intercept.
+  val testData = GradientDescentSuite.generateGDInput(A, B, nPoints, 42)
+  val data = testData.map { case LabeledPoint(label, features) =>
+    label -> Vectors.dense(1.0 +: features.toArray)
+  }
+
+  lazy val dataRDD = sc.parallelize(data, 2).cache()
+
+  test("Tron loss should be decreasing and match the result of L-BFGS.") {
+    val regParam = 1.0
+
+    val initialWeightsWithIntercept = Vectors.dense(1.0 +: initialWeights.toArray)
+    val convergenceTol = 1e-5
+    val numIterations = 100
+    val (_, loss) = TRON.runTRON(
+      dataRDD,
+      gradient,
+      hessian,
+      convergenceTol,
+      numIterations,
+      regParam,
+      initialWeightsWithIntercept)
+
+    val lbfgs_reg = (1.0/regParam)/ nPoints
+    val (_, lossLBFGS) = LBFGS.runLBFGS(
+      dataRDD,
+      gradient,
+      simpleUpdater,
+      numCorrections,
+      convergenceTol,
+      numIterations,
+      lbfgs_reg,
+      initialWeightsWithIntercept)
+
+    // Since the cost function is convex, the loss is guaranteed to be monotonically decreasing
+    // with Tron optimizer.
+    assert((loss, loss.tail).zipped.forall(_ > _), "loss should be monotonically decreasing.")
+
+    assert(Math.abs((lossLBFGS.last / lbfgs_reg - loss.last) / loss.last) < 0.02,
+      "LBFGS should match TRON result within 2% difference.")
+    // Note that in TRON, the objective function is 1/2 w^T w + regparam \sum loss,
+    // while in LBFGS, the function is regparam/2 w^T w + 1/nPoints \sum loss
+  }
+
+  test("TRON and LBFGS with L2 regularization should get the same result.") {
+    val regParam = 0.2
+    val lbfgs_reg = (1.0/regParam)/ nPoints
+
+    // Prepare another non-zero weights to compare the loss in the first iteration.
+    val initialWeightsWithIntercept = Vectors.dense(0.3, 0.12)
+    val convergenceTol = 1e-5
+    val numIterations = 100
+
+    val (weightTRON, lossTRON) = TRON.runTRON(
+      dataRDD,
+      gradient,
+      hessian,
+      convergenceTol,
+      numIterations,
+      regParam,
+      initialWeightsWithIntercept)
+
+    val (weightLBFGS, lossLBFGS) = LBFGS.runLBFGS(
+      dataRDD,
+      gradient,
+      squaredL2Updater,
+      numCorrections,
+      convergenceTol,
+      numIterations,
+      lbfgs_reg,
+      initialWeightsWithIntercept)
+
+    assert(lossTRON(0) ~= lossLBFGS(0)/lbfgs_reg absTol 1E-5,
+      "The first losses of LBFGS and TRON should be the same.")
+
+    // The 2% difference here is based on observation, but is not theoretically guaranteed.
+    assert(lossLBFGS.last / lbfgs_reg ~= lossTRON.last relTol 0.02,
+      "The last losses of LBFGS and TRON should be within 2% difference.")
+
+    assert(
+      (weightLBFGS(0) ~= weightTRON(0) relTol 0.02) && (weightLBFGS(1) ~= weightTRON(1) relTol 0.02),
+      "The weight differences between LBFGS and TRON should be within 2%.")
+  }
+
+  test("The convergence criteria should work as we expect.") {
+    val regParam = 0.0
+
+    /**
+     * For the first run, we set the convergenceTol to 0.0, so that the algorithm will
+     * run up to the numIterations which is 8 here.
+     */
+    val initialWeightsWithIntercept = Vectors.dense(0.0, 0.0)
+    val numIterations = 2
+    var convergenceTol = 0.0
+
+    val (_, lossTRON1) = TRON.runTRON(
+      dataRDD,
+      gradient,
+      hessian,
+      convergenceTol,
+      numIterations,
+      regParam,
+      initialWeightsWithIntercept)
+
+
+    // Note that the first loss is computed with initial weights,
+    // so the total numbers of loss will be numbers of iterations + 1
+    assert(lossTRON1.length == 3)
+
+    convergenceTol = 0.1
+    val (_, lossTRON2) = TRON.runTRON(
+      dataRDD,
+      gradient,
+      hessian,
+      convergenceTol,
+      numIterations,
+      regParam,
+      initialWeightsWithIntercept)
+
+    convergenceTol = 0.01
+    val (_, lossTRON3) = TRON.runTRON(
+      dataRDD,
+      gradient,
+      hessian,
+      convergenceTol,
+      numIterations,
+      regParam,
+      initialWeightsWithIntercept)
+
+    // With smaller convergenceTol, it takes more steps.
+    assert(lossTRON3.length >= lossTRON2.length)
+  }
+
+  test("Optimize via class TRON.") {
+    val regParam = 0.2
+    val lbfgs_reg = (1.0/regParam)/ nPoints
+
+    // Prepare another non-zero weights to compare the loss in the first iteration.
+    val initialWeightsWithIntercept = Vectors.dense(0.3, 0.12)
+    val convergenceTol = 1e-5
+    val numIterations = 100
+
+    val lbfgsOptimizer = new LBFGS(gradient, squaredL2Updater)
+      .setNumCorrections(numCorrections)
+      .setConvergenceTol(convergenceTol)
+      .setNumIterations(numIterations)
+      .setRegParam(lbfgs_reg)
+
+    val weightLBFGS = lbfgsOptimizer.optimize(dataRDD, initialWeightsWithIntercept)
+
+    val tronOptimizer = new TRON(gradient, hessian)
+      .setConvergenceTol(convergenceTol)
+      .setNumIterations(numIterations)
+      .setRegParam(regParam)
+
+    val weightTRON = tronOptimizer.optimize(dataRDD, initialWeightsWithIntercept)
+
+    // for class TRON and the optimize method, we only look at the weights
+    assert(
+      (weightLBFGS(0) ~= weightTRON(0) relTol 0.02) && (weightLBFGS(1) ~= weightTRON(1) relTol 0.02),
+      "The weight differences between LBFGS and TRON should be within 2%.")
+  }
+}
+
+class TRONClusterSuite extends FunSuite with LocalClusterSparkContext {
+
+  test("task size should be small") {
+    val m = 10
+    val n = 200000
+    val examples = sc.parallelize(0 until m, 2).mapPartitionsWithIndex { (idx, iter) =>
+      val random = new Random(idx)
+      iter.map(i => (1.0, Vectors.dense(Array.fill(n)(random.nextDouble))))
+    }.cache()
+    val tron = new TRON(new LogisticGradient, new LogisticHessian)
+      .setConvergenceTol(1e-12)
+      .setNumIterations(1)
+      .setRegParam(1.0)
+    val random = new Random(0)
+    // If we serialize data directly in the task closure, the size of the serialized task would be
+    // greater than 1MB and hence Spark would throw an error.
+    val weights = tron.optimize(examples, Vectors.dense(Array.fill(n)(random.nextDouble)))
+  }
+}
+


### PR DESCRIPTION
This PR implements trust region Newton method (TRON) for optimizing twice-differentiable, unconstrained convex optimization problems based on the implementation in breeze. A hessian function for logistic regression is also implemented as recent research shows that TRON outperforms L-BFGS in training large-scale logistic regressions.
