### PR TITLE
SPARK-8078

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/DecisionTree.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/DecisionTree.scala
@@ -737,7 +737,12 @@ object DecisionTree extends Serializable with Logging {
     val leftWeight = leftCount / totalCount.toDouble
     val rightWeight = rightCount / totalCount.toDouble
 
-    val gain = impurity - leftWeight * leftImpurity - rightWeight * rightImpurity
+    val gainRatio = impurity - leftWeight * leftImpurity - rightWeight * rightImpurity
+  //calculate splitInfo
+  val splitInfo= -(scala.math.log(leftCount/totalCount.toDouble)    
+    +scala.math.log(rightCount/totalCount.toDouble))/scala.math.log(2)
+   //C4.5 algorithm instead of ID3 algorithm
+   val gain=gainRatio/splitInfo
 
     // if information gain doesn't satisfy minimum information gain,
     // then this split is invalid, return invalid information gain stats.


### PR DESCRIPTION
In Spark MLlib, Decision Trees use Gini impurity, Entropy and Variance as impurity. The Entropy impurity implement by calculating the Info Gain,  which is put forward by J. Ross Quinlan in ID3 algorithm. And it can be improved by implementing C4.5 algorithm,which using Info Gain Ratio instead of Info Gain to calculate impurity. By implementing C4.5 algorithm, the Decision Trees model can achieve higher forecast accuracy in most cases.
https://issues.apache.org/jira/browse/SPARK-8078
