### PR TITLE
WiP: SPARK-8064 Upgrade to Hive 1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -642,6 +642,16 @@
         </exclusions>
       </dependency>
       <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>${fasterxml.jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>${fasterxml.jackson.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.sun.jersey</groupId>
         <artifactId>jersey-server</artifactId>
         <version>1.9</version>
@@ -1061,6 +1071,11 @@
             <groupId>org.apache.calcite</groupId>
             <artifactId>calcite-avatica</artifactId>
           </exclusion>
+          <!-- excluded to keep out transitive dependencies -->
+          <exclusion>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -1074,7 +1089,6 @@
         <artifactId>hive-metastore</artifactId>
         <version>${hive.version}</version>
         <scope>${hive.deps.scope}</scope>
-<!--
         <exclusions>
           <exclusion>
             <groupId>org.apache.hive</groupId>
@@ -1085,7 +1099,6 @@
             <artifactId>hadoop-yarn-server-resourcemanager</artifactId>
           </exclusion>
         </exclusions>
--->
       </dependency>
       <dependency>
         <groupId>${hive.group}</groupId>
@@ -1155,11 +1168,39 @@
         <groupId>org.apache.calcite</groupId>
         <artifactId>calcite-core</artifactId>
         <version>${calcite.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.calcite</groupId>
         <artifactId>calcite-avatica</artifactId>
         <version>${calcite.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -130,12 +130,16 @@
     <flume.version>1.4.0</flume.version>
     <zookeeper.version>3.4.5</zookeeper.version>
     <curator.version>2.4.0</curator.version>
+    <hive.group>org.apache.hive</hive.group>
+<!--
     <hive.group>org.spark-project.hive</hive.group>
+-->
     <!-- Version used in Maven Hive dependency -->
-    <hive.version>0.13.1a</hive.version>
+    <hive.version>1.2.0</hive.version>
     <!-- Version used for internal directory structure -->
-    <hive.version.short>0.13.1</hive.version.short>
+    <hive.version.short>1.2.0</hive.version.short>
     <derby.version>10.10.1.1</derby.version>
+    <calcite.version>1.2.0-incubating</calcite.version>
     <parquet.version>1.7.0</parquet.version>
     <jblas.version>1.2.4</jblas.version>
     <jetty.version>8.1.14.v20131031</jetty.version>
@@ -262,7 +266,7 @@
       <name>Spring Release Repository</name>
       <url>https://repo.spring.io/libs-release</url>
       <releases>
-        <enabled>true</enabled>
+        <enabled>false</enabled>
       </releases>
       <snapshots>
         <enabled>false</enabled>
@@ -1049,6 +1053,14 @@
             <groupId>org.apache.avro</groupId>
             <artifactId>avro-mapred</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.apache.calcite</groupId>
+            <artifactId>calcite-core</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.calcite</groupId>
+            <artifactId>calcite-avatica</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -1062,6 +1074,18 @@
         <artifactId>hive-metastore</artifactId>
         <version>${hive.version}</version>
         <scope>${hive.deps.scope}</scope>
+<!--
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-shims</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-yarn-server-resourcemanager</artifactId>
+          </exclusion>
+        </exclusions>
+-->
       </dependency>
       <dependency>
         <groupId>${hive.group}</groupId>
@@ -1126,6 +1150,16 @@
             <artifactId>libthrift</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.calcite</groupId>
+        <artifactId>calcite-core</artifactId>
+        <version>${calcite.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.calcite</groupId>
+        <artifactId>calcite-avatica</artifactId>
+        <version>${calcite.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -1794,6 +1828,17 @@
         <scala.binary.version>2.10</scala.binary.version>
         <jline.version>${scala.version}</jline.version>
         <jline.groupid>org.scala-lang</jline.groupid>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>hive-1.2</id>
+      <properties>
+        <hive.group>org.apache.hive</hive.group>
+        <hive.version>1.2.0</hive.version>
+        <hive.version.short>1.2.0</hive.version.short>
+        <derby.version>10.10.1.1</derby.version>
+        <calcite.version>1.2.0-incubating</calcite.version>
       </properties>
     </profile>
 

--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -117,6 +117,18 @@
       <artifactId>calcite-avatica</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.scalacheck</groupId>
       <artifactId>scalacheck_${scala.binary.version}</artifactId>
       <scope>test</scope>

--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -79,6 +79,18 @@
       <groupId>${hive.group}</groupId>
       <artifactId>hive-serde</artifactId>
     </dependency>
+    <dependency>
+      <groupId>${hive.group}</groupId>
+      <artifactId>hive-cli</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${hive.group}</groupId>
+      <artifactId>hive-jdbc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${hive.group}</groupId>
+      <artifactId>hive-beeline</artifactId>
+    </dependency>
     <!-- hive-serde already depends on avro, but this brings in customized config of avro deps from parent -->
     <dependency>
       <groupId>org.apache.avro</groupId>
@@ -90,6 +102,19 @@
       <groupId>org.apache.avro</groupId>
       <artifactId>avro-mapred</artifactId>
       <classifier>${avro.mapred.classifier}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>com.twitter</groupId>
+      <artifactId>parquet-hive-bundle</artifactId>
+      <version>1.5.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.calcite</groupId>
+      <artifactId>calcite-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.calcite</groupId>
+      <artifactId>calcite-avatica</artifactId>
     </dependency>
     <dependency>
       <groupId>org.scalacheck</groupId>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -532,7 +532,7 @@ private[hive] object HiveContext {
     // as we used a local metastore here.
     HiveConf.ConfVars.values().foreach { confvar =>
       if (confvar.varname.contains("datanucleus") || confvar.varname.contains("jdo")) {
-        propMap.put(confvar.varname, confvar.defaultVal)
+        propMap.put(confvar.varname, confvar.defaultStrVal)
       }
     }
     propMap.put("javax.jdo.option.ConnectionURL",

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -518,7 +518,7 @@ class HiveContext(sc: SparkContext) extends SQLContext(sc) {
 
 private[hive] object HiveContext {
   /** The version of hive used internally by Spark SQL. */
-  val hiveExecutionVersion: String = "0.13.1"
+  val hiveExecutionVersion: String = "1.2.0"
 
   val HIVE_METASTORE_VERSION: String = "spark.sql.hive.metastore.version"
   val HIVE_METASTORE_JARS: String = "spark.sql.hive.metastore.jars"
@@ -532,7 +532,7 @@ private[hive] object HiveContext {
     // as we used a local metastore here.
     HiveConf.ConfVars.values().foreach { confvar =>
       if (confvar.varname.contains("datanucleus") || confvar.varname.contains("jdo")) {
-        propMap.put(confvar.varname, confvar.defaultStrVal)
+        propMap.put(confvar.varname, confvar.getDefaultValue())
       }
     }
     propMap.put("javax.jdo.option.ConnectionURL",

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
@@ -287,12 +287,13 @@ private[hive] object HiveQl {
         pe.getMessage match {
           case errorRegEx(line, start, message) =>
             throw new AnalysisException(message, Some(line.toInt), Some(start.toInt))
+                .initCause(pe)
           case otherMessage =>
-            throw new AnalysisException(otherMessage)
+            throw new AnalysisException(otherMessage).initCause(pe)
         }
       case e: MatchError => throw e
       case e: Exception =>
-        throw new AnalysisException(e.getMessage)
+        throw new AnalysisException(e.getMessage).initCause(e)
       case e: NotImplementedError =>
         throw new AnalysisException(
           s"""
@@ -300,7 +301,7 @@ private[hive] object HiveQl {
             |${dumpTree(getAst(sql))}
             |$e
             |${e.getStackTrace.head}
-          """.stripMargin)
+          """.stripMargin).initCause(e)
     }
   }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
@@ -390,7 +390,8 @@ private[hive] class ClientWrapper(
       replace,
       holdDDLTime,
       inheritTableSpecs,
-      isSkewedStoreAsSubdir)
+      isSkewedStoreAsSubdir,
+      false, false)
   }
 
   def loadTable(
@@ -402,7 +403,8 @@ private[hive] class ClientWrapper(
       new Path(loadPath),
       tableName,
       replace,
-      holdDDLTime)
+      holdDDLTime,
+      false, false, false)
   }
 
   def loadDynamicPartitions(
@@ -420,7 +422,8 @@ private[hive] class ClientWrapper(
       replace,
       numDP,
       holdDDLTime,
-      listBucketingEnabled)
+      listBucketingEnabled,
+      false, 0)
   }
 
   def reset(): Unit = withHiveState {
@@ -428,7 +431,8 @@ private[hive] class ClientWrapper(
         logDebug(s"Deleting table $t")
         val table = client.getTable("default", t)
         client.getIndexes("default", t, 255).foreach { index =>
-          client.dropIndex("default", t, index.getIndexName, true)
+          client.dropIndex("default", t, index.getIndexName, true,
+            false)
         }
         if (!table.isIndexTable) {
           client.dropTable("default", t)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
@@ -132,7 +132,7 @@ private[hive] class ClientWrapper(
       case hive.v12 =>
         classOf[SessionState]
           .callStatic[SessionState, SessionState]("start", state)
-      case hive.v13 =>
+      case hive.v13 | hive.v120 =>
         classOf[SessionState]
           .callStatic[SessionState, SessionState]("setCurrentSessionState", state)
     }
@@ -200,7 +200,7 @@ private[hive] class ClientWrapper(
         },
         location = version match {
           case hive.v12 => Option(h.call[URI]("getDataLocation")).map(_.toString)
-          case hive.v13 => Option(h.call[Path]("getDataLocation")).map(_.toString)
+          case hive.v13 | hive.v120 => Option(h.call[Path]("getDataLocation")).map(_.toString)
         },
         inputFormat = Option(h.getInputFormatClass).map(_.getName),
         outputFormat = Option(h.getOutputFormatClass).map(_.getName),
@@ -234,7 +234,7 @@ private[hive] class ClientWrapper(
     version match {
       case hive.v12 =>
         table.location.map(new URI(_)).foreach(u => qlTable.call[URI, Unit]("setDataLocation", u))
-      case hive.v13 =>
+      case hive.v13 | hive.v120 =>
         table.location
           .map(new org.apache.hadoop.fs.Path(_))
           .foreach(qlTable.call[Path, Unit]("setDataLocation", _))
@@ -282,7 +282,7 @@ private[hive] class ClientWrapper(
     val qlPartitions = version match {
       case hive.v12 =>
         client.call[metadata.Table, JSet[metadata.Partition]]("getAllPartitionsForPruner", qlTable)
-      case hive.v13 =>
+      case hive.v13 | hive.v120 =>
         client.call[metadata.Table, JSet[metadata.Partition]]("getAllPartitionsOf", qlTable)
     }
     qlPartitions.toSeq.map(toHivePartition)
@@ -319,7 +319,7 @@ private[hive] class ClientWrapper(
         case hive.v12 =>
           classOf[CommandProcessorFactory]
             .callStatic[String, HiveConf, CommandProcessor]("get", tokens(0), conf)
-        case hive.v13 =>
+        case hive.v13 | hive.v120 =>
           classOf[CommandProcessorFactory]
             .callStatic[Array[String], HiveConf, CommandProcessor]("get", Array(tokens(0)), conf)
       }
@@ -339,7 +339,7 @@ private[hive] class ClientWrapper(
               val res = new JArrayList[String]
               driver.call[JArrayList[String], Boolean]("getResults", res)
               res.toSeq
-            case hive.v13 =>
+            case hive.v13 | hive.v120 =>
               val res = new JArrayList[Object]
               driver.call[JList[Object], Boolean]("getResults", res)
               res.map { r =>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
@@ -48,6 +48,7 @@ private[hive] object IsolatedClientLoader {
   def hiveVersion(version: String): HiveVersion = version match {
     case "12" | "0.12" | "0.12.0" => hive.v12
     case "13" | "0.13" | "0.13.0" | "0.13.1" => hive.v13
+    case "1.2.0" => hive.v120
   }
 
   private def downloadVersion(version: HiveVersion): Seq[URL] = {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/package.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/package.scala
@@ -27,6 +27,7 @@ package object client {
     case object v11 extends HiveVersion("0.11.0", false)
     case object v12 extends HiveVersion("0.12.0", false)
     case object v13 extends HiveVersion("0.13.1", false)
+    case object v120 extends HiveVersion("1.2.0", false)
   }
   // scalastyle:on
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -124,7 +124,7 @@ case class InsertIntoHiveTable(
     // instances within the closure, since Serializer is not serializable while TableDesc is.
     val tableDesc = table.tableDesc
     val tableLocation = table.hiveQlTable.getDataLocation
-    val tmpLocation = hiveContext.getExternalTmpPath(tableLocation.toUri)
+    val tmpLocation = hiveContext.getExternalTmpPath(tableLocation)
     val fileSinkConf = new FileSinkDesc(tmpLocation.toString, tableDesc, false)
     val isCompressed = sc.hiveconf.getBoolean(
       ConfVars.COMPRESSRESULT.varname, ConfVars.COMPRESSRESULT.defaultBoolVal)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUdfs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUdfs.scala
@@ -220,7 +220,7 @@ private[spark] object ResolveHiveWindowFunction extends Rule[LogicalPlan] {
           // Get the class of this function.
           // In Hive 0.12, there is no windowFunctionInfo.getFunctionClass. So, we use
           // windowFunctionInfo.getfInfo().getFunctionClass for both Hive 0.13 and Hive 0.13.1.
-          val functionClass = windowFunctionInfo.getfInfo().getFunctionClass
+          val functionClass = windowFunctionInfo.getFunctionClass()
           val newChildren =
             // Rank(), DENSE_RANK(), CUME_DIST(), and PERCENT_RANK() do not take explicit
             // input parameters and requires implicit parameters, which

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveWriterContainers.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveWriterContainers.scala
@@ -167,7 +167,7 @@ private[spark] class SparkHiveDynamicPartitionWriterContainer(
   import SparkHiveDynamicPartitionWriterContainer._
 
   private val defaultPartName = jobConf.get(
-    ConfVars.DEFAULTPARTITIONNAME.varname, ConfVars.DEFAULTPARTITIONNAME.defaultVal)
+    ConfVars.DEFAULTPARTITIONNAME.varname, ConfVars.DEFAULTPARTITIONNAME.defaultStrVal)
 
   @transient private var writers: mutable.HashMap[String, FileSinkOperator.RecordWriter] = _
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveWriterContainers.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveWriterContainers.scala
@@ -167,7 +167,7 @@ private[spark] class SparkHiveDynamicPartitionWriterContainer(
   import SparkHiveDynamicPartitionWriterContainer._
 
   private val defaultPartName = jobConf.get(
-    ConfVars.DEFAULTPARTITIONNAME.varname, ConfVars.DEFAULTPARTITIONNAME.defaultStrVal)
+    ConfVars.DEFAULTPARTITIONNAME.varname, ConfVars.DEFAULTPARTITIONNAME.getDefaultValue())
 
   @transient private var writers: mutable.HashMap[String, FileSinkOperator.RecordWriter] = _
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFilters.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFilters.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.hive.orc
 
 import org.apache.hadoop.hive.common.`type`.{HiveChar, HiveDecimal, HiveVarchar}
-import org.apache.hadoop.hive.ql.io.sarg.SearchArgument
+import org.apache.hadoop.hive.ql.io.sarg.{SearchArgumentFactory, SearchArgument}
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgument.Builder
 import org.apache.hadoop.hive.serde2.io.DateWritable
 
@@ -33,13 +33,13 @@ import org.apache.spark.sql.sources._
 private[orc] object OrcFilters extends Logging {
   def createFilter(expr: Array[Filter]): Option[SearchArgument] = {
     expr.reduceOption(And).flatMap { conjunction =>
-      val builder = SearchArgument.FACTORY.newBuilder()
+      val builder = SearchArgumentFactory.newBuilder()
       buildSearchArgument(conjunction, builder).map(_.build())
     }
   }
 
   private def buildSearchArgument(expression: Filter, builder: Builder): Option[Builder] = {
-    def newBuilder = SearchArgument.FACTORY.newBuilder()
+    def newBuilder = SearchArgumentFactory.newBuilder()
 
     def isSearchableLiteral(value: Any) = value match {
       // These are types recognized by the `SearchArgumentImpl.BuilderImpl.boxLiteral()` method.

--- a/sql/hive/src/test/java/test/org/apache/spark/sql/hive/JavaDataFrameSuite.java
+++ b/sql/hive/src/test/java/test/org/apache/spark/sql/hive/JavaDataFrameSuite.java
@@ -61,7 +61,9 @@ public class JavaDataFrameSuite {
   @After
   public void tearDown() throws IOException {
     // Clean up tables.
-    hc.sql("DROP TABLE IF EXISTS window_table");
+    if (hc != null) {
+      hc.sql("DROP TABLE IF EXISTS window_table");
+    }
   }
 
   @Test

--- a/sql/hive/src/test/java/test/org/apache/spark/sql/hive/JavaMetastoreDataSourcesSuite.java
+++ b/sql/hive/src/test/java/test/org/apache/spark/sql/hive/JavaMetastoreDataSourcesSuite.java
@@ -90,8 +90,10 @@ public class JavaMetastoreDataSourcesSuite {
   @After
   public void tearDown() throws IOException {
     // Clean up tables.
-    sqlContext.sql("DROP TABLE IF EXISTS javaSavedTable");
-    sqlContext.sql("DROP TABLE IF EXISTS externalTable");
+    if (sqlContext != null) {
+      sqlContext.sql("DROP TABLE IF EXISTS javaSavedTable");
+      sqlContext.sql("DROP TABLE IF EXISTS externalTable");
+    }
   }
 
   @Test

--- a/sql/hive/src/test/java/test/org/apache/spark/sql/hive/LibraryDependenciesSuite.java
+++ b/sql/hive/src/test/java/test/org/apache/spark/sql/hive/LibraryDependenciesSuite.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.org.apache.spark.sql.hive;
+
+import com.google.common.base.Preconditions;
+import org.apache.spark.sql.hive.HiveContext;
+import org.apache.spark.sql.hive.client.IsolatedClientLoader$;
+import org.apache.spark.sql.hive.test.TestHive$;
+import org.junit.Assert;
+import org.junit.Test;
+import scala.Tuple2;
+import scala.collection.Iterator;
+import scala.collection.immutable.Map;
+
+/**
+ * This test suite contains some methods simply to force dependencies to load,
+ * and so detect transitive version conflicts and binding problems.
+ */
+public class LibraryDependenciesSuite extends Assert {
+
+  @Test
+  public void testLoadGuava() throws Throwable {
+    Preconditions.checkArgument(true);
+  }
+
+  @Test
+  public void testLoadTestHive() throws Throwable {
+    assertEquals("1.2.0", HiveContext.hiveExecutionVersion());
+  }
+
+  @Test
+  public void testContextConfig() throws Throwable {
+    Map<String, String> context = HiveContext.newTemporaryConfiguration();
+    Iterator<Tuple2<String, String>> iterator = context.iterator();
+    while (iterator.hasNext()) {
+      Tuple2<String, String> next = iterator.next();
+      assertNotNull(next._1(), "null key");
+      assertNotNull(next._2(), "null value for key " + next._1());
+    }
+
+  }
+}

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveComparisonTest.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveComparisonTest.scala
@@ -237,6 +237,7 @@ abstract class HiveComparisonTest
 
     test(testCaseName) {
       logDebug(s"=== HIVE TEST: $testCaseName ===")
+      logDebug(s"$sql")
 
       // Clear old output for this testcase.
       outputDirectories.map(new File(_, testCaseName)).filter(_.exists()).foreach(_.delete())

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -947,7 +947,7 @@ class HiveQuerySuite extends HiveComparisonTest with BeforeAndAfter {
         .zip(parts)
         .map { case (k, v) =>
           if (v == "NULL") {
-            s"$k=${ConfVars.DEFAULTPARTITIONNAME.defaultVal}"
+            s"$k=${ConfVars.DEFAULTPARTITIONNAME.defaultStrVal}"
           } else {
             s"$k=$v"
           }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -947,7 +947,7 @@ class HiveQuerySuite extends HiveComparisonTest with BeforeAndAfter {
         .zip(parts)
         .map { case (k, v) =>
           if (v == "NULL") {
-            s"$k=${ConfVars.DEFAULTPARTITIONNAME.defaultStrVal}"
+            s"$k=${ConfVars.DEFAULTPARTITIONNAME.getDefaultValue()}"
           } else {
             s"$k=$v"
           }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -194,7 +194,7 @@ class SQLQuerySuite extends QueryTest {
     val originalConf = getConf("spark.sql.hive.convertCTAS", "false")
 
     setConf("spark.sql.hive.convertCTAS", "true")
-
+    sql("DROP TABLE IF EXISTS ctas1")
     sql("CREATE TABLE ctas1 AS SELECT key k, value FROM src ORDER BY k, value")
     sql("CREATE TABLE IF NOT EXISTS ctas1 AS SELECT key k, value FROM src ORDER BY k, value")
     var message = intercept[AnalysisException] {
@@ -268,6 +268,7 @@ class SQLQuerySuite extends QueryTest {
   }
 
   test("CTAS with serde") {
+    sql("DROP TABLE IF EXISTS ctas1")
     sql("CREATE TABLE ctas1 AS SELECT key k, value FROM src ORDER BY k, value").collect()
     sql(
       """CREATE TABLE ctas2
@@ -414,6 +415,7 @@ class SQLQuerySuite extends QueryTest {
   }
 
   test("test CTAS") {
+    sql("DROP TABLE IF EXISTS test_ctas_123")
     checkAnswer(sql("CREATE TABLE test_ctas_123 AS SELECT key, value FROM src"), Seq.empty[Row])
     checkAnswer(
       sql("SELECT key, value FROM test_ctas_123 ORDER BY key"),
@@ -422,6 +424,8 @@ class SQLQuerySuite extends QueryTest {
 
   test("SPARK-4825 save join to table") {
     val testData = sparkContext.parallelize(1 to 10).map(i => TestData(i, i.toString)).toDF()
+    sql("DROP TABLE IF EXISTS test1")
+    sql("DROP TABLE IF EXISTS test2")
     sql("CREATE TABLE test1 (key INT, value STRING)")
     testData.write.mode(SaveMode.Append).insertInto("test1")
     sql("CREATE TABLE test2 (key INT, value STRING)")
@@ -508,6 +512,7 @@ class SQLQuerySuite extends QueryTest {
     val rowRdd = sparkContext.parallelize(row :: Nil)
 
     TestHive.createDataFrame(rowRdd, schema).registerTempTable("testTable")
+    sql("DROP TABLE IF EXISTS nullValuesInInnerComplexTypes")
 
     sql(
       """CREATE TABLE nullValuesInInnerComplexTypes
@@ -587,6 +592,7 @@ class SQLQuerySuite extends QueryTest {
     read.json(rdd).registerTempTable("data")
     val originalConf = getConf("spark.sql.hive.convertCTAS", "false")
     setConf("spark.sql.hive.convertCTAS", "false")
+    sql("DROP TABLE IF EXISTS explodeTest")
 
     sql("CREATE TABLE explodeTest (key bigInt)")
     table("explodeTest").queryExecution.analyzed match {
@@ -609,11 +615,14 @@ class SQLQuerySuite extends QueryTest {
   test("sanity test for SPARK-6618") {
     (1 to 100).par.map { i =>
       val tableName = s"SPARK_6618_table_$i"
-      sql(s"CREATE TABLE $tableName (col1 string)")
-      catalog.lookupRelation(Seq(tableName))
-      table(tableName)
-      tables()
-      sql(s"DROP TABLE $tableName")
+      try {
+        sql(s"CREATE TABLE $tableName (col1 string)")
+        catalog.lookupRelation(Seq(tableName))
+        table(tableName)
+        tables()
+      } finally {
+        sql(s"DROP TABLE  IF EXISTS $tableName")
+      }
     }
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/OrcPartitionDiscoverySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/OrcPartitionDiscoverySuite.scala
@@ -40,7 +40,7 @@ case class OrcParDataWithKey(intField: Int, pi: Int, stringField: String, ps: St
 
 // TODO This test suite duplicates ParquetPartitionDiscoverySuite a lot
 class OrcPartitionDiscoverySuite extends QueryTest with BeforeAndAfterAll {
-  val defaultPartitionName = ConfVars.DEFAULTPARTITIONNAME.defaultVal
+  val defaultPartitionName = ConfVars.DEFAULTPARTITIONNAME.defaultStrVal
 
   def withTempDir(f: File => Unit): Unit = {
     val dir = Utils.createTempDir().getCanonicalFile

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/OrcPartitionDiscoverySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/OrcPartitionDiscoverySuite.scala
@@ -40,7 +40,7 @@ case class OrcParDataWithKey(intField: Int, pi: Int, stringField: String, ps: St
 
 // TODO This test suite duplicates ParquetPartitionDiscoverySuite a lot
 class OrcPartitionDiscoverySuite extends QueryTest with BeforeAndAfterAll {
-  val defaultPartitionName = ConfVars.DEFAULTPARTITIONNAME.defaultStrVal
+  val defaultPartitionName = ConfVars.DEFAULTPARTITIONNAME.getDefaultValue()
 
   def withTempDir(f: File => Unit): Unit = {
     val dir = Utils.createTempDir().getCanonicalFile


### PR DESCRIPTION
This is work in progress branch to add Hive 1.2.0 support.

Current status: it compiles, initial instantiations don't throw up obscure linkage errors.  Tests fail fast on ClientWrapper linking
## Build

Some of the POM changes are probably just superstition: I had them in from my original Spark 1.3 + Hive 1.2 build and haven't gone through to see which explicit includes/excludes are needed now that
all the spark dependencies have changed.
## Compile

in `org.apache.spark.sql.hive.client.ClientWrapper`; `loadPartition`,
`loadTable` and `loadDynamicPartitions`: need to choose suitable defaults
for the new options, or add them to the signature

`org.apache.spark.sql.hive.client.ClientWrapper.reset()`: should the `deleteData`
flag be set?
## Kryo versions

HiveShim now has pasted in some of Hive Utilities to ser/deser using
the Spark Kryo version, not Hive's
