### PR TITLE
[SPARK-5173]support python application running on yarn cluster mode

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
@@ -26,7 +26,7 @@ import org.apache.spark.api.python.PythonUtils
 import org.apache.spark.util.{RedirectThread, Utils}
 
 /**
- * A main class used by spark-submit to launch Python applications. It executes python as a
+ * A main class used to launch Python applications. It executes python as a
  * subprocess and then has it connect back to the JVM to access system properties, etc.
  */
 object PythonRunner {

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -141,7 +141,8 @@ object SparkSubmit {
       case (MESOS, CLUSTER) =>
         printErrorAndExit("Cluster deploy mode is currently not supported for Mesos clusters.")
       case (STANDALONE, CLUSTER) if args.isPython =>
-        printErrorAndExit("Standalone-Cluster deploy mode is currently not supported for python applications.")
+        printErrorAndExit("Standalone-Cluster deploy mode is currently not supported" +
+          "for python applications.")
       case (_, CLUSTER) if isShell(args.primaryResource) =>
         printErrorAndExit("Cluster deploy mode is not applicable to Spark shells.")
       case (_, CLUSTER) if isSqlShell(args.mainClass) =>
@@ -167,7 +168,7 @@ object SparkSubmit {
       }
     }
 
-    //In yarn-cluster mode for a python app, add primary Resource and pyFiles to files
+    // In yarn-cluster mode for a python app, add primary Resource and pyFiles to files
     // that can be distributed with the job
     if (args.isPython && deployMode == CLUSTER) {
       args.files = mergeFileLists(args.files, args.primaryResource)
@@ -276,7 +277,7 @@ object SparkSubmit {
     // In yarn-cluster mode, use yarn.Client as a wrapper around the user class
     if (isYarnCluster) {
       childMainClass = "org.apache.spark.deploy.yarn.Client"
-      if (args.isPython) {//yarn-cluster mode for python application
+      if (args.isPython) {// yarn-cluster mode for python application
       val primaryResourceLocalPath = new Path(args.primaryResource)
         childArgs += ("--primaryResource", primaryResourceLocalPath.getName)
         val pyFilesLocalNames:String = if (args.pyFiles != null) {

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -140,7 +140,8 @@ object SparkSubmit {
     // when yarn-cluster, all python files can be non-local
     if (args.isPython && !isYarnClusterMode(clusterManager, deployMode)) {
       if (Utils.nonLocalPaths(args.primaryResource).nonEmpty) {
-        SparkSubmit.printErrorAndExit(s"Only local python files are supported: $args.primaryResource")
+        SparkSubmit.printErrorAndExit(
+          s"Only local python files are supported: $args.primaryResource")
       }
       val nonLocalPyFiles = Utils.nonLocalPaths(args.pyFiles).mkString(",")
       if (nonLocalPyFiles.nonEmpty) {

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -158,7 +158,7 @@ object SparkSubmit {
         printErrorAndExit("Cluster deploy mode is currently not supported for Mesos clusters.")
       case (STANDALONE, CLUSTER) if args.isPython =>
         printErrorAndExit("Cluster deploy mode is currently not supported for python " +
-          "applications on Standalone clusters")
+          "applications on standalone clusters.")
       case (_, CLUSTER) if isShell(args.primaryResource) =>
         printErrorAndExit("Cluster deploy mode is not applicable to Spark shells.")
       case (_, CLUSTER) if isSqlShell(args.mainClass) =>

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -295,12 +295,10 @@ object SparkSubmit {
       if (args.isPython) {
         val mainPyFile = new Path(args.primaryResource).getName
         childArgs += ("--primary-py-file", mainPyFile)
-        val pyFilesNames: String = if (args.pyFiles != null) {
-          args.pyFiles.split(",").map { p => (new Path(p)).getName }.mkString(",")
-        } else {
-          "null"
+        if (args.pyFiles != null) {
+          val pyFilesNames = args.pyFiles.split(",").map(p => (new Path(p)).getName).mkString(",")
+          childArgs += ("--py-files", pyFilesNames)
         }
-        childArgs += ("--py-files", pyFilesNames)
         childArgs += ("--class", "org.apache.spark.deploy.PythonRunner")
       } else {
         if (args.primaryResource != SPARK_INTERNAL) {

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -172,7 +172,8 @@ private[spark] class SparkSubmitArguments(args: Seq[String], env: Map[String, St
     }
 
     // Require all python files to be local, so we can add them to the PYTHONPATH
-    if (isPython) {
+    // when yarn-cluster, all python files can be non-local
+    if (isPython && !master.equalsIgnoreCase("yarn-cluster")) {
       if (Utils.nonLocalPaths(primaryResource).nonEmpty) {
         SparkSubmit.printErrorAndExit(s"Only local python files are supported: $primaryResource")
       }

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -171,19 +171,6 @@ private[spark] class SparkSubmitArguments(args: Seq[String], env: Map[String, St
       SparkSubmit.printErrorAndExit("--py-files given but primary resource is not a Python script")
     }
 
-    // Require all python files to be local, so we can add them to the PYTHONPATH
-    // when yarn-cluster, all python files can be non-local
-    if (isPython && !master.equalsIgnoreCase("yarn-cluster")) {
-      if (Utils.nonLocalPaths(primaryResource).nonEmpty) {
-        SparkSubmit.printErrorAndExit(s"Only local python files are supported: $primaryResource")
-      }
-      val nonLocalPyFiles = Utils.nonLocalPaths(pyFiles).mkString(",")
-      if (nonLocalPyFiles.nonEmpty) {
-        SparkSubmit.printErrorAndExit(
-          s"Only local additional python files are supported: $nonLocalPyFiles")
-      }
-    }
-
     if (master.startsWith("yarn")) {
       val hasHadoopEnv = env.contains("HADOOP_CONF_DIR") || env.contains("YARN_CONF_DIR")
       if (!hasHadoopEnv && !Utils.isTesting) {

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -132,7 +132,7 @@ private[spark] class ApplicationMaster(args: ApplicationMasterArguments,
         .get().addShutdownHook(cleanupHook, ApplicationMaster.SHUTDOWN_HOOK_PRIORITY)
 
       // Call this to force generation of secret so it gets populated into the
-      // Hadoop UGI. This has to happen before the startUserClass which does a
+      // Hadoop UGI. This has to happen before the startUserApplication which does a
       // doAs in order for the credentials to be passed on to the executor containers.
       val securityMgr = new SecurityManager(sparkConf)
 
@@ -233,7 +233,7 @@ private[spark] class ApplicationMaster(args: ApplicationMasterArguments,
 
   private def runDriver(securityMgr: SecurityManager): Unit = {
     addAmIpFilter()
-    userClassThread = startUserClass()
+    userClassThread = startUserApplication()
 
     // This a bit hacky, but we need to wait until the spark.driver.port property has
     // been set by the Thread executing the user class.
@@ -427,8 +427,8 @@ private[spark] class ApplicationMaster(args: ApplicationMasterArguments,
    *
    * Returns the user thread that was started.
    */
-  private def startUserClass(): Thread = {
-    logInfo("Starting the user JAR in a separate Thread")
+  private def startUserApplication(): Thread = {
+    logInfo("Starting the user application in a separate Thread")
     System.setProperty("spark.executor.instances", args.numExecutors.toString)
     if (args.primaryPyFile != null && args.primaryPyFile.endsWith(".py")) {
       System.setProperty("spark.submit.pyFiles",

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -430,7 +430,7 @@ private[spark] class ApplicationMaster(args: ApplicationMasterArguments,
   private def startUserClass(): Thread = {
     logInfo("Starting the user JAR in a separate Thread")
     System.setProperty("spark.executor.instances", args.numExecutors.toString)
-    if (args.primaryResource != null && args.primaryResource.endsWith(".py")) {
+    if (args.primaryPyFile != null && args.primaryPyFile.endsWith(".py")) {
       System.setProperty("spark.submit.pyFiles",
         PythonRunner.formatPaths(args.pyFiles).mkString(","))
     }

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -34,7 +34,7 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration
 
 import org.apache.spark.{Logging, SecurityManager, SparkConf, SparkContext, SparkEnv}
 import org.apache.spark.SparkException
-import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.deploy.{PythonRunner, SparkHadoopUtil}
 import org.apache.spark.deploy.history.HistoryServer
 import org.apache.spark.scheduler.cluster.YarnSchedulerBackend
 import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages._
@@ -430,6 +430,10 @@ private[spark] class ApplicationMaster(args: ApplicationMasterArguments,
   private def startUserClass(): Thread = {
     logInfo("Starting the user JAR in a separate Thread")
     System.setProperty("spark.executor.instances", args.numExecutors.toString)
+    if (args.primaryResource != null && args.primaryResource.endsWith(".py")) {
+      System.setProperty("spark.submit.pyFiles",
+        PythonRunner.formatPaths(args.pyFiles).mkString(","))
+    }
     val mainMethod = Class.forName(args.userClass, false,
       Thread.currentThread.getContextClassLoader).getMethod("main", classOf[Array[String]])
 

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMasterArguments.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMasterArguments.scala
@@ -24,7 +24,7 @@ import collection.mutable.ArrayBuffer
 class ApplicationMasterArguments(val args: Array[String]) {
   var userJar: String = null
   var userClass: String = null
-  var primaryResource: String = null
+  var primaryPyFile: String = null
   var pyFiles: String = null
   var userArgs: Seq[String] = Seq[String]()
   var executorMemory = 1024
@@ -50,8 +50,8 @@ class ApplicationMasterArguments(val args: Array[String]) {
           userClass = value
           args = tail
 
-        case ("--primaryResource") :: value :: tail =>
-          primaryResource = value
+        case ("--primary-py-file") :: value :: tail =>
+          primaryPyFile = value
           args = tail
 
         case ("--py-files") :: value :: tail =>
@@ -91,7 +91,7 @@ class ApplicationMasterArguments(val args: Array[String]) {
       |Options:
       |  --jar JAR_PATH       Path to your application's JAR file
       |  --class CLASS_NAME   Name of your application's main class
-      |  --primaryResource    A primary resource Python file
+      |  --primary-py-file    A primary Python file
       |  --py-files PY_FILES  Comma-separated list of .zip, .egg, or .py files to
       |                       place on the PYTHONPATH for Python apps.
       |  --args ARGS          Arguments to be passed to your application's main class.

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMasterArguments.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMasterArguments.scala
@@ -91,7 +91,7 @@ class ApplicationMasterArguments(val args: Array[String]) {
       |Options:
       |  --jar JAR_PATH       Path to your application's JAR file
       |  --class CLASS_NAME   Name of your application's main class
-      |  --primary-py-file    A primary Python file
+      |  --primary-py-file    A main Python file
       |  --py-files PY_FILES  Comma-separated list of .zip, .egg, or .py files to
       |                       place on the PYTHONPATH for Python apps.
       |  --args ARGS          Arguments to be passed to your application's main class.

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMasterArguments.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMasterArguments.scala
@@ -24,6 +24,8 @@ import collection.mutable.ArrayBuffer
 class ApplicationMasterArguments(val args: Array[String]) {
   var userJar: String = null
   var userClass: String = null
+  var primaryResource: String = null
+  var pyFiles: String = null
   var userArgs: Seq[String] = Seq[String]()
   var executorMemory = 1024
   var executorCores = 1
@@ -46,6 +48,14 @@ class ApplicationMasterArguments(val args: Array[String]) {
 
         case ("--class") :: value :: tail =>
           userClass = value
+          args = tail
+
+        case ("--primaryResource") :: value :: tail =>
+          primaryResource = value
+          args = tail
+
+        case ("--py-files") :: value :: tail =>
+          pyFiles = value
           args = tail
 
         case ("--args" | "--arg") :: value :: tail =>
@@ -81,6 +91,9 @@ class ApplicationMasterArguments(val args: Array[String]) {
       |Options:
       |  --jar JAR_PATH       Path to your application's JAR file
       |  --class CLASS_NAME   Name of your application's main class
+      |  --primaryResource    A primary resource Python file
+      |  --py-files PY_FILES  Comma-separated list of .zip, .egg, or .py files to
+      |                       place on the PYTHONPATH for Python apps.
       |  --args ARGS          Arguments to be passed to your application's main class.
       |                       Multiple invocations are possible, each will be passed in order.
       |  --num-executors NUM    Number of executors to start (Default: 2)

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -474,8 +474,8 @@ private[spark] class Client(
         Nil
       }
     val primaryResource =
-      if (args.primaryResource != null) {
-        Seq("--primaryResource", args.primaryResource)
+      if (args.primaryPyFile != null) {
+        Seq("--primary-py-file", args.primaryPyFile)
       } else {
         Nil
       }
@@ -491,8 +491,8 @@ private[spark] class Client(
       } else {
         Class.forName("org.apache.spark.deploy.yarn.ExecutorLauncher").getName
       }
-    if (args.primaryResource != null && args.primaryResource.endsWith(".py")) {
-      args.userArgs = ArrayBuffer(args.primaryResource, args.pyFiles) ++ args.userArgs
+    if (args.primaryPyFile != null && args.primaryPyFile.endsWith(".py")) {
+      args.userArgs = ArrayBuffer(args.primaryPyFile, args.pyFiles) ++ args.userArgs
     }
     val userArgs = args.userArgs.flatMap { arg =>
       Seq("--arg", YarnSparkHadoopUtil.escapeForShell(arg))

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -473,7 +473,7 @@ private[spark] class Client(
       } else {
         Nil
       }
-    val primaryResource =
+    val primaryPyFile =
       if (args.primaryPyFile != null) {
         Seq("--primary-py-file", args.primaryPyFile)
       } else {
@@ -498,7 +498,7 @@ private[spark] class Client(
       Seq("--arg", YarnSparkHadoopUtil.escapeForShell(arg))
     }
     val amArgs =
-      Seq(amClass) ++ userClass ++ userJar ++ primaryResource ++ pyFiles ++ userArgs ++
+      Seq(amClass) ++ userClass ++ userJar ++ primaryPyFile ++ pyFiles ++ userArgs ++
         Seq(
           "--executor-memory", args.executorMemory.toString + "m",
           "--executor-cores", args.executorCores.toString,

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -21,7 +21,7 @@ import java.net.{InetAddress, UnknownHostException, URI, URISyntaxException}
 import java.nio.ByteBuffer
 
 import scala.collection.JavaConversions._
-import scala.collection.mutable.{HashMap, ListBuffer, Map}
+import scala.collection.mutable.{ArrayBuffer, HashMap, ListBuffer, Map}
 import scala.util.{Try, Success, Failure}
 
 import com.google.common.base.Objects
@@ -473,17 +473,32 @@ private[spark] class Client(
       } else {
         Nil
       }
+    val primaryResource =
+      if (args.primaryResource != null) {
+        Seq("--primaryResource", args.primaryResource)
+      } else {
+        Nil
+      }
+    val pyFiles =
+      if (args.pyFiles != null) {
+        Seq("--py-files", args.pyFiles)
+      } else {
+        Nil
+      }
     val amClass =
       if (isClusterMode) {
         Class.forName("org.apache.spark.deploy.yarn.ApplicationMaster").getName
       } else {
         Class.forName("org.apache.spark.deploy.yarn.ExecutorLauncher").getName
       }
+    if (args.primaryResource != null && args.primaryResource.endsWith(".py")) {
+      args.userArgs = ArrayBuffer(args.primaryResource, args.pyFiles) ++ args.userArgs
+    }
     val userArgs = args.userArgs.flatMap { arg =>
       Seq("--arg", YarnSparkHadoopUtil.escapeForShell(arg))
     }
     val amArgs =
-      Seq(amClass) ++ userClass ++ userJar ++ userArgs ++
+      Seq(amClass) ++ userClass ++ userJar ++ primaryResource ++ pyFiles ++ userArgs ++
         Seq(
           "--executor-memory", args.executorMemory.toString + "m",
           "--executor-cores", args.executorCores.toString,

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
@@ -192,7 +192,7 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
       |  --jar JAR_PATH           Path to your application's JAR file (required in yarn-cluster
       |                           mode)
       |  --class CLASS_NAME       Name of your application's main class (required)
-      |  --primary-py-file        A primary Python file
+      |  --primary-py-file        A main Python file
       |  --arg ARG                Argument to be passed to your application's main class.
       |                           Multiple invocations are possible, each will be passed in order.
       |  --num-executors NUM      Number of executors to start (Default: 2)

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
@@ -31,7 +31,7 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
   var userJar: String = null
   var userClass: String = null
   var pyFiles: String = null
-  var primaryResource: String = null
+  var primaryPyFile: String = null
   var userArgs: ArrayBuffer[String] = new ArrayBuffer[String]()
   var executorMemory = 1024 // MB
   var executorCores = 1
@@ -104,8 +104,8 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
           userClass = value
           args = tail
 
-        case ("--primaryResource") :: value :: tail =>
-          primaryResource = value
+        case ("--primary-py-file") :: value :: tail =>
+          primaryPyFile = value
           args = tail
 
         case ("--args" | "--arg") :: value :: tail =>
@@ -192,7 +192,7 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
       |  --jar JAR_PATH           Path to your application's JAR file (required in yarn-cluster
       |                           mode)
       |  --class CLASS_NAME       Name of your application's main class (required)
-      |  --primaryResource        A primary resource Python file
+      |  --primary-py-file        A primary Python file
       |  --arg ARG                Argument to be passed to your application's main class.
       |                           Multiple invocations are possible, each will be passed in order.
       |  --num-executors NUM      Number of executors to start (Default: 2)

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
@@ -30,7 +30,9 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
   var archives: String = null
   var userJar: String = null
   var userClass: String = null
-  var userArgs: Seq[String] = Seq[String]()
+  var pyFiles: String = null
+  var primaryResource: String = null
+  var userArgs: ArrayBuffer[String] = new ArrayBuffer[String]()
   var executorMemory = 1024 // MB
   var executorCores = 1
   var numExecutors = DEFAULT_NUMBER_EXECUTORS
@@ -90,7 +92,6 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
   }
 
   private def parseArgs(inputArgs: List[String]): Unit = {
-    val userArgsBuffer = new ArrayBuffer[String]()
     var args = inputArgs
 
     while (!args.isEmpty) {
@@ -103,11 +104,15 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
           userClass = value
           args = tail
 
+        case ("--primaryResource") :: value :: tail =>
+          primaryResource = value
+          args = tail
+
         case ("--args" | "--arg") :: value :: tail =>
           if (args(0) == "--args") {
             println("--args is deprecated. Use --arg instead.")
           }
-          userArgsBuffer += value
+          userArgs += value
           args = tail
 
         case ("--master-class" | "--am-class") :: value :: tail =>
@@ -159,6 +164,10 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
           addJars = value
           args = tail
 
+        case ("--py-files") :: value :: tail =>
+          pyFiles = value
+          args = tail
+
         case ("--files") :: value :: tail =>
           files = value
           args = tail
@@ -173,8 +182,6 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
           throw new IllegalArgumentException(getUsageMessage(args))
       }
     }
-
-    userArgs = userArgsBuffer.readOnly
   }
 
   private def getUsageMessage(unknownParam: List[String] = null): String = {
@@ -185,6 +192,7 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
       |  --jar JAR_PATH           Path to your application's JAR file (required in yarn-cluster
       |                           mode)
       |  --class CLASS_NAME       Name of your application's main class (required)
+      |  --primaryResource        A primary resource Python file
       |  --arg ARG                Argument to be passed to your application's main class.
       |                           Multiple invocations are possible, each will be passed in order.
       |  --num-executors NUM      Number of executors to start (Default: 2)
@@ -196,6 +204,8 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
       |                           'default')
       |  --addJars jars           Comma separated list of local jars that want SparkContext.addJar
       |                           to work with.
+      |  --py-files PY_FILES      Comma-separated list of .zip, .egg, or .py files to
+      |                           place on the PYTHONPATH for Python apps.
       |  --files files            Comma separated list of files to be distributed with the job.
       |  --archives archives      Comma separated list of archives to be distributed with the job.
       """.stripMargin

--- a/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -51,21 +51,21 @@ class YarnClusterSuite extends FunSuite with BeforeAndAfterAll with Matchers wit
     |
     |from pyspark import SparkConf , SparkContext
     |if __name__ == "__main__":
-    |        if len(sys.argv) != 3:
-    |        		print >> sys.stderr, "Usage: test.py [master] [result file]"
-    |        		exit(-1)
-    |        conf = SparkConf()
-    |        conf.setMaster(sys.argv[1]).setAppName("python test in yarn cluster mode")
-    |        sc = SparkContext(conf=conf)
-    |        status = open(sys.argv[2],'w')
-    |        result = "failure"
-    |        rdd = sc.parallelize(range(10))
-    |        cnt = rdd.count()
-    |        if cnt == 10:
-    |        		result = "success"
-    |        status.write(result)
-    |        status.close()
-    |        sc.stop()
+    |    if len(sys.argv) != 3:
+    |        print >> sys.stderr, "Usage: test.py [master] [result file]"
+    |        exit(-1)
+    |    conf = SparkConf()
+    |    conf.setMaster(sys.argv[1]).setAppName("python test in yarn cluster mode")
+    |    sc = SparkContext(conf=conf)
+    |    status = open(sys.argv[2],'w')
+    |    result = "failure"
+    |    rdd = sc.parallelize(range(10))
+    |    cnt = rdd.count()
+    |    if cnt == 10:
+    |        result = "success"
+    |    status.write(result)
+    |    status.close()
+    |    sc.stop()
     """.stripMargin
 
   private var yarnCluster: MiniYARNCluster = _
@@ -178,7 +178,8 @@ class YarnClusterSuite extends FunSuite with BeforeAndAfterAll with Matchers wit
     Files.write(TEST_PYFILE, pyFile, Charsets.UTF_8)
     var result = File.createTempFile("result", null, tempDir)
 
-    val args = Array("--primary-py-file", primaryPyFile.getAbsolutePath(),
+    val args = Array("--class", "org.apache.spark.deploy.PythonRunner",
+      "--primary-py-file", primaryPyFile.getAbsolutePath(),
       "--py-files", pyFile.getAbsolutePath(),
       "--arg", "yarn-cluster",
       "--arg", result.getAbsolutePath(),

--- a/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -121,6 +121,8 @@ class YarnClusterSuite extends FunSuite with BeforeAndAfterAll with Matchers wit
     }
 
     fakeSparkJar = File.createTempFile("sparkJar", null, tempDir)
+    val sparkHome = sys.props.getOrElse("spark.test.home", fail("spark.test.home is not set!"))
+    sys.props += ("SPARK_HOME" -> sparkHome)
     sys.props += ("spark.yarn.jar" -> ("local:" + fakeSparkJar.getAbsolutePath()))
     sys.props += ("spark.executor.instances" -> "1")
     sys.props += ("spark.driver.extraClassPath" -> childClasspath)

--- a/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -122,7 +122,8 @@ class YarnClusterSuite extends FunSuite with BeforeAndAfterAll with Matchers wit
 
     fakeSparkJar = File.createTempFile("sparkJar", null, tempDir)
     val sparkHome = sys.props.getOrElse("spark.test.home", fail("spark.test.home is not set!"))
-    sys.props += ("SPARK_HOME" -> sparkHome)
+    sys.props += ("spark.yarn.appMasterEnv.SPARK_HOME" ->  sparkHome)
+    sys.props += ("spark.executorEnv.SPARK_HOME" -> sparkHome)
     sys.props += ("spark.yarn.jar" -> ("local:" + fakeSparkJar.getAbsolutePath()))
     sys.props += ("spark.executor.instances" -> "1")
     sys.props += ("spark.driver.extraClassPath" -> childClasspath)

--- a/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -51,11 +51,13 @@ class YarnClusterSuite extends FunSuite with BeforeAndAfterAll with Matchers wit
     |
     |from pyspark import SparkConf , SparkContext
     |if __name__ == "__main__":
-    |        if len(sys.argv) != 2:
-    |        		print >> sys.stderr, "Usage: test.py <file>"
+    |        if len(sys.argv) != 3:
+    |        		print >> sys.stderr, "Usage: test.py [master] [result file]"
     |        		exit(-1)
-    |        sc = SparkContext(appName="python-test")
-    |        status = open(sys.argv[1],'w')
+    |        conf = SparkConf()
+    |        conf.setMaster(sys.argv[1]).setAppName("python test in yarn cluster mode")
+    |        sc = SparkContext(conf=conf)
+    |        status = open(sys.argv[2],'w')
     |        result = "failure"
     |        rdd = sc.parallelize(range(10))
     |        cnt = rdd.count()
@@ -176,8 +178,9 @@ class YarnClusterSuite extends FunSuite with BeforeAndAfterAll with Matchers wit
 
     val args = Array("--primary-py-file", primaryPyFile.getAbsolutePath(),
       "--py-files", pyFile.getAbsolutePath(),
+      "--arg", "yarn-cluster",
       "--arg", result.getAbsolutePath(),
-      "--name", "python test on yarn-cluster",
+      "--name", "python test in yarn-cluster mode",
       "--num-executors", "1")
     Client.main(args)
     checkResult(result)


### PR DESCRIPTION
now when we run python application on yarn cluster mode through spark-submit, spark-submit does not support python application on yarn cluster mode. so i modify code of submit and yarn's AM in order to support it.
through specifying .py file or primaryResource file via spark-submit, we can make pyspark run in yarn-cluster mode.
example:spark-submit --master yarn-master --num-executors 1 --driver-memory 1g --executor-memory 1g  xx.py --primaryResource yy.conf
this config is same as pyspark on yarn-client mode.
firstly,we put local path of .py or primaryResource to yarn's dist.files.that can be distributed on slave nodes.and then in spark-submit we transfer --py-files and --primaryResource to yarn.Client and use "org.apache.spark.deploy.PythonRunner" to user class that can run .py files on ApplicationMaster.
in yarn.Client we transfer --py-files and --primaryResource to  ApplicationMaster.
in ApplicationMaster, user's class is org.apache.spark.deploy.PythonRunner, and user's args is primaryResource and -py-files. so that can make pyspark run on ApplicationMaster.
@JoshRosen @tgravescs @sryza
