### PR TITLE
[SPARK-7317] [Shuffle] Expose shuffle handle

### DIFF
--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleHandle.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleHandle.scala
@@ -17,9 +17,12 @@
 
 package org.apache.spark.shuffle
 
+import org.apache.spark.annotation.DeveloperApi
+
 /**
  * An opaque handle to a shuffle, used by a ShuffleManager to pass information about it to tasks.
  *
  * @param shuffleId ID of the shuffle
  */
-private[spark] abstract class ShuffleHandle(val shuffleId: Int) extends Serializable {}
+@DeveloperApi
+abstract class ShuffleHandle(val shuffleId: Int) extends Serializable {}


### PR DESCRIPTION
Details in JIRA, in a nut-shell, all machinary for custom RDD's to leverage spark shuffle directly (without exposing impl details of shuffle) exists - except for this small piece.

Exposing this will allow for custom dependencies to get a handle to ShuffleHandle - which they can then leverage on reduce side.
