### PR TITLE
[SPARK-11376] [SQL] Removes duplicated `mutableRow` field

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/columnar/GenerateColumnAccessor.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/columnar/GenerateColumnAccessor.scala
@@ -155,7 +155,6 @@ object GenerateColumnAccessor extends CodeGenerator[Seq[DataType], ColumnarItera
 
         public void initialize(Iterator input, DataType[] columnTypes, int[] columnIndexes) {
           this.input = input;
-          this.mutableRow = mutableRow;
           this.columnTypes = columnTypes;
           this.columnIndexes = columnIndexes;
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/columnar/GenerateColumnAccessor.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/columnar/GenerateColumnAccessor.scala
@@ -140,7 +140,6 @@ object GenerateColumnAccessor extends CodeGenerator[Seq[DataType], ColumnarItera
         private int numRowsInBatch = 0;
 
         private scala.collection.Iterator input = null;
-        private MutableRow mutableRow = null;
         private DataType[] columnTypes = null;
         private int[] columnIndexes = null;
 


### PR DESCRIPTION
This PR fixes a mistake in the code generated by `GenerateColumnAccessor`. Interestingly, although the code is illegal in Java (the class has two fields with the same name), Janino accepts it happily and accidentally works properly.
