### PR TITLE
Adding AWS d2 instances

### DIFF
--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -387,6 +387,9 @@ EC2_INSTANCE_TYPES = {
     "t2.medium":   "hvm",
     "t2.micro":    "hvm",
     "t2.small":    "hvm",
+    "d2.2xlarge":  "hvm",
+    "d2.4xlarge":  "hvm",
+    "d2.8xlarge":  "hvm"
 }
 
 
@@ -916,6 +919,10 @@ def get_num_disks(instance_type):
         "r3.large":    1,
         "r3.xlarge":   1,
         "t1.micro":    0,
+        "d2.xlarge":   3,
+        "d2.2xlarge":  6,
+        "d2.4xlarge":  12,
+        "d2.8xlarge":  24
     }
     if instance_type in disks_by_instance:
         return disks_by_instance[instance_type]


### PR DESCRIPTION
We were in need of creating a cluster with the d2 instances offered for AWS, and added the d2 instance type to the list.

The spark-ec2 command might look like something like: 

./spark-ec2 -k [my-spark-auth] -i ~[my-spark-auth].pem  -s 3 --zone=us-east-1c --ami ami-1ecae776 launch d2cluster
