### PR TITLE
[SPARK-5880][SQL] Change log level of pruned batch's statistics string

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/columnar/InMemoryColumnarTableScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/columnar/InMemoryColumnarTableScan.scala
@@ -299,7 +299,7 @@ private[sql] case class InMemoryColumnarTableScan(
                 .zip(cachedBatch.stats.toSeq)
                 .map { case (a, s) => s"${a.name}: $s" }
                 .mkString(", ")
-              logInfo(s"Skipping partition based on stats $statsString")
+              logDebug(s"Skipping partition based on stats $statsString")
               false
             } else {
               readBatches += 1


### PR DESCRIPTION
Change log level of pruned batch's statistics string in Spark SQL in-memory columnar store
