### PR TITLE
[SPARK-7592] Always set resolution to "Fixed" in PR merge script.

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -265,8 +265,11 @@ def resolve_jira_issue(merge_branches, comment, default_jira_id=""):
     jira_fix_versions = map(lambda v: get_version_json(v), fix_versions)
 
     resolve = filter(lambda a: a['name'] == "Resolve Issue", asf_jira.transitions(jira_id))[0]
+    resolution = filter(lambda r: r.raw['name'] == "Fixed", asf_jira.resolutions())[0]
+    custom_fields = {'resolution': {'id': resolution.raw['id']}}
     asf_jira.transition_issue(
-        jira_id, resolve["id"], fixVersions=jira_fix_versions, comment=comment)
+        jira_id, resolve["id"], fixVersions = jira_fix_versions, 
+        comment = comment, fields = custom_fields)
 
     print "Successfully resolved %s with fixVersions=%s!" % (jira_id, fix_versions)
 


### PR DESCRIPTION
The issue is that the behavior of the ASF JIRA silently
changed. Now when the "Resolve Issue" transition occurs,
the default resolution is "Pending Closed". We used to
count on the default behavior being to set the
resolution as "Fixed".

The solution is to explicitly set the resolution as "Fixed" and not
count on default behavior.
