### PR TITLE
[SPARK-10725] [TEST] Add dependencies required by HiveSparkSubmitSuite

### DIFF
--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -174,6 +174,12 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
+      <artifactId>spark-hive_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
       <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
       <type>test-jar</type>
       <version>${project.version}</version>


### PR DESCRIPTION
HiveSparkSubmitSuite under sql/hive project fails with NoClassDefFoundError as follows,

Exception in thread "main" java.lang.NoClassDefFoundError: org.apache.spark.sql.hive.test.TestHiveContext

TestHiveContext class is part of sql_hive jar. Since this jar is not part of the list of dependencies we encounter this issue.

So by adding the respective jar to the dependency list we should be able to successfully run all the tests under HiveSparkSubmitSuite .
