### PR TITLE
[SPARK-9926] [SPARK-10340] [SQL] Use S3 bulk listing for S3-backed Hive tables

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -40,6 +40,11 @@
       <classifier>${avro.mapred.classifier}</classifier>
     </dependency>
     <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk</artifactId>
+      <version>${aws.java.sdk.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -41,7 +41,12 @@
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk</artifactId>
+      <artifactId>aws-java-sdk-s3</artifactId>
+      <version>${aws.java.sdk.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-sts</artifactId>
       <version>${aws.java.sdk.version}</version>
     </dependency>
     <dependency>

--- a/core/src/main/scala/org/apache/spark/deploy/SparkS3Util.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkS3Util.scala
@@ -40,7 +40,7 @@ import org.apache.hadoop.fs.s3.S3Credentials
 import org.apache.hadoop.io.compress.{CompressionCodecFactory, SplittableCompressionCodec}
 import org.apache.hadoop.mapred.{FileInputFormat, FileSplit, InputSplit, JobConf}
 
-import org.apache.spark.{SparkConf, Logging}
+import org.apache.spark.{Logging, SparkEnv}
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.util.Utils
 
@@ -50,7 +50,7 @@ import org.apache.spark.util.Utils
  */
 @DeveloperApi
 object SparkS3Util extends Logging {
-  val sparkConf = new SparkConf()
+  val sparkConf = SparkEnv.get.conf
   val conf: Configuration = SparkHadoopUtil.get.newConfiguration(sparkConf)
 
   private val s3ClientCache: Cache[String, AmazonS3Client] = CacheBuilder
@@ -256,7 +256,7 @@ object SparkS3Util extends Logging {
    * Return whether S3 bulk listing can be enabled or not.
    */
   def s3BulkListingEnabled(jobConf: JobConf): Boolean = {
-    val enabledByUser = sparkConf.getBoolean(S3_BULK_LISTING_ENABLED, true)
+    val enabledByUser = sparkConf.getBoolean(S3_BULK_LISTING_ENABLED, false)
     val inputPaths = FileInputFormat.getInputPaths(jobConf)
     val noWildcard = inputPaths.forall(path => !new GlobPattern(path.toString).hasWildcard)
     val s3Paths = inputPaths.forall(SparkS3Util.isS3Path(_))

--- a/core/src/main/scala/org/apache/spark/deploy/SparkS3Util.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkS3Util.scala
@@ -86,7 +86,7 @@ object SparkS3Util extends Logging {
     val maxErrorRetries: Int = sparkConf.getInt(S3_MAX_ERROR_RETRIES, 10)
     val connectTimeout: Int = sparkConf.getInt(S3_CONNECT_TIMEOUT, 5000)
     val socketTimeout: Int = sparkConf.getInt(S3_SOCKET_TIMEOUT, 5000)
-    val maxConnections: Int = sparkConf.getInt(S3_MAX_CONNECTIONS, 500)
+    val maxConnections: Int = sparkConf.getInt(S3_MAX_CONNECTIONS, 5)
     val useInstanceCredentials: Boolean = sparkConf.getBoolean(S3_USE_INSTANCE_CREDENTIALS, false)
 
     val clientConf: ClientConfiguration = new ClientConfiguration

--- a/core/src/main/scala/org/apache/spark/deploy/SparkS3Util.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkS3Util.scala
@@ -278,14 +278,14 @@ object SparkS3Util extends Logging {
   }
 
   /**
-   * Compute input splits for the given files. Burrowed code from `FileInputFormat.getSplits`.
+   * Compute input splits for the given files. Borrowed code from `FileInputFormat.getSplits`.
    */
   @VisibleForTesting
   def computeSplits(
     jobConf: JobConf,
     files: Array[FileStatus],
     minSplits: Int): Array[InputSplit] = {
-    val totalSize: Long = files.map(_.getLen).reduceLeft(_ + _)
+    val totalSize: Long = files.map(_.getLen).foldLeft(0L)((sum, len) => sum + len)
     val goalSize: Long = totalSize / (if (minSplits == 0) 1 else minSplits)
     val minSize: Long = getMinSplitSize()
     val splits: ArrayBuffer[InputSplit] = ArrayBuffer[InputSplit]()

--- a/core/src/main/scala/org/apache/spark/deploy/SparkS3Util.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkS3Util.scala
@@ -29,7 +29,6 @@ import com.amazonaws.internal.StaticCredentialsProvider
 import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.model.{ListObjectsRequest, ObjectListing, S3ObjectSummary}
 
-import com.google.common.annotations.VisibleForTesting
 import com.google.common.base.{Preconditions, Strings}
 import com.google.common.cache.{Cache, CacheBuilder}
 import com.google.common.collect.AbstractSequentialIterator
@@ -272,8 +271,8 @@ object SparkS3Util extends Logging {
 
   /**
    * Return whether the given file is splittable or not.
+   * Exposed for testing.
    */
-  @VisibleForTesting
   def isSplitable(jobConf: JobConf, file: Path): Boolean = {
     val compressionCodecs = new CompressionCodecFactory(jobConf)
     val codec = compressionCodecs.getCodec(file)
@@ -286,8 +285,8 @@ object SparkS3Util extends Logging {
 
   /**
    * Compute input splits for the given files. Borrowed code from `FileInputFormat.getSplits`.
+   * Exposed for testing.
    */
-  @VisibleForTesting
   def computeSplits(
     jobConf: JobConf,
     files: Array[FileStatus],

--- a/core/src/main/scala/org/apache/spark/deploy/SparkS3Util.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkS3Util.scala
@@ -1,0 +1,336 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy
+
+import java.net.URI
+import java.util
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
+
+import com.amazonaws.{AmazonClientException, AmazonServiceException, ClientConfiguration, Protocol}
+import com.amazonaws.auth.{AWSCredentialsProvider, BasicAWSCredentials, InstanceProfileCredentialsProvider, STSAssumeRoleSessionCredentialsProvider}
+import com.amazonaws.internal.StaticCredentialsProvider
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.model.{ListObjectsRequest, ObjectListing, S3ObjectSummary}
+
+import com.google.common.annotations.VisibleForTesting
+import com.google.common.base.{Preconditions, Strings}
+import com.google.common.cache.{Cache, CacheBuilder}
+import com.google.common.collect.AbstractSequentialIterator
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileStatus, GlobPattern, Path, PathFilter}
+import org.apache.hadoop.fs.s3.S3Credentials
+import org.apache.hadoop.io.compress.{CompressionCodecFactory, SplittableCompressionCodec}
+import org.apache.hadoop.mapred.{FileInputFormat, FileSplit, InputSplit, JobConf}
+
+import org.apache.spark.{SparkConf, Logging}
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.util.Utils
+
+/**
+ * :: DeveloperApi ::
+ * Contains util methods to interact with S3 from Spark.
+ */
+@DeveloperApi
+object SparkS3Util extends Logging {
+  val sparkConf = new SparkConf()
+  val conf: Configuration = SparkHadoopUtil.get.newConfiguration(sparkConf)
+
+  private val s3ClientCache: Cache[String, AmazonS3Client] = CacheBuilder
+    .newBuilder
+    .concurrencyLevel(Runtime.getRuntime.availableProcessors)
+    .build[String, AmazonS3Client]
+
+  // Flag to enable S3 bulk listing. It is true by default.
+  private val S3_BULK_LISTING_ENABLED: String = "spark.s3.bulk.listing.enabled"
+
+  // Properties for AmazonS3Client. Default values should just work most of time.
+  private val S3_CONNECT_TIMEOUT: String = "spark.s3.connect.timeout"
+  private val S3_MAX_CONNECTIONS: String = "spark.s3.max.connections"
+  private val S3_MAX_ERROR_RETRIES: String = "spark.s3.max.error.retries"
+  private val S3_SOCKET_TIMEOUT: String = "spark.s3.socket.timeout"
+  private val S3_SSL_ENABLED: String = "spark.s3.ssl.enabled"
+  private val S3_USE_INSTANCE_CREDENTIALS: String = "spark.s3.use.instance.credentials"
+
+  // Ignore hidden files whose name starts with "_" and ".", or ends with "$folder$".
+  private val hiddenFileFilter = new PathFilter() {
+    override def accept(p: Path): Boolean = {
+      val name: String = p.getName()
+      !name.startsWith("_") && !name.startsWith(".") && !name.endsWith("$folder$")
+    }
+  }
+
+  /**
+   * Initialize AmazonS3Client per bucket. Since access permissions might be different from bucket
+   * to bucket, it is necessary to initialize AmazonS3Client on a per bucket basis.
+   */
+  private def getS3Client(bucket: String): AmazonS3Client = {
+    val sslEnabled: Boolean = sparkConf.getBoolean(S3_SSL_ENABLED, true)
+    val maxErrorRetries: Int = sparkConf.getInt(S3_MAX_ERROR_RETRIES, 10)
+    val connectTimeout: Int = sparkConf.getInt(S3_CONNECT_TIMEOUT, 5000)
+    val socketTimeout: Int = sparkConf.getInt(S3_SOCKET_TIMEOUT, 5000)
+    val maxConnections: Int = sparkConf.getInt(S3_MAX_CONNECTIONS, 500)
+    val useInstanceCredentials: Boolean = sparkConf.getBoolean(S3_USE_INSTANCE_CREDENTIALS, false)
+
+    val clientConf: ClientConfiguration = new ClientConfiguration
+    clientConf.setMaxErrorRetry(maxErrorRetries)
+    clientConf.setProtocol(if (sslEnabled) Protocol.HTTPS else Protocol.HTTP)
+    clientConf.setConnectionTimeout(connectTimeout)
+    clientConf.setSocketTimeout(socketTimeout)
+    clientConf.setMaxConnections(maxConnections)
+
+    // There are different ways of obtaining S3 bucket access. Try them in the following order:
+    //   1) Check if user specified an IAM role. If so, use it.
+    //   2) Check if instance is associated with an IAM role. If so, use it.
+    //   3) Check if default IAM role is set in Hadoop conf. If so, use it.
+    //   4) If no IAM role is found, search for an AWS key pair.
+    // If no credentials are found, throw an exception.
+    val s3RoleArn = Option(conf.get("aws.iam.role.arn"))
+    val s3RoleArnDefault = Option(conf.get("aws.iam.role.arn.default"))
+    val credentialsProvider: AWSCredentialsProvider =
+      s3RoleArn match {
+        case Some(role) =>
+          logDebug("Use user-specified IAM role: " + role)
+          new STSAssumeRoleSessionCredentialsProvider(
+            role, "RoleSessionName-" + Utils.random.nextInt)
+        case None if useInstanceCredentials =>
+          logDebug("Use IAM role associated with the instance")
+          new InstanceProfileCredentialsProvider
+        case _ =>
+          s3RoleArnDefault match {
+            case Some(role) =>
+              logDebug("Use default IAM role configured in Hadoop config: " + role)
+              new STSAssumeRoleSessionCredentialsProvider(
+                role, "RoleSessionName-" + Utils.random.nextInt)
+            case _ =>
+              try {
+                logDebug("Use AWS key pair")
+                val credentials: S3Credentials = new S3Credentials
+                credentials.initialize(URI.create(bucket), conf)
+                new StaticCredentialsProvider(
+                  new BasicAWSCredentials(credentials.getAccessKey, credentials.getSecretAccessKey))
+              } catch {
+                case e: Exception => throw new RuntimeException("S3 credentials not configured", e)
+              }
+        }
+      }
+
+    val providerName: String = credentialsProvider.getClass.getSimpleName
+    val s3ClientKey: String =
+      if (s3RoleArn == null) providerName
+      else providerName + "_" + s3RoleArn
+
+    Option(s3ClientCache.getIfPresent(s3ClientKey)).getOrElse {
+      val newClient = new AmazonS3Client(credentialsProvider, clientConf)
+      s3ClientCache.put(s3ClientKey, newClient)
+      newClient
+    }
+  }
+
+  /**
+   * Helper function to extract S3 object key name from the given path.
+   */
+  private def keyFromPath(path: Path): String = {
+    Preconditions.checkArgument(path.isAbsolute, "Path is not absolute: %s", path)
+    var key: String = Strings.nullToEmpty(path.toUri.getPath)
+    if (key.startsWith("/")) {
+      key = key.substring(1)
+    }
+    if (key.endsWith("/")) {
+      key = key.substring(0, key.length - 1)
+    }
+    key
+  }
+
+  /**
+   * Helper function to convert S3ObjectSummary into FileStatus.
+   */
+  private def statusFromObjects(
+      bucket: String,
+      objects: util.List[S3ObjectSummary]): Iterator[FileStatus] = {
+    val blockSize: Long = getS3BlockSize()
+    val list: ArrayBuffer[FileStatus] = ArrayBuffer()
+    for (obj: S3ObjectSummary <- objects.asScala) {
+      if (!obj.getKey.endsWith("/")) {
+        val path = new Path(bucket + "/" + obj.getKey)
+        if (hiddenFileFilter.accept(path)) {
+          val status: FileStatus = new FileStatus(
+            obj.getSize,
+            false,
+            1,
+            blockSize,
+            obj.getLastModified.getTime,
+            path)
+          list += status
+        }
+      }
+    }
+    list.iterator
+  }
+
+  /**
+   * For the given path, list S3 objects and return an iterator of returned FileStatuses.
+   */
+  @throws(classOf[AmazonClientException])
+  @throws(classOf[AmazonServiceException])
+  private def listPrefix(s3: AmazonS3Client, path: Path): Iterator[FileStatus] = {
+    val uri: URI = path.toUri
+    val key: String = keyFromPath(path)
+    val request: ListObjectsRequest = new ListObjectsRequest()
+      .withBucketName(uri.getAuthority)
+      .withPrefix(key)
+
+    val listings = new AbstractSequentialIterator[ObjectListing](s3.listObjects(request)) {
+      protected def computeNext(previous: ObjectListing): ObjectListing = {
+        if (!previous.isTruncated) {
+          return null
+        }
+        s3.listNextBatchOfObjects(previous)
+      }
+    }.asScala
+
+    val bucket: String = uri.getScheme + "://" + uri.getAuthority
+    listings
+      .map(listing => statusFromObjects(bucket, listing.getObjectSummaries))
+      .reduceLeft(_ ++ _)
+  }
+
+  /**
+   * For the given list of paths, sequentially list S3 objects per path and combine returned
+   * FileStatuses into a single array.
+   */
+  private def listStatus(s3: AmazonS3Client, paths: List[Path]): Array[FileStatus] = {
+    val list: ArrayBuffer[FileStatus] = ArrayBuffer()
+    paths.foreach { path =>
+      val iterator = listPrefix(s3, path)
+      while (iterator.hasNext) {
+        list += iterator.next
+      }
+    }
+    list.toArray
+  }
+
+  /**
+   * Find S3 block size from Hadoop conf. Try both s3 and s3n names.
+   */
+  private def getS3BlockSize(): Long = {
+    val value = Option(conf.get("fs.s3.block.size"))
+      .getOrElse(conf.get("fs.s3n.block.size", "67108864"))
+    value.toLong
+  }
+
+  /**
+   * Find min split size from Hadoop conf. Try both Hadoop 1 and 2 names.
+   */
+  private def getMinSplitSize(): Long = {
+    val value = Option(conf.get("mapred.min.split.size"))
+      .getOrElse(conf.get("mapreduce.input.fileinputformat.split.minsize", "1"))
+    value.toLong
+  }
+
+  /**
+   * Return whether the given path is an S3 path or not.
+   */
+  private def isS3Path(path: Path): Boolean = {
+    Option(path.toUri.getScheme).exists(_.toUpperCase.startsWith("S3"))
+  }
+
+  /**
+   * Return whether S3 bulk listing can be enabled or not.
+   */
+  def s3BulkListingEnabled(jobConf: JobConf): Boolean = {
+    val enabledByUser = sparkConf.getBoolean(S3_BULK_LISTING_ENABLED, true)
+    val inputPaths = FileInputFormat.getInputPaths(jobConf)
+    val noWildcard = inputPaths.forall(path => !new GlobPattern(path.toString).hasWildcard)
+    val s3Paths = inputPaths.forall(SparkS3Util.isS3Path(_))
+    enabledByUser && inputPaths.nonEmpty && s3Paths && noWildcard
+  }
+
+  /**
+   * Return whether the given file is splittable or not.
+   */
+  @VisibleForTesting
+  def isSplitable(jobConf: JobConf, file: Path): Boolean = {
+    val compressionCodecs = new CompressionCodecFactory(jobConf)
+    val codec = compressionCodecs.getCodec(file)
+    if (codec == null) {
+      true
+    } else {
+      codec.isInstanceOf[SplittableCompressionCodec]
+    }
+  }
+
+  /**
+   * Compute input splits for the given files. Burrowed code from `FileInputFormat.getSplits`.
+   */
+  @VisibleForTesting
+  def computeSplits(
+    jobConf: JobConf,
+    files: Array[FileStatus],
+    minSplits: Int): Array[InputSplit] = {
+    val totalSize: Long = files.map(_.getLen).reduceLeft(_ + _)
+    val goalSize: Long = totalSize / (if (minSplits == 0) 1 else minSplits)
+    val minSize: Long = getMinSplitSize()
+    val splits: ArrayBuffer[InputSplit] = ArrayBuffer[InputSplit]()
+    // Since S3 objects are remote, use a zero-length array to fake data local hosts.
+    val fakeHosts: Array[String] = Array()
+
+    for (file <- files) {
+      val path: Path = file.getPath
+      val length: Long = file.getLen
+      if (length > 0 && isSplitable(jobConf, path)) {
+        val blockSize: Long = file.getBlockSize
+        val splitSize: Long = Math.max(minSize, Math.min(goalSize, blockSize))
+        var bytesRemaining: Long = length
+        while (bytesRemaining.toDouble / splitSize > 1.1) {
+          splits += new FileSplit(path, length - bytesRemaining, splitSize, fakeHosts)
+          bytesRemaining -= splitSize
+        }
+        if (bytesRemaining != 0) {
+          splits += new FileSplit(path, length - bytesRemaining, bytesRemaining, fakeHosts)
+        }
+      } else {
+        splits += new FileSplit(path, 0, length, fakeHosts)
+      }
+    }
+
+    logDebug("Total size of input splits is " + totalSize)
+    logDebug("Num of input splits is " + splits.size)
+
+    splits.toArray
+  }
+
+  /**
+   * This is based on `FileInputFormat.getSplits` method. Two key differences are:
+   *   1) Use `AmazonS3Client.listObjects` instead of `FileSystem.listStatus`.
+   *   2) Bypass data locality hints since they're irrelevant to S3 objects.
+   */
+  def getSplits(jobConf: JobConf, minSplits: Int): Array[InputSplit] = {
+    val inputPaths: Array[Path] = FileInputFormat.getInputPaths(jobConf)
+    val files: Array[FileStatus] = inputPaths.toList
+      .groupBy[String] { path =>
+        val uri = path.toUri
+        uri.getScheme + "://" + uri.getAuthority
+      }
+      .map { case (bucket, paths) => (bucket, listStatus(getS3Client(bucket), paths)) }
+      .values.reduceLeft(_ ++ _)
+    computeSplits(jobConf, files, minSplits)
+  }
+}

--- a/core/src/main/scala/org/apache/spark/deploy/SparkS3Util.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkS3Util.scala
@@ -241,7 +241,7 @@ object SparkS3Util extends Logging {
    */
   private def getMinSplitSize(): Long = {
     val value = Option(conf.get("mapred.min.split.size"))
-      .getOrElse(conf.get("mapreduce.input.fileinputformat.split.minsize", "1"))
+      .getOrElse(conf.get("mapreduce.input.fileinputformat.split.minsize", "134217728"))
     value.toLong
   }
 

--- a/core/src/main/scala/org/apache/spark/deploy/SparkS3Util.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkS3Util.scala
@@ -231,9 +231,16 @@ object SparkS3Util extends Logging {
    * Find S3 block size from Hadoop conf. Try both s3 and s3n names.
    */
   private def getS3BlockSize(): Long = {
+    val minS3BlockSize = 10485760; // 10mb
+    val defaultS3BlockSize = 67108864; // 64mb
     val value = Option(conf.get("fs.s3.block.size"))
-      .getOrElse(conf.get("fs.s3n.block.size", "67108864"))
-    value.toLong
+      .getOrElse(conf.get("fs.s3n.block.size", defaultS3BlockSize.toString)).toLong
+    if (value < minS3BlockSize) {
+      logWarning("S3 block size is set too small: " + value + ". Overriding it to 10mb.");
+      minS3BlockSize
+    } else {
+      value
+    }
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
@@ -41,7 +41,7 @@ import org.apache.hadoop.util.ReflectionUtils
 import org.apache.spark._
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.broadcast.Broadcast
-import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.deploy.{SparkS3Util, SparkHadoopUtil}
 import org.apache.spark.executor.DataReadMethod
 import org.apache.spark.rdd.HadoopRDD.HadoopMapPartitionsWithSplitRDD
 import org.apache.spark.util.{SerializableConfiguration, ShutdownHookManager, NextIterator, Utils}
@@ -193,10 +193,15 @@ class HadoopRDD[K, V](
 
   override def getPartitions: Array[Partition] = {
     val jobConf = getJobConf()
-    // add the credentials here as this can be called before SparkContext initialized
+    // Add the credentials here as this can be called before SparkContext initialized
     SparkHadoopUtil.get.addCredentials(jobConf)
-    val inputFormat = getInputFormat(jobConf)
-    val inputSplits = inputFormat.getSplits(jobConf, minPartitions)
+    val inputSplits =
+      if (SparkS3Util.s3BulkListingEnabled(jobConf)) {
+        SparkS3Util.getSplits(jobConf, minPartitions)
+      } else {
+        val inputFormat = getInputFormat(jobConf)
+        inputFormat.getSplits(jobConf, minPartitions)
+      }
     val array = new Array[Partition](inputSplits.size)
     for (i <- 0 until inputSplits.size) {
       array(i) = new HadoopPartition(id, i, inputSplits(i))

--- a/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala
@@ -41,7 +41,7 @@ import org.apache.hadoop.util.ReflectionUtils
 import org.apache.spark._
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.broadcast.Broadcast
-import org.apache.spark.deploy.{SparkS3Util, SparkHadoopUtil}
+import org.apache.spark.deploy.{SparkHadoopUtil, SparkS3Util}
 import org.apache.spark.executor.DataReadMethod
 import org.apache.spark.rdd.HadoopRDD.HadoopMapPartitionsWithSplitRDD
 import org.apache.spark.util.{SerializableConfiguration, ShutdownHookManager, NextIterator, Utils}

--- a/core/src/main/scala/org/apache/spark/rdd/UnionRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/UnionRDD.scala
@@ -20,6 +20,8 @@ package org.apache.spark.rdd
 import java.io.{IOException, ObjectOutputStream}
 
 import scala.collection.mutable.ArrayBuffer
+import scala.collection.parallel.ForkJoinTaskSupport
+import scala.concurrent.forkjoin.ForkJoinPool
 import scala.reflect.ClassTag
 
 import org.apache.spark.{Dependency, Partition, RangeDependency, SparkContext, TaskContext}
@@ -62,7 +64,20 @@ class UnionRDD[T: ClassTag](
     var rdds: Seq[RDD[T]])
   extends RDD[T](sc, Nil) {  // Nil since we implement getDependencies
 
+  // Evaluate partitions in parallel (will be cached in each rdd)
+  private lazy val evaluatePartitions: Unit = {
+    val threshold = conf.getInt("spark.rdd.parallelListingThreshold", 10)
+    if (rdds.length > threshold) {
+      val parArray = rdds.toParArray
+      parArray.tasksupport = new ForkJoinTaskSupport(new ForkJoinPool(threshold))
+      parArray.foreach(_.partitions)
+    } else {
+      rdds.foreach(_.partitions)
+    }
+  }
+
   override def getPartitions: Array[Partition] = {
+    evaluatePartitions
     val array = new Array[Partition](rdds.map(_.partitions.length).sum)
     var pos = 0
     for ((rdd, rddIndex) <- rdds.zipWithIndex; split <- rdd.partitions) {

--- a/core/src/main/scala/org/apache/spark/rdd/UnionRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/UnionRDD.scala
@@ -28,8 +28,6 @@ import org.apache.spark.{Dependency, Partition, RangeDependency, SparkContext, T
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.util.Utils
 
-import com.google.common.base.Preconditions
-
 /**
  * Partition for UnionRDD.
  *
@@ -70,9 +68,7 @@ class UnionRDD[T: ClassTag](
   // val in `RDD`.
   private lazy val evaluatePartitions: Unit = {
     val threshold = conf.getInt("spark.rdd.parallelListingThreshold", 10)
-    Preconditions.checkArgument(threshold > 0,
-      "spark.rdd.parallelListingThreshold must be positive: %s", threshold.toString)
-    if (rdds.length > threshold) {
+    if (threshold > 0 && rdds.length > threshold) {
       val parArray = rdds.toParArray
       parArray.tasksupport = new ForkJoinTaskSupport(new ForkJoinPool(threshold))
       parArray.foreach(_.partitions)

--- a/core/src/test/scala/org/apache/spark/deploy/SparkS3UtilSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkS3UtilSuite.scala
@@ -42,7 +42,7 @@ class SparkS3UtilSuite extends SparkFunSuite {
 
     // Input paths copntain non-S3 files
     SparkS3Util.sparkConf.set("spark.s3.bulk.listing.enabled", "true")
-    FileInputFormat.setInputPaths(jobConf, "file://bucket/dir/file")
+    FileInputFormat.setInputPaths(jobConf, "file://dir/file")
     assert(SparkS3Util.s3BulkListingEnabled(jobConf) == false)
   }
 

--- a/core/src/test/scala/org/apache/spark/deploy/SparkS3UtilSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkS3UtilSuite.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy
+
+import java.util.Date
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.hadoop.fs.{FileStatus, Path}
+import org.apache.hadoop.mapred.{InputSplit, FileInputFormat, JobConf}
+
+import org.apache.spark.SparkFunSuite
+
+class SparkS3UtilSuite extends SparkFunSuite {
+  test("s3ListingEnabled function") {
+    val jobConf = new JobConf()
+
+    // Disabled by user
+    SparkS3Util.sparkConf.set("spark.s3.bulk.listing.enabled", "false")
+    FileInputFormat.setInputPaths(jobConf, "s3://bucket/dir/file")
+    assert(SparkS3Util.s3BulkListingEnabled(jobConf) == false)
+
+    // Input paths contain wildcards
+    SparkS3Util.sparkConf.set("spark.s3.bulk.listing.enabled", "true")
+    FileInputFormat.setInputPaths(jobConf, "s3://bucket/dir/*")
+    assert(SparkS3Util.s3BulkListingEnabled(jobConf) == false)
+
+    // Input paths copntain non-S3 files
+    SparkS3Util.sparkConf.set("spark.s3.bulk.listing.enabled", "true")
+    FileInputFormat.setInputPaths(jobConf, "file://bucket/dir/file")
+    assert(SparkS3Util.s3BulkListingEnabled(jobConf) == false)
+  }
+
+  test("isSplitable function") {
+    val jobConf: JobConf = new JobConf()
+
+    // Splitable files
+    val parquetFile: Path = new Path("file.parquet")
+    assert(SparkS3Util.isSplitable(jobConf, parquetFile) == true)
+    val textFile: Path = new Path("file.txt")
+    assert(SparkS3Util.isSplitable(jobConf, textFile) == true)
+
+    // Non-splitable files
+    val gzipFile: Path = new Path("file.gz")
+    assert(SparkS3Util.isSplitable(jobConf, gzipFile) == false)
+  }
+
+  test("computeSplits function") {
+    val jobConf: JobConf = new JobConf()
+    // Set S3 block size to 64mb
+    jobConf.set("fs.s3.block.size", "67108864")
+
+    val files: ArrayBuffer[FileStatus] = ArrayBuffer()
+    for (i <- 1 to 10) {
+      val status: FileStatus = new FileStatus(
+        256 * 1024 * 1024,
+        false,
+        1,
+        64 * 1024 * 1024,
+        new Date().getTime,
+        new Path(s"s3://bucket/dir/file${i}"))
+      files += status
+    }
+
+    val splits: Array[InputSplit] = SparkS3Util.computeSplits(jobConf, files.toArray, 1)
+
+    // 40 splits are expected: 256mb * 10 files / 64mb
+    assert(splits.length == 40)
+
+    // Zero-length array is expected for data local hosts
+    for (s <- splits) {
+      assert(s.getLocations.length == 0)
+    }
+  }
+}


### PR DESCRIPTION
This PR addresses both [SPARK-9926](https://issues.apache.org/jira/browse/SPARK-9926) and [SPARK-10340](https://issues.apache.org/jira/browse/SPARK-10340).

[SPARK-9926](https://issues.apache.org/jira/browse/SPARK-9926) makes it possible to calculate input splits for multiple partitions all together in `TableReader` and cache them in `HadoopRDD`. This improves performance because file listing can be done in parallel by taking advantage of `mapreduce.input.fileinputformat.list-status.num-threads`. This optimization can be enabled by a new property `spark.sql.hive.parallelFileListing`.

[SPARK-10340](https://issues.apache.org/jira/browse/SPARK-10340) makes it possible to list S3 files using `AmazonS3Client` instead of using `S3N`. This improves performance particularly when listing a large number of S3 files. Note that since S3 bulk listing may list more objects than what meets predicates, they must be additionally filtered after listed. This is done by comparing prefixes of S3 objects against original input paths in `JobConf`. This optimization can be enabled by a new property `spark.sql.hive.s3BulkListing`.

Here is my benchmark results for the following queries-

```
1 partition: select * from nccp_log where dateint=20150601 and hour=0 limit 10;
24 partitions: select * from nccp_log where dateint=20150601 limit 10;
240 partitions: select * from nccp_log where dateint>=20150601 and dateint<=20150610 limit 10;
720 partitions: select * from nccp_log where dateint>=20150601 and dateint<=20150630 limit 10;
```

| # of files | # of partitions | 1.5 rc2 (a) | SPARK-9926 w/ 10 threads (b) | SPARK-10340 (c) |
| --- | --- | --- | --- | --- |
| 972 | 1 | 38s | 36s | 27s |
| 13646 | 24 | 354s | 41s | 30s |
| 136222 | 240 | 1h | 321s | 195s |
| 445377 | 720 | 3h | 1194s | 274s |

![image](https://cloud.githubusercontent.com/assets/179618/9556501/fda27662-4d89-11e5-8ce1-0b5d7bab02d1.png)

The performance gains come from two factors-
- S3 bulk listing.
- Skipping data locality hints computation for S3 objects. This is possible because S3 objects have no data locality to begin with.

The code for S3 bulk listing is fully  implemented in `SparkS3Util`. My code is heavily based on Presto [S3FileSystem](https://github.com/facebook/presto/blob/master/presto-hive/src/main/java/com/facebook/presto/hive/PrestoS3FileSystem.java) and Hadoop [FileInputFormat](https://hadoop.apache.org/docs/current/api/org/apache/hadoop/mapred/FileInputFormat.html).
