### PR TITLE
SPARK-11348 Replace addOnCompleteCallback with addTaskCompletionListe…

### DIFF
--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
@@ -138,7 +138,7 @@ public final class UnsafeExternalSorter {
     // Register a cleanup task with TaskContext to ensure that memory is guaranteed to be freed at
     // the end of the task. This is necessary to avoid memory leaks in when the downstream operator
     // does not fully consume the sorter's output (e.g. sort followed by limit).
-    taskContext.addTaskCompletionListener(new AbstractFunction1<TaskContext,BoxedUnit>() {
+    taskContext.addTaskCompletionListener(new AbstractFunction1<TaskContext, BoxedUnit>() {
       @Override
       public BoxedUnit apply(TaskContext context) {
         cleanupResources();

--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
@@ -23,8 +23,8 @@ import java.util.LinkedList;
 
 import javax.annotation.Nullable;
 
-import scala.runtime.AbstractFunction0;
 import scala.runtime.BoxedUnit;
+import scala.runtime.AbstractFunction1;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
@@ -138,9 +138,9 @@ public final class UnsafeExternalSorter {
     // Register a cleanup task with TaskContext to ensure that memory is guaranteed to be freed at
     // the end of the task. This is necessary to avoid memory leaks in when the downstream operator
     // does not fully consume the sorter's output (e.g. sort followed by limit).
-    taskContext.addOnCompleteCallback(new AbstractFunction0<BoxedUnit>() {
+    taskContext.addTaskCompletionListener(new AbstractFunction1<TaskContext,BoxedUnit>() {
       @Override
-      public BoxedUnit apply() {
+      public BoxedUnit apply(TaskContext context) {
         cleanupResources();
         return null;
       }

--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
@@ -138,7 +138,7 @@ public final class UnsafeExternalSorter {
     // Register a cleanup task with TaskContext to ensure that memory is guaranteed to be freed at
     // the end of the task. This is necessary to avoid memory leaks in when the downstream operator
     // does not fully consume the sorter's output (e.g. sort followed by limit).
-    taskContext.addTaskCompletionListener(new AbstractFunction1<TaskContext, BoxedUnit>() {
+    taskContext.addTaskCompletionListener(new AbstractFunction1<TaskContext,BoxedUnit>() {
       @Override
       public BoxedUnit apply(TaskContext context) {
         cleanupResources();


### PR DESCRIPTION
…ner() in UnsafeExternalSorter

When practicing the command from SPARK-11318, I got the following:

```
[WARNING] /home/hbase/spark/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java:[141,15] [deprecation]                                      addOnCompleteCallback(Function0<BoxedUnit>) in TaskContext has been deprecated
```

addOnCompleteCallback should be replaced with addTaskCompletionListener()
