### PR TITLE
[SPARK-7051] [SQL] Configuration for parquet data writting

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
@@ -36,6 +36,8 @@ private[spark] object SQLConf {
   val PARQUET_INT96_AS_TIMESTAMP = "spark.sql.parquet.int96AsTimestamp"
   val PARQUET_CACHE_METADATA = "spark.sql.parquet.cacheMetadata"
   val PARQUET_COMPRESSION = "spark.sql.parquet.compression.codec"
+  val PARQUET_BLOCK_SIZE = "spark.sql.parquet.blocksize"
+  val PARQUET_PAGE_SIZE = "spark.sql.parquet.pagesize"
   val PARQUET_FILTER_PUSHDOWN_ENABLED = "spark.sql.parquet.filterPushdown"
   val PARQUET_USE_DATA_SOURCE_API = "spark.sql.parquet.useDataSourceApi"
 
@@ -109,6 +111,12 @@ private[sql] class SQLConf extends Serializable {
 
   /** The compression codec for writing to a Parquetfile */
   private[spark] def parquetCompressionCodec: String = getConf(PARQUET_COMPRESSION, "gzip")
+
+  /** The block size in parquet file 128 MB (128 * 1024 * 1024) by default */
+  private[spark] def parquetBlockSize: Int = getConf(PARQUET_BLOCK_SIZE, "134217728").toInt
+
+  /** The page size in parquet file 1 MB (1 * 1024 * 1024) by default */
+  private[spark] def parquetPageSize: Int = getConf(PARQUET_PAGE_SIZE, "1048576").toInt
 
   /** The number of rows that will be  */
   private[spark] def columnBatchSize: Int = getConf(COLUMN_BATCH_SIZE, "10000").toInt

--- a/sql/core/src/main/scala/org/apache/spark/sql/parquet/newParquet.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/parquet/newParquet.scala
@@ -642,6 +642,11 @@ private[sql] case class ParquetRelation2(
     }
 
     ParquetOutputFormat.setWriteSupportClass(job, writeSupport)
+    ParquetOutputFormat.setCompression(job,
+      ParquetRelation.shortParquetCompressionCodecNames.getOrElse(
+        sqlContext.conf.parquetCompressionCodec.toUpperCase, CompressionCodecName.UNCOMPRESSED))
+    ParquetOutputFormat.setBlockSize(job, sqlContext.conf.parquetBlockSize)
+    ParquetOutputFormat.setPageSize(job, sqlContext.conf.parquetPageSize)
 
     val conf = ContextUtil.getConfiguration(job)
     RowWriteSupport.setSchema(data.schema.toAttributes, conf)


### PR DESCRIPTION
```
CREATE TABLE parquet_test (
 id int,
 str string) 
STORED AS PARQUET;
set spark.sql.parquet.compression.codec=snappy;
insert into table parquet_test select * from src;
```
