### PR TITLE
[SPARK-6356][SQL] Support the ROLLUP/CUBE/GROUPING SETS/GROUPING() in SQLContext

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -136,15 +136,27 @@ class Analyzer(catalog: Catalog,
       g.bitmasks.foreach { bitmask =>
         // get the non selected grouping attributes according to the bit mask
         val nonSelectedGroupExprSet = buildNonSelectExprSet(bitmask, g.groupByExprs)
+        val groupings = new OpenHashSet[String](2)
 
-        val substitution = (g.child.output :+ g.gid).map(expr => expr transformDown {
+        val substitution = ((g.child.output :+ g.gid) ++ g.groupings).map(expr => expr transformDown {
           case x: Expression if nonSelectedGroupExprSet.contains(x) =>
+            x match {
+              case a: AttributeReference => groupings.add(a.name)
+              case _ =>
+            }
             // if the input attribute in the Invalid Grouping Expression set of for this group
             // replace it with constant null
             Literal(null, expr.dataType)
           case x if x == g.gid =>
             // replace the groupingId with concrete value (the bit mask)
             Literal(bitmask, IntegerType)
+          case GroupingAttributeName(x) if g.groupings.contains(x) =>
+            if (groupings.contains(x.name.drop(GroupingAttributeName.nameMarker.length))) {
+              Literal(1, IntegerType)
+            }
+            else {
+              Literal(0, IntegerType)
+            }
         })
 
         result += GroupExpression(substitution)
@@ -155,14 +167,14 @@ class Analyzer(catalog: Catalog,
 
     def apply(plan: LogicalPlan): LogicalPlan = plan transform {
       case a: Cube if a.resolved =>
-        GroupingSets(bitmasks(a), a.groupByExprs, a.child, a.aggregations, a.gid)
+        GroupingSets(bitmasks(a), a.groupByExprs, a.child, a.aggregations, a.gid, a.groupings)
       case a: Rollup if a.resolved =>
-        GroupingSets(bitmasks(a), a.groupByExprs, a.child, a.aggregations, a.gid)
+        GroupingSets(bitmasks(a), a.groupByExprs, a.child, a.aggregations, a.gid, a.groupings)
       case x: GroupingSets if x.resolved =>
         Aggregate(
-          x.groupByExprs :+ x.gid,
+          (x.groupByExprs :+ x.gid) ++ x.groupings,
           x.aggregations,
-          Expand(expand(x), x.child.output :+ x.gid, x.child))
+          Expand(expand(x), (x.child.output :+ x.gid) ++ x.groupings, x.child))
     }
   }
 
@@ -262,6 +274,9 @@ class Analyzer(catalog: Catalog,
             q.isInstanceOf[GroupingAnalytics] =>
             // Resolve the virtual column GROUPING__ID for the operator GroupingAnalytics
             q.asInstanceOf[GroupingAnalytics].gid
+          case UnresolvedGrouping(name) if q.isInstanceOf[GroupingAnalytics] =>
+            val groupings = q.asInstanceOf[GroupingAnalytics].groupings
+            groupings.find(p => GroupingAttributeName(name) == p.name).get
           case u @ UnresolvedAttribute(name) =>
             // Leave unchanged if resolution fails.  Hopefully will be resolved next round.
             val result = q.resolveChildren(name, resolver).getOrElse(u)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -86,7 +86,7 @@ class CheckAnalysis {
             cleaned.foreach(checkValidAggregateExpression)
 
           case o if o.children.nonEmpty &&
-            !o.references.filter(_.name != "grouping__id").subsetOf(o.inputSet) =>
+            !o.references.filter(x => exceptColumns(x.name)).subsetOf(o.inputSet) =>
             val missingAttributes = (o.references -- o.inputSet).map(_.prettyString).mkString(",")
             val input = o.inputSet.map(_.prettyString).mkString(",")
 
@@ -101,5 +101,9 @@ class CheckAnalysis {
         }
     }
     extendedCheckRules.foreach(_(plan))
+  }
+
+  def exceptColumns(name: String): Boolean = {
+    !(name == VirtualColumn.groupingIdName || name.startsWith(GroupingAttributeName.nameMarker))
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -189,3 +189,16 @@ case class UnresolvedGetField(child: Expression, fieldName: String) extends Unar
 
   override def toString = s"$child.$fieldName"
 }
+
+case class UnresolvedGrouping(name: String) extends LeafExpression {
+  override def dataType = throw new UnresolvedException(this, "dataType")
+  override def foldable = throw new UnresolvedException(this, "foldable")
+  override def nullable = throw new UnresolvedException(this, "nullable")
+  override lazy val resolved = false
+
+  override def eval(input: Row = null): EvaluatedType =
+    throw new TreeNodeException(this, s"No function to evaluate expression. type: ${this.nodeName}")
+
+  override def toString = s"Grouping($name)"
+}
+

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
@@ -224,4 +224,25 @@ case class PrettyAttribute(name: String) extends Attribute with trees.LeafNode[E
 object VirtualColumn {
   val groupingIdName = "grouping__id"
   def newGroupingId = AttributeReference(groupingIdName, IntegerType, false)()
+
+  def newGroupings(groupByExprs: Seq[Expression]) = {
+    groupByExprs.collect {
+      case x: NamedExpression => AttributeReference(GroupingAttributeName(x.name), IntegerType, false)()
+    }
+  }
+}
+
+object GroupingAttributeName {
+  val nameMarker = "grouping_"
+  def apply(name: String): String = {
+    nameMarker + name
+  }
+
+  def unapply(expr: Expression): Option[AttributeReference] = {
+    expr match {
+      case x: AttributeReference =>
+        if (x.name.startsWith(nameMarker)) Some(x) else None
+      case _ => None
+    }
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicOperators.scala
@@ -179,6 +179,7 @@ case class Expand(
 trait GroupingAnalytics extends UnaryNode {
   self: Product =>
   def gid: AttributeReference
+  def groupings: Seq[AttributeReference]
   def groupByExprs: Seq[Expression]
   def aggregations: Seq[NamedExpression]
 
@@ -207,7 +208,9 @@ case class GroupingSets(
     groupByExprs: Seq[Expression],
     child: LogicalPlan,
     aggregations: Seq[NamedExpression],
-    gid: AttributeReference = VirtualColumn.newGroupingId) extends GroupingAnalytics
+    gid: AttributeReference = VirtualColumn.newGroupingId,
+    groupings: Seq[AttributeReference] = Seq.empty) extends GroupingAnalytics
+
 
 /**
  * Cube is a syntactic sugar for GROUPING SETS, and will be transformed to GroupingSets,
@@ -225,7 +228,8 @@ case class Cube(
     groupByExprs: Seq[Expression],
     child: LogicalPlan,
     aggregations: Seq[NamedExpression],
-    gid: AttributeReference = VirtualColumn.newGroupingId) extends GroupingAnalytics
+    gid: AttributeReference = VirtualColumn.newGroupingId,
+    groupings: Seq[AttributeReference] = Seq.empty) extends GroupingAnalytics
 
 /**
  * Rollup is a syntactic sugar for GROUPING SETS, and will be transformed to GroupingSets,
@@ -244,7 +248,8 @@ case class Rollup(
     groupByExprs: Seq[Expression],
     child: LogicalPlan,
     aggregations: Seq[NamedExpression],
-    gid: AttributeReference = VirtualColumn.newGroupingId) extends GroupingAnalytics
+    gid: AttributeReference = VirtualColumn.newGroupingId,
+    groupings: Seq[AttributeReference] = Seq.empty) extends GroupingAnalytics
 
 case class Limit(limitExpr: Expression, child: LogicalPlan) extends UnaryNode {
   override def output = child.output

--- a/sql/core/src/test/scala/org/apache/spark/sql/TestData.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TestData.scala
@@ -206,4 +206,14 @@ object TestData {
         :: ComplexData(Map(2 -> "2"), TestData(2, "2"), Seq(2), false)
         :: Nil).toDF()
   complexData.registerTempTable("complexData")
+
+  case class Student(name: String, course: String, score: Int)
+  val students = TestSQLContext.sparkContext.parallelize(
+    Student("Tom", "Math", 10) ::
+    Student("Tom", "English", 20) ::
+    Student("Phoebe", "Math", 30) ::
+    Student("Phoebe", "English", 40) ::
+    Student(null, "Math", 50) ::
+    Student("Jim", null, 60) :: Nil).toDF()
+  students.registerTempTable("students")
 }


### PR DESCRIPTION
Support for the expression below:

```
Like HiveQL:
GROUP BY expression list WITH ROLLUP
GROUP BY expression list WITH CUBE
GROUP BY expression list GROUPING SETS(expression list2)
```

and

```
GROUP BY ROLLUP(expression list)
GROUP BY CUBE(expression list)
GROUP BY GROUPING SETS(expression list)
```

and

```
GROUPING (column name)
```

Thanks to @scwf @haiyangsea
/cc @chenghao-intel @yhuai

https://github.com/apache/spark/pull/3964
