### PR TITLE
SPARK-11371 Make "mean" an alias for "avg" operator

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -184,6 +184,7 @@ object FunctionRegistry {
     expression[Last]("last"),
     expression[Last]("last_value"),
     expression[Max]("max"),
+    expression[Average]("mean"),
     expression[Min]("min"),
     expression[Stddev]("stddev"),
     expression[StddevPop]("stddev_pop"),

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
@@ -323,6 +323,53 @@ abstract class AggregationQuerySuite extends QueryTest with SQLTestUtils with Te
       Row(11.125) :: Nil)
   }
 
+  test("test mean no key in output") {
+    checkAnswer(
+      sqlContext.sql(
+        """
+          |SELECT mean(value)
+          |FROM agg1
+          |GROUP BY key
+        """.stripMargin),
+      Row(-0.5) :: Row(20.0) :: Row(null) :: Row(10.0) :: Nil)
+  }
+
+  test("test mean") {
+    checkAnswer(
+      sqlContext.sql(
+        """
+          |SELECT key, mean(value)
+          |FROM agg1
+          |GROUP BY key
+        """.stripMargin),
+      Row(1, 20.0) :: Row(2, -0.5) :: Row(3, null) :: Row(null, 10.0) :: Nil)
+
+    checkAnswer(
+      sqlContext.sql(
+        """
+          |SELECT mean(value), key
+          |FROM agg1
+          |GROUP BY key
+        """.stripMargin),
+      Row(20.0, 1) :: Row(-0.5, 2) :: Row(null, 3) :: Row(10.0, null) :: Nil)
+
+    checkAnswer(
+      sqlContext.sql(
+        """
+          |SELECT mean(value) + 1.5, key + 10
+          |FROM agg1
+          |GROUP BY key + 10
+        """.stripMargin),
+      Row(21.5, 11) :: Row(1.0, 12) :: Row(null, 13) :: Row(11.5, null) :: Nil)
+
+    checkAnswer(
+      sqlContext.sql(
+        """
+          |SELECT mean(value) FROM agg1
+        """.stripMargin),
+      Row(11.125) :: Nil)
+  }
+
   test("first_value and last_value") {
     // We force to use a single partition for the sort and aggregate to make result
     // deterministic.

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
@@ -300,6 +300,15 @@ abstract class AggregationQuerySuite extends QueryTest with SQLTestUtils with Te
     checkAnswer(
       sqlContext.sql(
         """
+          |SELECT key, mean(value)
+          |FROM agg1
+          |GROUP BY key
+        """.stripMargin),
+      Row(1, 20.0) :: Row(2, -0.5) :: Row(3, null) :: Row(null, 10.0) :: Nil)
+
+    checkAnswer(
+      sqlContext.sql(
+        """
           |SELECT avg(value), key
           |FROM agg1
           |GROUP BY key
@@ -319,53 +328,6 @@ abstract class AggregationQuerySuite extends QueryTest with SQLTestUtils with Te
       sqlContext.sql(
         """
           |SELECT avg(value) FROM agg1
-        """.stripMargin),
-      Row(11.125) :: Nil)
-  }
-
-  test("test mean no key in output") {
-    checkAnswer(
-      sqlContext.sql(
-        """
-          |SELECT mean(value)
-          |FROM agg1
-          |GROUP BY key
-        """.stripMargin),
-      Row(-0.5) :: Row(20.0) :: Row(null) :: Row(10.0) :: Nil)
-  }
-
-  test("test mean") {
-    checkAnswer(
-      sqlContext.sql(
-        """
-          |SELECT key, mean(value)
-          |FROM agg1
-          |GROUP BY key
-        """.stripMargin),
-      Row(1, 20.0) :: Row(2, -0.5) :: Row(3, null) :: Row(null, 10.0) :: Nil)
-
-    checkAnswer(
-      sqlContext.sql(
-        """
-          |SELECT mean(value), key
-          |FROM agg1
-          |GROUP BY key
-        """.stripMargin),
-      Row(20.0, 1) :: Row(-0.5, 2) :: Row(null, 3) :: Row(10.0, null) :: Nil)
-
-    checkAnswer(
-      sqlContext.sql(
-        """
-          |SELECT mean(value) + 1.5, key + 10
-          |FROM agg1
-          |GROUP BY key + 10
-        """.stripMargin),
-      Row(21.5, 11) :: Row(1.0, 12) :: Row(null, 13) :: Row(11.5, null) :: Nil)
-
-    checkAnswer(
-      sqlContext.sql(
-        """
-          |SELECT mean(value) FROM agg1
         """.stripMargin),
       Row(11.125) :: Nil)
   }


### PR DESCRIPTION
From Reynold in the thread 'Exception when using some aggregate operators' (http://search-hadoop.com/m/q3RTt0xFr22nXB4/):

I don't think these are bugs. The SQL standard for average is "avg", not "mean". Similarly, a distinct count is supposed to be written as "count(distinct col)", not "countDistinct(col)".
We can, however, make "mean" an alias for "avg" to improve compatibility between DataFrame and SQL.
