### PR TITLE
[SPARK-8032] [PySpark] Make version checking for NumPy in MLlib more robust

### DIFF
--- a/python/pyspark/mllib/__init__.py
+++ b/python/pyspark/mllib/__init__.py
@@ -25,7 +25,7 @@ from __future__ import absolute_import
 import numpy
 
 ver = [int(x) for x in numpy.version.version.split(.)[:2]]
-if ver <= [1, 4]:
+if ver < [1, 4]:
     raise Exception("MLlib requires NumPy 1.4+")
 
 __all__ = ['classification', 'clustering', 'feature', 'fpm', 'linalg', 'random',

--- a/python/pyspark/mllib/__init__.py
+++ b/python/pyspark/mllib/__init__.py
@@ -23,14 +23,9 @@ from __future__ import absolute_import
 # MLlib currently needs NumPy 1.4+, so complain if lower
 
 import numpy
-ver = numpy.version.version
 
-fd = ver.find('.')
-ver1 = int(ver[: fd])
-ver = ver[fd + 1:]
-ver2 = int(ver[: ver.find('.')])
-
-if ver1 < 1 or (ver1 == 1 and ver2 <= 4):
+ver = [int(x) for x in numpy.version.version.split(.)[:2]]
+if ver < [1, 4]:
     raise Exception("MLlib requires NumPy 1.4+")
 
 __all__ = ['classification', 'clustering', 'feature', 'fpm', 'linalg', 'random',

--- a/python/pyspark/mllib/__init__.py
+++ b/python/pyspark/mllib/__init__.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import
 
 import numpy
 
-ver = [int(x) for x in numpy.version.version.split(.)[:2]]
+ver = [int(x) for x in numpy.version.version.split('.')[:2]]
 if ver < [1, 4]:
     raise Exception("MLlib requires NumPy 1.4+")
 

--- a/python/pyspark/mllib/__init__.py
+++ b/python/pyspark/mllib/__init__.py
@@ -25,7 +25,7 @@ from __future__ import absolute_import
 import numpy
 
 ver = [int(x) for x in numpy.version.version.split(.)[:2]]
-if ver < [1, 4]:
+if ver <= [1, 4]:
     raise Exception("MLlib requires NumPy 1.4+")
 
 __all__ = ['classification', 'clustering', 'feature', 'fpm', 'linalg', 'random',

--- a/python/pyspark/mllib/__init__.py
+++ b/python/pyspark/mllib/__init__.py
@@ -23,7 +23,14 @@ from __future__ import absolute_import
 # MLlib currently needs NumPy 1.4+, so complain if lower
 
 import numpy
-if numpy.version.version < '1.4':
+ver = numpy.version.version
+
+fd = ver.find('.')
+ver1 = int(ver[: fd])
+ver = ver[fd + 1:]
+ver2 = int(ver[: ver.find('.')])
+
+if ver1 < 1 or (ver1 == 1 and ver2 <= 4):
     raise Exception("MLlib requires NumPy 1.4+")
 
 __all__ = ['classification', 'clustering', 'feature', 'fpm', 'linalg', 'random',


### PR DESCRIPTION
The current checking does version `1.x' is less than`1.4' this will fail if x has greater than 1 digit, since x > 4, however `1.x` < `1.4`

It fails in my system since I have version `1.10` :P
