### PR TITLE
[SPARK-6239] [MLLib] [FPGrowth] Possibility to specify minSupport parameter as an absolute

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/mllib/fpm/FPGrowthSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/fpm/FPGrowthSuite.scala
@@ -66,7 +66,7 @@ class FPGrowthSuite extends FunSuite with MLlibTestSparkContext {
     assert(model2.freqItemsets.count() === 54)
 
     val model1 = fpg
-      .setMinSupport(0.1)
+      .setMinSupportAbsolute(1)
       .setNumPartitions(8)
       .run(rdd)
     assert(model1.freqItemsets.count() === 625)


### PR DESCRIPTION
This PR makes it possible to specify minSupport in MLLib.FPGrowth algorithm as an absolute value. In that situation there will be no additional RDD.count() operation performed upfront.

Let me know if this is something worth including and valid to merge - I will create a JIRA issue then and change the commit message to reflect ticket number etc.
