### PR TITLE
[SPARK-5337][Mesos][Standalone] respect spark.task.cpus when scheduling Applications

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/ApplicationDescription.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/ApplicationDescription.scala
@@ -28,12 +28,11 @@ private[spark] class ApplicationDescription(
     val eventLogDir: Option[URI] = None,
     // short name of compression codec used when writing event logs, if any (e.g. lzf)
     val eventLogCodec: Option[String] = None,
-    val coresPerExecutor: Option[Int] = None)
+    val coresPerExecutor: Option[Int] = None,
+    val coresPerTask: Int = 1)
   extends Serializable {
 
   val user = System.getProperty("user.name", "<unknown>")
-
-  var coreNumPerTask = 1
 
   def copy(
       name: String = name,

--- a/core/src/main/scala/org/apache/spark/deploy/ApplicationDescription.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/ApplicationDescription.scala
@@ -33,6 +33,8 @@ private[spark] class ApplicationDescription(
 
   val user = System.getProperty("user.name", "<unknown>")
 
+  var coreNumPerTask = 1
+
   def copy(
       name: String = name,
       maxCores: Option[Int] = maxCores,

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -541,20 +541,26 @@ private[master] class Master(
     // in the queue, then the second app, etc.
     if (spreadOutApps) {
       // Try to spread out each app among all the nodes, until it has all its cores
-      for (app <- waitingApps if app.coresLeft >= app.desc.coreNumPerTask) {
-        val coreNumPerTask = app.desc.coreNumPerTask
+      for (app <- waitingApps if app.coresLeft >= app.desc.coresPerTask) {
+        val coreNumPerTask = app.desc.coresPerTask
         val usableWorkers = workers.toArray.filter(_.state == WorkerState.ALIVE)
           .filter(worker => worker.memoryFree >= app.desc.memoryPerExecutorMB &&
-            worker.coresFree >= app.desc.coresPerExecutor.getOrElse(1))
+            worker.coresFree >= math.max(app.desc.coresPerExecutor.getOrElse(1),
+              app.desc.coresPerTask))
           .sortBy(_.coresFree).reverse
         val numUsable = usableWorkers.length
         val assigned = new Array[Int](numUsable) // Number of cores to give on each node
         var toAssign = math.min(app.coresLeft, usableWorkers.map(_.coresFree).sum)
         var pos = 0
-        while (toAssign >= coreNumPerTask) {
+        val availableWorkerSet = new HashSet[Int]
+        // Take into account the number of cores the application uses per task
+        // to avoid starving executors or wasting cluster resources (SPARK-5337)
+        while (toAssign >= coreNumPerTask && availableWorkerSet.size < usableWorkers.length) {
           if (usableWorkers(pos).coresFree - assigned(pos) >= coreNumPerTask) {
             toAssign -= coreNumPerTask
             assigned(pos) += coreNumPerTask
+          } else {
+            availableWorkerSet += pos
           }
           pos = (pos + 1) % numUsable
         }
@@ -566,7 +572,7 @@ private[master] class Master(
     } else {
       // Pack each app into as few workers as possible until we've assigned all its cores
       for (worker <- workers if worker.coresFree > 0 && worker.state == WorkerState.ALIVE) {
-        for (app <- waitingApps if app.coresLeft > 0) {
+        for (app <- waitingApps if app.coresLeft > app.desc.coresPerTask) {
           allocateWorkerResourceToExecutors(app, app.coresLeft, worker)
         }
       }
@@ -583,9 +589,12 @@ private[master] class Master(
       app: ApplicationInfo,
       coresToAllocate: Int,
       worker: WorkerInfo): Unit = {
+    val cpuPerTask = app.desc.coresPerTask
     val memoryPerExecutor = app.desc.memoryPerExecutorMB
-    val coresPerExecutor = app.desc.coresPerExecutor.getOrElse(coresToAllocate)
-    var coresLeft = coresToAllocate
+    var coresLeft = coresToAllocate - coresToAllocate % cpuPerTask
+    val coresPerExecutor = math.max(
+      app.desc.coresPerExecutor.getOrElse(coresLeft),
+      app.desc.coresPerTask)
     while (coresLeft >= coresPerExecutor && worker.memoryFree >= memoryPerExecutor) {
       val exec = app.addExecutor(worker, coresPerExecutor)
       coresLeft -= coresPerExecutor

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -542,6 +542,7 @@ private[master] class Master(
     if (spreadOutApps) {
       // Try to spread out each app among all the nodes, until it has all its cores
       for (app <- waitingApps if app.coresLeft >= app.desc.coreNumPerTask) {
+        val coreNumPerTask = app.desc.coreNumPerTask
         val usableWorkers = workers.toArray.filter(_.state == WorkerState.ALIVE)
           .filter(worker => worker.memoryFree >= app.desc.memoryPerExecutorMB &&
             worker.coresFree >= app.desc.coresPerExecutor.getOrElse(1))
@@ -550,10 +551,10 @@ private[master] class Master(
         val assigned = new Array[Int](numUsable) // Number of cores to give on each node
         var toAssign = math.min(app.coresLeft, usableWorkers.map(_.coresFree).sum)
         var pos = 0
-        while (toAssign >= app.desc.coreNumPerTask) {
-          if (usableWorkers(pos).coresFree - assigned(pos) >= app.desc.coreNumPerTask) {
-            toAssign -= app.desc.coreNumPerTask
-            assigned(pos) += app.desc.coreNumPerTask
+        while (toAssign >= coreNumPerTask) {
+          if (usableWorkers(pos).coresFree - assigned(pos) >= coreNumPerTask) {
+            toAssign -= coreNumPerTask
+            assigned(pos) += coreNumPerTask
           }
           pos = (pos + 1) % numUsable
         }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -72,7 +72,7 @@ private[spark] class TaskSchedulerImpl(
 
   if (CPUS_PER_TASK < 1) {
     throw new IllegalArgumentException(
-      s"\"spark.task.cpus\" must be greater than 0! (was $CPUS_PER_TASK)")
+      s"spark.task.cpus must be greater than 0! (was $CPUS_PER_TASK)")
   }
 
   // TaskSetManagers are not thread safe, so any access to one should be synchronized

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -75,6 +75,13 @@ private[spark] class TaskSchedulerImpl(
       s"spark.task.cpus must be greater than 0! (was $CPUS_PER_TASK)")
   }
 
+  val maxCores = conf.get("spark.cores.max",  Int.MaxValue.toString).toInt
+
+  if (maxCores < CPUS_PER_TASK) {
+    throw new IllegalArgumentException(
+      s"spark.task.cpus ($CPUS_PER_TASK) should not be larger than spark.cores.max ($maxCores)")
+  }
+
   // TaskSetManagers are not thread safe, so any access to one should be synchronized
   // on this class.
   val activeTaskSets = new HashMap[String, TaskSetManager]

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -70,6 +70,11 @@ private[spark] class TaskSchedulerImpl(
   // CPUs to request per task
   val CPUS_PER_TASK = conf.getInt("spark.task.cpus", 1)
 
+  if (CPUS_PER_TASK < 1) {
+    throw new IllegalArgumentException(
+      s"\"spark.task.cpus\" must be greater than 0! (was $CPUS_PER_TASK)")
+  }
+
   // TaskSetManagers are not thread safe, so any access to one should be synchronized
   // on this class.
   val activeTaskSets = new HashMap[String, TaskSetManager]

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
@@ -95,7 +95,7 @@ private[spark] class SparkDeploySchedulerBackend(
       args, sc.executorEnvs, classPathEntries ++ testingClassPath, libraryPathEntries, javaOpts)
     val appUIAddress = sc.ui.map(_.appUIAddress).getOrElse("")
     val appDesc = new ApplicationDescription(sc.appName, maxCores, sc.executorMemory, command,
-      appUIAddress, sc.eventLogDir)
+      appUIAddress, sc.eventLogDir, sc.eventLogCodec)
     appDesc.coreNumPerTask = coreNumPerTask
     client = new AppClient(sc.env.actorSystem, masters, appDesc, this, conf)
     client.start()

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
@@ -49,6 +49,11 @@ private[spark] class SparkDeploySchedulerBackend(
     throw new IllegalArgumentException(
       s"spark.task.cpus is set to an invalid value $coreNumPerTask")
   }
+
+  if (maxCores.isDefined && maxCores.get < coreNumPerTask) {
+    throw new IllegalArgumentException(
+      s"spark.task.cpus ($coreNumPerTask) should not be larger than spark.cores.max ($maxCores)")
+  }
   
   val totalExpectedCores = maxCores.getOrElse(0)
 

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
@@ -85,6 +85,11 @@ private[spark] class SparkDeploySchedulerBackend(
     val coresPerExecutor = conf.getOption("spark.executor.cores").map(_.toInt)
     val appDesc = new ApplicationDescription(sc.appName, maxCores, sc.executorMemory,
       command, appUIAddress, sc.eventLogDir, sc.eventLogCodec, coresPerExecutor)
+    appDesc.coreNumPerTask = scheduler.CPUS_PER_TASK
+    if (appDesc.coreNumPerTask < 1) {
+      throw new IllegalArgumentException("spark.task.cpus is set to an invalid value " +
+        s"${appDesc.coreNumPerTask}")
+    }
     client = new AppClient(sc.env.actorSystem, masters, appDesc, this, conf)
     client.start()
     waitForRegistration()

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
@@ -43,14 +43,13 @@ private[spark] class SparkDeploySchedulerBackend(
   private val registrationBarrier = new Semaphore(0)
 
   val maxCores = conf.getOption("spark.cores.max").map(_.toInt)
-  val coreNumPerTask = {
-    val corePerTask = scheduler.CPUS_PER_TASK
-    if (corePerTask < 1) {
-      throw new IllegalArgumentException(
-        s"spark.task.cpus is set to an invalid value $corePerTask")
-    }
-    corePerTask
+  val coreNumPerTask = scheduler.CPUS_PER_TASK
+    
+  if (coreNumPerTask < 1) {
+    throw new IllegalArgumentException(
+      s"spark.task.cpus is set to an invalid value $coreNumPerTask")
   }
+  
   val totalExpectedCores = maxCores.getOrElse(0)
 
   override def start() {

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
@@ -87,8 +87,8 @@ private[spark] class SparkDeploySchedulerBackend(
       command, appUIAddress, sc.eventLogDir, sc.eventLogCodec, coresPerExecutor)
     appDesc.coreNumPerTask = scheduler.CPUS_PER_TASK
     if (appDesc.coreNumPerTask < 1) {
-      throw new IllegalArgumentException("spark.task.cpus is set to an invalid value " +
-        s"${appDesc.coreNumPerTask}")
+      throw new IllegalArgumentException(
+        s"spark.task.cpus is set to an invalid value ${appDesc.coreNumPerTask}")  
     }
     client = new AppClient(sc.env.actorSystem, masters, appDesc, this, conf)
     client.start()

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
@@ -43,15 +43,9 @@ private[spark] class SparkDeploySchedulerBackend(
   private val registrationBarrier = new Semaphore(0)
 
   val maxCores = conf.getOption("spark.cores.max").map(_.toInt)
-  val coreNumPerTask = scheduler.CPUS_PER_TASK
-    
-  if (maxCores.isDefined && maxCores.get < coreNumPerTask) {
-    throw new IllegalArgumentException(
-      s"spark.task.cpus ($coreNumPerTask) should not be larger than spark.cores.max ($maxCores)")
-  }
-  
   val totalExpectedCores = maxCores.getOrElse(0)
-
+  val coresPerTask = scheduler.CPUS_PER_TASK
+    
   override def start() {
     super.start()
 
@@ -91,7 +85,7 @@ private[spark] class SparkDeploySchedulerBackend(
     val appUIAddress = sc.ui.map(_.appUIAddress).getOrElse("")
     val coresPerExecutor = conf.getOption("spark.executor.cores").map(_.toInt)
     val appDesc = new ApplicationDescription(sc.appName, maxCores, sc.executorMemory, command,
-      appUIAddress, sc.eventLogDir, sc.eventLogCodec, coresPerExecutor, coreNumPerTask)
+      appUIAddress, sc.eventLogDir, sc.eventLogCodec, coresPerExecutor, coresPerTask)
     client = new AppClient(sc.env.actorSystem, masters, appDesc, this, conf)
     client.start()
     waitForRegistration()

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
@@ -96,7 +96,7 @@ private[spark] class CoarseMesosSchedulerBackend(
 
   override def start() {
     super.start()
-    
+
     synchronized {
       new Thread("CoarseMesosSchedulerBackend driver") {
         setDaemon(true)

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
@@ -65,11 +65,6 @@ private[spark] class CoarseMesosSchedulerBackend(
   
   val coresPerTask = scheduler.CPUS_PER_TASK
 
-  if (maxCores < coresPerTask) {
-    throw new IllegalArgumentException(
-      s"spark.task.cpus ($coresPerTask) should not be larger than spark.cores.max ($maxCores)")
-  }
-
   // Cores we have acquired with each Mesos task ID
   val coresByTaskId = new HashMap[Int, Int]
   var totalCoresAcquired = 0

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
@@ -62,7 +62,9 @@ private[spark] class CoarseMesosSchedulerBackend(
 
   // Maximum number of cores to acquire (TODO: we'll need more flexible controls here)
   val maxCores = conf.get("spark.cores.max",  Int.MaxValue.toString).toInt
-
+  
+  val coreNumPerTask = conf.getInt("spark.task.cpus", 1)
+  
   // Cores we have acquired with each Mesos task ID
   val coresByTaskId = new HashMap[Int, Int]
   var totalCoresAcquired = 0
@@ -87,7 +89,12 @@ private[spark] class CoarseMesosSchedulerBackend(
 
   override def start() {
     super.start()
-
+    
+    if (coreNumPerTask < 1) {
+      throw new IllegalArgumentException(
+        s"spark.task.cpus is set to an invalid value $coreNumPerTask")
+    }
+    
     synchronized {
       new Thread("CoarseMesosSchedulerBackend driver") {
         setDaemon(true)
@@ -213,13 +220,13 @@ private[spark] class CoarseMesosSchedulerBackend(
         val slaveId = offer.getSlaveId.toString
         val mem = getResource(offer.getResourcesList, "mem")
         val cpus = getResource(offer.getResourcesList, "cpus").toInt
+        val cpusToUse = math.min(cpus, maxCores - totalCoresAcquired)
         if (totalCoresAcquired < maxCores &&
+            cpusToUse >= coreNumPerTask &&
             mem >= MemoryUtils.calculateTotalMemory(sc) &&
-            cpus >= 1 &&
             failuresBySlaveId.getOrElse(slaveId, 0) < MAX_SLAVE_FAILURES &&
             !slaveIdsWithExecutors.contains(slaveId)) {
           // Launch an executor on the slave
-          val cpusToUse = math.min(cpus, maxCores - totalCoresAcquired)
           totalCoresAcquired += cpusToUse
           val taskId = newMesosTaskId()
           taskIdToSlaveId(taskId) = slaveId

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
@@ -70,6 +70,11 @@ private[spark] class CoarseMesosSchedulerBackend(
       s"spark.task.cpus is set to an invalid value $coreNumPerTask")
   }
 
+  if (maxCores < coreNumPerTask) {
+    throw new IllegalArgumentException(
+      s"spark.task.cpus ($coreNumPerTask) should not be larger than spark.cores.max ($maxCores)")
+  }
+
   // Cores we have acquired with each Mesos task ID
   val coresByTaskId = new HashMap[Int, Int]
   var totalCoresAcquired = 0

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
@@ -63,13 +63,11 @@ private[spark] class CoarseMesosSchedulerBackend(
   // Maximum number of cores to acquire (TODO: we'll need more flexible controls here)
   val maxCores = conf.get("spark.cores.max",  Int.MaxValue.toString).toInt
   
-  val coreNumPerTask = {
-    val corePerTask = conf.getInt("spark.task.cpus", 1)
-    if (corePerTask < 1) {
-      throw new IllegalArgumentException(
-        s"spark.task.cpus is set to an invalid value $corePerTask")
-    }
-    corePerTask
+  val coreNumPerTask = conf.getInt("spark.task.cpus", 1)
+    
+  if (coreNumPerTask < 1) {
+    throw new IllegalArgumentException(
+      s"spark.task.cpus is set to an invalid value $coreNumPerTask")
   }
 
   // Cores we have acquired with each Mesos task ID


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-5337

Currently, we didn't consider spark.task.cpus when scheduling the applications in Master, so that we may fall into one of the following cases
1. the executor gets N cores but we need M cores to run a single task, where N < M
2. the executor gets N cores, we need M cores to run a single task, where N % M != 0 && N > M; so that we waste some cores in the executor

Patch for YARN is in submitted by @WangTaoTheTonic : https://github.com/apache/spark/pull/4123
