### PR TITLE
[SPARK-8851][YARN] In Yarn client mode, Client.scala does not login even when credentials are specified

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -547,6 +547,7 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
       }
     _cleaner.foreach(_.start())
 
+    SparkHadoopUtil.get.startDriverDelegationTokenRenewer(conf)
     setupAndStartListenerBus()
     postEnvironmentUpdate()
     postApplicationStart()
@@ -1666,6 +1667,7 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
       _env.stop()
       SparkEnv.set(null)
     }
+    SparkHadoopUtil.get.stopDriverDelegationTokenRenewer()
     SparkContext.clearActiveContext()
     logInfo("Successfully stopped SparkContext")
   }

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -325,6 +325,17 @@ class SparkHadoopUtil extends Logging {
   }
 
   /**
+   * Start a thread to periodically re-login to the KDC and create new delegation tokens for HDFS
+   * access.
+   */
+  private[spark] def startDriverDelegationTokenRenewer(conf: SparkConf): Unit = {}
+
+  /**
+   * Stop the thread that does delegation token updates on the driver.
+   */
+  private[spark] def stopDriverDelegationTokenRenewer(): Unit = {}
+
+  /**
    * Start a thread to periodically update the current user's credentials with new delegation
    * tokens so that writes to HDFS do not fail.
    */

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/DriverDelegationTokenRenewer.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/DriverDelegationTokenRenewer.scala
@@ -48,7 +48,7 @@ import org.apache.spark.util.ThreadUtils
  * appeared, it will read the credentials and update the currently running UGI with it. This
  * process happens again once 80% of the validity of this has expired.
  */
-private[yarn] class AMDelegationTokenRenewer(
+private[yarn] class DriverDelegationTokenRenewer(
     sparkConf: SparkConf,
     hadoopConf: Configuration) extends Logging {
 


### PR DESCRIPTION
Client.scala does not login since we check if args.principal is null before logging in, which it is since it is passed via SparkConf.
This PR addresses this by ensuring that we login in Client.scala in either case, and also pass the credentials correctly.
