### PR TITLE
[SPARK-8079] [SQL] Makes InsertIntoHadoopFsRelation job/task abortion more robust

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/hadoopFsRelationSuites.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/hadoopFsRelationSuites.scala
@@ -597,9 +597,7 @@ class ParquetHadoopFsRelationSuite extends HadoopFsRelationTest {
 
   test("SPARK-8079: Avoid NPE thrown from BaseWriterContainer.abortJob") {
     withTempPath { dir =>
-      val path = dir.getCanonicalPath
-
-      val cause = intercept[Throwable] {
+      intercept[AnalysisException] {
         // Parquet doesn't allow field names with spaces.  Here we are intentionally making an
         // exception thrown from the `ParquetRelation2.prepareForWriteJob()` method to trigger
         // the bug.  Please refer to spark-8079 for more details.
@@ -607,15 +605,7 @@ class ParquetHadoopFsRelationSuite extends HadoopFsRelationTest {
           .withColumnRenamed("id", "a b")
           .write
           .format("parquet")
-          .save(path)
-      }
-
-      cause match {
-        case _: NullPointerException =>
-          fail("Shouldn't throw NPE")
-
-        case e: RuntimeException =>
-          assert(e.getMessage.contains("Attribute name \"a b\" contains invalid character"))
+          .save(dir.getCanonicalPath)
       }
     }
   }


### PR DESCRIPTION
As described in SPARK-8079, when writing a DataFrame to a `HadoopFsRelation`, if `HadoopFsRelation.prepareForWriteJob` throws exception, an unexpected NPE will be thrown during job abortion. (This issue doesn't bring much damage since the job is failing anyway.)

This PR makes the job/task abortion logic in `InsertIntoHadoopFsRelation` more robust to avoid such confusing exceptions.
