### PR TITLE
[SPARK-7149] [SQL] Fix system default alias problem

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
@@ -116,7 +116,7 @@ class SqlParser extends AbstractSparkSQLParser with DataTypeParser {
   protected def assignAliases(exprs: Seq[Expression]): Seq[NamedExpression] = {
     exprs.zipWithIndex.map {
       case (ne: NamedExpression, _) => ne
-      case (e, i) => Alias(e, s"c$i")()
+      case (e, i) => Alias(e, s"col-$i")()
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -452,7 +452,7 @@ class Analyzer(
     def apply(plan: LogicalPlan): LogicalPlan = plan transformUp {
       case filter @ Filter(havingCondition, aggregate @ Aggregate(_, originalAggExprs, _))
           if aggregate.resolved && containsAggregate(havingCondition) => {
-        val evaluatedCondition = Alias(havingCondition,  "havingCondition")()
+        val evaluatedCondition = Alias(havingCondition,  "having-Condition")()
         val aggExprsWithHaving = evaluatedCondition +: originalAggExprs
 
         Project(aggregate.output,

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -1252,4 +1252,15 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(sql("SELECT a.`c.b`, `b.$q`[0].`a@!.q`, `q.w`.`w.i&`[0] FROM t"), Row(1, 1, 1))
   }
+
+
+  test("test default column alias") {
+    checkAnswer(
+      sql("select substr(value, 0, 2), key as c0 from testData order by c0 desc limit 2"),
+      Row("10", 100) :: Row("99", 99) :: Nil)
+
+    checkAnswer(
+      sql("select key as havingCondition from testData group by key having key > count(*)"),
+      (2 to 100).map(Row(_)))
+  }
 }


### PR DESCRIPTION
executing the following sql statement will throw exception:

``` sql
select key as havingCondition from testData group by key having key > count(*)
```

org.apache.spark.sql.AnalysisException: Reference 'havingCondition' is ambiguous, could be: havingCondition#42, havingCondition#41.

``` sql
select substr(value, 0, 2), key as c0 from testData order by c0 desc limit 2
```

org.apache.spark.sql.AnalysisException: Reference 'c0' is ambiguous, could be: c0#42, c0#41.

Here we fix this problem by changing system default alias to an invalid name.if user uses system default alias in project, it will throw parse exception not analysis exception.
