### PR TITLE
[SPARK-7031][ThriftServer]let thrift server take SPARK_DAEMON_MEMORY and SPARK_DAEMON_JAVA_OPTS

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -190,6 +190,10 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
       firstNonEmptyValue(SparkLauncher.DRIVER_EXTRA_CLASSPATH, conf, props) : null;
 
     List<String> cmd = buildJavaCommand(extraClassPath);
+    // Take Thrift Server as daemon
+    if (isThriftServer(mainClass)) {
+      addOptionString(cmd, System.getenv("SPARK_DAEMON_JAVA_OPTS"));
+    }
     addOptionString(cmd, System.getenv("SPARK_SUBMIT_OPTS"));
     addOptionString(cmd, System.getenv("SPARK_JAVA_OPTS"));
 
@@ -201,8 +205,16 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
       // - SPARK_DRIVER_MEMORY env variable
       // - SPARK_MEM env variable
       // - default value (512m)
-      String memory = firstNonEmpty(firstNonEmptyValue(SparkLauncher.DRIVER_MEMORY, conf, props),
-        System.getenv("SPARK_DRIVER_MEMORY"), System.getenv("SPARK_MEM"), DEFAULT_MEM);
+      String memory;
+      // Take Thrift Server as daemon
+      if (isThriftServer(mainClass)) {
+        memory = firstNonEmpty(System.getenv("SPARK_DAEMON_MEMORY"),
+            firstNonEmptyValue(SparkLauncher.DRIVER_MEMORY, conf, props),
+            System.getenv("SPARK_DRIVER_MEMORY"), System.getenv("SPARK_MEM"), DEFAULT_MEM);
+      } else {
+        memory = firstNonEmpty(firstNonEmptyValue(SparkLauncher.DRIVER_MEMORY, conf, props),
+            System.getenv("SPARK_DRIVER_MEMORY"), System.getenv("SPARK_MEM"), DEFAULT_MEM);
+      }
       cmd.add("-Xms" + memory);
       cmd.add("-Xmx" + memory);
       addOptionString(cmd, firstNonEmptyValue(SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS, conf, props));
@@ -291,6 +303,14 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
       "client".equals(deployMode) ||
       (!userMaster.equals("yarn-cluster") && deployMode == null);
   }
+
+  /**
+   * Return whether the given main class represents a thrift server.
+   */
+  private boolean isThriftServer(String mainClass) {
+    return mainClass.equals("org.apache.spark.sql.hive.thriftserver.HiveThriftServer2");
+  }
+
 
   private class OptionParser extends SparkSubmitOptionParser {
 

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -207,10 +207,10 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
       // - default value (512m)
       // Take Thrift Server as daemon
       String tsMemory =
-          isThriftServer(mainClass) ? System.getenv("SPARK_DAEMON_MEMORY") : null;
+        isThriftServer(mainClass) ? System.getenv("SPARK_DAEMON_MEMORY") : null;
       String memory = firstNonEmpty(tsMemory,
-          firstNonEmptyValue(SparkLauncher.DRIVER_MEMORY, conf, props),
-          System.getenv("SPARK_DRIVER_MEMORY"), System.getenv("SPARK_MEM"), DEFAULT_MEM);
+        firstNonEmptyValue(SparkLauncher.DRIVER_MEMORY, conf, props),
+        System.getenv("SPARK_DRIVER_MEMORY"), System.getenv("SPARK_MEM"), DEFAULT_MEM);
       cmd.add("-Xms" + memory);
       cmd.add("-Xmx" + memory);
       addOptionString(cmd, firstNonEmptyValue(SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS, conf, props));
@@ -305,7 +305,7 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
    */
   private boolean isThriftServer(String mainClass) {
     return (mainClass != null &&
-        mainClass.equals("org.apache.spark.sql.hive.thriftserver.HiveThriftServer2"));
+      mainClass.equals("org.apache.spark.sql.hive.thriftserver.HiveThriftServer2"));
   }
 
 

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -205,16 +205,12 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
       // - SPARK_DRIVER_MEMORY env variable
       // - SPARK_MEM env variable
       // - default value (512m)
-      String memory;
       // Take Thrift Server as daemon
-      if (isThriftServer(mainClass)) {
-        memory = firstNonEmpty(System.getenv("SPARK_DAEMON_MEMORY"),
-            firstNonEmptyValue(SparkLauncher.DRIVER_MEMORY, conf, props),
-            System.getenv("SPARK_DRIVER_MEMORY"), System.getenv("SPARK_MEM"), DEFAULT_MEM);
-      } else {
-        memory = firstNonEmpty(firstNonEmptyValue(SparkLauncher.DRIVER_MEMORY, conf, props),
-            System.getenv("SPARK_DRIVER_MEMORY"), System.getenv("SPARK_MEM"), DEFAULT_MEM);
-      }
+      String tsMemory =
+          isThriftServer(mainClass) ? System.getenv("SPARK_DAEMON_MEMORY") : null;
+      String memory = firstNonEmpty(tsMemory,
+          firstNonEmptyValue(SparkLauncher.DRIVER_MEMORY, conf, props),
+          System.getenv("SPARK_DRIVER_MEMORY"), System.getenv("SPARK_MEM"), DEFAULT_MEM);
       cmd.add("-Xms" + memory);
       cmd.add("-Xmx" + memory);
       addOptionString(cmd, firstNonEmptyValue(SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS, conf, props));

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -308,7 +308,8 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
    * Return whether the given main class represents a thrift server.
    */
   private boolean isThriftServer(String mainClass) {
-    return mainClass.equals("org.apache.spark.sql.hive.thriftserver.HiveThriftServer2");
+    return (mainClass != null &&
+        mainClass.equals("org.apache.spark.sql.hive.thriftserver.HiveThriftServer2"));
   }
 
 

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -59,6 +59,8 @@ public class SparkSubmitCommandBuilderSuite {
   @Test
   public void testCliParser() throws Exception {
     List<String> sparkSubmitArgs = Arrays.asList(
+      parser.CLASS,
+      "org.apache.spark.sql.hive.thriftserver.SparkSQLCLIDriver",
       parser.MASTER,
       "local",
       parser.DRIVER_MEMORY,
@@ -135,6 +137,7 @@ public class SparkSubmitCommandBuilderSuite {
   @Test
   public void testPySparkFallback() throws Exception {
     List<String> sparkSubmitArgs = Arrays.asList(
+      "pyspark-shell-main",
       "--master=foo",
       "--deploy-mode=bar",
       "script.py",

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -59,8 +59,6 @@ public class SparkSubmitCommandBuilderSuite {
   @Test
   public void testCliParser() throws Exception {
     List<String> sparkSubmitArgs = Arrays.asList(
-      parser.CLASS,
-      "org.apache.spark.sql.hive.thriftserver.SparkSQLCLIDriver",
       parser.MASTER,
       "local",
       parser.DRIVER_MEMORY,
@@ -137,7 +135,6 @@ public class SparkSubmitCommandBuilderSuite {
   @Test
   public void testPySparkFallback() throws Exception {
     List<String> sparkSubmitArgs = Arrays.asList(
-      "pyspark-shell-main",
       "--master=foo",
       "--deploy-mode=bar",
       "script.py",


### PR DESCRIPTION
We should let Thrift Server take these two parameters as it is a daemon. And it is better to read driver-related configs as an app submited by spark-submit.

https://issues.apache.org/jira/browse/SPARK-7031 
