### PR TITLE
[SPARK-9899] [SQL] Fixes HadoopFsRelation speculative writes when used together with direct output committer

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcRelation.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcRelation.scala
@@ -113,9 +113,12 @@ private[orc] class OrcOutputWriter(
     val uniqueWriteJobId = conf.get("spark.sql.sources.writeJobUUID")
     val partition = context.getTaskAttemptID.getTaskID.getId
     val filename = f"part-r-$partition%05d-$uniqueWriteJobId.orc"
+    val filePath = new Path(path, filename)
+    val fs = filePath.getFileSystem(conf)
+    fs.delete(filePath, false)
 
     new OrcOutputFormat().getRecordWriter(
-      new Path(path, filename).getFileSystem(conf),
+      fs,
       conf.asInstanceOf[JobConf],
       new Path(path, filename).toString,
       Reporter.NULL


### PR DESCRIPTION
Hadoop output format classes call `FileSystem.create()` to create output files, and set `overwrite` argument to `false`. This causes trouble for speculative write tasks when a direct output committer is used, since previous tasks may leave partial output files there.

This PR tries to fix this issue by removing the output file when generating output file paths. This is equivalent to creating output files with `overwrite` flag set to `true`.
