### PR TITLE
[SPARK-7915] [SQL] Support specifying the column list for target table in CTAS

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -365,23 +365,18 @@ class SQLQuerySuite extends QueryTest {
   test("specifying the column list for CTAS") {
     Seq((1, "111111"), (2, "222222")).toDF("key", "value").registerTempTable("mytable1")
 
-    try {
-      sql("create table gen__tmp(a int, b string) as select key, value from mytable1")
-      checkAnswer(
-        sql("SELECT a, b from gen__tmp"),
-        sql("select key, value from src").collect())
-    } finally {
-      sql("DROP TABLE gen__tmp")
-    }
+    sql("create table gen__tmp(a int, b string) as select key, value from mytable1")
+    checkAnswer(
+      sql("SELECT a, b from gen__tmp"),
+      sql("select key, value from src").collect())
+    sql("DROP TABLE gen__tmp")
 
-    try {
-      sql("create table gen__tmp(a double, b double) as select key, value from mytable1")
-      checkAnswer(
-        sql("SELECT a, b from gen__tmp"),
-        sql("select cast(key as double), cast(value as double) from src").collect())
-    } finally {
-      sql("DROP TABLE gen__tmp")
-    }
+    sql("create table gen__tmp(a double, b double) as select key, value from mytable1")
+    checkAnswer(
+      sql("SELECT a, b from gen__tmp"),
+      sql("select cast(key as double), cast(value as double) from src").collect())
+    sql("DROP TABLE gen__tmp")
+
     sql("drop table mytable1")
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -368,13 +368,13 @@ class SQLQuerySuite extends QueryTest {
     sql("create table gen__tmp(a int, b string) as select key, value from mytable1")
     checkAnswer(
       sql("SELECT a, b from gen__tmp"),
-      sql("select key, value from src").collect())
+      sql("select key, value from mytable1").collect())
     sql("DROP TABLE gen__tmp")
 
     sql("create table gen__tmp(a double, b double) as select key, value from mytable1")
     checkAnswer(
       sql("SELECT a, b from gen__tmp"),
-      sql("select cast(key as double), cast(value as double) from src").collect())
+      sql("select cast(key as double), cast(value as double) from mytable1").collect())
     sql("DROP TABLE gen__tmp")
 
     sql("drop table mytable1")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -362,6 +362,29 @@ class SQLQuerySuite extends QueryTest {
     }
   }
 
+  test("specifying the column list for CTAS") {
+    Seq((1, "111111"), (2, "222222")).toDF("key", "value").registerTempTable("mytable1")
+
+    try {
+      sql("create table gen__tmp(a int, b string) as select key, value from mytable1")
+      checkAnswer(
+        sql("SELECT a, b from gen__tmp"),
+        sql("select key, value from src").collect())
+    } finally {
+      sql("DROP TABLE gen__tmp")
+    }
+
+    try {
+      sql("create table gen__tmp(a double, b double) as select key, value from mytable1")
+      checkAnswer(
+        sql("SELECT a, b from gen__tmp"),
+        sql("select cast(key as double), cast(value as double) from src").collect())
+    } finally {
+      sql("DROP TABLE gen__tmp")
+    }
+    sql("drop table mytable1")
+  }
+
   test("command substitution") {
     sql("set tbl=src")
     checkAnswer(


### PR DESCRIPTION
```
create table t1 (a int, b string) as select key, value from src;

desc t1;
key int NULL
value   string  NULL
```

Thus Hive doesn't support specifying the column list for target table in CTAS, however, we should either throwing exception explicity, or supporting the this feature, we just pick up the later one, which seems useful and straightforward.
