### PR TITLE
[SPARK-7516] [Minor] [DOC] Replace depreciated inferSchema() with createDataFrame()

### DIFF
--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -470,7 +470,7 @@ parts = lines.map(lambda l: l.split(","))
 people = parts.map(lambda p: Row(name=p[0], age=int(p[1])))
 
 # Infer the schema, and register the DataFrame as a table.
-schemaPeople = sqlContext.inferSchema(people)
+schemaPeople = sqlContext.createDataFrame(people)
 schemaPeople.registerTempTable("people")
 
 # SQL can be run over DataFrames that have been registered as a table.


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-7516

In sql-programming-guide, deprecated python data frame api inferSchema() should be replaced by createDataFrame():

schemaPeople = sqlContext.inferSchema(people) -> 
schemaPeople = sqlContext.createDataFrame(people)
