### PR TITLE
[SPARK-9231] [MLlib] DistributedLDAModel method for top topics per document

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAModel.scala
@@ -568,9 +568,12 @@ class DistributedLDAModel private[clustering] (
   def topTopicsPerDocument(k: Int): RDD[(Long, Array[Int], Array[Double])] = {
     graph.vertices.filter(LDA.isDocumentVertex).map { case (docID, topicCounts) =>
       val topIndices = argtopk(topicCounts, k)
-      var sumCounts = sum(topicCounts)
-      sumCounts = if (sumCounts != 0) sumCounts else 1D
-      val weights = topicCounts(topIndices) / sumCounts
+      val sumCounts = sum(topicCounts)
+      val weights = if (sumCounts != 0) {
+        topicCounts(topIndices) / sumCounts
+      } else {
+        topicCounts(topIndices)
+      }
       (docID.toLong, topIndices.toArray, weights.toArray)
     }
   }


### PR DESCRIPTION
jira: https://issues.apache.org/jira/browse/SPARK-9231

Helper method in DistributedLDAModel of this form:

```
/**
 * For each document, return the top k weighted topics for that document.
 * @return RDD of (doc ID, topic indices, topic weights)
 */
def topTopicsPerDocument(k: Int): RDD[(Long, Array[Int], Array[Double])]
```
