### PR TITLE
[SPARK-6715][SQL] Eliminate duplicate filters from pushdown predicates

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JDBCRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JDBCRelation.scala
@@ -25,7 +25,8 @@ import scala.collection.mutable.ArrayBuffer
 import org.apache.spark.Partition
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SQLContext
-import org.apache.spark.sql.catalyst.expressions.Row
+import org.apache.spark.sql.catalyst.expressions
+import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.StructType
 
@@ -144,5 +145,16 @@ private[sql] case class JDBCRelation(
       requiredColumns,
       filters,
       parts)
+  }
+
+  override def supportPredicate(filter: Expression): Boolean = {
+    filter match {
+      case e: expressions.EqualTo => true
+      case e: expressions.LessThan => true
+      case e: expressions.GreaterThan => true
+      case e: expressions.LessThanOrEqual => true
+      case e: expressions.GreaterThanOrEqual => true
+      case o => false
+    }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -162,6 +162,7 @@ trait PrunedScan {
 @DeveloperApi
 trait PrunedFilteredScan {
   def buildScan(requiredColumns: Array[String], filters: Array[Filter]): RDD[Row]
+  def supportPredicate(predicate: Expression): Boolean
 }
 
 /**


### PR DESCRIPTION
Now in `DataSourceStrategy`, the pushdown predicates are duplicate of original `Filter` conditions. Thus, some predicates are performed both by data source relation and `Filter` plan. I think it is a duplicate loading. Once the predicates are pushed down and performed by a data source relation, it
can be eliminated from outside `Filter` plan's condition.
