### PR TITLE
[SPARK-5032] [graphx] Remove GraphX MIMA exclude for 1.3

### DIFF
--- a/dev/run-tests
+++ b/dev/run-tests
@@ -21,8 +21,10 @@
 FWDIR="$(cd "`dirname $0`"/..; pwd)"
 cd "$FWDIR"
 
-# Remove work directory
+# Clean up work directory and caches
 rm -rf ./work
+rm -rf ~/.ivy2/local/org.apache.spark
+rm -rf ~/.ivy2/cache/org.apache.spark
 
 source "$FWDIR/dev/run-tests-codes.sh"
 

--- a/dev/run-tests-jenkins
+++ b/dev/run-tests-jenkins
@@ -22,6 +22,8 @@
 # Environment variables are populated by the code here:
 #+ https://github.com/jenkinsci/ghprb-plugin/blob/master/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java#L139
 
+rm -rf ~/.m2/repository/org/apache/spark
+
 # Go to the Spark project root directory
 FWDIR="$(cd `dirname $0`/..; pwd)"
 cd "$FWDIR"

--- a/dev/run-tests-jenkins
+++ b/dev/run-tests-jenkins
@@ -22,9 +22,6 @@
 # Environment variables are populated by the code here:
 #+ https://github.com/jenkinsci/ghprb-plugin/blob/master/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java#L139
 
-rm -rf ~/.ivy2/cache/org.apache.spark/
-rm -rf ~/.ivy2/local/org.apache.spark/
-
 # Go to the Spark project root directory
 FWDIR="$(cd `dirname $0`/..; pwd)"
 cd "$FWDIR"

--- a/dev/run-tests-jenkins
+++ b/dev/run-tests-jenkins
@@ -22,7 +22,8 @@
 # Environment variables are populated by the code here:
 #+ https://github.com/jenkinsci/ghprb-plugin/blob/master/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java#L139
 
-rm -rf ~/.m2/repository/org/apache/spark
+rm -rf ~/.ivy2/cache/org.apache.spark/
+rm -rf ~/.ivy2/local/org.apache.spark/
 
 # Go to the Spark project root directory
 FWDIR="$(cd `dirname $0`/..; pwd)"

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -36,7 +36,6 @@ object MimaExcludes {
         case v if v.startsWith("1.3") =>
           Seq(
             MimaBuild.excludeSparkPackage("deploy"),
-            MimaBuild.excludeSparkPackage("graphx"),
             // These are needed if checking against the sbt build, since they are part of
             // the maven-generated artifacts in the 1.2 build.
             MimaBuild.excludeSparkPackage("unused"),

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -52,6 +52,18 @@ object MimaExcludes {
               "org.apache.spark.mllib.linalg.Matrices.randn"),
             ProblemFilters.exclude[MissingMethodProblem](
               "org.apache.spark.mllib.linalg.Matrices.rand")
+          ) ++ Seq(
+            // SPARK-3623
+            ProblemFilters.exclude[MissingMethodProblem](
+              "org.apache.spark.graphx.Graph.checkpoint"),
+            // SPARK-4444
+            ProblemFilters.exclude[IncompatibleResultTypeProblem](
+              "org.apache.spark.graphx.EdgeRDD.fromEdges"),
+            ProblemFilters.exclude[MissingMethodProblem]("org.apache.spark.graphx.EdgeRDD.filter"),
+            ProblemFilters.exclude[IncompatibleResultTypeProblem](
+              "org.apache.spark.graphx.impl.EdgeRDDImpl.filter"),
+            // SPARK-4620
+            ProblemFilters.exclude[MissingMethodProblem]("org.apache.spark.graphx.Graph.unpersist")
           )
 
         case v if v.startsWith("1.2") =>

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -52,18 +52,6 @@ object MimaExcludes {
               "org.apache.spark.mllib.linalg.Matrices.randn"),
             ProblemFilters.exclude[MissingMethodProblem](
               "org.apache.spark.mllib.linalg.Matrices.rand")
-          ) ++ Seq(
-            // SPARK-3623
-            ProblemFilters.exclude[MissingMethodProblem](
-              "org.apache.spark.graphx.Graph.checkpoint"),
-            // SPARK-4444
-            ProblemFilters.exclude[IncompatibleResultTypeProblem](
-              "org.apache.spark.graphx.EdgeRDD.fromEdges"),
-            ProblemFilters.exclude[MissingMethodProblem]("org.apache.spark.graphx.EdgeRDD.filter"),
-            ProblemFilters.exclude[IncompatibleResultTypeProblem](
-              "org.apache.spark.graphx.impl.EdgeRDDImpl.filter"),
-            // SPARK-4620
-            ProblemFilters.exclude[MissingMethodProblem]("org.apache.spark.graphx.Graph.unpersist")
           )
 
         case v if v.startsWith("1.2") =>


### PR DESCRIPTION
Since GraphX is no longer alpha as of 1.2, MimaExcludes should not exclude GraphX for 1.3

Here are the individual excludes I had to add + the associated commits:

```
            // SPARK-4444
            ProblemFilters.exclude[IncompatibleResultTypeProblem](
              "org.apache.spark.graphx.EdgeRDD.fromEdges"),
            ProblemFilters.exclude[MissingMethodProblem]("org.apache.spark.graphx.EdgeRDD.filter"),
            ProblemFilters.exclude[IncompatibleResultTypeProblem](
              "org.apache.spark.graphx.impl.EdgeRDDImpl.filter"),
```

[https://github.com/apache/spark/commit/9ac2bb18ede2e9f73c255fa33445af89aaf8a000]

```
            // SPARK-3623
            ProblemFilters.exclude[MissingMethodProblem]("org.apache.spark.graphx.Graph.checkpoint")
```

[https://github.com/apache/spark/commit/e895e0cbecbbec1b412ff21321e57826d2d0a982]

```
            // SPARK-4620
            ProblemFilters.exclude[MissingMethodProblem]("org.apache.spark.graphx.Graph.unpersist"),
```

[https://github.com/apache/spark/commit/8817fc7fe8785d7b11138ca744f22f7e70f1f0a0]

CC: @rxin 
