### PR TITLE
[SPARK-10121] [SQL] [WIP] When add jar, also explicitly set the classloader of metadataHive's HiveConf inside metadataHive's state.

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientInterface.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientInterface.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.hive.client
 import java.io.PrintStream
 import java.util.{Map => JMap}
 
+import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.spark.sql.catalyst.analysis.{NoSuchDatabaseException, NoSuchTableException}
 import org.apache.spark.sql.catalyst.expressions.Expression
 
@@ -90,6 +91,9 @@ private[hive] trait ClientInterface {
 
   /** Returns the Hive Version of this client. */
   def version: HiveVersion
+
+  /** Returns the initial HiveConf used to create this client. */
+  def initialConf: HiveConf
 
   /** Returns the configuration for the given key in the current session. */
   def getConf(key: String, defaultValue: String): String

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
@@ -184,6 +184,8 @@ private[hive] class ClientWrapper(
   /** Returns the configuration for the current session. */
   def conf: HiveConf = SessionState.get().getConf
 
+  override def initialConf: HiveConf = state.getConf
+
   override def getConf(key: String, defaultValue: String): String = {
     conf.get(key, defaultValue)
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/commands.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/commands.scala
@@ -100,8 +100,9 @@ case class AddJar(path: String) extends RunnableCommand {
     // returns the value of a thread local variable and its HiveConf may not be the HiveConf
     // associated with `executionHive.state` (for example, HiveContext is created in one thread
     // and then add jar is called from another thread).
-    hiveContext.executionHive.state.getConf.setClassLoader(newClassLoader)
+    hiveContext.executionHive.initialConf.setClassLoader(newClassLoader)
     // Add jar to isolated hive (metadataHive) class loader.
+    hiveContext.metadataHive.initialConf.setClassLoader(newClassLoader)
     hiveContext.runSqlHive(s"ADD JAR $path")
 
     // Add jar to executors


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-10121

This will make sure the HiveConf inside metadataHive's state actually loads the class. Otherwise, if we add jar in one thread and the query using the custom class in another thread, we may see ClassNotFoundException.
