### PR TITLE
[SPARK-5200] Disable web UI in Hive ThriftServer tests

### DIFF
--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suite.scala
@@ -143,6 +143,7 @@ class HiveThriftServer2Suite extends FunSuite with Logging {
              |  --hiveconf ${ConfVars.HIVE_SERVER2_TRANSPORT_MODE}=http
              |  --hiveconf ${ConfVars.HIVE_SERVER2_THRIFT_HTTP_PORT}=$port
              |  --driver-class-path ${sys.props("java.class.path")}
+             |  --conf spark.ui.enabled=false
            """.stripMargin.split("\\s+").toSeq
       } else {
           s"""$startScript
@@ -153,6 +154,7 @@ class HiveThriftServer2Suite extends FunSuite with Logging {
              |  --hiveconf ${ConfVars.HIVE_SERVER2_THRIFT_BIND_HOST}=localhost
              |  --hiveconf ${ConfVars.HIVE_SERVER2_THRIFT_PORT}=$port
              |  --driver-class-path ${sys.props("java.class.path")}
+             |  --conf spark.ui.enabled=false
            """.stripMargin.split("\\s+").toSeq
       }
 


### PR DESCRIPTION
Disables the Spark web UI in HiveThriftServer2Suite in order to prevent Jenkins test failures due to port contention.
