### PR TITLE
[MINOR] Enable PySpark SQL readerwriter and window tests

### DIFF
--- a/python/run-tests
+++ b/python/run-tests
@@ -76,6 +76,8 @@ function run_sql_tests() {
     run_test "pyspark.sql.dataframe"
     run_test "pyspark.sql.group"
     run_test "pyspark.sql.functions"
+    run_test "pyspark.sql.readwriter"
+    run_test "pyspark.sql.window"
     run_test "pyspark.sql.tests"
 }
 


### PR DESCRIPTION
PySpark SQL's `readerwriter` and `window` doctests weren't being run by our test runner script; this patch re-enables them.
