### PR TITLE
[SPARK-7659] [SQL] Sort by attributes that are not present in the select clause when there is windowexpression analyze error 

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -394,7 +394,8 @@ class Analyzer(
           if !s.resolved && child.resolved && resolvedExceptWindowExpressions(projectList) =>
         val windowAttributes =
           projectList.filter(e => hasWindowExpression(e)).map(_.toAttribute).toSet
-        val (resolvedOrdering, missing) = resolveAndFindMissing(ordering, windowAttributes, p, child)
+        val (resolvedOrdering, missing) =
+          resolveAndFindMissing(ordering, windowAttributes, p, child)
 
         // If this rule was not a no-op, return the transformed plan, otherwise return the original.
         if (missing.nonEmpty) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -387,21 +387,14 @@ class Analyzer(
    */
   object ResolveSortReferences extends Rule[LogicalPlan] {
 
-    private def hasWindowExpression(expr: NamedExpression): Boolean = {
-      expr.find {
-        case window: WindowExpression => true
-        case _ => false
-      }.isDefined
-    }
-
-    private def resolvedExceptWindowExpressions(exprs: Seq[NamedExpression]): Boolean = {
-      exprs.filter(e => !hasWindowExpression(e)).forall(_.resolved)
-    }
-
+    // Ignore window expressions so that this rule is valid
+    // when there are window function in select clause.
     def apply(plan: LogicalPlan): LogicalPlan = plan transformUp {
       case s @ Sort(ordering, global, p @ Project(projectList, child))
           if !s.resolved && child.resolved && resolvedExceptWindowExpressions(projectList) =>
-        val (resolvedOrdering, missing) = resolveAndFindMissing(ordering, p, child)
+        val windowAttributes =
+          projectList.filter(e => hasWindowExpression(e)).map(_.toAttribute).toSet
+        val (resolvedOrdering, missing) = resolveAndFindMissing(ordering, windowAttributes, p, child)
 
         // If this rule was not a no-op, return the transformed plan, otherwise return the original.
         if (missing.nonEmpty) {
@@ -415,14 +408,15 @@ class Analyzer(
         }
       case s @ Sort(ordering, global, a @ Aggregate(grouping, aggs, child))
           if !s.resolved && child.resolved && resolvedExceptWindowExpressions(aggs) =>
-        val unresolved = ordering.flatMap(_.collect { case UnresolvedAttribute(name) => name })
+        val windowAttributes = aggs.filter(e => hasWindowExpression(e)).map(_.toAttribute).toSet
         // A small hack to create an object that will allow us to resolve any references that
         // refer to named expressions that are present in the grouping expressions.
         val groupingRelation = LocalRelation(
           grouping.collect { case ne: NamedExpression => ne.toAttribute }
         )
 
-        val (resolvedOrdering, missing) = resolveAndFindMissing(ordering, a, groupingRelation)
+        val (resolvedOrdering, missing) =
+          resolveAndFindMissing(ordering, windowAttributes, a, groupingRelation)
 
         if (missing.nonEmpty) {
           // Add missing grouping exprs and then project them away after the sort.
@@ -434,6 +428,18 @@ class Analyzer(
         }
     }
 
+    private def hasWindowExpression(expr: NamedExpression): Boolean = {
+      expr.find {
+        case window: WindowExpression => true
+        case _ => false
+      }.isDefined
+    }
+
+    // check resolved ignore window expressions
+    private def resolvedExceptWindowExpressions(exprs: Seq[NamedExpression]): Boolean = {
+      exprs.filter(e => !hasWindowExpression(e)).forall(_.resolved)
+    }
+
     /**
      * Given a child and a grandchild that are present beneath a sort operator, returns
      * a resolved sort ordering and a list of attributes that are missing from the child
@@ -441,11 +447,17 @@ class Analyzer(
      */
     def resolveAndFindMissing(
         ordering: Seq[SortOrder],
+        windowAttributes: Set[Attribute],
         child: LogicalPlan,
         grandchild: LogicalPlan): (Seq[SortOrder], Seq[Attribute]) = {
-      // Find any attributes that remain unresolved in the sort.
+      // Find any attributes that remain unresolved in the sort, ignore window attribute here
       val unresolved: Seq[Seq[String]] =
-        ordering.flatMap(_.collect { case UnresolvedAttribute(nameParts) => nameParts })
+        ordering
+          .flatMap(
+            _.collect {
+              case u @ UnresolvedAttribute(nameParts) if !windowAttributes.contains(u) => nameParts
+            }
+          )
 
       // Create a map from name, to resolved attributes, when the desired name can be found
       // prior to the projection.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicOperators.scala
@@ -32,7 +32,7 @@ case class Project(projectList: Seq[NamedExpression], child: LogicalPlan) extend
       }.nonEmpty
     )
 
-    !expressions.exists(!_.resolved) && childrenResolved && !hasSpecialExpressions
+    expressions.forall(_.resolved) && childrenResolved && !hasSpecialExpressions
   }
 }
 
@@ -198,7 +198,7 @@ case class Aggregate(
       }.nonEmpty
     )
 
-    !expressions.exists(!_.resolved) && childrenResolved && !hasWindowExpressions
+    expressions.forall(_.resolved) && childrenResolved && !hasWindowExpressions
   }
 
   override def output: Seq[Attribute] = aggregateExpressions.map(_.toAttribute)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -684,6 +684,8 @@ class SQLQuerySuite extends QueryTest {
         ("c", 10, 10d/17),
         ("c", 9, 9d/17)
       ).map(i => Row(i._1, i._2, i._3)))
+
+    dropTempTable("windowData")
   }
 
   test("window function: partition and order expressions") {
@@ -727,6 +729,8 @@ class SQLQuerySuite extends QueryTest {
         (5, "c", 9, 9),
         (6, "c", 10, 10)
       ).map(i => Row(i._1, i._2, i._3, i._4)))
+
+    dropTempTable("windowData")
   }
 
   test("window function: expressions in arguments of a window functions") {
@@ -755,6 +759,43 @@ class SQLQuerySuite extends QueryTest {
         (5, "c", 1, 5),
         (6, "c", 0, 6)
       ).map(i => Row(i._1, i._2, i._3, i._4)))
+
+    dropTempTable("windowData")
+  }
+
+  test("window function: sort by attributes that are not present in the SELECT clause") {
+    val data = Seq(
+      WindowData(1, "a", 5),
+      WindowData(3, "b", 7),
+      WindowData(5, "c", 9)
+    )
+    sparkContext.parallelize(data).toDF().registerTempTable("windowData")
+    checkAnswer(
+      sql(
+        """
+          |select month,
+          |sum(product) over (partition by month)
+          |from windowData order by area
+        """.stripMargin),
+      Seq(
+        (1, 5),
+        (3, 7),
+        (5, 9)
+      ).map(i => Row(i._1, i._2)))
+
+    checkAnswer(
+      sql(
+        """
+          |select month,
+          |sum(sum(product)) over (partition by month)
+          |from windowData group by area, month order by area
+        """.stripMargin),
+      Seq(
+        (1, 5),
+        (3, 7),
+        (5, 9)
+      ).map(i => Row(i._1, i._2)))
+    dropTempTable("windowData")
   }
 
   test("test case key when") {


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/SPARK-7659

If there are `WindowExpression` in select clause, sorting by attributes that are not present in the child analyze failure. such as

```
select month,
sum(product) over (partition by month)
from windowData order by area
```

/cc @yhuai
