### PR TITLE
SPARK-6085 Part. 2 Increase default value for memory overhead

### DIFF
--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -224,9 +224,9 @@ See the [configuration page](configuration.html) for information on Spark config
   <td><code>spark.mesos.executor.memoryOverhead</code></td>
   <td>executor memory * 0.10, with minimum of 384</td>
   <td>
-    This value is an additive for <code>spark.executor.memory</code>, specified in MiB,
+    This value is an additive for <code>spark.executor.memory</code>, specified in MB,
     which is used to calculate the total Mesos task memory. A value of <code>384</code>
-    implies a 384MiB overhead. Additionally, there is a hard-coded 10% minimum
+    implies a 384MB overhead. Additionally, there is a hard-coded 10% minimum
     overhead. The final overhead will be the larger of either
     `spark.mesos.executor.memoryOverhead` or 10% of `spark.executor.memory`.
   </td>

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -226,9 +226,9 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>
     This value is an additive for <code>spark.executor.memory</code>, specified in MiB,
     which is used to calculate the total Mesos task memory. A value of <code>384</code>
-    implies a 384MiB overhead. Additionally, there is a hard-coded 7% minimum
+    implies a 384MiB overhead. Additionally, there is a hard-coded 10% minimum
     overhead. The final overhead will be the larger of either
-    `spark.mesos.executor.memoryOverhead` or 7% of `spark.executor.memory`.
+    `spark.mesos.executor.memoryOverhead` or 10% of `spark.executor.memory`.
   </td>
 </tr>
 </table>


### PR DESCRIPTION
- fixed a description of spark.mesos.executor.memoryOverhead from 7% to 10%
- This is a second part of SPARK-6085
