### PR TITLE
[FIX][MLLIB] fix seed handling in Python GMM

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
@@ -295,7 +295,7 @@ class PythonMLLibAPI extends Serializable {
       k: Int, 
       convergenceTol: Double, 
       maxIterations: Int,
-      seed: Long): JList[Object] = {
+      seed: java.lang.Long): JList[Object] = {
     val gmmAlg = new GaussianMixture()
       .setK(k)
       .setConvergenceTol(convergenceTol)


### PR DESCRIPTION
If `seed` is `None` on the python side, it will pass in as a `null`. So we should use `java.lang.Long` instead of `Long` to take it.
