### PR TITLE
[MINOR] fix RegressionEvaluator doc

### DIFF
--- a/python/pyspark/ml/evaluation.py
+++ b/python/pyspark/ml/evaluation.py
@@ -205,7 +205,7 @@ class RegressionEvaluator(JavaEvaluator, HasLabelCol, HasPredictionCol):
     def setParams(self, predictionCol="prediction", labelCol="label",
                   metricName="rmse"):
         """
-        setParams(self, predictionCol="prediction", labelCol="label",
+        setParams(self, predictionCol="prediction", labelCol="label", \
                   metricName="rmse")
         Sets params for regression evaluator.
         """


### PR DESCRIPTION
`make clean html` under `python/doc` returns

```
/Users/meng/src/spark/python/pyspark/ml/evaluation.py:docstring of pyspark.ml.evaluation.RegressionEvaluator.setParams:3: WARNING: Definition list ends without a blank line; unexpected unindent.
```

@harsha2010
