### PR TITLE
[SPARK-5656] Fail gracefully for large values of k and/or n that will ex...

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/EigenValueDecomposition.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/EigenValueDecomposition.scala
@@ -66,9 +66,6 @@ private[mllib] object EigenValueDecomposition {
     // ncv must be smaller than n
     val ncv = math.min(2 * k, n)
 
-    require(ncv * n.toLong < Integer.MAX_VALUE, "Product of 2*k*n must be smaller than " +
-      s"Integer.MAX_VALUE. Found required eigenvalues k = $k and matrix dimension n = $n")
-
     // "I" for standard eigenvalue problem, "G" for generalized eigenvalue problem
     val bmat = "I"
     // "LM" : compute the NEV largest (in magnitude) eigenvalues
@@ -82,6 +79,10 @@ private[mllib] object EigenValueDecomposition {
     // Mode 1: A*x = lambda*x, A symmetric
     iparam(6) = 1
 
+    require(ncv * n.toLong <= Integer.MAX_VALUE, "Product of 2*k*n must be smaller than " +
+      s"Integer.MAX_VALUE. Found required eigenvalues k = $k and matrix dimension n = $n")
+    require(ncv * (ncv.toLong + 8) <= Integer.MAX_VALUE, "Product of ncv * (ncv + 8) must be smaller than " +
+      s"Integer.MAX_VALUE. The value of ncv is computed by: math.min(2 * k, n). Found ncv = $ncv and k = $k.")
     var ido = new intW(0)
     var info = new intW(0)
     var resid = new Array[Double](n)

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/EigenValueDecomposition.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/EigenValueDecomposition.scala
@@ -79,10 +79,11 @@ private[mllib] object EigenValueDecomposition {
     // Mode 1: A*x = lambda*x, A symmetric
     iparam(6) = 1
 
-    require(ncv * n.toLong <= Integer.MAX_VALUE, "Product of 2*k*n must be smaller than " +
-      s"Integer.MAX_VALUE. Found required eigenvalues k = $k and matrix dimension n = $n")
-    require(ncv * (ncv.toLong + 8) <= Integer.MAX_VALUE, "Product of ncv * (ncv + 8) must be smaller than " +
-      s"Integer.MAX_VALUE. The value of ncv is computed by: math.min(2 * k, n). Found ncv = $ncv and k = $k.")
+    require(n * ncv.toLong <= Integer.MAX_VALUE, "Large n and/or k will exceed " +
+      s"max array size. Found required eigenvalues k = $k and matrix dimension n = $n")
+    require(ncv * (ncv.toLong + 8) <= Integer.MAX_VALUE, "Large k will exceed " +
+      s"max array size. Found k=$k.")
+    
     var ido = new intW(0)
     var info = new intW(0)
     var resid = new Array[Double](n)

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/EigenValueDecomposition.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/EigenValueDecomposition.scala
@@ -66,6 +66,9 @@ private[mllib] object EigenValueDecomposition {
     // ncv must be smaller than n
     val ncv = math.min(2 * k, n)
 
+    require(ncv * n.toLong < Integer.MAX_VALUE, "Product of 2*k*n must be smaller than " +
+      s"Integer.MAX_VALUE. Found required eigenvalues k = $k and matrix dimension n = $n")
+
     // "I" for standard eigenvalue problem, "G" for generalized eigenvalue problem
     val bmat = "I"
     // "LM" : compute the NEV largest (in magnitude) eigenvalues

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/EigenValueDecomposition.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/EigenValueDecomposition.scala
@@ -79,10 +79,8 @@ private[mllib] object EigenValueDecomposition {
     // Mode 1: A*x = lambda*x, A symmetric
     iparam(6) = 1
 
-    require(n * ncv.toLong <= Integer.MAX_VALUE, "Large n and/or k will exceed " +
-      s"max array size. Found required eigenvalues k = $k and matrix dimension n = $n")
-    require(ncv * (ncv.toLong + 8) <= Integer.MAX_VALUE, "Large k will exceed " +
-      s"max array size. Found k=$k.")
+    require(n * ncv.toLong <= Integer.MAX_VALUE && ncv * (ncv.toLong + 8) <= Integer.MAX_VALUE,
+      s"k = $k and/or n = $n are too large to compute an eigendecomposition")
     
     var ido = new intW(0)
     var info = new intW(0)


### PR DESCRIPTION
...ceed max int.

Large values of k and/or n in EigenValueDecomposition.symmetricEigs will result in array initialization to a value larger than Integer.MAX_VALUE in the following: var v = new Array[Double](n * ncv)
