### PR TITLE
[SPARK-11592][SQL]flush spark-sql command line history to history file

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -194,6 +194,22 @@ private[hive] object SparkSQLCLIDriver extends Logging {
         logWarning(e.getMessage)
     }
 
+    // add shutdown hook to flush the history to history file
+    Runtime.getRuntime.addShutdownHook(new Thread(new Runnable() {
+      override def run() = {
+        reader.getHistory match {
+          case h: FileHistory =>
+            try {
+              h.flush()
+            } catch {
+              case e: IOException =>
+                logWarning("WARNING: Failed to write command history file: " + e.getMessage)
+            }
+          case _ =>
+        }
+      }
+    }))
+
     // TODO: missing
 /*
     val clientTransportTSocketField = classOf[CliSessionState].getDeclaredField("transport")


### PR DESCRIPTION
Currently, `spark-sql` would not flush command history when exiting.
