### PR TITLE
[SPARK-8691][WebUI]Enable GZip by default for Web UI

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -146,6 +146,11 @@
       <artifactId>jetty-servlet</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlets</artifactId>
+      <scope>compile</scope>
+    </dependency>
     <!-- Because we mark jetty as provided and shade it, its dependency
          orbit is ignored, so we explicitly list it here (see SPARK-5557).-->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -384,6 +384,12 @@
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-servlets</artifactId>
+        <version>${jetty.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util</artifactId>
         <version>${jetty.version}</version>
         <scope>provided</scope>
@@ -1442,6 +1448,7 @@
               <include>org.eclipse.jetty:jetty-http</include>
               <include>org.eclipse.jetty:jetty-continuation</include>
               <include>org.eclipse.jetty:jetty-servlet</include>
+              <include>org.eclipse.jetty:jetty-servlets</include>
               <include>org.eclipse.jetty:jetty-plus</include>
               <include>org.eclipse.jetty:jetty-security</include>
               <include>org.eclipse.jetty:jetty-util</include>


### PR DESCRIPTION
When there are massive tasks in the stage page (such as, running `sc.parallelize(1 to 100000, 10000).count()`), the size of the stage page is large. Enabling GZip can reduce the size significantly. For example, in my environment, the size of a stage page with 10000 tasks reduces from 9.8MB to 138KB.

I also added a configuration so that if the user wants to use an alternative `Filter`, he can turn off it.
