### PR TITLE
[SPARK-11562][SQL] Provide option to switch SqlContext/HiveContext for spark shell

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -201,6 +201,13 @@ of the most common options to set are:
     or remotely ("cluster") on one of the nodes inside the cluster.
   </td>
 </tr>
+<tr>
+  <td><code>spark.sql.useHiveContext</code></td>
+  <td>true</td>
+  <td>
+    A flag to toggle HiveContext/SQLContext as the default type of sqlContext when spark-shell launches.
+  </td>
+</tr>
 </table>
 
 Apart from these, the following properties are also available, and may be useful in some situations:

--- a/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -132,7 +132,6 @@ class SparkILoop(
   @DeveloperApi
   var sparkContext: SparkContext = _
   var sqlContext: SQLContext = _
-  var useHiveContext: Boolean = _
 
   override def echoCommandMessage(msg: String) {
     intp.reporter printMessage msg
@@ -1027,7 +1026,7 @@ class SparkILoop(
 
   @DeveloperApi
   def createSQLContext(): SQLContext = {
-    useHiveContext = sparkContext.getConf.getBoolean("spark.sql.useHiveContext", true)
+    val useHiveContext = sparkContext.getConf.getBoolean("spark.sql.useHiveContext", true)
     val name = {
       if (useHiveContext) "org.apache.spark.sql.hive.HiveContext"
       else "org.apache.spark.sql.SQLContext"
@@ -1049,8 +1048,8 @@ class SparkILoop(
       case _: java.lang.ClassNotFoundException | _: java.lang.NoClassDefFoundError
         if useHiveContext =>
         sqlContext = new SQLContext(sparkContext)
-        logInfo("Created sql context without Hive support, " +
-          "build Spark with -Phive to enable Hive support.")
+        logInfo("Created sql context without Hive support. " +
+          "To enable Hive support, build Spark with -Phive profile.")
     }
     sqlContext
   }

--- a/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -132,6 +132,7 @@ class SparkILoop(
   @DeveloperApi
   var sparkContext: SparkContext = _
   var sqlContext: SQLContext = _
+  var useHiveContext: Boolean = _
 
   override def echoCommandMessage(msg: String) {
     intp.reporter printMessage msg
@@ -1026,17 +1027,30 @@ class SparkILoop(
 
   @DeveloperApi
   def createSQLContext(): SQLContext = {
-    val name = "org.apache.spark.sql.hive.HiveContext"
+    useHiveContext = sparkContext.getConf.getBoolean("spark.sql.useHiveContext", true)
+    val name = {
+      if (useHiveContext) "org.apache.spark.sql.hive.HiveContext"
+      else "org.apache.spark.sql.SQLContext"
+    }
+
     val loader = Utils.getContextOrSparkClassLoader
     try {
       sqlContext = loader.loadClass(name).getConstructor(classOf[SparkContext])
         .newInstance(sparkContext).asInstanceOf[SQLContext]
-      logInfo("Created sql context (with Hive support)..")
+      if (useHiveContext) {
+        logInfo("Created sql context (with Hive support). To use sqlContext (without Hive), " +
+          "set spark.sql.useHiveContext to false before launching spark-shell.")
+      }
+      else {
+        logInfo("Created sql context.")
+      }
     }
     catch {
-      case _: java.lang.ClassNotFoundException | _: java.lang.NoClassDefFoundError =>
+      case _: java.lang.ClassNotFoundException | _: java.lang.NoClassDefFoundError
+        if useHiveContext =>
         sqlContext = new SQLContext(sparkContext)
-        logInfo("Created sql context..")
+        logInfo("Created sql context without Hive support, " +
+          "build Spark with -Phive to enable Hive support.")
     }
     sqlContext
   }

--- a/repl/scala-2.11/src/main/scala/org/apache/spark/repl/Main.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/spark/repl/Main.scala
@@ -37,6 +37,7 @@ object Main extends Logging {
   // the creation of SecurityManager has to be lazy so SPARK_YARN_MODE is set if needed
   var sparkContext: SparkContext = _
   var sqlContext: SQLContext = _
+  var useHiveContext: Boolean = conf.getBoolean("spark.sql.useHiveContext", true)
   var interp = new SparkILoop // this is a public var because tests reset it.
 
   private var hasErrors = false
@@ -66,7 +67,8 @@ object Main extends Logging {
   def getAddedJars: Array[String] = {
     val envJars = sys.env.get("ADD_JARS")
     if (envJars.isDefined) {
-      logWarning("ADD_JARS environment variable is deprecated, use --jar spark submit argument instead")
+      logWarning("ADD_JARS environment variable is deprecated, " +
+        "use --jar spark submit argument instead")
     }
     val propJars = sys.props.get("spark.jars").flatMap { p => if (p == "") None else Some(p) }
     val jars = propJars.orElse(envJars).getOrElse("")
@@ -98,16 +100,28 @@ object Main extends Logging {
   }
 
   def createSQLContext(): SQLContext = {
-    val name = "org.apache.spark.sql.hive.HiveContext"
+    val name = {
+      if (useHiveContext) "org.apache.spark.sql.hive.HiveContext"
+      else "org.apache.spark.sql.SQLContext"
+    }
+
     val loader = Utils.getContextOrSparkClassLoader
     try {
       sqlContext = loader.loadClass(name).getConstructor(classOf[SparkContext])
         .newInstance(sparkContext).asInstanceOf[SQLContext]
-      logInfo("Created sql context (with Hive support)..")
+      if (useHiveContext) {
+        logInfo("Created sql context (with Hive support). To use sqlContext (without Hive), " +
+          "set spark.sql.useHiveContext to false before launching spark-shell.")
+      }
+      else {
+        logInfo("Created sql context.")
+      }
     } catch {
-      case _: java.lang.ClassNotFoundException | _: java.lang.NoClassDefFoundError =>
+      case _: java.lang.ClassNotFoundException | _: java.lang.NoClassDefFoundError
+        if useHiveContext =>
         sqlContext = new SQLContext(sparkContext)
-        logInfo("Created sql context..")
+        logInfo("Created sql context without Hive support, " +
+          "build Spark with -Phive to enable Hive support.")
     }
     sqlContext
   }

--- a/repl/scala-2.11/src/main/scala/org/apache/spark/repl/Main.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/spark/repl/Main.scala
@@ -37,7 +37,6 @@ object Main extends Logging {
   // the creation of SecurityManager has to be lazy so SPARK_YARN_MODE is set if needed
   var sparkContext: SparkContext = _
   var sqlContext: SQLContext = _
-  var useHiveContext: Boolean = conf.getBoolean("spark.sql.useHiveContext", true)
   var interp = new SparkILoop // this is a public var because tests reset it.
 
   private var hasErrors = false
@@ -100,6 +99,7 @@ object Main extends Logging {
   }
 
   def createSQLContext(): SQLContext = {
+    val useHiveContext = conf.getBoolean("spark.sql.useHiveContext", true)
     val name = {
       if (useHiveContext) "org.apache.spark.sql.hive.HiveContext"
       else "org.apache.spark.sql.SQLContext"
@@ -120,8 +120,8 @@ object Main extends Logging {
       case _: java.lang.ClassNotFoundException | _: java.lang.NoClassDefFoundError
         if useHiveContext =>
         sqlContext = new SQLContext(sparkContext)
-        logInfo("Created sql context without Hive support, " +
-          "build Spark with -Phive to enable Hive support.")
+        logInfo("Created sql context without Hive support. " +
+          "To enable Hive support, build Spark with -Phive profile.")
     }
     sqlContext
   }


### PR DESCRIPTION
Introducing a boolean property 'spark.sql.hive.context' to turn HiveContext on and off as the default sqlContext type.
