### PR TITLE
[SPARK-8996] [MLlib] [PySpark] Python API for Kolmogorov-Smirnov Test

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
@@ -1095,23 +1095,14 @@ private[python] class PythonMLLibAPI extends Serializable {
   }
 
   /**
-   * Wrapper around Statistics.kolmogorovSmirnovTestWrapper with default params.
+   * Java stub for Statistics.kolmogorovSmirnovTest()
    */
-  def kolmogorovSmirnovTestWrapper(
-      data: JavaRDD[Double],
-      distName: String): KolmogorovSmirnovTestResult = {
-    Statistics.kolmogorovSmirnovTest(data, distName)
-  }
-
-  /**
-   * Wrapper around Statistics.kolmogorovSmirnovTestWrapper.
-   */
-  def kolmogorovSmirnovTestWrapper(
+  def kolmogorovSmirnovTest(
       data: JavaRDD[Double],
       distName: String,
       params: JList[Double]): KolmogorovSmirnovTestResult = {
-    val seqParams = params.asScala.toSeq
-    Statistics.kolmogorovSmirnovTest(data, distName, seqParams: _*)
+    val paramsSeq = params.asScala.toSeq
+    Statistics.kolmogorovSmirnovTest(data, distName, paramsSeq: _*)
   }
 
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
@@ -43,7 +43,7 @@ import org.apache.spark.mllib.recommendation._
 import org.apache.spark.mllib.regression._
 import org.apache.spark.mllib.stat.correlation.CorrelationNames
 import org.apache.spark.mllib.stat.distribution.MultivariateGaussian
-import org.apache.spark.mllib.stat.test.ChiSqTestResult
+import org.apache.spark.mllib.stat.test.{ChiSqTestResult, KolmogorovSmirnovTestResult}
 import org.apache.spark.mllib.stat.{
   KernelDensity, MultivariateStatisticalSummary, Statistics}
 import org.apache.spark.mllib.tree.configuration.{Algo, BoostingStrategy, Strategy}
@@ -1093,6 +1093,27 @@ private[python] class PythonMLLibAPI extends Serializable {
     LinearDataGenerator.generateLinearRDD(
       sc, nexamples, nfeatures, eps, nparts, intercept)
   }
+
+  /**
+   * Wrapper around Statistics.kolmogorovSmirnovTestWrapper with default params.
+   */
+  def kolmogorovSmirnovTestWrapper(
+      data: JavaRDD[Double],
+      distName: String): KolmogorovSmirnovTestResult = {
+    Statistics.kolmogorovSmirnovTest(data, distName)
+  }
+
+  /**
+   * Wrapper around Statistics.kolmogorovSmirnovTestWrapper.
+   */
+  def kolmogorovSmirnovTestWrapper(
+      data: JavaRDD[Double],
+      distName: String,
+      params: JList[Double]): KolmogorovSmirnovTestResult = {
+    val seqParams = params.asScala.toSeq
+    Statistics.kolmogorovSmirnovTest(data, distName, seqParams: _*)
+  }
+
 }
 
 /**

--- a/python/pyspark/mllib/stat/_statistics.py
+++ b/python/pyspark/mllib/stat/_statistics.py
@@ -248,7 +248,7 @@ class Statistics(object):
         """
         .. note:: Experimental
 
-        Performs the Kolmogorov Smirnov (KS) test for data sampled from
+        Performs the Kolmogorov-Smirnov (KS) test for data sampled from
         a continuous distribution. It tests the null hypothesis that
         the data is generated from a particular distribution.
 
@@ -286,6 +286,13 @@ class Statistics(object):
         0.175
         >>> ksmodel.nullHypothesis
         u'Sample follows theoretical distribution'
+
+        >>> data = sc.parallelize([2.0, 3.0, 4.0])
+        >>> ksmodel = kstest(data, "norm", 3.0, 1.0)
+        >>> print(round(ksmodel.pValue, 3))
+        1.0
+        >>> print(round(ksmodel.statistic, 3))
+        0.175
         """
         if not isinstance(data, RDD):
             raise TypeError("data should be an RDD, got %s." % type(data))

--- a/python/pyspark/mllib/stat/_statistics.py
+++ b/python/pyspark/mllib/stat/_statistics.py
@@ -15,11 +15,15 @@
 # limitations under the License.
 #
 
+import sys
+if sys.version >= '3':
+    basestring = str
+
 from pyspark.rdd import RDD, ignore_unicode_prefix
 from pyspark.mllib.common import callMLlibFunc, JavaModelWrapper
 from pyspark.mllib.linalg import Matrix, _convert_to_vector
 from pyspark.mllib.regression import LabeledPoint
-from pyspark.mllib.stat.test import ChiSqTestResult
+from pyspark.mllib.stat.test import ChiSqTestResult, KolmogorovSmirnovTestResult
 
 
 __all__ = ['MultivariateStatisticalSummary', 'Statistics']
@@ -237,6 +241,54 @@ class Statistics(object):
                 raise ValueError("`expected` should have same length with `observed`")
             jmodel = callMLlibFunc("chiSqTest", _convert_to_vector(observed), expected)
         return ChiSqTestResult(jmodel)
+
+    @staticmethod
+    @ignore_unicode_prefix
+    def kolmogorovSmirnovTest(data, distName="norm", *params):
+        """
+        .. note:: Experimental
+
+        Performs the Kolmogorov Smirnov (KS) test for data sampled from a continuous
+        distribution. It tests the null hypothesis that the data is generated from a
+        particular distribution.
+
+        The given data is sorted, the Empirical Cumulative Distribution Function (ECDF)
+        is calculated which is the number of points having a CDF value lesser than a given point
+        divided by the total number of points. Since the data is sorted, this is a step function
+        that rises by (1 / length of data) for every ordered point.
+
+        The KS statistic gives us the maximum distance between the ECDF and the CDF. Intuitively
+        if this value is large, the probabilty that the null hypothesis is true becomes small.
+        For specific details of the implementation, please have a look at the Scala documentation.
+
+        :param data: RDD, samples from the data
+        :param distName: string, currently only "norm" is suuported. (Normal distribution)
+        :param params: additional values which need to be provided for a certain distribution.
+                       If not provided, the default values are used.
+        :return: KolmogorovSmirnovTestResult object containing the test statistic, degrees
+                 of freedom, p-value, the method used, and the null hypothesis.
+
+        >>> kstest = Statistics.kolmogorovSmirnovTest
+        >>> data = sc.parallelize([-1.0, 0.0, 1.0])
+        >>> ksmodel = kstest(data, "norm")
+        >>> print(round(ksmodel.pValue, 3))
+        1.0
+        >>> print(round(ksmodel.statistic, 3))
+        0.175
+        >>> ksmodel.nullHypothesis
+        u'Sample follows theoretical distribution'
+
+        """
+        if not isinstance(data, RDD):
+            raise TypeError("data should be an RDD, got %s." % type(data))
+        if not isinstance(distName, str):
+            raise TypeError("distName should be a string, got %s." % type(distname))
+
+        if len(params) == 0:
+            jmodel = callMLlibFunc("kolmogorovSmirnovTestWrapper", data, distName)
+        else:
+            jmodel = callMLlibFunc("kolmogorovSmirnovTestWrapper", data, distName, list(params))
+        return KolmogorovSmirnovTestResult(jmodel)
 
 
 def _test():

--- a/python/pyspark/mllib/stat/_statistics.py
+++ b/python/pyspark/mllib/stat/_statistics.py
@@ -248,25 +248,34 @@ class Statistics(object):
         """
         .. note:: Experimental
 
-        Performs the Kolmogorov Smirnov (KS) test for data sampled from a continuous
-        distribution. It tests the null hypothesis that the data is generated from a
-        particular distribution.
+        Performs the Kolmogorov Smirnov (KS) test for data sampled from
+        a continuous distribution. It tests the null hypothesis that
+        the data is generated from a particular distribution.
 
-        The given data is sorted, the Empirical Cumulative Distribution Function (ECDF)
-        is calculated which is the number of points having a CDF value lesser than a given point
-        divided by the total number of points. Since the data is sorted, this is a step function
+        The given data is sorted and the Empirical Cumulative
+        Distribution Function (ECDF) is calculated
+        which for a given point is the number of points having a CDF
+        value lesser than it divided by the total number of points.
+
+        Since the data is sorted, this is a step function
         that rises by (1 / length of data) for every ordered point.
 
-        The KS statistic gives us the maximum distance between the ECDF and the CDF. Intuitively
-        if this value is large, the probabilty that the null hypothesis is true becomes small.
-        For specific details of the implementation, please have a look at the Scala documentation.
+        The KS statistic gives us the maximum distance between the
+        ECDF and the CDF. Intuitively if this statistic is large, the
+        probabilty that the null hypothesis is true becomes small.
+        For specific details of the implementation, please have a look
+        at the Scala documentation.
 
         :param data: RDD, samples from the data
-        :param distName: string, currently only "norm" is suuported. (Normal distribution)
-        :param params: additional values which need to be provided for a certain distribution.
+        :param distName: string, currently only "norm" is supported.
+                         (Normal distribution) to calculate the
+                         theoretical distribution of the data.
+        :param params: additional values which need to be provided for
+                       a certain distribution.
                        If not provided, the default values are used.
-        :return: KolmogorovSmirnovTestResult object containing the test statistic, degrees
-                 of freedom, p-value, the method used, and the null hypothesis.
+        :return: KolmogorovSmirnovTestResult object containing the test
+                 statistic, degrees of freedom, p-value,
+                 the method used, and the null hypothesis.
 
         >>> kstest = Statistics.kolmogorovSmirnovTest
         >>> data = sc.parallelize([-1.0, 0.0, 1.0])
@@ -277,18 +286,15 @@ class Statistics(object):
         0.175
         >>> ksmodel.nullHypothesis
         u'Sample follows theoretical distribution'
-
         """
         if not isinstance(data, RDD):
             raise TypeError("data should be an RDD, got %s." % type(data))
-        if not isinstance(distName, str):
-            raise TypeError("distName should be a string, got %s." % type(distname))
+        if not isinstance(distName, basestring):
+            raise TypeError("distName should be a string, got %s." % type(distName))
 
-        if len(params) == 0:
-            jmodel = callMLlibFunc("kolmogorovSmirnovTestWrapper", data, distName)
-        else:
-            jmodel = callMLlibFunc("kolmogorovSmirnovTestWrapper", data, distName, list(params))
-        return KolmogorovSmirnovTestResult(jmodel)
+        params = [float(param) for param in params]
+        return KolmogorovSmirnovTestResult(
+            callMLlibFunc("kolmogorovSmirnovTest", data, distName, params))
 
 
 def _test():

--- a/python/pyspark/mllib/stat/test.py
+++ b/python/pyspark/mllib/stat/test.py
@@ -61,9 +61,10 @@ class TestResult(JavaModelWrapper):
         return self._java_model.toString()
 
 
+@inherit_doc
 class ChiSqTestResult(TestResult):
     """
-    Object containing the test results for the chi-squared hypothesis test.
+    Contains test results for the chi-squared hypothesis test.
     """
 
     @property
@@ -74,7 +75,8 @@ class ChiSqTestResult(TestResult):
         return self._java_model.method()
 
 
+@inherit_doc
 class KolmogorovSmirnovTestResult(TestResult):
     """
-    Object containing the test results for the ks tests.
+    Contains test results for the Kolmogorov-Smirnov test.
     """

--- a/python/pyspark/mllib/stat/test.py
+++ b/python/pyspark/mllib/stat/test.py
@@ -15,24 +15,16 @@
 # limitations under the License.
 #
 
-from pyspark.mllib.common import JavaModelWrapper
+from pyspark.mllib.common import inherit_doc, JavaModelWrapper
 
 
-__all__ = ["ChiSqTestResult"]
+__all__ = ["ChiSqTestResult", "KolmogorovSmirnovTestResult"]
 
 
-class ChiSqTestResult(JavaModelWrapper):
+class TestResult(JavaModelWrapper):
     """
-    .. note:: Experimental
-
-    Object containing the test results for the chi-squared hypothesis test.
+    Base class for all test results.
     """
-    @property
-    def method(self):
-        """
-        Name of the test method
-        """
-        return self._java_model.method()
 
     @property
     def pValue(self):
@@ -67,3 +59,22 @@ class ChiSqTestResult(JavaModelWrapper):
 
     def __str__(self):
         return self._java_model.toString()
+
+
+class ChiSqTestResult(TestResult):
+    """
+    Object containing the test results for the chi-squared hypothesis test.
+    """
+
+    @property
+    def method(self):
+        """
+        Name of the test method
+        """
+        return self._java_model.method()
+
+
+class KolmogorovSmirnovTestResult(TestResult):
+    """
+    Object containing the test results for the ks tests.
+    """

--- a/python/pyspark/mllib/tests.py
+++ b/python/pyspark/mllib/tests.py
@@ -869,6 +869,21 @@ class ChiSqTestTests(MLlibTestCase):
         self.assertIsNotNone(chi[1000])
 
 
+class KolmogorovSmirnovTest(MLlibTestCase):
+
+    def test_R_implementation_equivalence(self):
+        data = self.sc.parallelize([
+            1.1626852897838, -0.585924465893051, 1.78546500331661, -1.33259371048501,
+            -0.446566766553219, 0.569606122374976, -2.88971761441412, -0.869018343326555,
+            -0.461702683149641, -0.555540910137444, -0.0201353678515895, -0.150382224136063,
+            -0.628126755843964, 1.32322085193283, -1.52135057001199, -0.437427868856691,
+            0.970577579543399, 0.0282226444247749, -0.0857821886527593, 0.389214404984942
+        ])
+        model = Statistics.kolmogorovSmirnovTest(data, "norm")
+        self.assertAlmostEqual(model.statistic, 0.189, 3)
+        self.assertAlmostEqual(model.pValue, 0.422, 3)
+
+
 class SerDeTest(MLlibTestCase):
     def test_to_java_object_rdd(self):  # SPARK-6660
         data = RandomRDDs.uniformRDD(self.sc, 10, 5, seed=0)

--- a/python/pyspark/mllib/tests.py
+++ b/python/pyspark/mllib/tests.py
@@ -883,6 +883,10 @@ class KolmogorovSmirnovTest(MLlibTestCase):
         self.assertAlmostEqual(model.statistic, 0.189, 3)
         self.assertAlmostEqual(model.pValue, 0.422, 3)
 
+        model = Statistics.kolmogorovSmirnovTest(data, "norm", 0, 1)
+        self.assertAlmostEqual(model.statistic, 0.189, 3)
+        self.assertAlmostEqual(model.pValue, 0.422, 3)
+
 
 class SerDeTest(MLlibTestCase):
     def test_to_java_object_rdd(self):  # SPARK-6660


### PR DESCRIPTION
Python API for the KS-test

Statistics.kolmogorovSmirnovTest(data, distName, *params)
I'm not quite sure how to support the callable function since it is not serializable.
