### PR TITLE
SPARK-5607: Update to Kryo 2.24.0 to avoid including objenesis 1.2.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,7 @@
     <jblas.version>1.2.3</jblas.version>
     <jetty.version>8.1.14.v20131031</jetty.version>
     <chill.version>0.5.0</chill.version>
+    <kryo.version>2.24.0</kryo.version>
     <ivy.version>2.4.0</ivy.version>
     <oro.version>2.0.8</oro.version>
     <codahale.metrics.version>3.1.0</codahale.metrics.version>
@@ -340,7 +341,13 @@
           </exclusion>
         </exclusions>
       </dependency>
- 
+      <!-- Bump kryo version (included via chill) due to SPARK-5607 -->
+      <dependency>
+        <groupId>com.esotericsoftware.kryo</groupId>
+        <artifactId>kryo</artifactId>
+        <version>${kryo.version}</version>
+      </dependency>
+
       <!-- Shaded deps marked as provided. These are promoted to compile scope
            in the modules where we want the shaded classes to appear in the
            associated jar. -->


### PR DESCRIPTION
Our existing Kryo version actually embeds objenesis 1.2 classes in
its jar, causing dependency conflicts during tests. This updates us to
Kryo 2.24.0 (which was changed to not embed objenesis) to avoid this
behavior. See the JIRA for more detail.
