### PR TITLE
[SPARK-6166] [Spark Core] Limit number of concurrent outbound connections.

### DIFF
--- a/core/src/main/scala/org/apache/spark/shuffle/hash/BlockStoreShuffleFetcher.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/hash/BlockStoreShuffleFetcher.scala
@@ -80,7 +80,8 @@ private[hash] object BlockStoreShuffleFetcher extends Logging {
       blocksByAddress,
       serializer,
       // Note: we use getSizeAsMb when no suffix is provided for backwards compatibility
-      SparkEnv.get.conf.getSizeAsMb("spark.reducer.maxSizeInFlight", "48m") * 1024 * 1024) 
+      SparkEnv.get.conf.getSizeAsMb("spark.reducer.maxSizeInFlight", "48m") * 1024 * 1024,
+      SparkEnv.get.conf.getInt("spark.reducer.maxReqsInFlight", Int.MaxValue)) 
     val itr = blockFetcherItr.flatMap(unpackBlock)
 
     val completionIter = CompletionIterator[T, Iterator[T]](itr, {

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -36,7 +36,8 @@ import org.apache.spark.util.{CompletionIterator, Utils}
  * pipelined fashion as they are received.
  *
  * The implementation throttles the remote fetches to they don't exceed maxBytesInFlight to avoid
- * using too much memory.
+ * using too much memory. It also limits number of outbound connections to utmost maxReqsInFlight
+ * so that in general too many incoming connections do not hit a single node.
  *
  * @param context [[TaskContext]], used for metrics update
  * @param shuffleClient [[ShuffleClient]] for fetching remote blocks
@@ -46,6 +47,7 @@ import org.apache.spark.util.{CompletionIterator, Utils}
  *                        order to throttle the memory usage.
  * @param serializer serializer used to deserialize the data.
  * @param maxBytesInFlight max size (in bytes) of remote blocks to fetch at any given point.
+ * @param maxReqsInFlight max number of remote blocks to fetch at any given point.
  */
 private[spark]
 final class ShuffleBlockFetcherIterator(
@@ -54,7 +56,8 @@ final class ShuffleBlockFetcherIterator(
     blockManager: BlockManager,
     blocksByAddress: Seq[(BlockManagerId, Seq[(BlockId, Long)])],
     serializer: Serializer,
-    maxBytesInFlight: Long)
+    maxBytesInFlight: Long,
+    maxReqsInFlight: Int)
   extends Iterator[(BlockId, Try[Iterator[Any]])] with Logging {
 
   import ShuffleBlockFetcherIterator._
@@ -102,6 +105,9 @@ final class ShuffleBlockFetcherIterator(
   /** Current bytes in flight from our requests */
   private[this] var bytesInFlight = 0L
 
+  /** Current number of requests in flight */
+  private[this] var reqsInFlight = 0
+
   private[this] val shuffleMetrics = context.taskMetrics.createShuffleReadMetricsForDependency()
 
   private[this] val serializerInstance: SerializerInstance = serializer.newInstance()
@@ -121,7 +127,7 @@ final class ShuffleBlockFetcherIterator(
     isZombie = true
     // Release the current buffer if necessary
     currentResult match {
-      case SuccessFetchResult(_, _, buf) => buf.release()
+      case SuccessFetchResult(_, _, buf, _) => buf.release()
       case _ =>
     }
 
@@ -130,7 +136,7 @@ final class ShuffleBlockFetcherIterator(
     while (iter.hasNext) {
       val result = iter.next()
       result match {
-        case SuccessFetchResult(_, _, buf) => buf.release()
+        case SuccessFetchResult(_, _, buf, _) => buf.release()
         case _ =>
       }
     }
@@ -140,9 +146,11 @@ final class ShuffleBlockFetcherIterator(
     logDebug("Sending request for %d blocks (%s) from %s".format(
       req.blocks.size, Utils.bytesToString(req.size), req.address.hostPort))
     bytesInFlight += req.size
+    reqsInFlight += 1
 
     // so we can look up the size of each blockID
     val sizeMap = req.blocks.map { case (blockId, size) => (blockId.toString, size) }.toMap
+    val remainingBlocks = new ArrayBuffer[String]() ++ sizeMap.keys
     val blockIds = req.blocks.map(_._1.toString)
 
     val address = req.address
@@ -155,7 +163,9 @@ final class ShuffleBlockFetcherIterator(
             // Increment the ref count because we need to pass this to a different thread.
             // This needs to be released after use.
             buf.retain()
-            results.put(new SuccessFetchResult(BlockId(blockId), sizeMap(blockId), buf))
+            remainingBlocks -= blockId
+            results.put(new SuccessFetchResult(BlockId(blockId), sizeMap(blockId), buf,
+                remainingBlocks.isEmpty))
             shuffleMetrics.incRemoteBytesRead(buf.size)
             shuffleMetrics.incRemoteBlocksFetched(1)
           }
@@ -236,7 +246,7 @@ final class ShuffleBlockFetcherIterator(
         shuffleMetrics.incLocalBlocksFetched(1)
         shuffleMetrics.incLocalBytesRead(buf.size)
         buf.retain()
-        results.put(new SuccessFetchResult(blockId, 0, buf))
+        results.put(new SuccessFetchResult(blockId, 0, buf, false))
       } catch {
         case e: Exception =>
           // If we see an exception, stop immediately.
@@ -256,9 +266,13 @@ final class ShuffleBlockFetcherIterator(
     // Add the remote requests into our queue in a random order
     fetchRequests ++= Utils.randomize(remoteRequests)
 
+    assert ((0 == reqsInFlight) == (0 == bytesInFlight),
+      "reqsInFlight = " + reqsInFlight + ", bytesInFlight = " + bytesInFlight)
     // Send out initial requests for blocks, up to our maxBytesInFlight
     while (fetchRequests.nonEmpty &&
-      (bytesInFlight == 0 || bytesInFlight + fetchRequests.front.size <= maxBytesInFlight)) {
+      (bytesInFlight == 0 || 
+        (reqsInFlight + 1 <= maxReqsInFlight &&
+          bytesInFlight + fetchRequests.front.size <= maxBytesInFlight))) {
       sendRequest(fetchRequests.dequeue())
     }
 
@@ -281,19 +295,25 @@ final class ShuffleBlockFetcherIterator(
     shuffleMetrics.incFetchWaitTime(stopFetchWait - startFetchWait)
 
     result match {
-      case SuccessFetchResult(_, size, _) => bytesInFlight -= size
+      case SuccessFetchResult(_, size, _, networkReqDone) => {
+        bytesInFlight -= size
+        // For local blocks, size == 0
+        if (networkReqDone) reqsInFlight -= 1
+      }
       case _ =>
     }
-    // Send fetch requests up to maxBytesInFlight
+    // Send fetch requests up to maxBytesInFlight and reqsInFlight requests
     while (fetchRequests.nonEmpty &&
-      (bytesInFlight == 0 || bytesInFlight + fetchRequests.front.size <= maxBytesInFlight)) {
+      (bytesInFlight == 0 || 
+        (reqsInFlight + 1 <= maxReqsInFlight &&
+          bytesInFlight + fetchRequests.front.size <= maxBytesInFlight))) {
       sendRequest(fetchRequests.dequeue())
     }
 
     val iteratorTry: Try[Iterator[Any]] = result match {
       case FailureFetchResult(_, e) =>
         Failure(e)
-      case SuccessFetchResult(blockId, _, buf) =>
+      case SuccessFetchResult(blockId, _, buf, _) =>
         // There is a chance that createInputStream can fail (e.g. fetching a local file that does
         // not exist, SPARK-4085). In that case, we should propagate the right exception so
         // the scheduler gets a FetchFailedException.
@@ -341,8 +361,8 @@ object ShuffleBlockFetcherIterator {
    *             Note that this is NOT the exact bytes.
    * @param buf [[ManagedBuffer]] for the content.
    */
-  private[storage] case class SuccessFetchResult(blockId: BlockId, size: Long, buf: ManagedBuffer)
-    extends FetchResult {
+  private[storage] case class SuccessFetchResult(blockId: BlockId, size: Long, 
+      buf: ManagedBuffer, networkReqDone: Boolean) extends FetchResult {
     require(buf != null)
     require(size >= 0)
   }

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -360,6 +360,8 @@ object ShuffleBlockFetcherIterator {
    * @param size estimated size of the block, used to calculate bytesInFlight.
    *             Note that this is NOT the exact bytes.
    * @param buf [[ManagedBuffer]] for the content.
+   * @param networkReqDone Is this the last network request for this host in
+   *             this fetch request.
    */
   private[storage] case class SuccessFetchResult(blockId: BlockId, size: Long, 
       buf: ManagedBuffer, networkReqDone: Boolean) extends FetchResult {

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -94,7 +94,8 @@ class ShuffleBlockFetcherIteratorSuite extends FunSuite {
       blockManager,
       blocksByAddress,
       new TestSerializer,
-      48 * 1024 * 1024)
+      48 * 1024 * 1024,
+      Int.MaxValue)
 
     // 3 local blocks fetched in initialization
     verify(blockManager, times(3)).getBlockData(any())
@@ -161,7 +162,8 @@ class ShuffleBlockFetcherIteratorSuite extends FunSuite {
       blockManager,
       blocksByAddress,
       new TestSerializer,
-      48 * 1024 * 1024)
+      48 * 1024 * 1024,
+      Int.MaxValue)
 
     // Exhaust the first block, and then it should be released.
     iterator.next()._2.get.foreach(_ => Unit)
@@ -224,7 +226,8 @@ class ShuffleBlockFetcherIteratorSuite extends FunSuite {
       blockManager,
       blocksByAddress,
       new TestSerializer,
-      48 * 1024 * 1024)
+      48 * 1024 * 1024,
+      Int.MaxValue)
 
     // Continue only after the mock calls onBlockFetchFailure
     sem.acquire()


### PR DESCRIPTION
The overall number of requests in the cluster comes down with this (though in theory, you can still have one node getting swamped). In our experiments this has allowed jobs to progress where they previously die due to workers repeatedly going down when number of requests go up.
Typically happens when you have large number of nodes, and data per node is not too high (in one of the many jobs in the application) - drastic lowering of spark.reducer.maxSizeInFlightMb results is very poor performance overall.

Note: I have not included any testcases - suggestions on how to do the same in current spark test framework would be great - I have not looked at spark test suites in a while. Simulating this is slightly 'interesting'
