### PR TITLE
[SPARK-5380][GraphX]  Solve an ArrayIndexOutOfBoundsException when build graph with a file format error

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/GraphLoader.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/GraphLoader.scala
@@ -77,15 +77,14 @@ object GraphLoader extends Logging {
         if (!line.isEmpty && line(0) != '#') {
           val lineArray = line.split("\\s+")
           if (lineArray.length < 2) {
-            logWarning("Invalid line: " + line)
+            throw new IllegalArgumentException("Invalid line: " + line)
+          }
+          val srcId = lineArray(0).toLong
+          val dstId = lineArray(1).toLong
+          if (canonicalOrientation && srcId > dstId) {
+            builder.add(dstId, srcId, 1)
           } else {
-            val srcId = lineArray(0).toLong
-            val dstId = lineArray(1).toLong
-            if (canonicalOrientation && srcId > dstId) {
-              builder.add(dstId, srcId, 1)
-            } else {
-              builder.add(srcId, dstId, 1)
-            }
+            builder.add(srcId, dstId, 1)
           }
         }
       }

--- a/graphx/src/main/scala/org/apache/spark/graphx/GraphLoader.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/GraphLoader.scala
@@ -78,13 +78,14 @@ object GraphLoader extends Logging {
           val lineArray = line.split("\\s+")
           if (lineArray.length < 2) {
             logWarning("Invalid line: " + line)
-          }
-          val srcId = lineArray(0).toLong
-          val dstId = lineArray(1).toLong
-          if (canonicalOrientation && srcId > dstId) {
-            builder.add(dstId, srcId, 1)
           } else {
-            builder.add(srcId, dstId, 1)
+            val srcId = lineArray(0).toLong
+            val dstId = lineArray(1).toLong
+            if (canonicalOrientation && srcId > dstId) {
+              builder.add(dstId, srcId, 1)
+            } else {
+              builder.add(srcId, dstId, 1)
+            }
           }
         }
       }


### PR DESCRIPTION
When I build a graph with a file format error, there will be an ArrayIndexOutOfBoundsException
