### PR TITLE
[SPARK-9020][SQL] Support mutable state in code gen expressions

### DIFF
--- a/core/src/main/scala/org/apache/spark/TaskContext.scala
+++ b/core/src/main/scala/org/apache/spark/TaskContext.scala
@@ -32,7 +32,13 @@ object TaskContext {
    */
   def get(): TaskContext = taskContext.get
 
-  private val taskContext: ThreadLocal[TaskContext] = new ThreadLocal[TaskContext]
+  /**
+   * Returns the partition id of currently active TaskContext. It will return 0
+   * if there is no active TaskContext for cases like local execution.
+   */
+  def getPartitionId(): Int = Option(taskContext.get).map(_.partitionId).getOrElse(0)
+
+  private[this] val taskContext: ThreadLocal[TaskContext] = new ThreadLocal[TaskContext]
 
   // Note: protected[spark] instead of private[spark] to prevent the following two from
   // showing up in JavaDoc.

--- a/core/src/main/scala/org/apache/spark/TaskContext.scala
+++ b/core/src/main/scala/org/apache/spark/TaskContext.scala
@@ -36,7 +36,14 @@ object TaskContext {
    * Returns the partition id of currently active TaskContext. It will return 0
    * if there is no active TaskContext for cases like local execution.
    */
-  def getPartitionId(): Int = Option(taskContext.get).map(_.partitionId).getOrElse(0)
+  def getPartitionId(): Int = {
+    val tc = taskContext.get()
+    if (tc == null) {
+      0
+    } else {
+      tc.partitionId()
+    }
+  }
 
   private[this] val taskContext: ThreadLocal[TaskContext] = new ThreadLocal[TaskContext]
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -56,13 +56,15 @@ class CodeGenContext {
    */
   val references: mutable.ArrayBuffer[Expression] = new mutable.ArrayBuffer[Expression]()
 
+  val mutableStates: mutable.ArrayBuffer[String] = mutable.ArrayBuffer.empty[String]
+
   /**
-   * Holding expressions' mutable states like `Rand.rng`, and keep them as member variables
-   * in generated classes like `SpecificProjection`.
-   * Each element is a 3-tuple: java type, variable name, variable value.
+   * Register expressions' mutable states like `MonotonicallyIncreasingID.count`, they will be
+   * kept as member variables in generated classes like `SpecificProjection`.
    */
-  val mutableStates: mutable.ArrayBuffer[(String, String, Any)] =
-    mutable.ArrayBuffer.empty[(String, String, Any)]
+  def addMutableState(javaType: String, variableName: String, initialValue: String): Unit = {
+    mutableStates += s"private $javaType $variableName = $initialValue;"
+  }
 
   val stringType: String = classOf[UTF8String].getName
   val decimalType: String = classOf[Decimal].getName
@@ -211,9 +213,12 @@ class CodeGenContext {
   def isPrimitiveType(dt: DataType): Boolean = isPrimitiveType(javaType(dt))
 }
 
-
+/**
+ * A wrapper for generated class, defines a `generate` method so that we can pass extra objects
+ * into generated class.
+ */
 abstract class GeneratedClass {
-  def generate(expressions: Array[Expression], states: Array[Any]): Any
+  def generate(expressions: Array[Expression]): Any
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -56,6 +56,14 @@ class CodeGenContext {
    */
   val references: mutable.ArrayBuffer[Expression] = new mutable.ArrayBuffer[Expression]()
 
+  /**
+   * Holding expressions' mutable states like `Rand.rng`, and keep them as member variables
+   * in generated classes like `SpecificProjection`.
+   * Each element is a 3-tuple: java type, variable name, variable value.
+   */
+  val mutableStates: mutable.ArrayBuffer[(String, String, Any)] =
+    mutable.ArrayBuffer.empty[(String, String, Any)]
+
   val stringType: String = classOf[UTF8String].getName
   val decimalType: String = classOf[Decimal].getName
 
@@ -205,7 +213,7 @@ class CodeGenContext {
 
 
 abstract class GeneratedClass {
-  def generate(expressions: Array[Expression]): Any
+  def generate(expressions: Array[Expression], states: Array[Any]): Any
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -56,14 +56,16 @@ class CodeGenContext {
    */
   val references: mutable.ArrayBuffer[Expression] = new mutable.ArrayBuffer[Expression]()
 
-  val mutableStates: mutable.ArrayBuffer[String] = mutable.ArrayBuffer.empty[String]
-
   /**
-   * Register expressions' mutable states like `MonotonicallyIncreasingID.count`, they will be
-   * kept as member variables in generated classes like `SpecificProjection`.
+   * Holding expressions' mutable states like `MonotonicallyIncreasingID.count` as a
+   * 3-tuple: java type, variable name, code to init it.
+   * They will be kept as member variables in generated classes like `SpecificProjection`.
    */
+  val mutableStates: mutable.ArrayBuffer[(String, String, String)] =
+    mutable.ArrayBuffer.empty[(String, String, String)]
+
   def addMutableState(javaType: String, variableName: String, initialValue: String): Unit = {
-    mutableStates += s"private $javaType $variableName = $initialValue;"
+    mutableStates += ((javaType, variableName, initialValue))
   }
 
   val stringType: String = classOf[UTF8String].getName

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateMutableProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateMutableProjection.scala
@@ -46,19 +46,30 @@ object GenerateMutableProjection extends CodeGenerator[Seq[Expression], () => Mu
             ${ctx.setColumn("mutableRow", e.dataType, i, evaluationCode.primitive)};
         """
     }.mkString("\n")
+
+    val mutableStates = ctx.mutableStates.map {
+      case (jt, name, _) => s"private $jt $name;"
+    }.mkString("\n      ")
+
+    val initStates = ctx.mutableStates.zipWithIndex.map {
+      case ((jt, name, _), index) => s"$name = (${ctx.boxedType(jt)}) states[$index];"
+    }.mkString("\n        ")
+
     val code = s"""
-      public Object generate($exprType[] expr) {
-        return new SpecificProjection(expr);
+      public Object generate($exprType[] expr, Object[] states) {
+        return new SpecificProjection(expr, states);
       }
 
       class SpecificProjection extends ${classOf[BaseMutableProjection].getName} {
 
         private $exprType[] expressions = null;
         private $mutableRowType mutableRow = null;
+        $mutableStates
 
-        public SpecificProjection($exprType[] expr) {
+        public SpecificProjection($exprType[] expr, Object[] states) {
           expressions = expr;
           mutableRow = new $genericMutableRowType(${expressions.size});
+          $initStates
         }
 
         public ${classOf[BaseMutableProjection].getName} target($mutableRowType row) {
@@ -84,7 +95,8 @@ object GenerateMutableProjection extends CodeGenerator[Seq[Expression], () => Mu
 
     val c = compile(code)
     () => {
-      c.generate(ctx.references.toArray).asInstanceOf[MutableProjection]
+      c.generate(ctx.references.toArray, ctx.mutableStates.map(_._3).toArray)
+        .asInstanceOf[MutableProjection]
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateMutableProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateMutableProjection.scala
@@ -46,6 +46,9 @@ object GenerateMutableProjection extends CodeGenerator[Seq[Expression], () => Mu
             ${ctx.setColumn("mutableRow", e.dataType, i, evaluationCode.primitive)};
         """
     }.mkString("\n")
+    val mutableStates = ctx.mutableStates.map { case (jt, name, init) =>
+      s"private $jt $name = $init;"
+    }.mkString("\n      ")
     val code = s"""
       public Object generate($exprType[] expr) {
         return new SpecificProjection(expr);
@@ -55,7 +58,7 @@ object GenerateMutableProjection extends CodeGenerator[Seq[Expression], () => Mu
 
         private $exprType[] expressions = null;
         private $mutableRowType mutableRow = null;
-        ${ctx.mutableStates.mkString("\n      ")}
+        $mutableStates
 
         public SpecificProjection($exprType[] expr) {
           expressions = expr;

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateMutableProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateMutableProjection.scala
@@ -46,8 +46,8 @@ object GenerateMutableProjection extends CodeGenerator[Seq[Expression], () => Mu
             ${ctx.setColumn("mutableRow", e.dataType, i, evaluationCode.primitive)};
         """
     }.mkString("\n")
-    val mutableStates = ctx.mutableStates.map { case (jt, name, init) =>
-      s"private $jt $name = $init;"
+    val mutableStates = ctx.mutableStates.map { case (javaType, variableName, initialValue) =>
+      s"private $javaType $variableName = $initialValue;"
     }.mkString("\n      ")
     val code = s"""
       public Object generate($exprType[] expr) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateOrdering.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateOrdering.scala
@@ -70,27 +70,18 @@ object GenerateOrdering extends CodeGenerator[Seq[SortOrder], Ordering[InternalR
       """
     }.mkString("\n")
 
-    val mutableStates = ctx.mutableStates.map {
-      case (jt, name, _) => s"private $jt $name;"
-    }.mkString("\n      ")
-
-    val initStates = ctx.mutableStates.zipWithIndex.map {
-      case ((jt, name, _), index) => s"$name = (${ctx.boxedType(jt)}) states[$index];"
-    }.mkString("\n        ")
-
     val code = s"""
-      public SpecificOrdering generate($exprType[] expr, Object[] states) {
-        return new SpecificOrdering(expr, states);
+      public SpecificOrdering generate($exprType[] expr) {
+        return new SpecificOrdering(expr);
       }
 
       class SpecificOrdering extends ${classOf[BaseOrdering].getName} {
 
         private $exprType[] expressions = null;
-        $mutableStates
+        ${ctx.mutableStates.mkString("\n      ")}
 
-        public SpecificOrdering($exprType[] expr, Object[] states) {
+        public SpecificOrdering($exprType[] expr) {
           expressions = expr;
-          $initStates
         }
 
         @Override
@@ -103,7 +94,6 @@ object GenerateOrdering extends CodeGenerator[Seq[SortOrder], Ordering[InternalR
 
     logDebug(s"Generated Ordering: $code")
 
-    compile(code).generate(ctx.references.toArray, ctx.mutableStates.map(_._3).toArray)
-      .asInstanceOf[BaseOrdering]
+    compile(code).generate(ctx.references.toArray).asInstanceOf[BaseOrdering]
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateOrdering.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateOrdering.scala
@@ -69,8 +69,8 @@ object GenerateOrdering extends CodeGenerator[Seq[SortOrder], Ordering[InternalR
           }
       """
     }.mkString("\n")
-    val mutableStates = ctx.mutableStates.map { case (jt, name, init) =>
-      s"private $jt $name = $init;"
+    val mutableStates = ctx.mutableStates.map { case (javaType, variableName, initialValue) =>
+      s"private $javaType $variableName = $initialValue;"
     }.mkString("\n      ")
     val code = s"""
       public SpecificOrdering generate($exprType[] expr) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateOrdering.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateOrdering.scala
@@ -69,7 +69,9 @@ object GenerateOrdering extends CodeGenerator[Seq[SortOrder], Ordering[InternalR
           }
       """
     }.mkString("\n")
-
+    val mutableStates = ctx.mutableStates.map { case (jt, name, init) =>
+      s"private $jt $name = $init;"
+    }.mkString("\n      ")
     val code = s"""
       public SpecificOrdering generate($exprType[] expr) {
         return new SpecificOrdering(expr);
@@ -78,7 +80,7 @@ object GenerateOrdering extends CodeGenerator[Seq[SortOrder], Ordering[InternalR
       class SpecificOrdering extends ${classOf[BaseOrdering].getName} {
 
         private $exprType[] expressions = null;
-        ${ctx.mutableStates.mkString("\n      ")}
+        $mutableStates
 
         public SpecificOrdering($exprType[] expr) {
           expressions = expr;

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateOrdering.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateOrdering.scala
@@ -46,23 +46,38 @@ object GenerateOrdering extends CodeGenerator[Seq[SortOrder], Ordering[InternalR
   protected def create(ordering: Seq[SortOrder]): Ordering[InternalRow] = {
     val ctx = newCodeGenContext()
 
-    val comparisons = ordering.zipWithIndex.map { case (order, i) =>
-      val evalA = order.child.gen(ctx)
-      val evalB = order.child.gen(ctx)
+    val comparisons = ordering.map { order =>
+      val eval = order.child.gen(ctx)
       val asc = order.direction == Ascending
+      val isNullA = ctx.freshName("isNullA")
+      val primitiveA = ctx.freshName("primitiveA")
+      val isNullB = ctx.freshName("isNullB")
+      val primitiveB = ctx.freshName("primitiveB")
       s"""
           i = a;
-          ${evalA.code}
+          boolean $isNullA;
+          ${ctx.javaType(order.child.dataType)} $primitiveA;
+          {
+            ${eval.code}
+            $isNullA = ${eval.isNull};
+            $primitiveA = ${eval.primitive};
+          }
           i = b;
-          ${evalB.code}
-          if (${evalA.isNull} && ${evalB.isNull}) {
+          boolean $isNullB;
+          ${ctx.javaType(order.child.dataType)} $primitiveB;
+          {
+            ${eval.code}
+            $isNullB = ${eval.isNull};
+            $primitiveB = ${eval.primitive};
+          }
+          if ($isNullA && $isNullB) {
             // Nothing
-          } else if (${evalA.isNull}) {
+          } else if ($isNullA) {
             return ${if (order.direction == Ascending) "-1" else "1"};
-          } else if (${evalB.isNull}) {
+          } else if ($isNullB) {
             return ${if (order.direction == Ascending) "1" else "-1"};
           } else {
-            int comp = ${ctx.genComp(order.child.dataType, evalA.primitive, evalB.primitive)};
+            int comp = ${ctx.genComp(order.child.dataType, primitiveA, primitiveB)};
             if (comp != 0) {
               return ${if (asc) "comp" else "-comp"};
             }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GeneratePredicate.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GeneratePredicate.scala
@@ -40,8 +40,8 @@ object GeneratePredicate extends CodeGenerator[Expression, (InternalRow) => Bool
   protected def create(predicate: Expression): ((InternalRow) => Boolean) = {
     val ctx = newCodeGenContext()
     val eval = predicate.gen(ctx)
-    val mutableStates = ctx.mutableStates.map { case (jt, name, init) =>
-      s"private $jt $name = $init;"
+    val mutableStates = ctx.mutableStates.map { case (javaType, variableName, initialValue) =>
+      s"private $javaType $variableName = $initialValue;"
     }.mkString("\n      ")
     val code = s"""
       public SpecificPredicate generate($exprType[] expr) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GeneratePredicate.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GeneratePredicate.scala
@@ -40,15 +40,26 @@ object GeneratePredicate extends CodeGenerator[Expression, (InternalRow) => Bool
   protected def create(predicate: Expression): ((InternalRow) => Boolean) = {
     val ctx = newCodeGenContext()
     val eval = predicate.gen(ctx)
+
+    val mutableStates = ctx.mutableStates.map {
+      case (jt, name, _) => s"private $jt $name;"
+    }.mkString("\n      ")
+
+    val initStates = ctx.mutableStates.zipWithIndex.map {
+      case ((jt, name, _), index) => s"$name = (${ctx.boxedType(jt)}) states[$index];"
+    }.mkString("\n        ")
+
     val code = s"""
-      public SpecificPredicate generate($exprType[] expr) {
-        return new SpecificPredicate(expr);
+      public SpecificPredicate generate($exprType[] expr, Object[] states) {
+        return new SpecificPredicate(expr, states);
       }
 
       class SpecificPredicate extends ${classOf[Predicate].getName} {
         private final $exprType[] expressions;
-        public SpecificPredicate($exprType[] expr) {
+        $mutableStates
+        public SpecificPredicate($exprType[] expr, Object[] states) {
           expressions = expr;
+          $initStates
         }
 
         @Override
@@ -60,7 +71,8 @@ object GeneratePredicate extends CodeGenerator[Expression, (InternalRow) => Bool
 
     logDebug(s"Generated predicate '$predicate':\n$code")
 
-    val p = compile(code).generate(ctx.references.toArray).asInstanceOf[Predicate]
+    val p = compile(code).generate(ctx.references.toArray, ctx.mutableStates.map(_._3).toArray)
+      .asInstanceOf[Predicate]
     (r: InternalRow) => p.eval(r)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateProjection.scala
@@ -151,6 +151,10 @@ object GenerateProjection extends CodeGenerator[Seq[Expression], Projection] {
         s"""if (!nullBits[$i]) arr[$i] = c$i;"""
     }.mkString("\n      ")
 
+    val mutableStates = ctx.mutableStates.map { case (jt, name, init) =>
+      s"private $jt $name = $init;"
+    }.mkString("\n      ")
+
     val code = s"""
     public SpecificProjection generate($exprType[] expr) {
       return new SpecificProjection(expr);
@@ -158,7 +162,7 @@ object GenerateProjection extends CodeGenerator[Seq[Expression], Projection] {
 
     class SpecificProjection extends ${classOf[BaseProject].getName} {
       private $exprType[] expressions = null;
-      ${ctx.mutableStates.mkString("\n      ")}
+      $mutableStates
 
       public SpecificProjection($exprType[] expr) {
         expressions = expr;

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateProjection.scala
@@ -151,8 +151,8 @@ object GenerateProjection extends CodeGenerator[Seq[Expression], Projection] {
         s"""if (!nullBits[$i]) arr[$i] = c$i;"""
     }.mkString("\n      ")
 
-    val mutableStates = ctx.mutableStates.map { case (jt, name, init) =>
-      s"private $jt $name = $init;"
+    val mutableStates = ctx.mutableStates.map { case (javaType, variableName, initialValue) =>
+      s"private $javaType $variableName = $initialValue;"
     }.mkString("\n      ")
 
     val code = s"""

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateProjection.scala
@@ -151,85 +151,96 @@ object GenerateProjection extends CodeGenerator[Seq[Expression], Projection] {
         s"""if (!nullBits[$i]) arr[$i] = c$i;"""
     }.mkString("\n      ")
 
+    val mutableStates = ctx.mutableStates.map {
+      case (jt, name, _) => s"private $jt $name;"
+    }.mkString("\n      ")
+
+    val initStates = ctx.mutableStates.zipWithIndex.map {
+      case ((jt, name, _), index) => s"$name = (${ctx.boxedType(jt)}) states[$index];"
+    }.mkString("\n        ")
+
     val code = s"""
-    public SpecificProjection generate($exprType[] expr) {
-      return new SpecificProjection(expr);
+    public SpecificProjection generate($exprType[] expr, Object[] states) {
+      return new SpecificProjection(expr, states);
     }
 
     class SpecificProjection extends ${classOf[BaseProject].getName} {
       private $exprType[] expressions = null;
+      $mutableStates
 
-      public SpecificProjection($exprType[] expr) {
+      public SpecificProjection($exprType[] expr, Object[] states) {
         expressions = expr;
+        $initStates
       }
 
       @Override
       public Object apply(Object r) {
-        return new SpecificRow(expressions, (InternalRow) r);
-      }
-    }
-
-    final class SpecificRow extends ${classOf[MutableRow].getName} {
-
-      $columns
-
-      public SpecificRow($exprType[] expressions, InternalRow i) {
-        $initColumns
+        return new SpecificRow((InternalRow) r);
       }
 
-      public int length() { return ${expressions.length};}
-      protected boolean[] nullBits = new boolean[${expressions.length}];
-      public void setNullAt(int i) { nullBits[i] = true; }
-      public boolean isNullAt(int i) { return nullBits[i]; }
+      final class SpecificRow extends ${classOf[MutableRow].getName} {
 
-      public Object get(int i) {
-        if (isNullAt(i)) return null;
-        switch (i) {
-        $getCases
+        $columns
+
+        public SpecificRow(InternalRow i) {
+          $initColumns
         }
-        return null;
-      }
-      public void update(int i, Object value) {
-        if (value == null) {
-          setNullAt(i);
-          return;
-        }
-        nullBits[i] = false;
-        switch (i) {
-        $updateCases
-        }
-      }
-      $specificAccessorFunctions
-      $specificMutatorFunctions
 
-      @Override
-      public int hashCode() {
-        int result = 37;
-        $hashUpdates
-        return result;
-      }
+        public int length() { return ${expressions.length};}
+        protected boolean[] nullBits = new boolean[${expressions.length}];
+        public void setNullAt(int i) { nullBits[i] = true; }
+        public boolean isNullAt(int i) { return nullBits[i]; }
 
-      @Override
-      public boolean equals(Object other) {
-        if (other instanceof SpecificRow) {
-          SpecificRow row = (SpecificRow) other;
-          $columnChecks
-          return true;
+        public Object get(int i) {
+          if (isNullAt(i)) return null;
+          switch (i) {
+          $getCases
+          }
+          return null;
         }
-        return super.equals(other);
-      }
+        public void update(int i, Object value) {
+          if (value == null) {
+            setNullAt(i);
+            return;
+          }
+          nullBits[i] = false;
+          switch (i) {
+          $updateCases
+          }
+        }
+        $specificAccessorFunctions
+        $specificMutatorFunctions
 
-      @Override
-      public InternalRow copy() {
-        Object[] arr = new Object[${expressions.length}];
-        ${copyColumns}
-        return new ${classOf[GenericInternalRow].getName}(arr);
+        @Override
+        public int hashCode() {
+          int result = 37;
+          $hashUpdates
+          return result;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+          if (other instanceof SpecificRow) {
+            SpecificRow row = (SpecificRow) other;
+            $columnChecks
+            return true;
+          }
+          return super.equals(other);
+        }
+
+        @Override
+        public InternalRow copy() {
+          Object[] arr = new Object[${expressions.length}];
+          ${copyColumns}
+          return new ${classOf[GenericInternalRow].getName}(arr);
+        }
       }
     }
     """
 
     logDebug(s"MutableRow, initExprs: ${expressions.mkString(",")} code:\n${code}")
 
-    compile(code).generate(ctx.references.toArray).asInstanceOf[Projection]
+    compile(code).generate(ctx.references.toArray, ctx.mutableStates.map(_._3).toArray)
+      .asInstanceOf[Projection]
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/expressions/SparkPartitionID.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/expressions/SparkPartitionID.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.expressions
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.LeafExpression
+import org.apache.spark.sql.catalyst.expressions.codegen.{GeneratedExpressionCode, CodeGenContext}
 import org.apache.spark.sql.types.{IntegerType, DataType}
 
 
@@ -32,5 +33,18 @@ private[sql] case object SparkPartitionID extends LeafExpression {
 
   override def dataType: DataType = IntegerType
 
-  override def eval(input: InternalRow): Int = TaskContext.get().partitionId()
+  @transient private lazy val partitionId = TaskContext.get() match {
+    case null => 0
+    case _ => TaskContext.get().partitionId()
+  }
+
+  override def eval(input: InternalRow): Int = partitionId
+
+  override def genCode(ctx: CodeGenContext, ev: GeneratedExpressionCode): String = {
+    val idTerm = ctx.freshName("partitionId")
+    ctx.mutableStates += (("int", idTerm, partitionId))
+    ev.isNull = "false"
+    ev.primitive = idTerm
+    ""
+  }
 }


### PR DESCRIPTION
We can keep expressions' mutable states in generated class(like `SpecificProjection`) as member variables, so that we can read and modify them inside codegened expressions.
