### PR TITLE
[SPARK-11027][SQL] Better group distinct columns in query compilation for aggregation query

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -508,7 +508,7 @@ class Analyzer(
                 // So, we wrap it in AggregateExpression2.
                 case agg2: AggregateFunction2 => AggregateExpression2(agg2, Complete, isDistinct)
                 // Currently, our old aggregate function interface supports SUM(DISTINCT ...)
-                // and COUTN(DISTINCT ...).
+                // and COUNT(DISTINCT ...).
                 case sumDistinct: SumDistinct => sumDistinct
                 case countDistinct: CountDistinct => countDistinct
                 // DISTINCT is not meaningful with Max and Min.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/utils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/utils.scala
@@ -138,8 +138,12 @@ object Utils {
         }
       }.toSet.toSeq
       val functionsWithDistinct = aggregateExpressions.filter(_.isDistinct)
+      val distinctColumnCount = functionsWithDistinct.map(_.aggregateFunction.children.collect {
+          case Cast(c, dt) => c
+          case other => other
+      }).distinct.length
       val hasMultipleDistinctColumnSets =
-        if (functionsWithDistinct.map(_.aggregateFunction.children).distinct.length > 1) {
+        if (distinctColumnCount > 1) {
           true
         } else {
           false

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -216,10 +216,11 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
             val (functionsWithDistinct, functionsWithoutDistinct) =
               aggregateExpressions.partition(_.isDistinct)
 
-            val distinctColumnCount = functionsWithDistinct.map(_.aggregateFunction.children.collect {
+            val distinctColumnCount =
+              functionsWithDistinct.map(_.aggregateFunction.children.collect {
                 case Cast(c, dt) => c
                 case other => other
-            }).distinct.length
+              }).distinct.length
 
             if (distinctColumnCount > 1) {
               // This is a sanity check. We should not reach here when we have multiple distinct

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/utils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/utils.scala
@@ -166,7 +166,7 @@ object Utils {
     // It is safe to call head at here since functionsWithDistinct has at least one
     // AggregateExpression2.
     val distinctColumnExpressions =
-      functionsWithDistinct.head.aggregateFunction.children
+      functionsWithDistinct.flatMap(_.aggregateFunction.children)
     val namedDistinctColumnExpressions = distinctColumnExpressions.map {
       case ne: NamedExpression => ne -> ne
       case other =>


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-11027

Currently, for a query like:

```
SELECT sum(distinct value1), kEY - 100, count(distinct value1) FROM agg2 GROUP BY Key - 100
```

We will treat it as having two distinct columns because sum is working on a cast of value1. We can ignore cast expression for such cases to have just one distinct column.
