### PR TITLE
[SPARK-5764]  Delete the cache and lock file after executor fetching the jar

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -433,6 +433,13 @@ private[spark] object Utils extends Logging {
         targetFile,
         conf.getBoolean("spark.files.overwrite", false)
       )
+
+      if(cachedFile.exists()) {
+        cachedFile.delete()
+      }
+      if(lockFile.exists()) {
+        lockFile.delete()
+      }
     } else {
       doFetchFile(url, targetDir, fileName, conf, securityMgr, hadoopConf)
     }


### PR DESCRIPTION
Every time while executor fetching a jar from httpserver,  a lock file and a cache file will be created on the local. After fetching, this two files will be useless.
And when the jar package is big, the cache file also be big. it wates the disk space. 
