### PR TITLE
[SPARK-9346][SQL] Eliminate extra row conversion on data sources

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -328,7 +328,7 @@ private[sql] object DataSourceStrategy extends Strategy with Logging {
       relation: LogicalRelation,
       output: Seq[Attribute],
       rdd: RDD[Row]): RDD[InternalRow] = {
-    if (relation.relation.needConversion) {
+    if (relation.relation.outputNeedConversion) {
       execution.RDDConversions.rowToRowRdd(rdd, output.map(_.dataType))
     } else {
       rdd.asInstanceOf[RDD[InternalRow]]

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRelation.scala
@@ -86,7 +86,9 @@ private[sql] case class JDBCRelation(
   with PrunedFilteredScan
   with InsertableRelation {
 
-  override val needConversion: Boolean = false
+  override val inputNeedConversion: Boolean = false
+
+  override val outputNeedConversion: Boolean = false
 
   override val schema: StructType = JDBCRDD.resolveTable(url, table, properties)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRelation.scala
@@ -86,7 +86,7 @@ private[sql] case class JDBCRelation(
   with PrunedFilteredScan
   with InsertableRelation {
 
-  override val inputNeedConversion: Boolean = false
+  override val needConversion: Boolean = false
 
   override val outputNeedConversion: Boolean = false
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JSONRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JSONRelation.scala
@@ -77,7 +77,7 @@ private[sql] class JSONRelation(
     }
   }
 
-  override val inputNeedConversion: Boolean = false
+  override val needConversion: Boolean = false
 
   override val outputNeedConversion: Boolean = false
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JSONRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JSONRelation.scala
@@ -77,7 +77,9 @@ private[sql] class JSONRelation(
     }
   }
 
-  override val needConversion: Boolean = false
+  override val inputNeedConversion: Boolean = false
+
+  override val outputNeedConversion: Boolean = false
 
   private def createBaseRdd(inputPaths: Array[FileStatus]): RDD[String] = {
     val job = new Job(sqlContext.sparkContext.hadoopConfiguration)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRelation.scala
@@ -206,7 +206,9 @@ private[sql] class ParquetRelation(
   }
 
   // Parquet data source always uses Catalyst internal representations.
-  override val needConversion: Boolean = false
+  override val inputNeedConversion: Boolean = false
+
+  override val outputNeedConversion: Boolean = false
 
   override def sizeInBytes: Long = metadataCache.dataStatuses.map(_.getLen).sum
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRelation.scala
@@ -206,7 +206,7 @@ private[sql] class ParquetRelation(
   }
 
   // Parquet data source always uses Catalyst internal representations.
-  override val inputNeedConversion: Boolean = false
+  override val needConversion: Boolean = false
 
   override val outputNeedConversion: Boolean = false
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -639,6 +639,7 @@ abstract class HadoopFsRelation private[sql](maybePartitionSpec: Option[Partitio
     val dataSchema = this.dataSchema
     val codegenEnabled = this.codegenEnabled
     val inputNeedConversion = this.inputNeedConversion
+    val outputNeedConversion = this.outputNeedConversion
 
     val requiredOutput = requiredColumns.map { col =>
       val field = dataSchema(col)
@@ -667,7 +668,7 @@ abstract class HadoopFsRelation private[sql](maybePartitionSpec: Option[Partitio
         rows.map(r => mutableProjection(r))
       }
 
-      if (this.outputNeedConversion) {
+      if (outputNeedConversion) {
         val requiredSchema = StructType(requiredColumns.map(dataSchema(_)))
         val toScala = CatalystTypeConverters.createToScalaConverter(requiredSchema)
         projectedRows.map(toScala(_).asInstanceOf[Row])

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/DDLTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/DDLTestSuite.scala
@@ -59,7 +59,7 @@ case class SimpleDDLScan(from: Int, to: Int, table: String)(@transient val sqlCo
       )
     ))
 
-  override def needConversion: Boolean = false
+  override def inputNeedConversion: Boolean = false
 
   override def buildScan(): RDD[Row] = {
     // Rely on a type erasure hack to pass RDD[InternalRow] back as RDD[Row]

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/DDLTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/DDLTestSuite.scala
@@ -59,7 +59,7 @@ case class SimpleDDLScan(from: Int, to: Int, table: String)(@transient val sqlCo
       )
     ))
 
-  override def inputNeedConversion: Boolean = false
+  override def needConversion: Boolean = false
 
   override def buildScan(): RDD[Row] = {
     // Rely on a type erasure hack to pass RDD[InternalRow] back as RDD[Row]

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/TableScanSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/TableScanSuite.scala
@@ -66,8 +66,6 @@ case class AllDataTypesScan(
 
   override def schema: StructType = userSpecifiedSchema
 
-  override def needConversion: Boolean = true
-
   override def buildScan(): RDD[Row] = {
     sqlContext.sparkContext.parallelize(from to to).map { i =>
       Row(

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcRelation.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcRelation.scala
@@ -180,7 +180,7 @@ private[sql] class OrcRelation(
       paths.head, Some(sqlContext.sparkContext.hadoopConfiguration))
   }
 
-  override def inputNeedConversion: Boolean = false
+  override def needConversion: Boolean = false
 
   override def outputNeedConversion: Boolean = false
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcRelation.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcRelation.scala
@@ -180,7 +180,9 @@ private[sql] class OrcRelation(
       paths.head, Some(sqlContext.sparkContext.hadoopConfiguration))
   }
 
-  override def needConversion: Boolean = false
+  override def inputNeedConversion: Boolean = false
+
+  override def outputNeedConversion: Boolean = false
 
   override def equals(other: Any): Boolean = other match {
     case that: OrcRelation =>


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-9346

Currently we reply on `needConversion` to decide whether to do both input and output conversion. Thus we perform an unnecessary conversion from `InternalRow` to `Row`. We can eliminate it on some data sources such as JDBC, JSON, Orc and Parquet.
