### PR TITLE
Modify default value description for spark.scheduler.minRegisteredResourcesRatio on docs.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1018,7 +1018,7 @@ Apart from these, the following properties are also available, and may be useful
 </tr>
 <tr>
   <td><code>spark.scheduler.minRegisteredResourcesRatio</code></td>
-  <td>0.0 for Mesos and Standalone mode, 0.8 for YARN</td>
+  <td>0.0 for Standalone mode, 0.8 for YARN</td>
   <td>
     The minimum ratio of registered resources (registered resources / total expected resources)
     (resources are executors in yarn mode, CPU cores in standalone mode)


### PR DESCRIPTION
The configuration is not supported in mesos mode now.
See https://github.com/apache/spark/pull/1462
