### PR TITLE
[Spark-8662] SparkR Update SparkSQL Test

### DIFF
--- a/R/pkg/inst/tests/test_sparkSQL.R
+++ b/R/pkg/inst/tests/test_sparkSQL.R
@@ -19,6 +19,14 @@ library(testthat)
 
 context("SparkSQL functions")
 
+# Utility function for easily checking the values of a StructField
+checkStructField <- function(actual, expectedName, expectedType, expectedNullable) {
+  expect_equal(class(actual), "structField")
+  expect_equal(actual$name(), expectedName)
+  expect_equal(actual$dataType.toString(), expectedType)
+  expect_equal(actual$nullable(), expectedNullable)
+}
+
 # Tests for SparkSQL functions in SparkR
 
 sc <- sparkR.init()
@@ -54,11 +62,8 @@ test_that("infer types", {
                list(type = 'array', elementType = "integer", containsNull = TRUE))
   testStruct <- infer_type(list(a = 1L, b = "2"))
   expect_true(class(testStruct) == "structType")
-  expect_true(length(testStruct$fields()) == 2)
-  testSF <- testStruct$fields()[[1]]
-  expect_true(class(testSF) == "structField")
-  expect_true(testSF$name() == "a")
-  expect_true(testSF$dataType.toString() == "IntegerType")
+  checkStructField(testStruct$fields()[[1]], "a", "IntegerType", TRUE)
+  checkStructField(testStruct$fields()[[2]], "b", "StringType", TRUE)
   e <- new.env()
   assign("a", 1L, envir = e)
   expect_equal(infer_type(e),

--- a/R/pkg/inst/tests/test_sparkSQL.R
+++ b/R/pkg/inst/tests/test_sparkSQL.R
@@ -52,9 +52,13 @@ test_that("infer types", {
                list(type = 'array', elementType = "integer", containsNull = TRUE))
   expect_equal(infer_type(list(1L, 2L)),
                list(type = 'array', elementType = "integer", containsNull = TRUE))
-  expect_equal(infer_type(list(a = 1L, b = "2")),
-               structType(structField(x = "a", type = "integer", nullable = TRUE),
-                          structField(x = "b", type = "string", nullable = TRUE)))
+  testStruct <- infer_type(list(a = 1L, b = "2"))
+  expect_true(class(testStruct) == "structType")
+  expect_true(length(testStruct$fields()) == 2)
+  testSF <- testStruct$fields()[[1]]
+  expect_true(class(testSF) == "structField")
+  expect_true(testSF$name() == "a")
+  expect_true(testSF$dataType.toString() == "IntegerType")
   e <- new.env()
   assign("a", 1L, envir = e)
   expect_equal(infer_type(e),


### PR DESCRIPTION
Test `infer_type` using a more fine-grained approach rather than comparing environments. Since `all.equal`'s behavior has changed in R 3.2, the test became unpassable.

JIRA here:
https://issues.apache.org/jira/browse/SPARK-8662
