### PR TITLE
SPARK-4044 [CORE] Thriftserver fails to start when JAVA_HOME points to JRE instead of JDK

### DIFF
--- a/bin/compute-classpath.sh
+++ b/bin/compute-classpath.sh
@@ -93,14 +93,17 @@ if [ "$num_jars" -gt "1" ]; then
   exit 1
 fi
 
-# Verify that versions of java used to build the jars and run Spark are compatible
-jar_error_check=$("$JAR_CMD" -tf "$ASSEMBLY_JAR" nonexistent/class/path 2>&1)
-if [[ "$jar_error_check" =~ "invalid CEN header" ]]; then
-  echo "Loading Spark jar with '$JAR_CMD' failed. " 1>&2
-  echo "This is likely because Spark was compiled with Java 7 and run " 1>&2
-  echo "with Java 6. (see SPARK-1703). Please use Java 7 to run Spark " 1>&2
-  echo "or build Spark with Java 6." 1>&2
-  exit 1
+# Only able to make this check if 'jar' command is available
+if [ $(command -v "$JAR_CMD") ] ; then
+  # Verify that versions of java used to build the jars and run Spark are compatible
+  jar_error_check=$("$JAR_CMD" -tf "$ASSEMBLY_JAR" nonexistent/class/path 2>&1)
+  if [[ "$jar_error_check" =~ "invalid CEN header" ]]; then
+    echo "Loading Spark jar with '$JAR_CMD' failed. " 1>&2
+    echo "This is likely because Spark was compiled with Java 7 and run " 1>&2
+    echo "with Java 6. (see SPARK-1703). Please use Java 7 to run Spark " 1>&2
+    echo "or build Spark with Java 6." 1>&2
+    exit 1
+  fi
 fi
 
 CLASSPATH="$CLASSPATH:$ASSEMBLY_JAR"
@@ -121,10 +124,15 @@ datanucleus_jars="$(find "$datanucleus_dir" 2>/dev/null | grep "datanucleus-.*\\
 datanucleus_jars="$(echo "$datanucleus_jars" | tr "\n" : | sed s/:$//g)"
 
 if [ -n "$datanucleus_jars" ]; then
-  hive_files=$("$JAR_CMD" -tf "$ASSEMBLY_JAR" org/apache/hadoop/hive/ql/exec 2>/dev/null)
-  if [ -n "$hive_files" ]; then
-    echo "Spark assembly has been built with Hive, including Datanucleus jars on classpath" 1>&2
-    CLASSPATH="$CLASSPATH:$datanucleus_jars"
+  if [ $(command -v "$JAR_CMD") ] ; then
+    hive_files=$("$JAR_CMD" -tf "$ASSEMBLY_JAR" org/apache/hadoop/hive/ql/exec 2>/dev/null)
+    if [ -n "$hive_files" ]; then
+      echo "Spark assembly has been built with Hive, including Datanucleus jars on classpath" 1>&2
+      CLASSPATH="$CLASSPATH:$datanucleus_jars"
+    fi
+  else
+    echo "No jar command available; unable to check if assembly was built with Hive."
+    echo "Please install a JDK instead of a JRE."
   fi
 fi
 

--- a/bin/compute-classpath.sh
+++ b/bin/compute-classpath.sh
@@ -124,16 +124,7 @@ datanucleus_jars="$(find "$datanucleus_dir" 2>/dev/null | grep "datanucleus-.*\\
 datanucleus_jars="$(echo "$datanucleus_jars" | tr "\n" : | sed s/:$//g)"
 
 if [ -n "$datanucleus_jars" ]; then
-  if [ $(command -v "$JAR_CMD") ] ; then
-    hive_files=$("$JAR_CMD" -tf "$ASSEMBLY_JAR" org/apache/hadoop/hive/ql/exec 2>/dev/null)
-    if [ -n "$hive_files" ]; then
-      echo "Spark assembly has been built with Hive, including Datanucleus jars on classpath" 1>&2
-      CLASSPATH="$CLASSPATH:$datanucleus_jars"
-    fi
-  else
-    echo "No jar command available; unable to check if assembly was built with Hive."
-    echo "Please install a JDK instead of a JRE."
-  fi
+  CLASSPATH="$CLASSPATH:$datanucleus_jars"
 fi
 
 # Add test classes if we're running from SBT or Maven with SPARK_TESTING set to 1


### PR DESCRIPTION
So, I think it would be a step too far to tell people they have to run Spark with a JDK instead of a JRE. It's uncommon to put a JDK in production. So this runtime script needs to cope with not having `jar` available. 

I've added explicit checks to the two cases where it's used, but yes it's only the second datanucleus case that matters.

At least there's an error message now, but, how about just adding the jars anyway, if they're present, in this case?

CC @JoshRosen 
