### PR TITLE
[SPARK-10958] Use json4s 3.3.0. Formats is now serializable.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -201,7 +201,7 @@
     <dependency>
       <groupId>org.json4s</groupId>
       <artifactId>json4s-jackson_${scala.binary.version}</artifactId>
-      <version>3.2.10</version>
+      <version>3.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>


### PR DESCRIPTION
Having serializable Formats makes json4s much nicer to work with in
Spark. This seems like a worthwhile upgrade, especially since it's
pretty much unchanged besides a few fixes.
