### PR TITLE
[SPARK-6692][YARN] Add an option for client to kill AM when it is killed

### DIFF
--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -50,8 +50,8 @@ Most of the configs are the same for Spark on YARN as for other deployment modes
   <td><code>spark.yarn.am.force.shutdown</code></td>
   <td>false</td>
   <td>
-    In yarn-cluster mode, the YARN Application Master is not killed when the client is terminated by default.
-    But if spark.yarn.am.force.shutdown is set true, the YARN AM is force shutdown.
+    In yarn-cluster mode, the YARN Application Master is not killed by default even when the client is terminated.
+    But if spark.yarn.am.force.shutdown is set true, the YARN AM is force shutdown when the client exits.
   </td>
 </tr>
 <tr>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -47,6 +47,14 @@ Most of the configs are the same for Spark on YARN as for other deployment modes
   </td>
 </tr>
 <tr>
+  <td><code>spark.yarn.am.force.shutdown</code></td>
+  <td>false</td>
+  <td>
+    In yarn-cluster mode, the YARN Application Master is not killed when the client is terminated by default.
+    But if spark.yarn.am.force.shutdown is set true, the YARN AM is force shutdown.
+  </td>
+</tr>
+<tr>
   <td><code>spark.yarn.am.waitTime</code></td>
   <td>100s</td>
   <td>


### PR DESCRIPTION
I understand that the yarn-cluster mode is designed for fire-and-forget model; therefore, terminating the yarn client doesn't kill AM.

However, it is very common that users submit Spark jobs via job scheduler (e.g. Apache Oozie) or remote job server (e.g. Netflix Genie) where it is expected that killing the yarn client will terminate AM.
It is true that the yarn-client mode can be used in such cases. But then, the yarn client sometimes needs lots of heap memory for big jobs if it runs in the yarn-client mode. In fact, the yarn-cluster mode is ideal for big jobs because AM can be given arbitrary heap memory unlike the yarn client. So it would be very useful to make it possible to kill AM even in the yarn-cluster mode.

In addition, Spark jobs often become zombie jobs if users ctrl-c them as soon as they're accepted (but not yet running). Although they're eventually shutdown after AM timeout, it would be nice if AM could immediately get killed in such cases too.
