### PR TITLE
[SPARK-6712][YARN] Allow lower the log level in YARN client while keeping AM tracking URL printed

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -588,7 +588,7 @@ private[spark] class Client(
         if (log.isDebugEnabled) {
           logDebug(formattedDetails)
         } else if (lastState != state) {
-          logInfo(formattedDetails)
+          println(formattedDetails)
         }
       }
 


### PR DESCRIPTION
In YARN mode, log messages are quite verbose in interactive shells (spark-shell, spark-sql, pyspark), and they sometimes mingle with shell prompts. In fact, it's very easy to tone it down via log4j.properties, but the problem is that the AM tracking URL is not printed if I do that.

It would be nice if I could keep the AM tracking URL while disabling the other INFO messages that don't matter to most end users.
