### PR TITLE
[SPARK-6244] Implement VectorSpace to easy create a complicated feature vector

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
@@ -32,6 +32,8 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions.GenericMutableRow
 import org.apache.spark.sql.types._
 
+import scala.collection.mutable
+
 /**
  * Represents a numeric vector, whose index type is Int and value type is Double.
  *
@@ -99,6 +101,11 @@ sealed trait Vector extends Serializable {
   def copy: Vector = {
     throw new NotImplementedError(s"copy is not implemented for ${this.getClass}.")
   }
+
+  /**
+   * Multiplication vectors by scalar.
+   */
+  def scale(scalar: Double): Vector
 
   /**
    * Applies a function `f` to all the active elements of dense and sparse vector.
@@ -460,6 +467,132 @@ object Vectors {
     }
     allEqual
   }
+
+  /**
+   * Concating vectors to single vector.
+   */
+  def concat(vectors: Iterable[Vector]): Vector = {
+    var elements: List[(Int, Double)] = Nil
+    var idx = 0
+
+    vectors.foreach {
+      case SparseVector(size, indices, values) =>
+        var i = 0
+        for (sv_idx <- indices) {
+          elements ::=(idx + sv_idx, values(i))
+          i += 1
+        }
+        idx += size
+
+      case DenseVector(values) =>
+        for (elm <- values) {
+          elements ::=(idx, elm)
+          idx += 1
+        }
+
+      case vector =>
+        throw new IllegalArgumentException(f"Don't support vector type ${vector.getClass}")
+    }
+
+    Vectors.sparse(idx, elements)
+  }
+
+  /**
+   * Concating vectors to single vector.
+   */
+  @varargs
+  def concat(firstVector: Vector, otherVectors: Vector*): Vector=
+    concat(firstVector +: otherVectors)
+
+  /**
+   * Adding vectors together.
+   */
+  def sum(vectors: Iterable[Vector]): Vector = {
+    val sparse_size = vectors.map {
+      case SparseVector(size, _, _) =>
+        size
+      case _ =>
+        0
+    }.max
+
+    val dense_size = vectors.map {
+      case DenseVector(values) =>
+        values.length
+      case _ =>
+        0
+    }.max
+
+    if (dense_size >= sparse_size / 2)
+      denseSum(vectors)
+    else
+      sparseSum(vectors)
+  }
+
+  /**
+   * Adding vectors together.
+   */
+  @varargs
+  def sum(firstVector: Vector, otherVectors: Vector*): Vector=
+    sum(firstVector +: otherVectors)
+
+  private[mllib] def sparseSum(vectors: Iterable[Vector]): SparseVector = {
+    val size = vectors.map(_.size).max
+    val elements = new mutable.HashMap[Int, Double]()
+
+    vectors.foreach {
+      case SparseVector(_, indices, values) =>
+        var i = 0
+        for (idx <- indices) {
+          if (elements.contains(idx))
+            elements(idx) += values(i)
+          else
+            elements(idx) = values(i)
+          i += 1
+        }
+
+      case DenseVector(values) =>
+        var i = 0
+        for (elm <- values) {
+          if (elements.contains(i))
+            elements(i) += elm
+          else
+            elements(i) = elm
+          i += 1
+        }
+
+      case vector =>
+        throw new IllegalArgumentException(f"Don't support vector type ${vector.getClass}")
+    }
+
+    Vectors.sparse(size, elements.toSeq).asInstanceOf[SparseVector]
+  }
+
+  private[mllib] def denseSum(vectors: Iterable[Vector]): DenseVector = {
+    val size = vectors.map(_.size).max
+    val sum_values: Array[Double] = new Array(size)
+
+    vectors.foreach {
+      case SparseVector(_, indices, values) =>
+        var i = 0
+        for (idx <- indices) {
+          sum_values(idx) += values(i)
+          i += 1
+        }
+
+      case DenseVector(values) =>
+        var i = 0
+        for (elm <- values) {
+          sum_values(i) += elm
+          i += 1
+        }
+
+      case vector =>
+        throw new IllegalArgumentException(f"Don't support vector type ${vector.getClass}")
+    }
+
+    Vectors.dense(sum_values).asInstanceOf[DenseVector]
+  }
+
 }
 
 /**
@@ -481,6 +614,9 @@ class DenseVector(val values: Array[Double]) extends Vector {
   override def copy: DenseVector = {
     new DenseVector(values.clone())
   }
+
+  override def scale(scalar: Double): Vector =
+    new DenseVector(values.map(_ * scalar))
 
   private[spark] override def foreachActive(f: (Int, Double) => Unit) = {
     var i = 0
@@ -531,6 +667,9 @@ class SparseVector(
   override def copy: SparseVector = {
     new SparseVector(size, indices.clone(), values.clone())
   }
+
+  override def scale(scalar: Double): Vector =
+    new SparseVector(size, indices, values.map(_ * scalar))
 
   private[mllib] override def toBreeze: BV[Double] = new BSV[Double](indices, values, size)
 

--- a/mllib/src/test/java/org/apache/spark/mllib/linalg/JavaVectorsSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/linalg/JavaVectorsSuite.java
@@ -42,4 +42,16 @@ public class JavaVectorsSuite implements Serializable {
         new Tuple2<Integer, Double>(2, 3.0)));
     assertArrayEquals(new double[]{2.0, 0.0, 3.0}, v.toArray(), 0.0);
   }
+
+  @Test
+  public void vectorsConcat() {
+    Vector v = Vectors.concat(Vectors.dense(1.0, 2.0), Vectors.dense(3.0));
+    assertArrayEquals(new double[]{1.0, 2.0, 3.0}, v.toArray(), 0.0);
+  }
+
+  @Test
+  public void vectorsSum() {
+    Vector v = Vectors.sum(Vectors.dense(1.0, 2.0), Vectors.dense(3.0));
+    assertArrayEquals(new double[]{4.0, 2.0}, v.toArray(), 0.0);
+  }
 }

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
@@ -268,4 +268,38 @@ class VectorsSuite extends FunSuite {
     assert(Vectors.norm(sv, 3.7) ~== math.pow(sv.toArray.foldLeft(0.0)((a, v) =>
       a + math.pow(math.abs(v), 3.7)), 1.0 / 3.7) relTol 1E-8)
   }
+
+  test("vector scaling") {
+    val dv = Vectors.dense(arr)
+      .scale(-1d)
+      .asInstanceOf[DenseVector]
+
+    val sv = Vectors.sparse(n, indices.zip(values).reverse)
+      .scale(-1d)
+      .asInstanceOf[SparseVector]
+
+    assert(dv.values === arr.map(_ * -1d))
+    assert(sv.size === n)
+    assert(sv.indices === indices)
+    assert(sv.values === values.map(_ * -1d))
+  }
+
+  test("vectors concat") {
+    val dv = Vectors.dense(arr)
+    val sv = Vectors.sparse(n, indices.zip(values).reverse)
+
+    val concat = Vectors.concat(dv, sv)
+
+    assert(concat.toArray.take(dv.size) === dv.toArray)
+    assert(concat.toArray.drop(dv.size) === sv.toArray)
+  }
+
+  test("vectors sum") {
+    val dv = Vectors.dense(1, 2, 1)
+    val sv = Vectors.sparse(5, Array((0, 7d), (2, 1d), (4, 3d)))
+
+    val sum = Vectors.sum(dv, sv)
+
+    assert(sum.toArray === Array(8d, 2d, 2d, 0d, 3d))
+  }
 }


### PR DESCRIPTION
VectorSpace is wrapper what implement three operation:
- concat -- concat all vectors to single vector
- sum -- sum of vectors
- scaled -- multiple scalar to vector

Example of usage:

```
import org.apache.spark.mllib.linalg.Vectors
import org.apache.spark.mllib.linalg.VectorSpace

// Create a new Vector Space with one dense vector.
val vs = VectorSpace.create(Vectors.dense(1.0, 0.0, 3.0))

// Add a to vector space a scaled vector space
val vs2 = vs.add(vs.scaled(-1d))

// concat vectors from vector space, result: Vectors.dense(1.0, 0.0, 3.0, -1.0, 0.0, -3.0)
val concat = vs2.concat

// take a sum from vector space, result: Vectors.dense(0.0, 0.0, 0.0)
val sum = vs2.sum
```

This wrapper is very useful when create a complicated feature vector from structured objects.
