### PR TITLE
SPARK-4705:[core] Write event logs of different application attempts to different files.

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -370,7 +370,7 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
   taskScheduler.start()
 
   val applicationId: String = taskScheduler.applicationId()
-  val applicationAttemptId : String = taskScheduler.applicationAttemptId()
+  val applicationAttemptId: String = taskScheduler.applicationAttemptId()
   conf.set("spark.app.id", applicationId)
 
   env.blockManager.initialize(applicationId)
@@ -386,9 +386,8 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
   // Optionally log Spark events
   private[spark] val eventLogger: Option[EventLoggingListener] = {
     if (isEventLogEnabled) {
-      val logger =
-        new EventLoggingListener(applicationId, applicationAttemptId,
-                                 eventLogDir.get, conf, hadoopConfiguration)
+      val logger = new EventLoggingListener(
+          applicationId, applicationAttemptId, eventLogDir.get, conf, hadoopConfiguration)
       logger.start()
       listenerBus.addListener(logger)
       Some(logger)

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -370,6 +370,7 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
   taskScheduler.start()
 
   val applicationId: String = taskScheduler.applicationId()
+  val applicationAttemptId : String = taskScheduler.applicationAttemptId()
   conf.set("spark.app.id", applicationId)
 
   env.blockManager.initialize(applicationId)
@@ -386,7 +387,8 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
   private[spark] val eventLogger: Option[EventLoggingListener] = {
     if (isEventLogEnabled) {
       val logger =
-        new EventLoggingListener(applicationId, eventLogDir.get, conf, hadoopConfiguration)
+        new EventLoggingListener(applicationId, applicationAttemptId,
+                                 eventLogDir.get, conf, hadoopConfiguration)
       logger.start()
       listenerBus.addListener(logger)
       Some(logger)

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1736,7 +1736,7 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
     // Note: this code assumes that the task scheduler has been initialized and has contacted
     // the cluster manager to get an application ID (in case the cluster manager provides one).
     listenerBus.post(SparkListenerApplicationStart(appName, Some(applicationId),
-      startTime, sparkUser))
+      startTime, sparkUser, applicationAttemptId))
   }
 
   /** Post the application end event */

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
@@ -26,7 +26,8 @@ private[spark] case class ApplicationHistoryInfo(
     endTime: Long,
     lastUpdated: Long,
     sparkUser: String,
-    completed: Boolean = false)
+    completed: Boolean = false,
+    appAttemptId: String = "") 
 
 private[spark] abstract class ApplicationHistoryProvider {
 

--- a/core/src/main/scala/org/apache/spark/scheduler/ApplicationEventListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ApplicationEventListener.scala
@@ -26,6 +26,7 @@ package org.apache.spark.scheduler
 private[spark] class ApplicationEventListener extends SparkListener {
   var appName: Option[String] = None
   var appId: Option[String] = None
+  var appAttemptId: Option[String] = None
   var sparkUser: Option[String] = None
   var startTime: Option[Long] = None
   var endTime: Option[Long] = None
@@ -35,6 +36,7 @@ private[spark] class ApplicationEventListener extends SparkListener {
   override def onApplicationStart(applicationStart: SparkListenerApplicationStart) {
     appName = Some(applicationStart.appName)
     appId = applicationStart.appId
+    appAttemptId = Some(applicationStart.appAttemptId)
     startTime = Some(applicationStart.time)
     sparkUser = Some(applicationStart.sparkUser)
   }

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -282,9 +282,9 @@ private[spark] object EventLoggingListener extends Logging {
     val name = appId.replaceAll("[ :/]", "-").replaceAll("[${}'\"]", "_").toLowerCase
     
    if (appAttemptId.equals("")) { 
-      Utils.resolveURI(logBaseDir) + "/" + name.stripSuffix("/")
+      Utils.resolveURI(logBaseDir) + "/" + name.stripSuffix("/") 
    } else {
-      Utils.resolveURI(logBaseDir) + "/" + appAttemptId + "/" + name.stripSuffix("/")
+      Utils.resolveURI(logBaseDir) + "/" + name.stripSuffix("/") +  "_" + appAttemptId 
    }
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/SchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SchedulerBackend.scala
@@ -41,4 +41,11 @@ private[spark] trait SchedulerBackend {
    */
   def applicationId(): String = appId
 
+  /**
+   * Get an application ID associated with the job.
+   *
+   * @return An application attempt id
+   */
+  def applicationAttemptId(): String = ""
+
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
@@ -110,8 +110,8 @@ case class SparkListenerExecutorMetricsUpdate(
   extends SparkListenerEvent
 
 @DeveloperApi
-case class SparkListenerApplicationStart(appName: String, appId: Option[String], time: Long,
-  sparkUser: String) extends SparkListenerEvent
+case class SparkListenerApplicationStart(appName: String, appId: Option[String], 
+   time: Long, sparkUser: String, appAttemptId: String = "") extends SparkListenerEvent 
 
 @DeveloperApi
 case class SparkListenerApplicationEnd(time: Long) extends SparkListenerEvent

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskScheduler.scala
@@ -78,4 +78,12 @@ private[spark] trait TaskScheduler {
    * Process a lost executor
    */
   def executorLost(executorId: String, reason: ExecutorLossReason): Unit
+
+  /**
+   * Get an application's attempt Id  associated with the job.
+   *
+   * @return An application's Attempt ID
+   */
+  def applicationAttemptId(): String = ""
+
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -514,6 +514,8 @@ private[spark] class TaskSchedulerImpl(
   }
 
   override def applicationId(): String = backend.applicationId()
+  
+  override def applicationAttemptId() : String = backend.applicationAttemptId()
 
 }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -515,7 +515,7 @@ private[spark] class TaskSchedulerImpl(
 
   override def applicationId(): String = backend.applicationId()
   
-  override def applicationAttemptId() : String = backend.applicationAttemptId()
+  override def applicationAttemptId(): String = backend.applicationAttemptId()
 
 }
 

--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -192,7 +192,8 @@ private[spark] object JsonProtocol {
     ("App Name" -> applicationStart.appName) ~
     ("App ID" -> applicationStart.appId.map(JString(_)).getOrElse(JNothing)) ~
     ("Timestamp" -> applicationStart.time) ~
-    ("User" -> applicationStart.sparkUser)
+    ("User" -> applicationStart.sparkUser) ~
+    ("appAttemptId" -> applicationStart.appAttemptId)
   }
 
   def applicationEndToJson(applicationEnd: SparkListenerApplicationEnd): JValue = {
@@ -553,7 +554,8 @@ private[spark] object JsonProtocol {
     val appId = Utils.jsonOption(json \ "App ID").map(_.extract[String])
     val time = (json \ "Timestamp").extract[Long]
     val sparkUser = (json \ "User").extract[String]
-    SparkListenerApplicationStart(appName, appId, time, sparkUser)
+    val appAttemptId = (json \ "appAttemptId").extract[String]
+    SparkListenerApplicationStart(appName, appId, time, sparkUser, appAttemptId)
   }
 
   def applicationEndFromJson(json: JValue): SparkListenerApplicationEnd = {

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -92,6 +92,10 @@ private[spark] class ApplicationMaster(
 
         // Propagate the application ID so that YarnClusterSchedulerBackend can pick it up.
         System.setProperty("spark.yarn.app.id", appAttemptId.getApplicationId().toString())
+
+       //Propagate the attempt if, so that in case of event logging, different attempt's logs gets created in different directory
+       System.setProperty("spark.yarn.app.attemptid", appAttemptId.getAttemptId().toString())
+
       }
 
       logInfo("ApplicationAttemptId: " + appAttemptId)

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -93,7 +93,8 @@ private[spark] class ApplicationMaster(
         // Propagate the application ID so that YarnClusterSchedulerBackend can pick it up.
         System.setProperty("spark.yarn.app.id", appAttemptId.getApplicationId().toString())
 
-       //Propagate the attempt if, so that in case of event logging, different attempt's logs gets created in different directory
+       // Propagate the attempt if, so that in case of event logging, 
+       // different attempt's logs gets created in different directory
        System.setProperty("spark.yarn.app.attemptid", appAttemptId.getAttemptId().toString())
 
       }

--- a/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClusterSchedulerBackend.scala
+++ b/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClusterSchedulerBackend.scala
@@ -46,5 +46,10 @@ private[spark] class YarnClusterSchedulerBackend(
       logError("Application ID is not set.")
       super.applicationId
     }
-
+  
+  override def applicationAttemptId(): String =
+    sc.getConf.getOption("spark.yarn.app.attemptid").getOrElse {
+      logError("Application attempt ID is not set.")
+      super.applicationAttemptId
+    }
 }

--- a/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClusterSchedulerBackend.scala
+++ b/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClusterSchedulerBackend.scala
@@ -48,6 +48,9 @@ private[spark] class YarnClusterSchedulerBackend(
     }
   
   override def applicationAttemptId(): String =
+    // In YARN Cluster mode, spark.yarn.app.attemptid is expect to be set
+    // before user application is launched.
+    // So, if spark.yarn.app.id is not set, it is something wrong.
     sc.getConf.getOption("spark.yarn.app.attemptid").getOrElse {
       logError("Application attempt ID is not set.")
       super.applicationAttemptId


### PR DESCRIPTION
Hi,

Following is the approach taken:
1. For applications with attempt ID," _<attempt_id>" has been added to file name, while creating the event log file. For example, with attempt id file name will be : application_1423546284151_0031_2
1. Added the attempt id inside the SparkListenerApplicationStart event, so that same can be read while replaying the event log file too.
2. If there is no application with attempt id info (e.g. all played in client mode ), then old UI will continue to display, as an application with attempt id has been logged, then following new UI will start appearing 

![updated ui - ii](https://cloud.githubusercontent.com/assets/7300226/6431362/9387c7be-c053-11e4-9ea9-127d637e3a45.png)
