### PR TITLE
[SPARK-11081] Shade Jersey and javax.rs.ws

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -693,13 +693,13 @@
         <groupId>com.sun.jersey</groupId>
         <artifactId>jersey-server</artifactId>
         <version>${jersey.version}</version>
-        <scope>${hadoop.deps.scope}</scope>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>com.sun.jersey</groupId>
         <artifactId>jersey-core</artifactId>
         <version>${jersey.version}</version>
-        <scope>${hadoop.deps.scope}</scope>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>com.sun.jersey</groupId>
@@ -711,6 +711,7 @@
             <artifactId>stax-api</artifactId>
           </exclusion>
         </exclusions>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.scala-lang</groupId>
@@ -2165,6 +2166,9 @@
               <include>org.eclipse.jetty:jetty-security</include>
               <include>org.eclipse.jetty:jetty-util</include>
               <include>org.eclipse.jetty:jetty-server</include>
+              <include>com.sun.jersey:jersey-core</include>
+              <include>com.sun.jersey:jersey-json</include>
+              <include>com.sun.jersey:jersey-server</include>
               <include>com.google.guava:guava</include>
             </includes>
           </artifactSet>
@@ -2190,6 +2194,20 @@
                 <exclude>com/google/common/base/Present*</exclude>
                 <exclude>com/google/common/base/Supplier</exclude>
               </excludes>
+            </relocation>
+            <relocation>
+              <pattern>com.sun.jersey</pattern>
+              <shadedPattern>org.spark-project.jersey</shadedPattern>
+              <includes>
+                <include>com.sun.jersey.**</include>
+              </includes>
+            </relocation>
+            <relocation>
+              <pattern>javax.ws.rs</pattern>
+              <shadedPattern>org.spark-project.javax.ws.rs</shadedPattern>
+              <includes>
+                  <include>javax.ws.rs.**</include>
+              </includes>
             </relocation>
           </relocations>
         </configuration>


### PR DESCRIPTION
Jersey and javax.rs.ws are commonly depended on and cause dependency
conflicts in many applications that depend on the Spark maven artifacts.
This patch attempts to shade them.

However this patch set is a work in progress. Currently, the javax.rs.ws shading appears to be broken. When I run the mvn package task and generate the assembly jar, and unpack it, I'm missing the javax.rs.ws classes - they're not under org/spark-project/javax/rs/ws. I would appreciate some assistance in debugging how the shading is being done incorrectly here.
