### PR TITLE
[minor] [build] Set java options when generating mima ignores.

### DIFF
--- a/dev/mima
+++ b/dev/mima
@@ -27,16 +27,21 @@ cd "$FWDIR"
 echo -e "q\n" | build/sbt oldDeps/update
 rm -f .generated-mima*
 
+generate_mima_ignore() {
+  SPARK_JAVA_OPTS="-XX:MaxPermSize=1g -Xmx2g" \
+    ./bin/spark-class org.apache.spark.tools.GenerateMIMAIgnore
+}
+
 # Generate Mima Ignore is called twice, first with latest built jars
 # on the classpath and then again with previous version jars on the classpath.
 # Because of a bug in GenerateMIMAIgnore that when old jars are ahead on classpath
 # it did not process the new classes (which are in assembly jar).
-./bin/spark-class org.apache.spark.tools.GenerateMIMAIgnore
+generate_mima_ignore
 
 export SPARK_CLASSPATH="`find lib_managed \( -name '*spark*jar' -a -type f \) | tr "\\n" ":"`"
 echo "SPARK_CLASSPATH=$SPARK_CLASSPATH"
 
-./bin/spark-class org.apache.spark.tools.GenerateMIMAIgnore
+generate_mima_ignore
 
 echo -e "q\n" | build/sbt mima-report-binary-issues | grep -v -e "info.*Resolving"
 ret_val=$?


### PR DESCRIPTION
The default java options make the call to GenerateMIMAIgnore take
forever to run since it's gc'ing all the time. Improve things by
setting the perm gen size / max heap size to larger values.
