### PR TITLE
[SPARK-10694][STREAMING]Prevent Data Loss in Spark Streaming when used with OFF_HEAP ExternalBlockStore (Tachyon)

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -258,12 +258,6 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
   private[spark] def eventLogDir: Option[URI] = _eventLogDir
   private[spark] def eventLogCodec: Option[String] = _eventLogCodec
 
-  // Generate the random name for a temp folder in external block store.
-  // Add a timestamp as the suffix here to make it more safe
-  val externalBlockStoreFolderName = "spark-" + randomUUID.toString()
-  @deprecated("Use externalBlockStoreFolderName instead.", "1.4.0")
-  val tachyonFolderName = externalBlockStoreFolderName
-
   def isLocal: Boolean = (master == "local" || master.startsWith("local["))
 
   // An asynchronous listener bus for Spark events
@@ -432,8 +426,6 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
         None
       }
     }
-
-    _conf.set("spark.externalBlockStore.folderName", externalBlockStoreFolderName)
 
     if (master == "yarn-client") System.setProperty("SPARK_YARN_MODE", "true")
 

--- a/core/src/main/scala/org/apache/spark/rdd/ExternalStoreBlockRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ExternalStoreBlockRDD.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.rdd
+
+import scala.reflect.ClassTag
+
+import org.apache.spark._
+import org.apache.spark.storage.{BlockId, BlockManager}
+import scala.Some
+
+private[spark] class ExternalStoreBlockRDDPartition
+  (val blockId: BlockId, idx: Int) extends Partition {
+   val index = idx
+}
+
+private[spark]
+class ExternalStoreBlockRDD[T: ClassTag](
+    sc: SparkContext,
+    @transient private val _blockIds: Array[BlockId])
+  extends BlockRDD[T](sc, _blockIds) {
+
+  override def getPartitions: Array[Partition] = {
+    assertValid()
+    (0 until blockIds.length).map(i => {
+      new ExternalStoreBlockRDDPartition(blockIds(i), i).asInstanceOf[Partition]
+    }).toArray
+  }
+
+  override def compute(split: Partition, context: TaskContext): Iterator[T] = {
+    assertValid()
+    val blockManager = SparkEnv.get.blockManager
+    val blockId = split.asInstanceOf[ExternalStoreBlockRDDPartition].blockId
+
+    def getBlockFromBlockManager(): Option[Iterator[T]] = {
+      blockManager.get(blockId).map(_.data.asInstanceOf[Iterator[T]])
+    }
+
+    // Only when get from Block Manager fails but Block may be still there in ExternalStore
+    def getBlockFromExternalStore(): Iterator[T] = {
+      blockManager.getBlockResultFromExternalBlockStore(blockId) match {
+        case Some(block) => block.data.asInstanceOf[Iterator[T]]
+        case None =>
+          throw new Exception("Could not compute split, block " + blockId + " not found")
+      }
+    }
+
+    getBlockFromBlockManager().getOrElse { getBlockFromExternalStore() }
+  }
+
+  override def getPreferredLocations(split: Partition): Seq[String] = {
+    assertValid()
+    _locations(split.asInstanceOf[ExternalStoreBlockRDDPartition].blockId)
+  }
+
+}
+

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -458,6 +458,48 @@ private[spark] class BlockManager(
     }
   }
 
+  /**
+   * Get block from ExternalBlock Store if Local BlockManager do not have the block.
+   * Only happen when StoreLevel is OFF_HEAP and BlockManager failure happen
+   */
+  def getBlockResultFromExternalBlockStore(blockId: BlockId) : Option[BlockResult] = {
+    if (externalBlockStore.contains(blockId)) {
+      logDebug(s" block $blockId present in ExternalBlockStore")
+      val putBlockInfo = {
+        val tinfo = new BlockInfo(StorageLevel.OFF_HEAP, true)
+        val oldBlockOpt = blockInfo.putIfAbsent(blockId, tinfo)
+        if (oldBlockOpt.isDefined) {
+          oldBlockOpt.get
+        } else {
+          tinfo
+        }
+      }
+      putBlockInfo.synchronized {
+        val size = externalBlockStore.getSize(blockId)
+        val result = {
+          externalBlockStore.getValues(blockId)
+            .map(new BlockResult(_, DataReadMethod.Memory, size))
+        }
+        result match {
+          case Some(values) =>
+            val putBlockStatus = BlockStatus(StorageLevel.OFF_HEAP, 0L, 0L, size)
+            putBlockInfo.markReady(size)
+            reportBlockStatus(blockId, putBlockInfo, putBlockStatus)
+            logDebug(s" block $blockId reported back to BlockManagerMaster")
+            return result
+          case None =>
+            blockInfo.remove(blockId)
+            putBlockInfo.markFailure()
+            logWarning(s"Putting block $blockId failed")
+            logDebug(s"Block $blockId not found in ExternalBlockStore")
+        }
+      }
+    } else {
+      logDebug(s"Block $blockId not present in External Store")
+    }
+    None
+  }
+
   private def doGetLocal(blockId: BlockId, asBlockResult: Boolean): Option[Any] = {
     val info = blockInfo.get(blockId).orNull
     if (info != null) {

--- a/core/src/main/scala/org/apache/spark/storage/ExternalBlockStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ExternalBlockStore.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.storage
 
 import java.nio.ByteBuffer
+import java.util.UUID._
 
 import scala.util.control.NonFatal
 
@@ -213,5 +214,9 @@ private[spark] object ExternalBlockStore extends Logging {
   val FOLD_NAME = "spark.externalBlockStore.folderName"
   val MASTER_URL = "spark.externalBlockStore.url"
   val BLOCK_MANAGER_NAME = "spark.externalBlockStore.blockManager"
+  val DIR_ID = "spark.externalBlockStore.dirId"
   val DEFAULT_BLOCK_MANAGER_NAME = "org.apache.spark.storage.TachyonBlockManager"
+  val KEEP_EXTERNAL_DIR_ON_SHUTDOWN =
+    "spark.externalBlockStore.keepExternalBlockStoreDirOnShutdown"
+  val externalBlockStoreFolderName = "spark-" + randomUUID.toString()
 }

--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/ReceivedBlockHandler.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/ReceivedBlockHandler.scala
@@ -58,6 +58,14 @@ private[streaming] case class BlockManagerBasedStoreResult(
       blockId: StreamBlockId, numRecords: Option[Long])
   extends ReceivedBlockStoreResult
 
+/**
+ * Implementation of [[org.apache.spark.streaming.receiver.ReceivedBlockStoreResult]]
+ * that stores the metadata related to blocks having OFF_HEAP StorageLevel using
+ * [[org.apache.spark.streaming.receiver.BlockManagerBasedBlockHandler]]
+ */
+private[streaming] case class ExternalBlockStoreResult(
+    blockId: StreamBlockId, numRecords: Option[Long])
+  extends ReceivedBlockStoreResult
 
 /**
  * Implementation of a [[org.apache.spark.streaming.receiver.ReceivedBlockHandler]] which
@@ -92,7 +100,12 @@ private[streaming] class BlockManagerBasedBlockHandler(
       throw new SparkException(
         s"Could not store $blockId to block manager with storage level $storageLevel")
     }
-    BlockManagerBasedStoreResult(blockId, numRecords)
+    if(storageLevel == StorageLevel.OFF_HEAP) {
+      ExternalBlockStoreResult(blockId, numRecords)
+    } else {
+      BlockManagerBasedStoreResult(blockId, numRecords)
+    }
+
   }
 
   def cleanupOldBlocks(threshTime: Long) {

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceivedBlockInfo.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceivedBlockInfo.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.streaming.scheduler
 
 import org.apache.spark.storage.StreamBlockId
-import org.apache.spark.streaming.receiver.{ReceivedBlockStoreResult, WriteAheadLogBasedStoreResult}
+import org.apache.spark.streaming.receiver.{ExternalBlockStoreResult, ReceivedBlockStoreResult, WriteAheadLogBasedStoreResult}
 import org.apache.spark.streaming.util.WriteAheadLogRecordHandle
 
 /** Information about blocks received by the receiver */
@@ -38,6 +38,13 @@ private[streaming] case class ReceivedBlockInfo(
   def walRecordHandleOption: Option[WriteAheadLogRecordHandle] = {
     blockStoreResult match {
       case walStoreResult: WriteAheadLogBasedStoreResult => Some(walStoreResult.walRecordHandle)
+      case _ => None
+    }
+  }
+
+  def externalBlockRecord: Option[ExternalBlockStoreResult] = {
+    blockStoreResult match {
+      case externalBlockStoreResult: ExternalBlockStoreResult => Some(externalBlockStoreResult)
       case _ => None
     }
   }


### PR DESCRIPTION
The Motivation :

If Streaming application stores the blocks OFF_HEAP, it may not need any WAL like feature to recover from Driver failure. As long as the writing of blocks to Tachyon from Streaming receiver is durable, it should be recoverable from Tachyon directly on Driver failure. 
This can solve the issue of expensive WAL write and duplicating the blocks both in MEMORY and also WAL and also guarantee end to end No-Data-Loss channel using OFF_HEAP store.

The Challenges. 

There are few challenges I faced while implementing this feature. 

1 . Even If I enable the metadata check-pointing (which stores the checkpoint files in HDFS ), if Driver fails, it is still not possible to recover the block information from OFF_HEAP store as the Blocks are not longer in BlockManagerMaster . 
1. By default,  TachyonBlockMaager stores the blocks in folders created with Random ID  and it uses the Executor-Id also in the path where it stores the block. Thus if new Executor is started after failures, it can not read the block written by earlier executor with different executor-id and in different folder.
2.  By default, TachyonBlockMaager uses Shutdown-hook to delete the files written during a given context once context is shutdown . Hence if Streaming program starts after the failure, it can not get the blocks form  Tachyon.

The Solution .
1. For 1, I have implemented new RDD called ExternalStoreBlockRDD which upon failure, try to fetch the blocks recovered  via Metadata Checkpoint location from ExternalBlockStore. It then update the BlockManagerMaster about those recovered blocks. 
2. For 2 , I made few configurable Tachyon folder location where Blocks needs to be stored. This locations will not change during Streaming application failure and restart as I have omitted the Random-Id based and Executor based folder creation. The default behavior kept unchanged.
3. For 3 , also I made the configurable property to keep the Tachyon folder not to be included in Shutdown-hook. Default if false ( i.e. Default behavior ) , but for Streaming application it need to set to true. 
