### PR TITLE
[SPARK-11632][Streaming] Filter out empty partition in KafkaRDD

### DIFF
--- a/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaRDD.scala
+++ b/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaRDD.scala
@@ -56,10 +56,12 @@ class KafkaRDD[
     messageHandler: MessageAndMetadata[K, V] => R
   ) extends RDD[R](sc, Nil) with Logging with HasOffsetRanges {
   override def getPartitions: Array[Partition] = {
-    offsetRanges.zipWithIndex.map { case (o, i) =>
+    offsetRanges
+      .filter(_.count() > 0)
+      .zipWithIndex.map { case (o, i) =>
         val (host, port) = leaders(TopicAndPartition(o.topic, o.partition))
         new KafkaRDDPartition(i, o.topic, o.partition, o.fromOffset, o.untilOffset, host, port)
-    }.toArray
+      }.toArray
   }
 
   override def count(): Long = offsetRanges.map(_.count).sum

--- a/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaRDD.scala
+++ b/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaRDD.scala
@@ -56,12 +56,10 @@ class KafkaRDD[
     messageHandler: MessageAndMetadata[K, V] => R
   ) extends RDD[R](sc, Nil) with Logging with HasOffsetRanges {
   override def getPartitions: Array[Partition] = {
-    offsetRanges
-      .filter(_.count() > 0)
-      .zipWithIndex.map { case (o, i) =>
+    offsetRanges.zipWithIndex.filter(_._1.count() > 0).map { case (o, i) =>
         val (host, port) = leaders(TopicAndPartition(o.topic, o.partition))
         new KafkaRDDPartition(i, o.topic, o.partition, o.fromOffset, o.untilOffset, host, port)
-      }.toArray
+    }.toArray
   }
 
   override def count(): Long = offsetRanges.map(_.count).sum


### PR DESCRIPTION
Currently empty partitions or empty `KafkaRDD` will still submit and run tasks to remotely, this is unnecessary since no data is processed. This patch fix this by filtering out the empty partition, this could potentially alleviate the scheduling overhead, since now empty partition will not generate task, even stage could be skipped if current rdd is empty. Also this could make dynamic allocation effective (no tasks generated if there's no data injected).

Please help to review @tdas @koeninger and @zsxwing , thanks a lot!
