### PR TITLE
Added Companion Object for LogisticRegressionWithLBFGS

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/classification/LogisticRegression.scala
@@ -362,3 +362,46 @@ class LogisticRegressionWithLBFGS
     }
   }
 }
+
+/**
+ * Top-level methods for calling Logistic Regression using L-BFGS.
+ * NOTE: Labels used in Logistic Regression should be {0, 1}
+ */
+object LogisticRegressionWithLBFGS {
+
+  /**
+  * Train a logistic regression model given an RDD of (label, features) pairs.
+  *
+  * @param input RDD of (label, array of features) pairs.
+  */
+  def train(input: RDD[LabeledPoint]) = {
+    new LogisticRegressionWithLBFGS()
+      .run(input)
+  }
+
+  /**
+   * Train a logistic regression model given an RDD of (label, features) pairs.
+   *
+   * @param input RDD of (label, array of features) pairs.
+   * @param numIterations Number of iterations of BFGS to run.
+   */
+  def train(input: RDD[LabeledPoint], numIterations: Int) = {
+    val lr = new LogisticRegressionWithLBFGS()
+    lr.optimizer.setNumIterations(numIterations)
+    lr.run(input)
+  }
+
+  /**
+   * Train a logistic regression model given an RDD of (label, features) pairs.
+   * The weights used in LBFGS are initialized using the initial weights provided.
+   * NOTE: Labels used in Logistic Regression should be {0, 1}
+   *
+   * @param input RDD of (label, array of features) pairs.
+   * @param initialWeights Initial set of weights to be used. Array should be equal in size to
+   *        the number of features in the data.
+   */
+  def train(input: RDD[LabeledPoint], initialWeights: Vector) = {
+    new LogisticRegressionWithLBFGS()
+      .run(input, initialWeights)
+  }
+}

--- a/mllib/src/test/scala/org/apache/spark/mllib/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/classification/LogisticRegressionSuite.scala
@@ -562,9 +562,7 @@ class LogisticRegressionClusterSuite extends FunSuite with LocalClusterSparkCont
     }.cache()
     // If we serialize data directly in the task closure, the size of the serialized task would be
     // greater than 1MB and hence Spark would throw an error.
-    val lr = new LogisticRegressionWithLBFGS().setIntercept(true)
-    lr.optimizer.setNumIterations(2)
-    val model = lr.run(points)
+    val model = LogisticRegressionWithLBFGS.train(points, 2)
 
     val predictions = model.predict(points.map(_.features))
 


### PR DESCRIPTION
I added companion object for LogisticRegressionWithLBFGS. LogisticRegressionWithSGD can use method train() for creating model instance, but LogisticRegressionWithLBFGS cannot use it because it does not have companion object. It will be more clear to use than before.
