### PR TITLE
[SPARK-6910] [SQL] Support for pushing predicates down to metastore for partition pruning

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -300,7 +300,7 @@ private[hive] class HiveMetastoreCatalog(val client: ClientInterface, hive: Hive
     val result = if (metastoreRelation.hiveQlTable.isPartitioned) {
       val partitionSchema = StructType.fromAttributes(metastoreRelation.partitionKeys)
       val partitionColumnDataTypes = partitionSchema.map(_.dataType)
-      val partitions = metastoreRelation.hiveQlPartitions.map { p =>
+      val partitions = metastoreRelation.getHiveQlPartitions(None).map { p =>
         val location = p.getLocation
         val values = InternalRow.fromSeq(p.getValues.zip(partitionColumnDataTypes).map {
           case (rawValue, dataType) => Cast(Literal(rawValue), dataType).eval(null)
@@ -643,32 +643,6 @@ private[hive] case class MetastoreRelation
     new Table(tTable)
   }
 
-  @transient val hiveQlPartitions: Seq[Partition] = table.getAllPartitions.map { p =>
-    val tPartition = new org.apache.hadoop.hive.metastore.api.Partition
-    tPartition.setDbName(databaseName)
-    tPartition.setTableName(tableName)
-    tPartition.setValues(p.values)
-
-    val sd = new org.apache.hadoop.hive.metastore.api.StorageDescriptor()
-    tPartition.setSd(sd)
-    sd.setCols(table.schema.map(c => new FieldSchema(c.name, c.hiveType, c.comment)))
-
-    sd.setLocation(p.storage.location)
-    sd.setInputFormat(p.storage.inputFormat)
-    sd.setOutputFormat(p.storage.outputFormat)
-
-    val serdeInfo = new org.apache.hadoop.hive.metastore.api.SerDeInfo
-    sd.setSerdeInfo(serdeInfo)
-    serdeInfo.setSerializationLib(p.storage.serde)
-
-    val serdeParameters = new java.util.HashMap[String, String]()
-    serdeInfo.setParameters(serdeParameters)
-    table.serdeProperties.foreach { case (k, v) => serdeParameters.put(k, v) }
-    p.storage.serdeProperties.foreach { case (k, v) => serdeParameters.put(k, v) }
-
-    new Partition(hiveQlTable, tPartition)
-  }
-
   @transient override lazy val statistics: Statistics = Statistics(
     sizeInBytes = {
       val totalSize = hiveQlTable.getParameters.get(StatsSetupConst.TOTAL_SIZE)
@@ -688,6 +662,34 @@ private[hive] case class MetastoreRelation
           .getOrElse(sqlContext.conf.defaultSizeInBytes)))
     }
   )
+
+  def getHiveQlPartitions(filter: Option[String]): Seq[Partition] = {
+    table.getPartitions(filter).map { p =>
+      val tPartition = new org.apache.hadoop.hive.metastore.api.Partition
+      tPartition.setDbName(databaseName)
+      tPartition.setTableName(tableName)
+      tPartition.setValues(p.values)
+
+      val sd = new org.apache.hadoop.hive.metastore.api.StorageDescriptor()
+      tPartition.setSd(sd)
+      sd.setCols(table.schema.map(c => new FieldSchema(c.name, c.hiveType, c.comment)))
+
+      sd.setLocation(p.storage.location)
+      sd.setInputFormat(p.storage.inputFormat)
+      sd.setOutputFormat(p.storage.outputFormat)
+
+      val serdeInfo = new org.apache.hadoop.hive.metastore.api.SerDeInfo
+      sd.setSerdeInfo(serdeInfo)
+      serdeInfo.setSerializationLib(p.storage.serde)
+
+      val serdeParameters = new java.util.HashMap[String, String]()
+      serdeInfo.setParameters(serdeParameters)
+      table.serdeProperties.foreach { case (k, v) => serdeParameters.put(k, v) }
+      p.storage.serdeProperties.foreach { case (k, v) => serdeParameters.put(k, v) }
+
+      new Partition(hiveQlTable, tPartition)
+    }
+  }
 
   /** Only compare database and tablename, not alias. */
   override def sameResult(plan: LogicalPlan): Boolean = {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -300,6 +300,8 @@ private[hive] class HiveMetastoreCatalog(val client: ClientInterface, hive: Hive
     val result = if (metastoreRelation.hiveQlTable.isPartitioned) {
       val partitionSchema = StructType.fromAttributes(metastoreRelation.partitionKeys)
       val partitionColumnDataTypes = partitionSchema.map(_.dataType)
+      // This is for non-partitioned tables, so partition pruning predicates
+      // cannot be pushed into Hive metastore.
       val partitions = metastoreRelation.getHiveQlPartitions(None).map { p =>
         val location = p.getLocation
         val values = InternalRow.fromSeq(p.getValues.zip(partitionColumnDataTypes).map {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveShim.scala
@@ -109,9 +109,9 @@ private[hive] object HiveShim {
       partitionKeys: List[FieldSchema],
       hiveMetastoreVersion: String): Option[String] = {
 
-    // Binary comparison operators such as >, <, >=, and <= started being supported by
-    // getPartitionsByFilter() in 0.13. So if Hive matastore version is older than 0.13,
-    // no predicate is pushed down. See HIVE-4888.
+    // Binary comparison operators have been supported in getPartitionsByFilter() since 0.13.
+    // So if Hive matastore version is older than 0.13, predicates cannot be pushed down.
+    // See HIVE-4888.
     val versionPattern = "([\\d]+\\.[\\d]+).*".r
     hiveMetastoreVersion match {
       case versionPattern(version) => if (version.toDouble < 0.13) return None

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveShim.scala
@@ -17,30 +17,31 @@
 
 package org.apache.spark.sql.hive
 
-import java.io.{InputStream, OutputStream}
-import java.rmi.server.UID
-
-/* Implicit conversions */
-import scala.collection.JavaConversions._
-import scala.language.implicitConversions
-import scala.reflect.ClassTag
-
 import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.io.{Input, Output}
+
+import java.io.{InputStream, OutputStream}
+import java.rmi.server.UID
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.hive.ql.exec.{UDF, Utilities}
 import org.apache.hadoop.hive.ql.plan.{FileSinkDesc, TableDesc}
+import org.apache.hadoop.hive.serde.serdeConstants
 import org.apache.hadoop.hive.serde2.ColumnProjectionUtils
 import org.apache.hadoop.hive.serde2.avro.AvroGenericRecordWritable
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.HiveDecimalObjectInspector
 import org.apache.hadoop.io.Writable
 
 import org.apache.spark.Logging
-import org.apache.spark.sql.catalyst.expressions.{BinaryComparison, Expression}
-import org.apache.spark.sql.types.Decimal
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, BinaryComparison, Expression}
+import org.apache.spark.sql.types.{StringType, IntegralType, Decimal}
 import org.apache.spark.util.Utils
+
+/* Implicit conversions */
+import scala.collection.JavaConversions._
+import scala.language.implicitConversions
+import scala.reflect.ClassTag
 
 private[hive] object HiveShim {
   // Precision and scale to pass for unlimited decimals; these are the same as the precision and
@@ -101,28 +102,51 @@ private[hive] object HiveShim {
     }
   }
 
-  def toMetastoreFilter(predicates: Seq[Expression]): Option[String] = {
-    if (predicates.nonEmpty) {
-      // Hive getPartitionsByFilter() takes a string that represents partition
-      // predicates like "str_key_1=\"value_1\" and int_key_2=value_2 ..."
-      Some(predicates.foldLeft("") {
-        (str, expr) => {
-          expr match {
-            case op @ BinaryComparison(lhs, rhs) => {
-              val hiveFriendlyExpr =
-                lhs.prettyString + op.symbol + "\"" + rhs.prettyString + "\""
-              if (str.isEmpty) {
-                s"$hiveFriendlyExpr"
-              } else {
-                s"$str and $hiveFriendlyExpr"
+  def toMetastoreFilter(
+      predicates: Seq[Expression],
+      partitionKeyTypes: Map[String, String]): Option[String] = {
+    // Hive getPartitionsByFilter() takes a string that represents partition
+    // predicates like "str_key=\"value\" and int_key=1 ..."
+    val filter = predicates.foldLeft("") {
+      (str, expr) => {
+        expr match {
+          case op @ BinaryComparison(lhs, rhs) => {
+            val cond: String =
+              lhs match {
+                case AttributeReference(_,_,_,_) => {
+                  rhs.dataType match {
+                    case _: IntegralType =>
+                      lhs.prettyString + op.symbol + "\"" + rhs.prettyString + "\""
+                    case StringType => {
+                      // hive varchar is string type in catalyst, but varchar cannot be pushed down.
+                      if (!partitionKeyTypes.getOrElse(lhs.prettyString, "").startsWith(
+                          serdeConstants.VARCHAR_TYPE_NAME)) {
+                        lhs.prettyString + op.symbol + "\"" + rhs.prettyString + "\""
+                      } else {
+                        ""
+                      }
+                    }
+                    case _ => ""
+                  }
+                }
+                case _ => ""
               }
-            }
-            case _ => {
+            if (cond.nonEmpty) {
+              if (str.nonEmpty) {
+                s"$str and $cond"
+              } else {
+                cond
+              }
+            } else {
               str
             }
           }
+          case _ => str
         }
-      })
+      }
+    }
+    if (filter.nonEmpty) {
+      Some(filter)
     } else {
       None
     }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -124,7 +124,7 @@ private[hive] trait HiveStrategies {
                 InterpretedPredicate.create(castedPredicate)
               }
 
-            val partitions = relation.hiveQlPartitions.filter { part =>
+            val partitions = relation.getHiveQlPartitions(None).filter { part =>
               val partitionValues = part.getValues
               var i = 0
               while (i < partitionValues.size()) {
@@ -212,7 +212,7 @@ private[hive] trait HiveStrategies {
           projectList,
           otherPredicates,
           identity[Seq[Expression]],
-          HiveTableScan(_, relation, pruningPredicates.reduceLeftOption(And))(hiveContext)) :: Nil
+          HiveTableScan(_, relation, pruningPredicates)(hiveContext)) :: Nil
       case _ =>
         Nil
     }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -106,7 +106,6 @@ private[hive] trait HiveStrategies {
 
         try {
           if (relation.hiveQlTable.isPartitioned) {
-
             val metastoreFilter =
               HiveShim.toMetastoreFilter(
                 pruningPredicates,

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientInterface.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientInterface.scala
@@ -71,7 +71,12 @@ private[hive] case class HiveTable(
 
   def isPartitioned: Boolean = partitionColumns.nonEmpty
 
-  def getAllPartitions: Seq[HivePartition] = client.getAllPartitions(this)
+  def getPartitions(filter: Option[String]): Seq[HivePartition] = {
+    filter match {
+      case None => client.getAllPartitions(this)
+      case Some(expr) => client.getPartitionsByFilter(this, expr)
+    }
+  }
 
   // Hive does not support backticks when passing names to the client.
   def qualifiedName: String = s"$database.$name"
@@ -131,6 +136,9 @@ private[hive] trait ClientInterface {
 
   /** Returns all partitions for the given table. */
   def getAllPartitions(hTable: HiveTable): Seq[HivePartition]
+
+  /** Returns partitions filtered by predicates for the given table. */
+  def getPartitionsByFilter(hTable: HiveTable, filter: String): Seq[HivePartition]
 
   /** Loads a static partition into an existing table. */
   def loadPartition(

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.hive.client
 
-import java.io.{BufferedReader, InputStreamReader, File, PrintStream}
+import java.io.{BufferedReader, File, InputStreamReader, PrintStream}
 import java.net.URI
 import java.util.{ArrayList => JArrayList, Map => JMap, List => JList, Set => JSet}
 import javax.annotation.concurrent.GuardedBy
@@ -28,16 +28,13 @@ import scala.collection.JavaConversions._
 import scala.language.reflectiveCalls
 
 import org.apache.hadoop.fs.Path
-import org.apache.hadoop.hive.metastore.api.Database
 import org.apache.hadoop.hive.conf.HiveConf
+import org.apache.hadoop.hive.metastore.api.{Database, FieldSchema}
 import org.apache.hadoop.hive.metastore.{TableType => HTableType}
-import org.apache.hadoop.hive.metastore.api
-import org.apache.hadoop.hive.metastore.api.FieldSchema
-import org.apache.hadoop.hive.ql.metadata
 import org.apache.hadoop.hive.ql.metadata.Hive
-import org.apache.hadoop.hive.ql.session.SessionState
 import org.apache.hadoop.hive.ql.processors._
-import org.apache.hadoop.hive.ql.Driver
+import org.apache.hadoop.hive.ql.session.SessionState
+import org.apache.hadoop.hive.ql.{Driver, metadata}
 
 import org.apache.spark.Logging
 import org.apache.spark.sql.execution.QueryExecutionException
@@ -314,6 +311,13 @@ private[hive] class ClientWrapper(
   override def getAllPartitions(hTable: HiveTable): Seq[HivePartition] = withHiveState {
     val qlTable = toQlTable(hTable)
     shim.getAllPartitions(client, qlTable).map(toHivePartition)
+  }
+
+  override def getPartitionsByFilter(
+      hTable: HiveTable,
+      filter: String): Seq[HivePartition] = withHiveState {
+    val qlTable = toQlTable(hTable)
+    shim.getPartitionsByFilter(client, qlTable, filter).map(toHivePartition)
   }
 
   override def listTables(dbName: String): Seq[String] = withHiveState {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -61,6 +61,8 @@ private[client] sealed abstract class Shim {
 
   def getAllPartitions(hive: Hive, table: Table): Seq[Partition]
 
+  def getPartitionsByFilter(hive: Hive, table: Table, filter: String): Seq[Partition]
+
   def getCommandProcessor(token: String, conf: HiveConf): CommandProcessor
 
   def getDriverResults(driver: Driver): Seq[String]
@@ -127,6 +129,12 @@ private[client] class Shim_v0_12 extends Shim {
       classOf[Hive],
       "getAllPartitionsForPruner",
       classOf[Table])
+  private lazy val getPartitionsByFilterMethod =
+    findMethod(
+      classOf[Hive],
+      "getPartitionsByFilter",
+      classOf[Table],
+      classOf[String])
   private lazy val getCommandProcessorMethod =
     findStaticMethod(
       classOf[CommandProcessorFactory],
@@ -195,6 +203,10 @@ private[client] class Shim_v0_12 extends Shim {
 
   override def getAllPartitions(hive: Hive, table: Table): Seq[Partition] =
     getAllPartitionsMethod.invoke(hive, table).asInstanceOf[JSet[Partition]].toSeq
+
+  override def getPartitionsByFilter(hive: Hive, table: Table, filter: String): Seq[Partition] =
+    getPartitionsByFilterMethod.invoke(hive, table, filter).asInstanceOf[JArrayList[Partition]]
+      .toSeq
 
   override def getCommandProcessor(token: String, conf: HiveConf): CommandProcessor =
     getCommandProcessorMethod.invoke(null, token, conf).asInstanceOf[CommandProcessor]
@@ -267,6 +279,12 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
       classOf[Hive],
       "getAllPartitionsOf",
       classOf[Table])
+  private lazy val getPartitionsByFilterMethod =
+    findMethod(
+      classOf[Hive],
+      "getPartitionsByFilter",
+      classOf[Table],
+      classOf[String])
   private lazy val getCommandProcessorMethod =
     findStaticMethod(
       classOf[CommandProcessorFactory],
@@ -287,6 +305,10 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
 
   override def getAllPartitions(hive: Hive, table: Table): Seq[Partition] =
     getAllPartitionsMethod.invoke(hive, table).asInstanceOf[JSet[Partition]].toSeq
+
+  override def getPartitionsByFilter(hive: Hive, table: Table, filter: String): Seq[Partition] =
+    getPartitionsByFilterMethod.invoke(hive, table, filter).asInstanceOf[JArrayList[Partition]]
+      .toSeq
 
   override def getCommandProcessor(token: String, conf: HiveConf): CommandProcessor =
     getCommandProcessorMethod.invoke(null, Array(token), conf).asInstanceOf[CommandProcessor]

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScan.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScan.scala
@@ -53,7 +53,8 @@ case class HiveTableScan(
   // Retrieve the original attributes based on expression ID so that capitalization matches.
   val attributes = requestedAttributes.map(relation.attributeMap)
 
-  private[this] val metastoreFilter = HiveShim.toMetastoreFilter(partitionPruningPred)
+  private[this] val metastoreFilter = HiveShim.toMetastoreFilter(partitionPruningPred,
+    relation.hiveQlTable.getPartitionKeys.map(col => (col.getName, col.getType)).toMap)
 
   // Bind all partition key attribute references in the partition pruning predicate for later
   // evaluation.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScan.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScan.scala
@@ -53,8 +53,8 @@ case class HiveTableScan(
   // Retrieve the original attributes based on expression ID so that capitalization matches.
   val attributes = requestedAttributes.map(relation.attributeMap)
 
-  private[this] val metastoreFilter = HiveShim.toMetastoreFilter(partitionPruningPred,
-    relation.hiveQlTable.getPartitionKeys.map(col => (col.getName, col.getType)).toMap)
+  private[this] val metastoreFilter =
+    HiveShim.toMetastoreFilter(partitionPruningPred, relation.hiveQlTable.getPartitionKeys)
 
   // Bind all partition key attribute references in the partition pruning predicate for later
   // evaluation.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScan.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScan.scala
@@ -54,7 +54,10 @@ case class HiveTableScan(
   val attributes = requestedAttributes.map(relation.attributeMap)
 
   private[this] val metastoreFilter =
-    HiveShim.toMetastoreFilter(partitionPruningPred, relation.hiveQlTable.getPartitionKeys)
+    HiveShim.toMetastoreFilter(
+      partitionPruningPred,
+      relation.hiveQlTable.getPartitionKeys,
+      context.hiveMetastoreVersion)
 
   // Bind all partition key attribute references in the partition pruning predicate for later
   // evaluation.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScan.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScan.scala
@@ -43,7 +43,7 @@ private[hive]
 case class HiveTableScan(
     requestedAttributes: Seq[Attribute],
     relation: MetastoreRelation,
-    partitionPruningPred: Option[Expression])(
+    partitionPruningPred: Seq[Expression])(
     @transient val context: HiveContext)
   extends LeafNode {
 
@@ -53,9 +53,11 @@ case class HiveTableScan(
   // Retrieve the original attributes based on expression ID so that capitalization matches.
   val attributes = requestedAttributes.map(relation.attributeMap)
 
+  private[this] val metastoreFilter = HiveShim.toMetastoreFilter(partitionPruningPred)
+
   // Bind all partition key attribute references in the partition pruning predicate for later
   // evaluation.
-  private[this] val boundPruningPred = partitionPruningPred.map { pred =>
+  private[this] val boundPruningPred = partitionPruningPred.reduceLeftOption(And).map { pred =>
     require(
       pred.dataType == BooleanType,
       s"Data type of predicate $pred must be BooleanType rather than ${pred.dataType}.")
@@ -132,7 +134,9 @@ case class HiveTableScan(
   protected override def doExecute(): RDD[InternalRow] = if (!relation.hiveQlTable.isPartitioned) {
     hadoopReader.makeRDDForTable(relation.hiveQlTable)
   } else {
-    hadoopReader.makeRDDForPartitionedTable(prunePartitions(relation.hiveQlPartitions))
+    logDebug(s"Hive metastore filter is $metastoreFilter")
+    hadoopReader.makeRDDForPartitionedTable(
+      prunePartitions(relation.getHiveQlPartitions(metastoreFilter)))
   }
 
   override def output: Seq[Attribute] = attributes

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
@@ -151,6 +151,10 @@ class VersionsSuite extends SparkFunSuite with Logging {
       client.getAllPartitions(client.getTable("default", "src_part"))
     }
 
+    test(s"$version: getPartitionsByFilter") {
+      client.getPartitionsByFilter(client.getTable("default", "src_part"), "key = 1")
+    }
+
     test(s"$version: loadPartition") {
       client.loadPartition(
         emptyDir,

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/PruningSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/PruningSuite.scala
@@ -151,7 +151,7 @@ class PruningSuite extends HiveComparisonTest with BeforeAndAfter {
         case p @ HiveTableScan(columns, relation, _) =>
           val columnNames = columns.map(_.name)
           val partValues = if (relation.table.isPartitioned) {
-            p.prunePartitions(relation.hiveQlPartitions).map(_.getValues)
+            p.prunePartitions(relation.getHiveQlPartitions(None)).map(_.getValues)
           } else {
             Seq.empty
           }


### PR DESCRIPTION
@marmbrus per our email conversation, I am sending a PR that implements the idea that I outlined in the jira FYI.
- `Analyzer` captures predicates if a `unresolved relation` is followed by a `filter expression` and pushes them down into `HiveMetastoreCatalog`.
- `HiveMetastoreCatalog` extracts partition predicates whose types are string and integral and constructs a string representation for them.
- Hive client invokes `getPartitionsByFilter(Table tbl, String filter)` with the filter string.

In addition, I understand better the limitations of Hive `getPartitionsByFilter(Table tbl, String filter)` function now.
- Good news: it works with integral types as well as string.
- Bad news: it only works with equals operators.

The following is where the _"filtering is supported only on partition keys of type string"_ error from in Hive-

``` java
// metastore/src/java/org/apache/hadoop/hive/metastore/parser/ExpressionTree.java
public String getFilterPushdownParam(Table table, int partColIndex) throws MetaException {
  boolean isIntegralSupported = doesOperatorSupportIntegral(operator);
  String colType = table.getPartitionKeys().get(partColIndex).getType();
  // Can only support partitions whose types are string, or maybe integers
  if (!colType.equals(serdeConstants.STRING_TYPE_NAME)
      && (!isIntegralSupported || !isIntegralType(colType))) {
    throw new MetaException("Filtering is supported only on partition keys of type " +
        "string" + (isIntegralSupported ? ", or integral types" : ""));
  }
  boolean isStringValue = value instanceof String;
  if (!isStringValue && (!isIntegralSupported || !(value instanceof Long))) {
    throw new MetaException("Filtering is supported only on partition keys of type " +
        "string" + (isIntegralSupported ? ", or integral types" : ""));
  }
  return isStringValue ? (String) value : Long.toString((Long) value);
}
```

As can be seen, one of following conditions has to be met-
- Partition key is string type; or
- Partition key is integral type, and operator supports integral types. (i.e `doesOperatorSupportIntegral()` returns true.) 

But looking at the `doesOperatorSupportIntegral()` function, only equals and  not-equals operators support integral types-

``` java
// metastore/src/java/org/apache/hadoop/hive/metastore/parser/ExpressionTree.java
private static boolean doesOperatorSupportIntegral(Operator operator) {
  // TODO: for SQL-based filtering, this could be amended if we added casts.
  return (operator == Operator.EQUALS)
      || (operator == Operator.NOTEQUALS)
      || (operator == Operator.NOTEQUALS2);
}
```

This is not good because `<`, `>`, `<=`, and `>=` which are very common in practice are not supported.

In this PR, I restricted predicate pushdown to `=`. With that restriction, all the unit tests pass now.
