### PR TITLE
[SPARK-7663][MLlib] Add requirement for word2vec model

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/Word2Vec.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/Word2Vec.scala
@@ -158,6 +158,9 @@ class Word2Vec extends Serializable with Logging {
       .sortWith((a, b) => a.cn > b.cn)
     
     vocabSize = vocab.length
+    require(vocabSize > 0, "The vocabulary size should be large than 0. You may need to check " +
+      "the setting of minCount, which could be large enough to remove all your words in sentences.")
+
     var a = 0
     while (a < vocabSize) {
       vocabHash += vocab(a).word -> a
@@ -409,9 +412,6 @@ class Word2Vec extends Serializable with Logging {
       word2VecMap += word -> vector
       i += 1
     }
-
-    require(word2VecMap.size > 0, "The word2vec map should not be empty. You may need to check " +
-      "the setting of minCount, which could be large enough to remove all your words in sentences.")
 
     new Word2VecModel(word2VecMap.toMap)
   }

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/Word2Vec.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/Word2Vec.scala
@@ -410,6 +410,9 @@ class Word2Vec extends Serializable with Logging {
       i += 1
     }
 
+    require(word2VecMap.size > 0, "The word2vec map should not be empty. You may need to check " +
+      "the setting of minCount, which could be large enough to remove all your words in sentences.")
+
     new Word2VecModel(word2VecMap.toMap)
   }
 


### PR DESCRIPTION
JIRA issue [link](https://issues.apache.org/jira/browse/SPARK-7663).

We should check the model size of word2vec, to prevent the unexpected empty.

CC @srowen.
