### PR TITLE
[SPARK-8392] RDDOperationGraph: getting cached nodes is slow

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -362,7 +362,7 @@ private[spark] object UIUtils extends Logging {
               { g.incomingEdges.map { e => <div class="incoming-edge">{e.fromId},{e.toId}</div> } }
               { g.outgoingEdges.map { e => <div class="outgoing-edge">{e.fromId},{e.toId}</div> } }
               {
-                g.rootCluster.getCachedNode.map { n =>
+                g.rootCluster.getCachedNodes.map { n =>
                   <div class="cached-rdd">{n.id}</div>
                 }
               }

--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -362,7 +362,7 @@ private[spark] object UIUtils extends Logging {
               { g.incomingEdges.map { e => <div class="incoming-edge">{e.fromId},{e.toId}</div> } }
               { g.outgoingEdges.map { e => <div class="outgoing-edge">{e.fromId},{e.toId}</div> } }
               {
-                g.rootCluster.getAllNodes.filter(_.cached).map { n =>
+                g.rootCluster.getCachedNode.map { n =>
                   <div class="cached-rdd">{n.id}</div>
                 }
               }

--- a/core/src/main/scala/org/apache/spark/ui/scope/RDDOperationGraph.scala
+++ b/core/src/main/scala/org/apache/spark/ui/scope/RDDOperationGraph.scala
@@ -66,16 +66,9 @@ private[ui] class RDDOperationCluster(val id: String, private var _name: String)
     _childClusters += childCluster
   }
 
-  /** Return all the nodes container in this cluster, including ones nested in other clusters. */
-  def getAllNodes: Seq[RDDOperationNode] = {
-    _childNodes ++ _childClusters.flatMap(_.childNodes)
-  }
-
   /** Return all the nodes which are cached. */
   def getCachedNodes: Seq[RDDOperationNode] = {
-    val cachedNodes = _childNodes.filter(_.cached)
-    _childClusters.foreach(cluster => cachedNodes ++= cluster._childNodes.filter(_.cached))
-    cachedNodes
+    _childNodes.filter(_.cached) ++ _childClusters.flatMap(_.getCachedNodes)
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/ui/scope/RDDOperationGraph.scala
+++ b/core/src/main/scala/org/apache/spark/ui/scope/RDDOperationGraph.scala
@@ -72,12 +72,9 @@ private[ui] class RDDOperationCluster(val id: String, private var _name: String)
   }
 
   /** Return all the node which are cached. */
-  def getCachedNode: Seq[RDDOperationNode] = {
-    var cachedNodes = new ListBuffer[RDDOperationNode]
-    cachedNodes ++= (_childNodes.filter(_.cached))
-    for(cluster <- _childClusters) {
-      cachedNodes ++= (cluster._childNodes.filter(_.cached))
-    }
+  def getCachedNodes: Seq[RDDOperationNode] = {
+    val cachedNodes = _childNodes.filter(_.cached)
+    _childClusters.foreach(cluster => cachedNodes ++= cluster._childNodes.filter(_.cached))
     cachedNodes
   }
 }

--- a/core/src/main/scala/org/apache/spark/ui/scope/RDDOperationGraph.scala
+++ b/core/src/main/scala/org/apache/spark/ui/scope/RDDOperationGraph.scala
@@ -70,6 +70,16 @@ private[ui] class RDDOperationCluster(val id: String, private var _name: String)
   def getAllNodes: Seq[RDDOperationNode] = {
     _childNodes ++ _childClusters.flatMap(_.childNodes)
   }
+
+  /** Return all the node which are cached. */
+  def getCachedNode: Seq[RDDOperationNode] = {
+    var cachedNodes = new ListBuffer[RDDOperationNode]
+    cachedNodes ++= (_childNodes.filter(_.cached))
+    for(cluster <- _childClusters) {
+      cachedNodes ++= (cluster._childNodes.filter(_.cached))
+    }
+    cachedNodes
+  }
 }
 
 private[ui] object RDDOperationGraph extends Logging {

--- a/core/src/main/scala/org/apache/spark/ui/scope/RDDOperationGraph.scala
+++ b/core/src/main/scala/org/apache/spark/ui/scope/RDDOperationGraph.scala
@@ -71,7 +71,7 @@ private[ui] class RDDOperationCluster(val id: String, private var _name: String)
     _childNodes ++ _childClusters.flatMap(_.childNodes)
   }
 
-  /** Return all the node which are cached. */
+  /** Return all the nodes which are cached. */
   def getCachedNodes: Seq[RDDOperationNode] = {
     val cachedNodes = _childNodes.filter(_.cached)
     _childClusters.foreach(cluster => cachedNodes ++= cluster._childNodes.filter(_.cached))


### PR DESCRIPTION
`def getAllNodes: Seq[RDDOperationNode] =
{ _childNodes ++ _childClusters.flatMap(_.childNodes) }`

when the `_childClusters` has so many nodes, the process will hang on. I think we can improve the efficiency here.
