### PR TITLE
[SPARK-9091][STREAMING]Add the CompressionCodec to the saveAsTextFiles interface in DStream.

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
@@ -912,16 +912,12 @@ abstract class DStream[T: ClassTag] (
    * is defined, it will use specific `CompressionCodec` to compress the text.
    */
   def saveAsTextFiles(
-    prefix: String,
-    suffix: String = "",
-    codec: Option[Class[_ <: CompressionCodec]] = None): Unit = ssc.withScope {
+      prefix: String,
+      suffix: String = "",
+      codec: Option[Class[_ <: CompressionCodec]] = None): Unit = ssc.withScope {
     val saveFunc = (rdd: RDD[T], time: Time) => {
       val file = rddToFileName(prefix, suffix, time)
-      if (codec.isDefined) {
-        rdd.saveAsTextFile(file, codec.get)
-      } else {
-        rdd.saveAsTextFile(file)
-      }
+      codec.map(rdd.saveAsTextFile(file, _)).getOrElse(rdd.saveAsTextFile(file))
     }
     this.foreachRDD(saveFunc)
   }

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
@@ -20,12 +20,12 @@ package org.apache.spark.streaming.dstream
 
 import java.io.{IOException, ObjectInputStream, ObjectOutputStream}
 
-import org.apache.hadoop.io.compress.CompressionCodec
-
 import scala.collection.mutable.HashMap
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 import scala.util.matching.Regex
+
+import org.apache.hadoop.io.compress.CompressionCodec
 
 import org.apache.spark.{Logging, SparkContext, SparkException}
 import org.apache.spark.rdd.{BlockRDD, PairRDDFunctions, RDD, RDDOperationScope}


### PR DESCRIPTION
Add the `CompressionCodec` to the `saveAsTextFiles` interface. 
To be compatible with old interface, use the `Option` to adapt the code.

[Jira Address](https://issues.apache.org/jira/browse/SPARK-9091)
