### PR TITLE
[SPARK-8802] [WIP] [SQL] Decimal.apply(BigDecimal).toBigDecimal may throw NumberFormatException

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/decimal/DecimalSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/decimal/DecimalSuite.scala
@@ -17,13 +17,16 @@
 
 package org.apache.spark.sql.types.decimal
 
-import org.apache.spark.SparkFunSuite
-import org.apache.spark.sql.types.Decimal
-import org.scalatest.PrivateMethodTester
-
 import scala.language.postfixOps
 
-class DecimalSuite extends SparkFunSuite with PrivateMethodTester {
+import org.scalacheck.Prop.forAll
+import org.scalatest.PrivateMethodTester
+import org.scalatest.prop.Checkers
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.types.Decimal
+
+class DecimalSuite extends SparkFunSuite with PrivateMethodTester with Checkers {
   test("creating decimals") {
     /** Check that a Decimal has the given string representation, precision and scale */
     def checkDecimal(d: Decimal, string: String, precision: Int, scale: Int): Unit = {
@@ -51,6 +54,12 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester {
     intercept[IllegalArgumentException](Decimal(BigDecimal("10.030"), 2, 1))
     intercept[IllegalArgumentException](Decimal(BigDecimal("-9.95"), 2, 1))
     intercept[IllegalArgumentException](Decimal(1e17.toLong, 17, 0))
+  }
+
+  test("SPARK-8802: Decimal.apply(x: BigDecimal).toBigDecimal === x") {
+    val x = BigDecimal(BigInt("18889465931478580854784"), -2147483648)
+    assert(Decimal(x).toBigDecimal === x)
+    check(forAll((d: BigDecimal) => Decimal(d).toBigDecimal === d))
   }
 
   test("double and long values") {


### PR DESCRIPTION
There are certain BigDecimals that can be converted into Spark SQL's Decimal class but which produce Decimals that cannot be converted back to BigDecimal without throwing NumberFormatException.

For instance:

``` scala
val x = BigDecimal(BigInt("18889465931478580854784"), -2147483648)
assert(Decimal(x).toBigDecimal === x)
```

fails with the following exception:

``` scala
java.lang.NumberFormatException
    at java.math.BigDecimal.<init>(BigDecimal.java:511)
    at java.math.BigDecimal.<init>(BigDecimal.java:757)
    at scala.math.BigDecimal$.apply(BigDecimal.scala:119)
    at scala.math.BigDecimal.apply(BigDecimal.scala:324)
    at org.apache.spark.sql.types.Decimal.toBigDecimal(Decimal.scala:142)
```

This PR adds a failing regression test for this issue.  I'll try to fix this shortly.
