### PR TITLE
[SPARK-6901][Ml]ParamGridBuilder.build with no grids should return an emty array

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/ParamGridBuilder.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/ParamGridBuilder.scala
@@ -100,14 +100,16 @@ class ParamGridBuilder {
    * Builds and returns all combinations of parameters specified by the param grid.
    */
   def build(): Array[ParamMap] = {
-    var paramMaps = Array.empty[ParamMap]
-    paramGrid.foreach { case (param, values) =>
-      val newParamMaps = values.flatMap { v =>
-        {if (paramMaps.isEmpty) Array(new ParamMap) else paramMaps}
-        .map(_.copy.put(param.asInstanceOf[Param[Any]], v))
+    if (paramGrid.isEmpty) Array.empty[ParamMap]
+    else {
+      var paramMaps = Array(new ParamMap)
+      paramGrid.foreach { case (param, values) =>
+        val newParamMaps = values.flatMap { v =>
+          paramMaps.map(_.copy.put(param.asInstanceOf[Param[Any]], v))
+        }
+        paramMaps = newParamMaps.toArray
       }
-      paramMaps = newParamMaps.toArray
+      paramMaps
     }
-    paramMaps
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/ParamGridBuilder.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/ParamGridBuilder.scala
@@ -100,8 +100,9 @@ class ParamGridBuilder {
    * Builds and returns all combinations of parameters specified by the param grid.
    */
   def build(): Array[ParamMap] = {
-    if (paramGrid.isEmpty) Array.empty[ParamMap]
-    else {
+    if (paramGrid.isEmpty) {
+      Array.empty[ParamMap]
+    } else {
       var paramMaps = Array(new ParamMap)
       paramGrid.foreach { case (param, values) =>
         val newParamMaps = values.flatMap { v =>

--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/ParamGridBuilder.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/ParamGridBuilder.scala
@@ -100,10 +100,11 @@ class ParamGridBuilder {
    * Builds and returns all combinations of parameters specified by the param grid.
    */
   def build(): Array[ParamMap] = {
-    var paramMaps = Array(new ParamMap)
+    var paramMaps = Array.empty[ParamMap]
     paramGrid.foreach { case (param, values) =>
       val newParamMaps = values.flatMap { v =>
-        paramMaps.map(_.copy.put(param.asInstanceOf[Param[Any]], v))
+        {if (paramMaps.isEmpty) Array(new ParamMap) else paramMaps}
+        .map(_.copy.put(param.asInstanceOf[Param[Any]], v))
       }
       paramMaps = newParamMaps.toArray
     }

--- a/mllib/src/test/scala/org/apache/spark/ml/tuning/ParamGridBuilderSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tuning/ParamGridBuilderSuite.scala
@@ -59,5 +59,9 @@ class ParamGridBuilderSuite extends FunSuite {
       (10, "input1"),
       (20, "input1"))
     validateGrid(maps1, expected1)
+
+    val maps2 = (new ParamGridBuilder()).build()
+    val expected2 = mutable.Set.empty[(Int, String)]
+    validateGrid(maps2, expected2)
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/tuning/ParamGridBuilderSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tuning/ParamGridBuilderSuite.scala
@@ -60,7 +60,7 @@ class ParamGridBuilderSuite extends FunSuite {
       (20, "input1"))
     validateGrid(maps1, expected1)
 
-    val maps2 = (new ParamGridBuilder()).build()
+    val maps2 = new ParamGridBuilder().build()
     val expected2 = mutable.Set.empty[(Int, String)]
     validateGrid(maps2, expected2)
   }


### PR DESCRIPTION
ParamGridBuilder.build with no grid points returns an array with an empty param map.

``` scala
assert((new ParamGridBuilder).build().size == 1)
```

I have a logic if ParamGridBuilder is empty - then not use CrossValidator. It confuses because if the ParamGridBuilder has one grid point in it will also return an array of size 1:

``` scala
assert((new ParamGridBuilder).addGrid(lr.regParam, Array(0.1)).build().size == 1)
```
