### PR TITLE
[SPARK-7864] [Web UI] Clicking a job's DAG graph on Web UI kills the job as the link is broken

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/jobs/StageTable.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StageTable.scala
@@ -118,7 +118,7 @@ private[ui] class StageTableBase(
     } yield {
       <span class="description-input" title={desc}>{desc}</span>
     }
-    <div>{stageDesc.getOrElse("")} {killLink} {nameLink} {details}</div>
+    <div>{stageDesc.getOrElse("")} {nameLink} {killLink} {details}</div>
   }
 
   protected def missingStageRow(stageId: Int): Seq[Node] = {


### PR DESCRIPTION
When clicking a job's DAG graph on Web UI, the user is expected to be redirected to the corresponding stage page. The link is got from the stage table by selecting the first link. But there are two links in each row, the first one is the killLink, the second is the nameLink.

To solve this, I made the nameLink as the first one. The UI doesn't change as the style is controlled by css.
