### PR TITLE
[SPARK-9927][SQL]Revert 8049 since it's pushing wrong filter down

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -284,7 +284,7 @@ private[sql] class JDBCRDD(
   /**
    * `filters`, but as a WHERE clause suitable for injection into a SQL query.
    */
-  val filterWhereClause: String = {
+  private val filterWhereClause: String = {
     val filterStrings = filters map compileFilter filter (_ != null)
     if (filterStrings.size > 0) {
       val sb = new StringBuilder("WHERE ")

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -25,8 +25,6 @@ import org.h2.jdbc.JdbcSQLException
 import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.sql.execution.datasources.jdbc.JDBCRDD
-import org.apache.spark.sql.execution.PhysicalRDD
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 
@@ -148,18 +146,6 @@ class JDBCSuite extends SparkFunSuite with BeforeAndAfter {
         |CREATE TEMPORARY TABLE flttypes
         |USING org.apache.spark.sql.jdbc
         |OPTIONS (url '$url', dbtable 'TEST.FLTTYPES', user 'testUser', password 'testPass')
-      """.stripMargin.replaceAll("\n", " "))
-
-    conn.prepareStatement("create table test.decimals (a DECIMAL(7, 2), b DECIMAL(4, 0))").
-      executeUpdate()
-    conn.prepareStatement("insert into test.decimals values (12345.67, 1234)").executeUpdate()
-    conn.prepareStatement("insert into test.decimals values (34567.89, 1428)").executeUpdate()
-    conn.commit()
-    sql(
-      s"""
-         |CREATE TEMPORARY TABLE decimals
-         |USING org.apache.spark.sql.jdbc
-         |OPTIONS (url '$url', dbtable 'TEST.DECIMALS', user 'testUser', password 'testPass')
       """.stripMargin.replaceAll("\n", " "))
 
     conn.prepareStatement(
@@ -457,26 +443,5 @@ class JDBCSuite extends SparkFunSuite with BeforeAndAfter {
     assert(!agg.canHandle("jdbc:h2"))
     assert(agg.getCatalystType(0, "", 1, null) === Some(LongType))
     assert(agg.getCatalystType(1, "", 1, null) === Some(StringType))
-  }
-
-  test("SPARK-9182: filters are not passed through to jdbc source") {
-    def checkPushedFilter(query: String, filterStr: String): Unit = {
-      val rddOpt = sql(query).queryExecution.executedPlan.collectFirst {
-        case PhysicalRDD(_, rdd: JDBCRDD, _) => rdd
-      }
-      assert(rddOpt.isDefined)
-      val pushedFilterStr = rddOpt.get.filterWhereClause
-      assert(pushedFilterStr.contains(filterStr),
-        s"Expected to push [$filterStr], actually we pushed [$pushedFilterStr]")
-    }
-
-    checkPushedFilter("select * from foobar where NAME = 'fred'", "NAME = 'fred'")
-    checkPushedFilter("select * from inttypes where A > '15'", "A > 15")
-    checkPushedFilter("select * from inttypes where C <= 20", "C <= 20")
-    checkPushedFilter("select * from decimals where A > 1000", "A > 1000.00")
-    checkPushedFilter("select * from decimals where A > 1000 AND A < 2000",
-      "A > 1000.00 AND A < 2000.00")
-    checkPushedFilter("select * from decimals where A = 2000 AND B > 20", "A = 2000.00 AND B > 20")
-    checkPushedFilter("select * from timetypes where B > '1998-09-10'", "B > 1998-09-10")
   }
 }


### PR DESCRIPTION
I made a mistake in #8049 by casting literal value to attribute's data type, which would cause simply truncate the literal value and push a wrong filter down.

JIRA: https://issues.apache.org/jira/browse/SPARK-9927
