### PR TITLE
[SPARK-7945][CORE]Do trim to values in properties file

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -297,7 +297,7 @@ abstract class AbstractCommandBuilder {
         fd = new FileInputStream(propsFile);
         props.load(new InputStreamReader(fd, "UTF-8"));
         for (Map.Entry<Object, Object> e : props.entrySet()) {
-            e.setValue(e.getValue().toString().trim());
+          e.setValue(e.getValue().toString().trim());
         }
       } finally {
         if (fd != null) {

--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -295,7 +295,11 @@ abstract class AbstractCommandBuilder {
       FileInputStream fd = null;
       try {
         fd = new FileInputStream(propsFile);
-        props.load(new InputStreamReader(fd, "UTF-8"));
+        Properties rawProps = new Properties();
+        rawProps.load(new InputStreamReader(fd, "UTF-8"));
+        for (String str : rawProps.stringPropertyNames()) {
+          props.setProperty(str, rawProps.getProperty(str).trim());
+        }
       } finally {
         if (fd != null) {
           try {

--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -295,10 +295,9 @@ abstract class AbstractCommandBuilder {
       FileInputStream fd = null;
       try {
         fd = new FileInputStream(propsFile);
-        Properties rawProps = new Properties();
-        rawProps.load(new InputStreamReader(fd, "UTF-8"));
-        for (String str : rawProps.stringPropertyNames()) {
-          props.setProperty(str, rawProps.getProperty(str).trim());
+        props.load(new InputStreamReader(fd, "UTF-8"));
+        for (Map.Entry<Object, Object> e : props.entrySet()) {
+            e.setValue(e.getValue().toString().trim());
         }
       } finally {
         if (fd != null) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-7945

Now applications submited by org.apache.spark.launcher.Main read properties file without doing trim to values in it.
If user left a space after a value(say spark.driver.extraClassPath) then it probably affect global functions(like some jar could not be included in the classpath), so we should do it like Utils.getPropertiesFromFile.
