### PR TITLE
[SPARK-10534][SQL] ORDER BY clause allows only columns that are present in the select projection list

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -482,7 +482,12 @@ class Analyzer(
       val newOrdering = resolveSortOrders(ordering, grandchild, throws = true)
       // Construct a set that contains all of the attributes that we need to evaluate the
       // ordering.
-      val requiredAttributes = AttributeSet(newOrdering.filter(_.resolved))
+
+      val resolvedAttributes =
+        newOrdering.flatMap(_.collect {case a : AttributeReference if a.resolved => a})
+
+      val requiredAttributes = AttributeSet(resolvedAttributes)
+
       // Figure out which ones are missing from the projection, so that we can add them and
       // remove them after the sort.
       val missingInProject = requiredAttributes -- child.output

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -482,9 +482,7 @@ class Analyzer(
       val newOrdering = resolveSortOrders(ordering, grandchild, throws = true)
       // Construct a set that contains all of the attributes that we need to evaluate the
       // ordering.
-
       val requiredAttributes = AttributeSet(newOrdering).filter(_.resolved)
-
       // Figure out which ones are missing from the projection, so that we can add them and
       // remove them after the sort.
       val missingInProject = requiredAttributes -- child.output

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -483,10 +483,7 @@ class Analyzer(
       // Construct a set that contains all of the attributes that we need to evaluate the
       // ordering.
 
-      val resolvedAttributes =
-        newOrdering.flatMap(_.collect {case a : AttributeReference if a.resolved => a})
-
-      val requiredAttributes = AttributeSet(resolvedAttributes)
+      val requiredAttributes = AttributeSet(newOrdering).filter(_.resolved)
 
       // Figure out which ones are missing from the projection, so that we can add them and
       // remove them after the sort.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -140,7 +140,7 @@ class AnalysisSuite extends AnalysisTest {
     val a = testRelation2.output(0)
     val c = testRelation2.output(2)
 
-    val plan = testRelation2.select(c).orderBy(Floor(a).asc)
+    val plan = testRelation2.select('c).orderBy(Floor('a).asc)
     val expected = testRelation2.select(c, a).orderBy(Floor(a.cast(DoubleType)).asc).select(c)
 
     checkAnalysis(plan, expected)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -137,19 +137,12 @@ class AnalysisSuite extends AnalysisTest {
   }
 
   test("SPARK-10534: resolve attribute references in order by clause") {
+    val a = testRelation2.output(0)
+    val c = testRelation2.output(2)
 
-    val a = testRelation2.output.head
-    val c = testRelation2.output.toArray.apply(2)
+    val plan = testRelation2.select(c).orderBy(Floor(a).asc)
+    val expected = testRelation2.select(c, a).orderBy(Floor(a.cast(DoubleType)).asc).select(c)
 
-    val sortProjected = Floor(Cast(Floor(c), DoubleType))
-    val projected = Alias(a, "a")()
-    val plan = testRelation2.select(a).orderBy(SortOrder(Floor(Floor(c)), Ascending))
-
-    val expected =
-      Project(Seq(a),
-        Sort(Seq(SortOrder(sortProjected, Ascending)), true,
-          Project(Seq(a, c), testRelation2)))
     checkAnalysis(plan, expected)
-
   }
 }


### PR DESCRIPTION
Find out the missing attributes by recursively looking
at the sort order expression and rest of the code
takes care of projecting them out.

Added description from @cloud-fan 

I wanna explain a bit more about this bug.

When we resolve sort ordering, we will use a special method, which only resolves UnresolvedAttributes and UnresolvedExtractValue. However, for something like Floor('a), even the 'a is resolved, the floor expression may still being unresolved as data type mismatch(for example, 'a is string type and Floor need double type), thus can't pass this filter, and we can't push down this missing attribute 'a
