### PR TITLE
fix spark-6033, clarify the spark.worker.cleanup behavior in standalone mode

### DIFF
--- a/docs/spark-standalone.md
+++ b/docs/spark-standalone.md
@@ -222,8 +222,7 @@ SPARK_WORKER_OPTS supports the following system properties:
   <td>false</td>
   <td>
     Enable periodic cleanup of worker / application directories.  Note that this only affects standalone
-    mode, as YARN works differently. Applications directories are cleaned up regardless of whether
-    the application is still running.
+    mode, as YARN works differently. Only the stopped applications directories are cleaned up.
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
jira case spark-6033 https://issues.apache.org/jira/browse/SPARK-6033

In standalone deploy mode, the cleanup will only remove the stopped application's directories.  

The original description about the cleanup behavior is incorrect.
