### PR TITLE
[SPARK-11082][YARN] Fix wrong core number when response vcore is less than requested vcore

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -395,6 +395,10 @@ private[yarn] class YarnAllocator(
       val executorId = executorIdCounter.toString
 
       assert(container.getResource.getMemory >= resource.getMemory)
+      if (container.getResource.getVirtualCores < resource.getVirtualCores) {
+        logWarning(s"Number of vcore ${container.getResource.getVirtualCores} in allocated " +
+          s"container response is less than the requested number ${resource.getVirtualCores}")
+      }
 
       logInfo("Launching container %s for on host %s".format(containerId, executorHostname))
       executorIdToContainer(executorId) = container
@@ -414,7 +418,7 @@ private[yarn] class YarnAllocator(
         executorId,
         executorHostname,
         executorMemory,
-        executorCores,
+        container.getResource.getVirtualCores,
         appAttemptId.getApplicationId.toString,
         securityMgr)
       if (launchContainers) {


### PR DESCRIPTION
This should be guarded out and use response vcore number, this will be happened when use `DefaultResourceCalculator` in capacity scheduler by default.
