### PR TITLE
[SPARK-9209] Using executor allocation, a executor is removed but it exists in ExecutorsPage of the web ui

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsPage.scala
@@ -58,7 +58,11 @@ private[ui] class ExecutorsPage(
     val diskUsed = storageStatusList.map(_.diskUsed).sum
     val execInfo = for (statusId <- 0 until storageStatusList.size) yield
       ExecutorsPage.getExecInfo(listener, statusId)
-    val execInfoSorted = execInfo.sortBy(_.id)
+    val execInfoSorted = execInfo.filter(x => {
+      val numPattern = "[0-9]+".r
+      val noIntId = numPattern.findFirstIn(x.id).isEmpty
+      listener.getExecutorIds.contains(x.id).||(noIntId)
+    }).sortBy(_.id)
     val logsExist = execInfo.filter(_.executorLogs.nonEmpty).nonEmpty
 
     val execTable =

--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsTab.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorsTab.scala
@@ -59,7 +59,7 @@ class ExecutorsListener(storageStatusListener: StorageStatusListener) extends Sp
   private var executorIds = Seq[String]()
 
   def storageStatusList: Seq[StorageStatus] = storageStatusListener.storageStatusList
-  
+
   def getExecutorIds: Seq[String] = executorIds
 
   override def onExecutorAdded(executorAdded: SparkListenerExecutorAdded): Unit = synchronized {


### PR DESCRIPTION
I set "spark.dynamicAllocation.enabled = true”, and  run a big job.  After some minutes, in driver, a executor is  asked to remove. Then it's removed successfully, and the process of this executor is not exist. But it exists in ExecutorsPage of the web ui.

The log in driver :
2015-07-17 11:48:14,543 | INFO  | [sparkDriver-akka.actor.default-dispatcher-3] | Removing block manager BlockManagerId(264, 172.1.1.8, 23811) 
2015-07-17 11:48:14,543 | INFO  | [dag-scheduler-event-loop] | Removed 264 successfully in removeExecutor 
2015-07-17 11:48:21,226 | INFO  | [sparkDriver-akka.actor.default-dispatcher-3] | Registering block manager 172.1.1.8:23811 with 10.4 GB RAM, BlockManagerId(264, 172.1.1.8, 23811) 
2015-07-17 11:48:21,228 | INFO  | [sparkDriver-akka.actor.default-dispatcher-3] | Added broadcast_781_piece0 in memory on 172.1.1.8:23811 (size: 38.6 KB, free: 10.4 GB)  
2015-07-17 11:48:35,277 | ERROR | [sparkDriver-akka.actor.default-dispatcher-16] | Lost executor 264 on datasight-195: remote Rpc client disassociated 
2015-07-17 11:48:35,277 | WARN  | [sparkDriver-akka.actor.default-dispatcher-4] | Association with remote system [akka.tcp://sparkExecutor@datasight-195:23929] has failed, address is now gated for [5000] ms. Reason is: [Disassociated].
2015-07-17 11:48:35,277 | INFO  | [sparkDriver-akka.actor.default-dispatcher-16] | Re-queueing tasks for 264 from TaskSet 415.0 
2015-07-17 11:48:35,804 | INFO  | [SparkListenerBus] | Existing executor 264 has been removed (new total is 10)
