### PR TITLE
[SPARK-11194] [SQL] [BRANCH-1.5] [WIP] Use MutableURLClassLoader for the classLoader in IsolatedClientLoader.

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -150,6 +150,18 @@ class HiveContext(sc: SparkContext) extends SQLContext(sc) with Logging {
   protected[sql] lazy val substitutor = new VariableSubstitution()
 
   /**
+   * The classLoader used to store all user-added jars through "ADD JAR" command.
+   * This classLoader is a special URLClassLoader that exposes its addURL method.
+   * So, when we add jar, we can add this new jar directly through the addURL method
+   * instead of stacking a new URLClassLoader on top of it.
+   */
+  @transient
+  protected[hive] val libraryClassLoader: NonClosableMutableURLClassLoader = {
+    val baseClassLoader = Utils.getContextOrSparkClassLoader
+    new NonClosableMutableURLClassLoader(baseClassLoader)
+  }
+
+  /**
    * The copy of the hive client that is used for execution.  Currently this must always be
    * Hive 13 as this is the version of Hive that is packaged with Spark SQL.  This copy of the
    * client is used for execution related tasks like registering temporary functions or ensuring

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
@@ -29,7 +29,7 @@ import org.apache.commons.io.{FileUtils, IOUtils}
 
 import org.apache.spark.Logging
 import org.apache.spark.deploy.SparkSubmitUtils
-import org.apache.spark.util.Utils
+import org.apache.spark.util.{MutableURLClassLoader, Utils}
 
 import org.apache.spark.sql.catalyst.util.quietly
 import org.apache.spark.sql.hive.HiveContext
@@ -196,4 +196,15 @@ private[hive] class IsolatedClientLoader(
   } finally {
     Thread.currentThread.setContextClassLoader(baseClassLoader)
   }
+}
+
+/**
+ * URL class loader that exposes the `addURL` and `getURLs` methods in URLClassLoader.
+ * This class loader cannot be closed (its `close` method is a no-op).
+ */
+private[sql] class NonClosableMutableURLClassLoader(
+    parent: ClassLoader)
+  extends MutableURLClassLoader(Array.empty, parent) {
+
+  override def close(): Unit = {}
 }


### PR DESCRIPTION
This PR is a test fix for SPARK-11194 in branch 1.5. However, since it fundamentally changes the way that we do add jar in branch 1.5, we will not merge it into 1.5 branch.
