### PR TITLE
SPARK-11415: Remove timezone shift of Catalyst DateType

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -82,14 +82,12 @@ object DateTimeUtils {
   def millisToDays(millisUtc: Long): SQLDate = {
     // SPARK-6785: use Math.floor so negative number of days (dates before 1970)
     // will correctly work as input for function toJavaDate(Int)
-    val millisLocal = millisUtc + threadLocalLocalTimeZone.get().getOffset(millisUtc)
-    Math.floor(millisLocal.toDouble / MILLIS_PER_DAY).toInt
+    Math.floor(millisUtc.toDouble / MILLIS_PER_DAY).toInt
   }
 
   // reverse of millisToDays
   def daysToMillis(days: SQLDate): Long = {
-    val millisUtc = days.toLong * MILLIS_PER_DAY
-    millisUtc - threadLocalLocalTimeZone.get().getOffset(millisUtc)
+    days.toLong * MILLIS_PER_DAY
   }
 
   def dateToString(days: SQLDate): String =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -78,10 +78,7 @@ object DateTimeUtils {
     }
   }
 
-  // we should use the exact day as Int, for example, (year, month, day) -> day
   def millisToDays(millisUtc: Long): SQLDate = {
-    // SPARK-6785: use Math.floor so negative number of days (dates before 1970)
-    // will correctly work as input for function toJavaDate(Int)
     Math.floor(millisUtc.toDouble / MILLIS_PER_DAY).toInt
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -63,13 +63,20 @@ class DateTimeUtilsSuite extends SparkFunSuite {
   }
 
   test("SPARK-6785: java date conversion before and after epoch") {
+    val of = new SimpleDateFormat("yyyy-MM-dd" )
+    of.setTimeZone(TimeZone.getTimeZone(("UTC")))
+
     def checkFromToJavaDate(d1: Date): Unit = {
       val d2 = toJavaDate(fromJavaDate(d1))
-      assert(d2.toString === d1.toString)
+      val d3 = toJavaDate(fromJavaDate(d2))
+      assert(of.format(d1) == of.format(d2))
+      assert(d3.getTime == d2.getTime)
     }
 
     val df1 = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
     val df2 = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z")
+
+    checkFromToJavaDate(new Date(0))
 
     checkFromToJavaDate(new Date(100))
 
@@ -377,10 +384,10 @@ class DateTimeUtilsSuite extends SparkFunSuite {
   }
 
   test("date add months") {
-    val c1 = Calendar.getInstance()
+    val c1 = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
     c1.set(1997, 1, 28, 10, 30, 0)
     val days1 = millisToDays(c1.getTimeInMillis)
-    val c2 = Calendar.getInstance()
+    val c2 = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
     c2.set(2000, 1, 29)
     assert(dateAddMonths(days1, 36) === millisToDays(c2.getTimeInMillis))
     c2.set(1996, 0, 31)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -99,6 +99,16 @@ class DateTimeUtilsSuite extends SparkFunSuite {
     checkFromToJavaDate(new Date(df2.parse("1776-07-04 18:30:00 UTC").getTime))
   }
 
+  test("millisToDays returns the correct days from epoch ") {
+
+    assert(millisToDays(86400000L) == 1)
+    assert(millisToDays(172800000L) == 2)
+
+    assert(daysToMillis(1) == 86400000L)
+    assert(daysToMillis(10) == 864000000L)
+
+  }
+
   test("string to date") {
 
     var c = Calendar.getInstance()


### PR DESCRIPTION
Shifting the timestamp before calculating the days since epoch was
yielding off by one errors. Machines operating in different time zones
would also yeild different results. Treating the input to millisToDays
and daysToMillis as a straight UTC timestamp fixes this issue.
