### PR TITLE
[SPARK-4072][Streaming][WebUI]Display Streaming blocks in Streaming UI

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
@@ -30,7 +30,7 @@ import org.apache.spark.rdd.{BlockRDD, PairRDDFunctions, RDD, RDDOperationScope}
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming._
 import org.apache.spark.streaming.StreamingContext.rddToFileName
-import org.apache.spark.streaming.scheduler.Job
+import org.apache.spark.streaming.scheduler.{Job, StreamingListenerBlockRemoved}
 import org.apache.spark.streaming.ui.UIUtils
 import org.apache.spark.util.{CallSite, MetadataCleaner, Utils}
 
@@ -445,6 +445,7 @@ abstract class DStream[T: ClassTag] (
           case b: BlockRDD[_] =>
             logInfo("Removing blocks of RDD " + b + " of time " + time)
             b.removeBlocks()
+            ssc.scheduler.listenerBus.post(StreamingListenerBlockRemoved(b.blockIds))
           case _ =>
         }
       }

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceiverTracker.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceiverTracker.scala
@@ -178,7 +178,12 @@ class ReceiverTracker(ssc: StreamingContext, skipReceiverLaunch: Boolean = false
 
   /** Add new blocks for the given stream */
   private def addBlock(receivedBlockInfo: ReceivedBlockInfo): Boolean = {
-    receivedBlockTracker.addBlock(receivedBlockInfo)
+    if (receivedBlockTracker.addBlock(receivedBlockInfo)) {
+      listenerBus.post(StreamingListenerBlockAdded(receivedBlockInfo))
+      true
+    } else {
+      false
+    }
   }
 
   /** Report error sent by a receiver */

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/StreamingListener.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/StreamingListener.scala
@@ -19,8 +19,9 @@ package org.apache.spark.streaming.scheduler
 
 import scala.collection.mutable.Queue
 
-import org.apache.spark.util.Distribution
 import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.storage.BlockId
+import org.apache.spark.util.Distribution
 
 /**
  * :: DeveloperApi ::
@@ -50,6 +51,14 @@ case class StreamingListenerReceiverError(receiverInfo: ReceiverInfo)
 case class StreamingListenerReceiverStopped(receiverInfo: ReceiverInfo)
   extends StreamingListenerEvent
 
+@DeveloperApi
+case class StreamingListenerBlockAdded(blockInfo: ReceivedBlockInfo)
+  extends StreamingListenerEvent
+
+@DeveloperApi
+case class StreamingListenerBlockRemoved(blockIds: Seq[BlockId])
+  extends StreamingListenerEvent
+
 /**
  * :: DeveloperApi ::
  * A listener interface for receiving information about an ongoing streaming
@@ -75,6 +84,12 @@ trait StreamingListener {
 
   /** Called when processing of a batch of jobs has completed. */
   def onBatchCompleted(batchCompleted: StreamingListenerBatchCompleted) { }
+
+  /** Called when adding a block to the block manager. */
+  def onBlockAdded(blockAdded: StreamingListenerBlockAdded) { }
+
+  /** Called when removing blocks from the block manager. */
+  def onBlockRemoved(blockRemoved: StreamingListenerBlockRemoved) { }
 }
 
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/StreamingListenerBus.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/StreamingListenerBus.scala
@@ -43,6 +43,10 @@ private[spark] class StreamingListenerBus
         listener.onBatchStarted(batchStarted)
       case batchCompleted: StreamingListenerBatchCompleted =>
         listener.onBatchCompleted(batchCompleted)
+      case blockAdded: StreamingListenerBlockAdded =>
+        listener.onBlockAdded(blockAdded)
+      case blockRemoved: StreamingListenerBlockRemoved =>
+        listener.onBlockRemoved(blockRemoved)
       case _ =>
     }
   }

--- a/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamBlockUIData.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamBlockUIData.scala
@@ -17,18 +17,11 @@
 
 package org.apache.spark.streaming.ui
 
-import org.apache.spark.streaming.StreamingContext
-import org.apache.spark.ui.{SparkUI, SparkUITab}
+import org.apache.spark.storage.{StreamBlockId, StorageLevel}
 
-/**
- * Spark Web UI tab that shows statistics of a streaming job.
- * This assumes the given SparkContext has enabled its SparkUI.
- */
-private[spark] class StreamingTab(parent: SparkUI, val ssc: StreamingContext)
-  extends SparkUITab(parent, "streaming") {
-
-  val listener = ssc.progressListener
-
-  attachPage(new StreamingPage(this))
-  attachPage(new BatchPage(this))
-}
+case class StreamBlockUIData(
+    blockId: StreamBlockId,
+    storageLevel: StorageLevel,
+    memSize: Long,
+    diskSize: Long,
+    externalBlockStoreSize: Long)

--- a/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingStoragePage.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingStoragePage.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.streaming.ui
+
+import javax.servlet.http.HttpServletRequest
+
+import scala.xml.Node
+
+import org.apache.spark.Logging
+import org.apache.spark.ui.WebUIPage
+import org.apache.spark.ui.{UIUtils => SparkUIUtils}
+import org.apache.spark.util.Utils
+
+private[ui] class StreamingStoragePage(parent: StreamingStorageTab)
+  extends WebUIPage("") with Logging {
+
+  private val listener = parent.listener
+
+  override def render(request: HttpServletRequest): Seq[Node] = {
+    // Sort by (timestamp, streamId) in descending order
+    val blockInfos =
+      listener.getAllBlocks.sortBy(b => (b.blockId.uniqueId, b.blockId.streamId)).reverse
+    val content = SparkUIUtils.listingTable(blockHeader, blockRow, blockInfos)
+    SparkUIUtils.headerSparkPage("Receiver Blocks", content, parent)
+  }
+
+  private def blockHeader = Seq(
+    "Block Id",
+    "Storage Level",
+    "Size in Memory",
+    "Size in ExternalBlockStore",
+    "Size on Disk")
+
+  private def blockRow(blockInfo: StreamBlockUIData): Seq[Node] = {
+    <tr>
+      <td>
+        {blockInfo.blockId.toString}
+      </td>
+      <td>
+        {blockInfo.storageLevel.description}
+      </td>
+      <td sorttable_customkey={blockInfo.memSize.toString}>
+        {Utils.bytesToString(blockInfo.memSize)}
+      </td>
+      <td sorttable_customkey={blockInfo.externalBlockStoreSize.toString}>
+        {Utils.bytesToString(blockInfo.externalBlockStoreSize)}
+      </td>
+      <td sorttable_customkey={blockInfo.diskSize.toString}>
+        {Utils.bytesToString(blockInfo.diskSize)}
+      </td>
+    </tr>
+  }
+}

--- a/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingStorageTab.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingStorageTab.scala
@@ -17,18 +17,15 @@
 
 package org.apache.spark.streaming.ui
 
-import org.apache.spark.streaming.StreamingContext
+import org.apache.spark.Logging
 import org.apache.spark.ui.{SparkUI, SparkUITab}
 
 /**
- * Spark Web UI tab that shows statistics of a streaming job.
- * This assumes the given SparkContext has enabled its SparkUI.
+ * Spark Web UI tab that shows blocks of a streaming job.
  */
-private[spark] class StreamingTab(parent: SparkUI, val ssc: StreamingContext)
-  extends SparkUITab(parent, "streaming") {
+private[ui] class StreamingStorageTab(parent: SparkUI, val listener: StreamingJobProgressListener)
+  extends SparkUITab(parent, "streaming storage") with Logging {
 
-  val listener = ssc.progressListener
-
-  attachPage(new StreamingPage(this))
-  attachPage(new BatchPage(this))
+  attachPage(new StreamingStoragePage(this))
 }
+

--- a/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingUI.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingUI.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.streaming.ui
+
+import org.apache.spark.SparkException
+import org.apache.spark.streaming.StreamingContext
+import org.apache.spark.ui.{SparkUI, JettyUtils}
+import org.eclipse.jetty.servlet.ServletContextHandler
+
+class StreamingUI(val ssc: StreamingContext) {
+
+  private val STATIC_RESOURCE_DIR = "org/apache/spark/streaming/ui/static"
+
+  val listener = ssc.progressListener
+  ssc.addStreamingListener(listener)
+  ssc.sc.addSparkListener(listener)
+
+  var staticHandler: ServletContextHandler = null
+  var streamingTab: StreamingTab = null
+  var streamingStorageTab: StreamingStorageTab = null
+
+  def start() {
+    val sparkUI = StreamingUI.getSparkUI(ssc)
+    streamingTab = new StreamingTab(sparkUI, ssc)
+    sparkUI.attachTab(streamingTab)
+    streamingStorageTab = new StreamingStorageTab(sparkUI, listener)
+    sparkUI.attachTab(streamingStorageTab)
+    staticHandler = JettyUtils.createStaticHandler(STATIC_RESOURCE_DIR, "/static/streaming")
+    StreamingUI.getSparkUI(ssc).attachHandler(staticHandler)
+  }
+
+  def stop() {
+    val sparkUI = StreamingUI.getSparkUI(ssc)
+    if (streamingTab != null) {
+      sparkUI.detachTab(streamingTab)
+      streamingTab = null
+    }
+    if (streamingStorageTab != null) {
+      sparkUI.detachTab(streamingStorageTab)
+      streamingStorageTab = null
+    }
+    if (staticHandler != null) {
+      StreamingUI.getSparkUI(ssc).detachHandler(staticHandler)
+      staticHandler = null
+    }
+  }
+}
+
+object StreamingUI {
+  def getSparkUI(ssc: StreamingContext): SparkUI = {
+    ssc.sc.ui.getOrElse {
+      throw new SparkException("Parent SparkUI to attach this tab to not found!")
+    }
+  }
+}

--- a/streaming/src/test/scala/org/apache/spark/streaming/ReceivedBlockTrackerSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/ReceivedBlockTrackerSuite.scala
@@ -29,7 +29,7 @@ import org.scalatest.{BeforeAndAfter, Matchers}
 import org.scalatest.concurrent.Eventually._
 
 import org.apache.spark.{Logging, SparkConf, SparkException, SparkFunSuite}
-import org.apache.spark.storage.StreamBlockId
+import org.apache.spark.storage.{BlockStatus, StreamBlockId, StorageLevel}
 import org.apache.spark.streaming.receiver.BlockManagerBasedStoreResult
 import org.apache.spark.streaming.scheduler._
 import org.apache.spark.streaming.util.{WriteAheadLogUtils, FileBasedWriteAheadLogReader}
@@ -225,7 +225,9 @@ class ReceivedBlockTrackerSuite
   /** Generate blocks infos using random ids */
   def generateBlockInfos(): Seq[ReceivedBlockInfo] = {
     List.fill(5)(ReceivedBlockInfo(streamId, 0, None,
-      BlockManagerBasedStoreResult(StreamBlockId(streamId, math.abs(Random.nextInt)))))
+      BlockManagerBasedStoreResult(
+        StreamBlockId(streamId, math.abs(Random.nextInt)),
+        BlockStatus(StorageLevel.MEMORY_AND_DISK, 100, 100, 0))))
   }
 
   /** Get all the data written in the given write ahead log file. */

--- a/streaming/src/test/scala/org/apache/spark/streaming/UISeleniumSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/UISeleniumSuite.scala
@@ -86,9 +86,14 @@ class UISeleniumSuite
       eventually(timeout(10 seconds), interval(50 milliseconds)) {
         go to (sparkUI.appUIAddress.stripSuffix("/"))
         find(cssSelector( """ul li a[href*="streaming"]""")) should not be (None)
+        find(cssSelector( """ul li a[href*="streaming storage"]""")) should not be (None)
       }
 
       eventually(timeout(10 seconds), interval(50 milliseconds)) {
+        // check whether streaming storage page exists
+        go to (sparkUI.appUIAddress.stripSuffix("/") + "/streaming%20storage")
+        findAll(cssSelector("h3")).map(_.text).toSeq should contain("Receiver Blocks")
+
         // check whether streaming page exists
         go to (sparkUI.appUIAddress.stripSuffix("/") + "/streaming")
         val h3Text = findAll(cssSelector("h3")).map(_.text).toSeq
@@ -190,6 +195,10 @@ class UISeleniumSuite
         go to (sparkUI.appUIAddress.stripSuffix("/") + "/streaming")
         val h3Text = findAll(cssSelector("h3")).map(_.text).toSeq
         h3Text should not contain("Streaming Statistics")
+
+        // check whether streaming storage page exists
+        go to (sparkUI.appUIAddress.stripSuffix("/") + "/streaming%20storage")
+        findAll(cssSelector("h3")).map(_.text).toSeq should not contain("Receiver Blocks")
       }
     }
   }


### PR DESCRIPTION
This PR includes the following changes:
- Add `StreamingListenerBlockAdded` and `StreamingListenerBlockRemoved` events for `StreamingListener` to track the block statuses.
- Add `StreamingUI` to support more than one tabs in the Streaming UI.
- Add `Streaming Storage` tab to display blocks used by Streaming. 

![screen shot 2015-06-04 at 3 40 43 pm](https://cloud.githubusercontent.com/assets/1000778/7979284/829f2204-0ad0-11e5-90e1-5fbccf3639f9.png)
