### PR TITLE
[SPARK-10352][SQL]Adds handling for java.lang.String on getUTF8String

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/rows.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/rows.scala
@@ -27,6 +27,7 @@ import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
  * and equals/hashCode by `genericGet`.
  */
 trait BaseGenericInternalRow extends InternalRow {
+
   protected def genericGet(ordinal: Int): Any
 
   // default implementation (slow)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/rows.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/rows.scala
@@ -27,7 +27,6 @@ import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
  * and equals/hashCode by `genericGet`.
  */
 trait BaseGenericInternalRow extends InternalRow {
-
   protected def genericGet(ordinal: Int): Any
 
   // default implementation (slow)
@@ -42,7 +41,10 @@ trait BaseGenericInternalRow extends InternalRow {
   override def getFloat(ordinal: Int): Float = getAs(ordinal)
   override def getDouble(ordinal: Int): Double = getAs(ordinal)
   override def getDecimal(ordinal: Int, precision: Int, scale: Int): Decimal = getAs(ordinal)
-  override def getUTF8String(ordinal: Int): UTF8String = getAs(ordinal)
+  override def getUTF8String(ordinal: Int): UTF8String = genericGet(ordinal) match {
+    case s: String => UTF8String.fromString(s)
+    case _ => getAs(ordinal)
+  }
   override def getBinary(ordinal: Int): Array[Byte] = getAs(ordinal)
   override def getArray(ordinal: Int): ArrayData = getAs(ordinal)
   override def getInterval(ordinal: Int): CalendarInterval = getAs(ordinal)

--- a/sql/core/src/test/scala/org/apache/spark/sql/UnsafeRowSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UnsafeRowSuite.scala
@@ -78,6 +78,13 @@ class UnsafeRowSuite extends SparkFunSuite {
     assert(bytesFromArrayBackedRow === bytesFromOffheapRow)
   }
 
+  test("calling getUTF8String() on non-null columns") {
+    val inputString = "abc"
+    val row = InternalRow.apply(inputString)
+    val unsafeRow = UnsafeProjection.create(Array[DataType](StringType)).apply(row)
+    assert(unsafeRow.getString(0) === inputString)
+  }
+
   test("calling getDouble() and getFloat() on null columns") {
     val row = InternalRow.apply(null, null)
     val unsafeRow = UnsafeProjection.create(Array[DataType](FloatType, DoubleType)).apply(row)

--- a/sql/core/src/test/scala/org/apache/spark/sql/UnsafeRowSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UnsafeRowSuite.scala
@@ -78,7 +78,7 @@ class UnsafeRowSuite extends SparkFunSuite {
     assert(bytesFromArrayBackedRow === bytesFromOffheapRow)
   }
 
-  test("calling getUTF8String() on non-null columns") {
+  test("calling getString() on non-null column") {
     val inputString = "abc"
     val row = InternalRow.apply(inputString)
     val unsafeRow = UnsafeProjection.create(Array[DataType](StringType)).apply(row)


### PR DESCRIPTION
Adds automatic conversion from `java.lang.String` to `UTF8String` in `BaseGenericInternalRow`.

This is necessary because `ScalaReflections` infers a `StringType` SQL type for `java.lang.String`.

CC @rxin @marmbrus 
