### PR TITLE
[SPARK-6150][mllib] Validate indices before constructing a SparseVector

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
@@ -515,6 +515,7 @@ class SparseVector(
     val values: Array[Double]) extends Vector {
 
   require(indices.length == values.length)
+  require(indices.forall(index => index < size))
 
   override def toString: String =
     "(%s,%s,%s)".format(size, indices.mkString("[", ",", "]"), values.mkString("[", ",", "]"))

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
@@ -51,6 +51,12 @@ class VectorsSuite extends FunSuite {
     assert(vec.values.eq(values))
   }
 
+  test("sparse vector construction with invalid index") {
+    intercept[IllegalArgumentException] {
+      Vectors.sparse(n, Array(100), Array(1.0))
+    }
+  }
+
   test("sparse vector construction with unordered elements") {
     val vec = Vectors.sparse(n, indices.zip(values).reverse).asInstanceOf[SparseVector]
     assert(vec.size === n)


### PR DESCRIPTION
We should validate indices for arguments before constructing a SparseVector.
https://issues.apache.org/jira/browse/SPARK-6150
