### PR TITLE
[SPARK-6305] add log4j2 profile and prevent log4j 1.2 shading

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -170,14 +170,6 @@
       <artifactId>jcl-over-slf4j</artifactId>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.ning</groupId>
       <artifactId>compress-lzf</artifactId>
     </dependency>

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -119,6 +119,9 @@ Scala 2.11 support in Spark does not support a few features due to dependencies
 which are themselves not Scala 2.11 ready. Specifically, Spark's external 
 Kafka library and JDBC component are not yet supported in Scala 2.11 builds.
 
+# Building with log4j2
+mvn -Plog4j2 -DskipTests clean package
+
 # Spark Tests in Maven
 
 Tests are run by default via the [ScalaTest Maven plugin](http://www.scalatest.org/user_guide/using_the_scalatest_maven_plugin).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1440,6 +1440,7 @@ compute `SPARK_LOCAL_IP` by looking up the IP of a specific network interface.
 Spark uses [log4j](http://logging.apache.org/log4j/) for logging. You can configure it by adding a
 `log4j.properties` file in the `conf` directory. One way to start is to copy the existing
 `log4j.properties.template` located there.
+You can also use [spark with log4j2](building-spark.html#building-with-log4j2).
 
 # Overriding configuration directory
 

--- a/launcher/pom.xml
+++ b/launcher/pom.xml
@@ -38,11 +38,6 @@
   <dependencies>
     <!-- NOTE: only test-scope dependencies are allowed in this module. -->
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
@@ -62,12 +57,6 @@
       <artifactId>slf4j-api</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <scope>test</scope>
-    </dependency>
-
     <!-- Not needed by the test code, but referenced by SparkSubmit which is used by the tests. -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1706,6 +1706,43 @@
         <jline.groupid>jline</jline.groupid>
       </properties>
     </profile>
+    <profile>
+        <id>log4j2</id>
+        <activation>
+            <property><name>log4j2</name></property>
+        </activation>
+        <properties>
+            <log4j2.version>2.1</log4j2.version>
+        </properties>
+        <dependencies>
+            <dependency>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-log4j12</artifactId>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j-impl</artifactId>
+                <version>2.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>2.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>log4j-over-slf4j</artifactId>
+                <version>1.7.9</version>
+            </dependency>
+        </dependencies>
+    </profile>
+
 
     <!--
       These empty profiles are available in some sub-modules. Declare them here so that


### PR DESCRIPTION
- log4j and slf4j-log4j12 compile dependencies in submodules removed
- log4j2 profile added with log4h12 and slf4j-log4j12 dependencies declared with provided scope (to avoid transitive dependencies when shading), and log4j2 dependencies declared with compile scope
- updated documentation
