### PR TITLE
SPARK-10546 Check partitionId's range in ExternalSorter#spill()

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
@@ -294,8 +294,8 @@ private[spark] class ExternalSorter[K, V, C](
         if (partitionId < 0) {
            throw new IllegalArgumentException("Encountered negative partition Id: " + partitionId)
         }
-				if (partitionId >= numPartitions) {
-					throw new IllegalArgumentException("Encountered partition Id: " + partitionId + " which is >= " + numPartitions)
+        if (partitionId >= numPartitions) {
+           throw new IllegalArgumentException("Encountered partition Id: " + partitionId + " which is >= " + numPartitions)
         }
         it.writeNext(writer)
         elementsPerPartition(partitionId) += 1

--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
@@ -292,10 +292,11 @@ private[spark] class ExternalSorter[K, V, C](
       while (it.hasNext) {
         val partitionId = it.nextPartition()
         if (partitionId < 0) {
-           throw new IllegalArgumentException("Encountered negative partition Id: " + partitionId)
+          throw new IllegalArgumentException("Encountered negative partition Id: " + partitionId)
         }
         if (partitionId >= numPartitions) {
-           throw new IllegalArgumentException("Encountered partition Id: " + partitionId + " which is >= " + numPartitions)
+          throw new IllegalArgumentException("Encountered partition Id: " + partitionId +
+            " which is >= " + numPartitions)
         }
         it.writeNext(writer)
         elementsPerPartition(partitionId) += 1

--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
@@ -292,7 +292,7 @@ private[spark] class ExternalSorter[K, V, C](
       while (it.hasNext) {
         val partitionId = it.nextPartition()
         require(partitionId >= 0 && partitionId < numPartitions,
-          s"partition Id: ${partitionId} should be in the range (0, ${numPartitions})")
+          s"partition Id: ${partitionId} should be in the range [0, ${numPartitions})")
         it.writeNext(writer)
         elementsPerPartition(partitionId) += 1
         objectsWritten += 1

--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
@@ -291,6 +291,12 @@ private[spark] class ExternalSorter[K, V, C](
       val it = collection.destructiveSortedWritablePartitionedIterator(comparator)
       while (it.hasNext) {
         val partitionId = it.nextPartition()
+        if (partitionId < 0) {
+           throw new IllegalArgumentException("Encountered negative partition Id: " + partitionId)
+        }
+				if (partitionId >= numPartitions) {
+					throw new IllegalArgumentException("Encountered partition Id: " + partitionId + " which is >= " + numPartitions)
+        }
         it.writeNext(writer)
         elementsPerPartition(partitionId) += 1
         objectsWritten += 1

--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
@@ -291,13 +291,8 @@ private[spark] class ExternalSorter[K, V, C](
       val it = collection.destructiveSortedWritablePartitionedIterator(comparator)
       while (it.hasNext) {
         val partitionId = it.nextPartition()
-        if (partitionId < 0) {
-          throw new IllegalArgumentException("Encountered negative partition Id: " + partitionId)
-        }
-        if (partitionId >= numPartitions) {
-          throw new IllegalArgumentException("Encountered partition Id: " + partitionId +
-            " which is >= " + numPartitions)
-        }
+        require(partitionId >= 0 && partitionId < numPartitions,
+          s"partition Id: ${partitionId} should be in the range (0, ${numPartitions})")
         it.writeNext(writer)
         elementsPerPartition(partitionId) += 1
         objectsWritten += 1


### PR DESCRIPTION
See this thread for background:
http://search-hadoop.com/m/q3RTt0rWvIkHAE81

We should check the range of partition Id and provide meaningful message through exception.

Alternatively, we can use abs() and modulo to force the partition Id into legitimate range. However, expectation is that user should correct the logic error in his / her code.
