### PR TITLE
[SPARK-9277] [MLLIB] SparseVector constructor must throw an error when declared number of elements less than array length

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
@@ -637,6 +637,8 @@ class SparseVector(
   require(indices.length == values.length, "Sparse vectors require that the dimension of the" +
     s" indices match the dimension of the values. You provided ${indices.length} indices and " +
     s" ${values.length} values.")
+  require(indices.length <= size, s"You provided ${indices.length} indices and values, " +
+    s"which exceeds the specified vector size ${size}.")
 
   override def toString: String =
     s"($size,${indices.mkString("[", ",", "]")},${values.mkString("[", ",", "]")})"

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
@@ -57,6 +57,21 @@ class VectorsSuite extends SparkFunSuite with Logging {
     assert(vec.values === values)
   }
 
+  test("sparse vector construction with mismatched indices/values array") {
+    intercept[IllegalArgumentException] {
+      Vectors.sparse(4, Array(1,2,3), Array(3.0, 5.0, 7.0, 9.0))
+    }
+    intercept[IllegalArgumentException] {
+      Vectors.sparse(4, Array(1,2,3), Array(3.0, 5.0))
+    }
+  }
+
+  test("sparse vector construction with too many indices vs size") {
+    intercept[IllegalArgumentException] {
+      Vectors.sparse(3, Array(1,2,3,4), Array(3.0, 5.0, 7.0, 9.0))
+    }
+  }
+
   test("dense to array") {
     val vec = Vectors.dense(arr).asInstanceOf[DenseVector]
     assert(vec.toArray.eq(arr))

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/VectorsSuite.scala
@@ -59,16 +59,16 @@ class VectorsSuite extends SparkFunSuite with Logging {
 
   test("sparse vector construction with mismatched indices/values array") {
     intercept[IllegalArgumentException] {
-      Vectors.sparse(4, Array(1,2,3), Array(3.0, 5.0, 7.0, 9.0))
+      Vectors.sparse(4, Array(1, 2, 3), Array(3.0, 5.0, 7.0, 9.0))
     }
     intercept[IllegalArgumentException] {
-      Vectors.sparse(4, Array(1,2,3), Array(3.0, 5.0))
+      Vectors.sparse(4, Array(1, 2, 3), Array(3.0, 5.0))
     }
   }
 
   test("sparse vector construction with too many indices vs size") {
     intercept[IllegalArgumentException] {
-      Vectors.sparse(3, Array(1,2,3,4), Array(3.0, 5.0, 7.0, 9.0))
+      Vectors.sparse(3, Array(1, 2, 3, 4), Array(3.0, 5.0, 7.0, 9.0))
     }
   }
 


### PR DESCRIPTION
Check that SparseVector size is at least as big as the number of indices/values provided. And add tests for constructor checks.

CC @MechCoder @jkbradley -- I am not sure if a change needs to also happen in the Python API? I didn't see it had any similar checks to begin with, but I don't know it well.
