### PR TITLE
[SPARK-7704] Updating Programming Guides per SPARK-4397

### DIFF
--- a/docs/programming-guide.md
+++ b/docs/programming-guide.md
@@ -48,7 +48,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.SparkConf
 {% endhighlight %}
 
-(Before Spark 1.3.0, you need to explicitly import `import org.apache.spark.SparkContext._` to enable essential implicit conversions.)
+(Before Spark 1.3.0, you need to explicitly `import org.apache.spark.SparkContext._` to enable essential implicit conversions.)
 
 </div>
 

--- a/docs/programming-guide.md
+++ b/docs/programming-guide.md
@@ -41,11 +41,10 @@ In addition, if you wish to access an HDFS cluster, you need to add a dependency
     artifactId = hadoop-client
     version = <your-hdfs-version>
 
-Finally, you need to import some Spark classes and implicit conversions into your program. Add the following lines:
+Finally, you need to import some Spark classes into your program. Add the following lines:
 
 {% highlight scala %}
 import org.apache.spark.SparkContext
-import org.apache.spark.SparkContext._
 import org.apache.spark.SparkConf
 {% endhighlight %}
 
@@ -821,9 +820,7 @@ by a key.
 
 In Scala, these operations are automatically available on RDDs containing
 [Tuple2](http://www.scala-lang.org/api/{{site.SCALA_VERSION}}/index.html#scala.Tuple2) objects
-(the built-in tuples in the language, created by simply writing `(a, b)`), as long as you
-import `org.apache.spark.SparkContext._` in your program to enable Spark's implicit
-conversions. The key-value pair operations are available in the
+(the built-in tuples in the language, created by simply writing `(a, b)`). The key-value pair operations are available in the
 [PairRDDFunctions](api/scala/index.html#org.apache.spark.rdd.PairRDDFunctions) class,
 which automatically wraps around an RDD of tuples if you import the conversions.
 

--- a/docs/programming-guide.md
+++ b/docs/programming-guide.md
@@ -48,7 +48,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.SparkConf
 {% endhighlight %}
 
-(If the Spark version is prior to 1.3.0, user needs to explicitly import org.apache.spark.SparkContext._ to allow the implicit conversions.)
+(Before Spark 1.3.0, you need to explicitly import `import org.apache.spark.SparkContext._` to enable essential implicit conversions.)
 
 </div>
 

--- a/docs/programming-guide.md
+++ b/docs/programming-guide.md
@@ -48,6 +48,8 @@ import org.apache.spark.SparkContext
 import org.apache.spark.SparkConf
 {% endhighlight %}
 
+(If the Spark version is prior to 1.3.0, user needs to explicitly import org.apache.spark.SparkContext._ to allow the implicit conversions.)
+
 </div>
 
 <div data-lang="java"  markdown="1">


### PR DESCRIPTION
The change per SPARK-4397 makes implicit objects in SparkContext to be found by the compiler automatically. So that we don't need to import the o.a.s.SparkContext._ explicitly any more and can remove some statements around the "implicit conversions" from the latest Programming Guides (1.3.0 and higher)
