### PR TITLE
[SPARK-9591][CORE]Job may  fail for exception during getting remote block

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockFetchException.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockFetchException.scala
@@ -17,5 +17,8 @@
 
 package org.apache.spark.storage
 
+import org.apache.spark.SparkException
+
 private[spark]
-case class BlockFetchException(throwable: Throwable) extends Exception(throwable)
+case class BlockFetchException(messages: String, throwable: Throwable)
+  extends SparkException(messages, throwable)

--- a/core/src/main/scala/org/apache/spark/storage/BlockFetchException.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockFetchException.scala
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.storage
+
+private[spark]
+case class BlockFetchException(throwable: Throwable) extends Exception(throwable)

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -606,7 +606,8 @@ private[spark] class BlockManager(
         case t: Throwable =>
           // Throw BlockFetchException wraps the last Exception when
           // there is no block we can fetch
-          throw new BlockFetchException(t)
+          throw new BlockFetchException(s"Failed to fetch block from" +
+            s" ${locations.size} locations. Most recent failure cause:", t)
       }
 
       if (data != null) {

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -449,12 +449,12 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
     store2 = makeBlockManager(8000)
     val list1 = List(new Array[Byte](4000))
     store2.putIterator("list1", list1.iterator, StorageLevel.MEMORY_ONLY, tellMaster = true)
-    val list1get = store.getRemote("list1")
-    assert(list1get.isDefined, "list1get expected to be fetched")
-    //simulate block manager crash
+    val list1Get = store.getRemote("list1")
+    assert(list1Get.isDefined, "list1get expected to be fetched")
+    // simulate block manager crashed
     store2.stop()
-    val list1getagain = store.getRemoteBytes("list1")
-    assert(!list1getagain.isDefined, "list1getagain expected to be not fetched")
+    val list1GetAgain = store.getRemoteBytes("list1")
+    assert(!list1GetAgain.isDefined, "list1getagain expected to be not fetched")
     conf.set("spark.network.timeout", "120s")
   }
 

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -443,6 +443,21 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
     assert(list2DiskGet.get.readMethod === DataReadMethod.Disk)
   }
 
+  test("block manager crash test") {
+    conf.set("spark.network.timeout", "5s")
+    store = makeBlockManager(8000)
+    store2 = makeBlockManager(8000)
+    val list1 = List(new Array[Byte](4000))
+    store2.putIterator("list1", list1.iterator, StorageLevel.MEMORY_ONLY, tellMaster = true)
+    val list1get = store.getRemote("list1")
+    assert(list1get.isDefined, "list1get expected to be fetched")
+    //simulate block manager crash
+    store2.stop()
+    val list1getagain = store.getRemoteBytes("list1")
+    assert(!list1getagain.isDefined, "list1getagain expected to be not fetched")
+    conf.set("spark.network.timeout", "120s")
+  }
+
   test("in-memory LRU storage") {
     store = makeBlockManager(12000)
     val a1 = new Array[Byte](4000)

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -451,23 +451,20 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
   test("(SPARK-9591)getRemoteBytes from another location when  IOException throw") {
     try {
       conf.set("spark.network.timeout", "2s")
-      store = makeBlockManager(8000, "excutor1")
-      store2 = makeBlockManager(8000, "excutor2")
+      store = makeBlockManager(8000, "executor1")
+      store2 = makeBlockManager(8000, "executor2")
       store3 = makeBlockManager(8000, "executor3")
       val list1 = List(new Array[Byte](4000))
       store2.putIterator("list1", list1.iterator, StorageLevel.MEMORY_ONLY, tellMaster = true)
       store3.putIterator("list1", list1.iterator, StorageLevel.MEMORY_ONLY, tellMaster = true)
-
       var list1Get = store.getRemoteBytes("list1")
       assert(list1Get.isDefined, "list1Get expected to be fetched")
       // block manager exit
       store2.stop()
       store2 = null
       list1Get = store.getRemoteBytes("list1")
-
       // get `list1` block
       assert(list1Get.isDefined, "list1Get expected to be fetched")
-
       store3.stop()
       store3 = null
       // exception throw because there is no locations

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -448,7 +448,7 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
     assert(list2DiskGet.get.readMethod === DataReadMethod.Disk)
   }
 
-  test("SPARK-9591:getRemoteBytes from another location when  IOException throw") {
+  test("SPARK-9591: getRemoteBytes from another location when Exception throw") {
     val origTimeoutOpt = conf.getOption("spark.network.timeout")
     try {
       conf.set("spark.network.timeout", "2s")

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -47,6 +47,7 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
   private val conf = new SparkConf(false)
   var store: BlockManager = null
   var store2: BlockManager = null
+  var store3: BlockManager = null
   var rpcEnv: RpcEnv = null
   var master: BlockManagerMaster = null
   conf.set("spark.authenticate", "false")
@@ -98,6 +99,10 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
     if (store2 != null) {
       store2.stop()
       store2 = null
+    }
+    if (store3 != null) {
+      store3.stop()
+      store3 = null
     }
     rpcEnv.shutdown()
     rpcEnv.awaitTermination()
@@ -443,19 +448,35 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
     assert(list2DiskGet.get.readMethod === DataReadMethod.Disk)
   }
 
-  test("block manager crash test") {
-    conf.set("spark.network.timeout", "5s")
-    store = makeBlockManager(8000)
-    store2 = makeBlockManager(8000)
-    val list1 = List(new Array[Byte](4000))
-    store2.putIterator("list1", list1.iterator, StorageLevel.MEMORY_ONLY, tellMaster = true)
-    val list1Get = store.getRemote("list1")
-    assert(list1Get.isDefined, "list1get expected to be fetched")
-    // simulate block manager crashed
-    store2.stop()
-    val list1GetAgain = store.getRemoteBytes("list1")
-    assert(!list1GetAgain.isDefined, "list1getagain expected to be not fetched")
-    conf.set("spark.network.timeout", "120s")
+  test("(SPARK-9591)getRemoteBytes from another location when  IOException throw") {
+    try {
+      conf.set("spark.network.timeout", "2s")
+      store = makeBlockManager(8000, "excutor1")
+      store2 = makeBlockManager(8000, "excutor2")
+      store3 = makeBlockManager(8000, "executor3")
+      val list1 = List(new Array[Byte](4000))
+      store2.putIterator("list1", list1.iterator, StorageLevel.MEMORY_ONLY, tellMaster = true)
+      store3.putIterator("list1", list1.iterator, StorageLevel.MEMORY_ONLY, tellMaster = true)
+
+      var list1Get = store.getRemoteBytes("list1")
+      assert(list1Get.isDefined, "list1Get expected to be fetched")
+      // block manager exit
+      store2.stop()
+      store2 = null
+      list1Get = store.getRemoteBytes("list1")
+
+      // get `list1` block
+      assert(list1Get.isDefined, "list1Get expected to be fetched")
+
+      store3.stop()
+      store3 = null
+      // exception throw because there is no locations
+      intercept[java.io.IOException] {
+        list1Get = store.getRemoteBytes("list1")
+      }
+    } finally {
+      conf.remove("spark.network.timeout")
+    }
   }
 
   test("in-memory LRU storage") {


### PR DESCRIPTION
[SPARK-9591](https://issues.apache.org/jira/browse/SPARK-9591) 
When we getting the broadcast variable, we can fetch the block form several location,but now when connecting the lost blockmanager(idle for enough time removed by driver when using dynamic resource allocate and so on) will cause task fail,and the worse case will cause the job fail.
