### PR TITLE
[SPARK-11641][SQL] Exchange plan string is too verbose

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/Exchange.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/Exchange.scala
@@ -43,15 +43,13 @@ case class Exchange(
 
   override def nodeName: String = {
     val extraInfo = coordinator match {
-      case Some(exchangeCoordinator) if exchangeCoordinator.isEstimated =>
-        "Shuffle"
-      case Some(exchangeCoordinator) if !exchangeCoordinator.isEstimated =>
-        "May shuffle"
-      case None => "Shuffle without coordinator"
+      case Some(exchangeCoordinator) if exchangeCoordinator.isEstimated => "(Shuffle)"
+      case Some(exchangeCoordinator) if !exchangeCoordinator.isEstimated => "(May shuffle)"
+      case None => ""
     }
 
     val simpleNodeName = if (tungstenMode) "TungstenExchange" else "Exchange"
-    s"$simpleNodeName($extraInfo)"
+    s"$simpleNodeName$extraInfo"
   }
 
   /**


### PR DESCRIPTION
By default it says "TungstenExchange(Shuffle without coordinator)". It should just say "TungstenExchange".
