### PR TITLE
[SPARK-10515] When killing executor,  the pending replacement executors should not be lost

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -426,14 +426,6 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
     val executorsToKill = knownExecutors.filter { id => !executorsPendingToRemove.contains(id) }
     executorsPendingToRemove ++= executorsToKill
 
-    // If we do not wish to replace the executors we kill, sync the target number of executors
-    // with the cluster manager to avoid allocating new ones. When computing the new target,
-    // take into account executors that are pending to be added or removed.
-    if (!replace) {
-      doRequestTotalExecutors(
-        numExistingExecutors + numPendingExecutors - executorsPendingToRemove.size)
-    }
-
     doKillExecutors(executorsToKill)
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -152,8 +152,8 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
             }
             if (numReplacingExecutors > 0) {
               numReplacingExecutors -= 1
-              logDebug(s"Decremented number of executors being replaced executors
-                ($numReplacingExecutors left)")
+               logDebug(s"Decremented number of executors being replaced executors " +
+                s"($numReplacingExecutors left)")
             }
           }
           // Note: some tests expect the reply to come after we put the executor in the map

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -66,9 +66,6 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
   // Executors we have requested the cluster manager to kill that have not died yet
   private val executorsPendingToRemove = new HashSet[String]
 
-  // Executors we have requested the cluster manager to replace with new ones that have killed
-  private val executorsToReplace = new HashSet[String]
-
   // Number of executors requested from the cluster manager that have not replaced yet
   private var numReplacingExecutors = 0
 
@@ -246,12 +243,6 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
             addressToExecutorId -= executorInfo.executorAddress
             executorDataMap -= executorId
             executorsPendingToRemove -= executorId
-            if (executorsToReplace.contains(executorId)) {
-              executorsToReplace -= executorId
-              if (numReplacingExecutors > 0) {
-                numReplacingExecutors -= 1
-              }
-            }
           }
           totalCoreCount.addAndGet(-executorInfo.totalCores)
           totalRegisteredExecutors.addAndGet(-1)
@@ -450,7 +441,6 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
         numExistingExecutors + numPendingExecutors - executorsPendingToRemove.size
         + numReplacingExecutors)
     } else {
-      executorsToReplace ++= knownExecutors
       numReplacingExecutors += knownExecutors.size
     }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -66,7 +66,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
   // Executors we have requested the cluster manager to kill that have not died yet
   private val executorsPendingToRemove = new HashSet[String]
 
-  // Number of executors requested from the cluster manager that have not replaced yet
+  // Number of executors requested from the cluster manager that have not been replaced yet
   private var numReplacingExecutors = 0
 
   // A map to store hostname with its possible task number running on it
@@ -152,7 +152,8 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
             }
             if (numReplacingExecutors > 0) {
               numReplacingExecutors -= 1
-              logDebug(s"Decremented number of replaceing executors ($numReplacingExecutors left)")
+              logDebug(s"Decremented number of executors being replaced executors
+                ($numReplacingExecutors left)")
             }
           }
           // Note: some tests expect the reply to come after we put the executor in the map

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -426,14 +426,6 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
     val executorsToKill = knownExecutors.filter { id => !executorsPendingToRemove.contains(id) }
     executorsPendingToRemove ++= executorsToKill
 
-    // If we do not wish to replace the executors we kill, sync the target number of executors
-    // with the cluster manager to avoid allocating new ones. When computing the new target,
-    // take into account executors that are pending to be added or removed.
-    if (!replace) {
-      doRequestTotalExecutors(
-        numExistingExecutors + numPendingExecutors - knownExecutors.size)
-    }
-
     doKillExecutors(executorsToKill)
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -65,7 +65,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
 
   // Executors we have requested the cluster manager to kill that have not died yet
   private val executorsPendingToRemove = new HashSet[String]
-  
+
   // Executors we have requested the cluster manager to replace with new ones that have killed
   private val executorsToReplace = new HashSet[String]
 
@@ -447,7 +447,8 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
     // take into account executors that are pending to be added or removed.
     if (!replace) {
       doRequestTotalExecutors(
-        numExistingExecutors + numPendingExecutors - executorsPendingToRemove.size + numReplacingExecutors)
+        numExistingExecutors + numPendingExecutors - executorsPendingToRemove.size
+        + numReplacingExecutors)
     } else {
       executorsToReplace ++= knownExecutors
       numReplacingExecutors += knownExecutors.size

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -155,7 +155,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
             }
             if (numReplacingExecutors > 0) {
               numReplacingExecutors -= 1
-              logError(s"Decremented number of replaceing executors ($numReplacingExecutors left)")
+              logDebug(s"Decremented number of replaceing executors ($numReplacingExecutors left)")
             }
           }
           // Note: some tests expect the reply to come after we put the executor in the map

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -426,6 +426,14 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
     val executorsToKill = knownExecutors.filter { id => !executorsPendingToRemove.contains(id) }
     executorsPendingToRemove ++= executorsToKill
 
+    // If we do not wish to replace the executors we kill, sync the target number of executors
+    // with the cluster manager to avoid allocating new ones. When computing the new target,
+    // take into account executors that are pending to be added or removed.
+    if (!replace) {
+      doRequestTotalExecutors(
+        numExistingExecutors + numPendingExecutors - knownExecutors.size)
+    }
+
     doKillExecutors(executorsToKill)
   }
 

--- a/core/src/test/scala/org/apache/spark/deploy/StandaloneDynamicAllocationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/StandaloneDynamicAllocationSuite.scala
@@ -303,6 +303,32 @@ class StandaloneDynamicAllocationSuite
     assert(master.apps.head.getExecutorLimit === 1)
   }
 
+   test("the pending replacement executors should not be lost (SPARK-10515)") {
+    sc = new SparkContext(appConf)
+    val appId = sc.applicationId
+    assert(master.apps.size === 1)
+    assert(master.apps.head.id === appId)
+    assert(master.apps.head.executors.size === 2)
+    assert(master.apps.head.getExecutorLimit === Int.MaxValue)
+    // sync executors between the Master and the driver, needed because
+    // the driver refuses to kill executors it does not know about
+    syncExecutors(sc)
+    val executors = getExecutorIds(sc)
+    assert(executors.size === 2)
+
+    // kill executor,and replace it
+    assert(sc.killAndReplaceExecutor(executors.head))
+    assert(master.apps.head.executors.size === 2)
+
+    assert(sc.killExecutor(executors.head))
+    assert(master.apps.head.executors.size === 2)
+    assert(master.apps.head.getExecutorLimit === 2)
+
+    assert(sc.killExecutor(executors(1)))
+    assert(master.apps.head.executors.size === 1)
+    assert(master.apps.head.getExecutorLimit === 1)
+  }
+
   // ===============================
   // | Utility methods for testing |
   // ===============================


### PR DESCRIPTION
When killing executor, driver will send RequestExecutors to AM. But in ExecutorAllocationManager, the value of numExecutorsTarget will be not changed.
