### PR TITLE
[SPARK-10188] [Pyspark] Pyspark CrossValidator with RMSE selects incorrect model

### DIFF
--- a/python/pyspark/ml/evaluation.py
+++ b/python/pyspark/ml/evaluation.py
@@ -66,6 +66,9 @@ class Evaluator(Params):
         else:
             raise ValueError("Params must be a param map but got %s." % type(params))
 
+    def isLargerBetter(self):
+        return True
+
 
 @inherit_doc
 class JavaEvaluator(Evaluator, JavaWrapper):
@@ -84,6 +87,9 @@ class JavaEvaluator(Evaluator, JavaWrapper):
         """
         self._transfer_params_to_java()
         return self._java_obj.evaluate(dataset._jdf)
+
+    def isLargerBetter(self):
+        return self._java_obj.isLargerBetter()
 
 
 @inherit_doc

--- a/python/pyspark/ml/evaluation.py
+++ b/python/pyspark/ml/evaluation.py
@@ -67,6 +67,11 @@ class Evaluator(Params):
             raise ValueError("Params must be a param map but got %s." % type(params))
 
     def isLargerBetter(self):
+        """
+        Indicates whether the metric returned by :py:meth:`evaluate` should be maximized
+        (True, default) or minimized (False).
+        A given evaluator may support multiple metrics which may be maximized or minimized.
+        """
         return True
 
 
@@ -89,6 +94,7 @@ class JavaEvaluator(Evaluator, JavaWrapper):
         return self._java_obj.evaluate(dataset._jdf)
 
     def isLargerBetter(self):
+        self._transfer_params_to_java()
         return self._java_obj.isLargerBetter()
 
 

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -319,8 +319,6 @@ class CrossValidatorTests(PySparkTestCase):
         bestModel = cvModel.bestModel
         bestModelMetric = evaluator.evaluate(bestModel.transform(dataset))
 
-        print bestModel.getOrDefault('inducedError'), "Best model should have zero induced error"
-        print bestModelMetric, "Best model should fit exactly"
         self.assertEqual(0.0, bestModel.getOrDefault('inducedError'), "Best model should have zero induced error")
         self.assertEqual(0.0, bestModelMetric, "Best model has RMSE of 0")
 
@@ -344,8 +342,6 @@ class CrossValidatorTests(PySparkTestCase):
         bestModel = cvModel.bestModel
         bestModelMetric = evaluator.evaluate(bestModel.transform(dataset))
 
-        print bestModel.getOrDefault('inducedError'), "Best model should have zero induced error"
-        print bestModelMetric, "Best model should fit exactly"
         self.assertEqual(0.0, bestModel.getOrDefault('inducedError'), "Best model should have zero induced error")
         self.assertEqual(1.0, bestModelMetric, "Best model has R-squared of 1")
 

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -267,24 +267,26 @@ class FeatureTests(PySparkTestCase):
         self.assertEquals(transformedDF.head().output, ["a b c d", "b c d e"])
 
 
-
 class HasInducedError(Params):
 
     def __init__(self):
         super(HasInducedError, self).__init__()
-        self.inducedError = Param(self, "inducedError", "Uniformly-distributed error added to feature")
+        self.inducedError = Param(self, "inducedError",
+                                  "Uniformly-distributed error added to feature")
 
     def getInducedError(self):
         return self.getOrDefault(self.inducedError)
+
 
 class InducedErrorModel(Model, HasInducedError):
 
     def __init__(self):
         super(InducedErrorModel, self).__init__()
-    
+
     def _transform(self, dataset):
-        return dataset.withColumn("prediction", 
+        return dataset.withColumn("prediction",
                                   dataset.feature + (rand(0) * self.getInducedError()))
+
 
 class InducedErrorEstimator(Estimator, HasInducedError):
 
@@ -297,14 +299,15 @@ class InducedErrorEstimator(Estimator, HasInducedError):
         self._copyValues(model)
         return model
 
+
 class CrossValidatorTests(PySparkTestCase):
 
     def test_fit_minimize_metric(self):
         sqlContext = SQLContext(self.sc)
         dataset = sqlContext.createDataFrame([
-            (10, 10.0), 
-            (50, 50.0), 
-            (100, 100.0), 
+            (10, 10.0),
+            (50, 50.0),
+            (100, 100.0),
             (500, 500.0)] * 10,
             ["feature", "label"])
 
@@ -312,22 +315,23 @@ class CrossValidatorTests(PySparkTestCase):
         evaluator = RegressionEvaluator(metricName="rmse")
 
         grid = (ParamGridBuilder()
-            .addGrid( iee.inducedError, [100.0, 0.0, 10000.0] )
-            .build())
+                .addGrid(iee.inducedError, [100.0, 0.0, 10000.0])
+                .build())
         cv = CrossValidator(estimator=iee, estimatorParamMaps=grid, evaluator=evaluator)
         cvModel = cv.fit(dataset)
         bestModel = cvModel.bestModel
         bestModelMetric = evaluator.evaluate(bestModel.transform(dataset))
 
-        self.assertEqual(0.0, bestModel.getOrDefault('inducedError'), "Best model should have zero induced error")
+        self.assertEqual(0.0, bestModel.getOrDefault('inducedError'),
+                         "Best model should have zero induced error")
         self.assertEqual(0.0, bestModelMetric, "Best model has RMSE of 0")
 
     def test_fit_maximize_metric(self):
         sqlContext = SQLContext(self.sc)
         dataset = sqlContext.createDataFrame([
-            (10, 10.0), 
-            (50, 50.0), 
-            (100, 100.0), 
+            (10, 10.0),
+            (50, 50.0),
+            (100, 100.0),
             (500, 500.0)] * 10,
             ["feature", "label"])
 
@@ -335,14 +339,15 @@ class CrossValidatorTests(PySparkTestCase):
         evaluator = RegressionEvaluator(metricName="r2")
 
         grid = (ParamGridBuilder()
-            .addGrid( iee.inducedError, [100.0, 0.0, 10000.0] )
-            .build())
+                .addGrid(iee.inducedError, [100.0, 0.0, 10000.0])
+                .build())
         cv = CrossValidator(estimator=iee, estimatorParamMaps=grid, evaluator=evaluator)
         cvModel = cv.fit(dataset)
         bestModel = cvModel.bestModel
         bestModelMetric = evaluator.evaluate(bestModel.transform(dataset))
 
-        self.assertEqual(0.0, bestModel.getOrDefault('inducedError'), "Best model should have zero induced error")
+        self.assertEqual(0.0, bestModel.getOrDefault('inducedError'),
+                         "Best model should have zero induced error")
         self.assertEqual(1.0, bestModelMetric, "Best model has R-squared of 1")
 
 

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -223,7 +223,7 @@ class CrossValidator(Estimator):
                 # TODO: duplicate evaluator to take extra params from input
                 metric = eva.evaluate(model.transform(validation, epm[j]))
                 metrics[j] += metric
-        
+
         if eva.isLargerBetter():
             bestIndex = np.argmax(metrics)
         else:

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -223,7 +223,11 @@ class CrossValidator(Estimator):
                 # TODO: duplicate evaluator to take extra params from input
                 metric = eva.evaluate(model.transform(validation, epm[j]))
                 metrics[j] += metric
-        bestIndex = np.argmax(metrics)
+        
+        if eva.isLargerBetter():
+            bestIndex = np.argmax(metrics)
+        else:
+            bestIndex = np.argmin(metrics)
         bestModel = est.fit(dataset, epm[bestIndex])
         return CrossValidatorModel(bestModel)
 


### PR DESCRIPTION
- Added isLargerBetter() method to Pyspark Evaluator to match the Scala version.
- JavaEvaluator delegates isLargerBetter() to underlying Scala object.
- Added check for isLargerBetter() in CrossValidator to determine whether to use argmin or argmax.
- Added test cases for where smaller is better (RMSE) and larger is better (R-Squared).

(This contribution is my original work and that I license the work to the project under Sparks' open source license)
