### PR TITLE
[SPARK-5565] [ML] LDA wrapper for Pipelines API

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
@@ -1,0 +1,505 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.clustering
+
+import org.apache.spark.annotation.{Experimental, Since}
+import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.ml.{Estimator, Model}
+import org.apache.spark.ml.param.shared.{HasCheckpointInterval, HasFeaturesCol, HasSeed, HasMaxIter}
+import org.apache.spark.ml.param._
+import org.apache.spark.mllib.clustering.{DistributedLDAModel => OldDistributedLDAModel,
+    EMLDAOptimizer => OldEMLDAOptimizer, LDA => OldLDA, LDAModel => OldLDAModel,
+    LDAOptimizer => OldLDAOptimizer, LocalLDAModel => OldLocalLDAModel,
+    OnlineLDAOptimizer => OldOnlineLDAOptimizer}
+import org.apache.spark.mllib.linalg.{Vectors, Matrix, Vector}
+import org.apache.spark.sql.{SQLContext, DataFrame, Row}
+import org.apache.spark.sql.functions.monotonicallyIncreasingId
+import org.apache.spark.sql.types.StructType
+
+
+// TODO: Add since tags everywhere, and fix the ones which say 1.6.0
+
+private[clustering] trait LDAParams extends Params with HasFeaturesCol with HasMaxIter
+  with HasSeed with HasCheckpointInterval {
+
+  /**
+   * Param for the number of topics (clusters). Must be > 1. Default: 10.
+   * @group param
+   */
+  @Since("1.6.0")
+  final val k = new IntParam(this, "k", "number of clusters to create", ParamValidators.gt(1))
+
+  setDefault(k -> 10)
+
+  /** @group getParam */
+  @Since("1.6.0")
+  def getK: Int = $(k)
+
+  /**
+   * Concentration parameter (commonly named "alpha") for the prior placed on documents'
+   * distributions over topics ("theta").
+   *
+   * This is the parameter to a Dirichlet distribution, where larger values mean more smoothing
+   * (more regularization).
+   *
+   * If set to a singleton vector [-1], then docConcentration is set automatically. If set to
+   * singleton vector [alpha] where alpha != -1, then alpha is replicated to a vector of
+   * length k in fitting. Otherwise, the [[docConcentration]] vector must be length k.
+   * (default = [-1] = automatic)
+   *
+   * Optimizer-specific parameter settings:
+   *  - EM
+   *     - Currently only supports symmetric distributions, so all values in the vector should be
+   *       the same.
+   *     - Values should be > 1.0
+   *     - default = uniformly (50 / k) + 1, where 50/k is common in LDA libraries and +1 follows
+   *       from Asuncion et al. (2009), who recommend a +1 adjustment for EM.
+   *  - Online
+   *     - Values should be >= 0
+   *     - default = uniformly (1.0 / k), following the implementation from
+   *       [[https://github.com/Blei-Lab/onlineldavb]].
+   * @group param
+   */
+  @Since("1.6.0")
+  final val docConcentration = new DoubleArrayParam(this, "docConcentration",
+    "Concentration parameter (commonly named \"alpha\") for the prior placed on documents'" +
+      " distributions over topics (\"theta\").", validDocConcentration)
+
+  setDefault(docConcentration -> Array(-1.0))
+
+  /** Check that the docConcentration is valid, independently of other Params */
+  private def validDocConcentration(alpha: Array[Double]): Boolean = {
+    if (alpha.length == 1) {
+      alpha(0) == -1 || alpha(0) >= 1.0
+    } else if (alpha.length > 1) {
+      alpha.forall(_ >= 1.0)
+    } else {
+      false
+    }
+  }
+
+  /** @group getParam */
+  @Since("1.6.0")
+  def getDocConcentration: Array[Double] = $(docConcentration)
+
+  /**
+   * Alias for [[getDocConcentration]]
+   * @group getParam
+   */
+  def getAlpha: Array[Double] = getDocConcentration
+
+  /**
+   * Concentration parameter (commonly named "beta" or "eta") for the prior placed on topics'
+   * distributions over terms.
+   *
+   * This is the parameter to a symmetric Dirichlet distribution.
+   *
+   * Note: The topics' distributions over terms are called "beta" in the original LDA paper
+   * by Blei et al., but are called "phi" in many later papers such as Asuncion et al., 2009.
+   *
+   * If set to -1, then topicConcentration is set automatically.
+   *  (default = -1 = automatic)
+   *
+   * Optimizer-specific parameter settings:
+   *  - EM
+   *     - Value should be > 1.0
+   *     - default = 0.1 + 1, where 0.1 gives a small amount of smoothing and +1 follows
+   *       Asuncion et al. (2009), who recommend a +1 adjustment for EM.
+   *  - Online
+   *     - Value should be >= 0
+   *     - default = (1.0 / k), following the implementation from
+   *       [[https://github.com/Blei-Lab/onlineldavb]].
+   * @group param
+   */
+  @Since("1.6.0")
+  final val topicConcentration = new DoubleParam(this, "topicConcentration",
+    "Concentration parameter (commonly named \"beta\" or \"eta\") for the prior placed on topic'" +
+      " distributions over terms.", (beta: Double) => beta == -1 || beta >= 0.0)
+
+  setDefault(topicConcentration -> -1.0)
+
+  /** @group getParam */
+  @Since("1.6.0")
+  def getTopicConcentration: Double = $(topicConcentration)
+
+  /**
+   * Alias for [[getTopicConcentration]]
+   * @group getParam
+   */
+  def getBeta: Double = getTopicConcentration
+
+  /**
+   * Optimizer or inference algorithm used to estimate the LDA model, specified as a
+   * [[LDAOptimizer]] type.
+   * Currently supported:
+   *  - Online Variational Bayes: [[OnlineLDAOptimizer]] (default)
+   *  - Expectation-Maximization (EM): [[EMLDAOptimizer]]
+   * @group param
+   */
+  final val optimizer = new Param[LDAOptimizer](this, "optimizer", "Optimizer or inference" +
+    " algorithm used to estimate the LDA model")
+
+  setDefault(optimizer -> new OnlineLDAOptimizer)
+
+  /** @group getParam */
+  def getOptimizer: LDAOptimizer = $(optimizer)
+
+  // Developers should override these setOptimizer() methods.  These are defined here to
+  // ensure identical behavior when setting the optimizer using a String.
+  /** @group setParam */
+  def setOptimizer(value: LDAOptimizer): this.type = set(optimizer, value)
+
+  /**
+   * Set [[optimizer]] by name (case-insensitive):
+   *  - "online" = [[OnlineLDAOptimizer]]
+   *  - "em" = [[EMLDAOptimizer]]
+   * @group setParam
+   */
+  def setOptimizer(optimizer: String): this.type = optimizer.toLowerCase match {
+    case "online" => setOptimizer(new OnlineLDAOptimizer)
+    case "em" => setOptimizer(new EMLDAOptimizer)
+    case _ => throw new IllegalArgumentException(
+      s"LDA was given unknown optimizer \"$optimizer\".  Supported values: em, online")
+  }
+
+  /**
+   * Output column with estimates of the topic mixture distribution for each document (often called
+   * "theta" in the literature).  Returns a vector of zeros for an empty document.
+   *
+   * This uses a variational approximation following Hoffman et al. (2010), where the approximate
+   * distribution is called "gamma."  Technically, this method returns this approximation "gamma"
+   * for each document.
+   */
+  final val topicDistributionCol = new Param[String](this, "topicDistribution", "Output column" +
+    " with estimates of the topic mixture distribution for each document (often called \"theta\"" +
+    " in the literature).  Returns a vector of zeros for an empty document.")
+
+  setDefault(topicDistributionCol -> "topicDistribution")
+
+  def getTopicDistributionCol: String = $(topicDistributionCol)
+
+  /**
+   * Validates and transforms the input schema.
+   * @param schema input schema
+   * @return output schema
+   */
+  protected def validateAndTransformSchema(schema: StructType): StructType = ???
+}
+
+
+/**
+ * :: Experimental ::
+ * Model fitted by LDA.
+ *
+ * TODO
+ * @param vocabSize  Vocabulary size (number of terms or terms in the vocabulary)
+ * @param oldLocalModel  Underlying spark.mllib model.  Only used if this is not a
+ *                       [[DistributedLDAModel]].
+ */
+@Since("1.6.0")
+@Experimental
+class LDAModel private[ml] (
+    @Since("1.6.0") override val uid: String,
+    @Since("1.6.0") val vocabSize: Int,
+    private val oldLocalModel: Option[OldLocalLDAModel],
+    protected val sqlContext: SQLContext) extends Model[LDAModel] with LDAParams {
+
+  protected def getModel: OldLDAModel = oldLocalModel match {
+    case Some(m) => m
+    case None =>
+      // Should never happen.
+      throw new RuntimeException("LocalLDAModel.estimatedDocConcentration was called," +
+        " but the underlying model is missing.")
+  }
+
+  // TODO: ADD PARAM SETTERS
+
+  @Since("1.6.0")
+  override def copy(extra: ParamMap): LDAModel = ???
+
+  @Since("1.6.0")
+  override def transform(dataset: DataFrame): DataFrame = ???
+
+  @Since("1.6.0")
+  override def transformSchema(schema: StructType): StructType = {
+    validateAndTransformSchema(schema)
+  }
+
+  /**
+   * Value for [[docConcentration]] estimated from data.
+   * If [[estimatedDocConcentration]] was set to false, then this returns the fixed (given) value
+   * for the [[docConcentration]] parameter.
+   */
+  def estimatedDocConcentration: Vector = getModel.docConcentration
+
+  /**
+   * Inferred topics, where each topic is represented by a distribution over terms.
+   * This is a matrix of size vocabSize x k, where each column is a topic.
+   * No guarantees are given about the ordering of the topics.
+   *
+   * WARNING: If this model is actually a [[DistributedLDAModel]] instance, then this method
+   *          could involve collecting a large amount of data to the driver (vocabSize x k).
+   */
+  @Since("1.6.0")
+  def topicsMatrix: Matrix = getModel.topicsMatrix
+
+  /** Indicates whether this instance is of type [[DistributedLDAModel]] */
+  def isDistributed: Boolean = false
+
+  def logLikelihood(data: DataFrame): Double = ???
+
+  def logPerplexity(data: DataFrame): Double = ???
+
+  /**
+   * Return the topics described by weighted terms, returned as lists sorted in order of decreasing
+   * term importance.
+   *
+   * @param maxTermsPerTopic  Maximum number of terms to collect for each topic.
+   *                          Default value of 10.
+   * @return  Local DataFrame with one topic per Row, with columns:
+   *           - "topic": IntegerType: topic index
+   *           - "termIndices": ArrayType(IntegerType): sorted term indices
+   *           - "termWeights": ArrayType(DoubleType): corresponding sorted term weights
+   */
+  @Since("1.6.0")
+  def describeTopics(maxTermsPerTopic: Int): DataFrame = {
+    val topics = getModel.describeTopics(maxTermsPerTopic).zipWithIndex.map {
+      case ((termIndices, termWeights), topic) =>
+        (topic, termIndices, termWeights)
+    }
+    sqlContext.createDataFrame() // TODO: RIGHT HERE NOW
+  }
+
+  @Since("1.6.0")
+  def describeTopics(): DataFrame = describeTopics(10)
+
+}
+
+/**
+ * :: Experimental ::
+ *
+ * TODO
+ */
+@Experimental
+class DistributedLDAModel private[ml] (
+    uid: String,
+    vocabSize: Int,
+    private val oldDistributedModel: OldDistributedLDAModel)
+  extends LDAModel(uid, vocabSize, None) {
+
+  override protected def getModel: OldLDAModel = oldDistributedModel
+
+  @Since("1.6.0")
+  override def copy(extra: ParamMap): DistributedLDAModel = ???
+
+  // TODO
+  override def isDistributed: Boolean = true
+
+  def trainingLogLikelihood(): Double = ???
+
+  def trainingLogPerplexity(): Double = ???
+}
+
+
+/**
+ * :: Experimental ::
+ *
+ * TODO
+ */
+@Experimental
+class LDA @Since("1.6.0") (
+    @Since("1.6.0") override val uid: String) extends Estimator[LDAModel] with LDAParams {
+
+  // TODO: setDefault()
+
+  // TODO: ADD PARAM SETTERS
+
+  @Since("1.6.0")
+  override def copy(extra: ParamMap): LDA = defaultCopy(extra)
+
+  @Since("1.6.0")
+  def this() = this(Identifiable.randomUID("lda"))
+
+  /** @group setParam */
+  @Since("1.6.0")
+  def setMaxIter(value: Int): this.type = set(maxIter, value)
+
+  @Since("1.6.0")
+  override def fit(dataset: DataFrame): LDAModel = {
+    val oldLDA = new OldLDA()
+      .setK($(k))
+      .setDocConcentration(Vectors.dense($(docConcentration)))
+      .setTopicConcentration($(topicConcentration))
+      .setMaxIterations($(maxIter))
+      .setSeed($(seed))
+      .setCheckpointInterval($(checkpointInterval))
+      .setOptimizer($(optimizer).getOldOptimizer)
+    val oldData = dataset
+      .withColumn("docId", monotonicallyIncreasingId())
+      .select("docId", $(featuresCol))
+      .map { case Row(docId: Long, features: Vector) =>
+        (docId, features)
+      }
+    val oldModel = oldLDA.run(oldData)
+    oldModel match {
+      case m: OldLocalLDAModel => // TODO
+      case m: OldDistributedLDAModel => // TODO
+    }
+  }
+
+  @Since("1.6.0")
+  override def transformSchema(schema: StructType): StructType = {
+    validateAndTransformSchema(schema)
+  }
+}
+
+
+/**
+ * :: Experimental ::
+ *
+ * Abstraction for specifying the [[LDA.optimizer]] Param.
+ */
+@Experimental
+sealed abstract class LDAOptimizer extends Params {
+  private[clustering] def getOldOptimizer: OldLDAOptimizer
+}
+
+
+/**
+ * :: Experimental ::
+ *
+ * Expectation-Maximization (EM) [[LDA.optimizer]].
+ * This class may be used for specifying optimizer-specific Params.
+ */
+@Experimental
+class EMLDAOptimizer @Since("1.6.0") (
+    @Since("1.6.0") override val uid: String) extends LDAOptimizer {
+
+  @Since("1.6.0")
+  override def copy(extra: ParamMap): EMLDAOptimizer = defaultCopy(extra)
+
+  @Since("1.6.0")
+  def this() = this(Identifiable.randomUID("EMLDAOpt"))
+
+  private[clustering] override def getOldOptimizer: OldEMLDAOptimizer = {
+    new OldEMLDAOptimizer
+  }
+}
+
+
+/**
+ * :: Experimental ::
+ *
+ * Online Variational Bayes [[LDA.optimizer]].
+ * This class may be used for specifying optimizer-specific Params.
+ */
+@Experimental
+class OnlineLDAOptimizer @Since("1.6.0") (
+    @Since("1.6.0") override val uid: String) extends LDAOptimizer {
+
+  @Since("1.6.0")
+  override def copy(extra: ParamMap): OnlineLDAOptimizer = defaultCopy(extra)
+
+  @Since("1.6.0")
+  def this() = this(Identifiable.randomUID("OnlineLDAOpt"))
+
+  private[clustering] override def getOldOptimizer: OldOnlineLDAOptimizer = {
+    new OldOnlineLDAOptimizer()
+      .setTau0($(tau0))
+      .setKappa($(kappa))
+      .setMiniBatchFraction($(subsamplingRate))
+      .setOptimizeDocConcentration($(optimizeDocConcentration))
+  }
+
+  /**
+   * A (positive) learning parameter that downweights early iterations. Larger values make early
+   * iterations count less.
+   * Default: 1024, following the original Online LDA paper.
+   * @group param
+   */
+  @Since("1.6.0")
+  final val tau0 = new DoubleParam(this, "tau0", "A (positive) learning parameter that" +
+    " downweights early iterations. Larger values make early iterations count less.",
+    ParamValidators.gt(0))
+
+  setDefault(tau0 -> 1024)
+
+  /** @group getParam */
+  @Since("1.6.0")
+  def getTau0: Double = $(tau0)
+
+  /**
+   * Learning rate, set as an exponential decay rate.
+   * This should be between (0.5, 1.0] to guarantee asymptotic convergence.
+   * Default: 0.51, based on the original Online LDA paper.
+   * @group param
+   */
+  @Since("1.6.0")
+  final val kappa = new DoubleParam(this, "kappa", "Learning rate, set as an exponential decay" +
+    " rate. This should be between (0.5, 1.0] to guarantee asymptotic convergence.",
+    ParamValidators.gt(0))
+
+  setDefault(kappa -> 0.51)
+
+  /** @group getParam */
+  @Since("1.6.0")
+  def getKappa: Double = $(kappa)
+
+  /**
+   * Fraction of the corpus to be sampled and used in each iteration of mini-batch gradient descent,
+   * in range (0, 1].
+   *
+   * Note that this should be adjusted in synch with [[LDA.maxIter]]
+   * so the entire corpus is used.  Specifically, set both so that
+   * maxIterations * miniBatchFraction >= 1.
+   *
+   * Note: This is the same as the `miniBatchFraction` parameter in
+   *       [[org.apache.spark.mllib.clustering.OnlineLDAOptimizer]].
+   *
+   * Default: 0.05, i.e., 5% of total documents.
+   * @group param
+   */
+  @Since("1.6.0")
+  final val subsamplingRate = new DoubleParam(this, "subsamplingRate", "Fraction of the corpus" +
+    " to be sampled and used in each iteration of mini-batch gradient descent, in range (0, 1].",
+    ParamValidators.inRange(0.0, 1.0, lowerInclusive = false, upperInclusive = true))
+
+  setDefault(subsamplingRate -> 0.05)
+
+  /** @group getParam */
+  @Since("1.6.0")
+  def getSubsamplingRate: Double = $(subsamplingRate)
+
+  /**
+   * Indicates whether the docConcentration (Dirichlet parameter for
+   * document-topic distribution) will be optimized during training.
+   * Default: true
+   * TODO: Check defaults of other libraries.
+   * @group param
+   */
+  @Since("1.5.0")
+  final val optimizeDocConcentration = new BooleanParam(this, "optimizeDocConcentration",
+    "Indicates whether the docConcentration (Dirichlet parameter for document-topic" +
+      " distribution) will be optimized during training.")
+
+  setDefault(optimizeDocConcentration -> true)
+
+  /** @group getParam */
+  @Since("1.6.0")
+  def getOptimizeDocConcentration: Boolean = $(optimizeDocConcentration)
+}

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
@@ -134,6 +134,7 @@ private[clustering] trait LDAParams extends Params with HasFeaturesCol with HasM
   }
 
   /** Supported values for Param [[optimizer]]. */
+  @Since("1.6.0")
   final val supportedOptimizers: Array[String] = Array("online", "em")
 
   /**
@@ -186,32 +187,34 @@ private[clustering] trait LDAParams extends Params with HasFeaturesCol with HasM
   /**
    * A (positive) learning parameter that downweights early iterations. Larger values make early
    * iterations count less.
-   * Default: 1024, following the Online LDA paper (Hoffman et al., 2010).
+   * This is called "tau0" in the Online LDA paper (Hoffman et al., 2010)
+   * Default: 1024, following Hoffman et al.
    * @group expertParam
    */
   @Since("1.6.0")
-  final val tau0 = new DoubleParam(this, "tau0", "A (positive) learning parameter that" +
-    " downweights early iterations. Larger values make early iterations count less.",
+  final val learningOffset = new DoubleParam(this, "learningOffset", "A (positive) learning" +
+    " parameter that downweights early iterations. Larger values make early iterations count less.",
     ParamValidators.gt(0))
 
   /** @group expertGetParam */
   @Since("1.6.0")
-  def getTau0: Double = $(tau0)
+  def getLearningOffset: Double = $(learningOffset)
 
   /**
    * Learning rate, set as an exponential decay rate.
    * This should be between (0.5, 1.0] to guarantee asymptotic convergence.
-   * Default: 0.51, based on the Online LDA paper (Hoffman et al., 2010).
+   * This is called "kappa" in the Online LDA paper (Hoffman et al., 2010).
+   * Default: 0.51, based on Hoffman et al.
    * @group expertParam
    */
   @Since("1.6.0")
-  final val kappa = new DoubleParam(this, "kappa", "Learning rate, set as an exponential decay" +
-    " rate. This should be between (0.5, 1.0] to guarantee asymptotic convergence.",
-    ParamValidators.gt(0))
+  final val learningDecay = new DoubleParam(this, "learningDecay", "Learning rate, set as an" +
+    " exponential decay rate. This should be between (0.5, 1.0] to guarantee asymptotic" +
+    " convergence.", ParamValidators.gt(0))
 
   /** @group expertGetParam */
   @Since("1.6.0")
-  def getKappa: Double = $(kappa)
+  def getLearningDecay: Double = $(learningDecay)
 
   /**
    * Fraction of the corpus to be sampled and used in each iteration of mini-batch gradient descent,
@@ -262,6 +265,7 @@ private[clustering] trait LDAParams extends Params with HasFeaturesCol with HasM
     SchemaUtils.appendColumn(schema, $(topicDistributionCol), new VectorUDT)
   }
 
+  @Since("1.6.0")
   override def validateParams(): Unit = {
     if (isSet(docConcentration)) {
       if (getDocConcentration.length != 1) {
@@ -295,8 +299,8 @@ private[clustering] trait LDAParams extends Params with HasFeaturesCol with HasM
   private[clustering] def getOldOptimizer: OldLDAOptimizer = getOptimizer match {
     case "online" =>
       new OldOnlineLDAOptimizer()
-        .setTau0($(tau0))
-        .setKappa($(kappa))
+        .setTau0($(learningOffset))
+        .setKappa($(learningDecay))
         .setMiniBatchFraction($(subsamplingRate))
         .setOptimizeDocConcentration($(optimizeDocConcentration))
     case "em" =>
@@ -587,7 +591,8 @@ class LDA @Since("1.6.0") (
   def this() = this(Identifiable.randomUID("lda"))
 
   setDefault(maxIter -> 20, k -> 10, optimizer -> "online", checkpointInterval -> 10,
-    tau0 -> 1024, kappa -> 0.51, subsamplingRate -> 0.05, optimizeDocConcentration -> true)
+    learningOffset -> 1024, learningDecay -> 0.51, subsamplingRate -> 0.05,
+    optimizeDocConcentration -> true)
 
   /**
    * The features for LDA should be a [[Vector]] representing the word counts in a document.
@@ -635,11 +640,11 @@ class LDA @Since("1.6.0") (
 
   /** @group expertSetParam */
   @Since("1.6.0")
-  def setTau0(value: Double): this.type = set(tau0, value)
+  def setLearningOffset(value: Double): this.type = set(learningOffset, value)
 
   /** @group expertSetParam */
   @Since("1.6.0")
-  def setKappa(value: Double): this.type = set(kappa, value)
+  def setLearningDecay(value: Double): this.type = set(learningDecay, value)
 
   /** @group setParam */
   @Since("1.6.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
@@ -266,8 +266,8 @@ private[clustering] trait LDAParams extends Params with HasFeaturesCol with HasM
     if (isSet(docConcentration)) {
       if (getDocConcentration.length != 1) {
         require(getDocConcentration.length == getK, s"LDA docConcentration was of length" +
-          s" ${getDocConcentration.length}, but k = $getK.  docConcentration must be either" +
-          s" length 1 (scalar) or an array of length k.")
+          s" ${getDocConcentration.length}, but k = $getK.  docConcentration must be an array of" +
+          s" length either 1 (scalar) or k (num topics).")
       }
       getOptimizer match {
         case "online" =>

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/LDA.scala
@@ -662,7 +662,7 @@ class OnlineLDAOptimizer @Since("1.6.0") (
 
   /** @group setParam */
   @Since("1.6.0")
-  def setTau0(value: Double) = set(tau0, value)
+  def setTau0(value: Double): this.type = set(tau0, value)
 
   /**
    * Learning rate, set as an exponential decay rate.
@@ -679,7 +679,7 @@ class OnlineLDAOptimizer @Since("1.6.0") (
 
   /** @group setParam */
   @Since("1.6.0")
-  def setKappa(value: Double) = set(kappa, value)
+  def setKappa(value: Double): this.type = set(kappa, value)
 
   /** @group getParam */
   @Since("1.6.0")
@@ -714,7 +714,7 @@ class OnlineLDAOptimizer @Since("1.6.0") (
 
   /** @group setParam */
   @Since("1.6.0")
-  def setSubsamplingRate(value: Double) = set(subsamplingRate, value)
+  def setSubsamplingRate(value: Double): this.type = set(subsamplingRate, value)
 
   /**
    * Indicates whether the docConcentration (Dirichlet parameter for
@@ -736,5 +736,5 @@ class OnlineLDAOptimizer @Since("1.6.0") (
 
   /** @group setParam */
   @Since("1.6.0")
-  def setOptimizeDocConcentration(value: Boolean) = set(optimizeDocConcentration, value)
+  def setOptimizeDocConcentration(value: Boolean): this.type = set(optimizeDocConcentration, value)
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/LDAModel.scala
@@ -273,9 +273,9 @@ class LocalLDAModel private[clustering] (
 
   /**
    * Estimate the variational likelihood bound of from `documents`:
-   * log p(documents) >= E_q[log p(documents)] - E_q[log q(documents)]
+   *    log p(documents) >= E_q[log p(documents)] - E_q[log q(documents)]
    * This bound is derived by decomposing the LDA model to:
-   * log p(documents) = E_q[log p(documents)] - E_q[log q(documents)] + D(q|p)
+   *    log p(documents) = E_q[log p(documents)] - E_q[log q(documents)] + D(q|p)
    * and noting that the KL-divergence D(q|p) >= 0.
    *
    * See Equation (16) in original Online LDA paper, as well as Appendix A.3 in the JMLR version of
@@ -290,13 +290,13 @@ class LocalLDAModel private[clustering] (
    * @param vocabSize number of unique terms in the entire test corpus
    */
   private def logLikelihoodBound(
-                                  documents: RDD[(Long, Vector)],
-                                  alpha: Vector,
-                                  eta: Double,
-                                  lambda: BDM[Double],
-                                  gammaShape: Double,
-                                  k: Int,
-                                  vocabSize: Long): Double = {
+      documents: RDD[(Long, Vector)],
+      alpha: Vector,
+      eta: Double,
+      lambda: BDM[Double],
+      gammaShape: Double,
+      k: Int,
+      vocabSize: Long): Double = {
     val brzAlpha = alpha.toBreeze.toDenseVector
     // transpose because dirichletExpectation normalizes by row and we need to normalize
     // by topic (columns of lambda)

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/LDASuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/LDASuite.scala
@@ -63,12 +63,11 @@ class LDASuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(lda.getK === 10)
     assert(lda.getDocConcentration === Array(-1.0))
     assert(lda.getTopicConcentration === -1.0)
-    assert(lda.getOptimizer.isInstanceOf[OnlineLDAOptimizer])
-    val optimizer = lda.getOptimizer.asInstanceOf[OnlineLDAOptimizer]
-    assert(optimizer.getKappa === 0.51)
-    assert(optimizer.getTau0 === 1024)
-    assert(optimizer.getSubsamplingRate === 0.05)
-    assert(optimizer.getOptimizeDocConcentration)
+    assert(lda.getOptimizer === "online")
+    assert(lda.getKappa === 0.51)
+    assert(lda.getTau0 === 1024)
+    assert(lda.getSubsamplingRate === 0.05)
+    assert(lda.getOptimizeDocConcentration)
     assert(lda.getTopicDistributionCol === "topicDistribution")
   }
 
@@ -93,18 +92,17 @@ class LDASuite extends SparkFunSuite with MLlibTestSparkContext {
 
     // setOptimizer
     lda.setOptimizer("em")
-    assert(lda.getOptimizer.isInstanceOf[EMLDAOptimizer])
+    assert(lda.getOptimizer === "em")
     lda.setOptimizer("online")
-    assert(lda.getOptimizer.isInstanceOf[OnlineLDAOptimizer])
-    val optimizer = lda.getOptimizer.asInstanceOf[OnlineLDAOptimizer]
-    optimizer.setKappa(0.53)
-    assert(optimizer.getKappa === 0.53)
-    optimizer.setTau0(1027)
-    assert(optimizer.getTau0 === 1027)
-    optimizer.setSubsamplingRate(0.06)
-    assert(optimizer.getSubsamplingRate === 0.06)
-    optimizer.setOptimizeDocConcentration(false)
-    assert(!optimizer.getOptimizeDocConcentration)
+    assert(lda.getOptimizer === "online")
+    lda.setKappa(0.53)
+    assert(lda.getKappa === 0.53)
+    lda.setTau0(1027)
+    assert(lda.getTau0 === 1027)
+    lda.setSubsamplingRate(0.06)
+    assert(lda.getSubsamplingRate === 0.06)
+    lda.setOptimizeDocConcentration(false)
+    assert(!lda.getOptimizeDocConcentration)
   }
 
   test("parameters validation") {
@@ -139,18 +137,18 @@ class LDASuite extends SparkFunSuite with MLlibTestSparkContext {
       }
     }
 
-    // OnlineLDAOptimizer
+    // Online LDA
     intercept[IllegalArgumentException] {
-      new OnlineLDAOptimizer().setTau0(0)
+      new LDA().setTau0(0)
     }
     intercept[IllegalArgumentException] {
-      new OnlineLDAOptimizer().setKappa(0)
+      new LDA().setKappa(0)
     }
     intercept[IllegalArgumentException] {
-      new OnlineLDAOptimizer().setSubsamplingRate(0)
+      new LDA().setSubsamplingRate(0)
     }
     intercept[IllegalArgumentException] {
-      new OnlineLDAOptimizer().setSubsamplingRate(1.1)
+      new LDA().setSubsamplingRate(1.1)
     }
   }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/LDASuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/LDASuite.scala
@@ -64,8 +64,8 @@ class LDASuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(!lda.isSet(lda.docConcentration))
     assert(!lda.isSet(lda.topicConcentration))
     assert(lda.getOptimizer === "online")
-    assert(lda.getKappa === 0.51)
-    assert(lda.getTau0 === 1024)
+    assert(lda.getLearningDecay === 0.51)
+    assert(lda.getLearningOffset === 1024)
     assert(lda.getSubsamplingRate === 0.05)
     assert(lda.getOptimizeDocConcentration)
     assert(lda.getTopicDistributionCol === "topicDistribution")
@@ -95,10 +95,10 @@ class LDASuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(lda.getOptimizer === "em")
     lda.setOptimizer("online")
     assert(lda.getOptimizer === "online")
-    lda.setKappa(0.53)
-    assert(lda.getKappa === 0.53)
-    lda.setTau0(1027)
-    assert(lda.getTau0 === 1027)
+    lda.setLearningDecay(0.53)
+    assert(lda.getLearningDecay === 0.53)
+    lda.setLearningOffset(1027)
+    assert(lda.getLearningOffset === 1027)
     lda.setSubsamplingRate(0.06)
     assert(lda.getSubsamplingRate === 0.06)
     lda.setOptimizeDocConcentration(false)
@@ -137,10 +137,10 @@ class LDASuite extends SparkFunSuite with MLlibTestSparkContext {
 
     // Online LDA
     intercept[IllegalArgumentException] {
-      new LDA().setTau0(0)
+      new LDA().setLearningOffset(0)
     }
     intercept[IllegalArgumentException] {
-      new LDA().setKappa(0)
+      new LDA().setLearningDecay(0)
     }
     intercept[IllegalArgumentException] {
       new LDA().setSubsamplingRate(0)

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/LDASuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/LDASuite.scala
@@ -61,8 +61,8 @@ class LDASuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(lda.isDefined(lda.seed))
     assert(lda.getCheckpointInterval === 10)
     assert(lda.getK === 10)
-    assert(lda.getDocConcentration === Array(-1.0))
-    assert(lda.getTopicConcentration === -1.0)
+    assert(!lda.isSet(lda.docConcentration))
+    assert(!lda.isSet(lda.topicConcentration))
     assert(lda.getOptimizer === "online")
     assert(lda.getKappa === 0.51)
     assert(lda.getTau0 === 1024)
@@ -123,8 +123,6 @@ class LDASuite extends SparkFunSuite with MLlibTestSparkContext {
     }
 
     // validateParams()
-    lda.setDocConcentration(-1)
-    assert(lda.getDocConcentration === Array(-1.0))
     lda.validateParams()
     lda.setDocConcentration(1.1)
     lda.validateParams()


### PR DESCRIPTION
This adds LDA to spark.ml, the Pipelines API.  It follows the design doc in the JIRA: [https://issues.apache.org/jira/browse/SPARK-5565], with one major change:
- I eliminated doc IDs.  These are not necessary with DataFrames since the user can add an ID column as needed.

Note: This will conflict with [https://github.com/apache/spark/pull/9484], but I'll try to merge [https://github.com/apache/spark/pull/9484] first and then rebase this PR.

CC: @hhbyyh @feynmanliang  If you have a chance to make a pass, that'd be really helpful--thanks!  Now that I'm done traveling & this PR is almost ready, I'll see about reviewing other PRs critical for 1.6.

CC: @mengxr 
