### PR TITLE
[SPARK-5387] [SQL] parquet writer runs into OOM during writing when number of rows is large

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/parquet/newParquet.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/parquet/newParquet.scala
@@ -619,22 +619,27 @@ private[sql] case class ParquetRelation2(
 
     def writeShard(context: TaskContext, iterator: Iterator[Row]): Unit = {
       /* "reduce task" <split #> <attempt # = spark task #> */
-      val attemptId = newTaskAttemptID(
-        jobTrackerId, stageId, isMap = false, context.partitionId(), context.attemptNumber())
-      val hadoopContext = newTaskAttemptContext(wrappedConf.value, attemptId)
-      val format = new AppendingParquetOutputFormat(taskIdOffset)
-      val committer = format.getOutputCommitter(hadoopContext)
-      committer.setupTask(hadoopContext)
-      val writer = format.getRecordWriter(hadoopContext)
       try {
-        while (iterator.hasNext) {
-          val row = iterator.next()
-          writer.write(null, row)
+        val attemptId = newTaskAttemptID(
+          jobTrackerId, stageId, isMap = false, context.partitionId(), context.attemptNumber())
+        val hadoopContext = newTaskAttemptContext(wrappedConf.value, attemptId)
+        val format = new AppendingParquetOutputFormat(taskIdOffset)
+        val committer = format.getOutputCommitter(hadoopContext)
+        committer.setupTask(hadoopContext)
+        val writer = format.getRecordWriter(hadoopContext)
+        try {
+          while (iterator.hasNext) {
+            val row = iterator.next()
+            writer.write(null, row)
+          }
+        } finally {
+          writer.close(hadoopContext)
         }
-      } finally {
-        writer.close(hadoopContext)
+        committer.commitTask(hadoopContext)
+      } catch {
+        case e: Throwable =>
+          logError(e.getMessage, e)
       }
-      committer.commitTask(hadoopContext)
     }
     val jobFormat = new AppendingParquetOutputFormat(taskIdOffset)
     /* apparently we need a TaskAttemptID to construct an OutputCommitter;


### PR DESCRIPTION
In some extreme cases, e.g. one row has thousands of columns, this line of code "val writter = format.getRecordWriter(hadoopContext)" will throw OOM exception by parquet and lead to shutdown of Spark application. Adding "try {...} catch {...}" can prevent that issue.

I'm developing a data processing system based on Spark SQL. There are some very special table which is derived from json file. Every row of those table has thousands columns. If I want to save DataFrame(or SchemaRDD) generated by `SQLContext.jsonFile` as parquet file, OOM exception will be thrown by parquet-mr and Spark application will be shutdown. To handle that fatal exception, `try {...} catch {...}` the code in function writeShard is needed.
