### PR TITLE
[SPARK-10562][SQL] support mixed case partitionBy column names for tables stored in metastore

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -203,10 +203,21 @@ private[hive] class HiveMetastoreCatalog(val client: ClientInterface, hive: Hive
     val tableProperties = new mutable.HashMap[String, String]
     tableProperties.put("spark.sql.sources.provider", provider)
 
+    val normalizedSchema = userSpecifiedSchema.map { schema =>
+      val newFields = schema.map { f =>
+        if (partitionColumns.contains(f.name)) {
+          f.copy(name = f.name.toLowerCase)
+        } else {
+          f
+        }
+      }
+      StructType(newFields)
+    }
+
     // Saves optional user specified schema.  Serialized JSON schema string may be too long to be
     // stored into a single metastore SerDe property.  In this case, we split the JSON string and
     // store each part as a separate SerDe property.
-    userSpecifiedSchema.foreach { schema =>
+    normalizedSchema.foreach { schema =>
       val threshold = conf.schemaStringLengthThreshold
       val schemaJsonString = schema.json
       // Split the JSON string.
@@ -248,7 +259,7 @@ private[hive] class HiveMetastoreCatalog(val client: ClientInterface, hive: Hive
 
     val maybeSerDe = HiveSerDe.sourceToSerDe(provider, hive.hiveconf)
     val dataSource = ResolvedDataSource(
-      hive, userSpecifiedSchema, partitionColumns, provider, options)
+      hive, normalizedSchema, partitionColumns.map(_.toLowerCase), provider, options)
 
     def newSparkSQLSpecificMetastoreTable(): HiveTable = {
       HiveTable(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -1410,4 +1410,12 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
       }
     }
   }
+
+  test("SPARK-10562: partition by column with mixed case name") {
+    withTable("tbl10562") {
+      val df = Seq(2012 -> "a").toDF("Year", "val")
+      df.write.partitionBy("Year").saveAsTable("tbl10562")
+      checkAnswer(sql("SELECT year FROM tbl10562"), Row(2012))
+    }
+  }
 }


### PR DESCRIPTION
This PR implements approach 1 of https://github.com/apache/spark/pull/9226#issuecomment-150272837
