### PR TITLE
[SPARK-10780] [ML]  Set initialModel in KMeans in Pipelines API

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -176,6 +176,21 @@ class KMeans @Since("1.5.0") (
   @Since("1.5.0")
   def setSeed(value: Long): this.type = set(seed, value)
 
+  // Initial cluster centers can be provided as a KMeansModel object rather than using the
+  // random or k-means|| initializationMode
+  private var initialModel: Option[MLlibKMeansModel] = None
+
+  /**
+   * Set the initial starting point, bypassing the random initialization or k-means||
+   * The condition model.k == this.k must be met, failure results
+   * in an IllegalArgumentException.
+   */
+  def setInitialModel(model: MLlibKMeansModel): this.type = {
+    require(model.k == this.getK, "mismatched cluster count")
+    initialModel = Some(model)
+    this
+  }
+
   @Since("1.5.0")
   override def fit(dataset: DataFrame): KMeansModel = {
     val rdd = dataset.select(col($(featuresCol))).map { case Row(point: Vector) => point }
@@ -187,6 +202,15 @@ class KMeans @Since("1.5.0") (
       .setMaxIterations($(maxIter))
       .setSeed($(seed))
       .setEpsilon($(tol))
+
+    initialModel match {
+      case Some(kMeansCenters) => {
+        algo.setInitialModel(kMeansCenters)
+      }
+      case None => {
+      }
+    }
+
     val parentModel = algo.run(rdd)
     val model = new KMeansModel(uid, parentModel)
     copyValues(model)

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.ml.clustering
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.mllib.clustering.{KMeans => MLlibKMeans}
+import org.apache.spark.mllib.clustering.{KMeans => MLlibKMeans, KMeansModel => MLlibKMeansModel}
 import org.apache.spark.mllib.linalg.{Vector, Vectors}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.sql.{DataFrame, SQLContext}
@@ -105,4 +105,32 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(clusters.size === k)
     assert(clusters === Set(0, 1, 2, 3, 4))
   }
+
+  test("Initialize using given cluster centers") {
+    val points = Seq(
+      Vectors.dense(0.0, 0.0, 0.0),
+      Vectors.dense(1.0, 1.0, 1.0),
+      Vectors.dense(2.0, 2.0, 2.0),
+      Vectors.dense(3.0, 3.0, 3.0),
+      Vectors.dense(4.0, 4.0, 4.0)
+    )
+
+    // creating an initial model
+    val initialModel = new MLlibKMeansModel(Array(points(0), points(1), points(2), points(3), points(4)))
+
+    val predictionColName = "kmeans_prediction"
+    var kmeans : KMeans = new KMeans().setK(k).setPredictionCol(predictionColName).setSeed(1).setInitialModel(initialModel)
+    val model = kmeans.fit(dataset)
+    assert(model.clusterCenters.length === k)
+
+    val transformed = model.transform(dataset)
+    val expectedColumns = Array("features", predictionColName)
+    expectedColumns.foreach { column =>
+      assert(transformed.columns.contains(column))
+    }
+    val clusters = transformed.select(predictionColName).map(_.getInt(0)).distinct().collect().toSet
+    assert(clusters.size === k)
+    assert(clusters === Set(0, 1, 2, 3, 4))
+  }
+
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -116,10 +116,16 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
     )
 
     // creating an initial model
-    val initialModel = new MLlibKMeansModel(Array(points(0), points(1), points(2), points(3), points(4)))
+    val initialModel = new MLlibKMeansModel(
+      Array(points(0), points(1), points(2), points(3), points(4))
+    )
 
     val predictionColName = "kmeans_prediction"
-    var kmeans : KMeans = new KMeans().setK(k).setPredictionCol(predictionColName).setSeed(1).setInitialModel(initialModel)
+    val kmeans = new KMeans()
+      .setK(k)
+      .setPredictionCol(predictionColName)
+      .setSeed(1)
+      .setInitialModel(initialModel)
     val model = kmeans.fit(dataset)
     assert(model.clusterCenters.length === k)
 


### PR DESCRIPTION
Added private var initialModel: Option[MLlibKMeansModel] = None to KMeans.scala to support the functionality.

Hoping that is the right place for it. Adding to KMeansParams would probably not be right. It would be great to get inputs.
