### PR TITLE
[SPARK-9036][Core] SparkListenerExecutorMetricsUpdate messages not included in JsonProtocol

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -232,7 +232,7 @@ private[spark] object JsonProtocol {
     ("Metrics Updated" -> taskMetrics.map(s =>
       ("Task ID" -> s._1) ~
         ("Stage ID" -> s._2) ~
-        ("Stage Attempt" -> s._3) ~
+        ("Stage Attempt ID" -> s._3) ~
         ("Task Metrics" -> taskMetricsToJson(s._4)))
     )
   }
@@ -618,7 +618,7 @@ private[spark] object JsonProtocol {
     val taskMetrics = (json \"Metrics Updated").extract[List[JValue]].map(s =>
       ((s\"Task ID").extract[Long],
         (s\"Stage ID").extract[Int],
-        (s\"Stage Attempt").extract[Int],
+        (s\"Stage Attempt ID").extract[Int],
         taskMetricsFromJson(s\"Task Metrics"))
     ).toSeq
     SparkListenerExecutorMetricsUpdate(execInfo, taskMetrics)

--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -615,7 +615,7 @@ private[spark] object JsonProtocol {
 
   def executorMetricsUpdateFromJson(json: JValue): SparkListenerExecutorMetricsUpdate = {
     val execInfo = (json \ "Executor ID").extract[String]
-    val taskMetrics =(json \"Metrics Updated").extract[List[JValue]].map(s =>
+    val taskMetrics = (json \"Metrics Updated").extract[List[JValue]].map(s =>
       ((s\"Task ID").extract[Long],
         (s\"Stage ID").extract[Int],
         (s\"Stage Attempt").extract[Int],

--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -227,13 +227,14 @@ private[spark] object JsonProtocol {
   def executorMetricsUpdateToJson(metricsUpdate: SparkListenerExecutorMetricsUpdate): JValue = {
     val execId = metricsUpdate.execId
     val taskMetrics = metricsUpdate.taskMetrics
-    ("ExecID" -> execId) ~
-      ("Metrics Updated" -> taskMetrics.map(s =>
-        ("Task ID" -> s._1) ~
-          ("Stage ID" -> s._2) ~
-          ("Stage Attempt" -> s._3) ~
-          ("Task Metrics" -> taskMetricsToJson(s._4)))
-        )
+    ("Event" -> Utils.getFormattedClassName(metricsUpdate)) ~
+    ("Executor ID" -> execId) ~
+    ("Metrics Updated" -> taskMetrics.map(s =>
+      ("Task ID" -> s._1) ~
+        ("Stage ID" -> s._2) ~
+        ("Stage Attempt" -> s._3) ~
+        ("Task Metrics" -> taskMetricsToJson(s._4)))
+    )
   }
 
   /** ------------------------------------------------------------------- *
@@ -613,7 +614,7 @@ private[spark] object JsonProtocol {
   }
 
   def executorMetricsUpdateFromJson(json: JValue): SparkListenerExecutorMetricsUpdate = {
-    val execInfo = (json \ "ExecID").extract[String]
+    val execInfo = (json \ "Executor ID").extract[String]
     val taskMetrics =(json \"Metrics Updated").extract[List[JValue]].map(s =>
       ((s\"Task ID").extract[Long],
         (s\"Stage ID").extract[Int],

--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -92,8 +92,8 @@ private[spark] object JsonProtocol {
         executorRemovedToJson(executorRemoved)
       case logStart: SparkListenerLogStart =>
         logStartToJson(logStart)
-      // These aren't used, but keeps compiler happy
-      case SparkListenerExecutorMetricsUpdate(_, _) => JNothing
+      case metricsUpdate: SparkListenerExecutorMetricsUpdate =>
+        executorMetricsUpdateToJson(metricsUpdate)
     }
   }
 
@@ -222,6 +222,18 @@ private[spark] object JsonProtocol {
   def logStartToJson(logStart: SparkListenerLogStart): JValue = {
     ("Event" -> Utils.getFormattedClassName(logStart)) ~
     ("Spark Version" -> SPARK_VERSION)
+  }
+
+  def executorMetricsUpdateToJson(metricsUpdate: SparkListenerExecutorMetricsUpdate): JValue = {
+    val execId = metricsUpdate.execId
+    val taskMetrics = metricsUpdate.taskMetrics
+    ("ExecID" -> execId) ~
+      ("Metrics Updated" -> taskMetrics.map(s =>
+        ("Task ID" -> s._1) ~
+          ("Stage ID" -> s._2) ~
+          ("Stage Attempt" -> s._3) ~
+          ("Task Metrics" -> taskMetricsToJson(s._4)))
+        )
   }
 
   /** ------------------------------------------------------------------- *
@@ -463,6 +475,7 @@ private[spark] object JsonProtocol {
     val executorAdded = Utils.getFormattedClassName(SparkListenerExecutorAdded)
     val executorRemoved = Utils.getFormattedClassName(SparkListenerExecutorRemoved)
     val logStart = Utils.getFormattedClassName(SparkListenerLogStart)
+    val metricsUpdate = Utils.getFormattedClassName(SparkListenerExecutorMetricsUpdate)
 
     (json \ "Event").extract[String] match {
       case `stageSubmitted` => stageSubmittedFromJson(json)
@@ -481,6 +494,7 @@ private[spark] object JsonProtocol {
       case `executorAdded` => executorAddedFromJson(json)
       case `executorRemoved` => executorRemovedFromJson(json)
       case `logStart` => logStartFromJson(json)
+      case `metricsUpdate` => executorMetricsUpdateFromJson(json)
     }
   }
 
@@ -596,6 +610,17 @@ private[spark] object JsonProtocol {
   def logStartFromJson(json: JValue): SparkListenerLogStart = {
     val sparkVersion = (json \ "Spark Version").extract[String]
     SparkListenerLogStart(sparkVersion)
+  }
+
+  def executorMetricsUpdateFromJson(json: JValue): SparkListenerExecutorMetricsUpdate = {
+    val execInfo = (json \ "ExecID").extract[String]
+    val taskMetrics =(json \"Metrics Updated").extract[List[JValue]].map(s =>
+      ((s\"Task ID").extract[Long],
+        (s\"Stage ID").extract[Int],
+        (s\"Stage Attempt").extract[Int],
+        taskMetricsFromJson(s\"Task Metrics"))
+    ).toSeq
+    SparkListenerExecutorMetricsUpdate(execInfo, taskMetrics)
   }
 
   /** --------------------------------------------------------------------- *

--- a/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
@@ -444,17 +444,19 @@ class JsonProtocolSuite extends SparkFunSuite {
       case (e1: SparkListenerEnvironmentUpdate, e2: SparkListenerEnvironmentUpdate) =>
         assertEquals(e1.environmentDetails, e2.environmentDetails)
       case (e1: SparkListenerExecutorAdded, e2: SparkListenerExecutorAdded) =>
-        assert(e1.executorId == e1.executorId)
+        assert(e1.executorId === e1.executorId)
         assertEquals(e1.executorInfo, e2.executorInfo)
       case (e1: SparkListenerExecutorRemoved, e2: SparkListenerExecutorRemoved) =>
-        assert(e1.executorId == e1.executorId)
+        assert(e1.executorId === e1.executorId)
       case (e1: SparkListenerExecutorMetricsUpdate, e2: SparkListenerExecutorMetricsUpdate) =>
-        assert(e1.execId == e2.execId)
+        assert(e1.execId === e2.execId)
         assertSeqEquals[(Long, Int, Int, TaskMetrics)](e1.taskMetrics, e2.taskMetrics, (a, b) => {
-          assert(a._1==b._1)
-          assert(a._2==b._2)
-          assert(a._3==b._3)
-          assertEquals(a._4, b._4)
+          val (taskId1, stageId1, stageAttemptId1, metrics1) = a
+          val (taskId2, stageId2, stageAttemptId2, metrics2) = b
+          assert(taskId1 === taskId2)
+          assert(stageId1 === stageId2)
+          assert(stageAttemptId1 === stageAttemptId2)
+          assertEquals(metrics1, metrics2)
         })
       case (e1, e2) =>
         assert(e1 === e2)

--- a/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
@@ -84,7 +84,8 @@ class JsonProtocolSuite extends SparkFunSuite {
       new ExecutorInfo("Hostee.awesome.com", 11, logUrlMap))
     val executorRemoved = SparkListenerExecutorRemoved(executorRemovedTime, "exec2", "test reason")
     val executorMetricsUpdate = SparkListenerExecutorMetricsUpdate("exec3", Seq(
-      (1L, 2, 3, makeTaskMetrics(300L, 400L, 500L, 600L, 700, 800, hasHadoopInput = true, hasOutput = true))))
+      (1L, 2, 3,
+        makeTaskMetrics(300L, 400L, 500L, 600L, 700, 800, hasHadoopInput = true, hasOutput = true))))
 
     testEvent(stageSubmitted, stageSubmittedJsonString)
     testEvent(stageCompleted, stageCompletedJsonString)

--- a/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
@@ -84,7 +84,7 @@ class JsonProtocolSuite extends SparkFunSuite {
       new ExecutorInfo("Hostee.awesome.com", 11, logUrlMap))
     val executorRemoved = SparkListenerExecutorRemoved(executorRemovedTime, "exec2", "test reason")
     val executorMetricsUpdate = SparkListenerExecutorMetricsUpdate("exec3", Seq(
-      (1L,2,3,makeTaskMetrics(300L, 400L, 500L, 600L, 700, 800, hasHadoopInput = true, hasOutput = true))))
+      (1L, 2, 3, makeTaskMetrics(300L, 400L, 500L, 600L, 700, 800, hasHadoopInput = true, hasOutput = true))))
 
     testEvent(stageSubmitted, stageSubmittedJsonString)
     testEvent(stageCompleted, stageCompletedJsonString)
@@ -447,13 +447,13 @@ class JsonProtocolSuite extends SparkFunSuite {
         assertEquals(e1.executorInfo, e2.executorInfo)
       case (e1: SparkListenerExecutorRemoved, e2: SparkListenerExecutorRemoved) =>
         assert(e1.executorId == e1.executorId)
-      case (e1: SparkListenerExecutorMetricsUpdate, e2:SparkListenerExecutorMetricsUpdate) =>
-        assert(e1.execId==e2.execId)
-        assertSeqEquals[(Long, Int, Int, TaskMetrics)](e1.taskMetrics,e2.taskMetrics,(a,b) => {
+      case (e1: SparkListenerExecutorMetricsUpdate, e2: SparkListenerExecutorMetricsUpdate) =>
+        assert(e1.execId == e2.execId)
+        assertSeqEquals[(Long, Int, Int, TaskMetrics)](e1.taskMetrics, e2.taskMetrics, (a, b) => {
           assert(a._1==b._1)
           assert(a._2==b._2)
           assert(a._3==b._3)
-          assertEquals(a._4,b._4)
+          assertEquals(a._4, b._4)
         })
       case (e1, e2) =>
         assert(e1 === e2)

--- a/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
@@ -83,6 +83,8 @@ class JsonProtocolSuite extends SparkFunSuite {
     val executorAdded = SparkListenerExecutorAdded(executorAddedTime, "exec1",
       new ExecutorInfo("Hostee.awesome.com", 11, logUrlMap))
     val executorRemoved = SparkListenerExecutorRemoved(executorRemovedTime, "exec2", "test reason")
+    val executorMetricsUpdate = SparkListenerExecutorMetricsUpdate("Jean Valjean", Seq(
+      (1L,2,3,makeTaskMetrics(300L, 400L, 500L, 600L, 700, 800, hasHadoopInput = true, hasOutput = false))))
 
     testEvent(stageSubmitted, stageSubmittedJsonString)
     testEvent(stageCompleted, stageCompletedJsonString)
@@ -102,6 +104,7 @@ class JsonProtocolSuite extends SparkFunSuite {
     testEvent(applicationEnd, applicationEndJsonString)
     testEvent(executorAdded, executorAddedJsonString)
     testEvent(executorRemoved, executorRemovedJsonString)
+    testEvent(executorMetricsUpdate, executorMetricsUpdateJsonString)
   }
 
   test("Dependent Classes") {
@@ -1598,4 +1601,52 @@ class JsonProtocolSuite extends SparkFunSuite {
       |  "Removed Reason": "test reason"
       |}
     """
+
+  private val executorMetricsUpdateJsonString =
+  s"""
+     |{
+     |  "ExecID": "Jean Valjean",
+     |  "Metrics Updated": {
+     |    "Task ID": 1,
+     |    "Stage ID": 2,
+     |    "Stage Attempt": 3,
+     |    "Task Metrics": {
+     |    "Host Name": "localhost",
+     |    "Executor Deserialize Time": 300,
+     |    "Executor Run Time": 400,
+     |    "Result Size": 500,
+     |    "JVM GC Time": 600,
+     |    "Result Serialization Time": 700,
+     |    "Memory Bytes Spilled": 800,
+     |    "Disk Bytes Spilled": 0,
+     |    "Input Metrics": {
+     |      "Data Read Method": "Hadoop",
+     |      "Bytes Read": 2100,
+     |      "Records Read": 21
+     |    },
+     |    "Output Metrics": {
+     |      "Data Write Method": "Hadoop",
+     |      "Bytes Written": 1200,
+     |      "Records Written": 12
+     |    },
+     |    "Updated Blocks": [
+     |      {
+     |        "Block ID": "rdd_0_0",
+     |        "Status": {
+     |          "Storage Level": {
+     |            "Use Disk": true,
+     |            "Use Memory": true,
+     |            "Use ExternalBlockStore": false,
+     |            "Deserialized": false,
+     |            "Replication": 2
+     |          },
+     |          "Memory Size": 0,
+     |          "ExternalBlockStore Size": 0,
+     |          "Disk Size": 0
+     |        }
+     |      }
+     |    ]
+     |  }
+     |}
+   """
 }

--- a/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
@@ -83,8 +83,8 @@ class JsonProtocolSuite extends SparkFunSuite {
     val executorAdded = SparkListenerExecutorAdded(executorAddedTime, "exec1",
       new ExecutorInfo("Hostee.awesome.com", 11, logUrlMap))
     val executorRemoved = SparkListenerExecutorRemoved(executorRemovedTime, "exec2", "test reason")
-    val executorMetricsUpdate = SparkListenerExecutorMetricsUpdate("Jean Valjean", Seq(
-      (1L,2,3,makeTaskMetrics(300L, 400L, 500L, 600L, 700, 800, hasHadoopInput = true, hasOutput = false))))
+    val executorMetricsUpdate = SparkListenerExecutorMetricsUpdate("exec3", Seq(
+      (1L,2,3,makeTaskMetrics(300L, 400L, 500L, 600L, 700, 800, hasHadoopInput = true, hasOutput = true))))
 
     testEvent(stageSubmitted, stageSubmittedJsonString)
     testEvent(stageCompleted, stageCompletedJsonString)
@@ -447,6 +447,14 @@ class JsonProtocolSuite extends SparkFunSuite {
         assertEquals(e1.executorInfo, e2.executorInfo)
       case (e1: SparkListenerExecutorRemoved, e2: SparkListenerExecutorRemoved) =>
         assert(e1.executorId == e1.executorId)
+      case (e1: SparkListenerExecutorMetricsUpdate, e2:SparkListenerExecutorMetricsUpdate) =>
+        assert(e1.execId==e2.execId)
+        assertSeqEquals[(Long, Int, Int, TaskMetrics)](e1.taskMetrics,e2.taskMetrics,(a,b) => {
+          assert(a._1==b._1)
+          assert(a._2==b._2)
+          assert(a._3==b._3)
+          assertEquals(a._4,b._4)
+        })
       case (e1, e2) =>
         assert(e1 === e2)
       case _ => fail("Events don't match in types!")
@@ -1605,8 +1613,10 @@ class JsonProtocolSuite extends SparkFunSuite {
   private val executorMetricsUpdateJsonString =
   s"""
      |{
-     |  "ExecID": "Jean Valjean",
-     |  "Metrics Updated": {
+     |  "Event": "SparkListenerExecutorMetricsUpdate",
+     |  "Executor ID": "exec3",
+     |  "Metrics Updated": [
+     |  {
      |    "Task ID": 1,
      |    "Stage ID": 2,
      |    "Stage Attempt": 3,
@@ -1647,6 +1657,7 @@ class JsonProtocolSuite extends SparkFunSuite {
      |      }
      |    ]
      |  }
+     |  }]
      |}
-   """
+   """.stripMargin
 }

--- a/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
@@ -1620,7 +1620,7 @@ class JsonProtocolSuite extends SparkFunSuite {
      |  {
      |    "Task ID": 1,
      |    "Stage ID": 2,
-     |    "Stage Attempt": 3,
+     |    "Stage Attempt ID": 3,
      |    "Task Metrics": {
      |    "Host Name": "localhost",
      |    "Executor Deserialize Time": 300,

--- a/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
@@ -84,8 +84,8 @@ class JsonProtocolSuite extends SparkFunSuite {
       new ExecutorInfo("Hostee.awesome.com", 11, logUrlMap))
     val executorRemoved = SparkListenerExecutorRemoved(executorRemovedTime, "exec2", "test reason")
     val executorMetricsUpdate = SparkListenerExecutorMetricsUpdate("exec3", Seq(
-      (1L, 2, 3,
-        makeTaskMetrics(300L, 400L, 500L, 600L, 700, 800, hasHadoopInput = true, hasOutput = true))))
+      (1L, 2, 3, makeTaskMetrics(300L, 400L, 500L, 600L, 700, 800,
+        hasHadoopInput = true, hasOutput = true))))
 
     testEvent(stageSubmitted, stageSubmittedJsonString)
     testEvent(stageCompleted, stageCompletedJsonString)


### PR DESCRIPTION
This PR implements a JSON serializer and deserializer in the JSONProtocol to handle the (de)serialization of SparkListenerExecutorMetricsUpdate events. It also includes a unit test in the JSONProtocolSuite file. This was implemented to satisfy the improvement request in the JIRA  issue SPARK-9036. 
