### PR TITLE
[SPARK-8301][SQL] Improve UTF8String substring/startsWith/endsWith/contains performance

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
@@ -310,7 +310,6 @@ public final class UnsafeRow extends BaseMutableRow {
 
   public UTF8String getUTF8String(int i) {
     assertIndexIsValid(i);
-    final UTF8String str = new UTF8String();
     final long offsetToStringSize = getLong(i);
     final int stringSizeInBytes =
       (int) PlatformDependent.UNSAFE.getLong(baseObject, baseOffset + offsetToStringSize);
@@ -322,8 +321,7 @@ public final class UnsafeRow extends BaseMutableRow {
       PlatformDependent.BYTE_ARRAY_OFFSET,
       stringSizeInBytes
     );
-    str.set(strBytes);
-    return str;
+    return UTF8String.fromBytes(strBytes);
   }
 
   @Override

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -437,17 +437,17 @@ case class Cast(child: Expression, dataType: DataType) extends UnaryExpression w
 
       case (BinaryType, StringType) =>
         defineCodeGen (ctx, ev, c =>
-          s"new ${ctx.stringType}().set($c)")
+          s"new ${ctx.stringType}().fromString($c)")
       case (DateType, StringType) =>
         defineCodeGen(ctx, ev, c =>
-          s"""new ${ctx.stringType}().set(
+          s"""new ${ctx.stringType}().fromString(
                 org.apache.spark.sql.catalyst.util.DateUtils.toString($c))""")
       // Special handling required for timestamps in hive test cases since the toString function
       // does not match the expected output.
       case (TimestampType, StringType) =>
         super.genCode(ctx, ev)
       case (_, StringType) =>
-        defineCodeGen(ctx, ev, c => s"new ${ctx.stringType}().set(String.valueOf($c))")
+        defineCodeGen(ctx, ev, c => s"new ${ctx.stringType}().fromString(String.valueOf($c))")
 
       // fallback for DecimalType, this must be before other numeric types
       case (_, dt: DecimalType) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -437,17 +437,17 @@ case class Cast(child: Expression, dataType: DataType) extends UnaryExpression w
 
       case (BinaryType, StringType) =>
         defineCodeGen (ctx, ev, c =>
-          s"new ${ctx.stringType}().fromBytes($c)")
+          s"${ctx.stringType}().fromBytes($c)")
       case (DateType, StringType) =>
         defineCodeGen(ctx, ev, c =>
-          s"""new ${ctx.stringType}().fromString(
+          s"""${ctx.stringType}().fromString(
                 org.apache.spark.sql.catalyst.util.DateUtils.toString($c))""")
       // Special handling required for timestamps in hive test cases since the toString function
       // does not match the expected output.
       case (TimestampType, StringType) =>
         super.genCode(ctx, ev)
       case (_, StringType) =>
-        defineCodeGen(ctx, ev, c => s"new ${ctx.stringType}().fromString(String.valueOf($c))")
+        defineCodeGen(ctx, ev, c => s"${ctx.stringType}().fromString(String.valueOf($c))")
 
       // fallback for DecimalType, this must be before other numeric types
       case (_, dt: DecimalType) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -437,7 +437,7 @@ case class Cast(child: Expression, dataType: DataType) extends UnaryExpression w
 
       case (BinaryType, StringType) =>
         defineCodeGen (ctx, ev, c =>
-          s"new ${ctx.stringType}().fromString($c)")
+          s"new ${ctx.stringType}().fromBytes($c)")
       case (DateType, StringType) =>
         defineCodeGen(ctx, ev, c =>
           s"""new ${ctx.stringType}().fromString(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -437,17 +437,17 @@ case class Cast(child: Expression, dataType: DataType) extends UnaryExpression w
 
       case (BinaryType, StringType) =>
         defineCodeGen (ctx, ev, c =>
-          s"${ctx.stringType}().fromBytes($c)")
+          s"${ctx.stringType}.fromBytes($c)")
       case (DateType, StringType) =>
         defineCodeGen(ctx, ev, c =>
-          s"""${ctx.stringType}().fromString(
+          s"""${ctx.stringType}.fromString(
                 org.apache.spark.sql.catalyst.util.DateUtils.toString($c))""")
       // Special handling required for timestamps in hive test cases since the toString function
       // does not match the expected output.
       case (TimestampType, StringType) =>
         super.genCode(ctx, ev)
       case (_, StringType) =>
-        defineCodeGen(ctx, ev, c => s"${ctx.stringType}().fromString(String.valueOf($c))")
+        defineCodeGen(ctx, ev, c => s"${ctx.stringType}.fromString(String.valueOf($c))")
 
       // fallback for DecimalType, this must be before other numeric types
       case (_, dt: DecimalType) =>

--- a/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -56,12 +56,16 @@ public final class UTF8String implements Comparable<UTF8String>, Serializable {
    * Updates the UTF8String with String.
    */
   public UTF8String set(final String str) {
-    try {
-      bytes = str.getBytes("utf-8");
-    } catch (UnsupportedEncodingException e) {
-      // Turn the exception into unchecked so we can find out about it at runtime, but
-      // don't need to add lots of boilerplate code everywhere.
-      PlatformDependent.throwException(e);
+    if (str == null) {
+      bytes = new byte[0];
+    } else {
+      try {
+        bytes = str.getBytes("utf-8");
+      } catch (UnsupportedEncodingException e) {
+        // Turn the exception into unchecked so we can find out about it at runtime, but
+        // don't need to add lots of boilerplate code everywhere.
+        PlatformDependent.throwException(e);
+      }
     }
     return this;
   }
@@ -70,7 +74,7 @@ public final class UTF8String implements Comparable<UTF8String>, Serializable {
    * Updates the UTF8String with byte[], which should be encoded in UTF-8.
    */
   public UTF8String set(final byte[] bytes) {
-    this.bytes = bytes;
+    this.bytes = (bytes != null) ? bytes : new byte[0];
     return this;
   }
 
@@ -185,6 +189,7 @@ public final class UTF8String implements Comparable<UTF8String>, Serializable {
 
   @Override
   public int compareTo(final UTF8String other) {
+    if (other == null) return 1;
     final byte[] b = other.getBytes();
     for (int i = 0; i < bytes.length && i < b.length; i++) {
       int res = bytes[i] - b[i];

--- a/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -125,37 +125,37 @@ public final class UTF8String implements Comparable<UTF8String>, Serializable {
   }
 
   public boolean contains(final UTF8String substring) {
+    if (substring == null) return false;
     final byte[] b = substring.getBytes();
     if (b.length == 0) {
       return true;
     }
 
     for (int i = 0; i <= bytes.length - b.length; i++) {
-      if (bytes[i] == b[0] && startsWith(substring, i)) {
+      if (bytes[i] == b[0] && startsWith(b, i)) {
         return true;
       }
     }
     return false;
   }
 
-  private boolean startsWith(final UTF8String prefix, int offset) {
-    byte[] b = prefix.getBytes();
-    if (b.length + offset > bytes.length || offset < 0) {
+  private boolean startsWith(final byte[] prefix, int offset) {
+    if (prefix.length + offset > bytes.length || offset < 0) {
       return false;
     }
     int i = 0;
-    while (i < b.length && b[i] == bytes[i + offset]) {
+    while (i < prefix.length && prefix[i] == bytes[i + offset]) {
       i++;
     }
-    return i == b.length;
+    return i == prefix.length;
   }
 
   public boolean startsWith(final UTF8String prefix) {
-    return startsWith(prefix, 0);
+    return prefix != null && startsWith(prefix.getBytes(), 0);
   }
 
   public boolean endsWith(final UTF8String suffix) {
-    return startsWith(suffix, bytes.length - suffix.getBytes().length);
+    return suffix != null && startsWith(suffix.getBytes(), bytes.length - suffix.getBytes().length);
   }
 
   public UTF8String toUpperCase() {

--- a/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -20,7 +20,7 @@ package org.apache.spark.unsafe.types;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 
 import org.apache.spark.unsafe.PlatformDependent;
 
@@ -34,7 +34,7 @@ import org.apache.spark.unsafe.PlatformDependent;
  */
 public final class UTF8String implements Comparable<UTF8String>, Serializable {
 
-  @Nullable
+  @Nonnull
   private byte[] bytes;
 
   private static int[] bytesOfCodePointInUTF8 = {2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
@@ -55,7 +55,7 @@ public final class UTF8String implements Comparable<UTF8String>, Serializable {
   /**
    * Updates the UTF8String with String.
    */
-  public UTF8String set(final String str) {
+  protected UTF8String set(final String str) {
     if (str == null) {
       bytes = new byte[0];
     } else {
@@ -73,7 +73,7 @@ public final class UTF8String implements Comparable<UTF8String>, Serializable {
   /**
    * Updates the UTF8String with byte[], which should be encoded in UTF-8.
    */
-  public UTF8String set(final byte[] bytes) {
+  protected UTF8String set(final byte[] bytes) {
     this.bytes = (bytes != null) ? bytes : new byte[0];
     return this;
   }

--- a/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -131,24 +131,31 @@ public final class UTF8String implements Comparable<UTF8String>, Serializable {
     }
 
     for (int i = 0; i <= bytes.length - b.length; i++) {
-      // TODO: Avoid copying.
-      if (bytes[i] == b[0] && Arrays.equals(Arrays.copyOfRange(bytes, i, i + b.length), b)) {
+      if (bytes[i] == b[0] && startsWith(substring, i)) {
         return true;
       }
     }
     return false;
   }
 
+  private boolean startsWith(final UTF8String prefix, int offset) {
+    byte[] b = prefix.getBytes();
+    if (b.length + offset > bytes.length || offset < 0) {
+      return false;
+    }
+    int i = 0;
+    while (i < b.length && b[i] == bytes[i + offset]) {
+      i++;
+    }
+    return i == b.length;
+  }
+
   public boolean startsWith(final UTF8String prefix) {
-    final byte[] b = prefix.getBytes();
-    // TODO: Avoid copying.
-    return b.length <= bytes.length && Arrays.equals(Arrays.copyOfRange(bytes, 0, b.length), b);
+    return startsWith(prefix, 0);
   }
 
   public boolean endsWith(final UTF8String suffix) {
-    final byte[] b = suffix.getBytes();
-    return b.length <= bytes.length &&
-      Arrays.equals(Arrays.copyOfRange(bytes, bytes.length - b.length, bytes.length), b);
+    return startsWith(suffix, bytes.length - suffix.getBytes().length);
   }
 
   public UTF8String toUpperCase() {

--- a/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -20,7 +20,7 @@ package org.apache.spark.unsafe.types;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 
 import org.apache.spark.unsafe.PlatformDependent;
 
@@ -34,7 +34,7 @@ import org.apache.spark.unsafe.PlatformDependent;
  */
 public final class UTF8String implements Comparable<UTF8String>, Serializable {
 
-  @Nullable
+  @Nonnull
   private byte[] bytes;
 
   private static int[] bytesOfCodePointInUTF8 = {2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,

--- a/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -20,7 +20,7 @@ package org.apache.spark.unsafe.types;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
-import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import org.apache.spark.unsafe.PlatformDependent;
 
@@ -34,7 +34,7 @@ import org.apache.spark.unsafe.PlatformDependent;
  */
 public final class UTF8String implements Comparable<UTF8String>, Serializable {
 
-  @Nonnull
+  @Nullable
   private byte[] bytes;
 
   private static int[] bytesOfCodePointInUTF8 = {2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
@@ -56,16 +56,12 @@ public final class UTF8String implements Comparable<UTF8String>, Serializable {
    * Updates the UTF8String with String.
    */
   protected UTF8String set(final String str) {
-    if (str == null) {
-      bytes = new byte[0];
-    } else {
-      try {
-        bytes = str.getBytes("utf-8");
-      } catch (UnsupportedEncodingException e) {
-        // Turn the exception into unchecked so we can find out about it at runtime, but
-        // don't need to add lots of boilerplate code everywhere.
-        PlatformDependent.throwException(e);
-      }
+    try {
+      bytes = str.getBytes("utf-8");
+    } catch (UnsupportedEncodingException e) {
+      // Turn the exception into unchecked so we can find out about it at runtime, but
+      // don't need to add lots of boilerplate code everywhere.
+      PlatformDependent.throwException(e);
     }
     return this;
   }
@@ -74,7 +70,7 @@ public final class UTF8String implements Comparable<UTF8String>, Serializable {
    * Updates the UTF8String with byte[], which should be encoded in UTF-8.
    */
   protected UTF8String set(final byte[] bytes) {
-    this.bytes = (bytes != null) ? bytes : new byte[0];
+    this.bytes = bytes;
     return this;
   }
 
@@ -129,7 +125,6 @@ public final class UTF8String implements Comparable<UTF8String>, Serializable {
   }
 
   public boolean contains(final UTF8String substring) {
-    if (substring == null) return false;
     final byte[] b = substring.getBytes();
     if (b.length == 0) {
       return true;
@@ -143,23 +138,23 @@ public final class UTF8String implements Comparable<UTF8String>, Serializable {
     return false;
   }
 
-  private boolean startsWith(final byte[] prefix, int offset) {
-    if (prefix.length + offset > bytes.length || offset < 0) {
+  private boolean startsWith(final byte[] prefix, int offsetInBytes) {
+    if (prefix.length + offsetInBytes > bytes.length || offsetInBytes < 0) {
       return false;
     }
     int i = 0;
-    while (i < prefix.length && prefix[i] == bytes[i + offset]) {
+    while (i < prefix.length && prefix[i] == bytes[i + offsetInBytes]) {
       i++;
     }
     return i == prefix.length;
   }
 
   public boolean startsWith(final UTF8String prefix) {
-    return prefix != null && startsWith(prefix.getBytes(), 0);
+    return startsWith(prefix.getBytes(), 0);
   }
 
   public boolean endsWith(final UTF8String suffix) {
-    return suffix != null && startsWith(suffix.getBytes(), bytes.length - suffix.getBytes().length);
+    return startsWith(suffix.getBytes(), bytes.length - suffix.getBytes().length);
   }
 
   public UTF8String toUpperCase() {

--- a/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -184,7 +184,6 @@ public final class UTF8String implements Comparable<UTF8String>, Serializable {
 
   @Override
   public int compareTo(final UTF8String other) {
-    if (other == null) return 1;
     final byte[] b = other.getBytes();
     for (int i = 0; i < bytes.length && i < b.length; i++) {
       int res = bytes[i] - b[i];

--- a/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
+++ b/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
@@ -46,6 +46,7 @@ public class UTF8StringSuite {
 
   @Test
   public void contains() {
+    Assert.assertFalse(UTF8String.fromString("hello").contains(null));
     Assert.assertTrue(UTF8String.fromString("hello").contains(UTF8String.fromString("ello")));
     Assert.assertFalse(UTF8String.fromString("hello").contains(UTF8String.fromString("vello")));
     Assert.assertFalse(UTF8String.fromString("hello").contains(UTF8String.fromString("hellooo")));
@@ -57,6 +58,7 @@ public class UTF8StringSuite {
 
   @Test
   public void startsWith() {
+    Assert.assertFalse(UTF8String.fromString("hello").startsWith(null));
     Assert.assertTrue(UTF8String.fromString("hello").startsWith(UTF8String.fromString("hell")));
     Assert.assertFalse(UTF8String.fromString("hello").startsWith(UTF8String.fromString("ell")));
     Assert.assertFalse(UTF8String.fromString("hello").startsWith(UTF8String.fromString("hellooo")));
@@ -68,6 +70,7 @@ public class UTF8StringSuite {
 
   @Test
   public void endsWith() {
+    Assert.assertFalse(UTF8String.fromString("hello").endsWith(null));
     Assert.assertTrue(UTF8String.fromString("hello").endsWith(UTF8String.fromString("ello")));
     Assert.assertFalse(UTF8String.fromString("hello").endsWith(UTF8String.fromString("ellov")));
     Assert.assertFalse(UTF8String.fromString("hello").endsWith(UTF8String.fromString("hhhello")));

--- a/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
+++ b/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
@@ -46,7 +46,6 @@ public class UTF8StringSuite {
 
   @Test
   public void contains() {
-    Assert.assertFalse(UTF8String.fromString("hello").contains(null));
     Assert.assertTrue(UTF8String.fromString("hello").contains(UTF8String.fromString("ello")));
     Assert.assertFalse(UTF8String.fromString("hello").contains(UTF8String.fromString("vello")));
     Assert.assertFalse(UTF8String.fromString("hello").contains(UTF8String.fromString("hellooo")));
@@ -58,7 +57,6 @@ public class UTF8StringSuite {
 
   @Test
   public void startsWith() {
-    Assert.assertFalse(UTF8String.fromString("hello").startsWith(null));
     Assert.assertTrue(UTF8String.fromString("hello").startsWith(UTF8String.fromString("hell")));
     Assert.assertFalse(UTF8String.fromString("hello").startsWith(UTF8String.fromString("ell")));
     Assert.assertFalse(UTF8String.fromString("hello").startsWith(UTF8String.fromString("hellooo")));
@@ -70,7 +68,6 @@ public class UTF8StringSuite {
 
   @Test
   public void endsWith() {
-    Assert.assertFalse(UTF8String.fromString("hello").endsWith(null));
     Assert.assertTrue(UTF8String.fromString("hello").endsWith(UTF8String.fromString("ello")));
     Assert.assertFalse(UTF8String.fromString("hello").endsWith(UTF8String.fromString("ellov")));
     Assert.assertFalse(UTF8String.fromString("hello").endsWith(UTF8String.fromString("hhhello")));


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/SPARK-8301

Added the private method startsWith(prefix, offset) to implement startsWith, endsWith and contains without copying the array

I hope that the component SQL is still correct. I copied it from the Jira ticket.
