### PR TITLE
[SPARK-7194][MLLIB] Vectors factors method for sparse vectors should accept the output of zipWithIndex

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
@@ -211,6 +211,17 @@ object Vectors {
   def dense(values: Array[Double]): Vector = new DenseVector(values)
 
   /**
+   * Creates a sparse vector providing its value array.
+   *
+   * @param values value array, must have the same length as indices.
+   */
+  def sparse(values: Array[Double]): Vector = {
+    val size = values.length
+    val (result, indices) = values.zipWithIndex.filter(_._1 != 0.0).unzip
+    new SparseVector(size, indices.toArray, result.toArray)
+  }
+
+  /**
    * Creates a sparse vector providing its index array and value array.
    *
    * @param size vector size.

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
@@ -68,6 +68,11 @@ class VectorsSuite extends FunSuite {
     assert(vec.toArray === arr)
   }
 
+  test("SPARK-7149 sparse to array") {
+    val vec = Vectors.sparse(arr).asInstanceOf[SparseVector]
+    assert(vec.toArray === arr)
+  }
+
   test("vector equals") {
     val dv1 = Vectors.dense(arr.clone())
     val dv2 = Vectors.dense(arr.clone())

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
@@ -68,7 +68,7 @@ class VectorsSuite extends FunSuite {
     assert(vec.toArray === arr)
   }
 
-  test("SPARK-7149 sparse to array") {
+  test("SPARK-7194 sparse to array") {
     val vec = Vectors.sparse(arr).asInstanceOf[SparseVector]
     assert(vec.toArray === arr)
   }


### PR DESCRIPTION
Add a new Vectors.sparse(arr: Array[Double])
