### PR TITLE
[SPARK-10533] [SQL] handle scientific notation in sqlParser

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/AbstractSparkSQLParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/AbstractSparkSQLParser.scala
@@ -108,7 +108,7 @@ class SqlLexical extends StdLexical {
   override lazy val token: Parser[Token] =
     ( rep1(digit) ~ ('.' ~> digit.*).? ~ (exp ~> sign.? ~ rep1(digit)) ^^ {
         case i ~ None ~ (sig ~ rest) =>
-          DecimalLit(i.mkString + "e" + sig.getOrElse("") + rest.mkString)
+          DecimalLit(i.mkString + "e" + sig.mkString + rest.mkString)
         case i ~ Some(d) ~ (sig ~ rest) =>
           DecimalLit(i.mkString + "." + d.mkString + "e" + sig.mkString + rest.mkString)
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/AbstractSparkSQLParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/AbstractSparkSQLParser.scala
@@ -110,7 +110,7 @@ class SqlLexical extends StdLexical {
         case i ~ None ~ (sig ~ rest) =>
           DecimalLit(i.mkString + "e" + sig.getOrElse("") + rest.mkString)
         case i ~ Some(d) ~ (sig ~ rest) =>
-          DecimalLit(i.mkString + "." + d.mkString + "e" + sig.getOrElse("") + rest.mkString)
+          DecimalLit(i.mkString + "." + d.mkString + "e" + sig.mkString + rest.mkString)
       }
     | digit.* ~ identChar ~ (identChar | digit).* ^^
       { case first ~ middle ~ rest => processIdent((first ++ (middle :: rest)).mkString) }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
@@ -334,12 +334,18 @@ object SqlParser extends AbstractSparkSQLParser with DataTypeParser {
     | sign.? ~ unsignedFloat ^^ {
       case s ~ f => Literal(toDecimalOrDouble(s.getOrElse("") + f))
     }
+    | sign.? ~ unsignedDecimal ^^ {
+      case s ~ d => Literal(toDecimalOrDouble(s.getOrElse("") + d))
+    }
     )
 
   protected lazy val unsignedFloat: Parser[String] =
     ( "." ~> numericLit ^^ { u => "0." + u }
     | elem("decimal", _.isInstanceOf[lexical.FloatLit]) ^^ (_.chars)
     )
+
+  protected lazy val unsignedDecimal: Parser[String] =
+    elem("decimal", _.isInstanceOf[lexical.DecimalLit]) ^^ (_.chars)
 
   protected lazy val sign: Parser[String] = ("+" | "-")
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
@@ -345,7 +345,12 @@ object SqlParser extends AbstractSparkSQLParser with DataTypeParser {
     )
 
   protected lazy val unsignedDecimal: Parser[String] =
-    elem("decimal", _.isInstanceOf[lexical.DecimalLit]) ^^ (_.chars)
+    ( "." ~> decimalLit ^^ { u => "0." + u }
+    | elem("scientific_notation", _.isInstanceOf[lexical.DecimalLit]) ^^ (_.chars)
+    )
+
+  def decimalLit: Parser[String] =
+    elem("scientific_notation", _.isInstanceOf[lexical.DecimalLit]) ^^ (_.chars)
 
   protected lazy val sign: Parser[String] = ("+" | "-")
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -175,7 +175,11 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
       testData.collect().filter(_.getInt(0) > 90).toSeq)
 
     checkAnswer(
-      testData.filter("key > 9.e+1"),
+      testData.filter("key > .9e+2"),
+      testData.collect().filter(_.getInt(0) > 90).toSeq)
+
+    checkAnswer(
+      testData.filter("key > 0.9e+2"),
       testData.collect().filter(_.getInt(0) > 90).toSeq)
 
     checkAnswer(

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -169,6 +169,22 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     checkAnswer(
       testData.filter("key > 90"),
       testData.collect().filter(_.getInt(0) > 90).toSeq)
+
+    checkAnswer(
+      testData.filter("key > 9.0e1"),
+      testData.collect().filter(_.getInt(0) > 90).toSeq)
+
+    checkAnswer(
+      testData.filter("key > 9.e+1"),
+      testData.collect().filter(_.getInt(0) > 90).toSeq)
+
+    checkAnswer(
+      testData.filter("key > 900e-1"),
+      testData.collect().filter(_.getInt(0) > 90).toSeq)
+
+    checkAnswer(
+      testData.filter("key > 900.0E-1"),
+      testData.collect().filter(_.getInt(0) > 90).toSeq)
   }
 
   test("filterExpr using where") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -166,29 +166,14 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
   }
 
   test("filterExpr") {
-    checkAnswer(
-      testData.filter("key > 90"),
-      testData.collect().filter(_.getInt(0) > 90).toSeq)
-
-    checkAnswer(
-      testData.filter("key > 9.0e1"),
-      testData.collect().filter(_.getInt(0) > 90).toSeq)
-
-    checkAnswer(
-      testData.filter("key > .9e+2"),
-      testData.collect().filter(_.getInt(0) > 90).toSeq)
-
-    checkAnswer(
-      testData.filter("key > 0.9e+2"),
-      testData.collect().filter(_.getInt(0) > 90).toSeq)
-
-    checkAnswer(
-      testData.filter("key > 900e-1"),
-      testData.collect().filter(_.getInt(0) > 90).toSeq)
-
-    checkAnswer(
-      testData.filter("key > 900.0E-1"),
-      testData.collect().filter(_.getInt(0) > 90).toSeq)
+    val res = testData.collect().filter(_.getInt(0) > 90).toSeq
+    checkAnswer(testData.filter("key > 90"), res)
+    checkAnswer(testData.filter("key > 9.0e1"), res)
+    checkAnswer(testData.filter("key > .9e+2"), res)
+    checkAnswer(testData.filter("key > 0.9e+2"), res)
+    checkAnswer(testData.filter("key > 900e-1"), res)
+    checkAnswer(testData.filter("key > 900.0E-1"), res)
+    checkAnswer(testData.filter("key > 9.e+1"), res)
   }
 
   test("filterExpr using where") {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-10533

val df = sqlContext.createDataFrame(Seq(("a",1.0),("b",2.0),("c",3.0)))
df.filter("_2 < 2.0e1").show

Scientific notation didn't work.
