### PR TITLE
[SPARK-6586][SQL] Add the capability of retrieving original logical plan of DataFrame

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -64,8 +64,16 @@ class Analyzer(catalog: Catalog,
       UnresolvedHavingClauseAttributes ::
       TrimGroupingAliases ::
       typeCoercionRules ++
-      extendedResolutionRules : _*)
+      extendedResolutionRules : _*),
+    Batch("SetAnalyzed", Once, SetLogicalPlanAnalyzed)
   )
+
+  object SetLogicalPlanAnalyzed extends Rule[LogicalPlan] {
+    def apply(plan: LogicalPlan): LogicalPlan = {
+      plan.analyzed = true
+      plan
+    }
+  }
 
   /**
    * Removes no-op Alias expressions from the plan.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
@@ -29,6 +29,15 @@ import org.apache.spark.sql.catalyst.trees
 abstract class LogicalPlan extends QueryPlan[LogicalPlan] with Logging {
   self: Product =>
 
+  protected[sql] var analyzed: Boolean = false
+
+  def originalPlan: LogicalPlan = this transform {
+    case p if p.analyzed =>
+      p._origPlan.getOrElse(p)
+  }
+
+  protected[sql] var _origPlan: Option[LogicalPlan] = None
+
   /**
    * Computes [[Statistics]] for this plan. The default implementation assumes the output
    * cardinality is the product of of all child plan's cardinality, i.e. applies in the case

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -149,6 +149,8 @@ class DataFrame private[sql](
       queryExecution.analyzed
   }
 
+  @transient val originalPlan: LogicalPlan = logicalPlan.originalPlan
+
   /**
    * An implicit conversion function internal to this class for us to avoid doing
    * "new DataFrame(...)" everywhere.

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -1107,7 +1107,14 @@ class SQLContext(@transient val sparkContext: SparkContext)
   protected[sql] class QueryExecution(val logical: LogicalPlan) {
     def assertAnalyzed(): Unit = checkAnalysis(analyzed)
 
-    lazy val analyzed: LogicalPlan = analyzer(logical)
+    lazy val analyzed: LogicalPlan = if (!logical.analyzed) {
+      val plan = analyzer(logical)
+      plan._origPlan = Some(logical)
+      plan
+    } else {
+      logical
+    }
+
     lazy val withCachedData: LogicalPlan = {
       assertAnalyzed()
       cacheManager.useCachedData(analyzed)


### PR DESCRIPTION
In order to solve a bug, since #5217, `DataFrame` now uses analyzed plan instead of logical plan. However, by doing that we can't know the logical plan of a `DataFrame`. But it might be still useful and important to retrieve the original logical plan in some use cases.

In this pr, we introduce the capability of retrieving original logical plan of `DataFrame`.

The approach is that we add an `analyzed` variable to `LogicalPlan`. Once `Analyzer` finishes analysis, it sets `analyzed` of `LogicalPlan` as `true`.  In `QueryExecution`, we keep the original logical plan in the analyzed plan. In `LogicalPlan`, a method `originalPlan` is added to recursively replace the analyzed logical plan with original logical plan and retrieve it.

Besides the capability of retrieving original logical plan, this modification also can avoid do plan analysis if it is already analyzed.
