### PR TITLE
[SPARK-10530] [CORE] Kill other task attempts when one taskattempt belonging 

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskScheduler.scala
@@ -53,6 +53,9 @@ private[spark] trait TaskScheduler {
   // Cancel a stage.
   def cancelTasks(stageId: Int, interruptThread: Boolean)
 
+  // kill speculated task
+  def killSpeculatedTask(taskId: Long)
+
   // Set the DAG scheduler for upcalls. This is guaranteed to be set before submitTasks is called.
   def setDAGScheduler(dagScheduler: DAGScheduler): Unit
 

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -220,6 +220,15 @@ private[spark] class TaskSchedulerImpl(
     }
   }
 
+  def killSpeculatedTask(taskId:Long) : Unit = synchronized {
+    taskIdToExecutorId.get(taskId) match {
+      case Some(execId) =>
+        logInfo("Kill speculated task " + taskId)
+        backend.killTask(taskId, execId, true)
+      case None => log.debug("Ignore killing speculated task {}, due to it has not been started", taskId)
+    }
+  }
+
   /**
    * Called to indicate that all task attempts (including speculated tasks) associated with the
    * given TaskSetManager have completed, so state associated with the TaskSetManager should be

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -629,7 +629,9 @@ private[spark] class TaskSetManager(
     sched.dagScheduler.taskEnded(
       tasks(index), Success, result.value(), result.accumUpdates, info, result.metrics)
     // kill other attempts of this task when speculation is enabled.
-    taskAttempts(index).filter(_.taskId != tid).foreach(e=>sched.killSpeculatedTask(e.taskId))
+    for (ta <- taskAttempts(index) if ta.taskId != tid) {
+      sched.killSpeculatedTask(ta.taskId)
+    }
 
     if (!successful(index)) {
       tasksSuccessful += 1

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -628,6 +628,9 @@ private[spark] class TaskSetManager(
     // here "result.value()" just returns the value and won't block other threads.
     sched.dagScheduler.taskEnded(
       tasks(index), Success, result.value(), result.accumUpdates, info, result.metrics)
+    // kill other attempts of this task when speculation is enabled.
+    taskAttempts(index).filter(_.taskId != tid).foreach(e=>sched.killSpeculatedTask(e.taskId))
+
     if (!successful(index)) {
       tasksSuccessful += 1
       logInfo("Finished task %s in stage %s (TID %d) in %d ms on %s (%d/%d)".format(


### PR DESCRIPTION
SPARK-10530 Kill other task attempts when one taskattempt belonging the same task is succeeded in speculation

Verify it manually. Unit test will be added in the followup commit. Initial review on the approach is very appreciated. 
