### PR TITLE
[SPARK-8312] [SQL] Populate statistics info of hive tables if it's needed to be

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -202,7 +202,9 @@ class SQLContext private[sql](
     }
 
   @transient
-  protected[sql] lazy val optimizer: Optimizer = DefaultOptimizer
+  protected[sql] lazy val optimizer: Optimizer = newOptimizer
+
+  protected[sql] def newOptimizer: Optimizer = DefaultOptimizer
 
   @transient
   protected[sql] val ddlParser = new DDLParser(sqlParser.parse(_))

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -202,9 +202,7 @@ class SQLContext private[sql](
     }
 
   @transient
-  protected[sql] lazy val optimizer: Optimizer = newOptimizer
-
-  protected[sql] def newOptimizer: Optimizer = DefaultOptimizer
+  protected[sql] lazy val optimizer: Optimizer = DefaultOptimizer
 
   @transient
   protected[sql] val ddlParser = new DDLParser(sqlParser.parse(_))

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -573,6 +573,7 @@ class HiveContext private[hive](
     }
   }
 
+  @transient
   override protected[sql] lazy val optimizer: Optimizer = new Optimizer {
     override protected val batches =
       DefaultOptimizer.batches.asInstanceOf[Seq[Batch]] ++

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -198,6 +198,12 @@ class HiveContext private[hive](
    */
   protected[hive] def hiveThriftServerAsync: Boolean = getConf(HIVE_THRIFT_SERVER_ASYNC)
 
+  /*
+   * Calculate table statistics in runtime if needed.
+   */
+  protected[hive] def hiveCalculateStatsRuntime: Boolean =
+    getConf(HIVE_TABLE_CALCULATE_STATS_RUNTIME)
+
   protected[hive] def hiveThriftServerSingleSession: Boolean =
     sc.conf.get("spark.sql.hive.thriftServer.singleSession", "false").toBoolean
 
@@ -749,7 +755,11 @@ private[hive] object HiveContext {
 
   val HIVE_THRIFT_SERVER_ASYNC = booleanConf("spark.sql.hive.thriftServer.async",
     defaultValue = Some(true),
-    doc = "TODO")
+    doc = "hive thrift server use background spark sql thread pool to execute sql queries.")
+
+  val HIVE_TABLE_CALCULATE_STATS_RUNTIME = booleanConf("spark.sql.hive.calulcate.stats.runtime",
+    defaultValue = Some(false),
+    doc = "Calculate table statistics in runtime if needed.")
 
   /** Constructs a configuration for hive, where the metastore is located in a temp directory. */
   def newTemporaryConfiguration(): Map[String, String] = {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -576,10 +576,10 @@ class HiveContext private[hive](
   override protected[sql] def newOptimizer: Optimizer = new Optimizer {
     override protected val batches =
       DefaultOptimizer.batches.asInstanceOf[Seq[Batch]] ++
-      Seq(Batch("Hive Table Stats", Once, HiveTableStats))
+      Seq(Batch("Hive Table Stats", Once, new HiveTableStats))
   }
 
-  object HiveTableStats extends Rule[LogicalPlan] {
+  class HiveTableStats extends Rule[LogicalPlan] {
     def apply(plan: LogicalPlan): LogicalPlan = plan match {
       case PhysicalOperation(projectList, predicates, relation: MetastoreRelation) =>
         // Filter out all predicates that only deal with partition keys, these are given to the

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -32,7 +32,6 @@ import org.apache.spark.sql.catalyst.optimizer.{DefaultOptimizer, Optimizer}
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.rules.Rule
 
-import scala.collection.JavaConversions._
 import scala.collection.mutable.HashMap
 import scala.language.implicitConversions
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -719,7 +719,7 @@ private[hive] case class MetastoreRelation
     (@transient private val sqlContext: HiveContext)
   extends LeafNode with MultiInstanceRelation with FileRelation {
 
-  private[hive] var pruningPredicates: Seq[Expression] = null
+  private[hive] var pruningPredicates: Seq[Expression] = Nil
 
   override def equals(other: Any): Boolean = other match {
     case relation: MetastoreRelation =>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -20,15 +20,23 @@ package org.apache.spark.sql.hive
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
+import java.util
+
 import com.google.common.base.Objects
 import com.google.common.cache.{CacheBuilder, CacheLoader, LoadingCache}
-import org.apache.hadoop.fs.Path
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path, ContentSummary}
 import org.apache.hadoop.hive.common.StatsSetupConst
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.metastore.Warehouse
-import org.apache.hadoop.hive.metastore.api.FieldSchema
+import org.apache.hadoop.hive.metastore.api.{MetaException, FieldSchema}
+import org.apache.hadoop.hive.ql.Context
+import org.apache.hadoop.hive.ql.exec.{TableScanOperator, Operator, Utilities}
+import org.apache.hadoop.hive.ql.hooks.ReadEntity
 import org.apache.hadoop.hive.ql.metadata._
-import org.apache.hadoop.hive.ql.plan.TableDesc
+import org.apache.hadoop.hive.ql.optimizer.GenMapRedUtils
+import org.apache.hadoop.hive.ql.parse.ParseContext
+import org.apache.hadoop.hive.ql.plan.{PartitionDesc, OperatorDesc, MapWork, TableDesc}
 
 import org.apache.spark.Logging
 import org.apache.spark.sql.catalyst.analysis.{Catalog, MultiInstanceRelation, OverrideCatalog}
@@ -44,6 +52,7 @@ import org.apache.spark.sql.execution.{FileRelation, datasources}
 import org.apache.spark.sql.hive.client._
 import org.apache.spark.sql.hive.execution.HiveNativeCommand
 import org.apache.spark.sql.sources._
+import org.apache.spark.sql.hive.execution.HiveTableScan
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{AnalysisException, SQLContext, SaveMode}
 
@@ -707,7 +716,7 @@ private[hive] case class InsertIntoHiveTable(
 private[hive] case class MetastoreRelation
     (databaseName: String, tableName: String, alias: Option[String])
     (val table: HiveTable)
-    (@transient private val sqlContext: SQLContext)
+    (@transient private val sqlContext: HiveContext)
   extends LeafNode with MultiInstanceRelation with FileRelation {
 
   override def equals(other: Any): Boolean = other match {
@@ -782,13 +791,28 @@ private[hive] case class MetastoreRelation
   lazy val allPartitions = table.getAllPartitions
 
   def getHiveQlPartitions(predicates: Seq[Expression] = Nil): Seq[Partition] = {
+    getHiveQlPartitions(predicates, bindPredicate(predicates))
+  }
+
+  def bindPredicate(predicates: Seq[Expression]): Option[Expression] = {
+    predicates.reduceLeftOption(org.apache.spark.sql.catalyst.expressions.And).map { pred =>
+      require(
+        pred.dataType == BooleanType,
+        s"Data type of predicate $pred must be BooleanType rather than ${pred.dataType}.")
+      BindReferences.bindReference(pred, partitionKeys)
+    }
+  }
+
+  def getHiveQlPartitions(
+      predicates: Seq[Expression],
+      pruner: Option[Expression]): Seq[Partition] = {
     val rawPartitions = if (sqlContext.conf.metastorePartitionPruning) {
       table.getPartitions(predicates)
     } else {
       allPartitions
     }
 
-    rawPartitions.map { p =>
+    prunePartitions(rawPartitions, pruner).map { p =>
       val tPartition = new org.apache.hadoop.hive.metastore.api.Partition
       tPartition.setDbName(databaseName)
       tPartition.setTableName(tableName)
@@ -813,6 +837,65 @@ private[hive] case class MetastoreRelation
 
       new Partition(hiveQlTable, tPartition)
     }
+  }
+
+  def prepareStats(partitionPruningPred: Seq[Expression]) {
+    val totalSize = hiveQlTable.getParameters.get(StatsSetupConst.TOTAL_SIZE)
+    val rawDataSize = hiveQlTable.getParameters.get(StatsSetupConst.RAW_DATA_SIZE)
+    if (!hiveQlTable.isNonNative && hiveQlTable.getDataLocation != null &&
+        (partitionPruningPred.isEmpty && hiveQlTable.isPartitioned) ||
+        Option(totalSize).map(_.toLong).filter(_ > 0).isEmpty &&
+        Option(rawDataSize).map(_.toLong).filter(_ > 0).isEmpty) {
+
+      val dummy: MapWork = new MapWork
+      val alias: String = "_dummy"
+      val operator: Operator[_ <: OperatorDesc] = new TableScanOperator
+
+      dummy.getAliasToWork.put(alias, operator)
+      val pathToAliases = dummy.getPathToAliases
+      val pathToPartition = dummy.getPathToPartitionInfo
+      if (hiveQlTable.isPartitioned) {
+        for (partition <- getHiveQlPartitions(partitionPruningPred)) {
+          val partPath = getDnsPath(partition.getDataLocation, sqlContext.hiveconf).toString
+          pathToAliases.put(partPath, new util.ArrayList(util.Arrays.asList(alias)))
+          pathToPartition.put(partPath, new PartitionDesc(partition, tableDesc))
+        }
+      } else {
+        val tablePath = getDnsPath(hiveQlTable.getDataLocation, sqlContext.hiveconf).toString
+        pathToAliases.put(tablePath, new util.ArrayList(util.Arrays.asList(alias)))
+        pathToPartition.put(tablePath, new PartitionDesc(tableDesc, null))
+      }
+      // update
+      hiveQlTable.getParameters.put(StatsSetupConst.TOTAL_SIZE,
+        Utilities.getInputSummary(new Context(sqlContext.hiveconf), dummy, null).getLength.toString)
+    }
+  }
+
+  // moved from org.apache.spark.sql.hive.execution.HiveTableScan
+  private[hive] def prunePartitions(partitions: Seq[HivePartition], pruner: Option[Expression]) = {
+    pruner match {
+      case None => partitions
+      case Some(shouldKeep) => partitions.filter { part =>
+        val dataTypes = partitionKeys.map(_.dataType)
+        val castedValues = for ((value, dataType) <- part.values.zip(dataTypes)) yield {
+          castFromString(value, dataType)
+        }
+
+        // Only partitioned values are needed here, since the predicate has already been bound to
+        // partition key attribute references.
+        val row = InternalRow.fromSeq(castedValues)
+        shouldKeep.eval(row).asInstanceOf[Boolean]
+      }
+    }
+  }
+
+  private[this] def castFromString(value: String, dataType: DataType) = {
+    Cast(Literal(value), dataType).eval(null)
+  }
+
+  private[this] def getDnsPath(path: Path, conf: Configuration): Path = {
+    val fs = path.getFileSystem(conf)
+    return new Path(fs.getUri.getScheme, fs.getUri.getAuthority, path.toUri.getPath)
   }
 
   /** Only compare database and tablename, not alias. */

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientInterface.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientInterface.scala
@@ -42,6 +42,7 @@ private[hive] case class HiveStorageDescriptor(
 
 private[hive] case class HivePartition(
     values: Seq[String],
+    properties: Map[String, String],
     storage: HiveStorageDescriptor)
 
 private[hive] case class HiveColumn(name: String, @Nullable hiveType: String, comment: String)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
@@ -422,6 +422,7 @@ private[hive] class ClientWrapper(
     val apiPartition = partition.getTPartition
     HivePartition(
       values = Option(apiPartition.getValues).map(_.asScala).getOrElse(Seq.empty),
+      properties = Option(apiPartition.getParameters).map(_.asScala.toMap).getOrElse(Map.empty),
       storage = HiveStorageDescriptor(
         location = apiPartition.getSd.getLocation,
         inputFormat = apiPartition.getSd.getInputFormat,

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
@@ -103,7 +103,8 @@ class StatisticsSuite extends QueryTest with TestHiveSingleton {
         |SELECT * FROM src
       """.stripMargin).collect()
 
-    assert(queryTotalSize("analyzeTable_part") === hiveContext.conf.defaultSizeInBytes)
+    // stats for partition is populated in insert query
+    assert(queryTotalSize("analyzeTable_part") === BigInt(17436))
 
     sql("ANALYZE TABLE analyzeTable_part COMPUTE STATISTICS noscan")
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/PruningSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/PruningSuite.scala
@@ -150,7 +150,7 @@ class PruningSuite extends HiveComparisonTest with BeforeAndAfter {
         case p @ HiveTableScan(columns, relation, _) =>
           val columnNames = columns.map(_.name)
           val partValues = if (relation.table.isPartitioned) {
-            p.prunePartitions(relation.getHiveQlPartitions()).map(_.getValues)
+            relation.getHiveQlPartitions(p.partitionPruningPred).map(_.getValues.asScala)
           } else {
             Seq.empty
           }
@@ -160,7 +160,7 @@ class PruningSuite extends HiveComparisonTest with BeforeAndAfter {
       assert(actualOutputColumns === expectedOutputColumns, "Output columns mismatch")
       assert(actualScannedColumns === expectedScannedColumns, "Scanned columns mismatch")
 
-      val actualPartitions = actualPartValues.map(_.asScala.mkString(",")).sorted
+      val actualPartitions = actualPartValues.map(_.mkString(",")).sorted
       val expectedPartitions = expectedPartValues.map(_.mkString(",")).sorted
 
       assert(actualPartitions === expectedPartitions, "Partitions selected do not match")


### PR DESCRIPTION
Currently, spark-sql uses stats in metastore for estimating size of hive table, which means analyze command should be executed before accessing the table for better planning especially for joins. But still with the stats, it cannot reflect real input size of the query when partition prunning predicate exists in it.

Even worse is that hive cannot update metastore stats for external tables, which is fixed recently in HIVE-6727. The issue detail says the bug is applied to all hive version between 0.13.0 and 1.2.0
