### PR TITLE
[SPARK-10178][SQL] HiveComparisionTest should print out dependent tables

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveComparisonTest.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveComparisonTest.scala
@@ -19,8 +19,8 @@ package org.apache.spark.sql.hive.execution
 
 import java.io._
 
-import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.hive.MetastoreRelation
+import scala.util.control.NonFatal
+
 import org.scalatest.{BeforeAndAfterAll, GivenWhenThen}
 
 import org.apache.spark.{Logging, SparkFunSuite}
@@ -30,8 +30,6 @@ import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.execution.{SetCommand, ExplainCommand}
 import org.apache.spark.sql.execution.datasources.DescribeCommand
 import org.apache.spark.sql.hive.test.TestHive
-
-import scala.util.control.NonFatal
 
 /**
  * Allows the creations of tests that execute the same query against both hive

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveComparisonTest.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveComparisonTest.scala
@@ -423,7 +423,7 @@ abstract class HiveComparisonTest
               } catch {
                 case NonFatal(e) =>
                   e.printStackTrace()
-                  s"Couldn't compute tables: $e"
+                  s"Couldn't compute dependent tables: $e"
               }
 
               val errorMessage =


### PR DESCRIPTION
In `HiveComparisionTest`s it is possible to fail a query of the form `SELECT * FROM dest1`, where `dest1` is the query that is actually computing the incorrect results.  To aid debugging this patch improves the harness to also print these query plans and their results.
