### PR TITLE
Ignore NoClassDefFoundError in obtainTokenForHiveMetastore()

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1383,6 +1383,7 @@ object Client extends Logging {
       } catch {
         case e: java.lang.NoSuchMethodException => { logInfo("Hive Method not found " + e); return }
         case e: java.lang.ClassNotFoundException => { logInfo("Hive Class not found " + e); return }
+        case e: java.lang.NoClassDefFoundError => { logDebug("Hive Class not found: " + e); return }
         case e: Exception => { logError("Unexpected Exception " + e)
           throw new RuntimeException("Unexpected exception", e)
         }


### PR DESCRIPTION
This follows the same approach used by obtainTokenForHBase()

Thanks to Chester who discovered the discrepancy in the thread 'Possible bug on Spark Yarn Client (1.5.1) during kerberos mode'

If PR for SPARK-11265 doesn't encompass mine, I will create new JIRA for this PR.
