### PR TITLE
[SPARK-5383][SQL] support alias for udfs with multi output columns

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
@@ -109,7 +109,7 @@ class SqlParser extends AbstractSparkSQLParser {
   protected def assignAliases(exprs: Seq[Expression]): Seq[NamedExpression] = {
     exprs.zipWithIndex.map {
       case (ne: NamedExpression, _) => ne
-      case (e, i) => Alias(e, s"c$i")()
+      case (e, i) => Alias(e, Seq(s"c$i"))()
     }
   }
 
@@ -152,7 +152,7 @@ class SqlParser extends AbstractSparkSQLParser {
 
   protected lazy val projection: Parser[Expression] =
     expression ~ (AS.? ~> ident.?) ^^ {
-      case e ~ a => a.fold(e)(Alias(e, _)())
+      case e ~ a => a.fold(e)(x => Alias(e, Seq(x))())
     }
 
   // Based very loosely on the MySQL Grammar.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
@@ -152,7 +152,7 @@ class SqlParser extends AbstractSparkSQLParser {
 
   protected lazy val projection: Parser[Expression] =
     expression ~ (AS.? ~> ident.?) ^^ {
-      case e ~ a => a.fold(e)(x => Alias(e, Seq(x))())
+      case e ~ a => a.fold(e)(name => Alias(e, Seq(name))())
     }
 
   // Based very loosely on the MySQL Grammar.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -389,7 +389,7 @@ class Analyzer(catalog: Catalog,
     def apply(plan: LogicalPlan): LogicalPlan = plan transformUp {
       case filter @ Filter(havingCondition, aggregate @ Aggregate(_, originalAggExprs, _))
           if aggregate.resolved && containsAggregate(havingCondition) => {
-        val evaluatedCondition = Alias(havingCondition,  "havingCondition")()
+        val evaluatedCondition = Alias(havingCondition, Seq("havingCondition"))()
         val aggExprsWithHaving = evaluatedCondition +: originalAggExprs
 
         Project(aggregate.output,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
@@ -169,17 +169,17 @@ trait HiveTypeCoercion {
         val castedInput = left.output.zip(right.output).map {
           // When a string is found on one side, make the other side a string too.
           case (l, r) if l.dataType == StringType && r.dataType != StringType =>
-            (l, Alias(Cast(r, StringType), r.name)())
+            (l, Alias(Cast(r, StringType), Seq(r.name))())
           case (l, r) if l.dataType != StringType && r.dataType == StringType =>
-            (Alias(Cast(l, StringType), l.name)(), r)
+            (Alias(Cast(l, StringType), Seq(l.name))(), r)
 
           case (l, r) if l.dataType != r.dataType =>
             logDebug(s"Resolving mismatched union input ${l.dataType}, ${r.dataType}")
             findTightestCommonType(l.dataType, r.dataType).map { widestType =>
               val newLeft =
-                if (l.dataType == widestType) l else Alias(Cast(l, widestType), l.name)()
+                if (l.dataType == widestType) l else Alias(Cast(l, widestType), Seq(l.name))()
               val newRight =
-                if (r.dataType == widestType) r else Alias(Cast(r, widestType), r.name)()
+                if (r.dataType == widestType) r else Alias(Cast(r, widestType), Seq(r.name))()
 
               (newLeft, newRight)
             }.getOrElse((l, r)) // If there is no applicable conversion, leave expression unchanged.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/package.scala
@@ -30,6 +30,9 @@ package object analysis {
    */
   type Resolver = (String, String) => Boolean
 
-  val caseInsensitiveResolution = (a: String, b: String) => a.equalsIgnoreCase(b)
-  val caseSensitiveResolution = (a: String, b: String) => a == b
+  val caseInsensitiveResolution = (a: String, b: String) =>
+    a.split("\\|").exists(_.equalsIgnoreCase(b)) || b.split("\\|").exists(_.equalsIgnoreCase(a))
+
+  val caseSensitiveResolution = (a: String, b: String) =>
+    a.split("\\|").exists(_ == b) || b.split("\\|").exists(_.equalsIgnoreCase(a))
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/package.scala
@@ -31,8 +31,8 @@ package object analysis {
   type Resolver = (String, String) => Boolean
 
   val caseInsensitiveResolution = (a: String, b: String) =>
-    a.split("\\|").exists(_.equalsIgnoreCase(b)) || b.split("\\|").exists(_.equalsIgnoreCase(a))
+    (a.split("\\|").map(_.toLowerCase) intersect b.split("\\|").map(_.toLowerCase)).nonEmpty
 
   val caseSensitiveResolution = (a: String, b: String) =>
-    a.split("\\|").exists(_ == b) || b.split("\\|").exists(_.equalsIgnoreCase(a))
+    (a.split("\\|") intersect b.split("\\|")).nonEmpty
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -109,7 +109,7 @@ case class Star(
     val mappedAttributes = expandedAttributes.map(mapFunction).zip(input).map {
       case (n: NamedExpression, _) => n
       case (e, originalAttribute) =>
-        Alias(e, originalAttribute.name)(qualifiers = originalAttribute.qualifiers)
+        Alias(e, Seq(originalAttribute.name))(qualifiers = originalAttribute.qualifiers)
     }
     mappedAttributes
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -108,8 +108,8 @@ package object dsl {
     def asc = SortOrder(expr, Ascending)
     def desc = SortOrder(expr, Descending)
 
-    def as(alias: String) = Alias(expr, alias)()
-    def as(alias: Symbol) = Alias(expr, alias.name)()
+    def as(alias: String) = Alias(expr, Seq(alias))()
+    def as(alias: Symbol) = Alias(expr, Seq(alias.name))()
   }
 
   trait ExpressionConversions {
@@ -260,7 +260,7 @@ package object dsl {
     def groupBy(groupingExprs: Expression*)(aggregateExprs: Expression*) = {
       val aliasedExprs = aggregateExprs.map {
         case ne: NamedExpression => ne
-        case e => Alias(e, e.toString)()
+        case e => Alias(e, Seq(e.toString))()
       }
       Aggregate(groupingExprs, aliasedExprs, logicalPlan)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregates.scala
@@ -95,7 +95,7 @@ case class Min(child: Expression) extends PartialAggregate with trees.UnaryNode[
   override def toString = s"MIN($child)"
 
   override def asPartial: SplitEvaluation = {
-    val partialMin = Alias(Min(child), "PartialMin")()
+    val partialMin = Alias(Min(child), Seq("PartialMin"))()
     SplitEvaluation(Min(partialMin.toAttribute), partialMin :: Nil)
   }
 
@@ -126,7 +126,7 @@ case class Max(child: Expression) extends PartialAggregate with trees.UnaryNode[
   override def toString = s"MAX($child)"
 
   override def asPartial: SplitEvaluation = {
-    val partialMax = Alias(Max(child), "PartialMax")()
+    val partialMax = Alias(Max(child), Seq("PartialMax"))()
     SplitEvaluation(Max(partialMax.toAttribute), partialMax :: Nil)
   }
 
@@ -157,7 +157,7 @@ case class Count(child: Expression) extends PartialAggregate with trees.UnaryNod
   override def toString = s"COUNT($child)"
 
   override def asPartial: SplitEvaluation = {
-    val partialCount = Alias(Count(child), "PartialCount")()
+    val partialCount = Alias(Count(child), Seq("PartialCount"))()
     SplitEvaluation(Coalesce(Seq(Sum(partialCount.toAttribute), Literal(0L))), partialCount :: Nil)
   }
 
@@ -175,7 +175,7 @@ case class CountDistinct(expressions: Seq[Expression]) extends PartialAggregate 
   override def newInstance() = new CountDistinctFunction(expressions, this)
 
   override def asPartial = {
-    val partialSet = Alias(CollectHashSet(expressions), "partialSets")()
+    val partialSet = Alias(CollectHashSet(expressions), Seq("partialSets"))()
     SplitEvaluation(
       CombineSetsAndCount(partialSet.toAttribute),
       partialSet :: Nil)
@@ -273,7 +273,7 @@ case class ApproxCountDistinct(child: Expression, relativeSD: Double = 0.05)
 
   override def asPartial: SplitEvaluation = {
     val partialCount =
-      Alias(ApproxCountDistinctPartition(child, relativeSD), "PartialApproxCountDistinct")()
+      Alias(ApproxCountDistinctPartition(child, relativeSD), Seq("PartialApproxCountDistinct"))()
 
     SplitEvaluation(
       ApproxCountDistinctMerge(partialCount.toAttribute, relativeSD),
@@ -302,8 +302,8 @@ case class Average(child: Expression) extends PartialAggregate with trees.UnaryN
     child.dataType match {
       case DecimalType.Fixed(_, _) =>
         // Turn the child to unlimited decimals for calculation, before going back to fixed
-        val partialSum = Alias(Sum(Cast(child, DecimalType.Unlimited)), "PartialSum")()
-        val partialCount = Alias(Count(child), "PartialCount")()
+        val partialSum = Alias(Sum(Cast(child, DecimalType.Unlimited)), Seq("PartialSum"))()
+        val partialCount = Alias(Count(child), Seq("PartialCount"))()
 
         val castedSum = Cast(Sum(partialSum.toAttribute), DecimalType.Unlimited)
         val castedCount = Cast(Sum(partialCount.toAttribute), DecimalType.Unlimited)
@@ -312,8 +312,8 @@ case class Average(child: Expression) extends PartialAggregate with trees.UnaryN
           partialCount :: partialSum :: Nil)
 
       case _ =>
-        val partialSum = Alias(Sum(child), "PartialSum")()
-        val partialCount = Alias(Count(child), "PartialCount")()
+        val partialSum = Alias(Sum(child), Seq("PartialSum"))()
+        val partialCount = Alias(Count(child), Seq("PartialCount"))()
 
         val castedSum = Cast(Sum(partialSum.toAttribute), dataType)
         val castedCount = Cast(Sum(partialCount.toAttribute), dataType)
@@ -344,13 +344,13 @@ case class Sum(child: Expression) extends PartialAggregate with trees.UnaryNode[
   override def asPartial: SplitEvaluation = {
     child.dataType match {
       case DecimalType.Fixed(_, _) =>
-        val partialSum = Alias(Sum(Cast(child, DecimalType.Unlimited)), "PartialSum")()
+        val partialSum = Alias(Sum(Cast(child, DecimalType.Unlimited)), Seq("PartialSum"))()
         SplitEvaluation(
           Cast(Sum(partialSum.toAttribute), dataType),
           partialSum :: Nil)
 
       case _ =>
-        val partialSum = Alias(Sum(child), "PartialSum")()
+        val partialSum = Alias(Sum(child), Seq("PartialSum"))()
         SplitEvaluation(
           Sum(partialSum.toAttribute),
           partialSum :: Nil)
@@ -377,7 +377,7 @@ case class SumDistinct(child: Expression)
   override def newInstance() = new SumDistinctFunction(child, this)
 
   override def asPartial = {
-    val partialSet = Alias(CollectHashSet(child :: Nil), "partialSets")()
+    val partialSet = Alias(CollectHashSet(child :: Nil), Seq("partialSets"))()
     SplitEvaluation(
       CombineSetsAndSum(partialSet.toAttribute, this),
       partialSet :: Nil)
@@ -430,7 +430,7 @@ case class First(child: Expression) extends PartialAggregate with trees.UnaryNod
   override def toString = s"FIRST($child)"
 
   override def asPartial: SplitEvaluation = {
-    val partialFirst = Alias(First(child), "PartialFirst")()
+    val partialFirst = Alias(First(child), Seq("PartialFirst"))()
     SplitEvaluation(
       First(partialFirst.toAttribute),
       partialFirst :: Nil)
@@ -445,7 +445,7 @@ case class Last(child: Expression) extends PartialAggregate with trees.UnaryNode
   override def toString = s"LAST($child)"
 
   override def asPartial: SplitEvaluation = {
-    val partialLast = Alias(Last(child), "PartialLast")()
+    val partialLast = Alias(Last(child), Seq("PartialLast"))()
     SplitEvaluation(
       Last(partialLast.toAttribute),
       partialLast :: Nil)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
@@ -78,13 +78,14 @@ abstract class Attribute extends NamedExpression {
  *  Alias(Add(Literal(1), Literal(1), "a")()
  *
  * @param child the computation being performed
- * @param name the name to be associated with the result of computing [[child]].
+ * @param name the names to be associated with the result of computing [[child]].
  * @param exprId A globally unique id used to check if an [[AttributeReference]] refers to this
  *               alias. Auto-assigned if left blank.
  */
-case class Alias(child: Expression, name: String)
+case class Alias(child: Expression, names: Seq[String])
     (val exprId: ExprId = NamedExpression.newExprId, val qualifiers: Seq[String] = Nil)
   extends NamedExpression with trees.UnaryNode[Expression] {
+  override def name = names.mkString("|")
 
   override type EvaluatedType = Any
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
@@ -78,7 +78,7 @@ abstract class Attribute extends NamedExpression {
  *  Alias(Add(Literal(1), Literal(1), "a")()
  *
  * @param child the computation being performed
- * @param name the names to be associated with the result of computing [[child]].
+ * @param names the names to be associated with the result of computing [[child]].
  * @param exprId A globally unique id used to check if an [[AttributeReference]] refers to this
  *               alias. Auto-assigned if left blank.
  */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -100,7 +100,7 @@ object PhysicalOperation extends PredicateHelper {
       aliases.get(ref).map(Alias(_, name)(a.exprId, a.qualifiers)).getOrElse(a)
 
     case a: AttributeReference =>
-      aliases.get(a).map(Alias(_, a.name)(a.exprId, a.qualifiers)).getOrElse(a)
+      aliases.get(a).map(Alias(_, Seq(a.name))(a.exprId, a.qualifiers)).getOrElse(a)
   }
 }
 
@@ -143,7 +143,7 @@ object PartialAggregation {
         // referenced in the second aggregation.
         val namedGroupingExpressions: Map[Expression, NamedExpression] = groupingExpressions.map {
           case n: NamedExpression => (n, n)
-          case other => (other, Alias(other, "PartialGroup")())
+          case other => (other, Alias(other, Seq("PartialGroup"))())
         }.toMap
 
         // Replace aggregations with a new expression that computes the result from the already

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
@@ -163,7 +163,7 @@ abstract class LogicalPlan extends QueryPlan[LogicalPlan] with Logging {
         val aliased =
           Alias(
             resolveNesting(nestedFields, a, resolver),
-            nestedFields.last)() // Preserve the case of the user's field access.
+            Seq(nestedFields.last))() // Preserve the case of the user's field access.
         Some(aliased)
 
       // No matches.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -138,11 +138,11 @@ class AnalysisSuite extends FunSuite with BeforeAndAfter {
     val expr3 = 'a / 'd
     val expr4 = 'e / 'e
     val plan = caseInsensitiveAnalyze(Project(
-      Alias(expr0, s"Analyzer($expr0)")() ::
-      Alias(expr1, s"Analyzer($expr1)")() ::
-      Alias(expr2, s"Analyzer($expr2)")() ::
-      Alias(expr3, s"Analyzer($expr3)")() ::
-      Alias(expr4, s"Analyzer($expr4)")() :: Nil, testRelation2))
+      Alias(expr0, Seq(s"Analyzer($expr0)"))() ::
+      Alias(expr1, Seq(s"Analyzer($expr1)"))() ::
+      Alias(expr2, Seq(s"Analyzer($expr2)"))() ::
+      Alias(expr3, Seq(s"Analyzer($expr3)"))() ::
+      Alias(expr4, Seq(s"Analyzer($expr4)"))() :: Nil, testRelation2))
     val pl = plan.asInstanceOf[Project].projectList
     assert(pl(0).dataType == DoubleType)
     assert(pl(1).dataType == DoubleType)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/DecimalPrecisionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/DecimalPrecisionSuite.scala
@@ -45,12 +45,12 @@ class DecimalPrecisionSuite extends FunSuite with BeforeAndAfter {
   }
 
   private def checkType(expression: Expression, expectedType: DataType): Unit = {
-    val plan = Project(Seq(Alias(expression, "c")()), relation)
+    val plan = Project(Seq(Alias(expression, Seq("c"))()), relation)
     assert(analyzer(plan).schema.fields(0).dataType === expectedType)
   }
 
   private def checkComparison(expression: Expression, expectedType: DataType): Unit = {
-    val plan = Project(Alias(expression, "c")() :: Nil, relation)
+    val plan = Project(Alias(expression, Seq("c"))() :: Nil, relation)
     val comparison = analyzer(plan).collect {
       case Project(Alias(e: BinaryComparison, _) :: Nil, _) => e
     }.head

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercionSuite.scala
@@ -106,8 +106,8 @@ class HiveTypeCoercionSuite extends FunSuite {
     val booleanCasts = new HiveTypeCoercion { }.BooleanCasts
     def ruleTest(initial: Expression, transformed: Expression) {
       val testRelation = LocalRelation(AttributeReference("a", IntegerType)())
-      assert(booleanCasts(Project(Seq(Alias(initial, "a")()), testRelation)) ==
-        Project(Seq(Alias(transformed, "a")()), testRelation))
+      assert(booleanCasts(Project(Seq(Alias(initial, Seq("a"))()), testRelation)) ==
+        Project(Seq(Alias(transformed, Seq("a"))()), testRelation))
     }
     // Remove superflous boolean -> boolean casts.
     ruleTest(Cast(Literal(true), BooleanType), Literal(true))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/GeneratedEvaluationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/GeneratedEvaluationSuite.scala
@@ -29,7 +29,7 @@ class GeneratedEvaluationSuite extends ExpressionEvaluationSuite {
       expected: Any,
       inputRow: Row = EmptyRow): Unit = {
     val plan = try {
-      GenerateMutableProjection(Alias(expression, s"Optimized($expression)")() :: Nil)()
+      GenerateMutableProjection(Alias(expression, Seq(s"Optimized($expression)"))() :: Nil)()
     } catch {
       case e: Throwable =>
         val evaluated = GenerateProjection.expressionEvaluator(expression)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/GeneratedMutableEvaluationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/GeneratedMutableEvaluationSuite.scala
@@ -31,7 +31,7 @@ class GeneratedMutableEvaluationSuite extends ExpressionEvaluationSuite {
     lazy val evaluated = GenerateProjection.expressionEvaluator(expression)
 
     val plan = try {
-      GenerateProjection(Alias(expression, s"Optimized($expression)")() :: Nil)
+      GenerateProjection(Alias(expression, Seq(s"Optimized($expression)"))() :: Nil)
     } catch {
       case e: Throwable =>
         fail(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ExpressionOptimizationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ExpressionOptimizationSuite.scala
@@ -29,7 +29,7 @@ class ExpressionOptimizationSuite extends ExpressionEvaluationSuite {
       expression: Expression,
       expected: Any,
       inputRow: Row = EmptyRow): Unit = {
-    val plan = Project(Alias(expression, s"Optimized($expression)")() :: Nil, NoRelation)
+    val plan = Project(Alias(expression, Seq(s"Optimized($expression)"))() :: Nil, NoRelation)
     val optimizedPlan = DefaultOptimizer(plan)
     super.checkEvaluation(optimizedPlan.expressions.head, expected, inputRow)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/SchemaRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SchemaRDD.scala
@@ -166,7 +166,7 @@ class SchemaRDD(
   def select(exprs: Expression*): SchemaRDD = {
     val aliases = exprs.zipWithIndex.map {
       case (ne: NamedExpression, _) => ne
-      case (e, i) => Alias(e, s"c$i")()
+      case (e, i) => Alias(e, Seq(s"c$i"))()
     }
     new SchemaRDD(sqlContext, Project(aliases, logicalPlan))
   }
@@ -254,7 +254,7 @@ class SchemaRDD(
   def groupBy(groupingExprs: Expression*)(aggregateExprs: Expression*): SchemaRDD = {
     val aliasedExprs = aggregateExprs.map {
       case ne: NamedExpression => ne
-      case e => Alias(e, e.toString)()
+      case e => Alias(e, Seq(e.toString))()
     }
     new SchemaRDD(sqlContext, Aggregate(groupingExprs, aliasedExprs, logicalPlan))
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/Aggregate.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/Aggregate.scala
@@ -103,7 +103,7 @@ case class Aggregate(
   /** Named attributes used to substitute grouping attributes into the final result. */
   private[this] val namedGroups = groupingExpressions.map {
     case ne: NamedExpression => ne -> ne.toAttribute
-    case e => e -> Alias(e, s"groupingExpr:$e")().toAttribute
+    case e => e -> Alias(e, Seq(s"groupingExpr:$e"))().toAttribute
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/GeneratedAggregate.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/GeneratedAggregate.scala
@@ -197,7 +197,7 @@ case class GeneratedAggregate(
 
     val namedGroups = groupingExpressions.zipWithIndex.map {
       case (ne: NamedExpression, _) => (ne, ne)
-      case (e, i) => (e, Alias(e, s"GroupingExpr$i")())
+      case (e, i) => (e, Alias(e, Seq(s"GroupingExpr$i"))())
     }
 
     val groupMap: Map[Expression, Attribute] =

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -434,7 +434,7 @@ private[hive] class HiveMetastoreCatalog(hive: HiveContext) extends Catalog with
         // Only do the casting when child output data types differ from table output data types.
         val castedChildOutput = child.output.zip(table.output).map {
           case (input, output) if input.dataType != output.dataType =>
-            Alias(Cast(input, output.dataType), input.name)()
+            Alias(Cast(input, output.dataType), Seq(input.name))()
           case (input, _) => input
         }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
@@ -389,7 +389,7 @@ private[hive] object HiveQl {
   protected def nameExpressions(exprs: Seq[Expression]): Seq[NamedExpression] = {
     exprs.zipWithIndex.map {
       case (ne: NamedExpression, _) => ne
-      case (e, i) => Alias(e, s"_c$i")()
+      case (e, i) => Alias(e, Seq(s"_c$i"))()
     }
   }
 
@@ -939,7 +939,7 @@ https://cwiki.apache.org/confluence/display/Hive/Enhanced+Aggregation%2C+Cube%2C
 
     case Token("TOK_SELEXPR",
            e :: Token(alias, Nil) :: Nil) =>
-      Some(Alias(nodeToExpr(e), cleanIdentifier(alias))())
+      Some(Alias(nodeToExpr(e), Seq(cleanIdentifier(alias)))())
 
     /* Hints are ignored */
     case Token("TOK_HINTLIST", _) => None

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -508,6 +508,16 @@ class HiveQuerySuite extends HiveComparisonTest with BeforeAndAfter {
     assert(sql("select key from src having key > 490").collect().size < 100)
   }
 
+  test("support multi names for alias") {
+    sql("select key as (k1, k2), value as (v1, v2) from src limit 5").collect()
+    sql("select k1, k2 from (select key as (k1, k2), value as (v1, v2) from src) t limit 5")
+      .collect()
+      .foreach { row =>
+      assert(row.getInt(0) == row.getInt(1))
+    }
+
+  }
+
   test("Query Hive native command execution result") {
     val tableName = "test_native_commands"
 


### PR DESCRIPTION
when a udf output multi columns, now we can not use alias for them in spark-sql, see this flowing sql: 

select stack(1, key, value, key, value) as (a, b, c, d) from src limit 5;
