### PR TITLE
[SPARK-5615] Let the test stop gracefully and don't throw exception

### DIFF
--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -434,7 +434,7 @@ package object testPackage extends Assertions {
         assert(rddGenerated && foreachCallSiteCorrect, "Call site in foreachRDD was not correct")
       }
     } finally {
-      ssc.stop(stopSparkContext = false, stopGracefully = true)
+      ssc.stop(stopSparkContext = true, stopGracefully = true)
     }
   }
 }

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -434,6 +434,7 @@ package object testPackage extends Assertions {
         assert(rddGenerated && foreachCallSiteCorrect, "Call site in foreachRDD was not correct")
       }
     } finally {
+      ssc.awaitTermination(500)
       ssc.stop(stopSparkContext = true, stopGracefully = true)
     }
   }

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -434,7 +434,7 @@ package object testPackage extends Assertions {
         assert(rddGenerated && foreachCallSiteCorrect, "Call site in foreachRDD was not correct")
       }
     } finally {
-      ssc.stop()
+      ssc.stop(stopSparkContext = false, stopGracefully = true)
     }
   }
 }


### PR DESCRIPTION
`testPackage` in `StreamingContextSuite` often throws `SparkException` because its `ssc` is not shut down gracefully. Not affect the unit test but I think we can make it graceful.
