### PR TITLE
[SPARK-8062] Fix NullPointerException in SparkHadoopUtil.getFileSystemThreadStatistics (branch-1.2)

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -179,7 +179,7 @@ class SparkHadoopUtil extends Logging {
       Seq.empty
     } else {
       FileSystem.getAllStatistics
-        .filter { stats => scheme.equals(stats.getScheme) }
+        .filter { stats => stats.getScheme.equals(scheme) }
         .map(Utils.invoke(classOf[Statistics], _, "getThreadStatistics"))
     }
   }

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -179,7 +179,7 @@ class SparkHadoopUtil extends Logging {
       Seq.empty
     } else {
       FileSystem.getAllStatistics
-        .filter { stats => stats.getScheme.equals(scheme) }
+        .filter { stats => scheme.equals(stats.getScheme()) }
         .map(Utils.invoke(classOf[Statistics], _, "getThreadStatistics"))
     }
   }

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -175,8 +175,13 @@ class SparkHadoopUtil extends Logging {
   private def getFileSystemThreadStatistics(path: Path, conf: Configuration): Seq[AnyRef] = {
     val qualifiedPath = path.getFileSystem(conf).makeQualified(path)
     val scheme = qualifiedPath.toUri().getScheme()
-    val stats = FileSystem.getAllStatistics().filter(_.getScheme().equals(scheme))
-    stats.map(Utils.invoke(classOf[Statistics], _, "getThreadStatistics"))
+    if (scheme == null) {
+      Seq.empty
+    } else {
+      FileSystem.getAllStatistics
+        .filter { stats => scheme.equals(stats.getScheme) }
+        .map(Utils.invoke(classOf[Statistics], _, "getThreadStatistics"))
+    }
   }
 
   private def getFileSystemThreadStatisticsMethod(methodName: String): Method = {

--- a/core/src/test/scala/org/apache/spark/metrics/InputOutputMetricsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/metrics/InputOutputMetricsSuite.scala
@@ -108,7 +108,7 @@ class InputOutputMetricsSuite extends FunSuite with SharedSparkContext with Shou
     }
   }
 
-  test("exceptions while getting IO thread statistics should not fail tasks / jobs (SPARK-8062)") {
+  test("getFileSystemThreadStatistics should guard against null schemes (SPARK-8062)") {
     val tempDir = Utils.createTempDir()
     val outPath = new File(tempDir, "outfile")
 


### PR DESCRIPTION
This patch adds a regression test for an extremely rare bug where `SparkHadoopUtil.getFileSystemThreadStatistics` would fail with a `NullPointerException` if the Hadoop `FileSystem.statisticsTable` contained a `Statistics` entry without a schema.  I'm not sure exactly how Hadoop gets into such a state, but this patch's regression test forces that state in order to reproduce this bug.

The fix is to add additional null-checking.  I debated adding an additional try-catch block around this entire metrics code to just ignore exceptions and keep going in the case of errors, but decided against that approach for now because it seemed overly conservative and might mask other bugs. We can revisit this in followup patches.
