### PR TITLE
[CORE] The newest log will be loaded many times when running HistoryServer

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -191,7 +191,7 @@ private[history] class FsHistoryProvider(conf: SparkConf) extends ApplicationHis
           try {
             getModificationTime(entry).map { time =>
               newLastModifiedTime = math.max(newLastModifiedTime, time)
-              time >= lastModifiedTime
+              time > lastModifiedTime
             }.getOrElse(false)
           } catch {
             case e: AccessControlException =>


### PR DESCRIPTION
When running HistoryServer, the info about the newest application are loaded many times.
For example:
2015-04-07 15:04:32,406 | INFO  | [log-replay-executor-0] | Replaying log path: hdfs://hacluster/sparkJobHistory/application_1428400855101_0004 | org.apache.spark.Logging$class.logInfo(Logging.scala:59)
2015-04-07 15:04:32,503 | INFO  | [log-replay-executor-0] | Application log application_1428400855101_0004 loaded successfully. | org.apache.spark.Logging$class.logInfo(Logging.scala:59)
2015-04-07 15:04:42,410 | INFO  | [log-replay-executor-0] | Replaying log path: hdfs://hacluster/sparkJobHistory/application_1428400855101_0004 | org.apache.spark.Logging$class.logInfo(Logging.scala:59)
2015-04-07 15:04:42,501 | INFO  | [log-replay-executor-0] | Application log application_1428400855101_0004 loaded successfully. | org.apache.spark.Logging$class.logInfo(Logging.scala:59)
2015-04-07 15:04:52,406 | INFO  | [log-replay-executor-0] | Replaying log path: hdfs://hacluster/sparkJobHistory/application_1428400855101_0004 | org.apache.spark.Logging$class.logInfo(Logging.scala:59)
2015-04-07 15:04:52,502 | INFO  | [log-replay-executor-0] | Application log application_1428400855101_0004 loaded successfully. | org.apache.spark.Logging$class.logInfo(Logging.scala:59)
