### PR TITLE
[SPARK-5942][SQL] DataFrame should not do query optimization when dataFrameEagerAnalysis is off

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -45,10 +45,17 @@ class DataFrameSuite extends QueryTest {
     intercept[Exception] {
       testData.groupBy($"abcd").agg(Map("key" -> "sum"))
     }
-
+ 
+    testData.registerTempTable("testDataTemp")
+    intercept[Exception] {
+      sql("INSERT OVERWRITE TABLE testDataTemp SELECT nonExistentName, value FROM testData")
+    }
+ 
     // No more eager analysis once the flag is turned off
     TestSQLContext.setConf(SQLConf.DATAFRAME_EAGER_ANALYSIS, "false")
     testData.select('nonExistentName)
+
+    sql("INSERT OVERWRITE TABLE testDataTemp SELECT nonExistentName, value FROM testData")
 
     // Set the flag back to original value before this test.
     TestSQLContext.setConf(SQLConf.DATAFRAME_EAGER_ANALYSIS, oldSetting.toString)


### PR DESCRIPTION
`DataFrame` will force query optimization to happen right away for the commands and queries with side effects.

However, I think maybe we should not do that when `dataFrameEagerAnalysis` is off.
