### PR TITLE
[SPARK-7318][Streaming] DStream cleans objects that are not closures

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/ClosureCleaner.scala
+++ b/core/src/main/scala/org/apache/spark/util/ClosureCleaner.scala
@@ -102,6 +102,10 @@ private[spark] object ClosureCleaner extends Logging {
   }
 
   def clean(func: AnyRef, checkSerializable: Boolean = true) {
+    if (!isClosure(func.getClass)) {
+      throw new IllegalArgumentException("Expected a closure; got " + func.getClass.getName)
+    }
+
     // TODO: cache outerClasses / innerClasses / accessedFields
     val outerClasses = getOuterClasses(func)
     val innerClasses = getInnerClasses(func)

--- a/core/src/main/scala/org/apache/spark/util/ClosureCleaner.scala
+++ b/core/src/main/scala/org/apache/spark/util/ClosureCleaner.scala
@@ -180,7 +180,8 @@ private[spark] object ClosureCleaner extends Logging {
       accessedFields: Map[Class[_], Set[String]]): Unit = {
 
     if (!isClosure(func.getClass)) {
-      throw new IllegalArgumentException("Expected a closure; got " + func.getClass.getName)
+      logWarning("Expected a closure; got " + func.getClass.getName)
+      return
     }
 
     // TODO: clean all inner closures first. This requires us to find the inner objects.

--- a/core/src/test/scala/org/apache/spark/util/ClosureCleanerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/ClosureCleanerSuite.scala
@@ -67,10 +67,10 @@ class ClosureCleanerSuite extends FunSuite {
   test("should clean only closures") {
     withSpark(new SparkContext("local", "test")) { sc =>
       val rdd = sc.makeRDD(1 to 100)
-      intercept[IllegalArgumentException] { sc.clean(1) }
+      intercept[IllegalArgumentException] { sc.clean(new Integer(1)) }
       intercept[IllegalArgumentException] { sc.clean("not a closure") }
       intercept[IllegalArgumentException] { sc.clean(rdd) }
-      sc.clean(() => 1)
+      sc.clean(() => new Integer(1))
       sc.clean(() => "part of a closure")
       sc.clean(() => rdd)
     }

--- a/core/src/test/scala/org/apache/spark/util/ClosureCleanerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/ClosureCleanerSuite.scala
@@ -63,18 +63,6 @@ class ClosureCleanerSuite extends FunSuite {
     val result = TestObjectWithNestedReturns.run()
     assert(result === 1)
   }
-
-  test("should clean only closures") {
-    withSpark(new SparkContext("local", "test")) { sc =>
-      val rdd = sc.makeRDD(1 to 100)
-      intercept[IllegalArgumentException] { sc.clean(new Integer(1)) }
-      intercept[IllegalArgumentException] { sc.clean("not a closure") }
-      intercept[IllegalArgumentException] { sc.clean(rdd) }
-      sc.clean(() => new Integer(1))
-      sc.clean(() => "part of a closure")
-      sc.clean(() => rdd)
-    }
-  }
 }
 
 // A non-serializable class we create in closures to make sure that we aren't

--- a/core/src/test/scala/org/apache/spark/util/ClosureCleanerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/ClosureCleanerSuite.scala
@@ -63,6 +63,18 @@ class ClosureCleanerSuite extends FunSuite {
     val result = TestObjectWithNestedReturns.run()
     assert(result == 1)
   }
+
+  test("should clean only closures") {
+    withSpark(new SparkContext("local", "test")) { sc =>
+      val rdd = sc.makeRDD(1 to 100)
+      intercept[IllegalArgumentException] { sc.clean(1) }
+      intercept[IllegalArgumentException] { sc.clean("not a closure") }
+      intercept[IllegalArgumentException] { sc.clean(rdd) }
+      sc.clean(() => 1)
+      sc.clean(() => "part of a closure")
+      sc.clean(() => rdd)
+    }
+  }
 }
 
 // A non-serializable class we create in closures to make sure that we aren't

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
@@ -553,7 +553,8 @@ abstract class DStream[T: ClassTag] (
     // because the DStream is reachable from the outer object here, and because 
     // DStreams can't be serialized with closures, we can't proactively check 
     // it for serializability and so we pass the optional false to SparkContext.clean
-    transform((r: RDD[T], t: Time) => context.sparkContext.clean(transformFunc(r), false))
+    val cleanedF = context.sparkContext.clean(transformFunc, false)
+    transform((r: RDD[T], t: Time) => cleanedF(r))
   }
 
   /**

--- a/streaming/src/test/scala/org/apache/spark/streaming/ReceiverSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/ReceiverSuite.scala
@@ -256,8 +256,8 @@ class ReceiverSuite extends TestSuiteBase with Timeouts with Serializable {
     }
 
     withStreamingContext(new StreamingContext(sparkConf, batchDuration)) { ssc =>
-      val receiver1 = ssc.sparkContext.clean(new FakeReceiver(sendData = true))
-      val receiver2 = ssc.sparkContext.clean(new FakeReceiver(sendData = true))
+      val receiver1 = new FakeReceiver(sendData = true)
+      val receiver2 = new FakeReceiver(sendData = true)
       val receiverStream1 = ssc.receiverStream(receiver1)
       val receiverStream2 = ssc.receiverStream(receiver2)
       receiverStream1.register()


### PR DESCRIPTION
I added a check in `ClosureCleaner#clean` to fail fast if this is detected in the future. @tdas
