### PR TITLE
[SPARK-8971][MLLIB][ML] Support balanced class labels when splitting train/cross validation sets

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
@@ -344,7 +344,9 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
         val finalResult = StratifiedSamplingUtils.getAcceptanceResults(self, false, w, None, seed)
         StratifiedSamplingUtils.computeThresholdByKey(finalResult, w)
       }
-    } else normedCumWeightsByKey
+    } else {
+      normedCumWeightsByKey
+    }
 
     val allSplits = weights(0).map(x => (x._1, 0.0)) +: splits :+ weights(0).map(x => (x._1, 1.0))
     allSplits.sliding(2).map { x =>

--- a/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
@@ -370,7 +370,6 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
    * @param complement boolean specifying whether to return subsample or its complement
    * @return A random, stratified sub-sample of the RDD without replacement.
    */
-  // TODO: look at withscope
   private[spark] def randomSampleByKeyWithRange(lb: Map[K, Double],
       ub: Map[K, Double],
       seed: Long,

--- a/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
@@ -332,7 +332,7 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
     val rightBoundary = weights(0).map(x => (x._1, 1.0))
 
     // normalize and cumulative sum
-    val cumWeightsByKey = weights.scanLeft(leftBoundary){ case (accMap, iterMap) =>
+    val cumWeightsByKey = weights.scanLeft(leftBoundary) { case (accMap, iterMap) =>
       accMap.map { case (k, v) => (k, v + iterMap(k)) }
     }.drop(1)
 

--- a/core/src/main/scala/org/apache/spark/util/random/StratifiedSamplingUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/random/StratifiedSamplingUtils.scala
@@ -216,7 +216,10 @@ private[spark] object StratifiedSamplingUtils extends Logging {
   }
 
   /**
-   * WIP sample with range
+   * Return the per partition sampling function used for partitioning a dataset without
+   * replacement.
+   *
+   * The sampling function has a unique seed per partition.
    */
   def getBernoulliCellSamplingFunction[K, V](rdd: RDD[(K, V)],
       lb: Map[K, Double],
@@ -226,8 +229,7 @@ private[spark] object StratifiedSamplingUtils extends Logging {
     (idx: Int, iter: Iterator[(K, V)]) => {
       val rng = new RandomDataGenerator()
       rng.reSeed(seed + idx)
-      // Must use the same invoke pattern on the rng as in getSeqOp for without replacement
-      // in order to generate the same sequence of random numbers when creating the sample
+
       if (complement) {
         iter.filter { t =>
           val x = rng.nextUniform()

--- a/core/src/main/scala/org/apache/spark/util/random/StratifiedSamplingUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/random/StratifiedSamplingUtils.scala
@@ -231,14 +231,14 @@ private[spark] object StratifiedSamplingUtils extends Logging {
       rng.reSeed(seed + idx)
 
       if (complement) {
-        iter.filter { t =>
+        iter.filter { case(k, _) =>
           val x = rng.nextUniform()
-          (x < lb(t._1)) || (x >= ub(t._1))
+          (x < lb(k)) || (x >= ub(k))
         }
       } else {
-        iter.filter { t =>
+        iter.filter { case(k, _) =>
           val x = rng.nextUniform()
-          (x >= lb(t._1)) && (x < ub(t._1))
+          (x >= lb(k)) && (x < ub(k))
         }
       }
     }

--- a/core/src/test/scala/org/apache/spark/rdd/PairRDDFunctionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/PairRDDFunctionsSuite.scala
@@ -793,7 +793,7 @@ class PairRDDFunctionsSuite extends SparkFunSuite with SharedSparkContext {
         n: Int,
         exact: Boolean): Unit = {
       val baseFold = weights(0).map(x => (x._1, 0.0))
-      val totalWeightByKey = weights.foldLeft(baseFold){ case (accMap, iterMap) =>
+      val totalWeightByKey = weights.foldLeft(baseFold) { case (accMap, iterMap) =>
         accMap.map { case (k, v) => (k, v + iterMap(k)) }
       }
       val normedWeights = weights.map(m => m.map { case(k, v) => (k, v / totalWeightByKey(k))})

--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/CrossValidator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/CrossValidator.scala
@@ -55,7 +55,8 @@ private[ml] trait CrossValidatorParams extends ValidatorParams with HasSeed {
    * Default: "None"
    * @group param
    */
-  val stratifiedCol: Param[String] = new Param[String](this, "stratifiedCol", "stratified column name")
+  val stratifiedCol: Param[String] = new Param[String](this, "stratifiedCol",
+    "stratified column name")
 
   /** @group getParam */
   def getStratifiedCol: String = $(stratifiedCol)
@@ -119,9 +120,9 @@ class CrossValidator @Since("1.2.0") (@Since("1.4.0") override val uid: String)
     val metrics = new Array[Double](epm.length)
 
     val splits = if (dataset.columns.contains($(stratifiedCol))) {
-      // stratified kFold
       val stratifiedColIndex = dataset.columns.indexOf($(stratifiedCol))
-      val splitsWithKeys = MLUtils.kFoldStrat(dataset.rdd.map(row => (row(stratifiedColIndex), row)), $(numFolds), 0)
+      val pairData = dataset.rdd.map(row => (row(stratifiedColIndex), row))
+      val splitsWithKeys = MLUtils.kFoldStratified(pairData, $(numFolds), 0)
       splitsWithKeys.map { case (training, validation) => (training.values, validation.values)}
     } else {
       if (isSet(stratifiedCol)) logWarning(s"Stratified column does not exist. Performing regular k-fold subsampling.")

--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/CrossValidator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/CrossValidator.scala
@@ -50,10 +50,22 @@ private[ml] trait CrossValidatorParams extends ValidatorParams with HasSeed {
   val numFolds: IntParam = new IntParam(this, "numFolds",
     "number of folds for cross validation (>= 2)", ParamValidators.gtEq(2))
 
+  /**
+   * Param for stratified sampling column name
+   * Default: "None"
+   * @group param
+   */
+  val stratifiedCol: Param[String] = new Param[String](this, "stratifiedCol", "stratified column name")
+
+  /** @group getParam */
+  def getStratifiedCol: String = $(stratifiedCol)
+
   /** @group getParam */
   def getNumFolds: Int = $(numFolds)
 
   setDefault(numFolds -> 3)
+  setDefault(stratifiedCol -> "None")
+
 }
 
 /**
@@ -91,6 +103,10 @@ class CrossValidator @Since("1.2.0") (@Since("1.4.0") override val uid: String)
   @Since("2.0.0")
   def setSeed(value: Long): this.type = set(seed, value)
 
+  /** @group setParam */
+  @Since("2.0.0")
+  def setStratifiedCol(value: String): this.type = set(stratifiedCol, value)
+
   @Since("1.4.0")
   override def fit(dataset: DataFrame): CrossValidatorModel = {
     val schema = dataset.schema
@@ -101,7 +117,18 @@ class CrossValidator @Since("1.2.0") (@Since("1.4.0") override val uid: String)
     val epm = $(estimatorParamMaps)
     val numModels = epm.length
     val metrics = new Array[Double](epm.length)
-    val splits = MLUtils.kFold(dataset.rdd, $(numFolds), $(seed))
+
+    val splits = if (dataset.columns.contains($(stratifiedCol))) {
+      // stratified kFold
+      val stratifiedColIndex = dataset.columns.indexOf($(stratifiedCol))
+      val splitsWithKeys = MLUtils.kFoldStrat(dataset.rdd.map(row => (row(stratifiedColIndex), row)), $(numFolds), 0)
+      splitsWithKeys.map { case (training, validation) => (training.values, validation.values)}
+    } else {
+      if (isSet(stratifiedCol)) logWarning(s"Stratified column does not exist. Performing regular k-fold subsampling.")
+      // regular kFold
+      MLUtils.kFold(dataset.rdd, $(numFolds), $(seed))
+    }
+
     splits.zipWithIndex.foreach { case ((training, validation), splitIndex) =>
       val trainingDataset = sqlCtx.createDataFrame(training, schema).cache()
       val validationDataset = sqlCtx.createDataFrame(validation, schema).cache()

--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/CrossValidator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/CrossValidator.scala
@@ -125,7 +125,8 @@ class CrossValidator @Since("1.2.0") (@Since("1.4.0") override val uid: String)
       val splitsWithKeys = MLUtils.kFoldStratified(pairData, $(numFolds), 0)
       splitsWithKeys.map { case (training, validation) => (training.values, validation.values)}
     } else {
-      if (isSet(stratifiedCol)) logWarning(s"Stratified column does not exist. Performing regular k-fold subsampling.")
+      if (isSet(stratifiedCol)) logWarning(s"Stratified column does not exist. " +
+        s"Performing regular k-fold subsampling.")
       // regular kFold
       MLUtils.kFold(dataset.rdd, $(numFolds), $(seed))
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/CrossValidator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/CrossValidator.scala
@@ -119,8 +119,8 @@ class CrossValidator @Since("1.2.0") (@Since("1.4.0") override val uid: String)
     val numModels = epm.length
     val metrics = new Array[Double](epm.length)
 
-    val splits = if (dataset.columns.contains($(stratifiedCol))) {
-      val stratifiedColIndex = dataset.columns.indexOf($(stratifiedCol))
+    val splits = if (schema.fieldNames.contains($(stratifiedCol))) {
+      val stratifiedColIndex = schema.fieldNames.indexOf($(stratifiedCol))
       val pairData = dataset.rdd.map(row => (row(stratifiedColIndex), row))
       val splitsWithKeys = MLUtils.kFoldStratified(pairData, $(numFolds), 0)
       splitsWithKeys.map { case (training, validation) => (training.values, validation.values)}

--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/CrossValidator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/CrossValidator.scala
@@ -119,7 +119,7 @@ class CrossValidator @Since("1.2.0") (@Since("1.4.0") override val uid: String)
     val numModels = epm.length
     val metrics = new Array[Double](epm.length)
 
-    val splits = if (schema.fieldNames.contains($(stratifiedCol))) {
+    val splits = if (schema.fieldNames.contains($(stratifiedCol)) & isSet(stratifiedCol)) {
       val stratifiedColIndex = schema.fieldNames.indexOf($(stratifiedCol))
       val pairData = dataset.rdd.map(row => (row(stratifiedColIndex), row))
       val splitsWithKeys = MLUtils.kFoldStratified(pairData, $(numFolds), 0)

--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/TrainValidationSplit.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/TrainValidationSplit.scala
@@ -45,7 +45,8 @@ private[ml] trait TrainValidationSplitParams extends ValidatorParams {
    * Default: "None"
    * @group param
    */
-  val stratifiedCol: Param[String] = new Param[String](this, "stratifiedCol", "stratified column name")
+  val stratifiedCol: Param[String] = new Param[String](this, "stratifiedCol",
+    "stratified column name")
 
   /** @group getParam */
   def getTrainRatio: Double = $(trainRatio)
@@ -106,14 +107,14 @@ class TrainValidationSplit @Since("1.5.0") (@Since("1.5.0") override val uid: St
 
     val Array(training, validation) = if (dataset.columns.contains($(stratifiedCol))) {
       val stratifiedColIndex = dataset.columns.indexOf($(stratifiedCol))
-      val keyedRDD = dataset.rdd.map(row => (row(stratifiedColIndex), row))
-      val keys = keyedRDD.keys.distinct.collect()
+      val pairData = dataset.rdd.map(row => (row(stratifiedColIndex), row))
+      val keys = pairData.keys.distinct.collect()
       val weights: Array[scala.collection.Map[Any, Double]] =
         Array(keys.map(k => (k, $(trainRatio))).toMap, keys.map(k => (k, 1 - $(trainRatio))).toMap)
-      val splitsWithKeys = keyedRDD.randomSplitByKey(weights, exact = true, 0)
+      val splitsWithKeys = pairData.randomSplitByKey(weights, exact = true, 0)
       splitsWithKeys.map { case (subsample, complement) => subsample.values }
     } else {
-      if (isSet(stratifiedCol)) logWarning(s"Stratified column does not exist. Performing approximate split.")
+      if (isSet(stratifiedCol)) logWarning("Stratified column not found. Using standard split.")
       dataset.rdd.randomSplit(Array($(trainRatio), 1 - $(trainRatio)))
     }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/TrainValidationSplit.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/TrainValidationSplit.scala
@@ -23,6 +23,7 @@ import org.apache.spark.ml.evaluation.Evaluator
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.{Estimator, Model}
 import org.apache.spark.ml.evaluation.Evaluator
+import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.{DoubleParam, ParamMap, ParamValidators}
 import org.apache.spark.ml.util.Identifiable
 import org.apache.spark.sql.DataFrame

--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/TrainValidationSplit.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/TrainValidationSplit.scala
@@ -19,8 +19,6 @@ package org.apache.spark.ml.tuning
 
 import org.apache.spark.annotation.{Experimental, Since}
 import org.apache.spark.internal.Logging
-import org.apache.spark.ml.evaluation.Evaluator
-import org.apache.spark.ml.param._
 import org.apache.spark.ml.{Estimator, Model}
 import org.apache.spark.ml.evaluation.Evaluator
 import org.apache.spark.ml.param._

--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/TrainValidationSplit.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/TrainValidationSplit.scala
@@ -105,16 +105,18 @@ class TrainValidationSplit @Since("1.5.0") (@Since("1.5.0") override val uid: St
     val numModels = epm.length
     val metrics = new Array[Double](epm.length)
 
-    val Array(training, validation) = if (dataset.columns.contains($(stratifiedCol))) {
-      val stratifiedColIndex = dataset.columns.indexOf($(stratifiedCol))
+    val Array(training, validation) = if (schema.fieldNames.contains($(stratifiedCol))) {
+      val stratifiedColIndex = schema.fieldNames.indexOf($(stratifiedCol))
       val pairData = dataset.rdd.map(row => (row(stratifiedColIndex), row))
-      val keys = pairData.keys.distinct.collect()
+      val keys = pairData.keys.distinct().collect()
       val weights: Array[scala.collection.Map[Any, Double]] =
         Array(keys.map(k => (k, $(trainRatio))).toMap, keys.map(k => (k, 1 - $(trainRatio))).toMap)
       val splitsWithKeys = pairData.randomSplitByKey(weights, exact = true, 0)
       splitsWithKeys.map { case (subsample, complement) => subsample.values }
     } else {
-      if (isSet(stratifiedCol)) logWarning("Stratified column not found. Using standard split.")
+      if (isSet(stratifiedCol)) {
+        logWarning("Stratified column not found. Using standard split.")
+      }
       dataset.rdd.randomSplit(Array($(trainRatio), 1 - $(trainRatio)))
     }
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
@@ -23,9 +23,8 @@ import org.apache.spark.SparkContext
 import org.apache.spark.annotation.Since
 import org.apache.spark.mllib.linalg.{DenseVector, SparseVector, Vector, Vectors}
 import org.apache.spark.mllib.linalg.BLAS.dot
-
 import org.apache.spark.mllib.regression.LabeledPoint
-import org.apache.spark.rdd.{PartitionwiseSampledRDD, RDD, PairRDDFunctions}
+import org.apache.spark.rdd.{PartitionwiseSampledRDD, RDD}
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util.random.BernoulliCellSampler
 
@@ -285,7 +284,6 @@ object MLUtils {
   }
 
   /**
-   * :: Experimental ::
    * Return a k element array of pairs of RDDs with the first element of each pair
    * containing the training data, a complement of the validation data and the second
    * element, the validation data, containing a unique 1/kth of the data. Where k=numFolds.
@@ -293,7 +291,6 @@ object MLUtils {
    * ratios in the original data are maintained in each stratum of the train and validation
    * data.
    */
-  @Experimental
   def kFoldStratified[K: ClassTag, V: ClassTag](rdd: RDD[(K, V)],
       numFolds: Int,
       seed: Int): Array[(RDD[(K, V)], RDD[(K, V)])] = {

--- a/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
@@ -29,14 +29,6 @@ import org.apache.spark.rdd.{PartitionwiseSampledRDD, RDD, PairRDDFunctions}
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util.random.BernoulliCellSampler
 
-// My changes
-import scala.util.Random
-import org.apache.spark.util.random.StratifiedSamplingUtils
-import scala.collection.mutable
-import scala.collection.mutable.ArrayBuffer
-import org.apache.spark.util.random.XORShiftRandom
-
-
 /**
  * Helper methods to load, save and pre-process data used in ML Lib.
  */
@@ -293,10 +285,16 @@ object MLUtils {
   }
 
   /**
-   * Seth Code
+   * :: Experimental ::
+   * Return a k element array of pairs of RDDs with the first element of each pair
+   * containing the training data, a complement of the validation data and the second
+   * element, the validation data, containing a unique 1/kth of the data. Where k=numFolds.
+   * The training and validation data are stratified by the key of the rdd, and the key
+   * ratios in the original data are maintained in each stratum of the train and validation
+   * data.
    */
   @Experimental
-  def kFoldStrat[K: ClassTag, V: ClassTag](rdd: RDD[(K, V)],
+  def kFoldStratified[K: ClassTag, V: ClassTag](rdd: RDD[(K, V)],
       numFolds: Int,
       seed: Int): Array[(RDD[(K, V)], RDD[(K, V)])] = {
     val keys: Array[K] = rdd.keys.collect().distinct

--- a/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
@@ -297,7 +297,7 @@ object MLUtils {
   def kFoldStratified[K: ClassTag, V: ClassTag](rdd: RDD[(K, V)],
       numFolds: Int,
       seed: Int): Array[(RDD[(K, V)], RDD[(K, V)])] = {
-    val keys = rdd.keys.collect().distinct
+    val keys = rdd.keys.distinct().collect()
     val weights: Array[scala.collection.Map[K, Double]] = (1 to numFolds).map {
       n => keys.map(k => (k, 1 / numFolds.toDouble)).toMap
     }.toArray

--- a/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
@@ -297,7 +297,7 @@ object MLUtils {
   def kFoldStratified[K: ClassTag, V: ClassTag](rdd: RDD[(K, V)],
       numFolds: Int,
       seed: Int): Array[(RDD[(K, V)], RDD[(K, V)])] = {
-    val keys: Array[K] = rdd.keys.collect().distinct
+    val keys = rdd.keys.collect().distinct
     val weights: Array[scala.collection.Map[K, Double]] = (1 to numFolds).map {
       n => keys.map(k => (k, 1 / numFolds.toDouble)).toMap
     }.toArray

--- a/mllib/src/test/scala/org/apache/spark/ml/tuning/CrossValidatorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tuning/CrossValidatorSuite.scala
@@ -55,6 +55,7 @@ class CrossValidatorSuite
       .setEstimatorParamMaps(lrParamMaps)
       .setEvaluator(eval)
       .setNumFolds(3)
+      .setStratifiedCol("label")
     val cvModel = cv.fit(dataset)
 
     // copied model must have the same paren.
@@ -109,6 +110,8 @@ class CrossValidatorSuite
       .setEstimator(est)
       .setEstimatorParamMaps(paramMaps)
       .setEvaluator(eval)
+      .setNumFolds(3)
+      .setStratifiedCol("label")
 
     cv.transformSchema(new StructType()) // This should pass.
 

--- a/mllib/src/test/scala/org/apache/spark/ml/tuning/TrainValidationSplitSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tuning/TrainValidationSplitSuite.scala
@@ -45,6 +45,7 @@ class TrainValidationSplitSuite extends SparkFunSuite with MLlibTestSparkContext
       .setEstimatorParamMaps(lrParamMaps)
       .setEvaluator(eval)
       .setTrainRatio(0.5)
+      .setStratifiedCol("label")
     val cvModel = cv.fit(dataset)
     val parent = cvModel.bestModel.parent.asInstanceOf[LogisticRegression]
     assert(cv.getTrainRatio === 0.5)
@@ -97,7 +98,10 @@ class TrainValidationSplitSuite extends SparkFunSuite with MLlibTestSparkContext
       .setEstimatorParamMaps(paramMaps)
       .setEvaluator(eval)
       .setTrainRatio(0.5)
+      .setStratifiedCol("label")
+
     cv.transformSchema(new StructType()) // This should pass.
+
 
     val invalidParamMaps = paramMaps :+ ParamMap(est.inputCol -> "")
     cv.setEstimatorParamMaps(invalidParamMaps)

--- a/mllib/src/test/scala/org/apache/spark/ml/tuning/TrainValidationSplitSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tuning/TrainValidationSplitSuite.scala
@@ -99,9 +99,7 @@ class TrainValidationSplitSuite extends SparkFunSuite with MLlibTestSparkContext
       .setEvaluator(eval)
       .setTrainRatio(0.5)
       .setStratifiedCol("label")
-
     cv.transformSchema(new StructType()) // This should pass.
-
 
     val invalidParamMaps = paramMaps :+ ParamMap(est.inputCol -> "")
     cv.setEstimatorParamMaps(invalidParamMaps)

--- a/mllib/src/test/scala/org/apache/spark/mllib/util/MLUtilsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/util/MLUtilsSuite.scala
@@ -208,6 +208,32 @@ class MLUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
     }
   }
 
+  test("kFoldStratified") {
+    /**
+     * Most of the functionality of [[kFoldStratified]] is tested in the PairRDD function `randomSplitByKey`. All
+     * that needs to be checked here is that the folds are even splits for each key.
+     */
+    val defaultSeed = 1
+    val n = 100
+    val data = sc.parallelize(1 to n, 2)
+    val fractionPositive = 0.3
+    val keys = Array("0", "1")
+    val stratifiedData = data.map { x =>
+      if (x > n*fractionPositive) ("0", x) else ("1", x)
+    }
+    val counts = stratifiedData.countByKey()
+    for (numFolds <- 1 to 3) {
+      val folds = kFoldStratified(stratifiedData, numFolds, defaultSeed)
+      val expectedSize = keys.map(k => (k, counts(k) / numFolds.toDouble)).toMap
+      for ((sample, complement) <- folds) {
+        val sampleCounts = sample.countByKey()
+        val complementCounts = complement.countByKey()
+        sampleCounts.foreach { case(key, count) => assert(math.abs(count - expectedSize(key)) <= 1)}
+        complementCounts.foreach { case(key, count) => assert(math.abs(count - (counts(key) - expectedSize(key))) <= 1)}
+      }
+    }
+  }
+
   test("loadVectors") {
     val vectors = sc.parallelize(Seq(
       Vectors.dense(1.0, 2.0),

--- a/mllib/src/test/scala/org/apache/spark/mllib/util/MLUtilsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/util/MLUtilsSuite.scala
@@ -210,8 +210,9 @@ class MLUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
 
   test("kFoldStratified") {
     /**
-     * Most of the functionality of [[kFoldStratified]] is tested in the PairRDD function `randomSplitByKey`. All
-     * that needs to be checked here is that the folds are even splits for each key.
+     * Most of the functionality of [[kFoldStratified]] is tested in the PairRDD function
+     * `randomSplitByKey`. All that needs to be checked here is that the folds are even
+     * splits for each key.
      */
     val defaultSeed = 1
     val n = 100
@@ -228,8 +229,12 @@ class MLUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
       for ((sample, complement) <- folds) {
         val sampleCounts = sample.countByKey()
         val complementCounts = complement.countByKey()
-        sampleCounts.foreach { case(key, count) => assert(math.abs(count - expectedSize(key)) <= 1)}
-        complementCounts.foreach { case(key, count) => assert(math.abs(count - (counts(key) - expectedSize(key))) <= 1)}
+        sampleCounts.foreach { case(key, count) =>
+          assert(math.abs(count - expectedSize(key)) <= 1)
+        }
+        complementCounts.foreach { case(key, count) =>
+          assert(math.abs(count - (counts(key) - expectedSize(key))) <= 1)
+        }
       }
     }
   }


### PR DESCRIPTION
I'm leaving a few comments about some of the design choices made in this PR.
- both train/validation split and k fold require a full dataset be partitioned into random samples. For this reason, there has to be some way to group random keys into ranges. `sampleByKeyExact` does not currently allow this and also has no way to return the complement of a subsample.
- the RDD package has a `randomSplit` method that returns approximate splits of an RDD. I chose to implement a `randomSplitByKey` method in the _PairRDDFunctions_. This uses a new sampling function in _StratifiedSamplingUtils_ which allows sampling by filtering random keys into a range and can provide a complement.
- The `randomSplitByKey` function uses the [ScaSRS](http://jmlr.org/proceedings/papers/v28/meng13a.html) method of computing the exact thresholds for each stratum k-1 times to provide exact partitioning of each stratum. These exact thresholds are passed into the sampling function which then samples the data into partitions. For simplicity, this method returns each split AND each split's complement.
- The current proposed solution avoids changing any existing RDD level functions or methods. 
