### PR TITLE
[SPARK-7026][SQL] Fix bugs when there are non equal join predicates for left semi join

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -36,12 +36,14 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
     def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
       case ExtractEquiJoinKeys(LeftSemi, leftKeys, rightKeys, condition, left, right)
         if sqlContext.conf.autoBroadcastJoinThreshold > 0 &&
-          right.statistics.sizeInBytes <= sqlContext.conf.autoBroadcastJoinThreshold =>
+          right.statistics.sizeInBytes <= sqlContext.conf.autoBroadcastJoinThreshold &&
+          canEvaluate(condition.getOrElse(Literal(true)), left) =>
         val semiJoin = joins.BroadcastLeftSemiJoinHash(
           leftKeys, rightKeys, planLater(left), planLater(right))
         condition.map(Filter(_, semiJoin)).getOrElse(semiJoin) :: Nil
       // Find left semi joins where at least some predicates can be evaluated by matching join keys
-      case ExtractEquiJoinKeys(LeftSemi, leftKeys, rightKeys, condition, left, right) =>
+      case ExtractEquiJoinKeys(LeftSemi, leftKeys, rightKeys, condition, left, right)
+        if canEvaluate(condition.getOrElse(Literal(true)), left) =>
         val semiJoin = joins.LeftSemiJoinHash(
           leftKeys, rightKeys, planLater(left), planLater(right))
         condition.map(Filter(_, semiJoin)).getOrElse(semiJoin) :: Nil

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -1242,7 +1242,7 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll {
     checkAnswer(
       sql("""
             |SELECT * FROM testData2 x
-            |LEFT SEMI JOIN testData2 y
+            |LEFT SEMI JOIN testData4 y
             |ON x.b = y.b
             |AND x.a >= y.a + 2""".stripMargin),
       Seq(Row(3,1), Row(3,2))
@@ -1251,7 +1251,7 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll {
     checkAnswer(
       sql("""
             |SELECT * FROM testData2 x
-            |LEFT SEMI JOIN testData2 y
+            |LEFT SEMI JOIN testData4 y
             |ON x.b = y.b
             |AND x.a >= y.a + 2
             |AND x.a >= y.a + 1""".stripMargin),

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -1238,6 +1238,27 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll {
     checkAnswer(sql("SELECT c[0].d FROM nestedOrder ORDER BY c[0].d"), Row(1))
   }
 
+  test("SPARK-7026: Fix bug when there are non equal join predicates for left semi join") {
+    checkAnswer(
+      sql("""
+            |SELECT * FROM testData2 x
+            |LEFT SEMI JOIN testData2 y
+            |ON x.b = y.b
+            |AND x.a >= y.a + 2""".stripMargin),
+      Seq(Row(3,1), Row(3,2))
+    )
+
+    checkAnswer(
+      sql("""
+            |SELECT * FROM testData2 x
+            |LEFT SEMI JOIN testData2 y
+            |ON x.b = y.b
+            |AND x.a >= y.a + 2
+            |AND x.a >= y.a + 1""".stripMargin),
+      Seq(Row(3,1), Row(3,2))
+    )
+  }
+
   test("SPARK-6145: special cases") {
     jsonRDD(sparkContext.makeRDD(
       """{"a": {"b": [1]}, "b": [{"a": 1}], "c0": {"a": 1}}""" :: Nil)).registerTempTable("t")

--- a/sql/core/src/test/scala/org/apache/spark/sql/TestData.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TestData.scala
@@ -86,6 +86,15 @@ object TestData {
       TestData3(2, Some(2)) :: Nil).toDF()
   testData3.registerTempTable("testData3")
 
+  case class TestData4(a: Int, b: Int)
+  val testData4 =
+    TestSQLContext.sparkContext.parallelize(
+      TestData4(1, 1) ::
+      TestData4(1, 1) ::
+      TestData4(1, 2) ::
+      TestData4(1, 2) :: Nil, 2).toDF()
+  testData4.registerTempTable("testData4")
+
   val emptyTableData = logical.LocalRelation($"a".int, $"b".int)
 
   case class UpperCaseData(N: Int, L: String)


### PR DESCRIPTION
When the `condition` extracted by `ExtractEquiJoinKeys` contain join Predicate for left semi join, we can not plan it as semiJoin.  Such as

```
SELECT * FROM testData2 x
LEFT SEMI JOIN testData2 y
ON x.b = y.b
AND x.a >= y.a + 2
```

Condition `x.a >= y.a + 2` can not evaluate on table x, so it throw errors
