### PR TITLE
[Spark-5889] Remove pid file after stopping service.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-test<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one or more
   ~ contributor license agreements.  See the NOTICE file distributed with

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+test<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one or more
   ~ contributor license agreements.  See the NOTICE file distributed with

--- a/sbin/spark-daemon.sh
+++ b/sbin/spark-daemon.sh
@@ -168,8 +168,7 @@ case $option in
       TARGET_ID="$(cat "$pid")"
       if [[ $(ps -p "$TARGET_ID" -o comm=) =~ "java" ]]; then
         echo "stopping $command"
-        kill "$TARGET_ID"
-        rm -f $pid
+        kill "$TARGET_ID" && rm -f $pid
       else
         echo "no $command to stop"
       fi

--- a/sbin/spark-daemon.sh
+++ b/sbin/spark-daemon.sh
@@ -169,6 +169,7 @@ case $option in
       if [[ $(ps -p "$TARGET_ID" -o comm=) =~ "java" ]]; then
         echo "stopping $command"
         kill "$TARGET_ID"
+        rm -f $pid
       else
         echo "no $command to stop"
       fi

--- a/sbin/spark-daemon.sh
+++ b/sbin/spark-daemon.sh
@@ -168,7 +168,7 @@ case $option in
       TARGET_ID="$(cat "$pid")"
       if [[ $(ps -p "$TARGET_ID" -o comm=) =~ "java" ]]; then
         echo "stopping $command"
-        kill "$TARGET_ID" && rm -f $pid
+        kill "$TARGET_ID" && rm -f "$pid"
       else
         echo "no $command to stop"
       fi


### PR DESCRIPTION
Currently the pid file is not deleted, and potentially may cause some problem after service is stopped. The fix remove the pid file after service stopped.
