### PR TITLE
[minor] [build] Declare ivy dependency in root pom.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -273,7 +273,6 @@
     <dependency>
       <groupId>org.apache.ivy</groupId>
       <artifactId>ivy</artifactId>
-      <version>${ivy.version}</version>
     </dependency>
     <dependency>
       <groupId>oro</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -417,6 +417,11 @@
         <version>${commons.math3.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.ivy</groupId>
+        <artifactId>ivy</artifactId>
+        <version>${ivy.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
         <version>1.3.9</version>


### PR DESCRIPTION
Without this, any dependency that pulls ivy transitively may override
the version and potentially cause issue. In my machine, the hive tests
were pulling an old version of ivy, and subsequently failing with a
"NoSuchMethodError".
