### PR TITLE
[SPARK-8582][Core]Optimize checkpointing to avoid computing an RDD twice

### DIFF
--- a/core/src/main/scala/org/apache/spark/CheckpointManager.scala
+++ b/core/src/main/scala/org/apache/spark/CheckpointManager.scala
@@ -26,7 +26,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.rdd.{ReliableRDDCheckpointData, ReliableCheckpointRDD, RDD}
 import org.apache.spark.storage._
 
-class CheckpointManager extends Logging {
+private[spark] class CheckpointManager extends Logging {
 
   /** Keys of RDD partitions that are being checkpointed. */
   private val checkpointingRDDPartitions = new mutable.HashSet[RDDBlockId]

--- a/core/src/main/scala/org/apache/spark/CheckpointManager.scala
+++ b/core/src/main/scala/org/apache/spark/CheckpointManager.scala
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark
+
+import scala.collection.mutable
+import scala.reflect.ClassTag
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.rdd.{ReliableRDDCheckpointData, ReliableCheckpointRDD, RDD}
+import org.apache.spark.storage._
+
+class CheckpointManager extends Logging {
+
+  /** Keys of RDD partitions that are being checkpointed. */
+  private val checkpointingRDDPartitions = new mutable.HashSet[RDDBlockId]
+
+  /** Gets or computes an RDD partition. Used by RDD.iterator() when an RDD is cached. */
+  def getOrCompute[T: ClassTag](
+      rdd: RDD[T],
+      checkpointData: ReliableRDDCheckpointData[T],
+      partition: Partition,
+      context: TaskContext): Iterator[T] = {
+    val conf = checkpointData.broadcastedConf.value.value
+    val path =
+      new Path(checkpointData.cpDir, ReliableCheckpointRDD.checkpointFileName(partition.index))
+    val key = RDDBlockId(rdd.id, partition.index)
+    logDebug(s"Looking for partition $key")
+    if (checkpointData.isCheckpointed) {
+      // TODO how to know we should checkpoint
+      return new InterruptibleIterator[T](context,
+        ReliableCheckpointRDD.readCheckpointFile(path, conf, context))
+    } else {
+      // Acquire a lock for loading this partition
+      // If another thread already holds the lock, wait for it to finish return its results
+      val checkpoint = acquireLockForPartition[T](key, path, conf, context)
+      if (checkpoint.isDefined) {
+        return new InterruptibleIterator[T](context, checkpoint.get)
+      }
+    }
+
+    // Otherwise, we have to load the partition ourselves
+    try {
+      logInfo(s"Partition $key not found, computing it")
+      val computedValues = rdd.computeOrReadCache(partition, context)
+      ReliableCheckpointRDD.writeCheckpointFile(
+        context, computedValues, checkpointData.cpDir, conf, partition.index)
+      ReliableCheckpointRDD.readCheckpointFile(path, conf, context)
+    } finally {
+      checkpointingRDDPartitions.synchronized {
+        checkpointingRDDPartitions.remove(key)
+        checkpointingRDDPartitions.notifyAll()
+      }
+    }
+  }
+
+  /**
+   * Acquire a loading lock for the partition identified by the given block ID.
+   *
+   * If the lock is free, just acquire it and return None. Otherwise, another thread is already
+   * checkpointing the partition, so we wait for it to finish and return the values loaded by the
+   * thread.
+   */
+  private def acquireLockForPartition[T](
+      id: RDDBlockId, path: Path, conf: Configuration, context: TaskContext): Option[Iterator[T]] =
+  {
+    checkpointingRDDPartitions.synchronized {
+      if (!checkpointingRDDPartitions.contains(id)) {
+        // If the partition is free, acquire its lock to compute its value
+        checkpointingRDDPartitions.add(id)
+       return None
+      } else {
+        // Otherwise, wait for another thread to finish and return its result
+        logInfo(s"Another thread is checkpointing $id, waiting for it to finish...")
+        while (checkpointingRDDPartitions.contains(id)) {
+          checkpointingRDDPartitions.wait()
+        }
+        logInfo(s"Finished waiting for $id")
+      }
+    }
+    Some(ReliableCheckpointRDD.readCheckpointFile(path, conf, context))
+  }
+
+}

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1817,6 +1817,7 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
     if (conf.getBoolean("spark.logLineage", false)) {
       logInfo("RDD's recursive dependencies:\n" + rdd.toDebugString)
     }
+    rdd.doPrepareCheckpoint()
     dagScheduler.runJob(rdd, cleanedFunc, partitions, callSite, resultHandler, localProperties.get)
     progressBar.foreach(_.finishAll())
     rdd.doCheckpoint()

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -81,7 +81,7 @@ class SparkEnv (
   @deprecated("Actor system is no longer supported as of 1.4.0", "1.4.0")
   val actorSystem: ActorSystem = _actorSystem
 
-  private[spark] val checkpointMananger = new CheckpointManager
+  private[spark] val checkpointManager = new CheckpointManager
 
   private[spark] var isStopped = false
   private val pythonWorkers = mutable.HashMap[(String, Map[String, String]), PythonWorkerFactory]()

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -81,6 +81,8 @@ class SparkEnv (
   @deprecated("Actor system is no longer supported as of 1.4.0", "1.4.0")
   val actorSystem: ActorSystem = _actorSystem
 
+  private[spark] val checkpointMananger = new CheckpointManager
+
   private[spark] var isStopped = false
   private val pythonWorkers = mutable.HashMap[(String, Map[String, String]), PythonWorkerFactory]()
 

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -258,11 +258,10 @@ abstract class RDD[T: ClassTag](
    * subclasses of RDD.
    */
   final def iterator(split: Partition, context: TaskContext): Iterator[T] = {
-    if (!isCheckpointedAndMaterialized) {
-      if (checkpointData.exists(_.isInstanceOf[ReliableRDDCheckpointData[T]])) {
-        return SparkEnv.get.checkpointManager.getOrCompute(
-          this, checkpointData.get.asInstanceOf[ReliableRDDCheckpointData[T]], split, context)
-      }
+    if (!isCheckpointedAndMaterialized &&
+      checkpointData.exists(_.isInstanceOf[ReliableRDDCheckpointData[T]])) {
+      SparkEnv.get.checkpointManager.doCheckpoint(
+        this, checkpointData.get.asInstanceOf[ReliableRDDCheckpointData[T]], split, context)
     }
     computeOrReadCache(split, context)
   }

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -258,6 +258,16 @@ abstract class RDD[T: ClassTag](
    * subclasses of RDD.
    */
   final def iterator(split: Partition, context: TaskContext): Iterator[T] = {
+    if (!isCheckpointedAndMaterialized) {
+      if (checkpointData.exists(_.isInstanceOf[ReliableRDDCheckpointData[T]])) {
+        return SparkEnv.get.checkpointMananger.getOrCompute(
+          this, checkpointData.get.asInstanceOf[ReliableRDDCheckpointData[T]], split, context)
+      }
+    }
+    computeOrReadCache(split, context)
+  }
+
+  private[spark] def computeOrReadCache(split: Partition, context: TaskContext): Iterator[T] = {
     if (storageLevel != StorageLevel.NONE) {
       SparkEnv.get.cacheManager.getOrCompute(this, split, context, storageLevel)
     } else {
@@ -1635,6 +1645,19 @@ abstract class RDD[T: ClassTag](
 
   // Avoid handling doCheckpoint multiple times to prevent excessive recursion
   @transient private var doCheckpointCalled = false
+
+  @transient private var doPrepareCheckpointCalled = false
+
+  private[spark] def doPrepareCheckpoint(): Unit = {
+    if (!doPrepareCheckpointCalled) {
+      doPrepareCheckpointCalled = true
+      if (checkpointData.isDefined) {
+        checkpointData.get.prepareCheckpoint()
+      } else {
+        dependencies.foreach(_.rdd.doPrepareCheckpoint())
+      }
+    }
+  }
 
   /**
    * Performs the checkpointing of this RDD by saving this. It is called after a job using this RDD

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -260,7 +260,7 @@ abstract class RDD[T: ClassTag](
   final def iterator(split: Partition, context: TaskContext): Iterator[T] = {
     if (!isCheckpointedAndMaterialized) {
       if (checkpointData.exists(_.isInstanceOf[ReliableRDDCheckpointData[T]])) {
-        return SparkEnv.get.checkpointMananger.getOrCompute(
+        return SparkEnv.get.checkpointManager.getOrCompute(
           this, checkpointData.get.asInstanceOf[ReliableRDDCheckpointData[T]], split, context)
       }
     }


### PR DESCRIPTION
Unlike #7021, this PR uses an approach similar to `persist` to compute and checkpoint an RDD at the same job. When computing an RDD at the first time, each partition will be checkpointed and read back as  an iterator (maybe compute it again, not sure which one is better). After finishing the job, we also check if all partitions are checkpointed, if not, we still need to launch a job to checkpoint the missing partitions.
