### PR TITLE
[Spark-7179][SQL]add tablenamepattern to  hive sql  of "show tables"

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSQLParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSQLParser.scala
@@ -65,7 +65,8 @@ private[sql] class SparkSQLParser(fallback: String => LogicalPlan) extends Abstr
   protected val TABLES = Keyword("TABLES")
   protected val UNCACHE = Keyword("UNCACHE")
 
-  override protected lazy val start: Parser[LogicalPlan] = cache ||| uncache ||| set ||| show ||| others
+  override protected lazy val start: Parser[LogicalPlan] =
+    cache ||| uncache ||| set ||| show ||| others
 
   private lazy val cache: Parser[LogicalPlan] =
     CACHE ~> LAZY.? ~ (TABLE ~> ident) ~ (AS ~> restInput).? ^^ {

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSQLParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSQLParser.scala
@@ -65,7 +65,7 @@ private[sql] class SparkSQLParser(fallback: String => LogicalPlan) extends Abstr
   protected val TABLES = Keyword("TABLES")
   protected val UNCACHE = Keyword("UNCACHE")
 
-  override protected lazy val start: Parser[LogicalPlan] = cache | uncache | set | show | others
+  override protected lazy val start: Parser[LogicalPlan] = cache ||| uncache ||| set ||| show ||| others
 
   private lazy val cache: Parser[LogicalPlan] =
     CACHE ~> LAZY.? ~ (TABLE ~> ident) ~ (AS ~> restInput).? ^^ {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/ExtendedHiveQlParser.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/ExtendedHiveQlParser.scala
@@ -21,8 +21,7 @@ import scala.language.implicitConversions
 
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.AbstractSparkSQLParser
-import org.apache.spark.sql.hive.execution.{AddJar, AddFile, HiveNativeCommand}
-import org.apache.spark.sql.execution.ShowTablesCommand
+import org.apache.spark.sql.hive.execution.{AddJar, AddFile, HiveNativeCommand, ShowTablesCommand}
 
 /**
  * A parser that recognizes all HiveQL constructs together with Spark SQL specific extensions.
@@ -64,6 +63,6 @@ private[hive] class ExtendedHiveQlParser extends AbstractSparkSQLParser {
 
   private lazy val showInHive: Parser[LogicalPlan] =
     SHOW ~ TABLES ~> (IN ~> ident).? ~ opt(stringLit) ^^ {
-      case dbName ~ reg => {println("aaa:" + reg + "|dbName:" + dbName);ShowTablesCommand(dbName)}
+      case dbName ~ reg => ShowTablesCommand(dbName, reg)
     }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/ExtendedHiveQlParser.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/ExtendedHiveQlParser.scala
@@ -33,11 +33,9 @@ private[hive] class ExtendedHiveQlParser extends AbstractSparkSQLParser {
   protected val DFS = Keyword("DFS")
   protected val FILE = Keyword("FILE")
   protected val JAR = Keyword("JAR")
-
-  protected val IN      = Keyword("IN")
-  protected val SHOW    = Keyword("SHOW")
-  protected val TABLES  = Keyword("TABLES")
-
+  protected val IN = Keyword("IN")
+  protected val SHOW = Keyword("SHOW")
+  protected val TABLES = Keyword("TABLES")
 
   protected lazy val start: Parser[LogicalPlan] = dfs | addJar | addFile | showInHive | hiveQl
 
@@ -63,6 +61,6 @@ private[hive] class ExtendedHiveQlParser extends AbstractSparkSQLParser {
 
   private lazy val showInHive: Parser[LogicalPlan] =
     SHOW ~ TABLES ~> (IN ~> ident).? ~ opt(stringLit) ^^ {
-      case dbName ~ reg => ShowTablesCommand(dbName, reg)
+      case dbName ~ regexPattern => ShowTablesCommand(dbName, regexPattern)
     }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -343,6 +343,12 @@ private[hive] class HiveMetastoreCatalog(val client: ClientInterface, hive: Hive
     client.listTables(db).map(tableName => (tableName, false))
   }
 
+  def getTables(databaseName: Option[String], pattern: String): Seq[(String, Boolean)] = {
+    val db = databaseName.getOrElse(client.currentDatabase)
+
+    client.listTables(db, Some(pattern)).map(tableName => (tableName, false))
+  }
+
   protected def processDatabaseAndTableName(
       databaseName: Option[String],
       tableName: String): (Option[String], String) = {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -345,7 +345,6 @@ private[hive] class HiveMetastoreCatalog(val client: ClientInterface, hive: Hive
 
   def getTables(databaseName: Option[String], pattern: String): Seq[(String, Boolean)] = {
     val db = databaseName.getOrElse(client.currentDatabase)
-
     client.listTables(db, Some(pattern)).map(tableName => (tableName, false))
   }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientInterface.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientInterface.scala
@@ -94,8 +94,7 @@ private[hive] trait ClientInterface {
   def setError(stream: PrintStream): Unit
 
   /** Returns the names of all tables in the given database. */
-  def listTables(dbName: String): Seq[String]
-
+  def listTables(dbName: String, pattern: Option[String] = None): Seq[String]
   /** Returns the name of the active database. */
   def currentDatabase: String
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
@@ -289,7 +289,11 @@ private[hive] class ClientWrapper(
   }
 
   override def listTables(dbName: String, pattern: Option[String]): Seq[String] = withHiveState {
-    pattern.map(client.getTablesByPattern(dbName, _)).getOrElse(client.getAllTables(dbName))
+    if (pattern.isDefined) {
+      client.getTablesByPattern(dbName, pattern.get)
+    } else {
+      client.getAllTables(dbName)
+    }
   }
 
   /**

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
@@ -288,8 +288,12 @@ private[hive] class ClientWrapper(
     qlPartitions.toSeq.map(toHivePartition)
   }
 
-  override def listTables(dbName: String): Seq[String] = withHiveState {
-    client.getAllTables(dbName)
+  override def listTables(dbName: String, pattern: Option[String]): Seq[String] = withHiveState {
+    if (pattern.isDefined) {
+      client.getTablesByPattern(dbName, pattern.get)
+    } else {
+      client.getAllTables(dbName)
+    }
   }
 
   /**

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
@@ -289,11 +289,7 @@ private[hive] class ClientWrapper(
   }
 
   override def listTables(dbName: String, pattern: Option[String]): Seq[String] = withHiveState {
-    if (pattern.isDefined) {
-      client.getTablesByPattern(dbName, pattern.get)
-    } else {
-      client.getAllTables(dbName)
-    }
+    pattern.map(client.getTablesByPattern(dbName, _)).getOrElse(client.getAllTables(dbName))
   }
 
   /**

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/commands.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/commands.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.{SaveMode, DataFrame, SQLContext}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Row}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.RunnableCommand
-import org.apache.spark.sql.hive.HiveContext
+import org.apache.spark.sql.hive.{HiveMetastoreCatalog, HiveContext}
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 
@@ -254,5 +254,35 @@ case class CreateMetastoreDataSourceAsSelect(
     // Refresh the cache of the table in the catalog.
     hiveContext.refreshTable(tableName)
     Seq.empty[Row]
+  }
+}
+
+private[hive]
+case class ShowTablesCommand(databaseName: Option[String], pattern: Option[String]) extends RunnableCommand {
+
+  // The result of SHOW TABLES has two columns, tableName and isTemporary.
+  override val output: Seq[Attribute] = {
+    val schema = StructType(
+      StructField("tableName", StringType, false) ::
+        StructField("isTemporary", BooleanType, false) :: Nil)
+
+    schema.toAttributes
+  }
+
+  override def run(sqlContext: SQLContext): Seq[Row] = {
+    // Since we need to return a Seq of rows, we will call getTables directly
+    // instead of calling tables in sqlContext.
+    val rows = pattern.isDefined match {
+      case true => sqlContext.catalog.asInstanceOf[HiveMetastoreCatalog]
+        .getTables(databaseName, pattern.get).map {
+        case (tableName, isTemporary) => Row(tableName, isTemporary)
+      }
+      // we should notic this branch wll can OverrideCatalog.getTables first
+      case false => sqlContext.catalog.getTables(databaseName).map {
+        case (tableName, isTemporary) => Row(tableName, isTemporary)
+      }
+    }
+
+    rows
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/ListTablesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/ListTablesSuite.scala
@@ -81,9 +81,9 @@ class ListTablesSuite extends QueryTest with BeforeAndAfterAll {
 
   test("SPARK-7179:show tables with pattern") {
     checkAnswer(
-      sql("TABLES IN in listTablesSuitedb 'hive*'"),
+      sql("SHOW TABLES IN listTablesSuitedb 'hive*'"),
       Row("hiveindblisttablessuitetable", false))
     // not match the pattern
-    assert(sql("TABLES IN in listTablesSuitedb 'aa*'").count() === 0)
+    assert(sql("SHOW TABLES IN listTablesSuitedb 'aa*'").count() === 0)
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/ListTablesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/ListTablesSuite.scala
@@ -79,12 +79,11 @@ class ListTablesSuite extends QueryTest with BeforeAndAfterAll {
     }
   }
 
-  test("SPARK-7179:shwo table with pattern") {
-    val tables = sql("SHOW TABLes in listTablesSuitedb 'hive*'")
+  test("SPARK-7179:show tables with pattern") {
     checkAnswer(
-      sql("SHOW TABLes in listTablesSuitedb 'hive*'"),
+      sql("TABLES IN in listTablesSuitedb 'hive*'"),
       Row("hiveindblisttablessuitetable", false))
     // not match the pattern
-    assert(sql("SHOW TABLes in listTablesSuitedb 'aa*'").count() === 0)
+    assert(sql("TABLES IN in listTablesSuitedb 'aa*'").count() === 0)
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/ListTablesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/ListTablesSuite.scala
@@ -78,4 +78,13 @@ class ListTablesSuite extends QueryTest with BeforeAndAfterAll {
           Row("hiveindblisttablessuitetable", false))
     }
   }
+
+  test("SPARK-7179:shwo table with pattern") {
+    val tables = sql("SHOW TABLes in listTablesSuitedb 'hive*'")
+    checkAnswer(
+      sql("SHOW TABLes in listTablesSuitedb 'hive*'"),
+      Row("hiveindblisttablessuitetable", false))
+    // not match the pattern
+    assert(sql("SHOW TABLes in listTablesSuitedb 'aa*'").count() === 0)
+  }
 }


### PR DESCRIPTION
the whole hive sql grammar of "show tables " is like "show tables [in databasename] [tablenamepattern]",  "show tables [in databasename]"  is already implement at spark **sql** component, and this PR implement "show tables [in databasename] tablenamepattern" at  spark **hive** component
