### PR TITLE
[SPARK-10449][SQL] Don't merge decimal types with incompatable precision or scales

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -373,10 +373,7 @@ object StructType extends AbstractDataType {
       case (DecimalType.Fixed(leftPrecision, leftScale),
         DecimalType.Fixed(rightPrecision, rightScale)) =>
         if ((leftPrecision == rightPrecision) && (leftScale == rightScale)) {
-          DecimalType(
-            max(leftScale, rightScale) +
-              max(leftPrecision - leftScale, rightPrecision - rightScale),
-            max(leftScale, rightScale))
+          DecimalType(leftPrecision, leftScale)
         } else if ((leftPrecision != rightPrecision) && (leftScale != rightScale)) {
           throw new SparkException("Failed to merge Decimal Tpes with incompatible " +
             s"precision $leftPrecision and $rightPrecision & scale $leftScale and $rightScale")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -380,7 +380,7 @@ object StructType extends AbstractDataType {
         } else if ((leftPrecision != rightPrecision) && (leftScale != rightScale)) {
           throw new SparkException("Failed to merge Decimal Tpes with incompatible " +
             s"precision $leftPrecision and $rightPrecision & scale $leftScale and $rightScale")
-        } else if(leftPrecision != rightPrecision) {
+        } else if (leftPrecision != rightPrecision) {
           throw new SparkException("Failed to merge Decimal Tpes with incompatible " +
             s"precision $leftPrecision and $rightPrecision")
         } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -371,10 +371,22 @@ object StructType extends AbstractDataType {
         StructType(newFields)
 
       case (DecimalType.Fixed(leftPrecision, leftScale),
-      DecimalType.Fixed(rightPrecision, rightScale)) =>
-        DecimalType(
-          max(leftScale, rightScale) + max(leftPrecision - leftScale, rightPrecision - rightScale),
-          max(leftScale, rightScale))
+        DecimalType.Fixed(rightPrecision, rightScale)) =>
+        if ((leftPrecision == rightPrecision) && (leftScale == rightScale)) {
+          DecimalType(
+            max(leftScale, rightScale) +
+              max(leftPrecision - leftScale, rightPrecision - rightScale),
+            max(leftScale, rightScale))
+        } else if ((leftPrecision != rightPrecision) && (leftScale != rightScale)) {
+          throw new SparkException("Failed to merge Decimal Tpes with incompatible " +
+            s"precision $leftPrecision and $rightPrecision & scale $leftScale and $rightScale")
+        } else if(leftPrecision != rightPrecision) {
+          throw new SparkException("Failed to merge Decimal Tpes with incompatible " +
+            s"precision $leftPrecision and $rightPrecision")
+        } else {
+          throw new SparkException("Failed to merge Decimal Tpes with incompatible " +
+            s"scala $leftScale and $rightScale")
+        }
 
       case (leftUdt: UserDefinedType[_], rightUdt: UserDefinedType[_])
         if leftUdt.userClass == rightUdt.userClass => leftUdt


### PR DESCRIPTION
From JIRA: Schema merging should only handle struct fields. But currently we also reconcile decimal precision and scale information.
