### PR TITLE
[SPARK-10852][PySpark][SQL] Override built-in methods for special column names

### DIFF
--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -208,7 +208,7 @@ class SQLTests(ReusedPySparkTestCase):
 
     def test_row_with_special_column_names(self):
         rdd = self.sc.parallelize([1, 2, 1, 3])
-        df = self.sqlCtx.createDataFrame(rdd.map(lambda x: Row(id = x)))
+        df = self.sqlCtx.createDataFrame(rdd.map(lambda x: Row(id=x)))
         df = df.groupby("id").count()
         self.assertEqual(df.map(lambda x: x.count).collect(), [2, 1, 1])
 

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -206,6 +206,12 @@ class SQLTests(ReusedPySparkTestCase):
             row2.id = 2
         self.assertRaises(Exception, foo2)
 
+    def test_row_with_special_column_names(self):
+        rdd = self.sc.parallelize([1, 2, 1, 3])
+        df = self.sqlCtx.createDataFrame(rdd.map(lambda x: Row(id = x)))
+        df = df.groupby("id").count()
+        self.assertEqual(df.map(lambda x: x.count).collect(), [2, 1, 1])
+
     def test_range(self):
         self.assertEqual(self.sqlCtx.range(1, 1).count(), 0)
         self.assertEqual(self.sqlCtx.range(1, 0, -1).count(), 1)

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1189,6 +1189,16 @@ class Row(tuple):
     <Row(name, age)>
     >>> Person("Alice", 11)
     Row(name='Alice', age=11)
+
+    Some special column names such as aggregated column count, should
+    work properly.
+
+    >>> from pyspark.sql import Row
+    >>> rdd = sc.parallelize([1, 2, 1, 3])
+    >>> df = sqlContext.createDataFrame(rdd.map(lambda x: Row(id = x)))
+    >>> df = df.groupby("id").count()
+    >>> df.map(lambda x: x.count).collect()
+    [2, 1, 1]
     """
 
     def __new__(self, *args, **kwargs):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1189,16 +1189,6 @@ class Row(tuple):
     <Row(name, age)>
     >>> Person("Alice", 11)
     Row(name='Alice', age=11)
-
-    Some special column names such as aggregated column count, should
-    work properly.
-
-    >>> from pyspark.sql import Row
-    >>> rdd = sc.parallelize([1, 2, 1, 3])
-    >>> df = sqlContext.createDataFrame(rdd.map(lambda x: Row(id = x)))
-    >>> df = df.groupby("id").count()
-    >>> df.map(lambda x: x.count).collect()
-    [2, 1, 1]
     """
 
     def __new__(self, *args, **kwargs):
@@ -1219,11 +1209,11 @@ class Row(tuple):
         else:
             raise ValueError("No args or kwargs")
 
-    def __init__(self, *args, **kwargs):
-        if hasattr(self, "__fields__") and "count" in self.__fields__:
-            self.__dict__["count"] = self.__getattr__("count")
-        if hasattr(self, "__fields__") and "index" in self.__fields__:
-            self.__dict__["index"] = self.__getattr__("index")
+    def count(self):
+        self.__getattr__("count")
+
+    def index(self):
+        self.__getattr__("index")
 
     def asDict(self, recursive=False):
         """
@@ -1291,10 +1281,6 @@ class Row(tuple):
         if key != '__fields__':
             raise Exception("Row is read-only")
         self.__dict__[key] = value
-        if "count" in self.__fields__:
-            self.__dict__["count"] = self.__getattr__("count")
-        if "index" in self.__fields__:
-            self.__dict__["index"] = self.__getattr__("index")
 
     def __reduce__(self):
         """Returns a tuple so Python knows how to pickle Row."""

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1209,11 +1209,11 @@ class Row(tuple):
         else:
             raise ValueError("No args or kwargs")
 
-    def count(self):
-        self.__getattr__("count")
-
-    def index(self):
-        self.__getattr__("index")
+    def __init__(self, *args, **kwargs):
+        if hasattr(self, "__fields__") and "count" in self.__fields__:
+          self.__dict__["count"] = self.__getattr__("count")
+        if hasattr(self, "__fields__") and "index" in self.__fields__:
+          self.__dict__["index"] = self.__getattr__("index")
 
     def asDict(self, recursive=False):
         """
@@ -1281,6 +1281,10 @@ class Row(tuple):
         if key != '__fields__':
             raise Exception("Row is read-only")
         self.__dict__[key] = value
+        if "count" in self.__fields__:
+            self.__dict__["count"] = self.__getattr__("count")
+        if "index" in self.__fields__:
+            self.__dict__["index"] = self.__getattr__("index")
 
     def __reduce__(self):
         """Returns a tuple so Python knows how to pickle Row."""

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1209,6 +1209,12 @@ class Row(tuple):
         else:
             raise ValueError("No args or kwargs")
 
+    def __init__(self, *args, **kwargs):
+        if hasattr(self, "__fields__") and "count" in self.__fields__:
+          self.__dict__["count"] = self.__getattr__("count")
+        if hasattr(self, "__fields__") and "index" in self.__fields__:
+          self.__dict__["index"] = self.__getattr__("index")
+
     def asDict(self, recursive=False):
         """
         Return as an dict
@@ -1275,6 +1281,10 @@ class Row(tuple):
         if key != '__fields__':
             raise Exception("Row is read-only")
         self.__dict__[key] = value
+        if "count" in self.__fields__:
+            self.__dict__["count"] = self.__getattr__("count")
+        if "index" in self.__fields__:
+            self.__dict__["index"] = self.__getattr__("index")
 
     def __reduce__(self):
         """Returns a tuple so Python knows how to pickle Row."""

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1211,9 +1211,9 @@ class Row(tuple):
 
     def __init__(self, *args, **kwargs):
         if hasattr(self, "__fields__") and "count" in self.__fields__:
-          self.__dict__["count"] = self.__getattr__("count")
+            self.__dict__["count"] = self.__getattr__("count")
         if hasattr(self, "__fields__") and "index" in self.__fields__:
-          self.__dict__["index"] = self.__getattr__("index")
+            self.__dict__["index"] = self.__getattr__("index")
 
     def asDict(self, recursive=False):
         """

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1221,9 +1221,9 @@ class Row(tuple):
 
     def __init__(self, *args, **kwargs):
         if hasattr(self, "__fields__") and "count" in self.__fields__:
-          self.__dict__["count"] = self.__getattr__("count")
+            self.__dict__["count"] = self.__getattr__("count")
         if hasattr(self, "__fields__") and "index" in self.__fields__:
-          self.__dict__["index"] = self.__getattr__("index")
+            self.__dict__["index"] = self.__getattr__("index")
 
     def asDict(self, recursive=False):
         """

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1210,9 +1210,9 @@ class Row(tuple):
             raise ValueError("No args or kwargs")
 
     def __init__(self, *args, **kwargs):
-        if hasattr(self, "__fields__") and "count" in self.__fields__:
+        if "count" in kwargs:
             self.__dict__["count"] = self.__getattr__("count")
-        if hasattr(self, "__fields__") and "index" in self.__fields__:
+        if "index" in kwargs:
             self.__dict__["index"] = self.__getattr__("index")
 
     def asDict(self, recursive=False):


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-10852

For few special columns such as `count` and `index`, because they are built-in methods of `Row(tuple)` in Python. We should override them in order to properly access the values.
