### PR TITLE
[SPARK-5205][Streaming]:Inconsistent behaviour between Streaming job and others, when click kill link in WebUI

### DIFF
--- a/core/src/main/java/org/apache/spark/TaskContext.java
+++ b/core/src/main/java/org/apache/spark/TaskContext.java
@@ -94,6 +94,12 @@ public abstract class TaskContext implements Serializable {
   @Deprecated
   public abstract void addOnCompleteCallback(final Function0<Unit> f);
 
+  /**
+   * Add a callback function to be executed on task stop.
+   * This will be called when task is being killed.
+   *
+   * @param f Callback function.
+   */
   public abstract void addOnStopCallback(final Function1<String, Unit> f);
 
   public abstract int stageId();

--- a/core/src/main/java/org/apache/spark/TaskContext.java
+++ b/core/src/main/java/org/apache/spark/TaskContext.java
@@ -96,24 +96,16 @@ public abstract class TaskContext implements Serializable {
   public abstract void addOnCompleteCallback(final Function0<Unit> f);
 
   /**
-   * Add a callback function to be executed on task stop.
-   * This will be called when task is being killed.
-   *
-   * @param f Callback function.
-   */
-  public abstract void addOnStopCallback(final Function1<String, Unit> f);
-
-  /**
-   * Add a (Java friendly) listener to be executed on task completion.
-   * This will be called in all situation - success, failure, or cancellation.
-   * An example use is for HadoopRDD to register a callback to close the input stream.
+   * Add a (Java friendly) listener to be executed when kill a task. We add this
+   * listener for some more clean works. For example, we need to register a "kill"
+   * callback to completely stop a receiver supervisor.
    */
   public abstract TaskContext addTaskKilledListener(TaskKilledListener listener);
 
   /**
-   * Add a listener in the form of a Scala closure to be executed on task completion.
-   * This will be called in all situations - success, failure, or cancellation.
-   * An example use is for HadoopRDD to register a callback to close the input stream.
+   * Add a (Java friendly) listener to be executed when kill a task. We add this
+   * listener for some more clean works. For example, we need to register a "kill"
+   * callback to completely stop a receiver supervisor.
    */
   public abstract TaskContext addTaskKilledListener(final Function1<TaskContext, Unit> f);
 

--- a/core/src/main/java/org/apache/spark/TaskContext.java
+++ b/core/src/main/java/org/apache/spark/TaskContext.java
@@ -94,6 +94,8 @@ public abstract class TaskContext implements Serializable {
   @Deprecated
   public abstract void addOnCompleteCallback(final Function0<Unit> f);
 
+  public abstract void addOnStopCallback(final Function1<String, Unit> f);
+
   public abstract int stageId();
 
   public abstract int partitionId();

--- a/core/src/main/java/org/apache/spark/TaskContext.java
+++ b/core/src/main/java/org/apache/spark/TaskContext.java
@@ -96,18 +96,18 @@ public abstract class TaskContext implements Serializable {
   public abstract void addOnCompleteCallback(final Function0<Unit> f);
 
   /**
-   * Add a (Java friendly) listener to be executed when kill a task. We add this
+   * Add a listener to be executed when kill a task. We add this
    * listener for some more clean works. For example, we need to register a "kill"
    * callback to completely stop a receiver supervisor.
    */
   public abstract TaskContext addTaskKilledListener(TaskKilledListener listener);
 
   /**
-   * Add a (Java friendly) listener to be executed when kill a task. We add this
+   * Add a listener to be executed when kill a task. We add this
    * listener for some more clean works. For example, we need to register a "kill"
    * callback to completely stop a receiver supervisor.
    */
-  public abstract TaskContext addTaskKilledListener(final Function1<TaskContext, Unit> f);
+  public abstract TaskContext addTaskKilledCallback(final Function1<TaskContext, Unit> f);
 
   public abstract int stageId();
 

--- a/core/src/main/java/org/apache/spark/TaskContext.java
+++ b/core/src/main/java/org/apache/spark/TaskContext.java
@@ -26,6 +26,7 @@ import scala.Unit;
 import org.apache.spark.annotation.DeveloperApi;
 import org.apache.spark.executor.TaskMetrics;
 import org.apache.spark.util.TaskCompletionListener;
+import org.apache.spark.util.TaskKilledListener;
 
 /**
  * Contextual information about a task which can be read or mutated during
@@ -101,6 +102,20 @@ public abstract class TaskContext implements Serializable {
    * @param f Callback function.
    */
   public abstract void addOnStopCallback(final Function1<String, Unit> f);
+
+  /**
+   * Add a (Java friendly) listener to be executed on task completion.
+   * This will be called in all situation - success, failure, or cancellation.
+   * An example use is for HadoopRDD to register a callback to close the input stream.
+   */
+  public abstract TaskContext addTaskKilledListener(TaskKilledListener listener);
+
+  /**
+   * Add a listener in the form of a Scala closure to be executed on task completion.
+   * This will be called in all situations - success, failure, or cancellation.
+   * An example use is for HadoopRDD to register a callback to close the input stream.
+   */
+  public abstract TaskContext addTaskKilledListener(final Function1<TaskContext, Unit> f);
 
   public abstract int stageId();
 

--- a/core/src/main/java/org/apache/spark/TaskContext.java
+++ b/core/src/main/java/org/apache/spark/TaskContext.java
@@ -96,18 +96,18 @@ public abstract class TaskContext implements Serializable {
   public abstract void addOnCompleteCallback(final Function0<Unit> f);
 
   /**
-   * Add a listener to be executed when kill a task. We add this
-   * listener for some more clean works. For example, we need to register a "kill"
-   * callback to completely stop a receiver supervisor.
+   * Add a (Java friendly) listener to be executed on task interruption. We add this
+   * listener for some more clean works. An example use is to stop `receiver supervisor`
+   * properly.
    */
   public abstract TaskContext addTaskKilledListener(TaskKilledListener listener);
 
   /**
-   * Add a listener to be executed when kill a task. We add this
-   * listener for some more clean works. For example, we need to register a "kill"
-   * callback to completely stop a receiver supervisor.
+   * Add a listener in the form of a Scala closure to be executed on task interruption.
+   * We add this listener for some more clean works. An example use is stop `receiver
+   * supervisor` properly.
    */
-  public abstract TaskContext addTaskKilledCallback(final Function1<TaskContext, Unit> f);
+  public abstract TaskContext addTaskKilledListener(final Function1<TaskContext, Unit> f);
 
   public abstract int stageId();
 

--- a/core/src/main/scala/org/apache/spark/TaskContextImpl.scala
+++ b/core/src/main/scala/org/apache/spark/TaskContextImpl.scala
@@ -66,7 +66,7 @@ private[spark] class TaskContextImpl(val stageId: Int,
     this
   }
 
-  override def addTaskKilledListener(f: TaskContext => Unit): this.type = {
+  override def addTaskKilledCallback(f: TaskContext => Unit): this.type = {
     onKilledCallbacks += new TaskKilledListener {
       override def onTaskKilled(context: TaskContext): Unit = f(context)
     }

--- a/core/src/main/scala/org/apache/spark/TaskContextImpl.scala
+++ b/core/src/main/scala/org/apache/spark/TaskContextImpl.scala
@@ -39,6 +39,8 @@ private[spark] class TaskContextImpl(val stageId: Int,
   // Whether the task has completed.
   @volatile private var completed: Boolean = false
 
+  private var stopCallback = (message: String) => {}
+
   override def addTaskCompletionListener(listener: TaskCompletionListener): this.type = {
     onCompleteCallbacks += listener
     this
@@ -56,6 +58,10 @@ private[spark] class TaskContextImpl(val stageId: Int,
     onCompleteCallbacks += new TaskCompletionListener {
       override def onTaskCompletion(context: TaskContext): Unit = f()
     }
+  }
+
+  override def addOnStopCallback(f: String => Unit) {
+    stopCallback = f
   }
 
   /** Marks the task as completed and triggers the listeners. */
@@ -80,6 +86,10 @@ private[spark] class TaskContextImpl(val stageId: Int,
   /** Marks the task for interruption, i.e. cancellation. */
   private[spark] def markInterrupted(): Unit = {
     interrupted = true
+  }
+
+  def stop(message: String) {
+    stopCallback(message)
   }
 
   override def isCompleted: Boolean = completed

--- a/core/src/main/scala/org/apache/spark/TaskContextImpl.scala
+++ b/core/src/main/scala/org/apache/spark/TaskContextImpl.scala
@@ -39,6 +39,7 @@ private[spark] class TaskContextImpl(val stageId: Int,
   // Whether the task has completed.
   @volatile private var completed: Boolean = false
 
+  // Do nothing acquiescently
   private var stopCallback = (message: String) => {}
 
   override def addTaskCompletionListener(listener: TaskCompletionListener): this.type = {
@@ -88,7 +89,8 @@ private[spark] class TaskContextImpl(val stageId: Int,
     interrupted = true
   }
 
-  def stop(message: String) {
+  /** Stop the task by custom style. */
+  private[spark] def stop(message: String) {
     stopCallback(message)
   }
 

--- a/core/src/main/scala/org/apache/spark/TaskContextImpl.scala
+++ b/core/src/main/scala/org/apache/spark/TaskContextImpl.scala
@@ -66,7 +66,7 @@ private[spark] class TaskContextImpl(val stageId: Int,
     this
   }
 
-  override def addTaskKilledCallback(f: TaskContext => Unit): this.type = {
+  override def addTaskKilledListener(f: TaskContext => Unit): this.type = {
     onKilledCallbacks += new TaskKilledListener {
       override def onTaskKilled(context: TaskContext): Unit = f(context)
     }

--- a/core/src/main/scala/org/apache/spark/scheduler/Task.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Task.scala
@@ -94,6 +94,7 @@ private[spark] abstract class Task[T](val stageId: Int, var partitionId: Int) ex
     _killed = true
     if (context != null) {
       context.markInterrupted()
+      context.stop("Task was killed through ui.")
     }
     if (interruptThread && taskThread != null) {
       taskThread.interrupt()

--- a/core/src/main/scala/org/apache/spark/scheduler/Task.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Task.scala
@@ -94,7 +94,7 @@ private[spark] abstract class Task[T](val stageId: Int, var partitionId: Int) ex
     _killed = true
     if (context != null) {
       context.markInterrupted()
-      context.stop("Task was killed.")
+      context.markTaskKilled()
     }
     if (interruptThread && taskThread != null) {
       taskThread.interrupt()

--- a/core/src/main/scala/org/apache/spark/scheduler/Task.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Task.scala
@@ -94,7 +94,7 @@ private[spark] abstract class Task[T](val stageId: Int, var partitionId: Int) ex
     _killed = true
     if (context != null) {
       context.markInterrupted()
-      context.stop("Task was killed through ui.")
+      context.stop("Task was killed.")
     }
     if (interruptThread && taskThread != null) {
       taskThread.interrupt()

--- a/core/src/main/scala/org/apache/spark/util/TaskKilledListener.scala
+++ b/core/src/main/scala/org/apache/spark/util/TaskKilledListener.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util
+
+import java.util.EventListener
+
+import org.apache.spark.TaskContext
+import org.apache.spark.annotation.DeveloperApi
+
+/**
+ * :: DeveloperApi ::
+ *
+ * Listener providing a callback function to invoke when kill a task.
+ */
+@DeveloperApi
+trait TaskKilledListener extends EventListener {
+  def onTaskKilled(context: TaskContext)
+}

--- a/core/src/main/scala/org/apache/spark/util/TaskKilledListenerException.scala
+++ b/core/src/main/scala/org/apache/spark/util/TaskKilledListenerException.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util
+
+/**
+ * Exception thrown when there is an exception in
+ * executing the callback in TaskKilledListener.
+ */
+private[spark]
+class TaskKilledListenerException(errorMessages: Seq[String]) extends Exception {
+
+  override def getMessage: String = {
+    if (errorMessages.size == 1) {
+      errorMessages.head
+    } else {
+      errorMessages.zipWithIndex.map { case (msg, i) => s"Exception $i: $msg" }.mkString("\n")
+    }
+  }
+}

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -89,6 +89,9 @@ object MimaExcludes {
             // TaskContext was promoted to Abstract class
             ProblemFilters.exclude[AbstractClassProblem](
               "org.apache.spark.TaskContext"),
+            ProblemFilters.exclude[MissingMethodProblem](
+              "org.apache.spark.TaskContext.addTaskKilledListener"
+            ),
             ProblemFilters.exclude[IncompatibleTemplateDefProblem](
               "org.apache.spark.util.collection.SortDataFormat")
           ) ++ Seq(

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -92,6 +92,9 @@ object MimaExcludes {
             ProblemFilters.exclude[MissingMethodProblem](
               "org.apache.spark.TaskContext.addTaskKilledListener"
             ),
+            ProblemFilters.exclude[MissingMethodProblem](
+              "org.apache.spark.TaskContext.addTaskKilledCallback"
+            ),
             ProblemFilters.exclude[IncompatibleTemplateDefProblem](
               "org.apache.spark.util.collection.SortDataFormat")
           ) ++ Seq(

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -61,6 +61,14 @@ object MimaExcludes {
             ProblemFilters.exclude[IncompatibleResultTypeProblem](
               "org.apache.spark.streaming.flume.sink.SparkAvroCallbackHandler." +
                 "removeAndGetProcessor")
+          ) ++ Seq(
+            // SPARK-5205
+            ProblemFilters.exclude[MissingMethodProblem](
+              "org.apache.spark.TaskContext.addTaskKilledListener"
+            ),
+            ProblemFilters.exclude[MissingMethodProblem](
+              "org.apache.spark.TaskContext.addTaskKilledCallback"
+            )
           )
 
         case v if v.startsWith("1.2") =>
@@ -89,12 +97,6 @@ object MimaExcludes {
             // TaskContext was promoted to Abstract class
             ProblemFilters.exclude[AbstractClassProblem](
               "org.apache.spark.TaskContext"),
-            ProblemFilters.exclude[MissingMethodProblem](
-              "org.apache.spark.TaskContext.addTaskKilledListener"
-            ),
-            ProblemFilters.exclude[MissingMethodProblem](
-              "org.apache.spark.TaskContext.addTaskKilledCallback"
-            ),
             ProblemFilters.exclude[IncompatibleTemplateDefProblem](
               "org.apache.spark.util.collection.SortDataFormat")
           ) ++ Seq(

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -65,9 +65,6 @@ object MimaExcludes {
             // SPARK-5205
             ProblemFilters.exclude[MissingMethodProblem](
               "org.apache.spark.TaskContext.addTaskKilledListener"
-            ),
-            ProblemFilters.exclude[MissingMethodProblem](
-              "org.apache.spark.TaskContext.addTaskKilledCallback"
             )
           )
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/ReceiverSupervisor.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/ReceiverSupervisor.scala
@@ -114,12 +114,6 @@ private[streaming] abstract class ReceiverSupervisor(
     stopLatch.countDown()
   }
 
-  val stop: String => Unit = (message: String) => {
-    if (receiverState != Stopped) {
-      stop(message, None)
-    }
-  }
-
   /** Start receiver */
   def startReceiver(): Unit = synchronized {
     try {

--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/ReceiverSupervisor.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/ReceiverSupervisor.scala
@@ -115,8 +115,9 @@ private[streaming] abstract class ReceiverSupervisor(
   }
 
   val stop: String => Unit = (message: String) => {
-    if(receiverState != Stopped)
+    if (receiverState != Stopped) {
       stop(message, None)
+    }
   }
 
   /** Start receiver */

--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/ReceiverSupervisor.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/ReceiverSupervisor.scala
@@ -106,16 +106,17 @@ private[streaming] abstract class ReceiverSupervisor(
     startReceiver()
   }
 
-  val stop: String => Unit = (message: String) => {
-    stop(message, None)
-  }
-
   /** Mark the supervisor and the receiver for stopping */
   def stop(message: String, error: Option[Throwable]) {
     stoppingError = error.orNull
     stopReceiver(message, error)
     onStop(message, error)
     stopLatch.countDown()
+  }
+
+  val stop: String => Unit = (message: String) => {
+    if(receiverState != Stopped)
+      stop(message, None)
   }
 
   /** Start receiver */

--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/ReceiverSupervisor.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/ReceiverSupervisor.scala
@@ -106,6 +106,10 @@ private[streaming] abstract class ReceiverSupervisor(
     startReceiver()
   }
 
+  val stop: String => Unit = (message: String) => {
+    stop(message, None)
+  }
+
   /** Mark the supervisor and the receiver for stopping */
   def stop(message: String, error: Option[Throwable]) {
     stoppingError = error.orNull

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceiverTracker.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceiverTracker.scala
@@ -275,8 +275,9 @@ class ReceiverTracker(ssc: StreamingContext, skipReceiverLaunch: Boolean = false
         val receiver = iterator.next()
         val supervisor = new ReceiverSupervisorImpl(
           receiver, SparkEnv.get, serializableHadoopConf.value, checkpointDirOption)
-        /* Due to SPARK-5205, `Receiver` stage can not be stopped properly, we need to add a
-         * callback to do some more clean works.*/
+
+        // Due to SPARK-5205, `Receiver` stage can not be stopped properly, we need to add a
+        // callback to do some more clean works.
         context.addTaskKilledListener(context => supervisor.stop("Receiver was killed.", None))
         supervisor.start()
         supervisor.awaitTermination()

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceiverTracker.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceiverTracker.scala
@@ -284,7 +284,7 @@ class ReceiverTracker(ssc: StreamingContext, skipReceiverLaunch: Boolean = false
         val receiver = iterator.next()
         val supervisor = new ReceiverSupervisorImpl(
           receiver, SparkEnv.get, serializableHadoopConf.value, checkpointDirOption)
-        context.addOnStopCallback(supervisor.stop)
+        context.addTaskKilledListener(context => supervisor.stop("Receiver was killed.", None))
         supervisor.start()
         supervisor.awaitTermination()
       }

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceiverTracker.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceiverTracker.scala
@@ -284,7 +284,7 @@ class ReceiverTracker(ssc: StreamingContext, skipReceiverLaunch: Boolean = false
         val receiver = iterator.next()
         val supervisor = new ReceiverSupervisorImpl(
           receiver, SparkEnv.get, serializableHadoopConf.value, checkpointDirOption)
-        context.addTaskKilledListener(context => supervisor.stop("Receiver was killed.", None))
+        context.addTaskKilledCallback(context => supervisor.stop("Receiver was killed.", None))
         supervisor.start()
         supervisor.awaitTermination()
       }


### PR DESCRIPTION
The "kill" link is used to kill a stage in job. It works in any kinds of Spark job but Spark Streaming. To be specific, we can only kill the stage which is used to run "Receiver", but not kill the "Receivers". Well, the stage can be killed and cleaned from the ui, but the receivers are still alive and receiving data. I think it dose not fit with the common sense. IMHO, killing the "receiver" stage means kill the "receivers" and stopping receiving data.
