### PR TITLE
[SPARK-7936] [SQL] Add configuration for initial size of hash for aggregation and limit

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
@@ -420,6 +420,16 @@ private[spark] object SQLConf {
   val USE_SQL_AGGREGATE2 = booleanConf("spark.sql.useAggregate2",
     defaultValue = Some(true), doc = "<TODO>")
 
+  val AGGREGATION_HASH_INIT_SIZE = intConf(
+    "spark.sql.aggregation.hash.initSize",
+    defaultValue = Some(16384),
+    doc = "initialize size of hash for (partial or full) aggregation")
+
+  val PARTIAL_AGGREGATION_MAX_ENTRY = intConf(
+    "spark.sql.partial.aggregation.maxEntry",
+    defaultValue = Some(-1),
+    doc = "maximum size of hash for partial aggregation. -1 for unlimited, which is default")
+
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"
   }
@@ -526,6 +536,10 @@ private[sql] class SQLConf extends Serializable with CatalystConf {
     getConf(DATAFRAME_SELF_JOIN_AUTO_RESOLVE_AMBIGUITY)
 
   private[spark] def dataFrameRetainGroupColumns: Boolean = getConf(DATAFRAME_RETAIN_GROUP_COLUMNS)
+
+  private[spark] def aggregationHashInitSize: Int = getConf(AGGREGATION_HASH_INIT_SIZE)
+
+  private[spark] def partialAggregationMaxEntry: Int = getConf(PARTIAL_AGGREGATION_MAX_ENTRY)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
@@ -426,7 +426,7 @@ private[spark] object SQLConf {
     doc = "initialize size of hash for (partial or full) aggregation")
 
   val PARTIAL_AGGREGATION_MAX_ENTRY = intConf(
-    "spark.sql.partial.aggregation.maxEntry",
+    "spark.sql.partialAggregation.maxEntry",
     defaultValue = Some(-1),
     doc = "maximum size of hash for partial aggregation. -1 for unlimited, which is default")
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/Aggregate.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/Aggregate.scala
@@ -160,9 +160,11 @@ case class Aggregate(
       }
     } else {
       child.execute().mapPartitions { iter =>
-        val hashTable = if (initSize < 0)
-          new java.util.HashMap[InternalRow, Array[AggregateFunction1]]() else
+        val hashTable = if (initSize < 0) {
+          new java.util.HashMap[InternalRow, Array[AggregateFunction1]]()
+        } else {
           new java.util.HashMap[InternalRow, Array[AggregateFunction1]](initSize)
+        }
 
         val groupingProjection = new InterpretedMutableProjection(groupingExpressions, child.output)
 


### PR DESCRIPTION
Added two configuration 
1. spark.sql.aggregation.hash.initSize : initialize size of hash. Applied to both(final, partial) aggregation
2. spark.sql.partial.aggregation.maxEntry : max size of hash for partial aggregation. should not be used for final aggregation
