### PR TITLE
Bump SparkR version string to 1.5.0

### DIFF
--- a/R/pkg/DESCRIPTION
+++ b/R/pkg/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SparkR
 Type: Package
 Title: R frontend for Spark
-Version: 1.4.0
+Version: 1.5.0
 Date: 2013-09-09
 Author: The Apache Software Foundation
 Maintainer: Shivaram Venkataraman <shivaram@cs.berkeley.edu>


### PR DESCRIPTION
This patch is against master, but we need to apply it to 1.5 branch as well.

cc @shivaram  and @rxin 
