### PR TITLE
[CORE] [SPARK-6593] Provide a HadoopRDD variant that wraps all reads in a Try

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -64,6 +64,8 @@ import org.apache.spark.ui.{SparkUI, ConsoleProgressBar}
 import org.apache.spark.ui.jobs.JobProgressListener
 import org.apache.spark.util._
 
+import scala.util.Try
+
 /**
  * Main entry point for Spark functionality. A SparkContext represents the connection to a Spark
  * cluster, and can be used to create RDDs, accumulators and broadcast variables on that cluster.
@@ -747,6 +749,32 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
     // Add necessary security credentials to the JobConf before broadcasting it.
     SparkHadoopUtil.get.addCredentials(conf)
     new HadoopRDD(this, conf, inputFormatClass, keyClass, valueClass, minPartitions)
+  }
+
+  /**
+   * Get an RDD for a Hadoop file with an arbitrary InputFormat, but wrap all reads in a Try
+   * @return a RDD of Try elements, one Try per hadoop read
+   */
+  @Experimental
+  def hadoopReliableFile[K, V](
+                        path: String,
+                        inputFormatClass: Class[_ <: InputFormat[K, V]],
+                        keyClass: Class[K],
+                        valueClass: Class[V],
+                        minPartitions: Int = defaultMinPartitions
+                        ): RDD[Try[(K, V)]] = {
+    assertNotStopped()
+    // A Hadoop configuration can be about 10 KB, which is pretty big, so broadcast it.
+    val confBroadcast = broadcast(new SerializableWritable(hadoopConfiguration))
+    val setInputPathsFunc = (jobConf: JobConf) => FileInputFormat.setInputPaths(jobConf, path)
+    new HadoopReliableRDD(
+      this,
+      confBroadcast,
+      Some(setInputPathsFunc),
+      inputFormatClass,
+      keyClass,
+      valueClass,
+      minPartitions).setName(path)
   }
 
   /** Get an RDD for a Hadoop file with an arbitrary InputFormat

--- a/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
@@ -208,9 +208,9 @@ class HadoopRDD[K, V](
     array
   }
 
-  override def compute(theSplit: Partition, context: TaskContext): InterruptibleIterator[(K, V)] = {
-    val iter = new NextIterator[(K, V)] {
-
+  protected[spark] def constructIter(theSplit: Partition, context: TaskContext):
+      NextIterator[(K,V)] = {
+    new NextIterator[(K, V)] {
       val split = theSplit.asInstanceOf[HadoopPartition]
       logInfo("Input split: " + split.inputSplit)
       val jobConf = getJobConf()
@@ -258,7 +258,7 @@ class HadoopRDD[K, V](
           if (bytesReadCallback.isDefined) {
             inputMetrics.updateBytesRead()
           } else if (split.inputSplit.value.isInstanceOf[FileSplit] ||
-                     split.inputSplit.value.isInstanceOf[CombineFileSplit]) {
+            split.inputSplit.value.isInstanceOf[CombineFileSplit]) {
             // If we can't get the bytes read from the FS stats, fall back to the split size,
             // which may be inaccurate.
             try {
@@ -277,6 +277,10 @@ class HadoopRDD[K, V](
         }
       }
     }
+  }
+
+  override def compute(theSplit: Partition, context: TaskContext): InterruptibleIterator[(K, V)] = {
+    val iter: NextIterator[(K,V)] = constructIter(theSplit, context)
     new InterruptibleIterator[(K, V)](context, iter)
   }
 

--- a/core/src/main/scala/org/apache/spark/rdd/HadoopReliableRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/HadoopReliableRDD.scala
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.rdd
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.mapred._
+import org.apache.spark._
+import org.apache.spark.annotation.{DeveloperApi, Experimental}
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.util.NextIterator
+
+import scala.reflect.ClassTag
+import scala.util.control.NonFatal
+import scala.util.{Failure, Success, Try}
+
+@Experimental
+class HadoopReliableRDD[K, V](sc: SparkContext,
+    broadcastedConf: Broadcast[SerializableWritable[Configuration]],
+    initLocalJobConfFuncOpt: Option[JobConf => Unit],
+    inputFormatClass: Class[_ <: InputFormat[K, V]],
+    keyClass: Class[K],
+    valueClass: Class[V],
+    minPartitions: Int)
+    extends RDD[Try[(K, V)]](sc, Nil) with Logging {
+
+  private val hadoopRDD: HadoopRDD[K,V] = new HadoopRDD[K,V](sc, broadcastedConf,
+    initLocalJobConfFuncOpt,inputFormatClass, keyClass,valueClass,minPartitions)
+
+  def this(sc: SparkContext,
+            conf: JobConf,
+            inputFormatClass: Class[_ <: InputFormat[K, V]],
+            keyClass: Class[K],
+            valueClass: Class[V],
+            minPartitions: Int) = {
+    this(
+      sc,
+      sc.broadcast(new SerializableWritable(conf))
+        .asInstanceOf[Broadcast[SerializableWritable[Configuration]]],
+      None /* initLocalJobConfFuncOpt */,
+      inputFormatClass,
+      keyClass,
+      valueClass,
+      minPartitions)
+  }
+
+  override def getPartitions: Array[Partition] = hadoopRDD.getPartitions
+
+  /** Maps over a partition, providing the InputSplit that was used as the base of the partition */
+  @DeveloperApi
+  def mapPartitionsWithInputSplit[U: ClassTag](
+      f: (InputSplit, Iterator[(K, V)]) => Iterator[U],
+      preservesPartitioning: Boolean = false): RDD[U] = {
+    hadoopRDD.mapPartitionsWithInputSplit(f, preservesPartitioning)
+  }
+
+  override def getPreferredLocations(split: Partition): Seq[String] =
+    hadoopRDD.getPreferredLocations(split)
+
+  override def checkpoint() {
+    // Do nothing. Hadoop RDD should not be checkpointed.
+  }
+
+  override def persist(storageLevel: StorageLevel): this.type = {
+    if (storageLevel.deserialized) {
+      logWarning("Caching NewHadoopRDDs as deserialized objects usually leads to undesired" +
+        "behavior because Hadoop's RecordReader reuses the same Writable object for all records." +
+        "Use a map transformation to make copies of the records.")
+    }
+    super.persist(storageLevel)
+  }
+
+  def compute(theSplit: Partition, context: TaskContext): InterruptibleIterator[Try[(K, V)]] = {
+    val iter:  NextIterator[(K,V)] = hadoopRDD.constructIter(theSplit, context)
+    val tryIter = new  NextIterator[Try[(K,V)]] {
+      override protected def getNext(): Try[(K, V)] = {
+        val readAttempt = SparkTaskTry(iter.next())
+        finished = readAttempt.isFailure
+        readAttempt
+      }
+      override protected def close(): Unit = iter.closeIfNeeded()
+    }
+    new InterruptibleIterator[Try[(K, V)]](context, tryIter)
+  }
+}
+
+object SparkTaskTry {
+  /**
+   *  Extends the normal Try constructor to allow TaskKilledExceptions to propagate
+   */
+  def apply[T](r: => T): Try[T] =
+    try Success(r) catch {
+      case e: TaskKilledException => throw e
+      case NonFatal(e) => Failure(e)
+    }
+}


### PR DESCRIPTION
@rxin @sryza  @srowen
As per attached jira ticket, I was proposing some way of making hadoop IO more robust in response to malformated files that cause an exception in the hadoop input libraries.  The previous PR (#5250) simply added an option to ignore exceptions and continue processing.  This raised some concerns about not giving any indication to the user that an error had occurred (other than a warning message in the logs.)

As an alternative to the first PR, and to keep the conversation moving, I'm putting forward this PR, which contains HadoopReliableRDD, which wraps all Hadoop IO in a Try structure and passes that back to the user so that the user is forced to act upon any non-fatal errors that occur when reading from an Hadoop file system using this API. 

An example of using this API is given below:

```
import org.apache.hadoop.io.{LongWritable, Text}
import org.apache.hadoop.mapred.TextInputFormat
import scala.util.{Failure, Success, Try}

// hdfs directory contains test[1.4].txt.gz  - test4.txt.gz is corrupted
val path = "hdfs:///user/cloudera/*.gz"

val testRdd = sc.hadoopReliableFile(path, classOf[TextInputFormat], classOf[LongWritable], classOf[Text],2)
…
15/04/05 21:24:57 INFO rdd.HadoopRDD: Input split: hdfs://quickstart.cloudera:8020/user/cloudera/test4.txt.gz:0+42544
15/04/05 21:24:57 INFO rdd.HadoopRDD: Input split: hdfs://quickstart.cloudera:8020/user/cloudera/test3.txt.gz:0+15043
15/04/05 21:24:57 INFO rdd.HadoopRDD: Input split: hdfs://quickstart.cloudera:8020/user/cloudera/test1.txt.gz:0+15043
15/04/05 21:24:57 INFO rdd.HadoopRDD: Input split: hdfs://quickstart.cloudera:8020/user/cloudera/test2.txt.gz:0+15043
…
15/04/05 21:24:57 WARN rdd.HadoopReliableRDD: Exception on read attempt IOException - not a gzip file - stopping any further read attempts from this split
…

testRdd.count 
…
res5: Long = 4384

testRdd.filter(x=>x.isSuccess).count
...
res6: Long = 4383

testRdd.map( _ match {
  case Failure(ex) => s"${ex.getClass.getSimpleName}: ${ex.getMessage}"
  case Success(_) => "success"
}).countByValue()
..
res7: scala.collection.Map[String,Long] = Map(IOException: not a gzip file -> 1, success -> 4383)


testRdd.filter(_.isSuccess).map(_.get.toString).flatMap(_.split(" ")).countByValue
...
… and on we go…

```

Just to emphasise what we are doing here.  We are trapping exceptions that previously would have stopped Spark from executing, and continuing to process data in other tasks rather than terminating the entire application which is what previously happened .  If the exceptions were being raised in a non-deterministic way (eg temporary network failure) then the produced data could be different if the code is run a second time.  If we didn't handle these errors, then the entire application will currently fail in a non-deterministic way.  A lot of times the later behavior is the desirable response, but sometimes it is not.

If the exceptions were being raised in a deterministic way (eg file was corrupt before it was copied into HDFS), then the data will be produced in a deterministic way that can be repeated with the same results.  

I believe giving users some way to process data that Spark currently crashes on is worth considering, what ever form it finally takes.
