### PR TITLE
[SPARK-5657][Examples][PySpark] Add PySpark Avro Output Format example

### DIFF
--- a/examples/src/main/python/avro_outputformat.py
+++ b/examples/src/main/python/avro_outputformat.py
@@ -1,0 +1,57 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import sys
+
+"""
+Writes a record to avro file
+"""
+from pyspark import SparkContext
+
+if __name__ == "__main__":
+    if len(sys.argv) != 4 and len(sys.argv) != 5:
+        print >> sys.stderr, """
+        Usage: avro_outputformat <hdfs_path> <name> <favorite_color> <writer_schema_hdfs_file>
+
+        Run with example jar locally:
+        spark-submit --driver-class-path /path/to/example/jar /path/to/examples/avro_outputformat.py <path> <name> <favorite_color> <writer_schema_file>
+        Writer schema is mandatory and needs to match schema used by Converter (there is no way to pass schema from PySpark to Converter due to API limitations).
+        Given example is for the user.asvc schema from Spark examples jar
+        
+        Run on Hadoop/Spark cluster:
+        spark-submit --master local --jars /path/to/jars/avro.jar,/path/to/jars/avro-mapred.jar,/path/to/jars/spark-examples.jar /path/to/avro_outputformat.py <hdfs_path> <name> <favorite_color> <user.avsc_in_hdfs>
+        """
+        exit(-1)
+
+    path = sys.argv[1]
+    sc = SparkContext(appName="AvroKeyOutputFormat")
+
+    conf = None
+    if len(sys.argv) == 5:
+        schema_rdd = sc.textFile(sys.argv[4], 1).collect()
+        conf = {"avro.schema.output.key" : reduce(lambda x, y: x+y, schema_rdd)}
+    
+    record = {"name" : sys.argv[2], "favorite_color" : sys.argv[3]}
+    sc.parallelize([record]).map(lambda x: (x, None)).saveAsNewAPIHadoopFile(
+    	path,
+        "org.apache.avro.mapreduce.AvroKeyOutputFormat",
+        "org.apache.avro.mapred.AvroKey",
+        "org.apache.hadoop.io.NullWritable",
+        keyConverter="org.apache.spark.examples.pythonconverters.UserToAvroKeyConverter",
+        conf=conf)
+
+    sc.stop()

--- a/examples/src/main/scala/org/apache/spark/examples/pythonconverters/AvroConverters.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/pythonconverters/AvroConverters.scala
@@ -21,10 +21,12 @@ import java.util.{Collection => JCollection, Map => JMap}
 
 import scala.collection.JavaConversions._
 
-import org.apache.avro.generic.{GenericFixed, IndexedRecord}
-import org.apache.avro.mapred.AvroWrapper
+import org.apache.avro.generic.{GenericFixed, IndexedRecord, GenericRecordBuilder}
+import org.apache.avro.mapred.{AvroWrapper, AvroKey}
 import org.apache.avro.Schema
 import org.apache.avro.Schema.Type._
+
+
 
 import org.apache.spark.api.python.Converter
 import org.apache.spark.SparkException
@@ -142,5 +144,40 @@ class AvroWrapperToJavaConverter extends Converter[Any, Any] {
       case other => throw new SparkException(
         s"Unsupported top-level Avro data type ${other.getClass.getName}")
     }
+  }
+}
+
+/**
+ * Implementation of [[org.apache.spark.api.python.Converter]] that converts 
+ * a Java Map to an Avro Record wrapped in an AvroKey.
+ * Requires [[org.apache.avro.generic.GenericRecordBuilder]] initialized with 
+ * specific Avro schema.
+ * With current Spark API it's not possible to pass schema directly to Converter, 
+ * so we need a concrete Converter implementation for each given schema. 
+ */
+abstract class JavaToAvroKeyConverter extends Converter[Any, Any] {
+  
+  final override def convert(obj: Any): Any = {
+    if (obj == null) {
+      return null
+    }
+    val recordBuilder = getRecordBuilder()
+    obj.asInstanceOf[JMap[_, _]].map { 
+      case (key, value) => recordBuilder.set(key.toString, value)
+    }
+    new AvroKey(recordBuilder.build)
+  }
+  
+  def getRecordBuilder(): GenericRecordBuilder //Override in subclass
+}
+
+object UserToAvroKeyConverter {
+  //Schema stays in companion object to avoid task serialization problems
+  val schema = new Schema.Parser().parse(getClass.getResourceAsStream("/user.avsc"));  
+}
+
+class UserToAvroKeyConverter extends JavaToAvroKeyConverter {
+  override def getRecordBuilder(): GenericRecordBuilder = {
+    new GenericRecordBuilder(UserToAvroKeyConverter.schema)
   }
 }


### PR DESCRIPTION
There is an Avro Input Format example that shows how to read Avro data in PySpark, but nothing shows how to write from PySpark to Avro. The main challenge, a Converter needs an Avro schema to build a record, but current Spark API doesn't provide a way to supply extra parameters to custom converters. Provided workaround is possible.
https://issues.apache.org/jira/browse/SPARK-5657
