### PR TITLE
[SPARK-10957][ML] setParams changes quantileProbabilities unexpectly in PySpark's AFTSurvivalRegression

### DIFF
--- a/python/pyspark/ml/regression.py
+++ b/python/pyspark/ml/regression.py
@@ -701,11 +701,7 @@ class AFTSurvivalRegression(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredi
                   quantilesCol=None):
         """
         kwargs = self.setParams._input_kwargs
-        if quantileProbabilities is None:
-            return self._set(**kwargs).setQuantileProbabilities([0.01, 0.05, 0.1, 0.25, 0.5,
-                                                                 0.75, 0.9, 0.95, 0.99])
-        else:
-            return self._set(**kwargs)
+        return self._set(**kwargs)
 
     def _create_model(self, java_model):
         return AFTSurvivalRegressionModel(java_model)


### PR DESCRIPTION
If user doesn't specify `quantileProbs` in `setParams`, it will get reset to the default value. We don't need special handling here. @vectorijk @yanboliang 
