### PR TITLE
[SPARK-10875][MLLib] Computed covariance matrix should be symmetric

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/RowMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/RowMatrix.scala
@@ -357,9 +357,10 @@ class RowMatrix @Since("1.0.0") (
     var alpha = 0.0
     while (i < n) {
       alpha = m / m1 * mean(i)
-      j = 0
+      j = i
       while (j < n) {
         G(i, j) = G(i, j) / m1 - alpha * mean(j)
+        G(j, i) = G(i, j)
         j += 1
       }
       i += 1

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/RowMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/RowMatrix.scala
@@ -359,8 +359,9 @@ class RowMatrix @Since("1.0.0") (
       alpha = m / m1 * mean(i)
       j = i
       while (j < n) {
-        G(i, j) = G(i, j) / m1 - alpha * mean(j)
-        G(j, i) = G(i, j)
+        val Gij = G(i, j) / m1 - alpha * mean(j)
+        G(i, j) = Gij
+        G(j, i) = Gij
         j += 1
       }
       i += 1


### PR DESCRIPTION
Compute upper triangular values of the covariance matrix, then copy to lower triangular values.
