### PR TITLE
[SPARK-5135][SQL] Add support for describe [extended] table to DDL in SQLContext

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
@@ -23,7 +23,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{SchemaRDD, SQLConf, SQLContext}
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.errors.TreeNodeException
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Row, Attribute}
+import org.apache.spark.sql.catalyst.expressions.{Row, Attribute}
 import org.apache.spark.sql.catalyst.plans.logical
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import scala.collection.mutable.ArrayBuffer

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
@@ -21,10 +21,12 @@ import org.apache.spark.Logging
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{SchemaRDD, SQLConf, SQLContext}
+import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.errors.TreeNodeException
-import org.apache.spark.sql.catalyst.expressions.{Row, Attribute}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Row, Attribute}
 import org.apache.spark.sql.catalyst.plans.logical
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import scala.collection.mutable.ArrayBuffer
 
 /**
  * A logical command that is executed for its side-effects.  `RunnableCommand`s are
@@ -178,3 +180,34 @@ case class DescribeCommand(
     child.output.map(field => Row(field.name, field.dataType.toString, null))
   }
 }
+
+/**
+ * :: DeveloperApi ::
+ */
+@DeveloperApi
+case class DDLDescribeCommand(
+    dbName: Option[String],
+    tableName: String, isExtended: Boolean) extends RunnableCommand {
+
+  override def run(sqlContext: SQLContext) = {
+    val tblRelation = dbName match {
+      case Some(db) => UnresolvedRelation(Seq(db, tableName))
+      case None => UnresolvedRelation(Seq(tableName))
+    }
+    val logicalRelation = sqlContext.executePlan(tblRelation).analyzed
+    val rows = new ArrayBuffer[Row]()
+    rows ++= logicalRelation.schema.fields.map{field =>
+      Row(field.name, field.dataType.toSimpleString, null)}
+
+    /*
+     * TODO if future support partition table, add header below:
+     * # Partition Information
+     * # col_name data_type comment
+     */
+    if (isExtended) { // TODO describe extended table
+      // rows += Row("# extended", null, null)
+    }
+    rows
+   }
+}
+

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/DDLTestSuit.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/DDLTestSuit.scala
@@ -1,0 +1,120 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.apache.spark.sql.sources
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.types._
+
+class DDLScanSource extends RelationProvider {
+  override def createRelation(
+      sqlContext: SQLContext,
+      parameters: Map[String, String]): BaseRelation = {
+      SimpleDDLScan(parameters("from").toInt, parameters("TO").toInt)(sqlContext)
+    }
+}
+
+case class SimpleDDLScan(from: Int, to: Int)(@transient val sqlContext: SQLContext)
+  extends TableScan {
+
+  override def schema =
+    StructType(Seq(
+      StructField("intType", IntegerType, nullable = false),
+      StructField("stringType", StringType, nullable = false),
+      StructField("dateType", DateType, nullable = false),
+      StructField("timestampType", TimestampType, nullable = false),
+      StructField("doubleType", DoubleType, nullable = false),
+      StructField("bigintType", LongType, nullable = false),
+      StructField("tinyintType", ByteType, nullable = false),
+      StructField("decimalType", DecimalType.Unlimited, nullable = false),
+      StructField("fixedDecimalType", DecimalType(5,1), nullable = false),
+      StructField("binaryType", BinaryType, nullable = false),
+      StructField("booleanType", BooleanType, nullable = false),
+      StructField("smallIntType", ShortType, nullable = false),
+      StructField("floatType", FloatType, nullable = false),
+      StructField("mapType", MapType(StringType, StringType)),
+      StructField("arrayType", ArrayType(StringType)),
+      StructField("structType",
+        StructType(StructField("f1",StringType) ::
+          (StructField("f2",IntegerType)) :: Nil
+        )
+      )
+    ))
+
+
+  override def buildScan() = sqlContext.sparkContext.parallelize(from to to).
+    map(e => Row(s"people$e",e*2))
+}
+
+class DDLTestSuit extends DataSourceTest {
+  import caseInsensisitiveContext._
+
+  before {
+      sql(
+          """
+          |CREATE TEMPORARY TABLE ddlPeople
+          |USING org.apache.spark.sql.sources.DDLScanSource
+          |OPTIONS (
+          |  From '1',
+          |  To '10'
+          |)
+          """.stripMargin)
+  }
+
+  sqlTest(
+      "describe ddlPeople",
+      Seq(
+        Row("intType", "int", null),
+        Row("stringType", "string", null),
+        Row("dateType", "date", null),
+        Row("timestampType", "timestamp", null),
+        Row("doubleType", "double", null),
+        Row("bigintType", "bigint", null),
+        Row("tinyintType", "tinyint", null),
+        Row("decimalType", "decimal(10,0)", null),
+        Row("fixedDecimalType", "decimal(5,1)", null),
+        Row("binaryType", "binary", null),
+        Row("booleanType", "boolean", null),
+        Row("smallIntType", "smallint", null),
+        Row("floatType", "float", null),
+        Row("mapType", "map<string,string>", null),
+        Row("arrayType", "array<string>", null),
+        Row("structType", "struct<f1:string,f2:int>", null)
+      ))
+
+  sqlTest(
+      "describe extended ddlPeople",
+      Seq(
+        Row("intType", "int", null),
+        Row("stringType", "string", null),
+        Row("dateType", "date", null),
+        Row("timestampType", "timestamp", null),
+        Row("doubleType", "double", null),
+        Row("bigintType", "bigint", null),
+        Row("tinyintType", "tinyint", null),
+        Row("decimalType", "decimal(10,0)", null),
+        Row("fixedDecimalType", "decimal(5,1)", null),
+        Row("binaryType", "binary", null),
+        Row("booleanType", "boolean", null),
+        Row("smallIntType", "smallint", null),
+        Row("floatType", "float", null),
+        Row("mapType", "map<string,string>", null),
+        Row("arrayType", "array<string>", null),
+        Row("structType", "struct<f1:string,f2:int>", null)
+        // Row("# extended", null, null)
+      ))
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/DDLTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/DDLTestSuite.scala
@@ -60,61 +60,61 @@ case class SimpleDDLScan(from: Int, to: Int)(@transient val sqlContext: SQLConte
     map(e => Row(s"people$e",e*2))
 }
 
-class DDLTestSuit extends DataSourceTest {
+class DDLTestSuite extends DataSourceTest {
   import caseInsensisitiveContext._
 
   before {
-      sql(
-          """
-          |CREATE TEMPORARY TABLE ddlPeople
-          |USING org.apache.spark.sql.sources.DDLScanSource
-          |OPTIONS (
-          |  From '1',
-          |  To '10'
-          |)
-          """.stripMargin)
+    sql(
+      """
+      |CREATE TEMPORARY TABLE ddlPeople
+      |USING org.apache.spark.sql.sources.DDLScanSource
+      |OPTIONS (
+      |  From '1',
+      |  To '10'
+      |)
+      """.stripMargin)
   }
 
   sqlTest(
-      "describe ddlPeople",
-      Seq(
-        Row("intType", "int", null),
-        Row("stringType", "string", null),
-        Row("dateType", "date", null),
-        Row("timestampType", "timestamp", null),
-        Row("doubleType", "double", null),
-        Row("bigintType", "bigint", null),
-        Row("tinyintType", "tinyint", null),
-        Row("decimalType", "decimal(10,0)", null),
-        Row("fixedDecimalType", "decimal(5,1)", null),
-        Row("binaryType", "binary", null),
-        Row("booleanType", "boolean", null),
-        Row("smallIntType", "smallint", null),
-        Row("floatType", "float", null),
-        Row("mapType", "map<string,string>", null),
-        Row("arrayType", "array<string>", null),
-        Row("structType", "struct<f1:string,f2:int>", null)
-      ))
+    "describe ddlPeople",
+    Seq(
+      Row("intType", "int", null),
+      Row("stringType", "string", null),
+      Row("dateType", "date", null),
+      Row("timestampType", "timestamp", null),
+      Row("doubleType", "double", null),
+      Row("bigintType", "bigint", null),
+      Row("tinyintType", "tinyint", null),
+      Row("decimalType", "decimal(10,0)", null),
+      Row("fixedDecimalType", "decimal(5,1)", null),
+      Row("binaryType", "binary", null),
+      Row("booleanType", "boolean", null),
+      Row("smallIntType", "smallint", null),
+      Row("floatType", "float", null),
+      Row("mapType", "map<string,string>", null),
+      Row("arrayType", "array<string>", null),
+      Row("structType", "struct<f1:string,f2:int>", null)
+    ))
 
   sqlTest(
-      "describe extended ddlPeople",
-      Seq(
-        Row("intType", "int", null),
-        Row("stringType", "string", null),
-        Row("dateType", "date", null),
-        Row("timestampType", "timestamp", null),
-        Row("doubleType", "double", null),
-        Row("bigintType", "bigint", null),
-        Row("tinyintType", "tinyint", null),
-        Row("decimalType", "decimal(10,0)", null),
-        Row("fixedDecimalType", "decimal(5,1)", null),
-        Row("binaryType", "binary", null),
-        Row("booleanType", "boolean", null),
-        Row("smallIntType", "smallint", null),
-        Row("floatType", "float", null),
-        Row("mapType", "map<string,string>", null),
-        Row("arrayType", "array<string>", null),
-        Row("structType", "struct<f1:string,f2:int>", null)
-        // Row("# extended", null, null)
-      ))
+    "describe extended ddlPeople",
+    Seq(
+      Row("intType", "int", null),
+      Row("stringType", "string", null),
+      Row("dateType", "date", null),
+      Row("timestampType", "timestamp", null),
+      Row("doubleType", "double", null),
+      Row("bigintType", "bigint", null),
+      Row("tinyintType", "tinyint", null),
+      Row("decimalType", "decimal(10,0)", null),
+      Row("fixedDecimalType", "decimal(5,1)", null),
+      Row("binaryType", "binary", null),
+      Row("booleanType", "boolean", null),
+      Row("smallIntType", "smallint", null),
+      Row("floatType", "float", null),
+      Row("mapType", "map<string,string>", null),
+      Row("arrayType", "array<string>", null),
+      Row("structType", "struct<f1:string,f2:int>", null)
+      // Row("# extended", null, null)
+    ))
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/DDLTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/DDLTestSuite.scala
@@ -24,8 +24,8 @@ class DDLScanSource extends RelationProvider {
   override def createRelation(
       sqlContext: SQLContext,
       parameters: Map[String, String]): BaseRelation = {
-      SimpleDDLScan(parameters("from").toInt, parameters("TO").toInt)(sqlContext)
-    }
+    SimpleDDLScan(parameters("from").toInt, parameters("TO").toInt)(sqlContext)
+  }
 }
 
 case class SimpleDDLScan(from: Int, to: Int)(@transient val sqlContext: SQLContext)
@@ -50,14 +50,15 @@ case class SimpleDDLScan(from: Int, to: Int)(@transient val sqlContext: SQLConte
       StructField("arrayType", ArrayType(StringType)),
       StructField("structType",
         StructType(StructField("f1",StringType) ::
-          (StructField("f2",IntegerType)) :: Nil
+          StructField("f2",IntegerType) :: Nil
         )
       )
     ))
 
 
-  override def buildScan() = sqlContext.sparkContext.parallelize(from to to).
-    map(e => Row(s"people$e",e*2))
+  override def buildScan() = sqlContext.sparkContext.parallelize(from to to).map { e =>
+    Row(s"people$e", e * 2)
+  }
 }
 
 class DDLTestSuite extends DataSourceTest {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -74,7 +74,7 @@ class HiveContext(sc: SparkContext) extends SQLContext(sc) {
       val ddlPlan = ddlParser(sqlText)
       val basicPlan = try {
         HiveQl.parseSql(sqlText)
-      }catch {
+      } catch {
         case e: Exception if ddlPlan.nonEmpty => ddlPlan.get
         case e: Throwable => throw e
       }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -80,7 +80,7 @@ class HiveContext(sc: SparkContext) extends SQLContext(sc) {
       }
       new SchemaRDD(this, basicPlan)
     } else {
-      sys.error(s"Unsupported SQL dialect: ${conf.dialect}.  Try 'sql' or 'hiveql'")
+      sys.error(s"Unsupported SQL dialect: ${conf.dialect}. Try 'sql' or 'hiveql'")
     }
   }
 


### PR DESCRIPTION
This brings https://github.com/apache/spark/pull/3935 up to date and fixes style violations. 
