### PR TITLE
[SPARK-6440][CORE]Handle IPv6 addresses properly when constructing URI

### DIFF
--- a/core/src/main/scala/org/apache/spark/HttpServer.scala
+++ b/core/src/main/scala/org/apache/spark/HttpServer.scala
@@ -18,6 +18,9 @@
 package org.apache.spark
 
 import java.io.File
+import java.net.InetAddress
+
+import com.google.common.net.InetAddresses
 
 import org.eclipse.jetty.server.ssl.SslSocketConnector
 import org.eclipse.jetty.util.security.{Constraint, Password}
@@ -160,7 +163,8 @@ private[spark] class HttpServer(
       throw new ServerStateException("Server is not started")
     } else {
       val scheme = if (securityManager.fileServerSSLOptions.enabled) "https" else "http"
-      s"$scheme://${Utils.localIpAddress}:$port"
+      val hostUri = InetAddresses.toUriString(InetAddress.getByName(Utils.localIpAddress))
+      s"$scheme://${hostUri}:$port"
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/deploy/LocalSparkCluster.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/LocalSparkCluster.scala
@@ -17,9 +17,12 @@
 
 package org.apache.spark.deploy
 
+import java.net.InetAddress
+
 import scala.collection.mutable.ArrayBuffer
 
 import akka.actor.ActorSystem
+import com.google.common.net.InetAddresses
 
 import org.apache.spark.{Logging, SparkConf}
 import org.apache.spark.deploy.worker.Worker
@@ -53,7 +56,8 @@ class LocalSparkCluster(
     /* Start the Master */
     val (masterSystem, masterPort, _, _) = Master.startSystemAndActor(localHostname, 0, 0, _conf)
     masterActorSystems += masterSystem
-    val masterUrl = "spark://" + localHostname + ":" + masterPort
+    val hostUri = InetAddresses.toUriString(InetAddress.getByName(localHostname))
+    val masterUrl = "spark://" + hostUri + ":" + masterPort
     val masters = Array(masterUrl)
 
     /* Start the Workers */


### PR DESCRIPTION
The toUriString() method in guava takes care of properly formatting IPv4 and v6 addresses to a URI
