### PR TITLE
[SPARK-9778][SQL] remove unnecessary evaluation from SortOrder

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -129,7 +129,6 @@ class AnalysisSuite extends AnalysisTest {
     val b = testRelation2.output(1)
     val c = testRelation2.output(2)
     val alias_a3 = count(a).as("a3")
-    val alias_b = b.as("aggOrder")
 
     // Case 1: when the child of Sort is not Aggregate,
     //   the sort reference is handled by the rule ResolveSortReferences
@@ -153,8 +152,8 @@ class AnalysisSuite extends AnalysisTest {
       .orderBy('b.asc)
 
     val expected2 = testRelation2
-      .groupBy(a, c, b)(a, c, alias_a3, alias_b)
-      .orderBy(alias_b.toAttribute.asc)
+      .groupBy(a, c, b)(a, c, alias_a3, b)
+      .orderBy(b.asc)
       .select(a, c, alias_a3.toAttribute)
 
     checkAnalysis(plan2, expected2)
@@ -316,8 +315,8 @@ class AnalysisSuite extends AnalysisTest {
       .orderBy('a1.asc, 'c.asc)
 
     val expected = testRelation2
-      .groupBy(a, c)(alias1, alias2, alias3)
-      .orderBy(alias1.toAttribute.asc, alias2.toAttribute.asc)
+      .groupBy(a, c)(alias1, alias2, alias3, c)
+      .orderBy(alias1.toAttribute.asc, c.asc)
       .select(alias1.toAttribute, alias2.toAttribute, alias3.toAttribute)
     checkAnalysis(plan, expected)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SortOptimizationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SortOptimizationSuite.scala
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+
+class SortOptimizationSuite extends PlanTest {
+
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches =
+      Batch("Operator Optimizations", FixedPoint(100),
+        ColumnPruning,
+        CollapseProject) :: Nil
+  }
+
+  private val testRelation = LocalRelation('a.int, 'b.int)
+
+  test("sort on projection") {
+    val query =
+      testRelation
+        .select(('a * 2).as("eval"), 'b)
+        .orderBy(('a * 2).asc, ('a * 2 + 3).asc).analyze
+    val optimized = Optimize.execute(query)
+
+    val correctAnswer =
+      testRelation
+        .select(('a * 2).as("eval"), 'b)
+        .orderBy('eval.asc, ('eval + 3).asc).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("sort on aggregation") {
+    val query =
+      testRelation
+        .groupBy('a * 2)(sum('b).as("sum"))
+        .orderBy(('a * 2).asc, ('a * 2 + 3).asc).analyze
+
+    val optimized = Optimize.execute(query)
+
+    val correctAnswer =
+      testRelation
+        .groupBy('a * 2)(('a * 2).as("aggOrder"), sum('b).as("sum"))
+        .orderBy('aggOrder.asc, ('aggOrder + 3).asc)
+        .select('sum)
+        .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("sort on aggregation: order by aggregate expression") {
+    val query =
+      testRelation
+        .groupBy('a)('a)
+        .orderBy(sum('b).asc, (sum('b) + 1).asc).analyze
+
+    val optimized = Optimize.execute(query)
+
+    val correctAnswer =
+      testRelation
+        .groupBy('a)('a, sum('b).as("aggOrder"))
+        .orderBy('aggOrder.asc, ('aggOrder + 1).asc)
+        .select('a).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SortOptimizationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SortOptimizationSuite.scala
@@ -29,7 +29,8 @@ class SortOptimizationSuite extends PlanTest {
     val batches =
       Batch("Operator Optimizations", FixedPoint(100),
         ColumnPruning,
-        CollapseProject) :: Nil
+        CollapseProject,
+        RemoveUnnecessarySortOrderEvaluation) :: Nil
   }
 
   private val testRelation = LocalRelation('a.int, 'b.int)
@@ -59,7 +60,7 @@ class SortOptimizationSuite extends PlanTest {
 
     val correctAnswer =
       testRelation
-        .groupBy('a * 2)(('a * 2).as("aggOrder"), sum('b).as("sum"))
+        .groupBy('a * 2)(sum('b).as("sum"), ('a * 2).as("aggOrder"))
         .orderBy('aggOrder.asc, ('aggOrder + 3).asc)
         .select('sum)
         .analyze


### PR DESCRIPTION
If the order-by expression is already in child's output, we can just reference it instead of evaluate it agian.
