### PR TITLE
[SPARK-9834][MLLIB] implement weighted least squares via normal equation

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/optim/WeightedLeastSquares.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/WeightedLeastSquares.scala
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.optim
+
+import com.github.fommil.netlib.LAPACK.{getInstance => lapack}
+import org.netlib.util.intW
+
+import org.apache.spark.Logging
+import org.apache.spark.mllib.linalg._
+import org.apache.spark.mllib.linalg.distributed.RowMatrix
+import org.apache.spark.rdd.RDD
+
+private[ml] class WeightedLeastSquaresModel(
+    val coefficients: DenseVector,
+    val intercept: Double) extends Serializable
+
+private[ml] class WeightedLeastSquares(
+    val fitIntercept: Boolean,
+    val regParam: Double,
+    val standardization: Boolean) extends Logging with Serializable {
+  import WeightedLeastSquares._
+
+  require(regParam >= 0.0, s"regParam cannot be negative: $regParam")
+  if (regParam == 0.0) {
+    logWarning("regParam is zero, which might cause numerical instability and overfit.")
+  }
+
+  /**
+   * Creates a [[WeightedLeastSquaresModel]] from an RDD of [[Instance]]s.
+   */
+  def fit(instances: RDD[Instance]): WeightedLeastSquaresModel = {
+    val summary = instances.treeAggregate(new Aggregator)(_.add(_), _.merge(_))
+    assert(summary.initialized, "Training dataset is empty.")
+    assert(summary.wSum > 0.0, "Sum of weights cannot be zero.")
+    assert(summary.count > 1.0, "Must have more than one instances.")
+    val triK = summary.triK
+    val wSum = summary.wSum
+    val wwSum = summary.wwSum
+    val bSum = summary.bSum
+    val aSum = summary.aSum
+    val abSum = summary.abSum
+    val aaSum = summary.aaSum
+    val aaValues = aaSum.values
+
+    // add regularization to diagonals
+    var i = 0
+    var j = 2
+    while (i < triK) {
+      val scale = if (standardization) {
+        val l = j - 2
+        aaValues(i) - aSum(l) * aSum(l) / wSum
+      } else {
+        wSum
+      }
+      aaValues(i) += scale * regParam
+      i += j
+      j += 1
+    }
+
+    if (fitIntercept) {
+      // shift centers
+      BLAS.axpy(-bSum / wSum, aSum, abSum)
+      RowMatrix.dspr(-1.0 / wSum, aSum, aaValues)
+    }
+
+    if (standardization) {
+      // correct bias
+      BLAS.scal(1.0 - wwSum / (wSum * wSum), abSum)
+    }
+
+    val x = choleskySolve(aaValues, abSum)
+
+    // compute intercept
+    val intercept = if (fitIntercept) {
+      (bSum - BLAS.dot(aSum, x)) / wSum
+    } else {
+      0.0
+    }
+
+    new WeightedLeastSquaresModel(x, intercept)
+  }
+
+  private def choleskySolve(A: Array[Double], bx: DenseVector): DenseVector = {
+    val k = bx.size
+    val info = new intW(0)
+    lapack.dppsv("U", k, 1, A, bx.values, k, info)
+    val code = info.`val`
+    assert(code == 0, s"lapack.dpotrs returned $code.")
+    bx
+  }
+}
+
+private[ml] object WeightedLeastSquares {
+
+  case class Instance(w: Double, a: Vector, b: Double) {
+    require(w >= 0.0, s"Weight cannot be negative: $w.")
+  }
+
+  private class Aggregator extends Serializable {
+    var initialized: Boolean = false
+    var k: Int = _
+    var count: Long = _
+    var triK: Int = _
+    var wSum: Double = _
+    var wwSum: Double = _
+    var bSum: Double = _
+    var aSum: DenseVector = _
+    var abSum: DenseVector = _
+    var aaSum: DenseVector = _
+
+    private def init(k: Int): Unit = {
+      require(k <= 4096, "In order to take the normal equation approach efficiently, " +
+        s"we set the max number of features to 4096 but got $k.")
+      this.k = k
+      triK = k * (k + 1) / 2
+      count = 0L
+      wSum = 0.0
+      wwSum = 0.0
+      bSum = 0.0
+      aSum = DenseVector.zeros(k)
+      abSum = DenseVector.zeros(k)
+      aaSum = DenseVector.zeros(triK)
+      initialized = true
+    }
+
+    def add(instance: Instance): this.type = {
+      val Instance(w, a, b) = instance
+      val ak = a.size
+      if (!initialized) {
+        init(ak)
+        initialized = true
+      }
+      assert(ak == k, s"Dimension mismatch. Expect vectors of size $k but got $ak.")
+      count += 1L
+      wSum += w
+      wwSum += w * w
+      bSum += w * b
+      BLAS.axpy(w, a, aSum)
+      BLAS.axpy(w * b, a, abSum)
+      RowMatrix.dspr(w, a, aaSum.values)
+      this
+    }
+
+    def merge(other: Aggregator): this.type = {
+      if (!other.initialized) {
+        this
+      } else {
+        if (!initialized) {
+          init(other.k)
+        }
+        assert(k == other.k)
+        count += other.count
+        wSum += other.wSum
+        wwSum += other.wwSum
+        bSum += other.bSum
+        BLAS.axpy(1.0, other.aSum, aSum)
+        BLAS.axpy(1.0, other.abSum, abSum)
+        BLAS.axpy(1.0, other.aaSum, aaSum)
+        this
+      }
+    }
+  }
+}

--- a/mllib/src/main/scala/org/apache/spark/ml/optim/WeightedLeastSquares.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/WeightedLeastSquares.scala
@@ -66,7 +66,7 @@ private[ml] class WeightedLeastSquares(
 
   require(regParam >= 0.0, s"regParam cannot be negative: $regParam")
   if (regParam == 0.0) {
-    logWarning("regParam is zero, which might cause numerical instability and overfit.")
+    logWarning("regParam is zero, which might cause numerical instability and overfitting.")
   }
 
   /**
@@ -129,6 +129,7 @@ private[ml] class WeightedLeastSquares(
    * @param bx right-hand side
    * @return the solution vector
    */
+  // TODO: SPARK-10490 - consolidate this and the Cholesky solver in ALS
   private def choleskySolve(A: Array[Double], bx: DenseVector): DenseVector = {
     val k = bx.size
     val info = new intW(0)
@@ -216,7 +217,7 @@ private[ml] object WeightedLeastSquares {
         if (!initialized) {
           init(other.k)
         }
-        assert(k == other.k)
+        assert(k == other.k, s"dimension mismatch: this.k = $k but other.k = ${other.k}")
         count += other.count
         wSum += other.wSum
         wwSum += other.wwSum

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
@@ -92,6 +92,7 @@ private[spark] object BLAS extends Serializable with Logging {
     }
   }
 
+  /** Y += a * x */
   private[spark] def axpy(a: Double, X: DenseMatrix, Y: DenseMatrix): Unit = {
     require(X.numRows == Y.numRows && X.numCols == Y.numCols, "Dimension mismatch: " +
       s"size(X) = ${(X.numRows, X.numCols)} but size(Y) = ${(Y.numRows, Y.numCols)}.")

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/BLAS.scala
@@ -92,6 +92,12 @@ private[spark] object BLAS extends Serializable with Logging {
     }
   }
 
+  private[spark] def axpy(a: Double, X: DenseMatrix, Y: DenseMatrix): Unit = {
+    require(X.numRows == Y.numRows && X.numCols == Y.numCols, "Dimension mismatch: " +
+      s"size(X) = ${(X.numRows, X.numCols)} but size(Y) = ${(Y.numRows, Y.numCols)}.")
+    f2jBLAS.daxpy(X.numRows * X.numCols, a, X.values, 1, Y.values, 1)
+  }
+
   /**
    * dot(x, y)
    */

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
@@ -655,8 +655,6 @@ object DenseVector {
   /** Extracts the value array from a dense vector. */
   @Since("1.3.0")
   def unapply(dv: DenseVector): Option[Array[Double]] = Some(dv.values)
-
-  def zeros(size: Int): DenseVector = new DenseVector(Array.ofDim(size))
 }
 
 /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
@@ -655,6 +655,8 @@ object DenseVector {
   /** Extracts the value array from a dense vector. */
   @Since("1.3.0")
   def unapply(dv: DenseVector): Option[Array[Double]] = Some(dv.values)
+
+  def zeros(size: Int): DenseVector = new DenseVector(Array.ofDim(size))
 }
 
 /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/RowMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/RowMatrix.scala
@@ -678,6 +678,7 @@ object RowMatrix {
    *
    * @param U the upper triangular part of the matrix packed in an array (column major)
    */
+  // TODO: SPARK-10491 - move this method to linalg.BLAS
   private[spark] def dspr(alpha: Double, v: Vector, U: Array[Double]): Unit = {
     // TODO: Find a better home (breeze?) for this method.
     val n = v.size

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/RowMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/RowMatrix.scala
@@ -678,7 +678,7 @@ object RowMatrix {
    *
    * @param U the upper triangular part of the matrix packed in an array (column major)
    */
-  private def dspr(alpha: Double, v: Vector, U: Array[Double]): Unit = {
+  private[spark] def dspr(alpha: Double, v: Vector, U: Array[Double]): Unit = {
     // TODO: Find a better home (breeze?) for this method.
     val n = v.size
     v match {

--- a/mllib/src/test/scala/org/apache/spark/ml/optim/WeightedLeastSquaresSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/optim/WeightedLeastSquaresSuite.scala
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.optim
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.ml.optim.WeightedLeastSquares.Instance
+import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.mllib.util.MLlibTestSparkContext
+import org.apache.spark.mllib.util.TestingUtils._
+import org.apache.spark.rdd.RDD
+
+class WeightedLeastSquaresSuite extends SparkFunSuite with MLlibTestSparkContext {
+
+  private var instances: RDD[Instance] = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    instances = sc.parallelize(Seq(
+      Instance(1.0, Vectors.dense(0.0, 5.0).toSparse, 17.0),
+      Instance(2.0, Vectors.dense(1.0, 7.0), 19.0),
+      Instance(3.0, Vectors.dense(2.0, 11.0), 23.0),
+      Instance(4.0, Vectors.dense(3.0, 13.0), 29.0)
+    ), 2)
+  }
+
+  test("WLS against glmnet") {
+    /*
+       R code:
+
+library(glmnet)
+
+A <- matrix(c(0, 1, 2, 3, 5, 7, 11, 13), 4, 2)
+b <- c(17, 19, 23, 29)
+w <- c(1, 2, 3, 4)
+
+for (intercept in c(FALSE, TRUE)) {
+  model <- glmnet(A, b, weights=w, intercept=intercept, lambda=0.0, standardize=FALSE, alpha=0)
+  print(as.vector(coef(model)))
+}
+
+[1]  0.000000 -3.713230  3.007162
+[1] 17.9935922  6.0267241 -0.5814462
+     */
+
+    val expected = Seq(
+      Vectors.dense(0.0, -3.713230, 3.007162),
+      Vectors.dense(17.9935922, 6.0267241, -0.5814462))
+
+    var idx = 0
+    for (fitIntercept <- Seq(false, true);
+         regParam <- Seq(0.0);
+         standardization <- Seq(false)) {
+      val wls = new WeightedLeastSquares(fitIntercept, regParam, standardization)
+        .fit(instances)
+      val actual = Vectors.dense(wls.intercept, wls.coefficients(0), wls.coefficients(1))
+      assert(actual ~== expected(idx) absTol 1e-1)
+      idx += 1
+    }
+  }
+}

--- a/mllib/src/test/scala/org/apache/spark/ml/optim/WeightedLeastSquaresSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/optim/WeightedLeastSquaresSuite.scala
@@ -50,7 +50,7 @@ w <- c(1, 2, 3, 4)
 
 for (intercept in c(FALSE, TRUE)) {
   for (lambda in c(0.0, 0.1, 1.0)) {
-    for (standardize in c(FALSE)) {
+    for (standardize in c(FALSE, TRUE)) {
       model <- glmnet(A, b, weights=w, intercept=intercept, lambda=lambda, standardize=standardize,
                       alpha=0, thresh=1E-14)
       print(as.vector(coef(model)))
@@ -59,33 +59,43 @@ for (intercept in c(FALSE, TRUE)) {
 }
 
 [1]  0.000000 -3.727117  3.009982
+[1]  0.000000 -3.727117  3.009982
 [1]  0.000000 -3.307532  2.924206
+[1]  0.000000 -2.914790  2.840627
 [1]  0.000000 -1.526575  2.558158
+[1] 0.00000000 0.06984238 2.20488344
+[1] 18.0799727  6.0799832 -0.5999941
 [1] 18.0799727  6.0799832 -0.5999941
 [1] 13.5356178  3.2714044  0.3770744
+[1] 14.064629  3.565802  0.269593
 [1] 10.1238013  0.9708569  1.1475466
+[1] 13.1860638  2.1761382  0.6213134
      */
 
     val expected = Seq(
-      Vectors.dense(0.000000, -3.727117, 3.009982),
-      Vectors.dense(0.000000, -3.307532, 2.924206),
-      Vectors.dense(0.000000, -1.526575, 2.558158),
+      Vectors.dense(0.0, -3.727117, 3.009982),
+      Vectors.dense(0.0, -3.727117, 3.009982),
+      Vectors.dense(0.0, -3.307532, 2.924206),
+      Vectors.dense(0.0, -2.914790, 2.840627),
+      Vectors.dense(0.0, -1.526575, 2.558158),
+      Vectors.dense(0.0, 0.06984238, 2.20488344),
+      Vectors.dense(18.0799727, 6.0799832, -0.5999941),
       Vectors.dense(18.0799727, 6.0799832, -0.5999941),
       Vectors.dense(13.5356178, 3.2714044, 0.3770744),
-      Vectors.dense(10.1238013, 0.9708569, 1.1475466))
+      Vectors.dense(14.064629, 3.565802, 0.269593),
+      Vectors.dense(10.1238013, 0.9708569, 1.1475466),
+      Vectors.dense(13.1860638, 2.1761382, 0.6213134))
 
     var idx = 0
     for (fitIntercept <- Seq(false, true);
          regParam <- Seq(0.0, 0.1, 1.0);
-         standardization <- Seq(false)) {
+         standardization <- Seq(false, true)) {
       val wls = new WeightedLeastSquares(fitIntercept, regParam, standardization)
         .fit(instances)
       val actual = Vectors.dense(wls.intercept, wls.coefficients(0), wls.coefficients(1))
-      println(actual, expected(idx))
-      // assert(actual ~== expected(idx) absTol 1e-2)
+      // println(actual, expected(idx))
+      assert(actual ~== expected(idx) absTol 1e-4)
       idx += 1
     }
-
-    assert(false)
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/optim/WeightedLeastSquaresSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/optim/WeightedLeastSquaresSuite.scala
@@ -49,28 +49,43 @@ b <- c(17, 19, 23, 29)
 w <- c(1, 2, 3, 4)
 
 for (intercept in c(FALSE, TRUE)) {
-  model <- glmnet(A, b, weights=w, intercept=intercept, lambda=0.0, standardize=FALSE,
-                  alpha=0, thresh=1E-14)
-  print(as.vector(coef(model)))
+  for (lambda in c(0.0, 0.1, 1.0)) {
+    for (standardize in c(FALSE)) {
+      model <- glmnet(A, b, weights=w, intercept=intercept, lambda=lambda, standardize=standardize,
+                      alpha=0, thresh=1E-14)
+      print(as.vector(coef(model)))
+    }
+  }
 }
 
 [1]  0.000000 -3.727117  3.009982
+[1]  0.000000 -3.307532  2.924206
+[1]  0.000000 -1.526575  2.558158
 [1] 18.0799727  6.0799832 -0.5999941
+[1] 13.5356178  3.2714044  0.3770744
+[1] 10.1238013  0.9708569  1.1475466
      */
 
     val expected = Seq(
-      Vectors.dense(0.0, -3.727117, 3.009982),
-      Vectors.dense(18.0799727, 6.0799832, -0.5999941))
+      Vectors.dense(0.000000, -3.727117, 3.009982),
+      Vectors.dense(0.000000, -3.307532, 2.924206),
+      Vectors.dense(0.000000, -1.526575, 2.558158),
+      Vectors.dense(18.0799727, 6.0799832, -0.5999941),
+      Vectors.dense(13.5356178, 3.2714044, 0.3770744),
+      Vectors.dense(10.1238013, 0.9708569, 1.1475466))
 
     var idx = 0
     for (fitIntercept <- Seq(false, true);
-         regParam <- Seq(0.0);
+         regParam <- Seq(0.0, 0.1, 1.0);
          standardization <- Seq(false)) {
       val wls = new WeightedLeastSquares(fitIntercept, regParam, standardization)
         .fit(instances)
       val actual = Vectors.dense(wls.intercept, wls.coefficients(0), wls.coefficients(1))
-      assert(actual ~== expected(idx) absTol 1e-2)
+      println(actual, expected(idx))
+      // assert(actual ~== expected(idx) absTol 1e-2)
       idx += 1
     }
+
+    assert(false)
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/optim/WeightedLeastSquaresSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/optim/WeightedLeastSquaresSuite.scala
@@ -49,17 +49,18 @@ b <- c(17, 19, 23, 29)
 w <- c(1, 2, 3, 4)
 
 for (intercept in c(FALSE, TRUE)) {
-  model <- glmnet(A, b, weights=w, intercept=intercept, lambda=0.0, standardize=FALSE, alpha=0)
+  model <- glmnet(A, b, weights=w, intercept=intercept, lambda=0.0, standardize=FALSE,
+                  alpha=0, thresh=1E-14)
   print(as.vector(coef(model)))
 }
 
-[1]  0.000000 -3.713230  3.007162
-[1] 17.9935922  6.0267241 -0.5814462
+[1]  0.000000 -3.727117  3.009982
+[1] 18.0799727  6.0799832 -0.5999941
      */
 
     val expected = Seq(
-      Vectors.dense(0.0, -3.713230, 3.007162),
-      Vectors.dense(17.9935922, 6.0267241, -0.5814462))
+      Vectors.dense(0.0, -3.727117, 3.009982),
+      Vectors.dense(18.0799727, 6.0799832, -0.5999941))
 
     var idx = 0
     for (fitIntercept <- Seq(false, true);
@@ -68,7 +69,7 @@ for (intercept in c(FALSE, TRUE)) {
       val wls = new WeightedLeastSquares(fitIntercept, regParam, standardization)
         .fit(instances)
       val actual = Vectors.dense(wls.intercept, wls.coefficients(0), wls.coefficients(1))
-      assert(actual ~== expected(idx) absTol 1e-1)
+      assert(actual ~== expected(idx) absTol 1e-2)
       idx += 1
     }
   }

--- a/mllib/src/test/scala/org/apache/spark/ml/optim/WeightedLeastSquaresSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/optim/WeightedLeastSquaresSuite.scala
@@ -33,9 +33,9 @@ class WeightedLeastSquaresSuite extends SparkFunSuite with MLlibTestSparkContext
     /*
        R code:
 
-A <- matrix(c(0, 1, 2, 3, 5, 7, 11, 13), 4, 2)
-b <- c(17, 19, 23, 29)
-w <- c(1, 2, 3, 4)
+       A <- matrix(c(0, 1, 2, 3, 5, 7, 11, 13), 4, 2)
+       b <- c(17, 19, 23, 29)
+       w <- c(1, 2, 3, 4)
      */
     instances = sc.parallelize(Seq(
       Instance(1.0, Vectors.dense(0.0, 5.0).toSparse, 17.0),
@@ -49,14 +49,14 @@ w <- c(1, 2, 3, 4)
     /*
        R code:
 
-df <- as.data.frame(cbind(A, b))
-for (formula in c(b ~ . -1, b ~ .)) {
-  model <- lm(formula, data=df, weights=w)
-  print(as.vector(coef(model)))
-}
+       df <- as.data.frame(cbind(A, b))
+       for (formula in c(b ~ . -1, b ~ .)) {
+         model <- lm(formula, data=df, weights=w)
+         print(as.vector(coef(model)))
+       }
 
-[1] -3.727121  3.009983
-[1] 18.08  6.08 -0.60
+       [1] -3.727121  3.009983
+       [1] 18.08  6.08 -0.60
      */
 
     val expected = Seq(
@@ -78,30 +78,30 @@ for (formula in c(b ~ . -1, b ~ .)) {
     /*
        R code:
 
-library(glmnet)
+       library(glmnet)
 
-for (intercept in c(FALSE, TRUE)) {
-  for (lambda in c(0.0, 0.1, 1.0)) {
-    for (standardize in c(FALSE, TRUE)) {
-      model <- glmnet(A, b, weights=w, intercept=intercept, lambda=lambda, standardize=standardize,
-                      alpha=0, thresh=1E-14)
-      print(as.vector(coef(model)))
-    }
-  }
-}
+       for (intercept in c(FALSE, TRUE)) {
+         for (lambda in c(0.0, 0.1, 1.0)) {
+           for (standardize in c(FALSE, TRUE)) {
+             model <- glmnet(A, b, weights=w, intercept=intercept, lambda=lambda,
+                             standardize=standardize, alpha=0, thresh=1E-14)
+             print(as.vector(coef(model)))
+           }
+         }
+       }
 
-[1]  0.000000 -3.727117  3.009982
-[1]  0.000000 -3.727117  3.009982
-[1]  0.000000 -3.307532  2.924206
-[1]  0.000000 -2.914790  2.840627
-[1]  0.000000 -1.526575  2.558158
-[1] 0.00000000 0.06984238 2.20488344
-[1] 18.0799727  6.0799832 -0.5999941
-[1] 18.0799727  6.0799832 -0.5999941
-[1] 13.5356178  3.2714044  0.3770744
-[1] 14.064629  3.565802  0.269593
-[1] 10.1238013  0.9708569  1.1475466
-[1] 13.1860638  2.1761382  0.6213134
+       [1]  0.000000 -3.727117  3.009982
+       [1]  0.000000 -3.727117  3.009982
+       [1]  0.000000 -3.307532  2.924206
+       [1]  0.000000 -2.914790  2.840627
+       [1]  0.000000 -1.526575  2.558158
+       [1] 0.00000000 0.06984238 2.20488344
+       [1] 18.0799727  6.0799832 -0.5999941
+       [1] 18.0799727  6.0799832 -0.5999941
+       [1] 13.5356178  3.2714044  0.3770744
+       [1] 14.064629  3.565802  0.269593
+       [1] 10.1238013  0.9708569  1.1475466
+       [1] 13.1860638  2.1761382  0.6213134
      */
 
     val expected = Seq(


### PR DESCRIPTION
The goal of this PR is to have a weighted least squares implementation that takes the normal equation approach, and hence to be able to provide R-like summary statistics and support IRLS (used by GLMs). The tests match R's lm and glmnet.

There are couple TODOs that can be addressed in future PRs:
- consolidate summary statistics aggregators
- move `dspr` to `BLAS`
- etc

It would be nice to have this merged first because it blocks couple other features.

@dbtsai
