### PR TITLE
[SQL] Adds private implicit tungstenCache to DataFrame

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
@@ -391,11 +391,16 @@ public final class UnsafeRow extends MutableRow {
 
   @Override
   public UTF8String getUTF8String(int ordinal) {
-    if (isNullAt(ordinal)) return null;
-    final long offsetAndSize = getLong(ordinal);
-    final int offset = (int) (offsetAndSize >> 32);
-    final int size = (int) (offsetAndSize & ((1L << 32) - 1));
-    return UTF8String.fromAddress(baseObject, baseOffset + offset, size);
+    if (isNullAt(ordinal)) {
+      return null;
+    } else if (baseObject == null) { // off-heap storage
+      return UTF8String.fromBytes(getBinary(ordinal));
+    } else {
+      final long offsetAndSize = getLong(ordinal);
+      final int offset = (int) (offsetAndSize >> 32);
+      final int size = (int) (offsetAndSize & ((1L << 32) - 1));
+      return UTF8String.fromAddress(baseObject, baseOffset + offset, size);
+    }
   }
 
   @Override

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
@@ -582,7 +582,9 @@ public final class UnsafeRow extends MutableRow {
     StringBuilder build = new StringBuilder("[");
     for (int i = 0; i < sizeInBytes; i += 8) {
       build.append(java.lang.Long.toHexString(Platform.getLong(baseObject, baseOffset + i)));
-      build.append(',');
+      if (i <= sizeInBytes-1)  {
+        build.append(',');
+      }
     }
     build.append(']');
     return build.toString();

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/rows.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/rows.scala
@@ -27,6 +27,7 @@ import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
  * and equals/hashCode by `genericGet`.
  */
 trait BaseGenericInternalRow extends InternalRow {
+
   protected def genericGet(ordinal: Int): Any
 
   // default implementation (slow)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/rows.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/rows.scala
@@ -27,7 +27,6 @@ import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
  * and equals/hashCode by `genericGet`.
  */
 trait BaseGenericInternalRow extends InternalRow {
-
   protected def genericGet(ordinal: Int): Any
 
   // default implementation (slow)
@@ -42,7 +41,10 @@ trait BaseGenericInternalRow extends InternalRow {
   override def getFloat(ordinal: Int): Float = getAs(ordinal)
   override def getDouble(ordinal: Int): Double = getAs(ordinal)
   override def getDecimal(ordinal: Int, precision: Int, scale: Int): Decimal = getAs(ordinal)
-  override def getUTF8String(ordinal: Int): UTF8String = getAs(ordinal)
+  override def getUTF8String(ordinal: Int): UTF8String = genericGet(ordinal) match {
+    case s: String => UTF8String.fromString(s)
+    case _ => getAs(ordinal)
+  }
   override def getBinary(ordinal: Int): Array[Byte] = getAs(ordinal)
   override def getArray(ordinal: Int): ArrayData = getAs(ordinal)
   override def getInterval(ordinal: Int): CalendarInterval = getAs(ordinal)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/rows.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/rows.scala
@@ -42,10 +42,7 @@ trait BaseGenericInternalRow extends InternalRow {
   override def getFloat(ordinal: Int): Float = getAs(ordinal)
   override def getDouble(ordinal: Int): Double = getAs(ordinal)
   override def getDecimal(ordinal: Int, precision: Int, scale: Int): Decimal = getAs(ordinal)
-  override def getUTF8String(ordinal: Int): UTF8String = genericGet(ordinal) match {
-    case s: String => UTF8String.fromString(s)
-    case _ => getAs(ordinal)
-  }
+  override def getUTF8String(ordinal: Int): UTF8String = getAs(ordinal)
   override def getBinary(ordinal: Int): Array[Byte] = getAs(ordinal)
   override def getArray(ordinal: Int): ArrayData = getAs(ordinal)
   override def getInterval(ordinal: Int): CalendarInterval = getAs(ordinal)

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -17,14 +17,6 @@
 
 package org.apache.spark.sql
 
-import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{UnsafeProjection, UnsafeRow}
-import org.apache.spark.sql.execution.datasources.LogicalRelation
-import org.apache.spark.sql.sources.{BaseRelation, TableScan}
-import org.apache.spark.unsafe.memory.{UnsafeMemoryAllocator, MemoryBlock}
-
-import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
@@ -34,7 +26,7 @@ import org.apache.spark.Accumulators
 import org.apache.spark.sql.columnar._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SharedSQLContext
-import org.apache.spark.storage.{StorageLevel, RDDBlockId}
+import org.apache.spark.storage.{RDDBlockId, StorageLevel}
 
 private case class BigData(s: String)
 
@@ -55,299 +47,299 @@ class CachedTableSuite extends QueryTest with SharedSQLContext {
     ctx.sparkContext.env.blockManager.get(RDDBlockId(rddId, 0)).nonEmpty
   }
 
-//  test("withColumn doesn't invalidate cached dataframe") {
-//    var evalCount = 0
-//    val myUDF = udf((x: String) => { evalCount += 1; "result" })
-//    val df = Seq(("test", 1)).toDF("s", "i").select(myUDF($"s"))
-//    df.cache()
-//
-//    df.collect()
-//    assert(evalCount === 1)
-//
-//    df.collect()
-//    assert(evalCount === 1)
-//
-//    val df2 = df.withColumn("newColumn", lit(1))
-//    df2.collect()
-//
-//    // We should not reevaluate the cached dataframe
-//    assert(evalCount === 1)
-//  }
-//
-//  test("cache temp table") {
-//    testData.select('key).registerTempTable("tempTable")
-//    assertCached(sql("SELECT COUNT(*) FROM tempTable"), 0)
-//    ctx.cacheTable("tempTable")
-//    assertCached(sql("SELECT COUNT(*) FROM tempTable"))
-//    ctx.uncacheTable("tempTable")
-//  }
-//
-//  test("unpersist an uncached table will not raise exception") {
-//    assert(None == ctx.cacheManager.lookupCachedData(testData))
-//    testData.unpersist(blocking = true)
-//    assert(None == ctx.cacheManager.lookupCachedData(testData))
-//    testData.unpersist(blocking = false)
-//    assert(None == ctx.cacheManager.lookupCachedData(testData))
-//    testData.persist()
-//    assert(None != ctx.cacheManager.lookupCachedData(testData))
-//    testData.unpersist(blocking = true)
-//    assert(None == ctx.cacheManager.lookupCachedData(testData))
-//    testData.unpersist(blocking = false)
-//    assert(None == ctx.cacheManager.lookupCachedData(testData))
-//  }
-//
-//  test("cache table as select") {
-//    sql("CACHE TABLE tempTable AS SELECT key FROM testData")
-//    assertCached(sql("SELECT COUNT(*) FROM tempTable"))
-//    ctx.uncacheTable("tempTable")
-//  }
-//
-//  test("uncaching temp table") {
-//    testData.select('key).registerTempTable("tempTable1")
-//    testData.select('key).registerTempTable("tempTable2")
-//    ctx.cacheTable("tempTable1")
-//
-//    assertCached(sql("SELECT COUNT(*) FROM tempTable1"))
-//    assertCached(sql("SELECT COUNT(*) FROM tempTable2"))
-//
-//    // Is this valid?
-//    ctx.uncacheTable("tempTable2")
-//
-//    // Should this be cached?
-//    assertCached(sql("SELECT COUNT(*) FROM tempTable1"), 0)
-//  }
-//
-//  test("too big for memory") {
-//    val data = "*" * 1000
-//    ctx.sparkContext.parallelize(1 to 200000, 1).map(_ => BigData(data)).toDF()
-//      .registerTempTable("bigData")
-//    ctx.table("bigData").persist(StorageLevel.MEMORY_AND_DISK)
-//    assert(ctx.table("bigData").count() === 200000L)
-//    ctx.table("bigData").unpersist(blocking = true)
-//  }
-//
-//  test("calling .cache() should use in-memory columnar caching") {
-//    ctx.table("testData").cache()
-//    assertCached(ctx.table("testData"))
-//    ctx.table("testData").unpersist(blocking = true)
-//  }
-//
-//  test("calling .unpersist() should drop in-memory columnar cache") {
-//    ctx.table("testData").cache()
-//    ctx.table("testData").count()
-//    ctx.table("testData").unpersist(blocking = true)
-//    assertCached(ctx.table("testData"), 0)
-//  }
-//
-//  test("isCached") {
-//    ctx.cacheTable("testData")
-//
-//    assertCached(ctx.table("testData"))
-//    assert(ctx.table("testData").queryExecution.withCachedData match {
-//      case _: InMemoryRelation => true
-//      case _ => false
-//    })
-//
-//    ctx.uncacheTable("testData")
-//    assert(!ctx.isCached("testData"))
-//    assert(ctx.table("testData").queryExecution.withCachedData match {
-//      case _: InMemoryRelation => false
-//      case _ => true
-//    })
-//  }
-//
-//  test("SPARK-1669: cacheTable should be idempotent") {
-//    assume(!ctx.table("testData").logicalPlan.isInstanceOf[InMemoryRelation])
-//
-//    ctx.cacheTable("testData")
-//    assertCached(ctx.table("testData"))
-//
-//    assertResult(1, "InMemoryRelation not found, testData should have been cached") {
-//      ctx.table("testData").queryExecution.withCachedData.collect {
-//        case r: InMemoryRelation => r
-//      }.size
-//    }
-//
-//    ctx.cacheTable("testData")
-//    assertResult(0, "Double InMemoryRelations found, cacheTable() is not idempotent") {
-//      ctx.table("testData").queryExecution.withCachedData.collect {
-//        case r @ InMemoryRelation(_, _, _, _, _: InMemoryColumnarTableScan, _) => r
-//      }.size
-//    }
-//
-//    ctx.uncacheTable("testData")
-//  }
-//
-//  test("read from cached table and uncache") {
-//    ctx.cacheTable("testData")
-//    checkAnswer(ctx.table("testData"), testData.collect().toSeq)
-//    assertCached(ctx.table("testData"))
-//
-//    ctx.uncacheTable("testData")
-//    checkAnswer(ctx.table("testData"), testData.collect().toSeq)
-//    assertCached(ctx.table("testData"), 0)
-//  }
-//
-//  test("correct error on uncache of non-cached table") {
-//    intercept[IllegalArgumentException] {
-//      ctx.uncacheTable("testData")
-//    }
-//  }
-//
-//  test("SELECT star from cached table") {
-//    sql("SELECT * FROM testData").registerTempTable("selectStar")
-//    ctx.cacheTable("selectStar")
-//    checkAnswer(
-//      sql("SELECT * FROM selectStar WHERE key = 1"),
-//      Seq(Row(1, "1")))
-//    ctx.uncacheTable("selectStar")
-//  }
-//
-//  test("Self-join cached") {
-//    val unCachedAnswer =
-//      sql("SELECT * FROM testData a JOIN testData b ON a.key = b.key").collect()
-//    ctx.cacheTable("testData")
-//    checkAnswer(
-//      sql("SELECT * FROM testData a JOIN testData b ON a.key = b.key"),
-//      unCachedAnswer.toSeq)
-//    ctx.uncacheTable("testData")
-//  }
-//
-//  test("'CACHE TABLE' and 'UNCACHE TABLE' SQL statement") {
-//    sql("CACHE TABLE testData")
-//    assertCached(ctx.table("testData"))
-//
-//    val rddId = rddIdOf("testData")
-//    assert(
-//      isMaterialized(rddId),
-//      "Eagerly cached in-memory table should have already been materialized")
-//
-//    sql("UNCACHE TABLE testData")
-//    assert(!ctx.isCached("testData"), "Table 'testData' should not be cached")
-//
-//    eventually(timeout(10 seconds)) {
-//      assert(!isMaterialized(rddId), "Uncached in-memory table should have been unpersisted")
-//    }
-//  }
-//
-//  test("CACHE TABLE tableName AS SELECT * FROM anotherTable") {
-//    sql("CACHE TABLE testCacheTable AS SELECT * FROM testData")
-//    assertCached(ctx.table("testCacheTable"))
-//
-//    val rddId = rddIdOf("testCacheTable")
-//    assert(
-//      isMaterialized(rddId),
-//      "Eagerly cached in-memory table should have already been materialized")
-//
-//    ctx.uncacheTable("testCacheTable")
-//    eventually(timeout(10 seconds)) {
-//      assert(!isMaterialized(rddId), "Uncached in-memory table should have been unpersisted")
-//    }
-//  }
-//
-//  test("CACHE TABLE tableName AS SELECT ...") {
-//    sql("CACHE TABLE testCacheTable AS SELECT key FROM testData LIMIT 10")
-//    assertCached(ctx.table("testCacheTable"))
-//
-//    val rddId = rddIdOf("testCacheTable")
-//    assert(
-//      isMaterialized(rddId),
-//      "Eagerly cached in-memory table should have already been materialized")
-//
-//    ctx.uncacheTable("testCacheTable")
-//    eventually(timeout(10 seconds)) {
-//      assert(!isMaterialized(rddId), "Uncached in-memory table should have been unpersisted")
-//    }
-//  }
-//
-//  test("CACHE LAZY TABLE tableName") {
-//    sql("CACHE LAZY TABLE testData")
-//    assertCached(ctx.table("testData"))
-//
-//    val rddId = rddIdOf("testData")
-//    assert(
-//      !isMaterialized(rddId),
-//      "Lazily cached in-memory table shouldn't be materialized eagerly")
-//
-//    sql("SELECT COUNT(*) FROM testData").collect()
-//    assert(
-//      isMaterialized(rddId),
-//      "Lazily cached in-memory table should have been materialized")
-//
-//    ctx.uncacheTable("testData")
-//    eventually(timeout(10 seconds)) {
-//      assert(!isMaterialized(rddId), "Uncached in-memory table should have been unpersisted")
-//    }
-//  }
-//
-//  test("InMemoryRelation statistics") {
-//    sql("CACHE TABLE testData")
-//    ctx.table("testData").queryExecution.withCachedData.collect {
-//      case cached: InMemoryRelation =>
-//        val actualSizeInBytes = (1 to 100).map(i => INT.defaultSize + i.toString.length + 4).sum
-//        assert(cached.statistics.sizeInBytes === actualSizeInBytes)
-//    }
-//  }
-//
-//  test("Drops temporary table") {
-//    testData.select('key).registerTempTable("t1")
-//    ctx.table("t1")
-//    ctx.dropTempTable("t1")
-//    assert(intercept[RuntimeException](ctx.table("t1")).getMessage.startsWith("Table Not Found"))
-//  }
-//
-//  test("Drops cached temporary table") {
-//    testData.select('key).registerTempTable("t1")
-//    testData.select('key).registerTempTable("t2")
-//    ctx.cacheTable("t1")
-//
-//    assert(ctx.isCached("t1"))
-//    assert(ctx.isCached("t2"))
-//
-//    ctx.dropTempTable("t1")
-//    assert(intercept[RuntimeException](ctx.table("t1")).getMessage.startsWith("Table Not Found"))
-//    assert(!ctx.isCached("t2"))
-//  }
-//
-//  test("Clear all cache") {
-//    sql("SELECT key FROM testData LIMIT 10").registerTempTable("t1")
-//    sql("SELECT key FROM testData LIMIT 5").registerTempTable("t2")
-//    ctx.cacheTable("t1")
-//    ctx.cacheTable("t2")
-//    ctx.clearCache()
-//    assert(ctx.cacheManager.isEmpty)
-//
-//    sql("SELECT key FROM testData LIMIT 10").registerTempTable("t1")
-//    sql("SELECT key FROM testData LIMIT 5").registerTempTable("t2")
-//    ctx.cacheTable("t1")
-//    ctx.cacheTable("t2")
-//    sql("Clear CACHE")
-//    assert(ctx.cacheManager.isEmpty)
-//  }
-//
-//  test("Clear accumulators when uncacheTable to prevent memory leaking") {
-//    sql("SELECT key FROM testData LIMIT 10").registerTempTable("t1")
-//    sql("SELECT key FROM testData LIMIT 5").registerTempTable("t2")
-//
-//    ctx.cacheTable("t1")
-//    ctx.cacheTable("t2")
-//
-//    sql("SELECT * FROM t1").count()
-//    sql("SELECT * FROM t2").count()
-//    sql("SELECT * FROM t1").count()
-//    sql("SELECT * FROM t2").count()
-//
-//    Accumulators.synchronized {
-//      val accsSize = Accumulators.originals.size
-//      ctx.uncacheTable("t1")
-//      ctx.uncacheTable("t2")
-//      assert((accsSize - 2) == Accumulators.originals.size)
-//    }
-//  }
+  test("withColumn doesn't invalidate cached dataframe") {
+    var evalCount = 0
+    val myUDF = udf((x: String) => { evalCount += 1; "result" })
+    val df = Seq(("test", 1)).toDF("s", "i").select(myUDF($"s"))
+    df.cache()
+
+    df.collect()
+    assert(evalCount === 1)
+
+    df.collect()
+    assert(evalCount === 1)
+
+    val df2 = df.withColumn("newColumn", lit(1))
+    df2.collect()
+
+    // We should not reevaluate the cached dataframe
+    assert(evalCount === 1)
+  }
+
+  test("cache temp table") {
+    testData.select('key).registerTempTable("tempTable")
+    assertCached(sql("SELECT COUNT(*) FROM tempTable"), 0)
+    ctx.cacheTable("tempTable")
+    assertCached(sql("SELECT COUNT(*) FROM tempTable"))
+    ctx.uncacheTable("tempTable")
+  }
+
+  test("unpersist an uncached table will not raise exception") {
+    assert(None === ctx.cacheManager.lookupCachedData(testData))
+    testData.unpersist(blocking = true)
+    assert(None === ctx.cacheManager.lookupCachedData(testData))
+    testData.unpersist(blocking = false)
+    assert(None === ctx.cacheManager.lookupCachedData(testData))
+    testData.persist()
+    assert(None !== ctx.cacheManager.lookupCachedData(testData))
+    testData.unpersist(blocking = true)
+    assert(None === ctx.cacheManager.lookupCachedData(testData))
+    testData.unpersist(blocking = false)
+    assert(None === ctx.cacheManager.lookupCachedData(testData))
+  }
+
+  test("cache table as select") {
+    sql("CACHE TABLE tempTable AS SELECT key FROM testData")
+    assertCached(sql("SELECT COUNT(*) FROM tempTable"))
+    ctx.uncacheTable("tempTable")
+  }
+
+  test("uncaching temp table") {
+    testData.select('key).registerTempTable("tempTable1")
+    testData.select('key).registerTempTable("tempTable2")
+    ctx.cacheTable("tempTable1")
+
+    assertCached(sql("SELECT COUNT(*) FROM tempTable1"))
+    assertCached(sql("SELECT COUNT(*) FROM tempTable2"))
+
+    // Is this valid?
+    ctx.uncacheTable("tempTable2")
+
+    // Should this be cached?
+    assertCached(sql("SELECT COUNT(*) FROM tempTable1"), 0)
+  }
+
+  test("too big for memory") {
+    val data = "*" * 1000
+    ctx.sparkContext.parallelize(1 to 200000, 1).map(_ => BigData(data)).toDF()
+      .registerTempTable("bigData")
+    ctx.table("bigData").persist(StorageLevel.MEMORY_AND_DISK)
+    assert(ctx.table("bigData").count() === 200000L)
+    ctx.table("bigData").unpersist(blocking = true)
+  }
+
+  test("calling .cache() should use in-memory columnar caching") {
+    ctx.table("testData").cache()
+    assertCached(ctx.table("testData"))
+    ctx.table("testData").unpersist(blocking = true)
+  }
+
+  test("calling .unpersist() should drop in-memory columnar cache") {
+    ctx.table("testData").cache()
+    ctx.table("testData").count()
+    ctx.table("testData").unpersist(blocking = true)
+    assertCached(ctx.table("testData"), 0)
+  }
+
+  test("isCached") {
+    ctx.cacheTable("testData")
+
+    assertCached(ctx.table("testData"))
+    assert(ctx.table("testData").queryExecution.withCachedData match {
+      case _: InMemoryRelation => true
+      case _ => false
+    })
+
+    ctx.uncacheTable("testData")
+    assert(!ctx.isCached("testData"))
+    assert(ctx.table("testData").queryExecution.withCachedData match {
+      case _: InMemoryRelation => false
+      case _ => true
+    })
+  }
+
+  test("SPARK-1669: cacheTable should be idempotent") {
+    assume(!ctx.table("testData").logicalPlan.isInstanceOf[InMemoryRelation])
+
+    ctx.cacheTable("testData")
+    assertCached(ctx.table("testData"))
+
+    assertResult(1, "InMemoryRelation not found, testData should have been cached") {
+      ctx.table("testData").queryExecution.withCachedData.collect {
+        case r: InMemoryRelation => r
+      }.size
+    }
+
+    ctx.cacheTable("testData")
+    assertResult(0, "Double InMemoryRelations found, cacheTable() is not idempotent") {
+      ctx.table("testData").queryExecution.withCachedData.collect {
+        case r @ InMemoryRelation(_, _, _, _, _: InMemoryColumnarTableScan, _) => r
+      }.size
+    }
+
+    ctx.uncacheTable("testData")
+  }
+
+  test("read from cached table and uncache") {
+    ctx.cacheTable("testData")
+    checkAnswer(ctx.table("testData"), testData.collect().toSeq)
+    assertCached(ctx.table("testData"))
+
+    ctx.uncacheTable("testData")
+    checkAnswer(ctx.table("testData"), testData.collect().toSeq)
+    assertCached(ctx.table("testData"), 0)
+  }
+
+  test("correct error on uncache of non-cached table") {
+    intercept[IllegalArgumentException] {
+      ctx.uncacheTable("testData")
+    }
+  }
+
+  test("SELECT star from cached table") {
+    sql("SELECT * FROM testData").registerTempTable("selectStar")
+    ctx.cacheTable("selectStar")
+    checkAnswer(
+      sql("SELECT * FROM selectStar WHERE key = 1"),
+      Seq(Row(1, "1")))
+    ctx.uncacheTable("selectStar")
+  }
+
+  test("Self-join cached") {
+    val unCachedAnswer =
+      sql("SELECT * FROM testData a JOIN testData b ON a.key = b.key").collect()
+    ctx.cacheTable("testData")
+    checkAnswer(
+      sql("SELECT * FROM testData a JOIN testData b ON a.key = b.key"),
+      unCachedAnswer.toSeq)
+    ctx.uncacheTable("testData")
+  }
+
+  test("'CACHE TABLE' and 'UNCACHE TABLE' SQL statement") {
+    sql("CACHE TABLE testData")
+    assertCached(ctx.table("testData"))
+
+    val rddId = rddIdOf("testData")
+    assert(
+      isMaterialized(rddId),
+      "Eagerly cached in-memory table should have already been materialized")
+
+    sql("UNCACHE TABLE testData")
+    assert(!ctx.isCached("testData"), "Table 'testData' should not be cached")
+
+    eventually(timeout(10 seconds)) {
+      assert(!isMaterialized(rddId), "Uncached in-memory table should have been unpersisted")
+    }
+  }
+
+  test("CACHE TABLE tableName AS SELECT * FROM anotherTable") {
+    sql("CACHE TABLE testCacheTable AS SELECT * FROM testData")
+    assertCached(ctx.table("testCacheTable"))
+
+    val rddId = rddIdOf("testCacheTable")
+    assert(
+      isMaterialized(rddId),
+      "Eagerly cached in-memory table should have already been materialized")
+
+    ctx.uncacheTable("testCacheTable")
+    eventually(timeout(10 seconds)) {
+      assert(!isMaterialized(rddId), "Uncached in-memory table should have been unpersisted")
+    }
+  }
+
+  test("CACHE TABLE tableName AS SELECT ...") {
+    sql("CACHE TABLE testCacheTable AS SELECT key FROM testData LIMIT 10")
+    assertCached(ctx.table("testCacheTable"))
+
+    val rddId = rddIdOf("testCacheTable")
+    assert(
+      isMaterialized(rddId),
+      "Eagerly cached in-memory table should have already been materialized")
+
+    ctx.uncacheTable("testCacheTable")
+    eventually(timeout(10 seconds)) {
+      assert(!isMaterialized(rddId), "Uncached in-memory table should have been unpersisted")
+    }
+  }
+
+  test("CACHE LAZY TABLE tableName") {
+    sql("CACHE LAZY TABLE testData")
+    assertCached(ctx.table("testData"))
+
+    val rddId = rddIdOf("testData")
+    assert(
+      !isMaterialized(rddId),
+      "Lazily cached in-memory table shouldn't be materialized eagerly")
+
+    sql("SELECT COUNT(*) FROM testData").collect()
+    assert(
+      isMaterialized(rddId),
+      "Lazily cached in-memory table should have been materialized")
+
+    ctx.uncacheTable("testData")
+    eventually(timeout(10 seconds)) {
+      assert(!isMaterialized(rddId), "Uncached in-memory table should have been unpersisted")
+    }
+  }
+
+  test("InMemoryRelation statistics") {
+    sql("CACHE TABLE testData")
+    ctx.table("testData").queryExecution.withCachedData.collect {
+      case cached: InMemoryRelation =>
+        val actualSizeInBytes = (1 to 100).map(i => INT.defaultSize + i.toString.length + 4).sum
+        assert(cached.statistics.sizeInBytes === actualSizeInBytes)
+    }
+  }
+
+  test("Drops temporary table") {
+    testData.select('key).registerTempTable("t1")
+    ctx.table("t1")
+    ctx.dropTempTable("t1")
+    assert(intercept[RuntimeException](ctx.table("t1")).getMessage.startsWith("Table Not Found"))
+  }
+
+  test("Drops cached temporary table") {
+    testData.select('key).registerTempTable("t1")
+    testData.select('key).registerTempTable("t2")
+    ctx.cacheTable("t1")
+
+    assert(ctx.isCached("t1"))
+    assert(ctx.isCached("t2"))
+
+    ctx.dropTempTable("t1")
+    assert(intercept[RuntimeException](ctx.table("t1")).getMessage.startsWith("Table Not Found"))
+    assert(!ctx.isCached("t2"))
+  }
+
+  test("Clear all cache") {
+    sql("SELECT key FROM testData LIMIT 10").registerTempTable("t1")
+    sql("SELECT key FROM testData LIMIT 5").registerTempTable("t2")
+    ctx.cacheTable("t1")
+    ctx.cacheTable("t2")
+    ctx.clearCache()
+    assert(ctx.cacheManager.isEmpty)
+
+    sql("SELECT key FROM testData LIMIT 10").registerTempTable("t1")
+    sql("SELECT key FROM testData LIMIT 5").registerTempTable("t2")
+    ctx.cacheTable("t1")
+    ctx.cacheTable("t2")
+    sql("Clear CACHE")
+    assert(ctx.cacheManager.isEmpty)
+  }
+
+  test("Clear accumulators when uncacheTable to prevent memory leaking") {
+    sql("SELECT key FROM testData LIMIT 10").registerTempTable("t1")
+    sql("SELECT key FROM testData LIMIT 5").registerTempTable("t2")
+
+    ctx.cacheTable("t1")
+    ctx.cacheTable("t2")
+
+    sql("SELECT * FROM t1").count()
+    sql("SELECT * FROM t2").count()
+    sql("SELECT * FROM t1").count()
+    sql("SELECT * FROM t2").count()
+
+    Accumulators.synchronized {
+      val accsSize = Accumulators.originals.size
+      ctx.uncacheTable("t1")
+      ctx.uncacheTable("t2")
+      assert((accsSize - 2) === Accumulators.originals.size)
+    }
+  }
 
   test("tungsten cache table and read") {
     val data = testData
     val tungstenCached = data.tungstenCache()
-    println(tungstenCached.collect().toSeq)
+    assert(tungstenCached.collect() === testData.collect())
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -17,6 +17,14 @@
 
 package org.apache.spark.sql
 
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{UnsafeProjection, UnsafeRow}
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.sources.{BaseRelation, TableScan}
+import org.apache.spark.unsafe.memory.{UnsafeMemoryAllocator, MemoryBlock}
+
+import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
@@ -47,293 +55,299 @@ class CachedTableSuite extends QueryTest with SharedSQLContext {
     ctx.sparkContext.env.blockManager.get(RDDBlockId(rddId, 0)).nonEmpty
   }
 
-  test("withColumn doesn't invalidate cached dataframe") {
-    var evalCount = 0
-    val myUDF = udf((x: String) => { evalCount += 1; "result" })
-    val df = Seq(("test", 1)).toDF("s", "i").select(myUDF($"s"))
-    df.cache()
+//  test("withColumn doesn't invalidate cached dataframe") {
+//    var evalCount = 0
+//    val myUDF = udf((x: String) => { evalCount += 1; "result" })
+//    val df = Seq(("test", 1)).toDF("s", "i").select(myUDF($"s"))
+//    df.cache()
+//
+//    df.collect()
+//    assert(evalCount === 1)
+//
+//    df.collect()
+//    assert(evalCount === 1)
+//
+//    val df2 = df.withColumn("newColumn", lit(1))
+//    df2.collect()
+//
+//    // We should not reevaluate the cached dataframe
+//    assert(evalCount === 1)
+//  }
+//
+//  test("cache temp table") {
+//    testData.select('key).registerTempTable("tempTable")
+//    assertCached(sql("SELECT COUNT(*) FROM tempTable"), 0)
+//    ctx.cacheTable("tempTable")
+//    assertCached(sql("SELECT COUNT(*) FROM tempTable"))
+//    ctx.uncacheTable("tempTable")
+//  }
+//
+//  test("unpersist an uncached table will not raise exception") {
+//    assert(None == ctx.cacheManager.lookupCachedData(testData))
+//    testData.unpersist(blocking = true)
+//    assert(None == ctx.cacheManager.lookupCachedData(testData))
+//    testData.unpersist(blocking = false)
+//    assert(None == ctx.cacheManager.lookupCachedData(testData))
+//    testData.persist()
+//    assert(None != ctx.cacheManager.lookupCachedData(testData))
+//    testData.unpersist(blocking = true)
+//    assert(None == ctx.cacheManager.lookupCachedData(testData))
+//    testData.unpersist(blocking = false)
+//    assert(None == ctx.cacheManager.lookupCachedData(testData))
+//  }
+//
+//  test("cache table as select") {
+//    sql("CACHE TABLE tempTable AS SELECT key FROM testData")
+//    assertCached(sql("SELECT COUNT(*) FROM tempTable"))
+//    ctx.uncacheTable("tempTable")
+//  }
+//
+//  test("uncaching temp table") {
+//    testData.select('key).registerTempTable("tempTable1")
+//    testData.select('key).registerTempTable("tempTable2")
+//    ctx.cacheTable("tempTable1")
+//
+//    assertCached(sql("SELECT COUNT(*) FROM tempTable1"))
+//    assertCached(sql("SELECT COUNT(*) FROM tempTable2"))
+//
+//    // Is this valid?
+//    ctx.uncacheTable("tempTable2")
+//
+//    // Should this be cached?
+//    assertCached(sql("SELECT COUNT(*) FROM tempTable1"), 0)
+//  }
+//
+//  test("too big for memory") {
+//    val data = "*" * 1000
+//    ctx.sparkContext.parallelize(1 to 200000, 1).map(_ => BigData(data)).toDF()
+//      .registerTempTable("bigData")
+//    ctx.table("bigData").persist(StorageLevel.MEMORY_AND_DISK)
+//    assert(ctx.table("bigData").count() === 200000L)
+//    ctx.table("bigData").unpersist(blocking = true)
+//  }
+//
+//  test("calling .cache() should use in-memory columnar caching") {
+//    ctx.table("testData").cache()
+//    assertCached(ctx.table("testData"))
+//    ctx.table("testData").unpersist(blocking = true)
+//  }
+//
+//  test("calling .unpersist() should drop in-memory columnar cache") {
+//    ctx.table("testData").cache()
+//    ctx.table("testData").count()
+//    ctx.table("testData").unpersist(blocking = true)
+//    assertCached(ctx.table("testData"), 0)
+//  }
+//
+//  test("isCached") {
+//    ctx.cacheTable("testData")
+//
+//    assertCached(ctx.table("testData"))
+//    assert(ctx.table("testData").queryExecution.withCachedData match {
+//      case _: InMemoryRelation => true
+//      case _ => false
+//    })
+//
+//    ctx.uncacheTable("testData")
+//    assert(!ctx.isCached("testData"))
+//    assert(ctx.table("testData").queryExecution.withCachedData match {
+//      case _: InMemoryRelation => false
+//      case _ => true
+//    })
+//  }
+//
+//  test("SPARK-1669: cacheTable should be idempotent") {
+//    assume(!ctx.table("testData").logicalPlan.isInstanceOf[InMemoryRelation])
+//
+//    ctx.cacheTable("testData")
+//    assertCached(ctx.table("testData"))
+//
+//    assertResult(1, "InMemoryRelation not found, testData should have been cached") {
+//      ctx.table("testData").queryExecution.withCachedData.collect {
+//        case r: InMemoryRelation => r
+//      }.size
+//    }
+//
+//    ctx.cacheTable("testData")
+//    assertResult(0, "Double InMemoryRelations found, cacheTable() is not idempotent") {
+//      ctx.table("testData").queryExecution.withCachedData.collect {
+//        case r @ InMemoryRelation(_, _, _, _, _: InMemoryColumnarTableScan, _) => r
+//      }.size
+//    }
+//
+//    ctx.uncacheTable("testData")
+//  }
+//
+//  test("read from cached table and uncache") {
+//    ctx.cacheTable("testData")
+//    checkAnswer(ctx.table("testData"), testData.collect().toSeq)
+//    assertCached(ctx.table("testData"))
+//
+//    ctx.uncacheTable("testData")
+//    checkAnswer(ctx.table("testData"), testData.collect().toSeq)
+//    assertCached(ctx.table("testData"), 0)
+//  }
+//
+//  test("correct error on uncache of non-cached table") {
+//    intercept[IllegalArgumentException] {
+//      ctx.uncacheTable("testData")
+//    }
+//  }
+//
+//  test("SELECT star from cached table") {
+//    sql("SELECT * FROM testData").registerTempTable("selectStar")
+//    ctx.cacheTable("selectStar")
+//    checkAnswer(
+//      sql("SELECT * FROM selectStar WHERE key = 1"),
+//      Seq(Row(1, "1")))
+//    ctx.uncacheTable("selectStar")
+//  }
+//
+//  test("Self-join cached") {
+//    val unCachedAnswer =
+//      sql("SELECT * FROM testData a JOIN testData b ON a.key = b.key").collect()
+//    ctx.cacheTable("testData")
+//    checkAnswer(
+//      sql("SELECT * FROM testData a JOIN testData b ON a.key = b.key"),
+//      unCachedAnswer.toSeq)
+//    ctx.uncacheTable("testData")
+//  }
+//
+//  test("'CACHE TABLE' and 'UNCACHE TABLE' SQL statement") {
+//    sql("CACHE TABLE testData")
+//    assertCached(ctx.table("testData"))
+//
+//    val rddId = rddIdOf("testData")
+//    assert(
+//      isMaterialized(rddId),
+//      "Eagerly cached in-memory table should have already been materialized")
+//
+//    sql("UNCACHE TABLE testData")
+//    assert(!ctx.isCached("testData"), "Table 'testData' should not be cached")
+//
+//    eventually(timeout(10 seconds)) {
+//      assert(!isMaterialized(rddId), "Uncached in-memory table should have been unpersisted")
+//    }
+//  }
+//
+//  test("CACHE TABLE tableName AS SELECT * FROM anotherTable") {
+//    sql("CACHE TABLE testCacheTable AS SELECT * FROM testData")
+//    assertCached(ctx.table("testCacheTable"))
+//
+//    val rddId = rddIdOf("testCacheTable")
+//    assert(
+//      isMaterialized(rddId),
+//      "Eagerly cached in-memory table should have already been materialized")
+//
+//    ctx.uncacheTable("testCacheTable")
+//    eventually(timeout(10 seconds)) {
+//      assert(!isMaterialized(rddId), "Uncached in-memory table should have been unpersisted")
+//    }
+//  }
+//
+//  test("CACHE TABLE tableName AS SELECT ...") {
+//    sql("CACHE TABLE testCacheTable AS SELECT key FROM testData LIMIT 10")
+//    assertCached(ctx.table("testCacheTable"))
+//
+//    val rddId = rddIdOf("testCacheTable")
+//    assert(
+//      isMaterialized(rddId),
+//      "Eagerly cached in-memory table should have already been materialized")
+//
+//    ctx.uncacheTable("testCacheTable")
+//    eventually(timeout(10 seconds)) {
+//      assert(!isMaterialized(rddId), "Uncached in-memory table should have been unpersisted")
+//    }
+//  }
+//
+//  test("CACHE LAZY TABLE tableName") {
+//    sql("CACHE LAZY TABLE testData")
+//    assertCached(ctx.table("testData"))
+//
+//    val rddId = rddIdOf("testData")
+//    assert(
+//      !isMaterialized(rddId),
+//      "Lazily cached in-memory table shouldn't be materialized eagerly")
+//
+//    sql("SELECT COUNT(*) FROM testData").collect()
+//    assert(
+//      isMaterialized(rddId),
+//      "Lazily cached in-memory table should have been materialized")
+//
+//    ctx.uncacheTable("testData")
+//    eventually(timeout(10 seconds)) {
+//      assert(!isMaterialized(rddId), "Uncached in-memory table should have been unpersisted")
+//    }
+//  }
+//
+//  test("InMemoryRelation statistics") {
+//    sql("CACHE TABLE testData")
+//    ctx.table("testData").queryExecution.withCachedData.collect {
+//      case cached: InMemoryRelation =>
+//        val actualSizeInBytes = (1 to 100).map(i => INT.defaultSize + i.toString.length + 4).sum
+//        assert(cached.statistics.sizeInBytes === actualSizeInBytes)
+//    }
+//  }
+//
+//  test("Drops temporary table") {
+//    testData.select('key).registerTempTable("t1")
+//    ctx.table("t1")
+//    ctx.dropTempTable("t1")
+//    assert(intercept[RuntimeException](ctx.table("t1")).getMessage.startsWith("Table Not Found"))
+//  }
+//
+//  test("Drops cached temporary table") {
+//    testData.select('key).registerTempTable("t1")
+//    testData.select('key).registerTempTable("t2")
+//    ctx.cacheTable("t1")
+//
+//    assert(ctx.isCached("t1"))
+//    assert(ctx.isCached("t2"))
+//
+//    ctx.dropTempTable("t1")
+//    assert(intercept[RuntimeException](ctx.table("t1")).getMessage.startsWith("Table Not Found"))
+//    assert(!ctx.isCached("t2"))
+//  }
+//
+//  test("Clear all cache") {
+//    sql("SELECT key FROM testData LIMIT 10").registerTempTable("t1")
+//    sql("SELECT key FROM testData LIMIT 5").registerTempTable("t2")
+//    ctx.cacheTable("t1")
+//    ctx.cacheTable("t2")
+//    ctx.clearCache()
+//    assert(ctx.cacheManager.isEmpty)
+//
+//    sql("SELECT key FROM testData LIMIT 10").registerTempTable("t1")
+//    sql("SELECT key FROM testData LIMIT 5").registerTempTable("t2")
+//    ctx.cacheTable("t1")
+//    ctx.cacheTable("t2")
+//    sql("Clear CACHE")
+//    assert(ctx.cacheManager.isEmpty)
+//  }
+//
+//  test("Clear accumulators when uncacheTable to prevent memory leaking") {
+//    sql("SELECT key FROM testData LIMIT 10").registerTempTable("t1")
+//    sql("SELECT key FROM testData LIMIT 5").registerTempTable("t2")
+//
+//    ctx.cacheTable("t1")
+//    ctx.cacheTable("t2")
+//
+//    sql("SELECT * FROM t1").count()
+//    sql("SELECT * FROM t2").count()
+//    sql("SELECT * FROM t1").count()
+//    sql("SELECT * FROM t2").count()
+//
+//    Accumulators.synchronized {
+//      val accsSize = Accumulators.originals.size
+//      ctx.uncacheTable("t1")
+//      ctx.uncacheTable("t2")
+//      assert((accsSize - 2) == Accumulators.originals.size)
+//    }
+//  }
 
-    df.collect()
-    assert(evalCount === 1)
-
-    df.collect()
-    assert(evalCount === 1)
-
-    val df2 = df.withColumn("newColumn", lit(1))
-    df2.collect()
-
-    // We should not reevaluate the cached dataframe
-    assert(evalCount === 1)
-  }
-
-  test("cache temp table") {
-    testData.select('key).registerTempTable("tempTable")
-    assertCached(sql("SELECT COUNT(*) FROM tempTable"), 0)
-    ctx.cacheTable("tempTable")
-    assertCached(sql("SELECT COUNT(*) FROM tempTable"))
-    ctx.uncacheTable("tempTable")
-  }
-
-  test("unpersist an uncached table will not raise exception") {
-    assert(None == ctx.cacheManager.lookupCachedData(testData))
-    testData.unpersist(blocking = true)
-    assert(None == ctx.cacheManager.lookupCachedData(testData))
-    testData.unpersist(blocking = false)
-    assert(None == ctx.cacheManager.lookupCachedData(testData))
-    testData.persist()
-    assert(None != ctx.cacheManager.lookupCachedData(testData))
-    testData.unpersist(blocking = true)
-    assert(None == ctx.cacheManager.lookupCachedData(testData))
-    testData.unpersist(blocking = false)
-    assert(None == ctx.cacheManager.lookupCachedData(testData))
-  }
-
-  test("cache table as select") {
-    sql("CACHE TABLE tempTable AS SELECT key FROM testData")
-    assertCached(sql("SELECT COUNT(*) FROM tempTable"))
-    ctx.uncacheTable("tempTable")
-  }
-
-  test("uncaching temp table") {
-    testData.select('key).registerTempTable("tempTable1")
-    testData.select('key).registerTempTable("tempTable2")
-    ctx.cacheTable("tempTable1")
-
-    assertCached(sql("SELECT COUNT(*) FROM tempTable1"))
-    assertCached(sql("SELECT COUNT(*) FROM tempTable2"))
-
-    // Is this valid?
-    ctx.uncacheTable("tempTable2")
-
-    // Should this be cached?
-    assertCached(sql("SELECT COUNT(*) FROM tempTable1"), 0)
-  }
-
-  test("too big for memory") {
-    val data = "*" * 1000
-    ctx.sparkContext.parallelize(1 to 200000, 1).map(_ => BigData(data)).toDF()
-      .registerTempTable("bigData")
-    ctx.table("bigData").persist(StorageLevel.MEMORY_AND_DISK)
-    assert(ctx.table("bigData").count() === 200000L)
-    ctx.table("bigData").unpersist(blocking = true)
-  }
-
-  test("calling .cache() should use in-memory columnar caching") {
-    ctx.table("testData").cache()
-    assertCached(ctx.table("testData"))
-    ctx.table("testData").unpersist(blocking = true)
-  }
-
-  test("calling .unpersist() should drop in-memory columnar cache") {
-    ctx.table("testData").cache()
-    ctx.table("testData").count()
-    ctx.table("testData").unpersist(blocking = true)
-    assertCached(ctx.table("testData"), 0)
-  }
-
-  test("isCached") {
-    ctx.cacheTable("testData")
-
-    assertCached(ctx.table("testData"))
-    assert(ctx.table("testData").queryExecution.withCachedData match {
-      case _: InMemoryRelation => true
-      case _ => false
-    })
-
-    ctx.uncacheTable("testData")
-    assert(!ctx.isCached("testData"))
-    assert(ctx.table("testData").queryExecution.withCachedData match {
-      case _: InMemoryRelation => false
-      case _ => true
-    })
-  }
-
-  test("SPARK-1669: cacheTable should be idempotent") {
-    assume(!ctx.table("testData").logicalPlan.isInstanceOf[InMemoryRelation])
-
-    ctx.cacheTable("testData")
-    assertCached(ctx.table("testData"))
-
-    assertResult(1, "InMemoryRelation not found, testData should have been cached") {
-      ctx.table("testData").queryExecution.withCachedData.collect {
-        case r: InMemoryRelation => r
-      }.size
-    }
-
-    ctx.cacheTable("testData")
-    assertResult(0, "Double InMemoryRelations found, cacheTable() is not idempotent") {
-      ctx.table("testData").queryExecution.withCachedData.collect {
-        case r @ InMemoryRelation(_, _, _, _, _: InMemoryColumnarTableScan, _) => r
-      }.size
-    }
-
-    ctx.uncacheTable("testData")
-  }
-
-  test("read from cached table and uncache") {
-    ctx.cacheTable("testData")
-    checkAnswer(ctx.table("testData"), testData.collect().toSeq)
-    assertCached(ctx.table("testData"))
-
-    ctx.uncacheTable("testData")
-    checkAnswer(ctx.table("testData"), testData.collect().toSeq)
-    assertCached(ctx.table("testData"), 0)
-  }
-
-  test("correct error on uncache of non-cached table") {
-    intercept[IllegalArgumentException] {
-      ctx.uncacheTable("testData")
-    }
-  }
-
-  test("SELECT star from cached table") {
-    sql("SELECT * FROM testData").registerTempTable("selectStar")
-    ctx.cacheTable("selectStar")
-    checkAnswer(
-      sql("SELECT * FROM selectStar WHERE key = 1"),
-      Seq(Row(1, "1")))
-    ctx.uncacheTable("selectStar")
-  }
-
-  test("Self-join cached") {
-    val unCachedAnswer =
-      sql("SELECT * FROM testData a JOIN testData b ON a.key = b.key").collect()
-    ctx.cacheTable("testData")
-    checkAnswer(
-      sql("SELECT * FROM testData a JOIN testData b ON a.key = b.key"),
-      unCachedAnswer.toSeq)
-    ctx.uncacheTable("testData")
-  }
-
-  test("'CACHE TABLE' and 'UNCACHE TABLE' SQL statement") {
-    sql("CACHE TABLE testData")
-    assertCached(ctx.table("testData"))
-
-    val rddId = rddIdOf("testData")
-    assert(
-      isMaterialized(rddId),
-      "Eagerly cached in-memory table should have already been materialized")
-
-    sql("UNCACHE TABLE testData")
-    assert(!ctx.isCached("testData"), "Table 'testData' should not be cached")
-
-    eventually(timeout(10 seconds)) {
-      assert(!isMaterialized(rddId), "Uncached in-memory table should have been unpersisted")
-    }
-  }
-
-  test("CACHE TABLE tableName AS SELECT * FROM anotherTable") {
-    sql("CACHE TABLE testCacheTable AS SELECT * FROM testData")
-    assertCached(ctx.table("testCacheTable"))
-
-    val rddId = rddIdOf("testCacheTable")
-    assert(
-      isMaterialized(rddId),
-      "Eagerly cached in-memory table should have already been materialized")
-
-    ctx.uncacheTable("testCacheTable")
-    eventually(timeout(10 seconds)) {
-      assert(!isMaterialized(rddId), "Uncached in-memory table should have been unpersisted")
-    }
-  }
-
-  test("CACHE TABLE tableName AS SELECT ...") {
-    sql("CACHE TABLE testCacheTable AS SELECT key FROM testData LIMIT 10")
-    assertCached(ctx.table("testCacheTable"))
-
-    val rddId = rddIdOf("testCacheTable")
-    assert(
-      isMaterialized(rddId),
-      "Eagerly cached in-memory table should have already been materialized")
-
-    ctx.uncacheTable("testCacheTable")
-    eventually(timeout(10 seconds)) {
-      assert(!isMaterialized(rddId), "Uncached in-memory table should have been unpersisted")
-    }
-  }
-
-  test("CACHE LAZY TABLE tableName") {
-    sql("CACHE LAZY TABLE testData")
-    assertCached(ctx.table("testData"))
-
-    val rddId = rddIdOf("testData")
-    assert(
-      !isMaterialized(rddId),
-      "Lazily cached in-memory table shouldn't be materialized eagerly")
-
-    sql("SELECT COUNT(*) FROM testData").collect()
-    assert(
-      isMaterialized(rddId),
-      "Lazily cached in-memory table should have been materialized")
-
-    ctx.uncacheTable("testData")
-    eventually(timeout(10 seconds)) {
-      assert(!isMaterialized(rddId), "Uncached in-memory table should have been unpersisted")
-    }
-  }
-
-  test("InMemoryRelation statistics") {
-    sql("CACHE TABLE testData")
-    ctx.table("testData").queryExecution.withCachedData.collect {
-      case cached: InMemoryRelation =>
-        val actualSizeInBytes = (1 to 100).map(i => INT.defaultSize + i.toString.length + 4).sum
-        assert(cached.statistics.sizeInBytes === actualSizeInBytes)
-    }
-  }
-
-  test("Drops temporary table") {
-    testData.select('key).registerTempTable("t1")
-    ctx.table("t1")
-    ctx.dropTempTable("t1")
-    assert(intercept[RuntimeException](ctx.table("t1")).getMessage.startsWith("Table Not Found"))
-  }
-
-  test("Drops cached temporary table") {
-    testData.select('key).registerTempTable("t1")
-    testData.select('key).registerTempTable("t2")
-    ctx.cacheTable("t1")
-
-    assert(ctx.isCached("t1"))
-    assert(ctx.isCached("t2"))
-
-    ctx.dropTempTable("t1")
-    assert(intercept[RuntimeException](ctx.table("t1")).getMessage.startsWith("Table Not Found"))
-    assert(!ctx.isCached("t2"))
-  }
-
-  test("Clear all cache") {
-    sql("SELECT key FROM testData LIMIT 10").registerTempTable("t1")
-    sql("SELECT key FROM testData LIMIT 5").registerTempTable("t2")
-    ctx.cacheTable("t1")
-    ctx.cacheTable("t2")
-    ctx.clearCache()
-    assert(ctx.cacheManager.isEmpty)
-
-    sql("SELECT key FROM testData LIMIT 10").registerTempTable("t1")
-    sql("SELECT key FROM testData LIMIT 5").registerTempTable("t2")
-    ctx.cacheTable("t1")
-    ctx.cacheTable("t2")
-    sql("Clear CACHE")
-    assert(ctx.cacheManager.isEmpty)
-  }
-
-  test("Clear accumulators when uncacheTable to prevent memory leaking") {
-    sql("SELECT key FROM testData LIMIT 10").registerTempTable("t1")
-    sql("SELECT key FROM testData LIMIT 5").registerTempTable("t2")
-
-    ctx.cacheTable("t1")
-    ctx.cacheTable("t2")
-
-    sql("SELECT * FROM t1").count()
-    sql("SELECT * FROM t2").count()
-    sql("SELECT * FROM t1").count()
-    sql("SELECT * FROM t2").count()
-
-    Accumulators.synchronized {
-      val accsSize = Accumulators.originals.size
-      ctx.uncacheTable("t1")
-      ctx.uncacheTable("t2")
-      assert((accsSize - 2) == Accumulators.originals.size)
-    }
+  test("tungsten cache table and read") {
+    val data = testData
+    val tungstenCached = data.tungstenCache()
+    println(tungstenCached.collect().toSeq)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/UnsafeRowSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UnsafeRowSuite.scala
@@ -78,6 +78,13 @@ class UnsafeRowSuite extends SparkFunSuite {
     assert(bytesFromArrayBackedRow === bytesFromOffheapRow)
   }
 
+  test("calling getUTF8String() on non-null columns") {
+    val inputString = "abc"
+    val row = InternalRow.apply(inputString)
+    val unsafeRow = UnsafeProjection.create(Array[DataType](StringType)).apply(row)
+    assert(unsafeRow.getString(0) === inputString)
+  }
+
   test("calling getDouble() and getFloat() on null columns") {
     val row = InternalRow.apply(null, null)
     val unsafeRow = UnsafeProjection.create(Array[DataType](FloatType, DoubleType)).apply(row)

--- a/sql/core/src/test/scala/org/apache/spark/sql/UnsafeRowSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UnsafeRowSuite.scala
@@ -43,12 +43,12 @@ class UnsafeRowSuite extends SparkFunSuite {
     val arrayBackedUnsafeRow: UnsafeRow =
       UnsafeProjection.create(Array[DataType](StringType, StringType, IntegerType)).apply(row)
     assert(arrayBackedUnsafeRow.getBaseObject.isInstanceOf[Array[Byte]])
-    val bytesFromArrayBackedRow: Array[Byte] = {
+    val (bytesFromArrayBackedRow, field0StringFromArrayBackedRow): (Array[Byte], String) = {
       val baos = new ByteArrayOutputStream()
       arrayBackedUnsafeRow.writeToStream(baos, null)
-      baos.toByteArray
+      (baos.toByteArray, arrayBackedUnsafeRow.getString(0))
     }
-    val bytesFromOffheapRow: Array[Byte] = {
+    val (bytesFromOffheapRow, field0StringFromOffheapRow): (Array[Byte], String) = {
       val offheapRowPage = MemoryAllocator.UNSAFE.allocate(arrayBackedUnsafeRow.getSizeInBytes)
       try {
         Platform.copyMemory(
@@ -69,13 +69,14 @@ class UnsafeRowSuite extends SparkFunSuite {
         val baos = new ByteArrayOutputStream()
         val writeBuffer = new Array[Byte](1024)
         offheapUnsafeRow.writeToStream(baos, writeBuffer)
-        baos.toByteArray
+        (baos.toByteArray, offheapUnsafeRow.getString(0))
       } finally {
         MemoryAllocator.UNSAFE.free(offheapRowPage)
       }
     }
 
     assert(bytesFromArrayBackedRow === bytesFromOffheapRow)
+    assert(field0StringFromArrayBackedRow === field0StringFromOffheapRow)
   }
 
   test("calling getString() on non-null column") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/UnsafeRowSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UnsafeRowSuite.scala
@@ -78,7 +78,7 @@ class UnsafeRowSuite extends SparkFunSuite {
     assert(bytesFromArrayBackedRow === bytesFromOffheapRow)
   }
 
-  test("calling getUTF8String() on non-null columns") {
+  test("calling getString() on non-null column") {
     val inputString = "abc"
     val row = InternalRow.apply(inputString)
     val unsafeRow = UnsafeProjection.create(Array[DataType](StringType)).apply(row)


### PR DESCRIPTION
Adds `tungstenCache` to `DataFrame`, which caches the `DataFrame`'s rows using contiguous blocks of off-heap memory.

CC @rxin @marmbrus 

Closes #8523 (changes there are included, can also rebase if easier)
