### PR TITLE
[SPARK-8335] [MLLIB] DecisionTreeModel.predict() return type not convenient

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/DecisionTreeModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/DecisionTreeModel.scala
@@ -70,8 +70,8 @@ class DecisionTreeModel(val topNode: Node, val algo: Algo) extends Serializable 
    * @param features JavaRDD representing data points to be predicted
    * @return JavaRDD of predictions for each of the given data points
    */
-  def predict(features: JavaRDD[Vector]): JavaRDD[Double] = {
-    predict(features.rdd)
+  def predict(features: JavaRDD[Vector]): JavaRDD[java.lang.Double] = {
+    predict(features.rdd).toJavaRDD().asInstanceOf[JavaRDD[java.lang.Double]]
   }
 
   /**


### PR DESCRIPTION
Make Java-friendly predict return a JavaRDD of java.lang.Double instead of Scala Double, in the way ClassificationModel et al do

CC @jkbradley Is it OK to change the API in an `@Experimental` class? it's a fix, but a change too.
