### PR TITLE
Fix compilation error due to buildScan() being final

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -481,7 +481,7 @@ abstract class HadoopFsRelation private[sql](maybePartitionSpec: Option[Partitio
     })
   }
 
-  private[sources] final def buildScan(
+  private[sources] def buildScan(
       requiredColumns: Array[String],
       filters: Array[Filter],
       inputPaths: Array[String]): RDD[Row] = {


### PR DESCRIPTION
This PR fixes the following compilation error:

[error] /home/jenkins/workspace/Spark-Master-Maven-with-YARN/HADOOP_PROFILE/hadoop-2.4/label/centos/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcRelation.scala:174: overriding method buildScan in class HadoopFsRelation of type (requiredColumns: Array[String], filters: Array[org.apache.spark.sql.sources.Filter], inputPaths: Array[String])org.apache.spark.rdd.RDD[org.apache.spark.sql.catalyst.expressions.Row];
[error]  method buildScan cannot override final member
[error]   override def buildScan(requiredColumns: Array[String],
