### PR TITLE
[SPARK-8576] Add spark-ec2 options to set IAM roles and instance-initiated shutdown behavior

### DIFF
--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -308,7 +308,8 @@ def parse_args():
              "requires that.")
     parser.add_option(
         "--instance-initiated-shutdown-behavior", default="stop",
-        choices=["stop", "terminate"])
+        choices=["stop", "terminate"],
+        help="Whether instances should terminate when shut down or just stop")
     parser.add_option(
         "--instance-profile-name", default=None,
         help="IAM profile name to launch instances under")

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -306,6 +306,9 @@ def parse_args():
         "--private-ips", action="store_true", default=False,
         help="Use private IPs for instances rather than public if VPC/subnet " +
              "requires that.")
+    parser.add_option(
+        "--instance-initiated-shutdown-behavior", default="stop",
+        choices=["stop", "terminate"])
 
     (opts, args) = parser.parse_args()
     if len(args) != 2:
@@ -656,7 +659,8 @@ def launch_cluster(conn, opts, cluster_name):
                                       block_device_map=block_map,
                                       subnet_id=opts.subnet_id,
                                       placement_group=opts.placement_group,
-                                      user_data=user_data_content)
+                                      user_data=user_data_content,
+                                      instance_initiated_shutdown_behavior=opts.instance_initiated_shutdown_behavior)
                 slave_nodes += slave_res.instances
                 print("Launched {s} slave{plural_s} in {z}, regid = {r}".format(
                       s=num_slaves_this_zone,
@@ -687,7 +691,8 @@ def launch_cluster(conn, opts, cluster_name):
                                block_device_map=block_map,
                                subnet_id=opts.subnet_id,
                                placement_group=opts.placement_group,
-                               user_data=user_data_content)
+                               user_data=user_data_content,
+                               instance_initiated_shutdown_behavior=opts.instance_initiated_shutdown_behavior)
 
         master_nodes = master_res.instances
         print("Launched master in %s, regid = %s" % (zone, master_res.id))

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -309,6 +309,10 @@ def parse_args():
     parser.add_option(
         "--instance-initiated-shutdown-behavior", default="stop",
         choices=["stop", "terminate"])
+    parser.add_option(
+        "--instance-profile-name", default=None,
+        help="IAM profile name to launch instances under")
+
 
     (opts, args) = parser.parse_args()
     if len(args) != 2:
@@ -605,7 +609,8 @@ def launch_cluster(conn, opts, cluster_name):
                 block_device_map=block_map,
                 subnet_id=opts.subnet_id,
                 placement_group=opts.placement_group,
-                user_data=user_data_content)
+                user_data=user_data_content,
+                instance_profile_name=opts.instance_profile_name)
             my_req_ids += [req.id for req in slave_reqs]
             i += 1
 
@@ -660,7 +665,8 @@ def launch_cluster(conn, opts, cluster_name):
                                       subnet_id=opts.subnet_id,
                                       placement_group=opts.placement_group,
                                       user_data=user_data_content,
-                                      instance_initiated_shutdown_behavior=opts.instance_initiated_shutdown_behavior)
+                                      instance_initiated_shutdown_behavior=opts.instance_initiated_shutdown_behavior,
+                                      instance_profile_name=opts.instance_profile_name)
                 slave_nodes += slave_res.instances
                 print("Launched {s} slave{plural_s} in {z}, regid = {r}".format(
                       s=num_slaves_this_zone,
@@ -692,7 +698,8 @@ def launch_cluster(conn, opts, cluster_name):
                                subnet_id=opts.subnet_id,
                                placement_group=opts.placement_group,
                                user_data=user_data_content,
-                               instance_initiated_shutdown_behavior=opts.instance_initiated_shutdown_behavior)
+                               instance_initiated_shutdown_behavior=opts.instance_initiated_shutdown_behavior,
+                               instance_profile_name=opts.instance_profile_name)
 
         master_nodes = master_res.instances
         print("Launched master in %s, regid = %s" % (zone, master_res.id))

--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -314,7 +314,6 @@ def parse_args():
         "--instance-profile-name", default=None,
         help="IAM profile name to launch instances under")
 
-
     (opts, args) = parser.parse_args()
     if len(args) != 2:
         parser.print_help()
@@ -656,18 +655,19 @@ def launch_cluster(conn, opts, cluster_name):
         for zone in zones:
             num_slaves_this_zone = get_partition(opts.slaves, num_zones, i)
             if num_slaves_this_zone > 0:
-                slave_res = image.run(key_name=opts.key_pair,
-                                      security_group_ids=[slave_group.id] + additional_group_ids,
-                                      instance_type=opts.instance_type,
-                                      placement=zone,
-                                      min_count=num_slaves_this_zone,
-                                      max_count=num_slaves_this_zone,
-                                      block_device_map=block_map,
-                                      subnet_id=opts.subnet_id,
-                                      placement_group=opts.placement_group,
-                                      user_data=user_data_content,
-                                      instance_initiated_shutdown_behavior=opts.instance_initiated_shutdown_behavior,
-                                      instance_profile_name=opts.instance_profile_name)
+                slave_res = image.run(
+                    key_name=opts.key_pair,
+                    security_group_ids=[slave_group.id] + additional_group_ids,
+                    instance_type=opts.instance_type,
+                    placement=zone,
+                    min_count=num_slaves_this_zone,
+                    max_count=num_slaves_this_zone,
+                    block_device_map=block_map,
+                    subnet_id=opts.subnet_id,
+                    placement_group=opts.placement_group,
+                    user_data=user_data_content,
+                    instance_initiated_shutdown_behavior=opts.instance_initiated_shutdown_behavior,
+                    instance_profile_name=opts.instance_profile_name)
                 slave_nodes += slave_res.instances
                 print("Launched {s} slave{plural_s} in {z}, regid = {r}".format(
                       s=num_slaves_this_zone,
@@ -689,18 +689,19 @@ def launch_cluster(conn, opts, cluster_name):
             master_type = opts.instance_type
         if opts.zone == 'all':
             opts.zone = random.choice(conn.get_all_zones()).name
-        master_res = image.run(key_name=opts.key_pair,
-                               security_group_ids=[master_group.id] + additional_group_ids,
-                               instance_type=master_type,
-                               placement=opts.zone,
-                               min_count=1,
-                               max_count=1,
-                               block_device_map=block_map,
-                               subnet_id=opts.subnet_id,
-                               placement_group=opts.placement_group,
-                               user_data=user_data_content,
-                               instance_initiated_shutdown_behavior=opts.instance_initiated_shutdown_behavior,
-                               instance_profile_name=opts.instance_profile_name)
+        master_res = image.run(
+            key_name=opts.key_pair,
+            security_group_ids=[master_group.id] + additional_group_ids,
+            instance_type=master_type,
+            placement=opts.zone,
+            min_count=1,
+            max_count=1,
+            block_device_map=block_map,
+            subnet_id=opts.subnet_id,
+            placement_group=opts.placement_group,
+            user_data=user_data_content,
+            instance_initiated_shutdown_behavior=opts.instance_initiated_shutdown_behavior,
+            instance_profile_name=opts.instance_profile_name)
 
         master_nodes = master_res.instances
         print("Launched master in %s, regid = %s" % (zone, master_res.id))


### PR DESCRIPTION
Both of these options are useful when spark-ec2 is being used as part of an automated pipeline and the engineers want to minimize the need to pass around AWS keys for access to things like S3 (keys are replaced by the IAM role) and to be able to launch a cluster that can terminate itself cleanly.
