### PR TITLE
[SPARK-11335][STREAMING] update kafka direct python docs on how to get the offset ranges for a KafkaRDD

### DIFF
--- a/docs/streaming-kafka-integration.md
+++ b/docs/streaming-kafka-integration.md
@@ -181,7 +181,20 @@ Next, we discuss how to use this approach in your streaming application.
 		);
 	</div>
 	<div data-lang="python" markdown="1">
-		Not supported yet
+		offsetRanges = []
+
+		def storeOffsetRanges(rdd):
+		    del offsetRanges[:]
+		    offsetRanges.extend(rdd.offsetRanges())
+		    return rdd
+
+		def printOffsetRanges(rdd):
+		    for o in offsetRanges:
+		        print "%s %s %s %s" % (o.topic, o.partition, o.fromOffset, o.untilOffset)
+
+		directKafkaStream\
+		    .transform(storeOffsetRanges)\
+		    .foreachRDD(printOffsetRanges)
 	</div>
    	</div>
 

--- a/docs/streaming-kafka-integration.md
+++ b/docs/streaming-kafka-integration.md
@@ -184,8 +184,8 @@ Next, we discuss how to use this approach in your streaming application.
 		offsetRanges = []
 
 		def storeOffsetRanges(rdd):
-		    del offsetRanges[:]
-		    offsetRanges.extend(rdd.offsetRanges())
+		    global offsetRanges
+		    offsetRanges = rdd.offsetRanges()
 		    return rdd
 
 		def printOffsetRanges(rdd):


### PR DESCRIPTION
@tdas @koeninger 

This updates the Spark Streaming + Kafka Integration Guide doc with a working method to access the offsets of a `KafkaRDD` through Python.
