### PR TITLE
SPARK-11402: Use ChildRunnerProvider to create ExecutorRunner and DriverRunner

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/ApplicationDescription.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/ApplicationDescription.scala
@@ -29,7 +29,7 @@ private[spark] class ApplicationDescription(
     // short name of compression codec used when writing event logs, if any (e.g. lzf)
     val eventLogCodec: Option[String] = None,
     val coresPerExecutor: Option[Int] = None)
-  extends Serializable {
+  extends Description with Serializable {
 
   val user = System.getProperty("user.name", "<unknown>")
 

--- a/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
@@ -23,7 +23,7 @@ import org.apache.spark.deploy.ExecutorState.ExecutorState
 import org.apache.spark.deploy.master.{ApplicationInfo, DriverInfo, WorkerInfo}
 import org.apache.spark.deploy.master.DriverState.DriverState
 import org.apache.spark.deploy.master.RecoveryState.MasterState
-import org.apache.spark.deploy.worker.{DriverRunner, ExecutorRunner}
+import org.apache.spark.deploy.worker.{DriverRunnerInfo, ExecutorRunnerInfo}
 import org.apache.spark.rpc.RpcEndpointRef
 import org.apache.spark.util.Utils
 
@@ -188,8 +188,8 @@ private[deploy] object DeployMessages {
   // Worker to WorkerWebUI
 
   case class WorkerStateResponse(host: String, port: Int, workerId: String,
-    executors: List[ExecutorRunner], finishedExecutors: List[ExecutorRunner],
-    drivers: List[DriverRunner], finishedDrivers: List[DriverRunner], masterUrl: String,
+    executors: List[ExecutorRunnerInfo], finishedExecutors: List[ExecutorRunnerInfo],
+    drivers: List[DriverRunnerInfo], finishedDrivers: List[DriverRunnerInfo], masterUrl: String,
     cores: Int, memory: Int, coresUsed: Int, memoryUsed: Int, masterWebUiUrl: String) {
 
     Utils.checkHost(host, "Required hostname")

--- a/core/src/main/scala/org/apache/spark/deploy/Description.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/Description.scala
@@ -17,12 +17,6 @@
 
 package org.apache.spark.deploy
 
-private[deploy] case class DriverDescription(
-    jarUrl: String,
-    mem: Int,
-    cores: Int,
-    supervise: Boolean,
-    command: Command) extends Description {
-
-  override def toString: String = s"DriverDescription (${command.mainClass})"
+trait Description {
+  def command: Command
 }

--- a/core/src/main/scala/org/apache/spark/deploy/ExecutorDescription.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/ExecutorDescription.scala
@@ -22,12 +22,11 @@ package org.apache.spark.deploy
  * This state is sufficient for the Master to reconstruct its internal data structures during
  * failover.
  */
-private[deploy] class ExecutorDescription(
-    val appId: String,
-    val execId: Int,
-    val cores: Int,
-    val state: ExecutorState.Value)
-  extends Serializable {
+private[deploy] case class ExecutorDescription(
+    appId: String,
+    execId: Int,
+    cores: Int,
+    state: ExecutorState.Value) {
 
   override def toString: String =
     "ExecutorState(appId=%s, execId=%d, cores=%d, state=%s)".format(appId, execId, cores, state)

--- a/core/src/main/scala/org/apache/spark/deploy/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/JsonProtocol.scala
@@ -22,7 +22,7 @@ import org.json4s.JsonDSL._
 
 import org.apache.spark.deploy.DeployMessages.{MasterStateResponse, WorkerStateResponse}
 import org.apache.spark.deploy.master.{ApplicationInfo, DriverInfo, WorkerInfo}
-import org.apache.spark.deploy.worker.ExecutorRunner
+import org.apache.spark.deploy.worker.ExecutorRunnerInfo
 
 private[deploy] object JsonProtocol {
  def writeWorkerInfo(obj: WorkerInfo): JObject = {
@@ -60,11 +60,11 @@ private[deploy] object JsonProtocol {
     ("command" -> obj.command.toString)
   }
 
-  def writeExecutorRunner(obj: ExecutorRunner): JObject = {
-    ("id" -> obj.execId) ~
-    ("memory" -> obj.memory) ~
+  def writeExecutorRunner(obj: ExecutorRunnerInfo): JObject = {
+    ("id" -> obj.setup.id) ~
+    ("memory" -> obj.setup.memory) ~
     ("appid" -> obj.appId) ~
-    ("appdesc" -> writeApplicationDescription(obj.appDesc))
+    ("appdesc" -> writeApplicationDescription(obj.setup.description))
   }
 
   def writeDriverInfo(obj: DriverInfo): JObject = {

--- a/core/src/main/scala/org/apache/spark/deploy/LocalSparkCluster.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/LocalSparkCluster.scala
@@ -62,7 +62,7 @@ class LocalSparkCluster(
 
     /* Start the Workers */
     for (workerNum <- 1 to numWorkers) {
-      val workerEnv = Worker.startRpcEnvAndEndpoint(localHostname, 0, 0, coresPerWorker,
+      val (workerEnv, _) = Worker.startRpcEnvAndEndpoint(localHostname, 0, 0, coresPerWorker,
         memoryPerWorker, masters, null, Some(workerNum), _conf)
       workerRpcEnvs += workerEnv
     }

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ChildRunnerFactory.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ChildRunnerFactory.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.worker
+
+import org.apache.spark.deploy.{DriverDescription, Description, ApplicationDescription, ExecutorState}
+
+private[deploy] trait ChildRunnerFactory[D <: Description, T <: ChildRunnerInfo[D]] {
+  def createRunner(
+    appId: Option[String],
+    processSetup: ChildProcessCommonSetup[D],
+    workerSetup: WorkerSetup,
+    stateChangeListener: StateChangeListener[D, T],
+    localDirs: Seq[String]): ChildProcessRunner[D, T]
+}
+
+private[deploy] object DriverRunnerFactoryImpl
+  extends ChildRunnerFactory[DriverDescription, DriverRunnerInfo] {
+
+  override def createRunner(
+    appId: Option[String],
+    processSetup: ChildProcessCommonSetup[DriverDescription],
+    workerSetup: WorkerSetup,
+    stateChangeListener: StateChangeListener[DriverDescription, DriverRunnerInfo],
+    localDirs: Seq[String]): DriverRunner = {
+
+    val manager = new DriverRunnerImpl(
+      processSetup,
+      workerSetup,
+      stateChangeListener)
+
+    manager
+  }
+}
+
+private[deploy] object ExecutorRunnerFactoryImpl
+  extends ChildRunnerFactory[ApplicationDescription, ExecutorRunnerInfo] {
+
+  override def createRunner(
+    appId: Option[String],
+    processSetup: ChildProcessCommonSetup[ApplicationDescription],
+    workerSetup: WorkerSetup,
+    stateChangeListener:
+      StateChangeListener[ApplicationDescription, ExecutorRunnerInfo],
+    localDirs: Seq[String]): ExecutorRunner = {
+
+    val manager = new ExecutorRunnerImpl(
+      processSetup,
+      workerSetup,
+      stateChangeListener,
+      appId.get,
+      localDirs,
+      ExecutorState.LOADING)
+
+    manager
+  }
+
+}

--- a/core/src/main/scala/org/apache/spark/deploy/worker/package.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/package.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy
+
+import java.io.File
+
+import org.apache.spark.{SecurityManager, SparkConf}
+import org.apache.spark.executor.ExecutorExitCode
+
+package object worker {
+
+  type StateChangeListener[D <: Description, T <: ChildRunnerInfo[D]] =
+    (ChildProcessRunner[D, T], Option[String], Option[Exception]) => Unit
+
+  type ExecutorRunner = ChildProcessRunner[ApplicationDescription, ExecutorRunnerInfo]
+  type DriverRunner = ChildProcessRunner[DriverDescription, DriverRunnerInfo]
+
+  private[deploy] trait ChildRunnerInfo[+T <: Description] {
+    def setup: ChildProcessCommonSetup[T]
+    def state: Enumeration#Value
+    def exception: Option[Exception]
+  }
+
+  private[deploy] trait ChildProcessRunner[D <: Description, T <: ChildRunnerInfo[D]] {
+    def start(): Unit
+
+    def kill(): Unit
+
+    def info: T
+  }
+
+  private[spark] class NonZeroExitCodeException(val exitCode: Int)
+    extends Exception(ExecutorExitCode.explainExitCode(exitCode))
+
+  case class ChildProcessCommonSetup[+T <: Description](
+    id: String,
+    cores: Int,
+    memory: Int,
+    host: String,
+    publicAddress: String,
+    webUIPort: Int,
+    workDir: File,
+    description: T
+  )
+
+  case class WorkerSetup(
+    workerUri: String,
+    sparkHome: File,
+    conf: SparkConf,
+    securityManager: SecurityManager
+  )
+
+
+}

--- a/core/src/test/scala/org/apache/spark/deploy/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/JsonProtocolSuite.scala
@@ -20,12 +20,12 @@ package org.apache.spark.deploy
 import java.util.Date
 
 import com.fasterxml.jackson.core.JsonParseException
+import org.apache.spark.deploy.worker.ExecutorRunnerInfo
 import org.json4s._
 import org.json4s.jackson.JsonMethods
 
 import org.apache.spark.deploy.DeployMessages.{MasterStateResponse, WorkerStateResponse}
 import org.apache.spark.deploy.master.{ApplicationInfo, RecoveryState}
-import org.apache.spark.deploy.worker.ExecutorRunner
 import org.apache.spark.{JsonTestUtils, SparkFunSuite}
 
 class JsonProtocolSuite extends SparkFunSuite with JsonTestUtils {
@@ -51,7 +51,7 @@ class JsonProtocolSuite extends SparkFunSuite with JsonTestUtils {
   }
 
   test("writeExecutorRunner") {
-    val output = JsonProtocol.writeExecutorRunner(createExecutorRunner(123))
+    val output = JsonProtocol.writeExecutorRunner(createExecutorRunner(123).info)
     assertValidJson(output)
     assertValidDataInJson(output, JsonMethods.parse(JsonConstants.executorRunnerJsonStr))
   }
@@ -77,11 +77,12 @@ class JsonProtocolSuite extends SparkFunSuite with JsonTestUtils {
   }
 
   test("writeWorkerState") {
-    val executors = List[ExecutorRunner]()
-    val finishedExecutors = List[ExecutorRunner](createExecutorRunner(123),
-      createExecutorRunner(123))
-    val drivers = List(createDriverRunner("driverId"))
-    val finishedDrivers = List(createDriverRunner("driverId"), createDriverRunner("driverId"))
+    val executors = List[ExecutorRunnerInfo]()
+    val finishedExecutors = List[ExecutorRunnerInfo](createExecutorRunner(123).info,
+      createExecutorRunner(123).info)
+    val drivers = List(createDriverRunner("driverId").info)
+    val finishedDrivers = List(createDriverRunner("driverId").info,
+      createDriverRunner("driverId").info)
     val stateResponse = new WorkerStateResponse("host", 8080, "workerId", executors,
       finishedExecutors, drivers, finishedDrivers, "masterUrl", 4, 1234, 4, 1234, "masterWebUiUrl")
     val output = JsonProtocol.writeWorkerState(stateResponse)

--- a/core/src/test/scala/org/apache/spark/deploy/worker/DriverRunnerTest.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/worker/DriverRunnerTest.scala
@@ -33,8 +33,12 @@ class DriverRunnerTest extends SparkFunSuite {
     val command = new Command("mainClass", Seq(), Map(), Seq(), Seq(), Seq())
     val driverDescription = new DriverDescription("jarUrl", 512, 1, true, command)
     val conf = new SparkConf()
-    new DriverRunner(conf, "driverId", new File("workDir"), new File("sparkHome"),
-      driverDescription, null, "akka://1.2.3.4/worker/", new SecurityManager(conf))
+    val processSetup = ChildProcessCommonSetup(
+      "driverId", driverDescription.cores, driverDescription.mem, "localhost", "localhost", 8081,
+      new File("workDir"), driverDescription)
+    val workerSetup = WorkerSetup("akka://1.2.3.4/worker/", new File("sparkHome"),
+      conf, new SecurityManager(conf))
+    new DriverRunnerImpl(processSetup, workerSetup, (x, y, z) => {})
   }
 
   private def createProcessBuilderAndProcess(): (ProcessBuilderLike, Process) = {

--- a/core/src/test/scala/org/apache/spark/deploy/worker/ExecutorRunnerTest.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/worker/ExecutorRunnerTest.scala
@@ -29,9 +29,11 @@ class ExecutorRunnerTest extends SparkFunSuite {
     val sparkHome = sys.props.getOrElse("spark.test.home", fail("spark.test.home is not set!"))
     val appDesc = new ApplicationDescription("app name", Some(8), 500,
       Command("foo", Seq(appId), Map(), Seq(), Seq(), Seq()), "appUiUrl")
-    val er = new ExecutorRunner(appId, 1, appDesc, 8, 500, null, "blah", "worker321", 123,
-      "publicAddr", new File(sparkHome), new File("ooga"), "blah", conf, Seq("localDir"),
-      ExecutorState.RUNNING)
+    val processSetup = ChildProcessCommonSetup("1", 8, 500, "worker123", "publicAddr", 123,
+      new File("ooga"), appDesc)
+    val workerSetup = WorkerSetup("blah", new File(sparkHome), conf, new SecurityManager(conf))
+    val er = new ExecutorRunnerImpl(processSetup, workerSetup, (x, y, z) => {},
+      appId, Seq("localDir"), ExecutorState.RUNNING)
     val builder = CommandUtils.buildProcessBuilder(
       appDesc.command, new SecurityManager(conf), 512, sparkHome, er.substituteVariables)
     val builderCommand = builder.command()


### PR DESCRIPTION
Abstracted ExecutorRunner and DriverRunner. The current implementations were renamed to ExecutorRunnerImpl and DriverRunnerImpl respectively.
Added a way to provide a custom implemnetation of the runners by defining their factories.
