### PR TITLE
[SPARK-6307][Core] Coalesce RDDs before RDD.cartesian

### DIFF
--- a/core/src/test/scala/org/apache/spark/metrics/InputOutputMetricsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/metrics/InputOutputMetricsSuite.scala
@@ -132,7 +132,7 @@ class InputOutputMetricsSuite extends FunSuite with SharedSparkContext
     assert(cartRead != 0)
     assert(bytesRead != 0)
     // We read from the first rdd of the cartesian once per partition.
-    assert(cartRead == bytesRead * numPartitions)
+    assert(cartRead == bytesRead + bytesRead2)
   }
 
   test("input metrics for new Hadoop API with coalesce") {
@@ -286,7 +286,7 @@ class InputOutputMetricsSuite extends FunSuite with SharedSparkContext
     // As a result we read from the second partition n times where n is the number of keys in
     // p1. Thus the math below for the test.
     assert(cartesianBytes != 0)
-    assert(cartesianBytes == firstSize * numPartitions + (cartVector.length  * secondSize))
+    assert(cartesianBytes == firstSize + secondSize)
   }
 
   private def runAndReturnBytesRead(job: => Unit): Long = {


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-6307 and https://issues.apache.org/jira/browse/SPARK-6922

Alternative approach to this issue. Ref. #5572.

This PR tries to coalesce RDDs before `RDD.cartesian`. It also implements the idea 1 discussed in #5572. So in `cartesian` we will fetch each partition in RDD2 once for each partition in RDD1.

For performance test, using the same example codes in #5572, it costs about 4s.

cc @tbertelsen, @squito, @cloud-fan.
