### PR TITLE
[SPARK-8676][SQL]Lazy start event logger in sql application to avoid TGT expiring in l…

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -520,7 +520,6 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
         val logger =
           new EventLoggingListener(_applicationId, _applicationAttemptId, _eventLogDir.get,
             _conf, _hadoopConfiguration)
-        logger.start()
         listenerBus.addListener(logger)
         Some(logger)
       } else {

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -153,11 +153,11 @@ private[spark] class EventLoggingListener(
         writer.foreach(_.flush())
         hadoopDataStream.foreach(hadoopFlushMethod.invoke(_))
       }
+      if (testing) {
+        loggedEvents += eventJson
+      }
     } else {
       bufferedEvents += ((event, flushLogger))
-    }
-    if (testing) {
-      loggedEvents += eventJson
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -19,6 +19,7 @@ package org.apache.spark.scheduler
 
 import java.io._
 import java.net.URI
+import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -34,7 +35,6 @@ import org.apache.spark.{Logging, SparkConf, SPARK_VERSION}
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.io.CompressionCodec
 import org.apache.spark.util.{JsonProtocol, Utils}
-import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * A SparkListener that logs events to persistent storage.
@@ -154,7 +154,7 @@ private[spark] class EventLoggingListener(
         hadoopDataStream.foreach(hadoopFlushMethod.invoke(_))
       }
     } else {
-      bufferedEvents += (event, flushLogger)
+      bufferedEvents += ((event, flushLogger))
     }
     if (testing) {
       loggedEvents += eventJson


### PR DESCRIPTION
…ong connection

Now in Thrift Server/Spark SQL, it will login first in `Client.scala`, then open the file stream in event logger. After that the login action will be executed twice again, one of them is in `SparkSQLCLIService`, and another is in `ThriftHttpCLIService/ThriftBinaryCLIService`.

If we open a long-connected file stream to HDFS between two login, the UserGroupInformation that RPC took will be refreshed by second login. After the TGT expires, it will cause "No invalid credentials" excepiton.

So in SQL application, we will start event logger only after the HiveServer2 being launched.
