### PR TITLE
[SPARK-6930][Build]Build with Hive Thrift Server error, because of missing guava

### DIFF
--- a/sql/hive-thriftserver/pom.xml
+++ b/sql/hive-thriftserver/pom.xml
@@ -44,7 +44,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>${hive.group}</groupId>


### PR DESCRIPTION
change scope of dependency guava to default value : compile
