### PR TITLE
[SPARK-11057] [SQL] Add correlation and covariance matrices

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -53,12 +53,38 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
   }
 
   /**
+   * Calculate the sample covariance between columns of a DataFrame.
+   *
+   * @return a covariance matrix as a DataFrame
+   *
+   * {{{
+   *    val df = sc.parallelize(0 until 10).toDF("id").withColumn("rand1", rand(seed=10))
+   *      .withColumn("rand2", rand(seed=27))
+   *    val covmatrix = df.stat.cov()
+   *    covmatrix.show()
+   *    +---------+------------------+-------------------+-------------------+
+   *    |FieldName|                id|              rand1|              rand2|
+   *    +---------+------------------+-------------------+-------------------+
+   *    |       id| 9.166666666666666| 0.4131594565676311| 0.7012982830955725|
+   *    |    rand1|0.4131594565676311|0.11982701890603772|0.06500805072758595|
+   *    |    rand2|0.7012982830955725|0.06500805072758595|0.09383550706974164|
+   *    +---------+------------------+-------------------+-------------------+
+   * }}}
+   *
+   * @since 1.6.0
+   */
+  def cov(): DataFrame = {
+    StatFunctions.calculateCov(df)
+  }
+
+  /**
    * Calculates the correlation of two columns of a DataFrame. Currently only supports the Pearson
    * Correlation Coefficient. For Spearman Correlation, consider using RDD methods found in
    * MLlib's Statistics.
    *
    * @param col1 the name of the column
    * @param col2 the name of the column to calculate the correlation against
+   * @param method the name of the correlation method
    * @return The Pearson Correlation Coefficient as a Double.
    *
    * {{{
@@ -95,6 +121,63 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
   def corr(col1: String, col2: String): Double = {
     corr(col1, col2, "pearson")
   }
+
+  /**
+   * Calculates the correlation of columns in the DataFrame. Currently only supports the Pearson
+   * Correlation Coefficient. For Spearman Correlation, consider using RDD methods found in
+   * MLlib's Statistics.
+   *
+   * @param method the name of the correlation method
+   * @return The Pearson Correlation matrix as a DataFrame.
+   *
+   * {{{
+   *    val df = sc.parallelize(0 until 10).toDF("id").withColumn("rand1", rand(seed=10))
+   *      .withColumn("rand2", rand(seed=27))
+   *    val corrmatrix = df.stat.corr()
+   *    corrmatrix.show()
+   *    +---------+------------------+------------------+------------------+
+   *    |FieldName|                id|             rand1|             rand2|
+   *    +---------+------------------+------------------+------------------+
+   *    |       id|               1.0|   0.3942163209095|0.7561595709319909|
+   *    |    rand1|   0.3942163209095|               1.0|0.6130644931298477|
+   *    |    rand2|0.7561595709319909|0.6130644931298477|               1.0|
+   *    +---------+------------------+------------------+------------------+
+   * }}}
+   *
+   * @since 1.6.0
+   */
+ def corr(method: String): DataFrame = {
+    require(method == "pearson", "Currently only the calculation of the Pearson Correlation " +
+      "coefficient is supported.")
+    StatFunctions.pearsonCorrelation(df)
+ }
+
+  /**
+   * Calculates the correlation of columns in the DataFrame. Currently only supports the Pearson
+   * Correlation Coefficient. For Spearman Correlation, consider using RDD methods found in
+   * MLlib's Statistics.
+   *
+   * @return The Pearson Correlation matrix as a DataFrame.
+   *
+   * {{{
+   *    val df = sc.parallelize(0 until 10).toDF("id").withColumn("rand1", rand(seed=10))
+   *      .withColumn("rand2", rand(seed=27))
+   *    val corrmatrix = df.stat.corr()
+   *    corrmatrix.show()
+   *    +---------+------------------+------------------+------------------+
+   *    |FieldName|                id|             rand1|             rand2|
+   *    +---------+------------------+------------------+------------------+
+   *    |       id|               1.0|   0.3942163209095|0.7561595709319909|
+   *    |    rand1|   0.3942163209095|               1.0|0.6130644931298477|
+   *    |    rand2|0.7561595709319909|0.6130644931298477|               1.0|
+   *    +---------+------------------+------------------+------------------+
+   * }}}
+   *
+   * @since 1.6.0
+   */
+ def corr(): DataFrame = {
+    corr("pearson")
+ }
 
   /**
    * Computes a pair-wise frequency table of the given columns. Also known as a contingency table.

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
@@ -85,6 +85,35 @@ class DataFrameStatSuite extends QueryTest with SharedSQLContext {
     assert(math.abs(corr3 - 0.95723391394758572) < 1e-12)
   }
 
+  test("pearson correlation matrix") {
+    val df1 = Seq.tabulate(10)(i => (i, 2.0 * i, toLetter(i))).toDF("singles", "doubles", "letters")
+
+    intercept[IllegalArgumentException] {
+      df1.stat.corr() // doesn't accept non-numerical dataTypes
+    }
+
+    val df2 = Seq.tabulate(10)(i => (i, 2 * i, i * -1.0)).toDF("a", "b", "c")
+    val results = df2.stat.corr()
+
+    val row1 = results.where($"FieldName" === "a").collect()(0)
+    assert(row1.getString(0) == "a")
+    assert(row1.getDouble(1) == 1.0)
+    assert(row1.getDouble(2) == 1.0)
+    assert(row1.getDouble(3) == -1.0)
+
+    val row2 = results.where($"FieldName" === "b").collect()(0)
+    assert(row2.getString(0) == "b")
+    assert(row2.getDouble(1) == 1.0)
+    assert(row2.getDouble(2) == 1.0)
+    assert(row2.getDouble(3) == -1.0)
+
+    val row3 = results.where($"FieldName" === "c").collect()(0)
+    assert(row3.getString(0) == "c")
+    assert(row3.getDouble(1) == -1.0)
+    assert(row3.getDouble(2) == -1.0)
+    assert(row3.getDouble(3) == 1.0)
+  }
+
   test("covariance") {
     val df = Seq.tabulate(10)(i => (i, 2.0 * i, toLetter(i))).toDF("singles", "doubles", "letters")
 
@@ -96,6 +125,27 @@ class DataFrameStatSuite extends QueryTest with SharedSQLContext {
     val decimalData = Seq.tabulate(6)(i => (BigDecimal(i % 3), BigDecimal(i % 2))).toDF("a", "b")
     val decimalRes = decimalData.stat.cov("a", "b")
     assert(math.abs(decimalRes) < 1e-12)
+  }
+
+  test("covariance matrix") {
+    val df1 = Seq.tabulate(10)(i => (i, 2.0 * i, toLetter(i))).toDF("singles", "doubles", "letters")
+
+    intercept[IllegalArgumentException] {
+      df1.stat.cov() // doesn't accept non-numerical dataTypes
+    }
+
+    val df2 = Seq.tabulate(10)(i => (i, 2.0 * i)).toDF("singles", "doubles")
+    val results = df2.stat.cov()
+
+    val row1 = results.where($"FieldName" === "singles").collect()(0)
+    assert(row1.getString(0) == "singles")
+    assert(row1.getDouble(1) == 9.166666666666666)
+    assert(row1.getDouble(2) == 18.333333333333332)
+
+    val row2 = results.where($"FieldName" === "doubles").collect()(0)
+    assert(row2.getString(0) == "doubles")
+    assert(row2.getDouble(1) == row1.getDouble(2))
+    assert(row2.getDouble(2) == 36.666666666666664)
   }
 
   test("crosstab") {


### PR DESCRIPTION
Hi there,

As we know R has the option to calculate the correlation and covariance for all columns of a dataframe or between columns of two dataframes.

If we look at apache math package we can see that, they have that too. 
http://commons.apache.org/proper/commons-math/apidocs/org/apache/commons/math3/stat/correlation/PearsonsCorrelation.html#computeCorrelationMatrix%28org.apache.commons.math3.linear.RealMatrix%29

In case we have as input only one DataFrame:

---

for correlation:
cor[i,j] = cor[j,i]
and for the main diagonal we can have 1s.

---

for covariance: 
cov[i,j] = cov[j,i]
and for main diagonal: we can compute the variance for that specific column:
See:
http://commons.apache.org/proper/commons-math/apidocs/org/apache/commons/math3/stat/correlation/Covariance.html#computeCovarianceMatrix%28org.apache.commons.math3.linear.RealMatrix%29

Thanks,
Narine
