### PR TITLE
[SPARK-8953] SPARK_EXECUTOR_CORES has no effect to dynamic executor allocation function

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -162,6 +162,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
       .orNull
     executorCores = Option(executorCores)
       .orElse(sparkProperties.get("spark.executor.cores"))
+      .orElse(env.get("SPARK_EXECUTOR_CORES"))
       .orNull
     totalExecutorCores = Option(totalExecutorCores)
       .orElse(sparkProperties.get("spark.cores.max"))


### PR DESCRIPTION
The configuration `SPARK_EXECUTOR_CORES` won't put into `SparkConf`, so it has no effect to the dynamic executor allocation.
