### PR TITLE
[SPARK-8862][SQL]Support multiple SQLContexts in Web UI

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/ui/AllExecutionsPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/ui/AllExecutionsPage.scala
@@ -178,7 +178,7 @@ private[ui] abstract class ExecutionTable(
     "%s/jobs/job?id=%s".format(UIUtils.prependBaseUri(parent.basePath), jobId)
 
   private def executionURL(executionID: Long): String =
-    "%s/sql/execution?id=%s".format(UIUtils.prependBaseUri(parent.basePath), executionID)
+    s"${UIUtils.prependBaseUri(parent.basePath)}/${parent.prefix}/execution?id=$executionID"
 }
 
 private[ui] class RunningExecutionTable(

--- a/sql/core/src/main/scala/org/apache/spark/sql/ui/SQLTab.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/ui/SQLTab.scala
@@ -44,6 +44,6 @@ private[sql] object SQLTab {
 
   private def nextTabName: String = {
     val nextId = nextTabId.getAndIncrement()
-    if (nextId == 0) "sql" else s"sql${nextId}"
+    if (nextId == 0) "SQL" else s"SQL${nextId}"
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/ui/SQLTab.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/ui/SQLTab.scala
@@ -17,13 +17,14 @@
 
 package org.apache.spark.sql.ui
 
+import java.util.concurrent.atomic.AtomicInteger
+
 import org.apache.spark.Logging
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.ui.{SparkUI, SparkUITab}
 
 private[sql] class SQLTab(sqlContext: SQLContext, sparkUI: SparkUI)
-  extends SparkUITab(sparkUI, "sql") with Logging {
-
+  extends SparkUITab(sparkUI, SQLTab.nextTabName) with Logging {
 
   val parent = sparkUI
   val listener = sqlContext.listener
@@ -38,4 +39,11 @@ private[sql] class SQLTab(sqlContext: SQLContext, sparkUI: SparkUI)
 private[sql] object SQLTab {
 
   private val STATIC_RESOURCE_DIR = "org/apache/spark/sql/ui/static"
+
+  private val nextTabId = new AtomicInteger(0)
+
+  private def nextTabName: String = {
+    val nextId = nextTabId.getAndIncrement()
+    if (nextId == 0) "sql" else s"sql${nextId}"
+  }
 }


### PR DESCRIPTION
This is a follow-up PR to solve the UI issue when there are multiple SQLContexts. Each SQLContext has a separate tab and contains queries which are executed by this SQLContext.

<img width="1366" alt="multiple sqlcontexts" src="https://cloud.githubusercontent.com/assets/1000778/9088391/54584434-3bc2-11e5-9caf-94c2b0da528e.png">
