### PR TITLE
[EC2] [SPARK-6188] Instance types can be mislabeled when re-starting cluster with default arguments

### DIFF
--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -1267,7 +1267,7 @@ def real_main():
             existing_master_type = ""
         opts.master_instance_type = existing_master_type
         opts.instance_type = existing_slave_type
-        
+
         setup_cluster(conn, master_nodes, slave_nodes, opts, False)
 
     else:

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -1263,6 +1263,8 @@ def real_main():
         # Determine types of running instances
         existing_master_type = master_nodes[0].instance_type
         existing_slave_type = slave_nodes[0].instance_type
+        # Setting opts.master_instance_type to the empty string indicates we
+        # have the same instance type for the master and the slaves
         if existing_master_type == existing_slave_type:
             existing_master_type = ""
         opts.master_instance_type = existing_master_type

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -1259,6 +1259,15 @@ def real_main():
             cluster_instances=(master_nodes + slave_nodes),
             cluster_state='ssh-ready'
         )
+        
+        # Determine types of running instances
+        existing_master_type = master_nodes[0].instance_type
+        existing_slave_type = slave_nodes[0].instance_type
+        if existing_master_type == existing_slave_type:
+            existing_master_type = ""
+        opts.master_instance_type = existing_master_type
+        opts.instance_type = existing_slave_type
+        
         setup_cluster(conn, master_nodes, slave_nodes, opts, False)
 
     else:

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -1259,7 +1259,7 @@ def real_main():
             cluster_instances=(master_nodes + slave_nodes),
             cluster_state='ssh-ready'
         )
-        
+
         # Determine types of running instances
         existing_master_type = master_nodes[0].instance_type
         existing_slave_type = slave_nodes[0].instance_type


### PR DESCRIPTION
As described in https://issues.apache.org/jira/browse/SPARK-6188 and discovered in https://issues.apache.org/jira/browse/SPARK-5838.

When re-starting a cluster, if the user does not provide the instance types, which is the recommended behavior in the docs currently, the instance will be assigned the default type m1.large. This then affects the setup of the machines.

This solves this by getting the instance types from the existing instances, and overwriting the default options.

EDIT: Further clarification of the issue:

In short, while the instances themselves are the same as launched, their setup is done assuming the default instance type, m1.large.

This means that the machines are assumed to have 2 disks, and that leads to problems that are described in in issue [5838](https://issues.apache.org/jira/browse/SPARK-5838), where machines that have one disk end up having shuffle spills in the in the small (8GB) snapshot partitions that quickly fills up and results in failing jobs due to "No space left on device" errors.

Other instance specific settings that are set in the spark_ec2.py script are likely to be wrong as well.
