### PR TITLE
ignore cache paths for RAT tests

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -1,4 +1,5 @@
 target
+cache
 .gitignore
 .gitattributes
 .project


### PR DESCRIPTION
RAT fails on cache paths. add to .rat-excludes
