### PR TITLE
SPARK-9446 Clear Active SparkContext in stop() method

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1714,8 +1714,8 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
     if (_dagScheduler != null) {
       Utils.tryLogNonFatalError {
         _dagScheduler.stop()
-        _dagScheduler = null
       }
+      _dagScheduler = null
     }
     if (_listenerBusStarted) {
       Utils.tryLogNonFatalError {
@@ -1739,8 +1739,8 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
     if (_env != null) {
       Utils.tryLogNonFatalError {
         _env.stop()
-        SparkEnv.set(null)
       }
+      SparkEnv.set(null)
     }
     SparkContext.clearActiveContext()
     logInfo("Successfully stopped SparkContext")

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1685,44 +1685,65 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
       logInfo("SparkContext already stopped.")
       return
     }
-    try {
-      if (_shutdownHookRef != null) {
-        Utils.removeShutdownHook(_shutdownHookRef)
-      }
-  
+    if (_shutdownHookRef != null) {
+      Utils.removeShutdownHook(_shutdownHookRef)
+    }
+
+    Utils.tryLogNonFatalError {
       postApplicationEnd()
+    }
+    Utils.tryLogNonFatalError {
       _ui.foreach(_.stop())
-      if (env != null) {
+    }
+    if (env != null) {
+      Utils.tryLogNonFatalError {
         env.metricsSystem.report()
       }
-      if (metadataCleaner != null) {
+    }
+    if (metadataCleaner != null) {
+      Utils.tryLogNonFatalError {
         metadataCleaner.cancel()
       }
+    }
+    Utils.tryLogNonFatalError {
       _cleaner.foreach(_.stop())
+    }
+    Utils.tryLogNonFatalError {
       _executorAllocationManager.foreach(_.stop())
-      if (_dagScheduler != null) {
+    }
+    if (_dagScheduler != null) {
+      Utils.tryLogNonFatalError {
         _dagScheduler.stop()
         _dagScheduler = null
       }
-      if (_listenerBusStarted) {
+    }
+    if (_listenerBusStarted) {
+      Utils.tryLogNonFatalError {
         listenerBus.stop()
         _listenerBusStarted = false
       }
+    }
+    Utils.tryLogNonFatalError {
       _eventLogger.foreach(_.stop())
-      if (env != null && _heartbeatReceiver != null) {
+    }
+    if (env != null && _heartbeatReceiver != null) {
+      Utils.tryLogNonFatalError {
         env.rpcEnv.stop(_heartbeatReceiver)
       }
+    }
+    Utils.tryLogNonFatalError {
       _progressBar.foreach(_.stop())
-      _taskScheduler = null
-      // TODO: Cache.stop()?
-      if (_env != null) {
+    }
+    _taskScheduler = null
+    // TODO: Cache.stop()?
+    if (_env != null) {
+      Utils.tryLogNonFatalError {
         _env.stop()
         SparkEnv.set(null)
       }
-    } finally {
-      SparkContext.clearActiveContext()
-      logInfo("Successfully stopped SparkContext")
     }
+    SparkContext.clearActiveContext()
+    logInfo("Successfully stopped SparkContext")
   }
 
 


### PR DESCRIPTION
In thread 'stopped SparkContext remaining active' on mailing list, Andres observed the following in driver log:

```
15/07/29 15:17:09 WARN YarnSchedulerBackend$YarnSchedulerEndpoint: ApplicationMaster has disassociated: <address removed>
15/07/29 15:17:09 INFO YarnClientSchedulerBackend: Shutting down all executors
Exception in thread "Yarn application state monitor" org.apache.spark.SparkException: Error asking standalone scheduler to shut down executors
        at org.apache.spark.scheduler.cluster.CoarseGrainedSchedulerBackend.stopExecutors(CoarseGrainedSchedulerBackend.scala:261)
        at org.apache.spark.scheduler.cluster.CoarseGrainedSchedulerBackend.stop(CoarseGrainedSchedulerBackend.scala:266)
        at org.apache.spark.scheduler.cluster.YarnClientSchedulerBackend.stop(YarnClientSchedulerBackend.scala:158)
        at org.apache.spark.scheduler.TaskSchedulerImpl.stop(TaskSchedulerImpl.scala:416)
        at org.apache.spark.scheduler.DAGScheduler.stop(DAGScheduler.scala:1411)
        at org.apache.spark.SparkContext.stop(SparkContext.scala:1644)
        at org.apache.spark.scheduler.cluster.YarnClientSchedulerBackend$$anon$1.run(YarnClientSchedulerBackend.scala:139)
Caused by: java.lang.InterruptedException
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.tryAcquireSharedNanos(AbstractQueuedSynchronizer.java:1325)
        at scala.concurrent.impl.Promise$DefaultPromise.tryAwait(Promise.scala:208)
        at scala.concurrent.impl.Promise$DefaultPromise.ready(Promise.scala:218)
        at scala.concurrent.impl.Promise$DefaultPromise.result(Promise.scala:223)
        at scala.concurrent.Await$$anonfun$result$1.apply(package.scala:190)
        at scala.concurrent.BlockContext$DefaultBlockContext$.blockOn(BlockContext.scala:53)
        at scala.concurrent.Await$.result(package.scala:190)15/07/29 15:17:09 INFO YarnClientSchedulerBackend: Asking each executor to shut down

        at org.apache.spark.rpc.RpcEndpointRef.askWithRetry(RpcEndpointRef.scala:102)
        at org.apache.spark.rpc.RpcEndpointRef.askWithRetry(RpcEndpointRef.scala:78)
        at org.apache.spark.scheduler.cluster.CoarseGrainedSchedulerBackend.stopExecutors(CoarseGrainedSchedulerBackend.scala:257)
        ... 6 more
```

Effect of the above exception is that a stopped SparkContext is returned to user since SparkContext.clearActiveContext() is not called.
