### PR TITLE
SPARK-7811: Fix typo on slf4j configuration on metrics.properties.tem…

### DIFF
--- a/conf/metrics.properties.template
+++ b/conf/metrics.properties.template
@@ -126,9 +126,9 @@
 #*.sink.slf4j.class=org.apache.spark.metrics.sink.Slf4jSink
 
 # Polling period for Slf4JSink
-#*.sink.sl4j.period=1
+#*.sink.slf4j.period=1
 
-#*.sink.sl4j.unit=minutes
+#*.sink.slf4j.unit=minutes
 
 
 # Enable jvm source for instance master, worker, driver and executor


### PR DESCRIPTION
Fix minor typo on metrics.properties.template where slf4j is incorrectly spelled as sl4j.
