### PR TITLE
[BUILD] Remove MaxPermSize option from build/mvn for Java8

### DIFF
--- a/build/mvn
+++ b/build/mvn
@@ -142,8 +142,25 @@ if [ -n "${ZINC_INSTALL_FLAG}" -o -z "`${ZINC_BIN} -status`" ]; then
     -scala-library "${SCALA_LIBRARY}" &>/dev/null
 fi
 
+# Find the java binary
+if [ -n "${JAVA_HOME}" ]; then
+  RUNNER="${JAVA_HOME}/bin/java"
+else
+  if [ `command -v java` ]; then
+    RUNNER="java"
+  else
+    echo "JAVA_HOME is not set" >&2
+    exit 1
+  fi
+fi
+JAVA_VERSION=$("$RUNNER" -version 2>&1 | grep 'version' | sed 's/.* version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q')
+
 # Set any `mvn` options if not already present
-export MAVEN_OPTS=${MAVEN_OPTS:-"-Xmx2g -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=512m"}
+if [ "$JAVA_VERSION" -ge 18 ]; then
+  export MAVEN_OPTS=${MAVEN_OPTS:-"-Xmx2g -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=512m"}
+else
+  export MAVEN_OPTS=${MAVEN_OPTS:-"-Xmx2g -XX:ReservedCodeCacheSize=512m"}
+fi
 
 # Last, call the `mvn` command as usual
 ${MVN_BIN} "$@"

--- a/core/src/main/scala/org/apache/spark/deploy/worker/CommandUtils.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/CommandUtils.scala
@@ -114,8 +114,9 @@ object CommandUtils extends Logging {
       extraEnvironment = command.environment)
     val userClassPath = command.classPathEntries ++ Seq(classPath)
 
-    val javaVersion = System.getProperty("java.version")
-    val permGenOpt = if (!javaVersion.startsWith("1.8")) Some("-XX:MaxPermSize=128m") else None
+    val Array(major, minor, _) = System.getProperty("java.version").split("\\.", 3)
+    val javaVersion = (major + minor).toInt
+    val permGenOpt = if (javaVersion <= 17) Some("-XX:MaxPermSize=128m") else None
     Seq("-cp", userClassPath.filterNot(_.isEmpty).mkString(File.pathSeparator)) ++
       permGenOpt ++ workerLocalOpts ++ command.javaOpts ++ memoryOpts
   }

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -147,7 +147,8 @@ object SparkBuild extends PomBuild {
 
     javacOptions in (Compile, doc) ++= {
       val Array(major, minor, _) = System.getProperty("java.version").split("\\.", 3)
-      if (major.toInt >= 1 && minor.toInt >= 8) Seq("-Xdoclint:all", "-Xdoclint:-missing") else Seq.empty
+      val javaVersion = (major + minor).toInt
+      if (javaVersion >= 18) Seq("-Xdoclint:all", "-Xdoclint:-missing") else Seq.empty
     }
   )
 


### PR DESCRIPTION
In buld/mvn, MaxPermSize option is set for JVM option but Java8 don't have the option.
Also, this PR fixes something related to Java8+.
