### PR TITLE
[SPARK-6139] [Streaming] Allow pre-populate sliding window with initial RDDs

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaDStream.scala
@@ -17,6 +17,9 @@
 
 package org.apache.spark.streaming.api.java
 
+import java.util.{List => JList}
+import scala.collection.JavaConversions._
+import com.google.common.base.Optional
 import org.apache.spark.streaming.{Duration, Time}
 import org.apache.spark.api.java.function.{Function => JFunction}
 import org.apache.spark.api.java.JavaRDD
@@ -81,6 +84,22 @@ class JavaDStream[T](val dstream: DStream[T])(implicit val classTag: ClassTag[T]
    */
   def window(windowDuration: Duration, slideDuration: Duration): JavaDStream[T] =
     dstream.window(windowDuration, slideDuration)
+
+  /**
+   * Return a new DStream in which each RDD contains all the elements in seen in a
+   * sliding window of time over this DStream.
+   * @param windowDuration width of the window; must be a multiple of this DStream's
+   *                       batching interval
+   * @param slideDuration  sliding interval of the window (i.e., the interval after which
+   *                       the new DStream will generate RDDs); must be a multiple of this
+   *                       DStream's batching interval
+   * @param initialWindow  initial window values to prepend starting with the oldest entry
+   */
+  def window(windowDuration: Duration, slideDuration: Duration, initialWindow: Optional[JList[JavaRDD[T]]]): JavaDStream[T] =
+    dstream.window(windowDuration, slideDuration, initialWindow.isPresent match {
+      case true => Some(initialWindow.get.toList.map(rdd => rdd.rdd))
+      case _ => None
+    })
 
   /**
    * Return a new DStream by unifying data of another DStream with this DStream.

--- a/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaDStream.scala
@@ -95,7 +95,9 @@ class JavaDStream[T](val dstream: DStream[T])(implicit val classTag: ClassTag[T]
    *                       DStream's batching interval
    * @param initialWindow  initial window values to prepend starting with the oldest entry
    */
-  def window(windowDuration: Duration, slideDuration: Duration, initialWindow: Optional[JList[JavaRDD[T]]]): JavaDStream[T] =
+  def window(windowDuration: Duration,
+             slideDuration: Duration,
+             initialWindow: Optional[JList[JavaRDD[T]]]): JavaDStream[T] =
     dstream.window(windowDuration, slideDuration, initialWindow.isPresent match {
       case true => Some(initialWindow.get.toList.map(rdd => rdd.rdd))
       case _ => None

--- a/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaPairDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaPairDStream.scala
@@ -101,6 +101,21 @@ class JavaPairDStream[K, V](val dstream: DStream[(K, V)])(
     dstream.window(windowDuration, slideDuration)
 
   /**
+   * Return a new DStream which is computed based on windowed batches of this DStream.
+   * @param windowDuration duration (i.e., width) of the window;
+   *                   must be a multiple of this DStream's interval
+   * @param slideDuration  sliding interval of the window (i.e., the interval after which
+   *                   the new DStream will generate RDDs); must be a multiple of this
+   *                   DStream's interval
+   * @param initialWindow  initial window values to prepend starting with the oldest entry
+   */
+  def window(windowDuration: Duration, slideDuration: Duration, initialWindow: Optional[JList[JavaPairRDD[K, V]]]): JavaPairDStream[K, V] =
+    dstream.window(windowDuration, slideDuration, initialWindow.isPresent match {
+      case true => Some(initialWindow.get.toList.map(rdd => rdd.rdd))
+      case _ => None
+    })
+
+  /**
    * Return a new DStream by unifying data of another DStream with this DStream.
    * @param that Another DStream having the same interval (i.e., slideDuration) as this DStream.
    */

--- a/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaPairDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaPairDStream.scala
@@ -109,7 +109,9 @@ class JavaPairDStream[K, V](val dstream: DStream[(K, V)])(
    *                   DStream's interval
    * @param initialWindow  initial window values to prepend starting with the oldest entry
    */
-  def window(windowDuration: Duration, slideDuration: Duration, initialWindow: Optional[JList[JavaPairRDD[K, V]]]): JavaPairDStream[K, V] =
+  def window(windowDuration: Duration,
+             slideDuration: Duration,
+             initialWindow: Optional[JList[JavaPairRDD[K, V]]]): JavaPairDStream[K, V] =
     dstream.window(windowDuration, slideDuration, initialWindow.isPresent match {
       case true => Some(initialWindow.get.toList.map(rdd => rdd.rdd))
       case _ => None

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
@@ -662,7 +662,9 @@ abstract class DStream[T: ClassTag] (
    *                       DStream's batching interval
    * @param initialWindow  initial window values to prepend starting with the oldest entry
    */
-  def window(windowDuration: Duration, slideDuration: Duration, initialWindow: Option[Seq[RDD[T]]]): DStream[T] = {
+  def window(windowDuration: Duration,
+             slideDuration: Duration,
+             initialWindow: Option[Seq[RDD[T]]]): DStream[T] = {
     new WindowedDStream(this, windowDuration, slideDuration, initialWindow)
   }
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
@@ -649,7 +649,21 @@ abstract class DStream[T: ClassTag] (
    *                       DStream's batching interval
    */
   def window(windowDuration: Duration, slideDuration: Duration): DStream[T] = {
-    new WindowedDStream(this, windowDuration, slideDuration)
+    new WindowedDStream(this, windowDuration, slideDuration, None)
+  }
+
+  /**
+   * Return a new DStream in which each RDD contains all the elements in seen in a
+   * sliding window of time over this DStream.
+   * @param windowDuration width of the window; must be a multiple of this DStream's
+   *                       batching interval
+   * @param slideDuration  sliding interval of the window (i.e., the interval after which
+   *                       the new DStream will generate RDDs); must be a multiple of this
+   *                       DStream's batching interval
+   * @param initialWindow  initial window values to prepend starting with the oldest entry
+   */
+  def window(windowDuration: Duration, slideDuration: Duration, initialWindow: Option[Seq[RDD[T]]]): DStream[T] = {
+    new WindowedDStream(this, windowDuration, slideDuration, initialWindow)
   }
 
   /**

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/WindowedDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/WindowedDStream.scala
@@ -76,7 +76,8 @@ class WindowedDStream[T: ClassTag](
           parentRddsInWindow
         } else {
           // Fill the remainder of the window with initial data
-          parentRddsInWindow ++ initialWindowRDD.drop(initialWindowRDD.length + parentRddsInWindow.length - windowBatchCount)
+          parentRddsInWindow ++ initialWindowRDD.drop(
+            initialWindowRDD.length + parentRddsInWindow.length - windowBatchCount)
         }
       }
     }

--- a/streaming/src/test/java/org/apache/spark/streaming/JavaAPISuite.java
+++ b/streaming/src/test/java/org/apache/spark/streaming/JavaAPISuite.java
@@ -160,6 +160,38 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
 
   @SuppressWarnings("unchecked")
   @Test
+  public void testWindowWithInitialData()
+  {
+
+    List<JavaRDD<Integer>> initialData = Arrays.asList(
+        ssc.sparkContext().parallelize(Arrays.asList(-3, -2, -1)),
+        ssc.sparkContext().parallelize(Arrays.asList(1, 2, 3)),
+        ssc.sparkContext().parallelize(Arrays.asList(4, 5, 6)));
+
+    List<List<Integer>> inputData = Arrays.asList(
+        Arrays.asList(7, 8, 9),
+        Arrays.asList(10, 11, 12),
+        Arrays.asList(13, 14, 15),
+        Arrays.asList(16, 17, 18),
+        Arrays.asList(19, 20, 21),
+        Arrays.asList(22, 23, 24));
+
+    List<List<Integer>> expected = Arrays.asList(
+        Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12),
+        Arrays.asList(7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18),
+        Arrays.asList(13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24),
+        Arrays.asList(19, 20, 21, 22, 23, 24));
+
+    JavaDStream<Integer> stream = JavaTestUtils.attachTestInputStream(ssc, inputData, 1);
+    JavaDStream<Integer> windowed = stream.window(new Duration(4000), new Duration(2000), Optional.of(initialData));
+    JavaTestUtils.attachTestOutputStream(windowed);
+    List<List<Integer>> result = JavaTestUtils.runStreams(ssc, 8, 4);
+
+    assertOrderInvariantEquals(expected, result);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
   public void testFilter() {
     List<List<String>> inputData = Arrays.asList(
         Arrays.asList("giants", "dodgers"),

--- a/streaming/src/test/java/org/apache/spark/streaming/JavaAPISuite.java
+++ b/streaming/src/test/java/org/apache/spark/streaming/JavaAPISuite.java
@@ -183,7 +183,10 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
         Arrays.asList(19, 20, 21, 22, 23, 24));
 
     JavaDStream<Integer> stream = JavaTestUtils.attachTestInputStream(ssc, inputData, 1);
-    JavaDStream<Integer> windowed = stream.window(new Duration(4000), new Duration(2000), Optional.of(initialData));
+    JavaDStream<Integer> windowed = stream.window(
+        new Duration(4000),
+        new Duration(2000),
+        Optional.of(initialData));
     JavaTestUtils.attachTestOutputStream(windowed);
     List<List<Integer>> result = JavaTestUtils.runStreams(ssc, 8, 4);
 


### PR DESCRIPTION
Each new computed window in WindowedDStream checks for empty slots and fills them with the initial list of supplied RDDs.
