### PR TITLE
[SPARK-5434] [EC2] Preserve spaces in EC2 path

### DIFF
--- a/ec2/spark-ec2
+++ b/ec2/spark-ec2
@@ -20,6 +20,6 @@
 
 # Preserve the user's CWD so that relative paths are passed correctly to 
 #+ the underlying Python script.
-SPARK_EC2_DIR="$(dirname $0)"
+SPARK_EC2_DIR="$(dirname "$0")"
 
 python -Wdefault "${SPARK_EC2_DIR}/spark_ec2.py" "$@"


### PR DESCRIPTION
Fixes [SPARK-5434](https://issues.apache.org/jira/browse/SPARK-5434).

Simple demonstration of the problem and the fix:

```
$ spacey_path="/path/with some/spaces"
$ dirname $spacey_path
usage: dirname path
$ echo $?
1
$ dirname "$spacey_path"
/path/with some
$ echo $?
0
```
