### PR TITLE
Fixed overflow on large range with high number of partitions

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/JdbcRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/JdbcRDD.scala
@@ -64,8 +64,8 @@ class JdbcRDD[T: ClassTag](
     // bounds are inclusive, hence the + 1 here and - 1 on end
     val length = 1 + upperBound - lowerBound
     (0 until numPartitions).map(i => {
-      val start = lowerBound + ((i * length) / numPartitions).toLong
-      val end = lowerBound + (((i + 1) * length) / numPartitions).toLong - 1
+       val start = lowerBound + i * (length / numPartitions).toLong
+       val end = lowerBound + (i + 1) * (length / numPartitions).toLong - 1
       new JdbcPartition(i, start, end)
     }).toArray
   }


### PR DESCRIPTION
The following use case causes an overflow when creating the partitions inside JdbcRDD:

```
val jdbcRDD = new JdbcRDD(sc, () =>
      DriverManager.getConnection(url, username, password),
      "SELECT id FROM documents WHERE ? <= id AND id <= ?",
      lowerBound = 1131544775L,
      upperBound = 567279358897692673L,
      numPartitions = 20,
      mapRow = r => (r.getLong("id"))
)
```

This is fixed by swapping division and multiplication in the creation of partitions.
