### PR TITLE
[SPARK-10586] fix bug: BlockManager ca't be removed when it is re-registered, then disassociats

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1176,7 +1176,7 @@ class DAGScheduler(
   private[scheduler] def handleExecutorAdded(execId: String, host: String) {
     // remove from failedEpoch(execId) ?
     if (failedEpoch.contains(execId)) {
-      logInfo("Host added was in lost list earlier: " + host)
+      logInfo(s"Executor $execId added was in lost list earlier.")
       failedEpoch -= execId
     }
     submitWaitingStages()

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -285,9 +285,12 @@ private[spark] class TaskSchedulerImpl(
       activeExecutorIds += o.executorId
       if (!executorsByHost.contains(o.host)) {
         executorsByHost(o.host) = new HashSet[String]()
+      }
+      if (!executorsByHost.get(o.host).get.contains(o.executorId)) {
         executorAdded(o.executorId, o.host)
         newExecAvail = true
       }
+
       for (rack <- getRackForHost(o.host)) {
         hostsByRack.getOrElseUpdate(rack, new HashSet[String]()) += o.host
       }


### PR DESCRIPTION
Scene: When the executor has been removed, but it still exists on the SparkUI web.

Process: 
1. Driver Lost executor because heartbeat timed out;
2. Executor received SIGNAL 15: SIGTERM and **re-registered** the blockmanager;
3. Driver Lost executor because remote Rpc client disassociated and attempt to remove blockmanager but not success;

Reason:
The first time lost executor, the [SchedulerBackend reviveOffers](https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala#L481), when the host also has other executors, it won't [add this executor](https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala#L288). So the second time lost executor, DAGScheduler won't remove BlockManager because the executorId has been in `failedEpoch`.
