### PR TITLE
[Spark-6924]Fix driver hangs in yarn-client mode when net is broken

### DIFF
--- a/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
@@ -132,6 +132,10 @@ private[spark] class HeartbeatReceiver(sc: SparkContext)
         executorLastSeen.remove(executorId)
       }
     }
+
+    if (!sc.conf.getBoolean("spark.dynamicAllocation.enabled", false) && sc.isInited) {
+      if (executorLastSeen.keySet.size == 0) sc.stop()
+    }
   }
   
   override def onStop(): Unit = {

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -75,6 +75,8 @@ import org.apache.spark.util._
  */
 class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationClient {
 
+  var isInited: Boolean = false
+
   // The call site where this SparkContext was constructed.
   private val creationSite: CallSite = Utils.getCallSite()
 
@@ -1786,6 +1788,8 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
   // context as having finished construction.
   // NOTE: this must be placed at the end of the SparkContext constructor.
   SparkContext.setActiveContext(this, allowMultipleContexts)
+
+  isInited = true
 }
 
 /**


### PR DESCRIPTION
In yarn-client mode, client is deployed out side of cluster. When the net between client and cluster is broken, driver lost all executors. In normal situation, client returns and app fails. Actually, the driver hangs, user do not know  whether app is ok. So we should let driver return not hang.
The solution: in HeartbeatReceiver thread, check whether some executor send heartbeat to dirver at the fixed rate. If no execuor send heartbeats to driver, close SparkContext. 

https://issues.apache.org/jira/browse/SPARK-6924
