### PR TITLE
[YARN][Minor] Swallow the interrupted exception in yarn client

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -756,7 +756,12 @@ private[spark] class Client(
     val interval = sparkConf.getLong("spark.yarn.report.interval", 1000)
     var lastState: YarnApplicationState = null
     while (true) {
-      Thread.sleep(interval)
+      try {
+        Thread.sleep(interval)
+      } catch {
+        case i: InterruptedException => // Swallow the InterruptedException
+      }
+
       val report: ApplicationReport =
         try {
           getApplicationReport(appId)


### PR DESCRIPTION
```
java.lang.InterruptedException: sleep interrupted
  at java.lang.Thread.sleep(Native Method)
  at org.apache.spark.deploy.yarn.Client.monitorApplication(Client.scala:572)
  at org.apache.spark.scheduler.cluster.YarnClientSchedulerBackend$$anon$1.run(YarnClientSchedulerBackend.scala:131)
```
