### PR TITLE
Upgrade the json4s version

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -217,7 +217,7 @@
     <dependency>
       <groupId>org.json4s</groupId>
       <artifactId>json4s-jackson_${scala.binary.version}</artifactId>
-      <version>3.2.10</version>
+      <version>3.2.11</version>
     </dependency>
     <dependency>
       <groupId>org.apache.mesos</groupId>


### PR DESCRIPTION
The new version of json4s adds support to parse Map[String,Any] out the box. This is a very useful feature that i've been using in my custom version of spark.
