### PR TITLE
[SPARK-8839][SQL]ThriftServer2 will remove session and execution no matter it's finished or not.

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
@@ -218,7 +218,9 @@ object HiveThriftServer2 extends Logging {
       if (executionList.size > retainedStatements) {
         val toRemove = math.max(retainedStatements / 10, 1)
         executionList.take(toRemove).foreach { s =>
-          executionList.remove(s._1)
+          if (s._2.finishTimestamp != 0) {
+            executionList.remove(s._1)
+          }
         }
       }
     }
@@ -227,7 +229,9 @@ object HiveThriftServer2 extends Logging {
       if (sessionList.size > retainedSessions) {
         val toRemove = math.max(retainedSessions / 10, 1)
         sessionList.take(toRemove).foreach { s =>
-          sessionList.remove(s._1)
+          if (s._2.finishTimestamp != 0) {
+            sessionList.remove(s._1)
+          }
         }
       }
 

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
@@ -200,7 +200,6 @@ object HiveThriftServer2 extends Logging {
     def onStatementParsed(id: String, executionPlan: String): Unit = {
       executionList(id).executePlan = executionPlan
       executionList(id).state = ExecutionState.COMPILED
-      trimExecutionIfNecessary()
     }
 
     def onStatementError(id: String, errorMessage: String, errorTrace: String): Unit = {


### PR DESCRIPTION
In my test, `sessions` and `executions` in ThriftServer2 is not the same number as the connection number.
For example, if there are 200 clients connecting to the server,  but it will have more than 200 `sessions` and `executions`.
So if it reaches the `retainedStatements`, it has to remove some object which is not finished.
So it may cause the exception described in [Jira Address](https://issues.apache.org/jira/browse/SPARK-8839)
