### PR TITLE
Introduce config constants object

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -995,7 +995,6 @@ object Client extends Logging {
   val SPARK_STAGING: String = ".sparkStaging"
 
   // Location of any user-defined Spark jars
-  val CONF_SPARK_JAR = "spark.yarn.jar"
   val ENV_SPARK_JAR = "SPARK_JAR"
 
   // Internal config to propagate the location of the user's jar to the driver/executors
@@ -1037,6 +1036,7 @@ object Client extends Logging {
    * user environment if that is not found (for backwards compatibility).
    */
   private def sparkJar(conf: SparkConf): String = {
+    import YarnConfigParameter.CONF_SPARK_JAR
     if (conf.contains(CONF_SPARK_JAR)) {
       conf.get(CONF_SPARK_JAR)
     } else if (System.getenv(ENV_SPARK_JAR) != null) {
@@ -1047,7 +1047,7 @@ object Client extends Logging {
     } else {
       SparkContext.jarOfClass(this.getClass).getOrElse(throw new SparkException("Could not "
         + "find jar containing Spark classes. The jar can be defined using the "
-        + "spark.yarn.jar configuration option. If testing Spark, either set that option or "
+        + s"$CONF_SPARK_JAR configuration option. If testing Spark, either set that option or "
         + "make sure SPARK_PREPEND_CLASSES is not set."))
     }
   }

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnConfigParameter.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnConfigParameter.scala
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.yarn
+
+/**
+ * Configuration names used to set up Spark on YARN
+ */
+object YarnConfigParameter {
+  val CONF_SPARK_JAR = "spark.yarn.jar"
+}

--- a/yarn/src/test/scala/org/apache/spark/deploy/yarn/BaseYarnClusterSuite.scala
+++ b/yarn/src/test/scala/org/apache/spark/deploy/yarn/BaseYarnClusterSuite.scala
@@ -128,7 +128,7 @@ abstract class BaseYarnClusterSuite
     val master = if (clientMode) "yarn-client" else "yarn-cluster"
     val props = new Properties()
 
-    props.setProperty("spark.yarn.jar", "local:" + fakeSparkJar.getAbsolutePath())
+    props.setProperty(YarnConfigParameter.CONF_SPARK_JAR, "local:" + fakeSparkJar.getAbsolutePath())
 
     val testClasspath = new TestClasspathBuilder()
       .buildClassPath(

--- a/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
+++ b/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
@@ -58,7 +58,7 @@ class YarnAllocatorSuite extends SparkFunSuite with Matchers with BeforeAndAfter
   val sparkConf = new SparkConf()
   sparkConf.set("spark.driver.host", "localhost")
   sparkConf.set("spark.driver.port", "4040")
-  sparkConf.set("spark.yarn.jar", "notarealjar.jar")
+  sparkConf.set(YarnConfigParameter.CONF_SPARK_JAR, "notarealjar.jar")
   sparkConf.set("spark.yarn.launchContainers", "false")
 
   val appAttemptId = ApplicationAttemptId.newInstance(ApplicationId.newInstance(0, 0), 0)


### PR DESCRIPTION
A small refactoring to introduce a Scala object to keep property/environment names in a single place for YARN cluster deployment first (as I hate seeing strings all over the code, and most importantly avoid any typos in the future). I couldn't resist after reviewing c0052d8d09eebadadb5ed35ac512caaf73919551.

If it gets accepted I'm going to move all the configuration names to the file. I did the first step and want to be told I'm right or get corrected.

(It's also to verify my understanding of how the pull request process works in the project.)
