### PR TITLE
[SPARK-8682][SQL][WIP] Range Join

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
@@ -315,6 +315,10 @@ private[spark] object SQLConf {
     defaultValue = Some(false),
     doc = "<TODO>")
 
+  val RANGE_JOIN = booleanConf("spark.sql.planner.rangeJoin",
+    defaultValue = Some(false),
+    doc = "<TODO>")
+
   // This is only used for the thriftserver
   val THRIFTSERVER_POOL = stringConf("spark.sql.thriftserver.scheduler.pool",
     doc = "Set a Fair Scheduler pool for a JDBC client session")
@@ -456,6 +460,9 @@ private[sql] class SQLConf extends Serializable with CatalystConf {
    * to HashJoin.
    */
   private[spark] def sortMergeJoinEnabled: Boolean = getConf(SORTMERGE_JOIN)
+
+  /** When true the planner will use range join operator (instead of BNL) for range queries. */
+  private[spark] def rangeJoinEnabled: Boolean = getConf(RANGE_JOIN)
 
   /**
    * When set to true, Spark SQL will use the Janino at runtime to generate custom bytecode

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -868,6 +868,7 @@ class SQLContext(@transient val sparkContext: SparkContext)
       InMemoryScans ::
       ParquetOperations ::
       BasicOperators ::
+      BroadcastRangeJoin ::
       CartesianProduct ::
       BroadcastNestedLoopJoin :: Nil)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -228,10 +228,10 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
 
     def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
       case ExtractRangeJoinKeys(CanBroadcast(left), right,
-          leftKeys, rightKeys, equality) =>
+          leftKeys, rightKeys, equality) if sqlContext.conf.rangeJoinEnabled =>
         makeRangeJoin(leftKeys, rightKeys, equality, joins.BuildLeft, left, right) :: Nil
       case ExtractRangeJoinKeys(left, CanBroadcast(right),
-          leftKeys, rightKeys, equality) =>
+          leftKeys, rightKeys, equality) if sqlContext.conf.rangeJoinEnabled =>
         makeRangeJoin(leftKeys, rightKeys, equality, joins.BuildRight, left, right) :: Nil
       case _ => Nil
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastRangeJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastRangeJoin.scala
@@ -1,0 +1,312 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.joins
+
+import org.apache.spark.sql.catalyst.util.TypeUtils
+import org.apache.spark.util.ThreadUtils
+
+import scala.annotation.tailrec
+import scala.collection.mutable
+import scala.concurrent._
+import scala.concurrent.duration._
+
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.execution.{BinaryNode, SparkPlan}
+
+/**
+ * Performs an inner range join on two tables. A range join typically has the following form:
+ *
+ * SELECT A.*
+ *        ,B.*
+ * FROM   tableA A
+ *        JOIN tableB B
+ *         ON A.start <= B.end
+ *          AND A.end > B.start
+ *
+ * The implementation builds a range index from the smaller build side, broadcasts this index
+ * to all executors. The streaming side is then matched against the index. This reduces the number
+ * of comparisons made by log(n) (n is the number of records in the build table) over the
+ * typical solution (Nested Loop Join).
+ *
+ * TODO
+ * TODO NULL values
+ * TODO Equality
+ * TODO Outer joins?
+ */
+@DeveloperApi
+case class BroadcastRangeJoin(
+    leftKeys: Seq[Expression],
+    rightKeys: Seq[Expression],
+    equality: Seq[Boolean],
+    buildSide: BuildSide,
+    left: SparkPlan,
+    right: SparkPlan)
+  extends BinaryNode {
+
+  private[this] lazy val (buildPlan, streamedPlan) = buildSide match {
+    case BuildLeft => (left, right)
+    case BuildRight => (right, left)
+  }
+
+  private[this] lazy val (buildKeys, streamedKeys) = buildSide match {
+    case BuildLeft => (leftKeys, rightKeys)
+    case BuildRight => (rightKeys, leftKeys)
+  }
+
+  override def output: Seq[Attribute] = left.output ++ right.output
+
+  @transient
+  private[this] lazy val buildSideKeyGenerator: Projection =
+    newProjection(buildKeys, buildPlan.output)
+
+  @transient
+  private[this] lazy val streamSideKeyGenerator: () => MutableProjection =
+    newMutableProjection(streamedKeys, streamedPlan.output)
+
+  private[this] val timeout: Duration = {
+    val timeoutValue = sqlContext.conf.broadcastTimeout
+    if (timeoutValue < 0) {
+      Duration.Inf
+    } else {
+      timeoutValue.seconds
+    }
+  }
+
+  // Construct the range index.
+  @transient
+  private[this] val indexBroadcastFuture = future {
+    // Deal with equality.
+    val Seq(allowLowEqual: Boolean, allowHighEqual: Boolean) = buildSide match {
+      case BuildLeft => equality.head
+      case BuildRight => equality.reverse
+    }
+
+    // Get the ordering for the datatype.
+    val ordering = TypeUtils.getOrdering(buildKeys.head.dataType)
+
+    // Note that we use .execute().collect() because we don't want to convert data to Scala types
+    // TODO find out if the result of a sort and a collect is still sorted.
+    val events = buildPlan.execute().flatMap(RangeIndex.toRangeEvent(
+      buildSideKeyGenerator, ordering)).collect()
+
+    // Create the index.
+    val index = RangeIndex.build(ordering, events, allowLowEqual, allowHighEqual)
+
+    // Broadcast the index.
+    sparkContext.broadcast(index)
+  }(BroadcastRangeJoin.broadcastRangeJoinExecutionContext)
+
+  override def doExecute(): RDD[InternalRow] = {
+    // Construct the range index.
+    val indexBC = Await.result(indexBroadcastFuture, timeout)
+
+    // Iterate over the streaming relation.
+    streamedPlan.execute().mapPartitions { stream =>
+      val index = indexBC.value
+      val streamSideKeys = streamSideKeyGenerator()
+      val join = new JoinedRow2 // TODO create our own join row...
+      stream.flatMap { sRow =>
+        // Get the bounds.
+        val lowHigh = streamSideKeys(sRow)
+        val low = lowHigh(0)
+        val high = lowHigh(1)
+
+        // Only allow non-null keys.
+        if (low != null && high != null) {
+          index.intersect(low, high).map { bRow =>
+            buildSide match {
+              case BuildRight => join(sRow, bRow)
+              case BuildLeft => join(bRow, sRow)
+            }
+          }
+        }
+        else Iterator.empty
+      }
+    }
+  }
+}
+
+private[joins] object BroadcastRangeJoin {
+  private val broadcastRangeJoinExecutionContext = ExecutionContext.fromExecutorService(
+    ThreadUtils.newDaemonCachedThreadPool("broadcast-range-join", 128))
+}
+
+private[joins] object RangeIndex {
+  type RangeEvent = (Any, Int, InternalRow)
+
+  /** Build a range index from an array of unsorted events. */
+  def build(ordering: Ordering[Any], events: Array[RangeEvent],
+      allowLowEqual: Boolean, allowHighEqual: Boolean): RangeIndex = {
+    buildFromSorted(ordering, events.sortBy(_._1)(ordering), allowLowEqual, allowHighEqual)
+  }
+
+  /** Build a range index from an array of sorted events. */
+  def buildFromSorted(ordering: Ordering[Any], events: Array[RangeEvent],
+      allowLowEqual: Boolean, allowHighEqual: Boolean): RangeIndex = {
+    // Persisted index components. A dummy null value is added to the array. This makes searching
+    // easier and it allows us to deal gracefully with unbound keys.
+    val keys = mutable.Buffer[Any](null)
+    val activatedRows = mutable.Buffer(Array.empty[InternalRow])
+    val activeRows = mutable.Buffer(Array.empty[InternalRow])
+
+    // Current State of the iteration.
+    var currentKey: Any = null
+    var currentRowCount = 0
+    val currentActivatedRows = mutable.Buffer.empty[InternalRow]
+    val currentActiveRows = mutable.Buffer.empty[InternalRow]
+
+    // Store the current key state in the final results.
+    def finishKey = {
+      if (currentRowCount > 0) {
+        keys += currentKey
+        activatedRows += currentActivatedRows.toArray
+        activeRows += currentActiveRows.toArray
+      }
+    }
+    events.foreach {
+      case (key, flow, row) =>
+        // Check if we have finished processing a key
+        if (currentKey != key) {
+          finishKey
+          currentKey = key
+          currentActivatedRows.clear()
+          currentRowCount = 0
+        }
+
+        // Keep track of rows.
+        flow match {
+          case 1 =>
+            currentActiveRows += row
+            currentActivatedRows += row
+          case -1 =>
+            currentActiveRows -= row
+        }
+        currentRowCount += 1
+    }
+
+    // Store the final events.
+    finishKey
+
+    // Determine corrections based on equality
+    val lowBoundEqualCorrection = if (allowLowEqual) 0 else 1
+    val highBoundEqualCorrection = if (allowHighEqual) 1 else 0
+
+    // Create the index.
+    new RangeIndex(ordering, keys.toArray, activeRows.toArray, activatedRows.toArray,
+      lowBoundEqualCorrection, highBoundEqualCorrection)
+  }
+
+  /** Create a function that turns a row into its respective range events. */
+  def toRangeEvent(lowHighExtr: Projection, cmp: Ordering[Any]):
+      (InternalRow => Seq[RangeEvent]) = {
+    (row: InternalRow) => {
+      val Row(low, high) = lowHighExtr(row)
+      // Valid points and intervals.
+      if (low != null && high != null && cmp.compare(low, high) <= 0) {
+        val copy = row.copy()
+        (low, 1, copy) ::(high, -1, copy) :: Nil
+      }
+      // Nulls
+      else Nil
+    }
+  }
+}
+
+/**
+ *
+ * @param ordering used retrieve
+ * @param keys array
+ * @param active contains the rows that are 'active' between the current key and the next key.
+ * @param activated contains the row that have been activated at the current key.
+ */
+private[joins] class RangeIndex(
+    private[this] val ordering: Ordering[Any],
+    private[this] val keys: Array[Any],
+    private[this] val active: Array[Array[InternalRow]],
+    private[this] val activated: Array[Array[InternalRow]],
+    private[this] val lowBoundEqualCorrection: Int,
+    private[this] val highBoundEqualCorrection: Int) {
+
+  /**
+   * Find the index of the closest upper bound to the value given. We can correct the result of a
+   * match by passing an index correction to the function.
+   *
+   * @param value to find the index of the closest upper bound.
+   * @return the index of the closest upper bound.
+   */
+  @tailrec
+  final def closestLowerKey(value: Any, equalCorrection: Int,
+      first: Int = 0, last: Int = keys.length): Int = {
+    if (first < last) {
+      val index = first + (last - first - 1) / 2
+      val key = keys(index)
+      val cmp = if (key == null) 1
+      else ordering.compare(key, value)
+      if (cmp == 0) index + equalCorrection
+      else if (cmp < 0) closestLowerKey(value, equalCorrection, first, index)
+      else closestLowerKey(value, equalCorrection, index + 1, last)
+    } else first
+  }
+
+  /**
+   * Calculate the intersection between the index and a given range.
+   *
+   * @param low point of the range. Note that a NULL value is currently interpreted as an unbound
+   *            (negative infinite) value.
+   * @param high point of the range to intersect with. Note that a NULL value is currently
+   *            interpreted as an unbound (infinite) value.
+   * @return an iterator containing all the rows that fall within the given range.
+   */
+  final def intersect(low: Any, high: Any): Iterator[InternalRow] = {
+    // Find first index by searching for closest the upper bound to the low value.
+    val first = if (low == null) 0
+    else closestLowerKey(low, lowBoundEqualCorrection)
+
+    // Find last index by searching for closest the upper bound to the high value.
+    val last = if (high == null || first == keys.length - 1) keys.length - 1
+    else closestLowerKey(high, highBoundEqualCorrection, first)
+
+    // Return the iterator.
+    new Iterator[InternalRow] {
+      var index = first
+      var rowIndex = 0
+      var rows = active(index)
+
+      def hasNext: Boolean = {
+        var result = rows != null && rowIndex < rows.length
+        while (!result && index < last) {
+          index += 1
+          rowIndex = 0
+          rows = activated(index)
+          result = rows != null && rowIndex < rows.length
+        }
+        result
+      }
+
+      def next() = {
+        val row = rows(rowIndex)
+        rowIndex += 1
+        row
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/RangeIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/RangeIndexSuite.scala
@@ -95,7 +95,7 @@ class RangeIndexSuite extends SparkFunSuite {
 
     // Points
     assertResult(Nil)(index1.intersect(2, 2).toSeq)
-    assertResult(r3 :: r5 :: Nil)(index1.intersect(3, 3).toSeq)
+    assertResult(r5 :: Nil)(index1.intersect(4, 4).toSeq)
 
     // Low Bound Included - High Bound Included:
     val index2 = RangeIndex.build(ordering, rs, allowLowEqual = true, allowHighEqual = true)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/RangeIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/RangeIndexSuite.scala
@@ -1,0 +1,100 @@
+package org.apache.spark.sql.execution.joins
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{BoundReference, InterpretedMutableProjection}
+import org.apache.spark.sql.catalyst.util.TypeUtils
+import org.apache.spark.sql.types.IntegerType
+
+class RangeIndexSuite extends SparkFunSuite {
+  private[this] val ordering = TypeUtils.getOrdering(IntegerType)
+
+  private[this] val projection = new InterpretedMutableProjection(Seq(
+    BoundReference(0, IntegerType, nullable = false),
+    BoundReference(1, IntegerType, nullable = false)))
+
+  private[this] val eventifier = RangeIndex.toRangeEvent(projection, ordering)
+
+  test("RangeIndex Point Query") {
+    val r1 = InternalRow(1, 1)
+    val r2 = InternalRow(2, 2)
+    val r3 = InternalRow(3, 3)
+    val r4 = InternalRow(4, 4)
+    val r5 = InternalRow(4, 4)
+    val rs = Array(r1, r2, r3, r4, r5).flatMap(eventifier)
+
+    // Low Bound Included - High Bound Excluded:
+    val index1 = RangeIndex.build(ordering, rs, allowLowEqual = true, allowHighEqual = false)
+
+    // All
+    assertResult(Seq(r1, r2, r3, r4, r5))(index1.intersect(null, null).toSeq)
+
+    // Bounds - l <= p && p < h
+    assertResult(Nil)(index1.intersect(5, null).toSeq)
+    assertResult(r3 :: r4 :: r5 :: Nil)(index1.intersect(3, null).toSeq)
+    assertResult(Nil)(index1.intersect(null, 1).toSeq)
+    assertResult(r1 :: Nil)(index1.intersect(null, 2).toSeq)
+
+    // Ranges
+    assertResult(r1 :: Nil)(index1.intersect(1, 2).toSeq)
+    assertResult(r3 :: r4 :: r5 :: Nil)(index1.intersect(3, 5).toSeq)
+
+    // Low Bound Excluded - High Bound Included:
+    val index2 = RangeIndex.build(ordering, rs, allowLowEqual = false, allowHighEqual = true)
+
+    // Bounds
+    assertResult(r4 :: r5 :: Nil)(index2.intersect(3, null).toSeq)
+    assertResult(r1 :: Nil)(index2.intersect(null, 1).toSeq)
+    assertResult(r1 :: r2 :: Nil)(index2.intersect(null, 2).toSeq)
+
+    // Ranges
+    assertResult(r2 :: Nil)(index2.intersect(1, 2).toSeq)
+    assertResult(r4 :: r5 :: Nil)(index2.intersect(3, 5).toSeq)
+  }
+
+  test("RangeIndex Interval Query") {
+    val r1 = InternalRow(1, 2)
+    val r3 = InternalRow(3, 4)
+    val r4 = InternalRow(4, 5)
+    val r5 = InternalRow(3, 6)
+    val rs = Array(r1, r3, r4, r5).flatMap(eventifier)
+
+    // Low Bound Excluded - High Bound Excluded (Normal when intersecting intervals):
+    val index1 = RangeIndex.build(ordering, rs, allowLowEqual = false, allowHighEqual = false)
+
+    // All
+    assertResult(Seq(r1, r3, r5, r4))(index1.intersect(null, null).toSeq)
+
+    // Bounds
+    assertResult(r5 :: Nil)(index1.intersect(5, null).toSeq)
+    assertResult(r3 :: r5 :: r4 :: Nil)(index1.intersect(3, null).toSeq)
+    assertResult(Nil)(index1.intersect(null, 1).toSeq)
+    assertResult(r1 :: Nil)(index1.intersect(null, 2).toSeq)
+
+    // Ranges
+    assertResult(r1 :: Nil)(index1.intersect(1, 2).toSeq)
+    assertResult(r3 :: r5 :: r4 :: Nil)(index1.intersect(3, 5).toSeq)
+    assertResult(r5 :: r4 :: Nil)(index1.intersect(4, 5).toSeq)
+
+    // Points
+    assertResult(Nil)(index1.intersect(2, 2).toSeq)
+    assertResult(r3 :: r5 :: Nil)(index1.intersect(3, 3).toSeq)
+
+    // Low Bound Included - High Bound Included:
+    val index2 = RangeIndex.build(ordering, rs, allowLowEqual = true, allowHighEqual = true)
+
+    // Bounds
+    assertResult(r5 :: r4 :: Nil)(index2.intersect(5, null).toSeq)
+    assertResult(r1 :: Nil)(index2.intersect(null, 1).toSeq)
+    assertResult(r1 :: Nil)(index2.intersect(null, 2).toSeq)
+
+    // Ranges
+    assertResult(r1 :: r3 :: r5 :: Nil)(index2.intersect(1, 3).toSeq)
+    assertResult(r3 :: r5 :: r4 :: Nil)(index2.intersect(3, 5).toSeq)
+    assertResult(r3 :: r5 :: r4 :: Nil)(index2.intersect(4, 5).toSeq)
+
+    // Points
+    assertResult(r1 :: Nil)(index2.intersect(2, 2).toSeq)
+    assertResult(r3 :: r5 :: Nil)(index2.intersect(3, 3).toSeq)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/RangeIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/RangeIndexSuite.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.sql.execution.joins
 
 import org.apache.spark.SparkFunSuite

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/RangeJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/RangeJoinSuite.scala
@@ -43,7 +43,13 @@ class RangeJoinSuite extends SparkPlanTest {
   test("interval-point range join") {
     // low1 <= point && point < high1
     checkAnswer2(intervals1, points, (left: SparkPlan, right: SparkPlan) =>
-      BroadcastRangeJoin(intervalKeys1, pointKeys, true :: false :: Nil, BuildRight, left, right),
+      BroadcastRangeJoin(
+        intervalKeys1,
+        pointKeys,
+        true :: false :: Nil,
+        BuildRight,
+        left,
+        right),
       Seq(
         (0, 2, 1),
         (1, 5, 1),
@@ -52,7 +58,13 @@ class RangeJoinSuite extends SparkPlanTest {
 
     // low1 <= point && point < high1
     checkAnswer2(intervals1, points, (left: SparkPlan, right: SparkPlan) =>
-      BroadcastRangeJoin(intervalKeys1, pointKeys, false :: false :: Nil, BuildRight, left, right),
+      BroadcastRangeJoin(
+        intervalKeys1,
+        pointKeys,
+        false :: false :: Nil,
+        BuildRight,
+        left,
+        right),
       Seq(
         (0, 2, 1),
         (1, 5, 3)
@@ -60,7 +72,13 @@ class RangeJoinSuite extends SparkPlanTest {
 
     // low <= point && point <= high1
     checkAnswer2(points, intervals1, (left: SparkPlan, right: SparkPlan) =>
-      BroadcastRangeJoin(pointKeys, intervalKeys1, true :: true :: Nil, BuildRight, left, right),
+      BroadcastRangeJoin(
+        pointKeys,
+        intervalKeys1,
+        true :: true :: Nil,
+        BuildRight,
+        left,
+        right),
       Seq(
         (1, 0, 1),
         (1, 0, 2),
@@ -70,7 +88,13 @@ class RangeJoinSuite extends SparkPlanTest {
 
     // low1 < point && point < high1
     checkAnswer2(intervals1, points, (left: SparkPlan, right: SparkPlan) =>
-      BroadcastRangeJoin(intervalKeys1, pointKeys, false :: false :: Nil, BuildLeft, left, right),
+      BroadcastRangeJoin(
+        intervalKeys1,
+        pointKeys,
+        false :: false :: Nil,
+        BuildLeft,
+        left,
+        right),
       Seq(
         (0, 2, 1),
         (1, 5, 3)
@@ -80,7 +104,13 @@ class RangeJoinSuite extends SparkPlanTest {
   test("interval-interval range join") {
     // low1 <= high2 && low2 < high1
     checkAnswer2(intervals1, intervals2, (left: SparkPlan, right: SparkPlan) =>
-      BroadcastRangeJoin(intervalKeys1, intervalKeys2, true :: false :: Nil, BuildRight, left, right),
+      BroadcastRangeJoin(
+        intervalKeys1,
+        intervalKeys2,
+        true :: false :: Nil,
+        BuildRight,
+        left,
+        right),
       Seq(
         (-1, 0, -2, -1),
         (0, 2, 1, 3),
@@ -89,7 +119,13 @@ class RangeJoinSuite extends SparkPlanTest {
 
     // low1 < high2 && low2 <= high1
     checkAnswer2(intervals1, intervals2, (left: SparkPlan, right: SparkPlan) =>
-      BroadcastRangeJoin(intervalKeys1, intervalKeys2, false :: true :: Nil, BuildLeft, left, right),
+      BroadcastRangeJoin(
+        intervalKeys1,
+        intervalKeys2,
+        false :: true :: Nil,
+        BuildLeft,
+        left,
+        right),
       Seq(
         (0, 1, 1, 3),
         (0, 2, 1, 3),
@@ -99,7 +135,13 @@ class RangeJoinSuite extends SparkPlanTest {
 
     // low1 < high2 && low2 < high1
     checkAnswer2(intervals1, intervals2, (left: SparkPlan, right: SparkPlan) =>
-      BroadcastRangeJoin(intervalKeys1, intervalKeys2, false :: false :: Nil, BuildRight, left, right),
+      BroadcastRangeJoin(
+        intervalKeys1,
+        intervalKeys2,
+        false :: false :: Nil,
+        BuildRight,
+        left,
+        right),
       Seq(
         (0, 2, 1, 3),
         (1, 5, 1, 3)
@@ -107,7 +149,13 @@ class RangeJoinSuite extends SparkPlanTest {
 
     // low1 <= high2 && low2 <= high1
     checkAnswer2(intervals1, intervals2, (left: SparkPlan, right: SparkPlan) =>
-      BroadcastRangeJoin(intervalKeys1, intervalKeys2, true :: true :: Nil, BuildLeft, left, right),
+      BroadcastRangeJoin(
+        intervalKeys1,
+        intervalKeys2,
+        true :: true :: Nil,
+        BuildLeft,
+        left,
+        right),
       Seq(
         (-1, 0, -2, -1),
         (0, 1, 1, 3),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/RangeJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/RangeJoinSuite.scala
@@ -32,7 +32,7 @@ class RangeJoinSuite extends SparkPlanTest {
   val intervals2 = Seq(
     (-2, -1),
     (-4, -2),
-    (1 ,3),
+    (1, 3),
     (5, 7)
   ).toDF("low2", "high2")
   val intervalKeys2 = Seq("low2", "high2").map(UnresolvedAttribute.apply)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/RangeJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/RangeJoinSuite.scala
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.joins
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.execution.{SparkPlan, SparkPlanTest}
+
+class RangeJoinSuite extends SparkPlanTest {
+  val intervals1 = Seq(
+    (-1, 0),
+    (0, 1),
+    (0, 2),
+    (1, 5)
+  ).toDF("low1", "high1")
+  val intervalKeys1 = Seq("low1", "high1").map(UnresolvedAttribute.apply)
+
+  val intervals2 = Seq(
+    (-2, -1),
+    (-4, -2),
+    (1 ,3),
+    (5, 7)
+  ).toDF("low2", "high2")
+  val intervalKeys2 = Seq("low2", "high2").map(UnresolvedAttribute.apply)
+
+  val points = Seq(-3, 1, 3, 6).map(Tuple1.apply).toDF("point")
+  val pointKeys = Seq("point", "point").map(UnresolvedAttribute.apply)
+
+  test("interval-point range join") {
+    // low1 <= point && point < high1
+    checkAnswer2(intervals1, points, (left: SparkPlan, right: SparkPlan) =>
+      BroadcastRangeJoin(intervalKeys1, pointKeys, true :: false :: Nil, BuildRight, left, right),
+      Seq(
+        (0, 2, 1),
+        (1, 5, 1),
+        (1, 5, 3)
+      ).map(Row.fromTuple))
+
+    // low1 <= point && point < high1
+    checkAnswer2(intervals1, points, (left: SparkPlan, right: SparkPlan) =>
+      BroadcastRangeJoin(intervalKeys1, pointKeys, false :: false :: Nil, BuildRight, left, right),
+      Seq(
+        (0, 2, 1),
+        (1, 5, 3)
+      ).map(Row.fromTuple))
+
+    // low <= point && point <= high1
+    checkAnswer2(points, intervals1, (left: SparkPlan, right: SparkPlan) =>
+      BroadcastRangeJoin(pointKeys, intervalKeys1, true :: true :: Nil, BuildRight, left, right),
+      Seq(
+        (1, 0, 1),
+        (1, 0, 2),
+        (1, 1, 5),
+        (3, 1, 5)
+      ).map(Row.fromTuple))
+
+    // low1 < point && point < high1
+    checkAnswer2(intervals1, points, (left: SparkPlan, right: SparkPlan) =>
+      BroadcastRangeJoin(intervalKeys1, pointKeys, false :: false :: Nil, BuildLeft, left, right),
+      Seq(
+        (0, 2, 1),
+        (1, 5, 3)
+      ).map(Row.fromTuple))
+  }
+
+  test("interval-interval range join") {
+    // low1 <= high2 && low2 < high1
+    checkAnswer2(intervals1, intervals2, (left: SparkPlan, right: SparkPlan) =>
+      BroadcastRangeJoin(intervalKeys1, intervalKeys2, true :: false :: Nil, BuildRight, left, right),
+      Seq(
+        (-1, 0, -2, -1),
+        (0, 2, 1, 3),
+        (1, 5, 1, 3)
+      ).map(Row.fromTuple))
+
+    // low1 < high2 && low2 <= high1
+    checkAnswer2(intervals1, intervals2, (left: SparkPlan, right: SparkPlan) =>
+      BroadcastRangeJoin(intervalKeys1, intervalKeys2, false :: true :: Nil, BuildLeft, left, right),
+      Seq(
+        (0, 1, 1, 3),
+        (0, 2, 1, 3),
+        (1, 5, 1, 3),
+        (1, 5, 5, 7)
+      ).map(Row.fromTuple))
+
+    // low1 < high2 && low2 < high1
+    checkAnswer2(intervals1, intervals2, (left: SparkPlan, right: SparkPlan) =>
+      BroadcastRangeJoin(intervalKeys1, intervalKeys2, false :: false :: Nil, BuildRight, left, right),
+      Seq(
+        (0, 2, 1, 3),
+        (1, 5, 1, 3)
+      ).map(Row.fromTuple))
+
+    // low1 <= high2 && low2 <= high1
+    checkAnswer2(intervals1, intervals2, (left: SparkPlan, right: SparkPlan) =>
+      BroadcastRangeJoin(intervalKeys1, intervalKeys2, true :: true :: Nil, BuildLeft, left, right),
+      Seq(
+        (-1, 0, -2, -1),
+        (0, 1, 1, 3),
+        (0, 2, 1, 3),
+        (1, 5, 1, 3),
+        (1, 5, 5, 7)
+      ).map(Row.fromTuple))
+  }
+}

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -454,6 +454,7 @@ class HiveContext(sc: SparkContext) extends SQLContext(sc) with Logging {
       LeftSemiJoin,
       HashJoin,
       BasicOperators,
+      BroadcastRangeJoin,
       CartesianProduct,
       BroadcastNestedLoopJoin
     )


### PR DESCRIPTION
_...copied from JIRA (SPARK-8682):_

Currently Spark SQL uses a Broadcast Nested Loop join (or a filtered Cartesian Join) when it has to execute the following range query:

```
SELECT A.*,
       B.*
FROM   tableA A
       JOIN tableB B
        ON A.start <= B.end
         AND A.end > B.start
```

This is horribly inefficient. The performance of this query can be greatly improved, when one of the tables can be broadcasted, by creating a range index. A range index is basically a sorted map containing the rows of the smaller table, indexed by both the high and low keys. using this structure the complexity of the query would go from O(N \* M) to O(N \* 2 \* LOG(M)), N = number of records in the larger table, M = number of records in the smaller (indexed) table.

This is currently a work in progress. I will be adding more tests and a small benchmark in the next couple of days. If you want to try this out, set the `spark.sql.planner.rangeJoin` option to `true` in the SQL configuration.
