### PR TITLE
[SPARK-5961][Streaming]Allow specific nodes in a Spark Streaming cluster to be preferred as Receiver Worker Nodes

### DIFF
--- a/external/flume/src/main/scala/org/apache/spark/streaming/flume/FlumeInputDStream.scala
+++ b/external/flume/src/main/scala/org/apache/spark/streaming/flume/FlumeInputDStream.scala
@@ -44,12 +44,14 @@ import org.jboss.netty.handler.codec.compression._
 
 private[streaming]
 class FlumeInputDStream[T: ClassTag](
-  @transient ssc_ : StreamingContext,
-  host: String,
-  port: Int,
-  storageLevel: StorageLevel,
-  enableDecompression: Boolean
-) extends ReceiverInputDStream[SparkFlumeEvent](ssc_) {
+    @transient ssc_ : StreamingContext,
+    host: String,
+    port: Int,
+    storageLevel: StorageLevel,
+    enableDecompression: Boolean
+  ) extends ReceiverInputDStream[SparkFlumeEvent](ssc_) {
+
+  super.setPreferredLocation(Some(host));
 
   override def getReceiver(): Receiver[SparkFlumeEvent] = {
     new FlumeReceiver(host, port, storageLevel, enableDecompression)
@@ -63,7 +65,7 @@ class FlumeInputDStream[T: ClassTag](
  * which are not serializable.
  */
 class SparkFlumeEvent() extends Externalizable {
-  var event : AvroFlumeEvent = new AvroFlumeEvent()
+  var event: AvroFlumeEvent = new AvroFlumeEvent()
 
   /* De-serialize from bytes. */
   def readExternal(in: ObjectInput): Unit = Utils.tryOrIOException {
@@ -186,8 +188,6 @@ class FlumeReceiver(
     }
     logInfo("Flume receiver stopped")
   }
-
-  override def preferredLocation = Some(host)
   
   /** A Netty Pipeline factory that will decompress incoming data from 
     * and the Netty client and compress data going back to the client.
@@ -205,6 +205,6 @@ class FlumeReceiver(
       pipeline.addFirst("deflater", encoder)
       pipeline.addFirst("inflater", new ZlibDecoder())
       pipeline
+    }
   }
-}
 }

--- a/external/flume/src/main/scala/org/apache/spark/streaming/flume/FlumeInputDStream.scala
+++ b/external/flume/src/main/scala/org/apache/spark/streaming/flume/FlumeInputDStream.scala
@@ -51,7 +51,7 @@ class FlumeInputDStream[T: ClassTag](
     enableDecompression: Boolean
   ) extends ReceiverInputDStream[SparkFlumeEvent](ssc_) {
 
-  super.setPreferredLocation(Some(host));
+  super.setPreferredLocation(host)
 
   override def getReceiver(): Receiver[SparkFlumeEvent] = {
     new FlumeReceiver(host, port, storageLevel, enableDecompression)

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/ReceiverInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/ReceiverInputDStream.scala
@@ -39,6 +39,7 @@ import org.apache.spark.streaming.scheduler.ReceivedBlockInfo
 abstract class ReceiverInputDStream[T: ClassTag](@transient ssc_ : StreamingContext)
   extends InputDStream[T](ssc_) {
 
+  private[streaming] var _preferredLocation: Option[String] = None
   /** This is an unique identifier for the receiver input stream. */
   val id = ssc.getNewReceiverStreamId()
 
@@ -53,6 +54,14 @@ abstract class ReceiverInputDStream[T: ClassTag](@transient ssc_ : StreamingCont
   def start() {}
 
   def stop() {}
+
+  def setPreferredLocation(_preferredLocation: String){
+    if (null != _preferredLocation){
+      this._preferredLocation = Some(_preferredLocation)
+    }
+  }
+
+  def preferredLocation = _preferredLocation
 
   /**
    * Generates RDDs with blocks received by the receiver of this stream. */

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/ReceiverInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/ReceiverInputDStream.scala
@@ -55,10 +55,8 @@ abstract class ReceiverInputDStream[T: ClassTag](@transient ssc_ : StreamingCont
 
   def stop() {}
 
-  def setPreferredLocation(_preferredLocation: String){
-    if (null != _preferredLocation){
-      this._preferredLocation = Some(_preferredLocation)
-    }
+  def setPreferredLocation(_preferredLocation: String) {
+    this._preferredLocation = Option(_preferredLocation)
   }
 
   def preferredLocation = _preferredLocation

--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/Receiver.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/Receiver.scala
@@ -107,9 +107,6 @@ abstract class Receiver[T](val storageLevel: StorageLevel) extends Serializable 
    */
   def onStop()
 
-  /** Override this to specify a preferred location (hostname). */
-  def preferredLocation : Option[String] = None
-
   /**
    * Store a single item of received data to Spark's memory.
    * These single items will be aggregated together into data blocks before


### PR DESCRIPTION
1.The function ’setPreferredLocation‘ is in  class ReceiverInputDStream.
2.FlumeInputDStream take data send node as the defalut PreferredLocation
