### PR TITLE
[SPARK-6928][Spark Shell]Fixed spark-shell exception after :replay command

### DIFF
--- a/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -992,7 +992,7 @@ class SparkILoop(
     // printWelcome()
 
     loadFiles(settings)
-
+    intp.saveCheckpoint()
     try loop()
     catch AbstractOrMissingHandler()
     finally closeInterpreter()

--- a/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkIMain.scala
+++ b/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkIMain.scala
@@ -981,19 +981,20 @@ import org.apache.spark.annotation.DeveloperApi
     resetAllCreators()
     resetToCheckpoint()
   }
-    /** Save  previous Requests,referenced Names  and defined Names
-      * later these values can be used in reset operation
-      */
+  /**
+   * Save  previous Requests,referenced Names  and defined Names
+   * later these values can be used in reset operation
+   */
     @DeveloperApi
   def saveCheckpoint() {
     prevRequestsCheckpoint      ++= prevRequests.clone()
     referencedNameMapCheckpoint ++= referencedNameMap.clone()
     definedNameMapCheckpoint    ++=definedNameMap.clone()
   }
-
-    /** Reset prevRequests,referencedNameMap and definedNameMap to
-      * checkpointed state, so that it will only retain  spark initialization details
-      */
+  /**
+   * Reset prevRequests,referencedNameMap and definedNameMap to
+   * checkpointed state, so that it will only retain  spark initialization details
+   */
   def resetToCheckpoint() {
     prevRequests.clear()
     referencedNameMap.clear()
@@ -1003,7 +1004,6 @@ import org.apache.spark.annotation.DeveloperApi
     referencedNameMap ++= referencedNameMapCheckpoint
     definedNameMap    ++= definedNameMapCheckpoint
   }
-
   /**
    * Stops the underlying REPL class server and flushes the reporter used
    * for compiler output.

--- a/repl/scala-2.10/src/test/scala/org/apache/spark/repl/ReplSuite.scala
+++ b/repl/scala-2.10/src/test/scala/org/apache/spark/repl/ReplSuite.scala
@@ -71,6 +71,11 @@ class ReplSuite extends FunSuite {
       "Interpreter output did not contain '" + message + "':\n" + output)
   }
 
+  def assertContains(message: String, output: String,expectedCount: Int) {
+    assert(output.split(message).length >= expectedCount,
+      "Interpreter output did not contain " + expectedCount + " '" + message + "':\n" + output)
+  }
+
   def assertDoesNotContain(message: String, output: String) {
     val isContain = output.contains(message)
     assert(!isContain,
@@ -115,6 +120,17 @@ class ReplSuite extends FunSuite {
     assertDoesNotContain("error:", output)
     assertDoesNotContain("Exception", output)
     assertContains("res1: Int = 55", output)
+  }
+
+  test("replay command") {
+    val output = runInterpreter("local",
+      """
+        |sc.parallelize(1 to 10).collect().reduceLeft(_+_)
+        |:replay
+      """.stripMargin)
+    assertDoesNotContain("error:", output)
+    assertDoesNotContain("Exception", output)
+    assertContains("res0: Int = 55", output,2)
   }
 
   test("external vars") {


### PR DESCRIPTION
On replay command , Spark REPL calls reset method  before playing the previous commands.Since reset method currently  recreates the classloader and deletes directories , which stores .class files, any further scala/spark APIs will not be able to compile and run user commands.

To handle this issue, just after Spark loop initialization , interpreter has to cache the configurations  and then reinitialize that cached  values in interpreter reset method .
