### PR TITLE
[SPARK-8574] org/apache/spark/unsafe doesn't honor the java source/ta…

### DIFF
--- a/unsafe/pom.xml
+++ b/unsafe/pom.xml
@@ -83,6 +83,10 @@
             <javacArgs>
               <!-- This option is needed to suppress warnings from sun.misc.Unsafe usage -->
               <javacArg>-XDignore.symbol.file</javacArg>
+              <javacArg>-source</javacArg>
+              <javacArg>${java.version}</javacArg>
+              <javacArg>-target</javacArg>
+              <javacArg>${java.version}</javacArg>
             </javacArgs>
           </configuration>
         </plugin>
@@ -90,6 +94,8 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <configuration>
+            <source>${java.version}</source>
+            <target>${java.version}</target>
             <compilerArgs>
               <!-- This option is needed to suppress warnings from sun.misc.Unsafe usage -->
               <arg>-XDignore.symbol.file</arg>

--- a/unsafe/pom.xml
+++ b/unsafe/pom.xml
@@ -80,13 +80,9 @@
           <groupId>net.alchim31.maven</groupId>
           <artifactId>scala-maven-plugin</artifactId>
           <configuration>
-            <javacArgs>
+            <javacArgs combine.children="append">
               <!-- This option is needed to suppress warnings from sun.misc.Unsafe usage -->
               <javacArg>-XDignore.symbol.file</javacArg>
-              <javacArg>-source</javacArg>
-              <javacArg>${java.version}</javacArg>
-              <javacArg>-target</javacArg>
-              <javacArg>${java.version}</javacArg>
             </javacArgs>
           </configuration>
         </plugin>
@@ -94,8 +90,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <configuration>
-            <source>${java.version}</source>
-            <target>${java.version}</target>
             <compilerArgs>
               <!-- This option is needed to suppress warnings from sun.misc.Unsafe usage -->
               <arg>-XDignore.symbol.file</arg>


### PR DESCRIPTION
…rget versions.

I basically copied the compatibility rules from the top level pom.xml into here.  Someone more familiar with all the options in the top level pom may want to make sure nothing else should be copied on down.

With this is allows me to build with jdk8 and run with lower versions.  Source shows compiled for jdk6 as its supposed to.
