### PR TITLE
[SPARK-10154][SQL] remove the no-longer-necessary CatalystScan

### DIFF
--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -192,6 +192,10 @@ object MimaExcludes {
             // SPARK-9704 Made ProbabilisticClassifier, Identifiable, VectorUDT public APIs
             ProblemFilters.exclude[IncompatibleResultTypeProblem](
               "org.apache.spark.mllib.linalg.VectorUDT.serialize")
+          ) ++ Seq(
+            // SPARK-10154 remove the no-longer-necessary CatalystScan
+            ProblemFilters.exclude[MissingClassProblem](
+              "org.apache.spark.sql.sources.CatalystScan")
           )
 
         case v if v.startsWith("1.4") =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -36,13 +36,6 @@ import org.apache.spark.util.{SerializableConfiguration, Utils}
  */
 private[sql] object DataSourceStrategy extends Strategy with Logging {
   def apply(plan: LogicalPlan): Seq[execution.SparkPlan] = plan match {
-    case PhysicalOperation(projects, filters, l @ LogicalRelation(t: CatalystScan)) =>
-      pruneFilterProjectRaw(
-        l,
-        projects,
-        filters,
-        (a, f) => toCatalystRDD(l, a, t.buildScan(a, f))) :: Nil
-
     case PhysicalOperation(projects, filters, l @ LogicalRelation(t: PrunedFilteredScan)) =>
       pruneFilterProject(
         l,

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -190,6 +190,29 @@ trait CreatableRelationProvider {
 
 /**
  * ::DeveloperApi::
+ * A BaseRelation that can be used to insert data into it through the insert method.
+ * If overwrite in insert method is true, the old data in the relation should be overwritten with
+ * the new data. If overwrite in insert method is false, the new data should be appended.
+ *
+ * InsertableRelation has the following three assumptions.
+ * 1. It assumes that the data (Rows in the DataFrame) provided to the insert method
+ * exactly matches the ordinal of fields in the schema of the BaseRelation.
+ * 2. It assumes that the schema of this relation will not be changed.
+ * Even if the insert method updates the schema (e.g. a relation of JSON or Parquet data may have a
+ * schema update after an insert operation), the new schema will not be used.
+ * 3. It assumes that fields of the data provided in the insert method are nullable.
+ * If a data source needs to check the actual nullability of a field, it needs to do it in the
+ * insert method.
+ *
+ * @since 1.3.0
+ */
+@DeveloperApi
+trait InsertableRelation {
+  def insert(data: DataFrame, overwrite: Boolean): Unit
+}
+
+/**
+ * ::DeveloperApi::
  * Represents a collection of tuples with a known schema. Classes that extend BaseRelation must
  * be able to produce the schema of their data in the form of a [[StructType]]. Concrete
  * implementation should inherit from one of the descendant `Scan` classes, which define various
@@ -275,44 +298,6 @@ trait PrunedScan {
 @DeveloperApi
 trait PrunedFilteredScan {
   def buildScan(requiredColumns: Array[String], filters: Array[Filter]): RDD[Row]
-}
-
-/**
- * ::DeveloperApi::
- * A BaseRelation that can be used to insert data into it through the insert method.
- * If overwrite in insert method is true, the old data in the relation should be overwritten with
- * the new data. If overwrite in insert method is false, the new data should be appended.
- *
- * InsertableRelation has the following three assumptions.
- * 1. It assumes that the data (Rows in the DataFrame) provided to the insert method
- * exactly matches the ordinal of fields in the schema of the BaseRelation.
- * 2. It assumes that the schema of this relation will not be changed.
- * Even if the insert method updates the schema (e.g. a relation of JSON or Parquet data may have a
- * schema update after an insert operation), the new schema will not be used.
- * 3. It assumes that fields of the data provided in the insert method are nullable.
- * If a data source needs to check the actual nullability of a field, it needs to do it in the
- * insert method.
- *
- * @since 1.3.0
- */
-@DeveloperApi
-trait InsertableRelation {
-  def insert(data: DataFrame, overwrite: Boolean): Unit
-}
-
-/**
- * ::Experimental::
- * An interface for experimenting with a more direct connection to the query planner.  Compared to
- * [[PrunedFilteredScan]], this operator receives the raw expressions from the
- * [[org.apache.spark.sql.catalyst.plans.logical.LogicalPlan]].  Unlike the other APIs this
- * interface is NOT designed to be binary compatible across releases and thus should only be used
- * for experimentation.
- *
- * @since 1.3.0
- */
-@Experimental
-trait CatalystScan {
-  def buildScan(requiredColumns: Seq[Attribute], filters: Seq[Expression]): RDD[Row]
 }
 
 /**


### PR DESCRIPTION
There is no build-in data source depending on it and no example to demonstrate how to use it.
