### PR TITLE
[SPARK-7110] [CORE] when use saveAsNewAPIHadoopFile, sometimes it throws "Delegation Token can be issued only with kerberos or web authentication"

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
@@ -997,7 +997,9 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
   def saveAsNewAPIHadoopDataset(conf: Configuration): Unit = self.withScope {
     // Rename this as hadoopConf internally to avoid shadowing (see SPARK-2038).
     val hadoopConf = conf
-    val job = new NewAPIHadoopJob(hadoopConf)
+    val jobConf = new JobConf(hadoopConf)
+    SparkHadoopUtil.get.addCredentials(jobConf)
+    val job = new NewAPIHadoopJob(jobConf)
     val formatter = new SimpleDateFormat("yyyyMMddHHmm")
     val jobtrackerID = formatter.format(new Date())
     val stageId = self.id


### PR DESCRIPTION
Call `addCredentials` in `saveAsNewAPIHadoopDataset` too to propagate credential for new-API calls.

@tgravescs -- to your comment, `new NewAPIHadoopJob(hadoopConf)` does merge the credentials but I don't see they were set in `hadoopConf` before? or did I miss your point entirely? 
