### PR TITLE
[SPARK-10306][WIP] Add dependency so sbt can resolve (and then evict)

### DIFF
--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -36,6 +36,12 @@
   </properties>
 
   <dependencies>
+    <!-- Added for sbt issue, expected to be evicted -->
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>2.10.3</version>
+    </dependency>
     <!-- Added for Hive Parquet SerDe -->
     <dependency>
       <groupId>com.twitter</groupId>


### PR DESCRIPTION
Sometimes running hive/update in sbt inside of Spark results in a ivy resolution failure, a simple work around is adding it as a dependency so that it can be resolved and then subsequently evicted.
