### PR TITLE
[SPARK-8510] [CORE] [PYSPARK] NumPy matrices as values in sequence files

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/ArrayWritableConverters.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/ArrayWritableConverters.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.api.python
+
+import org.apache.hadoop.io._
+import org.apache.spark.SparkException
+
+private[python] class DoubleArrayWritable extends ArrayWritable(classOf[DoubleWritable])
+
+private[python] class BytesArrayWritable extends ArrayWritable(classOf[BytesWritable])
+
+private[python] class ByteArrayToWritableConverter extends Converter[Any, Writable] {
+
+    override def convert(obj: Any) = obj match {
+      case aob: Array[Byte] => new BytesWritable(aob)
+      case other =>
+        val simpleName = other.getClass.getSimpleName
+        throw new SparkException(s"Data of type $simpleName is not supported")
+    }
+}
+
+private[python] class WritableToByteArrayConverter extends Converter[Any, Array[Byte]] {
+
+  override def convert(obj: Any) = obj match {
+    case bw : BytesWritable => bw.getBytes
+    case other => throw new SparkException(s"Data of type $other is not supported")
+  }
+}
+
+private[python] class DoubleArrayToWritableConverter extends Converter[Any, Writable] {
+
+  override def convert(obj: Any) = obj match {
+      case arr: Array[Double] =>
+        val daw = new DoubleArrayWritable
+        daw.set(arr.asInstanceOf[Array[Double]].map(new DoubleWritable(_)))
+        daw
+      case other => throw new SparkException(s"Data of type $other is not supported")
+    }
+}
+
+private[python] class WritableToDoubleArrayConverter extends Converter[Any, Array[Double]] {
+
+  override def convert(obj: Any) = obj match {
+    case daw : DoubleArrayWritable => daw.get.map(_.asInstanceOf[DoubleWritable].get)
+    case other => throw new SparkException(s"Data of type $other is not supported")
+  }
+}

--- a/core/src/main/scala/org/apache/spark/api/python/PythonHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonHadoopUtil.scala
@@ -138,11 +138,6 @@ private[python] class JavaToWritableConverter extends Converter[Any, Writable] {
           mapWritable.put(convertToWritable(k), convertToWritable(v))
         }
         mapWritable
-      case array: Array[Any] => {
-        val arrayWriteable = new ArrayWritable(classOf[Writable])
-        arrayWriteable.set(array.map(convertToWritable(_)))
-        arrayWriteable
-      }
       case other => throw new SparkException(
         s"Data of type ${other.getClass.getName} cannot be used")
     }

--- a/core/src/main/scala/org/apache/spark/api/python/WriteInputFormatTestDataGenerator.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/WriteInputFormatTestDataGenerator.scala
@@ -25,7 +25,6 @@ import com.google.common.base.Charsets.UTF_8
 import org.apache.hadoop.io._
 import org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat
 
-import org.apache.spark.SparkException
 import org.apache.spark.api.java.JavaSparkContext
 
 /**
@@ -82,25 +81,6 @@ private[python] class TestOutputValueConverter extends Converter[Any, Any] {
   }
 }
 
-private[python] class DoubleArrayWritable extends ArrayWritable(classOf[DoubleWritable])
-
-private[python] class DoubleArrayToWritableConverter extends Converter[Any, Writable] {
-  override def convert(obj: Any): DoubleArrayWritable = obj match {
-    case arr if arr.getClass.isArray && arr.getClass.getComponentType == classOf[Double] =>
-      val daw = new DoubleArrayWritable
-      daw.set(arr.asInstanceOf[Array[Double]].map(new DoubleWritable(_)))
-      daw
-    case other => throw new SparkException(s"Data of type $other is not supported")
-  }
-}
-
-private[python] class WritableToDoubleArrayConverter extends Converter[Any, Array[Double]] {
-  override def convert(obj: Any): Array[Double] = obj match {
-    case daw : DoubleArrayWritable => daw.get().map(_.asInstanceOf[DoubleWritable].get())
-    case other => throw new SparkException(s"Data of type $other is not supported")
-  }
-}
-
 /**
  * This object contains method to generate SequenceFile test data and write it to a
  * given directory (probably a temp directory)
@@ -143,7 +123,7 @@ object WriteInputFormatTestDataGenerator {
       (new IntWritable(k), NullWritable.get())
     }.saveAsSequenceFile(nullPath)
 
-    // Create test data for ArrayWritable
+    // Create test data for DoubleArrayWritable
     val data = Seq(
       (1, Array()),
       (2, Array(3.0, 4.0, 5.0)),
@@ -185,6 +165,4 @@ object WriteInputFormatTestDataGenerator {
       classOf[Text], classOf[TestWritable],
       classOf[SequenceFileOutputFormat[Text, TestWritable]])
   }
-
-
 }

--- a/core/src/test/scala/org/apache/spark/api/python/PythonHadoopUtilSuite.scala
+++ b/core/src/test/scala/org/apache/spark/api/python/PythonHadoopUtilSuite.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except expected compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to expected writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.api.python
+
+import org.scalatest.FunSuite
+import org.scalatest.Matchers._
+
+import scala.language.implicitConversions
+
+class ShouldBeClose private (lhs: Either[Array[Double], Double]) {
+  val precision = 1e-7
+
+  def shouldBeClose(rhs: Double) = {
+    val lhsVal = lhs.right.get
+    rhs +- precision == lhsVal +- precision
+  }
+
+  def shouldBeClose(rhs: Array[Double]) : Unit = {
+    val lhsVal = lhs.left.get
+    lhsVal.size shouldBe rhs.size
+    (lhsVal.toSeq zip rhs.toSeq).map(e => ShouldBeClose(e._1).shouldBeClose(e._2)).reduceLeft(_ == _) shouldBe true
+  }
+}
+
+object ShouldBeClose {
+   def apply(arg:Array[Double]) = new ShouldBeClose(Left(arg))
+   def apply(arg:Double) = new ShouldBeClose(Right(arg))
+}
+
+class PythonHadoopUtilSuite extends FunSuite {
+
+  implicit def arrayDouble2ArrayDouble(i: Array[Double]) = ShouldBeClose(i)
+
+  test("test convert array of doubles") {
+
+    val expected = Array(1.1, 2.2, 3.3, 4.4, 5.5)
+
+    val daConverter = new DoubleArrayToWritableConverter
+    val writable = daConverter.convert(expected)
+    val writableConverter = new WritableToDoubleArrayConverter()
+    val actual = writableConverter.convert(writable)
+
+    expected shouldBeClose actual
+  }
+
+  test("test convert Array of Bytes to byte array") {
+
+    val expected = Array(1.toByte, 2.toByte, 3.toByte, 5.toByte, 8.toByte, 13.toByte)
+
+    val converter = new ByteArrayToWritableConverter
+    val writable = converter.convert(expected)
+    val writableConverter = new WritableToByteArrayConverter
+    val actual = writableConverter.convert(writable)
+
+    expected shouldEqual actual
+  }
+}

--- a/python/pyspark/__init__.py
+++ b/python/pyspark/__init__.py
@@ -47,6 +47,7 @@ from pyspark.broadcast import Broadcast
 from pyspark.serializers import MarshalSerializer, PickleSerializer
 from pyspark.status import *
 from pyspark.profiler import Profiler, BasicProfiler
+from pyspark.numpyconverter import numpy_to_python, python_to_numpy
 
 # for back compatibility
 from pyspark.sql import SQLContext, HiveContext, SchemaRDD, Row

--- a/python/pyspark/numpyconverter.py
+++ b/python/pyspark/numpyconverter.py
@@ -1,0 +1,67 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import io
+import sys
+
+PY3 = sys.version_info > (3,)
+
+_have_numpy = False
+
+try:
+    import numpy as np
+    _have_numpy = True
+except:
+    # No NumPy 
+    pass
+
+def numpy_to_python(convertable):
+    if not _have_numpy:
+        raise RuntimeError('Numpy is not available')
+
+    if isinstance(convertable, np.generic):
+        return np.asscalar(convertable)
+    elif isinstance(convertable, list):
+        return [numpy_to_python(elem) for elem in convertable]
+    elif isinstance(convertable, tuple):
+        return tuple([numpy_to_python(elem) for elem in convertable])
+    elif isinstance(convertable, np.ndarray):
+        output = io.BytesIO()
+        np.save(output, arr=convertable)
+        output.seek(0)
+
+        if PY3:
+            return bytes(output.read())
+        else:
+            return bytearray(output.read())
+    else:
+        return convertable
+
+
+def python_to_numpy(convertable):
+    if not _have_numpy:
+        raise RuntimeError('Numpy is not available')
+
+    if isinstance(convertable, list):
+        return [python_to_numpy(elem) for elem in convertable]
+    elif isinstance(convertable, tuple):
+        return tuple([python_to_numpy(elem) for elem in convertable])
+    elif (PY3 and isinstance(convertable, bytes)) or isinstance(convertable, bytearray):
+        input_bytes = io.BytesIO(convertable)
+        return np.load(input_bytes)
+    else:
+        return convertable


### PR DESCRIPTION
Added support for storing NumPy arrays and matrices as value elements of Sequence Files.

Each value element is a discrete matrix or array.  This is useful where you have many matrices that you don't want to join into a single Spark DataFrame to store in a Parquet file.
