### PR TITLE
[SPARK-10105] Add most frequent k parameter to Word2Vec

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
@@ -68,6 +68,14 @@ private[feature] trait Word2VecBase extends Params
     "appear to be included in the word2vec model's vocabulary")
   setDefault(minCount -> 5)
 
+  /**
+   * the max number of tokens that will appear to be included in the word2vec model's vocabulary
+   * @group param
+   */
+  final val mostFrequentK = new IntParam(this, "mostFrequentK", "the max number of tokens that " +
+    "will appear to be included in the word2vec model's vocabulary")
+  setDefault(mostFrequentK -> -1)
+
   /** @group getParam */
   def getMinCount: Int = $(minCount)
 
@@ -117,6 +125,9 @@ final class Word2Vec(override val uid: String) extends Estimator[Word2VecModel] 
   /** @group setParam */
   def setMinCount(value: Int): this.type = set(minCount, value)
 
+  /** @group setParam */
+  def setMostFrequentK(value: Int): this.type = set(mostFrequentK, value)
+
   override def fit(dataset: DataFrame): Word2VecModel = {
     transformSchema(dataset.schema, logging = true)
     val input = dataset.select($(inputCol)).map(_.getAs[Seq[String]](0))
@@ -127,6 +138,7 @@ final class Word2Vec(override val uid: String) extends Estimator[Word2VecModel] 
       .setNumPartitions($(numPartitions))
       .setSeed($(seed))
       .setVectorSize($(vectorSize))
+      .setMostFrequentK($(mostFrequentK))
       .fit(input)
     copyValues(new Word2VecModel(uid, wordVectors).setParent(this))
   }

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/Word2Vec.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/Word2Vec.scala
@@ -79,7 +79,7 @@ class Word2Vec extends Serializable with Logging {
   private var numIterations = 1
   private var seed = Utils.random.nextLong()
   private var minCount = 5
-
+  private var mostFrequentK = -1
   /**
    * Sets vector size (default: 100).
    */
@@ -131,6 +131,11 @@ class Word2Vec extends Serializable with Logging {
     this
   }
 
+  def setMostFrequentK(mostFrequentK: Int): this.type = {
+    this.mostFrequentK = mostFrequentK
+    this
+  }
+
   private val EXP_TABLE_SIZE = 1000
   private val MAX_EXP = 6
   private val MAX_CODE_LENGTH = 40
@@ -145,7 +150,7 @@ class Word2Vec extends Serializable with Logging {
   private var vocabHash = mutable.HashMap.empty[String, Int]
 
   private def learnVocab(words: RDD[String]): Unit = {
-    vocab = words.map(w => (w, 1))
+    val fullVocab = words.map(w => (w, 1))
       .reduceByKey(_ + _)
       .map(x => VocabWord(
         x._1,
@@ -153,10 +158,21 @@ class Word2Vec extends Serializable with Logging {
         new Array[Int](MAX_CODE_LENGTH),
         new Array[Int](MAX_CODE_LENGTH),
         0))
-      .filter(_.cn >= minCount)
-      .collect()
-      .sortWith((a, b) => a.cn > b.cn)
+      
 
+    vocab = if (mostFrequentK>0) {
+      logInfo(s"mostFrequentK was set to $mostFrequentK minCount will be ignored")
+      fullVocab.takeOrdered(mostFrequentK)(new Ordering[VocabWord]{
+        override def compare(x: VocabWord, y: VocabWord): Int = -scala.math.Ordering.Long.compare(x.cn,y.cn)
+      })
+    }
+    else{
+      fullVocab.filter(_.cn >= minCount)
+        .sortBy(_.cn)
+        .collect()
+        .sortWith((a, b) => a.cn > b.cn)
+    }
+    
     vocabSize = vocab.length
     require(vocabSize > 0, "The vocabulary size should be > 0. You may need to check " +
       "the setting of minCount, which could be large enough to remove all your words in sentences.")


### PR DESCRIPTION
When training Word2Vec on a really big dataset, it's really hard to evaluate the right minCount parameter, it would really help having a parameter to choose how many words you want to be in the vocabulary.
Furthermore, the original Word2Vec paper, state that they took into account the most frequent 1M words.
When the mostFrequentK parameter is set, the minCount parameter is ignored. In this way we'll end up with the most frequent k words in the vocabulary.
