### PR TITLE
[SPARK-11102] [SQL] Uninformative exception when specifing non-exist

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -29,7 +29,7 @@ import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.execution.datasources.jdbc.{JDBCPartition, JDBCPartitioningInfo, JDBCRelation}
-import org.apache.spark.sql.execution.datasources.json.JSONRelation
+import org.apache.spark.sql.execution.datasources.json.{JSONRDDRelation, JSONRelation}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetRelation
 import org.apache.spark.sql.execution.datasources.{LogicalRelation, ResolvedDataSource}
 import org.apache.spark.sql.types.StructType
@@ -258,13 +258,11 @@ class DataFrameReader private[sql](sqlContext: SQLContext) extends Logging {
     val samplingRatio = extraOptions.getOrElse("samplingRatio", "1.0").toDouble
     val primitivesAsString = extraOptions.getOrElse("primitivesAsString", "false").toBoolean
     sqlContext.baseRelationToDataFrame(
-      new JSONRelation(
-        Some(jsonRDD),
+      new JSONRDDRelation(
+        jsonRDD,
         samplingRatio,
         primitivesAsString,
-        userSpecifiedSchema,
-        None,
-        None)(sqlContext)
+        userSpecifiedSchema)(sqlContext)
     )
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JSONRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JSONRelation.scala
@@ -179,7 +179,7 @@ private[sql] class JSONRDDRelation (
     val maybeDataSchema: Option[StructType])(@transient val sqlContext: SQLContext)
   extends BaseRelation with PrunedFilteredScan with JSONSchemaCheck {
 
-  override def schema = {
+  override def schema: StructType = {
     val jsonSchema = maybeDataSchema.getOrElse {
       InferSchema(
         inputRDD,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JSONRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JSONRelation.scala
@@ -109,7 +109,7 @@ private[sql] class JSONRelation(
       classOf[Text]).map(_._2.toString) // get the text line
   }
 
-  override def allowEmptyInputPaths: Boolean = true
+  override def allowEmptyInputPaths: Boolean = inputRDD.isDefined
 
   override lazy val dataSchema = {
     val jsonSchema = maybeDataSchema.getOrElse {
@@ -133,9 +133,6 @@ private[sql] class JSONRelation(
       filters: Array[Filter],
       inputPaths: Array[FileStatus],
       broadcastedConf: Broadcast[SerializableConfiguration]): RDD[InternalRow] = {
-    if (inputPaths.isEmpty) {
-      throw new IOException()
-    }
     val requiredDataSchema = StructType(requiredColumns.map(dataSchema(_)))
     val rows = JacksonParser(
       inputRDD.getOrElse(createBaseRdd(inputPaths)),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JSONRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JSONRelation.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.json
 
-import java.io.CharArrayWriter
+import java.io.{IOException, CharArrayWriter}
 
 import com.fasterxml.jackson.core.JsonFactory
 import com.google.common.base.Objects
@@ -98,7 +98,7 @@ private[sql] class JSONRelation(
     if (rddInputPaths.nonEmpty) {
       FileInputFormat.setInputPaths(job, rddInputPaths: _*)
     } else {
-      throw new RuntimeException("Input paths do not exist or are empty directories, "
+      throw new IOException("Input paths do not exist or are empty directories, "
             + "Input Paths=" + paths.mkString(","))
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JSONRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JSONRelation.scala
@@ -145,6 +145,8 @@ private[sql] class JSONRelation(
 
   override def inputExists: Boolean = inputRDD.isDefined || super.inputExists
 
+  override def readFromHDFS: Boolean = !inputRDD.isDefined
+
   override def equals(other: Any): Boolean = other match {
     case that: JSONRelation =>
       ((inputRDD, that.inputRDD) match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JSONRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JSONRelation.scala
@@ -109,6 +109,8 @@ private[sql] class JSONRelation(
       classOf[Text]).map(_._2.toString) // get the text line
   }
 
+  override def allowEmptyInputPaths: Boolean = true
+
   override lazy val dataSchema = {
     val jsonSchema = maybeDataSchema.getOrElse {
       val files = cachedLeafStatuses().filterNot { status =>
@@ -131,6 +133,9 @@ private[sql] class JSONRelation(
       filters: Array[Filter],
       inputPaths: Array[FileStatus],
       broadcastedConf: Broadcast[SerializableConfiguration]): RDD[InternalRow] = {
+    if (inputPaths.isEmpty) {
+      throw new IOException()
+    }
     val requiredDataSchema = StructType(requiredColumns.map(dataSchema(_)))
     val rows = JacksonParser(
       inputRDD.getOrElse(createBaseRdd(inputPaths)),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JSONRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JSONRelation.scala
@@ -93,10 +93,13 @@ private[sql] class JSONRelation(
     val job = new Job(sqlContext.sparkContext.hadoopConfiguration)
     val conf = SparkHadoopUtil.get.getConfigurationFromJobContext(job)
 
-    val paths = inputPaths.map(_.getPath)
+    val rddInputPaths = inputPaths.map(_.getPath)
 
-    if (paths.nonEmpty) {
-      FileInputFormat.setInputPaths(job, paths: _*)
+    if (rddInputPaths.nonEmpty) {
+      FileInputFormat.setInputPaths(job, rddInputPaths: _*)
+    } else {
+      throw new RuntimeException("Input paths do not exist or are empty directories, "
+            + "Input Paths=" + paths.mkString(","))
     }
 
     sqlContext.sparkContext.hadoopRDD(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JSONRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JSONRelation.scala
@@ -109,8 +109,6 @@ private[sql] class JSONRelation(
       classOf[Text]).map(_._2.toString) // get the text line
   }
 
-  override def allowEmptyInputPaths: Boolean = inputRDD.isDefined
-
   override lazy val dataSchema = {
     val jsonSchema = maybeDataSchema.getOrElse {
       val files = cachedLeafStatuses().filterNot { status =>
@@ -144,6 +142,8 @@ private[sql] class JSONRelation(
       iterator.map(unsafeProjection)
     }
   }
+
+  override def inputExists: Boolean = inputRDD.isDefined || super.inputExists
 
   override def equals(other: Any): Boolean = other match {
     case that: JSONRelation =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -622,13 +622,11 @@ abstract class HadoopFsRelation private[sql](maybePartitionSpec: Option[Partitio
     if (!fileStatusCache.inputExists) {
       throw new IOException("Input paths do not exist, input paths="
         + inputPaths.mkString("[", ",", "]"))
+    } else if (inputStatuses.isEmpty) {
+      logWarning("Input paths are empty, input paths=" + inputPaths.mkString("[", ",", "]"))
+      sqlContext.sparkContext.emptyRDD[InternalRow]
     } else {
-      if (inputStatuses.isEmpty) {
-        logWarning("Input paths are empty, input paths=" + inputPaths.mkString("[", ",", "]"))
-        sqlContext.sparkContext.emptyRDD[InternalRow]
-      } else {
-        buildInternalScan(requiredColumns, filters, inputStatuses, broadcastedConf)
-      }
+      buildInternalScan(requiredColumns, filters, inputStatuses, broadcastedConf)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -454,7 +454,7 @@ abstract class HadoopFsRelation private[sql](maybePartitionSpec: Option[Partitio
     }
 
     // at least one of the root inputs exist
-    private def isInputExists(paths: Array[String]): Boolean ={
+    private def isInputExists(paths: Array[String]): Boolean = {
       paths.exists(path => {
         val hdfsPath = new Path(path)
         val fs = hdfsPath.getFileSystem(hadoopConf)

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.sources
 
+import java.io.IOException
+
 import scala.collection.mutable
 import scala.util.Try
 
@@ -603,9 +605,20 @@ abstract class HadoopFsRelation private[sql](maybePartitionSpec: Option[Partitio
         !name.startsWith("_") && !name.startsWith(".")
       }
     }
+    if (!allowEmptyInputPaths && inputStatuses.isEmpty) {
+       throw new IOException("Input paths do not exist or are empty directories, "
+         + "Input Paths=" + inputPaths.mkString(","))
+    }
 
     buildInternalScan(requiredColumns, filters, inputStatuses, broadcastedConf)
   }
+
+  /**
+   * By default inputPaths must be not empty. But it can be empty for some cases like JsonRelation
+   *
+   * @since 1.6.0
+   */
+  def allowEmptyInputPaths: Boolean = false
 
   /**
    * Specifies schema of actual data files.  For partitioned relations, if one or more partitioned

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -1884,6 +1884,11 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
       sql("select * from json.invalid_file")
     }
     assert(e3.message.contains("Input paths do not exist or are empty directories"))
+
+    val e4 = intercept[AnalysisException] {
+      sql("select * from text.invalid_file")
+    }
+    assert(e4.message.contains("Input paths do not exist or are empty directories"))
   }
 
   test("SortMergeJoin returns wrong results when using UnsafeRows") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -1883,7 +1883,7 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
     val e3 = intercept[AnalysisException] {
       sql("select * from json.invalid_file")
     }
-    assert(e3.message.contains("No input paths specified"))
+    assert(e3.message.contains("Input paths do not exist or are empty directories"))
   }
 
   test("SortMergeJoin returns wrong results when using UnsafeRows") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql
 
+import java.io.IOException
 import java.math.MathContext
 import java.sql.Timestamp
 
@@ -1881,14 +1882,17 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
     assert(e2.message.contains("Table not found"))
 
     val e3 = intercept[AnalysisException] {
+      // exception happens in analysis stage, because need to infer schema from json data
       sql("select * from json.invalid_file")
     }
     assert(e3.message.contains("Input paths do not exist or are empty directories"))
 
-    val e4 = intercept[AnalysisException] {
-      sql("select * from text.invalid_file")
+    val e4 = intercept[IOException] {
+      // exception happens in execution stage, no schema infer happens in analysis stage
+      // for text data
+      sql("select * from text.invalid_file").count()
     }
-    assert(e4.message.contains("Input paths do not exist or are empty directories"))
+    assert(e4.getMessage.contains("Input paths do not exist or are empty directories"))
   }
 
   test("SortMergeJoin returns wrong results when using UnsafeRows") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -1164,32 +1164,28 @@ class JsonSuite extends QueryTest with SharedSQLContext with TestJsonData {
 
   test("JSONRelation equality test") {
     val relation0 = new JSONRelation(
-      Some(empty),
       1.0,
       false,
       Some(StructType(StructField("a", IntegerType, true) :: Nil)),
       None, None)(sqlContext)
     val logicalRelation0 = LogicalRelation(relation0)
-    val relation1 = new JSONRelation(
-      Some(singleRow),
+    val relation1 = new JSONRDDRelation(
+      singleRow,
       1.0,
       false,
-      Some(StructType(StructField("a", IntegerType, true) :: Nil)),
-      None, None)(sqlContext)
+      Some(StructType(StructField("a", IntegerType, true) :: Nil)))(sqlContext)
     val logicalRelation1 = LogicalRelation(relation1)
-    val relation2 = new JSONRelation(
-      Some(singleRow),
+    val relation2 = new JSONRDDRelation(
+      singleRow,
       0.5,
       false,
-      Some(StructType(StructField("a", IntegerType, true) :: Nil)),
-      None, None)(sqlContext)
+      Some(StructType(StructField("a", IntegerType, true) :: Nil)))(sqlContext)
     val logicalRelation2 = LogicalRelation(relation2)
-    val relation3 = new JSONRelation(
-      Some(singleRow),
+    val relation3 = new JSONRDDRelation(
+      singleRow,
       1.0,
       false,
-      Some(StructType(StructField("b", IntegerType, true) :: Nil)),
-      None, None)(sqlContext)
+      Some(StructType(StructField("b", IntegerType, true) :: Nil)))(sqlContext)
     val logicalRelation3 = LogicalRelation(relation3)
 
     assert(relation0 !== relation1)


### PR DESCRIPTION
Rebase the code base and create another PR, and close the previous PR #9223
Paste comment from last PR here to give more context

The JsonRelation has another special case that it allow input paths as empty when it takes RDD[String] as input. So HadoopFsRelation can not assume all its sub classes must have non-empty input paths. Maybe need to add another flag "allowEmptyInputPaths" in HadoopFsRelation and allow its implementation to decide that.
