### PR TITLE
[SPARK-5759][Yarn]ExecutorRunnable should catch YarnException while NMClient start contain...

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
@@ -35,11 +35,10 @@ import org.apache.hadoop.yarn.api._
 import org.apache.hadoop.yarn.api.records._
 import org.apache.hadoop.yarn.client.api.NMClient
 import org.apache.hadoop.yarn.conf.YarnConfiguration
-import org.apache.hadoop.yarn.exceptions.YarnException
 import org.apache.hadoop.yarn.ipc.YarnRPC
 import org.apache.hadoop.yarn.util.{ConverterUtils, Records}
 
-import org.apache.spark.{SecurityManager, SparkConf, Logging}
+import org.apache.spark.{SparkException, SecurityManager, SparkConf, Logging}
 import org.apache.spark.network.util.JavaUtils
 
 class ExecutorRunnable(
@@ -113,10 +112,9 @@ class ExecutorRunnable(
     try {
       nmClient.startContainer(container, ctx)
     } catch {
-      case ex: YarnException =>
-        logError("Exception while start container %s on host %s:"
-          .format(container.getId, hostname), ex)
-        throw ex
+      case ex: Exception =>
+        throw new SparkException("Exception while starting container ${container.getId}" +
+          " on host $hostname", ex)
     }
   }
 

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
@@ -35,6 +35,7 @@ import org.apache.hadoop.yarn.api._
 import org.apache.hadoop.yarn.api.records._
 import org.apache.hadoop.yarn.client.api.NMClient
 import org.apache.hadoop.yarn.conf.YarnConfiguration
+import org.apache.hadoop.yarn.exceptions.YarnException
 import org.apache.hadoop.yarn.ipc.YarnRPC
 import org.apache.hadoop.yarn.util.{ConverterUtils, Records}
 
@@ -109,7 +110,14 @@ class ExecutorRunnable(
     }
 
     // Send the start request to the ContainerManager
-    nmClient.startContainer(container, ctx)
+    try {
+      nmClient.startContainer(container, ctx)
+    } catch {
+      case ex: YarnException =>
+        logError("Exception while start container %s on host %s:"
+          .format(container.getId, hostname), ex)
+        throw ex
+    }
   }
 
   private def prepareCommand(


### PR DESCRIPTION
some time since some reasons, it lead to some exception while NMClient start some containers.example:we do not config spark_shuffle on some machines, so it will throw a exception:
java.lang.Error: org.apache.hadoop.yarn.exceptions.InvalidAuxServiceException: The auxService:spark_shuffle does not exist.
because YarnAllocator use ThreadPoolExecutor to start Container, so we can not find which container or hostname throw exception. I think we should catch YarnException in ExecutorRunnable when start container. if there are some exceptions, we can know the container id or hostname of failed container.
