### PR TITLE
[SPARK-5620][DOC] group methods in generated unidoc

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -374,7 +374,10 @@ object Unidoc {
       ),
       "-group", "Spark SQL", packageList("sql.api.java", "sql.api.java.types", "sql.hive.api.java"),
       "-noqualifier", "java.lang"
-    )
+    ),
+
+    // Group similar methods together based on the @group annotation.
+    scalacOptions in (ScalaUnidoc, unidoc) ++= Seq("-groups")
   )
 }
 


### PR DESCRIPTION
It seems that `(ScalaUnidoc, unidoc)` is the correct way to overwrite `scalacOptions` in unidoc.

CC: @rxin @gzm0
