### PR TITLE
[SPARK-6897][Streaming]remove volatile from BlockingGenerator.currentBuffer to reduce unnecessary overhead

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/BlockGenerator.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/BlockGenerator.scala
@@ -86,7 +86,7 @@ private[streaming] class BlockGenerator(
   private val blocksForPushing = new ArrayBlockingQueue[Block](blockQueueSize)
   private val blockPushingThread = new Thread() { override def run() { keepPushingBlocks() } }
 
-  @volatile private var currentBuffer = new ArrayBuffer[Any]
+  private var currentBuffer = new ArrayBuffer[Any] //protected by synchronized
   @volatile private var stopped = false
 
   /** Start block generating and pushing threads. */

--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/BlockGenerator.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/BlockGenerator.scala
@@ -86,7 +86,7 @@ private[streaming] class BlockGenerator(
   private val blocksForPushing = new ArrayBlockingQueue[Block](blockQueueSize)
   private val blockPushingThread = new Thread() { override def run() { keepPushingBlocks() } }
 
-  private var currentBuffer = new ArrayBuffer[Any] //protected by synchronized
+  private var currentBuffer = new ArrayBuffer[Any]   // protected by synchronized
   @volatile private var stopped = false
 
   /** Start block generating and pushing threads. */


### PR DESCRIPTION
currentBuffer has been protected by synchronized, so it would introduce unnecessary overhead for adding an extra volatile modifier here.

Hi @srowen , Found this while walking through the source code, could you pls review if we need to take this since it's only a trivial stuff ? 
