### PR TITLE
[SPARK-10292][SQL] make metadata query-able by adding meta table

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -182,7 +182,7 @@ class SQLContext private[sql](
   lazy val listenerManager: ExecutionListenerManager = new ExecutionListenerManager
 
   @transient
-  protected[sql] lazy val catalog: Catalog = new SimpleCatalog(conf)
+  protected[sql] lazy val catalog: Catalog = new SimpleCatalog(conf) with MetaDataCatalog
 
   @transient
   protected[sql] lazy val functionRegistry: FunctionRegistry = FunctionRegistry.builtin.copy()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
@@ -282,7 +282,13 @@ case class ShowTablesCommand(databaseName: Option[String]) extends RunnableComma
   override def run(sqlContext: SQLContext): Seq[Row] = {
     // Since we need to return a Seq of rows, we will call getTables directly
     // instead of calling tables in sqlContext.
-    val rows = sqlContext.catalog.getTables(databaseName).map {
+    val tables = if (databaseName.isDefined) {
+      sqlContext.catalog.getTables(databaseName)
+    } else {
+      Nil
+    } ++ sqlContext.catalog.getTables(None)
+
+    val rows = tables.map {
       case (tableName, isTemporary) => Row(tableName, isTemporary)
     }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -1818,4 +1818,34 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
         Row(1))
     }
   }
+
+  test("query meta table") {
+    withTempTable("t1", "t2", "t3") {
+      Seq(1 -> "a").toDF("key", "value").registerTempTable("t1")
+      Seq(1 -> Array("a")).toDF("int", "array").registerTempTable("t2")
+      Seq((1, 2, 3)).toDF("i", "j", "k").registerTempTable("t3")
+
+      val allTables = sql("select * from catalog_tables")
+        .filter('name.startsWith("t") && length('name) === 2)
+        .sort('name)
+      checkAnswer(allTables, Seq(
+        Row("t1", null, true),
+        Row("t2", null, true),
+        Row("t3", null, true)
+      ))
+
+      val allColumns = sql("select * from catalog_columns")
+        .filter('table.startsWith("t") && length('table) === 2)
+        .sort('name)
+      checkAnswer(allColumns, Seq(
+        Row("array", "t2", null, "array<string>", true),
+        Row("i", "t3", null, "int", false),
+        Row("int", "t2", null, "int", false),
+        Row("j", "t3", null, "int", false),
+        Row("k", "t3", null, "int", false),
+        Row("key", "t1", null, "int", false),
+        Row("value", "t1", null, "string", true)
+      ))
+    }
+  }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -449,7 +449,7 @@ class HiveContext private[hive](
   /* A catalyst metadata catalog that points to the Hive Metastore. */
   @transient
   override protected[sql] lazy val catalog =
-    new HiveMetastoreCatalog(metadataHive, this) with OverrideCatalog
+    new HiveMetastoreCatalog(metadataHive, this) with OverrideCatalog with MetaDataCatalog
 
   // Note that HiveUDFs will be overridden by functions registered in this context.
   @transient

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -485,6 +485,10 @@ private[hive] class HiveMetastoreCatalog(val client: ClientInterface, hive: Hive
     client.listTables(db).map(tableName => (tableName, false))
   }
 
+  override def getDatabases(): Seq[String] = {
+    client.listDatabases()
+  }
+
   /**
    * When scanning or writing to non-partitioned Metastore Parquet tables, convert them to Parquet
    * data source relations for better performance.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientInterface.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientInterface.scala
@@ -106,6 +106,9 @@ private[hive] trait ClientInterface {
   /** Returns the names of all tables in the given database. */
   def listTables(dbName: String): Seq[String]
 
+  /** Returns the names of all databases. */
+  def listDatabases(): Seq[String]
+
   /** Returns the name of the active database. */
   def currentDatabase: String
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
@@ -434,6 +434,10 @@ private[hive] class ClientWrapper(
     client.getAllTables(dbName).asScala
   }
 
+  override def listDatabases(): Seq[String] = withHiveState {
+    client.getAllDatabases.asScala
+  }
+
   /**
    * Runs the specified SQL query using Hive.
    */

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -1403,32 +1403,33 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
 
     withTempTable("t1") {
       Seq(1 -> "a").toDF("key", "value").registerTempTable("t1")
-
       withTable("t2", "t3") {
-        Seq(1 -> Array("a")).toDF("int", "array").write.format("json").saveAsTable("t2")
-        Seq((1, 2, 3)).toDF("i", "j", "k").write.format("json").saveAsTable("t3")
+        withTempDatabase { db =>
+          Seq(1 -> Array("a")).toDF("int", "array").write.format("json").saveAsTable(s"$db.t2")
+          Seq((1, 2, 3)).toDF("i", "j", "k").write.format("json").saveAsTable("t3")
 
-        val allTables = sql("select * from catalog_tables")
-          .filter('name.startsWith("t") && length('name) === 2)
-          .sort('name)
-        checkAnswer(allTables, Seq(
-          Row("t1", null, true),
-          Row("t2", "default", false),
-          Row("t3", "default", false)
-        ))
+          val allTables = sql("select * from catalog_tables")
+            .filter('name.startsWith("t") && length('name) === 2)
+            .sort('name)
+          checkAnswer(allTables, Seq(
+            Row("t1", null, true),
+            Row("t2", db, false),
+            Row("t3", "default", false)
+          ))
 
-        val allColumns = sql("select * from catalog_columns")
-          .filter('table.startsWith("t") && length('table) === 2)
-          .sort('name)
-        checkAnswer(allColumns, Seq(
-          Row("array", "t2", "default", "array<string>", true),
-          Row("i", "t3", "default", "int", true),
-          Row("int", "t2", "default", "int", true),
-          Row("j", "t3", "default", "int", true),
-          Row("k", "t3", "default", "int", true),
-          Row("key", "t1", null, "int", false),
-          Row("value", "t1", null, "string", true)
-        ))
+          val allColumns = sql("select * from catalog_columns")
+            .filter('table.startsWith("t") && length('table) === 2)
+            .sort('name)
+          checkAnswer(allColumns, Seq(
+            Row("array", "t2", db, "array<string>", true),
+            Row("i", "t3", "default", "int", true),
+            Row("int", "t2", db, "int", true),
+            Row("j", "t3", "default", "int", true),
+            Row("k", "t3", "default", "int", true),
+            Row("key", "t1", null, "int", false),
+            Row("value", "t1", null, "string", true)
+          ))
+        }
       }
     }
   }


### PR DESCRIPTION
To begin with, we can set up 2 meta tables: `catalog_tables` and `catalog_columns`.
`catalog_tables` have 3 columns: `name`, `database`, `is_temporary`.
`catalog_columns` have 5 columns: `name`, `table`, `database`, `data_type`, `nullable`.

We can add more meta tables in the future.
