### PR TITLE
[SPARK-7009] repackaging spark assembly jar with jdk1.6 to make it work with pyspark

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -36,6 +36,9 @@
     <spark.jar.dir>scala-${scala.binary.version}</spark.jar.dir>
     <spark.jar.basename>spark-assembly-${project.version}-hadoop${hadoop.version}.jar</spark.jar.basename>
     <spark.jar>${project.build.directory}/${spark.jar.dir}/${spark.jar.basename}</spark.jar>
+    <spark.shaded.dir>${project.build.directory}/${spark.jar.dir}/shaded</spark.shaded.dir>
+    <spark.shaded.jar>${spark.shaded.dir}/${spark.jar.basename}</spark.shaded.jar>
+    <spark.shaded.unjar>${spark.shaded.dir}/unjar</spark.shaded.unjar>
   </properties>
 
   <dependencies>
@@ -242,6 +245,44 @@
       <properties>
         <parquet.deps.scope>provided</parquet.deps.scope>
       </properties>
+    </profile>
+    <!-- Profiles that enable repackaging assembly jar. -->
+    <profile>
+      <id>repackage</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>java6-package</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <tasks if="jar.tool">
+                    <mkdir dir="${spark.shaded.unjar}"/>
+                    <echo message="Unjar ${spark.jar} to ${spark.shaded.unjar}"/>
+                    <unzip src="${spark.jar}" dest="${spark.shaded.unjar}"/>
+                    <echo message="move original ${spark.jar} to ${spark.shaded.jar} ."/>
+                    <copy file="${spark.jar}" tofile="${spark.shaded.jar}"/>
+                    <echo message="Jar file to ${spark.jar} -C ${spark.shaded.unjar} . with tool ${jar.tool}"/>
+                    <exec executable="${jar.tool}">
+                      <arg value="cf"/>
+                      <arg value="${spark.jar}"/>
+                      <arg value="-C"/>
+                      <arg value="${spark.shaded.unjar}"/>
+                      <arg value="."/>
+                    </exec>
+                    <delete dir="${spark.shaded.unjar}"/>
+                  </tasks>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
 Due to zip format issue, python cannot recognize the jar file packaged with jdk-1.7. Discussed with @steveloughran, this patch provide a walkaround to unzip and zip the assembly jar with java6. In other words, it supports to build spark with jdk-1.7 and generate package with java6.  

It is done by a profile named repackage. User has to provide the location of their jar tools from jdk-1.6. By default, there is no behavior change.
mvn clean pakage -Prepackage -Djar.tool=<jdk1.6 jar location>
