### PR TITLE
[SPARK-10648] Oracle dialect to handle nonspecific numeric types

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -139,6 +139,7 @@ object JdbcDialects {
   registerDialect(DB2Dialect)
   registerDialect(MsSqlServerDialect)
   registerDialect(DerbyDialect)
+  registerDialect(OracleDialect)
 
 
   /**
@@ -323,6 +324,7 @@ case object DerbyDialect extends JdbcDialect {
  */
 @DeveloperApi
 case object OracleDialect extends JdbcDialect {
+  override def canHandle(url: String): Boolean = url.startsWith("jdbc:oracle")
   override def getCatalystType(
       sqlType: Int, typeName: String, size: Int, md: MetadataBuilder): Option[DataType] = {
     // Handle NUMBER fields that have no precision/scale in special way

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -318,7 +318,7 @@ case object DerbyDialect extends JdbcDialect {
 
 /**
  * :: DeveloperApi ::
- * Default Oracle dialect, mapping a nonspecific 
+ * Default Oracle dialect, mapping a nonspecific
  * numeric type to a general decimal type.
  * Solution by @cloud-fan and @bdolbeare (github.com)
  */
@@ -330,9 +330,10 @@ case object OracleDialect extends JdbcDialect {
     // Handle NUMBER fields that have no precision/scale in special way
     // because JDBC ResultSetMetaData converts this to 0 procision and -127 scale
     if (sqlType == Types.NUMERIC && size == 0) {
-      // This is sub-optimal as we have to pick a precision/scale in advance whereas the data in Oracle is allowed 
-      //  to have different precision/scale for each value.  This conversion works in our domain for now though we 
-      //  need a more durable solution.  Look into changing JDBCRDD (line 406):
+      // This is sub-optimal as we have to pick a precision/scale in advance whereas the data
+      //  in Oracle is allowed to have different precision/scale for each value.
+      //  This conversion works in our domain for now though we need a more durable solution.
+      //  Look into changing JDBCRDD (line 406):
       //    FROM:  mutableRow.update(i, Decimal(decimalVal, p, s))
       //    TO:  mutableRow.update(i, Decimal(decimalVal))
       Some(DecimalType(DecimalType.MAX_PRECISION, 10))

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -320,7 +320,7 @@ case object DerbyDialect extends JdbcDialect {
  * :: DeveloperApi ::
  * Default Oracle dialect, mapping a nonspecific 
  * numeric type to a general decimal type.
- * Solution by @bdolbeare (github.com)
+ * Solution by @cloud-fan and @bdolbeare (github.com)
  */
 @DeveloperApi
 case object OracleDialect extends JdbcDialect {


### PR DESCRIPTION
This is the alternative/agreed upon solution to PR #8780.

Creating an OracleDialect to handle the nonspecific numeric types that can be defined in oracle.
