### PR TITLE
[Yarn][minor]Fix: avoid printing InterruptedException when application is finished in yarn mode.

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -570,7 +570,12 @@ private[spark] class Client(
     val interval = sparkConf.getLong("spark.yarn.report.interval", 1000)
     var lastState: YarnApplicationState = null
     while (true) {
-      Thread.sleep(interval)
+      try {
+        Thread.sleep(interval)
+      } catch {
+        case e: InterruptedException =>
+          logInfo(e.getMessage)
+      }
       val report: ApplicationReport =
         try {
           getApplicationReport(appId)


### PR DESCRIPTION
Driver log print some Exception message when stop application in yarn-client mode just like
<code>Exception in thread "Yarn application state monitor" 15/04/10 10:39:04 INFO YarnClientSchedulerBackend: Shutting down all executors</code>
<code>java.lang.InterruptedException: sleep interrupted</code>
<code>        at java.lang.Thread.sleep(Native Method)</code>
<code>        at org.apache.spark.deploy.yarn.Client.monitorApplication(Client.scala:572)</code>
<code>        at org.apache.spark.scheduler.cluster.YarnClientSchedulerBackend$$anon$1.run(YarnClientSchedulerBackend.scala:131)</code>
It's unnecessary and  puzzling.
