### PR TITLE
SPARK-4159 [BUILD] Addendum: improve running of single test after enabling Java tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1130,6 +1130,7 @@
               <spark.executor.extraClassPath>${test_classpath}</spark.executor.extraClassPath>
               <spark.driver.allowMultipleContexts>true</spark.driver.allowMultipleContexts>
             </systemProperties>
+            <failIfNoTests>false</failIfNoTests>
           </configuration>
         </plugin>
         <!-- Scalatest runs all Scala tests -->


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-4159 was resolved but as Sandy points out, the guidance in https://cwiki.apache.org/confluence/display/SPARK/Useful+Developer+Tools under "Running Individual Tests" no longer quite works, not optimally.

This minor change is not really the important change, which is an update to the wiki text. The correct way to run one Scala test suite in Maven is now:

```
mvn test -DwildcardSuites=org.apache.spark.io.CompressionCodecSuite -Dtests=none
```

The correct way to run one Java test is

```
mvn test -DwildcardSuites=none -Dtests=org.apache.spark.streaming.JavaAPISuite
```

Basically, you have to set two properties in order to suppress all of one type of test (with a non-existent test name like 'none') and all but one test of the other type.

The change in the PR just prevents Surefire from barfing when it finds no "none" test.
I'd make the wiki edit but I can't myself.
