### PR TITLE
[SPARK-5266][Yarn]AM's numExecutorsFailed should exclude number of killExecutor

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -145,6 +145,7 @@ private[yarn] class YarnAllocator(
       val container = executorIdToContainer.remove(executorId).get
       internalReleaseContainer(container)
       numExecutorsRunning.decrementAndGet()
+      numExecutorsFailed.decrementAndGet()
       maxExecutors -= 1
       assert(maxExecutors >= 0, "Allocator killed more executors than are allocated!")
     } else {


### PR DESCRIPTION
when driver request killExecutor, am will kill container and numExecutorsFailed will increment. when numExecutorsFailed> maxNumExecutorFailures in AM, AM will exit with EXIT_MAX_EXECUTOR_FAILURES reason. so numExecutorsFailed should exclude the killExecutor from driver.@andrewor14 @tdas @sryza 
