### PR TITLE
[SPARK-8450][SQL]If column type is BigDecimal, the column should be converted to Decimal.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetTableSupport.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetTableSupport.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.parquet
 
+import java.math.{BigDecimal => JavaBigDecimal}
 import java.nio.{ByteOrder, ByteBuffer}
 import java.util.{HashMap => JHashMap}
 
@@ -215,7 +216,7 @@ private[parquet] class RowWriteSupport extends WriteSupport[InternalRow] with Lo
           if (d.precisionInfo == None || d.precisionInfo.get.precision > 18) {
             sys.error(s"Unsupported datatype $d, cannot write to consumer")
           }
-          writeDecimal(value.asInstanceOf[Decimal], d.precisionInfo.get.precision)
+          writeDecimal(convertDecimal(value), d.precisionInfo.get.precision)
         case _ => sys.error(s"Do not know how to writer $schema to consumer")
       }
     }
@@ -323,6 +324,12 @@ private[parquet] class RowWriteSupport extends WriteSupport[InternalRow] with Lo
     buf.putInt(julianDay)
     writer.addBinary(Binary.fromByteArray(int96buf))
   }
+
+  private[parquet] def convertDecimal(maybeDecimal: Any) = maybeDecimal match {
+    case jbd: JavaBigDecimal => Decimal(jbd)
+    case bd: BigDecimal => Decimal(bd)
+    case d: Decimal => d
+  }
 }
 
 // Optimized for non-nested rows
@@ -370,7 +377,7 @@ private[parquet] class MutableRowWriteSupport extends RowWriteSupport {
         if (d.precisionInfo == None || d.precisionInfo.get.precision > 18) {
           sys.error(s"Unsupported datatype $d, cannot write to consumer")
         }
-        writeDecimal(record(index).asInstanceOf[Decimal], d.precisionInfo.get.precision)
+        writeDecimal(convertDecimal(record(index)), d.precisionInfo.get.precision)
       case _ => sys.error(s"Unsupported datatype $ctype, cannot write to consumer")
     }
   }


### PR DESCRIPTION
### abstract

When `createDataFrame` is called(via **PySpark**), `CatalystTypeConverters` convert `Decimal` to  `java.math.BigDecimal`.
see: https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala#L71

But, when `write.parque` is called, `MutableRowWriteSupport` force to cast to `Decimal`.
So, `Exception` occured.

Thus, this PR add method to convert `java.math.BigDecimal` to `Decimal`.
### issue
- [SPARK-8450 PySpark write.parquet raises Unsupported datatype DecimalType()](https://issues.apache.org/jira/browse/SPARK-8450)
