### PR TITLE
[SPARK-9461] [mllib] [python] [streaming] disabled two flaky mllib streaming pyspark lin/log reg tests

### DIFF
--- a/python/pyspark/mllib/tests.py
+++ b/python/pyspark/mllib/tests.py
@@ -1160,7 +1160,7 @@ class StreamingLogisticRegressionWithSGDTests(MLLibStreamingTestCase):
         self.ssc.start()
         self._ssc_wait(t, 20.0, 0.01)
         rel = (1.5 - slr.latestModel().weights.array[0]) / 1.5
-        self.assertAlmostEqual(rel, 0.1, 1)
+        # self.assertAlmostEqual(rel, 0.1, 1)
 
     def test_convergence(self):
         """
@@ -1278,8 +1278,8 @@ class StreamingLinearRegressionWithTests(MLLibStreamingTestCase):
         slr.trainOn(input_stream)
         self.ssc.start()
         self._ssc_wait(t, 10, 0.01)
-        self.assertArrayAlmostEqual(
-            slr.latestModel().weights.array, [10., 10.], 1)
+        # self.assertArrayAlmostEqual(
+        #     slr.latestModel().weights.array, [10., 10.], 1)
         self.assertAlmostEqual(slr.latestModel().intercept, 0.0, 1)
 
     def test_parameter_convergence(self):


### PR DESCRIPTION
CC: @mengxr  @rxin 
