### PR TITLE
remove out of date statements since assembly is ON by default

### DIFF
--- a/assembly/README
+++ b/assembly/README
@@ -1,11 +1,6 @@
 This is an assembly module for Spark project.
 
-It creates a single tar.gz file that includes all needed dependency of the project
-except for org.apache.hadoop.* jars that are supposed to be available from the
-deployed Hadoop cluster.
-
-This module is off by default. To activate it specify the profile in the command line
-  -Pbigtop-dist
+It creates a single tar.gz file that includes all needed dependency of the project.
 
 If you need to build an assembly for a different version of Hadoop the
 hadoop-version system property needs to be set as in this example:


### PR DESCRIPTION
From the git history, this behavior has been changed long time ago

255597:commit 666d93c294458cb056cb590eb11bb6cf979861e5
255645-Author: Matei Zaharia matei@eecs.berkeley.edu
255693-Date:   Tue Aug 27 19:23:54 2013 -0700
255732-
255733-    Update Maven build to create assemblies expected by new scripts
255801-  
255806-    This includes the following changes:
255847-    - The "assembly" package now builds in Maven by default, and creates an
255923-      assembly containing both hadoop-client and Spark, unlike the old
255994-      BigTop distribution assembly that skipped hadoop-client
256056-    - There is now a bigtop-dist package to build the old BigTop assembly
