### PR TITLE
[SPARK-9879][SQL][WIP] Fix OOM in Limit clause with large number

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
@@ -192,6 +192,12 @@ private[spark] object SQLConf {
       "column based on statistics of the data.",
     isPublic = false)
 
+  val LIMIT_ROWS = longConf("spark.sql.limit.rows",
+    defaultValue = Some(100000L),
+    doc = "For the LIMIT clause, put all of the output rows in a single partition " +
+      "iif the required row number less than the threshold, otherwise fetch the rows in a " +
+      "distributed way to avoid the OOM.")
+
   val COLUMN_BATCH_SIZE = intConf("spark.sql.inMemoryColumnarStorage.batchSize",
     defaultValue = Some(10000),
     doc = "Controls the size of batches for columnar caching.  Larger batch sizes can improve " +
@@ -506,6 +512,8 @@ private[sql] class SQLConf extends Serializable with CatalystConf {
   private[spark] def broadcastTimeout: Int = getConf(BROADCAST_TIMEOUT)
 
   private[spark] def defaultDataSourceName: String = getConf(DEFAULT_DATA_SOURCE_NAME)
+
+  private[spark] def thresholdOfLimitClause: Long = getConf(LIMIT_ROWS)
 
   private[spark] def partitionDiscoveryEnabled(): Boolean =
     getConf(SQLConf.PARTITION_DISCOVERY_ENABLED)


### PR DESCRIPTION
```
create table tablsetest as select * from dpa_ord_bill_tf order by member_id limit 20000000
```

It causes OOM, and the error log as below:

```
15/07/27 10:22:43 ERROR ActorSystemImpl: Uncaught fatal error from thread [sparkDriver-akka.actor.default-dispatcher-20]shutting down ActorSystem [sparkDriver]
java.lang.OutOfMemoryError: Requested array size exceeds VM limit
at java.util.Arrays.copyOf(Arrays.java:2271)
at java.io.ByteArrayOutputStream.grow(ByteArrayOutputStream.java:113)
at java.io.ByteArrayOutputStream.ensureCapacity(ByteArrayOutputStream.java:93)
at java.io.ByteArrayOutputStream.write(ByteArrayOutputStream.java:140)
at java.io.ObjectOutputStream$BlockDataOutputStream.write(ObjectOutputStream.java:1852)
at java.io.ObjectOutputStream.write(ObjectOutputStream.java:708)
at org.apache.spark.util.Utils$$anon$2.write(Utils.scala:134)
at com.esotericsoftware.kryo.io.Output.flush(Output.java:155)
at com.esotericsoftware.kryo.io.Output.close(Output.java:165)
at org.apache.spark.serializer.KryoSerializationStream.close(KryoSerializer.scala:162)
at org.apache.spark.util.Utils$.serializeViaNestedStream(Utils.scala:139)
at org.apache.spark.rdd.ParallelCollectionPartition$$anonfun$writeObject$1.apply$mcV$sp(ParallelCollectionRDD.scala:65)
at org.apache.spark.util.Utils$.tryOrIOException(Utils.scala:1239)
at org.apache.spark.rdd.ParallelCollectionPartition.writeObject(ParallelCollectionRDD.scala:51)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.lang.reflect.Method.invoke(Method.java:606)
at java.io.ObjectStreamClass.invokeWriteObject(ObjectStreamClass.java:988)
at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1495)
at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1431)
at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1177)
at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1547)
at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1508)
at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1431)
at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1177)
at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:347)
at org.apache.spark.serializer.JavaSerializationStream.writeObject(JavaSerializer.scala:44)
at org.apache.spark.serializer.JavaSerializerInstance.serialize(JavaSerializer.scala:81)
at org.apache.spark.scheduler.Task$.serializeWithDependencies(Task.scala:168)
at org.apache.spark.scheduler.TaskSetManager.resourceOffer(TaskSetManager.scala:467)
at org.apache.spark.scheduler.TaskSchedulerImpl$$anonfun$org$apache$spark$scheduler$TaskSchedulerImpl$$resourceOfferSingleTaskSet$1.apply$mcVI$sp(TaskSchedulerImpl.scala:231)
15/07/27 10:22:43 ERROR ErrorMonitor: Uncaught fatal error from thread [sparkDriver-akka.actor.default-dispatcher-20]shutting down ActorSystem [sparkDriver]
java.lang.OutOfMemoryError: Requested array size exceeds VM limit
... 13 more
```

I create a new physical operator called `LargeLimit`, and will take effect when the `limit` is equal or greater than the `SqlConf.LIMIT_ROWS` in LIMIT clause.

`LargeLimit` will trigger the children RDD execution and persist its result, and we need to iterate the persisted data twice. The first iteration to get the number of records in each partition, then we can compute how many records we need to take from each of the partition, to satisfy the total number of records we need; in the second iteration, we just take the records from each of partition, according to the specified numbers.

The main advantage of this approach:
- No single node shuffle required, even no data shuffle required, and the result data is still in distributed mode.
- Keep the same output partitioning as its child.

One open issue, when to release the persisted data.
