### PR TITLE
[CORE] [TEST] Fix SimpleDateParamTest

### DIFF
--- a/core/src/test/scala/org/apache/spark/status/api/v1/SimpleDateParamSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/api/v1/SimpleDateParamSuite.scala
@@ -18,12 +18,13 @@ package org.apache.spark.status.api.v1
 
 import org.scalatest.{Matchers, FunSuite}
 
-class SimpleDateParamTest extends FunSuite with Matchers {
+class SimpleDateParamSuite extends FunSuite with Matchers {
 
   test("date parsing") {
     new SimpleDateParam("2015-02-20T23:21:17.190GMT").timestamp should be (1424474477190L)
-    new SimpleDateParam("2015-02-20T17:21:17.190CST").timestamp should be (1424474477190L)
-    new SimpleDateParam("2015-02-20").timestamp should be (1424390400000L)  // GMT
+    new SimpleDateParam("2015-02-20T17:21:17.190EST").timestamp should be (1424470877190L)
+    new SimpleDateParam("2015-02-20GMT").timestamp should be (1424390400000L)
+    new SimpleDateParam("2015-02-20EST").timestamp should be (1424390400000L)
   }
 
 }

--- a/core/src/test/scala/org/apache/spark/status/api/v1/SimpleDateParamSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/api/v1/SimpleDateParamSuite.scala
@@ -23,8 +23,7 @@ class SimpleDateParamSuite extends FunSuite with Matchers {
   test("date parsing") {
     new SimpleDateParam("2015-02-20T23:21:17.190GMT").timestamp should be (1424474477190L)
     new SimpleDateParam("2015-02-20T17:21:17.190EST").timestamp should be (1424470877190L)
-    new SimpleDateParam("2015-02-20GMT").timestamp should be (1424390400000L)
-    new SimpleDateParam("2015-02-20EST").timestamp should be (1424390400000L)
+    new SimpleDateParam("2015-02-20").timestamp should be (1424390400000L) // GMT
   }
 
 }


### PR DESCRIPTION
```
sbt.ForkMain$ForkError: 1424424077190 was not equal to 1424474477190
    at org.scalatest.MatchersHelper$.newTestFailedException(MatchersHelper.scala:160)
    at org.scalatest.Matchers$ShouldMethodHelper$.shouldMatcher(Matchers.scala:6231)
    at org.scalatest.Matchers$AnyShouldWrapper.should(Matchers.scala:6265)
    at org.apache.spark.status.api.v1.SimpleDateParamTest$$anonfun$1.apply$mcV$sp(SimpleDateParamTest.scala:25)
    at org.apache.spark.status.api.v1.SimpleDateParamTest$$anonfun$1.apply(SimpleDateParamTest.scala:23)
    at org.apache.spark.status.api.v1.SimpleDateParamTest$$anonfun$1.apply(SimpleDateParamTest.scala:23)
    at org.scalatest.Transformer$$anonfun$apply$1.apply$mcV$sp(Transformer.scala:22)
    at org.scalatest.OutcomeOf$class.outcomeOf(OutcomeOf.scala:85)
    at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
    at org.scalatest.Transformer.apply(Transformer.scala:22)
    at org.scalatest.Transformer.apply(Transformer.scala:20)
    at org.scalatest.FunSuiteLike$$anon$1.apply(FunSuiteLike.scala:166)
    at org.scalatest.Suite$class.withFixture(Suite.scala:
```

Set timezone to fix SimpleDateParamTest
