### PR TITLE
SPARK-3276 Added a new configuration spark.streaming.minRememberDuration

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
@@ -86,8 +86,8 @@ class FileInputDStream[K, V, F <: NewInputFormat[K,V]](
    * Files with mod times older than this "window" of remembering will be ignored. So if new
    * files are visible within this window, then the file will get selected in the next batch.
    */
-  private val minRememberDurationMin = Minutes(ssc.conf
-                                            .getLong("spark.streaming.minRememberDurationMin", 1L))
+  private val minRememberDurationMin =
+    Minutes(ssc.conf.getLong("spark.streaming.minRememberDurationMin", 1L))
 
   // This is a def so that it works during checkpoint recovery:
   private def clock = ssc.scheduler.clock

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
@@ -86,8 +86,8 @@ class FileInputDStream[K, V, F <: NewInputFormat[K,V]](
    * Files with mod times older than this "window" of remembering will be ignored. So if new
    * files are visible within this window, then the file will get selected in the next batch.
    */
-  private val minRememberDuration =
-    Seconds(ssc.conf.getLong("spark.streaming.minRememberDuration", 60L))
+  private val minRememberDurationS =
+    Seconds(ssc.conf.getTimeAsSeconds("spark.streaming.minRememberDuration", "60s"))
 
   // This is a def so that it works during checkpoint recovery:
   private def clock = ssc.scheduler.clock
@@ -105,7 +105,7 @@ class FileInputDStream[K, V, F <: NewInputFormat[K,V]](
    * selected and processed.
    */
   private val numBatchesToRemember = FileInputDStream
-    .calculateNumBatchesToRemember(slideDuration, minRememberDuration)
+    .calculateNumBatchesToRemember(slideDuration, minRememberDurationS)
   private val durationToRemember = slideDuration * numBatchesToRemember
   remember(durationToRemember)
 
@@ -344,10 +344,10 @@ object FileInputDStream {
 
   /**
    * Calculate the number of last batches to remember, such that all the files selected in
-   * at least last minRememberDuration duration can be remembered.
+   * at least last minRememberDurationS duration can be remembered.
    */
   def calculateNumBatchesToRemember(batchDuration: Duration,
-                                    minRememberDuration: Duration): Int = {
-    math.ceil(minRememberDuration.milliseconds.toDouble / batchDuration.milliseconds).toInt
+                                    minRememberDurationS: Duration): Int = {
+    math.ceil(minRememberDurationS.milliseconds.toDouble / batchDuration.milliseconds).toInt
   }
 }

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
@@ -86,9 +86,8 @@ class FileInputDStream[K, V, F <: NewInputFormat[K,V]](
    * Files with mod times older than this "window" of remembering will be ignored. So if new
    * files are visible within this window, then the file will get selected in the next batch.
    */
-  private val minRememberDurationMin = Minutes(ssc.sparkContext.getConf
-                                               .get("spark.streaming.minRememberDurationMin", "1")
-                                               .toLong)
+  private val minRememberDurationMin = Minutes(ssc.conf
+                                            .getLong("spark.streaming.minRememberDurationMin", 1L))
 
   // This is a def so that it works during checkpoint recovery:
   private def clock = ssc.scheduler.clock

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
@@ -26,7 +26,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path, PathFilter}
 import org.apache.hadoop.mapreduce.{InputFormat => NewInputFormat}
 
-import org.apache.spark.SerializableWritable
+import org.apache.spark.{SparkConf, SerializableWritable}
 import org.apache.spark.rdd.{RDD, UnionRDD}
 import org.apache.spark.streaming._
 import org.apache.spark.util.{TimeStampedHashMap, Utils}
@@ -331,11 +331,13 @@ private[streaming]
 object FileInputDStream {
 
   /**
-   * Minimum duration of remembering the information of selected files. Files with mod times
-   * older than this "window" of remembering will be ignored. So if new files are visible
-   * within this window, then the file will get selected in the next batch.
+   * Minimum duration of remembering the information of selected files. Defaults to 1 minute.
+   *
+   * Files with mod times older than this "window" of remembering will be ignored. So if new
+   * files are visible within this window, then the file will get selected in the next batch.
    */
-  private val MIN_REMEMBER_DURATION = Minutes(1)
+  private val minRememberDuration = new SparkConf().get("spark.streaming.minRememberDuration", "1")
+  private val MIN_REMEMBER_DURATION = Minutes(minRememberDuration.toLong)
 
   def defaultFilter(path: Path): Boolean = !path.getName().startsWith(".")
 


### PR DESCRIPTION
SPARK-3276 Added a new configuration parameter `spark.streaming.minRememberDuration`, with a default value of 1 minute.

So that when a Spark Streaming application is started, an arbitrary number of minutes can be taken as threshold for remembering.
