### PR TITLE
[MINOR][BUILD] Restore to previous branch instead of detached commit

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -363,7 +363,7 @@ def main():
     global original_head
 
     os.chdir(SPARK_HOME)
-    original_head = run_cmd("git rev-parse HEAD")[:8]
+    original_head = run_cmd("git rev-parse --abbrev-ref HEAD").replace("\n", "")
 
     branches = get_json("%s/branches" % GITHUB_API_BASE)
     branch_names = filter(lambda x: x.startswith("branch-"), [x['name'] for x in branches])


### PR DESCRIPTION
The right command to get the branch name is `git rev-parse --abbrev-ref HEAD`
instead of `git rev-parse HEAD`. The latter returns the commit hash causing
a detached branch when we checkout to it.

We are using the same script (with some modifications) in Kafka and that is how the issue was noticed.
