### PR TITLE
[SPARK-8694][WebUI]Defer executing drawTaskAssignmentTimeline until page loaded to avoid to freeze the page

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -659,8 +659,12 @@ private[ui] class StagePage(parent: StagesTab) extends WebUIPage("stage") {
       {TIMELINE_LEGEND}
     </div> ++
     <script type="text/javascript">
-      {Unparsed(s"drawTaskAssignmentTimeline(" +
-      s"$groupArrayStr, $executorsArrayStr, $minLaunchTime, $maxFinishTime)")}
+      {
+        Unparsed(s"""$$(function() {
+          drawTaskAssignmentTimeline(
+            $groupArrayStr, $executorsArrayStr, $minLaunchTime, $maxFinishTime)
+        })""")
+      }
     </script>
   }
 


### PR DESCRIPTION
When there are massive tasks in the stage page (such as, running `sc.parallelize(1 to 100000, 10000).count()`), `Event Timeline` needs 15+ seconds to render the graph (drawTaskAssignmentTimeline) in my environment. The page is unresponsive until the graph is ready.

However, since `Event Timeline` is hidden by default, we can defer `drawTaskAssignmentTimeline` until page loaded to avoid freezing the page. So that the user can view the page while rendering `Event Timeline` in the background.

This PR puts `drawTaskAssignmentTimeline` into `$(function(){})` to avoid blocking loading page.
