### PR TITLE
[SPARK-10148][Streaming]Display active and inactive receiver numbers in Streaming page

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingJobProgressListener.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingJobProgressListener.scala
@@ -148,6 +148,14 @@ private[streaming] class StreamingJobProgressListener(ssc: StreamingContext)
     receiverInfos.size
   }
 
+  def numActiveReceivers: Int = synchronized {
+    receiverInfos.count(_._2.active)
+  }
+
+  def numInactiveReceivers: Int = {
+    ssc.graph.getReceiverInputStreams().size - numActiveReceivers
+  }
+
   def numTotalCompletedBatches: Long = synchronized {
     totalCompletedBatches
   }

--- a/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingPage.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingPage.scala
@@ -303,6 +303,7 @@ private[ui] class StreamingPage(parent: StreamingTab)
 
     val numCompletedBatches = listener.retainedCompletedBatches.size
     val numActiveBatches = batchTimes.length - numCompletedBatches
+    val numReceivers = listener.numInactiveReceivers + listener.numActiveReceivers
     val table =
       // scalastyle:off
       <table id="stat-table" class="table table-bordered" style="width: auto">
@@ -330,7 +331,11 @@ private[ui] class StreamingPage(parent: StreamingTab)
                 }
               }
               </div>
-              <div>{listener.numActiveReceivers}/{listener.numInactiveReceivers + listener.numActiveReceivers} receiver(s) active</div>
+              {
+                if (numReceivers > 0) {
+                  <div>Receivers: {listener.numActiveReceivers} / {numReceivers} active</div>
+                }
+              }
               <div>Avg: {eventRateForAllStreams.formattedAvg} events/sec</div>
             </div>
           </td>

--- a/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingPage.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingPage.scala
@@ -173,10 +173,6 @@ private[ui] class StreamingPage(parent: StreamingTab)
 
   /** Generate basic information of the streaming program */
   private def generateBasicInfo(): Seq[Node] = {
-    val (numActiveReceivers, numInactiveReceivers) = listener.synchronized {
-      (listener.numActiveReceivers, listener.numInactiveReceivers)
-    }
-
     val timeSinceStart = System.currentTimeMillis() - startTime
     <div>Running batches of
       <strong>
@@ -191,9 +187,7 @@ private[ui] class StreamingPage(parent: StreamingTab)
         {SparkUIUtils.formatDate(startTime)}
       </strong>
       (<strong>{listener.numTotalCompletedBatches}</strong>
-      completed batches, <strong>{listener.numTotalReceivedRecords}</strong> records,
-      <strong>{numActiveReceivers}</strong> active receivers,
-      <strong>{numInactiveReceivers}</strong> inactive receivers)
+      completed batches, <strong>{listener.numTotalReceivedRecords}</strong> records)
     </div>
     <br />
   }
@@ -336,6 +330,7 @@ private[ui] class StreamingPage(parent: StreamingTab)
                 }
               }
               </div>
+              <div>{listener.numActiveReceivers}/{listener.numInactiveReceivers + listener.numActiveReceivers} receiver(s) active</div>
               <div>Avg: {eventRateForAllStreams.formattedAvg} events/sec</div>
             </div>
           </td>

--- a/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingPage.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingPage.scala
@@ -173,6 +173,10 @@ private[ui] class StreamingPage(parent: StreamingTab)
 
   /** Generate basic information of the streaming program */
   private def generateBasicInfo(): Seq[Node] = {
+    val (numActiveReceivers, numInactiveReceivers) = listener.synchronized {
+      (listener.numActiveReceivers, listener.numInactiveReceivers)
+    }
+
     val timeSinceStart = System.currentTimeMillis() - startTime
     <div>Running batches of
       <strong>
@@ -187,7 +191,9 @@ private[ui] class StreamingPage(parent: StreamingTab)
         {SparkUIUtils.formatDate(startTime)}
       </strong>
       (<strong>{listener.numTotalCompletedBatches}</strong>
-      completed batches, <strong>{listener.numTotalReceivedRecords}</strong> records)
+      completed batches, <strong>{listener.numTotalReceivedRecords}</strong> records,
+      <strong>{numActiveReceivers}</strong> active receivers,
+      <strong>{numInactiveReceivers}</strong> inactive receivers)
     </div>
     <br />
   }


### PR DESCRIPTION
Added the active and inactive receiver numbers in the summary section of Streaming page.

<img width="1074" alt="screen shot 2015-08-21 at 2 08 54 pm" src="https://cloud.githubusercontent.com/assets/1000778/9402437/ff2806a2-480f-11e5-8f8e-efdf8e5d514d.png">
