### PR TITLE
[SPARK-6138][CORE][minor] enhance the `toArray` method in `SizeTrackingVector`

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/collection/PrimitiveVector.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/PrimitiveVector.scala
@@ -78,7 +78,12 @@ class PrimitiveVector[@specialized(Long, Int, Double) V: ClassTag](initialSize: 
     this
   }
 
-  protected def copyArrayWithLength(length: Int): Array[V] = {
+  /** Return a trimmed version of the underlying array. */
+  def toArray: Array[V] = {
+    copyArrayWithLength(size)
+  }
+
+  private def copyArrayWithLength(length: Int): Array[V] = {
     val copy = new Array[V](length)
     _array.copyToArray(copy)
     copy

--- a/core/src/main/scala/org/apache/spark/util/collection/PrimitiveVector.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/PrimitiveVector.scala
@@ -71,12 +71,16 @@ class PrimitiveVector[@specialized(Long, Int, Double) V: ClassTag](initialSize: 
 
   /** Resizes the array, dropping elements if the total length decreases. */
   def resize(newLength: Int): PrimitiveVector[V] = {
-    val newArray = new Array[V](newLength)
-    _array.copyToArray(newArray)
-    _array = newArray
+    _array = copyArrayWithLength(newLength)
     if (newLength < _numElements) {
       _numElements = newLength
     }
     this
+  }
+
+  protected def copyArrayWithLength(length: Int): Array[V] = {
+    val copy = new Array[V](length)
+    _array.copyToArray(copy)
+    copy
   }
 }

--- a/core/src/main/scala/org/apache/spark/util/collection/SizeTrackingVector.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/SizeTrackingVector.scala
@@ -36,11 +36,4 @@ private[spark] class SizeTrackingVector[T: ClassTag]
     resetSamples()
     this
   }
-
-  /**
-   * Return a trimmed version of the underlying array.
-   */
-  def toArray: Array[T] = {
-    super.copyArrayWithLength(size)
-  }
 }

--- a/core/src/main/scala/org/apache/spark/util/collection/SizeTrackingVector.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/SizeTrackingVector.scala
@@ -41,6 +41,6 @@ private[spark] class SizeTrackingVector[T: ClassTag]
    * Return a trimmed version of the underlying array.
    */
   def toArray: Array[T] = {
-    super.iterator.toArray
+    super.copyArrayWithLength(size)
   }
 }


### PR DESCRIPTION
Use array copy instead of `Iterator#toArray` to make it more efficient.
