### PR TITLE
[SPARK-10474][SQL][WIP]Avoid eat out all of the offheap memory by UnsafeHashAggregation

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeFixedWidthAggregationMap.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeFixedWidthAggregationMap.java
@@ -126,6 +126,13 @@ public final class UnsafeFixedWidthAggregationMap {
     return getAggregationBufferFromUnsafeRow(unsafeGroupingKeyRow);
   }
 
+  /**
+   * Return the count of the element in the Aggregation Map.
+   */
+  public int size() {
+    return map.numElements();
+  }
+
   public UnsafeRow getAggregationBufferFromUnsafeRow(UnsafeRow unsafeGroupingKeyRow) {
     // Probe our map using the serialized key
     final BytesToBytesMap.Location loc = map.lookup(


### PR DESCRIPTION
As https://issues.apache.org/jira/browse/SPARK-10474 shows, before turn to SortBased Aggregation, the Hash Aggregation probably has eat out all of the offheap memory, and eventually cause unable allocate memory exception when spill the data.

A workaround solution is to control the size of hash aggregation buffer. And in long term, we should have to provide a mechanism to estimate how much we have to left for data spill.
