### PR TITLE
[SPARK-10715][ML] Duplicate initialization flag in WeightedLeastSquare

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/optim/WeightedLeastSquares.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/WeightedLeastSquares.scala
@@ -193,7 +193,6 @@ private[ml] object WeightedLeastSquares {
       val ak = a.size
       if (!initialized) {
         init(ak)
-        initialized = true
       }
       assert(ak == k, s"Dimension mismatch. Expect vectors of size $k but got $ak.")
       count += 1L


### PR DESCRIPTION
There are duplicate set of initialization flag in `WeightedLeastSquares#add`. 
`initialized` is already set in `init(Int)`.
