### PR TITLE
[SPARK-11476] [DOCS] Incorrect function referred to in MLib Random data generation documentation

### DIFF
--- a/docs/mllib-statistics.md
+++ b/docs/mllib-statistics.md
@@ -594,7 +594,7 @@ sc = ... # SparkContext
 
 # Generate a random double RDD that contains 1 million i.i.d. values drawn from the
 # standard normal distribution `N(0, 1)`, evenly distributed in 10 partitions.
-u = RandomRDDs.uniformRDD(sc, 1000000L, 10)
+u = RandomRDDs.normalRDD(sc, 1000000L, 10)
 # Apply a transform to get a random double RDD following `N(1, 4)`.
 v = u.map(lambda x: 1.0 + 2.0 * x)
 {% endhighlight %}


### PR DESCRIPTION
Fix Python example to use normalRDD as advertised
