### PR TITLE
[SPARK-5186] [MLLIB]  Vector.equals and Vector.hashCode are very inefficient

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
@@ -460,7 +460,7 @@ class SparseVector(
           while (k2 < v.values.size && v.values(k2) == 0) k2 += 1
 
           if (k1 == this.values.size || k2 == v.values.size) {
-            return (k1 == this.values.size && k2 == v.values.size) //check end alignment
+            return (k1 == this.values.size && k2 == v.values.size) // check end alignment
           }
           if (this.indices(k1) != v.indices(k2) || this.values(k1) != v.values(k2)) {
             return false

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
@@ -451,10 +451,25 @@ class SparseVector(
 
   override def equals(other: Any): Boolean = {
     other match {
-      case v: SparseVector =>
-        this.size == v.size &&
-          util.Arrays.equals(this.indices, v.indices) &&
-          util.Arrays.equals(this.values, v.values)
+      case v: SparseVector => {
+        if (this.size != v.size) { return false }
+        var k1 = 0
+        var k2 = 0
+        while (true) {
+          while (k1 < this.values.size && this.values(k1) == 0) k1 += 1
+          while (k2 < v.values.size && v.values(k2) == 0) k2 += 1
+
+          if (k1 == this.values.size || k2 == v.values.size) {
+            return (k1 == this.values.size && k2 == v.values.size) //check end alignment
+          }
+          if (this.indices(k1) != v.indices(k2) || this.values(k1) != v.values(k2)) {
+            return false
+          }
+          k1 += 1
+          k2 += 1
+        }
+        throw new Exception("unreachable")
+      }
       case _ => super.equals(other)
     }
   }

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
@@ -462,27 +462,31 @@ class SparseVector(
     "(%s,%s,%s)".format(size, indices.mkString("[", ",", "]"), values.mkString("[", ",", "]"))
 
   override def equals(other: Any): Boolean = {
-    def nextNonzero(values: Array[Double], from: Int): Int = {
-      var index = from
-      while (index < values.size && values(index) == 0.0) index += 1
-      index
-    }
-
     other match {
       case v: SparseVector => {
         if (this.size != v.size) { return false }
-        var k1 = nextNonzero(this.values, 0)
-        var k2 = nextNonzero(v.values, 0)
+        val thisValues = this.values
+        val thisIndices = this.indices
+        val thisSize = thisValues.size
+        val otherValues = v.values
+        val otherIndices = v.indices
+        val otherSize = otherValues.size
 
-        while (k1 < this.values.size && k2 < v.values.size) {
-          if (this.indices(k1) != v.indices(k2) || this.values(k1) != v.values(k2)) {
-            return false
+        var k1 = 0
+        var k2 = 0
+        var allEqual = true
+        while (allEqual) {
+          while (k1 < thisSize && thisValues(k1) == 0) k1 += 1
+          while (k2 < otherSize && otherValues(k2) == 0) k2 += 1
+
+          if (k1 >= thisSize || k2 >= otherSize) {
+            return k1 >= thisSize && k2 >= otherSize // check end alignment
           }
-          k1 = nextNonzero(this.values, k1 + 1)
-          k2 = nextNonzero(v.values, k2 + 1)
+          allEqual = thisIndices(k1) == otherIndices(k2) && thisValues(k1) == otherValues(k2)
+          k1 += 1
+          k2 += 1
         }
-
-        return (k1 == this.values.size && k2 == v.values.size)
+        allEqual
       }
       case _ => super.equals(other)
     }

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
@@ -449,6 +449,16 @@ class SparseVector(
   override def toString: String =
     "(%s,%s,%s)".format(size, indices.mkString("[", ",", "]"), values.mkString("[", ",", "]"))
 
+  override def equals(other: Any): Boolean = {
+    other match {
+      case v: SparseVector =>
+        this.size == v.size &&
+          util.Arrays.equals(this.indices, v.indices) &&
+          util.Arrays.equals(this.values, v.values)
+      case _ => super.equals(other)
+    }
+  }
+
   override def toArray: Array[Double] = {
     val data = new Array[Double](size)
     var i = 0

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
@@ -55,11 +55,11 @@ sealed trait Vector extends Serializable {
         if (this.size != v2.size) return false
         (this, v2) match {
           case (s1: SparseVector, s2: SparseVector) =>
-            Vectors.getEquality(s1.indices, s1.values, s2.indices, s2.values)
+            Vectors.equals(s1.indices, s1.values, s2.indices, s2.values)
           case (s1: SparseVector, d1: DenseVector) =>
-            Vectors.getEquality(s1.indices, s1.values, 0 until d1.size, d1.values)
+            Vectors.equals(s1.indices, s1.values, 0 until d1.size, d1.values)
           case (d1: DenseVector, s1: SparseVector) =>
-            Vectors.getEquality(0 until d1.size, d1.values, s1.indices, s1.values)
+            Vectors.equals(0 until d1.size, d1.values, s1.indices, s1.values)
           case (_, _) => util.Arrays.equals(this.toArray, v2.toArray)
         }
       }
@@ -419,7 +419,7 @@ object Vectors {
   /**
    * Check equality between sparse/dense vectors
    */
-  private[mllib] def getEquality(
+  private[mllib] def equals(
       v1Indices: IndexedSeq[Int],
       v1Values: Array[Double],
       v2Indices: IndexedSeq[Int],

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
@@ -92,7 +92,7 @@ class VectorsSuite extends FunSuite {
   test("sparse equals with explicit 0") {
     val sv1 = Vectors.sparse(10, Array(1, 3, 4, 7), Array(0.9, 0.8, 0.7, 0.6))
     val sv2 = Vectors.sparse(10, Array(0, 1, 3, 4, 7), Array(0.0, 0.9, 0.8, 0.7, 0.6))
-    val sv3 = Vectors.sparse(10, Array(1, 3, 4, 5, 6, 7), Array(0.9, 0.8, 0, 0, 0.7, 0.6))
+    val sv3 = Vectors.sparse(10, Array(1, 3, 4, 5, 6, 7), Array(0.9, 0.8, 0.7, 0, 0, 0.6))
     val sv4 = Vectors.sparse(10, Array(1, 3, 4, 7, 9), Array(0.9, 0.8, 0.7, 0.6, 0))
     val sv5 = Vectors.sparse(10, Array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9),
       Array(0, 0.9, 0, 0.8, 0.7, 0, 0, 0.6, 0, 0))

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
@@ -89,23 +89,18 @@ class VectorsSuite extends FunSuite {
     }
   }
 
-  test("sparse equals with explicit 0") {
-    val sv1 = Vectors.sparse(10, Array(1, 3, 4, 7), Array(0.9, 0.8, 0.7, 0.6))
-    val sv2 = Vectors.sparse(10, Array(0, 1, 3, 4, 7), Array(0.0, 0.9, 0.8, 0.7, 0.6))
-    val sv3 = Vectors.sparse(10, Array(1, 3, 4, 5, 6, 7), Array(0.9, 0.8, 0.7, 0, 0, 0.6))
-    val sv4 = Vectors.sparse(10, Array(1, 3, 4, 7, 9), Array(0.9, 0.8, 0.7, 0.6, 0))
-    val sv5 = Vectors.sparse(10, Array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9),
-      Array(0, 0.9, 0, 0.8, 0.7, 0, 0, 0.6, 0, 0))
+  test("vectors equals with explicit 0") {
+    val dv1 = Vectors.dense(Array(0, 0.9, 0, 0.8, 0))
+    val sv1 = Vectors.sparse(5, Array(1, 3), Array(0.9, 0.8))
+    val sv2 = Vectors.sparse(5, Array(0, 1, 2, 3, 4), Array(0, 0.9, 0, 0.8, 0))
 
-    val vectors = Seq(sv1, sv2, sv3, sv4, sv5)
-
+    val vectors = Seq(dv1, sv1, sv2)
     for (v <- vectors; u <- vectors) {
       assert(v === u)
       assert(v.## === u.##)
     }
 
-    val another = Vectors.sparse(10, Array(1, 3, 4, 7), Array(0.9, 0.2, 0.7, 0.6))
-
+    val another = Vectors.sparse(5, Array(0, 1, 3), Array(0, 0.9, 0.2))
     for (v <- vectors) {
       assert(v != another)
       assert(v.## != another.##)

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
@@ -89,6 +89,29 @@ class VectorsSuite extends FunSuite {
     }
   }
 
+  test("sparse equals with explicit 0") {
+    val sv1 = Vectors.sparse(10, Array(1, 3, 4, 7), Array(0.9, 0.8, 0.7, 0.6))
+    val sv2 = Vectors.sparse(10, Array(0, 1, 3, 4, 7), Array(0.0, 0.9, 0.8, 0.7, 0.6))
+    val sv3 = Vectors.sparse(10, Array(1, 3, 4, 5, 6, 7), Array(0.9, 0.8, 0, 0, 0.7, 0.6))
+    val sv4 = Vectors.sparse(10, Array(1, 3, 4, 7, 9), Array(0.9, 0.8, 0.7, 0.6, 0))
+    val sv5 = Vectors.sparse(10, Array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9),
+      Array(0, 0.9, 0, 0.8, 0.7, 0, 0, 0.6, 0, 0))
+
+    val vectors = Seq(sv1, sv2, sv3, sv4, sv5)
+
+    for (v <- vectors; u <- vectors) {
+      assert(v === u)
+      assert(v.## === u.##)
+    }
+
+    val another = Vectors.sparse(10, Array(1, 3, 4, 7), Array(0.9, 0.2, 0.7, 0.6))
+
+    for (v <- vectors) {
+      assert(v != another)
+      assert(v.## != another.##)
+    }
+  }
+
   test("indexing dense vectors") {
     val vec = Vectors.dense(1.0, 2.0, 3.0, 4.0)
     assert(vec(0) === 1.0)


### PR DESCRIPTION
JIRA Issue: https://issues.apache.org/jira/browse/SPARK-5186

Currently SparseVector is using the inherited equals from Vector, which will create a full-size array for even the sparse vector. The pull request contains a specialized equals optimization that improves on both time and space. 
1. The implementation will be consistent with the original. Especially it will keep equality comparison between SparseVector and DenseVector.
