### PR TITLE
[SPARK-5771][UI] Display the actual cores requested when app is finished

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/ApplicationInfo.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ApplicationInfo.scala
@@ -43,6 +43,7 @@ private[spark] class ApplicationInfo(
   @transient var coresGranted: Int = _
   @transient var endTime: Long = _
   @transient var appSource: ApplicationSource = _
+  @transient var actualCoresRequested: Int = _
 
   @transient private var nextExecutorId: Int = _
 
@@ -79,6 +80,7 @@ private[spark] class ApplicationInfo(
     val exec = new ExecutorDesc(newExecutorId(useID), this, worker, cores, desc.memoryPerSlave)
     executors(exec.id) = exec
     coresGranted += cores
+    actualCoresRequested += cores
     exec
   }
 

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
@@ -218,7 +218,13 @@ private[spark] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
         }
       }
       <td>
-        {if (app.requestedCores == Int.MaxValue) "*" else app.requestedCores}
+        {
+          if (active) {
+            if (app.requestedCores == Int.MaxValue) "*" else app.requestedCores
+          } else {
+            app.actualCoresRequested
+          }
+        }
       </td>
       <td sorttable_customkey={app.desc.memoryPerSlave.toString}>
         {Utils.megabytesToString(app.desc.memoryPerSlave)}


### PR DESCRIPTION
Display the actual requested cores when app is finished if default core is not set, shows as below:

![image](https://cloud.githubusercontent.com/assets/850797/6429570/52c5ef1c-bf90-11e4-98bb-32b6320be10a.png)

CC @andrewor14, is that what you intended to? My concern is that if standalone dynamic scaling is supported, it is hard to get the actual requested cores.
