### PR TITLE
[SPARK-8021] [SQL] [PYSPARK] make Python read/write API consistent with Scala

### DIFF
--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -259,6 +259,8 @@ class DataFrameWriter(object):
 
         :param cols: name of columns
         """
+        if len(cols) == 1 and isinstance(cols[0], (list, tuple)):
+            cols = cols[0]
         self._jwrite = self._jwrite.partitionBy(_to_seq(self._sqlContext._sc, cols))
         return self
 

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -219,6 +219,7 @@ class DataFrameWriter(object):
         self._sqlContext = df.sql_ctx
         self._jwrite = df._jdf.write()
 
+    @since(1.4)
     def mode(self, saveMode):
         """
         Specifies the behavior when data or table already exists. Options include:


### PR DESCRIPTION
add schema()/format()/options() for reader,  add mode()/format()/options()/partitionBy() for writer

cc @rxin @yhuai  @pwendell 
