### PR TITLE
[SPARK-10750] [ML] ML Param validate should print better error information

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
@@ -65,7 +65,11 @@ class Param[T](val parent: String, val name: String, val doc: String, val isVali
    */
   private[param] def validate(value: T): Unit = {
     if (!isValid(value)) {
-      throw new IllegalArgumentException(s"$parent parameter $name given invalid value $value.")
+      val valueToString = value match {
+        case v: Array[_] => v.mkString("[", ",", "]")
+        case _ => value.toString
+      }
+      throw new IllegalArgumentException(s"$parent parameter $name given invalid value $valueToString.")
     }
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
@@ -69,7 +69,8 @@ class Param[T](val parent: String, val name: String, val doc: String, val isVali
         case v: Array[_] => v.mkString("[", ",", "]")
         case _ => value.toString
       }
-      throw new IllegalArgumentException(s"$parent parameter $name given invalid value $valueToString.")
+      throw new IllegalArgumentException(
+        s"$parent parameter $name given invalid value $valueToString.")
     }
   }
 


### PR DESCRIPTION
Currently when you set illegal value for params of array type (such as IntArrayParam, DoubleArrayParam, StringArrayParam), it will throw IllegalArgumentException but with incomprehensible error information.
Take `VectorSlicer.setNames` as an example:

``` scala
val vectorSlicer = new VectorSlicer().setInputCol("features").setOutputCol("result")
// The value of setNames must be contain distinct elements, so the next line will throw exception.
vectorSlicer.setIndices(Array.empty).setNames(Array("f1", "f4", "f1"))
```

It will throw IllegalArgumentException as:

```
vectorSlicer_b3b4d1a10f43 parameter names given invalid value [Ljava.lang.String;@798256c5.
java.lang.IllegalArgumentException: vectorSlicer_b3b4d1a10f43 parameter names given invalid value [Ljava.lang.String;@798256c5.
```

We should distinguish the value of array type from primitive type at Param.validate(value: T), and we will get better error information.

```
vectorSlicer_3b744ea277b2 parameter names given invalid value [f1,f4,f1].
java.lang.IllegalArgumentException: vectorSlicer_3b744ea277b2 parameter names given invalid value [f1,f4,f1].
```
