### PR TITLE
[SPARK-6350][Mesos] Make mesosExecutorCores configurable in mesos "fine-grained" mode

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
@@ -222,7 +222,6 @@ private[spark] class MesosSchedulerBackend(
         val mem = getResource(o.getResourcesList, "mem")
         val cpus = getResource(o.getResourcesList, "cpus")
         val slaveId = o.getSlaveId.getValue
-        // TODO(pwendell): Should below be 1 + scheduler.CPUS_PER_TASK?
         (mem >= MemoryUtils.calculateTotalMemory(sc) &&
           // need at least 1 for executor, 1 for task
           cpus >= (executorCores + scheduler.CPUS_PER_TASK)) ||
@@ -235,7 +234,6 @@ private[spark] class MesosSchedulerBackend(
           getResource(o.getResourcesList, "cpus").toInt
         } else {
           // If the executor doesn't exist yet, subtract CPU for executor
-          // TODO(pwendell): Should below just subtract "1"?
           (getResource(o.getResourcesList, "cpus") - executorCores).toInt
         }
         new WorkerOffer(

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
@@ -68,7 +68,7 @@ private[spark] class MesosSchedulerBackend(
   // The listener bus to publish executor added/removed events.
   val listenerBus = sc.listenerBus
   
-  val executorCores = sc.conf.getInt("spark.executor.frameworkCores", 1)
+  val executorCores = sc.conf.getInt("spark.mesos.executor.cores", 1)
 
   @volatile var appId: String = _
 

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
@@ -68,7 +68,7 @@ private[spark] class MesosSchedulerBackend(
   // The listener bus to publish executor added/removed events.
   val listenerBus = sc.listenerBus
   
-  val executorCores = sc.conf.getInt("spark.mesos.executor.cores", 1)
+  val executorCores = sc.conf.getInt("spark.executor.frameworkCores", 1)
 
   @volatile var appId: String = _
 

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
@@ -68,7 +68,7 @@ private[spark] class MesosSchedulerBackend(
   // The listener bus to publish executor added/removed events.
   val listenerBus = sc.listenerBus
   
-  val executorCores = sc.conf.getInt("spark.mesos.executor.cores", 1)
+  val executorCores = sc.conf.getDouble("spark.mesos.executor.cores", 1)
 
   @volatile var appId: String = _
 
@@ -236,7 +236,7 @@ private[spark] class MesosSchedulerBackend(
         } else {
           // If the executor doesn't exist yet, subtract CPU for executor
           // TODO(pwendell): Should below just subtract "1"?
-          getResource(o.getResourcesList, "cpus").toInt - executorCores
+          (getResource(o.getResourcesList, "cpus") - executorCores).toInt
         }
         new WorkerOffer(
           o.getSlaveId.getValue,

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
@@ -67,6 +67,8 @@ private[spark] class MesosSchedulerBackend(
 
   // The listener bus to publish executor added/removed events.
   val listenerBus = sc.listenerBus
+  
+  val executorCores = sc.conf.getInt("spark.mesos.executor.cores", 1)
 
   @volatile var appId: String = _
 
@@ -139,7 +141,7 @@ private[spark] class MesosSchedulerBackend(
       .setName("cpus")
       .setType(Value.Type.SCALAR)
       .setScalar(Value.Scalar.newBuilder()
-        .setValue(scheduler.CPUS_PER_TASK).build())
+        .setValue(executorCores).build())
       .build()
     val memory = Resource.newBuilder()
       .setName("mem")
@@ -223,7 +225,7 @@ private[spark] class MesosSchedulerBackend(
         // TODO(pwendell): Should below be 1 + scheduler.CPUS_PER_TASK?
         (mem >= MemoryUtils.calculateTotalMemory(sc) &&
           // need at least 1 for executor, 1 for task
-          cpus >= 2 * scheduler.CPUS_PER_TASK) ||
+          cpus >= (executorCores + scheduler.CPUS_PER_TASK)) ||
           (slaveIdsWithExecutors.contains(slaveId) &&
             cpus >= scheduler.CPUS_PER_TASK)
       }
@@ -234,8 +236,7 @@ private[spark] class MesosSchedulerBackend(
         } else {
           // If the executor doesn't exist yet, subtract CPU for executor
           // TODO(pwendell): Should below just subtract "1"?
-          getResource(o.getResourcesList, "cpus").toInt -
-            scheduler.CPUS_PER_TASK
+          getResource(o.getResourcesList, "cpus").toInt - executorCores
         }
         new WorkerOffer(
           o.getSlaveId.getValue,

--- a/core/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendSuite.scala
@@ -118,12 +118,12 @@ class MesosSchedulerBackendSuite extends FunSuite with LocalSparkContext with Mo
     expectedWorkerOffers.append(new WorkerOffer(
       mesosOffers.get(0).getSlaveId.getValue,
       mesosOffers.get(0).getHostname,
-      2
+      minCpu - backend.executorCores
     ))
     expectedWorkerOffers.append(new WorkerOffer(
       mesosOffers.get(2).getSlaveId.getValue,
       mesosOffers.get(2).getHostname,
-      2
+      minCpu - backend.executorCores
     ))
     val taskDesc = new TaskDescription(1L, 0, "s1", "n1", 0, ByteBuffer.wrap(new Array[Byte](0)))
     when(taskScheduler.resourceOffers(expectedWorkerOffers)).thenReturn(Seq(Seq(taskDesc)))

--- a/core/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendSuite.scala
@@ -118,12 +118,12 @@ class MesosSchedulerBackendSuite extends FunSuite with LocalSparkContext with Mo
     expectedWorkerOffers.append(new WorkerOffer(
       mesosOffers.get(0).getSlaveId.getValue,
       mesosOffers.get(0).getHostname,
-      minCpu - backend.executorCores
+      (minCpu - backend.executorCores).toInt
     ))
     expectedWorkerOffers.append(new WorkerOffer(
       mesosOffers.get(2).getSlaveId.getValue,
       mesosOffers.get(2).getHostname,
-      minCpu - backend.executorCores
+      (minCpu - backend.executorCores).toInt
     ))
     val taskDesc = new TaskDescription(1L, 0, "s1", "n1", 0, ByteBuffer.wrap(new Array[Byte](0)))
     when(taskScheduler.resourceOffers(expectedWorkerOffers)).thenReturn(Seq(Seq(taskDesc)))

--- a/core/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackendSuite.scala
@@ -118,12 +118,12 @@ class MesosSchedulerBackendSuite extends FunSuite with LocalSparkContext with Mo
     expectedWorkerOffers.append(new WorkerOffer(
       mesosOffers.get(0).getSlaveId.getValue,
       mesosOffers.get(0).getHostname,
-      (minCpu - backend.executorCores).toInt
+      (minCpu - backend.mesosExecutorCores).toInt
     ))
     expectedWorkerOffers.append(new WorkerOffer(
       mesosOffers.get(2).getSlaveId.getValue,
       mesosOffers.get(2).getHostname,
-      (minCpu - backend.executorCores).toInt
+      (minCpu - backend.mesosExecutorCores).toInt
     ))
     val taskDesc = new TaskDescription(1L, 0, "s1", "n1", 0, ByteBuffer.wrap(new Array[Byte](0)))
     when(taskScheduler.resourceOffers(expectedWorkerOffers)).thenReturn(Seq(Seq(taskDesc)))

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -137,6 +137,14 @@ of the most common options to set are:
     or in your default properties file.
   </td>
 </tr>
+  <td><code>spark.executor.frameworkCores</code></td>
+  <td>1</td>
+  <td>
+    Set the amount of cores allocated to the executor itself. This setting is currently used for Mesos fine-grained mode.
+    By default, executor will use the amount of cores even though no task is running on an executor.
+  </td>
+</tr>
+<tr>
 <tr>
   <td><code>spark.executor.memory</code></td>
   <td>512m</td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -137,14 +137,6 @@ of the most common options to set are:
     or in your default properties file.
   </td>
 </tr>
-  <td><code>spark.executor.frameworkCores</code></td>
-  <td>1</td>
-  <td>
-    Set the amount of cores allocated to the executor itself. This setting is currently used for Mesos fine-grained mode.
-    By default, executor will use the amount of cores even though no task is running on an executor.
-  </td>
-</tr>
-<tr>
 <tr>
   <td><code>spark.executor.memory</code></td>
   <td>512m</td>

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -211,14 +211,6 @@ See the [configuration page](configuration.html) for information on Spark config
   </td>
 </tr>
 <tr>
-  <td><code>spark.mesos.executor.cores</code></td>
-  <td>1</td>
-  <td>
-    Set the amount of cores to request for running a mesos executor. This setting is only used for Mesos fine-grained mode.
-    By default, executor will use the amount of cores even though no task is running on an executor.
-  </td>
-</tr>
-<tr>
   <td><code>spark.mesos.executor.home</code></td>
   <td>driver side <code>SPARK_HOME</code></td>
   <td>

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -214,9 +214,10 @@ See the [configuration page](configuration.html) for information on Spark config
   <td><code>spark.mesos.executor.cores</code></td>
   <td>1.0</td>
   <td>
-    The setting, which can be a floating point number, controls the number of cores allocated
-    to the executor not for use by tasks. By default, executor will use the amount of cores
-    even though no task is running on an executor. This setting is only used for Mesos fine-grained mode.
+    Set the amount of cores, which can be a floating point number, to request for running a mesos executor.
+    The setting controls the number of cores allocated to the executor not for use by tasks. By default,
+    executor will use the amount of cores even though no task is running on an executor. This setting is
+    only used for Mesos fine-grained mode.
   </td>
 </tr>
 <tr>

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -214,8 +214,8 @@ See the [configuration page](configuration.html) for information on Spark config
   <td><code>spark.mesos.executor.cores</code></td>
   <td>1.0</td>
   <td>
-    Set the amount of cores to request for running a mesos executor. This setting is only used for Mesos fine-grained mode.
-    By default, executor will use the amount of cores even though no task is running on an executor.
+    The setting, which can be a floating point number, controls the number of cores allocated
+    to the executor not for use by tasks. This setting is only used for Mesos fine-grained mode.
   </td>
 </tr>
 <tr>

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -211,13 +211,13 @@ See the [configuration page](configuration.html) for information on Spark config
   </td>
 </tr>
 <tr>
-  <td><code>spark.mesos.executor.cores</code></td>
+  <td><code>spark.mesos.mesosExecutor.cores</code></td>
   <td>1.0</td>
   <td>
-    Set the amount of cores, which can be a floating point number, to request for running a Mesos executor.
-    The setting controls the number of cores allocated to the executor not for use by tasks. By default,
-    executor will use the amount of cores even though no task is running on an executor. This setting is
-    only used for Mesos fine-grained mode.
+    (Fine-grained mode only) Number of cores to give each Mesos executor. This does not
+    include the cores used to run the Spark tasks. In other words, even if no Spark task
+    is being run, each Mesos executor will occupy the number of cores configured here.
+    The value can be a floating point number.
   </td>
 </tr>
 <tr>

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -214,7 +214,7 @@ See the [configuration page](configuration.html) for information on Spark config
   <td><code>spark.mesos.executor.cores</code></td>
   <td>1.0</td>
   <td>
-    Set the amount of cores, which can be a floating point number, to request for running a mesos executor.
+    Set the amount of cores, which can be a floating point number, to request for running a Mesos executor.
     The setting controls the number of cores allocated to the executor not for use by tasks. By default,
     executor will use the amount of cores even though no task is running on an executor. This setting is
     only used for Mesos fine-grained mode.

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -215,7 +215,8 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>1.0</td>
   <td>
     The setting, which can be a floating point number, controls the number of cores allocated
-    to the executor not for use by tasks. This setting is only used for Mesos fine-grained mode.
+    to the executor not for use by tasks. By default, executor will use the amount of cores
+    even though no task is running on an executor. This setting is only used for Mesos fine-grained mode.
   </td>
 </tr>
 <tr>

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -212,7 +212,7 @@ See the [configuration page](configuration.html) for information on Spark config
 </tr>
 <tr>
   <td><code>spark.mesos.executor.cores</code></td>
-  <td>1</td>
+  <td>1.0</td>
   <td>
     Set the amount of cores to request for running a mesos executor. This setting is only used for Mesos fine-grained mode.
     By default, executor will use the amount of cores even though no task is running on an executor.

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -211,6 +211,14 @@ See the [configuration page](configuration.html) for information on Spark config
   </td>
 </tr>
 <tr>
+  <td><code>spark.mesos.executor.cores</code></td>
+  <td>1</td>
+  <td>
+    Set the amount of cores to request for running a mesos executor. This setting is only used for Mesos fine-grained mode.
+    By default, executor will use the amount of cores even though no task is running on an executor.
+  </td>
+</tr>
+<tr>
   <td><code>spark.mesos.executor.home</code></td>
   <td>driver side <code>SPARK_HOME</code></td>
   <td>


### PR DESCRIPTION
- Defined executorCores from "spark.mesos.executor.cores"
- Changed the amount of mesosExecutor's cores to executorCores.
- Added new configuration option on running-on-mesos.md
