### PR TITLE
[SPARK-8839][SQL]High concurrence will also cause the `key not found` error in HiveThriftServer2

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
@@ -188,12 +188,18 @@ object HiveThriftServer2 extends Logging {
         statement: String,
         groupId: String,
         userName: String = "UNKNOWN"): Unit = {
+      while (!sessionList.contains(sessionId)) {
+        logWarning(s"sessionList don't contain the specific sessionId, wait one second " +
+          s"for the session complete adding into sessionList.")
+        Thread.sleep(1000)
+      }
       val info = new ExecutionInfo(statement, sessionId, System.currentTimeMillis, userName)
       info.state = ExecutionState.STARTED
+      info.groupId = groupId
+
       executionList.put(id, info)
       trimExecutionIfNecessary()
       sessionList(sessionId).totalExecution += 1
-      executionList(id).groupId = groupId
       totalRunning += 1
     }
 


### PR DESCRIPTION
This PR is related to [7239](https://github.com/apache/spark/pull/7239).
It's show in a high concurrence scenario.
When there are about 500 clients connecting to the server at the same time, the method `onStatementStart`  will be executed before `onSessionCreated` at about 10% probability.
So it's better to add a wait for the session to build up.
