### PR TITLE
[SPARK-10020][MLlib]: ML model broadcasts should be stored in private vars: mllib GeneralizedLinearModel

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/GeneralizedLinearAlgorithm.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/GeneralizedLinearAlgorithm.scala
@@ -67,9 +67,10 @@ abstract class GeneralizedLinearModel(val weights: Vector, val intercept: Double
       }
       case _ =>
     }
+    val localBcWeights = bcWeights
     val localIntercept = intercept
     testData.mapPartitions { iter =>
-      val w = bcWeights.get.value
+      val w = localBcWeights.get.value
       iter.map(v => predictPoint(v, w, localIntercept))
     }
   }


### PR DESCRIPTION
ML model broadcasts should be stored in private vars: mllib GeneralizedLinearModel:
Applies to: spark.mllib.regression.GeneralizedLinearModel
