### PR TITLE
[SPARK-5239][CORE]JdbcRDD throws "java.lang.AbstractMethodError: oracle.jdbc.driver.xxxxxx.isClosed()Z"

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/JdbcRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/JdbcRDD.scala
@@ -99,21 +99,21 @@ class JdbcRDD[T: ClassTag](
 
     override def close() {
       try {
-        if (null != rs && ! rs.isClosed()) {
+        if (null != rs) {
           rs.close()
         }
       } catch {
         case e: Exception => logWarning("Exception closing resultset", e)
       }
       try {
-        if (null != stmt && ! stmt.isClosed()) {
+        if (null != stmt) {
           stmt.close()
         }
       } catch {
         case e: Exception => logWarning("Exception closing statement", e)
       }
       try {
-        if (null != conn && ! conn.isClosed()) {
+        if (null != conn) {
           conn.close()
         }
         logInfo("closed connection")


### PR DESCRIPTION
`rs.isClosed()` will throws:

```
Exception in thread "main" java.lang.AbstractMethodError: oracle.jdbc.driver.OracleResultSetImpl.isClosed()Z
```

Similarly,`stmt.isClosed()` will throws 

```
Exception in thread "main" java.lang.AbstractMethodError: oracle.jdbc.driver.T4CPreparedStatement.isClosed()Z
```

Above exception is throwing because "isClosed()" is not implemented in the "OracleResultSetImpl" class which implements the ResultSet Interface in Ojdbc14.jar, I think use below condition to check whether resultset is null or not is enough

```
if (null != rs) { 
    rs.close()
}
```
