### PR TITLE
SPARK-2285 [CORE] Give various TaskEndReason subclass more descriptive names

### DIFF
--- a/core/src/main/scala/org/apache/spark/TaskEndReason.scala
+++ b/core/src/main/scala/org/apache/spark/TaskEndReason.scala
@@ -36,7 +36,7 @@ sealed trait TaskEndReason
  * Task succeeded.
  */
 @DeveloperApi
-case object Success extends TaskEndReason
+case object TaskSucceeded extends TaskEndReason
 
 /**
  * :: DeveloperApi ::

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -911,7 +911,7 @@ class DAGScheduler(
 
     // The success case is dealt with separately below, since we need to compute accumulator
     // updates before posting.
-    if (event.reason != Success) {
+    if (event.reason != TaskSucceeded) {
       val attemptId = stageIdToStage.get(task.stageId).map(_.latestInfo.attemptId).getOrElse(-1)
       listenerBus.post(SparkListenerTaskEnd(stageId, attemptId, taskType, event.reason,
         event.taskInfo, event.taskMetrics))
@@ -939,7 +939,7 @@ class DAGScheduler(
       runningStages -= stage
     }
     event.reason match {
-      case Success =>
+      case TaskSucceeded =>
         listenerBus.post(SparkListenerTaskEnd(stageId, stage.latestInfo.attemptId, taskType,
           event.reason, event.taskInfo, event.taskMetrics))
         stage.pendingTasks -= task

--- a/core/src/main/scala/org/apache/spark/scheduler/JobLogger.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/JobLogger.scala
@@ -214,7 +214,7 @@ class JobLogger(val user: String, val logDirName: String) extends SparkListener 
     var taskStatus = "TASK_TYPE=%s".format(taskEnd.taskType)
     val taskMetrics = if (taskEnd.taskMetrics != null) taskEnd.taskMetrics else TaskMetrics.empty
     taskEnd.reason match {
-      case Success => taskStatus += " STATUS=SUCCESS"
+      case TaskSucceeded => taskStatus += " STATUS=SUCCESS"
         recordTaskMetrics(taskEnd.stageId, taskStatus, taskInfo, taskMetrics)
       case Resubmitted =>
         taskStatus += " STATUS=RESUBMITTED TID=" + taskInfo.taskId +

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -566,7 +566,7 @@ private[spark] class TaskSetManager(
     info.markSuccessful()
     removeRunningTask(tid)
     sched.dagScheduler.taskEnded(
-      tasks(index), Success, result.value(), result.accumUpdates, info, result.metrics)
+      tasks(index), TaskSucceeded, result.value(), result.accumUpdates, info, result.metrics)
     if (!successful(index)) {
       tasksSuccessful += 1
       logInfo("Finished task %s in stage %s (TID %d) in %d ms on %s (%d/%d)".format(

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
@@ -328,7 +328,7 @@ class JobProgressListener(conf: SparkConf) extends SparkListener with Logging {
       val execSummary = execSummaryMap.getOrElseUpdate(info.executorId, new ExecutorSummary)
 
       taskEnd.reason match {
-        case Success =>
+        case TaskSucceeded =>
           execSummary.succeededTasks += 1
         case _ =>
           execSummary.failedTasks += 1
@@ -338,7 +338,7 @@ class JobProgressListener(conf: SparkConf) extends SparkListener with Logging {
 
       val (errorMessage, metrics): (Option[String], Option[TaskMetrics]) =
         taskEnd.reason match {
-          case org.apache.spark.Success =>
+          case org.apache.spark.TaskSucceeded =>
             stageData.completedIndices.add(info.index)
             stageData.numCompleteTasks += 1
             (None, Option(taskEnd.taskMetrics))
@@ -367,7 +367,7 @@ class JobProgressListener(conf: SparkConf) extends SparkListener with Logging {
       ) {
         jobData.numActiveTasks -= 1
         taskEnd.reason match {
-          case Success =>
+          case TaskSucceeded =>
             jobData.numCompletedTasks += 1
           case _ =>
             jobData.numFailedTasks += 1

--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -690,7 +690,7 @@ private[spark] object JsonProtocol {
   }
 
   def taskEndReasonFromJson(json: JValue): TaskEndReason = {
-    val success = Utils.getFormattedClassName(Success)
+    val success = Utils.getFormattedClassName(TaskSucceeded)
     val resubmitted = Utils.getFormattedClassName(Resubmitted)
     val fetchFailed = Utils.getFormattedClassName(FetchFailed)
     val exceptionFailure = Utils.getFormattedClassName(ExceptionFailure)
@@ -700,7 +700,7 @@ private[spark] object JsonProtocol {
     val unknownReason = Utils.getFormattedClassName(UnknownReason)
 
     (json \ "Reason").extract[String] match {
-      case `success` => Success
+      case `success` => TaskSucceeded
       case `resubmitted` => Resubmitted
       case `fetchFailed` =>
         val blockManagerAddress = blockManagerIdFromJson(json \ "Block Manager Address")

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -560,14 +560,14 @@ class ExecutorAllocationManagerSuite extends FunSuite with LocalSparkContext {
 
     // Finishing all tasks running on an executor should start the remove timer for that executor
     sc.listenerBus.postToAll(SparkListenerTaskEnd(
-      0, 0, "task-type", Success, createTaskInfo(0, 0, "executor-1"), new TaskMetrics))
+      0, 0, "task-type", TaskSucceeded, createTaskInfo(0, 0, "executor-1"), new TaskMetrics))
     sc.listenerBus.postToAll(SparkListenerTaskEnd(
-      0, 0, "task-type", Success, createTaskInfo(2, 2, "executor-2"), new TaskMetrics))
+      0, 0, "task-type", TaskSucceeded, createTaskInfo(2, 2, "executor-2"), new TaskMetrics))
     assert(removeTimes(manager).size === 4)
     assert(!removeTimes(manager).contains("executor-1")) // executor-1 has not finished yet
     assert(removeTimes(manager).contains("executor-2"))
     sc.listenerBus.postToAll(SparkListenerTaskEnd(
-      0, 0, "task-type", Success, createTaskInfo(1, 1, "executor-1"), new TaskMetrics))
+      0, 0, "task-type", TaskSucceeded, createTaskInfo(1, 1, "executor-1"), new TaskMetrics))
     assert(removeTimes(manager).size === 5)
     assert(removeTimes(manager).contains("executor-1")) // executor-1 has now finished
   }

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.scheduler
 
-import java.io.{ObjectInputStream, ObjectOutputStream, IOException}
 import java.util.Random
 
 import scala.collection.mutable.ArrayBuffer
@@ -174,7 +173,7 @@ class TaskSetManagerSuite extends FunSuite with LocalSparkContext with Logging {
 
     // Tell it the task has finished
     manager.handleSuccessfulTask(0, createTaskResult(0))
-    assert(sched.endedTasks(0) === Success)
+    assert(sched.endedTasks(0) === TaskSucceeded)
     assert(sched.finishedManagers.contains(manager))
   }
 
@@ -199,13 +198,13 @@ class TaskSetManagerSuite extends FunSuite with LocalSparkContext with Logging {
     // Finish the first two tasks
     manager.handleSuccessfulTask(0, createTaskResult(0))
     manager.handleSuccessfulTask(1, createTaskResult(1))
-    assert(sched.endedTasks(0) === Success)
-    assert(sched.endedTasks(1) === Success)
+    assert(sched.endedTasks(0) === TaskSucceeded)
+    assert(sched.endedTasks(1) === TaskSucceeded)
     assert(!sched.finishedManagers.contains(manager))
 
     // Finish the last task
     manager.handleSuccessfulTask(2, createTaskResult(2))
-    assert(sched.endedTasks(2) === Success)
+    assert(sched.endedTasks(2) === TaskSucceeded)
     assert(sched.finishedManagers.contains(manager))
   }
 

--- a/core/src/test/scala/org/apache/spark/storage/StorageStatusListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/StorageStatusListenerSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.storage
 
 import org.scalatest.FunSuite
-import org.apache.spark.Success
+import org.apache.spark.TaskSucceeded
 import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.scheduler._
 
@@ -69,10 +69,10 @@ class StorageStatusListenerSuite extends FunSuite {
     // Task end with no updated blocks
     assert(listener.executorIdToStorageStatus("big").numBlocks === 0)
     assert(listener.executorIdToStorageStatus("fat").numBlocks === 0)
-    listener.onTaskEnd(SparkListenerTaskEnd(1, 0, "obliteration", Success, taskInfo1, taskMetrics))
+    listener.onTaskEnd(SparkListenerTaskEnd(1, 0, "obliteration", TaskSucceeded, taskInfo1, taskMetrics))
     assert(listener.executorIdToStorageStatus("big").numBlocks === 0)
     assert(listener.executorIdToStorageStatus("fat").numBlocks === 0)
-    listener.onTaskEnd(SparkListenerTaskEnd(1, 0, "obliteration", Success, taskInfo2, taskMetrics))
+    listener.onTaskEnd(SparkListenerTaskEnd(1, 0, "obliteration", TaskSucceeded, taskInfo2, taskMetrics))
     assert(listener.executorIdToStorageStatus("big").numBlocks === 0)
     assert(listener.executorIdToStorageStatus("fat").numBlocks === 0)
   }
@@ -92,13 +92,13 @@ class StorageStatusListenerSuite extends FunSuite {
     // Task end with new blocks
     assert(listener.executorIdToStorageStatus("big").numBlocks === 0)
     assert(listener.executorIdToStorageStatus("fat").numBlocks === 0)
-    listener.onTaskEnd(SparkListenerTaskEnd(1, 0, "obliteration", Success, taskInfo1, taskMetrics1))
+    listener.onTaskEnd(SparkListenerTaskEnd(1, 0, "obliteration", TaskSucceeded, taskInfo1, taskMetrics1))
     assert(listener.executorIdToStorageStatus("big").numBlocks === 2)
     assert(listener.executorIdToStorageStatus("fat").numBlocks === 0)
     assert(listener.executorIdToStorageStatus("big").containsBlock(RDDBlockId(1, 1)))
     assert(listener.executorIdToStorageStatus("big").containsBlock(RDDBlockId(1, 2)))
     assert(listener.executorIdToStorageStatus("fat").numBlocks === 0)
-    listener.onTaskEnd(SparkListenerTaskEnd(1, 0, "obliteration", Success, taskInfo2, taskMetrics2))
+    listener.onTaskEnd(SparkListenerTaskEnd(1, 0, "obliteration", TaskSucceeded, taskInfo2, taskMetrics2))
     assert(listener.executorIdToStorageStatus("big").numBlocks === 2)
     assert(listener.executorIdToStorageStatus("fat").numBlocks === 1)
     assert(listener.executorIdToStorageStatus("big").containsBlock(RDDBlockId(1, 1)))
@@ -112,13 +112,13 @@ class StorageStatusListenerSuite extends FunSuite {
     taskMetrics1.updatedBlocks = Some(Seq(droppedBlock1, droppedBlock3))
     taskMetrics2.updatedBlocks = Some(Seq(droppedBlock2, droppedBlock3))
 
-    listener.onTaskEnd(SparkListenerTaskEnd(1, 0, "obliteration", Success, taskInfo1, taskMetrics1))
+    listener.onTaskEnd(SparkListenerTaskEnd(1, 0, "obliteration", TaskSucceeded, taskInfo1, taskMetrics1))
     assert(listener.executorIdToStorageStatus("big").numBlocks === 1)
     assert(listener.executorIdToStorageStatus("fat").numBlocks === 1)
     assert(!listener.executorIdToStorageStatus("big").containsBlock(RDDBlockId(1, 1)))
     assert(listener.executorIdToStorageStatus("big").containsBlock(RDDBlockId(1, 2)))
     assert(listener.executorIdToStorageStatus("fat").containsBlock(RDDBlockId(4, 0)))
-    listener.onTaskEnd(SparkListenerTaskEnd(1, 0, "obliteration", Success, taskInfo2, taskMetrics2))
+    listener.onTaskEnd(SparkListenerTaskEnd(1, 0, "obliteration", TaskSucceeded, taskInfo2, taskMetrics2))
     assert(listener.executorIdToStorageStatus("big").numBlocks === 1)
     assert(listener.executorIdToStorageStatus("fat").numBlocks === 0)
     assert(!listener.executorIdToStorageStatus("big").containsBlock(RDDBlockId(1, 1)))
@@ -136,8 +136,8 @@ class StorageStatusListenerSuite extends FunSuite {
     val block3 = (RDDBlockId(4, 0), BlockStatus(StorageLevel.DISK_ONLY, 0L, 300L, 0L))
     taskMetrics1.updatedBlocks = Some(Seq(block1, block2))
     taskMetrics2.updatedBlocks = Some(Seq(block3))
-    listener.onTaskEnd(SparkListenerTaskEnd(1, 0, "obliteration", Success, taskInfo1, taskMetrics1))
-    listener.onTaskEnd(SparkListenerTaskEnd(1, 0, "obliteration", Success, taskInfo1, taskMetrics2))
+    listener.onTaskEnd(SparkListenerTaskEnd(1, 0, "obliteration", TaskSucceeded, taskInfo1, taskMetrics1))
+    listener.onTaskEnd(SparkListenerTaskEnd(1, 0, "obliteration", TaskSucceeded, taskInfo1, taskMetrics2))
     assert(listener.executorIdToStorageStatus("big").numBlocks === 3)
 
     // Unpersist RDD

--- a/core/src/test/scala/org/apache/spark/ui/jobs/JobProgressListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/jobs/JobProgressListenerSuite.scala
@@ -21,7 +21,7 @@ import org.scalatest.FunSuite
 import org.scalatest.Matchers
 
 import org.apache.spark._
-import org.apache.spark.{LocalSparkContext, SparkConf, Success}
+import org.apache.spark.{LocalSparkContext, SparkConf, TaskSucceeded}
 import org.apache.spark.executor._
 import org.apache.spark.scheduler._
 import org.apache.spark.util.Utils
@@ -147,7 +147,7 @@ class JobProgressListenerSuite extends FunSuite with LocalSparkContext with Matc
     var task = new ShuffleMapTask(0)
     val taskType = Utils.getFormattedClassName(task)
     listener.onTaskEnd(
-      SparkListenerTaskEnd(task.stageId, 0, taskType, Success, taskInfo, taskMetrics))
+      SparkListenerTaskEnd(task.stageId, 0, taskType, TaskSucceeded, taskInfo, taskMetrics))
     assert(listener.stageIdToData.getOrElse((0, 0), fail())
       .executorSummary.getOrElse("exe-1", fail()).shuffleRead === 1000)
 
@@ -157,7 +157,7 @@ class JobProgressListenerSuite extends FunSuite with LocalSparkContext with Matc
     taskInfo.finishTime = 1
     task = new ShuffleMapTask(0)
     listener.onTaskEnd(
-      SparkListenerTaskEnd(task.stageId, 0, taskType, Success, taskInfo, taskMetrics))
+      SparkListenerTaskEnd(task.stageId, 0, taskType, TaskSucceeded, taskInfo, taskMetrics))
     assert(listener.stageIdToData.size === 1)
 
     // finish this task, should get updated duration
@@ -165,7 +165,7 @@ class JobProgressListenerSuite extends FunSuite with LocalSparkContext with Matc
     taskInfo.finishTime = 1
     task = new ShuffleMapTask(0)
     listener.onTaskEnd(
-      SparkListenerTaskEnd(task.stageId, 0, taskType, Success, taskInfo, taskMetrics))
+      SparkListenerTaskEnd(task.stageId, 0, taskType, TaskSucceeded, taskInfo, taskMetrics))
     assert(listener.stageIdToData.getOrElse((0, 0), fail())
       .executorSummary.getOrElse("exe-1", fail()).shuffleRead === 2000)
 
@@ -174,7 +174,7 @@ class JobProgressListenerSuite extends FunSuite with LocalSparkContext with Matc
     taskInfo.finishTime = 1
     task = new ShuffleMapTask(0)
     listener.onTaskEnd(
-      SparkListenerTaskEnd(task.stageId, 0, taskType, Success, taskInfo, taskMetrics))
+      SparkListenerTaskEnd(task.stageId, 0, taskType, TaskSucceeded, taskInfo, taskMetrics))
     assert(listener.stageIdToData.getOrElse((0, 0), fail())
       .executorSummary.getOrElse("exe-2", fail()).shuffleRead === 1000)
   }
@@ -208,7 +208,7 @@ class JobProgressListenerSuite extends FunSuite with LocalSparkContext with Matc
 
     // Make sure we count success as success.
     listener.onTaskEnd(
-      SparkListenerTaskEnd(task.stageId, 1, taskType, Success, taskInfo, metrics))
+      SparkListenerTaskEnd(task.stageId, 1, taskType, TaskSucceeded, taskInfo, metrics))
     assert(listener.stageIdToData((task.stageId, 1)).numCompleteTasks === 1)
     assert(listener.stageIdToData((task.stageId, 0)).numFailedTasks === failCount)
   }
@@ -282,10 +282,10 @@ class JobProgressListenerSuite extends FunSuite with LocalSparkContext with Matc
       .totalBlocksFetched == 202)
 
     // task that was included in a heartbeat
-    listener.onTaskEnd(SparkListenerTaskEnd(0, 0, taskType, Success, makeTaskInfo(1234L, 1),
+    listener.onTaskEnd(SparkListenerTaskEnd(0, 0, taskType, TaskSucceeded, makeTaskInfo(1234L, 1),
       makeTaskMetrics(300)))
     // task that wasn't included in a heartbeat
-    listener.onTaskEnd(SparkListenerTaskEnd(1, 0, taskType, Success, makeTaskInfo(1237L, 1),
+    listener.onTaskEnd(SparkListenerTaskEnd(1, 0, taskType, TaskSucceeded, makeTaskInfo(1237L, 1),
       makeTaskMetrics(400)))
 
     stage0Data = listener.stageIdToData.get((0, 0)).get

--- a/core/src/test/scala/org/apache/spark/ui/storage/StorageTabSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/storage/StorageTabSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.ui.storage
 
 import org.scalatest.{BeforeAndAfter, FunSuite}
-import org.apache.spark.Success
+import org.apache.spark.TaskSucceeded
 import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.scheduler._
 import org.apache.spark.storage._
@@ -117,7 +117,7 @@ class StorageTabSuite extends FunSuite with BeforeAndAfter {
     assert(!storageListener._rddInfoMap(2).isCached)
 
     // Task end with no updated blocks. This should not change anything.
-    bus.postToAll(SparkListenerTaskEnd(0, 0, "obliteration", Success, taskInfo, new TaskMetrics))
+    bus.postToAll(SparkListenerTaskEnd(0, 0, "obliteration", TaskSucceeded, taskInfo, new TaskMetrics))
     assert(storageListener._rddInfoMap.size === 3)
     assert(storageListener.rddInfoList.size === 0)
 
@@ -129,7 +129,7 @@ class StorageTabSuite extends FunSuite with BeforeAndAfter {
       (RDDBlockId(0, 102), BlockStatus(memAndDisk, 400L, 0L, 200L)),
       (RDDBlockId(1, 20), BlockStatus(memAndDisk, 0L, 240L, 0L))
     ))
-    bus.postToAll(SparkListenerTaskEnd(1, 0, "obliteration", Success, taskInfo, metrics1))
+    bus.postToAll(SparkListenerTaskEnd(1, 0, "obliteration", TaskSucceeded, taskInfo, metrics1))
     assert(storageListener._rddInfoMap(0).memSize === 800L)
     assert(storageListener._rddInfoMap(0).diskSize === 400L)
     assert(storageListener._rddInfoMap(0).tachyonSize === 200L)
@@ -151,7 +151,7 @@ class StorageTabSuite extends FunSuite with BeforeAndAfter {
       (RDDBlockId(2, 40), BlockStatus(none, 0L, 0L, 0L)), // doesn't actually exist
       (RDDBlockId(4, 80), BlockStatus(none, 0L, 0L, 0L)) // doesn't actually exist
     ))
-    bus.postToAll(SparkListenerTaskEnd(2, 0, "obliteration", Success, taskInfo, metrics2))
+    bus.postToAll(SparkListenerTaskEnd(2, 0, "obliteration", TaskSucceeded, taskInfo, metrics2))
     assert(storageListener._rddInfoMap(0).memSize === 400L)
     assert(storageListener._rddInfoMap(0).diskSize === 400L)
     assert(storageListener._rddInfoMap(0).tachyonSize === 200L)
@@ -178,13 +178,13 @@ class StorageTabSuite extends FunSuite with BeforeAndAfter {
     bus.postToAll(SparkListenerBlockManagerAdded(1L, bm1, 1000L))
     bus.postToAll(SparkListenerStageSubmitted(stageInfo0))
     assert(storageListener.rddInfoList.size === 0)
-    bus.postToAll(SparkListenerTaskEnd(0, 0, "big", Success, taskInfo, taskMetrics0))
+    bus.postToAll(SparkListenerTaskEnd(0, 0, "big", TaskSucceeded, taskInfo, taskMetrics0))
     assert(storageListener.rddInfoList.size === 1)
     bus.postToAll(SparkListenerStageSubmitted(stageInfo1))
     assert(storageListener.rddInfoList.size === 1)
     bus.postToAll(SparkListenerStageCompleted(stageInfo0))
     assert(storageListener.rddInfoList.size === 1)
-    bus.postToAll(SparkListenerTaskEnd(1, 0, "small", Success, taskInfo1, taskMetrics1))
+    bus.postToAll(SparkListenerTaskEnd(1, 0, "small", TaskSucceeded, taskInfo1, taskMetrics1))
     assert(storageListener.rddInfoList.size === 2)
     bus.postToAll(SparkListenerStageCompleted(stageInfo1))
     assert(storageListener.rddInfoList.size === 2)

--- a/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
@@ -854,7 +854,7 @@ class JsonProtocolSuite extends FunSuite {
       |  "Stage Attempt ID": 0,
       |  "Task Type": "ShuffleMapTask",
       |  "Task End Reason": {
-      |    "Reason": "Success"
+      |    "Reason": "TaskSucceeded"
       |  },
       |  "Task Info": {
       |    "Task ID": 123,
@@ -937,7 +937,7 @@ class JsonProtocolSuite extends FunSuite {
       |  "Stage Attempt ID": 0,
       |  "Task Type": "ShuffleMapTask",
       |  "Task End Reason": {
-      |    "Reason": "Success"
+      |    "Reason": "TaskSucceeded"
       |  },
       |  "Task Info": {
       |    "Task ID": 123,
@@ -1018,7 +1018,7 @@ class JsonProtocolSuite extends FunSuite {
       |  "Stage Attempt ID": 0,
       |  "Task Type": "ResultTask",
       |  "Task End Reason": {
-      |    "Reason": "Success"
+      |    "Reason": "TaskSucceeded"
       |  },
       |  "Task Info": {
       |    "Task ID": 123,

--- a/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
@@ -44,13 +44,13 @@ class JsonProtocolSuite extends FunSuite {
     val taskStart = SparkListenerTaskStart(111, 0, makeTaskInfo(222L, 333, 1, 444L, false))
     val taskGettingResult =
       SparkListenerTaskGettingResult(makeTaskInfo(1000L, 2000, 5, 3000L, true))
-    val taskEnd = SparkListenerTaskEnd(1, 0, "ShuffleMapTask", Success,
+    val taskEnd = SparkListenerTaskEnd(1, 0, "ShuffleMapTask", TaskSucceeded,
       makeTaskInfo(123L, 234, 67, 345L, false),
       makeTaskMetrics(300L, 400L, 500L, 600L, 700, 800, hasHadoopInput = false, hasOutput = false))
-    val taskEndWithHadoopInput = SparkListenerTaskEnd(1, 0, "ShuffleMapTask", Success,
+    val taskEndWithHadoopInput = SparkListenerTaskEnd(1, 0, "ShuffleMapTask", TaskSucceeded,
       makeTaskInfo(123L, 234, 67, 345L, false),
       makeTaskMetrics(300L, 400L, 500L, 600L, 700, 800, hasHadoopInput = true, hasOutput = false))
-    val taskEndWithOutput = SparkListenerTaskEnd(1, 0, "ResultTask", Success,
+    val taskEndWithOutput = SparkListenerTaskEnd(1, 0, "ResultTask", TaskSucceeded,
       makeTaskInfo(123L, 234, 67, 345L, false),
       makeTaskMetrics(300L, 400L, 500L, 600L, 700, 800, hasHadoopInput = true, hasOutput = true))
     val jobStart = {
@@ -131,7 +131,7 @@ class JsonProtocolSuite extends FunSuite {
     val fetchMetadataFailed = new MetadataFetchFailedException(17,
       19, "metadata Fetch failed exception").toTaskEndReason
     val exceptionFailure = new ExceptionFailure(exception, None)
-    testTaskEndReason(Success)
+    testTaskEndReason(TaskSucceeded)
     testTaskEndReason(Resubmitted)
     testTaskEndReason(fetchFailed)
     testTaskEndReason(fetchMetadataFailed)
@@ -474,7 +474,7 @@ class JsonProtocolSuite extends FunSuite {
 
   private def assertEquals(reason1: TaskEndReason, reason2: TaskEndReason) {
     (reason1, reason2) match {
-      case (Success, Success) =>
+      case (TaskSucceeded, TaskSucceeded) =>
       case (Resubmitted, Resubmitted) =>
       case (r1: FetchFailed, r2: FetchFailed) =>
         assert(r1.shuffleId === r2.shuffleId)


### PR DESCRIPTION
Was this all that you had in mind @rxin -- just a rename? or did I miss the point. The other subclasses look fairly descriptive as class names go, like `TaskKilled`.
