### PR TITLE
[SPARK-7736] [core] Fix a race introduced in PythonRunner.

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
@@ -49,7 +49,7 @@ object PythonRunner {
     val gatewayServer = new py4j.GatewayServer(null, 0)
     val thread = new Thread(new Runnable() {
       override def run(): Unit = Utils.logUncaughtExceptions {
-        gatewayServer.start()
+        gatewayServer.start(false)
       }
     })
     thread.setName("py4j-gateway")

--- a/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
@@ -24,7 +24,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.collection.JavaConversions._
 import scala.util.Try
 
-import org.apache.spark.SparkUserAppException
+import org.apache.spark.{SparkException, SparkUserAppException}
 import org.apache.spark.api.python.PythonUtils
 import org.apache.spark.util.{RedirectThread, Utils}
 
@@ -55,6 +55,16 @@ object PythonRunner {
     thread.setName("py4j-gateway")
     thread.setDaemon(true)
     thread.start()
+
+    // Wait until the gateway server has started, so that we know which port is it bound to.
+    // Fail if the thread exits before it's set.
+    while (thread.isAlive() && gatewayServer.getListeningPort() == -1) {
+      thread.join(10)
+    }
+    if (gatewayServer.getListeningPort() == -1) {
+      gatewayServer.shutdown()
+      throw new SparkException("Python GatewayServer failed to start.")
+    }
 
     // Build up a PYTHONPATH that includes the Spark assembly JAR (where this class is), the
     // python directories in SPARK_HOME (if set), and any files in the pyFiles argument


### PR DESCRIPTION
The fix for SPARK-7736 introduced a race where a port value of "-1"
could be passed down to the pyspark process, causing it to fail to
connect back to the JVM. This change adds code to fix that race.
