### PR TITLE
[SPARK-4069] [YARN] When AppMaster finishes, this change calls AMRMClient to removeContainer...

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -193,6 +193,8 @@ private[spark] class ApplicationMaster(
       finalStatus = status
       finalMsg = msg
       finished = true
+      allocator.removeContainerRequests()
+      allocator.releaseAssignedContainers()
       if (!inShutdown && Thread.currentThread() != reporterThread && reporterThread != null) {
         logDebug("shutting down reporter thread")
         reporterThread.interrupt()


### PR DESCRIPTION
Currently Application Master goes down without releasing the containers. Once AM goes down, YARN kills those containers. This change is to explicitly remove all container requests made, also release all assigned containers.
