### PR TITLE
[SPARK-7705][Yarn] Cleanup of .sparkStaging directory fails if application is killed

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -121,11 +121,9 @@ private[spark] class ApplicationMaster(
           // we only want to unregister if we don't want the RM to retry
           if (finalStatus == FinalApplicationStatus.SUCCEEDED || isLastAttempt) {
             unregister(finalStatus, finalMsg)
+            cleanupStagingDir(fs)
           }
         }
-
-        // Clean up staging directory when AppMaster exit at any final application status
-        cleanupStagingDir(fs)
       }
 
       // Call this to force generation of secret so it gets populated into the

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -121,9 +121,11 @@ private[spark] class ApplicationMaster(
           // we only want to unregister if we don't want the RM to retry
           if (finalStatus == FinalApplicationStatus.SUCCEEDED || isLastAttempt) {
             unregister(finalStatus, finalMsg)
-            cleanupStagingDir(fs)
           }
         }
+
+        // Clean up staging directory when AppMaster exit at any final application status
+        cleanupStagingDir(fs)
       }
 
       // Call this to force generation of secret so it gets populated into the

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -846,7 +846,7 @@ private[spark] class Client(
    * of SPARK_STAGING directory.
    */
   private def cleanupStagingDir(appId: ApplicationId = null): Unit = {
-    val stagingDirPath =  if (appId != null) {
+    val stagingDirPath = if (appId != null) {
       new Path(getAppStagingDir(appId))
     } else {
       new Path(SPARK_STAGING)

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -813,8 +813,8 @@ private[spark] class Client(
    * throw an appropriate SparkException.
    */
   def run(): Unit = {
-    // Clean up staging director as some appStagingDir can not be deleted when job is failed or
-    // killed, Please see SPARK-7705 for details.
+    // Cleanup staging director as some appStagingDir can not be deleted when job is failed or
+    // killed, please see SPARK-7705 for details.
     cleanupStagingDir()
     val appId = submitApplication()
     if (fireAndForget) {

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -105,7 +105,7 @@ private[spark] class Client(
       // Get a new application from our RM
       val newApp = yarnClient.createApplication()
       val newAppResponse = newApp.getNewApplicationResponse()
-      val appId = newAppResponse.getApplicationId()
+      appId = newAppResponse.getApplicationId()
 
       // Verify whether the cluster has enough resources for our AM
       verifyClusterResources(newAppResponse)

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -128,7 +128,7 @@ private[spark] class Client(
   }
 
   /**
-   * Cleanup  all subdirectory of SPARK_STAGING directory.
+   * Cleanup application staging directory.
    */
   private def cleanupStagingDir(appId: ApplicationId): Unit = {
     val appStagingDir = getAppStagingDir(appId)


### PR DESCRIPTION
As I have tested, if we cancel or kill the app then the final status may be undefined, killed or succeeded, so clean up staging directory when appMaster exit at any final application status.
