### PR TITLE
[SPARK-8056][SQL][WIP] Design an easier way to construct schema for both Scala and Python

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructField.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructField.scala
@@ -21,6 +21,16 @@ import org.json4s.JsonAST.JValue
 import org.json4s.JsonDSL._
 
 /**
+ * An indexed StructField that can be used to track order within a schema.
+ * @param field A field inside a StructType
+ * @param idx The index within the schema          
+ */
+case class FieldIdx(field: StructField, idx: Int) {
+  /** No-arg constructor for kryo. */
+  protected def this() = this(null, null)
+}
+
+/**
  * A field inside a StructType.
  * @param name The name of this field.
  * @param dataType The data type of this field.


### PR DESCRIPTION
I've added functionality to create new `StructType` similar to how we add parameters to a new `SparkContext`.

I've updated most of the `StructType` class to make it so the underlying data store is based off a map of fields instead of the array used to construct it. This both enables the above functionality and clarifies some semantics of what's going on internally in terms of how the data is used and also guards against an issue previously present where one could have duplicates in the schema that would cause problems. 
