### PR TITLE
[Minor][MLLIB] Refactor toString method in MLLIB

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
@@ -526,7 +526,7 @@ class SparseVector(
     s" ${values.size} values.")
 
   override def toString: String =
-    "(%s,%s,%s)".format(size, indices.mkString("[", ",", "]"), values.mkString("[", ",", "]"))
+    s"($size,${indices.mkString("[", ",", "]")},${values.mkString("[", ",", "]")})"
 
   override def toArray: Array[Double] = {
     val data = new Array[Double](size)

--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/LabeledPoint.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/LabeledPoint.scala
@@ -32,7 +32,7 @@ import org.apache.spark.SparkException
 @BeanInfo
 case class LabeledPoint(label: Double, features: Vector) {
   override def toString: String = {
-    "(%s,%s)".format(label, features)
+    s"($label,$features)"
   }
 }
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/InformationGainStats.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/InformationGainStats.scala
@@ -39,7 +39,8 @@ class InformationGainStats(
     val rightPredict: Predict) extends Serializable {
 
   override def toString: String = {
-    s"gain = $gain, impurity = $impurity, left impurity = $leftImpurity, right impurity = $rightImpurity"
+    s"gain = $gain, impurity = $impurity, left impurity = $leftImpurity, " +
+      s"right impurity = $rightImpurity"
   }
 
   override def equals(o: Any): Boolean = o match {

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/InformationGainStats.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/InformationGainStats.scala
@@ -39,8 +39,7 @@ class InformationGainStats(
     val rightPredict: Predict) extends Serializable {
 
   override def toString: String = {
-    "gain = %f, impurity = %f, left impurity = %f, right impurity = %f"
-      .format(gain, impurity, leftImpurity, rightImpurity)
+    s"gain = $gain, impurity = $impurity, left impurity = $leftImpurity, right impurity = $rightImpurity"
   }
 
   override def equals(o: Any): Boolean = o match {

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/Node.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/Node.scala
@@ -51,8 +51,8 @@ class Node (
     var stats: Option[InformationGainStats]) extends Serializable with Logging {
 
   override def toString: String = {
-    "id = " + id + ", isLeaf = " + isLeaf + ", predict = " + predict + ", " +
-      "impurity = " + impurity + ", split = " + split + ", stats = " + stats
+    s"id = $id, isLeaf = $isLeaf, predict = $predict, impurity = $impurity, " +
+      s"split = $split, stats = $stats"
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/Node.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/Node.scala
@@ -51,7 +51,7 @@ class Node (
     var stats: Option[InformationGainStats]) extends Serializable with Logging {
 
   override def toString: String = {
-    "id = " + id + ", isLeaf = " + isLeaf + ", " + predict + ", " +
+    "id = " + id + ", isLeaf = " + isLeaf + ", predict = " + predict + ", " +
       "impurity = " + impurity + ", split = " + split + ", stats = " + stats
   }
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/Node.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/Node.scala
@@ -51,8 +51,8 @@ class Node (
     var stats: Option[InformationGainStats]) extends Serializable with Logging {
 
   override def toString: String = {
-    "id = " + id + ", isLeaf = " + isLeaf + ", predict = " + predict + ", " +
-      "impurity =  " + impurity + ", split = " + split + ", stats = " + stats
+    "id = " + id + ", isLeaf = " + isLeaf + ", " + predict + ", " +
+      "impurity = " + impurity + ", split = " + split + ", stats = " + stats
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/Predict.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/Predict.scala
@@ -29,7 +29,7 @@ class Predict(
     val predict: Double,
     val prob: Double = 0.0) extends Serializable {
 
-  override def toString: String = s"$predict(prob = $prob)"
+  override def toString: String = s"$predict (prob = $prob)"
 
   override def equals(other: Any): Boolean = {
     other match {

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/Predict.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/Predict.scala
@@ -29,9 +29,7 @@ class Predict(
     val predict: Double,
     val prob: Double = 0.0) extends Serializable {
 
-  override def toString: String = {
-    "predict = %f, prob = %f".format(predict, prob)
-  }
+  override def toString: String = s"$predict(prob = $prob)"
 
   override def equals(other: Any): Boolean = {
     other match {

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/Split.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/Split.scala
@@ -39,7 +39,7 @@ case class Split(
     categories: List[Double]) {
 
   override def toString: String = {
-    "Feature = " + feature + ", threshold = " + threshold + ", featureType =  " + featureType +
+    "Feature = " + feature + ", threshold = " + threshold + ", featureType = " + featureType +
       ", categories = " + categories
   }
 }
@@ -68,4 +68,3 @@ private[tree] class DummyHighSplit(feature: Int, featureType: FeatureType)
  */
 private[tree] class DummyCategoricalSplit(feature: Int, featureType: FeatureType)
   extends Split(feature, Double.MaxValue, featureType, List())
-

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/Split.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/Split.scala
@@ -39,8 +39,8 @@ case class Split(
     categories: List[Double]) {
 
   override def toString: String = {
-    "Feature = " + feature + ", threshold = " + threshold + ", featureType = " + featureType +
-      ", categories = " + categories
+    s"Feature = $feature, threshold = $threshold, featureType = $featureType, " +
+      s"categories = $categories"
   }
 }
 


### PR DESCRIPTION
1. predict(predict.toString) has already output prefix “predict” thus it’s duplicated to print ", predict = " again
2. there are some extra spaces
