### PR TITLE
Fix broken build against Scala 2.11

### DIFF
--- a/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
@@ -308,7 +308,7 @@ private[netty] class NettyRpcEnvFactory extends RpcEnvFactory with Logging {
   }
 }
 
-private[netty] class NettyRpcEndpointRef(@transient conf: SparkConf)
+private[netty] class NettyRpcEndpointRef(@transient var conf: SparkConf)
   extends RpcEndpointRef(conf) with Serializable with Logging {
 
   @transient @volatile private var nettyEnv: NettyRpcEnv = _


### PR DESCRIPTION
Compilation passed using the following command line:

-Dscala-2.11 -Phive -Pyarn -Phadoop-2.3 -Pkinesis-asl -Pspark-ganglia-lgpl -DskipTests clean compile

-Phive -Pyarn -Phadoop-2.3 -Pkinesis-asl -Pspark-ganglia-lgpl -DskipTests clean compile
