### PR TITLE
[SPARK-9926] [SQL] parallelize file listing for partitioned Hive table

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -392,7 +392,8 @@ class SparkHadoopUtil extends Logging {
       inputFormat: FileInputFormat[_, _],
       minSplits: Int): Unit = {
     val inputSplits = inputFormat.getSplits(jobConf, minSplits)
-    val groupedInputSplits = inputSplits.groupBy(_.asInstanceOf[FileSplit].getPath.getParent.toString)
+    val groupedInputSplits =
+      inputSplits.groupBy(_.asInstanceOf[FileSplit].getPath.getParent.toString)
     inputPaths.foreach { partitionPath =>
       var files: Array[InputSplit] = Array()
       groupedInputSplits.foreach { case (commonParentPath, array) =>

--- a/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
@@ -35,7 +35,6 @@ import org.apache.hadoop.mapred.Reporter
 import org.apache.hadoop.mapred.JobID
 import org.apache.hadoop.mapred.TaskAttemptID
 import org.apache.hadoop.mapred.TaskID
-import org.apache.hadoop.mapred.FileInputFormat
 import org.apache.hadoop.mapred.lib.CombineFileSplit
 import org.apache.hadoop.util.ReflectionUtils
 
@@ -106,7 +105,8 @@ class HadoopRDD[K, V](
     inputFormatClass: Class[_ <: InputFormat[K, V]],
     keyClass: Class[K],
     valueClass: Class[V],
-    minPartitions: Int)
+    minPartitions: Int,
+    @transient inputSplitsCache: Option[Array[InputSplit]] = None)
   extends RDD[(K, V)](sc, Nil) with Logging {
 
   if (initLocalJobConfFuncOpt.isDefined) {
@@ -198,21 +198,17 @@ class HadoopRDD[K, V](
   }
 
   override def getPartitions: Array[Partition] = {
-    val jobConf = getJobConf()
-    val inputPaths = FileInputFormat.getInputPaths(jobConf).map(_.toString)
-    val inputSplits: Array[InputSplit] =
-      // first check whether input splits are already computed
-      if (SparkHadoopUtil.get.hasInputSplitsCache(inputPaths)) {
-        SparkHadoopUtil.get.getInputSplitsCache(inputPaths)
-      } else {
-        // add the credentials here as this can be called before SparkContext initialized
-        SparkHadoopUtil.get.addCredentials(jobConf)
-        val inputFormat = getInputFormat(jobConf)
-        if (inputFormat.isInstanceOf[Configurable]) {
-          inputFormat.asInstanceOf[Configurable].setConf(jobConf)
-        }
-        inputFormat.getSplits(jobConf, minPartitions)
+    // First check whether input splits are already computed
+    val inputSplits: Array[InputSplit] = inputSplitsCache.getOrElse {
+      val jobConf = getJobConf()
+      // Add the credentials here as this can be called before SparkContext initialized
+      SparkHadoopUtil.get.addCredentials(jobConf)
+      val inputFormat = getInputFormat(jobConf)
+      if (inputFormat.isInstanceOf[Configurable]) {
+        inputFormat.asInstanceOf[Configurable].setConf(jobConf)
       }
+      inputFormat.getSplits(jobConf, minPartitions)
+    }
     val array = new Array[Partition](inputSplits.size)
     for (i <- 0 until inputSplits.size) {
       array(i) = new HadoopPartition(id, i, inputSplits(i))

--- a/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
@@ -202,8 +202,8 @@ class HadoopRDD[K, V](
     val inputPaths = FileInputFormat.getInputPaths(jobConf).map(_.toString)
     val inputSplits: Array[InputSplit] =
       // first check whether input splits are already computed
-      if (SparkHadoopUtil.get.hasCache(inputPaths)) {
-        SparkHadoopUtil.get.getCache(inputPaths)
+      if (SparkHadoopUtil.get.hasInputSplitsCache(inputPaths)) {
+        SparkHadoopUtil.get.getInputSplitsCache(inputPaths)
       } else {
         // add the credentials here as this can be called before SparkContext initialized
         SparkHadoopUtil.get.addCredentials(jobConf)

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
@@ -311,6 +311,13 @@ private[spark] object SQLConf {
     defaultValue = Some(false),
     doc = "When true, enable filter pushdown for ORC files.")
 
+  val HIVE_PARALLEL_FILE_LISTING_ENABLED = booleanConf("spark.sql.hive.parallelFileListing",
+    defaultValue = Some(false),
+    doc = "When true, input files for multiple partitions will be listed in parallel in any " +
+      "partitioned Hive table backed by Hadoop storage such as HDFS and S3.  The parallelism " +
+      "is controlled by \"mapreduce.input.fileinputformat.list-status.num-threads\"."
+  )
+
   val HIVE_VERIFY_PARTITION_PATH = booleanConf("spark.sql.hive.verifyPartitionPath",
     defaultValue = Some(true),
     doc = "<TODO>")
@@ -471,6 +478,8 @@ private[sql] class SQLConf extends Serializable with CatalystConf {
   private[spark] def parquetFilterPushDown: Boolean = getConf(PARQUET_FILTER_PUSHDOWN_ENABLED)
 
   private[spark] def orcFilterPushDown: Boolean = getConf(ORC_FILTER_PUSHDOWN_ENABLED)
+
+  private[spark] def parallelFileListing: Boolean = getConf(HIVE_PARALLEL_FILE_LISTING_ENABLED)
 
   private[spark] def verifyPartitionPath: Boolean = getConf(HIVE_VERIFY_PARTITION_PATH)
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.hive
 
+import scala.collection.mutable.ArrayBuffer
+
 import org.apache.hadoop.fs.{Path, PathFilter}
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants._
@@ -27,7 +29,7 @@ import org.apache.hadoop.hive.serde2.Deserializer
 import org.apache.hadoop.hive.serde2.objectinspector.primitive._
 import org.apache.hadoop.hive.serde2.objectinspector.{ObjectInspectorConverters, StructObjectInspector}
 import org.apache.hadoop.io.Writable
-import org.apache.hadoop.mapred.{FileInputFormat, InputFormat, JobConf}
+import org.apache.hadoop.mapred.{FileInputFormat, FileSplit, InputFormat, InputSplit, JobConf}
 import org.apache.hadoop.util.ReflectionUtils
 
 import org.apache.spark.Logging
@@ -186,6 +188,46 @@ class HadoopTableReader(
 
     val hivePartitions = verifyPartitionPath(partitionToDeserializer)
 
+    // This map holds input splits per Hive partition path.
+    val inputSplitsCache = collection.mutable.Map[String, ArrayBuffer[InputSplit]]()
+
+    // Compute input splits for all the partitions together if they have the same input format.
+    // This is faster than computing them individually because listing multiple input dirs can be
+    // done in parallel using "mapreduce.input.fileinputformat.list-status.num-threads".
+    if (sc.conf.parallelFileListing) {
+      val inputFormatClass = hivePartitions.head._1.getInputFormatClass
+      val homogeneousInputFormat = hivePartitions.forall {
+        case (part, _) => part.getInputFormatClass == inputFormatClass
+      }
+
+      if (homogeneousInputFormat) {
+        val jobConf = new JobConf(hiveExtraConf)
+        val minPartitions = _minSplitsPerRDD * hivePartitions.size
+        val combinedPaths = hivePartitions.map { case (part, _) =>
+          applyFilterIfNeeded(part.getDataLocation, filterOpt)
+        }.mkString(",")
+        val inputFormat = ReflectionUtils
+          .newInstance(inputFormatClass.asInstanceOf[Class[_]], jobConf)
+          .asInstanceOf[FileInputFormat[_, _]]
+        HadoopTableReader.initializeLocalJobConfFunc(combinedPaths, relation.tableDesc)(jobConf)
+        SparkHadoopUtil.get.addCredentials(jobConf)
+        val inputSplits = inputFormat.getSplits(jobConf, minPartitions)
+        val groupedInputSplits = inputSplits.groupBy(_.asInstanceOf[FileSplit].getPath.getParent)
+        for (path <- combinedPaths.split(",")) {
+          val cache = inputSplitsCache.get(path).getOrElse {
+            val emptyArray: ArrayBuffer[InputSplit] = ArrayBuffer()
+            inputSplitsCache.put(path, emptyArray)
+            emptyArray
+          }
+          for ((key, values) <- groupedInputSplits) {
+            if (key.toString.startsWith(path)) {
+              cache ++= values
+            }
+          }
+        }
+      }
+    }
+
     val hivePartitionRDDs = hivePartitions.map { case (partition, partDeserializer) =>
       val partDesc = Utilities.getPartitionDesc(partition)
       val partPath = partition.getDataLocation
@@ -229,7 +271,9 @@ class HadoopTableReader(
       // Fill all partition keys to the given MutableRow object
       fillPartitionKeys(partValues, mutableRow)
 
-      createHadoopRdd(tableDesc, inputPathStr, ifc).mapPartitions { iter =>
+      val inputSplits = inputSplitsCache.get(inputPathStr).map(_.toArray)
+
+      createHadoopRdd(tableDesc, inputPathStr, ifc, inputSplits).mapPartitions { iter =>
         val hconf = broadcastedHiveConf.value.value
         val deserializer = localDeserializer.newInstance()
         deserializer.initialize(hconf, partProps)
@@ -242,30 +286,6 @@ class HadoopTableReader(
           mutableRow, tableSerDe)
       }
     }.toSeq
-
-    // Compute input splits for all the partitions together if they have the same input format.
-    // This is faster than computing them individually because listing multiple input dirs can be
-    // done in parallel using "mapreduce.input.fileinputformat.list-status.num-threads".
-    if (sc.conf.parallelFileListing) {
-      val homogeneousInputFormat =
-        if (hivePartitions.groupBy { case (part, _) => part.getInputFormatClass }.size == 1) {
-          true
-        } else {
-          false
-        }
-
-      if (homogeneousInputFormat) {
-        val combinedPaths = hivePartitions.map { case (part, _) => part.getLocation }.toSeq
-        val jobConf = new JobConf(hiveExtraConf)
-        val minPartitions = _minSplitsPerRDD * hivePartitions.size
-        val inputFormatClass = hivePartitions.head._1.getInputFormatClass
-        HadoopTableReader.initializeLocalJobConfFunc(combinedPaths, relation.tableDesc)(jobConf)
-        val inputFormat =
-          ReflectionUtils.newInstance(inputFormatClass.asInstanceOf[Class[_]], jobConf)
-            .asInstanceOf[FileInputFormat[_, _]]
-        SparkHadoopUtil.get.computeInputSplits(combinedPaths, jobConf, inputFormat, minPartitions)
-      }
-    }
 
     // Even if we don't use any partitions, we still need an empty RDD
     if (hivePartitionRDDs.size == 0) {
@@ -296,9 +316,10 @@ class HadoopTableReader(
   private def createHadoopRdd(
     tableDesc: TableDesc,
     path: String,
-    inputFormatClass: Class[InputFormat[Writable, Writable]]): RDD[Writable] = {
+    inputFormatClass: Class[InputFormat[Writable, Writable]],
+    inputSplitsCache: Option[Array[InputSplit]] = None): RDD[Writable] = {
 
-    val initializeJobConfFunc = HadoopTableReader.initializeLocalJobConfFunc(Seq(path), tableDesc) _
+    val initializeJobConfFunc = HadoopTableReader.initializeLocalJobConfFunc(path, tableDesc) _
 
     val rdd = new HadoopRDD(
       sc.sparkContext,
@@ -307,7 +328,8 @@ class HadoopTableReader(
       inputFormatClass,
       classOf[Writable],
       classOf[Writable],
-      _minSplitsPerRDD)
+      _minSplitsPerRDD,
+      inputSplitsCache)
 
     // Only take the value (skip the key) because Hive works only with values.
     rdd.map(_._2)
@@ -319,8 +341,8 @@ private[hive] object HadoopTableReader extends HiveInspectors with Logging {
    * Curried. After given an argument for 'path', the resulting JobConf => Unit closure is used to
    * instantiate a HadoopRDD.
    */
-  def initializeLocalJobConfFunc(path: Seq[String], tableDesc: TableDesc)(jobConf: JobConf) {
-    FileInputFormat.setInputPaths(jobConf, path.map(new Path(_)): _*)
+  def initializeLocalJobConfFunc(path: String, tableDesc: TableDesc)(jobConf: JobConf) {
+    FileInputFormat.setInputPaths(jobConf, path.split(",").map(new Path(_)): _*)
     if (tableDesc != null) {
       PlanUtils.configureInputJobPropertiesForStorageHandler(tableDesc)
       Utilities.copyTableJobPropertiesToConf(tableDesc, jobConf)


### PR DESCRIPTION
Instead of listing files on a per-partition basis, listing all the partitions together in parallel improves query performance quite a bit.

Here are benchmark results of my test query in the [jira](https://issues.apache.org/jira/browse/SPARK-9926) w/ setting `mapreduce.input.fileinputformat.list-status.num-threads` to 25-
- Parquet-backed Hive table
- Partitioned by dateint and hour
- Stored on S3

| # of files | # of partitions | before | after | improvement |
| --- | --- | --- | --- | --- |
| 972 | 1 | 38 secs | 20 secs | 1.9x |
| 13646 | 24 | 354  secs | 28 secs | 12x |
| 136222 | 240 | 3507  secs | 156 secs | 22x |

The changes include-
- Added a new property `spark.sql.hive.parallelFileListing` that enables parallel file listing in a partitioned Hive table backed by Hadoop storage such as HDFS and S3. By default, false.
- When the property is true, `TableReader` computes input splits for all the partitions in parallel and cache them in `HadoopRDD`.
- In `HadoopRDD.getPartitions()`, first check whether input splits are already computed, and if so, reuse them.
