### PR TITLE
[SPARK-8314][MLlib] improvement in performance of MLUtils.appendBias

### DIFF
--- a/examples/src/main/scala/org/apache/spark/examples/ml/LogisticRegressionExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/LogisticRegressionExample.scala
@@ -145,9 +145,9 @@ object LogisticRegressionExample {
     val elapsedTime = (System.nanoTime() - startTime) / 1e9
     println(s"Training time: $elapsedTime seconds")
 
-    val lirModel = pipelineModel.stages.last.asInstanceOf[LogisticRegressionModel]
+    val lorModel = pipelineModel.stages.last.asInstanceOf[LogisticRegressionModel]
     // Print the weights and intercept for logistic regression.
-    println(s"Weights: ${lirModel.weights} Intercept: ${lirModel.intercept}")
+    println(s"Weights: ${lorModel.weights} Intercept: ${lorModel.intercept}")
 
     println("Training data results:")
     DecisionTreeExample.evaluateClassificationModel(pipelineModel, training, "indexedLabel")

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
@@ -213,9 +213,9 @@ private[spark] object BLAS extends Serializable with Logging {
   def scal(a: Double, x: Vector): Unit = {
     x match {
       case sx: SparseVector =>
-        f2jBLAS.dscal(sx.values.size, a, sx.values, 1)
+        f2jBLAS.dscal(sx.values.length, a, sx.values, 1)
       case dx: DenseVector =>
-        f2jBLAS.dscal(dx.values.size, a, dx.values, 1)
+        f2jBLAS.dscal(dx.values.length, a, dx.values, 1)
       case _ =>
         throw new IllegalArgumentException(s"scal doesn't support vector type ${x.getClass}.")
     }

--- a/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
@@ -290,7 +290,7 @@ object MLUtils {
         outputValues(inputValuesLength) = 1.0
         outputIndices(inputValuesLength) = dim
         Vectors.sparse(dim + 1, outputIndices, outputValues)
-      case _ => throw new IllegalArgumentException("Do not support vector type " + vector.getClass)
+      case _ => throw new IllegalArgumentException(s"Do not support vector type ${vector.getClass}")
     }
   }
 

--- a/mllib/src/test/scala/org/apache/spark/mllib/util/MLUtilsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/util/MLUtilsSuite.scala
@@ -161,10 +161,10 @@ class MLUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
   }
 
   test("appendBias") {
-    val sv = Vectors.sparse(3, Seq((0, 1.0), (2, 3.0)))
+    val sv = Vectors.sparse(4, Seq((0, 1.0), (2, 3.0)))
     val sv1 = appendBias(sv).asInstanceOf[SparseVector]
-    assert(sv1.size === 4)
-    assert(sv1.indices === Array(0, 2, 3))
+    assert(sv1.size === 5)
+    assert(sv1.indices === Array(0, 2, 4))
     assert(sv1.values === Array(1.0, 3.0, 1.0))
 
     val dv = Vectors.dense(1.0, 0.0, 3.0)

--- a/mllib/src/test/scala/org/apache/spark/mllib/util/MLUtilsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/util/MLUtilsSuite.scala
@@ -161,10 +161,10 @@ class MLUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
   }
 
   test("appendBias") {
-    val sv = Vectors.sparse(4, Seq((0, 1.0), (2, 3.0)))
+    val sv = Vectors.sparse(3, Seq((0, 1.0), (2, 3.0)))
     val sv1 = appendBias(sv).asInstanceOf[SparseVector]
-    assert(sv1.size === 5)
-    assert(sv1.indices === Array(0, 2, 4))
+    assert(sv1.size === 4)
+    assert(sv1.indices === Array(0, 2, 3))
     assert(sv1.values === Array(1.0, 3.0, 1.0))
 
     val dv = Vectors.dense(1.0, 0.0, 3.0)


### PR DESCRIPTION
MLUtils.appendBias method is heavily used in creating intercepts for linear models. 
This method uses Breeze's vector concatenation which is very slow compared to the plain 
System.arrayCopy. This improvement is to change the implementation to use System.arrayCopy.

I saw the following performance improvements after the change:
Benchmark with mnist dataset for 50 times:
MLUtils.appendBias (SparseVector Before): 47320 ms
MLUtils.appendBias (SparseVector After): 1935 ms
MLUtils.appendBias (DenseVector Before): 5340 ms
MLUtils.appendBias (DenseVector After): 4080 ms
This is almost a 24 times performance boost for SparseVectors.
