### PR TITLE
[SPARK-8813][SQL] Support combine text/parquet format file in SQL

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -26,7 +26,8 @@ import org.apache.hadoop.hive.ql.plan.{PlanUtils, TableDesc}
 import org.apache.hadoop.hive.serde2.Deserializer
 import org.apache.hadoop.hive.serde2.objectinspector.primitive._
 import org.apache.hadoop.hive.serde2.objectinspector.{ObjectInspectorConverters, StructObjectInspector}
-import org.apache.hadoop.io.Writable
+import org.apache.hadoop.io.{ArrayWritable, Text, LongWritable, Writable}
+import org.apache.hadoop.mapred.lib.CombineTextInputFormat
 import org.apache.hadoop.mapred.{FileInputFormat, InputFormat, JobConf}
 
 import org.apache.spark.Logging
@@ -34,6 +35,7 @@ import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.{EmptyRDD, HadoopRDD, RDD, UnionRDD}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
+import org.apache.spark.sql.hive.parquet.CombineParquetInputFormat
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.{SerializableConfiguration, Utils}
 
@@ -274,14 +276,39 @@ class HadoopTableReader(
 
     val initializeJobConfFunc = HadoopTableReader.initializeLocalJobConfFunc(path, tableDesc) _
 
-    val rdd = new HadoopRDD(
-      sc.sparkContext,
-      _broadcastedHiveConf.asInstanceOf[Broadcast[SerializableConfiguration]],
-      Some(initializeJobConfFunc),
-      inputFormatClass,
-      classOf[Writable],
-      classOf[Writable],
-      _minSplitsPerRDD)
+    val combineSmallFile = _broadcastedHiveConf.value.value.
+      getBoolean("spark.sql.combine.small.file", false)
+
+    val inputFormatClassName = inputFormatClass.getName
+    // Only support combine text/parquet format file in current version.
+    val rdd = if (combineSmallFile && inputFormatClassName.contains("TextInputFormat")) {
+      new HadoopRDD(
+        sc.sparkContext,
+        _broadcastedHiveConf.asInstanceOf[Broadcast[SerializableConfiguration]],
+        Some(initializeJobConfFunc),
+        classOf[CombineTextInputFormat],
+        classOf[LongWritable],
+        classOf[Text],
+        _minSplitsPerRDD)
+    } else if (combineSmallFile && inputFormatClassName.contains("MapredParquetInputFormat")) {
+      new HadoopRDD(
+        sc.sparkContext,
+        _broadcastedHiveConf.asInstanceOf[Broadcast[SerializableConfiguration]],
+        Some(initializeJobConfFunc),
+        classOf[CombineParquetInputFormat],
+        classOf[Void],
+        classOf[ArrayWritable],
+        _minSplitsPerRDD)
+    } else {
+      new HadoopRDD(
+        sc.sparkContext,
+        _broadcastedHiveConf.asInstanceOf[Broadcast[SerializableConfiguration]],
+        Some(initializeJobConfFunc),
+        inputFormatClass,
+        classOf[Writable],
+        classOf[Writable],
+        _minSplitsPerRDD)
+    }
 
     // Only take the value (skip the key) because Hive works only with values.
     rdd.map(_._2)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/parquet/CombineParquetInputFormat.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/parquet/CombineParquetInputFormat.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive.parquet
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat
+import org.apache.hadoop.io.ArrayWritable
+import org.apache.hadoop.mapred.lib.{CombineFileInputFormat, CombineFileRecordReader, CombineFileRecordReaderWrapper, CombineFileSplit}
+import org.apache.hadoop.mapred.{InputSplit, JobConf, RecordReader, Reporter}
+
+/**
+ * Input format that is a <code>CombineFileInputFormat</code>-equivalent for
+ * <code>MapredParquetInputFormat</code>.
+ *
+ * @see CombineFileInputFormat
+ */
+class CombineParquetInputFormat extends CombineFileInputFormat[Void, ArrayWritable] {
+  override def getRecordReader(
+      split: InputSplit,
+      job: JobConf,
+      reporter: Reporter): RecordReader[Void, ArrayWritable] = {
+    new CombineFileRecordReader[Void, ArrayWritable](
+      job,
+      split.asInstanceOf[CombineFileSplit],
+      reporter,
+      classOf[ParquetRecordReaderWrapper].asInstanceOf[Class[RecordReader[Void, ArrayWritable]]])
+  }
+}
+
+/**
+ * A record reader that may be passed to <code>CombineFileRecordReader</code>
+ * so that it can be used in a <code>CombineFileInputFormat</code>-equivalent
+ * for <code>MapredParquetInputFormat</code>.
+ *
+ * @see CombineFileRecordReader
+ * @see CombineFileInputFormat
+ * @see MapredParquetInputFormat
+ */
+private class ParquetRecordReaderWrapper(
+    split: CombineFileSplit,
+    conf: Configuration,
+    reporter: Reporter,
+    idx: Integer)
+  extends CombineFileRecordReaderWrapper[Void, ArrayWritable](
+    new MapredParquetInputFormat(), split, conf, reporter, idx)
+


### PR DESCRIPTION
Combine text/parquet format file is off default and can be turn on throught 

```
set spark.sql.combine.small.file=true;
```

The reason why don't support orc format is the first parameter of `CombineFileRecordReaderWrapper` is `FileInputFormat`

```
CombineFileRecordReaderWrapper(FileInputFormat<K,V> inputFormat, CombineFileSplit split, Configuration conf, Reporter reporter, Integer idx)
```

and

```
class OrcInputFormat implements InputFormat<NullWritable, OrcStruct>
```
