### PR TITLE
[SPARK-1537][WIP]: ats support for spark-on-yarn

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -189,6 +189,16 @@
         </dependency>
       </dependencies>
     </profile>
+      <profile>
+          <id>yarn-history</id>
+          <dependencies>
+              <dependency>
+                  <groupId>org.apache.spark</groupId>
+                  <artifactId>spark-yarn-history_${scala.binary.version}</artifactId>
+                  <version>${project.version}</version>
+              </dependency>
+          </dependencies>
+      </profile>
     <profile>
       <id>hive</id>
       <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -846,8 +846,25 @@
         <!-- Matches the version of jackson-core-asl pulled in by avro -->
         <groupId>org.codehaus.jackson</groupId>
         <artifactId>jackson-mapper-asl</artifactId>
-        <version>1.8.8</version>
+        <version>1.9.13</version>
       </dependency>
+        <dependency>
+            <!-- Matches the version of jackson-core-asl pulled in by avro -->
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-core-asl</artifactId>
+            <version>1.9.13</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-xc</artifactId>
+            <version>1.9.13</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-jaxrs</artifactId>
+            <version>1.9.5</version>
+        </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -1320,6 +1337,13 @@
       <modules>
         <module>yarn</module>
         <module>network/yarn</module>
+      </modules>
+    </profile>
+
+    <profile>
+      <id>yarn-history</id>
+      <modules>
+        <module>yarn/history</module>
       </modules>
     </profile>
 

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -40,8 +40,8 @@ object BuildCommons {
       "streaming-flume", "streaming-kafka", "streaming-mqtt", "streaming-twitter",
       "streaming-zeromq").map(ProjectRef(buildLocation, _))
 
-  val optionallyEnabledProjects@Seq(yarn, yarnStable, yarnAlpha, java8Tests,
-    sparkGangliaLgpl, sparkKinesisAsl) = Seq("yarn", "yarn-stable", "yarn-alpha",
+  val optionallyEnabledProjects@Seq(yarn, yarnStable, yarnAlpha, yarnHistory, java8Tests,
+    sparkGangliaLgpl, sparkKinesisAsl) = Seq("yarn", "yarn-stable", "yarn-alpha", "yarn-history",
     "java8-tests", "ganglia-lgpl", "kinesis-asl").map(ProjectRef(buildLocation, _))
 
   val assemblyProjects@Seq(assembly, examples, networkYarn) =
@@ -347,9 +347,9 @@ object Unidoc {
     publish := {},
 
     unidocProjectFilter in(ScalaUnidoc, unidoc) :=
-      inAnyProject -- inProjects(OldDeps.project, repl, examples, tools, catalyst, streamingFlumeSink, yarn, yarnAlpha),
+      inAnyProject -- inProjects(OldDeps.project, repl, examples, tools, catalyst, streamingFlumeSink, yarn, yarnAlpha, yarnHistory),
     unidocProjectFilter in(JavaUnidoc, unidoc) :=
-      inAnyProject -- inProjects(OldDeps.project, repl, bagel, examples, tools, catalyst, streamingFlumeSink, yarn, yarnAlpha),
+      inAnyProject -- inProjects(OldDeps.project, repl, bagel, examples, tools, catalyst, streamingFlumeSink, yarn, yarnAlpha, yarnHistory),
 
     // Skip class names containing $ and some internal packages in Javadocs
     unidocAllSources in (JavaUnidoc, unidoc) := {

--- a/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -74,6 +74,10 @@ private[spark] class ApplicationMaster(args: ApplicationMasterArguments,
   // Fields used in cluster mode.
   private val sparkContextRef = new AtomicReference[SparkContext](null)
 
+  def getAttempId() = {
+    client.getAttemptId()
+  }
+
   final def run(): Int = {
     try {
       val appAttemptId = client.getAttemptId()
@@ -530,6 +534,9 @@ object ApplicationMaster extends Logging {
     }
   }
 
+  def getAttempId() = {
+    master.getAttempId
+  }
   private[spark] def sparkContextInitialized(sc: SparkContext) = {
     master.sparkContextInitialized(sc)
   }

--- a/yarn/common/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
@@ -23,7 +23,9 @@ import org.apache.hadoop.yarn.api.records.{ApplicationId, YarnApplicationState}
 
 import org.apache.spark.{SparkException, Logging, SparkContext}
 import org.apache.spark.deploy.yarn.{Client, ClientArguments}
+import org.apache.spark.scheduler.cluster.YarnServices
 import org.apache.spark.scheduler.TaskSchedulerImpl
+
 
 private[spark] class YarnClientSchedulerBackend(
     scheduler: TaskSchedulerImpl,
@@ -55,6 +57,7 @@ private[spark] class YarnClientSchedulerBackend(
     totalExpectedExecutors = args.numExecutors
     client = new Client(args, conf)
     appId = client.submitApplication()
+    YarnServices.start(sc, appId)
     waitForApplication()
     asyncMonitorApplication()
   }
@@ -159,6 +162,7 @@ private[spark] class YarnClientSchedulerBackend(
     stopping = true
     super.stop()
     client.stop()
+    YarnServices.stop
     logInfo("Stopped")
   }
 

--- a/yarn/common/src/main/scala/org/apache/spark/scheduler/cluster/YarnClusterSchedulerBackend.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/scheduler/cluster/YarnClusterSchedulerBackend.scala
@@ -18,7 +18,9 @@
 package org.apache.spark.scheduler.cluster
 
 import org.apache.spark.SparkContext
+import org.apache.spark.deploy.yarn.{ApplicationMaster,ApplicationMasterArguments}
 import org.apache.spark.deploy.yarn.YarnSparkHadoopUtil._
+import org.apache.spark.scheduler.cluster.YarnServices
 import org.apache.spark.scheduler.TaskSchedulerImpl
 import org.apache.spark.util.IntParam
 
@@ -29,6 +31,7 @@ private[spark] class YarnClusterSchedulerBackend(
 
   override def start() {
     super.start()
+    YarnServices.start(sc, ApplicationMaster.getAttempId.getApplicationId())
     totalExpectedExecutors = DEFAULT_NUMBER_EXECUTORS
     if (System.getenv("SPARK_EXECUTOR_INSTANCES") != null) {
       totalExpectedExecutors = IntParam.unapply(System.getenv("SPARK_EXECUTOR_INSTANCES"))

--- a/yarn/common/src/main/scala/org/apache/spark/scheduler/cluster/YarnService.scala
+++ b/yarn/common/src/main/scala/org/apache/spark/scheduler/cluster/YarnService.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler.cluster
+
+import org.apache.hadoop.yarn.api.records.ApplicationId
+import org.apache.spark.{Logging, SparkContext}
+import scala.collection.mutable.LinkedList
+
+private [spark] trait YarnService {
+  // For Yarn services, SparkContext, and ApplicationId is the basic info required.
+  // May change upon new services added.
+  def start(sc: SparkContext, appId: ApplicationId): Unit
+  def stop: Unit
+}
+
+private[spark] object YarnServices extends Logging{
+  var services: LinkedList[YarnService] = _
+  def start(sc: SparkContext, appId: ApplicationId) {
+    val sNames = sc.getConf.getOption("spark.yarn.services")
+    sNames match {
+      case Some(names) =>
+        services = new LinkedList[YarnService]
+        val sClasses = names.split(",")
+        sClasses.foreach {
+          sClass => {
+            try {
+              val instance = Class.forName(sClass)
+                .newInstance()
+                .asInstanceOf[YarnService]
+              instance.start(sc, appId)
+              services :+= instance
+              logInfo("Service " + sClass + " started")
+            } catch {
+              case e: Exception =>
+                logWarning("Cannot start Yarn service $sClass ", e)
+            }
+          }
+        }
+      case _ =>
+    }
+  }
+  //stop all services
+  def stop() {
+    if (services != null) {
+      services.foreach(_.stop)
+    }
+  }
+}
+

--- a/yarn/history/pom.xml
+++ b/yarn/history/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.spark</groupId>
+    <artifactId>yarn-parent_2.10</artifactId>
+    <version>1.2.1</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <properties>
+    <sbt.project.name>yarn-history</sbt.project.name>
+  </properties>
+
+  <groupId>org.apache.spark</groupId>
+  <artifactId>spark-yarn-history_2.10</artifactId>
+  <packaging>jar</packaging>
+  <name>Spark Project YARN Application History Integration</name>
+
+  <dependencies>
+      <dependency>
+          <!-- Matches the version of jackson-core-asl pulled in by avro -->
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-core-asl</artifactId>
+      </dependency>
+
+      <dependency>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-xc</artifactId>
+      </dependency>
+      <dependency>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-jaxrs</artifactId>
+      </dependency>
+      <dependency>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-yarn_${scala.binary.version}</artifactId>
+          <version>${project.version}</version>
+      </dependency>
+  </dependencies>
+</project>

--- a/yarn/history/src/main/scala/org/apache/spark/deploy/yarn/history/YarnEventListener.scala
+++ b/yarn/history/src/main/scala/org/apache/spark/deploy/yarn/history/YarnEventListener.scala
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.yarn.history
+
+import org.apache.spark.{Logging, SparkContext}
+import org.apache.spark.scheduler._
+
+case class TimestampEvent(sparkEvent: SparkListenerEvent, time: Long)
+
+class YarnEventListener(sc: SparkContext, service: YarnHistoryService)
+  extends SparkListener with Logging {
+
+  /**
+   * Called when a stage completes successfully or fails, with information on the completed stage.
+   */
+  override def onStageCompleted(stageCompleted: SparkListenerStageCompleted) {
+    service.enqueue(new TimestampEvent(stageCompleted, System.currentTimeMillis))
+  }
+
+  /**
+   * Called when a stage is submitted
+   */
+  override def onStageSubmitted(stageSubmitted: SparkListenerStageSubmitted) {
+    service.enqueue(new TimestampEvent(stageSubmitted, System.currentTimeMillis))
+  }
+
+  /**
+   * Called when a task starts
+   */
+  override def onTaskStart(taskStart: SparkListenerTaskStart) {
+    service.enqueue(new TimestampEvent(taskStart, System.currentTimeMillis))
+  }
+
+  /**
+   * Called when a task begins remotely fetching its result (will not be called for tasks that do
+   * not need to fetch the result remotely).
+   */
+  override def onTaskGettingResult(taskGettingResult: SparkListenerTaskGettingResult) {
+    service.enqueue(new TimestampEvent(taskGettingResult, System.currentTimeMillis))
+  }
+
+  /**
+   * Called when a task ends
+   */
+  override def onTaskEnd(taskEnd: SparkListenerTaskEnd) {
+    service.enqueue(new TimestampEvent(taskEnd, System.currentTimeMillis))
+  }
+
+  /**
+   * Called when a job starts
+   */
+  override def onJobStart(jobStart: SparkListenerJobStart) {
+    service.enqueue(new TimestampEvent(jobStart, System.currentTimeMillis))
+  }
+
+
+  /**
+   * Called when a job ends
+   */
+  override def onJobEnd(jobEnd: SparkListenerJobEnd) {
+    service.enqueue(new TimestampEvent(jobEnd, System.currentTimeMillis))
+  }
+
+  /**
+   * Called when environment properties have been updated
+   */
+  override def onEnvironmentUpdate(environmentUpdate: SparkListenerEnvironmentUpdate) {
+    service.enqueue(new TimestampEvent(environmentUpdate, System.currentTimeMillis))
+  }
+
+  /**
+   * Called when a new block manager has joined
+   */
+  override def onBlockManagerAdded(blockManagerAdded: SparkListenerBlockManagerAdded) {
+    service.enqueue(new TimestampEvent(blockManagerAdded, System.currentTimeMillis))
+  }
+
+  /**
+   * Called when an existing block manager has been removed
+   */
+  override def onBlockManagerRemoved(blockManagerRemoved: SparkListenerBlockManagerRemoved) {
+    service.enqueue(new TimestampEvent(blockManagerRemoved, System.currentTimeMillis))
+  }
+
+  /**
+   * Called when an RDD is manually unpersisted by the application
+   */
+  override def onUnpersistRDD(unpersistRDD: SparkListenerUnpersistRDD) {
+    service.enqueue(new TimestampEvent(unpersistRDD, System.currentTimeMillis))
+  }
+
+  /**
+   * Called when the application starts
+   */
+  override def onApplicationStart(applicationStart: SparkListenerApplicationStart) {
+    service.enqueue(new TimestampEvent(applicationStart, System.currentTimeMillis))
+  }
+
+  /**
+   * Called when the application ends
+   */
+  override def onApplicationEnd(applicationEnd: SparkListenerApplicationEnd) {
+    service.enqueue(new TimestampEvent(applicationEnd, System.currentTimeMillis))
+  }
+
+  /**
+   * Called when the driver receives task metrics from an executor in a heartbeat.
+   */
+  override def onExecutorMetricsUpdate(executorMetricsUpdate: SparkListenerExecutorMetricsUpdate) {
+    service.enqueue(new TimestampEvent(executorMetricsUpdate, System.currentTimeMillis))
+  }
+}

--- a/yarn/history/src/main/scala/org/apache/spark/deploy/yarn/history/YarnHistoryProvider.scala
+++ b/yarn/history/src/main/scala/org/apache/spark/deploy/yarn/history/YarnHistoryProvider.scala
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.yarn.history
+
+import org.apache.spark.{Logging, SparkConf}
+import org.apache.spark.deploy.history.{HistoryServer, ApplicationHistoryProvider, ApplicationHistoryInfo}
+import java.io.FileNotFoundException
+import java.net.URI
+import java.util.{Collection => JCollection, Map => JMap}
+import javax.ws.rs.core.MediaType
+
+import org.json4s.jackson.JsonMethods._
+
+import scala.collection.JavaConversions._
+import scala.collection.mutable
+
+import com.sun.jersey.api.client.{Client, ClientResponse, WebResource}
+import com.sun.jersey.api.client.config.{ClientConfig, DefaultClientConfig}
+import org.apache.hadoop.yarn.api.records.timeline.{TimelineEntities, TimelineEvents}
+import org.apache.hadoop.yarn.conf.YarnConfiguration
+import org.apache.hadoop.yarn.webapp.YarnJacksonJaxbJsonProvider
+import org.json4s.JsonAST._
+
+import org.apache.spark.{Logging, SecurityManager, SparkConf}
+import org.apache.spark.scheduler.{ApplicationEventListener, SparkListenerBus}
+import org.apache.spark.ui.SparkUI
+import org.apache.spark.util.JsonProtocol
+import org.apache.spark.scheduler._
+import org.apache.hadoop.yarn.api.records.timeline.{TimelineEntity, TimelineEvent}
+
+class YarnHistoryProvider(conf: SparkConf)
+  extends ApplicationHistoryProvider with Logging {
+
+  private val yarnConf = new YarnConfiguration()
+  private val NOT_STARTED = "<Not Started>"
+
+  // Copied from Yarn's TimelineClientImpl.java.
+  private val RESOURCE_URI_STR = s"/ws/v1/timeline/${YarnHistoryService.ENTITY_TYPE}"
+
+  private val timelineUri = {
+    val isHttps = YarnConfiguration.useHttps(yarnConf)
+    val addressKey =
+      if (isHttps) {
+        YarnConfiguration.TIMELINE_SERVICE_WEBAPP_HTTPS_ADDRESS
+      } else {
+        YarnConfiguration.TIMELINE_SERVICE_WEBAPP_ADDRESS
+      }
+    val protocol = if (isHttps) "https://" else "http://"
+    URI.create(s"$protocol${yarnConf.get(addressKey)}$RESOURCE_URI_STR")
+  }
+
+  override def getListing(): Seq[ApplicationHistoryInfo] = {
+    logInfo("getListing with Uri: " + timelineUri)
+    val resource = client.resource(timelineUri)
+    val entities = resource
+      .queryParam("primaryFilter", "endApp:oldApp")
+      // .queryParam("fields", "primaryFilters,otherInfo")
+      .accept(MediaType.APPLICATION_JSON)
+      .get(classOf[ClientResponse])
+      .getEntity(classOf[TimelineEntities])
+
+    entities.getEntities().flatMap { en =>
+      try {
+        Some(ApplicationHistoryInfo(en.getEntityId(),
+          en.getOtherInfo().get("appName").asInstanceOf[String],
+          en.getOtherInfo().get("startTime").asInstanceOf[Number].longValue,
+          en.getOtherInfo().get("endTime").asInstanceOf[Number].longValue,
+          en.getOtherInfo().get("endTime").asInstanceOf[Number].longValue,
+          en.getOtherInfo().get("appUser").asInstanceOf[String]))
+      } catch {
+        case e: Exception =>
+          logInfo("Failed to parse event.", e)
+          None
+      }
+    }
+  }
+
+
+
+  private val client = {
+    val cc = new DefaultClientConfig()
+    // Note: this class is "interface audience private" but since there is no public API
+    // for the timeline server, this makes it much easier to talk to it.
+    cc.getClasses().add(classOf[YarnJacksonJaxbJsonProvider])
+    Client.create(cc)
+  }
+
+  override def getAppUI(appId: String): Option[SparkUI] = {
+    logInfo("Requst UI with appId " + appId)
+    val eventsUri = timelineUri.resolve(s"${timelineUri.getPath()}/$appId")
+    val resource = client.resource(eventsUri)
+    val entity = resource
+      .accept(MediaType.APPLICATION_JSON)
+      .get(classOf[ClientResponse])
+      .getEntity(classOf[TimelineEntity])
+    logDebug(entity.toString)
+    //  val entities = resource.get(classOf[ClientResponse]).getEntity(classOf[TimelineEntities])
+    val bus = new SparkListenerBus() { }
+    val appListener = new ApplicationEventListener()
+    bus.addListener(appListener)
+
+    val ui = {
+      val conf = this.conf.clone()
+      val appSecManager = new SecurityManager(conf)
+      SparkUI.createHistoryUI(conf, bus, appSecManager, appId,"/history/" + appId)
+    }
+    val events = entity.getEvents.flatMap(_.getEventInfo.values)
+
+    events.reverse.foreach { line =>
+      bus.postToAll(JsonProtocol.sparkEventFromJson(parse(line.asInstanceOf[String])))
+    }
+    ui.setAppName(s"${appListener.appName.getOrElse(NOT_STARTED)} ($appId)")
+
+    val uiAclsEnabled = conf.getBoolean("spark.history.ui.acls.enable", false)
+    ui.getSecurityManager.setAcls(uiAclsEnabled)
+    // make sure to set admin acls before view acls so they are properly picked up
+    ui.getSecurityManager.setAdminAcls(appListener.adminAcls.getOrElse(""))
+    ui.getSecurityManager.setViewAcls(appListener.sparkUser.getOrElse(NOT_STARTED),
+      appListener.viewAcls.getOrElse(""))
+    Some(ui)
+  }
+  override def getConfig(): Map[String, String] = {
+    logInfo("getConfig ...:" +  timelineUri.resolve("/").toString())
+    Map(("Yarn Application History Server" -> timelineUri.resolve("/").toString()))
+  }
+
+  override def stop(): Unit = client.destroy()
+
+}

--- a/yarn/history/src/main/scala/org/apache/spark/deploy/yarn/history/YarnHistoryService.scala
+++ b/yarn/history/src/main/scala/org/apache/spark/deploy/yarn/history/YarnHistoryService.scala
@@ -1,0 +1,379 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.yarn.history
+
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.{HashMap => JHashMap}
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.security.UserGroupInformation
+import org.apache.hadoop.service.AbstractService
+import org.apache.hadoop.yarn.api.records.ApplicationId
+import org.apache.hadoop.yarn.api.records.timeline.{TimelineEntity,
+  TimelineEvent, TimelineDomain, TimelinePutResponse}
+import org.apache.hadoop.yarn.client.api.TimelineClient
+import org.apache.hadoop.yarn.exceptions.YarnException
+import org.apache.hadoop.yarn.conf.YarnConfiguration
+import org.apache.spark.deploy.yarn.history.TimestampEvent
+import org.apache.spark.scheduler.cluster.YarnService
+import org.apache.spark.scheduler._
+import org.apache.spark.util.{JsonProtocol, Utils}
+import org.apache.spark.{Logging, SparkContext}
+import org.json4s.jackson.JsonMethods._
+import scala.collection.mutable.LinkedList
+
+import scala.collection.JavaConversions._
+
+class YarnHistoryService  extends AbstractService("ATS")
+  with YarnService with Logging {
+
+  private var sc: SparkContext = _
+  private var appId: ApplicationId = _
+  private var timelineClient: Option[TimelineClient] = None
+  private var listener: YarnEventListener = _
+  private var appName: String = null
+  private var userName: String = null
+  private var startTime: Long = _
+
+  private var batchSize: Int = YarnHistoryService.DEFAULT_BATCH_SIZE
+
+  // enqueue event to avoid blocking on main thread.
+  private var eventQueue = new LinkedBlockingQueue[TimestampEvent]
+  // cache layer to handle timeline client failure.
+  private var entityList = new LinkedList[TimelineEntity]
+  private var curEntity: Option[TimelineEntity] = None
+  // Do we have enough information filled for the entity
+  private var bAppStart = false
+  private var bAppEnd = false
+  // How many event we saved
+  private var curEventNum = 0
+  private var eventsProcessed: Int = 0
+  private var eventHandlingThread: Thread = null
+  private var stopped: AtomicBoolean = new AtomicBoolean(true)
+  private final val lock: AnyRef = new AnyRef
+  private var maxTimeToWaitOnShutdown: Long = YarnHistoryService.DEFAULT_WAIT_TIME
+  private var clientFailure = 0
+  private var domainId: String = null
+
+  def createTimelineClient = {
+    clientFailure += 1
+    logInfo("Creating timelineClient " + clientFailure)
+    val client = TimelineClient.createTimelineClient()
+    client.init(sc.hadoopConfiguration)
+    client.start
+    timelineClient = Some(client)
+    client
+  }
+
+  def getTimelineClient = timelineClient.getOrElse(createTimelineClient)
+
+  def stopTimelineClient = {
+    timelineClient.map(_.stop)
+    timelineClient = None
+  }
+
+  /**
+   * Split a comma separated String, filter out any empty items, and return a Set of strings
+   */
+  private def stringToSet(list: String): Set[String] = {
+    list.split(',').map(_.trim).filter(!_.isEmpty).toSet
+  }
+
+  private  def createTimelineDomain():String = {
+    val sparkConf = sc.getConf
+    val aclsOn = sparkConf.getOption("spark.acls.enable").getOrElse(
+      sparkConf.get("spark.ui.acls.enable", "false")).toBoolean
+    if (!aclsOn) {
+      return null
+    }
+    val predefDomain = sparkConf.getOption("spark.ui.domain")
+    if (predefDomain.isDefined) {
+      domainId = predefDomain.get
+      return null
+    }
+    val current = UserGroupInformation.getCurrentUser.getShortUserName
+    val adminAcls  = stringToSet(sparkConf.get("spark.admin.acls", ""))
+    val viewAcls = stringToSet(sparkConf.get("spark.ui.view.acls", ""))
+    val modifyAcls = stringToSet(sparkConf.get("spark.modify.acls", ""))
+
+    val readers = (adminAcls ++ modifyAcls ++ viewAcls).foldLeft(current)(_ + " " + _)
+    val writers = (adminAcls ++ modifyAcls).foldLeft(current)(_ + " " + _)
+    var tmpId = YarnHistoryService.DOMAIN_ID_PREFIX + appId
+    logInfo("Creating domain " + tmpId + " with  readers: "
+      + readers + " and writers:" + writers)
+    val timelineDomain = new TimelineDomain();
+    timelineDomain.setId(tmpId);
+
+    timelineDomain.setReaders(readers)
+    timelineDomain.setWriters(writers);
+    try {
+      getTimelineClient.putDomain(timelineDomain);
+    } catch {
+      case e: YarnException => {
+        logError("cannot create the domain")
+        // fallback to default
+        tmpId = null
+      }
+    }
+    tmpId
+  }
+
+  def start(context: SparkContext, id: ApplicationId): Unit = {
+    // Check that the configuration points at an AHS, otherwise the client code will
+    // not be able to connect.
+    val yarnConf = new YarnConfiguration(context.hadoopConfiguration)
+    if (!yarnConf.getBoolean(YarnConfiguration.TIMELINE_SERVICE_ENABLED,
+      YarnConfiguration.DEFAULT_TIMELINE_SERVICE_ENABLED)) {
+      logInfo("Yarn timeline service not available, disabling client.")
+      return
+    }
+    if (!stopped.get()) {
+      return
+    }
+    stopped.set(false)
+    sc = context
+    appId = id
+    addShutdownHook(this)
+    init(sc.hadoopConfiguration)
+    start()
+    listener = new YarnEventListener(sc, this)
+    sc.listenerBus.addListener(listener)
+    logInfo("History service started")
+  }
+
+  override def serviceInit(conf: Configuration) {
+    createTimelineClient
+    domainId = createTimelineDomain
+  }
+
+  private def addShutdownHook(service: YarnHistoryService) {
+    Runtime.getRuntime.addShutdownHook(new Thread("terminating logging service") {
+      override def run() = {
+        logInfo("Shutdown hook called")
+        service.stop
+      }
+    })
+  }
+
+  override def serviceStart {
+    eventHandlingThread = new Thread(new Runnable {
+      def run {
+        var event: Any = null
+        log.info("Starting service for AppId " + appId)
+        while (!stopped.get && !Thread.currentThread.isInterrupted) {
+          try {
+            event = eventQueue.take
+            eventsProcessed += 1
+            handleEvent(event.asInstanceOf[TimestampEvent], false)
+          } catch {
+            case e: Exception => {
+              logWarning("EventQueue take interrupted. Returning")
+            }
+          }
+        }
+      }
+    }, "HistoryEventHandlingThread")
+    eventHandlingThread.start
+  }
+
+  def enqueue(event: TimestampEvent) = {
+    if (!stopped.get()) {
+      eventQueue.add(event)
+    } else {
+      logInfo("enqueue events with ATS service stopped")
+    }
+  }
+
+  override def serviceStop {
+    if (!stopped.getAndSet(true)) {
+      if (eventHandlingThread != null) {
+        eventHandlingThread.interrupt
+      }
+      if (!bAppEnd) {
+        eventQueue.add(new TimestampEvent(SparkListenerApplicationEnd(System.currentTimeMillis()),
+          System.currentTimeMillis()))
+      }
+      logDebug("push out all events")
+      if (!eventQueue.isEmpty) {
+        if (maxTimeToWaitOnShutdown > 0) {
+          val curTime: Long = System.currentTimeMillis()
+          val endTime: Long = curTime + maxTimeToWaitOnShutdown
+          var event = eventQueue.poll
+          while (endTime >= System.currentTimeMillis() && event != null) {
+            handleEvent(event, true)
+            event = eventQueue.poll
+          }
+        }
+      } else {
+        //flush all entities
+        handleEvent(null, true)
+      }
+      if (!eventQueue.isEmpty) {
+        logWarning("Did not finish flushing eventQueue before " +
+          "stopping ATSService, eventQueueBacklog=" + eventQueue.size)
+      }
+      stopTimelineClient
+      logInfo("ATS service terminated")
+    }
+  }
+
+  def getCurrentEntity = {
+    curEntity.getOrElse {
+      val entity: TimelineEntity = new TimelineEntity
+      logDebug("Create new entity")
+      curEventNum = 0
+      entity.setEntityType(YarnHistoryService.ENTITY_TYPE)
+      entity.setEntityId(appId.toString)
+      if (bAppStart) {
+        entity.addPrimaryFilter("appName", appName)
+        entity.addPrimaryFilter("appUser", userName)
+        entity.addOtherInfo("appName", appName)
+        entity.addOtherInfo("appUser", userName)
+      }
+      curEntity = Some(entity)
+      entity
+    }
+  }
+
+  /**
+   * If there is any available entity to be sent, push to timeline server
+   * @return
+   */
+  def flushEntity(): Unit = {
+    if (entityList.isEmpty) {
+      return
+    }
+    logDebug("before pushEntities: " + entityList.size())
+    var client = getTimelineClient
+    entityList = entityList.filter {
+      en => {
+        if (en == null) {
+          false
+        } else {
+          if (domainId != null) {
+            en.setDomainId(domainId);
+          }
+          try {
+            val response: TimelinePutResponse = client.putEntities(en)
+            if (response != null && !response.getErrors.isEmpty) {
+              val err: TimelinePutResponse.TimelinePutError = response.getErrors.get(0)
+              if (err.getErrorCode != 0) {
+                timelineClient = None
+                logError("Could not post history event to ATS, eventType=" + err.getErrorCode)
+              }
+              true
+            } else {
+              logDebug("entity pushed: " + en)
+              false
+            }
+          } catch {
+            case e: Exception => {
+              timelineClient = None
+              client = getTimelineClient
+              logError("Could not handle history entity: " + e)
+              true
+            }
+          }
+        }
+      }
+    }
+    logDebug("after pushEntities: " + entityList.size())
+  }
+
+  /**
+   * If the event reaches the batch size or flush is true, push events to ATS.
+   *
+   * @param event
+   * @param flush
+   * @return
+   */
+  private def handleEvent(event: TimestampEvent,  flush: Boolean): Unit = {
+    var push = false
+    // if we receive a new appStart event, we always push
+    // not much contention here, only happens when service is stopped
+    lock synchronized {
+      if (event != null) {
+        if (eventsProcessed % 1000 == 0) {
+          logDebug("$eventProcessed events are processed")
+        }
+        eventsProcessed += 1
+        val obj = JsonProtocol.sparkEventToJson(event.sparkEvent)
+        val map = compact(render(obj))
+        if (map == null || map == "") return
+        event.sparkEvent match {
+          case start: SparkListenerApplicationStart =>
+            // we already have all information,
+            // flush it for old one to switch to new one
+            logDebug("Receive application start event: " + event)
+            // flush old entity
+            curEntity.foreach(entityList :+= _)
+            curEntity = None
+            appName =start.appName;
+            userName = start.sparkUser
+            startTime = start.time
+            val en = getCurrentEntity
+            en.addPrimaryFilter("startApp", "newApp")
+            push = true
+            bAppStart = true
+            bAppEnd = false
+          case end: SparkListenerApplicationEnd =>
+            if (!bAppEnd) {
+              // we already have all information,
+              // flush it for old one to switch to new one
+              logDebug("Receive application end event: " + event)
+              // flush old entity
+              curEntity.foreach(entityList :+= _)
+              curEntity = None
+
+              val en = getCurrentEntity
+              en.addPrimaryFilter("endApp", "oldApp")
+              en.addOtherInfo("startTime", startTime)
+              en.addOtherInfo("endTime", end.time)
+              bAppEnd = true
+              bAppStart = false
+              push = true
+              this.stop
+            }
+          case _ =>
+        }
+        val tlEvent = new TimelineEvent()
+        tlEvent.setEventType(Utils.getFormattedClassName(event.sparkEvent).toString)
+        tlEvent.setTimestamp(event.time)
+        val kvMap = new JHashMap[String, Object]();
+        kvMap.put(Utils.getFormattedClassName(event.sparkEvent).toString, map)
+        tlEvent.setEventInfo(kvMap)
+        getCurrentEntity.addEvent(tlEvent)
+        curEventNum += 1
+      }
+      logDebug("current event num: " + curEventNum)
+      if (curEventNum == batchSize || flush || push) {
+        curEntity.foreach(entityList :+= _)
+        curEntity = None
+        curEventNum = 0
+      }
+      flushEntity()
+    }
+  }
+}
+
+object YarnHistoryService {
+  val ENTITY_TYPE = "SparkApplication"
+  val DOMAIN_ID_PREFIX = "Spark_ATS_"
+  val DEFAULT_BATCH_SIZE = 3
+  val DEFAULT_WAIT_TIME = 1000L
+}

--- a/yarn/pom.xml
+++ b/yarn/pom.xml
@@ -33,6 +33,20 @@
   </properties>
 
   <dependencies>
+      <dependency>
+          <!-- Matches the version of jackson-core-asl pulled in by avro -->
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-core-asl</artifactId>
+      </dependency>
+
+      <dependency>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-xc</artifactId>
+      </dependency>
+      <dependency>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-jaxrs</artifactId>
+      </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
@@ -107,7 +121,6 @@
       </modules>
     </profile>
   </profiles>
-
   <build>
     <plugins>
       <plugin>

--- a/yarn/stable/pom.xml
+++ b/yarn/stable/pom.xml
@@ -33,6 +33,18 @@
   <name>Spark Project YARN Stable API</name>
 
   <dependencies>
+      <dependency>
+          <!-- Matches the version of jackson-core-asl pulled in by avro -->
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-mapper-asl</artifactId>
+          <version>1.9.5</version>
+      </dependency>
+      <dependency>
+          <!-- Matches the version of jackson-core-asl pulled in by avro -->
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-core-asl</artifactId>
+          <version>1.9.5</version>
+      </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-yarn-server-tests</artifactId>


### PR DESCRIPTION
This is the patch to integrate ats and spark-on-yarn build against brach-1.2.  The patch also partially integrate the code from Marcelo Vanzin (Spark-1537).

To enable it, build with -Pyarn-history, and configure spark.yarn.services and spark.history.provider in spark-defaults.conf.
