### PR TITLE
[SPARK-5107][Streaming][Log]: Distinguish the "register state" and "start state" of receiver

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/ReceiverSupervisorImpl.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/ReceiverSupervisorImpl.scala
@@ -73,16 +73,15 @@ private[streaming] class ReceiverSupervisorImpl(
 
   /** Timeout for Akka actor messages */
   private val askTimeout = AkkaUtils.askTimeout(env.conf)
-  private var numRegisterAttemps = -1
+  private var numStartAttempts = 0
 
   /** Akka actor for receiving messages from the ReceiverTracker in the driver */
   private val actor = env.actorSystem.actorOf(
     Props(new Actor {
       override def preStart() {
-        numRegisterAttemps += 1
-        logInfo("Register receiver " + streamId + " before it starts ")
-        val msg = RegisterReceiver(streamId, receiver.getClass.getSimpleName,
-          Utils.localHostName(), numRegisterAttemps, self)
+        logInfo(s"Registered receiver ${streamId} ")
+        val msg = RegisterReceiver(
+          streamId, receiver.getClass.getSimpleName, Utils.localHostName(), self)
         val future = trackerActor.ask(msg)(askTimeout)
         Await.result(future, askTimeout)
       }
@@ -185,10 +184,14 @@ private[streaming] class ReceiverSupervisorImpl(
   }
 
   override protected def onReceiverStart() {
-    numRegisterAttemps += 1
-    logInfo("Attempt to start receiver " + streamId + " for the " + numRegisterAttemps + " time.")
-    val msg = RegisterReceiver(
-      streamId, receiver.getClass.getSimpleName, Utils.localHostName(), numRegisterAttemps, actor)
+    numStartAttempts += 1
+    if(numStartAttempts > 1) {
+      logInfo(s"Receiver ${streamId} failed ${numStartAttempts -1} times, " +
+        s"and attempts to restart.")
+    } else {
+      logInfo(s"Receiver ${streamId} attempts to start.")
+    }
+    val msg = StartingReceiver(streamId, numStartAttempts)
     val future = trackerActor.ask(msg)(askTimeout)
     Await.result(future, askTimeout)
   }

--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/ReceiverSupervisorImpl.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/ReceiverSupervisorImpl.scala
@@ -81,8 +81,8 @@ private[streaming] class ReceiverSupervisorImpl(
       override def preStart() {
         numRegisterAttemps += 1
         logInfo("Register receiver " + streamId + " before it starts ")
-        val msg = RegisterReceiver(
-          streamId, receiver.getClass.getSimpleName, Utils.localHostName(), numRegisterAttemps, self)
+        val msg = RegisterReceiver(streamId, receiver.getClass.getSimpleName,
+          Utils.localHostName(), numRegisterAttemps, self)
         val future = trackerActor.ask(msg)(askTimeout)
         Await.result(future, askTimeout)
       }

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceiverTracker.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceiverTracker.scala
@@ -154,7 +154,7 @@ class ReceiverTracker(ssc: StreamingContext, skipReceiverLaunch: Boolean = false
     listenerBus.post(StreamingListenerReceiverStarted(receiverInfo(streamId)))
     if(numStartAttempts > 1) {
       logInfo(s"Receiver for stream ${streamId} from ${sender.path.address} " +
-        s"failed ${numAttempts -1} times, and attempts to restart.")
+        s"failed ${numStartAttempts -1} times, and attempts to restart.")
     } else {
       logInfo(s"Receiver for stream ${streamId} from ${sender.path.address} " +
         s"attempts to start.")

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceiverTracker.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceiverTracker.scala
@@ -145,11 +145,10 @@ class ReceiverTracker(ssc: StreamingContext, skipReceiverLaunch: Boolean = false
         " attempts to register.")
     } else if(numAttempts == 1) {
       logInfo("Receiver for stream " + streamId + " from " + sender.path.address +
-        " attempts to start for the " + numAttempts + " time.")
+        " attempts to start.")
     } else {
       logInfo("Receiver for stream " + streamId + " from " + sender.path.address +
-        " failed " + (numAttempts - 1) + " times, and attempts to start for the " +
-        numAttempts + " time.")
+        " failed " + (numAttempts - 1) + " times, and attempts to restart.")
     }
   }
 


### PR DESCRIPTION
Receiver will register itself whenever it begins to start. What is more, receiver will send a  "Register Receiver" message in preStart. It is trick to log the same information, and will lead to misunderstanding. Just like the following partial info:
![3](https://cloud.githubusercontent.com/assets/7402327/5633172/ad35a078-960f-11e4-8841-d8e647341b70.JPG)
We can distinguish the "register state" and "start state" of receiver, and log the information more clearly. Well, nothing matters performance or use. After improve:
![4](https://cloud.githubusercontent.com/assets/7402327/5641861/227a9058-967b-11e4-8ea1-4a8ebf5717ce.JPG)
