### PR TITLE
[BUILD] [SPARK-9179] Use default primary author if unspecified

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -133,6 +133,8 @@ def merge_pr(pr_num, target_ref, title, body, pr_repo_desc):
     primary_author = raw_input(
         "Enter primary author in the format of \"name <email>\" [%s]: " %
         distinct_authors[0])
+    if primary_author == "":
+        primary_author = distinct_authors[0]
 
     commits = run_cmd(['git', 'log', 'HEAD..%s' % pr_branch_name,
                       '--pretty=format:%h [%an] %s']).split("\n\n")


### PR DESCRIPTION
Fixes feature introduced in #7508 to use the default value if nothing is specified in command line

cc @liancheng @rxin @pwendell 
