### PR TITLE
[SPARK-2205][SPARK-7871][SQL]Advoid redundancy exchange

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -197,19 +197,13 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
 
 private[sql] trait LeafNode extends SparkPlan with trees.LeafNode[SparkPlan] {
   self: Product =>
-  meetPartitions = Set(outputPartitioning)
 }
 
 private[sql] trait UnaryNode extends SparkPlan with trees.UnaryNode[SparkPlan] {
   self: Product =>
   override def outputPartitioning: Partitioning = child.outputPartitioning
-  meetPartitions = child.meetPartitions ++ Set(outputPartitioning)
 }
 
 private[sql] trait BinaryNode extends SparkPlan with trees.BinaryNode[SparkPlan] {
   self: Product =>
-  meetPartitions =
-    left.meetPartitions ++
-    right.meetPartitions ++
-    Set(left.outputPartitioning, right.outputPartitioning)
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -143,7 +143,7 @@ class PlannerSuite extends SparkFunSuite {
     setConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD, origThreshold.toString)
   }
 
-  test("unnecessary exchange operators test") {
+  test("unnecessary exchange operators") {
     val planned1 = testData
       .join(testData2, testData("key") === testData2("a"), "outer")
       .join(testData3, testData("key") === testData3("a"), "outer")


### PR DESCRIPTION
When only use the output partitioning of `BinaryNode` will probably add unnecessary `Exchange` like multiway join.
This PR add `meetPartitions` to SparkPlan advoid redundancy  exchanges by  use to save the partitioning of the node and the child,and will be reset to node partitioning when need shuffle.
