### PR TITLE
[SPARK-5684][SQL]: Pass in partition name along with location information, as the location can be different (that is may not contain the partition keys)

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
+import java.net.URLDecoder
 import java.sql.{Date, Timestamp}
 import java.text.{DateFormat, SimpleDateFormat}
 
@@ -158,6 +159,8 @@ case class Cast(child: Expression, dataType: DataType) extends UnaryExpression w
         if (periodIdx != -1 && n.length() - periodIdx > 9) {
           n = n.substring(0, periodIdx + 10)
         }
+        // Timestamp value in the partition could be in the form: (2015-02-09 00%3A55%3A00)
+        n = URLDecoder.decode(n, "UTF-8");
         try Timestamp.valueOf(n) catch { case _: java.lang.IllegalArgumentException => null }
       })
     case BooleanType =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/dataTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/dataTypes.scala
@@ -434,7 +434,7 @@ case object BooleanType extends BooleanType
  * @group dataType
  */
 @DeveloperApi
-class TimestampType private() extends NativeType {
+class TimestampType private() extends NativeType with PrimitiveType {
   // The companion object and this class is separated so the companion object also subclasses
   // this type. Otherwise, the companion object would be of type "TimestampType$" in byte code.
   // Defined with a private constructor so the companion object is the only possible instantiation.

--- a/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetRelation.scala
@@ -49,7 +49,8 @@ private[sql] case class ParquetRelation(
     path: String,
     @transient conf: Option[Configuration],
     @transient sqlContext: SQLContext,
-    partitioningAttributes: Seq[Attribute] = Nil)
+    partitioningAttributes: Seq[Attribute] = Nil,
+    partitionValues: String = "")
   extends LeafNode with MultiInstanceRelation {
 
   self: Product =>
@@ -65,7 +66,7 @@ private[sql] case class ParquetRelation(
   override val output =
     partitioningAttributes ++
     ParquetTypesConverter.readSchemaFromFile(
-      new Path(path.split(",").head.split("->").head),
+      new Path(path.split(",").head),
       conf,
       sqlContext.conf.isParquetBinaryAsString,
       sqlContext.conf.isParquetINT96AsTimestamp)

--- a/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetRelation.scala
@@ -65,7 +65,7 @@ private[sql] case class ParquetRelation(
   override val output =
     partitioningAttributes ++
     ParquetTypesConverter.readSchemaFromFile(
-      new Path(path.split(",").head),
+      new Path(path.split(",").head.split("->").head),
       conf,
       sqlContext.conf.isParquetBinaryAsString,
       sqlContext.conf.isParquetINT96AsTimestamp)

--- a/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetTableOperations.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetTableOperations.scala
@@ -88,10 +88,11 @@ private[sql] case class ParquetTableScan(
     val conf: Configuration = ContextUtil.getConfiguration(job)
 
     if (requestedPartitionOrdinals.nonEmpty) {
-      relation.path.split(",").foreach { tcurPath =>
-        val p = tcurPath.split("->")
-        val curPath = p.apply(0)
-        val partition = p.apply(1)
+      val partVals = relation.partitionValues.split(",")
+      var i = 0
+      relation.path.split(",").foreach { curPath =>
+        val partition = partVals.apply(i)
+        i += 1
         val qualifiedPath = {
           val path = new Path(curPath)
           path.getFileSystem(conf).makeQualified(path)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -60,7 +60,7 @@ private[hive] trait HiveStrategies {
     implicit class LogicalPlanHacks(s: DataFrame) {
       def lowerCase: DataFrame = DataFrame(s.sqlContext, s.logicalPlan)
 
-      def addPartitioningAttributes(attrs: Seq[Attribute]): DataFrame = {
+      def addPartitioningAttributes(attrs: Seq[Attribute], partVals: String): DataFrame = {
         // Don't add the partitioning key if its already present in the data.
         if (attrs.map(_.name).toSet.subsetOf(s.logicalPlan.output.map(_.name).toSet)) {
           s
@@ -68,7 +68,8 @@ private[hive] trait HiveStrategies {
           DataFrame(
             s.sqlContext,
             s.logicalPlan transform {
-              case p: ParquetRelation => p.copy(partitioningAttributes = attrs)
+              case p: ParquetRelation => p.copy(partitioningAttributes = attrs, 
+                partitionValues = partVals)
             })
         }
       }
@@ -137,15 +138,15 @@ private[hive] trait HiveStrategies {
               pruningCondition(inputData)
             }
 
-            val partitionLocations = partitions.map(part =>
-              part.getLocation() + "->" + part.getName())
+            val partitionLocations = partitions.map(part => part.getLocation)
+            val partitionNames = partitions.map(part => part.getName)
 
             if (partitionLocations.isEmpty) {
               PhysicalRDD(plan.output, sparkContext.emptyRDD[Row]) :: Nil
             } else {
               hiveContext
                 .parquetFile(partitionLocations: _*)
-                .addPartitioningAttributes(relation.partitionKeys)
+                .addPartitioningAttributes(relation.partitionKeys, partitionNames.mkString(","))
                 .lowerCase
                 .where(unresolvedOtherPredicates)
                 .select(unresolvedProjection: _*)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -137,7 +137,8 @@ private[hive] trait HiveStrategies {
               pruningCondition(inputData)
             }
 
-            val partitionLocations = partitions.map(_.getLocation)
+            val partitionLocations = partitions.map(part =>
+              part.getLocation() + "->" + part.getName())
 
             if (partitionLocations.isEmpty) {
               PhysicalRDD(plan.output, sparkContext.emptyRDD[Row]) :: Nil


### PR DESCRIPTION
While parsing the partition keys from the locations, in parquetRelations, it is assumed that location path string will always contain the partition keys, which is not true. Different location can be specified while adding partitions to the table, which results in key not found exception while reading from such partitions:

Create a partitioned parquet table :
create table test_table (dummy string) partitioned by (timestamp bigint) stored as parquet;
Add a partition to the table and specify a different location:
alter table test_table add partition (timestamp=9) location '/data/pth/different'
Run a simple select \* query
we get an exception :
15/02/09 08:27:25 ERROR thriftserver.SparkSQLDriver: Failed in [select \* from db4_mi2mi_binsrc1_default limit 5]
org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 21.0 failed 1 times, most recent failure: Lost task 0.0 in stage 21.0 (TID 21, localhost): java
.util.NoSuchElementException: key not found: timestamp
at scala.collection.MapLike$class.default(MapLike.scala:228)
at scala.collection.AbstractMap.default(Map.scala:58)
at scala.collection.MapLike$class.apply(MapLike.scala:141)
at scala.collection.AbstractMap.apply(Map.scala:58)
at org.apache.spark.sql.parquet.ParquetTableScan$$anonfun$execute$4$$anonfun$6.apply(ParquetTableOperations.scala:141)
at org.apache.spark.sql.parquet.ParquetTableScan$$anonfun$execute$4$$anonfun$6.apply(ParquetTableOperations.scala:141)
at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:244)
at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:244)
at scala.collection.mutable.ResizableArray$class.foreach(ResizableArray.scala:59)
at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:47)
