### PR TITLE
[SPARK-7810] [pyspark] solve python rdd socket connection problem

### DIFF
--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -121,14 +121,21 @@ def _parse_memory(s):
 
 
 def _load_from_socket(port, serializer):
-    sock = socket.socket()
-    sock.settimeout(3)
-    try:
-        sock.connect(("localhost", port))
+    sock = None
+    for res in socket.getaddrinfo("localhost", port, socket.AF_UNSPEC, socket.SOCK_STREAM):
+        af, socktype, proto, canonname, sa = res
+        try:
+            sock = socket.socket(af, socktype, proto)
+            sock.settimeout(3)
+            sock.connect(sa)
+        except socket.error:
+            sock = None
+            continue
+        break
+    if sock:
         rf = sock.makefile("rb", 65536)
         for item in serializer.load_stream(rf):
             yield item
-    finally:
         sock.close()
 
 

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -134,17 +134,14 @@ def _load_from_socket(port, serializer):
             sock = None
             continue
         break
-    if sock:
-        try:
-            rf = sock.makefile("rb", 65536)
-            for item in serializer.load_stream(rf):
-                yield item
-        except socket.error:
-            raise Exception("encounter error when connecting to socket server")
-        finally:
-            sock.close()
-    else:
+    if not sock:
         raise Exception("could not open socket")
+    try:
+        rf = sock.makefile("rb", 65536)
+        for item in serializer.load_stream(rf):
+            yield item
+    finally:
+        sock.close()
 
 
 def ignore_unicode_prefix(f):


### PR DESCRIPTION
Method "_load_from_socket" in rdd.py cannot load data from jvm socket when ipv6 is used. The current method only works well with ipv4. New modification should work around both two protocols.
