### PR TITLE
[MINOR][ML] removed the old `getModelWeights` function

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/r/SparkRWrappers.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/SparkRWrappers.scala
@@ -51,16 +51,6 @@ private[r] object SparkRWrappers {
     pipeline.fit(df)
   }
 
-  @deprecated("Use getModelCoefficients instead.", "1.6.0")
-  def getModelWeights(model: PipelineModel): Array[Double] = {
-    model.stages.last match {
-      case m: LinearRegressionModel =>
-        Array(m.intercept) ++ m.weights.toArray
-      case m: LogisticRegressionModel =>
-        Array(m.intercept) ++ m.weights.toArray
-    }
-  }
-
   def getModelCoefficients(model: PipelineModel): Array[Double] = {
     model.stages.last match {
       case m: LinearRegressionModel =>


### PR DESCRIPTION
Removed the old `getModelWeights` function which was private and renamed into `getModelCoefficients`
