### PR TITLE
[SPARK-9726] [Python] PySpark DF join no longer accepts on=None

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -568,8 +568,7 @@ class DataFrame(object):
 
         if on is None or len(on) == 0:
             jdf = self._jdf.join(other._jdf)
-
-        if isinstance(on[0], basestring):
+        elif isinstance(on[0], basestring):
             jdf = self._jdf.join(other._jdf, self._jseq(on))
         else:
             assert isinstance(on[0], Column), "on should be Column or list of Column"


### PR DESCRIPTION
@rxin 

First pull request for Spark so let me know if I am missing anything
The contribution is my original work and I license the work to the project under the project's open source license. 
