### PR TITLE
[SPARK-10515] When killing executor, the pending replacement executors should not be lost

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -438,6 +438,8 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
     if (!replace) {
       doRequestTotalExecutors(
         numExistingExecutors + numPendingExecutors - executorsPendingToRemove.size)
+    } else {
+      numPendingExecutors += knownExecutors.size
     }
 
     doKillExecutors(executorsToKill)

--- a/core/src/test/scala/org/apache/spark/deploy/StandaloneDynamicAllocationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/StandaloneDynamicAllocationSuite.scala
@@ -390,12 +390,12 @@ class StandaloneDynamicAllocationSuite
     var apps = getApplications()
     assert(apps.head.executors.size === 2)
     // kill executor 1
-    assert(killNExecutors(sc, 1))
+    assert(sc.killExecutor(executors.head))
     apps = getApplications()
     assert(apps.head.executors.size === 2)
     assert(apps.head.getExecutorLimit === 2)
-    // kill all executors
-    assert(killAllExecutors(sc)
+    // kill executor 2
+    assert(sc.killExecutor(executors(1)))
     apps = getApplications()
     assert(apps.head.executors.size === 1)
     assert(apps.head.getExecutorLimit === 1)

--- a/core/src/test/scala/org/apache/spark/deploy/StandaloneDynamicAllocationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/StandaloneDynamicAllocationSuite.scala
@@ -369,6 +369,35 @@ class StandaloneDynamicAllocationSuite
     assert(apps.head.getExecutorLimit === 1)
   }
 
+test("the pending replacement executors should not be lost (SPARK-10515)") {
+  sc = new SparkContext(appConf)
+  val appId = sc.applicationId
+  eventually(timeout(10.seconds), interval(10.millis)) {
+    val apps = getApplications()
+    assert(apps.size === 1)
+    assert(apps.head.id === appId)
+    assert(apps.head.executors.size === 2)
+    assert(apps.head.getExecutorLimit === Int.MaxValue)
+  }
+  // sync executors between the Master and the driver, needed because
+  // the driver refuses to kill executors it does not know about
+  syncExecutors(sc)
+   val executors = getExecutorIds(sc)
+   assert(executors.size === 2)
+
+   // kill executor,and replace it
+   assert(sc.killAndReplaceExecutor(executors.head))
+   assert(master.apps.head.executors.size === 2)
+
+   assert(sc.killExecutor(executors.head))
+   assert(master.apps.head.executors.size === 2)
+   assert(master.apps.head.getExecutorLimit === 2)
+
+   assert(sc.killExecutor(executors(1)))
+   assert(master.apps.head.executors.size === 1)
+   assert(master.apps.head.getExecutorLimit === 1)
+  }
+
   // ===============================
   // | Utility methods for testing |
   // ===============================

--- a/core/src/test/scala/org/apache/spark/deploy/StandaloneDynamicAllocationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/StandaloneDynamicAllocationSuite.scala
@@ -385,17 +385,20 @@ class StandaloneDynamicAllocationSuite
     val executors = getExecutorIds(sc)
     assert(executors.size === 2)
 
-    // kill executor,and replace it
+    // kill executor 1, and replace it
     assert(sc.killAndReplaceExecutor(executors.head))
-    assert(master.apps.head.executors.size === 2)
-
-    assert(sc.killExecutor(executors.head))
-    assert(master.apps.head.executors.size === 2)
-    assert(master.apps.head.getExecutorLimit === 2)
-
-    assert(sc.killExecutor(executors(1)))
-    assert(master.apps.head.executors.size === 1)
-    assert(master.apps.head.getExecutorLimit === 1)
+    var apps = getApplications()
+    assert(apps.head.executors.size === 2)
+    // kill executor 1
+    assert(killNExecutors(sc, 1))
+    apps = getApplications()
+    assert(apps.head.executors.size === 2)
+    assert(apps.head.getExecutorLimit === 2)
+    // kill all executors
+    assert(killAllExecutors(sc)
+    apps = getApplications()
+    assert(apps.head.executors.size === 1)
+    assert(apps.head.getExecutorLimit === 1)
   }
 
   // ===============================

--- a/core/src/test/scala/org/apache/spark/deploy/StandaloneDynamicAllocationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/StandaloneDynamicAllocationSuite.scala
@@ -369,33 +369,33 @@ class StandaloneDynamicAllocationSuite
     assert(apps.head.getExecutorLimit === 1)
   }
 
-test("the pending replacement executors should not be lost (SPARK-10515)") {
-  sc = new SparkContext(appConf)
-  val appId = sc.applicationId
-  eventually(timeout(10.seconds), interval(10.millis)) {
-    val apps = getApplications()
-    assert(apps.size === 1)
-    assert(apps.head.id === appId)
-    assert(apps.head.executors.size === 2)
-    assert(apps.head.getExecutorLimit === Int.MaxValue)
-  }
-  // sync executors between the Master and the driver, needed because
-  // the driver refuses to kill executors it does not know about
-  syncExecutors(sc)
-   val executors = getExecutorIds(sc)
-   assert(executors.size === 2)
+  test("the pending replacement executors should not be lost (SPARK-10515)") {
+    sc = new SparkContext(appConf)
+    val appId = sc.applicationId
+    eventually(timeout(10.seconds), interval(10.millis)) {
+      val apps = getApplications()
+      assert(apps.size === 1)
+      assert(apps.head.id === appId)
+      assert(apps.head.executors.size === 2)
+      assert(apps.head.getExecutorLimit === Int.MaxValue)
+    }
+    // sync executors between the Master and the driver, needed because
+    // the driver refuses to kill executors it does not know about
+    syncExecutors(sc)
+    val executors = getExecutorIds(sc)
+    assert(executors.size === 2)
 
-   // kill executor,and replace it
-   assert(sc.killAndReplaceExecutor(executors.head))
-   assert(master.apps.head.executors.size === 2)
+    // kill executor,and replace it
+    assert(sc.killAndReplaceExecutor(executors.head))
+    assert(master.apps.head.executors.size === 2)
 
-   assert(sc.killExecutor(executors.head))
-   assert(master.apps.head.executors.size === 2)
-   assert(master.apps.head.getExecutorLimit === 2)
+    assert(sc.killExecutor(executors.head))
+    assert(master.apps.head.executors.size === 2)
+    assert(master.apps.head.getExecutorLimit === 2)
 
-   assert(sc.killExecutor(executors(1)))
-   assert(master.apps.head.executors.size === 1)
-   assert(master.apps.head.getExecutorLimit === 1)
+    assert(sc.killExecutor(executors(1)))
+    assert(master.apps.head.executors.size === 1)
+    assert(master.apps.head.getExecutorLimit === 1)
   }
 
   // ===============================

--- a/core/src/test/scala/org/apache/spark/deploy/StandaloneDynamicAllocationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/StandaloneDynamicAllocationSuite.scala
@@ -384,11 +384,14 @@ class StandaloneDynamicAllocationSuite
     syncExecutors(sc)
     val executors = getExecutorIds(sc)
     assert(executors.size === 2)
-
     // kill executor 1, and replace it
     assert(sc.killAndReplaceExecutor(executors.head))
+    eventually(timeout(10.seconds), interval(10.millis)) {
+      val apps = getApplications()
+      assert(apps.head.executors.size === 2)
+    }
+
     var apps = getApplications()
-    assert(apps.head.executors.size === 2)
     // kill executor 1
     assert(sc.killExecutor(executors.head))
     apps = getApplications()


### PR DESCRIPTION
If the heartbeat receiver kills executors (and new ones are not registered to replace them), the idle timeout for the old executors will be lost (and then change a total number of executors requested by Driver), So new ones will be not to asked to replace them.
For example, executorsPendingToRemove=Set(1), and executor 2 is idle timeout before a new executor is asked to replace executor 1. Then driver kill executor 2, and sending RequestExecutors to AM. But executorsPendingToRemove=Set(1,2), So AM doesn't allocate a executor to replace 1.

see: https://github.com/apache/spark/pull/8668
