### PR TITLE
[SPARK-7527][Core]Fix createNullValue to return the correct null values and REPL mode detection

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/ClosureCleaner.scala
+++ b/core/src/main/scala/org/apache/spark/util/ClosureCleaner.scala
@@ -109,15 +109,13 @@ private[spark] object ClosureCleaner extends Logging {
 
   private def createNullValue(cls: Class[_]): AnyRef = {
     if (cls.isPrimitive) {
-      if (cls == java.lang.Boolean.TYPE) {
-        new java.lang.Boolean(false)
-      } else if (cls == java.lang.Character.TYPE) {
-        new java.lang.Character('\0')
-      } else if (cls == java.lang.Void.TYPE) {
-        // It should not happen because `Foo(void x) {}` won't be compiled.
-        throw new IllegalStateException("This should not happen")
-      } else {
-        new java.lang.Byte(0: Byte)
+      cls match {
+        case java.lang.Boolean.TYPE => new java.lang.Boolean(false)
+        case java.lang.Character.TYPE => new java.lang.Character('\0')
+        case java.lang.Void.TYPE =>
+          // This should not happen because `Foo(void x) {}` cannot be compiled.
+          throw new IllegalStateException("This should not happen")
+        case _ => new java.lang.Byte(0: Byte)
       }
     } else {
       null

--- a/core/src/main/scala/org/apache/spark/util/ClosureCleaner.scala
+++ b/core/src/main/scala/org/apache/spark/util/ClosureCleaner.scala
@@ -109,7 +109,16 @@ private[spark] object ClosureCleaner extends Logging {
 
   private def createNullValue(cls: Class[_]): AnyRef = {
     if (cls.isPrimitive) {
-      new java.lang.Byte(0: Byte) // Should be convertible to any primitive type
+      if (cls == java.lang.Boolean.TYPE) {
+        new java.lang.Boolean(false)
+      } else if (cls == java.lang.Character.TYPE) {
+        new java.lang.Character('\0')
+      } else if (cls == java.lang.Void.TYPE) {
+        // It should not happen because `Foo(void x) {}` won't be compiled.
+        throw new IllegalStateException("This should not happen")
+      } else {
+        new java.lang.Byte(0: Byte)
+      }
     } else {
       null
     }

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1804,15 +1804,10 @@ private[spark] object Utils extends Logging {
 
   lazy val isInInterpreter: Boolean = {
     try {
-      val interpClass = classForName("spark.repl.Main")
+      val interpClass = classForName("org.apache.spark.repl.Main")
       interpClass.getMethod("interp").invoke(null) != null
     } catch {
-      // Returning true seems to be a mistake.
-      // Currently changing it to false causes tests failures in Streaming.
-      // For a more detailed discussion, please, refer to
-      // https://github.com/apache/spark/pull/5835#issuecomment-101042271 and subsequent comments.
-      // Addressing this changed is tracked as https://issues.apache.org/jira/browse/SPARK-7527
-      case _: ClassNotFoundException => true
+      case _: ClassNotFoundException => false
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/util/ClosureCleanerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/ClosureCleanerSuite.scala
@@ -372,14 +372,16 @@ class TestCreateNullValue {
     val d: Double = 1
 
     val nestedClosure = () => {
-      println(bo)
-      println(c)
-      println(b)
-      println(s)
-      println(i)
-      println(l)
-      println(f)
-      println(d)
+      if (s.toString == "123") { // Don't really output them to avoid noisy
+        println(bo)
+        println(c)
+        println(b)
+        println(s)
+        println(i)
+        println(l)
+        println(f)
+        println(d)
+      }
 
       val closure = () => {
         println(getX)

--- a/core/src/test/scala/org/apache/spark/util/ClosureCleanerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/ClosureCleanerSuite.scala
@@ -121,6 +121,10 @@ class ClosureCleanerSuite extends SparkFunSuite {
       expectCorrectException { TestUserClosuresActuallyCleaned.testSubmitJob(sc) }
     }
   }
+
+  test("createNullValue") {
+    new TestCreateNullValue().run()
+  }
 }
 
 // A non-serializable class we create in closures to make sure that we aren't
@@ -348,5 +352,40 @@ private object TestUserClosuresActuallyCleaned {
       { case (_, _) => return }: (Int, Int) => Unit,
       { return }
     )
+  }
+}
+
+class TestCreateNullValue {
+
+  var x = 5
+
+  def getX: Int = x
+
+  def run(): Unit = {
+    val bo: Boolean = true
+    val c: Char = '1'
+    val b: Byte = 1
+    val s: Short = 1
+    val i: Int = 1
+    val l: Long = 1
+    val f: Float = 1
+    val d: Double = 1
+
+    val nestedClosure = () => {
+      println(bo)
+      println(c)
+      println(b)
+      println(s)
+      println(i)
+      println(l)
+      println(f)
+      println(d)
+
+      val closure = () => {
+        println(getX)
+      }
+      ClosureCleaner.clean(closure)
+    }
+    nestedClosure()
   }
 }


### PR DESCRIPTION
The root cause of SPARK-7527 is `createNullValue` returns an incompatible value `Byte(0)` for `char` and `boolean`. 

This PR fixes it and corrects the class name of the main class, and also adds an unit test to demonstrate it.
