### PR TITLE
[SPARK-10849][SQL] Adding field metadata property to override default jdbc data source type mapping.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -172,7 +172,14 @@ object JdbcUtils extends Logging {
       val dbcolumntype = {
         // check if user specified target database column type for the field.
         if (field.metadata.contains("db.column.type")) {
-          Option(field.metadata.getString("db.column.type"))
+          val coltype: String = field.metadata.getString("db.column.type")
+            if (coltype != null) {
+              // remove spaces to avoid any invalid sql statements in the input.
+              // spaces are not required in the database type names.
+              Some(coltype.replaceAll("\\s", ""))
+            } else {
+              None
+            }
         } else {
           None
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -169,8 +169,16 @@ object JdbcUtils extends Logging {
     val dialect = JdbcDialects.get(url)
     df.schema.fields foreach { field => {
       val name = field.name
-      val typ: String =
-        dialect.getJDBCType(field.dataType).map(_.databaseTypeDefinition).getOrElse(
+      val dbcolumntype = {
+        // check if user specified target database column type for the field.
+        if (field.metadata.contains("db.column.type")) {
+          Option(field.metadata.getString("db.column.type"))
+        } else {
+          None
+        }
+      }
+      val typ: String = dbcolumntype.
+        orElse(dialect.getJDBCType(field.dataType).map(_.databaseTypeDefinition)).getOrElse(
           field.dataType match {
             case IntegerType => "INTEGER"
             case LongType => "BIGINT"

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCWriteSuite.scala
@@ -20,9 +20,11 @@ package org.apache.spark.sql.jdbc
 import java.sql.DriverManager
 import java.util.Properties
 
+import org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils
 import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.sql.{Row, SaveMode}
+import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
@@ -150,5 +152,56 @@ class JDBCWriteSuite extends SharedSQLContext with BeforeAndAfter {
     sql("INSERT OVERWRITE TABLE PEOPLE1 SELECT * FROM PEOPLE")
     assert(2 === sqlContext.read.jdbc(url1, "TEST.PEOPLE1", properties).count)
     assert(2 === sqlContext.read.jdbc(url1, "TEST.PEOPLE1", properties).collect()(0).length)
+  }
+
+  test("Test write with user specified database types.") {
+
+    val valueArray = Array[Row](
+      Row.apply("dave", 1, "UsA", "expert in electric cars", BigDecimal(42.33456)),
+      Row.apply("mary", 2, "USA", "Building planes", BigDecimal(42.33456)),
+      Row.apply("kathy", 3, "France", null, BigDecimal(42.33456)),
+      Row.apply("Mike", 4, null, "video games", BigDecimal(42.33456))
+    )
+
+    val (varcharIgnoreMd: Metadata, clobMd: Metadata, decimalMd: Metadata) = {
+      List("varchar_ignorecase(20)", "clob(20k)", "DECIMAL(31,2)").map(dbcoltype => {
+        val metadataBuilder = new MetadataBuilder()
+        metadataBuilder.putString("db.column.type", dbcoltype)
+        metadataBuilder.build()
+      }) match {
+        case List(a, b, c) => (a, b, c)
+      }
+    }
+
+    val schema = StructType(
+      StructField("name", StringType) ::
+        StructField("id", IntegerType) ::
+        StructField("country", StringType, true, varcharIgnoreMd) ::
+        StructField("description", StringType, true, clobMd) ::
+        StructField("expense", DecimalType(38, 18)) ::
+        Nil)
+
+    val properties = new Properties()
+    val df = sqlContext.createDataFrame(sparkContext.parallelize(valueArray), schema)
+    assert(JdbcUtils.schemaString(df, url) ==
+      s"""name TEXT , id INTEGER , country varchar_ignorecase(20) ,
+         | description clob(20k) , expense DECIMAL(38,18) """.stripMargin.replaceAll("\n", ""))
+    df.write.jdbc(url, "TEST.USERDBTYPETEST", new Properties)
+    assert(2 == sqlContext.read.jdbc(url,
+      "(select * from TEST.USERDBTYPETEST where country='usa' )", properties).count)
+    assert(1 == sqlContext.read.jdbc(url,
+      "(select * from TEST.USERDBTYPETEST where description is null)", properties).count)
+    assert(1 == sqlContext.read.jdbc(url,
+      "(select * from TEST.USERDBTYPETEST where country is null)", properties).count)
+
+    // test specifying a different decimal type for existing data frame.
+    val newDF = df.withColumn("expense", col("expense").as("expense", decimalMd))
+    assert(JdbcUtils.schemaString(newDF, url) ==
+      s"""name TEXT , id INTEGER , country varchar_ignorecase(20) ,
+         | description clob(20k) , expense DECIMAL(31,2) """.stripMargin.replaceAll("\n", ""))
+    newDF.write.mode(SaveMode.Overwrite).jdbc(url, "TEST.USERDBTYPETEST", properties)
+    assert(4 == sqlContext.read.jdbc(url, "TEST.USERDBTYPETEST", properties).count)
+    assert(BigDecimal(sqlContext.read.jdbc(url, "TEST.USERDBTYPETEST",
+      new Properties).collect()(0).get(4).asInstanceOf[java.math.BigDecimal]) == BigDecimal(42.33))
   }
 }


### PR DESCRIPTION
This patch allows users to override default type mapping of  data frame field to database column type when writing data frame to jdbc data sources.  

In some cases user may want to use specific database data type mapping for fields based on the database configuration (page size , type of table spaces ..etc) instead of the defaults.  For example large varchar size  for all the columns may not fit in row size limits , user may want to use mix of varchar , and clob types. Max precision supported in some database systems might be less than the spark decimal precision, in such cases user can use this option to adjust the decimal type precision , and scale to match the target database. 

Added a new field meta data property name    db.column.type .   I am not sure what is the convention for these type of property names. Please let me know it it needs to be changed. 

@rxin  @marmbrus
