### PR TITLE
[SPARK-5036][Graphx]Better support sending partial messages in Pregel API

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/PregelOps.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/PregelOps.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.graphx
 
 import org.apache.spark.Logging

--- a/graphx/src/main/scala/org/apache/spark/graphx/PregelOps.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/PregelOps.scala
@@ -1,0 +1,182 @@
+package org.apache.spark.graphx
+
+import org.apache.spark.Logging
+
+import scala.reflect.ClassTag
+
+/**
+ * Contains additional functionality for [[Pregel]] of partially sending message.
+ *
+ * Execute a Pregel-like iterative vertex-parallel abstraction with current iterative number.
+ * Part of the vertexes(called `ActiveVertexes`) send messages to their neighbours
+ * in each iteration.
+ *
+ * In some cases, `ActiveVertexes` are the vertexes that their attributes do not change
+ * between the previous and current iteration, so they need not to send message.
+ * At first, user can set Int value(eg. `flag:Int`) with `vprog`'s first parameter `curIter`
+ * to vertex's attribute in function `vprog`.
+ * Then in `sendMsg`, compare the Int value (`flag`) of Vertex attribute with `curIter` of
+ * `sendMsg`'s first parameter.
+ * In this way, it can determine whether sending message in current iteration.
+ *
+ * @example sample:
+ * {{{
+ *
+ *   // invoke
+ *  PregelOps[(Int, Int), Int, Map[Int, Int]](graph, isTerminal = isTerminal)(
+ *    vprog, sendMessage, mergeMessage)
+ *
+ *  //  set a `flag:Int` value of vertex attribute object
+ *  def vprog(curIter: Int, vid: VertexId, attr: (Int, Int),
+ *   messages: Map[Int, Int]): (Int, Int) = {
+ *   if (attr > 1024) {
+ *   //  logic code...
+ *   //  assign the curIter, the vertex can send message to its neighbors in sendMsg
+ *     (curIter, xxxx)
+ *   } else {
+ *     (0, xxxx)
+ *   }
+ *  }
+ *
+ *  def sendMessage(curIter: Int,
+ *    ctx: EdgeContext[(Int, Int), Int, Map[Int, Int]]): Unit = {
+ *    if (curIter == 0) {
+ *     ctx.sendToDst(Map(ctx.srcAttr._2 -> -1, ctx.srcAttr.xx -> 1))
+ *     ctx.sendToSrc(Map(ctx.dstAttr._2 -> -1, ctx.dstAttr.xx -> 1))
+ *    } else if (curIter == ctx.srcAttr._1) {
+ *     //  determine whether sending message
+ *     ctx.sendToDst(Map(ctx.srcAttr.preKCore -> -1, ctx.srcAttr.curKCore -> 1))
+ *     ctx.sendToSrc(Map(ctx.dstAttr.preKCore -> -1, ctx.dstAttr.curKCore -> 1))
+ *    }
+ *   }
+ *
+ *  def isTerminal(curIter: Int, messageCount: Long): Boolean = {
+ *   if (messageCount < 10 || curIter > 1000)  false else  true
+ *  }
+ *
+ *  // mergeMessage
+ *  def mergeMessage(source: Map[Int, Int], target: Map[Int, Int]): Map[Int, Int] = {
+ *   //  logic code...
+ *
+ *   target
+ *  }
+ *
+ * }}}
+ *
+ */
+object PregelOps extends Logging {
+
+  /**
+   * Implementing Part of the vertexes(we call them ActiveVertexes) send messages to their
+   * neighbours in each iteration.
+   *
+   * Provide a `isTerminal` to determine end up the loop with Int value `curIter` and the number
+   * of message count number previous iterate.
+   *
+   * @tparam VD the vertex data type
+   * @tparam ED the edge data type
+   * @tparam A the Pregel message type
+   *
+   * @param originGraph the input graph.
+   *
+   * @param initialMsg the message each vertex will receive at the on
+   * the first iteration. default is [[None]]
+   *
+   * @param isTerminal checking whether can finish loop
+   * Parameter Int is the current iteration variable `curIter`
+   * Parameter Long is the aggregate message number of previous iteration
+   *
+   * @param tripletFields which fields should be included in the [[EdgeContext]] passed to the
+   * `sendMsg` function. If not all fields are needed, specifying this can improve performance.
+   * default is [[TripletFields.All]]
+   *
+   * @param vprog the user-defined vertex program which runs on each
+   * vertex and receives the inbound message and computes a new vertex
+   * value.  On the first iteration the vertex program is invoked on
+   * all vertices and is passed the default message.  On subsequent
+   * iterations the vertex program is only invoked on those vertices
+   * that receive messages.
+   *
+   * @param sendMsg a user supplied function that is applied to out
+   * edges of vertices that received messages in the current iteration
+   *
+   * @param mergeMsg a user supplied function that takes two incoming
+   * messages of type A and merges them into a single message of type A.
+   * ''This function must be commutative and associative and
+   * ideally the size of A should not increase.''
+   *
+   * @return the resulting graph at the end of the computation
+   */
+  def apply[VD: ClassTag, ED: ClassTag, A: ClassTag]
+  (originGraph: Graph[VD, ED],
+    initialMsg: Option[A] = None,
+    isTerminal: (Int, Long) => Boolean = defaultTerminal,
+    tripletFields: TripletFields)
+    (vprog: (Int, VertexId, VD, A) => VD,
+      sendMsg: (Int, EdgeContext[VD, ED, A]) => Unit,
+      mergeMsg: (A, A) => A): Graph[VD, ED] = {
+
+    //  init iterate 0
+    val initIter = 0
+    var graph = initialMsg match {
+      case None => originGraph.cache()
+      case _ => originGraph.mapVertices((vid, vdata) => vprog(initIter, vid, vdata,
+        initialMsg.get)).cache()
+    }
+
+    // compute the messages
+    var messageRDD = graph.aggregateMessages(sendMsg(initIter, _: EdgeContext[VD, ED, A]), mergeMsg)
+    var activeMsgCount = messageRDD.count()
+
+    // Loop, from i = 1
+    var i = 1
+    while (activeMsgCount > 0 && isTerminal(i, activeMsgCount)) {
+      val ct = System.currentTimeMillis()
+      val curIter = i
+
+      // 1. Receive the messages. Vertices that didn't get any messages do not appear in newVerts.
+      val newVerts = graph.vertices.innerJoin(messageRDD)(
+        vprog(curIter, _: VertexId, _: VD, _: A)).cache()
+
+      // 2. Update the graph with the new vertices.
+      val preGraph: Graph[VD, ED] = graph
+      graph = graph.outerJoinVertices(newVerts) { (vid, old, newOpt) => newOpt.getOrElse(old)}
+      graph.cache()
+
+      val oldMessages = messageRDD
+      // 3. aggregate message
+      // Send new messages. Vertices that didn't get any messages don't appear in newVerts, so don't
+      // get to send messages. We must cache messages so it can be materialized on the next line,
+      // allowing us to uncache the previous iteration.
+      messageRDD = graph.aggregateMessages(sendMsg(curIter, _: EdgeContext[VD, ED, A]), mergeMsg,
+        tripletFields).cache()
+      // The call to count() materializes `messages`, `newVerts`, and the vertices of `g`. This
+      // hides oldMessages (depended on by newVerts), newVerts (depended on by messages), and the
+      // vertices of prevG (depended on by newVerts, oldMessages, and the vertices of g).
+      activeMsgCount = messageRDD.count()
+
+      // Unpersist the RDDs hidden by newly-materialized RDDs
+      oldMessages.unpersist(blocking = false)
+      newVerts.unpersist(blocking = false)
+      preGraph.unpersistVertices(blocking = false)
+      preGraph.edges.unpersist(blocking = false)
+      if (i == 1) {
+        originGraph.unpersistVertices(blocking = false)
+        originGraph.edges.unpersist(blocking = false)
+      }
+
+      i += 1
+
+      logInfo("{\"name\":\"pregel\", \"iterate\":" + i + ",\"cost\":"
+        + (System.currentTimeMillis() - ct) + "}")
+    }
+
+    graph
+  } // end of apply
+
+  /**
+   * default terminal function
+   * @return
+   */
+  private def defaultTerminal(curIter: Int, msgCount: Long): Boolean = true
+}


### PR DESCRIPTION
# Better support sending partial messages in Pregel API
### 1. the reqirement

In many iterative graph algorithms, only a part of the vertexes (we call them ActiveVertexes) need to send messages to their neighbours in each iteration. In many cases, ActiveVertexes are the vertexes that their attributes do not change between the previous and current iteration. To implement this requirement, we can use Pregel API + a flag (e.g., `bool isAttrChanged`) in each vertex's attribute. 

However, after `aggregateMessage` or `mapReduceTriplets` of each iteration, we need to reset this flag to the init value in every vertex, which needs a heavy `joinVertices`. 

We find a more efficient way to meet this requirement and want to discuss it here.

Look at a simple example as follows:

In i-th iteartion, the previous attribute of each vertex is `Attr` and the newly computed attribute is `NewAttr`:

| VID | Attr | NewAttr | Neighbours |
| :-- | :-- | :-- | :-- |
| 1 | 4 | 5 | 2, 3 |
| 2 | 3 | 2 | 1, 4 |
| 3 | 2 | 2 | 1, 4 |
| 4 | 3 | 4 | 1, 2, 3 |

Our requirement is that: 
1.  Set each vertex's `Attr` to be `NewAttr` in i-th iteration  
2.  For each vertex whose `Attr!=NewAttr`, send message to its neighbours in the next iteration's `aggregateMessage`.

We found it is hard to implement this requirment using current Pregel API efficiently. The reason is that we not only need to perform `pregel()` to  compute the `NewAttr`  (2) but also need to perform `outJoin()` to satisfy (1).

A simple idea is to keep a `isAttrChanged:Boolean` (solution 1)  or `flag:Int` (solution 2) in each vertex's attribute.
### 2. two solution

---
#### 2.1 solution 1: label and reset `isAttrChanged:Boolean` of Vertex Attr

![s1](https://cloud.githubusercontent.com/assets/648508/5591527/3911977a-919f-11e4-9147-37cb3d2f940c.jpg)
1. init message by `aggregateMessage`
   it return a messageRDD
2. `innerJoin`
   compute the messages on the received vertex, return a new VertexRDD which have the computed value by customed logic function `vprog`, set `isAttrChanged = true`
3. `outerJoinVertices`
   update the changed vertex to the whole graph. now the graph is new.
4. `aggregateMessage`. it return a messageRDD
5. `joinVertices`  reset erery `isAttrChanged` of Vertex attr to false
   
   ```
   //  here reset the isAttrChanged to false
   g = updateG.joinVertices(updateG.vertices) {
       (vid, oriVertex, updateGVertex) => updateGVertex.reset()
       }
   ```
   
   here need to reset the vertex attribute object's variable as false

if don't reset the `isAttrChanged`, it will send message next iteration directly.

**result:**  
-   Edge: 890041895 
-   Vertex: 181640208
-   Iterate: 150 times
-   Cost total: 8.4h
-   can't run until the 0 message 
#### solution 2. color vertex. (Choose this)

![s2](https://cloud.githubusercontent.com/assets/648508/5591530/434bafc8-919f-11e4-8ac7-44a8a2314cb5.jpg)

iterate process:
1. innerJoin 
   `vprog` using as a partial function, looks like `vprog(curIter, _: VertexId, _: VD, _: A)`
   `i = i + 1; val curIter = i`. 
   in `vprog`, user can fetch `curIter` and assign to `falg`.
2. outerJoinVertices
   `graph = graph.outerJoinVertices(changedVerts) { (vid, old, newOpt) => newOpt.getOrElse(old)}.cache()`
3. aggregateMessages  
   sendMsg is partial function, looks like `sendMsg(curIter, _: EdgeContext[VD, ED, A]`  
   **in `sendMsg`, compare `curIter` with `flag`, determine whether sending message**
#### result

raw data       from
-   vertex: 181640208
-   edge: 890041895

|  | iteration average cost | 150 iteration cost | 420 iteration cost |
| --- | --- | --- | --- |
| solution 1 | 188m | 7.8h | cannot finish |
| solution 2 | 24m | 1.2h | 3.1h |
| compare | 7x | 6.5x | finished in 3.1 |
## the end

i think the second solution(Pregel + a flag) is better.  
this can really support the iterative graph algorithms which only part of the vertexes send messages to their neighbours in each iteration.
