### PR TITLE
[SPARK-10739][Yarn] Add application attempt window for Spark on Yarn

### DIFF
--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -307,10 +307,9 @@ If you need a reference to the proper location to put log files in the YARN so t
   <td><code>spark.yarn.am.attemptFailuresValidityInterval</code></td>
   <td>(none)</td>
   <td>
-  Defines the validity interval (in millisecond) for AM failure tracking.
-  If the AM has been running for at least long, the AM failure count will be reset.
-  Default value None means this validity interval is not enabled.
-  This feaure is only supported in Hadoop 2.6+.
+  Defines the validity interval for AM failure tracking.
+  If the AM has been running for at least defined interval, the AM failure count will be reset.
+  This feature is not enabled if not configured, and only supported in Hadoop 2.6+.
   </td>
 </tr>
 <tr>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -304,11 +304,13 @@ If you need a reference to the proper location to put log files in the YARN so t
   </td>
 </tr>
 <tr>
-  <td><code>spark.yarn.attemptFailuresValidityInterval</code></td>
-  <td>-1</td>
+  <td><code>spark.yarn.am.attemptFailuresValidityInterval</code></td>
+  <td>none</td>
   <td>
-  Ignore the failure number which happens out the validity interval (in millisecond).
-  Default value -1 means this validity interval is not enabled.
+  Defines the validity interval (in millisecond) for AM failure tracking.
+  If the AM has been running for at least long, the AM failure count will be reset.
+  Default value None means this validity interval is not enabled.
+  This feaure is only supported in Hadoop 2.6+.
   </td>
 </tr>
 <tr>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -305,7 +305,7 @@ If you need a reference to the proper location to put log files in the YARN so t
 </tr>
 <tr>
   <td><code>spark.yarn.am.attemptFailuresValidityInterval</code></td>
-  <td>none</td>
+  <td>(none)</td>
   <td>
   Defines the validity interval (in millisecond) for AM failure tracking.
   If the AM has been running for at least long, the AM failure count will be reset.

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -304,6 +304,14 @@ If you need a reference to the proper location to put log files in the YARN so t
   </td>
 </tr>
 <tr>
+  <td><code>spark.yarn.attemptFailuresValidityInterval</code></td>
+  <td>-1</td>
+  <td>
+  Ignore the failure number which happens out the validity interval (in millisecond).
+  Default value -1 means this validity interval is not enabled.
+  </td>
+</tr>
+<tr>
   <td><code>spark.yarn.submit.waitAppCompletion</code></td>
   <td><code>true</code></td>
   <td>

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -185,21 +185,18 @@ private[spark] class Client(
       case None => logDebug("spark.yarn.maxAppAttempts is not set. " +
           "Cluster's default value will be used.")
     }
-    sparkConf.getOption("spark.yarn.attemptFailuresValidityInterval").map(_.toLong) match {
-      case Some(v) =>
-        require(v > 0, "spark.yarn.attemptFailuresValidityInterval should be greater than 0")
-        try {
-          val method = appContext.getClass().getMethod(
-            "setAttemptFailuresValidityInterval", classOf[Long])
-          method.invoke(appContext, v: java.lang.Long)
-        } catch {
-          case e: NoSuchMethodException =>
-            logWarning("Ignoring spark.yarn.attemptFailuresValidityInterval because the version " +
-              "of YARN does not support it")
-        }
-      case None =>
-        logDebug("spark.yarn.attemptFailuresValidityInterval is not set, " +
-          "only use spark.yarn.maxAppAppAttempts to control the application failure attempts")
+
+    if (sparkConf.contains("spark.yarn.am.attemptFailuresValidityInterval")) {
+      try {
+        val interval = sparkConf.getTimeAsMs("spark.yarn.am.attemptFailuresValidityInterval")
+        val method = appContext.getClass().getMethod(
+          "setAttemptFailuresValidityInterval", classOf[Long])
+        method.invoke(appContext, interval: java.lang.Long)
+      } catch {
+        case e: NoSuchMethodException =>
+          logWarning("Ignoring spark.yarn.am.attemptFailuresValidityInterval because the version " +
+            "of YARN does not support it")
+      }
     }
 
     val capability = Records.newRecord(classOf[Resource])


### PR DESCRIPTION
Add application attempt window for Spark on Yarn to ignore old out of window failures, this is useful for long running applications to recover from failures.
