### PR TITLE
[SPARK-8754][YARN] YarnClientSchedulerBackend doesn't stop gracefully in failure conditions

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
+++ b/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
@@ -148,7 +148,9 @@ private[spark] class YarnClientSchedulerBackend(
    */
   override def stop() {
     assert(client != null, "Attempted to stop this scheduler before starting it!")
-    monitorThread.interrupt()
+    if (monitorThread != null) {
+      monitorThread.interrupt()
+    }
     super.stop()
     client.stop()
     logInfo("Stopped")


### PR DESCRIPTION
In YarnClientSchedulerBackend.stop(), added a check for monitorThread.
