### PR TITLE
[ML] [Minor] Rename NaiveBayes to {NaiveBayes => OldNaiveBayes} in import

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/ml/classification/NaiveBayesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/NaiveBayesSuite.scala
@@ -21,7 +21,7 @@ import breeze.linalg.{Vector => BV}
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.param.ParamsSuite
-import org.apache.spark.mllib.classification.NaiveBayes
+import org.apache.spark.mllib.classification.{NaiveBayes => OldNaiveBayes}
 import org.apache.spark.mllib.linalg._
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
@@ -31,7 +31,7 @@ import org.apache.spark.sql.Row
 
 class NaiveBayesSuite extends SparkFunSuite with MLlibTestSparkContext {
 
-  import NaiveBayes.{Multinomial, Bernoulli}
+  import OldNaiveBayes.{Multinomial, Bernoulli}
 
   def validatePrediction(predictionAndLabels: DataFrame): Unit = {
     val numOfErrorPredictions = predictionAndLabels.collect().count {


### PR DESCRIPTION
Rename mllib..NaiveBayes to mllib..{NaiveBayes => OldNaiveBayes} in import of ml..NaiveBayesSuite, which shadows the NaiveBayes class defined under spark.ml.
