### PR TITLE
[SPARK][SPARK-10842]Eliminate creating duplicate stage while generate job dag

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -283,7 +283,9 @@ class DAGScheduler(
       case None =>
         // We are going to register ancestor shuffle dependencies
         getAncestorShuffleDependencies(shuffleDep.rdd).foreach { dep =>
-          shuffleToMapStage(dep.shuffleId) = newOrUsedShuffleStage(dep, firstJobId)
+          if (!shuffleToMapStage.contains(dep.shuffleId)) {
+            shuffleToMapStage(dep.shuffleId) = newOrUsedShuffleStage(dep, firstJobId)
+          }
         }
         // Then register current shuffleDep
         val stage = newOrUsedShuffleStage(shuffleDep, firstJobId)

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -23,7 +23,8 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.Map
-import scala.collection.mutable.{HashMap, HashSet, Set, Stack}
+import scala.collection.immutable.Set
+import scala.collection.mutable.{HashMap, HashSet, Stack}
 import scala.concurrent.duration._
 import scala.language.existentials
 import scala.language.postfixOps
@@ -427,7 +428,7 @@ class DAGScheduler(
     while (waitingForVisit.nonEmpty) {
       visit(waitingForVisit.pop())
     }
-    parents
+    parents.toSet
   }
 
   private def getMissingParentStages(stage: Stage): List[Stage] = {

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -1901,6 +1901,26 @@ class DAGSchedulerSuite
     assertDataStructuresEmpty()
   }
 
+  test("Eliminate creating duplicate stage") {
+    val rdd2 = new MyRDD(sc, 2, Nil)
+    val rdd1 = new MyRDD(sc, 2, Nil)
+    val dep1 = new ShuffleDependency(rdd1, new HashPartitioner(1))
+    val dep2 = new ShuffleDependency(rdd2, new HashPartitioner(1))
+    val rdd3 = new MyRDD(sc, 1, List(dep1, dep2), tracker = mapOutputTracker)
+    val dep3 = new ShuffleDependency(rdd3, new HashPartitioner(2))
+    val dep4 = new ShuffleDependency(rdd3, new HashPartitioner(2))
+    val rdd4 = new MyRDD(sc, 2, List(dep3), tracker = mapOutputTracker)
+    val rdd5 = new MyRDD(sc, 2, List(dep4), tracker = mapOutputTracker)
+    val dep5 = new ShuffleDependency(rdd4, new HashPartitioner(1))
+    val dep6 = new ShuffleDependency(rdd5, new HashPartitioner(1))
+    val rdd6 = new MyRDD(sc, 1, List(dep5, dep6), tracker = mapOutputTracker)
+    val dep7 = new ShuffleDependency(rdd6, new HashPartitioner(2))
+    val rdd7 = new MyRDD(sc, 2, List(dep7), tracker = mapOutputTracker)
+    submit(rdd7, Array(0, 1))
+    assert(scheduler.stageIdToStage.size == 8)
+    assert(scheduler.shuffleToMapStage.size == 7)
+  }
+
   /**
    * Assert that the supplied TaskSet has exactly the given hosts as its preferred locations.
    * Note that this checks only the host and not the executor ID.


### PR DESCRIPTION
When we traverse RDD, to generate Stage DAG, Spark will skip to judge the stage was added into shuffleIdToStage or not in some condition: get shuffleDep from getAncestorShuffleDependency

Before:
![before1](https://cloud.githubusercontent.com/assets/9818852/10117739/9e1e8778-6493-11e5-935d-ea32099e94c9.png)
![before2](https://cloud.githubusercontent.com/assets/9818852/10117740/9e20ee46-6493-11e5-95b4-f30df5ac22e1.png)

After:
![after](https://cloud.githubusercontent.com/assets/9818852/10117737/9e1864c4-6493-11e5-8541-31ff0ead329a.png)
![after2](https://cloud.githubusercontent.com/assets/9818852/10117738/9e1c8658-6493-11e5-954a-fb00f36f4d3b.png)
