### PR TITLE
[SPARK-7303] [SQL] push down project if possible when the child is sort

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -175,7 +175,7 @@ object ColumnPruning extends Rule[LogicalPlan] {
 
     // push down project if possible when the child is sort
     case p @ Project(projectList, s @ Sort(order, _, grandChild))
-      if (s.references -- p.references).size == 0 =>
+      if (s.references -- p.outputSet).isEmpty =>
       s.copy(child = Project(projectList, grandChild))
       
     // Eliminate no-op Projects

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -174,8 +174,8 @@ object ColumnPruning extends Rule[LogicalPlan] {
       Limit(exp, Project(projectList, child))
 
     // push down project if possible when the child is sort
-    case p @ Project(projectList, s @ Sort(order, _, grandChild))
-      if (s.references -- p.outputSet).isEmpty =>
+    case p @ Project(projectList, s @ Sort(_, _, grandChild))
+        if s.references.subsetOf(p.outputSet) =>
       s.copy(child = Project(projectList, grandChild))
       
     // Eliminate no-op Projects

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -172,6 +172,11 @@ object ColumnPruning extends Rule[LogicalPlan] {
 
     case Project(projectList, Limit(exp, child)) =>
       Limit(exp, Project(projectList, child))
+
+    // push down project if possible when the child is sort
+    case p @ Project(projectList, s @ Sort(order, _, grandChild))
+      if (s.references -- p.references).size == 0 =>
+      s.copy(child = Project(projectList, grandChild))
       
     // Eliminate no-op Projects
     case Project(projectList, child) if child.output == projectList => child

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.catalyst.optimizer
 
 import org.apache.spark.sql.catalyst.analysis
 import org.apache.spark.sql.catalyst.analysis.EliminateSubQueries
-import org.apache.spark.sql.catalyst.expressions.{Count, Explode}
+import org.apache.spark.sql.catalyst.expressions.{SortOrder, Ascending, Count, Explode}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.plans.{LeftSemi, PlanTest, LeftOuter, RightOuter}
 import org.apache.spark.sql.catalyst.rules._
@@ -540,5 +540,22 @@ class FilterPushdownSuite extends PlanTest {
     val optimized = Optimize.execute(originalQuery)
 
     comparePlans(optimized, originalQuery)
+  }
+
+  test("push down project") {
+    val x = testRelation.subquery('x)
+
+    val originalQuery = {
+      x.select('a, 'b)
+       .sortBy(SortOrder('a, Ascending))
+       .select('a)
+    }
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+    val correctAnswer =
+      x.select('a)
+       .sortBy(SortOrder('a, Ascending)).analyze
+
+    comparePlans(optimized, analysis.EliminateSubQueries(correctAnswer))
   }
 }


### PR DESCRIPTION
Optimize the case of `project(_, sort)` , a example is:

`select key from (select * from testData order by key) t`

before this PR:

```
== Parsed Logical Plan ==
'Project ['key]
 'Subquery t
  'Sort ['key ASC], true
   'Project [*]
    'UnresolvedRelation [testData], None

== Analyzed Logical Plan ==
Project [key#0]
 Subquery t
  Sort [key#0 ASC], true
   Project [key#0,value#1]
    Subquery testData
     LogicalRDD [key#0,value#1], MapPartitionsRDD[1]

== Optimized Logical Plan ==
Project [key#0]
 Sort [key#0 ASC], true
  LogicalRDD [key#0,value#1], MapPartitionsRDD[1] 

== Physical Plan ==
Project [key#0]
 Sort [key#0 ASC], true
  Exchange (RangePartitioning [key#0 ASC], 5), []
   PhysicalRDD [key#0,value#1], MapPartitionsRDD[1] 
```

after this PR 

```
== Parsed Logical Plan ==
'Project ['key]
 'Subquery t
  'Sort ['key ASC], true
   'Project [*]
    'UnresolvedRelation [testData], None

== Analyzed Logical Plan ==
Project [key#0]
 Subquery t
  Sort [key#0 ASC], true
   Project [key#0,value#1]
    Subquery testData
     LogicalRDD [key#0,value#1], MapPartitionsRDD[1] 

== Optimized Logical Plan ==
Sort [key#0 ASC], true
 Project [key#0]
  LogicalRDD [key#0,value#1], MapPartitionsRDD[1] 

== Physical Plan ==
Sort [key#0 ASC], true
 Exchange (RangePartitioning [key#0 ASC], 5), []
  Project [key#0]
   PhysicalRDD [key#0,value#1], MapPartitionsRDD[1] 
```

with this rule we will first do column pruning on the table and then do sorting.
