### PR TITLE
SPARK-4644 blockjoin

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/java/JavaPairRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaPairRDD.scala
@@ -515,6 +515,76 @@ class JavaPairRDD[K, V](val rdd: RDD[(K, V)])
   }
 
   /**
+   * Same as join, but uses a block join, otherwise known as a replicate fragment join.
+   * This is useful in cases where the data has extreme skew.
+   * The input params leftReplication and rightReplication control the replication of the left
+   * (this rdd) and right (other rdd) respectively.
+   */
+  def blockJoin[W](other: JavaPairRDD[K, W], leftReplication: Int, rightReplication: Int, 
+    partitioner: Partitioner): JavaPairRDD[K, (V, W)] = {
+    fromRDD(rdd.blockJoin(other, leftReplication, rightReplication, partitioner))
+  }
+
+  /**
+   * Same as join, but uses a block join, otherwise known as a replicate fragment join.
+   * This is useful in cases where the data has extreme skew.
+   * The input params leftReplication and rightReplication control the replication of the left
+   * (this rdd) and right (other rdd) respectively.
+   */
+  def blockJoin[W](other: JavaPairRDD[K, W], leftReplication: Int, rightReplication: Int) 
+      : JavaPairRDD[K, (V, W)] = {
+    fromRDD(rdd.blockJoin(other, leftReplication, rightReplication))
+  }
+
+  /**
+   * Same as leftOuterJoin, but uses a block join, otherwise known as a replicate fragment join.
+   * This is useful in cases where the data has extreme skew.
+   * The input param rightReplication controls the replication of the right (other rdd).
+   */
+  def blockLeftOuterJoin[W](other: JavaPairRDD[K, W], rightReplication: Int,
+    partitioner: Partitioner): JavaPairRDD[K, (V, Optional[W])] = {
+    fromRDD(rdd.blockLeftOuterJoin(other, rightReplication, partitioner).mapValues{ case (v, w) =>
+      (v, JavaUtils.optionToOptional(w))
+    })
+  }
+
+  /**
+   * Same as leftOuterJoin, but uses a block join, otherwise known as a replicate fragment join.
+   * This is useful in cases where the data has extreme skew.
+   * The input param rightReplication controls the replication of the right (other rdd).
+   */
+  def blockLeftOuterJoin[W](other: JavaPairRDD[K, W], rightReplication: Int)
+      : JavaPairRDD[K, (V, Optional[W])] = {
+    fromRDD(rdd.blockLeftOuterJoin(other, rightReplication).mapValues{ case (v, w) =>
+      (v, JavaUtils.optionToOptional(w))
+    })
+  }
+
+  /**
+   * Same as rightOuterJoin, but uses a block join, otherwise known as a replicate fragment join.
+   * This is useful in cases where the data has extreme skew.
+   * The input param leftReplication controls the replication of the left (this rdd).
+   */
+  def blockRightOuterJoin[W](other: JavaPairRDD[K, W], leftReplication: Int, 
+    partitioner: Partitioner): JavaPairRDD[K, (Optional[V], W)] = {
+    fromRDD(rdd.blockRightOuterJoin(other, leftReplication, partitioner).mapValues{ case (v, w) =>
+      (JavaUtils.optionToOptional(v), w)
+    })
+  }
+
+  /**
+   * Same as rightOuterJoin, but uses a block join, otherwise known as a replicate fragment join.
+   * This is useful in cases where the data has extreme skew.
+   * The input param leftReplication controls the replication of the left (this rdd).
+   */
+  def blockRightOuterJoin[W](other: JavaPairRDD[K, W], leftReplication: Int) 
+      : JavaPairRDD[K, (Optional[V], W)] = {
+    fromRDD(rdd.blockRightOuterJoin(other, leftReplication).mapValues{ case (v, w) =>
+      (JavaUtils.optionToOptional(v), w)
+    })
+  }
+  
+  /**
    * Simplified version of combineByKey that hash-partitions the resulting RDD using the existing
    * partitioner/parallelism level and using map-side aggregation.
    */

--- a/core/src/main/scala/org/apache/spark/api/java/JavaPairRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaPairRDD.scala
@@ -520,7 +520,10 @@ class JavaPairRDD[K, V](val rdd: RDD[(K, V)])
    * The input params leftReplication and rightReplication control the replication of the left
    * (this rdd) and right (other rdd) respectively.
    */
-  def blockJoin[W](other: JavaPairRDD[K, W], leftReplication: Int, rightReplication: Int, 
+  def blockJoin[W](
+    other: JavaPairRDD[K, W],
+    leftReplication: Int,
+    rightReplication: Int,
     partitioner: Partitioner): JavaPairRDD[K, (V, W)] = {
     fromRDD(rdd.blockJoin(other, leftReplication, rightReplication, partitioner))
   }
@@ -531,8 +534,10 @@ class JavaPairRDD[K, V](val rdd: RDD[(K, V)])
    * The input params leftReplication and rightReplication control the replication of the left
    * (this rdd) and right (other rdd) respectively.
    */
-  def blockJoin[W](other: JavaPairRDD[K, W], leftReplication: Int, rightReplication: Int) 
-      : JavaPairRDD[K, (V, W)] = {
+  def blockJoin[W](
+    other: JavaPairRDD[K, W],
+    leftReplication: Int,
+    rightReplication: Int) : JavaPairRDD[K, (V, W)] = {
     fromRDD(rdd.blockJoin(other, leftReplication, rightReplication))
   }
 
@@ -541,9 +546,11 @@ class JavaPairRDD[K, V](val rdd: RDD[(K, V)])
    * This is useful in cases where the data has extreme skew.
    * The input param rightReplication controls the replication of the right (other rdd).
    */
-  def blockLeftOuterJoin[W](other: JavaPairRDD[K, W], rightReplication: Int,
+  def blockLeftOuterJoin[W](
+    other: JavaPairRDD[K, W],
+    rightReplication: Int,
     partitioner: Partitioner): JavaPairRDD[K, (V, Optional[W])] = {
-    fromRDD(rdd.blockLeftOuterJoin(other, rightReplication, partitioner).mapValues{ case (v, w) =>
+    fromRDD(rdd.blockLeftOuterJoin(other, rightReplication, partitioner).mapValues { case (v, w) =>
       (v, JavaUtils.optionToOptional(w))
     })
   }
@@ -553,9 +560,10 @@ class JavaPairRDD[K, V](val rdd: RDD[(K, V)])
    * This is useful in cases where the data has extreme skew.
    * The input param rightReplication controls the replication of the right (other rdd).
    */
-  def blockLeftOuterJoin[W](other: JavaPairRDD[K, W], rightReplication: Int)
-      : JavaPairRDD[K, (V, Optional[W])] = {
-    fromRDD(rdd.blockLeftOuterJoin(other, rightReplication).mapValues{ case (v, w) =>
+  def blockLeftOuterJoin[W](
+    other: JavaPairRDD[K, W],
+    rightReplication: Int): JavaPairRDD[K, (V, Optional[W])] = {
+    fromRDD(rdd.blockLeftOuterJoin(other, rightReplication).mapValues { case (v, w) =>
       (v, JavaUtils.optionToOptional(w))
     })
   }
@@ -565,9 +573,11 @@ class JavaPairRDD[K, V](val rdd: RDD[(K, V)])
    * This is useful in cases where the data has extreme skew.
    * The input param leftReplication controls the replication of the left (this rdd).
    */
-  def blockRightOuterJoin[W](other: JavaPairRDD[K, W], leftReplication: Int, 
+  def blockRightOuterJoin[W](
+    other: JavaPairRDD[K, W],
+    leftReplication: Int,
     partitioner: Partitioner): JavaPairRDD[K, (Optional[V], W)] = {
-    fromRDD(rdd.blockRightOuterJoin(other, leftReplication, partitioner).mapValues{ case (v, w) =>
+    fromRDD(rdd.blockRightOuterJoin(other, leftReplication, partitioner).mapValues { case (v, w) =>
       (JavaUtils.optionToOptional(v), w)
     })
   }
@@ -577,9 +587,10 @@ class JavaPairRDD[K, V](val rdd: RDD[(K, V)])
    * This is useful in cases where the data has extreme skew.
    * The input param leftReplication controls the replication of the left (this rdd).
    */
-  def blockRightOuterJoin[W](other: JavaPairRDD[K, W], leftReplication: Int) 
-      : JavaPairRDD[K, (Optional[V], W)] = {
-    fromRDD(rdd.blockRightOuterJoin(other, leftReplication).mapValues{ case (v, w) =>
+  def blockRightOuterJoin[W](
+    other: JavaPairRDD[K, W],
+    leftReplication: Int): JavaPairRDD[K, (Optional[V], W)] = {
+    fromRDD(rdd.blockRightOuterJoin(other, leftReplication).mapValues { case (v, w) =>
       (JavaUtils.optionToOptional(v), w)
     })
   }

--- a/core/src/main/scala/org/apache/spark/api/java/JavaPairRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaPairRDD.scala
@@ -594,7 +594,7 @@ class JavaPairRDD[K, V](val rdd: RDD[(K, V)])
       (JavaUtils.optionToOptional(v), w)
     })
   }
-  
+
   /**
    * Simplified version of combineByKey that hash-partitions the resulting RDD using the existing
    * partitioner/parallelism level and using map-side aggregation.

--- a/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
@@ -19,7 +19,7 @@ package org.apache.spark.rdd
 
 import java.nio.ByteBuffer
 import java.text.SimpleDateFormat
-import java.util.{Date, HashMap => JHashMap}
+import java.util.{Date, HashMap => JHashMap, Random => JRandom}
 
 import scala.collection.{Map, mutable}
 import scala.collection.JavaConversions._
@@ -562,6 +562,109 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
       case (Seq(), ws) => ws.iterator.map(w => (None, Some(w)))
       case (vs, ws) => for (v <- vs.iterator; w <- ws.iterator) yield (Some(v), Some(w))
     }
+  }
+
+  // based on blockJoinWithSmaller in scalding. See com.twitter.scalding.JoinAlgorithms
+  private def blockCogroup[W](other: RDD[(K, W)], leftReplication: Int, rightReplication: Int, 
+    partitioner: Partitioner): RDD[((K, (Int, Int)), (Iterable[V], Iterable[W]))] = self.withScope {
+    assert(leftReplication >= 1, "must specify a positive number for left replication")
+    assert(rightReplication >= 1, "must specify a positive number for right replication")
+
+    def getReplication(random: JRandom, replication: Int, otherReplication: Int): Seq[(Int, Int)] = {
+      val rand = random.nextInt(otherReplication)
+      (0 until replication).map{ rep => (rand, rep) }
+    }
+
+    val selfBlocked = self.mapPartitions{ it =>
+      val random = new JRandom
+      it.flatMap{ kv => 
+        getReplication(random, leftReplication, rightReplication).map{ rl =>
+          ((kv._1, rl.swap), kv._2)
+        }
+      }
+    }
+
+    val otherBlocked = other.mapPartitions{ it =>
+      val random = new JRandom
+      it.flatMap{ kv => 
+        getReplication(random, rightReplication, leftReplication).map{ lr =>
+          ((kv._1, lr), kv._2)
+        }
+      }
+    }
+
+    selfBlocked.cogroup(otherBlocked, partitioner)
+  }
+
+  /**
+   * Same as join, but uses a block join, otherwise known as a replicate fragment join.
+   * This is useful in cases where the data has extreme skew.
+   * The input params leftReplication and rightReplication control the replication of the left
+   * (this rdd) and right (other rdd) respectively.
+   */
+  def blockJoin[W](other: RDD[(K, W)], leftReplication: Int, rightReplication: Int, 
+    partitioner: Partitioner): RDD[(K, (V, W))] = self.withScope {
+    this.blockCogroup(other, leftReplication, rightReplication, partitioner).flatMap{ blockPair =>
+      for (v <- blockPair._2._1.iterator; w <- blockPair._2._2.iterator) yield 
+        (blockPair._1._1, (v, w))
+    }
+  }
+
+  /**
+   * Same as join, but uses a block join, otherwise known as a replicate fragment join.
+   * This is useful in cases where the data has extreme skew.
+   * The input params leftReplication and rightReplication control the replication of the left
+   * (this rdd) and right (other rdd) respectively.
+   */
+  def blockJoin[W](other: RDD[(K, W)], leftReplication: Int, rightReplication: Int)
+      : RDD[(K, (V, W))] = self.withScope {
+    blockJoin(other, leftReplication, rightReplication, defaultPartitioner(self, other))
+  }
+
+  /**
+   * Same as leftOuterJoin, but uses a block join, otherwise known as a replicate fragment join.
+   * This is useful in cases where the data on the right (other rdd) has extreme skew.
+   * The input param rightReplication controls the replication of the right (other rdd).
+   */
+  def blockLeftOuterJoin[W](other: RDD[(K, W)], rightReplication: Int,
+    partitioner: Partitioner): RDD[(K, (V, Option[W]))] = self.withScope {
+    this.blockCogroup(other, 1, rightReplication, partitioner).flatMap{ 
+      case ((k, _), (itv, Seq())) => itv.iterator.map(v => (k, (v, None)))
+      case ((k, _), (itv, itw)) => for (v <- itv; w <- itw) yield (k, (v, Some(w)))
+    }
+  }
+
+  /**
+   * Same as leftOuterJoin, but uses a block join, otherwise known as a replicate fragment join.
+   * This is useful in cases where the data on the right (other rdd) has extreme skew.
+   * The input param rightReplication controls the replication of the right (other rdd).
+   */
+  def blockLeftOuterJoin[W](other: RDD[(K, W)], rightReplication: Int)
+      : RDD[(K, (V, Option[W]))] = self.withScope {
+    blockLeftOuterJoin(other, rightReplication, defaultPartitioner(self, other))
+  }
+
+  /**
+   * Same as rightOuterJoin, but uses a block join, otherwise known as a replicate fragment join.
+   * This is useful in cases where the left data (this rdd) has extreme skew.
+   * The input param leftReplication controls the replication of the left (this rdd).
+   */
+  def blockRightOuterJoin[W](other: RDD[(K, W)], leftReplication: Int, 
+    partitioner: Partitioner): RDD[(K, (Option[V], W))] = self.withScope {
+    this.blockCogroup(other, leftReplication, 1, partitioner).flatMap{ 
+      case ((k, _), (Seq(), itw)) => itw.iterator.map(w => (k, (None, w)))
+      case ((k, _), (itv, itw)) => for (v <- itv; w <- itw) yield (k, (Some(v), w))
+    }
+  }
+
+  /**
+   * Same as rightOuterJoin, but uses a block join, otherwise known as a replicate fragment join.
+   * This is useful in cases where the left data (this rdd) has extreme skew.
+   * The input param leftReplication controls the replication of the left (this rdd).
+   */
+  def blockRightOuterJoin[W](other: RDD[(K, W)], leftReplication: Int)
+      : RDD[(K, (Option[V], W))] = self.withScope {
+    blockRightOuterJoin(other, leftReplication, defaultPartitioner(self, other))
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
@@ -570,7 +570,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
     assert(leftReplication >= 1, "must specify a positive number for left replication")
     assert(rightReplication >= 1, "must specify a positive number for right replication")
 
-    def getReplication(random: JRandom, replication: Int, 
+    def getReplication(random: JRandom, replication: Int,
       otherReplication: Int) : Seq[(Int, Int)] = {
       val rand = random.nextInt(otherReplication)
       (0 until replication).map{ rep => (rand, rep) }

--- a/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
@@ -623,7 +623,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
 
   /**
    * Same as leftOuterJoin, but uses a block join, otherwise known as a replicate fragment join.
-   * This is useful in cases where the data on the right (other rdd) has extreme skew.
+   * This is useful in cases where the data has extreme skew.
    * The input param rightReplication controls the replication of the right (other rdd).
    */
   def blockLeftOuterJoin[W](other: RDD[(K, W)], rightReplication: Int,
@@ -636,7 +636,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
 
   /**
    * Same as leftOuterJoin, but uses a block join, otherwise known as a replicate fragment join.
-   * This is useful in cases where the data on the right (other rdd) has extreme skew.
+   * This is useful in cases where the data has extreme skew.
    * The input param rightReplication controls the replication of the right (other rdd).
    */
   def blockLeftOuterJoin[W](other: RDD[(K, W)], rightReplication: Int)
@@ -646,7 +646,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
 
   /**
    * Same as rightOuterJoin, but uses a block join, otherwise known as a replicate fragment join.
-   * This is useful in cases where the left data (this rdd) has extreme skew.
+   * This is useful in cases where the data has extreme skew.
    * The input param leftReplication controls the replication of the left (this rdd).
    */
   def blockRightOuterJoin[W](other: RDD[(K, W)], leftReplication: Int, 
@@ -659,7 +659,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
 
   /**
    * Same as rightOuterJoin, but uses a block join, otherwise known as a replicate fragment join.
-   * This is useful in cases where the left data (this rdd) has extreme skew.
+   * This is useful in cases where the data has extreme skew.
    * The input param leftReplication controls the replication of the left (this rdd).
    */
   def blockRightOuterJoin[W](other: RDD[(K, W)], leftReplication: Int)

--- a/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
@@ -565,19 +565,20 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
   }
 
   // based on blockJoinWithSmaller in scalding. See com.twitter.scalding.JoinAlgorithms
-  private def blockCogroup[W](other: RDD[(K, W)], leftReplication: Int, rightReplication: Int, 
+  private def blockCogroup[W](other: RDD[(K, W)], leftReplication: Int, rightReplication: Int,
     partitioner: Partitioner): RDD[((K, (Int, Int)), (Iterable[V], Iterable[W]))] = self.withScope {
     assert(leftReplication >= 1, "must specify a positive number for left replication")
     assert(rightReplication >= 1, "must specify a positive number for right replication")
 
-    def getReplication(random: JRandom, replication: Int, otherReplication: Int): Seq[(Int, Int)] = {
+    def getReplication(random: JRandom, replication: Int, 
+      otherReplication: Int) : Seq[(Int, Int)] = {
       val rand = random.nextInt(otherReplication)
       (0 until replication).map{ rep => (rand, rep) }
     }
 
     val selfBlocked = self.mapPartitions{ it =>
       val random = new JRandom
-      it.flatMap{ kv => 
+      it.flatMap{ kv =>
         getReplication(random, leftReplication, rightReplication).map{ rl =>
           ((kv._1, rl.swap), kv._2)
         }
@@ -586,7 +587,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
 
     val otherBlocked = other.mapPartitions{ it =>
       val random = new JRandom
-      it.flatMap{ kv => 
+      it.flatMap{ kv =>
         getReplication(random, rightReplication, leftReplication).map{ lr =>
           ((kv._1, lr), kv._2)
         }
@@ -602,10 +603,10 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
    * The input params leftReplication and rightReplication control the replication of the left
    * (this rdd) and right (other rdd) respectively.
    */
-  def blockJoin[W](other: RDD[(K, W)], leftReplication: Int, rightReplication: Int, 
+  def blockJoin[W](other: RDD[(K, W)], leftReplication: Int, rightReplication: Int,
     partitioner: Partitioner): RDD[(K, (V, W))] = self.withScope {
     this.blockCogroup(other, leftReplication, rightReplication, partitioner).flatMap{ blockPair =>
-      for (v <- blockPair._2._1.iterator; w <- blockPair._2._2.iterator) yield 
+      for (v <- blockPair._2._1.iterator; w <- blockPair._2._2.iterator) yield
         (blockPair._1._1, (v, w))
     }
   }
@@ -628,7 +629,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
    */
   def blockLeftOuterJoin[W](other: RDD[(K, W)], rightReplication: Int,
     partitioner: Partitioner): RDD[(K, (V, Option[W]))] = self.withScope {
-    this.blockCogroup(other, 1, rightReplication, partitioner).flatMap{ 
+    this.blockCogroup(other, 1, rightReplication, partitioner).flatMap{
       case ((k, _), (itv, Seq())) => itv.iterator.map(v => (k, (v, None)))
       case ((k, _), (itv, itw)) => for (v <- itv; w <- itw) yield (k, (v, Some(w)))
     }
@@ -649,9 +650,9 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
    * This is useful in cases where the data has extreme skew.
    * The input param leftReplication controls the replication of the left (this rdd).
    */
-  def blockRightOuterJoin[W](other: RDD[(K, W)], leftReplication: Int, 
+  def blockRightOuterJoin[W](other: RDD[(K, W)], leftReplication: Int,
     partitioner: Partitioner): RDD[(K, (Option[V], W))] = self.withScope {
-    this.blockCogroup(other, leftReplication, 1, partitioner).flatMap{ 
+    this.blockCogroup(other, leftReplication, 1, partitioner).flatMap{
       case ((k, _), (Seq(), itw)) => itw.iterator.map(w => (k, (None, w)))
       case ((k, _), (itv, itw)) => for (v <- itv; w <- itw) yield (k, (Some(v), w))
     }

--- a/core/src/test/java/org/apache/spark/JavaAPISuite.java
+++ b/core/src/test/java/org/apache/spark/JavaAPISuite.java
@@ -497,6 +497,35 @@ public class JavaAPISuite implements Serializable {
     Assert.assertEquals(3, firstUnmatched._1().intValue());
   }
 
+  @SuppressWarnings("unchecked")
+  @Test
+  public void blockLeftOuterJoin() {
+    JavaPairRDD<Integer, Integer> rdd1 = sc.parallelizePairs(Arrays.asList(
+      new Tuple2<Integer, Integer>(1, 1),
+      new Tuple2<Integer, Integer>(1, 2),
+      new Tuple2<Integer, Integer>(2, 1),
+      new Tuple2<Integer, Integer>(3, 1)
+      ));
+    JavaPairRDD<Integer, Character> rdd2 = sc.parallelizePairs(Arrays.asList(
+      new Tuple2<Integer, Character>(1, 'x'),
+      new Tuple2<Integer, Character>(2, 'y'),
+      new Tuple2<Integer, Character>(2, 'z'),
+      new Tuple2<Integer, Character>(4, 'w')
+    ));
+    List<Tuple2<Integer,Tuple2<Integer,Optional<Character>>>> joined =
+      rdd1.blockLeftOuterJoin(rdd2, 3).collect();
+    Assert.assertEquals(5, joined.size());
+    Tuple2<Integer,Tuple2<Integer,Optional<Character>>> firstUnmatched =
+      rdd1.leftOuterJoin(rdd2).filter(
+        new Function<Tuple2<Integer, Tuple2<Integer, Optional<Character>>>, Boolean>() {
+          @Override
+          public Boolean call(Tuple2<Integer, Tuple2<Integer, Optional<Character>>> tup) {
+            return !tup._2()._2().isPresent();
+          }
+      }).first();
+    Assert.assertEquals(3, firstUnmatched._1().intValue());
+  }
+
   @Test
   public void foldReduce() {
     JavaRDD<Integer> rdd = sc.parallelize(Arrays.asList(1, 1, 2, 3, 5, 8, 13));

--- a/core/src/test/scala/org/apache/spark/rdd/PairRDDFunctionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/PairRDDFunctionsSuite.scala
@@ -363,7 +363,7 @@ class PairRDDFunctionsSuite extends SparkFunSuite with SharedSparkContext {
     ))
   }
 
-  test("blockReftOuterJoin") {
+  test("blockRightOuterJoin") {
     val rdd1 = sc.parallelize(Array((1, 1), (1, 2), (2, 1), (2, 2), (3, 1)))
     val rdd2 = sc.parallelize(Array((1, 'x'), (2, 'y'), (2, 'z'), (4, 'w')))
     val joined = rdd1.blockRightOuterJoin(rdd2, 5).collect()

--- a/core/src/test/scala/org/apache/spark/rdd/PairRDDFunctionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/PairRDDFunctionsSuite.scala
@@ -331,6 +331,54 @@ class PairRDDFunctionsSuite extends SparkFunSuite with SharedSparkContext {
     ))
   }
 
+  test("blockJoin") {
+    val rdd1 = sc.parallelize(Array((1, 1), (1, 2), (2, 1), (2, 2), (3, 1)))
+    val rdd2 = sc.parallelize(Array((1, 'x'), (2, 'y'), (2, 'z'), (4, 'w')))
+    val joined = rdd1.blockJoin(rdd2, 5, 5).collect()
+
+    assert(joined.size === 6)
+    assert(joined.toSet === Set(
+      (1, (1, 'x')),
+      (1, (2, 'x')),
+      (2, (1, 'y')),
+      (2, (1, 'z')),
+      (2, (2, 'y')),
+      (2, (2, 'z'))
+    ))
+  }
+
+  test("blockLeftOuterJoin") {
+    val rdd1 = sc.parallelize(Array((1, 1), (1, 2), (2, 1), (2, 2), (3, 1)))
+    val rdd2 = sc.parallelize(Array((1, 'x'), (2, 'y'), (2, 'z'), (4, 'w')))
+    val joined = rdd1.blockLeftOuterJoin(rdd2, 5).collect()
+    assert(joined.size === 7)
+    assert(joined.toSet === Set(
+      (1, (1, Some('x'))),
+      (1, (2, Some('x'))),
+      (2, (1, Some('y'))),
+      (2, (1, Some('z'))),
+      (2, (2, Some('y'))),
+      (2, (2, Some('z'))),
+      (3, (1, None))
+    ))
+  }
+
+  test("blockReftOuterJoin") {
+    val rdd1 = sc.parallelize(Array((1, 1), (1, 2), (2, 1), (2, 2), (3, 1)))
+    val rdd2 = sc.parallelize(Array((1, 'x'), (2, 'y'), (2, 'z'), (4, 'w')))
+    val joined = rdd1.blockRightOuterJoin(rdd2, 5).collect()
+    assert(joined.size === 7)
+    assert(joined.toSet === Set(
+      (1, (Some(1), 'x')),
+      (1, (Some(2), 'x')),
+      (2, (Some(1), 'y')),
+      (2, (Some(1), 'z')),
+      (2, (Some(2), 'y')),
+      (2, (Some(2), 'z')),
+      (4, (None, 'w'))
+    ))
+  }
+
   test("groupWith") {
     val rdd1 = sc.parallelize(Array((1, 1), (1, 2), (2, 1), (3, 1)))
     val rdd2 = sc.parallelize(Array((1, 'x'), (2, 'y'), (2, 'z'), (4, 'w')))


### PR DESCRIPTION
Although the discussion (and design doc) under SPARK-4644 seem focussed on other aspects of skew (OOM mostly) than this pullreq (which focusses on avoiding a single reducer taking a long time), i decided to put this pullreq under SPARK-4644 anyhow, to avoid the proliferation of JIRA tickets. If this is not the right place let me know and i will move it.

Inspired by block join in scalding.
From scalding docs:

This is useful in cases where the data has extreme skew. A symptom of this is that we may see a job stuck for a very long time on a small number of reducers.
A block join is way to get around this: we add a random integer field and a replica field to every tuple in the left and right pipes. We then join on the original keys and on these new dummy fields. These dummy fields make it less likely that the skewed keys will be hashed to the same reducer.

The final data size is right \* rightReplication + left \* leftReplication but because of the fragmentation, we are guaranteed the same number of hits as the original join.
