### PR TITLE
[SPARK-7385][Core] Add RDD.foreachPartitionWithIndex

### DIFF
--- a/core/src/main/java/org/apache/spark/api/java/function/VoidFunction2.java
+++ b/core/src/main/java/org/apache/spark/api/java/function/VoidFunction2.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.api.java.function;
+
+import java.io.Serializable;
+
+/**
+ * A function with no return value.
+ */
+public interface VoidFunction2<T1, T2> extends Serializable {
+  public void call(T1 t1, T2 t2) throws Exception;
+}

--- a/core/src/main/scala/org/apache/spark/api/java/JavaRDDLike.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaRDDLike.scala
@@ -220,6 +220,14 @@ trait JavaRDDLike[T, This <: JavaRDDLike[T, This]] extends Serializable {
   }
 
   /**
+   * Applies a function f to each partition of this RDD, while tracking the index
+   * of the original partition.
+   */
+  def foreachPartitionWithIndex(f: VoidFunction2[java.lang.Integer, java.util.Iterator[T]]) {
+    rdd.foreachPartitionWithIndex((idx, iter) => f.call(idx, asJavaIterator(iter)))
+  }
+
+  /**
    * Return an RDD created by coalescing all elements within each partition into an array.
    */
   def glom(): JavaRDD[JList[T]] =

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -869,6 +869,13 @@ abstract class RDD[T: ClassTag](
     sc.runJob(this, (iter: Iterator[T]) => cleanF(iter))
   }
 
+  def foreachPartitionWithIndex(f: (Int, Iterator[T]) => Unit): Unit = withScope {
+    val cleanF = sc.clean(f)
+    val processPartitionF = (taskContext: TaskContext, iter: Iterator[T]) =>
+      cleanF(taskContext.partitionId(), iter)
+    sc.runJob(this, processPartitionF)
+  }
+
   /**
    * Return an array that contains all of the elements in this RDD.
    */

--- a/core/src/test/java/org/apache/spark/JavaAPISuite.java
+++ b/core/src/test/java/org/apache/spark/JavaAPISuite.java
@@ -275,15 +275,15 @@ public class JavaAPISuite implements Serializable {
   public void foreachPartitionWithIndex() {
     final Accumulator<Integer> accum = sc.accumulator(0);
     final Accumulator<Integer> accum2 = sc.accumulator(0);
-    JavaRDD<String> rdd = sc.parallelize(Arrays.asList("Hello", "World"));
+    JavaRDD<String> rdd = sc.parallelize(Arrays.asList("Hello", "World"), 2);
     rdd.foreachPartitionWithIndex(new VoidFunction2<Integer, Iterator<String>>() {
       @Override
       public void call(Integer index, Iterator<String> iter) throws IOException {
         while (iter.hasNext()) {
           iter.next();
           accum.add(1);
-          accum2.add(index);
         }
+        accum2.add(index);
       }
     });
     Assert.assertEquals(2, accum.value().intValue());

--- a/core/src/test/java/org/apache/spark/JavaAPISuite.java
+++ b/core/src/test/java/org/apache/spark/JavaAPISuite.java
@@ -157,7 +157,7 @@ public class JavaAPISuite implements Serializable {
   public void randomSplit() {
     List<Integer> ints = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     JavaRDD<Integer> rdd = sc.parallelize(ints);
-    JavaRDD<Integer>[] splits = rdd.randomSplit(new double[] { 0.4, 0.6, 1.0 }, 31);
+    JavaRDD<Integer>[] splits = rdd.randomSplit(new double[]{0.4, 0.6, 1.0}, 31);
     Assert.assertEquals(3, splits.length);
     Assert.assertEquals(1, splits[0].count());
     Assert.assertEquals(2, splits[1].count());
@@ -269,6 +269,25 @@ public class JavaAPISuite implements Serializable {
       }
     });
     Assert.assertEquals(2, accum.value().intValue());
+  }
+
+  @Test
+  public void foreachPartitionWithIndex() {
+    final Accumulator<Integer> accum = sc.accumulator(0);
+    final Accumulator<Integer> accum2 = sc.accumulator(0);
+    JavaRDD<String> rdd = sc.parallelize(Arrays.asList("Hello", "World"));
+    rdd.foreachPartitionWithIndex(new VoidFunction2<Integer, Iterator<String>>() {
+      @Override
+      public void call(Integer index, Iterator<String> iter) throws IOException {
+        while (iter.hasNext()) {
+          iter.next();
+          accum.add(1);
+          accum2.add(index);
+        }
+      }
+    });
+    Assert.assertEquals(2, accum.value().intValue());
+    Assert.assertEquals(1, accum2.value().intValue());
   }
 
   @Test

--- a/core/src/test/java/org/apache/spark/JavaAPISuite.java
+++ b/core/src/test/java/org/apache/spark/JavaAPISuite.java
@@ -157,7 +157,7 @@ public class JavaAPISuite implements Serializable {
   public void randomSplit() {
     List<Integer> ints = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     JavaRDD<Integer> rdd = sc.parallelize(ints);
-    JavaRDD<Integer>[] splits = rdd.randomSplit(new double[]{0.4, 0.6, 1.0}, 31);
+    JavaRDD<Integer>[] splits = rdd.randomSplit(new double[] { 0.4, 0.6, 1.0 }, 31);
     Assert.assertEquals(3, splits.length);
     Assert.assertEquals(1, splits[0].count());
     Assert.assertEquals(2, splits[1].count());

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -52,7 +52,10 @@ object MimaExcludes {
             ProblemFilters.exclude[IncompatibleResultTypeProblem](
               "org.apache.spark.broadcast.TorrentBroadcastFactory.newBroadcast"),
             ProblemFilters.exclude[MissingClassProblem](
-              "org.apache.spark.scheduler.OutputCommitCoordinator$OutputCommitCoordinatorActor")
+              "org.apache.spark.scheduler.OutputCommitCoordinator$OutputCommitCoordinatorActor"),
+            // SPARK-7385 - Add RDD.foreachPartitionWithIndex
+            ProblemFilters.exclude[MissingMethodProblem](
+              "org.apache.spark.api.java.JavaRDDLike.foreachPartitionWithIndex")
           ) ++ Seq(
             // SPARK-4655 - Making Stage an Abstract class broke binary compatility even though
             // the stage class is defined as private[spark]

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -737,6 +737,24 @@ class RDD(object):
                 return iter([])
         self.mapPartitions(func).count()  # Force evaluation
 
+    def foreachPartitionWithIndex(self, f):
+        """
+        Applies a function to each partition of this RDD,
+        while tracking the index of the original partition.
+
+        >>> def f(idx, iterator):
+        ...      for x in iterator:
+        ...           print(idx, x)
+        >>> sc.parallelize([1, 2, 3, 4, 5]).foreachPartitionWithIndex(f)
+        """
+        def func(idx, it):
+            r = f(idx, it)
+            try:
+                return iter(r)
+            except TypeError:
+                return iter([])
+        self.mapPartitionsWithIndex(func).count()  # Force evaluation
+
     def collect(self):
         """
         Return a list that contains all of the elements in this RDD.


### PR DESCRIPTION
Spark Streaming apps often update external stores transactionally, which requires it to have an id that uniquely identifies the partition of data to be inserted. This can be the (batch time, partition index).
Current work around is to use `mapPartitionsWithIndex().count()` which is quite hacky. This PR is to add `foreachPartitionWithIndex()`. 
