### PR TITLE
[SPARK-11293] Fix shuffle memory leaks in Spillable collections and UnsafeShuffleWriter (branch-1.5)

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/Task.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Task.scala
@@ -23,7 +23,7 @@ import java.nio.ByteBuffer
 import scala.collection.mutable.HashMap
 
 import org.apache.spark.metrics.MetricsSystem
-import org.apache.spark.{Accumulator, SparkException, SparkEnv, TaskContextImpl, TaskContext}
+import org.apache.spark._
 import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.serializer.SerializerInstance
 import org.apache.spark.unsafe.memory.TaskMemoryManager
@@ -48,7 +48,7 @@ private[spark] abstract class Task[T](
     val stageId: Int,
     val stageAttemptId: Int,
     val partitionId: Int,
-    internalAccumulators: Seq[Accumulator[Long]]) extends Serializable {
+    internalAccumulators: Seq[Accumulator[Long]]) extends Logging with Serializable {
 
   /**
    * The key of the Map is the accumulator id and the value of the Map is the latest accumulator
@@ -84,17 +84,16 @@ private[spark] abstract class Task[T](
     if (_killed) {
       kill(interruptThread = false)
     }
+    var exceptionThrown: Boolean = true
     try {
-      (runTask(context), context.collectAccumulators())
+      val res = (runTask(context), context.collectAccumulators())
+      exceptionThrown = false
+      res
     } finally {
       context.markTaskCompleted()
       try {
         val shuffleMemoryManager = SparkEnv.get.shuffleMemoryManager
         val shuffleMemoryUsed = shuffleMemoryManager.getMemoryConsumptionForThisTask()
-        if (SparkEnv.get.conf.contains("spark.testing") && shuffleMemoryUsed != 0) {
-          throw new SparkException(
-            s"Shuffle memory leak detected; size = $shuffleMemoryUsed bytes, TID = $taskAttemptId")
-        }
         Utils.tryLogNonFatalError {
           // Release memory used by this thread for shuffles
           shuffleMemoryManager.releaseMemoryForThisTask()
@@ -102,6 +101,17 @@ private[spark] abstract class Task[T](
         Utils.tryLogNonFatalError {
           // Release memory used by this thread for unrolling blocks
           SparkEnv.get.blockManager.memoryStore.releaseUnrollMemoryForThisTask()
+        }
+        if (SparkEnv.get.conf.contains("spark.testing") && shuffleMemoryUsed != 0) {
+          val errMsg =
+            s"Shuffle memory leak detected; size = $shuffleMemoryUsed bytes, TID = $taskAttemptId"
+          if (!exceptionThrown) {
+            throw new SparkException(errMsg)
+          } else {
+            // The task failed with an exception, so don't throw here in order to avoid masking
+            // the original exception:
+            logWarning(errMsg)
+          }
         }
       } finally {
         TaskContext.unset()

--- a/core/src/main/scala/org/apache/spark/scheduler/Task.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Task.scala
@@ -23,7 +23,7 @@ import java.nio.ByteBuffer
 import scala.collection.mutable.HashMap
 
 import org.apache.spark.metrics.MetricsSystem
-import org.apache.spark.{Accumulator, SparkEnv, TaskContextImpl, TaskContext}
+import org.apache.spark.{Accumulator, SparkException, SparkEnv, TaskContextImpl, TaskContext}
 import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.serializer.SerializerInstance
 import org.apache.spark.unsafe.memory.TaskMemoryManager
@@ -89,9 +89,15 @@ private[spark] abstract class Task[T](
     } finally {
       context.markTaskCompleted()
       try {
+        val shuffleMemoryManager = SparkEnv.get.shuffleMemoryManager
+        val shuffleMemoryUsed = shuffleMemoryManager.getMemoryConsumptionForThisTask()
+        if (SparkEnv.get.conf.contains("spark.testing") && shuffleMemoryUsed != 0) {
+          throw new SparkException(
+            s"Shuffle memory leak detected; size = $shuffleMemoryUsed bytes, TID = $taskAttemptId")
+        }
         Utils.tryLogNonFatalError {
           // Release memory used by this thread for shuffles
-          SparkEnv.get.shuffleMemoryManager.releaseMemoryForThisTask()
+          shuffleMemoryManager.releaseMemoryForThisTask()
         }
         Utils.tryLogNonFatalError {
           // Release memory used by this thread for unrolling blocks

--- a/core/src/main/scala/org/apache/spark/shuffle/hash/HashShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/hash/HashShuffleReader.scala
@@ -104,7 +104,7 @@ private[spark] class HashShuffleReader[K, C](
         context.taskMetrics().incDiskBytesSpilled(sorter.diskBytesSpilled)
         context.internalMetricsToAccumulators(
           InternalAccumulator.PEAK_EXECUTION_MEMORY).add(sorter.peakMemoryUsedBytes)
-        sorter.iterator
+        CompletionIterator[Product2[K, C], Iterator[Product2[K, C]]](sorter.iterator, sorter.stop())
       case None =>
         aggregatedIter
     }

--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
@@ -123,6 +123,10 @@ class ExternalAppendOnlyMap[K, V, C](
    * The shuffle memory usage of the first trackMemoryThreshold entries is not tracked.
    */
   def insertAll(entries: Iterator[Product2[K, V]]): Unit = {
+    if (currentMap == null) {
+      throw new IllegalStateException(
+        "Cannot insert new elements into a map after calling iterator")
+    }
     // An update function for the map that we reuse across entries to avoid allocating
     // a new closure each time
     var curEntry: Product2[K, V] = null
@@ -223,10 +227,14 @@ class ExternalAppendOnlyMap[K, V, C](
   }
 
   /**
-   * Return an iterator that merges the in-memory map with the spilled maps.
+   * Return a destructive iterator that merges the in-memory map with the spilled maps.
    * If no spill has occurred, simply return the in-memory map's iterator.
    */
   override def iterator: Iterator[(K, C)] = {
+    if (currentMap == null) {
+      throw new IllegalStateException(
+        "ExternalAppendOnlyMap.iterator is destructive and should only be called once.")
+    }
     if (spilledMaps.isEmpty) {
       CompletionIterator[(K, C), Iterator[(K, C)]](currentMap.iterator, freeCurrentMap())
     } else {

--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
@@ -30,6 +30,7 @@ import org.apache.spark.{Logging, SparkEnv, TaskContext}
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.serializer.{DeserializationStream, Serializer}
 import org.apache.spark.storage.{BlockId, BlockManager}
+import org.apache.spark.util.CompletionIterator
 import org.apache.spark.util.collection.ExternalAppendOnlyMap.HashComparator
 import org.apache.spark.executor.ShuffleWriteMetrics
 
@@ -216,13 +217,18 @@ class ExternalAppendOnlyMap[K, V, C](
     spilledMaps.append(new DiskMapIterator(file, blockId, batchSizes))
   }
 
+  private def freeCurrentMap(): Unit = {
+    currentMap = null // So that the memory can be garbage-collected
+    releaseMemoryForThisThread()
+  }
+
   /**
    * Return an iterator that merges the in-memory map with the spilled maps.
    * If no spill has occurred, simply return the in-memory map's iterator.
    */
   override def iterator: Iterator[(K, C)] = {
     if (spilledMaps.isEmpty) {
-      currentMap.iterator
+      CompletionIterator[(K, C), Iterator[(K, C)]](currentMap.iterator, freeCurrentMap())
     } else {
       new ExternalIterator()
     }
@@ -239,7 +245,8 @@ class ExternalAppendOnlyMap[K, V, C](
 
     // Input streams are derived both from the in-memory map and spilled maps on disk
     // The in-memory map is sorted in place, while the spilled maps are already in sorted order
-    private val sortedMap = currentMap.destructiveSortedIterator(keyComparator)
+    private val sortedMap = CompletionIterator[(K, C), Iterator[(K, C)]](
+      currentMap.destructiveSortedIterator(keyComparator), freeCurrentMap())
     private val inputStreams = (Seq(sortedMap) ++ spilledMaps).map(it => it.buffered)
 
     inputStreams.foreach { it =>

--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
@@ -709,6 +709,9 @@ private[spark] class ExternalSorter[K, V, C](
   }
 
   def stop(): Unit = {
+    map = null // So that the memory can be garbage-collected
+    buffer = null // So that the memory can be garbage-collected
+    releaseMemoryForThisThread()
     spills.foreach(s => s.file.delete())
     spills.clear()
   }

--- a/core/src/main/scala/org/apache/spark/util/collection/Spillable.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/Spillable.scala
@@ -100,7 +100,7 @@ private[spark] trait Spillable[C] extends Logging {
   /**
    * Release our memory back to the shuffle pool so that other threads can grab it.
    */
-  private def releaseMemoryForThisThread(): Unit = {
+  protected def releaseMemoryForThisThread(): Unit = {
     // The amount we requested does not include the initial memory tracking threshold
     shuffleMemoryManager.release(myMemoryThreshold - initialMemoryThreshold)
     myMemoryThreshold = initialMemoryThreshold


### PR DESCRIPTION
This patch fixes multiple memory leaks in `Spillable` collections, as well as a leak in `UnsafeShuffleWriter`. There were a small handful of places where tasks would acquire memory from the `ShuffleMemoryManager` but would not release it by the time the task had ended. The `UnsafeShuffleWriter` case was harmless, since the leak could only occur at the very end of a task, but the other two cases are somewhat serious:
- `ExternalSorter.stop()` did not release the sorter's memory. In addition, `BlockStoreShuffleReader` never called `stop()` once the sorter's iterator was fully-consumed. Put together, these bugs meant that a shuffle which performed a reduce-side could starve downstream piplelined transformations of shuffle memory.
- `ExternalAppendOnlyMap` exposes no equivalent of `stop()` and its iterators do not automatically free its in-memory data upon completion. This could cause aggregation operations to starve other operations of shuffle memory.

This patch adds a regression test and fixes all three leaks.

This patch was originally opened as #9260; this version is the 1.5.x backport.
