### PR TITLE
[SQL] There are three tests of sql are failed because of the error path

### DIFF
--- a/sql/hive/src/test/resources/ql/src/test/queries/clientpositive/drop_database_removes_partition_dirs.q
+++ b/sql/hive/src/test/resources/ql/src/test/queries/clientpositive/drop_database_removes_partition_dirs.q
@@ -16,12 +16,12 @@ LOCATION 'file:${system:test.tmp.dir}/drop_database_removes_partition_dirs_table
 INSERT OVERWRITE TABLE test_table PARTITION (part = '1')
 SELECT * FROM default.src;
 
-dfs -ls ${system:test.tmp.dir}/drop_database_removes_partition_dirs_table2;
+dfs -ls file:${system:test.tmp.dir}/drop_database_removes_partition_dirs_table2;
 
 USE default;
 
 DROP DATABASE test_database CASCADE;
 
-dfs -ls ${system:test.tmp.dir}/drop_database_removes_partition_dirs_table2;
+dfs -ls file:${system:test.tmp.dir}/drop_database_removes_partition_dirs_table2;
 
-dfs -rmr ${system:test.tmp.dir}/drop_database_removes_partition_dirs_table2;
+dfs -rmr file:${system:test.tmp.dir}/drop_database_removes_partition_dirs_table2;

--- a/sql/hive/src/test/resources/ql/src/test/queries/clientpositive/drop_index_removes_partition_dirs.q
+++ b/sql/hive/src/test/resources/ql/src/test/queries/clientpositive/drop_index_removes_partition_dirs.q
@@ -13,10 +13,10 @@ IN TABLE test_index_table;
 ALTER TABLE test_index_table ADD PARTITION (part = '1')
 LOCATION 'file:${system:test.tmp.dir}/drop_index_removes_partition_dirs_index_table2/part=1';
 
-dfs -ls ${system:test.tmp.dir}/drop_index_removes_partition_dirs_index_table2;
+dfs -ls file:${system:test.tmp.dir}/drop_index_removes_partition_dirs_index_table2;
 
 DROP INDEX test_index ON test_table;
 
-dfs -ls ${system:test.tmp.dir}/drop_index_removes_partition_dirs_index_table2;
+dfs -ls file:${system:test.tmp.dir}/drop_index_removes_partition_dirs_index_table2;
 
-dfs -rmr ${system:test.tmp.dir}/drop_index_removes_partition_dirs_index_table2;
+dfs -rmr file:${system:test.tmp.dir}/drop_index_removes_partition_dirs_index_table2;

--- a/sql/hive/src/test/resources/ql/src/test/queries/clientpositive/drop_table_removes_partition_dirs.q
+++ b/sql/hive/src/test/resources/ql/src/test/queries/clientpositive/drop_table_removes_partition_dirs.q
@@ -12,10 +12,10 @@ LOCATION 'file:${system:test.tmp.dir}/drop_table_removes_partition_dirs_table2/p
 INSERT OVERWRITE TABLE test_table PARTITION (part = '1')
 SELECT * FROM src;
 
-dfs -ls ${system:test.tmp.dir}/drop_table_removes_partition_dirs_table2;
+dfs -ls file:${system:test.tmp.dir}/drop_table_removes_partition_dirs_table2;
 
 DROP TABLE test_table;
 
-dfs -ls ${system:test.tmp.dir}/drop_table_removes_partition_dirs_table2;
+dfs -ls file:${system:test.tmp.dir}/drop_table_removes_partition_dirs_table2;
 
-dfs -rmr ${system:test.tmp.dir}/drop_table_removes_partition_dirs_table2;
+dfs -rmr file:${system:test.tmp.dir}/drop_table_removes_partition_dirs_table2;


### PR DESCRIPTION
When running tests, the local path is created, but go to hdfs to check this path. So cause error.

For example, the info of running drop_index_removes_partition_dirs :
[info] - drop_index_removes_partition_dirs **\* FAILED **\* (1 second, 13 milliseconds)
[info]   Results do not match for drop_index_removes_partition_dirs:
[info]   dfs -ls ${system:test.tmp.dir}/drop_index_removes_partition_dirs_index_table2
[info]   == Parsed Logical Plan ==
[info]   HiveNativeCommand dfs -ls /tmp/spark-df56ff5d-75f7-4d5b-9b23-38b3dc21b420/drop_index_removes_partition_dirs_index_table2
[info]  
[info]   == Analyzed Logical Plan ==
[info]   HiveNativeCommand dfs -ls /tmp/spark-df56ff5d-75f7-4d5b-9b23-38b3dc21b420/drop_index_removes_partition_dirs_index_table2
[info]  
[info]   == Optimized Logical Plan ==
[info]   HiveNativeCommand dfs -ls /tmp/spark-df56ff5d-75f7-4d5b-9b23-38b3dc21b420/drop_index_removes_partition_dirs_index_table2
[info]  
[info]   == Physical Plan ==
[info]   ExecutedCommand (HiveNativeCommand dfs -ls /tmp/spark-df56ff5d-75f7-4d5b-9b23-38b3dc21b420/drop_index_removes_partition_dirs_index_table2)
[info]  
[info]   Code Generation: false
[info]   == RDD ==
[info]   result
[info]   !== HIVE - 1 row(s) ==   == CATALYST - 1 row(s) ==
[info]   !0                       1 (HiveComparisonTest.scala:387)
