### PR TITLE
[SPARK-8048] Partitionning of an RDD with 0 partition shouldn't yield empty outer join

### DIFF
--- a/core/src/main/scala/org/apache/spark/Partitioner.scala
+++ b/core/src/main/scala/org/apache/spark/Partitioner.scala
@@ -57,7 +57,7 @@ object Partitioner {
   def defaultPartitioner(rdd: RDD[_], others: RDD[_]*): Partitioner = {
     val bySize = (Seq(rdd) ++ others).sortBy(_.partitions.size).reverse
     for (r <- bySize if r.partitioner.isDefined) {
-      return r.partitioner.get
+      if (r.partitions.size > 0) return r.partitioner.get
     }
     if (rdd.context.conf.contains("spark.default.parallelism")) {
       new HashPartitioner(rdd.context.defaultParallelism)

--- a/core/src/main/scala/org/apache/spark/Partitioner.scala
+++ b/core/src/main/scala/org/apache/spark/Partitioner.scala
@@ -56,8 +56,8 @@ object Partitioner {
    */
   def defaultPartitioner(rdd: RDD[_], others: RDD[_]*): Partitioner = {
     val bySize = (Seq(rdd) ++ others).sortBy(_.partitions.size).reverse
-    for (r <- bySize if r.partitioner.isDefined) {
-      if (r.partitions.size > 0) return r.partitioner.get
+    for (r <- bySize if r.partitioner.isDefined && r.partitions.nonEmpty) {
+      return r.partitioner.get
     }
     if (rdd.context.conf.contains("spark.default.parallelism")) {
       new HashPartitioner(rdd.context.defaultParallelism)

--- a/core/src/main/scala/org/apache/spark/Partitioner.scala
+++ b/core/src/main/scala/org/apache/spark/Partitioner.scala
@@ -56,9 +56,10 @@ object Partitioner {
    */
   def defaultPartitioner(rdd: RDD[_], others: RDD[_]*): Partitioner = {
     val bySize = (Seq(rdd) ++ others).sortBy(_.partitions.size).reverse
-    for (r <- bySize if r.partitioner.isDefined && r.partitions.nonEmpty) {
-      return r.partitioner.get
-    }
+    for {
+      r <- bySize
+      partitioner <- r.partitioner if r.partitions.nonEmpty
+    } return partitioner
     if (rdd.context.conf.contains("spark.default.parallelism")) {
       new HashPartitioner(rdd.context.defaultParallelism)
     } else {

--- a/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
@@ -229,14 +229,25 @@ class RDDSuite extends SparkFunSuite with SharedSparkContext {
     }
     assert(thrown.getMessage.contains("empty"))
 
+    def testEmptyRDD(emptyKv: RDD[Tuple2[Int,Int]], rdd : RDD[Tuple2[Int,Int]])
+    {
+      assert(rdd.join(emptyKv).collect().size === 0)
+      assert(rdd.rightOuterJoin(emptyKv).collect().size === 0)
+      assert(rdd.leftOuterJoin(emptyKv).collect().size === 2)
+      assert(rdd.fullOuterJoin(emptyKv).collect().size === 2)
+      assert(rdd.cogroup(emptyKv).collect().size === 2)
+      assert(rdd.union(emptyKv).collect().size === 2)
+
+    }
+
     val emptyKv = new EmptyRDD[(Int, Int)](sc)
     val rdd = sc.parallelize(1 to 2, 2).map(x => (x, x))
-    assert(rdd.join(emptyKv).collect().size === 0)
-    assert(rdd.rightOuterJoin(emptyKv).collect().size === 0)
-    assert(rdd.leftOuterJoin(emptyKv).collect().size === 2)
-    assert(rdd.fullOuterJoin(emptyKv).collect().size === 2)
-    assert(rdd.cogroup(emptyKv).collect().size === 2)
-    assert(rdd.union(emptyKv).collect().size === 2)
+    testEmptyRDD(emptyKv,rdd)
+
+    // Regression test for SPARK-8048. Zero partitioned RDD should behave similar to emptyRDD.
+    val zeroPartitionRDD = sc.parallelize(List[Tuple2[Int,Int]]()).
+          partitionBy(new HashPartitioner(0))
+    testEmptyRDD(zeroPartitionRDD,rdd)
   }
 
   test("repartitioned RDDs") {

--- a/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
@@ -229,7 +229,7 @@ class RDDSuite extends SparkFunSuite with SharedSparkContext {
     }
     assert(thrown.getMessage.contains("empty"))
 
-    def testEmptyRDD(emptyKv: RDD[Tuple2[Int,Int]], rdd : RDD[Tuple2[Int,Int]])
+    def testEmptyRDD(emptyKv: RDD[Tuple2[Int, Int]], rdd : RDD[Tuple2[Int, Int]])
     {
       assert(rdd.join(emptyKv).collect().size === 0)
       assert(rdd.rightOuterJoin(emptyKv).collect().size === 0)
@@ -242,12 +242,12 @@ class RDDSuite extends SparkFunSuite with SharedSparkContext {
 
     val emptyKv = new EmptyRDD[(Int, Int)](sc)
     val rdd = sc.parallelize(1 to 2, 2).map(x => (x, x))
-    testEmptyRDD(emptyKv,rdd)
+    testEmptyRDD(emptyKv, rdd)
 
     // Regression test for SPARK-8048. Zero partitioned RDD should behave similar to emptyRDD.
-    val zeroPartitionRDD = sc.parallelize(List[Tuple2[Int,Int]]()).
+    val zeroPartitionRDD = sc.parallelize(List[Tuple2[Int, Int]]()).
           partitionBy(new HashPartitioner(0))
-    testEmptyRDD(zeroPartitionRDD,rdd)
+    testEmptyRDD(zeroPartitionRDD, rdd)
   }
 
   test("repartitioned RDDs") {


### PR DESCRIPTION
The defaultPartitioner method in org.apache.spark.Partitioner.scala selects the explicitly defined partitioner as the default partitioner, otherwise it selects the partitioner which has more number of partition. 

Introduced an additional check to select the explicitly defined partitioner only when number of partitions are > 0. This would avoid operators creating null result set
