### PR TITLE
[SPARK-10257][MLlib] Removes Guava from all spark.mllib Java tests

### DIFF
--- a/mllib/src/test/java/org/apache/spark/mllib/classification/JavaStreamingLogisticRegressionSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/classification/JavaStreamingLogisticRegressionSuite.java
@@ -18,11 +18,11 @@
 package org.apache.spark.mllib.classification;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.List;
 
 import scala.Tuple2;
 
-import com.google.common.collect.Lists;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -60,16 +60,16 @@ public class JavaStreamingLogisticRegressionSuite implements Serializable {
   @Test
   @SuppressWarnings("unchecked")
   public void javaAPI() {
-    List<LabeledPoint> trainingBatch = Lists.newArrayList(
+    List<LabeledPoint> trainingBatch = Arrays.asList(
       new LabeledPoint(1.0, Vectors.dense(1.0)),
       new LabeledPoint(0.0, Vectors.dense(0.0)));
     JavaDStream<LabeledPoint> training =
-      attachTestInputStream(ssc, Lists.newArrayList(trainingBatch, trainingBatch), 2);
-    List<Tuple2<Integer, Vector>> testBatch = Lists.newArrayList(
+      attachTestInputStream(ssc, Arrays.asList(trainingBatch, trainingBatch), 2);
+    List<Tuple2<Integer, Vector>> testBatch = Arrays.asList(
       new Tuple2<Integer, Vector>(10, Vectors.dense(1.0)),
       new Tuple2<Integer, Vector>(11, Vectors.dense(0.0)));
     JavaPairDStream<Integer, Vector> test = JavaPairDStream.fromJavaDStream(
-      attachTestInputStream(ssc, Lists.newArrayList(testBatch, testBatch), 2));
+      attachTestInputStream(ssc, Arrays.asList(testBatch, testBatch), 2));
     StreamingLogisticRegressionWithSGD slr = new StreamingLogisticRegressionWithSGD()
       .setNumIterations(2)
       .setInitialWeights(Vectors.dense(0.0));

--- a/mllib/src/test/java/org/apache/spark/mllib/clustering/JavaGaussianMixtureSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/clustering/JavaGaussianMixtureSuite.java
@@ -18,9 +18,9 @@
 package org.apache.spark.mllib.clustering;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.List;
 
-import com.google.common.collect.Lists;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -48,7 +48,7 @@ public class JavaGaussianMixtureSuite implements Serializable {
 
   @Test
   public void runGaussianMixture() {
-    List<Vector> points = Lists.newArrayList(
+    List<Vector> points = Arrays.asList(
       Vectors.dense(1.0, 2.0, 6.0),
       Vectors.dense(1.0, 3.0, 0.0),
       Vectors.dense(1.0, 4.0, 6.0)

--- a/mllib/src/test/java/org/apache/spark/mllib/clustering/JavaKMeansSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/clustering/JavaKMeansSuite.java
@@ -18,14 +18,13 @@
 package org.apache.spark.mllib.clustering;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.*;
-
-import com.google.common.collect.Lists;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -48,7 +47,7 @@ public class JavaKMeansSuite implements Serializable {
 
   @Test
   public void runKMeansUsingStaticMethods() {
-    List<Vector> points = Lists.newArrayList(
+    List<Vector> points = Arrays.asList(
       Vectors.dense(1.0, 2.0, 6.0),
       Vectors.dense(1.0, 3.0, 0.0),
       Vectors.dense(1.0, 4.0, 6.0)
@@ -67,7 +66,7 @@ public class JavaKMeansSuite implements Serializable {
 
   @Test
   public void runKMeansUsingConstructor() {
-    List<Vector> points = Lists.newArrayList(
+    List<Vector> points = Arrays.asList(
       Vectors.dense(1.0, 2.0, 6.0),
       Vectors.dense(1.0, 3.0, 0.0),
       Vectors.dense(1.0, 4.0, 6.0)
@@ -90,7 +89,7 @@ public class JavaKMeansSuite implements Serializable {
 
   @Test
   public void testPredictJavaRDD() {
-    List<Vector> points = Lists.newArrayList(
+    List<Vector> points = Arrays.asList(
       Vectors.dense(1.0, 2.0, 6.0),
       Vectors.dense(1.0, 3.0, 0.0),
       Vectors.dense(1.0, 4.0, 6.0)

--- a/mllib/src/test/java/org/apache/spark/mllib/clustering/JavaStreamingKMeansSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/clustering/JavaStreamingKMeansSuite.java
@@ -18,11 +18,11 @@
 package org.apache.spark.mllib.clustering;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.List;
 
 import scala.Tuple2;
 
-import com.google.common.collect.Lists;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -60,16 +60,16 @@ public class JavaStreamingKMeansSuite implements Serializable {
   @Test
   @SuppressWarnings("unchecked")
   public void javaAPI() {
-    List<Vector> trainingBatch = Lists.newArrayList(
+    List<Vector> trainingBatch = Arrays.asList(
       Vectors.dense(1.0),
       Vectors.dense(0.0));
     JavaDStream<Vector> training =
-      attachTestInputStream(ssc, Lists.newArrayList(trainingBatch, trainingBatch), 2);
-    List<Tuple2<Integer, Vector>> testBatch = Lists.newArrayList(
+      attachTestInputStream(ssc, Arrays.asList(trainingBatch, trainingBatch), 2);
+    List<Tuple2<Integer, Vector>> testBatch = Arrays.asList(
       new Tuple2<Integer, Vector>(10, Vectors.dense(1.0)),
       new Tuple2<Integer, Vector>(11, Vectors.dense(0.0)));
     JavaPairDStream<Integer, Vector> test = JavaPairDStream.fromJavaDStream(
-      attachTestInputStream(ssc, Lists.newArrayList(testBatch, testBatch), 2));
+      attachTestInputStream(ssc, Arrays.asList(testBatch, testBatch), 2));
     StreamingKMeans skmeans = new StreamingKMeans()
       .setK(1)
       .setDecayFactor(1.0)

--- a/mllib/src/test/java/org/apache/spark/mllib/feature/JavaTfIdfSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/feature/JavaTfIdfSuite.java
@@ -18,14 +18,13 @@
 package org.apache.spark.mllib.feature;
 
 import java.io.Serializable;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import com.google.common.collect.Lists;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -50,10 +49,10 @@ public class JavaTfIdfSuite implements Serializable {
     // The tests are to check Java compatibility.
     HashingTF tf = new HashingTF();
     @SuppressWarnings("unchecked")
-    JavaRDD<ArrayList<String>> documents = sc.parallelize(Lists.newArrayList(
-      Lists.newArrayList("this is a sentence".split(" ")),
-      Lists.newArrayList("this is another sentence".split(" ")),
-      Lists.newArrayList("this is still a sentence".split(" "))), 2);
+    JavaRDD<List<String>> documents = sc.parallelize(Arrays.asList(
+      Arrays.asList("this is a sentence".split(" ")),
+      Arrays.asList("this is another sentence".split(" ")),
+      Arrays.asList("this is still a sentence".split(" "))), 2);
     JavaRDD<Vector> termFreqs = tf.transform(documents);
     termFreqs.collect();
     IDF idf = new IDF();
@@ -70,10 +69,10 @@ public class JavaTfIdfSuite implements Serializable {
     // The tests are to check Java compatibility.
     HashingTF tf = new HashingTF();
     @SuppressWarnings("unchecked")
-    JavaRDD<ArrayList<String>> documents = sc.parallelize(Lists.newArrayList(
-      Lists.newArrayList("this is a sentence".split(" ")),
-      Lists.newArrayList("this is another sentence".split(" ")),
-      Lists.newArrayList("this is still a sentence".split(" "))), 2);
+    JavaRDD<List<String>> documents = sc.parallelize(Arrays.asList(
+      Arrays.asList("this is a sentence".split(" ")),
+      Arrays.asList("this is another sentence".split(" ")),
+      Arrays.asList("this is still a sentence".split(" "))), 2);
     JavaRDD<Vector> termFreqs = tf.transform(documents);
     termFreqs.collect();
     IDF idf = new IDF(2);

--- a/mllib/src/test/java/org/apache/spark/mllib/feature/JavaWord2VecSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/feature/JavaWord2VecSuite.java
@@ -18,12 +18,12 @@
 package org.apache.spark.mllib.feature;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.List;
 
 import scala.Tuple2;
 
-import com.google.common.collect.Lists;
-import com.google.common.base.Strings;
+import org.apache.commons.lang.StringUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -50,9 +50,9 @@ public class JavaWord2VecSuite implements Serializable {
   @SuppressWarnings("unchecked")
   public void word2Vec() {
     // The tests are to check Java compatibility.
-    String sentence = Strings.repeat("a b ", 100) + Strings.repeat("a c ", 10);
-    List<String> words = Lists.newArrayList(sentence.split(" "));
-    List<List<String>> localDoc = Lists.newArrayList(words, words);
+    String sentence = StringUtils.repeat("a b ", 100) + StringUtils.repeat("a c ", 10);
+    List<String> words = Arrays.asList(sentence.split(" "));
+    List<List<String>> localDoc = Arrays.asList(words, words);
     JavaRDD<List<String>> doc = sc.parallelize(localDoc);
     Word2Vec word2vec = new Word2Vec()
       .setVectorSize(10)

--- a/mllib/src/test/java/org/apache/spark/mllib/feature/JavaWord2VecSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/feature/JavaWord2VecSuite.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 import scala.Tuple2;
 
-import org.apache.commons.lang.StringUtils;
+import com.google.common.base.Strings;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -50,7 +50,7 @@ public class JavaWord2VecSuite implements Serializable {
   @SuppressWarnings("unchecked")
   public void word2Vec() {
     // The tests are to check Java compatibility.
-    String sentence = StringUtils.repeat("a b ", 100) + StringUtils.repeat("a c ", 10);
+    String sentence = Strings.repeat("a b ", 100) + Strings.repeat("a c ", 10);
     List<String> words = Arrays.asList(sentence.split(" "));
     List<List<String>> localDoc = Arrays.asList(words, words);
     JavaRDD<List<String>> doc = sc.parallelize(localDoc);

--- a/mllib/src/test/java/org/apache/spark/mllib/fpm/JavaAssociationRulesSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/fpm/JavaAssociationRulesSuite.java
@@ -17,16 +17,15 @@
 package org.apache.spark.mllib.fpm;
 
 import java.io.Serializable;
+import java.util.Arrays;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import com.google.common.collect.Lists;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.mllib.fpm.FPGrowth.FreqItemset;
-
 
 public class JavaAssociationRulesSuite implements Serializable {
   private transient JavaSparkContext sc;
@@ -46,7 +45,7 @@ public class JavaAssociationRulesSuite implements Serializable {
   public void runAssociationRules() {
 
     @SuppressWarnings("unchecked")
-    JavaRDD<FPGrowth.FreqItemset<String>> freqItemsets = sc.parallelize(Lists.newArrayList(
+    JavaRDD<FPGrowth.FreqItemset<String>> freqItemsets = sc.parallelize(Arrays.asList(
       new FreqItemset<String>(new String[] {"a"}, 15L),
       new FreqItemset<String>(new String[] {"b"}, 35L),
       new FreqItemset<String>(new String[] {"a", "b"}, 12L)

--- a/mllib/src/test/java/org/apache/spark/mllib/fpm/JavaFPGrowthSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/fpm/JavaFPGrowthSuite.java
@@ -18,13 +18,12 @@
 package org.apache.spark.mllib.fpm;
 
 import java.io.Serializable;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import com.google.common.collect.Lists;
 import static org.junit.Assert.*;
 
 import org.apache.spark.api.java.JavaRDD;
@@ -48,13 +47,13 @@ public class JavaFPGrowthSuite implements Serializable {
   public void runFPGrowth() {
 
     @SuppressWarnings("unchecked")
-    JavaRDD<ArrayList<String>> rdd = sc.parallelize(Lists.newArrayList(
-      Lists.newArrayList("r z h k p".split(" ")),
-      Lists.newArrayList("z y x w v u t s".split(" ")),
-      Lists.newArrayList("s x o n r".split(" ")),
-      Lists.newArrayList("x z y m t s q e".split(" ")),
-      Lists.newArrayList("z".split(" ")),
-      Lists.newArrayList("x z y r q t p".split(" "))), 2);
+    JavaRDD<List<String>> rdd = sc.parallelize(Arrays.asList(
+      Arrays.asList("r z h k p".split(" ")),
+      Arrays.asList("z y x w v u t s".split(" ")),
+      Arrays.asList("s x o n r".split(" ")),
+      Arrays.asList("x z y m t s q e".split(" ")),
+      Arrays.asList("z".split(" ")),
+      Arrays.asList("x z y r q t p".split(" "))), 2);
 
     FPGrowthModel<String> model = new FPGrowth()
       .setMinSupport(0.5)

--- a/mllib/src/test/java/org/apache/spark/mllib/linalg/JavaVectorsSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/linalg/JavaVectorsSuite.java
@@ -18,10 +18,9 @@
 package org.apache.spark.mllib.linalg;
 
 import java.io.Serializable;
+import java.util.Arrays;
 
 import scala.Tuple2;
-
-import com.google.common.collect.Lists;
 
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -37,7 +36,7 @@ public class JavaVectorsSuite implements Serializable {
   @Test
   public void sparseArrayConstruction() {
     @SuppressWarnings("unchecked")
-    Vector v = Vectors.sparse(3, Lists.<Tuple2<Integer, Double>>newArrayList(
+    Vector v = Vectors.sparse(3, Arrays.asList(
         new Tuple2<Integer, Double>(0, 2.0),
         new Tuple2<Integer, Double>(2, 3.0)));
     assertArrayEquals(new double[]{2.0, 0.0, 3.0}, v.toArray(), 0.0);

--- a/mllib/src/test/java/org/apache/spark/mllib/random/JavaRandomRDDsSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/random/JavaRandomRDDsSuite.java
@@ -17,7 +17,8 @@
 
 package org.apache.spark.mllib.random;
 
-import com.google.common.collect.Lists;
+import java.util.Arrays;
+
 import org.apache.spark.api.java.JavaRDD;
 import org.junit.Assert;
 import org.junit.After;
@@ -51,7 +52,7 @@ public class JavaRandomRDDsSuite {
     JavaDoubleRDD rdd1 = uniformJavaRDD(sc, m);
     JavaDoubleRDD rdd2 = uniformJavaRDD(sc, m, p);
     JavaDoubleRDD rdd3 = uniformJavaRDD(sc, m, p, seed);
-    for (JavaDoubleRDD rdd: Lists.newArrayList(rdd1, rdd2, rdd3)) {
+    for (JavaDoubleRDD rdd: Arrays.asList(rdd1, rdd2, rdd3)) {
       Assert.assertEquals(m, rdd.count());
     }
   }
@@ -64,7 +65,7 @@ public class JavaRandomRDDsSuite {
     JavaDoubleRDD rdd1 = normalJavaRDD(sc, m);
     JavaDoubleRDD rdd2 = normalJavaRDD(sc, m, p);
     JavaDoubleRDD rdd3 = normalJavaRDD(sc, m, p, seed);
-    for (JavaDoubleRDD rdd: Lists.newArrayList(rdd1, rdd2, rdd3)) {
+    for (JavaDoubleRDD rdd: Arrays.asList(rdd1, rdd2, rdd3)) {
       Assert.assertEquals(m, rdd.count());
     }
   }
@@ -79,7 +80,7 @@ public class JavaRandomRDDsSuite {
     JavaDoubleRDD rdd1 = logNormalJavaRDD(sc, mean, std, m);
     JavaDoubleRDD rdd2 = logNormalJavaRDD(sc, mean, std, m, p);
     JavaDoubleRDD rdd3 = logNormalJavaRDD(sc, mean, std, m, p, seed);
-    for (JavaDoubleRDD rdd: Lists.newArrayList(rdd1, rdd2, rdd3)) {
+    for (JavaDoubleRDD rdd: Arrays.asList(rdd1, rdd2, rdd3)) {
       Assert.assertEquals(m, rdd.count());
     }
   }
@@ -93,7 +94,7 @@ public class JavaRandomRDDsSuite {
     JavaDoubleRDD rdd1 = poissonJavaRDD(sc, mean, m);
     JavaDoubleRDD rdd2 = poissonJavaRDD(sc, mean, m, p);
     JavaDoubleRDD rdd3 = poissonJavaRDD(sc, mean, m, p, seed);
-    for (JavaDoubleRDD rdd: Lists.newArrayList(rdd1, rdd2, rdd3)) {
+    for (JavaDoubleRDD rdd: Arrays.asList(rdd1, rdd2, rdd3)) {
       Assert.assertEquals(m, rdd.count());
     }
   }
@@ -107,7 +108,7 @@ public class JavaRandomRDDsSuite {
     JavaDoubleRDD rdd1 = exponentialJavaRDD(sc, mean, m);
     JavaDoubleRDD rdd2 = exponentialJavaRDD(sc, mean, m, p);
     JavaDoubleRDD rdd3 = exponentialJavaRDD(sc, mean, m, p, seed);
-    for (JavaDoubleRDD rdd: Lists.newArrayList(rdd1, rdd2, rdd3)) {
+    for (JavaDoubleRDD rdd: Arrays.asList(rdd1, rdd2, rdd3)) {
       Assert.assertEquals(m, rdd.count());
     }
   }
@@ -122,7 +123,7 @@ public class JavaRandomRDDsSuite {
     JavaDoubleRDD rdd1 = gammaJavaRDD(sc, shape, scale, m);
     JavaDoubleRDD rdd2 = gammaJavaRDD(sc, shape, scale, m, p);
     JavaDoubleRDD rdd3 = gammaJavaRDD(sc, shape, scale, m, p, seed);
-    for (JavaDoubleRDD rdd: Lists.newArrayList(rdd1, rdd2, rdd3)) {
+    for (JavaDoubleRDD rdd: Arrays.asList(rdd1, rdd2, rdd3)) {
       Assert.assertEquals(m, rdd.count());
     }
   }
@@ -138,7 +139,7 @@ public class JavaRandomRDDsSuite {
     JavaRDD<Vector> rdd1 = uniformJavaVectorRDD(sc, m, n);
     JavaRDD<Vector> rdd2 = uniformJavaVectorRDD(sc, m, n, p);
     JavaRDD<Vector> rdd3 = uniformJavaVectorRDD(sc, m, n, p, seed);
-    for (JavaRDD<Vector> rdd: Lists.newArrayList(rdd1, rdd2, rdd3)) {
+    for (JavaRDD<Vector> rdd: Arrays.asList(rdd1, rdd2, rdd3)) {
       Assert.assertEquals(m, rdd.count());
       Assert.assertEquals(n, rdd.first().size());
     }
@@ -154,7 +155,7 @@ public class JavaRandomRDDsSuite {
     JavaRDD<Vector> rdd1 = normalJavaVectorRDD(sc, m, n);
     JavaRDD<Vector> rdd2 = normalJavaVectorRDD(sc, m, n, p);
     JavaRDD<Vector> rdd3 = normalJavaVectorRDD(sc, m, n, p, seed);
-    for (JavaRDD<Vector> rdd: Lists.newArrayList(rdd1, rdd2, rdd3)) {
+    for (JavaRDD<Vector> rdd: Arrays.asList(rdd1, rdd2, rdd3)) {
       Assert.assertEquals(m, rdd.count());
       Assert.assertEquals(n, rdd.first().size());
     }
@@ -172,7 +173,7 @@ public class JavaRandomRDDsSuite {
     JavaRDD<Vector> rdd1 = logNormalJavaVectorRDD(sc, mean, std, m, n);
     JavaRDD<Vector> rdd2 = logNormalJavaVectorRDD(sc, mean, std, m, n, p);
     JavaRDD<Vector> rdd3 = logNormalJavaVectorRDD(sc, mean, std, m, n, p, seed);
-    for (JavaRDD<Vector> rdd: Lists.newArrayList(rdd1, rdd2, rdd3)) {
+    for (JavaRDD<Vector> rdd: Arrays.asList(rdd1, rdd2, rdd3)) {
       Assert.assertEquals(m, rdd.count());
       Assert.assertEquals(n, rdd.first().size());
     }
@@ -189,7 +190,7 @@ public class JavaRandomRDDsSuite {
     JavaRDD<Vector> rdd1 = poissonJavaVectorRDD(sc, mean, m, n);
     JavaRDD<Vector> rdd2 = poissonJavaVectorRDD(sc, mean, m, n, p);
     JavaRDD<Vector> rdd3 = poissonJavaVectorRDD(sc, mean, m, n, p, seed);
-    for (JavaRDD<Vector> rdd: Lists.newArrayList(rdd1, rdd2, rdd3)) {
+    for (JavaRDD<Vector> rdd: Arrays.asList(rdd1, rdd2, rdd3)) {
       Assert.assertEquals(m, rdd.count());
       Assert.assertEquals(n, rdd.first().size());
     }
@@ -206,7 +207,7 @@ public class JavaRandomRDDsSuite {
     JavaRDD<Vector> rdd1 = exponentialJavaVectorRDD(sc, mean, m, n);
     JavaRDD<Vector> rdd2 = exponentialJavaVectorRDD(sc, mean, m, n, p);
     JavaRDD<Vector> rdd3 = exponentialJavaVectorRDD(sc, mean, m, n, p, seed);
-    for (JavaRDD<Vector> rdd: Lists.newArrayList(rdd1, rdd2, rdd3)) {
+    for (JavaRDD<Vector> rdd: Arrays.asList(rdd1, rdd2, rdd3)) {
       Assert.assertEquals(m, rdd.count());
       Assert.assertEquals(n, rdd.first().size());
     }
@@ -224,7 +225,7 @@ public class JavaRandomRDDsSuite {
     JavaRDD<Vector> rdd1 = gammaJavaVectorRDD(sc, shape, scale, m, n);
     JavaRDD<Vector> rdd2 = gammaJavaVectorRDD(sc, shape, scale, m, n, p);
     JavaRDD<Vector> rdd3 = gammaJavaVectorRDD(sc, shape, scale, m, n, p, seed);
-    for (JavaRDD<Vector> rdd: Lists.newArrayList(rdd1, rdd2, rdd3)) {
+    for (JavaRDD<Vector> rdd: Arrays.asList(rdd1, rdd2, rdd3)) {
       Assert.assertEquals(m, rdd.count());
       Assert.assertEquals(n, rdd.first().size());
     }

--- a/mllib/src/test/java/org/apache/spark/mllib/recommendation/JavaALSSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/recommendation/JavaALSSuite.java
@@ -56,7 +56,7 @@ public class JavaALSSuite implements Serializable {
       double matchThreshold,
       boolean implicitPrefs,
       DoubleMatrix truePrefs) {
-    List<Tuple2<Integer, Integer>> localUsersProducts = new ArrayList();
+    List<Tuple2<Integer, Integer>> localUsersProducts = new ArrayList(users * products);
     for (int u=0; u < users; ++u) {
       for (int p=0; p < products; ++p) {
         localUsersProducts.add(new Tuple2<Integer, Integer>(u, p));

--- a/mllib/src/test/java/org/apache/spark/mllib/recommendation/JavaALSSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/recommendation/JavaALSSuite.java
@@ -18,12 +18,12 @@
 package org.apache.spark.mllib.recommendation;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 
 import scala.Tuple2;
 import scala.Tuple3;
 
-import com.google.common.collect.Lists;
 import org.jblas.DoubleMatrix;
 import org.junit.After;
 import org.junit.Assert;
@@ -56,8 +56,7 @@ public class JavaALSSuite implements Serializable {
       double matchThreshold,
       boolean implicitPrefs,
       DoubleMatrix truePrefs) {
-    List<Tuple2<Integer, Integer>> localUsersProducts =
-      Lists.newArrayListWithCapacity(users * products);
+    List<Tuple2<Integer, Integer>> localUsersProducts = new ArrayList();
     for (int u=0; u < users; ++u) {
       for (int p=0; p < products; ++p) {
         localUsersProducts.add(new Tuple2<Integer, Integer>(u, p));

--- a/mllib/src/test/java/org/apache/spark/mllib/regression/JavaIsotonicRegressionSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/regression/JavaIsotonicRegressionSuite.java
@@ -18,6 +18,7 @@
 package org.apache.spark.mllib.regression;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -36,7 +37,7 @@ public class JavaIsotonicRegressionSuite implements Serializable {
   private transient JavaSparkContext sc;
 
   private List<Tuple3<Double, Double, Double>> generateIsotonicInput(double[] labels) {
-    List<Tuple3<Double, Double, Double>> input = Arrays.asList();
+    ArrayList<Tuple3<Double, Double, Double>> input = new ArrayList(labels.length);
 
     for (int i = 1; i <= labels.length; i++) {
       input.add(new Tuple3<Double, Double, Double>(labels[i-1], (double) i, 1d));

--- a/mllib/src/test/java/org/apache/spark/mllib/regression/JavaIsotonicRegressionSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/regression/JavaIsotonicRegressionSuite.java
@@ -18,11 +18,11 @@
 package org.apache.spark.mllib.regression;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.List;
 
 import scala.Tuple3;
 
-import com.google.common.collect.Lists;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -36,7 +36,7 @@ public class JavaIsotonicRegressionSuite implements Serializable {
   private transient JavaSparkContext sc;
 
   private List<Tuple3<Double, Double, Double>> generateIsotonicInput(double[] labels) {
-    List<Tuple3<Double, Double, Double>> input = Lists.newArrayList();
+    List<Tuple3<Double, Double, Double>> input = Arrays.asList();
 
     for (int i = 1; i <= labels.length; i++) {
       input.add(new Tuple3<Double, Double, Double>(labels[i-1], (double) i, 1d));
@@ -77,7 +77,7 @@ public class JavaIsotonicRegressionSuite implements Serializable {
     IsotonicRegressionModel model =
       runIsotonicRegression(new double[]{1, 2, 3, 3, 1, 6, 7, 8, 11, 9, 10, 12});
 
-    JavaDoubleRDD testRDD = sc.parallelizeDoubles(Lists.newArrayList(0.0, 1.0, 9.5, 12.0, 13.0));
+    JavaDoubleRDD testRDD = sc.parallelizeDoubles(Arrays.asList(0.0, 1.0, 9.5, 12.0, 13.0));
     List<Double> predictions = model.predict(testRDD).collect();
 
     Assert.assertTrue(predictions.get(0) == 1d);

--- a/mllib/src/test/java/org/apache/spark/mllib/regression/JavaStreamingLinearRegressionSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/regression/JavaStreamingLinearRegressionSuite.java
@@ -18,11 +18,11 @@
 package org.apache.spark.mllib.regression;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.List;
 
 import scala.Tuple2;
 
-import com.google.common.collect.Lists;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -59,16 +59,16 @@ public class JavaStreamingLinearRegressionSuite implements Serializable {
   @Test
   @SuppressWarnings("unchecked")
   public void javaAPI() {
-    List<LabeledPoint> trainingBatch = Lists.newArrayList(
+    List<LabeledPoint> trainingBatch = Arrays.asList(
       new LabeledPoint(1.0, Vectors.dense(1.0)),
       new LabeledPoint(0.0, Vectors.dense(0.0)));
     JavaDStream<LabeledPoint> training =
-      attachTestInputStream(ssc, Lists.newArrayList(trainingBatch, trainingBatch), 2);
-    List<Tuple2<Integer, Vector>> testBatch = Lists.newArrayList(
+      attachTestInputStream(ssc, Arrays.asList(trainingBatch, trainingBatch), 2);
+    List<Tuple2<Integer, Vector>> testBatch = Arrays.asList(
       new Tuple2<Integer, Vector>(10, Vectors.dense(1.0)),
       new Tuple2<Integer, Vector>(11, Vectors.dense(0.0)));
     JavaPairDStream<Integer, Vector> test = JavaPairDStream.fromJavaDStream(
-      attachTestInputStream(ssc, Lists.newArrayList(testBatch, testBatch), 2));
+      attachTestInputStream(ssc, Arrays.asList(testBatch, testBatch), 2));
     StreamingLinearRegressionWithSGD slr = new StreamingLinearRegressionWithSGD()
       .setNumIterations(2)
       .setInitialWeights(Vectors.dense(0.0));

--- a/mllib/src/test/java/org/apache/spark/mllib/stat/JavaStatisticsSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/stat/JavaStatisticsSuite.java
@@ -19,7 +19,8 @@ package org.apache.spark.mllib.stat;
 
 import java.io.Serializable;
 
-import com.google.common.collect.Lists;
+import java.util.Arrays;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,8 +51,8 @@ public class JavaStatisticsSuite implements Serializable {
 
   @Test
   public void testCorr() {
-    JavaRDD<Double> x = sc.parallelize(Lists.newArrayList(1.0, 2.0, 3.0, 4.0));
-    JavaRDD<Double> y = sc.parallelize(Lists.newArrayList(1.1, 2.2, 3.1, 4.3));
+    JavaRDD<Double> x = sc.parallelize(Arrays.asList(1.0, 2.0, 3.0, 4.0));
+    JavaRDD<Double> y = sc.parallelize(Arrays.asList(1.1, 2.2, 3.1, 4.3));
 
     Double corr1 = Statistics.corr(x, y);
     Double corr2 = Statistics.corr(x, y, "pearson");
@@ -61,7 +62,7 @@ public class JavaStatisticsSuite implements Serializable {
 
   @Test
   public void kolmogorovSmirnovTest() {
-    JavaDoubleRDD data = sc.parallelizeDoubles(Lists.newArrayList(0.2, 1.0, -1.0, 2.0));
+    JavaDoubleRDD data = sc.parallelizeDoubles(Arrays.asList(0.2, 1.0, -1.0, 2.0));
     KolmogorovSmirnovTestResult testResult1 = Statistics.kolmogorovSmirnovTest(data, "norm");
     KolmogorovSmirnovTestResult testResult2 = Statistics.kolmogorovSmirnovTest(
       data, "norm", 0.0, 1.0);
@@ -69,7 +70,7 @@ public class JavaStatisticsSuite implements Serializable {
 
   @Test
   public void chiSqTest() {
-    JavaRDD<LabeledPoint> data = sc.parallelize(Lists.newArrayList(
+    JavaRDD<LabeledPoint> data = sc.parallelize(Arrays.asList(
       new LabeledPoint(0.0, Vectors.dense(0.1, 2.3)),
       new LabeledPoint(1.0, Vectors.dense(1.5, 5.1)),
       new LabeledPoint(0.0, Vectors.dense(2.4, 8.1))));


### PR DESCRIPTION
- Replaces instances of `Lists.newArrayList` with `Arrays.asList`
- Replaces `commons.lang.StringUtils` over `com.google.collections.Strings`
- Replaces `List` interface over `ArrayList` implementations

This PR along with #8445 #8446 #8447 completely removes all `com.google.collections.Lists` dependencies within mllib's Java tests.
