### PR TITLE
DirectPartitioner - directly use integer keys when partitioning is pre-computed.

### DIFF
--- a/core/src/main/scala/org/apache/spark/Partitioner.scala
+++ b/core/src/main/scala/org/apache/spark/Partitioner.scala
@@ -94,6 +94,30 @@ class HashPartitioner(partitions: Int) extends Partitioner {
 }
 
 /**
+ * A [[org.apache.spark.Partitioner]] that uses pre-partitioned integer keys.
+ * Key is reduced modulo numPartitions.
+ *
+ */
+class DirectPartitioner(partitions: Int) extends Partitioner {
+  def numPartitions = partitions
+
+  def getPartition(key: Any): Int = key match {
+    case null => 0
+    case a: Int => Utils.nonNegativeMod(a, numPartitions)
+    case _ => throw new IllegalArgumentException("RDD key type must be 'Int' when using DirectPartitioner.")
+  }
+
+  override def equals(other: Any): Boolean = other match {
+    case d: DirectPartitioner =>
+      d.numPartitions == numPartitions
+    case _ =>
+      false
+  }
+
+  override def hashCode: Int = numPartitions
+}
+
+/**
  * A [[org.apache.spark.Partitioner]] that partitions sortable records by range into roughly
  * equal ranges. The ranges are determined by sampling the content of the RDD passed in.
  *

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1016,7 +1016,7 @@ abstract class RDD[T: ClassTag](
       val curNumPartitions = numPartitions
       partiallyAggregated = partiallyAggregated.mapPartitionsWithIndex { (i, iter) =>
         iter.map((i % curNumPartitions, _))
-      }.reduceByKey(new HashPartitioner(curNumPartitions), cleanCombOp).values
+      }.reduceByKey(new DirectPartitioner(curNumPartitions), cleanCombOp).values
     }
     partiallyAggregated.reduce(cleanCombOp)
   }


### PR DESCRIPTION
Add DirectPartitioner uses pre-computed partition numbers, provided as keys.
Update RDD.treeAggregate to use DirectPartitioner when it is sufficient (avoid computing hashes when not necessary).
