### PR TITLE
[SPARK-5614][SQL] Predicate pushdown through Generate.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -457,7 +457,7 @@ object PushPredicateThroughProject extends Rule[LogicalPlan] {
 }
 
 /**
- * Push [[Filter]] operators through [[Generate]] operators. Part of the predicate which referenced
+ * Push [[Filter]] operators through [[Generate]] operators. Parts of the predicate that reference
  * attributes generated in [[Generate]] will remain above, and the rest should be pushed beneath.
  */
 object PushPredicateThroughGenerate extends Rule[LogicalPlan] with PredicateHelper {
@@ -465,8 +465,8 @@ object PushPredicateThroughGenerate extends Rule[LogicalPlan] with PredicateHelp
   def apply(plan: LogicalPlan): LogicalPlan = plan transform {
     case filter @ Filter(condition,
     generate @ Generate(generator, join, outer, alias, grandChild)) =>
-      // Those conjuncts referenced a attributes generated in `generate` can not
-      // be pushed below `generate`
+      // Predicates that reference attributes produced by the `Generate` operator cannot
+      // be pushed below the operator.
       val (pushDown, stayUp) = splitConjunctivePredicates(condition).partition {
         conjunct => conjunct.references subsetOf grandChild.outputSet
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -460,66 +460,22 @@ object PushPredicateThroughProject extends Rule[LogicalPlan] {
  * Push [[Filter]] operators through [[Generate]] operators. Part of the predicate which referenced
  * attributes generated in [[Generate]] will remain above, and the rest should be pushed beneath.
  */
-object PushPredicateThroughGenerate extends Rule[LogicalPlan] {
-  /**
-   * Split a condition / predicate into conjuncts
-   * @param condition predicate
-   * @return conjuncts
-   */
-  private def split(condition: Expression): List[Expression] = condition match {
-    case And(left, right) => split(left) ++ split(right)
-    case e: Expression => List(e)
-  }
-
-  /**
-   * Join a list of conjuncts into a single predicate
-   * @param conjuncts conjuncts
-   * @return Some(predicate) or None if conjunct list is empty
-   */
-  private def joinConjuncts(conjuncts: Seq[Expression]): Option[Expression] = {
-    conjuncts.foldRight(None.asInstanceOf[Option[Expression]]) {
-      (conjunct, joint) => (conjunct, joint) match {
-        case (c: Expression, Some(j)) => Some(And(c, j))
-        case (c: Expression, None) => Some(c)
-      }
-    }
-  }
+object PushPredicateThroughGenerate extends Rule[LogicalPlan] with PredicateHelper {
 
   def apply(plan: LogicalPlan): LogicalPlan = plan transform {
     case filter @ Filter(condition,
     generate @ Generate(generator, join, outer, alias, grandChild)) =>
-      val conjuncts = split(condition)
-      val referencedAttrsInConjuncts = conjuncts.zip(conjuncts.map(_.references))
-      val generatedAttrNames = generator match {
-        case Explode(attrs, expr) => attrs
-        case _ => Seq[String]()
-      }
       // Those conjuncts referenced a attributes generated in `generate` can not
       // be pushed below `generate`
-      val (predicatesUp, predicatesDown) = referencedAttrsInConjuncts.partition {
-        conjunctsWithReferences =>
-          conjunctsWithReferences._2.exists(attr => generatedAttrNames.contains(attr.name))
+      val (pushDown, stayUp) = splitConjunctivePredicates(condition).partition {
+        conjunct => conjunct.references subsetOf grandChild.outputSet
       }
-      val upCondition = joinConjuncts(predicatesUp.map(_._1))
-      val downCondition = joinConjuncts(predicatesDown.map(_._1))
-      (upCondition, downCondition) match {
-        case (Some(upPredicate), Some(downPredicate)) =>
-          // UpPredicate <- Generate <- DownPredicate <- Grand Child
-          Filter(upPredicate,
-            generate.copy(generator, join, outer, alias,
-              Filter(downPredicate, grandChild)))
-
-        case (Some(upPredicate), None) =>
-          filter
-
-        case (None, Some(downPredicate)) =>
-          // Generate <- DownPredicate <- Grand Child
-          generate.copy(generator, join, outer, alias,
-            Filter(downPredicate, grandChild))
-
-        case (None, None) =>
-          // This seems not possible, but the correct handling would be remove the filter
-          generate.copy(generator, join, outer, alias, grandChild)
+      if (pushDown.nonEmpty) {
+        val pushDownPredicate = pushDown.reduce(And)
+        val withPushdown = generate.copy(child = Filter(pushDownPredicate, grandChild))
+        stayUp.reduceOption(And).map(Filter(_, withPushdown)).getOrElse(withPushdown)
+      } else {
+        filter
       }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -19,11 +19,13 @@ package org.apache.spark.sql.catalyst.optimizer
 
 import org.apache.spark.sql.catalyst.analysis
 import org.apache.spark.sql.catalyst.analysis.EliminateAnalysisOperators
+import org.apache.spark.sql.catalyst.expressions.Explode
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.plans.{PlanTest, LeftOuter, RightOuter}
 import org.apache.spark.sql.catalyst.rules._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.types.IntegerType
 
 class FilterPushdownSuite extends PlanTest {
 
@@ -34,7 +36,8 @@ class FilterPushdownSuite extends PlanTest {
       Batch("Filter Pushdown", Once,
         CombineFilters,
         PushPredicateThroughProject,
-        PushPredicateThroughJoin) :: Nil
+        PushPredicateThroughJoin,
+        PushPredicateThroughGenerate) :: Nil
   }
 
   val testRelation = LocalRelation('a.int, 'b.int, 'c.int)
@@ -410,5 +413,63 @@ class FilterPushdownSuite extends PlanTest {
         .analyze
 
     comparePlans(optimized, analysis.EliminateAnalysisOperators(correctAnswer))
+  }
+
+  val testRelationWithArrayType = LocalRelation('a.int, 'b.int, 'c_arr.array(IntegerType))
+
+  test("generate: predicate referenced no generated column") {
+    val originalQuery = {
+      testRelationWithArrayType
+        .generate(Explode(Seq("c"), 'c_arr), true, false, Some("arr"))
+        .where(('b >= 5) && ('a > 6))
+    }
+    val optimized = Optimize(originalQuery.analyze)
+    val correctAnswer = {
+      testRelationWithArrayType
+        .where(('b >= 5) && ('a > 6))
+        .generate(Explode(Seq("c"), 'c_arr), true, false, Some("arr")).analyze
+    }
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("generate: part of conjuncts referenced generated column") {
+    val generator = Explode(Seq("c"), 'c_arr)
+    val originalQuery = {
+      testRelationWithArrayType
+        .generate(generator, true, false, Some("arr"))
+        .where(('b >= 5) && ('c > 6))
+    }
+    val optimized = Optimize(originalQuery.analyze)
+    val referenceResult = {
+      testRelationWithArrayType
+        .where('b >= 5)
+        .generate(generator, true, false, Some("arr"))
+        .where('c > 6).analyze
+    }
+
+    // Since newly generated columns get different ids every time being analyzed
+    // e.g. comparePlans(originalQuery.analyze, originalQuery.analyze) fails.
+    // So we check operators manually here.
+    // Filter("c" > 6)
+    assertResult(classOf[Filter])(optimized.getClass)
+    assertResult(1)(optimized.asInstanceOf[Filter].condition.references.size)
+    assertResult("c"){
+      optimized.asInstanceOf[Filter].condition.references.toSeq(0).name
+    }
+
+    // the rest part
+    comparePlans(optimized.children(0), referenceResult.children(0))
+  }
+
+  test("generate: all conjuncts referenced generated column") {
+    val originalQuery = {
+      testRelationWithArrayType
+        .generate(Explode(Seq("c"), 'c_arr), true, false, Some("arr"))
+        .where(('c > 6) || ('b > 5)).analyze
+    }
+    val optimized = Optimize(originalQuery)
+
+    comparePlans(optimized, originalQuery)
   }
 }


### PR DESCRIPTION
Now in Catalyst's rules, predicates can not be pushed through "Generate" nodes. Further more, partition pruning in HiveTableScan can not be applied on those queries involves "Generate". This makes such queries very inefficient. In practice, it finds patterns like 

``` scala
Filter(predicate, Generate(generator, _, _, _, grandChild))
```

and splits the predicate into 2 parts by referencing the generated column from Generate node or not. And a new Filter will be created for those conjuncts can be pushed beneath Generate node. If nothing left for the original Filter, it will be removed.
For example, physical plan for query

``` sql
select len, bk
from s_server lateral view explode(len_arr) len_table as len 
where len > 5 and day = '20150102';
```

where 'day' is a partition column in metastore is like this in current version of Spark SQL:

> Project [len, bk]
> 
> Filter ((len > "5") && "(day = "20150102")")
> 
> Generate explode(len_arr), true, false
> 
> HiveTableScan [bk, len_arr, day], (MetastoreRelation default, s_server, None), None

But theoretically the plan should be like this

> Project [len, bk]
> 
> Filter (len > "5")
> 
> Generate explode(len_arr), true, false
> 
> HiveTableScan [bk, len_arr, day], (MetastoreRelation default, s_server, None), Some(day = "20150102")

Where partition pruning predicates can be pushed to HiveTableScan nodes.
