### PR TITLE
[SPARK-8405][WebUI] Show executor logs on Web UI when Yarn log aggregation is enabled

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -438,7 +438,7 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
     _ui =
       if (conf.getBoolean("spark.ui.enabled", true)) {
         Some(SparkUI.createLiveUI(this, _conf, listenerBus, _jobProgressListener,
-          _env.securityManager, appName, startTime = startTime))
+          _env.securityManager, appName, applicationId, startTime = startTime))
       } else {
         // For tests, do not enable the UI
         None

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -151,7 +151,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
           val ui = {
             val conf = this.conf.clone()
             val appSecManager = new SecurityManager(conf)
-            SparkUI.createHistoryUI(conf, replayBus, appSecManager, appId,
+            SparkUI.createHistoryUI(conf, replayBus, appSecManager, appId, appId,
               HistoryServer.getAttemptURI(appId, attempt.attemptId), attempt.startTime)
             // Do not call ui.bind() to avoid creating a new server for each application
           }

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -787,7 +787,7 @@ private[master] class Master(
       val logInput = EventLoggingListener.openEventLog(new Path(eventLogFile), fs)
       val replayBus = new ReplayListenerBus()
       val ui = SparkUI.createHistoryUI(new SparkConf, replayBus, new SecurityManager(conf),
-        appName + status, HistoryServer.UI_PATH_PREFIX + s"/${app.id}", app.startTime)
+        appName + status, app.id, HistoryServer.UI_PATH_PREFIX + s"/${app.id}", app.startTime)
       val maybeTruncated = eventLogFile.endsWith(EventLoggingListener.IN_PROGRESS)
       try {
         replayBus.replay(logInput, eventLogFile, maybeTruncated)

--- a/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
@@ -140,7 +140,7 @@ private[spark] object SparkUI {
       securityManager: SecurityManager,
       appName: String,
       appId: String,
-      startTime: Long): SparkUI =  {
+      startTime: Long): SparkUI = {
     create(Some(sc), conf, listenerBus, securityManager, appName, appId,
       jobProgressListener = Some(jobProgressListener), startTime = startTime)
   }

--- a/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
@@ -45,8 +45,10 @@ private[spark] class SparkUI private (
     val storageListener: StorageListener,
     val operationGraphListener: RDDOperationGraphListener,
     var appName: String,
+    val appId: String,
     val basePath: String,
-    val startTime: Long)
+    val startTime: Long,
+    val isHistoryUI: Boolean)
   extends WebUI(securityManager, SparkUI.getUIPort(conf), conf, basePath, "SparkUI")
   with Logging
   with UIRoot {
@@ -137,8 +139,9 @@ private[spark] object SparkUI {
       jobProgressListener: JobProgressListener,
       securityManager: SecurityManager,
       appName: String,
-      startTime: Long): SparkUI = {
-    create(Some(sc), conf, listenerBus, securityManager, appName,
+      appId: String,
+      startTime: Long): SparkUI =  {
+    create(Some(sc), conf, listenerBus, securityManager, appName, appId,
       jobProgressListener = Some(jobProgressListener), startTime = startTime)
   }
 
@@ -147,9 +150,11 @@ private[spark] object SparkUI {
       listenerBus: SparkListenerBus,
       securityManager: SecurityManager,
       appName: String,
+      appId: String,
       basePath: String,
       startTime: Long): SparkUI = {
-    create(None, conf, listenerBus, securityManager, appName, basePath, startTime = startTime)
+    create(None, conf, listenerBus, securityManager, appName, appId, basePath,
+      startTime = startTime, isHistoryUI = true)
   }
 
   /**
@@ -165,9 +170,11 @@ private[spark] object SparkUI {
       listenerBus: SparkListenerBus,
       securityManager: SecurityManager,
       appName: String,
+      appId: String,
       basePath: String = "",
       jobProgressListener: Option[JobProgressListener] = None,
-      startTime: Long): SparkUI = {
+      startTime: Long,
+      isHistoryUI: Boolean = false): SparkUI = {
 
     val _jobProgressListener: JobProgressListener = jobProgressListener.getOrElse {
       val listener = new JobProgressListener(conf)
@@ -189,6 +196,6 @@ private[spark] object SparkUI {
 
     new SparkUI(sc, conf, securityManager, environmentListener, storageStatusListener,
       executorsListener, _jobProgressListener, storageListener, operationGraphListener,
-      appName, basePath, startTime)
+      appName, appId, basePath, startTime, isHistoryUI)
   }
 }

--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsPage.scala
@@ -50,6 +50,7 @@ private[ui] class ExecutorsPage(
     threadDumpEnabled: Boolean)
   extends WebUIPage("") {
   private val listener = parent.listener
+  private val isHistoryUI = parent.isHistoryUI
 
   def render(request: HttpServletRequest): Seq[Node] = {
     val storageStatusList = listener.storageStatusList
@@ -100,6 +101,11 @@ private[ui] class ExecutorsPage(
               {Utils.bytesToString(memUsed)} Used
               ({Utils.bytesToString(maxMem)} Total) </li>
             <li><strong>Disk:</strong> {Utils.bytesToString(diskUsed)} Used </li>
+            {
+              if (isHistoryUI) {
+                <li><a href="logPage">Aggregated Logs</a></li>
+              }
+            }
           </ul>
         </div>
       </div>

--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsPage.scala
@@ -90,8 +90,12 @@ private[ui] class ExecutorsPage(
               Shuffle Write
             </span>
           </th>
-          {if ((!isHistoryUI && nonAggregatedLogsExist) || (isHistoryUI && logsExist))
-            <th class="sorttable_nosort">Logs</th> else Seq.empty
+          {
+            if ((!isHistoryUI && nonAggregatedLogsExist) || (isHistoryUI && logsExist)) {
+              <th class="sorttable_nosort">Logs</th>
+            } else {
+              Seq.empty
+            }
           }
           {if (threadDumpEnabled) <th class="sorttable_nosort">Thread Dump</th> else Seq.empty}
         </thead>

--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsPage.scala
@@ -20,8 +20,6 @@ package org.apache.spark.ui.exec
 import java.net.URLEncoder
 import javax.servlet.http.HttpServletRequest
 
-import org.apache.spark.Logging
-
 import scala.xml.Node
 
 import org.apache.spark.status.api.v1.ExecutorSummary
@@ -50,10 +48,10 @@ private[ui] case class ExecutorSummaryInfo(
 private[ui] class ExecutorsPage(
     parent: ExecutorsTab,
     threadDumpEnabled: Boolean)
-  extends WebUIPage("") with Logging {
+  extends WebUIPage("") {
   private val listener = parent.listener
   private val isHistoryUI = parent.isHistoryUI
-  private val aggregationLogPrefix = "aggregated_"
+  private val aggregatedLogPrefix = "aggregated_"
 
   def render(request: HttpServletRequest): Seq[Node] = {
     val storageStatusList = listener.storageStatusList
@@ -64,9 +62,9 @@ private[ui] class ExecutorsPage(
       ExecutorsPage.getExecInfo(listener, statusId)
     val execInfoSorted = execInfo.sortBy(_.id)
     val aggregatedLogsExist = execInfo.filter(
-      _.executorLogs.filter(_._1.startsWith(aggregationLogPrefix)).nonEmpty).nonEmpty
+      _.executorLogs.filter(_._1.startsWith(aggregatedLogPrefix)).nonEmpty).nonEmpty
     val nonAggregatedLogsExist = execInfo.filter(
-      _.executorLogs.filter(!_._1.startsWith(aggregationLogPrefix)).nonEmpty).nonEmpty
+      _.executorLogs.filter(!_._1.startsWith(aggregatedLogPrefix)).nonEmpty).nonEmpty
     val logsExist = aggregatedLogsExist || nonAggregatedLogsExist
 
     val execTable =
@@ -123,7 +121,8 @@ private[ui] class ExecutorsPage(
   }
 
   /** Render an HTML row representing an executor */
-  private def execRow(info: ExecutorSummary,
+  private def execRow(
+      info: ExecutorSummary,
       aggregatedLogsExist: Boolean,
       nonAggregatedLogsExist: Boolean): Seq[Node] = {
     val maximumMemory = info.maxMemory
@@ -160,11 +159,11 @@ private[ui] class ExecutorsPage(
         if (isHistoryUI && aggregatedLogsExist) {
           <td>
             {
-              info.executorLogs.filter(_._1.startsWith(aggregationLogPrefix)).map {
+              info.executorLogs.filter(_._1.startsWith(aggregatedLogPrefix)).map {
                 case (logName, logUrl) =>
                   <div>
                     <a href={logUrl}>
-                      {logName.substring(aggregationLogPrefix.length)}
+                      {logName.substring(aggregatedLogPrefix.length)}
                     </a>
                   </div>
               }
@@ -173,7 +172,7 @@ private[ui] class ExecutorsPage(
         } else if (nonAggregatedLogsExist) {
           <td>
             {
-              info.executorLogs.filter(!_._1.startsWith(aggregationLogPrefix)).map {
+              info.executorLogs.filter(!_._1.startsWith(aggregatedLogPrefix)).map {
                 case (logName, logUrl) =>
                   <div>
                     <a href={logUrl}>

--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsTab.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsTab.scala
@@ -29,13 +29,17 @@ import org.apache.spark.ui.jobs.UIData.ExecutorUIData
 private[ui] class ExecutorsTab(parent: SparkUI) extends SparkUITab(parent, "executors") {
   val listener = parent.executorsListener
   val sc = parent.sc
+  val isHistoryUI = parent.isHistoryUI
   val threadDumpEnabled =
     sc.isDefined && parent.conf.getBoolean("spark.ui.threadDumpsEnabled", true)
 
   attachPage(new ExecutorsPage(this, threadDumpEnabled))
+  attachPage(new LogPage(this))
   if (threadDumpEnabled) {
     attachPage(new ExecutorThreadDumpPage(this))
   }
+
+  def appId = parent.appId
 }
 
 /**

--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsTab.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsTab.scala
@@ -29,6 +29,7 @@ import org.apache.spark.ui.jobs.UIData.ExecutorUIData
 private[ui] class ExecutorsTab(parent: SparkUI) extends SparkUITab(parent, "executors") {
   val listener = parent.executorsListener
   val sc = parent.sc
+  val conf = parent.conf
   val isHistoryUI = parent.isHistoryUI
   val threadDumpEnabled =
     sc.isDefined && parent.conf.getBoolean("spark.ui.threadDumpsEnabled", true)

--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsTab.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsTab.scala
@@ -30,6 +30,7 @@ private[ui] class ExecutorsTab(parent: SparkUI) extends SparkUITab(parent, "exec
   val listener = parent.executorsListener
   val sc = parent.sc
   val conf = parent.conf
+  val appId = parent.appId
   val isHistoryUI = parent.isHistoryUI
   val threadDumpEnabled =
     sc.isDefined && parent.conf.getBoolean("spark.ui.threadDumpsEnabled", true)
@@ -39,8 +40,6 @@ private[ui] class ExecutorsTab(parent: SparkUI) extends SparkUITab(parent, "exec
   if (threadDumpEnabled) {
     attachPage(new ExecutorThreadDumpPage(this))
   }
-
-  def appId = parent.appId
 }
 
 /**

--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsTab.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsTab.scala
@@ -19,14 +19,15 @@ package org.apache.spark.ui.exec
 
 import scala.collection.mutable.HashMap
 
-import org.apache.spark.{ExceptionFailure, SparkContext}
+import org.apache.spark.{Logging, ExceptionFailure, SparkContext}
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.scheduler._
 import org.apache.spark.storage.{StorageStatus, StorageStatusListener}
-import org.apache.spark.ui.{SparkUI, SparkUITab}
+import org.apache.spark.ui.{WebUIPage, SparkUI, SparkUITab}
 import org.apache.spark.ui.jobs.UIData.ExecutorUIData
 
-private[ui] class ExecutorsTab(parent: SparkUI) extends SparkUITab(parent, "executors") {
+private[spark] class ExecutorsTab(parent: SparkUI) extends SparkUITab(parent, "executors")
+  with Logging {
   val listener = parent.executorsListener
   val sc = parent.sc
   val conf = parent.conf
@@ -36,7 +37,17 @@ private[ui] class ExecutorsTab(parent: SparkUI) extends SparkUITab(parent, "exec
     sc.isDefined && parent.conf.getBoolean("spark.ui.threadDumpsEnabled", true)
 
   attachPage(new ExecutorsPage(this, threadDumpEnabled))
-  attachPage(new LogPage(this))
+  try {
+    val clazz = Class.forName("org.apache.spark.deploy.yarn.LogPage")
+    val cons = clazz.getConstructor(classOf[ExecutorsTab])
+    val logPage = cons.newInstance(this).asInstanceOf[WebUIPage]
+    attachPage(logPage)
+    logDebug("Attach yarn log page in ExecutorTab successfully.")
+  } catch {
+    case e: Exception => {
+      logDebug("There is no yarn log page to attach in ExecutorTab.")
+    }
+  }
   if (threadDumpEnabled) {
     attachPage(new ExecutorThreadDumpPage(this))
   }

--- a/core/src/main/scala/org/apache/spark/ui/exec/LogPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/LogPage.scala
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ui.exec
+
+import java.io.File
+import javax.servlet.http.HttpServletRequest
+
+import org.apache.spark.Logging
+import org.apache.spark.ui.{UIUtils, WebUIPage}
+import org.apache.spark.util.Utils
+
+import scala.xml.Node
+import scala.sys.process._
+
+
+private[ui] class LogPage(
+    parent: ExecutorsTab)
+  extends WebUIPage("logPage") with Logging {
+
+  def renderLog(request: HttpServletRequest): String = {
+    val defaultBytes = 100 * 1024
+    val appId = parent.appId
+    val offset = Option(request.getParameter("offset")).map(_.toLong)
+    val byteLength = Option(request.getParameter("byteLength")).map(_.toInt).getOrElse(defaultBytes)
+
+    val logPath = s"/tmp/$appId.log"
+
+    val (logText, startByte, endByte, logLength) = getLog(logPath, offset, byteLength)
+    val pre = s"==== Bytes $startByte-$endByte of $logLength of $logPath ====\n"
+    pre + logText
+  }
+
+
+  def render(request: HttpServletRequest): Seq[Node] = {
+    val defaultBytes = 100 * 1024
+    val appId = parent.appId
+    val offset = Option(request.getParameter("offset")).map(_.toLong)
+    val byteLength = Option(request.getParameter("byteLength")).map(_.toInt).getOrElse(defaultBytes)
+
+    val logPath = s"/tmp/$appId.log"
+
+    val (logText, startByte, endByte, logLength) = getLog(logPath, offset, byteLength)
+    val range = <span>Bytes {startByte.toString} - {endByte.toString} of {logLength}</span>
+
+    val backButton =
+      if (startByte > 0) {
+        <a href={"?appId=%s&offset=%s&byteLength=%s"
+          .format(appId, math.max(startByte - byteLength, 0), byteLength)}>
+          <button type="button" class="btn btn-default">
+            Previous {Utils.bytesToString(math.min(byteLength, startByte))}
+          </button>
+        </a>
+      } else {
+        <button type="button" class="btn btn-default" disabled="disabled">
+          Previous 0 B
+        </button>
+      }
+
+    val nextButton =
+      if (endByte < logLength) {
+        <a href={"?appId=%s&offset=%s&byteLength=%s".
+          format(appId, endByte, byteLength)}>
+          <button type="button" class="btn btn-default">
+            Next {Utils.bytesToString(math.min(byteLength, logLength - endByte))}
+          </button>
+        </a>
+      } else {
+        <button type="button" class="btn btn-default" disabled="disabled">
+          Next 0 B
+        </button>
+      }
+
+    val content =
+      <html>
+        <body>
+          <div>
+            <div style="float:left; margin-right:10px">{backButton}</div>
+            <div style="float:left;">{range}</div>
+            <div style="float:right; margin-left:10px">{nextButton}</div>
+          </div>
+          <br />
+          <div style="height:500px; overflow:auto; padding:5px;">
+            <pre>{logText}</pre>
+          </div>
+        </body>
+      </html>
+    UIUtils.basicSparkPage(content, "Aggregated log page for " + appId)
+  }
+
+  /** Get the part of the log files given the offset and desired length of bytes */
+  private def getLog(
+    filePath: String,
+    offsetOption: Option[Long],
+    byteLength: Int
+  ): (String, Long, Long, Long) = {
+    try {
+      var file = new File(filePath)
+      if (!file.exists()) {
+        (s"yarn logs -applicationId ${parent.appId}"  #> new File(filePath)) !
+          ProcessLogger(line => logInfo("ProcessLogger: " + line))
+        file = new File(filePath)
+      }
+
+      val offset = offsetOption.getOrElse(file.length - byteLength)
+      val startIndex = {
+        if (offset < 0) {
+          0L
+        } else if (offset > file.length) {
+          file.length
+        } else {
+          offset
+        }
+      }
+      val endIndex = math.min(startIndex + byteLength, file.length)
+      logDebug(s"Getting log from $startIndex to $endIndex")
+      val logText = Utils.offsetBytes(Seq(file), startIndex, endIndex)
+      logDebug(s"Got log of length ${logText.length} bytes")
+      (logText, startIndex, endIndex, file.length)
+    } catch {
+      case e: Exception =>
+        logError(s"Error getting log $filePath ", e)
+        ("The log does not exist. Please make sure log aggregation is enabled in Yarn mode", 0, 0, 0)
+    }
+  }
+
+}

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
@@ -300,11 +300,17 @@ class ExecutorRunnable(
     // Add log urls
     sys.env.get("SPARK_USER").foreach { user =>
       val containerId = ConverterUtils.toString(container.getId)
+      val nodeAddress = container.getNodeId.toString
       val address = container.getNodeHttpAddress
       val baseUrl = s"$httpScheme$address/node/containerlogs/$containerId/$user"
 
       env("SPARK_LOG_URL_STDERR") = s"$baseUrl/stderr?start=-4096"
       env("SPARK_LOG_URL_STDOUT") = s"$baseUrl/stdout?start=-4096"
+
+      if (yarnConf.getBoolean(YarnConfiguration.LOG_AGGREGATION_ENABLED, false)) {
+        env("SPARK_LOG_URL_AGGREGATED_LOGS") =
+          s"logPage?containerId=$containerId&nodeAddress=$nodeAddress&appOwner=$user"
+      }
     }
 
     System.getenv().filterKeys(_.startsWith("SPARK")).foreach { case (k, v) => env(k) = v }

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
@@ -308,8 +308,10 @@ class ExecutorRunnable(
       env("SPARK_LOG_URL_STDOUT") = s"$baseUrl/stdout?start=-4096"
 
       if (yarnConf.getBoolean(YarnConfiguration.LOG_AGGREGATION_ENABLED, false)) {
-        env("SPARK_LOG_URL_AGGREGATED_LOGS") =
+        val aggregatedLogBaseUrl =
           s"logPage?containerId=$containerId&nodeAddress=$nodeAddress&appOwner=$user"
+        env("SPARK_LOG_URL_AGGREGATED_STDERR") = s"$aggregatedLogBaseUrl&logType=stderr"
+        env("SPARK_LOG_URL_AGGREGATED_STDOUT") = s"$aggregatedLogBaseUrl&logType=stdout"
       }
     }
 

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/LogPage.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/LogPage.scala
@@ -51,8 +51,8 @@ private[spark] class LogPage(parent: ExecutorsTab) extends WebUIPage("logPage") 
 
     val (logText, startByte, endByte, logLength) = getLog(
       appId, containerId, nodeAddress, appOwner, logType, offset, byteLength)
-    val params = s"containerId=$containerId&nodeAddress=$nodeAddress&appOwner=$appOwner" +
-      s"&logType=$logType"
+    val params =
+      s"containerId=$containerId&nodeAddress=$nodeAddress&appOwner=$appOwner&logType=$logType"
 
     val range = <span>Bytes {startByte.toString} - {endByte.toString} of {logLength}</span>
 

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/LogPage.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/LogPage.scala
@@ -15,23 +15,24 @@
  * limitations under the License.
  */
 
-package org.apache.spark.ui.exec
+package org.apache.spark.deploy.yarn
 
-import java.io.DataInputStream
+import java.io.{FileNotFoundException, DataInputStream}
 import javax.servlet.http.HttpServletRequest
 
 import org.apache.hadoop.fs.{FileContext, Path}
 import org.apache.hadoop.yarn.conf.YarnConfiguration
-import org.apache.hadoop.yarn.logaggregation.AggregatedLogFormat.LogKey
 import org.apache.hadoop.yarn.logaggregation.AggregatedLogFormat
+import org.apache.hadoop.yarn.logaggregation.AggregatedLogFormat.LogKey
 import org.apache.spark.Logging
 import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.ui.exec.ExecutorsTab
 import org.apache.spark.ui.{UIUtils, WebUIPage}
 import org.apache.spark.util.Utils
 
 import scala.xml.Node
 
-private[ui] class LogPage(parent: ExecutorsTab) extends WebUIPage("logPage") with Logging {
+private[spark] class LogPage(parent: ExecutorsTab) extends WebUIPage("logPage") with Logging {
 
   def render(request: HttpServletRequest): Seq[Node] = {
     val defaultBytes = 100 * 1024
@@ -205,6 +206,7 @@ private[ui] class LogPage(parent: ExecutorsTab) extends WebUIPage("logPage") wit
         return thisFile.getPath
       }
     }
-    null
+    throw new FileNotFoundException(
+      s"Log file for node $nodeAddress does not exist under ${qualifiedLogDir.toString}.")
   }
 }

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/LogPage.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/LogPage.scala
@@ -158,7 +158,8 @@ private[spark] class LogPage(parent: ExecutorsTab) extends WebUIPage("logPage") 
     } catch {
       case e: Exception =>
         logError("Error getting log ", e)
-        ("The log does not exist. Please make sure log aggregation is enabled and finished", 0, 0, 0)
+        ("The log does not exist. Please make sure log aggregation is enabled and finished",
+          0, 0, 0)
     } finally {
       if (reader != null) {
         reader.close()

--- a/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClusterSchedulerBackend.scala
+++ b/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClusterSchedulerBackend.scala
@@ -112,12 +112,29 @@ private[spark] class YarnClusterSchedulerBackend(
             YarnConfiguration.YARN_HTTP_POLICY_DEFAULT
           )
           val user = Utils.getCurrentUserName()
+          val nodeAddress = report.getNodeId.toString
           val httpScheme = if (yarnHttpPolicy == "HTTPS_ONLY") "https://" else "http://"
           val baseUrl = s"$httpScheme$httpAddress/node/containerlogs/$containerId/$user"
+          val aggregatedLogsUrl =
+            s"logPage?containerId=$containerId&nodeAddress=$nodeAddress&appOwner=$user"
           logDebug(s"Base URL for logs: $baseUrl")
-          driverLogs = Some(Map(
-            "stderr" -> s"$baseUrl/stderr?start=-4096",
-            "stdout" -> s"$baseUrl/stdout?start=-4096"))
+          logDebug(s"Aggregated logs URL: $aggregatedLogsUrl")
+
+          driverLogs = Some(
+            Map("stderr" -> s"$baseUrl/stderr?start=0", "stdout" -> s"$baseUrl/stdout?start=0"))
+
+          driverLogs = {
+            if (yarnConf.getBoolean(YarnConfiguration.LOG_AGGREGATION_ENABLED, false)) {
+              Some(Map(
+                "stderr" -> s"$baseUrl/stderr?start=-4096",
+                "stdout" -> s"$baseUrl/stdout?start=-4096",
+                "aggregated_logs" -> aggregatedLogsUrl))
+            } else {
+              Some(Map(
+                "stderr" -> s"$baseUrl/stderr?start=-4096",
+                "stdout" -> s"$baseUrl/stdout?start=-4096"))
+            }
+          }
         }
       }
     } catch {

--- a/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClusterSchedulerBackend.scala
+++ b/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClusterSchedulerBackend.scala
@@ -115,20 +115,20 @@ private[spark] class YarnClusterSchedulerBackend(
           val nodeAddress = report.getNodeId.toString
           val httpScheme = if (yarnHttpPolicy == "HTTPS_ONLY") "https://" else "http://"
           val baseUrl = s"$httpScheme$httpAddress/node/containerlogs/$containerId/$user"
-          val aggregatedLogsUrl =
-            s"logPage?containerId=$containerId&nodeAddress=$nodeAddress&appOwner=$user"
           logDebug(s"Base URL for logs: $baseUrl")
-          logDebug(s"Aggregated logs URL: $aggregatedLogsUrl")
 
           driverLogs = Some(
             Map("stderr" -> s"$baseUrl/stderr?start=0", "stdout" -> s"$baseUrl/stdout?start=0"))
 
           driverLogs = {
             if (yarnConf.getBoolean(YarnConfiguration.LOG_AGGREGATION_ENABLED, false)) {
+              val aggregatedLogBaseUrl =
+                s"logPage?containerId=$containerId&nodeAddress=$nodeAddress&appOwner=$user"
               Some(Map(
                 "stderr" -> s"$baseUrl/stderr?start=-4096",
                 "stdout" -> s"$baseUrl/stdout?start=-4096",
-                "aggregated_logs" -> aggregatedLogsUrl))
+                "aggregated_stderr" -> s"$aggregatedLogBaseUrl&logType=stderr",
+                "aggregated_stdout" -> s"$aggregatedLogBaseUrl&logType=stdout"))
             } else {
               Some(Map(
                 "stderr" -> s"$baseUrl/stderr?start=-4096",

--- a/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClusterSchedulerBackend.scala
+++ b/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClusterSchedulerBackend.scala
@@ -117,9 +117,6 @@ private[spark] class YarnClusterSchedulerBackend(
           val baseUrl = s"$httpScheme$httpAddress/node/containerlogs/$containerId/$user"
           logDebug(s"Base URL for logs: $baseUrl")
 
-          driverLogs = Some(
-            Map("stderr" -> s"$baseUrl/stderr?start=0", "stdout" -> s"$baseUrl/stdout?start=0"))
-
           driverLogs = {
             if (yarnConf.getBoolean(YarnConfiguration.LOG_AGGREGATION_ENABLED, false)) {
               val aggregatedLogBaseUrl =


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-8405
When running Spark application in Yarn mode and Yarn log aggregation is enabled, customer is not able to view executor logs on the history server Web UI. The only way for customer to view the logs is through the Yarn command "yarn logs -applicationId <appId>".

An screenshot of the error is attached in the Jira. When you click an executor’s log link on the Spark history server, you’ll see the error if Yarn log aggregation is enabled. The log URL redirects user to the node manager’s UI. This works if the logs are located on that node. But since log aggregation is enabled, the local logs are deleted once log aggregation is completed.

The logs should be available through the web UIs just like other Hadoop components like MapReduce. For security reasons, end users may not be able to log into the nodes and run the yarn logs -applicationId command. The web UIs can be viewable and exposed through the firewall if necessary.
