### PR TITLE
[MINOR] Avoid passing the PermGenSize option to IBM JVMs.

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -121,7 +121,10 @@ abstract class AbstractCommandBuilder {
    * set it.
    */
   void addPermGenSizeOpt(List<String> cmd) {
-    // Don't set MaxPermSize for Java 8 and later.
+    // Don't set MaxPermSize for IBM Java, or Oracle Java 8 and later.
+    if (getJavaVendor() == JavaVendor.IBM) {
+      return;
+    }
     String[] version = System.getProperty("java.version").split("\\.");
     if (Integer.parseInt(version[0]) > 1 || Integer.parseInt(version[1]) > 7) {
       return;

--- a/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
@@ -32,6 +32,11 @@ class CommandBuilderUtils {
   static final String ENV_SPARK_HOME = "SPARK_HOME";
   static final String ENV_SPARK_ASSEMBLY = "_SPARK_ASSEMBLY";
 
+  /** The set of known JVM vendors. */
+  static enum JavaVendor {
+    Oracle, IBM, OpenJDK, Unknown
+  };
+
   /** Returns whether the given string is null or empty. */
   static boolean isEmpty(String s) {
     return s == null || s.isEmpty();
@@ -106,6 +111,23 @@ class CommandBuilderUtils {
   static boolean isWindows() {
     String os = System.getProperty("os.name");
     return os.startsWith("Windows");
+  }
+
+  /**  Returns an enum value indicating whose JVM is being used. */
+  static JavaVendor getJavaVendor() {
+    String vendorString = System.getProperty("java.vendor");
+    if (vendorString.contains("Oracle")) {
+      return JavaVendor.Oracle;
+    } else {
+      if (vendorString.contains("IBM")) {
+        return JavaVendor.IBM;
+      } else {
+        if (vendorString.contains("OpenJDK")) {
+          return JavaVendor.OpenJDK;
+        }
+      }
+    }
+    return JavaVendor.Unknown;
   }
 
   /**

--- a/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
@@ -113,22 +113,20 @@ class CommandBuilderUtils {
     return os.startsWith("Windows");
   }
 
-  /**  Returns an enum value indicating whose JVM is being used. */
-  static JavaVendor getJavaVendor() {
-    String vendorString = System.getProperty("java.vendor");
-    if (vendorString.contains("Oracle")) {
-      return JavaVendor.Oracle;
-    } else {
-      if (vendorString.contains("IBM")) {
-        return JavaVendor.IBM;
-      } else {
-        if (vendorString.contains("OpenJDK")) {
-          return JavaVendor.OpenJDK;
-        }
-      }
-    }
-    return JavaVendor.Unknown;
-  }
+	/** Returns an enum value indicating whose JVM is being used. */
+	static JavaVendor getJavaVendor() {
+		String vendorString = System.getProperty("java.vendor");
+		if (vendorString.contains("Oracle")) {
+			return JavaVendor.Oracle;
+		}
+		if (vendorString.contains("IBM")) {
+			return JavaVendor.IBM;
+		}
+		if (vendorString.contains("OpenJDK")) {
+			return JavaVendor.OpenJDK;
+		}
+		return JavaVendor.Unknown;
+	}
 
   /**
    * Updates the user environment, appending the given pathList to the existing value of the given

--- a/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/CommandBuilderUtils.java
@@ -113,20 +113,20 @@ class CommandBuilderUtils {
     return os.startsWith("Windows");
   }
 
-	/** Returns an enum value indicating whose JVM is being used. */
-	static JavaVendor getJavaVendor() {
-		String vendorString = System.getProperty("java.vendor");
-		if (vendorString.contains("Oracle")) {
-			return JavaVendor.Oracle;
-		}
-		if (vendorString.contains("IBM")) {
-			return JavaVendor.IBM;
-		}
-		if (vendorString.contains("OpenJDK")) {
-			return JavaVendor.OpenJDK;
-		}
-		return JavaVendor.Unknown;
-	}
+  /** Returns an enum value indicating whose JVM is being used. */
+  static JavaVendor getJavaVendor() {
+    String vendorString = System.getProperty("java.vendor");
+    if (vendorString.contains("Oracle")) {
+      return JavaVendor.Oracle;
+    }
+    if (vendorString.contains("IBM")) {
+      return JavaVendor.IBM;
+    }
+    if (vendorString.contains("OpenJDK")) {
+      return JavaVendor.OpenJDK;
+    }
+    return JavaVendor.Unknown;
+  }
 
   /**
    * Updates the user environment, appending the given pathList to the existing value of the given


### PR DESCRIPTION
IBM's Java VM doesn't have the concept of a permgen, so this option shouldn't be passed when the vendor property shows it is an IBM JDK.
