### PR TITLE
[SPARK-10421] [build] Exclude curator artifacts from tachyon dependencies.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -274,6 +274,10 @@
         </exclusion>
         <exclusion>
           <groupId>org.apache.curator</groupId>
+          <artifactId>curator-framework</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.curator</groupId>
           <artifactId>curator-recipes</artifactId>
         </exclusion>
         <exclusion>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -274,6 +274,10 @@
         </exclusion>
         <exclusion>
           <groupId>org.apache.curator</groupId>
+          <artifactId>curator-client</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.curator</groupId>
           <artifactId>curator-framework</artifactId>
         </exclusion>
         <exclusion>


### PR DESCRIPTION
This avoids them being mistakenly pulled instead of the newer ones that
Spark actually uses. Spark only depends on these artifacts transitively,
so sometimes maven just decides to pick tachyon's version of the 
dependency for whatever reason.
