### PR TITLE
[SPARK-6200] [SQL] Add a manager for dialects

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -20,8 +20,6 @@ package org.apache.spark.sql
 import java.beans.Introspector
 import java.util.Properties
 
-import org.apache.spark.sql.dialect.{DialectManager, DefaultDialectManager}
-
 import scala.collection.JavaConversions._
 import scala.collection.immutable
 import scala.language.implicitConversions
@@ -36,6 +34,7 @@ import org.apache.spark.sql.catalyst.optimizer.{DefaultOptimizer, Optimizer}
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan, NoRelation}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 import org.apache.spark.sql.catalyst.{ScalaReflection, expressions}
+import org.apache.spark.sql.dialect.{DialectManager, DefaultDialectManager}
 import org.apache.spark.sql.execution.{Filter, _}
 import org.apache.spark.sql.jdbc.{JDBCPartition, JDBCPartitioningInfo, JDBCRelation}
 import org.apache.spark.sql.json._

--- a/sql/core/src/main/scala/org/apache/spark/sql/dialect/Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/dialect/Dialect.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.dialect
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+
+trait Dialect {
+  /**
+   * description about this dialect
+   * @return description string
+   */
+  def description: String = null
+
+  def parse(sql: String): LogicalPlan
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/dialect/DialectCommandParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/dialect/DialectCommandParser.scala
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.dialect
+
+import org.apache.spark.Logging
+import org.apache.spark.sql.catalyst.AbstractSparkSQLParser
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.{DropDialectCommand, SwitchDialectCommand, ShowDialectsCommand, AddDialectCommand}
+
+private[sql] object DialectCommandParser extends AbstractSparkSQLParser with Logging {
+
+  def apply(input: String, exceptionOnError: Boolean): Option[LogicalPlan] = {
+    try {
+      Some(apply(input))
+    } catch {
+      case _ if !exceptionOnError => None
+      case x: Throwable => throw x
+    }
+  }
+
+  protected val CREATE   = Keyword("CREATE")
+  protected val DIALECT  = Keyword("DIALECT")
+  protected val DIALECTS = Keyword("DIALECTS")
+  protected val DROP     = Keyword("DROP")
+  protected val EXTENDED = Keyword("EXTENDED")
+  protected val SHOW     = Keyword("SHOW")
+  protected val USE      = Keyword("USE")
+  protected val USING    = Keyword("USING")
+
+  protected def start: Parser[LogicalPlan] =
+    addDialect | showDialects | showCurrentDialect | switchDialect | dropDialect
+
+  protected lazy val className: Parser[String] = rep1sep(ident, ".") ^^ { case s => s.mkString(".")}
+
+  protected lazy val addDialect =
+    (CREATE ~ DIALECT) ~> ident ~ (USING ~> className) ^^ {
+      case n ~ c => AddDialectCommand(n, c)
+    }
+
+  protected lazy val showDialects =
+    SHOW ~> EXTENDED.? <~ DIALECTS ^^ {
+      case e => ShowDialectsCommand(e.isDefined, false)
+    }
+
+  protected lazy val showCurrentDialect =
+    SHOW ~> EXTENDED.? <~ DIALECT ^^ {
+      case e => ShowDialectsCommand(e.isDefined, true)
+    }
+
+  protected lazy val switchDialect =
+    USE ~ DIALECT ~> ident ^^ {
+      case i => SwitchDialectCommand(i)
+    }
+
+  protected lazy val dropDialect =
+    DROP ~ DIALECT ~> ident ^^ {
+      case i => DropDialectCommand(i)
+    }
+}
+

--- a/sql/core/src/main/scala/org/apache/spark/sql/dialect/DialectManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/dialect/DialectManager.scala
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.dialect
+
+import org.apache.spark.Logging
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.{DataFrame, SQLContext}
+
+import scala.collection.JavaConversions._
+
+/**
+ * Dialect Information
+ */
+case class DialectDesc(name: String, dialect: Dialect)
+
+abstract class DialectManager(context: SQLContext) {
+
+  def parse(sql: String): LogicalPlan
+
+  def buildDataFrame(sql: String): DataFrame = {
+    DataFrame(context, parse(sql))
+  }
+
+  def switchDialect(dialect: String)
+
+  def getCurrentDialect: DialectDesc
+
+  def getAvailableDialects: Map[String, Dialect]
+
+  def registerDialect(name: String, dialect: Dialect)
+
+  def registerDialect(name: String, fullClassName: String)
+
+  def dropDialect(name: String)
+}
+
+class DefaultDialectManager(context: SQLContext)
+  extends DialectManager(context) with Logging {
+
+  val dialects = java.util.Collections.synchronizedMap(
+    new java.util.HashMap[String, Dialect]())
+
+  @volatile
+  var curDialect = context.conf.dialect
+
+  // add sql parser
+  dialects.put(SparkSqlDialect.name, SparkSqlDialect)
+  loadDefaultDialects()
+
+  /**
+   * load default dialects from `SQLConf`
+   */
+  private def loadDefaultDialects(): Unit = {
+    context.conf.getAllConfs.foreach({
+      case (key, value) if key.startsWith(DefaultDialectManager.CONF_MARKER) =>
+        registerDialect(key.drop(DefaultDialectManager.CONF_MARKER.length + 1), value)
+      case _ =>
+    })
+  }
+
+  override def switchDialect(dialect: String): Unit = {
+    logInfo(s"Switching dialect from ${getCurrentDialect.name} to $dialect")
+    curDialect = dialect
+  }
+
+  override def getCurrentDialect = {
+    Option(dialects.get(curDialect)).map(DialectDesc(curDialect, _))
+      .getOrElse(sys.error(s"The dialect $curDialect dose not exist!"))
+  }
+
+  override def getAvailableDialects = dialects.toMap
+
+  override def registerDialect(name: String, dialect: Dialect): Unit = {
+    if (dialects.containsKey(name)) {
+      sys.error(s"The dialect $name already exists,try another name!")
+    }
+
+    logInfo(s"Registering dialect with name $name")
+    dialects.put(name, dialect)
+  }
+
+  override def registerDialect(name: String, fullClassName: String): Unit = {
+    try {
+      // TODO: support  singleton object
+      val clazz = Class.forName(fullClassName)
+      val dialect = clazz.newInstance().asInstanceOf[Dialect]
+
+      registerDialect(name, dialect)
+    } catch {
+      case _: ClassNotFoundException =>
+        sys.error(s"Dialect class $fullClassName not found!")
+      case _: ClassCastException =>
+        sys.error(s"Class $fullClassName is not a subclass of " +
+          s"org.apache.spark.sql.dialect.Dialect")
+    }
+  }
+
+  override def dropDialect(name: String) = {
+    if (curDialect == name) {
+      sys.error(s"Can not drop a dialect that is being used!")
+    }
+
+    if (dialects.containsKey(name)) {
+      dialects.remove(name)
+      logInfo(s"Drop dialect $name successfully")
+    } else {
+      logWarning(s"Drop dialect failed,because dialect $name dose not exist!")
+    }
+  }
+
+  override def parse(sql: String): LogicalPlan = {
+    // check if the input sql is dialect command first
+    DialectCommandParser(sql, false).getOrElse(
+      getCurrentDialect.dialect.parse(sql)
+    )
+  }
+}
+
+object DefaultDialectManager {
+  val CONF_MARKER = "spark.sql.dialects"
+}
+

--- a/sql/core/src/main/scala/org/apache/spark/sql/dialect/DialectManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/dialect/DialectManager.scala
@@ -49,7 +49,7 @@ abstract class DialectManager(context: SQLContext) {
   def dropDialect(name: String)
 }
 
-class DefaultDialectManager(context: SQLContext)
+private[sql] class DefaultDialectManager(context: SQLContext)
   extends DialectManager(context) with Logging {
 
   val dialects = java.util.Collections.synchronizedMap(

--- a/sql/core/src/main/scala/org/apache/spark/sql/dialect/SparkSqlDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/dialect/SparkSqlDialect.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.dialect
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.sources.DDLParser
+import org.apache.spark.sql.{SparkSQLParser, catalyst}
+
+object SparkSqlDialect extends Dialect {
+
+  protected[sql] val ddlParser = new DDLParser(sqlParser.apply(_))
+
+  protected[sql] val sqlParser = {
+   val fallback = new catalyst.SqlParser
+   new SparkSQLParser(fallback(_))
+  }
+
+  override def parse(sql: String): LogicalPlan = {
+   ddlParser(sql, false).getOrElse(sqlParser(sql))
+  }
+
+  val name = "sql"
+
+  override def description = "spark sql native parser"
+}
+

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
@@ -213,8 +213,8 @@ case class DescribeCommand(
  */
 @DeveloperApi
 case class ShowDialectsCommand(
-                                isExtended: Boolean,
-                                isCurrent: Boolean) extends RunnableCommand {
+    isExtended: Boolean,
+    isCurrent: Boolean) extends RunnableCommand {
 
   override val output = {
     val schema = if (isExtended) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution
 import org.apache.spark.Logging
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.dialect.DialectDesc
 import org.apache.spark.sql.types.{BooleanType, StructField, StructType, StringType}
 import org.apache.spark.sql.{DataFrame, SQLConf, SQLContext}
 import org.apache.spark.sql.catalyst.errors.TreeNodeException
@@ -204,6 +205,87 @@ case class DescribeCommand(
       val comment = if (field.metadata.contains(cmtKey)) field.metadata.getString(cmtKey) else ""
       Row(field.name, field.dataType.simpleString, comment)
     }
+  }
+}
+
+/**
+ * :: DeveloperApi ::
+ */
+@DeveloperApi
+case class ShowDialectsCommand(
+                                isExtended: Boolean,
+                                isCurrent: Boolean) extends RunnableCommand {
+
+  override val output = {
+    val schema = if (isExtended) {
+      StructType(
+        StructField("dialectName", StringType, false) ::
+          StructField("className", StringType, false) ::
+          StructField("description", StringType, true) :: Nil)
+    } else {
+      StructType(
+        StructField("dialectName", StringType, false) :: Nil)
+    }
+
+    schema.toAttributes
+  }
+
+  override def run(sqlContext: SQLContext) = {
+    val dialects = if (isCurrent) {
+      Seq(sqlContext.dialectManager.getCurrentDialect)
+    } else {
+      sqlContext.dialectManager.getAvailableDialects.map { dialect =>
+        DialectDesc(dialect._1, dialect._2)
+      }.toSeq
+    }
+
+    val rows = if (isExtended) {
+      dialects.map { desc =>
+        Row(desc.name, getClassName(desc.dialect), desc.dialect.description)
+      }
+    } else {
+      dialects.map(desc => Row(desc.name))
+    }
+
+    rows
+  }
+
+  private def getClassName(obj: Any): String = {
+    val fullName = obj.getClass.getCanonicalName
+    if (fullName.endsWith("$")) fullName.dropRight(1) else fullName
+  }
+}
+
+/**
+ * :: DeveloperApi ::
+ */
+@DeveloperApi
+case class SwitchDialectCommand(name: String) extends RunnableCommand {
+  override def run(sqlContext: SQLContext) = {
+    sqlContext.dialectManager.switchDialect(name)
+    Seq.empty
+  }
+}
+
+/**
+ * :: DeveloperApi ::
+ */
+@DeveloperApi
+case class AddDialectCommand(name: String, fullClassName: String) extends RunnableCommand {
+  override def run(sqlContext: SQLContext) = {
+    sqlContext.dialectManager.registerDialect(name, fullClassName)
+    Seq.empty
+  }
+}
+
+/**
+ * :: DeveloperApi ::
+ */
+@DeveloperApi
+case class DropDialectCommand(name: String) extends RunnableCommand {
+  override def run(sqlContext: SQLContext) = {
+    sqlContext.dialectManager.dropDialect(name)
+    Seq.empty
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/dialect/DefaultDialectManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/dialect/DefaultDialectManagerSuite.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.dialect
+
+import org.apache.spark.sql.catalyst.plans.logical.{Project, NoRelation, LogicalPlan}
+import org.scalatest.{FunSuite, Matchers}
+
+object TestObjectDialect extends Dialect {
+
+  override def parse(sql: String): LogicalPlan = {
+    NoRelation
+  }
+
+  override def description = "test object dialect"
+}
+
+class TestClassDialect extends Dialect {
+
+  override def parse(sql: String): LogicalPlan = {
+    Project(Seq.empty, NoRelation)
+  }
+
+  override def description = TestClassDialect.description
+}
+
+object TestClassDialect {
+  val description = "test class dialect"
+}
+
+object ErrorDialect
+
+class ErrorClassDialect
+
+class DefaultDialectManagerSuite extends FunSuite with Matchers {
+  test("object dialect reflect") {
+    val dialect = DefaultDialectManager
+      .buildDialect("org.apache.spark.sql.dialect.TestObjectDialect")
+
+    dialect.description should be (TestObjectDialect.description)
+    dialect.parse("sql statement") should be (NoRelation)
+
+    intercept[Exception](DefaultDialectManager
+      .buildDialect("org.apache.spark.sql.dialect.ErrorDialect"))
+  }
+
+  test("class dialect reflect") {
+    val dialect = DefaultDialectManager
+      .buildDialect("org.apache.spark.sql.dialect.TestClassDialect")
+
+    dialect.description should be (TestClassDialect.description)
+    dialect.parse("sql statement") should be (Project(Seq.empty, NoRelation))
+
+    intercept[Exception](DefaultDialectManager
+      .buildDialect("org.apache.spark.sql.dialect.ErrorClassDialect"))
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/dialect/DialectCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/dialect/DialectCommandSuite.scala
@@ -51,6 +51,8 @@ class DialectCommandSuite extends QueryTest {
 
   test("create dialect") {
     val dialectName = "tql"
+
+    // dialect is a keyword
     sql(s"""CREATE DIALECT $dialectName USING org.apache.spark.sql.`dialect`.TestDialect""")
 
     checkAnswer(
@@ -82,3 +84,4 @@ class DialectCommandSuite extends QueryTest {
     intercept[RuntimeException](sql("create dialect test using "))
   }
 }
+

--- a/sql/core/src/test/scala/org/apache/spark/sql/dialect/DialectCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/dialect/DialectCommandSuite.scala
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.dialect
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.test.TestSQLContext.{udf => _, _}
+import org.apache.spark.sql.{QueryTest, Row, SparkSQLParser, catalyst}
+
+class TestDialect extends Dialect {
+  val sqlParser = {
+    val fallback = new catalyst.SqlParser
+    new SparkSQLParser(fallback(_))
+  }
+
+  override def parse(sql: String): LogicalPlan = {
+    sqlParser(sql)
+  }
+
+  override def description = "test dialect"
+}
+
+class DialectCommandSuite extends QueryTest {
+
+  test("show dialect") {
+    checkAnswer(
+      sql("show dialect"),
+      Row(SparkSqlDialect.name))
+
+    checkAnswer(
+      sql("show extended dialect"),
+      Row(SparkSqlDialect.name,
+        SparkSqlDialect.getClass.getCanonicalName.dropRight(1),
+        SparkSqlDialect.description)
+    )
+  }
+
+  test("create dialect") {
+    val dialectName = "tql"
+    sql(s"""CREATE DIALECT $dialectName USING org.apache.spark.sql.`dialect`.TestDialect""")
+
+    checkAnswer(
+      sql("show dialects"),
+      Row("sql") :: Row(dialectName) :: Nil
+    )
+
+    sql(s"use dialect $dialectName")
+
+    checkAnswer(
+      sql("show dialect"),
+      Row(dialectName)
+    )
+
+    intercept[RuntimeException](sql(s"drop dialect $dialectName"))
+
+    sql("use dialect sql")
+
+    sql(s"drop dialect $dialectName")
+
+    checkAnswer(
+      sql("show dialects"),
+      Row("sql")
+    )
+  }
+
+  test("dialect parser") {
+    // class name can't be empty
+    intercept[RuntimeException](sql("create dialect test using "))
+  }
+}

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -83,7 +83,8 @@ class HiveContext(sc: SparkContext) extends SQLContext(sc) {
     new this.QueryExecution(plan)
 
   override def sql(sqlText: String): DataFrame = {
-    dialectManager.buildDataFrame(sqlText)
+    val substituted = new VariableSubstitution().substitute(hiveconf, sqlText)
+    dialectManager.buildDataFrame(substituted)
   }
 
   /**

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -31,6 +31,7 @@ import org.apache.hadoop.hive.serde2.{Deserializer, SerDeException}
 import org.apache.hadoop.util.ReflectionUtils
 
 import org.apache.spark.Logging
+import org.apache.spark.sql.dialect.SparkSqlDialect
 import org.apache.spark.sql.{SaveMode, AnalysisException, SQLContext}
 import org.apache.spark.sql.catalyst.analysis.{NoSuchTableException, Catalog, OverrideCatalog}
 import org.apache.spark.sql.catalyst.expressions._
@@ -756,7 +757,7 @@ private[hive] case class MetastoreRelation
   implicit class SchemaAttribute(f: FieldSchema) {
     def toAttribute = AttributeReference(
       f.getName,
-      sqlContext.ddlParser.parseType(f.getType),
+      SparkSqlDialect.ddlParser.parseType(f.getType),
       // Since data can be dumped in randomly with no validation, everything is nullable.
       nullable = true
     )(qualifiers = Seq(alias.getOrElse(tableName)))

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQlDialect.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQlDialect.scala
@@ -1,0 +1,17 @@
+package org.apache.spark.sql.hive
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.dialect.Dialect
+
+/**
+ * Created by Sally on 2015/3/8.
+ */
+object HiveQlDialect extends Dialect {
+  val name = "hiveql"
+
+  override def description = "Hive query language dialect"
+
+  override def parse(sql: String): LogicalPlan = {
+    HiveQl.parseSql(sql)
+  }
+}

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQlDialect.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQlDialect.scala
@@ -19,13 +19,18 @@ package org.apache.spark.sql.hive
 
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.dialect.Dialect
+import org.apache.spark.sql.sources.DDLParser
 
 object HiveQlDialect extends Dialect {
   val name = "hiveql"
 
+  @transient
+  protected[sql] val ddlParserWithHiveQL = new DDLParser(HiveQl.parseSql(_))
+
   override def description = "Hive query language dialect"
 
   override def parse(sql: String): LogicalPlan = {
-    HiveQl.parseSql(sql)
+    val ddlPlan = ddlParserWithHiveQL(sql, exceptionOnError = false)
+    ddlPlan.getOrElse(HiveQl.parseSql(sql))
   }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQlDialect.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQlDialect.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.sql.hive
 
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQlDialect.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQlDialect.scala
@@ -20,9 +20,6 @@ package org.apache.spark.sql.hive
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.dialect.Dialect
 
-/**
- * Created by Sally on 2015/3/8.
- */
 object HiveQlDialect extends Dialect {
   val name = "hiveql"
 


### PR DESCRIPTION
This PR added an independent dialect manager.

support sql statement to manage dialect:

SHOW [EXTENDED] DIALECT -> show dialect name that is being used,if there is extended keyword,show the extended info.

SHOW [EXTENDED] DIALECTS -> show all dialects

CREATE DIALECT dialect_name USING dialect_full_classname -> add a new dialect with name "dialect_name" using the class that "dialect_full_classname" represented

DROP DIALECT dialect_name -> drop a dialect

USE DIALECT dialect_name -> switch dialect
