### PR TITLE
[SPARK-8355] [SQL] Python DataFrameReader/Writer should mirror Scala

### DIFF
--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -73,7 +73,7 @@ class DataFrameReader(object):
         self._jreader = self._jreader.schema(jschema)
         return self
 
-    @since(1.4)
+    @since(1.5)
     def option(self, key, value):
         """Adds an input option for the underlying data source.
         """
@@ -242,7 +242,7 @@ class DataFrameWriter(object):
         self._jwrite = self._jwrite.format(source)
         return self
 
-    @since(1.4)
+    @since(1.5)
     def option(self, key, value):
         """Adds an output option for the underlying data source.
         """

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -74,6 +74,13 @@ class DataFrameReader(object):
         return self
 
     @since(1.4)
+    def option(self, key, value):
+        """Adds an input option for the underlying data source.
+        """
+        self._jreader = self._jreader.option(key, value)
+        return self
+
+    @since(1.4)
     def options(self, **options):
         """Adds input options for the underlying data source.
         """
@@ -233,6 +240,13 @@ class DataFrameWriter(object):
         >>> df.write.format('json').save(os.path.join(tempfile.mkdtemp(), 'data'))
         """
         self._jwrite = self._jwrite.format(source)
+        return self
+
+    @since(1.4)
+    def option(self, key, value):
+        """Adds an output option for the underlying data source.
+        """
+        self._jwrite = self._jwrite.option(key, value)
         return self
 
     @since(1.4)

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -564,6 +564,7 @@ class SQLTests(ReusedPySparkTestCase):
         self.assertEqual(sorted(df.collect()), sorted(actual.collect()))
 
         df.write.mode("overwrite").options(noUse="this options will not be used in save.")\
+                .option("noUse", "this option will not be used in save.")\
                 .format("json").save(path=tmpPath)
         actual =\
             self.sqlCtx.read.format("json")\


### PR DESCRIPTION
I compared PySpark DataFrameReader/Writer against Scala ones. `Option` function is missing in both reader and writer, but the rest seems to all match.

I added `Option` to reader and writer and updated the `pyspark-sql` test.
