### PR TITLE
[SPARK-6671] Add status command for spark daemons

### DIFF
--- a/sbin/spark-daemon.sh
+++ b/sbin/spark-daemon.sh
@@ -29,7 +29,7 @@
 #   SPARK_NICENESS The scheduling priority for daemons. Defaults to 0.
 ##
 
-usage="Usage: spark-daemon.sh [--config <conf-dir>] (start|stop) <spark-command> <spark-instance-number> <args...>"
+usage="Usage: spark-daemon.sh [--config <conf-dir>] (start|stop|status) <spark-command> <spark-instance-number> <args...>"
 
 # if no args specified, show usage
 if [ $# -le 1 ]; then
@@ -195,6 +195,23 @@ case $option in
     fi
     ;;
 
+  (status)
+
+    if [ -f $pid ]; then
+      TARGET_PID=`cat $pid`
+      if kill -0 $TARGET_PID > /dev/null 2>&1; then
+        echo $command is running.
+        exit 0
+      else
+        echo $pid file is present but $command not running.
+        exit 1
+      fi
+    else
+      echo $command not running.
+      exit 2
+    fi
+    ;;
+  
   (*)
     echo $usage
     exit 1

--- a/sbin/spark-daemon.sh
+++ b/sbin/spark-daemon.sh
@@ -198,19 +198,19 @@ case $option in
   (status)
 
     if [ -f $pid ]; then
-      TARGET_PID=`cat $pid`
-      if kill -0 $TARGET_PID > /dev/null 2>&1; then
-        echo $command is running.
-        exit 0
-      else
-        echo $pid file is present but $command not running.
-        exit 1
-      fi
-    else
-      echo $command not running.
-      exit 2
-    fi
-    ;;
+         TARGET_ID="$(cat "$pid")"
+         if [[ $(ps -p "$TARGET_ID" -o args=) =~ $command ]]; then
+                 echo $command is running.
+                 exit 0
+         else
+             echo $pid file is present but $command not running
+             exit 1
+         fi  
+     else
+         echo $command not running.
+         exit 2
+     fi  
+     ;;
   
   (*)
     echo $usage

--- a/sbin/spark-daemon.sh
+++ b/sbin/spark-daemon.sh
@@ -198,19 +198,19 @@ case $option in
   (status)
 
     if [ -f $pid ]; then
-         TARGET_ID="$(cat "$pid")"
-         if [[ $(ps -p "$TARGET_ID" -o args=) =~ $command ]]; then
-                 echo $command is running.
-                 exit 0
-         else
-             echo $pid file is present but $command not running
-             exit 1
-         fi  
-     else
-         echo $command not running.
-         exit 2
-     fi  
-     ;;
+      TARGET_ID="$(cat "$pid")"
+      if [[ $(ps -p "$TARGET_ID" -o args=) =~ $command ]]; then
+        echo $command is running.
+        exit 0
+      else
+        echo $pid file is present but $command not running
+        exit 1
+      fi  
+    else
+      echo $command not running.
+      exit 2
+    fi  
+    ;;
   
   (*)
     echo $usage

--- a/sbin/spark-daemon.sh
+++ b/sbin/spark-daemon.sh
@@ -199,7 +199,7 @@ case $option in
 
     if [ -f $pid ]; then
       TARGET_ID="$(cat "$pid")"
-      if [[ $(ps -p "$TARGET_ID" -o args=) =~ $command ]]; then
+      if [[ $(ps -p "$TARGET_ID" -o comm=) =~ "java" ]]; then
         echo $command is running.
         exit 0
       else


### PR DESCRIPTION
SPARK-6671
Currently using the spark-daemon.sh script we can start and stop the spark demons. But we cannot get the status of the daemons. It will be nice to include the status command in the spark-daemon.sh script, through which we can know if the spark demon is alive or not.
