### PR TITLE
[SPARK-6107][CORE] Display inprogress application information for event log history for standalone mode

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -755,7 +755,7 @@ private[spark] class Master(
       }
       
       val eventLogFile = eventLogFilePrefix + {
-        if(inProgressExists) EventLoggingListener.IN_PROGRESS
+        if (inProgressExists) EventLoggingListener.IN_PROGRESS
       }
       val status = if (eventLogFile.endsWith(EventLoggingListener.IN_PROGRESS)) " (inprogress)" 
         else " (completed)"

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -755,7 +755,7 @@ private[spark] class Master(
       }
       
       val (eventLogFile, status) = if (inProgressExists) {
-        (eventLogFilePrefix + EventLoggingListener.IN_PROGRESS, " (inprogress)")
+        (eventLogFilePrefix + EventLoggingListener.IN_PROGRESS, " (in progress)")
       } else {
         (eventLogFilePrefix, " (completed)")
       }

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -750,7 +750,7 @@ private[spark] class Master(
       
       if (inProgressExists) {
         // Event logging is enabled for this application, but the application is still in progress
-        logWarning(s"Application $appName is still in progress, it may be terminated accidently.")
+        logWarning(s"Application $appName is still in progress, it may be terminated abnormally.")
       }
       
       val (eventLogFile, status) = if (inProgressExists) {

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -750,16 +750,16 @@ private[spark] class Master(
       
       if (inProgressExists) {
         // Event logging is enabled for this application, but the application is still in progress
-        var msg = s"Application $appName is still in progress, it may be terminated accidently."
-        logWarning(msg)
+        logWarning(s"Application $appName is still in progress, it may be terminated accidently.")
       }
       
-      val eventLogFile = eventLogFilePrefix + {
-        if (inProgressExists) EventLoggingListener.IN_PROGRESS
+      val eventLogFile = if (inProgressExists) {
+        eventLogFilePrefix + EventLoggingListener.IN_PROGRESS
+      } else {
+        eventLogFilePrefix
       }
-      val status = if (eventLogFile.endsWith(EventLoggingListener.IN_PROGRESS)) " (inprogress)" 
-        else " (completed)"
 
+      val status = if (inProgressExists) " (inprogress)" else " (completed)"
       val logInput = EventLoggingListener.openEventLog(new Path(eventLogFile), fs)
       val replayBus = new ReplayListenerBus()
       val ui = SparkUI.createHistoryUI(new SparkConf, replayBus, new SecurityManager(conf),

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -753,13 +753,12 @@ private[spark] class Master(
         logWarning(s"Application $appName is still in progress, it may be terminated accidently.")
       }
       
-      val eventLogFile = if (inProgressExists) {
-        eventLogFilePrefix + EventLoggingListener.IN_PROGRESS
+      val (eventLogFile, status) = if (inProgressExists) {
+        (eventLogFilePrefix + EventLoggingListener.IN_PROGRESS, " (inprogress)")
       } else {
-        eventLogFilePrefix
+        (eventLogFilePrefix, " (completed)")
       }
-
-      val status = if (inProgressExists) " (inprogress)" else " (completed)"
+      
       val logInput = EventLoggingListener.openEventLog(new Path(eventLogFile), fs)
       val replayBus = new ReplayListenerBus()
       val ui = SparkUI.createHistoryUI(new SparkConf, replayBus, new SecurityManager(conf),

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -747,7 +747,7 @@ private[spark] class Master(
       val fs = Utils.getHadoopFileSystem(eventLogDir, hadoopConf)
       val eventLogFileSuffix = if (fs.exists(new Path(eventLogFilePrefix + 
           EventLoggingListener.IN_PROGRESS))) {
-        // Event logging is enabled for this application, but the application is still in progress        
+        // Event logging is enabled for this application, but the application is still in progress
         var msg = s"Application $appName is still in progress, it may be terminated accidently."
         logWarning(msg)
         EventLoggingListener.IN_PROGRESS

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -745,15 +745,18 @@ private[spark] class Master(
       
       val eventLogFilePrefix = EventLoggingListener.getLogPath(eventLogDir, app.id, app.desc.eventLogCodec)        
       val fs = Utils.getHadoopFileSystem(eventLogDir, hadoopConf)
-      val eventLogFileSuffix = if (fs.exists(new Path(eventLogFilePrefix + 
-          EventLoggingListener.IN_PROGRESS))) {
+      val inProgressExists = fs.exists(new Path(eventLogFilePrefix + 
+          EventLoggingListener.IN_PROGRESS))
+      
+      if (inProgressExists) {
         // Event logging is enabled for this application, but the application is still in progress
         var msg = s"Application $appName is still in progress, it may be terminated accidently."
         logWarning(msg)
-        EventLoggingListener.IN_PROGRESS
-      } else ""
+      }
       
-      val eventLogFile = eventLogFilePrefix + eventLogFileSuffix
+      val eventLogFile = eventLogFilePrefix + {
+        if(inProgressExists) EventLoggingListener.IN_PROGRESS
+      }
       val status = if (eventLogFile.endsWith(EventLoggingListener.IN_PROGRESS)) " (inprogress)" 
         else " (completed)"
 

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -745,7 +745,7 @@ private[spark] class Master(
       
       val eventLogFilePrefix = EventLoggingListener.getLogPath(eventLogDir, app.id, app.desc.eventLogCodec)        
       val fs = Utils.getHadoopFileSystem(eventLogDir, hadoopConf)
-      val eventLogFileSuffix = if (fs.exists(new Path(eventLogDir + 
+      val eventLogFileSuffix = if (fs.exists(new Path(eventLogFilePrefix + 
           EventLoggingListener.IN_PROGRESS))) {
         // Event logging is enabled for this application, but the application is still in progress        
         var msg = s"Application $appName is still in progress, it may be terminated accidently."
@@ -775,7 +775,7 @@ private[spark] class Master(
       case fnf: FileNotFoundException =>
         // Event logging is enabled for this application, but no event logs are found
         val title = s"Application history not found (${app.id})"
-        var msg = s"No event logs found for application $appName in ${app.desc.eventLogDir}."
+        var msg = s"No event logs found for application $appName in ${app.desc.eventLogDir.get}."
         logWarning(msg)
         msg += " Did you specify the correct logging directory?"
         msg = URLEncoder.encode(msg, "UTF-8")

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -754,8 +754,8 @@ private[spark] class Master(
       } else ""
       
       val eventLogFile = eventLogFilePrefix + eventLogFileSuffix
-      val status = if (eventLogFile.endsWith(EventLoggingListener.IN_PROGRESS)) 
-        " (inprogress)" else " (completed)"
+      val status = if (eventLogFile.endsWith(EventLoggingListener.IN_PROGRESS)) " (inprogress)" 
+        else " (completed)"
 
       val logInput = EventLoggingListener.openEventLog(new Path(eventLogFile), fs)
       val replayBus = new ReplayListenerBus()

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -743,7 +743,8 @@ private[spark] class Master(
           return false
         }
       
-      val eventLogFilePrefix = EventLoggingListener.getLogPath(eventLogDir, app.id, app.desc.eventLogCodec)        
+      val eventLogFilePrefix = EventLoggingListener.getLogPath(
+          eventLogDir, app.id, app.desc.eventLogCodec)
       val fs = Utils.getHadoopFileSystem(eventLogDir, hadoopConf)
       val inProgressExists = fs.exists(new Path(eventLogFilePrefix + 
           EventLoggingListener.IN_PROGRESS))


### PR DESCRIPTION
when application is finished running abnormally (Ctrl + c for example), the history event log file is still ends with `.inprogress` suffix. And the application state can not be showed on webUI, User can only see "_Application history not foud xxxx, Application xxx is still in progress_". 

For application that not finished normally, the history will show:
![image](https://cloud.githubusercontent.com/assets/4716022/6437137/184f9fc0-c0f5-11e4-88cc-a2eb087e4561.png)
