### PR TITLE
[DOCUMENTATION]Fixed Missing Type Import in Documentation

### DIFF
--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -624,6 +624,7 @@ tuples or lists in the RDD created in the step 1.
 For example:
 {% highlight python %}
 # Import SQLContext and data types
+from pyspark.sql import SQLContext
 from pyspark.sql.types import *
 
 # sc is an existing SparkContext.

--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -624,7 +624,7 @@ tuples or lists in the RDD created in the step 1.
 For example:
 {% highlight python %}
 # Import SQLContext and data types
-from pyspark.sql import *
+from pyspark.sql.types import *
 
 # sc is an existing SparkContext.
 sqlContext = SQLContext(sc)


### PR DESCRIPTION
Needed to import the types specifically, not the more general pyspark.sql
