### PR TITLE
[SPARK-6356][SQL] Support the ROLLUP/CUBE/GROUPING SETS in SQLContext

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -91,6 +91,103 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll {
       Row(1, 1) :: Nil)
   }
 
+  test("SPARK-6356 ROLLUP") {
+    val expectedResult =
+      Row(null, null, 50) ::
+      Row(null, "Math", 50) ::
+      Row(null, null, 210) ::
+      Row("Jim", null, 60) ::
+      Row("Jim", null, 60) ::
+      Row("Phoebe", null, 70) ::
+      Row("Phoebe", "English", 40) ::
+      Row("Phoebe", "Math", 30) ::
+      Row("Tom", null, 30) ::
+      Row("Tom", "English", 20) ::
+      Row("Tom", "Math", 10) :: Nil
+
+    // GROUP BY expression list WITH ROLLUP
+    checkAnswer(
+      sql("SELECT name, course, sum(score) FROM students GROUP BY name, course WITH ROLLUP"),
+      expectedResult
+    )
+  }
+
+  test("SPARK-6356 CUBE") {
+    val expectedResult =
+      Row(null, "English", 60) ::
+      Row(null, null, 50) ::
+      Row(null, "Math", 50) ::
+      Row(null, null, 60) ::
+      Row(null, "Math", 90) ::
+      Row(null, null, 210) ::
+      Row("Jim", null, 60) ::
+      Row("Jim", null, 60) ::
+      Row("Phoebe", null, 70) ::
+      Row("Phoebe", "English", 40) ::
+      Row("Phoebe", "Math", 30) ::
+      Row("Tom", null, 30) ::
+      Row("Tom", "English", 20) ::
+      Row("Tom", "Math", 10) :: Nil
+
+    // GROUP BY expression list WITH CUBE
+    checkAnswer(
+      sql("SELECT name, course, sum(score) FROM students GROUP BY name, course WITH CUBE"),
+      expectedResult
+    )
+  }
+
+  test("SPARK-6356 GROUPING SETS") {
+    val expectedResult1 =
+      Row(null, 50) ::
+      Row("Jim", 60) ::
+      Row("Phoebe", 70) ::
+      Row("Tom", 30) :: Nil
+
+    val expectedResult2 =
+      Row(null, "Math", 50) ::
+      Row("Jim", null, 60) ::
+      Row("Phoebe", "Math", 30) ::
+      Row("Phoebe", "English", 40) ::
+      Row("Tom", "Math", 10) ::
+      Row("Tom", "English", 20) :: Nil
+
+    val expectedResult3 =
+      Row(null, null, 50) ::
+      Row(null, "Math", 50) ::
+      Row("Jim", null, 60) ::
+      Row("Jim", null, 60) ::
+      Row("Phoebe", null, 70) ::
+      Row("Phoebe", "Math", 30) ::
+      Row("Phoebe", "English", 40) ::
+      Row("Tom", null, 30) ::
+      Row("Tom", "Math", 10) ::
+      Row("Tom", "English", 20) :: Nil
+
+    // GROUP BY expression list GROUPING SETS(expression list2)
+    checkAnswer(
+      sql("SELECT name, course, sum(score) FROM students GROUP BY name, course " +
+        "GROUPING SETS(())"),
+      Row(null, null, 210) :: Nil
+    )
+
+    checkAnswer(
+      sql("SELECT name, sum(score) FROM students GROUP BY name GROUPING SETS(name)"),
+      expectedResult1
+    )
+
+    checkAnswer(
+      sql("SELECT name, course, sum(score) FROM students GROUP BY name, course " +
+        "GROUPING SETS(name, course)"),
+      expectedResult2
+    )
+
+    checkAnswer(
+      sql("SELECT name, course, sum(score) FROM students GROUP BY name, course " +
+        "GROUPING SETS(name, (name, course))"),
+      expectedResult3
+    )
+  }
+
   test("SPARK-3176 Added Parser of SQL ABS()") {
     checkAnswer(
       sql("SELECT ABS(-1.3)"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/TestData.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TestData.scala
@@ -206,4 +206,14 @@ object TestData {
         :: ComplexData(Map(2 -> "2"), TestData(2, "2"), Seq(2), false)
         :: Nil).toDF()
   complexData.registerTempTable("complexData")
+
+  case class Student(name: String, course: String, score: Int)
+  val students = TestSQLContext.sparkContext.parallelize(
+    Student("Tom", "Math", 10) ::
+    Student("Tom", "English", 20) ::
+    Student("Phoebe", "Math", 30) ::
+    Student("Phoebe", "English", 40) ::
+    Student(null, "Math", 50) ::
+    Student("Jim", null, 60) :: Nil).toDF()
+  students.registerTempTable("students")
 }


### PR DESCRIPTION
Support for the syntax(also supported by HiveContext) below:

```
GROUP BY expression list WITH ROLLUP
GROUP BY expression list WITH CUBE
GROUP BY expression list GROUPING SETS(expression list2)
```

https://github.com/apache/spark/pull/5045

/cc @yhuai
