### PR TITLE
[YARN] When driver sends message "GetExecutorLossReason" to AM, there should have reture value

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -599,6 +599,7 @@ private[spark] class ApplicationMaster(
           case None => logWarning(s"Container allocator is not ready to find" +
             s" executor loss reasons yet.")
         }
+        context.reply(true)
     }
 
     override def onDisconnected(remoteAddress: RpcAddress): Unit = {


### PR DESCRIPTION
I get lastest code form github, and just run "bin/spark-shell  --master yarn --conf spark.dynamicAllocation.enabled=true --conf spark.dynamicAllocation.initialExecutors=1 --conf spark.shuffle.service.enabled=true". There is error infor:
15/10/13 10:20:06 ERROR TransportChannelHandler: Connection to /IP:45380 has been quiet for 120000 ms while there are outstanding requests. Assuming connection is dead; please adjust spark.network.timeout if this is wrong.
15/10/13 10:20:06 ERROR TransportResponseHandler: Still have 1 requests outstanding when connection from HOSTNAME/IP:45380 is closedclosed.

From log, when driver sends message "GetExecutorLossReason" to AM, the error appears. From code, i think AM  gets this message, should reply.
