### PR TITLE
[SPARK-11036][SQL] AttributeReference should not be assigned new expression id inside tasks

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
+import org.apache.spark.TaskContext
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.expressions.codegen._
@@ -240,6 +241,10 @@ case class AttributeReference(
     if (exprId == newExprId) {
       this
     } else {
+      if (Option(TaskContext.get()).isDefined) {
+        throw new IllegalStateException("AttributeReference should not be assigned with " +
+          "new expression id inside of tasks")
+      }
       AttributeReference(name, dataType, nullable, metadata)(newExprId, qualifiers)
     }
   }


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-11036

Related to #9093, SPARK-11036 is proposed to not allow AttributeReference to be created in executors. #9093 solves part of SPARK-11036. But the method `withExprId` will possibly assign new expression id to AttributeReference too. This patch tries to prevent that by using the same mechanism of #9093.
