### PR TITLE
[SPARK-6396][Core] Add broadcast timeout

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -588,11 +588,12 @@ private[spark] class BlockManager(
 
   private def doGetRemote(blockId: BlockId, asBlockResult: Boolean): Option[Any] = {
     require(blockId != null, "BlockId is null")
+    val timeout = conf.getInt("spark.storage.fetchBlockTimeout", 1000) // seconds
     val locations = Random.shuffle(master.getLocations(blockId))
     for (loc <- locations) {
       logDebug(s"Getting remote block $blockId from $loc")
       val data = blockTransferService.fetchBlockSync(
-        loc.host, loc.port, loc.executorId, blockId.toString).nioByteBuffer()
+        loc.host, loc.port, loc.executorId, blockId.toString, timeout).nioByteBuffer()
 
       if (data != null) {
         if (asBlockResult) {

--- a/core/src/test/scala/org/apache/spark/DistributedSuite.scala
+++ b/core/src/test/scala/org/apache/spark/DistributedSuite.scala
@@ -194,7 +194,7 @@ class DistributedSuite extends FunSuite with Matchers with LocalSparkContext {
     val blockTransfer = SparkEnv.get.blockTransferService
     blockManager.master.getLocations(blockId).foreach { cmId =>
       val bytes = blockTransfer.fetchBlockSync(cmId.host, cmId.port, cmId.executorId,
-        blockId.toString)
+        blockId.toString, 1000)
       val deserialized = blockManager.dataDeserialize(blockId, bytes.nioByteBuffer())
         .asInstanceOf[Iterator[Int]].toList
       assert(deserialized === (1 to 100).toList)

--- a/pom.xml
+++ b/pom.xml
@@ -1131,7 +1131,7 @@
           <configuration>
             <scalaVersion>${scala.version}</scalaVersion>
             <recompileMode>incremental</recompileMode>
-            <useZincServer>true</useZincServer>
+            <useZincServer>false</useZincServer>
             <args>
               <arg>-unchecked</arg>
               <arg>-deprecation</arg>


### PR DESCRIPTION
TorrentBroadcast uses fetchBlockSync method of BlockTransferService.scala which wait Infinite. A timeout would be better.
