### PR TITLE
[SPARK-11188][SQL] Elide stacktraces in bin/spark-sql for AnalysisExceptions

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/AbstractSparkSQLDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/AbstractSparkSQLDriver.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.hive.thriftserver
 
-import org.apache.spark.sql.AnalysisException
-
 import scala.collection.JavaConversions._
 
 import org.apache.commons.lang3.exception.ExceptionUtils
@@ -27,6 +25,7 @@ import org.apache.hadoop.hive.ql.Driver
 import org.apache.hadoop.hive.ql.processors.CommandProcessorResponse
 
 import org.apache.spark.Logging
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.hive.{HiveContext, HiveMetastoreTypes}
 
 private[hive] abstract class AbstractSparkSQLDriver(
@@ -92,5 +91,6 @@ private[hive] abstract class AbstractSparkSQLDriver(
   }
 }
 
-private[hive] case class CommandProcessorResponseWrapper (rc : CommandProcessorResponse,
-                                                          cause : Throwable)
+private[hive] case class CommandProcessorResponseWrapper(
+    rc : CommandProcessorResponse,
+    cause : Throwable)

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -17,15 +17,12 @@
 
 package org.apache.spark.sql.hive.thriftserver
 
-import scala.collection.JavaConversions._
-
 import java.io._
 import java.util.{ArrayList => JArrayList}
-import org.apache.spark.sql.AnalysisException
 
+import scala.collection.JavaConversions._
 
 import jline.{ConsoleReader, History}
-
 import org.apache.commons.lang3.StringUtils
 import org.apache.commons.logging.LogFactory
 import org.apache.hadoop.conf.Configuration
@@ -34,13 +31,14 @@ import org.apache.hadoop.hive.common.{HiveInterruptCallback, HiveInterruptUtils}
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.ql.Driver
 import org.apache.hadoop.hive.ql.exec.Utilities
-import org.apache.hadoop.hive.ql.processors.{AddResourceProcessor, SetProcessor, CommandProcessor}
+import org.apache.hadoop.hive.ql.processors.{AddResourceProcessor, CommandProcessor, SetProcessor}
 import org.apache.hadoop.hive.ql.session.SessionState
 import org.apache.thrift.transport.TSocket
 
 import org.apache.spark.Logging
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.hive.{HiveContext, HiveShim}
-import org.apache.spark.util.{ShutdownHookManager, Utils}
+import org.apache.spark.util.ShutdownHookManager
 
 private[hive] object SparkSQLCLIDriver {
   private var prompt = "spark-sql"
@@ -291,7 +289,7 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
           if (ret != 0) {
             // For analysis exception, only the error is printed out to the console.
             rcWrapper.cause match {
-              case e : AnalysisException =>
+              case e: AnalysisException =>
                 err.println(s"""Error in query: ${e.getMessage}""")
               case _ => err.println(rcWrapper.rc.getErrorMessage())
             }

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -21,6 +21,8 @@ import scala.collection.JavaConversions._
 
 import java.io._
 import java.util.{ArrayList => JArrayList}
+import org.apache.spark.sql.AnalysisException
+
 
 import jline.{ConsoleReader, History}
 
@@ -276,19 +278,23 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
 
           driver.init()
           val out = sessionState.out
+          val err = sessionState.err
           val start: Long = System.currentTimeMillis()
           if (sessionState.getIsVerbose) {
             out.println(cmd)
           }
-          val rc = driver.run(cmd)
+          val rcWrapper = driver.runWrapper(cmd)
           val end = System.currentTimeMillis()
           val timeTaken: Double = (end - start) / 1000.0
 
-          ret = rc.getResponseCode
+          ret = rcWrapper.rc.getResponseCode
           if (ret != 0) {
-            console.printError(rc.getErrorMessage())
-            driver.close()
-            return ret
+            // For analysis exception, only the error is printed out to the console.
+            rcWrapper.cause match {
+              case e : AnalysisException =>
+                err.println(s"""Error in query: ${e.getMessage}""")
+              case _ => err.println(rcWrapper.rc.getErrorMessage())
+            }
           }
 
           val res = new JArrayList[String]()

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -59,7 +59,6 @@ class CliSuite extends SparkFunSuite with BeforeAndAfter with Logging {
    *
    * @param queriesAndExpectedAnswers one or more tupes of query + answer
    */
-
   def runCliWithin(
       timeout: FiniteDuration,
       extraArgs: Seq[String] = Seq.empty,
@@ -95,15 +94,14 @@ class CliSuite extends SparkFunSuite with BeforeAndAfter with Logging {
           foundAllExpectedAnswers.trySuccess(())
         }
       }
-      else
-        {
-          errorResponses.foreach { r =>
-            if (line.contains(r)) {
-              foundAllExpectedAnswers.tryFailure(
-                new RuntimeException(s"Failed with error line '$line'"))
-            }
+      else {
+        errorResponses.foreach { r =>
+          if (line.contains(r)) {
+            foundAllExpectedAnswers.tryFailure(
+              new RuntimeException(s"Failed with error line '$line'"))
           }
         }
+      }
     }
 
     // Searching expected output line from both stdout and stderr of the CLI process


### PR DESCRIPTION
Only print the error message to the console for Analysis Exceptions in sql-shell
