### PR TITLE
[SPARK-5946][Streaming] Add Python API for direct Kafka stream

### DIFF
--- a/examples/src/main/python/streaming/direct_kafka_wordcount.py
+++ b/examples/src/main/python/streaming/direct_kafka_wordcount.py
@@ -23,7 +23,7 @@
  http://kafka.apache.org/documentation.html#quickstart
 
  and then run the example
-    `$ bin/spark-submit --driver-class-path external/kafka-assembly/target/scala-*/\
+    `$ bin/spark-submit --jars external/kafka-assembly/target/scala-*/\
       spark-streaming-kafka-assembly-*.jar \
       examples/src/main/python/streaming/direct_kafka_wordcount.py \
       localhost:9092 test`

--- a/examples/src/main/python/streaming/direct_kafka_wordcount.py
+++ b/examples/src/main/python/streaming/direct_kafka_wordcount.py
@@ -17,14 +17,15 @@
 
 """
  Counts words in UTF8 encoded, '\n' delimited text directly received from Kafka in every 2 seconds.
- Usage: network_wordcount.py <broker_list> <topic>
+ Usage: direct_kafka_wordcount.py <broker_list> <topic>
 
  To run this on your local machine, you need to setup Kafka and create a producer first, see
  http://kafka.apache.org/documentation.html#quickstart
 
  and then run the example
     `$ bin/spark-submit --driver-class-path external/kafka-assembly/target/scala-*/\
-      spark-streaming-kafka-assembly-*.jar examples/src/main/python/streaming/direct_kafka_wordcount.py \
+      spark-streaming-kafka-assembly-*.jar \
+      examples/src/main/python/streaming/direct_kafka_wordcount.py \
       localhost:9092 test`
 """
 
@@ -43,7 +44,7 @@ if __name__ == "__main__":
     ssc = StreamingContext(sc, 2)
 
     brokers, topic = sys.argv[1:]
-    kvs = KafkaUtils.createStream(ssc, [topic], {"metadata.broker.list": brokers})
+    kvs = KafkaUtils.createDirectStream(ssc, [topic], {"metadata.broker.list": brokers})
     lines = kvs.map(lambda x: x[1])
     counts = lines.flatMap(lambda line: line.split(" ")) \
         .map(lambda word: (word, 1)) \

--- a/examples/src/main/python/streaming/direct_kafka_wordcount.py
+++ b/examples/src/main/python/streaming/direct_kafka_wordcount.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
     ssc = StreamingContext(sc, 2)
 
     brokers, topic = sys.argv[1:]
-    kvs = KafkaUtils.createDirectStream(ssc, [topic], {"metadata.broker.list": brokers})
+    kvs = KafkaUtils.createDirectStream(ssc, brokers, [topic])
     lines = kvs.map(lambda x: x[1])
     counts = lines.flatMap(lambda line: line.split(" ")) \
         .map(lambda word: (word, 1)) \

--- a/examples/src/main/python/streaming/direct_kafka_wordcount.py
+++ b/examples/src/main/python/streaming/direct_kafka_wordcount.py
@@ -1,0 +1,54 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+ Counts words in UTF8 encoded, '\n' delimited text directly received from Kafka in every 2 seconds.
+ Usage: network_wordcount.py <broker_list> <topic>
+
+ To run this on your local machine, you need to setup Kafka and create a producer first, see
+ http://kafka.apache.org/documentation.html#quickstart
+
+ and then run the example
+    `$ bin/spark-submit --driver-class-path external/kafka-assembly/target/scala-*/\
+      spark-streaming-kafka-assembly-*.jar examples/src/main/python/streaming/direct_kafka_wordcount.py \
+      localhost:9092 test`
+"""
+
+import sys
+
+from pyspark import SparkContext
+from pyspark.streaming import StreamingContext
+from pyspark.streaming.kafka import KafkaUtils
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print >> sys.stderr, "Usage: direct_kafka_wordcount.py <broker_list> <topic>"
+        exit(-1)
+
+    sc = SparkContext(appName="PythonStreamingDirectKafkaWordCount")
+    ssc = StreamingContext(sc, 2)
+
+    brokers, topic = sys.argv[1:]
+    kvs = KafkaUtils.createStream(ssc, [topic], {"metadata.broker.list": brokers})
+    lines = kvs.map(lambda x: x[1])
+    counts = lines.flatMap(lambda line: line.split(" ")) \
+        .map(lambda word: (word, 1)) \
+        .reduceByKey(lambda a, b: a+b)
+    counts.pprint()
+
+    ssc.start()
+    ssc.awaitTermination()

--- a/examples/src/main/python/streaming/direct_kafka_wordcount.py
+++ b/examples/src/main/python/streaming/direct_kafka_wordcount.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
     ssc = StreamingContext(sc, 2)
 
     brokers, topic = sys.argv[1:]
-    kvs = KafkaUtils.createDirectStream(ssc, brokers, [topic])
+    kvs = KafkaUtils.createDirectStream(ssc, {"metadata.broker.list": brokers}, [topic])
     lines = kvs.map(lambda x: x[1])
     counts = lines.flatMap(lambda line: line.split(" ")) \
         .map(lambda word: (word, 1)) \

--- a/examples/src/main/python/streaming/direct_kafka_wordcount.py
+++ b/examples/src/main/python/streaming/direct_kafka_wordcount.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
     ssc = StreamingContext(sc, 2)
 
     brokers, topic = sys.argv[1:]
-    kvs = KafkaUtils.createDirectStream(ssc, {"metadata.broker.list": brokers}, [topic])
+    kvs = KafkaUtils.createDirectStream(ssc, [topic], {"metadata.broker.list": brokers})
     lines = kvs.map(lambda x: x[1])
     counts = lines.flatMap(lambda line: line.split(" ")) \
         .map(lambda word: (word, 1)) \

--- a/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaUtils.scala
+++ b/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaUtils.scala
@@ -21,6 +21,7 @@ import java.lang.{Integer => JInt}
 import java.lang.{Long => JLong}
 import java.util.{Map => JMap}
 import java.util.{Set => JSet}
+import java.util.{List => JList}
 
 import scala.reflect.ClassTag
 import scala.collection.JavaConversions._
@@ -558,4 +559,36 @@ private class KafkaUtilsPythonHelper {
       topics,
       storageLevel)
   }
+
+  def createRDD(
+      jsc: JavaSparkContext,
+      kafkaParams: JMap[String, String],
+      offsetRanges: JList[OffsetRange]): JavaPairRDD[Array[Byte], Array[Byte]] = {
+    KafkaUtils.createRDD[Array[Byte], Array[Byte], DefaultDecoder, DefaultDecoder](
+      jsc,
+      classOf[Array[Byte]],
+      classOf[Array[Byte]],
+      classOf[DefaultDecoder],
+      classOf[DefaultDecoder],
+      kafkaParams,
+      offsetRanges.toArray(new Array[OffsetRange](offsetRanges.size())))
+  }
+
+  def createDirectStream(
+      jssc: JavaStreamingContext,
+      kafkaParams: JMap[String, String],
+      topics: JSet[String]): JavaPairInputDStream[Array[Byte], Array[Byte]] = {
+    KafkaUtils.createDirectStream[Array[Byte], Array[Byte], DefaultDecoder, DefaultDecoder](
+      jssc,
+      classOf[Array[Byte]],
+      classOf[Array[Byte]],
+      classOf[DefaultDecoder],
+      classOf[DefaultDecoder],
+      kafkaParams,
+      topics
+    )
+  }
+
+  def createOffsetRange(topic: String, partition: Int, fromOffset: Long, untilOffset: Long)
+      : OffsetRange = OffsetRange.create(topic, partition, fromOffset, untilOffset)
 }

--- a/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaUtils.scala
+++ b/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaUtils.scala
@@ -585,8 +585,7 @@ private class KafkaUtilsPythonHelper {
       classOf[DefaultDecoder],
       classOf[DefaultDecoder],
       kafkaParams,
-      topics
-    )
+      topics)
   }
 
   def createOffsetRange(topic: String, partition: Int, fromOffset: Long, untilOffset: Long)

--- a/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaUtils.scala
+++ b/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaUtils.scala
@@ -578,7 +578,7 @@ private class KafkaUtilsPythonHelper {
   def createRDD(
       jsc: JavaSparkContext,
       kafkaParams: JMap[String, String],
-      offsetRages: JList[OffsetRange],
+      offsetRanges: JList[OffsetRange],
       leaders: JMap[TopicAndPartition, Broker]): JavaPairRDD[Array[Byte], Array[Byte]] = {
     val messageHandler = new JFunction[MessageAndMetadata[Array[Byte], Array[Byte]],
       (Array[Byte], Array[Byte])] {
@@ -599,7 +599,7 @@ private class KafkaUtilsPythonHelper {
         classOf[DefaultDecoder],
         classOf[(Array[Byte], Array[Byte])],
         kafkaParams,
-        offsetRages.toArray(new Array[OffsetRange](offsetRages.size())),
+        offsetRanges.toArray(new Array[OffsetRange](offsetRanges.size())),
         leaders,
         messageHandler
       )

--- a/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaUtils.scala
+++ b/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaUtils.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.streaming.kafka
 
-import java.io.{DataOutputStream, ByteArrayOutputStream}
 import java.lang.{Integer => JInt}
 import java.lang.{Long => JLong}
 import java.util.{Map => JMap}
@@ -642,11 +641,11 @@ private class KafkaUtilsPythonHelper {
     }
   }
 
-  def createOffsetRange(topic: String, partition: Int, fromOffset: Long, untilOffset: Long
+  def createOffsetRange(topic: String, partition: JInt, fromOffset: JLong, untilOffset: JLong
     ): OffsetRange = OffsetRange.create(topic, partition, fromOffset, untilOffset)
 
-  def createTopicAndPartition(topic: String, partition: Int): TopicAndPartition =
+  def createTopicAndPartition(topic: String, partition: JInt): TopicAndPartition =
     TopicAndPartition(topic, partition)
 
-  def createBroker(host: String, port: Int): Broker = Broker(host, port)
+  def createBroker(host: String, port: JInt): Broker = Broker(host, port)
 }

--- a/python/pyspark/streaming/kafka.py
+++ b/python/pyspark/streaming/kafka.py
@@ -18,12 +18,12 @@
 from py4j.java_collections import MapConverter, SetConverter
 from py4j.java_gateway import java_import, Py4JError, Py4JJavaError
 
+from pyspark.rdd import RDD
 from pyspark.storagelevel import StorageLevel
 from pyspark.serializers import PairDeserializer, NoOpSerializer
 from pyspark.streaming import DStream
-from pyspark.rdd import RDD
 
-__all__ = ['OffsetRange', 'KafkaUtils', 'utf8_decoder']
+__all__ = ['KafkaUtils', 'OffsetRange', 'utf8_decoder']
 
 
 def utf8_decoder(s):
@@ -193,6 +193,7 @@ ________________________________________________________________________________
     @staticmethod
     def _getClassByName(jvm, name):
         return jvm.org.apache.spark.util.Utils.classForName(name)
+
 
 class OffsetRange(object):
     """

--- a/python/pyspark/streaming/kafka.py
+++ b/python/pyspark/streaming/kafka.py
@@ -163,7 +163,7 @@ class KafkaUtils(object):
                 .loadClass("org.apache.spark.streaming.kafka.KafkaUtilsPythonHelper")
             helper = helperClass.newInstance()
             jfromOffsets = MapConverter().convert(
-                {k._jTopicAndPartition(helper): v for (k, v) in fromOffsets.items()},
+                dict([(k._jTopicAndPartition(helper), v) for (k, v) in fromOffsets.items()]),
                 ssc.sparkContext._gateway._gateway_client)
             jstream = helper.createDirectStream(ssc._jssc, jparam, jfromOffsets)
         except Py4JJavaError, e:
@@ -242,7 +242,8 @@ class KafkaUtils(object):
             joffsetRanges = ListConverter().convert([o._jOffsetRange(helper) for o in offsetRanges],
                                                     sc._gateway._gateway_client)
             jleaders = MapConverter().convert(
-                {k._jTopicAndPartition(helper): v._jBroker(helper) for (k, v) in leaders.items()},
+                dict([(k._jTopicAndPartition(helper),
+                       v._jBroker(helper)) for (k, v) in leaders.items()]),
                 sc._gateway._gateway_client)
             jrdd = helper.createRDD(sc._jsc, jparam, joffsetRanges, jleaders)
         except Py4JJavaError, e:

--- a/python/pyspark/streaming/kafka.py
+++ b/python/pyspark/streaming/kafka.py
@@ -195,7 +195,6 @@ ________________________________________________________________________________
               "scala-*/spark-streaming-kafka-assembly-*.jar"
 
 
-
 class OffsetRange(object):
     """
     Represents a range of offsets from a single Kafka TopicAndPartition.

--- a/python/pyspark/streaming/kafka.py
+++ b/python/pyspark/streaming/kafka.py
@@ -94,7 +94,7 @@ ________________________________________________________________________________
 
     @staticmethod
     def createDirectStream(ssc, topics, kafkaParams={},
-                     keyDecoder=utf8_decoder, valueDecoder=utf8_decoder):
+                           keyDecoder=utf8_decoder, valueDecoder=utf8_decoder):
         """
         Create an input stream that directly pulls messages from a Kafka Broker.
 
@@ -116,7 +116,7 @@ ________________________________________________________________________________
             array = KafkaUtils._getClassByName(ssc, "[B")
             decoder = KafkaUtils._getClassByName(ssc, "kafka.serializer.DefaultDecoder")
             jstream = ssc._jvm.KafkaUtils.createDirectStream(ssc._jssc, array, array, decoder,
-                                                            decoder, jparam, jtopics)
+                                                             decoder, jparam, jtopics)
         except Py4JError, e:
             # TODO: use --jar once it also work on driver
             if not e.message or 'call a package' in e.message:

--- a/python/pyspark/streaming/kafka.py
+++ b/python/pyspark/streaming/kafka.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-from struct import unpack
 from py4j.java_collections import ListConverter, MapConverter, SetConverter
 from py4j.java_gateway import java_import, Py4JError, Py4JJavaError
 
@@ -24,7 +23,7 @@ from pyspark.storagelevel import StorageLevel
 from pyspark.serializers import PairDeserializer, NoOpSerializer
 from pyspark.streaming import DStream
 
-__all__ = ['KafkaUtils', 'OffsetRange', 'utf8_decoder']
+__all__ = ['Broker', 'KafkaUtils', 'OffsetRange', 'TopicAndPartition', 'utf8_decoder']
 
 
 def utf8_decoder(s):

--- a/python/pyspark/streaming/kafka.py
+++ b/python/pyspark/streaming/kafka.py
@@ -106,9 +106,9 @@ ________________________________________________________________________________
         Zookeeper, you have to update Kafka/Zookeeper yourself from the streaming application.
         You can access the offsets used in each batch from the generated RDDs (see
 
-        Failure Recovery: To recover from driver failures, you have to enable checkpointing
-        in the StreamingContext. The information on consumed offset can be
-        recovered from the checkpoint. See the programming guide for details (constraints, etc.).
+        To recover from driver failures, you have to enable checkpointing in the StreamingContext.
+        The information on consumed offset can be recovered from the checkpoint.
+        See the programming guide for details (constraints, etc.).
 
         :param ssc:  StreamingContext object
         :param brokerList: A String representing a list of seed Kafka brokers (hostname:port,...)

--- a/python/pyspark/streaming/tests.py
+++ b/python/pyspark/streaming/tests.py
@@ -21,6 +21,7 @@ from itertools import chain
 import time
 import operator
 import tempfile
+import random
 import struct
 from functools import reduce
 
@@ -35,7 +36,7 @@ else:
 
 from pyspark.context import SparkConf, SparkContext, RDD
 from pyspark.streaming.context import StreamingContext
-from pyspark.streaming.kafka import KafkaUtils
+from pyspark.streaming.kafka import Broker, KafkaUtils, OffsetRange, TopicAndPartition
 
 
 class PySparkStreamingTestCase(unittest.TestCase):
@@ -590,9 +591,27 @@ class KafkaStreamTests(PySparkStreamingTestCase):
 
         super(KafkaStreamTests, self).tearDown()
 
+    def _randomTopic(self):
+        return "topic-%d" % random.randint(0, 10000)
+
+    def _validateStreamResult(self, sendData, stream):
+        result = {}
+        for i in chain.from_iterable(self._collect(stream.map(lambda x: x[1]),
+                                                   sum(sendData.values()))):
+            result[i] = result.get(i, 0) + 1
+
+        self.assertEqual(sendData, result)
+
+    def _validateRddResult(self, sendData, rdd):
+        result = {}
+        for i in rdd.map(lambda x: x[1]).collect():
+            result[i] = result.get(i, 0) + 1
+
+        self.assertEqual(sendData, result)
+
     def test_kafka_stream(self):
         """Test the Python Kafka stream API."""
-        topic = "topic1"
+        topic = self._randomTopic()
         sendData = {"a": 3, "b": 5, "c": 10}
 
         self._kafkaTestUtils.createTopic(topic)
@@ -601,13 +620,69 @@ class KafkaStreamTests(PySparkStreamingTestCase):
         stream = KafkaUtils.createStream(self.ssc, self._kafkaTestUtils.zkAddress(),
                                          "test-streaming-consumer", {topic: 1},
                                          {"auto.offset.reset": "smallest"})
+        self._validateStreamResult(sendData, stream)
 
-        result = {}
-        for i in chain.from_iterable(self._collect(stream.map(lambda x: x[1]),
-                                                   sum(sendData.values()))):
-            result[i] = result.get(i, 0) + 1
+    def test_kafka_direct_stream(self):
+        """Test the Python direct Kafka stream API."""
+        topic = self._randomTopic()
+        sendData = {"a": 1, "b": 2, "c": 3}
+        jSendData = MapConverter().convert(sendData,
+                                           self.ssc.sparkContext._gateway._gateway_client)
+        kafkaParams = {"metadata.broker.list": self._kafkaTestUtils.brokerAddress(),
+                       "auto.offset.reset": "smallest"}
 
-        self.assertEqual(sendData, result)
+        self._kafkaTestUtils.createTopic(topic)
+        self._kafkaTestUtils.sendMessages(topic, jSendData)
+
+        stream = KafkaUtils.createDirectStream(self.ssc, [topic], kafkaParams)
+        self._validateStreamResult(sendData, stream)
+
+    def test_kafka_direct_stream_from_offset(self):
+        """Test the Python direct Kafka stream API with start offset specified."""
+        topic = self._randomTopic()
+        sendData = {"a": 1, "b": 2, "c": 3}
+        jSendData = MapConverter().convert(sendData,
+                                           self.ssc.sparkContext._gateway._gateway_client)
+        fromOffsets = {TopicAndPartition(topic, 0): 0L}
+        kafkaParams = {"metadata.broker.list": self._kafkaTestUtils.brokerAddress()}
+
+        self._kafkaTestUtils.createTopic(topic)
+        self._kafkaTestUtils.sendMessages(topic, jSendData)
+
+        stream = KafkaUtils.createDirectStreamFromOffset(self.ssc, kafkaParams, fromOffsets)
+        self._validateStreamResult(sendData, stream)
+
+    def test_kafka_rdd(self):
+        """Test the Python direct Kafka RDD API."""
+        topic = self._randomTopic()
+        sendData = {"a": 1, "b": 2}
+        jSendData = MapConverter().convert(sendData,
+                                           self.ssc.sparkContext._gateway._gateway_client)
+        offsetRanges = [OffsetRange(topic, 0, 0L, sum(sendData.values()))]
+        kafkaParams = {"metadata.broker.list": self._kafkaTestUtils.brokerAddress()}
+
+        self._kafkaTestUtils.createTopic(topic)
+        self._kafkaTestUtils.sendMessages(topic, jSendData)
+
+        rdd = KafkaUtils.createRDD(self.sc, kafkaParams, offsetRanges)
+        self._validateRddResult(sendData, rdd)
+
+    def test_kafka_rdd_with_leaders(self):
+        """Test the Python direct Kafka RDD API with leaders."""
+        topic = self._randomTopic()
+        sendData = {"a": 1, "b": 2, "c": 3}
+        jSendData = MapConverter().convert(sendData,
+                                           self.ssc.sparkContext._gateway._gateway_client)
+        offsetRanges = [OffsetRange(topic, 0, 0L, sum(sendData.values()))]
+        kafkaParams = {"metadata.broker.list": self._kafkaTestUtils.brokerAddress()}
+        address = self._kafkaTestUtils.brokerAddress().split(":")
+        leaders = {TopicAndPartition(topic, 0): Broker(address[0], int(address[1]))}
+
+        self._kafkaTestUtils.createTopic(topic)
+        self._kafkaTestUtils.sendMessages(topic, jSendData)
+
+        rdd = KafkaUtils.createRDDWithLeaders(self.sc, kafkaParams, offsetRanges, leaders)
+        self._validateRddResult(sendData, rdd)
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/pyspark/streaming/tests.py
+++ b/python/pyspark/streaming/tests.py
@@ -649,7 +649,7 @@ class KafkaStreamTests(PySparkStreamingTestCase):
         self._kafkaTestUtils.createTopic(topic)
         self._kafkaTestUtils.sendMessages(topic, jSendData)
 
-        stream = KafkaUtils.createDirectStreamFromOffset(self.ssc, kafkaParams, fromOffsets)
+        stream = KafkaUtils.createDirectStream(self.ssc, [topic], kafkaParams, fromOffsets)
         self._validateStreamResult(sendData, stream)
 
     def test_kafka_rdd(self):
@@ -681,7 +681,7 @@ class KafkaStreamTests(PySparkStreamingTestCase):
         self._kafkaTestUtils.createTopic(topic)
         self._kafkaTestUtils.sendMessages(topic, jSendData)
 
-        rdd = KafkaUtils.createRDDWithLeaders(self.sc, kafkaParams, offsetRanges, leaders)
+        rdd = KafkaUtils.createRDD(self.sc, kafkaParams, offsetRanges, leaders)
         self._validateRddResult(sendData, rdd)
 
 if __name__ == "__main__":

--- a/python/pyspark/streaming/tests.py
+++ b/python/pyspark/streaming/tests.py
@@ -626,60 +626,55 @@ class KafkaStreamTests(PySparkStreamingTestCase):
         """Test the Python direct Kafka stream API."""
         topic = self._randomTopic()
         sendData = {"a": 1, "b": 2, "c": 3}
-        jSendData = MapConverter().convert(sendData,
-                                           self.ssc.sparkContext._gateway._gateway_client)
         kafkaParams = {"metadata.broker.list": self._kafkaTestUtils.brokerAddress(),
                        "auto.offset.reset": "smallest"}
 
         self._kafkaTestUtils.createTopic(topic)
-        self._kafkaTestUtils.sendMessages(topic, jSendData)
+        self._kafkaTestUtils.sendMessages(topic, sendData)
 
         stream = KafkaUtils.createDirectStream(self.ssc, [topic], kafkaParams)
         self._validateStreamResult(sendData, stream)
 
+    @unittest.skipIf(sys.version >= "3", "long type not support")
     def test_kafka_direct_stream_from_offset(self):
         """Test the Python direct Kafka stream API with start offset specified."""
         topic = self._randomTopic()
         sendData = {"a": 1, "b": 2, "c": 3}
-        jSendData = MapConverter().convert(sendData,
-                                           self.ssc.sparkContext._gateway._gateway_client)
-        fromOffsets = {TopicAndPartition(topic, 0): 0L}
+        fromOffsets = {TopicAndPartition(topic, 0): long(0)}
         kafkaParams = {"metadata.broker.list": self._kafkaTestUtils.brokerAddress()}
 
         self._kafkaTestUtils.createTopic(topic)
-        self._kafkaTestUtils.sendMessages(topic, jSendData)
+        self._kafkaTestUtils.sendMessages(topic, sendData)
 
         stream = KafkaUtils.createDirectStream(self.ssc, [topic], kafkaParams, fromOffsets)
         self._validateStreamResult(sendData, stream)
 
+    @unittest.skipIf(sys.version >= "3", "long type not support")
     def test_kafka_rdd(self):
         """Test the Python direct Kafka RDD API."""
         topic = self._randomTopic()
         sendData = {"a": 1, "b": 2}
-        jSendData = MapConverter().convert(sendData,
-                                           self.ssc.sparkContext._gateway._gateway_client)
-        offsetRanges = [OffsetRange(topic, 0, 0L, sum(sendData.values()))]
+        offsetRanges = [OffsetRange(topic, 0, long(0), long(sum(sendData.values())))]
         kafkaParams = {"metadata.broker.list": self._kafkaTestUtils.brokerAddress()}
 
         self._kafkaTestUtils.createTopic(topic)
-        self._kafkaTestUtils.sendMessages(topic, jSendData)
+        self._kafkaTestUtils.sendMessages(topic, sendData)
 
         rdd = KafkaUtils.createRDD(self.sc, kafkaParams, offsetRanges)
         self._validateRddResult(sendData, rdd)
 
+    @unittest.skipIf(sys.version >= "3", "long type not support")
     def test_kafka_rdd_with_leaders(self):
         """Test the Python direct Kafka RDD API with leaders."""
         topic = self._randomTopic()
         sendData = {"a": 1, "b": 2, "c": 3}
-        jSendData = MapConverter().convert(sendData,
-                                           self.ssc.sparkContext._gateway._gateway_client)
-        offsetRanges = [OffsetRange(topic, 0, 0L, sum(sendData.values()))]
+        offsetRanges = [OffsetRange(topic, 0, long(0), long(sum(sendData.values())))]
         kafkaParams = {"metadata.broker.list": self._kafkaTestUtils.brokerAddress()}
         address = self._kafkaTestUtils.brokerAddress().split(":")
         leaders = {TopicAndPartition(topic, 0): Broker(address[0], int(address[1]))}
 
         self._kafkaTestUtils.createTopic(topic)
-        self._kafkaTestUtils.sendMessages(topic, jSendData)
+        self._kafkaTestUtils.sendMessages(topic, sendData)
 
         rdd = KafkaUtils.createRDD(self.sc, kafkaParams, offsetRanges, leaders)
         self._validateRddResult(sendData, rdd)


### PR DESCRIPTION
Currently only added `createDirectStream` API, I'm not sure if `createRDD` is also needed, since some Java object needs to be wrapped in Python. Please help to review, thanks a lot.
