### PR TITLE
[SPARK-7558] Guard against direct uses of FunSuite / FunSuiteLike

### DIFF
--- a/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
@@ -17,12 +17,14 @@
 
 package org.apache.spark
 
+// scalastyle:off
 import org.scalatest.{FunSuite, Outcome}
 
 /**
  * Base abstract class for all unit tests in Spark for handling common functionality.
  */
 private[spark] abstract class SparkFunSuite extends FunSuite with Logging {
+// scalastyle:on
 
   /**
    * Log the suite name and the test name before and after each test.

--- a/external/flume-sink/src/test/scala/org/apache/spark/streaming/flume/sink/SparkSinkSuite.scala
+++ b/external/flume-sink/src/test/scala/org/apache/spark/streaming/flume/sink/SparkSinkSuite.scala
@@ -31,9 +31,18 @@ import org.apache.flume.Context
 import org.apache.flume.channel.MemoryChannel
 import org.apache.flume.event.EventBuilder
 import org.jboss.netty.channel.socket.nio.NioClientSocketChannelFactory
+
+// Due to MNG-1378, there is not a way to include test dependencies transitively.
+// We cannot include Spark core tests as a dependency here because it depends on
+// Spark core main, which has too many dependencies to require here manually.
+// For this reason, we continue to use FunSuite and ignore the scalastyle checks
+// that fail if this is detected.
+//scalastyle:off
 import org.scalatest.FunSuite
 
 class SparkSinkSuite extends FunSuite {
+//scalastyle:on
+
   val eventsPerBatch = 1000
   val channelCapacity = 5000
 

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -153,4 +153,11 @@
     </parameters>
   </check>
   <check level="error" class="org.scalastyle.scalariform.NotImplementedErrorUsage" enabled="true"></check>
+  <!-- As of SPARK-7558, all tests in Spark should extend o.a.s.SparkFunSuite instead of FunSuited directly -->
+  <check level="error" class="org.scalastyle.scalariform.TokenChecker" enabled="true">
+   <parameters>
+    <parameter name="regex">^FunSuite[A-Za-z]*$</parameter>
+   </parameters>
+   <customMessage>Tests must extend org.apache.spark.SparkFunSuite instead.</customMessage>
+  </check>
 </scalastyle>


### PR DESCRIPTION
This is a follow-up patch to #6441.
