### PR TITLE
[SPARK-9453] [SQL] support records larger than page size in UnsafeShuffleExternalSorter

### DIFF
--- a/core/src/main/java/org/apache/spark/shuffle/unsafe/UnsafeShuffleExternalSorter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/unsafe/UnsafeShuffleExternalSorter.java
@@ -44,7 +44,7 @@ import org.apache.spark.unsafe.memory.TaskMemoryManager;
 import org.apache.spark.util.Utils;
 
 /**
- * An external inMemSorter that is specialized for sort-based shuffle.
+ * An external sorter that is specialized for sort-based shuffle.
  * <p>
  * Incoming records are appended to data pages. When all records have been inserted (or when the
  * current thread's shuffle memory limit is reached), the in-memory records are sorted according to
@@ -55,7 +55,7 @@ import org.apache.spark.util.Utils;
  * written as a single serialized, compressed stream that can be read with a new decompression and
  * deserialization stream.
  * <p>
- * Unlike {@link org.apache.spark.util.collection.ExternalSorter}, this inMemSorter does not merge its
+ * Unlike {@link org.apache.spark.util.collection.ExternalSorter}, this sorter does not merge its
  * spill files. Instead, this merging is performed in {@link UnsafeShuffleWriter}, which uses a
  * specialized merge procedure that avoids extra serialization/deserialization.
  */
@@ -90,7 +90,7 @@ final class UnsafeShuffleExternalSorter {
 
   private final LinkedList<SpillInfo> spills = new LinkedList<SpillInfo>();
 
-  /** Peak memory used by this inMemSorter so far, in bytes. **/
+  /** Peak memory used by this sorter so far, in bytes. **/
   private long peakMemoryUsedBytes;
 
   // These variables are reset after spilling:
@@ -126,10 +126,10 @@ final class UnsafeShuffleExternalSorter {
   }
 
   /**
-   * Allocates new sort data structures. Called when creating the inMemSorter and after each spill.
+   * Allocates new sort data structures. Called when creating the sorter and after each spill.
    */
   private void initializeForWriting() throws IOException {
-    // TODO: move this sizing calculation logic into a static method of inMemSorter:
+    // TODO: move this sizing calculation logic into a static method of sorter:
     final long memoryRequested = initialSize * 8L;
     final long memoryAcquired = shuffleMemoryManager.tryToAcquire(memoryRequested);
     if (memoryAcquired != memoryRequested) {
@@ -399,7 +399,7 @@ final class UnsafeShuffleExternalSorter {
   }
 
   /**
-   * Write a record to the shuffle inMemSorter.
+   * Write a record to the shuffle sorter.
    */
   public void insertRecord(
       Object recordBaseObject,
@@ -461,10 +461,10 @@ final class UnsafeShuffleExternalSorter {
   }
 
   /**
-   * Close the inMemorySorter, causing any buffered data to be sorted and written out to disk.
+   * Close the sorter, causing any buffered data to be sorted and written out to disk.
    *
-   * @return metadata for the spill files written by this inMemSorter. If no records were ever inserted
-   *         into this inMemSorter, then this will return an empty array.
+   * @return metadata for the spill files written by this sorter. If no records were ever inserted
+   *         into this sorter, then this will return an empty array.
    * @throws IOException
    */
   public SpillInfo[] closeAndGetSpills() throws IOException {

--- a/core/src/main/java/org/apache/spark/shuffle/unsafe/UnsafeShuffleWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/unsafe/UnsafeShuffleWriter.java
@@ -17,17 +17,17 @@
 
 package org.apache.spark.shuffle.unsafe;
 
+import javax.annotation.Nullable;
 import java.io.*;
 import java.nio.channels.FileChannel;
 import java.util.Iterator;
-import javax.annotation.Nullable;
 
 import scala.Option;
 import scala.Product2;
 import scala.collection.JavaConversions;
+import scala.collection.immutable.Map;
 import scala.reflect.ClassTag;
 import scala.reflect.ClassTag$;
-import scala.collection.immutable.Map;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.ByteStreams;
@@ -38,10 +38,10 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.spark.*;
 import org.apache.spark.annotation.Private;
+import org.apache.spark.executor.ShuffleWriteMetrics;
 import org.apache.spark.io.CompressionCodec;
 import org.apache.spark.io.CompressionCodec$;
 import org.apache.spark.io.LZFCompressionCodec;
-import org.apache.spark.executor.ShuffleWriteMetrics;
 import org.apache.spark.network.util.LimitedInputStream;
 import org.apache.spark.scheduler.MapStatus;
 import org.apache.spark.scheduler.MapStatus$;
@@ -178,7 +178,7 @@ public class UnsafeShuffleWriter<K, V> extends ShuffleWriter<K, V> {
     } finally {
       if (sorter != null) {
         try {
-          sorter.cleanupAfterError();
+          sorter.cleanupResources();
         } catch (Exception e) {
           // Only throw this error if we won't be masking another
           // error.
@@ -482,7 +482,7 @@ public class UnsafeShuffleWriter<K, V> extends ShuffleWriter<K, V> {
       if (sorter != null) {
         // If sorter is non-null, then this implies that we called stop() in response to an error,
         // so we need to clean up memory and spill files created by the sorter
-        sorter.cleanupAfterError();
+        sorter.cleanupResources();
       }
     }
   }

--- a/core/src/test/java/org/apache/spark/shuffle/unsafe/UnsafeShuffleWriterSuite.java
+++ b/core/src/test/java/org/apache/spark/shuffle/unsafe/UnsafeShuffleWriterSuite.java
@@ -219,10 +219,6 @@ public class UnsafeShuffleWriterSuite {
   }
 
   private List<Tuple2<Object, Object>> readRecordsFromFile() throws IOException {
-    return readRecordsFromFile(serializer);
-  }
-
-  private List<Tuple2<Object, Object>> readRecordsFromFile(Serializer serializer) throws IOException {
     final ArrayList<Tuple2<Object, Object>> recordsList = new ArrayList<Tuple2<Object, Object>>();
     long startOffset = 0;
     for (int i = 0; i < NUM_PARTITITONS; i++) {
@@ -238,7 +234,7 @@ public class UnsafeShuffleWriterSuite {
         Iterator<Tuple2<Object, Object>> records = recordsStream.asKeyValueIterator();
         while (records.hasNext()) {
           Tuple2<Object, Object> record = records.next();
-          //assertEquals(i, hashPartitioner.getPartition(record._1()));
+          assertEquals(i, hashPartitioner.getPartition(record._1()));
           recordsList.add(record);
         }
         recordsStream.close();
@@ -485,7 +481,7 @@ public class UnsafeShuffleWriterSuite {
     final byte[] atMaxRecordSize = new byte[writer.maxRecordSizeBytes()];
     new Random(42).nextBytes(atMaxRecordSize);
     dataToWrite.add(new Tuple2<Object, Object>(2, ByteBuffer.wrap(atMaxRecordSize)));
-    // Inserting a record that's larger than the max record size should fail:
+    // Inserting a record that's larger than the max record size
     final byte[] exceedsMaxRecordSize = new byte[writer.maxRecordSizeBytes() + 1];
     new Random(42).nextBytes(exceedsMaxRecordSize);
     dataToWrite.add(new Tuple2<Object, Object>(3, ByteBuffer.wrap(exceedsMaxRecordSize)));


### PR DESCRIPTION
This patch follows exactly #7891 (except testing)
