### PR TITLE
[SPARK-5926] [SQL] make DataFrame.explain leverage queryExecution.logical

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -123,7 +123,7 @@ class DataFrame protected[sql](
     })
   }
 
-  @transient protected[sql] lazy val logicalPlan: LogicalPlan = queryExecution.logical match {
+  @transient protected[sql] val logicalPlan: LogicalPlan = queryExecution.logical match {
     // For various commands (like DDL) and queries with side effects, we force query optimization to
     // happen right away to let these side effects take place eagerly.
     case _: Command |

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -123,7 +123,7 @@ class DataFrame protected[sql](
     })
   }
 
-  @transient protected[sql] val logicalPlan: LogicalPlan = queryExecution.logical match {
+  @transient protected[sql] lazy val logicalPlan: LogicalPlan = queryExecution.logical match {
     // For various commands (like DDL) and queries with side effects, we force query optimization to
     // happen right away to let these side effects take place eagerly.
     case _: Command |
@@ -264,7 +264,7 @@ class DataFrame protected[sql](
    */
   def explain(extended: Boolean): Unit = {
     ExplainCommand(
-      logicalPlan,
+      queryExecution.logical,
       extended = extended).queryExecution.executedPlan.executeCollect().map {
       r => println(r.getString(0))
     }


### PR DESCRIPTION
DataFrame.explain return wrong result when the query is DDL command.

For example, the following two queries should print out the same execution plan, but it not.
sql("create table tb as select \* from src where key > 490").explain(true)
sql("explain extended create table tb as select \* from src where key > 490")

This is because DataFrame.explain leverage logicalPlan which had been forced executed, we should use  the unexecuted plan queryExecution.logical.
