### PR TITLE
SPARK-794 [CORE] Backport. Remove sleep() in ClusterScheduler.stop

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -394,9 +394,6 @@ private[spark] class TaskSchedulerImpl(
       taskResultGetter.stop()
     }
     starvationTimer.cancel()
-
-    // sleeping for an arbitrary 1 seconds to ensure that messages are sent out.
-    Thread.sleep(1000L)
   }
 
   override def defaultParallelism() = backend.defaultParallelism()


### PR DESCRIPTION
Backport https://github.com/apache/spark/pull/3851 to branch 1.2: remove Thread.sleep(1000) in TaskSchedulerImpl.
Teeing this up for Jenkins per discussion in the JIRA / PR.
