### PR TITLE
[SPARK-5938][SQL] Generate Row from JSON string efficiently

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/json/JsonRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/json/JsonRDD.scala
@@ -439,7 +439,8 @@ private[sql] object JsonRDD extends Logging {
       , schemaFuncs: Seq[(String, Any => Any)]): Row = {
     var i = 0
     while (i < schemaFuncs.size) {
-      row.update(i, json.get(schemaFuncs(i)._1).flatMap(v => Option(v)).map(schemaFuncs(i)._2).orNull)
+      row.update(i, json.get(schemaFuncs(i)._1).flatMap(v => Option(v)).map(
+        schemaFuncs(i)._2).orNull)
       i += 1
     }
 


### PR DESCRIPTION
When we generate `Row` from JSON String, we zip the schema with index for every record and update current row's fields. That is inefficient.

This pr prepares the necessary functions for updating row's fields in advance, and reuses them for every row.

This pr also reuses a `GenericMutableRow`  instead of creating a new row for every record.
