### PR TITLE
[SPARK-5352][GraphX] Add getPartitionStrategy in Graph 

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/Graph.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/Graph.scala
@@ -79,6 +79,9 @@ abstract class Graph[VD: ClassTag, ED: ClassTag] protected () extends Serializab
    */
   @transient val triplets: RDD[EdgeTriplet[VD, ED]]
 
+  /** Return a strategy to specify how edges are partitioned. */
+  def getPartitionStrategy: Option[PartitionStrategy]
+
   /**
    * Caches the vertices and edges associated with this graph at the specified storage level,
    * ignoring any target storage levels previously set.

--- a/graphx/src/main/scala/org/apache/spark/graphx/impl/GraphImpl.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/impl/GraphImpl.scala
@@ -53,6 +53,10 @@ class GraphImpl[VD: ClassTag, ED: ClassTag] protected (
     })
   }
 
+  @transient var partitionStrategy: Option[PartitionStrategy] = None
+
+  override def getPartitionStrategy: Option[PartitionStrategy] = partitionStrategy
+
   override def persist(newLevel: StorageLevel): Graph[VD, ED] = {
     vertices.persist(newLevel)
     replicatedVertexView.edges.persist(newLevel)
@@ -99,6 +103,7 @@ class GraphImpl[VD: ClassTag, ED: ClassTag] protected (
 
   override def partitionBy(
       partitionStrategy: PartitionStrategy, numPartitions: Int): Graph[VD, ED] = {
+    this.partitionStrategy = Some(partitionStrategy)
     val edTag = classTag[ED]
     val vdTag = classTag[VD]
     val newEdges = edges.withPartitionsRDD(edges.map { e =>

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -68,7 +68,12 @@ object MimaExcludes {
             // SPARK-6693 add tostring with max lines and width for matrix
             ProblemFilters.exclude[MissingMethodProblem](
               "org.apache.spark.mllib.linalg.Matrix.toString")
+          )++ Seq(
+            // SPARK-5352 Add getPartitionStrategy in Graph
+            ProblemFilters.exclude[MissingMethodProblem](
+              "org.apache.spark.graphx.Graph.getPartitionStrategy")
           )
+
 
         case v if v.startsWith("1.3") =>
           Seq(


### PR DESCRIPTION
Graph remembers an applied partition strategy in partitionBy() and returns it via getPartitionStrategy().
This is useful in case of the following situation;

val g1 = GraphLoader.edgeListFile(sc, "graph.txt")
val g2 = g1.partitionBy(EdgePartition2D, 2)

// Modify (e.g., add, contract, ...) edges in g2
val newEdges = ...

// Re-build a new graph based on g2
val g3 = Graph(g1.vertices, newEdges)

// Partition edges in a similar way of g2
val g4 = g3.partitionBy(g2.getPartitionStrategy, 2)
