### PR TITLE
[SPARK-4630][Core]Dynamically determine optimal number of partitions

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonPartitioner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonPartitioner.scala
@@ -32,9 +32,11 @@ import org.apache.spark.util.Utils
  */
 
 private[spark] class PythonPartitioner(
-  override val numPartitions: Int,
+  var partitions: Int,
   val pyPartitionFunctionId: Long)
   extends Partitioner {
+
+  override def numPartitions = partitions
 
   override def getPartition(key: Any): Int = key match {
     case null => 0
@@ -42,6 +44,10 @@ private[spark] class PythonPartitioner(
     // let's do a modulo numPartitions in any case
     case key: Long => Utils.nonNegativeMod(key.toInt, numPartitions)
     case _ => Utils.nonNegativeMod(key.hashCode(), numPartitions)
+  }
+
+  override def setNumPartitions(numPartitions: Int) = {
+    partitions = numPartitions
   }
 
   override def equals(other: Any): Boolean = other match {

--- a/core/src/main/scala/org/apache/spark/rdd/CoGroupedRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/CoGroupedRDD.scala
@@ -114,6 +114,12 @@ class CoGroupedRDD[K](@transient var rdds: Seq[RDD[_ <: Product2[K, _]]], part: 
     array
   }
 
+  override def resetPartitions(numPartitions: Int): Array[Partition] = {
+    part.setNumPartitions(numPartitions)
+    this.partitions_ = getPartitions
+    this.partitions_
+  }
+
   override val partitioner: Some[Partitioner] = Some(part)
 
   override def compute(s: Partition, context: TaskContext): Iterator[(K, Array[Iterable[_]])] = {

--- a/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
@@ -190,6 +190,18 @@ class HadoopRDD[K, V](
     newInputFormat
   }
 
+  override def getInputSize:  Long = {
+    var totalSize:Long = 0L
+    this.partitions_.map(partition =>
+      if (partition.isInstanceOf[HadoopPartition]) {
+        val hadoopSplit = partition.asInstanceOf[HadoopPartition]
+        totalSize += hadoopSplit.inputSplit.value.getLength
+      }
+    )
+    logInfo("Input Size: " + totalSize)
+    totalSize
+  }
+
   override def getPartitions: Array[Partition] = {
     val jobConf = getJobConf()
     // add the credentials here as this can be called before SparkContext initialized

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -222,7 +222,6 @@ abstract class RDD[T: ClassTag](
       dep.rdd.resetPartitions(numPartitions)
     )
     this.partitions_ = getPartitions
-    logDebug("resetPartitions:" + this.partitions.size)
     this.partitions_
   }
 

--- a/core/src/main/scala/org/apache/spark/rdd/ShuffledRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ShuffledRDD.scala
@@ -86,6 +86,12 @@ class ShuffledRDD[K, V, C](
     Array.tabulate[Partition](part.numPartitions)(i => new ShuffledRDDPartition(i))
   }
 
+  override def resetPartitions(numPartitions: Int): Array[Partition] = {
+    part.setNumPartitions(numPartitions)
+    this.partitions_ = getPartitions
+    this.partitions_
+  }
+
   override def compute(split: Partition, context: TaskContext): Iterator[(K, C)] = {
     val dep = dependencies.head.asInstanceOf[ShuffleDependency[K, V, C]]
     SparkEnv.get.shuffleManager.getReader(dep.shuffleHandle, split.index, split.index + 1, context)

--- a/core/src/main/scala/org/apache/spark/scheduler/ActiveJob.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ActiveJob.scala
@@ -29,12 +29,24 @@ private[spark] class ActiveJob(
     val jobId: Int,
     val finalStage: Stage,
     val func: (TaskContext, Iterator[_]) => _,
-    val partitions: Array[Int],
+    var partitions: Array[Int],
     val callSite: CallSite,
     val listener: JobListener,
     val properties: Properties) {
 
-  val numPartitions = partitions.length
-  val finished = Array.fill[Boolean](numPartitions)(false)
+  var numPartitions = partitions.length
+  var finished = Array.fill[Boolean](numPartitions)(false)
   var numFinished = 0
+
+  def resetPartition(numPartitions: Int){
+    this.numPartitions = numPartitions
+    partitions = (0 until numPartitions).toArray
+    finished = Array.fill[Boolean](numPartitions)(false)
+    if(listener.isInstanceOf[JobWaiter[_]]){
+      val waiter:JobWaiter[_] = listener.asInstanceOf[JobWaiter[_]]
+      val results = new Array[Any](numPartitions)
+      waiter.resultHandler = (index, res) => results(index) = res
+      waiter.totalTasks = numPartitions
+    }
+  }
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -829,16 +829,16 @@ class DAGScheduler(
 
   private def estimateNumPartitionsOfStage(childStage: Stage): Int = {
     var inputSize:Long = 0L
-    //sum inputSize of childStage's parents stage
+    // sum inputSize of childStage's parents stage
     for (parentStage <- childStage.parents) {
-      //stage's inputSize is sum outputSize of his parents stage
+      // stage's inputSize is sum outputSize of his parents stage
       inputSize += estimateStageInputSize(parentStage)
     }
     val estimateNumPartitions = ((inputSize + bytesPerPartition - 1) / bytesPerPartition).toInt
     val numPartitions:Int = Math.min(Math.max(estimateNumPartitions, minNumPartitions),
       maxNumPartitions)
     logInfo("estimate " + childStage + " 's inputSize=" + Utils.bytesToString(inputSize) +
-      ",bytesPerPartition=" + Utils.bytesToString(bytesPerPartition) +",numPartitions=" +
+      ",bytesPerPartition=" + Utils.bytesToString(bytesPerPartition) + ",numPartitions=" +
       numPartitions)
     numPartitions
   }
@@ -871,7 +871,7 @@ class DAGScheduler(
         if (!childStage.get.isResetNumPartitions) {
           updateNumPartitionsOfStage(childStage.get, estimateNumPartitionsOfStage(childStage.get))
         } else {
-          logInfo(stage + "'s child " + childStage +" have been estimated, partitionNumber=" +
+          logInfo(stage + "'s child " + childStage + " have been estimated, partitionNumber=" +
             childStage.get.numPartitions)
         }
         stageIdToChildStage.remove(stage.id)

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -89,6 +89,7 @@ class DAGScheduler(
   private[scheduler] val stageIdToStage = new HashMap[Int, Stage]
   private[scheduler] val shuffleToMapStage = new HashMap[Int, Stage]
   private[scheduler] val jobIdToActiveJob = new HashMap[Int, ActiveJob]
+  private[scheduler] val stageIdToChildStage = new HashMap[Int, Stage]
 
   // Stages we need to run whose parents aren't done
   private[scheduler] val waitingStages = new HashSet[Stage]
@@ -126,6 +127,23 @@ class DAGScheduler(
 
   /** If enabled, FetchFailed will not cause stage retry, in order to surface the problem. */
   private val disallowStageRetryForTest = sc.getConf.getBoolean("spark.test.noStageRetry", false)
+
+  private var isAutoPartition = sc.getConf.getBoolean("spark.reduce.autoPartition", false)
+  private var minNumPartitions = sc.getConf.getInt("spark.reduce.partition.min", 2)
+  private var maxNumPartitions = sc.getConf.getInt("spark.reduce.partition.max", 2)
+  private var bytesPerPartition = sc.getConf.getInt("spark.reduce.per.partition.bytes",
+    256 * 1024 * 1024)
+  private var isAutoPartitionForTest = false
+
+  def setAutoPartitionForTest(isAutoPartitionForTest: Boolean, maxNumPartitions: Int,
+                              bytesPerPartition: Int){
+    this.isAutoPartitionForTest = isAutoPartitionForTest
+    this.isAutoPartition = isAutoPartitionForTest
+    if (isAutoPartitionForTest) {
+      this.maxNumPartitions = maxNumPartitions
+      this.bytesPerPartition = bytesPerPartition
+    }
+  }
 
   private def initializeEventProcessActor() {
     // blocking the thread until supervisor is started, which ensures eventProcessActor is
@@ -779,6 +797,9 @@ class DAGScheduler(
           submitMissingTasks(stage, jobId.get)
         } else {
           for (parent <- missing) {
+            if(isAutoPartition){
+              stageIdToChildStage(parent.id) = stage
+            }
             submitStage(parent)
           }
           waitingStages += stage
@@ -789,11 +810,75 @@ class DAGScheduler(
     }
   }
 
+  private def estimateStageInputSize(stage: Stage): Long = {
+    var inputSize:Long = 0L
+    if (stage.parents.isEmpty) {// when first level stage, compute rdd.inputSize
+      inputSize += stage.rdd.getInputSize
+    } else {
+      for (parentStage <- stage.parents) {
+        if(parentStage.isAvailable){
+          inputSize += parentStage.getOutputSize
+        } else {
+          inputSize += estimateStageInputSize(parentStage)
+        }
+      }
+    }
+    logInfo("estimate " + stage + " 's inputSize=" + Utils.bytesToString(inputSize))
+    inputSize
+  }
+
+  private def estimateNumPartitionsOfStage(childStage: Stage): Int = {
+    var inputSize:Long = 0L
+    //sum inputSize of childStage's parents stage
+    for (parentStage <- childStage.parents) {
+      //stage's inputSize is sum outputSize of his parents stage
+      inputSize += estimateStageInputSize(parentStage)
+    }
+    val estimateNumPartitions = ((inputSize + bytesPerPartition - 1) / bytesPerPartition).toInt
+    val numPartitions:Int = Math.min(Math.max(estimateNumPartitions, minNumPartitions),
+      maxNumPartitions)
+    logInfo("estimate " + childStage + " 's inputSize=" + Utils.bytesToString(inputSize) +
+      ",bytesPerPartition=" + Utils.bytesToString(bytesPerPartition) +",numPartitions=" +
+      numPartitions)
+    numPartitions
+  }
+
+  private def updateNumPartitionsOfStage(stage: Stage, numPartitions: Int) {
+    logInfo("update " + stage + " 's  numPartitions=" + numPartitions)
+    for (parentStage <- stage.parents) {
+      if (parentStage.shuffleDep.isDefined) {
+        logInfo("update " + parentStage + " 's shuffleDep's numPartitions=" + numPartitions)
+        val partitioner:Partitioner = parentStage.shuffleDep.get.partitioner
+        if (!isAutoPartitionForTest) {
+          partitioner.setNumPartitions(numPartitions)
+        }
+      }
+    }
+
+    stage.resetNumPartitions(numPartitions)
+    logInfo("update " + stage + " 's  numPartitions=" + numPartitions + " finished.")
+  }
+
   /** Called when stage's parents are available and we can now do its task. */
   private def submitMissingTasks(stage: Stage, jobId: Int) {
     logDebug("submitMissingTasks(" + stage + ")")
     // Get our pending tasks and remember them in our pendingTasks entry
     stage.pendingTasks.clear()
+
+    if(isAutoPartition){
+      if (stageIdToChildStage.contains(stage.id)) {
+        val childStage = stageIdToChildStage.get(stage.id)
+        if (!childStage.get.isResetNumPartitions) {
+          updateNumPartitionsOfStage(childStage.get, estimateNumPartitionsOfStage(childStage.get))
+        } else {
+          logInfo(stage + "'s child " + childStage +" have been estimated, partitionNumber=" +
+            childStage.get.numPartitions)
+        }
+        stageIdToChildStage.remove(stage.id)
+      } else {
+        logInfo(stage + " has no child stage ")
+      }
+    }
 
     // First figure out the indexes of partition ids to compute.
     val partitionsToCompute: Seq[Int] = {

--- a/core/src/main/scala/org/apache/spark/scheduler/JobWaiter.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/JobWaiter.scala
@@ -24,8 +24,8 @@ package org.apache.spark.scheduler
 private[spark] class JobWaiter[T](
     dagScheduler: DAGScheduler,
     val jobId: Int,
-    totalTasks: Int,
-    resultHandler: (Int, T) => Unit)
+    var totalTasks: Int,
+    var resultHandler: (Int, T) => Unit)
   extends JobListener {
 
   private var finishedTasks = 0

--- a/core/src/main/scala/org/apache/spark/scheduler/Stage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Stage.scala
@@ -22,7 +22,7 @@ import scala.collection.mutable.HashSet
 import org.apache.spark._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.BlockManagerId
-import org.apache.spark.util.CallSite
+import org.apache.spark.util.{Utils, CallSite}
 
 /**
  * A stage is a set of independent tasks all computing the same function that need to run as part

--- a/core/src/main/scala/org/apache/spark/scheduler/Stage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Stage.scala
@@ -50,7 +50,7 @@ import org.apache.spark.util.CallSite
 private[spark] class Stage(
     val id: Int,
     val rdd: RDD[_],
-    val numTasks: Int,
+    var numTasks: Int,
     val shuffleDep: Option[ShuffleDependency[_, _, _]],  // Output shuffle if stage is a map stage
     val parents: List[Stage],
     val jobId: Int,
@@ -58,9 +58,11 @@ private[spark] class Stage(
   extends Logging {
 
   val isShuffleMap = shuffleDep.isDefined
-  val numPartitions = rdd.partitions.size
-  val outputLocs = Array.fill[List[MapStatus]](numPartitions)(Nil)
+  var numPartitions = rdd.partitions.size
+  var outputLocs = Array.fill[List[MapStatus]](numPartitions)(Nil)
   var numAvailableOutputs = 0
+  var outputSize:Long = -1L
+  var isResetNumPartitions:Boolean = false
 
   /** Set of jobs that this stage belongs to. */
   val jobIds = new HashSet[Int]
@@ -121,6 +123,41 @@ private[spark] class Stage(
     if (becameUnavailable) {
       logInfo("%s is now unavailable on executor %s (%d/%d, %s)".format(
         this, execId, numAvailableOutputs, numPartitions, isAvailable))
+    }
+  }
+
+  def getOutputSize(): Long = {
+    if (outputSize < 0) {
+      updateOutputSize
+    }
+    outputSize
+  }
+
+  def updateOutputSize() {
+    outputSize = 0
+    for (partition <- 0 until numPartitions) {
+      val prevList = outputLocs(partition)
+      prevList.foreach { mapStatus =>
+        outputSize += mapStatus.getUncompressedSize
+      }
+    }
+    logInfo("%s 's numPartition:%d outputSize is %s".format(this, numPartitions,
+      Utils.bytesToString(outputSize)))
+  }
+
+  def resetNumPartitions(partitions: Int) {
+    if (!isResetNumPartitions) {
+      numPartitions = rdd.resetPartitions(partitions).size
+      logInfo("after " + rdd + " reset " + numPartitions +
+        " partitions, actual paritionNumber is " + numPartitions)
+      latestInfo = StageInfo.fromStage(this)
+      outputLocs = Array.fill[List[MapStatus]](numPartitions)(Nil)
+      numTasks = numPartitions
+      if (!isShuffleMap) {
+        val job = resultOfJob.get
+        job.resetPartition(numPartitions)
+      }
+      isResetNumPartitions = true
     }
   }
 


### PR DESCRIPTION
stages in application have different size of data. if user doesnot set numPartitions for any stages, spark will use same defaultParallelism as partitons.
then in DAGScheduler number of stage's running tasks is equal to partition size of stage.so usually this number is a same value.
so if number of stage's partitions is too small, then task need to process large mount of data and slows down due to spilling or gc.
if number of stage's partitions is too large, there is big cost in schedule.
To improve performance of application, we need to determine optimal number of partitions according to stage's input data size.
there are two steps:
1. estimate number of Stage's Partitions
according to its parent stages's input data size and spark.reduce.per.partition.bytes configuration we can determine number of stage's partitions.
how to get parent stages's input data Size?
if it has no parent, we get its inputSize through summing its input path's length.
else if it has parents, but its parents is no available, so we get its parents' input data size.
else if its parents is avilable, we just compute its parents' shuffle data size as its input size.
2. update Stage's Partitioner
firstly, update partition of parents' shuffleDep. that make shuffleMapTask write wanted number of partition files.
and then, update stage's information, particularly stage's rdd. it make stage's shuffleRDD can correctly pull data from map task.

finally, now this feature can be turned off/on with a configuration option.

TODO:
1. consider spark.shuffle.memoryFraction to determine spark.reduce.per.partition.bytes configuration.
2. when stage is final stage, resultHandler's value cannot be returned to SparkContext because partitions has been changed.
3. when number of stage's tasks has been changed, report stage's new information to UI.before submitStage,event SparkListenerJobStart that include all stage Infos of job has been post to listenerBus.
@ksakellis  @sryza @JoshRosen @rxin
