### PR TITLE
[SPARK-8739][WEB UI][Windows] A illegal character `\r` can be contained in StagePage.

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -620,7 +620,7 @@ private[ui] class StagePage(parent: StagesTab) extends WebUIPage("stage") {
                |'start': new Date($launchTime),
                |'end': new Date($finishTime)
              |}
-           |""".stripMargin.replaceAll("\n", " ")
+           |""".stripMargin.replaceAll("""[\r\n]+""", " ")
         timelineObject
       }.mkString("[", ",", "]")
 


### PR DESCRIPTION
This issue was reported by @saurfang. Thanks!

There is a following code in StagePage.scala.

```
                   |width="$serializationTimeProportion%"></rect>
                 |<rect class="getting-result-time-proportion"
                   |x="$gettingResultTimeProportionPos%" y="0px" height="26px"
                   |width="$gettingResultTimeProportion%"></rect></svg>',
               |'start': new Date($launchTime),
               |'end': new Date($finishTime)
             |}
           |""".stripMargin.replaceAll("\n", " ")
```

The last `replaceAll("\n", "")` doesn't work when we checkout and build source code on Windows and deploy on Linux.
It's because when we checkout the source code on Windows, new-line-code is replaced with `"\r\n"` and `replaceAll("\n", "")` replaces only `"\n"`.
