### PR TITLE
[DOCS][SQL][PYSPARK] Fix typo in ntile function

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -531,7 +531,7 @@ def lead(col, count=1, default=None):
 def ntile(n):
     """
     Window function: returns the ntile group id (from 1 to `n` inclusive)
-    in an ordered window partition. Fow example, if `n` is 4, the first
+    in an ordered window partition. For example, if `n` is 4, the first
     quarter of the rows will get value 1, the second quarter will get 2,
     the third quarter will get 3, and the last quarter will get 4.
 


### PR DESCRIPTION
Fix typo in ntile function.
