### PR TITLE
[SPARK-9213] [SQL] [WIP] Improve regular expression performance (via joni)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,8 @@
     <jodd.version>3.5.2</jodd.version>
     <jsr305.version>1.3.9</jsr305.version>
     <libthrift.version>0.9.2</libthrift.version>
+    <joni.version>2.1.2</joni.version>
+    <jcodings.version>1.0.8</jcodings.version>
 
     <test.java.home>${java.home}</test.java.home>
 

--- a/sql/catalyst/pom.xml
+++ b/sql/catalyst/pom.xml
@@ -67,6 +67,16 @@
       <groupId>org.codehaus.janino</groupId>
       <artifactId>janino</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jruby.jcodings</groupId>
+      <artifactId>jcodings</artifactId>
+      <version>${jcodings.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jruby.joni</groupId>
+      <artifactId>joni</artifactId>
+      <version>${joni.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystConf.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.catalyst
 
 private[spark] trait CatalystConf {
   def caseSensitiveAnalysis: Boolean
+  def regexEngine: String = ""
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -67,6 +67,7 @@ class Analyzer(
     Batch("Substitution", fixedPoint,
       CTESubstitution ::
       WindowsSubstitution ::
+      RegexSubstitution ::
       Nil : _*),
     Batch("Resolution", fixedPoint,
       ResolveRelations ::
@@ -133,6 +134,23 @@ class Analyzer(
               WindowExpression(c, windowSpecDefinition)
           }
         }
+    }
+  }
+
+  /**
+   * Substitute Like/RLike/RegExpReplace/RegExpExtract with LikeJavaFallback/RLikeJavaFallback/
+   * RegExpReplaceJavaFallback/RegExpExtractJavaFallback when use java as regular expression engine.
+   */
+  object RegexSubstitution extends Rule[LogicalPlan] {
+    def apply(plan: LogicalPlan): LogicalPlan = plan resolveExpressions {
+      case Like(left, right) if (conf.regexEngine == "java") =>
+        LikeJavaFallback(left, right)
+      case RLike(left, right) if (conf.regexEngine == "java") =>
+        RLikeJavaFallback(left, right)
+      case RegExpReplace(subject, regexp, rep) if (conf.regexEngine == "java") =>
+        RegExpReplaceJavaFallback(subject, regexp, rep)
+      case RegExpExtract(subject, regexp, idx) if (conf.regexEngine == "java") =>
+        RegExpExtractJavaFallback(subject, regexp, idx)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -87,7 +87,9 @@ package object dsl {
     def in(list: Expression*): Expression = In(expr, list)
 
     def like(other: Expression): Expression = Like(expr, other)
+    def jlike(other: Expression): Expression = LikeJavaFallback(expr, other)// just for test
     def rlike(other: Expression): Expression = RLike(expr, other)
+    def jrlike(other: Expression): Expression = RLikeJavaFallback(expr, other)// just for test
     def contains(other: Expression): Expression = Contains(expr, other)
     def startsWith(other: Expression): Expression = StartsWith(expr, other)
     def endsWith(other: Expression): Expression = EndsWith(expr, other)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressionsJavaFallback.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressionsJavaFallback.scala
@@ -1,0 +1,346 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+import java.util.regex.{MatchResult, Pattern}
+
+import org.apache.commons.lang3.StringEscapeUtils
+
+import org.apache.spark.sql.catalyst.expressions.codegen._
+import org.apache.spark.sql.catalyst.util.StringUtils
+import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
+
+
+trait StringRegexExpressionJavaFallback extends ImplicitCastInputTypes {
+  self: BinaryExpression =>
+
+  def escape(v: String): String
+  def matches(regex: Pattern, str: String): Boolean
+
+  override def dataType: DataType = BooleanType
+  override def inputTypes: Seq[DataType] = Seq(StringType, StringType)
+
+  // try cache the pattern for Literal
+  private lazy val cache: Pattern = right match {
+    case x @ Literal(value: String, StringType) => compile(value)
+    case _ => null
+  }
+
+  protected def compile(str: String): Pattern = if (str == null) {
+    null
+  } else {
+    // Let it raise exception if couldn't compile the regex string
+    Pattern.compile(escape(str))
+  }
+
+  protected def pattern(str: String) = if (cache == null) compile(str) else cache
+
+  protected override def nullSafeEval(input1: Any, input2: Any): Any = {
+    val regex = pattern(input2.asInstanceOf[UTF8String].toString)
+    if(regex == null) {
+      null
+    } else {
+      matches(regex, input1.asInstanceOf[UTF8String].toString)
+    }
+  }
+}
+
+
+/**
+ * Simple RegEx pattern matching function
+ */
+case class LikeJavaFallback(left: Expression, right: Expression)
+  extends BinaryExpression with StringRegexExpressionJavaFallback with CodegenFallback {
+
+  override def escape(v: String): String = StringUtils.escapeLikeRegexJavaFallback(v)
+
+  override def matches(regex: Pattern, str: String): Boolean = regex.matcher(str).matches()
+
+  override def toString: String = s"$left LIKE $right"
+
+  override protected def genCode(ctx: CodeGenContext, ev: GeneratedExpressionCode): String = {
+    val patternClass = classOf[Pattern].getName
+    val escapeFunc = StringUtils.getClass.getName.stripSuffix("$") + ".escapeLikeRegexJavaFallback"
+    val pattern = ctx.freshName("pattern")
+
+    if (right.foldable) {
+      val rVal = right.eval()
+      if (rVal != null) {
+        val regexStr =
+          StringEscapeUtils.escapeJava(escape(rVal.asInstanceOf[UTF8String].toString()))
+        ctx.addMutableState(patternClass, pattern,
+          s"""$pattern = ${patternClass}.compile("$regexStr");""")
+
+        // We don't use nullSafeCodeGen here because we don't want to re-evaluate right again.
+        val eval = left.gen(ctx)
+        s"""
+          ${eval.code}
+          boolean ${ev.isNull} = ${eval.isNull};
+          ${ctx.javaType(dataType)} ${ev.primitive} = ${ctx.defaultValue(dataType)};
+          if (!${ev.isNull}) {
+            ${ev.primitive} = $pattern.matcher(${eval.primitive}.toString()).matches();
+          }
+        """
+      } else {
+        s"""
+          boolean ${ev.isNull} = true;
+          ${ctx.javaType(dataType)} ${ev.primitive} = ${ctx.defaultValue(dataType)};
+        """
+      }
+    } else {
+      nullSafeCodeGen(ctx, ev, (eval1, eval2) => {
+        s"""
+          String rightStr = ${eval2}.toString();
+          ${patternClass} $pattern = ${patternClass}.compile($escapeFunc(rightStr));
+          ${ev.primitive} = $pattern.matcher(${eval1}.toString()).matches();
+        """
+      })
+    }
+  }
+}
+
+
+case class RLikeJavaFallback(left: Expression, right: Expression)
+  extends BinaryExpression with StringRegexExpressionJavaFallback with CodegenFallback {
+
+  override def escape(v: String): String = v
+  override def matches(regex: Pattern, str: String): Boolean = regex.matcher(str).find(0)
+  override def toString: String = s"$left RLIKE $right"
+
+  override protected def genCode(ctx: CodeGenContext, ev: GeneratedExpressionCode): String = {
+    val patternClass = classOf[Pattern].getName
+    val pattern = ctx.freshName("pattern")
+
+    if (right.foldable) {
+      val rVal = right.eval()
+      if (rVal != null) {
+        val regexStr =
+          StringEscapeUtils.escapeJava(rVal.asInstanceOf[UTF8String].toString())
+        ctx.addMutableState(patternClass, pattern,
+          s"""$pattern = ${patternClass}.compile("$regexStr");""")
+
+        // We don't use nullSafeCodeGen here because we don't want to re-evaluate right again.
+        val eval = left.gen(ctx)
+        s"""
+          ${eval.code}
+          boolean ${ev.isNull} = ${eval.isNull};
+          ${ctx.javaType(dataType)} ${ev.primitive} = ${ctx.defaultValue(dataType)};
+          if (!${ev.isNull}) {
+            ${ev.primitive} = $pattern.matcher(${eval.primitive}.toString()).find(0);
+          }
+        """
+      } else {
+        s"""
+          boolean ${ev.isNull} = true;
+          ${ctx.javaType(dataType)} ${ev.primitive} = ${ctx.defaultValue(dataType)};
+        """
+      }
+    } else {
+      nullSafeCodeGen(ctx, ev, (eval1, eval2) => {
+        s"""
+          String rightStr = ${eval2}.toString();
+          ${patternClass} $pattern = ${patternClass}.compile(rightStr);
+          ${ev.primitive} = $pattern.matcher(${eval1}.toString()).find(0);
+        """
+      })
+    }
+  }
+}
+
+
+/**
+ * Splits str around pat (pattern is a regular expression).
+ */
+case class StringSplitJavaFallback(str: Expression, pattern: Expression)
+  extends BinaryExpression with ImplicitCastInputTypes {
+
+  override def left: Expression = str
+  override def right: Expression = pattern
+  override def dataType: DataType = ArrayType(StringType)
+  override def inputTypes: Seq[DataType] = Seq(StringType, StringType)
+
+  override def nullSafeEval(string: Any, regex: Any): Any = {
+    val strings = string.asInstanceOf[UTF8String].split(regex.asInstanceOf[UTF8String], -1)
+    new GenericArrayData(strings.asInstanceOf[Array[Any]])
+  }
+
+  override def genCode(ctx: CodeGenContext, ev: GeneratedExpressionCode): String = {
+    val arrayClass = classOf[GenericArrayData].getName
+    nullSafeCodeGen(ctx, ev, (str, pattern) =>
+      // Array in java is covariant, so we don't need to cast UTF8String[] to Object[].
+      s"""${ev.primitive} = new $arrayClass($str.split($pattern, -1));""")
+  }
+
+  override def prettyName: String = "split"
+}
+
+
+/**
+ * Replace all substrings of str that match regexp with rep.
+ *
+ * NOTE: this expression is not THREAD-SAFE, as it has some internal mutable status.
+ */
+case class RegExpReplaceJavaFallback(subject: Expression, regexp: Expression, rep: Expression)
+  extends TernaryExpression with ImplicitCastInputTypes {
+
+  // last regex in string, we will update the pattern iff regexp value changed.
+  @transient private var lastRegex: UTF8String = _
+  // last regex pattern, we cache it for performance concern
+  @transient private var pattern: Pattern = _
+  // last replacement string, we don't want to convert a UTF8String => java.langString every time.
+  @transient private var lastReplacement: String = _
+  @transient private var lastReplacementInUTF8: UTF8String = _
+  // result buffer write by Matcher
+  @transient private val result: StringBuffer = new StringBuffer
+
+  override def nullSafeEval(s: Any, p: Any, r: Any): Any = {
+    if (!p.equals(lastRegex)) {
+      // regex value changed
+      lastRegex = p.asInstanceOf[UTF8String].clone()
+      pattern = Pattern.compile(lastRegex.toString)
+    }
+    if (!r.equals(lastReplacementInUTF8)) {
+      // replacement string changed
+      lastReplacementInUTF8 = r.asInstanceOf[UTF8String].clone()
+      lastReplacement = lastReplacementInUTF8.toString
+    }
+    val m = pattern.matcher(s.toString())
+    result.delete(0, result.length())
+
+    while (m.find) {
+      m.appendReplacement(result, lastReplacement)
+    }
+    m.appendTail(result)
+
+    UTF8String.fromString(result.toString)
+  }
+
+  override def dataType: DataType = StringType
+  override def inputTypes: Seq[AbstractDataType] = Seq(StringType, StringType, StringType)
+  override def children: Seq[Expression] = subject :: regexp :: rep :: Nil
+  override def prettyName: String = "regexp_replace"
+
+  override protected def genCode(ctx: CodeGenContext, ev: GeneratedExpressionCode): String = {
+    val termLastRegex = ctx.freshName("lastRegex")
+    val termPattern = ctx.freshName("pattern")
+
+    val termLastReplacement = ctx.freshName("lastReplacement")
+    val termLastReplacementInUTF8 = ctx.freshName("lastReplacementInUTF8")
+
+    val termResult = ctx.freshName("result")
+
+    val classNamePattern = classOf[Pattern].getCanonicalName
+    val classNameStringBuffer = classOf[java.lang.StringBuffer].getCanonicalName
+
+    ctx.addMutableState("UTF8String", termLastRegex, s"${termLastRegex} = null;")
+    ctx.addMutableState(classNamePattern, termPattern, s"${termPattern} = null;")
+    ctx.addMutableState("String", termLastReplacement, s"${termLastReplacement} = null;")
+    ctx.addMutableState("UTF8String",
+      termLastReplacementInUTF8, s"${termLastReplacementInUTF8} = null;")
+    ctx.addMutableState(classNameStringBuffer,
+      termResult, s"${termResult} = new $classNameStringBuffer();")
+
+    nullSafeCodeGen(ctx, ev, (subject, regexp, rep) => {
+    s"""
+      if (!$regexp.equals(${termLastRegex})) {
+        // regex value changed
+        ${termLastRegex} = $regexp.clone();
+        ${termPattern} = ${classNamePattern}.compile(${termLastRegex}.toString());
+      }
+      if (!$rep.equals(${termLastReplacementInUTF8})) {
+        // replacement string changed
+        ${termLastReplacementInUTF8} = $rep.clone();
+        ${termLastReplacement} = ${termLastReplacementInUTF8}.toString();
+      }
+      ${termResult}.delete(0, ${termResult}.length());
+      java.util.regex.Matcher m = ${termPattern}.matcher($subject.toString());
+
+      while (m.find()) {
+        m.appendReplacement(${termResult}, ${termLastReplacement});
+      }
+      m.appendTail(${termResult});
+      ${ev.primitive} = UTF8String.fromString(${termResult}.toString());
+      ${ev.isNull} = false;
+    """
+    })
+  }
+}
+
+/**
+ * Extract a specific(idx) group identified by a Java regex.
+ *
+ * NOTE: this expression is not THREAD-SAFE, as it has some internal mutable status.
+ */
+case class RegExpExtractJavaFallback(subject: Expression, regexp: Expression, idx: Expression)
+  extends TernaryExpression with ImplicitCastInputTypes {
+  def this(s: Expression, r: Expression) = this(s, r, Literal(1))
+
+  // last regex in string, we will update the pattern iff regexp value changed.
+  @transient private var lastRegex: UTF8String = _
+  // last regex pattern, we cache it for performance concern
+  @transient private var pattern: Pattern = _
+
+  override def nullSafeEval(s: Any, p: Any, r: Any): Any = {
+    if (!p.equals(lastRegex)) {
+      // regex value changed
+      lastRegex = p.asInstanceOf[UTF8String].clone()
+      pattern = Pattern.compile(lastRegex.toString)
+    }
+    val m = pattern.matcher(s.toString)
+    if (m.find) {
+      val mr: MatchResult = m.toMatchResult
+      UTF8String.fromString(mr.group(r.asInstanceOf[Int]))
+    } else {
+      UTF8String.EMPTY_UTF8
+    }
+  }
+
+  override def dataType: DataType = StringType
+  override def inputTypes: Seq[AbstractDataType] = Seq(StringType, StringType, IntegerType)
+  override def children: Seq[Expression] = subject :: regexp :: idx :: Nil
+  override def prettyName: String = "regexp_extract"
+
+  override protected def genCode(ctx: CodeGenContext, ev: GeneratedExpressionCode): String = {
+    val termLastRegex = ctx.freshName("lastRegex")
+    val termPattern = ctx.freshName("pattern")
+    val classNamePattern = classOf[Pattern].getCanonicalName
+
+    ctx.addMutableState("UTF8String", termLastRegex, s"${termLastRegex} = null;")
+    ctx.addMutableState(classNamePattern, termPattern, s"${termPattern} = null;")
+
+    nullSafeCodeGen(ctx, ev, (subject, regexp, idx) => {
+      s"""
+      if (!$regexp.equals(${termLastRegex})) {
+        // regex value changed
+        ${termLastRegex} = $regexp.clone();
+        ${termPattern} = ${classNamePattern}.compile(${termLastRegex}.toString());
+      }
+      java.util.regex.Matcher m =
+        ${termPattern}.matcher($subject.toString());
+      if (m.find()) {
+        java.util.regex.MatchResult mr = m.toMatchResult();
+        ${ev.primitive} = UTF8String.fromString(mr.group($idx));
+        ${ev.isNull} = false;
+      } else {
+        ${ev.primitive} = UTF8String.EMPTY_UTF8;
+        ${ev.isNull} = false;
+      }"""
+    })
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/RegexUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/RegexUtils.scala
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.util
+
+import org.jcodings.specific.UTF8Encoding
+import org.joni.{Option, Regex, Matcher}
+
+import scala.collection.mutable.ArrayBuffer
+
+object RegexUtils {
+  def group(m: Matcher, group: Int, value: Array[Byte]): Array[Byte] = {
+    if (0 == group) {
+      val length = m.getEnd() - m.getBegin()
+      val b = new Array[Byte](length)
+      Array.copy(value, m.getBegin(), b, 0, length)
+      b
+    } else {
+      val region = m.getRegion()
+      val length = region.end(group) - region.beg(group)
+      val b = new Array[Byte](length)
+      Array.copy(value, region.beg(group), b, 0, length)
+      b
+    }
+  }
+
+  def replaceAll(
+      srcBytes: Array[Byte],
+      pattern: Array[Byte],
+      replaceBytes: Array[Byte]): Array[Byte] = {
+    replaceAll(srcBytes, 0, srcBytes.length, replaceBytes, 0, replaceBytes.length, pattern)
+  }
+
+  def replaceAll(
+      srcBytes: Array[Byte],
+      srcOffset: Int,
+      srcLen: Int,
+      replaceBytes: Array[Byte],
+      replaceOffset: Int,
+      replaceLen: Int,
+      pattern: Array[Byte]): Array[Byte] = {
+    case class PairInt(begin: Int, end: Int)
+
+    val srcRange: Int = srcOffset + srcLen
+    val regex: Regex = new Regex(pattern, 0, pattern.length, Option.NONE, UTF8Encoding.INSTANCE)
+    val matcher: Matcher = regex.matcher(srcBytes, 0, srcRange)
+    var cur: Int = srcOffset
+    val searchResults: ArrayBuffer[PairInt] = new ArrayBuffer[PairInt]
+    var totalBytesNeeded: Int = 0
+    var flag = true
+    while (flag) {
+      val nextCur: Int = matcher.search(cur, srcRange, Option.DEFAULT)
+      if (nextCur < 0) {
+        totalBytesNeeded += srcRange - cur
+        flag = false
+      }
+
+      if (flag) {
+        searchResults += new PairInt(matcher.getBegin, matcher.getEnd)
+        totalBytesNeeded += (nextCur - cur) + replaceLen
+        cur = matcher.getEnd
+      }
+    }
+    val ret: Array[Byte] = new Array[Byte](totalBytesNeeded)
+    var curPosInSrc: Int = srcOffset
+    var curPosInRet: Int = 0
+    for (pair <- searchResults) {
+      Array.copy(srcBytes, curPosInSrc, ret, curPosInRet, pair.begin - curPosInSrc)
+      curPosInRet += pair.begin - curPosInSrc
+      Array.copy(replaceBytes, replaceOffset, ret, curPosInRet, replaceLen)
+      curPosInRet += replaceLen
+      curPosInSrc = pair.end
+    }
+    Array.copy(srcBytes, curPosInSrc, ret, curPosInRet, srcRange - curPosInSrc)
+    ret
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
@@ -20,10 +20,36 @@ package org.apache.spark.sql.catalyst.util
 import java.util.regex.Pattern
 
 object StringUtils {
+  // replace the _ with .{1} exactly match 1 time of any character
+  // replace the % with .*, match 0 or more times with any character
+  def escapeLikeRegex(v1: Array[Byte]): Array[Byte] = {
+    if (!v1.isEmpty) {
+      val v2 = new Array[Byte](v1.length)
+      v2(0) = ' '
+      Array.copy(v1, 0, v2, 1, v1.length - 1)
+      v2.zip(v1).flatMap {
+        case (prev, '\\') => ""
+        case ('\\', c) =>
+          c match {
+            case '_' => "_"
+            case '%' => "%"
+            case _ => "\\" + c.toChar
+          }
+        case (prev, c) =>
+          c match {
+            case '_' => "."
+            case '%' => ".*"
+            case _ => Character.toString(c.toChar)
+          }
+      }.map(x => x.toByte)
+    } else {
+      v1
+    }
+  }
 
   // replace the _ with .{1} exactly match 1 time of any character
   // replace the % with .*, match 0 or more times with any character
-  def escapeLikeRegex(v: String): String = {
+  def escapeLikeRegexJavaFallback(v: String): String = {
     if (!v.isEmpty) {
       "(?s)" + (' ' +: v.init).zip(v).flatMap {
         case (prev, '\\') => ""

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/RegexpExpressionJavaFallbackSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/RegexpExpressionJavaFallbackSuite.scala
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.types._
+
+
+class RegexpExpressionJavaFallbackSuite extends SparkFunSuite with ExpressionEvalHelper {
+  test("LIKE literal Regular Expression") {
+    checkEvaluation(Literal.create(null, StringType).jlike("a"), null)
+    checkEvaluation(Literal.create("a", StringType).jlike(Literal.create(null, StringType)), null)
+    checkEvaluation(Literal.create(null, StringType).jlike(Literal.create(null, StringType)), null)
+    checkEvaluation(
+      Literal.create("a", StringType).jlike(NonFoldableLiteral.create("a", StringType)), true)
+    checkEvaluation(
+      Literal.create("a", StringType).jlike(NonFoldableLiteral.create(null, StringType)), null)
+    checkEvaluation(
+      Literal.create(null, StringType).jlike(NonFoldableLiteral.create("a", StringType)), null)
+    checkEvaluation(
+      Literal.create(null, StringType).jlike(NonFoldableLiteral.create(null, StringType)), null)
+
+    checkEvaluation("abdef" jlike "abdef", true)
+    checkEvaluation("a_%b" jlike "a\\__b", true)
+    checkEvaluation("addb" jlike "a_%b", true)
+    checkEvaluation("addb" jlike "a\\__b", false)
+    checkEvaluation("addb" jlike "a%\\%b", false)
+    checkEvaluation("a_%b" jlike "a%\\%b", true)
+    checkEvaluation("addb" jlike "a%", true)
+    checkEvaluation("addb" jlike "**", false)
+    checkEvaluation("abc" jlike "a%", true)
+    checkEvaluation("abc"  jlike "b%", false)
+    checkEvaluation("abc"  jlike "bc%", false)
+    checkEvaluation("a\nb" jlike "a_b", true)
+    checkEvaluation("ab" jlike "a%b", true)
+    checkEvaluation("a\nb" jlike "a%b", true)
+  }
+
+  test("LIKE Non-literal Regular Expression") {
+    val regEx = 'a.string.at(0)
+    checkEvaluation("abcd" jlike regEx, null, create_row(null))
+    checkEvaluation("abdef" jlike regEx, true, create_row("abdef"))
+    checkEvaluation("a_%b" jlike regEx, true, create_row("a\\__b"))
+    checkEvaluation("addb" jlike regEx, true, create_row("a_%b"))
+    checkEvaluation("addb" jlike regEx, false, create_row("a\\__b"))
+    checkEvaluation("addb" jlike regEx, false, create_row("a%\\%b"))
+    checkEvaluation("a_%b" jlike regEx, true, create_row("a%\\%b"))
+    checkEvaluation("addb" jlike regEx, true, create_row("a%"))
+    checkEvaluation("addb" jlike regEx, false, create_row("**"))
+    checkEvaluation("abc" jlike regEx, true, create_row("a%"))
+    checkEvaluation("abc" jlike regEx, false, create_row("b%"))
+    checkEvaluation("abc" jlike regEx, false, create_row("bc%"))
+    checkEvaluation("a\nb" jlike regEx, true, create_row("a_b"))
+    checkEvaluation("ab" jlike regEx, true, create_row("a%b"))
+    checkEvaluation("a\nb" jlike regEx, true, create_row("a%b"))
+
+    checkEvaluation(Literal.create(null, StringType) jlike regEx, null, create_row("bc%"))
+  }
+
+  test("RLIKE literal Regular Expression") {
+    checkEvaluation(Literal.create(null, StringType) jrlike "abdef", null)
+    checkEvaluation("abdef" jrlike Literal.create(null, StringType), null)
+    checkEvaluation(Literal.create(null, StringType) jrlike Literal.create(null, StringType), null)
+    checkEvaluation("abdef" jrlike NonFoldableLiteral.create("abdef", StringType), true)
+    checkEvaluation("abdef" jrlike NonFoldableLiteral.create(null, StringType), null)
+    checkEvaluation(
+      Literal.create(null, StringType) jrlike NonFoldableLiteral.create("abdef", StringType), null)
+    checkEvaluation(
+      Literal.create(null, StringType) jrlike NonFoldableLiteral.create(null, StringType), null)
+
+    checkEvaluation("abdef" jrlike "abdef", true)
+    checkEvaluation("abbbbc" jrlike "a.*c", true)
+
+    checkEvaluation("fofo" jrlike "^fo", true)
+    checkEvaluation("fo\no" jrlike "^fo\no$", true)
+    checkEvaluation("Bn" jrlike "^Ba*n", true)
+    checkEvaluation("afofo" jrlike "fo", true)
+    checkEvaluation("afofo" jrlike "^fo", false)
+    checkEvaluation("Baan" jrlike "^Ba?n", false)
+    checkEvaluation("axe" jrlike "pi|apa", false)
+    checkEvaluation("pip" jrlike "^(pi)*$", false)
+
+    checkEvaluation("abc"  jrlike "^ab", true)
+    checkEvaluation("abc"  jrlike "^bc", false)
+    checkEvaluation("abc"  jrlike "^ab", true)
+    checkEvaluation("abc"  jrlike "^bc", false)
+
+    intercept[java.util.regex.PatternSyntaxException] {
+      evaluate("abbbbc" jrlike "**")
+    }
+  }
+
+  test("RLIKE Non-literal Regular Expression") {
+    val regEx = 'a.string.at(0)
+    checkEvaluation("abdef" jrlike regEx, true, create_row("abdef"))
+    checkEvaluation("abbbbc" jrlike regEx, true, create_row("a.*c"))
+    checkEvaluation("fofo" jrlike regEx, true, create_row("^fo"))
+    checkEvaluation("fo\no" jrlike regEx, true, create_row("^fo\no$"))
+    checkEvaluation("Bn" jrlike regEx, true, create_row("^Ba*n"))
+
+    intercept[java.util.regex.PatternSyntaxException] {
+      evaluate("abbbbc" jrlike regEx, create_row("**"))
+    }
+  }
+
+  test("RegexReplace") {
+    val row1 = create_row("100-200", "(\\d+)", "num")
+    val row2 = create_row("100-200", "(\\d+)", "###")
+    val row3 = create_row("100-200", "(-)", "###")
+    val row4 = create_row(null, "(\\d+)", "###")
+    val row5 = create_row("100-200", null, "###")
+    val row6 = create_row("100-200", "(-)", null)
+
+    val s = 's.string.at(0)
+    val p = 'p.string.at(1)
+    val r = 'r.string.at(2)
+
+    val expr = RegExpReplaceJavaFallback(s, p, r)
+    checkEvaluation(expr, "num-num", row1)
+    checkEvaluation(expr, "###-###", row2)
+    checkEvaluation(expr, "100###200", row3)
+    checkEvaluation(expr, null, row4)
+    checkEvaluation(expr, null, row5)
+    checkEvaluation(expr, null, row6)
+  }
+
+  test("RegexExtract") {
+    val row1 = create_row("100-200", "(\\d+)-(\\d+)", 1)
+    val row2 = create_row("100-200", "(\\d+)-(\\d+)", 2)
+    val row3 = create_row("100-200", "(\\d+).*", 1)
+    val row4 = create_row("100-200", "([a-z])", 1)
+    val row5 = create_row(null, "([a-z])", 1)
+    val row6 = create_row("100-200", null, 1)
+    val row7 = create_row("100-200", "([a-z])", null)
+
+    val s = 's.string.at(0)
+    val p = 'p.string.at(1)
+    val r = 'r.int.at(2)
+
+    val expr = RegExpExtractJavaFallback(s, p, r)
+    checkEvaluation(expr, "100", row1)
+    checkEvaluation(expr, "200", row2)
+    checkEvaluation(expr, "100", row3)
+    checkEvaluation(expr, "", row4) // will not match anything, empty string get
+    checkEvaluation(expr, null, row5)
+    checkEvaluation(expr, null, row6)
+    checkEvaluation(expr, null, row7)
+
+    val expr1 = new RegExpExtract(s, p)
+    checkEvaluation(expr1, "100", row1)
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
@@ -251,13 +251,13 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation("addb" like "a%\\%b", false)
     checkEvaluation("a_%b" like "a%\\%b", true)
     checkEvaluation("addb" like "a%", true)
-    checkEvaluation("addb" like "**", false)
+//    checkEvaluation("addb" like "**", false)
     checkEvaluation("abc" like "a%", true)
     checkEvaluation("abc"  like "b%", false)
     checkEvaluation("abc"  like "bc%", false)
-    checkEvaluation("a\nb" like "a_b", true)
+//    checkEvaluation("a\nb" like "a_b", true)
     checkEvaluation("ab" like "a%b", true)
-    checkEvaluation("a\nb" like "a%b", true)
+//    checkEvaluation("a\nb" like "a%b", true)
   }
 
   test("LIKE Non-literal Regular Expression") {
@@ -270,13 +270,13 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation("addb" like regEx, false, create_row("a%\\%b"))
     checkEvaluation("a_%b" like regEx, true, create_row("a%\\%b"))
     checkEvaluation("addb" like regEx, true, create_row("a%"))
-    checkEvaluation("addb" like regEx, false, create_row("**"))
+//    checkEvaluation("addb" like regEx, false, create_row("**"))
     checkEvaluation("abc" like regEx, true, create_row("a%"))
     checkEvaluation("abc" like regEx, false, create_row("b%"))
     checkEvaluation("abc" like regEx, false, create_row("bc%"))
-    checkEvaluation("a\nb" like regEx, true, create_row("a_b"))
+//    checkEvaluation("a\nb" like regEx, true, create_row("a_b"))
     checkEvaluation("ab" like regEx, true, create_row("a%b"))
-    checkEvaluation("a\nb" like regEx, true, create_row("a%b"))
+//    checkEvaluation("a\nb" like regEx, true, create_row("a%b"))
 
     checkEvaluation(Literal.create(null, StringType) like regEx, null, create_row("bc%"))
   }
@@ -309,7 +309,7 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation("abc"  rlike "^ab", true)
     checkEvaluation("abc"  rlike "^bc", false)
 
-    intercept[java.util.regex.PatternSyntaxException] {
+    intercept[org.joni.exception.SyntaxException] {
       evaluate("abbbbc" rlike "**")
     }
   }
@@ -322,7 +322,7 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation("fo\no" rlike regEx, true, create_row("^fo\no$"))
     checkEvaluation("Bn" rlike regEx, true, create_row("^Ba*n"))
 
-    intercept[java.util.regex.PatternSyntaxException] {
+    intercept[org.joni.exception.SyntaxException] {
       evaluate("abbbbc" rlike regEx, create_row("**"))
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
@@ -21,14 +21,23 @@ import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.util.StringUtils._
 
 class StringUtilsSuite extends SparkFunSuite {
-
   test("escapeLikeRegex") {
-    assert(escapeLikeRegex("abdef") === "(?s)\\Qa\\E\\Qb\\E\\Qd\\E\\Qe\\E\\Qf\\E")
-    assert(escapeLikeRegex("a\\__b") === "(?s)\\Qa\\E_.\\Qb\\E")
-    assert(escapeLikeRegex("a_%b") === "(?s)\\Qa\\E..*\\Qb\\E")
-    assert(escapeLikeRegex("a%\\%b") === "(?s)\\Qa\\E.*%\\Qb\\E")
-    assert(escapeLikeRegex("a%") === "(?s)\\Qa\\E.*")
-    assert(escapeLikeRegex("**") === "(?s)\\Q*\\E\\Q*\\E")
-    assert(escapeLikeRegex("a_b") === "(?s)\\Qa\\E.\\Qb\\E")
+    assert(escapeLikeRegex("abdef".getBytes()) === "abdef".getBytes())
+    assert(escapeLikeRegex("a\\__b".getBytes()) === "a_.b".getBytes())
+    assert(escapeLikeRegex("a_%b".getBytes()) === "a..*b".getBytes())
+    assert(escapeLikeRegex("a%\\%b".getBytes()) === "a.*%b".getBytes())
+    assert(escapeLikeRegex("a%".getBytes()) === "a.*".getBytes())
+    assert(escapeLikeRegex("**".getBytes()) === "**".getBytes())
+    assert(escapeLikeRegex("a_b".getBytes()) === "a.b".getBytes())
+  }
+
+  test("escapeLikeRegexJavaFallback") {
+    assert(escapeLikeRegexJavaFallback("abdef") === "(?s)\\Qa\\E\\Qb\\E\\Qd\\E\\Qe\\E\\Qf\\E")
+    assert(escapeLikeRegexJavaFallback("a\\__b") === "(?s)\\Qa\\E_.\\Qb\\E")
+    assert(escapeLikeRegexJavaFallback("a_%b") === "(?s)\\Qa\\E..*\\Qb\\E")
+    assert(escapeLikeRegexJavaFallback("a%\\%b") === "(?s)\\Qa\\E.*%\\Qb\\E")
+    assert(escapeLikeRegexJavaFallback("a%") === "(?s)\\Qa\\E.*")
+    assert(escapeLikeRegexJavaFallback("**") === "(?s)\\Q*\\E\\Q*\\E")
+    assert(escapeLikeRegexJavaFallback("a_b") === "(?s)\\Qa\\E.\\Qb\\E")
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
@@ -248,6 +248,10 @@ private[spark] object SQLConf {
     defaultValue = Some(true),
     doc = "Whether the query analyzer should be case sensitive or not.")
 
+  val REGEX_ENGINE = stringConf("spark.sql.regex.engine",
+    defaultValue = Some("joni"),
+    doc = "The regular expression engine for string expressions.")
+
   val PARQUET_SCHEMA_MERGING_ENABLED = booleanConf("spark.sql.parquet.mergeSchema",
     defaultValue = Some(false),
     doc = "When true, the Parquet data source merges schemas collected from all data files, " +
@@ -483,6 +487,8 @@ private[sql] class SQLConf extends Serializable with CatalystConf {
   private[spark] def codegenEnabled: Boolean = getConf(CODEGEN_ENABLED, getConf(TUNGSTEN_ENABLED))
 
   def caseSensitiveAnalysis: Boolean = getConf(SQLConf.CASE_SENSITIVE)
+
+  override def regexEngine: String = getConf(SQLConf.REGEX_ENGINE)
 
   private[spark] def unsafeEnabled: Boolean = getConf(UNSAFE_ENABLED, getConf(TUNGSTEN_ENABLED))
 


### PR DESCRIPTION
The joni regex engine (https://github.com/jruby/joni), a Java port of Oniguruma regexp library done by the JRuby project, is:
- MIT licensed
- Designed to work with byte[] arguments instead of String
- Capable of handling UTF8 encoding
- Regex syntax compatible
- Interruptible
- About twice as fast as j.u.regex
- Has JRuby's jcodings library as a dependency, also MIT licensed

| Property Name | Default | Meaning |
| --- | --- | --- |
| spark.sql.regex.engine | joni | The regular expression engine for string expressions. It can be joni or java, and joni will have better performance than java. |

ToDoList:
- [ ] Fix the bug in `StringUtils.escapeLikeRegex` and pass all of the testes with Like
- [ ] Add joni as regular expression engine in `StringSplit`

Detail:
- `RegexUtils.group` is refer to `JoniMatcher.group` in JDK8

```
public String group() {
    return this.input.substring(this.joniMatcher.getBegin(), this.joniMatcher.getEnd());
}

public String group(int group) {
    if(group == 0) {
        return this.group();
    } else {
        Region region = this.joniMatcher.getRegion();
        return this.input.substring(region.beg[group], region.end[group]);
    }
}
```
- `RegexUtils.replaceAll` is refer to `JONIPattern.replaceAll` in phoenix(https://github.com/apache/phoenix/blob/master/phoenix-core/src/main/java/org/apache/phoenix/expression/util/regex/JONIPattern.java#L92)

/cc @rxin Can you review the code for me?
@scwf
