### PR TITLE
[SPARK-5372][Streaming] Change the default storage level in window operators

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/ReducedWindowedDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/ReducedWindowedDStream.scala
@@ -54,9 +54,9 @@ class ReducedWindowedDStream[K: ClassTag, V: ClassTag](
   // by ReducedWindowedDStream
   val reducedStream = parent.reduceByKey(reduceFunc, partitioner)
 
-  // Persist RDDs to memory by default as these RDDs are going to be reused.
-  super.persist(StorageLevel.MEMORY_ONLY_SER)
-  reducedStream.persist(StorageLevel.MEMORY_ONLY_SER)
+  // Persist RDDs to memory and disk by default as these RDDs are going to be reused.
+  super.persist(StorageLevel.MEMORY_AND_DISK_SER)
+  reducedStream.persist(StorageLevel.MEMORY_AND_DISK_SER)
 
   def windowDuration: Duration =  _windowDuration
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/WindowedDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/WindowedDStream.scala
@@ -42,7 +42,7 @@ class WindowedDStream[T: ClassTag](
   }
 
   // Persist parent level by default, as those RDDs are going to be obviously reused.
-  parent.persist(StorageLevel.MEMORY_ONLY_SER)
+  parent.persist(StorageLevel.MEMORY_AND_DISK_SER)
 
   def windowDuration: Duration =  _windowDuration
 

--- a/streaming/src/test/scala/org/apache/spark/streaming/WindowOperationsSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/WindowOperationsSuite.scala
@@ -150,7 +150,7 @@ class WindowOperationsSuite extends TestSuiteBase {
     val inputStream = new TestInputStream[Int](ssc, input, 1)
     val windowStream1 = inputStream.window(batchDuration * 2)
     assert(windowStream1.storageLevel === StorageLevel.NONE)
-    assert(inputStream.storageLevel === StorageLevel.MEMORY_ONLY_SER)
+    assert(inputStream.storageLevel === StorageLevel.MEMORY_AND_DISK_SER)
     windowStream1.persist(StorageLevel.MEMORY_ONLY)
     assert(windowStream1.storageLevel === StorageLevel.NONE)
     assert(inputStream.storageLevel === StorageLevel.MEMORY_ONLY)


### PR DESCRIPTION
The default storage level in window operators is MEMORY_ONLY_SER, which will lead to unexpected behavior when memory is not enough. Besides for the reason of aligning this to the storage level of input DStream, here I'd change the storage level to MEMORY_AND_DISK_SER.
