### PR TITLE
[SPARK-8119][Scheduler]Do not let Spark set total executors when executor fails

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
@@ -53,8 +53,10 @@ private[spark] abstract class YarnSchedulerBackend(
    * This includes executors already pending or running.
    */
   override def doRequestTotalExecutors(requestedTotal: Int): Boolean = {
-    yarnSchedulerEndpoint.askWithRetry[Boolean](RequestExecutors(requestedTotal))
-  }
+    if (conf.getBoolean("spark.dynamicAllocation.enabled", false)) {
+      return yarnSchedulerEndpoint.askWithRetry[Boolean](RequestExecutors(requestedTotal))
+    }
+    false  }
 
   /**
    * Request that the ApplicationMaster kill the specified executors.

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
@@ -56,7 +56,8 @@ private[spark] abstract class YarnSchedulerBackend(
     if (conf.getBoolean("spark.dynamicAllocation.enabled", false)) {
       return yarnSchedulerEndpoint.askWithRetry[Boolean](RequestExecutors(requestedTotal))
     }
-    false  }
+    false
+  }
 
   /**
    * Request that the ApplicationMaster kill the specified executors.


### PR DESCRIPTION
`DynamicAllocation` will set the total executor to a little number when it wants to kill some executors.
But in no-DynamicAllocation scenario, Spark will also set the total executor.
So it will cause such problem: sometimes an executor fails down, there is no more executor which will be pull up by spark
