### PR TITLE
[SPARK-11651] [ML] LinearRegressionSummary should support get residuals by type

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -522,17 +522,39 @@ class LinearRegressionSummary private[regression] (
   }
 
   /**
+   * Return the residuals by type.
+   * Supported options: "deviance", "pearson", "working" and "response".
+   * Default is "deviance".
+   */
+  def residualsByType(residualsType: String = "deviance"): DataFrame = {
+    residualsType match {
+      case "deviance" => devianceResiduals
+      case "pearson" => pearsonResiduals
+      case "working" => workingResiduals
+      case "response" => responseResiduals
+      case other => throw new UnsupportedOperationException(
+        s"The residuals type ${other} is not supported by Linear Regression.")
+    }
+  }
+
+  /**
    * The weighted residuals, the usual residuals rescaled by
    * the square root of the instance weights.
    */
-  lazy val devianceResiduals: Array[Double] = {
+  private lazy val devianceResiduals: DataFrame = {
     val weighted = if (model.getWeightCol.isEmpty) lit(1.0) else sqrt(col(model.getWeightCol))
-    val dr = predictions.select(col(model.getLabelCol).minus(col(model.getPredictionCol))
-      .multiply(weighted).as("weightedResiduals"))
-      .select(min(col("weightedResiduals")).as("min"), max(col("weightedResiduals")).as("max"))
-      .first()
-    Array(dr.getDouble(0), dr.getDouble(1))
+    predictions.select(col(model.getLabelCol).minus(col(model.getPredictionCol))
+      .multiply(weighted).as("devianceResiduals"))
   }
+
+  private lazy val pearsonResiduals: DataFrame =
+    devianceResiduals.withColumnRenamed("devianceResiduals", "pearsonResiduals")
+
+  private lazy val workingResiduals: DataFrame =
+    residuals.withColumnRenamed("residuals", "workingResiduals")
+
+  private lazy val responseResiduals: DataFrame =
+    residuals.withColumnRenamed("residuals", "responseResiduals")
 
   /**
    * Standard error of estimated coefficients and intercept.

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
@@ -28,6 +28,7 @@ import org.apache.spark.mllib.linalg.{Vector, DenseVector, Vectors}
 import org.apache.spark.mllib.util.{LinearDataGenerator, MLlibTestSparkContext}
 import org.apache.spark.mllib.util.TestingUtils._
 import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.functions._
 
 class LinearRegressionSuite extends SparkFunSuite with MLlibTestSparkContext {
 
@@ -624,8 +625,11 @@ class LinearRegressionSuite extends SparkFunSuite with MLlibTestSparkContext {
         val seCoefR = Array(0.0011756, 0.0009032, 0.0018489)
         val tValsR = Array(3998, 7971, 3407)
         val pValsR = Array(0, 0, 0)
-        model.summary.devianceResiduals.zip(devianceResidualsR).foreach { x =>
-          assert(x._1 ~== x._2 absTol 1E-5) }
+        val devianceResiduals = model.summary.residualsByType("deviance")
+          .select(min(col("devianceResiduals")).as("min"), max(col("devianceResiduals")).as("max"))
+          .first()
+        Array(devianceResiduals.getDouble(0), devianceResiduals.getDouble(1))
+          .zip(devianceResidualsR).foreach { x => assert(x._1 ~== x._2 absTol 1E-3) }
         model.summary.coefficientStandardErrors.zip(seCoefR).foreach{ x =>
           assert(x._1 ~== x._2 absTol 1E-5) }
         model.summary.tValues.map(_.round).zip(tValsR).foreach{ x => assert(x._1 === x._2) }
@@ -795,8 +799,11 @@ class LinearRegressionSuite extends SparkFunSuite with MLlibTestSparkContext {
 
     assert(model.coefficients ~== coefficientsR absTol 1E-3)
     assert(model.intercept ~== interceptR absTol 1E-3)
-    model.summary.devianceResiduals.zip(devianceResidualsR).foreach { x =>
-      assert(x._1 ~== x._2 absTol 1E-3) }
+    val devianceResiduals = model.summary.residualsByType("deviance")
+      .select(min(col("devianceResiduals")).as("min"), max(col("devianceResiduals")).as("max"))
+      .first()
+    Array(devianceResiduals.getDouble(0), devianceResiduals.getDouble(1)).zip(devianceResidualsR)
+      .foreach { x => assert(x._1 ~== x._2 absTol 1E-3) }
     model.summary.coefficientStandardErrors.zip(seCoefR).foreach{ x =>
       assert(x._1 ~== x._2 absTol 1E-3) }
     model.summary.tValues.zip(tValsR).foreach{ x => assert(x._1 ~== x._2 absTol 1E-3) }
@@ -847,8 +854,11 @@ class LinearRegressionSuite extends SparkFunSuite with MLlibTestSparkContext {
 
     assert(model.coefficients ~== coefficientsR absTol 1E-3)
     assert(model.intercept === interceptR)
-    model.summary.devianceResiduals.zip(devianceResidualsR).foreach { x =>
-      assert(x._1 ~== x._2 absTol 1E-3) }
+    val devianceResiduals = model.summary.residualsByType("deviance")
+      .select(min(col("devianceResiduals")).as("min"), max(col("devianceResiduals")).as("max"))
+      .first()
+    Array(devianceResiduals.getDouble(0), devianceResiduals.getDouble(1)).zip(devianceResidualsR)
+      .foreach { x => assert(x._1 ~== x._2 absTol 1E-3) }
     model.summary.coefficientStandardErrors.zip(seCoefR).foreach{ x =>
       assert(x._1 ~== x._2 absTol 1E-3) }
     model.summary.tValues.zip(tValsR).foreach{ x => assert(x._1 ~== x._2 absTol 1E-3) }


### PR DESCRIPTION
LinearRegressionSummary should support get residuals by type like R glm:

``` R
residuals(object, type = c("deviance", "pearson", "working",
                           "response", "partial"), ...)
```
