### PR TITLE
[SPARK-11627] Add initial input rate limit for spark streaming backpressure mechanism.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1525,7 +1525,7 @@ Apart from these, the following properties are also available, and may be useful
 </tr>
 <tr>
   <td><code>spark.streaming.backpressure.initialRate</code></td>
-  <td>1000</td>
+  <td>not set</td>
   <td>
     Initial rate for backpressure mechanism (since 1.5). This provides maximum receiving rate of
     receivers in the first batch when enables the backpressure mechanism, then the maximum receiving

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1527,9 +1527,8 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.streaming.backpressure.initialRate</code></td>
   <td>not set</td>
   <td>
-    Initial rate for backpressure mechanism (since 1.5). This provides maximum receiving rate of
-    receivers in the first batch when enables the backpressure mechanism, then the maximum receiving
-    rate will compute dynamically based on the current batch scheduling delays and processing times.
+    This is the initial maximum receiving rate at which each receiver will receive data for the
+    first batch when the backpressure mechanism is enabled.
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1524,6 +1524,15 @@ Apart from these, the following properties are also available, and may be useful
   </td>
 </tr>
 <tr>
+  <td><code>spark.streaming.backpressure.initialRate</code></td>
+  <td>1000</td>
+  <td>
+    Initial rate for backpressure mechanism (since 1.5). This provides maximum receiving rate of
+    receivers in the first batch when enables the backpressure mechanism, then the maximum receiving
+    rate will compute dynamically based on the current batch scheduling delays and processing times.
+  </td>
+</tr>
+<tr>
   <td><code>spark.streaming.blockInterval</code></td>
   <td>200ms</td>
   <td>

--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/RateLimiter.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/RateLimiter.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.streaming.receiver
 
 import com.google.common.util.concurrent.{RateLimiter => GuavaRateLimiter}
-import org.apache.spark.streaming.scheduler.RateController
 
 import org.apache.spark.{Logging, SparkConf}
 
@@ -65,18 +64,8 @@ private[receiver] abstract class RateLimiter(conf: SparkConf) extends Logging {
 
   /**
    * Get the initial rateLimit to initial rateLimiter
-   * @return
    */
-  def getInitialRateLimit() : Long = {
-    if (RateController.isBackPressureEnabled(conf)) {
-      val initialRate = conf.getLong("spark.streaming.backpressure.initialRate", 1000)
-      if (initialRate < maxRateLimit) {
-        initialRate
-      } else {
-        maxRateLimit
-      }
-    } else {
-      maxRateLimit
-    }
+  private def getInitialRateLimit(): Long = {
+    math.min(conf.getLong("spark.streaming.backpressure.initialRate", maxRateLimit), maxRateLimit)
   }
 }

--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/RateLimiter.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/RateLimiter.scala
@@ -37,7 +37,7 @@ private[receiver] abstract class RateLimiter(conf: SparkConf) extends Logging {
 
   // treated as an upper limit
   private val maxRateLimit = conf.getLong("spark.streaming.receiver.maxRate", Long.MaxValue)
-  private lazy val rateLimiter = GuavaRateLimiter.create(getInitialRateLimit())
+  private lazy val rateLimiter = GuavaRateLimiter.create(getInitialRateLimit().toDouble)
 
   def waitToPush() {
     rateLimiter.acquire()

--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/RateLimiter.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/RateLimiter.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.streaming.receiver
 
 import com.google.common.util.concurrent.{RateLimiter => GuavaRateLimiter}
+import org.apache.spark.streaming.scheduler.RateController
 
 import org.apache.spark.{Logging, SparkConf}
 
@@ -61,4 +62,21 @@ private[receiver] abstract class RateLimiter(conf: SparkConf) extends Logging {
         rateLimiter.setRate(newRate)
       }
     }
+
+  /**
+   * Get the initial rateLimit to initial rateLimiter
+   * @return
+   */
+  def getInitialRateLimit() : Long = {
+    if (RateController.isBackPressureEnabled(conf)) {
+      val initialRate = conf.getLong("spark.streaming.backpressure.initialRate", 1000)
+      if (initialRate < maxRateLimit) {
+        initialRate
+      } else {
+        maxRateLimit
+      }
+    } else {
+      maxRateLimit
+    }
+  }
 }

--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/RateLimiter.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/RateLimiter.scala
@@ -37,7 +37,7 @@ private[receiver] abstract class RateLimiter(conf: SparkConf) extends Logging {
 
   // treated as an upper limit
   private val maxRateLimit = conf.getLong("spark.streaming.receiver.maxRate", Long.MaxValue)
-  private lazy val rateLimiter = GuavaRateLimiter.create(maxRateLimit.toDouble)
+  private lazy val rateLimiter = GuavaRateLimiter.create(getInitialRateLimit())
 
   def waitToPush() {
     rateLimiter.acquire()


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-11627

Spark Streaming backpressure mechanism has no initial input rate limit, it might cause OOM exception.
In the firest batch task ,receivers receive data at the maximum speed they can reach,it might exhaust executors memory resources. Add a initial input rate limit value can make sure the Streaming job execute  success in the first batch,then the backpressure mechanism can adjust receiving rate adaptively.
