### PR TITLE
[SPARK-7389] [core]Tachyon integration improvement

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -17,8 +17,7 @@
 
 package org.apache.spark.storage
 
-import java.io.{BufferedOutputStream, BufferedInputStream, ByteArrayOutputStream, File,
-  InputStream, OutputStream}
+import java.io._
 import java.nio.{ByteBuffer, MappedByteBuffer}
 
 import scala.collection.mutable.{ArrayBuffer, HashMap}
@@ -500,7 +499,7 @@ private[spark] class BlockManager(
               case Some(values) =>
                 return result
               case None =>
-                logDebug(s"Block $blockId not found in externalBlockStore")
+                logDebug(s"Block $blockId not found in ExternalBlockStore")
             }
           }
         }

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -492,7 +492,7 @@ private[spark] class BlockManager(
           if (externalBlockStore.contains(blockId)) {
             val result = if (asBlockResult) {
               externalBlockStore.getValues(blockId)
-              .map(new BlockResult(_, DataReadMethod.Memory, info.size))
+                .map(new BlockResult(_, DataReadMethod.Memory, info.size))
             } else {
               externalBlockStore.getBytes(blockId)
             }

--- a/core/src/main/scala/org/apache/spark/storage/ExternalBlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ExternalBlockManager.scala
@@ -32,7 +32,7 @@ import java.nio.ByteBuffer
  */
 private[spark] abstract class ExternalBlockManager {
 
-  var blockManager: BlockManager = _
+  protected var blockManager: BlockManager = _
 
   override def toString: String = {"External Block Store"}
 

--- a/core/src/main/scala/org/apache/spark/storage/ExternalBlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ExternalBlockManager.scala
@@ -73,6 +73,8 @@ private[spark] abstract class ExternalBlockManager {
    */
   def putBytes(blockId: BlockId, bytes: ByteBuffer): Unit
 
+  def putValues(blockId: BlockId, values: Iterator[_]): Unit
+
   /**
    * Retrieve the block bytes.
    * @return Some(ByteBuffer) if the block bytes is successfully retrieved
@@ -81,6 +83,15 @@ private[spark] abstract class ExternalBlockManager {
    * @throws java.io.IOException if there is any file system failure in getting the block.
    */
   def getBytes(blockId: BlockId): Option[ByteBuffer]
+
+    /**
+   * Retrieve the block data.
+   * @return Some(Iterator[Any]) if the block data is successfully retrieved
+   *         None if the block does not exist in the external block store.
+   *
+   * @throws java.io.IOException if there is any file system failure in getting the block.
+   */
+  def getValues(blockId: BlockId): Option[Iterator[_]]
 
   /**
    * Get the size of the block saved in the underlying external block store,

--- a/core/src/main/scala/org/apache/spark/storage/ExternalBlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ExternalBlockManager.scala
@@ -84,7 +84,7 @@ private[spark] abstract class ExternalBlockManager {
    */
   def getBytes(blockId: BlockId): Option[ByteBuffer]
 
-    /**
+  /**
    * Retrieve the block data.
    * @return Some(Iterator[Any]) if the block data is successfully retrieved
    *         None if the block does not exist in the external block store.

--- a/core/src/main/scala/org/apache/spark/storage/ExternalBlockStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ExternalBlockStore.scala
@@ -40,7 +40,7 @@ private[spark] class ExternalBlockStore(blockManager: BlockManager, executorId: 
       externalBlockManager.map(_.getSize(blockId)).getOrElse(0)
     } catch {
       case NonFatal(t) =>
-        logError(s"error in getSize from $blockId", t)
+        logError(s"Error in getSize from $blockId", t)
         0L
     }
   }
@@ -69,7 +69,7 @@ private[spark] class ExternalBlockStore(blockManager: BlockManager, executorId: 
       blockId: BlockId,
       values: Iterator[_],
       returnValues: Boolean): PutResult = {
-    logDebug(s"Attempting to put block $blockId into ExtBlk store")
+    logTrace(s"Attempting to put block $blockId into ExternalBlockStore")
     // we should never hit here if externalBlockManager is None. Handle it anyway for safety.
     try {
       val startTime = System.currentTimeMillis
@@ -86,12 +86,12 @@ private[spark] class ExternalBlockStore(blockManager: BlockManager, executorId: 
           blockId, Utils.bytesToString(size), finishTime - startTime))
         PutResult(size, data)
       } else {
-        logError(s"error in putBytes $blockId")
+        logError(s"Error in putValues $blockId : no ExternalBlockManager exists!")
         PutResult(-1, null, Seq((blockId, BlockStatus.empty)))
       }
     } catch {
       case NonFatal(t) =>
-        logError(s"error in putBytes $blockId", t)
+        logError(s"Error in putValues $blockId", t)
         PutResult(-1, null, Seq((blockId, BlockStatus.empty)))
     }
   }
@@ -100,7 +100,7 @@ private[spark] class ExternalBlockStore(blockManager: BlockManager, executorId: 
       blockId: BlockId,
       bytes: ByteBuffer,
       returnValues: Boolean): PutResult = {
-    logDebug(s"Attempting to put block $blockId into ExtBlk store")
+    logTrace(s"Attempting to put block $blockId into ExternalBlockStore")
     // we should never hit here if externalBlockManager is None. Handle it anyway for safety.
     try {
       val startTime = System.currentTimeMillis
@@ -121,12 +121,12 @@ private[spark] class ExternalBlockStore(blockManager: BlockManager, executorId: 
           blockId, Utils.bytesToString(size), finishTime - startTime))
         PutResult(size, data)
       } else {
-        logError(s"error in putBytes $blockId")
+        logError(s"Error in putBytes $blockId : no ExternalBlockManager exists!")
         PutResult(-1, null, Seq((blockId, BlockStatus.empty)))
       }
     } catch {
       case NonFatal(t) =>
-        logError(s"error in putBytes $blockId", t)
+        logError(s"Error in putBytes $blockId", t)
         PutResult(-1, null, Seq((blockId, BlockStatus.empty)))
     }
   }
@@ -137,7 +137,7 @@ private[spark] class ExternalBlockStore(blockManager: BlockManager, executorId: 
       externalBlockManager.map(_.removeBlock(blockId)).getOrElse(true)
     } catch {
       case NonFatal(t) =>
-        logError(s"error in removing $blockId", t)
+        logError(s"Error in removing $blockId", t)
         true
     }
   }
@@ -147,7 +147,7 @@ private[spark] class ExternalBlockStore(blockManager: BlockManager, executorId: 
       externalBlockManager.flatMap(_.getValues(blockId))
     } catch {
       case NonFatal(t) =>
-        logError(s"error in getValues from $blockId", t)
+        logError(s"Error in getValues from $blockId", t)
         None
     }
   }
@@ -157,7 +157,7 @@ private[spark] class ExternalBlockStore(blockManager: BlockManager, executorId: 
       externalBlockManager.flatMap(_.getBytes(blockId))
     } catch {
       case NonFatal(t) =>
-        logError(s"error in getBytes from $blockId", t)
+        logError(s"Error in getBytes from $blockId", t)
         None
     }
   }
@@ -172,7 +172,7 @@ private[spark] class ExternalBlockStore(blockManager: BlockManager, executorId: 
       ret
     } catch {
       case NonFatal(t) =>
-        logError(s"error in getBytes from $blockId", t)
+        logError(s"Error in getBytes from $blockId", t)
         false
     }
   }

--- a/core/src/main/scala/org/apache/spark/storage/TachyonBlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/TachyonBlockManager.scala
@@ -96,11 +96,12 @@ private[spark] class TachyonBlockManager() extends ExternalBlockManager with Log
     val os = file.getOutStream(WriteType.TRY_CACHE)
     try {
       os.write(bytes.array())
-      os.close()
     } catch {
       case e : Exception => 
         logWarning(s"Failed to put byes of block $blockId into Tachyon", e)
         os.cancel()
+    } finally {
+      os.close()
     }
   }
 
@@ -109,11 +110,12 @@ private[spark] class TachyonBlockManager() extends ExternalBlockManager with Log
     val os = file.getOutStream(WriteType.TRY_CACHE)
     try {
       blockManager.dataSerializeStream(blockId, os, values)
-      os.close()
     } catch {
       case e : Exception => 
         logWarning(s"Failed to put values of block $blockId into Tachyon", e)
         os.cancel()
+    } finally {
+      os.close()
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/storage/TachyonBlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/TachyonBlockManager.scala
@@ -21,14 +21,13 @@ import java.io.IOException
 import java.nio.ByteBuffer
 import java.text.SimpleDateFormat
 import java.util.{Date, Random}
-
 import com.google.common.io.ByteStreams
 import tachyon.client.{ReadType, WriteType, TachyonFS, TachyonFile}
 import tachyon.TachyonURI
-
 import org.apache.spark.{SparkException, SparkConf, Logging}
 import org.apache.spark.executor.ExecutorExitCode
 import org.apache.spark.util.Utils
+import scala.util.control.NonFatal
 
 
 /**
@@ -97,7 +96,7 @@ private[spark] class TachyonBlockManager() extends ExternalBlockManager with Log
     try {
       os.write(bytes.array())
     } catch {
-      case e : Exception => 
+      case NonFatal(e) => 
         logWarning(s"Failed to put byes of block $blockId into Tachyon", e)
         os.cancel()
     } finally {
@@ -111,7 +110,7 @@ private[spark] class TachyonBlockManager() extends ExternalBlockManager with Log
     try {
       blockManager.dataSerializeStream(blockId, os, values)
     } catch {
-      case e : Exception => 
+      case NonFatal(e) => 
         logWarning(s"Failed to put values of block $blockId into Tachyon", e)
         os.cancel()
     } finally {
@@ -134,7 +133,7 @@ private[spark] class TachyonBlockManager() extends ExternalBlockManager with Log
       ByteStreams.readFully(is, bs)
       Some(ByteBuffer.wrap(bs))
     } catch {
-      case e: Exception =>
+      case NonFatal(e) =>
         logWarning(s"Failed to get bytes of block $blockId from Tachyon", e)
         None
     } finally {
@@ -218,7 +217,7 @@ private[spark] class TachyonBlockManager() extends ExternalBlockManager with Log
             tachyonDir = client.getFile(path)
           }
         } catch {
-          case e: Exception =>
+          case NonFatal(e) =>
             logWarning("Attempt " + tries + " to create tachyon dir " + tachyonDir + " failed", e)
         }
       }
@@ -240,7 +239,7 @@ private[spark] class TachyonBlockManager() extends ExternalBlockManager with Log
           Utils.deleteRecursively(tachyonDir, client)
         }
       } catch {
-        case e: Exception =>
+        case NonFatal(e) =>
           logError("Exception while deleting tachyon spark dir: " + tachyonDir, e)
       }
     }

--- a/core/src/main/scala/org/apache/spark/storage/TachyonBlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/TachyonBlockManager.scala
@@ -38,7 +38,6 @@ import org.apache.spark.util.Utils
  */
 private[spark] class TachyonBlockManager() extends ExternalBlockManager with Logging {
 
-  var blockManager: BlockManager =_
   var rootDirs: String = _
   var master: String = _
   var client: tachyon.client.TachyonFS = _
@@ -52,7 +51,7 @@ private[spark] class TachyonBlockManager() extends ExternalBlockManager with Log
 
 
   override def init(blockManager: BlockManager, executorId: String): Unit = {
-    this.blockManager = blockManager
+    super.init(blockManager, executorId)
     val storeDir = blockManager.conf.get(ExternalBlockStore.BASE_DIR, "/tmp_spark_tachyon")
     val appFolderName = blockManager.conf.get(ExternalBlockStore.FOLD_NAME)
 


### PR DESCRIPTION
Two main changes:

Add two functions in ExternalBlockManager, which are putValues and getValues
because the implementation may not rely on the putBytes and getBytes

improve Tachyon integration.
Currently, when putting data into Tachyon, Spark first serialize all data in one partition into a ByteBuffer, and then write into Tachyon, this will uses much memory and increase GC overhead

when get data from Tachyon, getValues depends on getBytes, which also read all data into On heap byte arry, and result in much memory usage.
This PR changes the approach of the two functions, make them read / write data by stream to reduce memory usage.

In our testing,  when data size is huge, this patch reduces about 30% GC time and 70% full GC time, and total execution time reduces about 10% 
