### PR TITLE
[HotFIX] Fix scala style in DFSReadWriteTest that causes tests failed

### DIFF
--- a/examples/src/main/scala/org/apache/spark/examples/DFSReadWriteTest.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/DFSReadWriteTest.scala
@@ -27,7 +27,7 @@ import org.apache.spark.SparkContext._
 /**
   * Simple test for reading and writing to a distributed
   * file system.  This example does the following:
-  * 
+  *
   *   1. Reads local file
   *   2. Computes word count on local file
   *   3. Writes local file to a DFS
@@ -36,7 +36,7 @@ import org.apache.spark.SparkContext._
   *   6. Compares the word count results
   */
 object DFSReadWriteTest {
-  
+
   private var localFilePath: File = new File(".")
   private var dfsDirPath: String = ""
 


### PR DESCRIPTION
This scala style problem causes tested failed.
