### PR TITLE
[SPARK-7866] [SQL] print the format string in dataframe explain

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -294,11 +294,11 @@ class DataFrame private[sql](
    * @since 1.3.0
    */
   def explain(extended: Boolean): Unit = {
-    ExplainCommand(
-      queryExecution.logical,
-      extended = extended).queryExecution.executedPlan.executeCollect().map {
-      r => println(r.getString(0))
-    }
+    println(
+      ExplainCommand(
+        queryExecution.logical,
+        extended = extended).queryExecution.toString
+    )
   }
 
   /**


### PR DESCRIPTION
jira: https://issues.apache.org/jira/browse/SPARK-7866

`QueryExecution.toString` give a format and clear string, so we print it in `DataFrame.explain` method
