### PR TITLE
[SPARK-2774] Set preferred locations for reduce tasks

### DIFF
--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -301,7 +301,10 @@ private[spark] class MapOutputTrackerMaster(conf: SparkConf)
   // of (location, size) of map outputs.
   //
   // This method is not thread-safe
-  def getStatusByReducer(shuffleId: Int, numReducers: Int): Option[Map[Int, Array[(BlockManagerId, Long)]]] = {
+  def getStatusByReducer(
+      shuffleId: Int,
+      numReducers: Int)
+    : Option[Map[Int, Array[(BlockManagerId, Long)]]] = {
     if (!statusByReducer.contains(shuffleId) && mapStatuses.contains(shuffleId)) {
       val statuses = mapStatuses(shuffleId)
       if (statuses.length > 0) {

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -39,6 +39,7 @@ import org.apache.spark.partial.{ApproximateActionListener, ApproximateEvaluator
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage._
 import org.apache.spark.util._
+import org.apache.spark.util.collection.{Utils => CollectionUtils}
 import org.apache.spark.storage.BlockManagerMessages.BlockManagerHeartbeat
 
 /**
@@ -127,6 +128,15 @@ class DAGScheduler(
   taskScheduler.setDAGScheduler(this)
 
   private val outputCommitCoordinator = env.outputCommitCoordinator
+
+  // Number of map, reduce tasks above which we do not assign preferred locations
+  // based on map output sizes.
+  private val SHUFFLE_PREF_MAP_THRESHOLD = 1000
+  // NOTE: This should be less than 2000 as we use HighlyCompressedMapStatus beyond that
+  private val SHUFFLE_PREF_REDUCE_THRESHOLD = 1000
+  // Number of preferred locations to use for reducer tasks
+  private[scheduler] val NUM_REDUCER_PREF_LOCS = 5
+
 
   // Called by TaskScheduler to report task's starting.
   def taskStarted(task: Task[_], taskInfo: TaskInfo) {
@@ -1295,7 +1305,7 @@ class DAGScheduler(
   {
     // If the partition has already been visited, no need to re-visit.
     // This avoids exponential path exploration.  SPARK-695
-    if (!visited.add((rdd,partition))) {
+    if (!visited.add((rdd, partition))) {
       // Nil has already been returned for previously visited partitions.
       return Nil
     }
@@ -1320,6 +1330,22 @@ class DAGScheduler(
             return locs
           }
         }
+      case s: ShuffleDependency[_, _, _] =>
+        if (rdd.partitions.size < SHUFFLE_PREF_REDUCE_THRESHOLD &&
+            s.rdd.partitions.size < SHUFFLE_PREF_MAP_THRESHOLD) {
+          // Assign preferred locations for reducers by looking at map output location and sizes
+          val mapStatuses = mapOutputTracker.getStatusByReducer(s.shuffleId, rdd.partitions.size)
+          mapStatuses.map { status =>
+            // Get the map output locations for this reducer
+            if (status.contains(partition)) {
+              // Select first few locations as preferred locations for the reducer
+              val topLocs = CollectionUtils.takeOrdered(status(partition).iterator,
+                NUM_REDUCER_PREF_LOCS)(Ordering.by[(BlockManagerId, Long), Long](_._2).reverse).toSeq
+              return topLocs.map(_._1).map(loc => TaskLocation(loc.host, loc.executorId))
+            }
+          }
+        }
+
       case _ =>
     }
     Nil

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1340,8 +1340,8 @@ class DAGScheduler(
             if (status.contains(partition)) {
               // Select first few locations as preferred locations for the reducer
               val topLocs = CollectionUtils.takeOrdered(
-                status(partition).iterator, NUM_REDUCER_PREF_LOCS)
-                  (Ordering.by[(BlockManagerId, Long), Long](_._2).reverse).toSeq
+                status(partition).iterator, NUM_REDUCER_PREF_LOCS)(
+                  Ordering.by[(BlockManagerId, Long), Long](_._2).reverse).toSeq
               return topLocs.map(_._1).map(loc => TaskLocation(loc.host, loc.executorId))
             }
           }

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1339,8 +1339,9 @@ class DAGScheduler(
             // Get the map output locations for this reducer
             if (status.contains(partition)) {
               // Select first few locations as preferred locations for the reducer
-              val topLocs = CollectionUtils.takeOrdered(status(partition).iterator,
-                NUM_REDUCER_PREF_LOCS)(Ordering.by[(BlockManagerId, Long), Long](_._2).reverse).toSeq
+              val topLocs = CollectionUtils.takeOrdered(
+                status(partition).iterator, NUM_REDUCER_PREF_LOCS)
+                  (Ordering.by[(BlockManagerId, Long), Long](_._2).reverse).toSeq
               return topLocs.map(_._1).map(loc => TaskLocation(loc.host, loc.executorId))
             }
           }


### PR DESCRIPTION
This is another attempt at #1697 addressing some of the earlier concerns.
This adds a couple of thresholds based on number map and reduce tasks beyond which we don't use preferred locations for reduce tasks.

This patch also fixes some bugs in DAGSchedulerSuite where the MapStatus objects created didn't have the right number of reducers set.

cc @JoshRosen @rxin @pwendell 
