### PR TITLE
[SPARK-8105] [SQL] sqlContext.table("databaseName.tableName") broke with SPARK-6908

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -347,6 +347,15 @@ private[hive] class HiveMetastoreCatalog(val client: ClientInterface, hive: Hive
     client.listTables(db).map(tableName => (tableName, false))
   }
 
+  override def processTableIdentifier(tableIdentifier: Seq[String]): Seq[String] = {
+    // If tblName contains a comma, split it into dbName and tblName
+    if (tableIdentifier.last.contains(".")) {
+      super.processTableIdentifier(tableIdentifier.last.split("\\.").toSeq)
+    } else {
+      super.processTableIdentifier(tableIdentifier)
+    }
+  }
+
   protected def processDatabaseAndTableName(
       databaseName: Option[String],
       tableName: String): (Option[String], String) = {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -805,6 +805,10 @@ class HiveQuerySuite extends HiveComparisonTest with BeforeAndAfter {
     assert(Try(q0.count()).isSuccess)
   }
 
+  test("HiveContext.table(dbname.tblname)") {
+    assert(Try(table("default.src")).isSuccess)
+  }
+
   test("DESCRIBE commands") {
     sql(s"CREATE TABLE test_describe_commands1 (key INT, value STRING) PARTITIONED BY (dt STRING)")
 


### PR DESCRIPTION
I am overriding `processTableIdentifier(tableIdentifier)` in `HiveMetastoreCatalog` to handle `dbName.tblName`. I assume this is Hive-specific, so I made it work with HiveMetastoreCatalog only.

Please let me know if this is not a good approach.
