### PR TITLE
[SPARK-10540] Fixes flaky all-data-type test

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/hadoopFsRelationSuites.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/hadoopFsRelationSuites.scala
@@ -114,8 +114,8 @@ abstract class HadoopFsRelationTest extends QueryTest with SQLTestUtils with Tes
     new MyDenseVectorUDT()
   ).filter(supportsDataType)
 
-  for (dataType <- supportedDataTypes) {
-    test(s"test all data types - $dataType") {
+  for (i <- 0 until 100; dataType <- supportedDataTypes) {
+    test(s"test all data types - $dataType - $i") {
       withTempPath { file =>
         val path = file.getCanonicalPath
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/hadoopFsRelationSuites.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/hadoopFsRelationSuites.scala
@@ -114,8 +114,8 @@ abstract class HadoopFsRelationTest extends QueryTest with SQLTestUtils with Tes
     new MyDenseVectorUDT()
   ).filter(supportsDataType)
 
-  for (i <- 0 until 100; dataType <- supportedDataTypes) {
-    test(s"test all data types - $dataType - $i") {
+  for (dataType <- supportedDataTypes) {
+    test(s"test all data types - $dataType") {
       withTempPath { file =>
         val path = file.getCanonicalPath
 


### PR DESCRIPTION
This PR breaks the original test case into multiple ones (one test case for each data type). In this way, test failure output can be much more readable.

Within each test case, we build a table with two columns, one of them is for the data type to test, the other is an "index" column, which is used to sort the DataFrame and workaround [SPARK-10591](https://issues.apache.org/jira/browse/SPARK-10591)
