### PR TITLE
[SPARK-5644] [Core]Delete tmp dir when sc is stop

### DIFF
--- a/core/src/main/scala/org/apache/spark/HttpFileServer.scala
+++ b/core/src/main/scala/org/apache/spark/HttpFileServer.scala
@@ -56,10 +56,8 @@ private[spark] class HttpFileServer(
     try {
       Utils.deleteRecursively(baseDir)
     } catch {
-      case e: Exception => {
-        val path = baseDir.getAbsolutePath
-        logWarning(s"Exception while deleting Spark temp dir: $path", e)
-      }
+      case e: Exception =>
+        logWarning(s"Exception while deleting Spark temp dir: ${baseDir.getAbsolutePath}", e)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/HttpFileServer.scala
+++ b/core/src/main/scala/org/apache/spark/HttpFileServer.scala
@@ -50,6 +50,15 @@ private[spark] class HttpFileServer(
 
   def stop() {
     httpServer.stop()
+    
+    // If we only stop sc, but sparksubmit still run as a services we need to delete the tmp dir
+    // if not, it will create too many tmp dir
+    try {
+      Utils.deleteRecursively(baseDir)
+    } catch {
+      case e: Exception =>
+        logError("Exception while deleting Spark temp dir: " + baseDir.getAbsolutePath, e)
+    }
   }
 
   def addFile(file: File) : String = {

--- a/core/src/main/scala/org/apache/spark/HttpFileServer.scala
+++ b/core/src/main/scala/org/apache/spark/HttpFileServer.scala
@@ -56,8 +56,10 @@ private[spark] class HttpFileServer(
     try {
       Utils.deleteRecursively(baseDir)
     } catch {
-      case e: Exception =>
-        logWarning("Exception while deleting Spark temp dir: " + baseDir.getAbsolutePath, e)
+      case e: Exception => {
+        val path = baseDir.getAbsolutePath
+        logWarning(s"Exception while deleting Spark temp dir: $path", e)
+      }
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/HttpFileServer.scala
+++ b/core/src/main/scala/org/apache/spark/HttpFileServer.scala
@@ -57,7 +57,7 @@ private[spark] class HttpFileServer(
       Utils.deleteRecursively(baseDir)
     } catch {
       case e: Exception =>
-        logError("Exception while deleting Spark temp dir: " + baseDir.getAbsolutePath, e)
+        logWarning("Exception while deleting Spark temp dir: " + baseDir.getAbsolutePath, e)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/HttpFileServer.scala
+++ b/core/src/main/scala/org/apache/spark/HttpFileServer.scala
@@ -51,8 +51,8 @@ private[spark] class HttpFileServer(
   def stop() {
     httpServer.stop()
     
-    // If we only stop sc, but sparksubmit still run as a services we need to delete the tmp dir
-    // if not, it will create too many tmp dir
+    // If we only stop sc, but the driver process still run as a services then we need to delete 
+    // the tmp dir, if not, it will create too many tmp dirs
     try {
       Utils.deleteRecursively(baseDir)
     } catch {

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -94,12 +94,20 @@ class SparkEnv (
 
     // Note that blockTransferService is stopped by BlockManager since it is started by it.
     
-    // If we only stop sc, but the driver process still run as a services then we need to delete 
-    // the tmp dir, if not, it will create too many tmp dirs
-    try {
-      Utils.deleteRecursively(new File(sparkFilesDir))
-    } catch {
-      case e: Exception => logError(s"Exception while deleting Spark temp dir: $sparkFilesDir", e)
+    /**
+     * If we only stop sc, but the driver process still run as a services then we need to delete
+     * the tmp dir, if not, it will create too many tmp dirs.
+     *
+     * We only need to delete the tmp dir create by driver, so we need to check the sparkFilesDir,
+     * because sparkFilesDir is point to the current working dir in executor.
+     */
+    if("." != sparkFilesDir){
+      try {
+        Utils.deleteRecursively(new File(sparkFilesDir))
+      } catch {
+        case e: Exception =>
+          logWarning(s"Exception while deleting Spark temp dir: $sparkFilesDir", e)
+      }
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -98,7 +98,7 @@ class SparkEnv (
     // the tmp dir, if not, it will create too many tmp dirs.
     // We only need to delete the tmp dir create by driver, because sparkFilesDir is point to the
     // current working dir in executor which we do not need to delete.
-    if (SparkContext.DRIVER_IDENTIFIER == executorId) {
+    if (sparkFilesDir != ".") {
       try {
         Utils.deleteRecursively(new File(sparkFilesDir))
       } catch {
@@ -351,6 +351,8 @@ object SparkEnv extends Logging {
     // Set the sparkFiles directory, used when downloading dependencies.  In local mode,
     // this is a temporary directory; in distributed mode, this is the executor's current working
     // directory.
+    // As we use this value to decide whether if we need to delete the tmp file in stop(), so if you
+    // want to change this code please be careful.
     val sparkFilesDir: String = if (isDriver) {
       Utils.createTempDir(Utils.getLocalDir(conf), "userFiles").getAbsolutePath
     } else {

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -93,6 +93,14 @@ class SparkEnv (
     // actorSystem.awaitTermination()
 
     // Note that blockTransferService is stopped by BlockManager since it is started by it.
+    
+    // If we only stop sc, but sparksubmit still run as a services we need to delete the tmp dir
+    // if not, it will create too many tmp dir
+    try {
+      Utils.deleteRecursively(new File(sparkFilesDir))
+    } catch {
+      case e: Exception => logError(s"Exception while deleting Spark temp dir: $sparkFilesDir", e)
+    }
   }
 
   private[spark]

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -94,8 +94,8 @@ class SparkEnv (
 
     // Note that blockTransferService is stopped by BlockManager since it is started by it.
     
-    // If we only stop sc, but sparksubmit still run as a services we need to delete the tmp dir
-    // if not, it will create too many tmp dir
+    // If we only stop sc, but the driver process still run as a services then we need to delete 
+    // the tmp dir, if not, it will create too many tmp dirs
     try {
       Utils.deleteRecursively(new File(sparkFilesDir))
     } catch {

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -94,14 +94,11 @@ class SparkEnv (
 
     // Note that blockTransferService is stopped by BlockManager since it is started by it.
     
-    /**
-     * If we only stop sc, but the driver process still run as a services then we need to delete
-     * the tmp dir, if not, it will create too many tmp dirs.
-     *
-     * We only need to delete the tmp dir create by driver, so we need to check the sparkFilesDir,
-     * because sparkFilesDir is point to the current working dir in executor.
-     */
-    if ("." != sparkFilesDir) {
+    // If we only stop sc, but the driver process still run as a services then we need to delete
+    // the tmp dir, if not, it will create too many tmp dirs.
+    // We only need to delete the tmp dir create by driver, because sparkFilesDir is point to the
+    // current working dir in executor which we do not need to delete.
+    if (SparkContext.DRIVER_IDENTIFIER == executorId) {
       try {
         Utils.deleteRecursively(new File(sparkFilesDir))
       } catch {

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -101,7 +101,7 @@ class SparkEnv (
      * We only need to delete the tmp dir create by driver, so we need to check the sparkFilesDir,
      * because sparkFilesDir is point to the current working dir in executor.
      */
-    if("." != sparkFilesDir){
+    if ("." != sparkFilesDir) {
       try {
         Utils.deleteRecursively(new File(sparkFilesDir))
       } catch {


### PR DESCRIPTION
When we run driver as a service, and for each time we run job we only call sc.stop, then will not delete tmp dir create by HttpFileServer and SparkEnv, it will be deleted until the service process exit, so we need to delete these tmp dirs when sc is stop directly.
