### PR TITLE
[HOTFIX] Rename the identifier of driver from `<driver>` to `driver`

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1682,7 +1682,7 @@ object SparkContext extends Logging {
 
   private[spark] val SPARK_UNKNOWN_USER = "<unknown>"
 
-  private[spark] val DRIVER_IDENTIFIER = "<driver>"
+  private[spark] val DRIVER_IDENTIFIER = "driver"
 
   // The following deprecated objects have already been copied to `object AccumulatorParam` to
   // make the compiler find them automatically. They are duplicate codes only for backward


### PR DESCRIPTION
This change is related to #3812.

The identifier of driver is defined as `<driver>` but this identifier is used for metrics name and some metrics sinks cannot parse `<` and `>`.
