### PR TITLE
[SPARK-8955][SQL] Replace a duplicated initialize() in HiveGenericUDTF with new one

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
@@ -501,7 +501,15 @@ private[hive] case class HiveGenericUDTF(
   protected lazy val inputInspectors = children.map(toInspector)
 
   @transient
-  protected lazy val outputInspector = function.initialize(inputInspectors.toArray)
+  protected lazy val outputInspector = {
+    /**
+     * Field names are not used in HiveGenericUDTF#initialize(),
+     * so they are filled with empty strings.
+     */
+    function.initialize(ObjectInspectorFactory.getStandardStructObjectInspector(
+      (0 until inputInspectors.size).map(_ => ""),
+      inputInspectors))
+  }
 
   @transient
   protected lazy val udtInput = new Array[AnyRef](children.length)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
@@ -501,15 +501,13 @@ private[hive] case class HiveGenericUDTF(
   protected lazy val inputInspectors = children.map(toInspector)
 
   @transient
-  protected lazy val outputInspector = {
-    /**
-     * Field names are not used in HiveGenericUDTF#initialize(),
-     * so they are filled with empty strings.
-     */
-    function.initialize(ObjectInspectorFactory.getStandardStructObjectInspector(
-      (0 until inputInspectors.size).map(_ => ""),
-      inputInspectors))
-  }
+  /**
+   * [[org.apache.hadoop.hive.ql.udf.generic.GenericUDTF#initialize(ObjectInspector[])]] is
+   * duplicated in Hive v0.13.1 though, we leave this code below unchanged
+   * because a new initialization interface has meaningless field names as an argument.
+   * We need to revisit SPARK-8955 to fix the issue in future.
+   */
+  protected lazy val outputInspector = function.initialize(inputInspectors.toArray)
 
   @transient
   protected lazy val udtInput = new Array[AnyRef](children.length)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
@@ -503,8 +503,8 @@ private[hive] case class HiveGenericUDTF(
   @transient
   /**
    * [[org.apache.hadoop.hive.ql.udf.generic.GenericUDTF#initialize(ObjectInspector[])]] is
-   * duplicated in Hive v0.13.1 though, we leave this code below unchanged
-   * because a new initialization interface has meaningless field names as an argument.
+   * deprecated in Hive v0.13.1 though, we leave this code below unchanged
+   * because the new initialization interface has meaningless field names as an argument.
    * We need to revisit SPARK-8955 to fix the issue in future.
    */
   protected lazy val outputInspector = function.initialize(inputInspectors.toArray)


### PR DESCRIPTION
HiveGenericUDTF#initialize(ObjectInspector[] argOIs) in v0.13.1 is duplicated, so it needs to be replaced with new one.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/apache/spark/7324)

<!-- Reviewable:end -->
