### PR TITLE
[SPARK-6396][Core] Add broadcast timeout

### DIFF
--- a/core/src/main/scala/org/apache/spark/network/BlockTransferService.scala
+++ b/core/src/main/scala/org/apache/spark/network/BlockTransferService.scala
@@ -19,9 +19,11 @@ package org.apache.spark.network
 
 import java.io.Closeable
 import java.nio.ByteBuffer
+import java.util.concurrent.TimeUnit
 
 import scala.concurrent.{Promise, Await, Future}
 import scala.concurrent.duration.Duration
+import scala.concurrent.duration.{Duration, FiniteDuration}
 
 import org.apache.spark.Logging
 import org.apache.spark.network.buffer.{NioManagedBuffer, ManagedBuffer}
@@ -83,7 +85,12 @@ abstract class BlockTransferService extends ShuffleClient with Closeable with Lo
    *
    * It is also only available after [[init]] is invoked.
    */
-  def fetchBlockSync(host: String, port: Int, execId: String, blockId: String): ManagedBuffer = {
+  def fetchBlockSync(
+      host: String,
+      port: Int,
+      execId: String,
+      blockId: String,
+      timeout: Int): ManagedBuffer = {
     // A monitor for the thread to wait on.
     val result = Promise[ManagedBuffer]()
     fetchBlocks(host, port, execId, Array(blockId),
@@ -99,7 +106,8 @@ abstract class BlockTransferService extends ShuffleClient with Closeable with Lo
         }
       })
 
-    Await.result(result.future, Duration.Inf)
+    val fetchTimeout = new FiniteDuration(timeout, TimeUnit.SECONDS)
+    Await.result(result.future, fetchTimeout)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -589,10 +589,11 @@ private[spark] class BlockManager(
   private def doGetRemote(blockId: BlockId, asBlockResult: Boolean): Option[Any] = {
     require(blockId != null, "BlockId is null")
     val locations = Random.shuffle(master.getLocations(blockId))
+    val timeout = conf.getInt("spark.storage.fetchBlockTimeout", 1000) // seconds
     for (loc <- locations) {
       logDebug(s"Getting remote block $blockId from $loc")
       val data = blockTransferService.fetchBlockSync(
-        loc.host, loc.port, loc.executorId, blockId.toString).nioByteBuffer()
+        loc.host, loc.port, loc.executorId, blockId.toString, timeout).nioByteBuffer()
 
       if (data != null) {
         if (asBlockResult) {

--- a/core/src/test/scala/org/apache/spark/DistributedSuite.scala
+++ b/core/src/test/scala/org/apache/spark/DistributedSuite.scala
@@ -194,7 +194,7 @@ class DistributedSuite extends FunSuite with Matchers with LocalSparkContext {
     val blockTransfer = SparkEnv.get.blockTransferService
     blockManager.master.getLocations(blockId).foreach { cmId =>
       val bytes = blockTransfer.fetchBlockSync(cmId.host, cmId.port, cmId.executorId,
-        blockId.toString)
+        blockId.toString, 1000)
       val deserialized = blockManager.dataDeserialize(blockId, bytes.nioByteBuffer())
         .asInstanceOf[Iterator[Int]].toList
       assert(deserialized === (1 to 100).toList)


### PR DESCRIPTION
TorrentBroadcast uses fetchBlockSync method of BlockTransferService.scala which call wait Duration.Inf. A timeout would be better.
