### PR TITLE
[SPARK-9228][SQL] Combine codegen/unsafe feature flag into spark.sql.tungsten.enabled

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
@@ -225,8 +225,8 @@ private[spark] object SQLConf {
 
   val TUNGSTEN_ENABLED = booleanConf("spark.sql.tungsten.enabled",
     defaultValue = Some(true),
-    doc = "When true, use the optimized Tungsten physical execution backend which explicitly manages memory and " +
-          "dynamically generates bytecode for expression evaluation.")
+    doc = "When true, use the optimized Tungsten physical execution backend which explicitly " +
+          "manages memory and dynamically generates bytecode for expression evaluation.")
 
   val DIALECT = stringConf(
     "spark.sql.dialect",
@@ -468,7 +468,7 @@ private[sql] class SQLConf extends Serializable with CatalystConf {
   private[spark] def externalSortEnabled: Boolean = getConf(EXTERNAL_SORT)
 
   private[spark] def sortMergeJoinEnabled: Boolean = getConf(SORTMERGE_JOIN)
-  
+
   def caseSensitiveAnalysis: Boolean = getConf(SQLConf.CASE_SENSITIVE)
 
   private[spark] def tungstenEnabled: Boolean = getConf(TUNGSTEN_ENABLED)

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
@@ -223,14 +223,10 @@ private[spark] object SQLConf {
     defaultValue = Some(200),
     doc = "The default number of partitions to use when shuffling data for joins or aggregations.")
 
-  val CODEGEN_ENABLED = booleanConf("spark.sql.codegen",
+  val TUNGSTEN_ENABLED = booleanConf("spark.sql.tungsten.enabled",
     defaultValue = Some(true),
-    doc = "When true, code will be dynamically generated at runtime for expression evaluation in" +
-      " a specific query.")
-
-  val UNSAFE_ENABLED = booleanConf("spark.sql.unsafe.enabled",
-    defaultValue = Some(true),
-    doc = "When true, use the new optimized Tungsten physical execution backend.")
+    doc = "When true, use the optimized Tungsten physical execution backend which explicitly manages memory and " +
+          "dynamically generates bytecode for expression evaluation.")
 
   val DIALECT = stringConf(
     "spark.sql.dialect",
@@ -427,7 +423,6 @@ private[spark] object SQLConf {
  *
  * SQLConf is thread-safe (internally synchronized, so safe to be used in multiple threads).
  */
-
 private[sql] class SQLConf extends Serializable with CatalystConf {
   import SQLConf._
 
@@ -473,12 +468,10 @@ private[sql] class SQLConf extends Serializable with CatalystConf {
   private[spark] def externalSortEnabled: Boolean = getConf(EXTERNAL_SORT)
 
   private[spark] def sortMergeJoinEnabled: Boolean = getConf(SORTMERGE_JOIN)
-
-  private[spark] def codegenEnabled: Boolean = getConf(CODEGEN_ENABLED)
-
+  
   def caseSensitiveAnalysis: Boolean = getConf(SQLConf.CASE_SENSITIVE)
 
-  private[spark] def unsafeEnabled: Boolean = getConf(UNSAFE_ENABLED)
+  private[spark] def tungstenEnabled: Boolean = getConf(TUNGSTEN_ENABLED)
 
   private[spark] def useSqlAggregate2: Boolean = getConf(USE_SQL_AGGREGATE2)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -856,9 +856,7 @@ class SQLContext(@transient val sparkContext: SparkContext)
 
     val sqlContext: SQLContext = self
 
-    def codegenEnabled: Boolean = self.conf.codegenEnabled
-
-    def unsafeEnabled: Boolean = self.conf.unsafeEnabled
+    def tungstenEnabled: Boolean = self.conf.tungstenEnabled
 
     def numPartitions: Int = self.conf.numShufflePartitions
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -54,7 +54,7 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
   // sqlContext will be null when we are being deserialized on the slaves.  In this instance
   // the value of codegenEnabled will be set by the desserializer after the constructor has run.
   val codegenEnabled: Boolean = if (sqlContext != null) {
-    sqlContext.conf.codegenEnabled
+    sqlContext.conf.tungstenEnabled
   } else {
     false
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -207,7 +207,8 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
    */
   object Aggregation extends Strategy {
     def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
-      case p: logical.Aggregate if sqlContext.conf.useSqlAggregate2 && sqlContext.conf.tungstenEnabled =>
+      case p: logical.Aggregate if sqlContext.conf.useSqlAggregate2 &&
+                                   sqlContext.conf.tungstenEnabled =>
         val converted = p.newAggregation
         converted match {
           case None => Nil // Cannot convert to new aggregation code path.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -147,18 +147,16 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
              if canBeCodeGened(
                   allAggregates(partialComputation) ++
                   allAggregates(rewrittenAggregateExpressions)) &&
-               codegenEnabled &&
+               tungstenEnabled &&
                !canBeConvertedToNewAggregation(plan) =>
           execution.GeneratedAggregate(
             partial = false,
             namedGroupingAttributes,
             rewrittenAggregateExpressions,
-            unsafeEnabled,
             execution.GeneratedAggregate(
               partial = true,
               groupingExpressions,
               partialComputation,
-              unsafeEnabled,
               planLater(child))) :: Nil
 
       // Cases where some aggregate can not be codegened
@@ -183,7 +181,7 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
 
     def canBeConvertedToNewAggregation(plan: LogicalPlan): Boolean = plan match {
       case a: logical.Aggregate =>
-        if (sqlContext.conf.useSqlAggregate2 && sqlContext.conf.codegenEnabled) {
+        if (sqlContext.conf.useSqlAggregate2 && sqlContext.conf.tungstenEnabled) {
           a.newAggregation.isDefined
         } else {
           Utils.checkInvalidAggregateFunction2(a)
@@ -209,8 +207,7 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
    */
   object Aggregation extends Strategy {
     def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
-      case p: logical.Aggregate if sqlContext.conf.useSqlAggregate2 &&
-          sqlContext.conf.codegenEnabled =>
+      case p: logical.Aggregate if sqlContext.conf.useSqlAggregate2 && sqlContext.conf.tungstenEnabled =>
         val converted = p.newAggregation
         converted match {
           case None => Nil // Cannot convert to new aggregation code path.
@@ -328,8 +325,7 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
      *               if necessary.
      */
     def getSortOperator(sortExprs: Seq[SortOrder], global: Boolean, child: SparkPlan): SparkPlan = {
-      if (sqlContext.conf.unsafeEnabled && sqlContext.conf.codegenEnabled &&
-        TungstenSort.supportsSchema(child.schema)) {
+      if (sqlContext.conf.tungstenEnabled && TungstenSort.supportsSchema(child.schema)) {
         execution.TungstenSort(sortExprs, global, child)
       } else if (sqlContext.conf.externalSortEnabled) {
         execution.ExternalSort(sortExprs, global, child)
@@ -355,7 +351,7 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
       case logical.Project(projectList, child) =>
         // If unsafe mode is enabled and we support these data types in Unsafe, use the
         // Tungsten project. Otherwise, use the normal project.
-        if (sqlContext.conf.unsafeEnabled &&
+        if (sqlContext.conf.tungstenEnabled &&
           UnsafeProjection.canSupport(projectList) && UnsafeProjection.canSupport(child.schema)) {
           execution.TungstenProject(projectList, planLater(child)) :: Nil
         } else {
@@ -366,7 +362,7 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
       case e @ logical.Expand(_, _, _, child) =>
         execution.Expand(e.projections, e.output, planLater(child)) :: Nil
       case a @ logical.Aggregate(group, agg, child) => {
-        val useNewAggregation = sqlContext.conf.useSqlAggregate2 && sqlContext.conf.codegenEnabled
+        val useNewAggregation = sqlContext.conf.useSqlAggregate2 && sqlContext.conf.tungstenEnabled
         if (useNewAggregation && a.newAggregation.isDefined) {
           // If this logical.Aggregate can be planned to use new aggregation code path
           // (i.e. it can be planned by the Strategy Aggregation), we will not use the old

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/Aggregate.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/Aggregate.scala
@@ -65,7 +65,7 @@ case class Aggregate(
         UnsafeProjection.canSupport(groupKeySchema)
 
     // TODO: Use the hybrid iterator for non-algebric aggregate functions.
-    sqlContext.conf.unsafeEnabled && schemaSupportsUnsafe && !hasNonAlgebricAggregateFunctions
+    sqlContext.conf.tungstenEnabled && schemaSupportsUnsafe && !hasNonAlgebricAggregateFunctions
   }
 
   // We need to use sorted input if we have grouping expressions, and

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/commands.scala
@@ -227,7 +227,7 @@ private[sql] case class InsertIntoHadoopFsRelation(
 
     val output = df.queryExecution.executedPlan.output
     val (partitionOutput, dataOutput) = output.partition(a => partitionColumns.contains(a.name))
-    val codegenEnabled = df.sqlContext.conf.codegenEnabled
+    val codegenEnabled = df.sqlContext.conf.tungstenEnabled
 
     // This call shouldn't be put into the `try` block below because it only initializes and
     // prepares the job, any exception thrown from here shouldn't cause abortJob() to be called.

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -389,7 +389,7 @@ abstract class HadoopFsRelation private[sql](maybePartitionSpec: Option[Partitio
 
   private val hadoopConf = new Configuration(sqlContext.sparkContext.hadoopConfiguration)
 
-  private val codegenEnabled = sqlContext.conf.codegenEnabled
+  private val codegenEnabled = sqlContext.conf.tungstenEnabled
 
   private var _partitionSpec: PartitionSpec = _
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -608,7 +608,7 @@ class DataFrameSuite extends QueryTest with SQLTestUtils {
   }
 
   test("SPARK-6899: type should match when using codegen") {
-    withSQLConf(SQLConf.CODEGEN_ENABLED.key -> "true") {
+    withSQLConf(SQLConf.TUNGSTEN_ENABLED.key -> "true") {
       checkAnswer(
         decimalData.agg(avg('a)),
         Row(new java.math.BigDecimal(2.0)))
@@ -844,12 +844,12 @@ class DataFrameSuite extends QueryTest with SQLTestUtils {
 
   test("SPARK-8608: call `show` on local DataFrame with random columns should return same value") {
     // Make sure we can pass this test for both codegen mode and interpreted mode.
-    withSQLConf(SQLConf.CODEGEN_ENABLED.key -> "true") {
+    withSQLConf(SQLConf.TUNGSTEN_ENABLED.key -> "true") {
       val df = testData.select(rand(33))
       assert(df.showString(5) == df.showString(5))
     }
 
-    withSQLConf(SQLConf.CODEGEN_ENABLED.key -> "false") {
+    withSQLConf(SQLConf.TUNGSTEN_ENABLED.key -> "false") {
       val df = testData.select(rand(33))
       assert(df.showString(5) == df.showString(5))
     }
@@ -861,11 +861,11 @@ class DataFrameSuite extends QueryTest with SQLTestUtils {
 
   test("SPARK-8609: local DataFrame with random columns should return same value after sort") {
     // Make sure we can pass this test for both codegen mode and interpreted mode.
-    withSQLConf(SQLConf.CODEGEN_ENABLED.key -> "true") {
+    withSQLConf(SQLConf.TUNGSTEN_ENABLED.key -> "true") {
       checkAnswer(testData.sort(rand(33)), testData.sort(rand(33)))
     }
 
-    withSQLConf(SQLConf.CODEGEN_ENABLED.key -> "false") {
+    withSQLConf(SQLConf.TUNGSTEN_ENABLED.key -> "false") {
       checkAnswer(testData.sort(rand(33)), testData.sort(rand(33)))
     }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTungstenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTungstenSuite.scala
@@ -33,14 +33,14 @@ class DataFrameTungstenSuite extends QueryTest with SQLTestUtils {
   import sqlContext.implicits._
 
   test("test simple types") {
-    withSQLConf(SQLConf.UNSAFE_ENABLED.key -> "true") {
+    withSQLConf(SQLConf.TUNGSTEN_ENABLED.key -> "true") {
       val df = sqlContext.sparkContext.parallelize(Seq((1, 2))).toDF("a", "b")
       assert(df.select(struct("a", "b")).first().getStruct(0) === Row(1, 2))
     }
   }
 
   test("test struct type") {
-    withSQLConf(SQLConf.UNSAFE_ENABLED.key -> "true") {
+    withSQLConf(SQLConf.TUNGSTEN_ENABLED.key -> "true") {
       val struct = Row(1, 2L, 3.0F, 3.0)
       val data = sqlContext.sparkContext.parallelize(Seq(Row(1, struct)))
 
@@ -59,7 +59,7 @@ class DataFrameTungstenSuite extends QueryTest with SQLTestUtils {
   }
 
   test("test nested struct type") {
-    withSQLConf(SQLConf.UNSAFE_ENABLED.key -> "true") {
+    withSQLConf(SQLConf.TUNGSTEN_ENABLED.key -> "true") {
       val innerStruct = Row(1, "abcd")
       val outerStruct = Row(1, 2L, 3.0F, 3.0, innerStruct, "efg")
       val data = sqlContext.sparkContext.parallelize(Seq(Row(1, outerStruct)))

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -230,13 +230,13 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll with SQLTestUtils {
 
   test("SPARK-8828 sum should return null if all input values are null") {
     withSQLConf(SQLConf.USE_SQL_AGGREGATE2.key -> "true") {
-      withSQLConf(SQLConf.CODEGEN_ENABLED.key -> "true") {
+      withSQLConf(SQLConf.TUNGSTEN_ENABLED.key -> "true") {
         checkAnswer(
           sql("select sum(a), avg(a) from allNulls"),
           Seq(Row(null, null))
         )
       }
-      withSQLConf(SQLConf.CODEGEN_ENABLED.key -> "false") {
+      withSQLConf(SQLConf.TUNGSTEN_ENABLED.key -> "false") {
         checkAnswer(
           sql("select sum(a), avg(a) from allNulls"),
           Seq(Row(null, null))
@@ -244,13 +244,13 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll with SQLTestUtils {
       }
     }
     withSQLConf(SQLConf.USE_SQL_AGGREGATE2.key -> "false") {
-      withSQLConf(SQLConf.CODEGEN_ENABLED.key -> "true") {
+      withSQLConf(SQLConf.TUNGSTEN_ENABLED.key -> "true") {
         checkAnswer(
           sql("select sum(a), avg(a) from allNulls"),
           Seq(Row(null, null))
         )
       }
-      withSQLConf(SQLConf.CODEGEN_ENABLED.key -> "false") {
+      withSQLConf(SQLConf.TUNGSTEN_ENABLED.key -> "false") {
         checkAnswer(
           sql("select sum(a), avg(a) from allNulls"),
           Seq(Row(null, null))
@@ -277,8 +277,8 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll with SQLTestUtils {
   }
 
   test("aggregation with codegen") {
-    val originalValue = sqlContext.conf.codegenEnabled
-    sqlContext.setConf(SQLConf.CODEGEN_ENABLED, true)
+    val originalValue = sqlContext.conf.tungstenEnabled
+    sqlContext.setConf(SQLConf.TUNGSTEN_ENABLED, true)
     // Prepare a table that we can group some rows.
     sqlContext.table("testData")
       .unionAll(sqlContext.table("testData"))
@@ -356,7 +356,7 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll with SQLTestUtils {
         Row(null, null, 0) :: Nil)
     } finally {
       sqlContext.dropTempTable("testData3x")
-      sqlContext.setConf(SQLConf.CODEGEN_ENABLED, originalValue)
+      sqlContext.setConf(SQLConf.TUNGSTEN_ENABLED, originalValue)
     }
   }
 
@@ -592,14 +592,14 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll with SQLTestUtils {
 
   test("SPARK-6927 sorting with codegen on") {
     withSQLConf(SQLConf.EXTERNAL_SORT.key -> "false",
-      SQLConf.CODEGEN_ENABLED.key -> "true") {
+      SQLConf.TUNGSTEN_ENABLED.key -> "true") {
       sortTest()
     }
   }
 
   test("SPARK-6927 external sorting with codegen on") {
     withSQLConf(SQLConf.EXTERNAL_SORT.key -> "true",
-      SQLConf.CODEGEN_ENABLED.key -> "true") {
+      SQLConf.TUNGSTEN_ENABLED.key -> "true") {
       sortTest()
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -1605,7 +1605,7 @@ class SQLQuerySuite extends QueryTest with BeforeAndAfterAll with SQLTestUtils {
 
   test("aggregation with codegen updates peak execution memory") {
     withSQLConf(
-        (SQLConf.CODEGEN_ENABLED.key, "true"),
+        (SQLConf.TUNGSTEN_ENABLED.key, "true"),
         (SQLConf.USE_SQL_AGGREGATE2.key, "false")) {
       val sc = sqlContext.sparkContext
       AccumulatorSuite.verifyPeakExecutionMemorySet(sc, "aggregation with codegen") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/AggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/AggregateSuite.scala
@@ -25,10 +25,10 @@ class AggregateSuite extends SparkPlanTest {
 
   test("SPARK-8357 unsafe aggregation path should not leak memory with empty input") {
     val codegenDefault = TestSQLContext.getConf(SQLConf.CODEGEN_ENABLED)
-    val unsafeDefault = TestSQLContext.getConf(SQLConf.UNSAFE_ENABLED)
+    val unsafeDefault = TestSQLContext.getConf(SQLConf.TUNGSTEN_ENABLED)
     try {
       TestSQLContext.setConf(SQLConf.CODEGEN_ENABLED, true)
-      TestSQLContext.setConf(SQLConf.UNSAFE_ENABLED, true)
+      TestSQLContext.setConf(SQLConf.TUNGSTEN_ENABLED, true)
       val df = Seq.empty[(Int, Int)].toDF("a", "b")
       checkAnswer(
         df,
@@ -42,7 +42,7 @@ class AggregateSuite extends SparkPlanTest {
       )
     } finally {
       TestSQLContext.setConf(SQLConf.CODEGEN_ENABLED, codegenDefault)
-      TestSQLContext.setConf(SQLConf.UNSAFE_ENABLED, unsafeDefault)
+      TestSQLContext.setConf(SQLConf.TUNGSTEN_ENABLED, unsafeDefault)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/AggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/AggregateSuite.scala
@@ -24,10 +24,8 @@ import org.apache.spark.sql.test.TestSQLContext
 class AggregateSuite extends SparkPlanTest {
 
   test("SPARK-8357 unsafe aggregation path should not leak memory with empty input") {
-    val codegenDefault = TestSQLContext.getConf(SQLConf.CODEGEN_ENABLED)
     val unsafeDefault = TestSQLContext.getConf(SQLConf.TUNGSTEN_ENABLED)
     try {
-      TestSQLContext.setConf(SQLConf.CODEGEN_ENABLED, true)
       TestSQLContext.setConf(SQLConf.TUNGSTEN_ENABLED, true)
       val df = Seq.empty[(Int, Int)].toDF("a", "b")
       checkAnswer(
@@ -36,12 +34,10 @@ class AggregateSuite extends SparkPlanTest {
           partial = true,
           Seq(df.col("b").expr),
           Seq(Alias(Count(df.col("a").expr), "cnt")()),
-          unsafeEnabled = true,
           _: SparkPlan),
         Seq.empty
       )
     } finally {
-      TestSQLContext.setConf(SQLConf.CODEGEN_ENABLED, codegenDefault)
       TestSQLContext.setConf(SQLConf.TUNGSTEN_ENABLED, unsafeDefault)
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/TungstenSortSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/TungstenSortSuite.scala
@@ -33,11 +33,11 @@ import org.apache.spark.sql.types._
 class TungstenSortSuite extends SparkPlanTest with BeforeAndAfterAll {
 
   override def beforeAll(): Unit = {
-    TestSQLContext.conf.setConf(SQLConf.CODEGEN_ENABLED, true)
+    TestSQLContext.conf.setConf(SQLConf.TUNGSTEN_ENABLED, true)
   }
 
   override def afterAll(): Unit = {
-    TestSQLContext.conf.setConf(SQLConf.CODEGEN_ENABLED, SQLConf.CODEGEN_ENABLED.defaultValue.get)
+    TestSQLContext.conf.setConf(SQLConf.TUNGSTEN_ENABLED, SQLConf.TUNGSTEN_ENABLED.defaultValue.get)
   }
 
   test("sort followed by limit") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
@@ -512,13 +512,13 @@ class SortBasedAggregationQuerySuite extends AggregationQuerySuite {
 
   override def beforeAll(): Unit = {
     originalUnsafeEnabled = sqlContext.conf.unsafeEnabled
-    sqlContext.setConf(SQLConf.UNSAFE_ENABLED.key, "false")
+    sqlContext.setConf(SQLConf.TUNGSTEN_ENABLED.key, "false")
     super.beforeAll()
   }
 
   override def afterAll(): Unit = {
     super.afterAll()
-    sqlContext.setConf(SQLConf.UNSAFE_ENABLED.key, originalUnsafeEnabled.toString)
+    sqlContext.setConf(SQLConf.TUNGSTEN_ENABLED.key, originalUnsafeEnabled.toString)
   }
 }
 
@@ -528,12 +528,12 @@ class TungstenAggregationQuerySuite extends AggregationQuerySuite {
 
   override def beforeAll(): Unit = {
     originalUnsafeEnabled = sqlContext.conf.unsafeEnabled
-    sqlContext.setConf(SQLConf.UNSAFE_ENABLED.key, "true")
+    sqlContext.setConf(SQLConf.TUNGSTEN_ENABLED.key, "true")
     super.beforeAll()
   }
 
   override def afterAll(): Unit = {
     super.afterAll()
-    sqlContext.setConf(SQLConf.UNSAFE_ENABLED.key, originalUnsafeEnabled.toString)
+    sqlContext.setConf(SQLConf.TUNGSTEN_ENABLED.key, originalUnsafeEnabled.toString)
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
@@ -511,7 +511,7 @@ class SortBasedAggregationQuerySuite extends AggregationQuerySuite {
   var originalUnsafeEnabled: Boolean = _
 
   override def beforeAll(): Unit = {
-    originalUnsafeEnabled = sqlContext.conf.unsafeEnabled
+    originalUnsafeEnabled = sqlContext.conf.tungstenEnabled
     sqlContext.setConf(SQLConf.TUNGSTEN_ENABLED.key, "false")
     super.beforeAll()
   }
@@ -527,7 +527,7 @@ class TungstenAggregationQuerySuite extends AggregationQuerySuite {
   var originalUnsafeEnabled: Boolean = _
 
   override def beforeAll(): Unit = {
-    originalUnsafeEnabled = sqlContext.conf.unsafeEnabled
+    originalUnsafeEnabled = sqlContext.conf.tungstenEnabled
     sqlContext.setConf(SQLConf.TUNGSTEN_ENABLED.key, "true")
     super.beforeAll()
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -126,12 +126,12 @@ class HiveUDFSuite extends QueryTest {
           |           "value", value)).value FROM src
         """.stripMargin), Seq(Row("val_0")))
     }
-    val codegenDefault = TestHive.getConf(SQLConf.CODEGEN_ENABLED)
-    TestHive.setConf(SQLConf.CODEGEN_ENABLED, true)
+    val codegenDefault = TestHive.getConf(SQLConf.TUNGSTEN_ENABLED)
+    TestHive.setConf(SQLConf.TUNGSTEN_ENABLED, true)
     testOrderInStruct()
-    TestHive.setConf(SQLConf.CODEGEN_ENABLED, false)
+    TestHive.setConf(SQLConf.TUNGSTEN_ENABLED, false)
     testOrderInStruct()
-    TestHive.setConf(SQLConf.CODEGEN_ENABLED, codegenDefault)
+    TestHive.setConf(SQLConf.TUNGSTEN_ENABLED, codegenDefault)
   }
 
   test("SPARK-6409 UDAFAverage test") {


### PR DESCRIPTION
The goal here is twofold:
- reduce testing complexity by only allowing code-gen/with managed memory or interpreted evaluation with gc.
- rename the public facing config to something less scary than `unsafe`.
