### PR TITLE
[SQL][SPARK-4226]: Add support for subqueries in where in clause

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -119,6 +119,20 @@ case class InSet(value: Expression, hset: Set[Any])
   }
 }
 
+/**
+ * Evaluates to `true` if `list` contains `value`.
+ */
+case class InSubquery(value: Expression) extends Predicate {
+  def children = Seq(value)
+
+  def nullable = true // TODO: Figure out correct nullability semantics of IN.
+  override def toString = s"$value IN subquery"
+
+  override def eval(input: Row): Any = {
+    null
+  }
+}
+
 case class And(left: Expression, right: Expression) extends BinaryPredicate {
   def symbol = "&&"
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicOperators.scala
@@ -64,6 +64,11 @@ case class Filter(condition: Expression, child: LogicalPlan) extends UnaryNode {
   override def output = child.output
 }
 
+case class DynamicFilter(condition: Expression, left: LogicalPlan, right: LogicalPlan)
+  extends BinaryNode {
+  override def output = left.output
+}
+
 case class Union(left: LogicalPlan, right: LogicalPlan) extends BinaryNode {
   // TODO: These aren't really the same attributes as nullability etc might change.
   override def output = left.output

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -275,6 +275,8 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         execution.Project(projectList, planLater(child)) :: Nil
       case logical.Filter(condition, child) =>
         execution.Filter(condition, planLater(child)) :: Nil
+      case logical.DynamicFilter(condition, child, subQuery) =>
+        execution.DynamicFilter(condition, planLater(child), planLater(subQuery)) :: Nil
       case logical.Expand(projections, output, child) =>
         execution.Expand(projections, output, planLater(child)) :: Nil
       case logical.Aggregate(group, agg, child) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicOperators.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution
 
 import scala.collection.mutable.ArrayBuffer
+import scala.collection.immutable.HashSet
 import scala.reflect.runtime.universe.TypeTag
 
 import org.apache.spark.{SparkEnv, HashPartitioner, SparkConf}
@@ -59,6 +60,48 @@ case class Filter(condition: Expression, child: SparkPlan) extends UnaryNode {
     iter.filter(conditionEvaluator)
   }
 }
+
+/**
+ * :: DeveloperApi ::
+ */
+@DeveloperApi
+case class DynamicFilter(condition: Expression, left: SparkPlan, right: SparkPlan)
+  extends BinaryNode {
+  override def output = left.output
+
+  def execute() = {
+    val modCod: Expression = condition match {
+      case InSubquery(value) =>
+
+        val iterList = right.execute().mapPartitions { iter =>
+          val hashSet = new scala.collection.mutable.HashSet[Row]()
+
+          var currentRow: Row = null
+          while (iter.hasNext) {
+            currentRow = iter.next()
+            if (!hashSet.contains(currentRow)) {
+              hashSet.add(currentRow.copy())
+            }
+          }
+
+          hashSet.iterator
+        }
+
+        // Taking only the first element for now
+        val values = iterList.collect().map(s => s.apply(0))
+
+        val hSet: HashSet[Any] = HashSet() ++ values
+        InSet(value, hSet)
+
+    }
+
+    lazy val conditionEvaluator = newPredicate(modCod, left.output)
+    left.execute().mapPartitions { iter =>
+      iter.filter(conditionEvaluator)
+    }
+  }
+}
+
 
 /**
  * :: DeveloperApi ::
@@ -311,3 +354,4 @@ case class OutputFaker(output: Seq[Attribute], child: SparkPlan) extends SparkPl
   def children = child :: Nil
   def execute() = child.execute()
 }
+

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
@@ -581,9 +581,18 @@ https://cwiki.apache.org/confluence/display/Hive/Enhanced+Aggregation%2C+Cube%2C
         }
 
         val relations = nodeToRelation(fromClause)
-        val withWhere = whereClause.map { whereNode =>
+
+        val withWhere: LogicalPlan = whereClause.map { whereNode =>
           val Seq(whereExpr) = whereNode.getChildren.toSeq
-          Filter(nodeToExpr(whereExpr), relations)
+          whereExpr match {
+            case Token("TOK_SUBQUERY_EXPR",
+            Token("TOK_SUBQUERY_OP", _) :: query :: value)  =>
+              val Some(squery) :: _ :: extended :: Nil =
+                getClauses(Seq("TOK_QUERY", "FORMATTED", "EXTENDED"), Seq(query))
+              val subqueryPlan = nodeToPlan(squery)
+              DynamicFilter(InSubquery(nodeToExpr(value.head)), relations, subqueryPlan)
+            case other => Filter(nodeToExpr(whereExpr), relations)
+          }
         }.getOrElse(relations)
 
         val select =


### PR DESCRIPTION
this PR adds support for subquery in where in clause by adding a dynamic filter class that will compute the values list from the subquery first and then create a hash-set , using it as input to inset class.
