### PR TITLE
[SPARK-7350][Streaming][WebUI] Attach the Streaming tab when calling ssc.start()

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -527,6 +527,7 @@ class StreamingContext private[streaming] (
     validate()
     sparkContext.setCallSite(DStream.getCreationSite())
     scheduler.start()
+    uiTab.foreach(_.attach())
     state = Started
   }
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingTab.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingTab.scala
@@ -37,7 +37,10 @@ private[spark] class StreamingTab(val ssc: StreamingContext)
   ssc.sc.addSparkListener(listener)
   attachPage(new StreamingPage(this))
   attachPage(new BatchPage(this))
-  parent.attachTab(this)
+
+  def attach() {
+    getSparkUI(ssc).attachTab(this)
+  }
 
   def detach() {
     getSparkUI(ssc).detachTab(this)


### PR DESCRIPTION
It's meaningless to display the Streaming tab before `ssc.start()`. So we should attach it in the `ssc.start` method.
