### PR TITLE
[SPARK-6006][SQL]: Optimize count distinct for high cardinality columns

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -446,11 +446,14 @@ class Analyzer(
     def apply(plan: LogicalPlan): LogicalPlan = plan transform {
       case Project(projectList, child) if containsAggregates(projectList) =>
         var op: Seq[Expression] = Nil
+        var i = 0
         projectList.foreach(_.foreach {
           case CountDistinct(exp) => op = op ++ exp
+          i += 1
+          case agg: AggregateExpression => i += 1
           case _ =>
         })
-        if(op.size > 0) {
+        if(i == 1) {
           Aggregate(op, projectList, child)
         } else {
           Aggregate(Nil, projectList, child)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -29,8 +29,6 @@ import org.apache.spark.sql.sources.{CreateTableUsing, CreateTempTableUsing, Des
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{SQLContext, Strategy, execution}
 
-import scala.collection.mutable.ArrayBuffer
-
 private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
   self: SQLContext#SparkPlanner =>
 
@@ -144,7 +142,7 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
              partialComputation,
              child) =>
         val cdExpression: NamedExpression = rewrittenAggregateExpressions match {
-          case ArrayBuffer(pname@Alias(CombineSetsAndCount(_), _)) => pname
+          case Seq(pname@Alias(CombineSetsAndCount(_), _)) => pname
           case _ => null
         }
         

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -149,18 +149,19 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         }
         
         if (cdExpression != null) {
-          execution.Aggregate(partial = false,
-          Nil,
-          Alias(Sum(cdExpression.toAttribute), "totalCount")()::Nil,
-           execution.Aggregate(
+          execution.Aggregate(
             partial = false,
-            namedGroupingAttributes,
-            rewrittenAggregateExpressions,
+            Nil,
+            Alias(Sum(cdExpression.toAttribute), "totalCount")()::Nil,
             execution.Aggregate(
-              partial = true,
-              groupingExpressions,
-              partialComputation,
-              planLater(child)))) :: Nil 
+              partial = false,
+              namedGroupingAttributes,
+              rewrittenAggregateExpressions,
+              execution.Aggregate(
+                partial = true,
+                groupingExpressions,
+                partialComputation,
+                planLater(child)))) :: Nil 
         } else {
           execution.Aggregate(
             partial = false,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -146,7 +146,7 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         rewrittenAggregateExpressions.map(
           exp => exp match {
             case pname@Alias(CombineSetsAndCount(_), _) =>
-              cdExpression = cdExpression :+ Alias(Sum(pname.toAttribute), "distinctCount")()
+              cdExpression = cdExpression :+ Alias(SumZero(pname.toAttribute), "distinctCount")()
               i += 1
             case _ => i += 2
         })


### PR DESCRIPTION
Currently the plan for count distinct looks like this : 

Aggregate false, [snAppProtocol#448], [CombineAndCount(partialSets#513) AS _c0#437L]
   Exchange SinglePartition
    Aggregate true, [snAppProtocol#448], [snAppProtocol#448,AddToHashSet(snAppProtocol#448) AS partialSets#513]
     !OutputFaker [snAppProtocol#448]
      ParquetTableScan [snAppProtocol#587], (ParquetRelation hdfs://192.168.160.57:9000/data/collector/13/11/14, Some(Configuration: core-default.xml, core-site.xml, mapred-default.xml, mapred-site.xml, yarn-default.xml, yarn-site.xml, hdfs-default.xml, hdfs-site.xml), org.apache.spark.sql.hive.HiveContext@6b1ed434, [ptime#443], ptime=2014-11-13 00%3A55%3A00), []

This can be slow if there are too many distinct values in a column. This PR changes the above plan to : 

Aggregate false, [], [SUM(_c0#437L) AS totalCount#514L]
 Exchange SinglePartition
  Aggregate false, [snAppProtocol#448], [CombineAndCount(partialSets#513) AS _c0#437L]
   Exchange (HashPartitioning [snAppProtocol#448], 200)
    Aggregate true, [snAppProtocol#448], [snAppProtocol#448,AddToHashSet(snAppProtocol#448) AS partialSets#513]
     !OutputFaker [snAppProtocol#448]
      ParquetTableScan [snAppProtocol#587], (ParquetRelation hdfs://192.168.160.57:9000/data/collector/13/11/14, Some(Configuration: core-default.xml, core-site.xml, mapred-default.xml, mapred-site.xml, yarn-default.xml, yarn-site.xml, hdfs-default.xml, hdfs-site.xml), org.apache.spark.sql.hive.HiveContext@6b1ed434, [ptime#443], ptime=2014-11-13 00%3A55%3A00), []

This way even if there are too many distinct values; we insert them into partial maps and computation remains distributed and thus faster.
