### PR TITLE
[SPARK-2945][YARN][Doc]add doc for spark.executor.instances

### DIFF
--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -108,7 +108,7 @@ Most of the configs are the same for Spark on YARN as for other deployment modes
  <td><code>spark.executor.instances</code></td>
   <td>2</td>
   <td>
-    The number of executors.
+    The number of executors. Don't set this when dynamic allocation is enabled as they are not compatible.
   </td>
 </tr>
 <tr>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -105,6 +105,13 @@ Most of the configs are the same for Spark on YARN as for other deployment modes
   </td>
 </tr>
 <tr>
+ <td><code>spark.executor.instances</code></td>
+  <td>2</td>
+  <td>
+    The number of executors.
+  </td>
+</tr>
+<tr>
  <td><code>spark.yarn.executor.memoryOverhead</code></td>
   <td>executorMemory * 0.07, with minimum of 384 </td>
   <td>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-2945

spark.executor.instances works. As this JIRA recommended, we should add docs for this common config.
