### PR TITLE
[SPARK-5147][Streaming] Delete the received data WAL log periodically

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/ReceiverInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/ReceiverInputDStream.scala
@@ -104,5 +104,6 @@ abstract class ReceiverInputDStream[T: ClassTag](@transient ssc_ : StreamingCont
   private[streaming] override def clearMetadata(time: Time) {
     super.clearMetadata(time)
     ssc.scheduler.receiverTracker.cleanupOldMetadata(time - rememberDuration)
+    ssc.scheduler.receiverTracker.cleanupOldReceivedBatchData(time - rememberDuration)
   }
 }

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
@@ -238,7 +238,6 @@ class JobGenerator(jobScheduler: JobScheduler) extends Logging {
   /** Clear DStream metadata for the given `time`. */
   private def clearMetadata(time: Time) {
     ssc.graph.clearMetadata(time)
-    jobScheduler.receiverTracker.cleanupOldMetadata(time - graph.batchDuration)
 
     // If checkpointing is enabled, then checkpoint,
     // else mark batch to be fully processed

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceiverTracker.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceiverTracker.scala
@@ -24,7 +24,6 @@ import scala.language.existentials
 import akka.actor._
 
 import org.apache.spark.{Logging, SerializableWritable, SparkEnv, SparkException}
-import org.apache.spark.SparkContext._
 import org.apache.spark.streaming.{StreamingContext, Time}
 import org.apache.spark.streaming.receiver.{Receiver, ReceiverSupervisorImpl, StopReceiver}
 
@@ -44,6 +43,7 @@ private[streaming] case class AddBlock(receivedBlockInfo: ReceivedBlockInfo)
 private[streaming] case class ReportError(streamId: Int, message: String, error: String)
 private[streaming] case class DeregisterReceiver(streamId: Int, msg: String, error: String)
   extends ReceiverTrackerMessage
+private[streaming] case class DeleteOldBatch(threshTime: Time) extends ReceiverTrackerMessage
 
 /**
  * This class manages the execution of the receivers of ReceiverInputDStreams. Instance of
@@ -119,10 +119,25 @@ class ReceiverTracker(ssc: StreamingContext, skipReceiverLaunch: Boolean = false
     }
   }
 
-    /** Clean up metadata older than the given threshold time */
+  /** Clean up metadata older than the given threshold time */
   def cleanupOldMetadata(cleanupThreshTime: Time) {
     receivedBlockTracker.cleanupOldBatches(cleanupThreshTime, waitForCompletion = false)
   }
+
+  /**
+   * Clean up received batch data old than the given threshold time.
+   * This is specific for write ahead log based ReceivedBlockHandler,
+   * for the previous BlockManager based ReceivedBlockHandler, the previous clearMetadata() is
+   * enough to clean the old data.
+   */
+  def cleanupOldReceivedBatchData(cleanupThreshTime: Time): Unit = {
+    // Signal the receivers to delete old batches
+    if (ssc.conf.getBoolean("spark.streaming.receiver.writeAheadLog.enable", false)) {
+      logInfo(s"Cleanup old received batch data: $cleanupThreshTime")
+      receiverInfo.values.flatMap { info => Option(info.actor) }
+        .foreach { _ ! DeleteOldBatch(cleanupThreshTime) }
+      }
+    }
 
   /** Register a receiver */
   private def registerReceiver(

--- a/streaming/src/main/scala/org/apache/spark/streaming/util/HdfsUtils.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/util/HdfsUtils.scala
@@ -63,7 +63,7 @@ private[streaming] object HdfsUtils {
   }
 
   def getFileSystemForPath(path: Path, conf: Configuration): FileSystem = {
-    // For local file systems, return the raw loca file system, such calls to flush()
+    // For local file systems, return the raw local file system, such calls to flush()
     // actually flushes the stream.
     val fs = path.getFileSystem(conf)
     fs match {


### PR DESCRIPTION
Currently received data WAL is not deleted after the timeout, this will make the data accumulated in HDFS. Here add an Akka message to notify the `ReceiverSupervisorImpl` to clean up the file accordingly.
