### PR TITLE
[SPARK-10901] [YARN] spark.yarn.user.classpath.first doesn't work

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1187,15 +1187,8 @@ object Client extends Logging {
    * @param conf Spark configuration.
    */
   def getUserClasspath(conf: SparkConf): Array[URI] = {
-    getUserClasspath(conf.getOption(CONF_SPARK_USER_JAR),
-      conf.getOption(CONF_SPARK_YARN_SECONDARY_JARS))
-  }
-
-  private def getUserClasspath(
-      mainJar: Option[String],
-      secondaryJars: Option[String]): Array[URI] = {
-    val mainUri = getMainJarUri(mainJar)
-    val secondaryUris = getSecondaryJarUris(secondaryJars)
+    val mainUri = getMainJarUri(conf.getOption(CONF_SPARK_USER_JAR))
+    val secondaryUris = getSecondaryJarUris(conf.getOption(CONF_SPARK_YARN_SECONDARY_JARS))
     (mainUri ++ secondaryUris).toArray
   }
 

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1156,7 +1156,7 @@ object Client extends Logging {
       // in order to properly add the app jar when user classpath is first
       // we have to do the mainJar separate in order to send the right thing
       // into addFileToClasspath
-      val mainJar = 
+      val mainJar =
         if (args != null) {
           getMainJarUri(Option(args.userJar))
         } else {
@@ -1193,7 +1193,7 @@ object Client extends Logging {
   }
 
   private def getMainJarUri(mainJar: Option[String]): Option[URI] = {
-    mainJar.flatMap { path =>
+    mainJar.flatMap { path =
       val uri = new URI(path)
       if (uri.getScheme == LOCAL_SCHEME) Some(uri) else None
     }.orElse(Some(new URI(APP_JAR))) 

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1193,10 +1193,10 @@ object Client extends Logging {
   }
 
   private def getMainJarUri(mainJar: Option[String]): Option[URI] = {
-    mainJar.flatMap { path =
+    mainJar.flatMap { path =>
       val uri = new URI(path)
       if (uri.getScheme == LOCAL_SCHEME) Some(uri) else None
-    }.orElse(Some(new URI(APP_JAR))) 
+    }.orElse(Some(new URI(APP_JAR)))
   }
 
   private def getSecondaryJarUris(secondaryJars: Option[String]): Seq[URI] = {

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1162,6 +1162,8 @@ object Client extends Logging {
       userClassPath.foreach { x =>
         addFileToClasspath(sparkConf, x, null, env)
       }
+      // add the users application jar if its distributed through dist cache
+      addFileToClasspath(sparkConf, null, APP_JAR, env)
     }
     addFileToClasspath(sparkConf, new URI(sparkJar(sparkConf)), SPARK_JAR, env)
     populateHadoopClasspath(conf, env)


### PR DESCRIPTION
This should go into 1.5.2 also.

The issue is we were no longer adding the **app**.jar to the system classpath.
