### PR TITLE
[SPARK-10649][STREAMING] Prevent inheriting job group and irrelevant job description in streaming jobs

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
@@ -88,15 +88,24 @@ private[spark] object ThreadUtils {
     Executors.newSingleThreadScheduledExecutor(threadFactory)
   }
 
+  /**
+   * Run a piece of code in a new thread, and the get result. Exception in the new thread is
+   * thrown in the caller thread with an adjusted stack trace that removes references to this
+   * method for clarity. The exception stack traces will be like the following
+   *
+   * SomeException: exception-message
+   *   at CallerClass.body-method (sourcefile.scala)
+	 *   at ... run in separate thread using org.apache.spark.util.ThreadUtils ... ()
+   *   at CallerClass.caller-method (sourcefile.scala)
+   *   ...
+   */
   def runInNewThread[T](
       threadName: String,
-      isDaemon: Boolean = true,
-      timeoutMillis: Long = 0)(body: => T): T = {
+      isDaemon: Boolean = true)(body: => T): T = {
     @volatile var exception: Option[Throwable] = None
     @volatile var result: T = null.asInstanceOf[T]
 
     val thread = new Thread(threadName) {
-
       override def run(): Unit = {
         try {
           result = body
@@ -108,18 +117,28 @@ private[spark] object ThreadUtils {
     }
     thread.setDaemon(isDaemon)
     thread.start()
-    thread.join(timeoutMillis)
+    thread.join()
 
     exception match {
       case Some(realException) =>
+        // Remove the part of the stack that shows method calls into this helper method
         val baseStackTrace = Thread.currentThread().getStackTrace().dropWhile(
           ! _.getClassName.contains(this.getClass.getSimpleName)).drop(1)
+
+        // Remove the part of the new thread stack that shows methods call from this helper method
         val extraStackTrace = realException.getStackTrace.takeWhile(
           ! _.getClassName.contains(this.getClass.getSimpleName))
+
+        // Combine the two stack traces, with a place holder just specifying that there
+        // was a helper method used, without any further details of the helper
         val placeHolderStackElem = new StackTraceElement(
-          s"... run in separate thread by ${ThreadUtils.getClass.getName} ..", " ", "", -1)
+          s"... run in separate thread using ${ThreadUtils.getClass.getName.stripSuffix("$")} ..",
+          " ", "", -1)
         val finalStackTrace = extraStackTrace ++ Seq(placeHolderStackElem) ++ baseStackTrace
+
+        // Update the stack trace and rethrow the exception in the caller thread
         realException.setStackTrace(finalStackTrace)
+        println(realException)
         throw realException
       case None =>
         result

--- a/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
@@ -95,7 +95,7 @@ private[spark] object ThreadUtils {
    *
    * SomeException: exception-message
    *   at CallerClass.body-method (sourcefile.scala)
-	 *   at ... run in separate thread using org.apache.spark.util.ThreadUtils ... ()
+   *   at ... run in separate thread using org.apache.spark.util.ThreadUtils ... ()
    *   at CallerClass.caller-method (sourcefile.scala)
    *   ...
    */
@@ -138,7 +138,6 @@ private[spark] object ThreadUtils {
 
         // Update the stack trace and rethrow the exception in the caller thread
         realException.setStackTrace(finalStackTrace)
-        println(realException)
         throw realException
       case None =>
         result

--- a/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
@@ -122,6 +122,8 @@ private[spark] object ThreadUtils {
     exception match {
       case Some(realException) =>
         // Remove the part of the stack that shows method calls into this helper method
+        // This means drop everything from the top until the stack element
+        // ThreadUtils.runInNewThread(), and then drop that as well (hence the `drop(1)`).
         val baseStackTrace = Thread.currentThread().getStackTrace().dropWhile(
           ! _.getClassName.contains(this.getClass.getSimpleName)).drop(1)
 

--- a/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/ThreadUtils.scala
@@ -89,7 +89,7 @@ private[spark] object ThreadUtils {
   }
 
   /**
-   * Run a piece of code in a new thread, and the get result. Exception in the new thread is
+   * Run a piece of code in a new thread and return the result. Exception in the new thread is
    * thrown in the caller thread with an adjusted stack trace that removes references to this
    * method for clarity. The exception stack traces will be like the following
    *

--- a/core/src/test/scala/org/apache/spark/util/ThreadUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/ThreadUtilsSuite.scala
@@ -20,8 +20,8 @@ package org.apache.spark.util
 
 import java.util.concurrent.{CountDownLatch, TimeUnit}
 
-import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
 
 import org.apache.spark.SparkFunSuite
 
@@ -65,5 +65,26 @@ class ThreadUtilsSuite extends SparkFunSuite {
     }(ThreadUtils.sameThread)
     val futureThreadName = Await.result(f, 10.seconds)
     assert(futureThreadName === callerThreadName)
+  }
+
+  test("runInNewThread") {
+    import ThreadUtils._
+    assert(runInNewThread("thread-name") { Thread.currentThread().getName } === "thread-name")
+    assert(runInNewThread("thread-name") { Thread.currentThread().isDaemon } === true)
+    assert(
+      runInNewThread("thread-name", isDaemon = false) { Thread.currentThread().isDaemon } === false
+    )
+    val exception = intercept[Exception] {
+      runInNewThread("thread-name") { throw new IllegalArgumentException("test") }
+    }
+    assert(exception.isInstanceOf[IllegalArgumentException])
+    assert(exception.asInstanceOf[IllegalArgumentException].getMessage.contains("test"))
+    assert(exception.getStackTrace.mkString("\n").contains(
+      "... run in separate thread by org.apache.spark.util.ThreadUtils$ ...") === true,
+      "stack trace does not contain expected place holder"
+    )
+    assert(exception.getStackTrace.mkString("\n").contains("ThreadUtils.scala") === false,
+      "stack trace contains unexpected references to ThreadUtils"
+    )
   }
 }

--- a/core/src/test/scala/org/apache/spark/util/ThreadUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/ThreadUtilsSuite.scala
@@ -74,10 +74,9 @@ class ThreadUtilsSuite extends SparkFunSuite {
     assert(
       runInNewThread("thread-name", isDaemon = false) { Thread.currentThread().isDaemon } === false
     )
-    val exception = intercept[Exception] {
+    val exception = intercept[IllegalArgumentException] {
       runInNewThread("thread-name") { throw new IllegalArgumentException("test") }
     }
-    assert(exception.isInstanceOf[IllegalArgumentException])
     assert(exception.asInstanceOf[IllegalArgumentException].getMessage.contains("test"))
     assert(exception.getStackTrace.mkString("\n").contains(
       "... run in separate thread using org.apache.spark.util.ThreadUtils ...") === true,

--- a/core/src/test/scala/org/apache/spark/util/ThreadUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/ThreadUtilsSuite.scala
@@ -80,7 +80,7 @@ class ThreadUtilsSuite extends SparkFunSuite {
     assert(exception.isInstanceOf[IllegalArgumentException])
     assert(exception.asInstanceOf[IllegalArgumentException].getMessage.contains("test"))
     assert(exception.getStackTrace.mkString("\n").contains(
-      "... run in separate thread by org.apache.spark.util.ThreadUtils$ ...") === true,
+      "... run in separate thread using org.apache.spark.util.ThreadUtils ...") === true,
       "stack trace does not contain expected place holder"
     )
     assert(exception.getStackTrace.mkString("\n").contains("ThreadUtils.scala") === false,

--- a/core/src/test/scala/org/apache/spark/util/ThreadUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/ThreadUtilsSuite.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.{CountDownLatch, TimeUnit}
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
+import scala.util.Random
 
 import org.apache.spark.SparkFunSuite
 
@@ -74,10 +75,11 @@ class ThreadUtilsSuite extends SparkFunSuite {
     assert(
       runInNewThread("thread-name", isDaemon = false) { Thread.currentThread().isDaemon } === false
     )
+    val uniqueExceptionMessage = "test" + Random.nextInt()
     val exception = intercept[IllegalArgumentException] {
-      runInNewThread("thread-name") { throw new IllegalArgumentException("test") }
+      runInNewThread("thread-name") { throw new IllegalArgumentException(uniqueExceptionMessage) }
     }
-    assert(exception.asInstanceOf[IllegalArgumentException].getMessage.contains("test"))
+    assert(exception.asInstanceOf[IllegalArgumentException].getMessage === uniqueExceptionMessage)
     assert(exception.getStackTrace.mkString("\n").contains(
       "... run in separate thread using org.apache.spark.util.ThreadUtils ...") === true,
       "stack trace does not contain expected place holder"

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -592,6 +592,10 @@ class StreamingContext private[streaming] (
           StreamingContext.assertNoOtherContextIsActive()
           try {
             validate()
+
+            // Start the streaming scheduler in a new thread, so that thread local properties
+            // like call sites and job groups can be reset without affecting those of the
+            // current thread.
             ThreadUtils.runInNewThread("streaming-start") {
               sparkContext.setCallSite(startSite.get)
               sparkContext.clearJobGroup()
@@ -614,7 +618,7 @@ class StreamingContext private[streaming] (
         assert(env.metricsSystem != null)
         env.metricsSystem.registerSource(streamingSource)
         uiTab.foreach(_.attach())
-        this.logInfo("StreamingContext started")
+        logInfo("StreamingContext started")
       case ACTIVE =>
         logWarning("StreamingContext has already been started")
       case STOPPED =>

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -594,8 +594,7 @@ class StreamingContext private[streaming] (
             validate()
             ThreadUtils.runInNewThread("streaming-start") {
               sparkContext.setCallSite(startSite.get)
-              sparkContext.setLocalProperty(SparkContext.SPARK_JOB_GROUP_ID, null)
-              sparkContext.setLocalProperty(SparkContext.SPARK_JOB_DESCRIPTION, null)
+              sparkContext.clearJobGroup()
               sparkContext.setLocalProperty(SparkContext.SPARK_JOB_INTERRUPT_ON_CANCEL, "false")
               scheduler.start()
             }

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -194,7 +194,6 @@ class StreamingContextSuite extends SparkFunSuite with BeforeAndAfter with Timeo
       jobGroupFound = sc.getLocalProperty(SparkContext.SPARK_JOB_GROUP_ID)
       jobDescFound = sc.getLocalProperty(SparkContext.SPARK_JOB_DESCRIPTION)
       jobInterruptFound = sc.getLocalProperty(SparkContext.SPARK_JOB_INTERRUPT_ON_CANCEL)
-      println("Found")
       allFound = true
     }
     ssc.start()

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -185,9 +185,9 @@ class StreamingContextSuite extends SparkFunSuite with BeforeAndAfter with Timeo
     ssc.sc.setJobGroup("non-streaming", "non-streaming", true)
     val sc = ssc.sc
 
-    @volatile var jobGroupFound: String = null
-    @volatile var jobDescFound: String = null
-    @volatile var jobInterruptFound: String = null
+    @volatile var jobGroupFound: String = ""
+    @volatile var jobDescFound: String = ""
+    @volatile var jobInterruptFound: String = ""
     @volatile var allFound: Boolean = false
 
     addInputStream(ssc).foreachRDD { rdd =>
@@ -203,8 +203,8 @@ class StreamingContextSuite extends SparkFunSuite with BeforeAndAfter with Timeo
     }
 
     // Verify streaming jobs have expected thread-local properties
-    assert(jobGroupFound === StreamingContext.STREAMING_JOB_GROUP_ID)
-    assert(jobDescFound === StreamingContext.STREAMING_JOB_DESCRIPTION)
+    assert(jobGroupFound === null)
+    assert(jobDescFound === null)
     assert(jobInterruptFound === "false")
 
     // Verify current thread's thread-local properties have not changed

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -180,7 +180,7 @@ class StreamingContextSuite extends SparkFunSuite with BeforeAndAfter with Timeo
     assert(ssc.scheduler.isStarted === false)
   }
 
-  test("start should set job group correctly") {
+  test("start should set job group and description of streaming jobs correctly") {
     ssc = new StreamingContext(conf, batchDuration)
     ssc.sc.setJobGroup("non-streaming", "non-streaming", true)
     val sc = ssc.sc
@@ -198,7 +198,7 @@ class StreamingContextSuite extends SparkFunSuite with BeforeAndAfter with Timeo
     }
     ssc.start()
 
-    eventually(timeout(5 seconds), interval(10 milliseconds)) {
+    eventually(timeout(10 seconds), interval(10 milliseconds)) {
       assert(allFound === true)
     }
 


### PR DESCRIPTION
The job group, and job descriptions information is passed through thread local properties, and get inherited by child threads. In case of spark streaming, the streaming jobs inherit these properties from the thread that called streamingContext.start(). This may not make sense. 
1. Job group: This is mainly used for cancelling a group of jobs together. It does not make sense to cancel streaming jobs like this, as the effect will be unpredictable. And its not a valid usecase any way, to cancel a streaming context, call streamingContext.stop()
2. Job description: This is used to pass on nice text descriptions for jobs to show up in the UI. The job description of the thread that calls streamingContext.start() is not useful for all the streaming jobs, as it does not make sense for all of the streaming jobs to have the same description, and the description may or may not be related to streaming.

The solution in this PR is meant for the Spark master branch, where local properties are inherited by cloning the properties. The job group and job description in the thread that starts the streaming scheduler are explicitly removed, so that all the subsequent child threads does not inherit them. Also, the starting is done in a new child thread, so that setting the job group and description for streaming, does not change those properties in the thread that called streamingContext.start(). 
