### PR TITLE
[minor] typo: duplicated space

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/Row.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/Row.scala
@@ -62,7 +62,7 @@ object Row {
 
 
 /**
- * Represents one row of output from a relational operator.  Allows both generic access by ordinal,
+ * Represents one row of output from a relational operator. Allows both generic access by ordinal,
  * which will incur boxing overhead for primitives, as well as native primitive access.
  *
  * It is invalid to use the native primitive interface to retrieve a value that is null, instead a


### PR DESCRIPTION
Removed duplicated space in line 65 before 'Allows'
