### PR TITLE
[SPARK-5016][MLLib] Distribute GMM mixture components to executors

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/GaussianMixture.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/GaussianMixture.scala
@@ -140,6 +140,9 @@ class GaussianMixture private (
     // Get length of the input vectors
     val d = breezeData.first().length
 
+    // indicate whether to update mixture components on driver or distribute the computation
+    val distributeComputation = true
+
     // Determine initial weights and corresponding Gaussians.
     // If the user supplied an initial GMM, we use those values, otherwise
     // we start with uniform weights, a random mean from the data, and
@@ -171,14 +174,30 @@ class GaussianMixture private (
       // Create new distributions based on the partial assignments
       // (often referred to as the "M" step in literature)
       val sumWeights = sums.weights.sum
-      var i = 0
-      while (i < k) {
-        val mu = sums.means(i) / sums.weights(i)
-        BLAS.syr(-sums.weights(i), Vectors.fromBreeze(mu),
-          Matrices.fromBreeze(sums.sigmas(i)).asInstanceOf[DenseMatrix])
-        weights(i) = sums.weights(i) / sumWeights
-        gaussians(i) = new MultivariateGaussian(mu, sums.sigmas(i) / sums.weights(i))
-        i = i + 1
+
+      if (distributeComputation) {
+        val (ws, gs) = sc.parallelize(0 until k).map { i =>
+          val mu = sums.means(i) / sums.weights(i)
+          BLAS.syr(-sums.weights(i), Vectors.fromBreeze(mu),
+            Matrices.fromBreeze(sums.sigmas(i)).asInstanceOf[DenseMatrix])
+          val weight = sums.weights(i) / sumWeights
+          val gaussian = new MultivariateGaussian(mu, sums.sigmas(i) / sums.weights(i))
+          (weight, gaussian)
+        }.collect.unzip
+        (0 until k).foreach { i =>
+          weights(i) = ws(i)
+          gaussians(i) = gs(i)
+        }
+      } else {
+        var i = 0
+        while (i < k) {
+          val mu = sums.means(i) / sums.weights(i)
+          BLAS.syr(-sums.weights(i), Vectors.fromBreeze(mu),
+            Matrices.fromBreeze(sums.sigmas(i)).asInstanceOf[DenseMatrix])
+          weights(i) = sums.weights(i) / sumWeights
+          gaussians(i) = new MultivariateGaussian(mu, sums.sigmas(i) / sums.weights(i))
+          i = i + 1
+        }
       }
 
       llhp = llh // current becomes previous

--- a/mllib/src/test/scala/org/apache/spark/mllib/clustering/GaussianMixtureSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/clustering/GaussianMixtureSuite.scala
@@ -39,7 +39,7 @@ class GaussianMixtureSuite extends SparkFunSuite with MLlibTestSparkContext {
 
     val seeds = Array(314589, 29032897, 50181, 494821, 4660)
     seeds.foreach { seed =>
-      val gmm = new GaussianMixture().setK(1).setSeed(seed).setDistributeGaussians(false).run(data)
+      val gmm = new GaussianMixture().setK(1).setSeed(seed).run(data)
       assert(gmm.weights(0) ~== Ew absTol 1E-5)
       assert(gmm.gaussians(0).mu ~== Emu absTol 1E-5)
       assert(gmm.gaussians(0).sigma ~== Esigma absTol 1E-5)
@@ -66,7 +66,7 @@ class GaussianMixtureSuite extends SparkFunSuite with MLlibTestSparkContext {
     val gmm = new GaussianMixture()
       .setK(2)
       .setInitialModel(initialGmm)
-      .setDistributeGaussians(false).run(data)
+      .run(data)
 
     assert(gmm.weights(0) ~== Ew(0) absTol 1E-3)
     assert(gmm.weights(1) ~== Ew(1) absTol 1E-3)
@@ -91,7 +91,7 @@ class GaussianMixtureSuite extends SparkFunSuite with MLlibTestSparkContext {
 
     val seeds = Array(42, 1994, 27, 11, 0)
     seeds.foreach { seed =>
-      val gmm = new GaussianMixture().setK(1).setSeed(seed).setDistributeGaussians(false).run(data)
+      val gmm = new GaussianMixture().setK(1).setSeed(seed).run(data)
       assert(gmm.weights(0) ~== Ew absTol 1E-5)
       assert(gmm.gaussians(0).mu ~== Emu absTol 1E-5)
       assert(gmm.gaussians(0).sigma ~== Esigma absTol 1E-5)
@@ -116,7 +116,7 @@ class GaussianMixtureSuite extends SparkFunSuite with MLlibTestSparkContext {
     val sparseGMM = new GaussianMixture()
       .setK(2)
       .setInitialModel(initialGmm)
-      .setDistributeGaussians(false).run(data)
+      .run(data)
 
     assert(sparseGMM.weights(0) ~== Ew(0) absTol 1E-3)
     assert(sparseGMM.weights(1) ~== Ew(1) absTol 1E-3)
@@ -126,32 +126,10 @@ class GaussianMixtureSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(sparseGMM.gaussians(1).sigma ~== Esigma(1) absTol 1E-3)
   }
 
-  test("single cluster with distributed gaussians") {
-    val data = sc.parallelize(Array(
-      Vectors.sparse(3, Array(0, 2), Array(4.0, 2.0)),
-      Vectors.sparse(3, Array(0, 2), Array(2.0, 4.0)),
-      Vectors.sparse(3, Array(1), Array(6.0))
-    ))
-
-    val Ew = 1.0
-    val Emu = Vectors.dense(2.0, 2.0, 2.0)
-    val Esigma = Matrices.dense(3, 3,
-      Array(8.0 / 3.0, -4.0, 4.0 / 3.0, -4.0, 8.0, -4.0, 4.0 / 3.0, -4.0, 8.0 / 3.0)
-    )
-
-    val seeds = Array(42, 1994, 27, 11, 0)
-    seeds.foreach { seed =>
-      val gmm = new GaussianMixture().setK(1).setSeed(seed).setDistributeGaussians(true).run(data)
-      assert(gmm.weights(0) ~== Ew absTol 1E-5)
-      assert(gmm.gaussians(0).mu ~== Emu absTol 1E-5)
-      assert(gmm.gaussians(0).sigma ~== Esigma absTol 1E-5)
-    }
-  }
-
   test("model save / load") {
     val data = sc.parallelize(GaussianTestData.data)
 
-    val gmm = new GaussianMixture().setK(2).setSeed(0).setDistributeGaussians(false).run(data)
+    val gmm = new GaussianMixture().setK(2).setSeed(0).run(data)
     val tempDir = Utils.createTempDir()
     val path = tempDir.toURI.toString
 

--- a/mllib/src/test/scala/org/apache/spark/mllib/clustering/GaussianMixtureSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/clustering/GaussianMixtureSuite.scala
@@ -106,7 +106,7 @@ class GaussianMixtureSuite extends SparkFunSuite with MLlibTestSparkContext {
       Array(0.5, 0.5),
       Array(
         new MultivariateGaussian(Vectors.dense(-1.0), Matrices.dense(1, 1, Array(1.0))),
-        new MultivariateGaussian(Vectors.dense(2.0), Matrices.dense(1, 1, Array(1.0)))
+        new MultivariateGaussian(Vectors.dense(1.0), Matrices.dense(1, 1, Array(1.0)))
       )
     )
     val Ew = Array(1.0 / 3.0, 2.0 / 3.0)


### PR DESCRIPTION
Distribute expensive portions of computation for Gaussian mixture components (in particular, pre-computation of `MultivariateGaussian.rootSigmaInv`, the inverse covariance matrix and covariance determinant) across executors. Repost of PR#4654.

Notes for reviewers:
- What should be the policy for when to distribute computation. Always? When numClusters > threshold? User-specified param?

TODO:
- Performance testing and comparison for large number of clusters
