### PR TITLE
[SPARK-8976] [PySpark] fix open mode in python3

### DIFF
--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -146,5 +146,5 @@ if __name__ == '__main__':
     java_port = int(sys.stdin.readline())
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.connect(("127.0.0.1", java_port))
-    sock_file = sock.makefile("a+", 65536)
+    sock_file = sock.makefile("rwb", 65536)
     main(sock_file, sock_file)


### PR DESCRIPTION
This bug only happen on Python 3 and Windows.

I tested this manually with python 3 and disable python daemon, no unit test yet.
