### PR TITLE
Spark 6359 expose imain binding

### DIFF
--- a/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -314,7 +314,16 @@ class SparkILoop(
   private var currentPrompt = Properties.shellPromptString
 
   /**
+   * Bind a specified name to a specified value in the Interpreter.  The name may
+   * later be used by expressions passed to interpret.
    *
+   * @note This binds via compilation and interpretation
+   *
+   * @param name The variable name to bind
+   * @param x The object value to bind to it
+   *
+   * @return An indication of whether the binding succeeded or failed
+   *         using interpreter results
    */
   @DeveloperApi
   def bindValue(name: String, x: Any): IR.Result = {
@@ -322,10 +331,12 @@ class SparkILoop(
   }
 
   /**
-   *
+    * URI of the class server used to feed REPL compiled classes in the underlying IMain.
+    *
+    * @return The string representing the class server uri
    */
   @DeveloperApi
-  def classServerUri = intp.classServerUri
+  def classServerUri: String = intp.classServerUri
 
   /**
    * Sets the prompt string used by the REPL.

--- a/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -252,7 +252,7 @@ class SparkILoop(
       case xs       => xs find (_.name == cmd)
     }
   }
-  private var fallbackMode = false 
+  private var fallbackMode = false
 
   private def toggleFallbackMode() {
     val old = fallbackMode
@@ -260,9 +260,9 @@ class SparkILoop(
     System.setProperty("spark.repl.fallback", fallbackMode.toString)
     echo(s"""
       |Switched ${if (old) "off" else "on"} fallback mode without restarting.
-      |       If you have defined classes in the repl, it would 
+      |       If you have defined classes in the repl, it would
       |be good to redefine them incase you plan to use them. If you still run
-      |into issues it would be good to restart the repl and turn on `:fallback` 
+      |into issues it would be good to restart the repl and turn on `:fallback`
       |mode as first command.
       """.stripMargin)
   }
@@ -314,6 +314,20 @@ class SparkILoop(
   private var currentPrompt = Properties.shellPromptString
 
   /**
+   *
+   */
+  @DeveloperApi
+  def bindValue(name: String, x: Any): IR.Result = {
+    intp.bindValue(name, x)
+  }
+
+  /**
+   *
+   */
+  @DeveloperApi
+  def classServerUri = intp.classServerUri
+
+  /**
    * Sets the prompt string used by the REPL.
    *
    * @param prompt The new prompt string
@@ -349,7 +363,7 @@ class SparkILoop(
     shCommand,
     nullary("silent", "disable/enable automatic printing of results", verbosity),
     nullary("fallback", """
-                           |disable/enable advanced repl changes, these fix some issues but may introduce others. 
+                           |disable/enable advanced repl changes, these fix some issues but may introduce others.
                            |This mode will be removed once these fixes stablize""".stripMargin, toggleFallbackMode),
     cmd("type", "[-v] <expr>", "display the type of an expression without evaluating it", typeCommand),
     nullary("warnings", "show the suppressed warnings from the most recent line which had any", warningsCommand)
@@ -1024,7 +1038,7 @@ class SparkILoop(
     val loader = Utils.getContextOrSparkClassLoader
     try {
       sqlContext = loader.loadClass(name).getConstructor(classOf[SparkContext])
-        .newInstance(sparkContext).asInstanceOf[SQLContext] 
+        .newInstance(sparkContext).asInstanceOf[SQLContext]
       logInfo("Created sql context (with Hive support)..")
     }
     catch {

--- a/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkIMain.scala
+++ b/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkIMain.scala
@@ -970,7 +970,7 @@ import org.apache.spark.annotation.DeveloperApi
   private def bind[T: ru.TypeTag : ClassTag](name: String, value: T): IR.Result = bind((name, value))
   private def bindSyntheticValue(x: Any): IR.Result                             = bindValue(freshInternalVarName(), x)
   private def bindValue(x: Any): IR.Result                                      = bindValue(freshUserVarName(), x)
-  private def bindValue(name: String, x: Any): IR.Result                        = bind(name, TypeStrings.fromValue(x), x)
+  private[repl] def bindValue(name: String, x: Any): IR.Result                        = bind(name, TypeStrings.fromValue(x), x)
 
   /**
    * Reset this interpreter, forgetting all user-specified requests.

--- a/repl/scala-2.10/src/test/scala/org/apache/spark/repl/ReplSuite.scala
+++ b/repl/scala-2.10/src/test/scala/org/apache/spark/repl/ReplSuite.scala
@@ -105,6 +105,39 @@ class ReplSuite extends FunSuite {
     System.clearProperty("spark.driver.port")
   }
 
+  test("publicly exposed bindValue and classServerUri") {
+    // A mock ILoop that doesn't install the SIGINT handler.
+    class ILoop(out: PrintWriter) extends SparkILoop(None, out, None) {
+      settings = new scala.tools.nsc.Settings
+      settings.usejavacp.value = true
+      org.apache.spark.repl.Main.interp = this
+      override def createInterpreter() {
+        intp = new SparkILoopInterpreter
+        intp.setContextClassLoader()
+      }
+    }
+
+    val out = new StringWriter()
+    val interp = new ILoop(new PrintWriter(out))
+    interp.sparkContext = new SparkContext("local", "repl-test")
+    interp.createInterpreter()
+    interp.intp.initialize()
+    interp.bindValue("someKey", 1)
+
+    // Make sure the value we set in the caller to interpret is propagated in the thread that
+    // interprets the command.
+    interp.interpret("someKey")
+    assertDoesNotContain("error:", out.toString)
+    assertDoesNotContain("Exception", out.toString)
+    assert(out.toString.contains("res0: Int = 1"))
+    val csu = interp.classServerUri
+    assertDoesNotContain("error:",csu)
+    assertDoesNotContain("Exception",csu)
+    assertContains("http://",csu)
+    interp.sparkContext.stop()
+    System.clearProperty("spark.driver.port")
+  }
+
   test("simple foreach with accumulator") {
     val output = runInterpreter("local",
       """

--- a/repl/scala-2.11/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -234,6 +234,20 @@ class SparkILoop(in0: Option[BufferedReader], protected val out: JPrintWriter)
   /** Prompt to print when awaiting input */
   def prompt = currentPrompt
 
+  /**
+   *
+   */
+  @DeveloperApi
+  def bind(name: String, x: Any): IR.Result = {
+    intp.bind((name, x))
+  }
+
+  /**
+   *
+   */
+  @DeveloperApi
+  def classServerUri = intp.classServerUri
+
   import LoopCommand.{ cmd, nullary }
 
   /** Standard commands **/


### PR DESCRIPTION
As per the associated JIRA ticket: in 1.2, some projects (e.g. Apache Zeppelin) rely on the ILoop exposing its IMain object for the purpose of binding UI variables to the underlying repl. The privatization of these methods in 1.3.0 breaks projects which rely on this.  This PR exposes the two methods Zeppelin relies on (bindValue and classServerUri).
