### PR TITLE
[SPARK-9793] [MLlib] [PySpark] PySpark DenseVector, SparseVector implement __eq__ and __hash__ correctly

### DIFF
--- a/python/pyspark/mllib/linalg/__init__.py
+++ b/python/pyspark/mllib/linalg/__init__.py
@@ -124,12 +124,10 @@ def _format_float_list(l):
 
 
 def _double_to_long_bits(value):
-    if value != value:
-        # value is NaN, standardize to canonical non-signaling NaN
-        return 0x7ff8000000000000
-    else:
-        # pack double into 64 bits, then unpack as long int
-        return struct.unpack('Q', struct.pack('d', value))[0]
+    if np.isnan(value):
+        value = float('nan')
+    # pack double into 64 bits, then unpack as long int
+    return struct.unpack('Q', struct.pack('d', value))[0]
 
 
 class VectorUDT(UserDefinedType):

--- a/python/pyspark/mllib/linalg/__init__.py
+++ b/python/pyspark/mllib/linalg/__init__.py
@@ -933,7 +933,8 @@ class Vectors(object):
     @staticmethod
     def equals(v1_indices, v1_values, v2_indices, v2_values):
         """
-        Check equality between sparse/dense vectors
+        Check equality between sparse/dense vectors,
+        v1_indices and v2_indices assume to be strictly increasing.
 
         >>> indices = [1, 2, 4]
         >>> values = [1., 3., 2.]

--- a/python/pyspark/mllib/linalg/__init__.py
+++ b/python/pyspark/mllib/linalg/__init__.py
@@ -418,9 +418,9 @@ class DenseVector(Vector):
             return np.array_equal(self.array, other.array)
         elif isinstance(other, SparseVector):
             if len(self) != other.size:
-                return false
-            return Vectors.equals(list(xrange(len(self))), self.array, other.indices, other.values)
-        return NotImplemented
+                return False
+            return Vectors._equals(list(xrange(len(self))), self.array, other.indices, other.values)
+        return False
 
     def __ne__(self, other):
         return not self == other
@@ -739,9 +739,9 @@ class SparseVector(Vector):
                 and np.array_equal(other.values, self.values)
         elif isinstance(other, DenseVector):
             if self.size != len(other):
-                return false
-            return Vectors.equals(self.indices, self.values, list(xrange(len(other))), other.array)
-        return NotImplemented
+                return False
+            return Vectors._equals(self.indices, self.values, list(xrange(len(other))), other.array)
+        return False
 
     def __getitem__(self, index):
         inds = self.indices
@@ -879,21 +879,10 @@ class Vectors(object):
         return DenseVector(np.zeros(size))
 
     @staticmethod
-    def equals(v1_indices, v1_values, v2_indices, v2_values):
+    def _equals(v1_indices, v1_values, v2_indices, v2_values):
         """
         Check equality between sparse/dense vectors,
         v1_indices and v2_indices assume to be strictly increasing.
-
-        >>> indices = [1, 2, 4]
-        >>> values = [1., 3., 2.]
-        >>> Vectors.equals(indices, values, list(range(5)), [0., 1., 3., 0., 2.])
-        True
-        >>> Vectors.equals(indices, values, list(range(5)), [0., 3., 1., 0., 2.])
-        False
-        >>> Vectors.equals(indices, values, list(range(5)), [0., 3., 0., 2.])
-        False
-        >>> Vectors.equals(indices, values, list(range(5)), [0., 1., 3., 2., 2.])
-        False
         """
         v1_size = len(v1_values)
         v2_size = len(v2_values)

--- a/python/pyspark/mllib/linalg/__init__.py
+++ b/python/pyspark/mllib/linalg/__init__.py
@@ -441,6 +441,7 @@ class DenseVector(Vector):
     def __hash__(self):
         """
         Compute hashcode
+
         >>> v1 = DenseVector([0.0, 1.0, 0.0, 5.5])
         >>> v2 = SparseVector(4, [(1, 1.0), (3, 5.5)])
         >>> hash(v1) == hash(v2)
@@ -454,14 +455,14 @@ class DenseVector(Vector):
         """
         size = len(self)
         result = 31 + size
-        count = 0
+        nnz = 0
         i = 0
-        while i < size and count < 16:
+        while i < size and nnz < 128:
             if self.array[i] != 0:
-                bits = _double_to_long_bits(self.array[i] + i)
+                result = 31 * result + i
+                bits = _double_to_long_bits(self.array[i])
                 result = 31 * result + (bits ^ (bits >> 32))
-
-            count += 1
+                nnz += 1
             i += 1
         return result
 
@@ -805,6 +806,7 @@ class SparseVector(Vector):
     def __hash__(self):
         """
         Compute hashcode
+
         >>> v1 = SparseVector(4, [(1, 1.0), (3, 5.5)])
         >>> v2 = SparseVector(4, [(1, 1.0), (3, 5.5)])
         >>> hash(v1) == hash(v2)
@@ -817,14 +819,14 @@ class SparseVector(Vector):
         False
         """
         result = 31 + self.size
-        count = 0
+        nnz = 0
         i = 0
-        while i < len(self.values) and count < 16:
+        while i < len(self.values) and nnz < 128:
             if self.values[i] != 0:
-                bits = _double_to_long_bits(self.values[i] + self.indices[i])
+                result = 31 * result + int(self.indices[i])
+                bits = _double_to_long_bits(self.values[i])
                 result = 31 * result + (bits ^ (bits >> 32))
-
-            count += 1
+                nnz += 1
             i += 1
         return result
 

--- a/python/pyspark/mllib/linalg/__init__.py
+++ b/python/pyspark/mllib/linalg/__init__.py
@@ -25,6 +25,7 @@ SciPy is available in their environment.
 
 import sys
 import array
+import struct
 
 if sys.version >= '3':
     basestring = str
@@ -120,6 +121,15 @@ def _format_float(f, digits=4):
 
 def _format_float_list(l):
     return [_format_float(x) for x in l]
+
+
+def _double_to_long_bits(value):
+    if value != value:
+        # value is NaN, standardize to canonical non-signaling NaN
+        return 0x7ff8000000000000
+    else:
+        # pack double into 64 bits, then unpack as long int
+        return struct.unpack('Q', struct.pack('d', value))[0]
 
 
 class VectorUDT(UserDefinedType):
@@ -427,6 +437,33 @@ class DenseVector(Vector):
 
     def __ne__(self, other):
         return not self == other
+
+    def __hash__(self):
+        """
+        Compute hashcode
+        >>> v1 = DenseVector([0.0, 1.0, 0.0, 5.5])
+        >>> v2 = SparseVector(4, [(1, 1.0), (3, 5.5)])
+        >>> hash(v1) == hash(v2)
+        True
+        >>> v2 = DenseVector([0.0, 1.0, 0.0, 5.5])
+        >>> hash(v1) == hash(v2)
+        True
+        >>> v2 = DenseVector([1.0, 1.0, 0.0, 5.5])
+        >>> hash(v1) == hash(v2)
+        False
+        """
+        size = len(self)
+        result = 31 + size
+        count = 0
+        i = 0
+        while i < size and count < 16:
+            if self.array[i] != 0:
+                bits = _double_to_long_bits(self.array[i] + i)
+                result = 31 * result + (bits ^ (bits >> 32))
+
+            count += 1
+            i += 1
+        return result
 
     def __getattr__(self, item):
         return getattr(self.array, item)
@@ -764,6 +801,32 @@ class SparseVector(Vector):
 
     def __ne__(self, other):
         return not self.__eq__(other)
+
+    def __hash__(self):
+        """
+        Compute hashcode
+        >>> v1 = SparseVector(4, [(1, 1.0), (3, 5.5)])
+        >>> v2 = SparseVector(4, [(1, 1.0), (3, 5.5)])
+        >>> hash(v1) == hash(v2)
+        True
+        >>> v2 = SparseVector(4, [(1, 1.0), (3, 2.5)])
+        >>> hash(v1) == hash(v2)
+        False
+        >>> v2 = SparseVector(4, [(2, 1.0), (3, 5.5)])
+        >>> hash(v1) == hash(v2)
+        False
+        """
+        result = 31 + self.size
+        count = 0
+        i = 0
+        while i < len(self.values) and count < 16:
+            if self.values[i] != 0:
+                bits = _double_to_long_bits(self.values[i] + self.indices[i])
+                result = 31 * result + (bits ^ (bits >> 32))
+
+            count += 1
+            i += 1
+        return result
 
 
 class Vectors(object):

--- a/python/pyspark/mllib/linalg/__init__.py
+++ b/python/pyspark/mllib/linalg/__init__.py
@@ -414,19 +414,6 @@ class DenseVector(Vector):
         return "DenseVector([%s])" % (', '.join(_format_float(i) for i in self.array))
 
     def __eq__(self, other):
-        """
-        Test DenseVector for equality.
-
-        >>> v1 = DenseVector([0.0, 1.0, 0.0, 5.5])
-        >>> v2 = SparseVector(4, [(1, 1.0), (3, 5.5)])
-        >>> v1 == v2
-        True
-        >>> v1 != v2
-        False
-        >>> v3 = DenseVector([0.0, 1.0, 0.0, 5.5])
-        >>> v1 == v3
-        True
-        """
         if isinstance(other, DenseVector):
             return np.array_equal(self.array, other.array)
         elif isinstance(other, SparseVector):
@@ -439,20 +426,6 @@ class DenseVector(Vector):
         return not self == other
 
     def __hash__(self):
-        """
-        Compute hashcode
-
-        >>> v1 = DenseVector([0.0, 1.0, 0.0, 5.5])
-        >>> v2 = SparseVector(4, [(1, 1.0), (3, 5.5)])
-        >>> hash(v1) == hash(v2)
-        True
-        >>> v2 = DenseVector([0.0, 1.0, 0.0, 5.5])
-        >>> hash(v1) == hash(v2)
-        True
-        >>> v2 = DenseVector([1.0, 1.0, 0.0, 5.5])
-        >>> hash(v1) == hash(v2)
-        False
-        """
         size = len(self)
         result = 31 + size
         nnz = 0
@@ -761,19 +734,6 @@ class SparseVector(Vector):
         return "SparseVector({0}, {{{1}}})".format(self.size, entries)
 
     def __eq__(self, other):
-        """
-        Test SparseVectors for equality.
-
-        >>> v1 = SparseVector(4, [(1, 1.0), (3, 5.5)])
-        >>> v2 = SparseVector(4, [(1, 1.0), (3, 5.5)])
-        >>> v1 == v2
-        True
-        >>> v1 != v2
-        False
-        >>> v3 = DenseVector([0.0, 1.0, 0.0, 5.5])
-        >>> v1 == v3
-        True
-        """
         if isinstance(other, SparseVector):
             return other.size == self.size and np.array_equal(other.indices, self.indices) \
                 and np.array_equal(other.values, self.values)
@@ -804,20 +764,6 @@ class SparseVector(Vector):
         return not self.__eq__(other)
 
     def __hash__(self):
-        """
-        Compute hashcode
-
-        >>> v1 = SparseVector(4, [(1, 1.0), (3, 5.5)])
-        >>> v2 = SparseVector(4, [(1, 1.0), (3, 5.5)])
-        >>> hash(v1) == hash(v2)
-        True
-        >>> v2 = SparseVector(4, [(1, 1.0), (3, 2.5)])
-        >>> hash(v1) == hash(v2)
-        False
-        >>> v2 = SparseVector(4, [(2, 1.0), (3, 5.5)])
-        >>> hash(v1) == hash(v2)
-        False
-        """
         result = 31 + self.size
         nnz = 0
         i = 0

--- a/python/pyspark/mllib/tests.py
+++ b/python/pyspark/mllib/tests.py
@@ -208,14 +208,22 @@ class VectorTests(MLlibTestCase):
         v1 = DenseVector([0.0, 1.0, 0.0, 5.5])
         v2 = SparseVector(4, [(1, 1.0), (3, 5.5)])
         v3 = DenseVector([0.0, 1.0, 0.0, 5.5])
-        v4 = SparseVector(4, [(1, 1.0), (3, 5.5)])
+        v4 = SparseVector(6, [(1, 1.0), (3, 5.5)])
         v5 = DenseVector([0.0, 1.0, 0.0, 2.5])
         v6 = SparseVector(4, [(1, 1.0), (3, 2.5)])
         self.assertTrue(v1 == v2)
         self.assertTrue(v1 == v3)
-        self.assertTrue(v2 == v4)
+        self.assertFalse(v2 == v4)
         self.assertFalse(v1 == v5)
         self.assertFalse(v1 == v6)
+
+    def test_equals(self):
+        indices = [1, 2, 4]
+        values = [1., 3., 2.]
+        self.assertTrue(Vectors._equals(indices, values, list(range(5)), [0., 1., 3., 0., 2.]))
+        self.assertFalse(Vectors._equals(indices, values, list(range(5)), [0., 3., 1., 0., 2.]))
+        self.assertFalse(Vectors._equals(indices, values, list(range(5)), [0., 3., 0., 2.]))
+        self.assertFalse(Vectors._equals(indices, values, list(range(5)), [0., 1., 3., 2., 2.]))
 
     def test_conversion(self):
         # numpy arrays should be automatically upcast to float64

--- a/python/pyspark/mllib/tests.py
+++ b/python/pyspark/mllib/tests.py
@@ -194,6 +194,29 @@ class VectorTests(MLlibTestCase):
         self.assertEquals(3.0, _squared_distance(sv, arr))
         self.assertEquals(3.0, _squared_distance(sv, narr))
 
+    def test_hash(self):
+        v1 = DenseVector([0.0, 1.0, 0.0, 5.5])
+        v2 = SparseVector(4, [(1, 1.0), (3, 5.5)])
+        v3 = DenseVector([1.0, 1.0, 0.0, 5.5])
+        v4 = SparseVector(4, [(1, 1.0), (3, 2.5)])
+        self.assertTrue(hash(v1) == hash(v2))
+        self.assertFalse(hash(v1) == hash(v3))
+        self.assertFalse(hash(v2) == hash(v3))
+        self.assertFalse(hash(v2) == hash(v4))
+
+    def test_eq(self):
+        v1 = DenseVector([0.0, 1.0, 0.0, 5.5])
+        v2 = SparseVector(4, [(1, 1.0), (3, 5.5)])
+        v3 = DenseVector([0.0, 1.0, 0.0, 5.5])
+        v4 = SparseVector(4, [(1, 1.0), (3, 5.5)])
+        v5 = DenseVector([0.0, 1.0, 0.0, 2.5])
+        v6 = SparseVector(4, [(1, 1.0), (3, 2.5)])
+        self.assertTrue(v1 == v2)
+        self.assertTrue(v1 == v3)
+        self.assertTrue(v2 == v4)
+        self.assertFalse(v1 == v5)
+        self.assertFalse(v1 == v6)
+
     def test_conversion(self):
         # numpy arrays should be automatically upcast to float64
         # tests for fix of [SPARK-5089]

--- a/python/pyspark/mllib/tests.py
+++ b/python/pyspark/mllib/tests.py
@@ -197,11 +197,12 @@ class VectorTests(MLlibTestCase):
     def test_hash(self):
         v1 = DenseVector([0.0, 1.0, 0.0, 5.5])
         v2 = SparseVector(4, [(1, 1.0), (3, 5.5)])
-        v3 = DenseVector([1.0, 1.0, 0.0, 5.5])
+        v3 = DenseVector([0.0, 1.0, 0.0, 5.5])
         v4 = SparseVector(4, [(1, 1.0), (3, 2.5)])
-        self.assertTrue(hash(v1) == hash(v2))
-        self.assertFalse(hash(v1) == hash(v3))
-        self.assertFalse(hash(v2) == hash(v3))
+        self.assertEquals(hash(v1), hash(v2))
+        self.assertEquals(hash(v1), hash(v3))
+        self.assertEquals(hash(v2), hash(v3))
+        self.assertFalse(hash(v1) == hash(v4))
         self.assertFalse(hash(v2) == hash(v4))
 
     def test_eq(self):
@@ -211,8 +212,8 @@ class VectorTests(MLlibTestCase):
         v4 = SparseVector(6, [(1, 1.0), (3, 5.5)])
         v5 = DenseVector([0.0, 1.0, 0.0, 2.5])
         v6 = SparseVector(4, [(1, 1.0), (3, 2.5)])
-        self.assertTrue(v1 == v2)
-        self.assertTrue(v1 == v3)
+        self.assertEquals(v1, v2)
+        self.assertEquals(v1, v3)
         self.assertFalse(v2 == v4)
         self.assertFalse(v1 == v5)
         self.assertFalse(v1 == v6)


### PR DESCRIPTION
PySpark DenseVector, SparseVector `__eq__` method should use semantics equality, and DenseVector can compared with SparseVector.
Implement PySpark DenseVector, SparseVector `__hash__` method based on the first 16 entries. That will make PySpark Vector objects can be used in collections.
