### PR TITLE
[SPARK-8887][SQL]Explicit define which data types can be used as dynamic partition columns

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -26,6 +26,7 @@ import scala.util.Try
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.util.Shell
 
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Cast, Literal}
 import org.apache.spark.sql.types._
@@ -270,7 +271,17 @@ private[sql] object PartitioningUtils {
   private val upCastingOrder: Seq[DataType] =
     Seq(NullType, IntegerType, LongType, FloatType, DoubleType, StringType)
 
-  val validPartitionColumnTypes: Set[DataType] = upCastingOrder.toSet
+  def checkPartitionColumnOfValidDataType(
+      schema: StructType,
+      partitionColumns: Array[String]): Unit = {
+
+    ResolvedDataSource.partitionColumnsSchema(schema, partitionColumns).foreach { field =>
+      field.dataType match {
+        case _: AtomicType | NullType => // OK
+        case _ => throw new AnalysisException(s"Cannot use ${field.dataType} for partition column")
+      }
+    }
+  }
 
   /**
    * Given a collection of [[Literal]]s, resolves possible type conflicts by up-casting "lower"

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -270,6 +270,8 @@ private[sql] object PartitioningUtils {
   private val upCastingOrder: Seq[DataType] =
     Seq(NullType, IntegerType, LongType, FloatType, DoubleType, StringType)
 
+  val validPartitionColumnTypes: Set[DataType] = upCastingOrder.toSet
+
   /**
    * Given a collection of [[Literal]]s, resolves possible type conflicts by up-casting "lower"
    * types.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -271,13 +271,13 @@ private[sql] object PartitioningUtils {
   private val upCastingOrder: Seq[DataType] =
     Seq(NullType, IntegerType, LongType, FloatType, DoubleType, StringType)
 
-  def checkPartitionColumnOfValidDataType(
+  def validatePartitionColumnDataTypes(
       schema: StructType,
       partitionColumns: Array[String]): Unit = {
 
     ResolvedDataSource.partitionColumnsSchema(schema, partitionColumns).foreach { field =>
       field.dataType match {
-        case _: AtomicType | NullType => // OK
+        case _: AtomicType => // OK
         case _ => throw new AnalysisException(s"Cannot use ${field.dataType} for partition column")
       }
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ResolvedDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ResolvedDataSource.scala
@@ -180,7 +180,7 @@ object ResolvedDataSource extends Logging {
           path.makeQualified(fs.getUri, fs.getWorkingDirectory)
         }
 
-        PartitioningUtils.checkPartitionColumnOfValidDataType(data.schema, partitionColumns)
+        PartitioningUtils.validatePartitionColumnDataTypes(data.schema, partitionColumns)
 
         val dataSchema = StructType(data.schema.filterNot(f => partitionColumns.contains(f.name)))
         val r = dataSource.createRelation(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ResolvedDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ResolvedDataSource.scala
@@ -180,11 +180,7 @@ object ResolvedDataSource extends Logging {
           path.makeQualified(fs.getUri, fs.getWorkingDirectory)
         }
 
-        partitionColumnsSchema(data.schema, partitionColumns).foreach { field =>
-          if (!PartitioningUtils.validPartitionColumnTypes.contains(field.dataType)) {
-            throw new AnalysisException(s"Cannot use ${field.dataType} for partition column")
-          }
-        }
+        PartitioningUtils.checkPartitionColumnOfValidDataType(data.schema, partitionColumns)
 
         val dataSchema = StructType(data.schema.filterNot(f => partitionColumns.contains(f.name)))
         val r = dataSource.createRelation(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/WriterContainer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/WriterContainer.scala
@@ -287,7 +287,7 @@ private[sql] class DynamicPartitionWriterContainer(
           PartitioningUtils.escapePathName _, StringType, Seq(Cast(c, StringType)), Seq(StringType))
       val str = If(IsNull(c), Literal(defaultPartitionName), escaped)
       val partitionName = Literal(c.name + "=") :: str :: Nil
-      if (i == 0) partitionName else Literal(Path.SEPARATOR_CHAR.toString) :: partitionName
+      if (i == 0) partitionName else Literal(Path.SEPARATOR) :: partitionName
     }
 
     // Returns the partition path given a partition key.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
@@ -116,7 +116,7 @@ private[sql] case class PreWriteCheck(catalog: Catalog) extends (LogicalPlan => 
           // OK
         }
 
-        PartitioningUtils.checkPartitionColumnOfValidDataType(r.schema, part.keySet.toArray)
+        PartitioningUtils.validatePartitionColumnDataTypes(r.schema, part.keySet.toArray)
 
         // Get all input data source relations of the query.
         val srcRelations = query.collect {
@@ -166,7 +166,7 @@ private[sql] case class PreWriteCheck(catalog: Catalog) extends (LogicalPlan => 
           // OK
         }
 
-        PartitioningUtils.checkPartitionColumnOfValidDataType(query.schema, partitionColumns)
+        PartitioningUtils.validatePartitionColumnDataTypes(query.schema, partitionColumns)
 
       case _ => // OK
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
@@ -116,11 +116,7 @@ private[sql] case class PreWriteCheck(catalog: Catalog) extends (LogicalPlan => 
           // OK
         }
 
-        r.partitionColumns.fields.foreach { field =>
-          if (!PartitioningUtils.validPartitionColumnTypes.contains(field.dataType)) {
-            failAnalysis(s"Cannot use ${field.dataType} for partition column")
-          }
-        }
+        PartitioningUtils.checkPartitionColumnOfValidDataType(r.schema, part.keySet.toArray)
 
         // Get all input data source relations of the query.
         val srcRelations = query.collect {
@@ -170,11 +166,7 @@ private[sql] case class PreWriteCheck(catalog: Catalog) extends (LogicalPlan => 
           // OK
         }
 
-        ResolvedDataSource.partitionColumnsSchema(query.schema, partitionColumns).foreach { field =>
-          if (!PartitioningUtils.validPartitionColumnTypes.contains(field.dataType)) {
-            throw new AnalysisException(s"Cannot use ${field.dataType} for partition column")
-          }
-        }
+        PartitioningUtils.checkPartitionColumnOfValidDataType(query.schema, partitionColumns)
 
       case _ => // OK
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/hadoopFsRelationSuites.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/hadoopFsRelationSuites.scala
@@ -559,16 +559,16 @@ abstract class HadoopFsRelationTest extends QueryTest with SQLTestUtils {
 
   test("SPARK-8887: Explicitly define which data types can be used as dynamic partition columns") {
     val df = Seq(
-      (1, "v1", Date.valueOf("2015-08-10")),
-      (2, "v2", Date.valueOf("2015-08-11")),
-      (3, "v3", Date.valueOf("2015-08-12"))).toDF("a", "b", "c")
+      (1, "v1", Array(1, 2, 3), Map("k1" -> "v1"), Tuple2(1, "4")),
+      (2, "v2", Array(4, 5, 6), Map("k2" -> "v2"), Tuple2(2, "5")),
+      (3, "v3", Array(7, 8, 9), Map("k3" -> "v3"), Tuple2(3, "6"))).toDF("a", "b", "c", "d", "e")
     withTempDir { file =>
       intercept[AnalysisException] {
-        df.write.format(dataSourceName).partitionBy("c").save(file.getCanonicalPath)
+        df.write.format(dataSourceName).partitionBy("c", "d", "e").save(file.getCanonicalPath)
       }
     }
     intercept[AnalysisException] {
-      df.write.format(dataSourceName).partitionBy("c").saveAsTable("t")
+      df.write.format(dataSourceName).partitionBy("c", "d", "e").saveAsTable("t")
     }
   }
 }


### PR DESCRIPTION
This PR enforce dynamic partition column data type requirements by adding analysis rules.

JIRA: https://issues.apache.org/jira/browse/SPARK-8887
