### PR TITLE
[SPARK-6954] [YARN] Dynamic allocation: numExecutorsPending in ExecutorAllocationManager should never become negative

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -315,7 +315,7 @@ private[spark] class ExecutorAllocationManager(
    */
   private def updateNumExecutorsPending(newTotalExecutors: Int): Int = {
     val newNumExecutorsPending =
-      newTotalExecutors - executorIds.size + executorsPendingToRemove.size
+      math.max(0, newTotalExecutors - executorIds.size + executorsPendingToRemove.size)
     val delta = newNumExecutorsPending - numExecutorsPending
     numExecutorsPending = newNumExecutorsPending
     delta


### PR DESCRIPTION
Make sure `numExecutorsPending` in `ExecutorAllocationManager` be non-negative.
