### PR TITLE
[SPARK-11449][Core] PortableDataStream should be a factory

### DIFF
--- a/core/src/main/scala/org/apache/spark/input/PortableDataStream.scala
+++ b/core/src/main/scala/org/apache/spark/input/PortableDataStream.scala
@@ -21,7 +21,7 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream, DataInputStream, Da
 
 import scala.collection.JavaConverters._
 
-import com.google.common.io.ByteStreams
+import com.google.common.io.{Closeables, ByteStreams}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapreduce.{InputSplit, JobContext, RecordReader, TaskAttemptContext}
@@ -187,7 +187,7 @@ class PortableDataStream(
     try {
       ByteStreams.toByteArray(stream)
     } finally {
-      stream.close()
+      Closeables.close(stream, true)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/input/PortableDataStream.scala
+++ b/core/src/main/scala/org/apache/spark/input/PortableDataStream.scala
@@ -191,6 +191,15 @@ class PortableDataStream(
     }
   }
 
+  /**
+   * Closing the PortableDataStream is not needed anymore. The user either can use the
+   * PortableDataStream to get a DataInputStream (which the user needs to close after usage),
+   * or a byte array.
+   */
+  @deprecated("Closing the PortableDataStream is not needed anymore.", "1.6.0")
+  def close(): Unit = {
+  }
+
   def getPath(): String = path
 }
 


### PR DESCRIPTION
`PortableDataStream` maintains some internal state. This makes it tricky to reuse a stream (one needs to call `close` on both the `PortableDataStream` and the `InputStream` it produces).

This PR removes all state from `PortableDataStream` and effectively turns it into an `InputStream`/`Array[Byte]` factory. This makes the user responsible for managing the `InputStream` it returns.

cc @srowen 
