### PR TITLE
[SPARK-7777][Streaming] Fix the flaky test in org.apache.spark.streaming.BasicOperationsSuite

### DIFF
--- a/streaming/src/test/scala/org/apache/spark/streaming/BasicOperationsSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/BasicOperationsSuite.scala
@@ -557,6 +557,9 @@ class BasicOperationsSuite extends TestSuiteBase {
     withTestServer(new TestServer()) { testServer =>
       withStreamingContext(new StreamingContext(conf, batchDuration)) { ssc =>
         testServer.start()
+
+        val batchCounter = new BatchCounter(ssc)
+
         // Set up the streaming context and input streams
         val networkStream =
           ssc.socketTextStream("localhost", testServer.port, StorageLevel.MEMORY_AND_DISK)
@@ -587,7 +590,11 @@ class BasicOperationsSuite extends TestSuiteBase {
         for (i <- 0 until input.size) {
           testServer.send(input(i).toString + "\n")
           Thread.sleep(200)
+          val numCompletedBatches = batchCounter.getNumCompletedBatches
           clock.advance(batchDuration.milliseconds)
+          if (!batchCounter.waitUntilBatchesCompleted(numCompletedBatches + 1, 5000)) {
+            fail("A batch cannot complete in 5 seconds")
+          }
           collectRddInfo()
         }
 

--- a/streaming/src/test/scala/org/apache/spark/streaming/BasicOperationsSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/BasicOperationsSuite.scala
@@ -593,7 +593,7 @@ class BasicOperationsSuite extends TestSuiteBase {
           val numCompletedBatches = batchCounter.getNumCompletedBatches
           clock.advance(batchDuration.milliseconds)
           if (!batchCounter.waitUntilBatchesCompleted(numCompletedBatches + 1, 5000)) {
-            fail("A batch cannot complete in 5 seconds")
+            fail("Batch took more than 5 seconds to complete")
           }
           collectRddInfo()
         }


### PR DESCRIPTION
Just added a guard to make sure a batch has completed before moving to the next batch.
