### PR TITLE
SPARK-7009 Build assembly JAR via ant to avoid zip64 problems

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -36,6 +36,9 @@
     <spark.jar.dir>scala-${scala.binary.version}</spark.jar.dir>
     <spark.jar.basename>spark-assembly-${project.version}-hadoop${hadoop.version}.jar</spark.jar.basename>
     <spark.jar>${project.build.directory}/${spark.jar.dir}/${spark.jar.basename}</spark.jar>
+    <!-- shaded artifacts are generated between shade and ant zip -->
+    <spark.shaded.dir>${project.build.directory}/${spark.jar.dir}/shaded</spark.shaded.dir>
+    <spark.shaded.jar>${spark.shaded.dir}/${spark.jar.basename}</spark.shaded.jar>
   </properties>
 
   <dependencies>
@@ -98,7 +101,7 @@
         <artifactId>maven-shade-plugin</artifactId>
         <configuration>
           <shadedArtifactAttached>false</shadedArtifactAttached>
-          <outputFile>${spark.jar}</outputFile>
+          <outputFile>${spark.shaded.jar}</outputFile>
           <artifactSet>
             <includes>
               <include>*:*</include>
@@ -137,6 +140,30 @@
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
               </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- ANTRUN plugin takes the shaded JAR and repackages it without zip64 packaging.
+       it must run after the shade; the ordering in the POM is critical -->
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>${antrun.plugin.version}</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <zip
+                  destfile="${spark.jar}"
+                  encoding="UTF-8"
+                  zip64mode="never">
+                  <zipfileset src="${spark.shaded.jar}" />
+                </zip>
+              </target>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,8 @@
     <fasterxml.jackson.version>2.4.4</fasterxml.jackson.version>
     <snappy.version>1.1.1.7</snappy.version>
     <netlib.java.version>1.1.2</netlib.java.version>
-
+    <!-- the apache 14 parent POM is at version 1.7 -->
+    <antrun.plugin.version>1.8</antrun.plugin.version>
     <test.java.home>${java.home}</test.java.home>
 
     <!--


### PR DESCRIPTION
This is the ~30 line patch to have ant generate a zip32 artifact straight off the shaded JAR. As noted however, the line class count is >64K, at least for trunk

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:1.8:run (default)
  on project spark-assembly_2.10:
  An Ant BuildException has occured: Problem creating zip: archive contains more than 65535 entries.
[ERROR] around Ant part ...<zip encoding="UTF-8" zip64mode="never" 
  destfile="/spark/assembly/target/scala-2.10/spark-assembly-1.4.0-SNAPSHOT-hadoop2.2.0.jar">
```
