### PR TITLE
[SPARK-3910] Remove pyspark/mllib/ from sys.path in tests to fix relative import issue

### DIFF
--- a/python/pyspark/mllib/_common.py
+++ b/python/pyspark/mllib/_common.py
@@ -561,4 +561,8 @@ def _test():
 
 
 if __name__ == "__main__":
+    # Remove python/pyspark/mllib from the module search path so so that mllib.random
+    # doesn't mask imports of Python's build-in random module (see SPARK-3910)
+    import sys
+    sys.path.pop(0)
     _test()

--- a/python/pyspark/mllib/classification.py
+++ b/python/pyspark/mllib/classification.py
@@ -256,4 +256,8 @@ def _test():
         exit(-1)
 
 if __name__ == "__main__":
+    # Remove python/pyspark/mllib from the module search path so so that mllib.random
+    # doesn't mask imports of Python's build-in random module (see SPARK-3910)
+    import sys
+    sys.path.pop(0)
     _test()

--- a/python/pyspark/mllib/clustering.py
+++ b/python/pyspark/mllib/clustering.py
@@ -106,4 +106,8 @@ def _test():
 
 
 if __name__ == "__main__":
+    # Remove python/pyspark/mllib from the module search path so so that mllib.random
+    # doesn't mask imports of Python's build-in random module (see SPARK-3910)
+    import sys
+    sys.path.pop(0)
     _test()

--- a/python/pyspark/mllib/linalg.py
+++ b/python/pyspark/mllib/linalg.py
@@ -267,8 +267,8 @@ def _test():
         exit(-1)
 
 if __name__ == "__main__":
-    # remove current path from list of search paths to avoid importing mllib.random
-    # for C{import random}, which is done in an external dependency of pyspark during doctests.
+    # Remove python/pyspark/mllib from the module search path so so that mllib.random
+    # doesn't mask imports of Python's build-in random module (see SPARK-3910)
     import sys
     sys.path.pop(0)
     _test()

--- a/python/pyspark/mllib/random.py
+++ b/python/pyspark/mllib/random.py
@@ -180,4 +180,8 @@ def _test():
 
 
 if __name__ == "__main__":
+    # Remove python/pyspark/mllib from the module search path so so that mllib.random
+    # doesn't mask imports of Python's build-in random module (see SPARK-3910)
+    import sys
+    sys.path.pop(0)
     _test()

--- a/python/pyspark/mllib/recommendation.py
+++ b/python/pyspark/mllib/recommendation.py
@@ -100,4 +100,8 @@ def _test():
 
 
 if __name__ == "__main__":
+    # Remove python/pyspark/mllib from the module search path so so that mllib.random
+    # doesn't mask imports of Python's build-in random module (see SPARK-3910)
+    import sys
+    sys.path.pop(0)
     _test()

--- a/python/pyspark/mllib/regression.py
+++ b/python/pyspark/mllib/regression.py
@@ -253,4 +253,8 @@ def _test():
         exit(-1)
 
 if __name__ == "__main__":
+    # Remove python/pyspark/mllib from the module search path so so that mllib.random
+    # doesn't mask imports of Python's build-in random module (see SPARK-3910)
+    import sys
+    sys.path.pop(0)
     _test()

--- a/python/pyspark/mllib/stat.py
+++ b/python/pyspark/mllib/stat.py
@@ -168,4 +168,8 @@ def _test():
 
 
 if __name__ == "__main__":
+    # Remove python/pyspark/mllib from the module search path so so that mllib.random
+    # doesn't mask imports of Python's build-in random module (see SPARK-3910)
+    import sys
+    sys.path.pop(0)
     _test()

--- a/python/pyspark/mllib/tests.py
+++ b/python/pyspark/mllib/tests.py
@@ -332,6 +332,10 @@ class SciPyTests(PySparkTestCase):
 
 
 if __name__ == "__main__":
+    # Remove python/pyspark/mllib from the module search path so so that mllib.random
+    # doesn't mask imports of Python's build-in random module (see SPARK-3910)
+    import sys
+    sys.path.pop(0)
     if not _have_scipy:
         print "NOTE: Skipping SciPy tests as it does not seem to be installed"
     unittest.main()

--- a/python/pyspark/mllib/tree.py
+++ b/python/pyspark/mllib/tree.py
@@ -206,4 +206,8 @@ def _test():
         exit(-1)
 
 if __name__ == "__main__":
+    # Remove python/pyspark/mllib from the module search path so so that mllib.random
+    # doesn't mask imports of Python's build-in random module (see SPARK-3910)
+    import sys
+    sys.path.pop(0)
     _test()

--- a/python/pyspark/mllib/util.py
+++ b/python/pyspark/mllib/util.py
@@ -201,4 +201,8 @@ def _test():
 
 
 if __name__ == "__main__":
+    # Remove python/pyspark/mllib from the module search path so so that mllib.random
+    # doesn't mask imports of Python's build-in random module (see SPARK-3910)
+    import sys
+    sys.path.pop(0)
     _test()


### PR DESCRIPTION
This patch addresses an issue where PySpark's MLlib unit tests might fail on certain environments due to circular import issues.  The root issue is that PySpark has a module named `random`, which shares its name as the built-in Python `random`.  This isn't a problem for consumers of Spark, though: `numpy` also has a `numpy.random` module, so it's perfectly fine to have _qualified_ module names that have components that match Python built-ins.  In normal operation, the top-level `pyspark` directory is added to `sys.path` so that PySpark's `random` module can only be imported via `pyspark.mllib.random`.  However, our unit tests end up invoking `./bin/pyspark python/pyspark/mllib/clustering.py`, which causes [the first entry of `sys.path`](https://docs.python.org/2/library/sys.html#sys.path) to be the directory containing `clustering.py` (`python/pyspark/mllib`, in that case); as a result, PySpark's `random` module shadows the built-in Python module.  This causes `numpy` and other dependencies to end up importing PySpark's `random`, which leads to circular import errors that cause tests to fail.

To fix this, we need to prevent our tests from adding the script's directory to `sys.path`.  There was already some code to do this in `linalg.py`, so this patch just copies that code to all of the other MLlib tests.
