### PR TITLE
[SPARK-11201] [YARN] Make sure SPARK_YARN_MODE is set before SparkHad…

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -430,6 +430,8 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
 
     _conf.set("spark.externalBlockStore.folderName", externalBlockStoreFolderName)
 
+    // This should have been set by spark-submit, but there are code paths that may not go
+    // through spark-submit.
     if (master == "yarn-client") System.setProperty("SPARK_YARN_MODE", "true")
 
     // "_jobProgressListener" should be set up before creating SparkEnv because when creating

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -430,6 +430,8 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
 
     _conf.set("spark.externalBlockStore.folderName", externalBlockStoreFolderName)
 
+    if (master == "yarn-client") System.setProperty("SPARK_YARN_MODE", "true")
+
     // "_jobProgressListener" should be set up before creating SparkEnv because when creating
     // "SparkEnv", some messages will be posted to "listenerBus" and we should not miss them.
     _jobProgressListener = new JobProgressListener(_conf)

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -430,8 +430,6 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
 
     _conf.set("spark.externalBlockStore.folderName", externalBlockStoreFolderName)
 
-    if (master == "yarn-client") System.setProperty("SPARK_YARN_MODE", "true")
-
     // "_jobProgressListener" should be set up before creating SparkEnv because when creating
     // "SparkEnv", some messages will be posted to "listenerBus" and we should not miss them.
     _jobProgressListener = new JobProgressListener(_conf)

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -264,6 +264,7 @@ object SparkSubmit {
           "Could not load YARN classes. " +
           "This copy of Spark may not have been compiled with YARN support.")
       }
+      System.setProperty("SPARK_YARN_MODE", "true")
     }
 
     // Update args.deployMode if it is null. It will be passed down as a Spark property later.

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1025,9 +1025,6 @@ object Client extends Logging {
         "future version of Spark. Use ./bin/spark-submit with \"--master yarn\"")
     }
 
-    // Set an env variable indicating we are running in YARN mode.
-    // Note that any env variable with the SPARK_ prefix gets propagated to all (remote) processes
-    System.setProperty("SPARK_YARN_MODE", "true")
     val sparkConf = new SparkConf
 
     val args = new ClientArguments(argStrings, sparkConf)

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1025,6 +1025,9 @@ object Client extends Logging {
         "future version of Spark. Use ./bin/spark-submit with \"--master yarn\"")
     }
 
+    // Set an env variable indicating we are running in YARN mode.
+    // Note that any env variable with the SPARK_ prefix gets propagated to all (remote) processes
+    System.setProperty("SPARK_YARN_MODE", "true")
     val sparkConf = new SparkConf
 
     val args = new ClientArguments(argStrings, sparkConf)

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1027,6 +1027,8 @@ object Client extends Logging {
 
     // Set an env variable indicating we are running in YARN mode.
     // Note that any env variable with the SPARK_ prefix gets propagated to all (remote) processes
+    // This should have been set by spark-submit, but there are code paths that may not go
+    // through spark-submit.
     System.setProperty("SPARK_YARN_MODE", "true")
     val sparkConf = new SparkConf
 


### PR DESCRIPTION
…oopUtil.get is called.

If `StreamingContext.getOrCreate` is used in `yarn-client` mode, a `ClassCastException` gets thrown when `Client.scala` is initialized and `YarnSparkHadoopUtil.get` is called. This fails because the `SparkHadoopUtil.get` method is called in the `getOrCreate` method default argument, before SPARK_YARN_MODE is set.
