### PR TITLE
[SPARK-6416] [DOCS] RDD.fold() requires the operator to be commutative

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/java/JavaRDDLike.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaRDDLike.scala
@@ -386,9 +386,16 @@ trait JavaRDDLike[T, This <: JavaRDDLike[T, This]] extends Serializable {
 
   /**
    * Aggregate the elements of each partition, and then the results for all the partitions, using a
-   * given associative function and a neutral "zero value". The function op(t1, t2) is allowed to
-   * modify t1 and return it as its result value to avoid object allocation; however, it should not
-   * modify t2.
+   * given associative and commutative function and a neutral "zero value". The function
+   * op(t1, t2) is allowed to modify t1 and return it as its result value to avoid object
+   * allocation; however, it should not modify t2.
+   *
+   * This behaves somewhat differently from fold operations implemented for non-distributed
+   * collections in functional languages like Scala. This fold operation may be applied to
+   * partitions individually, and then fold those results into the final result, rather than
+   * apply the fold to each element sequentially in some defined ordering. For functions
+   * that are not commutative, the result may differ from that of a fold applied to a
+   * non-distributed collection.
    */
   def fold(zeroValue: T)(f: JFunction2[T, T, T]): T =
     rdd.fold(zeroValue)(f)

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1015,9 +1015,16 @@ abstract class RDD[T: ClassTag](
 
   /**
    * Aggregate the elements of each partition, and then the results for all the partitions, using a
-   * given associative function and a neutral "zero value". The function op(t1, t2) is allowed to
-   * modify t1 and return it as its result value to avoid object allocation; however, it should not
-   * modify t2.
+   * given associative and commutative function and a neutral "zero value". The function
+   * op(t1, t2) is allowed to modify t1 and return it as its result value to avoid object
+   * allocation; however, it should not modify t2.
+   *
+   * This behaves somewhat differently from fold operations implemented for non-distributed
+   * collections in functional languages like Scala. This fold operation may be applied to
+   * partitions individually, and then fold those results into the final result, rather than
+   * apply the fold to each element sequentially in some defined ordering. For functions
+   * that are not commutative, the result may differ from that of a fold applied to a
+   * non-distributed collection.
    */
   def fold(zeroValue: T)(op: (T, T) => T): T = withScope {
     // Clone the zero value since we will also be serializing it as part of tasks

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -820,6 +820,14 @@ class RDD(object):
         as its result value to avoid object allocation; however, it should not
         modify C{t2}.
 
+        Currently, this implementation only works correctly if the fold operation
+        is commutative -- if op(a,b) == op(b,a) for any a and b. For example,
+        sc.parallelize(...).fold(0,lambda a,b:a+1) should return the count of
+        elements in the RDD, but currently does not work as intended. However,
+        sc.parallelize(...).fold(0,lambda a,b:a+b) works as intended to return
+        the sum of elements. In effect, it acts like a reduce operation with a
+        default value. See SPARK-6416.
+
         >>> from operator import add
         >>> sc.parallelize([1, 2, 3, 4, 5]).fold(0, add)
         15

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -813,20 +813,20 @@ class RDD(object):
     def fold(self, zeroValue, op):
         """
         Aggregate the elements of each partition, and then the results for all
-        the partitions, using a given associative function and a neutral "zero
-        value."
+        the partitions, using a given associative and commutative function and
+        a neutral "zero value."
 
         The function C{op(t1, t2)} is allowed to modify C{t1} and return it
         as its result value to avoid object allocation; however, it should not
         modify C{t2}.
 
-        Currently, this implementation only works correctly if the fold operation
-        is commutative -- if op(a,b) == op(b,a) for any a and b. For example,
-        sc.parallelize(...).fold(0,lambda a,b:a+1) should return the count of
-        elements in the RDD, but currently does not work as intended. However,
-        sc.parallelize(...).fold(0,lambda a,b:a+b) works as intended to return
-        the sum of elements. In effect, it acts like a reduce operation with a
-        default value. See SPARK-6416.
+        This behaves somewhat differently from fold operations implemented
+        for non-distributed collections in functional languages like Scala.
+        This fold operation may be applied to partitions individually, and then
+        fold those results into the final result, rather than apply the fold
+        to each element sequentially in some defined ordering. For functions
+        that are not commutative, the result may differ from that of a fold
+        applied to a non-distributed collection.
 
         >>> from operator import add
         >>> sc.parallelize([1, 2, 3, 4, 5]).fold(0, add)


### PR DESCRIPTION
Document current limitation of rdd.fold.

This does not resolve SPARK-6416 but just documents the issue.
CC @JoshRosen 
