### PR TITLE
[SPARK-6212][SQL] Fix bug of explain CTAS

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
@@ -69,6 +69,8 @@ private[sql] case class ExecutedCommand(cmd: RunnableCommand) extends SparkPlan 
     val converted = sideEffectResult.map(convert(_).asInstanceOf[InternalRow])
     sqlContext.sparkContext.parallelize(converted, 1)
   }
+
+  override def argString: String = s"[cmd:$cmd]"
 }
 
 /**

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/CreateTableAsSelect.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/CreateTableAsSelect.scala
@@ -37,6 +37,7 @@ case class CreateTableAsSelect(
     allowExisting: Boolean)
   extends RunnableCommand {
 
+  override def children: Seq[LogicalPlan] = query :: Nil
   def database: String = tableDesc.database
   def tableName: String = tableDesc.name
 
@@ -91,6 +92,6 @@ case class CreateTableAsSelect(
   }
 
   override def argString: String = {
-    s"[Database:$database, TableName: $tableName, InsertIntoHiveTable]\n" + query.toString
+    s"[AllowExisting: $allowExisting, HiveTable: $tableDesc]"
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveExplainSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveExplainSuite.scala
@@ -46,13 +46,18 @@ class HiveExplainSuite extends QueryTest {
                    "Limit",
                    "src")
 
-    checkExistence(sql("explain extended create table temp__b as select * from src limit 2"), true,
+    checkExistence(
+      sql("explain extended create table temp__b as select key, 1+4 from src limit 2"), true,
       "== Parsed Logical Plan ==",
       "== Analyzed Logical Plan ==",
       "== Optimized Logical Plan ==",
       "== Physical Plan ==",
       "CreateTableAsSelect",
       "InsertIntoHiveTable",
+      "Project [unresolvedalias('key),unresolvedalias((1 + 4))", // parsed plan
+      "(1 + 4) AS", // analyzed plan
+      "5 AS", // optimized plan
+      "ExecutedCommand [cmd:CreateTableAsSelect [", // physical plan
       "Limit",
       "src")
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveExplainSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveExplainSuite.scala
@@ -42,24 +42,19 @@ class HiveExplainSuite extends QueryTest {
   test("explain create table command") {
     checkExistence(sql("explain create table temp__b as select * from src limit 2"), true,
                    "== Physical Plan ==",
-                   "InsertIntoHiveTable",
+                   "ExecutedCommand [cmd:CreateTableAsSelect [",
                    "Limit",
                    "src")
 
     checkExistence(
-      sql("explain extended create table temp__b as select key, 1+4 from src limit 2"), true,
+      sql("explain create table temp__b as select *, 1+4 from src limit 2"), false,
       "== Parsed Logical Plan ==",
       "== Analyzed Logical Plan ==",
       "== Optimized Logical Plan ==",
-      "== Physical Plan ==",
-      "CreateTableAsSelect",
-      "InsertIntoHiveTable",
-      "Project [unresolvedalias('key),unresolvedalias((1 + 4))", // parsed plan
-      "(1 + 4) AS", // analyzed plan
-      "5 AS", // optimized plan
-      "ExecutedCommand [cmd:CreateTableAsSelect [", // physical plan
-      "Limit",
-      "src")
+      "unresolvedalias(*)", // parsed plan
+      "unresolvedalias((1 + 4))", // parsed plan
+      "(1 + 4) AS") // analyzed plan
+
 
     checkExistence(sql(
       """
@@ -68,15 +63,24 @@ class HiveExplainSuite extends QueryTest {
         | WITH SERDEPROPERTIES("serde_p1"="p1","serde_p2"="p2")
         | STORED AS RCFile
         | TBLPROPERTIES("tbl_p1"="p11", "tbl_p2"="p22")
-        | AS SELECT * FROM src LIMIT 2
+        | AS SELECT *, 4+1 FROM src LIMIT 2
       """.stripMargin), true,
       "== Parsed Logical Plan ==",
       "== Analyzed Logical Plan ==",
       "== Optimized Logical Plan ==",
       "== Physical Plan ==",
       "CreateTableAsSelect",
-      "InsertIntoHiveTable",
+      "HiveTable",
       "Limit",
+      "Map(tbl_p1 -> p11, tbl_p2 -> p22)",
+      "Map(serde_p1 -> p1, serde_p2 -> p2)",
+      "unresolvedalias(*)", // parsed logical plan
+      "unresolvedalias((4 + 1))", // parsed logical plan
+      "(4 + 1) AS", // analyzed logical plan
+      "key", // analyzed logical plan
+      "value", // analyzed logical plan
+      "5 AS", // optimized logical plan
+      "ExecutedCommand [cmd:", // pyhsical plan
       "src")
   }
 }


### PR DESCRIPTION
As we assume the `CreateTableAsSelect` is the leaf node, so it breaks the transformation rules applied recursively, while we do the `explain` command.

To execute the explain for CTAS like:

``` sql
explain extended create table temp__b as select key, 1+4 from src limit 2;
```

W/o this PR:

```
== Parsed Logical Plan ==
'CreateTableAsSelect HiveTable(None,temp__b,List(),List(),Map(),Map(),ManagedTable,None,Some(org.apache.hadoop.mapred.TextInputFormat),Some(org.apache.hadoop.hive.ql.io.IgnoreKeyTextOutputFormat),None,None), false
 'Limit 2
  'Project [unresolvedalias('key),unresolvedalias((1 + 4))]
   'UnresolvedRelation [src], None

== Analyzed Logical Plan ==

CreateTableAsSelect [Database:default, TableName: temp__b, InsertIntoHiveTable]
Limit 2
 Project [key#1,(1 + 4) AS _c1#3]
  MetastoreRelation default, src, None

== Optimized Logical Plan ==
CreateTableAsSelect [Database:default, TableName: temp__b, InsertIntoHiveTable]
Limit 2
 Project [key#1,(1 + 4) AS _c1#3]
  MetastoreRelation default, src, None

== Physical Plan ==
ExecutedCommand (CreateTableAsSelect [Database:default, TableName: temp__b, InsertIntoHiveTable]
Limit 2
 Project [key#1,(1 + 4) AS _c1#3]
  MetastoreRelation default, src, None)

Code Generation: true
== RDD ==
```

W/ this PR:

```
== Parsed Logical Plan ==
'CreateTableAsSelect HiveTable(None,temp__b,List(),List(),Map(),Map(),ManagedTable,None,Some(org.apache.hadoop.mapred.TextInputFormat),Some(org.apache.hadoop.hive.ql.io.IgnoreKeyTextOutputFormat),None,None), false
 'Limit 2
  'Project [unresolvedalias('key),unresolvedalias((1 + 4))]
   'UnresolvedRelation [src], None

== Analyzed Logical Plan ==

CreateTableAsSelect [AllowExisting: false, HiveTable: HiveTable(Some(default),temp__b,List(),List(),Map(),Map(),ManagedTable,None,Some(org.apache.hadoop.mapred.TextInputFormat),Some(org.apache.hadoop.hive.ql.io.IgnoreKeyTextOutputFormat),Some(org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe),None)]
 Limit 2
  Project [key#1,(1 + 4) AS _c1#3]
   MetastoreRelation default, src, None

== Optimized Logical Plan ==
CreateTableAsSelect [AllowExisting: false, HiveTable: HiveTable(Some(default),temp__b,List(),List(),Map(),Map(),ManagedTable,None,Some(org.apache.hadoop.mapred.TextInputFormat),Some(org.apache.hadoop.hive.ql.io.IgnoreKeyTextOutputFormat),Some(org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe),None)]
 Limit 2
  Project [key#1,5 AS _c1#3]
   MetastoreRelation default, src, None

== Physical Plan ==
ExecutedCommand [cmd:CreateTableAsSelect [AllowExisting: false, HiveTable: HiveTable(Some(default),temp__b,List(),List(),Map(),Map(),ManagedTable,None,Some(org.apache.hadoop.mapred.TextInputFormat),Some(org.apache.hadoop.hive.ql.io.IgnoreKeyTextOutputFormat),Some(org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe),None)]
 Limit 2
  Project [key#1,5 AS _c1#3]
   MetastoreRelation default, src, None
]

Code Generation: true
== RDD ==
```
