### PR TITLE
[SPARK-8657] [YARN] Fail to upload conf archive to viewfs

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -338,7 +338,8 @@ private[spark] class Client(
     createConfArchive().foreach { file =>
       require(addDistributedUri(file.toURI()))
       val destPath = copyFileToRemote(dst, new Path(file.toURI()), replication)
-      distCacheMgr.addResource(fs, hadoopConf, destPath, localResources, LocalResourceType.ARCHIVE,
+      val destFs = FileSystem.get(destPath.toUri(), hadoopConf)
+      distCacheMgr.addResource(destFs, hadoopConf, destPath, localResources, LocalResourceType.ARCHIVE,
         LOCALIZED_HADOOP_CONF_DIR, statCache, appMasterOnly = true)
     }
 


### PR DESCRIPTION
Fail to upload conf archive to viewfs in spark-1.4
JIRA Link: https://issues.apache.org/jira/browse/SPARK-8657
