### PR TITLE
[SPARK-5325] [SQL] Shrink the Hive shim layer

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -38,7 +38,7 @@ import org.apache.hadoop.hive.shims.ShimLoader
 import org.apache.thrift.transport.TSocket
 
 import org.apache.spark.Logging
-import org.apache.spark.sql.hive.HiveShim
+import org.apache.spark.sql.hive.{HiveCompat, HiveShim}
 import org.apache.spark.sql.hive.thriftserver.HiveThriftServerShim
 
 private[hive] object SparkSQLCLIDriver {
@@ -260,7 +260,7 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
     } else {
       var ret = 0
       val hconf = conf.asInstanceOf[HiveConf]
-      val proc: CommandProcessor = HiveShim.getCommandProcessor(Array(tokens(0)), hconf)
+      val proc: CommandProcessor = HiveCompat.getCommandProcessor(tokens.take(1), hconf)
 
       if (proc != null) {
         if (proc.isInstanceOf[Driver] || proc.isInstanceOf[SetProcessor]) {

--- a/sql/hive/src/main/scala/org/apache/hadoop/hive/serde2/objectinspector/primitive/WritableConstantObjectInspectors.scala
+++ b/sql/hive/src/main/scala/org/apache/hadoop/hive/serde2/objectinspector/primitive/WritableConstantObjectInspectors.scala
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.serde2.objectinspector.primitive
+
+import org.apache.hadoop.hive.serde2.{io => hiveIo}
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector
+import org.apache.hadoop.io.NullWritable
+import org.apache.hadoop.{io => hadoopIo}
+import org.apache.spark.sql.hive.HiveShim
+
+/**
+ * These methods have to be put in this package because we use package-private constructors of
+ * writable constant object inspectors here to avoid adding them to the Hive shim layer.
+ */
+object WritableConstantObjectInspectors {
+  def getStringWritableConstantObjectInspector(value: Any): ObjectInspector =
+    new WritableConstantStringObjectInspector(getStringWritable(value))
+
+  def getIntWritableConstantObjectInspector(value: Any): ObjectInspector =
+    new WritableConstantIntObjectInspector(getIntWritable(value))
+
+  def getDoubleWritableConstantObjectInspector(value: Any): ObjectInspector =
+    new WritableConstantDoubleObjectInspector(getDoubleWritable(value))
+
+  def getBooleanWritableConstantObjectInspector(value: Any): ObjectInspector =
+    new WritableConstantBooleanObjectInspector(getBooleanWritable(value))
+
+  def getLongWritableConstantObjectInspector(value: Any): ObjectInspector =
+    new WritableConstantLongObjectInspector(getLongWritable(value))
+
+  def getFloatWritableConstantObjectInspector(value: Any): ObjectInspector =
+    new WritableConstantFloatObjectInspector(getFloatWritable(value))
+
+  def getShortWritableConstantObjectInspector(value: Any): ObjectInspector =
+    new WritableConstantShortObjectInspector(getShortWritable(value))
+
+  def getByteWritableConstantObjectInspector(value: Any): ObjectInspector =
+    new WritableConstantByteObjectInspector(getByteWritable(value))
+
+  def getBinaryWritableConstantObjectInspector(value: Any): ObjectInspector =
+    new WritableConstantBinaryObjectInspector(getBinaryWritable(value))
+
+  def getDateWritableConstantObjectInspector(value: Any): ObjectInspector =
+    new WritableConstantDateObjectInspector(getDateWritable(value))
+
+  def getTimestampWritableConstantObjectInspector(value: Any): ObjectInspector =
+    new WritableConstantTimestampObjectInspector(getTimestampWritable(value))
+
+  def getDecimalWritableConstantObjectInspector(value: Any): ObjectInspector =
+    HiveShim.getDecimalWritableConstantObjectInspector(value)
+
+  def getPrimitiveNullWritableConstantObjectInspector: ObjectInspector =
+    new WritableVoidObjectInspector()
+
+  def getStringWritable(value: Any): hadoopIo.Text =
+    if (value == null) null else new hadoopIo.Text(value.asInstanceOf[String])
+
+  def getIntWritable(value: Any): hadoopIo.IntWritable =
+    if (value == null) null else new hadoopIo.IntWritable(value.asInstanceOf[Int])
+
+  def getDoubleWritable(value: Any): hiveIo.DoubleWritable =
+    if (value == null) null else new hiveIo.DoubleWritable(value.asInstanceOf[Double])
+
+  def getBooleanWritable(value: Any): hadoopIo.BooleanWritable =
+    if (value == null) null else new hadoopIo.BooleanWritable(value.asInstanceOf[Boolean])
+
+  def getLongWritable(value: Any): hadoopIo.LongWritable =
+    if (value == null) null else new hadoopIo.LongWritable(value.asInstanceOf[Long])
+
+  def getFloatWritable(value: Any): hadoopIo.FloatWritable =
+    if (value == null) null else new hadoopIo.FloatWritable(value.asInstanceOf[Float])
+
+  def getShortWritable(value: Any): hiveIo.ShortWritable =
+    if (value == null) null else new hiveIo.ShortWritable(value.asInstanceOf[Short])
+
+  def getByteWritable(value: Any): hiveIo.ByteWritable =
+    if (value == null) null else new hiveIo.ByteWritable(value.asInstanceOf[Byte])
+
+  def getBinaryWritable(value: Any): hadoopIo.BytesWritable =
+    if (value == null) null else new hadoopIo.BytesWritable(value.asInstanceOf[Array[Byte]])
+
+  def getDateWritable(value: Any): hiveIo.DateWritable =
+    if (value == null) null else new hiveIo.DateWritable(value.asInstanceOf[java.sql.Date])
+
+  def getTimestampWritable(value: Any): hiveIo.TimestampWritable =
+    if (value == null) null
+    else new hiveIo.TimestampWritable(value.asInstanceOf[java.sql.Timestamp])
+
+  def getDecimalWritable(value: Any): hiveIo.HiveDecimalWritable =
+    HiveShim.getDecimalWritable(value)
+
+  def getPrimitiveNullWritable: NullWritable = NullWritable.get()
+}

--- a/sql/hive/src/main/scala/org/apache/hadoop/hive/serde2/objectinspector/primitive/WritableConstantObjectInspectors.scala
+++ b/sql/hive/src/main/scala/org/apache/hadoop/hive/serde2/objectinspector/primitive/WritableConstantObjectInspectors.scala
@@ -1,13 +1,12 @@
-/**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.hadoop.hive.serde2.objectinspector.primitive
 
 import org.apache.hadoop.hive.serde2.{io => hiveIo}

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveCompat.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveCompat.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.hive
 
-import java.math.{BigDecimal => JBigDecimal}
 import java.util.{Properties, Set => JSet}
 
 import scala.collection.JavaConversions._
@@ -25,7 +24,6 @@ import scala.language.{existentials, implicitConversions}
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-import org.apache.hadoop.hive.common.`type`.HiveDecimal
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.ql.metadata.{Hive, Partition, Table}
 import org.apache.hadoop.hive.ql.plan.{FileSinkDesc, TableDesc}
@@ -84,15 +82,6 @@ object HiveCompat {
     Invoke[JSet[Partition]](classOf[Hive], client, "getAllPartitionsForPruner",
       classOf[Table] -> tbl)
   )
-
-  def newHiveDecimal(bd: JBigDecimal) = callWithAlternatives(
-    // For Hive 0.13.1
-    InvokeStatic[HiveDecimal](classOf[HiveDecimal], "create",
-      classOf[JBigDecimal] -> bd),
-
-    // For Hive 0.12.0
-    Construct(classOf[HiveDecimal],
-      classOf[JBigDecimal] -> bd))
 
   // Hive 0.13.1: org.apache.hadoop.hive.common.StatsSetupConst.TOTAL_SIZE
   // Hive 0.12.0: org.apache.hadoop.hive.ql.stats.StatsSetupConst.TOTAL_SIZE

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveCompat.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveCompat.scala
@@ -35,7 +35,10 @@ import org.apache.hadoop.mapred.InputFormat
 
 import org.apache.spark.Logging
 
-object HiveUtils {
+/**
+ * A utility object used to cope with Hive compatibility issues.
+ */
+object HiveCompat {
   def createDefaultDBIfNeeded(context: HiveContext) = {
     context.runSqlHive("CREATE DATABASE IF NOT EXISTS default")
     context.runSqlHive("USE default")

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveCompat.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveCompat.scala
@@ -1,13 +1,12 @@
-/**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.spark.sql.hive
 
 import java.math.{BigDecimal => JBigDecimal}
@@ -118,8 +118,8 @@ object HiveCompat {
   def getDataLocationPath(p: Partition) = p.getPath.apply(0)
 
   /**
-   * This class is used to workaround a bug introduced in Hive 0.13.1, which makes `FileSinkDesc` non-
-   * serializable
+   * This class is used to workaround a bug introduced in Hive 0.13.1, which makes `FileSinkDesc`
+   * non-serializable
    */
   class FileSinkDescWrapper(val dirName: String, var tableInfo: TableDesc, var compressed: Boolean)
     extends Serializable with Logging {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -411,7 +411,7 @@ private object HiveContext {
     case (bin: Array[Byte], BinaryType) => new String(bin, "UTF-8")
     case (decimal: java.math.BigDecimal, DecimalType()) =>
       // Hive strips trailing zeros so use its toString
-      HiveCompat.newHiveDecimal(decimal).toString
+      HiveShim.newHiveDecimal(decimal).toString
     case (other, tpe) if primitiveTypes contains tpe => other.toString
   }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -154,7 +154,7 @@ class HiveContext(sc: SparkContext) extends SQLContext(sc) {
 
         val tableParameters = relation.hiveQlTable.getParameters
         val oldTotalSize =
-          Option(tableParameters.get(HiveShim.getStatsSetupConstTotalSize))
+          Option(tableParameters.get(HiveUtils.getStatsSetupConstTotalSize))
             .map(_.toLong)
             .getOrElse(0L)
         val newTotalSize = getFileSizeForTable(hiveconf, relation.hiveQlTable)
@@ -162,7 +162,7 @@ class HiveContext(sc: SparkContext) extends SQLContext(sc) {
         // recorded in the Hive metastore.
         // This logic is based on org.apache.hadoop.hive.ql.exec.StatsTask.aggregateStats().
         if (newTotalSize > 0 && newTotalSize != oldTotalSize) {
-          tableParameters.put(HiveShim.getStatsSetupConstTotalSize, newTotalSize.toString)
+          tableParameters.put(HiveUtils.getStatsSetupConstTotalSize, newTotalSize.toString)
           val hiveTTable = relation.hiveQlTable.getTTable
           hiveTTable.setParameters(tableParameters)
           val tableFullName =
@@ -276,7 +276,7 @@ class HiveContext(sc: SparkContext) extends SQLContext(sc) {
       val cmd_trimmed: String = cmd.trim()
       val tokens: Array[String] = cmd_trimmed.split("\\s+")
       val cmd_1: String = cmd_trimmed.substring(tokens(0).length()).trim()
-      val proc: CommandProcessor = HiveShim.getCommandProcessor(Array(tokens(0)), hiveconf)
+      val proc: CommandProcessor = HiveUtils.getCommandProcessor(tokens.take(1), hiveconf)
 
       // Makes sure the session represented by the `sessionState` field is activated. This implies
       // Spark SQL Hive support uses a single `SessionState` for all Hive operations and breaks
@@ -411,7 +411,7 @@ private object HiveContext {
     case (bin: Array[Byte], BinaryType) => new String(bin, "UTF-8")
     case (decimal: java.math.BigDecimal, DecimalType()) =>
       // Hive strips trailing zeros so use its toString
-      HiveShim.createDecimal(decimal).toString
+      HiveUtils.createDecimal(decimal).toString
     case (other, tpe) if primitiveTypes contains tpe => other.toString
   }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -154,7 +154,7 @@ class HiveContext(sc: SparkContext) extends SQLContext(sc) {
 
         val tableParameters = relation.hiveQlTable.getParameters
         val oldTotalSize =
-          Option(tableParameters.get(HiveUtils.getStatsSetupConstTotalSize))
+          Option(tableParameters.get(HiveCompat.getStatsSetupConstTotalSize))
             .map(_.toLong)
             .getOrElse(0L)
         val newTotalSize = getFileSizeForTable(hiveconf, relation.hiveQlTable)
@@ -162,7 +162,7 @@ class HiveContext(sc: SparkContext) extends SQLContext(sc) {
         // recorded in the Hive metastore.
         // This logic is based on org.apache.hadoop.hive.ql.exec.StatsTask.aggregateStats().
         if (newTotalSize > 0 && newTotalSize != oldTotalSize) {
-          tableParameters.put(HiveUtils.getStatsSetupConstTotalSize, newTotalSize.toString)
+          tableParameters.put(HiveCompat.getStatsSetupConstTotalSize, newTotalSize.toString)
           val hiveTTable = relation.hiveQlTable.getTTable
           hiveTTable.setParameters(tableParameters)
           val tableFullName =
@@ -276,7 +276,7 @@ class HiveContext(sc: SparkContext) extends SQLContext(sc) {
       val cmd_trimmed: String = cmd.trim()
       val tokens: Array[String] = cmd_trimmed.split("\\s+")
       val cmd_1: String = cmd_trimmed.substring(tokens(0).length()).trim()
-      val proc: CommandProcessor = HiveUtils.getCommandProcessor(tokens.take(1), hiveconf)
+      val proc: CommandProcessor = HiveCompat.getCommandProcessor(tokens.take(1), hiveconf)
 
       // Makes sure the session represented by the `sessionState` field is activated. This implies
       // Spark SQL Hive support uses a single `SessionState` for all Hive operations and breaks
@@ -411,7 +411,7 @@ private object HiveContext {
     case (bin: Array[Byte], BinaryType) => new String(bin, "UTF-8")
     case (decimal: java.math.BigDecimal, DecimalType()) =>
       // Hive strips trailing zeros so use its toString
-      HiveUtils.newHiveDecimal(decimal).toString
+      HiveCompat.newHiveDecimal(decimal).toString
     case (other, tpe) if primitiveTypes contains tpe => other.toString
   }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -411,7 +411,7 @@ private object HiveContext {
     case (bin: Array[Byte], BinaryType) => new String(bin, "UTF-8")
     case (decimal: java.math.BigDecimal, DecimalType()) =>
       // Hive strips trailing zeros so use its toString
-      HiveUtils.createDecimal(decimal).toString
+      HiveUtils.newHiveDecimal(decimal).toString
     case (other, tpe) if primitiveTypes contains tpe => other.toString
   }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.hive
 
 import org.apache.hadoop.hive.common.`type`.{HiveDecimal, HiveVarchar}
+import org.apache.hadoop.hive.ql.metadata.HiveUtils
 import org.apache.hadoop.hive.serde2.objectinspector._
 import org.apache.hadoop.hive.serde2.objectinspector.primitive._
 import org.apache.hadoop.hive.serde2.{io => hiveIo}
@@ -428,7 +429,6 @@ private[hive] trait HiveInspectors {
       case _: ByteObjectInspector => a.asInstanceOf[java.lang.Byte]
       case _: HiveDecimalObjectInspector =>
         HiveCompat.newHiveDecimal(a.asInstanceOf[Decimal].toJavaBigDecimal)
-      case _: BinaryObjectInspector if x.preferWritable() => HiveShim.getBinaryWritable(a)
       case _: BinaryObjectInspector => a.asInstanceOf[Array[Byte]]
       case _: DateObjectInspector => a.asInstanceOf[java.sql.Date]
       case _: TimestampObjectInspector => a.asInstanceOf[java.sql.Timestamp]

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
@@ -342,7 +342,7 @@ private[hive] trait HiveInspectors {
       (o: Any) => new HiveVarchar(o.asInstanceOf[String], o.asInstanceOf[String].size)
 
     case _: JavaHiveDecimalObjectInspector =>
-      (o: Any) => HiveUtils.createDecimal(o.asInstanceOf[Decimal].toJavaBigDecimal)
+      (o: Any) => HiveUtils.newHiveDecimal(o.asInstanceOf[Decimal].toJavaBigDecimal)
 
     case soi: StandardStructObjectInspector =>
       val wrappers = soi.getAllStructFieldRefs.map(ref => wrapperFor(ref.getFieldObjectInspector))
@@ -427,7 +427,7 @@ private[hive] trait HiveInspectors {
       case _: ShortObjectInspector => a.asInstanceOf[java.lang.Short]
       case _: ByteObjectInspector => a.asInstanceOf[java.lang.Byte]
       case _: HiveDecimalObjectInspector =>
-        HiveUtils.createDecimal(a.asInstanceOf[Decimal].toJavaBigDecimal)
+        HiveUtils.newHiveDecimal(a.asInstanceOf[Decimal].toJavaBigDecimal)
       case _: BinaryObjectInspector if x.preferWritable() => HiveShim.getBinaryWritable(a)
       case _: BinaryObjectInspector => a.asInstanceOf[Array[Byte]]
       case _: DateObjectInspector => a.asInstanceOf[java.sql.Date]

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
@@ -343,7 +343,7 @@ private[hive] trait HiveInspectors {
       (o: Any) => new HiveVarchar(o.asInstanceOf[String], o.asInstanceOf[String].size)
 
     case _: JavaHiveDecimalObjectInspector =>
-      (o: Any) => HiveCompat.newHiveDecimal(o.asInstanceOf[Decimal].toJavaBigDecimal)
+      (o: Any) => HiveShim.newHiveDecimal(o.asInstanceOf[Decimal].toJavaBigDecimal)
 
     case soi: StandardStructObjectInspector =>
       val wrappers = soi.getAllStructFieldRefs.map(ref => wrapperFor(ref.getFieldObjectInspector))
@@ -428,7 +428,7 @@ private[hive] trait HiveInspectors {
       case _: ShortObjectInspector => a.asInstanceOf[java.lang.Short]
       case _: ByteObjectInspector => a.asInstanceOf[java.lang.Byte]
       case _: HiveDecimalObjectInspector =>
-        HiveCompat.newHiveDecimal(a.asInstanceOf[Decimal].toJavaBigDecimal)
+        HiveShim.newHiveDecimal(a.asInstanceOf[Decimal].toJavaBigDecimal)
       case _: BinaryObjectInspector => a.asInstanceOf[Array[Byte]]
       case _: DateObjectInspector => a.asInstanceOf[java.sql.Date]
       case _: TimestampObjectInspector => a.asInstanceOf[java.sql.Timestamp]

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
@@ -342,7 +342,7 @@ private[hive] trait HiveInspectors {
       (o: Any) => new HiveVarchar(o.asInstanceOf[String], o.asInstanceOf[String].size)
 
     case _: JavaHiveDecimalObjectInspector =>
-      (o: Any) => HiveUtils.newHiveDecimal(o.asInstanceOf[Decimal].toJavaBigDecimal)
+      (o: Any) => HiveCompat.newHiveDecimal(o.asInstanceOf[Decimal].toJavaBigDecimal)
 
     case soi: StandardStructObjectInspector =>
       val wrappers = soi.getAllStructFieldRefs.map(ref => wrapperFor(ref.getFieldObjectInspector))
@@ -427,7 +427,7 @@ private[hive] trait HiveInspectors {
       case _: ShortObjectInspector => a.asInstanceOf[java.lang.Short]
       case _: ByteObjectInspector => a.asInstanceOf[java.lang.Byte]
       case _: HiveDecimalObjectInspector =>
-        HiveUtils.newHiveDecimal(a.asInstanceOf[Decimal].toJavaBigDecimal)
+        HiveCompat.newHiveDecimal(a.asInstanceOf[Decimal].toJavaBigDecimal)
       case _: BinaryObjectInspector if x.preferWritable() => HiveShim.getBinaryWritable(a)
       case _: BinaryObjectInspector => a.asInstanceOf[Array[Byte]]
       case _: DateObjectInspector => a.asInstanceOf[java.sql.Date]

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -152,7 +152,7 @@ private[hive] class HiveMetastoreCatalog(hive: HiveContext) extends Catalog with
     } else {
       val partitions: Seq[Partition] =
         if (table.isPartitioned) {
-          HiveUtils.getAllPartitionsOf(client, table).toSeq
+          HiveCompat.getAllPartitionsOf(client, table).toSeq
         } else {
           Nil
         }
@@ -501,8 +501,8 @@ private[hive] case class MetastoreRelation
 
   @transient override lazy val statistics = Statistics(
     sizeInBytes = {
-      val totalSize = hiveQlTable.getParameters.get(HiveUtils.getStatsSetupConstTotalSize)
-      val rawDataSize = hiveQlTable.getParameters.get(HiveUtils.getStatsSetupConstRawDataSize)
+      val totalSize = hiveQlTable.getParameters.get(HiveCompat.getStatsSetupConstTotalSize)
+      val rawDataSize = hiveQlTable.getParameters.get(HiveCompat.getStatsSetupConstRawDataSize)
       // TODO: check if this estimate is valid for tables after partition pruning.
       // NOTE: getting `totalSize` directly from params is kind of hacky, but this should be
       // relatively cheap if parameters for the table are populated into the metastore.  An
@@ -519,7 +519,7 @@ private[hive] case class MetastoreRelation
     }
   )
 
-  val tableDesc = HiveUtils.newTableDesc(
+  val tableDesc = HiveCompat.newTableDesc(
     Class.forName(
       hiveQlTable.getSerializationLib,
       true,

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -152,7 +152,7 @@ private[hive] class HiveMetastoreCatalog(hive: HiveContext) extends Catalog with
     } else {
       val partitions: Seq[Partition] =
         if (table.isPartitioned) {
-          HiveShim.getAllPartitionsOf(client, table).toSeq
+          HiveUtils.getAllPartitionsOf(client, table).toSeq
         } else {
           Nil
         }
@@ -501,8 +501,8 @@ private[hive] case class MetastoreRelation
 
   @transient override lazy val statistics = Statistics(
     sizeInBytes = {
-      val totalSize = hiveQlTable.getParameters.get(HiveShim.getStatsSetupConstTotalSize)
-      val rawDataSize = hiveQlTable.getParameters.get(HiveShim.getStatsSetupConstRawDataSize)
+      val totalSize = hiveQlTable.getParameters.get(HiveUtils.getStatsSetupConstTotalSize)
+      val rawDataSize = hiveQlTable.getParameters.get(HiveUtils.getStatsSetupConstRawDataSize)
       // TODO: check if this estimate is valid for tables after partition pruning.
       // NOTE: getting `totalSize` directly from params is kind of hacky, but this should be
       // relatively cheap if parameters for the table are populated into the metastore.  An
@@ -519,7 +519,7 @@ private[hive] case class MetastoreRelation
     }
   )
 
-  val tableDesc = HiveShim.getTableDesc(
+  val tableDesc = HiveUtils.newTableDesc(
     Class.forName(
       hiveQlTable.getSerializationLib,
       true,

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -82,13 +82,13 @@ object HiveUtils {
       classOf[Table] -> tbl)
   )
 
-  def createDecimal(bd: JBigDecimal) = callWithAlternatives(
+  def newHiveDecimal(bd: JBigDecimal) = callWithAlternatives(
     // For Hive 0.13.1
-    Construct(classOf[HiveDecimal],
+    InvokeStatic[HiveDecimal](classOf[HiveDecimal], "create",
       classOf[JBigDecimal] -> bd),
 
     // For Hive 0.12.0
-    InvokeStatic[HiveDecimal](classOf[HiveDecimal], "create",
+    Construct(classOf[HiveDecimal],
       classOf[JBigDecimal] -> bd))
 
   // Hive 0.13.1: org.apache.hadoop.hive.common.StatsSetupConst.TOTAL_SIZE

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -1,0 +1,179 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.hive
+
+import java.math.{BigDecimal => JBigDecimal}
+import java.util.{Properties, Set => JSet}
+
+import scala.collection.JavaConversions._
+import scala.language.{existentials, implicitConversions}
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.hive.common.`type`.HiveDecimal
+import org.apache.hadoop.hive.conf.HiveConf
+import org.apache.hadoop.hive.ql.metadata.{Hive, Partition, Table}
+import org.apache.hadoop.hive.ql.plan.{FileSinkDesc, TableDesc}
+import org.apache.hadoop.hive.ql.processors.{CommandProcessor, CommandProcessorFactory}
+import org.apache.hadoop.hive.serde2.{ColumnProjectionUtils, Deserializer}
+import org.apache.hadoop.mapred.InputFormat
+
+import org.apache.spark.Logging
+
+object HiveUtils {
+  def createDefaultDBIfNeeded(context: HiveContext) = {
+    context.runSqlHive("CREATE DATABASE IF NOT EXISTS default")
+    context.runSqlHive("USE default")
+  }
+
+  def newTableDesc(
+      serdeClass: Class[_ <: Deserializer],
+      inputFormatClass: Class[_ <: InputFormat[_, _]],
+      outputFormatClass: Class[_],
+      properties: Properties) = callWithAlternatives(
+    // For Hive 0.13.1
+    Construct(classOf[TableDesc],
+      classOf[Class[_ <: InputFormat[_, _]]] -> inputFormatClass,
+      classOf[Class[_]] -> outputFormatClass,
+      classOf[Properties] -> properties),
+
+    // For Hive 0.12.0
+    Construct(classOf[TableDesc],
+      classOf[Class[_ <: Deserializer]] -> serdeClass,
+      classOf[Class[_ <: InputFormat[_, _]]] -> inputFormatClass,
+      classOf[Class[_]] -> outputFormatClass,
+      classOf[Properties] -> properties))
+
+  def getCommandProcessor(cmd: Array[String], conf: HiveConf) = {
+    callWithAlternatives[CommandProcessor](
+      // For Hive 0.13.1
+      InvokeStatic[CommandProcessor](classOf[CommandProcessorFactory], "get",
+        classOf[Array[String]] -> cmd,
+        classOf[HiveConf] -> conf),
+
+      // For Hive 0.12.0
+      InvokeStatic[CommandProcessor](classOf[CommandProcessorFactory], "get",
+        classOf[String] -> cmd(0),
+        classOf[HiveConf] -> conf))
+  }
+
+  def getAllPartitionsOf(client: Hive, tbl: Table) = callWithAlternatives[JSet[Partition]](
+    // For Hive 0.13.1
+    Invoke[JSet[Partition]](classOf[Hive], client, "getAllPartitionsOf",
+      classOf[Table] -> tbl),
+
+    // For Hive 0.12.0
+    Invoke[JSet[Partition]](classOf[Hive], client, "getAllPartitionsForPruner",
+      classOf[Table] -> tbl)
+  )
+
+  def createDecimal(bd: JBigDecimal) = callWithAlternatives(
+    // For Hive 0.13.1
+    Construct(classOf[HiveDecimal],
+      classOf[JBigDecimal] -> bd),
+
+    // For Hive 0.12.0
+    InvokeStatic[HiveDecimal](classOf[HiveDecimal], "create",
+      classOf[JBigDecimal] -> bd))
+
+  // Hive 0.13.1: org.apache.hadoop.hive.common.StatsSetupConst.TOTAL_SIZE
+  // Hive 0.12.0: org.apache.hadoop.hive.ql.stats.StatsSetupConst.TOTAL_SIZE
+  val getStatsSetupConstTotalSize = "totalSize"
+
+  // Hive 0.13.1: org.apache.hadoop.hive.common.StatsSetupConst.RAW_DATA_SIZE
+  // Hive 0.12.0: org.apache.hadoop.hive.ql.stats.StatsSetupConst.RAW_DATA_SIZE
+  val getStatsSetupConstRawDataSize = "rawDataSize"
+
+  def appendReadColumns(conf: Configuration, ids: Seq[Integer], names: Seq[String]) {
+    // ColumnProjectUtils.appendReadColumnNames was made private in Hive 0.13.1, have to
+    // re-implement it here to workaround Hive bugs.
+    def appendReadColumnNames(cols: Seq[String]) {
+      val original = Option(conf.get(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR, null)).toSeq
+      val merged = (original ++ names).mkString(",")
+      conf.set(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR, merged)
+    }
+
+    if (ids.nonEmpty) ColumnProjectionUtils.appendReadColumnIDs(conf, ids)
+    if (names.nonEmpty) appendReadColumnNames(names)
+  }
+
+  def getDataLocationPath(p: Partition) = p.getPath.apply(0)
+
+  /**
+   * This class is used to workaround a bug introduced in Hive 0.13.1, which makes `FileSinkDesc` non-
+   * serializable
+   */
+  class FileSinkDescWrapper(val dirName: String, var tableInfo: TableDesc, var compressed: Boolean)
+    extends Serializable with Logging {
+
+    var compressCodec: String = _
+    var compressType: String = _
+
+    // Used to workaround `FileSinkDesc` constructor incompatibility between Hive 0.12.0 and 0.13.1.
+    // The type of the `dirName` argument in 0.12.0 is `String`, but `Path` in 0.13.1.
+    private implicit def stringToPath(string: String): Path = new Path(dirName)
+
+    def value = {
+      val f = new FileSinkDesc(dirName, tableInfo, compressed)
+      f.setCompressCodec(compressCodec)
+      f.setCompressType(compressType)
+      f.setTableInfo(tableInfo)
+      f
+    }
+  }
+
+  // TODO Move these reflection utilities to ReflectionUtils
+
+  trait ReflectedCall[T] { def call: T }
+
+  case class Construct[T](clazz: Class[T], args: (Class[_], AnyRef)*) extends ReflectedCall[T] {
+    def call: T = {
+      val (argTypes, argValues) = args.unzip
+      val constructor = clazz.getConstructor(argTypes: _*)
+      constructor.setAccessible(true)
+      constructor.newInstance(argValues: _*)
+    }
+  }
+
+  case class Invoke[U](clazz: Class[_], obj: AnyRef, methodName: String, args: (Class[_], AnyRef)*)
+    extends ReflectedCall[U] {
+
+    def call: U = {
+      val (argTypes, argValues) = args.unzip
+      val method = clazz.getMethod(methodName, argTypes: _*)
+      method.setAccessible(true)
+      method.invoke(obj, argValues: _*).asInstanceOf[U]
+    }
+  }
+
+  case class InvokeStatic[U](clazz: Class[_], methodName: String, args: (Class[_], AnyRef)*)
+    extends ReflectedCall[U] {
+
+    def call: U = Invoke[U](clazz, null, methodName, args: _*).call
+  }
+
+  def callWithAlternatives[T](alternatives: ReflectedCall[T]*): T = {
+    alternatives.foreach { alternative =>
+      try return alternative.call catch { case e: NoSuchMethodException =>
+        // Just ignore and fallback to the next alternative.
+      }
+    }
+
+    throw new RuntimeException("No available alternative method/constructor can be invoked.")
+  }
+}

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -143,7 +143,7 @@ class HadoopTableReader(
       filterOpt: Option[PathFilter]): RDD[Row] = {
     val hivePartitionRDDs = partitionToDeserializer.map { case (partition, partDeserializer) =>
       val partDesc = Utilities.getPartitionDesc(partition)
-      val partPath = HiveUtils.getDataLocationPath(partition)
+      val partPath = HiveCompat.getDataLocationPath(partition)
       val inputPathStr = applyFilterIfNeeded(partPath, filterOpt)
       val ifc = partDesc.getInputFileFormatClass
         .asInstanceOf[java.lang.Class[InputFormat[Writable, Writable]]]

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -143,7 +143,7 @@ class HadoopTableReader(
       filterOpt: Option[PathFilter]): RDD[Row] = {
     val hivePartitionRDDs = partitionToDeserializer.map { case (partition, partDeserializer) =>
       val partDesc = Utilities.getPartitionDesc(partition)
-      val partPath = HiveShim.getDataLocationPath(partition)
+      val partPath = HiveUtils.getDataLocationPath(partition)
       val inputPathStr = applyFilterIfNeeded(partPath, filterOpt)
       val ifc = partDesc.getInputFileFormatClass
         .asInstanceOf[java.lang.Class[InputFormat[Writable, Writable]]]

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TestHive.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TestHive.scala
@@ -382,7 +382,7 @@ class TestHiveContext(sc: SparkContext) extends HiveContext(sc) {
   protected val originalUdfs: JavaSet[String] = FunctionRegistry.getFunctionNames
 
   // Database default may not exist in 0.13.1, create it if not exist
-  HiveUtils.createDefaultDBIfNeeded(this)
+  HiveCompat.createDefaultDBIfNeeded(this)
 
   /**
    * Resets the test instance by deleting any tables that have been created.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TestHive.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TestHive.scala
@@ -382,7 +382,7 @@ class TestHiveContext(sc: SparkContext) extends HiveContext(sc) {
   protected val originalUdfs: JavaSet[String] = FunctionRegistry.getFunctionNames
 
   // Database default may not exist in 0.13.1, create it if not exist
-  HiveShim.createDefaultDBIfNeeded(this)
+  HiveUtils.createDefaultDBIfNeeded(this)
 
   /**
    * Resets the test instance by deleting any tables that have been created.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScan.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScan.scala
@@ -84,7 +84,7 @@ case class HiveTableScan(
     // Specifies needed column IDs for those non-partitioning columns.
     val neededColumnIDs = attributes.flatMap(relation.columnOrdinals.get).map(o => o: Integer)
 
-    HiveUtils.appendReadColumns(hiveConf, neededColumnIDs, attributes.map(_.name))
+    HiveCompat.appendReadColumns(hiveConf, neededColumnIDs, attributes.map(_.name))
 
     val tableDesc = relation.tableDesc
     val deserializer = tableDesc.getDeserializerClass.newInstance

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScan.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScan.scala
@@ -22,8 +22,8 @@ import scala.collection.JavaConversions._
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.ql.metadata.{Partition => HivePartition}
 import org.apache.hadoop.hive.serde.serdeConstants
-import org.apache.hadoop.hive.serde2.objectinspector._
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils.ObjectInspectorCopyOption
+import org.apache.hadoop.hive.serde2.objectinspector._
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils
 
 import org.apache.spark.annotation.DeveloperApi
@@ -64,7 +64,7 @@ case class HiveTableScan(
     BindReferences.bindReference(pred, relation.partitionKeys)
   }
 
-  // Create a local copy of hiveconf,so that scan specific modifications should not impact 
+  // Create a local copy of hiveconf,so that scan specific modifications should not impact
   // other queries
   @transient
   private[this] val hiveExtraConf = new HiveConf(context.hiveconf)
@@ -73,7 +73,7 @@ case class HiveTableScan(
   addColumnMetadataToConf(hiveExtraConf)
 
   @transient
-  private[this] val hadoopReader = 
+  private[this] val hadoopReader =
     new HadoopTableReader(attributes, relation, context, hiveExtraConf)
 
   private[this] def castFromString(value: String, dataType: DataType) = {
@@ -84,7 +84,7 @@ case class HiveTableScan(
     // Specifies needed column IDs for those non-partitioning columns.
     val neededColumnIDs = attributes.flatMap(relation.columnOrdinals.get).map(o => o: Integer)
 
-    HiveShim.appendReadColumns(hiveConf, neededColumnIDs, attributes.map(_.name))
+    HiveUtils.appendReadColumns(hiveConf, neededColumnIDs, attributes.map(_.name))
 
     val tableDesc = relation.tableDesc
     val deserializer = tableDesc.getDeserializerClass.newInstance

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -36,7 +36,7 @@ import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.Row
 import org.apache.spark.sql.execution.{SparkPlan, UnaryNode}
-import org.apache.spark.sql.hive.HiveUtils.FileSinkDescWrapper
+import org.apache.spark.sql.hive.HiveCompat.FileSinkDescWrapper
 import org.apache.spark.sql.hive._
 import org.apache.spark.{SerializableWritable, SparkException, TaskContext}
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveWriterContainers.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveWriterContainers.scala
@@ -34,7 +34,7 @@ import org.apache.hadoop.mapred._
 
 import org.apache.spark.mapred.SparkHadoopMapRedUtil
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.hive.HiveUtils.FileSinkDescWrapper
+import org.apache.spark.sql.hive.HiveCompat.FileSinkDescWrapper
 import org.apache.spark.{Logging, SerializableWritable, SparkHadoopWriter}
 
 /**

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveWriterContainers.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveWriterContainers.scala
@@ -219,8 +219,8 @@ private[spark] class SparkHiveDynamicPartitionWriterContainer(
       .mkString
 
     def newWriter = {
-      // Used to workaround `FileSinkDesc` constructor incompatibility between Hive 0.12.0 and 0.13.1.
-      // The type of the `dirName` argument in 0.12.0 is `String`, but `Path` in 0.13.1.
+      // Used to workaround `FileSinkDesc` constructor incompatibility between Hive 0.12.0 and
+      // 0.13.1. The type of the `dirName` argument in 0.12.0 is `String`, but `Path` in 0.13.1.
       implicit def stringToPath(string: String): Path = new Path(string)
 
       val newFileSinkDesc = new FileSinkDesc(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
@@ -55,25 +55,28 @@ class MetastoreDataSourcesSuite extends QueryTest with BeforeAndAfterEach {
       jsonFile(filePath).collect().toSeq)
   }
 
-  test ("persistent JSON table with a user specified schema") {
-    sql(
-      s"""
-        |CREATE TABLE jsonTable (
-        |a string,
-        |b String,
-        |`c_!@(3)` int,
-        |`<d>` Struct<`d!`:array<int>, `=`:array<struct<Dd2: boolean>>>)
-        |USING org.apache.spark.sql.json.DefaultSource
-        |OPTIONS (
-        |  path '${filePath}'
-        |)
-      """.stripMargin)
+  // Hive 0.12.0 can't parse the SELECT statement used in this case.
+  if (HiveShim.version != "0.12.0") {
+    test ("persistent JSON table with a user specified schema") {
+      sql(
+        s"""
+          |CREATE TABLE jsonTable (
+          |a string,
+          |b String,
+          |`c_!@(3)` int,
+          |`<d>` Struct<`d!`:array<int>, `=`:array<struct<Dd2: boolean>>>)
+          |USING org.apache.spark.sql.json.DefaultSource
+          |OPTIONS (
+          |  path '${filePath}'
+          |)
+        """.stripMargin)
 
-    jsonFile(filePath).registerTempTable("expectedJsonTable")
+      jsonFile(filePath).registerTempTable("expectedJsonTable")
 
-    checkAnswer(
-      sql("SELECT a, b, `c_!@(3)`, `<d>`.`d!`, `<d>`.`=` FROM jsonTable"),
-      sql("SELECT a, b, `c_!@(3)`, `<d>`.`d!`, `<d>`.`=` FROM expectedJsonTable").collect().toSeq)
+      checkAnswer(
+        sql("SELECT a, b, `c_!@(3)`, `<d>`.`d!`, `<d>`.`=` FROM jsonTable"),
+        sql("SELECT a, b, `c_!@(3)`, `<d>`.`d!`, `<d>`.`=` FROM expectedJsonTable").collect().toSeq)
+    }
   }
 
   test ("persistent JSON table with a user specified schema with a subset of fields") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -62,7 +62,7 @@ class HiveQuerySuite extends HiveComparisonTest with BeforeAndAfter {
       sql("SHOW TABLES")
     }
   }
-  
+
   createQueryTest("! operator",
     """
       |SELECT a FROM (
@@ -79,8 +79,8 @@ class HiveQuerySuite extends HiveComparisonTest with BeforeAndAfter {
       printf("Bb%d", 12), "13",
       repeat(printf("s%d", 14), 2), "14") FROM src LIMIT 1""")
 
-  createQueryTest("NaN to Decimal",
-    "SELECT CAST(CAST('NaN' AS DOUBLE) AS DECIMAL(1,1)) FROM src LIMIT 1")
+//  createQueryTest("NaN to Decimal",
+//    "SELECT CAST(CAST('NaN' AS DOUBLE) AS DECIMAL(1,1)) FROM src LIMIT 1")
 
   createQueryTest("constant null testing",
     """SELECT

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -79,8 +79,11 @@ class HiveQuerySuite extends HiveComparisonTest with BeforeAndAfter {
       printf("Bb%d", 12), "13",
       repeat(printf("s%d", 14), 2), "14") FROM src LIMIT 1""")
 
-//  createQueryTest("NaN to Decimal",
-//    "SELECT CAST(CAST('NaN' AS DOUBLE) AS DECIMAL(1,1)) FROM src LIMIT 1")
+  // Hive 0.12.0 doesn't support decimal with precision and scale.
+  if (HiveShim.version != "0.12.0") {
+    createQueryTest("NaN to Decimal",
+      "SELECT CAST(CAST('NaN' AS DOUBLE) AS DECIMAL(1,1)) FROM src LIMIT 1")
+  }
 
   createQueryTest("constant null testing",
     """SELECT

--- a/sql/hive/v0.12.0/src/main/scala/org/apache/spark/sql/hive/Shim12.scala
+++ b/sql/hive/v0.12.0/src/main/scala/org/apache/spark/sql/hive/Shim12.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.hive
 
+import java.math.{BigDecimal => JBigDecimal}
 import java.net.URI
 import java.util.{ArrayList => JArrayList}
 
@@ -24,11 +25,9 @@ import scala.language.implicitConversions
 
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.hive.common.`type`.HiveDecimal
-import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.ql.Context
-import org.apache.hadoop.hive.ql.metadata.{Hive, Partition, Table}
+import org.apache.hadoop.hive.ql.metadata.{Hive, Table}
 import org.apache.hadoop.hive.ql.plan.CreateTableDesc
-import org.apache.hadoop.hive.ql.processors._
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.PrimitiveCategory
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.{HiveDecimalObjectInspector, PrimitiveObjectInspectorFactory}
 import org.apache.hadoop.hive.serde2.objectinspector.{ObjectInspector, PrimitiveObjectInspector}
@@ -64,8 +63,10 @@ object HiveShim {
       null
     } else {
       new hiveIo.HiveDecimalWritable(
-        HiveCompat.newHiveDecimal(value.asInstanceOf[Decimal].toJavaBigDecimal))
+        HiveShim.newHiveDecimal(value.asInstanceOf[Decimal].toJavaBigDecimal))
     }
+
+  def newHiveDecimal(bd: JBigDecimal) = new HiveDecimal(bd)
 
   def createDriverResultsArray = new JArrayList[String]
 

--- a/sql/hive/v0.12.0/src/main/scala/org/apache/spark/sql/hive/Shim12.scala
+++ b/sql/hive/v0.12.0/src/main/scala/org/apache/spark/sql/hive/Shim12.scala
@@ -85,7 +85,8 @@ object HiveShim {
     "serde_regex",
     "udf_to_date",
     "udaf_collect_set",
-    "udf_concat"
+    "udf_concat",
+    "udf_to_double"
   )
 
   def setLocation(tbl: Table, crtTbl: CreateTableDesc): Unit = {

--- a/sql/hive/v0.12.0/src/main/scala/org/apache/spark/sql/hive/Shim12.scala
+++ b/sql/hive/v0.12.0/src/main/scala/org/apache/spark/sql/hive/Shim12.scala
@@ -64,7 +64,7 @@ object HiveShim {
       null
     } else {
       new hiveIo.HiveDecimalWritable(
-        HiveUtils.createDecimal(value.asInstanceOf[Decimal].toJavaBigDecimal))
+        HiveUtils.newHiveDecimal(value.asInstanceOf[Decimal].toJavaBigDecimal))
     }
 
   def createDriverResultsArray = new JArrayList[String]

--- a/sql/hive/v0.12.0/src/main/scala/org/apache/spark/sql/hive/Shim12.scala
+++ b/sql/hive/v0.12.0/src/main/scala/org/apache/spark/sql/hive/Shim12.scala
@@ -86,7 +86,17 @@ object HiveShim {
     "udf_to_date",
     "udaf_collect_set",
     "udf_concat",
-    "udf_to_double"
+
+    // The following 3 cases use 0.13.1 decimal syntax
+    "udf_to_double",
+    "udf_to_float",
+    "udf_pmod",
+
+    // This case uses different ".q" files for 0.12.0 and 0.13.1.  The version used in 0.13.1
+    // includes a regression test for HIVE-4116, which wasn't fixed until 0.13.0 Developers who sets
+    // HIVE_DEV_HOME properly won't see any error.  However, we don't have Hive source tree on
+    // Jenkins nodes, thus this case is blacklisted for the sake of Jenkins.
+    "create_view_translate"
   )
 
   def setLocation(tbl: Table, crtTbl: CreateTableDesc): Unit = {

--- a/sql/hive/v0.12.0/src/main/scala/org/apache/spark/sql/hive/Shim12.scala
+++ b/sql/hive/v0.12.0/src/main/scala/org/apache/spark/sql/hive/Shim12.scala
@@ -64,7 +64,7 @@ object HiveShim {
       null
     } else {
       new hiveIo.HiveDecimalWritable(
-        HiveUtils.newHiveDecimal(value.asInstanceOf[Decimal].toJavaBigDecimal))
+        HiveCompat.newHiveDecimal(value.asInstanceOf[Decimal].toJavaBigDecimal))
     }
 
   def createDriverResultsArray = new JArrayList[String]

--- a/sql/hive/v0.12.0/src/main/scala/org/apache/spark/sql/hive/Shim12.scala
+++ b/sql/hive/v0.12.0/src/main/scala/org/apache/spark/sql/hive/Shim12.scala
@@ -18,28 +18,22 @@
 package org.apache.spark.sql.hive
 
 import java.net.URI
-import java.util.{ArrayList => JArrayList, Properties}
+import java.util.{ArrayList => JArrayList}
 
-import scala.collection.JavaConversions._
 import scala.language.implicitConversions
 
-import org.apache.hadoop.{io => hadoopIo}
-import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.hive.common.`type`.HiveDecimal
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.ql.Context
 import org.apache.hadoop.hive.ql.metadata.{Hive, Partition, Table}
-import org.apache.hadoop.hive.ql.plan.{CreateTableDesc, FileSinkDesc, TableDesc}
+import org.apache.hadoop.hive.ql.plan.CreateTableDesc
 import org.apache.hadoop.hive.ql.processors._
-import org.apache.hadoop.hive.ql.stats.StatsSetupConst
-import org.apache.hadoop.hive.serde2.{ColumnProjectionUtils, Deserializer, io => hiveIo}
-import org.apache.hadoop.hive.serde2.objectinspector.{ObjectInspector, PrimitiveObjectInspector}
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.PrimitiveCategory
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.{HiveDecimalObjectInspector, PrimitiveObjectInspectorFactory}
+import org.apache.hadoop.hive.serde2.objectinspector.{ObjectInspector, PrimitiveObjectInspector}
 import org.apache.hadoop.hive.serde2.typeinfo.{TypeInfo, TypeInfoFactory}
-import org.apache.hadoop.io.NullWritable
-import org.apache.hadoop.mapred.InputFormat
+import org.apache.hadoop.hive.serde2.{io => hiveIo}
 
 import org.apache.spark.sql.types.{Decimal, DecimalType}
 
@@ -57,156 +51,29 @@ case class HiveFunctionWrapper(functionClassName: String) extends java.io.Serial
 /**
  * A compatibility layer for interacting with Hive version 0.12.0.
  */
-private[hive] object HiveShim {
+object HiveShim {
   val version = "0.12.0"
-
-  def getTableDesc(
-    serdeClass: Class[_ <: Deserializer],
-    inputFormatClass: Class[_ <: InputFormat[_, _]],
-    outputFormatClass: Class[_],
-    properties: Properties) = {
-    new TableDesc(serdeClass, inputFormatClass, outputFormatClass, properties)
-  }
-
-  def getStringWritableConstantObjectInspector(value: Any): ObjectInspector =
-    PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
-      PrimitiveCategory.STRING,
-      getStringWritable(value))
-
-  def getIntWritableConstantObjectInspector(value: Any): ObjectInspector =
-    PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
-      PrimitiveCategory.INT,
-      getIntWritable(value))
-
-  def getDoubleWritableConstantObjectInspector(value: Any): ObjectInspector =
-    PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
-      PrimitiveCategory.DOUBLE,
-      getDoubleWritable(value))
-
-  def getBooleanWritableConstantObjectInspector(value: Any): ObjectInspector =
-    PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
-      PrimitiveCategory.BOOLEAN,
-      getBooleanWritable(value))
-
-  def getLongWritableConstantObjectInspector(value: Any): ObjectInspector =
-    PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
-      PrimitiveCategory.LONG,
-      getLongWritable(value))
-
-  def getFloatWritableConstantObjectInspector(value: Any): ObjectInspector =
-    PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
-      PrimitiveCategory.FLOAT,
-      getFloatWritable(value))
-
-  def getShortWritableConstantObjectInspector(value: Any): ObjectInspector =
-    PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
-      PrimitiveCategory.SHORT,
-      getShortWritable(value))
-
-  def getByteWritableConstantObjectInspector(value: Any): ObjectInspector =
-    PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
-      PrimitiveCategory.BYTE,
-      getByteWritable(value))
-
-  def getBinaryWritableConstantObjectInspector(value: Any): ObjectInspector =
-    PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
-      PrimitiveCategory.BINARY,
-      getBinaryWritable(value))
-
-  def getDateWritableConstantObjectInspector(value: Any): ObjectInspector =
-    PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
-      PrimitiveCategory.DATE,
-      getDateWritable(value))
-
-  def getTimestampWritableConstantObjectInspector(value: Any): ObjectInspector =
-    PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
-      PrimitiveCategory.TIMESTAMP,
-      getTimestampWritable(value))
 
   def getDecimalWritableConstantObjectInspector(value: Any): ObjectInspector =
     PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
       PrimitiveCategory.DECIMAL,
       getDecimalWritable(value))
 
-  def getPrimitiveNullWritableConstantObjectInspector: ObjectInspector =
-    PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
-      PrimitiveCategory.VOID, null)
-
-  def getStringWritable(value: Any): hadoopIo.Text =
-    if (value == null) null else new hadoopIo.Text(value.asInstanceOf[String])
-
-  def getIntWritable(value: Any): hadoopIo.IntWritable =
-    if (value == null) null else new hadoopIo.IntWritable(value.asInstanceOf[Int])
-
-  def getDoubleWritable(value: Any): hiveIo.DoubleWritable =
-    if (value == null) null else new hiveIo.DoubleWritable(value.asInstanceOf[Double])
-
-  def getBooleanWritable(value: Any): hadoopIo.BooleanWritable =
-    if (value == null) null else new hadoopIo.BooleanWritable(value.asInstanceOf[Boolean])
-
-  def getLongWritable(value: Any): hadoopIo.LongWritable =
-    if (value == null) null else new hadoopIo.LongWritable(value.asInstanceOf[Long])
-
-  def getFloatWritable(value: Any): hadoopIo.FloatWritable =
-    if (value == null) null else new hadoopIo.FloatWritable(value.asInstanceOf[Float])
-
-  def getShortWritable(value: Any): hiveIo.ShortWritable =
-    if (value == null) null else new hiveIo.ShortWritable(value.asInstanceOf[Short])
-
-  def getByteWritable(value: Any): hiveIo.ByteWritable =
-    if (value == null) null else new hiveIo.ByteWritable(value.asInstanceOf[Byte])
-
-  def getBinaryWritable(value: Any): hadoopIo.BytesWritable =
-    if (value == null) null else new hadoopIo.BytesWritable(value.asInstanceOf[Array[Byte]])
-
-  def getDateWritable(value: Any): hiveIo.DateWritable =
-    if (value == null) null else new hiveIo.DateWritable(value.asInstanceOf[java.sql.Date])
-
-  def getTimestampWritable(value: Any): hiveIo.TimestampWritable =
-    if (value == null) {
-      null
-    } else {
-      new hiveIo.TimestampWritable(value.asInstanceOf[java.sql.Timestamp])
-    }
-
   def getDecimalWritable(value: Any): hiveIo.HiveDecimalWritable =
     if (value == null) {
       null
     } else {
       new hiveIo.HiveDecimalWritable(
-        HiveShim.createDecimal(value.asInstanceOf[Decimal].toJavaBigDecimal))
+        HiveUtils.createDecimal(value.asInstanceOf[Decimal].toJavaBigDecimal))
     }
-
-  def getPrimitiveNullWritable: NullWritable = NullWritable.get()
 
   def createDriverResultsArray = new JArrayList[String]
 
   def processResults(results: JArrayList[String]) = results
 
-  def getStatsSetupConstTotalSize = StatsSetupConst.TOTAL_SIZE
-
-  def getStatsSetupConstRawDataSize = StatsSetupConst.RAW_DATA_SIZE
-
-  def createDefaultDBIfNeeded(context: HiveContext) = {  }
-
-  def getCommandProcessor(cmd: Array[String], conf: HiveConf) = {
-    CommandProcessorFactory.get(cmd(0), conf)
-  }
-
-  def createDecimal(bd: java.math.BigDecimal): HiveDecimal = {
-    new HiveDecimal(bd)
-  }
-
-  def appendReadColumns(conf: Configuration, ids: Seq[Integer], names: Seq[String]) {
-    ColumnProjectionUtils.appendReadColumnIDs(conf, ids)
-    ColumnProjectionUtils.appendReadColumnNames(conf, names)
-  }
-
   def getExternalTmpPath(context: Context, uri: URI) = {
     context.getExternalTmpFileURI(uri)
   }
-
-  def getDataLocationPath(p: Partition) = p.getPartitionPath
 
   def getAllPartitionsOf(client: Hive, tbl: Table) =  client.getAllPartitionsForPruner(tbl)
 
@@ -222,7 +89,7 @@ private[hive] object HiveShim {
   )
 
   def setLocation(tbl: Table, crtTbl: CreateTableDesc): Unit = {
-    tbl.setDataLocation(new Path(crtTbl.getLocation()).toUri())
+    tbl.setDataLocation(new Path(crtTbl.getLocation).toUri)
   }
 
   def decimalMetastoreString(decimalType: DecimalType): String = "decimal"
@@ -236,13 +103,9 @@ private[hive] object HiveShim {
 
   def toCatalystDecimal(hdoi: HiveDecimalObjectInspector, data: Any): Decimal = {
     if (hdoi.preferWritable()) {
-      Decimal(hdoi.getPrimitiveWritableObject(data).getHiveDecimal().bigDecimalValue)
+      Decimal(hdoi.getPrimitiveWritableObject(data).getHiveDecimal.bigDecimalValue)
     } else {
       Decimal(hdoi.getPrimitiveJavaObject(data).bigDecimalValue())
     }
   }
-}
-
-class ShimFileSinkDesc(var dir: String, var tableInfo: TableDesc, var compressed: Boolean)
-  extends FileSinkDesc(dir, tableInfo, compressed) {
 }

--- a/sql/hive/v0.13.1/src/main/scala/org/apache/spark/sql/hive/Shim13.scala
+++ b/sql/hive/v0.13.1/src/main/scala/org/apache/spark/sql/hive/Shim13.scala
@@ -156,7 +156,7 @@ object HiveShim {
     } else {
       // TODO precise, scale?
       new hiveIo.HiveDecimalWritable(
-        HiveUtils.createDecimal(value.asInstanceOf[Decimal].toJavaBigDecimal))
+        HiveUtils.newHiveDecimal(value.asInstanceOf[Decimal].toJavaBigDecimal))
     }
 
   def createDriverResultsArray = new JArrayList[Object]

--- a/sql/hive/v0.13.1/src/main/scala/org/apache/spark/sql/hive/Shim13.scala
+++ b/sql/hive/v0.13.1/src/main/scala/org/apache/spark/sql/hive/Shim13.scala
@@ -156,7 +156,7 @@ object HiveShim {
     } else {
       // TODO precise, scale?
       new hiveIo.HiveDecimalWritable(
-        HiveUtils.newHiveDecimal(value.asInstanceOf[Decimal].toJavaBigDecimal))
+        HiveCompat.newHiveDecimal(value.asInstanceOf[Decimal].toJavaBigDecimal))
     }
 
   def createDriverResultsArray = new JArrayList[Object]

--- a/sql/hive/v0.13.1/src/main/scala/org/apache/spark/sql/hive/Shim13.scala
+++ b/sql/hive/v0.13.1/src/main/scala/org/apache/spark/sql/hive/Shim13.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.hive
 
 import java.io.{InputStream, OutputStream}
+import java.math.{BigDecimal => JBigDecimal}
 import java.util.{ArrayList => JArrayList}
 
 import scala.collection.JavaConversions._
@@ -26,12 +27,10 @@ import scala.language.implicitConversions
 import com.esotericsoftware.kryo.Kryo
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.hive.common.`type`.HiveDecimal
-import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.ql.Context
 import org.apache.hadoop.hive.ql.exec.{UDF, Utilities}
-import org.apache.hadoop.hive.ql.metadata.{Hive, Partition, Table}
+import org.apache.hadoop.hive.ql.metadata.{Hive, Table}
 import org.apache.hadoop.hive.ql.plan.CreateTableDesc
-import org.apache.hadoop.hive.ql.processors.CommandProcessorFactory
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.{HiveDecimalObjectInspector, PrimitiveObjectInspectorFactory}
 import org.apache.hadoop.hive.serde2.objectinspector.{ObjectInspector, PrimitiveObjectInspector}
 import org.apache.hadoop.hive.serde2.typeinfo.{DecimalTypeInfo, TypeInfo, TypeInfoFactory}
@@ -156,8 +155,10 @@ object HiveShim {
     } else {
       // TODO precise, scale?
       new hiveIo.HiveDecimalWritable(
-        HiveCompat.newHiveDecimal(value.asInstanceOf[Decimal].toJavaBigDecimal))
+        HiveShim.newHiveDecimal(value.asInstanceOf[Decimal].toJavaBigDecimal))
     }
+
+  def newHiveDecimal(bd: JBigDecimal) = HiveDecimal.create(bd)
 
   def createDriverResultsArray = new JArrayList[Object]
 

--- a/sql/hive/v0.13.1/src/main/scala/org/apache/spark/sql/hive/Shim13.scala
+++ b/sql/hive/v0.13.1/src/main/scala/org/apache/spark/sql/hive/Shim13.scala
@@ -17,38 +17,34 @@
 
 package org.apache.spark.sql.hive
 
+import java.io.{InputStream, OutputStream}
 import java.util.{ArrayList => JArrayList}
-import java.util.Properties
 
 import scala.collection.JavaConversions._
 import scala.language.implicitConversions
 
-import org.apache.hadoop.conf.Configuration
+import com.esotericsoftware.kryo.Kryo
 import org.apache.hadoop.fs.Path
-import org.apache.hadoop.io.NullWritable
-import org.apache.hadoop.mapred.InputFormat
-import org.apache.hadoop.hive.common.StatsSetupConst
-import org.apache.hadoop.hive.common.`type`.{HiveDecimal}
+import org.apache.hadoop.hive.common.`type`.HiveDecimal
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.ql.Context
-import org.apache.hadoop.hive.ql.metadata.{Table, Hive, Partition}
-import org.apache.hadoop.hive.ql.plan.{CreateTableDesc, FileSinkDesc, TableDesc}
+import org.apache.hadoop.hive.ql.exec.{UDF, Utilities}
+import org.apache.hadoop.hive.ql.metadata.{Hive, Partition, Table}
+import org.apache.hadoop.hive.ql.plan.CreateTableDesc
 import org.apache.hadoop.hive.ql.processors.CommandProcessorFactory
-import org.apache.hadoop.hive.serde2.typeinfo.{TypeInfo, DecimalTypeInfo, TypeInfoFactory}
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.{HiveDecimalObjectInspector, PrimitiveObjectInspectorFactory}
-import org.apache.hadoop.hive.serde2.objectinspector.{PrimitiveObjectInspector, ObjectInspector}
-import org.apache.hadoop.hive.serde2.{Deserializer, ColumnProjectionUtils}
+import org.apache.hadoop.hive.serde2.objectinspector.{ObjectInspector, PrimitiveObjectInspector}
+import org.apache.hadoop.hive.serde2.typeinfo.{DecimalTypeInfo, TypeInfo, TypeInfoFactory}
 import org.apache.hadoop.hive.serde2.{io => hiveIo}
-import org.apache.hadoop.{io => hadoopIo}
 
-import org.apache.spark.Logging
 import org.apache.spark.sql.types.{Decimal, DecimalType}
+import org.apache.spark.util.Utils._
 
 
 /**
  * This class provides the UDF creation and also the UDF instance serialization and
  * de-serialization cross process boundary.
- * 
+ *
  * Detail discussion can be found at https://github.com/apache/spark/pull/3640
  *
  * @param functionClassName UDF class name
@@ -56,12 +52,6 @@ import org.apache.spark.sql.types.{Decimal, DecimalType}
 case class HiveFunctionWrapper(var functionClassName: String) extends java.io.Externalizable {
   // for Serialization
   def this() = this(null)
-
-  import java.io.{OutputStream, InputStream}
-  import com.esotericsoftware.kryo.Kryo
-  import org.apache.spark.util.Utils._
-  import org.apache.hadoop.hive.ql.exec.Utilities
-  import org.apache.hadoop.hive.ql.exec.UDF
 
   @transient
   private val methodDeSerialize = {
@@ -153,122 +143,12 @@ case class HiveFunctionWrapper(var functionClassName: String) extends java.io.Ex
 /**
  * A compatibility layer for interacting with Hive version 0.13.1.
  */
-private[hive] object HiveShim {
+object HiveShim {
   val version = "0.13.1"
-
-  def getTableDesc(
-    serdeClass: Class[_ <: Deserializer],
-    inputFormatClass: Class[_ <: InputFormat[_, _]],
-    outputFormatClass: Class[_],
-    properties: Properties) = {
-    new TableDesc(inputFormatClass, outputFormatClass, properties)
-  }
-
-
-  def getStringWritableConstantObjectInspector(value: Any): ObjectInspector =
-    PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
-      TypeInfoFactory.stringTypeInfo, getStringWritable(value))
-
-  def getIntWritableConstantObjectInspector(value: Any): ObjectInspector =
-    PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
-      TypeInfoFactory.intTypeInfo, getIntWritable(value))
-
-  def getDoubleWritableConstantObjectInspector(value: Any): ObjectInspector =
-    PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
-      TypeInfoFactory.doubleTypeInfo, getDoubleWritable(value))
-
-  def getBooleanWritableConstantObjectInspector(value: Any): ObjectInspector =
-    PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
-      TypeInfoFactory.booleanTypeInfo, getBooleanWritable(value))
-
-  def getLongWritableConstantObjectInspector(value: Any): ObjectInspector =
-    PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
-      TypeInfoFactory.longTypeInfo, getLongWritable(value))
-
-  def getFloatWritableConstantObjectInspector(value: Any): ObjectInspector =
-    PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
-      TypeInfoFactory.floatTypeInfo, getFloatWritable(value))
-
-  def getShortWritableConstantObjectInspector(value: Any): ObjectInspector =
-    PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
-      TypeInfoFactory.shortTypeInfo, getShortWritable(value))
-
-  def getByteWritableConstantObjectInspector(value: Any): ObjectInspector =
-    PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
-      TypeInfoFactory.byteTypeInfo, getByteWritable(value))
-
-  def getBinaryWritableConstantObjectInspector(value: Any): ObjectInspector =
-    PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
-      TypeInfoFactory.binaryTypeInfo, getBinaryWritable(value))
-
-  def getDateWritableConstantObjectInspector(value: Any): ObjectInspector =
-    PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
-      TypeInfoFactory.dateTypeInfo, getDateWritable(value))
-
-  def getTimestampWritableConstantObjectInspector(value: Any): ObjectInspector =
-    PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
-      TypeInfoFactory.timestampTypeInfo, getTimestampWritable(value))
 
   def getDecimalWritableConstantObjectInspector(value: Any): ObjectInspector =
     PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
       TypeInfoFactory.decimalTypeInfo, getDecimalWritable(value))
-
-  def getPrimitiveNullWritableConstantObjectInspector: ObjectInspector =
-    PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
-      TypeInfoFactory.voidTypeInfo, null)
-
-  def getStringWritable(value: Any): hadoopIo.Text =
-    if (value == null) null else new hadoopIo.Text(value.asInstanceOf[String])
-
-  def getIntWritable(value: Any): hadoopIo.IntWritable =
-    if (value == null) null else new hadoopIo.IntWritable(value.asInstanceOf[Int])
-
-  def getDoubleWritable(value: Any): hiveIo.DoubleWritable =
-    if (value == null) {
-      null
-    } else {
-      new hiveIo.DoubleWritable(value.asInstanceOf[Double])
-    }
-
-  def getBooleanWritable(value: Any): hadoopIo.BooleanWritable =
-    if (value == null) {
-      null
-    } else {
-      new hadoopIo.BooleanWritable(value.asInstanceOf[Boolean])
-    }
-
-  def getLongWritable(value: Any): hadoopIo.LongWritable =
-    if (value == null) null else new hadoopIo.LongWritable(value.asInstanceOf[Long])
-
-  def getFloatWritable(value: Any): hadoopIo.FloatWritable =
-    if (value == null) {
-      null
-    } else {
-      new hadoopIo.FloatWritable(value.asInstanceOf[Float])
-    }
-
-  def getShortWritable(value: Any): hiveIo.ShortWritable =
-    if (value == null) null else new hiveIo.ShortWritable(value.asInstanceOf[Short])
-
-  def getByteWritable(value: Any): hiveIo.ByteWritable =
-    if (value == null) null else new hiveIo.ByteWritable(value.asInstanceOf[Byte])
-
-  def getBinaryWritable(value: Any): hadoopIo.BytesWritable =
-    if (value == null) {
-      null
-    } else {
-      new hadoopIo.BytesWritable(value.asInstanceOf[Array[Byte]])
-    }
-
-  def getDateWritable(value: Any): hiveIo.DateWritable =
-    if (value == null) null else new hiveIo.DateWritable(value.asInstanceOf[java.sql.Date])
-
-  def getTimestampWritable(value: Any): hiveIo.TimestampWritable =
-    if (value == null) {
-      null
-    } else {
-      new hiveIo.TimestampWritable(value.asInstanceOf[java.sql.Timestamp])
-    }
 
   def getDecimalWritable(value: Any): hiveIo.HiveDecimalWritable =
     if (value == null) {
@@ -276,67 +156,15 @@ private[hive] object HiveShim {
     } else {
       // TODO precise, scale?
       new hiveIo.HiveDecimalWritable(
-        HiveShim.createDecimal(value.asInstanceOf[Decimal].toJavaBigDecimal))
+        HiveUtils.createDecimal(value.asInstanceOf[Decimal].toJavaBigDecimal))
     }
-
-  def getPrimitiveNullWritable: NullWritable = NullWritable.get()
 
   def createDriverResultsArray = new JArrayList[Object]
 
   def processResults(results: JArrayList[Object]) = {
-    results.map { r =>
-      r match {
-        case s: String => s
-        case a: Array[Object] => a(0).asInstanceOf[String]
-      }
-    }
-  }
-
-  def getStatsSetupConstTotalSize = StatsSetupConst.TOTAL_SIZE
-
-  def getStatsSetupConstRawDataSize = StatsSetupConst.RAW_DATA_SIZE
-
-  def createDefaultDBIfNeeded(context: HiveContext) = {
-    context.runSqlHive("CREATE DATABASE default")
-    context.runSqlHive("USE default")
-  }
-
-  def getCommandProcessor(cmd: Array[String], conf: HiveConf) = {
-    CommandProcessorFactory.get(cmd, conf)
-  }
-
-  def createDecimal(bd: java.math.BigDecimal): HiveDecimal = {
-    HiveDecimal.create(bd)
-  }
-
-  /*
-   * This function in hive-0.13 become private, but we have to do this to walkaround hive bug
-   */
-  private def appendReadColumnNames(conf: Configuration, cols: Seq[String]) {
-    val old: String = conf.get(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR, "")
-    val result: StringBuilder = new StringBuilder(old)
-    var first: Boolean = old.isEmpty
-
-    for (col <- cols) {
-      if (first) {
-        first = false
-      } else {
-        result.append(',')
-      }
-      result.append(col)
-    }
-    conf.set(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR, result.toString)
-  }
-
-  /*
-   * Cannot use ColumnProjectionUtils.appendReadColumns directly, if ids is null or empty
-   */
-  def appendReadColumns(conf: Configuration, ids: Seq[Integer], names: Seq[String]) {
-    if (ids != null && ids.size > 0) {
-      ColumnProjectionUtils.appendReadColumns(conf, ids)
-    }
-    if (names != null && names.size > 0) {
-      appendReadColumnNames(conf, names)
+    results.map {
+      case s: String => s
+      case a: Array[Object] => a(0).asInstanceOf[String]
     }
   }
 
@@ -344,27 +172,12 @@ private[hive] object HiveShim {
     context.getExternalTmpPath(path.toUri)
   }
 
-  def getDataLocationPath(p: Partition) = p.getDataLocation
-
   def getAllPartitionsOf(client: Hive, tbl: Table) =  client.getAllPartitionsOf(tbl)
 
   def compatibilityBlackList = Seq()
 
   def setLocation(tbl: Table, crtTbl: CreateTableDesc): Unit = {
-    tbl.setDataLocation(new Path(crtTbl.getLocation()))
-  }
-
-  /*
-   * Bug introdiced in hive-0.13. FileSinkDesc is serializable, but its member path is not.
-   * Fix it through wrapper.
-   * */
-  implicit def wrapperToFileSinkDesc(w: ShimFileSinkDesc): FileSinkDesc = {
-    var f = new FileSinkDesc(new Path(w.dir), w.tableInfo, w.compressed)
-    f.setCompressCodec(w.compressCodec)
-    f.setCompressType(w.compressType)
-    f.setTableInfo(w.tableInfo)
-    f.setDestTableId(w.destTableId)
-    f
+    tbl.setDataLocation(new Path(crtTbl.getLocation))
   }
 
   // Precision and scale to pass for unlimited decimals; these are the same as the precision and
@@ -389,43 +202,10 @@ private[hive] object HiveShim {
 
   def toCatalystDecimal(hdoi: HiveDecimalObjectInspector, data: Any): Decimal = {
     if (hdoi.preferWritable()) {
-      Decimal(hdoi.getPrimitiveWritableObject(data).getHiveDecimal().bigDecimalValue,
+      Decimal(hdoi.getPrimitiveWritableObject(data).getHiveDecimal.bigDecimalValue,
         hdoi.precision(), hdoi.scale())
     } else {
       Decimal(hdoi.getPrimitiveJavaObject(data).bigDecimalValue(), hdoi.precision(), hdoi.scale())
     }
-  }
-}
-
-/*
- * Bug introdiced in hive-0.13. FileSinkDesc is serilizable, but its member path is not.
- * Fix it through wrapper.
- */
-class ShimFileSinkDesc(var dir: String, var tableInfo: TableDesc, var compressed: Boolean)
-  extends Serializable with Logging {
-  var compressCodec: String = _
-  var compressType: String = _
-  var destTableId: Int = _
-
-  def setCompressed(compressed: Boolean) {
-    this.compressed = compressed
-  }
-
-  def getDirName = dir
-
-  def setDestTableId(destTableId: Int) {
-    this.destTableId = destTableId
-  }
-
-  def setTableInfo(tableInfo: TableDesc) {
-    this.tableInfo = tableInfo
-  }
-
-  def setCompressCodec(intermediateCompressorCodec: String) {
-    compressCodec = intermediateCompressorCodec
-  }
-
-  def setCompressType(intermediateCompressType: String) {
-    compressType = intermediateCompressType
   }
 }


### PR DESCRIPTION
This PR shrinks the Hive shim layer significantly to reduce maintenance cost.  Now the shim layer only contains decimal related stuff and Hive UDF wrapper (which can be further simplified, but I'd like to do it in a separate PR).  Methods/classes are moved out of the shim layer via two means:
1. Re-implement some functions in a backwards compatible way, e.g. constant object inspector methods in `WritableConstantObjectInspectors`, and the `FileSinkDescWrapper` class
2. For some simple functions that are not performance critical, re-implement them with reflection tricks.

Most functions are moved from `HiveShim` to `HiveCompat`. Constant object inspector related methods are moved to `o.a.h.h.s.o.p.WritableConstantObjectInspectors` because we need to call package private constructors.

Several Hive 0.13.1 specific test cases are blacklisted for Hive 0.12.0, so that future Hive 0.12.0 dedicated Jenkins builder won't complain.

Reflection utility function `callWithAlternativies` is introduced to simplify reflection tricks. It tries to invoke all provided reflected constructor calls, method calls, and static method calls one by one until any of them succeeds. For example, `HiveDecimal` objects are created via normal constructor in Hive 0.12.0, while `HiveDecimal.create` must be used in Hive 0.13.1. We can fix this by:

``` scala
  def createDecimal(bd: JBigDecimal) = callWithAlternatives(
    // For Hive 0.13.1
    InvokeStatic[HiveDecimal](classOf[HiveDecimal], "create",
      classOf[JBigDecimal] -> bd),

    // For Hive 0.12.0
    Construct(classOf[HiveDecimal],
      classOf[JBigDecimal] -> bd))
```

We should move `ReflectionUtils` from `sql/hive-thriftserver` to `sql/hive` or a more general location and merge the facility above into it. Would like to do it in another PR so that this one doesn't get too large.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/apache/spark/4107)

<!-- Reviewable:end -->
