### PR TITLE
[SPARK-6252] [mllib] Added getLambda to Scala NaiveBayes

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/classification/NaiveBayes.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/classification/NaiveBayes.scala
@@ -166,6 +166,9 @@ class NaiveBayes private (private var lambda: Double) extends Serializable with 
     this
   }
 
+  /** Get the smoothing parameter. Default: 1.0. */
+  def getLambda: Double = lambda
+
   /**
    * Run the algorithm with the configured parameters on an input RDD of LabeledPoint entries.
    *

--- a/mllib/src/test/scala/org/apache/spark/mllib/classification/NaiveBayesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/classification/NaiveBayesSuite.scala
@@ -88,9 +88,9 @@ class NaiveBayesSuite extends FunSuite with MLlibTestSparkContext {
   test("get, set params") {
     val nb = new NaiveBayes()
     nb.setLambda(2.0)
-    assert(nb.getLambda == 2.0)
+    assert(nb.getLambda === 2.0)
     nb.setLambda(3.0)
-    assert(nb.getLambda == 3.0)
+    assert(nb.getLambda === 3.0)
   }
 
   test("Naive Bayes") {

--- a/mllib/src/test/scala/org/apache/spark/mllib/classification/NaiveBayesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/classification/NaiveBayesSuite.scala
@@ -85,6 +85,14 @@ class NaiveBayesSuite extends FunSuite with MLlibTestSparkContext {
     assert(numOfPredictions < input.length / 5)
   }
 
+  test("get, set params") {
+    val nb = new NaiveBayes()
+    nb.setLambda(2.0)
+    assert(nb.getLambda == 2.0)
+    nb.setLambda(3.0)
+    assert(nb.getLambda == 3.0)
+  }
+
   test("Naive Bayes") {
     val nPoints = 10000
 


### PR DESCRIPTION
Note: not relevant for Python API since it only has a static train method
