### PR TITLE
SPARK-10614 SystemClock uses non-monotonic time in its wait logic. Th…

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -26,7 +26,7 @@ import com.codahale.metrics.{Gauge, MetricRegistry}
 
 import org.apache.spark.scheduler._
 import org.apache.spark.metrics.source.Source
-import org.apache.spark.util.{ThreadUtils, Clock, SystemClock, Utils}
+import org.apache.spark.util.{MonotonicClock, ThreadUtils, Clock}
 
 /**
  * An agent that dynamically allocates and removes executors based on the workload.
@@ -142,7 +142,7 @@ private[spark] class ExecutorAllocationManager(
   private val intervalMillis: Long = 100
 
   // Clock used to schedule when executors should be added and removed
-  private var clock: Clock = new SystemClock()
+  private var clock: Clock = new MonotonicClock()
 
   // Listener for Spark events that impact the allocation policy
   private val listener = new ExecutorAllocationListener

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -26,7 +26,7 @@ import com.codahale.metrics.{Gauge, MetricRegistry}
 
 import org.apache.spark.scheduler._
 import org.apache.spark.metrics.source.Source
-import org.apache.spark.util.{MonotonicClock, ThreadUtils, Clock}
+import org.apache.spark.util.{Clock, MonotonicClock, ThreadUtils}
 
 /**
  * An agent that dynamically allocates and removes executors based on the workload.

--- a/core/src/main/scala/org/apache/spark/util/Clock.scala
+++ b/core/src/main/scala/org/apache/spark/util/Clock.scala
@@ -22,9 +22,7 @@ package org.apache.spark.util
  */
 private[spark] trait Clock {
 
-  /**
-   * @return the time in milliseconds
-   */
+  /** @return the time in milliseconds */
   def getTimeMillis(): Long
 
   /**
@@ -64,7 +62,7 @@ private[spark] class SystemClock extends Clock {
     val pollTime = math.max(waitTime / 10.0, minPollTime).toLong
 
     while (true) {
-      currentTime = System.currentTimeMillis()
+      currentTime = getTimeMillis()
       waitTime = targetTime - currentTime
       if (waitTime <= 0) {
         return currentTime
@@ -72,7 +70,7 @@ private[spark] class SystemClock extends Clock {
       val sleepTime = math.min(waitTime, pollTime)
       Thread.sleep(sleepTime)
     }
-    -1
+    throw new Exception("waitTillTime reached code that should not be reachable")
   }
 }
 
@@ -82,11 +80,9 @@ private[spark] class SystemClock extends Clock {
  * initiated time shift)
  */
 private[spark] class MonotonicClock extends SystemClock {
-  /**
-   * @return the same time  in milliseconds
-   *         as is reported by `System.nanoTime()`
-   */
+
+  /** @return the same time in milliseconds as is reported by `System.nanoTime()` */
   override def getTimeMillis(): Long = {
-    (System.nanoTime() / (1000 * 1000))
+    System.nanoTime() / (1000 * 1000)
   }
 }


### PR DESCRIPTION
This patch adds a new subclass, `MonotonicClock`, and switches `ExecutorAllocationManager` to using it (it used to use `System.nanoTime()`).

A lot of the code which uses SystemClock would appear to benefit from moving to a monotonic clock —but that would a more significant piece of work, needing understanding of what's happening. Furthermore, some of the uses are of fields which may also be converted to human-formatted time; the nanotime clock shouldn't be used that way.
