### PR TITLE
[SPARK-8656][WebUI] Fix the webUI and JSON API number is not synced

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/JsonProtocol.scala
@@ -77,7 +77,7 @@ private[deploy] object JsonProtocol {
 
   def writeMasterState(obj: MasterStateResponse): JObject = {
     ("url" -> obj.uri) ~
-    ("workers" -> obj.workers.filter(_.isAlive()).toList.map(writeWorkerInfo)) ~
+    ("workers" -> obj.workers.toList.map(writeWorkerInfo)) ~
     ("cores" -> obj.workers.filter(_.isAlive()).map(_.cores).sum) ~
     ("coresused" -> obj.workers.filter(_.isAlive()).map(_.coresUsed).sum) ~
     ("memory" -> obj.workers.filter(_.isAlive()).map(_.memory).sum) ~

--- a/core/src/main/scala/org/apache/spark/deploy/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/JsonProtocol.scala
@@ -77,11 +77,11 @@ private[deploy] object JsonProtocol {
 
   def writeMasterState(obj: MasterStateResponse): JObject = {
     ("url" -> obj.uri) ~
-    ("workers" -> obj.workers.toList.map(writeWorkerInfo)) ~
-    ("cores" -> obj.workers.map(_.cores).sum) ~
-    ("coresused" -> obj.workers.map(_.coresUsed).sum) ~
-    ("memory" -> obj.workers.map(_.memory).sum) ~
-    ("memoryused" -> obj.workers.map(_.memoryUsed).sum) ~
+    ("workers" -> obj.workers.filter(_.isAlive()).toList.map(writeWorkerInfo)) ~
+    ("cores" -> obj.workers.filter(_.isAlive()).map(_.cores).sum) ~
+    ("coresused" -> obj.workers.filter(_.isAlive()).map(_.coresUsed).sum) ~
+    ("memory" -> obj.workers.filter(_.isAlive()).map(_.memory).sum) ~
+    ("memoryused" -> obj.workers.filter(_.isAlive()).map(_.memoryUsed).sum) ~
     ("activeapps" -> obj.activeApps.toList.map(writeApplicationInfo)) ~
     ("completedapps" -> obj.completedApps.toList.map(writeApplicationInfo)) ~
     ("activedrivers" -> obj.activeDrivers.toList.map(writeDriverInfo)) ~

--- a/core/src/main/scala/org/apache/spark/deploy/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/JsonProtocol.scala
@@ -76,12 +76,13 @@ private[deploy] object JsonProtocol {
   }
 
   def writeMasterState(obj: MasterStateResponse): JObject = {
+    val alive_workers = obj.workers.filter(_.isAlive())
     ("url" -> obj.uri) ~
     ("workers" -> obj.workers.toList.map(writeWorkerInfo)) ~
-    ("cores" -> obj.workers.filter(_.isAlive()).map(_.cores).sum) ~
-    ("coresused" -> obj.workers.filter(_.isAlive()).map(_.coresUsed).sum) ~
-    ("memory" -> obj.workers.filter(_.isAlive()).map(_.memory).sum) ~
-    ("memoryused" -> obj.workers.filter(_.isAlive()).map(_.memoryUsed).sum) ~
+    ("cores" -> alive_workers.map(_.cores).sum) ~
+    ("coresused" -> alive_workers.map(_.coresUsed).sum) ~
+    ("memory" -> alive_workers.map(_.memory).sum) ~
+    ("memoryused" -> alive_workers.map(_.memoryUsed).sum) ~
     ("activeapps" -> obj.activeApps.toList.map(writeApplicationInfo)) ~
     ("completedapps" -> obj.completedApps.toList.map(writeApplicationInfo)) ~
     ("activedrivers" -> obj.activeDrivers.toList.map(writeDriverInfo)) ~

--- a/core/src/main/scala/org/apache/spark/deploy/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/JsonProtocol.scala
@@ -76,13 +76,13 @@ private[deploy] object JsonProtocol {
   }
 
   def writeMasterState(obj: MasterStateResponse): JObject = {
-    val alive_workers = obj.workers.filter(_.isAlive())
+    val aliveWorkers = obj.workers.filter(_.isAlive())
     ("url" -> obj.uri) ~
     ("workers" -> obj.workers.toList.map(writeWorkerInfo)) ~
-    ("cores" -> alive_workers.map(_.cores).sum) ~
-    ("coresused" -> alive_workers.map(_.coresUsed).sum) ~
-    ("memory" -> alive_workers.map(_.memory).sum) ~
-    ("memoryused" -> alive_workers.map(_.memoryUsed).sum) ~
+    ("cores" -> aliveWorkers.map(_.cores).sum) ~
+    ("coresused" -> aliveWorkers.map(_.coresUsed).sum) ~
+    ("memory" -> aliveWorkers.map(_.memory).sum) ~
+    ("memoryused" -> aliveWorkers.map(_.memoryUsed).sum) ~
     ("activeapps" -> obj.activeApps.toList.map(writeApplicationInfo)) ~
     ("completedapps" -> obj.completedApps.toList.map(writeApplicationInfo)) ~
     ("activedrivers" -> obj.activeDrivers.toList.map(writeDriverInfo)) ~

--- a/core/src/main/scala/org/apache/spark/deploy/master/WorkerInfo.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/WorkerInfo.scala
@@ -107,4 +107,8 @@ private[spark] class WorkerInfo(
   def setState(state: WorkerState.Value): Unit = {
     this.state = state
   }
+
+  def isAlive(): Boolean={
+    this.state == WorkerState.ALIVE
+  }
 }

--- a/core/src/main/scala/org/apache/spark/deploy/master/WorkerInfo.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/WorkerInfo.scala
@@ -108,7 +108,5 @@ private[spark] class WorkerInfo(
     this.state = state
   }
 
-  def isAlive(): Boolean={
-    this.state == WorkerState.ALIVE
-  }
+  def isAlive(): Boolean = this.state == WorkerState.ALIVE
 }


### PR DESCRIPTION
Spark standalone master web UI show "Alive Workers" total core, total used cores and "Alive workers" total memory, memory used. 
But the JSON API page "http://MASTERURL:8088/json" shows "ALL workers"  core, memory number. 
This webUI data is not sync with the JSON API.
The proper way is to sync the number with webUI and JSON API.
