### PR TITLE
Fallback to GenericRow

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -91,9 +91,9 @@ trait ScalaReflection {
 
   def convertRowToScala(r: Row, schema: StructType): Row = {
     // TODO: This is very slow!!!
-    new GenericRowWithSchema(
+    new GenericRow(
       r.toSeq.zip(schema.fields.map(_.dataType))
-        .map(r_dt => convertToScala(r_dt._1, r_dt._2)).toArray, schema)
+        .map(r_dt => convertToScala(r_dt._1, r_dt._2)).toArray)
   }
 
   /** Returns a Sequence of attributes for the given case class type. */


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-6465

Cause: com.esotericsoftware.kryo.KryoException: Class cannot be created (missing no-arg constructor): org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema

I can't register GenericRowWithSchema and make a no-arg constructor, StructType would cause this exception, too.

Fallback to GenericRow.
