### PR TITLE
[SPARK-5332][Core] Efficient way to deal with ExecutorLost

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1108,11 +1108,9 @@ class DAGScheduler(
       blockManagerMaster.removeExecutor(execId)
 
       if (!env.blockManager.externalShuffleServiceEnabled || fetchFailed) {
-        // TODO: This will be really slow if we keep accumulating shuffle map stages
         for ((shuffleId, stage) <- shuffleToMapStage) {
           stage.removeOutputsOnExecutor(execId)
-          val locs = stage.outputLocs.map(list => if (list.isEmpty) null else list.head).toArray
-          mapOutputTracker.registerMapOutputs(shuffleId, locs, changeEpoch = true)
+          mapOutputTracker.registerMapOutputs(shuffleId, stage.curOutputLocs, changeEpoch = true)
         }
         if (shuffleToMapStage.isEmpty) {
           mapOutputTracker.incrementEpoch()


### PR DESCRIPTION
Currently, the handler of the case when an executor being lost in DAGScheduler (`handleExecutorLost`) looks not efficient. This pr tries to add a bit of extra information to Stage class to improve that.
