### PR TITLE
[SPARK-9973][SQL]correct buffer size

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/columnar/InMemoryColumnarTableScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/columnar/InMemoryColumnarTableScan.scala
@@ -121,8 +121,7 @@ private[sql] case class InMemoryRelation(
         def next(): CachedBatch = {
           val columnBuilders = output.map { attribute =>
             val columnType = ColumnType(attribute.dataType)
-            val initialBufferSize = columnType.defaultSize * batchSize
-            ColumnBuilder(attribute.dataType, initialBufferSize, attribute.name, useCompression)
+            ColumnBuilder(attribute.dataType, batchSize, attribute.name, useCompression)
           }.toArray
 
           var rowCount = 0


### PR DESCRIPTION
When cache table in memory in spark sql, we allocate too more memory.

InMemoryColumnarTableScan.class
  val initialBufferSize = columnType.defaultSize \* batchSize
  ColumnBuilder(attribute.dataType, initialBufferSize, attribute.name, useCompression)

BasicColumnBuilder.class
  buffer = ByteBuffer.allocate(4 + size \* columnType.defaultSize)

So total allocate size is (4+ size \* columnType.defaultSize  \* columnType.defaultSize), We should change it to 4+ size \* columnType.defaultSize.
