### PR TITLE
[SPARK-3862] [SQL] [WIP] MultiWayBroadcastJoin for LeftSemi & Inner JOIN

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/collection/CompactBuffer.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/CompactBuffer.scala
@@ -51,7 +51,7 @@ private[spark] class CompactBuffer[T: ClassTag] extends Seq[T] with Serializable
     }
   }
 
-  private def update(position: Int, value: T): Unit = {
+  def update(position: Int, value: T): Unit = {
     if (position < 0 || position >= curSize) {
       throw new IndexOutOfBoundsException
     }
@@ -152,6 +152,20 @@ private[spark] class CompactBuffer[T: ClassTag] extends Seq[T] with Serializable
 }
 
 private[spark] object CompactBuffer {
+  def constantEmpty[T: ClassTag](): CompactBuffer[T] = new CompactBuffer[T] {
+    override def apply(position: Int): T =
+      sys.error("apply() is not valid for a constant empty buffer")
+
+    override def update(position: Int, value: T): Unit =
+      sys.error("update() is not valid for a constant empty buffer")
+
+    override def += (value: T): CompactBuffer[T] =
+      sys.error("+= is not valid for a constant empty buffer")
+
+    override def ++= (values: TraversableOnce[T]): CompactBuffer[T] =
+      sys.error("++= is not valid for a constant empty")
+  }
+
   def apply[T: ClassTag](): CompactBuffer[T] = new CompactBuffer[T]
 
   def apply[T: ClassTag](value: T): CompactBuffer[T] = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -184,7 +184,6 @@ object PartialAggregation {
   }
 }
 
-
 /**
  * A pattern that finds joins with equality conditions that can be evaluated using equi-join.
  */

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
@@ -61,6 +61,8 @@ private[spark] object SQLConf {
   // Set to false when debugging requires the ability to look at invalid query plans.
   val DATAFRAME_EAGER_ANALYSIS = "spark.sql.eagerAnalysis"
 
+  val MULTIWAY_JOIN = "spark.sql.multiway_join"
+
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"
   }
@@ -189,6 +191,12 @@ private[sql] class SQLConf extends Serializable {
 
   private[spark] def dataFrameEagerAnalysis: Boolean =
     getConf(DATAFRAME_EAGER_ANALYSIS, "true").toBoolean
+
+  /**
+   * Enable the multi-way join in optimization, false by default
+   */
+  private[spark] def multiwayJoin: Boolean =
+    getConf(MULTIWAY_JOIN, "false").toBoolean
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
@@ -193,10 +193,10 @@ private[sql] class SQLConf extends Serializable {
     getConf(DATAFRAME_EAGER_ANALYSIS, "true").toBoolean
 
   /**
-   * Enable the multi-way join in optimization, false by default
+   * Enable the multi-way join in optimization, true by default
    */
   private[spark] def multiwayJoin: Boolean =
-    getConf(MULTIWAY_JOIN, "false").toBoolean
+    getConf(MULTIWAY_JOIN, "true").toBoolean
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -1016,6 +1016,7 @@ class SQLContext(@transient val sparkContext: SparkContext)
       DDLStrategy ::
       TakeOrdered ::
       HashAggregation ::
+      MultiwayJoin ::
       LeftSemiJoin ::
       HashJoin ::
       InMemoryScans ::

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -17,12 +17,14 @@
 
 package org.apache.spark.sql.execution
 
+import org.apache.spark.Logging
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.planning._
 import org.apache.spark.sql.catalyst.plans._
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical.{Join, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.columnar.{InMemoryColumnarTableScan, InMemoryRelation}
+import org.apache.spark.sql.execution.joins._
 import org.apache.spark.sql.execution.{DescribeCommand => RunnableDescribeCommand}
 import org.apache.spark.sql.parquet._
 import org.apache.spark.sql.sources.{CreateTableUsing, CreateTempTableUsing, DescribeCommand => LogicalDescribeCommand, _}
@@ -31,6 +33,73 @@ import org.apache.spark.sql.{SQLContext, Strategy, execution}
 
 private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
   self: SQLContext#SparkPlanner =>
+
+
+  /**
+   * Flat the binary joins as multi-way join, the original binary join tree should be left/right deep,
+   * we don't support the bushy join in this rule.
+   * TODO we probably can support the right deep join, but we need to get the join reordering involved.
+   */
+  object FlatMultiJoin extends Logging {
+    /** (build sides in join, join keys, join filters, multiple joins, index of the child node in the join, join keys of the streaming tables) */
+    type ReturnType = (MultiBuild, Seq[JoinKey], Seq[JoinFilter], Seq[LogicalPlan], Int, Set[Seq[Expression]])
+
+    def unapply(plan: LogicalPlan): Option[ReturnType] = plan match {
+      case ExtractEquiJoinKeys(joinType, leftKeys, rightKeys, condition, left, right) =>
+        // TODO we currently always assume the left side is fact relation, will add the join reordering later.
+        // left deep join
+        def extractMultiJoin(p: LogicalPlan): ReturnType = {
+          val tmp = unapply(p)
+          tmp match {
+            case Some((build, joinKeys, filters, plans, index, equiKeys))
+              if canBuildRelation(right) && (joinType == Inner || joinType == LeftSemi) =>
+              // for broadcast join, we only support the inner join & left semi join
+              build.add(index + 1)
+              (build, joinKeys :+ JoinKey(leftKeys, rightKeys), filters :+ JoinFilter(joinType, condition.getOrElse(Literal(true))), plans :+ right, index + 1, equiKeys)
+            case Some((build, joinKeys, filters, plans, index, equiKeys))
+              if equiKeys.contains(leftKeys) =>
+              // if it's the equi-join with the same join keys
+              (build, joinKeys :+ JoinKey(leftKeys, rightKeys), filters :+ JoinFilter(joinType, condition.getOrElse(Literal(true))), plans :+ right, index + 1, equiKeys + rightKeys)
+            case _ if canBuildRelation(right) && (joinType == Inner || joinType == LeftSemi) =>
+              // bottom of this join tree, and its right side is the dimensional relation
+              val build = new MultiBuild
+              build.add(1)
+              (build, JoinKey(leftKeys, rightKeys) :: Nil, JoinFilter(joinType, condition.getOrElse(Literal(true))) :: Nil, left :: right :: Nil, 1, Set(Seq.empty[Expression]))
+            case _ =>
+              // bottom of this join tree
+              (new MultiBuild, JoinKey(leftKeys, rightKeys) :: Nil, JoinFilter(joinType, condition.getOrElse(Literal(true))) :: Nil, left :: right :: Nil, 1, Set(leftKeys, rightKeys))
+          }
+        }
+
+        left match {
+          case logical.Project(_, p: Join) => Some(extractMultiJoin(p)) // ignore the Project node on top of the Join node
+          case _ => Some(extractMultiJoin(left))
+        }
+
+      case _ => None
+    }
+
+    /**
+     * To detect if the node can be built as an in-memory collection
+     */
+    def canBuildRelation(plan: LogicalPlan): Boolean = {
+      val d = plan.statistics.sizeInBytes <= sqlContext.conf.autoBroadcastJoinThreshold
+      d
+    }
+  }
+
+  object MultiwayJoin extends Strategy with PredicateHelper {
+    def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
+      case FlatMultiJoin(build, joinKeys, joinFilters, children, _, _)
+          if (build.size() == children.size - 1) && // only a single fact relation exists
+            children.size > 2 && // more than 2 nodes in the join TODO can replace the binary join
+            build.contains(0) == false && // the left-most is the only fact relation
+            !joinFilters.exists(f => f.joinType != LeftSemi && f.joinType != Inner) => // only inner and left semi join supported
+        // only a single fact relation
+        DimensionJoin(joinKeys.toArray, joinFilters.toArray, children.map(child => planLater(child))) :: Nil
+      case _ => Nil
+    }
+  }
 
   object LeftSemiJoin extends Strategy with PredicateHelper {
     def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -21,7 +21,7 @@ import org.apache.spark.Logging
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.planning._
 import org.apache.spark.sql.catalyst.plans._
-import org.apache.spark.sql.catalyst.plans.logical.{Join, LogicalPlan, Project}
+import org.apache.spark.sql.catalyst.plans.logical.{Join, LogicalPlan}
 import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.columnar.{InMemoryColumnarTableScan, InMemoryRelation}
 import org.apache.spark.sql.execution.joins._
@@ -96,7 +96,7 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
             build.contains(0) == false && // the left-most is the only fact relation
             !joinFilters.exists(f => f.joinType != LeftSemi && f.joinType != Inner) => // only inner and left semi join supported
         // only a single fact relation
-        DimensionJoin(joinKeys.toArray, joinFilters.toArray, children.map(child => planLater(child))) :: Nil
+        DimensionJoin(joinKeys, joinFilters, children.map(child => planLater(child))) :: Nil
       case _ => Nil
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastMultiwayJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastMultiwayJoin.scala
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.joins
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent._
+import scala.concurrent.duration._
+
+import org.apache.spark.annotation.AlphaComponent
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans.physical.{Distribution, Partitioning, UnspecifiedDistribution}
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.util.collection.CompactBuffer
+
+/**
+ * :: DeveloperApi ::
+ * Performs an inner hash join for multi child relations.  When the output RDD of this operator is
+ * being constructed, a Spark job is asynchronously started to calculate the values for the
+ * broadcasted relation.  This data is then placed in a Spark broadcast variable.  The streamed
+ * relation is not shuffled.
+ *
+ */
+@AlphaComponent
+case class DimensionJoin(
+    keys: Array[JoinKey],
+    joinFilters: Array[JoinFilter],
+    children: Seq[SparkPlan])
+  extends SparkPlan with MultiwayJoin {
+
+  val timeout: Duration = {
+    val timeoutValue = sqlContext.conf.broadcastTimeout
+    if (timeoutValue < 0) {
+      Duration.Inf
+    } else {
+      timeoutValue.seconds
+    }
+  }
+
+  private def joinKey(tblIdx: Int): Seq[Expression] = {
+    if (tblIdx == 0) keys(0).leftKeys else keys(tblIdx - 1).rightkeys
+  }
+
+  private def streamPlan = children(0)
+
+  override def outputPartitioning: Partitioning = {
+    streamPlan.outputPartitioning
+  }
+
+  override def childrenOutputs: Seq[Seq[Attribute]] = children.map(_.output)
+
+  override def requiredChildDistribution: Seq[Distribution] = children.map(_ => UnspecifiedDistribution)
+
+  @transient protected lazy val keyGenerators: Array[Projection] =
+    Array.tabulate(children.size)(i => newProjection(joinKey(i), children(i).output))
+
+  @transient
+  private val broadcastFuture = future {
+    val hashed = children.zipWithIndex.map { case (buildPlan, index) =>
+      if (index == 0) {
+        // we put the null for stream side as place holder,
+        // so we will not break the index-based relation accessing
+        null: HashedRelation
+      } else {
+        // Note that we use .execute().collect() because we
+        // don't want to convert data to Scala types
+        val input: Array[Row] = buildPlan.execute().map(_.copy()).collect()
+        HashedRelation(input.iterator, keyGenerators(index), input.length)
+      }
+    }.toArray
+
+    sparkContext.broadcast(hashed)
+  }
+
+  override def execute(): RDD[Row] = {
+    val relationFuture = Await.result(broadcastFuture, timeout)
+
+    streamPlan.execute().mapPartitions { streamedIter =>
+      val relations = relationFuture.value
+
+      var iteratorBuilder: IteratorBufferBuilder = null
+      val builders = Array.tabulate[CompactBufferBuilder](children.size) { i =>
+        if (i == 0) {
+          iteratorBuilder = new IteratorBufferBuilder()
+          iteratorBuilder
+        } else {
+          val keyProjection = newProjection(keys(i - 1).leftKeys, output)
+          new CorrelatedBufferBuilder(newProjection(keys(i - 1).leftKeys, output), relations(i))
+        }
+      }
+
+      streamedIter.flatMap { row =>
+        iteratorBuilder.withIterator(row)
+        product(builders)
+      }
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastMultiwayJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastMultiwayJoin.scala
@@ -38,8 +38,8 @@ import org.apache.spark.util.collection.CompactBuffer
  */
 @AlphaComponent
 case class DimensionJoin(
-    keys: Array[JoinKey],
-    filters: Array[JoinFilter],
+    keys: Seq[JoinKey],
+    filters: Seq[JoinFilter],
     children: Seq[SparkPlan])
   extends SparkPlan with MultiwayJoin {
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastMultiwayJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastMultiwayJoin.scala
@@ -38,8 +38,8 @@ import org.apache.spark.util.collection.CompactBuffer
  */
 @AlphaComponent
 case class DimensionJoin(
-    keys: Seq[JoinKey],
-    filters: Seq[JoinFilter],
+    keys: Array[JoinKey],
+    filters: Array[JoinFilter],
     children: Seq[SparkPlan])
   extends SparkPlan with MultiwayJoin {
 
@@ -58,11 +58,11 @@ case class DimensionJoin(
   }
 
   private def joinKey(tblIdx: Int): Seq[Expression] = {
-    if (tblIdx == 0) keys(0).leftKeys else keys(tblIdx - 1).rightkeys
+    if (tblIdx == 0) keys(0).leftKeys else keys(tblIdx - 1).rightKeys
   }
 
   private def correlatedJoinKey(tblIdx: Int): Seq[Expression] = {
-    if (tblIdx == 0) keys(0).rightkeys else keys(tblIdx - 1).leftKeys
+    if (tblIdx == 0) keys(0).rightKeys else keys(tblIdx - 1).leftKeys
   }
 
   private def streamPlan = children(0)
@@ -73,7 +73,7 @@ case class DimensionJoin(
 
   override def childrenOutputs: Seq[Seq[Attribute]] = children.map(_.output)
 
-  override def requiredChildDistribution: Seq[Distribution] = children.map(_ => UnspecifiedDistribution)
+  override def requiredChildDistribution = children.map(_ => UnspecifiedDistribution)
 
   @transient protected lazy val keyGenerators: Array[Projection] =
     Array.tabulate(children.size)(i => newProjection(joinKey(i), children(i).output))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
@@ -81,17 +81,17 @@ trait HashJoin {
        *         tuples.
        */
       private final def fetchNext(): Boolean = {
-        currentHashMatches = null
+        currentHashMatches = CompactBuffer.constantEmpty[Row]()
         currentMatchPosition = -1
 
-        while (currentHashMatches == null && streamIter.hasNext) {
+        while (currentHashMatches.size == 0 && streamIter.hasNext) {
           currentStreamedRow = streamIter.next()
           if (!joinKeys(currentStreamedRow).anyNull) {
             currentHashMatches = hashedRelation.get(joinKeys.currentValue)
           }
         }
 
-        if (currentHashMatches == null) {
+        if (currentHashMatches.size == 0) {
           false
         } else {
           currentMatchPosition = 0

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
@@ -81,17 +81,17 @@ trait HashJoin {
        *         tuples.
        */
       private final def fetchNext(): Boolean = {
-        currentHashMatches = CompactBuffer.constantEmpty[Row]()
+        currentHashMatches = null
         currentMatchPosition = -1
 
-        while (currentHashMatches.size == 0 && streamIter.hasNext) {
+        while (currentHashMatches == null && streamIter.hasNext) {
           currentStreamedRow = streamIter.next()
           if (!joinKeys(currentStreamedRow).anyNull) {
             currentHashMatches = hashedRelation.get(joinKeys.currentValue)
           }
         }
 
-        if (currentHashMatches.size == 0) {
+        if (currentHashMatches == null) {
           false
         } else {
           currentMatchPosition = 0

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/MultiwayJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/MultiwayJoin.scala
@@ -1,0 +1,354 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.apache.spark.sql.execution.joins
+
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.planning.JoinFilter
+import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.util.collection.BitSet
+
+/**
+ * A mutable wrapper that makes multiple rows appear as a single concatenated row.  Designed to
+ * be instantiated once per thread and reused.
+ */
+private[sql] class MultiJoinedRow(colNums: Int*) extends Row {
+  assert(colNums.length >= 2)
+
+  private[this] val cache = new Array[Row](colNums.length)
+
+  private[this] val mapping = {
+    val array = new Array[(Int, Int)](colNums.sum)
+
+    var tblIdx = 0
+    var passed = 0
+    for (i <- 0 until array.length) {
+      if (i >= passed + colNums(tblIdx)) {
+        passed += colNums(tblIdx)
+        tblIdx += 1
+      }
+      array(i) = (tblIdx, i - passed)
+    }
+
+    array
+  }
+
+  final def withNewTable(idx: Int, row: Row): MultiJoinedRow = {
+    // TODO check the columns count of the row, must equals to associated colNums
+    // assert(row == null || row.length == colNums(idx))
+    cache(idx) = row
+
+    this
+  }
+
+  final def clearTable(idx: Int): MultiJoinedRow = {
+    cache(idx) = null
+    this
+  }
+
+  override def toSeq: Seq[Any] = cache.map(_.toSeq).reduce(_ ++ _)
+
+  override def length = mapping.length
+
+  private def index(pos: Int) = mapping(pos)
+
+  private def eval[T](pos: Int, fun: (Row, Int) => T): T = {
+    val idx = index(pos)
+    val row = cache(idx._1)
+
+    if (row == null) {
+      null.asInstanceOf[T]
+    } else {
+      fun(row, idx._2)
+    }
+  }
+
+  override def apply(i: Int) =
+    eval(i, (row: Row, pos: Int) => row(pos))
+
+  override def isNullAt(i: Int) =
+    eval(i, (row: Row, pos: Int) => row(pos)) == null
+
+  override def getInt(i: Int): Int =
+    eval(i, (row: Row, pos: Int) => row.getInt(pos))
+
+  override def getLong(i: Int): Long =
+    eval(i, (row: Row, pos: Int) => row.getLong(pos))
+
+  override def getDouble(i: Int): Double =
+    eval(i, (row: Row, pos: Int) => row.getDouble(pos))
+
+  override def getBoolean(i: Int): Boolean =
+    eval(i, (row: Row, pos: Int) => row.getBoolean(pos))
+
+  override def getShort(i: Int): Short =
+    eval(i, (row: Row, pos: Int) => row.getShort(pos))
+
+  override def getByte(i: Int): Byte =
+    eval(i, (row: Row, pos: Int) => row.getByte(pos))
+
+  override def getFloat(i: Int): Float =
+    eval(i, (row: Row, pos: Int) => row.getFloat(pos))
+
+  override def getString(i: Int): String =
+    eval(i, (row: Row, pos: Int) => row.getString(pos))
+
+  override def getAs[T](i: Int): T =
+    eval(i, (row: Row, pos: Int) => row.getAs[T](pos))
+
+  override def copy() = {
+    val copiedValues = new Array[Any](length)
+    var i = 0
+    while(i < length) {
+      copiedValues(i) = apply(i)
+      i += 1
+    }
+    new GenericRow(copiedValues)
+  }
+
+  override def toString() = {
+    // Make sure toString never throws NullPointerException.
+    if (cache eq null) {
+      "[ empty row ]"
+    } else {
+      cache.mkString("[", ",", "]")
+    }
+  }
+}
+
+trait MultiwayJoin {
+  def joinFilters: Array[JoinFilter]
+
+  def childrenOutputs: Seq[Seq[Attribute]]
+
+  @transient
+  lazy val output = childrenOutputs.reduce(_ ++ _)
+
+  @transient
+  val lengths = childrenOutputs.map(_.length).toArray
+
+  @transient
+  lazy val result = new GenericMutableRow(output.length)
+
+
+  @transient
+  private[this] val NULL_ROWS = Array.tabulate(childrenOutputs.length) { idx =>
+    Array(Row(Array.fill[Any](childrenOutputs(idx).length)(null): _*))
+  }
+
+  @transient
+  private[this] val EMPTY_ROW = Array.empty[Row]
+
+  // The output buffer array. The product function returns an iterator that will
+  // always return this outputBuffer. Downstream operations need to make sure
+  // they are just streaming through the output.
+  @transient
+  private[this] val inputBuffer = new MultiJoinedRow(childrenOutputs.map(_.length).toArray: _*)
+
+  @inline
+  private[this] final def joinFilter(row: MultiJoinedRow, pos: Int): Boolean = {
+    true == joinFilters(pos).filter.eval(row)
+  }
+
+  def product(bufs: Array[Array[Row]]): Iterator[MultiJoinedRow] = {
+    assert(bufs.length == joinFilters.length + 1)
+
+    var i = 0
+
+    var partial: Iterator[MultiJoinedRow] = createBase(bufs(i), i)
+    while (i < joinFilters.length) {
+      val joinCondition = joinFilters(i)
+      i += 1
+
+      partial = joinCondition.joinType match {
+        case Inner =>
+          if (bufs(i).size == 0) {
+            createBase(EMPTY_ROW, i)
+          } else {
+            product2(partial, bufs(i), i)
+          }
+
+        case FullOuter =>
+          if (partial.hasNext == false && bufs(i).size == 0) {
+            createBase(EMPTY_ROW, i)
+          } else if (partial.hasNext == false) {
+            product2(createBase(NULL_ROWS(i - 1), i - 1), bufs(i), i)
+          } else if (bufs(i).size == 0) {
+            product2(partial, NULL_ROWS(i), i)
+          } else {
+            product2FullOuterJoin(partial, bufs(i), i)
+          }
+        case LeftOuter =>
+          if (partial.hasNext == false) {
+            createBase(EMPTY_ROW, i)
+          } else if (bufs(i).size == 0) {
+            product2(partial, NULL_ROWS(i), i)
+          } else {
+            product2LeftOuterJoin(partial, bufs(i), i)
+          }
+
+        case RightOuter =>
+          if (bufs(i).size == 0) {
+            createBase(EMPTY_ROW, i)
+          } else if (partial.hasNext == false) {
+            product2(createBase(NULL_ROWS(i - 1), i - 1), bufs(i), i)
+          } else {
+            product2RightOuterJoin(partial, bufs(i), i)
+          }
+
+        case LeftSemi =>
+          // For semi join, we only need one element from the table on the right
+          // to verify a row exists.
+          if (partial.hasNext == false || bufs(i).size == 0) {
+            createBase(EMPTY_ROW, i)
+          } else {
+            product2LeftSemiJoin(partial, bufs(i), i)
+          }
+      }
+    }
+    partial
+  }
+
+  @inline
+  private def filter(iter: Iterator[MultiJoinedRow], pos: Int)
+  : Iterator[MultiJoinedRow] = {
+    var occurs = 1
+    iter.filter { e =>
+      // Per outer join semantic, on more than 1 null table value allowed, we need to filter out
+      // the entries from the iterator if it's failed in join filter testing (just keep 1)
+      val valid = joinFilter(e, pos - 1)
+      if (valid) {
+        true
+      } else {
+        occurs = occurs - 1
+        e.clearTable(pos)
+        // if first appearance
+        occurs >= 0
+      }
+    }
+  }
+
+  private[this] def product2(left: Iterator[MultiJoinedRow], right: Array[Row], pos: Int): Iterator[MultiJoinedRow] = {
+    (for (l <- left; r <- right.iterator) yield {
+      l.withNewTable(pos, r)
+    }).filter(joinFilter(_, pos - 1))
+  }
+
+  private[this] def product2FullOuterJoin(left: Iterator[MultiJoinedRow], right: Array[Row], pos: Int): Iterator[MultiJoinedRow] =
+  {
+    val bs = new BitSet(right.length)
+    var needReset = true
+
+    var idxOuter = -1
+
+    (left.flatMap { l =>
+      var idxInner = -1
+      val r = right.iterator.map { r =>
+        l.withNewTable(pos, r)
+      }.filter { e =>
+        idxInner += 1
+        val filter = joinFilter(e, pos - 1)
+        if (filter) {
+          bs.set(idxInner)
+        }
+        filter
+      }
+      if (r.hasNext) r else Iterator(l.clearTable(pos))
+    }) ++ (right.iterator.filter { _ =>
+      // only take those unmatched entry
+      idxOuter += 1
+      val filter = !bs.get(idxOuter)
+      if (filter && needReset) {
+        // only reset once
+        resetInputBuffer(pos)
+        needReset = false
+      }
+
+      filter
+    }).map(e => inputBuffer.withNewTable(pos, e))
+  }
+
+  private[this] def product2LeftOuterJoin(left: Iterator[MultiJoinedRow], right: Array[Row], pos: Int)
+  : Iterator[MultiJoinedRow] = {
+    left.flatMap { l =>
+      val r = right.iterator.map { r =>
+        l.withNewTable(pos, r)
+      }.filter(joinFilter(_, pos - 1))
+      if (r.hasNext) r else Iterator(l.clearTable(pos))
+    }
+  }
+
+  private[this] def product2LeftSemiJoin(left: Iterator[MultiJoinedRow], right: Array[Row], pos: Int)
+  : Iterator[MultiJoinedRow] = {
+    (left.filter { l =>
+      right.exists { r =>
+        joinFilter(l.withNewTable(pos, r), pos - 1)
+      }
+    }).map(_.clearTable(pos))
+  }
+
+  private[this] def product2RightOuterJoin(left: Iterator[MultiJoinedRow], right: Array[Row], pos: Int)
+  : Iterator[MultiJoinedRow] = {
+    val bs = new BitSet(right.length)
+    var needReset = true
+
+    var idxOuter = -1
+    (left.flatMap { l =>
+      var idxInner = -1
+      right.iterator.flatMap { r =>
+        idxInner += 1
+        if (joinFilter(l.withNewTable(pos, r), pos - 1)) {
+          bs.set(idxInner)
+          Iterator(l)
+        } else {
+          Iterator.empty
+        }
+      }
+    }) ++ (right.iterator.filter { _ =>
+      // only take those unmatched entry
+      idxOuter += 1
+      val filter = !bs.get(idxOuter)
+      if (filter && needReset) {
+        // only reset once
+        resetInputBuffer(pos)
+        needReset = false
+      }
+
+      filter
+    }).map(e => inputBuffer.withNewTable(pos, e))
+  }
+
+  @inline
+  private[this] def resetInputBuffer(pos: Int): MultiJoinedRow = {
+    var i = 0
+    while (i <= pos) {
+      // reset the buffer
+      inputBuffer.clearTable(i)
+      i += 1
+    }
+    inputBuffer
+  }
+
+  private[this] def createBase(left: Array[Row], pos: Int): Iterator[MultiJoinedRow] = {
+    resetInputBuffer(pos)
+
+    left.iterator.map { l =>
+      inputBuffer.withNewTable(pos, l)
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/MultiwayJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/MultiwayJoin.scala
@@ -209,7 +209,7 @@ class ConstantBufferBuilder(row: Row) extends CompactBufferBuilder {
 }
 
 trait MultiwayJoin {
-  def joinFilters: Array[JoinFilter]
+  def joinFilters: Seq[JoinFilter]
 
   def childrenOutputs: Seq[Seq[Attribute]]
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/package.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/package.scala
@@ -17,7 +17,9 @@
 
 package org.apache.spark.sql.execution
 
-import org.apache.spark.annotation.DeveloperApi
+import java.util.HashSet
+
+import org.apache.spark.annotation.{AlphaComponent, DeveloperApi}
 
 /**
  * :: DeveloperApi ::
@@ -26,7 +28,7 @@ import org.apache.spark.annotation.DeveloperApi
 package object joins {
 
   @DeveloperApi
-  sealed abstract class BuildSide
+  sealed trait BuildSide
 
   @DeveloperApi
   case object BuildRight extends BuildSide
@@ -34,4 +36,11 @@ package object joins {
   @DeveloperApi
   case object BuildLeft extends BuildSide
 
+  @AlphaComponent
+  class MultiBuild extends HashSet[Int] with BuildSide {
+    def this(indices: Seq[Int]) = {
+      this()
+      indices.foreach(index => this.add(index))
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -1100,7 +1100,7 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll {
     checkAnswer(sql("SELECT b[0].a FROM t ORDER BY c0.a"), Row(1))
   }
 
-  test("JOIN OPTIMIZATION START SCHEMA") {
+  test("JOIN OPTIMIZATION STAR SCHEMA") {
     Seq(1,2,3).map(i => (i, i.toString)).toDF("a", "b").registerTempTable("df")
 
     checkAnswer(
@@ -1127,21 +1127,27 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll {
     checkAnswer(
       sql(
         """
-          SELECT x.a, y.a, z.a FROM df x JOIN df y ON x.a = y.a AND y.a > 2 JOIN df z ON x.a = z.a AND z.a > 1
+          | SELECT x.a, y.a, z.a
+          | FROM df x JOIN df y ON x.a = y.a AND y.a > 2
+          | JOIN df z ON x.a = z.a AND z.a > 1
         """.stripMargin),
       Row(3, 3, 3) :: Nil)
 
     checkAnswer(
       sql(
         """
-          SELECT x.a, z.a FROM df x LEFT SEMI JOIN df y ON x.a = y.a AND y.a > 2 JOIN df z ON x.a = z.a AND z.a > 1
+          | SELECT x.a, z.a
+          | FROM df x LEFT SEMI JOIN df y ON x.a = y.a AND y.a > 2
+          | JOIN df z ON x.a = z.a AND z.a > 1
         """.stripMargin),
       Row(3, 3) :: Nil)
 
     checkAnswer(
       sql(
         """
-          SELECT x.a, z.a FROM df x LEFT SEMI JOIN df y ON x.a = y.a AND y.a > 1 JOIN df z ON x.a = z.a AND z.a > 1
+          | SELECT x.a, z.a
+          | FROM df x LEFT SEMI JOIN df y ON x.a = y.a AND y.a > 1
+          | JOIN df z ON x.a = z.a AND z.a > 1
         """.stripMargin),
       Row(2, 2) :: Row(3, 3) :: Nil)
   }
@@ -1175,21 +1181,27 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll {
     checkAnswer(
       sql(
         """
-          SELECT x.a, y.a, z.a FROM x JOIN y ON x.a = y.a AND y.a < 3 JOIN z ON x.a = z.a AND z.a > 1
+          | SELECT x.a, y.a, z.a
+          | FROM x JOIN y ON x.a = y.a AND y.a < 3
+          | JOIN z ON x.a = z.a AND z.a > 1
         """.stripMargin),
       Row(2, 2, 2) :: Nil)
 
     checkAnswer(
       sql(
         """
-          SELECT x.a, z.a FROM x LEFT SEMI JOIN y ON x.a = y.a AND x.a >= 2 JOIN z ON x.a = z.a AND z.a > 1
+          | SELECT x.a, z.a
+          | FROM x LEFT SEMI JOIN y ON x.a = y.a AND x.a >= 2
+          | JOIN z ON x.a = z.a AND z.a > 1
         """.stripMargin),
       Row(2, 2) :: Nil)
 
     checkAnswer(
       sql(
         """
-          SELECT x.a, z.a FROM x LEFT SEMI JOIN y ON x.a = y.a AND y.a > 1 JOIN z ON x.a = z.a AND z.a > 1
+          | SELECT x.a, z.a
+          | FROM x LEFT SEMI JOIN y ON x.a = y.a AND y.a > 1
+          | JOIN z ON x.a = z.a AND z.a > 1
         """.stripMargin),
       Row(2, 2) :: Nil)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/HashedRelationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/HashedRelationSuite.scala
@@ -37,7 +37,7 @@ class HashedRelationSuite extends FunSuite {
 
     assert(hashed.get(data(0)) == CompactBuffer[Row](data(0)))
     assert(hashed.get(data(1)) == CompactBuffer[Row](data(1)))
-    assert(hashed.get(Row(10)) === null)
+    assert(hashed.get(Row(10)).size === 0)
 
     val data2 = CompactBuffer[Row](data(2))
     data2 += data(2)
@@ -52,12 +52,12 @@ class HashedRelationSuite extends FunSuite {
     assert(hashed.get(data(0)) == CompactBuffer[Row](data(0)))
     assert(hashed.get(data(1)) == CompactBuffer[Row](data(1)))
     assert(hashed.get(data(2)) == CompactBuffer[Row](data(2)))
-    assert(hashed.get(Row(10)) === null)
+    assert(hashed.get(Row(10)).size === 0)
 
     val uniqHashed = hashed.asInstanceOf[UniqueKeyHashedRelation]
     assert(uniqHashed.getValue(data(0)) == data(0))
     assert(uniqHashed.getValue(data(1)) == data(1))
     assert(uniqHashed.getValue(data(2)) == data(2))
-    assert(uniqHashed.getValue(Row(10)) == null)
+    assert(uniqHashed.getValue(Row(10)).size === 0)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/HashedRelationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/HashedRelationSuite.scala
@@ -37,7 +37,7 @@ class HashedRelationSuite extends FunSuite {
 
     assert(hashed.get(data(0)) == CompactBuffer[Row](data(0)))
     assert(hashed.get(data(1)) == CompactBuffer[Row](data(1)))
-    assert(hashed.get(Row(10)).size === 0)
+    assert(hashed.get(Row(10)) === null)
 
     val data2 = CompactBuffer[Row](data(2))
     data2 += data(2)
@@ -52,12 +52,12 @@ class HashedRelationSuite extends FunSuite {
     assert(hashed.get(data(0)) == CompactBuffer[Row](data(0)))
     assert(hashed.get(data(1)) == CompactBuffer[Row](data(1)))
     assert(hashed.get(data(2)) == CompactBuffer[Row](data(2)))
-    assert(hashed.get(Row(10)).size === 0)
+    assert(hashed.get(Row(10)) === null)
 
     val uniqHashed = hashed.asInstanceOf[UniqueKeyHashedRelation]
     assert(uniqHashed.getValue(data(0)) == data(0))
     assert(uniqHashed.getValue(data(1)) == data(1))
     assert(uniqHashed.getValue(data(2)) == data(2))
-    assert(uniqHashed.getValue(Row(10)).size === 0)
+    assert(uniqHashed.getValue(Row(10)) === null)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/MultiWayJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/MultiWayJoinSuite.scala
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.joins
+
+import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.types.IntegerType
+import org.scalatest.FunSuite
+
+import org.apache.spark.sql.catalyst.expressions._
+
+abstract class TestMultiwayJoin extends MultiwayJoin {
+  override def childrenOutputs: Seq[Seq[Attribute]] =
+    Seq(
+      Seq(AttributeReference("a", IntegerType)(), AttributeReference("b", IntegerType)()),
+      Seq(AttributeReference("c", IntegerType)(), AttributeReference("d", IntegerType)()))
+}
+
+abstract class TestMultiwayJoin2 extends MultiwayJoin {
+  override def childrenOutputs: Seq[Seq[Attribute]] =
+    Seq(
+      Seq(AttributeReference("a", IntegerType)(), AttributeReference("b", IntegerType)()),
+      Seq(AttributeReference("c", IntegerType)(), AttributeReference("d", IntegerType)()),
+      Seq(AttributeReference("e", IntegerType)(), AttributeReference("f", IntegerType)()))
+}
+
+class MultiWayJoinSuite extends FunSuite {
+  val tables = Array(Array(Row(3, 5), Row(7, 10)), Array(Row(4, 4), Row(7, 7)))
+  val tables2 = Array(Array(Row(3, 5), Row(7, 10)), Array(Row(4, 4), Row(7, 7)), Array(Row(1,1), Row(8, 8)))
+
+  test("With Multiple Input Row") {
+    val row1 = new MultiJoinedRow(2, 2)
+    val row2 = new MultiJoinedRow(1, 2)
+    val a = new GenericRow(Array[Any](1))
+    val b = new GenericRow(Array[Any]("1", "2"))
+    val c = new GenericRow(Array[Any]("3", 4))
+    row1.withNewTable(0, b).withNewTable(1, c)
+    row2.withNewTable(0, a).withNewTable(1, c)
+
+    assert("1" === row1(0))
+    assert("2" === row1(1))
+    assert("3" === row1(2))
+    assert(4 === row1(3))
+    assert("1" === row1.getString(0))
+    assert("2" === row1.getString(1))
+    assert("3" === row1.getString(2))
+    assert(4 === row1.getInt(3))
+
+    assert(Row("1", "2", "3", 4) === row1.copy())
+    assert(Row(1, "3", 4) === row2.copy())
+
+    assert(1 === row2(0))
+    assert("3" === row2(1))
+    assert(4 === row2(2))
+
+    assert(1 === row2.getInt(0))
+    assert("3" === row2.getString(1))
+    assert(4 === row2.getInt(2))
+
+    assert(false === row1.isNullAt(0))
+    assert(false === row1.isNullAt(1))
+    assert(false === row1.isNullAt(2))
+    row1.clearTable(0)
+    assert(true === row1.isNullAt(0))
+    assert(true === row1.isNullAt(1))
+    assert(false === row1.isNullAt(2))
+    assert(false === row1.isNullAt(3))
+  }
+
+  test("Test multiway join #1") {
+    val mwj = new TestMultiwayJoin() {
+      var joinFilters: Array[JoinFilter] = Array(
+        JoinFilter(Inner, GreaterThan(BoundReference(0, IntegerType, true), BoundReference(2, IntegerType, true))))
+    }
+    val results = mwj.product(tables).map(_.copy()).toArray
+    assert(1 === results.length)
+    assert(Row(7, 10, 4, 4) === results(0))
+  }
+
+  test("Test multiway join #2") {
+    val mwj = new TestMultiwayJoin() {
+      var joinFilters: Array[JoinFilter] = Array(
+        JoinFilter(LeftOuter, GreaterThan(BoundReference(0, IntegerType, true), Literal(3, IntegerType))))
+    }
+
+    val results = mwj.product(tables).map(_.copy()).toArray.sortWith(_.toString < _.toString)
+    assert(3 === results.length)
+    assert(Row(3, 5, null, null) === results(0))
+    assert(Row(7, 10, 4, 4) === results(1))
+    assert(Row(7, 10, 7, 7) === results(2))
+  }
+
+
+  test("Test multiway join #3") {
+    val mwj = new TestMultiwayJoin() {
+      var joinFilters: Array[JoinFilter] = Array(
+        JoinFilter(LeftOuter, GreaterThan(BoundReference(0, IntegerType, true), BoundReference(2, IntegerType, true))))
+    }
+
+    val results = mwj.product(tables).map(_.copy()).toArray.sortWith(_.toString < _.toString)
+    assert(2 === results.length)
+    assert(Row(3, 5, null, null) === results(0))
+    assert(Row(7, 10, 4, 4) === results(1))
+  }
+
+  test("Test multiway join #4") {
+    val mwj = new TestMultiwayJoin() {
+      var joinFilters: Array[JoinFilter] = Array(
+        JoinFilter(RightOuter, GreaterThan(BoundReference(0, IntegerType, true), Literal(5, IntegerType))))
+    }
+
+    val results = mwj.product(tables).map(_.copy()).toArray.sortWith(_.toString < _.toString)
+    assert(2 === results.length)
+    assert(Row(7, 10, 4, 4) === results(0))
+    assert(Row(7, 10, 7, 7) === results(1))
+  }
+
+  test("Test multiway join #5") {
+    val mwj = new TestMultiwayJoin() {
+      var joinFilters: Array[JoinFilter] = Array(
+        JoinFilter(RightOuter, GreaterThan(BoundReference(2, IntegerType, true), Literal(5, IntegerType))))
+    }
+
+    val results = mwj.product(tables).map(_.copy()).toArray.sortWith(_.toString < _.toString)
+    assert(3 === results.length)
+    assert(Row(3, 5, 7, 7) === results(0))
+    assert(Row(7, 10, 7, 7) === results(1))
+    assert(Row(null, null, 4, 4) === results(2))
+  }
+
+  test("Test multiway join #6") {
+    val mwj = new TestMultiwayJoin() {
+      var joinFilters: Array[JoinFilter] = Array(
+        JoinFilter(FullOuter, GreaterThan(BoundReference(0, IntegerType, true), Literal(5, IntegerType))))
+    }
+
+    val results = mwj.product(tables).map(_.copy()).toArray.sortWith(_.toString < _.toString)
+    assert(3 === results.length)
+    assert(Row(3, 5, null, null) === results(0))
+    assert(Row(7, 10, 4, 4) === results(1))
+    assert(Row(7, 10, 7, 7) === results(2))
+  }
+
+  test("Test multiway join #7") {
+    val mwj = new TestMultiwayJoin() {
+      var joinFilters: Array[JoinFilter] = Array(
+        JoinFilter(FullOuter, GreaterThan(BoundReference(2, IntegerType, true), Literal(5, IntegerType))))
+    }
+
+    val results = mwj.product(tables).map(_.copy()).toArray.sortWith(_.toString < _.toString)
+    assert(3 === results.length)
+    assert(Row(3, 5, 7, 7) === results(0))
+    assert(Row(7, 10, 7, 7) === results(1))
+    assert(Row(null, null, 4, 4) === results(2))
+  }
+
+  test("Test multiway join #8") {
+    val mwj = new TestMultiwayJoin() {
+      var joinFilters: Array[JoinFilter] = Array(
+        JoinFilter(LeftSemi, GreaterThan(BoundReference(2, IntegerType, true), Literal(5, IntegerType))))
+    }
+
+    val results = mwj.product(tables).map(_.copy()).toArray.sortWith(_.toString < _.toString)
+    assert(2 === results.length)
+    assert(Row(3, 5, null, null) === results(0))
+    assert(Row(7, 10, null, null) === results(1))
+  }
+
+  test("Test multiway join #9") {
+    val mwj = new TestMultiwayJoin() {
+      var joinFilters: Array[JoinFilter] = Array(
+        JoinFilter(LeftSemi, GreaterThan(BoundReference(0, IntegerType, true), Literal(5, IntegerType))))
+    }
+
+    val results = mwj.product(tables).map(_.copy()).toArray.sortWith(_.toString < _.toString)
+    assert(1 === results.length)
+    assert(Row(7, 10, null, null) === results(0))
+  }
+
+  test("Test multiway join #10") {
+    val mwj = new TestMultiwayJoin2() {
+      var joinFilters: Array[JoinFilter] = Array(
+        JoinFilter(LeftOuter, GreaterThan(BoundReference(0, IntegerType, true), Literal(5, IntegerType))),
+        JoinFilter(RightOuter, GreaterThan(BoundReference(4, IntegerType, true), Literal(5, IntegerType))))
+    }
+
+    val results = mwj.product(tables2).map(_.copy()).toArray.sortWith(_.toString < _.toString)
+    assert(4 === results.length)
+    assert(Row(3, 5, null, null, 8, 8) === results(0))
+    assert(Row(7, 10, 4, 4, 8, 8) === results(1))
+    assert(Row(7, 10, 7, 7, 8, 8) === results(2))
+    assert(Row(null, null, null, null, 1, 1) === results(3))
+  }
+
+  test("Test multiway join #11") {
+    val mwj = new TestMultiwayJoin2() {
+      var joinFilters: Array[JoinFilter] = Array(
+        JoinFilter(LeftOuter, GreaterThan(BoundReference(0, IntegerType, true), Literal(5, IntegerType))),
+        JoinFilter(RightOuter, GreaterThan(BoundReference(4, IntegerType, true), Literal(5, IntegerType))))
+    }
+
+    val results = mwj.product(tables2).map(_.copy()).toArray.sortWith(_.toString < _.toString)
+    assert(4 === results.length)
+    assert(Row(3, 5, null, null, 8, 8) === results(0))
+    assert(Row(7, 10, 4, 4, 8, 8) === results(1))
+    assert(Row(7, 10, 7, 7, 8, 8) === results(2))
+    assert(Row(null, null, null, null, 1, 1) === results(3))
+  }
+
+  test("Test multiway join #12") {
+    val mwj = new TestMultiwayJoin2() {
+      var joinFilters: Array[JoinFilter] = Array(
+        JoinFilter(LeftOuter, GreaterThan(BoundReference(0, IntegerType, true), BoundReference(2, IntegerType, true))),
+        JoinFilter(RightOuter, GreaterThan(BoundReference(2, IntegerType, true), BoundReference(4, IntegerType, true))))
+    }
+
+    val results = mwj.product(tables2).map(_.copy()).toArray.sortWith(_.toString < _.toString)
+    assert(2 === results.length)
+    assert(Row(7, 10, 4, 4, 1, 1) === results(0))
+    assert(Row(null, null, null, null, 8, 8) === results(1))
+  }
+}
+

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/MultiWayJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/MultiWayJoinSuite.scala
@@ -48,13 +48,15 @@ class MultiWayJoinSuite extends FunSuite {
   val tables = Array(
     CompactBuffer() += Row(3, 5) += Row(7, 10),
     CompactBuffer() += Row(4, 4) += Row(7, 7)).map { buffer =>
-    new HashedBufferBuilder(new TestHashedRelation(buffer)).withEquiJoinKey(null): CompactBufferBuilder
+    new HashedBufferBuilder(
+      new TestHashedRelation(buffer)).withEquiJoinKey(null): CompactBufferBuilder
   }
   val tables2 = Array(
     CompactBuffer() += Row(3, 5) += Row(7, 10),
     CompactBuffer() += Row(4, 4) += Row(7, 7),
     CompactBuffer() += Row(1, 1) += Row(8, 8)).map { buffer =>
-    new HashedBufferBuilder(new TestHashedRelation(buffer)).withEquiJoinKey(null): CompactBufferBuilder
+    new HashedBufferBuilder(
+      new TestHashedRelation(buffer)).withEquiJoinKey(null): CompactBufferBuilder
   }
 
   test("With Multiple Input Row") {
@@ -98,8 +100,10 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #1") {
     val mwj = new TestMultiwayJoin() {
-      var joinFilters: Seq[JoinFilter] = Seq(
-        JoinFilter(Inner, GreaterThan(BoundReference(0, IntegerType, true), BoundReference(2, IntegerType, true))))
+      var joinFilters = Array(
+        JoinFilter(
+          Inner,
+          GreaterThan(BoundReference(0, IntegerType, true), BoundReference(2, IntegerType, true))))
     }
     val results = mwj.product(tables).map(_.copy()).toArray
     assert(1 === results.length)
@@ -108,8 +112,10 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #2") {
     val mwj = new TestMultiwayJoin() {
-      var joinFilters: Seq[JoinFilter] = Seq(
-        JoinFilter(LeftOuter, GreaterThan(BoundReference(0, IntegerType, true), Literal(3, IntegerType))))
+      var joinFilters = Array(
+        JoinFilter(
+          LeftOuter,
+          GreaterThan(BoundReference(0, IntegerType, true), Literal(3, IntegerType))))
     }
 
     val results = mwj.product(tables).map(_.copy()).toArray.sortWith(_.toString < _.toString)
@@ -122,8 +128,10 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #3") {
     val mwj = new TestMultiwayJoin() {
-      var joinFilters: Seq[JoinFilter] = Array(
-        JoinFilter(LeftOuter, GreaterThan(BoundReference(0, IntegerType, true), BoundReference(2, IntegerType, true))))
+      var joinFilters = Array(
+        JoinFilter(
+          LeftOuter,
+          GreaterThan(BoundReference(0, IntegerType, true), BoundReference(2, IntegerType, true))))
     }
 
     val results = mwj.product(tables).map(_.copy()).toArray.sortWith(_.toString < _.toString)
@@ -134,8 +142,10 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #4") {
     val mwj = new TestMultiwayJoin() {
-      var joinFilters: Seq[JoinFilter] = Array(
-        JoinFilter(RightOuter, GreaterThan(BoundReference(0, IntegerType, true), Literal(5, IntegerType))))
+      var joinFilters = Array(
+        JoinFilter(
+          RightOuter,
+          GreaterThan(BoundReference(0, IntegerType, true), Literal(5, IntegerType))))
     }
 
     val results = mwj.product(tables).map(_.copy()).toArray.sortWith(_.toString < _.toString)
@@ -146,8 +156,10 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #5") {
     val mwj = new TestMultiwayJoin() {
-      var joinFilters: Seq[JoinFilter] = Array(
-        JoinFilter(RightOuter, GreaterThan(BoundReference(2, IntegerType, true), Literal(5, IntegerType))))
+      var joinFilters = Array(
+        JoinFilter(
+          RightOuter,
+          GreaterThan(BoundReference(2, IntegerType, true), Literal(5, IntegerType))))
     }
 
     val results = mwj.product(tables).map(_.copy()).toArray.sortWith(_.toString < _.toString)
@@ -159,8 +171,10 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #6") {
     val mwj = new TestMultiwayJoin() {
-      var joinFilters: Seq[JoinFilter] = Array(
-        JoinFilter(FullOuter, GreaterThan(BoundReference(0, IntegerType, true), Literal(5, IntegerType))))
+      var joinFilters = Array(
+        JoinFilter(
+          FullOuter,
+          GreaterThan(BoundReference(0, IntegerType, true), Literal(5, IntegerType))))
     }
 
     val results = mwj.product(tables).map(_.copy()).toArray.sortWith(_.toString < _.toString)
@@ -172,8 +186,10 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #7") {
     val mwj = new TestMultiwayJoin() {
-      var joinFilters: Seq[JoinFilter] = Array(
-        JoinFilter(FullOuter, GreaterThan(BoundReference(2, IntegerType, true), Literal(5, IntegerType))))
+      var joinFilters = Array(
+        JoinFilter(
+          FullOuter,
+          GreaterThan(BoundReference(2, IntegerType, true), Literal(5, IntegerType))))
     }
 
     val results = mwj.product(tables).map(_.copy()).toArray.sortWith(_.toString < _.toString)
@@ -185,8 +201,10 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #8") {
     val mwj = new TestMultiwayJoin() {
-      var joinFilters: Seq[JoinFilter] = Array(
-        JoinFilter(LeftSemi, GreaterThan(BoundReference(2, IntegerType, true), Literal(5, IntegerType))))
+      var joinFilters = Array(
+        JoinFilter(
+          LeftSemi,
+          GreaterThan(BoundReference(2, IntegerType, true), Literal(5, IntegerType))))
     }
 
     val results = mwj.product(tables).map(_.copy()).toArray.sortWith(_.toString < _.toString)
@@ -197,8 +215,10 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #9") {
     val mwj = new TestMultiwayJoin() {
-      var joinFilters: Seq[JoinFilter] = Array(
-        JoinFilter(LeftSemi, GreaterThan(BoundReference(0, IntegerType, true), Literal(5, IntegerType))))
+      var joinFilters = Array(
+        JoinFilter(
+          LeftSemi,
+          GreaterThan(BoundReference(0, IntegerType, true), Literal(5, IntegerType))))
     }
 
     val results = mwj.product(tables).map(_.copy()).toArray.sortWith(_.toString < _.toString)
@@ -208,9 +228,13 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #10") {
     val mwj = new TestMultiwayJoin2() {
-      var joinFilters: Seq[JoinFilter] = Array(
-        JoinFilter(LeftOuter, GreaterThan(BoundReference(0, IntegerType, true), Literal(5, IntegerType))),
-        JoinFilter(RightOuter, GreaterThan(BoundReference(4, IntegerType, true), Literal(5, IntegerType))))
+      var joinFilters = Array(
+        JoinFilter(
+          LeftOuter,
+          GreaterThan(BoundReference(0, IntegerType, true), Literal(5, IntegerType))),
+        JoinFilter(
+          RightOuter,
+          GreaterThan(BoundReference(4, IntegerType, true), Literal(5, IntegerType))))
     }
 
     val results = mwj.product(tables2).map(_.copy()).toArray.sortWith(_.toString < _.toString)
@@ -223,9 +247,13 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #11") {
     val mwj = new TestMultiwayJoin2() {
-      var joinFilters: Seq[JoinFilter] = Array(
-        JoinFilter(LeftOuter, GreaterThan(BoundReference(0, IntegerType, true), Literal(5, IntegerType))),
-        JoinFilter(RightOuter, GreaterThan(BoundReference(4, IntegerType, true), Literal(5, IntegerType))))
+      var joinFilters = Array(
+        JoinFilter(
+          LeftOuter,
+          GreaterThan(BoundReference(0, IntegerType, true), Literal(5, IntegerType))),
+        JoinFilter(
+          RightOuter,
+          GreaterThan(BoundReference(4, IntegerType, true), Literal(5, IntegerType))))
     }
 
     val results = mwj.product(tables2).map(_.copy()).toArray.sortWith(_.toString < _.toString)
@@ -238,9 +266,13 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #12") {
     val mwj = new TestMultiwayJoin2() {
-      var joinFilters: Seq[JoinFilter] = Array(
-        JoinFilter(LeftOuter, GreaterThan(BoundReference(0, IntegerType, true), BoundReference(2, IntegerType, true))),
-        JoinFilter(RightOuter, GreaterThan(BoundReference(2, IntegerType, true), BoundReference(4, IntegerType, true))))
+      var joinFilters = Array(
+        JoinFilter(
+          LeftOuter,
+          GreaterThan(BoundReference(0, IntegerType, true), BoundReference(2, IntegerType, true))),
+        JoinFilter(
+          RightOuter,
+          GreaterThan(BoundReference(2, IntegerType, true), BoundReference(4, IntegerType, true))))
     }
 
     val results = mwj.product(tables2).map(_.copy()).toArray.sortWith(_.toString < _.toString)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/MultiWayJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/MultiWayJoinSuite.scala
@@ -100,7 +100,7 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #1") {
     val mwj = new TestMultiwayJoin() {
-      var joinFilters = Array(
+      var joinFilters = Seq(
         JoinFilter(
           Inner,
           GreaterThan(BoundReference(0, IntegerType, true), BoundReference(2, IntegerType, true))))
@@ -112,7 +112,7 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #2") {
     val mwj = new TestMultiwayJoin() {
-      var joinFilters = Array(
+      var joinFilters = Seq(
         JoinFilter(
           LeftOuter,
           GreaterThan(BoundReference(0, IntegerType, true), Literal(3))))
@@ -128,7 +128,7 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #3") {
     val mwj = new TestMultiwayJoin() {
-      var joinFilters = Array(
+      var joinFilters = Seq(
         JoinFilter(
           LeftOuter,
           GreaterThan(BoundReference(0, IntegerType, true), BoundReference(2, IntegerType, true))))
@@ -142,7 +142,7 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #4") {
     val mwj = new TestMultiwayJoin() {
-      var joinFilters = Array(
+      var joinFilters = Seq(
         JoinFilter(
           RightOuter,
           GreaterThan(BoundReference(0, IntegerType, true), Literal(5))))
@@ -156,7 +156,7 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #5") {
     val mwj = new TestMultiwayJoin() {
-      var joinFilters = Array(
+      var joinFilters = Seq(
         JoinFilter(
           RightOuter,
           GreaterThan(BoundReference(2, IntegerType, true), Literal(5))))
@@ -171,7 +171,7 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #6") {
     val mwj = new TestMultiwayJoin() {
-      var joinFilters = Array(
+      var joinFilters = Seq(
         JoinFilter(
           FullOuter,
           GreaterThan(BoundReference(0, IntegerType, true), Literal(5))))
@@ -186,7 +186,7 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #7") {
     val mwj = new TestMultiwayJoin() {
-      var joinFilters = Array(
+      var joinFilters = Seq(
         JoinFilter(
           FullOuter,
           GreaterThan(BoundReference(2, IntegerType, true), Literal(5))))
@@ -201,7 +201,7 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #8") {
     val mwj = new TestMultiwayJoin() {
-      var joinFilters = Array(
+      var joinFilters = Seq(
         JoinFilter(
           LeftSemi,
           GreaterThan(BoundReference(2, IntegerType, true), Literal(5))))
@@ -215,7 +215,7 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #9") {
     val mwj = new TestMultiwayJoin() {
-      var joinFilters = Array(
+      var joinFilters = Seq(
         JoinFilter(
           LeftSemi,
           GreaterThan(BoundReference(0, IntegerType, true), Literal(5))))
@@ -228,7 +228,7 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #10") {
     val mwj = new TestMultiwayJoin2() {
-      var joinFilters = Array(
+      var joinFilters = Seq(
         JoinFilter(
           LeftOuter,
           GreaterThan(BoundReference(0, IntegerType, true), Literal(5))),
@@ -247,7 +247,7 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #11") {
     val mwj = new TestMultiwayJoin2() {
-      var joinFilters = Array(
+      var joinFilters = Seq(
         JoinFilter(
           LeftOuter,
           GreaterThan(BoundReference(0, IntegerType, true), Literal(5))),
@@ -266,7 +266,7 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #12") {
     val mwj = new TestMultiwayJoin2() {
-      var joinFilters = Array(
+      var joinFilters = Seq(
         JoinFilter(
           LeftOuter,
           GreaterThan(BoundReference(0, IntegerType, true), BoundReference(2, IntegerType, true))),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/MultiWayJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/MultiWayJoinSuite.scala
@@ -115,7 +115,7 @@ class MultiWayJoinSuite extends FunSuite {
       var joinFilters = Array(
         JoinFilter(
           LeftOuter,
-          GreaterThan(BoundReference(0, IntegerType, true), Literal(3, IntegerType))))
+          GreaterThan(BoundReference(0, IntegerType, true), Literal(3))))
     }
 
     val results = mwj.product(tables).map(_.copy()).toArray.sortWith(_.toString < _.toString)
@@ -145,7 +145,7 @@ class MultiWayJoinSuite extends FunSuite {
       var joinFilters = Array(
         JoinFilter(
           RightOuter,
-          GreaterThan(BoundReference(0, IntegerType, true), Literal(5, IntegerType))))
+          GreaterThan(BoundReference(0, IntegerType, true), Literal(5))))
     }
 
     val results = mwj.product(tables).map(_.copy()).toArray.sortWith(_.toString < _.toString)
@@ -159,7 +159,7 @@ class MultiWayJoinSuite extends FunSuite {
       var joinFilters = Array(
         JoinFilter(
           RightOuter,
-          GreaterThan(BoundReference(2, IntegerType, true), Literal(5, IntegerType))))
+          GreaterThan(BoundReference(2, IntegerType, true), Literal(5))))
     }
 
     val results = mwj.product(tables).map(_.copy()).toArray.sortWith(_.toString < _.toString)
@@ -174,7 +174,7 @@ class MultiWayJoinSuite extends FunSuite {
       var joinFilters = Array(
         JoinFilter(
           FullOuter,
-          GreaterThan(BoundReference(0, IntegerType, true), Literal(5, IntegerType))))
+          GreaterThan(BoundReference(0, IntegerType, true), Literal(5))))
     }
 
     val results = mwj.product(tables).map(_.copy()).toArray.sortWith(_.toString < _.toString)
@@ -189,7 +189,7 @@ class MultiWayJoinSuite extends FunSuite {
       var joinFilters = Array(
         JoinFilter(
           FullOuter,
-          GreaterThan(BoundReference(2, IntegerType, true), Literal(5, IntegerType))))
+          GreaterThan(BoundReference(2, IntegerType, true), Literal(5))))
     }
 
     val results = mwj.product(tables).map(_.copy()).toArray.sortWith(_.toString < _.toString)
@@ -204,7 +204,7 @@ class MultiWayJoinSuite extends FunSuite {
       var joinFilters = Array(
         JoinFilter(
           LeftSemi,
-          GreaterThan(BoundReference(2, IntegerType, true), Literal(5, IntegerType))))
+          GreaterThan(BoundReference(2, IntegerType, true), Literal(5))))
     }
 
     val results = mwj.product(tables).map(_.copy()).toArray.sortWith(_.toString < _.toString)
@@ -218,7 +218,7 @@ class MultiWayJoinSuite extends FunSuite {
       var joinFilters = Array(
         JoinFilter(
           LeftSemi,
-          GreaterThan(BoundReference(0, IntegerType, true), Literal(5, IntegerType))))
+          GreaterThan(BoundReference(0, IntegerType, true), Literal(5))))
     }
 
     val results = mwj.product(tables).map(_.copy()).toArray.sortWith(_.toString < _.toString)
@@ -231,10 +231,10 @@ class MultiWayJoinSuite extends FunSuite {
       var joinFilters = Array(
         JoinFilter(
           LeftOuter,
-          GreaterThan(BoundReference(0, IntegerType, true), Literal(5, IntegerType))),
+          GreaterThan(BoundReference(0, IntegerType, true), Literal(5))),
         JoinFilter(
           RightOuter,
-          GreaterThan(BoundReference(4, IntegerType, true), Literal(5, IntegerType))))
+          GreaterThan(BoundReference(4, IntegerType, true), Literal(5))))
     }
 
     val results = mwj.product(tables2).map(_.copy()).toArray.sortWith(_.toString < _.toString)
@@ -250,10 +250,10 @@ class MultiWayJoinSuite extends FunSuite {
       var joinFilters = Array(
         JoinFilter(
           LeftOuter,
-          GreaterThan(BoundReference(0, IntegerType, true), Literal(5, IntegerType))),
+          GreaterThan(BoundReference(0, IntegerType, true), Literal(5))),
         JoinFilter(
           RightOuter,
-          GreaterThan(BoundReference(4, IntegerType, true), Literal(5, IntegerType))))
+          GreaterThan(BoundReference(4, IntegerType, true), Literal(5))))
     }
 
     val results = mwj.product(tables2).map(_.copy()).toArray.sortWith(_.toString < _.toString)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/MultiWayJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/MultiWayJoinSuite.scala
@@ -98,7 +98,7 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #1") {
     val mwj = new TestMultiwayJoin() {
-      var joinFilters: Array[JoinFilter] = Array(
+      var joinFilters: Seq[JoinFilter] = Seq(
         JoinFilter(Inner, GreaterThan(BoundReference(0, IntegerType, true), BoundReference(2, IntegerType, true))))
     }
     val results = mwj.product(tables).map(_.copy()).toArray
@@ -108,7 +108,7 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #2") {
     val mwj = new TestMultiwayJoin() {
-      var joinFilters: Array[JoinFilter] = Array(
+      var joinFilters: Seq[JoinFilter] = Seq(
         JoinFilter(LeftOuter, GreaterThan(BoundReference(0, IntegerType, true), Literal(3, IntegerType))))
     }
 
@@ -122,7 +122,7 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #3") {
     val mwj = new TestMultiwayJoin() {
-      var joinFilters: Array[JoinFilter] = Array(
+      var joinFilters: Seq[JoinFilter] = Array(
         JoinFilter(LeftOuter, GreaterThan(BoundReference(0, IntegerType, true), BoundReference(2, IntegerType, true))))
     }
 
@@ -134,7 +134,7 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #4") {
     val mwj = new TestMultiwayJoin() {
-      var joinFilters: Array[JoinFilter] = Array(
+      var joinFilters: Seq[JoinFilter] = Array(
         JoinFilter(RightOuter, GreaterThan(BoundReference(0, IntegerType, true), Literal(5, IntegerType))))
     }
 
@@ -146,7 +146,7 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #5") {
     val mwj = new TestMultiwayJoin() {
-      var joinFilters: Array[JoinFilter] = Array(
+      var joinFilters: Seq[JoinFilter] = Array(
         JoinFilter(RightOuter, GreaterThan(BoundReference(2, IntegerType, true), Literal(5, IntegerType))))
     }
 
@@ -159,7 +159,7 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #6") {
     val mwj = new TestMultiwayJoin() {
-      var joinFilters: Array[JoinFilter] = Array(
+      var joinFilters: Seq[JoinFilter] = Array(
         JoinFilter(FullOuter, GreaterThan(BoundReference(0, IntegerType, true), Literal(5, IntegerType))))
     }
 
@@ -172,7 +172,7 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #7") {
     val mwj = new TestMultiwayJoin() {
-      var joinFilters: Array[JoinFilter] = Array(
+      var joinFilters: Seq[JoinFilter] = Array(
         JoinFilter(FullOuter, GreaterThan(BoundReference(2, IntegerType, true), Literal(5, IntegerType))))
     }
 
@@ -185,7 +185,7 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #8") {
     val mwj = new TestMultiwayJoin() {
-      var joinFilters: Array[JoinFilter] = Array(
+      var joinFilters: Seq[JoinFilter] = Array(
         JoinFilter(LeftSemi, GreaterThan(BoundReference(2, IntegerType, true), Literal(5, IntegerType))))
     }
 
@@ -197,7 +197,7 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #9") {
     val mwj = new TestMultiwayJoin() {
-      var joinFilters: Array[JoinFilter] = Array(
+      var joinFilters: Seq[JoinFilter] = Array(
         JoinFilter(LeftSemi, GreaterThan(BoundReference(0, IntegerType, true), Literal(5, IntegerType))))
     }
 
@@ -208,7 +208,7 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #10") {
     val mwj = new TestMultiwayJoin2() {
-      var joinFilters: Array[JoinFilter] = Array(
+      var joinFilters: Seq[JoinFilter] = Array(
         JoinFilter(LeftOuter, GreaterThan(BoundReference(0, IntegerType, true), Literal(5, IntegerType))),
         JoinFilter(RightOuter, GreaterThan(BoundReference(4, IntegerType, true), Literal(5, IntegerType))))
     }
@@ -223,7 +223,7 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #11") {
     val mwj = new TestMultiwayJoin2() {
-      var joinFilters: Array[JoinFilter] = Array(
+      var joinFilters: Seq[JoinFilter] = Array(
         JoinFilter(LeftOuter, GreaterThan(BoundReference(0, IntegerType, true), Literal(5, IntegerType))),
         JoinFilter(RightOuter, GreaterThan(BoundReference(4, IntegerType, true), Literal(5, IntegerType))))
     }
@@ -238,7 +238,7 @@ class MultiWayJoinSuite extends FunSuite {
 
   test("Test multiway join #12") {
     val mwj = new TestMultiwayJoin2() {
-      var joinFilters: Array[JoinFilter] = Array(
+      var joinFilters: Seq[JoinFilter] = Array(
         JoinFilter(LeftOuter, GreaterThan(BoundReference(0, IntegerType, true), BoundReference(2, IntegerType, true))),
         JoinFilter(RightOuter, GreaterThan(BoundReference(2, IntegerType, true), BoundReference(4, IntegerType, true))))
     }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -373,6 +373,7 @@ class HiveContext(sc: SparkContext) extends SQLContext(sc) {
       DataSinks,
       Scripts,
       HashAggregation,
+      MultiwayJoin,
       LeftSemiJoin,
       HashJoin,
       BasicOperators,


### PR DESCRIPTION
Assume we have table `x`, `y`, `z`, and the `x` is the fact table with large mount of data, and `y`, `z` are dimensional tables.

``` sql
SELECT x.a, y.a, z.a FROM x JOIN y ON x.a = y.a AND y.a < 3 JOIN z ON x.a = z.a AND z.a > 1
```

To compute the result, it's required multiple times reading / writing data for fact table(large amount of data) if we do that as binary join way; this PR (multiple way broadcast join) will reduce the IO overhead significantly by reading all of the data once, as well as the filtering effect of the multiple join filters.

This PR is for earlier feedbacks, some TODOs as below, but probably can be done in another PRs
- Multiway-join for JOINs in identical equi-join.
- Join Reordering.
- Integrated with Sort-Merge-Join in Multiway JOIN.
- Code Clean Up, to unify the JOIN code by removing the binary join(replaced with multiple way join)

Restrictions
- The fact table should be in the left-most, we can improve that in `Join Reordering`.

Benchmarking result will be provided soon...
