### PR TITLE
[SPARK-10270][SQL][WIP]Add more java-friendly DF API

### DIFF
--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
@@ -107,6 +107,11 @@ public class JavaDataFrameSuite {
 
     df2.select(rand(), acos("b"));
     df2.select(col("*"), randn(5L));
+
+    DataFrame l = df.toDF("a", "b");
+    DataFrame r = df2.toDF("a", "b");
+    l.join(r, "a", "b");
+    l.join(r, "a");
   }
 
   @Ignore

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
@@ -40,6 +40,10 @@ class DataFrameJoinSuite extends QueryTest with SharedSQLContext {
     checkAnswer(
       df.join(df2, Seq("int", "int2")),
       Row(1, 2, "1", "2") :: Row(2, 3, "2", "3") :: Row(3, 4, "3", "4") :: Nil)
+
+    checkAnswer(
+      df.join(df2, "int", "int2"),
+      Row(1, 2, "1", "2") :: Row(2, 3, "2", "3") :: Row(3, 4, "3", "4") :: Nil)
   }
 
   test("join - join using self join") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -678,6 +678,26 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     checkAnswer(
       testData.dropDuplicates(Seq("value2")),
       Seq(Row(2, 1, 2), Row(1, 1, 1)))
+
+    checkAnswer(
+      testData.dropDuplicates("key", "value1"),
+      Seq(Row(2, 1, 2), Row(1, 2, 1), Row(1, 1, 1), Row(2, 2, 2)))
+
+    checkAnswer(
+      testData.dropDuplicates("value1", "value2"),
+      Seq(Row(2, 1, 2), Row(1, 2, 1), Row(1, 1, 1), Row(2, 2, 2)))
+
+    checkAnswer(
+      testData.dropDuplicates("key"),
+      Seq(Row(2, 1, 2), Row(1, 1, 1)))
+
+    checkAnswer(
+      testData.dropDuplicates("value1"),
+      Seq(Row(2, 1, 2), Row(1, 2, 1)))
+
+    checkAnswer(
+      testData.dropDuplicates("value2"),
+      Seq(Row(2, 1, 2), Row(1, 1, 1)))
   }
 
   test("SPARK-7150 range api") {


### PR DESCRIPTION
Currently in DataFrame, we have API like:

``` scala
def join(right: DataFrame, usingColumns: Seq[String]): DataFrame
def dropDuplicates(colNames: Seq[String]): DataFrame
def dropDuplicates(colNames: Array[String]): DataFrame
```

Those API not like the so friendly to Java programmers, or not like the pattern of the other DF API, so change them to:

``` scala
def join(right: DataFrame, usingColumns: String*): DataFrame
def dropDuplicates(colNames: String*): DataFrame
```

However, when implemeting the 

``` scala
def join(right: DataFrame, usingColumns: String*): DataFrame
def dropDuplicates(colNames: String*): DataFrame
```

There are compiling error says duplicated method with `String*` and `Seq[String]`, so we change the API like:

``` scala
def join(right: DataFrame, colName: String, usingColumns: String*): DataFrame
def dropDuplicates(colName: String, colNames: String*): DataFrame
```
