### PR TITLE
[SPARK-6050] [yarn] Relax matching of vcore count in received containers.

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -291,16 +291,11 @@ private[yarn] class YarnAllocator(
       containersToUse: ArrayBuffer[Container],
       remaining: ArrayBuffer[Container]): Unit = {
     // SPARK-6050: certain Yarn configurations return a virtual core count that doesn't match the
-    // request; for example, capacity scheduler + DefaultResourceCalculator. Allow users in those
-    // situations to disable matching of the core count.
-    val matchingResource =
-      if (sparkConf.getBoolean("spark.yarn.container.disableCpuMatching", false)) {
-        Resource.newInstance(allocatedContainer.getResource().getMemory(),
-          resource.getVirtualCores())
-      } else {
-        allocatedContainer.getResource
-      }
-
+    // request; for example, capacity scheduler + DefaultResourceCalculator. So match on requested
+    // memory, but use the asked vcore count for matching, effectively disabling matching on vcore
+    // count.
+    val matchingResource = Resource.newInstance(allocatedContainer.getResource.getMemory,
+          resource.getVirtualCores)
     val matchingRequests = amClient.getMatchingRequests(allocatedContainer.getPriority, location,
       matchingResource)
 


### PR DESCRIPTION
Some YARN configurations return a vcore count for allocated
containers that does not match the requested resource. That means
Spark would always ignore those containers. So relax the the matching
of the vcore count to allow the Spark jobs to run.
