### PR TITLE
[SPARK-8755][Streaming]Login user before reading the checkpoint file in hdfs.

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/Checkpoint.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/Checkpoint.scala
@@ -291,7 +291,7 @@ object CheckpointReader extends Logging {
       conf: SparkConf,
       hadoopConf: Configuration,
       ignoreReadError: Boolean = false): Option[Checkpoint] = {
-    loginUserIfConfExsis(conf)
+    loginUserIfConfExists(conf)
     val checkpointPath = new Path(checkpointDir)
 
     // TODO(rxin): Why is this a def?!
@@ -331,7 +331,7 @@ object CheckpointReader extends Logging {
    * If using the keytab to login user in security mode, this checkpoint application has to login
    * before reading files from hdfs.
    */
-  private def loginUserIfConfExsis(conf: SparkConf): Unit = {
+  private def loginUserIfConfExists(conf: SparkConf): Unit = {
     for(principal <- conf.getOption("spark.yarn.principal");
       keytab <- conf.getOption("spark.yarn.keytab")) {
       UserGroupInformation.loginUserFromKeytab(principal, keytab)


### PR DESCRIPTION
If the user set `spark.yarn.principal` and `spark.yarn.keytab` , he does not need `kinit` in the client machine.
But when the application was recorved from checkpoint file, it had to `kinit`, because:
The checkpoint did not use this configurations before it use a DFSClient to fetch the ckeckpoint file.

But there is a small problem, the `UserGroupInformation.loginUserFromKeytab` will be called twice in checkpoint application. Ignored it in this PR.

[Jira Address](https://issues.apache.org/jira/browse/SPARK-8755)
