### PR TITLE
SPARK-984 [BUILD] SPARK_TOOLS_JAR not set if multiple tools jars exists

### DIFF
--- a/bin/spark-class
+++ b/bin/spark-class
@@ -127,16 +127,6 @@ fi
 # Attention: when changing the way the JAVA_OPTS are assembled, the change must be reflected in CommandUtils.scala!
 
 TOOLS_DIR="$FWDIR"/tools
-SPARK_TOOLS_JAR=""
-if [ -e "$TOOLS_DIR"/target/scala-$SPARK_SCALA_VERSION/spark-tools*[0-9Tg].jar ]; then
-  # Use the JAR from the SBT build
-  export SPARK_TOOLS_JAR="`ls "$TOOLS_DIR"/target/scala-$SPARK_SCALA_VERSION/spark-tools*[0-9Tg].jar`"
-fi
-if [ -e "$TOOLS_DIR"/target/spark-tools*[0-9Tg].jar ]; then
-  # Use the JAR from the Maven build
-  # TODO: this also needs to become an assembly!
-  export SPARK_TOOLS_JAR="`ls "$TOOLS_DIR"/target/spark-tools*[0-9Tg].jar`"
-fi
 
 # Compute classpath using external script
 classpath_output=$("$FWDIR"/bin/compute-classpath.sh)
@@ -147,20 +137,8 @@ else
   CLASSPATH="$classpath_output"
 fi
 
-if [[ "$1" =~ org.apache.spark.tools.* ]]; then
-  if test -z "$SPARK_TOOLS_JAR"; then
-    echo "Failed to find Spark Tools Jar in $FWDIR/tools/target/scala-$SPARK_SCALA_VERSION/" 1>&2
-    echo "You need to run \"build/sbt tools/package\" before running $1." 1>&2
-    exit 1
-  fi
-  CLASSPATH="$CLASSPATH:$SPARK_TOOLS_JAR"
-fi
-
 if $cygwin; then
   CLASSPATH="`cygpath -wp "$CLASSPATH"`"
-  if [ "$1" == "org.apache.spark.tools.JavaAPICompletenessChecker" ]; then
-    export SPARK_TOOLS_JAR="`cygpath -w "$SPARK_TOOLS_JAR"`"
-  fi
 fi
 export CLASSPATH
 

--- a/bin/spark-class2.cmd
+++ b/bin/spark-class2.cmd
@@ -110,16 +110,11 @@ if "%FOUND_JAR%"=="0" (
 :skip_build_test
 
 set TOOLS_DIR=%FWDIR%tools
-set SPARK_TOOLS_JAR=
-for %%d in ("%TOOLS_DIR%\target\scala-%SCALA_VERSION%\spark-tools*assembly*.jar") do (
-  set SPARK_TOOLS_JAR=%%d
-)
 
 rem Compute classpath using external script
 set DONT_PRINT_CLASSPATH=1
 call "%FWDIR%bin\compute-classpath.cmd"
 set DONT_PRINT_CLASSPATH=0
-set CLASSPATH=%CLASSPATH%;%SPARK_TOOLS_JAR%
 
 rem Figure out where java is.
 set RUNNER=java


### PR DESCRIPTION
Given the discussion in https://issues.apache.org/jira/browse/SPARK-984, this seems to be the outcome, but I'm not 100% sure if this is still the desired resolution. Simpler than modifying the scripts to deal with multiple tools assemblies if in fact these tools are not run specially this way by `spark-class`.
