### PR TITLE
[SPARK-8813][SQL] Combine files when there're many small files in table

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
@@ -420,6 +420,18 @@ private[spark] object SQLConf {
   val USE_SQL_AGGREGATE2 = booleanConf("spark.sql.useAggregate2",
     defaultValue = Some(true), doc = "<TODO>")
 
+  val COMBINE_SMALL_FILE = booleanConf(
+    "spark.sql.small.file.combine",
+    defaultValue = Some(true),
+    isPublic = false
+  )
+
+  val SPLIT_SIZE = intConf(
+    "spark.sql.small.file.split.size",
+    defaultValue = Some(256000000),
+    isPublic = false
+  )
+
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"
   }
@@ -487,6 +499,10 @@ private[sql] class SQLConf extends Serializable with CatalystConf {
   private[spark] def unsafeEnabled: Boolean = getConf(UNSAFE_ENABLED, getConf(TUNGSTEN_ENABLED))
 
   private[spark] def useSqlAggregate2: Boolean = getConf(USE_SQL_AGGREGATE2)
+
+  private[spark] def combineSmallFile: Boolean = getConf(COMBINE_SMALL_FILE)
+
+  private[spark] def splitSize: Long = getConf(SPLIT_SIZE)
 
   private[spark] def autoBroadcastJoinThreshold: Int = getConf(AUTO_BROADCASTJOIN_THRESHOLD)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JSONRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JSONRelation.scala
@@ -88,11 +88,13 @@ private[sql] class JSONRelation(
       FileInputFormat.setInputPaths(job, paths: _*)
     }
 
-    sqlContext.sparkContext.hadoopRDD(
+    val rdd = sqlContext.sparkContext.hadoopRDD(
       conf.asInstanceOf[JobConf],
       classOf[TextInputFormat],
       classOf[LongWritable],
       classOf[Text]).map(_._2.toString) // get the text line
+
+    CombineSmallFile.combineWithFiles(rdd, sqlContext, inputPaths)
   }
 
   override lazy val dataSchema = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/CombineSmallFile.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/CombineSmallFile.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.sources
+
+import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.SQLContext
+
+object CombineSmallFile {
+  def combineWithFiles[T](rdd: RDD[T], sqlContext: SQLContext, inputFiles: Array[FileStatus])
+      : RDD[T] = {
+    if (sqlContext.conf.combineSmallFile) {
+      val totalLen = inputFiles.map { file =>
+        if (file.isDir) 0L else file.getLen
+      }.sum
+      val numPartitions = (totalLen / sqlContext.conf.splitSize + 1).toInt
+      rdd.coalesce(numPartitions)
+    } else {
+      rdd
+    }
+  }
+
+  def combineWithPath[T](rdd: RDD[T], sqlContext: SQLContext, path: String): RDD[T] = {
+    val fs = FileSystem.get(sqlContext.sparkContext.hadoopConfiguration)
+    val inputFiles = fs.listStatus(new Path(path))
+    combineWithFiles[T](rdd, sqlContext, inputFiles)
+  }
+}

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.hive
 
-import org.apache.hadoop.fs.{Path, PathFilter}
+import org.apache.hadoop.fs.{FileSystem, Path, PathFilter}
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants._
 import org.apache.hadoop.hive.ql.exec.Utilities
@@ -35,6 +35,7 @@ import org.apache.spark.rdd.{EmptyRDD, HadoopRDD, RDD, UnionRDD}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
+import org.apache.spark.sql.sources.CombineSmallFile
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.{SerializableConfiguration, Utils}
 
@@ -283,7 +284,7 @@ class HadoopTableReader(
       _minSplitsPerRDD)
 
     // Only take the value (skip the key) because Hive works only with values.
-    rdd.map(_._2)
+    CombineSmallFile.combineWithPath(rdd, sc, path).map(_._2)
   }
 }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcRelation.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcRelation.scala
@@ -313,7 +313,7 @@ private[orc] case class OrcTableScan(
 
     val wrappedConf = new SerializableConfiguration(conf)
 
-    rdd.mapPartitionsWithInputSplit { case (split: OrcSplit, iterator) =>
+    val rddWithInputSplit = rdd.mapPartitionsWithInputSplit { case (split: OrcSplit, iterator) =>
       val mutableRow = new SpecificMutableRow(attributes.map(_.dataType))
       fillObject(
         split.getPath.toString,
@@ -322,6 +322,8 @@ private[orc] case class OrcTableScan(
         attributes.zipWithIndex,
         mutableRow)
     }
+
+    CombineSmallFile.combineWithFiles(rddWithInputSplit, sqlContext, inputPaths)
   }
 }
 


### PR DESCRIPTION
Many small files in table will lead to many small tasks in Spark. It will affect performance. So this patch use `coalesce` operator to combine small files in table. 
It'll cover `TableReader` and `HadoopFsRelation(ParquetRelation/OrcRelation/JSONRelation)`.
Many users use sql in `spark-sql` shell, and 

```
sqlContext.read.parquet("hdfs://some/path").coalesce(1).collect()
```

 advised by @liancheng is not convenience in this case.
This patch add two configurations below(if it is ok, I'll add them to doc):

| Property Name | Default | Meaning |
| --- | --- | --- |
| spark.sql.small.file.combine | true | Whether to combine small file. |
| spark.sql.small.file.split.size | 256000000 | The size of split after combine small file. |

/cc @liancheng @marmbrus @scwf 
