### PR TITLE
[SPARK-7884] Move block deserialization from BlockStoreShuffleFetcher to ShuffleReader

### DIFF
--- a/core/src/main/scala/org/apache/spark/shuffle/hash/BlockStoreShuffleFetcher.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/hash/BlockStoreShuffleFetcher.scala
@@ -25,7 +25,6 @@ import scala.util.{Failure, Success, Try}
 import org.apache.spark._
 import org.apache.spark.shuffle.FetchFailedException
 import org.apache.spark.storage.{BlockId, BlockManagerId, ShuffleBlockFetcherIterator, ShuffleBlockId}
-import org.apache.spark.util.CompletionIterator
 
 private[shuffle] object BlockStoreShuffleFetcher extends Logging {
   def fetchBlockStreams(
@@ -80,10 +79,6 @@ private[shuffle] object BlockStoreShuffleFetcher extends Logging {
       // Note: we use getSizeAsMb when no suffix is provided for backwards compatibility
       SparkEnv.get.conf.getSizeAsMb("spark.reducer.maxSizeInFlight", "48m") * 1024 * 1024)
 
-    val itr = blockFetcherItr.map(unpackBlock)
-
-    CompletionIterator[(BlockId, InputStream), Iterator[(BlockId, InputStream)]](itr, {
-      context.taskMetrics().updateShuffleReadMetrics()
-    })
+    blockFetcherItr.map(unpackBlock)
   }
 }

--- a/core/src/main/scala/org/apache/spark/shuffle/hash/BlockStoreShuffleFetcher.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/hash/BlockStoreShuffleFetcher.scala
@@ -27,7 +27,7 @@ import org.apache.spark.shuffle.FetchFailedException
 import org.apache.spark.storage.{BlockId, BlockManagerId, ShuffleBlockFetcherIterator, ShuffleBlockId}
 import org.apache.spark.util.CompletionIterator
 
-private[hash] object BlockStoreShuffleFetcher extends Logging {
+private[shuffle] object BlockStoreShuffleFetcher extends Logging {
   def fetchBlockStreams(
       shuffleId: Int,
       reduceId: Int,

--- a/core/src/main/scala/org/apache/spark/shuffle/hash/BlockStoreShuffleFetcher.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/hash/BlockStoreShuffleFetcher.scala
@@ -26,7 +26,7 @@ import org.apache.spark._
 import org.apache.spark.shuffle.FetchFailedException
 import org.apache.spark.storage.{BlockId, BlockManagerId, ShuffleBlockFetcherIterator, ShuffleBlockId}
 
-private[shuffle] object BlockStoreShuffleFetcher extends Logging {
+private[hash] object BlockStoreShuffleFetcher extends Logging {
   def fetchBlockStreams(
       shuffleId: Int,
       reduceId: Int,

--- a/core/src/main/scala/org/apache/spark/shuffle/hash/BlockStoreShuffleFetcher.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/hash/BlockStoreShuffleFetcher.scala
@@ -26,7 +26,8 @@ import org.apache.spark._
 import org.apache.spark.shuffle.FetchFailedException
 import org.apache.spark.storage.{BlockId, BlockManagerId, ShuffleBlockFetcherIterator, ShuffleBlockId}
 
-private[hash] object BlockStoreShuffleFetcher extends Logging {
+private[hash] class BlockStoreShuffleFetcher extends Logging {
+
   def fetchBlockStreams(
       shuffleId: Int,
       reduceId: Int,

--- a/core/src/main/scala/org/apache/spark/shuffle/hash/BlockStoreShuffleFetcher.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/hash/BlockStoreShuffleFetcher.scala
@@ -26,8 +26,7 @@ import org.apache.spark._
 import org.apache.spark.shuffle.FetchFailedException
 import org.apache.spark.storage.{BlockId, BlockManagerId, ShuffleBlockFetcherIterator, ShuffleBlockId}
 
-private[hash] class BlockStoreShuffleFetcher extends Logging {
-
+private[hash] object BlockStoreShuffleFetcher extends Logging {
   def fetchBlockStreams(
       shuffleId: Int,
       reduceId: Int,

--- a/core/src/main/scala/org/apache/spark/shuffle/hash/HashShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/hash/HashShuffleReader.scala
@@ -19,7 +19,7 @@ package org.apache.spark.shuffle.hash
 
 import org.apache.spark.{SparkEnv, TaskContext, InterruptibleIterator}
 import org.apache.spark.serializer.Serializer
-import org.apache.spark.shuffle.{ShuffleReader, BaseShuffleHandle}
+import org.apache.spark.shuffle.{BaseShuffleHandle, ShuffleReader}
 import org.apache.spark.util.CompletionIterator
 import org.apache.spark.util.collection.ExternalSorter
 

--- a/core/src/main/scala/org/apache/spark/shuffle/hash/HashShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/hash/HashShuffleReader.scala
@@ -38,7 +38,7 @@ private[spark] class HashShuffleReader[K, C](
   /** Read the combined key-values for this reduce task */
   override def read(): Iterator[Product2[K, C]] = {
     val blockStreams = BlockStoreShuffleFetcher.fetchBlockStreams(
-                       handle.shuffleId, startPartition, context)
+                         handle.shuffleId, startPartition, context)
 
     // Wrap the streams for compression based on configuration
     val wrappedStreams = blockStreams.map { case (blockId, inputStream) =>

--- a/core/src/main/scala/org/apache/spark/shuffle/hash/HashShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/hash/HashShuffleReader.scala
@@ -80,9 +80,7 @@ private[spark] class HashShuffleReader[K, C](
       }
     } else {
       require(!dep.mapSideCombine, "Map-side combine without Aggregator specified!")
-
-      // Convert the Product2s to pairs since this is what downstream RDDs currently expect
-      interruptibleIter.asInstanceOf[Iterator[Product2[K, C]]].map(pair => (pair._1, pair._2))
+      interruptibleIter.asInstanceOf[Iterator[Product2[K, C]]]
     }
 
     // Sort the output if there is a sort ordering defined.

--- a/core/src/main/scala/org/apache/spark/shuffle/hash/HashShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/hash/HashShuffleReader.scala
@@ -51,6 +51,9 @@ private[spark] class HashShuffleReader[K, C](
 
     // Create a key/value iterator for each stream
     val recordIter = wrappedStreams.flatMap { wrappedStream =>
+      // Note: the asKeyValueIterator below wraps a key/value iterator inside of a
+      // NextIterator. The NextIterator makes sure that close() is called on the
+      // underlying InputStream when all records have been read.
       serializerInstance.deserializeStream(wrappedStream).asKeyValueIterator
     }
 

--- a/core/src/main/scala/org/apache/spark/shuffle/hash/HashShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/hash/HashShuffleReader.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.shuffle.hash
 
-import org.apache.spark.{SparkEnv, TaskContext, InterruptibleIterator}
+import org.apache.spark.{InterruptibleIterator, SparkEnv, TaskContext}
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.{BaseShuffleHandle, ShuffleReader}
 import org.apache.spark.util.CompletionIterator

--- a/core/src/main/scala/org/apache/spark/shuffle/hash/HashShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/hash/HashShuffleReader.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.shuffle.hash
 
+import org.apache.spark.storage.BlockManager
 import org.apache.spark.{InterruptibleIterator, SparkEnv, TaskContext}
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.{BaseShuffleHandle, ShuffleReader}
@@ -27,18 +28,19 @@ private[spark] class HashShuffleReader[K, C](
     handle: BaseShuffleHandle[K, _, C],
     startPartition: Int,
     endPartition: Int,
-    context: TaskContext)
+    context: TaskContext,
+    blockManager: BlockManager = SparkEnv.get.blockManager,
+    blockStoreShuffleFetcher: BlockStoreShuffleFetcher = new BlockStoreShuffleFetcher)
   extends ShuffleReader[K, C]
 {
   require(endPartition == startPartition + 1,
     "Hash shuffle currently only supports fetching one partition")
 
   private val dep = handle.dependency
-  private val blockManager = SparkEnv.get.blockManager
 
   /** Read the combined key-values for this reduce task */
   override def read(): Iterator[Product2[K, C]] = {
-    val blockStreams = BlockStoreShuffleFetcher.fetchBlockStreams(
+    val blockStreams = blockStoreShuffleFetcher.fetchBlockStreams(
       handle.shuffleId, startPartition, context)
 
     // Wrap the streams for compression based on configuration

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -21,7 +21,7 @@ import java.io.InputStream
 import java.util.concurrent.LinkedBlockingQueue
 
 import scala.collection.mutable
-import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable.{ArrayBuffer, HashSet}
 import scala.util.{Failure, Try}
 
 import org.apache.spark.network.buffer.ManagedBuffer
@@ -78,7 +78,7 @@ final class ShuffleBlockFetcherIterator(
   private[this] val localBlocks = new ArrayBuffer[BlockId]()
 
   /** Remote blocks to fetch, excluding zero-sized blocks. */
-  private[this] val remoteBlocks = new mutable.HashSet[BlockId]()
+  private[this] val remoteBlocks = new HashSet[BlockId]()
 
   /**
    * A queue to hold our results. This turns the asynchronous model provided by

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -314,9 +314,12 @@ final class ShuffleBlockFetcherIterator(
   }
 }
 
-/** Helper class that ensures a ManagerBuffer is released upon InputStream.close() */
+/**
+ * Helper class that ensures a ManagedBuffer is release upon InputStream.close()
+ * Note: the delegate parameter is private[storage] to make it available to tests.
+ */
 private class BufferReleasingInputStream(
-    delegate: InputStream,
+    private[storage] val delegate: InputStream,
     iterator: ShuffleBlockFetcherIterator)
   extends InputStream {
   private var closed = false

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -319,10 +319,10 @@ final class ShuffleBlockFetcherIterator(
  * Note: the delegate parameter is private[storage] to make it available to tests.
  */
 private class BufferReleasingInputStream(
-    private[storage] val delegate: InputStream,
-    iterator: ShuffleBlockFetcherIterator)
+    private val delegate: InputStream,
+    private val iterator: ShuffleBlockFetcherIterator)
   extends InputStream {
-  private var closed = false
+  private[this] var closed = false
 
   override def read(): Int = delegate.read()
 

--- a/core/src/test/scala/org/apache/spark/shuffle/hash/HashShuffleManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/hash/HashShuffleManagerSuite.scala
@@ -17,22 +17,16 @@
 
 package org.apache.spark.shuffle.hash
 
-import java.io._
-import java.nio.ByteBuffer
+import java.io.{File, FileWriter}
 
 import scala.language.reflectiveCalls
 
-import org.mockito.Matchers.any
-import org.mockito.Mockito._
-import org.mockito.invocation.InvocationOnMock
-import org.mockito.stubbing.Answer
-
-import org.apache.spark._
-import org.apache.spark.executor.{ShuffleReadMetrics, TaskMetrics, ShuffleWriteMetrics}
+import org.apache.spark.{LocalSparkContext, SparkConf, SparkContext, SparkEnv, SparkFunSuite}
+import org.apache.spark.executor.ShuffleWriteMetrics
 import org.apache.spark.network.buffer.{FileSegmentManagedBuffer, ManagedBuffer}
-import org.apache.spark.serializer._
-import org.apache.spark.shuffle.{BaseShuffleHandle, FileShuffleBlockResolver}
-import org.apache.spark.storage.{BlockId, BlockManager, ShuffleBlockId, FileSegment}
+import org.apache.spark.serializer.JavaSerializer
+import org.apache.spark.shuffle.FileShuffleBlockResolver
+import org.apache.spark.storage.{ShuffleBlockId, FileSegment}
 
 class HashShuffleManagerSuite extends SparkFunSuite with LocalSparkContext {
   private val testConf = new SparkConf(false)
@@ -112,101 +106,5 @@ class HashShuffleManagerSuite extends SparkFunSuite with LocalSparkContext {
     val writer = new FileWriter(file, true)
     for (i <- 0 until numBytes) writer.write(i)
     writer.close()
-  }
-
-  test("HashShuffleReader.read() releases resources and tracks metrics") {
-    val shuffleId = 1
-    val numMaps = 2
-    val numKeyValuePairs = 10
-
-    val mockContext = mock(classOf[TaskContext])
-
-    val mockTaskMetrics = mock(classOf[TaskMetrics])
-    val mockReadMetrics = mock(classOf[ShuffleReadMetrics])
-    when(mockTaskMetrics.createShuffleReadMetricsForDependency()).thenReturn(mockReadMetrics)
-    when(mockContext.taskMetrics()).thenReturn(mockTaskMetrics)
-
-    val mockShuffleFetcher = mock(classOf[BlockStoreShuffleFetcher])
-
-    val mockDep = mock(classOf[ShuffleDependency[_, _, _]])
-    when(mockDep.keyOrdering).thenReturn(None)
-    when(mockDep.aggregator).thenReturn(None)
-    when(mockDep.serializer).thenReturn(Some(new Serializer {
-      override def newInstance(): SerializerInstance = new SerializerInstance {
-
-        override def deserializeStream(s: InputStream): DeserializationStream =
-          new DeserializationStream {
-            override def readObject[T: ClassManifest](): T = null.asInstanceOf[T]
-
-            override def close(): Unit = s.close()
-
-            private val values = {
-              for (i <- 0 to numKeyValuePairs * 2) yield i
-            }.iterator
-
-            private def getValueOrEOF(): Int = {
-              if (values.hasNext) {
-                values.next()
-              } else {
-                throw new EOFException("End of the file: mock deserializeStream")
-              }
-            }
-
-            // NOTE: the readKey and readValue methods are called by asKeyValueIterator()
-            // which is wrapped in a NextIterator
-            override def readKey[T: ClassManifest](): T = getValueOrEOF().asInstanceOf[T]
-
-            override def readValue[T: ClassManifest](): T = getValueOrEOF().asInstanceOf[T]
-          }
-
-        override def deserialize[T: ClassManifest](bytes: ByteBuffer, loader: ClassLoader): T =
-          null.asInstanceOf[T]
-
-        override def serialize[T: ClassManifest](t: T): ByteBuffer = ByteBuffer.allocate(0)
-
-        override def serializeStream(s: OutputStream): SerializationStream =
-          null.asInstanceOf[SerializationStream]
-
-        override def deserialize[T: ClassManifest](bytes: ByteBuffer): T = null.asInstanceOf[T]
-      }
-    }))
-
-    val mockBlockManager = {
-      // Create a block manager that isn't configured for compression, just returns input stream
-      val blockManager = mock(classOf[BlockManager])
-      when(blockManager.wrapForCompression(any[BlockId](), any[InputStream]()))
-        .thenAnswer(new Answer[InputStream] {
-        override def answer(invocation: InvocationOnMock): InputStream = {
-          val blockId = invocation.getArguments()(0).asInstanceOf[BlockId]
-          val inputStream = invocation.getArguments()(1).asInstanceOf[InputStream]
-          inputStream
-        }
-      })
-      blockManager
-    }
-
-    val mockInputStream = mock(classOf[InputStream])
-    when(mockShuffleFetcher.fetchBlockStreams(any[Int](), any[Int](), any[TaskContext]()))
-      .thenReturn(Iterator.single((mock(classOf[BlockId]), mockInputStream)))
-
-    val shuffleHandle = new BaseShuffleHandle(shuffleId, numMaps, mockDep)
-
-    val reader = new HashShuffleReader(shuffleHandle, 0, 1,
-      mockContext, mockBlockManager, mockShuffleFetcher)
-
-    val values = reader.read()
-    // Verify that we're reading the correct values
-    var numValuesRead = 0
-    for (((key: Int, value: Int), i) <- values.zipWithIndex) {
-      assert(key == i * 2)
-      assert(value == i * 2 + 1)
-      numValuesRead += 1
-    }
-    // Verify that we read the correct number of values
-    assert(numKeyValuePairs == numValuesRead)
-    // Verify that our input stream was closed
-    verify(mockInputStream, times(1)).close()
-    // Verify that we collected metrics for each key/value pair
-    verify(mockReadMetrics, times(numKeyValuePairs)).incRecordsRead(1)
   }
 }

--- a/core/src/test/scala/org/apache/spark/shuffle/hash/HashShuffleReaderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/hash/HashShuffleReaderSuite.scala
@@ -41,10 +41,10 @@ class RecordingManagedBuffer(underlyingBuffer: NioManagedBuffer) extends Managed
   var callsToRetain = 0
   var callsToRelease = 0
 
-  override def size() = underlyingBuffer.size()
-  override def nioByteBuffer() = underlyingBuffer.nioByteBuffer()
-  override def createInputStream() = underlyingBuffer.createInputStream()
-  override def convertToNetty() = underlyingBuffer.convertToNetty()
+  override def size(): Long = underlyingBuffer.size()
+  override def nioByteBuffer(): ByteBuffer = underlyingBuffer.nioByteBuffer()
+  override def createInputStream(): InputStream = underlyingBuffer.createInputStream()
+  override def convertToNetty(): AnyRef = underlyingBuffer.convertToNetty()
 
   override def retain(): ManagedBuffer = {
     callsToRetain += 1
@@ -81,7 +81,7 @@ class HashShuffleReaderSuite extends SparkFunSuite with LocalSparkContext {
     // Create a return function to use for the mocked wrapForCompression method that just returns
     // the original input stream.
     val dummyCompressionFunction = new Answer[InputStream] {
-      override def answer(invocation: InvocationOnMock) =
+      override def answer(invocation: InvocationOnMock): InputStream =
         invocation.getArguments()(1).asInstanceOf[InputStream]
     }
 
@@ -118,7 +118,7 @@ class HashShuffleReaderSuite extends SparkFunSuite with LocalSparkContext {
     // Test a scenario where all data is local, just to avoid creating a bunch of additional mocks
     // for the code to read data over the network.
     val statuses: Array[(BlockManagerId, Long)] =
-      Array.fill(numMaps)((localBlockManagerId, byteOutputStream.size()))
+      Array.fill(numMaps)((localBlockManagerId, byteOutputStream.size().toLong))
     when(mapOutputTracker.getServerStatuses(shuffleId, reduceId)).thenReturn(statuses)
 
     // Create a mocked shuffle handle to pass into HashShuffleReader.

--- a/core/src/test/scala/org/apache/spark/shuffle/hash/HashShuffleReaderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/hash/HashShuffleReaderSuite.scala
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.hash
+
+import java.io.{ByteArrayOutputStream, InputStream}
+import java.nio.ByteBuffer
+
+import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.Mockito.{mock, when}
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
+
+import org.apache.spark._
+import org.apache.spark.network.buffer.{ManagedBuffer, NioManagedBuffer}
+import org.apache.spark.serializer.JavaSerializer
+import org.apache.spark.shuffle.BaseShuffleHandle
+import org.apache.spark.storage.{BlockManager, BlockManagerId, ShuffleBlockId}
+
+/**
+ * Wrapper for a managed buffer that keeps track of how many times retain and release are called.
+ *
+ * We need to define this class ourselves instead of using a spy because the NioManagedBuffer class
+ * is final (final classes cannot be spied on).
+ */
+class RecordingManagedBuffer(underlyingBuffer: NioManagedBuffer) extends ManagedBuffer {
+  var callsToRetain = 0
+  var callsToRelease = 0
+
+  override def size() = underlyingBuffer.size()
+  override def nioByteBuffer() = underlyingBuffer.nioByteBuffer()
+  override def createInputStream() = underlyingBuffer.createInputStream()
+  override def convertToNetty() = underlyingBuffer.convertToNetty()
+
+  override def retain(): ManagedBuffer = {
+    callsToRetain += 1
+    underlyingBuffer.retain()
+  }
+  override def release(): ManagedBuffer = {
+    callsToRelease += 1
+    underlyingBuffer.release()
+  }
+}
+
+class HashShuffleReaderSuite extends SparkFunSuite with LocalSparkContext {
+
+  /**
+   * This test makes sure that, when data is read from a HashShuffleReader, the underlying
+   * ManagedBuffers that contain the data are eventually released.
+   */
+  test("read() releases resources on completion") {
+    val testConf = new SparkConf(false)
+    // Create a SparkContext as a convenient way of setting SparkEnv (needed because some of the
+    // shuffle code calls SparkEnv.get()).
+    sc = new SparkContext("local", "test", testConf)
+
+    val reduceId = 15
+    val shuffleId = 22
+    val numMaps = 6
+    val keyValuePairsPerMap = 10
+    val serializer = new JavaSerializer(testConf)
+
+    // Make a mock BlockManager that will return RecordingManagedByteBuffers of data, so that we
+    // can ensure retain() and release() are properly called.
+    val blockManager = mock(classOf[BlockManager])
+
+    // Create a return function to use for the mocked wrapForCompression method that just returns
+    // the original input stream.
+    val dummyCompressionFunction = new Answer[InputStream] {
+      override def answer(invocation: InvocationOnMock) =
+        invocation.getArguments()(1).asInstanceOf[InputStream]
+    }
+
+    // Create a buffer with some randomly generated key-value pairs to use as the shuffle data
+    // from each mappers (all mappers return the same shuffle data).
+    val byteOutputStream = new ByteArrayOutputStream()
+    val serializationStream = serializer.newInstance().serializeStream(byteOutputStream)
+    (0 until keyValuePairsPerMap).foreach { i =>
+      serializationStream.writeKey(i)
+      serializationStream.writeValue(2*i)
+    }
+
+    // Setup the mocked BlockManager to return RecordingManagedBuffers.
+    val localBlockManagerId = BlockManagerId("test-client", "test-client", 1)
+    when(blockManager.blockManagerId).thenReturn(localBlockManagerId)
+    val buffers = (0 until numMaps).map { mapId =>
+      // Create a ManagedBuffer with the shuffle data.
+      val nioBuffer = new NioManagedBuffer(ByteBuffer.wrap(byteOutputStream.toByteArray))
+      val managedBuffer = new RecordingManagedBuffer(nioBuffer)
+
+      // Setup the blockManager mock so the buffer gets returned when the shuffle code tries to
+      // fetch shuffle data.
+      val shuffleBlockId = ShuffleBlockId(shuffleId, mapId, reduceId)
+      when(blockManager.getBlockData(shuffleBlockId)).thenReturn(managedBuffer)
+      when(blockManager.wrapForCompression(meq(shuffleBlockId), isA(classOf[InputStream])))
+        .thenAnswer(dummyCompressionFunction)
+
+      managedBuffer
+    }
+
+    // Make a mocked MapOutputTracker for the shuffle reader to use to determine what
+    // shuffle data to read.
+    val mapOutputTracker = mock(classOf[MapOutputTracker])
+    // Test a scenario where all data is local, just to avoid creating a bunch of additional mocks
+    // for the code to read data over the network.
+    val statuses: Array[(BlockManagerId, Long)] =
+      Array.fill(numMaps)((localBlockManagerId, byteOutputStream.size()))
+    when(mapOutputTracker.getServerStatuses(shuffleId, reduceId)).thenReturn(statuses)
+
+    // Create a mocked shuffle handle to pass into HashShuffleReader.
+    val shuffleHandle = {
+      val dependency = mock(classOf[ShuffleDependency[Int, Int, Int]])
+      when(dependency.serializer).thenReturn(Some(serializer))
+      when(dependency.aggregator).thenReturn(None)
+      when(dependency.keyOrdering).thenReturn(None)
+      new BaseShuffleHandle(shuffleId, numMaps, dependency)
+    }
+
+    val shuffleReader = new HashShuffleReader(
+      shuffleHandle,
+      reduceId,
+      reduceId + 1,
+      new TaskContextImpl(0, 0, 0, 0, null),
+      blockManager,
+      mapOutputTracker)
+
+    assert(shuffleReader.read().length === keyValuePairsPerMap * numMaps)
+
+    // Calling .length above will have exhausted the iterator; make sure that exhausting the
+    // iterator caused retain and release to be called on each buffer.
+    buffers.foreach { buffer =>
+      assert(buffer.callsToRetain === 1)
+      assert(buffer.callsToRelease === 1)
+    }
+  }
+}

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -115,7 +115,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite {
 
       // Make sure we release buffers when a wrapped input stream is closed.
       val mockBuf = localBlocks.getOrElse(blockId, remoteBlocks(blockId))
-      val wrappedInputStream = new WrappedInputStream(mock(classOf[InputStream]), iterator)
+      val wrappedInputStream = new BufferReleasingInputStream(mock(classOf[InputStream]), iterator)
       verify(mockBuf, times(0)).release()
       wrappedInputStream.close()
       verify(mockBuf, times(1)).release()


### PR DESCRIPTION
This commit updates the shuffle read path to enable ShuffleReader implementations more control over the deserialization process.

The BlockStoreShuffleFetcher.fetch() method has been renamed to BlockStoreShuffleFetcher.fetchBlockStreams(). Previously, this method returned a record iterator; now, it returns an iterator of (BlockId, InputStream). Deserialization of records is now handled in the ShuffleReader.read() method.

This change creates a cleaner separation of concerns and allows implementations of ShuffleReader more flexibility in how records are retrieved.
