### PR TITLE
[SPARK-6720][MLLIB] PySpark MultivariateStatisticalSummary unit test for normL1...

### DIFF
--- a/python/pyspark/mllib/tests.py
+++ b/python/pyspark/mllib/tests.py
@@ -366,9 +366,9 @@ class StatTests(PySparkTestCase):
         data2 = self.sc.parallelize(xrange(10)).map(lambda x: Vectors.dense(x))
         summary2 = Statistics.colStats(data2)
         self.assertEqual(array([45.0]), summary2.normL1())
-        # Confirm normL2 is among this span because it is a float value.
-        self.assertTrue(summary2.normL2()[0] > 16.5)
-        self.assertTrue(summary2.normL2()[0] < 17.0)
+        import math
+        expectedNormL2 = math.sqrt(sum(map(lambda x: x*x, xrange(10))))
+        self.assertTrue(math.fabs(summary2.normL2()[0] - expectedNormL2) < 1e-14)
 
 
 class VectorUDTTests(PySparkTestCase):

--- a/python/pyspark/mllib/tests.py
+++ b/python/pyspark/mllib/tests.py
@@ -363,6 +363,13 @@ class StatTests(PySparkTestCase):
         self.assertEqual(10, len(summary.normL1()))
         self.assertEqual(10, len(summary.normL2()))
 
+        data2 = self.sc.parallelize(xrange(10)).map(lambda x: Vectors.dense(x))
+        summary2 = Statistics.colStats(data2)
+        self.assertEqual(array([45.0]), summary2.normL1())
+        # Confirm normL2 is among this span because it is a float value.
+        self.assertTrue(summary2.normL2()[0] > 16.5)
+        self.assertTrue(summary2.normL2()[0] < 17.0)
+
 
 class VectorUDTTests(PySparkTestCase):
 


### PR DESCRIPTION
... and normL2. 
Add test cases to insufficient unit test for `normL1` and `normL2`.

Ref: https://github.com/apache/spark/pull/5359
