### PR TITLE
Use VectorizedOrcInputFormat in place of OrcInputFormat

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -75,7 +75,7 @@ private[hive] object HiveSerDe {
 
       "orc" ->
         HiveSerDe(
-          inputFormat = Option("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat"),
+          inputFormat = Option("org.apache.hadoop.hive.ql.io.orc.VectorizedOrcInputFormat"),
           outputFormat = Option("org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat"),
           serde = Option("org.apache.hadoop.hive.ql.io.orc.OrcSerde")),
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
@@ -818,7 +818,7 @@ https://cwiki.apache.org/confluence/display/Hive/Enhanced+Aggregation%2C+Cube%2C
           child.getText().toLowerCase(Locale.ENGLISH) match {
             case "orc" =>
               tableDesc = tableDesc.copy(
-                inputFormat = Option("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat"),
+                inputFormat = Option("org.apache.hadoop.hive.ql.io.orc.VectorizedOrcInputFormat"),
                 outputFormat = Option("org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat"))
               if (tableDesc.serde.isEmpty) {
                 tableDesc = tableDesc.copy(

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcRelation.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcRelation.scala
@@ -25,7 +25,7 @@ import com.google.common.base.Objects
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars
-import org.apache.hadoop.hive.ql.io.orc.{OrcInputFormat, OrcOutputFormat, OrcSerde, OrcSplit, OrcStruct}
+import org.apache.hadoop.hive.ql.io.orc.{VectorizedOrcInputFormat, OrcOutputFormat, OrcSerde, OrcSplit, OrcStruct}
 import org.apache.hadoop.hive.serde2.objectinspector.SettableStructObjectInspector
 import org.apache.hadoop.hive.serde2.typeinfo.{TypeInfoUtils, StructTypeInfo}
 import org.apache.hadoop.io.{NullWritable, Writable}
@@ -309,7 +309,7 @@ private[orc] case class OrcTableScan(
     FileInputFormat.setInputPaths(job, inputPaths.map(_.getPath): _*)
 
     val inputFormatClass =
-      classOf[OrcInputFormat]
+      classOf[VectorizedOrcInputFormat]
         .asInstanceOf[Class[_ <: MapRedInputFormat[NullWritable, Writable]]]
 
     val rdd = sqlContext.sparkContext.hadoopRDD(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveMetastoreCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveMetastoreCatalogSuite.scala
@@ -67,7 +67,7 @@ class DataSourceWithHiveMetastoreCatalogSuite
     ),
 
     "orc" -> (
-      "org.apache.hadoop.hive.ql.io.orc.OrcInputFormat",
+      "org.apache.hadoop.hive.ql.io.orc.VectorizedOrcInputFormat",
       "org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat",
       "org.apache.hadoop.hive.ql.io.orc.OrcSerde"
     )


### PR DESCRIPTION
I am not sure an option is needed for switching to VectorizedOrcInputFormat
