### PR TITLE
[SPARK-5317]Set BoostingStrategy.defaultParams With Enumeration Algo.Classification or Algo.Regression

### DIFF
--- a/docs/mllib-ensembles.md
+++ b/docs/mllib-ensembles.md
@@ -506,7 +506,7 @@ JavaRDD<LabeledPoint> testData = splits[1];
 
 // Train a GradientBoostedTrees model.
 //  The defaultParams for Classification use LogLoss by default.
-BoostingStrategy boostingStrategy = BoostingStrategy.defaultParams(Algo.Classification);
+BoostingStrategy boostingStrategy = BoostingStrategy.defaultParams(Algo.Classification());
 boostingStrategy.setNumIterations(3); // Note: Use more iterations in practice.
 boostingStrategy.getTreeStrategy().setNumClassesForClassification(2);
 boostingStrategy.getTreeStrategy().setMaxDepth(5);
@@ -614,7 +614,7 @@ JavaRDD<LabeledPoint> testData = splits[1];
 
 // Train a GradientBoostedTrees model.
 //  The defaultParams for Regression use SquaredError by default.
-BoostingStrategy boostingStrategy = BoostingStrategy.defaultParams(Algo.Regression);
+BoostingStrategy boostingStrategy = BoostingStrategy.defaultParams(Algo.Regression());
 boostingStrategy.setNumIterations(3); // Note: Use more iterations in practice.
 boostingStrategy.getTreeStrategy().setMaxDepth(5);
 //  Empty categoricalFeaturesInfo indicates all features are continuous.

--- a/docs/mllib-ensembles.md
+++ b/docs/mllib-ensembles.md
@@ -456,7 +456,7 @@ val (trainingData, testData) = (splits(0), splits(1))
 
 // Train a GradientBoostedTrees model.
 //  The defaultParams for Classification use LogLoss by default.
-val boostingStrategy = BoostingStrategy.defaultParams("Classification")
+val boostingStrategy = BoostingStrategy.defaultParams(Algo.Classification)
 boostingStrategy.numIterations = 3 // Note: Use more iterations in practice.
 boostingStrategy.treeStrategy.numClassesForClassification = 2
 boostingStrategy.treeStrategy.maxDepth = 5
@@ -506,7 +506,7 @@ JavaRDD<LabeledPoint> testData = splits[1];
 
 // Train a GradientBoostedTrees model.
 //  The defaultParams for Classification use LogLoss by default.
-BoostingStrategy boostingStrategy = BoostingStrategy.defaultParams("Classification");
+BoostingStrategy boostingStrategy = BoostingStrategy.defaultParams(Algo.Classification);
 boostingStrategy.setNumIterations(3); // Note: Use more iterations in practice.
 boostingStrategy.getTreeStrategy().setNumClassesForClassification(2);
 boostingStrategy.getTreeStrategy().setMaxDepth(5);
@@ -564,7 +564,7 @@ val (trainingData, testData) = (splits(0), splits(1))
 
 // Train a GradientBoostedTrees model.
 //  The defaultParams for Regression use SquaredError by default.
-val boostingStrategy = BoostingStrategy.defaultParams("Regression")
+val boostingStrategy = BoostingStrategy.defaultParams(Algo.Regression)
 boostingStrategy.numIterations = 3 // Note: Use more iterations in practice.
 boostingStrategy.treeStrategy.maxDepth = 5
 //  Empty categoricalFeaturesInfo indicates all features are continuous.
@@ -614,7 +614,7 @@ JavaRDD<LabeledPoint> testData = splits[1];
 
 // Train a GradientBoostedTrees model.
 //  The defaultParams for Regression use SquaredError by default.
-BoostingStrategy boostingStrategy = BoostingStrategy.defaultParams("Regression");
+BoostingStrategy boostingStrategy = BoostingStrategy.defaultParams(Algo.Regression);
 boostingStrategy.setNumIterations(3); // Note: Use more iterations in practice.
 boostingStrategy.getTreeStrategy().setMaxDepth(5);
 //  Empty categoricalFeaturesInfo indicates all features are continuous.

--- a/docs/mllib-ensembles.md
+++ b/docs/mllib-ensembles.md
@@ -456,7 +456,7 @@ val (trainingData, testData) = (splits(0), splits(1))
 
 // Train a GradientBoostedTrees model.
 //  The defaultParams for Classification use LogLoss by default.
-val boostingStrategy = BoostingStrategy.defaultParams(Algo.Classification)
+val boostingStrategy = BoostingStrategy.defaultParams("Classification")
 boostingStrategy.numIterations = 3 // Note: Use more iterations in practice.
 boostingStrategy.treeStrategy.numClassesForClassification = 2
 boostingStrategy.treeStrategy.maxDepth = 5
@@ -506,7 +506,7 @@ JavaRDD<LabeledPoint> testData = splits[1];
 
 // Train a GradientBoostedTrees model.
 //  The defaultParams for Classification use LogLoss by default.
-BoostingStrategy boostingStrategy = BoostingStrategy.defaultParams(Algo.Classification());
+BoostingStrategy boostingStrategy = BoostingStrategy.defaultParams("Classification");
 boostingStrategy.setNumIterations(3); // Note: Use more iterations in practice.
 boostingStrategy.getTreeStrategy().setNumClassesForClassification(2);
 boostingStrategy.getTreeStrategy().setMaxDepth(5);
@@ -564,7 +564,7 @@ val (trainingData, testData) = (splits(0), splits(1))
 
 // Train a GradientBoostedTrees model.
 //  The defaultParams for Regression use SquaredError by default.
-val boostingStrategy = BoostingStrategy.defaultParams(Algo.Regression)
+val boostingStrategy = BoostingStrategy.defaultParams("Regression")
 boostingStrategy.numIterations = 3 // Note: Use more iterations in practice.
 boostingStrategy.treeStrategy.maxDepth = 5
 //  Empty categoricalFeaturesInfo indicates all features are continuous.
@@ -614,7 +614,7 @@ JavaRDD<LabeledPoint> testData = splits[1];
 
 // Train a GradientBoostedTrees model.
 //  The defaultParams for Regression use SquaredError by default.
-BoostingStrategy boostingStrategy = BoostingStrategy.defaultParams(Algo.Regression());
+BoostingStrategy boostingStrategy = BoostingStrategy.defaultParams("Regression");
 boostingStrategy.setNumIterations(3); // Note: Use more iterations in practice.
 boostingStrategy.getTreeStrategy().setMaxDepth(5);
 //  Empty categoricalFeaturesInfo indicates all features are continuous.

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/BoostingStrategy.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/BoostingStrategy.scala
@@ -88,4 +88,25 @@ object BoostingStrategy {
         throw new IllegalArgumentException(s"$algo is not supported by boosting.")
     }
   }
+
+  /**
+   * Returns default configuration for the boosting algorithm
+   * @param algo Learning goal.  Supported:
+   *             [[org.apache.spark.mllib.tree.configuration.Algo.Classification]],
+   *             [[org.apache.spark.mllib.tree.configuration.Algo.Regression]]
+   * @return Configuration for boosting algorithm
+   */
+  def defaultParams(algo: Algo): BoostingStrategy = {
+    val treeStragtegy = Strategy.defaultStategy(algo)
+    treeStragtegy.maxDepth = 3
+    algo match {
+      case Algo.Classification =>
+        treeStragtegy.numClasses = 2
+        new BoostingStrategy(treeStragtegy, LogLoss)
+      case Algo.Regression =>
+        new BoostingStrategy(treeStragtegy, SquaredError)
+      case _ =>
+        throw new IllegalArgumentException(s"$algo is not supported by boosting.")
+    }
+  }
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/BoostingStrategy.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/BoostingStrategy.scala
@@ -76,17 +76,7 @@ object BoostingStrategy {
    * @return Configuration for boosting algorithm
    */
   def defaultParams(algoStr: String): BoostingStrategy = {
-    val treeStrategy = Strategy.defaultStrategy(algoStr)
-    treeStrategy.maxDepth = 3
-    algoStr match {
-      case "Classification" =>
-        treeStrategy.numClasses = 2
-        new BoostingStrategy(treeStrategy, LogLoss)
-      case "Regression" =>
-        new BoostingStrategy(treeStrategy, SquaredError)
-      case _ =>
-        throw new IllegalArgumentException(s"$algoStr is not supported by boosting.")
-    }
+    defaultParams(Algo.fromString(algoStr))
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/BoostingStrategy.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/BoostingStrategy.scala
@@ -70,22 +70,22 @@ object BoostingStrategy {
 
   /**
    * Returns default configuration for the boosting algorithm
-   * @param algo Learning goal.  Supported:
+   * @param algoStr Learning goal.  Supported:
    *             [[org.apache.spark.mllib.tree.configuration.Algo.Classification]],
    *             [[org.apache.spark.mllib.tree.configuration.Algo.Regression]]
    * @return Configuration for boosting algorithm
    */
-  def defaultParams(algo: String): BoostingStrategy = {
-    val treeStrategy = Strategy.defaultStrategy(algo)
+  def defaultParams(algoStr: String): BoostingStrategy = {
+    val treeStrategy = Strategy.defaultStrategy(algoStr)
     treeStrategy.maxDepth = 3
-    algo match {
+    algoStr match {
       case "Classification" =>
         treeStrategy.numClasses = 2
         new BoostingStrategy(treeStrategy, LogLoss)
       case "Regression" =>
         new BoostingStrategy(treeStrategy, SquaredError)
       case _ =>
-        throw new IllegalArgumentException(s"$algo is not supported by boosting.")
+        throw new IllegalArgumentException(s"$algoStr is not supported by boosting.")
     }
   }
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/BoostingStrategy.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/BoostingStrategy.scala
@@ -70,13 +70,11 @@ object BoostingStrategy {
 
   /**
    * Returns default configuration for the boosting algorithm
-   * @param algoStr Learning goal.  Supported:
-   *             [[org.apache.spark.mllib.tree.configuration.Algo.Classification]],
-   *             [[org.apache.spark.mllib.tree.configuration.Algo.Regression]]
+   * @param algo Learning goal.  Supported: "Classification" or "Regression"
    * @return Configuration for boosting algorithm
    */
-  def defaultParams(algoStr: String): BoostingStrategy = {
-    defaultParams(Algo.fromString(algoStr))
+  def defaultParams(algo: String): BoostingStrategy = {
+    defaultParams(Algo.fromString(algo))
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/Strategy.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/Strategy.scala
@@ -171,9 +171,11 @@ object Strategy {
 
   /**
    * Construct a default set of parameters for [[org.apache.spark.mllib.tree.DecisionTree]]
-   * @param algoStr  "Classification" or "Regression"
+   * @param algo  "Classification" or "Regression"
    */
-  def defaultStrategy(algoStr: String): Strategy = defaultStategy(Algo.fromString(algoStr))
+  def defaultStrategy(algo: String): Strategy = {
+    defaultStategy(Algo.fromString(algo))
+  }
 
   /**
    * Construct a default set of parameters for [[org.apache.spark.mllib.tree.DecisionTree]]

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/Strategy.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/Strategy.scala
@@ -181,4 +181,17 @@ object Strategy {
       new Strategy(algo = Regression, impurity = Variance, maxDepth = 10,
         numClasses = 0)
   }
+
+  /**
+   * Construct a default set of parameters for [[org.apache.spark.mllib.tree.DecisionTree]]
+   * @param algo Algo.Classification or Algo.Regression
+   */
+  def defaultStategy(algo: Algo): Strategy = algo match {
+    case Algo.Classification =>
+      new Strategy(algo = Classification, impurity = Gini, maxDepth = 10,
+        numClasses = 2)
+    case Algo.Regression =>
+      new Strategy(algo = Regression, impurity = Variance, maxDepth = 10,
+        numClasses = 0)
+  }
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/Strategy.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/Strategy.scala
@@ -173,14 +173,7 @@ object Strategy {
    * Construct a default set of parameters for [[org.apache.spark.mllib.tree.DecisionTree]]
    * @param algoStr  "Classification" or "Regression"
    */
-  def defaultStrategy(algoStr: String): Strategy = algoStr match {
-    case "Classification" =>
-      new Strategy(algo = Classification, impurity = Gini, maxDepth = 10,
-        numClasses = 2)
-    case "Regression" =>
-      new Strategy(algo = Regression, impurity = Variance, maxDepth = 10,
-        numClasses = 0)
-  }
+  def defaultStrategy(algoStr: String): Strategy = defaultStategy(Algo.fromString(algoStr))
 
   /**
    * Construct a default set of parameters for [[org.apache.spark.mllib.tree.DecisionTree]]

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/Strategy.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/configuration/Strategy.scala
@@ -171,9 +171,9 @@ object Strategy {
 
   /**
    * Construct a default set of parameters for [[org.apache.spark.mllib.tree.DecisionTree]]
-   * @param algo  "Classification" or "Regression"
+   * @param algoStr  "Classification" or "Regression"
    */
-  def defaultStrategy(algo: String): Strategy = algo match {
+  def defaultStrategy(algoStr: String): Strategy = algoStr match {
     case "Classification" =>
       new Strategy(algo = Classification, impurity = Gini, maxDepth = 10,
         numClasses = 2)


### PR DESCRIPTION
JIRA Issue: https://issues.apache.org/jira/browse/SPARK-5317
When setting the BoostingStrategy.defaultParams("Classification"), It's more straightforward to set it with the Enumeration Algo.Classification, just like BoostingStragety.defaultParams(Algo.Classification).
I overload the method BoostingStragety.defaultParams().
