### PR TITLE
[Spark-8426] [scheduler] enhance blacklist mechanism

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/BlacklistStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/BlacklistStrategy.scala
@@ -19,9 +19,7 @@ package org.apache.spark.scheduler
 
 import scala.collection.mutable
 
-import org.apache.spark.Logging
 import org.apache.spark.SparkConf
-import org.apache.spark.util.SystemClock
 import org.apache.spark.util.Clock
 
 /**

--- a/core/src/main/scala/org/apache/spark/scheduler/BlacklistStrategy.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/BlacklistStrategy.scala
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler
+
+import scala.collection.mutable
+
+import org.apache.spark.Logging
+import org.apache.spark.SparkConf
+import org.apache.spark.util.SystemClock
+import org.apache.spark.util.Clock
+
+/**
+ * The interface to determine executor blacklist and node blacklist.
+ */
+private [scheduler] trait BlacklistStrategy {
+  /** Define a time interval to expire failure information of executors */
+  val expireTimeInMilliseconds: Long
+
+  /** Return executors in blacklist which are related to given stage and partition */
+  def getExecutorBlacklist(
+      executorIdToFailureStatus: mutable.HashMap[String, FailureStatus],
+      atomTask: StageAndPartition,
+      clock: Clock): Set[String]
+
+  /** Return all nodes in blacklist */
+  def getNodeBlacklist(
+      executorIdToFailureStatus: mutable.HashMap[String, FailureStatus],
+      clock: Clock): Set[String]
+
+  /** Return all nodes in blacklist for specified stage. By default it returns the same result as
+   *  getNodeBlacklist. It could be override in strategy implementation.
+   */
+  def getNodeBlacklistForStage(
+      executorIdToFailureStatus: mutable.HashMap[String, FailureStatus],
+      stageId: Int,
+      clock: Clock): Set[String] = getNodeBlacklist(executorIdToFailureStatus, clock)
+
+  /**
+   * Choose which executors should be removed from blacklist. Return true if any executors are
+   * removed from the blacklist, false otherwise. The default implementation removes executors from
+   * the blacklist after [[expireTimeInMilliseconds]]
+   */
+  def expireExecutorsInBlackList(
+      executorIdToFailureStatus: mutable.HashMap[String, FailureStatus],
+      clock: Clock): Boolean = {
+    val now = clock.getTimeMillis()
+    val expiredKey = executorIdToFailureStatus.filter {
+      case (executorid, failureStatus) => {
+        (now - failureStatus.updatedTime) >= expireTimeInMilliseconds
+      }
+    }.keySet
+
+    if (expiredKey.isEmpty) {
+      false
+    } else {
+      executorIdToFailureStatus --= expiredKey
+      true
+    }
+  }
+}
+
+/**
+ * This strategy adds an executor to the blacklist for all tasks when the executor has too many
+ * task failures. An executor is placed in the blacklist when there are more than
+ * [[maxFailedTasks]] failed tasks. Furthermore, all executors in one node are put into the
+ * blacklist if there are more than [[maxBlacklistedExecutors]] blacklisted executors on one node.
+ * The benefit of this strategy is that different taskSets can learn experience from other taskSet
+ * to avoid allocating tasks on problematic executors.
+ */
+private[scheduler] class ExecutorAndNodeStrategy(
+    maxFailedTasks: Int,
+    maxBlacklistedExecutors: Int,
+    val expireTimeInMilliseconds: Long
+  ) extends BlacklistStrategy {
+
+  private def getExecutorBlacklistInfo(
+      executorIdToFailureStatus: mutable.HashMap[String, FailureStatus]) = {
+    executorIdToFailureStatus.filter{
+      case (id, failureStatus) => failureStatus.totalNumFailures > maxFailedTasks
+    }
+  }
+
+  // As this is a task unrelated strategy, the input StageAndPartition info will be ignored
+  def getExecutorBlacklist(
+      executorIdToFailureStatus: mutable.HashMap[String, FailureStatus],
+      atomTask: StageAndPartition,
+      clock: Clock): Set[String] = {
+    getExecutorBlacklistInfo(executorIdToFailureStatus).keys.toSet
+  }
+
+  def getNodeBlacklist(
+      executorIdToFailureStatus: mutable.HashMap[String, FailureStatus],
+      clock: Clock): Set[String] = {
+    getExecutorBlacklistInfo(executorIdToFailureStatus)
+      .groupBy{case (id, failureStatus) => failureStatus.host}
+      .filter {case (host, executorIdToFailureStatus) =>
+        executorIdToFailureStatus.size > maxBlacklistedExecutors}
+      .keys.toSet
+  }
+}
+
+/**
+ * This strategy is applied as default to keep the same semantics as original. It's an task
+ * related strategy. If an executor failed running "task A", then we think this executor is
+ * blacked for "task A". And we think the executor is still healthy for other task. node blacklist
+ * is always empty.
+ *
+ * It was the standard behavior before spark 1.6
+ */
+private[scheduler] class SingleTaskStrategy(
+    val expireTimeInMilliseconds: Long) extends BlacklistStrategy {
+  def getExecutorBlacklist(
+      executorIdToFailureStatus: mutable.HashMap[String, FailureStatus],
+      atomTask: StageAndPartition,
+      clock: Clock): Set[String] = {
+    executorIdToFailureStatus.filter{
+      case (_, failureStatus) => failureStatus.numFailuresPerTask.keySet.contains(atomTask) &&
+        clock.getTimeMillis() - failureStatus.updatedTime < expireTimeInMilliseconds
+    }.keys.toSet
+  }
+
+  def getNodeBlacklist(
+      executorIdToFailureStatus: mutable.HashMap[String, FailureStatus],
+      clock: Clock): Set[String] = Set.empty[String]
+}
+
+/**
+ * Support getNodeBlacklistForStage. With this strategy, once executor failed running a task, we
+ * put all executors on the same node into blacklist, so all tasks on the same stage will not be
+ * allocated to that node.
+ */
+private[scheduler] class AdvancedSingleTaskStrategy(
+    expireTimeInMilliseconds: Long) extends SingleTaskStrategy(expireTimeInMilliseconds) {
+
+  override def getNodeBlacklistForStage(
+      executorIdToFailureStatus: mutable.HashMap[String, FailureStatus],
+      stageId: Int,
+      clock: Clock): Set[String] = {
+    executorIdToFailureStatus.filter{
+      case (_, failureStatus) =>
+        failureStatus.numFailuresPerTask.keySet.map(_.stageId).contains(stageId) &&
+        clock.getTimeMillis() - failureStatus.updatedTime < expireTimeInMilliseconds
+    }.values.map(_.host).toSet
+  }
+}
+
+/**
+ * Create BlacklistStrategy instance according to SparkConf
+ */
+private[scheduler] object BlacklistStrategy {
+  def apply(sparkConf: SparkConf): BlacklistStrategy = {
+    val timeout = sparkConf.getTimeAsMs("spark.scheduler.blacklist.timeout",
+        sparkConf.getLong("spark.scheduler.executorTaskBlacklistTime", 0L).toString() + "ms")
+    sparkConf.get("spark.scheduler.blacklist.strategy", "singleTask") match {
+      case "singleTask" =>
+        new SingleTaskStrategy(timeout)
+      case "advancedSingleTask" =>
+        new AdvancedSingleTaskStrategy(timeout)
+      case "executorAndNode" =>
+        new ExecutorAndNodeStrategy(
+            sparkConf.getInt("spark.scheduler.blacklist.executorAndNode.maxFailedTasks", 3),
+            sparkConf.getInt(
+                "spark.scheduler.blacklist.executorAndNode.maxBlacklistedExecutors", 3),
+            timeout)
+      case unsupported =>
+        throw new IllegalArgumentException(s"No matching blacklist strategy for: $unsupported")
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
@@ -24,11 +24,10 @@ import scala.collection.mutable
 import org.apache.spark.SparkConf
 import org.apache.spark.Success
 import org.apache.spark.TaskEndReason
-import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.util.Clock
 import org.apache.spark.util.SystemClock
 import org.apache.spark.util.ThreadUtils
 import org.apache.spark.util.Utils
-import org.apache.spark.util.Clock
 
 /**
  * BlacklistTracker is design to track problematic executors and node on application level.

--- a/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/BlacklistTracker.scala
@@ -1,0 +1,287 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler
+
+import java.util.concurrent.TimeUnit
+
+import scala.collection.mutable
+
+import org.apache.spark.SparkConf
+import org.apache.spark.Success
+import org.apache.spark.TaskEndReason
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.util.SystemClock
+import org.apache.spark.util.ThreadUtils
+import org.apache.spark.util.Utils
+import org.apache.spark.util.Clock
+
+/**
+ * BlacklistTracker is design to track problematic executors and node on application level.
+ * It is shared by all TaskSet, so that once a new TaskSet coming, it could be benefit from
+ * previous experience of other TaskSet.
+ *
+ * Once task finished, the callback method in TaskSetManager should update
+ * executorIdToFailureStatus Map.
+ */
+private[spark] class BlacklistTracker(
+    sparkConf: SparkConf,
+    clock: Clock = new SystemClock()) extends BlacklistCache{
+  // maintain a ExecutorId --> FailureStatus HashMap
+  private val executorIdToFailureStatus: mutable.HashMap[String, FailureStatus] = mutable.HashMap()
+
+  // Apply Strategy pattern here to change different blacklist detection logic
+  private val strategy = BlacklistStrategy(sparkConf)
+
+  // A daemon thread to expire blacklist executor periodically
+  private val scheduler = ThreadUtils.newDaemonSingleThreadScheduledExecutor(
+      "spark-scheduler-blacklist-expire-timer")
+
+  private val recoverPeriod = sparkConf.getTimeAsSeconds(
+    "spark.scheduler.blacklist.recoverPeriod", "60s")
+
+  def start(): Unit = {
+    val scheduleTask = new Runnable() {
+      override def run(): Unit = {
+        Utils.logUncaughtExceptions(expireExecutorsInBlackList())
+      }
+    }
+    scheduler.scheduleAtFixedRate(scheduleTask, 0L, recoverPeriod, TimeUnit.SECONDS)
+  }
+
+  def stop(): Unit = {
+    scheduler.shutdown()
+    scheduler.awaitTermination(10, TimeUnit.SECONDS)
+  }
+
+  // The actual implementation is delegated to strategy
+  /** VisibleForTesting */
+  private[scheduler] def expireExecutorsInBlackList(): Unit = synchronized {
+    val updated = strategy.expireExecutorsInBlackList(executorIdToFailureStatus, clock)
+    if (updated) {
+      invalidateCache()
+    }
+  }
+
+  def updateFailedExecutors(
+      stageId: Int,
+      partation: Int,
+      info: TaskInfo,
+      reason: TaskEndReason) : Unit = synchronized {
+
+    val atomTask = StageAndPartition(stageId, partation)
+    reason match {
+      // If the task succeeded, remove related record from executorIdToFailureStatus
+      case Success =>
+        removeFailedExecutorsForTaskId(info.executorId, stageId, partation)
+
+      // If the task failed, update latest failure time and failedTaskIds
+      case _ =>
+        val executorId = info.executorId
+        executorIdToFailureStatus.get(executorId) match {
+          case Some(failureStatus) =>
+            failureStatus.updatedTime = clock.getTimeMillis()
+            val failedTimes = failureStatus.numFailuresPerTask.getOrElse(atomTask, 0) + 1
+            failureStatus.numFailuresPerTask(atomTask) = failedTimes
+          case None =>
+            val failedTasks = mutable.HashMap(atomTask -> 1)
+            val failureStatus = new FailureStatus(
+              clock.getTimeMillis(), info.host, failedTasks)
+            executorIdToFailureStatus(executorId) = failureStatus
+        }
+        invalidateCache()
+    }
+  }
+
+  /** remove the executorId from executorIdToFailureStatus */
+  def removeFailedExecutors(executorId: String) : Unit = synchronized {
+    executorIdToFailureStatus.remove(executorId)
+    invalidateCache()
+  }
+
+  /**
+   * remove the failure record related to given taskId from executorIdToFailureStatus. If the
+   * number of records of given executorId becomes 0, remove the completed executorId.
+   */
+  def removeFailedExecutorsForTaskId(
+      executorId: String,
+      stageId: Int,
+      partation: Int) : Unit = synchronized {
+    val atomTask = StageAndPartition(stageId, partation)
+    executorIdToFailureStatus.get(executorId).map{ fs =>
+      fs.numFailuresPerTask.remove(atomTask)
+      if (fs.numFailuresPerTask.isEmpty) {
+        executorIdToFailureStatus.remove(executorId)
+      }
+      invalidateCache()
+    }
+  }
+
+  def isExecutorBlacklisted(
+      executorId: String,
+      sched: TaskSchedulerImpl,
+      stageId: Int,
+      partation: Int) : Boolean = {
+
+    executorBlacklist(sched, stageId, partation).contains(executorId)
+  }
+
+  // If the node is in blacklist, all executors allocated on that node will
+  // also be put into  executor blacklist.
+  private def executorsOnBlacklistedNode(
+      sched: TaskSchedulerImpl,
+      atomTask: StageAndPartition): Set[String] = {
+      nodeBlacklistForStage(atomTask.stageId).flatMap(sched.getExecutorsAliveOnHost(_)
+        .getOrElse(Set.empty[String])).toSet
+  }
+
+  def executorBlacklist(
+      sched: TaskSchedulerImpl, stageId: Int, partation: Int): Set[String] = synchronized {
+    val atomTask = StageAndPartition(stageId, partation)
+    if (!isBlacklistExecutorCacheValid) {
+      reEvaluateExecutorBlacklistAndUpdateCache(sched, atomTask, clock)
+    } else {
+      getExecutorBlacklistFromCache(atomTask).getOrElse {
+        reEvaluateExecutorBlacklistAndUpdateCache(sched, atomTask, clock)
+      }
+    }
+  }
+
+  private def reEvaluateExecutorBlacklistAndUpdateCache(
+      sched: TaskSchedulerImpl,
+      atomTask: StageAndPartition,
+      clock: Clock): Set[String] = {
+    val executors = executorsOnBlacklistedNode(sched, atomTask) ++
+      strategy.getExecutorBlacklist(executorIdToFailureStatus, atomTask, clock)
+    updateBlacklistExecutorCache(atomTask, executors)
+    executors
+  }
+
+  // The actual implementation is delegated to strategy
+  def nodeBlacklist(): Set[String] = synchronized {
+    if (isBlacklistNodeCacheValid) {
+      getNodeBlacklistFromCache
+    } else {
+      val nodes = strategy.getNodeBlacklist(executorIdToFailureStatus, clock)
+      updateBlacklistNodeCache(nodes)
+      nodes
+    }
+  }
+
+  // The actual implementation is delegated to strategy
+  def nodeBlacklistForStage(stageId: Int): Set[String] = synchronized {
+    if (isBlacklistNodeForStageCacheValid) {
+      getNodeBlacklistForStageFromCache(stageId).getOrElse(
+          reEvaluateNodeBlacklistForStageAndUpdateCache(stageId))
+    } else {
+      reEvaluateNodeBlacklistForStageAndUpdateCache(stageId)
+    }
+  }
+
+  private def reEvaluateNodeBlacklistForStageAndUpdateCache(stageId: Int): Set[String] = {
+    val nodes = strategy.getNodeBlacklistForStage(executorIdToFailureStatus, stageId, clock)
+    updateBlacklistNodeCache(nodes)
+    nodes
+  }
+}
+
+/**
+ * Hide cache details in this trait to make code clean and avoid operation mistake
+ */
+private[scheduler] trait BlacklistCache {
+
+  // local cache to minimize the the work when query blacklisted executor and node
+  private val blacklistExecutorCache = mutable.HashMap.empty[StageAndPartition, Set[String]]
+  private val blacklistNodeCache = mutable.Set.empty[String]
+  private val blacklistNodeForStageCache = mutable.HashMap.empty[Int, Set[String]]
+
+  // The flag to mark if cache is valid, it will be set to false when executorIdToFailureStatus be
+  // updated and it will be set to true, when called executorBlacklist and nodeBlacklist.
+  private var _isBlacklistExecutorCacheValid : Boolean = false
+  private var _isBlacklistNodeCacheValid: Boolean = false
+  private var _isBlacklistNodeForStageCacheValid: Boolean = false
+
+  private val cacheLock = new Object()
+
+  protected def isBlacklistExecutorCacheValid : Boolean = _isBlacklistExecutorCacheValid
+  protected def isBlacklistNodeCacheValid: Boolean = _isBlacklistNodeCacheValid
+  protected def isBlacklistNodeForStageCacheValid: Boolean = _isBlacklistNodeForStageCacheValid
+
+  protected def updateBlacklistExecutorCache(
+      atomTask: StageAndPartition,
+      blacklistExecutor: Set[String]): Unit = cacheLock.synchronized {
+    if (!_isBlacklistExecutorCacheValid) {
+      blacklistExecutorCache.clear()
+    }
+    blacklistExecutorCache.update(atomTask, blacklistExecutor)
+    _isBlacklistExecutorCacheValid = true
+  }
+
+  protected def updateBlacklistNodeCache(
+      blacklistNode: Set[String]): Unit = cacheLock.synchronized {
+    if (!_isBlacklistNodeCacheValid) {
+      blacklistNodeCache.clear()
+    }
+    blacklistNodeCache ++= blacklistNode
+    _isBlacklistNodeCacheValid = true
+  }
+
+  protected def updateBlacklistNodeForStageCache(
+      stageId: Int,
+      blacklistNode: Set[String]): Unit = cacheLock.synchronized {
+    if (!_isBlacklistNodeForStageCacheValid) {
+      blacklistNodeForStageCache.clear()
+    }
+    blacklistNodeForStageCache.update(stageId, blacklistNode)
+    _isBlacklistNodeForStageCacheValid = true
+  }
+
+  protected def invalidateCache(): Unit = cacheLock.synchronized {
+    _isBlacklistExecutorCacheValid = false
+    _isBlacklistNodeCacheValid = false
+    _isBlacklistNodeForStageCacheValid = false
+  }
+
+  protected def getExecutorBlacklistFromCache(
+      atomTask: StageAndPartition): Option[Set[String]] = {
+    blacklistExecutorCache.get(atomTask)
+  }
+
+  protected def getNodeBlacklistFromCache: Set[String] = blacklistNodeCache.toSet
+
+  protected def getNodeBlacklistForStageFromCache(stageId: Int): Option[Set[String]] =
+    blacklistNodeForStageCache.get(stageId)
+}
+
+/**
+ * A class to record details of failure.
+ *
+ * @param initialTime the time when failure status be created
+ * @param host the node name which running executor on
+ * @param numFailuresPerTask all tasks failed on the executor (key is StageAndPartition, value
+ *        is the number of failures of this task)
+ */
+private[scheduler] final class FailureStatus(
+    initialTime: Long,
+    val host: String,
+    val numFailuresPerTask: mutable.HashMap[StageAndPartition, Int]) {
+
+  var updatedTime = initialTime
+  def totalNumFailures : Int = numFailuresPerTask.values.sum
+}
+
+private[scheduler] case class StageAndPartition(val stageId: Int, val partation: Int)

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala
@@ -92,7 +92,8 @@ private[spark] object CoarseGrainedClusterMessages {
   case class RequestExecutors(
       requestedTotal: Int,
       localityAwareTasks: Int,
-      hostToLocalTaskCount: Map[String, Int])
+      hostToLocalTaskCount: Map[String, Int],
+      nodeBlacklist: Set[String])
     extends CoarseGrainedClusterMessage
 
   // Check if an executor was force-killed but for a reason unrelated to the running tasks.

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -268,6 +268,9 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
             SparkListenerExecutorRemoved(System.currentTimeMillis(), executorId, reason.toString))
         case None => logInfo(s"Asked to remove non-existent executor $executorId")
       }
+
+      // Remove disconnected executor from blacklistTracker to keep consistency
+      scheduler.sc.blacklistTracker.foreach(_.removeFailedExecutors(executorId))
     }
 
     /**

--- a/core/src/test/scala/org/apache/spark/HeartbeatReceiverSuite.scala
+++ b/core/src/test/scala/org/apache/spark/HeartbeatReceiverSuite.scala
@@ -268,7 +268,7 @@ private class FakeSchedulerBackend(
 
   protected override def doRequestTotalExecutors(requestedTotal: Int): Boolean = {
     clusterManagerEndpoint.askWithRetry[Boolean](
-      RequestExecutors(requestedTotal, localityAwareTasks, hostToLocalTaskCount))
+      RequestExecutors(requestedTotal, localityAwareTasks, hostToLocalTaskCount, Set.empty[String]))
   }
 
   protected override def doKillExecutors(executorIds: Seq[String]): Boolean = {
@@ -287,7 +287,7 @@ private class FakeClusterManager(override val rpcEnv: RpcEnv) extends RpcEndpoin
   def getExecutorIdsToKill: Set[String] = executorIdsToKill.toSet
 
   override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
-    case RequestExecutors(requestedTotal, _, _) =>
+    case RequestExecutors(requestedTotal, _, _, _) =>
       targetNumExecutors = requestedTotal
       context.reply(true)
     case KillExecutors(executorIds) =>

--- a/core/src/test/scala/org/apache/spark/scheduler/BlacklistTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BlacklistTrackerSuite.scala
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler
+
+import org.scalatest.BeforeAndAfter
+import org.scalatest.mock.MockitoSugar
+
+import org.mockito.Mockito.when
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.SparkConf
+import org.apache.spark.TaskEndReason
+import org.apache.spark.Success
+import org.apache.spark.ExceptionFailure
+import org.apache.spark.SparkContext
+import org.apache.spark.util.ManualClock
+
+class BlacklistTrackerSuite extends SparkFunSuite with BeforeAndAfter with MockitoSugar {
+
+  val FAILURE: TaskEndReason = new ExceptionFailure(
+      "Fake",
+      "fake failure",
+      Array.empty[StackTraceElement],
+      "fake stack trace",
+      None,
+      None)
+
+  val stage1 = 1
+  val stage2 = 2
+
+  val partation1 = 1
+  val partation2 = 2
+  val partation3 = 3
+
+  // Variable name can indicate basic information of taskInfo
+  // The format is "taskInfo_executorId_hostName"
+  val taskInfo_1_hostA = new TaskInfo(1L, 1, 1, 0L, "1", "hostA", TaskLocality.ANY, false)
+  val taskInfo_2_hostA = new TaskInfo(2L, 1, 1, 0L, "2", "hostA", TaskLocality.ANY, false)
+  val taskInfo_3_hostB = new TaskInfo(3L, 3, 1, 0L, "3", "hostB", TaskLocality.ANY, false)
+
+  val clock = new ManualClock(0)
+
+  test ("expireExecutorsInBlacklist works") {
+    // expire time is set to 6s
+    val conf = new SparkConf().setAppName("test").setMaster("local")
+      .set("spark.ui.enabled", "false")
+      .set("spark.scheduler.executorTaskBlacklistTime", "6000")
+
+    val scheduler = mock[TaskSchedulerImpl]
+
+    val tracker = new BlacklistTracker(conf, clock)
+    // Executor 1 into blacklist at Time 00:00:00
+    tracker.updateFailedExecutors(stage1, partation1, taskInfo_1_hostA, FAILURE)
+    assert(tracker.executorBlacklist(scheduler, stage1, 1) === Set("1"))
+
+    clock.setTime(2000)
+    tracker.expireExecutorsInBlackList()
+    assert(tracker.executorBlacklist(scheduler, stage1, 1) === Set("1"))
+    // Executor 1 failed again at Time 00::00:02
+    tracker.updateFailedExecutors(stage1, partation1, taskInfo_1_hostA, FAILURE)
+
+    clock.setTime(3000)
+    // Executor 2 failed at Time 00:00:03
+    tracker.updateFailedExecutors(stage1, partation1, taskInfo_2_hostA, FAILURE)
+    assert(tracker.executorBlacklist(scheduler, stage1, 1) === Set("1", "2"))
+
+    clock.setTime(6000)
+    tracker.expireExecutorsInBlackList()
+    assert(tracker.executorBlacklist(scheduler, stage1, 1) === Set("1", "2"))
+
+    clock.setTime(8000)
+    tracker.expireExecutorsInBlackList()
+    assert(tracker.executorBlacklist(scheduler, stage1, 1) === Set("2"))
+
+    clock.setTime(10000)
+    tracker.expireExecutorsInBlackList()
+    assert(tracker.executorBlacklist(scheduler, stage1, 1) === Set())
+  }
+
+  test("blacklist feature is off by default") {
+    val conf = new SparkConf().setAppName("test").setMaster("local")
+      .set("spark.ui.enabled", "false")
+    val scheduler = mock[TaskSchedulerImpl]
+
+    val tracker = new BlacklistTracker(conf, clock)
+    tracker.updateFailedExecutors(stage1, partation1, taskInfo_1_hostA, FAILURE)
+    tracker.updateFailedExecutors(stage1, partation1, taskInfo_2_hostA, FAILURE)
+    assert(tracker.executorBlacklist(scheduler, stage1, 1) === Set())
+    assert(tracker.executorBlacklist(scheduler, stage1, 1) === Set())
+
+    tracker.updateFailedExecutors(stage1, partation3, taskInfo_3_hostB, FAILURE)
+    assert(tracker.executorBlacklist(scheduler, stage1, 3) === Set())
+    assert(tracker.nodeBlacklist() === Set())
+  }
+
+  test("SingleTask strategy works") {
+    val conf = new SparkConf().setAppName("test").setMaster("local")
+      .set("spark.ui.enabled", "false")
+      .set("spark.scheduler.executorTaskBlacklistTime", "1000")
+    val scheduler = mock[TaskSchedulerImpl]
+
+    // Task 1 failed on both executor 1 and executor 2
+    val tracker = new BlacklistTracker(conf, clock)
+    tracker.updateFailedExecutors(stage1, partation1, taskInfo_1_hostA, FAILURE)
+    tracker.updateFailedExecutors(stage1, partation1, taskInfo_2_hostA, FAILURE)
+    assert(tracker.executorBlacklist(scheduler, stage1, 1) === Set("1", "2"))
+    assert(tracker.executorBlacklist(scheduler, stage1, 2) === Set())
+
+    // Task 1 succeeded on executor 1, so we remove executor 1 from blacklist
+    tracker.updateFailedExecutors(stage1, partation1, taskInfo_1_hostA, Success)
+    assert(tracker.executorBlacklist(scheduler, stage1, 1) === Set("2"))
+    assert(tracker.nodeBlacklist() === Set())
+
+    // Task 2 succeed on executor 3, no effect on blacklist for Task 1
+    tracker.updateFailedExecutors(stage1, partation3, taskInfo_3_hostB, Success)
+    assert(tracker.executorBlacklist(scheduler, stage1, 1) === Set("2"))
+
+    tracker.updateFailedExecutors(stage1, partation3, taskInfo_3_hostB, FAILURE)
+    assert(tracker.executorBlacklist(scheduler, stage1, 3) === Set("3"))
+    assert(tracker.nodeBlacklist() === Set())
+
+    tracker.updateFailedExecutors(stage1, partation1, taskInfo_2_hostA, Success)
+    assert(tracker.executorBlacklist(scheduler, stage1, 1) === Set())
+
+    // Task 2 on Stage 2 failed on Executor 2
+    tracker.updateFailedExecutors(stage2, partation2, taskInfo_2_hostA, FAILURE)
+    assert(tracker.executorBlacklist(scheduler, stage1, 1) === Set())
+    assert(tracker.executorBlacklist(scheduler, stage2, 1) === Set())
+    assert(tracker.executorBlacklist(scheduler, stage1, 2) === Set())
+    assert(tracker.executorBlacklist(scheduler, stage2, 2) === Set("2"))
+  }
+
+  test("AdvencedSingleTask strategy works") {
+    val conf = new SparkConf().setAppName("test").setMaster("local")
+      .set("spark.ui.enabled", "false")
+      .set("spark.scheduler.blacklist.strategy", "advancedSingleTask")
+      .set("spark.scheduler.executorTaskBlacklistTime", "1000")
+    val scheduler = mock[TaskSchedulerImpl]
+    when(scheduler.getExecutorsAliveOnHost("hostA")).thenReturn(Some(Set("1", "2", "4")))
+
+    // Task 1 failed on both executor 1
+    val tracker = new BlacklistTracker(conf, clock)
+    tracker.updateFailedExecutors(stage1, partation1, taskInfo_1_hostA, FAILURE)
+    assert(tracker.executorBlacklist(scheduler, stage1, 1) === Set("1", "2", "4"))
+    assert(tracker.executorBlacklist(scheduler, stage1, 2) === Set("1", "2", "4"))
+    assert(tracker.executorBlacklist(scheduler, stage2, 1) === Set())
+    assert(tracker.nodeBlacklistForStage(stage1) === Set("hostA"))
+    assert(tracker.nodeBlacklistForStage(stage2) === Set())
+
+    // Task 1 succeeded on executor 1, so we remove executor 1 from blacklist
+    tracker.updateFailedExecutors(stage1, partation1, taskInfo_1_hostA, Success)
+    assert(tracker.executorBlacklist(scheduler, stage1, 1) === Set())
+    assert(tracker.nodeBlacklistForStage(stage1) === Set())
+    assert(tracker.nodeBlacklist() === Set())
+  }
+
+  test ("ExecutorAndNode strategy works") {
+    val conf = new SparkConf().setAppName("test").setMaster("local")
+      .set("spark.ui.enabled", "false")
+      .set("spark.scheduler.blacklist.strategy", "executorAndNode")
+      .set("spark.scheduler.blacklist.executorAndNode.maxFailedTasks", "1")
+      .set("spark.scheduler.blacklist.executorAndNode.maxBlacklistedExecutors", "1")
+
+    val scheduler = mock[TaskSchedulerImpl]
+    when(scheduler.getExecutorsAliveOnHost("hostA")).thenReturn(Some(Set("1", "2", "4")))
+
+    val tracker = new BlacklistTracker(conf, clock)
+    // Task 1 failed on Executor 1
+    tracker.updateFailedExecutors(stage1, partation1, taskInfo_1_hostA, FAILURE)
+    assert(tracker.executorBlacklist(scheduler, stage1, 1) === Set())
+    // Task 2 failed on Executor 1
+    tracker.updateFailedExecutors(stage1, partation2, taskInfo_1_hostA, FAILURE)
+    // Executor 1 is now blacklisted from "all" tasks
+    (0 until 10).foreach { i =>
+      assert(tracker.executorBlacklist(scheduler, stage1, i) === Set("1"))
+    }
+    assert(tracker.nodeBlacklist() === Set())
+
+    // Task 1 and Task 2 failed on Executor 2
+    tracker.updateFailedExecutors(stage1, partation1, taskInfo_2_hostA, FAILURE)
+    tracker.updateFailedExecutors(stage1, partation2, taskInfo_2_hostA, FAILURE)
+    // Executor 2 is blacklisted, which leads to the node getting blaclisted so Executor 4 is
+    // blacklisted as well
+    assert(tracker.executorBlacklist(scheduler, stage1, 2) === Set("1", "2", "4"))
+    assert(tracker.nodeBlacklist() === Set("hostA"))
+
+    // Task 1 succeeded on Executor 1
+    tracker.updateFailedExecutors(stage1, partation1, taskInfo_1_hostA, Success)
+    assert(tracker.executorBlacklist(scheduler, stage1, 2) === Set("2"))
+    assert(tracker.nodeBlacklist() === Set())
+
+    // Task 2 succeeded on Executor 2
+    tracker.updateFailedExecutors(stage1, partation2, taskInfo_2_hostA, Success)
+    assert(tracker.executorBlacklist(scheduler, stage1, 1) === Set())
+
+    // Task 2 on Stage 2 failed on Executor 2
+    tracker.updateFailedExecutors(stage2, partation2, taskInfo_2_hostA, FAILURE)
+    assert(tracker.executorBlacklist(scheduler, stage1, 1) === Set("2"))
+    assert(tracker.executorBlacklist(scheduler, stage2, 1) === Set("2"))
+    assert(tracker.executorBlacklist(scheduler, stage1, 2) === Set("2"))
+    assert(tracker.executorBlacklist(scheduler, stage2, 2) === Set("2"))
+  }
+
+  test ("unsupported strategy throws helpful exception") {
+    val ex = intercept[Exception]{
+      val conf = new SparkConf().setAppName("test").setMaster("local")
+        .set("spark.ui.enabled", "false")
+        .set("spark.scheduler.blacklist.strategy", "FAKE")
+      BlacklistStrategy(conf)
+    }
+    assert(ex.getMessage === "No matching blacklist strategy for: FAKE")
+  }
+}

--- a/core/src/test/scala/org/apache/spark/scheduler/BlacklistTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/BlacklistTrackerSuite.scala
@@ -17,17 +17,15 @@
 
 package org.apache.spark.scheduler
 
+import org.mockito.Mockito.when
 import org.scalatest.BeforeAndAfter
 import org.scalatest.mock.MockitoSugar
 
-import org.mockito.Mockito.when
-
-import org.apache.spark.SparkFunSuite
-import org.apache.spark.SparkConf
-import org.apache.spark.TaskEndReason
-import org.apache.spark.Success
 import org.apache.spark.ExceptionFailure
-import org.apache.spark.SparkContext
+import org.apache.spark.SparkConf
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.Success
+import org.apache.spark.TaskEndReason
 import org.apache.spark.util.ManualClock
 
 class BlacklistTrackerSuite extends SparkFunSuite with BeforeAndAfter with MockitoSugar {

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -406,7 +406,11 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
     // affinity to exec1 on host1 - which we will fail.
     val taskSet = FakeTask.createTaskSet(1, Seq(TaskLocation("host1", "exec1")))
     val clock = new ManualClock
+
+    // spy taskSetManager to set Manual clock for BlacklistTracker
     val manager = new TaskSetManager(sched, taskSet, 4, clock)
+    val tracker = new BlacklistTracker(conf, clock)
+    manager.setBlacklistTracker(tracker)
 
     {
       val offerResult = manager.resourceOffer("exec1", "host1", PROCESS_LOCAL)
@@ -461,6 +465,7 @@ class TaskSetManagerSuite extends SparkFunSuite with LocalSparkContext with Logg
 
     // After reschedule delay, scheduling on exec1 should be possible.
     clock.advance(rescheduleDelay)
+    tracker.expireExecutorsInBlackList()
 
     {
       val offerResult = manager.resourceOffer("exec1", "host1", PROCESS_LOCAL)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1145,24 +1145,10 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
-  <td><code>spark.scheduler.blacklist.strategy</code></td>
-  <td>singleTask</td>
+  <td><code>spark.scheduler.blacklist.advancedStrategy</code></td>
+  <td>false</td>
   <td>
-    The strategy to determine executor blacklist and node blacklist. There are "singleTask" strategy which is the srandard behavior before spark 1.6 and "executorAndNode" strategy which is taskId unrelated and can learn experience from other taskSet to avoid allocating tasks on problematic executors.
-  </td>
-</tr>
-<tr>
-  <td><code>spark.scheduler.blacklist.executorAndNode.maxFailedTasks</code></td>
-  <td>3</td>
-  <td>
-    It is used in "executorAndNode" blacklist strategy. If failure task number is more than maxFailedTasks on same executor, then the executor will be in blacklist
-  </td>
-</tr>
-<tr>
-  <td><code>spark.scheduler.blacklist.executorAndNode.maxBlacklistedExecutors</code></td>
-  <td>3</td>
-  <td>
-    It is used in "executorAndNode" blacklist strategy. If failure executor number is more than maxBlacklistedExecutors on same node, then the node will be in blacklist
+    set to tree to enable experimental advanced blacklist strategy. Comparing with the standard behavior before spark 1.6, it enables blacklist on node level.
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1124,6 +1124,48 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+  <td><code>spark.scheduler.blacklist.enabled</code></td>
+  <td>true</td>
+  <td>
+    If set to "true", prevent Spark from scheduling tasks on executors that have been blacklisted due to too many task failures. The blacklisting algorithm can be further controlled by the other "spark.scheduler.blacklist" configuration options.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.scheduler.blacklist.timeout</code></td>
+  <td>0s</td>
+  <td>
+    If executor blacklisting is enabled, this controls how long an executor remains in the blacklist before it is returned to the pool of available executors.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.scheduler.blacklist.recoverPeriod</code></td>
+  <td>60s</td>
+  <td>
+    If executor blacklisting is enabled, this controls how often to check if executors can be returned to the pool of active executors.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.scheduler.blacklist.strategy</code></td>
+  <td>singleTask</td>
+  <td>
+    The strategy to determine executor blacklist and node blacklist. There are "singleTask" strategy which is the srandard behavior before spark 1.6 and "executorAndNode" strategy which is taskId unrelated and can learn experience from other taskSet to avoid allocating tasks on problematic executors.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.scheduler.blacklist.executorAndNode.maxFailedTasks</code></td>
+  <td>3</td>
+  <td>
+    It is used in "executorAndNode" blacklist strategy. If failure task number is more than maxFailedTasks on same executor, then the executor will be in blacklist
+  </td>
+</tr>
+<tr>
+  <td><code>spark.scheduler.blacklist.executorAndNode.maxBlacklistedExecutors</code></td>
+  <td>3</td>
+  <td>
+    It is used in "executorAndNode" blacklist strategy. If failure executor number is more than maxBlacklistedExecutors on same node, then the node will be in blacklist
+  </td>
+</tr>
+<tr>
   <td><code>spark.speculation</code></td>
   <td>false</td>
   <td>

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -598,11 +598,12 @@ private[spark] class ApplicationMaster(
     }
 
     override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
-      case RequestExecutors(requestedTotal, localityAwareTasks, hostToLocalTaskCount) =>
+      case RequestExecutors(
+          requestedTotal, localityAwareTasks, hostToLocalTaskCount, nodeBlacklist) =>
         Option(allocator) match {
           case Some(a) =>
             if (a.requestTotalExecutorsWithPreferredLocalities(requestedTotal,
-              localityAwareTasks, hostToLocalTaskCount)) {
+              localityAwareTasks, hostToLocalTaskCount, nodeBlacklist)) {
               resetAllocatorInterval()
             }
             context.reply(true)

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -21,7 +21,6 @@ import java.util.Collections
 import java.util.concurrent._
 import java.util.regex.Pattern
 
-import scala.collection.immutable.Set
 import scala.collection.mutable
 import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet}
 import scala.collection.JavaConverters._

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -21,6 +21,7 @@ import java.util.Collections
 import java.util.concurrent._
 import java.util.regex.Pattern
 
+import scala.collection.immutable.Set
 import scala.collection.mutable
 import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet}
 import scala.collection.JavaConverters._
@@ -87,6 +88,8 @@ private[yarn] class YarnAllocator(
 
   @volatile private var targetNumExecutors =
     YarnSparkHadoopUtil.getInitialTargetExecutorNumber(sparkConf)
+
+  private var currentNodeBlacklist = Set.empty[String]
 
   // Executor loss reason requests that are pending - maps from executor ID for inquiry to a
   // list of requesters that should be responded to once we find out why the given executor
@@ -176,18 +179,28 @@ private[yarn] class YarnAllocator(
    * @param localityAwareTasks number of locality aware tasks to be used as container placement hint
    * @param hostToLocalTaskCount a map of preferred hostname to possible task counts to be used as
    *                             container placement hint.
+   * @param nodeBlacklist a set of blacklisted node to avoid allocating new container on them. It
+   *                              will be used to update AM blacklist.
    * @return Whether the new requested total is different than the old value.
    */
   def requestTotalExecutorsWithPreferredLocalities(
       requestedTotal: Int,
       localityAwareTasks: Int,
-      hostToLocalTaskCount: Map[String, Int]): Boolean = synchronized {
+      hostToLocalTaskCount: Map[String, Int],
+      nodeBlacklist: Set[String]): Boolean = synchronized {
     this.numLocalityAwareTasks = localityAwareTasks
     this.hostToLocalTaskCounts = hostToLocalTaskCount
 
     if (requestedTotal != targetNumExecutors) {
       logInfo(s"Driver requested a total number of $requestedTotal executor(s).")
       targetNumExecutors = requestedTotal
+
+      // Update blacklist infomation to YARN ResouceManager for this application,
+      // in order to avoid allocating new Container on the problematic nodes.
+      val blacklistAdditions = nodeBlacklist -- currentNodeBlacklist
+      val blacklistRemovals = currentNodeBlacklist -- nodeBlacklist
+      amClient.updateBlacklist(blacklistAdditions.toList.asJava, blacklistRemovals.toList.asJava)
+      currentNodeBlacklist = nodeBlacklist
       true
     } else {
       false

--- a/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
+++ b/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
@@ -117,8 +117,12 @@ private[spark] abstract class YarnSchedulerBackend(
    * This includes executors already pending or running.
    */
   override def doRequestTotalExecutors(requestedTotal: Int): Boolean = {
+
+    val nodeBlacklist: Set[String] = scheduler.sc.blacklistTracker
+      .map(_.nodeBlacklist()).getOrElse(Set.empty[String])
+
     yarnSchedulerEndpointRef.askWithRetry[Boolean](
-      RequestExecutors(requestedTotal, localityAwareTasks, hostToLocalTaskCount))
+      RequestExecutors(requestedTotal, localityAwareTasks, hostToLocalTaskCount, nodeBlacklist))
   }
 
   /**

--- a/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
+++ b/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
@@ -178,7 +178,7 @@ class YarnAllocatorSuite extends SparkFunSuite with Matchers with BeforeAndAfter
     handler.getNumExecutorsRunning should be (0)
     handler.getPendingAllocate.size should be (4)
 
-    handler.requestTotalExecutorsWithPreferredLocalities(3, 0, Map.empty)
+    handler.requestTotalExecutorsWithPreferredLocalities(3, 0, Map.empty, Set.empty)
     handler.updateResourceRequests()
     handler.getPendingAllocate.size should be (3)
 
@@ -189,7 +189,7 @@ class YarnAllocatorSuite extends SparkFunSuite with Matchers with BeforeAndAfter
     handler.allocatedContainerToHostMap.get(container.getId).get should be ("host1")
     handler.allocatedHostToContainersMap.get("host1").get should contain (container.getId)
 
-    handler.requestTotalExecutorsWithPreferredLocalities(2, 0, Map.empty)
+    handler.requestTotalExecutorsWithPreferredLocalities(2, 0, Map.empty, Set.empty)
     handler.updateResourceRequests()
     handler.getPendingAllocate.size should be (1)
   }
@@ -200,7 +200,7 @@ class YarnAllocatorSuite extends SparkFunSuite with Matchers with BeforeAndAfter
     handler.getNumExecutorsRunning should be (0)
     handler.getPendingAllocate.size should be (4)
 
-    handler.requestTotalExecutorsWithPreferredLocalities(3, 0, Map.empty)
+    handler.requestTotalExecutorsWithPreferredLocalities(3, 0, Map.empty, Set.empty)
     handler.updateResourceRequests()
     handler.getPendingAllocate.size should be (3)
 
@@ -210,7 +210,7 @@ class YarnAllocatorSuite extends SparkFunSuite with Matchers with BeforeAndAfter
 
     handler.getNumExecutorsRunning should be (2)
 
-    handler.requestTotalExecutorsWithPreferredLocalities(1, 0, Map.empty)
+    handler.requestTotalExecutorsWithPreferredLocalities(1, 0, Map.empty, Set.empty)
     handler.updateResourceRequests()
     handler.getPendingAllocate.size should be (0)
     handler.getNumExecutorsRunning should be (2)
@@ -226,7 +226,7 @@ class YarnAllocatorSuite extends SparkFunSuite with Matchers with BeforeAndAfter
     val container2 = createContainer("host2")
     handler.handleAllocatedContainers(Array(container1, container2))
 
-    handler.requestTotalExecutorsWithPreferredLocalities(1, 0, Map.empty)
+    handler.requestTotalExecutorsWithPreferredLocalities(1, 0, Map.empty, Set.empty)
     handler.executorIdToContainer.keys.foreach { id => handler.killExecutor(id ) }
 
     val statuses = Seq(container1, container2).map { c =>
@@ -248,7 +248,7 @@ class YarnAllocatorSuite extends SparkFunSuite with Matchers with BeforeAndAfter
     val container2 = createContainer("host2")
     handler.handleAllocatedContainers(Array(container1, container2))
 
-    handler.requestTotalExecutorsWithPreferredLocalities(2, 0, Map())
+    handler.requestTotalExecutorsWithPreferredLocalities(2, 0, Map(), Set.empty)
 
     val statuses = Seq(container1, container2).map { c =>
       ContainerStatus.newInstance(c.getId(), ContainerState.COMPLETE, "Failed", -1)


### PR DESCRIPTION
1. add a global BlacklistTracker which is able to share blacklisted executors information across TaskSetManager. Different BlacklistStrategy could be applied to determine which executors should be put in blacklist. And it's convenient to add new strategy later according to current design.
2. remove duplicate "failedExecutors" list in TaskSetManager and make BlacklistTracker being the only interface for blacklist mechanism in codebase which is logically cleaner.
3. for backward compatibility, implement DefaultStrategy to keep the same semantics as current by default 
4. apply BlacklistTracker in YARN to avoid allocating new executors on blacklisted node, the blacklisted node information will be passed to YARN ResourceManager. it affects in dynamic allocation mode.
