### PR TITLE
[SPARK-11517][SQL]Calc partitions in parallel for multiple partitions table

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -214,7 +214,7 @@ abstract class RDD[T: ClassTag](
   // Our dependencies and partitions will be gotten by calling subclass's methods below, and will
   // be overwritten when we're checkpointed
   private var dependencies_ : Seq[Dependency[_]] = null
-  @transient @volatile private var partitions_ : Array[Partition] = null
+  @transient private var partitions_ : Array[Partition] = null
 
   /** An Option holding our checkpoint RDD, if we are checkpointed */
   private def checkpointRDD: Option[CheckpointRDD[T]] = checkpointData.flatMap(_.checkpointRDD)

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -214,7 +214,7 @@ abstract class RDD[T: ClassTag](
   // Our dependencies and partitions will be gotten by calling subclass's methods below, and will
   // be overwritten when we're checkpointed
   private var dependencies_ : Seq[Dependency[_]] = null
-  @transient private var partitions_ : Array[Partition] = null
+  @transient @volatile private var partitions_ : Array[Partition] = null
 
   /** An Option holding our checkpoint RDD, if we are checkpointed */
   private def checkpointRDD: Option[CheckpointRDD[T]] = checkpointData.flatMap(_.checkpointRDD)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/ParallelUnionRDD.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/ParallelUnionRDD.scala
@@ -19,11 +19,11 @@ package org.apache.spark.sql.hive
 
 import java.util.concurrent.Callable
 
+import scala.reflect.ClassTag
+
+import org.apache.spark.{Partition, SparkContext}
 import org.apache.spark.rdd.{RDD, UnionPartition, UnionRDD}
 import org.apache.spark.util.ThreadUtils
-import org.apache.spark.{Partition, SparkContext}
-
-import scala.reflect.ClassTag
 
 object ParallelUnionRDD {
   lazy val executorService = ThreadUtils.newDaemonFixedThreadPool(16, "ParallelUnionRDD")

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/ParallelUnionRDD.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/ParallelUnionRDD.scala
@@ -25,11 +25,11 @@ import org.apache.spark.{Partition, SparkContext}
 import org.apache.spark.rdd.{RDD, UnionPartition, UnionRDD}
 import org.apache.spark.util.ThreadUtils
 
-object ParallelUnionRDD {
+private[hive] object ParallelUnionRDD {
   lazy val executorService = ThreadUtils.newDaemonFixedThreadPool(16, "ParallelUnionRDD")
 }
 
-class ParallelUnionRDD[T: ClassTag](
+private[hive] class ParallelUnionRDD[T: ClassTag](
   sc: SparkContext,
   rdds: Seq[RDD[T]]) extends UnionRDD[T](sc, rdds){
 
@@ -39,7 +39,7 @@ class ParallelUnionRDD[T: ClassTag](
       (rdd, ParallelUnionRDD.executorService.submit(new Callable[Array[Partition]] {
         override def call(): Array[Partition] = rdd.partitions
       }))
-    }.map {case(r, f) => (r, f.get())}
+    }.map { case(r, f) => (r, f.get()) }
 
     val array = new Array[Partition](rddPartitions.map(_._2.length).sum)
     var pos = 0

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/ParallelUnionRDD.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/ParallelUnionRDD.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive
+
+import java.util.concurrent.Callable
+
+import org.apache.spark.rdd.{RDD, UnionPartition, UnionRDD}
+import org.apache.spark.util.ThreadUtils
+import org.apache.spark.{Partition, SparkContext}
+
+import scala.reflect.ClassTag
+
+class ParallelUnionRDD[T: ClassTag](
+  sc: SparkContext,
+  rdds: Seq[RDD[T]]) extends UnionRDD[T](sc, rdds){
+  // TODO: We might need to guess a more reasonable thread pool size here
+  @transient val executorService = ThreadUtils.newDaemonFixedThreadPool(
+    Math.min(rdds.size, Runtime.getRuntime.availableProcessors()), "ParallelUnionRDD")
+
+  override def getPartitions: Array[Partition] = {
+    // Calc partitions field for each RDD in parallel.
+    val rddPartitions = rdds.map {rdd =>
+      (rdd, executorService.submit(new Callable[Array[Partition]] {
+        override def call(): Array[Partition] = rdd.partitions
+      }))
+    }.map {case(r, f) => (r, f.get())}
+
+    val array = new Array[Partition](rddPartitions.map(_._2.length).sum)
+    var pos = 0
+    for (((rdd, partitions), rddIndex) <- rddPartitions.zipWithIndex; split <- partitions) {
+      array(pos) = new UnionPartition(pos, rdd, rddIndex, split.index)
+      pos += 1
+    }
+    array
+  }
+
+}

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -246,7 +246,7 @@ class HadoopTableReader(
     if (hivePartitionRDDs.size == 0) {
       new EmptyRDD[InternalRow](sc.sparkContext)
     } else {
-      new UnionRDD(hivePartitionRDDs(0).context, hivePartitionRDDs)
+      new ParallelUnionRDD(hivePartitionRDDs(0).context, hivePartitionRDDs)
     }
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveTableScanSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveTableScanSuite.scala
@@ -90,7 +90,6 @@ class HiveTableScanSuite extends HiveComparisonTest {
     assert(sql("select casesensitivecolname from spark_4959_2").head() === Row("hi"))
   }
 
-
   test("Spark-11517: calc partitions in parallel") {
     val partitionNum = 500
     val partitionTable = "combine"


### PR DESCRIPTION
Currently we calculate the getPartitions for each "hive partition" in sequence way, it would be faster if we can parallel this on driver side
