### PR TITLE
[SPARK-5494][SQL] SparkSqlSerializer Ignores KryoRegistrators

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlSerializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlSerializer.scala
@@ -39,8 +39,7 @@ import org.apache.spark.sql.catalyst.expressions.codegen.{IntegerHashSet, LongHa
 
 private[sql] class SparkSqlSerializer(conf: SparkConf) extends KryoSerializer(conf) {
   override def newKryo(): Kryo = {
-    val kryo = new Kryo()
-    kryo.setRegistrationRequired(false)
+    val kryo = super.newKryo
     kryo.register(classOf[MutablePair[_, _]])
     kryo.register(classOf[org.apache.spark.sql.catalyst.expressions.GenericRow])
     kryo.register(classOf[org.apache.spark.sql.catalyst.expressions.GenericMutableRow])
@@ -56,9 +55,7 @@ private[sql] class SparkSqlSerializer(conf: SparkConf) extends KryoSerializer(co
                   new OpenHashSetSerializer)
     kryo.register(classOf[Decimal])
 
-    kryo.setReferences(false)
     kryo.setClassLoader(Utils.getSparkClassLoader)
-    new AllScalaRegistrar().apply(kryo)
     kryo
   }
 }


### PR DESCRIPTION
SparkSqlSerializer completely ignores custom KryoRegistrators (unlike the regular Spark serializer). I've applied a change to call super.newKryo before registering their custom classes, and removed duplicate registrations/settings.
