### PR TITLE
[SPARK-6905] Upgrade to snappy-java 1.1.1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
     <jodd.version>3.6.3</jodd.version>
     <codehaus.jackson.version>1.8.8</codehaus.jackson.version>
     <fasterxml.jackson.version>2.4.4</fasterxml.jackson.version>
-    <snappy.version>1.1.1.6</snappy.version>
+    <snappy.version>1.1.1.7</snappy.version>
     <netlib.java.version>1.1.2</netlib.java.version>
 
     <test.java.home>${java.home}</test.java.home>


### PR DESCRIPTION
We should upgrade our snappy-java dependency to 1.1.1.7 in order to include a fix for a bug that results in worse compression in SnappyOutputStream (see https://github.com/xerial/snappy-java/issues/100).
