### PR TITLE
[SPARK-5914] to run spark-submit requiring only user perm on windows

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -439,13 +439,12 @@ private[spark] object Utils extends Logging {
       executeAndGetOutput(Seq("tar", "-xf", fileName), targetDir)
     }
     // Make the file executable - That's necessary for scripts
-    if(isWindows){
-      // Windows does not grant read permission by default to non-admin users
-      // Add read permission to owner explicitly
+    FileUtil.chmod(targetFile.getAbsolutePath, "a+x")
+
+    // Windows does not grant read permission by default to non-admin users
+    // Add read permission to owner explicitly
+    if (isWindows){
       FileUtil.chmod(targetFile.getAbsolutePath, "u+r")
-      FileUtil.chmod(targetFile.getAbsolutePath, "a+x")
-    } else {
-      FileUtil.chmod(targetFile.getAbsolutePath, "a+x")
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -439,7 +439,14 @@ private[spark] object Utils extends Logging {
       executeAndGetOutput(Seq("tar", "-xf", fileName), targetDir)
     }
     // Make the file executable - That's necessary for scripts
-    FileUtil.chmod(targetFile.getAbsolutePath, "a+x")
+    if(isWindows){
+      // Windows does not grant read permission by default to non-admin users
+      // Add read permission to owner explicitly
+      FileUtil.chmod(targetFile.getAbsolutePath, "u+r")
+      FileUtil.chmod(targetFile.getAbsolutePath, "a+x")
+    } else {
+      FileUtil.chmod(targetFile.getAbsolutePath, "a+x")
+    }
   }
 
   /**


### PR DESCRIPTION
Because windows on-default does not grant read permission to jars except to admin, spark-submit would fail with "ClassNotFound" exception if user runs slave service with only user permission. 
This fix is to add read permission to owner of the jar (which would be the slave service account in windows ) 
