### PR TITLE
[Minor][SQL] Allow spaces in the beginning and ending of string for Interval

### DIFF
--- a/unsafe/src/main/java/org/apache/spark/unsafe/types/Interval.java
+++ b/unsafe/src/main/java/org/apache/spark/unsafe/types/Interval.java
@@ -46,9 +46,10 @@ public final class Interval implements Serializable {
     return "(?:\\s+(-?\\d+)\\s+" + unit + "s?\\s*)?";
   }
 
-  private static Pattern p = Pattern.compile("\\s*interval" + unitRegex("year") + unitRegex("month") +
-    unitRegex("week") + unitRegex("day") + unitRegex("hour") + unitRegex("minute") +
-    unitRegex("second") + unitRegex("millisecond") + unitRegex("microsecond"));
+  private static Pattern p = Pattern.compile("\\s*interval" + unitRegex("year") +
+    unitRegex("month") + unitRegex("week") + unitRegex("day") + unitRegex("hour") +
+    unitRegex("minute") + unitRegex("second") + unitRegex("millisecond") +
+    unitRegex("microsecond"));
 
   private static long toLong(String s) {
     if (s == null) {

--- a/unsafe/src/main/java/org/apache/spark/unsafe/types/Interval.java
+++ b/unsafe/src/main/java/org/apache/spark/unsafe/types/Interval.java
@@ -43,10 +43,10 @@ public final class Interval implements Serializable {
    * Finally is the unit name, ends with an optional "s".
    */
   private static String unitRegex(String unit) {
-    return "(?:\\s+(-?\\d+)\\s+" + unit + "s?)?";
+    return "(?:\\s+(-?\\d+)\\s+" + unit + "s?\\s*)?";
   }
 
-  private static Pattern p = Pattern.compile("interval" + unitRegex("year") + unitRegex("month") +
+  private static Pattern p = Pattern.compile("\\s*interval" + unitRegex("year") + unitRegex("month") +
     unitRegex("week") + unitRegex("day") + unitRegex("hour") + unitRegex("minute") +
     unitRegex("second") + unitRegex("millisecond") + unitRegex("microsecond"));
 

--- a/unsafe/src/main/java/org/apache/spark/unsafe/types/Interval.java
+++ b/unsafe/src/main/java/org/apache/spark/unsafe/types/Interval.java
@@ -43,13 +43,12 @@ public final class Interval implements Serializable {
    * Finally is the unit name, ends with an optional "s".
    */
   private static String unitRegex(String unit) {
-    return "(?:\\s+(-?\\d+)\\s+" + unit + "s?\\s*)?";
+    return "(?:\\s+(-?\\d+)\\s+" + unit + "s?)?";
   }
 
-  private static Pattern p = Pattern.compile("\\s*interval" + unitRegex("year") +
-    unitRegex("month") + unitRegex("week") + unitRegex("day") + unitRegex("hour") +
-    unitRegex("minute") + unitRegex("second") + unitRegex("millisecond") +
-    unitRegex("microsecond"));
+  private static Pattern p = Pattern.compile("interval" + unitRegex("year") + unitRegex("month") +
+    unitRegex("week") + unitRegex("day") + unitRegex("hour") + unitRegex("minute") +
+    unitRegex("second") + unitRegex("millisecond") + unitRegex("microsecond"));
 
   private static long toLong(String s) {
     if (s == null) {
@@ -63,6 +62,7 @@ public final class Interval implements Serializable {
     if (s == null) {
       return null;
     }
+    s = s.trim();
     Matcher m = p.matcher(s);
     if (!m.matches() || s.equals("interval")) {
       return null;

--- a/unsafe/src/test/java/org/apache/spark/unsafe/types/IntervalSuite.java
+++ b/unsafe/src/test/java/org/apache/spark/unsafe/types/IntervalSuite.java
@@ -75,6 +75,12 @@ public class IntervalSuite {
     Interval result = new Interval(-5 * 12 + 23, 0);
     assertEquals(Interval.fromString(input), result);
 
+    input = "interval   -5  years  23   month   ";
+    assertEquals(Interval.fromString(input), result);
+
+    input = "  interval   -5  years  23   month   ";
+    assertEquals(Interval.fromString(input), result);
+
     // Error cases
     input = "interval   3month 1 hour";
     assertEquals(Interval.fromString(input), null);


### PR DESCRIPTION
This is a minor fixing for #7355 to allow spaces in the beginning and ending of string parsed to `Interval`.
