### PR TITLE
[SPARK-7269] [SQL] Incorrect analysis for aggregation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -150,12 +150,12 @@ class Analyzer(
      * @return the attributes of non selected specified via bitmask (with the bit set to 1)
      */
     private def buildNonSelectExprSet(bitmask: Int, exprs: Seq[Expression])
-    : OpenHashSet[Expression] = {
-      val set = new OpenHashSet[Expression](2)
+    : OpenHashSet[ExpressionEquals] = {
+      val set = new OpenHashSet[ExpressionEquals](2)
 
       var bit = exprs.length - 1
       while (bit >= 0) {
-        if (((bitmask >> bit) & 1) == 0) set.add(exprs(bit))
+        if (((bitmask >> bit) & 1) == 0) set.add(ExpressionEquals(exprs(bit)))
         bit -= 1
       }
 
@@ -201,7 +201,7 @@ class Analyzer(
         val nonSelectedGroupExprSet = buildNonSelectExprSet(bitmask, g.groupByExprs)
 
         val substitution = (g.child.output :+ g.gid).map(expr => expr transformDown {
-          case x: Expression if nonSelectedGroupExprSet.contains(x) =>
+          case x: Expression if nonSelectedGroupExprSet.contains(ExpressionEquals(x)) =>
             // if the input attribute in the Invalid Grouping Expression set of for this group
             // replace it with constant null
             Literal.create(null, expr.dataType)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -150,12 +150,12 @@ class Analyzer(
      * @return the attributes of non selected specified via bitmask (with the bit set to 1)
      */
     private def buildNonSelectExprSet(bitmask: Int, exprs: Seq[Expression])
-    : OpenHashSet[ExpressionEquals] = {
-      val set = new OpenHashSet[ExpressionEquals](2)
+    : ExpressionSet = {
+      val set = new ExpressionSet()
 
       var bit = exprs.length - 1
       while (bit >= 0) {
-        if (((bitmask >> bit) & 1) == 0) set.add(ExpressionEquals(exprs(bit)))
+        if (((bitmask >> bit) & 1) == 0) set.add(exprs(bit))
         bit -= 1
       }
 
@@ -201,7 +201,7 @@ class Analyzer(
         val nonSelectedGroupExprSet = buildNonSelectExprSet(bitmask, g.groupByExprs)
 
         val substitution = (g.child.output :+ g.gid).map(expr => expr transformDown {
-          case x: Expression if nonSelectedGroupExprSet.contains(ExpressionEquals(x)) =>
+          case x: Expression if nonSelectedGroupExprSet.contains(x) =>
             // if the input attribute in the Invalid Grouping Expression set of for this group
             // replace it with constant null
             Literal.create(null, expr.dataType)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -84,10 +84,10 @@ trait CheckAnalysis {
                 s"of type ${f.condition.dataType.simpleString} is not a boolean.")
 
           case Aggregate(groupingExprs, aggregateExprs, child) =>
-            val normalizedGroupingExprs = groupingExprs.map(ExpressionEquals.apply)
+            val normalizedGroupingExprs = ExpressionSet(groupingExprs)
             def checkValidAggregateExpression(expr: Expression): Unit = expr match {
               case _: AggregateExpression => // OK
-              case e if normalizedGroupingExprs.exists(_ == ExpressionEquals(e)) => // OK
+              case e if normalizedGroupingExprs.contains(e) => // OK
               case e if e.children.size > 0 => e.children.foreach(checkValidAggregateExpression)
               case e: NamedExpression =>
                 failAnalysis(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExpressionMap.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExpressionMap.scala
@@ -27,7 +27,7 @@ sealed class ExpressionMap[A] extends Serializable {
   def get(k: Expression): Option[A] = baseMap.get(ExpressionEquals.normalize(k))
 
   def add(k: Expression, value: A): Unit = {
-    baseMap.put(k, value)
+    baseMap.put(ExpressionEquals.normalize(k), value)
   }
 
   def values: Iterable[A] = baseMap.values

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExpressionMap.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExpressionMap.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+/**
+ * Builds a map that is keyed by an normalized expression. Using the expression allows values
+ * to be looked up even when the attributes used differ cosmetically (i.e., the capitalization
+ * of the name, or the expected nullability).
+ */
+sealed class ExpressionMap[A] extends Serializable {
+  private val baseMap = new collection.mutable.HashMap[Expression, A]()
+  def get(k: Expression): Option[A] = baseMap.get(ExpressionEquals.normalize(k))
+
+  def add(k: Expression, value: A): Unit = {
+    baseMap.put(k, value)
+  }
+
+  def values: Iterable[A] = baseMap.values
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExpressionSet.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExpressionSet.scala
@@ -40,6 +40,8 @@ object ExpressionSet {
  */
 sealed class ExpressionSet extends Serializable {
   private val baseSet: java.util.Set[Expression] = new java.util.HashSet[Expression]()
-  def contains(expr: Expression): Boolean = contains(ExpressionEquals.normalize(expr))
+  def contains(expr: Expression): Boolean = {
+    baseSet.contains(ExpressionEquals.normalize(expr))
+  }
   def add(expr: Expression): Unit = baseSet.add(ExpressionEquals.normalize(expr))
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExpressionSet.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExpressionSet.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+private[expressions] object ExpressionEquals {
+  def normalize(expr: Expression): Expression = expr.transformUp {
+    case n: AttributeReference =>
+      // We don't care about the name of AttributeReference in its semantic equality check
+      new AttributeReference(null, n.dataType, n.nullable, n.metadata)(n.exprId, n.qualifiers)
+  }
+}
+
+object ExpressionSet {
+  def apply(exprs: Iterable[Expression]): ExpressionSet = {
+    val set = new ExpressionSet()
+    exprs.foreach(e => set.add(e))
+
+    set
+  }
+}
+
+/**
+ * Builds a Expression Set that used to be looked up even when the attributes used
+ * differ cosmetically (i.e., the capitalization of the name, or the expected nullability).
+ */
+sealed class ExpressionSet extends Serializable {
+  private val baseSet: java.util.Set[Expression] = new java.util.HashSet[Expression]()
+  def contains(expr: Expression): Boolean = contains(ExpressionEquals.normalize(expr))
+  def add(expr: Expression): Unit = baseSet.add(ExpressionEquals.normalize(expr))
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/package.scala
@@ -101,9 +101,5 @@ package object expressions  {
         // We don't care about the name of AttributeReference in its semantic equality check
         new AttributeReference(null, n.dataType, n.nullable, n.metadata)(n.exprId, n.qualifiers)
     }
-
-    def semanticEquals(l: Expression, r: Expression): Boolean = {
-      normalize(l) == normalize(r)
-    }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/package.scala
@@ -77,29 +77,4 @@ package object expressions  {
     /** Uses the given row to store the output of the projection. */
     def target(row: MutableRow): MutableProjection
   }
-
-  /**
-   * A utility classes for check the expression equality in semantic, not literally.
-   */
-  trait ExpressionEquals
-
-  private[this] class AttributeRefEquals(private val normalized: Expression)
-    extends ExpressionEquals {
-    override def equals(other: Any): Boolean = other match {
-      case o: AttributeRefEquals => normalized == o.normalized
-      case _ => false
-    }
-
-    override def hashCode(): Int = normalized.hashCode()
-  }
-
-  object ExpressionEquals {
-    def apply(e: Expression): ExpressionEquals = new AttributeRefEquals(normalize(e))
-
-    protected def normalize(expr: Expression): Expression = expr.transformUp {
-      case n: AttributeReference =>
-        // We don't care about the name of AttributeReference in its semantic equality check
-        new AttributeReference(null, n.dataType, n.nullable, n.metadata)(n.exprId, n.qualifiers)
-    }
-  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/package.scala
@@ -83,7 +83,8 @@ package object expressions  {
    */
   trait ExpressionEquals
 
-  private[this] class AttributeRefEquals(private val normalized: Expression) extends ExpressionEquals {
+  private[this] class AttributeRefEquals(private val normalized: Expression)
+    extends ExpressionEquals {
     override def equals(other: Any): Boolean = other match {
       case o: AttributeRefEquals => normalized == o.normalized
       case _ => false

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/package.scala
@@ -77,4 +77,32 @@ package object expressions  {
     /** Uses the given row to store the output of the projection. */
     def target(row: MutableRow): MutableProjection
   }
+
+  /**
+   * A utility classes for check the expression equality in semantic, not literally.
+   */
+  trait ExpressionEquals
+
+  private[this] class AttributeRefEquals(private val normalized: Expression) extends ExpressionEquals {
+    override def equals(other: Any): Boolean = other match {
+      case o: AttributeRefEquals => normalized == o.normalized
+      case _ => false
+    }
+
+    override def hashCode(): Int = normalized.hashCode()
+  }
+
+  object ExpressionEquals {
+    def apply(e: Expression): ExpressionEquals = new AttributeRefEquals(normalize(e))
+
+    protected def normalize(expr: Expression): Expression = expr.transformUp {
+      case n: AttributeReference =>
+        // We don't care about the name of AttributeReference in its semantic equality check
+        new AttributeReference(null, n.dataType, n.nullable, n.metadata)(n.exprId, n.qualifiers)
+    }
+
+    def semanticEquals(l: Expression, r: Expression): Boolean = {
+      normalize(l) == normalize(r)
+    }
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -143,10 +143,10 @@ object PartialAggregation {
         // We need to pass all grouping expressions though so the grouping can happen a second
         // time. However some of them might be unnamed so we alias them allowing them to be
         // referenced in the second aggregation.
-        val namedGroupingExpressions: Map[Expression, NamedExpression] =
+        val namedGroupingExpressions: Map[ExpressionEquals, NamedExpression] =
           groupingExpressions.filter(!_.isInstanceOf[Literal]).map {
-            case n: NamedExpression => (n, n)
-            case other => (other, Alias(other, "PartialGroup")())
+            case n: NamedExpression => (ExpressionEquals(n), n)
+            case other => (ExpressionEquals(other), Alias(other, "PartialGroup")())
           }.toMap
 
         // Replace aggregations with a new expression that computes the result from the already
@@ -160,7 +160,7 @@ object PartialAggregation {
             // resolving struct field accesses, because `GetField` is not a `NamedExpression`.
             // (Should we just turn `GetField` into a `NamedExpression`?)
             namedGroupingExpressions
-              .get(e.transform { case Alias(g: ExtractValue, _) => g })
+              .get(ExpressionEquals(e.transform { case Alias(g: ExtractValue, _) => g }))
               .map(_.toAttribute)
               .getOrElse(e)
         }).asInstanceOf[Seq[NamedExpression]]

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -443,7 +443,9 @@ class SQLQuerySuite extends QueryTest {
   }
 
   test("SPARK-7269 Check analysis failed in case in-sensitive") {
-    Seq(1,2,3).map(i => (i.toString, i.toString)).toDF("key", "value").registerTempTable("df_analysis")
+    Seq(1,2,3).map { i =>
+      (i.toString, i.toString)
+    }.toDF("key", "value").registerTempTable("df_analysis")
     sql("SELECT kEy from df_analysis group by key").collect()
     sql("SELECT kEy+3 from df_analysis group by key+3").collect()
     sql("SELECT kEy+3, a.kEy, A.kEy from df_analysis A group by key").collect()

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -442,6 +442,22 @@ class SQLQuerySuite extends QueryTest {
       sql("SELECT `key` FROM src").collect().toSeq)
   }
 
+  test("SPARK-7269 Check analysis failed in case in-sensitive") {
+    Seq(1,2,3).map(i => (i.toString, i.toString)).toDF("key", "value").registerTempTable("df_analysis")
+    sql("SELECT kEy from df_analysis group by key").collect()
+    sql("SELECT kEy+3 from df_analysis group by key+3").collect()
+    sql("SELECT kEy+3, a.kEy, A.kEy from df_analysis A group by key").collect()
+    sql("SELECT cast(kEy+1 as Int) from df_analysis A group by cast(key+1 as int)").collect()
+    sql("SELECT cast(kEy+1 as Int) from df_analysis A group by key+1").collect()
+    sql("SELECT 2 from df_analysis A group by key+1").collect()
+    intercept[AnalysisException] {
+      sql("SELECT kEy+1 from df_analysis group by key+3")
+    }
+    intercept[AnalysisException] {
+      sql("SELECT cast(key+2 as Int) from df_analysis A group by cast(key+1 as int)")
+    }
+  }
+
   test("SPARK-3834 Backticks not correctly handled in subquery aliases") {
     checkAnswer(
       sql("SELECT a.key FROM (SELECT key FROM src) `a`"),


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-7269
In a case in-sensitive system, the `AttributeReference` object may not the same literally, as the `name` in different capital, however, in semantic it's should be identical, as after being resolved, the `exprId` is exactly the same.

For example:

```
SELECT kEy + 1 FROM src GROUP BY key+ 1
```

It's actually a legal query in HiveContext(case insensitive), however, it will fail in `CheckAnalysis` as
`Add(AttributeReference("key"), Literal(1))` and
`Add(AttributeReference("kEy"), Literal(1))` are not identical in literal. As we have code

``` scala
case e if groupingExprs.contains(e) => // OK
```

in `CheckAnalysis.scala` for `Aggregate`, as well as in `patterns.scala` for partial aggregation.

In order not to confusing people by overwriting the method `AttributeReference.equals()`, we provide a utility classes for the equality checking purpose.

In long term, we probably need to refactor the `Expression` a little bit for supporting the `semanticEquals()` instead of `equals()`(literally equality checking)
