### PR TITLE
[SPARK-10918] [CORE] Prevent task failed for executor kill by driver

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -125,7 +125,8 @@ private[spark] class ExecutorAllocationManager(
     conf.getInt("spark.dynamicAllocation.initialExecutors", minNumExecutors)
 
   // Executors that have been requested to be removed but have not been killed yet
-  private val executorsPendingToRemove = new mutable.HashSet[String] with mutable.SynchronizedSet[String]
+  private val executorsPendingToRemove = new mutable.HashSet[String]
+    with mutable.SynchronizedSet[String]
 
   // All known executors
   private val executorIds = new mutable.HashSet[String] with mutable.SynchronizedSet[String]
@@ -136,7 +137,8 @@ private[spark] class ExecutorAllocationManager(
 
   // A timestamp for each executor of when the executor should be removed, indexed by the ID
   // This is set when an executor is no longer running a task, or when it first registers
-  private val removeTimes = new mutable.HashMap[String, Long] with mutable.SynchronizedMap[String, Long]
+  private val removeTimes = new mutable.HashMap[String, Long]
+    with mutable.SynchronizedMap[String, Long]
 
   // Polling loop interval (ms)
   private val intervalMillis: Long = 100
@@ -501,7 +503,7 @@ private[spark] class ExecutorAllocationManager(
       logWarning(s"Attempted to mark unknown executor $executorId idle")
     }
   }
-  
+
   def isExecutorAlive(executorId: String): Boolean = {
     if (!executorsPendingToRemove.contains(executorId)) {
       true

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -125,10 +125,10 @@ private[spark] class ExecutorAllocationManager(
     conf.getInt("spark.dynamicAllocation.initialExecutors", minNumExecutors)
 
   // Executors that have been requested to be removed but have not been killed yet
-  private val executorsPendingToRemove = new mutable.HashSet[String]
+  private val executorsPendingToRemove = new mutable.HashSet[String] with mutable.SynchronizedSet[String]
 
   // All known executors
-  private val executorIds = new mutable.HashSet[String]
+  private val executorIds = new mutable.HashSet[String] with mutable.SynchronizedSet[String]
 
   // A timestamp of when an addition should be triggered, or NOT_SET if it is not set
   // This is set when pending tasks are added but not scheduled yet
@@ -136,7 +136,7 @@ private[spark] class ExecutorAllocationManager(
 
   // A timestamp for each executor of when the executor should be removed, indexed by the ID
   // This is set when an executor is no longer running a task, or when it first registers
-  private val removeTimes = new mutable.HashMap[String, Long]
+  private val removeTimes = new mutable.HashMap[String, Long] with mutable.SynchronizedMap[String, Long]
 
   // Polling loop interval (ms)
   private val intervalMillis: Long = 100
@@ -501,12 +501,20 @@ private[spark] class ExecutorAllocationManager(
       logWarning(s"Attempted to mark unknown executor $executorId idle")
     }
   }
+  
+  def isExecutorAlive(executorId: String): Boolean = {
+    if (!executorsPendingToRemove.contains(executorId)) {
+      true
+    } else {
+      false
+    }
+  }
 
   /**
    * Callback invoked when the specified executor is now running a task.
    * This resets all variables used for removing this executor.
    */
-  private def onExecutorBusy(executorId: String): Unit = synchronized {
+  def onExecutorBusy(executorId: String): Unit = synchronized {
     logDebug(s"Clearing idle timer for $executorId because it is now running a task")
     removeTimes.remove(executorId)
   }
@@ -605,7 +613,6 @@ private[spark] class ExecutorAllocationManager(
 
         // Mark the executor on which this task is scheduled as busy
         executorIdToTaskIds.getOrElseUpdate(executorId, new mutable.HashSet[Long]) += taskId
-        allocationManager.onExecutorBusy(executorId)
       }
     }
 

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -504,12 +504,8 @@ private[spark] class ExecutorAllocationManager(
     }
   }
 
-  def isExecutorAlive(executorId: String): Boolean = {
-    if (!executorsPendingToRemove.contains(executorId)) {
-      true
-    } else {
-      false
-    }
+  def isExecutorPendingToRemove(executorId: String): Boolean = {
+    !executorsPendingToRemove.contains(executorId)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -474,6 +474,14 @@ private[spark] class TaskSetManager(
               abort(s"$msg Exception during serialization: $e")
               throw new TaskNotSerializableException(e)
           }
+          val executorManager = sched.sc.executorAllocationManager.getOrElse(null)
+          if(executorManager != null) {
+            if(!executorManager.isExecutorAlive(execId)) {
+              return None
+            }
+            executorManager.onExecutorBusy(execId)
+          }
+          
           if (serializedTask.limit > TaskSetManager.TASK_SIZE_TO_WARN_KB * 1024 &&
               !emittedTaskSizeWarning) {
             emittedTaskSizeWarning = true

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -475,13 +475,13 @@ private[spark] class TaskSetManager(
               throw new TaskNotSerializableException(e)
           }
           val executorManager = sched.sc.executorAllocationManager.getOrElse(null)
-          if(executorManager != null) {
-            if(!executorManager.isExecutorAlive(execId)) {
+          if (executorManager != null) {
+            if (!executorManager.isExecutorAlive(execId)) {
               return None
             }
             executorManager.onExecutorBusy(execId)
           }
-          
+
           if (serializedTask.limit > TaskSetManager.TASK_SIZE_TO_WARN_KB * 1024 &&
               !emittedTaskSizeWarning) {
             emittedTaskSizeWarning = true

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -448,7 +448,7 @@ private[spark] class TaskSetManager(
           // Found a task; do some bookkeeping and return a task description
           val task = tasks(index)
           val taskId = sched.newTaskId()
-          
+
           val executorManager = sched.sc.executorAllocationManager.getOrElse(null)
           if (executorManager != null) {
             if (!executorManager.isExecutorPendingToRemove(execId)) {
@@ -484,7 +484,6 @@ private[spark] class TaskSetManager(
               abort(s"$msg Exception during serialization: $e")
               throw new TaskNotSerializableException(e)
           }
-          
           if (serializedTask.limit > TaskSetManager.TASK_SIZE_TO_WARN_KB * 1024 &&
               !emittedTaskSizeWarning) {
             emittedTaskSizeWarning = true


### PR DESCRIPTION
  When dynamicAllocation is enabled, when a executor was idle timeout, it will be kill by driver, if a task offer to the executor at the same time, the task will failed due to executor lost.
1. Before scheduler a task to a executor, check if it has been killed.
2. Call executorManager.onExecutorBusy before scheduler task.
