### PR TITLE
[SPARK-5687][Core]TaskResultGetter needs to catch OutOfMemoryError.

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskResultGetter.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskResultGetter.scala
@@ -83,6 +83,9 @@ private[spark] class TaskResultGetter(sparkEnv: SparkEnv, scheduler: TaskSchedul
           case cnf: ClassNotFoundException =>
             val loader = Thread.currentThread.getContextClassLoader
             taskSetManager.abort("ClassNotFound with classloader: " + loader)
+          case ex: OutOfMemoryError =>
+            logError("Exception while getting task result", ex)
+            taskSetManager.abort("Exception while getting task result: %s".format(ex))
           // Matching NonFatal so we don't catch the ControlThrowable from the "return" above.
           case NonFatal(ex) =>
             logError("Exception while getting task result", ex)


### PR DESCRIPTION
because in enqueueSuccessfulTask there is another thread to fetch result, if result is large,it maybe throw a OutOfMemoryError. so if we donot catch OutOfMemoryError, DAGDAGScheduler donot know the status of this task.
@andrewor14
