### PR TITLE
[SPARK-6444] [SQL] A quick fix for SPARK-6444

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
@@ -69,8 +69,8 @@ trait HiveTypeCoercion {
   val typeCoercionRules =
     PropagateTypes ::
     ConvertNaNs ::
-    WidenTypes ::
     PromoteStrings ::
+    WidenTypes ::
     DecimalPrecision ::
     BooleanComparisons ::
     BooleanCasts ::


### PR DESCRIPTION
As explained in the JIRA ticket [comment](https://issues.apache.org/jira/browse/SPARK-6444?focusedCommentId=14374838&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14374838), this PR introduces a simple quick fix for SPARK-6444. The root cause of this issue is that we don't check data types of input arguments for SQL functions. PR #4685 is heading the right direction. The reason why moving `PromoteStrings` before `WidenTypes` fixes this issue is that, `PromoteStrings` helps `Sum` to check and convert the data type of its argument.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/apache/spark/5127)

<!-- Reviewable:end -->
