### PR TITLE
[SPARK-10182] [MLlib] GeneralizedLinearModel doesn't unpersist cached data

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/GeneralizedLinearAlgorithm.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/GeneralizedLinearAlgorithm.scala
@@ -353,7 +353,7 @@ abstract class GeneralizedLinearAlgorithm[M <: GeneralizedLinearModel]
 
     // Warn at the end of the run as well, for increased visibility.
     if (input.getStorageLevel == StorageLevel.NONE) {
-      logWarning("The input data is not directly cached, which may hurt performance if its"
+      logWarning("The input data was not directly cached, which may hurt performance if its"
         + " parent RDDs are also uncached.")
     }
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/GeneralizedLinearAlgorithm.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/GeneralizedLinearAlgorithm.scala
@@ -239,6 +239,11 @@ abstract class GeneralizedLinearAlgorithm[M <: GeneralizedLinearModel]
       numFeatures = input.map(_.features.size).first()
     }
 
+    if (input.getStorageLevel == StorageLevel.NONE) {
+      logWarning("The input data is not directly cached, which may hurt performance if its"
+        + " parent RDDs are also uncached.")
+    }
+
     // Check the data properties before running the optimizer
     if (validateData && !validators.forall(func => func(input))) {
       throw new SparkException("Input validation failed.")
@@ -282,7 +287,7 @@ abstract class GeneralizedLinearAlgorithm[M <: GeneralizedLinearModel]
         if (useFeatureScaling) {
           input.map(lp => (lp.label, scaler.transform(lp.features))).cache()
         } else {
-          input.map(lp => (lp.label, lp.features)).cache()
+          input.map(lp => (lp.label, lp.features))
         }
       }
 
@@ -346,8 +351,16 @@ abstract class GeneralizedLinearAlgorithm[M <: GeneralizedLinearModel]
       }
     }
 
+    // Warn at the end of the run as well, for increased visibility.
+    if (input.getStorageLevel == StorageLevel.NONE) {
+      logWarning("The input data is not directly cached, which may hurt performance if its"
+        + " parent RDDs are also uncached.")
+    }
+
     // Unpersist cached data
-    data.unpersist(false)
+    if (data.getStorageLevel != StorageLevel.NONE) {
+      data.unpersist(false)
+    }
 
     createModel(weights, intercept)
   }


### PR DESCRIPTION
`GeneralizedLinearModel` creates a cached RDD when building a model. It's inconvenient, since these RDDs flood the memory when building several models in a row, so useful data might get evicted from the cache. 

The proposed solution is to always cache the dataset & remove the warning. There's a caveat though: input dataset gets evaluated twice, in line 270 when fitting `StandardScaler` for the first time, and when running optimizer for the second time. So, it might worth to return removed warning.

Another possible solution is to disable caching entirely & return removed warning. I don't really know what approach is better.
