### PR TITLE
[Python] Fixed typo in exception message

### DIFF
--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -255,7 +255,7 @@ class SparkContext(object):
         # This method is called when attempting to pickle SparkContext, which is always an error:
         raise Exception(
             "It appears that you are attempting to reference SparkContext from a broadcast "
-            "variable, action, or transforamtion. SparkContext can only be used on the driver, "
+            "variable, action, or transformation. SparkContext can only be used on the driver, "
             "not in code that it run on workers. For more information, see SPARK-5063."
         )
 


### PR DESCRIPTION
Just fixing a typo in exception message, raised when attempting to pickle SparkContext.
