### PR TITLE
[SPARK-5404] [SQL] update the default statistic number

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
@@ -209,6 +209,8 @@ abstract class LogicalPlan extends QueryPlan[LogicalPlan] with Logging {
  */
 abstract class LeafNode extends LogicalPlan with trees.LeafNode[LogicalPlan] {
   self: Product =>
+
+  override def statistics: Statistics = Statistics(1)
 }
 
 /**
@@ -216,6 +218,8 @@ abstract class LeafNode extends LogicalPlan with trees.LeafNode[LogicalPlan] {
  */
 abstract class UnaryNode extends LogicalPlan with trees.UnaryNode[LogicalPlan] {
   self: Product =>
+
+  override def statistics: Statistics = child.statistics
 }
 
 /**
@@ -223,4 +227,8 @@ abstract class UnaryNode extends LogicalPlan with trees.UnaryNode[LogicalPlan] {
  */
 abstract class BinaryNode extends LogicalPlan with trees.BinaryNode[LogicalPlan] {
   self: Product =>
+
+  override def statistics: Statistics = {
+    Statistics(left.statistics.sizeInBytes + right.statistics.sizeInBytes)
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicOperators.scala
@@ -93,6 +93,16 @@ case class Join(
         left.output ++ right.output
     }
   }
+
+  override def statistics: Statistics = joinType match {
+    case LeftSemi => left.statistics
+    // multiply by 10 is a guess number
+    case LeftOuter => Statistics(left.statistics.sizeInBytes * 10)
+    // multiply by 10 is a guess number
+    case RightOuter => Statistics(right.statistics.sizeInBytes * 10)
+    // multiply by 10 is a guess number
+    case _ => Statistics((left.statistics.sizeInBytes + right.statistics.sizeInBytes) * 10)
+  }
 }
 
 case class Except(left: LogicalPlan, right: LogicalPlan) extends BinaryNode {


### PR DESCRIPTION
The default statistic of a logical plan node is too aggressive for most of case, and probably doesn't work correctly for most of join order optimization.

e.g.  A (100k) JOIN B(50K) RIGHT JOIN C(1G)

Ideally, we expect to get 2 broadcast nested loop joins, however, the statistic of the logical `A JOIN B` is 5 G (=100K \* 50K).

This implementation still cannot get the accurate statistic, but perhaps useful for most of join cases.
