### PR TITLE
SPARK-10701 Expose SparkContext#stopped flag with @DeveloperApi

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -97,7 +97,7 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
 
   val startTime = System.currentTimeMillis()
 
-  private[spark] val stopped: AtomicBoolean = new AtomicBoolean(false)
+  @DeveloperApi val stopped: AtomicBoolean = new AtomicBoolean(false)
 
   private def assertNotStopped(): Unit = {
     if (stopped.get()) {


### PR DESCRIPTION
See this thread: http://search-hadoop.com/m/q3RTtqvncy17sSTx1

We should expose this flag to developers

@andrewor14 
