### PR TITLE
[SPARK-8400] [MLLIB] Allow ml.ALS to use -1 block size to auto-configure

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
@@ -134,6 +134,14 @@ object ParamValidators {
     getDouble(value) <= upperBound
   }
 
+  /** Check if value == requiredValue */
+  def eq[T](requiredValue: T): T => Boolean = {
+    case value @ (_: Double | _: Float) =>
+      throw new IllegalArgumentException("ParamValidator.eq not intended for real numbers, " +
+        s"value given is $value")
+    case value: Any => value == requiredValue
+  }
+
   /**
    * Check for value in range lowerBound to upperBound.
    * @param lowerInclusive  If true, check for value >= lowerBound.
@@ -165,6 +173,11 @@ object ParamValidators {
   /** Check for value in an allowed set of values. */
   def inArray[T](allowed: java.util.List[T]): T => Boolean = { (value: T) =>
     allowed.contains(value)
+  }
+
+  /** Use two validators together in a logical OR expression */
+  def or[T](a: T => Boolean, b: T => Boolean): T => Boolean = { (value: T) =>
+    a(value) || b(value)
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/param/ParamsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/param/ParamsSuite.scala
@@ -181,6 +181,13 @@ class ParamsSuite extends SparkFunSuite {
     val ltEq1Double = ParamValidators.ltEq[Double](1)
     assert(ltEq1Double(1.0) && !ltEq1Double(1.1))
 
+    val eq1Int = ParamValidators.eq[Int](1)
+    assert(eq1Int(1) && !eq1Int(0))
+    val eqDouble = ParamValidators.eq[Double](2/3.0)
+    intercept[IllegalArgumentException] {
+      eqDouble(1 - 1/3.0)
+    }
+
     val inRange02IntInclusive = ParamValidators.inRange[Int](0, 2)
     assert(inRange02IntInclusive(0) && inRange02IntInclusive(1) && inRange02IntInclusive(2) &&
       !inRange02IntInclusive(-1) && !inRange02IntInclusive(3))
@@ -199,6 +206,9 @@ class ParamsSuite extends SparkFunSuite {
 
     val inArray = ParamValidators.inArray[Int](Array(1, 2))
     assert(inArray(1) && inArray(2) && !inArray(0))
+
+    val orInt = ParamValidators.or(ParamValidators.eq[Int](-1), gtEq1Int)
+    assert(orInt(-1) && orInt(1) && !orInt(0))
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/recommendation/ALSSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/recommendation/ALSSuite.scala
@@ -412,6 +412,13 @@ class ALSSuite extends SparkFunSuite with MLlibTestSparkContext with Logging {
      numItemBlocks = 5, numUserBlocks = 5)
   }
 
+  test("auto-configured block settings") {
+    val (training, test) =
+      genExplicitTestData(numUsers = 4, numItems = 4, rank = 1)
+    testALS(training, test, maxIter = 2, rank = 1, regParam = 1e-4, targetRMSE = 0.002,
+      numUserBlocks = -1, numItemBlocks = -1)
+  }
+
   test("implicit feedback") {
     val (training, test) =
       genImplicitTestData(numUsers = 20, numItems = 40, rank = 2, noiseStd = 0.01)


### PR DESCRIPTION
If a param value of -1 is entered for user or item block size, the value will be auto-configured during training based on the level of parallelism.
