### PR TITLE
[SPARK-5000][SQL] Alias support string literal in spark sql

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
@@ -162,7 +162,7 @@ class SqlParser extends AbstractSparkSQLParser {
     }
 
   protected lazy val projection: Parser[Expression] =
-    expression ~ (AS.? ~> ident.?) ^^ {
+    expression ~ (AS.? ~> (ident | stringLit).?) ^^ {
       case e ~ a => a.fold(e)(Alias(e, _)())
     }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -1005,4 +1005,8 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll {
     rdd.registerTempTable("distinctData")
     checkAnswer(sql("SELECT COUNT(DISTINCT key,value) FROM distinctData"), 2)
   }
+
+  test("support alias field as string literal") {
+    assert(sql("select key , value as 'vvv' from testData").count == 100)
+  }
 }


### PR DESCRIPTION
Alias support string literal in spark sql parser, such as
select key , value as 'vvv' from tableA;
