### PR TITLE
[SPARK-7863][Core] Create SimpleDateFormat for every SimpleDateParam instance because it's not thread-safe

### DIFF
--- a/core/src/main/scala/org/apache/spark/status/api/v1/SimpleDateParam.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/SimpleDateParam.scala
@@ -25,8 +25,19 @@ import javax.ws.rs.core.Response.Status
 import scala.util.Try
 
 private[v1] class SimpleDateParam(val originalValue: String) {
+
+  private val formats: Seq[SimpleDateFormat] = {
+    val gmtDay = new SimpleDateFormat("yyyy-MM-dd")
+    gmtDay.setTimeZone(TimeZone.getTimeZone("GMT"))
+
+    Seq(
+      new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSz"),
+      gmtDay
+    )
+  }
+
   val timestamp: Long = {
-    SimpleDateParam.formats.collectFirst {
+    formats.collectFirst {
       case fmt if Try(fmt.parse(originalValue)).isSuccess =>
         fmt.parse(originalValue).getTime()
     }.getOrElse(
@@ -36,20 +47,6 @@ private[v1] class SimpleDateParam(val originalValue: String) {
           .entity("Couldn't parse date: " + originalValue)
           .build()
       )
-    )
-  }
-}
-
-private[v1] object SimpleDateParam {
-
-  val formats: Seq[SimpleDateFormat] = {
-
-    val gmtDay = new SimpleDateFormat("yyyy-MM-dd")
-    gmtDay.setTimeZone(TimeZone.getTimeZone("GMT"))
-
-    Seq(
-      new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSz"),
-      gmtDay
     )
   }
 }

--- a/core/src/main/scala/org/apache/spark/status/api/v1/SimpleDateParam.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/SimpleDateParam.scala
@@ -16,36 +16,33 @@
  */
 package org.apache.spark.status.api.v1
 
-import java.text.SimpleDateFormat
+import java.text.{ParseException, SimpleDateFormat}
 import java.util.TimeZone
 import javax.ws.rs.WebApplicationException
 import javax.ws.rs.core.Response
 import javax.ws.rs.core.Response.Status
 
-import scala.util.Try
-
 private[v1] class SimpleDateParam(val originalValue: String) {
 
   val timestamp: Long = {
-    val formats: Seq[SimpleDateFormat] = {
-      val gmtDay = new SimpleDateFormat("yyyy-MM-dd")
-      gmtDay.setTimeZone(TimeZone.getTimeZone("GMT"))
-
-      Seq(
-        new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSz"),
-        gmtDay
-      )
+    val format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSz")
+    try {
+      format.parse(originalValue).getTime()
+    } catch {
+      case _: ParseException =>
+        val gmtDay = new SimpleDateFormat("yyyy-MM-dd")
+        gmtDay.setTimeZone(TimeZone.getTimeZone("GMT"))
+        try {
+          gmtDay.parse(originalValue).getTime()
+        } catch {
+          case _: ParseException =>
+            throw new WebApplicationException(
+              Response
+                .status(Status.BAD_REQUEST)
+                .entity("Couldn't parse date: " + originalValue)
+                .build()
+            )
+        }
     }
-    formats.collectFirst {
-      case fmt if Try(fmt.parse(originalValue)).isSuccess =>
-        fmt.parse(originalValue).getTime()
-    }.getOrElse(
-      throw new WebApplicationException(
-        Response
-          .status(Status.BAD_REQUEST)
-          .entity("Couldn't parse date: " + originalValue)
-          .build()
-      )
-    )
   }
 }

--- a/core/src/main/scala/org/apache/spark/status/api/v1/SimpleDateParam.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/SimpleDateParam.scala
@@ -26,17 +26,16 @@ import scala.util.Try
 
 private[v1] class SimpleDateParam(val originalValue: String) {
 
-  private val formats: Seq[SimpleDateFormat] = {
-    val gmtDay = new SimpleDateFormat("yyyy-MM-dd")
-    gmtDay.setTimeZone(TimeZone.getTimeZone("GMT"))
-
-    Seq(
-      new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSz"),
-      gmtDay
-    )
-  }
-
   val timestamp: Long = {
+    val formats: Seq[SimpleDateFormat] = {
+      val gmtDay = new SimpleDateFormat("yyyy-MM-dd")
+      gmtDay.setTimeZone(TimeZone.getTimeZone("GMT"))
+
+      Seq(
+        new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSz"),
+        gmtDay
+      )
+    }
     formats.collectFirst {
       case fmt if Try(fmt.parse(originalValue)).isSuccess =>
         fmt.parse(originalValue).getTime()

--- a/core/src/test/scala/org/apache/spark/status/api/v1/SimpleDateParamSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/api/v1/SimpleDateParamSuite.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.spark.status.api.v1
 
+import javax.ws.rs.WebApplicationException
+
 import org.scalatest.{Matchers, FunSuite}
 
 class SimpleDateParamSuite extends FunSuite with Matchers {
@@ -24,6 +26,9 @@ class SimpleDateParamSuite extends FunSuite with Matchers {
     new SimpleDateParam("2015-02-20T23:21:17.190GMT").timestamp should be (1424474477190L)
     new SimpleDateParam("2015-02-20T17:21:17.190EST").timestamp should be (1424470877190L)
     new SimpleDateParam("2015-02-20").timestamp should be (1424390400000L) // GMT
+    intercept[WebApplicationException] {
+      new SimpleDateParam("invalid date")
+    }
   }
 
 }


### PR DESCRIPTION
SimpleDateFormat is not thread-safe. This PR creates new `SimpleDateFormat` for each `SimpleDateParam` instance.
