### PR TITLE
[SPARK-11408][SQL] display scientific notation correctly in DataFrame.show()

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -187,8 +187,58 @@ class DataFrame private[sql](
       row.toSeq.map { cell =>
         val str = cell match {
           case null => "null"
-          case array: Array[_] => array.mkString("[", ", ", "]")
-          case seq: Seq[_] => seq.mkString("[", ", ", "]")
+          case (arr : Double) :: tail => (arr :: tail).map(x => {
+            val temp = x.asInstanceOf[Double]
+            val tempStr = temp.toString
+            if (StringUtils.containsIgnoreCase(tempStr, "E") && tempStr.length > 20 && truncate) {
+              f"$temp%G"
+            } else {
+              temp
+            }
+          }).mkString("[", ", ", "]")
+          case (arr : BigDecimal) :: tail => (arr :: tail).map(x => {
+            val temp = x.asInstanceOf[BigDecimal]
+            val tempStr = temp.toString()
+            if (StringUtils.containsIgnoreCase(tempStr, "E") && tempStr.length > 20 &&
+              truncate) {
+              f"$temp%G"
+            } else {
+              temp
+            }
+          }).mkString("[", ", ", "]")
+          case (arr : Float) :: tail => (arr :: tail).map(x => {
+            val temp = x.asInstanceOf[Float]
+            val tempStr = temp.toString
+            if (StringUtils.containsIgnoreCase(tempStr, "E") && tempStr.length > 20 &&
+              truncate) {
+              f"$temp%G"
+            } else {
+              temp
+            }
+          }).mkString("[", ", ", "]")
+          case seq: Seq[_] =>
+            seq.mkString("[", ", ", "]")
+          case d: Float =>
+            val temp = d.toString
+            if (StringUtils.containsIgnoreCase(temp, "E") && temp.length > 20 && truncate) {
+              f"$d%G"
+            } else {
+              temp
+            }
+          case d: Double =>
+            val temp = d.toString
+            if (StringUtils.containsIgnoreCase(temp, "E") && temp.length > 20 && truncate) {
+              f"$d%G"
+            } else {
+              temp
+            }
+          case d: BigDecimal =>
+            val temp = d.toString()
+            if (StringUtils.containsIgnoreCase(temp, "E") && temp.length > 20 && truncate) {
+              f"$d%G"
+            } else {
+              temp
+            }
           case _ => cell.toString
         }
         if (truncate && str.length > 20) str.substring(0, 17) + "..." else str

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -604,6 +604,21 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     assert(testData.select($"*").filter($"key" < 0).showString(1) === expectedAnswer)
   }
 
+  test("SPARK-11408 show with scientific notation") {
+    val df = Seq(
+      (1.0, 1.0/3e5)
+    ).toDF()
+
+    val expectedAnswer = """+---+-----------+
+                           || _1|         _2|
+                           |+---+-----------+
+                           ||1.0|3.33333E-06|
+                           |+---+-----------+
+                           |""".stripMargin
+
+    assert(df.showString(10) === expectedAnswer)
+  }
+
   test("createDataFrame(RDD[Row], StructType) should convert UDTs (SPARK-6672)") {
     val rowRDD = sparkContext.parallelize(Seq(Row(new ExamplePoint(1.0, 2.0))))
     val schema = StructType(Array(StructField("point", new ExamplePointUDT(), false)))


### PR DESCRIPTION
Initial implementation for displaying scientific notation in DataFrame.show().

Advantages:
-- No type erasure issues, without using reflection utils.

Disadvantages:
-- Redundant code in case statements.
-- May degrade the performance (type castings, toStrings)
-- Looks hacky :(

Please suggest changes or a different approach altogether which doesn't have above mentioned issues.
