### PR TITLE
[SPARK-8265] [MLlib] [PySpark] Add LinearDataGenerator to pyspark.mllib.utils

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
@@ -961,7 +961,7 @@ private[python] class PythonMLLibAPI extends Serializable {
   def estimateKernelDensity(
       sample: JavaRDD[Double],
       bandwidth: Double, points: java.util.ArrayList[Double]): Array[Double] = {
-    return new KernelDensity().setSample(sample).setBandwidth(bandwidth).estimate(
+    new KernelDensity().setSample(sample).setBandwidth(bandwidth).estimate(
       points.asScala.toArray)
   }
 
@@ -985,20 +985,28 @@ private[python] class PythonMLLibAPI extends Serializable {
    */
   def generateLinearInputWrapper(
       intercept: Double,
-      weights: JArrayList[Double], xMean: JArrayList[Double],
-      xVariance: JArrayList[Double], nPoints: Int, seed: Int, eps: Double): Array[LabeledPoint] = {
-    return LinearDataGenerator.generateLinearInput(
-        intercept, weights.asScala.toArray, xMean.asScala.toArray,
-        xVariance.asScala.toArray, nPoints, seed, eps).toArray
+      weights: JList[Double],
+      xMean: JList[Double],
+      xVariance: JList[Double],
+      nPoints: Int,
+      seed: Int,
+      eps: Double): Array[LabeledPoint] = {
+    LinearDataGenerator.generateLinearInput(
+      intercept, weights.asScala.toArray, xMean.asScala.toArray,
+      xVariance.asScala.toArray, nPoints, seed, eps).toArray
   }
 
   /**
    * Wrapper around the generateLinearRDD method of LinearDataGenerator.
    */
   def generateLinearRDDWrapper(
-      sc: JavaSparkContext, nexamples: Int, nfeatures: Int,
-      eps: Double, nparts: Int, intercept: Double): JavaRDD[LabeledPoint] = {
-    return LinearDataGenerator.generateLinearRDD(
+      sc: JavaSparkContext,
+      nexamples: Int,
+      nfeatures: Int,
+      eps: Double,
+      nparts: Int,
+      intercept: Double): JavaRDD[LabeledPoint] = {
+    LinearDataGenerator.generateLinearRDD(
       sc, nexamples, nfeatures, eps, nparts, intercept)
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
@@ -51,6 +51,7 @@ import org.apache.spark.mllib.tree.loss.Losses
 import org.apache.spark.mllib.tree.model.{DecisionTreeModel, GradientBoostedTreesModel, RandomForestModel}
 import org.apache.spark.mllib.tree.{DecisionTree, GradientBoostedTrees, RandomForest}
 import org.apache.spark.mllib.util.MLUtils
+import org.apache.spark.mllib.util.LinearDataGenerator
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.storage.StorageLevel
@@ -979,6 +980,27 @@ private[python] class PythonMLLibAPI extends Serializable {
       List[AnyRef](model.clusterCenters, Vectors.dense(model.clusterWeights)).asJava
   }
 
+  /**
+   * Wrapper around the generateLinearInput method of LinearDataGenerator.
+   */
+  def generateLinearInputWrapper(
+      intercept: Double,
+      weights: JArrayList[Double], xMean: JArrayList[Double],
+      xVariance: JArrayList[Double], nPoints: Int, seed: Int, eps: Double): Array[LabeledPoint] = {
+    return LinearDataGenerator.generateLinearInput(
+        intercept, weights.asScala.toArray, xMean.asScala.toArray,
+        xVariance.asScala.toArray, nPoints, seed, eps).toArray
+  }
+
+  /**
+   * Wrapper around the generateLinearRDD method of LinearDataGenerator.
+   */
+  def generateLinearRDDWrapper(
+      sc: JavaSparkContext, nexamples: Int, nfeatures: Int,
+      eps: Double, nparts: Int, intercept: Double): JavaRDD[LabeledPoint] = {
+    return LinearDataGenerator.generateLinearRDD(
+      sc, nexamples, nfeatures, eps, nparts, intercept)
+  }
 }
 
 /**

--- a/python/pyspark/mllib/tests.py
+++ b/python/pyspark/mllib/tests.py
@@ -1013,17 +1013,19 @@ class StreamingKMeansTest(MLLibStreamingTestCase):
 
 class LinearDataGeneratorTests(MLlibTestCase):
     def test_dim(self):
-        points = LinearDataGenerator.generateLinearInput(
-            0.0, [0.0, 0.0, 0.0], [0.0, 0.0, 0.0],
-            [0.33, 0.33, 0.33], 4, 0, 0.1)
-        self.assertEqual(len(points), 4)
-        for point in points:
+        linear_data = LinearDataGenerator.generateLinearInput(
+            intercept=0.0, weights=[0.0, 0.0, 0.0],
+            xMean=[0.0, 0.0, 0.0], xVariance=[0.33, 0.33, 0.33],
+            nPoints=4, seed=0, eps=0.1)
+        self.assertEqual(len(linear_data), 4)
+        for point in linear_data:
             self.assertEqual(len(point.features), 3)
 
-        rdd = LinearDataGenerator.generateLinearRDD(
-            sc, 6, 2, 0.1, 2, 0.0).collect()
-        self.assertEqual(len(rdd), 6)
-        for point in rdd:
+        linear_data = LinearDataGenerator.generateLinearRDD(
+            sc=sc, nexamples=6, nfeatures=2, eps=0.1,
+            nParts=2, intercept=0.0).collect()
+        self.assertEqual(len(linear_data), 6)
+        for point in linear_data:
             self.assertEqual(len(point.features), 2)
 
 

--- a/python/pyspark/mllib/tests.py
+++ b/python/pyspark/mllib/tests.py
@@ -48,8 +48,8 @@ from pyspark.mllib.random import RandomRDDs
 from pyspark.mllib.stat import Statistics
 from pyspark.mllib.feature import Word2Vec
 from pyspark.mllib.feature import IDF
-from pyspark.mllib.feature import StandardScaler
-from pyspark.mllib.feature import ElementwiseProduct
+from pyspark.mllib.feature import StandardScaler, ElementwiseProduct
+from pyspark.mllib.util import LinearDataGenerator
 from pyspark.serializers import PickleSerializer
 from pyspark.streaming import StreamingContext
 from pyspark.sql import SQLContext
@@ -1009,6 +1009,22 @@ class StreamingKMeansTest(MLLibStreamingTestCase):
         self.ssc.start()
         self._ssc_wait(t, 6.0, 0.01)
         self.assertEqual(predict_results, [[0, 1, 1], [1, 0, 1]])
+
+
+class LinearDataGeneratorTests(MLlibTestCase):
+    def test_dim(self):
+        points = LinearDataGenerator.generateLinearInput(
+            0.0, [0.0, 0.0, 0.0], [0.0, 0.0, 0.0],
+            [0.33, 0.33, 0.33], 4, 0, 0.1)
+        self.assertEqual(len(points), 4)
+        for point in points:
+            self.assertEqual(len(point.features), 3)
+
+        rdd = LinearDataGenerator.generateLinearRDD(
+            sc, 6, 2, 0.1, 2, 0.0).collect()
+        self.assertEqual(len(rdd), 6)
+        for point in rdd:
+            self.assertEqual(len(point.features), 2)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/mllib/util.py
+++ b/python/pyspark/mllib/util.py
@@ -265,7 +265,7 @@ class LinearDataGenerator(object):
                             nPoints, seed, eps):
         """
         :param: intercept bias factor, the term c in X'w + c
-        :param: weights   feature vector the term w in X'w + c
+        :param: weights   feature vector, the term w in X'w + c
         :param: xMean     Point around which the data X is centered.
         :param: xVariance Variance of the given data
         :param: nPoints   Number of points to be generated

--- a/python/pyspark/mllib/util.py
+++ b/python/pyspark/mllib/util.py
@@ -257,6 +257,44 @@ class JavaLoader(Loader):
         return cls(java_model)
 
 
+class LinearDataGenerator(object):
+    """Utils for generating linear data"""
+
+    @staticmethod
+    def generateLinearInput(intercept, weights, xMean, xVariance,
+                            nPoints, seed, eps):
+        """
+        :param: intercept bias factor, the term c in X'w + c
+        :param: weights   feature vector the term w in X'w + c
+        :param: xMean     Point around which the data X is centered.
+        :param: xVariance Variance of the given data
+        :param: nPoints   Number of points to be generated
+        :param: seed      Random Seed
+        :param: eps       Used to scale the noise. If eps is set high,
+                          the amount of gaussian noise added is more.
+        Returns a list of LabeledPoints of length nPoints
+        """
+        seed, nPoints = int(seed), int(nPoints)
+        intercept, eps = float(intercept), float(eps)
+        weights = [float(weight) for weight in weights]
+        xMean = [float(mean) for mean in xMean]
+        xVariance = [float(var) for var in xVariance]
+        return list(callMLlibFunc(
+            "generateLinearInputWrapper", intercept, weights, xMean, xVariance,
+            nPoints, seed, eps))
+
+    @staticmethod
+    def generateLinearRDD(sc, nexamples, nfeatures, eps,
+                          nParts=2, intercept=0.0):
+        """
+        Generate a RDD of LabeledPoints.
+        """
+        nexamples, nfeatures, nParts = int(nexamples), int(nfeatures), int(nParts)
+        intercept, eps = float(intercept), float(eps)
+        return callMLlibFunc("generateLinearRDDWrapper", sc, nexamples, nfeatures,
+                             eps, nParts, intercept)
+
+
 def _test():
     import doctest
     from pyspark.context import SparkContext

--- a/python/pyspark/mllib/util.py
+++ b/python/pyspark/mllib/util.py
@@ -274,14 +274,12 @@ class LinearDataGenerator(object):
                           the amount of gaussian noise added is more.
         Returns a list of LabeledPoints of length nPoints
         """
-        seed, nPoints = int(seed), int(nPoints)
-        intercept, eps = float(intercept), float(eps)
         weights = [float(weight) for weight in weights]
         xMean = [float(mean) for mean in xMean]
         xVariance = [float(var) for var in xVariance]
         return list(callMLlibFunc(
-            "generateLinearInputWrapper", intercept, weights, xMean, xVariance,
-            nPoints, seed, eps))
+            "generateLinearInputWrapper", float(intercept), weights, xMean,
+            xVariance, int(nPoints), int(seed), float(eps)))
 
     @staticmethod
     def generateLinearRDD(sc, nexamples, nfeatures, eps,
@@ -289,10 +287,9 @@ class LinearDataGenerator(object):
         """
         Generate a RDD of LabeledPoints.
         """
-        nexamples, nfeatures, nParts = int(nexamples), int(nfeatures), int(nParts)
-        intercept, eps = float(intercept), float(eps)
-        return callMLlibFunc("generateLinearRDDWrapper", sc, nexamples, nfeatures,
-                             eps, nParts, intercept)
+        return callMLlibFunc(
+            "generateLinearRDDWrapper", sc, int(nexamples), int(nfeatures),
+            float(eps), int(nParts), float(intercept))
 
 
 def _test():


### PR DESCRIPTION
It is useful to generate linear data for easy testing of linear models and in general. Scala already has it. This is just a wrapper around the Scala code.
