### PR TITLE
[SPARK-9942] [PYSPARK] [SQL] ignore exceptions while try to import pandas

### DIFF
--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -39,7 +39,7 @@ from pyspark.sql.functions import UserDefinedFunction
 try:
     import pandas
     has_pandas = True
-except ImportError:
+except Exception:
     has_pandas = False
 
 __all__ = ["SQLContext", "HiveContext", "UDFRegistration"]


### PR DESCRIPTION
If pandas is broken (can't be imported, raise other exceptions other than ImportError), pyspark can't be imported, we should ignore all the exceptions.
