### PR TITLE
[SPARK-6297] EventLog permissions are always set to 770 which causes problems

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -510,6 +510,14 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+  <td><code>spark.eventLog.permissions</code></td>
+  <td>770</td>
+  <td>
+    What permissions to set on event log files. Same permissions are used for created directories
+    and event log files.
+  </td>
+</tr>
+<tr>
   <td><code>spark.ui.killEnabled</code></td>
   <td>true</td>
   <td>


### PR DESCRIPTION
By default permissions are set to 770, which in some cases is more problematic than relying on umask.

If we are using spark master and driver application in an containerized application, using different users which don't share user group it will cause process to fail.
