### PR TITLE
[HOTFIX][BUILD] Cannot build because of: [INFO] Dependency-reduced POM written at: …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1439,6 +1439,7 @@
         <artifactId>maven-shade-plugin</artifactId>
         <version>2.3</version>
         <configuration>
+          <createDependencyReducedPom>false</createDependencyReducedPom>
           <shadedArtifactAttached>false</shadedArtifactAttached>
           <artifactSet>
             <includes>


### PR DESCRIPTION
There might be a better solution. 

If someone want's to build the latest master, he can use this hotfix.

Building the latest master stucks in an infinity loop printing:
`[INFO] Dependency-reduced POM written at: /home/hbase/spark/bagel/dependency-reduced-pom.xml`

additional information:
https://github.com/apache/spark/pull/7193 (https://issues.apache.org/jira/browse/SPARK-8781) thanks @tedyu (mailing list)
