### PR TITLE
[SPARK-11341][SQL] Given non-zero ordinal toRow in the encoders of primitive types will cause problem

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/primitiveTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/primitiveTypes.scala
@@ -36,7 +36,7 @@ case class LongEncoder(fieldName: String = "value", ordinal: Int = 0) extends En
   override def fromRow(row: InternalRow): Long = row.getLong(ordinal)
 
   override def toRow(t: Long): InternalRow = {
-    row.setLong(ordinal, t)
+    row.setLong(0, t)
     row
   }
 
@@ -56,7 +56,7 @@ case class IntEncoder(fieldName: String = "value", ordinal: Int = 0) extends Enc
   override def fromRow(row: InternalRow): Int = row.getInt(ordinal)
 
   override def toRow(t: Int): InternalRow = {
-    row.setInt(ordinal, t)
+    row.setInt(0, t)
     row
   }
 


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-11341

The toRow in LongEncoder, IntEncoder writes given ordinal of an unsafe row with only one field. Since the ordinal is parametric. If given non-zero ordinal, it will cause problem.
