### PR TITLE
[SPARK-8095] Spark package dependencies not resolved when package is in local-ivy-cache

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -806,6 +806,7 @@ private[spark] object SparkSubmitUtils {
     val ivyPattern = Seq("[organisation]", "[module]", "[revision]", "[type]s",
       "[artifact](-[classifier]).[ext]").mkString(File.separator)
     localIvy.setPattern(ivyPattern)
+    localIvy.setUsepoms(true)
     localIvy.setName("local-ivy-cache")
     cr.add(localIvy)
 


### PR DESCRIPTION
@brkyvz This should be back ported into branch-1.4 and branch-1.3 as well.
