### PR TITLE
[SPARK-11639][STREAMING][FLAKY-TEST] Implement BlockingWriteAheadLog for testing the BatchedWriteAheadLog

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/util/BatchedWriteAheadLog.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/util/BatchedWriteAheadLog.scala
@@ -182,6 +182,9 @@ private[util] class BatchedWriteAheadLog(val wrappedLog: WriteAheadLog, conf: Sp
       buffer.clear()
     }
   }
+
+  /** Method for querying the queue length. Should only be used in tests. */
+  private def getQueueLength(): Int = walWriteQueue.size()
 }
 
 /** Static methods for aggregating and de-aggregating records. */

--- a/streaming/src/test/scala/org/apache/spark/streaming/util/WriteAheadLogSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/util/WriteAheadLogSuite.scala
@@ -642,9 +642,11 @@ object WriteAheadLogSuite {
       isWriteCalled = false
       handle
     }
-    override def read(segment: WriteAheadLogRecordHandle): ByteBuffer = ???
-    override def readAll(): JIterator[ByteBuffer] = ???
-    override def clean(threshTime: Long, waitForCompletion: Boolean): Unit = ???
+    override def read(segment: WriteAheadLogRecordHandle): ByteBuffer = wal.read(segment)
+    override def readAll(): JIterator[ByteBuffer] = wal.readAll()
+    override def clean(threshTime: Long, waitForCompletion: Boolean): Unit = {
+      wal.clean(threshTime, waitForCompletion)
+    }
     override def close(): Unit = wal.close()
 
     def allowWrite(): Unit = {


### PR DESCRIPTION
Several elements could be drained if the main thread is not fast enough. @zsxwing warned me about a similar problem, but missed it here :( Submitting the fix using a waiter.

cc @tdas 
