### PR TITLE
[SPARK-8320] [Streaming] Add example in streaming programming guide that shows union of multiple input streams

### DIFF
--- a/docs/streaming-programming-guide.md
+++ b/docs/streaming-programming-guide.md
@@ -1941,10 +1941,10 @@ unifiedStream.print();
 {% highlight python %}
 numStreams = 5
 kafkaStreams = []
-for x in range (0, numStreams):
-     kafkaStreams = x.map{ KafkaUtils.createStream(…)}
+for _ in range (numStreams):
+     kafkaStreams.append(KafkaUtils.createStream(...))
 unifiedStream = streamingContext.union(kafkaStreams)
-unifiedStream.show()
+unifiedStream.print()
 {% endhighlight %}
 </div>
 </div>

--- a/docs/streaming-programming-guide.md
+++ b/docs/streaming-programming-guide.md
@@ -1940,9 +1940,7 @@ unifiedStream.print();
 <div data-lang="python" markdown="1">
 {% highlight python %}
 numStreams = 5
-kafkaStreams = []
-for _ in range (numStreams):
-     kafkaStreams.append(KafkaUtils.createStream(...))
+kafkaStreams = [KafkaUtils.createStream(...) for _ in range (numStreams)]
 unifiedStream = streamingContext.union(kafkaStreams)
 unifiedStream.print()
 {% endhighlight %}

--- a/docs/streaming-programming-guide.md
+++ b/docs/streaming-programming-guide.md
@@ -1937,6 +1937,16 @@ JavaPairDStream<String, String> unifiedStream = streamingContext.union(kafkaStre
 unifiedStream.print();
 {% endhighlight %}
 </div>
+<div data-lang="python" markdown="1">
+{% highlight python %}
+numStreams = 5
+kafkaStreams = []
+for x in range (0, numStreams):
+     kafkaStreams = x.map{ KafkaUtils.createStream(…)}
+unifiedStream = streamingContext.union(kafkaStreams)
+unifiedStream.show()
+{% endhighlight %}
+</div>
 </div>
 
 Another parameter that should be considered is the receiver's blocking interval,


### PR DESCRIPTION
Added python code to https://spark.apache.org/docs/latest/streaming-programming-guide.html 
to the Level of Parallelism in Data Receiving section.

Please review and let me know if there are any additional changes that are needed.

Thank you.
