### PR TITLE
[SPARK-10797] RDD's coalesce should not write out the temporary key

### DIFF
--- a/core/src/main/java/org/apache/spark/shuffle/sort/SortShuffleFileWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/SortShuffleFileWriter.java
@@ -17,15 +17,14 @@
 
 package org.apache.spark.shuffle.sort;
 
-import java.io.File;
-import java.io.IOException;
-
+import org.apache.spark.TaskContext;
+import org.apache.spark.annotation.Private;
+import org.apache.spark.storage.BlockId;
 import scala.Product2;
 import scala.collection.Iterator;
 
-import org.apache.spark.annotation.Private;
-import org.apache.spark.TaskContext;
-import org.apache.spark.storage.BlockId;
+import java.io.File;
+import java.io.IOException;
 
 /**
  * Interface for objects that {@link SortShuffleWriter} uses to write its output files.
@@ -33,7 +32,7 @@ import org.apache.spark.storage.BlockId;
 @Private
 public interface SortShuffleFileWriter<K, V> {
 
-  void insertAll(Iterator<Product2<K, V>> records) throws IOException;
+  void insertAll(Iterator<Product2<K, V>> records, boolean dropKeys) throws IOException;
 
   /**
    * Write all the data added into this shuffle sorter into a file in the disk store. This is

--- a/core/src/main/scala/org/apache/spark/Dependency.scala
+++ b/core/src/main/scala/org/apache/spark/Dependency.scala
@@ -73,7 +73,8 @@ class ShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](
     val serializer: Option[Serializer] = None,
     val keyOrdering: Option[Ordering[K]] = None,
     val aggregator: Option[Aggregator[K, V, C]] = None,
-    val mapSideCombine: Boolean = false)
+    val mapSideCombine: Boolean = false,
+    val dropKeys: Boolean = false)
   extends Dependency[Product2[K, V]] {
 
   override def rdd: RDD[Product2[K, V]] = _rdd.asInstanceOf[RDD[Product2[K, V]]]
@@ -88,7 +89,7 @@ class ShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](
   val shuffleId: Int = _rdd.context.newShuffleId()
 
   val shuffleHandle: ShuffleHandle = _rdd.context.env.shuffleManager.registerShuffle(
-    shuffleId, _rdd.partitions.size, this)
+    shuffleId, _rdd.partitions.size, this).setDropKeys(dropKeys)
 
   _rdd.sparkContext.cleaner.foreach(_.registerShuffleForCleanup(this))
 }

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -398,8 +398,10 @@ abstract class RDD[T: ClassTag](
 
       // include a shuffle step so that our upstream tasks are still distributed
       new CoalescedRDD(
-        new ShuffledRDD[Int, T, T](mapPartitionsWithIndex(distributePartition),
-        new HashPartitioner(numPartitions)).setDropKeys(true).mapPartitions(_.asInstanceOf[Iterator[T]]),
+        new ShuffledRDD[Int, T, T](
+          mapPartitionsWithIndex(distributePartition),
+          new HashPartitioner(numPartitions)
+        ).setDropKeys(true).mapPartitions(_.asInstanceOf[Iterator[T]]),
         numPartitions)
     } else {
       new CoalescedRDD(this, numPartitions)

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -399,8 +399,8 @@ abstract class RDD[T: ClassTag](
       // include a shuffle step so that our upstream tasks are still distributed
       new CoalescedRDD(
         new ShuffledRDD[Int, T, T](mapPartitionsWithIndex(distributePartition),
-        new HashPartitioner(numPartitions)),
-        numPartitions).values
+        new HashPartitioner(numPartitions)).setDropKeys(true).mapPartitions(_.asInstanceOf[Iterator[T]]),
+        numPartitions)
     } else {
       new CoalescedRDD(this, numPartitions)
     }

--- a/core/src/main/scala/org/apache/spark/rdd/ShuffledRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ShuffledRDD.scala
@@ -85,8 +85,8 @@ class ShuffledRDD[K: ClassTag, V: ClassTag, C: ClassTag](
   }
 
   override def getDependencies: Seq[Dependency[_]] = {
-    List(new ShuffleDependency(prev, part, serializer, keyOrdering,
-      aggregator, mapSideCombine, dropKeys))
+    List(new ShuffleDependency(prev, part, serializer, keyOrdering, aggregator,
+      mapSideCombine, dropKeys))
   }
 
   override val partitioner = Some(part)

--- a/core/src/main/scala/org/apache/spark/rdd/ShuffledRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ShuffledRDD.scala
@@ -52,6 +52,8 @@ class ShuffledRDD[K: ClassTag, V: ClassTag, C: ClassTag](
 
   private var mapSideCombine: Boolean = false
 
+  private var dropKeys: Boolean = false
+
   /** Set a serializer for this RDD's shuffle, or null to use the default (spark.serializer) */
   def setSerializer(serializer: Serializer): ShuffledRDD[K, V, C] = {
     this.serializer = Option(serializer)
@@ -76,8 +78,15 @@ class ShuffledRDD[K: ClassTag, V: ClassTag, C: ClassTag](
     this
   }
 
+  /** Set dropKeys flag for RDD's shuffle. */
+  def setDropKeys(dropKeys: Boolean): ShuffledRDD[K, V, C] = {
+    this.dropKeys = dropKeys
+    this
+  }
+
   override def getDependencies: Seq[Dependency[_]] = {
-    List(new ShuffleDependency(prev, part, serializer, keyOrdering, aggregator, mapSideCombine))
+    List(new ShuffleDependency(prev, part, serializer, keyOrdering,
+      aggregator, mapSideCombine, dropKeys))
   }
 
   override val partitioner = Some(part)

--- a/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
@@ -61,7 +61,7 @@ private[spark] class BlockStoreShuffleReader[K, C](
       // Note: the asKeyValueIterator below wraps a key/value iterator inside of a
       // NextIterator. The NextIterator makes sure that close() is called on the
       // underlying InputStream when all records have been read.
-      if(!handle.dropKeys) {
+      if (!handle.dropKeys) {
         serializerInstance.deserializeStream(wrappedStream).asKeyValueIterator
       } else {
         serializerInstance.deserializeStream(wrappedStream).asIterator

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleHandle.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleHandle.scala
@@ -25,4 +25,15 @@ import org.apache.spark.annotation.DeveloperApi
  * @param shuffleId ID of the shuffle
  */
 @DeveloperApi
-abstract class ShuffleHandle(val shuffleId: Int) extends Serializable {}
+abstract class ShuffleHandle(val shuffleId: Int) extends Serializable {
+  private var _dropKeys: Boolean = false
+
+  def setDropKeys(dropKeys: Boolean): ShuffleHandle = {
+    this._dropKeys = dropKeys
+    this
+  }
+
+  def dropKeys: Boolean = {
+    _dropKeys
+  }
+}

--- a/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleWriter.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleWriter.scala
@@ -52,8 +52,8 @@ private[spark] class SortShuffleWriter[K, V, C](
   override def write(records: Iterator[Product2[K, V]]): Unit = {
     sorter = if (dep.mapSideCombine) {
       require(dep.aggregator.isDefined, "Map-side combine without Aggregator specified!")
-      new ExternalSorter[K, V, C](
-        dep.aggregator, Some(dep.partitioner), dep.keyOrdering, dep.serializer, dep.shuffleHandle.dropKeys)
+      new ExternalSorter[K, V, C](dep.aggregator, Some(dep.partitioner),
+        dep.keyOrdering, dep.serializer, dep.shuffleHandle.dropKeys)
     } else if (SortShuffleWriter.shouldBypassMergeSort(
         SparkEnv.get.conf, dep.partitioner.numPartitions, aggregator = None, keyOrdering = None)) {
       // If there are fewer than spark.shuffle.sort.bypassMergeThreshold partitions and we don't
@@ -67,8 +67,8 @@ private[spark] class SortShuffleWriter[K, V, C](
       // In this case we pass neither an aggregator nor an ordering to the sorter, because we don't
       // care whether the keys get sorted in each partition; that will be done on the reduce side
       // if the operation being run is sortByKey.
-      new ExternalSorter[K, V, V](
-        aggregator = None, Some(dep.partitioner), ordering = None, dep.serializer, dep.shuffleHandle.dropKeys)
+      new ExternalSorter[K, V, V](aggregator = None, Some(dep.partitioner),
+        ordering = None, dep.serializer, dep.shuffleHandle.dropKeys)
     }
     sorter.insertAll(records, handle.dropKeys)
 

--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockObjectWriter.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockObjectWriter.scala
@@ -185,6 +185,15 @@ private[spark] class DiskBlockObjectWriter(
     recordWritten()
   }
 
+  def write(obj: Any) {
+    if (!initialized) {
+      open()
+    }
+
+    objOut.writeObject(obj)
+    recordWritten()
+  }
+
   override def write(b: Int): Unit = throw new UnsupportedOperationException()
 
   override def write(kvBytes: Array[Byte], offs: Int, len: Int): Unit = {

--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockObjectWriter.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockObjectWriter.scala
@@ -185,6 +185,9 @@ private[spark] class DiskBlockObjectWriter(
     recordWritten()
   }
 
+  /**
+   * Writes an object.
+   */
   def write(obj: Any) {
     if (!initialized) {
       open()

--- a/core/src/main/scala/org/apache/spark/util/collection/PartitionedSerializedPairBuffer.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/PartitionedSerializedPairBuffer.scala
@@ -128,7 +128,8 @@ private[spark] class PartitionedSerializedPairBuffer[K, V](
 
   override def estimateSize: Long = metaBuffer.capacity * 4L + kvBuffer.capacity
 
-  override def destructiveSortedWritablePartitionedIterator(keyComparator: Option[Comparator[K]])
+  override def destructiveSortedWritablePartitionedIterator(keyComparator: Option[Comparator[K]],
+                                                            dropKeys: Boolean = false)
     : WritablePartitionedIterator = {
     sort(keyComparator)
     new WritablePartitionedIterator {

--- a/core/src/main/scala/org/apache/spark/util/collection/WritablePartitionedPairCollection.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/WritablePartitionedPairCollection.scala
@@ -45,14 +45,19 @@ private[spark] trait WritablePartitionedPairCollection[K, V] {
    * returned in order of their partition ID and then the given comparator.
    * This may destroy the underlying collection.
    */
-  def destructiveSortedWritablePartitionedIterator(keyComparator: Option[Comparator[K]])
+  def destructiveSortedWritablePartitionedIterator(keyComparator: Option[Comparator[K]],
+                                                   dropKeys: Boolean = false)
     : WritablePartitionedIterator = {
     val it = partitionedDestructiveSortedIterator(keyComparator)
     new WritablePartitionedIterator {
       private[this] var cur = if (it.hasNext) it.next() else null
 
       def writeNext(writer: DiskBlockObjectWriter): Unit = {
-        writer.write(cur._1._2, cur._2)
+        if (dropKeys) {
+          writer.write(cur._2)
+        } else {
+          writer.write(cur._1._2, cur._2)
+        }
         cur = if (it.hasNext) it.next() else null
       }
 

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriterSuite.scala
@@ -111,9 +111,10 @@ class BypassMergeSortShuffleWriterSuite extends SparkFunSuite with BeforeAndAfte
       blockManager,
       new HashPartitioner(7),
       shuffleWriteMetrics,
-      serializer
+      serializer,
+      false
     )
-    writer.insertAll(Iterator.empty)
+    writer.insertAll(Iterator.empty, false)
     val partitionLengths = writer.writePartitionedFile(shuffleBlockId, taskContext, outputFile)
     assert(partitionLengths.sum === 0)
     assert(outputFile.exists())
@@ -133,9 +134,10 @@ class BypassMergeSortShuffleWriterSuite extends SparkFunSuite with BeforeAndAfte
       blockManager,
       new HashPartitioner(7),
       shuffleWriteMetrics,
-      serializer
+      serializer,
+      false
     )
-    writer.insertAll(records)
+    writer.insertAll(records, false)
     assert(temporaryFilesCreated.nonEmpty)
     val partitionLengths = writer.writePartitionedFile(shuffleBlockId, taskContext, outputFile)
     assert(partitionLengths.sum === outputFile.length())
@@ -152,7 +154,8 @@ class BypassMergeSortShuffleWriterSuite extends SparkFunSuite with BeforeAndAfte
       blockManager,
       new HashPartitioner(7),
       shuffleWriteMetrics,
-      serializer
+      serializer,
+      false
     )
     intercept[SparkException] {
       writer.insertAll((0 until 100000).iterator.map(i => {
@@ -160,7 +163,7 @@ class BypassMergeSortShuffleWriterSuite extends SparkFunSuite with BeforeAndAfte
           throw new SparkException("Intentional failure")
         }
         (i, i)
-      }))
+      }), false)
     }
     assert(temporaryFilesCreated.nonEmpty)
     writer.stop()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/sort.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/sort.scala
@@ -49,7 +49,7 @@ case class Sort(
     child.execute().mapPartitions( { iterator =>
       val ordering = newOrdering(sortOrder, child.output)
       val sorter = new ExternalSorter[InternalRow, Null, InternalRow](ordering = Some(ordering))
-      sorter.insertAll(iterator.map(r => (r.copy(), null)))
+      sorter.insertAll(iterator.map(r => (r.copy(), null)), false)
       val baseIterator = sorter.iterator.map(_._1)
       val context = TaskContext.get()
       context.taskMetrics().incDiskBytesSpilled(sorter.diskBytesSpilled)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/UnsafeRowSerializerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/UnsafeRowSerializerSuite.scala
@@ -118,7 +118,7 @@ class UnsafeRowSerializerSuite extends SparkFunSuite with LocalSparkContext {
 
       // Ensure we spilled something and have to merge them later
       assert(sorter.numSpills === 0)
-      sorter.insertAll(data)
+      sorter.insertAll(data, false)
       assert(sorter.numSpills > 0)
 
       // Merging spilled files should not throw assertion error


### PR DESCRIPTION
I think we have the following options to solve this problem:
1. [General, but too complex] Create a new ShuffledRDD, add support to shuffle system to read values instead of key-value pairs.
2. [General, too complex] Create a new CoalescedRDD, that bypasses ShuffledRDD and reads from shuffle-layer directly - still need to add support to read values.
3. [Minimal impact on code] Add option for shuffle-layer to write out values only and cast the key-value iterator at read-site to Iterator[T].

I've implemented and I'm using the 3rd option. You will experience speed-up based on the size of current payload (values).
