### PR TITLE
[SPARK-7291][Core] Fix a flaky test in AkkaRpcEnvSuite

### DIFF
--- a/core/src/test/scala/org/apache/spark/rpc/akka/AkkaRpcEnvSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rpc/akka/AkkaRpcEnvSuite.scala
@@ -40,7 +40,7 @@ class AkkaRpcEnvSuite extends RpcEnvSuite {
       RpcEnvConfig(conf, "test", "localhost", 12346, new SecurityManager(conf)))
     try {
       val newRef = newRpcEnv.setupEndpointRef("local", ref.address, "test_endpoint")
-      assert("akka.tcp://local@localhost:12345/user/test_endpoint" ===
+      assert(s"akka.tcp://local@${env.address}/user/test_endpoint" ===
         newRef.asInstanceOf[AkkaRpcEndpointRef].actorRef.path.toString)
     } finally {
       newRpcEnv.shutdown()


### PR DESCRIPTION
Read the port from RpcEnv to check the result so that it will success even if port conflicts
