### PR TITLE
[SPARK-10018][MLlib]: ML model broadcasts should be stored in private vars: mllib clustering

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/GaussianMixtureModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/GaussianMixtureModel.scala
@@ -90,12 +90,14 @@ class GaussianMixtureModel(
       case None => bcDists = Some(sc.broadcast(gaussians))
       case _ =>
     }
+    val lclBcDists = bcDists
     bcWeights match {
       case None => bcWeights = Some(sc.broadcast(weights))
       case _ =>
     }
+    val lclBcWeights = bcWeights
     points.map { x =>
-      computeSoftAssignments(x.toBreeze.toDenseVector, bcDists.get.value, bcWeights.get.value, k)
+      computeSoftAssignments(x.toBreeze.toDenseVector, lclBcDists.get.value, lclBcWeights.get.value, k)
     }
   }
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeansModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeansModel.scala
@@ -62,7 +62,8 @@ class KMeansModel (
       }
       case _ =>
     }
-    points.map(p => KMeans.findClosest(bcCentersWithNorm.get.value, new VectorWithNorm(p))._1)
+    val lclBcCentersWithNorm = bcCentersWithNorm
+    points.map(p => KMeans.findClosest(lclBcCentersWithNorm.get.value, new VectorWithNorm(p))._1)
   }
 
   /** Maps given points to their cluster indices. */
@@ -81,7 +82,8 @@ class KMeansModel (
       }
       case _ =>
     }
-    data.map(p => KMeans.pointCost(bcCentersWithNorm.get.value, new VectorWithNorm(p))).sum()
+    val lclBcCentersWithNorm = bcCentersWithNorm
+    data.map(p => KMeans.pointCost(lclBcCentersWithNorm.get.value, new VectorWithNorm(p))).sum()
   }
 
   private def clusterCentersWithNorm: Iterable[VectorWithNorm] =


### PR DESCRIPTION
Applies to: spark.mllib.clustering types:
GaussianMixtureModel
KMeansModel
LocalLDAModel
