### PR TITLE
[SPARK-11486][SQL] Fix TungstenAggregate's handling of empty agg buffers during fallback

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
@@ -625,8 +625,10 @@ class TungstenAggregationIterator(
       // attributes in `originalInputAttributes`, which is why we can't use those attributes here.
       //
       // For more details, see the discussion on PR #9038.
+      val numBufferFields = allAggregateFunctions.flatMap(_.aggBufferAttributes).length
       val bufferExtractor = newMutableProjection(
-        originalInputAttributes.drop(initialInputBufferOffset),
+        originalInputAttributes
+          .slice(initialInputBufferOffset, initialInputBufferOffset + numBufferFields),
         originalInputAttributes)()
       bufferExtractor.target(buffer)
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
@@ -765,6 +765,13 @@ abstract class AggregationQuerySuite extends QueryTest with SQLTestUtils with Te
       )
     }
   }
+
+  test("aggregation with no aggregation buffer columns (SPARK-11486)") {
+    checkAnswer(
+      sqlContext.range(1000).selectExpr("id", "repeat(id, 20) as s").groupBy("s").agg($"s"),
+      sqlContext.range(1000).selectExpr( "repeat(id, 20)", "repeat(id, 20)")
+    )
+  }
 }
 
 class SortBasedAggregationQuerySuite extends AggregationQuerySuite {


### PR DESCRIPTION
This fixes an issue where TungstenAggregate would extract the wrong aggregation buffer columns when falling back to sort-based aggregation for aggregates that have no buffer columns

See https://github.com/apache/spark/pull/9383#issuecomment-153451560 for more details.
