### PR TITLE
[SPARK-9876] [SQL] Bumps parquet-mr to 1.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
     <!-- Version used for internal directory structure -->
     <hive.version.short>1.2.1</hive.version.short>
     <derby.version>10.10.1.1</derby.version>
-    <parquet.version>1.7.0</parquet.version>
+    <parquet.version>1.8.1</parquet.version>
     <hive.parquet.version>1.6.0</hive.parquet.version>
     <jblas.version>1.2.4</jblas.version>
     <jetty.version>8.1.14.v20131031</jetty.version>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/CatalystReadSupport.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/CatalystReadSupport.scala
@@ -25,6 +25,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.parquet.hadoop.api.ReadSupport.ReadContext
 import org.apache.parquet.hadoop.api.{InitContext, ReadSupport}
 import org.apache.parquet.io.api.RecordMaterializer
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32
 import org.apache.parquet.schema.Type.Repetition
 import org.apache.parquet.schema._
 
@@ -111,10 +112,30 @@ private[parquet] object CatalystReadSupport {
    */
   def clipParquetSchema(parquetSchema: MessageType, catalystSchema: StructType): MessageType = {
     val clippedParquetFields = clipParquetGroupFields(parquetSchema.asGroupType(), catalystSchema)
-    Types
-      .buildMessage()
-      .addFields(clippedParquetFields: _*)
-      .named(CatalystSchemaConverter.SPARK_PARQUET_SCHEMA_NAME)
+
+    if (clippedParquetFields.isEmpty) {
+      // !! HACK ALERT !!
+      //
+      // PARQUET-363 & PARQUET-278: parquet-mr 1.8.1 doesn't allow constructing empty GroupType,
+      // which prevents us to avoid selecting any columns for queries like `SELECT COUNT(*) FROM t`.
+      // This issue has been fixed in parquet-mr 1.8.2-SNAPSHOT.
+      //
+      // To workaround this problem, here we first construct a `MessageType` with a single dummy
+      // field, and then remove the field to obtain an empty `MessageType`.
+      //
+      // TODO Reverts this change after upgrading parquet-mr to 1.8.2+
+      val messageType = Types
+        .buildMessage()
+        .addField(Types.required(INT32).named("dummy"))
+        .named(CatalystSchemaConverter.SPARK_PARQUET_SCHEMA_NAME)
+      messageType.getFields.clear()
+      messageType
+    } else {
+      Types
+        .buildMessage()
+        .addFields(clippedParquetFields: _*)
+        .named(CatalystSchemaConverter.SPARK_PARQUET_SCHEMA_NAME)
+    }
   }
 
   private def clipParquetType(parquetType: Type, catalystType: DataType): Type = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/CatalystReadSupport.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/CatalystReadSupport.scala
@@ -29,7 +29,6 @@ import org.apache.parquet.schema.Type.Repetition
 import org.apache.parquet.schema._
 
 import org.apache.spark.Logging
-import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.types._
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilters.scala
@@ -22,8 +22,6 @@ import java.io.Serializable
 import org.apache.parquet.filter2.predicate.FilterApi._
 import org.apache.parquet.filter2.predicate._
 import org.apache.parquet.io.api.Binary
-import org.apache.parquet.schema.OriginalType
-import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
 
 import org.apache.spark.sql.sources
 import org.apache.spark.sql.types._
@@ -53,18 +51,15 @@ private[sql] object ParquetFilters {
     case DoubleType =>
       (n: String, v: Any) => FilterApi.eq(doubleColumn(n), v.asInstanceOf[java.lang.Double])
 
-    // See https://issues.apache.org/jira/browse/SPARK-11153
-    /*
-    // Binary.fromString and Binary.fromByteArray don't accept null values
+    // Binary.fromString and Binary.fromConstantByteArray don't accept null values
     case StringType =>
       (n: String, v: Any) => FilterApi.eq(
         binaryColumn(n),
-        Option(v).map(s => Binary.fromByteArray(s.asInstanceOf[String].getBytes("utf-8"))).orNull)
+        Option(v).map(s => Binary.fromString(s.asInstanceOf[String])).orNull)
     case BinaryType =>
       (n: String, v: Any) => FilterApi.eq(
         binaryColumn(n),
-        Option(v).map(b => Binary.fromByteArray(v.asInstanceOf[Array[Byte]])).orNull)
-     */
+        Option(v).map(b => Binary.fromConstantByteArray(v.asInstanceOf[Array[Byte]])).orNull)
   }
 
   private val makeNotEq: PartialFunction[DataType, (String, Any) => FilterPredicate] = {
@@ -79,17 +74,15 @@ private[sql] object ParquetFilters {
     case DoubleType =>
       (n: String, v: Any) => FilterApi.notEq(doubleColumn(n), v.asInstanceOf[java.lang.Double])
 
-    // See https://issues.apache.org/jira/browse/SPARK-11153
-    /*
+    // Binary.fromString and Binary.fromConstantByteArray don't accept null values
     case StringType =>
       (n: String, v: Any) => FilterApi.notEq(
         binaryColumn(n),
-        Option(v).map(s => Binary.fromByteArray(s.asInstanceOf[String].getBytes("utf-8"))).orNull)
+        Option(v).map(s => Binary.fromString(s.asInstanceOf[String])).orNull)
     case BinaryType =>
       (n: String, v: Any) => FilterApi.notEq(
         binaryColumn(n),
-        Option(v).map(b => Binary.fromByteArray(v.asInstanceOf[Array[Byte]])).orNull)
-     */
+        Option(v).map(b => Binary.fromConstantByteArray(v.asInstanceOf[Array[Byte]])).orNull)
   }
 
   private val makeLt: PartialFunction[DataType, (String, Any) => FilterPredicate] = {
@@ -101,17 +94,12 @@ private[sql] object ParquetFilters {
       (n: String, v: Any) => FilterApi.lt(floatColumn(n), v.asInstanceOf[java.lang.Float])
     case DoubleType =>
       (n: String, v: Any) => FilterApi.lt(doubleColumn(n), v.asInstanceOf[java.lang.Double])
-
-    // See https://issues.apache.org/jira/browse/SPARK-11153
-    /*
     case StringType =>
       (n: String, v: Any) =>
-        FilterApi.lt(binaryColumn(n),
-          Binary.fromByteArray(v.asInstanceOf[String].getBytes("utf-8")))
+        FilterApi.lt(binaryColumn(n), Binary.fromString(v.asInstanceOf[String]))
     case BinaryType =>
       (n: String, v: Any) =>
-        FilterApi.lt(binaryColumn(n), Binary.fromByteArray(v.asInstanceOf[Array[Byte]]))
-     */
+        FilterApi.lt(binaryColumn(n), Binary.fromConstantByteArray(v.asInstanceOf[Array[Byte]]))
   }
 
   private val makeLtEq: PartialFunction[DataType, (String, Any) => FilterPredicate] = {
@@ -123,17 +111,12 @@ private[sql] object ParquetFilters {
       (n: String, v: Any) => FilterApi.ltEq(floatColumn(n), v.asInstanceOf[java.lang.Float])
     case DoubleType =>
       (n: String, v: Any) => FilterApi.ltEq(doubleColumn(n), v.asInstanceOf[java.lang.Double])
-
-    // See https://issues.apache.org/jira/browse/SPARK-11153
-    /*
     case StringType =>
       (n: String, v: Any) =>
-        FilterApi.ltEq(binaryColumn(n),
-          Binary.fromByteArray(v.asInstanceOf[String].getBytes("utf-8")))
+        FilterApi.ltEq(binaryColumn(n), Binary.fromString(v.asInstanceOf[String]))
     case BinaryType =>
       (n: String, v: Any) =>
-        FilterApi.ltEq(binaryColumn(n), Binary.fromByteArray(v.asInstanceOf[Array[Byte]]))
-     */
+        FilterApi.ltEq(binaryColumn(n), Binary.fromConstantByteArray(v.asInstanceOf[Array[Byte]]))
   }
 
   private val makeGt: PartialFunction[DataType, (String, Any) => FilterPredicate] = {
@@ -145,17 +128,12 @@ private[sql] object ParquetFilters {
       (n: String, v: Any) => FilterApi.gt(floatColumn(n), v.asInstanceOf[java.lang.Float])
     case DoubleType =>
       (n: String, v: Any) => FilterApi.gt(doubleColumn(n), v.asInstanceOf[java.lang.Double])
-
-    // See https://issues.apache.org/jira/browse/SPARK-11153
-    /*
     case StringType =>
       (n: String, v: Any) =>
-        FilterApi.gt(binaryColumn(n),
-          Binary.fromByteArray(v.asInstanceOf[String].getBytes("utf-8")))
+        FilterApi.gt(binaryColumn(n), Binary.fromString(v.asInstanceOf[String]))
     case BinaryType =>
       (n: String, v: Any) =>
-        FilterApi.gt(binaryColumn(n), Binary.fromByteArray(v.asInstanceOf[Array[Byte]]))
-     */
+        FilterApi.gt(binaryColumn(n), Binary.fromConstantByteArray(v.asInstanceOf[Array[Byte]]))
   }
 
   private val makeGtEq: PartialFunction[DataType, (String, Any) => FilterPredicate] = {
@@ -167,17 +145,12 @@ private[sql] object ParquetFilters {
       (n: String, v: Any) => FilterApi.gtEq(floatColumn(n), v.asInstanceOf[java.lang.Float])
     case DoubleType =>
       (n: String, v: Any) => FilterApi.gtEq(doubleColumn(n), v.asInstanceOf[java.lang.Double])
-
-    // See https://issues.apache.org/jira/browse/SPARK-11153
-    /*
     case StringType =>
       (n: String, v: Any) =>
-        FilterApi.gtEq(binaryColumn(n),
-          Binary.fromByteArray(v.asInstanceOf[String].getBytes("utf-8")))
+        FilterApi.gtEq(binaryColumn(n), Binary.fromString(v.asInstanceOf[String]))
     case BinaryType =>
       (n: String, v: Any) =>
-        FilterApi.gtEq(binaryColumn(n), Binary.fromByteArray(v.asInstanceOf[Array[Byte]]))
-     */
+        FilterApi.gtEq(binaryColumn(n), Binary.fromConstantByteArray(v.asInstanceOf[Array[Byte]]))
   }
 
   private val makeInSet: PartialFunction[DataType, (String, Set[Any]) => FilterPredicate] = {
@@ -193,18 +166,14 @@ private[sql] object ParquetFilters {
     case DoubleType =>
       (n: String, v: Set[Any]) =>
         FilterApi.userDefined(doubleColumn(n), SetInFilter(v.asInstanceOf[Set[java.lang.Double]]))
-
-    // See https://issues.apache.org/jira/browse/SPARK-11153
-    /*
     case StringType =>
       (n: String, v: Set[Any]) =>
         FilterApi.userDefined(binaryColumn(n),
-          SetInFilter(v.map(s => Binary.fromByteArray(s.asInstanceOf[String].getBytes("utf-8")))))
+          SetInFilter(v.map(s => Binary.fromString(s.asInstanceOf[String]))))
     case BinaryType =>
       (n: String, v: Set[Any]) =>
         FilterApi.userDefined(binaryColumn(n),
-          SetInFilter(v.map(e => Binary.fromByteArray(e.asInstanceOf[Array[Byte]]))))
-     */
+          SetInFilter(v.map(e => Binary.fromConstantByteArray(e.asInstanceOf[Array[Byte]]))))
   }
 
   /**
@@ -212,8 +181,6 @@ private[sql] object ParquetFilters {
    */
   def createFilter(schema: StructType, predicate: sources.Filter): Option[FilterPredicate] = {
     val dataTypeOf = schema.map(f => f.name -> f.dataType).toMap
-
-    relaxParquetValidTypeMap
 
     // NOTE:
     //
@@ -270,36 +237,5 @@ private[sql] object ParquetFilters {
 
       case _ => None
     }
-  }
-
-  // !! HACK ALERT !!
-  //
-  // This lazy val is a workaround for PARQUET-201, and should be removed once we upgrade to
-  // parquet-mr 1.8.1 or higher versions.
-  //
-  // In Parquet, not all types of columns can be used for filter push-down optimization.  The set
-  // of valid column types is controlled by `ValidTypeMap`.  Unfortunately, in parquet-mr 1.7.0 and
-  // prior versions, the limitation is too strict, and doesn't allow `BINARY (ENUM)` columns to be
-  // pushed down.
-  //
-  // This restriction is problematic for Spark SQL, because Spark SQL doesn't have a type that maps
-  // to Parquet original type `ENUM` directly, and always converts `ENUM` to `StringType`.  Thus,
-  // a predicate involving a `ENUM` field can be pushed-down as a string column, which is perfectly
-  // legal except that it fails the `ValidTypeMap` check.
-  //
-  // Here we add `BINARY (ENUM)` into `ValidTypeMap` lazily via reflection to workaround this issue.
-  private lazy val relaxParquetValidTypeMap: Unit = {
-    val constructor = Class
-      .forName(classOf[ValidTypeMap].getCanonicalName + "$FullTypeDescriptor")
-      .getDeclaredConstructor(classOf[PrimitiveTypeName], classOf[OriginalType])
-
-    constructor.setAccessible(true)
-    val enumTypeDescriptor = constructor
-      .newInstance(PrimitiveTypeName.BINARY, OriginalType.ENUM)
-      .asInstanceOf[AnyRef]
-
-    val addMethod = classOf[ValidTypeMap].getDeclaredMethods.find(_.getName == "add").get
-    addMethod.setAccessible(true)
-    addMethod.invoke(null, classOf[Binary], enumTypeDescriptor)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRelation.scala
@@ -548,7 +548,20 @@ private[sql] object ParquetRelation extends Logging {
     }
 
     conf.set(CatalystReadSupport.SPARK_ROW_REQUESTED_SCHEMA, {
-      val requestedSchema = StructType(requiredColumns.map(dataSchema(_)))
+      // PARQUET-363 & PARQUET-278: parquet-mr 1.8.1 doesn't allow constructing empty GroupType,
+      // which prevents us to avoid selecting any columns for queries like `SELECT COUNT(*) FROM t`.
+      //  Here we select the "narrowest" column if `requiredColumns` is empty.
+      //
+      // This issue has been fixed in parquet-mr 1.8.2-SNAPSHOT. We should revert this change after
+      // upgrading to 1.8.2 or some later version.
+      val requestedSchema = {
+        val requiredDataColumns = requiredColumns.map(dataSchema(_))
+        if (requiredDataColumns.isEmpty) {
+          StructType(dataSchema.minBy(_.dataType.defaultSize) :: Nil)
+        } else {
+          StructType(requiredDataColumns)
+        }
+      }
       CatalystSchemaConverter.checkFieldNames(requestedSchema).json
     })
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRelation.scala
@@ -548,20 +548,7 @@ private[sql] object ParquetRelation extends Logging {
     }
 
     conf.set(CatalystReadSupport.SPARK_ROW_REQUESTED_SCHEMA, {
-      // PARQUET-363 & PARQUET-278: parquet-mr 1.8.1 doesn't allow constructing empty GroupType,
-      // which prevents us to avoid selecting any columns for queries like `SELECT COUNT(*) FROM t`.
-      //  Here we select the "narrowest" column if `requiredColumns` is empty.
-      //
-      // This issue has been fixed in parquet-mr 1.8.2-SNAPSHOT. We should revert this change after
-      // upgrading to 1.8.2 or some later version.
-      val requestedSchema = {
-        val requiredDataColumns = requiredColumns.map(dataSchema(_))
-        if (requiredDataColumns.isEmpty) {
-          StructType(dataSchema.minBy(_.dataType.defaultSize) :: Nil)
-        } else {
-          StructType(requiredDataColumns)
-        }
-      }
+      val requestedSchema = StructType(requiredColumns.map(dataSchema(_)))
       CatalystSchemaConverter.checkFieldNames(requestedSchema).json
     })
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala
@@ -1385,21 +1385,25 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
         |}
       """.stripMargin)
 
-  testSchemaClipping(
-    "empty requested schema",
+  // PARQUET-363 & PARQUET-278: parquet-mr 1.8.1 doesn't allow constructing empty GroupType.  Should
+  // re-enable this test case after upgrading to parquet-mr 1.8.2 or some later version.
+  ignore("empty requested schema") {
+    testSchemaClipping(
+      "empty requested schema",
 
-    parquetSchema =
-      """message root {
-        |  required group f0 {
-        |    required int32 f00;
-        |    required int64 f01;
-        |  }
-        |}
-      """.stripMargin,
+      parquetSchema =
+        """message root {
+          |  required group f0 {
+          |    required int32 f00;
+          |    required int64 f01;
+          |  }
+          |}
+        """.stripMargin,
 
-    catalystSchema = new StructType(),
+      catalystSchema = new StructType(),
 
-    expectedSchema = "message root {}")
+      expectedSchema = "message root {}")
+  }
 
   testSchemaClipping(
     "disjoint field sets",


### PR DESCRIPTION
This PR bumps parquet-mr to 1.8.1 to fix [PARQUET-251](https://issues.apache.org/jira/browse/PARQUET-251).

One unexpected issue is that parquet-mr 1.8.1 doesn't allow instantiating empty Parquet schema ([PARQUET-278](https://issues.apache.org/jira/browse/PARQUET-278)). This affects queries like `SELECT COUNT(1) FROM t`, since we have to leave at least one column in Parquet requested schema. This PR works around this issue by selecting the "narrowest" column when no columns is requested. This issue has already been fixed in parquet-mr 1.8.2-SNAPSHOT ([PARQUET-363](https://issues.apache.org/jira/browse/PARQUET-363)).

**UPDATE** We worked around the above issue by constructing a non-empty `MessageType` and then remove all its fields. See [this commit](https://github.com/liancheng/spark/commit/e48c83a9802acea9853ed27a22e5e6ed7a32f427).
