### PR TITLE
[SPARK-7180][SPARK-8090][SPARK-8091] Fix a number of SerializationDebugger bugs and limitations

### DIFF
--- a/core/src/main/scala/org/apache/spark/serializer/SerializationDebugger.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/SerializationDebugger.scala
@@ -129,8 +129,7 @@ private[spark] object SerializationDebugger extends Logging {
      * Visit an externalizable object.
      * Since writeExternal() can choose add arbitrary objects at the time of serialization,
      * the only way to capture all the objects it will serialize is by using a
-     * dummy ObjectOutput object that captures all the inner objects, and then visit all the
-     * captured objects to test their serializability.
+     * dummy ObjectOutput that collects all the relevant objects for further testing.
      */
     private def visitExternalizable(o: java.io.Externalizable, stack: List[String]): List[String] =
     {
@@ -164,8 +163,8 @@ private[spark] object SerializationDebugger extends Logging {
       // serialization code to recursively serialize the fields of an object and
       // its parent classes. For example, if there are the following classes.
       //
-      // class ParentClass(parentField: Int)
-      // class ChildClass(childField: Int) extends Parent(1)
+      //     class ParentClass(parentField: Int)
+      //     class ChildClass(childField: Int) extends ParentClass(1)
       //
       // Then serializing the an object Obj of type ChildClass requires for serializing the fields
       // of ParentClass (that is, parentField), and then serializing the fields of ChildClass
@@ -219,8 +218,7 @@ private[spark] object SerializationDebugger extends Logging {
      * Visit a serializable object which has the writeObject() defined.
      * Since writeObject() can choose add arbitrary objects at the time of serialization,
      * the only way to capture all the objects it will serialize is by using a
-     * dummy ObjectOutputStream that captures all the inner objects, and then visit all the
-     * captured objects to test their serializability.
+     * dummy ObjectOutputStream that collects all the relevant fields for further testing.
      */
     private def visitSerializableWithWriteObjectMethod(
         o: Object, stack: List[String]): List[String] = {

--- a/core/src/main/scala/org/apache/spark/serializer/SerializationDebugger.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/SerializationDebugger.scala
@@ -62,7 +62,7 @@ private[spark] object SerializationDebugger extends Logging {
    *
    * It does not yet handle writeObject override, but that shouldn't be too hard to do either.
    */
-  def find(obj: Any): List[String] = {
+  private[serializer] def find(obj: Any): List[String] = {
     new SerializationDebugger().visit(obj, List.empty)
   }
 

--- a/core/src/test/scala/org/apache/spark/serializer/SerializationDebuggerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/SerializationDebuggerSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.serializer
 
-import java.io.{ObjectOutput, ObjectInput}
+import java.io.{IOException, ObjectOutputStream, ObjectOutput, ObjectInput}
 
 import org.scalatest.BeforeAndAfterEach
 
@@ -98,13 +98,58 @@ class SerializationDebuggerSuite extends SparkFunSuite with BeforeAndAfterEach {
   }
 
   test("externalizable class writing out not serializable object") {
-    val s = find(new ExternalizableClass)
+    val s = find(new ExternalizableClass(new SerializableClass2(new NotSerializable)))
     assert(s.size === 5)
     assert(s(0).contains("NotSerializable"))
     assert(s(1).contains("objectField"))
     assert(s(2).contains("SerializableClass2"))
     assert(s(3).contains("writeExternal"))
     assert(s(4).contains("ExternalizableClass"))
+  }
+
+  test("externalizable class writing out serializable objects") {
+    assert(find(new ExternalizableClass(new SerializableClass1)).isEmpty)
+  }
+
+  test("object containing writeReplace() which returns not serializable object") {
+    val s = find(new SerializableClassWithWriteReplace(new NotSerializable))
+    println("-----\n" + s.zipWithIndex.mkString("\n") + "\n----")
+    assert(s.size === 3)
+    assert(s(0).contains("NotSerializable"))
+    assert(s(1).contains("writeReplace"))
+    assert(s(2).contains("SerializableClassWithWriteReplace"))
+  }
+
+  test("object containing writeObject() and not serializable field") {
+    val s = find(new SerializableClassWithWriteObject(new NotSerializable))
+    println("-----\n" + s.zipWithIndex.mkString("\n") + "\n----")
+    assert(s.size === 3)
+    assert(s(0).contains("NotSerializable"))
+    assert(s(1).contains("writeObject data"))
+    assert(s(2).contains("SerializableClassWithWriteObject"))
+  }
+
+  test("object containing writeObject() and serializable field") {
+    assert(find(new SerializableClassWithWriteObject(new SerializableClass1)).isEmpty)
+  }
+
+
+  test("object of serializable subclass with more fields than superclass (SPARK-7180)") {
+    // This should not throw ArrayOutOfBoundsException
+    find(new SerializableSubclass(new SerializableClass1))
+  }
+
+  test("crazy nested objects") {
+    val s = find(
+      new SerializableClassWithWriteReplace(
+        new ExternalizableClass(
+          new SerializableSubclass(
+            new SerializableArray(
+              Array(new SerializableClass1, new SerializableClass2(new NotSerializable))
+            ))))
+    )
+    assert(s.nonEmpty)
+    assert(s.head.contains("NotSerializable"))
   }
 }
 
@@ -118,10 +163,34 @@ class SerializableClass2(val objectField: Object) extends Serializable
 class SerializableArray(val arrayField: Array[Object]) extends Serializable
 
 
-class ExternalizableClass extends java.io.Externalizable {
+class SerializableSubclass(val objectField: Object) extends SerializableClass1
+
+
+class SerializableClassWithWriteObject(val objectField: Object) extends Serializable {
+  val serializableObjectField = new SerializableClass1
+
+  @throws(classOf[IOException])
+  private def writeObject(oos: ObjectOutputStream): Unit = {
+    oos.defaultWriteObject()
+  }
+}
+
+
+class SerializableClassWithWriteReplace(@transient replacementFieldObject: Object)
+  extends Serializable {
+  private def writeReplace(): Object = {
+    replacementFieldObject
+  }
+}
+
+
+class ExternalizableClass(objectField: Object) extends java.io.Externalizable {
+  val serializableObjectField = new SerializableClass1
+
   override def writeExternal(out: ObjectOutput): Unit = {
     out.writeInt(1)
-    out.writeObject(new SerializableClass2(new NotSerializable))
+    out.writeObject(serializableObjectField)
+    out.writeObject(objectField)
   }
 
   override def readExternal(in: ObjectInput): Unit = {}

--- a/core/src/test/scala/org/apache/spark/serializer/SerializationDebuggerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/SerializationDebuggerSuite.scala
@@ -113,7 +113,6 @@ class SerializationDebuggerSuite extends SparkFunSuite with BeforeAndAfterEach {
 
   test("object containing writeReplace() which returns not serializable object") {
     val s = find(new SerializableClassWithWriteReplace(new NotSerializable))
-    println("-----\n" + s.zipWithIndex.mkString("\n") + "\n----")
     assert(s.size === 3)
     assert(s(0).contains("NotSerializable"))
     assert(s(1).contains("writeReplace"))
@@ -122,7 +121,6 @@ class SerializationDebuggerSuite extends SparkFunSuite with BeforeAndAfterEach {
 
   test("object containing writeObject() and not serializable field") {
     val s = find(new SerializableClassWithWriteObject(new NotSerializable))
-    println("-----\n" + s.zipWithIndex.mkString("\n") + "\n----")
     assert(s.size === 3)
     assert(s(0).contains("NotSerializable"))
     assert(s(1).contains("writeObject data"))
@@ -132,7 +130,6 @@ class SerializationDebuggerSuite extends SparkFunSuite with BeforeAndAfterEach {
   test("object containing writeObject() and serializable field") {
     assert(find(new SerializableClassWithWriteObject(new SerializableClass1)).isEmpty)
   }
-
 
   test("object of serializable subclass with more fields than superclass (SPARK-7180)") {
     // This should not throw ArrayOutOfBoundsException

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -549,8 +549,8 @@ class StreamingContext private[streaming] (
         case e: NotSerializableException =>
           throw new NotSerializableException(
             "DStream checkpointing has been enabled but the DStreams with their functions " +
-              "are not serializable\nSerialization stack:\n" +
-              SerializationDebugger.find(checkpoint).map("\t- " + _).mkString("\n")
+              "are not serializable\n" +
+              SerializationDebugger.improveException(checkpoint, e).getMessage()
           )
       }
     }


### PR DESCRIPTION
This PR solves three SerializationDebugger issues. 
- SPARK-7180 - SerializationDebugger fails with ArrayOutOfBoundsException
- SPARK-8090 - SerializationDebugger does not handle classes with writeReplace correctly
- SPARK-8091 - SerializationDebugger does not handle classes with writeObject method

The solutions for each are explained as follows
- SPARK-7180 - The wrong slot desc was used for getting the value of the fields in the object being tested. 
- SPARK-8090 - Test the type of the replaced object.
- SPARK-8091 - Use a dummy ObjectOutputStream to collect all the objects written by the writeObject() method, and then test those objects as usual.

I also added more tests in the testsuite to increase code coverage. For example, added tests for cases where there are not serializability issues.
