### PR TITLE
[SPARK-5611] [EC2] Allow spark-ec2 repo and branch to be set on CLI of spark_ec2.py

### DIFF
--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -153,7 +153,7 @@ def parse_args():
     parser.add_option(
         "--spark-ec2-branch",
         default=DEFAULT_SPARK_EC2_BRANCH,
-        help="Spark-ec2 branch to use (default: %default)")
+        help="spark-ec2 branch to use (default: %default)")
     parser.add_option(
         "--hadoop-major-version", default="1",
         help="Major version of Hadoop (default: %default)")
@@ -341,7 +341,7 @@ def get_spark_ami(opts):
             "Don't recognize %s, assuming type is pvm" % opts.instance_type
 
     # URL prefix from which to fetch AMI information
-    ami_prefix = "{r}/{b}/ami-list".format(r=opts.spark_ec2_git_repo.replace("github","raw.github"), b=opts.spark_ec2_branch)
+    ami_prefix = "{r}/{b}/ami-list".format(r=opts.spark_ec2_git_repo.replace("https://github.com","https://raw.github.com",1), b=opts.spark_ec2_branch)
 
     ami_path = "%s/%s/%s" % (ami_prefix, opts.region, instance_type)
     try:
@@ -661,7 +661,7 @@ def setup_cluster(conn, master_nodes, slave_nodes, opts, deploy_ssh_key):
     # NOTE: We should clone the repository before running deploy_files to
     # prevent ec2-variables.sh from being overwritten
     repo_branch="{r} -b {b}".format(r=opts.spark_ec2_git_repo, b=opts.spark_ec2_branch)
-    print "Cloning spark-ec2 scripts from {rb} on master....".format(rb=repo_branch)
+    print "Cloning spark-ec2 scripts from {rb} on master...".format(rb=repo_branch)
     ssh(
         host=master,
         opts=opts,

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -662,7 +662,7 @@ def setup_cluster(conn, master_nodes, slave_nodes, opts, deploy_ssh_key):
 
     # NOTE: We should clone the repository before running deploy_files to
     # prevent ec2-variables.sh from being overwritten
-    print "Cloning spark-ec2 scripts from {r}/tree/{b}...".format(
+    print "Cloning spark-ec2 scripts from {r}/tree/{b} on master...".format(
         r=opts.spark_ec2_git_repo, b=opts.spark_ec2_git_branch)
     ssh(
         host=master,
@@ -1042,9 +1042,15 @@ def real_main():
         print >> stderr, "ebs-vol-num cannot be greater than 8"
         sys.exit(1)
 
-    # Prevent breaking ami_prefix
-    if opts.spark_ec2_git_repo.endswith("/") or opts.spark_ec2_git_repo.endswith(".git"):
-        print >> stderr, "spark-ec2-git-repo must not have a training / or .git"
+    # Prevent breaking ami_prefix (/, .git and startswith checks)
+    # Prevent forks with non spark-ec2 names for now.
+    if opts.spark_ec2_git_repo.endswith("/") or \
+            opts.spark_ec2_git_repo.endswith(".git") or \
+            not opts.spark_ec2_git_repo.startswith("https://github.com") or \
+            not opts.spark_ec2_git_repo.endswith("spark-ec2"):
+        print >> stderr, "spark-ec2-git-repo must be a github repo and it must not have a " \
+                         "training / or .git. " \
+                         "Furthermore, we currently only support forks named spark-ec2."
         sys.exit(1)
 
     try:

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -1049,7 +1049,7 @@ def real_main():
             not opts.spark_ec2_git_repo.startswith("https://github.com") or \
             not opts.spark_ec2_git_repo.endswith("spark-ec2"):
         print >> stderr, "spark-ec2-git-repo must be a github repo and it must not have a " \
-                         "training / or .git. " \
+                         "trailing / or .git. " \
                          "Furthermore, we currently only support forks named spark-ec2."
         sys.exit(1)
 

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -669,7 +669,8 @@ def setup_cluster(conn, master_nodes, slave_nodes, opts, deploy_ssh_key):
         opts=opts,
         command="rm -rf spark-ec2"
         + " && "
-        + "git clone {r} -b {b}".format(r=opts.spark_ec2_git_repo, b=opts.spark_ec2_git_branch)
+        + "git clone {r} -b {b} spark-ec2".format(r=opts.spark_ec2_git_repo,
+                                                  b=opts.spark_ec2_git_branch)
     )
 
     print "Deploying files to master..."
@@ -1041,12 +1042,9 @@ def real_main():
         print >> stderr, "ebs-vol-num cannot be greater than 8"
         sys.exit(1)
 
-    # Limit naming to avoid breaking things, as we rely on the repo
-    # being spark-ec2 in a few places.
-    # Also note that e.g. */spark-ec2/ and */spark-ec2.git are not allowed, as
-    # they would break the ami_prefix
-    if not opts.spark_ec2_git_repo.endswith("/spark-ec2"):
-        print >> stderr, "spark-ec2-git-repo must end with /spark-ec2"
+    # Prevent breaking ami_prefix
+    if opts.spark_ec2_git_repo.endswith("/") or opts.spark_ec2_git_repo.endswith(".git"):
+        print >> stderr, "spark-ec2-git-repo must not have a training / or .git"
         sys.exit(1)
 
     try:


### PR DESCRIPTION
and by extension, the ami-list

Useful for using alternate spark-ec2 repos or branches. 
