### PR TITLE
[SPARK-11583][Scheduler][Core] Make MapStatus use less memory uage

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
@@ -156,12 +156,14 @@ private[spark] class MapStatusTrackingEmptyBlocks private (
     loc.writeExternal(out)
     out.writeObject(markedBlocks)
     out.writeLong(avgSize)
+    out.writeBoolean(isSparse)
   }
 
   override def readExternal(in: ObjectInput): Unit = Utils.tryOrIOException {
     loc = BlockManagerId(in)
     markedBlocks = in.readObject().asInstanceOf[OpenHashSet[Int]]
     avgSize = in.readLong()
+    isSparse = in.readBoolean()
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
@@ -126,6 +126,8 @@ private[spark] class CompressedMapStatus(
 /**
  * A [[MapStatus]] implementation that only stores the average size of non-empty blocks,
  * plus a hashset for tracking which blocks are not empty.
+ * In this case, no-empty blocks are very sparse,
+ * using a HashSet[Int] can save more memory usage than BitSet
  *
  * @param loc location where the task is being executed
  * @param numNonEmptyBlocks the number of non-empty blocks
@@ -178,8 +180,9 @@ private[spark] object MapStatusTrackingNoEmptyBlocks {
 
 /**
  * A [[MapStatus]] implementation that only stores the average size of non-empty blocks,
- * plus a bitmap for tracking which blocks are empty.  During serialization, this bitmap
- * is compressed.
+ * plus a hashset for tracking which blocks are empty.
+ * In this case, no-empty blocks are very dense,
+ * using a HashSet[Int] can save more memory usage than BitSet
  *
  * @param loc location where the task is being executed
  * @param numNonEmptyBlocks the number of non-empty blocks
@@ -241,10 +244,10 @@ private[spark] object MapStatusTrackingEmptyBlocks {
  * @param avgSize average size of the non-empty blocks
  */
 private[spark] class HighlyCompressedMapStatus private (
-                                                         private[this] var loc: BlockManagerId,
-                                                         private[this] var numNonEmptyBlocks: Int,
-                                                         private[this] var emptyBlocks: BitSet,
-                                                         private[this] var avgSize: Long)
+    private[this] var loc: BlockManagerId,
+    private[this] var numNonEmptyBlocks: Int,
+    private[this] var emptyBlocks: BitSet,
+    private[this] var avgSize: Long)
   extends MapStatus with Externalizable {
 
   // loc could be null when the default constructor is called during deserialization

--- a/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
@@ -80,7 +80,6 @@ private[spark] object MapStatus {
   }
 }
 
-
 /**
  * A [[MapStatus]] implementation that tracks the size of each block. Size for each block is
  * represented using a single byte.
@@ -161,7 +160,6 @@ private[spark] class MapStatusTrackingEmptyBlocks private (
 
   override def readExternal(in: ObjectInput): Unit = Utils.tryOrIOException {
     loc = BlockManagerId(in)
-    markedBlocks = new OpenHashSet[Int]
     markedBlocks = in.readObject().asInstanceOf[OpenHashSet[Int]]
     avgSize = in.readLong()
   }
@@ -169,11 +167,11 @@ private[spark] class MapStatusTrackingEmptyBlocks private (
 
 private[spark] object MapStatusTrackingEmptyBlocks {
   def apply(
-    loc: BlockManagerId,
-    numNonEmptyBlocks: Int ,
-    markedBlocks: OpenHashSet[Int],
-    avgSize: Long,
-    isSparse: Boolean): MapStatusTrackingEmptyBlocks = {
+      loc: BlockManagerId,
+      numNonEmptyBlocks: Int ,
+      markedBlocks: OpenHashSet[Int],
+      avgSize: Long,
+      isSparse: Boolean): MapStatusTrackingEmptyBlocks = {
     new MapStatusTrackingEmptyBlocks(loc, numNonEmptyBlocks, markedBlocks, avgSize, isSparse)
   }
 }
@@ -256,15 +254,11 @@ private[spark] object HighlyCompressedMapStatus {
     } else {
       0
     }
-    var isSparse = true
     if(numNonEmptyBlocks * 32 < totalNumBlocks){
-      MapStatusTrackingEmptyBlocks(loc, numNonEmptyBlocks, nonEmptyBlocks, avgSize, isSparse)
-    }
-    else if ((totalNumBlocks - numNonEmptyBlocks) * 32 < totalNumBlocks){
-      isSparse = false
-      MapStatusTrackingEmptyBlocks(loc, numNonEmptyBlocks, emptyBlocksHashSet, avgSize, isSparse)
-    }
-    else {
+      MapStatusTrackingEmptyBlocks(loc, numNonEmptyBlocks, nonEmptyBlocks, avgSize, isSparse = true)
+    } else if ((totalNumBlocks - numNonEmptyBlocks) * 32 < totalNumBlocks){
+      MapStatusTrackingEmptyBlocks(loc, numNonEmptyBlocks, emptyBlocksHashSet, avgSize, isSparse = false)
+    } else {
       new HighlyCompressedMapStatus(loc, numNonEmptyBlocks, emptyBlocks, avgSize)
     }
   }

--- a/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
@@ -172,8 +172,11 @@ private[spark] class MapStatusTrackingNoEmptyBlocks private (
 }
 
 private[spark] object MapStatusTrackingNoEmptyBlocks {
-  def apply(loc: BlockManagerId, numNonEmptyBlocks: Int , nonEmptyBlocks: mutable.HashSet[Int], avgSize: Long): MapStatusTrackingNoEmptyBlocks =
-  {
+  def apply(
+    loc: BlockManagerId,
+    numNonEmptyBlocks: Int,
+    nonEmptyBlocks: mutable.HashSet[Int],
+    avgSize: Long): MapStatusTrackingNoEmptyBlocks = {
     new MapStatusTrackingNoEmptyBlocks(loc, numNonEmptyBlocks, nonEmptyBlocks, avgSize )
   }
 }
@@ -227,8 +230,11 @@ private[spark] class MapStatusTrackingEmptyBlocks private (
 }
 
 private[spark] object MapStatusTrackingEmptyBlocks {
-  def apply(loc: BlockManagerId, numNonEmptyBlocks: Int , emptyBlocksHashSet: mutable.HashSet[Int], avgSize: Long): MapStatusTrackingEmptyBlocks =
-  {
+  def apply(
+    loc: BlockManagerId,
+    numNonEmptyBlocks: Int ,
+    emptyBlocksHashSet: mutable.HashSet[Int],
+    avgSize: Long): MapStatusTrackingEmptyBlocks = {
     new MapStatusTrackingEmptyBlocks(loc, numNonEmptyBlocks, emptyBlocksHashSet, avgSize )
   }
 }

--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -35,7 +35,7 @@ import org.apache.spark._
 import org.apache.spark.api.python.PythonBroadcast
 import org.apache.spark.broadcast.HttpBroadcast
 import org.apache.spark.network.util.ByteUnit
-import org.apache.spark.scheduler.{MapStatusTrackingEmptyBlocks, MapStatusTrackingNoEmptyBlocks, CompressedMapStatus, HighlyCompressedMapStatus}
+import org.apache.spark.scheduler.{MapStatusTrackingEmptyBlocks, CompressedMapStatus, HighlyCompressedMapStatus}
 import org.apache.spark.storage._
 import org.apache.spark.util.{Utils, BoundedPriorityQueue, SerializableConfiguration, SerializableJobConf}
 import org.apache.spark.util.collection.{BitSet, CompactBuffer}
@@ -363,7 +363,6 @@ private[serializer] object KryoSerializer {
     classOf[CompressedMapStatus],
     classOf[HighlyCompressedMapStatus],
     classOf[BitSet],
-    classOf[MapStatusTrackingNoEmptyBlocks],
     classOf[MapStatusTrackingEmptyBlocks],
     classOf[CompactBuffer[_]],
     classOf[BlockManagerId],

--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -35,7 +35,7 @@ import org.apache.spark._
 import org.apache.spark.api.python.PythonBroadcast
 import org.apache.spark.broadcast.HttpBroadcast
 import org.apache.spark.network.util.ByteUnit
-import org.apache.spark.scheduler.{CompressedMapStatus, HighlyCompressedMapStatus}
+import org.apache.spark.scheduler.{MapStatusTrackingEmptyBlocks, MapStatusTrackingNoEmptyBlocks, CompressedMapStatus, HighlyCompressedMapStatus}
 import org.apache.spark.storage._
 import org.apache.spark.util.{Utils, BoundedPriorityQueue, SerializableConfiguration, SerializableJobConf}
 import org.apache.spark.util.collection.{BitSet, CompactBuffer}
@@ -363,6 +363,8 @@ private[serializer] object KryoSerializer {
     classOf[CompressedMapStatus],
     classOf[HighlyCompressedMapStatus],
     classOf[BitSet],
+    classOf[MapStatusTrackingNoEmptyBlocks],
+    classOf[MapStatusTrackingEmptyBlocks],
     classOf[CompactBuffer[_]],
     classOf[BlockManagerId],
     classOf[Array[Byte]],

--- a/core/src/test/scala/org/apache/spark/scheduler/MapStatusSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/MapStatusSuite.scala
@@ -78,11 +78,11 @@ class MapStatusSuite extends SparkFunSuite {
   }
 
   test("large tasks with sparse non-empty blocks should use " +
-    classOf[MapStatusTrackingNoEmptyBlocks].getName) {
+    classOf[MapStatusTrackingEmptyBlocks].getName) {
     val sizes = Array.fill[Long](2001)(0L)
     sizes(0) = 1L
     val status = MapStatus(null, sizes)
-    assert(status.isInstanceOf[MapStatusTrackingNoEmptyBlocks])
+    assert(status.isInstanceOf[MapStatusTrackingEmptyBlocks])
     assert(status.getSizeForBlock(0) === 1L)
     assert(status.getSizeForBlock(50) === 0L)
     assert(status.getSizeForBlock(99) === 0L)

--- a/core/src/test/scala/org/apache/spark/scheduler/MapStatusSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/MapStatusSuite.scala
@@ -66,7 +66,8 @@ class MapStatusSuite extends SparkFunSuite {
     }
   }
 
-  test("large tasks with dense non-empty blocks should use " + classOf[MapStatusTrackingEmptyBlocks].getName) {
+  test("large tasks with dense non-empty blocks should use" +
+    classOf[MapStatusTrackingEmptyBlocks].getName) {
     val sizes = Array.fill[Long](2001)(150L)
     val status = MapStatus(null, sizes)
     assert(status.isInstanceOf[MapStatusTrackingEmptyBlocks])
@@ -76,7 +77,8 @@ class MapStatusSuite extends SparkFunSuite {
     assert(status.getSizeForBlock(2000) === 150L)
   }
 
-  test("large tasks with sparse non-empty blocks should use " + classOf[MapStatusTrackingNoEmptyBlocks].getName) {
+  test("large tasks with sparse non-empty blocks should use " +
+    classOf[MapStatusTrackingNoEmptyBlocks].getName) {
     val sizes = Array.fill[Long](2001)(0L)
     sizes(0) = 1L
     val status = MapStatus(null, sizes)
@@ -87,10 +89,11 @@ class MapStatusSuite extends SparkFunSuite {
     assert(status.getSizeForBlock(2000) === 0L)
   }
 
-  test("large tasks with not dense or sparse non-empty blocks should use " + classOf[HighlyCompressedMapStatus].getName) {
+  test("large tasks with not dense or sparse non-empty blocks should use " +
+    classOf[HighlyCompressedMapStatus].getName) {
     val sizes = Array.fill[Long](2001)(0L)
     for(i <- 0 to sizes.length - 1){
-      if(i % 2 == 1){
+      if (i % 2 == 1) {
         sizes(i) = 1L
       }
     }

--- a/core/src/test/scala/org/apache/spark/scheduler/MapStatusSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/MapStatusSuite.scala
@@ -66,23 +66,49 @@ class MapStatusSuite extends SparkFunSuite {
     }
   }
 
-  test("large tasks should use " + classOf[HighlyCompressedMapStatus].getName) {
+  test("large tasks with dense non-empty blocks should use " + classOf[MapStatusTrackingEmptyBlocks].getName) {
     val sizes = Array.fill[Long](2001)(150L)
     val status = MapStatus(null, sizes)
-    assert(status.isInstanceOf[HighlyCompressedMapStatus])
+    assert(status.isInstanceOf[MapStatusTrackingEmptyBlocks])
     assert(status.getSizeForBlock(10) === 150L)
     assert(status.getSizeForBlock(50) === 150L)
     assert(status.getSizeForBlock(99) === 150L)
     assert(status.getSizeForBlock(2000) === 150L)
   }
 
-  test("HighlyCompressedMapStatus: estimated size should be the average non-empty block size") {
+  test("large tasks with sparse non-empty blocks should use " + classOf[MapStatusTrackingNoEmptyBlocks].getName) {
+    val sizes = Array.fill[Long](2001)(0L)
+    sizes(0) = 1L
+    val status = MapStatus(null, sizes)
+    assert(status.isInstanceOf[MapStatusTrackingNoEmptyBlocks])
+    assert(status.getSizeForBlock(0) === 1L)
+    assert(status.getSizeForBlock(50) === 0L)
+    assert(status.getSizeForBlock(99) === 0L)
+    assert(status.getSizeForBlock(2000) === 0L)
+  }
+
+  test("large tasks with not dense or sparse non-empty blocks should use " + classOf[HighlyCompressedMapStatus].getName) {
+    val sizes = Array.fill[Long](2001)(0L)
+    for(i <- 0 to sizes.length - 1){
+      if(i % 2 == 1){
+        sizes(i) = 1L
+      }
+    }
+    val status = MapStatus(null, sizes)
+    assert(status.isInstanceOf[HighlyCompressedMapStatus])
+    assert(status.getSizeForBlock(0) === 0L)
+    assert(status.getSizeForBlock(1) === 1L)
+    assert(status.getSizeForBlock(1999) === 1L)
+    assert(status.getSizeForBlock(2000) === 0L)
+  }
+
+  test("MapStatusTrackingEmptyBlocks: estimated size should be the average non-empty block size") {
     val sizes = Array.tabulate[Long](3000) { i => i.toLong }
     val avg = sizes.sum / sizes.filter(_ != 0).length
     val loc = BlockManagerId("a", "b", 10)
     val status = MapStatus(loc, sizes)
     val status1 = compressAndDecompressMapStatus(status)
-    assert(status1.isInstanceOf[HighlyCompressedMapStatus])
+    assert(status1.isInstanceOf[MapStatusTrackingEmptyBlocks])
     assert(status1.location == loc)
     for (i <- 0 until 3000) {
       val estimate = status1.getSizeForBlock(i)


### PR DESCRIPTION
Disscuss about this pr is at https://issues.apache.org/jira/browse/SPARK-11583

In the resolved issue https://issues.apache.org/jira/browse/SPARK-11271, as I said, using BitSet can save ≈20% memory usage compared to RoaringBitMap.
For a spark job contains quite a lot of tasks, 20% seems a drop in the ocean.
Essentially, BitSet uses long[]. For example a BitSet[200k] = long[3125].
So if we use a HashSet[Int] to store reduceId (when non-empty blocks are dense,use reduceId of empty blocks; when sparse, use non-empty ones).
For dense cases: if HashSet[Int](numNonEmptyBlocks).size < BitSet[totalBlockNum], I use MapStatusTrackingNoEmptyBlocks
For sparse cases: if HashSet[Int](numEmptyBlocks).size < BitSet[totalBlockNum], I use MapStatusTrackingEmptyBlocks
sparse case, 299/300 are empty
sc.makeRDD(1 to 30000, 3000).groupBy(x=>x).top(5)
dense case, no block is empty
sc.makeRDD(1 to 9000000, 3000).groupBy(x=>x).top(5)
