### PR TITLE
[SPARK-6649] [SQL] Made double quotes denote identifiers

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/AbstractSparkSQLParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/AbstractSparkSQLParser.scala
@@ -109,7 +109,7 @@ class SqlLexical extends StdLexical {
     | '\'' ~> chrExcept('\'', '\n', EofCh).* <~ '\'' ^^
       { case chars => StringLit(chars mkString "") }
     | '"' ~> chrExcept('"', '\n', EofCh).* <~ '"' ^^
-      { case chars => StringLit(chars mkString "") }
+      { case chars => Identifier(chars mkString "") }
     | '`' ~> chrExcept('`', '\n', EofCh).* <~ '`' ^^
       { case chars => Identifier(chars mkString "") }
     | EofCh ^^^ EOF

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -500,7 +500,7 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll {
 
   test("date row") {
     checkAnswer(sql(
-      """select cast("2015-01-28" as date) from testData limit 1"""),
+      """select cast('2015-01-28' as date) from testData limit 1"""),
       Row(java.sql.Date.valueOf("2015-01-28"))
     )
   }
@@ -1316,5 +1316,18 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll {
       .registerTempTable("t")
 
     checkAnswer(sql("SELECT a.`c.b`, `b.$q`[0].`a@!.q`, `q.w`.`w.i&`[0] FROM t"), Row(1, 1, 1))
+  }
+
+  test("SPARK-6649: DataFrame created through SQLContext.jdbc() failed if columns table must be quoted") {
+    jsonRDD(sparkContext.makeRDD(
+         """{"SELECT": "hello world", "WHERE": true, "AND": true }""" :: Nil))
+      .registerTempTable("FROM")
+
+    checkAnswer(sql(
+      """
+        SELECT "SELECT" AS "AS"
+        FROM "FROM" "FROM"
+        WHERE "WHERE" AND "AND"
+      """), Row("hello world"))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/TableScanSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/TableScanSuite.scala
@@ -350,7 +350,7 @@ class TableScanSuite extends DataSourceTest {
   test("SPARK-5196 schema field with comment") {
     sql(
       """
-       |CREATE TEMPORARY TABLE student(name string comment "SN", age int comment "SA", grade int)
+       |CREATE TEMPORARY TABLE student(name string comment 'SN', age int comment 'SA', grade int)
        |USING org.apache.spark.sql.sources.AllDataTypesScanSource
        |OPTIONS (
        |  from '1',


### PR DESCRIPTION
Jira link: https://issues.apache.org/jira/browse/SPARK-6649

After this change, the Spark SQL parser treats anything enclosed in
double quotes as an identifier (not a string), as described in the SQL
standard. The parser also treats backpacks (`) the same way as double
quotes.

Modified two test cases that used double quotes to delimit string
literals and added a new test case for the new behavior.
