### PR TITLE
[SPARK-9193] Avoid assigning tasks to "lost" executor(s)

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -187,7 +187,8 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
       // Filter out executors under killing
       if (!executorsPendingToRemove.contains(executorId)) {
         val executorData = executorDataMap(executorId)
-        val workOffers = Seq(new WorkerOffer(executorId, executorData.executorHost, executorData.freeCores))
+        val workOffers = Seq(
+          new WorkerOffer(executorId, executorData.executorHost, executorData.freeCores))
         launchTasks(scheduler.resourceOffers(workOffers))
       }
     }

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -170,6 +170,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
     // Make fake resource offers on all executors
     private def makeOffers() {
       launchTasks(scheduler.resourceOffers(executorDataMap
+        // Filter out executors under killing
         .filterKeys(!executorsPendingToRemove.contains(_))
         .map { case (id, executorData) =>
           new WorkerOffer(id, executorData.executorHost, executorData.freeCores)
@@ -183,6 +184,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
 
     // Make fake resource offers on just one executor
     private def makeOffers(executorId: String) {
+      // Filter out executors under killing
       if (!executorsPendingToRemove.contains(executorId)) {
         val executorData = executorDataMap(executorId)
         launchTasks(scheduler.resourceOffers(


### PR DESCRIPTION
Now, when some executors are killed by dynamic-allocation, it leads to some mis-assignment onto lost executors sometimes. Such kind of mis-assignment causes task failure(s) or even job failure if it repeats that errors for 4 times. 

The root cause is that **_killExecutors**_ doesn't remove those executors under killing ASAP. It depends on the **_OnDisassociated**_ event to refresh the active working list later. The delay time really depends on your cluster status (from several milliseconds to sub-minute). When new tasks to be scheduled during that period of time, it will be assigned to those "active" but "under killing" executors. Then the tasks will be failed due to "executor lost". The better way is to exclude those executors under killing in the makeOffers(). Then all those tasks won't be allocated onto those executors "to be lost" any more. 
