### PR TITLE
[SQL] [TEST] udf_java_method failed due to jdk version

### DIFF
--- a/sql/hive/compatibility/src/test/scala/org/apache/spark/sql/hive/execution/HiveCompatibilitySuite.scala
+++ b/sql/hive/compatibility/src/test/scala/org/apache/spark/sql/hive/execution/HiveCompatibilitySuite.scala
@@ -250,7 +250,10 @@ class HiveCompatibilitySuite extends HiveQueryFileTest with BeforeAndAfter {
 
     // The isolated classloader seemed to make some of our test reset mechanisms less robust.
     "combine1", // This test changes compression settings in a way that breaks all subsequent tests.
-    "load_dyn_part14.*" // These work alone but fail when run with other tests...
+    "load_dyn_part14.*", // These work alone but fail when run with other tests...
+
+    // the answer is sensitive for jdk version
+    "udf_java_method"
   ) ++ HiveShim.compatibilityBlackList
 
   /**

--- a/sql/hive/compatibility/src/test/scala/org/apache/spark/sql/hive/execution/HiveCompatibilitySuite.scala
+++ b/sql/hive/compatibility/src/test/scala/org/apache/spark/sql/hive/execution/HiveCompatibilitySuite.scala
@@ -877,7 +877,6 @@ class HiveCompatibilitySuite extends HiveQueryFileTest with BeforeAndAfter {
     "udf_int",
     "udf_isnotnull",
     "udf_isnull",
-    "udf_java_method",
     "udf_lcase",
     "udf_length",
     "udf_lessthan",

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -20,12 +20,9 @@ package org.apache.spark.sql.hive.execution
 import java.io.File
 import java.util.{Locale, TimeZone}
 
-import org.apache.hadoop.hive.ql.udf.generic.GenericUDTF
-import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory
-import org.apache.hadoop.hive.serde2.objectinspector.{ObjectInspectorFactory, StructObjectInspector, ObjectInspector}
-import org.scalatest.BeforeAndAfter
-
 import scala.util.Try
+
+import org.scalatest.BeforeAndAfter
 
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars
 
@@ -289,29 +286,6 @@ class HiveQuerySuite extends HiveComparisonTest with BeforeAndAfter {
     val res = sql("SELECT 2 / 1, 1 / 2, 1 / 3, 1 / COUNT(*) FROM src LIMIT 1").collect().head
     Seq(2.0, 0.5, 0.3333333333333333, 0.002).zip(res.toSeq).foreach( x =>
       assert(x._1 == x._2.asInstanceOf[Double]))
-  }
-
-  // `Math.exp(1.0)` has different result for different jdk version, so not use createQueryTest
-  test("udf_java_method") {
-    val res = sql(
-      """
-        |SELECT java_method("java.lang.String", "valueOf", 1),
-        |       java_method("java.lang.String", "isEmpty"),
-        |       java_method("java.lang.Math", "max", 2, 3),
-        |       java_method("java.lang.Math", "min", 2, 3),
-        |       java_method("java.lang.Math", "round", 2.5),
-        |       java_method("java.lang.Math", "exp", 1.0),
-        |       java_method("java.lang.Math", "floor", 1.9)
-        |FROM src tablesample (1 rows)
-      """.stripMargin).collect().head
-    Seq(
-      "1",
-      "true",
-      java.lang.Math.max(2, 3).toString,
-      java.lang.Math.min(2, 3).toString,
-      java.lang.Math.round(2.5).toString,
-      java.lang.Math.exp(1.0).toString,
-      java.lang.Math.floor(1.9).toString).zip(res.toSeq).foreach(x => assert(x._1 == x._2))
   }
 
   createQueryTest("modulus",

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -291,6 +291,29 @@ class HiveQuerySuite extends HiveComparisonTest with BeforeAndAfter {
       assert(x._1 == x._2.asInstanceOf[Double]))
   }
 
+  // `Math.exp(1.0)` has different result for different jdk version, so not use createQueryTest
+  test("udf_java_method") {
+    val res = sql(
+      """
+        |SELECT java_method("java.lang.String", "valueOf", 1),
+        |       java_method("java.lang.String", "isEmpty"),
+        |       java_method("java.lang.Math", "max", 2, 3),
+        |       java_method("java.lang.Math", "min", 2, 3),
+        |       java_method("java.lang.Math", "round", 2.5),
+        |       java_method("java.lang.Math", "exp", 1.0),
+        |       java_method("java.lang.Math", "floor", 1.9)
+        |FROM src tablesample (1 rows)
+      """.stripMargin).collect().head
+    Seq(
+      "1",
+      true,
+      java.lang.Math.max(2, 3),
+      java.lang.Math.min(2, 3),
+      java.lang.Math.round(2.5),
+      java.lang.Math.exp(1.0),
+      java.lang.Math.floor(1.9)).zip(res.toSeq).foreach( x => assert(x._1 == x._2))
+  }
+
   createQueryTest("modulus",
     "SELECT 11 % 10, IF((101.1 % 100.0) BETWEEN 1.01 AND 1.11, \"true\", \"false\"), " +
       "(101 / 2) % 10 FROM src LIMIT 1")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -306,12 +306,12 @@ class HiveQuerySuite extends HiveComparisonTest with BeforeAndAfter {
       """.stripMargin).collect().head
     Seq(
       "1",
-      true,
-      java.lang.Math.max(2, 3),
-      java.lang.Math.min(2, 3),
-      java.lang.Math.round(2.5),
-      java.lang.Math.exp(1.0),
-      java.lang.Math.floor(1.9)).zip(res.toSeq).foreach( x => assert(x._1 == x._2))
+      "true",
+      java.lang.Math.max(2, 3).toString,
+      java.lang.Math.min(2, 3).toString,
+      java.lang.Math.round(2.5).toString,
+      java.lang.Math.exp(1.0).toString,
+      java.lang.Math.floor(1.9).toString).zip(res.toSeq).foreach( x => assert(x._1 == x._2))
   }
 
   createQueryTest("modulus",

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -311,7 +311,7 @@ class HiveQuerySuite extends HiveComparisonTest with BeforeAndAfter {
       java.lang.Math.min(2, 3).toString,
       java.lang.Math.round(2.5).toString,
       java.lang.Math.exp(1.0).toString,
-      java.lang.Math.floor(1.9).toString).zip(res.toSeq).foreach( x => assert(x._1 == x._2))
+      java.lang.Math.floor(1.9).toString).zip(res.toSeq).foreach(x => assert(x._1 == x._2))
   }
 
   createQueryTest("modulus",

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -791,4 +791,27 @@ class SQLQuerySuite extends QueryTest {
       sql("SELECT cast(key+2 as Int) from df_analysis A group by cast(key+1 as int)")
     }
   }
+
+  // `Math.exp(1.0)` has different result for different jdk version, so not use createQueryTest
+  test("udf_java_method") {
+    checkAnswer(sql(
+      """
+        |SELECT java_method("java.lang.String", "valueOf", 1),
+        |       java_method("java.lang.String", "isEmpty"),
+        |       java_method("java.lang.Math", "max", 2, 3),
+        |       java_method("java.lang.Math", "min", 2, 3),
+        |       java_method("java.lang.Math", "round", 2.5),
+        |       java_method("java.lang.Math", "exp", 1.0),
+        |       java_method("java.lang.Math", "floor", 1.9)
+        |FROM src tablesample (1 rows)
+      """.stripMargin),
+      Row(
+        "1",
+        "true",
+        java.lang.Math.max(2, 3).toString,
+        java.lang.Math.min(2, 3).toString,
+        java.lang.Math.round(2.5).toString,
+        java.lang.Math.exp(1.0).toString,
+        java.lang.Math.floor(1.9).toString))
+  }
 }


### PR DESCRIPTION
java.lang.Math.exp(1.0) has different result between jdk versions. so do not use createQueryTest, write a separate test for it.

```
jdk version     result 
1.7.0_11        2.7182818284590455  
1.7.0_05        2.7182818284590455
1.7.0_71        2.718281828459045
```
