### PR TITLE
[SPARK-5929] Pyspark: Register a pip requirements file with spark_context

### DIFF
--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -107,15 +107,15 @@ class SparkContext(object):
         self._callsite = first_spark_call() or CallSite(None, None, None)
         SparkContext._ensure_initialized(self, gateway=gateway)
         try:
-            self._do_init(master, appName, sparkHome, pyFiles, requiremnetsFile, environment,
+            self._do_init(master, appName, sparkHome, pyFiles, requirementsFile, environment,
                     batchSize, serializer, conf, jsc, profiler_cls)
         except:
             # If an error occurs, clean up in order to allow future SparkContext creation:
             self.stop()
             raise
 
-    def _do_init(self, master, appName, sparkHome, pyFiles, environment, batchSize, serializer,
-                 conf, jsc, profiler_cls):
+    def _do_init(self, master, appName, sparkHome, pyFiles, requirementsFile, environment,
+                batchSize, serializer, conf, jsc, profiler_cls):
         self.environment = environment or {}
         self._conf = conf or SparkConf(_jvm=self._jvm)
         self._batchSize = batchSize  # -1 represents an unlimited batch size

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -184,7 +184,7 @@ class SparkContext(object):
             self.addPyFile(path)
 
         # Deplpoy code dependencies from requirements file in the constructor
-        if requirementsFIle:
+        if requirementsFile:
             self.addRequirementsFile(requirementsFile)
 
         # Deploy code dependencies set by spark-submit; these will already have been added
@@ -733,8 +733,9 @@ class SparkContext(object):
             mod = importlib.import_module(req.name) #throws ImportError
             mod_path = mod.__path__[0]
             tar_path = req.name+'.tar.gz'
-            with tarfile.open(tar_path, "w:gz") as tar:
-                tar.add(mod_path, arcname=os.path.basename(mod_path))
+            tar = tarfile.open(tar_path, "w:gz")
+            tar.add(mod_path, arcname=os.path.basename(mod_path))
+            tar.close()
             self.addPyFile(tar_path)
             os.remove(tar_path)
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-5929

Register a pip requirements file with the spark_context which will ship all defined dependencies to the workers. Functions similarly to addPyFile.
