### PR TITLE
[SPARK-11674] [ML] add private val after @transient in Word2VecModel

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Word2Vec.scala
@@ -146,7 +146,7 @@ final class Word2Vec(override val uid: String) extends Estimator[Word2VecModel] 
 @Experimental
 class Word2VecModel private[ml] (
     override val uid: String,
-    @transient wordVectors: feature.Word2VecModel)
+    @transient private val wordVectors: feature.Word2VecModel)
   extends Model[Word2VecModel] with Word2VecBase {
 
   /**


### PR DESCRIPTION
This causes compile failure with Scala 2.11. See https://issues.scala-lang.org/browse/SI-8813. (Jenkins won't test Scala 2.11. I tested compile locally.) @JoshRosen 
