### PR TITLE
[SPARK-6607][SQL] Check invalid characters for Parquet schema and show error messages

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetTypes.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetTypes.scala
@@ -390,10 +390,11 @@ private[parquet] object ParquetTypesConverter extends Logging {
 
   def convertFromAttributes(attributes: Seq[Attribute],
                             toThriftSchemaNames: Boolean = false): MessageType = {
-    val fields = attributes.map(
-      attribute =>
+    val fields = attributes.map { old_attribute =>
+        val attribute = old_attribute.withName(old_attribute.name.replaceAll("\\((.*)\\)", "[$1]"))
         fromDataType(attribute.dataType, attribute.name, attribute.nullable,
-                     toThriftSchemaNames = toThriftSchemaNames))
+                     toThriftSchemaNames = toThriftSchemaNames)
+    }
     new MessageType("root", fields)
   }
 
@@ -405,7 +406,10 @@ private[parquet] object ParquetTypesConverter extends Logging {
   }
 
   def convertToString(schema: Seq[Attribute]): String = {
-    StructType.fromAttributes(schema).json
+    val replaced_schema = schema.map { attribute =>
+         attribute.withName(attribute.name.replaceAll("\\((.*)\\)", "[$1]"))
+    }
+    StructType.fromAttributes(replaced_schema).json
   }
 
   def writeMetaData(attributes: Seq[Attribute], origPath: Path, conf: Configuration): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetTypes.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetTypes.scala
@@ -405,11 +405,15 @@ private[parquet] object ParquetTypesConverter extends Logging {
     }
   }
 
-  def checkSpecialCharacters(schema: Seq[Attribute]) = {
+  private def checkSpecialCharacters(schema: Seq[Attribute]) = {
     // ,;{}()\n\t= and space character are special characters in Parquet schema
-    if (schema.exists(_.name.matches(".*[ ,;{}()\n\t=].*"))) {
-      sys.error("""Attribute name can not contain any character among " ,;{}()\n\t=".
-                   | Use Alias to rename attribute name""".stripMargin)
+    schema.map(_.name).foreach { name =>
+      if (name.matches(".*[ ,;{}()\n\t=].*")) {
+        sys.error(
+          s"""Attribute name "$name" contains invalid character(s) among " ,;{}()\n\t=".
+             |Please use alias to rename it.
+           """.stripMargin.split("\n").mkString(" "))
+      }
     }
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/parquetSuites.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/parquetSuites.scala
@@ -578,6 +578,18 @@ class ParquetDataSourceOnSourceSuite extends ParquetSourceSuiteBase {
 
     sql("DROP TABLE alwaysNullable")
   }
+
+  test("Aggregation attribute names including special chars '(' and ')' should be replaced") {
+    val tempDir = Utils.createTempDir()
+    val filePath = new File(tempDir, "testParquet").getCanonicalPath
+
+    val df = Seq(1,2,3).map(i => (i, i.toString)).toDF("int", "str")
+    val df2 = df.as('x).join(df.as('y), $"x.str" === $"y.str").groupBy("y.str").max("y.int")
+    df2.saveAsParquetFile(filePath)
+    val df3 = parquetFile(filePath)
+    checkAnswer(df3, Row("1", 1) :: Row("2", 2) :: Row("3", 3) :: Nil)
+    assert(df3.columns === Array("str", "MAX[int]"))
+  }
 }
 
 class ParquetDataSourceOffSourceSuite extends ParquetSourceSuiteBase {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/parquetSuites.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/parquetSuites.scala
@@ -579,16 +579,20 @@ class ParquetDataSourceOnSourceSuite extends ParquetSourceSuiteBase {
     sql("DROP TABLE alwaysNullable")
   }
 
-  test("Aggregation attribute names including special chars '(' and ')' should be replaced") {
+  test("Aggregation attribute names can't contain special chars \" ,;{}()\\n\\t=\"") {
     val tempDir = Utils.createTempDir()
     val filePath = new File(tempDir, "testParquet").getCanonicalPath
+    val filePath2 = new File(tempDir, "testParquet2").getCanonicalPath
 
     val df = Seq(1,2,3).map(i => (i, i.toString)).toDF("int", "str")
     val df2 = df.as('x).join(df.as('y), $"x.str" === $"y.str").groupBy("y.str").max("y.int")
-    df2.saveAsParquetFile(filePath)
-    val df3 = parquetFile(filePath)
-    checkAnswer(df3, Row("1", 1) :: Row("2", 2) :: Row("3", 3) :: Nil)
-    assert(df3.columns === Array("str", "MAX[int]"))
+    intercept[RuntimeException](df2.saveAsParquetFile(filePath))
+
+    val df3 = df2.toDF("str", "max_int")
+    df3.saveAsParquetFile(filePath2)
+    val df4 = parquetFile(filePath2)
+    checkAnswer(df4, Row("1", 1) :: Row("2", 2) :: Row("3", 3) :: Nil)
+    assert(df4.columns === Array("str", "max_int"))
   }
 }
 


### PR DESCRIPTION
'(' and ')' are special characters used in Parquet schema for type annotation. When we run an aggregation query, we will obtain attribute name such as "MAX(a)".

If we directly store the generated DataFrame as Parquet file, it causes failure when reading and parsing the stored schema string.

This pr adds the function to detect these invalid characters in field names of a Parquet schema. If any invalid characters are found, we show an error message to the user and suggest the user to add an alias to the field.
