### PR TITLE
[SPARK-11542] [SPARKR] fix glm with long fomular

### DIFF
--- a/R/pkg/R/mllib.R
+++ b/R/pkg/R/mllib.R
@@ -48,8 +48,9 @@ setMethod("glm", signature(formula = "formula", family = "ANY", data = "DataFram
           function(formula, family = c("gaussian", "binomial"), data, lambda = 0, alpha = 0,
             standardize = TRUE, solver = "auto") {
             family <- match.arg(family)
+            formula <- paste(deparse(formula), collapse="")
             model <- callJStatic("org.apache.spark.ml.api.r.SparkRWrappers",
-                                 "fitRModelFormula", deparse(formula), data@sdf, family, lambda,
+                                 "fitRModelFormula", formula, data@sdf, family, lambda,
                                  alpha, standardize, solver)
             return(new("PipelineModel", model = model))
           })

--- a/R/pkg/inst/tests/test_mllib.R
+++ b/R/pkg/inst/tests/test_mllib.R
@@ -36,11 +36,9 @@ test_that("glm and predict", {
 test_that("glm should work with long formula", {
   training <- createDataFrame(sqlContext, iris)
   training$LongLongLongLongLongName <- training$Sepal_Width
-  training$VeryLongLongLongLongLongLongLongLongLongLongLongLongName <- training$Sepal_Length
-  training$AnotherVeryLongLongLongLongLongLongLongLongLongLongLongName <- training$Species
-  model <- glm(LongLongLongLongLongName ~
-               VeryLongLongLongLongLongLongLongLongLongLongLongLongName +
-               AnotherVeryLongLongLongLongLongLongLongLongLongLongLongName,
+  training$VeryLongLongLongLonLongName <- training$Sepal_Length
+  training$AnotherLongLongLongLongName <- training$Species
+  model <- glm(LongLongLongLongLongName ~ VeryLongLongLongLonLongName + AnotherLongLongLongLongName,
                data = training)
   vals <- collect(select(predict(model, training), "prediction"))
   rVals <- predict(glm(Sepal.Width ~ Sepal.Length + Species, data = iris), iris)

--- a/R/pkg/inst/tests/test_mllib.R
+++ b/R/pkg/inst/tests/test_mllib.R
@@ -33,6 +33,20 @@ test_that("glm and predict", {
   expect_equal(typeof(take(select(prediction, "prediction"), 1)$prediction), "double")
 })
 
+test_that("glm should work with long formula", {
+  training <- createDataFrame(sqlContext, iris)
+  training$LongLongLongLongLongName <- training$Sepal_Width
+  training$VeryLongLongLongLongLongLongLongLongLongLongLongLongName <- training$Sepal_Length
+  training$AnotherVeryLongLongLongLongLongLongLongLongLongLongLongName <- training$Species
+  model <- glm(LongLongLongLongLongName ~
+               VeryLongLongLongLongLongLongLongLongLongLongLongLongName +
+               AnotherVeryLongLongLongLongLongLongLongLongLongLongLongName,
+               data = training)
+  vals <- collect(select(predict(model, training), "prediction"))
+  rVals <- predict(glm(Sepal.Width ~ Sepal.Length + Species, data = iris), iris)
+  expect_true(all(abs(rVals - vals) < 1e-6), rVals - vals)
+})
+
 test_that("predictions match with native glm", {
   training <- createDataFrame(sqlContext, iris)
   model <- glm(Sepal_Width ~ Sepal_Length + Species, data = training)


### PR DESCRIPTION
Because deparse() will break the long string into multiple lines, the deserialization will fail
