### PR TITLE
[SPARK-7221] [Streaming] Expose the current processed file name of FileInputDStream to the users

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
@@ -815,6 +815,21 @@ abstract class DStream[T: ClassTag] (
   }
 
   /**
+   * Save filenames of Dstream to a set provided in the argument
+   * by parsing the .toDebugString output of RDD and searching 
+   * for the pattern ":/" ( as in file:/, hdfs:/ etc.)
+   * The set `x` should be mutable for the method to function.
+   */
+  def generateFileList(x:Set[String]) : Unit = { 
+    this.foreachRDD{ rdd  => {
+        if(rdd.count > 0){
+          val files = rdd.toDebugString.stripMargin.split("\n").filter(_.contains(":/"))
+          for(ms <- files) x += ms.split(" ")(2)
+        }
+      }
+  } }
+
+  /**
    * Register this streaming as an output stream. This would ensure that RDDs of this
    * DStream will be generated.
    */

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
@@ -20,7 +20,7 @@ package org.apache.spark.streaming.dstream
 
 import java.io.{IOException, ObjectInputStream, ObjectOutputStream}
 
-import scala.collection.mutable.HashMap
+import scala.collection.mutable.{HashMap, Set}
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 import scala.util.matching.Regex


### PR DESCRIPTION
Created a public method called getFileList which takes a mutable set as an argument and adds the file names from which the Dstream is generated to this set. 
File names are obtained by parsing the .toDebugString of each RDD in the Dstream and searching for the pattern " :/ " as in file:/, hdfs:/ etc.
