### PR TITLE
[SPARK-5454] [SQL] Fix duplicated exprId for self join the temp table

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -53,11 +53,11 @@ class Analyzer(catalog: Catalog,
   val extendedRules: Seq[Rule[LogicalPlan]] = Nil
 
   lazy val batches: Seq[Batch] = Seq(
+    Batch("PreRelationResolution", fixedPoint, ResolveRelations),
     Batch("MultiInstanceRelations", Once,
       NewRelationInstances),
     Batch("Resolution", fixedPoint,
       ResolveReferences ::
-      ResolveRelations ::
       ResolveGroupingAnalytics ::
       ResolveSortReferences ::
       NewRelationInstances ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Catalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Catalog.scala
@@ -69,7 +69,7 @@ class SimpleCatalog(val caseSensitive: Boolean) extends Catalog {
       tableIdentifier: Seq[String],
       plan: LogicalPlan): Unit = {
     val tableIdent = processTableIdentifier(tableIdentifier)
-    tables += ((getDbTableName(tableIdent), plan))
+    tables += ((getDbTableName(tableIdent), plan.toMultiInstanceRelation))
   }
 
   override def unregisterTable(tableIdentifier: Seq[String]) = {
@@ -141,7 +141,7 @@ trait OverrideCatalog extends Catalog {
       tableIdentifier: Seq[String],
       plan: LogicalPlan): Unit = {
     val tableIdent = processTableIdentifier(tableIdentifier)
-    overrides.put(getDBTable(tableIdent), plan)
+    overrides.put(getDBTable(tableIdent), plan.toMultiInstanceRelation)
   }
 
   override def unregisterTable(tableIdentifier: Seq[String]): Unit = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/MultiInstanceRelation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/MultiInstanceRelation.scala
@@ -30,7 +30,10 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
  * of itself with globally unique expression ids.
  */
 trait MultiInstanceRelation {
-  def newInstance(): this.type
+  self: LogicalPlan =>
+
+  def newInstance(): LogicalPlan
+  override def toMultiInstanceRelation: LogicalPlan = self
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
@@ -56,12 +56,6 @@ abstract class NamedExpression extends Expression {
     } else {
       ""
     }
-
-  override def equals(other: Any): Boolean = {
-    super.equals(other) &&
-    exprId == other.asInstanceOf[NamedExpression].exprId &&
-    qualifiers == other.asInstanceOf[NamedExpression].qualifiers
-  }
 }
 
 abstract class Attribute extends NamedExpression {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
@@ -56,6 +56,12 @@ abstract class NamedExpression extends Expression {
     } else {
       ""
     }
+
+  override def equals(other: Any): Boolean = {
+    super.equals(other) &&
+    exprId == other.asInstanceOf[NamedExpression].exprId &&
+    qualifiers == other.asInstanceOf[NamedExpression].qualifiers
+  }
 }
 
 abstract class Attribute extends NamedExpression {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
@@ -43,6 +43,8 @@ private[sql] case class Statistics(sizeInBytes: BigInt)
 abstract class LogicalPlan extends QueryPlan[LogicalPlan] with Logging {
   self: Product =>
 
+  def toMultiInstanceRelation: LogicalPlan = new Project(output, this)
+
   def statistics: Statistics = {
     if (children.size == 0) {
       throw new UnsupportedOperationException(s"LeafNode $nodeName must implement statistics.")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicOperators.scala
@@ -17,12 +17,27 @@
 
 package org.apache.spark.sql.catalyst.plans.logical
 
+import org.apache.spark.sql.catalyst.analysis.{MultiInstanceRelation, UnresolvedAttribute}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.types._
 
-case class Project(projectList: Seq[NamedExpression], child: LogicalPlan) extends UnaryNode {
+case class Project(projectList: Seq[NamedExpression], child: LogicalPlan)
+    extends UnaryNode
+    with MultiInstanceRelation {
+
   def output = projectList.map(_.toAttribute)
+
+  // This will be used when register the temp table, to create a new instance
+  // with the same attribute names, but totally different exprId
+  def newInstance(): Project = {
+    Project(projectList.map(e => e match {
+      case a @ Alias(child, name) => Alias(child, name)(qualifiers = a.qualifiers)
+      case a: AttributeReference => a.newInstance
+      case a @ UnresolvedAttribute(name) => Alias(a, name)()
+      case e => e
+    }), child)
+  }
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicOperators.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.plans.logical
 
-import org.apache.spark.sql.catalyst.analysis.{MultiInstanceRelation, UnresolvedAttribute}
+import org.apache.spark.sql.catalyst.analysis.{Star, MultiInstanceRelation}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.types._
@@ -32,10 +32,10 @@ case class Project(projectList: Seq[NamedExpression], child: LogicalPlan)
   // with the same attribute names, but totally different exprId
   def newInstance(): Project = {
     Project(projectList.map(e => e match {
-      case a @ Alias(child, name) => Alias(child, name)(qualifiers = a.qualifiers)
-      case a: AttributeReference => a.newInstance
-      case a @ UnresolvedAttribute(name) => Alias(a, name)()
-      case e => e
+      case a: Alias => Alias(a, a.name)(qualifiers = a.qualifiers)
+      case a: AttributeReference => Alias(a, a.name)(qualifiers = a.qualifiers)
+      case a: Star => a
+      case e => Alias(e, e.name)()
     }), child)
   }
 }


### PR DESCRIPTION
The output schema (attributes) of the temp table (the registered logical plan) keeps the consistent `exprId`s after `ResolveReference`, in the `Self Join` case, as they are actually the same object reference internally, and hence it will causes ambiguous references downward.
