### PR TITLE
[SPARK-10469][DOC] Try and document the three options

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -458,9 +458,12 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.shuffle.manager</code></td>
   <td>sort</td>
   <td>
-    Implementation to use for shuffling data. There are two implementations available:
-    <code>sort</code> and <code>hash</code>. Sort-based shuffle is more memory-efficient and is
-    the default option starting in 1.2.
+    Implementation to use for shuffling data. There are three implementations available:
+    <code>sort</code>, <code>hash</code> and the new <code>tungsten-sort</code>.
+    Sort-based shuffle is more memory-efficient and is the default option starting in 1.2.
+    Tungsten-sort is similar to sort based shuffle, with a direct binary cache-friendly
+    implementation with a fall back to regular sort based shuffle if its requirements are not
+    met.
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -459,9 +459,9 @@ Apart from these, the following properties are also available, and may be useful
   <td>sort</td>
   <td>
     Implementation to use for shuffling data. There are three implementations available:
-    <code>sort</code>, <code>hash</code> and the new <code>tungsten-sort</code>.
+    <code>sort</code>, <code>hash</code> and the new (1.5+) <code>tungsten-sort</code>.
     Sort-based shuffle is more memory-efficient and is the default option starting in 1.2.
-    Tungsten-sort is similar to sort based shuffle, with a direct binary cache-friendly
+    Tungsten-sort is similar to the sort based shuffle, with a direct binary cache-friendly
     implementation with a fall back to regular sort based shuffle if its requirements are not
     met.
   </td>


### PR DESCRIPTION
From JIRA:
Add documentation for tungsten-sort.
From the mailing list "I saw a new "spark.shuffle.manager=tungsten-sort" implemented in
https://issues.apache.org/jira/browse/SPARK-7081, but it can't be found its
corresponding description in
http://people.apache.org/~pwendell/spark-releases/spark-1.5.0-rc3-docs/configuration.html(Currenlty
there are only 'sort' and 'hash' two options)."
