### PR TITLE
[SPARK-5520][MLlib] Make FP-Growth implementation take generic item types (WIP)

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/fpm/FPGrowth.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/fpm/FPGrowth.scala
@@ -90,7 +90,8 @@ class FPGrowth private (
     new FPGrowthModel(freqItemsets)
   }
 
-  def run[Item: ClassTag, Basket <: JavaIterable[Item]](data: JavaRDD[Basket]): FPGrowthModel[Item] = {
+  def run[Item: ClassTag, Basket <: JavaIterable[Item]](
+      data: JavaRDD[Basket]): FPGrowthModel[Item] = {
     this.run(data.rdd.map(_.asScala))
   }
 

--- a/mllib/src/test/java/org/apache/spark/mllib/fpm/JavaFPGrowthSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/fpm/JavaFPGrowthSuite.java
@@ -19,78 +19,66 @@ package org.apache.spark.mllib.fpm;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import static org.junit.Assert.*;
-
 import com.google.common.collect.Lists;
+import static org.junit.Assert.*;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 
 public class JavaFPGrowthSuite implements Serializable {
-    private transient JavaSparkContext sc;
+  private transient JavaSparkContext sc;
 
-    @Before
-    public void setUp() {
-        sc = new JavaSparkContext("local", "JavaFPGrowth");
-    }
+  @Before
+  public void setUp() {
+    sc = new JavaSparkContext("local", "JavaFPGrowth");
+  }
 
-    @After
-    public void tearDown() {
-        sc.stop();
-        sc = null;
-    }
+  @After
+  public void tearDown() {
+    sc.stop();
+    sc = null;
+  }
 
-    @Test
-    public void runFPGrowth() {
-        JavaRDD<ArrayList<String>> rdd = sc.parallelize(Lists.newArrayList(
-                Lists.newArrayList("r z h k p".split(" ")),
-                Lists.newArrayList("z y x w v u t s".split(" ")),
-                Lists.newArrayList("s x o n r".split(" ")),
-                Lists.newArrayList("x z y m t s q e".split(" ")),
-                Lists.newArrayList("z".split(" ")),
-                Lists.newArrayList("x z y r q t p".split(" "))), 2);
+  @Test
+  public void runFPGrowth() {
 
-        FPGrowth fpg = new FPGrowth();
+    @SuppressWarnings("unchecked")
+    JavaRDD<ArrayList<String>> rdd = sc.parallelize(Lists.newArrayList(
+      Lists.newArrayList("r z h k p".split(" ")),
+      Lists.newArrayList("z y x w v u t s".split(" ")),
+      Lists.newArrayList("s x o n r".split(" ")),
+      Lists.newArrayList("x z y m t s q e".split(" ")),
+      Lists.newArrayList("z".split(" ")),
+      Lists.newArrayList("x z y r q t p".split(" "))), 2);
 
-        /*
-        FPGrowthModel model6 = fpg
-                .setMinSupport(0.9)
-                .setNumPartitions(1)
-                .run(rdd);
-        assert(model6.javaFreqItemsets().count() == 0);
+    FPGrowth fpg = new FPGrowth();
 
-        FPGrowthModel model3 = fpg
-                .setMinSupport(0.5)
-                .setNumPartitions(2)
-                .run(rdd);
-        val freqItemsets3 = model3.freqItemsets.collect().map { case (items, count) =>
-            (items.toSet, count)
-        }
-        val expected = Set(
-                (Set("s"), 3L), (Set("z"), 5L), (Set("x"), 4L), (Set("t"), 3L), (Set("y"), 3L),
-        (Set("r"), 3L),
-        (Set("x", "z"), 3L), (Set("t", "y"), 3L), (Set("t", "x"), 3L), (Set("s", "x"), 3L),
-        (Set("y", "x"), 3L), (Set("y", "z"), 3L), (Set("t", "z"), 3L),
-        (Set("y", "x", "z"), 3L), (Set("t", "x", "z"), 3L), (Set("t", "y", "z"), 3L),
-        (Set("t", "y", "x"), 3L),
-        (Set("t", "y", "x", "z"), 3L))
-        assert(freqItemsets3.toSet === expected)
+    FPGrowthModel<String> model6 = fpg
+      .setMinSupport(0.9)
+      .setNumPartitions(1)
+      .run(rdd);
+    assertEquals(0, model6.javaFreqItemsets().count());
 
-        val model2 = fpg
-                .setMinSupport(0.3)
-                .setNumPartitions(4)
-                .run[String](rdd)
-        assert(model2.freqItemsets.count() == 54)
+    FPGrowthModel<String> model3 = fpg
+      .setMinSupport(0.5)
+      .setNumPartitions(2)
+      .run(rdd);
+    assertEquals(18, model3.javaFreqItemsets().count());
 
-        val model1 = fpg
-                .setMinSupport(0.1)
-                .setNumPartitions(8)
-                .run[String](rdd)
-        assert(model1.freqItemsets.count() == 625) */
-    }
+    FPGrowthModel<String> model2 = fpg
+      .setMinSupport(0.3)
+      .setNumPartitions(4)
+      .run(rdd);
+    assertEquals(54, model2.javaFreqItemsets().count());
+
+    FPGrowthModel<String> model1 = fpg
+      .setMinSupport(0.1)
+      .setNumPartitions(8)
+      .run(rdd);
+    assertEquals(625, model1.javaFreqItemsets().count());
+  }
 }

--- a/mllib/src/test/java/org/apache/spark/mllib/fpm/JavaFPGrowthSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/fpm/JavaFPGrowthSuite.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.mllib.fpm;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import com.google.common.collect.Lists;
+
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+
+public class JavaFPGrowthSuite implements Serializable {
+    private transient JavaSparkContext sc;
+
+    @Before
+    public void setUp() {
+        sc = new JavaSparkContext("local", "JavaFPGrowth");
+    }
+
+    @After
+    public void tearDown() {
+        sc.stop();
+        sc = null;
+    }
+
+    @Test
+    public void runFPGrowth() {
+        JavaRDD<ArrayList<String>> rdd = sc.parallelize(Lists.newArrayList(
+                Lists.newArrayList("r z h k p".split(" ")),
+                Lists.newArrayList("z y x w v u t s".split(" ")),
+                Lists.newArrayList("s x o n r".split(" ")),
+                Lists.newArrayList("x z y m t s q e".split(" ")),
+                Lists.newArrayList("z".split(" ")),
+                Lists.newArrayList("x z y r q t p".split(" "))), 2);
+
+        FPGrowth fpg = new FPGrowth();
+
+        /*
+        FPGrowthModel model6 = fpg
+                .setMinSupport(0.9)
+                .setNumPartitions(1)
+                .run(rdd);
+        assert(model6.javaFreqItemsets().count() == 0);
+
+        FPGrowthModel model3 = fpg
+                .setMinSupport(0.5)
+                .setNumPartitions(2)
+                .run(rdd);
+        val freqItemsets3 = model3.freqItemsets.collect().map { case (items, count) =>
+            (items.toSet, count)
+        }
+        val expected = Set(
+                (Set("s"), 3L), (Set("z"), 5L), (Set("x"), 4L), (Set("t"), 3L), (Set("y"), 3L),
+        (Set("r"), 3L),
+        (Set("x", "z"), 3L), (Set("t", "y"), 3L), (Set("t", "x"), 3L), (Set("s", "x"), 3L),
+        (Set("y", "x"), 3L), (Set("y", "z"), 3L), (Set("t", "z"), 3L),
+        (Set("y", "x", "z"), 3L), (Set("t", "x", "z"), 3L), (Set("t", "y", "z"), 3L),
+        (Set("t", "y", "x"), 3L),
+        (Set("t", "y", "x", "z"), 3L))
+        assert(freqItemsets3.toSet === expected)
+
+        val model2 = fpg
+                .setMinSupport(0.3)
+                .setNumPartitions(4)
+                .run[String](rdd)
+        assert(model2.freqItemsets.count() == 54)
+
+        val model1 = fpg
+                .setMinSupport(0.1)
+                .setNumPartitions(8)
+                .run[String](rdd)
+        assert(model1.freqItemsets.count() == 625) */
+    }
+}

--- a/mllib/src/test/scala/org/apache/spark/mllib/fpm/FPGrowthSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/fpm/FPGrowthSuite.scala
@@ -31,7 +31,7 @@ class FPGrowthSuite extends FunSuite with MLlibTestSparkContext {
       "x z y m t s q e",
       "z",
       "x z y r q t p")
-      .map(_.split(" ").toSeq)
+      .map(_.split(" "))
     val rdd = sc.parallelize(transactions, 2).cache()
 
     val fpg = new FPGrowth()
@@ -39,13 +39,13 @@ class FPGrowthSuite extends FunSuite with MLlibTestSparkContext {
     val model6 = fpg
       .setMinSupport(0.9)
       .setNumPartitions(1)
-      .run[String, Seq[String]](rdd)
+      .run(rdd)
     assert(model6.freqItemsets.count() === 0)
 
     val model3 = fpg
       .setMinSupport(0.5)
       .setNumPartitions(2)
-      .run[String, Seq[String]](rdd)
+      .run(rdd)
     val freqItemsets3 = model3.freqItemsets.collect().map { case (items, count) =>
       (items.toSet, count)
     }
@@ -62,13 +62,13 @@ class FPGrowthSuite extends FunSuite with MLlibTestSparkContext {
     val model2 = fpg
       .setMinSupport(0.3)
       .setNumPartitions(4)
-      .run[String, Seq[String]](rdd)
+      .run(rdd)
     assert(model2.freqItemsets.count() === 54)
 
     val model1 = fpg
       .setMinSupport(0.1)
       .setNumPartitions(8)
-      .run[String, Seq[String]](rdd)
+      .run(rdd)
     assert(model1.freqItemsets.count() === 625)
   }
 
@@ -81,7 +81,7 @@ class FPGrowthSuite extends FunSuite with MLlibTestSparkContext {
       "2 4",
       "1 3",
       "1 7")
-      .map(_.split(" ").map(_.toInt).toList)
+      .map(_.split(" ").map(_.toInt).toArray)
     val rdd = sc.parallelize(transactions, 2).cache()
 
     val fpg = new FPGrowth()
@@ -89,13 +89,15 @@ class FPGrowthSuite extends FunSuite with MLlibTestSparkContext {
     val model6 = fpg
       .setMinSupport(0.9)
       .setNumPartitions(1)
-      .run[Int, List[Int]](rdd)
+      .run(rdd)
     assert(model6.freqItemsets.count() === 0)
 
     val model3 = fpg
       .setMinSupport(0.5)
       .setNumPartitions(2)
-      .run[Int, List[Int]](rdd)
+      .run(rdd)
+    assert(model3.freqItemsets.first()._1.getClass === Array(1).getClass,
+      "frequent itemsets should use primitive arrays")
     val freqItemsets3 = model3.freqItemsets.collect().map { case (items, count) =>
       (items.toSet, count)
     }
@@ -108,13 +110,13 @@ class FPGrowthSuite extends FunSuite with MLlibTestSparkContext {
     val model2 = fpg
       .setMinSupport(0.3)
       .setNumPartitions(4)
-      .run[Int, List[Int]](rdd)
+      .run(rdd)
     assert(model2.freqItemsets.count() === 15)
 
     val model1 = fpg
       .setMinSupport(0.1)
       .setNumPartitions(8)
-      .run[Int, List[Int]](rdd)
+      .run(rdd)
     assert(model1.freqItemsets.count() === 65)
   }
 }


### PR DESCRIPTION
Make FPGrowth.run API take generic item types: 
`def run[Item: ClassTag, Basket <: Iterable[Item]](data: RDD[Basket]): FPGrowthModel[Item]` 
so that user can invoke it by run[String, Seq[String]], run[Int, Seq[Int]], run[Int, List[Int]], etc.

Scala part is done, while java part is still in progress
