### PR TITLE
[SPARK-9964] [PySpark] [SQL] PySpark DataFrameReader accept RDD of String for JSON

### DIFF
--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -123,45 +123,35 @@ class DataFrameReader(object):
             return self._df(self._jreader.load())
 
     @since(1.4)
-    def json(self, path, schema=None):
+    def json(self, pathOrRdd, schema=None):
         """
-        Loads a JSON file (one object per line) and returns the result as
-        a :class`DataFrame`.
+        Loads a JSON file (one object per line) or an RDD of Strings storing JSON objects
+        (one object per record) and returns the result as a :class`DataFrame`.
 
         If the ``schema`` parameter is not specified, this function goes
         through the input once to determine the input schema.
 
-        :param path: string, path to the JSON dataset.
+        :param pathOrRdd: string represents path to the JSON dataset,
+                          or RDD of Strings storing JSON objects.
         :param schema: an optional :class:`StructType` for the input schema.
 
-        >>> df = sqlContext.read.json('python/test_support/sql/people.json')
-        >>> df.dtypes
+        >>> df1 = sqlContext.read.json('python/test_support/sql/people.json')
+        >>> df1.dtypes
         [('age', 'bigint'), ('name', 'string')]
-
-        """
-        if schema is not None:
-            self.schema(schema)
-        return self._df(self._jreader.json(path))
-
-    def json(self, rdd, schema=None):
-        """
-        Loads an RDD of Strings storing JSON objects (one object per record)
-        and returns the result as a :class`DataFrame`.
-
-        If the ``schema`` parameter is not specified, this function goes
-        through the input once to determine the input schema.
-
-        :param rdd: RDD of Strings storing JSON objects.
-        :param schema: an optional :class:`StructType` for the input schema.
-
         >>> rdd = sc.textFile('python/test_support/sql/people.json')
-        >>> df = sqlContext.read.json(rdd)
-        >>> df.dtypes
+        >>> df2 = sqlContext.read.json(rdd)
+        >>> df2.dtypes
         [('age', 'bigint'), ('name', 'string')]
+
         """
         if schema is not None:
             self.schema(schema)
-        return self._df(self._jreader.json(rdd._jrdd))
+        if isinstance(pathOrRdd, basestring):
+            return self._df(self._jreader.json(pathOrRdd))
+        elif isinstance(pathOrRdd, RDD):
+            return self._df(self._jreader.json(pathOrRdd._jrdd))
+        else:
+            raise Exception("DataFrameReader.json can only load path or RDD")
 
     @since(1.4)
     def table(self, tableName):

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -129,7 +129,7 @@ class DataFrameReader(object):
             return self._df(self._jreader.load())
 
     @since(1.4)
-    def json(self, pathOrRdd, schema=None):
+    def json(self, path, schema=None):
         """
         Loads a JSON file (one object per line) or an RDD of Strings storing JSON objects
         (one object per record) and returns the result as a :class`DataFrame`.
@@ -137,7 +137,7 @@ class DataFrameReader(object):
         If the ``schema`` parameter is not specified, this function goes
         through the input once to determine the input schema.
 
-        :param pathOrRdd: string represents path to the JSON dataset,
+        :param path: string represents path to the JSON dataset,
                           or RDD of Strings storing JSON objects.
         :param schema: an optional :class:`StructType` for the input schema.
 
@@ -152,12 +152,12 @@ class DataFrameReader(object):
         """
         if schema is not None:
             self.schema(schema)
-        if isinstance(pathOrRdd, basestring):
-            return self._df(self._jreader.json(pathOrRdd))
-        elif isinstance(pathOrRdd, RDD):
-            return self._df(self._jreader.json(pathOrRdd._jrdd))
+        if isinstance(path, basestring):
+            return self._df(self._jreader.json(path))
+        elif isinstance(path, RDD):
+            return self._df(self._jreader.json(path._jrdd))
         else:
-            raise Exception("DataFrameReader.json can only load path or RDD")
+            raise Exception("path can be only string or RDD")
 
     @since(1.4)
     def table(self, tableName):

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -15,8 +15,14 @@
 # limitations under the License.
 #
 
+import sys
+
+if sys.version >= '3':
+    basestring = unicode = str
+
 from py4j.java_gateway import JavaClass
 
+from pyspark import RDD
 from pyspark.sql import since
 from pyspark.sql.column import _to_seq
 from pyspark.sql.types import *

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -157,7 +157,7 @@ class DataFrameReader(object):
         elif isinstance(path, RDD):
             return self._df(self._jreader.json(path._jrdd))
         else:
-            raise Exception("path can be only string or RDD")
+            raise TypeError("path can be only string or RDD")
 
     @since(1.4)
     def table(self, tableName):

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -138,7 +138,7 @@ class DataFrameReader(object):
         through the input once to determine the input schema.
 
         :param path: string represents path to the JSON dataset,
-                          or RDD of Strings storing JSON objects.
+                     or RDD of Strings storing JSON objects.
         :param schema: an optional :class:`StructType` for the input schema.
 
         >>> df1 = sqlContext.read.json('python/test_support/sql/people.json')

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -143,6 +143,26 @@ class DataFrameReader(object):
             self.schema(schema)
         return self._df(self._jreader.json(path))
 
+    def json(self, rdd, schema=None):
+        """
+        Loads an RDD of Strings storing JSON objects (one object per record)
+        and returns the result as a :class`DataFrame`.
+
+        If the ``schema`` parameter is not specified, this function goes
+        through the input once to determine the input schema.
+
+        :param rdd: RDD of Strings storing JSON objects.
+        :param schema: an optional :class:`StructType` for the input schema.
+
+        >>> rdd = sc.textFile('python/test_support/sql/people.json')
+        >>> df = sqlContext.read.json(rdd)
+        >>> df.dtypes
+        [('age', 'bigint'), ('name', 'string')]
+        """
+        if schema is not None:
+            self.schema(schema)
+        return self._df(self._jreader.json(rdd._jrdd))
+
     @since(1.4)
     def table(self, tableName):
         """Returns the specified table as a :class:`DataFrame`.


### PR DESCRIPTION
PySpark DataFrameReader should could accept an RDD of Strings (like the Scala version does) for JSON, rather than only taking a path.
If this PR is merged, it should be duplicated to cover the other input types (not just JSON).
