### PR TITLE
[SPARK-10075][SparkR] Add `when` expressino function in SparkR

### DIFF
--- a/R/pkg/NAMESPACE
+++ b/R/pkg/NAMESPACE
@@ -152,6 +152,7 @@ exportMethods("abs",
               "n_distinct",
               "nanvl",
               "negate",
+              "otherwise",
               "pmod",
               "quarter",
               "reverse",
@@ -182,6 +183,7 @@ exportMethods("abs",
               "unhex",
               "upper",
               "weekofyear",
+              "when",
               "year")
 
 exportClasses("GroupedData")

--- a/R/pkg/R/column.R
+++ b/R/pkg/R/column.R
@@ -206,8 +206,8 @@ setMethod("%in%",
 
 #' otherwise
 #'
-#' Evaluates a list of conditions and returns one of multiple possible result expressions.
-#' If otherwise is not defined at the end, null is returned for unmatched conditions.
+#' If values in the specified column are null, returns the value. 
+#' Can be used in conjunction with `when` to specify a default value for expressions.
 #'
 #' @rdname column
 setMethod("otherwise",

--- a/R/pkg/R/column.R
+++ b/R/pkg/R/column.R
@@ -204,24 +204,8 @@ setMethod("%in%",
             return(column(jc))
           })
 
-
-#' when
-#'
-#' Evaluates a list of conditions and returns one of multiple possible result expressions.
-#' If otherwise is not defined at the end, null is returned for unmatched conditions.
-#'
-#' @rdname column
-setMethod("when",
-          signature(x = "Column", y = "character", z = "ANY"),
-          function(x, y, z) {
-            condition <- y
-            value <- z
-            jc <- callJMethod(x@jc, "when", condition, value)
-            column(jc)
-          })
-
 #' otherwise
-#' 
+#'
 #' Evaluates a list of conditions and returns one of multiple possible result expressions.
 #' If otherwise is not defined at the end, null is returned for unmatched conditions.
 #'
@@ -232,20 +216,4 @@ setMethod("otherwise",
             value <- ifelse(class(value) == "Column", value@jc, value)
             jc <- callJMethod(x@jc, "otherwise", value)
             column(jc)
-          })
-
-#' otherwise
-#'
-#' This is an alias of `otherwise` as an infix operator.
-#'
-#' @rdname column
-#' @aliases otherwise
-#' @examples
-#' \dontrun{
-#'   when(df$x > 1 & df$y < 10, 0) %otherwise% 1
-#' }
-setMethod("%otherwise%",
-          signature(x = "Column", value = "ANY"),
-          function(x, value) {
-            otherwise(x, value)
           })

--- a/R/pkg/R/column.R
+++ b/R/pkg/R/column.R
@@ -203,3 +203,45 @@ setMethod("%in%",
             jc <- callJMethod(x@jc, "in", table)
             return(column(jc))
           })
+
+
+#' when
+#'
+#' Evaluates a list of conditions and returns one of multiple possible result expressions.
+#' If otherwise is not defined at the end, null is returned for unmatched conditions.
+#'
+#' @rdname column
+setMethod("when",
+          signature(x = "Column", y = "character", z = "ANY"),
+          function(x, y, z) {
+            condition <- y
+            value <- z
+            jc <- callJMethod(x@jc, "when", condition, value)
+            column(jc)
+          })
+
+#' otherwise
+#' 
+#' Evaluates a list of conditions and returns one of multiple possible result expressions.
+#' If otherwise is not defined at the end, null is returned for unmatched conditions.
+#'
+#' @rdname column
+setMethod("otherwise",
+          signature(x = "Column", value = "ANY"),
+          function(x, value) {
+            value <- ifelse(class(value) == "Column", value@jc, value)
+            jc <- callJMethod(x@jc, "otherwise", value)
+            column(jc)
+          })
+
+#' otherwise
+#'
+#' This is an alias of `otherwise` as an infix operator.
+#'
+#' @rdname column
+#' @aliases otherwise
+setMethod("%otherwise%",
+          signature(x = "Column", value = "ANY"),
+          function(x, value) {
+            otherwise(x, value)
+          })

--- a/R/pkg/R/column.R
+++ b/R/pkg/R/column.R
@@ -240,6 +240,10 @@ setMethod("otherwise",
 #'
 #' @rdname column
 #' @aliases otherwise
+#' @examples
+#' \dontrun{
+#'   when(df$x > 1 & df$y < 10, 0) %otherwise% 1
+#' }
 setMethod("%otherwise%",
           signature(x = "Column", value = "ANY"),
           function(x, value) {

--- a/R/pkg/R/functions.R
+++ b/R/pkg/R/functions.R
@@ -172,11 +172,10 @@ setMethod("n", signature(x = "Column"),
 #' If otherwise is not defined at the end, null is returned for unmatched conditions.
 #'
 #' @rdname column
-#' @aliases otherwise
-setMethod("when", signature(x = "Column", y = "ANY"),
-          function(x, y) {
-              condition <- x@jc
-              value <- ifelse(class(y) == "Column", y@jc, y)
+setMethod("when", signature(condition = "Column", value = "ANY"),
+          function(condition, value) {
+              condition <- condition@jc
+              value <- ifelse(class(value) == "Column", value@jc, value)
               jc <- callJStatic("org.apache.spark.sql.functions", "when", condition, value)
               column(jc)
           })

--- a/R/pkg/R/functions.R
+++ b/R/pkg/R/functions.R
@@ -166,6 +166,13 @@ setMethod("n", signature(x = "Column"),
             count(x)
           })
 
+#' when
+#'
+#' Evaluates a list of conditions and returns one of multiple possible result expressions.
+#' If otherwise is not defined at the end, null is returned for unmatched conditions.
+#'
+#' @rdname column
+#' @aliases otherwise
 setMethod("when", signature(x = "Column", y = "ANY"),
           function(x, y) {
               condition <- x@jc

--- a/R/pkg/R/functions.R
+++ b/R/pkg/R/functions.R
@@ -165,3 +165,11 @@ setMethod("n", signature(x = "Column"),
           function(x) {
             count(x)
           })
+
+setMethod("when", signature(x = "Column", y = "ANY"),
+          function(x, y) {
+              condition <- x@jc
+              value <- ifelse(class(y) == "Column", y@jc, y)
+              jc <- callJStatic("org.apache.spark.sql.functions", "when", condition, value)
+              column(jc)
+          })

--- a/R/pkg/R/functions.R
+++ b/R/pkg/R/functions.R
@@ -169,7 +169,7 @@ setMethod("n", signature(x = "Column"),
 #' when
 #'
 #' Evaluates a list of conditions and returns one of multiple possible result expressions.
-#' If otherwise is not defined at the end, null is returned for unmatched conditions.
+#' For unmatched expressions null is returned.
 #'
 #' @rdname column
 setMethod("when", signature(condition = "Column", value = "ANY"),

--- a/R/pkg/R/generics.R
+++ b/R/pkg/R/generics.R
@@ -653,15 +653,11 @@ setGeneric("startsWith", function(x, ...) { standardGeneric("startsWith") })
 
 #' @rdname column
 #' @export
-setGeneric("when", function(x, y, z) { standardGeneric("when") })
+setGeneric("when", function(condition, value) { standardGeneric("when") })
 
 #' @rdname column
 #' @export
 setGeneric("otherwise", function(x, value) { standardGeneric("otherwise") })
-
-#' @rdname column
-#' @export
-setGeneric("%otherwise%", function(x, value) { standardGeneric("%otherwise%") })
 
 
 ###################### Expression Function Methods ##########################

--- a/R/pkg/R/generics.R
+++ b/R/pkg/R/generics.R
@@ -651,6 +651,18 @@ setGeneric("rlike", function(x, ...) { standardGeneric("rlike") })
 #' @export
 setGeneric("startsWith", function(x, ...) { standardGeneric("startsWith") })
 
+#' @rdname column
+#' @export
+setGeneric("when", function(x, y, z) { standardGeneric("when") })
+
+#' @rdname column
+#' @export
+setGeneric("otherwise", function(x, value) { standardGeneric("otherwise") })
+
+#' @rdname column
+#' @export
+setGeneric("%otherwise%", function(x, value) { standardGeneric("%otherwise%") })
+
 
 ###################### Expression Function Methods ##########################
 

--- a/R/pkg/inst/tests/test_sparkSQL.R
+++ b/R/pkg/inst/tests/test_sparkSQL.R
@@ -732,7 +732,6 @@ test_that("when() and otherwise() on a DataFrame", {
   df <- createDataFrame(sqlContext, l)
   expect_equal(collect(select(df, when(df$a > 1 & df$b > 2, 1)))[, 1], c(NA, 1))
   expect_equal(collect(select(df, otherwise(when(df$a > 1, 1), 0)))[, 1], c(0, 1))
-  expect_equal(collect(select(df, when(df$a > 1, 1) %otherwise% 0))[, 1], c(0, 1))
 })
 
 test_that("group by", {

--- a/R/pkg/inst/tests/test_sparkSQL.R
+++ b/R/pkg/inst/tests/test_sparkSQL.R
@@ -727,6 +727,14 @@ test_that("greatest() and least() on a DataFrame", {
   expect_equal(collect(select(df, least(df$a, df$b)))[, 1], c(1, 3))
 })
 
+test_that("when() and otherwise() on a DataFrame", {
+  l <- list(list(a = 1, b = 2), list(a = 3, b = 4))
+  df <- createDataFrame(sqlContext, l)
+  expect_equal(collect(select(df, when(df$a > 1 & df$b > 2, 1)))[, 1], c(NA, 1))
+  expect_equal(collect(select(df, otherwise(when(df$a > 1, 1), 0)))[, 1], c(0, 1))
+  expect_equal(collect(select(df, when(df$a > 1, 1) %otherwise% 0))[, 1], c(0, 1))
+})
+
 test_that("group by", {
   df <- jsonFile(sqlContext, jsonPath)
   df1 <- agg(df, name = "max", age = "sum")


### PR DESCRIPTION
- Add `when` and `otherwise` as `Column` methods
- Add `When` as an expression function
- Add `%otherwise%` infix as an alias of `otherwise`

Since R doesn't support a feature like method chaining, `otherwise(when(condition, value), value)` style is a little annoying for me. If `%otherwise%` looks strange for @shivaram, I can remove it. What do you think?
### JIRA

[[SPARK-10075] Add `when` expressino function in SparkR - ASF JIRA](https://issues.apache.org/jira/browse/SPARK-10075)
