### PR TITLE
[SPARK-6259][MLlib] Python API for LDA

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
@@ -526,8 +526,8 @@ private[python] class PythonMLLibAPI extends Serializable {
 
     val documents = data.rdd.map(_.asScala.toArray).map { r =>
       r(0).getClass.getSimpleName match {
-        case "Integer" =>  (r(0).asInstanceOf[java.lang.Integer].toLong, r(1).asInstanceOf[Vector])
-        case "Long" =>  (r(0).asInstanceOf[java.lang.Long].toLong, r(1).asInstanceOf[Vector])
+        case "Integer" => (r(0).asInstanceOf[java.lang.Integer].toLong, r(1).asInstanceOf[Vector])
+        case "Long" => (r(0).asInstanceOf[java.lang.Long].toLong, r(1).asInstanceOf[Vector])
         case _ => throw new IllegalArgumentException("input values contains invalid type value.")
       }
     }

--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
@@ -506,7 +506,7 @@ private[python] class PythonMLLibAPI extends Serializable {
    * Java stub for Python mllib LDA.run()
    */
   def trainLDAModel(
-      data: JavaRDD[LabeledPoint],
+      data: JavaRDD[java.util.List[Any]],
       k: Int,
       maxIterations: Int,
       docConcentration: Double,
@@ -524,11 +524,14 @@ private[python] class PythonMLLibAPI extends Serializable {
 
     if (seed != null) algo.setSeed(seed)
 
-    try {
-      algo.run(data.rdd.map(x => (x.label.toLong, x.features)))
-    } finally {
-      data.rdd.unpersist(blocking = false)
+    val documents = data.rdd.map(_.asScala.toArray).map { r =>
+      r(0).getClass.getSimpleName match {
+        case "Integer" =>  (r(0).asInstanceOf[java.lang.Integer].toLong, r(1).asInstanceOf[Vector])
+        case "Long" =>  (r(0).asInstanceOf[java.lang.Long].toLong, r(1).asInstanceOf[Vector])
+        case _ => throw new IllegalArgumentException("input values contains invalid type value.")
+      }
     }
+    algo.run(documents)
   }
 
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
@@ -525,9 +525,11 @@ private[python] class PythonMLLibAPI extends Serializable {
     if (seed != null) algo.setSeed(seed)
 
     val documents = data.rdd.map(_.asScala.toArray).map { r =>
-      r(0).getClass.getSimpleName match {
-        case "Integer" => (r(0).asInstanceOf[java.lang.Integer].toLong, r(1).asInstanceOf[Vector])
-        case "Long" => (r(0).asInstanceOf[java.lang.Long].toLong, r(1).asInstanceOf[Vector])
+      r(0) match {
+        case i: java.lang.Integer =>
+          (r(0).asInstanceOf[java.lang.Integer].toLong, r(1).asInstanceOf[Vector])
+        case i: java.lang.Long =>
+          (r(0).asInstanceOf[java.lang.Long].toLong, r(1).asInstanceOf[Vector])
         case _ => throw new IllegalArgumentException("input values contains invalid type value.")
       }
     }

--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
@@ -506,11 +506,21 @@ private[python] class PythonMLLibAPI extends Serializable {
    * Java stub for Python mllib LDA.run()
    */
   def trainLDAModel(
-    data: JavaRDD[LabeledPoint],
-    k: Int,
-    seed: java.lang.Long): LDAModel = {
+      data: JavaRDD[LabeledPoint],
+      k: Int,
+      maxIterations: Int,
+      docConcentration: Double,
+      topicConcentration: Double,
+      seed: java.lang.Long,
+      checkpointInterval: Int,
+      optimizer: String): LDAModel = {
     val algo = new LDA()
         .setK(k)
+        .setMaxIterations(maxIterations)
+        .setDocConcentration(docConcentration)
+        .setTopicConcentration(topicConcentration)
+        .setCheckpointInterval(checkpointInterval)
+        .setOptimizer(optimizer)
 
     if (seed != null) algo.setSeed(seed)
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
@@ -503,6 +503,26 @@ private[python] class PythonMLLibAPI extends Serializable {
   }
 
   /**
+   * Java stub for Python mllib LDA.run()
+   */
+  def trainLDAModel(
+    data: JavaRDD[LabeledPoint],
+    k: Int,
+    seed: java.lang.Long): LDAModel = {
+    val algo = new LDA()
+        .setK(k)
+
+    if (seed != null) algo.setSeed(seed)
+
+    try {
+      algo.run(data.rdd.map(x => (x.label.toLong, x.features)))
+    } finally {
+      data.rdd.unpersist(blocking = false)
+    }
+  }
+
+
+  /**
    * Java stub for Python mllib FPGrowth.train().  This stub returns a handle
    * to the Java object instead of the content of the Java object.  Extra care
    * needs to be taken in the Python code to ensure it gets freed on exit; see

--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
@@ -526,10 +526,8 @@ private[python] class PythonMLLibAPI extends Serializable {
 
     val documents = data.rdd.map(_.asScala.toArray).map { r =>
       r(0) match {
-        case i: java.lang.Integer =>
-          (r(0).asInstanceOf[java.lang.Integer].toLong, r(1).asInstanceOf[Vector])
-        case i: java.lang.Long =>
-          (r(0).asInstanceOf[java.lang.Long].toLong, r(1).asInstanceOf[Vector])
+        case i: java.lang.Integer => (i.toLong, r(1).asInstanceOf[Vector])
+        case i: java.lang.Long => (i.toLong, r(1).asInstanceOf[Vector])
         case _ => throw new IllegalArgumentException("input values contains invalid type value.")
       }
     }

--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
@@ -515,12 +515,12 @@ private[python] class PythonMLLibAPI extends Serializable {
       checkpointInterval: Int,
       optimizer: String): LDAModel = {
     val algo = new LDA()
-        .setK(k)
-        .setMaxIterations(maxIterations)
-        .setDocConcentration(docConcentration)
-        .setTopicConcentration(topicConcentration)
-        .setCheckpointInterval(checkpointInterval)
-        .setOptimizer(optimizer)
+      .setK(k)
+      .setMaxIterations(maxIterations)
+      .setDocConcentration(docConcentration)
+      .setTopicConcentration(topicConcentration)
+      .setCheckpointInterval(checkpointInterval)
+      .setOptimizer(optimizer)
 
     if (seed != null) algo.setSeed(seed)
 

--- a/python/pyspark/mllib/clustering.py
+++ b/python/pyspark/mllib/clustering.py
@@ -612,14 +612,6 @@ class LDAModel(JavaModelWrapper):
         """Vocabulary size (number of terms or terms in the vocabulary)"""
         return self.call("vocabSize")
 
-    def describeTopics(self, maxTermsPerTopic=None):
-        """Return the topics described by weighted terms.
-
-        TODO:
-        Implementing this method is a little hard. Since Scala's return value consistes of tuples.
-        """
-        raise NotImplementedError("LDAModel.describeTopics() in Python must be implemented.")
-
 
 class LDA():
 

--- a/python/pyspark/mllib/clustering.py
+++ b/python/pyspark/mllib/clustering.py
@@ -618,7 +618,20 @@ class LDA():
     @classmethod
     def train(cls, rdd, k=10, maxIterations=20, docConcentration=-1.0,
               topicConcentration=-1.0, seed=None, checkpointInterval=10, optimizer="em"):
-        """Train a LDA model."""
+        """Train a LDA model.
+
+        :param rdd:                 RDD of data points
+        :param k:                   Number of clusters you want
+        :param maxIterations:       Number of iterations. Default to 20
+        :param docConcentration:    Concentration parameter (commonly named "alpha")
+            for the prior placed on documents' distributions over topics ("theta").
+        :param topicConcentration:  Concentration parameter (commonly named "beta" or "eta")
+            for the prior placed on topics' distributions over terms.
+        :param seed:                Random Seed
+        :param checkpointInterval:  Period (in iterations) between checkpoints.
+        :param optimizer:           LDAOptimizer used to perform the actual calculation
+            (default = EMLDAOptimizer)
+        """
         model = callMLlibFunc("trainLDAModel", rdd, k, maxIterations,
                               docConcentration, topicConcentration, seed,
                               checkpointInterval, optimizer)

--- a/python/pyspark/mllib/clustering.py
+++ b/python/pyspark/mllib/clustering.py
@@ -602,7 +602,7 @@ class LDAModel(JavaModelWrapper):
         return self.call("vocabSize")
 
 
-class LDA():
+class LDA(object):
 
     @classmethod
     def train(cls, rdd, k=10, maxIterations=20, docConcentration=-1.0,

--- a/python/pyspark/mllib/clustering.py
+++ b/python/pyspark/mllib/clustering.py
@@ -597,7 +597,7 @@ class LDAModel(JavaModelWrapper):
     ...     LabeledPoint(2, [1.0, 0.0]),
     ... ]
     >>> rdd =  sc.parallelize(data)
-    >>> model = LDA.train(rdd, 2)
+    >>> model = LDA.train(rdd, k=2)
     >>> model.vocabSize()
     2
     >>> topics = model.topicsMatrix()
@@ -625,8 +625,12 @@ class LDAModel(JavaModelWrapper):
 class LDA():
 
     @classmethod
-    def train(cls, rdd, k, seed=None):
-        model = callMLlibFunc("trainLDAModel", rdd, k, seed)
+    def train(cls, rdd, k=10, maxIterations=20, docConcentration=-1.0,
+              topicConcentration=-1.0, seed=None, checkpointInterval=10, optimizer="em"):
+        """Train a LDA model."""
+        model = callMLlibFunc("trainLDAModel", rdd, k, maxIterations,
+                              docConcentration, topicConcentration, seed,
+                              checkpointInterval, optimizer)
         return LDAModel(model)
 
 

--- a/python/pyspark/mllib/clustering.py
+++ b/python/pyspark/mllib/clustering.py
@@ -629,8 +629,8 @@ class LDA():
             for the prior placed on topics' distributions over terms.
         :param seed:                Random Seed
         :param checkpointInterval:  Period (in iterations) between checkpoints.
-        :param optimizer:           LDAOptimizer used to perform the actual calculation
-            (default = EMLDAOptimizer). Currently "em", "online" are supported. Default to "em".
+        :param optimizer:           LDAOptimizer used to perform the actual calculation.
+            Currently "em", "online" are supported. Default to "em".
         """
         model = callMLlibFunc("trainLDAModel", rdd, k, maxIterations,
                               docConcentration, topicConcentration, seed,

--- a/python/pyspark/mllib/clustering.py
+++ b/python/pyspark/mllib/clustering.py
@@ -590,7 +590,6 @@ class LDAModel(JavaModelWrapper):
     Blei, Ng, and Jordan.  "Latent Dirichlet Allocation."  JMLR, 2003.
 
     >>> from pyspark.mllib.linalg import Vectors
-    >>> from collections import namedtuple
     >>> from numpy.testing import assert_almost_equal
     >>> data = [
     ...     [1, Vectors.dense([0.0, 1.0])],

--- a/python/pyspark/mllib/clustering.py
+++ b/python/pyspark/mllib/clustering.py
@@ -593,8 +593,8 @@ class LDAModel(JavaModelWrapper):
     >>> from collections import namedtuple
     >>> from numpy.testing import assert_almost_equal
     >>> data = [
-    ...     LabeledPoint(1, [0.0, 1.0]),
-    ...     LabeledPoint(2, [1.0, 0.0]),
+    ...     [1, Vectors.dense([0.0, 1.0])],
+    ...     [2, SparseVector(2, {0: 1.0})],
     ... ]
     >>> rdd =  sc.parallelize(data)
     >>> model = LDA.train(rdd, k=2)

--- a/python/pyspark/mllib/clustering.py
+++ b/python/pyspark/mllib/clustering.py
@@ -565,17 +565,6 @@ class StreamingKMeans(object):
         return dstream.mapValues(lambda x: self._model.predict(x))
 
 
-def _test():
-    import doctest
-    import pyspark.mllib.clustering
-    globs = pyspark.mllib.clustering.__dict__.copy()
-    globs['sc'] = SparkContext('local[4]', 'PythonTest', batchSize=2)
-    (failure_count, test_count) = doctest.testmod(globs=globs, optionflags=doctest.ELLIPSIS)
-    globs['sc'].stop()
-    if failure_count:
-        exit(-1)
-
-
 class LDAModel(JavaModelWrapper):
 
     """ A clustering model derived from the LDA method.
@@ -636,6 +625,17 @@ class LDA():
                               docConcentration, topicConcentration, seed,
                               checkpointInterval, optimizer)
         return LDAModel(model)
+
+
+def _test():
+    import doctest
+    import pyspark.mllib.clustering
+    globs = pyspark.mllib.clustering.__dict__.copy()
+    globs['sc'] = SparkContext('local[4]', 'PythonTest', batchSize=2)
+    (failure_count, test_count) = doctest.testmod(globs=globs, optionflags=doctest.ELLIPSIS)
+    globs['sc'].stop()
+    if failure_count:
+        exit(-1)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/mllib/clustering.py
+++ b/python/pyspark/mllib/clustering.py
@@ -630,7 +630,7 @@ class LDA():
         :param seed:                Random Seed
         :param checkpointInterval:  Period (in iterations) between checkpoints.
         :param optimizer:           LDAOptimizer used to perform the actual calculation
-            (default = EMLDAOptimizer)
+            (default = EMLDAOptimizer). Currently "em", "online" are supported. Default to "em".
         """
         model = callMLlibFunc("trainLDAModel", rdd, k, maxIterations,
                               docConcentration, topicConcentration, seed,

--- a/python/pyspark/mllib/clustering.py
+++ b/python/pyspark/mllib/clustering.py
@@ -581,7 +581,7 @@ class LDAModel(JavaModelWrapper):
     """ A clustering model derived from the LDA method.
 
     Latent Dirichlet Allocation (LDA), a topic model designed for text documents.
-    Terminologyu
+    Terminology
     - "word" = "term": an element of the vocabulary
     - "token": instance of a term appearing in a document
     - "topic": multinomial distribution over words representing some concept


### PR DESCRIPTION
I implemented the Python API for LDA. But I didn't implemented a method for `LDAModel.describeTopics()`, beause it's a little hard to implement it now. And adding document about that and an example code would fit for another issue.

TODO: LDAModel.describeTopics() in Python must be also implemented. But it would be nice to fit for another issue. Implementing it is a little hard, since the return value of `describeTopics` in Scala consists of Tuple classes.
