### PR TITLE
SPARK-5888. [MLLIB]. Add OneHotEncoder as a Transformer

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/OneHotEncoder.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/OneHotEncoder.scala
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.feature
+
+import org.apache.spark.annotation.AlphaComponent
+import org.apache.spark.ml.Transformer
+import org.apache.spark.ml.attribute.NominalAttribute
+import org.apache.spark.ml.param._
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{StringType, StructType}
+
+@AlphaComponent
+class OneHotEncoder(labelNames: Seq[String], includeFirst: Boolean = true) extends Transformer
+  with HasInputCol {
+
+  /** @group setParam */
+  def setInputCol(value: String): this.type = set(inputCol, value)
+
+  private def outputColName(index: Int): String = {
+    s"${get(inputCol)}_${labelNames(index)}"
+  }
+
+  override def transform(dataset: DataFrame, paramMap: ParamMap): DataFrame = {
+    val map = this.paramMap ++ paramMap
+
+    val startIndex = if (includeFirst) 0 else 1
+    val cols = (startIndex until labelNames.length).map { index =>
+      val colEncoder = udf { label: Double => if (index == label) 1.0 else 0.0 }
+      colEncoder(dataset(map(inputCol))).as(outputColName(index))
+    }
+
+    dataset.select(Array(col("*")) ++ cols: _*)
+  }
+
+  override def transformSchema(schema: StructType, paramMap: ParamMap): StructType = {
+    val map = this.paramMap ++ paramMap
+    checkInputColumn(schema, map(inputCol), StringType)
+    val inputFields = schema.fields
+    val startIndex = if (includeFirst) 0 else 1
+    val fields = (startIndex until labelNames.length).map { index =>
+      val colName = outputColName(index)
+      require(inputFields.forall(_.name != colName),
+        s"Output column $colName already exists.")
+      NominalAttribute.defaultAttr.withName(colName).toStructField()
+    }
+
+    val outputFields = inputFields ++ fields
+    StructType(outputFields)
+  }
+}

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/OneHotEncoder.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/OneHotEncoder.scala
@@ -32,8 +32,8 @@ import org.apache.spark.sql.types.{DataType, DoubleType, StructType}
  * with 5 categories, an input value of 2.0 would map to an output vector of
  * (0.0, 0.0, 1.0, 0.0, 0.0). If includeFirst is set to false, the first category is omitted, so the
  * output vector for the previous example would be (0.0, 1.0, 0.0, 0.0) and an input value
- * of 0.0 would map to a vector of all zeros.  Omitting the first category enables the vector
- * columns to be independent.
+ * of 0.0 would map to a vector of all zeros. Including the first category makes the vector columns
+ * linearly dependent because they sum up to one.
  */
 @AlphaComponent
 class OneHotEncoder extends UnaryTransformer[Double, Vector, OneHotEncoder]
@@ -43,8 +43,8 @@ class OneHotEncoder extends UnaryTransformer[Double, Vector, OneHotEncoder]
    * Whether to include a component in the encoded vectors for the first category, defaults to true.
    * @group param
    */
-  final val includeFirst: Param[Boolean] =
-    new Param[Boolean](this, "includeFirst", "include first category")
+  final val includeFirst: BooleanParam =
+    new BooleanParam(this, "includeFirst", "include first category")
   setDefault(includeFirst -> true)
 
   /**
@@ -59,7 +59,7 @@ class OneHotEncoder extends UnaryTransformer[Double, Vector, OneHotEncoder]
   def setIncludeFirst(value: Boolean): this.type = set(includeFirst, value)
 
   /** @group setParam */
-  def setLabelNames(value: Array[String]): this.type = set(labelNames, value)
+  def setLabelNames(attr: NominalAttribute): this.type = set(labelNames, attr.values.get)
 
   /** @group setParam */
   override def setInputCol(value: String): this.type = set(inputCol, value)

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/OneHotEncoder.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/OneHotEncoder.scala
@@ -18,49 +18,92 @@
 package org.apache.spark.ml.feature
 
 import org.apache.spark.annotation.AlphaComponent
-import org.apache.spark.ml.Transformer
+import org.apache.spark.ml.UnaryTransformer
 import org.apache.spark.ml.attribute.NominalAttribute
+import org.apache.spark.mllib.linalg.{Vector, Vectors, VectorUDT}
 import org.apache.spark.ml.param._
-import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types.{StringType, StructType}
+import org.apache.spark.ml.param.shared.{HasInputCol, HasOutputCol}
+import org.apache.spark.ml.util.SchemaUtils
+import org.apache.spark.sql.types.{DataType, DoubleType, StructType}
 
+/**
+ * A one-hot encoder that maps a column of label indices to a column of binary vectors, with
+ * at most a single one-value. By default, the binary vector has an element for each category, so
+ * with 5 categories, an input value of 2.0 would map to an output vector of
+ * (0.0, 0.0, 1.0, 0.0, 0.0). If includeFirst is set to false, the first category is omitted, so the
+ * output vector for the previous example would be (0.0, 1.0, 0.0, 0.0) and an input value
+ * of 0.0 would map to a vector of all zeros.  Omitting the first category enables the vector
+ * columns to be independent.
+ */
 @AlphaComponent
-class OneHotEncoder(labelNames: Seq[String], includeFirst: Boolean = true) extends Transformer
-  with HasInputCol {
+class OneHotEncoder extends UnaryTransformer[Double, Vector, OneHotEncoder]
+  with HasInputCol with HasOutputCol {
+
+  /**
+   * Whether to include a component in the encoded vectors for the first category, defaults to true.
+   * @group param
+   */
+  final val includeFirst: Param[Boolean] =
+    new Param[Boolean](this, "includeFirst", "include first category")
+  setDefault(includeFirst -> true)
+
+  /**
+   * The names of the categories. Used to identify them in the attributes of the output column.
+   * This is a required parameter.
+   * @group param
+   */
+  final val labelNames: Param[Array[String]] =
+    new Param[Array[String]](this, "labelNames", "categorical label names")
 
   /** @group setParam */
-  def setInputCol(value: String): this.type = set(inputCol, value)
+  def setIncludeFirst(value: Boolean): this.type = set(includeFirst, value)
 
-  private def outputColName(index: Int): String = {
-    s"${get(inputCol)}_${labelNames(index)}"
-  }
+  /** @group setParam */
+  def setLabelNames(value: Array[String]): this.type = set(labelNames, value)
 
-  override def transform(dataset: DataFrame, paramMap: ParamMap): DataFrame = {
-    val map = this.paramMap ++ paramMap
+  /** @group setParam */
+  override def setInputCol(value: String): this.type = set(inputCol, value)
 
-    val startIndex = if (includeFirst) 0 else 1
-    val cols = (startIndex until labelNames.length).map { index =>
-      val colEncoder = udf { label: Double => if (index == label) 1.0 else 0.0 }
-      colEncoder(dataset(map(inputCol))).as(outputColName(index))
-    }
-
-    dataset.select(Array(col("*")) ++ cols: _*)
-  }
+  /** @group setParam */
+  override def setOutputCol(value: String): this.type = set(outputCol, value)
 
   override def transformSchema(schema: StructType, paramMap: ParamMap): StructType = {
-    val map = this.paramMap ++ paramMap
-    checkInputColumn(schema, map(inputCol), StringType)
+    val map = extractParamMap(paramMap)
+    SchemaUtils.checkColumnType(schema, map(inputCol), DoubleType)
     val inputFields = schema.fields
-    val startIndex = if (includeFirst) 0 else 1
-    val fields = (startIndex until labelNames.length).map { index =>
-      val colName = outputColName(index)
-      require(inputFields.forall(_.name != colName),
-        s"Output column $colName already exists.")
-      NominalAttribute.defaultAttr.withName(colName).toStructField()
-    }
-
-    val outputFields = inputFields ++ fields
+    val outputColName = map(outputCol)
+    require(inputFields.forall(_.name != outputColName),
+      s"Output column $outputColName already exists.")
+    require(map.contains(labelNames), "OneHotEncoder missing category names")
+    val categories = map(labelNames)
+    val attrValues = (if (map(includeFirst)) categories else categories.drop(1)).toArray
+    val attr = NominalAttribute.defaultAttr.withName(outputColName).withValues(attrValues)
+    val outputFields = inputFields :+ attr.toStructField()
     StructType(outputFields)
   }
+
+  protected def createTransformFunc(paramMap: ParamMap): (Double) => Vector = {
+    val map = extractParamMap(paramMap)
+    val first = map(includeFirst)
+    val vecLen = if (first) map(labelNames).length else map(labelNames).length - 1
+    val oneValue = Array(1.0)
+    val emptyValues = Array[Double]()
+    val emptyIndices = Array[Int]()
+    label: Double => {
+      val values = if (first || label != 0.0) oneValue else emptyValues
+      val indices = if (first) {
+        Array(label.toInt)
+      } else if (label != 0.0) {
+        Array(label.toInt - 1)
+      } else {
+        emptyIndices
+      }
+      Vectors.sparse(vecLen, indices, values)
+    }
+  }
+
+  /**
+   * Returns the data type of the output column.
+   */
+  protected def outputDataType: DataType = new VectorUDT
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/OneHotEncoderSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/OneHotEncoderSuite.scala
@@ -17,13 +17,12 @@
 
 package org.apache.spark.ml.feature
 
-import org.apache.spark.ml.attribute.{Attribute, NominalAttribute}
+import org.scalatest.FunSuite
+
 import org.apache.spark.mllib.linalg.Vector
 import org.apache.spark.mllib.util.MLlibTestSparkContext
-
 import org.apache.spark.sql.{DataFrame, SQLContext}
 
-import org.scalatest.FunSuite
 
 class OneHotEncoderSuite extends FunSuite with MLlibTestSparkContext {
   private var sqlContext: SQLContext = _
@@ -33,23 +32,19 @@ class OneHotEncoderSuite extends FunSuite with MLlibTestSparkContext {
     sqlContext = new SQLContext(sc)
   }
 
-  def stringIndexed(): (DataFrame, NominalAttribute) = {
+  def stringIndexed(): DataFrame = {
     val data = sc.parallelize(Seq((0, "a"), (1, "b"), (2, "c"), (3, "a"), (4, "a"), (5, "c")), 2)
     val df = sqlContext.createDataFrame(data).toDF("id", "label")
     val indexer = new StringIndexer()
       .setInputCol("label")
       .setOutputCol("labelIndex")
       .fit(df)
-    val transformed = indexer.transform(df)
-    val attr = Attribute.fromStructField(transformed.schema("labelIndex"))
-      .asInstanceOf[NominalAttribute]
-    (transformed, attr)
+    indexer.transform(df)
   }
 
   test("OneHotEncoder includeFirst = true") {
-    val (transformed, attr) = stringIndexed()
+    val transformed = stringIndexed()
     val encoder = new OneHotEncoder()
-      .setLabelNames(attr)
       .setInputCol("labelIndex")
       .setOutputCol("labelVec")
     val encoded = encoder.transform(transformed)
@@ -65,10 +60,9 @@ class OneHotEncoderSuite extends FunSuite with MLlibTestSparkContext {
   }
 
   test("OneHotEncoder includeFirst = false") {
-    val (transformed, attr) = stringIndexed()
+    val transformed = stringIndexed()
     val encoder = new OneHotEncoder()
       .setIncludeFirst(false)
-      .setLabelNames(attr)
       .setInputCol("labelIndex")
       .setOutputCol("labelVec")
     val encoded = encoder.transform(transformed)

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/OneHotEncoderSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/OneHotEncoderSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.ml.feature
 
-import org.apache.spark.ml.attribute.{NominalAttribute, Attribute}
+import org.apache.spark.ml.attribute.{Attribute, NominalAttribute}
 import org.apache.spark.mllib.linalg.Vector
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 
@@ -49,7 +49,7 @@ class OneHotEncoderSuite extends FunSuite with MLlibTestSparkContext {
   test("OneHotEncoder includeFirst = true") {
     val (transformed, attr) = stringIndexed()
     val encoder = new OneHotEncoder()
-      .setLabelNames(attr.values.get)
+      .setLabelNames(attr)
       .setInputCol("labelIndex")
       .setOutputCol("labelVec")
     val encoded = encoder.transform(transformed)
@@ -68,7 +68,7 @@ class OneHotEncoderSuite extends FunSuite with MLlibTestSparkContext {
     val (transformed, attr) = stringIndexed()
     val encoder = new OneHotEncoder()
       .setIncludeFirst(false)
-      .setLabelNames(attr.values.get)
+      .setLabelNames(attr)
       .setInputCol("labelIndex")
       .setOutputCol("labelVec")
     val encoded = encoder.transform(transformed)

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/OneHotEncoderSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/OneHotEncoderSuite.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.feature
+
+import org.apache.spark.mllib.util.MLlibTestSparkContext
+
+import org.scalatest.FunSuite
+import org.apache.spark.sql.SQLContext
+import org.apache.spark.ml.attribute.{NominalAttribute, Attribute}
+
+class OneHotEncoderSuite extends FunSuite with MLlibTestSparkContext {
+  private var sqlContext: SQLContext = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    sqlContext = new SQLContext(sc)
+  }
+
+  test("OneHotEncoder") {
+    val data = sc.parallelize(Seq((0, "a"), (1, "b"), (2, "c"), (3, "a"), (4, "a"), (5, "c")), 2)
+    val df = sqlContext.createDataFrame(data).toDF("id", "label")
+    val indexer = new StringIndexer()
+      .setInputCol("label")
+      .setOutputCol("labelIndex")
+      .fit(df)
+    val transformed = indexer.transform(df)
+    val attr = Attribute.fromStructField(transformed.schema("labelIndex"))
+      .asInstanceOf[NominalAttribute]
+    assert(attr.values.get === Array("a", "c", "b"))
+
+    val encoder = new OneHotEncoder(attr.values.get)
+      .setInputCol("labelIndex")
+    val encoded = encoder.transform(transformed)
+
+    val output = encoded.select("id", "labelIndex_a", "labelIndex_c", "labelIndex_b").map { r =>
+      (r.getInt(0), r.getDouble(1), r.getDouble(2), r.getDouble(3))
+    }.collect().toSet
+    // a -> 0, b -> 2, c -> 1
+    val expected = Set((0, 1.0, 0.0, 0.0), (1, 0.0, 0.0, 1.0), (2, 0.0, 1.0, 0.0),
+      (3, 1.0, 0.0, 0.0), (4, 1.0, 0.0, 0.0), (5, 0.0, 1.0, 0.0))
+    assert(output === expected)
+  }
+
+}


### PR DESCRIPTION
This patch adds a one hot encoder for categorical features.  Planning to add documentation and another test after getting feedback on the approach.

A couple choices made here:
- There's an `includeFirst` option which, if false, creates numCategories - 1 columns and, if true, creates numCategories columns.  The default is true, which is the behavior in scikit-learn.
- The user is expected to pass a `Seq` of category names when instantiating a `OneHotEncoder`.  These can be easily gotten from a `StringIndexer`.  The names are used for the output column names, which take the form colName_categoryName.
