### PR TITLE
[SPARK-10960][SQL] SQL with windowing function should be able to refer column in inner select

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -761,13 +761,6 @@ class Analyzer(
       }.isDefined
     }
 
-    private def hasAggregation(expr: NamedExpression): Boolean = {
-      expr.find {
-        case agg: AggregateExpression => true
-        case _ => false
-      }.isDefined
-    }
-
     /**
      * From a Seq of [[NamedExpression]]s, extract expressions containing window expressions and
      * other regular expressions that do not contain any window expression. For example, for
@@ -839,11 +832,8 @@ class Analyzer(
             extractedExprBuffer += withName
             withName.toAttribute
 
-          case ne: Alias if hasWindowFunction(ne) && !hasAggregation(ne) =>
-            ne.children.map(_.transform {
-              case e: NamedExpression => extractExpr(e)
-            })
-            ne
+          // Extracts other attributes
+          case attr: Attribute => extractExpr(attr)
 
         }.asInstanceOf[NamedExpression]
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -761,6 +761,13 @@ class Analyzer(
       }.isDefined
     }
 
+    private def hasAggregation(expr: NamedExpression): Boolean = {
+      expr.find {
+        case agg: AggregateExpression => true
+        case _ => false
+      }.isDefined
+    }
+
     /**
      * From a Seq of [[NamedExpression]]s, extract expressions containing window expressions and
      * other regular expressions that do not contain any window expression. For example, for
@@ -831,6 +838,13 @@ class Analyzer(
             val withName = Alias(agg, s"_w${extractedExprBuffer.length}")()
             extractedExprBuffer += withName
             withName.toAttribute
+
+          case ne: Alias if hasWindowFunction(ne) && !hasAggregation(ne) =>
+            ne.children.map(_.transform {
+              case e: NamedExpression => extractExpr(e)
+            })
+            ne
+
         }.asInstanceOf[NamedExpression]
       }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -833,6 +833,33 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
       ).map(i => Row(i._1, i._2, i._3)))
   }
 
+  test("window function: refer column in inner select block") {
+    val data = Seq(
+      WindowData(1, "a", 5),
+      WindowData(2, "a", 6),
+      WindowData(3, "b", 7),
+      WindowData(4, "b", 8),
+      WindowData(5, "c", 9),
+      WindowData(6, "c", 10)
+    )
+    sparkContext.parallelize(data).toDF().registerTempTable("windowData")
+
+    checkAnswer(
+      sql(
+        """
+          |select area, rank() over (partition by area order by tmp.month) + tmp.tmp1 as c1
+          |from (select month, area, product, 1 as tmp1 from windowData) tmp
+        """.stripMargin),
+      Seq(
+        ("a", 2),
+        ("a", 3),
+        ("b", 2),
+        ("b", 3),
+        ("c", 2),
+        ("c", 3)
+      ).map(i => Row(i._1, i._2)))
+  }
+
   test("window function: partition and order expressions") {
     val data = Seq(
       WindowData(1, "a", 5),


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-10960

When accessing a column in inner select from a select with window function, `AnalysisException` will be thrown. For example, an query like this:

```
 select area, rank() over (partition by area order by tmp.month) + tmp.tmp1 as c1 from (select month, area, product, 1 as tmp1 from windowData) tmp
```

Currently, the rule `ExtractWindowExpressions` in `Analyzer` only extracts regular expressions from `WindowFunction`, `WindowSpecDefinition` and `AggregateExpression`. We need to also extract other attributes as the one in `Alias` as shown in the above query.
