### PR TITLE
[SPARK-8552] [THRIFTSERVER] Using incorrect database in multiple sessions

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
@@ -586,8 +586,8 @@ private[sql] class SQLConf(val config: Map[String, String] = Map.empty)
   }
 
   private def getValue(key: String): Option[String] = {
-    val conf = config.get(key)
-    if (conf.isEmpty) Option(settings.get(key)) else conf
+    val conf = Option(settings.get(key))
+    if (!conf.isDefined) config.get(key) else conf
   }
 
   /**
@@ -608,7 +608,7 @@ private[sql] class SQLConf(val config: Map[String, String] = Map.empty)
    * This creates a new copy of the config properties in the form of a Map.
    */
   def getAllConfs: immutable.Map[String, String] =
-    settings.synchronized { settings.asScala.toMap ++ config }
+    settings.synchronized { config ++ settings.asScala.toMap }
 
   /**
    * Return all the configuration definitions that have been defined in [[SQLConf]]. Each

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -204,6 +204,9 @@ class SQLContext(
     override def initialValue: SQLSession = openSession()
   }
 
+  @transient
+  protected[sql] val defaultSession = createSession()
+
   protected[sql] def dialectClassName = if (conf.dialect == "sql") {
     classOf[DefaultParserDialect].getCanonicalName
   } else {
@@ -867,6 +870,7 @@ class SQLContext(
     val session = createSession()
     session.conf.setConf(properties)
     setSession(session)
+    session
   }
 
   protected[sql] def currentSession(): SQLSession = {
@@ -881,9 +885,8 @@ class SQLContext(
     tlSession.remove()
   }
 
-  protected[sql] def setSession(session: SQLSession): SQLSession = {
+  protected[sql] def setSession(session: SQLSession): Unit = {
     tlSession.set(session)
-    session
   }
 
   protected[sql] class SQLSession {

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -205,7 +205,7 @@ class SQLContext(
   }
 
   @transient
-  protected[sql] lazy val defaultSession = createSession()
+  protected[sql] lazy val defaultSession = openSession()
 
   protected[sql] def dialectClassName = if (conf.dialect == "sql") {
     classOf[DefaultParserDialect].getCanonicalName

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -201,11 +201,11 @@ class SQLContext(
 
   @transient
   protected[sql] val tlSession = new ThreadLocal[SQLSession]() {
-    override def initialValue: SQLSession = openSession()
+    override def initialValue: SQLSession = defaultSession
   }
 
   @transient
-  protected[sql] val defaultSession = createSession()
+  protected[sql] lazy val defaultSession = createSession()
 
   protected[sql] def dialectClassName = if (conf.dialect == "sql") {
     classOf[DefaultParserDialect].getCanonicalName

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLConfSuite.scala
@@ -37,7 +37,7 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
     // Clear the conf.
     sqlContext.conf.clear()
     // After clear, only overrideConfs used by unit test should be in the SQLConf.
-    assert(sqlContext.getAllConfs === TestSQLContext.overrideConfs)
+    assert(sqlContext.getAllConfs === sqlContext.defaultOverrides().size)
 
     sqlContext.setConf(testKey, testVal)
     assert(sqlContext.getConf(testKey) === testVal)

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLConfSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql
 
-import org.apache.spark.sql.test.{TestSQLContext, SharedSQLContext}
+import org.apache.spark.sql.test.SharedSQLContext
 
 
 class SQLConfSuite extends QueryTest with SharedSQLContext {
@@ -37,7 +37,7 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
     // Clear the conf.
     sqlContext.conf.clear()
     // After clear, only overrideConfs used by unit test should be in the SQLConf.
-    assert(sqlContext.getAllConfs === sqlContext.defaultOverrides().size)
+    assert(sqlContext.getAllConfs === sqlContext.defaultOverrides())
 
     sqlContext.setConf(testKey, testVal)
     assert(sqlContext.getConf(testKey) === testVal)

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.errors.DialectException
 import org.apache.spark.sql.execution.aggregate
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SQLTestData._
-import org.apache.spark.sql.test.{SharedSQLContext, TestSQLContext}
+import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types._
 
 /** A SQL Dialect for testing purpose, and it can not be nested type */
@@ -1025,16 +1025,17 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
     val nonexistentKey = "nonexistent"
 
     // "set" itself returns all config variables currently specified in SQLConf.
-    assert(sql("SET").collect().size === TestSQLContext.overrideConfs.size)
+    val overrides = sqlContext.defaultOverrides()
+    assert(sql("SET").collect().size === overrides.size)
     sql("SET").collect().foreach { row =>
       val key = row.getString(0)
       val value = row.getString(1)
       assert(
-        TestSQLContext.overrideConfs.contains(key),
+        overrides.contains(key),
         s"$key should exist in SQLConf.")
       assert(
-        TestSQLContext.overrideConfs(key) === value,
-        s"The value of $key should be ${TestSQLContext.overrideConfs(key)} instead of $value.")
+        overrides(key) === value,
+        s"The value of $key should be ${overrides(key)} instead of $value.")
     }
     val overrideConfs = sql("SET").collect()
 

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
@@ -20,8 +20,6 @@ package org.apache.spark.sql.hive.thriftserver
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
 
-import org.apache.hadoop.hive.ql.session.SessionState
-
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
@@ -37,7 +35,7 @@ import org.apache.spark.sql.SQLConf
 import org.apache.spark.sql.hive.HiveContext
 import org.apache.spark.sql.hive.thriftserver.ReflectionUtils._
 import org.apache.spark.sql.hive.thriftserver.ui.ThriftServerTab
-import org.apache.spark.util.{ShutdownHookManager, Utils}
+import org.apache.spark.util.ShutdownHookManager
 import org.apache.spark.{Logging, SparkContext}
 
 

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
@@ -20,6 +20,8 @@ package org.apache.spark.sql.hive.thriftserver
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
 
+import org.apache.hadoop.hive.ql.session.SessionState
+
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
@@ -82,11 +84,13 @@ object HiveThriftServer2 extends Logging {
     }
 
     try {
-      val server = new HiveThriftServer2(SparkSQLEnv.hiveContext)
-      server.init(SparkSQLEnv.hiveContext.hiveconf)
-      server.start()
+      val hiveContext = SparkSQLEnv.hiveContext
+      val server = new HiveThriftServer2(hiveContext)
+      server.init(hiveContext.hiveconf)
+      hiveContext.execute(hiveContext.hiveconf, server.start())
+
       logInfo("HiveThriftServer2 started")
-      listener = new HiveThriftServer2Listener(server, SparkSQLEnv.hiveContext.conf)
+      listener = new HiveThriftServer2Listener(server, hiveContext.conf)
       SparkSQLEnv.sparkContext.addSparkListener(listener)
       uiTab = if (SparkSQLEnv.sparkContext.getConf.getBoolean("spark.ui.enabled", true)) {
         Some(new ThriftServerTab(SparkSQLEnv.sparkContext))

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
@@ -136,12 +136,12 @@ private[hive] class SparkExecuteStatementOperation(
     }
   }
 
-  override def run(): Unit = {
+  override def runInternal(): Unit = {
     setState(OperationState.PENDING)
     setHasResultSet(true) // avoid no resultset for async run
 
     if (!runInBackground) {
-      runInternal()
+      execute()
     } else {
       val parentSessionState = SessionState.get()
       val hiveConf = getConfigForOperation()
@@ -168,13 +168,13 @@ private[hive] class SparkExecuteStatementOperation(
               Hive.set(sessionHive)
               SessionState.setCurrentSessionState(parentSessionState)
               try {
-                runInternal()
+                execute()
               } catch {
                 case e: HiveSQLException =>
                   setOperationException(e)
                   log.error("Error running hive query: ", e)
               }
-              return null
+              null
             }
           }
 
@@ -206,7 +206,7 @@ private[hive] class SparkExecuteStatementOperation(
     }
   }
 
-  override def runInternal(): Unit = {
+  private def execute(): Unit = {
     statementId = UUID.randomUUID().toString
     logInfo(s"Running query '$statement' with $statementId")
     setState(OperationState.RUNNING)

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
@@ -157,16 +157,18 @@ private[hive] class SparkExecuteStatementOperation(
           val doAsAction = new PrivilegedExceptionAction[Object]() {
             override def run(): Object = {
 
+              Hive.set(sessionHive)
+              SessionState.setCurrentSessionState(parentSessionState)
+
               // User information is part of the metastore client member in Hive
               hiveContext.setSession(currentSqlSession)
+
               // Always use the latest class loader provided by executionHive's state.
               val executionHiveClassLoader =
                 hiveContext.executionHive.state.getConf.getClassLoader
               sessionHive.getConf.setClassLoader(executionHiveClassLoader)
               parentSessionState.getConf.setClassLoader(executionHiveClassLoader)
 
-              Hive.set(sessionHive)
-              SessionState.setCurrentSessionState(parentSessionState)
               try {
                 execute()
               } catch {

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIService.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIService.scala
@@ -70,6 +70,30 @@ private[hive] class SparkSQLCLIService(hiveServer: HiveServer2, hiveContext: Hiv
       case _ => super.getInfo(sessionHandle, getInfoType)
     }
   }
+
+  private def withMetaContext[A](f: => A): A = hiveContext.executionMetaHive.withHiveState(f)
+
+  override def getCatalogs(sessionHandle: SessionHandle): OperationHandle =
+    withMetaContext(super.getCatalogs(sessionHandle))
+
+  override def getSchemas(sessionHandle: SessionHandle, catalogName: String, schemaName: String):
+    OperationHandle =
+    withMetaContext(super.getSchemas(sessionHandle, catalogName, schemaName))
+
+  override def getTables(sessionHandle: SessionHandle, catalogName: String, schemaName: String,
+    tableName: String, tableTypes: java.util.List[String]): OperationHandle =
+    withMetaContext(super.getTables(sessionHandle, catalogName, schemaName, tableName, tableTypes))
+
+  override def getTableTypes(sessionHandle: SessionHandle): OperationHandle =
+    withMetaContext(super.getTableTypes(sessionHandle))
+
+  override def getColumns(sessionHandle: SessionHandle, catalogName: String, schemaName: String,
+    tableName: String, columnName: String): OperationHandle =
+    withMetaContext(super.getColumns(sessionHandle, catalogName, schemaName, tableName, columnName))
+
+  override def getFunctions(sessionHandle: SessionHandle, catalogName: String, schemaName: String,
+    functionName: String): OperationHandle =
+    withMetaContext(super.getFunctions(sessionHandle, catalogName, schemaName, functionName))
 }
 
 private[thriftserver] trait ReflectedCompositeService { this: AbstractService =>

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnv.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnv.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.hive.thriftserver
 
-import java.io.PrintStream
-
 import scala.collection.JavaConverters._
 
 import org.apache.spark.scheduler.StatsReportListener
@@ -55,13 +53,8 @@ private[hive] object SparkSQLEnv extends Logging {
 
       sparkContext = new SparkContext(sparkConf)
       sparkContext.addSparkListener(new StatsReportListener())
-      hiveContext = new HiveContext(sparkContext)
-
-      hiveContext.metadataHive.setOut(new PrintStream(System.out, true, "UTF-8"))
-      hiveContext.metadataHive.setInfo(new PrintStream(System.err, true, "UTF-8"))
-      hiveContext.metadataHive.setError(new PrintStream(System.err, true, "UTF-8"))
-
-      hiveContext.setConf("spark.sql.hive.version", HiveContext.hiveExecutionVersion)
+      hiveContext = new HiveContext(sparkContext,
+        Map(("spark.sql.hive.version", HiveContext.hiveExecutionVersion)))
 
       if (log.isDebugEnabled) {
         hiveContext.hiveconf.getAllProperties.asScala.toSeq.sorted.foreach { case (k, v) =>

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/server/SparkSQLOperationManager.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/server/SparkSQLOperationManager.scala
@@ -52,4 +52,7 @@ private[thriftserver] class SparkSQLOperationManager(hiveContext: HiveContext)
       s"runInBackground=$runInBackground")
     operation
   }
+
+  override def cancelOperation (opHandle: OperationHandle): Unit = {
+  }
 }

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/server/SparkSQLOperationManager.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/server/SparkSQLOperationManager.scala
@@ -52,7 +52,4 @@ private[thriftserver] class SparkSQLOperationManager(hiveContext: HiveContext)
       s"runInBackground=$runInBackground")
     operation
   }
-
-  override def cancelOperation (opHandle: OperationHandle): Unit = {
-  }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
@@ -379,7 +379,8 @@ class HiveThriftBinaryServerSuite extends HiveThriftJdbcTest {
   }
 
   test("test add jar") {
-    withMultipleConnectionJdbcStatement(
+    // this is only for a session and should not be shared to others
+    withSingleConnectionJdbcStatement(
       {
         statement =>
           val jarFile =
@@ -492,6 +493,24 @@ abstract class HiveThriftJdbcTest extends HiveThriftServer2Test {
     } finally {
       statements.foreach(_.close())
       connections.foreach(_.close())
+    }
+  }
+
+  def withSingleConnectionJdbcStatement(fs: (Statement => Unit)*) {
+    val user = System.getProperty("user.name")
+    val connection = DriverManager.getConnection(jdbcUri, user, "")
+
+    try {
+      fs.foreach { case f =>
+        val statement = connection.createStatement()
+        try {
+          f(statement)
+        } finally {
+          statement.close()
+        }
+      }
+    } finally {
+      connection.close()
     }
   }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -194,8 +194,8 @@ class HiveContext(sc: SparkContext, optionConf: Map[String, String] = Map.empty)
         try super.withHiveState(session, f) finally {
           val sessionConf = SessionState.get().getConf
           copyConf.foreach {
-            case (key, Some(value)) => sessionConf.set(key, value)
-            case (key, None) => sessionConf.unset(key)
+            case (key, Some(value)) => sessionConf.set(key, value); execConf.set(key, value)
+            case (key, None) => sessionConf.unset(key); execConf.unset(key)
           }
         }
       }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientInterface.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientInterface.scala
@@ -91,6 +91,9 @@ private[hive] trait ClientInterface {
   /** Returns the Hive Version of this client. */
   def version: HiveVersion
 
+  /** clear internal session state or something if needed */
+  def closeSession(sessionID: Int): Unit
+
   /** Returns the configuration for the given key in the current session. */
   def getConf(key: String, defaultValue: String): String
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
@@ -53,10 +53,7 @@ import org.apache.spark.util.{CircularBuffer, Utils}
  * must use reflection after matching on `version`.
  *
  * @param version the version of hive used when pick function calls that are not compatible.
- * @param config  a collection of configuration options that will be added to the hive conf before
- *                opening the hive client.
- * @param initClassLoader the classloader used when creating the `state` field of
- *                        this ClientWrapper.
+ * @param hiveContext  hive context which will be associated with this client wrapper
  */
 private[hive] abstract class ClientWrapper(
     override val version: HiveVersion,
@@ -491,6 +488,7 @@ private[hive] abstract class ClientWrapper(
   }
 }
 
+// this uses hive embedded with spark
 class SharedWrapper(
     version: HiveVersion,
     hiveContext: HiveContext)
@@ -527,6 +525,7 @@ class SharedWrapper(
   def closeSession(sessionID: Int): Unit = { /* Nothing to be done */ }
 }
 
+// this uses isolated class loader and so hive things are not shared to outside of it
 class IsolatedWrapper(
     version: HiveVersion,
     initClassLoader: ClassLoader,
@@ -534,6 +533,7 @@ class IsolatedWrapper(
     hiveContext: HiveContext)
   extends ClientWrapper(version, hiveContext) {
 
+  // map context id to internal session state
   private val mapping: mutable.HashMap[Int, SessionState] = mutable.HashMap.empty
 
   private def newConf: HiveConf = {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
@@ -504,7 +504,7 @@ class SharedWrapper(
     val err = session.err
     session.out = new PrintStream(outputBuffer, true, "UTF-8")
     session.err = new PrintStream(outputBuffer, true, "UTF-8")
-    try f finally {
+    try super.withHiveState(session, f) finally {
       session.out = out
       session.err = err
     }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
@@ -44,7 +44,8 @@ private[hive] object IsolatedClientLoader {
       config: Map[String, String] = Map.empty,
       ivyPath: Option[String] = None,
       sharedPrefixes: Seq[String] = Seq.empty,
-      barrierPrefixes: Seq[String] = Seq.empty): IsolatedClientLoader = synchronized {
+      barrierPrefixes: Seq[String] = Seq.empty,
+      hiveContext: HiveContext): IsolatedClientLoader = synchronized {
     val resolvedVersion = hiveVersion(version)
     val files = resolvedVersions.getOrElseUpdate(resolvedVersion,
       downloadVersion(resolvedVersion, ivyPath))
@@ -53,7 +54,8 @@ private[hive] object IsolatedClientLoader {
       execJars = files,
       config = config,
       sharedPrefixes = sharedPrefixes,
-      barrierPrefixes = barrierPrefixes)
+      barrierPrefixes = barrierPrefixes,
+      hiveContext = hiveContext)
   }
 
   def hiveVersion(version: String): HiveVersion = version match {
@@ -118,7 +120,8 @@ private[hive] class IsolatedClientLoader(
     val rootClassLoader: ClassLoader = ClassLoader.getSystemClassLoader.getParent.getParent,
     val baseClassLoader: ClassLoader = Thread.currentThread().getContextClassLoader,
     val sharedPrefixes: Seq[String] = Seq.empty,
-    val barrierPrefixes: Seq[String] = Seq.empty)
+    val barrierPrefixes: Seq[String] = Seq.empty,
+    val hiveContext: HiveContext)
   extends Logging {
 
   // Check to make sure that the root classloader does not know about Hive.
@@ -141,6 +144,8 @@ private[hive] class IsolatedClientLoader(
   /** True if `name` refers to a spark class that must see specific version of Hive. */
   protected def isBarrierClass(name: String): Boolean =
     name.startsWith(classOf[ClientWrapper].getName) ||
+    name.startsWith(classOf[IsolatedWrapper].getName) ||
+    name.startsWith(classOf[SharedWrapper].getName) ||
     name.startsWith(classOf[Shim].getName) ||
     barrierPrefixes.exists(name.startsWith)
 
@@ -179,9 +184,9 @@ private[hive] class IsolatedClientLoader(
   /** The isolated client interface to Hive. */
   val client: ClientInterface = try {
     classLoader
-      .loadClass(classOf[ClientWrapper].getName)
+      .loadClass(classOf[IsolatedWrapper].getName)
       .getConstructors.head
-      .newInstance(version, config, classLoader)
+      .newInstance(version, classLoader, config, hiveContext)
       .asInstanceOf[ClientInterface]
   } catch {
     case e: InvocationTargetException =>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
@@ -133,6 +133,7 @@ private[hive] class IsolatedClientLoader(
   protected def isSharedClass(name: String): Boolean =
     name.contains("slf4j") ||
     name.contains("log4j") ||
+    name.contains("commons.logging") ||
     name.startsWith("org.apache.spark.") ||
     (name.startsWith("org.apache.hadoop.") && !name.startsWith("org.apache.hadoop.hive.")) ||
     name.startsWith("scala.") ||

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/commands.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/commands.scala
@@ -29,7 +29,6 @@ import org.apache.spark.sql.execution.datasources.{ResolvedDataSource, LogicalRe
 import org.apache.spark.sql.hive.HiveContext
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types._
-import org.apache.spark.util.Utils
 
 /**
  * Analyzes the given table in the current database to generate statistics, which will be
@@ -87,21 +86,6 @@ case class AddJar(path: String) extends RunnableCommand {
 
   override def run(sqlContext: SQLContext): Seq[Row] = {
     val hiveContext = sqlContext.asInstanceOf[HiveContext]
-    val currentClassLoader = Utils.getContextOrSparkClassLoader
-
-    // Add jar to current context
-    val jarURL = new java.io.File(path).toURI.toURL
-    val newClassLoader = new java.net.URLClassLoader(Array(jarURL), currentClassLoader)
-    Thread.currentThread.setContextClassLoader(newClassLoader)
-    // We need to explicitly set the class loader associated with the conf in executionHive's
-    // state because this class loader will be used as the context class loader of the current
-    // thread to execute any Hive command.
-    // We cannot use `org.apache.hadoop.hive.ql.metadata.Hive.get().getConf()` because Hive.get()
-    // returns the value of a thread local variable and its HiveConf may not be the HiveConf
-    // associated with `executionHive.state` (for example, HiveContext is created in one thread
-    // and then add jar is called from another thread).
-    hiveContext.executionHive.state.getConf.setClassLoader(newClassLoader)
-    // Add jar to isolated hive (metadataHive) class loader.
     hiveContext.runSqlHive(s"ADD JAR $path")
 
     // Add jar to executors

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.hive.client
 import java.io.File
 
 import org.apache.spark.sql.hive.HiveContext
+import org.apache.spark.sql.hive.test.TestHive
 import org.apache.spark.{Logging, SparkFunSuite}
 import org.apache.spark.sql.catalyst.expressions.{NamedExpression, Literal, AttributeReference, EqualTo}
 import org.apache.spark.sql.catalyst.util.quietly
@@ -51,7 +52,8 @@ class VersionsSuite extends SparkFunSuite with Logging {
   test("success sanity check") {
     val badClient = IsolatedClientLoader.forVersion(HiveContext.hiveExecutionVersion,
       buildConf(),
-      ivyPath).client
+      ivyPath,
+      hiveContext = TestHive).client
     val db = new HiveDatabase("default", "")
     badClient.createDatabase(db)
   }
@@ -81,7 +83,7 @@ class VersionsSuite extends SparkFunSuite with Logging {
   ignore("failure sanity check") {
     val e = intercept[Throwable] {
       val badClient = quietly {
-        IsolatedClientLoader.forVersion("13", buildConf(), ivyPath).client
+        IsolatedClientLoader.forVersion("13", buildConf(), ivyPath, hiveContext = TestHive).client
       }
     }
     assert(getNestedMessages(e) contains "Unknown column 'A0.OWNER_NAME' in 'field list'")
@@ -95,7 +97,7 @@ class VersionsSuite extends SparkFunSuite with Logging {
     test(s"$version: create client") {
       client = null
       System.gc() // Hack to avoid SEGV on some JVM versions.
-      client = IsolatedClientLoader.forVersion(version, buildConf(), ivyPath).client
+      client = IsolatedClientLoader.forVersion(version, buildConf(), ivyPath, hiveContext = TestHive).client
     }
 
     test(s"$version: createDatabase") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
@@ -97,7 +97,8 @@ class VersionsSuite extends SparkFunSuite with Logging {
     test(s"$version: create client") {
       client = null
       System.gc() // Hack to avoid SEGV on some JVM versions.
-      client = IsolatedClientLoader.forVersion(version, buildConf(), ivyPath, hiveContext = TestHive).client
+      client = IsolatedClientLoader.forVersion(
+        version, buildConf(), ivyPath, hiveContext = TestHive).client
     }
 
     test(s"$version: createDatabase") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -31,7 +31,6 @@ import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
 import org.apache.spark.sql.catalyst.expressions.Cast
 import org.apache.spark.sql.catalyst.plans.logical.Project
 import org.apache.spark.sql.hive._
-import org.apache.spark.sql.hive.test.TestHiveContext
 import org.apache.spark.sql.hive.test.TestHive
 import org.apache.spark.sql.hive.test.TestHive._
 
@@ -1105,7 +1104,7 @@ class HiveQuerySuite extends HiveComparisonTest with BeforeAndAfter {
 
     // "SET" itself returns all config variables currently specified in SQLConf.
     // TODO: Should we be listing the default here always? probably...
-    assert(sql("SET").collect().size === TestHiveContext.overrideConfs.size)
+    assert(sql("SET").collect().size === defaultOverrides().size)
 
     val defaults = collectResults(sql("SET"))
     assertResult(Set(testKey -> testVal)) {


### PR DESCRIPTION
Currently, metaHive in HiveContext shares single SessionState instance with all execution threads, which makes problems especially with "use" command. I've also went into this problem and spent hard time to know what has happened. This is just first try and need more tests.
