### PR TITLE
[PySpark][MLlib][Docs] Replaced addversion with versionadded in mllib.random

### DIFF
--- a/python/pyspark/mllib/random.py
+++ b/python/pyspark/mllib/random.py
@@ -41,7 +41,7 @@ class RandomRDDs(object):
     Generator methods for creating RDDs comprised of i.i.d samples from
     some distribution.
 
-    .. addedversion:: 1.1.0
+    .. versionadded:: 1.1.0
     """
 
     @staticmethod


### PR DESCRIPTION
Missed this when reviewing `pyspark.mllib.random` for SPARK-10275.
