### PR TITLE
[SPARK-8951][SparkR] support Unicode characters in collect()

### DIFF
--- a/R/pkg/R/deserialize.R
+++ b/R/pkg/R/deserialize.R
@@ -56,8 +56,10 @@ readTypedObject <- function(con, type) {
 
 readString <- function(con) {
   stringLen <- readInt(con)
-  string <- readBin(con, raw(), stringLen, endian = "big")
-  rawToChar(string)
+  raw <- readBin(con, raw(), stringLen, endian = "big")
+  string <- rawToChar(raw)
+  Encoding(string) <- "UTF-8"
+  enc2native(string)
 }
 
 readInt <- function(con) {

--- a/R/pkg/R/deserialize.R
+++ b/R/pkg/R/deserialize.R
@@ -59,7 +59,7 @@ readString <- function(con) {
   raw <- readBin(con, raw(), stringLen, endian = "big")
   string <- rawToChar(raw)
   Encoding(string) <- "UTF-8"
-  enc2native(string)
+  string 
 }
 
 readInt <- function(con) {

--- a/R/pkg/R/serialize.R
+++ b/R/pkg/R/serialize.R
@@ -79,7 +79,7 @@ writeJobj <- function(con, value) {
 writeString <- function(con, value) {
   utfVal <- enc2utf8(value)
   writeInt(con, as.integer(nchar(utfVal, type = "bytes") + 1))
-  writeBin(utfVal, con, endian = "big")
+  writeBin(utfVal, con, endian = "big", useBytes=TRUE)
 }
 
 writeInt <- function(con, value) {

--- a/R/pkg/inst/tests/test_sparkSQL.R
+++ b/R/pkg/inst/tests/test_sparkSQL.R
@@ -417,8 +417,12 @@ test_that("collect() and take() on a DataFrame return the same number of rows an
   expect_equal(ncol(collect(df)), ncol(take(df, 10)))
 })
 
-
 test_that("collect() support Unicode characters", {
+  convertToNative <- function(s) {
+    Encoding(s) <- "UTF-8"
+    enc2native(s)
+  }
+
   lines <- c("{\"name\":\"안녕하세요\"}",
                  "{\"name\":\"您好\", \"age\":30}",
                  "{\"name\":\"こんにちは\", \"age\":19}",
@@ -430,12 +434,14 @@ test_that("collect() support Unicode characters", {
   rdf <- collect(df)
   expect_true(is.data.frame(rdf))
   expect_equal(rdf$name[1], "안녕하세요")
-  expect_equal(rdf$name[2], "您好")
-  expect_equal(rdf$name[3], "こんにちは")
-  expect_equal(rdf$name[4], "Xin chào")
+  expect_equal(rdf$name[1], convertToNative("안녕하세요"))
+  expect_equal(rdf$name[2], convertToNative("您好"))
+  expect_equal(rdf$name[3], convertToNative("こんにちは"))
+  expect_equal(rdf$name[4], convertToNative("Xin chào"))
 
-  df2 <- createDataFrame(sqlContext, rdf)
-  expect_equal(collect(where(df2, df2$name == "您好"))[[2]], "您好")
+  df1 <- createDataFrame(sqlContext, rdf)
+  expect_equal(collect(where(df1, df1$name == convertToNative("您好")))$name, convertToNative("您好"))
+  expect_equal(collect(where(df1, df1$name == "您好"))$name, "您好")
 })
 
 

--- a/R/pkg/inst/tests/test_sparkSQL.R
+++ b/R/pkg/inst/tests/test_sparkSQL.R
@@ -433,7 +433,6 @@ test_that("collect() support Unicode characters", {
   df <- read.df(sqlContext, jsonPath, "json")
   rdf <- collect(df)
   expect_true(is.data.frame(rdf))
-  expect_equal(rdf$name[1], "안녕하세요")
   expect_equal(rdf$name[1], convertToNative("안녕하세요"))
   expect_equal(rdf$name[2], convertToNative("您好"))
   expect_equal(rdf$name[3], convertToNative("こんにちは"))
@@ -441,7 +440,6 @@ test_that("collect() support Unicode characters", {
 
   df1 <- createDataFrame(sqlContext, rdf)
   expect_equal(collect(where(df1, df1$name == convertToNative("您好")))$name, convertToNative("您好"))
-  expect_equal(collect(where(df1, df1$name == "您好"))$name, "您好")
 })
 
 

--- a/R/pkg/inst/tests/test_sparkSQL.R
+++ b/R/pkg/inst/tests/test_sparkSQL.R
@@ -418,30 +418,30 @@ test_that("collect() and take() on a DataFrame return the same number of rows an
 })
 
 test_that("collect() support Unicode characters", {
-  convertToNative <- function(s) {
+  markUtf8 <- function(s) {
     Encoding(s) <- "UTF-8"
-    enc2native(s)
+    s
   }
 
   lines <- c("{\"name\":\"안녕하세요\"}",
-                 "{\"name\":\"您好\", \"age\":30}",
-                 "{\"name\":\"こんにちは\", \"age\":19}",
-                 "{\"name\":\"Xin chào\"}")
+             "{\"name\":\"您好\", \"age\":30}",
+             "{\"name\":\"こんにちは\", \"age\":19}",
+             "{\"name\":\"Xin chào\"}")
+
   jsonPath <- tempfile(pattern="sparkr-test", fileext=".tmp")
   writeLines(lines, jsonPath)
 
   df <- read.df(sqlContext, jsonPath, "json")
   rdf <- collect(df)
   expect_true(is.data.frame(rdf))
-  expect_equal(rdf$name[1], convertToNative("안녕하세요"))
-  expect_equal(rdf$name[2], convertToNative("您好"))
-  expect_equal(rdf$name[3], convertToNative("こんにちは"))
-  expect_equal(rdf$name[4], convertToNative("Xin chào"))
+  expect_equal(rdf$name[1], markUtf8("안녕하세요"))
+  expect_equal(rdf$name[2], markUtf8("您好"))
+  expect_equal(rdf$name[3], markUtf8("こんにちは"))
+  expect_equal(rdf$name[4], markUtf8("Xin chào"))
 
   df1 <- createDataFrame(sqlContext, rdf)
-  expect_equal(collect(where(df1, df1$name == convertToNative("您好")))$name, convertToNative("您好"))
+  expect_equal(collect(where(df1, df1$name == markUtf8("您好")))$name, markUtf8("您好"))
 })
-
 
 test_that("multiple pipeline transformations result in an RDD with the correct values", {
   df <- jsonFile(sqlContext, jsonPath)

--- a/R/pkg/inst/tests/test_sparkSQL.R
+++ b/R/pkg/inst/tests/test_sparkSQL.R
@@ -417,6 +417,28 @@ test_that("collect() and take() on a DataFrame return the same number of rows an
   expect_equal(ncol(collect(df)), ncol(take(df, 10)))
 })
 
+
+test_that("collect() support Unicode characters", {
+  lines <- c("{\"name\":\"안녕하세요\"}",
+                 "{\"name\":\"您好\", \"age\":30}",
+                 "{\"name\":\"こんにちは\", \"age\":19}",
+                 "{\"name\":\"Xin chào\"}")
+  jsonPath <- tempfile(pattern="sparkr-test", fileext=".tmp")
+  writeLines(lines, jsonPath)
+
+  df <- read.df(sqlContext, jsonPath, "json")
+  rdf <- collect(df)
+  expect_true(is.data.frame(rdf))
+  expect_equal(rdf$name[1], "안녕하세요")
+  expect_equal(rdf$name[2], "您好")
+  expect_equal(rdf$name[3], "こんにちは")
+  expect_equal(rdf$name[4], "Xin chào")
+
+  df2 <- createDataFrame(sqlContext, rdf)
+  expect_equal(collect(where(df2, df2$name == "您好"))[[2]], "您好")
+})
+
+
 test_that("multiple pipeline transformations result in an RDD with the correct values", {
   df <- jsonFile(sqlContext, jsonPath)
   first <- lapply(df, function(row) {

--- a/core/src/main/scala/org/apache/spark/api/r/SerDe.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/SerDe.scala
@@ -303,12 +303,11 @@ private[spark] object SerDe {
     out.writeDouble((value.getTime / 1000).toDouble + value.getNanos.toDouble / 1e9)
   }
 
-  // NOTE: Only works for ASCII right now
   def writeString(out: DataOutputStream, value: String): Unit = {
-    val len = value.length
-    out.writeInt(len + 1) // For the \0
-    out.writeBytes(value)
-    out.writeByte(0)
+    val utf8 = value.getBytes("UTF-8")
+    val len = utf8.length
+    out.writeInt(len)
+    out.write(utf8, 0, len)
   }
 
   def writeBytes(out: DataOutputStream, value: Array[Byte]): Unit = {


### PR DESCRIPTION
Spark gives an error message and does not show the output when a field of the result DataFrame contains characters in CJK.
I changed SerDe.scala in order that Spark support Unicode characters when writes a string to R. 
