### PR TITLE
Typo in mllib-evaluation-metrics.md

### DIFF
--- a/docs/mllib-evaluation-metrics.md
+++ b/docs/mllib-evaluation-metrics.md
@@ -141,7 +141,7 @@ precision.foreach { case (t, p) =>
 }
 
 // Recall by threshold
-val recall = metrics.precisionByThreshold
+val recall = metrics.recallByThreshold
 recall.foreach { case (t, r) =>
     println(s"Threshold: $t, Recall: $r")
 }


### PR DESCRIPTION
Recall by threshold snippet was using "precisionByThreshold"
