### PR TITLE
[SPARK-8845] [ML] ML use of Breeze optimization: use adjustedValue  instead of value

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -186,11 +186,11 @@ class LogisticRegression(override val uid: String)
     val states = optimizer.iterations(new CachedDiffFunction(costFun),
       initialWeightsWithIntercept.toBreeze.toDenseVector)
 
-    val (weights, intercept, lossHistory) = {
+    val (weights, intercept, objectiveHistory) = {
       /*
-         Note that in Logistic Regression, the loss is log-likelihood which is invariance
-         under feature standardization. As a result, the loss returned from optimizer is
-         the same as the one in the original space.
+         Note that in Logistic Regression, the objective history (loss + regularization)
+         is log-likelihood which is invariance under feature standardization. As a result,
+         the objective history from optimizer is the same as the one in the original space.
        */
       val arrayBuilder = mutable.ArrayBuilder.make[Double]
       var state: optimizer.State = null
@@ -219,8 +219,7 @@ class LogisticRegression(override val uid: String)
       }
 
       if ($(fitIntercept)) {
-        (Vectors.dense(rawWeights.slice(0, rawWeights.length - 1)).compressed,
-          rawWeights(rawWeights.length - 1), arrayBuilder.result())
+        (Vectors.dense(rawWeights.dropRight(1)).compressed, rawWeights.last, arrayBuilder.result())
       } else {
         (Vectors.dense(rawWeights).compressed, 0.0, arrayBuilder.result())
       }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -122,7 +122,7 @@ class LogisticRegression(override val uid: String)
           classSummarizer1: MultiClassSummarizer), (summarizer2: MultivariateOnlineSummarizer,
           classSummarizer2: MultiClassSummarizer)) =>
             (summarizer1.merge(summarizer2), classSummarizer1.merge(classSummarizer2))
-        })
+      })
 
     val histogram = labelSummarizer.histogram
     val numInvalid = labelSummarizer.countInvalid
@@ -166,18 +166,18 @@ class LogisticRegression(override val uid: String)
       Vectors.zeros(if ($(fitIntercept)) numFeatures + 1 else numFeatures)
 
     if ($(fitIntercept)) {
-      /**
-       * For binary logistic regression, when we initialize the weights as zeros,
-       * it will converge faster if we initialize the intercept such that
-       * it follows the distribution of the labels.
-       *
-       * {{{
-       * P(0) = 1 / (1 + \exp(b)), and
-       * P(1) = \exp(b) / (1 + \exp(b))
-       * }}}, hence
-       * {{{
-       * b = \log{P(1) / P(0)} = \log{count_1 / count_0}
-       * }}}
+      /*
+         For binary logistic regression, when we initialize the weights as zeros,
+         it will converge faster if we initialize the intercept such that
+         it follows the distribution of the labels.
+
+         {{{
+         P(0) = 1 / (1 + \exp(b)), and
+         P(1) = \exp(b) / (1 + \exp(b))
+         }}}, hence
+         {{{
+         b = \log{P(1) / P(0)} = \log{count_1 / count_0}
+         }}}
        */
       initialWeightsWithIntercept.toArray(numFeatures)
         = math.log(histogram(1).toDouble / histogram(0).toDouble)
@@ -187,10 +187,10 @@ class LogisticRegression(override val uid: String)
       initialWeightsWithIntercept.toBreeze.toDenseVector)
 
     val (weights, intercept, lossHistory) = {
-      /**
-       * Note that in Logistic Regression, the loss is log-likelihood which is invariance
-       * under feature standardization. As a result, the loss returned from optimizer is
-       * the same as the one in the original space.
+      /*
+         Note that in Logistic Regression, the loss is log-likelihood which is invariance
+         under feature standardization. As a result, the loss returned from optimizer is
+         the same as the one in the original space.
        */
       val arrayBuilder = mutable.ArrayBuilder.make[Double]
       var state: optimizer.State = null
@@ -205,11 +205,11 @@ class LogisticRegression(override val uid: String)
         throw new SparkException(msg)
       }
 
-      /**
-       * The weights are trained in the scaled space; we're converting them back to
-       * the original space.
-       * Note that the intercept in scaled space and original space is the same;
-       * as a result, no scaling is needed.
+      /*
+         The weights are trained in the scaled space; we're converting them back to
+         the original space.
+         Note that the intercept in scaled space and original space is the same;
+         as a result, no scaling is needed.
        */
       val rawWeights = state.x.toArray.clone()
       var i = 0
@@ -438,9 +438,7 @@ private class LogisticAggregator(
 
     numClasses match {
       case 2 =>
-        /**
-         * For Binary Logistic Regression.
-         */
+        // For Binary Logistic Regression.
         val margin = - {
           var sum = 0.0
           data.foreachActive { (index, value) =>

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -132,7 +132,6 @@ class LinearRegression(override val uid: String)
     val numFeatures = summarizer.mean.size
     val yMean = statCounter.mean
     val yStd = math.sqrt(statCounter.variance)
-    // look at glmnet5.m L761 maaaybe that has info
 
     // If the yStd is zero, then the intercept is yMean with zero weights;
     // as a result, training is not needed.
@@ -166,12 +165,12 @@ class LinearRegression(override val uid: String)
       initialWeights.toBreeze.toDenseVector)
 
     val (weights, lossHistory) = {
-      /**
-       * Note that in Linear Regression, the loss returned from optimizer is computed
-       * in the scaled space given by the following formula.
-       * {{{
-       * L = 1/2n||\sum_i w_i(x_i - \bar{x_i}) / \hat{x_i} - (y - \bar{y}) / \hat{y}||^2 + regTerms
-       * }}}
+      /*
+         Note that in Linear Regression, the loss returned from optimizer is computed
+         in the scaled space given by the following formula.
+         {{{
+         L = 1/2n||\sum_i w_i(x_i - \bar{x_i}) / \hat{x_i} - (y - \bar{y}) / \hat{y}||^2 + regTerms
+         }}}
        */
       val arrayBuilder = mutable.ArrayBuilder.make[Double]
       var state: optimizer.State = null
@@ -186,9 +185,9 @@ class LinearRegression(override val uid: String)
         throw new SparkException(msg)
       }
 
-      /**
-       * The weights are trained in the scaled space; we're converting them back to
-       * the original space.
+      /*
+         The weights are trained in the scaled space; we're converting them back to
+         the original space.
        */
       val rawWeights = state.x.toArray.clone()
       var i = 0
@@ -201,10 +200,10 @@ class LinearRegression(override val uid: String)
       (Vectors.dense(rawWeights).compressed, arrayBuilder.result())
     }
 
-    /**
-     * The intercept in R's GLMNET is computed using closed form after the coefficients are
-     * converged. See the following discussion for detail.
-     * http://stats.stackexchange.com/questions/13617/how-is-the-intercept-computed-in-glmnet
+    /*
+       The intercept in R's GLMNET is computed using closed form after the coefficients are
+       converged. See the following discussion for detail.
+       http://stats.stackexchange.com/questions/13617/how-is-the-intercept-computed-in-glmnet
      */
     val intercept = if ($(fitIntercept)) yMean - dot(weights, Vectors.dense(featuresMean)) else 0.0
 

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -163,37 +163,54 @@ class LinearRegression(override val uid: String)
 
     val initialWeights = Vectors.zeros(numFeatures)
     val states = optimizer.iterations(new CachedDiffFunction(costFun),
-      initialWeights.toBreeze.toDenseVector).toArray
+      initialWeights.toBreeze.toDenseVector)
 
-    if (states.length == 0) {
-      val msg = s"${optimizer.getClass.getName} failed."
-      logError(msg)
-      throw new SparkException(msg)
-    }
+    val (weights, lossHistory) = {
+      /**
+       * Note that in Linear Regression, the loss returned from optimizer is computed
+       * in the scaled space given by the following formula.
+       * {{{
+       * L = 1/2n||\sum_i w_i(x_i - \bar{x_i}) / \hat{x_i} - (y - \bar{y}) / \hat{y}||^2 + regTerms
+       * }}}
+       */
+      val arrayBuilder = mutable.ArrayBuilder.make[Double]
+      var state: optimizer.State = null
+      while (states.hasNext) {
+        state = states.next()
+        arrayBuilder += state.adjustedValue
+      }
 
-    val lossHistory = states.map(_.adjustedValue)
+      if (state == null) {
+        val msg = s"${optimizer.getClass.getName} failed."
+        logError(msg)
+        throw new SparkException(msg)
+      }
 
-    // The weights are trained in the scaled space; we're converting them back to
-    // the original space.
-    val weights = {
-      val rawWeights = states.last.x.toArray.clone()
+      /**
+       * The weights are trained in the scaled space; we're converting them back to
+       * the original space.
+       */
+      val rawWeights = state.x.toArray.clone()
       var i = 0
       val len = rawWeights.length
       while (i < len) {
         rawWeights(i) *= { if (featuresStd(i) != 0.0) yStd / featuresStd(i) else 0.0 }
         i += 1
       }
-      Vectors.dense(rawWeights)
+
+      (Vectors.dense(rawWeights).compressed, arrayBuilder.result())
     }
 
-    // The intercept in R's GLMNET is computed using closed form after the coefficients are
-    // converged. See the following discussion for detail.
-    // http://stats.stackexchange.com/questions/13617/how-is-the-intercept-computed-in-glmnet
+    /**
+     * The intercept in R's GLMNET is computed using closed form after the coefficients are
+     * converged. See the following discussion for detail.
+     * http://stats.stackexchange.com/questions/13617/how-is-the-intercept-computed-in-glmnet
+     */
     val intercept = if ($(fitIntercept)) yMean - dot(weights, Vectors.dense(featuresMean)) else 0.0
+
     if (handlePersistence) instances.unpersist()
 
-    // TODO: Converts to sparse format based on the storage, but may base on the scoring speed.
-    copyValues(new LinearRegressionModel(uid, weights.compressed, intercept))
+    copyValues(new LinearRegressionModel(uid, weights, intercept))
   }
 
   override def copy(extra: ParamMap): LinearRegression = defaultCopy(extra)

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -164,10 +164,10 @@ class LinearRegression(override val uid: String)
     val states = optimizer.iterations(new CachedDiffFunction(costFun),
       initialWeights.toBreeze.toDenseVector)
 
-    val (weights, lossHistory) = {
+    val (weights, objectiveHistory) = {
       /*
-         Note that in Linear Regression, the loss returned from optimizer is computed
-         in the scaled space given by the following formula.
+         Note that in Linear Regression, the objective history (loss + regularization) returned
+         from optimizer is computed in the scaled space given by the following formula.
          {{{
          L = 1/2n||\sum_i w_i(x_i - \bar{x_i}) / \hat{x_i} - (y - \bar{y}) / \hat{y}||^2 + regTerms
          }}}


### PR DESCRIPTION
In LinearRegression and LogisticRegression, we use Breeze's optimizers (LBFGS and OWLQN). We check the State.value to see the current objective. However, Breeze's documentation makes it sound like value and adjustedValue differ for some optimizers, possibly including OWLQN: https://github.com/scalanlp/breeze/blob/26faf622862e8d7a42a401aef601347aac655f2b/math/src/main/scala/breeze/optimize/FirstOrderMinimizer.scala#L36
If that is the case, then we should use adjustedValue instead of value. This is relevant to SPARK-8538 and SPARK-8539, where we will provide the objective trace to the user.
