### PR TITLE
[SQL] Use HiveContext's sessionState in HiveMetastoreCatalog.hiveDefaultTableFilePath

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -140,7 +140,8 @@ private[hive] class HiveMetastoreCatalog(hive: HiveContext) extends Catalog with
   }
 
   def hiveDefaultTableFilePath(tableName: String): String = {
-    hiveWarehouse.getTablePath(client.getDatabaseCurrent, tableName).toString
+    val currentDatabase = client.getDatabase(hive.sessionState.getCurrentDatabase())
+    hiveWarehouse.getTablePath(currentDatabase, tableName).toString
   }
 
   def tableExists(tableIdentifier: Seq[String]): Boolean = {


### PR DESCRIPTION
`client.getDatabaseCurrent` uses SessionState's local variable which can be an issue. 
