### PR TITLE
SPARK-5049: ParquetTableScan always prepends the values of partition col...

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -71,13 +71,15 @@ private[hive] trait HiveStrategies {
     }
 
     implicit class PhysicalPlanHacks(originalPlan: SparkPlan) {
-      def fakeOutput(newOutput: Seq[Attribute]) =
+      def fakeOutput(newOutput: Seq[Attribute]) = {
+        originalPlan.output.foreach(a =>
+          newOutput.find(a.name.toLowerCase == _.name.toLowerCase)
+          .getOrElse(
+            sys.error(s"Can't find attribute $a to fake in set ${newOutput.mkString(",")}")))
         OutputFaker(
-          originalPlan.output.map(a =>
-            newOutput.find(a.name.toLowerCase == _.name.toLowerCase)
-              .getOrElse(
-                sys.error(s"Can't find attribute $a to fake in set ${newOutput.mkString(",")}"))),
+          newOutput,
           originalPlan)
+        }
     }
 
     def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {


### PR DESCRIPTION
SPARK-5049: ParquetTableScan always prepends the values of partition columns in output rows irrespective of the order of the partition columns in the original SELECT query
- now forming a GenericRow by inserting column values at correct indexes
