### PR TITLE
[SPARK-10926][CORE] Create WeakReferenceCleaner interface that Contex…

### DIFF
--- a/core/src/main/scala/org/apache/spark/WeakReferenceCleaner.scala
+++ b/core/src/main/scala/org/apache/spark/WeakReferenceCleaner.scala
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark
+
+import java.lang.ref.ReferenceQueue
+
+import scala.collection.mutable.{ArrayBuffer, SynchronizedBuffer}
+
+import org.apache.spark.util.cleanup.{CleanupTask, CleanupTaskWeakReference}
+
+/**
+ * Utility trait that keeps a long running thread for cleaning up weak references
+ * after they are GCed. Currently implemented by ContextCleaner and ExecutorCleaner
+ * only.
+ */
+private[spark] trait WeakReferenceCleaner extends Logging {
+
+  private val referenceBuffer = new ArrayBuffer[CleanupTaskWeakReference]
+    with SynchronizedBuffer[CleanupTaskWeakReference]
+
+  private val referenceQueue = new ReferenceQueue[AnyRef]
+
+  private val cleaningThread = new Thread() { override def run() { keepCleaning() }}
+
+  private var stopped = false
+
+  /** Start the cleaner. */
+  def start(): Unit = {
+    cleaningThread.setDaemon(true)
+    cleaningThread.setName(cleanupThreadName())
+    cleaningThread.start()
+  }
+
+  def stop(): Unit = {
+    stopped = true
+    synchronized {
+      // Interrupt the cleaning thread, but wait until the current task has finished before
+      // doing so. This guards against the race condition where a cleaning thread may
+      // potentially clean similarly named variables created by a different SparkContext,
+      // resulting in otherwise inexplicable block-not-found exceptions (SPARK-6132).
+      cleaningThread.interrupt()
+    }
+    cleaningThread.join()
+  }
+
+  protected def keepCleaning(): Unit = {
+    while (!stopped) {
+      try {
+        val reference = Option(referenceQueue.remove(WeakReferenceCleaner.REF_QUEUE_POLL_TIMEOUT))
+          .map(_.asInstanceOf[CleanupTaskWeakReference])
+        // Synchronize here to avoid being interrupted on stop()
+        synchronized {
+          reference.map(_.task).foreach { task =>
+            logDebug("Got cleaning task " + task)
+            referenceBuffer -= reference.get
+            handleCleanupForSpecificTask(task)
+          }
+        }
+      } catch {
+        case ie: InterruptedException if stopped => // ignore
+        case e: Exception => logError("Error in cleaning thread", e)
+      }
+    }
+  }
+
+  /** Register an object for cleanup. */
+  protected def registerForCleanup(objectForCleanup: AnyRef, task: CleanupTask): Unit = {
+    referenceBuffer += new CleanupTaskWeakReference(task, objectForCleanup, referenceQueue)
+  }
+
+  protected def handleCleanupForSpecificTask(task: CleanupTask)
+  protected def cleanupThreadName(): String
+}
+
+private object WeakReferenceCleaner {
+  private val REF_QUEUE_POLL_TIMEOUT = 100
+}

--- a/core/src/main/scala/org/apache/spark/util/cleanup/CleanupTasks.scala
+++ b/core/src/main/scala/org/apache/spark/util/cleanup/CleanupTasks.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.util.cleanup
+
+import java.lang.ref.{ReferenceQueue, WeakReference}
+
+/**
+ * Classes that represent cleaning tasks.
+ */
+private[spark] sealed trait CleanupTask
+private[spark] case class CleanRDD(rddId: Int) extends CleanupTask
+private[spark] case class CleanShuffle(shuffleId: Int) extends CleanupTask
+private[spark] case class CleanBroadcast(broadcastId: Long) extends CleanupTask
+private[spark] case class CleanAccum(accId: Long) extends CleanupTask
+private[spark] case class CleanCheckpoint(rddId: Int) extends CleanupTask
+
+/**
+ * A WeakReference associated with a CleanupTask.
+ *
+ * When the referent object becomes only weakly reachable, the corresponding
+ * CleanupTaskWeakReference is automatically added to the given reference queue.
+ */
+private[spark] class CleanupTaskWeakReference(
+    val task: CleanupTask,
+    referent: AnyRef,
+    referenceQueue: ReferenceQueue[AnyRef])
+  extends WeakReference(referent, referenceQueue)

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -80,6 +80,35 @@ object MimaExcludes {
           "org.apache.spark.ml.regression.LeastSquaresAggregator.add"),
         ProblemFilters.exclude[MissingMethodProblem](
           "org.apache.spark.ml.regression.LeastSquaresCostFun.this")
+      ) ++ Seq(
+        // Cleanup task types are marked as private but Mima also confused by this change,
+        // similar to SPARK-10381.
+        ProblemFilters.exclude[MissingClassProblem](
+          "org.apache.spark.CleanAccum"),
+        ProblemFilters.exclude[MissingClassProblem](
+          "org.apache.spark.CleanAccum$"),
+        ProblemFilters.exclude[MissingClassProblem](
+          "org.apache.spark.CleanBroadcast"),
+        ProblemFilters.exclude[MissingClassProblem](
+          "org.apache.spark.CleanBroadcast$"),
+        ProblemFilters.exclude[MissingClassProblem](
+          "org.apache.spark.CleanCheckpoint"),
+        ProblemFilters.exclude[MissingClassProblem](
+          "org.apache.spark.CleanCheckpoint$"),
+        ProblemFilters.exclude[MissingClassProblem](
+          "org.apache.spark.CleanupTask"),
+        ProblemFilters.exclude[MissingClassProblem](
+          "org.apache.spark.CleanRDD"),
+        ProblemFilters.exclude[MissingClassProblem](
+          "org.apache.spark.CleanRDD$"),
+        ProblemFilters.exclude[MissingClassProblem](
+          "org.apache.spark.CleanShuffle"),
+        ProblemFilters.exclude[MissingClassProblem](
+          "org.apache.spark.CleanShuffle$"),
+        ProblemFilters.exclude[MissingClassProblem](
+          "org.apache.spark.CleanupTaskWeakReference"),
+        ProblemFilters.exclude[MissingClassProblem](
+          "org.apache.spark.CleanupTaskWeakReference$")
       )
     case v if v.startsWith("1.5") =>
       Seq(


### PR DESCRIPTION
Preparing the way for SPARK-10250 which will introduce other objects
that will be cleaned via detecting their being cleaned up. In particular, an existing PR - https://github.com/apache/spark/pull/8438 - has a dependency on this change, but this change was factored out to its own PR to facilitate reviewing: 
