### PR TITLE
Fixed First and Last aggregates to compute first and last value per G…

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregates.scala
@@ -722,27 +722,25 @@ case class CountDistinctFunction(
 case class FirstFunction(expr: Expression, base: AggregateExpression) extends AggregateFunction {
   def this() = this(null, null) // Required for serialization.
 
-  var result: Any = null
+  var result: MutableLiteral = MutableLiteral(null, expr.dataType)
 
   override def update(input: Row): Unit = {
-    if (result == null) {
-      result = expr.eval(input)
+    if (result.value == null) {
+      result.value = expr.eval(input)
     }
   }
 
-  override def eval(input: Row): Any = result
+  override def eval(input: Row): Any = result.value
 }
 
 case class LastFunction(expr: Expression, base: AggregateExpression) extends AggregateFunction {
   def this() = this(null, null) // Required for serialization.
 
-  var result: Any = null
+  var result: MutableLiteral = MutableLiteral(null, expr.dataType)
 
   override def update(input: Row): Unit = {
-    result = input
+    result.value = expr.eval(input)
   }
 
-  override def eval(input: Row): Any = {
-    if (result != null) expr.eval(result.asInstanceOf[Row]) else null
-  }
+  override def eval(input: Row): Any = result.value
 }


### PR DESCRIPTION
In current implementation, First and Last aggregates were calculating the values for entire DataFrame partition and then the same value was returned for all GroupedData in the partition.
Fixed the First and Last aggregates to compute first and last value per GroupedData instead of entire DataFrame
