### PR TITLE
[SPARK-5374][CORE] abstract RDD's DAG graph iteration in DAGScheduler

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -99,7 +99,7 @@ class DAGScheduler(
   private[scheduler] val activeJobs = new HashSet[ActiveJob]
 
   // Contains the locations that each RDD's partitions are cached on
-  private val cacheLocs = new HashMap[Int, Array[Seq[TaskLocation]]]
+  private val cacheLocs = new HashMap[Int, Seq[Seq[TaskLocation]]]
 
   // For tracking failed nodes, we use the MapOutputTracker's epoch number, which is sent with
   // every task. When we detect a node failing, we note the current epoch number and failed
@@ -181,19 +181,45 @@ class DAGScheduler(
     eventProcessLoop.post(TaskSetFailed(taskSet, reason))
   }
 
-  private def getCacheLocs(rdd: RDD[_]): Array[Seq[TaskLocation]] = {
+  private def getCacheLocs(rdd: RDD[_]): Seq[Seq[TaskLocation]] = {
     if (!cacheLocs.contains(rdd.id)) {
       val blockIds = rdd.partitions.indices.map(index => RDDBlockId(rdd.id, index)).toArray[BlockId]
-      val locs = BlockManager.blockIdsToBlockManagers(blockIds, env, blockManagerMaster)
-      cacheLocs(rdd.id) = blockIds.map { id =>
-        locs.getOrElse(id, Nil).map(bm => TaskLocation(bm.host, bm.executorId))
-      }
+      val locs = blockManagerMaster.getLocations(blockIds)
+        .map(_.map(bm => TaskLocation(bm.host, bm.executorId)))
+      cacheLocs(rdd.id) = locs
     }
     cacheLocs(rdd.id)
   }
 
   private def clearCacheLocs() {
     cacheLocs.clear()
+  }
+
+  /**
+   * iterate RDD graph through lineage, and process ShuffleDependency by user function
+   */
+  private def iterateRDDGraph(
+              rdd: RDD[_],
+              continueAfterShuffle: Boolean,
+              fun: ShuffleDependency[_, _, _] => Unit,
+              filter: RDD[_] => Boolean = _ => true): Unit = {
+    val visited = new HashSet[RDD[_]]
+    val waitingForVisit = new Stack[RDD[_]]
+    waitingForVisit.push(rdd)
+    while (waitingForVisit.nonEmpty) {
+      val r = waitingForVisit.pop()
+      if (visited.add(r) && filter(r)) {
+        for (dep <- r.dependencies) {
+          dep match {
+            case shufDep: ShuffleDependency[_, _, _] =>
+              fun(shufDep)
+              if (continueAfterShuffle) waitingForVisit.push(shufDep.rdd)
+            case _ =>
+              waitingForVisit.push(dep.rdd)
+          }
+        }
+      }
+    }
   }
 
   /**
@@ -277,29 +303,7 @@ class DAGScheduler(
    */
   private def getParentStages(rdd: RDD[_], jobId: Int): List[Stage] = {
     val parents = new HashSet[Stage]
-    val visited = new HashSet[RDD[_]]
-    // We are manually maintaining a stack here to prevent StackOverflowError
-    // caused by recursively visiting
-    val waitingForVisit = new Stack[RDD[_]]
-    def visit(r: RDD[_]) {
-      if (!visited(r)) {
-        visited += r
-        // Kind of ugly: need to register RDDs with the cache here since
-        // we can't do it in its constructor because # of partitions is unknown
-        for (dep <- r.dependencies) {
-          dep match {
-            case shufDep: ShuffleDependency[_, _, _] =>
-              parents += getShuffleMapStage(shufDep, jobId)
-            case _ =>
-              waitingForVisit.push(dep.rdd)
-          }
-        }
-      }
-    }
-    waitingForVisit.push(rdd)
-    while (!waitingForVisit.isEmpty) {
-      visit(waitingForVisit.pop())
-    }
+    iterateRDDGraph(rdd, false, shufDep => parents += getShuffleMapStage(shufDep, jobId))
     parents.toList
   }
 
@@ -319,37 +323,23 @@ class DAGScheduler(
   // Find ancestor shuffle dependencies that are not registered in shuffleToMapStage yet
   private def getAncestorShuffleDependencies(rdd: RDD[_]): Stack[ShuffleDependency[_, _, _]] = {
     val parents = new Stack[ShuffleDependency[_, _, _]]
-    val visited = new HashSet[RDD[_]]
-    // We are manually maintaining a stack here to prevent StackOverflowError
-    // caused by recursively visiting
-    val waitingForVisit = new Stack[RDD[_]]
-    def visit(r: RDD[_]) {
-      if (!visited(r)) {
-        visited += r
-        for (dep <- r.dependencies) {
-          dep match {
-            case shufDep: ShuffleDependency[_, _, _] =>
-              if (!shuffleToMapStage.contains(shufDep.shuffleId)) {
-                parents.push(shufDep)
-              }
-
-              waitingForVisit.push(shufDep.rdd)
-            case _ =>
-              waitingForVisit.push(dep.rdd)
-          }
-        }
+    iterateRDDGraph(rdd, true, shufDep => {
+      if (!shuffleToMapStage.contains(shufDep.shuffleId)) {
+        parents.push(shufDep)
       }
-    }
-
-    waitingForVisit.push(rdd)
-    while (!waitingForVisit.isEmpty) {
-      visit(waitingForVisit.pop())
-    }
+    })
     parents
   }
 
   private def getMissingParentStages(stage: Stage): List[Stage] = {
-    stage.parents.filter(s => getCacheLocs(s.rdd).contains(Nil) && !s.isAvailable)
+    val missing = new HashSet[Stage]
+    iterateRDDGraph(stage.rdd, false, shufDep => {
+      val mapStage = getShuffleMapStage(shufDep, stage.jobId)
+      if (!mapStage.isAvailable) {
+        missing += mapStage
+      }
+    }, rdd => getCacheLocs(rdd).contains(Nil))
+    missing.toList
   }
 
   /**
@@ -1230,7 +1220,7 @@ class DAGScheduler(
   {
     // If the partition has already been visited, no need to re-visit.
     // This avoids exponential path exploration.  SPARK-695
-    if (!visited.add((rdd,partition))) {
+    if (!visited.add((rdd, partition))) {
       // Nil has already been returned for previously visited partitions.
       return Nil
     }


### PR DESCRIPTION
There are many methods in `DAGScheduler` that iterate an RDD's DAG graph such as `getParentStages`, `getMissingParentStages` and so on. We should abstract this process to reduce code size.
