### PR TITLE
[SPARK-6379][SQL] Support a functon to call user-defined functions registered in SQLContext

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -259,6 +259,22 @@ class SQLContext(@transient val sparkContext: SparkContext)
       }
     }
 
+    /**
+     * Convert udf"registered function name" into a [[UnresolvedFunction]].
+     * Example:
+     * {{{
+     *  import org.apache.spark.sql._
+     *
+     *  val df = Seq(("id1", 1), ("id2", 4), ("id3", 5)).toDF("id", "value")
+     *  df.sqlContext.udf.register("simpleUdf", (v: Int) => v * v)
+     *  df.select($"id", udf"simpleUdf"($"value"))
+     * }}}
+     */
+    implicit class StringToUdf(val sc: StringContext) {
+      def udf(args: Any*)(cols: Column*) =
+        Column(UnresolvedFunction(sc.s(args: _*), cols.map(_.expr)))
+    }
+
     /** An implicit conversion that turns a Scala `Symbol` into a [[Column]]. */
     implicit def symbolToColumn(s: Symbol): ColumnName = new ColumnName(s.name)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -212,22 +212,6 @@ class SQLContext(@transient val sparkContext: SparkContext)
   val udf: UDFRegistration = new UDFRegistration(this)
 
   /**
-   * Call an user-defined function which is registered
-   * in functionRegistry.
-   * Example:
-   * {{{
-   *  import org.apache.spark.sql._
-   *
-   *  val df = Seq(("id1", 1), ("id2", 4), ("id3", 5)).toDF("id", "value")
-   *  val sqlctx = df.sqlContext
-   *  sqlctx.udf.register("simpleUdf", (v: Int) => v * v)
-   *  df.select($"id", sqlctx.callUdf("simpleUdf", $"value"))
-   * }}}
-   */
-  def callUdf(udfName: String, cols: Column*): Column =
-    Column(UnresolvedFunction(udfName, cols.map(_.expr)))
-
-  /**
    * Returns true if the table is currently cached in-memory.
    * @group cachemgmt
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -212,6 +212,22 @@ class SQLContext(@transient val sparkContext: SparkContext)
   val udf: UDFRegistration = new UDFRegistration(this)
 
   /**
+   * Call an user-defined function which is registered
+   * in functionRegistry.
+   * Example:
+   * {{{
+   *  import org.apache.spark.sql._
+   *
+   *  val df = Seq(("id1", 1), ("id2", 4), ("id3", 5)).toDF("id", "value")
+   *  val sqlctx = df.sqlContext
+   *  sqlctx.udf.register("simpleUdf", (v: Int) => v * v)
+   *  df.select($"id", sqlctx.callUdf("simpleUdf", $"value"))
+   * }}}
+   */
+  def callUdf(udfName: String, cols: Column*) =
+    Column(UnresolvedFunction(udfName, cols.map(_.expr)))
+
+  /**
    * Returns true if the table is currently cached in-memory.
    * @group cachemgmt
    */
@@ -257,22 +273,6 @@ class SQLContext(@transient val sparkContext: SparkContext)
       def $(args: Any*): ColumnName = {
         new ColumnName(sc.s(args :_*))
       }
-    }
-
-    /**
-     * Convert udf"registered function name" into a [[UnresolvedFunction]].
-     * Example:
-     * {{{
-     *  import org.apache.spark.sql._
-     *
-     *  val df = Seq(("id1", 1), ("id2", 4), ("id3", 5)).toDF("id", "value")
-     *  df.sqlContext.udf.register("simpleUdf", (v: Int) => v * v)
-     *  df.select($"id", udf"simpleUdf"($"value"))
-     * }}}
-     */
-    implicit class StringToUdf(val sc: StringContext) {
-      def udf(args: Any*)(cols: Column*) =
-        Column(UnresolvedFunction(sc.s(args: _*), cols.map(_.expr)))
     }
 
     /** An implicit conversion that turns a Scala `Symbol` into a [[Column]]. */

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -224,7 +224,7 @@ class SQLContext(@transient val sparkContext: SparkContext)
    *  df.select($"id", sqlctx.callUdf("simpleUdf", $"value"))
    * }}}
    */
-  def callUdf(udfName: String, cols: Column*) =
+  def callUdf(udfName: String, cols: Column*): Column =
     Column(UnresolvedFunction(udfName, cols.map(_.expr)))
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -22,7 +22,7 @@ import scala.reflect.runtime.universe.{TypeTag, typeTag}
 
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.sql.catalyst.ScalaReflection
-import org.apache.spark.sql.catalyst.analysis.Star
+import org.apache.spark.sql.catalyst.analysis.{UnresolvedFunction, Star}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types._
 
@@ -605,4 +605,23 @@ object functions {
   }
 
   // scalastyle:on
+
+  /**
+   * Call an user-defined function.
+   * Example:
+   * {{{
+   *  import org.apache.spark.sql._
+   *
+   *  val df = Seq(("id1", 1), ("id2", 4), ("id3", 5)).toDF("id", "value")
+   *  val sqlContext = df.sqlContext
+   *  sqlContext.udf.register("simpleUdf", (v: Int) => v * v)
+   *  df.select($"id", callUdf("simpleUdf", $"value"))
+   * }}}
+   *
+   * @group udf_funcs
+   */
+  def callUdf(udfName: String, cols: Column*): Column = {
+     UnresolvedFunction(udfName, cols.map(_.expr))
+  }
+
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -424,9 +424,10 @@ class DataFrameSuite extends QueryTest {
 
   test("call udf through an implicit conversion") {
     val df = Seq(("id1", 1), ("id2", 4), ("id3", 5)).toDF("id", "value")
-    df.sqlContext.udf.register("simpleUdf", (v: Int) => v * v)
+    val sqlctx = df.sqlContext
+    sqlctx.udf.register("simpleUdf", (v: Int) => v * v)
     checkAnswer(
-      df.select($"id", udf"simpleUdf"($"value")),
+      df.select($"id", sqlctx.callUdf("simpleUdf", $"value")),
       Row("id1", 1) :: Row("id2", 16) :: Row("id3", 25) :: Nil)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -422,12 +422,12 @@ class DataFrameSuite extends QueryTest {
     )
   }
 
-  test("call udf through an implicit conversion") {
+  test("call udf in SQLContext") {
     val df = Seq(("id1", 1), ("id2", 4), ("id3", 5)).toDF("id", "value")
     val sqlctx = df.sqlContext
     sqlctx.udf.register("simpleUdf", (v: Int) => v * v)
     checkAnswer(
-      df.select($"id", sqlctx.callUdf("simpleUdf", $"value")),
+      df.select($"id", callUdf("simpleUdf", $"value")),
       Row("id1", 1) :: Row("id2", 16) :: Row("id3", 25) :: Nil)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -422,6 +422,14 @@ class DataFrameSuite extends QueryTest {
     )
   }
 
+  test("call udf through an implicit conversion") {
+    val df = Seq(("id1", 1), ("id2", 4), ("id3", 5)).toDF("id", "value")
+    df.sqlContext.udf.register("simpleUdf", (v: Int) => v * v)
+    checkAnswer(
+      df.select($"id", udf"simpleUdf"($"value")),
+      Row("id1", 1) :: Row("id2", 16) :: Row("id3", 25) :: Nil)
+  }
+
   test("withColumn") {
     val df = testData.toDF().withColumn("newCol", col("key") + 1)
     checkAnswer(


### PR DESCRIPTION
This is useful for using pre-defined UDFs in SQLContext;

val df = Seq(("id1", 1), ("id2", 4), ("id3", 5)).toDF("id", "value")
val sqlctx = df.sqlContext
sqlctx.udf.register("simpleUdf", (v: Int) => v \* v)
df.select($"id", sqlctx.callUdf("simpleUdf", $"value"))
