### PR TITLE
[SPARK-8743] [Streaming]: Deregister Codahale metrics for streaming when StreamingContext is closed

### DIFF
--- a/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
@@ -73,7 +73,7 @@ private[spark] class MetricsSystem private (
   private[this] val metricsConfig = new MetricsConfig(conf)
 
   private val sinks = new mutable.ArrayBuffer[Sink]
-  val sources = new mutable.ArrayBuffer[Source]
+  private val sources = new mutable.ArrayBuffer[Source]
   private val registry = new MetricRegistry()
 
   private var running: Boolean = false

--- a/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
@@ -73,7 +73,7 @@ private[spark] class MetricsSystem private (
   private[this] val metricsConfig = new MetricsConfig(conf)
 
   private val sinks = new mutable.ArrayBuffer[Sink]
-  private val sources = new mutable.ArrayBuffer[Source]
+  val sources = new mutable.ArrayBuffer[Source]
   private val registry = new MetricRegistry()
 
   private var running: Boolean = false

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -575,9 +575,7 @@ class StreamingContext private[streaming] (
    * @throws IllegalStateException if the StreamingContext is already stopped.
    */
   def start(): Unit = synchronized {
-  /**
-   * Registering Streaming Metrics at the start of the StreamingContext
-   */
+  //Registering Streaming Metrics at the start of the StreamingContext
     assert(env != null)
     assert(env.metricsSystem != null)
     env.metricsSystem.registerSource(streamingSource)
@@ -692,9 +690,7 @@ class StreamingContext private[streaming] (
     } finally {
       // The state should always be Stopped after calling `stop()`, even if we haven't started yet
       state = STOPPED
-      /**
-       * De-registering Streaming Metrics at the stop of the StreamingContext
-       */
+      // De-registering Streaming Metrics of the StreamingContext
       env.metricsSystem.removeSource(streamingSource)
     }
   }

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -575,14 +575,13 @@ class StreamingContext private[streaming] (
    * @throws IllegalStateException if the StreamingContext is already stopped.
    */
   def start(): Unit = synchronized {
-    // Registering Streaming Metrics at the start of the StreamingContext
-    assert(env != null)
-    assert(env.metricsSystem != null)
-    env.metricsSystem.registerSource(streamingSource)
     state match {
       case INITIALIZED =>
         startSite.set(DStream.getCreationSite())
         sparkContext.setCallSite(startSite.get)
+        // Registering Streaming Metrics at the start of the StreamingContext
+        assert(env.metricsSystem != null)
+        env.metricsSystem.registerSource(streamingSource)
         StreamingContext.ACTIVATION_LOCK.synchronized {
           StreamingContext.assertNoOtherContextIsActive()
           try {

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -579,9 +579,6 @@ class StreamingContext private[streaming] (
       case INITIALIZED =>
         startSite.set(DStream.getCreationSite())
         sparkContext.setCallSite(startSite.get)
-        // Registering Streaming Metrics at the start of the StreamingContext
-        assert(env.metricsSystem != null)
-        env.metricsSystem.registerSource(streamingSource)
         StreamingContext.ACTIVATION_LOCK.synchronized {
           StreamingContext.assertNoOtherContextIsActive()
           try {
@@ -599,6 +596,9 @@ class StreamingContext private[streaming] (
         }
         shutdownHookRef = Utils.addShutdownHook(
           StreamingContext.SHUTDOWN_HOOK_PRIORITY)(stopOnShutdown)
+        // Registering Streaming Metrics at the start of the StreamingContext
+        assert(env.metricsSystem != null)
+        env.metricsSystem.registerSource(streamingSource)
         uiTab.foreach(_.attach())
         logInfo("StreamingContext started")
       case ACTIVE =>

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -192,11 +192,9 @@ class StreamingContext private[streaming] (
       None
     }
 
-  /** Register streaming source to metrics system */
+  /** Initializing a streaming source to help register metrics system */
   private val streamingSource = new StreamingSource(this)
-  assert(env != null)
-  assert(env.metricsSystem != null)
-  env.metricsSystem.registerSource(streamingSource)
+
 
   private var state: StreamingContextState = INITIALIZED
 
@@ -577,6 +575,12 @@ class StreamingContext private[streaming] (
    * @throws IllegalStateException if the StreamingContext is already stopped.
    */
   def start(): Unit = synchronized {
+  /**
+   * Registering Streaming Metrics at the start of the StreamingContext
+   */
+    assert(env != null)
+    assert(env.metricsSystem != null)
+    env.metricsSystem.registerSource(streamingSource)
     state match {
       case INITIALIZED =>
         startSite.set(DStream.getCreationSite())
@@ -688,6 +692,10 @@ class StreamingContext private[streaming] (
     } finally {
       // The state should always be Stopped after calling `stop()`, even if we haven't started yet
       state = STOPPED
+      /**
+       * De-registering Streaming Metrics at the stop of the StreamingContext
+       */
+      env.metricsSystem.removeSource(streamingSource)
     }
   }
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -676,6 +676,8 @@ class StreamingContext private[streaming] (
           logWarning("StreamingContext has already been stopped")
         case ACTIVE =>
           scheduler.stop(stopGracefully)
+          // De-registering Streaming Metrics of the StreamingContext
+          env.metricsSystem.removeSource(streamingSource)
           uiTab.foreach(_.detach())
           StreamingContext.setActiveContext(null)
           waiter.notifyStop()
@@ -690,8 +692,7 @@ class StreamingContext private[streaming] (
     } finally {
       // The state should always be Stopped after calling `stop()`, even if we haven't started yet
       state = STOPPED
-      // De-registering Streaming Metrics of the StreamingContext
-      env.metricsSystem.removeSource(streamingSource)
+
     }
   }
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -575,7 +575,7 @@ class StreamingContext private[streaming] (
    * @throws IllegalStateException if the StreamingContext is already stopped.
    */
   def start(): Unit = synchronized {
-  //Registering Streaming Metrics at the start of the StreamingContext
+    // Registering Streaming Metrics at the start of the StreamingContext
     assert(env != null)
     assert(env.metricsSystem != null)
     env.metricsSystem.registerSource(streamingSource)

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -308,8 +308,9 @@ class StreamingContextSuite extends SparkFunSuite with BeforeAndAfter with Timeo
     Thread.sleep(100)
 
     ssc.stop()
+    val updatedSourcesSize = ssc.env.metricsSystem.sources.size
     assert(ssc.getState() === StreamingContextState.STOPPED)
-    assert(sizeOfSourcesArrayBuffer == sizeOfSourcesArrayBuffer - 1 )
+    assert(updatedSourcesSize == sizeOfSourcesArrayBuffer - 1 )
   }
 
   test("awaitTermination") {

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -301,6 +301,7 @@ class StreamingContextSuite extends SparkFunSuite with BeforeAndAfter with Timeo
   test("registering and de-registering of streamingSource") {
     val conf = new SparkConf().setMaster(master).setAppName(appName)
     ssc = new StreamingContext(conf, batchDuration)
+    assert(ssc.getState() === StreamingContextState.INITIALIZED)
     addInputStream(ssc).register()
     ssc.start()
 

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -304,7 +304,6 @@ class StreamingContextSuite extends SparkFunSuite with BeforeAndAfter with Timeo
     addInputStream(ssc).register()
     ssc.start()
 
-    assert(ssc.getState() === StreamingContextState.INITIALIZED)
     val sources = StreamingContextSuite.getSources(ssc.env.metricsSystem)
     val streamingSource = StreamingContextSuite.getStreamingSource(ssc)
     assert(sources.contains(streamingSource))

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -21,13 +21,11 @@ import java.io.{File, NotSerializableException}
 import java.util.concurrent.atomic.AtomicInteger
 
 import org.apache.commons.io.FileUtils
-import org.apache.spark.metrics.MetricsSystem
-import org.apache.spark.metrics.source.Source
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.concurrent.Timeouts
 import org.scalatest.exceptions.TestFailedDueToTimeoutException
 import org.scalatest.time.SpanSugar._
-import org.scalatest.{PrivateMethodTester, Assertions, BeforeAndAfter}
+import org.scalatest.{Assertions, BeforeAndAfter}
 
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming.dstream.DStream

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -824,7 +824,6 @@ object StreamingContextSuite {
   val metricsSystemsObject = Class.forName("org.apache.spark.metrics.MetricsSystem")
   val sources = metricsSystemsObject.getDeclaredField("sources")
   sources.setAccessible(true)
-
   val streamingContextObject = classOf[StreamingContext]
   val streamingSource = getClass.getDeclaredField("streamingSource")
   streamingSource.setAccessible(true)

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -19,7 +19,6 @@ package org.apache.spark.streaming
 
 import java.io.{File, NotSerializableException}
 import java.util.concurrent.atomic.AtomicInteger
-
 import org.apache.commons.io.FileUtils
 import org.apache.spark.metrics.MetricsSystem
 import org.apache.spark.metrics.source.Source
@@ -28,14 +27,11 @@ import org.scalatest.concurrent.Timeouts
 import org.scalatest.exceptions.TestFailedDueToTimeoutException
 import org.scalatest.time.SpanSugar._
 import org.scalatest.{PrivateMethodTester, Assertions, BeforeAndAfter}
-
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming.dstream.DStream
 import org.apache.spark.streaming.receiver.Receiver
 import org.apache.spark.util.Utils
-
 import org.apache.spark.{Logging, SparkConf, SparkContext, SparkFunSuite}
-
 import scala.collection.mutable.ArrayBuffer
 
 
@@ -308,7 +304,7 @@ class StreamingContextSuite extends SparkFunSuite with BeforeAndAfter with Timeo
     addInputStream(ssc).register()
     ssc.start()
 
-    assert(ssc.getState() === StreamingContextState.INITIALIZED)
+    //assert(ssc.getState() === StreamingContextState.INITIALIZED)
     val sources = StreamingContextSuite.getSources(ssc.env.metricsSystem)
     val streamingSource = StreamingContextSuite.getStreamingSource(ssc)
     assert(sources.contains(streamingSource))
@@ -319,7 +315,7 @@ class StreamingContextSuite extends SparkFunSuite with BeforeAndAfter with Timeo
     val sourcesAfterStop = StreamingContextSuite.getSources(ssc.env.metricsSystem)
     val streamingSourceAfterStop = StreamingContextSuite.getStreamingSource(ssc)
     assert(ssc.getState() === StreamingContextState.STOPPED)
-    assert(sourcesAfterStop.contains(streamingSourceAfterStop))
+    assert(!sourcesAfterStop.contains(streamingSourceAfterStop))
   }
 
   test("awaitTermination") {
@@ -829,11 +825,11 @@ package object testPackage extends Assertions {
 private object StreamingContextSuite extends PrivateMethodTester {
   private val _sources = PrivateMethod[ArrayBuffer[Source]]('sources)
   private def getSources(metricsSystem: MetricsSystem): ArrayBuffer[Source] = {
-    metricsSystem invokePrivate _sources()
+    metricsSystem.invokePrivate(_sources())
   }
   private val _streamingSource = PrivateMethod[StreamingSource]('streamingSource)
   private def getStreamingSource(streamingContext: StreamingContext): StreamingSource = {
-    streamingContext invokePrivate _streamingSource()
+    streamingContext.invokePrivate(_streamingSource())
   }
 }
 

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -34,9 +34,8 @@ import org.apache.spark.streaming.dstream.DStream
 import org.apache.spark.streaming.receiver.Receiver
 import org.apache.spark.util.Utils
 
-import org.apache.spark._
+import org.apache.spark.{Logging, SparkConf, SparkContext, SparkFunSuite}
 
-import scala.collection._
 import scala.collection.mutable.ArrayBuffer
 
 

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -304,7 +304,7 @@ class StreamingContextSuite extends SparkFunSuite with BeforeAndAfter with Timeo
     addInputStream(ssc).register()
     ssc.start()
 
-    //assert(ssc.getState() === StreamingContextState.INITIALIZED)
+    assert(ssc.getState() === StreamingContextState.INITIALIZED)
     val sources = StreamingContextSuite.getSources(ssc.env.metricsSystem)
     val streamingSource = StreamingContextSuite.getStreamingSource(ssc)
     assert(sources.contains(streamingSource))

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -818,7 +818,7 @@ package object testPackage extends Assertions {
 
 /**
  * Helper methods for testing StreamingContextSuite.
- * This includes methods to access private methods and fields in ExecutorAllocationManager.
+ * This includes methods to access private methods and fields in StreamingContext and MetricsSystem.
  */
 object StreamingContextSuite {
   val metricsSystemsObject = Class.forName("org.apache.spark.metrics.MetricsSystem")

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -309,15 +309,15 @@ class StreamingContextSuite extends SparkFunSuite with BeforeAndAfter with Timeo
     ssc.start()
 
     assert(ssc.getState() === StreamingContextState.INITIALIZED)
-    val sources: ArrayBuffer[Source] = StreamingContextSuite.getSources(ssc.env.metricsSystem)
-    val streamingSource: StreamingSource = StreamingContextSuite.getStreamingSource(ssc)
+    val sources = StreamingContextSuite.getSources(ssc.env.metricsSystem)
+    val streamingSource = StreamingContextSuite.getStreamingSource(ssc)
     assert(sources.contains(streamingSource))
     assert(ssc.getState() === StreamingContextState.ACTIVE)
     Thread.sleep(100)
 
     ssc.stop()
-    val sourcesAfterStop: ArrayBuffer[Source] = StreamingContextSuite.getSources(ssc.env.metricsSystem)
-    val streamingSourceAfterStop: StreamingSource = StreamingContextSuite.getStreamingSource(ssc)
+    val sourcesAfterStop = StreamingContextSuite.getSources(ssc.env.metricsSystem)
+    val streamingSourceAfterStop = StreamingContextSuite.getStreamingSource(ssc)
     assert(ssc.getState() === StreamingContextState.STOPPED)
     assert(sourcesAfterStop.contains(streamingSourceAfterStop))
   }


### PR DESCRIPTION
The issue link: https://issues.apache.org/jira/browse/SPARK-8743
Deregister Codahale metrics for streaming when StreamingContext is closed

Design:
Adding the method calls in the appropriate start() and stop () methods for the StreamingContext

Actions in the PullRequest:
1) Added the registerSource method call to the start method for the Streaming Context. 
2) Added the removeSource method to the stop method. 
3) Added comments for both 1 and 2 and comment to show initialization of the StreamingSource

Requesting Review.
