### PR TITLE
[SPARK-6156][CORE]Not cache in memory again while first put memory_disk block in memory failed.

### DIFF
--- a/core/src/main/scala/org/apache/spark/CacheManager.scala
+++ b/core/src/main/scala/org/apache/spark/CacheManager.scala
@@ -152,7 +152,7 @@ private[spark] class CacheManager(blockManager: BlockManager) extends Logging {
        */
       updatedBlocks ++=
         blockManager.putIterator(key, values, level, tellMaster = true, effectiveStorageLevel)
-      blockManager.get(key) match {
+      blockManager.getLocal(key, !level.useMemory) match {
         case Some(v) => v.data.asInstanceOf[Iterator[T]]
         case None =>
           logInfo(s"Failure to store $key")

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -454,7 +454,7 @@ private[spark] class BlockManager(
 
   private def doGetLocal(blockId: BlockId,
                          asBlockResult: Boolean,
-                         isDiskToMemory: Boolean = True): Option[Any] = {
+                         isDiskToMemory: Boolean = true): Option[Any] = {
     val info = blockInfo.get(blockId).orNull
     if (info != null) {
       info.synchronized {

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -523,7 +523,7 @@ private[spark] class BlockManager(
           }
           assert(0 == bytes.position())
 
-          if (!level.useMemory || isDiskToMemory) {
+          if (!level.useMemory || !isDiskToMemory) {
             // If the block shouldn't be stored in memory, we can just return it
             if (asBlockResult) {
               return Some(new BlockResult(dataDeserialize(blockId, bytes), DataReadMethod.Disk,


### PR DESCRIPTION
In Current code, if we put a memory_and_disk level block in memory failed, then we will put it into disk. and then we verify put success or not, use `value = BlockManager.get(blockId)`, and use that value return to user.
But In `BlockManager.get(blockId)`, it will get that block from disk and put that in memory again.
I think the second try to put in memory is unnecessary, because we just try to put in memory a few time ago, and most of the second retry will failed again.

for use `blockManager.get(blockId)` to verify block is put success or not.
In that method, it first `getLocal()` and then `getRemote()`, I think is more reasonable use `getLocal` instead.

may this pull request is useless, because may have some design reasons to do that?
