### PR TITLE
[SQL][SPARK-5453] Use property 'mapreduce.input.pathFilter.class' to set a custom filter class for input files

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -21,7 +21,7 @@ import java.lang.reflect.Method
 import java.security.PrivilegedExceptionAction
 
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
+import org.apache.hadoop.fs.{FileStatus, FileSystem, Path, PathFilter}
 import org.apache.hadoop.fs.FileSystem.Statistics
 import org.apache.hadoop.mapred.JobConf
 import org.apache.hadoop.mapreduce.{JobContext, TaskAttemptContext}
@@ -195,6 +195,22 @@ class SparkHadoopUtil extends Logging {
   def listLeafStatuses(fs: FileSystem, basePath: Path): Seq[FileStatus] = {
     def recurse(path: Path): Array[FileStatus] = {
       val (directories, leaves) = fs.listStatus(path).partition(_.isDir)
+      leaves ++ directories.flatMap(f => listLeafStatuses(fs, f.getPath))
+    }
+
+    val baseStatus = fs.getFileStatus(basePath)
+    if (baseStatus.isDir) recurse(basePath) else Array(baseStatus)
+  }
+
+  /**
+   * Get [[FileStatus]] objects for all leaf children (files) under the given base path. If the
+   * given path points to a file, return a single-element collection containing [[FileStatus]] of
+   * that file. Uses pathFilter to filter out certain filestatuses
+   */
+  def listLeafStatusesFiltered(fs: FileSystem, basePath: Path,
+    filter: Option[PathFilter]): Seq[FileStatus] = {
+    def recurse(path: Path): Array[FileStatus] = {
+      val (directories, leaves) = fs.listStatus(path, filter.get).partition(_.isDir)
       leaves ++ directories.flatMap(f => listLeafStatuses(fs, f.getPath))
     }
 

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -207,16 +207,22 @@ class SparkHadoopUtil extends Logging {
    * given path points to a file, return a single-element collection containing [[FileStatus]] of
    * that file. Uses pathFilter to filter out certain filestatuses
    */
-  def listLeafStatusesFiltered(fs: FileSystem, basePath: Path,
+  def listLeafStatusesFiltered(
+    fs: FileSystem,
+    basePath: Path,
     filter: Option[PathFilter]): Seq[FileStatus] = {
-    def recurse(path: Path): Array[FileStatus] = {
-      val (directories, leaves) = fs.listStatus(path, filter.get).partition(_.isDir)
-      leaves ++ directories.flatMap(f => listLeafStatuses(fs, f.getPath))
-    }
+      if (filter.isDefined) {
+        def recurse(path: Path): Array[FileStatus] = {
+          val (directories, leaves) = fs.listStatus(path, filter.get).partition(_.isDir)
+          leaves ++ directories.flatMap(f => listLeafStatuses(fs, f.getPath))
+        }
 
-    val baseStatus = fs.getFileStatus(basePath)
-    if (baseStatus.isDir) recurse(basePath) else Array(baseStatus)
-  }
+        val baseStatus = fs.getFileStatus(basePath)
+        if (baseStatus.isDir) recurse(basePath) else Array(baseStatus)
+      } else {
+        listLeafStatuses(fs, basePath)
+      }
+    }
 }
 
 object SparkHadoopUtil {

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -166,13 +166,6 @@ class SQLContext(@transient val sparkContext: SparkContext)
   @transient
   protected[sql] val cacheManager = new CacheManager(this)
 
-  private val DEFAULT_FILTER: PathFilter = new PathFilter() {
-    @Override
-    def accept(file: Path): Boolean = {
-      return true
-    }
-  }
-
   /**
    * Return PathFilter to be used for filtering input files using custom filter class
    */
@@ -182,7 +175,7 @@ class SQLContext(@transient val sparkContext: SparkContext)
       val filterClazz = Class.forName(filterClassName).asInstanceOf[Class[_ <: PathFilter]]
       Option(ReflectionUtils.newInstance(filterClazz, null))
     } else {
-      Option(DEFAULT_FILTER)
+      None
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetRelation.scala
@@ -21,9 +21,11 @@ import java.io.IOException
 import java.util.logging.Level
 
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.Path
+import org.apache.hadoop.fs.{Path, PathFilter}
 import org.apache.hadoop.fs.permission.FsAction
+import org.apache.hadoop.mapreduce.lib.input.{FileInputFormat => NewFileInputFormat}
 import org.apache.spark.sql.types.{StructType, DataType}
+
 import parquet.hadoop.{ParquetOutputCommitter, ParquetOutputFormat}
 import parquet.hadoop.metadata.CompressionCodecName
 import parquet.schema.MessageType
@@ -53,6 +55,16 @@ private[sql] case class ParquetRelation(
   extends LeafNode with MultiInstanceRelation {
 
   self: Product =>
+
+  // will be used in the listStatus call in FilteringParquetRowInputFormat.readFooters
+  @transient val filterClassName = sqlContext.getConf(NewFileInputFormat.PATHFILTER_CLASS, "")
+  if (filterClassName.nonEmpty) {
+    val filterClazz = Class.forName(filterClassName).asInstanceOf[Class[_ <: PathFilter]]
+    if (conf.isDefined) {
+      conf.get.setClass(NewFileInputFormat.PATHFILTER_CLASS,
+      filterClazz, classOf[PathFilter])
+    }
+  }
 
   /** Schema derived from ParquetFile */
   def parquetSchema: MessageType =

--- a/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetRelation.scala
@@ -57,6 +57,7 @@ private[sql] case class ParquetRelation(
   self: Product =>
 
   // will be used in the listStatus call in FilteringParquetRowInputFormat.readFooters
+  // also used in readMetaData in ParquetTypes.scala
   @transient val filterClassName = sqlContext.getConf(NewFileInputFormat.PATHFILTER_CLASS, "")
   if (filterClassName.nonEmpty) {
     val filterClazz = Class.forName(filterClassName).asInstanceOf[Class[_ <: PathFilter]]

--- a/sql/core/src/main/scala/org/apache/spark/sql/parquet/newParquet.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/parquet/newParquet.scala
@@ -283,7 +283,7 @@ private[sql] case class ParquetRelation2(
       val leaves = baseStatuses.flatMap { f =>
         val fs = FileSystem.get(f.getPath.toUri, sparkContext.hadoopConfiguration)
         SparkHadoopUtil.get.listLeafStatusesFiltered(fs, f.getPath,
-          sqlContext.getPathFilter()).filter { f =>
+          sqlContext.getPathFilter).filter { f =>
             isSummaryFile(f.getPath) ||
               !(f.getPath.getName.startsWith("_") || f.getPath.getName.startsWith("."))
         }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -140,8 +140,13 @@ class HiveContext(sc: SparkContext) extends SQLContext(sc) {
         def calculateTableSize(fs: FileSystem, path: Path): Long = {
           val fileStatus = fs.getFileStatus(path)
           val size = if (fileStatus.isDir) {
-            fs.listStatus(path,
-              getPathFilter().get).map(status => calculateTableSize(fs, status.getPath)).sum
+            val filter = getPathFilter()
+            if (filter.isDefined) {
+              fs.listStatus(path, filter.get).map(
+                status => calculateTableSize(fs, status.getPath)).sum
+            } else {
+              fs.listStatus(path).map(status => calculateTableSize(fs, status.getPath)).sum 
+            }
           } else {
             fileStatus.getLen
           }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -140,7 +140,8 @@ class HiveContext(sc: SparkContext) extends SQLContext(sc) {
         def calculateTableSize(fs: FileSystem, path: Path): Long = {
           val fileStatus = fs.getFileStatus(path)
           val size = if (fileStatus.isDir) {
-            fs.listStatus(path).map(status => calculateTableSize(fs, status.getPath)).sum
+            fs.listStatus(path,
+              getPathFilter().get).map(status => calculateTableSize(fs, status.getPath)).sum
           } else {
             fileStatus.getLen
           }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -29,6 +29,8 @@ import org.apache.hadoop.hive.serde2.objectinspector.{ObjectInspectorConverters,
 import org.apache.hadoop.hive.serde2.objectinspector.primitive._
 import org.apache.hadoop.io.Writable
 import org.apache.hadoop.mapred.{FileInputFormat, InputFormat, JobConf}
+import org.apache.hadoop.mapreduce.lib.input.{FileInputFormat => NewFileInputFormat}
+import org.apache.hadoop.util.ReflectionUtils
 
 import org.apache.spark.SerializableWritable
 import org.apache.spark.broadcast.Broadcast
@@ -73,12 +75,21 @@ class HadoopTableReader(
   private val _broadcastedHiveConf =
     sc.sparkContext.broadcast(new SerializableWritable(hiveExtraConf))
 
-  override def makeRDDForTable(hiveTable: HiveTable): RDD[Row] =
+  override def makeRDDForTable(hiveTable: HiveTable): RDD[Row] = {
+    val filterClassName = sc.getConf(NewFileInputFormat.PATHFILTER_CLASS, "")
+    val filterOpt: Option[PathFilter] = {
+      if (filterClassName.nonEmpty) {
+        val filterClazz = Class.forName(filterClassName)
+        Option(ReflectionUtils.newInstance(filterClazz.asInstanceOf[Class[_ <: PathFilter]], null))
+      } else {
+        None
+      }
+    }
     makeRDDForTable(
       hiveTable,
       relation.tableDesc.getDeserializerClass.asInstanceOf[Class[Deserializer]],
-      filterOpt = None)
-
+      filterOpt)
+  }
   /**
    * Creates a Hadoop RDD to read data from the target table's data directory. Returns a transformed
    * RDD that contains deserialized rows.
@@ -125,7 +136,16 @@ class HadoopTableReader(
   override def makeRDDForPartitionedTable(partitions: Seq[HivePartition]): RDD[Row] = {
     val partitionToDeserializer = partitions.map(part =>
       (part, part.getDeserializer.getClass.asInstanceOf[Class[Deserializer]])).toMap
-    makeRDDForPartitionedTable(partitionToDeserializer, filterOpt = None)
+    val filterClassName = sc.getConf(NewFileInputFormat.PATHFILTER_CLASS, "")
+    val filterOpt: Option[PathFilter] = {
+      if (filterClassName.nonEmpty) {
+        val filterClazz = Class.forName(filterClassName)
+        Option(ReflectionUtils.newInstance(filterClazz.asInstanceOf[Class[_ <: PathFilter]], null))
+      } else {
+        None
+      }
+    }
+    makeRDDForPartitionedTable(partitionToDeserializer, filterOpt)
   }
 
   /**


### PR DESCRIPTION
This PR adds support for using a custom filter class for input files for queries. We can re-use the existing property in hive-site.xml for this.
