### PR TITLE
[SPARK-7980] [SQL] Support SQLContext.range(end)

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -701,6 +701,21 @@ class SQLContext(@transient val sparkContext: SparkContext)
   /**
    * :: Experimental ::
    * Creates a [[DataFrame]] with a single [[LongType]] column named `id`, containing elements
+   * in an range from 0 to `end`(exclusive) with step value 1.
+   *
+   * @since 1.4.0
+   * @group dataframe
+   */
+  @Experimental
+  def range(end: Long): DataFrame = {
+    createDataFrame(
+      sparkContext.range(0, end).map(Row(_)),
+      StructType(StructField("id", LongType, nullable = false) :: Nil))
+  }
+  
+  /**
+   * :: Experimental ::
+   * Creates a [[DataFrame]] with a single [[LongType]] column named `id`, containing elements
    * in an range from `start` to `end`(exclusive) with an step value, with partition number
    * specified.
    *

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -576,5 +576,16 @@ class DataFrameSuite extends QueryTest {
     val res9 = TestSQLContext.range(Long.MaxValue, Long.MinValue, Long.MinValue, 100).select("id")
     assert(res9.count == 2)
     assert(res9.agg(sum("id")).as("sumid").collect() === Seq(Row(Long.MaxValue - 1)))
+
+    //only end provided as argument
+    val res10 = TestSQLContext.range(-10).select("id")
+    assert(res10.count == 0)
+
+    val res11 = TestSQLContext.range(10).select("id")
+    assert(res11.count == 10)
+    assert(res11.agg(sum("id")).as("sumid").collect() === Seq(Row(45)))
+
+    val res12 = TestSQLContext.range(0).select("id")
+    assert(res12.count == 0)
   }
 }


### PR DESCRIPTION
Created an API range(end:Long) which generates dataframe containing entries from 0 to end-1.
Added three tests accordingly in DataFrameSuite.scala.
