### PR TITLE
[SPARK-6505][SQL]Remove the reflection call in HiveFunctionWrapper

### DIFF
--- a/sql/hive/v0.13.1/src/main/scala/org/apache/spark/sql/hive/Shim13.scala
+++ b/sql/hive/v0.13.1/src/main/scala/org/apache/spark/sql/hive/Shim13.scala
@@ -24,7 +24,7 @@ import scala.collection.JavaConversions._
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
-import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Kryo
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.hive.common.StatsSetupConst
@@ -65,8 +65,8 @@ private[hive] case class HiveFunctionWrapper(var functionClassName: String)
 
   import java.io.{OutputStream, InputStream}
 
-  import com.esotericsoftware.kryo.io.Input;
-  import com.esotericsoftware.kryo.io.Output;
+  import com.esotericsoftware.kryo.io.Input
+  import com.esotericsoftware.kryo.io.Output
 
   import org.apache.spark.util.Utils._
 
@@ -74,19 +74,19 @@ private[hive] case class HiveFunctionWrapper(var functionClassName: String)
   private def deserializeObjectByKryo[T: ClassTag](kryo: Kryo,
                                                    in: InputStream,
                                                    clazz: Class[_]): T = {
-    val inp = new Input(in);
-    val t: T = kryo.readObject(inp,clazz).asInstanceOf[T];
-    inp.close();
-    return t;
+    val inp = new Input(in)
+    val t: T = kryo.readObject(inp,clazz).asInstanceOf[T]
+    inp.close()
+    t
   }
 
   @transient
   private def serializeObjectByKryo(kryo: Kryo,
                                     plan: Object,
                                     out: OutputStream ) {
-    val output: Output = new Output(out);
-    kryo.writeObject(output, plan);
-    output.close();
+    val output: Output = new Output(out)
+    kryo.writeObject(output, plan)
+    output.close()
   }
 
   def deserializePlan[UDFType](is: java.io.InputStream, clazz: Class[_]): UDFType = {

--- a/sql/hive/v0.13.1/src/main/scala/org/apache/spark/sql/hive/Shim13.scala
+++ b/sql/hive/v0.13.1/src/main/scala/org/apache/spark/sql/hive/Shim13.scala
@@ -68,9 +68,9 @@ private[hive] case class HiveFunctionWrapper(var functionClassName: String)
 
   @transient
   def deserializeObjectByKryo[T: ClassTag](
-              kryo: Kryo,
-              in: InputStream,
-              clazz: Class[_]): T = {
+      kryo: Kryo,
+      in: InputStream,
+      clazz: Class[_]): T = {
     val inp = new Input(in)
     val t: T = kryo.readObject(inp,clazz).asInstanceOf[T]
     inp.close()
@@ -79,9 +79,9 @@ private[hive] case class HiveFunctionWrapper(var functionClassName: String)
 
   @transient
   def serializeObjectByKryo(
-              kryo: Kryo,
-              plan: Object,
-              out: OutputStream ) {
+      kryo: Kryo,
+      plan: Object,
+      out: OutputStream ) {
     val output: Output = new Output(out)
     kryo.writeObject(output, plan)
     output.close()


### PR DESCRIPTION
according @liancheng‘s  comment in https://issues.apache.org/jira/browse/SPARK-6505,  this patch remove the  reflection call in HiveFunctionWrapper, and implement the functions named "deserializeObjectByKryo" and "serializeObjectByKryo" according the functions with the save name in 
org.apache.hadoop.hive.ql.exec.Utilities.java
