### PR TITLE
SPARK-4968: takeOrdered to skip reduce step in case mappers return no partitions

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1146,15 +1146,20 @@ abstract class RDD[T: ClassTag](
     if (num == 0) {
       Array.empty
     } else {
-      mapPartitions { items =>
+      val mapRDDs = mapPartitions { items =>
         // Priority keeps the largest elements, so let's reverse the ordering.
         val queue = new BoundedPriorityQueue[T](num)(ord.reverse)
         queue ++= util.collection.Utils.takeOrdered(items, num)(ord)
         Iterator.single(queue)
-      }.reduce { (queue1, queue2) =>
-        queue1 ++= queue2
-        queue1
-      }.toArray.sorted(ord)
+      }
+      if (mapRDDs.partitions.size == 0) {
+        Array.empty
+      } else {
+        mapRDDs.reduce { (queue1, queue2) =>
+          queue1 ++= queue2
+          queue1
+        }.toArray.sorted(ord)
+      }
     }
   }
 


### PR DESCRIPTION
takeOrdered should skip reduce step in case mapped RDDs have no partitions. This prevents the mentioned exception : 
1. run query
   SELECT \* FROM testTable WHERE market = 'market2' ORDER BY End_Time DESC LIMIT 100;
   Error trace
   java.lang.UnsupportedOperationException: empty collection
   at org.apache.spark.rdd.RDD$$anonfun$reduce$1.apply(RDD.scala:863)
   at org.apache.spark.rdd.RDD$$anonfun$reduce$1.apply(RDD.scala:863)
   at scala.Option.getOrElse(Option.scala:120)
   at org.apache.spark.rdd.RDD.reduce(RDD.scala:863)
   at org.apache.spark.rdd.RDD.takeOrdered(RDD.scala:1136)
