### PR TITLE
[SMALL FIX] Return null if catch EOFException

### DIFF
--- a/core/src/main/scala/org/apache/spark/serializer/Serializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/Serializer.scala
@@ -182,6 +182,7 @@ abstract class DeserializationStream {
       } catch {
         case eof: EOFException =>
           finished = true
+          null
       }
     }
 


### PR DESCRIPTION
Return null if catch EOFException, just like function "asKeyValueIterator" in this class
