### PR TITLE
[SPARK-6703][Core] Provide a way to discover existing SparkContext's

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1857,14 +1857,23 @@ object SparkContext extends Logging {
   /**
    * Because we can only have one active Spark Context per JVM and there are times when multiple
    * applications may wish to share a SparkContext, this function may be used to get or instantiate
-   * a SparkContext and register it as a singleton object. 
+   * a SparkContext and register it as a singleton object.
+   * 
+   * Note: This function cannot be used to create multiple spark contexts even if multiple contexts
+   * are allowed. Multiple contexts will still need to be created with explicit calls to the 
+   * SparkContext constructor. 
    */
-  private[spark] def getOrCreate(config: SparkConf = new SparkConf()): SparkContext = {
+  def getOrCreate(config: SparkConf): SparkContext = {
     activeContext match {
       case None => setActiveContext(new SparkContext(config), 
           config.getBoolean("spark.driver.allowMultipleContexts", false))
     }
     activeContext.get
+  }
+  
+  /** Allow not passing a SparkConf (useful if just retrieving) */ 
+  def getOrCreate(): SparkContext = {
+    getOrCreate(new SparkConf())
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1860,14 +1860,13 @@ object SparkContext extends Logging {
    * This function may be used to get or instantiate a SparkContext and register it as a 
    * singleton object. Because we can only have one active SparkContext per JVM, 
    * this is useful when applications may wish to share a SparkContext. 
-   * 
-   * Note: This function cannot be used to create multiple SparkContexts even if multiple contexts
-   * are allowed. 
+   *
+   * Note: This function cannot be used to create multiple SparkContext instances 
+   * even if multiple contexts are allowed.
    */
   def getOrCreate(config: SparkConf): SparkContext = {
     if (activeContext.get() == null) {
-      setActiveContext(new SparkContext(config), 
-        config.getBoolean("spark.driver.allowMultipleContexts", false))
+      setActiveContext(new SparkContext(config), allowMultipleContexts = false)
     }
     activeContext.get()
   }
@@ -1877,10 +1876,10 @@ object SparkContext extends Logging {
    * singleton object. Because we can only have one active SparkContext per JVM, 
    * this is useful when applications may wish to share a SparkContext.
    * 
-   * This method allows not passing a SparkConf (useful if just retrieving) 
+   * This method allows not passing a SparkConf (useful if just retrieving).
    * 
-   * Note: This function cannot be used to create multiple SparkContexts even if multiple contexts
-   * are allowed. 
+   * Note: This function cannot be used to create multiple SparkContext instances 
+   * even if multiple contexts are allowed. 
    */ 
   def getOrCreate(): SparkContext = {
     getOrCreate(new SparkConf())

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1864,9 +1864,9 @@ object SparkContext extends Logging {
    * SparkContext constructor. 
    */
   def getOrCreate(config: SparkConf): SparkContext = {
-    activeContext match {
-      case None => setActiveContext(new SparkContext(config), 
-          config.getBoolean("spark.driver.allowMultipleContexts", false))
+    if (activeContext.isEmpty) {
+      setActiveContext(new SparkContext(config), 
+        config.getBoolean("spark.driver.allowMultipleContexts", false))
     }
     activeContext.get
   }

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1813,7 +1813,7 @@ object SparkContext extends Logging {
    * Access to this field is guarded by SPARK_CONTEXT_CONSTRUCTOR_LOCK
    */
   private var contextBeingConstructed: Option[SparkContext] = None
-
+  
   /**
    * Called to ensure that no other SparkContext is running in this JVM.
    *
@@ -1852,6 +1852,19 @@ object SparkContext extends Logging {
         }
       }
     }
+  }
+
+  /**
+   * Because we can only have one active Spark Context per JVM and there are times when multiple
+   * applications may wish to share a SparkContext, this function may be used to get or instantiate
+   * a SparkContext and register it as a singleton object. 
+   */
+  private[spark] def getOrCreate(config: SparkConf = new SparkConf()): SparkContext = {
+    activeContext match {
+      case None => setActiveContext(new SparkContext(config), 
+          config.getBoolean("spark.driver.allowMultipleContexts", false))
+    }
+    activeContext.get
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1857,23 +1857,31 @@ object SparkContext extends Logging {
   }
 
   /**
-   * Because we can only have one active Spark Context per JVM and there are times when multiple
-   * applications may wish to share a SparkContext, this function may be used to get or instantiate
-   * a SparkContext and register it as a singleton object.
+   * This function may be used to get or instantiate a SparkContext and register it as a 
+   * singleton object. Because we can only have one active SparkContext per JVM, 
+   * this is useful when applications may wish to share a SparkContext. 
    * 
-   * Note: This function cannot be used to create multiple spark contexts even if multiple contexts
-   * are allowed. Multiple contexts will still need to be created with explicit calls to the 
-   * SparkContext constructor. 
+   * Note: This function cannot be used to create multiple SparkContexts even if multiple contexts
+   * are allowed. 
    */
   def getOrCreate(config: SparkConf): SparkContext = {
-    if (activeContext.get() != null) {
+    if (activeContext.get() == null) {
       setActiveContext(new SparkContext(config), 
         config.getBoolean("spark.driver.allowMultipleContexts", false))
     }
     activeContext.get()
   }
   
-  /** Allow not passing a SparkConf (useful if just retrieving) */ 
+  /**
+   * This function may be used to get or instantiate a SparkContext and register it as a 
+   * singleton object. Because we can only have one active SparkContext per JVM, 
+   * this is useful when applications may wish to share a SparkContext.
+   * 
+   * This method allows not passing a SparkConf (useful if just retrieving) 
+   * 
+   * Note: This function cannot be used to create multiple SparkContexts even if multiple contexts
+   * are allowed. 
+   */ 
   def getOrCreate(): SparkContext = {
     getOrCreate(new SparkConf())
   }

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1800,9 +1800,9 @@ object SparkContext extends Logging {
   private val SPARK_CONTEXT_CONSTRUCTOR_LOCK = new Object()
 
   /**
-   * The active, fully-constructed SparkContext.  If no SparkContext is active, then this is `None`.
+   * The active, fully-constructed SparkContext.  If no SparkContext is active, then this is `null`.
    *
-   * Access to this field is guarded by SPARK_CONTEXT_CONSTRUCTOR_LOCK
+   * Access to this field is guarded by SPARK_CONTEXT_CONSTRUCTOR_LOCK.
    */
   private val activeContext: AtomicReference[SparkContext] = 
     new AtomicReference[SparkContext](null)
@@ -1840,7 +1840,7 @@ object SparkContext extends Logging {
           logWarning(warnMsg)
         }
 
-        if(activeContext.get() != null) {
+        if (activeContext.get() != null) {
           val ctx = activeContext.get()
           val errMsg = "Only one SparkContext may be running in this JVM (see SPARK-2243)." +
             " To ignore this error, set spark.driver.allowMultipleContexts = true. " +

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1813,7 +1813,7 @@ object SparkContext extends Logging {
    * Access to this field is guarded by SPARK_CONTEXT_CONSTRUCTOR_LOCK
    */
   private var contextBeingConstructed: Option[SparkContext] = None
-  
+
   /**
    * Called to ensure that no other SparkContext is running in this JVM.
    *

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -68,20 +68,19 @@ class SparkContextSuite extends FunSuite with LocalSparkContext {
   }
 
   test("Test getOrCreateContext") {
+    var sc2: SparkContext = null
     SparkContext.clearActiveContext()
-    var context: SparkContext = 
-      SparkContext.getOrCreate(new SparkConf().setAppName("test").setMaster("local")
-        .set("spark.driver.allowMultipleContexts", "true"))
+    val conf = new SparkConf().setAppName("test").setMaster("local")
+        .set("spark.driver.allowMultipleContexts", "true")
     
-    assert(context.getConf.getAppId)
-    try {
-      val conf = new SparkConf().setAppName("test").setMaster("local")
-          .set("spark.driver.allowMultipleContexts", "true")
-      sc = new SparkContext(conf)
-      secondSparkContext = new SparkContext(conf)
-    } finally {
-      Option(secondSparkContext).foreach(_.stop())
-    }
+    sc = SparkContext.getOrCreate(conf)
+    
+    assert(sc.getConf.get("spark.app.name").equals("test"))
+    sc2 = SparkContext.getOrCreate(new SparkConf().setAppName("test2").setMaster("local"))
+    assert(sc2.getConf.get("spark.app.name").equals("test"))
+    
+    // Try creating second context to confirm that it's still possible, if desired
+    sc2 = new SparkContext(new SparkConf().setAppName("test3"))
   }
   
   test("BytesWritable implicit conversion is correct") {

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -80,7 +80,8 @@ class SparkContextSuite extends FunSuite with LocalSparkContext {
     assert(sc2.getConf.get("spark.app.name").equals("test"))
     
     // Try creating second context to confirm that it's still possible, if desired
-    sc2 = new SparkContext(new SparkConf().setAppName("test3"))
+    sc2 = new SparkContext(new SparkConf().setAppName("test3").setMaster("local")
+        .set("spark.driver.allowMultipleContexts", "true"))
   }
   
   test("BytesWritable implicit conversion is correct") {

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -67,6 +67,23 @@ class SparkContextSuite extends FunSuite with LocalSparkContext {
     }
   }
 
+  test("Test getOrCreateContext") {
+    SparkContext.clearActiveContext()
+    var context: SparkContext = 
+      SparkContext.getOrCreate(new SparkConf().setAppName("test").setMaster("local")
+        .set("spark.driver.allowMultipleContexts", "true"))
+    
+    assert(context.getConf.getAppId)
+    try {
+      val conf = new SparkConf().setAppName("test").setMaster("local")
+          .set("spark.driver.allowMultipleContexts", "true")
+      sc = new SparkContext(conf)
+      secondSparkContext = new SparkContext(conf)
+    } finally {
+      Option(secondSparkContext).foreach(_.stop())
+    }
+  }
+  
   test("BytesWritable implicit conversion is correct") {
     // Regression test for SPARK-3121
     val bytesWritable = new BytesWritable()

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -78,6 +78,7 @@ class SparkContextSuite extends FunSuite with LocalSparkContext {
     sc2 = SparkContext.getOrCreate(new SparkConf().setAppName("test2").setMaster("local"))
     assert(sc2.getConf.get("spark.app.name").equals("test"))
     assert(sc === sc2)
+    assert(sc eq sc2)
     
     // Try creating second context to confirm that it's still possible, if desired
     sc2 = new SparkContext(new SparkConf().setAppName("test3").setMaster("local")

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -77,6 +77,7 @@ class SparkContextSuite extends FunSuite with LocalSparkContext {
     assert(sc.getConf.get("spark.app.name").equals("test"))
     sc2 = SparkContext.getOrCreate(new SparkConf().setAppName("test2").setMaster("local"))
     assert(sc2.getConf.get("spark.app.name").equals("test"))
+    assert(sc === sc2)
     
     // Try creating second context to confirm that it's still possible, if desired
     sc2 = new SparkContext(new SparkConf().setAppName("test3").setMaster("local")

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -67,11 +67,10 @@ class SparkContextSuite extends FunSuite with LocalSparkContext {
     }
   }
 
-  test("Test getOrCreateContext") {
+  test("Test getOrCreate") {
     var sc2: SparkContext = null
     SparkContext.clearActiveContext()
     val conf = new SparkConf().setAppName("test").setMaster("local")
-        .set("spark.driver.allowMultipleContexts", "true")
     
     sc = SparkContext.getOrCreate(conf)
     

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -83,6 +83,8 @@ class SparkContextSuite extends FunSuite with LocalSparkContext {
     // Try creating second context to confirm that it's still possible, if desired
     sc2 = new SparkContext(new SparkConf().setAppName("test3").setMaster("local")
         .set("spark.driver.allowMultipleContexts", "true"))
+    
+    sc2.stop()
   }
   
   test("BytesWritable implicit conversion is correct") {

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -68,6 +68,10 @@ object MimaExcludes {
             // SPARK-6693 add tostring with max lines and width for matrix
             ProblemFilters.exclude[MissingMethodProblem](
               "org.apache.spark.mllib.linalg.Matrix.toString")
+          )++ Seq(
+            // SPARK-6703 Add getOrCreate method to SparkContext
+            ProblemFilters.exclude[IncompatibleResultTypeProblem]
+                ("org.apache.spark.SparkContext.org$apache$spark$SparkContext$$activeContext")
           )
 
         case v if v.startsWith("1.3") =>


### PR DESCRIPTION
I've added a static getOrCreate method to the static SparkContext object that allows one to either retrieve a previously created SparkContext or to instantiate a new one with the provided config. The method accepts an optional SparkConf to make usage intuitive. 

Still working on a test for this, basically want to create a new context from scratch, then ensure that subsequent calls don't overwrite that. 
