### PR TITLE
[Spark-7879][MLlib] KMeans API for spark.ml Pipelines

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -338,6 +338,7 @@ pyspark_ml = Module(
     python_test_goals=[
         "pyspark.ml.feature",
         "pyspark.ml.classification",
+        "pyspark.ml.clustering",
         "pyspark.ml.recommendation",
         "pyspark.ml.regression",
         "pyspark.ml.tuning",

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -83,7 +83,8 @@ private[clustering] trait KMeansParams
    * setting -- the default of 5 is almost always enough. Default: 5.
    * @group param
    */
-  val initSteps = new Param[Int](this, "initSteps", "number of steps for k-means||")
+  val initSteps = new Param[Int](this, "initSteps", "number of steps for k-means||",
+    (value: Int) => value > 0)
 
   /** @group getParam */
   def getInitializationSteps: Int = $(initSteps)
@@ -161,10 +162,7 @@ class KMeans(override val uid: String) extends Estimator[KMeansModel] with KMean
   def setInitializationMode(value: String): this.type = set(initMode, value)
 
   /** @group setParam */
-  def setInitializationSteps(value: Int): this.type = {
-    require(value > 0, "Number of initialization steps must be positive")
-    set(initSteps, value)
-  }
+  def setInitializationSteps(value: Int): this.type = set(initSteps, value)
 
   /** @group setParam */
   def setMaxIter(value: Int): this.type = set(maxIter, value)

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -115,10 +115,7 @@ class KMeansModel private[ml] (
   }
 
   override def transform(dataset: DataFrame): DataFrame = {
-    dataset.select(
-          dataset("*"),
-          callUDF(predict _, IntegerType, col($(featuresCol))).as($(predictionCol))
-        )
+    dataset.withColumn($(predictionCol), callUDF(predict _, IntegerType, col($(featuresCol))))
   }
 
   override def transformSchema(schema: StructType): StructType = {

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -72,10 +72,10 @@ private[clustering] trait KMeansParams
    * (Bahmani et al., Scalable K-Means++, VLDB 2012). Default: k-means||.
    * @group param
    */
-  val initializationMode = new Param[String](this, "initializationMode", "initialization algorithm")
+  val initMode = new Param[String](this, "initMode", "initialization algorithm")
 
   /** @group getParam */
-  def getInitializationMode: String = $(initializationMode)
+  def getInitializationMode: String = $(initMode)
 
   /**
    * Param for the number of steps for the k-means|| initialization mode. This is an advanced
@@ -152,7 +152,7 @@ class KMeans(override val uid: String) extends Estimator[KMeansModel] with KMean
   setDefault(k, 2)
   setDefault(maxIter, 20)
   setDefault(runs, 1)
-  setDefault(initializationMode, MLlibKMeans.K_MEANS_PARALLEL)
+  setDefault(initMode, MLlibKMeans.K_MEANS_PARALLEL)
   setDefault(initializationSteps, 5)
   setDefault(epsilon, 1e-4)
   setDefault(seed, Utils.random.nextLong())
@@ -173,7 +173,7 @@ class KMeans(override val uid: String) extends Estimator[KMeansModel] with KMean
   /** @group setParam */
   def setInitializationMode(value: String): this.type = {
     MLlibKMeans.validateInitializationMode(value)
-    set(initializationMode, value)
+    set(initMode, value)
   }
 
   /** @group setParam */

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -72,7 +72,8 @@ private[clustering] trait KMeansParams
    * (Bahmani et al., Scalable K-Means++, VLDB 2012). Default: k-means||.
    * @group param
    */
-  val initMode = new Param[String](this, "initMode", "initialization algorithm")
+  val initMode = new Param[String](this, "initMode", "initialization algorithm",
+    (value: String) => MLlibKMeans.validateInitializationMode(value))
 
   /** @group getParam */
   def getInitializationMode: String = $(initMode)
@@ -157,10 +158,7 @@ class KMeans(override val uid: String) extends Estimator[KMeansModel] with KMean
   def setK(value: Int): this.type = set(k, value)
 
   /** @group setParam */
-  def setInitializationMode(value: String): this.type = {
-    MLlibKMeans.validateInitializationMode(value)
-    set(initMode, value)
-  }
+  def setInitializationMode(value: String): this.type = set(initMode, value)
 
   /** @group setParam */
   def setInitializationSteps(value: Int): this.type = {

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -178,13 +178,16 @@ class KMeans(override val uid: String) extends Estimator[KMeansModel] with KMean
   def setSeed(value: Long): this.type = set(seed, value)
 
   override def fit(dataset: DataFrame): KMeansModel = {
-    val map = this.extractParamMap()
-    val rdd = dataset.select(col(map(featuresCol))).map { case Row(point: Vector) => point}
+    val rdd = dataset.select(col($(featuresCol))).map { case Row(point: Vector) => point }
 
     val algo = new MLlibKMeans()
-        .setK(map(k))
-        .setMaxIterations(map(maxIter))
-        .setSeed(map(seed))
+      .setK($(k))
+      .setInitializationMode($(initMode))
+      .setInitializationSteps($(initSteps))
+      .setMaxIterations($(maxIter))
+      .setSeed($(seed))
+      .setEpsilon($(epsilon))
+      .setRuns($(runs))
     val parentModel = algo.run(rdd)
     val model = new KMeansModel(uid, parentModel)
     copyValues(model)

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -24,8 +24,8 @@ import org.apache.spark.ml.util.{Identifiable, SchemaUtils}
 import org.apache.spark.ml.{Estimator, Model}
 import org.apache.spark.mllib.clustering.{KMeans => MLlibKMeans, KMeansModel => MLlibKMeansModel}
 import org.apache.spark.mllib.linalg.{Vector, VectorUDT}
-import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.functions.{col, callUDF}
+import org.apache.spark.sql.types.{IntegerType, StructType}
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.util.Utils
 

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -22,8 +22,7 @@ import org.apache.spark.ml.param.shared.{HasFeaturesCol, HasMaxIter, HasPredicti
 import org.apache.spark.ml.param.{Param, ParamMap, Params}
 import org.apache.spark.ml.util.{Identifiable, SchemaUtils}
 import org.apache.spark.ml.{Estimator, Model}
-import org.apache.spark.mllib
-import org.apache.spark.mllib.clustering.KMeans
+import org.apache.spark.mllib.clustering.{KMeans => MLlibKMeans, KMeansModel => MLlibKMeansModel}
 import org.apache.spark.mllib.linalg.{Vector, VectorUDT}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
@@ -105,7 +104,7 @@ private[clustering] trait KMeansParams
 class KMeansModel private[ml] (
   override val uid: String,
   val paramMap: ParamMap,
-  val parentModel: mllib.clustering.KMeansModel
+  val parentModel: MLlibKMeansModel
 ) extends Model[KMeansModel] with KMeansParams {
 
   override def copy(extra: ParamMap): KMeansModel = {
@@ -146,7 +145,7 @@ class KMeans(override val uid: String) extends Estimator[KMeansModel] with KMean
   setK(2)
   setMaxIter(20)
   setRuns(1)
-  setInitializationMode(KMeans.K_MEANS_PARALLEL)
+  setInitializationMode(MLlibKMeans.K_MEANS_PARALLEL)
   setInitializationSteps(5)
   setEpsilon(1e-4)
   setSeed(Utils.random.nextLong())
@@ -166,7 +165,7 @@ class KMeans(override val uid: String) extends Estimator[KMeansModel] with KMean
 
   /** @group setParam */
   def setInitializationMode(value: String): this.type = {
-    mllib.clustering.KMeans.validateInitializationMode(value)
+    MLlibKMeans.validateInitializationMode(value)
     set(initializationMode, value)
   }
 
@@ -193,7 +192,7 @@ class KMeans(override val uid: String) extends Estimator[KMeansModel] with KMean
     val map = this.extractParamMap()
     val rdd = dataset.select(col(map(featuresCol))).map { case Row(point: Vector) => point}
 
-    val algo = new mllib.clustering.KMeans()
+    val algo = new MLlibKMeans()
         .setK(map(k))
         .setMaxIterations(map(maxIter))
         .setSeed(map(seed))

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -37,7 +37,7 @@ private[clustering] trait KMeansParams
     extends Params with HasMaxIter with HasFeaturesCol with HasSeed with HasPredictionCol {
 
   /**
-   * Param for the column name for the number of clusters to create.
+   * Set the number of clusters to create (k). Default: 2.
    * @group param
    */
   val k = new Param[Int](this, "k", "number of clusters to create")
@@ -46,7 +46,9 @@ private[clustering] trait KMeansParams
   def getK: Int = $(k)
 
   /**
-   * Param for the column name for the number of runs of the algorithm to execute in parallel.
+   * Param the number of runs of the algorithm to execute in parallel. We initialize the algorithm
+   * this many times with random starting conditions (configured by the initialization mode), then
+   * return the best clustering found over any run. Default: 1.
    * @group param
    */
   val runs = new Param[Int](this, "runs", "number of runs of the algorithm to execute in parallel")
@@ -55,8 +57,8 @@ private[clustering] trait KMeansParams
   def getRuns: Int = $(runs)
 
   /**
-   * Param for the column name for the distance threshold
-   * within which we've consider centers to have converged.
+   * Param the distance threshold within which we've consider centers to have converged.
+   * If all centers move less than this Euclidean distance, we stop iterating one run.
    * @group param
    */
   val epsilon = new Param[Double](this, "epsilon", "distance threshold")
@@ -65,7 +67,9 @@ private[clustering] trait KMeansParams
   def getEpsilon: Double = $(epsilon)
 
   /**
-   * Param for the initialization algorithm.
+   * Param for the initialization algorithm. This can be either "random" to choose random points as
+   * initial cluster centers, or "k-means||" to use a parallel variant of k-means++
+   * (Bahmani et al., Scalable K-Means++, VLDB 2012). Default: k-means||.
    * @group param
    */
   val initializationMode = new Param[String](this, "initializationMode", "initialization algorithm")
@@ -74,7 +78,8 @@ private[clustering] trait KMeansParams
   def getInitializationMode: String = $(initializationMode)
 
   /**
-   * Param for the number of steps for k-means initialization mode.
+   * Param for the number of steps for the k-means|| initialization mode. This is an advanced
+   * setting -- the default of 5 is almost always enough. Default: 5.
    * @group param
    */
   val initializationSteps =

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -40,7 +40,7 @@ private[clustering] trait KMeansParams
    * Set the number of clusters to create (k). Default: 2.
    * @group param
    */
-  val k = new Param[Int](this, "k", "number of clusters to create")
+  val k = new Param[Int](this, "k", "number of clusters to create", (x: Int) => x > 1)
 
   /** @group getParam */
   def getK: Int = $(k)

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -51,7 +51,8 @@ private[clustering] trait KMeansParams
    * return the best clustering found over any run. Default: 1.
    * @group param
    */
-  val runs = new Param[Int](this, "runs", "number of runs of the algorithm to execute in parallel")
+  val runs = new Param[Int](this, "runs", "number of runs of the algorithm to execute in parallel",
+    (value: Int) => value >= 1)
 
   /** @group getParam */
   def getRuns: Int = $(runs)

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -35,6 +35,15 @@ import org.apache.spark.util.Utils
  */
 private[clustering] trait KMeansParams
     extends Params with HasMaxIter with HasFeaturesCol with HasSeed with HasPredictionCol {
+
+  setDefault(k, 2)
+  setDefault(maxIter, 20)
+  setDefault(runs, 1)
+  setDefault(initializationMode, MLlibKMeans.K_MEANS_PARALLEL)
+  setDefault(initializationSteps, 5)
+  setDefault(epsilon, 1e-4)
+  setDefault(seed, Utils.random.nextLong())
+
   /**
    * Param for the column name for the number of clusters to create.
    * @group param
@@ -142,13 +151,6 @@ class KMeansModel private[ml] (
  */
 @Experimental
 class KMeans(override val uid: String) extends Estimator[KMeansModel] with KMeansParams {
-  setK(2)
-  setMaxIter(20)
-  setRuns(1)
-  setInitializationMode(MLlibKMeans.K_MEANS_PARALLEL)
-  setInitializationSteps(5)
-  setEpsilon(1e-4)
-  setSeed(Utils.random.nextLong())
 
   override def copy(extra: ParamMap): Estimator[KMeansModel] = defaultCopy(extra)
 

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -107,6 +107,12 @@ class KMeansModel private[ml] (
   val paramMap: ParamMap,
   val parentModel: mllib.clustering.KMeansModel
 ) extends Model[KMeansModel] with KMeansParams {
+
+  override def copy(extra: ParamMap): KMeansModel = {
+    val copied = new KMeansModel(uid, paramMap, parentModel)
+    copyValues(copied, extra)
+  }
+
   /**
    * Transforms the input dataset.
    */
@@ -144,6 +150,8 @@ class KMeans(override val uid: String) extends Estimator[KMeansModel] with KMean
   setInitializationSteps(5)
   setEpsilon(1e-4)
   setSeed(Utils.random.nextLong())
+
+  override def copy(extra: ParamMap): Estimator[KMeansModel] = defaultCopy(extra)
 
   def this() = this(Identifiable.randomUID("kmeans"))
 

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -122,6 +122,7 @@ class KMeansModel private[ml] (
     validateAndTransformSchema(schema)
   }
 
+  private[clustering]
   def predict(features: Vector): Int = parentModel.predict(features)
 
   def clusterCenters: Array[Vector] = parentModel.clusterCenters

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -82,11 +82,10 @@ private[clustering] trait KMeansParams
    * setting -- the default of 5 is almost always enough. Default: 5.
    * @group param
    */
-  val initializationSteps =
-    new Param[Int](this, "initializationSteps", "number of steps for k-means||")
+  val initSteps = new Param[Int](this, "initSteps", "number of steps for k-means||")
 
   /** @group getParam */
-  def getInitializationSteps: Int = $(initializationSteps)
+  def getInitializationSteps: Int = $(initSteps)
 
   /**
    * Validates and transforms the input schema.
@@ -153,7 +152,7 @@ class KMeans(override val uid: String) extends Estimator[KMeansModel] with KMean
   setDefault(maxIter, 20)
   setDefault(runs, 1)
   setDefault(initMode, MLlibKMeans.K_MEANS_PARALLEL)
-  setDefault(initializationSteps, 5)
+  setDefault(initSteps, 5)
   setDefault(epsilon, 1e-4)
   setDefault(seed, Utils.random.nextLong())
 
@@ -179,7 +178,7 @@ class KMeans(override val uid: String) extends Estimator[KMeansModel] with KMean
   /** @group setParam */
   def setInitializationSteps(value: Int): this.type = {
     require(value > 0, "Number of initialization steps must be positive")
-    set(initializationSteps, value)
+    set(initSteps, value)
   }
 
   /** @group setParam */

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -114,9 +114,6 @@ class KMeansModel private[ml] (
     copyValues(copied, extra)
   }
 
-  /**
-   * Transforms the input dataset.
-   */
   override def transform(dataset: DataFrame): DataFrame = {
     dataset.select(
           dataset("*"),
@@ -124,11 +121,6 @@ class KMeansModel private[ml] (
         )
   }
 
-  /**
-   * :: DeveloperApi ::
-   *
-   * Derives the output schema from the input schema.
-   */
   override def transformSchema(schema: StructType): StructType = {
     validateAndTransformSchema(schema)
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -151,6 +151,9 @@ class KMeans(override val uid: String) extends Estimator[KMeansModel] with KMean
   def setFeaturesCol(value: String): this.type = set(featuresCol, value)
 
   /** @group setParam */
+  def setPredictionCol(value: String): this.type = set(predictionCol, value)
+
+  /** @group setParam */
   def setK(value: Int): this.type = set(k, value)
 
   /** @group setParam */
@@ -187,7 +190,8 @@ class KMeans(override val uid: String) extends Estimator[KMeansModel] with KMean
         .setMaxIterations(map(maxIter))
         .setSeed(map(seed))
     val parentModel = algo.run(rdd)
-    new KMeansModel(uid, map, parentModel)
+    val model = new KMeansModel(uid, map, parentModel)
+    copyValues(model)
   }
 
   override def transformSchema(schema: StructType): StructType = {

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -106,9 +106,8 @@ private[clustering] trait KMeansParams
  */
 @Experimental
 class KMeansModel private[ml] (
-  override val uid: String,
-  val parentModel: MLlibKMeansModel
-) extends Model[KMeansModel] with KMeansParams {
+    override val uid: String,
+    private val parentModel: MLlibKMeansModel) extends Model[KMeansModel] with KMeansParams {
 
   override def copy(extra: ParamMap): KMeansModel = {
     val copied = new KMeansModel(uid, parentModel)

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -102,18 +102,16 @@ private[clustering] trait KMeansParams
  * :: Experimental ::
  * Model fitted by KMeans.
  *
- * @param paramMap a parameter map for fitting.
  * @param parentModel a model trained by spark.mllib.clustering.KMeans.
  */
 @Experimental
 class KMeansModel private[ml] (
   override val uid: String,
-  val paramMap: ParamMap,
   val parentModel: MLlibKMeansModel
 ) extends Model[KMeansModel] with KMeansParams {
 
   override def copy(extra: ParamMap): KMeansModel = {
-    val copied = new KMeansModel(uid, paramMap, parentModel)
+    val copied = new KMeansModel(uid, parentModel)
     copyValues(copied, extra)
   }
 
@@ -203,7 +201,7 @@ class KMeans(override val uid: String) extends Estimator[KMeansModel] with KMean
         .setMaxIterations(map(maxIter))
         .setSeed(map(seed))
     val parentModel = algo.run(rdd)
-    val model = new KMeansModel(uid, map, parentModel)
+    val model = new KMeansModel(uid, parentModel)
     copyValues(model)
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -177,7 +177,6 @@ class KMeans(override val uid: String) extends Estimator[KMeansModel] with KMean
   /** @group setParam */
   def setSeed(value: Long): this.type = set(seed, value)
 
-
   override def fit(dataset: DataFrame): KMeansModel = {
     val map = this.extractParamMap()
     val rdd = dataset.select(col(map(featuresCol))).map { case Row(point: Vector) => point}

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -36,14 +36,6 @@ import org.apache.spark.util.Utils
 private[clustering] trait KMeansParams
     extends Params with HasMaxIter with HasFeaturesCol with HasSeed with HasPredictionCol {
 
-  setDefault(k, 2)
-  setDefault(maxIter, 20)
-  setDefault(runs, 1)
-  setDefault(initializationMode, MLlibKMeans.K_MEANS_PARALLEL)
-  setDefault(initializationSteps, 5)
-  setDefault(epsilon, 1e-4)
-  setDefault(seed, Utils.random.nextLong())
-
   /**
    * Param for the column name for the number of clusters to create.
    * @group param
@@ -151,6 +143,14 @@ class KMeansModel private[ml] (
  */
 @Experimental
 class KMeans(override val uid: String) extends Estimator[KMeansModel] with KMeansParams {
+
+  setDefault(k, 2)
+  setDefault(maxIter, 20)
+  setDefault(runs, 1)
+  setDefault(initializationMode, MLlibKMeans.K_MEANS_PARALLEL)
+  setDefault(initializationSteps, 5)
+  setDefault(epsilon, 1e-4)
+  setDefault(seed, Utils.random.nextLong())
 
   override def copy(extra: ParamMap): Estimator[KMeansModel] = defaultCopy(extra)
 

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.clustering
+
+import org.apache.spark.annotation.Experimental
+import org.apache.spark.ml.param.shared.{HasFeaturesCol, HasMaxIter, HasPredictionCol, HasSeed}
+import org.apache.spark.ml.param.{Param, ParamMap, Params}
+import org.apache.spark.ml.util.{Identifiable, SchemaUtils}
+import org.apache.spark.ml.{Estimator, Model}
+import org.apache.spark.mllib
+import org.apache.spark.mllib.clustering.KMeans
+import org.apache.spark.mllib.linalg.{Vector, VectorUDT}
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.util.Utils
+
+
+/**
+ * Common params for KMeans and KMeansModel
+ */
+private[clustering] trait KMeansParams
+    extends Params with HasMaxIter with HasFeaturesCol with HasSeed with HasPredictionCol {
+  /**
+   * Param for the column name for the number of clusters to create.
+   * @group param
+   */
+  val k = new Param[Int](this, "k", "number of clusters to create")
+
+  /** @group getParam */
+  def getK: Int = $(k)
+
+  /**
+   * Param for the column name for the number of runs of the algorithm to execute in parallel.
+   * @group param
+   */
+  val runs = new Param[Int](this, "runs", "number of runs of the algorithm to execute in parallel")
+
+  /** @group getParam */
+  def getRuns: Int = $(runs)
+
+  /**
+   * Param for the column name for the distance threshold
+   * within which we've consider centers to have converged.
+   * @group param
+   */
+  val epsilon = new Param[Double](this, "epsilon", "distance threshold")
+
+  /** @group getParam */
+  def getEpsilon: Double = $(epsilon)
+
+  /**
+   * Param for the initialization algorithm.
+   * @group param
+   */
+  val initializationMode = new Param[String](this, "initializationMode", "initialization algorithm")
+
+  /** @group getParam */
+  def getInitializationMode: String = $(initializationMode)
+
+  /**
+   * Param for the number of steps for k-means initialization mode.
+   * @group param
+   */
+  val initializationSteps =
+    new Param[Int](this, "initializationSteps", "number of steps for k-means||")
+
+  /** @group getParam */
+  def getInitializationSteps: Int = $(initializationSteps)
+
+  /**
+   * Validates and transforms the input schema.
+   * @param schema input schema
+   * @return output schema
+   */
+  protected def validateAndTransformSchema(schema: StructType): StructType = {
+    SchemaUtils.checkColumnType(schema, $(featuresCol), new VectorUDT)
+    SchemaUtils.appendColumn(schema, $(predictionCol), IntegerType)
+  }
+}
+
+/**
+ * :: Experimental ::
+ * Model fitted by KMeans.
+ *
+ * @param paramMap a parameter map for fitting.
+ * @param parentModel a model trained by spark.mllib.clustering.KMeans.
+ */
+@Experimental
+class KMeansModel private[ml] (
+  override val uid: String,
+  val paramMap: ParamMap,
+  val parentModel: mllib.clustering.KMeansModel
+) extends Model[KMeansModel] with KMeansParams {
+  /**
+   * Transforms the input dataset.
+   */
+  override def transform(dataset: DataFrame): DataFrame = {
+    dataset.select(
+          dataset("*"),
+          callUDF(predict _, IntegerType, col($(featuresCol))).as($(predictionCol))
+        )
+  }
+
+  /**
+   * :: DeveloperApi ::
+   *
+   * Derives the output schema from the input schema.
+   */
+  override def transformSchema(schema: StructType): StructType = {
+    validateAndTransformSchema(schema)
+  }
+
+  def predict(features: Vector): Int = parentModel.predict(features)
+
+  def clusterCenters: Array[Vector] = parentModel.clusterCenters
+}
+
+/**
+ * :: Experimental ::
+ * KMeans API for spark.ml Pipeline.
+ */
+@Experimental
+class KMeans(override val uid: String) extends Estimator[KMeansModel] with KMeansParams {
+  setK(2)
+  setMaxIter(20)
+  setRuns(1)
+  setInitializationMode(KMeans.K_MEANS_PARALLEL)
+  setInitializationSteps(5)
+  setEpsilon(1e-4)
+  setSeed(Utils.random.nextLong())
+
+  def this() = this(Identifiable.randomUID("kmeans"))
+
+  /** @group setParam */
+  def setFeaturesCol(value: String): this.type = set(featuresCol, value)
+
+  /** @group setParam */
+  def setK(value: Int): this.type = set(k, value)
+
+  /** @group setParam */
+  def setInitializationMode(value: String): this.type = {
+    mllib.clustering.KMeans.validateInitializationMode(value)
+    set(initializationMode, value)
+  }
+
+  /** @group setParam */
+  def setInitializationSteps(value: Int): this.type = {
+    require(value > 0, "Number of initialization steps must be positive")
+    set(initializationSteps, value)
+  }
+
+  /** @group setParam */
+  def setMaxIter(value: Int): this.type = set(maxIter, value)
+
+  /** @group setParam */
+  def setRuns(value: Int): this.type = set(runs, value)
+
+  /** @group setParam */
+  def setEpsilon(value: Double): this.type = set(epsilon, value)
+
+  /** @group setParam */
+  def setSeed(value: Long): this.type = set(seed, value)
+
+
+  override def fit(dataset: DataFrame): KMeansModel = {
+    val map = this.extractParamMap()
+    val rdd = dataset.select(col(map(featuresCol))).map { case Row(point: Vector) => point}
+
+    val algo = new mllib.clustering.KMeans()
+        .setK(map(k))
+        .setMaxIterations(map(maxIter))
+        .setSeed(map(seed))
+    val parentModel = algo.run(rdd)
+    new KMeansModel(uid, map, parentModel)
+  }
+
+  override def transformSchema(schema: StructType): StructType = {
+    validateAndTransformSchema(schema)
+  }
+}
+

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -76,7 +76,7 @@ private[clustering] trait KMeansParams
    * @group expertParam
    */
   final val initMode = new Param[String](this, "initMode", "initialization algorithm",
-    (value: String) => MLlibKMeans.validateInitializationMode(value))
+    (value: String) => MLlibKMeans.validateInitMode(value))
 
   /** @group getExpertParam */
   def getInitMode: String = $(initMode)

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -18,8 +18,8 @@
 package org.apache.spark.ml.clustering
 
 import org.apache.spark.annotation.Experimental
+import org.apache.spark.ml.param.{Param, Params, IntParam, DoubleParam, ParamMap}
 import org.apache.spark.ml.param.shared.{HasFeaturesCol, HasMaxIter, HasPredictionCol, HasSeed}
-import org.apache.spark.ml.param.{Param, ParamMap, Params}
 import org.apache.spark.ml.util.{Identifiable, SchemaUtils}
 import org.apache.spark.ml.{Estimator, Model}
 import org.apache.spark.mllib.clustering.{KMeans => MLlibKMeans, KMeansModel => MLlibKMeansModel}
@@ -40,7 +40,7 @@ private[clustering] trait KMeansParams
    * Set the number of clusters to create (k). Default: 2.
    * @group param
    */
-  val k = new Param[Int](this, "k", "number of clusters to create", (x: Int) => x > 1)
+  final val k = new IntParam(this, "k", "number of clusters to create", (x: Int) => x > 1)
 
   /** @group getParam */
   def getK: Int = $(k)
@@ -51,8 +51,8 @@ private[clustering] trait KMeansParams
    * return the best clustering found over any run. Default: 1.
    * @group param
    */
-  val runs = new Param[Int](this, "runs", "number of runs of the algorithm to execute in parallel",
-    (value: Int) => value >= 1)
+  final val runs = new IntParam(this, "runs",
+    "number of runs of the algorithm to execute in parallel", (value: Int) => value >= 1)
 
   /** @group getParam */
   def getRuns: Int = $(runs)
@@ -62,7 +62,7 @@ private[clustering] trait KMeansParams
    * If all centers move less than this Euclidean distance, we stop iterating one run.
    * @group param
    */
-  val epsilon = new Param[Double](this, "epsilon", "distance threshold")
+  final val epsilon = new DoubleParam(this, "epsilon", "distance threshold")
 
   /** @group getParam */
   def getEpsilon: Double = $(epsilon)
@@ -73,7 +73,7 @@ private[clustering] trait KMeansParams
    * (Bahmani et al., Scalable K-Means++, VLDB 2012). Default: k-means||.
    * @group param
    */
-  val initMode = new Param[String](this, "initMode", "initialization algorithm",
+  final val initMode = new Param[String](this, "initMode", "initialization algorithm",
     (value: String) => MLlibKMeans.validateInitializationMode(value))
 
   /** @group getParam */
@@ -84,7 +84,7 @@ private[clustering] trait KMeansParams
    * setting -- the default of 5 is almost always enough. Default: 5.
    * @group param
    */
-  val initSteps = new Param[Int](this, "initSteps", "number of steps for k-means||",
+  final val initSteps = new IntParam(this, "initSteps", "number of steps for k-means||",
     (value: Int) => value > 0)
 
   /** @group getParam */
@@ -139,13 +139,14 @@ class KMeansModel private[ml] (
 @Experimental
 class KMeans(override val uid: String) extends Estimator[KMeansModel] with KMeansParams {
 
-  setDefault(k, 2)
-  setDefault(maxIter, 20)
-  setDefault(runs, 1)
-  setDefault(initMode, MLlibKMeans.K_MEANS_PARALLEL)
-  setDefault(initSteps, 5)
-  setDefault(epsilon, 1e-4)
-  setDefault(seed, Utils.random.nextLong())
+  setDefault(
+    k -> 2,
+    maxIter -> 20,
+    runs -> 1,
+    initMode -> MLlibKMeans.K_MEANS_PARALLEL,
+    initSteps -> 5,
+    epsilon -> 1e-4,
+    seed -> Utils.random.nextLong())
 
   override def copy(extra: ParamMap): Estimator[KMeansModel] = defaultCopy(extra)
 

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -148,8 +148,7 @@ class KMeans(override val uid: String) extends Estimator[KMeansModel] with KMean
     runs -> 1,
     initMode -> MLlibKMeans.K_MEANS_PARALLEL,
     initSteps -> 5,
-    epsilon -> 1e-4,
-    seed -> Utils.random.nextLong())
+    epsilon -> 1e-4)
 
   override def copy(extra: ParamMap): Estimator[KMeansModel] = defaultCopy(extra)
 

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -24,7 +24,7 @@ import org.apache.spark.ml.util.{Identifiable, SchemaUtils}
 import org.apache.spark.ml.{Estimator, Model}
 import org.apache.spark.mllib.clustering.{KMeans => MLlibKMeans, KMeansModel => MLlibKMeansModel}
 import org.apache.spark.mllib.linalg.{Vector, VectorUDT}
-import org.apache.spark.sql.functions.{col, callUDF}
+import org.apache.spark.sql.functions.{col, udf}
 import org.apache.spark.sql.types.{IntegerType, StructType}
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.util.Utils
@@ -118,7 +118,8 @@ class KMeansModel private[ml] (
   }
 
   override def transform(dataset: DataFrame): DataFrame = {
-    dataset.withColumn($(predictionCol), callUDF(predict _, IntegerType, col($(featuresCol))))
+    val predictUDF = udf((vector: Vector) => predict(vector))
+    dataset.withColumn($(predictionCol), predictUDF(col($(featuresCol))))
   }
 
   override def transformSchema(schema: StructType): StructType = {

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -135,7 +135,9 @@ class KMeansModel private[ml] (
 
 /**
  * :: Experimental ::
- * KMeans API for spark.ml Pipeline.
+ * K-means clustering with support for multiple parallel runs and a k-means++ like initialization
+ * mode (the k-means|| algorithm by Bahmani et al). When multiple concurrent runs are requested,
+ * they are executed together with joint passes over the data for efficiency.
  */
 @Experimental
 class KMeans(override val uid: String) extends Estimator[KMeansModel] with KMeansParams {

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -78,7 +78,7 @@ private[clustering] trait KMeansParams
   final val initMode = new Param[String](this, "initMode", "initialization algorithm",
     (value: String) => MLlibKMeans.validateInitMode(value))
 
-  /** @group getExpertParam */
+  /** @group expertGetParam */
   def getInitMode: String = $(initMode)
 
   /**
@@ -89,7 +89,7 @@ private[clustering] trait KMeansParams
   final val initSteps = new IntParam(this, "initSteps", "number of steps for k-means||",
     (value: Int) => value > 0)
 
-  /** @group getExpertParam */
+  /** @group expertGetParam */
   def getInitSteps: Int = $(initSteps)
 
   /**
@@ -163,10 +163,10 @@ class KMeans(override val uid: String) extends Estimator[KMeansModel] with KMean
   /** @group setParam */
   def setK(value: Int): this.type = set(k, value)
 
-  /** @group setExpertParam */
+  /** @group expertSetParam */
   def setInitMode(value: String): this.type = set(initMode, value)
 
-  /** @group setExpertParam */
+  /** @group expertSetParam */
   def setInitSteps(value: Int): this.type = set(initSteps, value)
 
   /** @group setParam */

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -150,7 +150,7 @@ class KMeans(override val uid: String) extends Estimator[KMeansModel] with KMean
     initSteps -> 5,
     epsilon -> 1e-4)
 
-  override def copy(extra: ParamMap): Estimator[KMeansModel] = defaultCopy(extra)
+  override def copy(extra: ParamMap): KMeans = defaultCopy(extra)
 
   def this() = this(Identifiable.randomUID("kmeans"))
 

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -128,8 +128,7 @@ class KMeansModel private[ml] (
     validateAndTransformSchema(schema)
   }
 
-  private[clustering]
-  def predict(features: Vector): Int = parentModel.predict(features)
+  private[clustering] def predict(features: Vector): Int = parentModel.predict(features)
 
   def clusterCenters: Array[Vector] = parentModel.clusterCenters
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -62,7 +62,9 @@ private[clustering] trait KMeansParams
    * If all centers move less than this Euclidean distance, we stop iterating one run. Default: 1e-4
    * @group param
    */
-  final val epsilon = new DoubleParam(this, "epsilon", "distance threshold")
+  final val epsilon = new DoubleParam(this, "epsilon",
+    "distance threshold within which we've consider centers to have converge",
+    (value: Double) => value >= 0.0)
 
   /** @group getParam */
   def getEpsilon: Double = $(epsilon)

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -90,7 +90,7 @@ private[clustering] trait KMeansParams
     (value: Int) => value > 0)
 
   /** @group getParam */
-  def getInitializationSteps: Int = $(initSteps)
+  def getInitSteps: Int = $(initSteps)
 
   /**
    * Validates and transforms the input schema.
@@ -167,7 +167,7 @@ class KMeans(override val uid: String) extends Estimator[KMeansModel] with KMean
   def setInitMode(value: String): this.type = set(initMode, value)
 
   /** @group setParam */
-  def setInitializationSteps(value: Int): this.type = set(initSteps, value)
+  def setInitSteps(value: Int): this.type = set(initSteps, value)
 
   /** @group setParam */
   def setMaxIter(value: Int): this.type = set(maxIter, value)

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -37,7 +37,7 @@ private[clustering] trait KMeansParams
     extends Params with HasMaxIter with HasFeaturesCol with HasSeed with HasPredictionCol {
 
   /**
-   * Set the number of clusters to create (k). Default: 2.
+   * Set the number of clusters to create (k). Must be > 1. Default: 2.
    * @group param
    */
   final val k = new IntParam(this, "k", "number of clusters to create", (x: Int) => x > 1)
@@ -48,7 +48,7 @@ private[clustering] trait KMeansParams
   /**
    * Param the number of runs of the algorithm to execute in parallel. We initialize the algorithm
    * this many times with random starting conditions (configured by the initialization mode), then
-   * return the best clustering found over any run. Default: 1.
+   * return the best clustering found over any run. Must be >= 1. Default: 1.
    * @group param
    */
   final val runs = new IntParam(this, "runs",
@@ -59,7 +59,8 @@ private[clustering] trait KMeansParams
 
   /**
    * Param the distance threshold within which we've consider centers to have converged.
-   * If all centers move less than this Euclidean distance, we stop iterating one run. Default: 1e-4
+   * If all centers move less than this Euclidean distance, we stop iterating one run.
+   * Must be >= 0.0. Default: 1e-4
    * @group param
    */
   final val epsilon = new DoubleParam(this, "epsilon",
@@ -83,7 +84,7 @@ private[clustering] trait KMeansParams
 
   /**
    * Param for the number of steps for the k-means|| initialization mode. This is an advanced
-   * setting -- the default of 5 is almost always enough. Default: 5.
+   * setting -- the default of 5 is almost always enough. Must be > 0. Default: 5.
    * @group expertParam
    */
   final val initSteps = new IntParam(this, "initSteps", "number of steps for k-means||",

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -59,7 +59,7 @@ private[clustering] trait KMeansParams
 
   /**
    * Param the distance threshold within which we've consider centers to have converged.
-   * If all centers move less than this Euclidean distance, we stop iterating one run.
+   * If all centers move less than this Euclidean distance, we stop iterating one run. Default: 1e-4
    * @group param
    */
   final val epsilon = new DoubleParam(this, "epsilon", "distance threshold")

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -73,23 +73,23 @@ private[clustering] trait KMeansParams
    * Param for the initialization algorithm. This can be either "random" to choose random points as
    * initial cluster centers, or "k-means||" to use a parallel variant of k-means++
    * (Bahmani et al., Scalable K-Means++, VLDB 2012). Default: k-means||.
-   * @group param
+   * @group expertParam
    */
   final val initMode = new Param[String](this, "initMode", "initialization algorithm",
     (value: String) => MLlibKMeans.validateInitializationMode(value))
 
-  /** @group getParam */
+  /** @group getExpertParam */
   def getInitMode: String = $(initMode)
 
   /**
    * Param for the number of steps for the k-means|| initialization mode. This is an advanced
    * setting -- the default of 5 is almost always enough. Default: 5.
-   * @group param
+   * @group expertParam
    */
   final val initSteps = new IntParam(this, "initSteps", "number of steps for k-means||",
     (value: Int) => value > 0)
 
-  /** @group getParam */
+  /** @group getExpertParam */
   def getInitSteps: Int = $(initSteps)
 
   /**
@@ -163,10 +163,10 @@ class KMeans(override val uid: String) extends Estimator[KMeansModel] with KMean
   /** @group setParam */
   def setK(value: Int): this.type = set(k, value)
 
-  /** @group setParam */
+  /** @group setExpertParam */
   def setInitMode(value: String): this.type = set(initMode, value)
 
-  /** @group setParam */
+  /** @group setExpertParam */
   def setInitSteps(value: Int): this.type = set(initSteps, value)
 
   /** @group setParam */

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -79,7 +79,7 @@ private[clustering] trait KMeansParams
     (value: String) => MLlibKMeans.validateInitializationMode(value))
 
   /** @group getParam */
-  def getInitializationMode: String = $(initMode)
+  def getInitMode: String = $(initMode)
 
   /**
    * Param for the number of steps for the k-means|| initialization mode. This is an advanced
@@ -164,7 +164,7 @@ class KMeans(override val uid: String) extends Estimator[KMeansModel] with KMean
   def setK(value: Int): this.type = set(k, value)
 
   /** @group setParam */
-  def setInitializationMode(value: String): this.type = set(initMode, value)
+  def setInitMode(value: String): this.type = set(initMode, value)
 
   /** @group setParam */
   def setInitializationSteps(value: Int): this.type = set(initSteps, value)

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeans.scala
@@ -85,9 +85,7 @@ class KMeans private (
    * (Bahmani et al., Scalable K-Means++, VLDB 2012). Default: k-means||.
    */
   def setInitializationMode(initializationMode: String): this.type = {
-    if (initializationMode != KMeans.RANDOM && initializationMode != KMeans.K_MEANS_PARALLEL) {
-      throw new IllegalArgumentException("Invalid initialization mode: " + initializationMode)
-    }
+    KMeans.validateInitializationMode(initializationMode)
     this.initializationMode = initializationMode
     this
   }
@@ -520,6 +518,13 @@ object KMeans {
       v1: VectorWithNorm,
       v2: VectorWithNorm): Double = {
     MLUtils.fastSquaredDistance(v1.vector, v1.norm, v2.vector, v2.norm)
+  }
+
+  private[spark] def validateInitializationMode(initializationMode: String): Boolean = {
+    if (initializationMode != KMeans.RANDOM && initializationMode != KMeans.K_MEANS_PARALLEL) {
+      throw new IllegalArgumentException("Invalid initialization mode: " + initializationMode)
+    }
+    true
   }
 }
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeans.scala
@@ -85,7 +85,7 @@ class KMeans private (
    * (Bahmani et al., Scalable K-Means++, VLDB 2012). Default: k-means||.
    */
   def setInitializationMode(initializationMode: String): this.type = {
-    KMeans.validateInitializationMode(initializationMode)
+    KMeans.validateInitMode(initializationMode)
     this.initializationMode = initializationMode
     this
   }
@@ -520,11 +520,12 @@ object KMeans {
     MLUtils.fastSquaredDistance(v1.vector, v1.norm, v2.vector, v2.norm)
   }
 
-  private[spark] def validateInitializationMode(initializationMode: String): Boolean = {
-    if (initializationMode != KMeans.RANDOM && initializationMode != KMeans.K_MEANS_PARALLEL) {
-      throw new IllegalArgumentException("Invalid initialization mode: " + initializationMode)
+  private[spark] def validateInitMode(initMode: String): Boolean = {
+    initMode match {
+      case KMeans.RANDOM => true
+      case KMeans.K_MEANS_PARALLEL => true
+      case _ => false
     }
-    true
   }
 }
 

--- a/mllib/src/test/java/org/apache/spark/ml/clustering/JavaKMeansSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/clustering/JavaKMeansSuite.java
@@ -42,7 +42,7 @@ public class JavaKMeansSuite implements Serializable {
     sc = new JavaSparkContext("local", "JavaKMeansSuite");
     sql = new SQLContext(sc);
 
-    dataset = KMeansSuite.generateKMeansData(sql, 1000, 3, k);
+    dataset = KMeansSuite.generateKMeansData(sql, 50, 3, k);
   }
 
   @After

--- a/mllib/src/test/java/org/apache/spark/ml/clustering/JavaKMeansSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/clustering/JavaKMeansSuite.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.clustering;
+
+import java.io.Serializable;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.mllib.linalg.Vector;
+import org.apache.spark.sql.DataFrame;
+import org.apache.spark.sql.SQLContext;
+
+public class JavaKMeansSuite implements Serializable {
+
+  private transient int k = 5;
+  private transient JavaSparkContext sc;
+  private transient DataFrame dataset;
+  private transient SQLContext sql;
+
+  @Before
+  public void setUp() {
+    sc = new JavaSparkContext("local", "JavaKMeansSuite");
+    sql = new SQLContext(sc);
+
+    dataset = KMeansSuite.generateKMeansData(sql, 1000, 3, k);
+  }
+
+  @After
+  public void tearDown() {
+    sc.stop();
+    sc = null;
+  }
+
+  @Test
+  public void fitAndTransform() {
+    KMeans kmeans = new KMeans().setK(k).setSeed(1);
+    KMeansModel model = kmeans.fit(dataset);
+
+    Vector[] centers = model.clusterCenters();
+    assertEquals(k, centers.length);
+
+    DataFrame transformed = model.transform(dataset);
+    assertArrayEquals(new String[]{"features", "prediction"}, transformed.columns());
+  }
+}

--- a/mllib/src/test/java/org/apache/spark/ml/clustering/JavaKMeansSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/clustering/JavaKMeansSuite.java
@@ -18,12 +18,15 @@
 package org.apache.spark.ml.clustering;
 
 import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.mllib.linalg.Vector;
@@ -60,6 +63,9 @@ public class JavaKMeansSuite implements Serializable {
     assertEquals(k, centers.length);
 
     DataFrame transformed = model.transform(dataset);
-    assertArrayEquals(new String[]{"features", "prediction"}, transformed.columns());
+    List<String> expectedColumns = Arrays.asList("features", "prediction");
+    for (String clm: transformed.columns()) {
+      assertTrue(expectedColumns.contains(clm));
+    }
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/clustering/JavaKMeansSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/clustering/JavaKMeansSuite.java
@@ -66,7 +66,7 @@ public class JavaKMeansSuite implements Serializable {
     List<String> columns = Arrays.asList(transformed.columns());
     List<String> expectedColumns = Arrays.asList("features", "prediction");
     for (String column: expectedColumns) {
-      columns.contains(column);
+      assertTrue(columns.contains(column));
     }
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/clustering/JavaKMeansSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/clustering/JavaKMeansSuite.java
@@ -63,9 +63,10 @@ public class JavaKMeansSuite implements Serializable {
     assertEquals(k, centers.length);
 
     DataFrame transformed = model.transform(dataset);
+    List<String> columns = Arrays.asList(transformed.columns());
     List<String> expectedColumns = Arrays.asList("features", "prediction");
-    for (String clm: transformed.columns()) {
-      assertTrue(expectedColumns.contains(clm));
+    for (String column: expectedColumns) {
+      columns.contains(column);
     }
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -65,6 +65,9 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
     intercept[IllegalArgumentException] {
       new KMeans().setInitializationMode("no_such_a_mode")
     }
+    intercept[IllegalArgumentException] {
+      new KMeans().setInitializationSteps(0)
+    }
   }
 
   test("fit & transform") {

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.clustering
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.mllib.clustering.KMeans
+import org.apache.spark.mllib.linalg.{Vector, Vectors}
+import org.apache.spark.mllib.util.MLlibTestSparkContext
+import org.apache.spark.sql.{DataFrame, SQLContext}
+
+private[clustering] case class TestRow(features: Vector)
+
+object KMeansSuite {
+  def generateKMeansData(sql: SQLContext, rows: Int, dim: Int, k: Int): DataFrame = {
+    val sc = sql.sparkContext
+    val rdd = sc.parallelize(1 to rows).map(i => Vectors.dense(Array.fill(dim)((i % k).toDouble)))
+        .map(v => new TestRow(v))
+    sql.createDataFrame(rdd)
+  }
+}
+
+class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
+
+  val k = 5
+  @transient var dataset: DataFrame = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    dataset = KMeansSuite.generateKMeansData(sqlContext, 1000, 3, k)
+  }
+
+  test("default parameters") {
+    val kmeans = new KMeans()
+
+    assert(kmeans.getK === 2)
+    assert(kmeans.getFeaturesCol === "features")
+    assert(kmeans.getMaxIter === 20)
+    assert(kmeans.getRuns === 1)
+    assert(kmeans.getInitializationMode === KMeans.K_MEANS_PARALLEL)
+    assert(kmeans.getInitializationSteps === 5)
+    assert(kmeans.getEpsilon === 1e-4)
+  }
+
+  test("fit & transform") {
+    val kmeans = new KMeans().setK(k)
+    val model = kmeans.fit(dataset)
+    assert(model.clusterCenters.length === k)
+
+    val transformed = model.transform(dataset)
+    assert(transformed.columns === Array("features", "prediction"))
+    val clusters = transformed.select("prediction")
+        .map(row => row.apply(0)).distinct().collect().toSet
+    assert(clusters === Set(0, 1, 2, 3, 4))
+  }
+}

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -68,6 +68,9 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
     intercept[IllegalArgumentException] {
       new KMeans().setInitializationSteps(0)
     }
+    intercept[IllegalArgumentException] {
+      new KMeans().setRuns(0)
+    }
   }
 
   test("fit & transform") {

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.ml.clustering
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.mllib.clustering.KMeans
+import org.apache.spark.mllib.clustering.{KMeans => MLlibKMeans}
 import org.apache.spark.mllib.linalg.{Vector, Vectors}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.sql.{DataFrame, SQLContext}
@@ -53,7 +53,7 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(kmeans.getPredictionCol === "prediction")
     assert(kmeans.getMaxIter === 20)
     assert(kmeans.getRuns === 1)
-    assert(kmeans.getInitializationMode === KMeans.K_MEANS_PARALLEL)
+    assert(kmeans.getInitializationMode === MLlibKMeans.K_MEANS_PARALLEL)
     assert(kmeans.getInitializationSteps === 5)
     assert(kmeans.getEpsilon === 1e-4)
   }

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -42,7 +42,7 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
   override def beforeAll(): Unit = {
     super.beforeAll()
 
-    dataset = KMeansSuite.generateKMeansData(sqlContext, 1000, 3, k)
+    dataset = KMeansSuite.generateKMeansData(sqlContext, 50, 3, k)
   }
 
   test("default parameters") {

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -58,6 +58,12 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(kmeans.getEpsilon === 1e-4)
   }
 
+  test("parameters validation") {
+    intercept[IllegalArgumentException] {
+      new KMeans().setK(1)
+    }
+  }
+
   test("fit & transform") {
     val predictionColName = "kmeans_prediction"
     val kmeans = new KMeans().setK(k).setPredictionCol(predictionColName)

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -106,7 +106,7 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(transformed.columns === Array("features", predictionColName))
     val clusters = transformed.select(predictionColName)
         .map(row => row.apply(0)).distinct().collect().toSet
-    assert(clusters.size == 5)
+    assert(clusters.size === k)
     assert(clusters === Set(0, 1, 2, 3, 4))
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -62,6 +62,9 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
     intercept[IllegalArgumentException] {
       new KMeans().setK(1)
     }
+    intercept[IllegalArgumentException] {
+      new KMeans().setInitializationMode("no_such_a_mode")
+    }
   }
 
   test("fit & transform") {

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -58,6 +58,29 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(kmeans.getEpsilon === 1e-4)
   }
 
+  test("set parameters") {
+    val kmeans = new KMeans()
+      .setK(9)
+      .setFeaturesCol("test_feature")
+      .setPredictionCol("test_prediction")
+      .setMaxIter(33)
+      .setRuns(7)
+      .setInitializationMode(MLlibKMeans.RANDOM)
+      .setInitializationSteps(3)
+      .setSeed(123)
+      .setEpsilon(1e-3)
+
+    assert(kmeans.getK === 9)
+    assert(kmeans.getFeaturesCol === "test_feature")
+    assert(kmeans.getPredictionCol === "test_prediction")
+    assert(kmeans.getMaxIter === 33)
+    assert(kmeans.getRuns === 7)
+    assert(kmeans.getInitializationMode === MLlibKMeans.RANDOM)
+    assert(kmeans.getInitializationSteps === 3)
+    assert(kmeans.getSeed === 123)
+    assert(kmeans.getEpsilon === 1e-3)
+  }
+
   test("parameters validation") {
     intercept[IllegalArgumentException] {
       new KMeans().setK(1)

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -29,7 +29,7 @@ object KMeansSuite {
   def generateKMeansData(sql: SQLContext, rows: Int, dim: Int, k: Int): DataFrame = {
     val sc = sql.sparkContext
     val rdd = sc.parallelize(1 to rows).map(i => Vectors.dense(Array.fill(dim)((i % k).toDouble)))
-        .map(v => new TestRow(v))
+      .map(v => new TestRow(v))
     sql.createDataFrame(rdd)
   }
 }
@@ -105,7 +105,7 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
     val transformed = model.transform(dataset)
     assert(transformed.columns === Array("features", predictionColName))
     val clusters = transformed.select(predictionColName)
-        .map(row => row.apply(0)).distinct().collect().toSet
+      .map(row => row.apply(0)).distinct().collect().toSet
     assert(clusters.size === k)
     assert(clusters === Set(0, 1, 2, 3, 4))
   }

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -98,7 +98,7 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
 
   test("fit & transform") {
     val predictionColName = "kmeans_prediction"
-    val kmeans = new KMeans().setK(k).setPredictionCol(predictionColName)
+    val kmeans = new KMeans().setK(k).setPredictionCol(predictionColName).setSeed(1)
     val model = kmeans.fit(dataset)
     assert(model.clusterCenters.length === k)
 

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -50,6 +50,7 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
 
     assert(kmeans.getK === 2)
     assert(kmeans.getFeaturesCol === "features")
+    assert(kmeans.getPredictionCol === "prediction")
     assert(kmeans.getMaxIter === 20)
     assert(kmeans.getRuns === 1)
     assert(kmeans.getInitializationMode === KMeans.K_MEANS_PARALLEL)
@@ -58,14 +59,16 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
   }
 
   test("fit & transform") {
-    val kmeans = new KMeans().setK(k)
+    val predictionColName = "kmeans_prediction"
+    val kmeans = new KMeans().setK(k).setPredictionCol(predictionColName)
     val model = kmeans.fit(dataset)
     assert(model.clusterCenters.length === k)
 
     val transformed = model.transform(dataset)
-    assert(transformed.columns === Array("features", "prediction"))
-    val clusters = transformed.select("prediction")
+    assert(transformed.columns === Array("features", predictionColName))
+    val clusters = transformed.select(predictionColName)
         .map(row => row.apply(0)).distinct().collect().toSet
+    assert(clusters.size == 5)
     assert(clusters === Set(0, 1, 2, 3, 4))
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -106,8 +106,7 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
     transformed.columns.foreach { column =>
       Array("features", predictionColName).contains(column)
     }
-    val clusters = transformed.select(predictionColName)
-      .map(row => row.apply(0)).distinct().collect().toSet
+    val clusters = transformed.select(predictionColName).map(_.get(0)).distinct().collect().toSet
     assert(clusters.size === k)
     assert(clusters === Set(0, 1, 2, 3, 4))
   }

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -105,7 +105,7 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
     val transformed = model.transform(dataset)
     val expectedColumns = Array("features", predictionColName)
     expectedColumns.foreach { column =>
-      transformed.columns.contains(column)
+      assert(transformed.columns.contains(column))
     }
     val clusters = transformed.select(predictionColName).map(_.getInt(0)).distinct().collect().toSet
     assert(clusters.size === k)

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -103,8 +103,9 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(model.clusterCenters.length === k)
 
     val transformed = model.transform(dataset)
-    transformed.columns.foreach { column =>
-      Array("features", predictionColName).contains(column)
+    val expectedColumns = Array("features", predictionColName)
+    expectedColumns.foreach { column =>
+      transformed.columns.contains(column)
     }
     val clusters = transformed.select(predictionColName).map(_.get(0)).distinct().collect().toSet
     assert(clusters.size === k)

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -103,7 +103,9 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(model.clusterCenters.length === k)
 
     val transformed = model.transform(dataset)
-    assert(transformed.columns === Array("features", predictionColName))
+    transformed.columns.foreach { column =>
+      Array("features", predictionColName).contains(column)
+    }
     val clusters = transformed.select(predictionColName)
       .map(row => row.apply(0)).distinct().collect().toSet
     assert(clusters.size === k)

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -53,7 +53,7 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(kmeans.getPredictionCol === "prediction")
     assert(kmeans.getMaxIter === 20)
     assert(kmeans.getRuns === 1)
-    assert(kmeans.getInitializationMode === MLlibKMeans.K_MEANS_PARALLEL)
+    assert(kmeans.getInitMode === MLlibKMeans.K_MEANS_PARALLEL)
     assert(kmeans.getInitializationSteps === 5)
     assert(kmeans.getEpsilon === 1e-4)
   }
@@ -65,7 +65,7 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
       .setPredictionCol("test_prediction")
       .setMaxIter(33)
       .setRuns(7)
-      .setInitializationMode(MLlibKMeans.RANDOM)
+      .setInitMode(MLlibKMeans.RANDOM)
       .setInitializationSteps(3)
       .setSeed(123)
       .setEpsilon(1e-3)
@@ -75,7 +75,7 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(kmeans.getPredictionCol === "test_prediction")
     assert(kmeans.getMaxIter === 33)
     assert(kmeans.getRuns === 7)
-    assert(kmeans.getInitializationMode === MLlibKMeans.RANDOM)
+    assert(kmeans.getInitMode === MLlibKMeans.RANDOM)
     assert(kmeans.getInitializationSteps === 3)
     assert(kmeans.getSeed === 123)
     assert(kmeans.getEpsilon === 1e-3)
@@ -86,7 +86,7 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
       new KMeans().setK(1)
     }
     intercept[IllegalArgumentException] {
-      new KMeans().setInitializationMode("no_such_a_mode")
+      new KMeans().setInitMode("no_such_a_mode")
     }
     intercept[IllegalArgumentException] {
       new KMeans().setInitializationSteps(0)

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -36,7 +36,7 @@ object KMeansSuite {
 
 class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
 
-  val k = 5
+  final val k = 5
   @transient var dataset: DataFrame = _
 
   override def beforeAll(): Unit = {

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -107,7 +107,7 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
     expectedColumns.foreach { column =>
       transformed.columns.contains(column)
     }
-    val clusters = transformed.select(predictionColName).map(_.get(0)).distinct().collect().toSet
+    val clusters = transformed.select(predictionColName).map(_.getInt(0)).distinct().collect().toSet
     assert(clusters.size === k)
     assert(clusters === Set(0, 1, 2, 3, 4))
   }

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -54,7 +54,7 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(kmeans.getMaxIter === 20)
     assert(kmeans.getRuns === 1)
     assert(kmeans.getInitMode === MLlibKMeans.K_MEANS_PARALLEL)
-    assert(kmeans.getInitializationSteps === 5)
+    assert(kmeans.getInitSteps === 5)
     assert(kmeans.getEpsilon === 1e-4)
   }
 
@@ -66,7 +66,7 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
       .setMaxIter(33)
       .setRuns(7)
       .setInitMode(MLlibKMeans.RANDOM)
-      .setInitializationSteps(3)
+      .setInitSteps(3)
       .setSeed(123)
       .setEpsilon(1e-3)
 
@@ -76,7 +76,7 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(kmeans.getMaxIter === 33)
     assert(kmeans.getRuns === 7)
     assert(kmeans.getInitMode === MLlibKMeans.RANDOM)
-    assert(kmeans.getInitializationSteps === 3)
+    assert(kmeans.getInitSteps === 3)
     assert(kmeans.getSeed === 123)
     assert(kmeans.getEpsilon === 1e-3)
   }
@@ -89,7 +89,7 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
       new KMeans().setInitMode("no_such_a_mode")
     }
     intercept[IllegalArgumentException] {
-      new KMeans().setInitializationSteps(0)
+      new KMeans().setInitSteps(0)
     }
     intercept[IllegalArgumentException] {
       new KMeans().setRuns(0)

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -477,8 +477,8 @@ object Unidoc {
         "mllib.tree.impurity", "mllib.tree.model", "mllib.util",
         "mllib.evaluation", "mllib.feature", "mllib.random", "mllib.stat.correlation",
         "mllib.stat.test", "mllib.tree.impl", "mllib.tree.loss",
-        "ml", "ml.attribute", "ml.classification", "ml.evaluation", "ml.feature", "ml.param",
-        "ml.recommendation", "ml.regression", "ml.tuning"
+        "ml", "ml.attribute", "ml.classification", "ml.clustering", "ml.evaluation", "ml.feature",
+        "ml.param", "ml.recommendation", "ml.regression", "ml.tuning"
       ),
       "-group", "Spark SQL", packageList("sql.api.java", "sql.api.java.types", "sql.hive.api.java"),
       "-noqualifier", "java.lang"

--- a/python/docs/pyspark.ml.rst
+++ b/python/docs/pyspark.ml.rst
@@ -33,6 +33,14 @@ pyspark.ml.classification module
     :undoc-members:
     :inherited-members:
 
+pyspark.ml.clustering module
+--------------------------------
+
+.. automodule:: pyspark.ml.clustering
+    :members:
+    :undoc-members:
+    :inherited-members:
+
 pyspark.ml.recommendation module
 --------------------------------
 

--- a/python/docs/pyspark.ml.rst
+++ b/python/docs/pyspark.ml.rst
@@ -34,7 +34,7 @@ pyspark.ml.classification module
     :inherited-members:
 
 pyspark.ml.clustering module
---------------------------------
+----------------------------
 
 .. automodule:: pyspark.ml.clustering
     :members:

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -58,6 +58,10 @@ class KMeans(JavaEstimator, HasFeaturesCol, HasMaxIter, HasSeed):
     True
     >>> rows[2].prediction == rows[3].prediction
     True
+    >>> kmeans.setParams("features")
+    Traceback (most recent call last):
+        ...
+    TypeError: Method setParams forces keyword arguments.
     """
 
     @keyword_only

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -61,18 +61,21 @@ class KMeans(JavaEstimator, HasFeaturesCol, HasMaxIter, HasSeed):
     """
 
     @keyword_only
-    def __init__(self, k=2):
+    def __init__(self, k=2, maxIter=20, runs=1, epsilon=1e-4, initMode="k-means||", initStep=5):
         super(KMeans, self).__init__()
         self._java_obj = self._new_java_obj("org.apache.spark.ml.clustering.KMeans", self.uid)
-        self.k = Param(self, "k", "number of clusters you want")
-        self.epsilon = Param(self, "epsilon", "distance threshold to have coveraged")
-        self.runs = Param(self, "runs", "number runs of the algorithm to execute in parallel")
+        self.k = Param(self, "k", "number of clusters to create")
+        self.epsilon = Param(self, "epsilon",
+                             "distance threshold within which " +
+                             "we've consider centers to have converged")
+        self.runs = Param(self, "runs", "number of runs of the algorithm to execute in parallel")
         self.seed = Param(self, "seed", "random seed")
-        self.initializationMode = Param(self, "initializationMode", "initialization algorithm")
-        self.initializationSteps = Param(self, "initializationSteps",
-                                         "steps for k-means initialization mode")
-        self._setDefault(k=2, maxIter=20, runs=1, epsilon=1e-4,
-                         initializationMode="k-means||", initializationSteps=5)
+        self.initMode = Param(self, "initMode",
+                              "the initialization algorithm. This can be either \"random\" to " +
+                              "choose random points as initial cluster centers, or \"k-means||\" " +
+                              "to use a parallel variant of k-means++")
+        self.initSteps = Param(self, "initSteps", "steps for k-means initialization mode")
+        self._setDefault(k=2, maxIter=20, runs=1, epsilon=1e-4, initMode="k-means||", initSteps=5)
         kwargs = self.__init__._input_kwargs
         self.setParams(**kwargs)
 
@@ -80,10 +83,9 @@ class KMeans(JavaEstimator, HasFeaturesCol, HasMaxIter, HasSeed):
         return KMeansModel(java_model)
 
     @keyword_only
-    def setParams(self, k=2, maxIter=20, runs=1, epsilon=1e-4,
-                  initializationMode="k-means||", initializationSteps=5):
+    def setParams(self, k=2, maxIter=20, runs=1, epsilon=1e-4, initMode="k-means||", initSteps=5):
         """
-        setParams(self, k=2, maxIter=20, runs=1, initializationMode="k-means||"):
+        setParams(self, k=2, maxIter=20, runs=1, epsilon=1e-4, initMode="k-means||", initSteps=5):
 
         Sets params for KMeans.
         """
@@ -143,7 +145,7 @@ class KMeans(JavaEstimator, HasFeaturesCol, HasMaxIter, HasSeed):
 
     def setInitializationMode(self, value):
         """
-        Sets the value of :py:attr:`initializationMode`.
+        Sets the value of :py:attr:`initMode`.
 
         >>> algo = KMeans()
         >>> algo.getInitializationMode()
@@ -152,31 +154,31 @@ class KMeans(JavaEstimator, HasFeaturesCol, HasMaxIter, HasSeed):
         >>> algo.getInitializationMode()
         'random'
         """
-        self._paramMap[self.initializationMode] = value
+        self._paramMap[self.initMode] = value
         return self
 
     def getInitializationMode(self):
         """
-        Gets the value of `initializationMode`
+        Gets the value of `initMode`
         """
-        return self.getOrDefault(self.initializationMode)
+        return self.getOrDefault(self.initMode)
 
     def setInitializationSteps(self, value):
         """
-        Sets the value of :py:attr:`initializationSteps`.
+        Sets the value of :py:attr:`initSteps`.
 
         >>> algo = KMeans().setInitializationSteps(10)
         >>> algo.getInitializationSteps()
         10
         """
-        self._paramMap[self.initializationSteps] = value
+        self._paramMap[self.initSteps] = value
         return self
 
     def getInitializationSteps(self):
         """
-        Gets the value of `initializationSteps`
+        Gets the value of `initSteps`
         """
-        return self.getOrDefault(self.initializationSteps)
+        return self.getOrDefault(self.initSteps)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -49,8 +49,10 @@ class KMeans(JavaEstimator, HasFeaturesCol, HasMaxIter, HasSeed):
     >>> len(centers)
     2
     >>> transformed = model.transform(df)
-    >>> transformed.columns
-    [u'features', u'prediction']
+    >>> (transformed.columns)[0] == 'features'
+    True
+    >>> (transformed.columns)[1] == 'prediction'
+    True
     >>> rows = sorted(transformed.collect(), key = lambda r: r[0])
     >>> rows[0].prediction == rows[1].prediction
     True

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -1,0 +1,194 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pyspark.ml.util import keyword_only
+from pyspark.ml.wrapper import JavaEstimator, JavaModel
+from pyspark.ml.param.shared import *
+from pyspark.mllib.common import inherit_doc
+from pyspark.mllib.linalg import _convert_to_vector
+
+__all__ = ['KMeans', 'KMeansModel']
+
+
+class KMeansModel(JavaModel):
+    """
+    Model fitted by KMeans.
+    """
+
+    def clusterCenters(self):
+        """Get the cluster centers, represented as a list of NumPy arrays."""
+        return [c.toArray() for c in self._call_java("clusterCenters")]
+
+
+@inherit_doc
+class KMeans(JavaEstimator, HasFeaturesCol, HasMaxIter, HasSeed):
+    """
+    K-means Clustering
+
+    >>> from pyspark.mllib.linalg import Vectors
+    >>> data = [(Vectors.dense([0.0, 0.0]),), (Vectors.dense([1.0, 1.0]),),
+    ...         (Vectors.dense([9.0, 8.0]),), (Vectors.dense([8.0, 9.0]),)]
+    >>> df = sqlContext.createDataFrame(data, ["features"])
+    >>> kmeans = KMeans().setK(2).setSeed(1).setFeaturesCol("features")
+    >>> model = kmeans.fit(df)
+    >>> centers = model.clusterCenters()
+    >>> len(centers)
+    2
+    >>> transformed = model.transform(df)
+    >>> transformed.columns
+    [u'features', u'prediction']
+    >>> rows = sorted(transformed.collect(), key = lambda r: r[0])
+    >>> rows[0].prediction == rows[1].prediction
+    True
+    >>> rows[2].prediction == rows[3].prediction
+    True
+    """
+
+    @keyword_only
+    def __init__(self, k=2):
+        super(KMeans, self).__init__()
+        self._java_obj = self._new_java_obj("org.apache.spark.ml.clustering.KMeans", self.uid)
+        self.k = Param(self, "k", "number of clusters you want")
+        self.epsilon = Param(self, "epsilon", "distance threshold to have coveraged")
+        self.runs = Param(self, "runs", "number runs of the algorithm to execute in parallel")
+        self.seed = Param(self, "seed", "random seed")
+        self.initializationMode = Param(self, "initializationMode", "initialization algorithm")
+        self.initializationSteps = Param(self, "initializationSteps",
+                                         "steps for k-means initialization mode")
+        self._setDefault(k=2, maxIter=20, runs=1, epsilon=1e-4,
+                         initializationMode="k-means||", initializationSteps=5)
+        kwargs = self.__init__._input_kwargs
+        self.setParams(**kwargs)
+
+    def _create_model(self, java_model):
+        return KMeansModel(java_model)
+
+    @keyword_only
+    def setParams(self, k=2, maxIter=20, runs=1, epsilon=1e-4,
+                  initializationMode="k-means||", initializationSteps=5):
+        """
+        setParams(self, k=2, maxIter=20, runs=1, initializationMode="k-means||"):
+
+        Sets params for KMeans.
+        """
+        kwargs = self.setParams._input_kwargs
+        return self._set(**kwargs)
+
+    def setK(self, value):
+        """
+        Sets the value of :py:attr:`k`.
+
+        >>> algo = KMeans().setK(10)
+        >>> algo.getK()
+        10
+        """
+        self._paramMap[self.k] = value
+        return self
+
+    def getK(self):
+        """
+        Gets the value of `k`
+        """
+        return self.getOrDefault(self.k)
+
+    def setEpsilon(self, value):
+        """
+        Sets the value of :py:attr:`epsilon`.
+
+        >>> algo = KMeans().setEpsilon(1e-5)
+        >>> abs(algo.getEpsilon() - 1e-5) < 1e-5
+        True
+        """
+        self._paramMap[self.epsilon] = value
+        return self
+
+    def getEpsilon(self):
+        """
+        Gets the value of `epsilon`
+        """
+        return self.getOrDefault(self.epsilon)
+
+    def setRuns(self, value):
+        """
+        Sets the value of :py:attr:`runs`.
+
+        >>> algo = KMeans().setRuns(10)
+        >>> algo.getRuns()
+        10
+        """
+        self._paramMap[self.runs] = value
+        return self
+
+    def getRuns(self):
+        """
+        Gets the value of `runs`
+        """
+        return self.getOrDefault(self.runs)
+
+    def setInitializationMode(self, value):
+        """
+        Sets the value of :py:attr:`initializationMode`.
+
+        >>> algo = KMeans()
+        >>> algo.getInitializationMode()
+        'k-means||'
+        >>> algo = algo.setInitializationMode("random")
+        >>> algo.getInitializationMode()
+        'random'
+        """
+        self._paramMap[self.initializationMode] = value
+        return self
+
+    def getInitializationMode(self):
+        """
+        Gets the value of `initializationMode`
+        """
+        return self.getOrDefault(self.initializationMode)
+
+    def setInitializationSteps(self, value):
+        """
+        Sets the value of :py:attr:`initializationSteps`.
+
+        >>> algo = KMeans().setInitializationSteps(10)
+        >>> algo.getInitializationSteps()
+        10
+        """
+        self._paramMap[self.initializationSteps] = value
+        return self
+
+    def getInitializationSteps(self):
+        """
+        Gets the value of `initializationSteps`
+        """
+        return self.getOrDefault(self.initializationSteps)
+
+
+if __name__ == "__main__":
+    import doctest
+    from pyspark.context import SparkContext
+    from pyspark.sql import SQLContext
+    globs = globals().copy()
+    # The small batch size here ensures that we see multiple batches,
+    # even in these small test examples:
+    sc = SparkContext("local[2]", "ml.clustering tests")
+    sqlContext = SQLContext(sc)
+    globs['sc'] = sc
+    globs['sqlContext'] = sqlContext
+    (failure_count, test_count) = doctest.testmod(globs=globs, optionflags=doctest.ELLIPSIS)
+    sc.stop()
+    if failure_count:
+        exit(-1)

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -48,12 +48,12 @@ class KMeans(JavaEstimator, HasFeaturesCol, HasMaxIter, HasSeed):
     >>> centers = model.clusterCenters()
     >>> len(centers)
     2
-    >>> transformed = model.transform(df)
-    >>> (transformed.columns)[0] == 'features'
+    >>> transformed = model.transform(df).select("features", "prediction")
+    >>> "features" in transformed.columns
     True
-    >>> (transformed.columns)[1] == 'prediction'
+    >>> "prediction" in transformed.columns
     True
-    >>> rows = sorted(transformed.collect(), key = lambda r: r[0])
+    >>> rows = transformed.collect()
     >>> rows[0].prediction == rows[1].prediction
     True
     >>> rows[2].prediction == rows[3].prediction

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -147,21 +147,21 @@ class KMeans(JavaEstimator, HasFeaturesCol, HasMaxIter, HasSeed):
         """
         return self.getOrDefault(self.runs)
 
-    def setInitializationMode(self, value):
+    def setInitMode(self, value):
         """
         Sets the value of :py:attr:`initMode`.
 
         >>> algo = KMeans()
-        >>> algo.getInitializationMode()
+        >>> algo.getInitMode()
         'k-means||'
-        >>> algo = algo.setInitializationMode("random")
-        >>> algo.getInitializationMode()
+        >>> algo = algo.setInitMode("random")
+        >>> algo.getInitMode()
         'random'
         """
         self._paramMap[self.initMode] = value
         return self
 
-    def getInitializationMode(self):
+    def getInitMode(self):
         """
         Gets the value of `initMode`
         """

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -49,10 +49,6 @@ class KMeans(JavaEstimator, HasFeaturesCol, HasMaxIter, HasSeed):
     >>> len(centers)
     2
     >>> transformed = model.transform(df).select("features", "prediction")
-    >>> "features" in transformed.columns
-    True
-    >>> "prediction" in transformed.columns
-    True
     >>> rows = transformed.collect()
     >>> rows[0].prediction == rows[1].prediction
     True

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -167,18 +167,18 @@ class KMeans(JavaEstimator, HasFeaturesCol, HasMaxIter, HasSeed):
         """
         return self.getOrDefault(self.initMode)
 
-    def setInitializationSteps(self, value):
+    def setInitSteps(self, value):
         """
         Sets the value of :py:attr:`initSteps`.
 
-        >>> algo = KMeans().setInitializationSteps(10)
-        >>> algo.getInitializationSteps()
+        >>> algo = KMeans().setInitSteps(10)
+        >>> algo.getInitSteps()
         10
         """
         self._paramMap[self.initSteps] = value
         return self
 
-    def getInitializationSteps(self):
+    def getInitSteps(self):
         """
         Gets the value of `initSteps`
         """

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -64,6 +64,18 @@ class KMeans(JavaEstimator, HasFeaturesCol, HasMaxIter, HasSeed):
     TypeError: Method setParams forces keyword arguments.
     """
 
+    # a placeholder to make it appear in the generated doc
+    k = Param(Params._dummy(), "k", "number of clusters to create")
+    epsilon = Param(Params._dummy(), "epsilon",
+                    "distance threshold within which " +
+                    "we've consider centers to have converged")
+    runs = Param(Params._dummy(), "runs", "number of runs of the algorithm to execute in parallel")
+    initMode = Param(Params._dummy(), "initMode",
+                     "the initialization algorithm. This can be either \"random\" to " +
+                     "choose random points as initial cluster centers, or \"k-means||\" " +
+                     "to use a parallel variant of k-means++")
+    initSteps = Param(Params._dummy(), "initSteps", "steps for k-means initialization mode")
+
     @keyword_only
     def __init__(self, k=2, maxIter=20, runs=1, epsilon=1e-4, initMode="k-means||", initStep=5):
         super(KMeans, self).__init__()

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -58,10 +58,6 @@ class KMeans(JavaEstimator, HasFeaturesCol, HasMaxIter, HasSeed):
     True
     >>> rows[2].prediction == rows[3].prediction
     True
-    >>> kmeans.setParams("features")
-    Traceback (most recent call last):
-        ...
-    TypeError: Method setParams forces keyword arguments.
     """
 
     # a placeholder to make it appear in the generated doc


### PR DESCRIPTION
I Implemented the KMeans API for spark.ml Pipelines. But it doesn't include clustering abstractions for spark.ml (SPARK-7610). It would fit for another issues. And I'll try it later, since we are trying to add the hierarchical clustering algorithms in another issue. Thanks.

[SPARK-7879] KMeans API for spark.ml Pipelines - ASF JIRA https://issues.apache.org/jira/browse/SPARK-7879
