### PR TITLE
[SPARK-9409] [build] make-distribution.sh now copies any files in the conf directory.

### DIFF
--- a/make-distribution.sh
+++ b/make-distribution.sh
@@ -209,7 +209,7 @@ cp -r "$SPARK_HOME/data" "$DISTDIR"
 
 # Copy other things
 mkdir "$DISTDIR"/conf
-cp "$SPARK_HOME"/conf/*.template "$DISTDIR"/conf
+cp "$SPARK_HOME"/conf/* "$DISTDIR"/conf
 cp "$SPARK_HOME/README.md" "$DISTDIR"
 cp -r "$SPARK_HOME/bin" "$DISTDIR"
 cp -r "$SPARK_HOME/python" "$DISTDIR"


### PR DESCRIPTION
make-distribution.sh modified to copy all files in `conf` to the target archive, not just the `*.template` files. This makes it convenient to build an archive with custom property and configuration files. The change has no affect on the build unless a user explicit adds new files to the directory.
