### PR TITLE
[SPARK-7734][DataFrame] support struct type in Explode

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -558,7 +558,10 @@ class Analyzer(
         }
     }
 
-    /** Extracts a resolved [[Generator]] expression and any names assigned by aliases to their output. */
+    /**
+     * Extracts a resolved [[Generator]] expression and any names assigned by aliases
+     * to their output.
+     */
     private object AliasedResolvedGenerator {
       def unapply(e: Expression): Option[(Generator, Seq[String])] = e match {
         case Alias(g: Generator, name) if g.childrenResolved &&

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -366,7 +366,7 @@ object functions {
   /**
    * Creates a new row for each element in the given array or map column.
    */
-   def explode(e: Column): Column = Explode(e.expr)
+  def explode(e: Column): Column = Explode(e.expr)
 
   /**
    * Converts a string exprsesion to lower case.

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -132,6 +132,18 @@ class DataFrameSuite extends QueryTest {
     )
   }
 
+  test("struct type explode") {
+    val df1 = complexData.select(explode('s))
+    assert(df1.schema.map(_.name) === Seq("key", "value"))
+    assert(df1.schema.map(_.dataType) === Seq(IntegerType, StringType))
+    checkAnswer(df1, Row(1, "1") :: Row(2, "2") :: Nil)
+
+    val df2 = complexData.select(explode('s).as(Seq("i", "s")))
+    assert(df2.schema.map(_.name) === Seq("i", "s"))
+    assert(df2.schema.map(_.dataType) === Seq(IntegerType, StringType))
+    checkAnswer(df2, Row(1, "1") :: Row(2, "2") :: Nil)
+  }
+
   test("selectExpr") {
     checkAnswer(
       testData.selectExpr("abs(key)", "value"),


### PR DESCRIPTION
It's easier to write `df.select(explode(df("s")))` than `df.select(df("s")("field1"), df("s")("field2"))`.
