### PR TITLE
[SQL] Remove space from DataFrame Scala/Java API.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2237,26 +2237,6 @@ object functions {
     StringReverse(str.expr)
   }
 
-  /**
-   * Make a n spaces of string.
-   *
-   * @group string_funcs
-   * @since 1.5.0
-   */
-  def space(n: String): Column = {
-    space(Column(n))
-  }
-
-  /**
-   * Make a n spaces of string.
-   *
-   * @group string_funcs
-   * @since 1.5.0
-   */
-  def space(n: Column): Column = {
-    StringSpace(n.expr)
-  }
-
   //////////////////////////////////////////////////////////////////////////////////////////////
   // DateTime functions
   //////////////////////////////////////////////////////////////////////////////////////////////

--- a/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
@@ -191,10 +191,6 @@ class StringFunctionsSuite extends QueryTest {
     val df = Seq((2, 3)).toDF("a", "b")
 
     checkAnswer(
-      df.select(space($"a"), space("b")),
-      Row("  ", "   "))
-
-    checkAnswer(
       df.selectExpr("space(b)"),
       Row("   "))
   }


### PR DESCRIPTION
I don't think this function is useful at all in Scala/Java, since users can easily compute n \* space easily.
