### PR TITLE
SPARK-6698: where RandomForest input specifies a storage level, honor it internally

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/RandomForest.scala
@@ -163,7 +163,13 @@ private class RandomForest (
     val baggedInput
       = BaggedPoint.convertToBaggedRDD(treeInput,
           strategy.subsamplingRate, numTrees,
-          withReplacement, seed).persist(StorageLevel.MEMORY_AND_DISK)
+          withReplacement, seed)
+
+    if (input.getStorageLevel == StorageLevel.NONE) {
+      baggedInput.persist(StorageLevel.MEMORY_AND_DISK)
+    } else {
+      baggedInput.persist(input.getStorageLevel)
+    }
 
     // depth of the decision tree
     val maxDepth = strategy.maxDepth

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/impl/NodeIdCache.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/impl/NodeIdCache.scala
@@ -127,7 +127,11 @@ private[tree] class NodeIdCache(
     }
 
     // Keep on persisting new ones.
-    nodeIdsForInstances.persist(StorageLevel.MEMORY_AND_DISK)
+    if (data.getStorageLevel == StorageLevel.NONE) {
+      nodeIdsForInstances.persist(StorageLevel.MEMORY_AND_DISK)
+    } else {
+      nodeIdsForInstances.persist(data.getStorageLevel)
+    }
     rddUpdateCount += 1
 
     // Handle checkpointing if the directory is not None.


### PR DESCRIPTION
Currently RandomForest re-persists input data unconditionally with StorageLevel.MEMORY_AND_DISK.  This makes it difficult to tune GC with different StorageLevels.  Instead, if the input has already been persisted at a different level, use that same level.  
