### PR TITLE
[SPARK-8391] catch the Throwable and report error to DAG graph

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/spark-dag-viz.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/spark-dag-viz.js
@@ -140,7 +140,7 @@ function renderDagViz(forJob) {
    for (var i = 0; i < dotFiles.length; i++) {
      if (dotFiles[i] == "") {
        var message =
-       "<b>Throwable occurs while getting metadata of the " + jobOrStage +
+       "<b>NonFatal occurs while getting metadata of the " + jobOrStage +
        "! More information can get from server log.</b>";
        graphContainer().append("div").attr("id", "empty-dag-viz-message").html(message);
        return;

--- a/core/src/main/resources/org/apache/spark/ui/static/spark-dag-viz.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/spark-dag-viz.js
@@ -130,6 +130,23 @@ function renderDagViz(forJob) {
     return;
   }
 
+   // If some stage's dotFile is empty because Throwable, fail fast and report error
+   var dotFiles = [];
+   metadataContainer().selectAll(".stage-metadata").each(function() {
+     var metadata = d3.select(this);
+     var dot = metadata.select(".dot-file").text();
+     dotFiles.push(dot);
+   });
+   for (var i = 0; i < dotFiles.length; i++) {
+     if (dotFiles[i] == "") {
+       var message =
+       "<b>Throwable occurs while getting metadata of the " + jobOrStage +
+       "! More information can get from server log.</b>";
+       graphContainer().append("div").attr("id", "empty-dag-viz-message").html(message);
+       return;
+     }
+   }
+
   // Render
   var svg = graphContainer().append("svg").attr("class", jobOrStage);
   if (forJob) {

--- a/core/src/main/resources/org/apache/spark/ui/static/spark-dag-viz.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/spark-dag-viz.js
@@ -130,7 +130,7 @@ function renderDagViz(forJob) {
     return;
   }
 
-   // If some stage's dotFile is empty because Throwable, fail fast and report error
+   // If some stage's dot-file is empty because Throwable, fail fast and report error
    var dotFiles = [];
    metadataContainer().selectAll(".stage-metadata").each(function() {
      var metadata = d3.select(this);

--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -358,7 +358,7 @@ private[spark] object UIUtils extends Logging {
             val stageId = g.rootCluster.id.replaceAll(RDDOperationGraph.STAGE_CLUSTER_PREFIX, "")
             val skipped = g.rootCluster.name.contains("skipped").toString
             <div class="stage-metadata" stage-id={stageId} skipped={skipped}>
-              <div class="dot-file">{RDDOperationGraph.makeDotFile(g)}</div>
+              <div class="dot-file">{RDDOperationGraph.makeDotFile(g, stageId)}</div>
               { g.incomingEdges.map { e => <div class="incoming-edge">{e.fromId},{e.toId}</div> } }
               { g.outgoingEdges.map { e => <div class="outgoing-edge">{e.fromId},{e.toId}</div> } }
               {

--- a/core/src/main/scala/org/apache/spark/ui/scope/RDDOperationGraph.scala
+++ b/core/src/main/scala/org/apache/spark/ui/scope/RDDOperationGraph.scala
@@ -24,6 +24,8 @@ import org.apache.spark.Logging
 import org.apache.spark.scheduler.StageInfo
 import org.apache.spark.storage.StorageLevel
 
+import scala.util.control.NonFatal
+
 /**
  * A representation of a generic cluster graph used for storing information on RDD operations.
  *

--- a/core/src/main/scala/org/apache/spark/ui/scope/RDDOperationGraph.scala
+++ b/core/src/main/scala/org/apache/spark/ui/scope/RDDOperationGraph.scala
@@ -164,12 +164,20 @@ private[ui] object RDDOperationGraph extends Logging {
    *
    * For the complete DOT specification, see http://www.graphviz.org/Documentation/dotguide.pdf.
    */
-  def makeDotFile(graph: RDDOperationGraph): String = {
+  def makeDotFile(graph: RDDOperationGraph, stageId: String): String = {
     val dotFile = new StringBuilder
     dotFile.append("digraph G {\n")
-    dotFile.append(makeDotSubgraph(graph.rootCluster, indent = "  "))
-    graph.edges.foreach { edge => dotFile.append(s"""  ${edge.fromId}->${edge.toId};\n""") }
-    dotFile.append("}")
+    try {
+      dotFile.append(makeDotSubgraph(graph.rootCluster, indent = "  "))
+      graph.edges.foreach { edge => dotFile.append(s"""  ${edge.fromId}->${edge.toId};\n""") }
+      dotFile.append("}")
+    } catch {
+      case t: Throwable =>
+        dotFile.clear()
+        logError(s"Failed to making dot file of $stageId", t)
+        return ""
+    }
+
     val result = dotFile.toString()
     logDebug(result)
     result

--- a/core/src/main/scala/org/apache/spark/ui/scope/RDDOperationGraph.scala
+++ b/core/src/main/scala/org/apache/spark/ui/scope/RDDOperationGraph.scala
@@ -172,9 +172,9 @@ private[ui] object RDDOperationGraph extends Logging {
       graph.edges.foreach { edge => dotFile.append(s"""  ${edge.fromId}->${edge.toId};\n""") }
       dotFile.append("}")
     } catch {
-      case t: Throwable =>
+      case NonFatal(e) =>
         dotFile.clear()
-        logError(s"Failed to making dot file of $stageId", t)
+        logError(s"Failed to make dot file of $stageId", e)
         return ""
     }
 


### PR DESCRIPTION
1. Maybe there has different Throwables while making dot file, in order to prevent the whole page dies, I think using try-catch is a reasonable resolution.
2. When making dot file occurs Throwable, report error to DAG graph, to tell user what happens.
