### PR TITLE
[SPARK-9189][CORE] Takes locality and the sum of partition length into account when partition is instance of HadoopPartition in operator coalesce

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/CoalescedRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/CoalescedRDD.scala
@@ -298,7 +298,7 @@ private class PartitionCoalescer(maxPartitions: Int, prev: RDD[_], balanceSlack:
     val minPowerOfTwo = if (p.isInstanceOf[HadoopPartition]) {
       val groupLen1 = groupArr(r1).arr.map(part =>
         part.asInstanceOf[HadoopPartition].inputSplit.value.getLength).sum
-      val groupLen2 = groupArr(r1).arr.map(part =>
+      val groupLen2 = groupArr(r2).arr.map(part =>
         part.asInstanceOf[HadoopPartition].inputSplit.value.getLength).sum
       if (groupLen1 < groupLen2) groupArr(r1) else groupArr(r2)
     } else {

--- a/core/src/main/scala/org/apache/spark/rdd/CoalescedRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/CoalescedRDD.scala
@@ -295,7 +295,15 @@ private class PartitionCoalescer(maxPartitions: Int, prev: RDD[_], balanceSlack:
 
     val r1 = rnd.nextInt(groupArr.size)
     val r2 = rnd.nextInt(groupArr.size)
-    val minPowerOfTwo = if (groupArr(r1).size < groupArr(r2).size) groupArr(r1) else groupArr(r2)
+    val minPowerOfTwo = if (p.isInstanceOf[HadoopPartition]) {
+      val groupLen1 = groupArr(r1).arr.map(part =>
+        part.asInstanceOf[HadoopPartition].inputSplit.value.getLength).sum
+      val groupLen2 = groupArr(r1).arr.map(part =>
+        part.asInstanceOf[HadoopPartition].inputSplit.value.getLength).sum
+      if (groupLen1 < groupLen2) groupArr(r1) else groupArr(r2)
+    } else {
+      if (groupArr(r1).size < groupArr(r2).size) groupArr(r1) else groupArr(r2)
+    }
     if (prefPart.isEmpty) {
       // if no preferred locations, just use basic power of two
       return minPowerOfTwo


### PR DESCRIPTION
Before:
Takes locality and `the number of partitions` into account in operator coalesce.

After:
Takes locality and `the sum of partition length(part1.len + part2.len + ... + partN.len)` into account when partition is instance of HadoopPartition in operator coalesce.

To make the data size of partition more balanced.

/cc @liancheng @scwf 
