### PR TITLE
[SPARK-9782] [YARN] Support YARN application tags via SparkConf

### DIFF
--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -320,11 +320,11 @@ If you need a reference to the proper location to put log files in the YARN so t
   </td>
 </tr>
 <tr>
-  <td><code>spark.yarn.application.tags</code></td>
+  <td><code>spark.yarn.tags</code></td>
   <td>(none)</td>
   <td>
   Comma-separated list of strings to pass through as YARN application tags appearing
-  in YARN ApplicationReports, which can be used for filtering when querying YARN.
+  in YARN ApplicationReports, which can be used for filtering when querying YARN apps.
   </td>
 </tr>
 <tr>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -320,6 +320,14 @@ If you need a reference to the proper location to put log files in the YARN so t
   </td>
 </tr>
 <tr>
+  <td><code>spark.yarn.application.tags</code></td>
+  <td>(none)</td>
+  <td>
+  Comma-separated list of strings to pass through as YARN application tags appearing
+  in YARN ApplicationReports, which can be used for filtering when querying YARN.
+  </td>
+</tr>
+<tr>
   <td><code>spark.yarn.keytab</code></td>
   <td>(none)</td>
   <td>

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -176,8 +176,8 @@ private[spark] class Client(
           method.invoke(appContext, new java.util.HashSet[String](tagCollection))
         } catch {
           case e: NoSuchMethodException =>
-            logWarning("Ignoring %s='%s' because this version of YARN does not support it"
-              .format(CONF_SPARK_YARN_APPLICATION_TAGS, tagCollection))
+            logWarning(s"Ignoring $CONF_SPARK_YARN_APPLICATION_TAGS because this version of " +
+              "YARN does not support it")
         }
       }
     sparkConf.getOption("spark.yarn.maxAppAttempts").map(_.toInt) match {


### PR DESCRIPTION
Add a new test case in yarn/ClientSuite which checks how the various SparkConf
and ClientArguments propagate into the ApplicationSubmissionContext.
