### PR TITLE
[SPARK-5428]: Declare the 'assembly' module at the bottom of the <modules> element in the parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,6 @@
     <module>sql/catalyst</module>
     <module>sql/core</module>
     <module>sql/hive</module>
-    <module>assembly</module>
     <module>external/twitter</module>
     <module>external/flume</module>
     <module>external/flume-sink</module>
@@ -105,6 +104,8 @@
     <module>external/zeromq</module>
     <module>examples</module>
     <module>repl</module>
+    <!-- (SPARK-5428) Ensure the assembly module is built last -->
+    <module>assembly</module>
   </modules>
 
   <properties>


### PR DESCRIPTION
- Reorder the pom's <modules> element list to put the assembly module at the bottom. 
- Add a comment that reminds to keep this order.
