### PR TITLE
SPARK-8562: Log the lost of an executor only if SparkContext is alive

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -103,6 +103,8 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
     }
   }
 
+  private[spark] def isStopped = stopped
+
   /**
    * Create a SparkContext that loads settings from system properties (for instance, when
    * launching with ./bin/spark-submit).


### PR DESCRIPTION
When the context is being stopped, the executors are stopped first and then the actor system. However, sometimes it happens that the actor system receives the information about stopping executors before it gets shutdown and therefore it reports the "Executor lost" errors.
Simple way to fix that is to log errors in `TaskSchedulerImpl.executorLost` method, only if Spark context isn't stopped yet (`stopped` flag is set to true as the very first instruction in the `stop` method).
