### PR TITLE
[SPARK-7716] [UI] Stage page hangs with many tasks

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -210,9 +210,15 @@ private[spark] object JettyUtils extends Logging {
       conf: SparkConf,
       serverName: String = ""): ServerInfo = {
 
-    val collection = new ContextHandlerCollection
-    collection.setHandlers(handlers.toArray)
     addFilters(handlers, conf)
+
+    val collection = new ContextHandlerCollection
+    val gzipHandlers = handlers.map { h =>
+      val gzipHandler = new GzipHandler
+      gzipHandler.setHandler(h)
+      gzipHandler
+    }
+    collection.setHandlers(gzipHandlers.toArray)
 
     // Bind to the given port, or throw a java.net.BindException if the port is occupied
     def connect(currentPort: Int): (Server, Int) = {


### PR DESCRIPTION
When you view the stage page while running the following:

```
sc.parallelize(1 to X, 10000).count()
```

The page never loads, the job is stalled, and you end up running into an OOM:

```
HTTP ERROR 500

Problem accessing /stages/stage/. Reason:

    Server Error
Caused by:

java.lang.OutOfMemoryError: Java heap space
    at java.util.Arrays.copyOf(Arrays.java:2367)
    at java.lang.AbstractStringBuilder.expandCapacity(AbstractStringBuilder.java:130)
    at 
```

This patch compresses Jetty responses in gzip. The correct long-term fix is to add pagination.
