### PR TITLE
SPARK-9070 JavaDataFrameSuite teardown NPEs if setup failed

### DIFF
--- a/sql/hive/src/test/java/test/org/apache/spark/sql/hive/JavaDataFrameSuite.java
+++ b/sql/hive/src/test/java/test/org/apache/spark/sql/hive/JavaDataFrameSuite.java
@@ -61,7 +61,9 @@ public class JavaDataFrameSuite {
   @After
   public void tearDown() throws IOException {
     // Clean up tables.
-    hc.sql("DROP TABLE IF EXISTS window_table");
+    if (hc != null) {
+      hc.sql("DROP TABLE IF EXISTS window_table");
+    }
   }
 
   @Test


### PR DESCRIPTION
fix teardown to skip table delete if hive context is null
