### PR TITLE
[SPARK-11182] HDFS Delegation Token will be expired when calling "UserGroupInformation.getCurrentUser.addCredentials" in HA mode

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -130,7 +130,7 @@ class SparkHadoopUtil extends Logging {
     UserGroupInformation.loginUserFromKeytab(principalName, keytabFilename)
   }
 
-  def addCredentialsToCurrentUser(credentials: Credentials, hadoopConf: Configuration): Unit ={
+  def addCredentialsToCurrentUser(credentials: Credentials, freshHadoopConf: Configuration): Unit ={
     UserGroupInformation.getCurrentUser.addCredentials(credentials)
 
     // HACK:
@@ -142,7 +142,7 @@ class SparkHadoopUtil extends Logging {
     // So:
     // We create a new HDFS Client, so that the new HDFS Client will generate and update the
     // private tokens for each NameNode.
-    FileSystem.newInstance(hadoopConf).close()
+    FileSystem.get(freshHadoopConf).close()
   }
 
   /**

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/AMDelegationTokenRenewer.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/AMDelegationTokenRenewer.scala
@@ -176,7 +176,7 @@ private[yarn] class AMDelegationTokenRenewer(
       }
     })
     // Add the temp credentials back to the original ones.
-    SparkHadoopUtil.get.addCredentialsToCurrentUser(tempCreds, hadoopConf)
+    SparkHadoopUtil.get.addCredentialsToCurrentUser(tempCreds, freshHadoopConf)
     val remoteFs = FileSystem.get(freshHadoopConf)
     // If lastCredentialsFileSuffix is 0, then the AM is either started or restarted. If the AM
     // was restarted, then the lastCredentialsFileSuffix might be > 0, so find the newest file

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/AMDelegationTokenRenewer.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/AMDelegationTokenRenewer.scala
@@ -176,7 +176,7 @@ private[yarn] class AMDelegationTokenRenewer(
       }
     })
     // Add the temp credentials back to the original ones.
-    UserGroupInformation.getCurrentUser.addCredentials(tempCreds)
+    SparkHadoopUtil.get.addCredentialsToCurrentUser(tempCreds, hadoopConf)
     val remoteFs = FileSystem.get(freshHadoopConf)
     // If lastCredentialsFileSuffix is 0, then the AM is either started or restarted. If the AM
     // was restarted, then the lastCredentialsFileSuffix might be > 0, so find the newest file

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorDelegationTokenUpdater.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorDelegationTokenUpdater.scala
@@ -62,7 +62,7 @@ private[spark] class ExecutorDelegationTokenUpdater(
           logInfo("Reading new delegation tokens from " + credentialsStatus.getPath)
           val newCredentials = getCredentialsFromHDFSFile(remoteFs, credentialsStatus.getPath)
           lastCredentialsFileSuffix = suffix
-          SparkHadoopUtil.get.addCredentialsToCurrentUser(newCredentials, hadoopConf)
+          SparkHadoopUtil.get.addCredentialsToCurrentUser(newCredentials, freshHadoopConf)
           logInfo("Tokens updated from credentials file.")
         } else {
           // Check every hour to see if new credentials arrived.

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorDelegationTokenUpdater.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorDelegationTokenUpdater.scala
@@ -62,7 +62,7 @@ private[spark] class ExecutorDelegationTokenUpdater(
           logInfo("Reading new delegation tokens from " + credentialsStatus.getPath)
           val newCredentials = getCredentialsFromHDFSFile(remoteFs, credentialsStatus.getPath)
           lastCredentialsFileSuffix = suffix
-          UserGroupInformation.getCurrentUser.addCredentials(newCredentials)
+          SparkHadoopUtil.get.addCredentialsToCurrentUser(newCredentials, hadoopConf)
           logInfo("Tokens updated from credentials file.")
         } else {
           // Check every hour to see if new credentials arrived.


### PR DESCRIPTION
In HA mode, DFSClient will generate HDFS Delegation Token for each Name Node automatically, which will not be updated when Spark update Credentials for the current user.
Spark should update these tokens in order to avoid Token Expired Error.
