### PR TITLE
SPARK-5039 [BUILD] Spark 1.0 2.0.0-mr1-cdh4.1.2 Maven build fails due to "javax.servlet.FilterRegistration's signer information" errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -528,6 +528,10 @@
             <artifactId>servlet-api-2.5</artifactId>
           </exclusion>
           <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
           </exclusion>
@@ -610,6 +614,10 @@
         <artifactId>hadoop-yarn-api</artifactId>
         <version>${yarn.version}</version>
         <exclusions>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>asm</groupId>
             <artifactId>asm</artifactId>


### PR DESCRIPTION
Add servlet-api excludes from SPARK-1776 to avoid javax.servlet.FilterRegistration signer error in branch 1.0.
