### PR TITLE
redir stderr better, remove unused code, better java exe detection

### DIFF
--- a/dev/run-tests
+++ b/dev/run-tests
@@ -62,7 +62,12 @@ export SBT_MAVEN_PROFILES_ARGS="$SBT_MAVEN_PROFILES_ARGS -Pkinesis-asl"
   if test -x "$JAVA_HOME/bin/java"; then
       declare java_cmd="$JAVA_HOME/bin/java"
   else
-      declare java_cmd=java
+      declare java_cmd=$(which java)
+  fi
+
+  if [ ! -x $java_cmd ]; then
+      echo "[error] JAVA_HOME unset and java executable not found in system path: ${PATH}"
+      exit 1
   fi
 
   # We can't use sed -r -e due to OS X / BSD compatibility; hence, all the parentheses.

--- a/dev/run-tests-jenkins
+++ b/dev/run-tests-jenkins
@@ -171,15 +171,14 @@ for t in "${PR_TESTS[@]}"; do
   # Ensure the test can be found and is a file
   if [ -f "${this_test}" ]; then
     echo "Running test: $t"
-    this_mssg="$(bash "${this_test}" "${ghprbActualCommit}" "${sha1}" "${current_pr_head}")"
-    # Check if this is the merge test as we submit that note *before* and *after*
-    # the tests run
-    [ "$t" == "pr_merge_ability" ] && merge_note="${this_mssg}"
+    this_mssg="$(bash "${this_test}" "${ghprbActualCommit}" "${sha1}" "${current_pr_head}" "2> /dev/null")"
+
     pr_message="${pr_message}\n${this_mssg}"
     # Ensure, after each test, that we're back on the current PR
     git checkout -f "${current_pr_head}" &>/dev/null
   else
     echo "Cannot find test ${this_test}."
+    die 1
   fi
 done
 

--- a/dev/run-tests-jenkins
+++ b/dev/run-tests-jenkins
@@ -178,7 +178,7 @@ for t in "${PR_TESTS[@]}"; do
     git checkout -f "${current_pr_head}" &>/dev/null
   else
     echo "Cannot find test ${this_test}."
-    die 1
+    exit 1
   fi
 done
 


### PR DESCRIPTION
- redirect stderr on the pr_\* scripts to /dev/null, so the error messages (which are unuseful) don't pollute test logs.
- remove the test/setting of $merge_note as it never once seems to be used (and the message is appended anyways)
- set java using which(), fail if no java exe is found
