### PR TITLE
[SPARK-4989][CORE] avoid wrong eventlog conf cause cluster down in standalone mode

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -759,11 +759,10 @@ private[spark] class Master(
         // Event logging is enabled for this application, but no event logs are found
         val title = s"Application history not found (${app.id})"
         var msg = s"No event logs found for application $appName in ${app.desc.eventLogDir}."
-        val exception = URLEncoder.encode(Utils.exceptionString(fnf), "UTF-8")
-        logWarning(msg, fnf)
+        logWarning(msg)
         msg += " Did you specify the correct logging directory?"
         msg = URLEncoder.encode(msg, "UTF-8")
-        app.desc.appUiUrl = notFoundBasePath + s"?msg=$msg&exception=$exception&title=$title"
+        app.desc.appUiUrl = notFoundBasePath + s"?msg=$msg&title=$title"
         false
       case e: Exception =>
         // Relay exception message to application UI page

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -719,26 +719,28 @@ private[spark] class Master(
   def rebuildSparkUI(app: ApplicationInfo): Boolean = {
     val appName = app.desc.name
     val notFoundBasePath = HistoryServer.UI_PATH_PREFIX + "/not-found"
-    val eventLogFile = app.desc.eventLogDir
-      .map { dir => EventLoggingListener.getLogPath(dir, app.id) }
-      .getOrElse {
-        // Event logging is not enabled for this application
-        app.desc.appUiUrl = notFoundBasePath
-        return false
-    }
-    val fs = Utils.getHadoopFileSystem(eventLogFile, hadoopConf)
-
-    if (fs.exists(new Path(eventLogFile + EventLoggingListener.IN_PROGRESS))) {
-      // Event logging is enabled for this application, but the application is still in progress
-      val title = s"Application history not found (${app.id})"
-      var msg = s"Application $appName is still in progress."
-      logWarning(msg)
-      msg = URLEncoder.encode(msg, "UTF-8")
-      app.desc.appUiUrl = notFoundBasePath + s"?msg=$msg&title=$title"
-      return false
-    }
-
+    var eventLogFile: String = null
     try {
+      eventLogFile = app.desc.eventLogDir
+        .map { dir => EventLoggingListener.getLogPath(dir, app.id) }
+        .getOrElse {
+          // Event logging is not enabled for this application
+          app.desc.appUiUrl = notFoundBasePath
+          return false
+        }
+        
+      val fs = Utils.getHadoopFileSystem(eventLogFile, hadoopConf)
+
+      if (fs.exists(new Path(eventLogFile + EventLoggingListener.IN_PROGRESS))) {
+        // Event logging is enabled for this application, but the application is still in progress
+        val title = s"Application history not found (${app.id})"
+        var msg = s"Application $appName is still in progress."
+        logWarning(msg)
+        msg = URLEncoder.encode(msg, "UTF-8")
+        app.desc.appUiUrl = notFoundBasePath + s"?msg=$msg&title=$title"
+        return false
+      }
+
       val (logInput, sparkVersion) = EventLoggingListener.openEventLog(new Path(eventLogFile), fs)
       val replayBus = new ReplayListenerBus()
       val ui = SparkUI.createHistoryUI(new SparkConf, replayBus, new SecurityManager(conf),
@@ -764,7 +766,7 @@ private[spark] class Master(
         app.desc.appUiUrl = notFoundBasePath + s"?msg=$msg&title=$title"
         false
       case e: Exception =>
-        // Relay exception message to application UI page
+        // Replay exception message to application UI page
         val title = s"Application history load error (${app.id})"
         val exception = URLEncoder.encode(Utils.exceptionString(e), "UTF-8")
         var msg = s"Exception in replaying log for application $appName!"

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -767,7 +767,7 @@ private[spark] class Master(
         app.desc.appUiUrl = notFoundBasePath + s"?msg=$msg&exception=$exception&title=$title"
         false
       case e: Exception =>
-        // Replay exception message to application UI page
+        // Relay exception message to application UI page
         val title = s"Application history load error (${app.id})"
         val exception = URLEncoder.encode(Utils.exceptionString(e), "UTF-8")
         var msg = s"Exception in replaying log for application $appName!"

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -760,10 +760,11 @@ private[spark] class Master(
         // Event logging is enabled for this application, but no event logs are found
         val title = s"Application history not found (${app.id})"
         var msg = s"No event logs found for application $appName in $eventLogFile."
-        logWarning(msg)
+        val exception = URLEncoder.encode(Utils.exceptionString(fnf), "UTF-8")
+        logWarning(msg, fnf)
         msg += " Did you specify the correct logging directory?"
         msg = URLEncoder.encode(msg, "UTF-8")
-        app.desc.appUiUrl = notFoundBasePath + s"?msg=$msg&title=$title"
+        app.desc.appUiUrl = notFoundBasePath + s"?msg=$msg&exception=$exception&title=$title"
         false
       case e: Exception =>
         // Replay exception message to application UI page

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -719,9 +719,8 @@ private[spark] class Master(
   def rebuildSparkUI(app: ApplicationInfo): Boolean = {
     val appName = app.desc.name
     val notFoundBasePath = HistoryServer.UI_PATH_PREFIX + "/not-found"
-    var eventLogFile: String = null
     try {
-      eventLogFile = app.desc.eventLogDir
+      val eventLogFile = app.desc.eventLogDir
         .map { dir => EventLoggingListener.getLogPath(dir, app.id) }
         .getOrElse {
           // Event logging is not enabled for this application
@@ -759,7 +758,7 @@ private[spark] class Master(
       case fnf: FileNotFoundException =>
         // Event logging is enabled for this application, but no event logs are found
         val title = s"Application history not found (${app.id})"
-        var msg = s"No event logs found for application $appName in $eventLogFile."
+        var msg = s"No event logs found for application $appName in ${app.desc.eventLogDir}."
         val exception = URLEncoder.encode(Utils.exceptionString(fnf), "UTF-8")
         logWarning(msg, fnf)
         msg += " Did you specify the correct logging directory?"


### PR DESCRIPTION
when enabling eventlog in standalone mode, if give the wrong configuration, the standalone cluster will down (cause master restart, lose connection with workers).
How to reproduce: just give an invalid value to "spark.eventLog.dir", for example: spark.eventLog.dir=hdfs://tmp/logdir1, hdfs://tmp/logdir2. This will throw illegalArgumentException, which will cause the Master restart. And the whole cluster is not available.
