### PR TITLE
SPARK-7355 FlakyTest - o.a.s.DriverSuite

### DIFF
--- a/core/src/test/scala/org/apache/spark/DriverSuite.scala
+++ b/core/src/test/scala/org/apache/spark/DriverSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.util.Utils
 
 class DriverSuite extends FunSuite with Timeouts {
 
-  ignore("driver should exit after finishing without cleanup (SPARK-530)") {
+  test("driver should exit after finishing without cleanup (SPARK-530)") {
     val sparkHome = sys.props.getOrElse("spark.test.home", fail("spark.test.home is not set!"))
     val masters = Table("master", "local", "local-cluster[2,1,512]")
     forAll(masters) { (master: String) =>


### PR DESCRIPTION
The test passed locally:
{code}
^[[32mDriverSuite:^[[0m
^[[32m- driver should exit after finishing without cleanup (SPARK-530)^[[0m
^[[36mRun completed in 32 seconds, 350 milliseconds.^[[0m
^[[36mTotal number of tests run: 1^[[0m
^[[36mSuites: completed 2, aborted 0^[[0m
^[[36mTests: succeeded 1, failed 0, canceled 0, ignored 0, pending 0^[[0m
^[[32mAll tests passed.^[[0m
{code}
