### PR TITLE
SPARK-10074 Include Float in @specialized annotation

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/MutablePair.scala
+++ b/core/src/main/scala/org/apache/spark/util/MutablePair.scala
@@ -28,8 +28,8 @@ import org.apache.spark.annotation.DeveloperApi
  * @param  _2   Element 2 of this MutablePair
  */
 @DeveloperApi
-case class MutablePair[@specialized(Int, Long, Double, Char, Boolean/* , AnyRef */) T1,
-                       @specialized(Int, Long, Double, Char, Boolean/* , AnyRef */) T2]
+case class MutablePair[@specialized(Int, Long, Double, Float, Char, Boolean/* , AnyRef */) T1,
+                       @specialized(Int, Long, Double, Float, Char, Boolean/* , AnyRef */) T2]
   (var _1: T1, var _2: T2)
   extends Product2[T1, T2]
 {

--- a/core/src/main/scala/org/apache/spark/util/collection/OpenHashMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/OpenHashMap.scala
@@ -31,7 +31,7 @@ import org.apache.spark.annotation.DeveloperApi
  */
 @DeveloperApi
 private[spark]
-class OpenHashMap[K : ClassTag, @specialized(Long, Int, Double) V: ClassTag](
+class OpenHashMap[K : ClassTag, @specialized(Long, Int, Double, Float) V: ClassTag](
     initialCapacity: Int)
   extends Iterable[(K, V)]
   with Serializable {

--- a/core/src/main/scala/org/apache/spark/util/collection/PrimitiveKeyOpenHashMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/PrimitiveKeyOpenHashMap.scala
@@ -28,7 +28,7 @@ import scala.reflect._
  */
 private[spark]
 class PrimitiveKeyOpenHashMap[@specialized(Long, Int) K: ClassTag,
-                              @specialized(Long, Int, Double) V: ClassTag](
+                              @specialized(Long, Int, Double, Float) V: ClassTag](
     initialCapacity: Int)
   extends Iterable[(K, V)]
   with Serializable {

--- a/graphx/src/main/scala/org/apache/spark/graphx/impl/EdgePartitionBuilder.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/impl/EdgePartitionBuilder.scala
@@ -25,7 +25,7 @@ import org.apache.spark.util.collection.{SortDataFormat, Sorter, PrimitiveVector
 
 /** Constructs an EdgePartition from scratch. */
 private[graphx]
-class EdgePartitionBuilder[@specialized(Long, Int, Double) ED: ClassTag, VD: ClassTag](
+class EdgePartitionBuilder[@specialized(Long, Int, Double, Float) ED: ClassTag, VD: ClassTag](
     size: Int = 64) {
   private[this] val edges = new PrimitiveVector[Edge[ED]](size)
 
@@ -81,7 +81,7 @@ class EdgePartitionBuilder[@specialized(Long, Int, Double) ED: ClassTag, VD: Cla
  */
 private[impl]
 class ExistingEdgePartitionBuilder[
-    @specialized(Long, Int, Double) ED: ClassTag, VD: ClassTag](
+    @specialized(Long, Int, Double, Float) ED: ClassTag, VD: ClassTag](
     global2local: GraphXPrimitiveKeyOpenHashMap[VertexId, Int],
     local2global: Array[VertexId],
     vertexAttrs: Array[VD],

--- a/graphx/src/main/scala/org/apache/spark/graphx/impl/VertexPartitionBase.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/impl/VertexPartitionBase.scala
@@ -60,7 +60,7 @@ private[graphx] object VertexPartitionBase {
  * `VertexPartitionBaseOpsConstructor` typeclass (for example,
  * [[VertexPartition.VertexPartitionOpsConstructor]]).
  */
-private[graphx] abstract class VertexPartitionBase[@specialized(Long, Int, Double) VD: ClassTag]
+private[graphx] abstract class VertexPartitionBase[@specialized(Long, Int, Double, Float) VD: ClassTag]
   extends Serializable {
 
   def index: VertexIdToIndexMap

--- a/graphx/src/main/scala/org/apache/spark/graphx/impl/VertexPartitionBase.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/impl/VertexPartitionBase.scala
@@ -60,8 +60,8 @@ private[graphx] object VertexPartitionBase {
  * `VertexPartitionBaseOpsConstructor` typeclass (for example,
  * [[VertexPartition.VertexPartitionOpsConstructor]]).
  */
-private[graphx] abstract class VertexPartitionBase[@specialized(Long, Int, Double, Float) VD: ClassTag]
-  extends Serializable {
+private[graphx] abstract class VertexPartitionBase[@specialized(Long, Int, Double, Float)
+  VD: ClassTag] extends Serializable {
 
   def index: VertexIdToIndexMap
   def values: Array[VD]

--- a/graphx/src/main/scala/org/apache/spark/graphx/util/collection/GraphXPrimitiveKeyOpenHashMap.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/util/collection/GraphXPrimitiveKeyOpenHashMap.scala
@@ -30,7 +30,7 @@ import scala.reflect._
  */
 private[graphx]
 class GraphXPrimitiveKeyOpenHashMap[@specialized(Long, Int) K: ClassTag,
-                              @specialized(Long, Int, Double) V: ClassTag](
+                              @specialized(Long, Int, Double, Float) V: ClassTag](
     val keySet: OpenHashSet[K], var _values: Array[V])
   extends Iterable[(K, V)]
   with Serializable {


### PR DESCRIPTION
There're several places in Spark codebase where we use @specialized annotation covering Long and Double.
e.g. in OpenHashMap.scala :

```
class OpenHashMap[K : ClassTag, @specialized(Long, Int, Double) V: ClassTag](
    initialCapacity: Int)
```

Float should be added to @specialized annotation as well.
