### PR TITLE
SPARK-8153 Add configuration for disabling partial aggregation in runtime

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/collection/BitSet.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/BitSet.scala
@@ -32,6 +32,10 @@ class BitSet(numBits: Int) extends Serializable {
    */
   def capacity: Int = numWords * 64
 
+  def clear(): Unit = {
+    java.util.Arrays.fill(words, 0L)
+  }
+
   /**
    * Set all the bits up to a given index
    */

--- a/core/src/main/scala/org/apache/spark/util/collection/OpenHashSet.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/OpenHashSet.scala
@@ -104,6 +104,13 @@ class OpenHashSet[@specialized(Long, Int) T: ClassTag](
   /** Return true if this set contains the specified element. */
   def contains(k: T): Boolean = getPos(k) != INVALID_POS
 
+  def clear(): Unit = {
+    _size = 0
+    _bitset.clear()
+    _capacity = nextPowerOf2(initialCapacity)
+    _data = new Array[T](_capacity)
+  }
+
   /**
    * Add an element to the set. If the set is over capacity after the insertion, grow the set
    * and rehash all elements.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -150,5 +150,9 @@ case class MutableLiteral(var value: Any, dataType: DataType, nullable: Boolean 
     value = expression.eval(input)
   }
 
+  def update(value: Any): Unit = {
+    this.value = value
+  }
+
   override def eval(input: InternalRow): Any = value
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
@@ -114,6 +114,20 @@ private[spark] object SQLConf {
         }
       }, _.toString, doc, isPublic)
 
+    def floatConf(
+        key: String,
+        defaultValue: Option[Float] = None,
+        doc: String = "",
+        isPublic: Boolean = true): SQLConfEntry[Float] =
+      SQLConfEntry(key, defaultValue, { v =>
+        try {
+          v.toFloat
+        } catch {
+          case _: NumberFormatException =>
+            throw new IllegalArgumentException(s"$key should be float, but was $v")
+        }
+      }, _.toString, doc, isPublic)
+
     def doubleConf(
         key: String,
         defaultValue: Option[Double] = None,
@@ -420,6 +434,17 @@ private[spark] object SQLConf {
   val USE_SQL_AGGREGATE2 = booleanConf("spark.sql.useAggregate2",
     defaultValue = Some(true), doc = "<TODO>")
 
+  val PARTIAL_AGGREGATION_CHECK_INTERVAL = intConf(
+    "spark.sql.partial.aggregation.checkInterval",
+    defaultValue = Some(1000000),
+    doc = "Number of input rows for checking aggregation status of hash")
+
+  val PARTIAL_AGGREGATION_MIN_REDUCTION = floatConf(
+    "spark.sql.partial.aggregation.minReduction",
+    defaultValue = Some(0.5f),
+    doc = "Partial aggregation will be turned off when reduction ratio by hash is not " +
+      "enough to this threshold")
+
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"
   }
@@ -526,6 +551,12 @@ private[sql] class SQLConf extends Serializable with CatalystConf {
     getConf(DATAFRAME_SELF_JOIN_AUTO_RESOLVE_AMBIGUITY)
 
   private[spark] def dataFrameRetainGroupColumns: Boolean = getConf(DATAFRAME_RETAIN_GROUP_COLUMNS)
+
+  private[spark] def partialAggregationCheckInterval: Int =
+    getConf(PARTIAL_AGGREGATION_CHECK_INTERVAL)
+
+  private[spark] def partialAggregationMinReduction: Float =
+    getConf(PARTIAL_AGGREGATION_MIN_REDUCTION)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
@@ -628,5 +628,10 @@ private[hive] case class HiveUDAFFunction(
     val inputs = inputProjection(input)
     function.iterate(buffer, wrap(inputs, inspectors, cached, inputDataTypes))
   }
+
+  override def reset(): AggregateFunction1 = {
+    function.reset(buffer)
+    this
+  }
 }
 


### PR DESCRIPTION
Same thing with "hive.map.aggr.hash.min.reduction" in hive, which disables hash aggregation if it's not sufficiently decreasing the output size.

Added two configuration
- spark.sql.partial.aggregation.checkInterval
- spark.sql.partial.aggregation.minReduction
