### PR TITLE
[SPARK-8436][SQL] Inconsistent behavior when converting a Timestamp column to Integer/Long and then convert back to Timestamp

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -198,11 +198,11 @@ case class Cast(child: Expression, dataType: DataType)
 
   // converting milliseconds to us
   private[this] def longToTimestamp(t: Long): Long = t * 1000L
-  // converting us to seconds
-  private[this] def timestampToLong(ts: Long): Long = math.floor(ts.toDouble / 1000000L).toLong
-  // converting us to seconds in double
+  // converting us to milliseconds
+  private[this] def timestampToLong(ts: Long): Long = math.floor(ts.toDouble / 1000L).toLong
+  // converting us to milliseconds in double
   private[this] def timestampToDouble(ts: Long): Double = {
-    ts / 1000000.0
+    ts / 1000.0
   }
 
   // DateConverter

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -887,4 +887,12 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
       .select(struct($"b"))
       .collect()
   }
+
+  test("SPARK-8436: When convert Timestamp to Long, return milliseconds.") {
+    val ms = new java.sql.Timestamp(1440065000)
+    val df = Seq(Tuple1(ms)).toDF("time")
+    val res = df.select(df("time") cast LongType cast TimestampType).first()
+    assert(res === Row(ms))
+  }
+
 }


### PR DESCRIPTION
### abstract

Through casting Timestamp to Long and Long to Timestamp, we should use same time unit.
I aligned milliseconds.
### issue
- [Inconsistent behavior when converting a Timestamp column to Integer/Long and then convert back to Timestamp](https://issues.apache.org/jira/browse/SPARK-8436)
- My JIRA name is https://issues.apache.org/jira/secure/ViewProfile.jspa?name=x1
