### PR TITLE
[SPARK-8373][PySpark] Remove PythonRDD.emptyRDD

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -425,11 +425,6 @@ private[spark] object PythonRDD extends Logging {
     iter.foreach(write)
   }
 
-  /** Create an RDD that has no partitions or elements. */
-  def emptyRDD[T](sc: JavaSparkContext): JavaRDD[T] = {
-    sc.emptyRDD[T]
-  }
-
   /**
    * Create an RDD from a path using [[org.apache.hadoop.mapred.SequenceFileInputFormat]],
    * key and value class.


### PR DESCRIPTION
This is a follow-up PR to remove unused `PythonRDD.emptyRDD` added by #6826
