### PR TITLE
[SPARK-6975][Yarn] Fix argument validation error

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
@@ -103,9 +103,14 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
    * This is intended to be called only after the provided arguments have been parsed.
    */
   private def validateArgs(): Unit = {
-    if (numExecutors <= 0) {
+    if (numExecutors < 0 || (!isDynamicAllocationEnabled && numExecutors == 0)) {
       throw new IllegalArgumentException(
-        "You must specify at least 1 executor!\n" + getUsageMessage())
+        s"""
+           |Number of executors $numExecutors is not legal.
+           |If dynamic allocation is enable, number of executors should at least be 0.
+           |If dynamic allocation is not enabled, number of executors should at least be 1.
+           |${getUsageMessage()}
+         """.stripMargin)
     }
     if (executorCores < sparkConf.getInt("spark.task.cpus", 1)) {
       throw new SparkException("Executor cores must not be less than " +

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ClientArguments.scala
@@ -106,9 +106,8 @@ private[spark] class ClientArguments(args: Array[String], sparkConf: SparkConf) 
     if (numExecutors < 0 || (!isDynamicAllocationEnabled && numExecutors == 0)) {
       throw new IllegalArgumentException(
         s"""
-           |Number of executors $numExecutors is not legal.
-           |If dynamic allocation is enable, number of executors should at least be 0.
-           |If dynamic allocation is not enabled, number of executors should at least be 1.
+           |Number of executors was $numExecutors, but must be at least 1
+           |(or 0 if dynamic executor allocation is enabled).
            |${getUsageMessage()}
          """.stripMargin)
     }


### PR DESCRIPTION
`numExecutors` checking is failed when dynamic allocation is enabled with default configuration. Details can be seen is [SPARK-6975](https://issues.apache.org/jira/browse/SPARK-6975). @sryza, please help me to review this, not sure is this the correct way, I think previous you change this part :)
