### PR TITLE
[SPARK-8443][SQL] Split GenerateMutableProjection Codegen due to JVM Code Size Limits

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateMutableProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateMutableProjection.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.catalyst.expressions.codegen
 
 import org.apache.spark.sql.catalyst.expressions._
 
+import scala.collection.mutable.ArrayBuffer
+
 // MutableProjection is not accessible in Java
 abstract class BaseMutableProjection extends MutableProjection
 
@@ -46,19 +48,18 @@ object GenerateMutableProjection extends CodeGenerator[Seq[Expression], () => Mu
             ${ctx.setColumn("mutableRow", e.dataType, i, evaluationCode.primitive)};
         """
     }
-    val projectionBlocks = projectionCode.foldLeft(List.empty[String]) {
-      (acc, code) =>
-        acc match {
-          case Nil => List(code)
-          case head::tail =>
-            // code size limit is 64kb and each char takes less or equal to 2 bytes
-            if (head.length < 32 * 1000) {
-              s"$head\n$code"::tail
-            } else {
-              code::acc
-            }
-        }
+    // collect projections into blocks as function has 64kb codesize limit in JVM
+    val projectionBlocks = new ArrayBuffer[String]()
+    val blockBuilder = new StringBuilder()
+    for (projection <- projectionCode) {
+      if (blockBuilder.length > 16 * 1000) {
+        projectionBlocks.append(blockBuilder.toString())
+        blockBuilder.clear()
       }
+      blockBuilder.append(projection)
+    }
+    projectionBlocks.append(blockBuilder.toString())
+
     val (projectionFuns, projectionCalls) = {
       // inline execution if codesize limit was not broken
       if (projectionBlocks.length == 1) {
@@ -72,13 +73,15 @@ object GenerateMutableProjection extends CodeGenerator[Seq[Expression], () => Mu
                |}
              """.stripMargin
           }.mkString,
-          ((projectionBlocks.length - 1) to 0 by -1).map(i => s"apply$i(i);").mkString("\n")
+          projectionBlocks.indices.map(i => s"apply$i(i);").mkString("\n")
         )
       }
     }
+
     val mutableStates = ctx.mutableStates.map { case (javaType, variableName, initialValue) =>
       s"private $javaType $variableName = $initialValue;"
     }.mkString("\n      ")
+
     val code = s"""
       public Object generate($exprType[] expr) {
         return new SpecificProjection(expr);

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.expressions.codegen._
 /**
  * Additional tests for code generation.
  */
-class CodeGenerationSuite extends SparkFunSuite {
+class CodeGenerationSuite extends SparkFunSuite with ExpressionEvalHelper {
 
   test("multithreaded eval") {
     import scala.concurrent._
@@ -43,7 +43,15 @@ class CodeGenerationSuite extends SparkFunSuite {
     futures.foreach(Await.result(_, 10.seconds))
   }
 
-  test("SPARK-8443: code size limit") {
-    GenerateMutableProjection.generate(List.fill(5000)(EqualTo(Literal(1), Literal(1))))
+  test("SPARK-8443: split wide projections into blocks due to JVM code size limit") {
+    val length = 5000
+    val expressions = List.fill(length)(EqualTo(Literal(1), Literal(1)))
+    val plan = GenerateMutableProjection.generate(expressions)()
+    val actual = plan(new GenericMutableRow(length)).toSeq
+    val expected = Seq.fill(length)(true)
+
+    if (!checkResult(actual, expected)) {
+      fail(s"Incorrect Evaluation: expressions: $expressions, actual: $actual, expected: $expected")
+    }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
@@ -42,4 +42,8 @@ class CodeGenerationSuite extends SparkFunSuite {
 
     futures.foreach(Await.result(_, 10.seconds))
   }
+
+  test("SPARK-8443: code size limit") {
+    GenerateMutableProjection.generate(List.fill(5000)(EqualTo(Literal(1), Literal(1))))
+  }
 }


### PR DESCRIPTION
By grouping projection calls into multiple apply function, we are able to push the number of projections codegen can handle from ~1k to ~60k. I have set the unit test to test against 5k as 60k took 15s for the unit test to complete.
