### PR TITLE
[SPARK-11105][yarn]  Distribute log4j.properties to executors

### DIFF
--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -81,7 +81,7 @@ all environment variables used for launching each container. This process is use
 classpath problems in particular. (Note that enabling this requires admin privileges on cluster
 settings and a restart of all node managers. Thus, this is not applicable to hosted clusters).
 
-To use a custom log4j configuration for the application master or executors, there are two options:
+To use a custom log4j configuration for the application master or executors, here are the options:
 
 - upload a custom `log4j.properties` using `spark-submit`, by adding it to the `--files` list of files
   to be uploaded with the application.
@@ -89,6 +89,9 @@ To use a custom log4j configuration for the application master or executors, the
   (for the driver) or `spark.executor.extraJavaOptions` (for executors). Note that if using a file,
   the `file:` protocol should be explicitly provided, and the file needs to exist locally on all
   the nodes.
+- update the `$SPARK_CONF_DIR/log4j.properties` file and it will be automatically uploaded along
+  with the other configurations. Note that other 2 options has higher priority than this option if
+  multiple options are specified.
 
 Note that for the first option, both executors and the application master will share the same
 log4j configuration, which may cause issues when they run on the same node (e.g. trying to write

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -345,9 +345,9 @@ private[spark] class Client(
     // required when user changes log4j.properties directly to set the log configurations. If
     // configuration file is provided through --files then executors will be taking configurations
     // from --files instead of $SPARK_CONF_DIR/log4j.properties.
-    val log4jConfUrl = getClass.getResource("/log4j.properties");
+    val log4jConfUrl = getClass.getResource("/log4j.properties")
     val log4jConf =
-      oldLog4jConf.orElse(Option(if (log4jConfUrl == null ) null else log4jConfUrl.toString())
+      oldLog4jConf.orElse(Option(if (log4jConfUrl == null) null else log4jConfUrl.toString())
 
     def addDistributedUri(uri: URI): Boolean = {
       val uriStr = uri.toString()

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -505,11 +505,11 @@ private[spark] class Client(
     // from --files instead of $SPARK_CONF_DIR/log4j.properties.
     Option(Utils.getContextOrSparkClassLoader.getResource("log4j.properties"))
       .map(_.getPath).map(path => {
-      val file = new File(path)
-      if(file.isFile && file.canRead) {
-        hadoopConfFiles(file.getName) = file
-      }
-    })
+        val file = new File(path)
+        if(file.isFile && file.canRead) {
+          hadoopConfFiles(file.getName) = file
+        }
+      })
 
     Seq("HADOOP_CONF_DIR", "YARN_CONF_DIR").foreach { envKey =>
       sys.env.get(envKey).foreach { path =>

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -347,7 +347,7 @@ private[spark] class Client(
     // from --files instead of $SPARK_CONF_DIR/log4j.properties.
     val log4jConfUrl = getClass.getResource("/log4j.properties")
     val log4jConf =
-      oldLog4jConf.orElse(Option(if (log4jConfUrl == null) null else log4jConfUrl.toString())
+      oldLog4jConf.orElse(Option(if (log4jConfUrl == null) null else log4jConfUrl.toString()))
 
     def addDistributedUri(uri: URI): Boolean = {
       val uriStr = uri.toString()

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -503,13 +503,12 @@ private[spark] class Client(
     // required when user changes log4j.properties directly to set the log configurations. If
     // configuration file is provided through --files then executors will be taking configurations
     // from --files instead of $SPARK_CONF_DIR/log4j.properties.
-    Option(Utils.getContextOrSparkClassLoader.getResource("log4j.properties"))
-      .map(_.getPath).map(path => {
-        val file = new File(path)
-        if(file.isFile && file.canRead) {
-          hadoopConfFiles(file.getName) = file
-        }
-      })
+    val log4jFileName = "log4j.properties"
+    Option(Utils.getContextOrSparkClassLoader.getResource(log4jFileName)).foreach {
+      url => if (url.getProtocol == "file") {
+        hadoopConfFiles(log4jFileName) = new File(url.getPath)
+      }
+    }
 
     Seq("HADOOP_CONF_DIR", "YARN_CONF_DIR").foreach { envKey =>
       sys.env.get(envKey).foreach { path =>

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -345,9 +345,8 @@ private[spark] class Client(
     // required when user changes log4j.properties directly to set the log configurations. If
     // configuration file is provided through --files then executors will be taking configurations
     // from --files instead of $SPARK_CONF_DIR/log4j.properties.
-    val log4jConfUrl = getClass.getResource("/log4j.properties")
-    val log4jConf =
-      oldLog4jConf.orElse(Option(if (log4jConfUrl == null) null else log4jConfUrl.toString()))
+    val log4jConf = oldLog4jConf.orElse(
+      Option(Utils.getContextOrSparkClassLoader.getResource("/log4j.properties")).map(_.toString))
 
     def addDistributedUri(uri: URI): Boolean = {
       val uriStr = uri.toString()

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -345,8 +345,9 @@ private[spark] class Client(
     // required when user changes log4j.properties directly to set the log configurations. If
     // configuration file is provided through --files then executors will be taking configurations
     // from --files instead of $SPARK_CONF_DIR/log4j.properties.
+    val log4jConfUrl = getClass.getResource("/log4j.properties");
     val log4jConf =
-      oldLog4jConf.orElse(Option(getClass.getResource("/log4j.properties").toString()))
+      oldLog4jConf.orElse(Option(if (log4jConfUrl == null ) null else log4jConfUrl.toString())
 
     def addDistributedUri(uri: URI): Boolean = {
       val uriStr = uri.toString()

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -504,8 +504,8 @@ private[spark] class Client(
     // configuration file is provided through --files then executors will be taking configurations
     // from --files instead of $SPARK_CONF_DIR/log4j.properties.
     val log4jFileName = "log4j.properties"
-    Option(Utils.getContextOrSparkClassLoader.getResource(log4jFileName)).foreach {
-      url => if (url.getProtocol == "file") {
+    Option(Utils.getContextOrSparkClassLoader.getResource(log4jFileName)).foreach { url =>
+      if (url.getProtocol == "file") {
         hadoopConfFiles(log4jFileName) = new File(url.getPath)
       }
     }

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -341,10 +341,10 @@ private[spark] class Client(
     }
 
     // Uploading $SPARK_CONF_DIR/log4j.properties file to the distributed cache to make sure that
-    // the executor's will use the latest configurations instead of the default values. This is
-    // required when user changes log4j.properties directly or use's UI (e.g., Cloudera Manager) to
-    // set the log configurations. If configuration file is provided through --files then executors
-    // will be taking configurations from --files instead of $SPARK_CONF_DIR/log4j.properties.
+    // the executors will use the latest configurations instead of the default values. This is
+    // required when user changes log4j.properties directly to set the log configurations. If
+    // configuration file is provided through --files then executors will be taking configurations
+    // from --files instead of $SPARK_CONF_DIR/log4j.properties.
     val log4jConf =
       oldLog4jConf.orElse(Option(getClass.getResource("/log4j.properties").toString()))
 


### PR DESCRIPTION
Currently log4j.properties file is not uploaded to executor's which is leading them to use the default values. This fix will make sure that file is always uploaded to distributed cache so that executor will use the latest settings. 

If user specifies log configurations through --files then executors will be picking configs from --files instead of $SPARK_CONF_DIR/log4j.properties
