### PR TITLE
[SPARK-8528] Expose SparkContext.applicationId in PySpark

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -315,6 +315,15 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
     _dagScheduler = ds
   }
 
+  /**
+   *
+   * unique identified for the Spark Application
+   * its format depends on the scheduler implementation used to run the app
+   * (i.e.
+   *  in case of local spark app something like u'local-1433865536131'
+   *  in case of YARN something like u'application_1433865536131_34483'
+   * )
+   */
   def applicationId: String = _applicationId
   def applicationAttemptId: Option[String] = _applicationAttemptId
 

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -316,9 +316,8 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
   }
 
   /**
-   *
-   * unique identified for the Spark Application
-   * its format depends on the scheduler implementation used to run the app
+   * A unique identifier for the Spark application.
+   * Its format depends on the scheduler implementation.
    * (i.e.
    *  in case of local spark app something like u'local-1433865536131'
    *  in case of YARN something like u'application_1433865536131_34483'

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -319,8 +319,8 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
    * A unique identifier for the Spark application.
    * Its format depends on the scheduler implementation.
    * (i.e.
-   *  in case of local spark app something like u'local-1433865536131'
-   *  in case of YARN something like u'application_1433865536131_34483'
+   *  in case of local spark app something like 'local-1433865536131'
+   *  in case of YARN something like 'application_1433865536131_34483'
    * )
    */
   def applicationId: String = _applicationId

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -300,8 +300,8 @@ class SparkContext(object):
             in case of local spark app something like u'local-1433865536131'
             in case of YARN something like u'application_1433865536131_34483'
         )
-        >>> sc.applicationId  # doctest: +ELLIPSIS
-        u'local-...'
+        >>> sc.applicationId is not None
+        True
         """
         return self._jsc.sc().applicationId()
 

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -292,6 +292,19 @@ class SparkContext(object):
         return self._jsc.version()
 
     @property
+    def applicationId(self):
+        """
+        applicationId - depends on used scheduler
+        (i.e.
+            in case of local spark app something like u'local-1433865536131'
+            in case of YARN something like u'application_1433865536131_34483'
+        )
+        >>> sc.applicationId()  # doctest:+ELLIPSIS
+        local-...
+        """
+        return self._jsc.sc().applicationId()
+
+    @property
     def startTime(self):
         """Return the epoch time when the Spark Context was started."""
         return self._jsc.startTime()

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -294,7 +294,8 @@ class SparkContext(object):
     @property
     def applicationId(self):
         """
-        applicationId - depends on used scheduler
+        applicationId - unique identified for the Spark Application
+        its format depends on the scheduler implementation used to run the app
         (i.e.
             in case of local spark app something like u'local-1433865536131'
             in case of YARN something like u'application_1433865536131_34483'

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -294,8 +294,8 @@ class SparkContext(object):
     @property
     def applicationId(self):
         """
-        applicationId - unique identified for the Spark Application
-        its format depends on the scheduler implementation used to run the app
+        A unique identifier for the Spark application.
+        Its format depends on the scheduler implementation.
         (i.e.
             in case of local spark app something like u'local-1433865536131'
             in case of YARN something like u'application_1433865536131_34483'

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -300,8 +300,8 @@ class SparkContext(object):
             in case of local spark app something like u'local-1433865536131'
             in case of YARN something like u'application_1433865536131_34483'
         )
-        >>> sc.applicationId()  # doctest:+ELLIPSIS
-        local-...
+        >>> sc.applicationId  # doctest: +ELLIPSIS
+        u'local-...'
         """
         return self._jsc.sc().applicationId()
 

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -292,16 +292,17 @@ class SparkContext(object):
         return self._jsc.version()
 
     @property
+    @ignore_unicode_prefix
     def applicationId(self):
         """
         A unique identifier for the Spark application.
         Its format depends on the scheduler implementation.
         (i.e.
-            in case of local spark app something like u'local-1433865536131'
-            in case of YARN something like u'application_1433865536131_34483'
+            in case of local spark app something like 'local-1433865536131'
+            in case of YARN something like 'application_1433865536131_34483'
         )
-        >>> sc.applicationId is not None
-        True
+        >>> sc.applicationId  # doctest: +ELLIPSIS
+        u'local-...'
         """
         return self._jsc.sc().applicationId()
 


### PR DESCRIPTION
Use case - we want to log applicationId (YARN in hour case) to request help with troubleshooting from the DevOps
