### PR TITLE
[SPARK-9121][SparkR] Get rid of the warnings about `no visible global function definition` in SparkR

### DIFF
--- a/R/pkg/inst/tests/test_sparkSQL.R
+++ b/R/pkg/inst/tests/test_sparkSQL.R
@@ -21,10 +21,10 @@ context("SparkSQL functions")
 
 # Utility function for easily checking the values of a StructField
 checkStructField <- function(actual, expectedName, expectedType, expectedNullable) {
-  expect_equal(class(actual), "structField")
-  expect_equal(actual$name(), expectedName)
-  expect_equal(actual$dataType.toString(), expectedType)
-  expect_equal(actual$nullable(), expectedNullable)
+  testthat::expect_equal(class(actual), "structField")
+  testthat::expect_equal(actual$name(), expectedName)
+  testthat::expect_equal(actual$dataType.toString(), expectedType)
+  testthat::expect_equal(actual$nullable(), expectedNullable)
 }
 
 # Tests for SparkSQL functions in SparkR

--- a/R/pkg/inst/tests/test_sparkSQL.R
+++ b/R/pkg/inst/tests/test_sparkSQL.R
@@ -21,10 +21,10 @@ context("SparkSQL functions")
 
 # Utility function for easily checking the values of a StructField
 checkStructField <- function(actual, expectedName, expectedType, expectedNullable) {
-  testthat::expect_equal(class(actual), "structField")
-  testthat::expect_equal(actual$name(), expectedName)
-  testthat::expect_equal(actual$dataType.toString(), expectedType)
-  testthat::expect_equal(actual$nullable(), expectedNullable)
+  expect_equal(class(actual), "structField")
+  expect_equal(actual$name(), expectedName)
+  expect_equal(actual$dataType.toString(), expectedType)
+  expect_equal(actual$nullable(), expectedNullable)
 }
 
 # Tests for SparkSQL functions in SparkR

--- a/dev/lint-r.R
+++ b/dev/lint-r.R
@@ -25,5 +25,6 @@ library(lintr)
 argv <- commandArgs(TRUE)
 SPARK_ROOT_DIR <- as.character(argv[1])
 
+library(SparkR, lib.loc = file.path(SPARK_ROOT_DIR, "R", "lib"))
 path.to.package <- file.path(SPARK_ROOT_DIR, "R", "pkg")
 lint_package(path.to.package, cache = FALSE)

--- a/dev/lint-r.R
+++ b/dev/lint-r.R
@@ -24,9 +24,12 @@ if ("lintr" %in% row.names(installed.packages())  == FALSE) {
   devtools::install_github("jimhester/lintr")
 }
 
-# NOTE: You should install SparkR with `R/install-dev.sh` before running this script.
 library(lintr)
+library(methods)
 library(testthat)
-library(SparkR, lib.loc = file.path(SPARK_ROOT_DIR, "R", "lib"))
+if (! library(SparkR, lib.loc = file.path(SPARK_ROOT_DIR, "R", "lib"), logical.return = TRUE)) {
+  stop("You should install SparkR in a local directory with `R/instlal-dev.sh`.")
+}
+
 path.to.package <- file.path(SPARK_ROOT_DIR, "R", "pkg")
 lint_package(path.to.package, cache = FALSE)

--- a/dev/lint-r.R
+++ b/dev/lint-r.R
@@ -28,7 +28,7 @@ library(lintr)
 library(methods)
 library(testthat)
 if (! library(SparkR, lib.loc = file.path(SPARK_ROOT_DIR, "R", "lib"), logical.return = TRUE)) {
-  stop("You should install SparkR in a local directory with `R/instlal-dev.sh`.")
+  stop("You should install SparkR in a local directory with `R/install-dev.sh`.")
 }
 
 path.to.package <- file.path(SPARK_ROOT_DIR, "R", "pkg")

--- a/dev/lint-r.R
+++ b/dev/lint-r.R
@@ -15,16 +15,18 @@
 # limitations under the License.
 #
 
+argv <- commandArgs(TRUE)
+SPARK_ROOT_DIR <- as.character(argv[1])
+
 # Installs lintr from Github.
 # NOTE: The CRAN's version is too old to adapt to our rules.
 if ("lintr" %in% row.names(installed.packages())  == FALSE) {
   devtools::install_github("jimhester/lintr")
 }
+
+# NOTE: You should install SparkR with `R/install-dev.sh` before running this script.
 library(lintr)
-
-argv <- commandArgs(TRUE)
-SPARK_ROOT_DIR <- as.character(argv[1])
-
+library(testthat)
 library(SparkR, lib.loc = file.path(SPARK_ROOT_DIR, "R", "lib"))
 path.to.package <- file.path(SPARK_ROOT_DIR, "R", "pkg")
 lint_package(path.to.package, cache = FALSE)


### PR DESCRIPTION
[[SPARK-9121] Get rid of the warnings about `no visible global function definition` in SparkR - ASF JIRA](https://issues.apache.org/jira/browse/SPARK-9121)
## The Result of `dev/lint-r`

[The result of lint-r for SPARK-9121 at the revision:1ddd0f2f1688560f88470e312b72af04364e2d49 when I have sent a PR](https://gist.github.com/yu-iskw/6f55953425901725edf6)
