### PR TITLE
[SPARK-7826][CORE] Suppress extra calling getCacheLocs.

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -383,8 +383,7 @@ class DAGScheduler(
     parents
   }
 
-  private[scheduler]
-  def getMissingParentStages(stage: Stage): List[Stage] = {
+  private def getMissingParentStages(stage: Stage): List[Stage] = {
     val missing = new HashSet[Stage]
     val visited = new HashSet[RDD[_]]
     // We are manually maintaining a stack here to prevent StackOverflowError

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -377,7 +377,8 @@ class DAGScheduler(
     parents
   }
 
-  private def getMissingParentStages(stage: Stage): List[Stage] = {
+  private[scheduler]
+  def getMissingParentStages(stage: Stage): List[Stage] = {
     val missing = new HashSet[Stage]
     val visited = new HashSet[RDD[_]]
     // We are manually maintaining a stack here to prevent StackOverflowError

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -386,13 +386,15 @@ class DAGScheduler(
     def visit(rdd: RDD[_]) {
       if (!visited(rdd)) {
         visited += rdd
-        if (getCacheLocs(rdd).contains(Nil)) {
+        if (rdd.dependencies.size < 2 || getCacheLocs(rdd).contains(Nil)) {
           for (dep <- rdd.dependencies) {
             dep match {
               case shufDep: ShuffleDependency[_, _, _] =>
-                val mapStage = getShuffleMapStage(shufDep, stage.jobId)
-                if (!mapStage.isAvailable) {
-                  missing += mapStage
+                if (getCacheLocs(rdd).contains(Nil)) {
+                  val mapStage = getShuffleMapStage(shufDep, stage.jobId)
+                  if (!mapStage.isAvailable) {
+                    missing += mapStage
+                  }
                 }
               case narrowDep: NarrowDependency[_] =>
                 waitingForVisit.push(narrowDep.rdd)

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -192,8 +192,9 @@ class DAGScheduler(
   private[scheduler]
   def getCacheLocs(rdd: RDD[_]): Seq[Seq[TaskLocation]] = cacheLocs.synchronized {
     // Note: if the storage level is NONE, we don't need to get locations from block manager.
-    if (rdd.getStorageLevel == StorageLevel.NONE)
+    if (rdd.getStorageLevel == StorageLevel.NONE) {
       return Seq.fill(rdd.partitions.size)(Nil)
+    }
 
     // Note: this doesn't use `getOrElse()` because this method is called O(num tasks) times
     if (!cacheLocs.contains(rdd.id)) {

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -191,6 +191,10 @@ class DAGScheduler(
 
   private[scheduler]
   def getCacheLocs(rdd: RDD[_]): Seq[Seq[TaskLocation]] = cacheLocs.synchronized {
+    // Note: if the storage level is NONE, we don't need to get locations from block manager.
+    if (rdd.getStorageLevel == StorageLevel.NONE)
+      return Seq.fill(rdd.partitions.size)(Nil)
+
     // Note: this doesn't use `getOrElse()` because this method is called O(num tasks) times
     if (!cacheLocs.contains(rdd.id)) {
       val blockIds = rdd.partitions.indices.map(index => RDDBlockId(rdd.id, index)).toArray[BlockId]

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -387,15 +387,13 @@ class DAGScheduler(
     def visit(rdd: RDD[_]) {
       if (!visited(rdd)) {
         visited += rdd
-        if (rdd.dependencies.size < 2 || getCacheLocs(rdd).contains(Nil)) {
+        if (getCacheLocs(rdd).contains(Nil)) {
           for (dep <- rdd.dependencies) {
             dep match {
               case shufDep: ShuffleDependency[_, _, _] =>
-                if (getCacheLocs(rdd).contains(Nil)) {
-                  val mapStage = getShuffleMapStage(shufDep, stage.jobId)
-                  if (!mapStage.isAvailable) {
-                    missing += mapStage
-                  }
+                val mapStage = getShuffleMapStage(shufDep, stage.jobId)
+                if (!mapStage.isAvailable) {
+                  missing += mapStage
                 }
               case narrowDep: NarrowDependency[_] =>
                 waitingForVisit.push(narrowDep.rdd)

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -391,7 +391,8 @@ class DAGScheduler(
     def visit(rdd: RDD[_]) {
       if (!visited(rdd)) {
         visited += rdd
-        if (getCacheLocs(rdd).contains(Nil)) {
+        val rddHasUncachedPartitions = getCacheLocs(rdd).contains(Nil)
+        if (rddHasUncachedPartitions) {
           for (dep <- rdd.dependencies) {
             dep match {
               case shufDep: ShuffleDependency[_, _, _] =>

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -191,16 +191,17 @@ class DAGScheduler(
 
   private[scheduler]
   def getCacheLocs(rdd: RDD[_]): Seq[Seq[TaskLocation]] = cacheLocs.synchronized {
-    // Note: if the storage level is NONE, we don't need to get locations from block manager.
-    if (rdd.getStorageLevel == StorageLevel.NONE) {
-      return Seq.fill(rdd.partitions.size)(Nil)
-    }
-
     // Note: this doesn't use `getOrElse()` because this method is called O(num tasks) times
     if (!cacheLocs.contains(rdd.id)) {
-      val blockIds = rdd.partitions.indices.map(index => RDDBlockId(rdd.id, index)).toArray[BlockId]
-      val locs: Seq[Seq[TaskLocation]] = blockManagerMaster.getLocations(blockIds).map { bms =>
-        bms.map(bm => TaskLocation(bm.host, bm.executorId))
+      // Note: if the storage level is NONE, we don't need to get locations from block manager.
+      val locs: Seq[Seq[TaskLocation]] = if (rdd.getStorageLevel == StorageLevel.NONE) {
+        Seq.fill(rdd.partitions.size)(Nil)
+      } else {
+        val blockIds =
+          rdd.partitions.indices.map(index => RDDBlockId(rdd.id, index)).toArray[BlockId]
+        blockManagerMaster.getLocations(blockIds).map { bms =>
+          bms.map(bm => TaskLocation(bm.host, bm.executorId))
+        }
       }
       cacheLocs(rdd.id) = locs
     }

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -343,13 +343,13 @@ class DAGSchedulerSuite
   }
 
   /**
-   * ┌───┐ shuffle ┌───┐    ┌───┐
-   * │ A │< ─ ─ ─ ─│ B │< ─ │ C │< ─┐
-   * └───┘         └───┘    └───┘   │  ┌───┐
-   *                                ├──│ E │
-   *                        ┌───┐   │  └───┘
-   *                        │ D │< ─┘
-   *                        └───┘
+   * +---+ shuffle +---+    +---+
+   * | A |<--------| B |<---| C |<--+
+   * +---+         +---+    +---+   |  +---+
+   *                                +--| E |
+   *                        +---+   |  +---+
+   *                        | D |<--+
+   *                        +---+
    * Here, E has one-to-one dependencies on C and D. C is derived from A by performing a shuffle
    * and then a map. If we're trying to determine which ancestor stages need to be computed in
    * order to compute E, we need to figure out whether the shuffle A -> B should be performed.

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -342,6 +342,35 @@ class DAGSchedulerSuite
     assert(locs === Seq(Seq("hostA", "hostB"), Seq("hostB", "hostC"), Seq("hostC", "hostD")))
   }
 
+  /**
+   * ┌───┐ shuffle ┌───┐    ┌───┐
+   * │ A │< ─ ─ ─ ─│ B │< ─ │ C │< ─┐
+   * └───┘         └───┘    └───┘   │  ┌───┐
+   *                                ├──│ E │
+   *                        ┌───┐   │  └───┘
+   *                        │ D │< ─┘
+   *                        └───┘
+   * Here, E has one-to-one dependencies on C and D. C is derived from A by performing a shuffle
+   * and then a map. If we're trying to determine which ancestor stages need to be computed in
+   * order to compute E, we need to figure out whether the shuffle A -> B should be performed.
+   * If the RDD C, which has only one ancestor via a narrow dependency, is cached, then we won't
+   * need to compute A, even if it has some unavailable output partitions. The same goes for B:
+   * if B is 100% cached, then we can avoid the shuffle on A.
+   */
+  test("SPARK-7826: regression test for getMissingParentStages") {
+    val rddA = new MyRDD(sc, 1, Nil)
+    val rddB = new MyRDD(sc, 1, List(new ShuffleDependency(rddA, null)))
+    val rddC = new MyRDD(sc, 1, List(new OneToOneDependency(rddB)))
+    val rddD = new MyRDD(sc, 1, Nil)
+    val rddE = new MyRDD(sc, 1,
+      List(new OneToOneDependency(rddC), new OneToOneDependency(rddD)))
+    cacheLocations(rddC.id -> 0) =
+      Seq(makeBlockManagerId("hostA"), makeBlockManagerId("hostB"))
+    val jobId = submit(rddE, Array(0))
+    val finalStage = scheduler.jobIdToActiveJob(jobId).finalStage
+    assert(scheduler.getMissingParentStages(finalStage).size === 0)
+  }
+
   test("avoid exponential blowup when getting preferred locs list") {
     // Build up a complex dependency graph with repeated zip operations, without preferred locations
     var rdd: RDD[_] = new MyRDD(sc, 1, Nil)

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -318,7 +318,7 @@ class DAGSchedulerSuite
   }
 
   test("cache location preferences w/ dependency") {
-    val baseRdd = new MyRDD(sc, 1, Nil)
+    val baseRdd = new MyRDD(sc, 1, Nil).cache()
     val finalRdd = new MyRDD(sc, 1, List(new OneToOneDependency(baseRdd)))
     cacheLocations(baseRdd.id -> 0) =
       Seq(makeBlockManagerId("hostA"), makeBlockManagerId("hostB"))
@@ -331,7 +331,7 @@ class DAGSchedulerSuite
   }
 
   test("regression test for getCacheLocs") {
-    val rdd = new MyRDD(sc, 3, Nil)
+    val rdd = new MyRDD(sc, 3, Nil).cache()
     cacheLocations(rdd.id -> 0) =
       Seq(makeBlockManagerId("hostA"), makeBlockManagerId("hostB"))
     cacheLocations(rdd.id -> 1) =
@@ -360,7 +360,7 @@ class DAGSchedulerSuite
   test("SPARK-7826: regression test for getMissingParentStages") {
     val rddA = new MyRDD(sc, 1, Nil)
     val rddB = new MyRDD(sc, 1, List(new ShuffleDependency(rddA, null)))
-    val rddC = new MyRDD(sc, 1, List(new OneToOneDependency(rddB)))
+    val rddC = new MyRDD(sc, 1, List(new OneToOneDependency(rddB))).cache()
     val rddD = new MyRDD(sc, 1, Nil)
     val rddE = new MyRDD(sc, 1,
       List(new OneToOneDependency(rddC), new OneToOneDependency(rddD)))
@@ -707,9 +707,9 @@ class DAGSchedulerSuite
   }
 
   test("cached post-shuffle") {
-    val shuffleOneRdd = new MyRDD(sc, 2, Nil)
+    val shuffleOneRdd = new MyRDD(sc, 2, Nil).cache()
     val shuffleDepOne = new ShuffleDependency(shuffleOneRdd, null)
-    val shuffleTwoRdd = new MyRDD(sc, 2, List(shuffleDepOne))
+    val shuffleTwoRdd = new MyRDD(sc, 2, List(shuffleDepOne)).cache()
     val shuffleDepTwo = new ShuffleDependency(shuffleTwoRdd, null)
     val finalRdd = new MyRDD(sc, 1, List(shuffleDepTwo))
     submit(finalRdd, Array(0))


### PR DESCRIPTION
There are too many extra call method `getCacheLocs` for `DAGScheduler`, which includes Akka communication.
To improve `DAGScheduler` performance, suppress extra calling the method.

In my application with over 1200 stages, the execution time became 3.8 min from 8.5 min with my patch.
