### PR TITLE
SPARK-7508 JettyUtils-generated servlets to log & report all errors

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -78,6 +78,14 @@ private[spark] object JettyUtils extends Logging {
         } catch {
           case e: IllegalArgumentException =>
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage)
+          case e: Exception =>
+            logWarn(s"GET ${request.getRequestURI} failed: $e", e)
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR)
+            response.setContentType("text/plain;charset=utf-8")
+            response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate")
+            val writer = response.getWriter
+            writer.println(e.toString)
+            e.printStackTrace(writer)
         }
       }
       // SPARK-5983 ensure TRACE is not supported

--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -80,7 +80,7 @@ private[spark] object JettyUtils extends Logging {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage)
           case e: Exception =>
             logWarning(s"GET ${request.getRequestURI} failed: $e", e)
-            throw e;
+            throw e
         }
       }
       // SPARK-5983 ensure TRACE is not supported

--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -80,12 +80,7 @@ private[spark] object JettyUtils extends Logging {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage)
           case e: Exception =>
             logWarning(s"GET ${request.getRequestURI} failed: $e", e)
-            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR)
-            response.setContentType("text/plain;charset=utf-8")
-            response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate")
-            val writer = response.getWriter
-            writer.println(e.toString)
-            e.printStackTrace(writer)
+            throw e;
         }
       }
       // SPARK-5983 ensure TRACE is not supported
@@ -225,6 +220,9 @@ private[spark] object JettyUtils extends Logging {
       val pool = new QueuedThreadPool
       pool.setDaemon(true)
       server.setThreadPool(pool)
+      val errorHandler = new ErrorHandler();
+      errorHandler.setShowStacks(true);
+      server.addBean(errorHandler);
       server.setHandler(collection)
       try {
         server.start()

--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -79,7 +79,7 @@ private[spark] object JettyUtils extends Logging {
           case e: IllegalArgumentException =>
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage)
           case e: Exception =>
-            logWarn(s"GET ${request.getRequestURI} failed: $e", e)
+            logWarning(s"GET ${request.getRequestURI} failed: $e", e)
             response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR)
             response.setContentType("text/plain;charset=utf-8")
             response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate")


### PR DESCRIPTION
Patch for SPARK-7508

This logs @ warn then generates a response which include the message body and stack trace as text/plain, no-cache. The exit code is 500.

In practise (in some tests in SPARK-1537 to be precise), jetty is getting in between this servlet and the web response the user sees —the body of the response is lost for any error response (500, even 404 and bad request). The standard Jetty handlers must be getting in the way. 

This patch doesn't address that, it ensures that 
1. if the jetty handlers were put to one side the users would see the errors
2. at least the exceptions appear in the server-side logs. 

This is better to users saying "I saw a 500 error" and you not having anything in the logs to see what went wrong.
