### PR TITLE
[SPARK-8129] [CORE] [SECURITY] Securely pass auth secrets to executors via stdin

### DIFF
--- a/core/src/main/scala/org/apache/spark/SecurityManager.scala
+++ b/core/src/main/scala/org/apache/spark/SecurityManager.scala
@@ -188,11 +188,12 @@ import org.apache.spark.util.Utils
 
 private[spark] class SecurityManager(sparkConf: SparkConf)
   extends Logging with SecretKeyHolder {
+  import SecurityManager._
 
   // key used to store the spark secret in the Hadoop UGI
   private val sparkSecretLookupKey = "sparkCookie"
 
-  private val authOn = sparkConf.getBoolean("spark.authenticate", false)
+  private val authOn = sparkConf.isAuthOn
   // keep spark.ui.acls.enable for backwards compatibility with 1.0
   private var aclsOn =
     sparkConf.getBoolean("spark.acls.enable", sparkConf.getBoolean("spark.ui.acls.enable", false))
@@ -365,10 +366,10 @@ private[spark] class SecurityManager(sparkConf: SparkConf)
       cookie
     } else {
       // user must have set spark.authenticate.secret config
-      sparkConf.getOption("spark.authenticate.secret") match {
+      sparkConf.getAuthSecret match {
         case Some(value) => value
         case None => throw new Exception("Error: a secret key must be specified via the " +
-          "spark.authenticate.secret config")
+          AUTH_SECRET + " config")
       }
     }
     sCookie
@@ -448,4 +449,11 @@ private[spark] class SecurityManager(sparkConf: SparkConf)
   // Default SecurityManager only has a single secret key, so ignore appId.
   override def getSaslUser(appId: String): String = getSaslUser()
   override def getSecretKey(appId: String): String = getSecretKey()
+}
+
+private[spark] object SecurityManager {
+
+  val AUTH_CONFIG: String = "spark.authenticate"
+  val AUTH_SECRET: String = "spark.authenticate.secret"
+
 }

--- a/core/src/main/scala/org/apache/spark/SecurityManager.scala
+++ b/core/src/main/scala/org/apache/spark/SecurityManager.scala
@@ -193,7 +193,7 @@ private[spark] class SecurityManager(sparkConf: SparkConf)
   // key used to store the spark secret in the Hadoop UGI
   private val sparkSecretLookupKey = "sparkCookie"
 
-  private val authOn = sparkConf.isAuthOn
+  private val authOn = sparkConf.authOn
   // keep spark.ui.acls.enable for backwards compatibility with 1.0
   private var aclsOn =
     sparkConf.getBoolean("spark.acls.enable", sparkConf.getBoolean("spark.ui.acls.enable", false))
@@ -366,10 +366,10 @@ private[spark] class SecurityManager(sparkConf: SparkConf)
       cookie
     } else {
       // user must have set spark.authenticate.secret config
-      sparkConf.getAuthSecret match {
+      sparkConf.getClusterAuthSecret match {
         case Some(value) => value
         case None => throw new Exception("Error: a secret key must be specified via the " +
-          AUTH_SECRET + " config")
+          CLUSTER_AUTH_SECRET_CONF + " config")
       }
     }
     sCookie
@@ -453,7 +453,7 @@ private[spark] class SecurityManager(sparkConf: SparkConf)
 
 private[spark] object SecurityManager {
 
-  val AUTH_CONFIG: String = "spark.authenticate"
-  val AUTH_SECRET: String = "spark.authenticate.secret"
+  val CLUSTER_AUTH_CONF: String = "spark.authenticate"
+  val CLUSTER_AUTH_SECRET_CONF: String = "spark.authenticate.secret"
 
 }

--- a/core/src/main/scala/org/apache/spark/SecurityManager.scala
+++ b/core/src/main/scala/org/apache/spark/SecurityManager.scala
@@ -367,8 +367,8 @@ private[spark] class SecurityManager(sparkConf: SparkConf)
     } else {
       // user must have set spark.authenticate.secret config
       sparkConf.getClusterAuthSecret match {
-        case Some(value) => value
-        case None => throw new Exception("Error: a secret key must be specified via the " +
+        case Some(value) if !value.isEmpty => value // empty string is not allowed
+        case _ => throw new Exception("Error: a secret key must be specified via the " +
           CLUSTER_AUTH_SECRET_CONF + " config")
       }
     }

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -337,7 +337,9 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging {
    * Check to see if authentication for the Spark communication protocols is enabled
    * @return true if authentication is enabled, otherwise false
    */
-  private[spark] def isAuthOn: Boolean = getBoolean(SecurityManager.AUTH_CONFIG, false)
+  private[spark] def authOn: Boolean = {
+    getBoolean(SecurityManager.CLUSTER_AUTH_CONF, false)
+  }
 
   /**
    * Return the authentication key for standalone cluster managers (Master and Worker).
@@ -345,7 +347,9 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging {
    * In non-YARN deployments, this key is also used for authentication in apps (e.g.,
    * between driver and executor). See [[org.apache.spark.SecurityManager]] for details.
    */
-  private[spark] def getAuthSecret: Option[String] = getOption(SecurityManager.AUTH_SECRET)
+  private[spark] def getClusterAuthSecret: Option[String] = {
+    getOption(SecurityManager.CLUSTER_AUTH_SECRET_CONF)
+  }
 
   /** Does the configuration contain a given parameter? */
   def contains(key: String): Boolean = settings.containsKey(key)
@@ -577,18 +581,20 @@ private[spark] object SparkConf extends Logging {
   }
 
   /**
-   * Return true if the given config is NOT for authentication secret.
+   * Return true if the given config is NOT for cluster authentication secret.
    */
-  private[spark] def isNotAuthSecretConf(name: String): Boolean =
-    name != SecurityManager.AUTH_SECRET
+  private[spark] def isNotClusterAuthSecretConf(name: String): Boolean = {
+    name != SecurityManager.CLUSTER_AUTH_SECRET_CONF
+  }
 
   /**
    * Return whether the given config should be passed to an executor launched by standalone
-   * cluster manager as JVM system properties on start-up. In particular, authentication
-   * secret is filtered out since it will be written to executor's stdin.
+   * cluster manager as JVM system properties on start-up. In particular, cluster
+   * authentication secret is filtered out since it will be written to executor's stdin.
    */
-  private[spark] def isStandaloneExecutorStartupConf(name: String): Boolean =
-    isExecutorStartupConf(name) && isNotAuthSecretConf(name)
+  private[spark] def isStandaloneExecutorStartupConf(name: String): Boolean = {
+    isExecutorStartupConf(name) && isNotClusterAuthSecretConf(name)
+  }
 
   /**
    * Return true if the given config matches either `spark.*.port` or `spark.port.*`.

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -589,8 +589,8 @@ private[spark] object SparkConf extends Logging {
 
   /**
    * Return whether the given config should be passed to an executor launched by standalone
-   * cluster manager as JVM system properties on start-up. In particular, cluster
-   * authentication secret is filtered out since it will be written to executor's stdin.
+   * cluster manager as java options on start-up. In particular, cluster authentication
+   * secret is filtered out since it will be written to executor's stdin.
    */
   private[spark] def isStandaloneExecutorStartupConf(name: String): Boolean = {
     isExecutorStartupConf(name) && isNotClusterAuthSecretConf(name)

--- a/core/src/main/scala/org/apache/spark/deploy/ApplicationDescription.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/ApplicationDescription.scala
@@ -25,6 +25,7 @@ private[spark] class ApplicationDescription(
     val memoryPerExecutorMB: Int,
     val command: Command,
     var appUiUrl: String,
+    val appSecret: Option[String] = None,
     val eventLogDir: Option[URI] = None,
     // short name of compression codec used when writing event logs, if any (e.g. lzf)
     val eventLogCodec: Option[String] = None,
@@ -39,10 +40,12 @@ private[spark] class ApplicationDescription(
       memoryPerExecutorMB: Int = memoryPerExecutorMB,
       command: Command = command,
       appUiUrl: String = appUiUrl,
+      appSecret: Option[String] = appSecret,
       eventLogDir: Option[URI] = eventLogDir,
       eventLogCodec: Option[String] = eventLogCodec): ApplicationDescription =
     new ApplicationDescription(
-      name, maxCores, memoryPerExecutorMB, command, appUiUrl, eventLogDir, eventLogCodec)
+      name, maxCores, memoryPerExecutorMB, command, appUiUrl,
+      appSecret, eventLogDir, eventLogCodec)
 
   override def toString: String = "ApplicationDescription(" + name + ")"
 }

--- a/core/src/main/scala/org/apache/spark/deploy/Client.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/Client.scala
@@ -82,7 +82,7 @@ private class ClientActor(driverArgs: ClientArguments, conf: SparkConf)
           driverArgs.cores,
           driverArgs.supervise,
           command,
-          conf.getClusterAuthSecret)  // app secret is cluster auth secret for now
+          if (conf.authOn) conf.getClusterAuthSecret else None)
 
         // This assumes only one Master is active at a time
         for (masterActor <- masterActors) {

--- a/core/src/main/scala/org/apache/spark/deploy/Client.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/Client.scala
@@ -70,7 +70,7 @@ private class ClientActor(driverArgs: ClientArguments, conf: SparkConf)
         val extraJavaOptsConf = "spark.driver.extraJavaOptions"
         val extraJavaOpts = sys.props.get(extraJavaOptsConf)
           .map(Utils.splitCommandString).getOrElse(Seq.empty)
-        val sparkJavaOpts = Utils.sparkJavaOpts(conf)
+        val sparkJavaOpts = Utils.sparkJavaOpts(conf, SparkConf.isNotAuthSecretConf)
         val javaOpts = sparkJavaOpts ++ extraJavaOpts
         val command = new Command(mainClass,
           Seq("{{WORKER_URL}}", "{{USER_JAR}}", driverArgs.mainClass) ++ driverArgs.driverOptions,
@@ -81,7 +81,8 @@ private class ClientActor(driverArgs: ClientArguments, conf: SparkConf)
           driverArgs.memory,
           driverArgs.cores,
           driverArgs.supervise,
-          command)
+          command,
+          conf.getAuthSecret)  // app secret is cluster auth secret for now
 
         // This assumes only one Master is active at a time
         for (masterActor <- masterActors) {

--- a/core/src/main/scala/org/apache/spark/deploy/Client.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/Client.scala
@@ -38,6 +38,7 @@ import org.apache.spark.util.{ActorLogReceive, AkkaUtils, RpcUtils, Utils}
  */
 private class ClientActor(driverArgs: ClientArguments, conf: SparkConf)
   extends Actor with ActorLogReceive with Logging {
+  import ClientActor._
 
   private val masterActors = driverArgs.masters.map { m =>
     context.actorSelection(Master.toAkkaUrl(m, AkkaUtils.protocol(context.system)))
@@ -55,34 +56,7 @@ private class ClientActor(driverArgs: ClientArguments, conf: SparkConf)
         // TODO: We could add an env variable here and intercept it in `sc.addJar` that would
         //       truncate filesystem paths similar to what YARN does. For now, we just require
         //       people call `addJar` assuming the jar is in the same directory.
-        val mainClass = "org.apache.spark.deploy.worker.DriverWrapper"
-
-        val classPathConf = "spark.driver.extraClassPath"
-        val classPathEntries = sys.props.get(classPathConf).toSeq.flatMap { cp =>
-          cp.split(java.io.File.pathSeparator)
-        }
-
-        val libraryPathConf = "spark.driver.extraLibraryPath"
-        val libraryPathEntries = sys.props.get(libraryPathConf).toSeq.flatMap { cp =>
-          cp.split(java.io.File.pathSeparator)
-        }
-
-        val extraJavaOptsConf = "spark.driver.extraJavaOptions"
-        val extraJavaOpts = sys.props.get(extraJavaOptsConf)
-          .map(Utils.splitCommandString).getOrElse(Seq.empty)
-        val sparkJavaOpts = Utils.sparkJavaOpts(conf, SparkConf.isNotClusterAuthSecretConf)
-        val javaOpts = sparkJavaOpts ++ extraJavaOpts
-        val command = new Command(mainClass,
-          Seq("{{WORKER_URL}}", "{{USER_JAR}}", driverArgs.mainClass) ++ driverArgs.driverOptions,
-          sys.env, classPathEntries, libraryPathEntries, javaOpts)
-
-        val driverDescription = new DriverDescription(
-          driverArgs.jarUrl,
-          driverArgs.memory,
-          driverArgs.cores,
-          driverArgs.supervise,
-          command,
-          if (conf.authOn) conf.getClusterAuthSecret else None)
+        val driverDescription = buildDriverDescription(driverArgs, conf)
 
         // This assumes only one Master is active at a time
         for (masterActor <- masterActors) {
@@ -172,6 +146,42 @@ private class ClientActor(driverArgs: ClientArguments, conf: SparkConf)
           System.exit(-1)
         }
       }
+  }
+}
+
+private object ClientActor {
+
+  // Exposed for testing
+  private def buildDriverDescription(driverArgs: ClientArguments,
+                                     conf: SparkConf): DriverDescription = {
+    val mainClass = "org.apache.spark.deploy.worker.DriverWrapper"
+
+    val classPathConf = "spark.driver.extraClassPath"
+    val classPathEntries = sys.props.get(classPathConf).toSeq.flatMap { cp =>
+      cp.split(java.io.File.pathSeparator)
+    }
+
+    val libraryPathConf = "spark.driver.extraLibraryPath"
+    val libraryPathEntries = sys.props.get(libraryPathConf).toSeq.flatMap { cp =>
+      cp.split(java.io.File.pathSeparator)
+    }
+
+    val extraJavaOptsConf = "spark.driver.extraJavaOptions"
+    val extraJavaOpts = sys.props.get(extraJavaOptsConf)
+      .map(Utils.splitCommandString).getOrElse(Seq.empty)
+    val sparkJavaOpts = Utils.sparkJavaOpts(conf, SparkConf.isNotClusterAuthSecretConf)
+    val javaOpts = sparkJavaOpts ++ extraJavaOpts
+    val command = new Command(mainClass,
+      Seq("{{WORKER_URL}}", "{{USER_JAR}}", driverArgs.mainClass) ++ driverArgs.driverOptions,
+      sys.env, classPathEntries, libraryPathEntries, javaOpts)
+
+    new DriverDescription(
+      driverArgs.jarUrl,
+      driverArgs.memory,
+      driverArgs.cores,
+      driverArgs.supervise,
+      command,
+      if (conf.authOn) conf.getClusterAuthSecret else None)
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/deploy/Client.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/Client.scala
@@ -70,7 +70,7 @@ private class ClientActor(driverArgs: ClientArguments, conf: SparkConf)
         val extraJavaOptsConf = "spark.driver.extraJavaOptions"
         val extraJavaOpts = sys.props.get(extraJavaOptsConf)
           .map(Utils.splitCommandString).getOrElse(Seq.empty)
-        val sparkJavaOpts = Utils.sparkJavaOpts(conf, SparkConf.isNotAuthSecretConf)
+        val sparkJavaOpts = Utils.sparkJavaOpts(conf, SparkConf.isNotClusterAuthSecretConf)
         val javaOpts = sparkJavaOpts ++ extraJavaOpts
         val command = new Command(mainClass,
           Seq("{{WORKER_URL}}", "{{USER_JAR}}", driverArgs.mainClass) ++ driverArgs.driverOptions,
@@ -82,7 +82,7 @@ private class ClientActor(driverArgs: ClientArguments, conf: SparkConf)
           driverArgs.cores,
           driverArgs.supervise,
           command,
-          conf.getAuthSecret)  // app secret is cluster auth secret for now
+          conf.getClusterAuthSecret)  // app secret is cluster auth secret for now
 
         // This assumes only one Master is active at a time
         for (masterActor <- masterActors) {

--- a/core/src/main/scala/org/apache/spark/deploy/DriverDescription.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DriverDescription.scala
@@ -22,7 +22,8 @@ private[deploy] class DriverDescription(
     val mem: Int,
     val cores: Int,
     val supervise: Boolean,
-    val command: Command)
+    val command: Command,
+    val appSecret: Option[String] = None)
   extends Serializable {
 
   def copy(
@@ -30,8 +31,9 @@ private[deploy] class DriverDescription(
       mem: Int = mem,
       cores: Int = cores,
       supervise: Boolean = supervise,
-      command: Command = command): DriverDescription =
-    new DriverDescription(jarUrl, mem, cores, supervise, command)
+      command: Command = command,
+      appSecret: Option[String] = appSecret): DriverDescription =
+    new DriverDescription(jarUrl, mem, cores, supervise, command, appSecret)
 
   override def toString: String = s"DriverDescription (${command.mainClass})"
 }

--- a/core/src/main/scala/org/apache/spark/deploy/rest/StandaloneRestServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/rest/StandaloneRestServer.scala
@@ -150,7 +150,7 @@ private[rest] class StandaloneSubmitRequestServlet(
     val extraClassPath = driverExtraClassPath.toSeq.flatMap(_.split(File.pathSeparator))
     val extraLibraryPath = driverExtraLibraryPath.toSeq.flatMap(_.split(File.pathSeparator))
     val extraJavaOpts = driverExtraJavaOptions.map(Utils.splitCommandString).getOrElse(Seq.empty)
-    val sparkJavaOpts = Utils.sparkJavaOpts(conf, SparkConf.isNotAuthSecretConf)
+    val sparkJavaOpts = Utils.sparkJavaOpts(conf, SparkConf.isNotClusterAuthSecretConf)
     val javaOpts = sparkJavaOpts ++ extraJavaOpts
     val command = new Command(
       "org.apache.spark.deploy.worker.DriverWrapper",
@@ -165,7 +165,7 @@ private[rest] class StandaloneSubmitRequestServlet(
       actualDriverCores,
       actualSuperviseDriver,
       command,
-      conf.getAuthSecret)  // app secret is cluster auth secret for now
+      conf.getClusterAuthSecret)  // app secret is cluster auth secret for now
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/deploy/rest/StandaloneRestServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/rest/StandaloneRestServer.scala
@@ -123,7 +123,7 @@ private[rest] class StandaloneSubmitRequestServlet(
    * fields used by python applications since python is not supported in standalone
    * cluster mode yet.
    */
-  private def buildDriverDescription(request: CreateSubmissionRequest): DriverDescription = {
+  private[rest] def buildDriverDescription(request: CreateSubmissionRequest): DriverDescription = {
     // Required fields, including the main class because python is not yet supported
     val appResource = Option(request.appResource).getOrElse {
       throw new SubmitRestMissingFieldException("Application jar is missing.")
@@ -165,7 +165,7 @@ private[rest] class StandaloneSubmitRequestServlet(
       actualDriverCores,
       actualSuperviseDriver,
       command,
-      conf.getClusterAuthSecret)  // app secret is cluster auth secret for now
+      if (conf.authOn) conf.getClusterAuthSecret else None)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/deploy/rest/StandaloneRestServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/rest/StandaloneRestServer.scala
@@ -150,7 +150,7 @@ private[rest] class StandaloneSubmitRequestServlet(
     val extraClassPath = driverExtraClassPath.toSeq.flatMap(_.split(File.pathSeparator))
     val extraLibraryPath = driverExtraLibraryPath.toSeq.flatMap(_.split(File.pathSeparator))
     val extraJavaOpts = driverExtraJavaOptions.map(Utils.splitCommandString).getOrElse(Seq.empty)
-    val sparkJavaOpts = Utils.sparkJavaOpts(conf)
+    val sparkJavaOpts = Utils.sparkJavaOpts(conf, SparkConf.isNotAuthSecretConf)
     val javaOpts = sparkJavaOpts ++ extraJavaOpts
     val command = new Command(
       "org.apache.spark.deploy.worker.DriverWrapper",
@@ -160,7 +160,12 @@ private[rest] class StandaloneSubmitRequestServlet(
     val actualDriverCores = driverCores.map(_.toInt).getOrElse(DEFAULT_CORES)
     val actualSuperviseDriver = superviseDriver.map(_.toBoolean).getOrElse(DEFAULT_SUPERVISE)
     new DriverDescription(
-      appResource, actualDriverMemory, actualDriverCores, actualSuperviseDriver, command)
+      appResource,
+      actualDriverMemory,
+      actualDriverCores,
+      actualSuperviseDriver,
+      command,
+      conf.getAuthSecret)  // app secret is cluster auth secret for now
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/deploy/rest/StandaloneRestServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/rest/StandaloneRestServer.scala
@@ -123,7 +123,7 @@ private[rest] class StandaloneSubmitRequestServlet(
    * fields used by python applications since python is not supported in standalone
    * cluster mode yet.
    */
-  private[rest] def buildDriverDescription(request: CreateSubmissionRequest): DriverDescription = {
+  private def buildDriverDescription(request: CreateSubmissionRequest): DriverDescription = {
     // Required fields, including the main class because python is not yet supported
     val appResource = Option(request.appResource).getOrElse {
       throw new SubmitRestMissingFieldException("Application jar is missing.")

--- a/core/src/main/scala/org/apache/spark/deploy/worker/DriverWrapper.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/DriverWrapper.scala
@@ -38,6 +38,7 @@ object DriverWrapper {
        */
       case workerUrl :: userJar :: mainClass :: extraArgs =>
         val conf = new SparkConf()
+        Utils.setAndExportAppSecretIfNeeded(conf)
         val rpcEnv = RpcEnv.create("Driver",
           Utils.localHostName(), 0, conf, new SecurityManager(conf))
         rpcEnv.setupEndpoint("workerWatcher", new WorkerWatcher(rpcEnv, workerUrl))

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ExecutorRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ExecutorRunner.scala
@@ -146,6 +146,8 @@ private[deploy] class ExecutorRunner(
       val header = "Spark Executor Command: %s\n%s\n\n".format(
         command.mkString("\"", "\" \"", "\""), "=" * 40)
 
+      // send app secret to executor via stdin if needed
+      Utils.pipeOutAppSecretIfNeeded(process, appDesc.appSecret, conf)
       // Redirect its stdout and stderr to files
       val stdout = new File(executorDir, "stdout")
       stdoutAppender = FileAppender(process.getInputStream, stdout, conf)

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -149,6 +149,7 @@ private[spark] object CoarseGrainedExecutorBackend extends Logging {
 
       // Bootstrap to fetch the driver's Spark properties.
       val executorConf = new SparkConf
+      Utils.setAndExportAppSecretIfNeeded(executorConf)
       val port = executorConf.getInt("spark.executor.port", 0)
       val fetcher = RpcEnv.create(
         "driverPropsFetcher",

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
@@ -83,8 +83,16 @@ private[spark] class SparkDeploySchedulerBackend(
       args, sc.executorEnvs, classPathEntries ++ testingClassPath, libraryPathEntries, javaOpts)
     val appUIAddress = sc.ui.map(_.appUIAddress).getOrElse("")
     val coresPerExecutor = conf.getOption("spark.executor.cores").map(_.toInt)
-    val appDesc = new ApplicationDescription(sc.appName, maxCores, sc.executorMemory,command,
-      appUIAddress, conf.getClusterAuthSecret, sc.eventLogDir, sc.eventLogCodec, coresPerExecutor)
+    val appDesc = new ApplicationDescription(
+      sc.appName,
+      maxCores,
+      sc.executorMemory,
+      command,
+      appUIAddress,
+      if (conf.authOn) conf.getClusterAuthSecret else None,
+      sc.eventLogDir,
+      sc.eventLogCodec,
+      coresPerExecutor)
     client = new AppClient(sc.env.actorSystem, masters, appDesc, this, conf)
     client.start()
     waitForRegistration()

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
@@ -84,7 +84,7 @@ private[spark] class SparkDeploySchedulerBackend(
     val appUIAddress = sc.ui.map(_.appUIAddress).getOrElse("")
     val coresPerExecutor = conf.getOption("spark.executor.cores").map(_.toInt)
     val appDesc = new ApplicationDescription(sc.appName, maxCores, sc.executorMemory,command,
-      appUIAddress, conf.getAuthSecret, sc.eventLogDir, sc.eventLogCodec, coresPerExecutor)
+      appUIAddress, conf.getClusterAuthSecret, sc.eventLogDir, sc.eventLogCodec, coresPerExecutor)
     client = new AppClient(sc.env.actorSystem, masters, appDesc, this, conf)
     client.start()
     waitForRegistration()

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
@@ -77,14 +77,14 @@ private[spark] class SparkDeploySchedulerBackend(
       }
 
     // Start executors with a few necessary configs for registering with the scheduler
-    val sparkJavaOpts = Utils.sparkJavaOpts(conf, SparkConf.isExecutorStartupConf)
+    val sparkJavaOpts = Utils.sparkJavaOpts(conf, SparkConf.isStandaloneExecutorStartupConf)
     val javaOpts = sparkJavaOpts ++ extraJavaOpts
     val command = Command("org.apache.spark.executor.CoarseGrainedExecutorBackend",
       args, sc.executorEnvs, classPathEntries ++ testingClassPath, libraryPathEntries, javaOpts)
     val appUIAddress = sc.ui.map(_.appUIAddress).getOrElse("")
     val coresPerExecutor = conf.getOption("spark.executor.cores").map(_.toInt)
-    val appDesc = new ApplicationDescription(sc.appName, maxCores, sc.executorMemory,
-      command, appUIAddress, sc.eventLogDir, sc.eventLogCodec, coresPerExecutor)
+    val appDesc = new ApplicationDescription(sc.appName, maxCores, sc.executorMemory,command,
+      appUIAddress, conf.getAuthSecret, sc.eventLogDir, sc.eventLogCodec, coresPerExecutor)
     client = new AppClient(sc.env.actorSystem, masters, appDesc, this, conf)
     client.start()
     waitForRegistration()

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -331,7 +331,7 @@ private[spark] object Utils extends Logging {
       process: Process,
       secret: Option[String],
       conf: SparkConf): Unit =
-    for (value <- secret if conf.isAuthOn) {
+    for (value <- secret if conf.authOn) {
       val out = new BufferedOutputStream(process.getOutputStream)
       out.write(value.getBytes)
       out.close
@@ -344,12 +344,12 @@ private[spark] object Utils extends Logging {
    * Note: This mutates state in the given SparkConf and in this JVM's system properties.
    */
   def setAndExportAppSecretIfNeeded(conf: SparkConf): Unit = {
-    if (conf.isAuthOn) {
+    if (conf.authOn) {
       val in = new BufferedReader(new InputStreamReader(System.in))
       Option(in.readLine) match {
         case Some(value) =>
-          conf.set(SecurityManager.AUTH_SECRET, value)
-          sys.props.update(SecurityManager.AUTH_SECRET, value)
+          conf.set(SecurityManager.CLUSTER_AUTH_SECRET_CONF, value)
+          sys.props.update(SecurityManager.CLUSTER_AUTH_SECRET_CONF, value)
 
         case None => throw new Exception("Error: authentication is enabled but " +
           "failed to obtain authentication key from stdin")

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -338,7 +338,7 @@ private[spark] object Utils extends Logging {
     }
 
   /**
-   * If authentication is enabled, retrieve app secret from stdin, set it in conf and 
+   * If authentication is enabled, retrieve app secret from stdin, set it in conf and
    * export it to system properties.
    *
    * Note: This mutates state in the given SparkConf and in this JVM's system properties.

--- a/core/src/test/scala/org/apache/spark/deploy/master/MasterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/master/MasterSuite.scala
@@ -102,6 +102,7 @@ class MasterSuite extends SparkFunSuite with Matchers with Eventually {
         memoryPerExecutorMB = 0,
         command = commandToPersist,
         appUiUrl = "",
+        appSecret = None,
         eventLogDir = None,
         eventLogCodec = None,
         coresPerExecutor = None),

--- a/core/src/test/scala/org/apache/spark/deploy/rest/StandaloneRestServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/rest/StandaloneRestServerSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.deploy.DriverDescription
  */
 class StandaloneRestServerSuite extends SparkFunSuite with PrivateMethodTester {
 
-  test("Auth secret shouldn't appear on the command line") {
+  test("Auth secret shouldn't appear in the command") {
     val servlet = new StandaloneSubmitRequestServlet(null , "", null)
     val buildDriverDesc = PrivateMethod[DriverDescription]('buildDriverDescription)
     val request = new CreateSubmissionRequest
@@ -45,31 +45,31 @@ class StandaloneRestServerSuite extends SparkFunSuite with PrivateMethodTester {
 
     // auth is not set
     request.sparkProperties = conf.getAll.toMap
-    var driver = servlet invokePrivate buildDriverDesc(request)
-    assert(driver.appSecret === None)
-    assert(!driver.command.javaOpts.exists(
+    var driverDesc = servlet invokePrivate buildDriverDesc(request)
+    assert(driverDesc.appSecret === None)
+    assert(!driverDesc.command.javaOpts.exists(
       _.startsWith("-D" + SecurityManager.CLUSTER_AUTH_CONF)))
-    assert(!driver.command.javaOpts.exists(
+    assert(!driverDesc.command.javaOpts.exists(
       _.startsWith("-D" + SecurityManager.CLUSTER_AUTH_SECRET_CONF)))
 
     // auth is set to false
     conf.set(SecurityManager.CLUSTER_AUTH_CONF, "false")
     request.sparkProperties = conf.getAll.toMap
-    driver = servlet invokePrivate buildDriverDesc(request)
-    assert(driver.appSecret === None)
-    assert(driver.command.javaOpts.contains(
+    driverDesc = servlet invokePrivate buildDriverDesc(request)
+    assert(driverDesc.appSecret === None)
+    assert(driverDesc.command.javaOpts.contains(
       "-D" + SecurityManager.CLUSTER_AUTH_CONF + "=false"))
-    assert(!driver.command.javaOpts.exists(
+    assert(!driverDesc.command.javaOpts.exists(
       _.startsWith("-D" + SecurityManager.CLUSTER_AUTH_SECRET_CONF)))
 
     // auth is set to true
     conf.set(SecurityManager.CLUSTER_AUTH_CONF, "true")
     request.sparkProperties = conf.getAll.toMap
-    driver = servlet invokePrivate buildDriverDesc(request)
-    assert(driver.appSecret === Some("This is the secret sauce"))
-    assert(driver.command.javaOpts.contains(
+    driverDesc = servlet invokePrivate buildDriverDesc(request)
+    assert(driverDesc.appSecret === Some("This is the secret sauce"))
+    assert(driverDesc.command.javaOpts.contains(
       "-D" + SecurityManager.CLUSTER_AUTH_CONF + "=true"))
-    assert(!driver.command.javaOpts.exists(
+    assert(!driverDesc.command.javaOpts.exists(
       _.startsWith("-D" + SecurityManager.CLUSTER_AUTH_SECRET_CONF)))
   }
 }

--- a/core/src/test/scala/org/apache/spark/deploy/rest/StandaloneRestServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/rest/StandaloneRestServerSuite.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.rest
+
+import org.apache.spark.{SecurityManager, SparkConf, SparkFunSuite}
+
+/**
+ * Tests for the Standalone REST server.
+ */
+class StandaloneRestServerSuite extends SparkFunSuite {
+
+  test("Auth secret shouldn't appear on the command line") {
+    val servlet = new StandaloneSubmitRequestServlet(null , "", null)
+    val request = new CreateSubmissionRequest
+    request.clientSparkVersion = "1.2.3"
+    request.appResource = "honey-walnut-cherry.jar"
+    request.mainClass = "org.apache.spark.examples.SparkPie"
+    request.appArgs = Array("two slices", "a hint of cinnamon")
+    val conf = new SparkConf(false)
+    conf.set("spark.app.name", "SparkPie")
+    request.sparkProperties = conf.getAll.toMap
+    request.validate()
+
+    // optional fields
+    conf.set(SecurityManager.CLUSTER_AUTH_SECRET_CONF, "This is the secret sauce")
+    request.sparkProperties = conf.getAll.toMap
+    request.validate()
+    var driver = servlet.buildDriverDescription(request)
+    assert(driver.appSecret === None)
+    assert(!driver.command.javaOpts.exists(
+      _.startsWith("-D" + SecurityManager.CLUSTER_AUTH_CONF)))
+    assert(!driver.command.javaOpts.exists(
+      _.startsWith("-D" + SecurityManager.CLUSTER_AUTH_SECRET_CONF)))
+
+    conf.set(SecurityManager.CLUSTER_AUTH_CONF, "false")
+    conf.set(SecurityManager.CLUSTER_AUTH_SECRET_CONF, "This is the secret sauce")
+    request.sparkProperties = conf.getAll.toMap
+    request.validate()
+    driver = servlet.buildDriverDescription(request)
+    assert(driver.appSecret === None)
+    assert(driver.command.javaOpts.contains(
+      "-D" + SecurityManager.CLUSTER_AUTH_CONF + "=false"))
+    assert(!driver.command.javaOpts.exists(
+      _.startsWith("-D" + SecurityManager.CLUSTER_AUTH_SECRET_CONF)))
+
+    conf.set(SecurityManager.CLUSTER_AUTH_CONF, "true")
+    conf.set(SecurityManager.CLUSTER_AUTH_SECRET_CONF, "This is the secret sauce")
+    request.sparkProperties = conf.getAll.toMap
+    request.validate()
+    driver = servlet.buildDriverDescription(request)
+    assert(driver.appSecret === Some("This is the secret sauce"))
+    assert(driver.command.javaOpts.contains(
+      "-D" + SecurityManager.CLUSTER_AUTH_CONF + "=true"))
+    assert(!driver.command.javaOpts.exists(
+      _.startsWith("-D" + SecurityManager.CLUSTER_AUTH_SECRET_CONF)))
+  }
+}

--- a/core/src/test/scala/org/apache/spark/deploy/rest/StandaloneRestServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/rest/StandaloneRestServerSuite.scala
@@ -40,10 +40,11 @@ class StandaloneRestServerSuite extends SparkFunSuite with PrivateMethodTester {
     request.sparkProperties = conf.getAll.toMap
     request.validate()
 
-    // optional fields
+    // set secret
     conf.set(SecurityManager.CLUSTER_AUTH_SECRET_CONF, "This is the secret sauce")
+
+    // auth is not set
     request.sparkProperties = conf.getAll.toMap
-    request.validate()
     var driver = servlet invokePrivate buildDriverDesc(request)
     assert(driver.appSecret === None)
     assert(!driver.command.javaOpts.exists(
@@ -51,10 +52,9 @@ class StandaloneRestServerSuite extends SparkFunSuite with PrivateMethodTester {
     assert(!driver.command.javaOpts.exists(
       _.startsWith("-D" + SecurityManager.CLUSTER_AUTH_SECRET_CONF)))
 
+    // auth is set to false
     conf.set(SecurityManager.CLUSTER_AUTH_CONF, "false")
-    conf.set(SecurityManager.CLUSTER_AUTH_SECRET_CONF, "This is the secret sauce")
     request.sparkProperties = conf.getAll.toMap
-    request.validate()
     driver = servlet invokePrivate buildDriverDesc(request)
     assert(driver.appSecret === None)
     assert(driver.command.javaOpts.contains(
@@ -62,10 +62,9 @@ class StandaloneRestServerSuite extends SparkFunSuite with PrivateMethodTester {
     assert(!driver.command.javaOpts.exists(
       _.startsWith("-D" + SecurityManager.CLUSTER_AUTH_SECRET_CONF)))
 
+    // auth is set to true
     conf.set(SecurityManager.CLUSTER_AUTH_CONF, "true")
-    conf.set(SecurityManager.CLUSTER_AUTH_SECRET_CONF, "This is the secret sauce")
     request.sparkProperties = conf.getAll.toMap
-    request.validate()
     driver = servlet invokePrivate buildDriverDesc(request)
     assert(driver.appSecret === Some("This is the secret sauce"))
     assert(driver.command.javaOpts.contains(

--- a/core/src/test/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/cluster/SparkDeploySchedulerBackendSuite.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler.cluster
+
+import org.scalatest.PrivateMethodTester
+
+import org.apache.spark._
+import org.apache.spark.deploy.ApplicationDescription
+
+class SparkDeploySchedulerBackendSuite
+  extends SparkFunSuite with LocalSparkContext with PrivateMethodTester {
+
+  val buildAppDesc = PrivateMethod[ApplicationDescription]('buildAppDescription)
+
+  test("Auth secret shouldn't appear in the command when auth is not set") {
+    val conf = new SparkConf
+    // always set secret
+    conf.set(SecurityManager.CLUSTER_AUTH_SECRET_CONF, "This is the secret sauce")
+    sc = new SparkContext("local", "test", conf)
+    val appDesc = SparkDeploySchedulerBackend invokePrivate buildAppDesc("", Option(1), sc)
+    assert(appDesc.appSecret === None)
+    assert(!appDesc.command.javaOpts.exists(
+      _.startsWith("-D" + SecurityManager.CLUSTER_AUTH_CONF)))
+    assert(!appDesc.command.javaOpts.exists(
+      _.startsWith("-D" + SecurityManager.CLUSTER_AUTH_SECRET_CONF)))
+  }
+
+  test("Auth secret shouldn't appear in the command when auth is set to false") {
+    val conf = new SparkConf
+    conf.set(SecurityManager.CLUSTER_AUTH_CONF, "false")
+    // always set secret
+    conf.set(SecurityManager.CLUSTER_AUTH_SECRET_CONF, "This is the secret sauce")
+    sc = new SparkContext("local", "test", conf)
+    val appDesc = SparkDeploySchedulerBackend invokePrivate buildAppDesc("", Option(1), sc)
+    assert(appDesc.appSecret === None)
+    assert(appDesc.command.javaOpts.contains(
+      "-D" + SecurityManager.CLUSTER_AUTH_CONF + "=false"))
+    assert(!appDesc.command.javaOpts.exists(
+      _.startsWith("-D" + SecurityManager.CLUSTER_AUTH_SECRET_CONF)))
+  }
+
+  test("Auth secret shouldn't appear in the command when auth is set to true") {
+    val conf = new SparkConf
+    conf.set(SecurityManager.CLUSTER_AUTH_CONF, "true")
+    // always set secret
+    conf.set(SecurityManager.CLUSTER_AUTH_SECRET_CONF, "This is the secret sauce")
+    sc = new SparkContext("local", "test", conf)
+    val appDesc = SparkDeploySchedulerBackend invokePrivate buildAppDesc("", Option(1), sc)
+    assert(appDesc.appSecret === Some("This is the secret sauce"))
+    assert(appDesc.command.javaOpts.contains(
+      "-D" + SecurityManager.CLUSTER_AUTH_CONF + "=true"))
+    assert(!appDesc.command.javaOpts.exists(
+      _.startsWith("-D" + SecurityManager.CLUSTER_AUTH_SECRET_CONF)))
+  }
+}


### PR DESCRIPTION
Currently, in standalone cluster mode, auth secrets are passed to executors as java options on the command line. This is insecure since anyone running a 'ps' command can see it. This patch passes auth secrets to child processes' stdin.
