### PR TITLE
[SPARK-7968][CORE] Rename minPartitions to maxPartitions in wholeTextFiles/binaryFiles

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -825,11 +825,11 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
    *
    * @note Small files are preferred, large file is also allowable, but may cause bad performance.
    *
-   * @param minPartitions A suggestion value of the minimal splitting number for input data.
+   * @param maxPartitions A suggestion value of the maximal splitting number for input data.
    */
   def wholeTextFiles(
       path: String,
-      minPartitions: Int = defaultMinPartitions): RDD[(String, String)] = withScope {
+      maxPartitions: Int = defaultMinPartitions): RDD[(String, String)] = withScope {
     assertNotStopped()
     val job = new NewHadoopJob(hadoopConfiguration)
     // Use setInputPaths so that wholeTextFiles aligns with hadoopFile/textFile in taking
@@ -842,7 +842,7 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
       classOf[String],
       classOf[String],
       updateConf,
-      minPartitions).setName(path)
+      maxPartitions).setName(path)
   }
 
 
@@ -871,14 +871,14 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
    *   (a-hdfs-path/part-nnnnn, its content)
    * }}}
    *
-   * @param minPartitions A suggestion value of the minimal splitting number for input data.
+   * @param maxPartitions A suggestion value of the maximal splitting number for input data.
    *
    * @note Small files are preferred; very large files may cause bad performance.
    */
   @Experimental
   def binaryFiles(
       path: String,
-      minPartitions: Int = defaultMinPartitions): RDD[(String, PortableDataStream)] = withScope {
+      maxPartitions: Int = defaultMinPartitions): RDD[(String, PortableDataStream)] = withScope {
     assertNotStopped()
     val job = new NewHadoopJob(hadoopConfiguration)
     // Use setInputPaths so that binaryFiles aligns with hadoopFile/textFile in taking
@@ -891,7 +891,7 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
       classOf[String],
       classOf[PortableDataStream],
       updateConf,
-      minPartitions).setName(path)
+      maxPartitions).setName(path)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/input/PortableDataStream.scala
+++ b/core/src/main/scala/org/apache/spark/input/PortableDataStream.scala
@@ -43,7 +43,7 @@ private[spark] abstract class StreamFileInputFormat[T]
    * Allow minPartitions set by end-user in order to keep compatibility with old Hadoop API
    * which is set through setMaxSplitSize
    */
-  def setMinPartitions(context: JobContext, minPartitions: Int) {
+  def setMaxPartitions(context: JobContext, maxPartitions: Int) {
     val files = listStatus(context)
     val totalLen = files.map { file =>
       if (file.isDir) 0L else file.getLen

--- a/core/src/main/scala/org/apache/spark/input/WholeTextFileInputFormat.scala
+++ b/core/src/main/scala/org/apache/spark/input/WholeTextFileInputFormat.scala
@@ -51,13 +51,13 @@ private[spark] class WholeTextFileInputFormat
    * Allow minPartitions set by end-user in order to keep compatibility with old Hadoop API,
    * which is set through setMaxSplitSize
    */
-  def setMinPartitions(context: JobContext, minPartitions: Int) {
+  def setMaxPartitions(context: JobContext, maxPartitions: Int) {
     val files = listStatus(context)
     val totalLen = files.map { file =>
       if (file.isDir) 0L else file.getLen
     }.sum
     val maxSplitSize = Math.ceil(totalLen * 1.0 /
-      (if (minPartitions == 0) 1 else minPartitions)).toLong
+      (if (maxPartitions == 0) 1 else maxPartitions)).toLong
     super.setMaxSplitSize(maxSplitSize)
   }
 }

--- a/core/src/main/scala/org/apache/spark/rdd/BinaryFileRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/BinaryFileRDD.scala
@@ -29,7 +29,7 @@ private[spark] class BinaryFileRDD[T](
     keyClass: Class[String],
     valueClass: Class[T],
     @transient conf: Configuration,
-    minPartitions: Int)
+    maxPartitions: Int)
   extends NewHadoopRDD[String, T](sc, inputFormatClass, keyClass, valueClass, conf) {
 
   override def getPartitions: Array[Partition] = {
@@ -40,7 +40,7 @@ private[spark] class BinaryFileRDD[T](
       case _ =>
     }
     val jobContext = newJobContext(conf, jobId)
-    inputFormat.setMinPartitions(jobContext, minPartitions)
+    inputFormat.setMaxPartitions(jobContext, maxPartitions)
     val rawSplits = inputFormat.getSplits(jobContext).toArray
     val result = new Array[Partition](rawSplits.size)
     for (i <- 0 until rawSplits.size) {

--- a/core/src/main/scala/org/apache/spark/rdd/NewHadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/NewHadoopRDD.scala
@@ -252,7 +252,7 @@ private[spark] class WholeTextFileRDD(
     keyClass: Class[String],
     valueClass: Class[String],
     @transient conf: Configuration,
-    minPartitions: Int)
+    maxPartitions: Int)
   extends NewHadoopRDD[String, String](sc, inputFormatClass, keyClass, valueClass, conf) {
 
   override def getPartitions: Array[Partition] = {
@@ -263,7 +263,7 @@ private[spark] class WholeTextFileRDD(
       case _ =>
     }
     val jobContext = newJobContext(conf, jobId)
-    inputFormat.setMinPartitions(jobContext, minPartitions)
+    inputFormat.setMaxPartitions(jobContext, maxPartitions)
     val rawSplits = inputFormat.getSplits(jobContext).toArray
     val result = new Array[Partition](rawSplits.size)
     for (i <- 0 until rawSplits.size) {


### PR DESCRIPTION
The actual number of partition(task) in wholeTextFiles/binaryFiles is less than or equal to minPartitions, so maxPartitions is better than minPartitions.
