### PR TITLE
[SPARK-10656][SQL]fix selection fails when a column has special characters

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -648,7 +648,7 @@ class DataFrame private[sql](
    */
   def col(colName: String): Column = colName match {
     case "*" =>
-      Column(ResolvedStar(schema.fieldNames.map(resolve)))
+      Column(ResolvedStar(schema.fieldNames.map(name => resolve(s"`$name`"))))
     case _ =>
       val expr = resolve(colName)
       Column(expr)
@@ -1181,7 +1181,7 @@ class DataFrame private[sql](
     if (shouldRename) {
       val colNames = schema.map { field =>
         val name = field.name
-        if (resolver(name, existingName)) Column(name).as(newName) else Column(name)
+        if (resolver(name, existingName)) Column(s"`$name`").as(newName) else Column(s"`$name`")
       }
       select(colNames : _*)
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -1183,7 +1183,8 @@ class DataFrame private[sql](
     if (shouldRename) {
       val colNames = schema.map { field =>
         val name = field.name
-        if (resolver(name, resolvedExistingName)) Column(s"`$name`").as(newName) else Column(s"`$name`")
+        if (resolver(name, resolvedExistingName)) Column(s"`$name`").as(newName)
+        else Column(s"`$name`")
       }
       select(colNames : _*)
     } else {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -1123,8 +1123,10 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
       """{"a.b": 10, "d": 11, "f": {"g": 12} }""" :: Nil))
     checkAnswer(df.select("f.g"), Row(12))
     checkAnswer(df.select("`a.b`"), Row(10))
-    checkAnswer(df.select("*"), Row(10, 11, Row(12)))
+    checkAnswer(df.select(df("*")), Row(10, 11, Row(12)))
     checkAnswer(df.withColumnRenamed("f", "h").select("h"), Row(Row(12)))
+    checkAnswer(df.withColumnRenamed("f", "f").select("f"), Row(Row(12)))
+    checkAnswer(df.withColumnRenamed("`a.b`", "s").select("s"), Row(10))
     checkAnswer(df.withColumnRenamed("f", "h").select("`a.b`"), Row(10))
   }
 


### PR DESCRIPTION
Best explained with this example:
val df = sqlContext.read.json(sqlContext.sparkContext.makeRDD(
      """{"a.b": "c", "d": "e" }""" :: Nil))
df.select("_").show()     //successful
df.select(df("_")).show() //throws exception
df.withColumnRenamed("d", "f").show() //also fails

This PR address this by adding back tick for the column names.
