### PR TITLE
[SPARK-5201][CORE] deal with int overflow in the ParallelCollectionRDD.slice method

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -520,10 +520,12 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
 
   /** Distribute a local Scala collection to form an RDD.
    *
-   * @note Parallelize acts lazily. If `seq` is a mutable collection and is
-   * altered after the call to parallelize and before the first action on the
-   * RDD, the resultant RDD will reflect the modified collection. Pass a copy of
-   * the argument to avoid this.
+   * @note Parallelize acts lazily. If `seq` is a mutable collection and is altered after the call
+   * to parallelize and before the first action on the RDD, the resultant RDD will reflect the
+   * modified collection. Pass a copy of the argument to avoid this.
+   *
+   * @note When splitting Range, the sub Range is exclusive. However the last slice for inclusive
+   * Range is inclusive.
    */
   def parallelize[T: ClassTag](seq: Seq[T], numSlices: Int = defaultParallelism): RDD[T] = {
     new ParallelCollectionRDD[T](this, seq, numSlices, Map[Int, Seq[String]]())

--- a/core/src/main/scala/org/apache/spark/rdd/ParallelCollectionRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ParallelCollectionRDD.scala
@@ -128,11 +128,9 @@ private object ParallelCollectionRDD {
     }
     seq match {
       case r: Range => {
-        // 1 to Int.MaxValue and (-2 to Int.MinValue by -1) can trigger exclusive range int overflow
-        val needsInclusiveRange = r.isInclusive && (r.end == Int.MaxValue || r.end == Int.MinValue)
         positions(r.length, numSlices).zipWithIndex.map({ case ((start, end), index) =>
-          // If the range needs to be inclusive, include the last element in the last slice
-          if (needsInclusiveRange && index == numSlices - 1) {
+          // If the range is inclusive, include the last element in the last slice
+          if (r.isInclusive && index == numSlices - 1) {
             new Range.Inclusive(r.start + start * r.step, r.end, r.step)
           }
           else {

--- a/core/src/main/scala/org/apache/spark/rdd/ParallelCollectionRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ParallelCollectionRDD.scala
@@ -111,7 +111,8 @@ private object ParallelCollectionRDD {
   /**
    * Slice a collection into numSlices sub-collections. One extra thing we do here is to treat Range
    * collections specially, encoding the slices as other Ranges to minimize memory cost. This makes
-   * it efficient to run Spark over RDDs representing large sets of numbers.
+   * it efficient to run Spark over RDDs representing large sets of numbers. And if the collection
+   * is an inclusive Range, we use inclusive range for the last slice.
    */
   def slice[T: ClassTag](seq: Seq[T], numSlices: Int): Seq[Seq[T]] = {
     if (numSlices < 1) {
@@ -129,7 +130,7 @@ private object ParallelCollectionRDD {
     seq match {
       case r: Range => {
         positions(r.length, numSlices).zipWithIndex.map({ case ((start, end), index) =>
-          // If the range is inclusive, include the last element in the last slice
+          // If the range is inclusive, use inclusive range for the last slice
           if (r.isInclusive && index == numSlices - 1) {
             new Range.Inclusive(r.start + start * r.step, r.end, r.step)
           }

--- a/core/src/main/scala/org/apache/spark/rdd/ParallelCollectionRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ParallelCollectionRDD.scala
@@ -128,9 +128,12 @@ private object ParallelCollectionRDD {
     }
     seq match {
       case r: Range => {
-        val sign = r.isInclusive && (r.end == Int.MaxValue || r.end == Int.MinValue)
+        // 1 to Int.MaxValue and (-2 to Int.MinValue by -1) can trigger exclusive range int overflow
+        val needsInclusiveRange = r.isInclusive && (r.end == Int.MaxValue || r.end == Int.MinValue)
         positions(r.length, numSlices).zipWithIndex.map({
-          case ((start, end), index) if sign && index == numSlices - 1 =>
+          // we need an inclusive range to avoid int overflow and setting the last range to be
+          // inclusive is suffice 
+          case ((start, end), index) if needsInclusiveRange && index == numSlices - 1 =>
             new Range.Inclusive(r.start + start * r.step, r.end, r.step)
           case ((start, end), _) =>
             new Range(r.start + start * r.step, r.start + end * r.step, r.step)

--- a/core/src/test/scala/org/apache/spark/rdd/ParallelCollectionSplitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/ParallelCollectionSplitSuite.scala
@@ -227,4 +227,26 @@ class ParallelCollectionSplitSuite extends FunSuite with Checkers {
     assert(slices.map(_.size).reduceLeft(_+_) === 100)
     assert(slices.forall(_.isInstanceOf[NumericRange[_]]))
   }
+
+  test("inclusive ranges with Int.MaxValue and Int.MinValue") {
+    val data1 = 1 to Int.MaxValue
+    val slices1 = ParallelCollectionRDD.slice(data1, 3)
+    assert(slices1.size === 3)
+    assert(slices1.map(_.size).sum === Int.MaxValue)
+    val data2 = -2 to Int.MinValue by -1
+    val slices2 = ParallelCollectionRDD.slice(data2, 3)
+    assert(slices2.size == 3)
+    assert(slices2.map(_.size).sum === Int.MaxValue)
+  }
+
+  test("empty ranges with Int.MaxValue and Int.MinValue") {
+    val data1 = Int.MaxValue until Int.MaxValue
+    val slices1 = ParallelCollectionRDD.slice(data1, 5)
+    assert(slices1.size === 5)
+    for (i <- 0 until 5) assert(slices1(i).size === 0)
+    val data2 = Int.MaxValue until Int.MaxValue
+    val slices2 = ParallelCollectionRDD.slice(data2, 5)
+    assert(slices2.size === 5)
+    for (i <- 0 until 5) assert(slices2(i).size === 0)
+  }
 }

--- a/core/src/test/scala/org/apache/spark/rdd/ParallelCollectionSplitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/ParallelCollectionSplitSuite.scala
@@ -76,6 +76,7 @@ class ParallelCollectionSplitSuite extends FunSuite with Checkers {
     assert(slices(0).mkString(",") === (0 to 32).mkString(","))
     assert(slices(1).mkString(",") === (33 to 66).mkString(","))
     assert(slices(2).mkString(",") === (67 to 100).mkString(","))
+    assert(slices(2).isInstanceOf[Range.Inclusive])
   }
 
   test("empty data") {
@@ -233,10 +234,12 @@ class ParallelCollectionSplitSuite extends FunSuite with Checkers {
     val slices1 = ParallelCollectionRDD.slice(data1, 3)
     assert(slices1.size === 3)
     assert(slices1.map(_.size).sum === Int.MaxValue)
+    assert(slices1(2).isInstanceOf[Range.Inclusive])
     val data2 = -2 to Int.MinValue by -1
     val slices2 = ParallelCollectionRDD.slice(data2, 3)
     assert(slices2.size == 3)
     assert(slices2.map(_.size).sum === Int.MaxValue)
+    assert(slices2(2).isInstanceOf[Range.Inclusive])
   }
 
   test("empty ranges with Int.MaxValue and Int.MinValue") {


### PR DESCRIPTION
There is an int overflow in the ParallelCollectionRDD.slice method. That's originally reported by SaintBacchus. 

```
sc.makeRDD(1 to (Int.MaxValue)).count       // result = 0
sc.makeRDD(1 to (Int.MaxValue - 1)).count   // result = 2147483646 = Int.MaxValue - 1
sc.makeRDD(1 until (Int.MaxValue)).count    // result = 2147483646 = Int.MaxValue - 1
```

see https://github.com/apache/spark/pull/2874 for more details.
This pr try to fix the overflow. However, There's another issue I don't address. 

```
val largeRange = Int.MinValue to Int.MaxValue
largeRange.length // throws java.lang.IllegalArgumentException: -2147483648 to 2147483647 by 1: seqs cannot contain more than Int.MaxValue elements.
```

So, the range we feed to sc.makeRDD cannot contain more than Int.MaxValue elements. This is the limitation of Scala. However I think  we may want to support that kind of range. But the fix is beyond this pr.

@srowen @andrewor14 would you mind take a look at this pr?
