### PR TITLE
[SPARK-6870][Yarn] Catch InterruptedException when yarn application state monitor thread been interrupted

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
+++ b/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
@@ -132,7 +132,6 @@ private[spark] class YarnClientSchedulerBackend(
           val (state, _) = client.monitorApplication(appId, logApplicationReport = false)
           logError(s"Yarn application has already exited with state $state!")
           sc.stop()
-          Thread.currentThread().interrupt()
         } catch {
           case e: InterruptedException => logInfo("Interrupting monitor thread")
         }

--- a/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
+++ b/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
@@ -127,11 +127,13 @@ private[spark] class YarnClientSchedulerBackend(
   private def asyncMonitorApplication(): Thread = {
     assert(client != null && appId != null, "Application has not been submitted yet!")
     val t = new Thread {
-      override def run() {
+      try {
         val (state, _) = client.monitorApplication(appId, logApplicationReport = false)
         logError(s"Yarn application has already exited with state $state!")
         sc.stop()
         Thread.currentThread().interrupt()
+      } catch {
+        case e : InterruptedException => logInfo("Interrupting monitor thread")
       }
     }
     t.setName("Yarn application state monitor")

--- a/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
+++ b/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
@@ -134,7 +134,7 @@ private[spark] class YarnClientSchedulerBackend(
           sc.stop()
           Thread.currentThread().interrupt()
         } catch {
-          case e : InterruptedException => logInfo("Interrupting monitor thread")
+          case e: InterruptedException => logInfo("Interrupting monitor thread")
         }
       }
     }

--- a/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
+++ b/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
@@ -127,13 +127,15 @@ private[spark] class YarnClientSchedulerBackend(
   private def asyncMonitorApplication(): Thread = {
     assert(client != null && appId != null, "Application has not been submitted yet!")
     val t = new Thread {
-      try {
-        val (state, _) = client.monitorApplication(appId, logApplicationReport = false)
-        logError(s"Yarn application has already exited with state $state!")
-        sc.stop()
-        Thread.currentThread().interrupt()
-      } catch {
-        case e : InterruptedException => logInfo("Interrupting monitor thread")
+      override def run() {
+        try {
+          val (state, _) = client.monitorApplication(appId, logApplicationReport = false)
+          logError(s"Yarn application has already exited with state $state!")
+          sc.stop()
+          Thread.currentThread().interrupt()
+        } catch {
+          case e : InterruptedException => logInfo("Interrupting monitor thread")
+        }
       }
     }
     t.setName("Yarn application state monitor")


### PR DESCRIPTION
On PR #5305 we interrupt the monitor thread but forget to catch the InterruptedException, then in the log will print the stack info, so we need to catch it.
