### PR TITLE
[SPARK-5738] [SQL] Reuse mutable row for each record at jsonStringToRow

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/json/JsonRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/json/JsonRDD.scala
@@ -405,7 +405,8 @@ private[sql] object JsonRDD extends Logging {
     }
   }
 
-  private[json] def enforceCorrectType(value: Any, desiredType: DataType, slot: Any = null): Any ={
+  private[json] def enforceCorrectType(
+    value: Any, desiredType: DataType, slot: Any = null): Any = {
     if (value == null) {
       null
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/json/JsonRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/json/JsonRDD.scala
@@ -425,7 +425,9 @@ private[sql] object JsonRDD extends Logging {
           } else {
             slot.asInstanceOf[Seq[Any]]
           }
-          value.asInstanceOf[Seq[Any]].zip(arraySlot).map{case (v, s) => enforceCorrectType(v, elementType,s)}
+          value.asInstanceOf[Seq[Any]].zip(arraySlot).map {
+            case (v, s) => enforceCorrectType(v, elementType,s)
+          }
         }
         case struct: StructType => 
           asRow(value.asInstanceOf[Map[String, Any]], struct, slot.asInstanceOf[GenericMutableRow])


### PR DESCRIPTION
When serialize json string to row, reuse a mutable row for both each record and inner nested structure instead of creating a new one each time.
