### PR TITLE
[SPARK-6111] Fixed usage string in documentation.

### DIFF
--- a/examples/src/main/python/streaming/kafka_wordcount.py
+++ b/examples/src/main/python/streaming/kafka_wordcount.py
@@ -17,7 +17,7 @@
 
 """
  Counts words in UTF8 encoded, '\n' delimited text received from the network every second.
- Usage: network_wordcount.py <zk> <topic>
+ Usage: kafka_wordcount.py <zk> <topic>
 
  To run this on your local machine, you need to setup Kafka and create a producer first, see
  http://kafka.apache.org/documentation.html#quickstart


### PR DESCRIPTION
Usage info in documentation does not match actual usage info.

Doc string usage says `Usage: network_wordcount.py <zk> <topic>` whereas the actual usage is `Usage: kafka_wordcount.py <zk> <topic>`
