### PR TITLE
[SPARK-7346][Streaming] Fix a bug that ssc.stop(true, stopGracefully = true) may block forever

### DIFF
--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -209,6 +209,17 @@ class StreamingContextSuite extends FunSuite with BeforeAndAfter with Timeouts w
     }
   }
 
+  test("stop gracefully even if a receiver misses StopReceiver") {
+    val conf = new SparkConf().setMaster(master).setAppName(appName)
+    sc = new SparkContext(conf)
+    ssc = new StreamingContext(sc, Milliseconds(100))
+    val input = ssc.receiverStream(new TestReceiver)
+    input.foreachRDD(_ => {})
+    ssc.start()
+    // Call `ssc.stop` at once so that it's possible that the receiver will miss "StopReceiver"
+    ssc.stop(stopSparkContext = true, stopGracefully = true)
+  }
+
   test("stop slow receiver gracefully") {
     val conf = new SparkConf().setMaster(master).setAppName(appName)
     conf.set("spark.streaming.gracefulStopTimeout", "20000s")


### PR DESCRIPTION
Sometimes, when calling `ssc.stop(true, stopGracefully = true)`, some `ReceiverSupervisorImpl` may not receive `StopReceiver` because it has not yet registered (or started). `ssc.stop(true, stopGracefully = true)` won't send `StopReceiver` to this `ReceiverSupervisorImpl`, so this `ReceiverSupervisorImpl` won't exit and will block `stop` forever.

This PR adds a `stopped` flag so that we can check if it's stopped in `registerReceiver` when a new receiver registers. If it's already stopped, send `StopReceiver` again to make the receiver exit.
