### PR TITLE
[SPARK-7221] [Streaming] Expose the current processed file name of FileInputDStream to the users

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -400,6 +400,17 @@ class StreamingContext private[streaming] (
     new FileInputDStream[K, V, F](this, directory, filter, newFilesOnly, Option(conf))
   }
 
+  /** Private variable to display the filenames being processesd */
+  private[streaming] var display_filename : Boolean = false
+
+  /**
+   * Function sets the display_filename parameter
+   * @param flag paramater to which display_filename will be set
+   */
+  def display_filename_enable(flag: Boolean){
+    display_filename = flag
+  }
+  
   /**
    * Create a input stream that monitors a Hadoop-compatible filesystem
    * for new files and reads them as text files (using key as LongWritable, value


### PR DESCRIPTION
@akhilthatipamula

Introduced a parameter called display_filename in StreamingContext which if true displays the filenames being processed otherwise the file names will not be displayed.

I affirm that the contribution is my original work and I license the work to the project under the project's open source license.
