### PR TITLE
[SPARK-4346][SPARK-3596][YARN] Commonize the monitor logic

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -40,7 +40,6 @@ import org.apache.hadoop.yarn.api.protocolrecords._
 import org.apache.hadoop.yarn.api.records._
 import org.apache.hadoop.yarn.client.api.{YarnClient, YarnClientApplication}
 import org.apache.hadoop.yarn.conf.YarnConfiguration
-import org.apache.hadoop.yarn.exceptions.ApplicationNotFoundException
 import org.apache.hadoop.yarn.util.Records
 
 import org.apache.spark.{Logging, SecurityManager, SparkConf, SparkContext, SparkException}
@@ -560,56 +559,51 @@ private[spark] class Client(
     var lastState: YarnApplicationState = null
     while (true) {
       Thread.sleep(interval)
-      try {
-        val report = getApplicationReport(appId)
-        val state = report.getYarnApplicationState
+      val report = getApplicationReport(appId)
+      val state = report.getYarnApplicationState
 
-        if (logApplicationReport) {
-          logInfo(s"Application report for $appId (state: $state)")
-          val details = Seq[(String, String)](
-            ("client token", getClientToken(report)),
-            ("diagnostics", report.getDiagnostics),
-            ("ApplicationMaster host", report.getHost),
-            ("ApplicationMaster RPC port", report.getRpcPort.toString),
-            ("queue", report.getQueue),
-            ("start time", report.getStartTime.toString),
-            ("final status", report.getFinalApplicationStatus.toString),
-            ("tracking URL", report.getTrackingUrl),
-            ("user", report.getUser)
-          )
+      if (logApplicationReport) {
+        logInfo(s"Application report for $appId (state: $state)")
+        val details = Seq[(String, String)](
+          ("client token", getClientToken(report)),
+          ("diagnostics", report.getDiagnostics),
+          ("ApplicationMaster host", report.getHost),
+          ("ApplicationMaster RPC port", report.getRpcPort.toString),
+          ("queue", report.getQueue),
+          ("start time", report.getStartTime.toString),
+          ("final status", report.getFinalApplicationStatus.toString),
+          ("tracking URL", report.getTrackingUrl),
+          ("user", report.getUser)
+        )
 
-          // Use more loggable format if value is null or empty
-          val formattedDetails = details
-            .map { case (k, v) =>
-            val newValue = Option(v).filter(_.nonEmpty).getOrElse("N/A")
-            s"\n\t $k: $newValue" }
-            .mkString("")
-
-          // If DEBUG is enabled, log report details every iteration
-          // Otherwise, log them every time the application changes state
-          if (log.isDebugEnabled) {
-            logDebug(formattedDetails)
-          } else if (lastState != state) {
-            logInfo(formattedDetails)
-          }
+        // Use more loggable format if value is null or empty
+        val formattedDetails = details
+          .map { case (k, v) =>
+          val newValue = Option(v).filter(_.nonEmpty).getOrElse("N/A")
+          s"\n\t $k: $newValue"
         }
+          .mkString("")
 
-        if (state == YarnApplicationState.FINISHED ||
-          state == YarnApplicationState.FAILED ||
-          state == YarnApplicationState.KILLED) {
-          return (state, report.getFinalApplicationStatus)
+        // If DEBUG is enabled, log report details every iteration
+        // Otherwise, log them every time the application changes state
+        if (log.isDebugEnabled) {
+          logDebug(formattedDetails)
+        } else if (lastState != state) {
+          logInfo(formattedDetails)
         }
-
-        if (returnOnRunning && state == YarnApplicationState.RUNNING) {
-          return (state, report.getFinalApplicationStatus)
-        }
-
-        lastState = state
-      } catch {
-        case e: ApplicationNotFoundException =>
-          logError(s"Application $appId not found.")
-          return (YarnApplicationState.KILLED, FinalApplicationStatus.KILLED)
       }
+
+      if (state == YarnApplicationState.FINISHED ||
+        state == YarnApplicationState.FAILED ||
+        state == YarnApplicationState.KILLED) {
+        return (state, report.getFinalApplicationStatus)
+      }
+
+      if (returnOnRunning && state == YarnApplicationState.RUNNING) {
+        return (state, report.getFinalApplicationStatus)
+      }
+
+      lastState = state
     }
 
     // Never reached, but keeps compiler happy
@@ -816,9 +810,7 @@ object Client extends Logging {
       }
     }
     addFileToClasspath(new URI(sparkJar(sparkConf)), SPARK_JAR, env)
-    if (sparkConf.getBoolean("spark.yarn.includeClusterHadoopClasspath", true)) {
-      populateHadoopClasspath(conf, env)
-    }
+    populateHadoopClasspath(conf, env)
     sys.env.get(ENV_DIST_CLASSPATH).foreach(addClasspathEntry(_, env))
   }
 

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -40,6 +40,7 @@ import org.apache.hadoop.yarn.api.protocolrecords._
 import org.apache.hadoop.yarn.api.records._
 import org.apache.hadoop.yarn.client.api.{YarnClient, YarnClientApplication}
 import org.apache.hadoop.yarn.conf.YarnConfiguration
+import org.apache.hadoop.yarn.exceptions.ApplicationNotFoundException
 import org.apache.hadoop.yarn.util.Records
 
 import org.apache.spark.{Logging, SecurityManager, SparkConf, SparkContext, SparkException}
@@ -559,7 +560,14 @@ private[spark] class Client(
     var lastState: YarnApplicationState = null
     while (true) {
       Thread.sleep(interval)
-      val report = getApplicationReport(appId)
+      val report: ApplicationReport =
+        try {
+          getApplicationReport(appId)
+        } catch {
+          case e: ApplicationNotFoundException =>
+            logError(s"Application $appId not found.")
+            return (YarnApplicationState.KILLED, FinalApplicationStatus.KILLED)
+        }
       val state = report.getYarnApplicationState
 
       if (logApplicationReport) {

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -816,9 +816,7 @@ object Client extends Logging {
       }
     }
     addFileToClasspath(new URI(sparkJar(sparkConf)), SPARK_JAR, env)
-    if (sparkConf.getBoolean("spark.yarn.includeClusterHadoopClasspath", true)) {
-      populateHadoopClasspath(conf, env)
-    }
+    populateHadoopClasspath(conf, env)
     sys.env.get(ENV_DIST_CLASSPATH).foreach(addClasspathEntry(_, env))
   }
 

--- a/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
+++ b/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
@@ -127,15 +127,11 @@ private[spark] class YarnClientSchedulerBackend(
     assert(client != null && appId != null, "Application has not been submitted yet!")
     val t = new Thread {
       override def run() {
-        while (!stopping) {
-          val (state, _) = client.monitorApplication(appId, logApplicationReport = false)
-          if (state == YarnApplicationState.FINISHED ||
-            state == YarnApplicationState.KILLED ||
-            state == YarnApplicationState.FAILED) {
-            logError(s"Yarn application has already exited with state $state!")
-            sc.stop()
-            stopping = true
-          }
+        val (state, _) = client.monitorApplication(appId, logApplicationReport = false)
+        if (!stopping) {
+          logError(s"Yarn application has already exited with state $state!")
+          sc.stop()
+          stopping = true
         }
         Thread.currentThread().interrupt()
       }

--- a/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
+++ b/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
@@ -128,14 +128,7 @@ private[spark] class YarnClientSchedulerBackend(
     val t = new Thread {
       override def run() {
         while (!stopping) {
-          var state: YarnApplicationState = null
-          try {
-            val report = client.getApplicationReport(appId)
-            state = report.getYarnApplicationState()
-          } catch {
-            case e: ApplicationNotFoundException =>
-              state = YarnApplicationState.KILLED
-          }
+          val (state, _) = client.monitorApplication(appId, logApplicationReport = false)
           if (state == YarnApplicationState.FINISHED ||
             state == YarnApplicationState.KILLED ||
             state == YarnApplicationState.FAILED) {
@@ -143,7 +136,6 @@ private[spark] class YarnClientSchedulerBackend(
             sc.stop()
             stopping = true
           }
-          Thread.sleep(1000L)
         }
         Thread.currentThread().interrupt()
       }


### PR DESCRIPTION
1. YarnClientSchedulerBack.asyncMonitorApplication use Client.monitorApplication so that commonize the monitor logic
2. Support changing the yarn client monitor interval, see #5292
3. More details see discussion on https://github.com/apache/spark/pull/3143
