### PR TITLE
[SPARK-7484][SQL]Support jdbc connection properties

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -1489,15 +1489,29 @@ class DataFrame private[sql](
 
   /**
    * Save this [[DataFrame]] to a JDBC database at `url` under the table name `table`
-   * and connection propeties optionally passed in `properties`.
    * This will run a `CREATE TABLE` and a bunch of `INSERT INTO` statements.
    * If you pass `true` for `allowExisting`, it will drop any table with the
    * given name; if you pass `false`, it will throw if the table already
    * exists.
    * @group output
    */
-  def createJDBCTable(url: String, table: String, allowExisting: Boolean,
-      properties: Properties = new Properties()): Unit = {
+  def createJDBCTable(url: String, table: String, allowExisting: Boolean): Unit = {
+    createJDBCTable(url, table, allowExisting, new Properties())
+  }
+    
+  /**
+   * Save this [[DataFrame]] to a JDBC database at `url` under the table name `table`
+   * and connection properties passed in `properties`.
+   * This will run a `CREATE TABLE` and a bunch of `INSERT INTO` statements.
+   * If you pass `true` for `allowExisting`, it will drop any table with the
+   * given name; if you pass `false`, it will throw if the table already
+   * exists.
+   * @group output
+   */
+  def createJDBCTable(url: String,
+      table: String,
+      allowExisting: Boolean,
+      properties: Properties): Unit = {
     val conn = DriverManager.getConnection(url, properties)
     try {
       if (allowExisting) {
@@ -1515,7 +1529,6 @@ class DataFrame private[sql](
 
   /**
    * Save this [[DataFrame]] to a JDBC database at `url` under the table name `table`
-   * and connection propeties optionally passed in `properties`.
    * Assumes the table already exists and has a compatible schema.  If you
    * pass `true` for `overwrite`, it will `TRUNCATE` the table before
    * performing the `INSERT`s.
@@ -1526,8 +1539,27 @@ class DataFrame private[sql](
    * `INSERT INTO table VALUES (?, ?, ..., ?)` should not fail.
    * @group output
    */
-  def insertIntoJDBC(url: String, table: String, overwrite: Boolean,
-      properties: Properties = new Properties()): Unit = {
+  def insertIntoJDBC(url: String, table: String, overwrite: Boolean): Unit = {
+    insertIntoJDBC(url, table, overwrite, new Properties())
+  }
+
+  /**
+   * Save this [[DataFrame]] to a JDBC database at `url` under the table name `table`
+   * and connection properties passed in `properties`.
+   * Assumes the table already exists and has a compatible schema.  If you
+   * pass `true` for `overwrite`, it will `TRUNCATE` the table before
+   * performing the `INSERT`s.
+   *
+   * The table must already exist on the database.  It must have a schema
+   * that is compatible with the schema of this RDD; inserting the rows of
+   * the RDD in order via the simple statement
+   * `INSERT INTO table VALUES (?, ?, ..., ?)` should not fail.
+   * @group output
+   */
+  def insertIntoJDBC(url: String,
+      table: String,
+      overwrite: Boolean,
+      properties: Properties): Unit = {
     if (overwrite) {
       val conn = DriverManager.getConnection(url, properties)
       try {
@@ -1539,7 +1571,7 @@ class DataFrame private[sql](
     }
     JDBCWriteDetails.saveTable(this, url, table, properties)
   }
-
+  
   ////////////////////////////////////////////////////////////////////////////
   // for Python API
   ////////////////////////////////////////////////////////////////////////////

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -1488,7 +1488,7 @@ class DataFrame private[sql](
   ////////////////////////////////////////////////////////////////////////////
 
   /**
-   * Save this [[DataFrame]] to a JDBC database at `url` under the table name `table`
+   * Save this [[DataFrame]] to a JDBC database at `url` under the table name `table`.
    * This will run a `CREATE TABLE` and a bunch of `INSERT INTO` statements.
    * If you pass `true` for `allowExisting`, it will drop any table with the
    * given name; if you pass `false`, it will throw if the table already
@@ -1501,14 +1501,15 @@ class DataFrame private[sql](
     
   /**
    * Save this [[DataFrame]] to a JDBC database at `url` under the table name `table`
-   * and connection properties passed in `properties`.
+   * using connection properties defined in `properties`.
    * This will run a `CREATE TABLE` and a bunch of `INSERT INTO` statements.
    * If you pass `true` for `allowExisting`, it will drop any table with the
    * given name; if you pass `false`, it will throw if the table already
    * exists.
    * @group output
    */
-  def createJDBCTable(url: String,
+  def createJDBCTable(
+      url: String,
       table: String,
       allowExisting: Boolean,
       properties: Properties): Unit = {
@@ -1528,7 +1529,7 @@ class DataFrame private[sql](
   }
 
   /**
-   * Save this [[DataFrame]] to a JDBC database at `url` under the table name `table`
+   * Save this [[DataFrame]] to a JDBC database at `url` under the table name `table`.
    * Assumes the table already exists and has a compatible schema.  If you
    * pass `true` for `overwrite`, it will `TRUNCATE` the table before
    * performing the `INSERT`s.
@@ -1545,7 +1546,7 @@ class DataFrame private[sql](
 
   /**
    * Save this [[DataFrame]] to a JDBC database at `url` under the table name `table`
-   * and connection properties passed in `properties`.
+   * using connection properties defined in `properties`.
    * Assumes the table already exists and has a compatible schema.  If you
    * pass `true` for `overwrite`, it will `TRUNCATE` the table before
    * performing the `INSERT`s.
@@ -1556,7 +1557,8 @@ class DataFrame private[sql](
    * `INSERT INTO table VALUES (?, ?, ..., ?)` should not fail.
    * @group output
    */
-  def insertIntoJDBC(url: String,
+  def insertIntoJDBC(
+      url: String,
       table: String,
       overwrite: Boolean,
       properties: Properties): Unit = {
@@ -1571,7 +1573,6 @@ class DataFrame private[sql](
     }
     JDBCWriteDetails.saveTable(this, url, table, properties)
   }
-  
   ////////////////////////////////////////////////////////////////////////////
   // for Python API
   ////////////////////////////////////////////////////////////////////////////

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -911,14 +911,27 @@ class SQLContext(@transient val sparkContext: SparkContext)
   /**
    * :: Experimental ::
    * Construct a [[DataFrame]] representing the database table accessible via JDBC URL
+   * url named table.
+   *
+   * @group specificdata
+   */
+  @Experimental
+  def jdbc(url: String, table: String): DataFrame = {
+    jdbc(url, table, JDBCRelation.columnPartition(null), new Properties())
+  }
+  
+  /**
+   * :: Experimental ::
+   * Construct a [[DataFrame]] representing the database table accessible via JDBC URL
    * url named table and connection properties.
    *
    * @group specificdata
    */
   @Experimental
-  def jdbc(url: String, table: String, properties: Properties = new Properties()): DataFrame = {
+  def jdbc(url: String, table: String, properties: Properties): DataFrame = {
     jdbc(url, table, JDBCRelation.columnPartition(null), properties)
   }
+  
   /**
    * :: Experimental ::
    * Construct a [[DataFrame]] representing the database table accessible via JDBC URL
@@ -995,16 +1008,20 @@ class SQLContext(@transient val sparkContext: SparkContext)
    * @group specificdata
    */
   @Experimental
-  def jdbc(url: String, table: String,
-      theParts: Array[String], properties: Properties): DataFrame = {
+  def jdbc(url: String,
+      table: String,
+      theParts: Array[String],
+      properties: Properties): DataFrame = {
     val parts: Array[Partition] = theParts.zipWithIndex.map { case (part, i) =>
       JDBCPartition(part, i) : Partition
     }
     jdbc(url, table, parts, properties)
   }
   
-  private def jdbc(url: String, table: String,
-      parts: Array[Partition], properties: Properties): DataFrame = {
+  private def jdbc(url: String,
+      table: String,
+      parts: Array[Partition],
+      properties: Properties): DataFrame = {
     val relation = JDBCRelation(url, table, parts, properties)(this)
     baseRelationToDataFrame(relation)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -911,13 +911,36 @@ class SQLContext(@transient val sparkContext: SparkContext)
   /**
    * :: Experimental ::
    * Construct a [[DataFrame]] representing the database table accessible via JDBC URL
-   * url named table.
+   * url named table and connection properties.
    *
    * @group specificdata
    */
   @Experimental
-  def jdbc(url: String, table: String): DataFrame = {
-    jdbc(url, table, JDBCRelation.columnPartition(null))
+  def jdbc(url: String, table: String, properties: Properties = new Properties()): DataFrame = {
+    jdbc(url, table, JDBCRelation.columnPartition(null), properties)
+  }
+  /**
+   * :: Experimental ::
+   * Construct a [[DataFrame]] representing the database table accessible via JDBC URL
+   * url named table.  Partitions of the table will be retrieved in parallel based on the parameters
+   * passed to this function.
+   *
+   * @param columnName the name of a column of integral type that will be used for partitioning.
+   * @param lowerBound the minimum value of `columnName` used to decide partition stride
+   * @param upperBound the maximum value of `columnName` used to decide partition stride
+   * @param numPartitions the number of partitions.  the range `minValue`-`maxValue` will be split
+   *                      evenly into this many partitions
+   * @group specificdata
+   */
+  @Experimental
+  def jdbc(
+      url: String,
+      table: String,  
+      columnName: String,
+      lowerBound: Long,
+      upperBound: Long,
+      numPartitions: Int): DataFrame = {
+    jdbc(url, table, columnName, lowerBound, upperBound, numPartitions, new Properties())
   }
 
   /**
@@ -931,7 +954,7 @@ class SQLContext(@transient val sparkContext: SparkContext)
    * @param upperBound the maximum value of `columnName` used to decide partition stride
    * @param numPartitions the number of partitions.  the range `minValue`-`maxValue` will be split
    *                      evenly into this many partitions
-   *
+   * @param properties connection properties
    * @group specificdata
    */
   @Experimental
@@ -941,16 +964,17 @@ class SQLContext(@transient val sparkContext: SparkContext)
       columnName: String,
       lowerBound: Long,
       upperBound: Long,
-      numPartitions: Int): DataFrame = {
+      numPartitions: Int,
+      properties: Properties): DataFrame = {
     val partitioning = JDBCPartitioningInfo(columnName, lowerBound, upperBound, numPartitions)
     val parts = JDBCRelation.columnPartition(partitioning)
-    jdbc(url, table, parts)
+    jdbc(url, table, parts, properties)
   }
-
+  
   /**
    * :: Experimental ::
    * Construct a [[DataFrame]] representing the database table accessible via JDBC URL
-   * url named table.  The theParts parameter gives a list expressions
+   * url named table. The theParts parameter gives a list expressions
    * suitable for inclusion in WHERE clauses; each one defines one partition
    * of the [[DataFrame]].
    *
@@ -958,14 +982,30 @@ class SQLContext(@transient val sparkContext: SparkContext)
    */
   @Experimental
   def jdbc(url: String, table: String, theParts: Array[String]): DataFrame = {
+    jdbc(url, table, theParts, new Properties())
+  }
+
+    /**
+   * :: Experimental ::
+   * Construct a [[DataFrame]] representing the database table accessible via JDBC URL
+   * url named table and connection properties. The theParts parameter gives a list expressions
+   * suitable for inclusion in WHERE clauses; each one defines one partition
+   * of the [[DataFrame]].
+   *
+   * @group specificdata
+   */
+  @Experimental
+  def jdbc(url: String, table: String,
+      theParts: Array[String], properties: Properties): DataFrame = {
     val parts: Array[Partition] = theParts.zipWithIndex.map { case (part, i) =>
       JDBCPartition(part, i) : Partition
     }
-    jdbc(url, table, parts)
+    jdbc(url, table, parts, properties)
   }
-
-  private def jdbc(url: String, table: String, parts: Array[Partition]): DataFrame = {
-    val relation = JDBCRelation(url, table, parts)(this)
+  
+  private def jdbc(url: String, table: String,
+      parts: Array[Partition], properties: Properties): DataFrame = {
+    val relation = JDBCRelation(url, table, parts, properties)(this)
     baseRelationToDataFrame(relation)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -998,17 +998,18 @@ class SQLContext(@transient val sparkContext: SparkContext)
     jdbc(url, table, theParts, new Properties())
   }
 
-    /**
+  /**
    * :: Experimental ::
    * Construct a [[DataFrame]] representing the database table accessible via JDBC URL
-   * url named table and connection properties. The theParts parameter gives a list expressions
+   * url named table using connection properties. The theParts parameter gives a list expressions
    * suitable for inclusion in WHERE clauses; each one defines one partition
    * of the [[DataFrame]].
    *
    * @group specificdata
    */
   @Experimental
-  def jdbc(url: String,
+  def jdbc(
+      url: String,
       table: String,
       theParts: Array[String],
       properties: Properties): DataFrame = {
@@ -1018,7 +1019,8 @@ class SQLContext(@transient val sparkContext: SparkContext)
     jdbc(url, table, parts, properties)
   }
   
-  private def jdbc(url: String,
+  private def jdbc(
+      url: String,
       table: String,
       parts: Array[Partition],
       properties: Properties): DataFrame = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/jdbc.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/jdbc.scala
@@ -57,7 +57,8 @@ package object jdbc {
      * non-Serializable.  Instead, we explicitly close over all variables that
      * are used.
      */
-    def savePartition(url: String,
+    def savePartition(
+        url: String,
         table: String,
         iterator: Iterator[Row],
         rddSchema: StructType,
@@ -156,7 +157,8 @@ package object jdbc {
     /**
      * Saves the RDD to the database in a single transaction.
      */
-    def saveTable(df: DataFrame,
+    def saveTable(
+        df: DataFrame,
         url: String,
         table: String,
         properties: Properties = new Properties()) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/jdbc.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/jdbc.scala
@@ -57,8 +57,11 @@ package object jdbc {
      * non-Serializable.  Instead, we explicitly close over all variables that
      * are used.
      */
-    def savePartition(url: String, table: String, iterator: Iterator[Row],
-        rddSchema: StructType, nullTypes: Array[Int],
+    def savePartition(url: String,
+        table: String,
+        iterator: Iterator[Row],
+        rddSchema: StructType,
+        nullTypes: Array[Int],
         properties: Properties): Iterator[Byte] = {
       val conn = DriverManager.getConnection(url, properties)
       var committed = false
@@ -153,7 +156,9 @@ package object jdbc {
     /**
      * Saves the RDD to the database in a single transaction.
      */
-    def saveTable(df: DataFrame, url: String, table: String,
+    def saveTable(df: DataFrame,
+        url: String,
+        table: String,
         properties: Properties = new Properties()) {
       val quirks = DriverQuirks.get(url)
       var nullTypes: Array[Int] = df.schema.fields.map(field => {


### PR DESCRIPTION
Few jdbc drivers like SybaseIQ support passing username and password only through connection properties. So the same needs to be supported for 
SQLContext.jdbc, dataframe.createJDBCTable and dataframe.insertIntoJDBC.
Added as default arguments or overrided function to support backward compatability.
