### PR TITLE
SPARK-5017 [MLlib] - Use SVD to compute determinant and inverse of covariance matrix

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/stat/impl/MultivariateGaussian.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/stat/impl/MultivariateGaussian.scala
@@ -17,23 +17,62 @@
 
 package org.apache.spark.mllib.stat.impl
 
-import breeze.linalg.{DenseVector => DBV, DenseMatrix => DBM, Transpose, det, pinv}
+import breeze.linalg.{DenseVector => DBV, DenseMatrix => DBM, max, diag, eigSym}
 
-/** 
-   * Utility class to implement the density function for multivariate Gaussian distribution.
-   * Breeze provides this functionality, but it requires the Apache Commons Math library,
-   * so this class is here so-as to not introduce a new dependency in Spark.
-   */
+import org.apache.spark.mllib.util.MLUtils
+
+/*
+ * This class provides basic functionality for a Multivariate Gaussian (Normal) Distribution
+ * 
+ * @param mu The mean vector of the distribution
+ * @param sigma The covariance matrix of the distribution
+ */
 private[mllib] class MultivariateGaussian(
     val mu: DBV[Double], 
     val sigma: DBM[Double]) extends Serializable {
-  private val sigmaInv2 = pinv(sigma) * -0.5
-  private val U = math.pow(2.0 * math.Pi, -mu.length / 2.0) * math.pow(det(sigma), -0.5)
-    
+
+  private val (sigmaInv2, u) = calculateCovarianceConstants
+  
   /** Returns density of this multivariate Gaussian at given point, x */
   def pdf(x: DBV[Double]): Double = {
     val delta = x - mu
-    val deltaTranspose = new Transpose(delta)
-    U * math.exp(deltaTranspose * sigmaInv2 * delta)
+    u * math.exp(delta.t * sigmaInv2 * delta)
+  }
+  
+  /*
+   * Calculate distribution dependent components used for the density function:
+   *    pdf(x) = (2*pi)^(-k/2) * det(sigma)^(-1/2) * exp( (-1/2) * (x-mu).t * inv(sigma) * (x-mu) )
+   * where k is length of the mean vector.
+   * 
+   * We here compute distribution-fixed parts 
+   *  (2*pi)^(-k/2) * det(sigma)^(-1/2)
+   * and
+   *  (-1/2) * inv(sigma)
+   *  
+   * Both the determinant and the inverse can be computed from the singular value decomposition
+   * of sigma.  Noting that covariance matrices are always symmetric and positive semi-definite,
+   * we can use the eigendecomposition (breeze provides one specifically for symmetric matrices,
+   * so I am making an assumption here that there is some efficiency gain).
+   * 
+   * To guard against singular covariance matrices, this method computes both the 
+   * pseudo-determinant and the pseudo-inverse (Moore-Penrose).  Singular values are considered
+   * to be non-zero only if they exceed a tolerance based on machine precision, matrix size, and
+   * relation to the maximum singular value (same tolerance used by, ie, Octave).
+   */
+  private def calculateCovarianceConstants: (DBM[Double], Double) = {
+    val eigSym.EigSym(d, u) = eigSym(sigma) // sigma = u * diag(d) * u.t
+    
+    // For numerical stability, values are considered to be non-zero only if they exceed tol.
+    // This prevents any inverted value from exceeding (eps * n * max(d))^-1
+    val tol = MLUtils.EPSILON * max(d) * d.length
+    
+    // pseudo-determinant is product of all non-zero eigenvalues
+    val pdetSigma = (0 until d.length).map(i => if (d(i) > tol) d(i) else 1.0).reduce(_ * _)
+    
+    // calculate pseudo-inverse by inverting all non-zero eigenvalues
+    val pinvS = new DBV((0 until d.length).map(i => if (d(i) > tol) (1.0 / d(i)) else 0.0).toArray)
+    val pinvSigma = u * diag(pinvS) * u.t
+    
+    (pinvSigma * -0.5, math.pow(2.0 * math.Pi, -mu.length / 2.0) * math.pow(pdetSigma, -0.5))
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/stat/impl/MultivariateGaussian.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/stat/impl/MultivariateGaussian.scala
@@ -25,7 +25,7 @@ import org.apache.spark.mllib.util.MLUtils
  * This class provides basic functionality for a Multivariate Gaussian (Normal) Distribution. In
  * the event that the covariance matrix is singular, the density will be computed in a
  * reduced dimensional subspace under which the distribution is supported.
- * (see http://en.wikipedia.org/wiki/Multivariate_normal_distribution#Degenerate_case)
+ * (see [[http://en.wikipedia.org/wiki/Multivariate_normal_distribution#Degenerate_case]])
  * 
  * @param mu The mean vector of the distribution
  * @param sigma The covariance matrix of the distribution

--- a/mllib/src/test/scala/org/apache/spark/mllib/stat/impl/MultivariateGaussianSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/stat/impl/MultivariateGaussianSuite.scala
@@ -28,26 +28,26 @@ class MultivariateGaussianSuite extends FunSuite with MLlibTestSparkContext {
     val x = Vectors.dense(0.0).toBreeze.toDenseVector
     
     val mu = Vectors.dense(0.0).toBreeze.toDenseVector
-    var sigma = Matrices.dense(1, 1, Array(1.0)).toBreeze.toDenseMatrix
-    var dist = new MultivariateGaussian(mu, sigma)
-    assert(dist.pdf(x) ~== 0.39894 absTol 1E-5)
+    val sigma1 = Matrices.dense(1, 1, Array(1.0)).toBreeze.toDenseMatrix
+    val dist1 = new MultivariateGaussian(mu, sigma1)
+    assert(dist1.pdf(x) ~== 0.39894 absTol 1E-5)
     
-    sigma = Matrices.dense(1, 1, Array(4.0)).toBreeze.toDenseMatrix
-    dist = new MultivariateGaussian(mu, sigma)
-    assert(dist.pdf(x) ~== 0.19947 absTol 1E-5)
+    val sigma2 = Matrices.dense(1, 1, Array(4.0)).toBreeze.toDenseMatrix
+    val dist2 = new MultivariateGaussian(mu, sigma2)
+    assert(dist2.pdf(x) ~== 0.19947 absTol 1E-5)
   }
   
   test("multivariate") {
     val x = Vectors.dense(0.0, 0.0).toBreeze.toDenseVector
     
     val mu = Vectors.dense(0.0, 0.0).toBreeze.toDenseVector
-    var sigma = Matrices.dense(2, 2, Array(1.0, 0.0, 0.0, 1.0)).toBreeze.toDenseMatrix
-    var dist = new MultivariateGaussian(mu, sigma)
-    assert(dist.pdf(x) ~== 0.15915 absTol 1E-5)
+    val sigma1 = Matrices.dense(2, 2, Array(1.0, 0.0, 0.0, 1.0)).toBreeze.toDenseMatrix
+    val dist1 = new MultivariateGaussian(mu, sigma1)
+    assert(dist1.pdf(x) ~== 0.15915 absTol 1E-5)
     
-    sigma = Matrices.dense(2, 2, Array(4.0, -1.0, -1.0, 2.0)).toBreeze.toDenseMatrix
-    dist = new MultivariateGaussian(mu, sigma)
-    assert(dist.pdf(x) ~== 0.060155 absTol 1E-5)
+    val sigma2 = Matrices.dense(2, 2, Array(4.0, -1.0, -1.0, 2.0)).toBreeze.toDenseMatrix
+    val dist2 = new MultivariateGaussian(mu, sigma2)
+    assert(dist2.pdf(x) ~== 0.060155 absTol 1E-5)
   }
   
   test("multivariate degenerate") {

--- a/mllib/src/test/scala/org/apache/spark/mllib/stat/impl/MultivariateGaussianSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/stat/impl/MultivariateGaussianSuite.scala
@@ -25,37 +25,45 @@ import org.apache.spark.mllib.util.TestingUtils._
 
 class MultivariateGaussianSuite extends FunSuite with MLlibTestSparkContext {
   test("univariate") {
-    val x = Vectors.dense(0.0).toBreeze.toDenseVector
+    val x1 = Vectors.dense(0.0).toBreeze.toDenseVector
+    val x2 = Vectors.dense(1.5).toBreeze.toDenseVector
     
     val mu = Vectors.dense(0.0).toBreeze.toDenseVector
     val sigma1 = Matrices.dense(1, 1, Array(1.0)).toBreeze.toDenseMatrix
     val dist1 = new MultivariateGaussian(mu, sigma1)
-    assert(dist1.pdf(x) ~== 0.39894 absTol 1E-5)
+    assert(dist1.pdf(x1) ~== 0.39894 absTol 1E-5)
+    assert(dist1.pdf(x2) ~== 0.12952 absTol 1E-5)
     
     val sigma2 = Matrices.dense(1, 1, Array(4.0)).toBreeze.toDenseMatrix
     val dist2 = new MultivariateGaussian(mu, sigma2)
-    assert(dist2.pdf(x) ~== 0.19947 absTol 1E-5)
+    assert(dist2.pdf(x1) ~== 0.19947 absTol 1E-5)
+    assert(dist2.pdf(x2) ~== 0.15057 absTol 1E-5)
   }
   
   test("multivariate") {
-    val x = Vectors.dense(0.0, 0.0).toBreeze.toDenseVector
+    val x1 = Vectors.dense(0.0, 0.0).toBreeze.toDenseVector
+    val x2 = Vectors.dense(1.0, 1.0).toBreeze.toDenseVector
     
     val mu = Vectors.dense(0.0, 0.0).toBreeze.toDenseVector
     val sigma1 = Matrices.dense(2, 2, Array(1.0, 0.0, 0.0, 1.0)).toBreeze.toDenseMatrix
     val dist1 = new MultivariateGaussian(mu, sigma1)
-    assert(dist1.pdf(x) ~== 0.15915 absTol 1E-5)
+    assert(dist1.pdf(x1) ~== 0.15915 absTol 1E-5)
+    assert(dist1.pdf(x2) ~== 0.05855 absTol 1E-5)
     
     val sigma2 = Matrices.dense(2, 2, Array(4.0, -1.0, -1.0, 2.0)).toBreeze.toDenseMatrix
     val dist2 = new MultivariateGaussian(mu, sigma2)
-    assert(dist2.pdf(x) ~== 0.060155 absTol 1E-5)
+    assert(dist2.pdf(x1) ~== 0.060155 absTol 1E-5)
+    assert(dist2.pdf(x2) ~== 0.033971 absTol 1E-5)
   }
   
   test("multivariate degenerate") {
-    val x = Vectors.dense(0.0, 0.0).toBreeze.toDenseVector
+    val x1 = Vectors.dense(0.0, 0.0).toBreeze.toDenseVector
+    val x2 = Vectors.dense(1.0, 1.0).toBreeze.toDenseVector
     
     val mu = Vectors.dense(0.0, 0.0).toBreeze.toDenseVector
     val sigma = Matrices.dense(2, 2, Array(1.0, 1.0, 1.0, 1.0)).toBreeze.toDenseMatrix
     val dist = new MultivariateGaussian(mu, sigma)
-    assert(dist.pdf(x) ~== 0.11254 absTol 1E-5)
+    assert(dist.pdf(x1) ~== 0.11254 absTol 1E-5)
+    assert(dist.pdf(x2) ~== 0.068259 absTol 1E-5)
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/mllib/stat/impl/MultivariateGaussianSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/stat/impl/MultivariateGaussianSuite.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.mllib.stat.impl
+
+import org.scalatest.FunSuite
+
+import org.apache.spark.mllib.linalg.{Vectors, Matrices}
+import org.apache.spark.mllib.util.MLlibTestSparkContext
+import org.apache.spark.mllib.util.TestingUtils._
+
+class MultivariateGaussianSuite extends FunSuite with MLlibTestSparkContext {
+  test("univariate") {
+    val x = Vectors.dense(0.0).toBreeze.toDenseVector
+    
+    val mu = Vectors.dense(0.0).toBreeze.toDenseVector
+    var sigma = Matrices.dense(1, 1, Array(1.0)).toBreeze.toDenseMatrix
+    var dist = new MultivariateGaussian(mu, sigma)
+    assert(dist.pdf(x) ~== 0.39894 absTol 1E-5)
+    
+    sigma = Matrices.dense(1, 1, Array(4.0)).toBreeze.toDenseMatrix
+    dist = new MultivariateGaussian(mu, sigma)
+    assert(dist.pdf(x) ~== 0.19947 absTol 1E-5)
+  }
+  
+  test("multivariate") {
+    val x = Vectors.dense(0.0, 0.0).toBreeze.toDenseVector
+    
+    val mu = Vectors.dense(0.0, 0.0).toBreeze. toDenseVector
+    var sigma = Matrices.dense(2, 2, Array(1.0, 0.0, 0.0, 1.0)).toBreeze.toDenseMatrix
+    var dist = new MultivariateGaussian(mu, sigma)
+    assert(dist.pdf(x) ~== 0.15915 absTol 1E-5)
+    
+    sigma = Matrices.dense(2, 2, Array(4.0, -1.0, -1.0, 2.0)).toBreeze.toDenseMatrix
+    dist = new MultivariateGaussian(mu, sigma)
+    assert(dist.pdf(x) ~== 0.060155 absTol 1E-5)
+  }
+  
+  test("multivariate degenerate") {
+    val x = Vectors.dense(0.0, 0.0).toBreeze.toDenseVector
+    
+    val mu = Vectors.dense(0.0, 0.0).toBreeze. toDenseVector
+    var sigma = Matrices.dense(2, 2, Array(1.0, 1.0, 1.0, 1.0)).toBreeze.toDenseMatrix
+    var dist = new MultivariateGaussian(mu, sigma)
+    assert(dist.pdf(x) ~== 0.11254 absTol 1E-5)
+  }
+}

--- a/mllib/src/test/scala/org/apache/spark/mllib/stat/impl/MultivariateGaussianSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/stat/impl/MultivariateGaussianSuite.scala
@@ -40,7 +40,7 @@ class MultivariateGaussianSuite extends FunSuite with MLlibTestSparkContext {
   test("multivariate") {
     val x = Vectors.dense(0.0, 0.0).toBreeze.toDenseVector
     
-    val mu = Vectors.dense(0.0, 0.0).toBreeze. toDenseVector
+    val mu = Vectors.dense(0.0, 0.0).toBreeze.toDenseVector
     var sigma = Matrices.dense(2, 2, Array(1.0, 0.0, 0.0, 1.0)).toBreeze.toDenseMatrix
     var dist = new MultivariateGaussian(mu, sigma)
     assert(dist.pdf(x) ~== 0.15915 absTol 1E-5)
@@ -53,9 +53,9 @@ class MultivariateGaussianSuite extends FunSuite with MLlibTestSparkContext {
   test("multivariate degenerate") {
     val x = Vectors.dense(0.0, 0.0).toBreeze.toDenseVector
     
-    val mu = Vectors.dense(0.0, 0.0).toBreeze. toDenseVector
-    var sigma = Matrices.dense(2, 2, Array(1.0, 1.0, 1.0, 1.0)).toBreeze.toDenseMatrix
-    var dist = new MultivariateGaussian(mu, sigma)
+    val mu = Vectors.dense(0.0, 0.0).toBreeze.toDenseVector
+    val sigma = Matrices.dense(2, 2, Array(1.0, 1.0, 1.0, 1.0)).toBreeze.toDenseMatrix
+    val dist = new MultivariateGaussian(mu, sigma)
     assert(dist.pdf(x) ~== 0.11254 absTol 1E-5)
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/mllib/stat/impl/MultivariateGaussianSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/stat/impl/MultivariateGaussianSuite.scala
@@ -19,49 +19,50 @@ package org.apache.spark.mllib.stat.impl
 
 import org.scalatest.FunSuite
 
-import org.apache.spark.mllib.linalg.{Vectors, Matrices}
+import breeze.linalg.{ DenseVector => BDV, DenseMatrix => BDM }
+
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
 
 class MultivariateGaussianSuite extends FunSuite with MLlibTestSparkContext {
   test("univariate") {
-    val x1 = Vectors.dense(0.0).toBreeze.toDenseVector
-    val x2 = Vectors.dense(1.5).toBreeze.toDenseVector
-    
-    val mu = Vectors.dense(0.0).toBreeze.toDenseVector
-    val sigma1 = Matrices.dense(1, 1, Array(1.0)).toBreeze.toDenseMatrix
+    val x1 = new BDV(Array(0.0))
+    val x2 = new BDV(Array(1.5))
+                     
+    val mu = new BDV(Array(0.0))
+    val sigma1 = new BDM(1, 1, Array(1.0))
     val dist1 = new MultivariateGaussian(mu, sigma1)
     assert(dist1.pdf(x1) ~== 0.39894 absTol 1E-5)
     assert(dist1.pdf(x2) ~== 0.12952 absTol 1E-5)
     
-    val sigma2 = Matrices.dense(1, 1, Array(4.0)).toBreeze.toDenseMatrix
+    val sigma2 = new BDM(1, 1, Array(4.0))
     val dist2 = new MultivariateGaussian(mu, sigma2)
     assert(dist2.pdf(x1) ~== 0.19947 absTol 1E-5)
     assert(dist2.pdf(x2) ~== 0.15057 absTol 1E-5)
   }
   
   test("multivariate") {
-    val x1 = Vectors.dense(0.0, 0.0).toBreeze.toDenseVector
-    val x2 = Vectors.dense(1.0, 1.0).toBreeze.toDenseVector
+    val x1 = new BDV(Array(0.0, 0.0))
+    val x2 = new BDV(Array(1.0, 1.0))
     
-    val mu = Vectors.dense(0.0, 0.0).toBreeze.toDenseVector
-    val sigma1 = Matrices.dense(2, 2, Array(1.0, 0.0, 0.0, 1.0)).toBreeze.toDenseMatrix
+    val mu = new BDV(Array(0.0, 0.0))
+    val sigma1 = new BDM(2, 2, Array(1.0, 0.0, 0.0, 1.0))
     val dist1 = new MultivariateGaussian(mu, sigma1)
     assert(dist1.pdf(x1) ~== 0.15915 absTol 1E-5)
     assert(dist1.pdf(x2) ~== 0.05855 absTol 1E-5)
     
-    val sigma2 = Matrices.dense(2, 2, Array(4.0, -1.0, -1.0, 2.0)).toBreeze.toDenseMatrix
+    val sigma2 = new BDM(2, 2, Array(4.0, -1.0, -1.0, 2.0))
     val dist2 = new MultivariateGaussian(mu, sigma2)
     assert(dist2.pdf(x1) ~== 0.060155 absTol 1E-5)
     assert(dist2.pdf(x2) ~== 0.033971 absTol 1E-5)
   }
   
   test("multivariate degenerate") {
-    val x1 = Vectors.dense(0.0, 0.0).toBreeze.toDenseVector
-    val x2 = Vectors.dense(1.0, 1.0).toBreeze.toDenseVector
+    val x1 = new BDV(Array(0.0, 0.0))
+    val x2 = new BDV(Array(1.0, 1.0))
     
-    val mu = Vectors.dense(0.0, 0.0).toBreeze.toDenseVector
-    val sigma = Matrices.dense(2, 2, Array(1.0, 1.0, 1.0, 1.0)).toBreeze.toDenseMatrix
+    val mu = new BDV(Array(0.0, 0.0))
+    val sigma = new BDM(2, 2, Array(1.0, 1.0, 1.0, 1.0))
     val dist = new MultivariateGaussian(mu, sigma)
     assert(dist.pdf(x1) ~== 0.11254 absTol 1E-5)
     assert(dist.pdf(x2) ~== 0.068259 absTol 1E-5)


### PR DESCRIPTION
MultivariateGaussian was calling both pinv() and det() on the covariance matrix, effectively performing two matrix decompositions.  Both values are now computed using the singular value decompositon. Both the pseudo-inverse and the pseudo-determinant are used to guard against singular matrices.
