### PR TITLE
[SPARK-9112] [ML] Implement Stats for LogisticRegression

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -451,22 +451,23 @@ private[classification] class MultiClassSummarizer extends Serializable {
 }
 
 /**
- * Abstract for multinomial Logistic regression training results.
- * @param predictions dataframe outputted by the model's `transform` method.
- * @param probabilityCol field in "predictions" which gives the calibrated probability of
- *                       each sample as a vector.
- * @param labelCol field in "predictions" which gives the true label of each sample.
- * @param objectiveHistory objective function (scaled loss + regularization) at each iteration.
+ * Abstraction for multinomial Logistic Regression Training results.
  */
-private [classification] class LogisticRegressionTrainingSummary private[classification] (
-    predictions: DataFrame,
-    probabilityCol: String,
-    labelCol: String,
-    val objectiveHistory: Array[Double])
-  extends LogisticRegressionSummary(predictions, probabilityCol, labelCol) {
+sealed trait LogisticRegressionTrainingSummary extends Serializable {
+
+  /** objective function (scaled loss + regularization) at each iteration. */
+  val objectiveHistory: Array[Double]
 
   /** Number of training iterations until termination */
-  val totalIterations = objectiveHistory.length
+  val totalIterations: Int = objectiveHistory.length
+
+}
+
+/**
+ * Abstraction for Logistic Regression Results for a given model.
+ */
+sealed trait LogisticRegressionSummary extends Serializable {
+
 }
 
 /**
@@ -484,23 +485,8 @@ class BinaryLogisticRegressionTrainingSummary private[classification] (
     probabilityCol: String,
     labelCol: String,
     val objectiveHistory: Array[Double])
-  extends BinaryLogisticRegressionSummary(predictions, probabilityCol, labelCol) {
-
-  /** Number of training iterations until termination */
-  val totalIterations = objectiveHistory.length
-}
-
-/**
- * Abstraction for Multiclass logistic regression results for a given model.
- * @param predictions dataframe outputted by the model's `transform` method.
- * @param probabilityCol field in "predictions" which gives the calibrated probability of
- *                       each sample.
- * @param labelCol field in "predictions" which gives the true label of each sample.
- */
-private [classification] class LogisticRegressionSummary private [classification] (
-  @transient val predictions: DataFrame,
-  val probabilityCol: String,
-  val labelCol: String) extends Serializable {
+  extends BinaryLogisticRegressionSummary(predictions, probabilityCol, labelCol)
+  with LogisticRegressionTrainingSummary {
 
 }
 
@@ -514,10 +500,9 @@ private [classification] class LogisticRegressionSummary private [classification
  */
 @Experimental
 class BinaryLogisticRegressionSummary private[classification] (
-    @transient override val predictions: DataFrame,
-    override val probabilityCol: String,
-    override val labelCol: String)
-  extends LogisticRegressionSummary(predictions, probabilityCol, labelCol) {
+    @transient val predictions: DataFrame,
+    val probabilityCol: String,
+    val labelCol: String) extends LogisticRegressionSummary {
 
   private val sqlContext = predictions.sqlContext
   import sqlContext.implicits._

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -487,7 +487,7 @@ class LogisticRegressionSummary private[classification] (
     val distributedRoc = metrics.roc()
     val sqlContext = SQLContext.getOrCreate(distributedRoc.sparkContext)
     import sqlContext.implicits._
-    distributedRoc.toDF("False Positive Rate", "True Positive Rate")
+    distributedRoc.toDF("FalsePositiveRate", "TruePositiveRate")
   }
 
   /**

--- a/mllib/src/test/java/org/apache/spark/ml/classification/JavaLogisticRegressionSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/classification/JavaLogisticRegressionSuite.java
@@ -147,4 +147,13 @@ public class JavaLogisticRegressionSuite implements Serializable {
       }
     }
   }
+
+  @Test
+  public void logisticRegressionTrainingSummary() {
+    LogisticRegression lr = new LogisticRegression();
+    LogisticRegressionModel model = lr.fit(dataset);
+
+    LogisticRegressionTrainingSummary summary = model.summary();
+    assert(summary.totalIterations() == summary.objectiveHistory().length);
+  }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -723,6 +723,7 @@ class LogisticRegressionSuite extends SparkFunSuite with MLlibTestSparkContext {
   }
 
   test("statistics on training data") {
+    // Test that loss is monotonically decreasing.
     val lr = new LogisticRegression()
       .setMaxIter(10)
       .setRegParam(1.0)

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -703,7 +703,6 @@ class LogisticRegressionSuite extends SparkFunSuite with MLlibTestSparkContext {
   }
 
   test("evaluate on test set") {
-
     // Evaluate on test set should be same as that of the transformed training data.
     val lr = new LogisticRegression()
       .setMaxIter(10)
@@ -714,6 +713,24 @@ class LogisticRegressionSuite extends SparkFunSuite with MLlibTestSparkContext {
 
     val sameSummary = model.evaluate(dataset)
     assert(summary.areaUnderROC === sameSummary.areaUnderROC)
+    assert(summary.roc.collect() === sameSummary.roc.collect())
+    assert(summary.pr.collect() === sameSummary.pr.collect())
+    assert(summary.fMeasureByThreshold.collect() === sameSummary.fMeasureByThreshold.collect())
+    assert(summary.recallByThreshold.collect() === sameSummary.recallByThreshold.collect())
+    assert(summary.precisionByThreshold.collect() === sameSummary.precisionByThreshold.collect())
+  }
+
+  test("statistics on training data") {
+    val lr = new LogisticRegression()
+      .setMaxIter(10)
+      .setRegParam(1.0)
+      .setThreshold(0.6)
+    val model = lr.fit(dataset)
+    assert(
+      model.summary
+        .objectiveHistory
+        .sliding(2)
+        .forall(x => x(0) >= x(1)))
 
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -709,17 +709,17 @@ class LogisticRegressionSuite extends SparkFunSuite with MLlibTestSparkContext {
       .setRegParam(1.0)
       .setThreshold(0.6)
     val model = lr.fit(dataset)
-    val summary = model.summary
+    val summary = model.summary.asInstanceOf[BinaryLogisticRegressionSummary]
 
-    val sameSummary = model.evaluate(dataset)
-    assert(summary.areaUnderROC() === sameSummary.areaUnderROC())
-    assert(summary.roc().collect() === sameSummary.roc.collect())
-    assert(summary.pr().collect() === sameSummary.pr.collect())
+    val sameSummary = model.evaluate(dataset).asInstanceOf[BinaryLogisticRegressionSummary]
+    assert(summary.areaUnderROC === sameSummary.areaUnderROC)
+    assert(summary.roc.collect() === sameSummary.roc.collect())
+    assert(summary.pr.collect === sameSummary.pr.collect())
     assert(
-      summary.fMeasureByThreshold().collect() === sameSummary.fMeasureByThreshold().collect())
-    assert(summary.recallByThreshold().collect() === sameSummary.recallByThreshold().collect())
+      summary.fMeasureByThreshold.collect() === sameSummary.fMeasureByThreshold.collect())
+    assert(summary.recallByThreshold.collect() === sameSummary.recallByThreshold.collect())
     assert(
-      summary.precisionByThreshold().collect() === sameSummary.precisionByThreshold().collect())
+      summary.precisionByThreshold.collect() === sameSummary.precisionByThreshold.collect())
   }
 
   test("statistics on training data") {

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -699,7 +699,7 @@ class LogisticRegressionSuite extends SparkFunSuite with MLlibTestSparkContext {
     val weightsR = Vectors.dense(0.0, 0.0, 0.0, 0.0)
 
     assert(model1.intercept ~== interceptR relTol 1E-5)
-    assert(model1.weights ~= weightsR absTol 1E-6)
+    assert(model1.weights ~== weightsR absTol 1E-6)
   }
 
   test("evaluate on test set") {
@@ -712,12 +712,14 @@ class LogisticRegressionSuite extends SparkFunSuite with MLlibTestSparkContext {
     val summary = model.summary
 
     val sameSummary = model.evaluate(dataset)
-    assert(summary.areaUnderROC === sameSummary.areaUnderROC)
-    assert(summary.roc.collect() === sameSummary.roc.collect())
-    assert(summary.pr.collect() === sameSummary.pr.collect())
-    assert(summary.fMeasureByThreshold.collect() === sameSummary.fMeasureByThreshold.collect())
-    assert(summary.recallByThreshold.collect() === sameSummary.recallByThreshold.collect())
-    assert(summary.precisionByThreshold.collect() === sameSummary.precisionByThreshold.collect())
+    assert(summary.areaUnderROC() === sameSummary.areaUnderROC())
+    assert(summary.roc().collect() === sameSummary.roc.collect())
+    assert(summary.pr().collect() === sameSummary.pr.collect())
+    assert(
+      summary.fMeasureByThreshold().collect() === sameSummary.fMeasureByThreshold().collect())
+    assert(summary.recallByThreshold().collect() === sameSummary.recallByThreshold().collect())
+    assert(
+      summary.precisionByThreshold().collect() === sameSummary.precisionByThreshold().collect())
   }
 
   test("statistics on training data") {

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -701,4 +701,19 @@ class LogisticRegressionSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(model1.intercept ~== interceptR relTol 1E-5)
     assert(model1.weights ~= weightsR absTol 1E-6)
   }
+
+  test("evaluate on test set") {
+
+    // Evaluate on test set should be same as that of the transformed training data.
+    val lr = new LogisticRegression()
+      .setMaxIter(10)
+      .setRegParam(1.0)
+      .setThreshold(0.6)
+    val model = lr.fit(dataset)
+    val summary = model.summary
+
+    val sameSummary = model.evaluate(dataset)
+    assert(summary.areaUnderROC === sameSummary.areaUnderROC)
+
+  }
 }


### PR DESCRIPTION
I have added support for stats in LogisticRegression. The API is similar to that of LinearRegression with LogisticRegressionTrainingSummary and LogisticRegressionSummary

I have some queries and asked them inline.
