### PR TITLE
[SPARK-5707][SQL] Avoid codegen for HashedRelation keys

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
@@ -44,7 +44,7 @@ trait HashJoin {
   override def output: Seq[Attribute] = left.output ++ right.output
 
   @transient protected lazy val buildSideKeyGenerator: Projection =
-    newProjection(buildKeys, buildPlan.output)
+    new InterpretedProjection(buildKeys, buildPlan.output)
 
   @transient protected lazy val streamSideKeyGenerator: () => MutableProjection =
     newMutableProjection(streamedKeys, streamedPlan.output)


### PR DESCRIPTION
Using codegen causes serialized code generated row types to leak out of the JVM when doing broadcast joins.  This PR changes it so we always use generic rows for hashtables.
