### PR TITLE
[SPARK-8930][SQL] Support a star '*' in generator function arguments

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -324,7 +324,7 @@ class Analyzer(
             failAnalysis(s"${g.simpleString} cannot have a star in expressions")
           case _ =>
             g.copy(
-              generator = g.generator.copy(children = g.generator.children.flatMap {
+              generator = g.generator.makeCopy(children = g.generator.children.flatMap {
                 case s: Star => s.expand(g.child.output, resolver)
                 case o => o :: Nil
               })

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -307,13 +307,22 @@ class Analyzer(
           }
         )
 
-      // If the aggregate function argument contains Stars, expand it.
+      // If the aggregate function argument contains a Star, expand it.
       case a: Aggregate if containsStar(a.aggregateExpressions) =>
         a.copy(
           aggregateExpressions = a.aggregateExpressions.flatMap {
             case s: Star => s.expand(a.child.output, resolver)
             case o => o :: Nil
           }
+        )
+
+      // If the generator function argument contains a Star, expand it.
+      case e: Generate if containsStar(e.generator.children) =>
+        e.copy(
+          generator = e.generator.copy(children = e.generator.children.flatMap {
+            case s: Star => s.expand(e.child.output, resolver)
+            case o => o :: Nil
+          })
         )
 
       // Special handling for cases when self-join introduce duplicate expression ids.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -51,9 +51,9 @@ trait CheckAnalysis {
 
       case operator: LogicalPlan =>
         operator transformExpressionsUp {
-          case a: Attribute if !a.resolved =>
+          case e: Expression if !e.resolved =>
             val from = operator.inputSet.map(_.name).mkString(", ")
-            a.failAnalysis(s"cannot resolve '${a.prettyString}' given input columns $from")
+            e.failAnalysis(s"cannot resolve '${e.prettyString}' given input columns $from")
 
           case e: Expression if e.checkInputDataTypes().isFailure =>
             e.checkInputDataTypes() match {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/generators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/generators.scala
@@ -70,7 +70,7 @@ trait Generator extends Expression {
    * Analyzer uses this function to expand a Star if the aggregator
    * function argument has it.
    */
-  def copy(children: Seq[Expression]): Generator
+  def makeCopy(children: Seq[Expression]): Generator
 }
 
 /**
@@ -103,7 +103,7 @@ case class UserDefinedGenerator(
 
   override def toString: String = s"UserDefinedGenerator(${children.mkString(",")})"
 
-  def copy(children: Seq[Expression]): Generator = {
+  override def makeCopy(children: Seq[Expression]): Generator = {
     new UserDefinedGenerator(
       elementTypes = this.elementTypes,
       function = this.function,
@@ -146,6 +146,6 @@ case class Explode(child: Expression) extends UnaryExpression with Generator wit
 
   override def toString: String = s"explode($child)"
 
-  def copy(children: Seq[Expression]): Generator =
+  override def makeCopy(children: Seq[Expression]): Generator =
     new Explode(child)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/generators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/generators.scala
@@ -64,6 +64,13 @@ trait Generator extends Expression {
    * rows can be made here.
    */
   def terminate(): TraversableOnce[InternalRow] = Nil
+
+  /**
+   * Copys this instance with new children.
+   * Analyzer uses this function to expand a Star if the aggregator
+   * function argument has it.
+   */
+  def copy(children: Seq[Expression]): Generator
 }
 
 /**
@@ -95,6 +102,13 @@ case class UserDefinedGenerator(
   }
 
   override def toString: String = s"UserDefinedGenerator(${children.mkString(",")})"
+
+  def copy(children: Seq[Expression]): Generator = {
+    new UserDefinedGenerator(
+      elementTypes = this.elementTypes,
+      function = this.function,
+      children)
+  }
 }
 
 /**
@@ -129,4 +143,9 @@ case class Explode(child: Expression) extends UnaryExpression with Generator wit
         else inputMap.map { case (k, v) => InternalRow(k, v) }
     }
   }
+
+  override def toString: String = s"explode($child)"
+
+  def copy(children: Seq[Expression]): Generator =
+    new Explode(child)
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -147,6 +147,19 @@ class DataFrameSuite extends QueryTest with SQLTestUtils {
       Row("a", Seq("a"), 1) :: Nil)
   }
 
+  test("explode takes UnresolvedStar") {
+    val df = Seq(("1", "1,2"), ("2", "4"), ("3", "7,8,9")).toDF("prefix", "csv")
+    checkAnswer(
+      df.explode($"*") { case Row(prefix: String, csv: String) =>
+        csv.split(",").map(v => Tuple1(prefix + ":" + v))
+      },
+      Row("1", "1,2", "1:1") :: Row("1", "1,2", "1:2")
+        :: Row("2", "4", "2:4")
+        :: Row("3", "7,8,9", "3:7") :: Row("3", "7,8,9", "3:8") :: Row("3", "7,8,9", "3:9")
+        :: Nil
+    )
+  }
+
   test("selectExpr") {
     checkAnswer(
       testData.selectExpr("abs(key)", "value"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -147,17 +147,15 @@ class DataFrameSuite extends QueryTest with SQLTestUtils {
       Row("a", Seq("a"), 1) :: Nil)
   }
 
-  test("explode takes UnresolvedStar") {
+  test("explode cannot take a star") {
     val df = Seq(("1", "1,2"), ("2", "4"), ("3", "7,8,9")).toDF("prefix", "csv")
-    checkAnswer(
+    val errMsg = intercept[AnalysisException] {
       df.explode($"*") { case Row(prefix: String, csv: String) =>
         csv.split(",").map(v => Tuple1(prefix + ":" + v))
-      },
-      Row("1", "1,2", "1:1") :: Row("1", "1,2", "1:2")
-        :: Row("2", "4", "2:4")
-        :: Row("3", "7,8,9", "3:7") :: Row("3", "7,8,9", "3:8") :: Row("3", "7,8,9", "3:9")
-        :: Nil
-    )
+      }
+    }
+    assert(errMsg.getMessage === "'Generate UserDefinedGenerator(*), true, false, None, ['_1] " +
+      "cannot have a star in expressions;")
   }
 
   test("selectExpr") {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
@@ -542,6 +542,9 @@ private[hive] case class HiveGenericUDTF(
     collector.collectRows()
   }
 
+  def copy(children: Seq[Expression]): Generator =
+    new HiveGenericUDTF(funcWrapper = this.funcWrapper, children)
+
   override def toString: String = {
     s"$nodeName#${funcWrapper.functionClassName}(${children.mkString(",")})"
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
@@ -542,7 +542,7 @@ private[hive] case class HiveGenericUDTF(
     collector.collectRows()
   }
 
-  def copy(children: Seq[Expression]): Generator =
+  override def makeCopy(children: Seq[Expression]): Generator =
     new HiveGenericUDTF(funcWrapper = this.funcWrapper, children)
 
   override def toString: String = {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -22,10 +22,10 @@ import java.util
 import java.util.Properties
 
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.hive.ql.udf.generic.{GenericUDAFAverage, GenericUDF}
+import org.apache.hadoop.hive.ql.udf.generic.{GenericUDTF, GenericUDAFAverage, GenericUDF}
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredObject
-import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory
-import org.apache.hadoop.hive.serde2.objectinspector.{ObjectInspector, ObjectInspectorFactory}
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.{PrimitiveObjectInspectorUtils, PrimitiveObjectInspectorFactory}
+import org.apache.hadoop.hive.serde2.objectinspector.{StructObjectInspector, ObjectInspector, ObjectInspectorFactory}
 import org.apache.hadoop.hive.serde2.{AbstractSerDe, SerDeStats}
 import org.apache.hadoop.io.Writable
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
@@ -41,6 +41,7 @@ case class Fields(f1: Int, f2: Int, f3: Int, f4: Int, f5: Int)
 case class IntegerCaseClass(i: Int)
 case class ListListIntCaseClass(lli: Seq[(Int, Int, Int)])
 case class StringCaseClass(s: String)
+case class IntStringCaseClass(i: Int, s: String)
 case class ListStringCaseClass(l: Seq[String])
 
 /**
@@ -256,6 +257,21 @@ class HiveUDFSuite extends QueryTest {
 
     TestHive.reset()
   }
+
+  test("hive UDTF has a star") {
+    val testData = TestHive.sparkContext.parallelize(
+      IntStringCaseClass(1, "data1") :: IntStringCaseClass(2, "data2") :: Nil).toDF()
+    testData.registerTempTable("inputTable")
+
+    sql(s"CREATE TEMPORARY FUNCTION testUDTF AS '${classOf[TestUDTF].getName}'")
+    checkAnswer(
+      sql("SELECT testUDTF(*) FROM inputTable"),
+      Seq(Row(1, "data1"), Row(2, "data2"))
+    )
+    sql("DROP TEMPORARY FUNCTION IF EXISTS testUDTF")
+
+    TestHive.reset()
+  }
 }
 
 class TestPair(x: Int, y: Int) extends Writable with Serializable {
@@ -320,3 +336,21 @@ class PairUDF extends GenericUDF {
 
   override def getDisplayString(p1: Array[String]): String = ""
 }
+
+class TestUDTF extends GenericUDTF {
+  val idOI = PrimitiveObjectInspectorFactory.javaIntObjectInspector
+  val valueOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector
+
+  override def initialize(p1: Array[ObjectInspector]): StructObjectInspector = {
+    ObjectInspectorFactory.getStandardStructObjectInspector(Seq("id", "data"), Seq(idOI, valueOI))
+  }
+
+  override def process(args: Array[AnyRef]): Unit = {
+    val id = PrimitiveObjectInspectorUtils.getInt(args(0), idOI)
+    val value = PrimitiveObjectInspectorUtils.getString(args(1), valueOI)
+    forward(Array(id, value))
+  }
+
+  override def close(): Unit = {}
+}
+

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -353,4 +353,3 @@ class TestUDTF extends GenericUDTF {
 
   override def close(): Unit = {}
 }
-

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -605,6 +605,15 @@ class SQLQuerySuite extends QueryTest {
     }
   }
 
+  test("explode() cannot take a star") {
+    val rdd = sparkContext.makeRDD((1 to 5).map(i => s"""{"a":[$i, ${i + 1}], "b":"test"}"""))
+    read.json(rdd).registerTempTable("data")
+    val errMsg = intercept[AnalysisException] {
+      sql("SELECT explode(*) AS val FROM data")
+    }
+    assert(errMsg === "cannot resolve '*' given input columns a, b;")
+  }
+
   // TGF with non-TGF in project is allowed in Spark SQL, but not in Hive
   test("TGF with non-TGF in projection") {
     val rdd = sparkContext.makeRDD( """{"a": "1", "b":"1"}""" :: Nil)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -611,7 +611,7 @@ class SQLQuerySuite extends QueryTest {
     val errMsg = intercept[AnalysisException] {
       sql("SELECT explode(*) AS val FROM data")
     }
-    assert(errMsg === "cannot resolve '*' given input columns a, b;")
+    assert(errMsg.getMessage === "cannot resolve '*' given input columns a, b; line 1 pos 7")
   }
 
   // TGF with non-TGF in project is allowed in Spark SQL, but not in Hive

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -611,7 +611,7 @@ class SQLQuerySuite extends QueryTest {
     val errMsg = intercept[AnalysisException] {
       sql("SELECT explode(*) AS val FROM data")
     }
-    assert(errMsg.getMessage === "cannot resolve '*' given input columns a, b; line 1 pos 7")
+    assert(errMsg.getMessage === "cannot resolve 'explode(*)'; line 1 pos 7")
   }
 
   // TGF with non-TGF in project is allowed in Spark SQL, but not in Hive


### PR DESCRIPTION
The current implementation throws an exception if generators contain a star '_' like codes blow;
val df = Seq(("1", "1,2"), ("2", "4"), ("3", "7,8,9")).toDF("prefix", "csv")
checkAnswer(
df.explode($"_")
{ case Row(prefix: String, csv: String) => csv.split(",").map(v => Tuple1(prefix + ":" + v)) }
,
Row("1", "1,2", "1:1") :: Row("1", "1,2", "1:2")
:: Row("2", "4", "2:4")
:: Row("3", "7,8,9", "3:7") :: Row("3", "7,8,9", "3:8") :: Row("3", "7,8,9", "3:9")
:: Nil
)
[info] - explode takes UnresolvedStar **\* FAILED **\* (14 milliseconds)
[info] org.apache.spark.sql.AnalysisException: cannot resolve '_1' given input columns prefix, csv;
[info] at org.apache.spark.sql.catalyst.analysis.package$AnalysisErrorAt.failAnalysis(package.scala:42)
[info] at org.apache.spark.sql.catalyst.analysis.CheckAnalysis$$anonfun$checkAnalysis$1$$anonfun$apply$2.applyOrElse(CheckAnalysis.scala:55)
[info] at org.apache.spark.sql.catalyst.analysis.CheckAnalysis$$anonfun$checkAnalysis$1$$anonfun$apply$2.applyOrElse(CheckAnalysis.scala:52)
[info] at org.apache.spark.sql.catalyst.trees.TreeNode$$anonfun$transformUp$1.apply(TreeNode.scala:291)
[info] at org.apache.spark.sql.catalyst.trees.TreeNode$$anonfun$transformUp$1.apply(TreeNode.scala:291)
[info] at org.apache.spark.sql.catalyst.trees.CurrentOrigin$.withOrigin(TreeNode.scala:51)
[info] at org.apache.spark.sql.catalyst.trees.TreeNode.transformUp(TreeNode.scala:290)
[info] at org.apache.spark.sql.catalyst.plans.QueryPlan.transformExpressionUp$1(QueryPlan.scala:107)
[info] at org.apache.spark.sql.catalyst.plans.QueryPlan.org$apache$spark$sql$catalyst$plans$QueryPlan$$recursiveTransform$2(QueryPlan.scala:117)
[info] at org.apache.spark.sql.catalyst.plans.QueryPlan$$anonfun$org$apache$spark$sql$catalyst$plans$QueryPlan$$recursiveTransform$2$1.apply(QueryPlan.scala:1
21)
[info] at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:244)
[info] at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:244)
[info] at scala.collection.immutable.List.foreach(List.scala:318)
[info] at scala.collection.TraversableLike$class.map(TraversableLike.scala:244)
[info] at scala.collection.AbstractTraversable.map(Traversable.scala:105)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/apache/spark/7305)

<!-- Reviewable:end -->
