### PR TITLE
[SPARK-11334] numRunningTasks can't be less than 0, or it will affect executor allocation

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -575,7 +575,7 @@ private[spark] class ExecutorAllocationManager(
         if (stageIdToNumTasks.isEmpty) {
           allocationManager.onSchedulerQueueEmpty()
           if (numRunningTasks != 0) {
-            logWarning("No stages are running, but numRunningTasks != 0")
+            logWarning(s"No stages are running, but numRunningTasks = $numRunningTasks")
             numRunningTasks = 0
           }
         }
@@ -615,7 +615,11 @@ private[spark] class ExecutorAllocationManager(
       val taskIndex = taskEnd.taskInfo.index
       val stageId = taskEnd.stageId
       allocationManager.synchronized {
-        numRunningTasks -= 1
+        if (numRunningTasks > 0) {
+          numRunningTasks -= 1
+        } else {
+          logWarning("SparkListenerTaskEnd got, but numRunningTasks == 0")
+        }
         // If the executor is no longer running any scheduled tasks, mark it as idle
         if (executorIdToTaskIds.contains(executorId)) {
           executorIdToTaskIds(executorId) -= taskId


### PR DESCRIPTION
With Dynamic Allocation function, a task failed over `maxFailure` time, all the dependent jobs, stages, tasks will be killed or aborted. In this process, `SparkListenerTaskEnd` event will be behind in `SparkListenerStageCompleted` and `SparkListenerJobEnd`. Like the Event Log below:

```
{"Event":"SparkListenerStageCompleted","Stage Info":{"Stage ID":20,"Stage Attempt ID":0,"Stage Name":"run at AccessController.java:-2","Number of Tasks":200}
{"Event":"SparkListenerJobEnd","Job ID":9,"Completion Time":1444914699829}
{"Event":"SparkListenerTaskEnd","Stage ID":20,"Stage Attempt ID":0,"Task Type":"ResultTask","Task End Reason":{"Reason":"TaskKilled"},"Task Info":{"Task ID":1955,"Index":88,"Attempt":2,"Launch Time":1444914699763,"Executor ID":"5","Host":"linux-223","Locality":"PROCESS_LOCAL","Speculative":false,"Getting Result Time":0,"Finish Time":1444914699864,"Failed":true,"Accumulables":[]}}
```

Because that, the `numRunningTasks` in `ExecutorAllocationManager` class will be less than 0, and it will affect executor allocation.
