### PR TITLE
[SPARK-4296][SQL] Trims aliases when resolving and checking aggregate expressions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -209,10 +209,10 @@ class Analyzer(catalog: Catalog,
 
           aggregateExprs.find { e =>
             !isValidAggregateExpression(e.transform {
-              // Should trim aliases around `GetField`s. These aliases are introduced while
-              // resolving struct field accesses, because `GetField` is not a `NamedExpression`.
-              // (Should we just turn `GetField` into a `NamedExpression`?)
-              case Alias(g: GetField, _) => g
+              // Should trim aliases. These aliases can only be introduced while resolving unnamed
+              // expressions like `GetField` and UDF calls, because GROUP BY clause doesn't allow
+              // aliasing.
+              case a: Alias => a.child
             })
           }.foreach { e =>
             throw new TreeNodeException(plan, s"Expression not in GROUP BY: $e")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -153,11 +153,11 @@ object PartialAggregation {
             partialEvaluations(new TreeNodeRef(e)).finalEvaluation
 
           case e: Expression =>
-            // Should trim aliases around `GetField`s. These aliases are introduced while
-            // resolving struct field accesses, because `GetField` is not a `NamedExpression`.
-            // (Should we just turn `GetField` into a `NamedExpression`?)
             namedGroupingExpressions
-              .get(e.transform { case Alias(g: GetField, _) => g })
+              // Should trim aliases. These aliases can only be introduced while resolving unnamed
+              // expressions like `GetField` and UDF calls, because GROUP BY clause doesn't allow
+              // aliasing.
+              .get(e.transform { case a: Alias => a.child })
               .map(_.toAttribute)
               .getOrElse(e)
         }).asInstanceOf[Seq[NamedExpression]]

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -980,6 +980,17 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll {
     dropTempTable("data")
   }
 
+  test("SPARK-4296 Grouping field with UDF as sub expression") {
+    registerFunction("triple", (_: Int) * 3)
+    jsonRDD(sparkContext.makeRDD("""{"a": 1}""" :: Nil)).registerTempTable("data")
+    checkAnswer(sql("SELECT triple(a) FROM data GROUP BY triple(a)"), 3)
+    dropTempTable("data")
+
+    jsonRDD(sparkContext.makeRDD("""{"a": 1}""" :: Nil)).registerTempTable("data")
+    checkAnswer(sql("SELECT triple(a) + 1 FROM data GROUP BY triple(a) + 1"), 4)
+    dropTempTable("data")
+  }
+
   test("SPARK-4432 Fix attribute reference resolution error when using ORDER BY") {
     checkAnswer(
       sql("SELECT a + b FROM testData2 ORDER BY a"),


### PR DESCRIPTION
This PR is a follow-up of PR #3248.  We should not only trim `Alias` around `GetField` but also all unnamed expressions when resolving and checking aggregate expressions. Trimming all aliases is safe because `GROUP BY` doesn't allow aliasing, thus all aliases added to an aggregate expression which is also a grouping expression must be introduced while resolving unnamed expressions like `GetField` and UDF calls.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/apache/spark/3910)

<!-- Reviewable:end -->
