### PR TITLE
[SPARK-8787][SQL]Changed  parameter order of @deprecated in package object sql

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/package.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/package.scala
@@ -46,6 +46,6 @@ package object sql {
    * Type alias for [[DataFrame]]. Kept here for backward source compatibility for Scala.
    * @deprecated As of 1.3.0, replaced by `DataFrame`.
    */
-  @deprecated("1.3.0", "use DataFrame")
+  @deprecated("use DataFrame instead", "1.3.0")
   type SchemaRDD = DataFrame
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/package.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/package.scala
@@ -46,6 +46,6 @@ package object sql {
    * Type alias for [[DataFrame]]. Kept here for backward source compatibility for Scala.
    * @deprecated As of 1.3.0, replaced by `DataFrame`.
    */
-  @deprecated("use DataFrame instead", "1.3.0")
+  @deprecated("use DataFrame", "1.3.0")
   type SchemaRDD = DataFrame
 }


### PR DESCRIPTION
Parameter order of @deprecated annotation in package object sql is wrong

> > deprecated("1.3.0", "use DataFrame") .

This has to be changed to deprecated("use DataFrame", "1.3.0")
