### PR TITLE
[SPARK-3340] Deprecate ADD_JARS and ADD_FILES

### DIFF
--- a/python/pyspark/shell.py
+++ b/python/pyspark/shell.py
@@ -35,14 +35,14 @@ import pyspark
 from pyspark.context import SparkContext
 from pyspark.storagelevel import StorageLevel
 
-# this is the equivalent of ADD_JARS
-add_files = (os.environ.get("ADD_FILES").split(',')
-             if os.environ.get("ADD_FILES") is not None else None)
+# this is the deprecated equivalent of ADD_JARS
+if os.environ.get("ADD_FILES") is not None:
+    print("Warning: ADD_FILES environment variable is deprecated, use --py-files argument instead")
 
 if os.environ.get("SPARK_EXECUTOR_URI"):
     SparkContext.setSystemProperty("spark.executor.uri", os.environ["SPARK_EXECUTOR_URI"])
 
-sc = SparkContext(appName="PySparkShell", pyFiles=add_files)
+sc = SparkContext(appName="PySparkShell")
 atexit.register(lambda: sc.stop())
 
 print("""Welcome to
@@ -57,9 +57,6 @@ print("Using Python version %s (%s, %s)" % (
     platform.python_build()[0],
     platform.python_build()[1]))
 print("SparkContext available as sc.")
-
-if add_files is not None:
-    print("Adding files: [%s]" % ", ".join(add_files))
 
 # The ./bin/pyspark script stores the old PYTHONSTARTUP value in OLD_PYTHONSTARTUP,
 # which allows us to execute the user's PYTHONSTARTUP file:

--- a/python/pyspark/shell.py
+++ b/python/pyspark/shell.py
@@ -36,13 +36,14 @@ from pyspark.context import SparkContext
 from pyspark.storagelevel import StorageLevel
 
 # this is the deprecated equivalent of ADD_JARS
+add_files = None
 if os.environ.get("ADD_FILES") is not None:
-    print("Warning: ADD_FILES environment variable is deprecated, use --py-files argument instead")
+    add_files = os.environ.get("ADD_FILES").split(',')
 
 if os.environ.get("SPARK_EXECUTOR_URI"):
     SparkContext.setSystemProperty("spark.executor.uri", os.environ["SPARK_EXECUTOR_URI"])
 
-sc = SparkContext(appName="PySparkShell")
+sc = SparkContext(appName="PySparkShell", pyFiles=add_files)
 atexit.register(lambda: sc.stop())
 
 print("""Welcome to
@@ -57,6 +58,10 @@ print("Using Python version %s (%s, %s)" % (
     platform.python_build()[0],
     platform.python_build()[1]))
 print("SparkContext available as sc.")
+
+if add_files is not None:
+    print("Warning: ADD_FILES environment variable is deprecated, use --py-files argument instead")
+    print("Adding files: [%s]" % ", ".join(add_files))
 
 # The ./bin/pyspark script stores the old PYTHONSTARTUP value in OLD_PYTHONSTARTUP,
 # which allows us to execute the user's PYTHONSTARTUP file:

--- a/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -1064,16 +1064,18 @@ class SparkILoop(
   private def main(settings: Settings): Unit = process(settings)
 }
 
-object SparkILoop {
+object SparkILoop extends Logging {
   implicit def loopToInterpreter(repl: SparkILoop): SparkIMain = repl.intp
   private def echo(msg: String) = Console println msg
 
   def getAddedJars: Array[String] = {
-    val envJars = sys.env.get("ADD_JARS")
-    val propJars = sys.props.get("spark.jars").flatMap { p =>
-      if (p == "") None else Some(p)
+    sys.env.get("ADD_JARS") match {
+      case Some(envJars) =>
+        logWarning("ADD_JARS environment variable is deprecated, use --jar spark submit argument instead")
+      case None =>
     }
-    val jars = propJars.orElse(envJars).getOrElse("")
+    val propJars = sys.props.get("spark.jars").flatMap { p => if (p == "") None else Some(p) }
+    val jars = propJars.getOrElse("")
     Utils.resolveURIs(jars).split(",").filter(_.nonEmpty)
   }
 

--- a/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -1070,11 +1070,8 @@ object SparkILoop extends Logging {
 
   def getAddedJars: Array[String] = {
     val envJars = sys.env.get("ADD_JARS")
-    envJars match {
-      case Some(_) =>
-        logWarning("ADD_JARS environment variable is deprecated, use --jar spark submit argument instead")
-      case _ =>
-    }
+    if (envJars.isDefined)
+      logWarning("ADD_JARS environment variable is deprecated, use --jar spark submit argument instead")
     val propJars = sys.props.get("spark.jars").flatMap { p => if (p == "") None else Some(p) }
     val jars = propJars.orElse(envJars).getOrElse("")
     Utils.resolveURIs(jars).split(",").filter(_.nonEmpty)

--- a/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -1069,13 +1069,14 @@ object SparkILoop extends Logging {
   private def echo(msg: String) = Console println msg
 
   def getAddedJars: Array[String] = {
-    sys.env.get("ADD_JARS") match {
-      case Some(envJars) =>
+    val envJars = sys.env.get("ADD_JARS")
+    envJars match {
+      case Some(_) =>
         logWarning("ADD_JARS environment variable is deprecated, use --jar spark submit argument instead")
-      case None =>
+      case _ =>
     }
     val propJars = sys.props.get("spark.jars").flatMap { p => if (p == "") None else Some(p) }
-    val jars = propJars.getOrElse("")
+    val jars = propJars.orElse(envJars).getOrElse("")
     Utils.resolveURIs(jars).split(",").filter(_.nonEmpty)
   }
 

--- a/repl/scala-2.11/src/main/scala/org/apache/spark/repl/Main.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/spark/repl/Main.scala
@@ -50,13 +50,14 @@ object Main extends Logging {
 
 
   def getAddedJars: Array[String] = {
-    sys.env.get("ADD_JARS") match {
-      case Some(envJars) =>
+    val envJars = sys.env.get("ADD_JARS")
+    envJars match {
+      case Some(_) =>
         logWarning("ADD_JARS environment variable is deprecated, use --jar spark submit argument instead")
-      case None =>
+      case _ =>
     }
     val propJars = sys.props.get("spark.jars").flatMap { p => if (p == "") None else Some(p) }
-    val jars = propJars.getOrElse("")
+    val jars = propJars.orElse(envJars).getOrElse("")
     Utils.resolveURIs(jars).split(",").filter(_.nonEmpty)
   }
 

--- a/repl/scala-2.11/src/main/scala/org/apache/spark/repl/Main.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/spark/repl/Main.scala
@@ -50,9 +50,13 @@ object Main extends Logging {
 
 
   def getAddedJars: Array[String] = {
-    val envJars = sys.env.get("ADD_JARS")
+    sys.env.get("ADD_JARS") match {
+      case Some(envJars) =>
+        logWarning("ADD_JARS environment variable is deprecated, use --jar spark submit argument instead")
+      case None =>
+    }
     val propJars = sys.props.get("spark.jars").flatMap { p => if (p == "") None else Some(p) }
-    val jars = propJars.orElse(envJars).getOrElse("")
+    val jars = propJars.getOrElse("")
     Utils.resolveURIs(jars).split(",").filter(_.nonEmpty)
   }
 

--- a/repl/scala-2.11/src/main/scala/org/apache/spark/repl/Main.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/spark/repl/Main.scala
@@ -51,11 +51,8 @@ object Main extends Logging {
 
   def getAddedJars: Array[String] = {
     val envJars = sys.env.get("ADD_JARS")
-    envJars match {
-      case Some(_) =>
-        logWarning("ADD_JARS environment variable is deprecated, use --jar spark submit argument instead")
-      case _ =>
-    }
+    if (envJars.isDefined)
+      logWarning("ADD_JARS environment variable is deprecated, use --jar spark submit argument instead")
     val propJars = sys.props.get("spark.jars").flatMap { p => if (p == "") None else Some(p) }
     val jars = propJars.orElse(envJars).getOrElse("")
     Utils.resolveURIs(jars).split(",").filter(_.nonEmpty)


### PR DESCRIPTION
I created a patch that disables the environment variables.
Thereby scala or python shell log a warning message to notify user about the deprecation 
with the following message:
scala: "ADD_JARS environment variable is deprecated, use --jar spark submit argument instead"
python: "Warning: ADD_FILES environment variable is deprecated, use --py-files argument instead"

Is it what is expected or the code associated with the variables should be just completely removed?
Should it be somewhere documented?
