### PR TITLE
[SPARK-8010][SQL]Promote types to StringType as implicit conversion in non-binary expression of HiveTypeCoercion

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
@@ -68,27 +68,14 @@ object HiveTypeCoercion {
   }
 
   /**
-   * Implicit promote the AtomicType to StringType if
-   * one of the data type in (dt1, dt2) is StringType, and the other is not either
-   * BooleanType or BinaryType, the TightestCommonType should be StringType
-   * eg: 1. CaseWhenLike  case when ... then dt1 else dt2 end
-   *     2. Coalesce(null, dt1, dt2)
+   * Similar to [[findTightestCommonType]], if can not find the TightestCommonType, try to use
+   * [[findTightestCommonTypeToString]] to find the TightestCommonType.
    */
-  private def promoteToStringType(t1: DataType, t2: DataType): Option[DataType] = (t1, t2) match {
-    case (t1: StringType, t2: AtomicType) if (t2 != BinaryType && t2 != BooleanType) =>
-        Some(StringType)
-
-    case (t1: AtomicType, t2: StringType) if (t1 != BinaryType && t1 != BooleanType) =>
-        Some(StringType)
-
-    case _ => None
-  }
-
   private def findTightestCommonTypeAndPromoteToString(types: Seq[DataType]): Option[DataType] = {
     types.foldLeft[Option[DataType]](Some(NullType))((r, c) => r match {
       case None => None
       case Some(d) =>
-        findTightestCommonTypeOfTwo(d, c).orElse(promoteToStringType(d, c))
+        findTightestCommonTypeOfTwo(d, c).orElse(findTightestCommonTypeToString(d, c))
     })
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
@@ -68,19 +68,18 @@ object HiveTypeCoercion {
   }
 
   /**
-   * Implicit promote the DataType to StringType if
+   * Implicit promote the AtomicType to StringType if
    * one of the data type in (dt1, dt2) is StringType, and the other is not either
    * BooleanType or BinaryType, the TightestCommonType should be StringType
    * eg: 1. CaseWhenLike  case when ... then dt1 else dt2 end
    *     2. Coalesce(null, dt1, dt2)
-
    */
   val promoteToStringTypeOfTwo: (DataType, DataType) => Option[DataType] = {
-    case (t1: StringType, t2: DataType) if (t2 != BinaryType && t2 != BooleanType) =>
-      Some(StringType)
+    case (t1: StringType, t2: AtomicType) if (t2 != BinaryType && t2 != BooleanType) =>
+        Some(StringType)
 
-    case (t1: DataType, t2: StringType) if (t1 != BinaryType && t1 != BooleanType) =>
-      Some(StringType)
+    case (t1: AtomicType, t2: StringType) if (t1 != BinaryType && t1 != BooleanType) =>
+        Some(StringType)
 
     case _ => None
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
@@ -85,20 +85,11 @@ object HiveTypeCoercion {
     case _ => None
   }
 
-  /**
-   * Find the tightest common type of a set of types by continuously applying
-   * `findTightestCommonTypeOfTwo` on these types.
-   */
   private def findTightestCommonTypeAndTryPromoteToString(types: Seq[DataType]) = {
     types.foldLeft[Option[DataType]](Some(NullType))((r, c) => r match {
       case None => None
       case Some(d) =>
-        val dt = findTightestCommonTypeOfTwo(d, c)
-        if (dt == None) {
-          promoteToStringTypeOfTwo(d, c)
-        } else {
-          dt
-        }
+        findTightestCommonTypeOfTwo(d, c).orElse(promoteToStringTypeOfTwo(d, c))
     })
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -45,6 +45,16 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll with SQLTestUtils {
       Row("one", 6) :: Row("three", 3) :: Nil)
   }
 
+  test("SPARK-8010: promote numeric to string") {
+    val df = Seq((1,1)).toDF("key","value")
+    df.registerTempTable("src")
+    val queryCaseWhen = sql("select case when true then 1.0 else '1' end from src ")
+    val queryCoalesce = sql("select coalesce(null, 1, '1') from src ")
+
+    checkAnswer(queryCaseWhen, Row("1.0") :: Nil)
+    checkAnswer(queryCoalesce, Row("1") :: Nil)
+  }
+
   test("SPARK-6743: no columns from cache") {
     Seq(
       (83, 0, 38),

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -46,7 +46,7 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll with SQLTestUtils {
   }
 
   test("SPARK-8010: promote numeric to string") {
-    val df = Seq((1,1)).toDF("key","value")
+    val df = Seq((1, 1)).toDF("key", "value")
     df.registerTempTable("src")
     val queryCaseWhen = sql("select case when true then 1.0 else '1' end from src ")
     val queryCoalesce = sql("select coalesce(null, 1, '1') from src ")


### PR DESCRIPTION
1. Given a query
   `select coalesce(null, 1, '1') from dual` will cause exception:
   java.lang.RuntimeException: Could not determine return type of Coalesce for IntegerType,StringType
2. Given a query:
   `select case when true then 1 else '1' end from dual` will cause exception:
   java.lang.RuntimeException: Types in CASE WHEN must be the same or coercible to a common type: StringType != IntegerType
   I checked the code, the main cause is the HiveTypeCoercion doesn't do implicit convert when there is a IntegerType and StringType.

Numeric types can be promoted to string type

Hive will always do this implicit conversion.
