### PR TITLE
[SPARK-9149][ML][Examples] Add an example of spark.ml KMeans

### DIFF
--- a/examples/src/main/java/org/apache/spark/examples/ml/JavaKMeansExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/ml/JavaKMeansExample.java
@@ -75,8 +75,7 @@ public class JavaKMeansExample {
 
     // Loads data
     JavaRDD<Row> points = jsc.textFile(inputFile).map(new ParsePoint());
-    StructField[] fields = new StructField[1];
-    fields[0] = new StructField("features", new VectorUDT(), false, Metadata.empty());
+    StructField[] fields = {new StructField("features", new VectorUDT(), false, Metadata.empty())};
     StructType schema = new StructType(fields);
     DataFrame dataset = sqlContext.createDataFrame(points, schema);
 

--- a/examples/src/main/java/org/apache/spark/examples/ml/JavaKMeansExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/ml/JavaKMeansExample.java
@@ -56,8 +56,7 @@ public class JavaKMeansExample {
         point[i] = Double.parseDouble(tok[i]);
       }
       Vector[] points = {Vectors.dense(point)};
-      Row row = new GenericRow(points);
-      return row;
+      return new GenericRow(points);
     }
   }
 

--- a/examples/src/main/java/org/apache/spark/examples/ml/JavaKMeansExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/ml/JavaKMeansExample.java
@@ -46,11 +46,11 @@ import org.apache.spark.sql.types.StructType;
 public class JavaKMeansExample {
 
   private static class ParsePoint implements Function<String, Row> {
-    private static Pattern separater = Pattern.compile(" ");
+    final private static Pattern separator = Pattern.compile(" ");
 
     @Override
     public Row call(String line) {
-      String[] tok = separater.split(line);
+      String[] tok = separator.split(line);
       double[] point = new double[tok.length];
       for (int i = 0; i < tok.length; ++i) {
         point[i] = Double.parseDouble(tok[i]);

--- a/examples/src/main/java/org/apache/spark/examples/ml/JavaKMeansExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/ml/JavaKMeansExample.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.examples.ml;
+
+import java.util.regex.Pattern;
+
+import org.apache.commons.cli.*;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.ml.clustering.KMeansModel;
+import org.apache.spark.mllib.clustering.KMeans;
+import org.apache.spark.mllib.linalg.Vector;
+import org.apache.spark.mllib.linalg.VectorUDT;
+import org.apache.spark.mllib.linalg.Vectors;
+import org.apache.spark.sql.DataFrame;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.catalyst.expressions.GenericRow;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+
+/**
+ * An example demonstrating a k-means clustering.
+ * Run with
+ * {{{
+ * bin/run-example ml.JavaSimpleParamsExample [options] -k <int> -input <file>
+ * }}}
+ */
+public class JavaKMeansExample {
+
+  private static class Params {
+    String input;
+    Integer k = 2;
+    Integer maxIter = 20;
+    Integer runs = 1;
+    Double epsilon = 1E-4;
+    Long seed = 1L;
+    String initMode = KMeans.K_MEANS_PARALLEL();
+    Integer initSteps = 5;
+  }
+
+  private static class ParsePoint implements Function<String, Row> {
+    Pattern separater = Pattern.compile(" ");
+
+    @Override
+    public Row call(String line) {
+      String[] tok = this.separater.split(line);
+      double[] point = new double[tok.length];
+      for (int i = 0; i < tok.length; ++i) {
+        point[i] = Double.parseDouble(tok[i]);
+      }
+      Vector[] points = {Vectors.dense(point)};
+      Row row = new GenericRow(points);
+      return row;
+    }
+  }
+
+  public static void main(String[] args) {
+    // parse the arguments
+    Params params = parse(args);
+    SparkConf conf = new SparkConf().setAppName("JavaKMeansExample");
+    JavaSparkContext jsc = new JavaSparkContext(conf);
+
+    DataFrame dataset = loadData(jsc, params.input);
+
+    org.apache.spark.ml.clustering.KMeans kmeans = new org.apache.spark.ml.clustering.KMeans()
+      .setK(params.k)
+      .setMaxIter(params.maxIter)
+      .setRuns(params.runs)
+      .setEpsilon(params.epsilon)
+      .setSeed(params.seed)
+      .setInitMode(params.initMode)
+      .setInitSteps(params.initSteps);
+    KMeansModel model = kmeans.fit(dataset);
+
+    Vector[] centers = model.clusterCenters();
+    System.out.println("Cluster Centers: ");
+    for (Vector center: centers) {
+      System.out.println(center);
+    }
+
+    jsc.stop();
+  }
+
+  private static DataFrame loadData(JavaSparkContext jsc, String input) {
+    SQLContext sqlContext = new SQLContext(jsc);
+
+    JavaRDD<Row> points = jsc.textFile(input).map(new ParsePoint());
+    StructField[] fields = new StructField[1];
+    fields[0] = new StructField("features", new VectorUDT(), false, Metadata.empty());
+    StructType schema = new StructType(fields);
+    DataFrame dataset = sqlContext.createDataFrame(points, schema);
+    return dataset;
+  }
+
+  private static Params parse(String[] args) {
+    Options options = generateCommandlineOptions();
+    CommandLineParser parser = new PosixParser();
+    Params params = new Params();
+
+    try {
+      CommandLine cmd = parser.parse(options, args);
+      if (cmd.hasOption("input")) {
+        params.input = cmd.getOptionValue("input");
+      }
+      if (cmd.hasOption("k")) {
+        String value = cmd.getOptionValue("k");
+        params.k = Integer.parseInt(value);
+      }
+      if (cmd.hasOption("maxIter")) {
+        String value = cmd.getOptionValue("maxIter");
+        params.maxIter = Integer.parseInt(value);
+      }
+      if (cmd.hasOption("runs")) {
+        String value = cmd.getOptionValue("runs");
+        params.runs = Integer.parseInt(value);
+      }
+      if (cmd.hasOption("epsilon")) {
+        String value = cmd.getOptionValue("epsilon");
+        params.epsilon = Double.parseDouble(value);
+      }
+      if (cmd.hasOption("seed")) {
+        String value = cmd.getOptionValue("seed");
+        params.seed = Long.parseLong(value);
+      }
+      if (cmd.hasOption("initMode")) {
+        params.initMode = cmd.getOptionValue("initMode");
+      }
+      if (cmd.hasOption("initSteps")) {
+        String value = cmd.getOptionValue("initSteps");
+        params.initSteps = Integer.parseInt(value);
+      }
+    } catch (ParseException e) {
+      printHelpAndQuit(options);
+    }
+    return params;
+  }
+
+  @SuppressWarnings("static-access")
+  private static Options generateCommandlineOptions() {
+    Option input = OptionBuilder.withArgName("input")
+      .hasArg()
+      .isRequired()
+      .withDescription("input path to labeled examples. This path must be specified")
+      .create("input");
+    Option k = OptionBuilder.withArgName("k")
+      .hasArg()
+      .isRequired()
+      .withDescription("number of clusters created (>= 2). Default: ${defaults.k}")
+      .create("k");
+    Option maxIter = OptionBuilder.withArgName("maxIter")
+      .hasArg()
+      .withDescription("maximum number of iterations for Logistic Regression. default:100")
+      .create("maxIter");
+    Option runs = OptionBuilder.withArgName("runs")
+      .hasArg()
+      .withDescription("number of runs of the algorithm to execute in parallel, default: 1")
+      .create("runs");
+    Option epsilon = OptionBuilder.withArgName("epsilon")
+      .hasArg()
+      .withDescription("distance threshold within which we've consider centers to have converge" +
+        ", default: 1E-4")
+      .create("epsilon");
+    Option seed = OptionBuilder.withArgName("seed")
+      .hasArg()
+      .withDescription("random seed, default: 1")
+      .create("seed");
+    Option initMode = OptionBuilder.withArgName("initMode")
+      .hasArg()
+      .withDescription("initialization algorithm (" + KMeans.RANDOM() + " or " +
+        KMeans.K_MEANS_PARALLEL() + "default: " + KMeans.K_MEANS_PARALLEL())
+      .create("initMode");
+    Option initSteps = OptionBuilder.withArgName("initSteps")
+      .hasArg()
+      .withDescription("number of steps for k-means||, default: 5")
+      .create("initSteps");
+
+    Options options = new Options()
+      .addOption(input)
+      .addOption(k)
+      .addOption(maxIter)
+      .addOption(runs)
+      .addOption(epsilon)
+      .addOption(seed)
+      .addOption(initMode)
+      .addOption(initSteps);
+    return options;
+  }
+
+  private static void printHelpAndQuit(Options options) {
+    HelpFormatter formatter = new HelpFormatter();
+    formatter.printHelp("JavaKMeansExample", options);
+    System.exit(-1);
+  }
+}

--- a/examples/src/main/java/org/apache/spark/examples/ml/JavaKMeansExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/ml/JavaKMeansExample.java
@@ -42,9 +42,9 @@ import org.apache.spark.sql.types.StructType;
 /**
  * An example demonstrating a k-means clustering.
  * Run with
- * {{{
+ * <pre>
  * bin/run-example ml.JavaSimpleParamsExample [options] -k <int> -input <file>
- * }}}
+ * </pre>
  */
 public class JavaKMeansExample {
 

--- a/examples/src/main/java/org/apache/spark/examples/ml/JavaKMeansExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/ml/JavaKMeansExample.java
@@ -24,6 +24,7 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.Function;
 import org.apache.spark.ml.clustering.KMeansModel;
+import org.apache.spark.ml.clustering.KMeans;
 import org.apache.spark.mllib.linalg.Vector;
 import org.apache.spark.mllib.linalg.VectorUDT;
 import org.apache.spark.mllib.linalg.Vectors;
@@ -80,7 +81,7 @@ public class JavaKMeansExample {
     DataFrame dataset = sqlContext.createDataFrame(points, schema);
 
     // Trains a k-means model
-    org.apache.spark.ml.clustering.KMeans kmeans = new org.apache.spark.ml.clustering.KMeans()
+    KMeans kmeans = new KMeans()
       .setK(k);
     KMeansModel model = kmeans.fit(dataset);
 

--- a/examples/src/main/python/ml/kmeans_example.py
+++ b/examples/src/main/python/ml/kmeans_example.py
@@ -1,0 +1,71 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import print_function
+
+import sys
+import re
+
+import numpy as np
+from pyspark import SparkContext
+from pyspark.ml.clustering import KMeans, KMeansModel
+from pyspark.mllib.linalg import VectorUDT, _convert_to_vector
+from pyspark.sql import SQLContext
+from pyspark.sql.types import Row, StructField, StructType
+
+"""
+A simple example demonstrating a k-means clustering.
+Run with:
+  bin/spark-submit examples/src/main/python/ml/kmeans_example.py <input> <k>
+
+This example requires NumPy (http://www.numpy.org/).
+"""
+
+
+def parseVector(line):
+    array = np.array([float(x) for x in line.split(' ')])
+    return _convert_to_vector(array)
+
+
+if __name__ == "__main__":
+
+    FEATURES_COL = "features"
+
+    if len(sys.argv) != 3:
+        print("Usage: kmeans_example.py <file> <k>", file=sys.stderr)
+        exit(-1)
+    path = sys.argv[1]
+    k = sys.argv[2]
+
+    sc = SparkContext(appName="PythonKMeansExample")
+    sqlContext = SQLContext(sc)
+
+    lines = sc.textFile(path)
+    data = lines.map(parseVector)
+    row_rdd = data.map(lambda x: Row(x))
+    schema = StructType([StructField(FEATURES_COL, VectorUDT(), False)])
+    df = sqlContext.createDataFrame(row_rdd, schema)
+
+    kmeans = KMeans().setK(2).setSeed(1).setFeaturesCol(FEATURES_COL)
+    model = kmeans.fit(df)
+    centers = model.clusterCenters()
+
+    print("Cluster Centers: ")
+    for center in centers:
+        print(center)
+
+    sc.stop()

--- a/examples/src/main/scala/org/apache/spark/examples/ml/KMeansExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/KMeansExample.scala
@@ -17,65 +17,54 @@
 
 package org.apache.spark.examples.ml
 
-import scopt.OptionParser
-
 import org.apache.spark.{SparkContext, SparkConf}
-import org.apache.spark.mllib.clustering.{KMeans => MLlibKMeans}
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.ml.clustering.KMeans
-import org.apache.spark.sql.{Row, SQLContext, DataFrame}
+import org.apache.spark.sql.{Row, SQLContext}
 import org.apache.spark.sql.types.{StructField, StructType}
-import org.apache.spark.examples.mllib.AbstractParams
 
 
 /**
  * An example demonstrating a k-means clustering.
  * Run with
  * {{{
- * bin/run-example ml.KMeansExample [options] <file>
+ * bin/run-example ml.KMeansExample <file> <k>
  * }}}
  */
 object KMeansExample {
 
   final val FEATURES_COL = "features"
 
-  case class Params(
-      input: String = null,
-      k: Int = 2,
-      maxIter: Int = 20,
-      runs: Int = 1,
-      epsilon: Double = 1e-4,
-      seed: Long = 1,
-      initMode: String = MLlibKMeans.K_MEANS_PARALLEL,
-      initSteps: Int = 5) extends AbstractParams[Params]
-
   def main(args: Array[String]): Unit = {
-    val parsedParams = parseArgs(args)
-    parsedParams.map { params =>
-      run(params)
-    }.getOrElse {
+    if (args.length != 2) {
+      // scalastyle:off println
+      System.err.println("Usage: ml.KMeansExample <file> <k>")
+      // scalastyle:of println
       System.exit(1)
     }
-  }
+    val input = args(0)
+    val k = args(1).toInt
 
-  private def run(params: Params): Unit = {
-    val conf = new SparkConf()
-      .setAppName(s"${this.getClass.getSimpleName} with $params")
+    // Creates a Spark context and a SQL context
+    val conf = new SparkConf().setAppName(s"${this.getClass.getSimpleName}")
     val sc = new SparkContext(conf)
+    val sqlContext = new SQLContext(sc)
+    import org.apache.spark.mllib.linalg.VectorUDT
 
-    val dataset = loadData(sc, params.input)
+    // Loads data
+    val rowRDD = sc.textFile(input).filter(l => l != "")
+      .map(_.split(" ").map(v => java.lang.Double.parseDouble(v)))
+      .map(v => Vectors.dense(v)).map(Row(_))
+    val schema = StructType(Array(StructField(FEATURES_COL, new VectorUDT, false)))
+    val dataset = sqlContext.createDataFrame(rowRDD, schema)
 
+    // Trains a k-means model
     val kmeans = new KMeans()
-      .setK(params.k)
-      .setMaxIter(params.maxIter)
-      .setRuns(params.runs)
-      .setEpsilon(params.epsilon)
-      .setSeed(params.seed)
-      .setInitMode(params.initMode)
-      .setInitSteps(params.initSteps)
+      .setK(k)
       .setFeaturesCol(FEATURES_COL)
     val model = kmeans.fit(dataset)
 
+    // Shows the result
     // scalastyle:off println
     println("Final Centers: ")
     model.clusterCenters.foreach(println)
@@ -83,52 +72,4 @@ object KMeansExample {
 
     sc.stop()
   }
-
-  private def parseArgs(args: Array[String]): Option[Params] = {
-    val defaults = Params()
-    val parser = new OptionParser[Params]("KMeansExample") {
-      head("KMeansExample: an example KMeans.")
-      opt[Int](s"k")
-        .text("number of clusters created (>= 2). Default: ${defaults.k}")
-        .action((x, c) => c.copy(k = x))
-      opt[Int]("maxIter")
-        .text(s"maximum number of iterations (>= 0), default: ${defaults.maxIter}")
-        .action((x, c) => c.copy(maxIter = x))
-      opt[Int]("runs")
-        .text(s"number of runs of the algorithm to execute in parallel, default: ${defaults.runs}")
-        .action((x, c) => c.copy(maxIter = x))
-      opt[Double]("epsilon")
-        .text(s"distance threshold within which we've consider centers to have converge, " +
-          s"default: ${defaults.epsilon}")
-        .action((x, c) => c.copy(epsilon = x))
-      opt[Long]("seed")
-        .text(s"random seed, default: ${defaults.seed}")
-        .action((x, c) => c.copy(seed = x))
-      opt[String]("initMode")
-        .text(s"initialization algorithm " +
-          s"(${MLlibKMeans.RANDOM} or ${MLlibKMeans.K_MEANS_PARALLEL}}), " +
-          s"default: ${defaults.initMode}")
-        .action((x, c) => c.copy(initMode = x))
-      opt[String]("initSteps")
-        .text(s"number of steps for k-means||, default: ${defaults.initSteps}")
-        .action((x, c) => c.copy(initMode = x))
-      arg[String]("<input>")
-        .text("input path to labeled examples")
-        .required()
-        .action((x, c) => c.copy(input = x))
-    }
-    parser.parse(args, defaults)
-  }
-
-  private def loadData(sc: SparkContext, input: String): DataFrame = {
-    val sqlContext = new SQLContext(sc)
-    import org.apache.spark.mllib.linalg.VectorUDT
-
-    val rowRDD = sc.textFile(input).filter(l => l != "")
-      .map(_.split(" ").map(v => java.lang.Double.parseDouble(v)))
-      .map(v => Vectors.dense(v)).map(Row(_))
-    val schema = StructType(Array(StructField(FEATURES_COL, new VectorUDT, false)))
-    sqlContext.createDataFrame(rowRDD, schema)
-  }
-
 }

--- a/examples/src/main/scala/org/apache/spark/examples/ml/KMeansExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/KMeansExample.scala
@@ -39,7 +39,7 @@ object KMeansExample {
     if (args.length != 2) {
       // scalastyle:off println
       System.err.println("Usage: ml.KMeansExample <file> <k>")
-      // scalastyle:of println
+      // scalastyle:on println
       System.exit(1)
     }
     val input = args(0)

--- a/examples/src/main/scala/org/apache/spark/examples/ml/KMeansExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/KMeansExample.scala
@@ -52,9 +52,8 @@ object KMeansExample {
     import org.apache.spark.mllib.linalg.VectorUDT
 
     // Loads data
-    val rowRDD = sc.textFile(input).filter(l => l != "")
-      .map(_.split(" ").map(v => java.lang.Double.parseDouble(v)))
-      .map(v => Vectors.dense(v)).map(Row(_))
+    val rowRDD = sc.textFile(input).filter(_.nonEmpty)
+      .map(_.split(" ").map(_.toDouble)).map(Vectors.dense).map(Row(_))
     val schema = StructType(Array(StructField(FEATURES_COL, new VectorUDT, false)))
     val dataset = sqlContext.createDataFrame(rowRDD, schema)
 

--- a/examples/src/main/scala/org/apache/spark/examples/ml/KMeansExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/KMeansExample.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.examples.ml
 
 import org.apache.spark.{SparkContext, SparkConf}
-import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.mllib.linalg.{VectorUDT, Vectors}
 import org.apache.spark.ml.clustering.KMeans
 import org.apache.spark.sql.{Row, SQLContext}
 import org.apache.spark.sql.types.{StructField, StructType}
@@ -49,7 +49,6 @@ object KMeansExample {
     val conf = new SparkConf().setAppName(s"${this.getClass.getSimpleName}")
     val sc = new SparkContext(conf)
     val sqlContext = new SQLContext(sc)
-    import org.apache.spark.mllib.linalg.VectorUDT
 
     // Loads data
     val rowRDD = sc.textFile(input).filter(_.nonEmpty)

--- a/examples/src/main/scala/org/apache/spark/examples/ml/KMeansExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/KMeansExample.scala
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.examples.ml
+
+import scopt.OptionParser
+
+import org.apache.spark.{SparkContext, SparkConf}
+import org.apache.spark.mllib.clustering.{KMeans => MLlibKMeans}
+import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.ml.clustering.KMeans
+import org.apache.spark.sql.{Row, SQLContext, DataFrame}
+import org.apache.spark.sql.types.{StructField, StructType}
+import org.apache.spark.examples.mllib.AbstractParams
+
+
+/**
+ * An example demonstrating a k-means clustering.
+ * Run with
+ * {{{
+ * bin/run-example ml.KMeansExample [options] <file>
+ * }}}
+ */
+object KMeansExample {
+
+  final val FEATURES_COL = "features"
+
+  case class Params(
+      input: String = null,
+      k: Int = 2,
+      maxIter: Int = 20,
+      runs: Int = 1,
+      epsilon: Double = 1e-4,
+      seed: Long = 1,
+      initMode: String = MLlibKMeans.K_MEANS_PARALLEL,
+      initSteps: Int = 5) extends AbstractParams[Params]
+
+  def main(args: Array[String]): Unit = {
+    val parsedParams = parseArgs(args)
+    parsedParams.map { params =>
+      run(params)
+    }.getOrElse {
+      System.exit(1)
+    }
+  }
+
+  private def run(params: Params): Unit = {
+    val conf = new SparkConf()
+      .setAppName(s"${this.getClass.getSimpleName} with $params")
+    val sc = new SparkContext(conf)
+
+    val dataset = loadData(sc, params.input)
+
+    val kmeans = new KMeans()
+      .setK(params.k)
+      .setMaxIter(params.maxIter)
+      .setRuns(params.runs)
+      .setEpsilon(params.epsilon)
+      .setSeed(params.seed)
+      .setInitMode(params.initMode)
+      .setInitSteps(params.initSteps)
+      .setFeaturesCol(FEATURES_COL)
+    val model = kmeans.fit(dataset)
+
+    // scalastyle:off println
+    println("Final Centers: ")
+    model.clusterCenters.foreach(println)
+    // scalastyle:on println
+
+    sc.stop()
+  }
+
+  private def parseArgs(args: Array[String]): Option[Params] = {
+    val defaults = Params()
+    val parser = new OptionParser[Params]("KMeansExample") {
+      head("KMeansExample: an example KMeans.")
+      opt[Int](s"k")
+        .text("number of clusters created (>= 2). Default: ${defaults.k}")
+        .action((x, c) => c.copy(k = x))
+      opt[Int]("maxIter")
+        .text(s"maximum number of iterations (>= 0), default: ${defaults.maxIter}")
+        .action((x, c) => c.copy(maxIter = x))
+      opt[Int]("runs")
+        .text(s"number of runs of the algorithm to execute in parallel, default: ${defaults.runs}")
+        .action((x, c) => c.copy(maxIter = x))
+      opt[Double]("epsilon")
+        .text(s"distance threshold within which we've consider centers to have converge, " +
+          s"default: ${defaults.epsilon}")
+        .action((x, c) => c.copy(epsilon = x))
+      opt[Long]("seed")
+        .text(s"random seed, default: ${defaults.seed}")
+        .action((x, c) => c.copy(seed = x))
+      opt[String]("initMode")
+        .text(s"initialization algorithm " +
+          s"(${MLlibKMeans.RANDOM} or ${MLlibKMeans.K_MEANS_PARALLEL}}), " +
+          s"default: ${defaults.initMode}")
+        .action((x, c) => c.copy(initMode = x))
+      opt[String]("initSteps")
+        .text(s"number of steps for k-means||, default: ${defaults.initSteps}")
+        .action((x, c) => c.copy(initMode = x))
+      arg[String]("<input>")
+        .text("input path to labeled examples")
+        .required()
+        .action((x, c) => c.copy(input = x))
+    }
+    parser.parse(args, defaults)
+  }
+
+  private def loadData(sc: SparkContext, input: String): DataFrame = {
+    val sqlContext = new SQLContext(sc)
+    import org.apache.spark.mllib.linalg.VectorUDT
+
+    val rowRDD = sc.textFile(input).filter(l => l != "")
+      .map(_.split(" ").map(v => java.lang.Double.parseDouble(v)))
+      .map(v => Vectors.dense(v)).map(Row(_))
+    val schema = StructType(Array(StructField(FEATURES_COL, new VectorUDT, false)))
+    sqlContext.createDataFrame(rowRDD, schema)
+  }
+
+}


### PR DESCRIPTION
[SPARK-9149] Add an example of spark.ml KMeans - ASF JIRA https://issues.apache.org/jira/browse/SPARK-9149

@jkbradley Should we support other data formats, such as TSV or CSV. I have implemented these examples which support only space separated file which is same as the example for `spark.mllib`'s `KMeans`.
