### PR TITLE
[SPARK-10304][SQL]: throw error when the table directory is invalid

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -436,7 +436,8 @@ abstract class HadoopFsRelation private[sql](maybePartitionSpec: Option[Partitio
           Try(fs.listStatus(qualified)).getOrElse(Array.empty)
         }.filterNot { status =>
           val name = status.getPath.getName
-          name.toLowerCase == "_temporary" || name.startsWith(".")
+          // Is it safe to replace "_temporary" to "_"?
+          name.startsWith(".") || name.startsWith("_")
         }
 
         val (dirs, files) = statuses.partition(_.isDir)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetPartitionDiscoverySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetPartitionDiscoverySuite.scala
@@ -103,6 +103,18 @@ class ParquetPartitionDiscoverySuite extends QueryTest with ParquetTest with Sha
     checkThrows[AssertionError]("file://path/a=", "Empty partition column value")
   }
 
+  test("parse invalid partitioned directories") {
+    val paths = Seq(
+      "hdfs://host:9000/invalidPath",
+      "hdfs://host:9000/path/a=10/b=20",
+      "hdfs://host:9000/path/a=10.5/b=hello")
+
+    val exception = intercept[Exception] {
+      parsePartitions(paths.map(new Path(_)), defaultPartitionName, true)
+    }
+    assert(exception.getMessage().contains("Conflicting directory structures detected"))
+  }
+
   test("parse partitions") {
     def check(paths: Seq[String], spec: PartitionSpec): Unit = {
       assert(parsePartitions(paths.map(new Path(_)), defaultPartitionName, true) === spec)


### PR DESCRIPTION
Throw error if the directory of a table is invalid, validated by either all files in the directory are partitioned, or none of them are partitioned.

The consistency of detailed partition spec is validated by existing parsePartitionColumn.
