### PR TITLE
SPARK-6735:[YARN] Adding properties to disable maximum number of executor failure's check or to make it relative to duration

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -60,8 +60,7 @@ private[spark] class ApplicationMaster(
     sparkConf.getInt("spark.yarn.max.worker.failures", math.max(args.numExecutors * 2, 3)))
 
   // Disable the maximum executor failure check
-  private val disableMaxExecutorFailureCheck = 
-              sparkConf.getBoolean("spark.yarn.max.executor.failures.disable", false)
+  private val disableMaxExecutorFailureCheck =  if (maxNumExecutorFailures == -1) true else false
 
   @volatile private var exitCode = 0
   @volatile private var unregistered = false

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -59,6 +59,10 @@ private[spark] class ApplicationMaster(
   private val maxNumExecutorFailures = sparkConf.getInt("spark.yarn.max.executor.failures",
     sparkConf.getInt("spark.yarn.max.worker.failures", math.max(args.numExecutors * 2, 3)))
 
+  // Disable the maximum executor failure check
+  private val disableMaxExecutorFailureCheck = 
+              sparkConf.getBoolean("spark.yarn.max.executor.failures.disable", false)
+
   @volatile private var exitCode = 0
   @volatile private var unregistered = false
   @volatile private var finished = false
@@ -308,7 +312,8 @@ private[spark] class ApplicationMaster(
         var failureCount = 0
         while (!finished) {
           try {
-            if (allocator.getNumExecutorsFailed >= maxNumExecutorFailures) {
+            if (!disableMaxExecutorFailureCheck && 
+                 allocator.getNumExecutorsFailed >= maxNumExecutorFailures) {
               finish(FinalApplicationStatus.FAILED,
                 ApplicationMaster.EXIT_MAX_EXECUTOR_FAILURES,
                 "Max number of executor failures reached")

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -418,7 +418,9 @@ private[yarn] class YarnAllocator(
             ". Exit status: " + completedContainer.getExitStatus +
             ". Diagnostics: " + completedContainer.getDiagnostics)
           numExecutorsFailed += 1
-          executorFailureTimeStamps.push(System.currentTimeMillis / 1000)
+          if(relativeMaxExecutorFailureCheck) {
+             executorFailureTimeStamps.push(System.currentTimeMillis / 1000)
+          }
         }
       }
 


### PR DESCRIPTION
For long running applications, user might want to disable this property or to make it relative to a duration window, so that some older failure does not cause Application to abort in long run.

Added properties 1) spark.yarn.max.executor.failures.disable: to disable maximum executor failure check 2) spark.yarn.max.executor.failures.relative: to make the maximum executor failure to be relative 3)spark.yarn.max.executor.failures.relative.window: specify relative window duration in sec , default being 600 sec
