### PR TITLE
[SPARK-6891] Fix the bug that ExecutorAllocationManager will request negative number executors

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -203,8 +203,8 @@ private[spark] class ExecutorAllocationManager(
    * The number of executors we would have if the cluster manager were to fulfill all our existing
    * requests.
    */
-  private def targetNumExecutors(): Int =
-    numExecutorsPending + executorIds.size - executorsPendingToRemove.size
+  private def targetNumExecutors(): Int = math.max(numExecutorsPending + executorIds.size -
+    executorsPendingToRemove.size, minNumExecutors)
 
   /**
    * The maximum number of executors we would need under the current load to satisfy all running


### PR DESCRIPTION
In ExecutorAllocationManager, executor allocate schedule at a fix rate(100ms), it will call the method 'addOrCancelExecutorRequests' first, and then remove expired excutors. 
Suppose at time T, no task is running or pending, and there a 5 executors runing, but all expired. 
1. the method 'addOrCancelExecutorRequests'  wiill be called, and the value of 'ExecutorAllocationManager.numExecutorsPending' will update to -5. 
2. remove 5 expired excutors.
Suppose still no task is running or pending at T+1, the method 'targetNumExecutors' will return -5, and method 'addExecutors' will be called,

private def addExecutors(maxNumExecutorsNeeded: Int): Int = {
    val currentTarget = targetNumExecutors
    ....
    val actualMaxNumExecutors = math.min(maxNumExecutors, maxNumExecutorsNeeded)
    val newTotalExecutors = math.min(currentTarget + numExecutorsToAdd, actualMaxNumExecutors)
    val addRequestAcknowledged = testing || client.requestTotalExecutors(newTotalExecutors)
    ....
  }

newTotalExecutors will be a negative number, when client.requestTotalExecutors(newTotalExecutors) called, it will throw an exception. 

Let method 'targetNumExecutors' return a value not less than minNumExecutors, then the newTotalExecutors will never be negative. 

And targetNumExecutors not less than minNumExecutors is also make sense.
