### PR TITLE
[SPARK-11433] [SQL] Cleanup the subquery name after eliminating subquery

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1020,15 +1020,14 @@ class Analyzer(
  */
 object EliminateSubQueries extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan transformDown {
-    case Project(projectList, child: Subquery) => {
+    case Project(projectList, child: Subquery) =>
       Project(
-        projectList.flatMap {
+        projectList.map {
           case ar: AttributeReference if ar.qualifiers.contains(child.alias) =>
-            ar.withQualifiers(ar.qualifiers.filter(_!=child.alias)) :: Nil
-          case o => o :: Nil
+            ar.withQualifiers(ar.qualifiers.filter(_!=child.alias))
+          case o => o
         },
         child)
-    }
     case Subquery(_, child) => child
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1019,7 +1019,16 @@ class Analyzer(
  * scoping information for attributes and can be removed once analysis is complete.
  */
 object EliminateSubQueries extends Rule[LogicalPlan] {
-  def apply(plan: LogicalPlan): LogicalPlan = plan transform {
+  def apply(plan: LogicalPlan): LogicalPlan = plan transformDown {
+    case Project(projectList, child: Subquery) => {
+      Project(
+        projectList.flatMap {
+          case ar: AttributeReference if ar.qualifiers.contains(child.alias) =>
+            ar.withQualifiers(ar.qualifiers.filter(_!=child.alias)) :: Nil
+          case o => o :: Nil
+        },
+        child)
+    }
     case Subquery(_, child) => child
   }
 }


### PR DESCRIPTION
This fix is to remove the subquery name in qualifiers after eliminating subquery.  
