### PR TITLE
[SPARK-10512][PySpark] Fix @since when a function doesn't have doc

### DIFF
--- a/python/pyspark/__init__.py
+++ b/python/pyspark/__init__.py
@@ -57,9 +57,12 @@ def since(version):
     indent_p = re.compile(r'\n( +)')
 
     def deco(f):
-        indents = indent_p.findall(f.__doc__)
-        indent = ' ' * (min(len(m) for m in indents) if indents else 0)
-        f.__doc__ = f.__doc__.rstrip() + "\n\n%s.. versionadded:: %s" % (indent, version)
+        if f.__doc__ is None:
+            f.__doc__ = ".. versionadded:: %s" % (version)
+        else:
+            indents = indent_p.findall(f.__doc__)
+            indent = ' ' * (min(len(m) for m in indents) if indents else 0)
+            f.__doc__ = f.__doc__.rstrip() + "\n\n%s.. versionadded:: %s" % (indent, version)
         return f
     return deco
 


### PR DESCRIPTION
cc @mengxr @davies 

[[SPARK-10512] Fix @since when a function doesn't have doc - ASF JIRA](https://issues.apache.org/jira/browse/SPARK-10512)
