### PR TITLE
[SPARK-6667] [PySpark] remove setReuseAddress

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -605,7 +605,6 @@ private[spark] object PythonRDD extends Logging {
    */
   private def serveIterator[T](items: Iterator[T], threadName: String): Int = {
     val serverSocket = new ServerSocket(0, 1)
-    serverSocket.setReuseAddress(true)
     // Close the socket if no connection in 3 seconds
     serverSocket.setSoTimeout(3000)
 

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -613,16 +613,7 @@ private[spark] object PythonRDD extends Logging {
       setDaemon(true)
       override def run() {
         try {
-          var sock: Socket = null
-          try {
-            sock = serverSocket.accept()
-          } catch {
-            case e: SocketTimeoutException =>
-              // there is a small chance that the client had connected, so retry
-              logWarning("Timed out after 4 seconds, retry once")
-              serverSocket.setSoTimeout(10)
-              sock = serverSocket.accept()
-          }
+          val sock = serverSocket.accept()
           val out = new DataOutputStream(new BufferedOutputStream(sock.getOutputStream))
           try {
             writeIteratorToStream(items, out)

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -613,7 +613,16 @@ private[spark] object PythonRDD extends Logging {
       setDaemon(true)
       override def run() {
         try {
-          val sock = serverSocket.accept()
+          var sock: Socket = null
+          try {
+            sock = serverSocket.accept()
+          } catch {
+            case e: SocketTimeoutException =>
+              // there is a small chance that the client had connected, so retry
+              logWarning("Timed out after 4 seconds, retry once")
+              serverSocket.setSoTimeout(10)
+              sock = serverSocket.accept()
+          }
           val out = new DataOutputStream(new BufferedOutputStream(sock.getOutputStream))
           try {
             writeIteratorToStream(items, out)

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -113,6 +113,7 @@ def _parse_memory(s):
 
 def _load_from_socket(port, serializer):
     sock = socket.socket()
+    sock.settimeout(5)
     try:
         sock.connect(("localhost", port))
         rf = sock.makefile("rb", 65536)

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -113,23 +113,11 @@ def _parse_memory(s):
 
 def _load_from_socket(port, serializer):
     sock = socket.socket()
-    sock.settimeout(1)
+    sock.settimeout(3)
     try:
         sock.connect(("localhost", port))
         rf = sock.makefile("rb", 65536)
-        iter = serializer.load_stream(rf)
-        try:
-            yield next(iter)
-        except socket.timeout as e:
-            # the connection is not acknowledged by JVM, retry
-            # server will be closed after 3 seconds, then it will be refused
-            for v in _load_from_socket(port, serializer):
-                yield v
-            return
-
-        # increase the timeout, because the server side may be slowed down by GC
-        sock.settimeout(10)
-        for item in iter:
+        for item in serializer.load_stream(rf):
             yield item
     finally:
         sock.close()


### PR DESCRIPTION
The reused address on server side had caused the server can not acknowledge the connected connections, remove it.

This PR will retry once after timeout, it also add a timeout at client side.
