### PR TITLE
[SPARK-10001] [CORE] Allow Ctrl-C in spark-shell to kill running job

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/JobWaiter.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/JobWaiter.scala
@@ -42,14 +42,14 @@ private[spark] class JobWaiter[T](
         logInfo("Cancelling running job.. This might take some time, so be patient. " +
           "Press Ctrl-C again to kill JVM.")
         // Detach sigint handler so that pressing ctrl-c again will interrupt the jvm.
-        detachSigintHandler(_originalHandler)
+        detachSigintHandler()
         cancel()
       }
     })
   }
 
-  def detachSigintHandler(originalHandler: SignalHandler): Unit = {
-    Signal.handle(sigint, originalHandler)
+  def detachSigintHandler(): Unit = {
+    Signal.handle(sigint, _originalHandler)
   }
 
   private var finishedTasks = 0
@@ -97,7 +97,7 @@ private[spark] class JobWaiter[T](
     while (!_jobFinished) {
       this.wait()
     }
-    detachSigintHandler(_originalHandler)
+    detachSigintHandler()
     return jobResult
   }
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/JobWaiter.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/JobWaiter.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.scheduler
 
-import sun.misc.{Signal, SignalHandler}
-
 import org.apache.spark.Logging
+
+import sun.misc.{Signal, SignalHandler}
 
 /**
  * An object that waits for a DAGScheduler job to complete. As tasks finish, it passes their

--- a/core/src/main/scala/org/apache/spark/scheduler/JobWaiter.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/JobWaiter.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.scheduler
 
-import java.lang.reflect.{InvocationHandler, Method, Proxy}
+import sun.misc.{Signal, SignalHandler}
 
-import org.apache.spark.util.Utils
+import org.apache.spark.Logging
 
 /**
  * An object that waits for a DAGScheduler job to complete. As tasks finish, it passes their
@@ -32,55 +32,24 @@ private[spark] class JobWaiter[T](
     resultHandler: (Int, T) => Unit)
   extends JobListener {
 
-  // Original signal handler that is overridden.
+  private val sigint: Signal = new Signal("INT")
   @volatile
-  private var _originalHandler: Object = _
+  private var _originalHandler: SignalHandler = _
 
-  // Override default signal handler for ctrl-c if sun.misc Signal handler classes exist.
-  private def attachSigintHandler(): Object = {
-    try {
-      val signalClazz = Utils.classForName("sun.misc.Signal")
-      val signalHandlerClazz = Utils.classForName("sun.misc.SignalHandler")
-      val newHandler = Proxy.newProxyInstance(Utils.getContextOrSparkClassLoader,
-        Array(signalHandlerClazz), new InvocationHandler {
-          override def invoke(proxy: Any, method: Method, args: Array[AnyRef]): AnyRef = {
-            // scalastyle:off println
-            println("Cancelling running job.. This might take some time, so be patient.\n" +
-              "Press Ctrl-C again to kill JVM.")
-            // scalastyle:on println
-            // Detach sigint handler so that pressing ctrl-c again will interrupt jvm.
-            detachSigintHandler()
-            cancel()
-            null
-          }
-        })
-      signalClazz.getMethod("handle", signalClazz, signalHandlerClazz)
-        .invoke(
-          null,
-          signalClazz.getConstructor(classOf[String]).newInstance("INT").asInstanceOf[Object],
-          newHandler)
-    } catch {
-      // Ignore. sun.misc Signal handler classes don't exist.
-      case _: ClassNotFoundException => null
-      case e: Exception => throw e
-    }
+  def attachSigintHandler(): SignalHandler = {
+    Signal.handle(sigint, new SignalHandler with Logging {
+      override def handle(signal: Signal): Unit = {
+        logInfo("Cancelling running job.. This might take some time, so be patient. " +
+          "Press Ctrl-C again to kill JVM.")
+        // Detach sigint handler so that pressing ctrl-c again will interrupt the jvm.
+        detachSigintHandler(_originalHandler)
+        cancel()
+      }
+    })
   }
 
-  // Reset signal handler to default
-  private def detachSigintHandler(): Unit = {
-    try {
-      val signalClazz = Utils.classForName("sun.misc.Signal")
-      val signalHandlerClazz = Utils.classForName("sun.misc.SignalHandler")
-      signalClazz.getMethod("handle", signalClazz, signalHandlerClazz)
-        .invoke(
-          null,
-          signalClazz.getConstructor(classOf[String]).newInstance("INT").asInstanceOf[Object],
-          _originalHandler)
-    } catch {
-      // Ignore. sun.misc Signal handler classes don't exist.
-      case _: ClassNotFoundException =>
-      case e: Exception => throw e
-    }
+  def detachSigintHandler(originalHandler: SignalHandler): Unit = {
+    Signal.handle(sigint, originalHandler)
   }
 
   private var finishedTasks = 0
@@ -128,7 +97,7 @@ private[spark] class JobWaiter[T](
     while (!_jobFinished) {
       this.wait()
     }
-    detachSigintHandler()
+    detachSigintHandler(_originalHandler)
     return jobResult
   }
 }


### PR DESCRIPTION
This patch attaches a signal handler for SIGINT to JobWaiter when a job is running and detaches it as soon as the job is finished. When ctrl-c is pressed during this time, spark-shell cancels the running job.

It's worth noting that signal handler is only overridden when job is running. So if ctrl-c is pressed when spark-shell is idle, it will still interrupt JVM and exit the shell (same as now).

In addition, if ctrl-c is pressed multiple times when job is running, it will interrupt JVM and exit the shell. This is to avoid any case that the shell becomes unresponsive. For eg, consider this scenario. User submits a job in the shell. But since the job lists a lot of files before running, it might be hanging in the driver. In this case, user can interrupt JVM and exit the shell by ctrl-c'ing twice.

Here is summary-

| # | case | before | after |
| --- | --- | --- | --- |
| 1 | shell is idle | ctrl-c will exit the shell | ctrl-c will exit the shell |
| 2 | job is submitted but not yet running (e.g. driver listing input files) | ctrl-c will exit the shell | ctrl-c will exit the shell [a] |
| 3 | job is submitted and running on cluster | ctrl-c will exit the shell | ctrl-c will not exit the shell but cancel the job [b] |

This patch basically improves `case 3` by allowing the user to cancel a running job on cluster w/o exiting the shell.

[a] 1st ctrl-c will print a log message saying `Cancelling running job.. This might take some time, so be patient.  Press Ctrl-C again to kill JVM.` 2nd ctrl-c will exit the shell.
[b] when job is running, ctrl-c immediately cancels the job, and the prompt is returned to user.
