### PR TITLE
[SPARK-10731] [PYSPARK] [SQL] use 1 partition in take() of Python DataFrame

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -300,7 +300,7 @@ class DataFrame(object):
         >>> df.take(2)
         [Row(age=2, name=u'Alice'), Row(age=5, name=u'Bob')]
         """
-        return self.limit(num).collect()
+        return self.coalesce(1).limit(num).collect()
 
     @ignore_unicode_prefix
     @since(1.3)


### PR DESCRIPTION
And optimize this special case (zero or one partition) in Limit, remove the unnecessary shuffle.
