### PR TITLE
[SPARK-9006] [PYSPARK] fix microsecond loss in Python 3

### DIFF
--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -188,7 +188,8 @@ class TimestampType(AtomicType):
 
     def fromInternal(self, ts):
         if ts is not None:
-            return datetime.datetime.fromtimestamp(ts / 1e6)
+            # using int to avoid precision loss in float
+            return datetime.datetime.fromtimestamp(ts // 1000000).replace(microsecond=ts % 1000000)
 
 
 class DecimalType(FractionalType):


### PR DESCRIPTION
It may loss a microsecond if using timestamp as float, should be `int` instead.
