### PR TITLE
[SPARK-8467][MLlib][PySpark] Add LDAModel.describeTopics() in Python

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/LDAModelWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/LDAModelWrapper.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.mllib.api.python
 
-import scala.collection.JavaConverters
+import scala.collection.JavaConverters._
 
 import org.apache.spark.SparkContext
 import org.apache.spark.mllib.clustering.LDAModel
@@ -31,14 +31,13 @@ private[python] class LDAModelWrapper(model: LDAModel) {
 
   def vocabSize(): Int = model.vocabSize
 
-  def describeTopics(): java.util.List[Array[Any]] = describeTopics(this.model.vocabSize)
+  def describeTopics(): Array[Byte] = describeTopics(this.model.vocabSize)
 
-  def describeTopics(maxTermsPerTopic: Int): java.util.List[Array[Any]] = {
-
-    val seq = model.describeTopics(maxTermsPerTopic).map { case (terms, termWeights) =>
-        Array.empty[Any] ++ terms ++ termWeights
-      }.toSeq
-    JavaConverters.seqAsJavaListConverter(seq).asJava
+  def describeTopics(maxTermsPerTopic: Int): Array[Byte]  = {
+    val topics = model.describeTopics(maxTermsPerTopic).map { case (terms, termWeights) =>
+      Array[Any](terms.toList.asJava, termWeights.toList.asJava)
+    }.toList.asJava
+    SerDe.dumps(topics)
   }
 
   def save(sc: SparkContext, path: String): Unit = model.save(sc, path)

--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/LDAModelWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/LDAModelWrapper.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.mllib.api.python
+
+import org.apache.spark.SparkContext
+import org.apache.spark.mllib.clustering.LDAModel
+import org.apache.spark.mllib.linalg.Matrix
+
+/**
+ * Wrapper around LDAModel to provide helper methods in Python
+ */
+private[python] class LDAModelWrapper(model: LDAModel) {
+
+  def topicsMatrix(): Matrix = model.topicsMatrix
+
+  def vocabSize(): Int = model.vocabSize
+
+  def describeTopics(): java.util.List[Array[Any]] = describeTopics(this.model.vocabSize)
+
+  def describeTopics(maxTermsPerTopic: Int): java.util.List[Array[Any]] = {
+    import scala.collection.JavaConversions._
+
+    val javaList: java.util.List[Array[Any]] =
+      model.describeTopics(maxTermsPerTopic).map { case (terms, termWeights) =>
+        var array = Array.empty[Any]
+        Array.empty[Any] ++ terms ++ termWeights
+      }.toList
+    javaList
+  }
+
+  def save(sc: SparkContext, path: String): Unit = model.save(sc, path)
+}

--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/LDAModelWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/LDAModelWrapper.scala
@@ -16,11 +16,11 @@
  */
 package org.apache.spark.mllib.api.python
 
-import scala.collection.JavaConverters
-
 import org.apache.spark.SparkContext
+import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.mllib.clustering.LDAModel
 import org.apache.spark.mllib.linalg.Matrix
+import org.apache.spark.sql.{DataFrame, SQLContext}
 
 /**
  * Wrapper around LDAModel to provide helper methods in Python
@@ -31,14 +31,17 @@ private[python] class LDAModelWrapper(model: LDAModel) {
 
   def vocabSize(): Int = model.vocabSize
 
-  def describeTopics(): java.util.List[Array[Any]] = describeTopics(this.model.vocabSize)
+  def describeTopics(jsc: JavaSparkContext): DataFrame = describeTopics(this.model.vocabSize, jsc)
 
-  def describeTopics(maxTermsPerTopic: Int): java.util.List[Array[Any]] = {
+  def describeTopics(maxTermsPerTopic: Int, jsc: JavaSparkContext): DataFrame = {
+    val sqlContext = new SQLContext(jsc.sc)
+    import sqlContext.implicits._
 
-    val seq = model.describeTopics(maxTermsPerTopic).map { case (terms, termWeights) =>
-        Array.empty[Any] ++ terms ++ termWeights
-      }.toSeq
-    JavaConverters.seqAsJavaListConverter(seq).asJava
+    // Since the return value of `describeTopics` is a little complicated,
+    // the return value are converted to `Row` to take advantage of DataFrame serialization.
+    val topics = model.describeTopics(maxTermsPerTopic)
+    val rdd = jsc.sc.parallelize(topics)
+    rdd.toDF("terms", "termWeights")
   }
 
   def save(sc: SparkContext, path: String): Unit = model.save(sc, path)

--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/LDAModelWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/LDAModelWrapper.scala
@@ -34,14 +34,11 @@ private[python] class LDAModelWrapper(model: LDAModel) {
   def describeTopics(jsc: JavaSparkContext): DataFrame = describeTopics(this.model.vocabSize, jsc)
 
   def describeTopics(maxTermsPerTopic: Int, jsc: JavaSparkContext): DataFrame = {
-    val sqlContext = new SQLContext(jsc.sc)
-    import sqlContext.implicits._
-
     // Since the return value of `describeTopics` is a little complicated,
-    // the return value are converted to `Row` to take advantage of DataFrame serialization.
+    // it is converted into `Row` to take advantage of DataFrame serialization.
+    val sqlContext = new SQLContext(jsc.sc)
     val topics = model.describeTopics(maxTermsPerTopic)
-    val rdd = jsc.sc.parallelize(topics)
-    rdd.toDF("terms", "termWeights")
+    sqlContext.createDataFrame(topics).toDF("terms", "termWeights")
   }
 
   def save(sc: SparkContext, path: String): Unit = model.save(sc, path)

--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/LDAModelWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/LDAModelWrapper.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.mllib.api.python
 
-import scala.collection.JavaConverters._
+import scala.collection.JavaConverters
 
 import org.apache.spark.SparkContext
 import org.apache.spark.mllib.clustering.LDAModel
@@ -33,11 +33,13 @@ private[python] class LDAModelWrapper(model: LDAModel) {
 
   def describeTopics(): Array[Byte] = describeTopics(this.model.vocabSize)
 
-  def describeTopics(maxTermsPerTopic: Int): Array[Byte]  = {
+  def describeTopics(maxTermsPerTopic: Int): Array[Byte] = {
     val topics = model.describeTopics(maxTermsPerTopic).map { case (terms, termWeights) =>
-      Array[Any](terms.toList.asJava, termWeights.toList.asJava)
-    }.toList.asJava
-    SerDe.dumps(topics)
+      val jTerms = JavaConverters.seqAsJavaListConverter(terms).asJava
+      val jTermWeights = JavaConverters.seqAsJavaListConverter(termWeights).asJava
+      Array[Any](jTerms, jTermWeights)
+    }
+    SerDe.dumps(JavaConverters.seqAsJavaListConverter(topics).asJava)
   }
 
   def save(sc: SparkContext, path: String): Unit = model.save(sc, path)

--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/LDAModelWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/LDAModelWrapper.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.spark.mllib.api.python
 
+import scala.collection.JavaConverters
+
 import org.apache.spark.SparkContext
 import org.apache.spark.mllib.clustering.LDAModel
 import org.apache.spark.mllib.linalg.Matrix
@@ -32,14 +34,11 @@ private[python] class LDAModelWrapper(model: LDAModel) {
   def describeTopics(): java.util.List[Array[Any]] = describeTopics(this.model.vocabSize)
 
   def describeTopics(maxTermsPerTopic: Int): java.util.List[Array[Any]] = {
-    import scala.collection.JavaConversions._
 
-    val javaList: java.util.List[Array[Any]] =
-      model.describeTopics(maxTermsPerTopic).map { case (terms, termWeights) =>
-        var array = Array.empty[Any]
+    val seq = model.describeTopics(maxTermsPerTopic).map { case (terms, termWeights) =>
         Array.empty[Any] ++ terms ++ termWeights
-      }.toList
-    javaList
+      }.toSeq
+    JavaConverters.seqAsJavaListConverter(seq).asJava
   }
 
   def save(sc: SparkContext, path: String): Unit = model.save(sc, path)

--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/LDAModelWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/LDAModelWrapper.scala
@@ -34,11 +34,14 @@ private[python] class LDAModelWrapper(model: LDAModel) {
   def describeTopics(jsc: JavaSparkContext): DataFrame = describeTopics(this.model.vocabSize, jsc)
 
   def describeTopics(maxTermsPerTopic: Int, jsc: JavaSparkContext): DataFrame = {
-    // Since the return value of `describeTopics` is a little complicated,
-    // it is converted into `Row` to take advantage of DataFrame serialization.
     val sqlContext = new SQLContext(jsc.sc)
+    import sqlContext.implicits._
+
+    // Since the return value of `describeTopics` is a little complicated,
+    // the return value are converted to `Row` to take advantage of DataFrame serialization.
     val topics = model.describeTopics(maxTermsPerTopic)
-    sqlContext.createDataFrame(topics).toDF("terms", "termWeights")
+    val rdd = jsc.sc.parallelize(topics)
+    rdd.toDF("terms", "termWeights")
   }
 
   def save(sc: SparkContext, path: String): Unit = model.save(sc, path)

--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
@@ -517,7 +517,7 @@ private[python] class PythonMLLibAPI extends Serializable {
       topicConcentration: Double,
       seed: java.lang.Long,
       checkpointInterval: Int,
-      optimizer: String): LDAModel = {
+      optimizer: String): LDAModelWrapper = {
     val algo = new LDA()
       .setK(k)
       .setMaxIterations(maxIterations)
@@ -535,7 +535,16 @@ private[python] class PythonMLLibAPI extends Serializable {
         case _ => throw new IllegalArgumentException("input values contains invalid type value.")
       }
     }
-    algo.run(documents)
+    val model = algo.run(documents)
+    new LDAModelWrapper(model)
+  }
+
+  /**
+   * Load a LDA model
+   */
+  def loadLDAModel(jsc: JavaSparkContext, path: String): LDAModelWrapper = {
+    val model = DistributedLDAModel.load(jsc.sc, path)
+    new LDAModelWrapper(model)
   }
 
 

--- a/python/pyspark/mllib/clustering.py
+++ b/python/pyspark/mllib/clustering.py
@@ -741,18 +741,20 @@ class LDAModel(JavaModelWrapper, JavaSaveable, Loader):
         WARNING: If vocabSize and k are large, this can return a large object!
         """
         if maxTermsPerTopic is None:
-            df = self.call("describeTopics", self._sc)
+            topics = self.call("describeTopics")
         else:
-            df = self.call("describeTopics", maxTermsPerTopic, self._sc)
+            topics = self.call("describeTopics", maxTermsPerTopic)
 
+        # Converts the result to make the format similar to Scala.
+        # The returned value is mixed up with topics and topi weights.
         converted = []
-        rows = df.collect()
-        for row in df.collect():
-            terms = row["terms"]
-            termWeights = row["termWeights"]
-            if len(terms) != len(termWeights):
+        for elms in [list(elms) for elms in topics]:
+            half_len = int(len(elms) / 2)
+            topics = elms[:half_len]
+            topicWeights = elms[(-1 * half_len):]
+            if len(topics) != len(topicWeights):
                 raise TypeError("Something wrong with a return value: %s" % (topics))
-            converted.append((terms, termWeights))
+            converted.append((topics, topicWeights))
         return converted
 
     @classmethod

--- a/python/pyspark/mllib/clustering.py
+++ b/python/pyspark/mllib/clustering.py
@@ -777,8 +777,8 @@ class LDA(object):
             Currently "em", "online" are supported. Default to "em".
         """
         model = callMLlibFunc("trainLDAModel", rdd, k, maxIterations,
-                                      docConcentration, topicConcentration, seed,
-                                      checkpointInterval, optimizer)
+                              docConcentration, topicConcentration, seed,
+                              checkpointInterval, optimizer)
         return LDAModel(model)
 
 

--- a/python/pyspark/mllib/clustering.py
+++ b/python/pyspark/mllib/clustering.py
@@ -741,20 +741,18 @@ class LDAModel(JavaModelWrapper, JavaSaveable, Loader):
         WARNING: If vocabSize and k are large, this can return a large object!
         """
         if maxTermsPerTopic is None:
-            topics = self.call("describeTopics")
+            df = self.call("describeTopics", self._sc)
         else:
-            topics = self.call("describeTopics", maxTermsPerTopic)
+            df = self.call("describeTopics", maxTermsPerTopic, self._sc)
 
-        # Converts the result to make the format similar to Scala.
-        # The returned value is mixed up with topics and topi weights.
         converted = []
-        for elms in [list(elms) for elms in topics]:
-            half_len = int(len(elms) / 2)
-            topics = elms[:half_len]
-            topicWeights = elms[(-1 * half_len):]
-            if len(topics) != len(topicWeights):
+        rows = df.collect()
+        for row in df.collect():
+            terms = row["terms"]
+            termWeights = row["termWeights"]
+            if len(terms) != len(termWeights):
                 raise TypeError("Something wrong with a return value: %s" % (topics))
-            converted.append((topics, topicWeights))
+            converted.append((terms, termWeights))
         return converted
 
     @classmethod

--- a/python/pyspark/mllib/clustering.py
+++ b/python/pyspark/mllib/clustering.py
@@ -687,7 +687,7 @@ class LDAModel(JavaModelWrapper, JavaSaveable, Loader):
     ...     [2, SparseVector(2, {0: 1.0})],
     ... ]
     >>> rdd =  sc.parallelize(data)
-    >>> model = LDA.train(rdd, k=2, seed = 1)
+    >>> model = LDA.train(rdd, k=2, seed=1)
     >>> model.vocabSize()
     2
     >>> model.describeTopics()
@@ -749,8 +749,8 @@ class LDAModel(JavaModelWrapper, JavaSaveable, Loader):
             raise TypeError("sc should be a SparkContext, got type %s" % type(sc))
         if not isinstance(path, basestring):
             raise TypeError("path should be a basestring, got type %s" % type(path))
-        wrapper_model = callMLlibFunc("loadLDAModel", sc, path)
-        return LDAModel(wrapper_model)
+        model = callMLlibFunc("loadLDAModel", sc, path)
+        return LDAModel(model)
 
 
 class LDA(object):
@@ -776,10 +776,10 @@ class LDA(object):
         :param optimizer:           LDAOptimizer used to perform the actual calculation.
             Currently "em", "online" are supported. Default to "em".
         """
-        wrapper_model = callMLlibFunc("trainLDAModel", rdd, k, maxIterations,
+        model = callMLlibFunc("trainLDAModel", rdd, k, maxIterations,
                                       docConcentration, topicConcentration, seed,
                                       checkpointInterval, optimizer)
-        return LDAModel(wrapper_model)
+        return LDAModel(model)
 
 
 def _test():

--- a/python/pyspark/mllib/clustering.py
+++ b/python/pyspark/mllib/clustering.py
@@ -687,23 +687,13 @@ class LDAModel(JavaModelWrapper, JavaSaveable, Loader):
     ...     [2, SparseVector(2, {0: 1.0})],
     ... ]
     >>> rdd =  sc.parallelize(data)
-    >>> model = LDA.train(rdd, k=2)
+    >>> model = LDA.train(rdd, k=2, seed = 1)
     >>> model.vocabSize()
     2
-    >>> topics = model.describeTopics()
-    >>> len(topics)
-    2
-    >>> len(list(topics[0])[0])
-    2
-    >>> len(list(topics[0])[1])
-    2
-    >>> topics = model.describeTopics(1)
-    >>> len(topics)
-    2
-    >>> len(list(topics[0])[0])
-    1
-    >>> len(list(topics[0])[1])
-    1
+    >>> model.describeTopics()
+    [([1, 0], [0.5..., 0.49...]), ([0, 1], [0.5..., 0.49...])]
+    >>> model.describeTopics(1)
+    [([1], [0.5...]), ([0], [0.5...])]
 
     >>> topics = model.topicsMatrix()
     >>> topics_expect = array([[0.5,  0.5], [0.5, 0.5]])
@@ -735,6 +725,7 @@ class LDAModel(JavaModelWrapper, JavaSaveable, Loader):
         """Vocabulary size (number of terms or terms in the vocabulary)"""
         return self.call("vocabSize")
 
+    @since('1.6.0')
     def describeTopics(self, maxTermsPerTopic=None):
         """Return the topics described by weighted terms.
 
@@ -744,18 +735,7 @@ class LDAModel(JavaModelWrapper, JavaSaveable, Loader):
             topics = self.call("describeTopics")
         else:
             topics = self.call("describeTopics", maxTermsPerTopic)
-
-        # Converts the result to make the format similar to Scala.
-        # The returned value is mixed up with topics and topi weights.
-        converted = []
-        for elms in [list(elms) for elms in topics]:
-            half_len = int(len(elms) / 2)
-            topics = elms[:half_len]
-            topicWeights = elms[(-1 * half_len):]
-            if len(topics) != len(topicWeights):
-                raise TypeError("Something wrong with a return value: %s" % (topics))
-            converted.append((topics, topicWeights))
-        return converted
+        return topics
 
     @classmethod
     @since('1.5.0')


### PR DESCRIPTION
Could @jkbradley and @davies review it?
- Create a wrapper class: `LDAModelWrapper` for `LDAModel`. Because we can't deal with the return value of`describeTopics` in Scala from pyspark directly. `Array[(Array[Int], Array[Double])]` is too complicated to convert it.
- Add `loadLDAModel` in `PythonMLlibAPI`. Since `LDAModel` in Scala is an abstract class and we need to call `load` of `DistributedLDAModel`.

[[SPARK-8467] Add LDAModel.describeTopics() in Python - ASF JIRA](https://issues.apache.org/jira/browse/SPARK-8467)
