### PR TITLE
[SPARK-9914] [ML] define setters explicitly for Java and use setParam group in RFormula

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
@@ -145,12 +145,6 @@ class RFormulaModel private[feature](
     pipelineModel: PipelineModel)
   extends Model[RFormulaModel] with RFormulaBase {
 
-  /** @group setParam */
-  def setFeaturesCol(value: String): this.type = set(featuresCol, value)
-
-  /** @group setParam */
-  def setLabelCol(value: String): this.type = set(labelCol, value)
-
   override def transform(dataset: DataFrame): DataFrame = {
     checkCanTransform(dataset.schema)
     transformLabel(pipelineModel.transform(dataset))

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/RFormula.scala
@@ -33,11 +33,6 @@ import org.apache.spark.sql.types._
  * Base trait for [[RFormula]] and [[RFormulaModel]].
  */
 private[feature] trait RFormulaBase extends HasFeaturesCol with HasLabelCol {
-  /** @group getParam */
-  def setFeaturesCol(value: String): this.type = set(featuresCol, value)
-
-  /** @group getParam */
-  def setLabelCol(value: String): this.type = set(labelCol, value)
 
   protected def hasLabelCol(schema: StructType): Boolean = {
     schema.map(_.name).contains($(labelCol))
@@ -70,6 +65,12 @@ class RFormula(override val uid: String) extends Estimator[RFormulaModel] with R
 
   /** @group getParam */
   def getFormula: String = $(formula)
+
+  /** @group setParam */
+  def setFeaturesCol(value: String): this.type = set(featuresCol, value)
+
+  /** @group setParam */
+  def setLabelCol(value: String): this.type = set(labelCol, value)
 
   /** Whether the formula specifies fitting an intercept. */
   private[ml] def hasIntercept: Boolean = {
@@ -143,6 +144,12 @@ class RFormulaModel private[feature](
     resolvedFormula: ResolvedRFormula,
     pipelineModel: PipelineModel)
   extends Model[RFormulaModel] with RFormulaBase {
+
+  /** @group setParam */
+  def setFeaturesCol(value: String): this.type = set(featuresCol, value)
+
+  /** @group setParam */
+  def setLabelCol(value: String): this.type = set(labelCol, value)
 
   override def transform(dataset: DataFrame): DataFrame = {
     checkCanTransform(dataset.schema)


### PR DESCRIPTION
The problem with defining setters in the base class is that it doesn't return the correct type in Java.

@ericl 
