### PR TITLE
[SPARK-9198] [mllib] [python] Fixed typo in pyspark sparsevector doc tests

### DIFF
--- a/python/pyspark/mllib/linalg.py
+++ b/python/pyspark/mllib/linalg.py
@@ -566,7 +566,7 @@ class SparseVector(Vector):
         25.0
         >>> a.dot(array.array('d', [1., 2., 3., 4.]))
         22.0
-        >>> b = SparseVector(4, [2, 4], [1.0, 2.0])
+        >>> b = SparseVector(4, [2], [1.0])
         >>> a.dot(b)
         0.0
         >>> a.dot(np.array([[1, 1], [2, 2], [3, 3], [4, 4]]))
@@ -624,7 +624,7 @@ class SparseVector(Vector):
         11.0
         >>> a.squared_distance(np.array([1., 2., 3., 4.]))
         11.0
-        >>> b = SparseVector(4, [2, 4], [1.0, 2.0])
+        >>> b = SparseVector(4, [2], [1.0])
         >>> a.squared_distance(b)
         30.0
         >>> b.squared_distance(a)

--- a/python/pyspark/mllib/linalg.py
+++ b/python/pyspark/mllib/linalg.py
@@ -626,9 +626,9 @@ class SparseVector(Vector):
         11.0
         >>> b = SparseVector(4, [2], [1.0])
         >>> a.squared_distance(b)
-        30.0
+        26.0
         >>> b.squared_distance(a)
-        30.0
+        26.0
         >>> b.squared_distance([1., 2.])
         Traceback (most recent call last):
             ...


### PR DESCRIPTION
Several places in the PySpark SparseVector docs have one defined as:

```
SparseVector(4, [2, 4], [1.0, 2.0])
```

The index 4 goes out of bounds (but this is not checked).

CC: @mengxr
