### PR TITLE
[SPARK-2909] [MLlib] [PySpark] SparseVector in pyspark now supports indexing

### DIFF
--- a/python/pyspark/mllib/linalg.py
+++ b/python/pyspark/mllib/linalg.py
@@ -510,6 +510,22 @@ class SparseVector(Vector):
                 and np.array_equal(other.indices, self.indices)
                 and np.array_equal(other.values, self.values))
 
+    def __getitem__(self, item):
+        inds = self.indices
+        vals = self.values
+        if not isinstance(item, int):
+            raise ValueError("Indices must be of type integer")
+        if item < 0:
+            item += self.size
+        if item >= self.size or item < 0:
+            raise ValueError("Index out of bounds.")
+
+        insert_item = np.searchsorted(inds, item)
+        row_ind = inds[insert_item]
+        if row_ind == item:
+            return vals[insert_item]
+        return 0.
+
     def __ne__(self, other):
         return not self.__eq__(other)
 

--- a/python/pyspark/mllib/linalg.py
+++ b/python/pyspark/mllib/linalg.py
@@ -510,20 +510,21 @@ class SparseVector(Vector):
                 and np.array_equal(other.indices, self.indices)
                 and np.array_equal(other.values, self.values))
 
-    def __getitem__(self, item):
+    def __getitem__(self, index):
         inds = self.indices
         vals = self.values
-        if not isinstance(item, int):
-            raise ValueError("Indices must be of type integer")
-        if item < 0:
-            item += self.size
-        if item >= self.size or item < 0:
-            raise ValueError("Index out of bounds.")
+        if not isinstance(index, int):
+            raise ValueError(
+                "Indices must be of type integer, got type %s" % type(index))
+        if index < 0:
+            index += self.size
+        if index >= self.size or index < 0:
+            raise ValueError("Index %d out of bounds." % index)
 
-        insert_item = np.searchsorted(inds, item)
-        row_ind = inds[insert_item]
-        if row_ind == item:
-            return vals[insert_item]
+        insert_index = np.searchsorted(inds, index)
+        row_ind = inds[insert_index]
+        if row_ind == index:
+            return vals[insert_index]
         return 0.
 
     def __ne__(self, other):

--- a/python/pyspark/mllib/tests.py
+++ b/python/pyspark/mllib/tests.py
@@ -120,6 +120,18 @@ class VectorTests(PySparkTestCase):
         dv = DenseVector(v)
         self.assertTrue(dv.array.dtype == 'float64')
 
+    def test_sparse_vector_indexing(self):
+        sv = SparseVector(4, {1: 1, 3: 2})
+        self.assertEquals(sv[0], 0.)
+        self.assertEquals(sv[3], 2.)
+        self.assertEquals(sv[1], 1.)
+        self.assertEquals(sv[2], 0.)
+        self.assertEquals(sv[-1], 2)
+        self.assertEquals(sv[-2], 0)
+        self.assertEquals(sv[-4], 0)
+        for ind in [4, -5, 7.8]:
+            self.assertRaises(ValueError, sv.__getitem__, ind)
+
 
 class ListTests(PySparkTestCase):
 


### PR DESCRIPTION
Slightly different than the scala code which converts the sparsevector into a densevector and then checks the index.

I also hope I've added tests in the right place.
