### PR TITLE
[SPARK-10019][MLlib]: ML model broadcasts should be stored in private vars: mllib IDFModel

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
@@ -179,7 +179,8 @@ class IDFModel private[spark] (val idf: Vector) extends Serializable {
       case None => bcIdf = Some(dataset.context.broadcast(idf))
       case _ =>
     }
-    dataset.mapPartitions(iter => iter.map(v => IDFModel.transform(bcIdf.get.value, v)))
+    val lclBcIdf = bcIdf
+    dataset.mapPartitions(iter => iter.map(v => IDFModel.transform(lclBcIdf.get.value, v)))
   }
 
   /**


### PR DESCRIPTION
ML model broadcasts should be stored in private vars: mllib IDFModel.
Applies to: spark.mllib.feature.IDFModel
