### PR TITLE
[SPARK-6554] [SQL] Don't push down predicates which reference partition column(s)

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/parquet/ParquetFilterSuite.scala
@@ -330,6 +330,8 @@ class ParquetDataSourceOnFilterSuite extends ParquetFilterSuiteBase with BeforeA
         val path = s"${dir.getCanonicalPath}/part=1"
         (1 to 3).map(i => (i, i.toString)).toDF("a", "b").saveAsParquetFile(path)
 
+        // If the "part = 1" filter gets pushed down, this query will throw an exception since
+        // "part" is not a valid column in the actual Parquet file
         checkAnswer(
           sqlContext.parquetFile(path).filter("part = 1"),
           (1 to 3).map(i => Row(i, i.toString, 1)))


### PR DESCRIPTION
There are two cases for the new Parquet data source:
1. Partition columns exist in the Parquet data files
   
   We don't need to push-down these predicates since partition pruning already handles them.
2. Partition columns don't exist in the Parquet data files
   
   We can't push-down these predicates since they are considered as invalid columns by Parquet.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/apache/spark/5210)

<!-- Reviewable:end -->
