### PR TITLE
[SPARK-8139] [SQL] Updates docs and comments of data sources and Parquet output committer options

### DIFF
--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -1911,20 +1911,6 @@ that these options will be deprecated in future release as more optimizations ar
       When true, performs sorts spilling to disk as needed otherwise sort each partition in memory.
     </td>
   </tr>
-  <tr>
-    <td><code>spark.sql.sources.outputCommitterClass</code></td>
-    <td></td>
-    <td>
-      <p>
-        The output committer class used by data sources that extend <code>HadoopFsRelation</code>. The
-        specified class needs to be a subclass of <code>org.apache.hadoop.mapreduce.OutputCommitter</code>.
-      </p>
-      <p>
-        <b>Note:</b> This option must be set via Hadoop <code>Configuration</code> rather than Spark
-        <code>SQLConf</code>.
-      </p>
-    </td>
-  </tr>
 </table>
 
 # Distributed SQL Engine

--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -1348,6 +1348,34 @@ Configuration of Parquet can be done using the `setConf` method on `SQLContext` 
     support.
   </td>
 </tr>
+<tr>
+  <td><code>spark.sql.parquet.output.committer.class</code></td>
+  <td><code>org.apache.parquet.hadoop.<br />ParquetOutputCommitter</code></td>
+  <td>
+    <p>
+      The output committer class used by Parquet. The specified class needs to be a subclass of
+      <code>org.apache.hadoop.<br />mapreduce.OutputCommitter</code>.  Typically, it's also a
+      subclass of <code>org.apache.parquet.hadoop.ParquetOutputCommitter</code>.
+    </p>
+    <p>
+      <b>Note:</b>
+      <ul>
+        <li>
+          This option must be set via Hadoop <code>Configuration</code> rather than Spark
+          <code>SQLConf</code>.
+        </li>
+        <li>
+          This option overrides <code>spark.sql.sources.<br />outputCommitterClass</code>.
+        </li>
+      </ul>
+    </p>
+    <p>
+      Spark SQL comes with a builtin
+      <code>org.apache.spark.sql.<br />parquet.DirectParquetOutputCommitter</code>, which can be more
+      efficient then the default Parquet output committer when writing data to S3.
+    </p>
+  </td>
+</tr>
 </table>
 
 ## JSON Datasets
@@ -1876,11 +1904,25 @@ that these options will be deprecated in future release as more optimizations ar
       Configures the number of partitions to use when shuffling data for joins or aggregations.
     </td>
   </tr>
-   <tr>
+  <tr>
     <td><code>spark.sql.planner.externalSort</code></td>
     <td>false</td>
     <td>
       When true, performs sorts spilling to disk as needed otherwise sort each partition in memory.
+    </td>
+  </tr>
+  <tr>
+    <td><code>spark.sql.sources.outputCommitterClass</code></td>
+    <td></td>
+    <td>
+      <p>
+        The output committer class used by data sources that extend <code>HadoopFsRelation</code>. The
+        specified class needs to be a subclass of <code>org.apache.hadoop.mapreduce.OutputCommitter</code>.
+      </p>
+      <p>
+        <b>Note:</b> This option must be set via Hadoop <code>Configuration</code> rather than Spark
+        <code>SQLConf</code>.
+      </p>
     </td>
   </tr>
 </table>

--- a/sql/core/src/main/scala/org/apache/spark/sql/parquet/newParquet.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/parquet/newParquet.scala
@@ -178,11 +178,11 @@ private[sql] class ParquetRelation2(
 
     val committerClass =
       conf.getClass(
-        "spark.sql.parquet.output.committer.class",
+        SQLConf.PARQUET_OUTPUT_COMMITTER_CLASS.key,
         classOf[ParquetOutputCommitter],
         classOf[ParquetOutputCommitter])
 
-    if (conf.get("spark.sql.parquet.output.committer.class") == null) {
+    if (conf.get(SQLConf.PARQUET_OUTPUT_COMMITTER_CLASS.key) == null) {
       logInfo("Using default output committer for Parquet: " +
         classOf[ParquetOutputCommitter].getCanonicalName)
     } else {


### PR DESCRIPTION
This PR only applies to master branch (1.5.0-SNAPSHOT) since it references `org.apache.parquet` classes which only appear in Parquet 1.7.0.
