### PR TITLE
[SPARK-11050][MLLIB] PySpark SparseVector can return wrong index in e…

### DIFF
--- a/python/pyspark/mllib/linalg/__init__.py
+++ b/python/pyspark/mllib/linalg/__init__.py
@@ -765,11 +765,10 @@ class SparseVector(Vector):
             raise TypeError(
                 "Indices must be of type integer, got type %s" % type(index))
 
-        original_index = index
+        if index >= self.size or index < -self.size:
+            raise ValueError("Index %d out of bounds." % index)
         if index < 0:
             index += self.size
-        if index >= self.size or index < 0:
-            raise ValueError("Index %d out of bounds." % original_index)
 
         insert_index = np.searchsorted(inds, index)
         if insert_index >= inds.size:

--- a/python/pyspark/mllib/linalg/__init__.py
+++ b/python/pyspark/mllib/linalg/__init__.py
@@ -764,10 +764,12 @@ class SparseVector(Vector):
         if not isinstance(index, int):
             raise TypeError(
                 "Indices must be of type integer, got type %s" % type(index))
+
+        original_index = index
         if index < 0:
             index += self.size
         if index >= self.size or index < 0:
-            raise ValueError("Index %d out of bounds." % index)
+            raise ValueError("Index %d out of bounds." % original_index)
 
         insert_index = np.searchsorted(inds, index)
         if insert_index >= inds.size:


### PR DESCRIPTION
…rror message

For negative indices in the SparseVector, we update the index value. If we have an incorrect index
at this point, the error message has the incorrect _updated_ index instead of the original one. This
change contains the fix for the same.
