### PR TITLE
[SPARK-6302][SQL] GeneratedAggregate uses wrong schema on updateProjection

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/GeneratedAggregate.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/GeneratedAggregate.scala
@@ -224,8 +224,7 @@ case class GeneratedAggregate(
       // This projection should be targeted at the current values for the group and then applied
       // to a joined row of the current values with the new input row.
       val updateExpressions = computeFunctions.flatMap(_.update)
-      val updateSchema = computeFunctions.flatMap(_.schema) ++ child.output
-      val updateProjection = newMutableProjection(updateExpressions, updateSchema)()
+      val updateProjection = newMutableProjection(updateExpressions, child.output)()
       log.info(s"Update Expressions: ${updateExpressions.mkString(",")}")
 
       // A projection that produces the final result, given a computation.
@@ -245,7 +244,7 @@ case class GeneratedAggregate(
 
         while (iter.hasNext) {
           currentRow = iter.next()
-          updateProjection(joinedRow(buffer, currentRow))
+          updateProjection(currentRow)
         }
 
         val resultProjection = resultProjectionBuilder()
@@ -264,7 +263,7 @@ case class GeneratedAggregate(
           }
           // Target the projection at the current aggregation buffer and then project the updated
           // values.
-          updateProjection.target(currentBuffer)(joinedRow(currentBuffer, currentRow))
+          updateProjection.target(currentBuffer)(currentRow)
         }
 
         new Iterator[Row] {


### PR DESCRIPTION
The `updateProjection` in `GeneratedAggregate` now uses the `updateSchema` as its input schema. In fact, the schema should be `child.output`.
