### PR TITLE
[SPARK-7399][Spark Core]Fixed compilation error in scala 2.11

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
@@ -111,7 +111,7 @@ private[spark] object RDDOperationScope {
   private[spark] def withScope[T](
       sc: SparkContext,
       name: String,
-      allowNesting: Boolean = false)(body: => T): T = {
+      allowNesting: Boolean)(body: => T): T = {
     // Save the old scope to restore it later
     val scopeKey = SparkContext.RDD_SCOPE_KEY
     val noOverrideKey = SparkContext.RDD_SCOPE_NO_OVERRIDE_KEY
@@ -134,4 +134,4 @@ private[spark] object RDDOperationScope {
       sc.setLocalProperty(noOverrideKey, oldNoOverride)
     }
   }
-}
+} 


### PR DESCRIPTION
scala has deterministic naming-scheme for the generated methods which return default arguments . here one of the default argument of overloaded method has to be removed
