### PR TITLE
[Build] Always run SQL tests in master build.

### DIFF
--- a/dev/run-tests
+++ b/dev/run-tests
@@ -82,24 +82,31 @@ export SBT_MAVEN_PROFILES_ARGS="$SBT_MAVEN_PROFILES_ARGS -Pkinesis-asl"
 if [ -n "$AMPLAB_JENKINS" ]; then
   git fetch origin master:master
 
-  sql_diffs=$(
-    git diff --name-only master \
-    | grep -e "^sql/" -e "^bin/spark-sql" -e "^sbin/start-thriftserver.sh"
-  )
+  # AMP_JENKINS_PRB indicates if the current build is a pull request build.
+  if [ -n "$AMP_JENKINS_PRB" ]; then
+    # It is a pull request build.
+    sql_diffs=$(
+      git diff --name-only master \
+      | grep -e "^sql/" -e "^bin/spark-sql" -e "^sbin/start-thriftserver.sh"
+    )
 
-  non_sql_diffs=$(
-    git diff --name-only master \
-    | grep -v -e "^sql/" -e "^bin/spark-sql" -e "^sbin/start-thriftserver.sh"
-  )
+    non_sql_diffs=$(
+      git diff --name-only master \
+      | grep -v -e "^sql/" -e "^bin/spark-sql" -e "^sbin/start-thriftserver.sh"
+    )
 
-  if [ -n "$sql_diffs" ]; then
-    echo "[info] Detected changes in SQL. Will run Hive test suite."
-    _RUN_SQL_TESTS=true
+    if [ -n "$sql_diffs" ]; then
+      echo "[info] Detected changes in SQL. Will run Hive test suite."
+      _RUN_SQL_TESTS=true
 
-    if [ -z "$non_sql_diffs" ]; then
-      echo "[info] Detected no changes except in SQL. Will only run SQL tests."
-      _SQL_TESTS_ONLY=true
+      if [ -z "$non_sql_diffs" ]; then
+        echo "[info] Detected no changes except in SQL. Will only run SQL tests."
+        _SQL_TESTS_ONLY=true
+      fi
     fi
+  else
+    # It is a regular build. We should run SQL tests.
+    _RUN_SQL_TESTS=true
   fi
 fi
 

--- a/dev/run-tests-jenkins
+++ b/dev/run-tests-jenkins
@@ -185,6 +185,8 @@ done
 
 # run tests
 {
+  # Marks this build is a pull request build.
+  export AMP_JENKINS_PRB=true
   timeout "${TESTS_TIMEOUT}" ./dev/run-tests
   test_result="$?"
 


### PR DESCRIPTION
Seems our master build does not run HiveCompatibilitySuite (because _RUN_SQL_TESTS is not set). This PR introduces a property `AMP_JENKINS_PRB` to differentiate a PR build and a regular build. If a build is a regular one, we always set _RUN_SQL_TESTS to true. 

cc @JoshRosen @nchammas 
