### PR TITLE
[SPARK-7097][SQL]: Partitioned tables should only consider referred partitions in query during size estimation for checking against autoBroadcastJoinThreshold

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -451,6 +451,7 @@ class HiveContext(sc: SparkContext) extends SQLContext(sc) {
       Scripts,
       HashAggregation,
       LeftSemiJoin,
+      HiveHashJoin,
       HashJoin,
       BasicOperators,
       CartesianProduct,

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -737,7 +737,7 @@ private[hive] case class MetastoreRelation
           val partParams = Option(refPart.getParameters)
           // If any of the parameters of referred partitions is not defined, skip BroadCastJoin
           if (partParams.isEmpty) {
-            return sqlContext.conf.defaultSizeInBytes  
+            return sqlContext.conf.defaultSizeInBytes
           }
           val partSize =
             Option(partParams.get.get(StatsSetupConst.TOTAL_SIZE))

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -30,6 +30,7 @@ import org.apache.hadoop.hive.ql.plan.TableDesc
 
 import org.apache.spark.Logging
 import org.apache.spark.sql.catalyst.analysis.{Catalog, MultiInstanceRelation, OverrideCatalog}
+import org.apache.spark.sql.catalyst.CatalystTypeConverters
 import org.apache.spark.sql.catalyst.expressions.codegen.GeneratePredicate
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
@@ -723,7 +724,7 @@ private[hive] case class MetastoreRelation
         val partitionValues = part.getValues
         var i = 0
         while (i < partitionValues.size()) {
-          inputData(i) = partitionValues(i)
+          inputData(i) = CatalystTypeConverters.convertToCatalyst(partitionValues(i))
           i += 1
         }
         pruningCondition(inputData)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -734,9 +734,13 @@ private[hive] case class MetastoreRelation
         var size: Long = 0
         refParts.foreach { refPart =>
           // get size of the partition
-          val partParams = refPart.getParameters
+          val partParams = Option(refPart.getParameters)
+          // If any of the parameters of referred partitions is not defined, skip BroadCastJoin
+          if (partParams.isEmpty) {
+            return sqlContext.conf.defaultSizeInBytes  
+          }
           val partSize =
-            Option(partParams.get(HiveShim.getStatsSetupConstTotalSize))
+            Option(partParams.get.get(HiveShim.getStatsSetupConstTotalSize))
               .map(_.toLong)
               .getOrElse(0L)
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -730,8 +730,6 @@ private[hive] case class MetastoreRelation
         pruningCondition(inputData)
       }
 
-      val sc = sqlContext.asInstanceOf[HiveContext]
-
       def sumParts(): Long = {
         var size: Long = 0
         refParts.foreach { refPart =>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -692,7 +692,7 @@ private[hive] case class MetastoreRelation
     }
   )
 
-  def updateStats(predicates: Seq[Expression]) = {
+  def updateStats(predicates: Seq[Expression]): Unit = {
     // Filter out all predicates that only deal with partition keys
     val partitionsKeys = AttributeSet(partitionKeys)
     val (pruningPredicates, otherPredicates) = predicates.partition {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -740,7 +740,7 @@ private[hive] case class MetastoreRelation
             return sqlContext.conf.defaultSizeInBytes  
           }
           val partSize =
-            Option(partParams.get.get(HiveShim.getStatsSetupConstTotalSize))
+            Option(partParams.get.get(StatsSetupConst.TOTAL_SIZE))
               .map(_.toLong)
               .getOrElse(0L)
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -287,7 +287,6 @@ private[hive] trait HiveStrategies {
       case ExtractEquiJoinKeys(Inner, leftKeys, rightKeys, condition, left, right)
         if {
           val (fields, filters, child, _) = PhysicalOperation.collectProjectsAndFilters(right)
-          Some((fields.getOrElse(child.output), filters, child))
           right transform {
               case relation: MetastoreRelation => relation.updateStats(filters)
                 relation
@@ -301,7 +300,6 @@ private[hive] trait HiveStrategies {
       case ExtractEquiJoinKeys(Inner, leftKeys, rightKeys, condition, left, right)
           if {
             val (fields, filters, child, _) = PhysicalOperation.collectProjectsAndFilters(left)
-            Some((fields.getOrElse(child.output), filters, child))
             left transform {
               case relation: MetastoreRelation => relation.updateStats(filters)
                 relation


### PR DESCRIPTION
This PR attempts to add support for better size estimation in case of partitioned tables so that only the referred partition's size are taken into consideration when testing against autoBroadCastJoinThreshold and  deciding whether to create a broadcast join or shuffle hash join.

We can use the values that get stored in the hive metastore during alter table / insert into partition commands to estimate the size of each of the referred partitions. 

In most cases, since both alter table query and 'insert into table <tablename> partition <part=val> select \* from .....'    store the partition size in the metastore automatically, we expect to get the correct value of partition size. We could use Analyze table query as well in case there is some mismatch. 
