### PR TITLE
[SPARK-10082] [MLLIB] minor style updates for matrix indexing after #8271

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
@@ -296,8 +296,8 @@ class DenseMatrix @Since("1.3.0") (
   override def apply(i: Int, j: Int): Double = values(index(i, j))
 
   private[mllib] def index(i: Int, j: Int): Int = {
-    require(i < numRows && i >=0, s"Expected 0 <= i < $numRows, got $i")
-    require(j < numCols && j >=0, s"Expected 0 <= j < $numCols, got $j")
+    require(i >= 0 && i < numRows, s"Expected 0 <= i < $numRows, got i = $i.")
+    require(j >= 0 && j < numCols, s"Expected 0 <= j < $numCols, got j = $j.")
     if (!isTransposed) i + numRows * j else j + numCols * i
   }
 
@@ -572,8 +572,8 @@ class SparseMatrix @Since("1.3.0") (
   }
 
   private[mllib] def index(i: Int, j: Int): Int = {
-    require(i < numRows && i >=0, s"Expected 0 <= i < $numRows, got $i")
-    require(j < numCols && j >=0, s"Expected 0 <= j < $numCols, got $j")
+    require(i >= 0 && i < numRows, s"Expected 0 <= i < $numRows, got i = $i.")
+    require(j >= 0 && j < numCols, s"Expected 0 <= j < $numCols, got j = $j.")
     if (!isTransposed) {
       Arrays.binarySearch(rowIndices, colPtrs(j), colPtrs(j + 1), i)
     } else {

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
@@ -78,10 +78,10 @@ class MatricesSuite extends SparkFunSuite {
     val sm = Matrices.sparse(3, 2, Array(0, 2, 3), Array(1, 2, 1), Array(0.0, 1.0, 2.0))
     val dm = Matrices.dense(3, 2, Array(0.0, 2.3, 1.4, 3.2, 1.0, 9.1))
     Array(sm, dm).foreach { mat =>
-        intercept[IllegalArgumentException] { mat.index(4, 1) }
-        intercept[IllegalArgumentException] { mat.index(1, 4) }
-        intercept[IllegalArgumentException] { mat.index(-1, 2) }
-        intercept[IllegalArgumentException] { mat.index(1, -2) }
+      intercept[IllegalArgumentException] { mat.index(4, 1) }
+      intercept[IllegalArgumentException] { mat.index(1, 4) }
+      intercept[IllegalArgumentException] { mat.index(-1, 2) }
+      intercept[IllegalArgumentException] { mat.index(1, -2) }
     }
   }
 


### PR DESCRIPTION
- `>=0` => `>= 0`
- print `i`, `j` in the log message

@MechCoder 
