### PR TITLE
[SQL] Set sessionState in QueryExecution.

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -424,6 +424,9 @@ class HiveContext(sc: SparkContext) extends SQLContext(sc) {
   /** Extends QueryExecution with hive specific features. */
   protected[sql] class QueryExecution(logicalPlan: LogicalPlan)
     extends super.QueryExecution(logicalPlan) {
+    // Set the current SessionState to our own SessionState. So, we will make sure
+    // this state can be always picked up.
+    SessionState.start(sessionState)
 
     /**
      * Returns the result as a hive compatible sequence of strings.  For native commands, the

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -424,9 +424,11 @@ class HiveContext(sc: SparkContext) extends SQLContext(sc) {
   /** Extends QueryExecution with hive specific features. */
   protected[sql] class QueryExecution(logicalPlan: LogicalPlan)
     extends super.QueryExecution(logicalPlan) {
-    // Set the current SessionState to our own SessionState. So, we will make sure
-    // this state can be always picked up.
-    SessionState.start(sessionState)
+    // Like what we do in runHive, makes sure the session represented by the
+    // `sessionState` field is activated.
+    if (SessionState.get() != sessionState) {
+      SessionState.start(sessionState)
+    }
 
     /**
      * Returns the result as a hive compatible sequence of strings.  For native commands, the

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -403,9 +403,6 @@ private[hive] class HiveMetastoreCatalog(hive: HiveContext) extends Catalog with
         val desc: Option[CreateTableDesc] = if (tableExists(Seq(databaseName, tblName))) {
           None
         } else {
-          // Set the current SessionState to our own SessionState. So, we will make sure
-          // this state can be picked up inside analyzeInternal.
-          SessionState.setCurrentSessionState(hive.sessionState)
           val sa = new SemanticAnalyzer(hive.hiveconf) {
             override def analyzeInternal(ast: ASTNode) {
               // A hack to intercept the SemanticAnalyzer.analyzeInternal,

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -27,7 +27,6 @@ import org.apache.hadoop.hive.metastore.{Warehouse, TableType}
 import org.apache.hadoop.hive.metastore.api.{Table => TTable, Partition => TPartition, FieldSchema}
 import org.apache.hadoop.hive.ql.metadata._
 import org.apache.hadoop.hive.ql.plan.CreateTableDesc
-import org.apache.hadoop.hive.ql.session.SessionState
 import org.apache.hadoop.hive.serde.serdeConstants
 import org.apache.hadoop.hive.serde2.{Deserializer, SerDeException}
 import org.apache.hadoop.hive.serde2.`lazy`.LazySimpleSerDe

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -27,6 +27,7 @@ import org.apache.hadoop.hive.metastore.{Warehouse, TableType}
 import org.apache.hadoop.hive.metastore.api.{Table => TTable, Partition => TPartition, FieldSchema}
 import org.apache.hadoop.hive.ql.metadata._
 import org.apache.hadoop.hive.ql.plan.CreateTableDesc
+import org.apache.hadoop.hive.ql.session.SessionState
 import org.apache.hadoop.hive.serde.serdeConstants
 import org.apache.hadoop.hive.serde2.{Deserializer, SerDeException}
 import org.apache.hadoop.hive.serde2.`lazy`.LazySimpleSerDe
@@ -402,6 +403,9 @@ private[hive] class HiveMetastoreCatalog(hive: HiveContext) extends Catalog with
         val desc: Option[CreateTableDesc] = if (tableExists(Seq(databaseName, tblName))) {
           None
         } else {
+          // Set the current SessionState to our own SessionState. So, we will make sure
+          // this state can be picked up inside analyzeInternal.
+          SessionState.setCurrentSessionState(hive.sessionState)
           val sa = new SemanticAnalyzer(hive.hiveconf) {
             override def analyzeInternal(ast: ASTNode) {
               // A hack to intercept the SemanticAnalyzer.analyzeInternal,


### PR DESCRIPTION
This PR sets the SessionState in HiveContext's QueryExecution. So, we can make sure that SessionState.get can return the SessionState every time.
