### PR TITLE
[SQL] Faster Scala row conversion

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -95,10 +95,14 @@ trait ScalaReflection {
   }
 
   def convertRowToScala(r: Row, schema: StructType): Row = {
-    // TODO: This is very slow!!!
-    new GenericRowWithSchema(
-      r.toSeq.zip(schema.fields.map(_.dataType))
-        .map(r_dt => convertToScala(r_dt._1, r_dt._2)).toArray, schema)
+    val fields = schema.fields
+    val values = new Array[Any](r.length)
+    var i = 0
+    while (i < values.length) {
+      values(i) = convertToScala(r(i), fields(i).dataType)
+      i += 1
+    }
+    new GenericRowWithSchema(values, schema)
   }
 
   /** Returns a Sequence of attributes for the given case class type. */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -150,7 +150,7 @@ abstract class QueryPlan[PlanType <: TreeNode[PlanType]] extends TreeNode[PlanTy
     }.toSeq
   }
 
-  def schema: StructType = StructType.fromAttributes(output)
+  lazy val schema: StructType = StructType.fromAttributes(output)
 
   /** Returns the output schema in the tree format. */
   def schemaString: String = schema.treeString


### PR DESCRIPTION
This is a follow-up of #5279 and #5398. `ScalaReflection.convertRowToScala` is on a critical path, but was implemented in a rather inefficient way.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/apache/spark/5419)

<!-- Reviewable:end -->
