### PR TITLE
[SPARK-5924] Add the ability to specify withMean or withStd parameters with StandarScaler

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
@@ -35,7 +35,7 @@ private[feature] trait StandardScalerParams extends Params with HasInputCol with
    * Whether to center the data before scaling
    * @group param
    */
-  val withMean: BooleanParam = new BooleanParam(this, "withMean", "Center data with mean before scaling")
+  val withMean: BooleanParam = new BooleanParam(this, "withMean", "Center data with mean")
   
   /**
    * Whether to scale the data to have unit standard deviation

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
@@ -56,7 +56,7 @@ class StandardScaler extends Estimator[StandardScalerModel] with StandardScalerP
   /** @group setParam */
   def setOutputCol(value: String): this.type = set(outputCol, value)
   
-  /** @grour setParam */
+  /** @group setParam */
   def setWithMean(value: Boolean): this.type = set(withMean, value)
   
   /** @group setParam */
@@ -66,8 +66,9 @@ class StandardScaler extends Estimator[StandardScalerModel] with StandardScalerP
     transformSchema(dataset.schema, paramMap, logging = true)
     val map = this.paramMap ++ paramMap
     val input = dataset.select(map(inputCol)).map { case Row(v: Vector) => v }
-    val scaler = new feature.StandardScaler(withMean = map(withMean), withStd = map(withStd)).fit(input)
-    val model = new StandardScalerModel(this, map, scaler)
+    val scaler = new feature.StandardScaler(withMean = map(withMean), withStd = map(withStd))
+    val scalerModel = scaler.fit(input)
+    val model = new StandardScalerModel(this, map, scalerModel)
     Params.inheritValues(map, this, model)
     model
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
@@ -32,19 +32,18 @@ import org.apache.spark.sql.types.{StructField, StructType}
 private[feature] trait StandardScalerParams extends Params with HasInputCol with HasOutputCol {
   
   /**
-   * Whether to center the data before scaling
+   * False by default. Centers the data with mean before scaling. 
+   * It will build a dense output, so this does not work on sparse input and will raise an exception.
    * @group param
    */
   val withMean: BooleanParam = new BooleanParam(this, "withMean", "Center data with mean")
   
   /**
-   * Whether to scale the data to have unit standard deviation
+   * True by default. Scales the data to unit standard deviation.
    * @group param
    */
   val withStd: BooleanParam = new BooleanParam(this, "withStd", "Scale to unit standard deviation")
 }
-
-
 
 /**
  * :: AlphaComponent ::

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
@@ -33,7 +33,8 @@ private[feature] trait StandardScalerParams extends Params with HasInputCol with
   
   /**
    * False by default. Centers the data with mean before scaling. 
-   * It will build a dense output, so this does not work on sparse input and will raise an exception.
+   * It will build a dense output, so this does not work on sparse input 
+   * and will raise an exception.
    * @group param
    */
   val withMean: BooleanParam = new BooleanParam(this, "withMean", "Center data with mean")

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
@@ -40,7 +40,7 @@ private[feature] trait StandardScalerParams extends Params with HasInputCol with
   )
 }
 
-setDefault(withMean -> false, withStd -> true)
+
 
 /**
  * :: AlphaComponent ::
@@ -50,6 +50,8 @@ setDefault(withMean -> false, withStd -> true)
 @AlphaComponent
 class StandardScaler extends Estimator[StandardScalerModel] with StandardScalerParams {
 
+  setDefault(withMean -> false, withStd -> true)
+  
   /** @group setParam */
   def setInputCol(value: String): this.type = set(inputCol, value)
 

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
@@ -32,15 +32,15 @@ import org.apache.spark.sql.types.{StructField, StructType}
 private[feature] trait StandardScalerParams extends Params with HasInputCol with HasOutputCol {
   val withMean: BooleanParam = new BooleanParam(this, 
     "withMean", 
-    "Center data with mean before scaling", 
-    defaultValue = Some(false)
+    "Center data with mean before scaling"
   )
   val withStd: BooleanParam = new BooleanParam(this,
     "withStd", 
-    "Scale to unit standard deviation", 
-    defaultValue = Some(true)
+    "Scale to unit standard deviation"
   )
 }
+
+setDefault(withMean -> false, withStd -> true)
 
 /**
  * :: AlphaComponent ::

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
@@ -30,14 +30,18 @@ import org.apache.spark.sql.types.{StructField, StructType}
  * Params for [[StandardScaler]] and [[StandardScalerModel]].
  */
 private[feature] trait StandardScalerParams extends Params with HasInputCol with HasOutputCol {
-  val withMean: BooleanParam = new BooleanParam(this, 
-    "withMean", 
-    "Center data with mean before scaling"
-  )
-  val withStd: BooleanParam = new BooleanParam(this,
-    "withStd", 
-    "Scale to unit standard deviation"
-  )
+  
+  /**
+   * Whether to center the data before scaling
+   * @group param
+   */
+  val withMean: BooleanParam = new BooleanParam(this, "withMean", "Center data with mean before scaling")
+  
+  /**
+   * Whether to scale the data to have unit standard deviation
+   * @group param
+   */
+  val withStd: BooleanParam = new BooleanParam(this, "withStd", "Scale to unit standard deviation")
 }
 
 
@@ -76,7 +80,7 @@ class StandardScaler extends Estimator[StandardScalerModel] with StandardScalerP
   }
 
   override def transformSchema(schema: StructType, paramMap: ParamMap): StructType = {
-    val map = this.paramMap ++ paramMap
+    val map = extractParamMap(paramMap)
     val inputType = schema(map(inputCol)).dataType
     require(inputType.isInstanceOf[VectorUDT],
       s"Input column ${map(inputCol)} must be a vector column")


### PR DESCRIPTION
The current implementation call the default constructor of mllib.feature.StandarScaler without the possibility to specify withMean or withStd options.
