### PR TITLE
[SPARK-9641] [DOCS] spark.shuffle.service.port is not documented

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -474,6 +474,22 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+  <td><code>spark.shuffle.service.enabled</code></td>
+  <td>false</td>
+  <td>
+    Enables the external shuffle service. This service preserves the shuffle files written by 
+    executors so the executors can be safely removed. This must be enabled if 
+    <code>spark.dynamicAllocation.enabled</code> is "true".
+  </td>
+</tr>
+<tr>
+  <td><code>spark.shuffle.service.port</code></td>
+  <td>7337</td>
+  <td>
+    Port on which the external shuffle service will run.
+  </td>
+</tr>
+<tr>
   <td><code>spark.shuffle.sort.bypassMergeThreshold</code></td>
   <td>200</td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -479,7 +479,10 @@ Apart from these, the following properties are also available, and may be useful
   <td>
     Enables the external shuffle service. This service preserves the shuffle files written by 
     executors so the executors can be safely removed. This must be enabled if 
-    <code>spark.dynamicAllocation.enabled</code> is "true".
+    <code>spark.dynamicAllocation.enabled</code> is "true". The external shuffle service
+    must be set up in order to enable it. See
+    <a href="job-scheduling.html#configuration-and-setup">dynamic allocation 
+    configuration and setup documentation</a> for more information.
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
Document spark.shuffle.service.{enabled,port}

CC @sryza @tgravescs
This is pretty minimal; is there more to say here about the service?
