### PR TITLE
[SPARK-4449][Core]Specify port range in spark

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -17,15 +17,10 @@
 
 package org.apache.spark.util
 
-import java.io._
-import java.lang.management.ManagementFactory
-import java.net._
-import java.nio.ByteBuffer
-import java.util.{PriorityQueue, Properties, Locale, Random, UUID}
-import java.util.concurrent._
-import javax.net.ssl.HttpsURLConnection
 
-import scala.collection.JavaConversions._
+import java.util.{PriorityQueue, Properties, Locale, Random, UUID}
+
+
 import scala.collection.Map
 import scala.collection.mutable.ArrayBuffer
 import scala.io.Source

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2055,7 +2055,7 @@ private[spark] object Utils extends Logging {
               s"${e.getMessage}: Service$serviceString failed after $maxRetries retries!"
             failedPorts.insert(tryPort)
             val exception = new BindException(exceptionMessage)
-            // restore original stack traceg
+            // restore original stack trace
             exception.setStackTrace(e.getStackTrace)
             throw exception
           }


### PR DESCRIPTION
Specify port range in spark
JIRA link: https://issues.apache.org/jira/browse/SPARK-4449

Goal: To add a port range to services
Design: (Based on the input and the suggestions in t #3314 and #5722):
1) Added variables maxPort and failedPorts to help the implementation
2) The maxPort was explicitly assigned to be startPort + maxRetries to avoid Retries being lesser or greater than the specified port range.
3) Added the failedPorts ArrayBuffer to catch the failedPorts (during retry) which are in the range of the maxPort - startPort ( see Random logic)
4) This failedPorts list will be checked and the tryPort will not attempt those ports again in the random..
5) If the randomized port does not belong to the failedPorts list and a privileged port, it will be tried. 
6) There’s a if block to check if there are sufficient ports left to attempt within the range (not sure if this is needed)

Requesting review.
