### PR TITLE
[SPARK-8573] [SPARK-8568] [SQL] [PYSPARK] raise Exception if column is used in booelan expression

### DIFF
--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -398,7 +398,7 @@ class Column(object):
 
     def __nonzero__(self):
         raise ValueError("Cannot convert column into bool: please use '&' for 'and', '|' for 'or', "
-                         "'~'for 'not', when using Column in a boolean expression.")
+                         "'~' for 'not' when building DataFrame boolean expressions.")
     __bool__ = __nonzero__
 
     def __repr__(self):

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -397,8 +397,8 @@ class Column(object):
         return Column(jc)
 
     def __nonzero__(self):
-        raise ValueError("Can't convert column into bool: please use '&' for 'and', '|' for 'or', "
-                         "when using Column in a boolean expression.")
+        raise ValueError("Cannot convert column into bool: please use '&' for 'and', '|' for 'or', "
+                         "'~'for 'not', when using Column in a boolean expression.")
     __bool__ = __nonzero__
 
     def __repr__(self):

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -396,6 +396,11 @@ class Column(object):
         jc = self._jc.over(window._jspec)
         return Column(jc)
 
+    def __nonzero__(self):
+        raise ValueError("Can't convert column into bool: please use '&' for 'and', '|' for 'or', "
+                         "when using Column in a boolean expression.")
+    __bool__ = __nonzero__
+
     def __repr__(self):
         return 'Column<%s>' % self._jc.toString().encode('utf8')
 

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -416,7 +416,7 @@ class SQLTests(ReusedPySparkTestCase):
         self.assertTrue(isinstance((- ci - 1 - 2) % 3 * 2.5 / 3.5, Column))
         rcc = (1 + ci), (1 - ci), (1 * ci), (1 / ci), (1 % ci)
         self.assertTrue(all(isinstance(c, Column) for c in rcc))
-        cb = [ci == 5, ci != 0, ci > 3, ci < 4, ci >= 0, ci <= 7, ci and cs, ci or cs]
+        cb = [ci == 5, ci != 0, ci > 3, ci < 4, ci >= 0, ci <= 7]
         self.assertTrue(all(isinstance(c, Column) for c in cb))
         cbool = (ci & ci), (ci | ci), (~ci)
         self.assertTrue(all(isinstance(c, Column) for c in cbool))

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -164,6 +164,13 @@ class SQLTests(ReusedPySparkTestCase):
         self.assertEqual(result[0][0], "a")
         self.assertEqual(result[0][1], "b")
 
+    def test_and_in_expression(self):
+        self.assertEqual(4, self.df.filter(self.df.key <= 10 & self.df.value <= "2").count())
+        self.assertRaises(ValueError, lambda: self.df.key <= 10 & self.df.value <= "2")
+        self.assertEqual(2, self.df.filter(self.df.key <= 3 | self.df.value < "2").count())
+        self.assertRaises(ValueError,
+                          lambda: self.df.filter(self.df.key <= 3 | self.df.value < "2").count())
+
     def test_udf_with_callable(self):
         d = [Row(number=i, squared=i**2) for i in range(10)]
         rdd = self.sc.parallelize(d)

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -165,11 +165,12 @@ class SQLTests(ReusedPySparkTestCase):
         self.assertEqual(result[0][1], "b")
 
     def test_and_in_expression(self):
-        self.assertEqual(4, self.df.filter(self.df.key <= 10 & self.df.value <= "2").count())
-        self.assertRaises(ValueError, lambda: self.df.key <= 10 & self.df.value <= "2")
-        self.assertEqual(2, self.df.filter(self.df.key <= 3 | self.df.value < "2").count())
-        self.assertRaises(ValueError,
-                          lambda: self.df.filter(self.df.key <= 3 | self.df.value < "2").count())
+        self.assertEqual(4, self.df.filter((self.df.key <= 10) & (self.df.value <= "2")).count())
+        self.assertRaises(ValueError, lambda: (self.df.key <= 10) and (self.df.value <= "2"))
+        self.assertEqual(14, self.df.filter((self.df.key <= 3) | (self.df.value < "2")).count())
+        self.assertRaises(ValueError, lambda: self.df.key <= 3 or self.df.value < "2")
+        self.assertEqual(99, self.df.filter(~(self.df.key == 1)).count())
+        self.assertRaises(ValueError, lambda: not self.df.key == 1)
 
     def test_udf_with_callable(self):
         d = [Row(number=i, squared=i**2) for i in range(10)]


### PR DESCRIPTION
It's a common mistake that user will put Column in a boolean expression (together with `and` , `or`), which does not work as expected, we should raise a exception in that case, and suggest user to use `&`, `|` instead.
