### PR TITLE
[SPARK-10065][SQL] Avoid triple copying of var-length objects in Array in tungsten projection

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
@@ -222,24 +222,27 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
     val convertedElement: GeneratedExpressionCode = createConvertCode(ctx, element, elementType)
 
     // go through the input array to calculate how many bytes we need.
-    val (calculateNumBytesSimple, calculateNumBytesComplex) = elementType match {
+    val calculateNumBytes = elementType match {
       case _ if ctx.isPrimitiveType(elementType) =>
         // Should we do word align?
         val elementSize = elementType.defaultSize
-        (s"""
+        s"""
           $numBytes += $elementSize * $numElements;
-          """, "")
+        """
       case t: DecimalType if t.precision <= Decimal.MAX_LONG_DIGITS =>
-        (s"""
+        s"""
           $numBytes += 8 * $numElements;
-          """, "")
+        """
       case _ =>
         val writer = getWriter(elementType)
-        ("", s"""
-          if (!${convertedElement.isNull}) {
-            $numBytes += $writer.getSize(${convertedElement.primitive});
+        s"""
+          for (int $index = 0; $index < $numElements; $index++) {
+            ${convertedElement.code}
+            if (!${convertedElement.isNull}) {
+              $numBytes += $writer.getSize(${convertedElement.primitive});
+            }
           }
-          """)
+        """
     }
 
     val writeElement = elementType match {
@@ -298,7 +301,7 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
           final int $fixedSize = 4 * $numElements;
           int $numBytes = $fixedSize;
 
-          $calculateNumBytesSimple
+          $calculateNumBytes
 
           if ($numBytes > $buffer.length) {
             $buffer = new byte[$numBytes];
@@ -307,7 +310,6 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
           int $cursor = $fixedSize;
           for (int $index = 0; $index < $numElements; $index++) {
             ${convertedElement.code}
-            $calculateNumBytesComplex
             if ($checkNull) {
               // If element is null, write the negative value address into offset region.
               Platform.putInt($buffer, Platform.BYTE_ARRAY_OFFSET + 4 * $index, -$cursor);

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
@@ -222,27 +222,24 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
     val convertedElement: GeneratedExpressionCode = createConvertCode(ctx, element, elementType)
 
     // go through the input array to calculate how many bytes we need.
-    val calculateNumBytes = elementType match {
+    val (calculateNumBytesSimple, calculateNumBytesComplex) = elementType match {
       case _ if ctx.isPrimitiveType(elementType) =>
         // Should we do word align?
         val elementSize = elementType.defaultSize
-        s"""
+        (s"""
           $numBytes += $elementSize * $numElements;
-        """
+          """, "")
       case t: DecimalType if t.precision <= Decimal.MAX_LONG_DIGITS =>
-        s"""
+        (s"""
           $numBytes += 8 * $numElements;
-        """
+          """, "")
       case _ =>
         val writer = getWriter(elementType)
-        s"""
-          for (int $index = 0; $index < $numElements; $index++) {
-            ${convertedElement.code}
-            if (!${convertedElement.isNull}) {
-              $numBytes += $writer.getSize(${convertedElement.primitive});
-            }
+        ("", s"""
+          if (!${convertedElement.isNull}) {
+            $numBytes += $writer.getSize(${convertedElement.primitive});
           }
-        """
+          """)
     }
 
     val writeElement = elementType match {
@@ -301,7 +298,7 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
           final int $fixedSize = 4 * $numElements;
           int $numBytes = $fixedSize;
 
-          $calculateNumBytes
+          $calculateNumBytesSimple
 
           if ($numBytes > $buffer.length) {
             $buffer = new byte[$numBytes];
@@ -310,6 +307,13 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
           int $cursor = $fixedSize;
           for (int $index = 0; $index < $numElements; $index++) {
             ${convertedElement.code}
+            $calculateNumBytesComplex
+            if ($buffer.length < $numBytes) {
+              byte[] newBuffer = new byte[$numBytes * 2];
+              Platform.copyMemory($buffer, Platform.BYTE_ARRAY_OFFSET,
+                newBuffer, Platform.BYTE_ARRAY_OFFSET, $buffer.length);
+              $buffer = newBuffer;
+            }
             if ($checkNull) {
               // If element is null, write the negative value address into offset region.
               Platform.putInt($buffer, Platform.BYTE_ARRAY_OFFSET + 4 * $index, -$cursor);

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
@@ -270,7 +270,7 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
           $cursor += $writer.write(
             $buffer,
             Platform.BYTE_ARRAY_OFFSET + $cursor,
-            ${convertedElement.primitive}.copy());
+            ${convertedElement.primitive});
         """
       case _ =>
         val writer = getWriter(elementType)


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-10065

Currently we do unnecessary copying of objects in the array. We should avoid them.
