### PR TITLE
[SPARK-6584][CORE]Provide ExecutorPrefixTaskLocation to support the rdd which can be aware of partition's executor location.

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskLocation.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskLocation.scala
@@ -34,6 +34,16 @@ case class ExecutorCacheTaskLocation(override val host: String, executorId: Stri
   extends TaskLocation
 
 /**
+ * A location that started with the prefix "Executor_" for the RDD.getPreferredLocations
+ * to pass the executor locations to TaskScheduler. The TaskLocality of this tasks should
+ * be PROCESS_LOCAL.
+ */
+private [spark]
+case class ExecutorPrefixTaskLocation(override val host: String, executorId: String)
+  extends TaskLocation {
+}
+
+/**
  * A location on a host.
  */
 private [spark] case class HostTaskLocation(override val host: String) extends TaskLocation {
@@ -52,6 +62,7 @@ private[spark] object TaskLocation {
   // underscores, which are not legal characters in hostnames, there should be no potential for
   // confusion.  See  RFC 952 and RFC 1123 for information about the format of hostnames.
   val inMemoryLocationTag = "hdfs_cache_"
+  val executorLocationTag = "Executor_"
 
   def apply(host: String, executorId: String): TaskLocation = {
     new ExecutorCacheTaskLocation(host, executorId)
@@ -59,15 +70,20 @@ private[spark] object TaskLocation {
 
   /**
    * Create a TaskLocation from a string returned by getPreferredLocations.
-   * These strings have the form [hostname] or hdfs_cache_[hostname], depending on whether the
-   * location is cached.
+   * These strings have the form Executor_[hostname]_[executorID] or [hostname]
+   * or hdfs_cache_[hostname], depending on whether the location is cached.
    */
   def apply(str: String): TaskLocation = {
-    val hstr = str.stripPrefix(inMemoryLocationTag)
-    if (hstr.equals(str)) {
-      new HostTaskLocation(str)
+    if (str.startsWith(executorLocationTag)) {
+      val elems = str.split("_")
+      new ExecutorPrefixTaskLocation(elems(1), elems(2))
     } else {
-      new HostTaskLocation(hstr)
+      val hstr = str.stripPrefix(inMemoryLocationTag)
+      if (hstr.equals(str)) {
+        new HostTaskLocation(str)
+      } else {
+        new HostTaskLocation(hstr)
+      }
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -193,6 +193,8 @@ private[spark] class TaskSetManager(
       loc match {
         case e: ExecutorCacheTaskLocation =>
           addTo(pendingTasksForExecutor.getOrElseUpdate(e.executorId, new ArrayBuffer))
+        case e: ExecutorPrefixTaskLocation =>
+          addTo(pendingTasksForExecutor.getOrElseUpdate(e.executorId, new ArrayBuffer))
         case e: HDFSCacheTaskLocation => {
           val exe = sched.getExecutorsAliveOnHost(loc.host)
           exe match {


### PR DESCRIPTION
The function `RDD.getPreferredLocations` can only be set the host awareness prefer locations.
If some RDD wants to be scheduled by executor(such as `BlockRDD`), spark can do nothing for this.
So I want to provide `ExecutorPrefixTaskLocation` to support the rdd which can be aware of partition's executor location. This mechanism can avoid data transfor in the case of many executor in the same host.
I think it's very useful especially for `SparkStreaming` since the `Receriver` save data into the `BlockMange`r and then become a `BlockRDD`
