### PR TITLE
spark-7300 remove temporary directories after the file is inserted into hive table

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -251,6 +251,10 @@ case class InsertIntoHiveTable(
       }
     }
 
+    //remove temporary directories
+    val fs = outputPath.getFileSystem(jobConf)
+    fs.delete(outputPath,true)
+
     // Invalidate the cache.
     sqlContext.cacheManager.invalidateCache(table)
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -253,7 +253,8 @@ case class InsertIntoHiveTable(
 
     //remove temporary directories
     val fs = outputPath.getFileSystem(jobConf)
-    fs.delete(outputPath,true)
+    if ( outputPath.getParent.isRoot == false ) 
+      fs.delete(outputPath.getParent,true)
 
     // Invalidate the cache.
     sqlContext.cacheManager.invalidateCache(table)


### PR DESCRIPTION
While using the _insertInto_ api provided in DataFrame, it'll finally call the _loadTable_ or _loadPartition_ provided by Hive. Those two APIs have one side effect. They will not delete the generated temporary directories automatically. 

In order to release the burden of HDFS NameNode, such directories should be removed in the end.

please refer to [spark-7300](https://issues.apache.org/jira/browse/SPARK-7300)
