### PR TITLE
[SPARK-9375] Make sure the total number of executor(s) requested by the driver is not negative

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -420,6 +420,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
     unknownExecutors.foreach { id =>
       logWarning(s"Executor to kill $id does not exist!")
     }
+    executorsPendingToRemove --= knownExecutors
 
     // If we do not wish to replace the executors we kill, sync the target number of executors
     // with the cluster manager to avoid allocating new ones. When computing the new target,


### PR DESCRIPTION
In the code:
  if (!replace) {
      doRequestTotalExecutors(numExistingExecutors + numPendingExecutors
        - executorsPendingToRemove.size - knownExecutors.size)
    }

The value of “(numExistingExecutors + numPendingExecutors  - executorsPendingToRemove.size - knownExecutors.size)” maybe negative if there is the same executorId in knownExecutors and executorsPendingToRemove.  And  knownExecutors and executorsPendingToRemove should not have the same executorId.
