### PR TITLE
[SPARK-5367][SQL] Support star expression in udfs 

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -250,9 +250,13 @@ class Analyzer(catalog: Catalog,
         Project(
           projectList.flatMap {
             case s: Star => s.expand(child.output, resolver)
-            case o => o transformUp {
-              case s: Star => s.expand(child.output, resolver)
-            }
+            case Alias(UnresolvedFunction(name1, clds), name2) if containsStar(clds) =>
+              val newClds = clds.flatMap {
+                case s: Star => s.expand(child.output, resolver)
+                case o => o :: Nil
+              }
+              Alias(UnresolvedFunction(name1, newClds), name2)() :: Nil
+            case o => o :: Nil
           },
           child)
       case t: ScriptTransformation if containsStar(t.input) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -311,10 +311,7 @@ class Analyzer(catalog: Catalog,
      * Returns true if `exprs` contains a [[Star]].
      */
     protected def containsStar(exprs: Seq[Expression]): Boolean =
-      exprs.flatMap { _ collect {
-          case s: Star => true
-        }
-      }.nonEmpty
+      exprs.exists(_.collect { case _: Star => true }.nonEmpty)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -246,7 +246,7 @@ class Analyzer(catalog: Catalog,
       case p: LogicalPlan if !p.childrenResolved => p
 
       // If the projection list contains Stars, expand it.
-      case p@Project(projectList, child) if containsStar(projectList) =>
+      case p @ Project(projectList, child) if containsStar(projectList) =>
         Project(
           projectList.flatMap {
             case s: Star => s.expand(child.output, resolver)
@@ -279,19 +279,18 @@ class Analyzer(catalog: Catalog,
       case q: LogicalPlan =>
         logTrace(s"Attempting to resolve ${q.simpleString}")
         q transformExpressions {
-          case u@UnresolvedAttribute(name)
-            if resolver(name, VirtualColumn.groupingIdName) &&
-              q.isInstanceOf[GroupingAnalytics] =>
+          case u @ UnresolvedAttribute(name) if resolver(name, VirtualColumn.groupingIdName) &&
+            q.isInstanceOf[GroupingAnalytics] =>
             // Resolve the virtual column GROUPING__ID for the operator GroupingAnalytics
             q.asInstanceOf[GroupingAnalytics].gid
-          case u@UnresolvedAttribute(name) =>
+          case u @ UnresolvedAttribute(name) =>
             // Leave unchanged if resolution fails.  Hopefully will be resolved next round.
             val result = q.resolveChildren(name, resolver).getOrElse(u)
             logDebug(s"Resolving $u to $result")
             result
 
           // Resolve field names using the resolver.
-          case f@GetField(child, fieldName) if !f.resolved && child.resolved =>
+          case f @ GetField(child, fieldName) if !f.resolved && child.resolved =>
             child.dataType match {
               case StructType(fields) =>
                 val resolvedFieldName = fields.map(_.name).find(resolver(_, fieldName))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -256,6 +256,12 @@ class Analyzer(catalog: Catalog,
                 case o => o :: Nil
               }
               Alias(UnresolvedFunction(name1, newClds), name2)() :: Nil
+            case Alias(CreateArray(clds), name) if containsStar(clds) =>
+              val newClds = clds.flatMap {
+                case s: Star => s.expand(child.output, resolver)
+                case o => o :: Nil
+              }
+              Alias(CreateArray(newClds), name)() :: Nil
             case o => o :: Nil
           },
           child)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -311,14 +311,10 @@ class Analyzer(catalog: Catalog,
      * Returns true if `exprs` contains a [[Star]].
      */
     protected def containsStar(exprs: Seq[Expression]): Boolean =
-<<<<<<< HEAD
-      exprs.exists(_.collect { case _: Star => true }.nonEmpty)
-=======
       exprs.flatMap { _ collect {
           case s: Star => true
         }
       }.nonEmpty
->>>>>>> 6ae00db691c4d51c6b99904b4b1984382add313b
   }
 
   /**

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -509,7 +509,7 @@ class HiveQuerySuite extends HiveComparisonTest with BeforeAndAfter {
   }
 
   test("SPARK-5367: resolve star expression in udf") {
-    assert(sql("select concat(*), array(*) from src limit 5").collect().size == 5)
+    assert(sql("select concat(*) from src limit 5").collect().size == 5)
     assert(sql("select array(*) from src limit 5").collect().size == 5)
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -508,6 +508,11 @@ class HiveQuerySuite extends HiveComparisonTest with BeforeAndAfter {
     assert(sql("select key from src having key > 490").collect().size < 100)
   }
 
+  test("SPARK-5367: resolve star expression in udf") {
+    assert(sql("select concat(*), array(*) from src limit 5").collect().size == 5)
+    assert(sql("select array(*) from src limit 5").collect().size == 5)
+  }
+
   test("Query Hive native command execution result") {
     val tableName = "test_native_commands"
 


### PR DESCRIPTION
A follow up for #4163: support  `select array(key, *) from src`

Since  array(key, *)  will not go into this case 

```
case Alias(f @ UnresolvedFunction(_, args), name) if containsStar(args) =>
              val expandedArgs = args.flatMap {
                case s: Star => s.expand(child.output, resolver)
                case o => o :: Nil
              }
```

here added a case to cover the corner case of array.

/cc @liancheng
