### PR TITLE
[SPARK-8738] [SQL] [PYSPARK] capture SQL AnalysisException in Python API

### DIFF
--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -126,11 +126,12 @@ def _load_from_socket(port, serializer):
     # On most of IPv6-ready systems, IPv6 will take precedence.
     for res in socket.getaddrinfo("localhost", port, socket.AF_UNSPEC, socket.SOCK_STREAM):
         af, socktype, proto, canonname, sa = res
+        sock = socket.socket(af, socktype, proto)
         try:
-            sock = socket.socket(af, socktype, proto)
             sock.settimeout(3)
             sock.connect(sa)
         except socket.error:
+            sock.close()
             sock = None
             continue
         break

--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -33,6 +33,7 @@ from pyspark.sql.types import Row, StringType, StructType, _verify_type, \
     _infer_schema, _has_nulltype, _merge_type, _create_converter, _python_to_sql_converter
 from pyspark.sql.dataframe import DataFrame
 from pyspark.sql.readwriter import DataFrameReader
+from pyspark.sql.utils import install_exception_handler
 
 try:
     import pandas
@@ -96,6 +97,7 @@ class SQLContext(object):
         self._jvm = self._sc._jvm
         self._scala_SQLContext = sqlContext
         _monkey_patch_RDD(self)
+        install_exception_handler()
 
     @property
     def _ssql_ctx(self):

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -46,6 +46,7 @@ from pyspark.sql.types import UserDefinedType, _infer_type
 from pyspark.tests import ReusedPySparkTestCase
 from pyspark.sql.functions import UserDefinedFunction
 from pyspark.sql.window import Window
+from pyspark.sql.utils import AnalysisException
 
 
 class UTC(datetime.tzinfo):
@@ -846,6 +847,12 @@ class SQLTests(ReusedPySparkTestCase):
         self.assertEqual(row.name, u'Alice')
         self.assertEqual(row.age, 10)
         self.assertEqual(row.height, None)
+
+    def test_capture_analysis_exception(self):
+        self.assertRaises(AnalysisException, lambda: self.sqlCtx.sql("select abc"))
+        self.assertRaises(AnalysisException, lambda: self.df.selectExpr("a + b"))
+        # RuntimeException should not be captured
+        self.assertRaises(py4j.protocol.Py4JJavaError, lambda: self.sqlCtx.sql("abc"))
 
 
 class HiveContextSQLTests(ReusedPySparkTestCase):

--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -20,7 +20,7 @@ import py4j
 
 class AnalysisException(Exception):
     """
-    Fail to analysis SQL query plan.
+    Failed to analyze a SQL query plan.
     """
 
 

--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -19,7 +19,9 @@ import py4j
 
 
 class AnalysisException(Exception):
-    pass
+    """
+    Fail to analysis SQL query plan.
+    """
 
 
 def capture_sql_exception(f):
@@ -35,6 +37,14 @@ def capture_sql_exception(f):
 
 
 def install_exception_handler():
+    """
+    Hook an exception handler into Py4j, which could capture some SQL exceptions in Java.
+
+    When calling Java API, it will call `get_return_value` to parse the returned object.
+    If any exception happened in JVM, the result will be Java exception object, it raise
+    py4j.protocol.Py4JJavaError. We replace the original `get_return_value` with one that
+    could capture the Java exception and throw a Python one (with the same error message).
+    """
     old_func = py4j.protocol.get_return_value
     new_func = capture_sql_exception(old_func)
     # only patch the one used in in py4j.java_gateway (call Java API)

--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -44,8 +44,11 @@ def install_exception_handler():
     If any exception happened in JVM, the result will be Java exception object, it raise
     py4j.protocol.Py4JJavaError. We replace the original `get_return_value` with one that
     could capture the Java exception and throw a Python one (with the same error message).
+
+    It's idempotent, could be called multiple times.
     """
-    old_func = py4j.protocol.get_return_value
-    new_func = capture_sql_exception(old_func)
+    original = py4j.protocol.get_return_value
+    # The original `get_return_value` is not patched, it's idempotent.
+    patched = capture_sql_exception(original)
     # only patch the one used in in py4j.java_gateway (call Java API)
-    py4j.java_gateway.get_return_value = new_func
+    py4j.java_gateway.get_return_value = patched

--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -26,7 +26,7 @@ def capture_sql_exception(f):
     def deco(*a, **kw):
         try:
             return f(*a, **kw)
-        except py4j.protocol.Py4JJavaError, e:
+        except py4j.protocol.Py4JJavaError as e:
             cls, msg = e.java_exception.toString().split(': ', 1)
             if cls == 'org.apache.spark.sql.AnalysisException':
                 raise AnalysisException(msg)

--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import py4j
+
+
+class AnalysisException(Exception):
+    pass
+
+
+def capture_sql_exception(f):
+    def deco(*a, **kw):
+        try:
+            return f(*a, **kw)
+        except py4j.protocol.Py4JJavaError, e:
+            cls, msg = e.java_exception.toString().split(': ', 1)
+            if cls == 'org.apache.spark.sql.AnalysisException':
+                raise AnalysisException(msg)
+            raise
+    return deco
+
+
+def install_exception_handler():
+    old_func = py4j.protocol.get_return_value
+    new_func = capture_sql_exception(old_func)
+    # only patch the one used in in py4j.java_gateway (call Java API)
+    py4j.java_gateway.get_return_value = new_func


### PR DESCRIPTION
Capture the AnalysisException in SQL, hide the long java stack trace, only show the error message.

cc @rxin 
