### PR TITLE
[SPARK-10076] [ML] make MultilayerPerceptronClassifier layers and weights public

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifier.scala
@@ -172,8 +172,8 @@ class MultilayerPerceptronClassifier(override val uid: String)
 @Experimental
 class MultilayerPerceptronClassificationModel private[ml] (
     override val uid: String,
-    layers: Array[Int],
-    weights: Vector)
+    val layers: Array[Int],
+    val weights: Vector)
   extends PredictionModel[Vector, MultilayerPerceptronClassificationModel]
   with Serializable {
 


### PR DESCRIPTION
Fix the issue that `layers` and `weights` should be public variables of `MultilayerPerceptronClassificationModel`. Users can not get `layers` and `weights` from a `MultilayerPerceptronClassificationModel` currently.
