### PR TITLE
[SPARK-11205] [PYSPARK] Match the output of DataFrame#explain() in both scala api and python

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -203,7 +203,7 @@ class DataFrame(object):
          |-- name: string (nullable = true)
         <BLANKLINE>
         """
-        print(self._jdf.schema().treeString())
+        self._jdf.printSchema()
 
     @since(1.3)
     def explain(self, extended=False):
@@ -224,10 +224,7 @@ class DataFrame(object):
         == Physical Plan ==
         ...
         """
-        if extended:
-            print(self._jdf.queryExecution().toString())
-        else:
-            print(self._jdf.queryExecution().executedPlan().toString())
+        self._jdf.explain(extended)
 
     @since(1.3)
     def isLocal(self):
@@ -253,7 +250,7 @@ class DataFrame(object):
         |  5|  Bob|
         +---+-----+
         """
-        print(self._jdf.showString(n, truncate))
+        self._jdf.show(n, truncate)
 
     def __repr__(self):
         return "DataFrame[%s]" % (", ".join("%s: %s" % c for c in self.dtypes))

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -203,7 +203,7 @@ class DataFrame(object):
          |-- name: string (nullable = true)
         <BLANKLINE>
         """
-        self._jdf.printSchema()
+        print(self._jdf.schema().treeString())
 
     @since(1.3)
     def explain(self, extended=False):
@@ -212,6 +212,7 @@ class DataFrame(object):
         :param extended: boolean, default ``False``. If ``False``, prints only the physical plan.
 
         >>> df.explain()
+        == Physical Plan ==
         Scan PhysicalRDD[age#0,name#1]
 
         >>> df.explain(True)
@@ -224,7 +225,10 @@ class DataFrame(object):
         == Physical Plan ==
         ...
         """
-        self._jdf.explain(extended)
+        if extended:
+            print(self._jdf.queryExecution().toString())
+        else:
+            print(self._jdf.queryExecution().simpleString())
 
     @since(1.3)
     def isLocal(self):
@@ -250,7 +254,7 @@ class DataFrame(object):
         |  5|  Bob|
         +---+-----+
         """
-        self._jdf.show(n, truncate)
+        print(self._jdf.showString(n, truncate))
 
     def __repr__(self):
         return "DataFrame[%s]" % (", ".join("%s: %s" % c for c in self.dtypes))


### PR DESCRIPTION
…rint in python

No test needed. Verify it manually in pyspark shell
