### PR TITLE
[SPARKR][SPARK-8452] expose jobGroup API in SparkR

### DIFF
--- a/R/pkg/NAMESPACE
+++ b/R/pkg/NAMESPACE
@@ -10,6 +10,11 @@ export("sparkR.init")
 export("sparkR.stop")
 export("print.jobj")
 
+# Job group lifecycle management methods
+export("setJobGroup",
+       "clearJobGroup",
+       "cancelJobGroup")
+
 exportClasses("DataFrame")
 
 exportMethods("arrange",

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -278,3 +278,38 @@ sparkRHive.init <- function(jsc = NULL) {
   assign(".sparkRHivesc", hiveCtx, envir = .sparkREnv)
   hiveCtx
 }
+
+#' Assigns a group ID to all the jobs started by this thread until the group ID is set to a
+#' different value or cleared.
+#'
+#' @param sc The existing 
+#' @param groupid the ID to be assigned to job groups
+#' @param description description for the the job group ID
+#' @param interruptOnCancel flag to indicate if the job is interrupted on job cancellation
+
+setJobGroup <- function(groupId, description, interruptOnCancel) {
+  if (exists(".sparkRjsc", envir = env)) {
+    sc <- get(".sparkRjsc", envir = env)
+    callJMethod(sc, "setJobGroup", groupId, description, interruptOnCancel)
+  }
+}
+
+#' Clear current job group ID and its description
+
+clearJobGroup <- function() {
+  if (exists(".sparkRjsc", envir = env)) {
+    sc <- get(".sparkRjsc", envir = env)
+    callJMethod(sc, "clearJobGroup")
+  }
+}
+
+#' Cancel active jobs for the specified group
+#'
+#' @param groupId the ID of job group to be cancelled
+
+cancelJobGroup <- function(groupId) {
+  if (exists(".sparkRjsc", envir = env)) {
+    sc <- get(".sparkRjsc", envir = env)
+    callJMethod(sc, "cancelJobGroup", groupId)
+  }
+}

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -286,6 +286,11 @@ sparkRHive.init <- function(jsc = NULL) {
 #' @param groupid the ID to be assigned to job groups
 #' @param description description for the the job group ID
 #' @param interruptOnCancel flag to indicate if the job is interrupted on job cancellation
+#' @examples
+#'\dontrun{
+#' sc <- sparkR.init()
+#' setJobGroup(sc, "myJobGroup", "My job group description", TRUE)
+#'}
 
 setJobGroup <- function(sc, groupId, description, interruptOnCancel) {
   callJMethod(sc, "setJobGroup", groupId, description, interruptOnCancel)
@@ -294,6 +299,11 @@ setJobGroup <- function(sc, groupId, description, interruptOnCancel) {
 #' Clear current job group ID and its description
 #'
 #' @param sc existing spark context
+#' @examples
+#'\dontrun{
+#' sc <- sparkR.init()
+#' clearJobGroup(sc)
+#'}
 
 clearJobGroup <- function(sc) {
   callJMethod(sc, "clearJobGroup")
@@ -303,6 +313,11 @@ clearJobGroup <- function(sc) {
 #'
 #' @param sc existing spark context
 #' @param groupId the ID of job group to be cancelled
+#' @examples
+#'\dontrun{
+#' sc <- sparkR.init()
+#' cancelJobGroup(sc, "myJobGroup)
+#'}
 
 cancelJobGroup <- function(sc, groupId) {
   callJMethod(sc, "cancelJobGroup", groupId)

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -282,34 +282,28 @@ sparkRHive.init <- function(jsc = NULL) {
 #' Assigns a group ID to all the jobs started by this thread until the group ID is set to a
 #' different value or cleared.
 #'
-#' @param sc The existing 
+#' @param sc existing spark context
 #' @param groupid the ID to be assigned to job groups
 #' @param description description for the the job group ID
 #' @param interruptOnCancel flag to indicate if the job is interrupted on job cancellation
 
-setJobGroup <- function(groupId, description, interruptOnCancel) {
-  if (exists(".sparkRjsc", envir = env)) {
-    sc <- get(".sparkRjsc", envir = env)
-    callJMethod(sc, "setJobGroup", groupId, description, interruptOnCancel)
-  }
+setJobGroup <- function(sc, groupId, description, interruptOnCancel) {
+  callJMethod(sc, "setJobGroup", groupId, description, interruptOnCancel)
 }
 
 #' Clear current job group ID and its description
+#'
+#' @param sc existing spark context
 
-clearJobGroup <- function() {
-  if (exists(".sparkRjsc", envir = env)) {
-    sc <- get(".sparkRjsc", envir = env)
-    callJMethod(sc, "clearJobGroup")
-  }
+clearJobGroup <- function(sc) {
+  callJMethod(sc, "clearJobGroup")
 }
 
 #' Cancel active jobs for the specified group
 #'
+#' @param sc existing spark context
 #' @param groupId the ID of job group to be cancelled
 
-cancelJobGroup <- function(groupId) {
-  if (exists(".sparkRjsc", envir = env)) {
-    sc <- get(".sparkRjsc", envir = env)
-    callJMethod(sc, "cancelJobGroup", groupId)
-  }
+cancelJobGroup <- function(sc, groupId) {
+  callJMethod(sc, "cancelJobGroup", groupId)
 }

--- a/R/pkg/inst/tests/test_context.R
+++ b/R/pkg/inst/tests/test_context.R
@@ -48,3 +48,10 @@ test_that("rdd GC across sparkR.stop", {
   count(rdd3)
   count(rdd4)
 })
+
+test_that("job group functions can be called", {
+  sc <- sparkR.init()
+  setJobGroup(sc, "groupId", "job description", TRUE)
+  cancelJobGroup(sc, "groupId")
+  clearJobGroup(sc)
+})


### PR DESCRIPTION
This pull request adds following methods to SparkR:

``` R
setJobGroup()
cancelJobGroup()
clearJobGroup()
```

For each method, the spark context is passed as the first argument. There does not seem to be a good way to test these in R.

cc @shivaram and @davies 
