### PR TITLE
[Core][ SPARK-5065]Fix: BroadCast can still work after sc had been stopped.

### DIFF
--- a/core/src/main/scala/org/apache/spark/broadcast/BroadcastManager.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/BroadcastManager.scala
@@ -53,12 +53,16 @@ private[spark] class BroadcastManager(
   }
 
   def stop() {
+    initialized = false
     broadcastFactory.stop()
   }
 
   private val nextBroadcastId = new AtomicLong(0)
 
   def newBroadcast[T: ClassTag](value_ : T, isLocal: Boolean) = {
+    if (!initialized) {
+      throw new SparkException("BroadcastManager has not been init or already shut down.")
+    }
     broadcastFactory.newBroadcast[T](value_, isLocal, nextBroadcastId.getAndIncrement())
   }
 

--- a/core/src/test/scala/org/apache/spark/broadcast/BroadcastSuite.scala
+++ b/core/src/test/scala/org/apache/spark/broadcast/BroadcastSuite.scala
@@ -56,6 +56,17 @@ class BroadcastSuite extends FunSuite with LocalSparkContext {
     assert(results.collect().toSet === Set((1, 10), (2, 10)))
   }
 
+  test("Using Broadcast locally with multiple SparkContext") {
+    val firstSc = new SparkContext("local", "test", httpConf)
+    firstSc.stop()
+    val secondSc = new SparkContext("local", "test", httpConf)
+    val list = List[Int](1, 2, 3, 4)
+    val thrown = intercept[Exception]{
+      val broadcast = firstSc.broadcast(list)
+    }
+    assert(thrown.getMessage.toLowerCase().contains("already shut down"))
+  }
+
   test("Accessing HttpBroadcast variables from multiple threads") {
     sc = new SparkContext("local[10]", "test", httpConf)
     val list = List[Int](1, 2, 3, 4)


### PR DESCRIPTION
Fix the bug as code shows:

``` scala
val sc1 = new SparkContext
sc1.stop
val sc2 = new SparkContext
sc1.broadcast(1)
```

The broadCast can still work after sc had down.
So throw an exception to fix it  when broadcast called in such scenario.
