### PR TITLE
[SPARK-11403] Log something when killing executors due to OOME

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -238,7 +238,7 @@ object YarnSparkHadoopUtil {
     if (Utils.isWindows) {
       escapeForShell("-XX:OnOutOfMemoryError=taskkill /F /PID %%%%p")
     } else {
-      "-XX:OnOutOfMemoryError='kill %p'"
+      "-XX:OnOutOfMemoryError='echo OnOutOfMemoryError; kill %p'"
     }
   }
 


### PR DESCRIPTION
Without anything printed it's very hard to figure out why the executor disappeared.

https://issues.apache.org/jira/browse/SPARK-11403
