### PR TITLE
[SPARK-5830][Core]Don't create unnecessary directory for local root dir

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -696,9 +696,6 @@ private[spark] object Utils extends Logging {
           try {
             val rootDir = new File(root)
             if (rootDir.exists || rootDir.mkdirs()) {
-//              val dir = createDirectory(root)
-//              chmod700(dir)
-//              Some(dir.getAbsolutePath)
               chmod700(rootDir)
               Some(rootDir.getAbsolutePath)
             } else {

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -695,7 +695,6 @@ private[spark] object Utils extends Logging {
             if (rootDir.exists) {
               Some(rootDir.getAbsolutePath)
             } else if (rootDir.mkdirs()) {
-              // We only chmod700 rootDir which created by Spark
               chmod700(rootDir)
               Some(rootDir.getAbsolutePath)
             } else {

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -692,10 +692,10 @@ private[spark] object Utils extends Logging {
         .flatMap { root =>
           try {
             val rootDir = new File(root)
-            if (rootDir.exists){
+            if (rootDir.exists) {
               Some(rootDir.getAbsolutePath)
-            } else if(rootDir.mkdirs()) {
-              // we only chmod700 rootDir which created by Spark
+            } else if (rootDir.mkdirs()) {
+              // We only chmod700 rootDir which created by Spark
               chmod700(rootDir)
               Some(rootDir.getAbsolutePath)
             } else {

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -686,16 +686,16 @@ private[spark] object Utils extends Logging {
       // user has access to them.
       getYarnLocalDirs(conf).split(",")
     } else {
-      // In non-Yarn mode (or for the driver in yarn-client mode), we cannot trust the user
-      // configuration to point to a secure directory. So create a subdirectory with restricted
-      // permissions under each listed directory.
       Option(conf.getenv("SPARK_LOCAL_DIRS"))
         .getOrElse(conf.get("spark.local.dir", System.getProperty("java.io.tmpdir")))
         .split(",")
         .flatMap { root =>
           try {
             val rootDir = new File(root)
-            if (rootDir.exists || rootDir.mkdirs()) {
+            if (rootDir.exists){
+              Some(rootDir.getAbsolutePath)
+            } else if(rootDir.mkdirs()) {
+              // we only chmod700 rootDir which created by Spark
               chmod700(rootDir)
               Some(rootDir.getAbsolutePath)
             } else {

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -696,9 +696,11 @@ private[spark] object Utils extends Logging {
           try {
             val rootDir = new File(root)
             if (rootDir.exists || rootDir.mkdirs()) {
-              val dir = createDirectory(root)
-              chmod700(dir)
-              Some(dir.getAbsolutePath)
+//              val dir = createDirectory(root)
+//              chmod700(dir)
+//              Some(dir.getAbsolutePath)
+              chmod700(rootDir)
+              Some(rootDir.getAbsolutePath)
             } else {
               logError(s"Failed to create dir in $root. Ignoring this directory.")
               None


### PR DESCRIPTION
Now will create an unnecessary directory for local root directory, and this directory will not be deleted after application exit.
For example:
before will create tmp dir like "/tmp/spark-UUID"
now will create tmp dir like "/tmp/spark-UUID/spark-UUID"
so the dir "/tmp/spark-UUID" will not be deleted as a local root directory.
