### PR TITLE
SPARK-5744 [CORE] RDD.isEmpty / take fails for (empty) RDD of Nothing

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -551,7 +551,11 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
    */
   def parallelize[T: ClassTag](seq: Seq[T], numSlices: Int = defaultParallelism): RDD[T] = {
     assertNotStopped()
-    new ParallelCollectionRDD[T](this, seq, numSlices, Map[Int, Seq[String]]())
+    if (seq.isEmpty) {
+      new EmptyRDD[T](this, numSlices)
+    } else {
+      new ParallelCollectionRDD[T](this, seq, numSlices, Map[Int, Seq[String]]())
+    }
   }
 
   /** Distribute a local Scala collection to form an RDD.

--- a/core/src/main/scala/org/apache/spark/rdd/DoubleRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/DoubleRDDFunctions.scala
@@ -213,7 +213,14 @@ class DoubleRDDFunctions(self: RDD[Double]) extends Logging with Serializable {
     } else {
       basicBucketFunction _
     }
-    self.mapPartitions(histogramPartition(bucketFunction)).reduce(mergeCounters)
+    if (self.partitions.length > 0) {
+      // reduce() requires a non-empty RDD. This works because the mapPartitions will make
+      // non-empty partitions out of empty ones. But it doesn't handle the no-partitions case,
+      // which is below
+      self.mapPartitions(histogramPartition(bucketFunction)).reduce(mergeCounters)
+    } else {
+      new Array[Long](buckets.length - 1)
+    }
   }
 
 }

--- a/core/src/main/scala/org/apache/spark/rdd/EmptyRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/EmptyRDD.scala
@@ -23,12 +23,27 @@ import org.apache.spark.{Partition, SparkContext, TaskContext}
 
 /**
  * An RDD that has no partitions and no elements.
+ *
+ * @param numPartitions optional number of (empty) partitions within the empty RDD
  */
-private[spark] class EmptyRDD[T: ClassTag](sc: SparkContext) extends RDD[T](sc, Nil) {
+private[spark] class EmptyRDD[T: ClassTag](sc: SparkContext, numPartitions: Int = 0)
+  extends RDD[T](sc, Nil) {
 
-  override def getPartitions: Array[Partition] = Array.empty
+  override def getPartitions: Array[Partition] =
+    Array.tabulate(numPartitions)(index => new EmptyPartition(index))
 
   override def compute(split: Partition, context: TaskContext): Iterator[T] = {
-    throw new UnsupportedOperationException("empty RDD")
+    Iterator.empty
   }
+}
+
+private[spark] class EmptyPartition(val index: Int) extends Partition {
+
+  // hashCode defined in parent
+
+  override def equals(other: Any): Boolean = other match {
+    case ep: EmptyPartition => ep.index == this.index
+    case _ => false
+  }
+
 }

--- a/core/src/test/scala/org/apache/spark/rdd/DoubleRDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/DoubleRDDSuite.scala
@@ -26,13 +26,14 @@ class DoubleRDDSuite extends FunSuite with SharedSparkContext {
   // and non-evenly spaced buckets as the bucket lookup function changes.
   test("WorksOnEmpty") {
     // Make sure that it works on an empty input
-    val rdd: RDD[Double] = sc.parallelize(Seq())
     val buckets = Array(0.0, 10.0)
-    val histogramResults = rdd.histogram(buckets)
-    val histogramResults2 = rdd.histogram(buckets, true)
     val expectedHistogramResults = Array(0)
-    assert(histogramResults === expectedHistogramResults)
-    assert(histogramResults2 === expectedHistogramResults)
+    val rddParSeq: RDD[Double] = sc.parallelize(Seq())
+    assert(rddParSeq.histogram(buckets) === expectedHistogramResults)
+    assert(rddParSeq.histogram(buckets, true) === expectedHistogramResults)
+    val emptyRDD: RDD[Double] = sc.emptyRDD
+    assert(emptyRDD.histogram(buckets) === expectedHistogramResults)
+    assert(emptyRDD.histogram(buckets, true) === expectedHistogramResults)
   }
 
   test("WorksWithOutOfRangeWithOneBucket") {

--- a/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
@@ -202,6 +202,7 @@ class RDDSuite extends FunSuite with SharedSparkContext {
     val empty = new EmptyRDD[Int](sc)
     assert(empty.count === 0)
     assert(empty.collect().size === 0)
+    assert(empty.partitions.length === 0)
 
     val thrown = intercept[UnsupportedOperationException]{
       empty.reduce(_+_)
@@ -520,6 +521,10 @@ class RDDSuite extends FunSuite with SharedSparkContext {
     assert(nums.take(501) === (1 to 501).toArray)
     assert(nums.take(999) === (1 to 999).toArray)
     assert(nums.take(1000) === (1 to 999).toArray)
+
+    // SPARK-5744:
+    assert(sc.makeRDD(Seq(), 0).take(1).size === 0)
+    assert(sc.makeRDD(Seq[Int]()).take(1).size === 0)
   }
 
   test("top with predefined ordering") {
@@ -567,6 +572,8 @@ class RDDSuite extends FunSuite with SharedSparkContext {
   test("isEmpty") {
     assert(sc.emptyRDD.isEmpty())
     assert(sc.parallelize(Seq[Int]()).isEmpty())
+    // SPARK-5744:
+    assert(sc.parallelize(Seq(), 0).isEmpty())
     assert(!sc.parallelize(Seq(1)).isEmpty())
     assert(sc.parallelize(Seq(1,2,3), 3).filter(_ < 0).isEmpty())
     assert(!sc.parallelize(Seq(1,2,3), 3).filter(_ > 1).isEmpty())

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -1174,6 +1174,8 @@ class RDD(object):
         [2, 3, 4, 5, 6]
         >>> sc.parallelize(range(100), 100).filter(lambda x: x > 90).take(3)
         [91, 92, 93]
+        >>> sc.parallelize([]).take(1)
+        []
         """
         items = []
         totalParts = self._jrdd.partitions().size()


### PR DESCRIPTION
Handle `take`, `isEmpty` for `parallelize(Seq())`.
As a knock-on effect of that fix: correctly handle 0 partitions in `histogram`. 
Plus tests.
