### PR TITLE
SPARK-5628 [EC2] Backport: Add version option to spark-ec2

### DIFF
--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -39,8 +39,10 @@ import boto
 from boto.ec2.blockdevicemapping import BlockDeviceMapping, BlockDeviceType, EBSBlockDeviceType
 from boto import ec2
 
-DEFAULT_SPARK_VERSION = "1.2.1"
+SPARK_EC2_VERSION = "1.2.2"
 SPARK_EC2_DIR = os.path.dirname(os.path.realpath(__file__))
+
+DEFAULT_SPARK_VERSION = SPARK_EC2_VERSION
 
 MESOS_SPARK_EC2_BRANCH = "v4"
 # A URL prefix from which to fetch AMI information
@@ -54,12 +56,10 @@ class UsageError(Exception):
 # Configure and parse our command-line arguments
 def parse_args():
     parser = OptionParser(
-        usage="spark-ec2 [options] <action> <cluster_name>"
-        + "\n\n<action> can be: launch, destroy, login, stop, start, get-master, reboot-slaves",
-        add_help_option=False)
-    parser.add_option(
-        "-h", "--help", action="help",
-        help="Show this help message and exit")
+        prog="spark-ec2",
+        version="%prog {v}".format(v=SPARK_EC2_VERSION),
+        usage="%prog [options] <action> <cluster_name>\n\n"
+        + "<action> can be: launch, destroy, login, stop, start, get-master, reboot-slaves")
     parser.add_option(
         "-s", "--slaves", type="int", default=1,
         help="Number of slaves to launch (default: %default)")


### PR DESCRIPTION
Backport of https://github.com/apache/spark/pull/4414 to 1.2: Add version option to spark-ec2

@nchammas @JoshRosen : is this about the right backporting of this change?
