### PR TITLE
[SPARK-5641] Allow spark_ec2.py to copy a wider range of files to cluster via deploy.generic

### DIFF
--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -38,6 +38,7 @@ import textwrap
 import time
 import urllib2
 import warnings
+import shutil
 from datetime import datetime
 from optparse import OptionParser
 from sys import stderr
@@ -889,6 +890,9 @@ def deploy_files(conn, root_dir, opts, master_nodes, slave_nodes, modules):
         template_vars["aws_access_key_id"] = ""
         template_vars["aws_secret_access_key"] = ""
 
+    # Note: It may be nicer to reverse logic and list supported substitutable types instead, but this is playing it safe.
+    non_substitutable = [".rpm", ".deb", ".7z", ".gz", ".tar", ".tgz", ".bz2", ".jar"]
+
     # Create a temp directory in which we will place all the files to be
     # deployed after we substitue template parameters in them
     tmp_dir = tempfile.mkdtemp()
@@ -902,13 +906,18 @@ def deploy_files(conn, root_dir, opts, master_nodes, slave_nodes, modules):
                 if filename[0] not in '#.~' and filename[-1] != '~':
                     dest_file = os.path.join(dest_dir, filename)
                     local_file = tmp_dir + dest_file
-                    with open(os.path.join(path, filename)) as src:
-                        with open(local_file, "w") as dest:
-                            text = src.read()
-                            for key in template_vars:
-                                text = text.replace("{{" + key + "}}", template_vars[key])
-                            dest.write(text)
-                            dest.close()
+                    if reduce(lambda x,y: x or y, map(lambda x: filename.endswith(x),non_substitutable)):
+                        # Just copy the file
+                        shutil.copyfile(os.path.join(path, filename),local_file)
+                    else:
+                        # Copy with substitution
+                        with open(os.path.join(path, filename)) as src:
+                            with open(local_file, "w") as dest:
+                                text = src.read()
+                                for key in template_vars:
+                                    text = text.replace("{{" + key + "}}", template_vars[key])
+                                dest.write(text)
+                                dest.close()
     # rsync the whole directory over to the master machine
     command = [
         'rsync', '-rv',

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -890,7 +890,8 @@ def deploy_files(conn, root_dir, opts, master_nodes, slave_nodes, modules):
         template_vars["aws_access_key_id"] = ""
         template_vars["aws_secret_access_key"] = ""
 
-    # Note: It may be nicer to reverse logic and list supported substitutable types instead, but this is playing it safe.
+    # Note: It may be nicer to reverse logic and list supported substitutable
+    # types instead, but this is playing it safe.
     non_substitutable = [".rpm", ".deb", ".7z", ".gz", ".tar", ".tgz", ".bz2", ".jar"]
 
     # Create a temp directory in which we will place all the files to be
@@ -906,9 +907,10 @@ def deploy_files(conn, root_dir, opts, master_nodes, slave_nodes, modules):
                 if filename[0] not in '#.~' and filename[-1] != '~':
                     dest_file = os.path.join(dest_dir, filename)
                     local_file = tmp_dir + dest_file
-                    if reduce(lambda x,y: x or y, map(lambda x: filename.endswith(x),non_substitutable)):
+                    if reduce(lambda x, y: x or y,
+                              map(lambda x: filename.endswith(x), non_substitutable)):
                         # Just copy the file
-                        shutil.copyfile(os.path.join(path, filename),local_file)
+                        shutil.copyfile(os.path.join(path, filename), local_file)
                     else:
                         # Copy with substitution
                         with open(os.path.join(path, filename)) as src:


### PR DESCRIPTION
Currently, deploy_files fails on binary files. This change fixes this for certain file extensions, thus allowing a greater range of files to be deployed to the cluster.  

This improvement is really useful if binary files need to be uploaded. E.g. I use this for rpm transfer to install extra stuff at cluster deployment time (I build or grab the rpms just prior and these rpms are not available externally - so this provides a convenient and secure way of delivering extra modules without code changes).

Note that it could also be used to override what's on the image (e.g. a jar) or to deliver a tar ball (e.g. if it's not on S3 - say, you built spark against a different hadoop or tachyon version)

To use this feature, a user can just dump the files into ec2/deploy.generic/ before calling spark_ec2.py.

Detecting binary files is non-trivial. So instead, the implementation has a list of file extensions that will trigger simple file copying.
