### PR TITLE
[SPARK-8429] [EC2] Add ability to set additional tags

### DIFF
--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -290,6 +290,9 @@ def parse_args():
         "--additional-security-group", type="string", default="",
         help="Additional security group to place the machines in")
     parser.add_option(
+        "--additional-tags", type="string", default="",
+        help="Additional tags to set on the machines; tags are comma-separated, while name and value are colon separated; ex: \"Task:MySparkProject,Env:production\"")
+    parser.add_option(
         "--copy-aws-credentials", action="store_true", default=False,
         help="Add AWS credentials to hadoop configuration to allow Spark to access S3")
     parser.add_option(
@@ -685,15 +688,25 @@ def launch_cluster(conn, opts, cluster_name):
     # This wait time corresponds to SPARK-4983
     print("Waiting for AWS to propagate instance metadata...")
     time.sleep(5)
-    # Give the instances descriptive names
+    
+    # Give the instances descriptive names and set additional tags    
+    additional_tags = []
+    if opts.additional_tags.strip():
+        additional_tags = [map(str.strip, tag.split(':', 1)) for tag in opts.additional_tags.split(',')]
+
     for master in master_nodes:
         master.add_tag(
             key='Name',
             value='{cn}-master-{iid}'.format(cn=cluster_name, iid=master.id))
+        for tag_name, tag_value in additional_tags:
+            master.add_tag(key=tag_name, value=tag_value)
+
     for slave in slave_nodes:
         slave.add_tag(
             key='Name',
             value='{cn}-slave-{iid}'.format(cn=cluster_name, iid=slave.id))
+        for tag_name, tag_value in additional_tags:
+            slave.add_tag(key=tag_name, value=tag_value)
 
     # Return all the instances
     return (master_nodes, slave_nodes)

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -690,23 +690,21 @@ def launch_cluster(conn, opts, cluster_name):
     time.sleep(15)
     
     # Give the instances descriptive names and set additional tags    
-    additional_tags = []
+    additional_tags = {}
     if opts.additional_tags.strip():
-        additional_tags = [map(str.strip, tag.split(':', 1)) for tag in opts.additional_tags.split(',')]
+        additional_tags = dict(
+            map(str.strip, tag.split(':', 1)) for tag in opts.additional_tags.split(',')
+        )
 
     for master in master_nodes:
-        master.add_tag(
-            key='Name',
-            value='{cn}-master-{iid}'.format(cn=cluster_name, iid=master.id))
-        for tag_name, tag_value in additional_tags:
-            master.add_tag(key=tag_name, value=tag_value)
+        master.add_tags(
+            dict(additional_tags, Name='{cn}-master-{iid}'.format(cn=cluster_name, iid=master.id))
+        )
 
     for slave in slave_nodes:
-        slave.add_tag(
-            key='Name',
-            value='{cn}-slave-{iid}'.format(cn=cluster_name, iid=slave.id))
-        for tag_name, tag_value in additional_tags:
-            slave.add_tag(key=tag_name, value=tag_value)
+        slave.add_tags(
+            dict(additional_tags, Name='{cn}-slave-{iid}'.format(cn=cluster_name, iid=slave.id))
+        )
 
     # Return all the instances
     return (master_nodes, slave_nodes)

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -291,7 +291,8 @@ def parse_args():
         help="Additional security group to place the machines in")
     parser.add_option(
         "--additional-tags", type="string", default="",
-        help="Additional tags to set on the machines; tags are comma-separated, while name and value are colon separated; ex: \"Task:MySparkProject,Env:production\"")
+        help="Additional tags to set on the machines; tags are comma-separated, while name and " +
+             "value are colon separated; ex: \"Task:MySparkProject,Env:production\"")
     parser.add_option(
         "--copy-aws-credentials", action="store_true", default=False,
         help="Add AWS credentials to hadoop configuration to allow Spark to access S3")
@@ -688,8 +689,8 @@ def launch_cluster(conn, opts, cluster_name):
     # This wait time corresponds to SPARK-4983
     print("Waiting for AWS to propagate instance metadata...")
     time.sleep(15)
-    
-    # Give the instances descriptive names and set additional tags    
+
+    # Give the instances descriptive names and set additional tags
     additional_tags = {}
     if opts.additional_tags.strip():
         additional_tags = dict(

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -687,7 +687,7 @@ def launch_cluster(conn, opts, cluster_name):
 
     # This wait time corresponds to SPARK-4983
     print("Waiting for AWS to propagate instance metadata...")
-    time.sleep(5)
+    time.sleep(15)
     
     # Give the instances descriptive names and set additional tags    
     additional_tags = []


### PR DESCRIPTION
Add the `--additional-tags` parameter that allows to set additional tags to all the created instances (masters and slaves).

The user can specify multiple tags by separating them with a comma (`,`), while each tag name and value should be separated by a colon (`:`); for example, `Task:MySparkProject,Env:production` would add two tags, `Task` and `Env`, with the given values.
