### PR TITLE
[SPARK-1267][PYSPARK] Adds pip installer for pyspark

### DIFF
--- a/python/pyspark/__init__.py
+++ b/python/pyspark/__init__.py
@@ -41,7 +41,7 @@ import sys
 
 import xml.etree.ElementTree as ET
 
-if (os.environ.get("SPARK_HOME", "not found") == "not found"):
+if os.environ.get("SPARK_HOME") is None:
     raise ImportError("Environment variable SPARK_HOME is undefined.")
 
 spark_home = os.environ['SPARK_HOME']

--- a/python/pyspark/__init__.py
+++ b/python/pyspark/__init__.py
@@ -36,6 +36,33 @@ Public classes:
       Finer-grained cache persistence levels.
 
 """
+import os
+import sys
+
+import xml.etree.ElementTree as ET
+
+if (os.environ.get("SPARK_HOME", "not found") == "not found"):
+    raise ImportError("Environment variable SPARK_HOME is undefined.")
+
+spark_home = os.environ['SPARK_HOME']
+pom_xml_file_path = spark_home + '/pom.xml'
+
+try:
+    tree = ET.parse(pom_xml_file_path)
+    root = tree.getroot()
+    version_tag = root[4].text
+    snapshot_version = version_tag[:5]
+except:
+    raise ImportError("Could not read the spark version, because pom.xml file" +
+                      " is not found in SPARK_HOME(%s) directory." % (spark_home))
+
+from pyspark.pyspark_version import __version__
+if (snapshot_version != __version__):
+    raise ImportError("Incompatible version of Spark(%s) and PySpark(%s)." %
+                      (snapshot_version, __version__))
+
+sys.path.insert(0, os.path.join(os.environ["SPARK_HOME"], "python/lib/py4j-0.8.1-src.zip"))
+
 
 from pyspark.conf import SparkConf
 from pyspark.context import SparkContext

--- a/python/pyspark/__init__.py
+++ b/python/pyspark/__init__.py
@@ -45,7 +45,7 @@ if (os.environ.get("SPARK_HOME", "not found") == "not found"):
     raise ImportError("Environment variable SPARK_HOME is undefined.")
 
 spark_home = os.environ['SPARK_HOME']
-pom_xml_file_path = spark_home + '/pom.xml'
+pom_xml_file_path = os.path.join(spark_home, 'pom.xml')
 
 try:
     tree = ET.parse(pom_xml_file_path)
@@ -60,8 +60,6 @@ from pyspark.pyspark_version import __version__
 if (snapshot_version != __version__):
     raise ImportError("Incompatible version of Spark(%s) and PySpark(%s)." %
                       (snapshot_version, __version__))
-
-sys.path.insert(0, os.path.join(os.environ["SPARK_HOME"], "python/lib/py4j-0.8.1-src.zip"))
 
 
 from pyspark.conf import SparkConf

--- a/python/pyspark/pyspark_version.py
+++ b/python/pyspark/pyspark_version.py
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+__version__ = '1.5.0'

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,14 +6,14 @@ exec(compile(open("pyspark/pyspark_version.py").read(),
    "pyspark/pyspark_version.py", 'exec'))
 VERSION = __version__
 
-setup(name = 'pyspark',
-   version = VERSION,
-   description = 'Apache Spark Python API',
-   author = 'Prabin Banka',
-   author_email = 'prabin.banka@imaginea.com',
-   url = 'https://github.com/apache/spark/tree/master/python',
-   packages = ['pyspark', 'pyspark.mllib', 'pyspark.ml', 'pyspark.sql', 'pyspark.streaming'],
-   data_files = [('pyspark', ['pyspark/pyspark_version.py'])],
-   install_requires = ['numpy>=1.7', 'py4j==0.8.2.1', 'pandas'],
-   license = 'http://www.apache.org/licenses/LICENSE-2.0',
-   )
+setup(name='pyspark',
+    version=VERSION,
+    description='Apache Spark Python API',
+    author='Spark Developers',
+    author_email='dev@spark.apache.org',
+    url='https://github.com/apache/spark/tree/master/python',
+    packages=['pyspark', 'pyspark.mllib', 'pyspark.ml', 'pyspark.sql', 'pyspark.streaming'],
+    data_files=[('pyspark', ['pyspark/pyspark_version.py'])],
+    install_requires=['numpy>=1.7', 'py4j==0.8.2.1', 'pandas'],
+    license='http://www.apache.org/licenses/LICENSE-2.0',
+    )

--- a/python/setup.py
+++ b/python/setup.py
@@ -13,7 +13,6 @@ setup(name='pyspark',
     author_email='dev@spark.apache.org',
     url='https://github.com/apache/spark/tree/master/python',
     packages=['pyspark', 'pyspark.mllib', 'pyspark.ml', 'pyspark.sql', 'pyspark.streaming'],
-    data_files=[('pyspark', ['pyspark/pyspark_version.py'])],
     install_requires=['numpy>=1.7', 'py4j==0.8.2.1', 'pandas'],
     license='http://www.apache.org/licenses/LICENSE-2.0',
     )

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+from setuptools import setup
+
+exec(compile(open("pyspark/pyspark_version.py").read(), 
+   "pyspark/pyspark_version.py", 'exec'))
+VERSION = __version__
+
+setup(name = 'pyspark',
+   version = VERSION,
+   description = 'Apache Spark Python API',
+   author = 'Prabin Banka',
+   author_email = 'prabin.banka@imaginea.com',
+   url = 'https://github.com/apache/spark/tree/master/python',
+   packages = ['pyspark', 'pyspark.mllib', 'pyspark.ml', 'pyspark.sql', 'pyspark.streaming'],
+   data_files = [('pyspark', ['pyspark/pyspark_version.py'])],
+   install_requires = ['numpy>=1.7', 'py4j==0.8.2.1', 'pandas'],
+   license = 'http://www.apache.org/licenses/LICENSE-2.0',
+   )

--- a/python/setup.py
+++ b/python/setup.py
@@ -13,6 +13,10 @@ setup(name='pyspark',
     author_email='dev@spark.apache.org',
     url='https://github.com/apache/spark/tree/master/python',
     packages=['pyspark', 'pyspark.mllib', 'pyspark.ml', 'pyspark.sql', 'pyspark.streaming'],
-    install_requires=['numpy>=1.7', 'py4j==0.8.2.1', 'pandas'],
+    install_requires=['py4j==0.8.2.1'],
+    extras_require = {
+        'ml': ['numpy>=1.7'],
+        'sql': ['pandas'] 
+    },
     license='http://www.apache.org/licenses/LICENSE-2.0',
     )

--- a/python/setup.py
+++ b/python/setup.py
@@ -13,7 +13,7 @@ setup(name='pyspark',
     author_email='dev@spark.apache.org',
     url='https://github.com/apache/spark/tree/master/python',
     packages=['pyspark', 'pyspark.mllib', 'pyspark.ml', 'pyspark.sql', 'pyspark.streaming'],
-    install_requires=['py4j==0.8.2.1'],
+    install_requires=['py4j==0.9'],
     extras_require = {
         'ml': ['numpy>=1.7'],
         'sql': ['pandas'] 


### PR DESCRIPTION
Adds a setup.py so that pyspark can be installed and packaged for pip.  This allows for easier setup, and declaration of dependencies.  Please see this discussion for more of the rationale behind this PR:
http://apache-spark-developers-list.1001551.n3.nabble.com/PySpark-on-PyPi-td12626.html

It is enforced at runtime that there must be a valid SPARK_HOME set, and that the version of pyspark and spark must match exactly.

To be used with pip, the package will need to be registered and uploaded to PyPi, see:
https://docs.python.org/2/distutils/packageindex.html

This code is based on a PR by @prabinb that I've updated due to renewed interest, see:
https://github.com/apache/spark/pull/464
