### PR TITLE
[SPARK-7890] [DOCS] Document that Spark 2.11 now supports Kafka

### DIFF
--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -130,10 +130,6 @@ To produce a Spark package compiled with Scala 2.11, use the `-Dscala-2.11` prop
     dev/change-version-to-2.11.sh
     mvn -Pyarn -Phadoop-2.4 -Dscala-2.11 -DskipTests clean package
 
-Scala 2.11 support in Spark does not support a few features due to dependencies
-which are themselves not Scala 2.11 ready. Specifically, Spark's external 
-Kafka library and JDBC component are not yet supported in Scala 2.11 builds.
-
 # Spark Tests in Maven
 
 Tests are run by default via the [ScalaTest Maven plugin](http://www.scalatest.org/user_guide/using_the_scalatest_maven_plugin).

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -130,7 +130,7 @@ To produce a Spark package compiled with Scala 2.11, use the `-Dscala-2.11` prop
     dev/change-version-to-2.11.sh
     mvn -Pyarn -Phadoop-2.4 -Dscala-2.11 -DskipTests clean package
 
-Scala 2.11 support in Spark does not yet support Spark's external JDBC component.
+Spark does not yet support its JDBC component for Scala 2.11.
 
 # Spark Tests in Maven
 

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -130,6 +130,8 @@ To produce a Spark package compiled with Scala 2.11, use the `-Dscala-2.11` prop
     dev/change-version-to-2.11.sh
     mvn -Pyarn -Phadoop-2.4 -Dscala-2.11 -DskipTests clean package
 
+Scala 2.11 support in Spark does not yet support Spark's external JDBC component.
+
 # Spark Tests in Maven
 
 Tests are run by default via the [ScalaTest Maven plugin](http://www.scalatest.org/user_guide/using_the_scalatest_maven_plugin).


### PR DESCRIPTION
Remove caveat about Kafka / JDBC not being supported for Scala 2.11
