### PR TITLE
[SPARK-5450][GraphX] Add APIs to save a graph as a SequenceFile and load it

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/GraphOps.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/GraphOps.scala
@@ -305,6 +305,16 @@ class GraphOps[VD: ClassTag, ED: ClassTag](graph: Graph[VD, ED]) extends Seriali
   }
 
   /**
+   * Save the VertexRDD in this Graph as a SequenceFile of serialized objects.
+   */
+  def saveVerticesAsObjectFile(path: String) = graph.vertices.saveAsObjectFile(path)
+
+  /**
+   * Save the EdgeRDD in this Graph as a SequenceFile of serialized objects.
+   */
+  def saveEdgesAsObjectFile(path: String) = graph.edges.saveAsObjectFile(path)
+
+  /**
    * Execute a Pregel-like iterative vertex-parallel abstraction.  The
    * user-defined vertex-program `vprog` is executed in parallel on
    * each vertex receiving any inbound messages and computing a new


### PR DESCRIPTION
As the size of input data increases, building Graph eat much processing time via
GraphLoader.edgeListFile() or RDD transformations.
APIs to save Graph as a object file is useful for those cases.
The operations are currently slow because of the default
serializer (Java serialization), so efficient serialization
is of future work.
