### PR TITLE
The web page is not found about api docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -5,7 +5,7 @@ title: Spark API Documentation
 
 Here you can API docs for Spark and its submodules.
 
-- [Spark Scala API (Scaladoc)](api/scala/index.html)
-- [Spark Java API (Javadoc)](api/java/index.html)
-- [Spark Python API (Sphinx)](api/python/index.html)
-- [Spark R API (Roxygen2)](api/R/index.html)
+- [Spark Scala API (Scaladoc)](https://spark.apache.org/docs/latest/api/scala/index.html)
+- [Spark Java API (Javadoc)](https://spark.apache.org/docs/latest/api/java/index.html)
+- [Spark Python API (Sphinx)](https://spark.apache.org/docs/latest/api/python/index.html)
+- [Spark R API (Roxygen2)](https://spark.apache.org/docs/latest/api/R/index.html)


### PR DESCRIPTION
The url gaven about api is not found. For example:
the url of [Spark Scala API (Scaladoc)] is https://github.com/apache/spark/blob/master/docs/api/scala/index.html 
, but this web page is not found. And the correct url is https://spark.apache.org/docs/latest/api/scala/index.html
