### PR TITLE
[SPARK-8100][UI]Make able to refer lost executor info in Spark UI

### DIFF
--- a/core/src/main/scala/org/apache/spark/status/api/v1/api.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/api.scala
@@ -60,7 +60,8 @@ class ExecutorSummary private[spark](
     val totalShuffleRead: Long,
     val totalShuffleWrite: Long,
     val maxMemory: Long,
-    val executorLogs: Map[String, String])
+    val executorLogs: Map[String, String],
+    val isRemoved: Boolean)
 
 class JobData private[spark](
     val jobId: Int,

--- a/core/src/main/scala/org/apache/spark/status/api/v1/api.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/api.scala
@@ -61,6 +61,7 @@ class ExecutorSummary private[spark](
     val totalShuffleWrite: Long,
     val maxMemory: Long,
     val executorLogs: Map[String, String],
+    // Since in 1.5.0
     val isRemoved: Boolean)
 
 class JobData private[spark](

--- a/core/src/main/scala/org/apache/spark/storage/StorageStatusListener.scala
+++ b/core/src/main/scala/org/apache/spark/storage/StorageStatusListener.scala
@@ -87,7 +87,7 @@ class StorageStatusListener extends SparkListener {
   override def onBlockManagerRemoved(blockManagerRemoved: SparkListenerBlockManagerRemoved) {
     synchronized {
       val executorId = blockManagerRemoved.blockManagerId.executorId
-      executorIdToStorageStatus.remove(executorId)
+      executorIdToStorageStatus(executorId).markAsRemoved
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/storage/StorageUtils.scala
+++ b/core/src/main/scala/org/apache/spark/storage/StorageUtils.scala
@@ -57,6 +57,11 @@ class StorageStatus(val blockManagerId: BlockManagerId, val maxMem: Long) {
   private val _rddStorageInfo = new mutable.HashMap[Int, (Long, Long, Long, StorageLevel)]
   private var _nonRddStorageInfo: (Long, Long, Long) = (0L, 0L, 0L)
 
+  private var _blockManagerRemoved = false
+
+  def isRemoved: Boolean = _blockManagerRemoved
+  def markAsRemoved(): Unit = _blockManagerRemoved = true
+
   /** Create a storage status with an initial set of blocks, leaving the source unmodified. */
   def this(bmid: BlockManagerId, maxMem: Long, initialBlocks: Map[BlockId, BlockStatus]) {
     this(bmid, maxMem)

--- a/core/src/main/scala/org/apache/spark/ui/storage/StorageTab.scala
+++ b/core/src/main/scala/org/apache/spark/ui/storage/StorageTab.scala
@@ -43,7 +43,8 @@ class StorageListener(storageStatusListener: StorageStatusListener) extends Bloc
 
   private[ui] val _rddInfoMap = mutable.Map[Int, RDDInfo]() // exposed for testing
 
-  def storageStatusList: Seq[StorageStatus] = storageStatusListener.storageStatusList
+  def storageStatusList: Seq[StorageStatus] =
+    storageStatusListener.storageStatusList.filter(!_.isRemoved)
 
   /** Filter RDD info to include only those with cached partitions */
   def rddInfoList: Seq[RDDInfo] = synchronized {

--- a/core/src/test/resources/HistoryServerExpectations/executor_list_json_expectation.json
+++ b/core/src/test/resources/HistoryServerExpectations/executor_list_json_expectation.json
@@ -13,5 +13,6 @@
   "totalShuffleRead" : 0,
   "totalShuffleWrite" : 13180,
   "maxMemory" : 278302556,
-  "executorLogs" : { }
+  "executorLogs" : { },
+  "isRemoved": false
 } ]

--- a/core/src/test/scala/org/apache/spark/storage/StorageStatusListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/StorageStatusListenerSuite.scala
@@ -50,13 +50,15 @@ class StorageStatusListenerSuite extends SparkFunSuite {
 
     // Block manager remove
     listener.onBlockManagerRemoved(SparkListenerBlockManagerRemoved(1L, bm1))
-    assert(listener.executorIdToStorageStatus.size === 1)
-    assert(!listener.executorIdToStorageStatus.get("big").isDefined)
-    assert(listener.executorIdToStorageStatus.get("fat").isDefined)
+    assert(listener.executorIdToStorageStatus.size === 2)
+    assert(listener.storageStatusList.count(!_.isRemoved) == 1)
+    assert(listener.executorIdToStorageStatus.get("big").get.isRemoved)
+    assert(!listener.executorIdToStorageStatus.get("fat").get.isRemoved)
     listener.onBlockManagerRemoved(SparkListenerBlockManagerRemoved(1L, bm2))
-    assert(listener.executorIdToStorageStatus.size === 0)
-    assert(!listener.executorIdToStorageStatus.get("big").isDefined)
-    assert(!listener.executorIdToStorageStatus.get("fat").isDefined)
+    assert(listener.executorIdToStorageStatus.size === 2)
+    assert(listener.storageStatusList.count(!_.isRemoved) == 0)
+    assert(listener.executorIdToStorageStatus.get("big").get.isRemoved)
+    assert(listener.executorIdToStorageStatus.get("fat").get.isRemoved)
   }
 
   test("task end without updated blocks") {

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -151,6 +151,10 @@ object MimaExcludes {
             ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.sql.sources.PartitionSpec$"),
             ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.sql.sources.DescribeCommand"),
             ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.sql.sources.DDLException")
+          ) ++ Seq(
+            // SPARK-8100 Make able to refer lost executor info in Spark UI
+            ProblemFilters.exclude[MissingMethodProblem](
+              "org.apache.spark.status.api.v1.ExecutorSummary.this")
           )
 
         case v if v.startsWith("1.4") =>


### PR DESCRIPTION
While  spark application is still running, and the lost executor info also disappear in Spark UI, it is not  
easy to see why that executor lost or refer other sth
