### PR TITLE
Spark history log show IOException Error while a application is running

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/ReplayListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ReplayListenerBus.scala
@@ -70,7 +70,13 @@ private[spark] class ReplayListenerBus extends SparkListenerBus with Logging {
       }
     } catch {
       case ioe: IOException =>
-        throw ioe
+        // we need to ignore exception of reading chunk fail while an app is still running
+        if(!maybeTruncated) {
+          throw ioe
+        } else {
+          logWarning(s"Got IOException from log file $sourceName" +
+            s" at line $lineNumber, the application maybe still running. ")
+        }
       case e: Exception =>
         logError(s"Exception parsing Spark event log: $sourceName", e)
         logError(s"Malformed line #$lineNumber: $currentLine\n")


### PR DESCRIPTION
After adding SPARK-6197 as a patch to spark-1.3.1, I found it no longer
prints out an Error Exception in history log after a application is
failed. But while a application is running, it may still print out a
IOException Error, like this:

ERROR FsHistoryProvider: Failed to load application log data from FileStatus{path=hdfs://yarncluster/history/sparkhistory/application_1426843812583_0085.snappy.inprogress; isDirectory=false; length=270; replication=2; blocksize=134217728; modification_time=1432797327877; access_time=1432797327877; owner=hxia; group=supergroup; permission=rwxrwx---; isSymlink=false}.
java.io.IOException: failed to read chunk
