### PR TITLE
[CORE][minor]remove unnecessary use of existential type in DAGScheduler

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/ActiveJob.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ActiveJob.scala
@@ -28,7 +28,7 @@ import org.apache.spark.util.CallSite
 private[spark] class ActiveJob(
     val jobId: Int,
     val finalStage: Stage,
-    val func: (TaskContext, Iterator[_]) => _,
+    val func: (TaskContext, Iterator[Any]) => Any,
     val partitions: Array[Int],
     val callSite: CallSite,
     val listener: JobListener,

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGSchedulerEvent.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGSchedulerEvent.scala
@@ -38,7 +38,7 @@ private[scheduler] sealed trait DAGSchedulerEvent
 private[scheduler] case class JobSubmitted(
     jobId: Int,
     finalRDD: RDD[_],
-    func: (TaskContext, Iterator[_]) => _,
+    func: (TaskContext, Iterator[Any]) => Any,
     partitions: Array[Int],
     allowLocal: Boolean,
     callSite: CallSite,

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -200,8 +200,8 @@ class DAGSchedulerSuite extends FunSuiteLike  with BeforeAndAfter with LocalSpar
    * below, we do not expect this function to ever be executed; instead, we will return results
    * directly through CompletionEvents.
    */
-  private val jobComputeFunc = (context: TaskContext, it: Iterator[(_)]) =>
-     it.next.asInstanceOf[Tuple2[_, _]]._1
+  private val jobComputeFunc = (context: TaskContext, it: Iterator[Any]) =>
+     it.next.asInstanceOf[(Any, Any)]._1
 
   /** Send the given CompletionEvent messages for the tasks in the TaskSet. */
   private def complete(taskSet: TaskSet, results: Seq[(TaskEndReason, Any)]) {
@@ -228,7 +228,7 @@ class DAGSchedulerSuite extends FunSuiteLike  with BeforeAndAfter with LocalSpar
   private def submit(
       rdd: RDD[_],
       partitions: Array[Int],
-      func: (TaskContext, Iterator[_]) => _ = jobComputeFunc,
+      func: (TaskContext, Iterator[Any]) => Any = jobComputeFunc,
       allowLocal: Boolean = false,
       listener: JobListener = jobListener): Int = {
     val jobId = scheduler.nextJobId.getAndIncrement()


### PR DESCRIPTION
In `DAGScheduler` we use `(TaskContext, Iterator[_]) => _` to represent the type of the function that process the elements of RDD. And it's a shorthand for `(TaskContext, Iterator[T] forSome {type T}) => U forSome {type U}`, means we don't care what's the type parameter of Iterator and the return type of this function.
As `Iterator` and the return type of `Function2` is covariant,  `(TaskContext, Iterator[_]) => _` is actually identical to `(TaskContext, Iterator[Any]) => Any`.
So I think we can avoid using existential type here and make the code clear and simple.
