### PR TITLE
[SPARK-6582][Streaming]Support SSL in Spark Streaming Flume

### DIFF
--- a/docs/streaming-flume-integration.md
+++ b/docs/streaming-flume-integration.md
@@ -27,6 +27,10 @@ Configure Flume agent to send data to an Avro sink by having the following in th
     agent.sinks.avroSink.channel = memoryChannel
     agent.sinks.avroSink.hostname = <chosen machine's hostname>
 	agent.sinks.avroSink.port = <chosen port on the machine>
+	agent.sinks.avroSink.ssl = <default: false>
+	agent.sinks.avroSink.keystore = <path of keyStore file: necessary if `ssl` is true>
+	agent.sinks.avroSink.keystore-password = <password of keyStore: necessary if `ssl` is true>
+	agent.sinks.avroSink.keystore-type = <default: JKS>
 
 See the [Flume's documentation](https://flume.apache.org/documentation.html) for more information about
 configuring Flume agents.
@@ -37,8 +41,15 @@ configuring Flume agents.
 		groupId = org.apache.spark
 		artifactId = spark-streaming-flume_{{site.SCALA_BINARY_VERSION}}
 		version = {{site.SPARK_VERSION_SHORT}}
+		
+2. **Configuration:** if `agent.sinks.avroSink.ssl` is true, this configuration has to set in the spark conf.
 
-2. **Programming:** In the streaming application code, import `FlumeUtils` and create input DStream as follows.
+        spark.streaming.flume.ssl = true
+        spark.streaming.flume.keystore = <path of keyStore file>
+        spark.streaming.flume.keystore-password = <password of keyStore>
+        spark.streaming.flume.keystore-type = <default: JKS>
+
+3. **Programming:** In the streaming application code, import `FlumeUtils` and create input DStream as follows.
 
 	<div class="codetabs">
 	<div data-lang="scala" markdown="1">
@@ -64,7 +75,7 @@ configuring Flume agents.
     cluster (Mesos, YARN or Spark Standalone), so that resource allocation can match the names and launch
     the receiver in the right machine.
 
-3. **Deploying:** Package `spark-streaming-flume_{{site.SCALA_BINARY_VERSION}}` and its dependencies (except `spark-core_{{site.SCALA_BINARY_VERSION}}` and `spark-streaming_{{site.SCALA_BINARY_VERSION}}` which are provided by `spark-submit`) into the application JAR. Then use `spark-submit` to launch your application (see [Deploying section](streaming-programming-guide.html#deploying-applications) in the main programming guide).
+4. **Deploying:** Package `spark-streaming-flume_{{site.SCALA_BINARY_VERSION}}` and its dependencies (except `spark-core_{{site.SCALA_BINARY_VERSION}}` and `spark-streaming_{{site.SCALA_BINARY_VERSION}}` which are provided by `spark-submit`) into the application JAR. Then use `spark-submit` to launch your application (see [Deploying section](streaming-programming-guide.html#deploying-applications) in the main programming guide).
 
 ## Approach 2: Pull-based Approach using a Custom Sink
 Instead of Flume pushing data directly to Spark Streaming, this approach runs a custom Flume sink that allows the following.

--- a/external/flume/src/main/scala/org/apache/spark/streaming/flume/FlumeConf.scala
+++ b/external/flume/src/main/scala/org/apache/spark/streaming/flume/FlumeConf.scala
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.streaming.flume
+
+
+case class FlumeConf(flumeMaxThread: Int, enableDecompression: Boolean,
+    enableSSL: Boolean, keyStore: String, keyStorePassword: String,
+    keyStoreType: String)

--- a/external/flume/src/main/scala/org/apache/spark/streaming/flume/FlumeConf.scala
+++ b/external/flume/src/main/scala/org/apache/spark/streaming/flume/FlumeConf.scala
@@ -17,7 +17,5 @@
 
 package org.apache.spark.streaming.flume
 
-
-case class FlumeConf(flumeMaxThread: Int, enableDecompression: Boolean,
-    enableSSL: Boolean, keyStore: String, keyStorePassword: String,
-    keyStoreType: String)
+private[flume] case class FlumeConf(flumeMaxThread: Int, enableDecompression: Boolean,
+    enableSSL: Boolean, keyStore: String, keyStorePassword: String, keyStoreType: String)

--- a/external/flume/src/main/scala/org/apache/spark/streaming/flume/FlumeInputDStream.scala
+++ b/external/flume/src/main/scala/org/apache/spark/streaming/flume/FlumeInputDStream.scala
@@ -162,25 +162,19 @@ class FlumeReceiver(
         Executors.newCachedThreadPool(), Executors.newCachedThreadPool())
       val channelPipelineFactory = new CompressionChannelPipelineFactory()
       
-      new NettyServer(
-        responder, 
-        new InetSocketAddress(host, port),
-        channelFactory,
-        channelPipelineFactory,
-        null)
+      new NettyServer(responder, new InetSocketAddress(host, port),
+        channelFactory,  channelPipelineFactory, null)
     } else {
       new NettyServer(responder, new InetSocketAddress(host, port))
     }
   }
 
   private def initSSLServer() = {
-    initSocketChannelFactory
-    initChannelPipelineFactory
     new NettyServer(responder, new InetSocketAddress(host, port),
       initSocketChannelFactory, initChannelPipelineFactory, null)
   }
-  
-  def initSocketChannelFactory = {
+
+  private def initSocketChannelFactory = {
     val maxThreads = flumeConf.flumeMaxThread
     if (maxThreads <= 0) {
       new NioServerSocketChannelFactory(Executors.newCachedThreadPool, 
@@ -196,8 +190,7 @@ class FlumeReceiver(
     if (enableDecompression || enableSsl) {
       pipelineFactory = new SSLCompressionChannelPipelineFactory(enableDecompression,
         enableSsl, keyStore, keyStorePassword, keyStoreType)
-    }
-    else {
+    } else {
       pipelineFactory = new ChannelPipelineFactory {
         def getPipeline: ChannelPipeline = {
           Channels.pipeline

--- a/external/flume/src/test/scala/org/apache/spark/streaming/flume/FlumeStreamSuite.scala
+++ b/external/flume/src/test/scala/org/apache/spark/streaming/flume/FlumeStreamSuite.scala
@@ -87,10 +87,9 @@ class FlumeStreamSuite extends FunSuite with BeforeAndAfter with Matchers with L
   /** Setup and start the streaming context */
   private def startContext(
       testPort: Int, testCompression: Boolean): (ArrayBuffer[Seq[SparkFlumeEvent]]) = {
-    System.setProperty("spark.streaming,flume.decompression", testCompression.toString)
     ssc = new StreamingContext(conf, Milliseconds(200))
     val flumeStream = FlumeUtils.createStream(
-      ssc, "localhost", testPort, StorageLevel.MEMORY_AND_DISK)
+      ssc, "localhost", testPort, StorageLevel.MEMORY_AND_DISK, testCompression)
     val outputBuffer = new ArrayBuffer[Seq[SparkFlumeEvent]]
       with SynchronizedBuffer[Seq[SparkFlumeEvent]]
     val outputStream = new TestOutputStream(flumeStream, outputBuffer)

--- a/external/flume/src/test/scala/org/apache/spark/streaming/flume/FlumeStreamSuite.scala
+++ b/external/flume/src/test/scala/org/apache/spark/streaming/flume/FlumeStreamSuite.scala
@@ -87,9 +87,10 @@ class FlumeStreamSuite extends FunSuite with BeforeAndAfter with Matchers with L
   /** Setup and start the streaming context */
   private def startContext(
       testPort: Int, testCompression: Boolean): (ArrayBuffer[Seq[SparkFlumeEvent]]) = {
+    System.setProperty("spark.streaming,flume.decompression", testCompression.toString)
     ssc = new StreamingContext(conf, Milliseconds(200))
     val flumeStream = FlumeUtils.createStream(
-      ssc, "localhost", testPort, StorageLevel.MEMORY_AND_DISK, testCompression)
+      ssc, "localhost", testPort, StorageLevel.MEMORY_AND_DISK)
     val outputBuffer = new ArrayBuffer[Seq[SparkFlumeEvent]]
       with SynchronizedBuffer[Seq[SparkFlumeEvent]]
     val outputStream = new TestOutputStream(flumeStream, outputBuffer)


### PR DESCRIPTION
`AvroSink` had support the `ssl`, so it's better to support `ssl` in the Spark Streaming External Flume.
The implementation was referenced from `AvroSource`
Here is the configurations which can enable the `ssl` in streaming:
- spark.streaming.flume.ssl = **default: false**
- spark.streaming.flume.keystore = **path of keyStore file**
- spark.streaming.flume.keystore-password = **password of keyStore**
- spark.streaming.flume.keystore-type = **default: JKS**

The annoyance is that we have to put the `keyStore` file in every node of the cluster
