### PR TITLE
[SPARK-8345] [ML] Add an SQL node as a feature transformer

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/SQLTransformer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/SQLTransformer.scala
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.feature
+
+import org.apache.spark.annotation.Experimental
+import org.apache.spark.ml.param.{ParamMap, Param}
+import org.apache.spark.ml.Transformer
+import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.StructType
+
+/**
+ * :: Experimental ::
+ * Implements the transforms which are defined by SQL statement.
+ * Currently we only support SQL syntax like 'SELECT ... FROM __THIS__'
+ * where '__THIS__' represents the underlying table of the input dataset.
+ */
+@Experimental
+class SQLTransformer (override val uid: String) extends Transformer {
+
+  def this() = this(Identifiable.randomUID("sql"))
+
+  /**
+   * SQL statement parameter. The statement is provided in string form.
+   * @group param
+   */
+  final val statement: Param[String] = new Param[String](this, "statement", "SQL statement")
+
+  /** @group setParam */
+  def setStatement(value: String): this.type = set(statement, value)
+
+  /** @group getParam */
+  def getStatement(): String = $(statement)
+
+  private val tableIdentifier: String = "__THIS__"
+
+  /**
+   * The output schema of this transformer.
+   * It is only valid after transform function has been called.
+   */
+  private var outputSchema: StructType = null
+
+  override def transform(dataset: DataFrame): DataFrame = {
+    val tableName = uid
+    val realStatement = $(statement).replace(tableIdentifier, tableName)
+    dataset.registerTempTable(tableName)
+    val originalSchema = dataset.schema
+    val additiveDF = dataset.sqlContext.sql(realStatement)
+    val additiveSchema = additiveDF.schema
+    outputSchema = StructType(Array.concat(originalSchema.fields, additiveSchema.fields))
+    additiveSchema.fieldNames.foreach {
+      case name =>
+        require(!originalSchema.fieldNames.contains(name), s"Output column $name already exists.")
+    }
+    val rdd = dataset.rdd.zip(additiveDF.rdd).map {
+      case (r1, r2) => Row.merge(r1, r2)
+    }
+    dataset.sqlContext.createDataFrame(rdd, outputSchema)
+  }
+
+  override def transformSchema(schema: StructType): StructType = {
+    outputSchema
+  }
+
+  override def copy(extra: ParamMap): SQLTransformer = defaultCopy(extra)
+}

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/SQLTransformerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/SQLTransformerSuite.scala
@@ -31,7 +31,7 @@ class SQLTransformerSuite extends SparkFunSuite with MLlibTestSparkContext {
     val original = sqlContext.createDataFrame(
       Seq((0, 1.0, 3.0), (2, 2.0, 5.0))).toDF("id", "v1", "v2")
     val sqlTrans = new SQLTransformer().setStatement(
-      "SELECT (v1 + v2) AS v3, (v1 * v2) AS v4 FROM __THIS__")
+      "SELECT *, (v1 + v2) AS v3, (v1 * v2) AS v4 FROM __THIS__")
     val result = sqlTrans.transform(original)
     val resultSchema = sqlTrans.transformSchema(original.schema)
     val expected = sqlContext.createDataFrame(
@@ -40,15 +40,5 @@ class SQLTransformerSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(result.schema.toString == resultSchema.toString)
     assert(resultSchema == expected.schema)
     assert(result.collect().toSeq == expected.collect().toSeq)
-  }
-
-  test("output column already exists") {
-    val original = sqlContext.createDataFrame(
-      Seq((0, 1.0, 3.0, 4.0), (2, 2.0, 5.0, 8.0))).toDF("id", "v1", "v2", "v3")
-    val sqlTrans = new SQLTransformer().setStatement(
-      "SELECT (v1 + v2) AS v3, (v1 * v2) AS v4 FROM __THIS__")
-    intercept[IllegalArgumentException] {
-      sqlTrans.transform(original)
-    }
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/SQLTransformerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/SQLTransformerSuite.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.feature
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.ml.param.ParamsSuite
+import org.apache.spark.mllib.util.MLlibTestSparkContext
+
+class SQLTransformerSuite extends SparkFunSuite with MLlibTestSparkContext {
+
+  test("params") {
+    ParamsSuite.checkParams(new SQLTransformer())
+  }
+
+  test("transform numeric data") {
+    val original = sqlContext.createDataFrame(
+      Seq((0, 1.0, 3.0), (2, 2.0, 5.0))).toDF("id", "v1", "v2")
+    val sqlTrans = new SQLTransformer().setStatement(
+      "SELECT (v1 + v2) AS v3, (v1 * v2) AS v4 FROM __THIS__")
+    val result = sqlTrans.transform(original)
+    val resultSchema = sqlTrans.transformSchema(original.schema)
+    val expected = sqlContext.createDataFrame(
+      Seq((0, 1.0, 3.0, 4.0, 3.0), (2, 2.0, 5.0, 7.0, 10.0)))
+      .toDF("id", "v1", "v2", "v3", "v4")
+    assert(result.schema.toString == resultSchema.toString)
+    assert(resultSchema == expected.schema)
+    assert(result.collect().toSeq == expected.collect().toSeq)
+  }
+
+  test("output column already exists") {
+    val original = sqlContext.createDataFrame(
+      Seq((0, 1.0, 3.0, 4.0), (2, 2.0, 5.0, 8.0))).toDF("id", "v1", "v2", "v3")
+    val sqlTrans = new SQLTransformer().setStatement(
+      "SELECT (v1 + v2) AS v3, (v1 * v2) AS v4 FROM __THIS__")
+    intercept[IllegalArgumentException] {
+      sqlTrans.transform(original)
+    }
+  }
+}


### PR DESCRIPTION
Implements the transforms which are defined by SQL statement.
Currently we only support SQL syntax like 'SELECT ... FROM **THIS**'
where '**THIS**' represents the underlying table of the input dataset.
