### PR TITLE
[SPARK-9687] Avoid throwing SparkException for errors during registration

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -425,10 +425,9 @@ private[spark] class TaskSchedulerImpl(
           }
         }
       } else {
-        // No task sets are active but we still got an error. Just exit since this
-        // must mean the error is during registration.
-        // It might be good to do something smarter here in the future.
-        throw new SparkException(s"Exiting due to error from cluster scheduler: $message")
+        // No task sets are active but we still got an error. Just log the error
+        // since this must mean the error is during registration.
+        logError(s"Exiting due to error from cluster scheduler: $message")
       }
     }
   }


### PR DESCRIPTION
This issue was already reported in #SPARK-4783. It was addressed in the #5492 PR but we are still having the same issue.

With this change we are not throwing a SparkException anymore
