### PR TITLE
[SPARK-8647][MLlib] Potential issue with constant hashCode

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
@@ -193,7 +193,8 @@ private[spark] class MatrixUDT extends UserDefinedType[Matrix] {
     }
   }
 
-  override def hashCode(): Int = 1994
+  // see [SPARK-8647], this achieves the needed constant hash code without constant no.
+  override def hashCode(): Int = this.getClass.getName.hashCode()
 
   override def typeName: String = "matrix"
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
@@ -194,7 +194,7 @@ private[spark] class MatrixUDT extends UserDefinedType[Matrix] {
   }
 
   // see [SPARK-8647], this achieves the needed constant hash code without constant no.
-  override def hashCode(): Int = this.getClass.getName.hashCode()
+  override def hashCode(): Int = classOf[MatrixUDT].getName.hashCode()
 
   override def typeName: String = "matrix"
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
@@ -234,7 +234,8 @@ private[spark] class VectorUDT extends UserDefinedType[Vector] {
     }
   }
 
-  override def hashCode: Int = 7919
+  // see [SPARK-8647], this achieves the needed constant hash code without constant no.
+  override def hashCode(): Int = this.getClass.getName.hashCode()
 
   override def typeName: String = "vector"
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
@@ -235,7 +235,7 @@ private[spark] class VectorUDT extends UserDefinedType[Vector] {
   }
 
   // see [SPARK-8647], this achieves the needed constant hash code without constant no.
-  override def hashCode(): Int = this.getClass.getName.hashCode()
+  override def hashCode(): Int = classOf[VectorUDT].getName.hashCode()
 
   override def typeName: String = "vector"
 


### PR DESCRIPTION
I added the code, 
  // see [SPARK-8647], this achieves the needed constant hash code without constant no.
  override def hashCode(): Int = this.getClass.getName.hashCode()

does getting the constant hash code as per jira
