### PR TITLE
[SPARK-6198][SQL] Support "select current_database()"

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUdfs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUdfs.scala
@@ -44,6 +44,8 @@ import scala.collection.JavaConversions._
 
 private[hive] abstract class HiveFunctionRegistry
   extends analysis.FunctionRegistry with HiveInspectors {
+  
+  FunctionRegistry.registerGenericUDF(true, "current_database", classOf[sqlUDFCurrentDB])
 
   def getFunctionInfo(name: String): FunctionInfo = FunctionRegistry.getFunctionInfo(name)
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/sqlUDFCurrentDB.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/sqlUDFCurrentDB.scala
@@ -1,0 +1,18 @@
+package org.apache.spark.sql.hive
+
+import org.apache.hadoop.hive.ql.udf.generic.UDFCurrentDB
+import org.apache.hadoop.hive.ql.exec.Description
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredObject
+import org.apache.hadoop.hive.ql.session.SessionState
+
+// deterministic in the query range
+@Description(name = "current_database",
+    value = "_FUNC_() - returns currently using database name")
+class sqlUDFCurrentDB extends UDFCurrentDB {
+
+  // This function just throws an exception in hive0.13
+  override def evaluate(arguments: Array[DeferredObject]): Object = {
+    SessionState.get().getCurrentDatabase()
+  }
+}
+

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/UDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/UDFSuite.scala
@@ -32,5 +32,6 @@ class UDFSuite extends QueryTest {
     assert(sql("SELECT RANDOM0() FROM src LIMIT 1").head().getDouble(0) >= 0.0)
     assert(sql("SELECT RANDOm1() FROM src LIMIT 1").head().getDouble(0) >= 0.0)
     assert(sql("SELECT strlenscala('test', 1) FROM src LIMIT 1").head().getInt(0) === 5)
+    assert(sql("SELECT current_database()").head().getString(0) === "default")
   }
 }


### PR DESCRIPTION
The method(evaluate) has changed in UDFCurrentDB, it just throws a exception.But hiveUdfs call this method and failed.
@Override
public Object evaluate(DeferredObject[] arguments) throws HiveException
{ throw new IllegalStateException("never");
