### PR TITLE
[SPARK-5037][STREAMING] dynamically loaded DStreams implementation and example

### DIFF
--- a/examples/src/main/python/streaming/zeromq_wordcount.py
+++ b/examples/src/main/python/streaming/zeromq_wordcount.py
@@ -1,0 +1,62 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+A sample wordcount using ZeroMQ in Python via reflection, based on the scala
+ZeroMQWordCount example.
+
+To work with zeroMQ, some native libraries have to be installed.
+Install zeroMQ (release 2.1) core libraries. [ZeroMQ Install guide]
+(http://www.zeromq.org/intro:get-the-software)
+
+Usage: zeromq_wordcount.py <zeroMQurl> <topic>
+   <zeroMQurl> and <topic> describe where zeroMq publisher is running.
+
+To run this locally, first launch the publisher from the scala ZeroMQWordCount example:
+    `$ bin/run-example \
+      org.apache.spark.examples.streaming.SimpleZeroMQPublisher tcp://127.0.1.1:1234 foo.bar`
+ and then run the subscriber, making sure to add the external jar with zeromq support to the
+ classpath via the spark-submit --jars flag:
+    `$ bin/spark-submit \
+    --jars external/zeromq/target/spark-streaming-zeromq_2.10-1.3.0-SNAPSHOT.jar \
+    examples/src/main/python/streaming/zeromq_wordcount.py tcp://127.0.1.1:1234 foo`
+"""
+
+import sys
+
+from pyspark import SparkContext
+from pyspark.streaming import StreamingContext
+from pyspark.serializers import UTF8Deserializer
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print >> sys.stderr, "Usage: zeromq_wordcount.py <zeromqUrl> <topic>"
+        exit(-1)
+    sc = SparkContext(appName="PythonZeroMQWordCount")
+    ssc = StreamingContext(sc, 1)
+
+    lines = ssc.reflectedStream(
+        "org.apache.spark.streaming.zeromq.ReflectedZeroMQStreamFactory",
+        UTF8Deserializer(),
+        sys.argv[1], sys.argv[2])
+    counts = lines.flatMap(lambda line: line.strip().split()) \
+        .map(lambda word: (word, 1)) \
+        .reduceByKey(lambda a, b: a+b)
+    counts.pprint()
+
+    ssc.start()
+    ssc.awaitTermination()

--- a/examples/src/main/scala/org/apache/spark/examples/streaming/ReflectedZeroMQWordCount.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/streaming/ReflectedZeroMQWordCount.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.examples.streaming
+
+import org.apache.spark.SparkConf
+import org.apache.spark.streaming.{Seconds, StreamingContext}
+
+// scalastyle:off
+/**
+ * An example using StreamingContext.reflectedStream, based on the ZeroMQWordCount example.
+ *
+ * To work with zeroMQ, some native libraries have to be installed.
+ * Install zeroMQ (release 2.1) core libraries. [ZeroMQ Install guide]
+ * (http://www.zeromq.org/intro:get-the-software)
+ *
+ * Usage: ReflectedZeroMQWordCount <zeroMQurl> <topic>
+ *   <zeroMQurl> and <topic> describe where zeroMq publisher is running.
+ *
+ * To run this example locally, you may run publisher as
+ *    `$ bin/run-example \
+ *      org.apache.spark.examples.streaming.SimpleZeroMQPublisher tcp://127.0.1.1:1234 foo.bar`
+ * and run the example as
+ *    `$ bin/run-example \
+ *      org.apache.spark.examples.streaming.ReflectedZeroMQWordCount tcp://127.0.1.1:1234 foo`
+ */
+// scalastyle:on
+object ReflectedZeroMQWordCount {
+  def main(args: Array[String]) {
+    if (args.length < 2) {
+      System.err.println("Usage: ReflectedZeroMQWordCount <zeroMQurl> <topic>")
+      System.exit(1)
+    }
+    StreamingExamples.setStreamingLogLevels()
+    val Seq(url, topic) = args.toSeq
+    val sparkConf = new SparkConf().setAppName("ReflectedZeroMQWordCount")
+    // Create the context and set the batch size
+    val ssc = new StreamingContext(sparkConf, Seconds(2))
+
+    // For this stream, a zeroMQ publisher should be running.
+    val lines = ssc.reflectedStream[String](
+      "org.apache.spark.streaming.zeromq.ReflectedZeroMQStreamFactory", url, topic)
+    val words = lines.flatMap(_.split(" "))
+    val wordCounts = words.map(x => (x, 1)).reduceByKey(_ + _)
+    wordCounts.print()
+    ssc.start()
+    ssc.awaitTermination()
+    }
+}

--- a/external/zeromq/src/main/scala/org/apache/spark/streaming/zeromq/ReflectedZeroMQStreamFactory.scala
+++ b/external/zeromq/src/main/scala/org/apache/spark/streaming/zeromq/ReflectedZeroMQStreamFactory.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.streaming.zeromq
+
+import akka.actor.Props
+import akka.util.ByteString
+import akka.zeromq.Subscribe
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.streaming.StreamingContext
+import org.apache.spark.streaming.dstream.{PluggableInputDStream, InputDStream, ReflectedDStreamFactory}
+import org.apache.spark.streaming.receiver.{ActorSupervisorStrategy, ActorReceiver}
+
+/**
+ * Creates [[org.apache.spark.streaming.zeromq.ZeroMQReceiver]] streams.
+ *
+ * This adapter class enables ZeroMQ streams to be instantiated via the
+ * [[org.apache.spark.streaming.StreamingContext]] reflectedStream method.
+ *
+ * It expects two String arguments in streamParams:
+ * 1. URL of the ZeroMQ publisher stream, e.g. "tcp://127.0.1.1:1234"
+ * 2. topic to which to subscribe
+ *
+ * @param streamParams parameters to pass to the underlying ZeroMQReceiver
+ */
+class ReflectedZeroMQStreamFactory(streamParams: Seq[String])
+  extends ReflectedDStreamFactory[String](streamParams) {
+
+  /**
+   * Creates a new ZeroMQ subscriber DStream[String] instance.
+   *
+   * @param ssc The active StreamingContext.
+   * @return new InputDStream[String]
+   */
+  override def instantiateStream(ssc: StreamingContext): InputDStream[String] = {
+    val receiver = new ActorReceiver[String](
+      Props(new ZeroMQReceiver(streamParams(0),
+        Subscribe(ByteString(streamParams(1))),
+        (x: Seq[ByteString]) => x.map(_.utf8String).iterator )),
+      "ZeroMQReceiverFromReflectedFactory",
+      StorageLevel.MEMORY_AND_DISK_SER_2,
+      ActorSupervisorStrategy.defaultStrategy
+    )
+    new PluggableInputDStream[String](ssc, receiver)
+  }
+}

--- a/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaStreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaStreamingContext.scala
@@ -35,7 +35,7 @@ import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming._
 import org.apache.spark.streaming.scheduler.StreamingListener
 import org.apache.hadoop.conf.Configuration
-import org.apache.spark.streaming.dstream.{PluggableInputDStream, ReceiverInputDStream, DStream}
+import org.apache.spark.streaming.dstream.DStream
 import org.apache.spark.streaming.receiver.Receiver
 
 /**
@@ -206,6 +206,25 @@ class JavaStreamingContext(val ssc: StreamingContext) extends Closeable {
    */
   def textFileStream(directory: String): JavaDStream[String] = {
     ssc.textFileStream(directory)
+  }
+
+  /**
+   * Create an input stream by reflection on a
+   * [[org.apache.spark.streaming.dstream.ReflectedDStreamFactory]] subclass.
+   *
+   * This allows InputDStream implementations to be loaded dynamically, without having to be
+   * compiled in to the org.apache.spark hierarchy.
+   *
+   * @param reflectedStreamFactoryClass Fully-qualified classname of a ReflectedDStreamFactory
+   *    subclass (e.g. "org.apache.spark.streaming.zeromq.ReflectedZeroMQStreamFactory")
+   * @param factoryClassParams String parameters to be passed into factory constructor
+   * @return new JavaInputDStream[T] instance
+   */
+  def reflectedStream[T](reflectedStreamFactoryClass: String,
+                         factoryClassParams: java.util.List[String]): JavaInputDStream[T] = {
+    implicit val cmt: ClassTag[T] =
+      implicitly[ClassTag[AnyRef]].asInstanceOf[ClassTag[T]]
+    ssc.reflectedStream[T](reflectedStreamFactoryClass, factoryClassParams:_*)
   }
 
   /**

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/ReflectedDStreamFactory.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/ReflectedDStreamFactory.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.streaming.dstream
+
+import org.apache.spark.streaming.StreamingContext
+
+import scala.reflect.ClassTag
+
+/**
+ * Abstract serializable factory for [[org.apache.spark.streaming.dstream.InputDStream]] instances.
+ *
+ * Intended to be used by the [[org.apache.spark.streaming.StreamingContext]] reflectedStream
+ * method.
+ *
+ * See [[org.apache.spark.streaming.zeromq.ReflectedZeroMQStreamFactory]] for an example concrete
+ * implementation.
+ *
+ * @param streamParams Parameters to be used during stream instantiation.
+ * @tparam T Data type handled by the instantiated DStreams.
+ */
+abstract class ReflectedDStreamFactory[T: ClassTag](streamParams: Seq[String])
+extends java.io.Serializable {
+  /**
+   * Creates a new [[org.apache.spark.streaming.dstream.InputDStream]] instance.
+   *
+   * Implementations should create a new InputDStream instance of the appropriate
+   * type, using the parameters passed in the factory constructor.
+   *
+   * @param ssc The active StreamingContext.
+   * @return new InputDStream
+   */
+  def instantiateStream(ssc: StreamingContext): InputDStream[T]
+}


### PR DESCRIPTION
This PR adds a new reflection-based method of creating input DStreams to the scala StreamingContext, and wires it through to the python streaming API.

Trying to create DStream instances directly by reflection runs into trouble with unwanted stuff getting dragged into closures, so I worked around this by defining a new abstract serializable `ReflectedDStreamFactory` class. The idea is that one subclasses this with a concrete implementation that directly instantiates the desired InputDStream; then the StreamingContext uses reflection to dynamically load this new Factory implementation. This PR also has an example showing how this works with the existing ZeroMQ example code in both the scala and python streaming APIs.

Parameters are passed into the input DStream indirectly by first putting them into the factory constructor, then requiring the factory implementation to pass them on into the DStream instance. At the moment these parameters are limited to String type, which I think should cover the majority of use cases, but I'd think it should be possible to generalize this further. 

Am throwing this out there for comment; suggestions and alternative approaches more than welcome.
