### PR TITLE
[SPARK-9750][MLlib] Improve equals on SparseMatrix and DenseMatrix

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
@@ -519,6 +519,11 @@ class SparseMatrix(
       rowIndices: Array[Int],
       values: Array[Double]) = this(numRows, numCols, colPtrs, rowIndices, values, false)
 
+  override def equals(o: Any): Boolean = o match {
+    case m: SparseMatrix => toBreeze == m.toBreeze
+    case _ => false
+  }
+
   private[mllib] def toBreeze: BM[Double] = {
      if (!isTransposed) {
        new BSM[Double](values, numRows, numCols, colPtrs, rowIndices)

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
@@ -257,7 +257,7 @@ class DenseMatrix(
     this(numRows, numCols, values, false)
 
   override def equals(o: Any): Boolean = o match {
-    case m: DenseMatrix =>
+    case m: Matrix =>
       m.numRows == numRows && m.numCols == numCols && Arrays.equals(toArray, m.toArray)
     case _ => false
   }
@@ -520,7 +520,8 @@ class SparseMatrix(
       values: Array[Double]) = this(numRows, numCols, colPtrs, rowIndices, values, false)
 
   override def equals(o: Any): Boolean = o match {
-    case m: SparseMatrix => toBreeze == m.toBreeze
+    case m: Matrix =>
+      m.numRows == numRows && m.numCols == numCols && Arrays.equals(toArray, m.toArray)
     case _ => false
   }
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
@@ -257,8 +257,7 @@ class DenseMatrix(
     this(numRows, numCols, values, false)
 
   override def equals(o: Any): Boolean = o match {
-    case m: Matrix =>
-      m.numRows == numRows && m.numCols == numCols && Arrays.equals(toArray, m.toArray)
+    case m: Matrix => toBreeze == m.toBreeze
     case _ => false
   }
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
@@ -520,8 +520,7 @@ class SparseMatrix(
       values: Array[Double]) = this(numRows, numCols, colPtrs, rowIndices, values, false)
 
   override def equals(o: Any): Boolean = o match {
-    case m: Matrix =>
-      m.numRows == numRows && m.numCols == numCols && Arrays.equals(toArray, m.toArray)
+    case m: Matrix => toBreeze == m.toBreeze
     case _ => false
   }
 

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
@@ -82,11 +82,11 @@ class MatricesSuite extends SparkFunSuite {
     val dm2 = Matrices.dense(2, 2, Array(0.0, 2.0, 1.0, 3.0))
     assert(dm1 === dm2.transpose)
 
-    val sm1 = dm1.toSparse
+    val sm1 = dm1.asInstanceOf[DenseMatrix].toSparse
     assert(sm1 === sm1)
     assert(sm1 !== sm1.transpose)
 
-    val sm2 = dm2.toSparse
+    val sm2 = dm2.asInstanceOf[DenseMatrix].toSparse
     assert(sm1 === sm2.transpose)
   }
 

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
@@ -84,10 +84,12 @@ class MatricesSuite extends SparkFunSuite {
 
     val sm1 = dm1.asInstanceOf[DenseMatrix].toSparse
     assert(sm1 === sm1)
+    assert(sm1 === dm1)
     assert(sm1 !== sm1.transpose)
 
     val sm2 = dm2.asInstanceOf[DenseMatrix].toSparse
     assert(sm1 === sm2.transpose)
+    assert(sm1 === dm2.transpose)
   }
 
   test("matrix copies are deep copies") {

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
@@ -74,6 +74,22 @@ class MatricesSuite extends SparkFunSuite {
     }
   }
 
+  test("equals") {
+    val dm1 = Matrices.dense(2, 2, Array(0.0, 1.0, 2.0, 3.0))
+    assert(dm1 === dm1)
+    assert(dm1 !== dm1.transpose)
+
+    val dm2 = Matrices.dense(2, 2, Array(0.0, 2.0, 1.0, 3.0))
+    assert(dm1 === dm2.transpose)
+
+    val sm1 = dm1.toSparse
+    assert(sm1 === sm1)
+    assert(sm1 !== sm1.transpose)
+
+    val sm2 = dm2.toSparse
+    assert(sm1 === sm2.transpose)
+  }
+
   test("matrix copies are deep copies") {
     val m = 3
     val n = 2


### PR DESCRIPTION
Adds unit test for `equals` on `mllib.linalg.Matrix` class and `equals` to both `SparseMatrix` and `DenseMatrix`. Supports equality testing between `SparseMatrix` and `DenseMatrix`.

@mengxr 
