### PR TITLE
[SPARK-7492] Method to convert a local DataFrame to a DenseMatrix

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
@@ -24,7 +24,8 @@ import scala.collection.mutable.{ArrayBuilder => MArrayBuilder, HashSet => MHash
 import breeze.linalg.{CSCMatrix => BSM, DenseMatrix => BDM, Matrix => BM}
 
 import org.apache.spark.annotation.DeveloperApi
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{Column, DataFrame, Row}
+import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.catalyst.expressions.GenericMutableRow
 
@@ -804,6 +805,43 @@ object Matrices {
         throw new UnsupportedOperationException(
           s"Do not support conversion from type ${breeze.getClass.getName}.")
     }
+  }
+
+  /**
+   * Converts a local DataFrame to a DenseMatrix. The values of the DataFrame should be cast-able
+   * to Double. Will create the Matrix from all the numerical columns of the DataFrame.
+   *
+   * TODO: Handle VectorUDT, MatrixUDT, ArrayType with Numerical values
+   * @param df The local DataFrame
+   */
+  def fromDataFrame(df: DataFrame): Matrix = {
+    require(df.isLocal, "This method is used to transform a local DataFrame to a matrix. Please " +
+      "use the BlockMatrix.fromDataFrame to generate a Matrix from a distributed DataFrame.")
+    val columns = new ArrayBuffer[Column](df.columns.length)
+    // The cast will throw an error if the value can't be cast to a Double.
+    df.schema.fields.foreach { field =>
+      if (field.dataType.isInstanceOf[NumericType]) {
+        columns += col(field.name).cast(DoubleType)
+      }
+    }
+    // cast fields to DoubleType
+    val doubleDF = df.select(columns: _*).collect()
+    val numRows = doubleDF.length
+    val numCols = columns.length
+    require(numRows.toLong * numCols <= Int.MaxValue,
+      s"$numRows x $numCols dense matrix is too large to allocate")
+    val mat = DenseMatrix.zeros(numRows, numCols)
+    var i = 0
+    while (i < numRows) {
+      var j = 0
+      val row = doubleDF(i)
+      while (j < numCols) {
+        if (!row.isNullAt(j)) mat.update(i, j, row.getDouble(j))
+        j += 1
+      }
+      i += 1
+    }
+    mat
   }
 
   /**


### PR DESCRIPTION
This PR adds a method: `fromDataFrame` to `Matrices`.
What benefit does this method give? With the addition of Statistical methods in DataFrames, such as `crosstab`, users will be able to call `crosstab` on their DataFrame to get a contingency matrix. Using this method, they will be able to extract the matrix from the DataFrame and then run a Chi-Squared test for feature selection!

An additional nice method to add would be `BlockMatrix.fromDataFrame`, to get the distributed version.

cc @mengxr, @rxin 
