### PR TITLE
[SPARK-6559][PySpark]specify port of python gateway server

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonGatewayServer.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonGatewayServer.scala
@@ -22,7 +22,7 @@ import java.net.Socket
 
 import py4j.GatewayServer
 
-import org.apache.spark.Logging
+import org.apache.spark.{SparkConf, Logging}
 import org.apache.spark.util.Utils
 
 /**
@@ -33,16 +33,8 @@ import org.apache.spark.util.Utils
  */
 private[spark] object PythonGatewayServer extends Logging {
   def main(args: Array[String]): Unit = Utils.tryOrExit {
-    // Start a GatewayServer on an ephemeral port
-    val gatewayServer: GatewayServer = new GatewayServer(null, 0)
-    gatewayServer.start()
-    val boundPort: Int = gatewayServer.getListeningPort
-    if (boundPort == -1) {
-      logError("GatewayServer failed to bind; exiting")
-      System.exit(1)
-    } else {
-      logDebug(s"Started PythonGatewayServer on port $boundPort")
-    }
+    // Start a GatewayServer
+    val (_, boundPort) = PythonUtils.startGatewayServer(new SparkConf())
 
     // Communicate the bound port back to the caller via the caller-specified callback port
     val callbackHost = sys.env("_PYSPARK_DRIVER_CALLBACK_HOST")

--- a/core/src/main/scala/org/apache/spark/api/python/PythonUtils.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonUtils.scala
@@ -23,8 +23,11 @@ import java.util.{List => JList}
 import scala.collection.JavaConversions._
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.spark.SparkContext
+import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.api.java.{JavaSparkContext, JavaRDD}
+import org.apache.spark.util.Utils
+import py4j.{Py4JNetworkException, GatewayServer}
+import java.net.BindException
 
 private[spark] object PythonUtils {
   /** Get the PYTHONPATH for PySpark, either from SPARK_HOME, if it is set, or from our JAR */
@@ -52,5 +55,22 @@ private[spark] object PythonUtils {
    */
   def toSeq[T](cols: JList[T]): Seq[T] = {
     cols.toList.toSeq
+  }
+
+  def startGatewayServer(conf: SparkConf): (GatewayServer, Int) = {
+   val port = conf.getInt("spark.python.gateway.port", 0)
+   Utils.startServiceOnPort[GatewayServer](
+    port, doStartGatewayServer, conf, "PythonGatewayServer")
+  }
+
+  private def doStartGatewayServer(startPort: Int): (GatewayServer, Int) = {
+    val server = new GatewayServer(null, startPort)
+    try {
+      server.start()
+    } catch {
+      case e: Py4JNetworkException =>
+        throw new BindException(e.getMessage)
+    }
+    (server, server.getListeningPort)
   }
 }

--- a/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
@@ -24,6 +24,7 @@ import scala.collection.JavaConversions._
 
 import org.apache.spark.api.python.PythonUtils
 import org.apache.spark.util.{RedirectThread, Utils}
+import org.apache.spark.SparkConf
 
 /**
  * A main class used to launch Python applications. It executes python as a
@@ -43,8 +44,7 @@ object PythonRunner {
 
     // Launch a Py4J gateway server for the process to connect to; this will let it see our
     // Java system properties and such
-    val gatewayServer = new py4j.GatewayServer(null, 0)
-    gatewayServer.start()
+    val (_, boundPort) = PythonUtils.startGatewayServer(new SparkConf())
 
     // Build up a PYTHONPATH that includes the Spark assembly JAR (where this class is), the
     // python directories in SPARK_HOME (if set), and any files in the pyFiles argument
@@ -60,7 +60,7 @@ object PythonRunner {
     env.put("PYTHONPATH", pythonPath)
     // This is equivalent to setting the -u flag; we use it because ipython doesn't support -u:
     env.put("PYTHONUNBUFFERED", "YES") // value is needed to be set to a non-empty string
-    env.put("PYSPARK_GATEWAY_PORT", "" + gatewayServer.getListeningPort)
+    env.put("PYSPARK_GATEWAY_PORT", "" + boundPort)
     builder.redirectErrorStream(true) // Ugly but needed for stdout and stderr to synchronize
     val process = builder.start()
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-6559
Add a config "spark.python.gateway.port" to specify gateway server's port, and use Utils.startServiceOnPort to give it a retry if bind failed.

/cc @davies
