### PR TITLE
[SPARK-10417][SQL] Iterating through Column results in infinite loop

### DIFF
--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -226,6 +226,10 @@ class Column(object):
             raise AttributeError(item)
         return self.getField(item)
 
+    def __iter__(self):
+        raise TypeError('%s.%s object is not iterable' % (self.__module__,
+                                                          self.__class__.__name__))
+
     # string methods
     rlike = _bin_op("rlike")
     like = _bin_op("like")

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -227,8 +227,7 @@ class Column(object):
         return self.getField(item)
 
     def __iter__(self):
-        raise TypeError('%s.%s object is not iterable' % (self.__module__,
-                                                          self.__class__.__name__))
+        raise TypeError("Column is not iterable")
 
     # string methods
     rlike = _bin_op("rlike")

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -1066,6 +1066,16 @@ class SQLTests(ReusedPySparkTestCase):
         keys = self.df.withColumn("key", self.df.key).select("key").collect()
         self.assertEqual([r.key for r in keys], list(range(100)))
 
+    # regression test for SPARK-10417
+    def test_column_iterator(self):
+        # Catch exception raised during improper construction
+        try:
+            for x in self.df.key:
+                break
+            self.assertEqual(0, 1)
+        except TypeError:
+            self.assertEqual(1, 1)
+
 
 class HiveContextSQLTests(ReusedPySparkTestCase):
 

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -1068,13 +1068,12 @@ class SQLTests(ReusedPySparkTestCase):
 
     # regression test for SPARK-10417
     def test_column_iterator(self):
-        # Catch exception raised during improper construction
-        try:
+
+        def foo():
             for x in self.df.key:
                 break
-            self.assertEqual(0, 1)
-        except TypeError:
-            self.assertEqual(1, 1)
+
+        self.assertRaises(TypeError, foo)
 
 
 class HiveContextSQLTests(ReusedPySparkTestCase):


### PR DESCRIPTION
`pyspark.sql.column.Column` object has `__getitem__` method, which makes it iterable for Python. In fact it has `__getitem__` to address the case when the column might be a list or dict, for you to be able to access certain element of it in DF API. The ability to iterate over it is just a side effect that might cause confusion for the people getting familiar with Spark DF (as you might iterate this way on Pandas DF for instance)

Issue reproduction:

```
df = sqlContext.jsonRDD(sc.parallelize(['{"name": "El Magnifico"}']))
for i in df["name"]: print i
```
