### PR TITLE
[SPARK-5158] [core] [security] Spark standalone mode can authenticate against a Kerberos-secured Hadoop cluster

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/StandaloneSparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/StandaloneSparkHadoopUtil.scala
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy
+
+import java.security.PrivilegedAction
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.mapred.JobConf
+import org.apache.hadoop.security.UserGroupInformation
+import org.apache.spark.{SparkConf, SparkEnv, Logging}
+import sun.security.jgss.krb5.Krb5InitCredential
+
+import scala.sys.process.Process
+
+private[spark] class StandaloneSparkHadoopUtil extends SparkHadoopUtil {
+
+  val hadoopSecurityAuthenticationKey = "spark.hadoop.security.authentication"
+  val principalKey = "spark.hadoop.dfs.namenode.kerberos.principal"
+  val keytabKey = "spark.hadoop.dfs.namenode.keytab.file"
+  val securityEnabledButKeyNotDefined = "Hadoop security was enabled, but %s" +
+    "was not set in the Spark configuration."
+
+  // Lazily evaluated upon invoking loginAsSparkUserAndReturnUGI()
+  lazy val loggedInUser: UserGroupInformation = {
+    val authenticationType = SparkEnv.get.conf.get(hadoopSecurityAuthenticationKey, "simple")
+    if (authenticationType.equalsIgnoreCase("kerberos")) {
+      logInfo("Setting up kerberos to authenticate")
+      SparkEnv.get.conf.getOption(principalKey) match {
+        case Some(principal) =>
+          SparkEnv.get.conf.getOption(keytabKey) match {
+            case Some(keytab) =>
+              UserGroupInformation.setConfiguration(newConfiguration(SparkEnv.get.conf))
+              loginUserFromKeytab(principal, keytab)
+              UserGroupInformation.getLoginUser()
+            case None =>
+              val errorMsg = securityEnabledButKeyNotDefined.format(keytabKey)
+              logError(errorMsg)
+              throw new IllegalStateException(errorMsg)
+          }
+        case None =>
+          val errorMsg = securityEnabledButKeyNotDefined.format(principalKey)
+          logError(errorMsg)
+          throw new IllegalStateException(errorMsg)
+      }
+    } else {
+      logInfo("Not using Kerberos to authenticate to Hadoop.")
+      UserGroupInformation.getCurrentUser()
+    }
+  }
+  override def getAuthenticatedUgiForSparkUser(user: String): UserGroupInformation = {
+    UserGroupInformation.createProxyUser(user, loginAsSparkUserAndReturnUGI())
+  }
+
+  override def loginAsSparkUser() {
+    loginAsSparkUserAndReturnUGI()
+  }
+
+  private def loginAsSparkUserAndReturnUGI(): UserGroupInformation = loggedInUser
+
+  override def newConfiguration(sparkConf: SparkConf): Configuration = {
+    val originalConf = super.newConfiguration(sparkConf)
+    originalConf.set("hadoop.security.authentication",
+      sparkConf.get(hadoopSecurityAuthenticationKey, "simple"))
+    originalConf
+  }
+
+}

--- a/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
@@ -196,6 +196,7 @@ class HadoopRDD[K, V](
     val jobConf = getJobConf()
     // add the credentials here as this can be called before SparkContext initialized
     SparkHadoopUtil.get.addCredentials(jobConf)
+    SparkHadoopUtil.get.loginAsSparkUser()
     val inputFormat = getInputFormat(jobConf)
     if (inputFormat.isInstanceOf[Configurable]) {
       inputFormat.asInstanceOf[Configurable].setConf(jobConf)

--- a/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
@@ -1043,6 +1043,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
       throw new SparkException("Output value class not set")
     }
     SparkHadoopUtil.get.addCredentials(hadoopConf)
+    SparkHadoopUtil.get.loginAsSparkUser()
 
     logDebug("Saving as hadoop file of type (" + keyClass.getSimpleName + ", " +
       valueClass.getSimpleName + ")")

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -42,6 +42,8 @@ import org.apache.spark.util.Utils
  * Contains util methods to interact with Hadoop from spark.
  */
 class YarnSparkHadoopUtil extends SparkHadoopUtil {
+  val sparkConf = new SparkConf()
+  UserGroupInformation.setConfiguration(newConfiguration(sparkConf))
 
   override def transferCredentials(source: UserGroupInformation, dest: UserGroupInformation) {
     dest.addCredentials(source.getCredentials())
@@ -69,6 +71,12 @@ class YarnSparkHadoopUtil extends SparkHadoopUtil {
 
   override def addCurrentUserCredentials(creds: Credentials) {
     UserGroupInformation.getCurrentUser().addCredentials(creds)
+  }
+
+  override def getAuthenticatedUgiForSparkUser(user: String): UserGroupInformation = {
+    val ugi = UserGroupInformation.createRemoteUser(user)
+    transferCredentials(UserGroupInformation.getCurrentUser, ugi)
+    ugi
   }
 
   override def addSecretKeyToUserCredentials(key: String, secret: String) {


### PR DESCRIPTION
Previously, Kerberos secured Hadoop clusters could only be accessed by Spark running on top of YARN. In other words, Spark standalone clusters had no way to read from secure Hadoop clusters. Other solutions were proposed previously, but all of them attempted to perform authentication by obtaining
a token on a single node and passing that token around to all of the other Spark worker nodes. The shipping of the token is risky, and all previous iterations fell short in leaving the token open to man-in-the-middle attacks.

This patch introduces an alternative approach. It assumes that the keytab file has already been distributed to every node in the cluster. When Spark starts in standalone mode, all of the workers individually log in via Kerberos using the principal and keytab file specified in hdfs-site.xml. We can assume this will be well formed because on standalone configurations all of the worker nodes should be using the same hdfs-site.xml configurations as the Hadoop cluster itself. In addition, on basic Hadoop cluster setups the key tab file is often already manually deployed on all of the cluster's nodes; it's not a huge stretch to expect the keytab files to be deployed to the Spark worker nodes as well, if they are not already there.

There are a number of caveats to this approach. Firstly, it assumes that Spark will always authenticate with Kerberos using the same principal and keytab, and the login is done at the very start of the job. Strictly speaking we should be trying to reduce the surface area of the region of code that operate under a logged-in state. Or to put it another way, the authentication should only be performed precisely when files are written or read from HDFS, and after the read or write is performed the subject should be logged out. However this is difficult to write and prone to errors, so this is left for a future refactor.

More concerningly, the code does not actually execute "kinit", and each of the executor nodes need to run kinit manually before starting the job. It is suggested that a call to kinit with the appropriate principal and keytab is done in spark-env.sh, and we should document this as being the case. I remark that UserGroupInformation.loginUserFromKeytab(...) does not actually run kinit, but merely creates a "delegation token", but doing this without running kinit still makes the Spark job crash with an exception message along the lines of "Unable to find tgt...". Any suggestions as to how to actually execute "kinit" in Java are appreciated; a system call is flaky at best due to cross-platform issues.

cc @mingyukim, @pwendell , @ash211 
