### PR TITLE
[SPARK-10134][SQL]Optimization for binary comparison

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TypeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TypeUtils.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.util
 
+import com.google.common.primitives.UnsignedBytes
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.expressions.RowOrdering
 import org.apache.spark.sql.types._
@@ -62,10 +63,6 @@ object TypeUtils {
   }
 
   def compareBinary(x: Array[Byte], y: Array[Byte]): Int = {
-    for (i <- 0 until x.length; if i < y.length) {
-      val res = x(i).compareTo(y(i))
-      if (res != 0) return res
-    }
-    x.length - y.length
+    UnsignedBytes.lexicographicalComparator().compare(x, y)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TypeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/TypeUtils.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.util
 
-import com.google.common.primitives.UnsignedBytes
+import com.google.common.primitives.SignedBytes
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.expressions.RowOrdering
 import org.apache.spark.sql.types._
@@ -63,6 +63,6 @@ object TypeUtils {
   }
 
   def compareBinary(x: Array[Byte], y: Array[Byte]): Int = {
-    UnsignedBytes.lexicographicalComparator().compare(x, y)
+    SignedBytes.lexicographicalComparator().compare(x, y)
   }
 }


### PR DESCRIPTION
In jdk9, probably we can use the JDK API directly for the binary comparison.
https://bugs.openjdk.java.net/browse/JDK-8033148
