### PR TITLE
use defaultParallelism for defaultMinPartitions

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1472,10 +1472,10 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
 
   /** Default min number of partitions for Hadoop RDDs when not given by user */
   @deprecated("use defaultMinPartitions", "1.0.0")
-  def defaultMinSplits: Int = math.min(defaultParallelism, 2)
+  def defaultMinSplits: Int = math.max(defaultParallelism, 2)
 
   /** Default min number of partitions for Hadoop RDDs when not given by user */
-  def defaultMinPartitions: Int = math.min(defaultParallelism, 2)
+  def defaultMinPartitions: Int = math.max(defaultParallelism, 2)
 
   private val nextShuffleId = new AtomicInteger(0)
 


### PR DESCRIPTION
The current configuration will always return 2 for defaultMinPartitions as the min with defaultParallelism is taken.
I suggest to use "max" so it makes it actually possible to determine how many splits are done, e.g. when trying the keep the partition  smaller in memory.
