### PR TITLE
[SPARK-10959] [PYSPARK] StreamingLogisticRegressionWithSGD does not t…

### DIFF
--- a/python/pyspark/mllib/classification.py
+++ b/python/pyspark/mllib/classification.py
@@ -632,7 +632,8 @@ class StreamingLogisticRegressionWithSGD(StreamingLinearAlgorithm):
             if not rdd.isEmpty():
                 self._model = LogisticRegressionWithSGD.train(
                     rdd, self.numIterations, self.stepSize,
-                    self.miniBatchFraction, self._model.weights)
+                    self.miniBatchFraction, self._model.weights,
+                    regParam=self.regParam  )
 
         dstream.foreachRDD(update)
 

--- a/python/pyspark/mllib/classification.py
+++ b/python/pyspark/mllib/classification.py
@@ -633,7 +633,7 @@ class StreamingLogisticRegressionWithSGD(StreamingLinearAlgorithm):
                 self._model = LogisticRegressionWithSGD.train(
                     rdd, self.numIterations, self.stepSize,
                     self.miniBatchFraction, self._model.weights,
-                    regParam=self.regParam  )
+                    regParam=self.regParam)
 
         dstream.foreachRDD(update)
 

--- a/python/pyspark/mllib/regression.py
+++ b/python/pyspark/mllib/regression.py
@@ -669,7 +669,7 @@ class StreamingLinearRegressionWithSGD(StreamingLinearAlgorithm):
                 self._model = LinearRegressionWithSGD.train(
                     rdd, self.numIterations, self.stepSize,
                     self.miniBatchFraction, self._model.weights,
-                    self._model.intercept)
+                    intercept=self._model.intercept)
 
         dstream.foreachRDD(update)
 


### PR DESCRIPTION
…rain with given regParam and StreamingLinearRegressionWithSGD intercept param is not in correct position.

regParam was being passed into the StreamingLogisticRegressionWithSGD constructor, but not transferred to the call for model training. The param is added as a named argument to the call.  For StreamingLinearRegressionWithSGC the intercept parameter was not in the correct position and was being passed in as the regularization value.
