### PR TITLE
[SPARK-7308][core] fail fast when we detect multiple concurrent attempts for one stage

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkException.scala
+++ b/core/src/main/scala/org/apache/spark/SparkException.scala
@@ -31,7 +31,6 @@ class SparkException(message: String, cause: Throwable)
 private[spark] class SparkDriverExecutionException(cause: Throwable)
   extends SparkException("Execution error", cause)
 
-
 /**
  * Exception indicating an error internal to Spark, not caused by user error
  */

--- a/core/src/main/scala/org/apache/spark/SparkException.scala
+++ b/core/src/main/scala/org/apache/spark/SparkException.scala
@@ -30,3 +30,13 @@ class SparkException(message: String, cause: Throwable)
  */
 private[spark] class SparkDriverExecutionException(cause: Throwable)
   extends SparkException("Execution error", cause)
+
+
+/**
+ * Exception indicating an error internal to Spark, not caused by user error
+ */
+class SparkInternalStateException(message: String, cause: Throwable)
+  extends SparkException(message, cause) {
+
+  def this(message: String) = this(message, null)
+}

--- a/core/src/main/scala/org/apache/spark/SparkException.scala
+++ b/core/src/main/scala/org/apache/spark/SparkException.scala
@@ -34,7 +34,7 @@ private[spark] class SparkDriverExecutionException(cause: Throwable)
 /**
  * Exception indicating an error internal to Spark, not caused by user error
  */
-class SparkInternalStateException(message: String, cause: Throwable)
+class SparkIllegalStateException(message: String, cause: Throwable)
   extends SparkException(message, cause) {
 
   def this(message: String) = this(message, null)

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -163,7 +163,7 @@ private[spark] class TaskSchedulerImpl(
       attemptsByStage.foreach { case (stageId, attempts) =>
         val n = attempts.size
         if (n > 1) {
-          throw new SparkInternalStateException(
+          throw new SparkIllegalStateException(
             s"Stage $stageId has $n concurrent attempts: ${attempts.map{_.attempt}}.  Spark " +
               "internal state is inconsistent, failing job")
         }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -159,7 +159,7 @@ private[spark] class TaskSchedulerImpl(
     this.synchronized {
       val manager = createTaskSetManager(taskSet, maxTaskFailures)
       activeTaskSets(taskSet.id) = manager
-      val attemptsByStage = activeTaskSets.values.map{manager => manager.taskSet}.groupBy{_.stageId}
+      val attemptsByStage = activeTaskSets.values.map(_.taskSet).groupBy(_.stageId)
       attemptsByStage.foreach { case (stageId, attempts) =>
         val n = attempts.size
         if (n > 1) {

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -768,26 +768,6 @@ class DAGSchedulerSuite
     assertDataStructuresEmpty()
   }
 
-  test("fail fast on multiple concurrent attempts for one stage", ActiveTag) {
-    val shuffleMapRdd = new MyRDD(sc, 2, Nil)
-    val shuffleDep = new ShuffleDependency(shuffleMapRdd, null)
-    val shuffleId = shuffleDep.shuffleId
-    val reduceRdd = new MyRDD(sc, 2, List(shuffleDep))
-    submit(reduceRdd, Array(0, 1))
-    complete(taskSets(0), Seq(
-      (Success, makeMapStatus("hostA", 1)),
-      (Success, makeMapStatus("hostB", 1))))
-    // fail one task
-    runEvent(CompletionEvent(taskSets(1).tasks(0),
-      FetchFailed(makeBlockManagerId("hostA"), shuffleId, 0, 0, "ignored"), null, null,
-      createFakeTaskInfo(), null))
-    scheduler.resubmitFailedStages()
-    // fail the other task
-    runEvent(CompletionEvent(taskSets(1).tasks(1),
-      FetchFailed(makeBlockManagerId("hostA"), shuffleId, 0, 0, "ignored"), null, null,
-      createFakeTaskInfo(), null))
-  }
-
   /**
    * Assert that the supplied TaskSet has exactly the given hosts as its preferred locations.
    * Note that this checks only the host and not the executor ID.

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -768,6 +768,26 @@ class DAGSchedulerSuite
     assertDataStructuresEmpty()
   }
 
+  test("fail fast on multiple concurrent attempts for one stage", ActiveTag) {
+    val shuffleMapRdd = new MyRDD(sc, 2, Nil)
+    val shuffleDep = new ShuffleDependency(shuffleMapRdd, null)
+    val shuffleId = shuffleDep.shuffleId
+    val reduceRdd = new MyRDD(sc, 2, List(shuffleDep))
+    submit(reduceRdd, Array(0, 1))
+    complete(taskSets(0), Seq(
+      (Success, makeMapStatus("hostA", 1)),
+      (Success, makeMapStatus("hostB", 1))))
+    // fail one task
+    runEvent(CompletionEvent(taskSets(1).tasks(0),
+      FetchFailed(makeBlockManagerId("hostA"), shuffleId, 0, 0, "ignored"), null, null,
+      createFakeTaskInfo(), null))
+    scheduler.resubmitFailedStages()
+    // fail the other task
+    runEvent(CompletionEvent(taskSets(1).tasks(1),
+      FetchFailed(makeBlockManagerId("hostA"), shuffleId, 0, 0, "ignored"), null, null,
+      createFakeTaskInfo(), null))
+  }
+
   /**
    * Assert that the supplied TaskSet has exactly the given hosts as its preferred locations.
    * Note that this checks only the host and not the executor ID.

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -146,7 +146,7 @@ class TaskSchedulerImplSuite extends FunSuite with LocalSparkContext with Loggin
       priority = taskSetAttempt1.priority,
       properties = taskSetAttempt1.properties
     )
-    intercept[SparkInternalStateException](taskScheduler.submitTasks(taskSetAttempt2))
+    intercept[SparkIllegalStateException](taskScheduler.submitTasks(taskSetAttempt2))
   }
 
 }

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -130,4 +130,23 @@ class TaskSchedulerImplSuite extends FunSuite with LocalSparkContext with Loggin
     assert(taskDescriptions.map(_.executorId) === Seq("executor0"))
   }
 
+  test("Scheduler fails fast on multiple active attempts for the same stage") {
+    sc = new SparkContext("local", "TaskSchedulerImplSuite")
+    val taskCpus = 2
+
+    sc.conf.set("spark.task.cpus", taskCpus.toString)
+    val taskScheduler = new TaskSchedulerImpl(sc)
+    taskScheduler.initialize(new FakeSchedulerBackend)
+    val taskSetAttempt1 = FakeTask.createTaskSet(1)
+    taskScheduler.submitTasks(taskSetAttempt1)
+    val taskSetAttempt2 = new TaskSet(
+      tasks = taskSetAttempt1.tasks,
+      stageId = taskSetAttempt1.stageId,
+      attempt = taskSetAttempt1.attempt + 1,
+      priority = taskSetAttempt1.priority,
+      properties = taskSetAttempt1.properties
+    )
+    intercept[SparkInternalStateException](taskScheduler.submitTasks(taskSetAttempt2))
+  }
+
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-7308

put this up quickly to try to get some discussions around it before the code freeze.  It would also really help https://github.com/apache/spark/pull/5636. There is only a very basic regression test for `TaskSchedulerImpl`, nothing at the `DAGScheduler` level.

Note that this is really not a proper fix, its just putting in "fail-fast", but I figure this as much as I can hope to change this close to release.
