### PR TITLE
SPARK-6630 [CORE] SparkConf.setIfMissing should only evaluate the assigned value if indeed missing

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -139,7 +139,7 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging {
   }
 
   /** Set a parameter if it isn't already configured */
-  def setIfMissing(key: String, value: String): SparkConf = {
+  def setIfMissing(key: String, value: => String): SparkConf = {
     settings.putIfAbsent(key, value)
     this
   }


### PR DESCRIPTION
Only evaluate value argument to `setIfMissing` if property value is actually missing and will be set.
