### PR TITLE
[SPARK-8649] [BUILD] Mapr repository is not defined properly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,7 @@
     <repository>
       <id>mapr-repo</id>
       <name>MapR Repository</name>
-      <url>http://repository.mapr.com/maven</url>
+      <url>http://repository.mapr.com/maven/</url>
       <releases>
         <enabled>true</enabled>
       </releases>


### PR DESCRIPTION
The previous commiter on this part was @pwendell 

The previous url gives 404, the new one seems to be OK.

This patch is added under the Apache License 2.0.

The JIRA link: https://issues.apache.org/jira/browse/SPARK-8649
