### PR TITLE
[SPARK-6422][STREAMING] support customized actor system for actor-based receiver

### DIFF
--- a/docs/streaming-custom-receivers.md
+++ b/docs/streaming-custom-receivers.md
@@ -279,5 +279,9 @@ And a new input stream can be created with this custom actor as
 val lines = ssc.actorStream[String](Props(new CustomActor()), "CustomReceiver")
 {% endhighlight %}
 
+Since Spark 1.4, Spark Streaming supports to start a customized Actor System for Actor-based receiver.
+You can configure the customized Actor System by passing the Akka configuration entries to SparkConf 
+or through spark-submit script, with a prefix "spark.streaming.receiver.".
+
 See [ActorWordCount.scala](https://github.com/apache/spark/blob/master/examples/src/main/scala/org/apache/spark/examples/streaming/ActorWordCount.scala)
 for an end-to-end example.

--- a/examples/src/main/scala/org/apache/spark/examples/streaming/ActorWordCount.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/streaming/ActorWordCount.scala
@@ -146,6 +146,9 @@ object ActorWordCount {
 
     val Seq(host, port) = args.toSeq
     val sparkConf = new SparkConf().setAppName("ActorWordCount")
+    // start a customized actor system for receiver
+    sparkConf.set("spark.streaming.receiver.akka.remote.transport-failure-detector." +
+      "heartbeat-interval", "1 s")
     // Create the context and set the batch size
     val ssc = new StreamingContext(sparkConf, Seconds(2))
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -275,8 +275,12 @@ class StreamingContext private[streaming] (
       }.toMap[String, String].map{case (key, value) => (key.substring(25), value)}
 
     val actorReceiver = new ActorReceiver[T](props, name, storageLevel, supervisorStrategy)
-    actorReceiver.actorReceiverConf = ConfigFactory.parseMap(getAkkaReceiverConf).withFallback(
-      SparkEnv.get.actorSystem.settings.config)
+
+    val akkaReceiverConf = getAkkaReceiverConf
+    if (!akkaReceiverConf.isEmpty) {
+      actorReceiver.actorReceiverConf = ConfigFactory.parseMap(akkaReceiverConf).withFallback(
+        SparkEnv.get.actorSystem.settings.config)
+    }
     receiverStream(actorReceiver)
   }
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -25,6 +25,7 @@ import scala.collection.mutable.Queue
 import scala.reflect.ClassTag
 
 import akka.actor.{Props, SupervisorStrategy}
+import com.typesafe.config.ConfigFactory
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.{BytesWritable, LongWritable, Text}
@@ -265,7 +266,18 @@ class StreamingContext private[streaming] (
       storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK_SER_2,
       supervisorStrategy: SupervisorStrategy = ActorSupervisorStrategy.defaultStrategy
     ): ReceiverInputDStream[T] = {
-    receiverStream(new ActorReceiver[T](props, name, storageLevel, supervisorStrategy))
+
+    import scala.collection.JavaConversions.mapAsJavaMap
+
+    def getAkkaReceiverConf: Map[String, String] =
+      sparkContext.conf.getAll.filter {
+        case (k, _) => k.startsWith("spark.streaming.receiver.akka.")
+      }.toMap[String, String].map{case (key, value) => (key.substring(25), value)}
+
+    val actorReceiver = new ActorReceiver[T](props, name, storageLevel, supervisorStrategy)
+    actorReceiver.actorReceiverConf = ConfigFactory.parseMap(getAkkaReceiverConf).withFallback(
+      SparkEnv.get.actorSystem.settings.config)
+    receiverStream(actorReceiver)
   }
 
   /**

--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/ActorReceiver.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/ActorReceiver.scala
@@ -19,14 +19,13 @@ package org.apache.spark.streaming.receiver
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import com.typesafe.config.Config
-
 import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.reflect.ClassTag
 
 import akka.actor._
 import akka.actor.SupervisorStrategy.{Escalate, Restart}
+import com.typesafe.config.Config
 import org.apache.spark.{Logging, SparkEnv}
 import org.apache.spark.storage.StorageLevel
 import java.nio.ByteBuffer


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-6422

To disable the Akka's fault detection system, we currently set large default values for Akka' transport failure detector threshold and heartbeat interval, and discourage users to customize these values..
Meanwhile, we are trying to eliminate the dependency to Akka, e.g. we are trying to implement a general RPC interface (https://github.com/apache/spark/pull/4588), etc.

Based on the above facts, enabling a customized Akka system for actor-based receiver has at least two benefits: 
1.  users can easily set values related to failure detector which are more practical in general Akka usage scenario; 
2. reduce the dependency level to Akka, (in future, we can even move Actor-based receiver to external project)

This patch proposes to enable the user to be able to configure  the customized Akka system by passing `spark.streaming.receiver.akka.*` parameters...if these parameters do not exist, then we fall back to the Spark's Actor System 
