### PR TITLE
[SPARK-8881][SPARK-9260] Fix algorithm for scheduling executors on workers

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -570,11 +570,11 @@ private[master] class Master(
       usableWorkers(pos).memoryFree - assignedMemory(pos) >= memoryPerExecutor
     }
 
-    while (coresToAssign > 0 && freeWorkers.nonEmpty) {
+    while (coresToAssign >= coresPerExecutor && freeWorkers.nonEmpty) {
       freeWorkers = freeWorkers.filter(canLaunchExecutor)
       freeWorkers.foreach { pos =>
         var keepScheduling = true
-        while (keepScheduling && canLaunchExecutor(pos) && coresToAssign > 0) {
+        while (keepScheduling && canLaunchExecutor(pos) && coresToAssign >= coresPerExecutor) {
           coresToAssign -= coresPerExecutor
           assignedCores(pos) += coresPerExecutor
           assignedMemory(pos) += memoryPerExecutor

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -605,7 +605,7 @@ private[master] class Master(
   }
 
   /**
-   * Allocate a worker's resources to one or more executors
+   * Allocate a worker's resources to one or more executors.
    * @param app the info of the application which the executors belong to
    * @param assignedCores number of cores on this worker for this application
    * @param coresPerExecutor number of cores per executor

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -569,7 +569,8 @@ private[master] class Master(
       // Pack executors into as few workers as possible (dense scheduling)
       while (toAssign > 0) {
         while (usableWorkers(pos).coresFree - assignedCores(pos) >= coresPerExecutor &&
-               usableWorkers(pos).memoryFree - assignedMemory(pos) >= memoryPerExecutor) {
+               usableWorkers(pos).memoryFree - assignedMemory(pos) >= memoryPerExecutor &&
+               toAssign > 0) {
           toAssign -= coresPerExecutor
           assignedCores(pos) += coresPerExecutor
           assignedMemory(pos) += memoryPerExecutor

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -605,7 +605,7 @@ private[master] class Master(
   }
 
   /**
-   * Allocate a worker's resources to one or more executors.
+   * Allocate a worker's resources to one or more executors
    * @param app the info of the application which the executors belong to
    * @param assignedCores number of cores on this worker for this application
    * @param coresPerExecutor number of cores per executor

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -545,8 +545,8 @@ private[master] class Master(
    * worker by default, in which case only one executor may be launched on each worker.
    */
 
-  private[master] def scheduleExecutorsOnWorkers(app: ApplicationInfo, usableWorkers: Array[WorkerInfo],
-    spreadOutApps: Boolean): Array[Int] = {
+  private[master] def scheduleExecutorsOnWorkers(app: ApplicationInfo,
+    usableWorkers: Array[WorkerInfo], spreadOutApps: Boolean): Array[Int] = {
     val coresPerExecutor = app.desc.coresPerExecutor.getOrElse(1)
     val memoryPerExecutor = app.desc.memoryPerExecutorMB
     val numUsable = usableWorkers.length
@@ -580,9 +580,9 @@ private[master] class Master(
     }
     assignedCores
   }
-  
+
   /**
-   * Schedule and launch executors on workers 
+   * Schedule and launch executors on workers
    */
   private def startExecutorsOnWorkers(): Unit = {
     // Right now this is a very simple FIFO scheduler. We keep trying to fit in the first app
@@ -598,7 +598,8 @@ private[master] class Master(
       // Now that we've decided how many cores to allocate on each worker, let's allocate them
       var pos = 0
       for (pos <- 0 until usableWorkers.length if assignedCores(pos) > 0) {
-        allocateWorkerResourceToExecutors(app, assignedCores(pos), coresPerExecutor, usableWorkers(pos))
+        allocateWorkerResourceToExecutors(app, assignedCores(pos), coresPerExecutor,
+        usableWorkers(pos))
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
@@ -180,7 +180,7 @@ class EventLoggingListenerSuite extends SparkFunSuite with LocalSparkContext wit
     // into SPARK-6688.
     val conf = getLoggingConf(testDirPath, compressionCodec)
       .set("spark.hadoop.fs.defaultFS", "unsupported://example.com")
-    val sc = new SparkContext("local-cluster[2,2,512]", "test", conf)
+    val sc = new SparkContext("local-cluster[2,2,1024]", "test", conf)
     assert(sc.eventLogger.isDefined)
     val eventLogger = sc.eventLogger.get
     val eventLogPath = eventLogger.logPath


### PR DESCRIPTION
Current scheduling algorithm allocates one core at a time and in doing so ends up ignoring spark.executor.cores. As a result, when spark.cores.max/spark.executor.cores (i.e, num_executors) < num_workers, executors are not launched and the app hangs. This PR fixes and refactors the scheduling algorithm. 

@andrewor14 
