### PR TITLE
SPARK-11442 Reduce numSlices for local metrics test of SparkListenerSuite

### DIFF
--- a/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
@@ -212,7 +212,7 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
       i
     }
 
-    val numSlices = 32
+    val numSlices = 16
     val d = sc.parallelize(0 to 1e3.toInt, numSlices).map(w)
     d.count()
     sc.listenerBus.waitUntilEmpty(WAIT_TIMEOUT_MILLIS)

--- a/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
@@ -182,7 +182,7 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
     stageInfo3.rddInfos.exists(_.name == "Trois") should be {true}
   }
 
-  test("StageInfo with fewer tasks than number of partitions") {
+  test("StageInfo with fewer tasks than partitions") {
     sc = new SparkContext("local", "SparkListenerSuite")
     val listener = new SaveStageAndTaskInfo
     sc.addSparkListener(listener)

--- a/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
@@ -142,6 +142,7 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
     stageInfo.submissionTime should be ('defined)
     stageInfo.completionTime should be ('defined)
     taskInfoMetrics.length should be {4}
+    sc.stop()
   }
 
   test("basic creation of StageInfo with shuffle") {
@@ -180,6 +181,7 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
     stageInfo3.rddInfos.size should be {1} // ShuffledRDD
     stageInfo3.rddInfos.forall(_.numPartitions == 4) should be {true}
     stageInfo3.rddInfos.exists(_.name == "Trois") should be {true}
+    sc.stop()
   }
 
   test("StageInfo with fewer tasks than partitions") {
@@ -197,6 +199,7 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
     stageInfo.numTasks should be {2}
     stageInfo.rddInfos.size should be {2}
     stageInfo.rddInfos.forall(_.numPartitions == 4) should be {true}
+    sc.stop()
   }
 
   test("local metrics") {
@@ -265,6 +268,7 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
         }
       }
     }
+    sc.stop()
   }
 
   test("onTaskGettingResult() called when result fetched remotely") {
@@ -286,6 +290,7 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
     assert(listener.startedTasks.contains(TASK_INDEX))
     assert(listener.startedGettingResultTasks.contains(TASK_INDEX))
     assert(listener.endedTasks.contains(TASK_INDEX))
+    sc.stop()
   }
 
   test("onTaskGettingResult() not called when result sent directly") {
@@ -302,6 +307,7 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
     assert(listener.startedTasks.contains(TASK_INDEX))
     assert(listener.startedGettingResultTasks.isEmpty)
     assert(listener.endedTasks.contains(TASK_INDEX))
+    sc.stop()
   }
 
   test("onTaskEnd() should be called for all started tasks, even after job has been killed") {
@@ -336,6 +342,7 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
       }
       assert(listener.endedTasks.size === listener.startedTasks.size)
     }
+    sc.stop()
   }
 
   test("SparkListener moves on if a listener throws an exception") {
@@ -368,6 +375,7 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
     sc.listenerBus.listeners.asScala.count(_.isInstanceOf[BasicJobCounter]) should be (1)
     sc.listenerBus.listeners.asScala
       .count(_.isInstanceOf[ListenerThatAcceptsSparkConf]) should be (1)
+    sc.stop()
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
@@ -184,7 +184,7 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
     sc.stop()
   }
 
-  test("StageInfo with fewer tasks than partitions") {
+  test("StageInfo with fewer tasks than number of partitions") {
     sc = new SparkContext("local", "SparkListenerSuite")
     val listener = new SaveStageAndTaskInfo
     sc.addSparkListener(listener)

--- a/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
@@ -123,6 +123,7 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
   }
 
   test("basic creation of StageInfo") {
+    sc.stop()
     sc = new SparkContext("local", "SparkListenerSuite")
     val listener = new SaveStageAndTaskInfo
     sc.addSparkListener(listener)
@@ -142,10 +143,10 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
     stageInfo.submissionTime should be ('defined)
     stageInfo.completionTime should be ('defined)
     taskInfoMetrics.length should be {4}
-    sc.stop()
   }
 
   test("basic creation of StageInfo with shuffle") {
+    sc.stop()
     sc = new SparkContext("local", "SparkListenerSuite")
     val listener = new SaveStageAndTaskInfo
     sc.addSparkListener(listener)
@@ -181,10 +182,10 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
     stageInfo3.rddInfos.size should be {1} // ShuffledRDD
     stageInfo3.rddInfos.forall(_.numPartitions == 4) should be {true}
     stageInfo3.rddInfos.exists(_.name == "Trois") should be {true}
-    sc.stop()
   }
 
   test("StageInfo with fewer tasks than number of partitions") {
+    sc.stop()
     sc = new SparkContext("local", "SparkListenerSuite")
     val listener = new SaveStageAndTaskInfo
     sc.addSparkListener(listener)
@@ -199,10 +200,10 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
     stageInfo.numTasks should be {2}
     stageInfo.rddInfos.size should be {2}
     stageInfo.rddInfos.forall(_.numPartitions == 4) should be {true}
-    sc.stop()
   }
 
   test("local metrics") {
+    sc.stop()
     sc = new SparkContext("local", "SparkListenerSuite")
     val listener = new SaveStageAndTaskInfo
     sc.addSparkListener(listener)
@@ -268,10 +269,10 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
         }
       }
     }
-    sc.stop()
   }
 
   test("onTaskGettingResult() called when result fetched remotely") {
+    sc.stop()
     sc = new SparkContext("local", "SparkListenerSuite")
     val listener = new SaveTaskEvents
     sc.addSparkListener(listener)
@@ -290,10 +291,10 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
     assert(listener.startedTasks.contains(TASK_INDEX))
     assert(listener.startedGettingResultTasks.contains(TASK_INDEX))
     assert(listener.endedTasks.contains(TASK_INDEX))
-    sc.stop()
   }
 
   test("onTaskGettingResult() not called when result sent directly") {
+    sc.stop()
     sc = new SparkContext("local", "SparkListenerSuite")
     val listener = new SaveTaskEvents
     sc.addSparkListener(listener)
@@ -307,10 +308,10 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
     assert(listener.startedTasks.contains(TASK_INDEX))
     assert(listener.startedGettingResultTasks.isEmpty)
     assert(listener.endedTasks.contains(TASK_INDEX))
-    sc.stop()
   }
 
   test("onTaskEnd() should be called for all started tasks, even after job has been killed") {
+    sc.stop()
     sc = new SparkContext("local", "SparkListenerSuite")
     val WAIT_TIMEOUT_MILLIS = 10000
     val listener = new SaveTaskEvents
@@ -342,7 +343,6 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
       }
       assert(listener.endedTasks.size === listener.startedTasks.size)
     }
-    sc.stop()
   }
 
   test("SparkListener moves on if a listener throws an exception") {
@@ -371,11 +371,11 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
     val conf = new SparkConf().setMaster("local").setAppName("test")
       .set("spark.extraListeners", classOf[ListenerThatAcceptsSparkConf].getName + "," +
         classOf[BasicJobCounter].getName)
+    sc.stop()
     sc = new SparkContext(conf)
     sc.listenerBus.listeners.asScala.count(_.isInstanceOf[BasicJobCounter]) should be (1)
     sc.listenerBus.listeners.asScala
       .count(_.isInstanceOf[ListenerThatAcceptsSparkConf]) should be (1)
-    sc.stop()
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
@@ -123,7 +123,6 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
   }
 
   test("basic creation of StageInfo") {
-    sc.stop()
     sc = new SparkContext("local", "SparkListenerSuite")
     val listener = new SaveStageAndTaskInfo
     sc.addSparkListener(listener)
@@ -143,10 +142,10 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
     stageInfo.submissionTime should be ('defined)
     stageInfo.completionTime should be ('defined)
     taskInfoMetrics.length should be {4}
+    sc.stop()
   }
 
   test("basic creation of StageInfo with shuffle") {
-    sc.stop()
     sc = new SparkContext("local", "SparkListenerSuite")
     val listener = new SaveStageAndTaskInfo
     sc.addSparkListener(listener)
@@ -182,10 +181,10 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
     stageInfo3.rddInfos.size should be {1} // ShuffledRDD
     stageInfo3.rddInfos.forall(_.numPartitions == 4) should be {true}
     stageInfo3.rddInfos.exists(_.name == "Trois") should be {true}
+    sc.stop()
   }
 
   test("StageInfo with fewer tasks than number of partitions") {
-    sc.stop()
     sc = new SparkContext("local", "SparkListenerSuite")
     val listener = new SaveStageAndTaskInfo
     sc.addSparkListener(listener)
@@ -200,10 +199,10 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
     stageInfo.numTasks should be {2}
     stageInfo.rddInfos.size should be {2}
     stageInfo.rddInfos.forall(_.numPartitions == 4) should be {true}
+    sc.stop()
   }
 
   test("local metrics") {
-    sc.stop()
     sc = new SparkContext("local", "SparkListenerSuite")
     val listener = new SaveStageAndTaskInfo
     sc.addSparkListener(listener)
@@ -269,10 +268,10 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
         }
       }
     }
+    sc.stop()
   }
 
   test("onTaskGettingResult() called when result fetched remotely") {
-    sc.stop()
     sc = new SparkContext("local", "SparkListenerSuite")
     val listener = new SaveTaskEvents
     sc.addSparkListener(listener)
@@ -291,10 +290,10 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
     assert(listener.startedTasks.contains(TASK_INDEX))
     assert(listener.startedGettingResultTasks.contains(TASK_INDEX))
     assert(listener.endedTasks.contains(TASK_INDEX))
+    sc.stop()
   }
 
   test("onTaskGettingResult() not called when result sent directly") {
-    sc.stop()
     sc = new SparkContext("local", "SparkListenerSuite")
     val listener = new SaveTaskEvents
     sc.addSparkListener(listener)
@@ -308,10 +307,10 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
     assert(listener.startedTasks.contains(TASK_INDEX))
     assert(listener.startedGettingResultTasks.isEmpty)
     assert(listener.endedTasks.contains(TASK_INDEX))
+    sc.stop()
   }
 
   test("onTaskEnd() should be called for all started tasks, even after job has been killed") {
-    sc.stop()
     sc = new SparkContext("local", "SparkListenerSuite")
     val WAIT_TIMEOUT_MILLIS = 10000
     val listener = new SaveTaskEvents
@@ -343,6 +342,7 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
       }
       assert(listener.endedTasks.size === listener.startedTasks.size)
     }
+    sc.stop()
   }
 
   test("SparkListener moves on if a listener throws an exception") {
@@ -371,11 +371,11 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
     val conf = new SparkConf().setMaster("local").setAppName("test")
       .set("spark.extraListeners", classOf[ListenerThatAcceptsSparkConf].getName + "," +
         classOf[BasicJobCounter].getName)
-    sc.stop()
     sc = new SparkContext(conf)
     sc.listenerBus.listeners.asScala.count(_.isInstanceOf[BasicJobCounter]) should be (1)
     sc.listenerBus.listeners.asScala
       .count(_.isInstanceOf[ListenerThatAcceptsSparkConf]) should be (1)
+    sc.stop()
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
@@ -259,8 +259,8 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
         if (stageInfo.rddInfos.exists(_.name == d4.name)) {
           taskMetrics.shuffleReadMetrics should be ('defined)
           val sm = taskMetrics.shuffleReadMetrics.get
-          sm.totalBlocksFetched should be (128)
-          sm.localBlocksFetched should be (128)
+          sm.totalBlocksFetched should be (2*numSlices)
+          sm.localBlocksFetched should be (2*numSlices)
           sm.remoteBlocksFetched should be (0)
           sm.remoteBytesRead should be (0L)
         }


### PR DESCRIPTION
In the thread, http://search-hadoop.com/m/q3RTtcQiFSlTxeP/test+failed+due+to+OOME&subj=test+failed+due+to+OOME, it was discussed that memory consumption for SparkListenerSuite should be brought down.

This is an attempt in that direction by reducing numSlices for local metrics test.
