### PR TITLE
SPARK-9690 Adding the possibility to set the seed of the rand in the …

### DIFF
--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -121,7 +121,7 @@ class CrossValidator(Estimator):
     numFolds = Param(Params._dummy(), "numFolds", "number of folds for cross validation")
 
     @keyword_only
-    def __init__(self, estimator=None, estimatorParamMaps=None, evaluator=None, numFolds=3):
+    def __init__(self, estimator=None, estimatorParamMaps=None, evaluator=None, numFolds=3, seed=0):
         """
         __init__(self, estimator=None, estimatorParamMaps=None, evaluator=None, numFolds=3)
         """
@@ -136,6 +136,8 @@ class CrossValidator(Estimator):
             self, "evaluator",
             "evaluator used to select hyper-parameters that maximize the cross-validated metric")
         #: param for number of folds for cross validation
+        self._setDefault(seed=0)
+        self.seed = Param(self, "seed", "seed value used for k-fold")
         self.numFolds = Param(self, "numFolds", "number of folds for cross validation")
         self._setDefault(numFolds=3)
         kwargs = self.__init__._input_kwargs
@@ -210,7 +212,7 @@ class CrossValidator(Estimator):
         nFolds = self.getOrDefault(self.numFolds)
         h = 1.0 / nFolds
         randCol = self.uid + "_rand"
-        df = dataset.select("*", rand(0).alias(randCol))
+        df = dataset.select("*", rand(self.getOrDefault(self.seed)).alias(randCol))
         metrics = np.zeros(numModels)
         for i in range(nFolds):
             validateLB = i * h


### PR DESCRIPTION
…CrossValidator fold

The fold in the ML CrossValidator depends on a rand whose seed is set to 0 and it leads the sql.functions rand to call sc._jvm.functions.rand() with no seed.
In order to be able to unit test a Cross Validation it would be a good idea to be able to set this seed so the output of the cross validation (with a featureSubsetStrategy set to "all") would always be the same.
