### PR TITLE
[SPARK-1301] add navigation links to StagePage for 3 tables

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/webui.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/webui.css
@@ -194,6 +194,24 @@ span.additional-metric-title {
   color: #777;
 }
 
+#additional-metrics {
+  float: left;
+  padding-bottom: 10px;
+}
+
+#links {
+  float: left;
+  padding-left: 100px;
+}
+
+#links a {
+  padding-left: 10px;
+}
+
+.clear {
+  clear: both;
+}
+
 /* Hide all additional metrics by default. This is done here rather than using JavaScript to
  * avoid slow page loads for stage pages with large numbers (e.g., thousands) of tasks. */
 .scheduler_delay, .deserialization_time, .fetch_wait_time, .shuffle_read_remote,

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -110,7 +110,7 @@ private[ui] class StagePage(parent: StagesTab) extends WebUIPage("stage") {
         </div>
 
       val showAdditionalMetrics =
-        <div>
+        <div id="additional-metrics">
           <span class="expand-additional-metrics">
             <span class="expand-additional-metrics-arrow arrow-closed"></span>
             <strong>Show additional metrics</strong>
@@ -168,6 +168,16 @@ private[ui] class StagePage(parent: StagesTab) extends WebUIPage("stage") {
             </ul>
           </div>
         </div>
+
+      val quickLinks: Seq[Elem] =
+        (Some(<a href="#executors">Executors</a>) ::
+          (if (accumulables.nonEmpty)
+            Some(<a href="#accumulators">Accumulators</a>)
+          else
+            None) ::
+          Some(<a href="#tasks">Tasks</a>) :: Nil).flatten
+
+      val showQuickLinks = <div id="links">Jump to: {quickLinks}</div>
 
       val accumulableHeaders: Seq[String] = Seq("Accumulable", "Value")
       def accumulableRow(acc: AccumulableInfo) = <tr><td>{acc.name}</td><td>{acc.value}</td></tr>
@@ -431,16 +441,17 @@ private[ui] class StagePage(parent: StagesTab) extends WebUIPage("stage") {
       val executorTable = new ExecutorTable(stageId, stageAttemptId, parent)
 
       val maybeAccumulableTable: Seq[Node] =
-        if (accumulables.size > 0) { <h4>Accumulators</h4> ++ accumulableTable } else Seq()
+        if (accumulables.size > 0) { <h4 id="accumulators">Accumulators</h4> ++ accumulableTable } else Seq()
 
       val content =
         summary ++
         showAdditionalMetrics ++
-        <h4>Summary Metrics for {numCompleted} Completed Tasks</h4> ++
+        showQuickLinks ++
+        <h4 class="clear">Summary Metrics for {numCompleted} Completed Tasks</h4> ++
         <div>{summaryTable.getOrElse("No tasks have reported metrics yet.")}</div> ++
-        <h4>Aggregated Metrics by Executor</h4> ++ executorTable.toNodeSeq ++
+        <h4 id="executors">Aggregated Metrics by Executor</h4> ++ executorTable.toNodeSeq ++
         maybeAccumulableTable ++
-        <h4>Tasks</h4> ++ taskTable
+        <h4 id="tasks">Tasks</h4> ++ taskTable
 
       UIUtils.headerSparkPage("Details for Stage %d".format(stageId), content, parent)
     }

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -20,7 +20,7 @@ package org.apache.spark.ui.jobs
 import java.util.Date
 import javax.servlet.http.HttpServletRequest
 
-import scala.xml.{Node, Unparsed}
+import scala.xml.{Elem, Node, Unparsed}
 
 import org.apache.commons.lang3.StringEscapeUtils
 
@@ -171,10 +171,11 @@ private[ui] class StagePage(parent: StagesTab) extends WebUIPage("stage") {
 
       val quickLinks: Seq[Elem] =
         (Some(<a href="#executors">Executors</a>) ::
-          (if (accumulables.nonEmpty)
+          (if (accumulables.nonEmpty) {
             Some(<a href="#accumulators">Accumulators</a>)
-          else
-            None) ::
+          } else {
+            None
+          }) ::
           Some(<a href="#tasks">Tasks</a>) :: Nil).flatten
 
       val showQuickLinks = <div id="links">Jump to: {quickLinks}</div>
@@ -441,7 +442,11 @@ private[ui] class StagePage(parent: StagesTab) extends WebUIPage("stage") {
       val executorTable = new ExecutorTable(stageId, stageAttemptId, parent)
 
       val maybeAccumulableTable: Seq[Node] =
-        if (accumulables.size > 0) { <h4 id="accumulators">Accumulators</h4> ++ accumulableTable } else Seq()
+        if (accumulables.size > 0) {
+          <h4 id="accumulators">Accumulators</h4> ++ accumulableTable
+        } else {
+          Seq()
+        }
 
       val content =
         summary ++


### PR DESCRIPTION
Executors table, accumulators table, tasks table.

If there are no accumulators then that link is not displayed.

Here are some screenshots of their appearance:

![](https://s3.amazonaws.com/f.cl.ly/items/1v0q2e3Q2L2o0C1G3R2D/Screen%20Shot%202015-03-21%20at%206.13.50%20PM.png)

With "Show additional metrics" expanded:
![](https://s3.amazonaws.com/f.cl.ly/items/1W2X3I2O0Z0u2E0U0Z3L/Screen%20Shot%202015-03-21%20at%206.13.59%20PM.png)

Without "Accumulators" link:
![](https://s3.amazonaws.com/f.cl.ly/items/3u0k0g1f2l443n1l1l1n/Screen%20Shot%202015-03-21%20at%206.14.09%20PM.png)
