### PR TITLE
[MLLIB] SPARK-5362 (4526, 2372) Gradient and Optimizer to support generic output (instead of label) and data batches

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/optimization/Gradient.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/optimization/Gradient.scala
@@ -51,6 +51,24 @@ abstract class Gradient extends Serializable {
    * @return loss
    */
   def compute(data: Vector, label: Double, weights: Vector, cumGradient: Vector): Double
+
+  /**
+   * Compute the gradient and loss given the features of a single data point,
+   * add the gradient to a provided vector to avoid creating new objects, and return loss.
+   * This is a more generic version of compute, when one can pass complex output
+   * instead of a single label or pass data and output in batches
+   *
+   * @param data features for one or many data points
+   * @param output vector of outputs for this (these) data point(s)
+   * @param weights weights/coefficients corresponding to features
+   * @param cumGradient the computed gradient will be added to this vector
+   *
+   * @return loss
+   */
+  def compute(data: Vector, output: Vector, weights: Vector, cumGradient: Vector): Double = {
+    val label = output(0)
+    compute(data, label, weights, cumGradient)
+  }
 }
 
 /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/optimization/GradientDescent.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/optimization/GradientDescent.scala
@@ -104,7 +104,7 @@ class GradientDescent private[mllib] (private var gradient: Gradient, private va
    * @return solution vector
    */
   @DeveloperApi
-  def optimize(data: RDD[(Double, Vector)], initialWeights: Vector): Vector = {
+  def optimize(data: RDD[(Vector, Vector)], initialWeights: Vector): Vector = {
     val (weights, _) = GradientDescent.runMiniBatchSGD(
       data,
       gradient,
@@ -148,7 +148,7 @@ object GradientDescent extends Logging {
    *         stochastic loss computed for every iteration.
    */
   def runMiniBatchSGD(
-      data: RDD[(Double, Vector)],
+      data: RDD[(Vector, Vector)],
       gradient: Gradient,
       updater: Updater,
       stepSize: Double,
@@ -189,7 +189,7 @@ object GradientDescent extends Logging {
       val (gradientSum, lossSum, miniBatchSize) = data.sample(false, miniBatchFraction, 42 + i)
         .treeAggregate((BDV.zeros[Double](n), 0.0, 0L))(
           seqOp = (c, v) => {
-            // c: (grad, loss, count), v: (label, features)
+            // c: (grad, loss, count), v: (output, features)
             val l = gradient.compute(v._2, v._1, bcWeights.value, Vectors.fromBreeze(c._1))
             (c._1, c._2 + l, c._3 + 1)
           },

--- a/mllib/src/main/scala/org/apache/spark/mllib/optimization/LBFGS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/optimization/LBFGS.scala
@@ -111,7 +111,7 @@ class LBFGS(private var gradient: Gradient, private var updater: Updater)
     this
   }
 
-  override def optimize(data: RDD[(Double, Vector)], initialWeights: Vector): Vector = {
+  override def optimize(data: RDD[(Vector, Vector)], initialWeights: Vector): Vector = {
     val (weights, _) = LBFGS.runLBFGS(
       data,
       gradient,
@@ -152,7 +152,7 @@ object LBFGS extends Logging {
    *         computed for every iteration.
    */
   def runLBFGS(
-      data: RDD[(Double, Vector)],
+      data: RDD[(Vector, Vector)],
       gradient: Gradient,
       updater: Updater,
       numCorrections: Int,
@@ -196,7 +196,7 @@ object LBFGS extends Logging {
    * at a particular point (weights). It's used in Breeze's convex optimization routines.
    */
   private class CostFun(
-    data: RDD[(Double, Vector)],
+    data: RDD[(Vector, Vector)],
     gradient: Gradient,
     updater: Updater,
     regParam: Double,
@@ -210,9 +210,9 @@ object LBFGS extends Logging {
       val localGradient = gradient
 
       val (gradientSum, lossSum) = data.treeAggregate((Vectors.zeros(n), 0.0))(
-          seqOp = (c, v) => (c, v) match { case ((grad, loss), (label, features)) =>
+          seqOp = (c, v) => (c, v) match { case ((grad, loss), (output, features)) =>
             val l = localGradient.compute(
-              features, label, bcW.value, grad)
+              features, output, bcW.value, grad)
             (grad, loss + l)
           },
           combOp = (c1, c2) => (c1, c2) match { case ((grad1, loss1), (grad2, loss2)) =>

--- a/mllib/src/main/scala/org/apache/spark/mllib/optimization/Optimizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/optimization/Optimizer.scala
@@ -32,5 +32,5 @@ trait Optimizer extends Serializable {
   /**
    * Solve the provided convex optimization problem.
    */
-  def optimize(data: RDD[(Double, Vector)], initialWeights: Vector): Vector
+  def optimize(data: RDD[(Vector, Vector)], initialWeights: Vector): Vector
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/GeneralizedLinearAlgorithm.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/GeneralizedLinearAlgorithm.scala
@@ -191,15 +191,19 @@ abstract class GeneralizedLinearAlgorithm[M <: GeneralizedLinearModel]
     val data = if (addIntercept) {
       if(useFeatureScaling) {
         input.map(labeledPoint =>
-          (labeledPoint.label, appendBias(scaler.transform(labeledPoint.features))))
+          (Vectors.dense(Array(labeledPoint.label)),
+            appendBias(scaler.transform(labeledPoint.features))))
       } else {
-        input.map(labeledPoint => (labeledPoint.label, appendBias(labeledPoint.features)))
+        input.map(labeledPoint =>
+          (Vectors.dense(Array(labeledPoint.label)), appendBias(labeledPoint.features)))
       }
     } else {
       if (useFeatureScaling) {
-        input.map(labeledPoint => (labeledPoint.label, scaler.transform(labeledPoint.features)))
+        input.map(labeledPoint =>
+          (Vectors.dense(Array(labeledPoint.label)), scaler.transform(labeledPoint.features)))
       } else {
-        input.map(labeledPoint => (labeledPoint.label, labeledPoint.features))
+        input.map(labeledPoint =>
+          (Vectors.dense(Array(labeledPoint.label)), labeledPoint.features))
       }
     }
 

--- a/mllib/src/test/scala/org/apache/spark/mllib/optimization/GradientDescentSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/optimization/GradientDescentSuite.scala
@@ -81,7 +81,7 @@ class GradientDescentSuite extends FunSuite with MLlibTestSparkContext with Matc
     // Add a extra variable consisting of all 1.0's for the intercept.
     val testData = GradientDescentSuite.generateGDInput(A, B, nPoints, 42)
     val data = testData.map { case LabeledPoint(label, features) =>
-      label -> Vectors.dense(1.0 +: features.toArray)
+      Vectors.dense(Array(label)) -> Vectors.dense(1.0 +: features.toArray)
     }
 
     val dataRDD = sc.parallelize(data, 2).cache()
@@ -111,7 +111,7 @@ class GradientDescentSuite extends FunSuite with MLlibTestSparkContext with Matc
     // Add a extra variable consisting of all 1.0's for the intercept.
     val testData = GradientDescentSuite.generateGDInput(2.0, -1.5, 10000, 42)
     val data = testData.map { case LabeledPoint(label, features) =>
-      label -> Vectors.dense(1.0 +: features.toArray)
+      Vectors.dense(Array(label)) -> Vectors.dense(1.0 +: features.toArray)
     }
 
     val dataRDD = sc.parallelize(data, 2).cache()
@@ -147,7 +147,7 @@ class GradientDescentClusterSuite extends FunSuite with LocalClusterSparkContext
     val n = 200000
     val points = sc.parallelize(0 until m, 2).mapPartitionsWithIndex { (idx, iter) =>
       val random = new Random(idx)
-      iter.map(i => (1.0, Vectors.dense(Array.fill(n)(random.nextDouble()))))
+      iter.map(i => (Vectors.dense(Array(1.0)), Vectors.dense(Array.fill(n)(random.nextDouble()))))
     }.cache()
     // If we serialize data directly in the task closure, the size of the serialized task would be
     // greater than 1MB and hence Spark would throw an error.

--- a/mllib/src/test/scala/org/apache/spark/mllib/optimization/LBFGSSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/optimization/LBFGSSuite.scala
@@ -45,7 +45,7 @@ class LBFGSSuite extends FunSuite with MLlibTestSparkContext with Matchers {
   // Add an extra variable consisting of all 1.0's for the intercept.
   val testData = GradientDescentSuite.generateGDInput(A, B, nPoints, 42)
   val data = testData.map { case LabeledPoint(label, features) =>
-    label -> Vectors.dense(1.0 +: features.toArray)
+    Vectors.dense(Array(label)) -> Vectors.dense(1.0 +: features.toArray)
   }
 
   lazy val dataRDD = sc.parallelize(data, 2).cache()
@@ -236,7 +236,7 @@ class LBFGSClusterSuite extends FunSuite with LocalClusterSparkContext {
     val n = 200000
     val examples = sc.parallelize(0 until m, 2).mapPartitionsWithIndex { (idx, iter) =>
       val random = new Random(idx)
-      iter.map(i => (1.0, Vectors.dense(Array.fill(n)(random.nextDouble))))
+      iter.map(i => (Vectors.dense(Array(1.0)), Vectors.dense(Array.fill(n)(random.nextDouble))))
     }.cache()
     val lbfgs = new LBFGS(new LogisticGradient, new SquaredL2Updater)
       .setNumCorrections(1)


### PR DESCRIPTION
Currently, Gradient and Optimizer interfaces support data in form of RDD[Double, Vector] which refers to label and features. This limits its application to classification problems. For example, artificial neural network demands Vector as output (instead of label: Double). Moreover, current interface does not support data batches. I propose to replace label: Double with output: Vector. It enables passing generic output instead of label and also passing data and output batches stored in corresponding vectors.
