### PR TITLE
[SPARK-5756][SQL] Analyzer should not throw scala.NotImplementedError for illegitimate sql

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
@@ -121,7 +121,7 @@ case class Alias(child: Expression, name: String)
     }
   }
 
-  override def toString: String = s"$child AS $name#${exprId.id}$typeSuffix"
+  override def toString: String = s"$child AS $name#${exprId.id}"
 
   override protected final def otherCopyArgs = exprId :: qualifiers :: Nil
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -27,7 +27,7 @@ import scala.util.Try
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars
 
 import org.apache.spark.{SparkFiles, SparkException}
-import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
 import org.apache.spark.sql.catalyst.plans.logical.Project
 import org.apache.spark.sql.Dsl._
 import org.apache.spark.sql.hive._
@@ -572,6 +572,12 @@ class HiveQuerySuite extends HiveComparisonTest with BeforeAndAfter {
     assertResult(Array(Row(2, "str2"))) {
       sql("SELECT tablealias.A, TABLEALIAS.b FROM reGisteredTABle TableAlias " +
         "WHERE TableAliaS.a > 1").collect()
+    }
+  }
+
+  test("analyzer should not throw NotImplementedError") {
+    intercept[AnalysisException] {
+      sql("SELECT CAST(x AS STRING) FROM src").collect()
     }
   }
 


### PR DESCRIPTION
`SELECT CAST(x AS STRING) FROM src`  comes a NotImplementedError:

 CliDriver: scala.NotImplementedError: an implementation is missing
        at scala.Predef$.$qmark$qmark$qmark(Predef.scala:252)
        at org.apache.spark.sql.catalyst.expressions.PrettyAttribute.dataType(namedExpressions.scala:221)
        at org.apache.spark.sql.catalyst.expressions.Cast.resolved$lzycompute(Cast.scala:30)
        at org.apache.spark.sql.catalyst.expressions.Cast.resolved(Cast.scala:30)
        at org.apache.spark.sql.catalyst.expressions.Expression$$anonfun$childrenResolved$1.apply(Expression.scala:68)
        at org.apache.spark.sql.catalyst.expressions.Expression$$anonfun$childrenResolved$1.apply(Expression.scala:68)
        at scala.collection.LinearSeqOptimized$class.exists(LinearSeqOptimized.scala:80)
        at scala.collection.immutable.List.exists(List.scala:84)
        at org.apache.spark.sql.catalyst.expressions.Expression.childrenResolved(Expression.scala:68)
        at org.apache.spark.sql.catalyst.expressions.Expression.resolved$lzycompute(Expression.scala:56)
        at org.apache.spark.sql.catalyst.expressions.Expression.resolved(Expression.scala:56)
        at org.apache.spark.sql.catalyst.expressions.NamedExpression.typeSuffix(namedExpressions.scala:62)
        at org.apache.spark.sql.catalyst.expressions.Alias.toString(namedExpressions.scala:124)
        at org.apache.spark.sql.catalyst.expressions.Expression.prettyString(Expression.scala:78)
        at org.apache.spark.sql.catalyst.analysis.Analyzer$CheckResolution$$anonfun$1$$anonfun$7.apply(Analyzer.scala:83)
        at org.apache.spark.sql.catalyst.analysis.Analyzer$CheckResolution$$anonfun$1$$anonfun$7.apply(Analyzer.scala:83)
        at scala.collection.immutable.Stream.map(Stream.scala:376)
        at org.apache.spark.sql.catalyst.analysis.Analyzer$CheckResolution$$anonfun$1.applyOrElse(Analyzer.scala:83)
        at org.apache.spark.sql.catalyst.analysis.Analyzer$CheckResolution$$anonfun$1.applyOrElse(Analyzer.scala:81)
        at org.apache.spark.sql.catalyst.trees.TreeNode.transformUp(TreeNode.scala:204)
        at org.apache.spark.sql.catalyst.analysis.Analyzer$CheckResolution$.apply(Analyzer.scala:81)
        at org.apache.spark.sql.catalyst.analysis.Analyzer$CheckResolution$.apply(Analyzer.scala:79)
