### PR TITLE
[SPARK-8339] [PySpark] integer division for python 3

### DIFF
--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -272,7 +272,7 @@ class AutoBatchedSerializer(BatchedSerializer):
             if size < best:
                 batch *= 2
             elif size > best * 10 and batch > 1:
-                batch /= 2
+                batch //= 2
 
     def __repr__(self):
         return "AutoBatchedSerializer(%s)" % self.serializer


### PR DESCRIPTION
Itertools islice requires an integer for the stop argument.  Switching to integer division here prevents a ValueError when vs is evaluated above.

@davies 

This is my original work, and I license it to the project.
