### PR TITLE
[SPARK-8038][SQL][PySpark] Fix when function of PySpark SQL Column definition

### DIFF
--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -333,7 +333,7 @@ class Column(object):
         if not isinstance(condition, Column):
             raise TypeError("condition should be a Column")
         v = value._jc if isinstance(value, Column) else value
-        jc = sc._jvm.functions.when(condition._jc, v)
+        jc = self._jc.when(condition._jc, v)
         return Column(jc)
 
     @since(1.4)


### PR DESCRIPTION
The chaining of when functions was broken in PySpark SQL.
This fix is only changing the Column.py file to fix the when function accordingly.

Regards, 

Olivier.
