### PR TITLE
[SPARK-7214] Reserve space for unrolling even when MemoryStore nearly full

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/MemoryStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/MemoryStore.scala
@@ -495,7 +495,7 @@ private[spark] class MemoryStore(blockManager: BlockManager, maxMemory: Long)
    * necessary. If blocks are dropped, adds them to droppedBlocks. Returns whether the
    * request was granted, and any blocks that were dropped trying to grant it.
    */
-  def reserveUnrollMemoryForThisThreadDroppingBlocks(
+  private def reserveUnrollMemoryForThisThreadDroppingBlocks(
         blockToAdd: BlockId,
         space: Long): ResultWithDroppedBlocks = {
     var droppedBlocks = Seq.empty[(BlockId, BlockStatus)]

--- a/core/src/main/scala/org/apache/spark/storage/MemoryStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/MemoryStore.scala
@@ -500,6 +500,8 @@ private[spark] class MemoryStore(blockManager: BlockManager, maxMemory: Long)
         space: Long): ResultWithDroppedBlocks = {
     var droppedBlocks = Seq.empty[(BlockId, BlockStatus)]
     var success = true
+    // Hold the accounting lock, in case another thread concurrently puts a block that
+    // takes up the unrolling space we just ensured here
     accountingLock.synchronized {
       if (!reserveUnrollMemoryForThisThread(space)) {
         logInfo(s"Initial reserveUnrollMemoryForThisThread($space) failed")

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -1241,7 +1241,7 @@ class BlockManagerSuite extends FunSuite with Matchers with BeforeAndAfterEach
     store.putIterator("most", mostList.iterator, memOnly)
     assert(memoryStore.contains("most"))
     
-    var unrollResult = memoryStore.unrollSafely("small", smallList.iterator, droppedBlocks)  
+    val unrollResult = memoryStore.unrollSafely("small", smallList.iterator, droppedBlocks)
     verifyUnroll(smallList.iterator, unrollResult, shouldBeArray = true)
     assert(memoryStore.currentUnrollMemoryForThisThread === 0)
     assert(droppedBlocks.size === 1)


### PR DESCRIPTION
If making the initial reservation of space to unrolling a block fails, attempt to drop blocks to make room before giving up.
