### PR TITLE
[SPARK-9303] Decimal should use java.math.Decimal directly instead of using Scala wrapper

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -192,7 +192,7 @@ case class Cast(child: Expression, dataType: DataType)
   }
 
   private[this] def decimalToTimestamp(d: Decimal): Long = {
-    (d.toBigDecimal * 1000000L).longValue()
+    d.toJavaBigDecimal.multiply(java.math.BigDecimal.valueOf(1000000L)).longValue()
   }
   private[this] def doubleToTimestamp(d: Double): Any = {
     if (d.isNaN || d.isInfinite) null else (d * 1000000L).toLong


### PR DESCRIPTION
Spark SQL's `Decimal` class should use Java's BigDecimal instead of Scala's, since this removes a layer of object allocation and works around an issue where Scala's BigDecimal.hashCode() can lead to OOMs (see https://issues.scala-lang.org/browse/SI-6173).
