### PR TITLE
[SPARK-6464][Core]Add a function named 'processCoalesce' in RDD to support partition combination

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/ProcessCoalesceRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ProcessCoalesceRDD.scala
@@ -29,7 +29,7 @@ import scala.reflect.ClassTag
  * An RDD which can combine small cached partition in the same executor
  * into only one partition to reduce the use of cpu resource.
  */
-class ProcessCoalesceRDD [T: ClassTag](@transient var prev: RDD[T])
+private[spark] class ProcessCoalesceRDD [T: ClassTag](@transient var prev: RDD[T])
   extends RDD[T](prev.context, Nil) {
   // Nil since we implement getDependencies
 
@@ -92,7 +92,7 @@ class ProcessCoalesceRDD [T: ClassTag](@transient var prev: RDD[T])
 /**
  * A location where a task should run. This can either be a host or a (host, executorID) pair.
  */
-case class ProcessCoalescePartition(
+private[spark] case class ProcessCoalescePartition(
     index: Int,
     @transient rdd: RDD[_],
     parentsIndices: Array[Int],

--- a/core/src/main/scala/org/apache/spark/rdd/ProcessCoalesceRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ProcessCoalesceRDD.scala
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.rdd
+
+import java.io.ObjectOutputStream
+import java.net.InetAddress
+
+import org.apache.spark.{NarrowDependency, Dependency, TaskContext, Partition}
+import org.apache.spark.scheduler.{ExecutorCacheTaskLocation, HostTaskLocation}
+
+import scala.reflect.ClassTag
+
+/**
+ * An RDD which can combine small cached partition in the same executor
+ * into only one partition to reduce the use of cpu resource.
+ */
+class ProcessCoalesceRDD [T: ClassTag](@transient var prev: RDD[T])
+  extends RDD[T](prev.context, Nil) {
+  // Nil since we implement getDependencies
+
+  override def getPartitions: Array[Partition] = {
+    //TODO: check boundary
+    val parentLocs = prev.partitions.map(p =>
+      (p.index, prev.sparkContext.getPreferredLocs(prev, p.index)(0)))
+
+    val parentLocHostMap = parentLocs.map { place =>
+      place._2 match {
+        case location: HostTaskLocation =>
+          (place._1, InetAddress.getByName(location.host).getHostName)
+        case location: ExecutorCacheTaskLocation =>
+          (place._1, "Executor_" + location.host + "_" + location.executorId)
+      }
+    }.toMap
+
+    val localtionList: Iterable[Array[Int]] = parentLocs.groupBy(pp =>
+      pp._2.toString()).map(_._2.map(_._1))
+    val result = localtionList.zipWithIndex.map {
+      case (parentParts, i) => new ProcessCoalescePartition(i, prev,
+        parentParts, parentLocHostMap(parentParts(0)))
+    }.toArray
+    logDebug(s"ProcessCoalesceRDD.getPartitions=${result.toList}")
+    result.asInstanceOf[Array[Partition]]
+  }
+
+  override def compute(partition: Partition, context: TaskContext): Iterator[T] = {
+    partition.asInstanceOf[ProcessCoalescePartition].parents.iterator.flatMap {
+      parentPartition =>
+        firstParent[T].iterator(parentPartition, context)
+    }
+  }
+
+  override def getDependencies: Seq[Dependency[_]] = {
+    Seq(new NarrowDependency(prev) {
+      def getParents(id: Int): Seq[Int] =
+        partitions(id).asInstanceOf[ProcessCoalescePartition].parentsIndices
+    })
+  }
+
+  override def clearDependencies() {
+    super.clearDependencies()
+    prev = null
+  }
+
+  /**
+   * Returns the preferred machine and the specific executor for the partition.
+   * @param partition
+   * @return the executor most preferred by split
+   */
+  override def getPreferredLocations(partition: Partition): Seq[String] = {
+    val loc = partition.asInstanceOf[ProcessCoalescePartition].preferredLocation
+    logDebug(s"ProcessCoalesceRDD.getPreferredLocations called for" +
+      s" ${partition.index}, ret=$loc")
+    List(loc)
+  }
+}
+
+/**
+ * A location where a task should run. This can either be a host or a (host, executorID) pair.
+ */
+case class ProcessCoalescePartition(
+    index: Int,
+    @transient rdd: RDD[_],
+    parentsIndices: Array[Int],
+    @transient preferredLocation: String = ""
+    ) extends Partition {
+  var parents: Seq[Partition] = parentsIndices.map(rdd.partitions(_))
+
+  private def writeObject(oos: ObjectOutputStream): Unit = {
+    // Update the reference to parent partition at the time of task serialization
+    parents = parentsIndices.map(rdd.partitions(_))
+    oos.defaultWriteObject()
+  }
+
+  override def toString = "ProcessCoalescePartition"  +
+    s"($index, ${parentsIndices.toList}, $preferredLocation)"
+}

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -371,14 +371,13 @@ abstract class RDD[T: ClassTag](
         new HashPartitioner(numPartitions)),
         numPartitions).values
     } else {
-      new CoalescedRDD(this, numPartitions)
+      if (conf.getBoolean("spark.rdd.coalesce.process", false)) {
+        new ProcessCoalesceRDD[T](this)
+      } else {
+        new CoalescedRDD(this, numPartitions)
+      }
     }
   }
-
-  /**
-   * Return a new RDD which can combine multi partition into one in the same executor.
-   */
-  def processCoalesce: RDD[T] = new ProcessCoalesceRDD[T](this)
 
   /**
    * Return a sampled subset of this RDD.

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -376,6 +376,11 @@ abstract class RDD[T: ClassTag](
   }
 
   /**
+   * Return a new RDD which can combine multi partition into one in the same executor.
+   */
+  def processCoalesce: RDD[T] = new ProcessCoalesceRDD[T](this)
+
+  /**
    * Return a sampled subset of this RDD.
    * 
    * @param withReplacement can elements be sampled multiple times (replaced when sampled out)

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -191,7 +191,7 @@ class DAGScheduler(
   private[scheduler]
   def getCacheLocs(rdd: RDD[_]): Seq[Seq[TaskLocation]] = cacheLocs.synchronized {
     // Note: this doesn't use `getOrElse()` because this method is called O(num tasks) times
-    if (!cacheLocs.contains(rdd.id) || (checkCacheRdd(rdd) && cacheLocs(rdd.id)(0).length == 0)) {
+    if (!cacheLocs.contains(rdd.id) || checkCacheRddLocs(rdd)) {
       val blockIds = rdd.partitions.indices.map(index => RDDBlockId(rdd.id, index)).toArray[BlockId]
       val locs: Seq[Seq[TaskLocation]] = blockManagerMaster.getLocations(blockIds).map { bms =>
         bms.map(bm => TaskLocation(bm.host, bm.executorId))
@@ -199,6 +199,22 @@ class DAGScheduler(
       cacheLocs(rdd.id) = locs
     }
     cacheLocs(rdd.id)
+  }
+
+  // Since rdd's delay computation, the cached rdd can't keep its locations
+  // in 'DAGScheduler.cacheLocs'. So we should check the cached rdd already
+  // have the it's locations or not.
+  private def checkCacheRddLocs(rdd: RDD[_]) = {
+    if (checkCacheRdd(rdd)) {
+      val cacheRddLocs = cacheLocs(rdd.id)
+      if (0 == cacheRddLocs.size || 0 == cacheRddLocs(0).size) {
+        true
+      } else {
+        false
+      }
+    } else {
+      false
+    }
   }
 
   private def checkCacheRdd(rdd: RDD[_]) = rdd.getStorageLevel != StorageLevel.NONE

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskLocation.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskLocation.scala
@@ -34,6 +34,13 @@ private [spark] case class ExecutorCacheTaskLocation(override val host: String,
 }
 
 /**
+ * A location that started with a  prefix to support executor level partition scheduler
+ */
+private [spark] case class ExecutorPrefixTaskLocation(override val host: String,
+    val executorId: String) extends TaskLocation {
+}
+
+/**
  * A location on a host.
  */
 private [spark] case class HostTaskLocation(override val host: String) extends TaskLocation {
@@ -53,20 +60,26 @@ private[spark] object TaskLocation {
   // underscores, which are not legal characters in hostnames, there should be no potential for
   // confusion.  See  RFC 952 and RFC 1123 for information about the format of hostnames.
   val inMemoryLocationTag = "hdfs_cache_"
+  val executorLocationTag = "Executor_"
 
   def apply(host: String, executorId: String) = new ExecutorCacheTaskLocation(host, executorId)
 
   /**
    * Create a TaskLocation from a string returned by getPreferredLocations.
-   * These strings have the form [hostname] or hdfs_cache_[hostname], depending on whether the
-   * location is cached.
+   * These strings have the form Executor_[hostname]_[executorID] or [hostname]
+   * or hdfs_cache_[hostname], depending on whether the location is cached.
    */
   def apply(str: String) = {
-    val hstr = str.stripPrefix(inMemoryLocationTag)
-    if (hstr.equals(str)) {
-      new HostTaskLocation(str)
+    if (str.startsWith(executorLocationTag)) {
+      val elems = str.split("_")
+      new ExecutorPrefixTaskLocation(elems(1), elems(2))
     } else {
-      new HostTaskLocation(hstr)
+      val hstr = str.stripPrefix(inMemoryLocationTag)
+      if (hstr.equals(str)) {
+        new HostTaskLocation(str)
+      } else {
+        new HostTaskLocation(hstr)
+      }
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -190,6 +190,8 @@ private[spark] class TaskSetManager(
       loc match {
         case e: ExecutorCacheTaskLocation =>
           addTo(pendingTasksForExecutor.getOrElseUpdate(e.executorId, new ArrayBuffer))
+        case e: ExecutorPrefixTaskLocation =>
+          addTo(pendingTasksForExecutor.getOrElseUpdate(e.executorId, new ArrayBuffer))
         case e: HDFSCacheTaskLocation => {
           val exe = sched.getExecutorsAliveOnHost(loc.host)
           exe match {


### PR DESCRIPTION
Nowadays, the transformation coalesce was always used to expand or reduce the number of the partition in order to gain a good performance.
But coalesce can't make sure that the child partition will be executed in the same executor as the parent partition. And this will lead to have a large network transfer.
In some scenario such as I mentioned in the title small and cached rdd, we want to coalesce all the partition in the same executor into one partition and make sure the child partition will be executed in this executor. It can avoid network transfer and reduce the scheduler of the Tasks and also can reused the cpu core to do other job. 
In this scenario, our performance had improved 20% than before.
