### PR TITLE
[minor] [sql] Partial revert of e683182c3e.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/JavaTypeInference.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/JavaTypeInference.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.catalyst
+package org.apache.spark.sql
 
 import java.beans.Introspector
 import java.lang.{Iterable => JIterable}


### PR DESCRIPTION
Moving this file to a different module breaks the maven build; because it
exposes a Guava type in an API used from a different module, unit tests
that end up calling into this code will fail because Guava is shaded in
the maven build.
