### PR TITLE
[SPARK-6257] [PySpark] [MLlib] MLlib API missing items in Recommendation

### DIFF
--- a/docs/mllib-collaborative-filtering.md
+++ b/docs/mllib-collaborative-filtering.md
@@ -216,7 +216,7 @@ model = ALS.train(ratings, rank, numIterations)
 testdata = ratings.map(lambda p: (p[0], p[1]))
 predictions = model.predictAll(testdata).map(lambda r: ((r[0], r[1]), r[2]))
 ratesAndPreds = ratings.map(lambda r: ((r[0], r[1]), r[2])).join(predictions)
-MSE = ratesAndPreds.map(lambda r: (r[1][0] - r[1][1])**2).reduce(lambda x, y: x + y) / ratesAndPreds.count()
+MSE = ratesAndPreds.map(lambda r: (r[1][0] - r[1][1])**2).mean()
 print("Mean Squared Error = " + str(MSE))
 
 # Save and load model

--- a/python/pyspark/mllib/recommendation.py
+++ b/python/pyspark/mllib/recommendation.py
@@ -66,9 +66,9 @@ class MatrixFactorizationModel(JavaModelWrapper, JavaSaveable, JavaLoader):
     [(1, array('d', [...])), (2, array('d', [...]))]
 
     >>> model.recommendUsers(1, 2)
-    (Rating(user=2, product=1, rating=1.9...), Rating(user=1, product=1, rating=1.0...))
+    [Rating(user=2, product=1, rating=1.9...), Rating(user=1, product=1, rating=1.0...)]
     >>> model.recommendProducts(1, 2)
-    (Rating(user=1, product=2, rating=1.9...), Rating(user=1, product=1, rating=1.0...))
+    [Rating(user=1, product=2, rating=1.9...), Rating(user=1, product=1, rating=1.0...)]
     >>> model.rank
     4
 
@@ -113,13 +113,13 @@ class MatrixFactorizationModel(JavaModelWrapper, JavaSaveable, JavaLoader):
     """
     def predict(self, user, product):
         """
-        Predicts rating for a given user and product.
+        Predicts rating for the given user and product.
         """
         return self._java_model.predict(int(user), int(product))
 
     def predictAll(self, user_product):
         """
-        Returns a list of predicted Ratings for a user and many products.
+        Returns a list of predicted ratings for input user and product pairs.
         """
         assert isinstance(user_product, RDD), "user_product should be RDD of (user, product)"
         first = user_product.first()
@@ -129,33 +129,31 @@ class MatrixFactorizationModel(JavaModelWrapper, JavaSaveable, JavaLoader):
 
     def userFeatures(self):
         """
-        Returns a coupled RDD, where the first element is the user and the
+        Returns a paired RDD, where the first element is the user and the
         second is an array of features corresponding to that user.
         """
         return self.call("getUserFeatures").mapValues(lambda v: array.array('d', v))
 
     def productFeatures(self):
         """
-        Returns a coupled RDD, where the first element is the product and the
+        Returns a paired RDD, where the first element is the product and the
         second is an array of features corresponding to that product.
         """
         return self.call("getProductFeatures").mapValues(lambda v: array.array('d', v))
 
     def recommendUsers(self, product, num):
         """
-        Recommends the top "num" number of products for a given user.
-        This is done by returning a tuple of Rating objects, the second id (product)
-        being constant and sorted according to the rating.
+        Recommends the top "num" number of users for a given product and returns a list
+        of Rating objects sorted by the predicted rating in descending order.
         """
-        return self.call("recommendUsers", product, num)
+        return list(self.call("recommendUsers", product, num))
 
     def recommendProducts(self, user, num):
         """
-        Recommends the top "num" number of products for a given user.
-        This is done by returning a tuple of Rating objects, the first id (user)
-        being constant and sorted according to the rating.
+        Recommends the top "num" number of products for a given user and returns a list
+        of Rating objects sorted by the predicted rating in descending order.
         """
-        return self.call("recommendProducts", user, num)
+        return list(self.call("recommendProducts", user, num))
 
     @property
     def rank(self):


### PR DESCRIPTION
Adds

rank, recommendUsers and RecommendProducts to MatrixFactorizationModel in PySpark.
