### PR TITLE
[SPARK-8374] [YARN] Job frequently hangs after YARN preemption

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -397,10 +397,12 @@ private[yarn] class YarnAllocator(
           completedContainer.getState,
           completedContainer.getExitStatus))
         // Hadoop 2.2.X added a ContainerExitStatus we should switch to use
-        // there are some exit status' we shouldn't necessarily count against us, but for
-        // now I think its ok as none of the containers are expected to exit
+        // there are some exit status' we shouldn't necessarily count against us.
+        // So we should keep targetNumExecutors == numExecutorsRunning 
+        // to avoid application starve because YARN scheduler PREEMPTED
         if (completedContainer.getExitStatus == ContainerExitStatus.PREEMPTED) {
           logInfo("Container preempted: " + containerId)
+          numExecutorsRunning -= 1
         } else if (completedContainer.getExitStatus == -103) { // vmem limit exceeded
           logWarning(memLimitExceededLogMessage(
             completedContainer.getDiagnostics,

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -399,7 +399,7 @@ private[yarn] class YarnAllocator(
         // Hadoop 2.2.X added a ContainerExitStatus we should switch to use
         // there are some exit status' we shouldn't necessarily count against us.
         // So we should keep targetNumExecutors == numExecutorsRunning 
-        // to avoid application starve because YARN scheduler PREEMPTED
+        // to avoid application starve because YARN scheduler preemption
         if (completedContainer.getExitStatus == ContainerExitStatus.PREEMPTED) {
           logInfo("Container preempted: " + containerId)
           numExecutorsRunning -= 1


### PR DESCRIPTION
Issue description [SPARK-8374](https://issues.apache.org/jira/browse/SPARK-8374)

Application starve because YARN scheduler preemption,we should to keep Running containers number
Do not think about the resource ,that is Yarn scheduler's job .
