### PR TITLE
[SPARK-5363] [PySpark] check ending mark in non-block way

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -155,13 +155,13 @@ private[spark] class PythonRDD(
                   if (ending == SpecialLengths.END_OF_STREAM) {
                     env.releasePythonWorker(pythonExec, envVars.toMap, worker)
                     released = true
-                    logInfo(s"Socket is ended cleanly, reuse it: $worker")
+                    logInfo(s"Communication with worker ended cleanly, re-use it: $worker")
                   } else {
-                    logInfo(s"Socket is not ended cleanly (ending with $ending), " +
+                    logInfo(s"Communication with worker did not end cleanly (ending with $ending), " +
                       s"close it: $worker")
                   }
                 } else {
-                  logInfo(s"The ending mark is not available, close it: $worker")
+                  logInfo(s"The ending mark from worker is not available, close it: $worker")
                 }
               }
               null

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -144,9 +144,12 @@ private[spark] class PythonRDD(
                 stream.readFully(update)
                 accumulator += Collections.singletonList(update)
               }
+
               // Check whether the worker is ready to be re-used.
-              if (stream.readInt() == SpecialLengths.END_OF_STREAM) {
-                if (reuse_worker) {
+              if (reuse_worker) {
+                // Tt has a high possibility that the ending mark is already available,
+                // And current task should not be blocked by checking it
+                if (stream.available() >= 4 && stream.readInt() == SpecialLengths.END_OF_STREAM) {
                   env.releasePythonWorker(pythonExec, envVars.toMap, worker)
                   released = true
                 }

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -147,7 +147,7 @@ private[spark] class PythonRDD(
 
               // Check whether the worker is ready to be re-used.
               if (reuse_worker) {
-                // Tt has a high possibility that the ending mark is already available,
+                // It has a high possibility that the ending mark is already available,
                 // And current task should not be blocked by checking it
                 if (stream.available() >= 4 && stream.readInt() == SpecialLengths.END_OF_STREAM) {
                   env.releasePythonWorker(pythonExec, envVars.toMap, worker)

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -121,6 +121,7 @@ def main(infile, outfile):
     write_int(len(_accumulatorRegistry), outfile)
     for (aid, accum) in _accumulatorRegistry.items():
         pickleSer._write_with_length((aid, accum._value), outfile)
+    outfile.flush()
 
     # check end of stream
     if read_int(infile) == SpecialLengths.END_OF_STREAM:


### PR DESCRIPTION
There is chance of dead lock that the Python process is waiting for ending mark from JVM, but which is eaten by corrupted stream.

This PR checks the ending mark from Python in non-block way, so it will not blocked by Python process.

There is a small chance that the ending mark is sent by Python process but not available right now, then Python process will not be used.

cc @JoshRosen @pwendell 
