### PR TITLE
[SPARK-5736][Web UI]Add executor log url to Executors page on Yarn

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -43,7 +43,8 @@ private[spark] class Executor(
     executorId: String,
     executorHostname: String,
     env: SparkEnv,
-    isLocal: Boolean = false)
+    isLocal: Boolean = false,
+    executorLogUrl: String = "")
   extends Logging
 {
 
@@ -79,6 +80,7 @@ private[spark] class Executor(
 
   if (!isLocal) {
     env.metricsSystem.registerSource(executorSource)
+    env.blockManager.setExecutorLogUrl(executorLogUrl)
     env.blockManager.initialize(conf.getAppId)
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
@@ -80,7 +80,11 @@ case class SparkListenerEnvironmentUpdate(environmentDetails: Map[String, Seq[(S
   extends SparkListenerEvent
 
 @DeveloperApi
-case class SparkListenerBlockManagerAdded(time: Long, blockManagerId: BlockManagerId, maxMem: Long)
+case class SparkListenerBlockManagerAdded(
+    time: Long, 
+    blockManagerId: BlockManagerId, 
+    maxMem: Long,
+    executorLogUrl: String = "")
   extends SparkListenerEvent
 
 @DeveloperApi

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMaster.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMaster.scala
@@ -46,9 +46,13 @@ class BlockManagerMaster(
   }
 
   /** Register the BlockManager's id with the driver. */
-  def registerBlockManager(blockManagerId: BlockManagerId, maxMemSize: Long, slaveActor: ActorRef) {
+  def registerBlockManager(
+      blockManagerId: BlockManagerId,
+      maxMemSize: Long,
+      slaveActor: ActorRef,
+      executorLogUrl: String) {
     logInfo("Trying to register BlockManager")
-    tell(RegisterBlockManager(blockManagerId, maxMemSize, slaveActor))
+    tell(RegisterBlockManager(blockManagerId, maxMemSize, slaveActor, executorLogUrl))
     logInfo("Registered BlockManager")
   }
 

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterActor.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterActor.scala
@@ -66,8 +66,8 @@ class BlockManagerMasterActor(val isLocal: Boolean, conf: SparkConf, listenerBus
   }
 
   override def receiveWithLogging = {
-    case RegisterBlockManager(blockManagerId, maxMemSize, slaveActor) =>
-      register(blockManagerId, maxMemSize, slaveActor)
+    case RegisterBlockManager(blockManagerId, maxMemSize, slaveActor, executoLogUrl) =>
+      register(blockManagerId, maxMemSize, slaveActor, executoLogUrl)
       sender ! true
 
     case UpdateBlockInfo(
@@ -325,7 +325,11 @@ class BlockManagerMasterActor(val isLocal: Boolean, conf: SparkConf, listenerBus
     ).map(_.flatten.toSeq)
   }
 
-  private def register(id: BlockManagerId, maxMemSize: Long, slaveActor: ActorRef) {
+  private def register(
+      id: BlockManagerId,
+      maxMemSize: Long,
+      slaveActor: ActorRef,
+      executorLogUrl: String) {
     val time = System.currentTimeMillis()
     if (!blockManagerInfo.contains(id)) {
       blockManagerIdByExecutor.get(id.executorId) match {
@@ -344,7 +348,7 @@ class BlockManagerMasterActor(val isLocal: Boolean, conf: SparkConf, listenerBus
       blockManagerInfo(id) = new BlockManagerInfo(
         id, System.currentTimeMillis(), maxMemSize, slaveActor)
     }
-    listenerBus.post(SparkListenerBlockManagerAdded(time, id, maxMemSize))
+    listenerBus.post(SparkListenerBlockManagerAdded(time, id, maxMemSize, executorLogUrl))
   }
 
   private def updateBlockInfo(

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMessages.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMessages.scala
@@ -52,7 +52,8 @@ private[spark] object BlockManagerMessages {
   case class RegisterBlockManager(
       blockManagerId: BlockManagerId,
       maxMemSize: Long,
-      sender: ActorRef)
+      sender: ActorRef,
+      executoLogUrl: String)
     extends ToBlockManagerMaster
 
   case class UpdateBlockInfo(

--- a/core/src/main/scala/org/apache/spark/storage/StorageStatusListener.scala
+++ b/core/src/main/scala/org/apache/spark/storage/StorageStatusListener.scala
@@ -76,7 +76,8 @@ class StorageStatusListener extends SparkListener {
       val blockManagerId = blockManagerAdded.blockManagerId
       val executorId = blockManagerId.executorId
       val maxMem = blockManagerAdded.maxMem
-      val storageStatus = new StorageStatus(blockManagerId, maxMem)
+      val executorLogUrl = blockManagerAdded.executorLogUrl
+      val storageStatus = new StorageStatus(blockManagerId, maxMem, executorLogUrl)
       executorIdToStorageStatus(executorId) = storageStatus
     }
   }

--- a/core/src/main/scala/org/apache/spark/storage/StorageUtils.scala
+++ b/core/src/main/scala/org/apache/spark/storage/StorageUtils.scala
@@ -30,7 +30,10 @@ import org.apache.spark.annotation.DeveloperApi
  * class cannot mutate the source of the information. Accesses are not thread-safe.
  */
 @DeveloperApi
-class StorageStatus(val blockManagerId: BlockManagerId, val maxMem: Long) {
+class StorageStatus(
+    val blockManagerId: BlockManagerId,
+    val maxMem: Long, 
+    val executorLogUrl: String = "") {
 
   /**
    * Internal representation of the blocks stored in this block manager.

--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsPage.scala
@@ -40,7 +40,8 @@ private case class ExecutorSummaryInfo(
     totalInputBytes: Long,
     totalShuffleRead: Long,
     totalShuffleWrite: Long,
-    maxMemory: Long)
+    maxMemory: Long,
+    executorLogUrl: String)
 
 private[ui] class ExecutorsPage(
     parent: ExecutorsTab,
@@ -80,6 +81,7 @@ private[ui] class ExecutorsPage(
             </span>
           </th>
           {if (threadDumpEnabled) <th class="sorttable_nosort">Thread Dump</th> else Seq.empty}
+          <th>Log</th>
         </thead>
         <tbody>
           {execInfoSorted.map(execRow)}
@@ -148,6 +150,9 @@ private[ui] class ExecutorsPage(
           Seq.empty
         }
       }
+      <td>
+        <a href={info.executorLogUrl}>Log</a>
+      </td>
     </tr>
   }
 
@@ -168,6 +173,7 @@ private[ui] class ExecutorsPage(
     val totalInputBytes = listener.executorToInputBytes.getOrElse(execId, 0L)
     val totalShuffleRead = listener.executorToShuffleRead.getOrElse(execId, 0L)
     val totalShuffleWrite = listener.executorToShuffleWrite.getOrElse(execId, 0L)
+    val executorLogUrl = status.executorLogUrl
 
     new ExecutorSummaryInfo(
       execId,
@@ -183,7 +189,8 @@ private[ui] class ExecutorsPage(
       totalInputBytes,
       totalShuffleRead,
       totalShuffleWrite,
-      maxMem
+      maxMem,
+      executorLogUrl
     )
   }
 }


### PR DESCRIPTION
Currently, there is not executor log url in spark ui (on Yarn), we have to read executor log by login the machine that executor in. I think we should add executor log url to executors pages.
