### PR TITLE
[SPARK-5196][SQL] Support `comment` field in StructField and in CREATE TABLE DDL

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -93,7 +93,7 @@ trait ScalaReflection {
   /** Returns a Sequence of attributes for the given case class type. */
   def attributesFor[T: TypeTag]: Seq[Attribute] = schemaFor[T] match {
     case Schema(s: StructType, _) =>
-      s.fields.map(f => AttributeReference(f.name, f.dataType, f.nullable, f.metadata)())
+      s.fields.map(f => AttributeReference(f.name, f.dataType, f.nullable, f.comment, f.metadata)())
   }
 
   /** Returns a catalyst DataType and its nullability for the given Scala Type using reflection. */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -47,11 +47,13 @@ case class UnresolvedAttribute(name: String) extends Attribute with trees.LeafNo
   override def exprId = throw new UnresolvedException(this, "exprId")
   override def dataType = throw new UnresolvedException(this, "dataType")
   override def nullable = throw new UnresolvedException(this, "nullable")
+  override def comment = throw new UnresolvedException(this, "comment")
   override def qualifiers = throw new UnresolvedException(this, "qualifiers")
   override lazy val resolved = false
 
   override def newInstance = this
   override def withNullability(newNullability: Boolean) = this
+  override def withComment(newComment: String) = this
   override def withQualifiers(newQualifiers: Seq[String]) = this
   override def withName(newName: String) = UnresolvedAttribute(name)
 
@@ -66,6 +68,7 @@ case class UnresolvedFunction(name: String, children: Seq[Expression]) extends E
   override def dataType = throw new UnresolvedException(this, "dataType")
   override def foldable = throw new UnresolvedException(this, "foldable")
   override def nullable = throw new UnresolvedException(this, "nullable")
+  override def comment = throw new UnresolvedException(this, "comment")
   override lazy val resolved = false
 
   // Unresolved functions are transient at compile time and don't get evaluated during execution.
@@ -91,11 +94,13 @@ case class Star(
   override def exprId = throw new UnresolvedException(this, "exprId")
   override def dataType = throw new UnresolvedException(this, "dataType")
   override def nullable = throw new UnresolvedException(this, "nullable")
+  override def comment = throw new UnresolvedException(this, "comment")
   override def qualifiers = throw new UnresolvedException(this, "qualifiers")
   override lazy val resolved = false
 
   override def newInstance = this
   override def withNullability(newNullability: Boolean) = this
+  override def withComment(newComment: String) = this
   override def withQualifiers(newQualifiers: Seq[String]) = this
   override def withName(newName: String) = this
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -172,56 +172,56 @@ package object dsl {
       def attr = analysis.UnresolvedAttribute(s)
 
       /** Creates a new AttributeReference of type boolean */
-      def boolean = AttributeReference(s, BooleanType, nullable = true)()
+      def boolean = AttributeReference(s, BooleanType, nullable = true, comment = "")()
 
       /** Creates a new AttributeReference of type byte */
-      def byte = AttributeReference(s, ByteType, nullable = true)()
+      def byte = AttributeReference(s, ByteType, nullable = true, comment = "")()
 
       /** Creates a new AttributeReference of type short */
-      def short = AttributeReference(s, ShortType, nullable = true)()
+      def short = AttributeReference(s, ShortType, nullable = true, comment = "")()
 
       /** Creates a new AttributeReference of type int */
-      def int = AttributeReference(s, IntegerType, nullable = true)()
+      def int = AttributeReference(s, IntegerType, nullable = true, comment = "")()
 
       /** Creates a new AttributeReference of type long */
-      def long = AttributeReference(s, LongType, nullable = true)()
+      def long = AttributeReference(s, LongType, nullable = true, comment = "")()
 
       /** Creates a new AttributeReference of type float */
-      def float = AttributeReference(s, FloatType, nullable = true)()
+      def float = AttributeReference(s, FloatType, nullable = true, comment = "")()
 
       /** Creates a new AttributeReference of type double */
-      def double = AttributeReference(s, DoubleType, nullable = true)()
+      def double = AttributeReference(s, DoubleType, nullable = true, comment = "")()
 
       /** Creates a new AttributeReference of type string */
-      def string = AttributeReference(s, StringType, nullable = true)()
+      def string = AttributeReference(s, StringType, nullable = true, comment = "")()
 
       /** Creates a new AttributeReference of type date */
-      def date = AttributeReference(s, DateType, nullable = true)()
+      def date = AttributeReference(s, DateType, nullable = true, comment = "")()
 
       /** Creates a new AttributeReference of type decimal */
-      def decimal = AttributeReference(s, DecimalType.Unlimited, nullable = true)()
+      def decimal = AttributeReference(s, DecimalType.Unlimited, nullable = true, comment = "")()
 
       /** Creates a new AttributeReference of type decimal */
       def decimal(precision: Int, scale: Int) =
-        AttributeReference(s, DecimalType(precision, scale), nullable = true)()
+        AttributeReference(s, DecimalType(precision, scale), nullable = true, comment = "")()
 
       /** Creates a new AttributeReference of type timestamp */
-      def timestamp = AttributeReference(s, TimestampType, nullable = true)()
+      def timestamp = AttributeReference(s, TimestampType, nullable = true, comment = "")()
 
       /** Creates a new AttributeReference of type binary */
-      def binary = AttributeReference(s, BinaryType, nullable = true)()
+      def binary = AttributeReference(s, BinaryType, nullable = true, comment = "")()
 
       /** Creates a new AttributeReference of type array */
-      def array(dataType: DataType) = AttributeReference(s, ArrayType(dataType), nullable = true)()
+      def array(dataType: DataType) = AttributeReference(s, ArrayType(dataType), nullable = true, comment = "")()
 
       /** Creates a new AttributeReference of type map */
       def map(keyType: DataType, valueType: DataType): AttributeReference =
         map(MapType(keyType, valueType))
-      def map(mapType: MapType) = AttributeReference(s, mapType, nullable = true)()
+      def map(mapType: MapType) = AttributeReference(s, mapType, nullable = true, comment = "")()
 
       /** Creates a new AttributeReference of type struct */
       def struct(fields: StructField*): AttributeReference = struct(StructType(fields))
-      def struct(structType: StructType) = AttributeReference(s, structType, nullable = true)()
+      def struct(structType: StructType) = AttributeReference(s, structType, nullable = true, comment = "")()
     }
 
     implicit class DslAttribute(a: AttributeReference) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -42,6 +42,7 @@ abstract class Expression extends TreeNode[Expression] {
    */
   def foldable: Boolean = false
   def nullable: Boolean
+  def comment: String = ""
   def references: AttributeSet = AttributeSet(children.flatMap(_.references.iterator))
 
   /** Returns the result of evaluating this expression on a given input Row */
@@ -295,6 +296,7 @@ case class GroupExpression(children: Seq[Expression]) extends Expression {
   type EvaluatedType = Seq[Any]
   override def eval(input: Row): EvaluatedType = ???
   override def nullable = false
+  override def comment = ""
   override def foldable = false
   override def dataType = ???
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/generators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/generators.scala
@@ -43,7 +43,7 @@ abstract class Generator extends Expression {
   override type EvaluatedType = TraversableOnce[Row]
 
   override lazy val dataType =
-    ArrayType(StructType(output.map(a => StructField(a.name, a.dataType, a.nullable, a.metadata))))
+    ArrayType(StructType(output.map(a => StructField(a.name, a.dataType, a.nullable, a.comment, a.metadata))))
 
   override def nullable = false
 
@@ -92,11 +92,11 @@ case class Explode(attributeNames: Seq[String], child: Expression)
   protected def makeOutput() =
     if (attributeNames.size == elementTypes.size) {
       attributeNames.zip(elementTypes).map {
-        case (n, (t, nullable)) => AttributeReference(n, t, nullable)()
+        case (n, (t, nullable)) => AttributeReference(n, t, nullable, "")()
       }
     } else {
       elementTypes.zipWithIndex.map {
-        case ((t, nullable), i) => AttributeReference(s"c_$i", t, nullable)()
+        case ((t, nullable), i) => AttributeReference(s"c_$i", t, nullable, "")()
       }
     }
 
@@ -110,6 +110,8 @@ case class Explode(attributeNames: Seq[String], child: Expression)
         if (inputMap == null) Nil else inputMap.map { case (k,v) => new GenericRow(Array(k,v)) }
     }
   }
+
+  override def comment = ""
 
   override def toString() = s"explode($child)"
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/dataTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/dataTypes.scala
@@ -82,12 +82,14 @@ object DataType {
         ("metadata", metadata: JObject),
         ("name", JString(name)),
         ("nullable", JBool(nullable)),
+        ("comment", JString(comment)),
         ("type", dataType: JValue)) =>
-      StructField(name, parseDataType(dataType), nullable, Metadata.fromJObject(metadata))
+      StructField(name, parseDataType(dataType), nullable, comment, Metadata.fromJObject(metadata))
     // Support reading schema when 'metadata' is missing.
     case JSortedObject(
         ("name", JString(name)),
         ("nullable", JBool(nullable)),
+        ("comment", JString(comment)),
         ("type", dataType: JValue)) =>
       StructField(name, parseDataType(dataType), nullable)
   }
@@ -492,6 +494,7 @@ case class StructField(
     name: String,
     dataType: DataType,
     nullable: Boolean = true,
+    comment: String = "",
     metadata: Metadata = Metadata.empty) {
 
   private[sql] def buildFormattedString(prefix: String, builder: StringBuilder): Unit = {
@@ -506,13 +509,14 @@ case class StructField(
     ("name" -> name) ~
       ("type" -> dataType.jsonValue) ~
       ("nullable" -> nullable) ~
+      ("comment" -> comment) ~
       ("metadata" -> metadata.jsonValue)
   }
 }
 
 object StructType {
   protected[sql] def fromAttributes(attributes: Seq[Attribute]): StructType =
-    StructType(attributes.map(a => StructField(a.name, a.dataType, a.nullable, a.metadata)))
+    StructType(attributes.map(a => StructField(a.name, a.dataType, a.nullable, "", a.metadata)))
 }
 
 case class StructType(fields: Seq[StructField]) extends DataType {
@@ -546,7 +550,7 @@ case class StructType(fields: Seq[StructField]) extends DataType {
   }
 
   protected[sql] def toAttributes =
-    fields.map(f => AttributeReference(f.name, f.dataType, f.nullable, f.metadata)())
+    fields.map(f => AttributeReference(f.name, f.dataType, f.nullable, f.comment, f.metadata)())
 
   def treeString: String = {
     val builder = new StringBuilder

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/dataTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/dataTypes.scala
@@ -498,12 +498,12 @@ case class StructField(
     metadata: Metadata = Metadata.empty) {
 
   private[sql] def buildFormattedString(prefix: String, builder: StringBuilder): Unit = {
-    builder.append(s"$prefix-- $name: ${dataType.typeName} (nullable = $nullable)\n")
+    builder.append(s"$prefix-- $name: ${dataType.typeName} (nullable = $nullable)(comment: $comment)\n")
     DataType.buildFormattedString(dataType, s"$prefix    |", builder)
   }
 
   // override the default toString to be compatible with legacy parquet files.
-  override def toString: String = s"StructField($name,$dataType,$nullable)"
+  override def toString: String = s"StructField($name,$dataType,$nullable,$comment)"
 
   private[sql] def jsonValue: JValue = {
     ("name" -> name) ~
@@ -516,7 +516,7 @@ case class StructField(
 
 object StructType {
   protected[sql] def fromAttributes(attributes: Seq[Attribute]): StructType =
-    StructType(attributes.map(a => StructField(a.name, a.dataType, a.nullable, "", a.metadata)))
+    StructType(attributes.map(a => StructField(a.name, a.dataType, a.nullable, a.comment, a.metadata)))
 }
 
 case class StructType(fields: Seq[StructField]) extends DataType {

--- a/sql/core/src/main/java/org/apache/spark/sql/api/java/DataType.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/api/java/DataType.java
@@ -153,6 +153,7 @@ public abstract class DataType {
       String name,
       DataType dataType,
       boolean nullable,
+      String comment,
       Metadata metadata) {
     if (name == null) {
       throw new IllegalArgumentException("name should not be null.");
@@ -164,7 +165,7 @@ public abstract class DataType {
       throw new IllegalArgumentException("metadata should not be null.");
     }
 
-    return new StructField(name, dataType, nullable, metadata);
+    return new StructField(name, dataType, nullable, comment, metadata);
   }
 
   /**
@@ -172,8 +173,8 @@ public abstract class DataType {
    *
    * @see #createStructField(String, DataType, boolean, Metadata)
    */
-  public static StructField createStructField(String name, DataType dataType, boolean nullable) {
-    return createStructField(name, dataType, nullable, (new MetadataBuilder()).build());
+  public static StructField createStructField(String name, DataType dataType, boolean nullable, String comment) {
+    return createStructField(name, dataType, nullable, comment, (new MetadataBuilder()).build());
   }
 
   /**

--- a/sql/core/src/main/java/org/apache/spark/sql/api/java/DataType.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/api/java/DataType.java
@@ -146,8 +146,9 @@ public abstract class DataType {
   }
 
   /**
-   * Creates a StructField by specifying the name ({@code name}), data type ({@code dataType}) and
-   * whether values of this field can be null values ({@code nullable}).
+   * Creates a StructField by specifying the name ({@code name}), data type ({@code dataType}),
+   * whether values of this field can be null values ({@code nullable})
+   * and comment of this StructField({@code comment}).
    */
   public static StructField createStructField(
       String name,
@@ -171,10 +172,10 @@ public abstract class DataType {
   /**
    * Creates a StructField with empty metadata.
    *
-   * @see #createStructField(String, DataType, boolean, Metadata)
+   * @see #createStructField(String, DataType, boolean, String, Metadata)
    */
-  public static StructField createStructField(String name, DataType dataType, boolean nullable, String comment) {
-    return createStructField(name, dataType, nullable, comment, (new MetadataBuilder()).build());
+  public static StructField createStructField(String name, DataType dataType, boolean nullable) {
+    return createStructField(name, dataType, nullable, "", (new MetadataBuilder()).build());
   }
 
   /**

--- a/sql/core/src/main/java/org/apache/spark/sql/api/java/StructField.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/api/java/StructField.java
@@ -36,21 +36,28 @@ public class StructField {
   private String name;
   private DataType dataType;
   private boolean nullable;
+  private String comment;
   private Metadata metadata;
 
   protected StructField(
       String name,
       DataType dataType,
       boolean nullable,
+      String comment,
       Metadata metadata) {
     this.name = name;
     this.dataType = dataType;
     this.nullable = nullable;
+    this.comment = comment;
     this.metadata = metadata;
   }
 
   public String getName() {
     return name;
+  }
+
+  public String getComment() {
+    return comment;
   }
 
   public DataType getDataType() {
@@ -73,6 +80,7 @@ public class StructField {
     StructField that = (StructField) o;
 
     if (nullable != that.nullable) return false;
+    if (!comment.equals(that.comment)) return false;
     if (!dataType.equals(that.dataType)) return false;
     if (!name.equals(that.name)) return false;
     if (!metadata.equals(that.metadata)) return false;
@@ -85,6 +93,7 @@ public class StructField {
     int result = name.hashCode();
     result = 31 * result + dataType.hashCode();
     result = 31 * result + (nullable ? 1 : 0);
+    result = 31 * result + comment.hashCode();
     result = 31 * result + metadata.hashCode();
     return result;
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/json/JsonRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/json/JsonRDD.scala
@@ -136,7 +136,7 @@ private[sql] object JsonRDD extends Logging {
 
   private[sql] def nullTypeToStringType(struct: StructType): StructType = {
     val fields = struct.fields.map {
-      case StructField(fieldName, dataType, nullable, _) => {
+      case StructField(fieldName, dataType, nullable, _, _) => {
         val newType = dataType match {
           case NullType => StringType
           case ArrayType(NullType, containsNull) => ArrayType(StringType, containsNull)
@@ -422,7 +422,7 @@ private[sql] object JsonRDD extends Logging {
     // TODO: Reuse the row instead of creating a new one for every record.
     val row = new GenericMutableRow(schema.fields.length)
     schema.fields.zipWithIndex.foreach {
-      case (StructField(name, dataType, _, _), i) =>
+      case (StructField(name, dataType, _, _, _), i) =>
         row.update(i, json.get(name).flatMap(v => Option(v)).map(
           enforceCorrectType(_, dataType)).orNull)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/ddl.scala
@@ -79,6 +79,7 @@ private[sql] class DDLParser extends StandardTokenParsers with PackratParsers wi
   protected val ARRAY = Keyword("ARRAY")
   protected val MAP = Keyword("MAP")
   protected val STRUCT = Keyword("STRUCT")
+  protected val COMMENT = Keyword("COMMENT")
 
   // Use reflection to find the reserved words defined in this class.
   protected val reservedWords =
@@ -120,8 +121,8 @@ private[sql] class DDLParser extends StandardTokenParsers with PackratParsers wi
   protected lazy val pair: Parser[(String, String)] = ident ~ stringLit ^^ { case k ~ v => (k,v) }
 
   protected lazy val column: Parser[StructField] =
-    ident ~ dataType ^^ { case columnName ~ typ =>
-      StructField(columnName, typ)
+    ident ~ dataType ~ (COMMENT ~> stringLit).?  ^^ { case columnName ~ typ ~ cm =>
+      StructField(columnName, typ, true, cm.getOrElse(""))
     }
 
   protected lazy val primitiveType: Parser[DataType] =

--- a/sql/core/src/main/scala/org/apache/spark/sql/types/util/DataTypeConversions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/types/util/DataTypeConversions.scala
@@ -39,6 +39,7 @@ protected[sql] object DataTypeConversions {
       scalaStructField.name,
       asJavaDataType(scalaStructField.dataType),
       scalaStructField.nullable,
+      scalaStructField.comment,
       (new JMetaDataBuilder).withMetadata(scalaStructField.metadata).build())
   }
 
@@ -82,7 +83,9 @@ protected[sql] object DataTypeConversions {
       javaStructField.getName,
       asScalaDataType(javaStructField.getDataType),
       javaStructField.isNullable,
-      javaStructField.getMetadata)
+      javaStructField.getComment,
+      javaStructField.getMetadata
+    )
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataTypeSuite.scala
@@ -84,5 +84,5 @@ class DataTypeSuite extends FunSuite {
     StructType(Seq(
       StructField("a", IntegerType, nullable = true),
       StructField("b", ArrayType(DoubleType), nullable = false),
-      StructField("c", DoubleType, nullable = false, metadata))))
+      StructField("c", DoubleType, nullable = false, "", metadata))))
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/api/java/ScalaSideDataTypeConversionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/api/java/ScalaSideDataTypeConversionSuite.scala
@@ -73,7 +73,7 @@ class ScalaSideDataTypeConversionSuite extends FunSuite {
       SStructField("simpleMap", simpleScalaMapType, true) ::
       SStructField("simpleStruct", simpleScalaStructType, true) ::
       SStructField("boolean", org.apache.spark.sql.BooleanType, false) ::
-      SStructField("withMeta", org.apache.spark.sql.DoubleType, false, metadata) :: Nil)
+      SStructField("withMeta", org.apache.spark.sql.DoubleType, false, "", metadata) :: Nil)
     checkDataType(complexScalaStructType)
 
     // Complex ArrayType.


### PR DESCRIPTION
Support `comment` in StructField and also in CREATE TABLE DDL
 sql(
      """
        |CREATE TEMPORARY TABLE people(name string `comment` "the name of a people")
        |USING org.apache.spark.sql.sources.AllDataTypesScanSource
        |OPTIONS (
        |  from '1',
        |  to '10'
        |)
      """.stripMargin)
