### PR TITLE
[SPARK-7993] [SQL] Improved DataFrame.show() output

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -76,6 +76,24 @@ abstract class DataType {
     DataType.equalsIgnoreNullability(this, other)
 
   /**
+   * Check if `this` is a primitive data type.
+   */
+  def isPrimitive: Boolean = {
+    sameType(StringType)    ||
+    sameType(FloatType)     ||
+    sameType(IntegerType)   ||
+    sameType(ByteType)      ||
+    sameType(ShortType)     ||
+    sameType(DoubleType)    ||
+    sameType(LongType)      ||
+    sameType(BinaryType)    ||
+    sameType(BooleanType)   ||
+    sameType(DateType)      ||
+    sameType(DecimalType()) ||
+    sameType(TimestampType)
+  }
+
+  /**
    * Returns the same data type but set all nullability fields are true
    * (`StructField.nullable`, `ArrayType.containsNull`, and `MapType.valueContainsNull`).
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -183,7 +183,7 @@ class DataFrame private[sql](
       row.toSeq.zipWithIndex.map { cell =>
         val str = {
           if (cell._1 == null) "null"
-          else if (primitive(cell._2) && cell._1.toString.last=='(') {
+          else if (primitive(cell._2) && cell._1.toString.last==')') {
             '[' + cell._1.toString.drop(cell._1.toString.indexOf('(') + 1).dropRight(1) + ']'
           }
           else cell._1.toString

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -230,8 +230,10 @@ class DataFrame private[sql](
 
     sb.append(sep)
 
-    // For Data that has more than 20 records.
-    if (this.count() > 20) sb.append("only showing the top 20 rows\n")
+    // For Data that has more than N(numRows) records.
+    if (take(numRows + 1).length > numRows) {
+      sb.append("only showing the top " + numRows.toString + " rows\n")
+    }
 
     sb.toString()
   }
@@ -362,7 +364,7 @@ class DataFrame private[sql](
 
   /**
    * Returns a [[DataFrameNaFunctions]] for working with missing data.
-   * {{{  
+   * {{{
    *   // Dropping rows containing any null values.
    *   df.na.drop()
    * }}}

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -229,6 +229,10 @@ class DataFrame private[sql](
     }
 
     sb.append(sep)
+
+    // For Data that has more than 20 records.
+    if (this.count() > 20) sb.append("only showing the top 20 rows\n")
+
     sb.toString()
   }
 
@@ -354,16 +358,11 @@ class DataFrame private[sql](
    * @group action
    * @since 1.3.0
    */
-  def show(): Unit = {
-    show(20)
-    if (this.count() > 20) {
-      println("only showing the top 20 rows\n")
-    }
-  }
+  def show(): Unit = show(20)
 
   /**
    * Returns a [[DataFrameNaFunctions]] for working with missing data.
-   * {{{
+   * {{{  
    *   // Dropping rows containing any null values.
    *   df.na.drop()
    * }}}

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -183,7 +183,7 @@ class DataFrame private[sql](
       row.toSeq.zipWithIndex.map { cell =>
         val str = {
           if (cell._1 == null) "null"
-          else if (primitive(cell._2) && cell._1.toString.last==')') {
+          else if (!primitive(cell._2) && cell._1.toString.last == ')') {
             '[' + cell._1.toString.drop(cell._1.toString.indexOf('(') + 1).dropRight(1) + ']'
           }
           else cell._1.toString


### PR DESCRIPTION
1. Increased the minimum width of each column to '3'.
2. If a DataFrame have more than 20 rows, displayed message "only showing the top 20 rows".
3. Added method isPrimitive which checks if a DataType is primitive.
4. For array values, instead of printing "ArrayBuffer", just printed square brackets.

@rxin 
@animeshbaranawal
