### PR TITLE
[SPARK-7919][CORE][tests] increase timeout in MasterSuite, make it scaled

### DIFF
--- a/core/src/test/scala/org/apache/spark/deploy/master/MasterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/master/MasterSuite.scala
@@ -167,7 +167,7 @@ class MasterSuite extends FunSuite with Matchers with Eventually {
     val localCluster = new LocalSparkCluster(2, 2, 512, conf)
     localCluster.start()
     try {
-      eventually(timeout(5 seconds), interval(100 milliseconds)) {
+      eventually(timeout(scaled(30 seconds)), interval(100 milliseconds)) {
         val json = Source.fromURL(s"http://localhost:${localCluster.masterWebUIPort}/json")
           .getLines().mkString("\n")
         val JArray(workers) = (parse(json) \ "workers")


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-7919

test fails sometimes on some of our slower build machines, so up the timeout.  Also add in a hook for scalatest to [scale the timeouts](http://doc.scalatest.org/2.0/index.html#org.scalatest.concurrent.ScaledTimeSpans).  That way the timeouts can be extended on slow machines, rather than a code change required for the slowest possible machine.
