### PR TITLE
[SPARK-8532][SQL] In Python's DataFrameWriter, save/saveAsTable/json/parquet/jdbc always override mode

### DIFF
--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -257,7 +257,7 @@ class DataFrameWriter(object):
         return self
 
     @since(1.4)
-    def save(self, path=None, format=None, mode="error", **options):
+    def save(self, path=None, format=None, mode=None, **options):
         """Saves the contents of the :class:`DataFrame` to a data source.
 
         The data source is specified by the ``format`` and a set of ``options``.
@@ -276,13 +276,9 @@ class DataFrameWriter(object):
 
         >>> df.write.mode('append').parquet(os.path.join(tempfile.mkdtemp(), 'data'))
         """
-        if mode is not "error":
+        if mode is not None:
             # At the JVM side, the default value of mode is already set to "error".
-            # So, if mode at here is "error", we will not call mode method.
-            # This behavior is used to prevent us accidentally overriding the mode because
-            # user can call mode method directly.
-            # We leave "error" as the default in the method signature, so users can
-            # see what is the default value in Python doc.
+            # We will only call mode method if the provided mode is not None.
             self.mode(mode)
         self.options(**options)
         if format is not None:
@@ -304,7 +300,7 @@ class DataFrameWriter(object):
         self._jwrite.mode("overwrite" if overwrite else "append").insertInto(tableName)
 
     @since(1.4)
-    def saveAsTable(self, name, format=None, mode="error", **options):
+    def saveAsTable(self, name, format=None, mode=None, **options):
         """Saves the content of the :class:`DataFrame` as the specified table.
 
         In the case the table already exists, behavior of this function depends on the
@@ -322,13 +318,9 @@ class DataFrameWriter(object):
         :param mode: one of `append`, `overwrite`, `error`, `ignore` (default: error)
         :param options: all other string options
         """
-        if mode is not "error":
+        if mode is not None:
             # At the JVM side, the default value of mode is already set to "error".
-            # So, if mode at here is "error", we will not call mode method.
-            # This behavior is used to prevent us accidentally overriding the mode because
-            # user can call mode method directly.
-            # We leave "error" as the default in the method signature, so users can
-            # see what is the default value in Python doc.
+            # We will only call mode method if the provided mode is not None.
             self.mode(mode)
         self.options(**options)
         if format is not None:
@@ -336,7 +328,7 @@ class DataFrameWriter(object):
         self._jwrite.saveAsTable(name)
 
     @since(1.4)
-    def json(self, path, mode="error"):
+    def json(self, path, mode=None):
         """Saves the content of the :class:`DataFrame` in JSON format at the specified path.
 
         :param path: the path in any Hadoop supported file system
@@ -349,18 +341,14 @@ class DataFrameWriter(object):
 
         >>> df.write.json(os.path.join(tempfile.mkdtemp(), 'data'))
         """
-        if mode is not "error":
+        if mode is not None:
             # At the JVM side, the default value of mode is already set to "error".
-            # So, if mode at here is "error", we will not call mode method.
-            # This behavior is used to prevent us accidentally overriding the mode because
-            # user can call mode method directly.
-            # We leave "error" as the default in the method signature, so users can
-            # see what is the default value in Python doc.
+            # We will only call mode method if the provided mode is not None.
             self.mode(mode)
         self._jwrite.json(path)
 
     @since(1.4)
-    def parquet(self, path, mode="error"):
+    def parquet(self, path, mode=None):
         """Saves the content of the :class:`DataFrame` in Parquet format at the specified path.
 
         :param path: the path in any Hadoop supported file system
@@ -373,18 +361,14 @@ class DataFrameWriter(object):
 
         >>> df.write.parquet(os.path.join(tempfile.mkdtemp(), 'data'))
         """
-        if mode is not "error":
+        if mode is not None:
             # At the JVM side, the default value of mode is already set to "error".
-            # So, if mode at here is "error", we will not call mode method.
-            # This behavior is used to prevent us accidentally overriding the mode because
-            # user can call mode method directly.
-            # We leave "error" as the default in the method signature, so users can
-            # see what is the default value in Python doc.
+            # We will only call mode method if the provided mode is not None.
             self.mode(mode)
         self._jwrite.parquet(path)
 
     @since(1.4)
-    def jdbc(self, url, table, mode="error", properties={}):
+    def jdbc(self, url, table, mode=None, properties={}):
         """Saves the content of the :class:`DataFrame` to a external database table via JDBC.
 
         .. note:: Don't create too many partitions in parallel on a large cluster;\
@@ -402,13 +386,9 @@ class DataFrameWriter(object):
                            arbitrary string tag/value. Normally at least a
                            "user" and "password" property should be included.
         """
-        if mode is not "error":
+        if mode is not None:
             # At the JVM side, the default value of mode is already set to "error".
-            # So, if mode at here is "error", we will not call mode method.
-            # This behavior is used to prevent us accidentally overriding the mode because
-            # user can call mode method directly.
-            # We leave "error" as the default in the method signature, so users can
-            # see what is the default value in Python doc.
+            # We will only call mode method if the provided mode is not None.
             self.mode(mode)
         jprop = JavaClass("java.util.Properties", self._sqlContext._sc._gateway._gateway_client)()
         for k in properties:

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -276,7 +276,15 @@ class DataFrameWriter(object):
 
         >>> df.write.mode('append').parquet(os.path.join(tempfile.mkdtemp(), 'data'))
         """
-        self.mode(mode).options(**options)
+        if mode is not "error":
+            # At the JVM side, the default value of mode is already set to "error".
+            # So, if mode at here is "error", we will not call mode method.
+            # This behavior is used to prevent us accidentally overriding the mode because
+            # user can call mode method directly.
+            # We leave "error" as the default in the method signature, so users can
+            # see what is the default value in Python doc.
+            self.mode(mode)
+        self.options(**options)
         if format is not None:
             self.format(format)
         if path is None:
@@ -314,7 +322,15 @@ class DataFrameWriter(object):
         :param mode: one of `append`, `overwrite`, `error`, `ignore` (default: error)
         :param options: all other string options
         """
-        self.mode(mode).options(**options)
+        if mode is not "error":
+            # At the JVM side, the default value of mode is already set to "error".
+            # So, if mode at here is "error", we will not call mode method.
+            # This behavior is used to prevent us accidentally overriding the mode because
+            # user can call mode method directly.
+            # We leave "error" as the default in the method signature, so users can
+            # see what is the default value in Python doc.
+            self.mode(mode)
+        self.options(**options)
         if format is not None:
             self.format(format)
         self._jwrite.saveAsTable(name)
@@ -333,7 +349,15 @@ class DataFrameWriter(object):
 
         >>> df.write.json(os.path.join(tempfile.mkdtemp(), 'data'))
         """
-        self._jwrite.mode(mode).json(path)
+        if mode is not "error":
+            # At the JVM side, the default value of mode is already set to "error".
+            # So, if mode at here is "error", we will not call mode method.
+            # This behavior is used to prevent us accidentally overriding the mode because
+            # user can call mode method directly.
+            # We leave "error" as the default in the method signature, so users can
+            # see what is the default value in Python doc.
+            self.mode(mode)
+        self._jwrite.json(path)
 
     @since(1.4)
     def parquet(self, path, mode="error"):
@@ -349,7 +373,15 @@ class DataFrameWriter(object):
 
         >>> df.write.parquet(os.path.join(tempfile.mkdtemp(), 'data'))
         """
-        self._jwrite.mode(mode).parquet(path)
+        if mode is not "error":
+            # At the JVM side, the default value of mode is already set to "error".
+            # So, if mode at here is "error", we will not call mode method.
+            # This behavior is used to prevent us accidentally overriding the mode because
+            # user can call mode method directly.
+            # We leave "error" as the default in the method signature, so users can
+            # see what is the default value in Python doc.
+            self.mode(mode)
+        self._jwrite.parquet(path)
 
     @since(1.4)
     def jdbc(self, url, table, mode="error", properties={}):
@@ -370,10 +402,18 @@ class DataFrameWriter(object):
                            arbitrary string tag/value. Normally at least a
                            "user" and "password" property should be included.
         """
+        if mode is not "error":
+            # At the JVM side, the default value of mode is already set to "error".
+            # So, if mode at here is "error", we will not call mode method.
+            # This behavior is used to prevent us accidentally overriding the mode because
+            # user can call mode method directly.
+            # We leave "error" as the default in the method signature, so users can
+            # see what is the default value in Python doc.
+            self.mode(mode)
         jprop = JavaClass("java.util.Properties", self._sqlContext._sc._gateway._gateway_client)()
         for k in properties:
             jprop.setProperty(k, properties[k])
-        self._jwrite.mode(mode).jdbc(url, table, jprop)
+        self._jwrite.jdbc(url, table, jprop)
 
 
 def _test():

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -276,6 +276,7 @@ class DataFrameWriter(object):
             * ``overwrite``: Overwrite existing data.
             * ``ignore``: Silently ignore this operation if data already exists.
             * ``error`` (default case): Throw an exception if data already exists.
+        :param partitionBy: names of partitioning columns
         :param options: all other string options
 
         >>> df.write.mode('append').parquet(os.path.join(tempfile.mkdtemp(), 'data'))
@@ -316,6 +317,7 @@ class DataFrameWriter(object):
         :param name: the table name
         :param format: the format used to save
         :param mode: one of `append`, `overwrite`, `error`, `ignore` (default: error)
+        :param partitionBy: names of partitioning columns
         :param options: all other string options
         """
         self.partitionBy(partitionBy).mode(mode).options(**options)
@@ -350,7 +352,7 @@ class DataFrameWriter(object):
             * ``overwrite``: Overwrite existing data.
             * ``ignore``: Silently ignore this operation if data already exists.
             * ``error`` (default case): Throw an exception if data already exists.
-
+        :param partitionBy: names of partitioning columns
         >>> df.write.parquet(os.path.join(tempfile.mkdtemp(), 'data'))
         """
         self.partitionBy(partitionBy).mode(mode)

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -353,6 +353,7 @@ class DataFrameWriter(object):
             * ``ignore``: Silently ignore this operation if data already exists.
             * ``error`` (default case): Throw an exception if data already exists.
         :param partitionBy: names of partitioning columns
+
         >>> df.write.parquet(os.path.join(tempfile.mkdtemp(), 'data'))
         """
         self.partitionBy(partitionBy).mode(mode)

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -339,7 +339,7 @@ class DataFrameWriter(object):
 
         >>> df.write.json(os.path.join(tempfile.mkdtemp(), 'data'))
         """
-        self._jwrite.mode(mode).json(path)
+        self.mode(mode)._jwrite.json(path)
 
     @since(1.4)
     def parquet(self, path, mode=None, partitionBy=()):

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -557,8 +557,9 @@ class SQLTests(ReusedPySparkTestCase):
 
         df.write.mode("overwrite").options(noUse="this options will not be used in save.")\
                 .format("json").save(path=tmpPath)
-        actual = self.sqlCtx.read.format("json").load(path=tmpPath,
-                                       noUse="this options will not be used in load.")
+        actual =\
+            self.sqlCtx.read.format("json")\
+                            .load(path=tmpPath, noUse="this options will not be used in load.")
         self.assertEqual(sorted(df.collect()), sorted(actual.collect()))
 
         defaultDataSourceName = self.sqlCtx.getConf("spark.sql.sources.default",

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -539,6 +539,37 @@ class SQLTests(ReusedPySparkTestCase):
 
         shutil.rmtree(tmpPath)
 
+    def test_save_and_load_builder(self):
+        df = self.df
+        tmpPath = tempfile.mkdtemp()
+        shutil.rmtree(tmpPath)
+        df.write.json(tmpPath)
+        actual = self.sqlCtx.read.json(tmpPath)
+        self.assertEqual(sorted(df.collect()), sorted(actual.collect()))
+
+        schema = StructType([StructField("value", StringType(), True)])
+        actual = self.sqlCtx.read.json(tmpPath, schema)
+        self.assertEqual(sorted(df.select("value").collect()), sorted(actual.collect()))
+
+        df.write.mode("overwrite").json(tmpPath)
+        actual = self.sqlCtx.read.json(tmpPath)
+        self.assertEqual(sorted(df.collect()), sorted(actual.collect()))
+
+        df.write.mode("overwrite").options(noUse="this options will not be used in save.")\
+                .format("json").save(path=tmpPath)
+        actual = self.sqlCtx.read.format("json").load(path=tmpPath,
+                                       noUse="this options will not be used in load.")
+        self.assertEqual(sorted(df.collect()), sorted(actual.collect()))
+
+        defaultDataSourceName = self.sqlCtx.getConf("spark.sql.sources.default",
+                                                    "org.apache.spark.sql.parquet")
+        self.sqlCtx.sql("SET spark.sql.sources.default=org.apache.spark.sql.json")
+        actual = self.sqlCtx.load(path=tmpPath)
+        self.assertEqual(sorted(df.collect()), sorted(actual.collect()))
+        self.sqlCtx.sql("SET spark.sql.sources.default=" + defaultDataSourceName)
+
+        shutil.rmtree(tmpPath)
+
     def test_help_command(self):
         # Regression test for SPARK-5464
         rdd = self.sc.parallelize(['{"foo":"bar"}', '{"foo":"baz"}'])


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-8532

This PR has two changes. First, it fixes the bug that save actions (i.e. `save/saveAsTable/json/parquet/jdbc`) always override mode. Second, it adds input argument `partitionBy` to `save/saveAsTable/parquet`.
