### PR TITLE
[doc][mllib] Fix typo of the page title in Isotonic regression documents

### DIFF
--- a/docs/mllib-isotonic-regression.md
+++ b/docs/mllib-isotonic-regression.md
@@ -1,6 +1,6 @@
 ---
 layout: global
-title: Naive Bayes - MLlib
+title: Isotonic regression - MLlib
 displayTitle: <a href="mllib-guide.html">MLlib</a> - Regression
 ---
 


### PR DESCRIPTION
- Fix the page title in Isotonic regression documents (Naive Bayes -> Isotonic regression)
- Add a newline character at the end of the file
