### PR TITLE
[Spark-5111][SQL]HiveContext and Thriftserver cannot work in secure cluster beyond hadoop2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-test<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one or more
   ~ contributor license agreements.  See the NOTICE file distributed with

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+test<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one or more
   ~ contributor license agreements.  See the NOTICE file distributed with

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
@@ -26,6 +26,7 @@ import org.apache.hive.service.server.{HiveServer2, ServerOptionsProcessor}
 import org.apache.spark.Logging
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.sql.hive.HiveContext
+import org.apache.spark.sql.hive.instrument.HiveInstrumentationAgent
 import org.apache.spark.sql.hive.thriftserver.ReflectionUtils._
 import org.apache.spark.scheduler.{SparkListenerApplicationEnd, SparkListener}
 
@@ -49,6 +50,7 @@ object HiveThriftServer2 extends Logging {
   }
 
   def main(args: Array[String]) {
+    HiveInstrumentationAgent.instrument
     val optionsProcessor = new ServerOptionsProcessor("HiveThriftServer2")
     if (!optionsProcessor.process(args)) {
       System.exit(-1)

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -40,6 +40,7 @@ import org.apache.thrift.transport.TSocket
 
 import org.apache.spark.Logging
 import org.apache.spark.sql.hive.HiveShim
+import org.apache.spark.sql.hive.instrument.HiveInstrumentationAgent
 
 private[hive] object SparkSQLCLIDriver {
   private var prompt = "spark-sql"
@@ -70,6 +71,7 @@ private[hive] object SparkSQLCLIDriver {
   }
 
   def main(args: Array[String]) {
+    HiveInstrumentationAgent.instrument
     val oproc = new OptionsProcessor()
     if (!oproc.process_stage1(args)) {
       System.exit(1)

--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -79,6 +79,11 @@
       <artifactId>avro-mapred</artifactId>
       <classifier>${avro.mapred.classifier}</classifier>
     </dependency>
+     <dependency>
+      <groupId>javassist</groupId>
+      <artifactId>javassist</artifactId>
+      <version>3.12.1.GA</version>
+    </dependency>
     <dependency>
       <groupId>org.scalacheck</groupId>
       <artifactId>scalacheck_${scala.binary.version}</artifactId>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -39,6 +39,7 @@ import org.apache.spark.sql.catalyst.analysis.{Analyzer, EliminateSubQueries, Ov
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.execution.{ExecutedCommand, ExtractPythonUdfs, QueryExecutionException, SetCommand}
 import org.apache.spark.sql.hive.execution.{DescribeHiveTableCommand, HiveNativeCommand}
+import org.apache.spark.sql.hive.instrument.HiveInstrumentationAgent
 import org.apache.spark.sql.sources.{DDLParser, DataSourceStrategy}
 import org.apache.spark.sql.types._
 
@@ -49,6 +50,7 @@ import org.apache.spark.sql.types._
 class HiveContext(sc: SparkContext) extends SQLContext(sc) {
   self =>
 
+  HiveInstrumentationAgent.instrument
   /**
    * When true, enables an experimental feature where metastore tables that use the parquet SerDe
    * are automatically converted to use the Spark SQL parquet table scan, instead of the Hive

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/instrument/HadoopThriftAuthBridge23.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/instrument/HadoopThriftAuthBridge23.scala
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.hadoop.hive.thrift
+
+import java.lang.reflect.{Field, Method}
+import java.util.Map
+import java.util.concurrent.atomic.AtomicBoolean
+import org.apache.hadoop.conf.{Configurable, Configuration}
+import org.apache.hadoop.security.SaslRpcServer
+import scala.collection.JavaConversions._
+import scala.language.implicitConversions
+
+/**
+ * Functions that bridge Thrift's SASL transports to Hadoop's SASL callback
+ * handlers and authentication classes.
+ *
+ * This is a 0.23/2.x specific implementation
+ */
+class HadoopThriftAuthBridge23 extends HadoopThriftAuthBridge20S {
+
+  /**
+   * Read and return Hadoop SASL configuration which can be configured using
+   * "hadoop.rpc.protection"
+   *
+   * @param conf
+   * @return Hadoop SASL configuration
+   */
+  override def getHadoopSaslProperties(conf: Configuration): Map[String, String] =
+  {
+    if (!HadoopThriftAuthBridge23.latch.getAndSet(true)) {
+      println("initializing HadoopThriftAuthBridge23")
+      try {
+        HadoopThriftAuthBridge23.SASL_PROPERTIES_RESOLVER_CLASS =
+          Class.forName(HadoopThriftAuthBridge23.SASL_PROP_RES_CLASSNAME);
+      } catch {
+        case e =>
+        case e => e.printStackTrace();
+          throw e
+      }
+
+      if (HadoopThriftAuthBridge23.SASL_PROPERTIES_RESOLVER_CLASS != null) {
+        // found the class, so this would be hadoop version 2.4 or newer (See
+        // HADOOP-10221, HADOOP-10451)
+        try {
+          HadoopThriftAuthBridge23.RES_GET_INSTANCE_METHOD =
+            HadoopThriftAuthBridge23.SASL_PROPERTIES_RESOLVER_CLASS
+              .getMethod("getInstance", classOf[Configuration])
+          HadoopThriftAuthBridge23.GET_DEFAULT_PROP_METHOD = HadoopThriftAuthBridge23
+            .SASL_PROPERTIES_RESOLVER_CLASS.getMethod("getDefaultProperties")
+        } catch {
+          case e => e.printStackTrace();
+            throw e
+          // this must be hadoop 2.4 , where getDefaultProperties was protected
+        }
+      }
+
+      if (HadoopThriftAuthBridge23.SASL_PROPERTIES_RESOLVER_CLASS == null
+        || HadoopThriftAuthBridge23.GET_DEFAULT_PROP_METHOD == null) {
+        // this must be a hadoop 2.4 version or earlier.
+        // Resorting to the earlier method of getting the properties, which uses SASL_PROPS field
+        try {
+          HadoopThriftAuthBridge23.SASL_PROPS_FIELD = classOf[SaslRpcServer]
+            .getField("SASL_PROPS");
+        } catch {
+          case e: NoSuchFieldException =>
+            throw new IllegalStateException("Error finding hadoop SASL_PROPS field in "
+              + classOf[SaslRpcServer].getSimpleName, e);
+        }
+      }
+    }
+    println("Instrumented method")
+    if (HadoopThriftAuthBridge23.SASL_PROPS_FIELD != null) {
+      // hadoop 2.4 and earlier way of finding the sasl property settings
+      // Initialize the SaslRpcServer to ensure QOP parameters are read from
+      // conf
+      SaslRpcServer.init(conf);
+      try {
+        return HadoopThriftAuthBridge23.SASL_PROPS_FIELD.get(null).asInstanceOf[Map[String, String]]
+      } catch {
+        case e =>
+          throw new IllegalStateException("Error finding hadoop SASL properties", e);
+      }
+    }
+    // 2.5 and later way of finding sasl property
+    try {
+      val saslPropertiesResolver: Configurable = HadoopThriftAuthBridge23
+        .RES_GET_INSTANCE_METHOD.invoke(null, conf)
+        .asInstanceOf[Configurable]
+      saslPropertiesResolver.setConf(conf);
+      return HadoopThriftAuthBridge23.GET_DEFAULT_PROP_METHOD.invoke(saslPropertiesResolver)
+        .asInstanceOf[Map[String, String]]
+    } catch {
+      case e => throw new IllegalStateException("Error finding hadoop SASL properties", e);
+    }
+  }
+}
+
+object HadoopThriftAuthBridge23 {
+  var SASL_PROPS_FIELD: Field = null
+  var SASL_PROPERTIES_RESOLVER_CLASS: Class[_] = null
+  var RES_GET_INSTANCE_METHOD: Method = _
+  var GET_DEFAULT_PROP_METHOD: Method = _
+  val SASL_PROP_RES_CLASSNAME = "org.apache.hadoop.security.SaslPropertiesResolver"
+  var latch = new AtomicBoolean(false)
+}

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/instrument/HadoopThriftAuthBridge23.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/instrument/HadoopThriftAuthBridge23.scala
@@ -44,14 +44,12 @@ class HadoopThriftAuthBridge23 extends HadoopThriftAuthBridge20S {
   override def getHadoopSaslProperties(conf: Configuration): Map[String, String] =
   {
     if (!HadoopThriftAuthBridge23.latch.getAndSet(true)) {
-      println("initializing HadoopThriftAuthBridge23")
       try {
         HadoopThriftAuthBridge23.SASL_PROPERTIES_RESOLVER_CLASS =
           Class.forName(HadoopThriftAuthBridge23.SASL_PROP_RES_CLASSNAME);
       } catch {
         case e =>
-        case e => e.printStackTrace();
-          throw e
+          throw new IllegalStateException("Error finding SaslPropertiesResolver", e);
       }
 
       if (HadoopThriftAuthBridge23.SASL_PROPERTIES_RESOLVER_CLASS != null) {
@@ -64,9 +62,8 @@ class HadoopThriftAuthBridge23 extends HadoopThriftAuthBridge20S {
           HadoopThriftAuthBridge23.GET_DEFAULT_PROP_METHOD = HadoopThriftAuthBridge23
             .SASL_PROPERTIES_RESOLVER_CLASS.getMethod("getDefaultProperties")
         } catch {
-          case e => e.printStackTrace();
-            throw e
-          // this must be hadoop 2.4 , where getDefaultProperties was protected
+          case e =>
+            throw new IllegalStateException("Error finding method getDefaultProperties", e);
         }
       }
 
@@ -84,7 +81,6 @@ class HadoopThriftAuthBridge23 extends HadoopThriftAuthBridge20S {
         }
       }
     }
-    println("Instrumented method")
     if (HadoopThriftAuthBridge23.SASL_PROPS_FIELD != null) {
       // hadoop 2.4 and earlier way of finding the sasl property settings
       // Initialize the SaslRpcServer to ensure QOP parameters are read from

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/instrument/HiveInstrumentationAgent.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/instrument/HiveInstrumentationAgent.scala
@@ -28,9 +28,6 @@ import java.util.HashMap
 import org.apache.hadoop.hive.shims.ShimLoader
 import sun.misc.Unsafe
 
-/**
- *
- */
 object HiveInstrumentationAgent {
   var latch = new AtomicBoolean(false)
   val unsafe = {
@@ -40,14 +37,9 @@ object HiveInstrumentationAgent {
   }
 
   private val pool = ClassPool.getDefault();
-
   private val newClass = pool.get("org.apache.hadoop.hive.thrift.HadoopThriftAuthBridge23")
   private val oldClass = pool.get("org.apache.hadoop.hive.thrift.HadoopThriftAuthBridge20S")
 
-  println("replaced")
-  /**
-   *
-   */
   def instrument = {
     if (ShimLoader.getHadoopShims.isSecurityEnabled && ShimLoader.getMajorVersion == "0.23")  {
       if (!latch.getAndSet(true)) {
@@ -57,7 +49,6 @@ object HiveInstrumentationAgent {
             this.swapMethodBody(targetMethod)
           }
         }
-        println("getting byte code");
         val scBytes = this.oldClass.toBytecode()
         unsafe.defineClass(null, scBytes, 0, scBytes.length,
           this.getClass.getClassLoader(), this.getClass.getProtectionDomain())
@@ -65,9 +56,6 @@ object HiveInstrumentationAgent {
     }
   }
 
-  /**
-   *
-   */
   private def swapMethodBody(targetMethod: CtMethod) {
     val desc = targetMethod.getMethodInfo().getDescriptor()
     try {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/instrument/HiveInstrumentationAgent.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/instrument/HiveInstrumentationAgent.scala
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive.instrument
+
+import javassist.ClassPool
+import javassist.CtClass
+import javassist.CtMethod
+import javassist.ClassMap
+import javassist.Modifier
+import javassist.CtField
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.HashMap
+import org.apache.hadoop.hive.shims.ShimLoader
+import sun.misc.Unsafe
+
+/**
+ *
+ */
+object HiveInstrumentationAgent {
+  var latch = new AtomicBoolean(false)
+  val unsafe = {
+    val field = classOf[Unsafe].getDeclaredField("theUnsafe");
+    field.setAccessible(true);
+    field.get(null).asInstanceOf[Unsafe]
+  }
+
+  private val pool = ClassPool.getDefault();
+
+  private val newClass = pool.get("org.apache.hadoop.hive.thrift.HadoopThriftAuthBridge23")
+  private val oldClass = pool.get("org.apache.hadoop.hive.thrift.HadoopThriftAuthBridge20S")
+
+  println("replaced")
+  /**
+   *
+   */
+  def instrument = {
+    if (ShimLoader.getHadoopShims.isSecurityEnabled && ShimLoader.getMajorVersion == "0.23")  {
+      if (!latch.getAndSet(true)) {
+        val targetMethods = oldClass.getDeclaredMethods
+        for (targetMethod <- targetMethods) {
+          if (targetMethod.getName() == "getHadoopSaslProperties") {
+            this.swapMethodBody(targetMethod)
+          }
+        }
+        println("getting byte code");
+        val scBytes = this.oldClass.toBytecode()
+        unsafe.defineClass(null, scBytes, 0, scBytes.length,
+          this.getClass.getClassLoader(), this.getClass.getProtectionDomain())
+      }
+    }
+  }
+
+  /**
+   *
+   */
+  private def swapMethodBody(targetMethod: CtMethod) {
+    val desc = targetMethod.getMethodInfo().getDescriptor()
+    try {
+      val sourceMethod = newClass.getMethod(targetMethod.getName(), desc)
+      targetMethod.setBody(sourceMethod, null)
+      println("swapMethodBody " + sourceMethod + " target: " + targetMethod)
+    } catch {
+      case _: Throwable =>
+    }
+
+  }
+}


### PR DESCRIPTION
Hive0.13 cannot work with secure cluster in hadoop-2.5 and beyound. Due to "java.lang.NoSuchFieldError: SASL_PROPS" error. Need to backport some hive-0.14 fix into spark, since there is no effort to upgrade hive to 0.14 support in spark.
