### PR TITLE
[SPARK-11261] [Core] Provide a more flexible alternative to Jdbc RDD

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/JdbcPartitioningRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/JdbcPartitioningRDD.scala
@@ -1,0 +1,329 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.rdd
+
+import java.sql.{PreparedStatement, Connection, ResultSet}
+
+import scala.reflect.ClassTag
+
+import org.apache.spark.api.java.JavaSparkContext.fakeClassTag
+import org.apache.spark.api.java.function.{Function => JFunction, Function2 => JFunction2}
+import org.apache.spark.api.java.{JavaRDD, JavaSparkContext}
+import org.apache.spark.util.NextIterator
+import org.apache.spark.{Logging, Partition, SparkContext, TaskContext}
+
+import scala.collection.JavaConverters._
+
+private[spark] class JdbcPartitioningPartition[A](idx: Int, val partitionArgs: A) extends Partition {
+  override def index: Int = idx
+}
+
+// TODO: Expose a jdbcRDD function in SparkContext and mark this as semi-private
+/**
+ * An RDD that executes an SQL query on a JDBC connection and reads results.
+ * For usage example, see test case JdbcPartioningRDDSuite.
+ *
+ * The number of partitions will be equivalent to the number of items in the partitionArgs argument, for simplicity.
+ * @param getConnection a function that returns an open Connection.
+ *   The RDD takes care of closing the connection.
+ * @param sql the text of the query.
+ *   The query should contain ? placeholders for each single value you intend to insert into the query.
+ *   For example: select * from some_table where partition_id = ? and something_else = 15;
+ *   If you want to handle inserting a set of items for an in-clause or similar use the
+ *   JdbcPartitioningRDD.SetPlaceholder value as a placeholder. This ties in with the setupPlaceholders argument that
+ *   will convert a specific partition sql query to have the correct ? placeholders for all items
+ * @param partitionArgs the value or group of values you require as query parameters for each partition of the query
+ *  For example if your query is : select * from some_table where partition_id = ?;
+ *  Then your partitionArgs could be a Seq[String] as you want to insert an id for each partition into the query
+ * @param insertPlaceholders function that takes your partitionArgs for the current partition and set's the values on
+ * the prepared statement for execution
+ * @param setupPlaceholders if you have to dynamically size the number of placeholders due to use of SetPlaceholder,
+ * then provide a function here that calls JdbcPartitioningRDD.insertStatementSetPlaceholders for each placeholder
+ * you need to replace in order of appearance in the String.
+ * For example: if your query is: select * from some_table where user_ids in (%SET_PLACEHOLDER%);
+ * Then you might provide a function here to get a ? placeholder for each user Id:
+ * { (query: String, userIds: Seq[String]) => JdbcPartitioningRDD.insertStatementSetPlaceholders(query, userIds.size) }
+ * @param mapRow a function from a ResultSet to a single row of the desired result type(s).
+ *   This should only call getInt, getString, etc; the RDD takes care of calling next.
+ *   The default maps a ResultSet to an array of Object.
+ */
+class JdbcPartitioningRDD[A, T: ClassTag](
+                            sc: SparkContext,
+                            getConnection: () => Connection,
+                            sql: String,
+                            partitionArgs: Seq[A],
+                            insertPlaceholders: (PreparedStatement, A) => Unit,
+                            setupPlaceholders: (String, A) => String = JdbcPartitioningRDD.noopSetupPlaceholders[A] _,
+                            mapRow: (ResultSet) => T = JdbcPartitioningRDD.resultSetToObjectArray _)
+  extends RDD[T](sc, Nil) with Logging {
+
+  override def getPartitions: Array[Partition] = {
+    partitionArgs.zipWithIndex.map { case (args, idx) =>
+      new JdbcPartitioningPartition(idx, args)
+    }.toArray
+  }
+
+  override def compute(thePart: Partition, context: TaskContext): Iterator[T] = new NextIterator[T]
+  {
+    context.addTaskCompletionListener{ context => closeIfNeeded() }
+    val part = thePart.asInstanceOf[JdbcPartitioningPartition[A]]
+    val conn = getConnection()
+
+    val adjustedQuery = setupPlaceholders(sql, part.partitionArgs)
+    val stmt = conn.prepareStatement(adjustedQuery, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)
+
+    // setFetchSize(Integer.MIN_VALUE) is a mysql driver specific way to force streaming results,
+    // rather than pulling entire resultset into memory.
+    // see http://dev.mysql.com/doc/refman/5.0/en/connector-j-reference-implementation-notes.html
+    if (conn.getMetaData.getURL.matches("jdbc:mysql:.*")) {
+      stmt.setFetchSize(Integer.MIN_VALUE)
+      logInfo("statement fetch size set to: " + stmt.getFetchSize + " to force MySQL streaming ")
+    }
+
+    insertPlaceholders(stmt, part.partitionArgs)
+
+    val rs = stmt.executeQuery()
+
+    override def getNext(): T = {
+      if (rs.next()) {
+        mapRow(rs)
+      } else {
+        finished = true
+        null.asInstanceOf[T]
+      }
+    }
+
+    override def close() {
+      try {
+        if (null != rs) {
+          rs.close()
+        }
+      } catch {
+        case e: Exception => logWarning("Exception closing resultset", e)
+      }
+      try {
+        if (null != stmt) {
+          stmt.close()
+        }
+      } catch {
+        case e: Exception => logWarning("Exception closing statement", e)
+      }
+      try {
+        if (null != conn) {
+          conn.close()
+        }
+        logInfo("closed connection")
+      } catch {
+        case e: Exception => logWarning("Exception closing connection", e)
+      }
+    }
+  }
+}
+
+object JdbcPartitioningRDD {
+  val SetPlaceholder = "%SET_PLACEHOLDER%"
+
+  /**
+   * Updates a SQL string by replacing the first instance of %SET_PLACEHOLDER% with n ? placeholders
+   * where n is the number of items in the set you want to insert into the statement
+   *
+   * for example:
+   * insertStatementSetPlaceholders(sqlString = "select * from some_table where id in (%SET_PLACEHOLDER%)", 5)
+   * should return
+   * "select * from some_table where id in (?,?,?,?,?)"
+   * so you can now iterate through your set and insert the values into a prepared statement
+   */
+  def insertStatementSetPlaceholders(sqlString: String, numberOfItems: Int): String = {
+    sqlString.replaceFirst(SetPlaceholder, Seq.fill(numberOfItems)("?").mkString(","))
+  }
+
+  def resultSetToObjectArray(rs: ResultSet): Array[Object] = {
+    Array.tabulate[Object](rs.getMetaData.getColumnCount)(i => rs.getObject(i + 1))
+  }
+
+  private def noopSetupPlaceholders[A](query: String, args: A): String = query
+
+  trait ConnectionFactory extends Serializable {
+    @throws[Exception]
+    def getConnection: Connection
+  }
+
+  /**
+   * Create an RDD that executes an SQL query on a JDBC connection and reads results.
+   * For usage example, see test case JavaAPISuite.testJavaJdbcPartitioningRDD.
+   *
+   * @param connectionFactory a factory that returns an open Connection.
+   *   The RDD takes care of closing the connection.
+   * @param sql the text of the query.
+   *   The query should contain ? placeholders for each single value you intend to insert into the query.
+   *   For example: select * from some_table where partition_id = ? and something_else = 15;
+   *   If you want to handle inserting a set of items for an in-clause or similar use the
+   *   JdbcPartitioningRDD.SetPlaceholder value as a placeholder. This ties in with the setupPlaceholders argument that
+   *   will convert a specific partition sql query to have the correct ? placeholders for all items
+   * @param partitionArgs the value or group of values you require as query parameters for each partition of the query
+   *  For example if your query is : select * from some_table where partition_id = ?;
+   *  Then your partitionArgs could be a Seq[String] as you want to insert an id for each partition into the query
+   * @param insertPlaceholders function that takes your partitionArgs for the current partition and set's the values on
+   * the prepared statement for execution
+   * @param setupPlaceholders if you have to dynamically size the number of placeholders due to use of SetPlaceholder,
+   * then provide a function here that calls JdbcPartitioningRDD.insertStatementSetPlaceholders for each placeholder
+   * you need to replace in order of appearance in the String.
+   * For example: if your query is: select * from some_table where user_ids in (%SET_PLACEHOLDER%);
+   * Then you might provide a function here to get a ? placeholder for each user Id:
+   * { (query: String, userIds: Seq[String]) => JdbcPartitioningRDD.insertStatementSetPlaceholders(query, userIds.size) }
+   * @param mapRow a function from a ResultSet to a single row of the desired result type(s).
+   *   This should only call getInt, getString, etc; the RDD takes care of calling next.
+   *   The default maps a ResultSet to an array of Object.
+   */
+  def create[A,T](
+                 sc: JavaSparkContext,
+                 connectionFactory: ConnectionFactory,
+                 sql: String,
+                 partitionArgs: java.util.List[A],
+                 insertPlaceholders: JFunction2[PreparedStatement, A, Void],
+                 setupPlaceholders: JFunction2[String, A, String],
+                 mapRow: JFunction[ResultSet, T]): JavaRDD[T] = {
+
+    val jdbcRDD = new JdbcPartitioningRDD[A,T](
+      sc.sc,
+      () => connectionFactory.getConnection,
+      sql,
+      partitionArgs.asScala,
+      (stmt: PreparedStatement, args: A) => insertPlaceholders.call(stmt, args),
+      (query: String, args: A) => setupPlaceholders.call(query, args),
+      (resultSet: ResultSet) => mapRow.call(resultSet))(fakeClassTag)
+
+    new JavaRDD[T](jdbcRDD)(fakeClassTag)
+  }
+
+  /**
+   * Create an RDD that executes an SQL query on a JDBC connection and reads results. Each row is
+   * converted into a `Object` array. For usage example, see test case JavaAPISuite.testJavaJdbcPartitioningRDD.
+   *
+   * @param connectionFactory a factory that returns an open Connection.
+   *   The RDD takes care of closing the connection.
+   * @param sql the text of the query.
+   *   The query should contain ? placeholders for each single value you intend to insert into the query.
+   *   For example: select * from some_table where partition_id = ? and something_else = 15;
+   *   If you want to handle inserting a set of items for an in-clause or similar use the
+   *   JdbcPartitioningRDD.SetPlaceholder value as a placeholder. This ties in with the setupPlaceholders argument that
+   *   will convert a specific partition sql query to have the correct ? placeholders for all items
+   * @param partitionArgs the value or group of values you require as query parameters for each partition of the query
+   *  For example if your query is : select * from some_table where partition_id = ?;
+   *  Then your partitionArgs could be a Seq[String] as you want to insert an id for each partition into the query
+   * @param insertPlaceholders function that takes your partitionArgs for the current partition and set's the values on
+   * the prepared statement for execution
+   * @param setupPlaceholders if you have to dynamically size the number of placeholders due to use of SetPlaceholder,
+   * then provide a function here that calls JdbcPartitioningRDD.insertStatementSetPlaceholders for each placeholder
+   * you need to replace in order of appearance in the String.
+   * For example: if your query is: select * from some_table where user_ids in (%SET_PLACEHOLDER%);
+   * Then you might provide a function here to get a ? placeholder for each user Id:
+   * { (query: String, userIds: Seq[String]) => JdbcPartitioningRDD.insertStatementSetPlaceholders(query, userIds.size) }
+   */
+  def create[A](
+              sc: JavaSparkContext,
+              connectionFactory: ConnectionFactory,
+              sql: String,
+              partitionArgs: java.util.List[A],
+              insertPlaceholders: JFunction2[PreparedStatement, A, Void],
+              setupPlaceholders: JFunction2[String, A, String]): JavaRDD[Array[Object]] = {
+
+    val mapRow = new JFunction[ResultSet, Array[Object]] {
+      override def call(resultSet: ResultSet): Array[Object] = {
+        resultSetToObjectArray(resultSet)
+      }
+    }
+
+    create(sc, connectionFactory, sql, partitionArgs, insertPlaceholders, setupPlaceholders, mapRow)
+  }
+
+  /**
+   * Create an RDD that executes an SQL query on a JDBC connection and reads results. Use this if you do not need to
+   * insert extra placeholders for a set of items like for an in clause in the query.
+   * usage example, see test case JavaAPISuite.testJavaJdbcPartitioningRDD.
+   *
+   * @param connectionFactory a factory that returns an open Connection.
+   *   The RDD takes care of closing the connection.
+   * @param sql the text of the query.
+   *   The query should contain ? placeholders for each single value you intend to insert into the query.
+   *   For example: select * from some_table where partition_id = ? and something_else = 15;
+   *   If you want to handle inserting a set of items for an in-clause or similar use the
+   *   JdbcPartitioningRDD.SetPlaceholder value as a placeholder. This ties in with the setupPlaceholders argument that
+   *   will convert a specific partition sql query to have the correct ? placeholders for all items
+   * @param partitionArgs the value or group of values you require as query parameters for each partition of the query
+   *  For example if your query is : select * from some_table where partition_id = ?;
+   *  Then your partitionArgs could be a Seq[String] as you want to insert an id for each partition into the query
+   * @param insertPlaceholders function that takes your partitionArgs for the current partition and set's the values on
+   * the prepared statement for execution
+   * @param mapRow a function from a ResultSet to a single row of the desired result type(s).
+   *   This should only call getInt, getString, etc; the RDD takes care of calling next.
+   *   The default maps a ResultSet to an array of Object.
+   */
+  def create[A,T](
+                   sc: JavaSparkContext,
+                   connectionFactory: ConnectionFactory,
+                   sql: String,
+                   partitionArgs: java.util.List[A],
+                   insertPlaceholders: JFunction2[PreparedStatement, A, Void],
+                   mapRow: JFunction[ResultSet, T]): JavaRDD[T] = {
+
+    val setupPlaceholders = new JFunction2[String, A, String] {
+      override def call(query: String, arg: A): String = query
+    }
+
+    create(sc, connectionFactory, sql, partitionArgs, insertPlaceholders, setupPlaceholders, mapRow)
+  }
+
+  /**
+   * Create an RDD that executes an SQL query on a JDBC connection and reads results. Use this if you do not need to
+   * insert extra placeholders for a set of items like for an in clause in the query. Each row is converted into a
+   * `Object` array. For usage example, see test case JavaAPISuite.testJavaJdbcPartitioningRDD.
+   * @param connectionFactory a factory that returns an open Connection.
+   *   The RDD takes care of closing the connection.
+   * @param sql the text of the query.
+   *   The query should contain ? placeholders for each single value you intend to insert into the query.
+   *   For example: select * from some_table where partition_id = ? and something_else = 15;
+   *   If you want to handle inserting a set of items for an in-clause or similar use the
+   *   JdbcPartitioningRDD.SetPlaceholder value as a placeholder. This ties in with the setupPlaceholders argument that
+   *   will convert a specific partition sql query to have the correct ? placeholders for all items
+   * @param partitionArgs the value or group of values you require as query parameters for each partition of the query
+   *  For example if your query is : select * from some_table where partition_id = ?;
+   *  Then your partitionArgs could be a Seq[String] as you want to insert an id for each partition into the query
+   * @param insertPlaceholders function that takes your partitionArgs for the current partition and set's the values on
+   * the prepared statement for execution
+   */
+  def create[A](
+                 sc: JavaSparkContext,
+                 connectionFactory: ConnectionFactory,
+                 sql: String,
+                 partitionArgs: java.util.List[A],
+                 insertPlaceholders: JFunction2[PreparedStatement, A, Void]): JavaRDD[Array[Object]] = {
+
+    val setupPlaceholders = new JFunction2[String, A, String] {
+      override def call(query: String, arg: A): String = query
+    }
+
+    val mapRow = new JFunction[ResultSet, Array[Object]] {
+      override def call(resultSet: ResultSet): Array[Object] = {
+        resultSetToObjectArray(resultSet)
+      }
+    }
+
+    create(sc, connectionFactory, sql, partitionArgs, insertPlaceholders, setupPlaceholders, mapRow)
+  }
+}

--- a/core/src/test/java/org/apache/spark/JavaJdbcPartitioningRDDSuite.java
+++ b/core/src/test/java/org/apache/spark/JavaJdbcPartitioningRDDSuite.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark;
+
+import java.io.Serializable;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.api.java.function.Function2;
+import org.apache.spark.rdd.JdbcPartitioningRDD;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class JavaJdbcPartitioningRDDSuite implements Serializable {
+    private transient JavaSparkContext sc;
+
+    @Before
+    public void setUp() throws ClassNotFoundException, SQLException {
+        sc = new JavaSparkContext("local", "JavaAPISuite");
+
+        Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
+        Connection connection =
+                DriverManager.getConnection("jdbc:derby:target/JavaJdbcPartitioningRDDSuiteDb;create=true");
+
+        try {
+            Statement create = connection.createStatement();
+            create.execute(
+                    "CREATE TABLE FOO(" +
+                            "ID INTEGER NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1)," +
+                            "DATA INTEGER)");
+            create.close();
+
+            PreparedStatement insert = connection.prepareStatement("INSERT INTO FOO(DATA) VALUES(?)");
+            for (int i = 1; i <= 100; i++) {
+                insert.setInt(1, i * 2);
+                insert.executeUpdate();
+            }
+            insert.close();
+        } catch (SQLException e) {
+            // If table doesn't exist...
+            if (e.getSQLState().compareTo("X0Y32") != 0) {
+                throw e;
+            }
+        } finally {
+            connection.close();
+        }
+    }
+
+    @After
+    public void tearDown() throws SQLException {
+        try {
+            DriverManager.getConnection("jdbc:derby:target/JavaJdbcPartitioningRDDSuiteDb;shutdown=true");
+        } catch(SQLException e) {
+            // Throw if not normal single database shutdown
+            // https://db.apache.org/derby/docs/10.2/ref/rrefexcept71493.html
+            if (e.getSQLState().compareTo("08006") != 0) {
+                throw e;
+            }
+        }
+
+        sc.stop();
+        sc = null;
+    }
+
+    @Test
+    public void testJavaJdbcPartitioningRDD() throws Exception {
+        List<Integer> args = new ArrayList<Integer>(100);
+
+        for (int i = 1; i <= 100; i++) {
+            args.add(i);
+        }
+
+        JavaRDD<Integer> rdd = JdbcPartitioningRDD.create(
+                sc,
+                new JdbcPartitioningRDD.ConnectionFactory() {
+                    @Override
+                    public Connection getConnection() throws SQLException {
+                        return DriverManager.getConnection("jdbc:derby:target/JavaJdbcPartitioningRDDSuiteDb");
+                    }
+                },
+                "SELECT DATA FROM FOO WHERE ID = ?",
+                args,
+                new Function2<PreparedStatement, Integer, Void>() {
+                    @Override
+                    public Void call(PreparedStatement stmt, Integer arg) throws SQLException {
+                        stmt.setInt(1, arg);
+                        return null;
+                    }
+                },
+                new Function<ResultSet, Integer>() {
+                    @Override
+                    public Integer call(ResultSet r) throws Exception {
+                        return r.getInt(1);
+                    }
+                }
+        ).cache();
+
+        Assert.assertEquals(100, rdd.count());
+        Assert.assertEquals(100, rdd.partitions().size());
+        Assert.assertEquals(
+                Integer.valueOf(10100),
+                rdd.reduce(new Function2<Integer, Integer, Integer>() {
+                    @Override
+                    public Integer call(Integer i1, Integer i2) {
+                        return i1 + i2;
+                    }
+                }));
+    }
+
+    @Test
+    public void testSetsInJavaJdbcPartitioningRDD() throws Exception {
+        List<List<Integer>> args = new ArrayList<List<Integer>>(100);
+
+        List<Integer> innerArgs = new ArrayList<Integer>(5);
+
+        for (int i = 1; i <= 100; i++) {
+            innerArgs.add(i);
+            if(innerArgs.size() == 5) {
+                args.add(innerArgs);
+                innerArgs = new ArrayList<Integer>(5);
+            }
+        }
+
+        if(!innerArgs.isEmpty()) {
+            args.add(innerArgs);
+        }
+
+        JavaRDD<Integer> rdd = JdbcPartitioningRDD.create(
+                sc,
+                new JdbcPartitioningRDD.ConnectionFactory() {
+                    @Override
+                    public Connection getConnection() throws SQLException {
+                        return DriverManager.getConnection("jdbc:derby:target/JavaJdbcPartitioningRDDSuiteDb");
+                    }
+                },
+                "SELECT DATA FROM FOO WHERE ID IN (" + JdbcPartitioningRDD.SetPlaceholder() + ")",
+                args,
+                new Function2<PreparedStatement, List<Integer>, Void>() {
+                    @Override
+                    public Void call(PreparedStatement stmt, List<Integer> args) throws SQLException {
+                        for (int i = 1; i <= args.size(); i++) {
+                            stmt.setInt(i, args.get(i - 1));
+                        }
+                        return null;
+                    }
+                },
+                new Function2<String, List<Integer>, String>() {
+                    @Override
+                    public String call(String query, List<Integer> args) {
+                        return JdbcPartitioningRDD.insertStatementSetPlaceholders(query, args.size());
+                    }
+                },
+                new Function<ResultSet, Integer>() {
+                    @Override
+                    public Integer call(ResultSet r) throws Exception {
+                        return r.getInt(1);
+                    }
+                }
+        ).cache();
+
+        Assert.assertEquals(100, rdd.count());
+        Assert.assertEquals(20, rdd.partitions().size());
+        Assert.assertEquals(
+                Integer.valueOf(10100),
+                rdd.reduce(new Function2<Integer, Integer, Integer>() {
+                    @Override
+                    public Integer call(Integer i1, Integer i2) {
+                        return i1 + i2;
+                    }
+                }));
+    }
+}

--- a/core/src/test/scala/org/apache/spark/rdd/JdbcPartitioningRDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/JdbcPartitioningRDDSuite.scala
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.rdd
+
+import java.sql._
+
+import org.scalatest.BeforeAndAfter
+
+import org.apache.spark.{LocalSparkContext, SparkContext, SparkFunSuite}
+import org.apache.spark.util.Utils
+
+class JdbcPartitioningRDDSuite extends SparkFunSuite with BeforeAndAfter with LocalSparkContext {
+
+  before {
+    Utils.classForName("org.apache.derby.jdbc.EmbeddedDriver")
+    val conn = DriverManager.getConnection("jdbc:derby:target/JdbcPartitioningRDDSuiteDb;create=true")
+    try {
+
+      try {
+        val create = conn.createStatement
+        create.execute("""
+          CREATE TABLE FOO(
+            ID INTEGER NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1),
+            DATA INTEGER
+          )""")
+        create.close()
+        val insert = conn.prepareStatement("INSERT INTO FOO(DATA) VALUES(?)")
+        (1 to 100).foreach { i =>
+          insert.setInt(1, i * 2)
+          insert.executeUpdate
+        }
+        insert.close()
+      } catch {
+        case e: SQLException if e.getSQLState == "X0Y32" =>
+        // table exists
+      }
+    } finally {
+      conn.close()
+    }
+  }
+
+  test("basic functionality") {
+    sc = new SparkContext("local", "test")
+    val rdd = new JdbcPartitioningRDD[Int, Int](
+      sc,
+      () => { DriverManager.getConnection("jdbc:derby:target/JdbcPartitioningRDDSuiteDb") },
+      "SELECT DATA FROM FOO WHERE ID = ?",
+      1 to 100,
+      insertPlaceholders = { case (stmt, args) =>
+        stmt.setInt(1, args)
+      },
+      mapRow = (r: ResultSet) => { r.getInt(1) } ).cache()
+
+    assert(rdd.count === 100)
+    assert(rdd.getPartitions.size == 100)
+    assert(rdd.reduce(_ + _) === 10100)
+  }
+
+  test("using SetPlaceholder") {
+    sc = new SparkContext("local", "test")
+    val rdd = new JdbcPartitioningRDD[Seq[Int], Int](
+      sc,
+      () => { DriverManager.getConnection("jdbc:derby:target/JdbcPartitioningRDDSuiteDb") },
+      s"SELECT DATA FROM FOO WHERE ID IN (${JdbcPartitioningRDD.SetPlaceholder})",
+      (1 to 100).grouped(5).toList,
+      insertPlaceholders = {
+        case (stmt, args) =>
+          args.zipWithIndex.foreach { case (id, idx) =>
+            stmt.setInt(idx+1, id)
+          }
+      },
+      setupPlaceholders = { case (sql, args) => JdbcPartitioningRDD.insertStatementSetPlaceholders(sql, args.size) },
+      mapRow = (r: ResultSet) => { r.getInt(1) } ).cache()
+    assert(rdd.count === 100)
+    assert(rdd.getPartitions.size == 20)
+    assert(rdd.reduce(_ + _) === 10100)
+  }
+
+  test("compound arguments with multiple SetPlaceholders") {
+    sc = new SparkContext("local", "test")
+    val rdd = new JdbcPartitioningRDD[(Seq[Int], Seq[Int]), Int](
+      sc,
+      () => { DriverManager.getConnection("jdbc:derby:target/JdbcPartitioningRDDSuiteDb") },
+      s"SELECT DATA FROM FOO WHERE ID IN (${JdbcPartitioningRDD.SetPlaceholder}) AND ID IN (${JdbcPartitioningRDD.SetPlaceholder})",
+      (1 to 100).toList.grouped(5).zip((1 to 100).toList.grouped(5)).toList,
+      insertPlaceholders = {
+        case (stmt, (ids1, ids2)) =>
+          ids1.++(ids2).zipWithIndex.foreach { case (id, idx) =>
+            stmt.setLong(idx+1, id)
+          }
+      },
+      setupPlaceholders = { case (sql, (ids1, ids2)) =>
+        val ids1Replaced = JdbcPartitioningRDD.insertStatementSetPlaceholders(sql, ids1.size)
+        JdbcPartitioningRDD.insertStatementSetPlaceholders(ids1Replaced, ids2.size)
+      },
+      mapRow = (r: ResultSet) => { r.getInt(1) } ).cache()
+    assert(rdd.count === 100)
+    assert(rdd.getPartitions.size == 20)
+    assert(rdd.reduce(_ + _) === 10100)
+  }
+
+  after {
+    try {
+      DriverManager.getConnection("jdbc:derby:target/JdbcPartitioningRDDSuiteDb;shutdown=true")
+    } catch {
+      case se: SQLException if se.getSQLState == "08006" =>
+      // Normal single database shutdown
+      // https://db.apache.org/derby/docs/10.2/ref/rrefexcept71493.html
+    }
+  }
+}


### PR DESCRIPTION
-Provide JdbcPartitioningRDD that allows fine grained control of the
queries run per Spark partition against the JDBC datastore.
-Supports dynamic placeholders with `SetPlaceholder` and the related
`insertStatementSetPlaceholders` method on the companion object along with overriding the default constructor argument `setupPlaceholders`.

Disclaimer: This contribution is my original work and I license the work to the project under the project's open source license.
