### PR TITLE
[SPARK-10904][SPARKR] Fix to support `select(df, c("col1", "col2"))`

### DIFF
--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -1075,12 +1075,16 @@ setMethod("subset", signature(x = "DataFrame"),
 #'   select(df, c("col1", "col2"))
 #'   select(df, list(df$name, df$age + 1))
 #'   # Similar to R data frames columns can also be selected using `$`
-#'   df$age
+#'   df[,df$age]
 #' }
 setMethod("select", signature(x = "DataFrame", col = "character"),
           function(x, col, ...) {
-            sdf <- callJMethod(x@sdf, "select", col, list(...))
-            dataFrame(sdf)
+            if (length(col) > 1) {
+              select(x, as.list(col))
+            } else {
+              sdf <- callJMethod(x@sdf, "select", col, list(...))
+              dataFrame(sdf)
+            }
           })
 
 #' @rdname select
@@ -1853,13 +1857,13 @@ setMethod("crosstab",
 #' This function downloads the contents of a DataFrame into an R's data.frame.
 #' Since data.frames are held in memory, ensure that you have enough memory
 #' in your system to accommodate the contents.
-#' 
+#'
 #' @title Download data from a DataFrame into a data.frame
 #' @param x a DataFrame
 #' @return a data.frame
 #' @rdname as.data.frame
 #' @examples \dontrun{
-#' 
+#'
 #' irisDF <- createDataFrame(sqlContext, iris)
 #' df <- as.data.frame(irisDF[irisDF$Species == "setosa", ])
 #' }

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -1080,6 +1080,10 @@ setMethod("subset", signature(x = "DataFrame"),
 setMethod("select", signature(x = "DataFrame", col = "character"),
           function(x, col, ...) {
             if (length(col) > 1) {
+              if (length(list(...)) > 0) {
+                stop("To select multiple columns, use a character vector or list for col")
+              }
+
               select(x, as.list(col))
             } else {
               sdf <- callJMethod(x@sdf, "select", col, list(...))

--- a/R/pkg/inst/tests/test_sparkSQL.R
+++ b/R/pkg/inst/tests/test_sparkSQL.R
@@ -677,6 +677,8 @@ test_that("select with column", {
   df4 <- select(df, c("name", "age"))
   expect_equal(columns(df4), c("name", "age"))
   expect_equal(count(df4), 3)
+
+  expect_error(select(df, c("name", "age"), "name"), "To select multiple columns, use a character vector or list for col")
 })
 
 test_that("subsetting", {

--- a/R/pkg/inst/tests/test_sparkSQL.R
+++ b/R/pkg/inst/tests/test_sparkSQL.R
@@ -678,7 +678,8 @@ test_that("select with column", {
   expect_equal(columns(df4), c("name", "age"))
   expect_equal(count(df4), 3)
 
-  expect_error(select(df, c("name", "age"), "name"), "To select multiple columns, use a character vector or list for col")
+  expect_error(select(df, c("name", "age"), "name"),
+                "To select multiple columns, use a character vector or list for col")
 })
 
 test_that("subsetting", {

--- a/R/pkg/inst/tests/test_sparkSQL.R
+++ b/R/pkg/inst/tests/test_sparkSQL.R
@@ -673,6 +673,10 @@ test_that("select with column", {
   expect_equal(columns(df3), c("x"))
   expect_equal(count(df3), 3)
   expect_equal(collect(select(df3, "x"))[[1, 1]], "x")
+
+  df4 <- select(df, c("name", "age"))
+  expect_equal(columns(df4), c("name", "age"))
+  expect_equal(count(df4), 3)
 })
 
 test_that("subsetting", {


### PR DESCRIPTION
The fix is to coerce `c("a", "b")` into a list such that it could be serialized to call JVM with.
