### PR TITLE
[MLlib] [SPARK-5301] Missing conversions and operations on IndexedRowMatrix and CoordinateMatrix

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/CoordinateMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/CoordinateMatrix.scala
@@ -69,6 +69,11 @@ class CoordinateMatrix(
     nRows
   }
 
+  /** Transposes this CoordinateMatrix. */
+  def transpose(): CoordinateMatrix = {
+    new CoordinateMatrix(entries.map(x => MatrixEntry(x.j, x.i, x.value)), numCols(), numRows())
+  }
+
   /** Converts to IndexedRowMatrix. The number of columns must be within the integer range. */
   def toIndexedRowMatrix(): IndexedRowMatrix = {
     val nl = numCols()

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrix.scala
@@ -84,9 +84,13 @@ class IndexedRowMatrix(
       val rowIndex = row.index
       row.vector match {
         case SparseVector(size, indices, values) =>
-          Array.tabulate(indices.size)(x => MatrixEntry(rowIndex, indices(x), values(x)))
+          indices.zip(values).map { case (i, iVal) =>
+            MatrixEntry(rowIndex, i, iVal)
+          }
         case DenseVector(values) =>
-          Array.tabulate(values.size)(x => MatrixEntry(rowIndex, x, values(x)))
+          values.zipWithIndex.map { case (iVal, i) =>
+            MatrixEntry(rowIndex, i, iVal)
+          }
       }
     }
     new CoordinateMatrix(entries, numRows(), numCols())

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrix.scala
@@ -84,13 +84,9 @@ class IndexedRowMatrix(
       val rowIndex = row.index
       row.vector match {
         case SparseVector(size, indices, values) =>
-          indices.zip(values).map { case (i, iVal) =>
-            MatrixEntry(rowIndex, i, iVal)
-          }
+          Iterator.tabulate(indices.size)(x => MatrixEntry(rowIndex, indices(x), values(x)))
         case DenseVector(values) =>
-          values.zipWithIndex.map { case (iVal, i) =>
-            MatrixEntry(rowIndex, i, iVal)
-          }
+          Iterator.tabulate(values.size)(x => MatrixEntry(rowIndex, x, values(x)))
       }
     }
     new CoordinateMatrix(entries, numRows(), numCols())

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrix.scala
@@ -24,8 +24,6 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.mllib.linalg._
 import org.apache.spark.mllib.linalg.SingularValueDecomposition
 
-import scala.collection.mutable.ListBuffer
-
 /**
  * :: Experimental ::
  * Represents a row of [[org.apache.spark.mllib.linalg.distributed.IndexedRowMatrix]].

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrix.scala
@@ -84,9 +84,9 @@ class IndexedRowMatrix(
       val rowIndex = row.index
       row.vector match {
         case SparseVector(size, indices, values) =>
-          Iterator.tabulate(indices.size)(x => MatrixEntry(rowIndex, indices(x), values(x)))
+          Iterator.tabulate(indices.size)(i => MatrixEntry(rowIndex, indices(i), values(i)))
         case DenseVector(values) =>
-          Iterator.tabulate(values.size)(x => MatrixEntry(rowIndex, x, values(x)))
+          Iterator.tabulate(values.size)(i => MatrixEntry(rowIndex, i, values(i)))
       }
     }
     new CoordinateMatrix(entries, numRows(), numCols())

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/distributed/CoordinateMatrixSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/distributed/CoordinateMatrixSuite.scala
@@ -73,6 +73,11 @@ class CoordinateMatrixSuite extends FunSuite with MLlibTestSparkContext {
     assert(mat.toBreeze() === expected)
   }
 
+  test("transpose") {
+    val transposed = mat.transpose()
+    assert(mat.toBreeze().t === transposed.toBreeze())
+  }
+
   test("toIndexedRowMatrix") {
     val indexedRowMatrix = mat.toIndexedRowMatrix()
     val expected = BDM(

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrixSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrixSuite.scala
@@ -80,6 +80,14 @@ class IndexedRowMatrixSuite extends FunSuite with MLlibTestSparkContext {
     assert(rowMat.rows.collect().toSeq === data.map(_.vector).toSeq)
   }
 
+  test("toCoordinateMatrix") {
+    val idxRowMat = new IndexedRowMatrix(indexedRows)
+    val coordMat = idxRowMat.toCoordinateMatrix()
+    assert(coordMat.numRows() === m)
+    assert(coordMat.numCols() === n)
+    assert(coordMat.toBreeze() === idxRowMat.toBreeze())
+  }
+
   test("multiply a local matrix") {
     val A = new IndexedRowMatrix(indexedRows)
     val B = Matrices.dense(3, 2, Array(0.0, 1.0, 2.0, 3.0, 4.0, 5.0))


### PR DESCRIPTION
- Transpose is missing from CoordinateMatrix (this is cheap to compute, so it should be there)
- IndexedRowMatrix should be convertable to CoordinateMatrix (conversion added)

Tests for both added.
