### PR TITLE
[SPARK-6224][SQL] Also collect NamedExpressions in PhysicalOperation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -93,6 +93,7 @@ object PhysicalOperation extends PredicateHelper {
 
   def collectAliases(fields: Seq[Expression]) = fields.collect {
     case a @ Alias(child, _) => a.toAttribute.asInstanceOf[Attribute] -> child
+    case e @ NamedExpression(_) => e.toAttribute.asInstanceOf[Attribute] -> e
   }.toMap
 
   def substitute(aliases: Map[Attribute, Expression])(expr: Expression) = expr.transform {


### PR DESCRIPTION
Currently in `PhysicalOperation`, only `Alias` expressions are collected. Similarly, `NamedExpression` can be collected for substitution.
