### PR TITLE
[SPARK-8720] [CORE] [HOTFIX] Escapes `/*' in the comment

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -824,8 +824,8 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
    * }}}
    *
    * @note Small files are preferred, large file is also allowable, but may cause bad performance.
-   * @note On some filesystems, `.../path/*` can be a more efficient way to read all files in a directory
-   *       rather than `.../path/` or `.../path`
+   * @note On some filesystems, <code>.../path/&#42;</code> can be a more efficient way to read all
+   *       files in a directory rather than `.../path/` or `.../path`
    *
    * @param minPartitions A suggestion value of the minimal splitting number for input data.
    */
@@ -874,8 +874,8 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
    * }}}
    *
    * @note Small files are preferred; very large files may cause bad performance.
-   * @note On some filesystems, `.../path/*` can be a more efficient way to read all files in a directory
-   *       rather than `.../path/` or `.../path`
+   * @note On some filesystems, <code>.../path/&#42;</code> can be a more efficient way to read all
+   *       files in a directory rather than `.../path/` or `.../path`
    *
    * @param minPartitions A suggestion value of the minimal splitting number for input data.
    */


### PR DESCRIPTION
The `/*` in the comment starts another unclosed comment block.
