### PR TITLE
[SPARK-10040][SQL] Use batch insert for JDBC writing

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -125,7 +125,7 @@ object JdbcUtils extends Logging {
           }
           stmt.addBatch()
           rowCount += 1
-          if (rowCount % 1000 == 0) {
+          if (rowCount % 10000 == 0) {
             stmt.executeBatch()
             rowCount = 0
           }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -221,7 +221,7 @@ object JdbcUtils extends Logging {
     val rddSchema = df.schema
     val driver: String = DriverRegistry.getDriverClassName(url)
     val getConnection: () => Connection = JDBCRDD.getConnector(driver, url, properties)
-    val batchSize = properties.getProperty("jdbc.batchsize", "1000").toInt
+    val batchSize = properties.getProperty("batchsize", "1000").toInt
     df.foreachPartition { iterator =>
       savePartition(getConnection, table, iterator, rddSchema, nullTypes, batchSize)
     }


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-10040

We should use batch insert instead of single row in JDBC.
