### PR TITLE
[Minor] Ignore python/lib/pyspark.zip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ scalastyle.txt
 scalastyle-output.xml
 R-unit-tests.log
 R/unit-tests.out
+python/lib/pyspark.zip
 
 # For Hive
 metastore_db/


### PR DESCRIPTION
Add `python/lib/pyspark.zip` to `.gitignore`. After merging #5580, `python/lib/pyspark.zip` will be generated when building Spark.
