### PR TITLE
Upgraded version of metrics library to 3.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
     <chill.version>0.5.0</chill.version>
     <ivy.version>2.4.0</ivy.version>
     <oro.version>2.0.8</oro.version>
-    <codahale.metrics.version>3.1.0</codahale.metrics.version>
+    <codahale.metrics.version>3.1.2</codahale.metrics.version>
     <avro.version>1.7.7</avro.version>
     <avro.mapred.classifier>hadoop2</avro.mapred.classifier>
     <jets3t.version>0.7.1</jets3t.version>


### PR DESCRIPTION
We have problems with the [reconnection to graphite issue](https://github.com/dropwizard/metrics/commit/70559816f1fc3a0a0122b5263d5478ff07396991)  of the metrics library used in Spark 1.4.0. This issue was resolved in release 3.1.2 of the metrics library dependency.
