### PR TITLE
[SPARK-11338][WebUI] Prepend app links on HistoryPage with uiRoot path

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryPage.scala
@@ -85,9 +85,8 @@ private[history] class HistoryPage(parent: HistoryServer) extends WebUIPage("") 
                 <span style="float: right">
                   {
                     if (actualPage > 1) {
-                      <a href={UIUtils.prependBaseUri(
-                        makePageLink(actualPage - 1, requestedIncomplete))}>&lt; </a>
-                      <a href={UIUtils.prependBaseUri(makePageLink(1, requestedIncomplete))}>1</a>
+                      <a href={makePageLink(actualPage - 1, requestedIncomplete)}>&lt; </a>
+                      <a href={makePageLink(1, requestedIncomplete)}>1</a>
                     }
                   }
                   {if (actualPage - plusOrMinus > secondPageFromLeft) " ... "}
@@ -97,10 +96,8 @@ private[history] class HistoryPage(parent: HistoryServer) extends WebUIPage("") 
                   {if (actualPage + plusOrMinus < secondPageFromRight) " ... "}
                   {
                     if (actualPage < pageCount) {
-                      <a href={UIUtils.prependBaseUri(
-                        makePageLink(pageCount, requestedIncomplete))}>{pageCount}</a>
-                      <a href={UIUtils.prependBaseUri(
-                        makePageLink(actualPage + 1, requestedIncomplete))}> &gt;</a>
+                      <a href={makePageLink(pageCount, requestedIncomplete)}>{pageCount}</a>
+                      <a href={makePageLink(actualPage + 1, requestedIncomplete)}> &gt;</a>
                     }
                   }
                 </span>
@@ -118,7 +115,7 @@ private[history] class HistoryPage(parent: HistoryServer) extends WebUIPage("") 
               </p>
             }
           }
-          <a href={UIUtils.prependBaseUri(makePageLink(actualPage, !requestedIncomplete))}>
+          <a href={makePageLink(actualPage, !requestedIncomplete)}>
             {
               if (requestedIncomplete) {
                 "Back to completed applications"
@@ -156,7 +153,7 @@ private[history] class HistoryPage(parent: HistoryServer) extends WebUIPage("") 
       condition: Int => Boolean,
       showIncomplete: Boolean): Seq[Node] = {
     range.filter(condition).map(nextPage =>
-      <a href={UIUtils.prependBaseUri(makePageLink(nextPage, showIncomplete))}> {nextPage} </a>)
+      <a href={makePageLink(nextPage, showIncomplete)}> {nextPage} </a>)
   }
 
   private def attemptRow(
@@ -164,7 +161,7 @@ private[history] class HistoryPage(parent: HistoryServer) extends WebUIPage("") 
       info: ApplicationHistoryInfo,
       attempt: ApplicationAttemptInfo,
       isFirst: Boolean): Seq[Node] = {
-    val uiAddress = HistoryServer.getAttemptURI(info.id, attempt.attemptId)
+    val uiAddress = UIUtils.prependBaseUri(HistoryServer.getAttemptURI(info.id, attempt.attemptId))
     val startTime = UIUtils.formatDate(attempt.startTime)
     val endTime = if (attempt.endTime > 0) UIUtils.formatDate(attempt.endTime) else "-"
     val duration =
@@ -179,11 +176,11 @@ private[history] class HistoryPage(parent: HistoryServer) extends WebUIPage("") 
         if (isFirst) {
           if (info.attempts.size > 1 || renderAttemptIdColumn) {
             <td rowspan={info.attempts.size.toString} style="background-color: #ffffff">
-              <a href={UIUtils.prependBaseUri(uiAddress)}>{info.id}</a></td>
+              <a href={uiAddress}>{info.id}</a></td>
             <td rowspan={info.attempts.size.toString} style="background-color: #ffffff">
               {info.name}</td>
           } else {
-            <td><a href={UIUtils.prependBaseUri(uiAddress)}>{info.id}</a></td>
+            <td><a href={uiAddress}>{info.id}</a></td>
             <td>{info.name}</td>
           }
         } else {
@@ -193,9 +190,7 @@ private[history] class HistoryPage(parent: HistoryServer) extends WebUIPage("") 
       {
         if (renderAttemptIdColumn) {
           if (info.attempts.size > 1 && attempt.attemptId.isDefined) {
-            <td><a href={UIUtils.prependBaseUri(
-              HistoryServer.getAttemptURI(info.id, attempt.attemptId))}>
-              {attempt.attemptId.get}</a></td>
+            <td><a href={uiAddress}>{attempt.attemptId.get}</a></td>
           } else {
             <td>&nbsp;</td>
           }
@@ -222,9 +217,9 @@ private[history] class HistoryPage(parent: HistoryServer) extends WebUIPage("") 
   }
 
   private def makePageLink(linkPage: Int, showIncomplete: Boolean): String = {
-    "/?" + Array(
+    UIUtils.prependBaseUri("/?" + Array(
       "page=" + linkPage,
       "showIncomplete=" + showIncomplete
-    ).mkString("&")
+    ).mkString("&"))
   }
 }

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryPage.scala
@@ -220,6 +220,6 @@ private[history] class HistoryPage(parent: HistoryServer) extends WebUIPage("") 
     UIUtils.prependBaseUri("/?" + Array(
       "page=" + linkPage,
       "showIncomplete=" + showIncomplete
-    ).mkString("&"))
+      ).mkString("&"))
   }
 }

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryPage.scala
@@ -85,8 +85,9 @@ private[history] class HistoryPage(parent: HistoryServer) extends WebUIPage("") 
                 <span style="float: right">
                   {
                     if (actualPage > 1) {
-                      <a href={makePageLink(actualPage - 1, requestedIncomplete)}>&lt; </a>
-                      <a href={makePageLink(1, requestedIncomplete)}>1</a>
+                      <a href={UIUtils.prependBaseUri(
+                        makePageLink(actualPage - 1, requestedIncomplete))}>&lt; </a>
+                      <a href={UIUtils.prependBaseUri(makePageLink(1, requestedIncomplete))}>1</a>
                     }
                   }
                   {if (actualPage - plusOrMinus > secondPageFromLeft) " ... "}
@@ -96,8 +97,10 @@ private[history] class HistoryPage(parent: HistoryServer) extends WebUIPage("") 
                   {if (actualPage + plusOrMinus < secondPageFromRight) " ... "}
                   {
                     if (actualPage < pageCount) {
-                      <a href={makePageLink(pageCount, requestedIncomplete)}>{pageCount}</a>
-                      <a href={makePageLink(actualPage + 1, requestedIncomplete)}> &gt;</a>
+                      <a href={UIUtils.prependBaseUri(
+                        makePageLink(pageCount, requestedIncomplete))}>{pageCount}</a>
+                      <a href={UIUtils.prependBaseUri(
+                        makePageLink(actualPage + 1, requestedIncomplete))}> &gt;</a>
                     }
                   }
                 </span>
@@ -115,7 +118,7 @@ private[history] class HistoryPage(parent: HistoryServer) extends WebUIPage("") 
               </p>
             }
           }
-          <a href={makePageLink(actualPage, !requestedIncomplete)}>
+          <a href={UIUtils.prependBaseUri(makePageLink(actualPage, !requestedIncomplete))}>
             {
               if (requestedIncomplete) {
                 "Back to completed applications"
@@ -153,7 +156,7 @@ private[history] class HistoryPage(parent: HistoryServer) extends WebUIPage("") 
       condition: Int => Boolean,
       showIncomplete: Boolean): Seq[Node] = {
     range.filter(condition).map(nextPage =>
-      <a href={makePageLink(nextPage, showIncomplete)}> {nextPage} </a>)
+      <a href={UIUtils.prependBaseUri(makePageLink(nextPage, showIncomplete))}> {nextPage} </a>)
   }
 
   private def attemptRow(
@@ -176,11 +179,11 @@ private[history] class HistoryPage(parent: HistoryServer) extends WebUIPage("") 
         if (isFirst) {
           if (info.attempts.size > 1 || renderAttemptIdColumn) {
             <td rowspan={info.attempts.size.toString} style="background-color: #ffffff">
-              <a href={uiAddress}>{info.id}</a></td>
+              <a href={UIUtils.prependBaseUri(uiAddress)}>{info.id}</a></td>
             <td rowspan={info.attempts.size.toString} style="background-color: #ffffff">
               {info.name}</td>
           } else {
-            <td><a href={uiAddress}>{info.id}</a></td>
+            <td><a href={UIUtils.prependBaseUri(uiAddress)}>{info.id}</a></td>
             <td>{info.name}</td>
           }
         } else {
@@ -190,7 +193,8 @@ private[history] class HistoryPage(parent: HistoryServer) extends WebUIPage("") 
       {
         if (renderAttemptIdColumn) {
           if (info.attempts.size > 1 && attempt.attemptId.isDefined) {
-            <td><a href={HistoryServer.getAttemptURI(info.id, attempt.attemptId)}>
+            <td><a href={UIUtils.prependBaseUri(
+              HistoryServer.getAttemptURI(info.id, attempt.attemptId))}>
               {attempt.attemptId.get}</a></td>
           } else {
             <td>&nbsp;</td>

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -29,7 +29,7 @@ import org.scalatest.{BeforeAndAfter, Matchers}
 import org.scalatest.mock.MockitoSugar
 
 import org.apache.spark.{JsonTestUtils, SecurityManager, SparkConf, SparkFunSuite}
-import org.apache.spark.ui.SparkUI
+import org.apache.spark.ui.{UIUtils, SparkUI}
 
 /**
  * A collection of tests against the historyserver, including comparing responses from the json
@@ -261,7 +261,24 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
       l <- links
       attrs <- l.attribute("href")
     } yield (attrs.toString)
-    justHrefs should contain(link)
+    justHrefs should contain (UIUtils.prependBaseUri(resource = link))
+  }
+
+  test("relative links are prefixed with uiRoot (spark.ui.proxyBase)") {
+    val proxyBaseBeforeTest = System.getProperty("spark.ui.proxyBase")
+    val uiRoot = Option(System.getenv("APPLICATION_WEB_PROXY_BASE")).getOrElse("/testwebproxybase")
+    val page = new HistoryPage(server)
+    val request = mock[HttpServletRequest]
+
+    // when
+    System.setProperty("spark.ui.proxyBase", uiRoot)
+    val response = page.render(request)
+    System.setProperty("spark.ui.proxyBase", Option(proxyBaseBeforeTest).getOrElse(""))
+
+    // then
+    val urls = response \\ "@href" map (_.toString)
+    val siteRelativeLinks = urls filter (_.startsWith("/"))
+    all (siteRelativeLinks) should startWith (uiRoot)
   }
 
   def getContentAndCode(path: String, port: Int = port): (Int, Option[String], Option[String]) = {

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -29,7 +29,7 @@ import org.scalatest.{BeforeAndAfter, Matchers}
 import org.scalatest.mock.MockitoSugar
 
 import org.apache.spark.{JsonTestUtils, SecurityManager, SparkConf, SparkFunSuite}
-import org.apache.spark.ui.{UIUtils, SparkUI}
+import org.apache.spark.ui.{SparkUI, UIUtils}
 
 /**
  * A collection of tests against the historyserver, including comparing responses from the json


### PR DESCRIPTION
[SPARK-11338: HistoryPage not multi-tenancy enabled ...](https://issues.apache.org/jira/browse/SPARK-11338)
- `HistoryPage.scala` ...prepending all page links with the web proxy (`uiRoot`) path
- `HistoryServerSuite.scala` ...adding a test case to verify all site-relative links are prefixed when the environment variable `APPLICATION_WEB_PROXY_BASE` (or System property `spark.ui.proxyBase`) is set
