### PR TITLE
[SPARK-7699][Core] Lazy start the scheduler for dynamic allocation

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -18,7 +18,6 @@
 package org.apache.spark
 
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.collection.mutable
 

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -719,7 +719,7 @@ class ExecutorAllocationManagerSuite
     assert(maxNumExecutorsNeeded(manager) === 2)
     schedule(manager)
 
-    //Verify that current number of executors should be ramp down when first job is submitted
+    // Verify that current number of executors should be ramp down when first job is submitted
     assert(numExecutorsTarget(manager) === 2)
   }
 
@@ -747,7 +747,7 @@ class ExecutorAllocationManagerSuite
 
     // Schedule again to recalculate the numExecutorsTarget after executor is timeout
     schedule(manager)
-    //Verify that current number of executors should be ramp down when executor is timeout
+    // Verify that current number of executors should be ramp down when executor is timeout
     assert(numExecutorsTarget(manager) === 2)
   }
 

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -751,7 +751,9 @@ class ExecutorAllocationManagerSuite
     assert(numExecutorsTarget(manager) === 2)
   }
 
-  private def createSparkContext(minExecutors: Int = 1, maxExecutors: Int = 5,
+  private def createSparkContext(
+      minExecutors: Int = 1,
+      maxExecutors: Int = 5,
       initialExecutors: Int = 1): SparkContext = {
     val conf = new SparkConf()
       .setMaster("local")

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -701,7 +701,7 @@ class ExecutorAllocationManagerSuite
     assert(numExecutorsTarget(manager) === 16)
   }
 
-  test("avoid ramp down initial executors when first job is submitted") {
+  test("avoid ramp down initial executors until first job is submitted") {
     sc = createSparkContext(2, 5, 3)
     val manager = sc.executorAllocationManager.get
     val clock = new ManualClock(10000L)
@@ -723,7 +723,7 @@ class ExecutorAllocationManagerSuite
     assert(numExecutorsTarget(manager) === 2)
   }
 
-  test("avoid ramp down initial executors when idle executor is timeout") {
+  test("avoid ramp down initial executors until idle executor is timeout") {
     sc = createSparkContext(2, 5, 3)
     val manager = sc.executorAllocationManager.get
     val clock = new ManualClock(10000L)


### PR DESCRIPTION
This patch propose to lazy start the scheduler for dynamic allocation to avoid fast ramp down executor numbers is load is less.

This implementation will:
1. immediately start the scheduler is `numExecutorsTarget` is 0, this is the expected behavior.
2. if `numExecutorsTarget` is not zero, start the scheduler until the number is satisfied, if the load is less, this initial started executors will last for at least 60 seconds, user will have a window to submit a job, no need to revamp the executors.
3. if `numExecutorsTarget` is not satisfied until the timeout, this means resource is not enough, the scheduler will start until this timeout, will not wait infinitely.

Please help to review, thanks a lot.
