### PR TITLE
[SPARK-8277][SPARKR] Faster createDataFrame using mapply

### DIFF
--- a/R/pkg/R/SQLContext.R
+++ b/R/pkg/R/SQLContext.R
@@ -98,8 +98,7 @@ createDataFrame <- function(sqlContext, data, schema = NULL, samplingRatio = 1.0
           x
         }
       }
-      data <- data.frame(lapply(data, dropFactor), stringsAsFactors = FALSE)
-      data <- do.call(mapply, c(list, as.list(data), SIMPLIFY = FALSE))
+      data <- do.call(mapply, c(list, unname(lapply(data, dropFactor)), SIMPLIFY = FALSE))
   }
   if (is.list(data)) {
     sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sqlContext)

--- a/R/pkg/R/SQLContext.R
+++ b/R/pkg/R/SQLContext.R
@@ -90,8 +90,6 @@ createDataFrame <- function(sqlContext, data, schema = NULL, samplingRatio = 1.0
       if (is.null(schema)) {
         schema <- names(data)
       }
-      n <- nrow(data)
-      m <- ncol(data)
       # get rid of factor type
       dropFactor <- function(x) {
         if (is.factor(x)) {

--- a/R/pkg/R/SQLContext.R
+++ b/R/pkg/R/SQLContext.R
@@ -100,9 +100,8 @@ createDataFrame <- function(sqlContext, data, schema = NULL, samplingRatio = 1.0
           x
         }
       }
-      data <- lapply(1:n, function(i) {
-        lapply(1:m, function(j) { dropFactor(data[i,j]) })
-      })
+      data <- data.frame(lapply(data, dropFactor), stringsAsFactors = FALSE)
+      data <- do.call(mapply, c(list, as.list(data), SIMPLIFY = FALSE))
   }
   if (is.list(data)) {
     sc <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", sqlContext)


### PR DESCRIPTION
With a single loop using `mapply`, I'm able to create DataFrame much faster from R data.frame.

Please see benchmark results and code:

``` r
Unit: milliseconds
 expr        min         lq       mean     median        uq        max neval
  old 284.874542 312.012427 426.822889 336.360288 436.47377 1356.91518   100
  new   4.875089   6.357665   9.013442   6.904729  10.41597   42.41479   100
```

``` r
library(nycflights13)
library(microbenchmark)
data <- head(flights, n = 1000)

# get rid of factor type
dropFactor <- function(x) {
  if (is.factor(x)) {
    as.character(x)
  } else {
    x
  }
}

createDataFrameNew <- function(data) {
  do.call(mapply, c(list, unname(lapply(data, dropFactor)), SIMPLIFY = FALSE))
}

createDataFrameOld <- function(data) {
  n <- nrow(data)
  m <- ncol(data)
  lapply(1:n, function(i) {
    lapply(1:m, function(j) { dropFactor(data[i,j]) })
  })
}

my_check <- function(values) {
  all(sapply(values[-1], function(x) identical(values[[1]], x)))
}

microbenchmark(old = createDataFrameOld(data), new = createDataFrameNew(data), check = my_check)
```
