### PR TITLE
[SPARK-5361]Multiple Java RDD <-> Python RDD conversions not working correctly

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonHadoopUtil.scala
@@ -138,6 +138,11 @@ private[python] class JavaToWritableConverter extends Converter[Any, Writable] {
           mapWritable.put(convertToWritable(k), convertToWritable(v))
         }
         mapWritable
+      case array: Array[Any] => {
+        val arrayWriteable = new ArrayWritable(classOf[Writable])
+        arrayWriteable.set(array.map(convertToWritable(_)))
+        arrayWriteable
+      }
       case other => throw new SparkException(
         s"Data of type ${other.getClass.getName} cannot be used")
     }

--- a/core/src/main/scala/org/apache/spark/api/python/SerDeUtil.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/SerDeUtil.scala
@@ -153,7 +153,10 @@ private[spark] object SerDeUtil extends Logging {
       iter.flatMap { row =>
         val obj = unpickle.loads(row)
         if (batched) {
-          obj.asInstanceOf[JArrayList[_]].asScala
+          obj match {
+            case array: Array[Any] => array.toList
+            case _ => obj.asInstanceOf[JArrayList[_]].asScala
+          }
         } else {
           Seq(obj)
         }

--- a/core/src/main/scala/org/apache/spark/api/python/SerDeUtil.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/SerDeUtil.scala
@@ -154,7 +154,7 @@ private[spark] object SerDeUtil extends Logging {
         val obj = unpickle.loads(row)
         if (batched) {
           obj match {
-            case array: Array[Any] => array.toList
+            case array: Array[Any] => array.toSeq
             case _ => obj.asInstanceOf[JArrayList[_]].asScala
           }
         } else {

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -1125,19 +1125,19 @@ class InputFormatTests(ReusedPySparkTestCase):
 
     def test_newhadoop(self):
         basepath = self.tempdir.name
-        ints = sorted(self.sc.newAPIHadoopFile(\
-            basepath + "/sftestdata/sfint/",\
-            "org.apache.hadoop.mapreduce.lib.input.SequenceFileInputFormat",\
-            "org.apache.hadoop.io.IntWritable",\
+        ints = sorted(self.sc.newAPIHadoopFile(
+            basepath + "/sftestdata/sfint/",
+            "org.apache.hadoop.mapreduce.lib.input.SequenceFileInputFormat",
+            "org.apache.hadoop.io.IntWritable",
             "org.apache.hadoop.io.Text").collect())
         ei = [(1, u'aa'), (1, u'aa'), (2, u'aa'), (2, u'bb'), (2, u'bb'), (3, u'cc')]
         self.assertEqual(ints, ei)
 
         hellopath = os.path.join(SPARK_HOME, "python/test_support/hello.txt")
         newconf = {"mapred.input.dir": hellopath}
-        hello = self.sc.newAPIHadoopRDD("org.apache.hadoop.mapreduce.lib.input.TextInputFormat",\
-                                        "org.apache.hadoop.io.LongWritable",\
-                                        "org.apache.hadoop.io.Text",\
+        hello = self.sc.newAPIHadoopRDD("org.apache.hadoop.mapreduce.lib.input.TextInputFormat",
+                                        "org.apache.hadoop.io.LongWritable",
+                                        "org.apache.hadoop.io.Text",
                                         conf=newconf).collect()
         result = [(0, u'Hello World!')]
         self.assertEqual(hello, result)

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -249,7 +249,6 @@ class SerializationTestCase(unittest.TestCase):
         self.assertEqual(["abc", u"123", range(5)] + range(1000), list(ser.load_stream(io)))
 
 
-
 class PySparkTestCase(unittest.TestCase):
 
     def setUp(self):
@@ -718,7 +717,7 @@ class RDDTests(ReusedPySparkTestCase):
     def test_multiple_python_java_RDD_conversions(self):
         # Regression test for SPARK-5361
         data = [
-            (u'1', {u'director': u'David Lean'}), 
+            (u'1', {u'director': u'David Lean'}),
             (u'2', {u'director': u'Andrew Dominik'})
         ]
         from pyspark.rdd import RDD


### PR DESCRIPTION
This is found through reading RDD from `sc.newAPIHadoopRDD` and writing it back using `rdd.saveAsNewAPIHadoopFile` in pyspark.

It turns out that whenever there are multiple RDD conversions from JavaRDD to PythonRDD then back to JavaRDD, the exception below happens:

```
15/01/16 10:28:31 ERROR Executor: Exception in task 0.0 in stage 3.0 (TID 7)
java.lang.ClassCastException: [Ljava.lang.Object; cannot be cast to java.util.ArrayList
    at org.apache.spark.api.python.SerDeUtil$$anonfun$pythonToJava$1$$anonfun$apply$1.apply(SerDeUtil.scala:157)
    at org.apache.spark.api.python.SerDeUtil$$anonfun$pythonToJava$1$$anonfun$apply$1.apply(SerDeUtil.scala:153)
    at scala.collection.Iterator$$anon$13.hasNext(Iterator.scala:371)
    at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:308)
```

The test case code below reproduces it:

```
from pyspark.rdd import RDD

dl = [
    (u'2', {u'director': u'David Lean'}), 
    (u'7', {u'director': u'Andrew Dominik'})
]

dl_rdd = sc.parallelize(dl)
tmp = dl_rdd._to_java_object_rdd()
tmp2 = sc._jvm.SerDe.javaToPython(tmp)
t = RDD(tmp2, sc)
t.count()

tmp = t._to_java_object_rdd()
tmp2 = sc._jvm.SerDe.javaToPython(tmp)
t = RDD(tmp2, sc)
t.count() # it blows up here during the 2nd time of conversion
```
