### PR TITLE
SPARK-5727 [BUILD] Deprecate Debian packaging

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -232,7 +232,7 @@
                 <configuration>
                   <target>
                     <echo>
-                      NOTE: Debian packaging is deprecated and will be removed in a future release.
+                      NOTE: Debian packaging is deprecated and is scheduled to be removed in Spark 1.4.
                     </echo>
                   </target>
                 </configuration>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -222,6 +222,24 @@
       <build>
         <plugins>
           <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <echo>
+                      NOTE: Debian packaging is deprecated and will be removed in a future release.
+                    </echo>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>buildnumber-maven-plugin</artifactId>
             <version>1.2</version>

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -161,7 +161,7 @@ For help in setting up IntelliJ IDEA or Eclipse for Spark development, and troub
 
 # Building Spark Debian Packages
 
-_NOTE: Debian packaging is deprecated and will be removed in a future release._
+_NOTE: Debian packaging is deprecated and is scheduled to be removed in Spark 1.4._
 
 The Maven build includes support for building a Debian package containing the assembly 'fat-jar', PySpark, and the necessary scripts and configuration files. This can be created by specifying the following:
 

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -161,6 +161,8 @@ For help in setting up IntelliJ IDEA or Eclipse for Spark development, and troub
 
 # Building Spark Debian Packages
 
+_NOTE: Debian packaging is deprecated and will be removed in a future release._
+
 The Maven build includes support for building a Debian package containing the assembly 'fat-jar', PySpark, and the necessary scripts and configuration files. This can be created by specifying the following:
 
     mvn -Pdeb -DskipTests clean package


### PR DESCRIPTION
This just adds a deprecation message. It's intended for backporting to branch 1.3 but can go in master too, to be followed by another PR that removes it for 1.4.
