### PR TITLE
[SPARK-10971][SPARKR] RRunner should allow setting path to Rscript.

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/RRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/RRunner.scala
@@ -42,7 +42,7 @@ object RRunner {
     val backendTimeout = sys.env.getOrElse("SPARKR_BACKEND_TIMEOUT", "120").toInt
     val rCommand = {
       var cmd = sys.props.getOrElse("spark.sparkr.r.command", "Rscript")
-      if (sys.props("spark.submit.deployMode") == "client") {
+      if (sys.props.getOrElse("spark.submit.deployMode", "client") == "client") {
         cmd = sys.props.getOrElse("spark.sparkr.r.driver.command", cmd)
       }
       cmd

--- a/core/src/main/scala/org/apache/spark/deploy/RRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/RRunner.scala
@@ -41,9 +41,12 @@ object RRunner {
     // Time to wait for SparkR backend to initialize in seconds
     val backendTimeout = sys.env.getOrElse("SPARKR_BACKEND_TIMEOUT", "120").toInt
     val rCommand = {
+      // "spark.sparkr.r.command" is deprecated and replaced by "spark.r.command",
+      // but kept here for backward compatibility.
       var cmd = sys.props.getOrElse("spark.sparkr.r.command", "Rscript")
+      cmd = sys.props.getOrElse("spark.r.command", cmd)
       if (sys.props.getOrElse("spark.submit.deployMode", "client") == "client") {
-        cmd = sys.props.getOrElse("spark.sparkr.r.driver.command", cmd)
+        cmd = sys.props.getOrElse("spark.r.driver.command", cmd)
       }
       cmd
     }

--- a/core/src/main/scala/org/apache/spark/deploy/RRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/RRunner.scala
@@ -40,7 +40,13 @@ object RRunner {
 
     // Time to wait for SparkR backend to initialize in seconds
     val backendTimeout = sys.env.getOrElse("SPARKR_BACKEND_TIMEOUT", "120").toInt
-    val rCommand = "Rscript"
+    val rCommand = {
+      var cmd = sys.props.getOrElse("spark.sparkr.r.command", "Rscript")
+      if (sys.props("spark.submit.deployMode") == "client") {
+        cmd = sys.props.getOrElse("spark.sparkr.r.driver.command", cmd)
+      }
+      cmd
+    }
 
     // Check if the file path exists.
     // If not, change directory to current working directory for YARN cluster mode

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1593,15 +1593,15 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
-  <td><code>spark.sparkr.r.command</code></td>
+  <td><code>spark.r.command</code></td>
   <td>Rscript</td>
   <td>
     Executable for executing R scripts in cluster modes for both driver and workers.
   </td>
 </tr>
 <tr>
-  <td><code>spark.sparkr.r.driver.command</code></td>
-  <td>spark.sparkr.r.command</td>
+  <td><code>spark.r.driver.command</code></td>
+  <td>spark.r.command</td>
   <td>
     Executable for executing R scripts in client modes for driver. Ignored in cluster modes.
   </td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1592,6 +1592,20 @@ Apart from these, the following properties are also available, and may be useful
     Number of threads used by RBackend to handle RPC calls from SparkR package.
   </td>
 </tr>
+<tr>
+  <td><code>spark.sparkr.r.command</code></td>
+  <td>Rscript</td>
+  <td>
+    Executable for executing R scripts in cluster modes for both driver and workers.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.sparkr.r.driver.command</code></td>
+  <td>spark.sparkr.r.command</td>
+  <td>
+    Executable for executing R scripts in client modes for driver. Ignored in cluster modes.
+  </td>
+</tr>
 </table>
 
 #### Cluster Managers
@@ -1630,6 +1644,10 @@ The following variables can be set in `spark-env.sh`:
   <tr>
     <td><code>PYSPARK_DRIVER_PYTHON</code></td>
     <td>Python binary executable to use for PySpark in driver only (default is <code>PYSPARK_PYTHON</code>).</td>
+  </tr>
+  <tr>
+    <td><code>SPARKR_DRIVER_R</code></td>
+    <td>R binary executable to use for SparkR shell (default is <code>R</code>).</td>
   </tr>
   <tr>
     <td><code>SPARK_LOCAL_IP</code></td>


### PR DESCRIPTION
Add a new spark conf option "spark.sparkr.r.driver.command" to specify the executable for an R script in client modes.

The existing spark conf option "spark.sparkr.r.command" is used to specify the executable for an R script in cluster modes for both driver and workers. See also [launch R worker script](https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/api/r/RRDD.scala#L395).

BTW, [envrionment variable "SPARKR_DRIVER_R"](https://github.com/apache/spark/blob/master/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java#L275) is used to locate R shell on the local host.

For your information, PYSPARK has two environment variables serving simliar purpose:
PYSPARK_PYTHON        Python binary executable to use for PySpark in both driver and workers (default is `python`).
PYSPARK_DRIVER_PYTHON   Python binary executable to use for PySpark in driver only (default is PYSPARK_PYTHON).
pySpark use the code [here](https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala#L41) to determine the python executable for a python script.
