### PR TITLE
[SPARK-8995][SQL] cast date strings like '2015-01-01 12:15:31' to date

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -164,10 +164,7 @@ case class Cast(child: Expression, dataType: DataType) extends UnaryExpression w
   // TimestampConverter
   private[this] def castToTimestamp(from: DataType): Any => Any = from match {
     case StringType =>
-      buildCast[UTF8String](_, utfs => {
-        val parsedDateString = DateTimeUtils.stringToTimestamp(utfs)
-        if (parsedDateString == null) null else DateTimeUtils.fromJavaTimestamp(parsedDateString)
-      })
+      buildCast[UTF8String](_, utfs => DateTimeUtils.stringToTimestamp(utfs))
     case BooleanType =>
       buildCast[Boolean](_, b => if (b) 1L else 0)
     case LongType =>
@@ -215,10 +212,7 @@ case class Cast(child: Expression, dataType: DataType) extends UnaryExpression w
   // DateConverter
   private[this] def castToDate(from: DataType): Any => Any = from match {
     case StringType =>
-      buildCast[UTF8String](_, s => {
-        val parsedDate = DateTimeUtils.stringToDate(s)
-        if (parsedDate == null) null else DateTimeUtils.fromJavaDate(parsedDate)
-      })
+      buildCast[UTF8String](_, s => DateTimeUtils.stringToDate(s))
     case TimestampType =>
       // throw valid precision more than seconds, according to Hive.
       // Timestamp.nanos is in 0 to 999,999,999, no more than a second.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -167,17 +167,7 @@ case class Cast(child: Expression, dataType: DataType) extends UnaryExpression w
       buildCast[UTF8String](_, utfs => {
         val parsedDateString = DateTimeUtils.stringToTimestamp(utfs)
         if (parsedDateString == null) {
-          // Throw away extra if more than 9 decimal places
-          val s = utfs.toString
-          val periodIdx = s.indexOf(".")
-          var n = s
-          if (periodIdx != -1 && n.length() - periodIdx > 9) {
-            n = n.substring(0, periodIdx + 10)
-          }
-          try DateTimeUtils.fromJavaTimestamp(Timestamp.valueOf(n))
-          catch {
-            case _: java.lang.IllegalArgumentException => null
-          }
+          null
         } else {
           DateTimeUtils.fromJavaTimestamp(parsedDateString)
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -166,11 +166,7 @@ case class Cast(child: Expression, dataType: DataType) extends UnaryExpression w
     case StringType =>
       buildCast[UTF8String](_, utfs => {
         val parsedDateString = DateTimeUtils.stringToTimestamp(utfs)
-        if (parsedDateString == null) {
-          null
-        } else {
-          DateTimeUtils.fromJavaTimestamp(parsedDateString)
-        }
+        if (parsedDateString == null) null else DateTimeUtils.fromJavaTimestamp(parsedDateString)
       })
     case BooleanType =>
       buildCast[Boolean](_, b => if (b) 1L else 0)
@@ -221,7 +217,7 @@ case class Cast(child: Expression, dataType: DataType) extends UnaryExpression w
     case StringType =>
       buildCast[UTF8String](_, s => {
         val parsedDate = DateTimeUtils.stringToDate(s)
-        if (parsedDate == null) null else DateTimeUtils.fromJavaDate (parsedDate)
+        if (parsedDate == null) null else DateTimeUtils.fromJavaDate(parsedDate)
       })
     case TimestampType =>
       // throw valid precision more than seconds, according to Hive.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -164,7 +164,7 @@ case class Cast(child: Expression, dataType: DataType) extends UnaryExpression w
   // TimestampConverter
   private[this] def castToTimestamp(from: DataType): Any => Any = from match {
     case StringType =>
-      buildCast[UTF8String](_, utfs => DateTimeUtils.stringToTimestamp(utfs))
+      buildCast[UTF8String](_, utfs => DateTimeUtils.stringToTimestamp(utfs).orNull)
     case BooleanType =>
       buildCast[Boolean](_, b => if (b) 1L else 0)
     case LongType =>
@@ -212,7 +212,7 @@ case class Cast(child: Expression, dataType: DataType) extends UnaryExpression w
   // DateConverter
   private[this] def castToDate(from: DataType): Any => Any = from match {
     case StringType =>
-      buildCast[UTF8String](_, s => DateTimeUtils.stringToDate(s))
+      buildCast[UTF8String](_, s => DateTimeUtils.stringToDate(s).orNull)
     case TimestampType =>
       // throw valid precision more than seconds, according to Hive.
       // Timestamp.nanos is in 0 to 999,999,999, no more than a second.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -284,7 +284,7 @@ object DateTimeUtils {
       segments(6) = segments(6) * 10
     }
     if (segments(0) < 0 || segments(0) > 9999 || segments(1) < 1 || segments(1) > 12 ||
-        segments(2) < 1 || segments(2) > 21 || segments(3) < 0 || segments(3) > 13 ||
+        segments(2) < 1 || segments(2) > 31 || segments(3) < 0 || segments(3) > 23 ||
         segments(4) < 0 || segments(4) > 59 || segments(5) < 0 || segments(5) > 59 ||
         segments(6) < 0 || segments(6) > 999 || segments(7) < 0 || segments(7) > 14 ||
         segments(8) < 0 || segments(8) > 59) {
@@ -333,7 +333,7 @@ object DateTimeUtils {
     }
     segments(i) = currentSegmentValue
     if (segments(0) < 0 || segments(0) > 9999 || segments(1) < 1 || segments(1) > 12 ||
-        segments(2) < 1 || segments(2) > 21) {
+        segments(2) < 1 || segments(2) > 31) {
       return null
     }
     val c = Calendar.getInstance()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -277,12 +277,18 @@ object DateTimeUtils {
     }
     segments(i) = currentSegmentValue
 
+    // Hive compatibility 2011-05-06 07:08:09.1000 == 2011-05-06 07:08:09.1
+    if (digitsMilli == 4) {
+      segments(6) = segments(6) / 10
+    }
+
     // 18:3:1.1 is equals to 18:3:1:100
     if (digitsMilli == 1) {
       segments(6) = segments(6) * 100
     } else if (digitsMilli == 2) {
       segments(6) = segments(6) * 10
     }
+
     if (segments(0) < 0 || segments(0) > 9999 || segments(1) < 1 || segments(1) > 12 ||
         segments(2) < 1 || segments(2) > 31 || segments(3) < 0 || segments(3) > 23 ||
         segments(4) < 0 || segments(4) > 59 || segments(5) < 0 || segments(5) > 59 ||

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -329,8 +329,7 @@ object DateTimeUtils {
       c.set(segments(0), segments(1) - 1, segments(2), segments(3), segments(4), segments(5))
     }
 
-    c.set(Calendar.MILLISECOND, segments(6) / 1000)
-    Some(c.getTimeInMillis * 1000 + segments(6) % 1000)
+    Some(c.getTimeInMillis / 1000 * 1000000 + segments(6))
   }
 
   /**
@@ -377,7 +376,6 @@ object DateTimeUtils {
     }
     val c = Calendar.getInstance()
     c.set(segments(0), segments(1) - 1, segments(2), 0, 0, 0)
-    c.set(Calendar.MILLISECOND, 0)
     Some((c.getTimeInMillis / 1000 / 3600 / 24).toInt)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -301,11 +301,11 @@ object DateTimeUtils {
       digitsMilli += 1
     }
 
-    if (segments(0) < 0 || segments(0) > 9999 || segments(1) < 1 || segments(1) > 12 ||
-        segments(2) < 1 || segments(2) > 31 || segments(3) < 0 || segments(3) > 23 ||
-        segments(4) < 0 || segments(4) > 59 || segments(5) < 0 || segments(5) > 59 ||
-        segments(6) < 0 || segments(6) > 999999 || segments(7) < 0 || segments(7) > 23 ||
-        segments(8) < 0 || segments(8) > 59) {
+    if ((!justTime && (segments(0) < 999 || segments(0) > 9999 || segments(1) < 1 ||
+        segments(1) > 12 || segments(2) < 1 || segments(2) > 31)) || segments(3) < 0 ||
+        segments(3) > 23 || segments(4) < 0 || segments(4) > 59 || segments(5) < 0 ||
+        segments(5) > 59 || segments(6) < 0 || segments(6) > 999999 || segments(7) < 0 ||
+        segments(7) > 23 || segments(8) < 0 || segments(8) > 59) {
       return null.asInstanceOf[Long]
     }
     val c = if (timeZone.isEmpty) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -184,8 +184,10 @@ object DateTimeUtils {
   }
 
   /**
-   * Parses a given UTF8 date string to the corresponding [[Timestamp]] object. The format of the
-   * date has to be one of the following:
+   * Parses a given UTF8 date string to the corresponding a corresponding [[Long]] value.
+   * The return type is [[Option]] in order to distinguish between 0L and null. The following
+   * formats are allowed:
+   *
    * `yyyy`
    * `yyyy-[m]m`
    * `yyyy-[m]m-[d]d`
@@ -207,9 +209,9 @@ object DateTimeUtils {
    * `T[h]h:[m]m:[s]s.[ms][ms][ms][us][us][us]-[h]h:[m]m`
    * `T[h]h:[m]m:[s]s.[ms][ms][ms][us][us][us]+[h]h:[m]m`
    */
-  def stringToTimestamp(s: UTF8String): Long = {
+  def stringToTimestamp(s: UTF8String): Option[Long] = {
     if (s == null) {
-      return null.asInstanceOf[Long]
+      return None
     }
     var timeZone: Option[Byte] = None
     val segments: Array[Int] = Array[Int](1, 1, 1, 0, 0, 0, 0, 0, 0)
@@ -237,7 +239,7 @@ object DateTimeUtils {
             currentSegmentValue = 0
             i = 4
           } else {
-            return null.asInstanceOf[Long]
+            return None
           }
         } else if (i == 2) {
           if (b == ' ' || b == 'T') {
@@ -245,7 +247,7 @@ object DateTimeUtils {
             currentSegmentValue = 0
             i += 1
           } else {
-            return null.asInstanceOf[Long]
+            return None
           }
         } else if (i == 3 || i == 4) {
           if (b == ':') {
@@ -253,7 +255,7 @@ object DateTimeUtils {
             currentSegmentValue = 0
             i += 1
           } else {
-            return null.asInstanceOf[Long]
+            return None
           }
         } else if (i == 5 || i == 6) {
           if (b == 'Z') {
@@ -271,7 +273,7 @@ object DateTimeUtils {
             currentSegmentValue = 0
             i += 1
           } else {
-            return null.asInstanceOf[Long]
+            return None
           }
           if (i == 6  && b != '.') {
             i += 1
@@ -282,7 +284,7 @@ object DateTimeUtils {
             currentSegmentValue = 0
             i += 1
           } else {
-            return null.asInstanceOf[Long]
+            return None
           }
         }
       } else {
@@ -301,19 +303,25 @@ object DateTimeUtils {
       digitsMilli += 1
     }
 
-    if ((!justTime && (segments(0) < 999 || segments(0) > 9999 || segments(1) < 1 ||
-        segments(1) > 12 || segments(2) < 1 || segments(2) > 31)) || segments(3) < 0 ||
+    if (!justTime && (segments(0) < 1000 || segments(0) > 9999 || segments(1) < 1 ||
+        segments(1) > 12 || segments(2) < 1 || segments(2) > 31)) {
+      return None
+    }
+
+    if (segments(3) < 0 ||
         segments(3) > 23 || segments(4) < 0 || segments(4) > 59 || segments(5) < 0 ||
         segments(5) > 59 || segments(6) < 0 || segments(6) > 999999 || segments(7) < 0 ||
         segments(7) > 23 || segments(8) < 0 || segments(8) > 59) {
-      return null.asInstanceOf[Long]
+      return None
     }
+
     val c = if (timeZone.isEmpty) {
       Calendar.getInstance()
     } else {
       Calendar.getInstance(
         TimeZone.getTimeZone(f"GMT${timeZone.get.toChar}${segments(7)}%02d:${segments(8)}%02d"))
     }
+
     if (justTime) {
       c.set(Calendar.HOUR, segments(3))
       c.set(Calendar.MINUTE, segments(4))
@@ -321,13 +329,16 @@ object DateTimeUtils {
     } else {
       c.set(segments(0), segments(1) - 1, segments(2), segments(3), segments(4), segments(5))
     }
+
     c.set(Calendar.MILLISECOND, segments(6) / 1000)
-    c.getTimeInMillis * 1000 + segments(6) % 1000
+    Some(c.getTimeInMillis * 1000 + segments(6) % 1000)
   }
 
   /**
-   * Parses a given UTF8 date string to the corresponding number of days since 1.1.1970.
-   * The format of the date has to be one of the following:
+   * Parses a given UTF8 date string to the corresponding a corresponding [[Int]] value.
+   * The return type is [[Option]] in order to distinguish between 0 and null. The following
+   * formats are allowed:
+   *
    * `yyyy`,
    * `yyyy-[m]m`
    * `yyyy-[m]m-[d]d`
@@ -335,9 +346,9 @@ object DateTimeUtils {
    * `yyyy-[m]m-[d]d *`
    * `yyyy-[m]m-[d]dT*`
    */
-  def stringToDate(s: UTF8String): Int = {
+  def stringToDate(s: UTF8String): Option[Int] = {
     if (s == null) {
-      return null.asInstanceOf[Int]
+      return None
     }
     val segments: Array[Int] = Array[Int](1, 1, 1)
     var i = 0
@@ -353,7 +364,7 @@ object DateTimeUtils {
       } else {
         val parsedValue = b - '0'.toByte
         if (parsedValue < 0 || parsedValue > 9) {
-          return null.asInstanceOf[Int]
+          return None
         } else {
           currentSegmentValue = currentSegmentValue * 10 + parsedValue
         }
@@ -361,13 +372,13 @@ object DateTimeUtils {
       j += 1
     }
     segments(i) = currentSegmentValue
-    if (segments(0) < 0 || segments(0) > 9999 || segments(1) < 1 || segments(1) > 12 ||
+    if (segments(0) < 1000 || segments(0) > 9999 || segments(1) < 1 || segments(1) > 12 ||
         segments(2) < 1 || segments(2) > 31) {
-      return null.asInstanceOf[Int]
+      return None
     }
     val c = Calendar.getInstance()
     c.set(segments(0), segments(1) - 1, segments(2), 0, 0, 0)
     c.set(Calendar.MILLISECOND, 0)
-    (c.getTimeInMillis / 1000 / 3600 / 24).toInt
+    Some((c.getTimeInMillis / 1000 / 3600 / 24).toInt)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -308,10 +308,9 @@ object DateTimeUtils {
       return None
     }
 
-    if (segments(3) < 0 ||
-        segments(3) > 23 || segments(4) < 0 || segments(4) > 59 || segments(5) < 0 ||
-        segments(5) > 59 || segments(6) < 0 || segments(6) > 999999 || segments(7) < 0 ||
-        segments(7) > 23 || segments(8) < 0 || segments(8) > 59) {
+    if (segments(3) < 0 || segments(3) > 23 || segments(4) < 0 || segments(4) > 59 ||
+        segments(5) < 0 || segments(5) > 59 || segments(6) < 0 || segments(6) > 999999 ||
+        segments(7) < 0 || segments(7) > 23 || segments(8) < 0 || segments(8) > 59) {
       return None
     }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -24,7 +24,6 @@ import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.types._
-import org.apache.spark.unsafe.types.UTF8String
 
 /**
  * Test suite for data type casting expression [[Cast]].
@@ -281,6 +280,18 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
     val sts = sd + " 00:00:02"
     val nts = sts + ".1"
     val ts = Timestamp.valueOf(nts)
+
+    val defaultTimeZone = TimeZone.getDefault
+    TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"))
+    var c = Calendar.getInstance()
+    c.set(2015, 2, 8, 2, 30, 0)
+    checkEvaluation(cast(cast(new Timestamp(c.getTimeInMillis), StringType), TimestampType),
+      c.getTimeInMillis * 1000)
+    c = Calendar.getInstance()
+    c.set(2015, 10, 1, 2, 30, 0)
+    checkEvaluation(cast(cast(new Timestamp(c.getTimeInMillis), StringType), TimestampType),
+      c.getTimeInMillis * 1000)
+    TimeZone.setDefault(defaultTimeZone)
 
     checkEvaluation(cast("abdef", StringType), "abdef")
     checkEvaluation(cast("abdef", DecimalType.Unlimited), null)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -69,6 +69,9 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("cast string to timestamp") {
+    checkEvaluation(Cast(Literal("123"), TimestampType),
+      null)
+
     var c = Calendar.getInstance()
     c.set(2015, 0, 1, 0, 0, 0)
     c.set(Calendar.MILLISECOND, 0)
@@ -168,9 +171,7 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(Cast(Literal("2015.03.18"), TimestampType), null)
     checkEvaluation(Cast(Literal("20150318"), TimestampType), null)
     checkEvaluation(Cast(Literal("2015-031-8"), TimestampType), null)
-    checkEvaluation(Cast(Literal("2015-03-18T12:03:17-20:0"), TimestampType), null)
     checkEvaluation(Cast(Literal("2015-03-18T12:03:17-0:70"), TimestampType), null)
-    checkEvaluation(Cast(Literal("2015-03-18T12:03:17-1:0:0"), TimestampType), null)
   }
 
   test("cast from int") {
@@ -307,7 +308,7 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(
       cast(cast(cast(cast(cast(cast("5", TimestampType), ByteType),
         DecimalType.Unlimited), LongType), StringType), ShortType),
-      0.toShort)
+      null)
     checkEvaluation(cast(cast(cast(cast(cast(cast("5", DecimalType.Unlimited),
       ByteType), TimestampType), LongType), StringType), ShortType),
       0.toShort)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -128,6 +128,10 @@ class DateTimeUtilsSuite extends SparkFunSuite {
   test("string to timestamp") {
 
     var c = Calendar.getInstance()
+    c.set(2011, 4, 6, 7, 8, 9)
+    c.set(Calendar.MILLISECOND, 100)
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2011-05-06 07:08:09.1000")) ==
+      new Timestamp(c.getTimeInMillis))
     c.set(1969, 11, 31, 16, 0, 0)
     c.set(Calendar.MILLISECOND, 0)
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("1969-12-31 16:00:00")) ==

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -91,6 +91,10 @@ class DateTimeUtilsSuite extends SparkFunSuite {
 
   test("string to date") {
     var c = Calendar.getInstance()
+    c.set(2015, 0, 28, 0, 0, 0)
+    c.set(Calendar.MILLISECOND, 0)
+    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-01-28")) ==
+      new Date(c.getTimeInMillis))
     c.set(2015, 0, 1, 0, 0, 0)
     c.set(Calendar.MILLISECOND, 0)
     assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015")) ==
@@ -124,6 +128,10 @@ class DateTimeUtilsSuite extends SparkFunSuite {
   test("string to timestamp") {
 
     var c = Calendar.getInstance()
+    c.set(1969, 11, 31, 16, 0, 0)
+    c.set(Calendar.MILLISECOND, 0)
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("1969-12-31 16:00:00")) ==
+      new Timestamp(c.getTimeInMillis))
     c.set(2015, 0, 1, 0, 0, 0)
     c.set(Calendar.MILLISECOND, 0)
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015")) ==

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -19,8 +19,10 @@ package org.apache.spark.sql.catalyst.util
 
 import java.sql.{Date, Timestamp}
 import java.text.SimpleDateFormat
+import java.util.Calendar
 
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.unsafe.types.UTF8String
 
 class DateTimeUtilsSuite extends SparkFunSuite {
 
@@ -85,5 +87,60 @@ class DateTimeUtilsSuite extends SparkFunSuite {
 
     checkFromToJavaDate(new Date(df1.parse("1776-07-04 10:30:00").getTime))
     checkFromToJavaDate(new Date(df2.parse("1776-07-04 18:30:00 UTC").getTime))
+  }
+
+  test("string to millis") {
+    assert(DateTimeUtils.stringToMillis(UTF8String.fromString("18,00:00")) ==
+      null.asInstanceOf[Long])
+    assert(DateTimeUtils.stringToMillis(UTF8String.fromString(null)) ==
+      null.asInstanceOf[Long])
+
+    var c = Calendar.getInstance()
+    c.set(2015, 0, 1, 0, 0, 0)
+    assert(DateTimeUtils.stringToMillis(UTF8String.fromString("2015-01-01")) / 1000 ==
+      c.getTimeInMillis / 1000)
+    c.set(2015, 2, 18, 0, 0, 0)
+    assert(DateTimeUtils.stringToMillis(UTF8String.fromString("2015-3-18")) / 1000 ==
+      c.getTimeInMillis / 1000)
+    assert(DateTimeUtils.stringToMillis(UTF8String.fromString("2015-03-18")) / 1000 ==
+      c.getTimeInMillis / 1000)
+    c.set(2015, 11, 24, 0, 0, 0)
+    assert(DateTimeUtils.stringToMillis(UTF8String.fromString("2015-12-24")) / 1000 ==
+      c.getTimeInMillis / 1000)
+
+    c.set(2015, 0, 1, 12, 30, 58)
+    assert(DateTimeUtils.stringToMillis(UTF8String.fromString("2015-01-01 12:30:58")) / 1000 ==
+      c.getTimeInMillis / 1000)
+    c.set(2015, 2, 18, 9, 7, 2)
+    assert(DateTimeUtils.stringToMillis(UTF8String.fromString("2015-3-18 9:7:2")) / 1000 ==
+      c.getTimeInMillis / 1000)
+    assert(DateTimeUtils.stringToMillis(UTF8String.fromString("2015-03-18 09:07:02")) / 1000 ==
+      c.getTimeInMillis / 1000)
+    c.set(2015, 11, 24, 18, 0, 0)
+    assert(DateTimeUtils.stringToMillis(UTF8String.fromString("2015-12-24 18:00:00")) / 1000 ==
+      c.getTimeInMillis / 1000)
+
+    c = Calendar.getInstance()
+    c.set(Calendar.HOUR, 12)
+    c.set(Calendar.MINUTE, 30)
+    c.set(Calendar.SECOND, 58)
+    assert(DateTimeUtils.stringToMillis(UTF8String.fromString("12:30:58")) / 1000 ==
+      c.getTimeInMillis / 1000)
+
+    c = Calendar.getInstance()
+    c.set(Calendar.HOUR, 9)
+    c.set(Calendar.MINUTE, 7)
+    c.set(Calendar.SECOND, 2)
+    assert(DateTimeUtils.stringToMillis(UTF8String.fromString("9:7:2")) / 1000 ==
+      c.getTimeInMillis / 1000)
+    assert(DateTimeUtils.stringToMillis(UTF8String.fromString("09:07:02")) / 1000 ==
+      c.getTimeInMillis / 1000)
+
+    c = Calendar.getInstance()
+    c.set(Calendar.HOUR, 18)
+    c.set(Calendar.MINUTE, 0)
+    c.set(Calendar.SECOND, 0)
+    assert(DateTimeUtils.stringToMillis(UTF8String.fromString("18:00:00")) / 1000 ==
+      c.getTimeInMillis / 1000)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -246,6 +246,22 @@ class DateTimeUtilsSuite extends SparkFunSuite {
     assert(DateTimeUtils.stringToTimestamp(
       UTF8String.fromString("2015-03-18T12:03:17.12312+7:30")) == c.getTimeInMillis * 1000 + 120)
 
+    c = Calendar.getInstance(TimeZone.getTimeZone("GMT+07:30"))
+    c.set(Calendar.HOUR, 18)
+    c.set(Calendar.MINUTE, 12)
+    c.set(Calendar.SECOND, 15)
+    c.set(Calendar.MILLISECOND, 123)
+    assert(DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("T18:12:15.12312+7:30")) == c.getTimeInMillis * 1000 + 120)
+
+    c = Calendar.getInstance(TimeZone.getTimeZone("GMT+07:30"))
+    c.set(Calendar.HOUR, 18)
+    c.set(Calendar.MINUTE, 12)
+    c.set(Calendar.SECOND, 15)
+    c.set(Calendar.MILLISECOND, 123)
+    assert(DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("18:12:15.12312+7:30")) == c.getTimeInMillis * 1000 + 120)
+
     c = Calendar.getInstance()
     c.set(2011, 4, 6, 7, 8, 9)
     c.set(Calendar.MILLISECOND, 100)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -94,157 +94,154 @@ class DateTimeUtilsSuite extends SparkFunSuite {
     var c = Calendar.getInstance()
     c.set(2015, 0, 28, 0, 0, 0)
     c.set(Calendar.MILLISECOND, 0)
-    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-01-28")) ==
+    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-01-28")).get ==
       c.getTimeInMillis / millisPerDay)
     c.set(2015, 0, 1, 0, 0, 0)
     c.set(Calendar.MILLISECOND, 0)
-    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015")) ==
+    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015")).get ==
       c.getTimeInMillis / millisPerDay)
     c = Calendar.getInstance()
     c.set(2015, 2, 1, 0, 0, 0)
     c.set(Calendar.MILLISECOND, 0)
-    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03")) ==
+    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03")).get ==
       c.getTimeInMillis / millisPerDay)
     c = Calendar.getInstance()
     c.set(2015, 2, 18, 0, 0, 0)
     c.set(Calendar.MILLISECOND, 0)
-    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18")) ==
+    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18")).get ==
       c.getTimeInMillis / millisPerDay)
-    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18 ")) ==
+    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18 ")).get ==
       c.getTimeInMillis / millisPerDay)
-    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18 123142")) ==
+    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18 123142")).get ==
       c.getTimeInMillis / millisPerDay)
-    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18T123123")) ==
+    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18T123123")).get ==
       c.getTimeInMillis / millisPerDay)
-    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18T")) ==
+    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18T")).get ==
       c.getTimeInMillis / millisPerDay)
 
-    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18X")) ==
-      null.asInstanceOf[Int])
-    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015/03/18")) ==
-      null.asInstanceOf[Int])
-    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015.03.18")) ==
-      null.asInstanceOf[Int])
-    assert(DateTimeUtils.stringToDate(UTF8String.fromString("20150318")) ==
-      null.asInstanceOf[Int])
-    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-031-8")) ==
-      null.asInstanceOf[Int])
+    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18X")).isEmpty)
+    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015/03/18")).isEmpty)
+    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015.03.18")).isEmpty)
+    assert(DateTimeUtils.stringToDate(UTF8String.fromString("20150318")).isEmpty)
+    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-031-8")).isEmpty)
   }
 
   test("string to timestamp") {
     var c = Calendar.getInstance()
     c.set(1969, 11, 31, 16, 0, 0)
     c.set(Calendar.MILLISECOND, 0)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("1969-12-31 16:00:00")) ==
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("1969-12-31 16:00:00")).get ==
       c.getTimeInMillis * 1000)
     c.set(2015, 0, 1, 0, 0, 0)
     c.set(Calendar.MILLISECOND, 0)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015")) ==
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015")).get ==
       c.getTimeInMillis * 1000)
     c = Calendar.getInstance()
     c.set(2015, 2, 1, 0, 0, 0)
     c.set(Calendar.MILLISECOND, 0)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03")) ==
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03")).get ==
       c.getTimeInMillis * 1000)
     c = Calendar.getInstance()
     c.set(2015, 2, 18, 0, 0, 0)
     c.set(Calendar.MILLISECOND, 0)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18")) ==
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18")).get ==
       c.getTimeInMillis * 1000)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18 ")) ==
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18 ")).get ==
       c.getTimeInMillis * 1000)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T")) ==
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T")).get ==
       c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance()
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 0)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18 12:03:17")) ==
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18 12:03:17")).get ==
       c.getTimeInMillis * 1000)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17")) ==
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17")).get ==
       c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("GMT-13:53"))
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 0)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17-13:53")) ==
-      c.getTimeInMillis * 1000)
+    assert(DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2015-03-18T12:03:17-13:53")).get == c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 0)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17Z")) ==
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17Z")).get ==
       c.getTimeInMillis * 1000)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18 12:03:17Z")) ==
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18 12:03:17Z")).get ==
       c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("GMT-01:00"))
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 0)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17-1:0")) ==
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17-1:0")).get ==
       c.getTimeInMillis * 1000)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17-01:00")) ==
-      c.getTimeInMillis * 1000)
+    assert(DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2015-03-18T12:03:17-01:00")).get == c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("GMT+07:30"))
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 0)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17+07:30")) ==
-      c.getTimeInMillis * 1000)
+    assert(DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2015-03-18T12:03:17+07:30")).get == c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("GMT+07:03"))
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 0)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17+07:03")) ==
-      c.getTimeInMillis * 1000)
+    assert(DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2015-03-18T12:03:17+07:03")).get == c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance()
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 123)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18 12:03:17.123")) ==
-      c.getTimeInMillis * 1000)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17.123")) ==
-      c.getTimeInMillis * 1000)
+    assert(DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2015-03-18 12:03:17.123")).get == c.getTimeInMillis * 1000)
+    assert(DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2015-03-18T12:03:17.123")).get == c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 456)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17.456Z")) ==
-      c.getTimeInMillis * 1000)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18 12:03:17.456Z")) ==
-      c.getTimeInMillis * 1000)
+    assert(DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2015-03-18T12:03:17.456Z")).get  == c.getTimeInMillis * 1000)
+    assert(DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2015-03-18 12:03:17.456Z")).get  == c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("GMT-01:00"))
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 123)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17.123-1:0")) ==
-      c.getTimeInMillis * 1000)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17.123-01:00"))
-      ==  c.getTimeInMillis * 1000)
-
-    c = Calendar.getInstance(TimeZone.getTimeZone("GMT+07:30"))
-    c.set(2015, 2, 18, 12, 3, 17)
-    c.set(Calendar.MILLISECOND, 123)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17.123+07:30"))
-      ==  c.getTimeInMillis * 1000)
-
-    c = Calendar.getInstance(TimeZone.getTimeZone("GMT+07:30"))
-    c.set(2015, 2, 18, 12, 3, 17)
-    c.set(Calendar.MILLISECOND, 123)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17.123+07:30"))
-      == c.getTimeInMillis * 1000)
+    assert(DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2015-03-18T12:03:17.123-1:0")).get  == c.getTimeInMillis * 1000)
+    assert(DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2015-03-18T12:03:17.123-01:00")).get ==  c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("GMT+07:30"))
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 123)
     assert(DateTimeUtils.stringToTimestamp(
-      UTF8String.fromString("2015-03-18T12:03:17.123121+7:30")) == c.getTimeInMillis * 1000 + 121)
+      UTF8String.fromString("2015-03-18T12:03:17.123+07:30")).get ==  c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("GMT+07:30"))
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 123)
     assert(DateTimeUtils.stringToTimestamp(
-      UTF8String.fromString("2015-03-18T12:03:17.12312+7:30")) == c.getTimeInMillis * 1000 + 120)
+      UTF8String.fromString("2015-03-18T12:03:17.123+07:30")).get == c.getTimeInMillis * 1000)
+
+    c = Calendar.getInstance(TimeZone.getTimeZone("GMT+07:30"))
+    c.set(2015, 2, 18, 12, 3, 17)
+    c.set(Calendar.MILLISECOND, 123)
+    assert(DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2015-03-18T12:03:17.123121+7:30")).get ==
+        c.getTimeInMillis * 1000 + 121)
+
+    c = Calendar.getInstance(TimeZone.getTimeZone("GMT+07:30"))
+    c.set(2015, 2, 18, 12, 3, 17)
+    c.set(Calendar.MILLISECOND, 123)
+    assert(DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2015-03-18T12:03:17.12312+7:30")).get ==
+        c.getTimeInMillis * 1000 + 120)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("GMT+07:30"))
     c.set(Calendar.HOUR, 18)
@@ -252,7 +249,8 @@ class DateTimeUtilsSuite extends SparkFunSuite {
     c.set(Calendar.SECOND, 15)
     c.set(Calendar.MILLISECOND, 123)
     assert(DateTimeUtils.stringToTimestamp(
-      UTF8String.fromString("T18:12:15.12312+7:30")) == c.getTimeInMillis * 1000 + 120)
+      UTF8String.fromString("T18:12:15.12312+7:30")).get ==
+      c.getTimeInMillis * 1000 + 120)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("GMT+07:30"))
     c.set(Calendar.HOUR, 18)
@@ -260,35 +258,28 @@ class DateTimeUtilsSuite extends SparkFunSuite {
     c.set(Calendar.SECOND, 15)
     c.set(Calendar.MILLISECOND, 123)
     assert(DateTimeUtils.stringToTimestamp(
-      UTF8String.fromString("18:12:15.12312+7:30")) == c.getTimeInMillis * 1000 + 120)
+      UTF8String.fromString("18:12:15.12312+7:30")).get ==
+      c.getTimeInMillis * 1000 + 120)
 
     c = Calendar.getInstance()
     c.set(2011, 4, 6, 7, 8, 9)
     c.set(Calendar.MILLISECOND, 100)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2011-05-06 07:08:09.1000")) ==
-      c.getTimeInMillis * 1000)
+    assert(DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2011-05-06 07:08:09.1000")).get == c.getTimeInMillis * 1000)
 
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("238")) ==
-      null.asInstanceOf[Long])
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18 123142")) ==
-      null.asInstanceOf[Long])
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T123123")) ==
-      null.asInstanceOf[Long])
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18X")) ==
-      null.asInstanceOf[Long])
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015/03/18")) ==
-      null.asInstanceOf[Long])
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015.03.18")) ==
-      null.asInstanceOf[Long])
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("20150318")) ==
-      null.asInstanceOf[Long])
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-031-8")) ==
-      null.asInstanceOf[Long])
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03.17-20:0"))
-      == null.asInstanceOf[Long])
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03.17-0:70"))
-      == null.asInstanceOf[Long])
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03.17-1:0:0"))
-      == null.asInstanceOf[Long])
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("238")).isEmpty)
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18 123142")).isEmpty)
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T123123")).isEmpty)
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18X")).isEmpty)
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015/03/18")).isEmpty)
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015.03.18")).isEmpty)
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("20150318")).isEmpty)
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-031-8")).isEmpty)
+    assert(DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2015-03-18T12:03.17-20:0")).isEmpty)
+    assert(DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2015-03-18T12:03.17-0:70")).isEmpty)
+    assert(DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2015-03-18T12:03.17-1:0:0")).isEmpty)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -94,29 +94,29 @@ class DateTimeUtilsSuite extends SparkFunSuite {
     var c = Calendar.getInstance()
     c.set(2015, 0, 28, 0, 0, 0)
     c.set(Calendar.MILLISECOND, 0)
-    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-01-28")).get ==
+    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-01-28")).get ===
       c.getTimeInMillis / millisPerDay)
     c.set(2015, 0, 1, 0, 0, 0)
     c.set(Calendar.MILLISECOND, 0)
-    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015")).get ==
+    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015")).get ===
       c.getTimeInMillis / millisPerDay)
     c = Calendar.getInstance()
     c.set(2015, 2, 1, 0, 0, 0)
     c.set(Calendar.MILLISECOND, 0)
-    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03")).get ==
+    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03")).get ===
       c.getTimeInMillis / millisPerDay)
     c = Calendar.getInstance()
     c.set(2015, 2, 18, 0, 0, 0)
     c.set(Calendar.MILLISECOND, 0)
-    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18")).get ==
+    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18")).get ===
       c.getTimeInMillis / millisPerDay)
-    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18 ")).get ==
+    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18 ")).get ===
       c.getTimeInMillis / millisPerDay)
-    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18 123142")).get ==
+    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18 123142")).get ===
       c.getTimeInMillis / millisPerDay)
-    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18T123123")).get ==
+    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18T123123")).get ===
       c.getTimeInMillis / millisPerDay)
-    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18T")).get ==
+    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18T")).get ===
       c.getTimeInMillis / millisPerDay)
 
     assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18X")).isEmpty)
@@ -130,117 +130,117 @@ class DateTimeUtilsSuite extends SparkFunSuite {
     var c = Calendar.getInstance()
     c.set(1969, 11, 31, 16, 0, 0)
     c.set(Calendar.MILLISECOND, 0)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("1969-12-31 16:00:00")).get ==
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("1969-12-31 16:00:00")).get ===
       c.getTimeInMillis * 1000)
     c.set(2015, 0, 1, 0, 0, 0)
     c.set(Calendar.MILLISECOND, 0)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015")).get ==
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015")).get ===
       c.getTimeInMillis * 1000)
     c = Calendar.getInstance()
     c.set(2015, 2, 1, 0, 0, 0)
     c.set(Calendar.MILLISECOND, 0)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03")).get ==
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03")).get ===
       c.getTimeInMillis * 1000)
     c = Calendar.getInstance()
     c.set(2015, 2, 18, 0, 0, 0)
     c.set(Calendar.MILLISECOND, 0)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18")).get ==
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18")).get ===
       c.getTimeInMillis * 1000)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18 ")).get ==
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18 ")).get ===
       c.getTimeInMillis * 1000)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T")).get ==
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T")).get ===
       c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance()
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 0)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18 12:03:17")).get ==
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18 12:03:17")).get ===
       c.getTimeInMillis * 1000)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17")).get ==
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17")).get ===
       c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("GMT-13:53"))
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 0)
     assert(DateTimeUtils.stringToTimestamp(
-      UTF8String.fromString("2015-03-18T12:03:17-13:53")).get == c.getTimeInMillis * 1000)
+      UTF8String.fromString("2015-03-18T12:03:17-13:53")).get === c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 0)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17Z")).get ==
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17Z")).get ===
       c.getTimeInMillis * 1000)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18 12:03:17Z")).get ==
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18 12:03:17Z")).get ===
       c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("GMT-01:00"))
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 0)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17-1:0")).get ==
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17-1:0")).get ===
       c.getTimeInMillis * 1000)
     assert(DateTimeUtils.stringToTimestamp(
-      UTF8String.fromString("2015-03-18T12:03:17-01:00")).get == c.getTimeInMillis * 1000)
+      UTF8String.fromString("2015-03-18T12:03:17-01:00")).get === c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("GMT+07:30"))
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 0)
     assert(DateTimeUtils.stringToTimestamp(
-      UTF8String.fromString("2015-03-18T12:03:17+07:30")).get == c.getTimeInMillis * 1000)
+      UTF8String.fromString("2015-03-18T12:03:17+07:30")).get === c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("GMT+07:03"))
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 0)
     assert(DateTimeUtils.stringToTimestamp(
-      UTF8String.fromString("2015-03-18T12:03:17+07:03")).get == c.getTimeInMillis * 1000)
+      UTF8String.fromString("2015-03-18T12:03:17+07:03")).get === c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance()
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 123)
     assert(DateTimeUtils.stringToTimestamp(
-      UTF8String.fromString("2015-03-18 12:03:17.123")).get == c.getTimeInMillis * 1000)
+      UTF8String.fromString("2015-03-18 12:03:17.123")).get === c.getTimeInMillis * 1000)
     assert(DateTimeUtils.stringToTimestamp(
-      UTF8String.fromString("2015-03-18T12:03:17.123")).get == c.getTimeInMillis * 1000)
+      UTF8String.fromString("2015-03-18T12:03:17.123")).get === c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 456)
     assert(DateTimeUtils.stringToTimestamp(
-      UTF8String.fromString("2015-03-18T12:03:17.456Z")).get  == c.getTimeInMillis * 1000)
+      UTF8String.fromString("2015-03-18T12:03:17.456Z")).get  === c.getTimeInMillis * 1000)
     assert(DateTimeUtils.stringToTimestamp(
-      UTF8String.fromString("2015-03-18 12:03:17.456Z")).get  == c.getTimeInMillis * 1000)
+      UTF8String.fromString("2015-03-18 12:03:17.456Z")).get  === c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("GMT-01:00"))
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 123)
     assert(DateTimeUtils.stringToTimestamp(
-      UTF8String.fromString("2015-03-18T12:03:17.123-1:0")).get  == c.getTimeInMillis * 1000)
+      UTF8String.fromString("2015-03-18T12:03:17.123-1:0")).get  === c.getTimeInMillis * 1000)
     assert(DateTimeUtils.stringToTimestamp(
-      UTF8String.fromString("2015-03-18T12:03:17.123-01:00")).get ==  c.getTimeInMillis * 1000)
+      UTF8String.fromString("2015-03-18T12:03:17.123-01:00")).get ===  c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("GMT+07:30"))
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 123)
     assert(DateTimeUtils.stringToTimestamp(
-      UTF8String.fromString("2015-03-18T12:03:17.123+07:30")).get ==  c.getTimeInMillis * 1000)
+      UTF8String.fromString("2015-03-18T12:03:17.123+07:30")).get ===  c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("GMT+07:30"))
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 123)
     assert(DateTimeUtils.stringToTimestamp(
-      UTF8String.fromString("2015-03-18T12:03:17.123+07:30")).get == c.getTimeInMillis * 1000)
+      UTF8String.fromString("2015-03-18T12:03:17.123+07:30")).get === c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("GMT+07:30"))
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 123)
     assert(DateTimeUtils.stringToTimestamp(
-      UTF8String.fromString("2015-03-18T12:03:17.123121+7:30")).get ==
+      UTF8String.fromString("2015-03-18T12:03:17.123121+7:30")).get ===
         c.getTimeInMillis * 1000 + 121)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("GMT+07:30"))
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 123)
     assert(DateTimeUtils.stringToTimestamp(
-      UTF8String.fromString("2015-03-18T12:03:17.12312+7:30")).get ==
+      UTF8String.fromString("2015-03-18T12:03:17.12312+7:30")).get ===
         c.getTimeInMillis * 1000 + 120)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("GMT+07:30"))
@@ -249,7 +249,7 @@ class DateTimeUtilsSuite extends SparkFunSuite {
     c.set(Calendar.SECOND, 15)
     c.set(Calendar.MILLISECOND, 123)
     assert(DateTimeUtils.stringToTimestamp(
-      UTF8String.fromString("T18:12:15.12312+7:30")).get ==
+      UTF8String.fromString("T18:12:15.12312+7:30")).get ===
       c.getTimeInMillis * 1000 + 120)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("GMT+07:30"))
@@ -258,14 +258,36 @@ class DateTimeUtilsSuite extends SparkFunSuite {
     c.set(Calendar.SECOND, 15)
     c.set(Calendar.MILLISECOND, 123)
     assert(DateTimeUtils.stringToTimestamp(
-      UTF8String.fromString("18:12:15.12312+7:30")).get ==
+      UTF8String.fromString("18:12:15.12312+7:30")).get ===
       c.getTimeInMillis * 1000 + 120)
 
     c = Calendar.getInstance()
     c.set(2011, 4, 6, 7, 8, 9)
     c.set(Calendar.MILLISECOND, 100)
     assert(DateTimeUtils.stringToTimestamp(
-      UTF8String.fromString("2011-05-06 07:08:09.1000")).get == c.getTimeInMillis * 1000)
+      UTF8String.fromString("2011-05-06 07:08:09.1000")).get === c.getTimeInMillis * 1000)
+
+    val defaultTimeZone = TimeZone.getDefault
+    TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"))
+
+    c = Calendar.getInstance()
+    c.set(2015, 2, 8, 2, 0, 0)
+    c.set(Calendar.MILLISECOND, 0)
+    assert(DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2015-3-8 2:0:0")).get === c.getTimeInMillis * 1000)
+    c.add(Calendar.MINUTE, 30)
+    assert(DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2015-3-8 3:30:0")).get === c.getTimeInMillis * 1000)
+    assert(DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2015-3-8 2:30:0")).get === c.getTimeInMillis * 1000)
+
+    c = Calendar.getInstance()
+    c.set(2015, 10, 1, 1, 59, 0)
+    c.set(Calendar.MILLISECOND, 0)
+    c.add(Calendar.MINUTE, 31)
+    assert(DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2015-11-1 2:30:0")).get === c.getTimeInMillis * 1000)
+    TimeZone.setDefault(defaultTimeZone)
 
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("238")).isEmpty)
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18 123142")).isEmpty)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -90,155 +90,187 @@ class DateTimeUtilsSuite extends SparkFunSuite {
   }
 
   test("string to date") {
+    val millisPerDay = 1000L * 3600L * 24L
     var c = Calendar.getInstance()
     c.set(2015, 0, 28, 0, 0, 0)
     c.set(Calendar.MILLISECOND, 0)
     assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-01-28")) ==
-      new Date(c.getTimeInMillis))
+      c.getTimeInMillis / millisPerDay)
     c.set(2015, 0, 1, 0, 0, 0)
     c.set(Calendar.MILLISECOND, 0)
     assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015")) ==
-      new Date(c.getTimeInMillis))
+      c.getTimeInMillis / millisPerDay)
     c = Calendar.getInstance()
     c.set(2015, 2, 1, 0, 0, 0)
     c.set(Calendar.MILLISECOND, 0)
     assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03")) ==
-      new Date(c.getTimeInMillis))
+      c.getTimeInMillis / millisPerDay)
     c = Calendar.getInstance()
     c.set(2015, 2, 18, 0, 0, 0)
     c.set(Calendar.MILLISECOND, 0)
     assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18")) ==
-      new Date(c.getTimeInMillis))
+      c.getTimeInMillis / millisPerDay)
     assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18 ")) ==
-      new Date(c.getTimeInMillis))
+      c.getTimeInMillis / millisPerDay)
     assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18 123142")) ==
-      new Date(c.getTimeInMillis))
+      c.getTimeInMillis / millisPerDay)
     assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18T123123")) ==
-      new Date(c.getTimeInMillis))
+      c.getTimeInMillis / millisPerDay)
     assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18T")) ==
-      new Date(c.getTimeInMillis))
+      c.getTimeInMillis / millisPerDay)
 
-    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18X")) == null)
-    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015/03/18")) == null)
-    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015.03.18")) == null)
-    assert(DateTimeUtils.stringToDate(UTF8String.fromString("20150318")) == null)
-    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-031-8")) == null)
+    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-03-18X")) ==
+      null.asInstanceOf[Int])
+    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015/03/18")) ==
+      null.asInstanceOf[Int])
+    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015.03.18")) ==
+      null.asInstanceOf[Int])
+    assert(DateTimeUtils.stringToDate(UTF8String.fromString("20150318")) ==
+      null.asInstanceOf[Int])
+    assert(DateTimeUtils.stringToDate(UTF8String.fromString("2015-031-8")) ==
+      null.asInstanceOf[Int])
   }
 
   test("string to timestamp") {
-
     var c = Calendar.getInstance()
-    c.set(2011, 4, 6, 7, 8, 9)
-    c.set(Calendar.MILLISECOND, 100)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2011-05-06 07:08:09.1000")) ==
-      new Timestamp(c.getTimeInMillis))
     c.set(1969, 11, 31, 16, 0, 0)
     c.set(Calendar.MILLISECOND, 0)
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("1969-12-31 16:00:00")) ==
-      new Timestamp(c.getTimeInMillis))
+      c.getTimeInMillis * 1000)
     c.set(2015, 0, 1, 0, 0, 0)
     c.set(Calendar.MILLISECOND, 0)
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015")) ==
-      new Timestamp(c.getTimeInMillis))
+      c.getTimeInMillis * 1000)
     c = Calendar.getInstance()
     c.set(2015, 2, 1, 0, 0, 0)
     c.set(Calendar.MILLISECOND, 0)
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03")) ==
-      new Timestamp(c.getTimeInMillis))
+      c.getTimeInMillis * 1000)
     c = Calendar.getInstance()
     c.set(2015, 2, 18, 0, 0, 0)
     c.set(Calendar.MILLISECOND, 0)
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18")) ==
-      new Timestamp(c.getTimeInMillis))
+      c.getTimeInMillis * 1000)
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18 ")) ==
-      new Timestamp(c.getTimeInMillis))
+      c.getTimeInMillis * 1000)
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T")) ==
-      new Timestamp(c.getTimeInMillis))
+      c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance()
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 0)
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18 12:03:17")) ==
-      new Timestamp(c.getTimeInMillis))
+      c.getTimeInMillis * 1000)
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17")) ==
-      new Timestamp(c.getTimeInMillis))
+      c.getTimeInMillis * 1000)
+
+    c = Calendar.getInstance(TimeZone.getTimeZone("GMT-13:53"))
+    c.set(2015, 2, 18, 12, 3, 17)
+    c.set(Calendar.MILLISECOND, 0)
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17-13:53")) ==
+      c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 0)
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17Z")) ==
-      new Timestamp(c.getTimeInMillis))
+      c.getTimeInMillis * 1000)
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18 12:03:17Z")) ==
-      new Timestamp(c.getTimeInMillis))
+      c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("GMT-01:00"))
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 0)
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17-1:0")) ==
-      new Timestamp(c.getTimeInMillis))
+      c.getTimeInMillis * 1000)
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17-01:00")) ==
-      new Timestamp(c.getTimeInMillis))
+      c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("GMT+07:30"))
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 0)
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17+07:30")) ==
-      new Timestamp(c.getTimeInMillis))
+      c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("GMT+07:03"))
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 0)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17+7:3")) ==
-      new Timestamp(c.getTimeInMillis))
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17+07:03")) ==
+      c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance()
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 123)
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18 12:03:17.123")) ==
-      new Timestamp(c.getTimeInMillis))
+      c.getTimeInMillis * 1000)
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17.123")) ==
-      new Timestamp(c.getTimeInMillis))
+      c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 456)
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17.456Z")) ==
-      new Timestamp(c.getTimeInMillis))
+      c.getTimeInMillis * 1000)
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18 12:03:17.456Z")) ==
-      new Timestamp(c.getTimeInMillis))
+      c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("GMT-01:00"))
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 123)
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17.123-1:0")) ==
-      new Timestamp(c.getTimeInMillis))
+      c.getTimeInMillis * 1000)
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17.123-01:00"))
-      == new Timestamp(c.getTimeInMillis))
+      ==  c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("GMT+07:30"))
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 123)
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17.123+07:30"))
-      == new Timestamp(c.getTimeInMillis))
+      ==  c.getTimeInMillis * 1000)
 
-    c = Calendar.getInstance(TimeZone.getTimeZone("GMT+07:03"))
+    c = Calendar.getInstance(TimeZone.getTimeZone("GMT+07:30"))
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 123)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17.123+7:3")) ==
-      new Timestamp(c.getTimeInMillis))
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17.123+07:30")) ==
+      c.getTimeInMillis * 1000)
 
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18 123142")) == null)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T123123")) == null)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18X")) == null)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015/03/18")) == null)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015.03.18")) == null)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("20150318")) == null)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-031-8")) == null)
+    c = Calendar.getInstance(TimeZone.getTimeZone("GMT+07:30"))
+    c.set(2015, 2, 18, 12, 3, 17)
+    c.set(Calendar.MILLISECOND, 123)
+    assert(DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2015-03-18T12:03:17.123121+7:30")) == c.getTimeInMillis * 1000 + 121)
+
+    c = Calendar.getInstance(TimeZone.getTimeZone("GMT+07:30"))
+    c.set(2015, 2, 18, 12, 3, 17)
+    c.set(Calendar.MILLISECOND, 123)
+    assert(DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2015-03-18T12:03:17.12312+7:30")) == c.getTimeInMillis * 1000 + 120)
+
+    c = Calendar.getInstance()
+    c.set(2011, 4, 6, 7, 8, 9)
+    c.set(Calendar.MILLISECOND, 100)
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2011-05-06 07:08:09.1000")) ==
+      c.getTimeInMillis * 1000)
+
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18 123142")) ==
+      null.asInstanceOf[Long])
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T123123")) ==
+      null.asInstanceOf[Long])
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18X")) ==
+      null.asInstanceOf[Long])
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015/03/18")) ==
+      null.asInstanceOf[Long])
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015.03.18")) ==
+      null.asInstanceOf[Long])
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("20150318")) ==
+      null.asInstanceOf[Long])
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-031-8")) ==
+      null.asInstanceOf[Long])
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03.17-20:0"))
-      == null)
+      == null.asInstanceOf[Long])
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03.17-0:70"))
-      == null)
+      == null.asInstanceOf[Long])
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03.17-1:0:0"))
-      == null)
+      == null.asInstanceOf[Long])
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -268,6 +268,8 @@ class DateTimeUtilsSuite extends SparkFunSuite {
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2011-05-06 07:08:09.1000")) ==
       c.getTimeInMillis * 1000)
 
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("238")) ==
+      null.asInstanceOf[Long])
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18 123142")) ==
       null.asInstanceOf[Long])
     assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T123123")) ==

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -231,8 +231,8 @@ class DateTimeUtilsSuite extends SparkFunSuite {
     c = Calendar.getInstance(TimeZone.getTimeZone("GMT+07:30"))
     c.set(2015, 2, 18, 12, 3, 17)
     c.set(Calendar.MILLISECOND, 123)
-    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17.123+07:30")) ==
-      c.getTimeInMillis * 1000)
+    assert(DateTimeUtils.stringToTimestamp(UTF8String.fromString("2015-03-18T12:03:17.123+07:30"))
+      == c.getTimeInMillis * 1000)
 
     c = Calendar.getInstance(TimeZone.getTimeZone("GMT+07:30"))
     c.set(2015, 2, 18, 12, 3, 17)


### PR DESCRIPTION
Jira https://issues.apache.org/jira/browse/SPARK-8995

In PR #6981we noticed that we cannot cast date strings that contains a time, like '2015-03-18 12:39:40' to date. Besides it's not possible to cast a string like '18:03:20' to a timestamp.

If a time is passed without a date, today is inferred as date.
