### PR TITLE
[SPARK-8705][WebUI]Don't display rects when totalExecutionTime is 0

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -570,6 +570,35 @@ private[ui] class StagePage(parent: StagesTab) extends WebUIPage("stage") {
 
         val index = taskInfo.index
         val attempt = taskInfo.attempt
+
+        val svgTag =
+          if (totalExecutionTime == 0) {
+            """<svg class="task-assignment-timeline-duration-bar"></svg>"""
+          }
+          else {
+           s"""<svg class="task-assignment-timeline-duration-bar">
+                 |<rect class="scheduler-delay-proportion"
+                   |x="$schedulerDelayProportionPos%" y="0px" height="26px"
+                   |width="$schedulerDelayProportion%""></rect>
+                 |<rect class="deserialization-time-proportion"
+                   |x="$deserializationTimeProportionPos%" y="0px" height="26px"
+                   |width="$deserializationTimeProportion%"></rect>
+                 |<rect class="shuffle-read-time-proportion"
+                   |x="$shuffleReadTimeProportionPos%" y="0px" height="26px"
+                   |width="$shuffleReadTimeProportion%"></rect>
+                 |<rect class="executor-runtime-proportion"
+                   |x="$executorRuntimeProportionPos%" y="0px" height="26px"
+                   |width="$executorComputingTimeProportion%"></rect>
+                 |<rect class="shuffle-write-time-proportion"
+                   |x="$shuffleWriteTimeProportionPos%" y="0px" height="26px"
+                   |width="$shuffleWriteTimeProportion%"></rect>
+                 |<rect class="serialization-time-proportion"
+                   |x="$serializationTimeProportionPos%" y="0px" height="26px"
+                   |width="$serializationTimeProportion%"></rect>
+                 |<rect class="getting-result-time-proportion"
+                   |x="$gettingResultTimeProportionPos%" y="0px" height="26px"
+                   |width="$gettingResultTimeProportion%"></rect></svg>""".stripMargin
+          }
         val timelineObject =
           s"""
              |{
@@ -595,28 +624,7 @@ private[ui] class StagePage(parent: StagesTab) extends WebUIPage("stage") {
                  |<br>Shuffle Write Time: ${UIUtils.formatDuration(shuffleWriteTime)}
                  |<br>Result Serialization Time: ${UIUtils.formatDuration(serializationTime)}
                  |<br>Getting Result Time: ${UIUtils.formatDuration(gettingResultTime)}">
-                 |<svg class="task-assignment-timeline-duration-bar">
-                 |<rect class="scheduler-delay-proportion"
-                   |x="$schedulerDelayProportionPos%" y="0px" height="26px"
-                   |width="$schedulerDelayProportion%""></rect>
-                 |<rect class="deserialization-time-proportion"
-                   |x="$deserializationTimeProportionPos%" y="0px" height="26px"
-                   |width="$deserializationTimeProportion%"></rect>
-                 |<rect class="shuffle-read-time-proportion"
-                   |x="$shuffleReadTimeProportionPos%" y="0px" height="26px"
-                   |width="$shuffleReadTimeProportion%"></rect>
-                 |<rect class="executor-runtime-proportion"
-                   |x="$executorRuntimeProportionPos%" y="0px" height="26px"
-                   |width="$executorComputingTimeProportion%"></rect>
-                 |<rect class="shuffle-write-time-proportion"
-                   |x="$shuffleWriteTimeProportionPos%" y="0px" height="26px"
-                   |width="$shuffleWriteTimeProportion%"></rect>
-                 |<rect class="serialization-time-proportion"
-                   |x="$serializationTimeProportionPos%" y="0px" height="26px"
-                   |width="$serializationTimeProportion%"></rect>
-                 |<rect class="getting-result-time-proportion"
-                   |x="$gettingResultTimeProportionPos%" y="0px" height="26px"
-                   |width="$gettingResultTimeProportion%"></rect></svg>',
+                 |$svgTag',
                |'start': new Date($launchTime),
                |'end': new Date($finishTime)
              |}

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -573,13 +573,13 @@ private[ui] class StagePage(parent: StagesTab) extends WebUIPage("stage") {
 
         val svgTag =
           if (totalExecutionTime == 0) {
+            // SPARK-8705: Avoid invalid attribute error in JavaScript if execution time is 0
             """<svg class="task-assignment-timeline-duration-bar"></svg>"""
-          }
-          else {
+          } else {
            s"""<svg class="task-assignment-timeline-duration-bar">
                  |<rect class="scheduler-delay-proportion"
                    |x="$schedulerDelayProportionPos%" y="0px" height="26px"
-                   |width="$schedulerDelayProportion%""></rect>
+                   |width="$schedulerDelayProportion%"></rect>
                  |<rect class="deserialization-time-proportion"
                    |x="$deserializationTimeProportionPos%" y="0px" height="26px"
                    |width="$deserializationTimeProportion%"></rect>


### PR DESCRIPTION
Because `System.currentTimeMillis()` is not accurate for tasks that only need several milliseconds, sometimes `totalExecutionTime` in `makeTimeline` will be 0. If `totalExecutionTime` is 0, there will the following error in the console.

![screen shot 2015-06-29 at 7 08 55 pm](https://cloud.githubusercontent.com/assets/1000778/8406776/5cd38e04-1e92-11e5-89f2-0c5134fe4b6b.png)

This PR fixes it by using an empty svg tag when `totalExecutionTime` is 0. This is a screenshot for a task that its totalExecutionTime is 0 after fixing it.

![screen shot 2015-06-30 at 12 26 52 am](https://cloud.githubusercontent.com/assets/1000778/8412896/7b33b4be-1ebf-11e5-9100-d6d656af3747.png)
