### PR TITLE
[SPARK-11572] Exit AsynchronousListenerBus thread when stop() is called

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/AsynchronousListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/util/AsynchronousListenerBus.scala
@@ -66,6 +66,7 @@ private[spark] abstract class AsynchronousListenerBus[L <: AnyRef, E](name: Stri
         self.synchronized {
           processingEvent = true
         }
+        if (stopped.get()) return
         try {
           val event = eventQueue.poll
           if (event == null) {

--- a/core/src/main/scala/org/apache/spark/util/AsynchronousListenerBus.scala
+++ b/core/src/main/scala/org/apache/spark/util/AsynchronousListenerBus.scala
@@ -66,11 +66,11 @@ private[spark] abstract class AsynchronousListenerBus[L <: AnyRef, E](name: Stri
         self.synchronized {
           processingEvent = true
         }
-        if (stopped.get()) {
-          // Get out of the while loop and shutdown the daemon thread
-          return
-        }
         try {
+          if (stopped.get()) {
+            // Get out of the while loop and shutdown the daemon thread
+            return
+          }
           val event = eventQueue.poll
           assert(event != null, "event queue was empty but the listener bus was not stopped")
           postToAll(event)


### PR DESCRIPTION
As vonnagy reported in the following thread:
http://search-hadoop.com/m/q3RTtk982kvIow22

Attempts to join the thread in AsynchronousListenerBus resulted in lock up because AsynchronousListenerBus thread was still getting messages `SparkListenerExecutorMetricsUpdate` from the DAGScheduler
