### PR TITLE
[SPARK-11067] Spark SQL thrift server fails to handle decimal value

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
@@ -22,6 +22,8 @@ import java.sql.{Date, Timestamp}
 import java.util.concurrent.RejectedExecutionException
 import java.util.{Arrays, UUID, Map => JMap}
 
+import org.apache.hadoop.hive.common.`type`.HiveDecimal
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable.{ArrayBuffer, Map => SMap}
 import scala.util.control.NonFatal
@@ -73,7 +75,7 @@ private[hive] class SparkExecuteStatementOperation(
       case FloatType =>
         to += from.getFloat(ordinal)
       case DecimalType() =>
-        to += from.getDecimal(ordinal)
+        to += HiveDecimal.create(from.getDecimal(ordinal))
       case LongType =>
         to += from.getLong(ordinal)
       case ByteType =>


### PR DESCRIPTION
When executing the following query through beeline connecting to Spark sql thrift server, it errors out for decimal column

Select decimal_column from table

```
WARN  2015-10-09 15:04:00 org.apache.hive.service.cli.thrift.ThriftCLIService: Error fetching results: 
java.lang.ClassCastException: java.math.BigDecimal cannot be cast to org.apache.hadoop.hive.common.type.HiveDecimal
    at org.apache.hive.service.cli.ColumnValue.toTColumnValue(ColumnValue.java:174) ~[hive-service-0.13.1a.jar:0.13.1a]
    at org.apache.hive.service.cli.RowBasedSet.addRow(RowBasedSet.java:60) ~[hive-service-0.13.1a.jar:0.13.1a]
    at org.apache.hive.service.cli.RowBasedSet.addRow(RowBasedSet.java:32) ~[hive-service-0.13.1a.jar:0.13.1a]
    at org.apache.spark.sql.hive.thriftserver.SparkExecuteStatementOperation.getNextRowSet(Shim13.scala:144) ~[spark-hive-thriftserver_2.10-1.4.1.1.jar:1.4.1.1]
    at org.apache.hive.service.cli.operation.OperationManager.getOperationNextRowSet(OperationManager.java:192) ~[hive-service-0.13.1a.jar:0.13.1a]
    at org.apache.hive.service.cli.session.HiveSessionImpl.fetchResults(HiveSessionImpl.java:471) ~[hive-service-0.13.1a.jar:0.13.1a]
    at org.apache.hive.service.cli.CLIService.fetchResults(CLIService.java:405) ~[hive-service-0.13.1a.jar:0.13.1a]
    at org.apache.hive.service.cli.thrift.ThriftCLIService.FetchResults(ThriftCLIService.java:530) ~[hive-service-0.13.1a.jar:0.13.1a]
    at org.apache.hive.service.cli.thrift.TCLIService$Processor$FetchResults.getResult(TCLIService.java:1553) [hive-service-0.13.1a.jar:0.13.1a]
    at org.apache.hive.service.cli.thrift.TCLIService$Processor$FetchResults.getResult(TCLIService.java:1538) [hive-service-0.13.1a.jar:0.13.1a]
    at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:39) [libthrift-0.9.2.jar:0.9.2]
    at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:39) [libthrift-0.9.2.jar:0.9.2]
    at org.apache.hive.service.auth.TSetIpAddressProcessor.process(TSetIpAddressProcessor.java:55) [hive-service-0.13.1a.jar:4.8.1-SNAPSHOT]
    at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:285) [libthrift-0.9.2.jar:0.9.2]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [na:1.7.0_55]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [na:1.7.0_55]
    at java.lang.Thread.run(Thread.java:745) [na:1.7.0_55]
```
