### PR TITLE
[SPARK-9099] [EC2] Add more ports to security group in spark_ec2

### DIFF
--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -500,7 +500,9 @@ def launch_cluster(conn, opts, cluster_name):
             master_group.authorize(ip_protocol='udp', from_port=0, to_port=65535,
                                    src_group=slave_group)
         master_group.authorize('tcp', 22, 22, authorized_address)
-        master_group.authorize('tcp', 8080, 8081, authorized_address)
+        # Spark master
+        master_group.authorize('tcp', 6066, 6066, authorized_address)
+        master_group.authorize('tcp', 8080, 8082, authorized_address)
         master_group.authorize('tcp', 18080, 18080, authorized_address)
         master_group.authorize('tcp', 19999, 19999, authorized_address)
         master_group.authorize('tcp', 50030, 50030, authorized_address)
@@ -538,7 +540,9 @@ def launch_cluster(conn, opts, cluster_name):
             slave_group.authorize(ip_protocol='udp', from_port=0, to_port=65535,
                                   src_group=slave_group)
         slave_group.authorize('tcp', 22, 22, authorized_address)
-        slave_group.authorize('tcp', 8080, 8081, authorized_address)
+        # Spark slave
+        slave_group.authorize('tcp', 4040, 4040, authorized_address)
+        slave_group.authorize('tcp', 8080, 8082, authorized_address)
         slave_group.authorize('tcp', 50060, 50060, authorized_address)
         slave_group.authorize('tcp', 50075, 50075, authorized_address)
         slave_group.authorize('tcp', 60060, 60060, authorized_address)


### PR DESCRIPTION
spark-ec2 scripts misses to add some few important ports to the security group, including:

Master 6066: Needed to submit jobs outside of the cluster
Slave 4040: Needed to view worker state
Slave 8082: Needed to view some worker logs

cc @JoshRosen
