### PR TITLE
[SQL][minor] make it more clear that we only need to re-throw GetField exception for UnresolvedAttribute

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -46,12 +46,11 @@ trait CheckAnalysis {
         operator transformExpressionsUp {
           case a: Attribute if !a.resolved =>
             if (operator.childrenResolved) {
-              val nameParts = a match {
-                case UnresolvedAttribute(nameParts) => nameParts
-                case _ => Seq(a.name)
+              a match {
+                case UnresolvedAttribute(nameParts) =>
+                  // Throw errors for specific problems with get field.
+                  operator.resolveChildren(nameParts, resolver, throwErrors = true)
               }
-              // Throw errors for specific problems with get field.
-              operator.resolveChildren(nameParts, resolver, throwErrors = true)
             }
 
             val from = operator.inputSet.map(_.name).mkString(", ")


### PR DESCRIPTION
For `GetField` outside `UnresolvedAttribute`, we will throw exception in `Analyzer`.
