### PR TITLE
[SPARK-5203][SQL] fix union with different decimal type

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
@@ -296,7 +296,7 @@ trait HiveTypeCoercion {
    *   e1 * e2      p1 + p2 + 1                             s1 + s2
    *   e1 / e2      p1 - s1 + s2 + max(6, s1 + p2 + 1)      max(6, s1 + p2 + 1)
    *   e1 % e2      min(p1-s1, p2-s2) + max(s1, s2)         max(s1, s2)
-   *   union        max(s1, s2) + max(p1-s1, p2-s2)         max(s1, s2)
+   *   e1 union e2  max(s1, s2) + max(p1-s1, p2-s2)         max(s1, s2)
    *   sum(e1)      p1 + 10                                 s1
    *   avg(e1)      p1 + 4                                  s1 + 4
    *
@@ -468,7 +468,7 @@ trait HiveTypeCoercion {
       case e: EqualNullSafe => e
       // Otherwise turn them to Byte types so that there exists and ordering.
       case p: BinaryComparison
-        if p.left.dataType == BooleanType && p.right.dataType == BooleanType =>
+          if p.left.dataType == BooleanType && p.right.dataType == BooleanType =>
         p.makeCopy(Array(Cast(p.left, ByteType), Cast(p.right, ByteType)))
     }
   }
@@ -609,7 +609,7 @@ trait HiveTypeCoercion {
           val commonType = valueTypes.reduce { (v1, v2) =>
             findTightestCommonType(v1, v2)
               .getOrElse(sys.error(
-              s"Types in CASE WHEN must be the same or coercible to a common type: $v1 != $v2"))
+                s"Types in CASE WHEN must be the same or coercible to a common type: $v1 != $v2"))
           }
           val transformedBranches = branches.sliding(2, 2).map {
             case Seq(cond, value) if value.dataType != commonType =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
@@ -172,7 +172,7 @@ trait HiveTypeCoercion {
    *   - INT gets turned into DECIMAL(10, 0)
    *   - LONG gets turned into DECIMAL(20, 0)
    *   - Fixed union decimals with precision/scale p1/s2 and p2/s2  will be promoted to
-   *   DecimalType(max(p1, p2), max(s1, s2))
+   *   DecimalType(max(s1, s2) + max(p1-s1, p2-s2), max(s1, s2))
    *   - FLOAT and DOUBLE cause fixed-length decimals to turn into DOUBLE (this is the same as Hive,
    *   but note that unlimited decimals are considered bigger than doubles in WidenTypes)
    *
@@ -203,11 +203,11 @@ trait HiveTypeCoercion {
     }
 
     // Union decimals with precision/scale p1/s2 and p2/s2  will be promoted to
-    // DecimalType(max(p1, p2), max(s1, s2))
+    // DecimalType(max(s1, s2) + max(p1-s1, p2-s2), max(s1, s2))
     private def findTightestDecimalType(t1: DataType, t2: DataType): Option[DataType] = {
       (t1, t2) match {
         case (DecimalType.Fixed(p1, s1), DecimalType.Fixed(p2, s2)) =>
-          Some(DecimalType(max(p1, p2), max(s1, s2)))
+          Some(DecimalType(max(s1, s2) + max(p1-s1, p2-s2), max(s1, s2)))
         case _ => None
       }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
@@ -285,6 +285,7 @@ trait HiveTypeCoercion {
    * Calculates and propagates precision for fixed-precision decimals. Hive has a number of
    * rules for this based on the SQL standard and MS SQL:
    * https://cwiki.apache.org/confluence/download/attachments/27362075/Hive_Decimal_Precision_Scale_Support.pdf
+   * https://msdn.microsoft.com/en-us/library/ms190476.aspx
    *
    * In particular, if we have expressions e1 and e2 with precision/scale p1/s2 and p2/s2
    * respectively, then the following operations have the following precision / scale:
@@ -338,8 +339,8 @@ trait HiveTypeCoercion {
               case (DecimalType.Fixed(p1, s1), DecimalType.Fixed(p2, s2)) =>
                 // Union decimals with precision/scale p1/s2 and p2/s2  will be promoted to
                 // DecimalType(max(s1, s2) + max(p1-s1, p2-s2), max(s1, s2))
-                val fixType = DecimalType(max(s1, s2) + max(p1-s1, p2-s2), max(s1, s2))
-                (Alias(Cast(l, fixType), l.name)(), Alias(Cast(r, fixType), r.name)())
+                val fixedType = DecimalType(max(s1, s2) + max(p1 - s1, p2 - s2), max(s1, s2))
+                (Alias(Cast(l, fixedType), l.name)(), Alias(Cast(r, fixedType), r.name)())
               case (t, DecimalType.Fixed(p, s)) if intTypeToFixed.contains(t) =>
                 (Alias(Cast(l, intTypeToFixed(t)), l.name)(), r)
               case (DecimalType.Fixed(p, s), t) if intTypeToFixed.contains(t) =>
@@ -370,6 +371,7 @@ trait HiveTypeCoercion {
           }
 
         Union(newLeft, newRight)
+
       // fix decimal precision for expressions
       case q => q.transformExpressions {
         // Skip nodes whose children have not been resolved yet

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/dataTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/dataTypes.scala
@@ -35,6 +35,15 @@ import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.sql.catalyst.ScalaReflectionLock
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Expression}
 import org.apache.spark.util.Utils
+import scala.math._
+import org.apache.spark.sql.types.StructField
+import org.apache.spark.sql.types.PrecisionInfo
+import scala.Some
+import scala.Fractional
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import scala.Numeric
+import scala.Ordering
+import scala.Integral
 
 
 object DataType {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/dataTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/dataTypes.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.types
 import java.sql.Timestamp
 
 import scala.collection.mutable.ArrayBuffer
+import scala.math._
 import scala.math.Numeric.{FloatAsIfIntegral, DoubleAsIfIntegral}
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.{TypeTag, runtimeMirror, typeTag}
@@ -35,15 +36,6 @@ import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.sql.catalyst.ScalaReflectionLock
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Expression}
 import org.apache.spark.util.Utils
-import scala.math._
-import org.apache.spark.sql.types.StructField
-import org.apache.spark.sql.types.PrecisionInfo
-import scala.Some
-import scala.Fractional
-import org.apache.spark.sql.catalyst.expressions.AttributeReference
-import scala.Numeric
-import scala.Ordering
-import scala.Integral
 
 
 object DataType {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/dataTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/dataTypes.scala
@@ -934,7 +934,9 @@ object StructType {
 
       case (DecimalType.Fixed(leftPrecision, leftScale),
             DecimalType.Fixed(rightPrecision, rightScale)) =>
-        DecimalType(leftPrecision.max(rightPrecision), leftScale.max(rightScale))
+        DecimalType(
+          max(leftScale, rightScale) + max(leftPrecision - leftScale, rightPrecision - rightScale),
+          max(leftScale, rightScale))
 
       case (leftUdt: UserDefinedType[_], rightUdt: UserDefinedType[_])
         if leftUdt.userClass == rightUdt.userClass => leftUdt

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/DecimalPrecisionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/DecimalPrecisionSuite.scala
@@ -31,7 +31,8 @@ class DecimalPrecisionSuite extends FunSuite with BeforeAndAfter {
     AttributeReference("d1", DecimalType(2, 1))(),
     AttributeReference("d2", DecimalType(5, 2))(),
     AttributeReference("u", DecimalType.Unlimited)(),
-    AttributeReference("f", FloatType)()
+    AttributeReference("f", FloatType)(),
+    AttributeReference("b", DoubleType)()
   )
 
   val i: Expression = UnresolvedAttribute("i")
@@ -39,6 +40,7 @@ class DecimalPrecisionSuite extends FunSuite with BeforeAndAfter {
   val d2: Expression = UnresolvedAttribute("d2")
   val u: Expression = UnresolvedAttribute("u")
   val f: Expression = UnresolvedAttribute("f")
+  val b: Expression = UnresolvedAttribute("b")
 
   before {
     catalog.registerTable(Seq("table"), relation)
@@ -98,8 +100,10 @@ class DecimalPrecisionSuite extends FunSuite with BeforeAndAfter {
     checkUnion(i, d2, DecimalType(12, 2))
     checkUnion(d1, d2, DecimalType(5, 2))
     checkUnion(d2, d1, DecimalType(5, 2))
-    checkUnion(d1, f, DoubleType)
-    checkUnion(f, d2, DoubleType)
+    checkUnion(d1, f, DecimalType(8, 7))
+    checkUnion(f, d2, DecimalType(10, 7))
+    checkUnion(d1, b, DecimalType(16, 15))
+    checkUnion(b, d2, DecimalType(18, 15))
     checkUnion(d1, u, DecimalType.Unlimited)
     checkUnion(u, d2, DecimalType.Unlimited)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercionSuite.scala
@@ -96,89 +96,10 @@ class HiveTypeCoercionSuite extends PlanTest {
     widenTest(StringType, TimestampType, None)
 
     // ComplexType
-    widenTest(NullType, MapType(IntegerType, StringType, false),
-      Some(MapType(IntegerType, StringType, false)))
+    widenTest(NullType, MapType(IntegerType, StringType, false), Some(MapType(IntegerType, StringType, false)))
     widenTest(NullType, StructType(Seq()), Some(StructType(Seq())))
     widenTest(StringType, MapType(IntegerType, StringType, true), None)
     widenTest(ArrayType(IntegerType), StructType(Seq()), None)
-  }
-
-  test("tightest bound for union types") {
-    val widenTypes = new HiveTypeCoercion { }.WidenTypes
-    def unionTypeTest(t1: DataType, t2: DataType, tightestCommon: Option[DataType]) {
-      var found = widenTypes.findUnionType(t1, t2)
-      assert(found == tightestCommon,
-        s"Expected $tightestCommon as tightest union type for $t1 and $t2, found $found")
-      // Test both directions to make sure the widening is symmetric.
-      found = widenTypes.findUnionType(t2, t1)
-      assert(found == tightestCommon,
-        s"Expected $tightestCommon as tightest union type for $t2 and $t1, found $found")
-    }
-    // Null
-    unionTypeTest(NullType, NullType, Some(NullType))
-
-    // Boolean
-    unionTypeTest(NullType, BooleanType, Some(BooleanType))
-    unionTypeTest(BooleanType, BooleanType, Some(BooleanType))
-    unionTypeTest(IntegerType, BooleanType, None)
-    unionTypeTest(LongType, BooleanType, None)
-
-    // Integral
-    unionTypeTest(NullType, ByteType, Some(ByteType))
-    unionTypeTest(NullType, IntegerType, Some(IntegerType))
-    unionTypeTest(NullType, LongType, Some(LongType))
-    unionTypeTest(ShortType, IntegerType, Some(IntegerType))
-    unionTypeTest(ShortType, LongType, Some(LongType))
-    unionTypeTest(IntegerType, LongType, Some(LongType))
-    unionTypeTest(LongType, LongType, Some(LongType))
-
-    // Floating point
-    unionTypeTest(NullType, FloatType, Some(FloatType))
-    unionTypeTest(NullType, DoubleType, Some(DoubleType))
-    unionTypeTest(FloatType, DoubleType, Some(DoubleType))
-    unionTypeTest(FloatType, FloatType, Some(FloatType))
-    unionTypeTest(DoubleType, DoubleType, Some(DoubleType))
-
-    // Integral mixed with floating point.
-    unionTypeTest(IntegerType, FloatType, Some(FloatType))
-    unionTypeTest(IntegerType, DoubleType, Some(DoubleType))
-    unionTypeTest(IntegerType, DoubleType, Some(DoubleType))
-    unionTypeTest(LongType, FloatType, Some(FloatType))
-    unionTypeTest(LongType, DoubleType, Some(DoubleType))
-
-    // Casting up to unlimited-precision decimal
-    unionTypeTest(IntegerType, DecimalType.Unlimited, Some(DecimalType.Unlimited))
-    unionTypeTest(DoubleType, DecimalType.Unlimited, Some(DecimalType.Unlimited))
-    unionTypeTest(DecimalType(3, 2), DecimalType.Unlimited, Some(DecimalType.Unlimited))
-    unionTypeTest(DecimalType.Unlimited, IntegerType, Some(DecimalType.Unlimited))
-    unionTypeTest(DecimalType.Unlimited, DoubleType, Some(DecimalType.Unlimited))
-    unionTypeTest(DecimalType.Unlimited, DecimalType(3, 2), Some(DecimalType.Unlimited))
-
-    // Casting up for fixed-precision decimal
-    unionTypeTest(DecimalType(2, 1), DecimalType(3, 2), Some(DecimalType(3, 2)))
-    unionTypeTest(DecimalType(2, 1), DoubleType, Some(DoubleType))
-    unionTypeTest(DecimalType(2, 1), IntegerType, Some(DecimalType(10, 1)))
-    unionTypeTest(DoubleType, DecimalType(2, 1), Some(DoubleType))
-    unionTypeTest(ShortType, DecimalType(2, 1), Some(DecimalType(5, 1)))
-
-    // StringType
-    unionTypeTest(NullType, StringType, Some(StringType))
-    unionTypeTest(StringType, StringType, Some(StringType))
-    unionTypeTest(IntegerType, StringType, Some(StringType))
-    unionTypeTest(LongType, StringType, Some(StringType))
-
-    // TimestampType
-    unionTypeTest(NullType, TimestampType, Some(TimestampType))
-    unionTypeTest(TimestampType, TimestampType, Some(TimestampType))
-    unionTypeTest(IntegerType, TimestampType, None)
-    unionTypeTest(StringType, TimestampType, Some(StringType))
-
-    // ComplexType
-    unionTypeTest(NullType, MapType(IntegerType, StringType, false),
-      Some(MapType(IntegerType, StringType, false)))
-    unionTypeTest(NullType, StructType(Seq()), Some(StructType(Seq())))
-    unionTypeTest(StringType, MapType(IntegerType, StringType, true), Some(StringType))
-    unionTypeTest(ArrayType(IntegerType), StructType(Seq()), None)
   }
 
   test("boolean casts") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -468,4 +468,17 @@ class SQLQuerySuite extends QueryTest {
       sql(s"DROP TABLE $tableName")
     }
   }
+  
+  test("SPARK-5203 union with different decimal precision") {
+    val testData = sparkContext.parallelize(1 to 10).map(i => TestData(i, i.toString))
+    sql("CREATE TABLE test_decimal1 (key INT, value DECIMAL(3, 1))")
+    testData.insertInto("test_decimal1")
+    sql("CREATE TABLE test_decimal2 (key INT, value DECIMAL(14, 1))")
+    testData.insertInto("test_decimal2")
+    testData.insertInto("test_decimal2")
+    checkAnswer(
+      sql("SELECT value FROM test_decimal1 UNION ALL SELECT value * 1 FROM test_decimal1"),
+      sql("SELECT value From test_decimal2").collect().toSeq)
+  }
+
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -470,7 +470,7 @@ class SQLQuerySuite extends QueryTest {
   }
   
   test("SPARK-5203 union with different decimal precision") {
-    val testData = sparkContext.parallelize(1 to 10).map(i => TestData(i, i.toString))
+    val testData = sparkContext.parallelize(1 to 10).map(i => TestData(i, i.toString)).toDF()
     sql("CREATE TABLE test_decimal1 (key INT, value DECIMAL(3, 1))")
     testData.insertInto("test_decimal1")
     sql("CREATE TABLE test_decimal2 (key INT, value DECIMAL(14, 1))")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -470,15 +470,13 @@ class SQLQuerySuite extends QueryTest {
   }
   
   test("SPARK-5203 union with different decimal precision") {
-    val testData = sparkContext.parallelize(1 to 10).map(i => TestData(i, i.toString)).toDF()
-    sql("CREATE TABLE test_decimal1 (key INT, value DECIMAL(3, 1))")
-    testData.insertInto("test_decimal1")
-    sql("CREATE TABLE test_decimal2 (key INT, value DECIMAL(14, 1))")
-    testData.insertInto("test_decimal2")
-    testData.insertInto("test_decimal2")
-    checkAnswer(
-      sql("SELECT value FROM test_decimal1 UNION ALL SELECT value * 1 FROM test_decimal1"),
-      sql("SELECT value From test_decimal2").collect().toSeq)
+    Seq.empty[(Decimal, Decimal)]
+      .toDF("d1", "d2")
+      .select($"d1".cast(DecimalType(10, 15)).as("d"))
+      .registerTempTable("dn")
+
+    sql("select d from dn union all select d * 2 from dn")
+      .queryExecution.analyzed
   }
 
 }


### PR DESCRIPTION
   When union non-decimal types with decimals, we use the following rules:
      - FIRST `intTypeToFixed`, then fixed union decimals with precision/scale p1/s2 and p2/s2  will be promoted to
      DecimalType(max(p1, p2), max(s1, s2))
      - FLOAT and DOUBLE cause fixed-length decimals to turn into DOUBLE (this is the same as Hive,
      but note that unlimited decimals are considered bigger than doubles in WidenTypes)
