### PR TITLE
[SPARK-8587][PySpark] KMeansModel predict return distance

### DIFF
--- a/python/pyspark/mllib/clustering.py
+++ b/python/pyspark/mllib/clustering.py
@@ -99,7 +99,7 @@ class KMeansModel(Saveable, Loader):
         """Total number of clusters."""
         return len(self.centers)
 
-    def predict(self, x):
+    def predict(self, x, return_distance=False):
         """Find the cluster to which x belongs in this model."""
         best = 0
         best_distance = float("inf")
@@ -112,7 +112,11 @@ class KMeansModel(Saveable, Loader):
             if distance < best_distance:
                 best = i
                 best_distance = distance
-        return best
+
+        if return_distance:
+            return best, best_distance
+        else:
+            return best
 
     def computeCost(self, rdd):
         """


### PR DESCRIPTION
Many use cases also require to know the distance to the closest
cluster. This commit adds a parameter to return the distance
by default this parameter is off to not break existing
applications.
