### PR TITLE
[SPARK-8603] [sparkR] In windows, Incorrect file seperator passed to Java and Scripts from R

### DIFF
--- a/R/pkg/R/client.R
+++ b/R/pkg/R/client.R
@@ -73,7 +73,6 @@ generateSparkSubmitArgs <- function(args, sparkHome, jars, sparkSubmitOpts, pack
 launchBackend <- function(args, sparkHome, jars, sparkSubmitOpts, packages) {
   sparkSubmitBin <- determineSparkSubmitBin()
   if (sparkHome != "") {
-    
     fileSeperator  <- determinefileSeperator()    
     sparkSubmitBin <- file.path(sparkHome, "bin", sparkSubmitBin, fileSeperator)
   } else {

--- a/R/pkg/R/client.R
+++ b/R/pkg/R/client.R
@@ -73,8 +73,9 @@ generateSparkSubmitArgs <- function(args, sparkHome, jars, sparkSubmitOpts, pack
 launchBackend <- function(args, sparkHome, jars, sparkSubmitOpts, packages) {
   sparkSubmitBin <- determineSparkSubmitBin()
   if (sparkHome != "") {
+    
     fileSeperator  <- determinefileSeperator()    
-    sparkSubmitBin <- file.path(sparkHome, "bin", sparkSubmitBinName, fileSeperator)
+    sparkSubmitBin <- file.path(sparkHome, "bin", sparkSubmitBin, fileSeperator)
   } else {
     sparkSubmitBin <- sparkSubmitBinName
   }

--- a/R/pkg/R/client.R
+++ b/R/pkg/R/client.R
@@ -71,10 +71,10 @@ generateSparkSubmitArgs <- function(args, sparkHome, jars, sparkSubmitOpts, pack
 }
 
 launchBackend <- function(args, sparkHome, jars, sparkSubmitOpts, packages) {
-  sparkSubmitBin <- determineSparkSubmitBin()
+  sparkSubmitBinName <- determineSparkSubmitBin()
   if (sparkHome != "") {
     fileSeperator  <- determinefileSeperator()    
-    sparkSubmitBin <- file.path(sparkHome, "bin", sparkSubmitBin, fileSeperator)
+    sparkSubmitBin <- file.path(sparkHome, "bin", sparkSubmitBinName, fileSeperator)
   } else {
     sparkSubmitBin <- sparkSubmitBinName
   }

--- a/R/pkg/R/client.R
+++ b/R/pkg/R/client.R
@@ -52,7 +52,7 @@ determinefileSeperator <- function() {
     } else {
 #      .Platform$file.sep contains "/" for windows too    
 #      http://www.inside-r.org/r-doc/base/file.path    
-         fileSeperator <- "\\"  
+       fileSeperator <- "\\"  
     }
  fileSeperator  
 }

--- a/R/pkg/R/client.R
+++ b/R/pkg/R/client.R
@@ -74,7 +74,7 @@ launchBackend <- function(args, sparkHome, jars, sparkSubmitOpts, packages) {
   sparkSubmitBinName <- determineSparkSubmitBin()
   if (sparkHome != "") {
     fileSeperator  <- determinefileSeperator()    
-    sparkSubmitBin <- file.path(sparkHome, "bin", sparkSubmitBinName, fileSeperator)
+    sparkSubmitBin <- file.path(sparkHome, "bin", sparkSubmitBinName, fsep = fileSeperator)
   } else {
     sparkSubmitBin <- sparkSubmitBinName
   }

--- a/R/pkg/R/client.R
+++ b/R/pkg/R/client.R
@@ -43,6 +43,20 @@ determineSparkSubmitBin <- function() {
   sparkSubmitBinName
 }
 
+# R supports both file separator in the file path (Unix : / and Windows: \) irrespective of the operating system
+# but when passing file path to Java or script program, it has to be converted according to operating system
+
+determinefileSeperator <- function() {
+  if (.Platform$OS.type == "unix") {
+    fileSeperator <- .Platform$file.sep    
+    } else {
+#      .Platform$file.sep contains "/" for windows too    
+#      http://www.inside-r.org/r-doc/base/file.path    
+         fileSeperator <- "\\"  
+    }
+ fileSeperator  
+}
+
 generateSparkSubmitArgs <- function(args, sparkHome, jars, sparkSubmitOpts, packages) {
   if (jars != "") {
     jars <- paste("--jars", jars)
@@ -59,7 +73,8 @@ generateSparkSubmitArgs <- function(args, sparkHome, jars, sparkSubmitOpts, pack
 launchBackend <- function(args, sparkHome, jars, sparkSubmitOpts, packages) {
   sparkSubmitBin <- determineSparkSubmitBin()
   if (sparkHome != "") {
-    sparkSubmitBin <- file.path(sparkHome, "bin", sparkSubmitBinName)
+    fileSeperator  <- determinefileSeperator()    
+    sparkSubmitBin <- file.path(sparkHome, "bin", sparkSubmitBinName, fileSeperator)
   } else {
     sparkSubmitBin <- sparkSubmitBinName
   }

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -132,7 +132,7 @@ sparkR.init <- function(
         sparkHome = sparkHome,
         jars = jars,
         sparkSubmitOpts = Sys.getenv("SPARKR_SUBMIT_ARGS", "sparkr-shell"),
-        sparkPackages = sparkPackages)
+        packages = sparkPackages)
     # wait atmost 100 seconds for JVM to launch
     wait <- 0.1
     for (i in 1:25) {

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -132,7 +132,7 @@ sparkR.init <- function(
         sparkHome = sparkHome,
         jars = jars,
         sparkSubmitOpts = Sys.getenv("SPARKR_SUBMIT_ARGS", "sparkr-shell"),
-        packages = sparkPackages)
+        packages = sparkPackages )
     # wait atmost 100 seconds for JVM to launch
     wait <- 0.1
     for (i in 1:25) {


### PR DESCRIPTION
[SPARK-8603] [sparkR] In windows, Incorrect file seperator passed to Java and Scripts from R

Issue 1:
R supports both file separator in the file path (Unix : / and Windows: ) irrespective of the operating system but when passing file path to Java or script program, it has to be converted according to operating system

issue 2: launchBackend function signature missmatch
