### PR TITLE
[SPARK-5396] Syntax error in spark scripts on windows.

### DIFF
--- a/bin/spark-submit2.cmd
+++ b/bin/spark-submit2.cmd
@@ -25,7 +25,7 @@ set ORIG_ARGS=%*
 rem Reset the values of all variables used
 set SPARK_SUBMIT_DEPLOY_MODE=client
 
-if not defined %SPARK_CONF_DIR% (
+if [%SPARK_CONF_DIR%] == [] (
   set SPARK_CONF_DIR=%SPARK_HOME%\conf
 )
 set SPARK_SUBMIT_PROPERTIES_FILE=%SPARK_CONF_DIR%\spark-defaults.conf


### PR DESCRIPTION
Modified syntax error in spark-submit2.cmd. Command prompt doesn't have "defined" operator.
