### PR TITLE
[SPARK-9328] [WIP] [BRANCH-1.2] Add read timeouts to Netty IO layer

### DIFF
--- a/core/src/test/scala/org/apache/spark/network/netty/NettyBlockTransferTimeoutSuite.scala
+++ b/core/src/test/scala/org/apache/spark/network/netty/NettyBlockTransferTimeoutSuite.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.netty
+
+import scala.concurrent.duration._
+
+import io.netty.handler.timeout.ReadTimeoutException
+import org.mockito.Mockito._
+import org.mockito.Matchers.any
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
+import org.scalatest.FunSuite
+
+import org.apache.spark.{SparkConf, SecurityManager}
+import org.apache.spark.network.BlockDataManager
+import org.apache.spark.network.buffer.ManagedBuffer
+import org.apache.spark.storage.ShuffleBlockId
+import org.scalatest.concurrent.Timeouts
+
+class NettyBlockTransferTimeoutSuite extends FunSuite with Timeouts {
+  test("read timeout") {
+    val conf = new SparkConf()
+      .set("spark.app.id", "appId")
+      .set("spark.shuffle.io.readTimeout", "5")
+    val securityManager = new SecurityManager(conf)
+    val bts = new NettyBlockTransferService(conf, securityManager, numCores = 1)
+    val blockDataManager = mock(classOf[BlockDataManager], RETURNS_SMART_NULLS)
+    when(blockDataManager.getBlockData(any())).thenAnswer(new Answer[ManagedBuffer] {
+      override def answer(invocation: InvocationOnMock): ManagedBuffer = {
+        Thread.sleep(30 * 10000)
+        null
+      }
+    })
+    bts.init(blockDataManager)
+
+
+    failAfter(30.seconds) {
+      intercept[ReadTimeoutException] {
+        bts.fetchBlockSync(bts.hostName, bts.port, "execId", ShuffleBlockId(0, 0, 0).toString)
+      }
+    }
+  }
+}

--- a/network/common/src/main/java/org/apache/spark/network/TransportContext.java
+++ b/network/common/src/main/java/org/apache/spark/network/TransportContext.java
@@ -22,6 +22,7 @@ import java.util.List;
 import com.google.common.collect.Lists;
 import io.netty.channel.Channel;
 import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.timeout.ReadTimeoutHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -104,6 +105,7 @@ public class TransportContext {
     try {
       TransportChannelHandler channelHandler = createChannelHandler(channel);
       channel.pipeline()
+        .addLast("readTimeoutHandler", new ReadTimeoutHandler(conf.readTimeoutSeconds()))
         .addLast("encoder", encoder)
         .addLast("frameDecoder", NettyUtils.createFrameDecoder())
         .addLast("decoder", decoder)

--- a/network/common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/network/common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -40,6 +40,11 @@ public class TransportConf {
     return conf.getInt("spark.shuffle.io.connectionTimeout", 120) * 1000;
   }
 
+  /** Read timeout in milliseconds. Default 120 secs. */
+  public int readTimeoutSeconds() {
+    return conf.getInt("spark.shuffle.io.readTimeout", 120);
+  }
+
   /** Number of concurrent connections between two nodes for fetching data. */
   public int numConnectionsPerPeer() {
     return conf.getInt("spark.shuffle.io.numConnectionsPerPeer", 1);


### PR DESCRIPTION
Spark's Netty-based network layer does not implement read timeouts which may lead to stalls during shuffle: if a remote shuffle server stalls while responding to a shuffle block fetch request but does not close the socket then the job may block until an OS-level socket timeout occurs.

I think that we can fix this using Netty's ReadTimeoutHandler (http://stackoverflow.com/questions/13390363/netty-connecttimeoutmillis-vs-readtimeouthandler). The tricky part of working on this will be figuring out the right place to add the handler and ensuring that we don't introduce performance issues by not re-using sockets.

Quoting from that linked StackOverflow question:

> Note that the ReadTimeoutHandler is also unaware of whether you have sent a request - it only cares whether data has been read from the socket. If your connection is persistent, and you only want read timeouts to fire when a request has been sent, you'll need to build a request / response aware timeout handler.

If we want to avoid tearing down connections between shuffles then we may have to do something like this.

This WIP pull request exists to discuss approaches to implementing this type of timeout.  I have opened it against `branch-1.2` because I'm trying to target a backport patch for a 1.2.x system. Once I've fixed this for branch-1.2 I will forward-port an updated version of this patch to newer releases.
