### PR TITLE
[SPARK-3533][Core] Add saveAsTextFileByKey() method to RDDs

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/java/JavaPairRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaPairRDD.scala
@@ -770,6 +770,24 @@ class JavaPairRDD[K, V](val rdd: RDD[(K, V)])
    */
   def lookup(key: K): JList[V] = seqAsJavaList(rdd.lookup(key))
 
+  /**
+   * Save this RDD as multiple text files, using string representations of elements.
+   * File paths are determined by the string representations of keys.
+   */
+  def saveAsTextFileByKey(path: String) {
+    RDD.rddToPairRDDFunctions(rdd).saveAsTextFileByKey(path)
+  }
+
+  /**
+   * Save this RDD as multiple text files, using string representations of elements.
+   * File paths are determined by the string representations of keys.
+   */
+  def saveAsTextFileByKey(
+    path: String,
+    codec: Class[_ <: CompressionCodec]) {
+    RDD.rddToPairRDDFunctions(rdd).saveAsTextFileByKey(path, codec)
+  }
+
   /** Output the RDD to any Hadoop-supported file system. */
   def saveAsHadoopFile[F <: OutputFormat[_, _]](
       path: String,

--- a/core/src/main/scala/org/apache/spark/io/RDDMultipleTextOutputFormat.scala
+++ b/core/src/main/scala/org/apache/spark/io/RDDMultipleTextOutputFormat.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.io
+
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.io.NullWritable
+import org.apache.hadoop.mapred.lib.MultipleTextOutputFormat
+
+/**
+ * This class extends the MultipleTextOutputFormat, allowing to write RDD
+ * data to different text files by key.
+ */
+class RDDMultipleTextOutputFormat[K, V] extends MultipleTextOutputFormat[K, V] {
+  override def generateActualKey(key: K, value: V): K =
+    NullWritable.get().asInstanceOf[K]
+
+  override def generateFileNameForKeyValue(key: K, value: V, name: String): String =
+    new Path(key.toString, name).toString
+}

--- a/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PairRDDFunctions.scala
@@ -41,6 +41,7 @@ import org.apache.spark.Partitioner.defaultPartitioner
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.executor.{DataWriteMethod, OutputMetrics}
+import org.apache.spark.io.RDDMultipleTextOutputFormat
 import org.apache.spark.mapreduce.SparkHadoopMapReduceUtil
 import org.apache.spark.partial.{BoundedDouble, PartialResult}
 import org.apache.spark.serializer.Serializer
@@ -886,6 +887,25 @@ class PairRDDFunctions[K, V](self: RDD[(K, V)])
       case None =>
         self.filter(_._1 == key).map(_._2).collect()
     }
+  }
+
+  /**
+   * Save this RDD as multiple text files, using string representations of elements.
+   * File paths are determined by the string representations of keys.
+   */
+  def saveAsTextFileByKey(
+    path: String): Unit = self.withScope {
+    saveAsHadoopFile(path, keyClass, valueClass, classOf[RDDMultipleTextOutputFormat[K, V]])
+  }
+
+  /**
+   * Save this RDD as multiple text files, using string representations of elements.
+   * File paths are determined by the string representations of keys.
+   */
+  def saveAsTextFileByKey(
+    path: String,
+    codec: Class[_ <: CompressionCodec]): Unit = self.withScope {
+    saveAsHadoopFile(path, keyClass, valueClass, classOf[RDDMultipleTextOutputFormat[K, V]], codec)
   }
 
   /**

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -1507,6 +1507,31 @@ class RDD(object):
         else:
             keyed._jrdd.map(self.ctx._jvm.BytesToString()).saveAsTextFile(path)
 
+    @ignore_unicode_prefix
+    def saveAsTextFileByKey(self, path, keyConverter=None, valueConverter=None,
+                            compressionCodecClass=None):
+        """
+        Save this RDD as multiple text files, using string representations of values.
+        File path is determined by string representations of keys.
+
+        @param path: path to text file
+        @param compressionCodecClass: (None by default) string i.e.
+            "org.apache.hadoop.io.compress.GzipCodec"
+
+        >>> tempFile = NamedTemporaryFile(delete=True)
+        >>> tempFile.close()
+        >>> sc.parallelize(zip(['a','b'] * 2, range(4))).saveAsTextFileByKey(tempFile.name)
+        >>> from fileinput import input
+        >>> from glob import glob
+        >>> ''.join(sorted(input(glob(tempFile.name + "/a/part-0000*"))))
+        '0\\n2\\n'
+        >>> ''.join(sorted(input(glob(tempFile.name + "/b/part-0000*"))))
+        '1\\n3\\n'
+        """
+        self.ctx._jvm.PythonRDD.saveAsTextFileByKey(self._jrdd, True,
+                                                     path, keyConverter, valueConverter,
+                                                     compressionCodecClass)
+
     # Pair functions
 
     def collectAsMap(self):


### PR DESCRIPTION
This adds the functionality of saving a `RDD[(K, V)]` to multiple text files split by key. It covers Scala/Java/Python API. 

This is based on the Stackoverflow answer linked in the original JIRA and  https://github.com/apache/spark/pull/4895. 
Furthermore, I have fixed an issue where part filenames were not included in the paths causing executors to override each other. Tests verify written contents.

I'm very intrigued by @silasdavis's approach to use `MultipleOutputs` providing a more generic interface to write arbitrary outputs by key: https://gist.github.com/silasdavis/d1d1f1f7ab78249af462
However I have been unsuccessful porting it to work with Hadoop 1 mapred API.

Therefore I'm put forth this PR that achieves the simpler but highly requested goal of writing text files only.
