### PR TITLE
[Spark-10994] Add clustering coefficient computation in GraphX

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/GraphOps.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/GraphOps.scala
@@ -435,4 +435,13 @@ class GraphOps[VD: ClassTag, ED: ClassTag](graph: Graph[VD, ED]) extends Seriali
   def stronglyConnectedComponents(numIter: Int): Graph[VertexId, ED] = {
     StronglyConnectedComponents.run(graph, numIter)
   }
+
+  /**
+   * Compute the local clustering coefficient for each vertex
+   *
+   * @see [[org.apache.spark.graphx.lib.LocalClusteringCoefficient#run]]
+   */
+  def localClusteringCoefficient(): Graph[Double, ED] = {
+    LocalClusteringCoefficient.run(graph)
+  }
 } // end of GraphOps

--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/LocalClusteringCoefficient.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/LocalClusteringCoefficient.scala
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.graphx.lib
+
+import org.apache.spark.graphx._
+
+import scala.reflect.ClassTag
+
+import scala.collection.mutable.ListBuffer
+
+/**
+ * Local clustering coefficient algorithm
+ *
+ * In a directed graph G=(V, E), we define the neighbourhood N_i of a vertex v_i as
+ * N_i={v_j: e_ij \in E or e_ji \in E}
+ *
+ * The local clustering coefficient C_i of a vertex v_i is then defined as
+ * C_i = |{e_jk: v_j, v_k \in N_i, e_jk \in E}| / (K_i * (K_i - 1))
+ * where K_i=|N_i| is the number of neighbors of v_i
+ *
+ * Note that the input graph must have been partitioned using
+ * [[org.apache.spark.graphx.Graph#partitionBy]].
+ */
+object LocalClusteringCoefficient {
+  /**
+   * Compute the local clustering coefficient for each vertex and
+   * return a graph with vertex value representing the local clustering coefficient of that vertex
+   *
+   * @param graph the graph for which to compute the connected components
+   *
+   * @return a graph with vertex attributes containing
+   *         the local clustering coefficient of that vertex
+   *
+   */
+  def run[VD: ClassTag, ED: ClassTag](graph: Graph[VD, ED]): Graph[Double, ED] = {
+    // Remove redundant edges
+    val g = graph.groupEdges((a, b) => a).cache()
+
+    // Construct set representations of the neighborhoods
+    // ()
+    val nbrSets: VertexRDD[VertexSet] =
+      g.collectNeighborIds(EdgeDirection.Either).mapValues { (vid, nbrs) =>
+        val set = new VertexSet(4)
+        var i = 0
+        while (i < nbrs.size) {
+          // prevent self cycle
+          if(nbrs(i) != vid) {
+            set.add(nbrs(i))
+          }
+          i += 1
+        }
+        set
+      }
+
+    // join the sets with the graph
+    val setGraph: Graph[VertexSet, ED] = g.outerJoinVertices(nbrSets) {
+      (vid, _, optSet) => optSet.getOrElse(null)
+    }
+
+    // Edge function computes intersection of smaller vertex with larger vertex
+    def edgeFunc(et: EdgeTriplet[VertexSet, ED]): Iterator[(VertexId, Double)] = {
+      assert(et.srcAttr != null)
+      assert(et.dstAttr != null)
+      val (smallSet, largeSet) = if (et.srcAttr.size < et.dstAttr.size) {
+        (et.srcAttr, et.dstAttr)
+      } else {
+        (et.dstAttr, et.srcAttr)
+      }
+      val iter = smallSet.iterator
+      val buf = new ListBuffer[(VertexId, Double)]
+      while (iter.hasNext) {
+        val vid = iter.next()
+        if (vid != et.srcId && vid != et.dstId && largeSet.contains(vid)) {
+          buf += ((vid, 1.0))
+        }
+      }
+      buf.toIterator
+    }
+
+    // compute the intersection along edges
+    val counters: VertexRDD[Double] = setGraph.mapReduceTriplets(edgeFunc, _ + _)
+
+    // count number of neighbors for each vertex
+    var nbNumMap = Map[VertexId, Int]()
+    nbrSets.collect().foreach { case (vid, nbVal) =>
+      nbNumMap += (vid -> nbVal.size)
+    }
+
+    // Merge counters with the graph
+    g.outerJoinVertices(counters) {
+      (vid, _, optCounter: Option[Double]) =>
+        val dblCount: Double = optCounter.getOrElse(0)
+        val nbNum = nbNumMap(vid)
+        if (nbNum > 1) {
+          dblCount / (nbNum * (nbNum - 1))
+        }
+        else {
+          0
+        }
+    }
+  }
+}

--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/LocalClusteringCoefficient.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/LocalClusteringCoefficient.scala
@@ -105,7 +105,6 @@ object LocalClusteringCoefficient {
           largeCount += smallVal
         }
       }
-      //println(smallId, smallCount, largeId, largeCount)
       if (ctx.srcId == smallId) {
         ctx.sendToSrc(smallCount)
         ctx.sendToDst(largeCount)
@@ -116,7 +115,6 @@ object LocalClusteringCoefficient {
     }
 
     // compute the intersection along edges
-    //val counters: VertexRDD[Double] = setGraph.mapReduceTriplets(edgeFunc, _ + _)
     val counters: VertexRDD[Double] = setGraph.aggregateMessages(edgeFunc, _ + _)
 
 
@@ -131,7 +129,6 @@ object LocalClusteringCoefficient {
       (vid, _, optCounter: Option[Double]) =>
         val dblCount: Double = optCounter.getOrElse(0)
         val nbNum = nbNumMap(vid)
-        //println(vid, dblCount, nbNum)
         assert((dblCount.toInt & 1) == 0)
         if (nbNum > 1) {
           dblCount / (2 * nbNum * (nbNum - 1))

--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/LocalClusteringCoefficient.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/LocalClusteringCoefficient.scala
@@ -80,6 +80,9 @@ object LocalClusteringCoefficient {
       assert(ctx.srcAttr != null)
       assert(ctx.dstAttr != null)
 
+      if (! ctx.srcAttr.contains(ctx.dstId)) {
+        return
+      }
       // handle duplated edge
       if ((ctx.srcAttr(ctx.dstId) == 2 && ctx.srcId > ctx.dstId) || (ctx.srcId == ctx.dstId)) {
         return

--- a/graphx/src/test/scala/org/apache/spark/graphx/lib/LocalClusteringCoefficientSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/lib/LocalClusteringCoefficientSuite.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.graphx.lib
+
+import org.apache.spark.graphx._
+import org.scalatest.FunSuite
+
+class LocalClusteringCoefficientSuite extends FunSuite with LocalSparkContext {
+
+  def approEqual(a: Double, b: Double): Boolean = {
+    (a - b).abs < 1e-20
+  }
+
+  test("test in a complete graph") {
+    withSpark { sc =>
+      val edges = Array( 0L->1L, 1L->2L, 2L->0L )
+      val revEdges = edges.map { case (a, b) => (b, a) }
+      val rawEdges = sc.parallelize(edges ++ revEdges, 2)
+      val graph = Graph.fromEdgeTuples(rawEdges, true).cache()
+      val lccCount = graph.localClusteringCoefficient()
+      val verts = lccCount.vertices
+      verts.collect.foreach { case (_, count) => assert(approEqual(count, 1.0)) }
+    }
+  }
+
+  test("test in a triangle with one bi-directed edges") {
+    withSpark { sc =>
+      val rawEdges = sc.parallelize(Array( 0L->1L, 1L->2L, 2L->1L, 2L->0L ), 2)
+      val graph = Graph.fromEdgeTuples(rawEdges, true).cache()
+      val lccCount = graph.localClusteringCoefficient()
+      val verts = lccCount.vertices
+      verts.collect.foreach { case (vid, count) =>
+          if (vid == 0) {
+            assert(approEqual(count, 1.0))
+          } else {
+            assert(approEqual(count, 0.5))
+          }
+      }
+    }
+  }
+
+  test("test in a graph with only self-edges") {
+    withSpark { sc =>
+      val rawEdges = sc.parallelize(Array(0L -> 0L, 1L -> 1L, 2L -> 2L, 3L -> 3L), 2)
+      val graph = Graph.fromEdgeTuples(rawEdges, true).cache()
+      val lccCount = graph.localClusteringCoefficient()
+      val verts = lccCount.vertices
+      verts.collect.foreach { case (vid, count) => assert(approEqual(count, 0.0)) }
+    }
+  }
+
+  test("test in a graph with duplicated edges") {
+    withSpark { sc =>
+      val edges = Array( 0L->1L, 1L->2L, 2L->0L )
+      val rawEdges = sc.parallelize(edges ++ edges, 2)
+      val graph = Graph.fromEdgeTuples(rawEdges, true).cache()
+      val lccCount = graph.localClusteringCoefficient()
+      val verts = lccCount.vertices
+      verts.collect.foreach { case (vid, count) => assert(approEqual(count, 1.0)) }
+    }
+  }
+}

--- a/graphx/src/test/scala/org/apache/spark/graphx/lib/LocalClusteringCoefficientSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/lib/LocalClusteringCoefficientSuite.scala
@@ -16,10 +16,10 @@
  */
 package org.apache.spark.graphx.lib
 
+import org.apache.spark.SparkFunSuite
 import org.apache.spark.graphx._
-import org.scalatest.FunSuite
 
-class LocalClusteringCoefficientSuite extends FunSuite with LocalSparkContext {
+class LocalClusteringCoefficientSuite extends SparkFunSuite with LocalSparkContext {
 
   def approEqual(a: Double, b: Double): Boolean = {
     (a - b).abs < 1e-20

--- a/graphx/src/test/scala/org/apache/spark/graphx/lib/LocalClusteringCoefficientSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/lib/LocalClusteringCoefficientSuite.scala
@@ -82,7 +82,7 @@ class LocalClusteringCoefficientSuite extends SparkFunSuite with LocalSparkConte
       val graph = Graph.fromEdgeTuples(rawEdges, true, uniqueEdges = Some(RandomVertexCut)).cache()
       val lccCount = graph.localClusteringCoefficient()
       val verts = lccCount.vertices
-      verts.collect.foreach { case (vid, count) => assert(approEqual(count, 1.0)) }
+      verts.collect.foreach { case (vid, count) => assert(approEqual(count, 0.5)) }
     }
   }
 }

--- a/graphx/src/test/scala/org/apache/spark/graphx/lib/LocalClusteringCoefficientSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/lib/LocalClusteringCoefficientSuite.scala
@@ -25,6 +25,17 @@ class LocalClusteringCoefficientSuite extends SparkFunSuite with LocalSparkConte
     (a - b).abs < 1e-20
   }
 
+  test("test in a single triangle") {
+    withSpark { sc =>
+      val edges = Array( 0L->1L, 1L->2L, 2L->0L )
+      val rawEdges = sc.parallelize(edges, 2)
+      val graph = Graph.fromEdgeTuples(rawEdges, true).cache()
+      val lccCount = graph.localClusteringCoefficient()
+      val verts = lccCount.vertices
+      verts.collect.foreach { case (_, count) => assert(approEqual(count, 2.0)) }
+    }
+  }
+
   test("test in a complete graph") {
     withSpark { sc =>
       val edges = Array( 0L->1L, 1L->2L, 2L->0L )

--- a/graphx/src/test/scala/org/apache/spark/graphx/lib/LocalClusteringCoefficientSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/lib/LocalClusteringCoefficientSuite.scala
@@ -32,7 +32,7 @@ class LocalClusteringCoefficientSuite extends SparkFunSuite with LocalSparkConte
       val graph = Graph.fromEdgeTuples(rawEdges, true).cache()
       val lccCount = graph.localClusteringCoefficient()
       val verts = lccCount.vertices
-      verts.collect.foreach { case (_, count) => assert(approEqual(count, 2.0)) }
+      verts.collect.foreach { case (_, count) => assert(approEqual(count, 0.5)) }
     }
   }
 

--- a/graphx/src/test/scala/org/apache/spark/graphx/lib/LocalClusteringCoefficientSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/lib/LocalClusteringCoefficientSuite.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.graphx.lib
 
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.graphx.PartitionStrategy.RandomVertexCut
 import org.apache.spark.graphx._
 
 class LocalClusteringCoefficientSuite extends SparkFunSuite with LocalSparkContext {
@@ -78,7 +79,7 @@ class LocalClusteringCoefficientSuite extends SparkFunSuite with LocalSparkConte
     withSpark { sc =>
       val edges = Array( 0L->1L, 1L->2L, 2L->0L )
       val rawEdges = sc.parallelize(edges ++ edges, 2)
-      val graph = Graph.fromEdgeTuples(rawEdges, true).cache()
+      val graph = Graph.fromEdgeTuples(rawEdges, true, uniqueEdges = Some(RandomVertexCut)).cache()
       val lccCount = graph.localClusteringCoefficient()
       val verts = lccCount.vertices
       verts.collect.foreach { case (vid, count) => assert(approEqual(count, 1.0)) }


### PR DESCRIPTION
The Clustering Coefficient (CC) is a fundamental measure in social (or other type of) network analysis assessing the degree to which nodes tend to cluster together [1][2]. Clustering coefficient, along with density, node degree, path length, diameter, connectedness, and node centrality are seven most important properties to characterise a network [3].

We found that GraphX has already implemented connectedness, node centrality, path length, but does not have a componenet for computing clustering coefficient. This actually was the first intention for us to implement an algorithm to compute clustering coefficient for each vertex of a given graph.

Clustering coefficient is very helpful to many real applications, such as user behaviour prediction and structure prediction (like link prediction). We did that before in a bunch of papers (e.g., [4-5]), and also found many other publication papers using this metric in their work [6-8]. We are very confident that this feature will benefit GraphX and attract a large number of users.

References
[1] https://en.wikipedia.org/wiki/Clustering_coefficient
[2] Watts, Duncan J., and Steven H. Strogatz. "Collective dynamics of ‘small-world’ networks." nature 393.6684 (1998): 440-442. (with 27266 citations).
[3] https://en.wikipedia.org/wiki/Network_science
[4] Jing Zhang, Zhanpeng Fang, Wei Chen, and Jie Tang. Diffusion of "Following" Links in Microblogging Networks. IEEE Transaction on Knowledge and Data Engineering (TKDE), Volume 27, Issue 8, 2015, Pages 2093-2106.
[5] Yang Yang, Jie Tang, Jacklyne Keomany, Yanting Zhao, Ying Ding, Juanzi Li, and Liangwei Wang. Mining Competitive Relationships by Learning across Heterogeneous Networks. In Proceedings of the Twenty-First Conference on Information and Knowledge Management (CIKM'12). pp. 1432-1441.
[6] Clauset, Aaron, Cristopher Moore, and Mark EJ Newman. Hierarchical structure and the prediction of missing links in networks. Nature 453.7191 (2008): 98-101. (with 973 citations)
[7] Adamic, Lada A., and Eytan Adar. Friends and neighbors on the web. Social networks 25.3 (2003): 211-230. (1238 citations)
[8] Lichtenwalter, Ryan N., Jake T. Lussier, and Nitesh V. Chawla. New perspectives and methods in link prediction. In KDD'10.
#### Usage

Here is a usage example for LocalClusteringCoefficient:

``` Scala
import org.apache.spark.graphx._
import org.apache.spark._

val conf = new SparkConf().setAppName("testApp")
val sc = new SparkContext(conf)
// load a graph
val graph = GraphLoader.edgeListFile(sc, "graph.txt").partitionBy(PartitionStrategy.RandomVertexCut)

// perform the local clustering coefficient computation 
val LccCounter = graph.localClusteringCoefficient()

// output results for each vertex
val verts = LccCounter.vertices
verts.collect().foreach { case (vid, count) =>
    println(vid + ": " + count)
}
```
