### PR TITLE
[SPARK-8801][SQL] Support TypeCollection in ExpectsInputTypes

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
+import javax.annotation.Nullable
+
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project, Union}
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -713,39 +715,62 @@ object HiveTypeCoercion {
 
       case e: ExpectsInputTypes =>
         val children: Seq[Expression] = e.children.zip(e.inputTypes).map { case (in, expected) =>
-          implicitCast(in, expected)
+          // If we cannot do the implicit cast, just use the original input.
+          implicitCast(in, expected).getOrElse(in)
         }
         e.withNewChildren(children)
     }
 
     /**
-     * If needed, cast the expression into the expected type.
-     * If the implicit cast is not allowed, return the expression itself.
+     * Given an expected data type, try to cast the expression and return the cast expression.
+     *
+     * If the expression already fits the input type, we simply return the expression itself.
+     * If the expression has an incompatible type that cannot be implicitly cast, return None.
      */
-    def implicitCast(e: Expression, expectedType: AbstractDataType): Expression = {
+    def implicitCast(e: Expression, expectedType: AbstractDataType): Option[Expression] = {
       val inType = e.dataType
-      (inType, expectedType) match {
+
+      // Note that ret is nullable to avoid typing a lot of Some(...) in this local scope.
+      // We wrap immediately an Option after this.
+      @Nullable val ret = (inType, expectedType) match {
         // Cast null type (usually from null literals) into target types
         case (NullType, target: DataType) => Cast(e, target.defaultConcreteType)
 
         // Implicit cast among numeric types
+        // If input is decimal, and we expect a decimal type, just use the input.
+        case (_: DecimalType, DecimalType) => e
+        // If input is a numeric type but not decimal, and we expect a decimal type,
+        // cast the input to unlimited precision decimal.
+        case (_: NumericType, DecimalType) if !inType.isInstanceOf[DecimalType] =>
+          Cast(e, DecimalType.Unlimited)
+        // For any other numeric types, implicitly cast to each other, e.g. long -> int, int -> long
         case (_: NumericType, target: NumericType) if e.dataType != target => Cast(e, target)
+        case (_: NumericType, target: NumericType) => e
 
         // Implicit cast between date time types
         case (DateType, TimestampType) => Cast(e, TimestampType)
         case (TimestampType, DateType) => Cast(e, DateType)
 
         // Implicit cast from/to string
-        case (StringType, NumericType) => Cast(e, DoubleType)
+        //case (StringType, NumericType) => Cast(e, DoubleType)  // not sure if we need this now.
+        case (StringType, DecimalType) => Cast(e, DecimalType.Unlimited)
         case (StringType, target: NumericType) => Cast(e, target)
         case (StringType, DateType) => Cast(e, DateType)
         case (StringType, TimestampType) => Cast(e, TimestampType)
         case (StringType, BinaryType) => Cast(e, BinaryType)
         case (any, StringType) if any != StringType => Cast(e, StringType)
 
+        // Type collection. Pick the first that we can implicit cast to.
+        case (_, TypeCollection(types)) =>
+          types.flatMap(implicitCast(e, _)).headOption.orNull
+
+        // If the expected type is already a parent of the input type, no need to cast.
+        case _ if expectedType.isParentOf(inType) => e
+
         // Else, just return the same input expression
-        case _ => e
+        case _ => null
       }
+      Option(ret)
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
@@ -756,7 +756,6 @@ object HiveTypeCoercion {
         case (TimestampType, DateType) => Cast(e, DateType)
 
         // Implicit cast from/to string
-        //case (StringType, NumericType) => Cast(e, DoubleType)  // not sure if we need this now.
         case (StringType, DecimalType) => Cast(e, DecimalType.Unlimited)
         case (StringType, target: NumericType) => Cast(e, target)
         case (StringType, DateType) => Cast(e, DateType)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/AbstractDataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/AbstractDataType.scala
@@ -29,6 +29,30 @@ import org.apache.spark.util.Utils
  */
 private[sql] abstract class AbstractDataType {
   private[sql] def defaultConcreteType: DataType
+
+  /**
+   * Returns true if this data type is a parent of the `childCandidate`.
+   */
+  private[sql] def isParentOf(childCandidate: DataType): Boolean
+}
+
+
+private[sql] class TypeCollection(private val types: Seq[DataType]) extends AbstractDataType {
+  require(types.nonEmpty, s"TypeCollection ($types) cannot be empty")
+
+  private[sql] override def defaultConcreteType: DataType = types.head
+
+  private[sql] override def isParentOf(childCandidate: DataType): Boolean = {
+    types.exists(typ => typ.isParentOf(childCandidate))
+  }
+}
+
+
+private[sql] object TypeCollection {
+  def unapply(typ: AbstractDataType): Option[Seq[DataType]] = typ match {
+    case typ: TypeCollection => Some(typ.types)
+    case _ => None
+  }
 }
 
 
@@ -61,7 +85,7 @@ abstract class NumericType extends AtomicType {
 }
 
 
-private[sql] object NumericType extends AbstractDataType {
+private[sql] object NumericType {
   /**
    * Enables matching against NumericType for expressions:
    * {{{
@@ -70,12 +94,10 @@ private[sql] object NumericType extends AbstractDataType {
    * }}}
    */
   def unapply(e: Expression): Boolean = e.dataType.isInstanceOf[NumericType]
-
-  private[sql] override def defaultConcreteType: DataType = IntegerType
 }
 
 
-private[sql] object IntegralType extends AbstractDataType {
+private[sql] object IntegralType {
   /**
    * Enables matching against IntegralType for expressions:
    * {{{
@@ -84,8 +106,6 @@ private[sql] object IntegralType extends AbstractDataType {
    * }}}
    */
   def unapply(e: Expression): Boolean = e.dataType.isInstanceOf[IntegralType]
-
-  private[sql] override def defaultConcreteType: DataType = IntegerType
 }
 
 
@@ -94,7 +114,7 @@ private[sql] abstract class IntegralType extends NumericType {
 }
 
 
-private[sql] object FractionalType extends AbstractDataType {
+private[sql] object FractionalType {
   /**
    * Enables matching against FractionalType for expressions:
    * {{{
@@ -103,8 +123,6 @@ private[sql] object FractionalType extends AbstractDataType {
    * }}}
    */
   def unapply(e: Expression): Boolean = e.dataType.isInstanceOf[FractionalType]
-
-  private[sql] override def defaultConcreteType: DataType = DoubleType
 }
 
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/ArrayType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/ArrayType.scala
@@ -26,7 +26,11 @@ object ArrayType extends AbstractDataType {
   /** Construct a [[ArrayType]] object with the given element type. The `containsNull` is true. */
   def apply(elementType: DataType): ArrayType = ArrayType(elementType, containsNull = true)
 
-  override def defaultConcreteType: DataType = ArrayType(NullType, containsNull = true)
+  private[sql] override def defaultConcreteType: DataType = ArrayType(NullType, containsNull = true)
+
+  private[sql] override def isParentOf(childCandidate: DataType): Boolean = {
+    childCandidate.isInstanceOf[ArrayType]
+  }
 }
 
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -75,7 +75,9 @@ abstract class DataType extends AbstractDataType {
    */
   private[spark] def asNullable: DataType
 
-  override def defaultConcreteType: DataType = this
+  private[sql] override def defaultConcreteType: DataType = this
+
+  private[sql] override def isParentOf(childCandidate: DataType): Boolean = this == childCandidate
 }
 
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalType.scala
@@ -86,6 +86,10 @@ object DecimalType extends AbstractDataType {
 
   private[sql] override def defaultConcreteType: DataType = Unlimited
 
+  private[sql] override def isParentOf(childCandidate: DataType): Boolean = {
+    childCandidate.isInstanceOf[DecimalType]
+  }
+
   val Unlimited: DecimalType = DecimalType(None)
 
   private[sql] object Fixed {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/MapType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/MapType.scala
@@ -71,6 +71,10 @@ object MapType extends AbstractDataType {
 
   private[sql] override def defaultConcreteType: DataType = apply(NullType, NullType)
 
+  private[sql] override def isParentOf(childCandidate: DataType): Boolean = {
+    childCandidate.isInstanceOf[MapType]
+  }
+
   /**
    * Construct a [[MapType]] object with the given key type and value type.
    * The `valueContainsNull` is true.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -301,7 +301,13 @@ case class StructType(fields: Array[StructField]) extends DataType with Seq[Stru
 }
 
 
-object StructType {
+object StructType extends AbstractDataType {
+
+  private[sql] override def defaultConcreteType: DataType = new StructType
+
+  private[sql] override def isParentOf(childCandidate: DataType): Boolean = {
+    childCandidate.isInstanceOf[StructType]
+  }
 
   def apply(fields: Seq[StructField]): StructType = StructType(fields.toArray)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercionSuite.scala
@@ -29,16 +29,17 @@ class HiveTypeCoercionSuite extends PlanTest {
   test("implicit type cast") {
     def shouldCast(from: DataType, to: AbstractDataType): Unit = {
       val got = HiveTypeCoercion.ImplicitTypeCasts.implicitCast(Literal.create(null, from), to)
-      assert(got.dataType === to.defaultConcreteType)
+      assert(got.map(_.dataType) == Option(to.defaultConcreteType),
+        s"Failed to cast $from to $to")
     }
 
     // TODO: write the entire implicit cast table out for test cases.
     shouldCast(ByteType, IntegerType)
     shouldCast(IntegerType, IntegerType)
     shouldCast(IntegerType, LongType)
-    shouldCast(IntegerType, DecimalType.Unlimited)
+    shouldCast(IntegerType, DecimalType)
     shouldCast(LongType, IntegerType)
-    shouldCast(LongType, DecimalType.Unlimited)
+    shouldCast(LongType, DecimalType)
 
     shouldCast(DateType, TimestampType)
     shouldCast(TimestampType, DateType)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercionSuite.scala
@@ -27,29 +27,47 @@ import org.apache.spark.sql.types._
 class HiveTypeCoercionSuite extends PlanTest {
 
   test("implicit type cast") {
-    def shouldCast(from: DataType, to: AbstractDataType): Unit = {
+    def shouldCast(from: DataType, to: AbstractDataType, expected: DataType): Unit = {
       val got = HiveTypeCoercion.ImplicitTypeCasts.implicitCast(Literal.create(null, from), to)
-      assert(got.map(_.dataType) == Option(to.defaultConcreteType),
+      assert(got.map(_.dataType) == Option(expected),
         s"Failed to cast $from to $to")
     }
 
+    shouldCast(NullType, NullType, NullType)
+    shouldCast(NullType, IntegerType, IntegerType)
+    shouldCast(NullType, DecimalType, DecimalType.Unlimited)
+
     // TODO: write the entire implicit cast table out for test cases.
-    shouldCast(ByteType, IntegerType)
-    shouldCast(IntegerType, IntegerType)
-    shouldCast(IntegerType, LongType)
-    shouldCast(IntegerType, DecimalType)
-    shouldCast(LongType, IntegerType)
-    shouldCast(LongType, DecimalType)
+    shouldCast(ByteType, IntegerType, IntegerType)
+    shouldCast(IntegerType, IntegerType, IntegerType)
+    shouldCast(IntegerType, LongType, LongType)
+    shouldCast(IntegerType, DecimalType, DecimalType.Unlimited)
+    shouldCast(LongType, IntegerType, IntegerType)
+    shouldCast(LongType, DecimalType, DecimalType.Unlimited)
 
-    shouldCast(DateType, TimestampType)
-    shouldCast(TimestampType, DateType)
+    shouldCast(DateType, TimestampType, TimestampType)
+    shouldCast(TimestampType, DateType, DateType)
 
-    shouldCast(StringType, IntegerType)
-    shouldCast(StringType, DateType)
-    shouldCast(StringType, TimestampType)
-    shouldCast(IntegerType, StringType)
-    shouldCast(DateType, StringType)
-    shouldCast(TimestampType, StringType)
+    shouldCast(StringType, IntegerType, IntegerType)
+    shouldCast(StringType, DateType, DateType)
+    shouldCast(StringType, TimestampType, TimestampType)
+    shouldCast(IntegerType, StringType, StringType)
+    shouldCast(DateType, StringType, StringType)
+    shouldCast(TimestampType, StringType, StringType)
+
+    shouldCast(StringType, BinaryType, BinaryType)
+    shouldCast(BinaryType, StringType, StringType)
+
+    shouldCast(NullType, TypeCollection(StringType, BinaryType), StringType)
+
+    shouldCast(StringType, TypeCollection(StringType, BinaryType), StringType)
+    shouldCast(BinaryType, TypeCollection(StringType, BinaryType), BinaryType)
+    shouldCast(StringType, TypeCollection(BinaryType, StringType), StringType)
+
+    shouldCast(IntegerType, TypeCollection(IntegerType, BinaryType), IntegerType)
+    shouldCast(IntegerType, TypeCollection(BinaryType, IntegerType), IntegerType)
+    shouldCast(BinaryType, TypeCollection(BinaryType, IntegerType), BinaryType)
+    shouldCast(BinaryType, TypeCollection(IntegerType, BinaryType), BinaryType)
   }
 
   test("tightest common bound for types") {


### PR DESCRIPTION
This patch adds a new TypeCollection AbstractDataType that can be used by expressions to specify more than one expected input types.
