### PR TITLE
added option for specifying AWS credential profile

### DIFF
--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -317,6 +317,10 @@ def parse_args():
     parser.add_option(
         "--instance-profile-name", default=None,
         help="IAM profile name to launch instances under")
+    parser.add_option(
+        "--aws-profile-name", default=None,
+        help="Use aws profile credentials")
+
 
     (opts, args) = parser.parse_args()
     if len(args) != 2:
@@ -1315,7 +1319,10 @@ def real_main():
         sys.exit(1)
 
     try:
-        conn = ec2.connect_to_region(opts.region)
+        if opts.aws_profile_name != None:
+            conn = ec2.connect_to_region(opts.region, profile_name = opts.aws_profile_name)
+        else:
+            conn = ec2.connect_to_region(opts.region)
     except Exception as e:
         print((e), file=stderr)
         sys.exit(1)


### PR DESCRIPTION
# Need

Utilizing AWS profiles is considered best practice: https://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs
# Solution

Added option to connect to AWS by specifying credential profile.
