### PR TITLE
[SPARK-3928][SQL] Support wildcard matches on Parquet files.

### DIFF
--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.3.0</version>
+      <version>2.4.4</version>
     </dependency>
     <dependency>
       <groupId>org.jodd</groupId>


### PR DESCRIPTION
Support wildcard matches on Parquet files for newParquet implementation.
