### PR TITLE
[SPARK-6903][SQL]Eliminate partition filters from execution.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/parquet/newParquet.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/parquet/newParquet.scala
@@ -398,7 +398,8 @@ private[sql] case class ParquetRelation2(
 
   def isPartitioned: Boolean = partitionColumns.nonEmpty
 
-  private def partitionKeysIncludedInDataSchema = metadataCache.partitionKeysIncludedInParquetSchema
+  def partitionKeysIncludedInDataSchema: Boolean =
+    metadataCache.partitionKeysIncludedInParquetSchema
 
   private def parquetSchema = metadataCache.parquetSchema
 


### PR DESCRIPTION
Eliminate partition filters from execution.Filter if partition key is included neither in original schema nor in filter's parents

Suppose I have a table t(id: String, event: String) saved as parquet file, and have directory hierarchy: hdfs://path/to/data/root/dt=2015-01-01/hr=00

After partition discovery, the result schema should be (id: String, event: String, dt: String, hr: Int)

If I have a query like:

df.select($“id”).filter(event match).filter($“dt” > “2015-01-01”).filter($”hr” > 13)

In current implementation, after (dt > 2015-01-01 && hr >13) is used to filter partitions, 
these two filters remains in execution plan and result in each row returned from parquet add two fields dt & hr each time,  

This PR just eliminate the partition filters from execution.Filter as well as requestedColumns from parquetRelation2, if partition key is included neither in original schema nor in filter's parents, therefore avoid the row construction involved in each row.
