### PR TITLE
[SPARK-746][CORE] Added Avro Serialization to Kryo

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -35,6 +35,16 @@
   <url>http://spark.apache.org/</url>
   <dependencies>
     <dependency>
+      <groupId>net.sf.py4j</groupId>
+      <artifactId>py4j</artifactId>
+      <version>0.8.2.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro-mapred</artifactId>
+      <classifier>${avro.mapred.classifier}</classifier>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
@@ -390,45 +400,6 @@
         <exclusion>
           <groupId>net.razorvine</groupId>
           <artifactId>serpent</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>net.sf.py4j</groupId>
-      <artifactId>py4j</artifactId>
-      <version>0.8.2.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.avro</groupId>
-      <artifactId>avro</artifactId>
-      <version>${avro.version}</version>
-      <scope>${hadoop.deps.scope}</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.avro</groupId>
-      <artifactId>avro-mapred</artifactId>
-      <version>${avro.version}</version>
-      <scope>${hadoop.deps.scope}</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.mortbay.jetty</groupId>
-          <artifactId>jetty</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.mortbay.jetty</groupId>
-          <artifactId>jetty-util</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.mortbay.jetty</groupId>
-          <artifactId>servlet-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.velocity</groupId>
-          <artifactId>velocity</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -35,11 +35,6 @@
   <url>http://spark.apache.org/</url>
   <dependencies>
     <dependency>
-      <groupId>net.sf.py4j</groupId>
-      <artifactId>py4j</artifactId>
-      <version>0.8.2.1</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro-mapred</artifactId>
       <classifier>${avro.mapred.classifier}</classifier>
@@ -402,6 +397,11 @@
           <artifactId>serpent</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>net.sf.py4j</groupId>
+      <artifactId>py4j</artifactId>
+      <version>0.8.2.1</version>
     </dependency>
   </dependencies>
   <build>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -402,14 +402,13 @@
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
       <version>${avro.version}</version>
-      <scope>${hadoop.deps.scope}</scope>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro-mapred</artifactId>
       <version>${avro.version}</version>
-      <classifier>${avro.mapred.classifier}</classifier>
-      <scope>${hive.deps.scope}</scope>
+      <scope>compile</scope>
       <exclusions>
         <exclusion>
           <groupId>io.netty</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -402,13 +402,13 @@
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
       <version>${avro.version}</version>
-      <scope>compile</scope>
+      <scope>${hadoop.deps.scope}</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro-mapred</artifactId>
       <version>${avro.version}</version>
-      <scope>compile</scope>
+      <scope>${hadoop.deps.scope}</scope>
       <exclusions>
         <exclusion>
           <groupId>io.netty</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -398,6 +398,41 @@
       <artifactId>py4j</artifactId>
       <version>0.8.2.1</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>${avro.version}</version>
+      <scope>${hadoop.deps.scope}</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro-mapred</artifactId>
+      <version>${avro.version}</version>
+      <classifier>${avro.mapred.classifier}</classifier>
+      <scope>${hive.deps.scope}</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.mortbay.jetty</groupId>
+          <artifactId>jetty</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.mortbay.jetty</groupId>
+          <artifactId>jetty-util</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.mortbay.jetty</groupId>
+          <artifactId>servlet-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.velocity</groupId>
+          <artifactId>velocity</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
   <build>
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -169,9 +169,10 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging {
    * record serializer can decrease network IO
    */
   def registerAvroSchemas(schemas: Schema*): SparkConf = {
-    schemas.foldLeft(this) { (conf, schema) =>
-      conf.set(avroNamespace + SchemaNormalization.parsingFingerprint64(schema), schema.toString)
+    for (schema <- schemas) {
+      set(avroNamespace + SchemaNormalization.parsingFingerprint64(schema), schema.toString)
     }
+    this
   }
 
   /** Gets all the avro schemas in the configuration used in the generic Avro record serializer */

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -166,17 +166,16 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging {
    * Use Kryo serialization and register the given set of Avro schemas so that the generic
    * record serializer can decrease network IO
    */
-  def registerAvroSchema(schemas: Array[Schema]): SparkConf =
-    schemas.foldLeft(this) { (conf, schema) =>
-      conf.set(avroSchemaKey(SchemaNormalization.parsingFingerprint64(schema)), schema.toString)
-    }
+  def registerAvroSchemas(schemas: Schema*): SparkConf = schemas.foldLeft(this) { (conf, schema) =>
+    conf.set(avroSchemaKey(schema), schema.toString)
+  }
 
   /** Gets all the avro schemas in the configuration used in the generic Avro record serializer */
-  def getAvroSchema: Map[Long, String] = {
+  def getAvroSchema: Map[Long, String] =
     getAll.filter { case (k, v) => k.startsWith(avroSchemaNamespace) }
           .map { case (k, v) => (k.substring(avroSchemaNamespace.length).toLong, v) }
           .toMap
-  }
+
 
   /** Remove a parameter from the configuration */
   def remove(key: String): SparkConf = {

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -18,12 +18,11 @@
 package org.apache.spark
 
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicBoolean
-
-import org.apache.avro.{Schema, SchemaNormalization}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.LinkedHashSet
+
+import org.apache.avro.{Schema, SchemaNormalization}
 
 import org.apache.spark.serializer.GenericAvroSerializer.avroSchemaKey
 import org.apache.spark.serializer.KryoSerializer

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -22,9 +22,8 @@ import java.util.concurrent.ConcurrentHashMap
 import scala.collection.JavaConverters._
 import scala.collection.mutable.LinkedHashSet
 
-import org.apache.avro.Schema
+import org.apache.avro.{SchemaNormalization, Schema}
 
-import org.apache.spark.serializer.GenericAvroSerializer.{avroSchemaNamespace, avroSchemaKey}
 import org.apache.spark.serializer.KryoSerializer
 import org.apache.spark.util.Utils
 
@@ -162,20 +161,25 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging {
     set("spark.serializer", classOf[KryoSerializer].getName)
     this
   }
+
+  private final val avroNamespace = "avro.schema."
+
   /**
    * Use Kryo serialization and register the given set of Avro schemas so that the generic
    * record serializer can decrease network IO
    */
-  def registerAvroSchemas(schemas: Schema*): SparkConf = schemas.foldLeft(this) { (conf, schema) =>
-    conf.set(avroSchemaKey(schema), schema.toString)
+  def registerAvroSchemas(schemas: Schema*): SparkConf = {
+    schemas.foldLeft(this) { (conf, schema) =>
+      conf.set(avroNamespace + SchemaNormalization.parsingFingerprint64(schema), schema.toString)
+    }
   }
 
   /** Gets all the avro schemas in the configuration used in the generic Avro record serializer */
-  def getAvroSchema: Map[Long, String] =
-    getAll.filter { case (k, v) => k.startsWith(avroSchemaNamespace) }
-          .map { case (k, v) => (k.substring(avroSchemaNamespace.length).toLong, v) }
-          .toMap
-
+  def getAvroSchema: Map[Long, String] = {
+    getAll.filter { case (k, v) => k.startsWith(avroNamespace) }
+      .map { case (k, v) => (k.substring(avroNamespace.length).toLong, v) }
+      .toMap
+  }
 
   /** Remove a parameter from the configuration */
   def remove(key: String): SparkConf = {

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -22,7 +22,7 @@ import java.util.concurrent.ConcurrentHashMap
 import scala.collection.JavaConverters._
 import scala.collection.mutable.LinkedHashSet
 
-import org.apache.avro.{Schema, SchemaNormalization}
+import org.apache.avro.Schema
 
 import org.apache.spark.serializer.GenericAvroSerializer.{avroSchemaNamespace, avroSchemaKey}
 import org.apache.spark.serializer.KryoSerializer

--- a/core/src/main/scala/org/apache/spark/serializer/GenericAvroSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/GenericAvroSerializer.scala
@@ -67,7 +67,6 @@ private[serializer] class GenericAvroSerializer(schemas: Map[Long, String])
     bos.toByteArray
   })
 
-
   /**
    * Decompresses the schema into the actual in-memory object. Keeps an internal cache of already
    * seen values so to limit the number of times that decompression has to be done.

--- a/core/src/main/scala/org/apache/spark/serializer/GenericAvroSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/GenericAvroSerializer.scala
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.serializer
+
+import java.io.ByteArrayOutputStream
+import java.util.zip.{Inflater, Deflater}
+
+import scala.collection.mutable
+
+import com.esotericsoftware.kryo.{Kryo, Serializer => KSerializer}
+import com.esotericsoftware.kryo.io.{Input => KryoInput, Output => KryoOutput}
+import org.apache.avro.generic.{GenericData, GenericRecord}
+import org.apache.avro.io._
+import org.apache.avro.{Schema, SchemaNormalization}
+
+import org.apache.spark.SparkConf
+
+import GenericAvroSerializer._
+
+object GenericAvroSerializer {
+  def avroSchemaKey(implicit fingerprint: Long): String = s"avro.schema.$fingerprint"
+}
+
+/**
+ * Custom serializer used for generic Avro records. If the user registers the schemas
+ * ahead of time, then the schema's fingerprint will be sent with each message instead of the actual
+ * schema, as to reduce network IO.
+ * Actions like parsing or compressing schemas are computationally expensive so the serializer
+ * caches all previously seen values as to reduce the amount of work needed to do.
+ */
+class GenericAvroSerializer(conf: SparkConf) extends KSerializer[GenericRecord] {
+
+  private val serializer = serialize()
+  private val deserializer = deserialize()
+
+  private def confSchema(implicit fingerprint: Long) = conf.getOption(avroSchemaKey)
+
+  /**
+   * Used to compress Schemas when they are being sent over the wire.
+   * The compression results are memoized to reduce the compression time since the
+   * same schema is compressed many times over
+   */
+  def compressor(): Schema => Array[Byte] = {
+    val cache = new mutable.HashMap[Schema, Array[Byte]]()
+
+    def compress(schema: Schema): Array[Byte] = cache.getOrElseUpdate(schema, {
+      val deflater = new Deflater(Deflater.BEST_COMPRESSION)
+      val schemaBytes = schema.toString.getBytes("UTF-8")
+      deflater.setInput(schemaBytes)
+      deflater.finish()
+      val buffer = Array.ofDim[Byte](schemaBytes.length)
+      val outputStream = new ByteArrayOutputStream(schemaBytes.length)
+      while(!deflater.finished()) {
+        val count = deflater.deflate(buffer)
+        outputStream.write(buffer, 0, count)
+      }
+      outputStream.close()
+      outputStream.toByteArray
+    })
+
+    compress
+  }
+
+  /**
+   * Decompresses the schema into the actual in-memory object. Keeps an internal cache of already
+   * seen values so to limit the number of times that decompression has to be done.
+   */
+  def decompressor(): Array[Byte] => Schema = {
+    val cache = new mutable.HashMap[Array[Byte], Schema]()
+
+    def decompress(schemaBytes: Array[Byte]): Schema = cache.getOrElseUpdate(schemaBytes, {
+      val inflater = new Inflater()
+      inflater.setInput(schemaBytes)
+      val outputStream = new ByteArrayOutputStream(schemaBytes.length)
+      val tmpBuffer = Array.ofDim[Byte](1024)
+      while (!inflater.finished()) {
+        val count = inflater.inflate(tmpBuffer)
+        outputStream.write(tmpBuffer, 0, count)
+      }
+      inflater.end()
+      outputStream.close()
+      new Schema.Parser().parse(new String(outputStream.toByteArray, "UTF-8"))
+    })
+
+    decompress
+  }
+
+  /**
+   * Serializes generic records into byte buffers. It keeps an internal cache of already seen
+   * schema as to reduce the amount of required work.
+   */
+  def serialize(): (GenericRecord, KryoOutput) => Unit = {
+    val writerCache = new mutable.HashMap[Schema, DatumWriter[_]]()
+    val schemaCache = new mutable.HashMap[Schema, Long]()
+    val compress = compressor()
+
+    def serialize[R <: GenericRecord](datum: R, schema: Schema, output: KryoOutput): Unit = {
+      val encoder = EncoderFactory.get.binaryEncoder(output, null)
+      writerCache.getOrElseUpdate(schema, GenericData.get.createDatumWriter(schema))
+                 .asInstanceOf[DatumWriter[R]]
+                 .write(datum, encoder)
+      encoder.flush()
+    }
+
+    def wrapDatum(datum: GenericRecord, output: KryoOutput): Unit = {
+      val schema = datum.getSchema
+      val fingerprint = schemaCache.getOrElseUpdate(schema, {
+        SchemaNormalization.parsingFingerprint64(schema)
+      })
+      confSchema(fingerprint) match {
+        case Some(_) => {
+          output.writeBoolean(true)
+          output.writeLong(fingerprint)
+        }
+        case None => {
+          output.writeBoolean(false)
+          val compressedSchema = compress(schema)
+          output.writeInt(compressedSchema.array.length)
+          output.writeBytes(compressedSchema.array)
+        }
+      }
+      serialize(datum, schema, output)
+    }
+    wrapDatum
+  }
+
+  /**
+   * Deserializes generic records into their in-memory form. There is internal
+   * state to keep a cache of already seen schemas and datum readers.
+   * @return
+   */
+  def deserialize(): KryoInput => GenericRecord = {
+    val readerCache = new mutable.HashMap[Schema, DatumReader[_]]()
+    val schemaCache = new mutable.HashMap[Long, Schema]()
+    val decompress = decompressor()
+
+    def deserialize(input: KryoInput, schema: Schema): GenericRecord = {
+      val decoder = DecoderFactory.get.directBinaryDecoder(input, null)
+      readerCache.getOrElseUpdate(schema, GenericData.get.createDatumReader(schema))
+        .asInstanceOf[DatumReader[GenericRecord]]
+        .read(null.asInstanceOf[GenericRecord], decoder)
+    }
+
+    def unwrapDatum(input: KryoInput): GenericRecord = {
+      val schema = {
+        if (input.readBoolean()) {
+          val fingerprint = input.readLong()
+          schemaCache.getOrElseUpdate(fingerprint, {
+            confSchema(fingerprint) match {
+              case Some(s) => new Schema.Parser().parse(s)
+              case None => throw new RuntimeException(s"Unknown fingerprint: $fingerprint")
+            }
+          })
+        } else {
+          val length = input.readInt()
+          decompress(input.readBytes(length))
+        }
+      }
+      deserialize(input, schema)
+    }
+    unwrapDatum
+  }
+
+  override def write(kryo: Kryo, output: KryoOutput, datum: GenericRecord): Unit =
+    serializer(datum, output)
+
+  override def read(kryo: Kryo, input: KryoInput, datumClass: Class[GenericRecord]): GenericRecord =
+    deserializer(input)
+}
+

--- a/core/src/main/scala/org/apache/spark/serializer/GenericAvroSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/GenericAvroSerializer.scala
@@ -20,6 +20,7 @@ package org.apache.spark.serializer
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 import java.nio.ByteBuffer
 
+import org.apache.spark.SparkConf
 import org.apache.spark.io.CompressionCodec
 
 import scala.collection.mutable
@@ -41,7 +42,7 @@ import org.apache.avro.io._
  * Actions like parsing or compressing schemas are computationally expensive so the serializer
  * caches all previously seen values as to reduce the amount of work needed to do.
  */
-private[serializer] class GenericAvroSerializer(schemas: Map[Long, String], codec: CompressionCodec)
+private[serializer] class GenericAvroSerializer(schemas: Map[Long, String])
   extends KSerializer[GenericRecord] {
 
   /** Used to reduce the amount of effort to compress the schema */
@@ -55,6 +56,8 @@ private[serializer] class GenericAvroSerializer(schemas: Map[Long, String], code
   /** Fingerprinting is very expensive so this alleviates most of the work */
   private val fingerprintCache = new mutable.HashMap[Schema, Long]()
   private val schemaCache = new mutable.HashMap[Long, Schema]()
+
+  private val codec = CompressionCodec.createCodec(new SparkConf())
 
   /**
    * Used to compress Schemas when they are being sent over the wire.

--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -74,6 +74,9 @@ class KryoSerializer(conf: SparkConf)
   private val classesToRegister = conf.get("spark.kryo.classesToRegister", "")
     .split(',')
     .filter(!_.isEmpty)
+  conf.getExecutorEnv
+
+  private val avroSchemas = conf.getAvroSchema
 
   def newKryoOutput(): KryoOutput = new KryoOutput(bufferSize, math.max(bufferSize, maxBufferSize))
 
@@ -101,8 +104,8 @@ class KryoSerializer(conf: SparkConf)
     kryo.register(classOf[HttpBroadcast[_]], new KryoJavaSerializer())
     kryo.register(classOf[PythonBroadcast], new KryoJavaSerializer())
 
-    kryo.register(classOf[GenericRecord], new GenericAvroSerializer(conf))
-    kryo.register(classOf[GenericData.Record], new GenericAvroSerializer(conf))
+    kryo.register(classOf[GenericRecord], new GenericAvroSerializer(avroSchemas))
+    kryo.register(classOf[GenericData.Record], new GenericAvroSerializer(avroSchemas))
 
     try {
       // Use the default classloader when calling the user registrator.

--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -21,6 +21,8 @@ import java.io.{EOFException, IOException, InputStream, OutputStream}
 import java.nio.ByteBuffer
 import javax.annotation.Nullable
 
+import org.apache.avro.generic.{GenericData, GenericRecord}
+
 import scala.reflect.ClassTag
 
 import com.esotericsoftware.kryo.{Kryo, KryoException}
@@ -98,6 +100,9 @@ class KryoSerializer(conf: SparkConf)
     kryo.register(classOf[SerializableWritable[_]], new KryoJavaSerializer())
     kryo.register(classOf[HttpBroadcast[_]], new KryoJavaSerializer())
     kryo.register(classOf[PythonBroadcast], new KryoJavaSerializer())
+
+    kryo.register(classOf[GenericRecord], new GenericAvroSerializer(conf))
+    kryo.register(classOf[GenericData.Record], new GenericAvroSerializer(conf))
 
     try {
       // Use the default classloader when calling the user registrator.

--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -74,7 +74,6 @@ class KryoSerializer(conf: SparkConf)
   private val classesToRegister = conf.get("spark.kryo.classesToRegister", "")
     .split(',')
     .filter(!_.isEmpty)
-  conf.getExecutorEnv
 
   private val avroSchemas = conf.getAvroSchema
 

--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -34,6 +34,7 @@ import org.roaringbitmap.{ArrayContainer, BitmapContainer, RoaringArray, Roaring
 import org.apache.spark._
 import org.apache.spark.api.python.PythonBroadcast
 import org.apache.spark.broadcast.HttpBroadcast
+import org.apache.spark.io.CompressionCodec
 import org.apache.spark.network.nio.{GetBlock, GotBlock, PutBlock}
 import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.scheduler.{CompressedMapStatus, HighlyCompressedMapStatus}

--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -21,9 +21,9 @@ import java.io.{EOFException, IOException, InputStream, OutputStream}
 import java.nio.ByteBuffer
 import javax.annotation.Nullable
 
-import org.apache.avro.generic.{GenericData, GenericRecord}
-
 import scala.reflect.ClassTag
+
+import org.apache.avro.generic.{GenericData, GenericRecord}
 
 import com.esotericsoftware.kryo.{Kryo, KryoException}
 import com.esotericsoftware.kryo.io.{Input => KryoInput, Output => KryoOutput}
@@ -34,7 +34,6 @@ import org.roaringbitmap.{ArrayContainer, BitmapContainer, RoaringArray, Roaring
 import org.apache.spark._
 import org.apache.spark.api.python.PythonBroadcast
 import org.apache.spark.broadcast.HttpBroadcast
-import org.apache.spark.io.CompressionCodec
 import org.apache.spark.network.nio.{GetBlock, GotBlock, PutBlock}
 import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.scheduler.{CompressedMapStatus, HighlyCompressedMapStatus}

--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -21,8 +21,6 @@ import java.io.{EOFException, IOException, InputStream, OutputStream}
 import java.nio.ByteBuffer
 import javax.annotation.Nullable
 
-import org.apache.spark.io.CompressionCodec
-
 import scala.reflect.ClassTag
 
 import org.apache.avro.generic.{GenericData, GenericRecord}
@@ -78,7 +76,6 @@ class KryoSerializer(conf: SparkConf)
     .filter(!_.isEmpty)
 
   private val avroSchemas = conf.getAvroSchema
-  private val codec = CompressionCodec.createCodec(conf)
 
   def newKryoOutput(): KryoOutput = new KryoOutput(bufferSize, math.max(bufferSize, maxBufferSize))
 
@@ -106,8 +103,8 @@ class KryoSerializer(conf: SparkConf)
     kryo.register(classOf[HttpBroadcast[_]], new KryoJavaSerializer())
     kryo.register(classOf[PythonBroadcast], new KryoJavaSerializer())
 
-    kryo.register(classOf[GenericRecord], new GenericAvroSerializer(avroSchemas, codec))
-    kryo.register(classOf[GenericData.Record], new GenericAvroSerializer(avroSchemas, codec))
+    kryo.register(classOf[GenericRecord], new GenericAvroSerializer(avroSchemas))
+    kryo.register(classOf[GenericData.Record], new GenericAvroSerializer(avroSchemas))
 
     try {
       // Use the default classloader when calling the user registrator.

--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -21,6 +21,8 @@ import java.io.{EOFException, IOException, InputStream, OutputStream}
 import java.nio.ByteBuffer
 import javax.annotation.Nullable
 
+import org.apache.spark.io.CompressionCodec
+
 import scala.reflect.ClassTag
 
 import org.apache.avro.generic.{GenericData, GenericRecord}
@@ -76,6 +78,7 @@ class KryoSerializer(conf: SparkConf)
     .filter(!_.isEmpty)
 
   private val avroSchemas = conf.getAvroSchema
+  private val codec = CompressionCodec.createCodec(conf)
 
   def newKryoOutput(): KryoOutput = new KryoOutput(bufferSize, math.max(bufferSize, maxBufferSize))
 
@@ -103,8 +106,8 @@ class KryoSerializer(conf: SparkConf)
     kryo.register(classOf[HttpBroadcast[_]], new KryoJavaSerializer())
     kryo.register(classOf[PythonBroadcast], new KryoJavaSerializer())
 
-    kryo.register(classOf[GenericRecord], new GenericAvroSerializer(avroSchemas))
-    kryo.register(classOf[GenericData.Record], new GenericAvroSerializer(avroSchemas))
+    kryo.register(classOf[GenericRecord], new GenericAvroSerializer(avroSchemas, codec))
+    kryo.register(classOf[GenericData.Record], new GenericAvroSerializer(avroSchemas, codec))
 
     try {
       // Use the default classloader when calling the user registrator.

--- a/core/src/test/scala/org/apache/spark/serializer/GenericAvroSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/GenericAvroSerializerSuite.scala
@@ -63,7 +63,7 @@ class GenericAvroSerializerSuite extends SparkFunSuite with SharedSparkContext {
     output.flush()
     val normalLength = output.total - beginningNormalPosition
 
-    conf.registerAvroSchema(Array(schema))
+    conf.registerAvroSchemas(schema)
     val genericSerFinger = new GenericAvroSerializer(conf.getAvroSchema)
     val beginningFingerprintPosition = output.total()
     genericSerFinger.serializeDatum(record, output)

--- a/core/src/test/scala/org/apache/spark/serializer/GenericAvroSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/GenericAvroSerializerSuite.scala
@@ -38,14 +38,12 @@ class GenericAvroSerializerSuite extends SparkFunSuite with SharedSparkContext {
   record.put("data", "test data")
 
   test("schema compression and decompression") {
-    val genericSer = new GenericAvroSerializer(conf.getAvroSchema,
-      CompressionCodec.createCodec(conf))
+    val genericSer = new GenericAvroSerializer(conf.getAvroSchema)
     assert(schema === genericSer.decompress(ByteBuffer.wrap(genericSer.compress(schema))))
   }
 
   test("record serialization and deserialization") {
-    val genericSer = new GenericAvroSerializer(conf.getAvroSchema,
-      CompressionCodec.createCodec(conf))
+    val genericSer = new GenericAvroSerializer(conf.getAvroSchema)
 
     val outputStream = new ByteArrayOutputStream()
     val output = new Output(outputStream)
@@ -58,8 +56,7 @@ class GenericAvroSerializerSuite extends SparkFunSuite with SharedSparkContext {
   }
 
   test("uses schema fingerprint to decrease message size") {
-    val genericSerFull = new GenericAvroSerializer(conf.getAvroSchema,
-      CompressionCodec.createCodec(conf))
+    val genericSerFull = new GenericAvroSerializer(conf.getAvroSchema)
 
     val output = new Output(new ByteArrayOutputStream())
 
@@ -69,8 +66,7 @@ class GenericAvroSerializerSuite extends SparkFunSuite with SharedSparkContext {
     val normalLength = output.total - beginningNormalPosition
 
     conf.registerAvroSchemas(schema)
-    val genericSerFinger = new GenericAvroSerializer(conf.getAvroSchema,
-      CompressionCodec.createCodec(conf))
+    val genericSerFinger = new GenericAvroSerializer(conf.getAvroSchema)
     val beginningFingerprintPosition = output.total()
     genericSerFinger.serializeDatum(record, output)
     val fingerprintLength = output.total - beginningFingerprintPosition
@@ -79,8 +75,7 @@ class GenericAvroSerializerSuite extends SparkFunSuite with SharedSparkContext {
   }
 
   test("caches previously seen schemas") {
-    val genericSer = new GenericAvroSerializer(conf.getAvroSchema,
-      CompressionCodec.createCodec(conf))
+    val genericSer = new GenericAvroSerializer(conf.getAvroSchema)
     val compressedSchema = genericSer.compress(schema)
     val decompressedScheam = genericSer.decompress(ByteBuffer.wrap(compressedSchema))
 

--- a/core/src/test/scala/org/apache/spark/serializer/GenericAvroSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/GenericAvroSerializerSuite.scala
@@ -17,13 +17,13 @@
 
 package org.apache.spark.serializer
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream, OutputStream}
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 import java.nio.ByteBuffer
 
 import com.esotericsoftware.kryo.io.{Output, Input}
-import org.apache.avro.generic.GenericData.Record
 import org.apache.avro.{SchemaBuilder, Schema}
-import org.apache.spark.io.CompressionCodec
+import org.apache.avro.generic.GenericData.Record
+
 import org.apache.spark.{SparkFunSuite, SharedSparkContext}
 
 class GenericAvroSerializerSuite extends SparkFunSuite with SharedSparkContext {

--- a/core/src/test/scala/org/apache/spark/serializer/GenericAvroSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/GenericAvroSerializerSuite.scala
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.serializer
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, OutputStream}
+
+import com.esotericsoftware.kryo.io.{Output, Input}
+import org.apache.avro.generic.GenericData.Record
+import org.apache.avro.{SchemaBuilder, Schema}
+import org.apache.spark.{SparkFunSuite, SharedSparkContext}
+
+class GenericAvroSerializerSuite extends SparkFunSuite with SharedSparkContext {
+  conf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+
+  val schema : Schema = SchemaBuilder
+    .record("testRecord").fields()
+    .requiredString("data")
+    .endRecord()
+  val record = new Record(schema)
+  record.put("data", "test data")
+
+  test("schema compression and decompression") {
+    val genericSer = new GenericAvroSerializer(conf)
+    val compressor = genericSer.compressor()
+    val decompessor = genericSer.decompressor()
+
+    assert(schema === decompessor.compose(compressor)(schema))
+  }
+
+  test("record serialization and deserialization") {
+    val genericSer = new GenericAvroSerializer(conf)
+    val serializer = genericSer.serialize()
+    val deserializer = genericSer.deserialize()
+
+    val outputStream = new ByteArrayOutputStream()
+    val output = new Output(outputStream)
+    serializer(record, output)
+    output.flush()
+    output.close()
+
+    val input = new Input(new ByteArrayInputStream(outputStream.toByteArray))
+    assert(deserializer(input) === record)
+  }
+
+  test("uses schema fingerprint to decrease message size") {
+    val genericSer = new GenericAvroSerializer(conf)
+    val serializer = genericSer.serialize()
+    val output = new Output(new ByteArrayOutputStream())
+
+    val beginningNormalPosition = output.total()
+    serializer(record, output)
+    output.flush()
+    val normalLength = output.total - beginningNormalPosition
+
+    conf.registerAvroSchema(Array(schema))
+    val beginningFingerprintPosition = output.total()
+    serializer(record, output)
+    val fingerprintLength = output.total - beginningFingerprintPosition
+
+    assert(fingerprintLength < normalLength)
+  }
+
+  test("caches previously seen schemas") {
+    val genericSer = new GenericAvroSerializer(conf)
+    val compressor = genericSer.compressor()
+    val decompressor = genericSer.decompressor()
+    val compressedSchema = compressor(schema)
+
+    assert(compressedSchema.eq(compressor(schema)))
+    assert(decompressor(compressedSchema).eq(decompressor(compressedSchema)))
+  }
+}

--- a/core/src/test/scala/org/apache/spark/serializer/GenericAvroSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/GenericAvroSerializerSuite.scala
@@ -23,7 +23,6 @@ import java.nio.ByteBuffer
 import com.esotericsoftware.kryo.io.{Output, Input}
 import org.apache.avro.{SchemaBuilder, Schema}
 import org.apache.avro.generic.GenericData.Record
-import org.apache.spark.io.CompressionCodec
 
 import org.apache.spark.{SparkFunSuite, SharedSparkContext}
 

--- a/core/src/test/scala/org/apache/spark/serializer/GenericAvroSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/GenericAvroSerializerSuite.scala
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer
 import com.esotericsoftware.kryo.io.{Output, Input}
 import org.apache.avro.generic.GenericData.Record
 import org.apache.avro.{SchemaBuilder, Schema}
+import org.apache.spark.io.CompressionCodec
 import org.apache.spark.{SparkFunSuite, SharedSparkContext}
 
 class GenericAvroSerializerSuite extends SparkFunSuite with SharedSparkContext {


### PR DESCRIPTION
Added a custom Kryo serializer for generic Avro records to reduce the network IO
involved during a shuffle. This compresses the schema and allows for users to
register their schemas ahead of time to further reduce traffic.

Currently Kryo tries to use its default serializer for generic Records, which will include
a lot of unneeded data in each record.
