### PR TITLE
[SPARK-10100] [SQL] Perfomance improvements to new MIN/MAX aggregate functions.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/functions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/functions.scala
@@ -202,11 +202,12 @@ case class Max(child: Expression) extends AlgebraicAggregate {
   )
 
   override val updateExpressions = Seq(
-    /* max = */ If(Or(IsNull(max), LessThan(max, child)), child, max)
+    /* max = */ If(IsNull(max), child, If(LessThan(max, child), child, max))
   )
 
   override val mergeExpressions = Seq(
-    /* max = */ If(Or(IsNull(max.right), LessThan(max.right, max.left)), max.left, max.right)
+    /* max = */
+    If(IsNull(max.right), max.left, If(LessThan(max.right, max.left), max.left, max.right))
   )
 
   override val evaluateExpression = max
@@ -233,11 +234,12 @@ case class Min(child: Expression) extends AlgebraicAggregate {
   )
 
   override val updateExpressions = Seq(
-    /* min = */  If(Or(IsNull(min), GreaterThan(min, child)), child, min)
+    /* min = */  If(IsNull(min), child, If(GreaterThan(min, child), child, min))
   )
 
   override val mergeExpressions = Seq(
-    /* min = */ If(Or(IsNull(min.right), GreaterThan(min.right, min.left)), min.left, min.right)
+    /* min = */
+    If(IsNull(min.right), min.left, If(GreaterThan(min.right, min.left), min.left, min.right))
   )
 
   override val evaluateExpression = min

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/functions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/functions.scala
@@ -202,15 +202,12 @@ case class Max(child: Expression) extends AlgebraicAggregate {
   )
 
   override val updateExpressions = Seq(
-    /* max = */ If(IsNull(child), max, If(IsNull(max), child, Greatest(Seq(max, child))))
+    /* max = */ If(Or(IsNull(max), LessThan(max, child)), child, max)
   )
 
-  override val mergeExpressions = {
-    val greatest = Greatest(Seq(max.left, max.right))
-    Seq(
-      /* max = */ If(IsNull(max.right), max.left, If(IsNull(max.left), max.right, greatest))
-    )
-  }
+  override val mergeExpressions = Seq(
+    /* max = */ If(Or(IsNull(max.right), LessThan(max.right, max.left)), max.left, max.right)
+  )
 
   override val evaluateExpression = max
 }
@@ -236,15 +233,12 @@ case class Min(child: Expression) extends AlgebraicAggregate {
   )
 
   override val updateExpressions = Seq(
-    /* min = */ If(IsNull(child), min, If(IsNull(min), child, Least(Seq(min, child))))
+    /* min = */  If(Or(IsNull(min), GreaterThan(min, child)), child, min)
   )
 
-  override val mergeExpressions = {
-    val least = Least(Seq(min.left, min.right))
-    Seq(
-      /* min = */ If(IsNull(min.right), min.left, If(IsNull(min.left), min.right, least))
-    )
-  }
+  override val mergeExpressions = Seq(
+    /* min = */ If(Or(IsNull(min.right), GreaterThan(min.right, min.left)), min.left, min.right)
+  )
 
   override val evaluateExpression = min
 }


### PR DESCRIPTION
The new MIN/MAX suffer from a performance regression. This PR aims to fix this by simplifying the evaluation of the MIN/MAX functions.

See the JIRA [ticket](https://issues.apache.org/jira/browse/SPARK-10100) for more information.
