### PR TITLE
[SPARK-6149] [SQL] [Build] Excludes Guava 15 referenced by jackson-module-scala_2.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -583,10 +583,18 @@
         <artifactId>jackson-databind</artifactId>
         <version>${fasterxml.jackson.version}</version>
       </dependency>
+      <!-- Guava is excluded because of SPARK-6149.  The Guava version referenced in this module is
+           15.0, which causes runtime incompatibility issues. -->
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-scala_2.10</artifactId>
         <version>${fasterxml.jackson.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.scala-lang</groupId>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -220,13 +220,7 @@ object Flume {
   */
 object ExludedDependencies {
   lazy val settings = Seq(
-    libraryDependencies ~= { libs =>
-      libs.filterNot(_.name == "groovy-all").map {
-        case m if m.organization == "com.fasterxml.jackson.module" =>
-          m.exclude("com.google.guava", "guava")
-        case m => m
-      }
-    }
+    libraryDependencies ~= { libs => libs.filterNot(_.name == "groovy-all") }
   )
 }
 

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -220,7 +220,13 @@ object Flume {
   */
 object ExludedDependencies {
   lazy val settings = Seq(
-    libraryDependencies ~= { libs => libs.filterNot(_.name == "groovy-all") }
+    libraryDependencies ~= { libs =>
+      libs.filterNot(_.name == "groovy-all").map {
+        case m if m.organization == "com.fasterxml.jackson.module" =>
+          m.exclude("com.google.guava", "guava")
+        case m => m
+      }
+    }
   )
 }
 


### PR DESCRIPTION
This PR excludes Guava 15.0 from the SBT build, to make Spark SQL CLI (`bin/spark-sql`) work when compiled against Hive 0.12.0.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/apache/spark/4890)

<!-- Reviewable:end -->
