### PR TITLE
[Minor][MLlib] Incorrect path to test data is used in DecisionTreeExample

### DIFF
--- a/examples/src/main/scala/org/apache/spark/examples/ml/DecisionTreeExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/DecisionTreeExample.scala
@@ -173,7 +173,8 @@ object DecisionTreeExample {
     val splits: Array[RDD[LabeledPoint]] = if (testInput != "") {
       // Load testInput.
       val numFeatures = origExamples.take(1)(0).features.size
-      val origTestExamples: RDD[LabeledPoint] = loadData(sc, testInput, dataFormat, Some(numFeatures))
+      val origTestExamples: RDD[LabeledPoint] =
+        loadData(sc, testInput, dataFormat, Some(numFeatures))
       Array(origExamples, origTestExamples)
     } else {
       // Split input into training, test.

--- a/examples/src/main/scala/org/apache/spark/examples/ml/DecisionTreeExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/DecisionTreeExample.scala
@@ -173,7 +173,7 @@ object DecisionTreeExample {
     val splits: Array[RDD[LabeledPoint]] = if (testInput != "") {
       // Load testInput.
       val numFeatures = origExamples.take(1)(0).features.size
-      val origTestExamples: RDD[LabeledPoint] = loadData(sc, input, dataFormat, Some(numFeatures))
+      val origTestExamples: RDD[LabeledPoint] = loadData(sc, testInput, dataFormat, Some(numFeatures))
       Array(origExamples, origTestExamples)
     } else {
       // Split input into training, test.


### PR DESCRIPTION
It should load from `testInput` instead of `input` for test data.
