### PR TITLE
[SPARK-10955][streaming] Add a warning if dynamic allocation for Streaming applications

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -568,7 +568,7 @@ class StreamingContext private[streaming] (
     if (Utils.isDynamicAllocationEnabled(sc.conf)) {
       logWarning("Dynamic Allocation is enabled for this application. " +
         "Enabling Dynamic allocation for Spark Streaming applications can cause data loss if " +
-        "Write Ahead Log is not enabled for non-replayable sources, like Flume.")
+        "Write Ahead Log is not enabled for non-replayable sources like Flume.")
     }
   }
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -565,14 +565,9 @@ class StreamingContext private[streaming] (
       }
     }
 
-    if (Utils.isDynamicAllocationEnabled(sc.conf)) {
-      val maxExecutors = sc.conf.getInt("spark.dynamicAllocation.maxExecutors", 2)
-      sc.conf.set("spark.dynamicAllocation.enabled", false.toString)
-      sc.conf.set("spark.executor.instances", maxExecutors.toString)
-      logWarning("Dynamic allocation is not supported with Spark Streaming currently, since it " +
-        s"could lead to data loss in some cases. " +
-        s"The number of executors is being set to $maxExecutors")
-    }
+    require(!Utils.isDynamicAllocationEnabled(sc.conf),
+      "Dynamic allocation is not supported with Spark Streaming currently, since it " +
+        s"could lead to data loss in some cases. ")
   }
 
   /**

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -565,12 +565,11 @@ class StreamingContext private[streaming] (
       }
     }
 
-    val enableDynamicAllocation =
-      sc.conf.getBoolean("spark.streaming.dynamicAllocation.enabled", defaultValue = false)
-
-    require(enableDynamicAllocation || !Utils.isDynamicAllocationEnabled(sc.conf),
-      "Dynamic allocation is not supported with Spark Streaming currently, since it " +
-        s"could lead to data loss in some cases. ")
+    if (Utils.isDynamicAllocationEnabled(sc.conf)) {
+      logWarning("Dynamic Allocation is enabled for this application. " +
+        "Enabling Dynamic allocation for Spark Streaming applications can cause data loss if " +
+        "Write Ahead Log is not enabled for non-replayable sources, like Flume.")
+    }
   }
 
   /**

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -44,7 +44,7 @@ import org.apache.spark.streaming.dstream._
 import org.apache.spark.streaming.receiver.{ActorReceiver, ActorSupervisorStrategy, Receiver}
 import org.apache.spark.streaming.scheduler.{JobScheduler, StreamingListener}
 import org.apache.spark.streaming.ui.{StreamingJobProgressListener, StreamingTab}
-import org.apache.spark.util.{Utils, CallSite, ShutdownHookManager, ThreadUtils}
+import org.apache.spark.util.{CallSite, ShutdownHookManager, ThreadUtils, Utils}
 
 /**
  * Main entry point for Spark Streaming functionality. It provides methods used to create
@@ -565,7 +565,10 @@ class StreamingContext private[streaming] (
       }
     }
 
-    require(!Utils.isDynamicAllocationEnabled(sc.conf),
+    val enableDynamicAllocation =
+      sc.conf.getBoolean("spark.streaming.dynamicAllocation.enabled", defaultValue = false)
+
+    require(enableDynamicAllocation || !Utils.isDynamicAllocationEnabled(sc.conf),
       "Dynamic allocation is not supported with Spark Streaming currently, since it " +
         s"could lead to data loss in some cases. ")
   }

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -568,7 +568,8 @@ class StreamingContext private[streaming] (
     if (Utils.isDynamicAllocationEnabled(sc.conf)) {
       logWarning("Dynamic Allocation is enabled for this application. " +
         "Enabling Dynamic allocation for Spark Streaming applications can cause data loss if " +
-        "Write Ahead Log is not enabled for non-replayable sources like Flume.")
+        "Write Ahead Log is not enabled for non-replayable sources like Flume. " +
+        "See the programming guide for details on how to enable the Write Ahead Log")
     }
   }
 


### PR DESCRIPTION
Dynamic allocation can be painful for streaming apps and can lose data. Log a warning for streaming applications if dynamic allocation is enabled.
