### PR TITLE
[SPARK-8811][SQL] Read array struct data from parquet error

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/parquet/CatalystSchemaConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/parquet/CatalystSchemaConverter.scala
@@ -490,7 +490,7 @@ private[parquet] class CatalystSchemaConverter(
           .buildGroup(repetition).as(LIST)
           .addField(
             Types.repeatedGroup()
-              .addField(convertField(StructField("array", elementType, containsNull)))
+              .addField(convertField(StructField("element", elementType, containsNull)))
               .named("list"))
           .named(field.name)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/parquet/CatalystSchemaConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/parquet/CatalystSchemaConverter.scala
@@ -446,7 +446,7 @@ private[parquet] class CatalystSchemaConverter(
           field.name,
           Types
             .buildGroup(REPEATED)
-            .addField(convertField(StructField("element", elementType, nullable)))
+            .addField(convertField(StructField("array_element", elementType, nullable)))
             .named(CatalystConverter.ARRAY_CONTAINS_NULL_BAG_SCHEMA_NAME))
 
       // Spark 1.4.x and prior versions convert ArrayType with non-nullable elements into a 2-level
@@ -459,7 +459,7 @@ private[parquet] class CatalystSchemaConverter(
         ConversionPatterns.listType(
           repetition,
           field.name,
-          convertField(StructField("element", elementType, nullable), REPEATED))
+          convertField(StructField("array_element", elementType, nullable), REPEATED))
 
       // Spark 1.4.x and prior versions convert MapType into a 3-level group annotated by
       // MAP_KEY_VALUE.  This is covered by `convertGroupField(field: GroupType): DataType`.
@@ -490,7 +490,7 @@ private[parquet] class CatalystSchemaConverter(
           .buildGroup(repetition).as(LIST)
           .addField(
             Types.repeatedGroup()
-              .addField(convertField(StructField("element", elementType, containsNull)))
+              .addField(convertField(StructField("array_element", elementType, containsNull)))
               .named("list"))
           .named(field.name)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/parquet/CatalystSchemaConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/parquet/CatalystSchemaConverter.scala
@@ -446,7 +446,7 @@ private[parquet] class CatalystSchemaConverter(
           field.name,
           Types
             .buildGroup(REPEATED)
-            .addField(convertField(StructField("array_element", elementType, nullable)))
+            .addField(convertField(StructField("array", elementType, nullable)))
             .named(CatalystConverter.ARRAY_CONTAINS_NULL_BAG_SCHEMA_NAME))
 
       // Spark 1.4.x and prior versions convert ArrayType with non-nullable elements into a 2-level
@@ -459,7 +459,7 @@ private[parquet] class CatalystSchemaConverter(
         ConversionPatterns.listType(
           repetition,
           field.name,
-          convertField(StructField("array_element", elementType, nullable), REPEATED))
+          convertField(StructField("array", elementType, nullable), REPEATED))
 
       // Spark 1.4.x and prior versions convert MapType into a 3-level group annotated by
       // MAP_KEY_VALUE.  This is covered by `convertGroupField(field: GroupType): DataType`.
@@ -490,7 +490,7 @@ private[parquet] class CatalystSchemaConverter(
           .buildGroup(repetition).as(LIST)
           .addField(
             Types.repeatedGroup()
-              .addField(convertField(StructField("array_element", elementType, containsNull)))
+              .addField(convertField(StructField("array", elementType, containsNull)))
               .named("list"))
           .named(field.name)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/parquet/ParquetSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/parquet/ParquetSchemaSuite.scala
@@ -478,7 +478,8 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
     StructType(Seq(
       StructField(
         "f1",
-        ArrayType(IntegerType, containsNull = true),
+        ArrayType(
+          StructType(Seq(StructField("num", IntegerType, nullable = false))), containsNull = true),
         nullable = true))),
     """message root {
       |  optional group f1 (LIST) {
@@ -505,7 +506,9 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
   testParquetToCatalyst(
     "Backwards-compatibility: LIST with non-nullable element type - 2",
     StructType(Seq(
-      StructField("f1", ArrayType(IntegerType, containsNull = false), nullable = true))),
+      StructField("f1",
+      ArrayType(StructType(Seq(StructField("num", IntegerType))), containsNull = false),
+      nullable = true))),
     """message root {
       |  optional group f1 (LIST) {
       |    repeated group array {

--- a/sql/core/src/test/scala/org/apache/spark/sql/parquet/ParquetSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/parquet/ParquetSchemaSuite.scala
@@ -479,7 +479,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
       StructField(
         "f1",
         ArrayType(
-          StructType(Seq(StructField("num", IntegerType, nullable = false))), containsNull = true),
+          StructType(Seq(StructField("num", IntegerType))), containsNull = true),
         nullable = true))),
     """message root {
       |  optional group f1 (LIST) {
@@ -507,7 +507,8 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
     "Backwards-compatibility: LIST with non-nullable element type - 2",
     StructType(Seq(
       StructField("f1",
-      ArrayType(StructType(Seq(StructField("num", IntegerType))), containsNull = false),
+      ArrayType(StructType(Seq(StructField("num", IntegerType, nullable = false))),
+        containsNull = false),
       nullable = true))),
     """message root {
       |  optional group f1 (LIST) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/parquet/ParquetSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/parquet/ParquetSchemaSuite.scala
@@ -174,7 +174,7 @@ class ParquetSchemaInferenceSuite extends ParquetSchemaTest {
     """
       |message root {
       |  optional group _1 (LIST) {
-      |    repeated int32 array_element;
+      |    repeated int32 array;
       |  }
       |}
     """.stripMargin)
@@ -185,7 +185,7 @@ class ParquetSchemaInferenceSuite extends ParquetSchemaTest {
       |message root {
       |  optional group _1 (LIST) {
       |    repeated group list {
-      |      required int32 array_element;
+      |      required int32 array;
       |    }
       |  }
       |}
@@ -198,7 +198,7 @@ class ParquetSchemaInferenceSuite extends ParquetSchemaTest {
       |message root {
       |  optional group _1 (LIST) {
       |    repeated group bag {
-      |      optional int32 array_element;
+      |      optional int32 array;
       |    }
       |  }
       |}
@@ -210,7 +210,7 @@ class ParquetSchemaInferenceSuite extends ParquetSchemaTest {
       |message root {
       |  optional group _1 (LIST) {
       |    repeated group list {
-      |      optional int32 array_element;
+      |      optional int32 array;
       |    }
       |  }
       |}
@@ -267,7 +267,7 @@ class ParquetSchemaInferenceSuite extends ParquetSchemaTest {
       |        optional binary _1 (UTF8);
       |        optional group _2 (LIST) {
       |          repeated group bag {
-      |            optional group array_element {
+      |            optional group array {
       |              required int32 _1;
       |              required double _2;
       |            }
@@ -290,7 +290,7 @@ class ParquetSchemaInferenceSuite extends ParquetSchemaTest {
       |        optional binary _1 (UTF8);
       |        optional group _2 (LIST) {
       |          repeated group list {
-      |            optional group array_element {
+      |            optional group array {
       |              required int32 _1;
       |              required double _2;
       |            }
@@ -467,7 +467,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
     """message root {
       |  optional group f1 (LIST) {
       |    repeated group list {
-      |      optional int32 array_element;
+      |      optional int32 array;
       |    }
       |  }
       |}
@@ -482,7 +482,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
         nullable = true))),
     """message root {
       |  optional group f1 (LIST) {
-      |    repeated group array_element {
+      |    repeated group array {
       |      optional int32 num;
       |    }
       |  }
@@ -496,7 +496,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
     """message root {
       |  optional group f1 (LIST) {
       |    repeated group list {
-      |      required int32 array_element;
+      |      required int32 array;
       |    }
       |  }
       |}
@@ -508,7 +508,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
       StructField("f1", ArrayType(IntegerType, containsNull = false), nullable = true))),
     """message root {
       |  optional group f1 (LIST) {
-      |    repeated group array_element {
+      |    repeated group array {
       |      required int32 num;
       |    }
       |  }
@@ -521,7 +521,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
       StructField("f1", ArrayType(IntegerType, containsNull = false), nullable = true))),
     """message root {
       |  optional group f1 (LIST) {
-      |    repeated int32 array_element;
+      |    repeated int32 array;
       |  }
       |}
     """.stripMargin)
@@ -539,7 +539,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
         nullable = true))),
     """message root {
       |  optional group f1 (LIST) {
-      |    repeated group array_element {
+      |    repeated group array {
       |      required binary str (UTF8);
       |      required int32 num;
       |    }
@@ -599,7 +599,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
     """message root {
       |  optional group f1 (LIST) {
       |    repeated group list {
-      |      optional int32 array_element;
+      |      optional int32 array;
       |    }
       |  }
       |}
@@ -616,7 +616,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
     """message root {
       |  optional group f1 (LIST) {
       |    repeated group bag {
-      |      optional int32 array_element;
+      |      optional int32 array;
       |    }
       |  }
       |}
@@ -632,7 +632,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
     """message root {
       |  optional group f1 (LIST) {
       |    repeated group list {
-      |      required int32 array_element;
+      |      required int32 array;
       |    }
       |  }
       |}
@@ -648,7 +648,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
         nullable = true))),
     """message root {
       |  optional group f1 (LIST) {
-      |    repeated int32 array_element;
+      |    repeated int32 array;
       |  }
       |}
     """.stripMargin)

--- a/sql/core/src/test/scala/org/apache/spark/sql/parquet/ParquetSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/parquet/ParquetSchemaSuite.scala
@@ -174,7 +174,7 @@ class ParquetSchemaInferenceSuite extends ParquetSchemaTest {
     """
       |message root {
       |  optional group _1 (LIST) {
-      |    repeated int32 element;
+      |    repeated int32 array_element;
       |  }
       |}
     """.stripMargin)
@@ -185,7 +185,7 @@ class ParquetSchemaInferenceSuite extends ParquetSchemaTest {
       |message root {
       |  optional group _1 (LIST) {
       |    repeated group list {
-      |      required int32 element;
+      |      required int32 array_element;
       |    }
       |  }
       |}
@@ -198,7 +198,7 @@ class ParquetSchemaInferenceSuite extends ParquetSchemaTest {
       |message root {
       |  optional group _1 (LIST) {
       |    repeated group bag {
-      |      optional int32 element;
+      |      optional int32 array_element;
       |    }
       |  }
       |}
@@ -210,7 +210,7 @@ class ParquetSchemaInferenceSuite extends ParquetSchemaTest {
       |message root {
       |  optional group _1 (LIST) {
       |    repeated group list {
-      |      optional int32 element;
+      |      optional int32 array_element;
       |    }
       |  }
       |}
@@ -267,7 +267,7 @@ class ParquetSchemaInferenceSuite extends ParquetSchemaTest {
       |        optional binary _1 (UTF8);
       |        optional group _2 (LIST) {
       |          repeated group bag {
-      |            optional group element {
+      |            optional group array_element {
       |              required int32 _1;
       |              required double _2;
       |            }
@@ -290,7 +290,7 @@ class ParquetSchemaInferenceSuite extends ParquetSchemaTest {
       |        optional binary _1 (UTF8);
       |        optional group _2 (LIST) {
       |          repeated group list {
-      |            optional group element {
+      |            optional group array_element {
       |              required int32 _1;
       |              required double _2;
       |            }
@@ -467,7 +467,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
     """message root {
       |  optional group f1 (LIST) {
       |    repeated group list {
-      |      optional int32 element;
+      |      optional int32 array_element;
       |    }
       |  }
       |}
@@ -482,7 +482,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
         nullable = true))),
     """message root {
       |  optional group f1 (LIST) {
-      |    repeated group element {
+      |    repeated group array_element {
       |      optional int32 num;
       |    }
       |  }
@@ -496,7 +496,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
     """message root {
       |  optional group f1 (LIST) {
       |    repeated group list {
-      |      required int32 element;
+      |      required int32 array_element;
       |    }
       |  }
       |}
@@ -508,7 +508,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
       StructField("f1", ArrayType(IntegerType, containsNull = false), nullable = true))),
     """message root {
       |  optional group f1 (LIST) {
-      |    repeated group element {
+      |    repeated group array_element {
       |      required int32 num;
       |    }
       |  }
@@ -521,7 +521,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
       StructField("f1", ArrayType(IntegerType, containsNull = false), nullable = true))),
     """message root {
       |  optional group f1 (LIST) {
-      |    repeated int32 element;
+      |    repeated int32 array_element;
       |  }
       |}
     """.stripMargin)
@@ -539,7 +539,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
         nullable = true))),
     """message root {
       |  optional group f1 (LIST) {
-      |    repeated group element {
+      |    repeated group array_element {
       |      required binary str (UTF8);
       |      required int32 num;
       |    }
@@ -599,7 +599,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
     """message root {
       |  optional group f1 (LIST) {
       |    repeated group list {
-      |      optional int32 element;
+      |      optional int32 array_element;
       |    }
       |  }
       |}
@@ -616,7 +616,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
     """message root {
       |  optional group f1 (LIST) {
       |    repeated group bag {
-      |      optional int32 element;
+      |      optional int32 array_element;
       |    }
       |  }
       |}
@@ -632,7 +632,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
     """message root {
       |  optional group f1 (LIST) {
       |    repeated group list {
-      |      required int32 element;
+      |      required int32 array_element;
       |    }
       |  }
       |}
@@ -648,7 +648,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
         nullable = true))),
     """message root {
       |  optional group f1 (LIST) {
-      |    repeated int32 element;
+      |    repeated int32 array_element;
       |  }
       |}
     """.stripMargin)

--- a/sql/core/src/test/scala/org/apache/spark/sql/parquet/ParquetSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/parquet/ParquetSchemaSuite.scala
@@ -603,7 +603,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
     """message root {
       |  optional group f1 (LIST) {
       |    repeated group list {
-      |      optional int32 array;
+      |      optional int32 element;
       |    }
       |  }
       |}
@@ -636,7 +636,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
     """message root {
       |  optional group f1 (LIST) {
       |    repeated group list {
-      |      required int32 array;
+      |      required int32 element;
       |    }
       |  }
       |}

--- a/sql/core/src/test/scala/org/apache/spark/sql/parquet/ParquetSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/parquet/ParquetSchemaSuite.scala
@@ -185,7 +185,7 @@ class ParquetSchemaInferenceSuite extends ParquetSchemaTest {
       |message root {
       |  optional group _1 (LIST) {
       |    repeated group list {
-      |      required int32 array;
+      |      required int32 element;
       |    }
       |  }
       |}
@@ -210,7 +210,7 @@ class ParquetSchemaInferenceSuite extends ParquetSchemaTest {
       |message root {
       |  optional group _1 (LIST) {
       |    repeated group list {
-      |      optional int32 array;
+      |      optional int32 element;
       |    }
       |  }
       |}
@@ -290,7 +290,7 @@ class ParquetSchemaInferenceSuite extends ParquetSchemaTest {
       |        optional binary _1 (UTF8);
       |        optional group _2 (LIST) {
       |          repeated group list {
-      |            optional group array {
+      |            optional group element {
       |              required int32 _1;
       |              required double _2;
       |            }
@@ -479,7 +479,7 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
       StructField(
         "f1",
         ArrayType(
-          StructType(Seq(StructField("num", IntegerType))), containsNull = true),
+          StructType(Seq(StructField("num", IntegerType))), containsNull = false),
         nullable = true))),
     """message root {
       |  optional group f1 (LIST) {


### PR DESCRIPTION
JIRA:https://issues.apache.org/jira/browse/SPARK-8811

```
we have a table: 
t1(c1 string, 
   c2 string, 
   arr_c1 array<struct<in_c1 string, in_c2 string>>, 
   arr_c2 array<struct<in_c1 string, in_c2 string>>
)

we save data in parquet.

for select * from t1, we know in parquet the fileSchema may be:
message hive_schema {
  optional binary c1;
  optional binary c2;
  optional group arr_c1 (LIST) {
    repeated group bag {
      optional group array_element {
        optional binary IN_C1;
        optional binary IN_C2;
      }
    }
  }
  optional group arr_c2 (LIST) {
    repeated group bag {
      optional group array_element {
        optional binary IN_C1;
        optional binary IN_C2;
      }
    }
  }
}
but the requestSchema is:
message root {
  optional binary c1;
  optional binary c2;
  optional group arr_c1 (LIST) {
    repeated group bag {
      optional group element {
        optional binary IN_C1;
        optional binary IN_C2;
      }
    }
  }
  optional group arr_c2 (LIST) {
    repeated group bag {
      optional group element {
        optional binary IN_C1;
        optional binary IN_C2;
      }
    }
  }
}
```

so when read data from parquet will cause java.lang.ArrayIndexOutOfBoundsException
