### PR TITLE
[SPARK-6405] Limiting the maximum Kryo buffer size to be 2GB.

### DIFF
--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -49,10 +49,20 @@ class KryoSerializer(conf: SparkConf)
   with Logging
   with Serializable {
 
-  private val bufferSize =
-    (conf.getDouble("spark.kryoserializer.buffer.mb", 0.064) * 1024 * 1024).toInt
+  private val bufferSizeMb: Double = conf.getDouble("spark.kryoserializer.buffer.mb", 0.064)
+  if (bufferSizeMb > 2048) {
+    throw new IllegalArgumentException("spark.kryoserializer.buffer.mb must be less than " +
+      s"2048 megabytes, got: + $bufferSizeMb mb.")
+  }
+  private val bufferSize = (bufferSizeMb * 1024 * 1024).toInt
 
-  private val maxBufferSize = conf.getInt("spark.kryoserializer.buffer.max.mb", 64) * 1024 * 1024
+  val maxBufferSizeMb: Int = conf.getInt("spark.kryoserializer.buffer.max.mb", 64)
+  if (maxBufferSizeMb > 2048) {
+    throw new IllegalArgumentException("spark.kryoserializer.buffer.max.mb must be less than " +
+      s"2048 megabytes, got: + $maxBufferSizeMb mb.")
+  }
+  private val maxBufferSize = maxBufferSizeMb * 1024 * 1024
+
   private val referenceTracking = conf.getBoolean("spark.kryo.referenceTracking", true)
   private val registrationRequired = conf.getBoolean("spark.kryo.registrationRequired", false)
   private val userRegistrator = conf.getOption("spark.kryo.registrator")

--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -49,19 +49,19 @@ class KryoSerializer(conf: SparkConf)
   with Logging
   with Serializable {
 
-  private val bufferSizeMb: Double = conf.getDouble("spark.kryoserializer.buffer.mb", 0.064)
+  private val bufferSizeMb = conf.getDouble("spark.kryoserializer.buffer.mb", 0.064)
   if (bufferSizeMb >= 2048) {
     throw new IllegalArgumentException("spark.kryoserializer.buffer.mb must be less than " +
       s"2048 mb, got: + $bufferSizeMb mb.")
   }
   private val bufferSize = (bufferSizeMb * 1024 * 1024).toInt
 
-  val maxBufferSizeMb: Int = conf.getInt("spark.kryoserializer.buffer.max.mb", 64)
+  val maxBufferSizeMb = conf.getInt("spark.kryoserializer.buffer.max.mb", 64)
   if (maxBufferSizeMb >= 2048) {
     throw new IllegalArgumentException("spark.kryoserializer.buffer.max.mb must be less than " +
       s"2048 mb, got: + $maxBufferSizeMb mb.")
   }
-  private val maxBufferSize = maxBufferSizeMb * 1024 * 1024
+  private val maxBufferSize = maxBufferSizeMb * 1026 * 1024
 
   private val referenceTracking = conf.getBoolean("spark.kryo.referenceTracking", true)
   private val registrationRequired = conf.getBoolean("spark.kryo.registrationRequired", false)

--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -50,16 +50,16 @@ class KryoSerializer(conf: SparkConf)
   with Serializable {
 
   private val bufferSizeMb: Double = conf.getDouble("spark.kryoserializer.buffer.mb", 0.064)
-  if (bufferSizeMb > 2048) {
+  if (bufferSizeMb >= 2048) {
     throw new IllegalArgumentException("spark.kryoserializer.buffer.mb must be less than " +
-      s"2048 megabytes, got: + $bufferSizeMb mb.")
+      s"2048 mb, got: + $bufferSizeMb mb.")
   }
   private val bufferSize = (bufferSizeMb * 1024 * 1024).toInt
 
   val maxBufferSizeMb: Int = conf.getInt("spark.kryoserializer.buffer.max.mb", 64)
-  if (maxBufferSizeMb > 2048) {
+  if (maxBufferSizeMb >= 2048) {
     throw new IllegalArgumentException("spark.kryoserializer.buffer.max.mb must be less than " +
-      s"2048 megabytes, got: + $maxBufferSizeMb mb.")
+      s"2048 mb, got: + $maxBufferSizeMb mb.")
   }
   private val maxBufferSize = maxBufferSizeMb * 1024 * 1024
 

--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -61,7 +61,7 @@ class KryoSerializer(conf: SparkConf)
     throw new IllegalArgumentException("spark.kryoserializer.buffer.max.mb must be less than " +
       s"2048 mb, got: + $maxBufferSizeMb mb.")
   }
-  private val maxBufferSize = maxBufferSizeMb * 1026 * 1024
+  private val maxBufferSize = maxBufferSizeMb * 1024 * 1024
 
   private val referenceTracking = conf.getBoolean("spark.kryo.referenceTracking", true)
   private val registrationRequired = conf.getBoolean("spark.kryo.registrationRequired", false)


### PR DESCRIPTION
Kryo buffers are backed by byte arrays, but primitive arrays can only be
up to 2GB in size. It is misleading to allow users to set buffers past
this size.
