### PR TITLE
[SPARK-9000][MLlib]Support generic item type in PrefixSpan

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/fpm/LocalPrefixSpan.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/fpm/LocalPrefixSpan.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.mllib.fpm
 
+import scala.reflect.ClassTag
+
 import org.apache.spark.Logging
 import org.apache.spark.annotation.Experimental
 
@@ -39,11 +41,11 @@ private[fpm] object LocalPrefixSpan extends Logging with Serializable {
    *         the key of pair is sequential pattern (a list of items),
    *         the value of pair is the pattern's count.
    */
-  def run(
+  def run[Item: ClassTag](
       minCount: Long,
       maxPatternLength: Int,
-      prefix: Array[Int],
-      projectedDatabase: Array[Array[Int]]): Array[(Array[Int], Long)] = {
+      prefix: Array[Item],
+      projectedDatabase: Array[Array[Item]]): Array[(Array[Item], Long)] = {
     val frequentPrefixAndCounts = getFreqItemAndCounts(minCount, projectedDatabase)
     val frequentPatternAndCounts = frequentPrefixAndCounts
       .map(x => (prefix ++ Array(x._1), x._2))
@@ -67,7 +69,7 @@ private[fpm] object LocalPrefixSpan extends Logging with Serializable {
    * @param sequence sequence
    * @return suffix sequence
    */
-  def getSuffix(prefix: Int, sequence: Array[Int]): Array[Int] = {
+  def getSuffix[Item: ClassTag](prefix: Item, sequence: Array[Item]): Array[Item] = {
     val index = sequence.indexOf(prefix)
     if (index == -1) {
       Array()
@@ -82,9 +84,9 @@ private[fpm] object LocalPrefixSpan extends Logging with Serializable {
    * @param sequences sequences data
    * @return array of item and count pair
    */
-  private def getFreqItemAndCounts(
+  private def getFreqItemAndCounts[Item: ClassTag](
       minCount: Long,
-      sequences: Array[Array[Int]]): Array[(Int, Long)] = {
+      sequences: Array[Array[Item]]): Array[(Item, Long)] = {
     sequences.flatMap(_.distinct)
       .groupBy(x => x)
       .mapValues(_.length.toLong)
@@ -99,10 +101,10 @@ private[fpm] object LocalPrefixSpan extends Logging with Serializable {
    * @param sequences sequences data
    * @return prefixes and projected database
    */
-  private def getPatternAndProjectedDatabase(
-      prePrefix: Array[Int],
-      frequentPrefixes: Array[Int],
-      sequences: Array[Array[Int]]): Array[(Array[Int], Array[Array[Int]])] = {
+  private def getPatternAndProjectedDatabase[Item: ClassTag](
+      prePrefix: Array[Item],
+      frequentPrefixes: Array[Item],
+      sequences: Array[Array[Item]]): Array[(Array[Item], Array[Array[Item]])] = {
     val filteredProjectedDatabase = sequences
       .map(x => x.filter(frequentPrefixes.contains(_)))
     frequentPrefixes.map { x =>

--- a/mllib/src/test/scala/org/apache/spark/mllib/fpm/PrefixSpanSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/fpm/PrefixSpanSuite.scala
@@ -117,4 +117,88 @@ class PrefixspanSuite extends SparkFunSuite with MLlibTestSparkContext {
     )
     assert(compareResult(expectedValue3, result3.collect()))
   }
+
+  test("PrefixSpan using Item type") {
+    val sequences = Array(
+      Array("1", "3", "4", "5"),
+      Array("2", "3", "1"),
+      Array("2", "4", "1"),
+      Array("3", "1", "3", "4", "5"),
+      Array("3", "4", "4", "3"),
+      Array("6", "5", "3"))
+
+    val rdd = sc.parallelize(sequences, 2).cache()
+
+    def compareResult(
+                       expectedValue: Array[(Array[String], Long)],
+                       actualValue: Array[(Array[String], Long)]): Boolean = {
+      val sortedExpectedValue = expectedValue.sortWith{ (x, y) =>
+        x._1.mkString(",") + ":" + x._2 < y._1.mkString(",") + ":" + y._2
+      }
+      val sortedActualValue = actualValue.sortWith{ (x, y) =>
+        x._1.mkString(",") + ":" + x._2 < y._1.mkString(",") + ":" + y._2
+      }
+      sortedExpectedValue.zip(sortedActualValue)
+        .map(x => x._1._1.mkString(",") == x._2._1.mkString(",") && x._1._2 == x._2._2)
+        .reduce(_&&_)
+    }
+
+    val prefixspan = new PrefixSpan()
+      .setMinSupport(0.33)
+      .setMaxPatternLength(50)
+    val result1 = prefixspan.run(rdd)
+    val expectedValue1 = Array(
+      (Array("1"), 4L),
+      (Array("1", "3"), 2L),
+      (Array("1", "3", "4"), 2L),
+      (Array("1", "3", "4", "5"), 2L),
+      (Array("1", "3", "5"), 2L),
+      (Array("1", "4"), 2L),
+      (Array("1", "4", "5"), 2L),
+      (Array("1", "5"), 2L),
+      (Array("2"), 2L),
+      (Array("2", "1"), 2L),
+      (Array("3"), 5L),
+      (Array("3", "1"), 2L),
+      (Array("3", "3"), 2L),
+      (Array("3", "4"), 3L),
+      (Array("3", "4", "5"), 2L),
+      (Array("3", "5"), 2L),
+      (Array("4"), 4L),
+      (Array("4", "5"), 2L),
+      (Array("5"), 3L)
+    )
+    assert(compareResult(expectedValue1, result1.collect()))
+
+    prefixspan.setMinSupport(0.5).setMaxPatternLength(50)
+    val result2 = prefixspan.run(rdd)
+    val expectedValue2 = Array(
+      (Array("1"), 4L),
+      (Array("3"), 5L),
+      (Array("3", "4"), 3L),
+      (Array("4"), 4L),
+      (Array("5"), 3L)
+    )
+    assert(compareResult(expectedValue2, result2.collect()))
+
+    prefixspan.setMinSupport(0.33).setMaxPatternLength(2)
+    val result3 = prefixspan.run(rdd)
+    val expectedValue3 = Array(
+      (Array("1"), 4L),
+      (Array("1", "3"), 2L),
+      (Array("1", "4"), 2L),
+      (Array("1", "5"), 2L),
+      (Array("2", "1"), 2L),
+      (Array("2"), 2L),
+      (Array("3"), 5L),
+      (Array("3", "1"), 2L),
+      (Array("3", "3"), 2L),
+      (Array("3", "4"), 3L),
+      (Array("3", "5"), 2L),
+      (Array("4"), 4L),
+      (Array("4", "5"), 2L),
+      (Array("5"), 3L)
+    )
+    assert(compareResult(expectedValue3, result3.collect()))
+  }
 }


### PR DESCRIPTION
modify to support generic item type according to the FPGrowth.
