### PR TITLE
[SPARK-4991][CORE] Worker should reconnect to Master when Master actor restart

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
@@ -89,6 +89,8 @@ private[deploy] object DeployMessages {
   case class KillDriver(driverId: String) extends DeployMessage
 
   case class ApplicationFinished(id: String)
+  
+  case class MasterDisconnected(masterUrl: String) extends DeployMessage
 
   // Worker internal
 

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -366,8 +366,11 @@ private[spark] class Master(
               " Asking it to re-register.")
             sender ! ReconnectWorker(masterUrl)
           } else {
+            // Get unknown worker's heart beat, tell the worker disconnected. And worker need to
+            // register to this master first.
             logWarning(s"Got heartbeat from unregistered worker $workerId." +
-              " This worker was never registered, so ignoring the heartbeat.")
+              " This worker was never registered, tell the worker connection is disconnected." +
+              " Need to re-register if want to connect.")
             sender ! MasterDisconnected(masterUrl)
           }
       }

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -368,6 +368,7 @@ private[spark] class Master(
           } else {
             logWarning(s"Got heartbeat from unregistered worker $workerId." +
               " This worker was never registered, so ignoring the heartbeat.")
+            sender ! MasterDisconnected(masterUrl)
           }
       }
     }

--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -466,7 +466,12 @@ private[spark] class Worker(
       maybeCleanupApplication(id)
       
     case MasterDisconnected(masterUrl) =>
-      masterDisconnected()
+      if (masterUrl != activeMasterUrl) {
+        logWarning(s"Get message from Invalid Master ($masterUrl)." +
+          s"Valid Master is : $activeMasterUrl, so ignore the message.")
+      } else {
+        masterDisconnected()
+      }
   }
 
   private def masterDisconnected() {

--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -464,6 +464,9 @@ private[spark] class Worker(
     case ApplicationFinished(id) =>
       finishedApps += id
       maybeCleanupApplication(id)
+      
+    case MasterDisconnected(masterUrl) =>
+      masterDisconnected()
   }
 
   private def masterDisconnected() {


### PR DESCRIPTION
When Master akka actor encounter an exception, the Master will restart (akka actor restart not JVM restart) (like the case in [SPARK-4989](https://issues.apache.org/jira/browse/SPARK-4991)). And all old information are cleared on Master (including workers, applications, etc). However, the workers are not aware of this at all. The state of the cluster is that: the master is on, and all workers are also on, but master is not aware of the exists of workers, and will ignore all worker's heartbeat because all workers are not registered. So that the whole cluster is not available.

In this PR, master will tell worker the connection is disconnected, so that worker will register to master again. 
