### PR TITLE
[SPARK-5257] [MLlib] SparseVector indices must be non-negative

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
@@ -444,6 +444,7 @@ class SparseVector(
     val values: Array[Double]) extends Vector {
 
   require(indices.length == values.length)
+  indices.map(index => require(index >= 0, s"Got negative index=$index"))
 
   override def toString: String =
     "(%s,%s,%s)".format(size, indices.mkString("[", ",", "]"), values.mkString("[", ",", "]"))

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
@@ -250,4 +250,11 @@ class VectorsSuite extends FunSuite {
     assert(Vectors.norm(sv, 3.7) ~== math.pow(sv.toArray.foldLeft(0.0)((a, v) =>
       a + math.pow(math.abs(v), 3.7)), 1.0 / 3.7) relTol 1E-8)
   }
+
+  test("SparseVector negative indices error") {
+    intercept[IllegalArgumentException] {
+      val sv = Vectors.sparse(3, Array(0, -1), Array(2, 5))
+    }
+  }
+
 }

--- a/python/pyspark/mllib/linalg.py
+++ b/python/pyspark/mllib/linalg.py
@@ -335,8 +335,8 @@ class SparseVector(Vector):
                 self.indices = np.array(args[0], dtype=np.int32)
                 self.values = np.array(args[1], dtype=np.float64)
             assert len(self.indices) == len(self.values), "index and value arrays not same length"
-            if np.any(self.indices < 0):
-                raise ValueError("indices should be positive.")
+            if np.min(self.indices) < 0:
+                raise ValueError("indices must be non-negative.")
             for i in xrange(len(self.indices) - 1):
                 if self.indices[i] >= self.indices[i + 1]:
                     raise TypeError("indices array must be sorted")

--- a/python/pyspark/mllib/linalg.py
+++ b/python/pyspark/mllib/linalg.py
@@ -335,6 +335,8 @@ class SparseVector(Vector):
                 self.indices = np.array(args[0], dtype=np.int32)
                 self.values = np.array(args[1], dtype=np.float64)
             assert len(self.indices) == len(self.values), "index and value arrays not same length"
+            if np.any(self.indices < 0):
+                raise ValueError("indices should be positive.")
             for i in xrange(len(self.indices) - 1):
                 if self.indices[i] >= self.indices[i + 1]:
                     raise TypeError("indices array must be sorted")

--- a/python/pyspark/mllib/tests.py
+++ b/python/pyspark/mllib/tests.py
@@ -132,6 +132,9 @@ class VectorTests(PySparkTestCase):
         for ind in [4, -5, 7.8]:
             self.assertRaises(ValueError, sv.__getitem__, ind)
 
+    def test_sparse_vector_neg_indices(self):
+        self.assertRaises(ValueError, SparseVector, 3, (-1, 3), (0, 3))
+
 
 class ListTests(PySparkTestCase):
 


### PR DESCRIPTION
Scala afaik does not support negative indexing. And fail early if negative indices are used.
