### PR TITLE
[SPARK-8422] [BUILD] [PROJECT INFRA] Add a module abstraction to dev/run-tests

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -98,22 +98,6 @@ hive_thriftserver = Module(
 )
 
 
-mllib = Module(
-    name="mllib",
-    dependencies=[sql],
-    source_file_regexes=[
-        "examples/src/main/java/org/apache/spark/examples/mllib/",
-        "examples/src/main/scala/org/apache/spark/examples/mllib",
-        "data/mllib/",
-        "mllib/",
-    ],
-    sbt_test_goals=[
-        "mllib/test",
-        "examples/test",
-    ]
-)
-
-
 graphx = Module(
     name="graphx",
     dependencies=[],
@@ -143,6 +127,22 @@ streaming = Module(
         "streaming-mqtt/test",
         "streaming-twitter/test",
         "streaming-zeromq/test",
+    ]
+)
+
+
+mllib = Module(
+    name="mllib",
+    dependencies=[streaming, sql],
+    source_file_regexes=[
+        "examples/src/main/java/org/apache/spark/examples/mllib/",
+        "examples/src/main/scala/org/apache/spark/examples/mllib",
+        "data/mllib/",
+        "mllib/",
+    ],
+    sbt_test_goals=[
+        "mllib/test",
+        "examples/test",
     ]
 )
 

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -551,6 +551,9 @@ def run_scala_tests_sbt(test_modules, test_profiles):
 
     sbt_test_goals = set(itertools.chain.from_iterable(m.sbt_test_goals for m in test_modules))
 
+    if not sbt_test_goals:
+        return
+
     profiles_and_goals = test_profiles + list(sbt_test_goals)
 
     print "[info] Running Spark tests using SBT with these arguments:",

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -551,7 +551,7 @@ def run_scala_tests_sbt(test_modules, test_profiles):
 
     sbt_test_goals = set(itertools.chain.from_iterable(m.sbt_test_goals for m in test_modules))
 
-    profiles_and_goals = test_profiles + sbt_test_goals
+    profiles_and_goals = test_profiles + list(sbt_test_goals)
 
     print "[info] Running Spark tests using SBT with these arguments:",
     print " ".join(profiles_and_goals)
@@ -641,7 +641,7 @@ def main():
         changed_modules = identify_changed_modules_from_git_commits("HEAD",
                                                                     target_branch=target_branch)
     if not changed_modules:
-        changed_modules = ['root']
+        changed_modules = [root]
     print "[info] Found the following changed modules:", ", ".join(x.name for x in changed_modules)
 
     test_modules = determine_modules_to_test(changed_modules)

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -569,7 +569,7 @@ def run_scala_tests(build_tool, hadoop_version, test_modules):
 
     test_modules = set(test_modules)
 
-    hive_profiles = (sql in test_modules)
+    hive_profiles = (sql in test_modules or root in test_modules)
     test_profiles = get_build_profiles(hadoop_version, enable_hive_profiles=hive_profiles)
 
     if build_tool == "maven":

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -474,14 +474,12 @@ def get_hadoop_profiles(hadoop_version):
 
 def get_build_profiles(hadoop_version,
                        enable_base_profiles=True,
-                       enable_hive_profiles=False,
-                       enable_doc_profiles=False):
+                       enable_hive_profiles=False):
     """Returns a list of hadoop profiles to be used as looked up from the passed in hadoop profile
     key with the option of adding on the base and hive profiles."""
 
     base_profiles = ["-Pkinesis-asl"]
     hive_profiles = ["-Phive", "-Phive-thriftserver"]
-    doc_profiles = []
     hadoop_profiles = get_hadoop_profiles(hadoop_version)
 
     build_profiles = hadoop_profiles
@@ -491,9 +489,6 @@ def get_build_profiles(hadoop_version,
 
     if enable_hive_profiles:
         build_profiles += hive_profiles
-
-    if enable_doc_profiles:
-        build_profiles += doc_profiles
 
     return build_profiles
 

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -75,8 +75,6 @@ sql = Module(
     source_file_regexes=[
         "sql/(?!hive-thriftserver)",
         "bin/spark-sql",
-        "examples/src/main/java/org/apache/spark/examples/sql/",
-        "examples/src/main/scala/org/apache/spark/examples/sql/",
     ],
     sbt_test_goals=[
         "catalyst/test",
@@ -114,19 +112,95 @@ streaming = Module(
     name="streaming",
     dependencies=[],
     source_file_regexes=[
-        "external/",
-        "extras/java8-tests/",
-        "extras/kinesis-asl/",
         "streaming",
     ],
     sbt_test_goals=[
         "streaming/test",
-        "streaming-flume/test",
-        "streaming-flume-sink/test",
-        "streaming-kafka/test",
-        "streaming-mqtt/test",
-        "streaming-twitter/test",
+    ]
+)
+
+
+streaming_kinesis_asl = Module(
+    name="kinesis-asl",
+    dependencies=[streaming],
+    source_file_regexes=[
+        "extras/kinesis-asl/",
+    ],
+    sbt_test_goals=[
+        "kinesis-asl/test",
+    ]
+)
+
+
+streaming_zeromq = Module(
+    name="streaming-zeromq",
+    dependencies=[streaming],
+    source_file_regexes=[
+        "external/zeromq",
+    ],
+    sbt_test_goals=[
         "streaming-zeromq/test",
+    ]
+)
+
+
+streaming_twitter = Module(
+    name="streaming-twitter",
+    dependencies=[streaming],
+    source_file_regexes=[
+        "external/twitter",
+    ],
+    sbt_test_goals=[
+        "streaming-twitter/test",
+    ]
+)
+
+
+streaming_mqqt = Module(
+    name="streaming-mqqt",
+    dependencies=[streaming],
+    source_file_regexes=[
+        "external/mqqt",
+    ],
+    sbt_test_goals=[
+        "streaming-mqqt/test",
+    ]
+)
+
+
+streaming_kafka = Module(
+    name="streaming-kafka",
+    dependencies=[streaming],
+    source_file_regexes=[
+        "external/kafka",
+        "external/kafka-assembly",
+    ],
+    sbt_test_goals=[
+        "streaming-kafka/test",
+    ]
+)
+
+
+streaming_flume_sink = Module(
+    name="streaming-flume-sink",
+    dependencies=[streaming],
+    source_file_regexes=[
+        "external/flume-sink",
+    ],
+    sbt_test_goals=[
+        "streaming-flume-sink/test",
+    ]
+)
+
+
+streaming_flume = Module(
+    name="streaming_flume",
+    dependencies=[streaming],
+    source_file_regexes=[
+        "external/flume",
+    ],
+    sbt_test_goals=[
+        "streaming-flume/test",
     ]
 )
 
@@ -135,14 +209,11 @@ mllib = Module(
     name="mllib",
     dependencies=[streaming, sql],
     source_file_regexes=[
-        "examples/src/main/java/org/apache/spark/examples/mllib/",
-        "examples/src/main/scala/org/apache/spark/examples/mllib",
         "data/mllib/",
         "mllib/",
     ],
     sbt_test_goals=[
         "mllib/test",
-        "examples/test",
     ]
 )
 
@@ -184,6 +255,15 @@ docs = Module(
     dependencies=[],
     source_file_regexes=[
         "docs/",
+    ]
+)
+
+
+ec2 = Module(
+    name="ec2",
+    dependencies=[],
+    source_file_regexes=[
+        "ec2/",
     ]
 )
 

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -635,11 +635,13 @@ def main():
     print "[info] Using build tool", build_tool, "with profile", hadoop_version,
     print "under environment", test_env
 
-    changed_modules = [root]
+    changed_modules = None
     if test_env == "amplab_jenkins" and os.environ.get("AMP_JENKINS_PRB"):
         target_branch = os.environ["ghprbTargetBranch"]
         changed_modules = identify_changed_modules_from_git_commits("HEAD",
                                                                     target_branch=target_branch)
+    if not changed_modules:
+        changed_modules = ['root']
     print "[info] Found the following changed modules:", ", ".join(x.name for x in changed_modules)
 
     test_modules = determine_modules_to_test(changed_modules)

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -654,9 +654,9 @@ def main():
     run_apache_rat_checks()
 
     # style checks
-    if not changed_files or any(f.endsWith(".scala") for f in changed_files):
+    if not changed_files or any(f.endswith(".scala") for f in changed_files):
         run_scala_style_checks()
-    if not changed_files or any(f.endsWith(".py") for f in changed_files):
+    if not changed_files or any(f.endswith(".py") for f in changed_files):
         run_python_style_checks()
 
     # determine if docs were changed and if we're inside the amplab environment

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -249,14 +249,15 @@ def determine_modules_to_test(changed_modules):
     >>> sorted(x.name for x in determine_modules_to_test([sql]))
     ['examples', 'hive-thriftserver', 'mllib', 'pyspark', 'sparkr', 'sql']
     """
+    # If we're going to have to run all of the tests, then we can just short-circuit
+    # and return 'root'. No module depends on root, so if it appears then it will be
+    # in changed_modules.
+    if root in changed_modules:
+        return [root]
     modules_to_test = set()
     for module in changed_modules:
         modules_to_test = modules_to_test.union(determine_modules_to_test(module.dependent_modules))
-    modules_to_test = modules_to_test.union(set(changed_modules))
-    if root in modules_to_test:
-        return [root]
-    else:
-        return modules_to_test
+    return modules_to_test.union(set(changed_modules))
 
 
 # -------------------------------------------------------------------------------------------------

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -38,9 +38,31 @@ all_modules = []
 
 
 class Module(object):
+    """
+    A module is the basic abstraction in our test runner script. Each module consists of a set of
+    source files, a set of test commands, and a set of dependencies on other modules. We use modules
+    to define a dependency graph that lets determine which tests to run based on which files have
+    changed.
+    """
 
     def __init__(self, name, dependencies, source_file_regexes, sbt_test_goals=(),
                  should_run_python_tests=False, should_run_r_tests=False):
+        """
+        Define a new module.
+
+        :param name: A short module name, for display in logging and error messages.
+        :param dependencies: A set of dependencies for this module. This should only include direct
+            dependencies; transitive dependencies are resolved automatically.
+        :param source_file_regexes: a set of regexes that match source files belonging to this
+            module. These regexes are applied by attempting to match at the beginning of the
+            filename strings.
+        :param sbt_test_goals: A set of SBT test goals for testing this module/
+        :param should_run_python_tests: If true, changes in this module will trigger Python tests.
+            For now, this has the effect of causing _all_ Python tests to be run, although in the
+            future this should be changed to run only a subset of the Python tests that depend
+            on this module.
+        :param should_run_r_tests: If true, changes in this module will trigger all R tests.
+        """
         self.name = name
         self.dependencies = dependencies
         self.source_file_prefixes = source_file_regexes
@@ -80,7 +102,8 @@ sql = Module(
         "catalyst/test",
         "sql/test",
         "hive/test",
-    ])
+    ]
+)
 
 
 hive_thriftserver = Module(
@@ -534,8 +557,10 @@ def exec_sbt(sbt_args=()):
 
 
 def get_hadoop_profiles(hadoop_version):
-    """Return a list of profiles indicating which Hadoop version to use from
-    a Hadoop version tag."""
+    """
+    For the given Hadoop version tag, return a list of SBT profile flags for
+    building and testing against that Hadoop version.
+    """
 
     sbt_maven_hadoop_profiles = {
         "hadoop1.0": ["-Phadoop-1", "-Dhadoop.version=1.0.4"],


### PR DESCRIPTION
This patch builds upon #5694 to add a 'module' abstraction to the `dev/run-tests` script which groups together the per-module test logic, including the mapping from file paths to modules, the mapping from modules to test goals and build profiles, and the dependencies / relationships between modules.

This refactoring makes it much easier to increase the granularity of test modules, which will let us skip even more tests.  It's also a prerequisite for other changes that will reduce test time, such as running subsets of the Python tests based on which files / modules have changed.

This patch also adds doctests for the new graph traversal / change mapping code.
