### PR TITLE
[SPARK-9056] [Streaming] Rename configuration `spark.streaming.minRememberDuration` to `spark.streaming.fileStream.minRememberDuration`

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -529,7 +529,7 @@ private[spark] object SparkConf extends Logging {
     "spark.rpc.lookupTimeout" -> Seq(
       AlternateConfig("spark.akka.lookupTimeout", "1.4")),
     "spark.streaming.fileStream.minRememberDuration" -> Seq(
-      AlternateConfig("spark.streaming.minRememberDuration", "1.4"))
+      AlternateConfig("spark.streaming.minRememberDuration", "1.5"))
     )
 
   /**

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -527,7 +527,9 @@ private[spark] object SparkConf extends Logging {
     "spark.rpc.askTimeout" -> Seq(
       AlternateConfig("spark.akka.askTimeout", "1.4")),
     "spark.rpc.lookupTimeout" -> Seq(
-      AlternateConfig("spark.akka.lookupTimeout", "1.4"))
+      AlternateConfig("spark.akka.lookupTimeout", "1.4")),
+    "spark.streaming.fileStream.minRememberDuration" -> Seq(
+      AlternateConfig("spark.streaming.minRememberDuration", "1.4"))
     )
 
   /**

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
@@ -87,9 +87,8 @@ class FileInputDStream[K, V, F <: NewInputFormat[K, V]](
    * files are visible within this window, then the file will get selected in the next batch.
    */
   private val minRememberDurationS =
-    Seconds(
-          ssc.conf.getTimeAsSeconds("spark.streaming.fileStream.minRememberDuration",
-           ssc.conf.get("spark.streaming.minRememberDuration", "60s")))
+    Seconds(ssc.conf.getTimeAsSeconds("spark.streaming.fileStream.minRememberDuration",
+    ssc.conf.get("spark.streaming.minRememberDuration", "60s")))
 
   // This is a def so that it works during checkpoint recovery:
   private def clock = ssc.scheduler.clock

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
@@ -87,7 +87,9 @@ class FileInputDStream[K, V, F <: NewInputFormat[K, V]](
    * files are visible within this window, then the file will get selected in the next batch.
    */
   private val minRememberDurationS =
-    Seconds(ssc.conf.getTimeAsSeconds("spark.streaming.minRememberDuration", "60s"))
+    Seconds(
+          ssc.conf.getTimeAsSeconds("spark.streaming.fileStream.minRememberDuration",
+           ssc.conf.get("spark.streaming.minRememberDuration", "60s")))
 
   // This is a def so that it works during checkpoint recovery:
   private def clock = ssc.scheduler.clock

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
@@ -86,9 +86,10 @@ class FileInputDStream[K, V, F <: NewInputFormat[K, V]](
    * Files with mod times older than this "window" of remembering will be ignored. So if new
    * files are visible within this window, then the file will get selected in the next batch.
    */
-  private val minRememberDurationS =
+  private val minRememberDurationS = {
     Seconds(ssc.conf.getTimeAsSeconds("spark.streaming.fileStream.minRememberDuration",
-    ssc.conf.get("spark.streaming.minRememberDuration", "60s")))
+      ssc.conf.get("spark.streaming.minRememberDuration", "60s")))
+  }
 
   // This is a def so that it works during checkpoint recovery:
   private def clock = ssc.scheduler.clock


### PR DESCRIPTION
Rename configuration `spark.streaming.minRememberDuration` to `spark.streaming.fileStream.minRememberDuration`
