### PR TITLE
[SPARK-7278] [PySpark] DateType should find datetime.datetime acceptable

### DIFF
--- a/python/pyspark/sql/_types.py
+++ b/python/pyspark/sql/_types.py
@@ -930,7 +930,7 @@ _acceptable_types = {
     DecimalType: (decimal.Decimal,),
     StringType: (str, unicode),
     BinaryType: (bytearray,),
-    DateType: (datetime.date,),
+    DateType: (datetime.date, datetime.datetime),
     TimestampType: (datetime.datetime,),
     ArrayType: (list, tuple, array),
     MapType: (dict,),


### PR DESCRIPTION
The DateType from `sql/_types.py` should not be restricted to `datetime.date`, but accept `datetime.datetime` objects as well. Could someone with a little more insight verify this?
