### PR TITLE
[SPARK-6331] Load new master URL if present when recovering streaming context from checkpoint

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/Checkpoint.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/Checkpoint.scala
@@ -47,9 +47,9 @@ class Checkpoint(@transient ssc: StreamingContext, val checkpointTime: Time)
     val newSparkConf = new SparkConf(loadDefaults = false).setAll(sparkConfPairs)
       .remove("spark.driver.host")
       .remove("spark.driver.port")
-    new SparkConf(loadDefaults = true).getOption("spark.master") match {
-      case Some(newMaster) => newSparkConf.setMaster(newMaster)
-      case _ => None
+    val oldMaster = new SparkConf(loadDefaults = true).getOption("spark.master")
+    oldMaster.foreach { newMaster =>
+      newSparkConf.setMaster(newMaster)
     }
     newSparkConf
   }

--- a/streaming/src/main/scala/org/apache/spark/streaming/Checkpoint.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/Checkpoint.scala
@@ -47,10 +47,8 @@ class Checkpoint(@transient ssc: StreamingContext, val checkpointTime: Time)
     val newSparkConf = new SparkConf(loadDefaults = false).setAll(sparkConfPairs)
       .remove("spark.driver.host")
       .remove("spark.driver.port")
-    val oldMaster = new SparkConf(loadDefaults = true).getOption("spark.master")
-    oldMaster.foreach { newMaster =>
-      newSparkConf.setMaster(newMaster)
-    }
+    val newMasterOption = new SparkConf(loadDefaults = true).getOption("spark.master")
+    newMasterOption.foreach { newMaster => newSparkConf.setMaster(newMaster) }
     newSparkConf
   }
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/Checkpoint.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/Checkpoint.scala
@@ -43,7 +43,7 @@ class Checkpoint(@transient ssc: StreamingContext, val checkpointTime: Time)
   val delaySeconds = MetadataCleaner.getDelaySeconds(ssc.conf)
   val sparkConfPairs = ssc.conf.getAll
 
-  def sparkConf: SparkConf = {
+  def createSparkConf(): SparkConf = {
     val newSparkConf = new SparkConf(loadDefaults = false).setAll(sparkConfPairs)
       .remove("spark.driver.host")
       .remove("spark.driver.port")

--- a/streaming/src/main/scala/org/apache/spark/streaming/Checkpoint.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/Checkpoint.scala
@@ -43,10 +43,15 @@ class Checkpoint(@transient ssc: StreamingContext, val checkpointTime: Time)
   val delaySeconds = MetadataCleaner.getDelaySeconds(ssc.conf)
   val sparkConfPairs = ssc.conf.getAll
 
-  def sparkConf = {
-    new SparkConf(false).setAll(sparkConfPairs)
+  def sparkConf: SparkConf = {
+    val newSparkConf = new SparkConf(loadDefaults = false).setAll(sparkConfPairs)
       .remove("spark.driver.host")
       .remove("spark.driver.port")
+    new SparkConf(loadDefaults = true).getOption("spark.master") match {
+      case Some(newMaster) => newSparkConf.setMaster(newMaster)
+      case _ => None
+    }
+    newSparkConf
   }
 
   def validate() {

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -116,7 +116,7 @@ class StreamingContext private[streaming] (
 
   private[streaming] val sc: SparkContext = {
     if (isCheckpointPresent) {
-      new SparkContext(cp_.sparkConf)
+      new SparkContext(cp_.createSparkConf())
     } else {
       sc_
     }

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -91,36 +91,18 @@ class StreamingContextSuite extends FunSuite with BeforeAndAfter with Timeouts w
   }
 
   test("from checkpoint") {
-    // Create Checkpoint and verify whether SparkConf configuration is captured
-    val myConf = SparkContext.updatedConf(new SparkConf(loadDefaults = false), master, appName)
+    val myConf = SparkContext.updatedConf(new SparkConf(false), master, appName)
     myConf.set("spark.cleaner.ttl", "10")
-    ssc = new StreamingContext(myConf, batchDuration)
-    addInputStream(ssc).register()
-    ssc.start()
-    val cp = new Checkpoint(ssc, Time(1000))
-    ssc.stop()
+    val ssc1 = new StreamingContext(myConf, batchDuration)
+    addInputStream(ssc1).register()
+    ssc1.start()
+    val cp = new Checkpoint(ssc1, Time(1000))
     assert(cp.sparkConfPairs.toMap.getOrElse("spark.cleaner.ttl", "-1") === "10")
-
-    // Verify SparkConf recreated from Checkpoint has the same configuration
+    ssc1.stop()
     val newCp = Utils.deserialize[Checkpoint](Utils.serialize(cp))
-    assert(newCp.sparkConf.getInt("spark.cleaner.ttl", -1) === 10)
+    assert(newCp.createSparkConf().getInt("spark.cleaner.ttl", -1) === 10)
     ssc = new StreamingContext(null, newCp, null)
     assert(ssc.conf.getInt("spark.cleaner.ttl", -1) === 10)
-    assert(ssc.conf.get("spark.master") === master)
-    ssc.stop()
-
-    // Verify SparkConf recreated from Checkpoint picks up new master
-    try {
-      val newMaster = "local[100]"
-      System.setProperty("spark.master", newMaster)
-      val anotherNewCp = Utils.deserialize[Checkpoint](Utils.serialize(cp))
-      ssc = new StreamingContext(null, anotherNewCp, null)
-      assert(ssc.conf.getInt("spark.cleaner.ttl", -1) === 10)
-      assert(ssc.conf.get("spark.master") === newMaster)
-      ssc.stop()
-    } finally {
-      System.clearProperty("spark.master")
-    }
   }
 
   test("start and stop state check") {


### PR DESCRIPTION
In streaming driver recovery, when the SparkConf is reconstructed based on the checkpointed configuration, it recovers the old master URL. This okay if the cluster on which the streaming application is relaunched is the same cluster as it was running before. But if that cluster changes, there is no way to inject the new master URL of the new cluster. As a result, the restarted app tries to connect to the non-existent old cluster and fails. 

The solution is to check whether a master URL is set in the System properties (by Spark submit) before recreating the SparkConf. If a new master url is set in the properties, then use it as that is obviously the most relevant one. Otherwise load the old one (to maintain existing behavior). 
