### PR TITLE
[SPARK-5195][sql]Update HiveMetastoreCatalog.scala(override the MetastoreRelation's sameresult method only compare databasename and table name)

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -428,11 +428,11 @@ private[hive] case class MetastoreRelation
     }
   )
   override def sameResult(plan: LogicalPlan): Boolean = {
-    val new_plan = plan.asInstanceOf[MetastoreRelation];
-    plan.getClass == this.getClass &&
-    plan.children.size == children.size &&
-    databaseName == new_plan.databaseName &&
-    tableName == new_plan.tableName
+      plan match {
+           case mr: MetastoreRelation =>
+                    mr.databaseName == databaseName && mr.tableName == tableName
+           case _ => false
+      }
   }
 
   val tableDesc = HiveShim.getTableDesc(

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -427,6 +427,13 @@ private[hive] case class MetastoreRelation
           .getOrElse(sqlContext.defaultSizeInBytes))
     }
   )
+  override def sameResult(plan: LogicalPlan): Boolean = {
+    val new_plan = plan.asInstanceOf[MetastoreRelation];
+    plan.getClass == this.getClass &&
+    plan.children.size == children.size &&
+    databaseName == new_plan.databaseName &&
+    tableName == new_plan.tableName
+  }
 
   val tableDesc = HiveShim.getTableDesc(
     Class.forName(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/CachedTableSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/CachedTableSuite.scala
@@ -64,6 +64,12 @@ class CachedTableSuite extends QueryTest {
       sql("SELECT * FROM src"),
       preCacheResults)
 
+    assertCached(sql("SELECT * FROM src s"))
+
+    checkAnswer(
+      sql("SELECT * FROM src s"),
+      preCacheResults)
+    
     uncacheTable("src")
     assertCached(sql("SELECT * FROM src"), 0)
   }


### PR DESCRIPTION
override  the MetastoreRelation's  sameresult method only compare databasename and table name

because in previous :
cache table t1;
select count(_) from t1;
it will read data from memory  but the sql below will not,instead it read from hdfs:
select count(_) from t1 t; 

because cache data is keyed by logical plan and compare with sameResult ,so  when table with alias  the same table 's logicalplan is not the same logical plan with out alias  so modify  the sameresult method only compare databasename and table name
