### PR TITLE
[SPARK-9923][Core]: ShuffleMapStage.numAvailableOutputs should be an Int instead of Long

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapStage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapStage.scala
@@ -37,7 +37,7 @@ private[spark] class ShuffleMapStage(
 
   override def toString: String = "ShuffleMapStage " + id
 
-  var numAvailableOutputs: Long = 0
+  var numAvailableOutputs: Int = 0
 
   def isAvailable: Boolean = numAvailableOutputs == numPartitions
 


### PR DESCRIPTION
Modified type of ShuffleMapStage.numAvailableOutputs from Long to Int
