### PR TITLE
[SPARK-8561][SQL]drop table under specific database

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/commands.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/commands.scala
@@ -61,12 +61,15 @@ case class DropTable(
     val databaseName = dbAndTableName
       .lift(dbAndTableName.size -2)
       .getOrElse(hiveContext.catalog.client.currentDatabase)
-    //tempDbname is used to pass the test "drop_partitions_filter"
-    //when we set hive.exec.drop.ignorenonexistent=false and run "drop table dbname.tablename"
-    //Hive will throws out Exception (This is a bug of Hive)
+    // tempDbname is used to pass the test "drop_partitions_filter"
+    // when we set hive.exec.drop.ignorenonexistent=false and run "drop table dbname.tablename"
+    // Hive will throws out Exception (This is a bug of Hive)
     val tempDbname =
-      if (hiveContext.hiveconf.getBoolVar(HiveConf.ConfVars.DROPIGNORESNONEXISTENT))
-      s"$databaseName."else ""
+      if (hiveContext.hiveconf.getBoolVar(HiveConf.ConfVars.DROPIGNORESNONEXISTENT)) {
+        s"$databaseName."
+      } else {
+        ""
+      }
     try {
       hiveContext.cacheManager.tryUncacheQuery(hiveContext.table(dbAndTableName.last))
     } catch {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/commands.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/commands.scala
@@ -56,6 +56,7 @@ case class DropTable(
   override def run(sqlContext: SQLContext): Seq[InternalRow] = {
     val hiveContext = sqlContext.asInstanceOf[HiveContext]
     val ifExistsClause = if (ifExists) "IF EXISTS " else ""
+    val databaseName = hiveContext.catalog.client.currentDatabase
     try {
       hiveContext.cacheManager.tryUncacheQuery(hiveContext.table(tableName))
     } catch {
@@ -68,8 +69,8 @@ case class DropTable(
       case e: Throwable => log.warn(s"${e.getMessage}", e)
     }
     hiveContext.invalidateTable(tableName)
-    hiveContext.runSqlHive(s"DROP TABLE $ifExistsClause$tableName")
-    hiveContext.catalog.unregisterTable(Seq(tableName))
+    hiveContext.runSqlHive(s"DROP TABLE $ifExistsClause$databaseName.$tableName")
+    hiveContext.catalog.unregisterTable(Seq(databaseName, tableName))
     Seq.empty[InternalRow]
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
@@ -850,4 +850,22 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with BeforeA
     sqlContext.sql("""use default""")
     sqlContext.sql("""drop database if exists testdb8156 CASCADE""")
   }
+
+  test("SPARK-8561:drop table under specific database ") {
+
+    val df = (1 to 3).map(i => (i, s"val_$i", i * 2)).toDF("a", "b", "c")
+    sqlContext.sql("""create database if not exists testdb8561""")
+    sqlContext.sql("""use testdb8561""")
+    df.write
+      .format("parquet")
+      .mode(SaveMode.Overwrite)
+      .saveAsTable("testdb8561_tbl1")
+
+    assert(sqlContext.sql("show TABLES in testdb8561").collect().size === 1)
+    sqlContext.sql("drop TABLE testdb8561_tbl1")
+    assert(sqlContext.sql("show TABLES in testdb8561").collect().size === 0)
+
+    sqlContext.sql("""use default""")
+    sqlContext.sql("""drop database if exists testdb8561 CASCADE""")
+  }
 }


### PR DESCRIPTION
we run the following code
hivecontext.sql("use dbname")
hivecontext.sql("drop table tablename")

it will drop the table under "default"
