### PR TITLE
[SPARK-6474][EC2] Use EC2Connection.run_instances to launch clusters

### DIFF
--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -502,7 +502,11 @@ def launch_cluster(conn, opts, cluster_name):
                                 if opts.additional_security_group in (sg.name, sg.id)]
     print "Launching instances..."
 
-    if conn.get_image(image_id=opts.ami) is None:
+    # Check if the AMI exists
+    try:
+        if conn.get_image(image_id=opts.ami) is None:
+            raise Exception()
+    except:
         print >> stderr, "Could not find AMI " + opts.ami
         sys.exit(1)
 

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -502,9 +502,7 @@ def launch_cluster(conn, opts, cluster_name):
                                 if opts.additional_security_group in (sg.name, sg.id)]
     print "Launching instances..."
 
-    try:
-        image = conn.get_all_images(image_ids=[opts.ami])[0]
-    except:
+    if conn.get_image(image_id=opts.ami) is None:
         print >> stderr, "Could not find AMI " + opts.ami
         sys.exit(1)
 
@@ -596,16 +594,19 @@ def launch_cluster(conn, opts, cluster_name):
         for zone in zones:
             num_slaves_this_zone = get_partition(opts.slaves, num_zones, i)
             if num_slaves_this_zone > 0:
-                slave_res = image.run(key_name=opts.key_pair,
-                                      security_group_ids=[slave_group.id] + additional_group_ids,
-                                      instance_type=opts.instance_type,
-                                      placement=zone,
-                                      min_count=num_slaves_this_zone,
-                                      max_count=num_slaves_this_zone,
-                                      block_device_map=block_map,
-                                      subnet_id=opts.subnet_id,
-                                      placement_group=opts.placement_group,
-                                      user_data=user_data_content)
+                slave_res = conn.run_instances(
+                    image_id=opts.ami,
+                    key_name=opts.key_pair,
+                    security_group_ids=[slave_group.id] + additional_group_ids,
+                    instance_type=opts.instance_type,
+                    placement=zone,
+                    min_count=num_slaves_this_zone,
+                    max_count=num_slaves_this_zone,
+                    block_device_map=block_map,
+                    subnet_id=opts.subnet_id,
+                    placement_group=opts.placement_group,
+                    user_data=user_data_content
+                )
                 slave_nodes += slave_res.instances
                 print "Launched {s} slave{plural_s} in {z}, regid = {r}".format(
                     s=num_slaves_this_zone,
@@ -627,16 +628,19 @@ def launch_cluster(conn, opts, cluster_name):
             master_type = opts.instance_type
         if opts.zone == 'all':
             opts.zone = random.choice(conn.get_all_zones()).name
-        master_res = image.run(key_name=opts.key_pair,
-                               security_group_ids=[master_group.id] + additional_group_ids,
-                               instance_type=master_type,
-                               placement=opts.zone,
-                               min_count=1,
-                               max_count=1,
-                               block_device_map=block_map,
-                               subnet_id=opts.subnet_id,
-                               placement_group=opts.placement_group,
-                               user_data=user_data_content)
+        master_res = conn.run_instances(
+            image_id=opts.ami,
+            key_name=opts.key_pair,
+            security_group_ids=[master_group.id] + additional_group_ids,
+            instance_type=master_type,
+            placement=opts.zone,
+            min_count=1,
+            max_count=1,
+            block_device_map=block_map,
+            subnet_id=opts.subnet_id,
+            placement_group=opts.placement_group,
+            user_data=user_data_content
+        )
 
         master_nodes = master_res.instances
         print "Launched master in %s, regid = %s" % (zone, master_res.id)


### PR DESCRIPTION
Instead of using the following call in spark_ec2.py to launch clusters:
- [`ec2.image.Image.run`](http://boto.readthedocs.org/en/latest/ref/ec2.html#boto.ec2.image.Image.run)

this patch uses the equivalent and more current call:
- [`ec2.connection.EC2Connection.run_instances`](http://boto.readthedocs.org/en/latest/ref/ec2.html#boto.ec2.connection.EC2Connection.run_instances)

This is a useful change in that connection.run_instances exposes
additional features such as the capability of handling ebs_optimized
instances, which image.run does not handle.

This improvement was first suggested by @nchammas in a boto issue:
https://github.com/boto/boto/issues/3054
