### PR TITLE
SPARK-10787 Reset ObjectOutputStream more often to prevent OOME

### DIFF
--- a/core/src/main/scala/org/apache/spark/serializer/JavaSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/JavaSerializer.scala
@@ -42,10 +42,13 @@ private[spark] class JavaSerializationStream(
   def writeObject[T: ClassTag](t: T): SerializationStream = {
     try {
       objOut.writeObject(t)
-      objOut.reset()
     } catch {
       case e: NotSerializableException if extraDebugInfo =>
         throw SerializationDebugger.improveException(t, e)
+      case e: OutOfMemoryError =>
+        objOut.reset()
+        counter = 0
+        objOut.writeObject(t)
     }
     counter += 1
     if (counterReset > 0 && counter >= counterReset) {

--- a/core/src/main/scala/org/apache/spark/serializer/JavaSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/JavaSerializer.scala
@@ -42,6 +42,7 @@ private[spark] class JavaSerializationStream(
   def writeObject[T: ClassTag](t: T): SerializationStream = {
     try {
       objOut.writeObject(t)
+      objOut.reset()
     } catch {
       case e: NotSerializableException if extraDebugInfo =>
         throw SerializationDebugger.improveException(t, e)

--- a/core/src/main/scala/org/apache/spark/serializer/JavaSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/JavaSerializer.scala
@@ -138,7 +138,7 @@ private[spark] class JavaSerializerInstance(
  */
 @DeveloperApi
 class JavaSerializer(conf: SparkConf) extends Serializer with Externalizable {
-  private var counterReset = conf.getInt("spark.serializer.objectStreamReset", 3)
+  private var counterReset = conf.getInt("spark.serializer.objectStreamReset", 10)
   private var extraDebugInfo = conf.getBoolean("spark.serializer.extraDebugInfo", true)
 
   protected def this() = this(new SparkConf())  // For deserialization only

--- a/core/src/main/scala/org/apache/spark/serializer/JavaSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/JavaSerializer.scala
@@ -142,7 +142,7 @@ private[spark] class JavaSerializerInstance(
  */
 @DeveloperApi
 class JavaSerializer(conf: SparkConf) extends Serializer with Externalizable {
-  private var counterReset = conf.getInt("spark.serializer.objectStreamReset", 100)
+  private var counterReset = conf.getInt("spark.serializer.objectStreamReset", 3)
   private var extraDebugInfo = conf.getBoolean("spark.serializer.extraDebugInfo", true)
 
   protected def this() = this(new SparkConf())  // For deserialization only

--- a/core/src/main/scala/org/apache/spark/serializer/JavaSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/JavaSerializer.scala
@@ -45,10 +45,6 @@ private[spark] class JavaSerializationStream(
     } catch {
       case e: NotSerializableException if extraDebugInfo =>
         throw SerializationDebugger.improveException(t, e)
-      case e: OutOfMemoryError =>
-        objOut.reset()
-        counter = 0
-        objOut.writeObject(t)
     }
     counter += 1
     if (counterReset > 0 && counter >= counterReset) {


### PR DESCRIPTION
In the thread, Spark ClosureCleaner or java serializer OOM when trying to grow (http://search-hadoop.com/m/q3RTtAr5X543dNn), Jay Luan reported that ClosureCleaner#ensureSerializable() resulted in OOME.

The cause was that ObjectOutputStream keeps a strong reference of every object that was written to it.

This PR tries to avoid OOME by calling reset().
