### PR TITLE
[SPARK-5706] [SQL] Add json schema inferring API

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -380,6 +380,11 @@ class SQLContext(@transient val sparkContext: SparkContext)
     jsonRDD(json.rdd, schema)
   }
 
+  @Experimental
+  def inferJsonSchema(json: String): StructType = {
+    JsonRDD.inferSchema(json, conf.columnNameOfCorruptRecord)
+  }
+
   /**
    * :: Experimental ::
    */
@@ -387,8 +392,7 @@ class SQLContext(@transient val sparkContext: SparkContext)
   def jsonRDD(json: RDD[String], samplingRatio: Double): DataFrame = {
     val columnNameOfCorruptJsonRecord = conf.columnNameOfCorruptRecord
     val appliedSchema =
-      JsonRDD.nullTypeToStringType(
-        JsonRDD.inferSchema(json, samplingRatio, columnNameOfCorruptJsonRecord))
+      JsonRDD.inferSchema(json, samplingRatio, columnNameOfCorruptJsonRecord)
     val rowRDD = JsonRDD.jsonStringToRow(json, appliedSchema, columnNameOfCorruptJsonRecord)
     applySchema(rowRDD, appliedSchema)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/json/JsonRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/json/JsonRDD.scala
@@ -54,6 +54,14 @@ private[sql] object JsonRDD extends Logging {
     createSchema(allKeys)
   }
 
+  private[sql] def inferSchema(json: String, columnNameOfCorruptRecords: String): StructType = {
+    val allKeys = 
+        parseJson(
+          new ObjectMapper(), 
+          columnNameOfCorruptRecords)(json).map(allKeysWithValueTypes).reduce(_ ++ _)
+    createSchema(allKeys)
+  }
+
   private def createSchema(allKeys: Set[(String, DataType)]): StructType = {
     // Resolve type conflicts
     val resolved = allKeys.groupBy {
@@ -127,7 +135,7 @@ private[sql] object JsonRDD extends Logging {
       StructType((topLevelFields ++ structFields).sortBy(_.name))
     }
 
-    makeStruct(resolved.keySet.toSeq, Nil)
+    nullTypeToStringType(makeStruct(resolved.keySet.toSeq, Nil))
   }
 
   private[sql] def nullTypeToStringType(struct: StructType): StructType = {
@@ -298,19 +306,23 @@ private[sql] object JsonRDD extends Logging {
       // the ObjectMapper will take the last value associated with this duplicate key.
       // For example: for {"key": 1, "key":2}, we will get "key"->2.
       val mapper = new ObjectMapper()
-      iter.flatMap { record =>
-        try {
-          val parsed = mapper.readValue(record, classOf[Object]) match {
-            case map: java.util.Map[_, _] => scalafy(map).asInstanceOf[Map[String, Any]] :: Nil
-            case list: java.util.List[_] => scalafy(list).asInstanceOf[Seq[Map[String, Any]]]
-          }
-
-          parsed
-        } catch {
-          case e: JsonProcessingException => Map(columnNameOfCorruptRecords -> record) :: Nil
-        }
-      }
+      iter.flatMap(parseJson(mapper, columnNameOfCorruptRecords))
     })
+  }
+
+  private def parseJson(
+      mapper: ObjectMapper,
+      columnNameOfCorruptRecords: String)(record: String): Seq[Map[String, Any]] = {
+    try {
+      val parsed = mapper.readValue(record, classOf[Object]) match {
+        case map: java.util.Map[_, _] => scalafy(map).asInstanceOf[Map[String, Any]] :: Nil
+        case list: java.util.List[_] => scalafy(list).asInstanceOf[Seq[Map[String, Any]]]
+      }
+
+      parsed
+    } catch {
+      case e: JsonProcessingException => Map(columnNameOfCorruptRecords -> record) :: Nil
+    }
   }
 
   private def toLong(value: Any): Long = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/json/JsonSuite.scala
@@ -243,32 +243,14 @@ class JsonSuite extends QueryTest {
     )
   }
 
+  test("Complex field and type inferring with single json row") {
+    assert(complexFieldAndType1Schema === inferJsonSchema(complexFieldAndType1Data))
+  }
+
   test("Complex field and type inferring") {
     val jsonDF = jsonRDD(complexFieldAndType1)
 
-    val expectedSchema = StructType(
-      StructField("arrayOfArray1", ArrayType(ArrayType(StringType, false), false), true) ::
-      StructField("arrayOfArray2", ArrayType(ArrayType(DoubleType, false), false), true) ::
-      StructField("arrayOfBigInteger", ArrayType(DecimalType.Unlimited, false), true) ::
-      StructField("arrayOfBoolean", ArrayType(BooleanType, false), true) ::
-      StructField("arrayOfDouble", ArrayType(DoubleType, false), true) ::
-      StructField("arrayOfInteger", ArrayType(IntegerType, false), true) ::
-      StructField("arrayOfLong", ArrayType(LongType, false), true) ::
-      StructField("arrayOfNull", ArrayType(StringType, true), true) ::
-      StructField("arrayOfString", ArrayType(StringType, false), true) ::
-      StructField("arrayOfStruct", ArrayType(
-        StructType(
-          StructField("field1", BooleanType, true) ::
-          StructField("field2", StringType, true) ::
-          StructField("field3", StringType, true) :: Nil), false), true) ::
-      StructField("struct", StructType(
-        StructField("field1", BooleanType, true) ::
-        StructField("field2", DecimalType.Unlimited, true) :: Nil), true) ::
-      StructField("structWithArrayFields", StructType(
-        StructField("field1", ArrayType(IntegerType, false), true) ::
-        StructField("field2", ArrayType(StringType, false), true) :: Nil), true) :: Nil)
-
-    assert(expectedSchema === jsonDF.schema)
+    assert(complexFieldAndType1Schema === jsonDF.schema)
 
     jsonDF.registerTempTable("jsonTable")
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/json/TestJsonData.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/json/TestJsonData.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.json
 
 import org.apache.spark.sql.test.TestSQLContext
+import org.apache.spark.sql.types._
 
 object TestJsonData {
 
@@ -76,9 +77,29 @@ object TestJsonData {
       """{"d":{"field":true}}""" ::
       """{"e":"str"}""" :: Nil)
 
-  val complexFieldAndType1 =
-    TestSQLContext.sparkContext.parallelize(
-      """{"struct":{"field1": true, "field2": 92233720368547758070},
+  val complexFieldAndType1Schema = StructType(
+      StructField("arrayOfArray1", ArrayType(ArrayType(StringType, false), false), true) ::
+      StructField("arrayOfArray2", ArrayType(ArrayType(DoubleType, false), false), true) ::
+      StructField("arrayOfBigInteger", ArrayType(DecimalType.Unlimited, false), true) ::
+      StructField("arrayOfBoolean", ArrayType(BooleanType, false), true) ::
+      StructField("arrayOfDouble", ArrayType(DoubleType, false), true) ::
+      StructField("arrayOfInteger", ArrayType(IntegerType, false), true) ::
+      StructField("arrayOfLong", ArrayType(LongType, false), true) ::
+      StructField("arrayOfNull", ArrayType(StringType, true), true) ::
+      StructField("arrayOfString", ArrayType(StringType, false), true) ::
+      StructField("arrayOfStruct", ArrayType(
+        StructType(
+          StructField("field1", BooleanType, true) ::
+          StructField("field2", StringType, true) ::
+          StructField("field3", StringType, true) :: Nil), false), true) ::
+      StructField("struct", StructType(
+        StructField("field1", BooleanType, true) ::
+        StructField("field2", DecimalType.Unlimited, true) :: Nil), true) ::
+      StructField("structWithArrayFields", StructType(
+        StructField("field1", ArrayType(IntegerType, false), true) ::
+        StructField("field2", ArrayType(StringType, false), true) :: Nil), true) :: Nil)
+
+  val complexFieldAndType1Data = """{"struct":{"field1": true, "field2": 92233720368547758070},
           "structWithArrayFields":{"field1":[4, 5, 6], "field2":["str1", "str2"]},
           "arrayOfString":["str1", "str2"],
           "arrayOfInteger":[1, 2147483647, -2147483648],
@@ -90,7 +111,10 @@ object TestJsonData {
           "arrayOfStruct":[{"field1": true, "field2": "str1"}, {"field1": false}, {"field3": null}],
           "arrayOfArray1":[[1, 2, 3], ["str1", "str2"]],
           "arrayOfArray2":[[1, 2, 3], [1.1, 2.1, 3.1]]
-         }"""  :: Nil)
+         }"""
+
+  val complexFieldAndType1 =
+    TestSQLContext.sparkContext.parallelize(complexFieldAndType1Data :: Nil)
 
   val complexFieldAndType2 =
     TestSQLContext.sparkContext.parallelize(


### PR DESCRIPTION
We need to provide json infer schema API instead of manually writing the json schema.

```
val completeJsonRecord = """{"struct":{"field1": true, "field2": 92233720368547758070},
           "structWithArrayFields":{"field1":[4, 5, 6], "field2":["str1", "str2"]},
           "arrayOfString":["str1", "str2"],
           "arrayOfInteger":[1, 2147483647, -2147483648],
           "arrayOfStruct":[{"field1": true, "field2": "str1"}, {"field1": false}, {"field3": null}],
           "arrayOfArray1":[[1, 2, 3], ["str1", "str2"]],
           "arrayOfArray2":[[1, 2, 3], [1.1, 2.1, 3.1]]
         }"""

val schema = sqlContext.inferJsonSchema(completeJsonRecord)
val jsonDF = sqlContext.jsonFile("/user/myjson", schema)
```
