### PR TITLE
[IDE] cannot import src/main/scala & src/test/scala into eclipse as sour...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1097,6 +1097,12 @@
           <version>3.2.0</version>
           <executions>
             <execution>
+              <id>eclipse-add-source</id>
+              <goals>
+                <goal>add-source</goal>
+              </goals>
+            </execution>
+            <execution>
               <id>scala-compile-first</id>
               <phase>process-resources</phase>
               <goals>


### PR DESCRIPTION
...ce folder

   When import the whole project into eclipse as maven project, found that the
   src/main/scala & src/test/scala can not be set as source folder as default
   behavior, so add a "add-source" goal in scala-maven-plugin to let this work.
