### PR TITLE
[SPARK-2018] [CORE] Upgrade LZF library to fix endian serialization p…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -481,7 +481,7 @@
       <dependency>
         <groupId>com.ning</groupId>
         <artifactId>compress-lzf</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.3</version>
       </dependency>
       <dependency>
         <groupId>org.xerial.snappy</groupId>


### PR DESCRIPTION
…roblem

Pick up newer version of dependency with fix for SPARK-2018.  The update involved patching the ning/compress LZF library to handle big endian systems correctly.

Credit goes to @gireeshpunathil for diagnosing the problem, and @cowtowncoder for fixing it.

Spark tests run clean for me.
