### PR TITLE
[SPARK-8592] [CORE] CoarseGrainedExecutorBackend: Cannot register with driver => NPE

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -66,7 +66,10 @@ private[spark] class CoarseGrainedExecutorBackend(
       case Success(msg) => Utils.tryLogNonFatalError {
         Option(self).foreach(_.send(msg)) // msg must be RegisteredExecutor
       }
-      case Failure(e) => logError(s"Cannot register with driver: $driverUrl", e)
+      case Failure(e) => {
+        logError(s"Cannot register with driver: $driverUrl", e)
+        System.exit(1)
+      }
     }(ThreadUtils.sameThread)
   }
 


### PR DESCRIPTION
Look detail of this issue at [SPARK-8592](https://issues.apache.org/jira/browse/SPARK-8592)

**CoarseGrainedExecutorBackend** should exit when **RegisterExecutor** failed
