### PR TITLE
SPARK-5020 [MLlib] GaussianMixtureModel.predictMembership() should take an RDD only

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/GaussianMixtureModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/GaussianMixtureModel.scala
@@ -45,7 +45,7 @@ class GaussianMixtureModel(
 
   /** Maps given points to their cluster indices. */
   def predict(points: RDD[Vector]): RDD[Int] = {
-    val responsibilityMatrix = predictMembership(points, mu, sigma, weight, k)
+    val responsibilityMatrix = predictMembership(points)
     responsibilityMatrix.map(r => r.indexOf(r.max))
   }
   
@@ -53,12 +53,7 @@ class GaussianMixtureModel(
    * Given the input vectors, return the membership value of each vector
    * to all mixture components. 
    */
-  def predictMembership(
-      points: RDD[Vector], 
-      mu: Array[Vector], 
-      sigma: Array[Matrix],
-      weight: Array[Double], 
-      k: Int): RDD[Array[Double]] = {
+  def predictMembership(points: RDD[Vector]): RDD[Array[Double]] = {
     val sc = points.sparkContext
     val dists = sc.broadcast {
       (0 until k).map { i => 

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/GaussianMixtureModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/GaussianMixtureModel.scala
@@ -45,7 +45,7 @@ class GaussianMixtureModel(
 
   /** Maps given points to their cluster indices. */
   def predict(points: RDD[Vector]): RDD[Int] = {
-    val responsibilityMatrix = predictMembership(points)
+    val responsibilityMatrix = predictSoft(points)
     responsibilityMatrix.map(r => r.indexOf(r.max))
   }
   
@@ -53,7 +53,7 @@ class GaussianMixtureModel(
    * Given the input vectors, return the membership value of each vector
    * to all mixture components. 
    */
-  def predictMembership(points: RDD[Vector]): RDD[Array[Double]] = {
+  def predictSoft(points: RDD[Vector]): RDD[Array[Double]] = {
     val sc = points.sparkContext
     val dists = sc.broadcast {
       (0 until k).map { i => 


### PR DESCRIPTION
Removed unnecessary parameters to predictMembership()

CC: @jkbradley
