### PR TITLE
[SPARK-5090][examples] The improvement of python converter for hbase

### DIFF
--- a/examples/src/main/python/hbase_inputformat.py
+++ b/examples/src/main/python/hbase_inputformat.py
@@ -16,7 +16,7 @@
 #
 
 import sys
-import ast
+import simplejson as json
 
 from pyspark import SparkContext
 
@@ -75,8 +75,8 @@ if __name__ == "__main__":
         keyConverter=keyConv,
         valueConverter=valueConv,
         conf=conf)
-    # hbase_rdd is a RDD[dict]
-    hbase_rdd = hbase_rdd.flatMapValues(lambda v: v.split(" ")).mapValues(ast.literal_eval)
+    # hbase_rdd is a RDD of dict
+    hbase_rdd = hbase_rdd.flatMapValues(lambda v: v).mapValues(json.loads)
 
     output = hbase_rdd.collect()
     for (k, v) in output:

--- a/examples/src/main/python/hbase_inputformat.py
+++ b/examples/src/main/python/hbase_inputformat.py
@@ -75,7 +75,6 @@ if __name__ == "__main__":
         keyConverter=keyConv,
         valueConverter=valueConv,
         conf=conf)
-    # hbase_rdd is a RDD of dict
     hbase_rdd = hbase_rdd.flatMapValues(lambda v: v).mapValues(json.loads)
 
     output = hbase_rdd.collect()

--- a/examples/src/main/python/hbase_inputformat.py
+++ b/examples/src/main/python/hbase_inputformat.py
@@ -16,7 +16,7 @@
 #
 
 import sys
-import simplejson as json
+import json
 
 from pyspark import SparkContext
 
@@ -75,7 +75,7 @@ if __name__ == "__main__":
         keyConverter=keyConv,
         valueConverter=valueConv,
         conf=conf)
-    hbase_rdd = hbase_rdd.flatMapValues(lambda v: v).mapValues(json.loads)
+    hbase_rdd = hbase_rdd.flatMapValues(lambda v: v.split("\n")).mapValues(json.loads)
 
     output = hbase_rdd.collect()
     for (k, v) in output:

--- a/examples/src/main/python/hbase_inputformat.py
+++ b/examples/src/main/python/hbase_inputformat.py
@@ -26,24 +26,24 @@ Create test data in HBase first:
 hbase(main):016:0> create 'test', 'f1'
 0 row(s) in 1.0430 seconds
 
-hbase(main):017:0> put 'test', 'row1', 'f1', 'value1'
+hbase(main):017:0> put 'test', 'row1', 'f1:a', 'value1'
 0 row(s) in 0.0130 seconds
 
-hbase(main):018:0> put 'test', 'row2', 'f1', 'value2'
+hbase(main):018:0> put 'test', 'row1', 'f1:b', 'value2'
 0 row(s) in 0.0030 seconds
 
-hbase(main):019:0> put 'test', 'row3', 'f1', 'value3'
+hbase(main):019:0> put 'test', 'row2', 'f1', 'value3'
 0 row(s) in 0.0050 seconds
 
-hbase(main):020:0> put 'test', 'row4', 'f1', 'value4'
+hbase(main):020:0> put 'test', 'row3', 'f1', 'value4'
 0 row(s) in 0.0110 seconds
 
 hbase(main):021:0> scan 'test'
 ROW                           COLUMN+CELL
- row1                         column=f1:, timestamp=1401883411986, value=value1
- row2                         column=f1:, timestamp=1401883415212, value=value2
- row3                         column=f1:, timestamp=1401883417858, value=value3
- row4                         column=f1:, timestamp=1401883420805, value=value4
+ row1                         column=f1:a, timestamp=1401883411986, value=value1
+ row1                         column=f1:b, timestamp=1401883415212, value=value2
+ row2                         column=f1:, timestamp=1401883417858, value=value3
+ row3                         column=f1:, timestamp=1401883420805, value=value4
 4 row(s) in 0.0240 seconds
 """
 if __name__ == "__main__":

--- a/examples/src/main/python/hbase_inputformat.py
+++ b/examples/src/main/python/hbase_inputformat.py
@@ -16,6 +16,7 @@
 #
 
 import sys
+import ast
 
 from pyspark import SparkContext
 
@@ -61,6 +62,8 @@ if __name__ == "__main__":
     table = sys.argv[2]
     sc = SparkContext(appName="HBaseInputFormat")
 
+    # Other options for configuring scan behavior are available. More information available at
+    # https://github.com/apache/hbase/blob/master/hbase-server/src/main/java/org/apache/hadoop/hbase/mapreduce/TableInputFormat.java
     conf = {"hbase.zookeeper.quorum": host, "hbase.mapreduce.inputtable": table}
     keyConv = "org.apache.spark.examples.pythonconverters.ImmutableBytesWritableToStringConverter"
     valueConv = "org.apache.spark.examples.pythonconverters.HBaseResultToStringConverter"
@@ -72,6 +75,9 @@ if __name__ == "__main__":
         keyConverter=keyConv,
         valueConverter=valueConv,
         conf=conf)
+    # hbase_rdd is a RDD[dict]
+    hbase_rdd = hbase_rdd.flatMapValues(lambda v: v.split(" ")).mapValues(ast.literal_eval)
+
     output = hbase_rdd.collect()
     for (k, v) in output:
         print (k, v)

--- a/examples/src/main/scala/org/apache/spark/examples/HBaseTest.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/HBaseTest.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.examples
 
 import org.apache.hadoop.hbase.client.HBaseAdmin
-import org.apache.hadoop.hbase.{HBaseConfiguration, HTableDescriptor}
+import org.apache.hadoop.hbase.{HBaseConfiguration, HTableDescriptor, TableName}
 import org.apache.hadoop.hbase.mapreduce.TableInputFormat
 
 import org.apache.spark._
@@ -36,7 +36,7 @@ object HBaseTest {
     // Initialize hBase table if necessary
     val admin = new HBaseAdmin(conf)
     if (!admin.isTableAvailable(args(0))) {
-      val tableDesc = new HTableDescriptor(args(0))
+      val tableDesc = new HTableDescriptor(TableName.valueOf(args(0)))
       admin.createTable(tableDesc)
     }
 

--- a/examples/src/main/scala/org/apache/spark/examples/pythonconverters/HBaseConverters.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/pythonconverters/HBaseConverters.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.examples.pythonconverters
 
 import scala.collection.JavaConversions._
-import scala.util.parsing.json._
+import scala.util.parsing.json.JSONObject
 
 import org.apache.spark.api.python.Converter
 import org.apache.hadoop.hbase.client.{Put, Result}

--- a/examples/src/main/scala/org/apache/spark/examples/pythonconverters/HBaseConverters.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/pythonconverters/HBaseConverters.scala
@@ -29,10 +29,10 @@ import org.apache.hadoop.hbase.CellUtil
 
 /**
  * Implementation of [[org.apache.spark.api.python.Converter]] that converts all
- * the records in an HBase Result to an Array[String]
+ * the records in an HBase Result to a String
  */
-class HBaseResultToStringConverter extends Converter[Any, Array[String]] {
-  override def convert(obj: Any): Array[String] = {
+class HBaseResultToStringConverter extends Converter[Any, String] {
+  override def convert(obj: Any): String = {
     import collection.JavaConverters._
     val result = obj.asInstanceOf[Result]
     val output = result.listCells.asScala.map(cell =>
@@ -45,7 +45,7 @@ class HBaseResultToStringConverter extends Converter[Any, Array[String]] {
           "value" -> Bytes.toStringBinary(CellUtil.cloneValue(cell))
         )
     )
-    output.map(JSONObject(_).toString()).toArray
+    output.map(JSONObject(_).toString()).mkString("\n")
   }
 }
 

--- a/examples/src/main/scala/org/apache/spark/examples/pythonconverters/HBaseConverters.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/pythonconverters/HBaseConverters.scala
@@ -35,7 +35,7 @@ class HBaseResultToStringConverter extends Converter[Any, String] {
     import collection.JavaConverters._
     val result = obj.asInstanceOf[Result]
     val output = result.listCells.asScala.map(cell =>
-        "{'columnFamliy':'%s','qualifier':'%s','timestamp':'%s','type':'%s','value':'%s'}".format(
+        "{'columnFamily':'%s','qualifier':'%s','timestamp':'%s','type':'%s','value':'%s'}".format(
           Bytes.toStringBinary(CellUtil.cloneFamily(cell)),
           Bytes.toStringBinary(CellUtil.cloneQualifier(cell)),
           cell.getTimestamp.toString,


### PR DESCRIPTION
Hi,

Following the discussion in http://apache-spark-developers-list.1001551.n3.nabble.com/python-converter-in-HBaseConverter-scala-spark-examples-td10001.html. I made some modification in three files in package examples:
1. HBaseConverters.scala: the new converter will converts all the records in an hbase results into a single string
2. hbase_input.py: as the value string may contain several records, we can use ast package to convert the string into dict
3. HBaseTest.scala: as the package examples use hbase 0.98.7 the original constructor HTableDescriptor is deprecated. The updation to new constructor is made
