### PR TITLE
[SPARK-7158] [SQL] Fix bug of cached data cannot be used in collect() after cache()

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -115,7 +115,7 @@ private[sql] object DataFrame {
 @Experimental
 class DataFrame private[sql](
     @transient val sqlContext: SQLContext,
-    @DeveloperApi @transient var queryExecution: SQLContext#QueryExecution)
+    @DeveloperApi @transient private var _queryExecution: SQLContext#QueryExecution)
   extends RDDApi[Row] with Serializable {
 
   /**
@@ -133,6 +133,8 @@ class DataFrame private[sql](
       qe
     })
   }
+
+  @DeveloperApi def queryExecution: SQLContext#QueryExecution = _queryExecution
 
   @transient protected[sql] val logicalPlan: LogicalPlan = queryExecution.logical match {
     // For various commands (like DDL) and queries with side effects, we force query optimization to
@@ -1317,7 +1319,7 @@ class DataFrame private[sql](
    */
   override def persist(newLevel: StorageLevel): this.type = {
     sqlContext.cacheManager.cacheQuery(this, None, newLevel)
-    this.queryExecution = new sqlContext.QueryExecution(this.queryExecution.logical)
+    this._queryExecution = new sqlContext.QueryExecution(this.queryExecution.logical)
     this
   }
 
@@ -1327,7 +1329,7 @@ class DataFrame private[sql](
    */
   override def unpersist(blocking: Boolean): this.type = {
     sqlContext.cacheManager.tryUncacheQuery(this, blocking)
-    this.queryExecution = new sqlContext.QueryExecution(this.queryExecution.logical)
+    this._queryExecution = new sqlContext.QueryExecution(this.queryExecution.logical)
     this
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
@@ -103,7 +103,7 @@ private[sql] class CacheManager(sqlContext: SQLContext) extends Logging {
             sqlContext.conf.useCompression,
             sqlContext.conf.columnBatchSize,
             storageLevel,
-            query.queryExecution.executedPlan,
+            sqlContext.executePlan(query.logicalPlan).executedPlan,
             tableName))
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -123,7 +123,7 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll with SQLTestUtils {
 
     val df = Seq(Tuple1(1), Tuple1(2), Tuple1(3)).toDF("index")
     // we except the id is materialized once
-    def id:() => String = () => { UUID.randomUUID().toString() }
+    def id: () => String = () => { UUID.randomUUID().toString() }
 
     val dfWithId = df.withColumn("id", callUDF(id, StringType))
     // Make a new DataFrame (actually the same reference to the old one)


### PR DESCRIPTION
When df.cache() method called, the `withCachedData` of `QueryExecution` has been created, which mean it will not look up the cached tables when action method called afterward.

Replace the lazy variable with method will fix this bug.
