### PR TITLE
[SPARK-5586][Spark Shell][SQL] Make `sqlContext` available in spark shell

### DIFF
--- a/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -1022,8 +1022,18 @@ class SparkILoop(
 
   @DeveloperApi
   def createSQLContext(): SQLContext = {
-    sqlContext = new SQLContext(sparkContext)
-    logInfo("Created sql context..")
+    val name = "org.apache.spark.sql.hive.HiveContext"
+    val loader = Utils.getContextOrSparkClassLoader
+    try {
+      sqlContext = loader.loadClass(name).getConstructor(classOf[SparkContext])
+        .newInstance(sparkContext).asInstanceOf[SQLContext] 
+      logInfo("Created sql context (with Hive support)..")
+    }
+    catch {
+      case cnf: java.lang.ClassNotFoundException =>
+        sqlContext = new SQLContext(sparkContext)
+        logInfo("Created sql context..")
+    }
     sqlContext
   }
 

--- a/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -45,6 +45,9 @@ import scala.reflect.api.{Mirror, TypeCreator, Universe => ApiUniverse}
 import org.apache.spark.Logging
 import org.apache.spark.SparkConf
 import org.apache.spark.SparkContext
+import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.Dsl._
+import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 
 /** The Scala interactive shell.  It provides a read-eval-print loop
@@ -130,6 +133,7 @@ class SparkILoop(
   // NOTE: Must be public for visibility
   @DeveloperApi
   var sparkContext: SparkContext = _
+  var sqlContext: SQLContext = _
 
   override def echoCommandMessage(msg: String) {
     intp.reporter printMessage msg
@@ -1014,6 +1018,13 @@ class SparkILoop(
     sparkContext = new SparkContext(conf)
     logInfo("Created spark context..")
     sparkContext
+  }
+
+  @DeveloperApi
+  def createSQLContext(): SQLContext = {
+    sqlContext = new SQLContext(sparkContext)
+    logInfo("Created sql context..")
+    sqlContext
   }
 
   private def getMaster(): String = {

--- a/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -46,8 +46,6 @@ import org.apache.spark.Logging
 import org.apache.spark.SparkConf
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.SQLContext
-import org.apache.spark.sql.Dsl._
-import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 
 /** The Scala interactive shell.  It provides a read-eval-print loop

--- a/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoopInit.scala
+++ b/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoopInit.scala
@@ -127,7 +127,17 @@ private[repl] trait SparkILoopInit {
            _sc
          }
         """)
+      command("""
+         @transient val sqlContext = {
+           val _sqlContext = org.apache.spark.repl.Main.interp.createSQLContext()
+           println("SQLContext available as sqlContext.")
+           _sqlContext
+         }
+        """)
       command("import org.apache.spark.SparkContext._")
+      command("import sqlContext._")
+      command("import org.apache.spark.sql.Dsl._")
+      command("import org.apache.spark.sql.types._")
     }
   }
 

--- a/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoopInit.scala
+++ b/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoopInit.scala
@@ -130,14 +130,13 @@ private[repl] trait SparkILoopInit {
       command("""
          @transient val sqlContext = {
            val _sqlContext = org.apache.spark.repl.Main.interp.createSQLContext()
-           println("SQLContext available as sqlContext.")
+           println("SQL context available as sqlContext.")
            _sqlContext
          }
         """)
       command("import org.apache.spark.SparkContext._")
-      command("import sqlContext._")
+      command("import sqlContext.implicits._")
       command("import org.apache.spark.sql.Dsl._")
-      command("import org.apache.spark.sql.types._")
     }
   }
 

--- a/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoopInit.scala
+++ b/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoopInit.scala
@@ -136,6 +136,7 @@ private[repl] trait SparkILoopInit {
         """)
       command("import org.apache.spark.SparkContext._")
       command("import sqlContext.implicits._")
+      command("import sqlContext.sql")
       command("import org.apache.spark.sql.Dsl._")
     }
   }

--- a/repl/scala-2.11/src/main/scala/org/apache/spark/repl/Main.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/spark/repl/Main.scala
@@ -77,8 +77,18 @@ object Main extends Logging {
   }
 
   def createSQLContext(): SQLContext = {
-    sqlContext = new SQLContext(sparkContext)
-    logInfo("Created sql context..")
+    val name = "org.apache.spark.sql.hive.HiveContext"
+    val loader = Utils.getContextOrSparkClassLoader
+    try {
+      sqlContext = loader.loadClass(name).getConstructor(classOf[SparkContext])
+        .newInstance(sparkContext).asInstanceOf[SQLContext] 
+      logInfo("Created sql context (with Hive support)..")
+    }
+    catch {
+      case cnf: java.lang.ClassNotFoundException =>
+        sqlContext = new SQLContext(sparkContext)
+        logInfo("Created sql context..")
+    }
     sqlContext
   }
 

--- a/repl/scala-2.11/src/main/scala/org/apache/spark/repl/Main.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/spark/repl/Main.scala
@@ -19,6 +19,7 @@ package org.apache.spark.repl
 
 import org.apache.spark.util.Utils
 import org.apache.spark._
+import org.apache.spark.sql.SQLContext
 
 import scala.tools.nsc.Settings
 import scala.tools.nsc.interpreter.SparkILoop
@@ -34,6 +35,7 @@ object Main extends Logging {
     "-Yrepl-outdir", s"${outputDir.getAbsolutePath}", "-Yrepl-sync"), true)
   val classServer = new HttpServer(conf, outputDir, new SecurityManager(conf))
   var sparkContext: SparkContext = _
+  var sqlContext: SQLContext = _
   var interp = new SparkILoop // this is a public var because tests reset it.
 
   def main(args: Array[String]) {
@@ -72,6 +74,12 @@ object Main extends Logging {
     sparkContext = new SparkContext(conf)
     logInfo("Created spark context..")
     sparkContext
+  }
+
+  def createSQLContext(): SQLContext = {
+    sqlContext = new SQLContext(sparkContext)
+    logInfo("Created sql context..")
+    sqlContext
   }
 
   private def getMaster: String = {

--- a/repl/scala-2.11/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -70,14 +70,13 @@ class SparkILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
       command( """
          @transient val sqlContext = {
            val _sqlContext = org.apache.spark.repl.Main.createSQLContext()
-           println("SQLContext available as sqlContext.")
+           println("SQL context available as sqlContext.")
            _sqlContext
          }
         """)
       command("import org.apache.spark.SparkContext._")
-      command("import sqlContext._")
+      command("import sqlContext.implicits._")
       command("import org.apache.spark.sql.Dsl._")
-      command("import org.apache.spark.sql.types._")
     }
   }
 

--- a/repl/scala-2.11/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -76,6 +76,7 @@ class SparkILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
         """)
       command("import org.apache.spark.SparkContext._")
       command("import sqlContext.implicits._")
+      command("import sqlContext.sql")
       command("import org.apache.spark.sql.Dsl._")
     }
   }

--- a/repl/scala-2.11/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -66,8 +66,18 @@ class SparkILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
            println("Spark context available as sc.")
            _sc
          }
-               """)
+        """)
+      command( """
+         @transient val sqlContext = {
+           val _sqlContext = org.apache.spark.repl.Main.createSQLContext()
+           println("SQLContext available as sqlContext.")
+           _sqlContext
+         }
+        """)
       command("import org.apache.spark.SparkContext._")
+      command("import sqlContext._")
+      command("import org.apache.spark.sql.Dsl._")
+      command("import org.apache.spark.sql.types._")
     }
   }
 


### PR DESCRIPTION
Result is like this 

```
15/02/05 13:41:22 INFO SparkILoop: Created spark context..
Spark context available as sc.
15/02/05 13:41:22 INFO SparkILoop: Created sql context..
SQLContext available as sqlContext.

scala> sq
sql          sqlContext   sqlParser    sqrt            
```
