### PR TITLE
[SPARK-7093] [SQL] Using newPredicate in NestedLoopJoin to enable code generation

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastNestedLoopJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastNestedLoopJoin.scala
@@ -59,7 +59,7 @@ case class BroadcastNestedLoopJoin(
   }
 
   @transient private lazy val boundCondition =
-    condition.map(newPredicate(_, left.output ++ right.output)).getOrElse((row: Row) => true)
+    newPredicate(condition.getOrElse(Literal(true)), left.output ++ right.output)
 
   override def execute(): RDD[Row] = {
     val broadcastedRelation =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastNestedLoopJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastNestedLoopJoin.scala
@@ -59,10 +59,7 @@ case class BroadcastNestedLoopJoin(
   }
 
   @transient private lazy val boundCondition =
-    InterpretedPredicate.create(
-      condition
-        .map(c => BindReferences.bindReference(c, left.output ++ right.output))
-        .getOrElse(Literal(true)))
+    condition.map(newPredicate(_, left.output ++ right.output)).getOrElse((row: Row) => true)
 
   override def execute(): RDD[Row] = {
     val broadcastedRelation =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/LeftSemiJoinBNL.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/LeftSemiJoinBNL.scala
@@ -45,7 +45,7 @@ case class LeftSemiJoinBNL(
   override def right: SparkPlan = broadcast
 
   @transient private lazy val boundCondition =
-    condition.map(newPredicate(_, left.output ++ right.output)).getOrElse((row: Row) => true)
+    newPredicate(condition.getOrElse(Literal(true)), left.output ++ right.output)
 
   override def execute(): RDD[Row] = {
     val broadcastedRelation =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/LeftSemiJoinBNL.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/LeftSemiJoinBNL.scala
@@ -45,10 +45,7 @@ case class LeftSemiJoinBNL(
   override def right: SparkPlan = broadcast
 
   @transient private lazy val boundCondition =
-    InterpretedPredicate.create(
-      condition
-        .map(c => BindReferences.bindReference(c, left.output ++ right.output))
-        .getOrElse(Literal(true)))
+    condition.map(newPredicate(_, left.output ++ right.output)).getOrElse((row: Row) => true)
 
   override def execute(): RDD[Row] = {
     val broadcastedRelation =


### PR DESCRIPTION
Using newPredicate in NestedLoopJoin instead of InterpretedPredicate to make it can make use of code generation
