### PR TITLE
[SPARK-11312][SQL]drop temporary function should match with create temporary function

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -587,7 +587,8 @@ class HiveContext private[hive](
   }
 
   protected[hive] def runSqlHive(sql: String): Seq[String] = {
-    if (sql.toLowerCase.contains("create temporary function")) {
+    if (sql.toLowerCase.contains("create temporary function") ||
+      sql.toLowerCase.contains("drop temporary function")) {
       executionHive.runSqlHive(sql)
     } else if (sql.trim.toLowerCase.startsWith("set")) {
       metadataHive.runSqlHive(sql)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -874,6 +874,17 @@ class HiveQuerySuite extends HiveComparisonTest with BeforeAndAfter {
     }
   }
 
+  test("DROP TEMPORARY FUNCTION") {
+    val funcJar = TestHive.getHiveFile("TestUDTF.jar").getCanonicalPath
+    sql(s"ADD JAR $funcJar")
+    sql(
+      """CREATE TEMPORARY FUNCTION udtf_count2 AS
+        | 'org.apache.spark.sql.hive.execution.GenericUDTFCount2'""".stripMargin)
+    assert(sql("show functions udtf_count2").count == 1)
+    sql("DROP TEMPORARY FUNCTION udtf_count2")
+    assert(sql("show functions udtf_count2").count == 0)
+  }
+
   test("ADD JAR command") {
     val testJar = TestHive.getHiveFile("data/files/TestSerDe.jar").getCanonicalPath
     sql("CREATE TABLE alter1(a INT, b INT)")


### PR DESCRIPTION
create temporary function is done by executionHive, while DROP TEMPORARY FUNCTION is done by metadataHive, so we will never be able to drop that function.
