### PR TITLE
Stevel/patches/spark 8789 sql query suite table drop

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -67,8 +67,12 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
   import hiveContext._
   import hiveContext.implicits._
 
+  def dropTable(t: String): Unit = {
+    sql(s"DROP TABLE IF EXISTS $t")
+  }
+
   test("UDTF") {
-    sql(s"ADD JAR ${hiveContext.getHiveFile("TestUDTF.jar").getCanonicalPath() }")
+    sql(s"ADD JAR ${hiveContext.getHiveFile("TestUDTF.jar").getCanonicalPath()}")
     // The function source code can be found at:
     // https://cwiki.apache.org/confluence/display/Hive/DeveloperGuide+UDTF
     sql(
@@ -84,10 +88,6 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
     checkAnswer(
       sql("SELECT udtf_count2(a) FROM (SELECT 1 AS a FROM src LIMIT 3) t"),
       Row(3) :: Row(3) :: Nil)
-  }
-
-  def dropTable(table: String): Unit = {
-    sql(s"DROP TABLE IF EXISTS $table")
   }
 
   test("SPARK-6835: udtf in lateral view") {
@@ -365,116 +365,110 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
   }
 
   test("CTAS with serde") {
-    dropTable("ctas1")
-    dropTable("ctas2")
-    dropTable("ctas3")
-    dropTable("ctas4")
-    dropTable("ctas5")
-    sql("CREATE TABLE ctas1 AS SELECT key k, value FROM src ORDER BY k, value").collect()
-    sql(
-      """CREATE TABLE ctas2
-        | ROW FORMAT SERDE "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe"
-        | WITH SERDEPROPERTIES("serde_p1"="p1","serde_p2"="p2")
-        | STORED AS RCFile
-        | TBLPROPERTIES("tbl_p1"="p11", "tbl_p2"="p22")
-        | AS
-        |   SELECT key, value
-        |   FROM src
-        |   ORDER BY key, value""".stripMargin).collect()
-    sql(
-      """CREATE TABLE ctas3
-        | ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' LINES TERMINATED BY '\012'
-        | STORED AS textfile AS
-        |   SELECT key, value
-        |   FROM src
-        |   ORDER BY key, value""".stripMargin).collect()
+    withTable("ctas1", "ctas2", "ctas3", "ctas4", "ctas5") {
+      sql("CREATE TABLE ctas1 AS SELECT key k, value FROM src ORDER BY k, value").collect()
+      sql(
+        """CREATE TABLE ctas2
+          | ROW FORMAT SERDE "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe"
+          | WITH SERDEPROPERTIES("serde_p1"="p1","serde_p2"="p2")
+          | STORED AS RCFile
+          | TBLPROPERTIES("tbl_p1"="p11", "tbl_p2"="p22")
+          | AS
+          |   SELECT key, value
+          |   FROM src
+          |   ORDER BY key, value""".stripMargin).collect()
+      sql(
+        """CREATE TABLE ctas3
+          | ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' LINES TERMINATED BY '\012'
+          | STORED AS textfile AS
+          |   SELECT key, value
+          |   FROM src
+          |   ORDER BY key, value""".stripMargin).collect()
 
-    // the table schema may like (key: integer, value: string)
-    sql(
-      """CREATE TABLE IF NOT EXISTS ctas4 AS
-        | SELECT 1 AS key, value FROM src LIMIT 1""".stripMargin).collect()
-    // do nothing cause the table ctas4 already existed.
-    sql(
-      """CREATE TABLE IF NOT EXISTS ctas4 AS
-        | SELECT key, value FROM src ORDER BY key, value""".stripMargin).collect()
-
-    checkAnswer(
-      sql("SELECT k, value FROM ctas1 ORDER BY k, value"),
-      sql("SELECT key, value FROM src ORDER BY key, value").collect().toSeq)
-    checkAnswer(
-      sql("SELECT key, value FROM ctas2 ORDER BY key, value"),
+      // the table schema may like (key: integer, value: string)
       sql(
-        """
-          SELECT key, value
-          FROM src
-          ORDER BY key, value""").collect().toSeq)
-    checkAnswer(
-      sql("SELECT key, value FROM ctas3 ORDER BY key, value"),
+        """CREATE TABLE IF NOT EXISTS ctas4 AS
+          | SELECT 1 AS key, value FROM src LIMIT 1""".stripMargin).collect()
+      // do nothing cause the table ctas4 already existed.
       sql(
-        """
-          SELECT key, value
-          FROM src
-          ORDER BY key, value""").collect().toSeq)
-    intercept[AnalysisException] {
-      sql(
-        """CREATE TABLE ctas4 AS
+        """CREATE TABLE IF NOT EXISTS ctas4 AS
           | SELECT key, value FROM src ORDER BY key, value""".stripMargin).collect()
-    }
-    checkAnswer(
-      sql("SELECT key, value FROM ctas4 ORDER BY key, value"),
-      sql("SELECT key, value FROM ctas4 LIMIT 1").collect().toSeq)
 
-    checkExistence(sql("DESC EXTENDED ctas2"), true,
-      "name:key", "type:string", "name:value", "ctas2",
-      "org.apache.hadoop.hive.ql.io.RCFileInputFormat",
-      "org.apache.hadoop.hive.ql.io.RCFileOutputFormat",
-      "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe",
-      "serde_p1=p1", "serde_p2=p2", "tbl_p1=p11", "tbl_p2=p22", "MANAGED_TABLE"
-    )
-
-    sql(
-      """CREATE TABLE ctas5
-        | STORED AS parquet AS
-        |   SELECT key, value
-        |   FROM src
-        |   ORDER BY key, value""".stripMargin).collect()
-
-    withSQLConf(HiveContext.CONVERT_METASTORE_PARQUET.key -> "false") {
-      checkExistence(sql("DESC EXTENDED ctas5"), true,
-        "name:key", "type:string", "name:value", "ctas5",
-        "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat",
-        "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat",
-        "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe",
-        "MANAGED_TABLE"
-      )
-    }
-
-    // use the Hive SerDe for parquet tables
-    withSQLConf(HiveContext.CONVERT_METASTORE_PARQUET.key -> "false") {
       checkAnswer(
-        sql("SELECT key, value FROM ctas5 ORDER BY key, value"),
+        sql("SELECT k, value FROM ctas1 ORDER BY k, value"),
         sql("SELECT key, value FROM src ORDER BY key, value").collect().toSeq)
+      checkAnswer(
+        sql("SELECT key, value FROM ctas2 ORDER BY key, value"),
+        sql(
+          """
+            SELECT key, value
+            FROM src
+            ORDER BY key, value""").collect().toSeq)
+      checkAnswer(
+        sql("SELECT key, value FROM ctas3 ORDER BY key, value"),
+        sql(
+          """
+            SELECT key, value
+            FROM src
+            ORDER BY key, value""").collect().toSeq)
+      intercept[AnalysisException] {
+        sql(
+          """CREATE TABLE ctas4 AS
+            | SELECT key, value FROM src ORDER BY key, value""".stripMargin).collect()
+      }
+      checkAnswer(
+        sql("SELECT key, value FROM ctas4 ORDER BY key, value"),
+        sql("SELECT key, value FROM ctas4 LIMIT 1").collect().toSeq)
+
+      checkExistence(sql("DESC EXTENDED ctas2"), true,
+        "name:key", "type:string", "name:value", "ctas2",
+        "org.apache.hadoop.hive.ql.io.RCFileInputFormat",
+        "org.apache.hadoop.hive.ql.io.RCFileOutputFormat",
+        "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe",
+        "serde_p1=p1", "serde_p2=p2", "tbl_p1=p11", "tbl_p2=p22", "MANAGED_TABLE"
+      )
+
+      sql(
+        """CREATE TABLE ctas5
+          | STORED AS parquet AS
+          |   SELECT key, value
+          |   FROM src
+          |   ORDER BY key, value""".stripMargin).collect()
+
+      withSQLConf(HiveContext.CONVERT_METASTORE_PARQUET.key -> "false") {
+        checkExistence(sql("DESC EXTENDED ctas5"), true,
+          "name:key", "type:string", "name:value", "ctas5",
+          "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat",
+          "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat",
+          "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe",
+          "MANAGED_TABLE"
+        )
+      }
+
+      // use the Hive SerDe for parquet tables
+      withSQLConf(HiveContext.CONVERT_METASTORE_PARQUET.key -> "false") {
+        checkAnswer(
+          sql("SELECT key, value FROM ctas5 ORDER BY key, value"),
+          sql("SELECT key, value FROM src ORDER BY key, value").collect().toSeq)
+      }
     }
   }
 
   test("specifying the column list for CTAS") {
-    dropTable("gen__tmp")
-    dropTable("mytable1")
-    Seq((1, "111111"), (2, "222222")).toDF("key", "value").registerTempTable("mytable1")
+    withTable("gen__tmp", "mytable1") {
+      Seq((1, "111111"), (2, "222222")).toDF("key", "value").registerTempTable("mytable1")
 
-    sql("create table gen__tmp(a int, b string) as select key, value from mytable1")
-    checkAnswer(
-      sql("SELECT a, b from gen__tmp"),
-      sql("select key, value from mytable1").collect())
-    sql("DROP TABLE gen__tmp")
+      sql("create table gen__tmp(a int, b string) as select key, value from mytable1")
+      checkAnswer(
+        sql("SELECT a, b from gen__tmp"),
+        sql("select key, value from mytable1").collect())
+      sql("DROP TABLE gen__tmp")
 
-    sql("create table gen__tmp(a double, b double) as select key, value from mytable1")
-    checkAnswer(
-      sql("SELECT a, b from gen__tmp"),
-      sql("select cast(key as double), cast(value as double) from mytable1").collect())
-    sql("DROP TABLE gen__tmp")
-
-    sql("drop table mytable1")
+      sql("create table gen__tmp(a double, b double) as select key, value from mytable1")
+      checkAnswer(
+        sql("SELECT a, b from gen__tmp"),
+        sql("select cast(key as double), cast(value as double) from mytable1").collect())
+    }
   }
 
   test("command substitution") {
@@ -531,26 +525,27 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
   }
 
   test("test CTAS") {
-    dropTable("test_ctas_123")
-    sql("CREATE TABLE test_ctas_123 AS SELECT key, value FROM src")
-    checkAnswer(
-      sql("SELECT key, value FROM test_ctas_123 ORDER BY key"),
-      sql("SELECT key, value FROM src ORDER BY key").collect().toSeq)
+    withTable("test_ctas_123") {
+      sql("CREATE TABLE test_ctas_123 AS SELECT key, value FROM src")
+      checkAnswer(
+        sql("SELECT key, value FROM test_ctas_123 ORDER BY key"),
+        sql("SELECT key, value FROM src ORDER BY key").collect().toSeq)
+    }
   }
 
   test("SPARK-4825 save join to table") {
-    dropTable("test1")
-    dropTable("test2")
-    val testData = sparkContext.parallelize(1 to 10).map(i => TestData(i, i.toString)).toDF()
-    sql("CREATE TABLE test1 (key INT, value STRING)")
-    testData.write.mode(SaveMode.Append).insertInto("test1")
-    sql("CREATE TABLE test2 (key INT, value STRING)")
-    testData.write.mode(SaveMode.Append).insertInto("test2")
-    testData.write.mode(SaveMode.Append).insertInto("test2")
-    sql("CREATE TABLE test AS SELECT COUNT(a.value) FROM test1 a JOIN test2 b ON a.key = b.key")
-    checkAnswer(
-      table("test"),
-      sql("SELECT COUNT(a.value) FROM test1 a JOIN test2 b ON a.key = b.key").collect().toSeq)
+    withTable("test1", "test2") {
+      val testData = sparkContext.parallelize(1 to 10).map(i => TestData(i, i.toString)).toDF()
+      sql("CREATE TABLE test1 (key INT, value STRING)")
+      testData.write.mode(SaveMode.Append).insertInto("test1")
+      sql("CREATE TABLE test2 (key INT, value STRING)")
+      testData.write.mode(SaveMode.Append).insertInto("test2")
+      testData.write.mode(SaveMode.Append).insertInto("test2")
+      sql("CREATE TABLE test AS SELECT COUNT(a.value) FROM test1 a JOIN test2 b ON a.key = b.key")
+      checkAnswer(
+        table("test"),
+        sql("SELECT COUNT(a.value) FROM test1 a JOIN test2 b ON a.key = b.key").collect().toSeq)
+    }
   }
 
   test("SPARK-3708 Backticks aren't handled correctly is aliases") {
@@ -617,39 +612,41 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
   }
 
   test("SPARK-5284 Insert into Hive throws NPE when a inner complex type field has a null value") {
-    val schema = StructType(
-      StructField("s",
-        StructType(
-          StructField("innerStruct", StructType(StructField("s1", StringType, true) :: Nil)) ::
-            StructField("innerArray", ArrayType(IntegerType), true) ::
-            StructField("innerMap", MapType(StringType, IntegerType)) :: Nil), true) :: Nil)
-    val row = Row(Row(null, null, null))
+    withTable("nullValuesInInnerComplexTypes") {
+      val schema = StructType(
+        StructField("s",
+          StructType(
+            StructField("innerStruct", StructType(StructField("s1", StringType, true) :: Nil)) ::
+              StructField("innerArray", ArrayType(IntegerType), true) ::
+              StructField("innerMap", MapType(StringType, IntegerType)) :: Nil), true) :: Nil)
+      val row = Row(Row(null, null, null))
 
-    val rowRdd = sparkContext.parallelize(row :: Nil)
+      val rowRdd = sparkContext.parallelize(row :: Nil)
 
     hiveContext.createDataFrame(rowRdd, schema).registerTempTable("testTable")
-    dropTable("nullValuesInInnerComplexTypes")
 
-    sql(
-      """CREATE TABLE nullValuesInInnerComplexTypes
-        |  (s struct<innerStruct: struct<s1:string>,
-        |            innerArray:array<int>,
-        |            innerMap: map<string, int>>)
-      """.stripMargin).collect()
+      sql(
+        """CREATE TABLE nullValuesInInnerComplexTypes
+          |  (s struct<innerStruct: struct<s1:string>,
+          |            innerArray:array<int>,
+          |            innerMap: map<string, int>>)
+        """.stripMargin).collect()
 
-    sql(
-      """
-        |INSERT OVERWRITE TABLE nullValuesInInnerComplexTypes
-        |SELECT * FROM testTable
-      """.stripMargin)
+      sql(
+        """
+          |INSERT OVERWRITE TABLE nullValuesInInnerComplexTypes
+          |SELECT * FROM testTable
+        """.stripMargin)
 
-    checkAnswer(
-      sql("SELECT * FROM nullValuesInInnerComplexTypes"),
-      Row(Row(null, null, null))
-    )
+      checkAnswer(
+        sql("SELECT * FROM nullValuesInInnerComplexTypes"),
+        Row(Row(null, null, null))
+      )
 
-    sql("DROP TABLE nullValuesInInnerComplexTypes")
-    dropTempTable("testTable")
+      sql("DROP TABLE nullValuesInInnerComplexTypes")
+      dropTempTable("testTable")
+    }
+
   }
 
   test("SPARK-4296 Grouping field with Hive UDF as sub expression") {
@@ -708,9 +705,7 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
     read.json(rdd).registerTempTable("data")
     val originalConf = convertCTAS
     setConf(HiveContext.CONVERT_CTAS, false)
-    sql("DROP TABLE IF EXISTS explodeTest")
-
-    try {
+    withTable("explodeTest")  try {
       sql("CREATE TABLE explodeTest (key bigInt)")
       table("explodeTest").queryExecution.analyzed match {
         case metastoreRelation: MetastoreRelation => // OK
@@ -725,8 +720,8 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
       )
 
       sql("DROP TABLE explodeTest")
-      dropTempTable("data")
     } finally {
+      dropTempTable("data")
       setConf(HiveContext.CONVERT_CTAS, originalConf)
     }
   }
@@ -734,13 +729,11 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
   test("sanity test for SPARK-6618") {
     (1 to 100).par.map { i =>
       val tableName = s"SPARK_6618_table_$i"
-      try {
+      withTable(tableName) {
         sql(s"CREATE TABLE $tableName (col1 string)")
         catalog.lookupRelation(Seq(tableName))
         table(tableName)
         tables()
-      } finally {
-        sql(s"DROP TABLE  IF EXISTS $tableName")
       }
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -67,8 +67,8 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
   import hiveContext._
   import hiveContext.implicits._
 
-  def dropTable(t: String): Unit = {
-    sql(s"DROP TABLE IF EXISTS $t")
+  def dropTable(table: String): Unit = {
+    sql(s"DROP TABLE IF EXISTS $table")
   }
 
   test("UDTF") {
@@ -286,9 +286,8 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
     val originalConf = convertCTAS
 
     setConf(HiveContext.CONVERT_CTAS, true)
-    dropTable("ctas1")
 
-    try {
+    withTable("ctas1") try {
       sql("CREATE TABLE ctas1 AS SELECT key k, value FROM src ORDER BY k, value")
       sql("CREATE TABLE IF NOT EXISTS ctas1 AS SELECT key k, value FROM src ORDER BY k, value")
       var message = intercept[AnalysisException] {
@@ -331,7 +330,6 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
       sql("DROP TABLE ctas1")
     } finally {
       setConf(HiveContext.CONVERT_CTAS, originalConf)
-      sql("DROP TABLE IF EXISTS ctas1")
     }
   }
 
@@ -646,7 +644,6 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
       sql("DROP TABLE nullValuesInInnerComplexTypes")
       dropTempTable("testTable")
     }
-
   }
 
   test("SPARK-4296 Grouping field with Hive UDF as sub expression") {
@@ -705,6 +702,7 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
     read.json(rdd).registerTempTable("data")
     val originalConf = convertCTAS
     setConf(HiveContext.CONVERT_CTAS, false)
+
     withTable("explodeTest")  try {
       sql("CREATE TABLE explodeTest (key bigInt)")
       table("explodeTest").queryExecution.analyzed match {


### PR DESCRIPTION
Updated version of SPARK-8789 which switches to `withSqlContext` for the operations which change the sql context.

Note that `withTable()` doesn't clean up tables before a test run: if there is a spurious table before the operation, then a test may fail. Ideally it should be doing cleanup in advance too; I didn't address that code as it would impact more test cases.
