### PR TITLE
[SPARK-5821] [SQL] JSON CTAS command should throw error message when delete path failure

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/json/JSONRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/json/JSONRelation.scala
@@ -67,13 +67,10 @@ private[sql] class DefaultSource
         case SaveMode.Append =>
           sys.error(s"Append mode is not supported by ${this.getClass.getCanonicalName}")
         case SaveMode.Overwrite => {
-          try {
-            fs.delete(filesystemPath, true)
-          } catch {
-            case e: IOException =>
-              throw new IOException(
-                s"Unable to clear output directory ${filesystemPath.toString} prior"
-                  + s" to CREATE a JSON table AS SELECT:\n${e.toString}")
+          if (!fs.delete(filesystemPath, true)) {
+            sys.error(
+              s"Unable to clear output directory ${filesystemPath.toString} prior"
+                + s" to CREATE a JSON table AS SELECT")
           }
           true
         }
@@ -117,13 +114,10 @@ private[sql] case class JSONRelation(
     val fs = filesystemPath.getFileSystem(sqlContext.sparkContext.hadoopConfiguration)
 
     if (overwrite) {
-      try {
-        fs.delete(filesystemPath, true)
-      } catch {
-        case e: IOException =>
-          throw new IOException(
-            s"Unable to clear output directory ${filesystemPath.toString} prior"
-              + s" to INSERT OVERWRITE a JSON table:\n${e.toString}")
+      if (!fs.delete(filesystemPath, true)) {
+        sys.error(
+          s"Unable to clear output directory ${filesystemPath.toString} prior"
+            + s" to CREATE a JSON table AS SELECT")
       }
       // Write the data.
       data.toJSON.saveAsTextFile(path)

--- a/sql/core/src/main/scala/org/apache/spark/sql/json/JSONRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/json/JSONRelation.scala
@@ -86,6 +86,9 @@ private[sql] class DefaultSource
     }
     if (doSave) {
       // Only save data when the save mode is not ignore.
+      if (fs.exists(filesystemPath)) {
+        sys.error(s"Unable to INSERT OVERWRITE a JSON table, because table path $path exists.")
+      }
       data.toJSON.saveAsTextFile(path)
     }
 
@@ -126,6 +129,9 @@ private[sql] case class JSONRelation(
               + s" to INSERT OVERWRITE a JSON table:\n${e.toString}")
       }
       // Write the data.
+      if (fs.exists(filesystemPath)) {
+        sys.error(s"Unable to INSERT OVERWRITE a JSON table, because table path $path exists.")
+      }
       data.toJSON.saveAsTextFile(path)
       // Right now, we assume that the schema is not changed. We will not update the schema.
       // schema = data.schema

--- a/sql/core/src/main/scala/org/apache/spark/sql/json/JSONRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/json/JSONRelation.scala
@@ -76,10 +76,11 @@ private[sql] class DefaultSource
                 s"Unable to clear output directory ${filesystemPath.toString} prior"
                   + s" to writing to JSON table:\n${e.toString}")
           }
-          if (!success)
+          if (!success) {
             throw new IOException(
               s"Unable to clear output directory ${filesystemPath.toString} prior"
                 + s" to writing to JSON table.")
+          }
           true
         }
         case SaveMode.ErrorIfExists =>
@@ -132,10 +133,11 @@ private[sql] case class JSONRelation(
               s"Unable to clear output directory ${filesystemPath.toString} prior"
                 + s" to writing to JSON table:\n${e.toString}")
         }
-        if (!success)
+        if (!success) {
           throw new IOException(
             s"Unable to clear output directory ${filesystemPath.toString} prior"
               + s" to writing to JSON table.")
+        }
       }
       // Write the data.
       data.toJSON.saveAsTextFile(path)

--- a/sql/core/src/main/scala/org/apache/spark/sql/json/JSONRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/json/JSONRelation.scala
@@ -66,9 +66,17 @@ private[sql] class DefaultSource
       mode match {
         case SaveMode.Append =>
           sys.error(s"Append mode is not supported by ${this.getClass.getCanonicalName}")
-        case SaveMode.Overwrite =>
-          fs.delete(filesystemPath, true)
+        case SaveMode.Overwrite => {
+          try {
+            fs.delete(filesystemPath, true)
+          } catch {
+            case e: IOException =>
+              throw new IOException(
+                s"Unable to clear output directory ${filesystemPath.toString} prior"
+                  + s" to CREATE a JSON table AS SELECT:\n${e.toString}")
+          }
           true
+        }
         case SaveMode.ErrorIfExists =>
           sys.error(s"path $path already exists.")
         case SaveMode.Ignore => false

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.sources
 
-import java.io.File
+import java.io.{IOException, File}
 
 import org.scalatest.BeforeAndAfterAll
 
@@ -60,6 +60,29 @@ class CreateTableAsSelectSuite extends DataSourceTest with BeforeAndAfterAll {
       sql("SELECT a, b FROM jt").collect())
 
     dropTempTable("jsonTable")
+  }
+
+  test("CREATE TEMPORARY TABLE AS SELECT based on the file without write permission") {
+    val childPath = new File(path.toString, "child")
+    path.mkdir()
+    childPath.createNewFile()
+    path.setWritable(false)
+
+    val e = intercept[IOException] {
+      sql(
+        s"""
+           |CREATE TEMPORARY TABLE jsonTable
+           |USING org.apache.spark.sql.json.DefaultSource
+           |OPTIONS (
+           |  path '${path.toString}'
+           |) AS
+           |SELECT a, b FROM jt
+        """.stripMargin)
+      sql("SELECT a, b FROM jsonTable").collect()
+    }
+    assert(e.getMessage().contains("Unable to clear output directory"))
+
+    path.setWritable(true)
   }
 
   test("create a table, drop it and create another one with the same name") {


### PR DESCRIPTION
When using "CREATE TEMPORARY TABLE AS SELECT" to create JSON table, we first delete the path file or directory and then generate a new directory with the same name. But if only read permission was granted, the delete failed.
Here we just throwing an error message to let users know what happened.
ParquetRelation2 may also hit this problem. I think to restrict JSONRelation and ParquetRelation2 must base on directory is more reasonable for access control. Maybe I can do it in follow up works. 
