### PR TITLE
[SPARK-9378][SQL][HotFix] Remove improper and failed test that checks schema stored by Hive

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -406,14 +406,6 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils {
         |   FROM src
         |   ORDER BY key, value""".stripMargin).collect()
 
-    checkExistence(sql("DESC EXTENDED ctas5"), true,
-      "name:key", "type:string", "name:value", "ctas5",
-      "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat",
-      "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat",
-      "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe",
-      "MANAGED_TABLE"
-    )
-
     // use the Hive SerDe for parquet tables
     withSQLConf(HiveContext.CONVERT_METASTORE_PARQUET.key -> "false") {
       checkAnswer(


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-9378

As old `ParquetRelation` is completely removed from codebase and `ParquetRelation2` becomes `ParquetRelation`, one test in `org.apache.spark.sql.hive.execution.SQLQuerySuite` that checks schema stored by Hive will fail as observed in #7520's recent test report. We should remove the test now.
