### PR TITLE
[SPARK-7775] YARN AM negative sleep exception

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -346,6 +346,9 @@ private[spark] class ApplicationMaster(
                 val currentAllocationInterval =
                   math.min(heartbeatInterval, nextAllocationInterval)
                 nextAllocationInterval *= 2
+                // avoid overflow
+                nextAllocationInterval = math.min(
+                  nextAllocationInterval, ApplicationMaster.MAX_RM_HEARTBEAT_INTERVAL_MS)
                 currentAllocationInterval
               } else {
                 nextAllocationInterval = initialAllocationInterval
@@ -576,6 +579,9 @@ object ApplicationMaster extends Logging {
   private val EXIT_SC_NOT_INITED = 13
   private val EXIT_SECURITY = 14
   private val EXIT_EXCEPTION_USER_CLASS = 15
+
+  // cap on heartbeat interval between us and the resource manager
+  private val MAX_RM_HEARTBEAT_INTERVAL_MS = 10000
 
   private var master: ApplicationMaster = _
 

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -345,10 +345,7 @@ private[spark] class ApplicationMaster(
               if (numPendingAllocate > 0) {
                 val currentAllocationInterval =
                   math.min(heartbeatInterval, nextAllocationInterval)
-                nextAllocationInterval *= 2
-                // avoid overflow
-                nextAllocationInterval = math.min(
-                  nextAllocationInterval, ApplicationMaster.MAX_RM_HEARTBEAT_INTERVAL_MS)
+                nextAllocationInterval = currentAllocationInterval * 2 // avoid overflow
                 currentAllocationInterval
               } else {
                 nextAllocationInterval = initialAllocationInterval
@@ -579,9 +576,6 @@ object ApplicationMaster extends Logging {
   private val EXIT_SC_NOT_INITED = 13
   private val EXIT_SECURITY = 14
   private val EXIT_EXCEPTION_USER_CLASS = 15
-
-  // cap on heartbeat interval between us and the resource manager
-  private val MAX_RM_HEARTBEAT_INTERVAL_MS = 10000
 
   private var master: ApplicationMaster = _
 


### PR DESCRIPTION
```
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.impl.Log4jLoggerFactory]
Exception in thread "Reporter" java.lang.IllegalArgumentException: timeout value is negative
  at java.lang.Thread.sleep(Native Method)
  at org.apache.spark.deploy.yarn.ApplicationMaster$$anon$1.run(ApplicationMaster.scala:356)
```

This kills the reporter thread. This is caused by #6082 (merged into master branch only).
