### PR TITLE
[SPARK-11336] Add links to example codes

### DIFF
--- a/docs/_plugins/include_example.rb
+++ b/docs/_plugins/include_example.rb
@@ -40,12 +40,8 @@ module Jekyll
  
       rendered_code = Pygments.highlight(code, :lexer => @lang)
 
-      spark_version_short = site.config['SPARK_VERSION_SHORT']
-      spark_version = site.config['SPARK_VERSION']
-      version = spark_version_short == spark_version ? "v#{spark_version}" : "master"
-
-      hint = "<div><small>Find full example code here: " \
-        "<u>examples/src/main/#{clean_markup}</u></small></div>"
+      hint = "<div><small>Find full example code at " \
+        "\"examples/src/main/#{clean_markup}\" in the Spark repo.</small></div>"
 
       rendered_code + hint
     end

--- a/docs/_plugins/include_example.rb
+++ b/docs/_plugins/include_example.rb
@@ -45,9 +45,7 @@ module Jekyll
       version = spark_version_short == spark_version ? "v#{spark_version}" : "master"
 
       hint = "<div><small>Find full example code here: " \
-        "<a href=\"https://github.com/apache/spark/tree/" \
-        "#{version}/examples/src/main/#{clean_markup}\">" \
-        "examples/src/main/#{clean_markup}</a></small></div>"
+        "<u>examples/src/main/#{clean_markup}</u></small></div>"
 
       rendered_code + hint
     end

--- a/docs/_plugins/include_example.rb
+++ b/docs/_plugins/include_example.rb
@@ -28,7 +28,7 @@ module Jekyll
  
     def render(context)
       site = context.registers[:site]
-      config_dir = (site.config['code_dir'] || '../examples/src/main').sub(/^\//,'')
+      config_dir = '../examples/src/main'
       @code_dir = File.join(site.source, config_dir)
 
       clean_markup = @markup.strip
@@ -38,7 +38,15 @@ module Jekyll
       code = File.open(@file).read.encode("UTF-8")
       code = select_lines(code)
  
-      Pygments.highlight(code, :lexer => @lang)
+      rendered_code = Pygments.highlight(code, :lexer => @lang)
+
+      spark_version = site.config['SPARK_VERSION_SHORT']
+      hint = "<div class=\"hint\">Find the example here: " \
+        "<a href=\"https://github.com/apache/spark/tree/" \
+        "v#{spark_version}/examples/src/main/#{clean_markup}\">" \
+        "examples/src/main/#{clean_markup}</a></div>"
+
+      rendered_code + hint
     end
  
     # Trim the code block so as to have the same indention, regardless of their positions in the

--- a/docs/_plugins/include_example.rb
+++ b/docs/_plugins/include_example.rb
@@ -40,10 +40,13 @@ module Jekyll
  
       rendered_code = Pygments.highlight(code, :lexer => @lang)
 
-      spark_version = site.config['SPARK_VERSION_SHORT']
-      hint = "<div class=\"hint\"><small>Find full example code here: " \
+      spark_version_short = site.config['SPARK_VERSION_SHORT']
+      spark_version = site.config['SPARK_VERSION']
+      version = spark_version_short == spark_version ? "v#{spark_version}" : "master"
+
+      hint = "<div><small>Find full example code here: " \
         "<a href=\"https://github.com/apache/spark/tree/" \
-        "v#{spark_version}/examples/src/main/#{clean_markup}\">" \
+        "#{version}/examples/src/main/#{clean_markup}\">" \
         "examples/src/main/#{clean_markup}</a></small></div>"
 
       rendered_code + hint

--- a/docs/_plugins/include_example.rb
+++ b/docs/_plugins/include_example.rb
@@ -41,10 +41,10 @@ module Jekyll
       rendered_code = Pygments.highlight(code, :lexer => @lang)
 
       spark_version = site.config['SPARK_VERSION_SHORT']
-      hint = "<div class=\"hint\">Find the example here: " \
+      hint = "<div class=\"hint\"><small>Find full example code here: " \
         "<a href=\"https://github.com/apache/spark/tree/" \
         "v#{spark_version}/examples/src/main/#{clean_markup}\">" \
-        "examples/src/main/#{clean_markup}</a></div>"
+        "examples/src/main/#{clean_markup}</a></small></div>"
 
       rendered_code + hint
     end

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -78,6 +78,10 @@ div .highlight pre {
   font-size: 12px;
 }
 
+div .hint {
+  font-size: 10px;
+}
+
 a code {
   color: #0088cc;
 }

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -78,10 +78,6 @@ div .highlight pre {
   font-size: 12px;
 }
 
-div .hint {
-  font-size: 10px;
-}
-
 a code {
   color: #0088cc;
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-11336

@mengxr I add a hyperlink of Spark on Github and a hint of their existences in Spark code repo in each code example. I remove the config key for changing the example code dir, since we assume all examples  should be in spark/examples.

The hyperlink, though we cannot use it now, since the Spark v1.6.0 has not been released yet, can be used after the release. So it is not a problem.

I add some screen shots, so you can get an instant feeling.

<img width="949" alt="screen shot 2015-10-27 at 10 47 18 pm" src="https://cloud.githubusercontent.com/assets/2637239/10780634/bd20e072-7cfc-11e5-8960-def4fc62a8ea.png">

<img width="1144" alt="screen shot 2015-10-27 at 10 47 31 pm" src="https://cloud.githubusercontent.com/assets/2637239/10780636/c3f6e180-7cfc-11e5-80b2-233589f4a9a3.png">
