### PR TITLE
[Spark-5967] [UI] Correctly clean JobProgressListener.stageIdToActiveJobIds

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
@@ -130,10 +130,6 @@ class JobProgressListener(conf: SparkConf) extends SparkListener with Logging {
       stages.take(toRemove).foreach { s =>
         stageIdToData.remove((s.stageId, s.attemptId))
         stageIdToInfo.remove(s.stageId)
-        stageIdToActiveJobIds.get(s.stageId).map(_.size) match {
-          case Some(0) => stageIdToActiveJobIds.remove(s.stageId)
-          case _ =>
-        }
       }
       stages.trimStart(toRemove)
     }
@@ -207,6 +203,9 @@ class JobProgressListener(conf: SparkConf) extends SparkListener with Logging {
     for (stageId <- jobData.stageIds) {
       stageIdToActiveJobIds.get(stageId).foreach { jobsUsingStage =>
         jobsUsingStage.remove(jobEnd.jobId)
+        if (jobsUsingStage.isEmpty) {
+          stageIdToActiveJobIds.remove(stageId)
+        }
         stageIdToInfo.get(stageId).foreach { stageInfo =>
           if (stageInfo.submissionTime.isEmpty) {
             // if this stage is pending, it won't complete, so mark it as "skipped":

--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobProgressListener.scala
@@ -130,6 +130,10 @@ class JobProgressListener(conf: SparkConf) extends SparkListener with Logging {
       stages.take(toRemove).foreach { s =>
         stageIdToData.remove((s.stageId, s.attemptId))
         stageIdToInfo.remove(s.stageId)
+        stageIdToActiveJobIds.get(s.stageId).map(_.size) match {
+          case Some(0) => stageIdToActiveJobIds.remove(s.stageId)
+          case _ =>
+        }
       }
       stages.trimStart(toRemove)
     }


### PR DESCRIPTION
Patch should be self-explanatory
@pwendell @JoshRosen 
