### PR TITLE
[SPARK-7885][SQL]add config to control map aggregation in spark sql

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
@@ -50,6 +50,8 @@ private[spark] object SQLConf {
   val COLUMN_NAME_OF_CORRUPT_RECORD = "spark.sql.columnNameOfCorruptRecord"
   val BROADCAST_TIMEOUT = "spark.sql.broadcastTimeout"
 
+  val PARTITIAL_AGGREGATION = "spark.sql.partialAggregation.enable"
+
   // Options that control which operators can be chosen by the query planner.  These should be
   // considered hints and may be ignored by future versions of Spark SQL.
   val EXTERNAL_SORT = "spark.sql.planner.externalSort"
@@ -165,6 +167,12 @@ private[sql] class SQLConf extends Serializable with CatalystConf {
    * to HashJoin.
    */
   private[spark] def sortMergeJoinEnabled: Boolean = getConf(SORTMERGE_JOIN, "false").toBoolean
+
+  /**
+   * The execution.HashAggregation will be apply by default
+   */
+  private[spark] def partAggregationEnabled: Boolean =
+    getConf(PARTITIAL_AGGREGATION, "true").toBoolean
 
   /**
    * When set to true, Spark SQL will use the Scala compiler at runtime to generate custom bytecode

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
@@ -50,7 +50,7 @@ private[spark] object SQLConf {
   val COLUMN_NAME_OF_CORRUPT_RECORD = "spark.sql.columnNameOfCorruptRecord"
   val BROADCAST_TIMEOUT = "spark.sql.broadcastTimeout"
 
-  val PARTITIAL_AGGREGATION = "spark.sql.partialAggregation.enable"
+  val PRE_AGGREGATION = "spark.sql.preAggregation.enable"
 
   // Options that control which operators can be chosen by the query planner.  These should be
   // considered hints and may be ignored by future versions of Spark SQL.
@@ -171,8 +171,8 @@ private[sql] class SQLConf extends Serializable with CatalystConf {
   /**
    * The execution.HashAggregation will be apply by default
    */
-  private[spark] def partAggregationEnabled: Boolean =
-    getConf(PARTITIAL_AGGREGATION, "true").toBoolean
+  private[spark] def preAggregationEnabled: Boolean =
+    getConf(PRE_AGGREGATION, "true").toBoolean
 
   /**
    * When set to true, Spark SQL will use the Scala compiler at runtime to generate custom bytecode

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -121,7 +121,7 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
     def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
       // We can cancel the map aggregation due to GC problems
       case logical.Aggregate(groupingExpressions, aggregateExpressions, child)
-        if !sqlContext.conf.partAggregationEnabled =>
+        if !sqlContext.conf.preAggregationEnabled =>
         execution.Aggregate(
           partial = false,
           groupingExpressions,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -119,6 +119,15 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
 
   object HashAggregation extends Strategy {
     def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
+      // We can cancel the map aggregation due to GC problems
+      case logical.Aggregate(groupingExpressions, aggregateExpressions, child)
+        if !sqlContext.conf.partAggregationEnabled =>
+        execution.Aggregate(
+          partial = false,
+          groupingExpressions,
+          aggregateExpressions,
+          planLater(child)) :: Nil
+
       // Aggregations that can be performed in two phases, before and after the shuffle.
 
       // Cases where all aggregates can be codegened.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -143,4 +143,15 @@ class PlannerSuite extends FunSuite {
 
     setConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD, origThreshold.toString)
   }
+
+  test("SPARK-7885:Turn off the HashAggregation optimization") {
+    setConf(SQLConf.PARTITIAL_AGGREGATION, false.toString)
+    val query = testData.groupBy('value).agg(count('key)).queryExecution.analyzed
+    val planned = HashAggregation(query).head
+    val aggregations = planned.collect { case n if n.nodeName contains "Aggregate" => n }
+
+    assert(aggregations.size === 1)
+
+
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -145,7 +145,7 @@ class PlannerSuite extends FunSuite {
   }
 
   test("SPARK-7885:Turn off the HashAggregation optimization") {
-    setConf(SQLConf.PARTITIAL_AGGREGATION, false.toString)
+    setConf(SQLConf.PRE_AGGREGATION, false.toString)
     val query = testData.groupBy('value).agg(count('key)).queryExecution.analyzed
     val planned = HashAggregation(query).head
     val aggregations = planned.collect { case n if n.nodeName contains "Aggregate" => n }


### PR DESCRIPTION
[SPARK-7885](https://issues.apache.org/jira/browse/SPARK-7885),we add ~~`spark.sql.partialAggregation.enable`~~ `spark.sql.preAggregation.enable`,it's true by default,we can set false to make map aggregation unable to avoid gc problem.For example,we run the sql

``` sql
insert overwrite table groupbytest
select sale_ord_id as order_id,
      coalesce(sum(sku_offer_amount),0.0) as sku_offer_amount,
      coalesce(sum(suit_offer_amount),0.0) as suit_offer_amount,
      coalesce(sum(flash_gp_offer_amount),0.0) + coalesce(sum(gp_offer_amount),0.0) as gp_offer_amount,
      coalesce(sum(flash_gp_offer_amount),0.0) as flash_gp_offer_amount,
      coalesce(sum(full_minus_offer_amount),0.0) as full_rebate_offer_amount,
      0.0 as telecom_point_offer_amount,
      coalesce(sum(coupon_pay_amount),0.0) as dq_and_jq_pay_amount,
      coalesce(sum(jq_pay_amount),0.0) + coalesce(sum(pop_shop_jq_pay_amount),0.0) + coalesce(sum(lim_cate_jq_pay_amount),0.0) as jq_pay_amount,
      coalesce(sum(dq_pay_amount),0.0) + coalesce(sum(pop_shop_dq_pay_amount),0.0) + coalesce(sum(lim_cate_dq_pay_amount),0.0) as dq_pay_amount,
      coalesce(sum(gift_cps_pay_amount),0.0) as gift_cps_pay_amount ,
      coalesce(sum(mobile_red_packet_pay_amount),0.0) as mobile_red_packet_pay_amount,
      coalesce(sum(acct_bal_pay_amount),0.0) as acct_bal_pay_amount,
      coalesce(sum(jbean_pay_amount),0.0) as jbean_pay_amount,
      coalesce(sum(sku_rebate_amount),0.0) as sku_rebate_amount,
      coalesce(sum(yixun_point_pay_amount),0.0) as yixun_point_pay_amount,
      coalesce(sum(sku_freight_coupon_amount),0.0) as freight_coupon_amount
from        ord_at_det_di
where       ds = '2015-05-20'
group  by   sale_ord_id
```

use 6 executor, each executor has 8GB memory and 2 cpu,we got gc problems during the map aggregation and finally the executor crash
![5869030a-d924-4249-9e1d-c637caa9363a](https://cloud.githubusercontent.com/assets/3426093/7828153/4afdaf88-0462-11e5-8af0-3bff04edab92.png) 

When we set ~~`spark.sql.partialAggregation.enable`~~ `spark.sql.preAggregation.enable` false ,the sql run in 2 min
