### PR TITLE
[SPARK-3298][SQL] Add `allowExisting` flag to control registerAsTable / registerTempTable

### DIFF
--- a/examples/src/main/java/org/apache/spark/examples/ml/JavaCrossValidatorExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/ml/JavaCrossValidatorExample.java
@@ -115,7 +115,7 @@ public class JavaCrossValidatorExample {
     DataFrame test = jsql.applySchema(jsc.parallelize(localTest), Document.class);
 
     // Make predictions on test documents. cvModel uses the best model found (lrModel).
-    cvModel.transform(test).registerTempTable("prediction");
+    cvModel.transform(test).registerTempTable("prediction", false);
     DataFrame predictions = jsql.sql("SELECT id, text, score, prediction FROM prediction");
     for (Row r: predictions.collect()) {
       System.out.println("(" + r.get(0) + ", " + r.get(1) + ") --> score=" + r.get(2)

--- a/examples/src/main/java/org/apache/spark/examples/ml/JavaSimpleParamsExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/ml/JavaSimpleParamsExample.java
@@ -100,7 +100,7 @@ public class JavaSimpleParamsExample {
     // LogisticRegression.transform will only use the 'features' column.
     // Note that model2.transform() outputs a 'probability' column instead of the usual 'score'
     // column since we renamed the lr.scoreCol parameter previously.
-    model2.transform(test).registerTempTable("results");
+    model2.transform(test).registerTempTable("results", false);
     DataFrame results =
         jsql.sql("SELECT features, label, probability, prediction FROM results");
     for (Row r: results.collect()) {

--- a/examples/src/main/java/org/apache/spark/examples/ml/JavaSimpleTextClassificationPipeline.java
+++ b/examples/src/main/java/org/apache/spark/examples/ml/JavaSimpleTextClassificationPipeline.java
@@ -82,7 +82,7 @@ public class JavaSimpleTextClassificationPipeline {
     DataFrame test = jsql.applySchema(jsc.parallelize(localTest), Document.class);
 
     // Make predictions on test documents.
-    model.transform(test).registerTempTable("prediction");
+    model.transform(test).registerTempTable("prediction", false);
     DataFrame predictions = jsql.sql("SELECT id, text, score, prediction FROM prediction");
     for (Row r: predictions.collect()) {
       System.out.println("(" + r.get(0) + ", " + r.get(1) + ") --> score=" + r.get(2)

--- a/examples/src/main/java/org/apache/spark/examples/sql/JavaSparkSQL.java
+++ b/examples/src/main/java/org/apache/spark/examples/sql/JavaSparkSQL.java
@@ -75,7 +75,7 @@ public class JavaSparkSQL {
 
     // Apply a schema to an RDD of Java Beans and register it as a table.
     DataFrame schemaPeople = sqlCtx.applySchema(people, Person.class);
-    schemaPeople.registerTempTable("people");
+    schemaPeople.registerTempTable("people", false);
 
     // SQL can be run over RDDs that have been registered as tables.
     DataFrame teenagers = sqlCtx.sql("SELECT name FROM people WHERE age >= 13 AND age <= 19");
@@ -102,7 +102,7 @@ public class JavaSparkSQL {
     DataFrame parquetFile = sqlCtx.parquetFile("people.parquet");
 
     //Parquet files can also be registered as tables and then used in SQL statements.
-    parquetFile.registerTempTable("parquetFile");
+    parquetFile.registerTempTable("parquetFile", false);
     DataFrame teenagers2 =
       sqlCtx.sql("SELECT name FROM parquetFile WHERE age >= 13 AND age <= 19");
     teenagerNames = teenagers2.toJavaRDD().map(new Function<Row, String>() {
@@ -131,7 +131,7 @@ public class JavaSparkSQL {
     //  |-- name: StringType
 
     // Register this DataFrame as a table.
-    peopleFromJsonFile.registerTempTable("people");
+    peopleFromJsonFile.registerTempTable("people", false);
 
     // SQL statements can be run by using the sql methods provided by sqlCtx.
     DataFrame teenagers3 = sqlCtx.sql("SELECT name FROM people WHERE age >= 13 AND age <= 19");
@@ -162,7 +162,7 @@ public class JavaSparkSQL {
     //  |    |-- state: StringType
     //  |-- name: StringType
 
-    peopleFromJsonRDD.registerTempTable("people2");
+    peopleFromJsonRDD.registerTempTable("people2", false);
 
     DataFrame peopleWithCity = sqlCtx.sql("SELECT name, address.city FROM people2");
     List<String> nameAndCity = peopleWithCity.toJavaRDD().map(new Function<Row, String>() {

--- a/mllib/src/test/java/org/apache/spark/ml/JavaPipelineSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/JavaPipelineSuite.java
@@ -64,7 +64,7 @@ public class JavaPipelineSuite {
     Pipeline pipeline = new Pipeline()
       .setStages(new PipelineStage[] {scaler, lr});
     PipelineModel model = pipeline.fit(dataset);
-    model.transform(dataset).registerTempTable("prediction");
+    model.transform(dataset).registerTempTable("prediction", false);
     DataFrame predictions = jsql.sql("SELECT label, score, prediction FROM prediction");
     predictions.collectAsList();
   }

--- a/mllib/src/test/java/org/apache/spark/ml/classification/JavaLogisticRegressionSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/classification/JavaLogisticRegressionSuite.java
@@ -54,7 +54,7 @@ public class JavaLogisticRegressionSuite implements Serializable {
   public void logisticRegression() {
     LogisticRegression lr = new LogisticRegression();
     LogisticRegressionModel model = lr.fit(dataset);
-    model.transform(dataset).registerTempTable("prediction");
+    model.transform(dataset).registerTempTable("prediction", true);
     DataFrame predictions = jsql.sql("SELECT label, score, prediction FROM prediction");
     predictions.collectAsList();
   }
@@ -66,7 +66,7 @@ public class JavaLogisticRegressionSuite implements Serializable {
       .setRegParam(1.0);
     LogisticRegressionModel model = lr.fit(dataset);
     model.transform(dataset, model.threshold().w(0.8)) // overwrite threshold
-      .registerTempTable("prediction");
+      .registerTempTable("prediction", true);
     DataFrame predictions = jsql.sql("SELECT label, score, prediction FROM prediction");
     predictions.collectAsList();
   }

--- a/python/pyspark/sql.py
+++ b/python/pyspark/sql.py
@@ -1469,7 +1469,7 @@ class SQLContext(object):
         df = self._ssql_ctx.applySchemaToPythonRDD(jrdd.rdd(), schema.json())
         return DataFrame(df, self)
 
-    def registerRDDAsTable(self, rdd, tableName):
+    def registerRDDAsTable(self, rdd, tableName, allowExisting=False):
         """Registers the given RDD as a temporary table in the catalog.
 
         Temporary tables exist only during the lifetime of this instance of
@@ -1480,7 +1480,7 @@ class SQLContext(object):
         """
         if (rdd.__class__ is DataFrame):
             df = rdd._jdf
-            self._ssql_ctx.registerRDDAsTable(df, tableName)
+            self._ssql_ctx.registerRDDAsTable(df, tableName, allowExisting)
         else:
             raise ValueError("Can only register DataFrame as table")
 
@@ -1894,7 +1894,7 @@ class DataFrame(object):
         """
         self._jdf.saveAsParquetFile(path)
 
-    def registerTempTable(self, name):
+    def registerTempTable(self, name, allowExisting=False):
         """Registers this RDD as a temporary table using the given name.
 
         The lifetime of this temporary table is tied to the L{SQLContext}
@@ -1906,12 +1906,12 @@ class DataFrame(object):
         >>> sorted(df.collect()) == sorted(df2.collect())
         True
         """
-        self._jdf.registerTempTable(name)
+        self._jdf.registerTempTable(name, allowExisting)
 
-    def registerAsTable(self, name):
+    def registerAsTable(self, name, allowExisting=False):
         """DEPRECATED: use registerTempTable() instead"""
         warnings.warn("Use registerTempTable instead of registerAsTable.", DeprecationWarning)
-        self.registerTempTable(name)
+        self.registerTempTable(name, allowExisting)
 
     def insertInto(self, tableName, overwrite=False):
         """Inserts the contents of this DataFrame into the specified table.

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -572,8 +572,8 @@ class DataFrame protected[sql](
    *
    * @group schema
    */
-  override def registerTempTable(tableName: String): Unit = {
-    sqlContext.registerRDDAsTable(this, tableName)
+  override def registerTempTable(tableName: String, allowExisting: Boolean = false): Unit = {
+    sqlContext.registerRDDAsTable(this, tableName, allowExisting)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/api.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api.scala
@@ -157,7 +157,7 @@ private[sql] trait DataFrameSpecificApi {
 
   def toJSON: RDD[String]
 
-  def registerTempTable(tableName: String): Unit
+  def registerTempTable(tableName: String, allowExisting: Boolean = false): Unit
 
   def saveAsParquetFile(path: String): Unit
 

--- a/sql/core/src/test/java/org/apache/spark/sql/api/java/JavaApplySchemaSuite.java
+++ b/sql/core/src/test/java/org/apache/spark/sql/api/java/JavaApplySchemaSuite.java
@@ -99,7 +99,7 @@ public class JavaApplySchemaSuite implements Serializable {
     StructType schema = DataTypes.createStructType(fields);
 
     DataFrame df = javaSqlCtx.applySchema(rowRDD.rdd(), schema);
-    df.registerTempTable("people");
+    df.registerTempTable("people", false);
     Row[] actual = javaSqlCtx.sql("SELECT * FROM people").collect();
 
     List<Row> expected = new ArrayList<Row>(2);
@@ -150,14 +150,15 @@ public class JavaApplySchemaSuite implements Serializable {
     DataFrame df1 = javaSqlCtx.jsonRDD(jsonRDD.rdd());
     StructType actualSchema1 = df1.schema();
     Assert.assertEquals(expectedSchema, actualSchema1);
-    df1.registerTempTable("jsonTable1");
+    df1.registerTempTable("jsonTable1", false);
     List<Row> actual1 = javaSqlCtx.sql("select * from jsonTable1").collectAsList();
     Assert.assertEquals(expectedResult, actual1);
 
     DataFrame df2 = javaSqlCtx.jsonRDD(jsonRDD.rdd(), expectedSchema);
     StructType actualSchema2 = df2.schema();
     Assert.assertEquals(expectedSchema, actualSchema2);
-    df2.registerTempTable("jsonTable2");
+    df2.registerTempTable("jsonTable2", false);
+
     List<Row> actual2 = javaSqlCtx.sql("select * from jsonTable2").collectAsList();
     Assert.assertEquals(expectedResult, actual2);
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -1034,4 +1034,26 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll {
     rdd.registerTempTable("distinctData")
     checkAnswer(sql("SELECT COUNT(DISTINCT key,value) FROM distinctData"), Row(2))
   }
+
+  test("SPARK-3298 registerTempTable add allowExisting flag, allowExisting = false ") {
+    val data = TestData(1,"val_1") :: TestData(2,"val_2") :: Nil
+    val rdd = sparkContext.parallelize((0 to 1).map(i => data(i)))
+    rdd.registerTempTable("tableABC")
+    val ex = intercept[Exception] {
+      rdd.registerTempTable("tableABC", false)
+    }
+    assert(ex.getMessage.contains("tableABC already exists"))
+  }
+
+  test("SPARK-3298 registerTempTable add allowExisting flag, allowExisting = true ") {
+    val data = TestData(1,"val_1") :: TestData(2,"val_2") :: Nil
+    val rdd = sparkContext.parallelize((0 to 1).map(i => data(i)))
+    rdd.registerTempTable("tableDEF", true)
+
+    val newData = TestData(1,"data_1") :: TestData(2,"data_2") :: TestData(3,"data_3") :: Nil
+    val newRdd = sparkContext.parallelize((0 to 2).map(i => newData(i)))
+    newRdd.registerTempTable("tableDEF", true)
+
+    checkAnswer(sql("SELECT count(*) FROM tableDEF"), Row(3))
+  }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-3298

add a parameter into `registerTempTable`

if `allowExisting` set to false, once register a existing table , there should be a table already exists exception to be thrown.

if `allowExisting` set to true, it will totally overwrite pre-existing table.

By default, it is `false`
