### PR TITLE
Allow spark port to be from 1 to 65535

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1975,8 +1975,8 @@ private[spark] object Utils extends Logging {
       conf: SparkConf,
       serviceName: String = ""): (T, Int) = {
 
-    require(startPort == 0 || (1024 <= startPort && startPort < 65536),
-      "startPort should be between 1024 and 65535 (inclusive), or 0 for a random free port.")
+    require(startPort == 0 || (1 <= startPort && startPort < 65536),
+      "startPort should be between 1 and 65535 (inclusive), or 0 for a random free port.")
 
     val serviceString = if (serviceName.isEmpty) "" else s" '$serviceName'"
     val maxRetries = portMaxRetries(conf)


### PR DESCRIPTION
To cope with firewall policies in various organizations, allow spark port from 1 to 65535, instead of limiting from 1024 to 65535.
