### PR TITLE
[SPARK-10648] [SQL] [BRANCH-1.4] Oracle dialect to handle nonspecific numeric types

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -125,6 +125,7 @@ object JdbcDialects {
 
   registerDialect(MySQLDialect)
   registerDialect(PostgresDialect)
+  registerDialect(OracleDialect)
 
   /**
    * Fetch the JdbcDialect class corresponding to a given database url.
@@ -220,5 +221,27 @@ case object MySQLDialect extends JdbcDialect {
 
   override def quoteIdentifier(colName: String): String = {
     s"`$colName`"
+  }
+}
+
+/**
+ * :: DeveloperApi ::
+ * Default Oracle dialect, mapping a nonspecific
+ * numeric type to a general decimal type.
+ */
+@DeveloperApi
+case object OracleDialect extends JdbcDialect {
+  override def canHandle(url: String): Boolean = url.startsWith("jdbc:oracle")
+  override def getCatalystType(
+      sqlType: Int, typeName: String, size: Int, md: MetadataBuilder): Option[DataType] = {
+    // Handle NUMBER fields that have no precision/scale in special way
+    // because JDBC ResultSetMetaData converts this to 0 precision and -127 scale
+    if (sqlType == Types.NUMERIC && size == 0) {
+      // This is sub-optimal as we have to pick a precision/scale in advance whereas the data
+      // in Oracle is allowed to have different precision/scale for each value.
+      Some(DecimalType(38, 10))
+    } else {
+      None
+    }
   }
 }


### PR DESCRIPTION
This backports https://github.com/apache/spark/pull/9495 to branch-1.4 (in case anyone needs this).
