### PR TITLE
[SPARK-6354][SQL] Replace the plan which is part of cached query

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
@@ -102,15 +102,13 @@ abstract class LogicalPlan extends QueryPlan[LogicalPlan] with Logging {
     plan.children.size == children.size && {
       logDebug(s"[${plan.cleanArgs.mkString(", ")}] is part of [${cleanArgs.mkString(", ")}]")
       !plan.cleanArgs.zip(cleanArgs).exists {
-        // If this arg is a sequence of Expression, we check if there is a sequence of Expression
-        // in cleanArgs of this logical plan at the same index that contains all elements of this
-        // arg.
-        case (s: Seq[Expression], ss: Seq[Expression]) =>
+        // If this arg is a sequence, we check if there is a sequence in cleanArgs of this logical
+        // plan at the same index that contains all elements of this arg.
+        case (s: Seq[_], ss: Seq[_]) =>
           s.exists(!ss.contains(_))
-
         // Otherwise, we check if the arg in cleanArgs at the same index is as same as this arg.
         case (o, oo) =>
-            o != oo
+          o != oo
       }
     } &&
     (children, plan.children).zipped.forall(_ partResult _)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
@@ -84,6 +84,9 @@ abstract class LogicalPlan extends QueryPlan[LogicalPlan] with Logging {
   /**
    * Returns true when the given logical plan will return part of the results of this logical plan.
    *
+   * The given logical plan is considered the part of this logical plan if all args of the given
+   * plan (i.e. cleanArgs) are contained in the ares of this logical plan.
+   *
    * Since its likely undecideable to generally determine if the given plan will produce part of
    * the results of another plan, it is okay for this function to return false, even if the results
    * are actually one part of another. Such behavior will not affect correctness, only the
@@ -99,6 +102,8 @@ abstract class LogicalPlan extends QueryPlan[LogicalPlan] with Logging {
     plan.children.size == children.size && {
       logDebug(s"[${plan.cleanArgs.mkString(", ")}] is part of [${cleanArgs.mkString(", ")}]")
       !plan.cleanArgs.exists {
+        // If this arg is a Seq, we check if there is a Seq in cleanArgs of this logical plan that
+        // contains all elements of this arg.
         case s: Seq[_] =>
             !cleanArgs.collect { case ss: Seq[_] if s.exists(!ss.contains(_)) => true }.isEmpty
         case o =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/CacheManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/CacheManager.scala
@@ -140,11 +140,16 @@ private[sql] class CacheManager(sqlContext: SQLContext) extends Logging {
     cachedData.find(cd => plan.sameResult(cd.plan))
   }
 
+  /** Optionally returns cached data containing the given LogicalPlan. */
+  private[sql] def lookupPartofCachedData(plan: LogicalPlan): Option[CachedData] = readLock {
+    cachedData.find(cd => cd.plan.partResult(plan))
+  }
+
   /** Replaces segments of the given logical plan with cached versions where possible. */
   private[sql] def useCachedData(plan: LogicalPlan): LogicalPlan = {
     plan transformDown {
       case currentFragment =>
-        lookupCachedData(currentFragment)
+        lookupPartofCachedData(currentFragment)
           .map(_.cachedRepresentation.withOutput(currentFragment.output))
           .getOrElse(currentFragment)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -62,6 +62,15 @@ class CachedTableSuite extends QueryTest {
     cacheTable("testTable")
     assertCached(sql("SELECT COUNT(*) FROM partTable"))
     uncacheTable("testTable")
+
+    sql("SELECT key, COUNT(*) AS c FROM testData GROUP BY key").registerTempTable("testTable")
+    cacheTable("testTable")
+    assertCached(sql("SELECT key FROM testData"), 0)
+    assertCached(sql("SELECT key FROM testData GROUP BY key"))
+    assertCached(sql("SELECT COUNT(*) FROM testData GROUP BY key"), 0)
+    assertCached(sql("SELECT COUNT(*) FROM testData"), 0)
+    assertCached(sql("SELECT COUNT(*) FROM testData GROUP BY value"), 0)
+    uncacheTable("testTable")
   }
 
   test("unpersist an uncached table will not raise exception") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -55,6 +55,15 @@ class CachedTableSuite extends QueryTest {
     uncacheTable("tempTable")
   }
 
+  test("replace the plan which is part of cached query") {
+    testData.select('key, 'value).registerTempTable("testTable")
+    testData.select('key).registerTempTable("partTable")
+    assertCached(sql("SELECT COUNT(*) FROM partTable"), 0)
+    cacheTable("testTable")
+    assertCached(sql("SELECT COUNT(*) FROM partTable"))
+    uncacheTable("testTable")
+  }
+
   test("unpersist an uncached table will not raise exception") {
     assert(None == cacheManager.lookupCachedData(testData))
     testData.unpersist(blocking = true)

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -82,6 +82,20 @@ class CachedTableSuite extends QueryTest {
     sql("CACHE TABLE tempTable AS SELECT key FROM testData")
     assertCached(sql("SELECT COUNT(*) FROM tempTable"))
     uncacheTable("tempTable")
+ 
+    sql("CACHE TABLE tempTable AS SELECT key, value FROM testData")
+    testData.select('key).registerTempTable("partTable")
+    assertCached(sql("SELECT COUNT(*) FROM partTable"))
+    testData.select('value).registerTempTable("partTable2")
+    assertCached(sql("SELECT COUNT(*) FROM partTable2"))
+    uncacheTable("tempTable")
+ 
+    sql("CACHE TABLE tempTable AS SELECT key, COUNT(*) FROM testData GROUP BY key")
+    testData.select('key).registerTempTable("partTable")
+    assertCached(sql("SELECT COUNT(*) FROM partTable"), 0)
+    testData.select('value).registerTempTable("partTable2")
+    assertCached(sql("SELECT COUNT(*) FROM partTable2"), 0)
+    uncacheTable("tempTable")
   }
 
   test("uncaching temp table") {
@@ -155,8 +169,40 @@ class CachedTableSuite extends QueryTest {
         case r @ InMemoryRelation(_, _, _, _, _: InMemoryColumnarTableScan, _) => r
       }.size
     }
-
+ 
     uncacheTable("testData")
+ 
+    testData.select('key, 'value).registerTempTable("testTable")
+    testData.select('key).registerTempTable("partTable")
+
+    cacheTable("testTable")
+    assertCached(table("testTable"))
+    assertCached(table("partTable"))
+ 
+    assertResult(1, "InMemoryRelation not found, testTable should have been cached") {
+      table("testTable").queryExecution.withCachedData.collect {
+        case r: InMemoryRelation => r
+      }.size
+    }
+    assertResult(1, "InMemoryRelation not found, partTable should have been cached") {
+      table("partTable").queryExecution.withCachedData.collect {
+        case r: InMemoryRelation => r
+      }.size
+    }
+ 
+    cacheTable("testTable")
+    assertResult(0, "Double InMemoryRelations found, cacheTable() is not idempotent") {
+      table("testTable").queryExecution.withCachedData.collect {
+        case r @ InMemoryRelation(_, _, _, _, _: InMemoryColumnarTableScan, _) => r
+      }.size
+    }
+    assertResult(0, "Double InMemoryRelations found, cacheTable() is not idempotent") {
+      table("partTable").queryExecution.withCachedData.collect {
+        case r @ InMemoryRelation(_, _, _, _, _: InMemoryColumnarTableScan, _) => r
+      }.size
+    }
+ 
+    uncacheTable("testTable")
   }
 
   test("read from cached table and uncache") {
@@ -178,9 +224,14 @@ class CachedTableSuite extends QueryTest {
   test("SELECT star from cached table") {
     sql("SELECT * FROM testData").registerTempTable("selectStar")
     cacheTable("selectStar")
+    sql("SELECT key FROM testData").registerTempTable("partTable")
+    assertCached(table("partTable"))
     checkAnswer(
       sql("SELECT * FROM selectStar WHERE key = 1"),
       Seq(Row(1, "1")))
+    checkAnswer(
+      sql("SELECT * FROM partTable WHERE key = 1"),
+      Seq(Row(1)))
     uncacheTable("selectStar")
   }
 
@@ -192,6 +243,18 @@ class CachedTableSuite extends QueryTest {
       sql("SELECT * FROM testData a JOIN testData b ON a.key = b.key"),
       unCachedAnswer.toSeq)
     uncacheTable("testData")
+ 
+    testData.select('key).registerTempTable("partTable")
+    val unCachedAnswer2 =
+      sql("SELECT * FROM partTable a JOIN partTable b ON a.key = b.key").collect()
+
+    cacheTable("testData")
+    assertCached(table("partTable"))
+    checkAnswer(
+      sql("SELECT * FROM partTable a JOIN partTable b ON a.key = b.key"),
+      unCachedAnswer2.toSeq)
+    uncacheTable("testData")
+ 
   }
 
   test("'CACHE TABLE' and 'UNCACHE TABLE' SQL statement") {
@@ -214,6 +277,9 @@ class CachedTableSuite extends QueryTest {
   test("CACHE TABLE tableName AS SELECT * FROM anotherTable") {
     sql("CACHE TABLE testCacheTable AS SELECT * FROM testData")
     assertCached(table("testCacheTable"))
+
+    testData.select('key).registerTempTable("partTable")
+    assertCached(table("partTable"))
 
     val rddId = rddIdOf("testCacheTable")
     assert(

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -739,6 +739,10 @@ private[hive] case class MetastoreRelation
     }
   }
 
+  override def partResult(plan: LogicalPlan): Boolean = {
+    this.sameResult(plan)
+  }
+
   val tableDesc = HiveShim.getTableDesc(
     Class.forName(
       hiveQlTable.getSerializationLib,


### PR DESCRIPTION
Currently we only replace the plan which equals to cached query. This approach can be extended to replace the plan which is part of cached query.

JIRA: https://issues.apache.org/jira/browse/SPARK-6354
