### PR TITLE
[SPARK-6105] enhance spark-ganglia to support redundant gmond addresses ...

### DIFF
--- a/conf/metrics.properties.template
+++ b/conf/metrics.properties.template
@@ -165,3 +165,4 @@ executor.sink.ganglia.class=org.apache.spark.metrics.sink.GangliaSink
 #*.sink.ganglia.servers=node1:8649,node2:9649
 
 #*.sink.ganglia.mode=unicast
+

--- a/conf/metrics.properties.template
+++ b/conf/metrics.properties.template
@@ -140,3 +140,28 @@
 
 #executor.source.jvm.class=org.apache.spark.metrics.source.JvmSource
 
+
+# Enable GangliaSink for instance master, worker, driver and executor
+#*.sink.ganglia.class=org.apache.spark.metrics.sink.GangliaSink
+master.sink.ganglia.class=org.apache.spark.metrics.sink.GangliaSink
+worker.sink.ganglia.class=org.apache.spark.metrics.sink.GangliaSink
+driver.sink.ganglia.class=org.apache.spark.metrics.sink.GangliaSink
+executor.sink.ganglia.class=org.apache.spark.metrics.sink.GangliaSink
+
+*.sink.ganglia.period=30
+*.sink.ganglia.unit=seconds
+
+#For multicast mode configuration
+*.sink.ganglia.host=239.2.11.71
+*.sink.ganglia.port=8649
+*.sink.ganglia.ttl=1
+*.sink.ganglia.mode=multicast
+
+
+#For unicast mode configuration
+#*.sink.ganglia.host=node1.example  #hostname or ip of gmond node for gathering metrics from other nodes
+#*.sink.ganglia.port=8649    #port of gmond node for gathering metrics from other nodes
+#or
+#*.sink.ganglia.servers=node1:8649,node2:9649
+
+#*.sink.ganglia.mode=unicast

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1880,7 +1880,7 @@ object SparkContext extends Logging {
 
   private[spark] val SPARK_JOB_INTERRUPT_ON_CANCEL = "spark.job.interruptOnCancel"
 
-  private[spark] val DRIVER_IDENTIFIER = "<driver>"
+  private[spark] val DRIVER_IDENTIFIER = "driver"
 
   // The following deprecated objects have already been copied to `object AccumulatorParam` to
   // make the compiler find them automatically. They are duplicate codes only for backward


### PR DESCRIPTION
This _PR_ is for preventing spark-GangliaSink from single point of failure in unicast mode configuration.

For details, please refer relatived JIRA: [enhance spark-ganglia to support redundant gmond addresses setting in ganglia unicast mode](https://issues.apache.org/jira/browse/SPARK-6105)
