### PR TITLE
[SPARK-8231][SQL] Add array_contains

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -34,6 +34,7 @@ from pyspark.sql.column import Column, _to_java_column, _to_seq
 
 __all__ = [
     'array',
+    'array_contains',
     'approxCountDistinct',
     'bin',
     'coalesce',
@@ -1014,6 +1015,21 @@ def soundex(col):
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.size(_to_java_column(col)))
+
+
+@since(1.5)
+def array_contains(col, value):
+    """
+    Collection function: returns True if the array contains the given value
+    :param col: name of column containing array
+    :param value: value to check for in array
+
+    >>> df = sqlContext.createDataFrame([([1, 2, 3],), ([],)], ['data'])
+    >>> df.select(array_contains(df.data, 1)).collect()
+    [Row(array_contains(data, 1)=True), Row(array_contains(data, 1)=False)]
+    """
+    sc = SparkContext._active_spark_context
+    return Column(sc._jvm.functions.array_contains(_to_java_column(col), value))
 
 
 class UserDefinedFunction(object):

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1025,9 +1025,9 @@ def array_contains(col, value):
     :param col: name of column containing array
     :param value: value to check for in array
 
-    >>> df = sqlContext.createDataFrame([([1, 2, 3],), ([],)], ['data'])
-    >>> df.select(array_contains(df.data, 1L)).collect()
-    [Row(array_contains(data,1)=True), Row(array_contains(data,1)=False)]
+    >>> df = sqlContext.createDataFrame([(["a", "b", "c"],), ([],)], ['data'])
+    >>> df.select(array_contains(df.data, "a")).collect()
+    [Row(array_contains(data,"a")=True), Row(array_contains(data,"a")=False)]
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.array_contains(_to_java_column(col), value))

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1022,6 +1022,7 @@ def array_contains(col, value):
     """
     Collection function: returns True if the array contains the given value. The collection
     elements and value must be of the same type.
+
     :param col: name of column containing array
     :param value: value to check for in array
 

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1025,7 +1025,7 @@ def array_contains(col, value):
     :param value: value to check for in array
 
     >>> df = sqlContext.createDataFrame([([1, 2, 3],), ([],)], ['data'])
-    >>> df.select(array_contains(df.data, 1)).collect()
+    >>> df.select(array_contains(df.data, 1L)).collect()
     [Row(array_contains(data, 1)=True), Row(array_contains(data, 1)=False)]
     """
     sc = SparkContext._active_spark_context

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1020,7 +1020,8 @@ def soundex(col):
 @since(1.5)
 def array_contains(col, value):
     """
-    Collection function: returns True if the array contains the given value
+    Collection function: returns True if the array contains the given value. The collection
+    elements and value must be of the same type.
     :param col: name of column containing array
     :param value: value to check for in array
 

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1027,7 +1027,7 @@ def array_contains(col, value):
 
     >>> df = sqlContext.createDataFrame([(["a", "b", "c"],), ([],)], ['data'])
     >>> df.select(array_contains(df.data, "a")).collect()
-    [Row(array_contains(data,"a")=True), Row(array_contains(data,"a")=False)]
+    [Row(array_contains(data,a)=True), Row(array_contains(data,a)=False)]
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.array_contains(_to_java_column(col), value))

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1027,7 +1027,7 @@ def array_contains(col, value):
 
     >>> df = sqlContext.createDataFrame([([1, 2, 3],), ([],)], ['data'])
     >>> df.select(array_contains(df.data, 1L)).collect()
-    [Row(array_contains(data, 1)=True), Row(array_contains(data, 1)=False)]
+    [Row(array_contains(data,1)=True), Row(array_contains(data,1)=False)]
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.array_contains(_to_java_column(col), value))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -238,6 +238,7 @@ object FunctionRegistry {
     // collection functions
     expression[Size]("size"),
     expression[SortArray]("sort_array"),
+    expression[ArrayContains]("array_contains"),
 
     // misc functions
     expression[Crc32]("crc32"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExpectsInputTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExpectsInputTypes.scala
@@ -44,8 +44,8 @@ trait ExpectsInputTypes extends Expression {
   override def checkInputDataTypes(): TypeCheckResult = {
     val mismatches = children.zip(inputTypes).zipWithIndex.collect {
       case ((child, expected), idx) if !expected.acceptsType(child.dataType) =>
-        s"argument ${idx + 1} is expected to be of type ${expected.simpleString}, " +
-          s"however, '${child.prettyString}' is of type ${child.dataType.simpleString}."
+        s"argument ${idx + 1} requires ${expected.simpleString} type, " +
+          s"however, '${child.prettyString}' is of ${child.dataType.simpleString} type."
     }
 
     if (mismatches.isEmpty) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExpectsInputTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExpectsInputTypes.scala
@@ -42,16 +42,21 @@ trait ExpectsInputTypes extends Expression {
   def inputTypes: Seq[AbstractDataType]
 
   override def checkInputDataTypes(): TypeCheckResult = {
-    val mismatches = children.zip(inputTypes).zipWithIndex.collect {
-      case ((child, expected), idx) if !expected.acceptsType(child.dataType) =>
-        s"argument ${idx + 1} requires ${expected.simpleString} type, " +
-          s"however, '${child.prettyString}' is of ${child.dataType.simpleString} type."
-    }
+    if (children.size == inputTypes.size) {
+      val mismatches = children.zip(inputTypes).zipWithIndex.collect {
+        case ((child, expected), idx) if !expected.acceptsType(child.dataType) =>
+          s"argument ${idx + 1} is expected to be of type ${expected.simpleString}, " +
+            s"however, '${child.prettyString}' is of type ${child.dataType.simpleString}."
+      }
 
-    if (mismatches.isEmpty) {
-      TypeCheckResult.TypeCheckSuccess
+      if (mismatches.isEmpty) {
+        TypeCheckResult.TypeCheckSuccess
+      } else {
+        TypeCheckResult.TypeCheckFailure(mismatches.mkString(" "))
+      }
     } else {
-      TypeCheckResult.TypeCheckFailure(mismatches.mkString(" "))
+      TypeCheckResult.TypeCheckFailure(
+        s"Length of children types was ${children.size}, but expected to be ${inputTypes.size}")
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExpectsInputTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExpectsInputTypes.scala
@@ -42,21 +42,16 @@ trait ExpectsInputTypes extends Expression {
   def inputTypes: Seq[AbstractDataType]
 
   override def checkInputDataTypes(): TypeCheckResult = {
-    if (children.size == inputTypes.size) {
-      val mismatches = children.zip(inputTypes).zipWithIndex.collect {
-        case ((child, expected), idx) if !expected.acceptsType(child.dataType) =>
-          s"argument ${idx + 1} is expected to be of type ${expected.simpleString}, " +
-            s"however, '${child.prettyString}' is of type ${child.dataType.simpleString}."
-      }
+    val mismatches = children.zip(inputTypes).zipWithIndex.collect {
+      case ((child, expected), idx) if !expected.acceptsType(child.dataType) =>
+        s"argument ${idx + 1} is expected to be of type ${expected.simpleString}, " +
+          s"however, '${child.prettyString}' is of type ${child.dataType.simpleString}."
+    }
 
-      if (mismatches.isEmpty) {
-        TypeCheckResult.TypeCheckSuccess
-      } else {
-        TypeCheckResult.TypeCheckFailure(mismatches.mkString(" "))
-      }
+    if (mismatches.isEmpty) {
+      TypeCheckResult.TypeCheckSuccess
     } else {
-      TypeCheckResult.TypeCheckFailure(
-        s"Length of children types was ${children.size}, but expected to be ${inputTypes.size}")
+      TypeCheckResult.TypeCheckFailure(mismatches.mkString(" "))
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -122,9 +122,19 @@ case class ArrayContains(left: Expression, right: Expression)
 
   override def dataType: DataType = BooleanType
 
-  override def inputTypes: Seq[AbstractDataType] = left.dataType match {
-    case n @ ArrayType(element, _) => Seq(n, element)
-    case n @ NullType => Seq(TypeCollection(ArrayType, NullType), AnyDataType)
+  override def inputTypes: Seq[AbstractDataType] = right.dataType match {
+    case NullType => Seq()
+    case _ => left.dataType match {
+      case n @ ArrayType(element, _) => Seq(n, element)
+      case _ => Seq()
+    }
+  }
+
+  override def checkInputDataTypes(): TypeCheckResult = {
+    inputTypes.size match {
+      case 0 => TypeCheckResult.TypeCheckFailure("Null typed values cannot be used as arguments")
+      case _ => super.checkInputDataTypes()
+    }
   }
 
   override def nullable: Boolean = false

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -117,7 +117,9 @@ case class SortArray(base: Expression, ascendingOrder: Expression)
   override def prettyName: String = "sort_array"
 }
 
-case class ArrayContains(left: Expression, right: Expression) extends BinaryExpression with ExpectsInputTypes {
+case class ArrayContains(left: Expression, right: Expression)
+  extends BinaryExpression with ExpectsInputTypes {
+
   override def dataType: DataType = BooleanType
 
   override def inputTypes: Seq[AbstractDataType] = left.dataType match {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -151,18 +151,19 @@ case class ArrayContains(left: Expression, right: Expression) extends BinaryExpr
     val arrGen = left.gen(ctx)
     val elementGen = right.gen(ctx)
     s"""
-       ${arrGen.code}
-       boolean ${ev.isNull} = false;
-       if (${arrGen.isNull}) {
-        ${ev.primitive} = false;
-       } else {
-        ${elementGen.code}
-        if (${elementGen.isNull}) {
+        ${arrGen.code}
+        boolean ${ev.isNull} = false;
+        boolean ${ev.primitive} = false;
+        if (${arrGen.isNull}) {
           ${ev.primitive} = false;
         } else {
-          ${ev.primitive} = ${arrGen.primitive}.contains(${elementGen.primitive});
+          ${elementGen.code}
+          if (${elementGen.isNull}) {
+            ${ev.primitive} = false;
+          } else {
+            ${ev.primitive} = ${arrGen.primitive}.contains(${elementGen.primitive});
+          }
         }
-       }
      """
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -126,7 +126,11 @@ case class ArrayContains(left: Expression, right: Expression) extends BinaryExpr
       false
     } else {
       val element = right.eval(input)
-      arr.asInstanceOf[Seq[Any]].contains(element)
+      if (element == null) {
+        false
+      } else {
+        arr.asInstanceOf[Seq[Any]].contains(element)
+      }
     }
   }
 
@@ -140,7 +144,11 @@ case class ArrayContains(left: Expression, right: Expression) extends BinaryExpr
         ${ev.primitive} = false;
        } else {
         ${elementGen.code}
-        ${ev.primitive} = ${arrGen.primitive}.contains(${elementGen.primitive});
+        if (${elementGen.isNull}) {
+          ${ev.primitive} = false;
+        } else {
+          ${ev.primitive} = ${arrGen.primitive}.contains(${elementGen.primitive});
+        }
        }
      """
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -120,7 +120,10 @@ case class SortArray(base: Expression, ascendingOrder: Expression)
 case class ArrayContains(left: Expression, right: Expression) extends BinaryExpression with ExpectsInputTypes {
   override def dataType: DataType = BooleanType
 
-  override def inputTypes: Seq[AbstractDataType] = Seq(ArrayType, AnyDataType)
+  override def inputTypes: Seq[AbstractDataType] = left.dataType match {
+    case n @ ArrayType(element, _) => Seq(n, element)
+    case n @ NullType => Seq(TypeCollection(ArrayType, NullType), AnyDataType)
+  }
 
   override def nullable: Boolean = false
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -116,22 +116,10 @@ case class SortArray(base: Expression, ascendingOrder: Expression)
   override def prettyName: String = "sort_array"
 }
 
-case class ArrayContains(left: Expression, right: Expression) extends BinaryExpression {
+case class ArrayContains(left: Expression, right: Expression) extends BinaryExpression with ExpectsInputTypes {
   override def dataType: DataType = BooleanType
 
-  override def checkInputDataTypes(): TypeCheckResult = {
-    if (!left.dataType.isInstanceOf[ArrayType]) {
-      TypeCheckResult.TypeCheckFailure(
-        s"type of first input must be an array, not ${left.dataType.simpleString}")
-    } else if (left.dataType.asInstanceOf[ArrayType].elementType != right.dataType) {
-      TypeCheckResult.TypeCheckFailure(
-        s"type of value must match array type " +
-          s"${left.dataType.asInstanceOf[ArrayType].elementType.simpleString}, not " +
-          s"${right.dataType.simpleString}")
-    } else {
-      TypeCheckResult.TypeCheckSuccess
-    }
-  }
+  override def inputTypes: Seq[AbstractDataType] = Seq(ArrayType, AnyDataType)
 
   override def nullable: Boolean = false
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -126,14 +126,14 @@ case class ArrayContains(left: Expression, right: Expression) extends BinaryExpr
     } else if (left.dataType.asInstanceOf[ArrayType].elementType != right.dataType) {
       TypeCheckResult.TypeCheckFailure(
         s"type of value must match array type " +
-          s"${left.dataType.asInstanceOf[ArrayType].elementType.simpleString}, not "+
+          s"${left.dataType.asInstanceOf[ArrayType].elementType.simpleString}, not " +
           s"${right.dataType.simpleString}")
     } else {
       TypeCheckResult.TypeCheckSuccess
     }
   }
 
-  override def nullable = false
+  override def nullable: Boolean = false
 
   override def eval(input: InternalRow): Boolean = {
     val arr = left.eval(input)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -133,6 +133,8 @@ case class ArrayContains(left: Expression, right: Expression) extends BinaryExpr
     }
   }
 
+  override def nullable = false
+
   override def eval(input: InternalRow): Boolean = {
     val arr = left.eval(input)
     if (arr == null) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -19,7 +19,8 @@ package org.apache.spark.sql.catalyst.expressions
 import java.util.Comparator
 
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
-import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenFallback, CodeGenContext, GeneratedExpressionCode}
+import org.apache.spark.sql.catalyst.expressions.codegen.{
+  CodegenFallback, CodeGenContext, GeneratedExpressionCode}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.types._
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionFunctionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionFunctionsSuite.scala
@@ -69,7 +69,7 @@ class CollectionFunctionsSuite extends SparkFunSuite with ExpressionEvalHelper {
   test("Array contains") {
     val a0 = Literal.create(Seq(1, 2, 3), ArrayType(IntegerType))
     val a1 = Literal.create(Seq[Int](), ArrayType(IntegerType))
-    val a2 = Literal.create(Seq(null), ArrayType(IntegerType))
+    val a2 = Literal.create(Seq(null), ArrayType(NullType))
 
     checkEvaluation(ArrayContains(a0, Literal(1)), true)
     checkEvaluation(ArrayContains(a0, Literal(0)), false)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionFunctionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionFunctionsSuite.scala
@@ -68,6 +68,13 @@ class CollectionFunctionsSuite extends SparkFunSuite with ExpressionEvalHelper {
 
   test("Array contains") {
     val a0 = Literal.create(Seq(1, 2, 3), ArrayType(IntegerType))
+    val a1 = Literal.create(Seq[Int](), ArrayType(IntegerType))
 
+    checkEvaluation(ArrayContains(a0, Literal(1)), true)
+    checkEvaluation(ArrayContains(a0, Literal(0)), false)
+    checkEvaluation(ArrayContains(a0, Literal(null)), false)
+
+    checkEvaluation(ArrayContains(a1, Literal(1)), false)
+    checkEvaluation(ArrayContains(a1, Literal(null)), false)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionFunctionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionFunctionsSuite.scala
@@ -65,4 +65,9 @@ class CollectionFunctionsSuite extends SparkFunSuite with ExpressionEvalHelper {
 
     checkEvaluation(Literal.create(null, ArrayType(StringType)), null)
   }
+
+  test("Array contains") {
+    val a0 = Literal.create(Seq(1, 2, 3), ArrayType(IntegerType))
+
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionFunctionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionFunctionsSuite.scala
@@ -69,6 +69,7 @@ class CollectionFunctionsSuite extends SparkFunSuite with ExpressionEvalHelper {
   test("Array contains") {
     val a0 = Literal.create(Seq(1, 2, 3), ArrayType(IntegerType))
     val a1 = Literal.create(Seq[Int](), ArrayType(IntegerType))
+    val a2 = Literal.create(Seq(null), ArrayType(IntegerType))
 
     checkEvaluation(ArrayContains(a0, Literal(1)), true)
     checkEvaluation(ArrayContains(a0, Literal(0)), false)
@@ -76,5 +77,7 @@ class CollectionFunctionsSuite extends SparkFunSuite with ExpressionEvalHelper {
 
     checkEvaluation(ArrayContains(a1, Literal(1)), false)
     checkEvaluation(ArrayContains(a1, Literal(null)), false)
+
+    checkEvaluation(ArrayContains(a2, Literal(null)), false)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2218,10 +2218,21 @@ object functions {
    */
   def sort_array(e: Column, asc: Boolean): Column = SortArray(e.expr, lit(asc).expr)
 
-  def array_contains(columnName: String, element: Any): Column = array_contains(Column(columnName), element)
+  /**
+   * Returns true if the array contain the value
+   * @group collection_funcs
+   * @since 1.5.0
+   */
+  def array_contains(columnName: String, value: Any): Column =
+    array_contains(Column(columnName), value)
 
-  def array_contains(column: Column, element: Any): Column =
-    ArrayContains(column.expr, Literal(element))
+  /**
+   * Returns true if the array contain the value
+   * @group collection_funcs
+   * @since 1.5.0
+   */
+  def array_contains(column: Column, value: Any): Column =
+    ArrayContains(column.expr, Literal(value))
 
 
   //////////////////////////////////////////////////////////////////////////////////////////////

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2223,14 +2223,6 @@ object functions {
    * @group collection_funcs
    * @since 1.5.0
    */
-  def array_contains(columnName: String, value: Any): Column =
-    array_contains(Column(columnName), value)
-
-  /**
-   * Returns true if the array contain the value
-   * @group collection_funcs
-   * @since 1.5.0
-   */
   def array_contains(column: Column, value: Any): Column =
     ArrayContains(column.expr, Literal(value))
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2218,6 +2218,12 @@ object functions {
    */
   def sort_array(e: Column, asc: Boolean): Column = SortArray(e.expr, lit(asc).expr)
 
+  def array_contains(columnName: String, element: Any): Column = array_contains(Column(columnName), element)
+
+  def array_contains(column: Column, element: Any): Column =
+    ArrayContains(column.expr, Literal(element))
+
+
   //////////////////////////////////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -315,9 +315,9 @@ class DataFrameFunctionsSuite extends QueryTest {
 
   test("array size function") {
     val df = Seq(
-      (Array[Int](1, 2), "x"),
-      (Array[Int](), "y"),
-      (Array[Int](1, 2, 3), "z")
+      (Seq[Int](1, 2), "x"),
+      (Seq[Int](), "y"),
+      (Seq[Int](1, 2, 3), "z")
     ).toDF("a", "b")
     checkAnswer(
       df.select(size($"a")),
@@ -347,29 +347,29 @@ class DataFrameFunctionsSuite extends QueryTest {
 
   test("array contains function") {
     val df = Seq(
-      (Array[Int](1, 2), "x"),
-      (Array[Int](), "y"),
+      (Seq[Int](1, 2), "x"),
+      (Seq[Int](), "y"),
       (null, "z")
     ).toDF("a", "b")
     checkAnswer(
       df.select(array_contains("a", 1)),
       Seq(Row(true), Row(false), Row(false))
     )
-    checkAnswer(
-      df.select(array_contains("a", null)),
-      Seq(Row(false), Row(false), Row(false))
-    )
+    //checkAnswer(
+    //  df.select(array_contains("a", null)),
+    //  Seq(Row(false), Row(false), Row(false))
+    //)
     checkAnswer(
       df.selectExpr("array_contains(a, 1)"),
       Seq(Row(true), Row(false), Row(false))
     )
-    checkAnswer(
-      df.selectExpr("array_contains(null, 1)"),
-      Seq(Row(false), Row(false), Row(false))
-    )
-    checkAnswer(
-      df.selectExpr("array_contains(a, null)"),
-      Seq(Row(false), Row(false))
-    )
+    //checkAnswer(
+    //  df.selectExpr("array_contains(null, 1)"),
+    //  Seq(Row(false), Row(false), Row(false))
+    //)
+    //checkAnswer(
+    //  df.selectExpr("array_contains(a, null)"),
+    //  Seq(Row(false), Row(false))
+    //)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -344,4 +344,15 @@ class DataFrameFunctionsSuite extends QueryTest {
       Seq(Row(2), Row(0), Row(3))
     )
   }
+
+  test("array contains function") {
+    val df = Seq(
+      (Array[Int](1, 2), "x"),
+      (Array[Int](), "y")
+    ).toDF("a", "b")
+    checkAnswer(
+      df.select(array_contains("a", 1)),
+      Seq(Row(true), Row(false))
+    )
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -355,14 +355,14 @@ class DataFrameFunctionsSuite extends QueryTest {
       df.select(array_contains("a", 1)),
       Seq(Row(true), Row(false), Row(false))
     )
-    //checkAnswer(
-    //  df.select(array_contains("a", null)),
-    //  Seq(Row(false), Row(false), Row(false))
-    //)
     checkAnswer(
       df.selectExpr("array_contains(a, 1)"),
       Seq(Row(true), Row(false), Row(false))
     )
+    //checkAnswer(
+    //  df.select(array_contains("a", null)),
+    //  Seq(Row(false), Row(false), Row(false))
+    //)
     //checkAnswer(
     //  df.selectExpr("array_contains(null, 1)"),
     //  Seq(Row(false), Row(false), Row(false))

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -375,5 +375,9 @@ class DataFrameFunctionsSuite extends QueryTest {
       df.select(array_contains(array(lit(2), lit(null)), 1)),
       Seq(Row(false), Row(false), Row(false))
     )
+    checkAnswer(
+      df.select(array_contains(array(lit(2), lit(null)), null)),
+      Seq(Row(false), Row(false), Row(false))
+    )
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -359,17 +359,13 @@ class DataFrameFunctionsSuite extends QueryTest {
       df.selectExpr("array_contains(a, 1)"),
       Seq(Row(true), Row(false), Row(false))
     )
-    //checkAnswer(
-    //  df.select(array_contains("a", null)),
-    //  Seq(Row(false), Row(false), Row(false))
-    //)
-    //checkAnswer(
-    //  df.selectExpr("array_contains(null, 1)"),
-    //  Seq(Row(false), Row(false), Row(false))
-    //)
-    //checkAnswer(
-    //  df.selectExpr("array_contains(a, null)"),
-    //  Seq(Row(false), Row(false))
-    //)
+    // checkAnswer(
+    //   df.select(array_contains("a", null)),
+    //   Seq(Row(false), Row(false), Row(false))
+    // )
+    // checkAnswer(
+    //   df.selectExpr("array_contains(a, null)"),
+    //   Seq(Row(false), Row(false))
+    // )
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -354,5 +354,21 @@ class DataFrameFunctionsSuite extends QueryTest {
       df.select(array_contains("a", 1)),
       Seq(Row(true), Row(false))
     )
+    checkAnswer(
+      df.select(array_contains("a", null)),
+      Seq(Row(false), Row(false))
+    )
+    checkAnswer(
+      df.selectExpr("array_contains(a, 1)"),
+      Seq(Row(true), Row(false))
+    )
+    checkAnswer(
+      df.selectExpr("array_contains(null, 1)"),
+      Seq(Row(false), Row(false))
+    )
+    checkAnswer(
+      df.selectExpr("array_contains(a, null)"),
+      Seq(Row(false), Row(false))
+    )
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -352,20 +352,24 @@ class DataFrameFunctionsSuite extends QueryTest {
       (null, "z")
     ).toDF("a", "b")
     checkAnswer(
-      df.select(array_contains("a", 1)),
+      df.select(array_contains(df("a"), 1)),
       Seq(Row(true), Row(false), Row(false))
     )
     checkAnswer(
       df.selectExpr("array_contains(a, 1)"),
       Seq(Row(true), Row(false), Row(false))
     )
-    // checkAnswer(
-    //   df.select(array_contains("a", null)),
-    //   Seq(Row(false), Row(false), Row(false))
-    // )
-    // checkAnswer(
-    //   df.selectExpr("array_contains(a, null)"),
-    //   Seq(Row(false), Row(false))
-    // )
+    checkAnswer(
+      df.select(array_contains(df("a"), null)),
+      Seq(Row(false), Row(false), Row(false))
+    )
+    checkAnswer(
+      df.selectExpr("array_contains(a, null)"),
+      Seq(Row(false), Row(false), Row(false))
+    )
+    checkAnswer(
+      df.select(array_contains(lit(null), 1)),
+      Seq(Row(false), Row(false), Row(false))
+    )
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -348,23 +348,24 @@ class DataFrameFunctionsSuite extends QueryTest {
   test("array contains function") {
     val df = Seq(
       (Array[Int](1, 2), "x"),
-      (Array[Int](), "y")
+      (Array[Int](), "y"),
+      (null, "z")
     ).toDF("a", "b")
     checkAnswer(
       df.select(array_contains("a", 1)),
-      Seq(Row(true), Row(false))
+      Seq(Row(true), Row(false), Row(false))
     )
     checkAnswer(
       df.select(array_contains("a", null)),
-      Seq(Row(false), Row(false))
+      Seq(Row(false), Row(false), Row(false))
     )
     checkAnswer(
       df.selectExpr("array_contains(a, 1)"),
-      Seq(Row(true), Row(false))
+      Seq(Row(true), Row(false), Row(false))
     )
     checkAnswer(
       df.selectExpr("array_contains(null, 1)"),
-      Seq(Row(false), Row(false))
+      Seq(Row(false), Row(false), Row(false))
     )
     checkAnswer(
       df.selectExpr("array_contains(a, null)"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -348,8 +348,8 @@ class DataFrameFunctionsSuite extends QueryTest {
   test("array contains function") {
     val df = Seq(
       (Seq[Int](1, 2), "x"),
-      (Seq[Int](), "y"),
-      (null, "z")
+      (Seq[Int](), "x"),
+      (null, "x")
     ).toDF("a", "b")
     checkAnswer(
       df.select(array_contains(df("a"), 1)),
@@ -369,6 +369,10 @@ class DataFrameFunctionsSuite extends QueryTest {
     )
     checkAnswer(
       df.select(array_contains(lit(null), 1)),
+      Seq(Row(false), Row(false), Row(false))
+    )
+    checkAnswer(
+      df.select(array_contains(array(lit(2), lit(null)), 1)),
       Seq(Row(false), Row(false), Row(false))
     )
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -348,36 +348,43 @@ class DataFrameFunctionsSuite extends QueryTest {
   test("array contains function") {
     val df = Seq(
       (Seq[Int](1, 2), "x"),
-      (Seq[Int](), "x"),
-      (null, "x")
+      (Seq[Int](), "x")
     ).toDF("a", "b")
+
+    // Simple test cases
     checkAnswer(
       df.select(array_contains(df("a"), 1)),
-      Seq(Row(true), Row(false), Row(false))
+      Seq(Row(true), Row(false))
     )
     checkAnswer(
       df.selectExpr("array_contains(a, 1)"),
-      Seq(Row(true), Row(false), Row(false))
-    )
-    checkAnswer(
-      df.select(array_contains(df("a"), null)),
-      Seq(Row(false), Row(false), Row(false))
-    )
-    checkAnswer(
-      df.selectExpr("array_contains(a, null)"),
-      Seq(Row(false), Row(false), Row(false))
-    )
-    checkAnswer(
-      df.select(array_contains(lit(null), 1)),
-      Seq(Row(false), Row(false), Row(false))
+      Seq(Row(true), Row(false))
     )
     checkAnswer(
       df.select(array_contains(array(lit(2), lit(null)), 1)),
-      Seq(Row(false), Row(false), Row(false))
+      Seq(Row(false), Row(false))
+    )
+
+    // In hive, this errors because null has no type information
+    intercept[AnalysisException] {
+      df.select(array_contains(df("a"), null))
+    }
+    intercept[AnalysisException] {
+      df.selectExpr("array_contains(a, null)")
+    }
+    intercept[AnalysisException] {
+      df.selectExpr("array_contains(null, 1)")
+    }
+
+    // In hive, if either argument has a matching type has a null value, return false, even if
+    // the first argument array contains a null and the second argument is null
+    checkAnswer(
+      df.selectExpr("array_contains(array(array(1), null)[1], 1)"),
+      Seq(Row(false), Row(false))
     )
     checkAnswer(
-      df.select(array_contains(array(lit(2), lit(null)), null)),
-      Seq(Row(false), Row(false), Row(false))
+      df.selectExpr("array_contains(array(0, null), array(1, null)[1])"),
+      Seq(Row(false), Row(false))
     )
   }
 }


### PR DESCRIPTION
PR for work on https://issues.apache.org/jira/browse/SPARK-8231

Currently, I have an initial implementation for contains. Based on discussion on JIRA, it should behave same as Hive: https://github.com/apache/hive/blob/master/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFArrayContains.java#L102-L128

Main points are:
1. If the array is empty, null, or the value is null, return false
2. If there is a type mismatch, throw error
3. If comparison is not supported, throw error

Thus far, I have 1 implemented, however the codegen is failing. A nudge in the right direction would be helpful. I am also uncertain if I should be directly outputting the code or using a helper function. I am directly outputting the code because my understanding is if the return value should not be null if any of the arguments are null, then it needs to be custom.

I have an idea of how to do 2 based on other code I have seen, and google probably knows how to find out 3.

Additionally, still need to:
1. Add docs
2. Add python API
