### PR TITLE
[SPARK-6617][MLLib] Word2Vec is nondeterministic

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/Word2Vec.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/Word2Vec.scala
@@ -288,7 +288,15 @@ class Word2Vec extends Serializable with Logging {
       }
     }
     
-    val newSentences = sentences.repartition(numPartitions).cache()
+    // Use sortBy to repartition and get a predictably sorted RDD.
+    val newSentences = sentences.sortBy( arr => {
+      if(arr.length > 0) {
+        arr(0)
+      } else {
+        ""
+      }
+    }, true, numPartitions).cache()
+    
     val initRandom = new XORShiftRandom(seed)
 
     if (vocabSize.toLong * vectorSize * 8 >= Int.MaxValue) {


### PR DESCRIPTION
I've replaced repartition with a call to sortBy which will generate a sorted RDD. Subsequent usage of that RDD uses mapPartitions which won't affect ordering. 
