### PR TITLE
[SPARK-11188][SQL] Elide stacktraces in bin/spark-sql for AnalysisExceptions

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -20,6 +20,8 @@ package org.apache.spark.sql.hive.thriftserver
 import java.io._
 import java.util.{ArrayList => JArrayList, Locale}
 
+import org.apache.spark.sql.AnalysisException
+
 import scala.collection.JavaConverters._
 
 import jline.console.ConsoleReader
@@ -308,7 +310,15 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
 
           ret = rc.getResponseCode
           if (ret != 0) {
-            console.printError(rc.getErrorMessage())
+            // For analysis exception, only the error is printed out to the console.
+            rc.getException() match {
+              case e : AnalysisException =>
+                console.printError(
+                  s"""Failed with exception ${e.getClass.getName}: ${e.getMessage}""")
+              case _ => {
+                console.printError(rc.getErrorMessage())
+              }
+            }
             driver.close()
             return ret
           }

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -300,6 +300,7 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
 
           driver.init()
           val out = sessionState.out
+          val err = sessionState.err
           val start: Long = System.currentTimeMillis()
           if (sessionState.getIsVerbose) {
             out.println(cmd)
@@ -313,8 +314,8 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
             // For analysis exception, only the error is printed out to the console.
             rc.getException() match {
               case e : AnalysisException =>
-                console.printError(s"""Error in query: ${e.getMessage}""")
-              case _ => console.printError(rc.getErrorMessage())
+                err.println(s"""Error in query: ${e.getMessage}""")
+              case _ => err.println(rc.getErrorMessage())
             }
             driver.close()
             return ret

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -313,11 +313,8 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
             // For analysis exception, only the error is printed out to the console.
             rc.getException() match {
               case e : AnalysisException =>
-                console.printError(
-                  s"""Failed with exception ${e.getClass.getName}: ${e.getMessage}""")
-              case _ => {
-                console.printError(rc.getErrorMessage())
-              }
+                console.printError(s"""Error in query: ${e.getMessage}""")
+              case _ => console.printError(rc.getErrorMessage())
             }
             driver.close()
             return ret

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLDriver.scala
@@ -66,21 +66,7 @@ private[hive] class SparkSQLDriver(
       new CommandProcessorResponse(0)
     } catch {
         case ae: AnalysisException =>
-          // On analysis exception we will supress printing of the exception
-          // on to console. We do that by removing the console appender. If
-          // Logging is setup to log to both console and file , we will still
-          // log the error to the file.
-          val appender = LogManager.getRootLogger().getAppender("console")
-          if (appender != null) {
-            LogManager.getRootLogger().removeAppender("console")
-          }
-
-          logError(s"Failed in [$command]", ae)
-
-          // Restore the console appender.
-          if (appender != null) {
-            LogManager.getRootLogger().addAppender(appender)
-          }
+          logDebug(s"Failed in [$command]", ae)
           new CommandProcessorResponse(1, ExceptionUtils.getStackTrace(ae), null, ae)
         case cause: Throwable =>
           logError(s"Failed in [$command]", cause)

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLDriver.scala
@@ -65,7 +65,7 @@ private[hive] class SparkSQLDriver(
     } catch {
       case cause: Throwable =>
         logError(s"Failed in [$command]", cause)
-        new CommandProcessorResponse(1, ExceptionUtils.getStackTrace(cause), null)
+        new CommandProcessorResponse(1, ExceptionUtils.getStackTrace(cause), null, cause)
     }
   }
 

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -58,7 +58,7 @@ class CliSuite extends SparkFunSuite with BeforeAndAfter with Logging {
    * @param timeout maximum time for the commands to complete
    * @param extraArgs any extra arguments
    * @param errorResponses a sequence of strings whose presence in the stdout of the forked process
-   *                       is taken as an immediate error condition. That is: if a line beginning
+   *                       is taken as an immediate error condition. That is: if a line containing
    *                       with one of these strings is found, fail the test immediately.
    *                       The default value is `Seq("Error:")`
    *
@@ -104,7 +104,7 @@ class CliSuite extends SparkFunSuite with BeforeAndAfter with Logging {
         }
       } else {
         errorResponses.foreach { r =>
-          if (line.startsWith(r)) {
+          if (line.contains(r)) {
             foundAllExpectedAnswers.tryFailure(
               new RuntimeException(s"Failed with error line '$line'"))
           }
@@ -221,7 +221,8 @@ class CliSuite extends SparkFunSuite with BeforeAndAfter with Logging {
   }
 
   test("SPARK-11188 Analysis error reporting") {
-    runCliWithin(2.minute)(
+    runCliWithin(timeout = 2.minute,
+      errorResponses = Seq("AnalysisException"))(
       "select * from nonexistent_table;"
         -> "Error in query: Table not found: nonexistent_table;"
     )

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -220,10 +220,10 @@ class CliSuite extends SparkFunSuite with BeforeAndAfter with Logging {
     )
   }
 
-  test("SPARK-11188: Analysis error reporting") {
+  test("SPARK-11188 Analysis error reporting") {
     runCliWithin(2.minute)(
       "select * from nonexistent_table;"
-        -> "Error in query: no such table nonexistent_table;"
+        -> "Error in query: Table Not Found: nonexistent_table;"
     )
   }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -223,7 +223,7 @@ class CliSuite extends SparkFunSuite with BeforeAndAfter with Logging {
   test("SPARK-11188 Analysis error reporting") {
     runCliWithin(2.minute)(
       "select * from nonexistent_table;"
-        -> "Error in query: Table not Found: nonexistent_table;"
+        -> "Error in query: Table not found: nonexistent_table;"
     )
   }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -219,4 +219,11 @@ class CliSuite extends SparkFunSuite with BeforeAndAfter with Logging {
         -> "OK"
     )
   }
+
+  test("SPARK-11188: Analysis error reporting") {
+    runCliWithin(2.minute)(
+      "select * from nonexistent_table;"
+        -> "Error in query: no such table nonexistent_table;"
+    )
+  }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -223,7 +223,7 @@ class CliSuite extends SparkFunSuite with BeforeAndAfter with Logging {
   test("SPARK-11188 Analysis error reporting") {
     runCliWithin(2.minute)(
       "select * from nonexistent_table;"
-        -> "Error in query: Table Not Found: nonexistent_table;"
+        -> "Error in query: Table not Found: nonexistent_table;"
     )
   }
 }


### PR DESCRIPTION
Only print the error message to the console for Analysis Exceptions in sql-shell.
