### PR TITLE
Limit help option regex

### DIFF
--- a/bin/spark-shell2.cmd
+++ b/bin/spark-shell2.cmd
@@ -19,7 +19,7 @@ rem
 
 set SPARK_HOME=%~dp0..
 
-echo "%*" | findstr " --help -h" >nul
+echo "%*" | findstr " \<--help\> \<-h\>" >nul
 if %ERRORLEVEL% equ 0 (
   call :usage
   exit /b 0


### PR DESCRIPTION
Added word-boundary delimiters so that embedded text such as "-h" within command line options and values doesn't trigger the usage script and exit.
