### PR TITLE
[SPARK-11265] [YARN] YarnClient can't get tokens to talk to Hive 1.2.1 in a secure cluster

### DIFF
--- a/yarn/pom.xml
+++ b/yarn/pom.xml
@@ -162,6 +162,31 @@
        <artifactId>jersey-server</artifactId>
        <scope>test</scope>
      </dependency>
+
+    <!--
+     Testing Hive reflection needs hive on the test classpath only.
+     It doesn't need the spark hive modules, so the -Phive flag is not checked.
+      -->
+    <dependency>
+      <groupId>${hive.group}</groupId>
+      <artifactId>hive-exec</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${hive.group}</groupId>
+      <artifactId>hive-metastore</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libfb303</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1337,7 +1337,8 @@ object Client extends Logging {
       conf: Configuration,
       credentials: Credentials) {
     if (shouldGetTokens(sparkConf, "hive") && UserGroupInformation.isSecurityEnabled) {
-      YarnSparkHadoopUtil.obtainTokenForHiveMetastore(sparkConf, conf).foreach {
+      val util = new YarnSparkHadoopUtil()
+      util.obtainTokenForHiveMetastore(sparkConf, conf).foreach {
         credentials.addToken(new Text("hive.server2.delegation.token"), _)
       }
     }

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1337,55 +1337,8 @@ object Client extends Logging {
       conf: Configuration,
       credentials: Credentials) {
     if (shouldGetTokens(sparkConf, "hive") && UserGroupInformation.isSecurityEnabled) {
-      val mirror = universe.runtimeMirror(getClass.getClassLoader)
-
-      try {
-        val hiveConfClass = mirror.classLoader.loadClass("org.apache.hadoop.hive.conf.HiveConf")
-        val hiveConf = hiveConfClass.newInstance()
-
-        val hiveConfGet = (param: String) => Option(hiveConfClass
-          .getMethod("get", classOf[java.lang.String])
-          .invoke(hiveConf, param))
-
-        val metastore_uri = hiveConfGet("hive.metastore.uris")
-
-        // Check for local metastore
-        if (metastore_uri != None && metastore_uri.get.toString.size > 0) {
-          val hiveClass = mirror.classLoader.loadClass("org.apache.hadoop.hive.ql.metadata.Hive")
-          val hive = hiveClass.getMethod("get").invoke(null, hiveConf.asInstanceOf[Object])
-
-          val metastore_kerberos_principal_conf_var = mirror.classLoader
-            .loadClass("org.apache.hadoop.hive.conf.HiveConf$ConfVars")
-            .getField("METASTORE_KERBEROS_PRINCIPAL").get("varname").toString
-
-          val principal = hiveConfGet(metastore_kerberos_principal_conf_var)
-
-          val username = Option(UserGroupInformation.getCurrentUser().getUserName)
-          if (principal != None && username != None) {
-            val tokenStr = hiveClass.getMethod("getDelegationToken",
-              classOf[java.lang.String], classOf[java.lang.String])
-              .invoke(hive, username.get, principal.get).asInstanceOf[java.lang.String]
-
-            val hive2Token = new Token[DelegationTokenIdentifier]()
-            hive2Token.decodeFromUrlString(tokenStr)
-            credentials.addToken(new Text("hive.server2.delegation.token"), hive2Token)
-            logDebug("Added hive.Server2.delegation.token to conf.")
-            hiveClass.getMethod("closeCurrent").invoke(null)
-          } else {
-            logError("Username or principal == NULL")
-            logError(s"""username=${username.getOrElse("(NULL)")}""")
-            logError(s"""principal=${principal.getOrElse("(NULL)")}""")
-            throw new IllegalArgumentException("username and/or principal is equal to null!")
-          }
-        } else {
-          logDebug("HiveMetaStore configured in localmode")
-        }
-      } catch {
-        case e: java.lang.NoSuchMethodException => { logInfo("Hive Method not found " + e); return }
-        case e: java.lang.ClassNotFoundException => { logInfo("Hive Class not found " + e); return }
-        case e: Exception => { logError("Unexpected Exception " + e)
-          throw new RuntimeException("Unexpected exception", e)
-        }
+      YarnSparkHadoopUtil.obtainTokenForHiveMetastore(sparkConf, conf).foreach {
+        credentials.addToken(new Text("hive.server2.delegation.token"), _)
       }
     }
   }

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1337,8 +1337,7 @@ object Client extends Logging {
       conf: Configuration,
       credentials: Credentials) {
     if (shouldGetTokens(sparkConf, "hive") && UserGroupInformation.isSecurityEnabled) {
-      val util = new YarnSparkHadoopUtil()
-      util.obtainTokenForHiveMetastore(conf).foreach {
+      YarnSparkHadoopUtil.get.obtainTokenForHiveMetastore(conf).foreach {
         credentials.addToken(new Text("hive.server2.delegation.token"), _)
       }
     }

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -322,10 +322,8 @@ private[spark] class Client(
     // multiple times, YARN will fail to launch containers for the app with an internal
     // error.
     val distributedUris = new HashSet[String]
-    if (isClusterMode) {
-      obtainTokenForHiveMetastore(sparkConf, hadoopConf, credentials)
-      obtainTokenForHBase(sparkConf, hadoopConf, credentials)
-    }
+    obtainTokenForHiveMetastore(sparkConf, hadoopConf, credentials)
+    obtainTokenForHBase(sparkConf, hadoopConf, credentials)
 
     val replication = sparkConf.getInt("spark.yarn.submit.file.replication",
       fs.getDefaultReplication(dst)).toShort

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1338,7 +1338,7 @@ object Client extends Logging {
       credentials: Credentials) {
     if (shouldGetTokens(sparkConf, "hive") && UserGroupInformation.isSecurityEnabled) {
       val util = new YarnSparkHadoopUtil()
-      util.obtainTokenForHiveMetastore(sparkConf, conf).foreach {
+      util.obtainTokenForHiveMetastore(conf).foreach {
         credentials.addToken(new Text("hive.server2.delegation.token"), _)
       }
     }

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -322,8 +322,10 @@ private[spark] class Client(
     // multiple times, YARN will fail to launch containers for the app with an internal
     // error.
     val distributedUris = new HashSet[String]
-    obtainTokenForHiveMetastore(sparkConf, hadoopConf, credentials)
-    obtainTokenForHBase(sparkConf, hadoopConf, credentials)
+    if (isClusterMode) {
+      obtainTokenForHiveMetastore(sparkConf, hadoopConf, credentials)
+      obtainTokenForHBase(sparkConf, hadoopConf, credentials)
+    }
 
     val replication = sparkConf.getInt("spark.yarn.submit.file.replication",
       fs.getDefaultReplication(dst)).toShort

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -177,8 +177,6 @@ class YarnSparkHadoopUtil extends SparkHadoopUtil {
         logInfo(s"$service class not found $e")
         logDebug("Hive Class not found", e)
       case t: Throwable => {
-        val msg = s"$service: Unexpected Exception " + t
-        logError(msg, t)
         throw t
       }
     }

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -438,6 +438,5 @@ object YarnSparkHadoopUtil {
       conf.getInt("spark.executor.instances", targetNumExecutors)
     }
   }
-
 }
 

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -18,7 +18,8 @@
 package org.apache.spark.deploy.yarn
 
 import java.io.File
-import java.util.regex.{Matcher, Pattern}
+import java.util.regex.Matcher
+import java.util.regex.Pattern
 
 import scala.collection.mutable.HashMap
 import scala.reflect.runtime._
@@ -28,17 +29,16 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.hdfs.security.token.delegation.DelegationTokenIdentifier
 import org.apache.hadoop.io.Text
-import org.apache.hadoop.mapred.{JobConf, Master}
+import org.apache.hadoop.mapred.{Master, JobConf}
 import org.apache.hadoop.security.token.Token
 import org.apache.hadoop.security.{Credentials, UserGroupInformation}
+import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.apache.hadoop.yarn.api.ApplicationConstants
 import org.apache.hadoop.yarn.api.ApplicationConstants.Environment
 import org.apache.hadoop.yarn.api.records.{ApplicationAccessType, ContainerId, Priority}
-import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.apache.hadoop.yarn.util.ConverterUtils
 
 import org.apache.spark.deploy.SparkHadoopUtil
-import org.apache.spark.deploy.yarn.Client._
 import org.apache.spark.launcher.YarnCommandBuilderUtils
 import org.apache.spark.util.Utils
 import org.apache.spark.{Logging, SecurityManager, SparkConf, SparkException}

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -175,7 +175,7 @@ class YarnSparkHadoopUtil extends SparkHadoopUtil {
     thrown match {
       case e: ClassNotFoundException =>
         logInfo(s"$service class not found $e")
-        logDebug("Hive Class not found", e)
+        logDebug("$service class not found", e)
       case t: Throwable => {
         throw t
       }

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -161,8 +161,6 @@ class YarnSparkHadoopUtil extends SparkHadoopUtil {
         logInfo(s"Hive class not found $e")
         logDebug("Hive class not found", e)
         None
-      case t: Throwable =>
-        throw t
     }
   }
 
@@ -203,16 +201,13 @@ class YarnSparkHadoopUtil extends SparkHadoopUtil {
 
         // invoke
         val hive = getHive.invoke(null, hiveConf)
-        val tokenStr = getDelegationToken.invoke(hive, username, principal)
-          .asInstanceOf[java.lang.String]
+        val tokenStr = getDelegationToken.invoke(hive, username, principal).asInstanceOf[String]
         val hive2Token = new Token[DelegationTokenIdentifier]()
         hive2Token.decodeFromUrlString(tokenStr)
         Some(hive2Token)
       } finally {
-        try {
+        Utils.tryLogNonFatalError {
           closeCurrent.invoke(null)
-        } catch {
-          case e: Exception => logWarning("In Hive.closeCurrent()", e)
         }
       }
     } else {

--- a/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtilSuite.scala
+++ b/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtilSuite.scala
@@ -18,10 +18,12 @@
 package org.apache.spark.deploy.yarn
 
 import java.io.{File, IOException}
+import java.lang.reflect.InvocationTargetException
 
 import com.google.common.io.{ByteStreams, Files}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
+import org.apache.hadoop.hive.ql.metadata.HiveException
 import org.apache.hadoop.yarn.api.ApplicationConstants
 import org.apache.hadoop.yarn.api.ApplicationConstants.Environment
 import org.apache.hadoop.yarn.conf.YarnConfiguration
@@ -243,6 +245,32 @@ class YarnSparkHadoopUtilSuite extends SparkFunSuite with Matchers with Logging 
       assert(SparkHadoopUtil.get.getClass === classOf[SparkHadoopUtil])
     } finally {
       System.clearProperty("SPARK_YARN_MODE")
+    }
+  }
+
+  test("Obtain tokens For HiveMetastore") {
+    val hadoopConf = new Configuration()
+    val sparkConf = new SparkConf()
+    hadoopConf.set("hive.metastore.kerberos.principal", "bob")
+    // thrift picks up on port 0 and bails out, without trying to talk to endpoint
+    hadoopConf.set("hive.metastore.uris", "http://localhost:0")
+    val util = new YarnSparkHadoopUtil
+    val e = intercept[InvocationTargetException] {
+      val token = util.obtainTokenForHiveMetastoreInner(sparkConf, hadoopConf, "alice")
+      fail(s"Expected an exception, got the token $token")
+    }
+    val inner = e.getCause
+    if (inner == null) {
+      fail("No inner cause", e)
+    }
+
+    if (!inner.isInstanceOf[HiveException]) {
+      fail(s"Not a hive exception", inner)
+    }
+    // expect exception trapping code to unwind this hive-side exception
+    intercept[HiveException] {
+      val token = util.obtainTokenForHiveMetastore(sparkConf, hadoopConf)
+      fail(s"Expected an exception, got the token $token")
     }
   }
 }

--- a/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtilSuite.scala
+++ b/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtilSuite.scala
@@ -269,7 +269,7 @@ class YarnSparkHadoopUtilSuite extends SparkFunSuite with Matchers with Logging 
       fail("No inner cause", e)
     }
     if (!inner.isInstanceOf[HiveException]) {
-      fail(s"Not a hive exception", inner)
+      fail("Not a hive exception", inner)
     }
     inner
   }

--- a/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtilSuite.scala
+++ b/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtilSuite.scala
@@ -250,26 +250,24 @@ class YarnSparkHadoopUtilSuite extends SparkFunSuite with Matchers with Logging 
 
   test("Obtain tokens For HiveMetastore") {
     val hadoopConf = new Configuration()
-    val sparkConf = new SparkConf()
     hadoopConf.set("hive.metastore.kerberos.principal", "bob")
     // thrift picks up on port 0 and bails out, without trying to talk to endpoint
     hadoopConf.set("hive.metastore.uris", "http://localhost:0")
     val util = new YarnSparkHadoopUtil
     val e = intercept[InvocationTargetException] {
-      val token = util.obtainTokenForHiveMetastoreInner(sparkConf, hadoopConf, "alice")
+      val token = util.obtainTokenForHiveMetastoreInner(hadoopConf, "alice")
       fail(s"Expected an exception, got the token $token")
     }
     val inner = e.getCause
     if (inner == null) {
       fail("No inner cause", e)
     }
-
     if (!inner.isInstanceOf[HiveException]) {
       fail(s"Not a hive exception", inner)
     }
     // expect exception trapping code to unwind this hive-side exception
     intercept[HiveException] {
-      val token = util.obtainTokenForHiveMetastore(sparkConf, hadoopConf)
+      val token = util.obtainTokenForHiveMetastore(hadoopConf)
       fail(s"Expected an exception, got the token $token")
     }
   }


### PR DESCRIPTION
This is a fix for SPARK-11265; the introspection code to get Hive delegation tokens failing on Spark 1.5.1+, due to changes in the Hive codebase
