### PR TITLE
[SPARK-6545][SQL][WIP] Minor changes

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/collection/CompactBuffer.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/CompactBuffer.scala
@@ -51,7 +51,7 @@ private[spark] class CompactBuffer[T: ClassTag] extends Seq[T] with Serializable
     }
   }
 
-  private def update(position: Int, value: T): Unit = {
+  def update(position: Int, value: T): Unit = {
     if (position < 0 || position >= curSize) {
       throw new IndexOutOfBoundsException
     }
@@ -152,6 +152,20 @@ private[spark] class CompactBuffer[T: ClassTag] extends Seq[T] with Serializable
 }
 
 private[spark] object CompactBuffer {
+  def constantEmpty[T: ClassTag](): CompactBuffer[T] = new CompactBuffer[T] {
+    override def apply(position: Int): T =
+      sys.error("apply() is not valid for a constant empty buffer")
+
+    override def update(position: Int, value: T): Unit =
+      sys.error("update() is not valid for a constant empty buffer")
+
+    override def += (value: T): CompactBuffer[T] =
+      sys.error("+= is not valid for a constant empty buffer")
+
+    override def ++= (values: TraversableOnce[T]): CompactBuffer[T] =
+      sys.error("++= is not valid for a constant empty")
+  }
+
   def apply[T: ClassTag](): CompactBuffer[T] = new CompactBuffer[T]
 
   def apply[T: ClassTag](value: T): CompactBuffer[T] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
@@ -81,17 +81,17 @@ trait HashJoin {
        *         tuples.
        */
       private final def fetchNext(): Boolean = {
-        currentHashMatches = null
+        currentHashMatches = CompactBuffer.constantEmpty[Row]()
         currentMatchPosition = -1
 
-        while (currentHashMatches == null && streamIter.hasNext) {
+        while (currentHashMatches.size == 0 && streamIter.hasNext) {
           currentStreamedRow = streamIter.next()
           if (!joinKeys(currentStreamedRow).anyNull) {
             currentHashMatches = hashedRelation.get(joinKeys.currentValue)
           }
         }
 
-        if (currentHashMatches == null) {
+        if (currentHashMatches.size == 0) {
           false
         } else {
           currentMatchPosition = 0

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/HashedRelationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/HashedRelationSuite.scala
@@ -37,7 +37,7 @@ class HashedRelationSuite extends FunSuite {
 
     assert(hashed.get(data(0)) == CompactBuffer[Row](data(0)))
     assert(hashed.get(data(1)) == CompactBuffer[Row](data(1)))
-    assert(hashed.get(Row(10)) === null)
+    assert(hashed.get(Row(10)).size === 0)
 
     val data2 = CompactBuffer[Row](data(2))
     data2 += data(2)
@@ -52,12 +52,12 @@ class HashedRelationSuite extends FunSuite {
     assert(hashed.get(data(0)) == CompactBuffer[Row](data(0)))
     assert(hashed.get(data(1)) == CompactBuffer[Row](data(1)))
     assert(hashed.get(data(2)) == CompactBuffer[Row](data(2)))
-    assert(hashed.get(Row(10)) === null)
+    assert(hashed.get(Row(10)).size === 0)
 
     val uniqHashed = hashed.asInstanceOf[UniqueKeyHashedRelation]
     assert(uniqHashed.getValue(data(0)) == data(0))
     assert(uniqHashed.getValue(data(1)) == data(1))
     assert(uniqHashed.getValue(data(2)) == data(2))
-    assert(uniqHashed.getValue(Row(10)) == null)
+    assert(uniqHashed.getValue(Row(10)).size === 0)
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertIntoHiveTableSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertIntoHiveTableSuite.scala
@@ -198,7 +198,7 @@ class InsertIntoHiveTableSuite extends QueryTest with BeforeAndAfter {
     val testDatawithNull = TestHive.sparkContext.parallelize(
       (1 to 10).map(i => ThreeCloumntable(i, i.toString,null))).toDF()
 
-    val tmpDir = Files.createTempDir()
+    val tmpDir = Utils.createTempDir()
     sql(s"CREATE TABLE table_with_partition(key int,value string) PARTITIONED by (ds string) location '${tmpDir.toURI.toString}' ")
     sql("INSERT OVERWRITE TABLE table_with_partition  partition (ds='1') SELECT key,value FROM testData")
 


### PR DESCRIPTION
In `HashedRelation`, we'd better always return a valid `CompactBuffer`, particularly an empty `CompactBuffer` instead of `null` for a given key, this will be great helpful for the multiway join of the future  improvement.
