### PR TITLE
[SPARK-10659][SQL] Add an option in SQLConf for setting schema nullable in datasource

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
@@ -381,6 +381,13 @@ private[spark] object SQLConf {
       doc = "The maximum number of concurent files to open before falling back on sorting when " +
             "writing out files using dynamic partitioning.")
 
+  val DATASOURCE_SCHEMA_AS_NULLABLE = booleanConf("spark.sql.sources.schemaAsNullable",
+    defaultValue = Some(true),
+    doc = "When true, we always set nullable/containsNull/valueContainsNull of data source " +
+          "schema to true. So, we will not face situations that we cannot append data because " +
+          "containsNull/valueContainsNull in an Array/Map column of the existing table has " +
+          "already been set to `false`.")
+
   // The output committer class used by HadoopFsRelation. The specified class needs to be a
   // subclass of org.apache.hadoop.mapreduce.OutputCommitter.
   //

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ResolvedDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ResolvedDataSource.scala
@@ -27,7 +27,7 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.Logging
 import org.apache.spark.deploy.SparkHadoopUtil
-import org.apache.spark.sql.{DataFrame, SaveMode, AnalysisException, SQLContext}
+import org.apache.spark.sql.{DataFrame, SaveMode, AnalysisException, SQLConf, SQLContext}
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.{CalendarIntervalType, StructType}
 import org.apache.spark.util.Utils
@@ -91,7 +91,7 @@ object ResolvedDataSource extends Logging {
         case dataSource: SchemaRelationProvider =>
           dataSource.createRelation(sqlContext, new CaseInsensitiveMap(options), schema)
         case dataSource: HadoopFsRelationProvider =>
-          val maybePartitionsSchema = if (partitionColumns.isEmpty) {
+          var maybePartitionsSchema = if (partitionColumns.isEmpty) {
             None
           } else {
             Some(partitionColumnsSchema(schema, partitionColumns))
@@ -105,8 +105,12 @@ object ResolvedDataSource extends Logging {
             SparkHadoopUtil.get.globPathIfNecessary(qualifiedPattern).map(_.toString).toArray
           }
 
-          val dataSchema =
-            StructType(schema.filterNot(f => partitionColumns.contains(f.name))).asNullable
+          var dataSchema = StructType(schema.filterNot(f => partitionColumns.contains(f.name)))
+
+          if (sqlContext.conf.getConf(SQLConf.DATASOURCE_SCHEMA_AS_NULLABLE)) {
+            dataSchema = dataSchema.asNullable
+            maybePartitionsSchema = maybePartitionsSchema.map(_.asNullable)
+          }
 
           dataSource.createRelation(
             sqlContext,
@@ -150,7 +154,7 @@ object ResolvedDataSource extends Logging {
       schema.find(_.name == col).getOrElse {
         throw new RuntimeException(s"Partition column $col not found in schema $schema")
       }
-    }).asNullable
+    })
   }
 
   /** Create a [[ResolvedDataSource]] for saving the content of the given DataFrame. */
@@ -182,12 +186,19 @@ object ResolvedDataSource extends Logging {
 
         PartitioningUtils.validatePartitionColumnDataTypes(data.schema, partitionColumns)
 
-        val dataSchema = StructType(data.schema.filterNot(f => partitionColumns.contains(f.name)))
+        var dataSchema = StructType(data.schema.filterNot(f => partitionColumns.contains(f.name)))
+        var partitionSchema = partitionColumnsSchema(data.schema, partitionColumns)
+
+        if (sqlContext.conf.getConf(SQLConf.DATASOURCE_SCHEMA_AS_NULLABLE)) {
+          dataSchema = dataSchema.asNullable
+          partitionSchema = partitionSchema.asNullable
+        }
+
         val r = dataSource.createRelation(
           sqlContext,
           Array(outputPath.toString),
-          Some(dataSchema.asNullable),
-          Some(partitionColumnsSchema(data.schema, partitionColumns)),
+          Some(dataSchema),
+          Some(partitionSchema),
           caseInsensitiveOptions)
 
         // For partitioned relation r, r.schema's column ordering can be different from the column


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-10659

If not preserve REQUIRED (not nullable) flag in schema is a problem for users, I think we can add an option (default is enabled) to enable this behavior or not.
