### PR TITLE
[SPARK-5852] [SQL] Passdown the schema for Parquet File in HiveContext

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -212,8 +212,7 @@ private[hive] class HiveMetastoreCatalog(hive: HiveContext) extends Catalog with
           Some(partitionSpec))(hive))
     } else {
       val paths = Seq(metastoreRelation.hiveQlTable.getDataLocation.toString)
-      LogicalRelation(
-        ParquetRelation2(
+      LogicalRelation(ParquetRelation2(
           paths,
           Map(ParquetRelation2.METASTORE_SCHEMA -> metastoreSchema.json),
           Some(metastoreSchema))(hive))

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -208,14 +208,15 @@ private[hive] class HiveMetastoreCatalog(hive: HiveContext) extends Catalog with
         ParquetRelation2(
           paths,
           Map(ParquetRelation2.METASTORE_SCHEMA -> metastoreSchema.json),
-          None,
+          Some(metastoreSchema),
           Some(partitionSpec))(hive))
     } else {
       val paths = Seq(metastoreRelation.hiveQlTable.getDataLocation.toString)
       LogicalRelation(
         ParquetRelation2(
           paths,
-          Map(ParquetRelation2.METASTORE_SCHEMA -> metastoreSchema.json))(hive))
+          Map(ParquetRelation2.METASTORE_SCHEMA -> metastoreSchema.json),
+          Some(metastoreSchema))(hive))
     }
   }
 


### PR DESCRIPTION
It's not allowed to be the empty directory for parquet, for example, it will failed when query the following

```
CREATE TABLE parquet_test (id int, str string) STORED AS PARQUET;
SELECT * FROM parquet_test;
```

It throws exception like:

```
java.lang.UnsupportedOperationException: empty.reduceLeft
    at scala.collection.TraversableOnce$class.reduceLeft(TraversableOnce.scala:167)
    at scala.collection.mutable.ArrayBuffer.scala$collection$IndexedSeqOptimized$$super$reduceLeft(ArrayBuffer.scala:47)
    at scala.collection.IndexedSeqOptimized$class.reduceLeft(IndexedSeqOptimized.scala:68)
    at scala.collection.mutable.ArrayBuffer.reduceLeft(ArrayBuffer.scala:47)
    at scala.collection.TraversableOnce$class.reduce(TraversableOnce.scala:195)
    at scala.collection.AbstractTraversable.reduce(Traversable.scala:105)
    at org.apache.spark.sql.parquet.ParquetRelation2$.readSchema(newParquet.scala:633)
    at org.apache.spark.sql.parquet.ParquetRelation2$MetadataCache.org$apache$spark$sql$parquet$ParquetRelation2$MetadataCache$$readSchema(newParquet.scala:349)
    at org.apache.spark.sql.parquet.ParquetRelation2$MetadataCache$$anonfun$refresh$8.apply(newParquet.scala:290)
    at org.apache.spark.sql.parquet.ParquetRelation2$MetadataCache$$anonfun$refresh$8.apply(newParquet.scala:290)
    at scala.Option.getOrElse(Option.scala:120)
    at org.apache.spark.sql.parquet.ParquetRelation2$MetadataCache.refresh(newParquet.scala:290)
    at org.apache.spark.sql.parquet.ParquetRelation2.<init>(newParquet.scala:354)
    at org.apache.spark.sql.hive.HiveMetastoreCatalog.org$apache$spark$sql$hive$HiveMetastoreCatalog$$convertToParquetRelation(HiveMetastoreCatalog.scala:218)
    at org.apache.spark.sql.hive.HiveMetastoreCatalog$ParquetConversions$$anonfun$apply$4.apply(HiveMetastoreCatalog.scala:446)
    at org.apache.spark.sql.hive.HiveMetastoreCatalog$ParquetConversions$$anonfun$apply$4.apply(HiveMetastoreCatalog.scala:445)
    at scala.collection.IndexedSeqOptimized$class.foldl(IndexedSeqOptimized.scala:51)
    at scala.collection.IndexedSeqOptimized$class.foldLeft(IndexedSeqOptimized.scala:60)
    at scala.collection.mutable.ArrayBuffer.foldLeft(ArrayBuffer.scala:47)
    at org.apache.spark.sql.hive.HiveMetastoreCatalog$ParquetConversions$.apply(HiveMetastoreCatalog.scala:445)
    at org.apache.spark.sql.hive.HiveMetastoreCatalog$ParquetConversions$.apply(HiveMetastoreCatalog.scala:422)
    at org.apache.spark.sql.catalyst.rules.RuleExecutor$$anonfun$apply$1$$anonfun$apply$2.apply(RuleExecutor.scala:61)
    at org.apache.spark.sql.catalyst.rules.RuleExecutor$$anonfun$apply$1$$anonfun$apply$2.apply(RuleExecutor.scala:59)
    at scala.collection.LinearSeqOptimized$class.foldLeft(LinearSeqOptimized.scala:111)
    at scala.collection.immutable.List.foldLeft(List.scala:84)
    at org.apache.spark.sql.catalyst.rules.RuleExecutor$$anonfun$apply$1.apply(RuleExecutor.scala:59)
    at org.apache.spark.sql.catalyst.rules.RuleExecutor$$anonfun$apply$1.apply(RuleExecutor.scala:51)
    at scala.collection.immutable.List.foreach(List.scala:318)
    at org.apache.spark.sql.catalyst.rules.RuleExecutor.apply(RuleExecutor.scala:51)
    at org.apache.spark.sql.SQLContext$QueryExecution.analyzed$lzycompute(SQLContext.scala:917)
    at org.apache.spark.sql.SQLContext$QueryExecution.analyzed(SQLContext.scala:917)
    at org.apache.spark.sql.DataFrameImpl.<init>(DataFrameImpl.scala:61)
    at org.apache.spark.sql.DataFrame$.apply(DataFrame.scala:35)
    at org.apache.spark.sql.hive.HiveContext.sql(HiveContext.scala:77)
    at org.apache.spark.sql.hive.thriftserver.AbstractSparkSQLDriver.run(AbstractSparkSQLDriver.scala:57)
    at org.apache.spark.sql.hive.thriftserver.SparkSQLCLIDriver.processCmd(SparkSQLCLIDriver.scala:275)
    at org.apache.hadoop.hive.cli.CliDriver.processLine(CliDriver.java:423)
    at org.apache.spark.sql.hive.thriftserver.SparkSQLCLIDriver$.main(SparkSQLCLIDriver.scala:211)
    at org.apache.spark.sql.hive.thriftserver.SparkSQLCLIDriver.main(SparkSQLCLIDriver.scala)
```
