### PR TITLE
[SPARK-7952][SPARK-7984][SQL] equality check between boolean type and numeric type is broken.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
@@ -482,7 +482,7 @@ trait HiveTypeCoercion {
   }
 
   /**
-   * Changes numeric values to booleans so that expressions like true = 1 can be Evaluated.
+   * Changes numeric values to booleans so that expressions like true = 1 can be evaluated.
    */
   object BooleanEqualization extends Rule[LogicalPlan] {
     val trueValue = Literal(new java.math.BigDecimal(1))
@@ -519,7 +519,8 @@ trait HiveTypeCoercion {
       // Skip nodes who's children have not been resolved yet.
       case e if !e.childrenResolved => e
 
-      // Hive treats (true = 1) as true and (false = 0) as true.
+      // Hive treats (true = 1) as true and (false = 0) as true,
+      // all other cases are considered as false.
       case EqualTo(l @ BooleanType(), r) if r.dataType.isInstanceOf[NumericType] =>
         transform(l, r)
       case EqualTo(l, r @ BooleanType()) if l.dataType.isInstanceOf[NumericType] =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
@@ -488,8 +488,6 @@ trait HiveTypeCoercion {
     val trueValue = Literal(new java.math.BigDecimal(1))
     val falseValue = Literal(new java.math.BigDecimal(0))
 
-    private def isNull(expr: Expression) = EqualNullSafe(expr, Literal.create(null, expr.dataType))
-
     private def buildCaseKeyWhen(booleanExpr: Expression, numericExpr: Expression) = {
       CaseKeyWhen(Cast(numericExpr, DecimalType.Unlimited),
         Seq(
@@ -500,17 +498,15 @@ trait HiveTypeCoercion {
 
     private def transform(booleanExpr: Expression, numericExpr: Expression) = {
       CaseWhen(Seq(
-        isNull(booleanExpr), Literal.create(null, BooleanType),
-        isNull(numericExpr), Literal.create(null, BooleanType),
+        Or(IsNull(booleanExpr), IsNull(numericExpr)), Literal.create(null, BooleanType),
         buildCaseKeyWhen(booleanExpr, numericExpr)
       ))
     }
 
     private def transformNullSafe(booleanExpr: Expression, numericExpr: Expression) = {
       CaseWhen(Seq(
-        And(isNull(booleanExpr), isNull(numericExpr)), Literal(true),
-        isNull(booleanExpr), Literal(false),
-        isNull(numericExpr), Literal(false),
+        And(IsNull(booleanExpr), IsNull(numericExpr)), Literal(true),
+        Or(IsNull(booleanExpr), IsNull(numericExpr)), Literal(false),
         buildCaseKeyWhen(booleanExpr, numericExpr)
       ))
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
@@ -488,9 +488,9 @@ trait HiveTypeCoercion {
     val trueValue = Literal(new java.math.BigDecimal(1))
     val falseValue = Literal(new java.math.BigDecimal(0))
 
-    def isNull(expr: Expression) = EqualNullSafe(expr, Literal.create(null, expr.dataType))
+    private def isNull(expr: Expression) = EqualNullSafe(expr, Literal.create(null, expr.dataType))
 
-    def buildCaseKeyWhen(booleanExpr: Expression, numericExpr: Expression) = {
+    private def buildCaseKeyWhen(booleanExpr: Expression, numericExpr: Expression) = {
       CaseKeyWhen(Cast(numericExpr, DecimalType.Unlimited),
         Seq(
           trueValue, booleanExpr,
@@ -498,7 +498,7 @@ trait HiveTypeCoercion {
           Literal(false)))
     }
 
-    def transform(booleanExpr: Expression, numericExpr: Expression) = {
+    private def transform(booleanExpr: Expression, numericExpr: Expression) = {
       CaseWhen(Seq(
         isNull(booleanExpr), Literal.create(null, BooleanType),
         isNull(numericExpr), Literal.create(null, BooleanType),
@@ -506,7 +506,7 @@ trait HiveTypeCoercion {
       ))
     }
 
-    def transformNullSafe(booleanExpr: Expression, numericExpr: Expression) = {
+    private def transformNullSafe(booleanExpr: Expression, numericExpr: Expression) = {
       CaseWhen(Seq(
         And(isNull(booleanExpr), isNull(numericExpr)), Literal(true),
         isNull(booleanExpr), Literal(false),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
@@ -497,10 +497,9 @@ trait HiveTypeCoercion {
     }
 
     private def transform(booleanExpr: Expression, numericExpr: Expression) = {
-      CaseWhen(Seq(
-        Or(IsNull(booleanExpr), IsNull(numericExpr)), Literal.create(null, BooleanType),
-        buildCaseKeyWhen(booleanExpr, numericExpr)
-      ))
+      If(Or(IsNull(booleanExpr), IsNull(numericExpr)),
+        Literal.create(null, BooleanType),
+        buildCaseKeyWhen(booleanExpr, numericExpr))
     }
 
     private def transformNullSafe(booleanExpr: Expression, numericExpr: Expression) = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
@@ -119,7 +119,7 @@ trait HiveTypeCoercion {
    * the appropriate numeric equivalent.
    */
   object ConvertNaNs extends Rule[LogicalPlan] {
-    val stringNaN = Literal("NaN")
+    private val stringNaN = Literal("NaN")
 
     def apply(plan: LogicalPlan): LogicalPlan = plan transform {
       case q: LogicalPlan => q transformExpressions {
@@ -349,17 +349,17 @@ trait HiveTypeCoercion {
     import scala.math.{max, min}
 
     // Conversion rules for integer types into fixed-precision decimals
-    val intTypeToFixed: Map[DataType, DecimalType] = Map(
+    private val intTypeToFixed: Map[DataType, DecimalType] = Map(
       ByteType -> DecimalType(3, 0),
       ShortType -> DecimalType(5, 0),
       IntegerType -> DecimalType(10, 0),
       LongType -> DecimalType(20, 0)
     )
 
-    def isFloat(t: DataType): Boolean = t == FloatType || t == DoubleType
+    private def isFloat(t: DataType): Boolean = t == FloatType || t == DoubleType
 
     // Conversion rules for float and double into fixed-precision decimals
-    val floatTypeToFixed: Map[DataType, DecimalType] = Map(
+    private val floatTypeToFixed: Map[DataType, DecimalType] = Map(
       FloatType -> DecimalType(7, 7),
       DoubleType -> DecimalType(15, 15)
     )
@@ -485,8 +485,8 @@ trait HiveTypeCoercion {
    * Changes numeric values to booleans so that expressions like true = 1 can be evaluated.
    */
   object BooleanEqualization extends Rule[LogicalPlan] {
-    val trueValues = Seq(1.toByte, 1.toShort, 1, 1L, new java.math.BigDecimal(1))
-    val falseValues = Seq(0.toByte, 0.toShort, 0, 0L, new java.math.BigDecimal(0))
+    private val trueValues = Seq(1.toByte, 1.toShort, 1, 1L, new java.math.BigDecimal(1))
+    private val falseValues = Seq(0.toByte, 0.toShort, 0, 0L, new java.math.BigDecimal(0))
 
     private def buildCaseKeyWhen(booleanExpr: Expression, numericExpr: Expression) = {
       CaseKeyWhen(numericExpr, Seq(
@@ -528,11 +528,11 @@ trait HiveTypeCoercion {
       case EqualNullSafe(l @ BooleanType(), Literal(value, _: NumericType))
         if trueValues.contains(value) => And(IsNotNull(l), l)
       case EqualNullSafe(l @ BooleanType(), Literal(value, _: NumericType))
-        if falseValues.contains(value) => Or(IsNull(l), l)
+        if falseValues.contains(value) => And(IsNotNull(l), Not(l))
       case EqualNullSafe(Literal(value, _: NumericType), r @ BooleanType())
         if trueValues.contains(value) => And(IsNotNull(r), r)
       case EqualNullSafe(Literal(value, _: NumericType), r @ BooleanType())
-        if falseValues.contains(value) => Or(IsNull(r), r)
+        if falseValues.contains(value) => And(IsNotNull(r), Not(r))
 
       case EqualTo(l @ BooleanType(), r @ NumericType()) =>
         transform(l , r)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -366,7 +366,7 @@ trait CaseWhenLike extends Expression {
 
   // both then and else val should be considered.
   def valueTypes: Seq[DataType] = (thenList ++ elseValue).map(_.dataType)
-  def valueTypesEqual: Boolean = valueTypes.distinct.size <= 1
+  def valueTypesEqual: Boolean = valueTypes.distinct.size == 1
 
   override def dataType: DataType = {
     if (!resolved) {
@@ -442,7 +442,8 @@ case class CaseKeyWhen(key: Expression, branches: Seq[Expression]) extends CaseW
   override def children: Seq[Expression] = key +: branches
 
   override lazy val resolved: Boolean =
-    childrenResolved && valueTypesEqual
+    childrenResolved && valueTypesEqual &&
+    (key +: whenList).map(_.dataType).distinct.size == 1
 
   /** Written in imperative fashion for performance considerations. */
   override def eval(input: Row): Any = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercionSuite.scala
@@ -20,7 +20,8 @@ package org.apache.spark.sql.catalyst.analysis
 import org.apache.spark.sql.catalyst.plans.PlanTest
 
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, Project}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, LocalRelation, Project}
+import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.types._
 
 class HiveTypeCoercionSuite extends PlanTest {
@@ -104,15 +105,16 @@ class HiveTypeCoercionSuite extends PlanTest {
     widenTest(ArrayType(IntegerType), StructType(Seq()), None)
   }
 
+  private def ruleTest(rule: Rule[LogicalPlan], initial: Expression, transformed: Expression) {
+    val testRelation = LocalRelation(AttributeReference("a", IntegerType)())
+    comparePlans(
+      rule(Project(Seq(Alias(initial, "a")()), testRelation)),
+      Project(Seq(Alias(transformed, "a")()), testRelation))
+  }
+
   test("coalesce casts") {
     val fac = new HiveTypeCoercion { }.FunctionArgumentConversion
-    def ruleTest(initial: Expression, transformed: Expression) {
-      val testRelation = LocalRelation(AttributeReference("a", IntegerType)())
-      comparePlans(
-        fac(Project(Seq(Alias(initial, "a")()), testRelation)),
-        Project(Seq(Alias(transformed, "a")()), testRelation))
-    }
-    ruleTest(
+    ruleTest(fac,
       Coalesce(Literal(1.0)
         :: Literal(1)
         :: Literal.create(1.0, FloatType)
@@ -121,7 +123,7 @@ class HiveTypeCoercionSuite extends PlanTest {
         :: Cast(Literal(1), DoubleType)
         :: Cast(Literal.create(1.0, FloatType), DoubleType)
         :: Nil))
-    ruleTest(
+    ruleTest(fac,
       Coalesce(Literal(1L)
         :: Literal(1)
         :: Literal(new java.math.BigDecimal("1000000000000000000000"))
@@ -130,5 +132,40 @@ class HiveTypeCoercionSuite extends PlanTest {
         :: Cast(Literal(1), DecimalType())
         :: Cast(Literal(new java.math.BigDecimal("1000000000000000000000")), DecimalType())
         :: Nil))
+  }
+
+  test("type coercion for CaseKeyWhen") {
+    val cwc = new HiveTypeCoercion {}.CaseWhenCoercion
+    ruleTest(cwc,
+      CaseKeyWhen(Literal(1.toShort), Seq(Literal(1), Literal("a"))),
+      CaseKeyWhen(Cast(Literal(1.toShort), IntegerType), Seq(Literal(1), Literal("a")))
+    )
+    // Will remove exception expectation in PR#6405
+    intercept[RuntimeException] {
+      ruleTest(cwc,
+        CaseKeyWhen(Literal(true), Seq(Literal(1), Literal("a"))),
+        CaseKeyWhen(Literal(true), Seq(Literal(1), Literal("a")))
+      )
+    }
+  }
+
+  test("type coercion simplification for equal to") {
+    val be = new HiveTypeCoercion {}.BooleanEqualization
+    ruleTest(be,
+      EqualTo(Literal(true), Literal(1)),
+      Literal(true)
+    )
+    ruleTest(be,
+      EqualTo(Literal(true), Literal(0)),
+      Not(Literal(true))
+    )
+    ruleTest(be,
+      EqualNullSafe(Literal(true), Literal(1)),
+      And(IsNotNull(Literal(true)), Literal(true))
+    )
+    ruleTest(be,
+      EqualNullSafe(Literal(true), Literal(0)),
+      Or(IsNull(Literal(true)), Literal(true))
+    )
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercionSuite.scala
@@ -165,7 +165,7 @@ class HiveTypeCoercionSuite extends PlanTest {
     )
     ruleTest(be,
       EqualNullSafe(Literal(true), Literal(0)),
-      Or(IsNull(Literal(true)), Literal(true))
+      And(IsNotNull(Literal(true)), Not(Literal(true)))
     )
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvaluationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvaluationSuite.scala
@@ -862,7 +862,7 @@ class ExpressionEvaluationSuite extends ExpressionEvaluationBaseSuite {
     val c5 = 'a.string.at(4)
     val c6 = 'a.string.at(5)
 
-    val literalNull = Literal.create(null, BooleanType)
+    val literalNull = Literal.create(null, IntegerType)
     val literalInt = Literal(1)
     val literalString = Literal("a")
 
@@ -871,12 +871,12 @@ class ExpressionEvaluationSuite extends ExpressionEvaluationBaseSuite {
     checkEvaluation(CaseKeyWhen(c2, Seq(literalInt, c4, c5)), "a", row)
     checkEvaluation(CaseKeyWhen(c2, Seq(c1, c4, c5)), "b", row)
     checkEvaluation(CaseKeyWhen(c4, Seq(literalString, c2, c3)), 1, row)
-    checkEvaluation(CaseKeyWhen(c4, Seq(c1, c3, c5, c2, Literal(3))), 3, row)
+    checkEvaluation(CaseKeyWhen(c4, Seq(c6, c3, c5, c2, Literal(3))), 3, row)
 
     checkEvaluation(CaseKeyWhen(literalInt, Seq(c2, c4, c5)), "a", row)
     checkEvaluation(CaseKeyWhen(literalString, Seq(c5, c2, c4, c3)), 2, row)
-    checkEvaluation(CaseKeyWhen(literalInt, Seq(c5, c2, c4, c3)), null, row)
-    checkEvaluation(CaseKeyWhen(literalNull, Seq(c5, c2, c1, c3)), 2, row)
+    checkEvaluation(CaseKeyWhen(c6, Seq(c5, c2, c4, c3)), null, row)
+    checkEvaluation(CaseKeyWhen(literalNull, Seq(c2, c5, c1, c6)), "c", row)
   }
 
   test("complex type") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -1332,8 +1332,8 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll {
     checkAnswer(sql("SELECT a.`c.b`, `b.$q`[0].`a@!.q`, `q.w`.`w.i&`[0] FROM t"), Row(1, 1, 1))
   }
 
-  test("SPARK-7952: fix the equality check between boolean type and numeric typegd") {
-    val data = Seq(
+  test("SPARK-7952: fix the equality check between boolean and numeric types") {
+    val df = Seq(
       (1, true),
       (0, false),
       (2, true),
@@ -1343,14 +1343,13 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll {
       (0, null),
       (1, null),
       (null, null)
-    )
-    val rowRDD = sparkContext.makeRDD(data).map(r => Row(r._1, r._2))
-    val schema = StructType(Seq(StructField("i", IntegerType), StructField("b", BooleanType)))
-    createDataFrame(rowRDD, schema).registerTempTable("t")
+    ).map { case (i, b) =>
+      (i.asInstanceOf[Integer], b.asInstanceOf[java.lang.Boolean])
+    }.toDF("i", "b")
 
-    checkAnswer(sql("select i = b from t"),
+    checkAnswer(df.select('i === 'b),
       Seq(true, true, false, false, null, null, null, null, null).map(Row(_)))
-    checkAnswer(sql("select i <=> b from t"),
+    checkAnswer(df.select('i <=> 'b),
       Seq(true, true, false, false, false, false, false, false, true).map(Row(_)))
   }
 }


### PR DESCRIPTION
The origin code has several problems:
- `true <=> 1` will return false as we didn't set a rule to handle it.
- `true = a` where `a` is not `Literal` and its value is 1, will return false as we only handle literal values.
