### PR TITLE
[SPARK-5268] don't stop CoarseGrainedExecutorBackend for irrelevant DisassociatedEvent

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -88,10 +88,7 @@ private[spark] class CoarseGrainedExecutorBackend(
         logError(s"Driver $x disassociated! Shutting down.")
         System.exit(1)
       } else {
-        val localAddress = x.localAddress
-        val remoteAddress = x.remoteAddress
-        logWarning(s"Received irrelevant DisassociatedEvent [$localAddress]" +
-          s"${if (x.inbound) " <- " else " -> "}[$remoteAddress]")
+        logWarning(s"Received irrelevant DisassociatedEvent $x")
       }
 
     case StopExecutor =>

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -90,7 +90,8 @@ private[spark] class CoarseGrainedExecutorBackend(
       } else {
         val localAddress = x.localAddress
         val remoteAddress = x.remoteAddress
-        logWarning(s"Received DisassociatedEvent from $remoteAddress to $localAddress")
+        logWarning(s"Received DisassociatedEvent [$localAddress]" +
+          s"${if (x.inbound) " <- " else " -> "}[$remoteAddress]")
       }
 
     case StopExecutor =>

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -90,7 +90,7 @@ private[spark] class CoarseGrainedExecutorBackend(
       } else {
         val localAddress = x.localAddress
         val remoteAddress = x.remoteAddress
-        logWarning(s"Received DisassociatedEvent [$localAddress]" +
+        logWarning(s"Received irrelevant DisassociatedEvent [$localAddress]" +
           s"${if (x.inbound) " <- " else " -> "}[$remoteAddress]")
       }
 

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -84,8 +84,14 @@ private[spark] class CoarseGrainedExecutorBackend(
       }
 
     case x: DisassociatedEvent =>
-      logError(s"Driver $x disassociated! Shutting down.")
-      System.exit(1)
+      if (x.remoteAddress == driver.anchorPath.address) {
+        logError(s"Driver $x disassociated! Shutting down.")
+        System.exit(1)
+      } else {
+        val localAddress = x.localAddress
+        val remoteAddress = x.remoteAddress
+        logWarning(s"Received DisassociatedEvent from $remoteAddress to $localAddress")
+      }
 
     case StopExecutor =>
       logInfo("Driver commanded a shutdown")


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-5268

In CoarseGrainedExecutorBackend, we subscribe DisassociatedEvent in executor backend actor and exit the program upon receive such event...

let's consider the following case

The user may develop an Akka-based program which starts the actor with Spark's actor system and communicate with an external actor system (e.g. an Akka-based receiver in spark streaming which communicates with an external system) If the external actor system fails or disassociates with the actor within spark's system with purpose, we may receive DisassociatedEvent and the executor is restarted.

This is not the expected behavior.....

---

This is a simple fix to check the event before making the quit decision
