### PR TITLE
[CORE] SPARK-6880: Fixed null check when all the dependent stages are cancelled due to previous stage failure

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -818,13 +818,12 @@ class DAGScheduler(
       }
     }
 
-    val properties = if (jobIdToActiveJob.contains(jobId)) {
-      jobIdToActiveJob(stage.jobId).properties
-    } else {
-      // this stage will be assigned to "default" pool
-      null
+    val activeJob = jobIdToActiveJob.get(stage.jobId).getOrElse(null)
+    val properties = if (activeJob != null) { 
+        activeJob.properties 
+    } else { 
+        null
     }
-
     runningStages += stage
     // SparkListenerStageSubmitted should be posted before testing whether tasks are
     // serializable. If tasks are not serializable, a SparkListenerStageCompleted event

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -818,12 +818,8 @@ class DAGScheduler(
       }
     }
 
-    val activeJob = jobIdToActiveJob.get(stage.jobId).getOrElse(null)
-    val properties = if (activeJob != null) { 
-        activeJob.properties 
-    } else { 
-        null
-    }
+    val properties = jobIdToActiveJob.get(stage.jobId).map(_.properties).getOrElse(null)    
+
     runningStages += stage
     // SparkListenerStageSubmitted should be posted before testing whether tasks are
     // serializable. If tasks are not serializable, a SparkListenerStageCompleted event


### PR DESCRIPTION
Fixed null check when all the dependent stages are cancelled due to previous stage failure. This happens when one of the executor node goes down and all the dependent stages are cancelled.
