### PR TITLE
[SPARK-5907][SQL] Selected column from DataFrame should not re-analyze logical plan

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameImpl.scala
@@ -210,7 +210,7 @@ private[sql] class DataFrameImpl protected[sql](
       Column(ResolvedStar(schema.fieldNames.map(resolve)))
     case _ =>
       val expr = resolve(colName)
-      Column(sqlContext, Project(Seq(expr), logicalPlan), expr)
+      Column(sqlContext, Project(Seq(expr), queryExecution.analyzed), expr)
   }
 
   override def as(alias: String): DataFrame = Subquery(alias, logicalPlan)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -387,6 +387,11 @@ class SQLQuerySuite extends QueryTest {
     dropTempTable("data")
   }
 
+  test("selected column from DataFrame should not re-analyze logical plan") {
+    val df = sql("SELECT explode(array(1, 2, 3)) AS val")
+    val col = df("val")
+  }
+
   test("logical.Project should not be resolved if it contains aggregates or generators") {
     // This test is used to test the fix of SPARK-5875.
     // The original issue was that Project's resolved will be true when it contains


### PR DESCRIPTION
Currently, selecting a column from DataFrame wraps the original logical plan with a Project. As the column is used, the logical plan will be analyzed again. For some query plans, re-analyzing would have side-effect that increases expression id. So when accessing the column, column's expr and its analyzed plan will point to different expressions.
