### PR TITLE
[SPARK-10686] [ML] Add quantilesCol to AFTSurvivalRegression

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
@@ -41,7 +41,7 @@ import org.apache.spark.storage.StorageLevel
  */
 private[regression] trait AFTSurvivalRegressionParams extends Params
   with HasFeaturesCol with HasLabelCol with HasPredictionCol with HasMaxIter
-  with HasTol with HasFitIntercept {
+  with HasTol with HasFitIntercept with Logging {
 
   /**
    * Param for censor column name.
@@ -108,8 +108,11 @@ private[regression] trait AFTSurvivalRegressionParams extends Params
       SchemaUtils.checkColumnType(schema, $(censorCol), DoubleType)
       SchemaUtils.checkColumnType(schema, $(labelCol), DoubleType)
     }
-    if (hasQuantileProbabilities) {
+    if (hasQuantileProbabilities && hasQuantilesCol) {
       SchemaUtils.appendColumn(schema, $(quantilesCol), new VectorUDT)
+    } else if (hasQuantileProbabilities || hasQuantilesCol) {
+      logWarning("The output will not include quantiles column. " +
+        "If you want to include, please set both quantileProbabilities and quantilesCol.")
     }
     SchemaUtils.appendColumn(schema, $(predictionCol), DoubleType)
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
@@ -59,13 +59,14 @@ private[regression] trait AFTSurvivalRegressionParams extends Params
 
   /**
    * Param for quantile probabilities array.
-   * Values of the quantile probabilities array should be in the range [0, 1].
+   * Values of the quantile probabilities array should be in the range [0, 1]
+   * and the array should be non-empty.
    * @group param
    */
   @Since("1.6.0")
   final val quantileProbabilities: DoubleArrayParam = new DoubleArrayParam(this,
     "quantileProbabilities", "quantile probabilities array",
-    (t: Array[Double]) => t.forall(ParamValidators.inRange(0, 1)))
+    (t: Array[Double]) => t.forall(ParamValidators.inRange(0, 1)) && t.length > 0)
 
   /** @group getParam */
   @Since("1.6.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
@@ -83,11 +83,15 @@ private[regression] trait AFTSurvivalRegressionParams extends Params
   /** @group getParam */
   @Since("1.6.0")
   def getQuantilesCol: String = $(quantilesCol)
-  setDefault(quantilesCol -> "quantiles")
 
   /** Checks whether the input has quantile probabilities array. */
   protected[regression] def hasQuantileProbabilities: Boolean = {
     isDefined(quantileProbabilities) && $(quantileProbabilities).size != 0
+  }
+
+  /** Checks whether the input has quantiles column name. */
+  protected[regression] def hasQuantilesCol: Boolean = {
+    isDefined(quantilesCol) && $(quantilesCol) != ""
   }
 
   /**
@@ -296,7 +300,7 @@ class AFTSurvivalRegressionModel private[ml] (
     transformSchema(dataset.schema)
     val predictUDF = udf { features: Vector => predict(features) }
     val predictQuantilesUDF = udf { features: Vector => predictQuantiles(features)}
-    if (hasQuantileProbabilities) {
+    if (hasQuantileProbabilities && hasQuantilesCol) {
       dataset.withColumn($(predictionCol), predictUDF(col($(featuresCol))))
         .withColumn($(quantilesCol), predictQuantilesUDF(col($(featuresCol))))
     } else {

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/AFTSurvivalRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/AFTSurvivalRegressionSuite.scala
@@ -22,8 +22,7 @@ import scala.util.Random
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.param.ParamsSuite
 import org.apache.spark.ml.util.MLTestingUtils
-import org.apache.spark.mllib.linalg.{DenseVector, Vector, Vectors}
-import org.apache.spark.mllib.linalg.BLAS
+import org.apache.spark.mllib.linalg.{Vector, Vectors}
 import org.apache.spark.mllib.random.{ExponentialGenerator, WeibullGenerator}
 import org.apache.spark.mllib.util.TestingUtils._
 import org.apache.spark.mllib.util.MLlibTestSparkContext
@@ -71,6 +70,8 @@ class AFTSurvivalRegressionSuite extends SparkFunSuite with MLlibTestSparkContex
       .collect()
     assert(model.getFeaturesCol === "features")
     assert(model.getPredictionCol === "prediction")
+    assert(model.getQuantileProbabilities === Array(0.1, 0.8))
+    assert(model.getQuantilesCol === "quantiles")
     assert(model.intercept !== 0.0)
     assert(model.hasParent)
   }
@@ -242,9 +243,9 @@ class AFTSurvivalRegressionSuite extends SparkFunSuite with MLlibTestSparkContex
 
     model.transform(datasetMultivariate).select("features", "prediction", "quantiles")
       .collect().foreach {
-      case Row(features: Vector, prediction: Double, quantiles: Vector) =>
-        assert(prediction ~== model.predict(features) relTol 1E-5)
-        assert(quantiles ~== model.predictQuantiles(features) relTol 1E-5)
+        case Row(features: Vector, prediction: Double, quantiles: Vector) =>
+          assert(prediction ~== model.predict(features) relTol 1E-5)
+          assert(quantiles ~== model.predictQuantiles(features) relTol 1E-5)
     }
   }
 
@@ -312,9 +313,9 @@ class AFTSurvivalRegressionSuite extends SparkFunSuite with MLlibTestSparkContex
 
     model.transform(datasetMultivariate).select("features", "prediction", "quantiles")
       .collect().foreach {
-      case Row(features: Vector, prediction: Double, quantiles: Vector) =>
-        assert(prediction ~== model.predict(features) relTol 1E-5)
-        assert(quantiles ~== model.predictQuantiles(features) relTol 1E-5)
+        case Row(features: Vector, prediction: Double, quantiles: Vector) =>
+          assert(prediction ~== model.predict(features) relTol 1E-5)
+          assert(quantiles ~== model.predictQuantiles(features) relTol 1E-5)
     }
   }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/AFTSurvivalRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/AFTSurvivalRegressionSuite.scala
@@ -59,7 +59,9 @@ class AFTSurvivalRegressionSuite extends SparkFunSuite with MLlibTestSparkContex
     assert(aftr.getFitIntercept)
     assert(aftr.getMaxIter === 100)
     assert(aftr.getTol === 1E-6)
-    val model = aftr.fit(datasetUnivariate).setQuantileProbabilities(Array(0.1, 0.8))
+    val model = aftr.fit(datasetUnivariate)
+      .setQuantileProbabilities(Array(0.1, 0.8))
+      .setQuantilesCol("quantiles")
 
     // copied model must have the same parent.
     MLTestingUtils.checkCopy(model)
@@ -167,6 +169,7 @@ class AFTSurvivalRegressionSuite extends SparkFunSuite with MLlibTestSparkContex
     model.setQuantileProbabilities(quantileProbabilities)
     assert(model.predictQuantiles(features) ~== quantilePredictR relTol 1E-3)
 
+    model.setQuantilesCol("quantiles")
     model.transform(datasetUnivariate).select("features", "prediction", "quantiles")
       .collect().foreach {
       case Row(features: DenseVector, prediction1: Double, predictionQuantiles1: Vector) =>
@@ -242,6 +245,7 @@ class AFTSurvivalRegressionSuite extends SparkFunSuite with MLlibTestSparkContex
     model.setQuantileProbabilities(quantileProbabilities)
     assert(model.predictQuantiles(features) ~== quantilePredictR relTol 1E-3)
 
+    model.setQuantilesCol("quantiles")
     model.transform(datasetMultivariate).select("features", "prediction", "quantiles")
       .collect().foreach {
       case Row(features: DenseVector, prediction1: Double, predictionQuantiles1: Vector) =>
@@ -316,6 +320,7 @@ class AFTSurvivalRegressionSuite extends SparkFunSuite with MLlibTestSparkContex
     model.setQuantileProbabilities(quantileProbabilities)
     assert(model.predictQuantiles(features) ~== quantilePredictR relTol 1E-3)
 
+    model.setQuantilesCol("quantiles")
     model.transform(datasetMultivariate).select("features", "prediction", "quantiles")
       .collect().foreach {
       case Row(features: DenseVector, prediction1: Double, predictionQuantiles1: Vector) =>


### PR DESCRIPTION
By default `quantilesCol` should be empty. If `quantileProbabilities` is set, we should append quantiles as a new column (of type Vector).
