### PR TITLE
[SPARK-9295] Analysis should detect sorting on unsupported column types

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -98,6 +98,10 @@ trait CheckAnalysis {
 
             aggregateExprs.foreach(checkValidAggregateExpression)
 
+          case Sort(order, _, _) if !order.forall(_.dataType.isInstanceOf[AtomicType]) =>
+            val c = order.filterNot(_.dataType.isInstanceOf[AtomicType]).head
+            failAnalysis(s"Sorting is not supported for columns of type ${c.dataType.simpleString}")
+
           case _ => // Fallbacks to the following checks
         }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -98,9 +98,14 @@ trait CheckAnalysis {
 
             aggregateExprs.foreach(checkValidAggregateExpression)
 
-          case Sort(order, _, _) if !order.forall(_.dataType.isInstanceOf[AtomicType]) =>
-            val c = order.filterNot(_.dataType.isInstanceOf[AtomicType]).head
-            failAnalysis(s"Sorting is not supported for columns of type ${c.dataType.simpleString}")
+          case Sort(orders, _, _) =>
+            def checkValidSortOrder(order: SortOrder): Unit = order.dataType match {
+              case t: AtomicType => // OK
+              case NullType => // OK
+              case t =>
+                failAnalysis(s"Sorting is not supported for columns of type ${t.simpleString}")
+            }
+            orders.foreach(checkValidSortOrder)
 
           case _ => // Fallbacks to the following checks
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -99,13 +99,14 @@ trait CheckAnalysis {
             aggregateExprs.foreach(checkValidAggregateExpression)
 
           case Sort(orders, _, _) =>
-            def checkValidSortOrder(order: SortOrder): Unit = order.dataType match {
-              case t: AtomicType => // OK
-              case NullType => // OK
-              case t =>
-                failAnalysis(s"Sorting is not supported for columns of type ${t.simpleString}")
+            orders.foreach { order =>
+              order.dataType match {
+                case t: AtomicType => // OK
+                case NullType => // OK
+                case t =>
+                  failAnalysis(s"Sorting is not supported for columns of type ${t.simpleString}")
+              }
             }
-            orders.foreach(checkValidSortOrder)
 
           case _ => // Fallbacks to the following checks
         }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -114,6 +114,11 @@ class AnalysisErrorSuite extends SparkFunSuite with BeforeAndAfter {
     "cannot cast" :: Literal(1).dataType.simpleString :: BinaryType.simpleString :: Nil)
 
   errorTest(
+    "sorting by unsupported column types",
+    listRelation.orderBy('list.asc),
+    "sorting" :: "type" :: "array<int>" :: Nil)
+
+  errorTest(
     "non-boolean filters",
     testRelation.where(Literal(1)),
     "filter" :: "'1'" :: "not a boolean" :: Literal(1).dataType.simpleString :: Nil)


### PR DESCRIPTION
This patch extends CheckAnalysis to throw errors for queries that try to sort on unsupported column types, such as ArrayType.
