### PR TITLE
[MINOR] [CORE] Warn about caching if dynamic allocation is enabled (1.3)

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1293,6 +1293,11 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
    * Register an RDD to be persisted in memory and/or disk storage
    */
   private[spark] def persistRDD(rdd: RDD[_]) {
+    executorAllocationManager.foreach { _ =>
+      logWarning(
+        s"Dynamic allocation currently does not support cached RDDs. Cached data for RDD " +
+        s"${rdd.id} will be lost when executors are removed.")
+    }
     persistentRdds(rdd.id) = rdd
   }
 


### PR DESCRIPTION
This is a resubmit of #5751 for branch-1.3. The previous cherry-pick caused a build break that was later [reverted](https://github.com/apache/spark/commit/2254576e10ee433423aa8accf2d84f12ec20fc97). Originally written by @vanzin.
