### PR TITLE
[SPARK-9372] [SQL] Filter nulls in Inner joins (null-skew)

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1000,6 +1000,7 @@ object JoinSkewOptimizer extends Rule[LogicalPlan] with PredicateHelper {
       // get "real" join conditions, which refer both left and right
       val joinConditionsOnBothRelations = joinCondition
         .map(splitConjunctivePredicates).getOrElse(Nil)
+        .filter(_.isInstanceOf[EqualTo])
         .filter(cond => !canEvaluate(cond, left) && !canEvaluate(cond, right))
 
       def nullableJoinKeys(leftOrRight: LogicalPlan) = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -307,8 +307,8 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val left = testRelation.where('a.isNotNull).where('b >= 1)
-    val right = testRelation1.where('d.isNotNull).where('d >= 2)
+    val left = testRelation.where('b >= 1 && 'a.isNotNull)
+    val right = testRelation1.where('d >= 2 && 'd.isNotNull)
     val correctAnswer =
       left.join(right, LeftSemi, Option("a".attr === "d".attr)).analyze
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -33,6 +33,8 @@ class FilterPushdownSuite extends PlanTest {
     val batches =
       Batch("Subqueries", Once,
         EliminateSubQueries) ::
+      Batch("Join Skew optimization", FixedPoint(1),
+          JoinSkewOptimizer) ::
       Batch("Filter Pushdown", Once,
         SamplePushDown,
         CombineFilters,
@@ -279,7 +281,7 @@ class FilterPushdownSuite extends PlanTest {
     comparePlans(optimized, correctAnswer)
   }
 
-  test("joins: push down left semi join") {
+  test("joins: push down left semi join, and add null filter") {
     val x = testRelation.subquery('x)
     val y = testRelation1.subquery('y)
 
@@ -288,8 +290,8 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val left = testRelation.where('b >= 1)
-    val right = testRelation1.where('d >= 2)
+    val left = testRelation.where('a.isNotNull).where('b >= 1)
+    val right = testRelation1.where('d.isNotNull).where('d >= 2)
     val correctAnswer =
       left.join(right, LeftSemi, Option("a".attr === "d".attr)).analyze
 
@@ -474,7 +476,7 @@ class FilterPushdownSuite extends PlanTest {
     comparePlans(optimized, correctAnswer)
   }
 
-  test("joins: can't push down") {
+  test("joins: can't push down query filters, but inner join can be optimized for null skew") {
     val x = testRelation.subquery('x)
     val y = testRelation.subquery('y)
 
@@ -483,7 +485,11 @@ class FilterPushdownSuite extends PlanTest {
     }
     val optimized = Optimize.execute(originalQuery.analyze)
 
-    comparePlans(analysis.EliminateSubQueries(originalQuery.analyze), optimized)
+    val expectedQueryWithNullFilters = {
+      x.where('b.isNotNull)
+        .join(y.where('b.isNotNull), condition = Some("x.b".attr === "y.b".attr))
+    }
+    comparePlans(analysis.EliminateSubQueries(expectedQueryWithNullFilters.analyze), optimized)
   }
 
   test("joins: conjunctive predicates") {


### PR DESCRIPTION
**Do not merge yet: Work in progress / waiting for comments**

Draft of first step in optimizing skew in joins (it is quite common to have skew in data, and lots of `nulls` on either side of join is quite common (for us), especially with left join, say when joining `dimensions` to `fact` tables)

feel free to propose a better approach / add commits.

any ideas for an easy way to check if the rule was already applied?  After adding a `isNotNull` filter `someAttribute.nullable`  still returns `true`. I couldn't come up with anything better than simply doing a separate batch of 1 iteration.

@marmbrus  (as discussed at Spark Summit EU)

---

the next more serious step will be to fight skew in left join, where most helpers of this PR will be reused.

here is a [rather simple implementation with DataFrames](https://gist.github.com/vidma/98332db0f82e7e5b09e5), solves the null skew, and don't seem to add lots of overhead (though tried only on subset of all our joins which used another abstraction of ours).

however this, so far, seems harder to express in optimizer rules:
- need to add "fake" colums. no idea yet how to do this to be able to refer to the added column in join conditions

``` scala
val leftNullsSprayValue = CaseWhen(
      Seq(
        nullableJoinKeys(left).map(IsNull).reduceLeft(Or), // if any join keys are null
        Cast(Multiply(new Rand(), Literal(100000)), IntegerType),
        Literal(0) // otherwise
      ))
// but how to add this column to left & right relations?
// e.g. this fails, saying it's not `resolved`
Alias(leftNullsSprayValue)("leftNullsSprayKey")()
```
