### PR TITLE
[SPARK-10724] [SQL] SQL's floor() returns DOUBLE

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
@@ -72,6 +72,18 @@ abstract class UnaryMathExpression(f: Double => Double, name: String)
   }
 }
 
+// for floor and ceil which returns bigint instead of double
+abstract class UnaryMathExpressionWithBigIntRet(f: Double => Double, name: String)
+  extends UnaryMathExpression(f, name) {
+  override def dataType: DataType = LongType
+  protected override def nullSafeEval(input: Any): Any = {
+    f(input.asInstanceOf[Double]).toLong
+  }
+  override def genCode(ctx: CodeGenContext, ev: GeneratedExpressionCode): String = {
+    defineCodeGen(ctx, ev, c => s"(long)java.lang.Math.${funcName}($c)")
+  }
+}
+
 abstract class UnaryLogExpression(f: Double => Double, name: String)
     extends UnaryMathExpression(f, name) {
 
@@ -152,7 +164,7 @@ case class Atan(child: Expression) extends UnaryMathExpression(math.atan, "ATAN"
 
 case class Cbrt(child: Expression) extends UnaryMathExpression(math.cbrt, "CBRT")
 
-case class Ceil(child: Expression) extends UnaryMathExpression(math.ceil, "CEIL")
+case class Ceil(child: Expression) extends UnaryMathExpressionWithBigIntRet(math.ceil, "CEIL")
 
 case class Cos(child: Expression) extends UnaryMathExpression(math.cos, "COS")
 
@@ -195,7 +207,7 @@ case class Exp(child: Expression) extends UnaryMathExpression(math.exp, "EXP")
 
 case class Expm1(child: Expression) extends UnaryMathExpression(math.expm1, "EXPM1")
 
-case class Floor(child: Expression) extends UnaryMathExpression(math.floor, "FLOOR")
+case class Floor(child: Expression) extends UnaryMathExpressionWithBigIntRet(math.floor, "FLOOR")
 
 object Factorial {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/AbstractDataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/AbstractDataType.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.types
 
 import scala.reflect.ClassTag
-import scala.reflect.runtime.universe.{TypeTag, runtimeMirror}
+import scala.reflect.runtime.universe._
 
 import org.apache.spark.sql.catalyst.ScalaReflectionLock
 import org.apache.spark.sql.catalyst.expressions.Expression
@@ -147,6 +147,18 @@ abstract class NumericType extends AtomicType {
   // desugared by the compiler into an argument to the objects constructor. This means there is no
   // longer an no argument constructor and thus the JVM cannot serialize the object anymore.
   private[sql] val numeric: Numeric[InternalType]
+
+  def cast(d: Double): InternalType
+
+  def cast(f: Float): InternalType
+
+  def cast(l: Long): InternalType
+
+  def cast(i: Int): InternalType
+
+  def cast(s: Short): InternalType
+
+  def cast(b: Byte): InternalType
 }
 
 
@@ -165,6 +177,24 @@ private[sql] object NumericType extends AbstractDataType {
   override private[sql] def simpleString: String = "numeric"
 
   override private[sql] def acceptsType(other: DataType): Boolean = other.isInstanceOf[NumericType]
+
+  def toType(ttag: TypeTag[_]): NumericType = {
+    ttag match {
+      case Byte => ByteType
+      case Short => ShortType
+      case Int => IntegerType
+      case Long => LongType
+      case Float => FloatType
+      case Double => DoubleType
+    }
+  }
+
+  val Byte    : TypeTag[ByteType]       = typeTag[ByteType]
+  val Short   : TypeTag[ShortType]      = typeTag[ShortType]
+  val Int     : TypeTag[IntegerType]    = typeTag[IntegerType]
+  val Long    : TypeTag[LongType]       = typeTag[LongType]
+  val Float   : TypeTag[FloatType]      = typeTag[FloatType]
+  val Double  : TypeTag[DoubleType]     = typeTag[DoubleType]
 }
 
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/ByteType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/ByteType.scala
@@ -47,6 +47,18 @@ class ByteType private() extends IntegralType {
   override def simpleString: String = "tinyint"
 
   private[spark] override def asNullable: ByteType = this
+
+  override def cast(d: Double): InternalType = d.toByte
+
+  override def cast(f: Float): InternalType = f.toByte
+
+  override def cast(l: Long): InternalType = l.toByte
+
+  override def cast(i: Int): InternalType = i.toByte
+
+  override def cast(s: Short): InternalType = s.toByte
+
+  override def cast(b: Byte): InternalType = b
 }
 
 case object ByteType extends ByteType

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalType.scala
@@ -98,6 +98,18 @@ case class DecimalType(precision: Int, scale: Int) extends FractionalType {
   override def simpleString: String = s"decimal($precision,$scale)"
 
   private[spark] override def asNullable: DecimalType = this
+
+  override def cast(d: Double): InternalType = throw new UnsupportedOperationException
+
+  override def cast(f: Float): InternalType = throw new UnsupportedOperationException
+
+  override def cast(l: Long): InternalType = throw new UnsupportedOperationException
+
+  override def cast(i: Int): InternalType = throw new UnsupportedOperationException
+
+  override def cast(s: Short): InternalType = throw new UnsupportedOperationException
+
+  override def cast(b: Byte): InternalType = throw new UnsupportedOperationException
 }
 
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DoubleType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DoubleType.scala
@@ -49,6 +49,18 @@ class DoubleType private() extends FractionalType {
   override def defaultSize: Int = 8
 
   private[spark] override def asNullable: DoubleType = this
+
+  override def cast(d: InternalType): InternalType = d
+
+  override def cast(f: Float): InternalType = f.toDouble
+
+  override def cast(l: Long): InternalType = l.toDouble
+
+  override def cast(i: Int): InternalType = i.toDouble
+
+  override def cast(s: Short): InternalType = s.toDouble
+
+  override def cast(b: Byte): InternalType = b.toDouble
 }
 
 case object DoubleType extends DoubleType

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/FloatType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/FloatType.scala
@@ -49,6 +49,18 @@ class FloatType private() extends FractionalType {
   override def defaultSize: Int = 4
 
   private[spark] override def asNullable: FloatType = this
+
+  override def cast(d: Double): InternalType = d.toFloat
+
+  override def cast(f: Float): InternalType = f
+
+  override def cast(l: Long): InternalType = l.toFloat
+
+  override def cast(i: Int): InternalType = i.toFloat
+
+  override def cast(s: Short): InternalType = s.toFloat
+
+  override def cast(b: Byte): InternalType = b.toFloat
 }
 
 case object FloatType extends FloatType

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/IntegerType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/IntegerType.scala
@@ -47,6 +47,18 @@ class IntegerType private() extends IntegralType {
   override def simpleString: String = "int"
 
   private[spark] override def asNullable: IntegerType = this
+
+  override def cast(d: Double): InternalType = d.toInt
+
+  override def cast(f: Float): InternalType = f.toInt
+
+  override def cast(l: Long): InternalType = l.toInt
+
+  override def cast(i: Int): InternalType = i
+
+  override def cast(s: Short): InternalType = s.toInt
+
+  override def cast(b: Byte): InternalType = b.toInt
 }
 
 case object IntegerType extends IntegerType

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/LongType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/LongType.scala
@@ -46,6 +46,19 @@ class LongType private() extends IntegralType {
   override def simpleString: String = "bigint"
 
   private[spark] override def asNullable: LongType = this
+
+  override def cast(d: Double): InternalType = d.toLong
+
+  override def cast(f: Float): InternalType = f.toLong
+
+  override def cast(l: Long): InternalType = l
+
+  override def cast(i: Int): InternalType = i.toLong
+
+  override def cast(s: Short): InternalType = s.toLong
+
+  override def cast(b: Byte): InternalType = b.toLong
+
 }
 
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/ShortType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/ShortType.scala
@@ -46,6 +46,18 @@ class ShortType private() extends IntegralType {
   override def simpleString: String = "smallint"
 
   private[spark] override def asNullable: ShortType = this
+  
+  override def cast(d: Double): InternalType = d.toShort
+
+  override def cast(f: Float): InternalType = f.toShort
+
+  override def cast(l: Long): InternalType = l.toShort
+
+  override def cast(i: Int): InternalType = i.toShort
+
+  override def cast(s: Short): InternalType = s
+
+  override def cast(b: Byte): InternalType = b.toShort
 }
 
 case object ShortType extends ShortType

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MathFunctionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MathFunctionsSuite.scala
@@ -244,12 +244,12 @@ class MathFunctionsSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("ceil") {
-    testUnary(Ceil, math.ceil)
+    testUnary(Ceil, (x: Double) => math.ceil(x).toLong)
     checkConsistencyBetweenInterpretedAndCodegen(Ceil, DoubleType)
   }
 
   test("floor") {
-    testUnary(Floor, math.floor)
+    testUnary(Floor, (x: Double) => math.floor(x).toLong)
     checkConsistencyBetweenInterpretedAndCodegen(Floor, DoubleType)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/MathExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MathExpressionsSuite.scala
@@ -39,7 +39,7 @@ class MathExpressionsSuite extends QueryTest with SharedSQLContext {
 
   private def testOneToOneMathFunction[@specialized(Int, Long, Float, Double) T](
       c: Column => Column,
-      f: T => T): Unit = {
+      f: T => Any): Unit = {
     checkAnswer(
       doubleData.select(c('a)),
       (1 to 10).map(n => Row(f((n * 0.2 - 1).asInstanceOf[T])))
@@ -165,7 +165,7 @@ class MathExpressionsSuite extends QueryTest with SharedSQLContext {
   }
 
   test("ceil and ceiling") {
-    testOneToOneMathFunction(ceil, math.ceil)
+    testOneToOneMathFunction(ceil, (x: Double) => math.ceil(x).toLong)
     checkAnswer(
       sql("SELECT ceiling(0), ceiling(1), ceiling(1.5)"),
       Row(0.0, 1.0, 2.0))
@@ -184,7 +184,7 @@ class MathExpressionsSuite extends QueryTest with SharedSQLContext {
   }
 
   test("floor") {
-    testOneToOneMathFunction(floor, math.floor)
+    testOneToOneMathFunction(floor, (x: Double) => math.floor(x).toLong)
   }
 
   test("factorial") {


### PR DESCRIPTION
This is a change in behavior from 1.4.1 where {{floor}} returns a BIGINT. 

{code}
scala> sql("select floor(1)").printSchema
root
 |-- _c0: double (nullable = true)
{code}

In the [Hive Language Manual|https://cwiki.apache.org/confluence/display/Hive/LanguageManual+UDF] {{floor}} is defined to return BIGINT.

This is a significant issue because it changes the DataFrame schema.

I wonder what caused this and whether other SQL functions are affected.
