### PR TITLE
[SPARK-11482][SQL] Make maven repo for Hive metastore jars configurable

### DIFF
--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -1747,6 +1747,13 @@ The following options can be used to configure the version of Hive that is used 
     </td>
   </tr>
   <tr>
+    <td><code>spark.sql.hive.metastore.mavenRepo</code></td>
+    <td><a href="http://www.datanucleus.org/downloads/maven2">http://www.datanucleus.org/downloads/maven2</a></td>
+    <td>
+      Maven repository to download Hive Metastore jars when <code>spark.sql.hive.metastore.jars</code> is set to <code>maven</code>.
+    </td>
+  </tr>
+  <tr>
     <td><code>spark.sql.hive.metastore.sharedPrefixes</code></td>
     <td><code>com.mysql.jdbc,<br/>org.postgresql,<br/>com.microsoft.sqlserver,<br/>oracle.jdbc</code></td>
     <td>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -169,6 +169,13 @@ class HiveContext private[hive](
   protected[hive] def hiveMetastoreJars: String = getConf(HIVE_METASTORE_JARS)
 
   /**
+   * The Maven repository where the jars are to be downloaded which should be used to instantiate
+   * the HiveMetastoreClient. This setting will take effect when HIVE_METASTORE_JARS is set to
+   * 'maven'.
+   */
+  protected[hive] def hiveMetastoreMavenRepo: String = getConf(HIVE_METASTORE_MAVEN_REPO)
+
+  /**
    * A comma separated list of class prefixes that should be loaded using the classloader that
    * is shared between Spark SQL and a specific version of Hive. An example of classes that should
    * be shared is JDBC drivers that are needed to talk to the metastore. Other classes that need
@@ -292,6 +299,7 @@ class HiveContext private[hive](
         hiveMetastoreVersion = hiveMetastoreVersion,
         hadoopVersion = VersionInfo.getVersion,
         config = allConfig,
+        mavenRepo = Some(hiveMetastoreMavenRepo),
         barrierPrefixes = hiveMetastoreBarrierPrefixes,
         sharedPrefixes = hiveMetastoreSharedPrefixes)
     } else {
@@ -685,6 +693,12 @@ private[hive] object HiveContext {
       |   Use Hive jars of specified version downloaded from Maven repositories.
       | 3. A classpath in the standard format for both Hive and Hadoop.
     """.stripMargin)
+
+  val HIVE_METASTORE_MAVEN_REPO = stringConf("spark.sql.hive.metastore.mavenRepo",
+    defaultValue = Some("http://www.datanucleus.org/downloads/maven2"),
+    doc = "Maven repositories where Hive metastore jars which are used to instantiate the" +
+      "HiveMetastoreClient are downloaded.")
+
   val CONVERT_METASTORE_PARQUET = booleanConf("spark.sql.hive.convertMetastoreParquet",
     defaultValue = Some(true),
     doc = "When set to false, Spark SQL will use the Hive SerDe for parquet tables instead of " +

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
@@ -45,7 +45,7 @@ class VersionsSuite extends SparkFunSuite with Logging {
       Some(new File(sys.props("java.io.tmpdir"), "hive-ivy-cache").getAbsolutePath))
   }
 
-  private val mavenRepo = Some("http://www.datanucleus.org/downloads/maven2")
+  private val mavenRepo = HiveContext.HIVE_METASTORE_MAVEN_REPO.defaultValue
 
   private def buildConf() = {
     lazy val warehousePath = Utils.createTempDir()

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
@@ -45,6 +45,8 @@ class VersionsSuite extends SparkFunSuite with Logging {
       Some(new File(sys.props("java.io.tmpdir"), "hive-ivy-cache").getAbsolutePath))
   }
 
+  private val mavenRepo = Some("http://www.datanucleus.org/downloads/maven2")
+
   private def buildConf() = {
     lazy val warehousePath = Utils.createTempDir()
     lazy val metastorePath = Utils.createTempDir()
@@ -59,6 +61,7 @@ class VersionsSuite extends SparkFunSuite with Logging {
       hiveMetastoreVersion = HiveContext.hiveExecutionVersion,
       hadoopVersion = VersionInfo.getVersion,
       config = buildConf(),
+      mavenRepo = mavenRepo,
       ivyPath = ivyPath).createClient()
     val db = new HiveDatabase("default", "")
     badClient.createDatabase(db)
@@ -93,6 +96,7 @@ class VersionsSuite extends SparkFunSuite with Logging {
           hiveMetastoreVersion = "13",
           hadoopVersion = VersionInfo.getVersion,
           config = buildConf(),
+          mavenRepo = mavenRepo,
           ivyPath = ivyPath).createClient()
       }
     }
@@ -112,6 +116,7 @@ class VersionsSuite extends SparkFunSuite with Logging {
           hiveMetastoreVersion = version,
           hadoopVersion = VersionInfo.getVersion,
           config = buildConf(),
+          mavenRepo = mavenRepo,
           ivyPath = ivyPath).createClient()
     }
 


### PR DESCRIPTION
Introducing a property called "spark.sql.hive.maven.repo" to let user configure the maven repository to download Hive Metastore jars.
