### PR TITLE
[SPARK-5011][SQL] Add support for WITH SERDEPROPERTIES, TBLPROPERTIES in CREATE TEMPORARY TABLE

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/ddl.scala
@@ -54,6 +54,9 @@ private[sql] class DDLParser extends StandardTokenParsers with PackratParsers wi
   protected val TABLE = Keyword("TABLE")
   protected val USING = Keyword("USING")
   protected val OPTIONS = Keyword("OPTIONS")
+  protected val WITH = Keyword("WITH")
+  protected val SERDEPROP = Keyword("SERDEPROP")
+  protected val TBLPROP = Keyword("TBLPROP")
 
   // Use reflection to find the reserved words defined in this class.
   protected val reservedWords =
@@ -70,12 +73,32 @@ private[sql] class DDLParser extends StandardTokenParsers with PackratParsers wi
    * CREATE TEMPORARY TABLE avroTable
    * USING org.apache.spark.sql.avro
    * OPTIONS (path "../hive/src/test/resources/data/files/episodes.avro")
+   * OR,
+   * For other external datasources not only a kind of file like:avro, parquet, json, but a cluster database, like: cassandra an hbase etc...
+   * DDL like this:
+   * CREATE TEMPORARY TABLE cassandraTable
+   * USING org.apache.spark.sql.cassandra
+   * WITH SERDEPROP("serialization.format"="1", "cassandra.columns.mapping"="key,data")
+   * TBLPROPERTIES("cassandra.keyspace.name" = "cassandra_keyspace")
    */
   protected lazy val createTable: Parser[LogicalPlan] =
-    CREATE ~ TEMPORARY ~ TABLE ~> ident ~ (USING ~> className) ~ (OPTIONS ~> options) ^^ {
-      case tableName ~ provider ~ opts =>
-        CreateTableUsing(tableName, provider, opts)
+    CREATE ~ TEMPORARY ~ TABLE ~> ident ~ (USING ~> className) ~
+      (OPTIONS ~> options).? ~ (WITH ~ SERDEPROP ~> properties).? ~
+      (TBLPROP ~> properties).? ^^ {
+      case tableName ~ provider ~ opts ~ serdeprop ~ tblprop =>
+        val optionParams = opts.getOrElse(Map[String,String]())
+        val serdeParams = serdeprop.getOrElse(Map[String,String]())
+        val tblParams = tblprop.getOrElse(Map[String,String]())
+        //TODO: in order to not break current interface, simple union them, if interface changes, also change this
+        val passedParams = optionParams ++ serdeParams ++ tblParams
+        passedParams.foreach(println)
+        CreateTableUsing(tableName, provider, passedParams)
     }
+
+  protected lazy val properties: Parser[Map[String,String]] =
+    "(" ~> repsep(equalStrKVPair, ",") <~ ")" ^^ { case s: Seq[(String, String)] => s.toMap }
+
+  protected lazy val equalStrKVPair: Parser[(String, String)] = stringLit ~ "=" ~ stringLit ^^ { case k ~ "=" ~ v => (k,v) }
 
   protected lazy val options: Parser[Map[String, String]] =
     "(" ~> repsep(pair, ",") <~ ")" ^^ { case s: Seq[(String, String)] => s.toMap }


### PR DESCRIPTION
issue is here:
https://issues.apache.org/jira/browse/SPARK-5011

Currently,  since I find a bug which block this PR: 
issues: https://issues.apache.org/jira/browse/SPARK-5009 ,

Temporarily, I replace `SERDEPROPERTIES` with `SERDEPROP`, replace `TBLPROPERTIES` with `TBLPROP`.

After fix that bug above,  I will rename them back.

And the final version will be like this, see below:

``````
val hbaseDDL = s"""
      |CREATE TEMPORARY TABLE hbase_people(row_key string, name string, age int, job string)
      |USING com.shengli.spark.hbase
      |OPTIONS (
      |  someOptions 'abcdefg'
      |) 
      |WITH SERDEPROPERTIES (
      |  'hbase.columns.mapping'=':key, profile:name, profile:age, career:job'
      |)
      |TBLPROPERTIES (
      | 'hbase.table.name' = 'people'
      |)
""".stripMargin```
``````
