### PR TITLE
[SPARK-7735] [pyspark] Raise Exception on non-zero exit from pipe commands

### DIFF
--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -704,7 +704,11 @@ class RDD(object):
                     out.write(s.encode('utf-8'))
                 out.close()
             Thread(target=pipe_objs, args=[pipe.stdin]).start()
-            return (x.rstrip(b'\n').decode('utf-8') for x in iter(pipe.stdout.readline, b''))
+            result = (x.rstrip(b'\n').decode('utf-8') for x in iter(pipe.stdout.readline, b''))
+            pipe.wait()
+            if pipe.returncode:
+                raise Exception("Pipe function `%s' exited with error code %d" %(command, pipe.returncode) )
+            return result
         return self.mapPartitions(func)
 
     def foreach(self, f):

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -707,7 +707,7 @@ class RDD(object):
             result = (x.rstrip(b'\n').decode('utf-8') for x in iter(pipe.stdout.readline, b''))
             pipe.wait()
             if pipe.returncode:
-                raise Exception("Pipe function `%s' exited"
+                raise Exception("Pipe function `%s' exited "
                                 "with error code %d" %(command, pipe.returncode))
             return result
         return self.mapPartitions(func)

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -707,7 +707,7 @@ class RDD(object):
             result = (x.rstrip(b'\n').decode('utf-8') for x in iter(pipe.stdout.readline, b''))
             pipe.wait()
             if pipe.returncode:
-                raise Exception("Pipe function `%s' exited with error code %d" %(command, pipe.returncode) )
+                raise Exception("Pipe function `%s' exited with error code %d" %(command, pipe.returncode))
             return result
         return self.mapPartitions(func)
 

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -707,7 +707,8 @@ class RDD(object):
             result = (x.rstrip(b'\n').decode('utf-8') for x in iter(pipe.stdout.readline, b''))
             pipe.wait()
             if pipe.returncode:
-                raise Exception("Pipe function `%s' exited with error code %d" %(command, pipe.returncode))
+                raise Exception("Pipe function `%s' exited"
+                                "with error code %d" %(command, pipe.returncode))
             return result
         return self.mapPartitions(func)
 

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -708,7 +708,7 @@ class RDD(object):
             pipe.wait()
             if pipe.returncode:
                 raise Exception("Pipe function `%s' exited "
-                                "with error code %d" %(command, pipe.returncode))
+                                "with error code %d" % (command, pipe.returncode))
             return result
         return self.mapPartitions(func)
 

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -693,7 +693,7 @@ class RDD(object):
 
         >>> sc.parallelize(['1', '2', '', '3']).pipe('cat').collect()
         [u'1', u'2', u'', u'3']
-        
+
         :param checkCode: whether or not to check the return value of the shell command.
         """
 

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -687,13 +687,25 @@ class RDD(object):
         return self.map(lambda x: (f(x), x)).groupByKey(numPartitions)
 
     @ignore_unicode_prefix
-    def pipe(self, command, env={}):
+    def pipe(self, command, env={}, mode='permissive'):
         """
         Return an RDD created by piping elements to a forked external process.
 
         >>> sc.parallelize(['1', '2', '', '3']).pipe('cat').collect()
         [u'1', u'2', u'', u'3']
         """
+        if mode == 'permissive':
+            def fail_condition(x):
+                return False
+        elif mode == 'strict':
+            def fail_condition(x):
+                return x == 0
+        elif mode == 'grep':
+            def fail_condition(x):
+                return x == 0 or x == 1
+        else:
+            raise ValueError("mode must be one of 'permissive', 'strict' or 'grep'.")
+
         def func(iterator):
             pipe = Popen(
                 shlex.split(command), env=env, stdin=PIPE, stdout=PIPE)
@@ -707,7 +719,7 @@ class RDD(object):
 
             def check_return_code():
                 pipe.wait()
-                if pipe.returncode:
+                if fail_condition(pipe.returncode):
                     raise Exception("Pipe function `%s' exited "
                                     "with error code %d" % (command, pipe.returncode))
                 else:

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -696,7 +696,6 @@ class RDD(object):
 
         :param checkCode: whether or not to check the return value of the shell command.
         """
-
         def func(iterator):
             pipe = Popen(
                 shlex.split(command), env=env, stdin=PIPE, stdout=PIPE)

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -711,9 +711,10 @@ class RDD(object):
                     raise Exception("Pipe function `%s' exited "
                                     "with error code %d" % (command, pipe.returncode))
                 else:
-                    yield None
+                    for i in range(0):
+                        yield i
             return (x.rstrip(b'\n').decode('utf-8') for x in
-                    chain(iter(pipe.stdout.readline, b''), iter(check_return_code, None)))
+                    chain(iter(pipe.stdout.readline, b''), check_return_code()))
         return self.mapPartitions(func)
 
     def foreach(self, f):

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -704,15 +704,16 @@ class RDD(object):
                     out.write(s.encode('utf-8'))
                 out.close()
             Thread(target=pipe_objs, args=[pipe.stdin]).start()
+
             def check_return_code():
                 pipe.wait()
                 if pipe.returncode:
                     raise Exception("Pipe function `%s' exited "
-                       "with error code %d" % (command, pipe.returncode))
+                                    "with error code %d" % (command, pipe.returncode))
                 else:
                     return None
             return (x.rstrip(b'\n').decode('utf-8') for x in
-                      chain(iter(pipe.stdout.readline, b''), iter(check_return_code, None)))
+                    chain(iter(pipe.stdout.readline, b''), iter(check_return_code, None)))
         return self.mapPartitions(func)
 
     def foreach(self, f):

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -711,7 +711,7 @@ class RDD(object):
                     raise Exception("Pipe function `%s' exited "
                                     "with error code %d" % (command, pipe.returncode))
                 else:
-                    return None
+                    yield None
             return (x.rstrip(b'\n').decode('utf-8') for x in
                     chain(iter(pipe.stdout.readline, b''), iter(check_return_code, None)))
         return self.mapPartitions(func)

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -699,10 +699,10 @@ class RDD(object):
                 return False
         elif mode == 'strict':
             def fail_condition(x):
-                return x == 0
+                return x != 0
         elif mode == 'grep':
             def fail_condition(x):
-                return x == 0 or x == 1
+                return x != 0 and x != 1
         else:
             raise ValueError("mode must be one of 'permissive', 'strict' or 'grep'.")
 

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -704,12 +704,15 @@ class RDD(object):
                     out.write(s.encode('utf-8'))
                 out.close()
             Thread(target=pipe_objs, args=[pipe.stdin]).start()
-            result = (x.rstrip(b'\n').decode('utf-8') for x in iter(pipe.stdout.readline, b''))
-            pipe.wait()
-            if pipe.returncode:
-                raise Exception("Pipe function `%s' exited "
-                                "with error code %d" % (command, pipe.returncode))
-            return result
+            def check_return_code():
+                pipe.wait()
+                if pipe.returncode:
+                    raise Exception("Pipe function `%s' exited "
+                       "with error code %d" % (command, pipe.returncode))
+                else:
+                    return None
+            return (x.rstrip(b'\n').decode('utf-8') for x in
+                      chain(iter(pipe.stdout.readline, b''), iter(check_return_code, None)))
         return self.mapPartitions(func)
 
     def foreach(self, f):

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -873,6 +873,13 @@ class RDDTests(ReusedPySparkTestCase):
             sizes = sort.glom().map(len).collect()
             for size in sizes:
                 self.assertGreater(size, 0)
+               
+    def test_pipe_functions(self):
+        data = ['1','2','3']
+        rdd = self.sc.parallelize(data)
+        self.assertRaises(Exception, rdd.pipe('cc').collect())
+        result = rdd.pipe('cat').collect().sort()
+        [self.assertEqual(x, y) for x, y in zip(data, result)]
 
 
 class ProfilerTests(PySparkTestCase):

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -875,7 +875,7 @@ class RDDTests(ReusedPySparkTestCase):
                 self.assertGreater(size, 0)
                
     def test_pipe_functions(self):
-        data = ['1','2','3']
+        data = ['1', '2', '3']
         rdd = self.sc.parallelize(data)
         self.assertRaises(Exception, rdd.pipe('cc').collect())
         result = rdd.pipe('cat').collect().sort()

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -878,10 +878,14 @@ class RDDTests(ReusedPySparkTestCase):
         data = ['1', '2', '3']
         rdd = self.sc.parallelize(data)
         with QuietTest(self.sc):
-            self.assertRaises(Py4JJavaError, rdd.pipe('cc').collect)
+            self.assertEqual([], rdd.pipe('cc').collect())
+            self.assertRaises(Py4JJavaError, rdd.pipe('cc', mode='strict').collect)
         result = rdd.pipe('cat').collect()
         result.sort()
         [self.assertEqual(x, y) for x, y in zip(data, result)]
+        self.assertRaises(Py4JJavaError, rdd.pipe('grep 4', mode='strict').collect)
+        self.assertEqual([], rdd.pipe('grep 4').collect())
+        self.assertEqual([], rdd.pipe('grep 4', mode='grep').collect())
 
 
 class ProfilerTests(PySparkTestCase):

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -879,13 +879,12 @@ class RDDTests(ReusedPySparkTestCase):
         rdd = self.sc.parallelize(data)
         with QuietTest(self.sc):
             self.assertEqual([], rdd.pipe('cc').collect())
-            self.assertRaises(Py4JJavaError, rdd.pipe('cc', mode='strict').collect)
+            self.assertRaises(Py4JJavaError, rdd.pipe('cc', checkCode=True).collect)
         result = rdd.pipe('cat').collect()
         result.sort()
         [self.assertEqual(x, y) for x, y in zip(data, result)]
-        self.assertRaises(Py4JJavaError, rdd.pipe('grep 4', mode='strict').collect)
+        self.assertRaises(Py4JJavaError, rdd.pipe('grep 4', checkCode=True).collect)
         self.assertEqual([], rdd.pipe('grep 4').collect())
-        self.assertEqual([], rdd.pipe('grep 4', mode='grep').collect())
 
 
 class ProfilerTests(PySparkTestCase):

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -873,7 +873,7 @@ class RDDTests(ReusedPySparkTestCase):
             sizes = sort.glom().map(len).collect()
             for size in sizes:
                 self.assertGreater(size, 0)
-               
+
     def test_pipe_functions(self):
         data = ['1', '2', '3']
         rdd = self.sc.parallelize(data)

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -877,7 +877,8 @@ class RDDTests(ReusedPySparkTestCase):
     def test_pipe_functions(self):
         data = ['1', '2', '3']
         rdd = self.sc.parallelize(data)
-        self.assertRaises(Exception, rdd.pipe('cc').collect())
+        with QuietTest(self.sc):
+            self.assertRaises(Exception, rdd.pipe('cc').collect())
         result = rdd.pipe('cat').collect().sort()
         [self.assertEqual(x, y) for x, y in zip(data, result)]
 

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -879,7 +879,8 @@ class RDDTests(ReusedPySparkTestCase):
         rdd = self.sc.parallelize(data)
         with QuietTest(self.sc):
             self.assertRaises(Py4JJavaError, rdd.pipe('cc').collect)
-        result = rdd.pipe('cat').collect().sort()
+        result = rdd.pipe('cat').collect()
+        result.sort()
         [self.assertEqual(x, y) for x, y in zip(data, result)]
 
 

--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -878,7 +878,7 @@ class RDDTests(ReusedPySparkTestCase):
         data = ['1', '2', '3']
         rdd = self.sc.parallelize(data)
         with QuietTest(self.sc):
-            self.assertRaises(Exception, rdd.pipe('cc').collect())
+            self.assertRaises(Py4JJavaError, rdd.pipe('cc').collect)
         result = rdd.pipe('cat').collect().sort()
         [self.assertEqual(x, y) for x, y in zip(data, result)]
 


### PR DESCRIPTION
This will allow problems with piped commands to be detected.
This will also allow tasks to be retried where errors are rare (such as network problems in piped commands).
