### PR TITLE
[SPARK-10044][SQL]Fix bug AnalysisException in resolving reference for sorting with agg…

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -465,12 +465,13 @@ class Analyzer(
 
         // Find aggregate expressions and evaluate them early, since they can't be evaluated in a
         // Sort.
-        val (withAggsRemoved, aliasedAggregateList) = newOrdering.map {
-          case aggOrdering if aggOrdering.collect { case a: AggregateExpression => a }.nonEmpty =>
-            val aliased = Alias(aggOrdering.child, "_aggOrdering")()
+        val (withAggsRemoved, aliasedAggregateList) = newOrdering.zipWithIndex.map {
+          case (aggOrdering, idx)
+            if aggOrdering.collect { case a: AggregateExpression => a }.nonEmpty =>
+            val aliased = Alias(aggOrdering.child, s"_aggOrdering_$idx")()
             (aggOrdering.copy(child = aliased.toAttribute), Some(aliased))
 
-          case other => (other, None)
+          case (other, _) => (other, None)
         }.unzip
 
         val missing = missingAttr ++ aliasedAggregateList.flatten

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -468,7 +468,7 @@ class Analyzer(
         val (withAggsRemoved, aliasedAggregateList) = newOrdering.zipWithIndex.map {
           case (aggOrdering, idx)
             if aggOrdering.collect { case a: AggregateExpression => a }.nonEmpty =>
-            val aliased = Alias(aggOrdering.child, s"_aggOrdering_$idx")()
+            val aliased = Alias(aggOrdering.child, s"${aggOrdering.toString}_$idx")()
             (aggOrdering.copy(child = aliased.toAttribute), Some(aliased))
 
           case (other, _) => (other, None)

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -23,6 +23,7 @@ import org.apache.spark.AccumulatorSuite
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
 import org.apache.spark.sql.catalyst.DefaultParserDialect
 import org.apache.spark.sql.catalyst.errors.DialectException
+import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.execution.aggregate
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SharedSQLContext
@@ -1632,9 +1633,14 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
         .toDF("key", "value")
         .registerTempTable("mytable")
       checkAnswer(sql(
-        """select max(value) from mytable group by key % 2
+        """select max(value) as _aggOrdering_0 from mytable group by key % 2
           |order by max(concat(value,",", key)), min(substr(value, 0, 4))
           |""".stripMargin), Row("8") :: Row("9") :: Nil)
+
+      checkAnswer(
+        sqlContext.table("mytable").groupBy($"key" % 2).agg(max($"value"))
+          .orderBy(max(concat($"value", lit(","), $"key")), min(substring($"value", 0, 4))),
+        Row(0, "8") :: Row(1, "9") :: Nil)
     }
   }
 }


### PR DESCRIPTION
``` scala
withTempTable("mytable") {
      sqlContext.sparkContext.parallelize(1 to 10).map(i => (i, i.toString))
        .toDF("key", "value")
        .registerTempTable("mytable")
      checkAnswer(sql(
        """select max(value) from mytable group by key % 2
          |order by max(concat(value,",", key)), min(substr(value, 0, 4))
          |""".stripMargin), Row("8") :: Row("9") :: Nil)
    }
```

Causes exception like:

```
cannot resolve '_aggOrdering' given input columns _c0, _aggOrdering, _aggOrdering;
org.apache.spark.sql.AnalysisException: cannot resolve '_aggOrdering' given input columns _c0, _aggOrdering, _aggOrdering;
    at org.apache.spark.sql.catalyst.analysis.package$AnalysisErrorAt.failAnalysis(package.scala:42)
    at org.apache.spark.sql.catalyst.analysis.CheckAnalysis$$anonfun$checkAnalysis$1$$anonfun$apply$2.applyOrElse(CheckAnalysis.scala:56)
    at org.apache.spark.sql.catalyst.analysis.CheckAnalysis$$anonfun$checkAnalysis$1$$anonfun$apply$2.applyOrElse(CheckAnalysis.scala:53)
    at org.apache.spark.sql.catalyst.trees.TreeNode$$anonfun$transformUp$1.apply(TreeNode.scala:293)
    at org.apache.spark.sql.catalyst.trees.TreeNode$$anonfun$transformUp$1.apply(TreeNode.scala:293)
    at org.apache.spark.sql.catalyst.trees.CurrentOrigin$.withOrigin(TreeNode.scala:51)
    at org.apache.spark.sql.catalyst.trees.TreeNode.transformUp(TreeNode.scala:292)
    at org.apache.spark.sql.catalyst.trees.TreeNode$$anonfun$5.apply(TreeNode.scala:290)
    at org.apache.spark.sql.catalyst.trees.TreeNode$$anonfun$5.apply(TreeNode.scala:290)
    at org.apache.spark.sql.catalyst.trees.TreeNode$$anonfun$4.apply(TreeNode.scala:249)
    at scala.collection.Iterator$$anon$11.next(Iterator.scala:328)
    at scala.collection.Iterator$class.foreach(Iterator.scala:727)
    at scala.collection.AbstractIterator.foreach(Iterator.scala:1157)
    at scala.collection.generic.Growable$class.$plus$plus$eq(Growable.scala:48)
    at scala.collection.mutable.ArrayBuffer.$plus$plus$eq(ArrayBuffer.scala:103)
    at scala.collection.mutable.ArrayBuffer.$plus$plus$eq(ArrayBuffer.scala:47)
    at scala.collection.TraversableOnce$class.to(TraversableOnce.scala:273)
    at scala.collection.AbstractIterator.to(Iterator.scala:1157)
    at scala.collection.TraversableOnce$class.toBuffer(TraversableOnce.scala:265)
    at scala.collection.AbstractIterator.toBuffer(Iterator.scala:1157)
```
