### PR TITLE
[SPARK-5321] Support for transposing local matrices

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
@@ -261,9 +261,7 @@ private[spark] object BLAS extends Serializable with Logging {
    * @param A the matrix A that will be left multiplied to B. Size of m x k.
    * @param B the matrix B that will be left multiplied by A. Size of k x n.
    * @param beta a scalar that can be used to scale matrix C.
-   * @param C the resulting matrix C. Size of m x n. C.isTransposed must be false. In other words,
-   *          C cannot be the product of a `transpose()` call, or be converted from a transposed
-   *          Breeze Matrix using `Matrices.fromBreeze()`.
+   * @param C the resulting matrix C. Size of m x n. C.isTransposed must be false.
    */
   def gemm(
       alpha: Double,

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
@@ -376,8 +376,8 @@ class SparseMatrix(
    * @param numRows number of rows
    * @param numCols number of columns
    * @param colPtrs the index corresponding to the start of a new column
-   * @param rowIndices the row index of the entry. They must be in strictly increasing order for each
-   *                   column
+   * @param rowIndices the row index of the entry. They must be in strictly increasing
+   *                   order for each column
    * @param values non-zero matrix entries in column major
    */
   def this(

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
@@ -735,77 +735,77 @@ object Matrices {
       new DenseMatrix(numRows, numCols, matrices.flatMap(_.toArray))
     } else {
       var startCol = 0
-      val entries: Array[(Int, Int, Double)] = matrices.flatMap {
-        case spMat: SparseMatrix =>
-          val colPtrs = spMat.colPtrs
-          val rowIndices = spMat.rowIndices
-          val values = spMat.values
-          val data = new Array[(Int, Int, Double)](values.length)
-          val nCols = spMat.numCols
-          if (!spMat.isTransposed) {
-            var j = 0
-            while (j < nCols) {
-              var idx = colPtrs(j)
-              while (idx < colPtrs(j + 1)) {
-                val i = rowIndices(idx)
-                val v = values(idx)
-                data(idx) = (i, j + startCol, v)
-                idx += 1
-              }
-              j += 1
-            }
-          } else {
-            var i = 0
-            val nRows = spMat.numRows
-            while (i < nRows) {
-              var idx = colPtrs(i)
-              while (idx < colPtrs(i + 1)) {
-                val j = rowIndices(idx)
-                val v = values(idx)
-                data(idx) = (i, j + startCol, v)
-                idx += 1
-              }
-              i += 1
-            }
-          }
-          startCol += nCols
-          data
-        case dnMat: DenseMatrix =>
-          val data = new ArrayBuffer[(Int, Int, Double)]()
-          val nCols = dnMat.numCols
-          val nRows = dnMat.numRows
-          val values = dnMat.values
-          if (!dnMat.isTransposed) {
-            var j = 0
-            while (j < nCols) {
-              var i = 0
-              val indStart = j * nRows
-              while (i < nRows) {
-                val v = values(indStart + i)
-                if (v != 0.0) {
-                  data.append((i, j + startCol, v))
-                }
-                i += 1
-              }
-              j += 1
-            }
-          } else {
-            var i = 0
-            while (i < nRows) {
+      val entries: Array[(Int, Int, Double)] = matrices.flatMap { mat =>
+        val nRows = mat.numRows
+        val nCols = mat.numCols
+        mat match {
+          case spMat: SparseMatrix =>
+            val colPtrs = spMat.colPtrs
+            val rowIndices = spMat.rowIndices
+            val values = spMat.values
+            val data = new Array[(Int, Int, Double)](values.length)
+            if (!spMat.isTransposed) {
               var j = 0
-              val indStart = i * nCols
               while (j < nCols) {
-                val v = values(indStart + j)
-                if (v != 0.0) {
-                  data.append((i, j + startCol, v))
+                var idx = colPtrs(j)
+                while (idx < colPtrs(j + 1)) {
+                  val i = rowIndices(idx)
+                  val v = values(idx)
+                  data(idx) = (i, j + startCol, v)
+                  idx += 1
                 }
                 j += 1
               }
-              i += 1
+            } else {
+              var i = 0
+              while (i < nRows) {
+                var idx = colPtrs(i)
+                while (idx < colPtrs(i + 1)) {
+                  val j = rowIndices(idx)
+                  val v = values(idx)
+                  data(idx) = (i, j + startCol, v)
+                  idx += 1
+                }
+                i += 1
+              }
             }
-          }
-          startCol += nCols
-          data
+            startCol += nCols
+            data
+          case dnMat: DenseMatrix =>
+            val data = new ArrayBuffer[(Int, Int, Double)]()
+            val values = dnMat.values
+            if (!dnMat.isTransposed) {
+              var j = 0
+              while (j < nCols) {
+                var i = 0
+                val indStart = j * nRows
+                while (i < nRows) {
+                  val v = values(indStart + i)
+                  if (v != 0.0) {
+                    data.append((i, j + startCol, v))
+                  }
+                  i += 1
+                }
+                j += 1
+              }
+            } else {
+              var i = 0
+              while (i < nRows) {
+                var j = 0
+                val indStart = i * nCols
+                while (j < nCols) {
+                  val v = values(indStart + j)
+                  if (v != 0.0) {
+                    data.append((i, j + startCol, v))
+                  }
+                  j += 1
+                }
+                i += 1
+              }
+            }
+            startCol += nCols
+            data
+        }
       }
       SparseMatrix.fromCOO(numRows, numCols, entries)
     }
@@ -860,76 +860,77 @@ object Matrices {
       new DenseMatrix(numRows, numCols, allValues)
     } else {
       var startRow = 0
-      val entries: Array[(Int, Int, Double)] = matrices.flatMap {
-        case spMat: SparseMatrix =>
-          val colPtrs = spMat.colPtrs
-          val rowIndices = spMat.rowIndices
-          val values = spMat.values
-          val data = new Array[(Int, Int, Double)](values.length)
-          val nRows = spMat.numRows
-          if (!spMat.isTransposed) {
-            var j = 0
-            while (j < numCols) {
-              var idx = colPtrs(j)
-              while (idx < colPtrs(j + 1)) {
-                val i = rowIndices(idx)
-                val v = values(idx)
-                data(idx) = (i + startRow, j, v)
-                idx += 1
-              }
-              j += 1
-            }
-          } else {
-            var i = 0
-            while (i < nRows) {
-              var idx = colPtrs(i)
-              while (idx < colPtrs(i + 1)) {
-                val j = rowIndices(idx)
-                val v = values(idx)
-                data(idx) = (i + startRow, j, v)
-                idx += 1
-              }
-              i += 1
-            }
-          }
-          startRow += nRows
-          data
-        case dnMat: DenseMatrix =>
-          val data = new ArrayBuffer[(Int, Int, Double)]()
-          val nCols = dnMat.numCols
-          val nRows = dnMat.numRows
-          val values = dnMat.values
-          if (!dnMat.isTransposed) {
-            var j = 0
-            while (j < nCols) {
-              var i = 0
-              val indStart = j * nRows
-              while (i < nRows) {
-                val v = values(indStart + i)
-                if (v != 0.0) {
-                  data.append((i + startRow, j, v))
-                }
-                i += 1
-              }
-              j += 1
-            }
-          } else {
-            var i = 0
-            while (i < nRows) {
+      val entries: Array[(Int, Int, Double)] = matrices.flatMap { mat =>
+        val nRows = mat.numRows
+        val nCols = mat.numCols
+        mat match {
+          case spMat: SparseMatrix =>
+            val colPtrs = spMat.colPtrs
+            val rowIndices = spMat.rowIndices
+            val values = spMat.values
+            val data = new Array[(Int, Int, Double)](values.length)
+            if (!spMat.isTransposed) {
               var j = 0
-              val indStart = i * nCols
               while (j < nCols) {
-                val v = values(indStart + j)
-                if (v != 0.0) {
-                  data.append((i + startRow, j, v))
+                var idx = colPtrs(j)
+                while (idx < colPtrs(j + 1)) {
+                  val i = rowIndices(idx)
+                  val v = values(idx)
+                  data(idx) = (i + startRow, j, v)
+                  idx += 1
                 }
                 j += 1
               }
-              i += 1
+            } else {
+              var i = 0
+              while (i < nRows) {
+                var idx = colPtrs(i)
+                while (idx < colPtrs(i + 1)) {
+                  val j = rowIndices(idx)
+                  val v = values(idx)
+                  data(idx) = (i + startRow, j, v)
+                  idx += 1
+                }
+                i += 1
+              }
             }
-          }
-          startRow += nRows
-          data
+            startRow += nRows
+            data
+          case dnMat: DenseMatrix =>
+            val data = new ArrayBuffer[(Int, Int, Double)]()
+            val values = dnMat.values
+            if (!dnMat.isTransposed) {
+              var j = 0
+              while (j < nCols) {
+                var i = 0
+                val indStart = j * nRows
+                while (i < nRows) {
+                  val v = values(indStart + i)
+                  if (v != 0.0) {
+                    data.append((i + startRow, j, v))
+                  }
+                  i += 1
+                }
+                j += 1
+              }
+            } else {
+              var i = 0
+              while (i < nRows) {
+                var j = 0
+                val indStart = i * nCols
+                while (j < nCols) {
+                  val v = values(indStart + j)
+                  if (v != 0.0) {
+                    data.append((i + startRow, j, v))
+                  }
+                  j += 1
+                }
+                i += 1
+              }
+            }
+            startRow += nRows
+            data
+        }
       }
       SparseMatrix.fromCOO(numRows, numCols, entries)
     }

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
@@ -181,7 +181,6 @@ class DenseMatrix(val numRows: Int, val numCols: Int, val values: Array[Double])
     var j = 0
     while (j < numCols) {
       var i = 0
-      val indStart = j * numRows
       while (i < numRows) {
         val v = values(index(i, j))
         if (v != 0.0) {

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/BLASSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/BLASSuite.scala
@@ -207,7 +207,7 @@ class BLASSuite extends FunSuite {
 
     withClue("columns of A don't match the rows of B") {
       intercept[Exception] {
-        gemm(1.0, dA, B, 2.0, C1)
+        gemm(1.0, dA.transpose, B, 2.0, C1)
       }
     }
 
@@ -272,7 +272,7 @@ class BLASSuite extends FunSuite {
     assert(y4 ~== expected3 absTol 1e-15)
     withClue("columns of A don't match the rows of B") {
       intercept[Exception] {
-        gemv(1.0, dA, x, 2.0, y1)
+        gemv(1.0, dA.transpose, x, 2.0, y1)
       }
     }
     val dAT =

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/BLASSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/BLASSuite.scala
@@ -193,6 +193,10 @@ class BLASSuite extends FunSuite {
     val C10 = C1.copy
     val C11 = C1.copy
     val C12 = C1.copy
+    val C13 = C1.copy
+    val C14 = C1.copy
+    val C15 = C1.copy
+    val C16 = C1.copy
     val expected2 = new DenseMatrix(4, 2, Array(2.0, 1.0, 4.0, 2.0, 4.0, 0.0, 4.0, 3.0))
     val expected3 = new DenseMatrix(4, 2, Array(2.0, 2.0, 4.0, 2.0, 8.0, 0.0, 6.0, 6.0))
 
@@ -233,6 +237,10 @@ class BLASSuite extends FunSuite {
     gemm(true, true, 1.0, sAT, BT, 2.0, C10)
     gemm(true, true, 2.0, dAT, BT, 2.0, C11)
     gemm(true, true, 2.0, sAT, BT, 2.0, C12)
+    gemm(false, true, 1.0, dA, BT, 2.0, C13)
+    gemm(false, true, 1.0, sA, BT, 2.0, C14)
+    gemm(false, true, 2.0, dA, BT, 2.0, C15)
+    gemm(false, true, 2.0, sA, BT, 2.0, C16)
     assert(C5 ~== expected2 absTol 1e-15)
     assert(C6 ~== expected2 absTol 1e-15)
     assert(C7 ~== expected3 absTol 1e-15)

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/BLASSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/BLASSuite.scala
@@ -176,9 +176,10 @@ class BLASSuite extends FunSuite {
 
     val B = new DenseMatrix(3, 2, Array(1.0, 0.0, 0.0, 0.0, 2.0, 1.0))
     val expected = new DenseMatrix(4, 2, Array(0.0, 1.0, 0.0, 0.0, 4.0, 0.0, 2.0, 3.0))
+    val BT = new DenseMatrix(2, 3, Array(1.0, 0.0, 0.0, 2.0, 0.0, 1.0))
 
-    assert(dA multiply B ~== expected absTol 1e-15)
-    assert(sA multiply B ~== expected absTol 1e-15)
+    assert(dA.multiply(B) ~== expected absTol 1e-15)
+    assert(sA.multiply(B) ~== expected absTol 1e-15)
 
     val C1 = new DenseMatrix(4, 2, Array(1.0, 0.0, 2.0, 1.0, 0.0, 0.0, 1.0, 0.0))
     val C2 = C1.copy
@@ -188,6 +189,10 @@ class BLASSuite extends FunSuite {
     val C6 = C1.copy
     val C7 = C1.copy
     val C8 = C1.copy
+    val C9 = C1.copy
+    val C10 = C1.copy
+    val C11 = C1.copy
+    val C12 = C1.copy
     val expected2 = new DenseMatrix(4, 2, Array(2.0, 1.0, 4.0, 2.0, 4.0, 0.0, 4.0, 3.0))
     val expected3 = new DenseMatrix(4, 2, Array(2.0, 2.0, 4.0, 2.0, 8.0, 0.0, 6.0, 6.0))
 
@@ -211,17 +216,31 @@ class BLASSuite extends FunSuite {
     val sAT =
       new SparseMatrix(3, 4, Array(0, 1, 2, 3, 4), Array(1, 0, 1, 2), Array(2.0, 1.0, 1.0, 3.0))
 
-    assert(dAT transposeMultiply B ~== expected absTol 1e-15)
-    assert(sAT transposeMultiply B ~== expected absTol 1e-15)
+    val dATT = dAT.transpose
+    val sATT = sAT.transpose
+    val BTT = BT.transpose.asInstanceOf[DenseMatrix]
+
+    assert(dATT.multiply(B) ~== expected absTol 1e-15)
+    assert(sATT.multiply(B) ~== expected absTol 1e-15)
+    assert(dATT.multiply(BTT) ~== expected absTol 1e-15)
+    assert(sATT.multiply(BTT) ~== expected absTol 1e-15)
 
     gemm(true, false, 1.0, dAT, B, 2.0, C5)
     gemm(true, false, 1.0, sAT, B, 2.0, C6)
     gemm(true, false, 2.0, dAT, B, 2.0, C7)
     gemm(true, false, 2.0, sAT, B, 2.0, C8)
+    gemm(true, true, 1.0, dAT, BT, 2.0, C9)
+    gemm(true, true, 1.0, sAT, BT, 2.0, C10)
+    gemm(true, true, 2.0, dAT, BT, 2.0, C11)
+    gemm(true, true, 2.0, sAT, BT, 2.0, C12)
     assert(C5 ~== expected2 absTol 1e-15)
     assert(C6 ~== expected2 absTol 1e-15)
     assert(C7 ~== expected3 absTol 1e-15)
     assert(C8 ~== expected3 absTol 1e-15)
+    assert(C9 ~== expected2 absTol 1e-15)
+    assert(C10 ~== expected2 absTol 1e-15)
+    assert(C11 ~== expected3 absTol 1e-15)
+    assert(C12 ~== expected3 absTol 1e-15)
   }
 
   test("gemv") {
@@ -233,8 +252,8 @@ class BLASSuite extends FunSuite {
     val x = new DenseVector(Array(1.0, 2.0, 3.0))
     val expected = new DenseVector(Array(4.0, 1.0, 2.0, 9.0))
 
-    assert(dA multiply x ~== expected absTol 1e-15)
-    assert(sA multiply x ~== expected absTol 1e-15)
+    assert(dA.multiply(x) ~== expected absTol 1e-15)
+    assert(sA.multiply(x) ~== expected absTol 1e-15)
 
     val y1 = new DenseVector(Array(1.0, 3.0, 1.0, 0.0))
     val y2 = y1.copy
@@ -266,8 +285,11 @@ class BLASSuite extends FunSuite {
     val sAT =
       new SparseMatrix(3, 4, Array(0, 1, 2, 3, 4), Array(1, 0, 1, 2), Array(2.0, 1.0, 1.0, 3.0))
 
-    assert(dAT transposeMultiply x ~== expected absTol 1e-15)
-    assert(sAT transposeMultiply x ~== expected absTol 1e-15)
+    val dATT = dAT.transpose
+    val sATT = sAT.transpose
+
+    assert(dATT.multiply(x) ~== expected absTol 1e-15)
+    assert(sATT.multiply(x) ~== expected absTol 1e-15)
 
     gemv(true, 1.0, dAT, x, 2.0, y5)
     gemv(true, 1.0, sAT, x, 2.0, y6)

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/BLASSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/BLASSuite.scala
@@ -169,14 +169,14 @@ class BLASSuite extends FunSuite {
   }
 
   test("gemm") {
-
     val dA =
       new DenseMatrix(4, 3, Array(0.0, 1.0, 0.0, 0.0, 2.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 3.0))
     val sA = new SparseMatrix(4, 3, Array(0, 1, 3, 4), Array(1, 0, 2, 3), Array(1.0, 2.0, 1.0, 3.0))
 
     val B = new DenseMatrix(3, 2, Array(1.0, 0.0, 0.0, 0.0, 2.0, 1.0))
     val expected = new DenseMatrix(4, 2, Array(0.0, 1.0, 0.0, 0.0, 4.0, 0.0, 2.0, 3.0))
-    val BT = new DenseMatrix(2, 3, Array(1.0, 0.0, 0.0, 2.0, 0.0, 1.0))
+    val BTman = new DenseMatrix(2, 3, Array(1.0, 0.0, 0.0, 2.0, 0.0, 1.0))
+    val BT = B.transpose
 
     assert(dA.multiply(B) ~== expected absTol 1e-15)
     assert(sA.multiply(B) ~== expected absTol 1e-15)
@@ -193,10 +193,6 @@ class BLASSuite extends FunSuite {
     val C10 = C1.copy
     val C11 = C1.copy
     val C12 = C1.copy
-    val C13 = C1.copy
-    val C14 = C1.copy
-    val C15 = C1.copy
-    val C16 = C1.copy
     val expected2 = new DenseMatrix(4, 2, Array(2.0, 1.0, 4.0, 2.0, 4.0, 0.0, 4.0, 3.0))
     val expected3 = new DenseMatrix(4, 2, Array(2.0, 2.0, 4.0, 2.0, 8.0, 0.0, 6.0, 6.0))
 
@@ -211,36 +207,32 @@ class BLASSuite extends FunSuite {
 
     withClue("columns of A don't match the rows of B") {
       intercept[Exception] {
-        gemm(true, false, 1.0, dA, B, 2.0, C1)
+        gemm(1.0, dA, B, 2.0, C1)
       }
     }
 
-    val dAT =
+    val dATman =
       new DenseMatrix(3, 4, Array(0.0, 2.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 3.0))
-    val sAT =
+    val sATman =
       new SparseMatrix(3, 4, Array(0, 1, 2, 3, 4), Array(1, 0, 1, 2), Array(2.0, 1.0, 1.0, 3.0))
 
-    val dATT = dAT.transpose
-    val sATT = sAT.transpose
-    val BTT = BT.transpose.asInstanceOf[DenseMatrix]
+    val dATT = dATman.transpose
+    val sATT = sATman.transpose
+    val BTT = BTman.transpose.asInstanceOf[DenseMatrix]
 
     assert(dATT.multiply(B) ~== expected absTol 1e-15)
     assert(sATT.multiply(B) ~== expected absTol 1e-15)
     assert(dATT.multiply(BTT) ~== expected absTol 1e-15)
     assert(sATT.multiply(BTT) ~== expected absTol 1e-15)
 
-    gemm(true, false, 1.0, dAT, B, 2.0, C5)
-    gemm(true, false, 1.0, sAT, B, 2.0, C6)
-    gemm(true, false, 2.0, dAT, B, 2.0, C7)
-    gemm(true, false, 2.0, sAT, B, 2.0, C8)
-    gemm(true, true, 1.0, dAT, BT, 2.0, C9)
-    gemm(true, true, 1.0, sAT, BT, 2.0, C10)
-    gemm(true, true, 2.0, dAT, BT, 2.0, C11)
-    gemm(true, true, 2.0, sAT, BT, 2.0, C12)
-    gemm(false, true, 1.0, dA, BT, 2.0, C13)
-    gemm(false, true, 1.0, sA, BT, 2.0, C14)
-    gemm(false, true, 2.0, dA, BT, 2.0, C15)
-    gemm(false, true, 2.0, sA, BT, 2.0, C16)
+    gemm(1.0, dATT, BTT, 2.0, C5)
+    gemm(1.0, sATT, BTT, 2.0, C6)
+    gemm(2.0, dATT, BTT, 2.0, C7)
+    gemm(2.0, sATT, BTT, 2.0, C8)
+    gemm(1.0, dA, BTT, 2.0, C9)
+    gemm(1.0, sA, BTT, 2.0, C10)
+    gemm(2.0, dA, BTT, 2.0, C11)
+    gemm(2.0, sA, BTT, 2.0, C12)
     assert(C5 ~== expected2 absTol 1e-15)
     assert(C6 ~== expected2 absTol 1e-15)
     assert(C7 ~== expected3 absTol 1e-15)
@@ -267,10 +259,6 @@ class BLASSuite extends FunSuite {
     val y2 = y1.copy
     val y3 = y1.copy
     val y4 = y1.copy
-    val y5 = y1.copy
-    val y6 = y1.copy
-    val y7 = y1.copy
-    val y8 = y1.copy
     val expected2 = new DenseVector(Array(6.0, 7.0, 4.0, 9.0))
     val expected3 = new DenseVector(Array(10.0, 8.0, 6.0, 18.0))
 
@@ -284,10 +272,9 @@ class BLASSuite extends FunSuite {
     assert(y4 ~== expected3 absTol 1e-15)
     withClue("columns of A don't match the rows of B") {
       intercept[Exception] {
-        gemv(true, 1.0, dA, x, 2.0, y1)
+        gemv(1.0, dA, x, 2.0, y1)
       }
     }
-
     val dAT =
       new DenseMatrix(3, 4, Array(0.0, 2.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 3.0))
     val sAT =
@@ -298,14 +285,5 @@ class BLASSuite extends FunSuite {
 
     assert(dATT.multiply(x) ~== expected absTol 1e-15)
     assert(sATT.multiply(x) ~== expected absTol 1e-15)
-
-    gemv(true, 1.0, dAT, x, 2.0, y5)
-    gemv(true, 1.0, sAT, x, 2.0, y6)
-    gemv(true, 2.0, dAT, x, 2.0, y7)
-    gemv(true, 2.0, sAT, x, 2.0, y8)
-    assert(y5 ~== expected2 absTol 1e-15)
-    assert(y6 ~== expected2 absTol 1e-15)
-    assert(y7 ~== expected3 absTol 1e-15)
-    assert(y8 ~== expected3 absTol 1e-15)
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/BreezeMatrixConversionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/BreezeMatrixConversionSuite.scala
@@ -36,6 +36,11 @@ class BreezeMatrixConversionSuite extends FunSuite {
     assert(mat.numRows === breeze.rows)
     assert(mat.numCols === breeze.cols)
     assert(mat.values.eq(breeze.data), "should not copy data")
+    // transposed matrix
+    val matTransposed = Matrices.fromBreeze(breeze.t).asInstanceOf[DenseMatrix]
+    assert(matTransposed.numRows === breeze.cols)
+    assert(matTransposed.numCols === breeze.rows)
+    assert(matTransposed.values.eq(breeze.data), "should not copy data")
   }
 
   test("sparse matrix to breeze") {
@@ -58,5 +63,9 @@ class BreezeMatrixConversionSuite extends FunSuite {
     assert(mat.numRows === breeze.rows)
     assert(mat.numCols === breeze.cols)
     assert(mat.values.eq(breeze.data), "should not copy data")
+    val matTransposed = Matrices.fromBreeze(breeze.t).asInstanceOf[SparseMatrix]
+    assert(matTransposed.numRows === breeze.cols)
+    assert(matTransposed.numCols === breeze.rows)
+    assert(!matTransposed.values.eq(breeze.data), "has to copy data")
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
@@ -187,6 +187,40 @@ class MatricesSuite extends FunSuite {
     assert(sAT.toDense().toBreeze === dATexpected.toBreeze)
   }
 
+  test("foreachActive") {
+    val m = 3
+    val n = 2
+    val values = Array(1.0, 2.0, 4.0, 5.0)
+    val allValues = Array(1.0, 2.0, 0.0, 0.0, 4.0, 5.0)
+    val colPtrs = Array(0, 2, 4)
+    val rowIndices = Array(0, 1, 1, 2)
+
+    val sp = new SparseMatrix(m, n, colPtrs, rowIndices, values)
+    val dn = new DenseMatrix(m, n, allValues)
+
+    val dnMap = scala.collection.mutable.Map[(Int, Int), Double]()
+    dn.foreachActive { (i, j, index, value) =>
+      dnMap.put((i, j), value)
+    }
+    assert(dnMap.size === 6)
+    assert(dnMap.get(0, 0) === Some(1.0))
+    assert(dnMap.get(1, 0) === Some(2.0))
+    assert(dnMap.get(2, 0) === Some(0.0))
+    assert(dnMap.get(0, 1) === Some(0.0))
+    assert(dnMap.get(1, 1) === Some(4.0))
+    assert(dnMap.get(2, 1) === Some(5.0))
+
+    val spMap = scala.collection.mutable.Map[Int, Double]()
+    sp.foreachActive { (i, j, index, value) =>
+      spMap.put(index, value)
+    }
+    assert(spMap.size === 4)
+    assert(spMap.get(0) === Some(1.0))
+    assert(spMap.get(1) === Some(2.0))
+    assert(spMap.get(2) === Some(4.0))
+    assert(spMap.get(3) === Some(5.0))
+  }
+
   test("horzcat, vertcat, eye, speye") {
     val m = 3
     val n = 2

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
@@ -199,7 +199,7 @@ class MatricesSuite extends FunSuite {
     val dn = new DenseMatrix(m, n, allValues)
 
     val dnMap = scala.collection.mutable.Map[(Int, Int), Double]()
-    dn.foreachActive { (i, j, index, value) =>
+    dn.foreachActive { (i, j, value) =>
       dnMap.put((i, j), value)
     }
     assert(dnMap.size === 6)
@@ -211,8 +211,10 @@ class MatricesSuite extends FunSuite {
     assert(dnMap.get(2, 1) === Some(5.0))
 
     val spMap = scala.collection.mutable.Map[Int, Double]()
-    sp.foreachActive { (i, j, index, value) =>
-      spMap.put(index, value)
+    var cnt = 0
+    sp.foreachActive { (i, j, value) =>
+      spMap.put(cnt, value)
+      cnt += 1
     }
     assert(spMap.size === 4)
     assert(spMap.get(0) === Some(1.0))

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -60,8 +60,8 @@ object MimaExcludes {
               "org.apache.spark.mllib.linalg.Matrix.transpose"),
             ProblemFilters.exclude[MissingMethodProblem](
               "org.apache.spark.mllib.linalg.DenseMatrix.transposeMultiply"),
-            ProblemFilters.exclude[MissingMethodProblem](
-              "org.apache.spark.mllib.linalg.Matrix.isTrans_="),
+            ProblemFilters.exclude[MissingMethodProblem]("org.apache.spark.mllib.linalg.Matrix." +
+                "org$apache$spark$mllib$linalg$Matrix$_setter_$isTransposed_="),
             ProblemFilters.exclude[MissingMethodProblem](
               "org.apache.spark.mllib.linalg.Matrix.isTransposed"),
             ProblemFilters.exclude[MissingMethodProblem](

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -53,6 +53,16 @@ object MimaExcludes {
             ProblemFilters.exclude[MissingMethodProblem](
               "org.apache.spark.mllib.linalg.Matrices.rand")
           ) ++ Seq(
+            // SPARK-5321
+            ProblemFilters.exclude[MissingMethodProblem](
+              "org.apache.spark.mllib.linalg.SparseMatrix.transposeMultiply"),
+            ProblemFilters.exclude[MissingMethodProblem](
+              "org.apache.spark.mllib.linalg.Matrix.transpose"),
+            ProblemFilters.exclude[MissingMethodProblem](
+              "org.apache.spark.mllib.linalg.DenseMatrix.transposeMultiply"),
+            ProblemFilters.exclude[MissingMethodProblem](
+              "org.apache.spark.mllib.linalg.Matrix.isTransposed_=")
+          ) ++ Seq(
             // SPARK-3325
             ProblemFilters.exclude[MissingMethodProblem](
               "org.apache.spark.streaming.api.java.JavaDStreamLike.print"),

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -61,7 +61,9 @@ object MimaExcludes {
             ProblemFilters.exclude[MissingMethodProblem](
               "org.apache.spark.mllib.linalg.DenseMatrix.transposeMultiply"),
             ProblemFilters.exclude[MissingMethodProblem](
-              "org.apache.spark.mllib.linalg.Matrix.isTransposed_="),
+              "org.apache.spark.mllib.linalg.Matrix.isTrans_="),
+            ProblemFilters.exclude[MissingMethodProblem](
+              "org.apache.spark.mllib.linalg.Matrix.isTransposed"),
             ProblemFilters.exclude[MissingMethodProblem](
               "org.apache.spark.mllib.linalg.Matrix.foreachActive")
           ) ++ Seq(

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -61,7 +61,9 @@ object MimaExcludes {
             ProblemFilters.exclude[MissingMethodProblem](
               "org.apache.spark.mllib.linalg.DenseMatrix.transposeMultiply"),
             ProblemFilters.exclude[MissingMethodProblem](
-              "org.apache.spark.mllib.linalg.Matrix.isTransposed_=")
+              "org.apache.spark.mllib.linalg.Matrix.isTransposed_="),
+            ProblemFilters.exclude[MissingMethodProblem](
+              "org.apache.spark.mllib.linalg.Matrix.foreachActive")
           ) ++ Seq(
             // SPARK-3325
             ProblemFilters.exclude[MissingMethodProblem](


### PR DESCRIPTION
Support for transposing local matrices added. The `.transpose` function creates a new object re-using the backing array(s) but switches `numRows` and `numCols`. Operations check the flag `.isTransposed` to see whether the indexing in `values` should be modified.

This PR will pave the way for transposing `BlockMatrix`.
