### PR TITLE
[SPARK-6222][STREAMING] Make sure batches are considered fully processed only after the checkpoint after batch is completed.

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/Checkpoint.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/Checkpoint.scala
@@ -116,7 +116,8 @@ class CheckpointWriter(
   private var stopped = false
   private var fs_ : FileSystem = _
 
-  class CheckpointWriteHandler(checkpointTime: Time, bytes: Array[Byte]) extends Runnable {
+  class CheckpointWriteHandler(
+      checkpointTime: Time, bytes: Array[Byte], clearCheckpointData: Boolean) extends Runnable {
     def run() {
       var attempts = 0
       val startTime = System.currentTimeMillis()
@@ -163,7 +164,7 @@ class CheckpointWriter(
           val finishTime = System.currentTimeMillis()
           logInfo("Checkpoint for time " + checkpointTime + " saved to file '" + checkpointFile +
             "', took " + bytes.length + " bytes and " + (finishTime - startTime) + " ms")
-          jobGenerator.onCheckpointCompletion(checkpointTime)
+          jobGenerator.onCheckpointCompletion(checkpointTime, clearCheckpointData)
           return
         } catch {
           case ioe: IOException =>
@@ -177,7 +178,7 @@ class CheckpointWriter(
     }
   }
 
-  def write(checkpoint: Checkpoint) {
+  def write(checkpoint: Checkpoint, clearCheckpointData: Boolean) {
     val bos = new ByteArrayOutputStream()
     val zos = compressionCodec.compressedOutputStream(bos)
     val oos = new ObjectOutputStream(zos)
@@ -185,7 +186,8 @@ class CheckpointWriter(
     oos.close()
     bos.close()
     try {
-      executor.execute(new CheckpointWriteHandler(checkpoint.checkpointTime, bos.toByteArray))
+      executor.execute(new CheckpointWriteHandler(
+        checkpoint.checkpointTime, bos.toByteArray, clearCheckpointData))
       logDebug("Submitted checkpoint of time " + checkpoint.checkpointTime + " writer queue")
     } catch {
       case rej: RejectedExecutionException =>

--- a/streaming/src/main/scala/org/apache/spark/streaming/Time.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/Time.scala
@@ -81,6 +81,18 @@ case class Time(private val millis: Long) {
 
   override def toString: String = (millis.toString + " ms")
 
+  override def hashCode: Int = {
+    milliseconds.hashCode()
+  }
+
+  override def equals(o2: Any): Boolean = {
+    if (o2 == null || !o2.isInstanceOf[Time]) {
+      false
+    } else {
+      o2.asInstanceOf[Time].millis == millis
+    }
+  }
+
 }
 
 object Time {

--- a/streaming/src/main/scala/org/apache/spark/streaming/Time.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/Time.scala
@@ -95,5 +95,5 @@ object Time {
 }
 
 private[streaming] class TimeComparator extends Comparator[Time] {
-override def compare (o1: Time, o2: Time): Int = Longs.compare (o1.milliseconds, o2.milliseconds)
+  override def compare(o1: Time, o2: Time): Int = Longs.compare(o1.milliseconds, o2.milliseconds)
 }

--- a/streaming/src/main/scala/org/apache/spark/streaming/Time.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/Time.scala
@@ -17,6 +17,10 @@
 
 package org.apache.spark.streaming
 
+import java.util.Comparator
+
+import com.google.common.primitives.Longs
+
 /**
  * This is a simple class that represents an absolute instant of time.
  * Internally, it represents time as the difference, measured in milliseconds, between the current
@@ -84,17 +88,12 @@ case class Time(private val millis: Long) {
   override def hashCode: Int = {
     milliseconds.hashCode()
   }
-
-  override def equals(o2: Any): Boolean = {
-    if (o2 == null || !o2.isInstanceOf[Time]) {
-      false
-    } else {
-      o2.asInstanceOf[Time].millis == millis
-    }
-  }
-
 }
 
 object Time {
   implicit val ordering = Ordering.by((time: Time) => time.millis)
+}
+
+private[streaming] class TimeComparator extends Comparator[Time] {
+override def compare (o1: Time, o2: Time): Int = Longs.compare (o1.milliseconds, o2.milliseconds)
 }

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.streaming.scheduler
 
-import java.util.{Comparator, TreeMap, TreeSet}
+import java.util.{Comparator, HashMap, TreeSet}
 
 import scala.collection.JavaConversions._
 import scala.util.{Failure, Success, Try}
@@ -47,8 +47,9 @@ class JobGenerator(jobScheduler: JobScheduler) extends Logging {
   private val ssc = jobScheduler.ssc
   private val conf = ssc.conf
   private val graph = ssc.graph
-  private val completedBothCheckpoints = new TreeMap[Time, Boolean](new TimeComparator)
-  private val batchesGenerated = new TreeSet[Time](new TimeComparator)
+  private lazy val completedBothCheckpoints = new HashMap[Time, Boolean]()
+  private lazy val batchesGenerated = new TreeSet[Time](new TimeComparator)
+  private val noConcurrentJobs = ssc.sc.conf.getInt("spark.streaming.concurrentJobs", 1) == 1
 
   val clock = {
     val clockClass = ssc.sc.conf.get(

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
@@ -165,7 +165,15 @@ class JobGenerator(jobScheduler: JobScheduler) extends Logging {
    * Callback called when a batch has been completely processed.
    */
   def onBatchCompletion(time: Time) {
-    lastCompletedBatch = time
+    // Update the lastCompletedBatch only if this batch is actually newer than the previously
+    // completed ones.
+    lastCompletedBatch = {
+      if (lastCompletedBatch < time) {
+        time
+      } else {
+        lastCompletedBatch
+      }
+    }
     eventActor ! ClearMetadata(time)
   }
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
@@ -317,7 +317,7 @@ class JobGenerator(jobScheduler: JobScheduler) extends Logging {
     // All the checkpoint information about which batches have been processed, etc have
     // been saved to checkpoints, so its safe to delete block metadata and data WAL files
     lastProcessedBatch.foreach { lastProcessed =>
-      val removalTime = lastProcessed -  graph.getMaxInputStreamRememberDuration()
+      val removalTime = lastProcessed - graph.getMaxInputStreamRememberDuration()
       ssc.graph.clearMetadata(removalTime)
       if (shouldCheckpoint) ssc.graph.clearCheckpointData(removalTime)
       jobScheduler.receiverTracker

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
@@ -268,7 +268,7 @@ class JobGenerator(jobScheduler: JobScheduler) extends Logging {
 
   /** Clear DStream metadata for the given `time`. */
   private def clearMetadata(time: Time) {
-
+    ssc.graph.clearMetadata(time)
     // If checkpointing is enabled, then checkpoint,
     // else mark batch to be fully processed
     if (isCheckpointRequired(time)) {
@@ -318,10 +318,8 @@ class JobGenerator(jobScheduler: JobScheduler) extends Logging {
     // been saved to checkpoints, so its safe to delete block metadata and data WAL files
     lastProcessedBatch.foreach { lastProcessed =>
       val removalTime = lastProcessed - graph.getMaxInputStreamRememberDuration()
-      ssc.graph.clearMetadata(removalTime)
       if (shouldCheckpoint) ssc.graph.clearCheckpointData(removalTime)
-      jobScheduler.receiverTracker
-        .cleanupOldBlocksAndBatches(removalTime)
+      jobScheduler.receiverTracker.cleanupOldBlocksAndBatches(removalTime)
     }
   }
 

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -180,7 +180,7 @@ class StreamingContextSuite extends FunSuite with BeforeAndAfter with Timeouts w
     sc = new SparkContext(conf)
     for (i <- 1 to 4) {
       logInfo("==================================\n\n\n")
-      ssc = new StreamingContext(sc, Milliseconds(500))
+      ssc = new StreamingContext(sc, Milliseconds(100))
       var runningCount = 0
       TestReceiver.counter.set(1)
       val input = ssc.receiverStream(new TestReceiver)

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -180,7 +180,7 @@ class StreamingContextSuite extends FunSuite with BeforeAndAfter with Timeouts w
     sc = new SparkContext(conf)
     for (i <- 1 to 4) {
       logInfo("==================================\n\n\n")
-      ssc = new StreamingContext(sc, Milliseconds(100))
+      ssc = new StreamingContext(sc, Milliseconds(500))
       var runningCount = 0
       TestReceiver.counter.set(1)
       val input = ssc.receiverStream(new TestReceiver)


### PR DESCRIPTION
Streaming jobs start a checkpoint as soon as the job is started, and then after the job is completed. Sometimes when the backlog is huge, the post-job checkpoint takes way too long and may not be executed at all. Since the time for which WAL files are retained is pretty low, WAL files may get deleted before the job that is processing them gets completed. In this case, there is data loss if the driver dies and restarts, because certain batches which were not completed at the time of checkpoint may have lost its WAL content as well.

This PR changes this to make sure that WAL cleanup happens only once the job is actually complete. This also changes the notion of what it means for a batch to be fully processed.
