### PR TITLE
[SPARK-7024][SQL] Improve performance of function containsStar.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -327,8 +327,13 @@ class Analyzer(
     /**
      * Returns true if `exprs` contains a [[Star]].
      */
-    protected def containsStar(exprs: Seq[Expression]): Boolean =
-      exprs.exists(_.collect { case _: Star => true }.nonEmpty)
+    def containsStar(exprs: Seq[Expression]): Boolean = {
+      exprs.foreach(_.foreach {
+        case agg: Star => return true
+        case _ =>
+      })
+      false
+    }
   }
 
   /**


### PR DESCRIPTION
The function before will calculate at least `expression.size` times.
The function after will calculate at least `1` times.
