### PR TITLE
[SPARK-10093][SQL] Avoid transformation on executors.

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -878,4 +878,13 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     val df = Seq(("x", (1, 1)), ("y", (2, 2))).toDF("a", "b")
     checkAnswer(df.groupBy("b._1").agg(sum("b._2")), Row(1, 1) :: Row(2, 2) :: Nil)
   }
+
+  test("SPARK-10093: Avoid transformations on executors") {
+    val df = Seq((1, 1)).toDF("a", "b")
+    df.where($"a" === 1)
+      .select($"a", $"b", struct($"b"))
+      .orderBy("a")
+      .select(struct($"b"))
+      .collect()
+  }
 }


### PR DESCRIPTION
This is kind of a weird case, but given a sufficiently complex query plan (in this case a `TungstenProject` with an `Exchange` underneath), we could have NPEs on the executors due to the time when we were calling `transformAllExpressions`

In general we should ensure that all transformations occur on the driver and not on the executors.  Some reasons for avoid executor side transformations include:
- (this case) Some operator constructors require state such as access to the Spark/SQL conf so doing a `makeCopy` on the executor can fail.
- (unrelated reason for avoid executor transformations) `ExprIds` are calculated using an atomic integer, so you can violate their uniqueness constraint by constructing them anywhere other than the driver.
