### PR TITLE
[SPARK-5177][Build] Adds parameters for specifying Hive and Scala version in dev/run-tests

### DIFF
--- a/dev/run-tests
+++ b/dev/run-tests
@@ -53,6 +53,32 @@ function handle_error () {
   fi
 }
 
+# Build against the right version of Scala.
+{
+  if [ -n "$AMPLAB_JENKINS_BUILD_SCALA_VERSION" ]; then
+    if [ "$AMPLAB_JENKINS_BUILD_SCALA_VERSION" = "2.10" ]; then
+      export SBT_MAVEN_PROFILES_ARGS="$SBT_MAVEN_PROFILES_ARGS -Pscala-2.10"
+    elif [ "$AMPLAB_JENKINS_BUILD_SCALA_VERSION" = "2.11" ]; then
+      export SBT_MAVEN_PROFILES_ARGS="$SBT_MAVEN_PROFILES_ARGS -Pscala-2.11"
+    fi
+  fi
+
+  # Defaults to Scala 2.10
+}
+
+# Build against the right version of Hive.
+{
+  if [ -n "$AMPLAB_JENKINS_BUILD_HIVE_VERSION" ]; then
+    if [ "$AMPLAB_JENKINS_BUILD_HIVE_VERSION" = "0.12.0" ]; then
+      export SBT_MAVEN_PROFILES_ARGS="$SBT_MAVEN_PROFILES_ARGS -Phive-0.12.0"
+    elif [ "$AMPLAB_JENKINS_BUILD_HIVE_VERSION" = "0.13.1" ]; then
+      export SBT_MAVEN_PROFILES_ARGS="$SBT_MAVEN_PROFILES_ARGS -Phive-0.13.1"
+    fi
+  fi
+
+  # Defaults to Hive 0.13.1
+}
+
 export SBT_MAVEN_PROFILES_ARGS="$SBT_MAVEN_PROFILES_ARGS -Pkinesis-asl"
 
 # Determine Java path and version.
@@ -148,15 +174,6 @@ CURRENT_BLOCK=$BLOCK_BUILD
   # QUESTION: Why doesn't 'yes "q"' work?
   # QUESTION: Why doesn't 'grep -v -e "^\[info\] Resolving"' work?
   # First build with Hive 0.12.0 to ensure patches do not break the Hive 0.12.0 build
-  HIVE_12_BUILD_ARGS="$SBT_MAVEN_PROFILES_ARGS -Phive -Phive-thriftserver -Phive-0.12.0"
-  echo "[info] Compile with Hive 0.12.0"
-  echo -e "q\n" \
-    | build/sbt $HIVE_12_BUILD_ARGS clean hive/compile hive-thriftserver/compile \
-    | grep -v -e "info.*Resolving" -e "warn.*Merging" -e "info.*Including"
-
-  # Then build with default Hive version (0.13.1) because tests are based on this version
-  echo "[info] Compile with Hive 0.13.1"
-  rm -rf lib_managed
   echo "[info] Building Spark with these arguments: $SBT_MAVEN_PROFILES_ARGS"\
     " -Phive -Phive-thriftserver"
   echo -e "q\n" \


### PR DESCRIPTION
This PR adds two environment variables, `AMPLAB_JENKINS_BUILD_SCALA_VERSION` and `AMPLAB_JENKINS_BUILD_HIVE_VERSION`, to control which Hive version and Scala version to test.  We can use them to add dedicated Jenkins builders for Hive 0.12.0 and Scala 2.11.  Currently, Jenkins PR builder only checks whether Hive 0.12.0 code paths compiles, but tests are not executed. Scala 2.11 is not tested at all.

This PR also removed the Hive 0.12.0 compilation check to reduce PR build time.

/cc @JoshRosen

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/apache/spark/3980)

<!-- Reviewable:end -->
