### PR TITLE
[SPARK-10111][PySpark] StringIndexerModel lacks of method "labels"

### DIFF
--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -817,6 +817,12 @@ class StringIndexerModel(JavaModel):
     """
     Model fitted by StringIndexer.
     """
+    @property
+    def labels(self):
+        """
+        Labels of StringIndexerModel
+        """
+        return self._call_java("labels")
 
 
 @inherit_doc


### PR DESCRIPTION
PySpark `StringIndexerModel` implements `labels` property.
