### PR TITLE
[SQL] [Build] [Minor] Removes nonexistent sql.Dsl imports from sql/console and hive/console

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -269,7 +269,6 @@ object SQL {
         |import org.apache.spark.sql.catalyst.plans.logical._
         |import org.apache.spark.sql.catalyst.rules._
         |import org.apache.spark.sql.catalyst.util._
-        |import org.apache.spark.sql.Dsl._
         |import org.apache.spark.sql.execution
         |import org.apache.spark.sql.test.TestSQLContext._
         |import org.apache.spark.sql.types._
@@ -300,7 +299,6 @@ object Hive {
         |import org.apache.spark.sql.catalyst.plans.logical._
         |import org.apache.spark.sql.catalyst.rules._
         |import org.apache.spark.sql.catalyst.util._
-        |import org.apache.spark.sql.Dsl._
         |import org.apache.spark.sql.execution
         |import org.apache.spark.sql.hive._
         |import org.apache.spark.sql.hive.test.TestHive._


### PR DESCRIPTION
The `org.apache.spark.sql.Dsl` object has been removed since branch-1.3, should also remove them from SBT `hive/console` and `sql/console` initial commands.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/apache/spark/5012)

<!-- Reviewable:end -->
