### PR TITLE
[SPARK-11117] [SQL] Makes PhysicalRDD aware of whether underlying data source produces UnsafeRow

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExistingRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExistingRDD.scala
@@ -97,7 +97,8 @@ private[sql] case class LogicalRDD(
 private[sql] case class PhysicalRDD(
     output: Seq[Attribute],
     rdd: RDD[InternalRow],
-    extraInformation: String) extends LeafNode {
+    extraInformation: String,
+    override val outputsUnsafeRows: Boolean = false) extends LeafNode {
 
   protected override def doExecute(): RDD[InternalRow] = rdd
 
@@ -109,7 +110,7 @@ private[sql] object PhysicalRDD {
       output: Seq[Attribute],
       rdd: RDD[InternalRow],
       relation: BaseRelation): PhysicalRDD = {
-    PhysicalRDD(output, rdd, relation.toString)
+    PhysicalRDD(output, rdd, relation.toString, outputsUnsafeRows = relation.outputsUnsafeRows)
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -328,7 +328,7 @@ private[sql] object DataSourceStrategy extends Strategy with Logging {
       relation: LogicalRelation,
       output: Seq[Attribute],
       rdd: RDD[Row]): RDD[InternalRow] = {
-    if (relation.relation.needConversion) {
+    if (!relation.relation.outputsInternalRows) {
       execution.RDDConversions.rowToRowRdd(rdd, output.map(_.dataType))
     } else {
       rdd.asInstanceOf[RDD[InternalRow]]

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/CatalystRecordMaterializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/CatalystRecordMaterializer.scala
@@ -21,6 +21,7 @@ import org.apache.parquet.io.api.{GroupConverter, RecordMaterializer}
 import org.apache.parquet.schema.MessageType
 
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 import org.apache.spark.sql.types.StructType
 
 /**
@@ -35,7 +36,7 @@ private[parquet] class CatalystRecordMaterializer(
 
   private val rootConverter = new CatalystRowConverter(parquetSchema, catalystSchema, NoopUpdater)
 
-  override def getCurrentRecord: InternalRow = rootConverter.currentRow
+  override def getCurrentRecord: InternalRow = rootConverter.currentRecord
 
   override def getRootConverter: GroupConverter = rootConverter
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/CatalystRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/CatalystRowConverter.scala
@@ -163,10 +163,14 @@ private[parquet] class CatalystRowConverter(
     override def setFloat(value: Float): Unit = row.setFloat(ordinal, value)
   }
 
+  private val currentRow = new SpecificMutableRow(catalystType.map(_.dataType))
+
+  private val unsafeProjection = UnsafeProjection.create(catalystType)
+
   /**
-   * Represents the converted row object once an entire Parquet record is converted.
+   * The [[UnsafeRow]] converted from an entire Parquet record.
    */
-  val currentRow = new SpecificMutableRow(catalystType.map(_.dataType))
+  def currentRecord: UnsafeRow = unsafeProjection(currentRow)
 
   // Converters for each field.
   private val fieldConverters: Array[Converter with HasParentContainerUpdater] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRelation.scala
@@ -282,6 +282,8 @@ private[sql] class ParquetRelation(
     }
   }
 
+  override private[sql] def outputsUnsafeRows: Boolean = true
+
   override def buildScan(
       requiredColumns: Array[String],
       filters: Array[Filter],

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -231,8 +231,9 @@ abstract class BaseRelation {
    * of Spark SQL should leave this as true.
    *
    * @since 1.4.0
+   * @deprecated As of 1.6.0, replaced by `!outputsInternalRows`.
    */
-  @deprecated("Use outputsInternalRows() instead", "1.6.0")
+  @deprecated("Use !outputsInternalRows", "1.6.0")
   def needConversion: Boolean = true
 
   def outputsInternalRows: Boolean = !needConversion

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -236,6 +236,19 @@ abstract class BaseRelation {
   @deprecated("Use !outputsInternalRows", "1.6.0")
   def needConversion: Boolean = true
 
+  /**
+   * Whether does it produce [[InternalRow]]s, which use internal representation for row fields, for
+   * example:
+   *  java.lang.String -> UTF8String
+   *  java.lang.Decimal -> Decimal
+   *
+   * If `outputsInternalRows` is `true`, `buildScan()` should return an [[RDD]] of [[InternalRow]]
+   *
+   * Note: The internal representation is not stable across releases and thus data sources outside
+   * of Spark SQL should leave this as true.
+   *
+   * @since 1.6.0
+   */
   def outputsInternalRows: Boolean = !needConversion
 
   private[sql] def outputsUnsafeRows: Boolean = false

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
@@ -24,6 +24,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.SpecificMutableRow
+import org.apache.spark.sql.execution.ConvertToUnsafe
 import org.apache.spark.sql.execution.datasources.parquet.TestingUDT.{NestedStruct, NestedStructUDT}
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types._
@@ -560,6 +561,32 @@ class ParquetQuerySuite extends QueryTest with ParquetTest with SharedSQLContext
       nullable = true)
 
     assert(CatalystReadSupport.expandUDT(schema) === expected)
+  }
+
+  test("ParquetRelation produces UnsafeRow") {
+    withTempTable("test_unsafe") {
+      withTempPath { dir =>
+        val path = dir.getCanonicalPath
+        sqlContext.range(3).write.parquet(path)
+        sqlContext.read.parquet(path).registerTempTable("test_unsafe")
+
+        val df = sqlContext.sql(
+          """SELECT COUNT(*)
+            |FROM test_unsafe a JOIN test_unsafe b
+            |WHERE a.id = b.id
+          """.stripMargin)
+
+        val plan = df.queryExecution.executedPlan
+
+        assert(
+          plan.collect { case plan: ConvertToUnsafe => plan }.isEmpty,
+          s"""Query plan shouldn't have ${classOf[ConvertToUnsafe].getSimpleName} node(s):
+             |$plan
+           """.stripMargin)
+
+        checkAnswer(df, Row(3))
+      }
+    }
   }
 }
 


### PR DESCRIPTION
This PR tries to address [this PR comment](https://github.com/apache/spark/pull/9104#issuecomment-147872722). Changes made here:
1. Adds a new data source interface method `BaseRelation.outputsUnsafeRows`.
2. Overrides `PhysicalRDD.outputsUnsafeRows` to avoid unnecessary `ConvertToUnsafe` operator
3. Makes `ParquetRelation` always produce `UnsafeRow`s.

In addition,  `BaseRelation.needsConversion` is deprecated by `BaseRelation.outputsInternalRow`. The reason is that I constantly find `needsConversion` confusing, and always need to double think what kind of conversion is actually needed.
