### PR TITLE
[SPARK-7269] [SQL] [WIP] Refactor the class AttributeReference

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -85,12 +85,12 @@ trait CheckAnalysis {
           case Aggregate(groupingExprs, aggregateExprs, child) =>
             def checkValidAggregateExpression(expr: Expression): Unit = expr match {
               case _: AggregateExpression => // OK
-              case e: Attribute if groupingExprs.find(_ semanticEquals e).isEmpty =>
+              case e: Attribute if groupingExprs.find(_ == e).isEmpty =>
                 failAnalysis(
                   s"expression '${e.prettyString}' is neither present in the group by, " +
                     s"nor is it an aggregate function. " +
                     "Add to group by or wrap in first() if you don't care which value you get.")
-              case e if groupingExprs.find(_ semanticEquals e).isDefined => // OK
+              case e if groupingExprs.find(_ == e).isDefined => // OK
               case e if e.references.isEmpty => // OK
               case e => e.children.foreach(checkValidAggregateExpression)
             }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -142,24 +142,6 @@ abstract class Expression extends TreeNode[Expression] {
   }
 
   /**
-   * Returns true when two expressions will always compute the same result, even if they differ
-   * cosmetically (i.e. capitalization of names in attributes may be different).
-   */
-  def semanticEquals(other: Expression): Boolean = this.getClass == other.getClass && {
-    def checkSemantic(elements1: Seq[Any], elements2: Seq[Any]): Boolean = {
-      elements1.length == elements2.length && elements1.zip(elements2).forall {
-        case (e1: Expression, e2: Expression) => e1 semanticEquals e2
-        case (Some(e1: Expression), Some(e2: Expression)) => e1 semanticEquals e2
-        case (t1: Traversable[_], t2: Traversable[_]) => checkSemantic(t1.toSeq, t2.toSeq)
-        case (i1, i2) => i1 == i2
-      }
-    }
-    val elements1 = this.productIterator.toSeq
-    val elements2 = other.asInstanceOf[Product].productIterator.toSeq
-    checkSemantic(elements1, elements2)
-  }
-
-  /**
    * Checks the input data types, returns `TypeCheckResult.success` if it's valid,
    * or returns a `TypeCheckResult` with an error message if invalid.
    * Note: it's not valid to call this method until `childrenResolved == true`

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
@@ -181,12 +181,8 @@ case class AttributeReference(
   def sameRef(other: AttributeReference): Boolean = this.exprId == other.exprId
 
   override def equals(other: Any): Boolean = other match {
-    case ar: AttributeReference => name == ar.name && exprId == ar.exprId && dataType == ar.dataType
-    case _ => false
-  }
-
-  override def semanticEquals(other: Expression): Boolean = other match {
-    case ar: AttributeReference => sameRef(ar)
+    case ar: AttributeReference =>
+      exprId == ar.exprId && dataType == ar.dataType && metadata == ar.metadata
     case _ => false
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -151,13 +151,13 @@ object PartialAggregation {
 
         // Replace aggregations with a new expression that computes the result from the already
         // computed partial evaluations and grouping values.
-        val rewrittenAggregateExpressions = aggregateExpressions.map(_.transformUp {
+        val rewrittenAggregateExpressions = aggregateExpressions.map(_.transformDown {
           case e: Expression if partialEvaluations.contains(new TreeNodeRef(e)) =>
             partialEvaluations(new TreeNodeRef(e)).finalEvaluation
 
           case e: Expression =>
             namedGroupingExpressions.collectFirst {
-              case (expr, ne) if expr semanticEquals e => ne.toAttribute
+              case (expr, ne) if expr == e => ne.toAttribute
             }.getOrElse(e)
         }).asInstanceOf[Seq[NamedExpression]]
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -154,7 +154,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] {
     val newArgs = productIterator.map {
       case arg: TreeNode[_] if containsChild(arg) =>
         val newChild = f(arg.asInstanceOf[BaseType])
-        if (newChild fastEquals arg) {
+        if (newChild eq arg) {
           arg
         } else {
           changed = true
@@ -181,7 +181,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] {
         case arg: TreeNode[_] if containsChild(arg) =>
           val newChild = remainingNewChildren.remove(0)
           val oldChild = remainingOldChildren.remove(0)
-          if (newChild fastEquals oldChild) {
+          if (newChild eq oldChild) {
             oldChild
           } else {
             changed = true
@@ -193,7 +193,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] {
       case arg: TreeNode[_] if containsChild(arg) =>
         val newChild = remainingNewChildren.remove(0)
         val oldChild = remainingOldChildren.remove(0)
-        if (newChild fastEquals oldChild) {
+        if (newChild eq oldChild) {
           oldChild
         } else {
           changed = true
@@ -228,7 +228,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] {
     }
 
     // Check if unchanged and then possibly return old copy to avoid gc churn.
-    if (this fastEquals afterRule) {
+    if (this eq afterRule) {
       transformChildrenDown(rule)
     } else {
       afterRule.transformChildrenDown(rule)
@@ -245,7 +245,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] {
     val newArgs = productIterator.map {
       case arg: TreeNode[_] if containsChild(arg) =>
         val newChild = arg.asInstanceOf[BaseType].transformDown(rule)
-        if (!(newChild fastEquals arg)) {
+        if (newChild ne arg) {
           changed = true
           newChild
         } else {
@@ -253,7 +253,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] {
         }
       case Some(arg: TreeNode[_]) if containsChild(arg) =>
         val newChild = arg.asInstanceOf[BaseType].transformDown(rule)
-        if (!(newChild fastEquals arg)) {
+        if (newChild ne arg) {
           changed = true
           Some(newChild)
         } else {
@@ -264,7 +264,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] {
       case args: Traversable[_] => args.map {
         case arg: TreeNode[_] if containsChild(arg) =>
           val newChild = arg.asInstanceOf[BaseType].transformDown(rule)
-          if (!(newChild fastEquals arg)) {
+          if (newChild ne arg) {
             changed = true
             newChild
           } else {
@@ -286,7 +286,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] {
    */
   def transformUp(rule: PartialFunction[BaseType, BaseType]): BaseType = {
     val afterRuleOnChildren = transformChildrenUp(rule)
-    if (this fastEquals afterRuleOnChildren) {
+    if (this eq afterRuleOnChildren) {
       CurrentOrigin.withOrigin(origin) {
         rule.applyOrElse(this, identity[BaseType])
       }
@@ -302,7 +302,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] {
     val newArgs = productIterator.map {
       case arg: TreeNode[_] if containsChild(arg) =>
         val newChild = arg.asInstanceOf[BaseType].transformUp(rule)
-        if (!(newChild fastEquals arg)) {
+        if (newChild ne arg) {
           changed = true
           newChild
         } else {
@@ -310,7 +310,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] {
         }
       case Some(arg: TreeNode[_]) if containsChild(arg) =>
         val newChild = arg.asInstanceOf[BaseType].transformUp(rule)
-        if (!(newChild fastEquals arg)) {
+        if (newChild ne arg) {
           changed = true
           Some(newChild)
         } else {
@@ -321,7 +321,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] {
       case args: Traversable[_] => args.map {
         case arg: TreeNode[_] if containsChild(arg) =>
           val newChild = arg.asInstanceOf[BaseType].transformUp(rule)
-          if (!(newChild fastEquals arg)) {
+          if (newChild ne arg) {
             changed = true
             newChild
           } else {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/AttributeSetSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/AttributeSetSuite.scala
@@ -34,8 +34,8 @@ class AttributeSetSuite extends SparkFunSuite {
   val aAndBSet = AttributeSet(aUpper :: bUpper :: Nil)
 
   test("sanity check") {
-    assert(aUpper != aLower)
-    assert(bUpper != bLower)
+    assert(aUpper == aLower)
+    assert(bUpper == bLower)
   }
 
   test("checks by id not name") {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/GeneratedAggregate.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/GeneratedAggregate.scala
@@ -224,7 +224,7 @@ case class GeneratedAggregate(
       case e: Expression if resultMap.contains(new TreeNodeRef(e)) => resultMap(new TreeNodeRef(e))
       case e: Expression =>
         namedGroups.collectFirst {
-          case (expr, attr) if expr semanticEquals e => attr
+          case (expr, attr) if expr == e => attr
         }.getOrElse(e)
     })
 


### PR DESCRIPTION
- Better integrated the TreeNode objects. with the language built-in collection utilities.

e.g. 

``` scala
val map: Map[Expression, Expression]=..
map.get(expr)
map.contains(expr)

// or
val set: Set[SparkPlan] = ...
if (set.contains(sparkPlan)) {
  ...
}
```

Currently we may not able to make the TreeNode object work with built-in collections as code shows above, because the methods `equals` and `hashCode` of case class `AttributeReference` is for literally not semantically in object comparison.
- TreeNode transformation APIs don't work with a identical instances return by a `rule`, as it has a `fastEquals` guard, we loose the guard by checking the instance reference equality only.
