### PR TITLE
[Minor][SQL] Little refactor DataFrame related codes

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -98,7 +98,7 @@ trait ScalaReflection {
   /** Returns a Sequence of attributes for the given case class type. */
   def attributesFor[T: TypeTag]: Seq[Attribute] = schemaFor[T] match {
     case Schema(s: StructType, _) =>
-      s.fields.map(f => AttributeReference(f.name, f.dataType, f.nullable, f.metadata)())
+      s.toAttributes
   }
 
   /** Returns a catalyst DataType and its nullability for the given Scala Type using reflection. */

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -139,13 +139,12 @@ class DataFrame protected[sql](
    *   val rdd: RDD[(Int, String)] = ...
    *   rdd.toDataFrame  // this implicit conversion creates a DataFrame with column name _1 and _2
    *   rdd.toDataFrame("id", "name")  // this creates a DataFrame with column name "id" and "name"
-   *   rdd.toDataFrame("id")          // this creates a DataFrame with only column name "id"
    * }}}
    */
   @scala.annotation.varargs
   def toDataFrame(colName: String, colNames: String*): DataFrame = {
     val newNames = colName +: colNames
-    require(schema.size >= newNames.size,
+    require(schema.size == newNames.size,
       "The number of columns doesn't match.\n" +
       "Old column names: " + schema.fields.map(_.name).mkString(", ") + "\n" +
       "New column names: " + newNames.mkString(", "))

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -139,12 +139,13 @@ class DataFrame protected[sql](
    *   val rdd: RDD[(Int, String)] = ...
    *   rdd.toDataFrame  // this implicit conversion creates a DataFrame with column name _1 and _2
    *   rdd.toDataFrame("id", "name")  // this creates a DataFrame with column name "id" and "name"
+   *   rdd.toDataFrame("id")          // this creates a DataFrame with only column name "id"
    * }}}
    */
   @scala.annotation.varargs
   def toDataFrame(colName: String, colNames: String*): DataFrame = {
     val newNames = colName +: colNames
-    require(schema.size == newNames.size,
+    require(schema.size >= newNames.size,
       "The number of columns doesn't match.\n" +
       "Old column names: " + schema.fields.map(_.name).mkString(", ") + "\n" +
       "New column names: " + newNames.mkString(", "))

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -168,8 +168,8 @@ class SQLContext(@transient val sparkContext: SparkContext)
    */
   implicit def createDataFrame[A <: Product: TypeTag](rdd: RDD[A]): DataFrame = {
     SparkPlan.currentContext.set(self)
-    val attributeSeq = ScalaReflection.attributesFor[A]
-    val schema = StructType.fromAttributes(attributeSeq)
+    val schema = ScalaReflection.schemaFor[A].dataType.asInstanceOf[StructType]
+    val attributeSeq = schema.toAttributes
     val rowRDD = RDDConversions.productToRowRdd(rdd, schema)
     new DataFrame(this, LogicalRDD(attributeSeq, rowRDD)(self))
   }


### PR DESCRIPTION
Simplify some codes related to DataFrame. 
-  Calling `toAttributes` instead of a `map`.
-  Original `createDataFrame` creates the `StructType` and its attributes in a redundant way. Refactored it to create `StructType` and call `toAttributes` on it directly.
