### PR TITLE
[SPARK-10766][SPARK-SUBMIT]Add some configuration for the client process in cluster mode.

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -519,6 +519,12 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
         |  --verbose, -v               Print additional debug output
         |  --version,                  Print the version of current Spark
         |
+        |  Cluster deploy mode only:
+        |  --client-memory MEM         Memory for client (e.g. 1000M, 2G) (Default: ${mem_mb}M).
+        |  --client-java-options       Extra Java options to pass to the client.
+        |  --client-library-path       Extra library path entries to pass to the client.
+        |  --client-class-path         Extra class path entries to pass to the client.
+        |
         | Spark standalone with cluster deploy mode only:
         |  --driver-cores NUM          Cores for driver (Default: 1).
         |

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkLauncher.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkLauncher.java
@@ -47,6 +47,15 @@ public class SparkLauncher {
   /** Configuration key for the driver native library path. */
   public static final String DRIVER_EXTRA_LIBRARY_PATH = "spark.driver.extraLibraryPath";
 
+  /** Configuration key for the client memory. */
+  public static final String CLIENT_MEMORY = "spark.client.memory";
+  /** Configuration key for the client class path. */
+  public static final String CLIENT_EXTRA_CLASSPATH = "spark.client.extraClassPath";
+  /** Configuration key for the client VM options. */
+  public static final String CLIENT_EXTRA_JAVA_OPTIONS = "spark.client.extraJavaOptions";
+  /** Configuration key for the client native library path. */
+  public static final String CLIENT_EXTRA_LIBRARY_PATH = "spark.client.extraLibraryPath";
+
   /** Configuration key for the executor memory. */
   public static final String EXECUTOR_MEMORY = "spark.executor.memory";
   /** Configuration key for the executor class path. */

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitOptionParser.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitOptionParser.java
@@ -44,6 +44,10 @@ class SparkSubmitOptionParser {
   protected final String DRIVER_JAVA_OPTIONS =  "--driver-java-options";
   protected final String DRIVER_LIBRARY_PATH = "--driver-library-path";
   protected final String DRIVER_MEMORY = "--driver-memory";
+  protected final String CLIENT_MEMORY = "--client-memory";
+  protected final String CLIENT_CLASS_PATH = "--client-class-path";
+  protected final String CLIENT_JAVA_OPTIONS = "--client-java-options";
+  protected final String CLIENT_LIBRARY_PATH = "--client-library-path";
   protected final String EXECUTOR_MEMORY = "--executor-memory";
   protected final String FILES = "--files";
   protected final String JARS = "--jars";
@@ -96,6 +100,10 @@ class SparkSubmitOptionParser {
     { DRIVER_JAVA_OPTIONS },
     { DRIVER_LIBRARY_PATH },
     { DRIVER_MEMORY },
+    { CLIENT_MEMORY },
+    { CLIENT_CLASS_PATH },
+    { CLIENT_JAVA_OPTIONS },
+    { CLIENT_LIBRARY_PATH },
     { EXECUTOR_CORES },
     { EXECUTOR_MEMORY },
     { FILES },


### PR DESCRIPTION
Add this four configurations for the client only in cluster mode:
-  `spark.client.memory` of property and `--client-memory` of cli command
- `spark.client.extraClassPath` of property and `--client-class-path` of cli command
- `spark.client.extraJavaOptions` of property and `--client-java-options` of cli command
- `spark.client.extraLibraryPath` of property and `--client-library-path` of cli command
