### PR TITLE
[SPARK-6762]Fix potential resource leaks in CheckPoint CheckpointWriter and CheckpointReader

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/Checkpoint.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/Checkpoint.scala
@@ -267,7 +267,9 @@ object CheckpointReader extends Logging {
             Thread.currentThread().getContextClassLoader)
           cp = ois.readObject.asInstanceOf[Checkpoint]
         } {
-          ois.close()
+          if (ois != null) {
+            ois.close()
+          }
         }
         cp.validate()
         logInfo("Checkpoint successfully loaded from file " + file)

--- a/streaming/src/main/scala/org/apache/spark/streaming/Checkpoint.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/Checkpoint.scala
@@ -26,7 +26,7 @@ import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.{SparkException, SparkConf, Logging}
 import org.apache.spark.io.CompressionCodec
-import org.apache.spark.util.MetadataCleaner
+import org.apache.spark.util.{MetadataCleaner, Utils}
 import org.apache.spark.streaming.scheduler.JobGenerator
 
 
@@ -139,11 +139,12 @@ class CheckpointWriter(
           // Write checkpoint to temp file
           fs.delete(tempFile, true)   // just in case it exists
           val fos = fs.create(tempFile)
-          try {
+          Utils.tryWithSafeFinally {
             fos.write(bytes)
-          } finally {
+          } {
             fos.close()
           }
+
           // If the checkpoint file exists, back it up
           // If the backup exists as well, just delete it, otherwise rename will fail
           if (fs.exists(checkpointFile)) {
@@ -189,13 +190,11 @@ class CheckpointWriter(
     val bos = new ByteArrayOutputStream()
     val zos = compressionCodec.compressedOutputStream(bos)
     val oos = new ObjectOutputStream(zos)
-    try {
+    Utils.tryWithSafeFinally {
       oos.writeObject(checkpoint)
-    } finally {
+    } {
       oos.close()
-      bos.close()
     }
-    
     try {
       executor.execute(new CheckpointWriteHandler(
         checkpoint.checkpointTime, bos.toByteArray, clearCheckpointDataLater))
@@ -253,34 +252,32 @@ object CheckpointReader extends Logging {
     val compressionCodec = CompressionCodec.createCodec(conf)
     checkpointFiles.foreach(file => {
       logInfo("Attempting to load checkpoint from file " + file)
-      var cpOption: Option[Checkpoint] = None
-      var ois: ObjectInputStreamWithLoader = null
       try {
-        val fis = fs.open(file)
-        // ObjectInputStream uses the last defined user-defined class loader in the stack
-        // to find classes, which maybe the wrong class loader. Hence, a inherited version
-        // of ObjectInputStream is used to explicitly use the current thread's default class
-        // loader to find and load classes. This is a well know Java issue and has popped up
-        // in other places (e.g., http://jira.codehaus.org/browse/GROOVY-1627)
-        val zis = compressionCodec.compressedInputStream(fis)
-        ois = new ObjectInputStreamWithLoader(zis,
+        var ois: ObjectInputStreamWithLoader = null
+        var cp: Checkpoint = null
+        Utils.tryWithSafeFinally {
+          val fis = fs.open(file)
+          // ObjectInputStream uses the last defined user-defined class loader in the stack
+          // to find classes, which maybe the wrong class loader. Hence, a inherited version
+          // of ObjectInputStream is used to explicitly use the current thread's default class
+          // loader to find and load classes. This is a well know Java issue and has popped up
+          // in other places (e.g., http://jira.codehaus.org/browse/GROOVY-1627)
+          val zis = compressionCodec.compressedInputStream(fis)
+          ois = new ObjectInputStreamWithLoader(zis,
             Thread.currentThread().getContextClassLoader)
-        cpOption = Some(ois.readObject.asInstanceOf[Checkpoint])
+          cp = ois.readObject.asInstanceOf[Checkpoint]
+        } {
+          ois.close()
+          fs.close()
+        }
+        cp.validate()
         logInfo("Checkpoint successfully loaded from file " + file)
+        logInfo("Checkpoint was generated at time " + cp.checkpointTime)
+        return Some(cp)
       } catch {
         case e: Exception =>
           logWarning("Error reading checkpoint from file " + file, e)
-      } finally {
-        if (ois != null) {
-          ois.close()
-        }
-        fs.close()
       }
-      cpOption.foreach { cp =>
-        cp.validate()
-        logInfo("Checkpoint was generated at time " + cp.checkpointTime)
-      }
-      return cpOption
     })
 
     // If none of checkpoint files could be read, then throw exception

--- a/streaming/src/main/scala/org/apache/spark/streaming/Checkpoint.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/Checkpoint.scala
@@ -268,7 +268,6 @@ object CheckpointReader extends Logging {
           cp = ois.readObject.asInstanceOf[Checkpoint]
         } {
           ois.close()
-          fs.close()
         }
         cp.validate()
         logInfo("Checkpoint successfully loaded from file " + file)

--- a/streaming/src/main/scala/org/apache/spark/streaming/util/RawTextSender.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/util/RawTextSender.scala
@@ -72,7 +72,8 @@ object RawTextSender extends Logging {
       } catch {
         case e: IOException =>
           logError("Client disconnected")
-          socket.close()
+      } finally {
+        socket.close()
       }
     }
   }


### PR DESCRIPTION
The close action should be placed within finally block to avoid the potential resource leaks
