### PR TITLE
[Docs] Fixing broken "IDE setup" link in the Building Spark documentation.

### DIFF
--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -176,7 +176,7 @@ Thus, the full flow for running continuous-compilation of the `core` submodule m
 # Building Spark with IntelliJ IDEA or Eclipse
 
 For help in setting up IntelliJ IDEA or Eclipse for Spark development, and troubleshooting, refer to the
-[wiki page for IDE setup](https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark#ContributingtoSpark-IDESetup).
+[wiki page for IDE setup](https://cwiki.apache.org/confluence/display/SPARK/Useful+Developer+Tools#UsefulDeveloperTools-IDESetup).
 
 # Running Java 8 Test Suites
 


### PR DESCRIPTION
The location of the IDE setup information has changed, so this just updates the link on the Building Spark page.
