### PR TITLE
[SPARK-5852][SQL]Fail to convert a newly created empty metastore parquet table to a data source parquet table.

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -208,14 +208,14 @@ private[hive] class HiveMetastoreCatalog(hive: HiveContext) extends Catalog with
         ParquetRelation2(
           paths,
           Map(ParquetRelation2.METASTORE_SCHEMA -> metastoreSchema.json),
-          Some(metastoreSchema),
+          None,
           Some(partitionSpec))(hive))
     } else {
       val paths = Seq(metastoreRelation.hiveQlTable.getDataLocation.toString)
-      LogicalRelation(ParquetRelation2(
+      LogicalRelation(
+        ParquetRelation2(
           paths,
-          Map(ParquetRelation2.METASTORE_SCHEMA -> metastoreSchema.json),
-          Some(metastoreSchema))(hive))
+          Map(ParquetRelation2.METASTORE_SCHEMA -> metastoreSchema.json))(hive))
     }
   }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -212,8 +212,7 @@ private[hive] class HiveMetastoreCatalog(hive: HiveContext) extends Catalog with
           Some(partitionSpec))(hive))
     } else {
       val paths = Seq(metastoreRelation.hiveQlTable.getDataLocation.toString)
-      LogicalRelation(
-        ParquetRelation2(
+      LogicalRelation(ParquetRelation2(
           paths,
           Map(ParquetRelation2.METASTORE_SCHEMA -> metastoreSchema.json),
           Some(metastoreSchema))(hive))

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -208,14 +208,15 @@ private[hive] class HiveMetastoreCatalog(hive: HiveContext) extends Catalog with
         ParquetRelation2(
           paths,
           Map(ParquetRelation2.METASTORE_SCHEMA -> metastoreSchema.json),
-          None,
+          Some(metastoreSchema),
           Some(partitionSpec))(hive))
     } else {
       val paths = Seq(metastoreRelation.hiveQlTable.getDataLocation.toString)
       LogicalRelation(
         ParquetRelation2(
           paths,
-          Map(ParquetRelation2.METASTORE_SCHEMA -> metastoreSchema.json))(hive))
+          Map(ParquetRelation2.METASTORE_SCHEMA -> metastoreSchema.json),
+          Some(metastoreSchema))(hive))
     }
   }
 


### PR DESCRIPTION
The problem is that after we create an empty hive metastore parquet table (e.g. `CREATE TABLE test (a int) STORED AS PARQUET`), Hive will create an empty dir for us, which cause our data source `ParquetRelation2` fail to get the schema of the table. See JIRA for the case to reproduce the bug and the exception.

This PR is based on #4562 from @chenghao-intel.

JIRA: https://issues.apache.org/jira/browse/SPARK-5852
