### PR TITLE
[SPARK-7283][Core] Ignore InterruptedException in SparkUncaughtExceptionHandler

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/SparkUncaughtExceptionHandler.scala
+++ b/core/src/main/scala/org/apache/spark/util/SparkUncaughtExceptionHandler.scala
@@ -29,6 +29,11 @@ private[spark] object SparkUncaughtExceptionHandler
 
   override def uncaughtException(thread: Thread, exception: Throwable) {
     try {
+      if (exception.isInstanceOf[InterruptedException]) {
+        // InterruptedException means other threads try to stop this thread intentionally. It's
+        // a normal exit approach and we should not call "System.exit".
+        return
+      }
       logError("Uncaught exception in thread " + thread, exception)
 
       // We may have been called from a shutdown hook. If so, we must not call System.exit().

--- a/core/src/main/scala/org/apache/spark/util/SparkUncaughtExceptionHandler.scala
+++ b/core/src/main/scala/org/apache/spark/util/SparkUncaughtExceptionHandler.scala
@@ -29,7 +29,9 @@ private[spark] object SparkUncaughtExceptionHandler
 
   override def uncaughtException(thread: Thread, exception: Throwable) {
     try {
-      if (exception.isInstanceOf[InterruptedException]) {
+      if (exception.isInstanceOf[InterruptedException] ||
+        (exception.isInstanceOf[Error] && exception.getCause != null &&
+          exception.getCause.isInstanceOf[InterruptedException])) {
         // InterruptedException means other threads try to stop this thread intentionally. It's
         // a normal exit approach and we should not call "System.exit".
         return


### PR DESCRIPTION
InterruptedException means other threads try to stop this thread intentionally. It's a normal exit approach and we should not call "System.exit".
