### PR TITLE
[SPARK-10582] If a new AM restarts, the total number of executors should be in initial state in driver side.

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -235,7 +235,7 @@ private[spark] class ExecutorAllocationManager(
   /**
    * Change the value of numExecutorsTarget.
    */
-  def reSetNumExecutorsTarget(): Unit ={
+  def reSetNumExecutorsTarget(): Unit = {
    logDebug(s"Now reset the value of numExecutorsTarget.")
     numExecutorsTarget = conf.getInt("spark.dynamicAllocation.initialExecutors", minNumExecutors)
   }

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -231,7 +231,7 @@ private[spark] class ExecutorAllocationManager(
     }
     executor.scheduleAtFixedRate(scheduleTask, 0, intervalMillis, TimeUnit.MILLISECONDS)
   }
-  
+
   /**
    * Change the value of numExecutorsTarget.
    */

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -231,6 +231,14 @@ private[spark] class ExecutorAllocationManager(
     }
     executor.scheduleAtFixedRate(scheduleTask, 0, intervalMillis, TimeUnit.MILLISECONDS)
   }
+  
+  /**
+   * Change the value of numExecutorsTarget.
+   */
+  def reSetNumExecutorsTarget(): Unit ={
+   logDebug(s"Now reset the value of numExecutorsTarget.")
+    numExecutorsTarget = conf.getInt("spark.dynamicAllocation.initialExecutors", minNumExecutors)
+  }
 
   /**
    * Stop the allocation manager.

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
@@ -91,7 +91,6 @@ private[spark] abstract class YarnSchedulerBackend(
       filterParams.foreach { case (k, v) => conf.set(s"spark.$filterName.param.$k", v) }
       scheduler.sc.ui.foreach { ui => JettyUtils.addFilters(ui.getHandlers, conf) }
     }
-    scheduler.sc.executorAllocationManager.foreach(_.reSetNumExecutorsTarget())
   }
 
   override def createDriverEndpoint(properties: Seq[(String, String)]): DriverEndpoint = {
@@ -171,6 +170,7 @@ private[spark] abstract class YarnSchedulerBackend(
       case RegisterClusterManager(am) =>
         logInfo(s"ApplicationMaster registered as $am")
         amEndpoint = Some(am)
+        scheduler.sc.executorAllocationManager.foreach(_.reSetNumExecutorsTarget())
 
       case AddWebUIFilter(filterName, filterParams, proxyBase) =>
         addWebUIFilter(filterName, filterParams, proxyBase)

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
@@ -91,6 +91,7 @@ private[spark] abstract class YarnSchedulerBackend(
       filterParams.foreach { case (k, v) => conf.set(s"spark.$filterName.param.$k", v) }
       scheduler.sc.ui.foreach { ui => JettyUtils.addFilters(ui.getHandlers, conf) }
     }
+    scheduler.sc.executorAllocationManager.foreach(_.reSetNumExecutorsTarget())
   }
 
   override def createDriverEndpoint(properties: Seq[(String, String)]): DriverEndpoint = {


### PR DESCRIPTION
During running tasks, when the total number of executors is the value of `spark.dynamicAllocation.maxExecutors` and the AM is failed. Then a new AM restarts. Because in ExecutorAllocationManager, the total number of executors does not changed, driver does not send RequestExecutors to AM to ask executors.  Then the total number of executors is the value of  `spark.dynamicAllocation.initialExecutors` . So the total number of executors in driver and AM is different.
