### PR TITLE
[SPARK-11413][BUILD] Bump joda-time version to 2.9 for java 8 and s3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
     <datanucleus-core.version>3.2.10</datanucleus-core.version>
     <janino.version>2.7.8</janino.version>
     <jersey.version>1.9</jersey.version>
-    <joda.version>2.5</joda.version>
+    <joda.version>2.9</joda.version>
     <jodd.version>3.5.2</jodd.version>
     <jsr305.version>1.3.9</jsr305.version>
     <libthrift.version>0.9.2</libthrift.version>


### PR DESCRIPTION
It's a known issue that joda-time before 2.8.1 is incompatible with java 1.8u60 or later, which causes s3 request to fail. This affects Spark when using s3 as data source.
https://github.com/aws/aws-sdk-java/issues/444
