### PR TITLE
[SPARK-6078][CORE] create event log dir if not exists

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -86,10 +86,13 @@ private[spark] class EventLoggingListener(
    * Creates the log file in the configured log directory.
    */
   def start() {
-    if (!fileSystem.isDirectory(new Path(logBaseDir))) {
-      throw new IllegalArgumentException(s"Log directory $logBaseDir does not exist.")
+    val logBasePath = new Path(logBaseDir)
+    if (!fileSystem.exists(logBasePath) || !fileSystem.isDirectory(logBasePath)) {
+      if (!fileSystem.mkdirs(logBasePath)) {
+        throw new IOException(s"Failed to create EventLog dir: $logBaseDir.")
+      }
     }
-
+      
     val workingPath = logPath + IN_PROGRESS
     val uri = new URI(workingPath)
     val path = new Path(workingPath)

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -87,9 +87,13 @@ private[spark] class EventLoggingListener(
    */
   def start() {
     val logBasePath = new Path(logBaseDir)
-    if (!fileSystem.exists(logBasePath) || !fileSystem.isDirectory(logBasePath)) {
+    if (!fileSystem.isDirectory(logBasePath)) {
+      if (fileSystem.exists(logBasePath)) {
+        throw new IllegalArgumentException(s"Event log dir $logBaseDir is not a directory.")
+      }
+      logWarning(s"Event log dir $logBaseDir does not exists, will newly create one.")
       if (!fileSystem.mkdirs(logBasePath)) {
-        throw new IOException(s"Failed to create EventLog dir: $logBaseDir.")
+        throw new IOException(s"Failed to create event log dir $logBaseDir.")
       }
     }
       


### PR DESCRIPTION
when event log directory does not exists, spark just throw IlleagalArgumentException and stop the job. User need manually create directory first. It's better to create the directory automatically if the directory does not exists.
