### PR TITLE
[SPARK-7553] [STREAMING] Added methods to maintain a singleton StreamingContext

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -638,8 +638,10 @@ class StreamingContext private[streaming] (
  */
 
 object StreamingContext extends Logging {
+
   /**
-   * Lock that guards access to global variables that track active StreamingContext.
+   * Lock that guards activation of a StreamingContext as well as access to the singleton active
+   * StreamingContext in getOrCreate().
    */
   private val ACTIVATION_LOCK = new Object()
 
@@ -662,12 +664,66 @@ object StreamingContext extends Logging {
     }
   }
 
+  /**
+   * Get the context that is currently active, that is, started but not stopped.
+   */
+  @Experimental
+  def getActive(): Option[StreamingContext] = {
+    ACTIVATION_LOCK.synchronized {
+      Option(activeContext.get())
+    }
+  }
+
   @deprecated("Replaced by implicit functions in the DStream companion object. This is " +
     "kept here only for backward compatibility.", "1.3.0")
   def toPairDStreamFunctions[K, V](stream: DStream[(K, V)])
       (implicit kt: ClassTag[K], vt: ClassTag[V], ord: Ordering[K] = null)
     : PairDStreamFunctions[K, V] = {
     DStream.toPairDStreamFunctions(stream)(kt, vt, ord)
+  }
+
+  /**
+   * Either return the "active" StreamingContext (that is, started but not stopped), or create a
+   * new StreamingContext that is
+   * @param creatingFunc   Function to create a new StreamingContext
+   */
+  @Experimental
+  def getActiveOrCreate(creatingFunc: () => StreamingContext): StreamingContext = {
+    ACTIVATION_LOCK.synchronized {
+      getActive().getOrElse {
+        creatingFunc()
+      }
+    }
+  }
+
+  /**
+   * Either get the currently active StreamingContext (that is, started but not stopped),
+   * OR recreate a StreamingContext from checkpoint data in the given path. If checkpoint data
+   * does not exist in the provided, then create a new StreamingContext by calling the provided
+   * `creatingFunc`.
+   *
+   * @param checkpointPath Checkpoint directory used in an earlier StreamingContext program
+   * @param creatingFunc   Function to create a new StreamingContext
+   * @param hadoopConf     Optional Hadoop configuration if necessary for reading from the
+   *                       file system
+   * @param createOnError  Optional, whether to create a new StreamingContext if there is an
+   *                       error in reading checkpoint data. By default, an exception will be
+   *                       thrown on error.
+   */
+  @Experimental
+  def getActiveOrCreate(
+      checkpointPath: String,
+      creatingFunc: () => StreamingContext,
+      hadoopConf: Configuration = new Configuration(),
+      createOnError: Boolean = false
+    ): StreamingContext = {
+    ACTIVATION_LOCK.synchronized {
+      getActive().getOrElse {
+        val checkpointOption = CheckpointReader.read(
+          checkpointPath, new SparkConf(), hadoopConf, createOnError)
+        checkpointOption.map(new StreamingContext(null, _, null)).getOrElse(creatingFunc())
+      }
+    }
   }
 
   /**
@@ -694,7 +750,6 @@ object StreamingContext extends Logging {
       checkpointPath, new SparkConf(), hadoopConf, createOnError)
     checkpointOption.map(new StreamingContext(null, _, null)).getOrElse(creatingFunc())
   }
-
 
   /**
    * Either recreate a StreamingContext from checkpoint data or create a new StreamingContext.
@@ -762,7 +817,7 @@ object StreamingContext extends Logging {
     ): SparkContext = {
     val conf = SparkContext.updatedConf(
       new SparkConf(), master, appName, sparkHome, jars, environment)
-    createNewSparkContext(conf)
+    new SparkContext(conf)
   }
 
   private[streaming] def rddToFileName[T](prefix: String, suffix: String, time: Time): String = {

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -664,6 +664,8 @@ object StreamingContext extends Logging {
   }
 
   /**
+   * :: Experimental ::
+   *
    * Get the currently active context, if there is one. Active means started but not stopped.
    */
   @Experimental
@@ -682,6 +684,8 @@ object StreamingContext extends Logging {
   }
 
   /**
+   * :: Experimental ::
+   *
    * Either return the "active" StreamingContext (that is, started but not stopped), or create a
    * new StreamingContext that is
    * @param creatingFunc   Function to create a new StreamingContext
@@ -694,6 +698,8 @@ object StreamingContext extends Logging {
   }
 
   /**
+   * :: Experimental ::
+   *
    * Either get the currently active StreamingContext (that is, started but not stopped),
    * OR recreate a StreamingContext from checkpoint data in the given path. If checkpoint data
    * does not exist in the provided, then create a new StreamingContext by calling the provided

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -690,9 +690,7 @@ object StreamingContext extends Logging {
   @Experimental
   def getActiveOrCreate(creatingFunc: () => StreamingContext): StreamingContext = {
     ACTIVATION_LOCK.synchronized {
-      getActive().getOrElse {
-        creatingFunc()
-      }
+      getActive().getOrElse { creatingFunc() }
     }
   }
 
@@ -718,11 +716,7 @@ object StreamingContext extends Logging {
       createOnError: Boolean = false
     ): StreamingContext = {
     ACTIVATION_LOCK.synchronized {
-      getActive().getOrElse {
-        val checkpointOption = CheckpointReader.read(
-          checkpointPath, new SparkConf(), hadoopConf, createOnError)
-        checkpointOption.map(new StreamingContext(null, _, null)).getOrElse(creatingFunc())
-      }
+      getActive().getOrElse { getOrCreate(checkpointPath, creatingFunc, hadoopConf, createOnError) }
     }
   }
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -640,7 +640,7 @@ object StreamingContext extends Logging {
 
   /**
    * Lock that guards activation of a StreamingContext as well as access to the singleton active
-   * StreamingContext in getOrCreate().
+   * StreamingContext in getActiveOrCreate().
    */
   private val ACTIVATION_LOCK = new Object()
 
@@ -664,7 +664,7 @@ object StreamingContext extends Logging {
   }
 
   /**
-   * Get the context that is currently active, that is, started but not stopped.
+   * Get the currently active context, if there is one. Active means started but not stopped.
    */
   @Experimental
   def getActive(): Option[StreamingContext] = {

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -533,9 +533,8 @@ class StreamingContextSuite extends FunSuite with BeforeAndAfter with Timeouts w
       assert(StreamingContext.getActiveOrCreate(creatingFunc _) === ssc,
         "active context not returned")
       ssc.stop()
-      assert(StreamingContext.getActive().nonEmpty,
+      assert(StreamingContext.getActive().isEmpty,
         "inactive context returned")
-      newContextCreated = false
       assert(StreamingContext.getActiveOrCreate(creatingFunc _) !== ssc,
         "inactive context returned")
     }
@@ -543,7 +542,7 @@ class StreamingContextSuite extends FunSuite with BeforeAndAfter with Timeouts w
     // getOrCreate and getActive should return independently created context after activating
     testGetActiveOrCreate {
       ssc = creatingFunc()  // Create
-      assert(ssc.state === ssc.StreamingContextState.Initialized)
+      assert(ssc.getState() === StreamingContextState.INITIALIZED)
       assert(StreamingContext.getActive().isEmpty,
         "new initialized context returned before starting")
       ssc.start()

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -610,7 +610,8 @@ class StreamingContextSuite extends FunSuite with BeforeAndAfter with Timeouts w
         corruptedCheckpointPath, creatingFunction _, createOnError = false)
     }
 
-    // getActiveOrCreate should create new context with fake checkpoint file and createOnError = true
+    // getActiveOrCreate should create new context with fake
+    // checkpoint file and createOnError = true
     testGetActiveOrCreate {
       ssc = StreamingContext.getActiveOrCreate(
         corruptedCheckpointPath, creatingFunction _, createOnError = true)


### PR DESCRIPTION
In a REPL/notebook environment, its very easy to lose a reference to a StreamingContext by overriding the variable name. So if you happen to execute the following commands

```
val ssc = new StreamingContext(...) // cmd 1
ssc.start() // cmd 2
...
val ssc = new StreamingContext(...) // accidentally run cmd 1 again
```

The value of ssc will be overwritten. Now you can neither start the new context (as only one context can be started), nor stop the previous context (as the reference is lost).
Hence its best to maintain a singleton reference to the active context, so that we never loose reference for the active context.
Since this problem occurs useful in REPL environments, its best to add this as an Experimental support in the Scala API only so that it can be used in Scala REPLs and notebooks.
