### PR TITLE
[SPARK-8420] [SQL] Inconsistent behavior with Dataframe Timestamp between 1.3.1 and 1.4.0

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
@@ -280,11 +280,11 @@ trait HiveTypeCoercion {
       // For equality between string and timestamp we cast the string to a timestamp
       // so that things like rounding of subsecond precision does not affect the comparison.
       case p @ Equality(left @ StringType(), right @ TimestampType()) =>
-        p.makeCopy(Array(Cast(left, TimestampType), right))
+        p.makeCopy(Array(NormalizeTS(left), Cast(right, StringType)))
       case p @ Equality(left @ TimestampType(), right @ StringType()) =>
-        p.makeCopy(Array(left, Cast(right, TimestampType)))
+        p.makeCopy(Array(Cast(left, StringType), NormalizeTS(right)))
 
-      // We should cast all relative timestamp/date/string comparison into string comparisions
+      // We should cast all relative timestamp/date/string comparison into string comparisons
       // This behaves as a user would expect because timestamp strings sort lexicographically.
       // i.e. TimeStamp(2013-01-01 00:00 ...) < "2014" = true
       case p @ BinaryComparison(left @ StringType(), right @ DateType()) =>
@@ -292,11 +292,10 @@ trait HiveTypeCoercion {
       case p @ BinaryComparison(left @ DateType(), right @ StringType()) =>
         p.makeCopy(Array(Cast(left, StringType), right))
       case p @ BinaryComparison(left @ StringType(), right @ TimestampType()) =>
-        p.makeCopy(Array(left, Cast(right, StringType)))
-      case p @ BinaryComparison(left @ TimestampType(), right @ StringType()) =>
-        p.makeCopy(Array(Cast(left, StringType), right))
-
       // Comparisons between dates and timestamps.
+        p.makeCopy(Array(NormalizeTS(left), Cast(right, StringType)))
+      case p @ BinaryComparison(left @ TimestampType(), right @ StringType()) =>
+        p.makeCopy(Array(Cast(left, StringType), NormalizeTS(right)))
       case p @ BinaryComparison(left @ TimestampType(), right @ DateType()) =>
         p.makeCopy(Array(Cast(left, StringType), Cast(right, StringType)))
       case p @ BinaryComparison(left @ DateType(), right @ TimestampType()) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -475,6 +475,10 @@ case class Cast(child: Expression, dataType: DataType) extends UnaryExpression w
 }
 
 object Cast {
+
+  private[sql] val timestampRegex =
+    """^(\d{4}\-\d{1,2}\-\d{1,2})( \d{2}:\d{2}:\d{2}(\.(\d+))?)?$""".r
+
   // `SimpleDateFormat` is not thread-safe.
   private[sql] val threadLocalTimestampFormat = new ThreadLocal[DateFormat] {
     override def initialValue(): SimpleDateFormat = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameDateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameDateSuite.scala
@@ -37,6 +37,10 @@ class DataFrameDateTimeSuite extends QueryTest {
     checkAnswer(
       df.select("t").filter($"t" >= "2014-06-01"),
       Row(Timestamp.valueOf("2015-01-01 00:00:00")) :: Nil)
+
+    checkAnswer(
+      df.select("t").filter($"t" === "2014-01-01"),
+      Row(Timestamp.valueOf("2014-01-01 00:00:00")) :: Nil)
   }
 
   test("date comparison with date strings") {


### PR DESCRIPTION
Havn't seen that the issue was fixed already. But It seemed it still has a inconsistency problem on equals and non-eauls. This patch proposes normalized format for string type to be compared with timestamp type.
