### PR TITLE
[SPARK-10290][SQL] Spark can register temp table and hive table with the same table name

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -649,6 +649,9 @@ class SQLContext(@transient val sparkContext: SparkContext)
    * only during the lifetime of this instance of SQLContext.
    */
   private[sql] def registerDataFrameAsTable(df: DataFrame, tableName: String): Unit = {
+    if (catalog.tableExists(tableName :: Nil)) {
+      throw new AnalysisException(s"Table $tableName already exists.")
+    }
     catalog.registerTable(Seq(tableName), df.logicalPlan)
   }
 


### PR DESCRIPTION
If trying to register temp table with the same table name which has been saved as hive table, an exception should be thrown:

``` scala
throw new AnalysisException(s"Table $tableName already exists.")
```

In reverse, if trying to save a hive table with the same table name which has been registered as temp table, then the outcome will be determined by `SaveMode`, which was already intact.
