### PR TITLE
[SPARK-10015][MLlib]: ML model broadcasts should be stored in private vars: spark.ml tree ensembles

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
@@ -187,8 +187,9 @@ final class GBTClassificationModel(
       case None => bcastModel = Some(dataset.sqlContext.sparkContext.broadcast(this))
       case _ =>
     }
+    val lclBcastModel = bcastModel
     val predictUDF = udf { (features: Any) =>
-      bcastModel.get.value.predict(features.asInstanceOf[Vector])
+      lclBcastModel.get.value.predict(features.asInstanceOf[Vector])
     }
     dataset.withColumn($(predictionCol), predictUDF(col($(featuresCol))))
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
@@ -157,8 +157,9 @@ final class RandomForestClassificationModel private[ml] (
       case None => bcastModel = Some(dataset.sqlContext.sparkContext.broadcast(this))
       case _ =>
     }
+    val lclBcastModel = bcastModel
     val predictUDF = udf { (features: Any) =>
-      bcastModel.get.value.predict(features.asInstanceOf[Vector])
+      lclBcastModel.get.value.predict(features.asInstanceOf[Vector])
     }
     dataset.withColumn($(predictionCol), predictUDF(col($(featuresCol))))
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
@@ -21,6 +21,7 @@ import com.github.fommil.netlib.BLAS.{getInstance => blas}
 
 import org.apache.spark.Logging
 import org.apache.spark.annotation.Experimental
+import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.ml.{PredictionModel, Predictor}
 import org.apache.spark.ml.param.{Param, ParamMap}
 import org.apache.spark.ml.tree.{DecisionTreeModel, GBTParams, TreeEnsembleModel, TreeRegressorParams}
@@ -165,14 +166,19 @@ final class GBTRegressionModel(
   require(_trees.length == _treeWeights.length, "GBTRegressionModel given trees, treeWeights of" +
     s" non-matching lengths (${_trees.length}, ${_treeWeights.length}, respectively).")
 
+  private var bcastModel: Option[Broadcast[GBTRegressionModel]] = None
+
   override def trees: Array[DecisionTreeModel] = _trees.asInstanceOf[Array[DecisionTreeModel]]
 
   override def treeWeights: Array[Double] = _treeWeights
 
   override protected def transformImpl(dataset: DataFrame): DataFrame = {
-    val bcastModel = dataset.sqlContext.sparkContext.broadcast(this)
+    bcastModel match {
+      case None => bcastModel = Some(dataset.sqlContext.sparkContext.broadcast(this))
+      case _ =>
+    }
     val predictUDF = udf { (features: Any) =>
-      bcastModel.value.predict(features.asInstanceOf[Vector])
+      bcastModel.get.value.predict(features.asInstanceOf[Vector])
     }
     dataset.withColumn($(predictionCol), predictUDF(col($(featuresCol))))
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
@@ -177,8 +177,9 @@ final class GBTRegressionModel(
       case None => bcastModel = Some(dataset.sqlContext.sparkContext.broadcast(this))
       case _ =>
     }
+    val lclBcastModel = bcastModel
     val predictUDF = udf { (features: Any) =>
-      bcastModel.get.value.predict(features.asInstanceOf[Vector])
+      lclBcastModel.get.value.predict(features.asInstanceOf[Vector])
     }
     dataset.withColumn($(predictionCol), predictUDF(col($(featuresCol))))
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -143,8 +143,9 @@ final class RandomForestRegressionModel private[ml] (
       case None => bcastModel = Some(dataset.sqlContext.sparkContext.broadcast(this))
       case _ =>
     }
+    val lclBcastModel = bcastModel
     val predictUDF = udf { (features: Any) =>
-      bcastModel.get.value.predict(features.asInstanceOf[Vector])
+      lclBcastModel.get.value.predict(features.asInstanceOf[Vector])
     }
     dataset.withColumn($(predictionCol), predictUDF(col($(featuresCol))))
   }


### PR DESCRIPTION
ML model broadcasts should be stored in private vars: spark.ml tree ensembles:
GBTClassifier
RandomForestClassifier
GBTRegressor
RandomForestRegressor
