### PR TITLE
[SPARK-6159][Core] Distinguish between inprogress and abnormal event log history

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -753,11 +753,12 @@ private[spark] class Master(
       
       if (inProgressExists) {
         // Event logging is enabled for this application, but the application is still in progress
-        logWarning(s"Application $appName is still in progress, it may be terminated abnormally.")
+        logWarning(s"Application $appName is still in progress.")
       }
 
       if (abnormalLogExists) {
-        // Event logging is enabled for this application, but the application is terminated abnormally.
+        // Event logging is enabled for this application,
+        // but the application may be terminated abnormally.
         logWarning(s"Application $appName may be terminated abnormally.")
       }
       

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -281,7 +281,7 @@ private[spark] object EventLoggingListener extends Logging {
 
     // Compression codec is encoded as an extension, e.g. app_123.lzf
     // Since we sanitize the app ID to not include periods, it is safe to split on it
-    val logName = log.getName.stripSuffix(IN_PROGRESS)
+    val logName = log.getName.stripSuffix(IN_PROGRESS).stripSuffix(ABNORMAL)
     val codecName: Option[String] = logName.split("\\.").tail.lastOption
     val codec = codecName.map { c =>
       codecMap.getOrElseUpdate(c, CompressionCodec.createCodec(new SparkConf, c))


### PR DESCRIPTION
This is the following up of #4848. Currently, when an application is terminated abnormally (ex. Ctrl + C), its log file is still in ".inprogress" format. #4848 makes the inprogress log readable to SparkUI.

However, I think we should be able to distinguish between real inprogress case and abnormal case. So this fixing tries to add a shutdownhook to `EventLoggingListener` and rename ".inprogress" log to ".abnormal" log. Then we can know what it is the case when reading log in `rebuildSparkUI`.

CC @liyezhang556520 @srowen.
