### PR TITLE
[PySpark] Fix tests with Python 2.6 in 0.9 branch

### DIFF
--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -26,7 +26,16 @@ import shutil
 import sys
 from tempfile import NamedTemporaryFile
 import time
-import unittest
+
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
+
 
 from pyspark.context import SparkContext
 from pyspark.files import SparkFiles

--- a/python/run-tests
+++ b/python/run-tests
@@ -33,6 +33,16 @@ function run_test() {
     FAILED=$((PIPESTATUS[0]||$FAILED))
 }
 
+echo "Running PySpark tests. Output is in python/unit-tests.log."
+
+# Try to test with Python 2.6, since that's the minimum version that we support:
+if [ $(which python2.6) ]; then
+    export PYSPARK_PYTHON="python2.6"
+fi
+
+echo "Testing with Python version:"
+$PYSPARK_PYTHON --version
+
 run_test "pyspark/rdd.py"
 run_test "pyspark/context.py"
 run_test "pyspark/conf.py"


### PR DESCRIPTION
[PySpark] [SPARK-2954] [SPARK-2948] [SPARK-2910] [SPARK-2101] Python 2.6 Fixes

```
- Modify python/run-tests to test with Python 2.6
- Use unittest2 when running on Python 2.6.
```

Author: Josh Rosen joshrosen@apache.org

Closes #3668 from davies/port_2365 and squashes the following commits:
