### PR TITLE
[SPARK-7401] [MLlib] [PySpark] Vectorize dot product and sq_dist between SparseVector and DenseVector

### DIFF
--- a/python/pyspark/mllib/linalg.py
+++ b/python/pyspark/mllib/linalg.py
@@ -577,23 +577,15 @@ class SparseVector(Vector):
             ...
         AssertionError: dimension mismatch
         """
-        if type(other) == np.ndarray:
+        assert len(self) == _vector_size(other), "dimension mismatch"
+        if isinstance(other, np.ndarray):
             if other.ndim == 2:
                 results = [self.dot(other[:, i]) for i in xrange(other.shape[1])]
                 return np.array(results)
-            elif other.ndim > 2:
+            elif other.ndim == 1:
+                return np.dot(other[self.indices], self.values)
+            else:
                 raise ValueError("Cannot call dot with %d-dimensional array" % other.ndim)
-
-        assert len(self) == _vector_size(other), "dimension mismatch"
-
-        if isinstance(other, array.array):
-            result = 0.0
-            for i, ind in enumerate(self.indices):
-                result += self.values[i] * other[ind]
-            return result
-
-        elif isinstance(other, np.ndarray):
-            return np.dot(other[self.indices], self.values)
 
         elif isinstance(other, DenseVector):
             return np.dot(other.array[self.indices], self.values)
@@ -641,19 +633,8 @@ class SparseVector(Vector):
         AssertionError: dimension mismatch
         """
         assert len(self) == _vector_size(other), "dimension mismatch"
-        if isinstance(other, list) or isinstance(other, array.array):
-            result = 0.0
-            j = 0   # index into our own array
-            for i, val in enumerate(other):
-                if j < len(self.indices) and self.indices[j] == i:
-                    diff = self.values[j] - val
-                    result += diff * diff
-                    j += 1
-                else:
-                    result += val * val
-            return result
 
-        elif isinstance(other, np.ndarray) or isinstance(other, DenseVector):
+        if isinstance(other, np.ndarray) or isinstance(other, DenseVector):
             if isinstance(other, np.ndarray) and other.ndim != 1:
                 raise Exception("Cannot call squared_distance with %d-dimensional array" %
                                 other.ndim)

--- a/python/pyspark/mllib/linalg.py
+++ b/python/pyspark/mllib/linalg.py
@@ -579,14 +579,10 @@ class SparseVector(Vector):
         """
 
         if isinstance(other, np.ndarray):
-            if other.ndim == 2:
-                results = [self.dot(other[:, i]) for i in xrange(other.shape[1])]
-                return np.array(results)
-            elif other.ndim == 1:
-                assert len(self) == _vector_size(other), "dimension mismatch"
-                return np.dot(other[self.indices], self.values)
-            else:
+            if other.ndim not in [2, 1]:
                 raise ValueError("Cannot call dot with %d-dimensional array" % other.ndim)
+            assert len(self) == other.shape[0], "dimension mismatch"
+            return np.dot(self.values, other[self.indices])
 
         assert len(self) == _vector_size(other), "dimension mismatch"
 

--- a/python/pyspark/mllib/linalg.py
+++ b/python/pyspark/mllib/linalg.py
@@ -577,17 +577,20 @@ class SparseVector(Vector):
             ...
         AssertionError: dimension mismatch
         """
-        assert len(self) == _vector_size(other), "dimension mismatch"
+
         if isinstance(other, np.ndarray):
             if other.ndim == 2:
                 results = [self.dot(other[:, i]) for i in xrange(other.shape[1])]
                 return np.array(results)
             elif other.ndim == 1:
+                assert len(self) == _vector_size(other), "dimension mismatch"
                 return np.dot(other[self.indices], self.values)
             else:
                 raise ValueError("Cannot call dot with %d-dimensional array" % other.ndim)
 
-        elif isinstance(other, DenseVector):
+        assert len(self) == _vector_size(other), "dimension mismatch"
+
+        if isinstance(other, DenseVector):
             return np.dot(other.array[self.indices], self.values)
 
         elif isinstance(other, SparseVector):

--- a/python/pyspark/mllib/linalg.py
+++ b/python/pyspark/mllib/linalg.py
@@ -586,7 +586,7 @@ class SparseVector(Vector):
 
         assert len(self) == _vector_size(other), "dimension mismatch"
 
-        if type(other) == array.array:
+        if isinstance(other, array.array):
             result = 0.0
             for i, ind in enumerate(self.indices):
                 result += self.values[i] * other[ind]
@@ -641,23 +641,23 @@ class SparseVector(Vector):
         AssertionError: dimension mismatch
         """
         assert len(self) == _vector_size(other), "dimension mismatch"
-        if type(other) in (list, array.array):
-            if type(other) is np.array and other.ndim != 1:
-                raise Exception("Cannot call squared_distance with %d-dimensional array" %
-                                other.ndim)
+        if isinstance(other, list) or isinstance(other, array.array):
             result = 0.0
             j = 0   # index into our own array
-            for i in xrange(len(other)):
+            for i, val in enumerate(other):
                 if j < len(self.indices) and self.indices[j] == i:
-                    diff = self.values[j] - other[i]
+                    diff = self.values[j] - val
                     result += diff * diff
                     j += 1
                 else:
-                    result += other[i] * other[i]
+                    result += val * val
             return result
 
-        elif type(other) in (np.array, np.ndarray, DenseVector):
-            if type(other) == DenseVector:
+        elif isinstance(other, np.ndarray) or isinstance(other, DenseVector):
+            if isinstance(other, np.ndarray) and other.ndim != 1:
+                raise Exception("Cannot call squared_distance with %d-dimensional array" %
+                                other.ndim)
+            if isinstance(other, DenseVector):
                 other = other.array
             sparse_ind = np.zeros(other.size, dtype=bool)
             sparse_ind[self.indices] = True
@@ -668,7 +668,7 @@ class SparseVector(Vector):
             result += np.dot(other_ind, other_ind)
             return result
 
-        elif type(other) is SparseVector:
+        elif isinstance(other, SparseVector):
             result = 0.0
             i, j = 0, 0
             while i < len(self.indices) and j < len(other.indices):

--- a/python/pyspark/mllib/tests.py
+++ b/python/pyspark/mllib/tests.py
@@ -128,17 +128,22 @@ class VectorTests(MLlibTestCase):
                      [1., 2., 3., 4.],
                      [1., 2., 3., 4.],
                      [1., 2., 3., 4.]])
+        arr = pyarray('d', [0, 1, 2, 3])
         self.assertEquals(10.0, sv.dot(dv))
         self.assertTrue(array_equal(array([3., 6., 9., 12.]), sv.dot(mat)))
         self.assertEquals(30.0, dv.dot(dv))
         self.assertTrue(array_equal(array([10., 20., 30., 40.]), dv.dot(mat)))
         self.assertEquals(30.0, lst.dot(dv))
         self.assertTrue(array_equal(array([10., 20., 30., 40.]), lst.dot(mat)))
+        self.assertTrue(7.0, sv.dot(arr))
 
     def test_squared_distance(self):
         sv = SparseVector(4, {1: 1, 3: 2})
         dv = DenseVector(array([1., 2., 3., 4.]))
         lst = DenseVector([4, 3, 2, 1])
+        lst1 = [4, 3, 2, 1]
+        arr = pyarray('d', [0, 2, 1, 3])
+        narr = array([0, 2, 1, 3])
         self.assertEquals(15.0, _squared_distance(sv, dv))
         self.assertEquals(25.0, _squared_distance(sv, lst))
         self.assertEquals(20.0, _squared_distance(dv, lst))
@@ -148,6 +153,9 @@ class VectorTests(MLlibTestCase):
         self.assertEquals(0.0, _squared_distance(sv, sv))
         self.assertEquals(0.0, _squared_distance(dv, dv))
         self.assertEquals(0.0, _squared_distance(lst, lst))
+        self.assertEquals(25.0, _squared_distance(sv, lst1))
+        self.assertEquals(3.0, _squared_distance(sv, arr))
+        self.assertEquals(3.0, _squared_distance(sv, narr))
 
     def test_conversion(self):
         # numpy arrays should be automatically upcast to float64

--- a/python/pyspark/mllib/tests.py
+++ b/python/pyspark/mllib/tests.py
@@ -135,7 +135,7 @@ class VectorTests(MLlibTestCase):
         self.assertTrue(array_equal(array([10., 20., 30., 40.]), dv.dot(mat)))
         self.assertEquals(30.0, lst.dot(dv))
         self.assertTrue(array_equal(array([10., 20., 30., 40.]), lst.dot(mat)))
-        self.assertTrue(7.0, sv.dot(arr))
+        self.assertEquals(7.0, sv.dot(arr))
 
     def test_squared_distance(self):
         sv = SparseVector(4, {1: 1, 3: 2})

--- a/python/pyspark/mllib/tests.py
+++ b/python/pyspark/mllib/tests.py
@@ -128,7 +128,7 @@ class VectorTests(MLlibTestCase):
                      [1., 2., 3., 4.],
                      [1., 2., 3., 4.],
                      [1., 2., 3., 4.]])
-        arr = pyarray('d', [0, 1, 2, 3])
+        arr = pyarray.array('d', [0, 1, 2, 3])
         self.assertEquals(10.0, sv.dot(dv))
         self.assertTrue(array_equal(array([3., 6., 9., 12.]), sv.dot(mat)))
         self.assertEquals(30.0, dv.dot(dv))
@@ -142,7 +142,7 @@ class VectorTests(MLlibTestCase):
         dv = DenseVector(array([1., 2., 3., 4.]))
         lst = DenseVector([4, 3, 2, 1])
         lst1 = [4, 3, 2, 1]
-        arr = pyarray('d', [0, 2, 1, 3])
+        arr = pyarray.array('d', [0, 2, 1, 3])
         narr = array([0, 2, 1, 3])
         self.assertEquals(15.0, _squared_distance(sv, dv))
         self.assertEquals(25.0, _squared_distance(sv, lst))


### PR DESCRIPTION
Currently we iterate over indices which can be vectorized.
