### PR TITLE
Upgrade version of jackson-databind in sql/core/pom.xml

### DIFF
--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.3.0</version>
+      <version>2.4.4</version>
     </dependency>
     <dependency>
       <groupId>org.jodd</groupId>


### PR DESCRIPTION
Currently version of jackson-databind in sql/core/pom.xml is 2.3.0

This is older than the version specified in root pom.xml

This PR upgrades the version in sql/core/pom.xml so that they're consistent.
