### PR TITLE
[SPARK-6365] jetty-security also needed for SPARK_PREPEND_CLASSES to work

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -414,7 +414,7 @@
               <overWriteIfNewer>true</overWriteIfNewer>
               <useSubDirectoryPerType>true</useSubDirectoryPerType>
               <includeArtifactIds>
-                guava,jetty-io,jetty-servlet,jetty-continuation,jetty-http,jetty-plus,jetty-util,jetty-server
+                guava,jetty-io,jetty-servlet,jetty-continuation,jetty-http,jetty-plus,jetty-util,jetty-server,jetty-security
               </includeArtifactIds>
               <silent>true</silent>
             </configuration>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-6365

thanks @vanzin for helping me figure this out
