### PR TITLE
[SPARK-8416] highlight and topping the executor threads in thread dumping page

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/webui.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/webui.css
@@ -225,10 +225,10 @@ a.expandbutton {
   cursor: pointer;
 }
 
-.executor_thread {
+.executor-thread {
   background: #E6E6E6;
 }
 
-.non-executor_thread {
+.non-executor-thread {
   background: #FAFAFA;
 }

--- a/core/src/main/resources/org/apache/spark/ui/static/webui.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/webui.css
@@ -224,3 +224,11 @@ span.additional-metric-title {
 a.expandbutton {
   cursor: pointer;
 }
+
+.executor_thread {
+  background: #C7BCCD;
+}
+
+.non-executor_thread {
+  background: #F8EEF0;
+}

--- a/core/src/main/resources/org/apache/spark/ui/static/webui.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/webui.css
@@ -226,9 +226,9 @@ a.expandbutton {
 }
 
 .executor_thread {
-  background: #C7BCCD;
+  background: #E6E6E6;
 }
 
 .non-executor_thread {
-  background: #F8EEF0;
+  background: #FAFAFA;
 }

--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorThreadDumpPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorThreadDumpPage.scala
@@ -54,7 +54,7 @@ private[ui] class ExecutorThreadDumpPage(parent: ExecutorsTab) extends WebUIPage
           val v1 = if (threadTrace1.threadName.contains("Executor task launch")) 1 else 0
           val v2 = if (threadTrace2.threadName.contains("Executor task launch")) 1 else 0
           if (v1 == v2) {
-            threadTrace1.threadName < threadTrace2.threadName
+            threadTrace1.threadName.toLowerCase < threadTrace2.threadName.toLowerCase
           } else {
             v1 > v2
           }

--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorThreadDumpPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorThreadDumpPage.scala
@@ -54,7 +54,7 @@ private[ui] class ExecutorThreadDumpPage(parent: ExecutorsTab) extends WebUIPage
           val v1 = if (threadTrace1.threadName.contains("Executor task launch")) 1 else 0
           val v2 = if (threadTrace2.threadName.contains("Executor task launch")) 1 else 0
           if (v1 == v2) {
-            threadTrace1.threadName > threadTrace2.threadName
+            threadTrace1.threadName < threadTrace2.threadName
           } else {
             v1 > v2
           }
@@ -63,9 +63,9 @@ private[ui] class ExecutorThreadDumpPage(parent: ExecutorsTab) extends WebUIPage
         val threadName = thread.threadName
         val className = "accordion-toggle " + {
           if (threadName.contains("Executor task launch")) {
-            "executor_thread"
+            "executor-thread"
           } else {
-            "non-executor_thread"
+            "non-executor-thread"
           }
         }
         <div class="accordion-group">

--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorThreadDumpPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorThreadDumpPage.scala
@@ -49,7 +49,7 @@ private[ui] class ExecutorThreadDumpPage(parent: ExecutorsTab) extends WebUIPage
     val maybeThreadDump = sc.get.getExecutorThreadDump(executorId)
 
     val content = maybeThreadDump.map { threadDump =>
-      val dumpRows = threadDump.sortWith{
+      val dumpRows = threadDump.sortWith {
         case (threadTrace1, threadTrace2) => {
           val v1 = if (threadTrace1.threadName.contains("Executor task launch")) 1 else 0
           val v2 = if (threadTrace2.threadName.contains("Executor task launch")) 1 else 0
@@ -61,16 +61,15 @@ private[ui] class ExecutorThreadDumpPage(parent: ExecutorsTab) extends WebUIPage
         }
       }.map { thread =>
         val threadName = thread.threadName
-        val styleString = "background:" + {
+        val className = "accordion-toggle " + {
           if (threadName.contains("Executor task launch")) {
-            "#C7BCCD"
+            "executor_thread"
           } else {
-           "#F8EEF0"
+            "non-executor_thread"
           }
         }
         <div class="accordion-group">
-          <div class="accordion-heading" onclick="$(this).next().toggleClass('hidden')"
-               style={styleString}>
+          <div class={className} onclick="$(this).next().toggleClass('hidden')">
             <a class="accordion-toggle">
               Thread {thread.threadId}: {thread.threadName} ({thread.threadState})
             </a>

--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorThreadDumpPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorThreadDumpPage.scala
@@ -71,7 +71,7 @@ private[ui] class ExecutorThreadDumpPage(parent: ExecutorsTab) extends WebUIPage
         <div class="accordion-group">
           <div class={className} onclick="$(this).next().toggleClass('hidden')">
             <a class="accordion-toggle">
-              Thread {thread.threadId}: {thread.threadName} ({thread.threadState})
+              Thread {thread.threadId}: {threadName} ({thread.threadState})
             </a>
           </div>
           <div class="accordion-body hidden">

--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorThreadDumpPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorThreadDumpPage.scala
@@ -54,7 +54,7 @@ private[ui] class ExecutorThreadDumpPage(parent: ExecutorsTab) extends WebUIPage
           val v1 = if (threadTrace1.threadName.contains("Executor task launch")) 1 else 0
           val v2 = if (threadTrace2.threadName.contains("Executor task launch")) 1 else 0
           if (v1 == v2) {
-            threadTrace1.threadId > threadTrace2.threadId
+            threadTrace1.threadName > threadTrace2.threadName
           } else {
             v1 > v2
           }

--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorThreadDumpPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorThreadDumpPage.scala
@@ -61,7 +61,7 @@ private[ui] class ExecutorThreadDumpPage(parent: ExecutorsTab) extends WebUIPage
         }
       }.map { thread =>
         val threadName = thread.threadName
-        val className = "accordion-toggle " + {
+        val className = "accordion-heading " + {
           if (threadName.contains("Executor task launch")) {
             "executor-thread"
           } else {

--- a/core/src/main/scala/org/apache/spark/ui/exec/ExecutorThreadDumpPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/exec/ExecutorThreadDumpPage.scala
@@ -49,9 +49,28 @@ private[ui] class ExecutorThreadDumpPage(parent: ExecutorsTab) extends WebUIPage
     val maybeThreadDump = sc.get.getExecutorThreadDump(executorId)
 
     val content = maybeThreadDump.map { threadDump =>
-      val dumpRows = threadDump.map { thread =>
+      val dumpRows = threadDump.sortWith{
+        case (threadTrace1, threadTrace2) => {
+          val v1 = if (threadTrace1.threadName.contains("Executor task launch")) 1 else 0
+          val v2 = if (threadTrace2.threadName.contains("Executor task launch")) 1 else 0
+          if (v1 == v2) {
+            threadTrace1.threadId > threadTrace2.threadId
+          } else {
+            v1 > v2
+          }
+        }
+      }.map { thread =>
+        val threadName = thread.threadName
+        val styleString = "background:" + {
+          if (threadName.contains("Executor task launch")) {
+            "#C7BCCD"
+          } else {
+           "#F8EEF0"
+          }
+        }
         <div class="accordion-group">
-          <div class="accordion-heading" onclick="$(this).next().toggleClass('hidden')">
+          <div class="accordion-heading" onclick="$(this).next().toggleClass('hidden')"
+               style={styleString}>
             <a class="accordion-toggle">
               Thread {thread.threadId}: {thread.threadName} ({thread.threadState})
             </a>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-8416

To facilitate debugging, I made this patch with three changes:
- render the executor-thread and non executor-thread entries with different background colors
- put the executor threads on the top of the list
- sort the threads alphabetically 
