### PR TITLE
[SPARK-7689] Deprecate spark.cleaner.ttl

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -478,7 +478,12 @@ private[spark] object SparkConf extends Logging {
       DeprecatedConfig("spark.kryoserializer.buffer.mb", "1.4",
         "Please use spark.kryoserializer.buffer instead. The default value for " +
           "spark.kryoserializer.buffer.mb was previously specified as '0.064'. Fractional values " +
-          "are no longer accepted. To specify the equivalent now, one may use '64k'.")
+          "are no longer accepted. To specify the equivalent now, one may use '64k'."),
+      DeprecatedConfig("spark.cleaner.ttl", "1.4",
+        "TTL-based metadata cleaning is no longer necessary in recent Spark versions " +
+        "and can lead to confusing errors if metadata is deleted for entities that are still in " +
+        "use. Except in extremely special circumstances, you should remove this setting and rely " +
+        "on Spark's reference-tracking-based cleanup instead. See SPARK-7689 for more details.")
     )
     
     Map(configs.map { cfg => (cfg.key -> cfg) }:_*)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -723,17 +723,6 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
-  <td><code>spark.cleaner.ttl</code></td>
-  <td>(infinite)</td>
-  <td>
-    Duration (seconds) of how long Spark will remember any metadata (stages generated, tasks
-    generated, etc.). Periodic cleanups will ensure that metadata older than this duration will be
-    forgotten. This is useful for running Spark for many hours / days (for example, running 24/7 in
-    case of Spark Streaming applications). Note that any RDD that persists in memory for more than
-    this duration will be cleared as well.
-  </td>
-</tr>
-<tr>
   <td><code>spark.executor.cores</code></td>
   <td>1 in YARN mode, all the available cores on the worker in standalone mode.</td>
   <td>


### PR DESCRIPTION
With the introduction of `ContextCleaner` (in #126), I think there's no longer any reason for users to enable the MetadataCleaner / `spark.cleaner.ttl`.  This patch removes the last remaining documentation for `spark.cleaner.ttl` and logs a deprecation warning if it is used.

I think that this configuration used to be relevant for Spark Streaming jobs, but I think that's no longer the case since the latest Streaming docs have removed all mentions of `spark.cleaner.ttl` (see https://github.com/apache/spark/pull/4956/files#diff-dbee746abf610b52d8a7cb65bf9ea765L1817, for example).  The TTL-based cleaning is not safe and may prematurely clean resources that are still being used, leading to confusing errors (such as https://issues.apache.org/jira/browse/SPARK-5594), so it generally should not be enabled (see http://apache-spark-user-list.1001560.n3.nabble.com/is-spark-cleaner-ttl-safe-td2557.html for an old, related discussion).

The only use-case that I can think of is super-long-lived Spark REPLs where you're worried about orphaning RDDs or broadcast variables in your REPL history and having them never get cleaned up, but I don't know that anyone uses `spark.cleaner.ttl` for this in practice.
