### PR TITLE
[SPARK-6931] [PYSPARK] Cast Python time float values to int before serialization

### DIFF
--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -39,9 +39,9 @@ utf8_deserializer = UTF8Deserializer()
 
 def report_times(outfile, boot, init, finish):
     write_int(SpecialLengths.TIMING_DATA, outfile)
-    write_long(1000 * boot, outfile)
-    write_long(1000 * init, outfile)
-    write_long(1000 * finish, outfile)
+    write_long(int(1000 * boot), outfile)
+    write_long(int(1000 * init), outfile)
+    write_long(int(1000 * finish), outfile)
 
 
 def add_path(path):


### PR DESCRIPTION
Python time values return a floating point value, need to cast to integer before serialize with struct.pack('!q', value)

https://issues.apache.org/jira/browse/SPARK-6931
