### PR TITLE
[SPARK-3591][YARN]fire and forget for YARN cluster mode

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/Client.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/Client.scala
@@ -89,7 +89,7 @@ private class ClientActor(driverArgs: ClientArguments, conf: SparkConf)
 
   /* Find out driver status then exit the JVM */
   def pollAndReportStatus(driverId: String) {
-    println(s"... waiting before polling master for driver state")
+    println("... waiting before polling master for driver state")
     Thread.sleep(5000)
     println("... polling master for driver state")
     val statusFuture = (masterActor ? RequestDriverStatus(driverId))(timeout)

--- a/core/src/main/scala/org/apache/spark/deploy/rest/StandaloneRestClient.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/rest/StandaloneRestClient.scala
@@ -241,7 +241,7 @@ private[deploy] class StandaloneRestClient extends Logging {
       }
     } else {
       val failMessage = Option(submitResponse.message).map { ": " + _ }.getOrElse("")
-      logError("Application submission failed" + failMessage)
+      logError(s"Application submission failed$failMessage")
     }
   }
 

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -200,8 +200,8 @@ Most of the configs are the same for Spark on YARN as for other deployment modes
   <td><code>spark.yarn.submit.waitAppCompletion</code></td>
   <td>true</td>
   <td>
-  Whether to wait for application to complete in cluster mode. If set this to true, client process will enter a loop to track application's status.
-  Otherwise, client process will exist as long as application is successfully submitted.
+  In YARN cluster mode, controls whether the client waits to exit until the application completes. If set to true, the client process will stay alive reporting the application's status.
+  Otherwise, the client process will exit after submission.
   </td>
 </tr>
 </table>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -200,7 +200,8 @@ Most of the configs are the same for Spark on YARN as for other deployment modes
   <td><code>spark.yarn.submit.waitAppCompletion</code></td>
   <td>true</td>
   <td>
-  In YARN cluster mode, controls whether the client waits to exit until the application completes. If set to true, the client process will stay alive reporting the application's status.
+  In YARN cluster mode, controls whether the client waits to exit until the application completes.
+  If set to true, the client process will stay alive reporting the application's status.
   Otherwise, the client process will exit after submission.
   </td>
 </tr>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -196,6 +196,14 @@ Most of the configs are the same for Spark on YARN as for other deployment modes
   It should be no larger than the global number of max attempts in the YARN configuration.
   </td>
 </tr>
+<tr>
+  <td><code>spark.yarn.waitForCompletion</code></td>
+  <td>true</td>
+  <td>
+  Whether to wait for application to complete in cluster mode. If set this to true, client process will enter a loop to track application's status.
+  Otherwise, client process will exist as long as application is successfully submitted.
+  </td>
+</tr>
 </table>
 
 # Launching Spark on YARN

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -197,7 +197,7 @@ Most of the configs are the same for Spark on YARN as for other deployment modes
   </td>
 </tr>
 <tr>
-  <td><code>spark.yarn.waitForCompletion</code></td>
+  <td><code>spark.yarn.submit.waitAppCompletion</code></td>
   <td>true</td>
   <td>
   Whether to wait for application to complete in cluster mode. If set this to true, client process will enter a loop to track application's status.

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -626,12 +626,11 @@ private[spark] class Client(
     if (fireAndForget) {
       val report = getApplicationReport(appId)
       val state = report.getYarnApplicationState
-      if (state == YarnApplicationState.FAILED || state == YarnApplicationState.KILLED) {
-        logInfo(formatReportDetails(report))
-        throw new SparkException(s"Application $appId finished with status: $state")
-      }
       logInfo(s"Application report for $appId (state: $state)")
       logInfo(formatReportDetails(report))
+      if (state == YarnApplicationState.FAILED || state == YarnApplicationState.KILLED) {
+        throw new SparkException(s"Application $appId finished with status: $state")
+      }
     } else {
       val (yarnApplicationState, finalApplicationStatus) = monitorApplication(appId)
       if (yarnApplicationState == YarnApplicationState.FAILED ||

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -626,7 +626,7 @@ private[spark] class Client(
       val report = getApplicationReport(appId)
       val state = report.getYarnApplicationState
       if (state == YarnApplicationState.FAILED || state == YarnApplicationState.KILLED) {
-        throw new SparkException(s"Application finished with status: $state")
+        throw new SparkException(s"Application $appId finished with status: $state")
       }
       logInfo(s"Application report for $appId (state: $state)")
       logInfo(formatReportDetails(report))
@@ -634,14 +634,14 @@ private[spark] class Client(
       val (yarnApplicationState, finalApplicationStatus) = monitorApplication(appId)
       if (yarnApplicationState == YarnApplicationState.FAILED ||
         finalApplicationStatus == FinalApplicationStatus.FAILED) {
-        throw new SparkException("Application finished with failed status")
+        throw new SparkException(s"Application $appId finished with failed status")
       }
       if (yarnApplicationState == YarnApplicationState.KILLED ||
         finalApplicationStatus == FinalApplicationStatus.KILLED) {
-        throw new SparkException("Application is killed")
+        throw new SparkException(s"Application $appId is killed")
       }
       if (finalApplicationStatus == FinalApplicationStatus.UNDEFINED) {
-        throw new SparkException("The final status of application is undefined")
+        throw new SparkException(s"The final status of application $appId is undefined")
       }
     }
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-3591

The output after this patch:

> doggie153:/opt/oss/spark-1.3.0-bin-hadoop2.4/bin # ./spark-submit  --class org.apache.spark.examples.SparkPi --master yarn-cluster ../lib/spark-examples*.jar
> 15/03/31 21:15:25 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
> 15/03/31 21:15:25 INFO RMProxy: Connecting to ResourceManager at doggie153/10.177.112.153:8032
> 15/03/31 21:15:25 INFO Client: Requesting a new application from cluster with 4 NodeManagers
> 15/03/31 21:15:25 INFO Client: Verifying our application has not requested more than the maximum memory capability of the cluster (8192 MB per container)
> 15/03/31 21:15:25 INFO Client: Will allocate AM container, with 896 MB memory including 384 MB overhead
> 15/03/31 21:15:25 INFO Client: Setting up container launch context for our AM
> 15/03/31 21:15:25 INFO Client: Preparing resources for our AM container
> 15/03/31 21:15:26 INFO Client: Uploading resource file:/opt/oss/spark-1.3.0-bin-hadoop2.4/lib/spark-assembly-1.4.0-SNAPSHOT-hadoop2.4.1.jar -> hdfs://doggie153:9000/user/root/.sparkStaging/application_1427257505534_0016/spark-assembly-1.4.0-SNAPSHOT-hadoop2.4.1.jar
> 15/03/31 21:15:27 INFO Client: Uploading resource file:/opt/oss/spark-1.3.0-bin-hadoop2.4/lib/spark-examples-1.3.0-hadoop2.4.0.jar -> hdfs://doggie153:9000/user/root/.sparkStaging/application_1427257505534_0016/spark-examples-1.3.0-hadoop2.4.0.jar
> 15/03/31 21:15:28 INFO Client: Setting up the launch environment for our AM container
> 15/03/31 21:15:28 INFO SecurityManager: Changing view acls to: root
> 15/03/31 21:15:28 INFO SecurityManager: Changing modify acls to: root
> 15/03/31 21:15:28 INFO SecurityManager: SecurityManager: authentication disabled; ui acls disabled; users with view permissions: Set(root); users with modify permissions: Set(root)
> 15/03/31 21:15:28 INFO Client: Submitting application 16 to ResourceManager
> 15/03/31 21:15:28 INFO YarnClientImpl: Submitted application application_1427257505534_0016
> 15/03/31 21:15:28 INFO Client: ... waiting before polling ResourceManager for application state
> 15/03/31 21:15:33 INFO Client: ... polling ResourceManager for application state
> 15/03/31 21:15:33 INFO Client: Application report for application_1427257505534_0016 (state: RUNNING)
> 15/03/31 21:15:33 INFO Client: 
>          client token: N/A
>          diagnostics: N/A
>          ApplicationMaster host: doggie157
>          ApplicationMaster RPC port: 0
>          queue: default
>          start time: 1427807728307
>          final status: UNDEFINED
>          tracking URL: http://doggie153:8088/proxy/application_1427257505534_0016/
>          user: root

/cc @andrewor14
