### PR TITLE
[SPARK-9408] [PySpark] [MLlib] Refactor linalg.py to /linalg

### DIFF
--- a/python/pyspark/mllib/linalg/__init__.py
+++ b/python/pyspark/mllib/linalg/__init__.py
@@ -23,4 +23,4 @@ from pyspark.mllib.linalg.local import *
 
 __all__ = ['Vector', 'DenseVector', 'SparseVector', 'Vectors',
            'Matrix', 'DenseMatrix', 'SparseMatrix', 'Matrices',
-           '_convert_to_vector']
+           '_convert_to_vector', 'VectorUDT', 'MatrixUDT']

--- a/python/pyspark/mllib/linalg/__init__.py
+++ b/python/pyspark/mllib/linalg/__init__.py
@@ -20,3 +20,7 @@ Python package for local and distributed linear algebra in mllib.
 """
 
 from pyspark.mllib.linalg.local import *
+
+__all__ = ['Vector', 'DenseVector', 'SparseVector', 'Vectors',
+           'Matrix', 'DenseMatrix', 'SparseMatrix', 'Matrices',
+           '_convert_to_vector']

--- a/python/pyspark/mllib/linalg/__init__.py
+++ b/python/pyspark/mllib/linalg/__init__.py
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Python package for local and distributed linear algebra in mllib.
+"""
+
+from pyspark.mllib.linalg.local import *

--- a/python/pyspark/mllib/linalg/local.py
+++ b/python/pyspark/mllib/linalg/local.py
@@ -42,7 +42,8 @@ from pyspark.sql.types import UserDefinedType, StructField, StructType, ArrayTyp
 
 
 __all__ = ['Vector', 'DenseVector', 'SparseVector', 'Vectors',
-           'Matrix', 'DenseMatrix', 'SparseMatrix', 'Matrices']
+           'Matrix', 'DenseMatrix', 'SparseMatrix', 'Matrices',
+           '_convert_to_vector']
 
 
 if sys.version_info[:2] == (2, 7):

--- a/python/pyspark/mllib/linalg/local.py
+++ b/python/pyspark/mllib/linalg/local.py
@@ -43,7 +43,7 @@ from pyspark.sql.types import UserDefinedType, StructField, StructType, ArrayTyp
 
 __all__ = ['Vector', 'DenseVector', 'SparseVector', 'Vectors',
            'Matrix', 'DenseMatrix', 'SparseMatrix', 'Matrices',
-           '_convert_to_vector']
+           '_convert_to_vector', 'VectorUDT', 'MatrixUDT']
 
 
 if sys.version_info[:2] == (2, 7):


### PR DESCRIPTION
I refactored linalg.py to a folder /linalg so that future updates like `distributed.py` can be made easily.
