### PR TITLE
[Core][minor] remove unnecessary `parents` in `ShuffleMapStage`

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -246,8 +246,7 @@ class DAGScheduler(
       jobId: Int,
       callSite: CallSite): ShuffleMapStage = {
     val (parentStages: List[Stage], id: Int) = getParentStagesAndId(rdd, jobId)
-    val stage: ShuffleMapStage = new ShuffleMapStage(id, rdd, numTasks, parentStages,
-      jobId, callSite, shuffleDep)
+    val stage: ShuffleMapStage = new ShuffleMapStage(id, rdd, numTasks, jobId, callSite, shuffleDep)
 
     stageIdToStage(id) = stage
     updateJobIdStageIdMaps(jobId, stage)

--- a/core/src/main/scala/org/apache/spark/scheduler/ResultStage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ResultStage.scala
@@ -27,10 +27,10 @@ private[spark] class ResultStage(
     id: Int,
     rdd: RDD[_],
     numTasks: Int,
-    parents: List[Stage],
+    val parents: List[Stage],
     jobId: Int,
     callSite: CallSite)
-  extends Stage(id, rdd, numTasks, parents, jobId, callSite) {
+  extends Stage(id, rdd, numTasks, jobId, callSite) {
 
   // The active job for this result stage. Will be empty if the job has already finished
   // (e.g., because the job was cancelled).

--- a/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapStage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapStage.scala
@@ -29,11 +29,10 @@ private[spark] class ShuffleMapStage(
     id: Int,
     rdd: RDD[_],
     numTasks: Int,
-    parents: List[Stage],
     jobId: Int,
     callSite: CallSite,
     val shuffleDep: ShuffleDependency[_, _, _])
-  extends Stage(id, rdd, numTasks, parents, jobId, callSite) {
+  extends Stage(id, rdd, numTasks, jobId, callSite) {
 
   override def toString: String = "ShuffleMapStage " + id
 

--- a/core/src/main/scala/org/apache/spark/scheduler/Stage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Stage.scala
@@ -50,7 +50,6 @@ private[spark] abstract class Stage(
     val id: Int,
     val rdd: RDD[_],
     val numTasks: Int,
-    val parents: List[Stage],
     val jobId: Int,
     val callSite: CallSite)
   extends Logging {


### PR DESCRIPTION
We never call `parents` on `ShuffleMapStage`, so we should define it only in `ResultStage`.
