### PR TITLE
[SPARK-10838][SPARK-11576][SQL][WIP] Incorrect results or exceptions when using self-joins

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -374,7 +374,12 @@ class Analyzer(
                 case a: Attribute => attributeRewrites.get(a).getOrElse(a)
               }
             }
-            j.copy(right = newRight)
+            val newCondition = j.condition.map ( _.transform {
+              case a: AttributeReference if a.resolved && a.qualifiers.head == "RIGHT_TREE" =>
+                attributeRewrites.get(a).getOrElse(a).withQualifiers(Nil)
+              case o => o
+            })
+            j.copy(right = newRight, condition = newCondition )
         }
 
       // When resolve `SortOrder`s in Sort based on child, don't report errors as

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
@@ -194,7 +194,8 @@ case class AttributeReference(
   def sameRef(other: AttributeReference): Boolean = this.exprId == other.exprId
 
   override def equals(other: Any): Boolean = other match {
-    case ar: AttributeReference => name == ar.name && exprId == ar.exprId && dataType == ar.dataType
+    case ar: AttributeReference => name == ar.name && exprId == ar.exprId &&
+      dataType == ar.dataType && qualifiers == ar.qualifiers
     case _ => false
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -560,6 +560,16 @@ class DataFrame private[sql](
    * @since 1.3.0
    */
   def join(right: DataFrame, joinExprs: Column, joinType: String): DataFrame = {
+    // Note that ...
+    val newJoinExprs = joinExprs.expr.transform {
+      case arLeft: AttributeReference
+        if arLeft.qualifiers.head == this.hashCode.toString =>
+        arLeft.withQualifiers("LEFT_TREE" :: Nil)
+      case arRight: AttributeReference
+        if arRight.qualifiers.head == right.hashCode.toString =>
+        arRight.withQualifiers("RIGHT_TREE" :: Nil)
+      case o => o
+    }
     // Note that in this function, we introduce a hack in the case of self-join to automatically
     // resolve ambiguous join conditions into ones that might make sense [SPARK-6231].
     // Consider this case: df.join(df, df("key") === df("key"))
@@ -570,7 +580,7 @@ class DataFrame private[sql](
 
     // Trigger analysis so in the case of self-join, the analyzer will clone the plan.
     // After the cloning, left and right side will have distinct expression ids.
-    val plan = Join(logicalPlan, right.logicalPlan, JoinType(joinType), Some(joinExprs.expr))
+    val plan = Join(logicalPlan, right.logicalPlan, JoinType(joinType), Some(newJoinExprs))
       .queryExecution.analyzed.asInstanceOf[Join]
 
     // If auto self join alias is disabled, return the plan.
@@ -669,7 +679,11 @@ class DataFrame private[sql](
     case "*" =>
       Column(ResolvedStar(schema.fieldNames.map(resolve)))
     case _ =>
-      val expr = resolve(colName)
+      val expr = resolve(colName) match {
+        case ar: AttributeReference =>
+          ar.withQualifiers(this.hashCode.toString :: Nil)
+        case o => o
+      }
       Column(expr)
   }
 


### PR DESCRIPTION
Spark SQL is using expression ID to identify the column references. For self joins, these IDs might not be unique. When resolving the attributeReference's ambiguity caused by self joins, the current solution only handles the conflicting attributes. However, this does not work when the join conditions use the column names that appear in both analyzed dataFrames, since the the columns in join conditions are analyzed before resolving the ambiguity of conflicting attributes. Currently, we did not update the search-condition during ambiguity resolution of attributeReference. When generating the new expression IDs in the right tree, we must update the corresponding columns' expression ID in search condition. This part is missing now. 

Here, I am trying to propose a solution to resolve the above issue. When analyzing the columns in the join conditions, we record the dataFrame hashCode of the search-condition columns. By using the information, we can determine which columns are from the right tree, and then update their expression IDs when resolving the ambiguity of conflicting attributes.  

When designing this PR, I am trying to avoid introducing a lot of code changes, and thus, I just use quantifiers to record this information, if and only if necessary. 

Ideally, I think each column reference always needs to maintain a dedicated identifier for identifying its source dataFrame. The ideal solution requires a lot of code changes, but this can help us further optimize the plan in the future. 

Thanks for any suggestion! 
