### PR TITLE
[SPARK-6866][Build] Remove duplicated dependency in launcher/pom.xml

### DIFF
--- a/launcher/pom.xml
+++ b/launcher/pom.xml
@@ -53,11 +53,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_${scala.binary.version}</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-6866

Remove duplicated dependency of scalatest in launcher/pom.xml since it already inherited the dependency from the parent pom.xml.
