### PR TITLE
[SPARK-6120] [mllib] Warnings about memory in tree, ensemble model save

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/DecisionTreeModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/DecisionTreeModel.scala
@@ -191,19 +191,22 @@ object DecisionTreeModel extends Loader[DecisionTreeModel] with Logging {
       // SPARK-6120: We do a hacky check here so users understand why save() is failing
       //             when they run the ML guide example.
       // TODO: Fix this issue for real.
-      val driverMemory = sc.getConf.getOption("spark.driver.memory")
-        .orElse(Option(System.getenv("SPARK_DRIVER_MEMORY")))
-        .map(Utils.memoryStringToMb)
-        .getOrElse(512)
+      val memThreshold = 768
       if (sc.isLocal) {
-        if (driverMemory <= 768) {
+        val driverMemory = sc.getConf.getOption("spark.driver.memory")
+          .orElse(Option(System.getenv("SPARK_DRIVER_MEMORY")))
+          .map(Utils.memoryStringToMb)
+          .getOrElse(512)
+        if (driverMemory <= memThreshold) {
           logWarning(s"$thisClassName.save() was called, but it may fail because of too little" +
-            " driver memory.  If failure occurs, try setting driver-memory 768m (or larger).")
+            s" driver memory (${driverMemory}m)." +
+            s"  If failure occurs, try setting driver-memory ${memThreshold}m (or larger).")
         }
       } else {
-        if (sc.executorMemory <= 768) {
+        if (sc.executorMemory <= memThreshold) {
           logWarning(s"$thisClassName.save() was called, but it may fail because of too little" +
-            " executor memory.  If failure occurs try setting executor-memory 768m (or larger).")
+            s" executor memory (${sc.executorMemory}m)." +
+            s"  If failure occurs try setting executor-memory ${memThreshold}m (or larger).")
         }
       }
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/DecisionTreeModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/DecisionTreeModel.scala
@@ -23,7 +23,7 @@ import org.json4s._
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods._
 
-import org.apache.spark.SparkContext
+import org.apache.spark.{Logging, SparkContext}
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.mllib.linalg.Vector
@@ -32,6 +32,7 @@ import org.apache.spark.mllib.tree.configuration.Algo._
 import org.apache.spark.mllib.util.{Loader, Saveable}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
+import org.apache.spark.util.Utils
 
 /**
  * :: Experimental ::
@@ -115,7 +116,7 @@ class DecisionTreeModel(val topNode: Node, val algo: Algo) extends Serializable 
   override protected def formatVersion: String = "1.0"
 }
 
-object DecisionTreeModel extends Loader[DecisionTreeModel] {
+object DecisionTreeModel extends Loader[DecisionTreeModel] with Logging {
 
   private[tree] object SaveLoadV1_0 {
 
@@ -186,6 +187,25 @@ object DecisionTreeModel extends Loader[DecisionTreeModel] {
     def save(sc: SparkContext, path: String, model: DecisionTreeModel): Unit = {
       val sqlContext = new SQLContext(sc)
       import sqlContext.implicits._
+
+      // SPARK-6120: We do a hacky check here so users understand why save() is failing
+      //             when they run the ML guide example.
+      // TODO: Fix this issue for real.
+      val driverMemory = sc.getConf.getOption("spark.driver.memory")
+        .orElse(Option(System.getenv("SPARK_DRIVER_MEMORY")))
+        .map(Utils.memoryStringToMb)
+        .getOrElse(512)
+      if (sc.isLocal) {
+        if (driverMemory <= 768) {
+          logWarning(s"$thisClassName.save() was called, but it may fail because of too little" +
+            " driver memory.  If failure occurs, try setting driver-memory 768m (or larger).")
+        }
+      } else {
+        if (sc.executorMemory <= 768) {
+          logWarning(s"$thisClassName.save() was called, but it may fail because of too little" +
+            " executor memory.  If failure occurs try setting executor-memory 768m (or larger).")
+        }
+      }
 
       // Create JSON metadata.
       val metadata = compact(render(

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/treeEnsembleModels.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/treeEnsembleModels.scala
@@ -281,19 +281,22 @@ private[tree] object TreeEnsembleModel extends Logging {
       // SPARK-6120: We do a hacky check here so users understand why save() is failing
       //             when they run the ML guide example.
       // TODO: Fix this issue for real.
-      val driverMemory = sc.getConf.getOption("spark.driver.memory")
-        .orElse(Option(System.getenv("SPARK_DRIVER_MEMORY")))
-        .map(Utils.memoryStringToMb)
-        .getOrElse(512)
+      val memThreshold = 768
       if (sc.isLocal) {
-        if (driverMemory <= 768) {
+        val driverMemory = sc.getConf.getOption("spark.driver.memory")
+          .orElse(Option(System.getenv("SPARK_DRIVER_MEMORY")))
+          .map(Utils.memoryStringToMb)
+          .getOrElse(512)
+        if (driverMemory <= memThreshold) {
           logWarning(s"$className.save() was called, but it may fail because of too little" +
-            " driver memory.  If failure occurs, try setting driver-memory 768m (or larger).")
+            s" driver memory (${driverMemory}m)." +
+            s"  If failure occurs, try setting driver-memory ${memThreshold}m (or larger).")
         }
       } else {
-        if (sc.executorMemory <= 768) {
+        if (sc.executorMemory <= memThreshold) {
           logWarning(s"$className.save() was called, but it may fail because of too little" +
-            " executor memory.  If failure occurs try setting executor-memory 768m (or larger).")
+            s" executor memory (${sc.executorMemory}m)." +
+            s"  If failure occurs try setting executor-memory ${memThreshold}m (or larger).")
         }
       }
 


### PR DESCRIPTION
Issue: When the Python DecisionTree example in the programming guide is run, it runs out of Java Heap Space when using the default memory settings for the spark shell.

This prints a warning.

CC: @mengxr
