### PR TITLE
[SPARK-9376][SQL] use a seed in RandomDataGeneratorSuite

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGeneratorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGeneratorSuite.scala
@@ -32,7 +32,7 @@ class RandomDataGeneratorSuite extends SparkFunSuite {
    */
   def testRandomDataGeneration(dataType: DataType, nullable: Boolean = true): Unit = {
     val toCatalyst = CatalystTypeConverters.createToCatalystConverter(dataType)
-    val generator = RandomDataGenerator.forType(dataType, nullable).getOrElse {
+    val generator = RandomDataGenerator.forType(dataType, nullable, Some(33)).getOrElse {
       fail(s"Random data generator was not defined for $dataType")
     }
     if (nullable) {


### PR DESCRIPTION
Make this test deterministic, i.e. make sure this test can be passed no matter how many times we run it.

The origin implementation uses a random seed and gives a chance that we may break the null check assertion `assert(Iterator.fill(100)(generator()).contains(null))`.
