### PR TITLE
[SPARK-8851][YARN] In Client mode, make sure the client logs in and updates tokens

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -25,6 +25,7 @@ import java.util.{Arrays, Comparator}
 import scala.collection.JavaConversions._
 import scala.concurrent.duration._
 import scala.language.postfixOps
+import scala.util.control.NonFatal
 
 import com.google.common.primitives.Longs
 import org.apache.hadoop.conf.Configuration
@@ -38,8 +39,6 @@ import org.apache.hadoop.security.{Credentials, UserGroupInformation}
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.util.Utils
 import org.apache.spark.{Logging, SparkConf, SparkException}
-
-import scala.util.control.NonFatal
 
 /**
  * :: DeveloperApi ::

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -266,7 +266,7 @@ class SparkHadoopUtil extends Logging {
       fileStatuses
     } catch {
       case NonFatal(e) =>
-        logWarning("Error while attempting to list files from application straging dir", e)
+        logWarning("Error while attempting to list files from application staging dir", e)
         Array.empty
     }
   }

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -481,8 +481,14 @@ object SparkSubmit {
     }
 
     // Let YARN know it's a pyspark app, so it distributes needed libraries.
-    if (clusterManager == YARN && args.isPython) {
-      sysProps.put("spark.yarn.isPython", "true")
+    if (clusterManager == YARN) {
+      if (args.isPython) {
+        sysProps.put("spark.yarn.isPython", "true")
+      }
+      if (!isYarnCluster && args.principal != null) {
+        require(args.keytab != null, "Keytab must be specified when the keytab is specified")
+        UserGroupInformation.loginUserFromKeytab(args.principal, args.keytab)
+      }
     }
 
     // In yarn-cluster mode, use yarn.Client as a wrapper around the user class

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -485,7 +485,7 @@ object SparkSubmit {
       if (args.isPython) {
         sysProps.put("spark.yarn.isPython", "true")
       }
-      if (!isYarnCluster && args.principal != null) {
+      if (args.principal != null) {
         require(args.keytab != null, "Keytab must be specified when the keytab is specified")
         UserGroupInformation.loginUserFromKeytab(args.principal, args.keytab)
       }

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -86,10 +86,7 @@ private[spark] class Client(
   private val fireAndForget = isClusterMode &&
     !sparkConf.getBoolean("spark.yarn.submit.waitAppCompletion", true)
 
-  def stop(): Unit = {
-    SparkHadoopUtil.get.stopExecutorDelegationTokenRenewer()
-    yarnClient.stop()
-  }
+  def stop(): Unit = yarnClient.stop()
 
   /**
    * Submit an application running our ApplicationMaster to the ResourceManager.
@@ -125,9 +122,6 @@ private[spark] class Client(
       // Finally, submit and monitor the application
       logInfo(s"Submitting application ${appId.getId} to ResourceManager")
       yarnClient.submitApplication(appContext)
-      if (loginFromKeytab && !isClusterMode) {
-        SparkHadoopUtil.get.startExecutorDelegationTokenRenewer(sparkConf)
-      }
       appId
     } catch {
       case e: Throwable =>

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -789,15 +789,16 @@ private[spark] class Client(
   def setupCredentials(): Unit = {
     loginFromKeytab = args.principal != null || sparkConf.contains("spark.yarn.principal")
     if (loginFromKeytab) {
-      principal = {
-        if (args.principal != null) {
-          keytab = args.keytab
-          args.principal
+      principal =
+        if (args.principal != null) args.principal else sparkConf.get("spark.yarn.principal")
+      keytab = {
+        if (args.keytab != null) {
+          args.keytab
         } else {
-          keytab = sparkConf.getOption("spark.yarn.keytab").orNull
-          sparkConf.get("spark.yarn.principal")
+          sparkConf.getOption("spark.yarn.keytab").orNull
         }
       }
+
       require(keytab != null, "Keytab must be specified when principal is specified.")
       logInfo("Attempting to login to the Kerberos" +
         s" using principal: $principal and keytab: $keytab")

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -80,8 +80,13 @@ private[spark] class Client(
   private val isClusterMode = args.isClusterMode
 
   private var loginFromKeytab = false
+  private var principal: String = null
+  private var keytab: String = null
+
   private val fireAndForget = isClusterMode &&
     !sparkConf.getBoolean("spark.yarn.submit.waitAppCompletion", true)
+
+  private var delegationTokenUpdater: Option[ExecutorDelegationTokenUpdater] = None
 
 
   def stop(): Unit = yarnClient.stop()
@@ -120,6 +125,10 @@ private[spark] class Client(
       // Finally, submit and monitor the application
       logInfo(s"Submitting application ${appId.getId} to ResourceManager")
       yarnClient.submitApplication(appContext)
+      if (loginFromKeytab && !isClusterMode) {
+        delegationTokenUpdater = Some(new ExecutorDelegationTokenUpdater(sparkConf, yarnConf))
+        delegationTokenUpdater.foreach(_.updateCredentialsIfRequired())
+      }
       appId
     } catch {
       case e: Throwable =>
@@ -339,7 +348,7 @@ private[spark] class Client(
     if (loginFromKeytab) {
       logInfo("To enable the AM to login from keytab, credentials are being copied over to the AM" +
         " via the YARN Secure Distributed Cache.")
-      val (_, localizedPath) = distribute(args.keytab,
+      val (_, localizedPath) = distribute(keytab,
         destName = Some(sparkConf.get("spark.yarn.keytab")),
         appMasterOnly = true)
       require(localizedPath != null, "Keytab file already distributed.")
@@ -785,19 +794,26 @@ private[spark] class Client(
   }
 
   def setupCredentials(): Unit = {
-    if (args.principal != null) {
-      require(args.keytab != null, "Keytab must be specified when principal is specified.")
+    loginFromKeytab = args.principal != null || sparkConf.contains("spark.yarn.principal")
+    if (loginFromKeytab) {
+      principal = {
+        if (args.principal != null) {
+          keytab = args.keytab
+          args.principal
+        } else {
+          keytab = sparkConf.getOption("spark.yarn.keytab").orNull
+          sparkConf.get("spark.yarn.principal")
+        }
+      }
+      require(keytab != null, "Keytab must be specified when principal is specified.")
       logInfo("Attempting to login to the Kerberos" +
-        s" using principal: ${args.principal} and keytab: ${args.keytab}")
-      val f = new File(args.keytab)
+        s" using principal: $principal and keytab: $keytab")
+      val f = new File(keytab)
       // Generate a file name that can be used for the keytab file, that does not conflict
       // with any user file.
       val keytabFileName = f.getName + "-" + UUID.randomUUID().toString
-      UserGroupInformation.loginUserFromKeytab(args.principal, args.keytab)
-      loginFromKeytab = true
       sparkConf.set("spark.yarn.keytab", keytabFileName)
-      sparkConf.set("spark.yarn.principal", args.principal)
-      logInfo("Successfully logged into the KDC.")
+      sparkConf.set("spark.yarn.principal", principal)
     }
     credentials = UserGroupInformation.getCurrentUser.getCredentials
   }
@@ -1162,7 +1178,7 @@ object Client extends Logging {
    *
    * If not a "local:" file and no alternate name, the environment is not modified.
    *
-   * @parma conf      Spark configuration.
+   * @param conf      Spark configuration.
    * @param uri       URI to add to classpath (optional).
    * @param fileName  Alternate name for the file (optional).
    * @param env       Map holding the environment variables.

--- a/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
+++ b/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
@@ -60,6 +60,9 @@ private[spark] class YarnClientSchedulerBackend(
     // to the executors
     super.start()
 
+    // SPARK-8851: In yarn-client mode, the AM still does the credentials refresh. The driver
+    // reads the credentials from HDFS, just like the executors and updates its own credentials
+    // cache.
     if (conf.contains("spark.yarn.credentials.file")) {
       YarnSparkHadoopUtil.get.startExecutorDelegationTokenRenewer(conf)
     }

--- a/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
+++ b/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
@@ -60,13 +60,14 @@ private[spark] class YarnClientSchedulerBackend(
     // to the executors
     super.start()
 
+    waitForApplication()
+
     // SPARK-8851: In yarn-client mode, the AM still does the credentials refresh. The driver
     // reads the credentials from HDFS, just like the executors and updates its own credentials
     // cache.
     if (conf.contains("spark.yarn.credentials.file")) {
       YarnSparkHadoopUtil.get.startExecutorDelegationTokenRenewer(conf)
     }
-    waitForApplication()
     monitorThread = asyncMonitorApplication()
     monitorThread.start()
   }


### PR DESCRIPTION
In client side, the flow is SparkSubmit -> SparkContext -> yarn/Client. Since the yarn client only gets a cloned config and the staging dir is set here, it is not really possible to do re-logins in the SparkContext. So, do the initial logins in Spark Submit and do re-logins as we do now in the AM, but the Client behaves like an executor in this specific context and reads the credentials file to update the tokens. This way, even if the streaming context is started up from checkpoint - it is fine since we have logged in from SparkSubmit itself itself.
