### PR TITLE
[SPARK-7489][Spark Shell]Spark shell crashes when compiled with scala 2.11

### DIFF
--- a/repl/scala-2.11/src/main/scala/org/apache/spark/repl/Main.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/spark/repl/Main.scala
@@ -88,7 +88,7 @@ object Main extends Logging {
       logInfo("Created sql context (with Hive support)..")
     }
     catch {
-      case cnf: java.lang.ClassNotFoundException =>
+      case _: java.lang.ClassNotFoundException | _: java.lang.NoClassDefFoundError =>
         sqlContext = new SQLContext(sparkContext)
         logInfo("Created sql context..")
     }


### PR DESCRIPTION
Spark shell crashes when compiled with scala 2.11 and  SPARK_PREPEND_CLASSES=true

There is a similar Resolved JIRA issue -SPARK-7470 and a PR https://github.com/apache/spark/pull/5997 , which handled same issue only in scala 2.10
