### PR TITLE
[SPARK-7935][SQL]change sparkContext in sparkPlan as val

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -47,7 +47,7 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
    */
   @transient
   protected[spark] final val sqlContext = SparkPlan.currentContext.get()
-
+  @transient
   protected val sparkContext = sqlContext.sparkContext
 
   // sqlContext will be null when we are being deserialized on the slaves.  In this instance

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -48,7 +48,7 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
   @transient
   protected[spark] final val sqlContext = SparkPlan.currentContext.get()
 
-  protected def sparkContext = sqlContext.sparkContext
+  protected val sparkContext = sqlContext.sparkContext
 
   // sqlContext will be null when we are being deserialized on the slaves.  In this instance
   // the value of codegenEnabled will be set by the desserializer after the constructor has run.


### PR DESCRIPTION
I thinke sparkContext  is better defined as val than a function
