### PR TITLE
[SPARK-9362][PySpark] Use org.apache.spark.sql.types.Decimal in JVM side for python decimal

### DIFF
--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -914,6 +914,17 @@ class SQLTests(ReusedPySparkTestCase):
         self.assertRaisesRegexp(IllegalArgumentException, "1024 is not in the permitted values",
                                 lambda: df.select(sha2(df.a, 1024)).collect())
 
+    def test_dataframe_group_with_decimal(self):
+        from decimal import Decimal
+        data = [('a', Decimal('1.1')), ('b', Decimal('2.3')), ('a', Decimal('3.4'))]
+        rdd = self.sc.parallelize(data)
+        df = self.sqlCtx.createDataFrame(rdd, ['key', 'value'])
+        df_local = df.map(lambda x: x.value).collect()
+        self.assertEquals(df_local, [Decimal('1.1'), Decimal('2.3'), Decimal('3.4')])
+        df_grouped = df.groupBy("key").sum("value").map(lambda x: x[1]).collect()
+        expected = [Decimal('4.5'), Decimal('2.3')]
+        self.assertEquals(df_grouped, expected)
+
 
 class HiveContextSQLTests(ReusedPySparkTestCase):
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1251,6 +1251,15 @@ class DatetimeConverter(object):
         return Timestamp(int(time.mktime(obj.timetuple())) * 1000 + obj.microsecond // 1000)
 
 
+class DecimalConverter(object):
+    def can_convert(self, obj):
+        return isinstance(obj, decimal.Decimal)
+
+    def convert(self, obj, gateway_client):
+        Decimal = JavaClass("org.apache.spark.sql.types.Decimal", gateway_client)
+        return Decimal(obj.to_eng_string())
+
+
 # datetime is a subclass of date, we should register DatetimeConverter first
 register_input_converter(DatetimeConverter())
 register_input_converter(DateConverter())


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-9362

Instead of `java.math.BigDecimal`, we should use `org.apache.spark.sql.types.Decimal` in JVM side for python decimal object.
