### PR TITLE
[SPARK-4879] Use the Spark driver to authorize Hadoop commits.

### DIFF
--- a/core/src/main/scala/org/apache/spark/CommitDeniedException.scala
+++ b/core/src/main/scala/org/apache/spark/CommitDeniedException.scala
@@ -29,3 +29,4 @@ class CommitDeniedException(msg: String, jobID: Int, splitID: Int, attemptID: In
   extends Exception(msg) {
   def toTaskEndReason(): TaskEndReason = new TaskCommitDenied(jobID, splitID, attemptID)
 }
+

--- a/core/src/main/scala/org/apache/spark/CommitDeniedException.scala
+++ b/core/src/main/scala/org/apache/spark/CommitDeniedException.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark
+
+import org.apache.spark.annotation.DeveloperApi
+
+/**
+ * :: DeveloperApi ::
+ * Exception thrown when a task attempts to commit output to Hadoop, but
+ * is denied by the driver.
+ */
+@DeveloperApi
+class CommitDeniedException(msg: String, jobID: Int, splitID: Int, attemptID: Int)
+  extends Exception(msg) {
+  def toTaskEndReason(): TaskEndReason = new TaskCommitDenied(jobID, splitID, attemptID)
+}

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -34,7 +34,7 @@ import org.apache.spark.metrics.MetricsSystem
 import org.apache.spark.network.BlockTransferService
 import org.apache.spark.network.netty.NettyBlockTransferService
 import org.apache.spark.network.nio.NioBlockTransferService
-import org.apache.spark.scheduler.LiveListenerBus
+import org.apache.spark.scheduler.{OutputCommitCoordinator, LiveListenerBus}
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.{ShuffleMemoryManager, ShuffleManager}
 import org.apache.spark.storage._
@@ -67,6 +67,7 @@ class SparkEnv (
     val sparkFilesDir: String,
     val metricsSystem: MetricsSystem,
     val shuffleMemoryManager: ShuffleMemoryManager,
+    val outputCommitCoordinator: OutputCommitCoordinator,
     val conf: SparkConf) extends Logging {
 
   private[spark] var isStopped = false
@@ -86,6 +87,7 @@ class SparkEnv (
     blockManager.stop()
     blockManager.master.stop()
     metricsSystem.stop()
+    outputCommitCoordinator.stop()
     actorSystem.shutdown()
     // Unfortunately Akka's awaitTermination doesn't actually wait for the Netty server to shut
     // down, but let's call it anyway in case it gets fixed in a later release
@@ -346,6 +348,11 @@ object SparkEnv extends Logging {
         "levels using the RDD.persist() method instead.")
     }
 
+    val outputCommitCoordinator = new OutputCommitCoordinator
+    val outputCommitCoordinatorActor = registerOrLookup("OutputCommitCoordinator",
+      OutputCommitCoordinator.createActor(outputCommitCoordinator))
+    outputCommitCoordinator.coordinatorActor = outputCommitCoordinatorActor
+
     new SparkEnv(
       executorId,
       actorSystem,
@@ -362,6 +369,7 @@ object SparkEnv extends Logging {
       sparkFilesDir,
       metricsSystem,
       shuffleMemoryManager,
+      outputCommitCoordinator,
       conf)
   }
 

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -353,8 +353,7 @@ object SparkEnv extends Logging {
     val outputCommitCoordinator = new OutputCommitCoordinator(conf)
     val outputCommitCoordinatorActor = registerOrLookup("OutputCommitCoordinator",
       new OutputCommitCoordinatorActor(outputCommitCoordinator))
-    outputCommitCoordinator.initialize(outputCommitCoordinatorActor, isDriver)
-
+    outputCommitCoordinator.coordinatorActor = Some(outputCommitCoordinatorActor)
     new SparkEnv(
       executorId,
       actorSystem,

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -351,7 +351,7 @@ object SparkEnv extends Logging {
     val outputCommitCoordinator = new OutputCommitCoordinator(conf)
     val outputCommitCoordinatorActor = registerOrLookup("OutputCommitCoordinator",
       OutputCommitCoordinator.createActor(outputCommitCoordinator))
-    outputCommitCoordinator.coordinatorActor = outputCommitCoordinatorActor
+    outputCommitCoordinator.coordinatorActor = Some(outputCommitCoordinatorActor)
 
     new SparkEnv(
       executorId,

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -20,6 +20,8 @@ package org.apache.spark
 import java.io.File
 import java.net.Socket
 
+import org.apache.spark.scheduler.OutputCommitCoordinator.OutputCommitCoordinatorActor
+
 import scala.collection.JavaConversions._
 import scala.collection.mutable
 import scala.util.Properties
@@ -350,8 +352,8 @@ object SparkEnv extends Logging {
 
     val outputCommitCoordinator = new OutputCommitCoordinator(conf)
     val outputCommitCoordinatorActor = registerOrLookup("OutputCommitCoordinator",
-      OutputCommitCoordinator.createActor(outputCommitCoordinator))
-    outputCommitCoordinator.coordinatorActor = Some(outputCommitCoordinatorActor)
+      new OutputCommitCoordinatorActor(outputCommitCoordinator))
+    outputCommitCoordinator.initialize(outputCommitCoordinatorActor, isDriver)
 
     new SparkEnv(
       executorId,

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -348,7 +348,7 @@ object SparkEnv extends Logging {
         "levels using the RDD.persist() method instead.")
     }
 
-    val outputCommitCoordinator = new OutputCommitCoordinator
+    val outputCommitCoordinator = new OutputCommitCoordinator(conf)
     val outputCommitCoordinatorActor = registerOrLookup("OutputCommitCoordinator",
       OutputCommitCoordinator.createActor(outputCommitCoordinator))
     outputCommitCoordinator.coordinatorActor = outputCommitCoordinatorActor

--- a/core/src/main/scala/org/apache/spark/SparkHadoopWriter.scala
+++ b/core/src/main/scala/org/apache/spark/SparkHadoopWriter.scala
@@ -108,8 +108,7 @@ class SparkHadoopWriter(@transient jobConf: JobConf)
     val cmtr = getOutputCommitter()
     if (cmtr.needsTaskCommit(taCtxt)) {
       val outputCommitCoordinator = SparkEnv.get.outputCommitCoordinator
-      val canCommit = outputCommitCoordinator.canCommit(jobID,
-        taID.value.getTaskID().getId(), splitID, attemptID)
+      val canCommit = outputCommitCoordinator.canCommit(jobID, splitID, attemptID)
       if (canCommit) {
         try {
           cmtr.commitTask(taCtxt)
@@ -124,13 +123,11 @@ class SparkHadoopWriter(@transient jobConf: JobConf)
       } else {
         val msg: String = s"$taID: Not committed because the driver did not authorize commit"
         logInfo(msg)
+        cmtr.abortTask(taCtxt)
         throw new CommitDeniedException(msg, jobID, splitID, attemptID)
       }
     } else {
-      val msg: String = s"No need to commit output of task" +
-        " because needsTaskCommit=false: ${taID.value}"
-      logInfo(msg)
-      throw new CommitDeniedException(msg, jobID, splitID, attemptID)
+      logInfo(s"No need to commit output of task because needsTaskCommit=false: ${taID.value}")
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/SparkHadoopWriter.scala
+++ b/core/src/main/scala/org/apache/spark/SparkHadoopWriter.scala
@@ -122,10 +122,14 @@ class SparkHadoopWriter(@transient jobConf: JobConf)
           }
         }
       } else {
-        logInfo(s"$taID: Not committed because DAGScheduler did not authorize commit")
+        val msg: String = s"$taID: Not committed because the driver did not authorize commit"
+        logInfo(msg)
+        throw new CommitDeniedException(msg, jobID, splitID, attemptID)
       }
     } else {
-      logInfo(s"No need to commit output of task because needsTaskCommit=false: ${taID.value}")
+      val msg: String = s"No need to commit output of task because needsTaskCommit=false: ${taID.value}"
+      logInfo(msg)
+      throw new CommitDeniedException(msg, jobID, splitID, attemptID)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/SparkHadoopWriter.scala
+++ b/core/src/main/scala/org/apache/spark/SparkHadoopWriter.scala
@@ -45,8 +45,6 @@ class SparkHadoopWriter(@transient jobConf: JobConf)
   private val now = new Date()
   private val conf = new SerializableWritable(jobConf)
 
-  private val outputCommitCoordinator = SparkEnv.get.outputCommitCoordinator
-
   private var jobID = 0
   private var splitID = 0
   private var attemptID = 0
@@ -109,6 +107,7 @@ class SparkHadoopWriter(@transient jobConf: JobConf)
     val taCtxt = getTaskContext()
     val cmtr = getOutputCommitter()
     if (cmtr.needsTaskCommit(taCtxt)) {
+      val outputCommitCoordinator = SparkEnv.get.outputCommitCoordinator
       val conf = SparkEnv.get.conf
       val timeout = AkkaUtils.askTimeout(conf)
       val maxAttempts = AkkaUtils.numRetries(conf)

--- a/core/src/main/scala/org/apache/spark/SparkHadoopWriter.scala
+++ b/core/src/main/scala/org/apache/spark/SparkHadoopWriter.scala
@@ -127,7 +127,8 @@ class SparkHadoopWriter(@transient jobConf: JobConf)
         throw new CommitDeniedException(msg, jobID, splitID, attemptID)
       }
     } else {
-      val msg: String = s"No need to commit output of task because needsTaskCommit=false: ${taID.value}"
+      val msg: String = s"No need to commit output of task"
+        + " because needsTaskCommit=false: ${taID.value}"
       logInfo(msg)
       throw new CommitDeniedException(msg, jobID, splitID, attemptID)
     }

--- a/core/src/main/scala/org/apache/spark/SparkHadoopWriter.scala
+++ b/core/src/main/scala/org/apache/spark/SparkHadoopWriter.scala
@@ -127,8 +127,8 @@ class SparkHadoopWriter(@transient jobConf: JobConf)
         throw new CommitDeniedException(msg, jobID, splitID, attemptID)
       }
     } else {
-      val msg: String = s"No need to commit output of task"
-        + " because needsTaskCommit=false: ${taID.value}"
+      val msg: String = s"No need to commit output of task" +
+        " because needsTaskCommit=false: ${taID.value}"
       logInfo(msg)
       throw new CommitDeniedException(msg, jobID, splitID, attemptID)
     }

--- a/core/src/main/scala/org/apache/spark/SparkHadoopWriter.scala
+++ b/core/src/main/scala/org/apache/spark/SparkHadoopWriter.scala
@@ -109,11 +109,7 @@ class SparkHadoopWriter(@transient jobConf: JobConf)
     if (cmtr.needsTaskCommit(taCtxt)) {
       val outputCommitCoordinator = SparkEnv.get.outputCommitCoordinator
       val conf = SparkEnv.get.conf
-      val timeout = AkkaUtils.askTimeout(conf)
-      val maxAttempts = AkkaUtils.numRetries(conf)
-      val retryInterval = AkkaUtils.retryWaitMs(conf)
-      val canCommit: Boolean = outputCommitCoordinator.canCommit(jobID, splitID, attemptID,
-        maxAttempts, retryInterval, timeout)
+      val canCommit: Boolean = outputCommitCoordinator.canCommit(jobID, splitID, attemptID)
       if (canCommit) {
         try {
           cmtr.commitTask(taCtxt)

--- a/core/src/main/scala/org/apache/spark/SparkHadoopWriter.scala
+++ b/core/src/main/scala/org/apache/spark/SparkHadoopWriter.scala
@@ -108,8 +108,8 @@ class SparkHadoopWriter(@transient jobConf: JobConf)
     val cmtr = getOutputCommitter()
     if (cmtr.needsTaskCommit(taCtxt)) {
       val outputCommitCoordinator = SparkEnv.get.outputCommitCoordinator
-      val conf = SparkEnv.get.conf
-      val canCommit: Boolean = outputCommitCoordinator.canCommit(jobID, splitID, attemptID)
+      val canCommit = outputCommitCoordinator.canCommit(jobID,
+        taID.value.getTaskID().getId(), splitID, attemptID)
       if (canCommit) {
         try {
           cmtr.commitTask(taCtxt)

--- a/core/src/main/scala/org/apache/spark/TaskEndReason.scala
+++ b/core/src/main/scala/org/apache/spark/TaskEndReason.scala
@@ -148,6 +148,20 @@ case object TaskKilled extends TaskFailedReason {
 
 /**
  * :: DeveloperApi ::
+ * Task requested the driver to commit, but was denied.
+ */
+@DeveloperApi
+case class TaskCommitDenied(
+    jobID: Int,
+    splitID: Int,
+    attemptID: Int)
+  extends TaskFailedReason {
+  override def toErrorString: String = s"TaskCommitDenied (Driver denied task commit)" +
+    s" for job: $jobID, split: $splitID, attempt: $attemptID"
+}
+
+/**
+ * :: DeveloperApi ::
  * The task failed because the executor that it was running on was lost. This may happen because
  * the task crashed the JVM.
  */

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -248,6 +248,11 @@ private[spark] class Executor(
           execBackend.statusUpdate(taskId, TaskState.KILLED, ser.serialize(TaskKilled))
         }
 
+        case cDE: CommitDeniedException => {
+          val reason = cDE.toTaskEndReason
+          execBackend.statusUpdate(taskId, TaskState.FAILED, ser.serialize(reason))
+        }
+
         case t: Throwable => {
           // Attempt to exit cleanly by informing the driver of our failure.
           // If anything goes wrong (or this was a fatal exception), we will delegate to

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -913,7 +913,8 @@ class DAGScheduler(
     val taskType = Utils.getFormattedClassName(task)
     val isSuccess = event.reason == Success
 
-    outputCommitCoordinator.taskCompleted(stageId, task.partitionId, event.taskInfo.taskId, isSuccess)
+    outputCommitCoordinator.taskCompleted(stageId, task.partitionId,
+      event.taskInfo.taskId, isSuccess)
 
     // The success case is dealt with separately below, since we need to compute accumulator
     // updates before posting.

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -113,6 +113,7 @@ class DAGScheduler(
   // This is only safe because DAGScheduler runs in a single thread.
   private val closureSerializer = SparkEnv.get.closureSerializer.newInstance()
 
+
   /** If enabled, we may run certain actions like take() and first() locally. */
   private val localExecutionEnabled = sc.getConf.getBoolean("spark.localExecution.enabled", false)
 
@@ -1374,7 +1375,6 @@ private[scheduler] class DAGSchedulerEventProcessLoop(dagScheduler: DAGScheduler
 
     case ResubmitFailedStages =>
       dagScheduler.resubmitFailedStages()
-
   }
 
   override def onError(e: Throwable): Unit = {

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1082,6 +1082,9 @@ class DAGScheduler(
           handleExecutorLost(bmAddress.executorId, fetchFailed = true, Some(task.epoch))
         }
 
+      case TaskCommitDenied(jobID, splitID, attemptID) =>
+      // Do nothing here, left up to the TaskScheduler to decide how to handle denied commits
+
       case ExceptionFailure(className, description, stackTrace, fullStackTrace, metrics) =>
         // Do nothing here, left up to the TaskScheduler to decide how to handle user failures
 

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -810,7 +810,7 @@ class DAGScheduler(
     // will be posted, which should always come after a corresponding SparkListenerStageSubmitted
     // event.
     stage.latestInfo = StageInfo.fromStage(stage, Some(partitionsToCompute.size))
-    outputCommitCoordinator.stageStart(stage.id)
+    outputCommitCoordinator.stageStart(stage.id, partitionsToCompute)
     listenerBus.post(SparkListenerStageSubmitted(stage.latestInfo, properties))
 
     // TODO: Maybe we can keep the taskBinary in Stage to avoid serializing it multiple times.
@@ -914,8 +914,9 @@ class DAGScheduler(
     val taskType = Utils.getFormattedClassName(task)
     val isSuccess = event.reason == Success
 
-    outputCommitCoordinator.taskCompleted(stageId, task.partitionId,
-      event.taskInfo.taskId, isSuccess)
+    outputCommitCoordinator.taskCompleted(stageId, event.taskInfo.taskId,
+       task.partitionId, event.taskInfo.attempt,
+       isSuccess)
 
     // The success case is dealt with separately below, since we need to compute accumulator
     // updates before posting.

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGSchedulerEvent.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGSchedulerEvent.scala
@@ -77,4 +77,3 @@ private[scheduler]
 case class TaskSetFailed(taskSet: TaskSet, reason: String) extends DAGSchedulerEvent
 
 private[scheduler] case object ResubmitFailedStages extends DAGSchedulerEvent
-

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGSchedulerEvent.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGSchedulerEvent.scala
@@ -77,3 +77,4 @@ private[scheduler]
 case class TaskSetFailed(taskSet: TaskSet, reason: String) extends DAGSchedulerEvent
 
 private[scheduler] case object ResubmitFailedStages extends DAGSchedulerEvent
+

--- a/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala
@@ -17,32 +17,38 @@
 
 package org.apache.spark.scheduler
 
-import scala.collection.mutable
-import scala.concurrent.duration.FiniteDuration
+import java.util.concurrent.{ExecutorService, TimeUnit, Executors, ConcurrentHashMap}
 
-import akka.actor.{PoisonPill, ActorRef, Actor}
+import scala.collection.{Map => ScalaImmutableMap}
+import scala.collection.concurrent.{Map => ScalaConcurrentMap}
+import scala.collection.convert.decorateAsScala._
+
+import akka.actor.{ActorRef, Actor}
 
 import org.apache.spark.{SparkConf, Logging}
 import org.apache.spark.util.{AkkaUtils, ActorLogReceive}
 
-private[spark] sealed trait OutputCommitCoordinationMessage extends Serializable
+private[spark] sealed trait OutputCommitCoordinationMessage
 
-private[spark] case class StageStarted(stage: Int) extends OutputCommitCoordinationMessage
+private[spark] case class StageStarted(stage: Int, partitionIds: Seq[Int])
+  extends OutputCommitCoordinationMessage
 private[spark] case class StageEnded(stage: Int) extends OutputCommitCoordinationMessage
 private[spark] case object StopCoordinator extends OutputCommitCoordinationMessage
 
 private[spark] case class AskPermissionToCommitOutput(
     stage: Int,
     task: Long,
+    partId: Int,
     taskAttempt: Long)
-    extends OutputCommitCoordinationMessage
+  extends OutputCommitCoordinationMessage with Serializable
 
 private[spark] case class TaskCompleted(
     stage: Int,
     task: Long,
+    partId: Int,
     attempt: Long,
     successful: Boolean)
-    extends OutputCommitCoordinationMessage
+  extends OutputCommitCoordinationMessage
 
 /**
  * Authority that decides whether tasks can commit output to HDFS.
@@ -52,96 +58,150 @@ private[spark] case class TaskCompleted(
  */
 private[spark] class OutputCommitCoordinator(conf: SparkConf) extends Logging {
 
-  // Initialized by SparkEnv
-  var coordinatorActor: Option[ActorRef] = None
-  private val timeout = AkkaUtils.askTimeout(conf)
-  private val maxAttempts = AkkaUtils.numRetries(conf)
-  private val retryInterval = AkkaUtils.retryWaitMs(conf)
-
   private type StageId = Int
+  private type PartitionId = Int
   private type TaskId = Long
   private type TaskAttemptId = Long
 
-  private val authorizedCommittersByStage:
-  mutable.Map[StageId, mutable.Map[TaskId, TaskAttemptId]] = mutable.HashMap()
+  // Wrapper for an int option that allows it to be locked via a synchronized block
+  // while still setting option itself to Some(...) or None.
+  private class LockableAttemptId(var value: Option[TaskAttemptId])
 
-  def stageStart(stage: StageId) {
-    sendToActor(StageStarted(stage))
+  private type CommittersByStageHashMap =
+    ConcurrentHashMap[StageId, ScalaImmutableMap[PartitionId, LockableAttemptId]]
+
+  // Initialized by SparkEnv
+  private var coordinatorActor: Option[ActorRef] = None
+  private val timeout = AkkaUtils.askTimeout(conf)
+  private val maxAttempts = AkkaUtils.numRetries(conf)
+  private val retryInterval = AkkaUtils.retryWaitMs(conf)
+  private val authorizedCommittersByStage = new CommittersByStageHashMap().asScala
+
+  private var executorRequestHandlingThreadPool: Option[ExecutorService] = None
+
+  def stageStart(stage: StageId, partitionIds: Seq[Int]): Unit = {
+    sendToActor(StageStarted(stage, partitionIds))
   }
-  def stageEnd(stage: StageId) {
+
+  def stageEnd(stage: StageId): Unit = {
     sendToActor(StageEnded(stage))
   }
 
   def canCommit(
       stage: StageId,
       task: TaskId,
+      partId: PartitionId,
       attempt: TaskAttemptId): Boolean = {
-    askActor(AskPermissionToCommitOutput(stage, task, attempt))
+    askActor(AskPermissionToCommitOutput(stage, task, partId, attempt))
   }
 
   def taskCompleted(
       stage: StageId,
       task: TaskId,
+      partId: PartitionId,
       attempt: TaskAttemptId,
-      successful: Boolean) {
-    sendToActor(TaskCompleted(stage, task, attempt, successful))
+      successful: Boolean): Unit = {
+    sendToActor(TaskCompleted(stage, task, partId, attempt, successful))
   }
 
-  def stop() {
+  def stop(): Unit = {
+    executorRequestHandlingThreadPool.foreach { pool =>
+      pool.shutdownNow()
+      pool.awaitTermination(10, TimeUnit.SECONDS)
+    }
     sendToActor(StopCoordinator)
     coordinatorActor = None
-    authorizedCommittersByStage.foreach(_._2.clear)
+    executorRequestHandlingThreadPool = None
     authorizedCommittersByStage.clear
   }
 
-  private def handleStageStart(stage: StageId): Unit = {
-    authorizedCommittersByStage(stage) = mutable.HashMap[TaskId, TaskAttemptId]()
+  def initialize(actor: ActorRef, isDriver: Boolean): Unit = {
+    coordinatorActor = Some(actor)
+    executorRequestHandlingThreadPool = {
+      if (isDriver) {
+        Some(Executors.newFixedThreadPool(4))
+      } else {
+        None
+      }
+    }
+  }
+
+  // Methods that mutate the internal state of the coordinator shouldn't be
+  // called directly, and are thus made private instead of public. The
+  // private methods should be called from the Actor, and callers use the
+  // public methods to send messages to the actor.
+  private def handleStageStart(stage: StageId, partitionIds: Seq[Int]): Unit = {
+    val initialLockStates = partitionIds.map(partId => {
+      partId -> new LockableAttemptId(None)
+    }).toMap
+    authorizedCommittersByStage.put(stage, initialLockStates)
   }
 
   private def handleStageEnd(stage: StageId): Unit = {
     authorizedCommittersByStage.remove(stage)
   }
 
-  private def handleAskPermissionToCommit(
+  private def determineIfCommitAllowed(
       stage: StageId,
       task: TaskId,
-      attempt: TaskAttemptId):
-      Boolean = {
-    if (!authorizedCommittersByStage.contains(stage)) {
-      logDebug(s"Stage $stage has completed, so not allowing task attempt $attempt to commit")
-      return false
+      partId: PartitionId,
+      attempt: TaskAttemptId): Boolean = {
+    authorizedCommittersByStage.get(stage) match {
+      case Some(authorizedCommitters) =>
+        val authorizedCommitMetadataForPart = authorizedCommitters(partId)
+        authorizedCommitMetadataForPart.synchronized {
+          // Don't use match - we'll be setting the value of the option in the else block
+          if (authorizedCommitMetadataForPart.value.isDefined) {
+            val existingCommitter = authorizedCommitMetadataForPart.value.get
+            logDebug(s"Denying $attempt to commit for stage=$stage, task=$task; " +
+              s"existingCommitter = $existingCommitter")
+            false
+          } else {
+            logDebug(s"Authorizing $attempt to commit for stage=$stage, task=$task")
+            authorizedCommitMetadataForPart.value = Some(attempt)
+            true
+          }
+        }
+      case None =>
+        logDebug(s"Stage $stage has completed, so not allowing task attempt $attempt to commit")
+        false
     }
-    val authorizedCommitters = authorizedCommittersByStage(stage)
-    if (authorizedCommitters.contains(task)) {
-      val existingCommitter = authorizedCommitters(task)
-      logDebug(s"Denying $attempt to commit for stage=$stage, task=$task; " +
-        s"existingCommitter = $existingCommitter")
-      false
-    } else {
-      logDebug(s"Authorizing $attempt to commit for stage=$stage, task=$task")
-      authorizedCommitters(task) = attempt
-      true
-    }
+  }
+
+  private def handleAskPermissionToCommitOutput(
+      requester: ActorRef,
+      stage: StageId,
+      task: TaskId,
+      partId: PartitionId,
+      attempt: TaskAttemptId): Unit = {
+    executorRequestHandlingThreadPool.foreach(_.submit(
+      new AskCommitRunnable(requester, this, stage, task, partId, attempt)))
   }
 
   private def handleTaskCompletion(
       stage: StageId,
       task: TaskId,
+      partId: PartitionId,
       attempt: TaskAttemptId,
       successful: Boolean): Unit = {
-    if (!authorizedCommittersByStage.contains(stage)) {
-      logDebug(s"Ignoring task completion for completed stage")
-      return
-    }
-    val authorizedCommitters = authorizedCommittersByStage(stage)
-    if (authorizedCommitters.get(task) == Some(attempt) && !successful) {
-      logDebug(s"Authorized committer $attempt (stage=$stage, task=$task) failed; clearing lock")
-      // The authorized committer failed; clear the lock so future attempts can commit their output
-      authorizedCommitters.remove(task)
+    authorizedCommittersByStage.get(stage) match {
+      case Some(authorizedCommitters) =>
+        val authorizedCommitMetadataForPart = authorizedCommitters(partId)
+        authorizedCommitMetadataForPart.synchronized {
+          if (authorizedCommitMetadataForPart.value == Some(attempt) && !successful) {
+            logDebug(s"Authorized committer $attempt (stage=$stage," +
+              s" task=$task) failed; clearing lock")
+            // The authorized committer failed; clear the lock so future attempts can
+            // commit their output
+            authorizedCommitMetadataForPart.value = None
+          }
+        }
+      case None =>
+        logDebug(s"Ignoring task completion for completed stage")
     }
   }
 
-  private def sendToActor(msg: OutputCommitCoordinationMessage) {
+  private def sendToActor(msg: OutputCommitCoordinationMessage): Unit = {
     coordinatorActor.foreach(_ ! msg)
   }
 
@@ -150,29 +210,43 @@ private[spark] class OutputCommitCoordinator(conf: SparkConf) extends Logging {
       .map(AkkaUtils.askWithReply[Boolean](msg, _, maxAttempts, retryInterval, timeout))
       .getOrElse(false)
   }
+
+  class AskCommitRunnable(
+      private val requester: ActorRef,
+      private val outputCommitCoordinator: OutputCommitCoordinator,
+      private val stage: StageId,
+      private val task: TaskId,
+      private val partId: PartitionId,
+      private val taskAttempt: TaskAttemptId)
+  extends Runnable {
+    override def run(): Unit = {
+     requester ! outputCommitCoordinator.determineIfCommitAllowed(stage, task, partId, taskAttempt)
+    }
+  }
 }
 
 private[spark] object OutputCommitCoordinator {
 
+  // Actor is defined inside the OutputCommitCoordinator object so that receiveWithLogging()
+  // can call the private methods, where it is safe to do so because it is in the actor event
+  // loop.
   class OutputCommitCoordinatorActor(outputCommitCoordinator: OutputCommitCoordinator)
     extends Actor with ActorLogReceive with Logging {
 
-    override def receiveWithLogging = {
-      case StageStarted(stage) =>
-        outputCommitCoordinator.handleStageStart(stage)
+    override def receiveWithLogging() = {
+      case StageStarted(stage, partitionIds) =>
+        outputCommitCoordinator.handleStageStart(stage, partitionIds)
       case StageEnded(stage) =>
         outputCommitCoordinator.handleStageEnd(stage)
-      case AskPermissionToCommitOutput(stage, task, taskAttempt) =>
-        sender ! outputCommitCoordinator.handleAskPermissionToCommit(stage, task, taskAttempt)
-      case TaskCompleted(stage, task, attempt, successful) =>
-        outputCommitCoordinator.handleTaskCompletion(stage, task, attempt, successful)
+      case AskPermissionToCommitOutput(stage, task, partId, taskAttempt) =>
+        outputCommitCoordinator.handleAskPermissionToCommitOutput(
+          sender, stage, task, partId, taskAttempt)
+      case TaskCompleted(stage, task, partId, attempt, successful) =>
+        outputCommitCoordinator.handleTaskCompletion(stage, task, partId, attempt, successful)
       case StopCoordinator =>
         logInfo("OutputCommitCoordinator stopped!")
         context.stop(self)
         sender ! true
     }
-  }
-  def createActor(coordinator: OutputCommitCoordinator): OutputCommitCoordinatorActor = {
-    new OutputCommitCoordinatorActor(coordinator)
   }
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala
@@ -17,12 +17,13 @@
 
 package org.apache.spark.scheduler
 
-import akka.actor.{PoisonPill, ActorRef, Actor}
-import org.apache.spark.Logging
-import org.apache.spark.util.{AkkaUtils, ActorLogReceive}
-
 import scala.collection.mutable
 import scala.concurrent.duration.FiniteDuration
+
+import akka.actor.{PoisonPill, ActorRef, Actor}
+
+import org.apache.spark.Logging
+import org.apache.spark.util.{AkkaUtils, ActorLogReceive}
 
 private[spark] sealed trait OutputCommitCoordinationMessage
 

--- a/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala
@@ -93,6 +93,8 @@ private[spark] class OutputCommitCoordinator(conf: SparkConf) extends Logging {
     if (!stopped) {
       logWarning("Expected true from stopping output coordinator actor, but got false!")
     }
+    authorizedCommittersByStage.foreach(_._2.clear)
+    authorizedCommittersByStage.clear
   }
 
   private def handleStageStart(stage: StageId): Unit = {

--- a/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler
+
+import akka.actor.{PoisonPill, ActorRef, Actor}
+import org.apache.spark.Logging
+import org.apache.spark.util.{AkkaUtils, ActorLogReceive}
+
+import scala.collection.mutable
+import scala.concurrent.duration.FiniteDuration
+
+private[spark] sealed trait OutputCommitCoordinationMessage
+
+private[spark] case class StageStarted(stage: Int) extends OutputCommitCoordinationMessage
+private[spark] case class StageEnded(stage: Int) extends OutputCommitCoordinationMessage
+
+private[spark] case class AskPermissionToCommitOutput(
+    stage: Int,
+    task: Long,
+    taskAttempt: Long)
+    extends OutputCommitCoordinationMessage
+
+private[spark] case class TaskCompleted(
+    stage: Int,
+    task: Long,
+    attempt: Long,
+    successful: Boolean)
+    extends OutputCommitCoordinationMessage
+
+/**
+ * Authority that decides whether tasks can commit output to HDFS.
+ *
+ * This lives on the driver, but the actor allows the tasks that commit
+ * to Hadoop to invoke it.
+ */
+private[spark] class OutputCommitCoordinator extends Logging {
+
+  // Initialized by SparkEnv
+  var coordinatorActor: ActorRef = _
+
+  // TODO: handling stage attempt ids?
+  private type StageId = Int
+  private type TaskId = Long
+  private type TaskAttemptId = Long
+
+  private val authorizedCommittersByStage:
+  mutable.Map[StageId, mutable.Map[TaskId, TaskAttemptId]] = mutable.HashMap()
+
+  def stageStart(stage: StageId) {
+    coordinatorActor ! StageStarted(stage)
+  }
+  def stageEnd(stage: StageId) {
+    coordinatorActor ! StageEnded(stage)
+  }
+
+  def canCommit(
+      stage: StageId,
+      task: TaskId,
+      attempt: TaskAttemptId,
+      timeout: FiniteDuration): Boolean = {
+    AkkaUtils.askWithReply(AskPermissionToCommitOutput(stage, task, attempt),
+      coordinatorActor, timeout)
+  }
+
+  def canCommit(
+      stage: StageId,
+      task: TaskId,
+      attempt: TaskAttemptId,
+      maxAttempts: Int,
+      retryInterval: Int,
+      timeout: FiniteDuration): Boolean = {
+    AkkaUtils.askWithReply(AskPermissionToCommitOutput(stage, task, attempt),
+        coordinatorActor, maxAttempts = maxAttempts, retryInterval, timeout)
+  }
+
+  def taskCompleted(
+      stage: StageId,
+      task: TaskId,
+      attempt: TaskAttemptId,
+      successful: Boolean) {
+    coordinatorActor ! TaskCompleted(stage, task, attempt, successful)
+  }
+
+  def stop() {
+    coordinatorActor ! PoisonPill
+  }
+
+  private def handleStageStart(stage: StageId): Unit = {
+    // TODO: assert that we're not overwriting an existing entry?
+    authorizedCommittersByStage(stage) = mutable.HashMap[TaskId, TaskAttemptId]()
+  }
+
+  private def handleStageEnd(stage: StageId): Unit = {
+    authorizedCommittersByStage.remove(stage)
+  }
+
+  private def handleAskPermissionToCommit(
+      stage: StageId,
+      task: TaskId,
+      attempt: TaskAttemptId):
+      Boolean = {
+    if (!authorizedCommittersByStage.contains(stage)) {
+      logDebug(s"Stage $stage has completed, so not allowing task attempt $attempt to commit")
+      return false
+    }
+    val authorizedCommitters = authorizedCommittersByStage(stage)
+    if (authorizedCommitters.contains(task)) {
+      val existingCommitter = authorizedCommitters(task)
+      logDebug(s"Denying $attempt to commit for stage=$stage, task=$task; " +
+        s"existingCommitter = $existingCommitter")
+      false
+    } else {
+      logDebug(s"Authorizing $attempt to commit for stage=$stage, task=$task")
+      authorizedCommitters(task) = attempt
+      true
+    }
+  }
+
+  private def handleTaskCompletion(
+      stage: StageId,
+      task: TaskId,
+      attempt: TaskAttemptId,
+      successful: Boolean): Unit = {
+    if (!authorizedCommittersByStage.contains(stage)) {
+      logDebug(s"Ignoring task completion for completed stage")
+      return
+    }
+    val authorizedCommitters = authorizedCommittersByStage(stage)
+    if (authorizedCommitters.get(task) == Some(attempt) && !successful) {
+      logDebug(s"Authorized committer $attempt (stage=$stage, task=$task) failed; clearing lock")
+      // The authorized committer failed; clear the lock so future attempts can commit their output
+      authorizedCommitters.remove(task)
+    }
+  }
+}
+
+private[spark] object OutputCommitCoordinator {
+
+  class OutputCommitCoordinatorActor(outputCommitCoordinator: OutputCommitCoordinator)
+    extends Actor with ActorLogReceive with Logging {
+
+    override def receiveWithLogging = {
+      case StageStarted(stage) =>
+        outputCommitCoordinator.handleStageStart(stage)
+      case StageEnded(stage) =>
+        outputCommitCoordinator.handleStageEnd(stage)
+      case AskPermissionToCommitOutput(stage, task, taskAttempt) =>
+        sender ! outputCommitCoordinator.handleAskPermissionToCommit(stage, task, taskAttempt)
+      case TaskCompleted(stage, task, attempt, successful) =>
+        outputCommitCoordinator.handleTaskCompletion(stage, task, attempt, successful)
+    }
+  }
+  def createActor(coordinator: OutputCommitCoordinator): OutputCommitCoordinatorActor = {
+    new OutputCommitCoordinatorActor(coordinator)
+  }
+}
+
+

--- a/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala
@@ -25,7 +25,7 @@ import akka.actor.{PoisonPill, ActorRef, Actor}
 import org.apache.spark.Logging
 import org.apache.spark.util.{AkkaUtils, ActorLogReceive}
 
-private[spark] sealed trait OutputCommitCoordinationMessage
+private[spark] sealed trait OutputCommitCoordinationMessage extends Serializable
 
 private[spark] case class StageStarted(stage: Int) extends OutputCommitCoordinationMessage
 private[spark] case class StageEnded(stage: Int) extends OutputCommitCoordinationMessage
@@ -54,13 +54,13 @@ private[spark] class OutputCommitCoordinator extends Logging {
   // Initialized by SparkEnv
   var coordinatorActor: ActorRef = _
 
-  // TODO: handling stage attempt ids?
   private type StageId = Int
   private type TaskId = Long
   private type TaskAttemptId = Long
 
   private val authorizedCommittersByStage:
   mutable.Map[StageId, mutable.Map[TaskId, TaskAttemptId]] = mutable.HashMap()
+
 
   def stageStart(stage: StageId) {
     coordinatorActor ! StageStarted(stage)
@@ -102,7 +102,6 @@ private[spark] class OutputCommitCoordinator extends Logging {
   }
 
   private def handleStageStart(stage: StageId): Unit = {
-    // TODO: assert that we're not overwriting an existing entry?
     authorizedCommittersByStage(stage) = mutable.HashMap[TaskId, TaskAttemptId]()
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala
@@ -136,7 +136,8 @@ private[spark] class OutputCommitCoordinator(conf: SparkConf) extends Logging {
           case TaskCommitDenied(jobID, splitID, attemptID) =>
             logInfo(s"Task was denied committing, stage: $stage, taskId: $task, attempt: $attempt")
           case otherReason =>
-            logDebug(s"Authorized committer $attempt (stage=$stage, task=$task) failed; clearing lock")
+            logDebug(s"Authorized committer $attempt (stage=$stage, task=$task) failed;" +
+              s" clearing lock")
             authorizedCommitters.remove(task)
         }
       case None =>

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -158,7 +158,7 @@ private[spark] class TaskSchedulerImpl(
     val tasks = taskSet.tasks
     logInfo("Adding task set " + taskSet.id + " with " + tasks.length + " tasks")
     this.synchronized {
-      val manager = new TaskSetManager(this, taskSet, maxTaskFailures)
+      val manager = createTaskSetManager(taskSet, maxTaskFailures)
       activeTaskSets(taskSet.id) = manager
       schedulableBuilder.addTaskSetManager(manager, manager.taskSet.properties)
 
@@ -178,6 +178,13 @@ private[spark] class TaskSchedulerImpl(
       hasReceivedTask = true
     }
     backend.reviveOffers()
+  }
+
+  // Label as private[scheduler] to allow tests to swap in different task set managers if necessary
+  private[scheduler] def createTaskSetManager(
+      taskSet: TaskSet,
+      maxTaskFailures: Int): TaskSetManager = {
+    new TaskSetManager(this, taskSet, maxTaskFailures)
   }
 
   override def cancelTasks(stageId: Int, interruptThread: Boolean): Unit = synchronized {

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSingleThreadedProcessLoop.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSingleThreadedProcessLoop.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler
+
+import scala.util.control.NonFatal
+
+class DAGSchedulerSingleThreadedProcessLoop(dagScheduler: DAGScheduler)
+  extends DAGSchedulerEventProcessLoop(dagScheduler) {
+
+  override def post(event: DAGSchedulerEvent): Unit = {
+    try {
+      // Forward event to `onReceive` directly to avoid processing event asynchronously.
+      onReceive(event)
+    } catch {
+      case NonFatal(e) => onError(e)
+    }
+  }
+}

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -196,7 +196,7 @@ class DAGSchedulerSuite extends FunSuiteLike  with BeforeAndAfter with LocalSpar
     assert(taskSet.tasks.size >= results.size)
     for ((result, i) <- results.zipWithIndex) {
       if (i < taskSet.tasks.size) {
-        runEvent(CompletionEvent(taskSet.tasks(i), result._1, result._2, null, createFakeTaskInfo, null))
+        runEvent(CompletionEvent(taskSet.tasks(i), result._1, result._2, null, createFakeTaskInfo(), null))
       }
     }
   }
@@ -207,7 +207,7 @@ class DAGSchedulerSuite extends FunSuiteLike  with BeforeAndAfter with LocalSpar
     for ((result, i) <- results.zipWithIndex) {
       if (i < taskSet.tasks.size) {
         runEvent(CompletionEvent(taskSet.tasks(i), result._1, result._2,
-          Map[Long, Any]((accumId, 1)), createFakeTaskInfo, null))
+          Map[Long, Any]((accumId, 1)), createFakeTaskInfo(), null))
       }
     }
   }
@@ -464,7 +464,7 @@ class DAGSchedulerSuite extends FunSuiteLike  with BeforeAndAfter with LocalSpar
       FetchFailed(makeBlockManagerId("hostA"), shuffleId, 0, 0, "ignored"),
       null,
       Map[Long, Any](),
-      createFakeTaskInfo,
+      createFakeTaskInfo(),
       null))
     assert(sc.listenerBus.waitUntilEmpty(WAIT_TIMEOUT_MILLIS))
     assert(sparkListener.failedStages.contains(1))
@@ -475,7 +475,7 @@ class DAGSchedulerSuite extends FunSuiteLike  with BeforeAndAfter with LocalSpar
       FetchFailed(makeBlockManagerId("hostA"), shuffleId, 1, 1, "ignored"),
       null,
       Map[Long, Any](),
-      createFakeTaskInfo,
+      createFakeTaskInfo(),
       null))
     // The SparkListener should not receive redundant failure events.
     assert(sc.listenerBus.waitUntilEmpty(WAIT_TIMEOUT_MILLIS))
@@ -495,14 +495,14 @@ class DAGSchedulerSuite extends FunSuiteLike  with BeforeAndAfter with LocalSpar
     assert(newEpoch > oldEpoch)
     val taskSet = taskSets(0)
     // should be ignored for being too old
-    runEvent(CompletionEvent(taskSet.tasks(0), Success, makeMapStatus("hostA", 1), null, createFakeTaskInfo, null))
+    runEvent(CompletionEvent(taskSet.tasks(0), Success, makeMapStatus("hostA", 1), null, createFakeTaskInfo(), null))
     // should work because it's a non-failed host
-    runEvent(CompletionEvent(taskSet.tasks(0), Success, makeMapStatus("hostB", 1), null, createFakeTaskInfo, null))
+    runEvent(CompletionEvent(taskSet.tasks(0), Success, makeMapStatus("hostB", 1), null, createFakeTaskInfo(), null))
     // should be ignored for being too old
-    runEvent(CompletionEvent(taskSet.tasks(0), Success, makeMapStatus("hostA", 1), null, createFakeTaskInfo, null))
+    runEvent(CompletionEvent(taskSet.tasks(0), Success, makeMapStatus("hostA", 1), null, createFakeTaskInfo(), null))
     // should work because it's a new epoch
     taskSet.tasks(1).epoch = newEpoch
-    runEvent(CompletionEvent(taskSet.tasks(1), Success, makeMapStatus("hostA", 1), null, createFakeTaskInfo, null))
+    runEvent(CompletionEvent(taskSet.tasks(1), Success, makeMapStatus("hostA", 1), null, createFakeTaskInfo(), null))
     assert(mapOutputTracker.getServerStatuses(shuffleId, 0).map(_._1) ===
            Array(makeBlockManagerId("hostB"), makeBlockManagerId("hostA")))
     complete(taskSets(1), Seq((Success, 42), (Success, 43)))

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -20,11 +20,10 @@ package org.apache.spark.scheduler
 import scala.collection.mutable.{ArrayBuffer, HashSet, HashMap, Map}
 import scala.language.reflectiveCalls
 
+import org.mockito.Mockito.mock
 import org.scalatest.{BeforeAndAfter, FunSuiteLike}
 import org.scalatest.concurrent.Timeouts
 import org.scalatest.time.SpanSugar._
-
-import org.mockito.Mockito.mock
 
 import org.apache.spark._
 import org.apache.spark.rdd.RDD

--- a/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorSuite.scala
@@ -100,7 +100,7 @@ class OutputCommitCoordinatorSuite
   /**
    * Function that constructs a SparkHadoopWriter with a mock committer and runs its commit
    */
-  private class OutputCommittingFunctionWithAccumulator
+  private class OutputCommittingFunction
       extends ((TaskContext, Iterator[Int]) => Int) with Serializable {
 
     def apply(ctxt: TaskContext, it: Iterator[Int]): Int = {
@@ -150,8 +150,8 @@ class OutputCommitCoordinatorSuite
   /**
    * Function that will explicitly fail to commit on the first attempt
    */
-  private class FailFirstTimeCommittingFunctionWithAccumulator
-      extends OutputCommittingFunctionWithAccumulator {
+  private class FailFirstTimeCommittingFunction
+      extends OutputCommittingFunction {
     override def apply(ctxt: TaskContext, it: Iterator[Int]): Int = {
       if (ctxt.attemptNumber == 0) {
         val outputCommitter = new FakeOutputCommitter {
@@ -168,13 +168,13 @@ class OutputCommitCoordinatorSuite
 
   test("Only one of two duplicate commit tasks should commit") {
     val rdd = sc.parallelize(1 to 10, 10)
-    sc.runJob(rdd, new OutputCommittingFunctionWithAccumulator)
+    sc.runJob(rdd, new OutputCommittingFunction)
     assert(accum.value === 10)
   }
 
   test("If commit fails, if task is retried it should not be locked, and will succeed.") {
     val rdd = sc.parallelize(Seq(1), 1)
-    sc.runJob(rdd, new FailFirstTimeCommittingFunctionWithAccumulator)
+    sc.runJob(rdd, new FailFirstTimeCommittingFunction)
     assert(accum.value == 1)
   }
 }

--- a/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorSuite.scala
@@ -32,9 +32,9 @@ import org.apache.spark.executor.{TaskMetrics}
 import org.apache.spark.rdd.FakeOutputCommitter
 
 /**
- * Unit tests for the output commit coordination functionality. Overrides the SchedulerImpl
- * to just run the tasks directly and send completion or error messages back to the
- * DAG scheduler.
+ * Unit tests for the output commit coordination functionality. Overrides the
+ * SchedulerImpl to just run the tasks directly and send completion or error
+ * messages back to the DAG scheduler.
  */
 class OutputCommitCoordinatorSuite
     extends FunSuiteLike

--- a/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorSuite.scala
@@ -21,11 +21,11 @@ import java.io.{ObjectInputStream, ObjectOutputStream, IOException}
 
 import scala.collection.mutable
 
+import org.mockito.Mockito._
 import org.scalatest.concurrent.Timeouts
-import org.scalatest.{BeforeAndAfter, FunSuiteLike}
+import org.scalatest.{BeforeAndAfter, FunSuite}
 
 import org.apache.hadoop.mapred.{TaskAttemptID, JobConf, TaskAttemptContext, OutputCommitter}
-import org.mockito.Mockito._
 
 import org.apache.spark._
 import org.apache.spark.executor.{TaskMetrics}
@@ -37,7 +37,7 @@ import org.apache.spark.rdd.FakeOutputCommitter
  * messages back to the DAG scheduler.
  */
 class OutputCommitCoordinatorSuite
-    extends FunSuiteLike
+    extends FunSuite
     with BeforeAndAfter
     with LocalSparkContext
     with Timeouts {
@@ -69,7 +69,7 @@ class OutputCommitCoordinatorSuite
 
       private def execTasks(taskSet: TaskSet, attemptNumber: Int) {
         var taskIndex = 0
-        taskSet.tasks.foreach(t => {
+        taskSet.tasks.foreach { t =>
           val tid = newTaskId
           val taskInfo = new TaskInfo(tid, taskIndex, 0, System.currentTimeMillis, "0",
             "localhost", TaskLocality.NODE_LOCAL, false)
@@ -87,7 +87,7 @@ class OutputCommitCoordinatorSuite
               dagSchedulerEventProcessLoop.post(new CompletionEvent(t, new ExceptionFailure(e,
                 Option.empty[TaskMetrics]), 1, accumUpdates, taskInfo, new TaskMetrics))
           }
-        })
+        }
       }
     }
 
@@ -136,6 +136,7 @@ class OutputCommitCoordinatorSuite
       }
     }
 
+    // Need this otherwise the entire test suite attempts to be serialized
     @throws(classOf[IOException])
     private def writeObject(out: ObjectOutputStream) {}
 
@@ -171,6 +172,6 @@ class OutputCommitCoordinatorSuite
   test("If commit fails, if task is retried it should not be locked, and will succeed.") {
     val rdd = sc.parallelize(Seq(1), 1)
     sc.runJob(rdd, new FailFirstTimeCommittingFunction)
-    assert(accum.value == 1)
+    assert(accum.value === 1)
   }
 }

--- a/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorSuite.scala
@@ -100,7 +100,7 @@ class OutputCommitCoordinatorSuite
   /**
    * Function that constructs a SparkHadoopWriter with a mock committer and runs its commit
    */
-  private class OutputCommittingFunctionWithAccumulator(var accum: Accumulator[Int])
+  private class OutputCommittingFunctionWithAccumulator
       extends ((TaskContext, Iterator[Int]) => Int) with Serializable {
 
     def apply(ctxt: TaskContext, it: Iterator[Int]): Int = {
@@ -150,8 +150,8 @@ class OutputCommitCoordinatorSuite
   /**
    * Function that will explicitly fail to commit on the first attempt
    */
-  private class FailFirstTimeCommittingFunctionWithAccumulator(accum: Accumulator[Int])
-      extends OutputCommittingFunctionWithAccumulator(accum) {
+  private class FailFirstTimeCommittingFunctionWithAccumulator
+      extends OutputCommittingFunctionWithAccumulator {
     override def apply(ctxt: TaskContext, it: Iterator[Int]): Int = {
       if (ctxt.attemptNumber == 0) {
         val outputCommitter = new FakeOutputCommitter {
@@ -168,13 +168,13 @@ class OutputCommitCoordinatorSuite
 
   test("Only one of two duplicate commit tasks should commit") {
     val rdd = sc.parallelize(1 to 10, 10)
-    sc.runJob(rdd, new OutputCommittingFunctionWithAccumulator(accum))
+    sc.runJob(rdd, new OutputCommittingFunctionWithAccumulator)
     assert(accum.value === 10)
   }
 
   test("If commit fails, if task is retried it should not be locked, and will succeed.") {
     val rdd = sc.parallelize(Seq(1), 1)
-    sc.runJob(rdd, new FailFirstTimeCommittingFunctionWithAccumulator(accum))
+    sc.runJob(rdd, new FailFirstTimeCommittingFunctionWithAccumulator)
     assert(accum.value == 1)
   }
 }

--- a/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorSuite.scala
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler
+
+import java.io.{ObjectInputStream, ObjectOutputStream, IOException}
+
+import scala.collection.mutable
+
+import org.scalatest.concurrent.Timeouts
+import org.scalatest.{BeforeAndAfter, FunSuiteLike}
+
+import org.apache.hadoop.mapred.{TaskAttemptID, JobConf, TaskAttemptContext, OutputCommitter}
+import org.mockito.Mockito._
+
+import org.apache.spark._
+import org.apache.spark.executor.{TaskMetrics}
+import org.apache.spark.rdd.FakeOutputCommitter
+
+/**
+ * Unit tests for the output commit coordination functionality. Overrides the SchedulerImpl
+ * to just run the tasks directly and send completion or error messages back to the
+ * DAG scheduler.
+ */
+class OutputCommitCoordinatorSuite
+    extends FunSuiteLike
+    with BeforeAndAfter
+    with LocalSparkContext
+    with Timeouts {
+
+  val conf = new SparkConf().set("spark.localExecution.enabled", "true")
+
+  var taskScheduler: TaskSchedulerImpl = null
+  var dagScheduler: DAGScheduler = null
+  var dagSchedulerEventProcessLoop: DAGSchedulerEventProcessLoop = null
+  var accum: Accumulator[Int] = null
+  var accumId: Long = 0
+
+  before {
+    sc = new SparkContext("local", "Output Commit Coordinator Suite")
+    accum = sc.accumulator[Int](0)
+    Accumulators.register(accum, true)
+    accumId = accum.id
+
+    taskScheduler = new TaskSchedulerImpl(sc, 4, true) {
+      override def submitTasks(taskSet: TaskSet) {
+        // Instead of submitting a task to some executor, just run the task directly.
+        // Make two attempts. The first may or may not succeed. If the first
+        // succeeds then the second is redundant and should be handled
+        // accordingly by OutputCommitCoordinator. Otherwise the second
+        // should not be blocked from succeeding.
+        execTasks(taskSet, 0)
+        execTasks(taskSet, 1)
+      }
+
+      private def execTasks(taskSet: TaskSet, attemptNumber: Int) {
+        var taskIndex = 0
+        taskSet.tasks.foreach(t => {
+          val tid = newTaskId
+          val taskInfo = new TaskInfo(tid, taskIndex, 0, System.currentTimeMillis, "0",
+            "localhost", TaskLocality.NODE_LOCAL, false)
+          taskIndex += 1
+          // Track the successful commits in an accumulator. However, we can't just invoke
+          // accum += 1 since this unit test circumvents the usual accumulator updating
+          // infrastructure. So just send the accumulator update manually.
+          val accumUpdates = new mutable.HashMap[Long, Any]
+          try {
+            accumUpdates(accumId) = t.run(attemptNumber, attemptNumber)
+            dagSchedulerEventProcessLoop.post(
+                new CompletionEvent(t, Success, 0, accumUpdates, taskInfo, new TaskMetrics))
+          } catch {
+            case e: Throwable =>
+              dagSchedulerEventProcessLoop.post(new CompletionEvent(t, new ExceptionFailure(e,
+                  Option.empty[TaskMetrics]), 1, accumUpdates, taskInfo, new TaskMetrics))
+          }
+        })
+      }
+    }
+
+    dagScheduler = new DAGScheduler(sc, taskScheduler)
+    taskScheduler.setDAGScheduler(dagScheduler)
+    sc.dagScheduler = dagScheduler
+    dagSchedulerEventProcessLoop = new DAGSchedulerSingleThreadedProcessLoop(dagScheduler)
+  }
+
+  /**
+   * Function that constructs a SparkHadoopWriter with a mock committer and runs its commit
+   */
+  private class OutputCommittingFunctionWithAccumulator(var accum: Accumulator[Int])
+      extends ((TaskContext, Iterator[Int]) => Int) with Serializable {
+
+    def apply(ctxt: TaskContext, it: Iterator[Int]): Int = {
+      val outputCommitter = new FakeOutputCommitter {
+        override def commitTask(taskAttemptContext: TaskAttemptContext) {
+          super.commitTask(taskAttemptContext)
+        }
+      }
+      runCommitWithProvidedCommitter(ctxt, it, outputCommitter)
+    }
+
+    protected def runCommitWithProvidedCommitter(
+        ctxt: TaskContext,
+        it: Iterator[Int],
+        outputCommitter: OutputCommitter): Int = {
+      def jobConf = new JobConf {
+        override def getOutputCommitter(): OutputCommitter = outputCommitter
+      }
+      val sparkHadoopWriter = new SparkHadoopWriter(jobConf) {
+        override def newTaskAttemptContext(
+            conf: JobConf,
+            attemptId: TaskAttemptID): TaskAttemptContext = {
+          mock(classOf[TaskAttemptContext])
+        }
+      }
+      sparkHadoopWriter.setup(ctxt.stageId, ctxt.partitionId, ctxt.attemptNumber)
+      sparkHadoopWriter.commit
+      if (FakeOutputCommitter.ran) {
+        FakeOutputCommitter.ran = false
+        1
+      } else {
+        0
+      }
+    }
+
+    @throws(classOf[IOException])
+    private def writeObject(out: ObjectOutputStream) {
+      out.writeObject(accum)
+    }
+
+    @throws(classOf[IOException])
+    private def readObject(in: ObjectInputStream) {
+      accum = in.readObject.asInstanceOf[Accumulator[Int]]
+    }
+  }
+
+  /**
+   * Function that will explicitly fail to commit on the first attempt
+   */
+  private class FailFirstTimeCommittingFunctionWithAccumulator(accum: Accumulator[Int])
+      extends OutputCommittingFunctionWithAccumulator(accum) {
+    override def apply(ctxt: TaskContext, it: Iterator[Int]): Int = {
+      if (ctxt.attemptNumber == 0) {
+        val outputCommitter = new FakeOutputCommitter {
+          override def commitTask(taskAttemptContext: TaskAttemptContext) {
+            throw new RuntimeException
+          }
+        }
+        runCommitWithProvidedCommitter(ctxt, it, outputCommitter)
+      } else {
+        super.apply(ctxt, it)
+      }
+    }
+  }
+
+  test("Only one of two duplicate commit tasks should commit") {
+    val rdd = sc.parallelize(1 to 10, 10)
+    sc.runJob(rdd, new OutputCommittingFunctionWithAccumulator(accum))
+    assert(accum.value === 10)
+  }
+
+  test("If commit fails, if task is retried it should not be locked, and will succeed.") {
+    val rdd = sc.parallelize(Seq(1), 1)
+    sc.runJob(rdd, new FailFirstTimeCommittingFunctionWithAccumulator(accum))
+    assert(accum.value == 1)
+  }
+}

--- a/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorSuite.scala
@@ -81,11 +81,11 @@ class OutputCommitCoordinatorSuite
           try {
             accumUpdates(accumId) = t.run(attemptNumber, attemptNumber)
             dagSchedulerEventProcessLoop.post(
-                new CompletionEvent(t, Success, 0, accumUpdates, taskInfo, new TaskMetrics))
+              new CompletionEvent(t, Success, 0, accumUpdates, taskInfo, new TaskMetrics))
           } catch {
             case e: Throwable =>
               dagSchedulerEventProcessLoop.post(new CompletionEvent(t, new ExceptionFailure(e,
-                  Option.empty[TaskMetrics]), 1, accumUpdates, taskInfo, new TaskMetrics))
+                Option.empty[TaskMetrics]), 1, accumUpdates, taskInfo, new TaskMetrics))
           }
         })
       }

--- a/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorSuite.scala
@@ -137,14 +137,10 @@ class OutputCommitCoordinatorSuite
     }
 
     @throws(classOf[IOException])
-    private def writeObject(out: ObjectOutputStream) {
-      out.writeObject(accum)
-    }
+    private def writeObject(out: ObjectOutputStream) {}
 
     @throws(classOf[IOException])
-    private def readObject(in: ObjectInputStream) {
-      accum = in.readObject.asInstanceOf[Accumulator[Int]]
-    }
+    private def readObject(in: ObjectInputStream) {}
   }
 
   /**


### PR DESCRIPTION
This is a version of https://github.com/apache/spark/pull/4066/ which is up to date with master and has unit tests.

Previously, SparkHadoopWriter always committed its tasks without question. The problem is that when speculation is turned on, sometimes this can result in multiple tasks committing their output to the same
partition. Even though an HDFS-writing task may be re-launched due to speculation, the original task is not killed and may eventually commit as well.

This can cause strange race conditions where multiple tasks that commit interfere with each other, with the result being that some partition files are actually lost entirely. For more context on these kinds of scenarios, see the aforementioned JIRA ticket.

In Hadoop MapReduce jobs, the application master is a central coordinator that authorizes whether or not any given task can commit. Before a task commits its output, it queries the application master as to whether or not such a commit is safe, and the application master does bookkeeping as tasks are requesting commits. Duplicate tasks that would write to files that were already written to from other tasks are prohibited from committing.

This patch emulates that functionality - the crucial missing component was a central arbitrator, which is now a module called the OutputCommitCoordinator. The coordinator lives on the driver and the executors can obtain a reference to this actor and request its permission to commit. As tasks commit and are reported as completed successfully or unsuccessfully by the DAGScheduler, the commit coordinator is informed of the task completion events as well to update its internal state.

Future work includes more rigorous unit testing and extra optimizations should this patch cause a performance regression. It is unclear what the overall cost of communicating back to the driver on every hadoop-committing task will be. It's also important for those hitting this issue to backport this onto previous version of Spark because the bug has serious consequences, that is, data is lost.

cc @MingyuKim @JoshRosen  @ash211 
