### PR TITLE
[SPARK-2165][YARN]add support for setting maxAppAttempts in the ApplicationSubmissionContext

### DIFF
--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -149,6 +149,14 @@ Most of the configs are the same for Spark on YARN as for other deployment modes
   In cluster mode, use spark.driver.extraJavaOptions instead.
   </td>
 </tr>
+<tr>
+  <td><code>spark.yarn.amMaxAttempts</code></td>
+  <td>YARN default</td>
+  <td>
+  The maximum number of ApplicationMaster attempts.
+  It should not be larger than the global number set by resourcemanager. Otherwise, it will be override.
+  </td>
+</tr>
 </table>
 
 # Launching Spark on YARN

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -153,8 +153,8 @@ Most of the configs are the same for Spark on YARN as for other deployment modes
   <td><code>spark.yarn.amMaxAttempts</code></td>
   <td>yarn.resourcemanager.am.max-attempts in YARN</td>
   <td>
-  The maximum number of ApplicationMaster attempts.
-  It should not be larger than the global number set by resourcemanager. Otherwise, it will be override.
+  The maximum number of attempts that will be made to submit the application.
+  It should be no larger than the global number of max attempts in the YARN configuration.
   </td>
 </tr>
 </table>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -150,7 +150,7 @@ Most of the configs are the same for Spark on YARN as for other deployment modes
   </td>
 </tr>
 <tr>
-  <td><code>spark.yarn.amMaxAttempts</code></td>
+  <td><code>spark.yarn.maxAppAttempts</code></td>
   <td>yarn.resourcemanager.am.max-attempts in YARN</td>
   <td>
   The maximum number of attempts that will be made to submit the application.

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -151,7 +151,7 @@ Most of the configs are the same for Spark on YARN as for other deployment modes
 </tr>
 <tr>
   <td><code>spark.yarn.amMaxAttempts</code></td>
-  <td>YARN default</td>
+  <td>yarn.resourcemanager.am.max-attempts in YARN</td>
   <td>
   The maximum number of ApplicationMaster attempts.
   It should not be larger than the global number set by resourcemanager. Otherwise, it will be override.

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -102,7 +102,7 @@ private[spark] class ApplicationMaster(args: ApplicationMasterArguments,
             logInfo("Invoking sc stop from shutdown hook")
             sc.stop()
           }
-          val maxAppAttempts = client.getMaxRegAttempts(yarnConf)
+          val maxAppAttempts = client.getMaxRegAttempts(sparkConf, yarnConf)
           val isLastAttempt = client.getAttemptId().getAttemptId() >= maxAppAttempts
 
           if (!finished) {

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -98,6 +98,11 @@ private[spark] class Client(
     appContext.setQueue(args.amQueue)
     appContext.setAMContainerSpec(containerContext)
     appContext.setApplicationType("SPARK")
+    sparkConf.getOption("spark.yarn.amMaxAttempts").map(_.toInt) match {
+      case Some(v) => appContext.setMaxAppAttempts(v)
+      case None => logDebug("spark.yarn.amMaxAttempts is not set. " +
+          "Cluster's default value will be used.")
+    }
     val capability = Records.newRecord(classOf[Resource])
     capability.setMemory(args.amMemory + amMemoryOverhead)
     appContext.setResource(capability)

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -98,9 +98,9 @@ private[spark] class Client(
     appContext.setQueue(args.amQueue)
     appContext.setAMContainerSpec(containerContext)
     appContext.setApplicationType("SPARK")
-    sparkConf.getOption("spark.yarn.amMaxAttempts").map(_.toInt) match {
+    sparkConf.getOption("spark.yarn.maxAppAttempts").map(_.toInt) match {
       case Some(v) => appContext.setMaxAppAttempts(v)
-      case None => logDebug("spark.yarn.amMaxAttempts is not set. " +
+      case None => logDebug("spark.yarn.maxAppAttempts is not set. " +
           "Cluster's default value will be used.")
     }
     val capability = Records.newRecord(classOf[Resource])

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnRMClient.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnRMClient.scala
@@ -120,7 +120,10 @@ private[spark] class YarnRMClient(args: ApplicationMasterArguments) extends Logg
   }
 
   /** Returns the maximum number of attempts to register the AM. */
-  def getMaxRegAttempts(conf: YarnConfiguration): Int =
-    conf.getInt(YarnConfiguration.RM_AM_MAX_ATTEMPTS, YarnConfiguration.DEFAULT_RM_AM_MAX_ATTEMPTS)
+  def getMaxRegAttempts(sparkConf: SparkConf, yarnConf: YarnConfiguration): Int = {
+    sparkConf.getOption("spark.yarn.amMaxAttempts").map(_.toInt).getOrElse(
+      yarnConf.getInt(
+        YarnConfiguration.RM_AM_MAX_ATTEMPTS, YarnConfiguration.DEFAULT_RM_AM_MAX_ATTEMPTS))
+  }
 
 }

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnRMClient.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnRMClient.scala
@@ -121,7 +121,7 @@ private[spark] class YarnRMClient(args: ApplicationMasterArguments) extends Logg
 
   /** Returns the maximum number of attempts to register the AM. */
   def getMaxRegAttempts(sparkConf: SparkConf, yarnConf: YarnConfiguration): Int = {
-    sparkConf.getOption("spark.yarn.amMaxAttempts").map(_.toInt).getOrElse(
+    sparkConf.getOption("spark.yarn.maxAppAttempts").map(_.toInt).getOrElse(
       yarnConf.getInt(
         YarnConfiguration.RM_AM_MAX_ATTEMPTS, YarnConfiguration.DEFAULT_RM_AM_MAX_ATTEMPTS))
   }


### PR DESCRIPTION
...xt

https://issues.apache.org/jira/browse/SPARK-2165

I still have 2 questions:
- If this config is not set, we should use yarn's corresponding value or a default value(like 2) on spark side?
- Is the config name best? Or "spark.yarn.am.maxAttempts"?
