### PR TITLE
[SPARK-8669] [SQL] Fix crash with BINARY (ENUM) fields with Parquet 1.7

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/parquet/CatalystSchemaConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/parquet/CatalystSchemaConverter.scala
@@ -177,7 +177,7 @@ private[parquet] class CatalystSchemaConverter(
 
       case BINARY =>
         field.getOriginalType match {
-          case UTF8 => StringType
+          case UTF8 | ENUM => StringType
           case null if assumeBinaryIsString => StringType
           case null => BinaryType
           case DECIMAL => makeDecimalType()

--- a/sql/core/src/test/scala/org/apache/spark/sql/parquet/ParquetSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/parquet/ParquetSchemaSuite.scala
@@ -161,6 +161,14 @@ class ParquetSchemaInferenceSuite extends ParquetSchemaTest {
     """.stripMargin,
     binaryAsString = true)
 
+  testSchemaInference[Tuple1[String]](
+    "binary enum as string",
+    """
+      |message root {
+      |  optional binary _1 (ENUM);
+      |}
+    """.stripMargin)
+
   testSchemaInference[Tuple1[Seq[Int]]](
     "non-nullable array - non-standard",
     """


### PR DESCRIPTION
Patch to fix crash with BINARY fields with ENUM original types.
