### PR TITLE
[SPARK-4983]insert waiting time before tagging ec2 instances

### DIFF
--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -569,7 +569,8 @@ def launch_cluster(conn, opts, cluster_name):
         master_nodes = master_res.instances
         print "Launched master in %s, regid = %s" % (zone, master_res.id)
 
-    # Wait for the information of the just-launched instances to be propagated within AWS
+    # The insert of waiting time corresponds to issue [SPARK-4983]
+    print "Waiting for AWS to propagate the information of instances..."
     time.sleep(5)
     # Give the instances descriptive names
     for master in master_nodes:

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -569,6 +569,8 @@ def launch_cluster(conn, opts, cluster_name):
         master_nodes = master_res.instances
         print "Launched master in %s, regid = %s" % (zone, master_res.id)
 
+    # Wait for the information of the just-launched instances to be propagated within AWS
+    time.sleep(5)
     # Give the instances descriptive names
     for master in master_nodes:
         master.add_tag(

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -569,15 +569,28 @@ def launch_cluster(conn, opts, cluster_name):
         master_nodes = master_res.instances
         print "Launched master in %s, regid = %s" % (zone, master_res.id)
 
-    # Give the instances descriptive names
+    # Give the instances descriptive names.
+    # The code of handling exceptions corresponds to issue [SPARK-4983]
     for master in master_nodes:
-        master.add_tag(
-            key='Name',
-            value='{cn}-master-{iid}'.format(cn=cluster_name, iid=master.id))
+        while True:
+            try:
+                master.add_tag(
+                    key='Name',
+                    value='{cn}-master-{iid}'.format(cn=cluster_name, iid=master.id))
+            except:
+                pass
+            else:
+                break
     for slave in slave_nodes:
-        slave.add_tag(
-            key='Name',
-            value='{cn}-slave-{iid}'.format(cn=cluster_name, iid=slave.id))
+        while True:
+            try:
+                slave.add_tag(
+                    key='Name',
+                    value='{cn}-slave-{iid}'.format(cn=cluster_name, iid=slave.id))
+            except:
+                pass
+            else:
+                break
 
     # Return all the instances
     return (master_nodes, slave_nodes)

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -592,7 +592,7 @@ def launch_cluster(conn, opts, cluster_name):
                     value='{cn}-slave-{iid}'.format(cn=cluster_name, iid=slave.id))
             except boto.exception.EC2ResponseError as e:
                 if e.error_code == "InvalidInstanceID.NotFound":
-                    time.sleep(0.1)
+                    time.Sleep(0.1)
                 else:
                     raise e
             else:

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -577,11 +577,8 @@ def launch_cluster(conn, opts, cluster_name):
                 master.add_tag(
                     key='Name',
                     value='{cn}-master-{iid}'.format(cn=cluster_name, iid=master.id))
-            except boto.exception.EC2ResponseError as e:
-                if e.error_code == "InvalidInstanceID.NotFound":
-                    time.sleep(0.1)
-                else:
-                    raise e
+            except:
+                pass
             else:
                 break
     for slave in slave_nodes:
@@ -590,11 +587,8 @@ def launch_cluster(conn, opts, cluster_name):
                 slave.add_tag(
                     key='Name',
                     value='{cn}-slave-{iid}'.format(cn=cluster_name, iid=slave.id))
-            except boto.exception.EC2ResponseError as e:
-                if e.error_code == "InvalidInstanceID.NotFound":
-                    time.Sleep(0.1)
-                else:
-                    raise e
+            except:
+                pass
             else:
                 break
 

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -569,8 +569,8 @@ def launch_cluster(conn, opts, cluster_name):
         master_nodes = master_res.instances
         print "Launched master in %s, regid = %s" % (zone, master_res.id)
 
-    # The insert of waiting time corresponds to issue [SPARK-4983]
-    print "Waiting for AWS to propagate the information of instances..."
+    # This wait time corresponds to SPARK-4983
+    print "Waiting for AWS to propagate instance metadata..."
     time.sleep(5)
     # Give the instances descriptive names
     for master in master_nodes:

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -569,28 +569,15 @@ def launch_cluster(conn, opts, cluster_name):
         master_nodes = master_res.instances
         print "Launched master in %s, regid = %s" % (zone, master_res.id)
 
-    # Give the instances descriptive names.
-    # The code of handling exceptions corresponds to issue [SPARK-4983]
+    # Give the instances descriptive names
     for master in master_nodes:
-        while True:
-            try:
-                master.add_tag(
-                    key='Name',
-                    value='{cn}-master-{iid}'.format(cn=cluster_name, iid=master.id))
-            except:
-                pass
-            else:
-                break
+        master.add_tag(
+            key='Name',
+            value='{cn}-master-{iid}'.format(cn=cluster_name, iid=master.id))
     for slave in slave_nodes:
-        while True:
-            try:
-                slave.add_tag(
-                    key='Name',
-                    value='{cn}-slave-{iid}'.format(cn=cluster_name, iid=slave.id))
-            except:
-                pass
-            else:
-                break
+        slave.add_tag(
+            key='Name',
+            value='{cn}-slave-{iid}'.format(cn=cluster_name, iid=slave.id))
 
     # Return all the instances
     return (master_nodes, slave_nodes)

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -592,7 +592,7 @@ def launch_cluster(conn, opts, cluster_name):
                     value='{cn}-slave-{iid}'.format(cn=cluster_name, iid=slave.id))
             except boto.exception.EC2ResponseError as e:
                 if e.error_code == "InvalidInstanceID.NotFound":
-                    time.Sleep(0.1)
+                    time.sleep(0.1)
                 else:
                     raise e
             else:

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -577,8 +577,11 @@ def launch_cluster(conn, opts, cluster_name):
                 master.add_tag(
                     key='Name',
                     value='{cn}-master-{iid}'.format(cn=cluster_name, iid=master.id))
-            except:
-                pass
+            except boto.exception.EC2ResponseError as e:
+                if e.error_code == "InvalidInstanceID.NotFound":
+                    time.sleep(0.1)
+                else:
+                    raise e
             else:
                 break
     for slave in slave_nodes:
@@ -587,8 +590,11 @@ def launch_cluster(conn, opts, cluster_name):
                 slave.add_tag(
                     key='Name',
                     value='{cn}-slave-{iid}'.format(cn=cluster_name, iid=slave.id))
-            except:
-                pass
+            except boto.exception.EC2ResponseError as e:
+                if e.error_code == "InvalidInstanceID.NotFound":
+                    time.Sleep(0.1)
+                else:
+                    raise e
             else:
                 break
 


### PR DESCRIPTION
As the boto API doesn't support tag ec2 instances in the same call that launches them. We use exception handling code to wait that ec2 has enough time to propagate the information. 
