### PR TITLE
[SPARK-10726] When task starting, executor should be in busy state

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -249,7 +249,7 @@ private[spark] class ExecutorAllocationManager(
       if (!allocationManager.executorIds.contains(executorId)) {
         allocationManager.onExecutorAdded(executorId)
       }
-      
+
       // Mark the executor on which this task is scheduled as busy
       allocationManager.onExecutorBusy(executorId)
     }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -491,6 +491,7 @@ private[spark] class TaskSetManager(
               taskName, taskId, host, taskLocality, serializedTask.limit))
 
           sched.dagScheduler.taskStarted(task, info)
+          sched.sc.executorAllocationManager.foreach(_.setExecutorBusy(info))
           return Some(new TaskDescription(taskId = taskId, attemptNumber = attemptNum, execId,
             taskName, index, serializedTask))
         }

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -586,6 +586,9 @@ class ExecutorAllocationManagerSuite
     assert(removeTimes(manager).size === 5)
 
     // Starting a task cancel the remove timer for that executor
+    setExecutorBusy(manager, createTaskInfo(0, 0, "executor-1"))
+    setExecutorBusy(manager, createTaskInfo(1, 1, "executor-1"))
+    setExecutorBusy(manager, createTaskInfo(2, 2, "executor-2"))
     sc.listenerBus.postToAll(SparkListenerTaskStart(0, 0, createTaskInfo(0, 0, "executor-1")))
     sc.listenerBus.postToAll(SparkListenerTaskStart(0, 0, createTaskInfo(1, 1, "executor-1")))
     sc.listenerBus.postToAll(SparkListenerTaskStart(0, 0, createTaskInfo(2, 2, "executor-2")))
@@ -661,6 +664,7 @@ class ExecutorAllocationManagerSuite
     assert(removeTimes(manager).isEmpty)
     sc.listenerBus.postToAll(SparkListenerExecutorAdded(
       0L, "executor-1", new ExecutorInfo("host1", 1, Map.empty)))
+    setExecutorBusy(manager, createTaskInfo(0, 0, "executor-1"))
     sc.listenerBus.postToAll(SparkListenerTaskStart(0, 0, createTaskInfo(0, 0, "executor-1")))
 
     assert(executorIds(manager).size === 1)
@@ -876,6 +880,7 @@ private object ExecutorAllocationManagerSuite extends PrivateMethodTester {
   private val _onExecutorBusy = PrivateMethod[Unit]('onExecutorBusy)
   private val _localityAwareTasks = PrivateMethod[Int]('localityAwareTasks)
   private val _hostToLocalTaskCount = PrivateMethod[Map[String, Int]]('hostToLocalTaskCount)
+  private val _setExecutorBusy = PrivateMethod[Map[String,Int]]('setExecutorBusy)
 
   private def numExecutorsToAdd(manager: ExecutorAllocationManager): Int = {
     manager invokePrivate _numExecutorsToAdd()
@@ -953,5 +958,9 @@ private object ExecutorAllocationManagerSuite extends PrivateMethodTester {
 
   private def hostToLocalTaskCount(manager: ExecutorAllocationManager): Map[String, Int] = {
     manager invokePrivate _hostToLocalTaskCount()
+  }
+
+  private def setExecutorBusy(manager: ExecutorAllocationManager, info: TaskInfo): Map[String, Int] = {
+    manager invokePrivate _setExecutorBusy(info)
   }
 }

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -880,7 +880,7 @@ private object ExecutorAllocationManagerSuite extends PrivateMethodTester {
   private val _onExecutorBusy = PrivateMethod[Unit]('onExecutorBusy)
   private val _localityAwareTasks = PrivateMethod[Int]('localityAwareTasks)
   private val _hostToLocalTaskCount = PrivateMethod[Map[String, Int]]('hostToLocalTaskCount)
-  private val _setExecutorBusy = PrivateMethod[Map[String,Int]]('setExecutorBusy)
+  private val _setExecutorBusy = PrivateMethod[Map[String, Int]]('setExecutorBusy)
 
   private def numExecutorsToAdd(manager: ExecutorAllocationManager): Int = {
     manager invokePrivate _numExecutorsToAdd()
@@ -960,7 +960,8 @@ private object ExecutorAllocationManagerSuite extends PrivateMethodTester {
     manager invokePrivate _hostToLocalTaskCount()
   }
 
-  private def setExecutorBusy(manager: ExecutorAllocationManager, info: TaskInfo): Map[String, Int] = {
+  private def setExecutorBusy(manager: ExecutorAllocationManager,
+                             info: TaskInfo): Map[String, Int] = {
     manager invokePrivate _setExecutorBusy(info)
   }
 }


### PR DESCRIPTION
I run jobs parallelly, exectors are removed before tasks finish because executors are idle timeout. I set "spark.dynamicAllocation.executorIdleTimeout=60s". But I find interval between last task finished in the executor and this executor removed is 10s. 
I read the dirver log and code, and find the tasks start and the SparkListenerTaskStart event does run.(In SparkListenerTaskStart  event, the executor state is set busy.)  And the tasks finish, and execuotor is removed  before this SparkListenerTaskStart  run.
So, I think when tasks will be running, the state of executor should be set busy.
