### PR TITLE
[SPARK-8554] Add the SparkR document files to `.rat-excludes` for `./dev/check-license`

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -86,4 +86,8 @@ local-1430917381535_2
 DESCRIPTION
 NAMESPACE
 test_support/*
+.*Rd
+help/*
+html/*
+INDEX
 .lintr


### PR DESCRIPTION
[[SPARK-8554] Add the SparkR document files to `.rat-excludes` for `./dev/check-license` - ASF JIRA](https://issues.apache.org/jira/browse/SPARK-8554)
