### PR TITLE
[SPARK-11369] [ML] [R] SparkR glm should support setting standardize

### DIFF
--- a/R/pkg/R/mllib.R
+++ b/R/pkg/R/mllib.R
@@ -46,11 +46,11 @@ setClass("PipelineModel", representation(model = "jobj"))
 #'}
 setMethod("glm", signature(formula = "formula", family = "ANY", data = "DataFrame"),
           function(formula, family = c("gaussian", "binomial"), data, lambda = 0, alpha = 0,
-            solver = "auto") {
+            standardize = TRUE, solver = "auto") {
             family <- match.arg(family)
             model <- callJStatic("org.apache.spark.ml.api.r.SparkRWrappers",
                                  "fitRModelFormula", deparse(formula), data@sdf, family, lambda,
-                                 alpha, solver)
+                                 alpha, standardize, solver)
             return(new("PipelineModel", model = model))
           })
 

--- a/mllib/src/main/scala/org/apache/spark/ml/r/SparkRWrappers.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/SparkRWrappers.scala
@@ -31,6 +31,7 @@ private[r] object SparkRWrappers {
       family: String,
       lambda: Double,
       alpha: Double,
+      standardize: Boolean,
       solver: String): PipelineModel = {
     val formula = new RFormula().setFormula(value)
     val estimator = family match {
@@ -38,11 +39,13 @@ private[r] object SparkRWrappers {
         .setRegParam(lambda)
         .setElasticNetParam(alpha)
         .setFitIntercept(formula.hasIntercept)
+        .setStandardization(standardize)
         .setSolver(solver)
       case "binomial" => new LogisticRegression()
         .setRegParam(lambda)
         .setElasticNetParam(alpha)
         .setFitIntercept(formula.hasIntercept)
+        .setStandardization(standardize)
     }
     val pipeline = new Pipeline().setStages(Array(formula, estimator))
     pipeline.fit(df)


### PR DESCRIPTION
SparkR glm currently support :
`formula, family = c(“gaussian”, “binomial”), data, lambda = 0, alpha = 0`
We should also support setting standardize which has been defined at [design documentation](https://docs.google.com/document/d/10NZNSEurN2EdWM31uFYsgayIPfCFHiuIu3pCWrUmP_c/edit)
