### PR TITLE
[SPARK-7756] CORE RDDOperationScope fix for IBM Java

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
@@ -97,7 +97,7 @@ private[spark] object RDDOperationScope extends Logging {
       allowNesting: Boolean = false)(body: => T): T = {
 
     val callerMethodName = Thread.currentThread.getStackTrace()
-      .dropWhile(! _.getMethodName().equals("withScope"))
+      .dropWhile(_.getMethodName != "withScope")
       .find(_.getMethodName != "withScope")
       .map(_.getMethodName)
       .getOrElse {

--- a/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
@@ -95,17 +95,17 @@ private[spark] object RDDOperationScope extends Logging {
   private[spark] def withScope[T](
       sc: SparkContext,
       allowNesting: Boolean = false)(body: => T): T = {
-    val stackTrace = Thread.currentThread.getStackTrace().tail // ignore "Thread#getStackTrace"
-    val ourMethodName = stackTrace(1).getMethodName // i.e. withScope
-    // Climb upwards to find the first method that's called something different
-    val callerMethodName = stackTrace
-      .find(_.getMethodName != ourMethodName)
+
+    val callerMethodName = Thread.currentThread.getStackTrace()
+      .dropWhile(! _.getMethodName().equals("withScope"))
+      .find(_.getMethodName != "withScope")
       .map(_.getMethodName)
       .getOrElse {
         // Log a warning just in case, but this should almost certainly never happen
         logWarning("No valid method name for this RDD operation scope!")
         "N/A"
       }
+
     withScope[T](sc, callerMethodName, allowNesting, ignoreParent = false)(body)
   }
 


### PR DESCRIPTION
IBM Java has an extra method when we do getStackTrace(): this is "getStackTraceImpl", a native method. This causes two tests to fail within "DStreamScopeSuite" when running with IBM Java. Instead of "map" or "filter" being the method names found, "getStackTrace" is returned. This commit addresses such an issue by using dropWhile. Given that our current method is withScope, we look for the next method that isn't ours: we don't care about methods that come before us in the stack trace: e.g. getStackTrace (regardless of how many levels this might go).

IBM:
java.lang.Thread.getStackTraceImpl(Native Method)
java.lang.Thread.getStackTrace(Thread.java:1117)
org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:104)

Oracle:
PRINTING STACKTRACE!!!
java.lang.Thread.getStackTrace(Thread.java:1552)
org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:106)

I've tested this with Oracle and IBM Java, no side effects for other tests introduced.
