### PR TITLE
[SPARK-11584][SQL] The attribute of temporay table shows false

### DIFF
--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -227,4 +227,15 @@ class CliSuite extends SparkFunSuite with BeforeAndAfter with Logging {
         -> "Error in query: Table not found: nonexistent_table;"
     )
   }
+
+  test("Temporary table") {
+    runCliWithin(2.minute)(
+      "USE hive_test_db;"
+        -> "OK",
+      "CREATE TEMPORARY TABLE hive_test_temp(key INT, val STRING);"
+        -> "OK",
+      "SHOW TABLES;"
+        -> "hive_test_temp\ttrue"
+    )
+  }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
@@ -526,7 +526,8 @@ https://cwiki.apache.org/confluence/display/Hive/Enhanced+Aggregation%2C+Cube%2C
       inputFormat = None,
       outputFormat = None,
       serde = None,
-      viewText = Some(originalText))
+      viewText = Some(originalText),
+      isTemporary = false)
 
     // We need to keep the original SQL string so that if `spark.sql.nativeView` is
     // false, we can fall back to use hive native command later.
@@ -723,7 +724,8 @@ https://cwiki.apache.org/confluence/display/Hive/Enhanced+Aggregation%2C+Cube%2C
         inputFormat = None,
         outputFormat = None,
         serde = None,
-        viewText = None)
+        viewText = None,
+        isTemporary = false)
 
       // default storage type abbreviation (e.g. RCFile, ORC, PARQUET etc.)
       val defaultStorageType = hiveConf.getVar(HiveConf.ConfVars.HIVEDEFAULTFILEFORMAT)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientInterface.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientInterface.scala
@@ -57,7 +57,8 @@ private[hive] case class HiveTable(
     inputFormat: Option[String] = None,
     outputFormat: Option[String] = None,
     serde: Option[String] = None,
-    viewText: Option[String] = None) {
+    viewText: Option[String] = None,
+    isTemporary: Boolean) {
 
   @transient
   private[client] var client: ClientInterface = _

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
@@ -322,7 +322,8 @@ private[hive] class ClientWrapper(
         inputFormat = Option(h.getInputFormatClass).map(_.getName),
         outputFormat = Option(h.getOutputFormatClass).map(_.getName),
         serde = Option(h.getSerializationLib),
-        viewText = Option(h.getViewExpandedText)).withClient(this)
+        viewText = Option(h.getViewExpandedText),
+        isTemporary = shim.isTemporary(h)).withClient(this)
     }
     converted
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
@@ -734,7 +734,8 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with TestHiv
           "EXTERNAL" -> "FALSE"),
         tableType = ManagedTable,
         serdeProperties = Map(
-          "path" -> catalog.hiveDefaultTableFilePath(TableIdentifier(tableName))))
+          "path" -> catalog.hiveDefaultTableFilePath(TableIdentifier(tableName))),
+        isTemporary = false)
 
       catalog.client.createTable(hiveTable)
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
@@ -121,7 +121,8 @@ class VersionsSuite extends SparkFunSuite with Logging {
           outputFormat =
             Some(classOf[org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat[_, _]].getName),
           serde =
-            Some(classOf[org.apache.hadoop.hive.serde2.`lazy`.LazySimpleSerDe].getName()))
+            Some(classOf[org.apache.hadoop.hive.serde2.`lazy`.LazySimpleSerDe].getName()),
+          isTemporary = false)
 
       client.createTable(table)
     }


### PR DESCRIPTION
The code used to hard-code the temporary attribute to false. Have changed the code to retrieve the attribute from meta store.

Question -
1) I have added a test case in CliSuite as an unit test. When running the tests on jenkins, can this test get executed against older version of hive ? If so, then it will fail as the method to query the temporary attribute is only available after hive 14. 
