### PR TITLE
[SPARK-10215][SQL][WIP]Div of Decimal returns null

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalType.scala
@@ -106,8 +106,8 @@ object DecimalType extends AbstractDataType {
   import scala.math.min
 
   val MAX_PRECISION = 38
-  val MAX_SCALE = 38
-  val SYSTEM_DEFAULT: DecimalType = DecimalType(MAX_PRECISION, 18)
+  val MAX_SCALE = 18
+  val SYSTEM_DEFAULT: DecimalType = DecimalType(MAX_PRECISION, MAX_SCALE)
   val USER_DEFAULT: DecimalType = DecimalType(10, 0)
 
   @deprecated("Does not support unlimited precision, please specify the precision and scale", "1.5")


### PR DESCRIPTION
``` scala
val d = Decimal(1.12321)
val df = Seq((d, 1)).toDF("a", "b")
df.selectExpr("b * a / b").collect()  // => Array(Row(null))
```

Seems we respect the scale part of a decimal more than the integral part, which causes incorrect overflow checking(returns null).
