### PR TITLE
[SPARK-11679][SQL] Invoking method " apply(fields: java.util.List[StructField])" in "StructType" gets ClassCastException

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -328,7 +328,8 @@ object StructType extends AbstractDataType {
   def apply(fields: Seq[StructField]): StructType = StructType(fields.toArray)
 
   def apply(fields: java.util.List[StructField]): StructType = {
-    StructType(fields.toArray.asInstanceOf[Array[StructField]])
+    val temp = new Array[StructField](0)
+    StructType(fields.toArray(temp))
   }
 
   protected[sql] def fromAttributes(attributes: Seq[Attribute]): StructType =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -328,8 +328,8 @@ object StructType extends AbstractDataType {
   def apply(fields: Seq[StructField]): StructType = StructType(fields.toArray)
 
   def apply(fields: java.util.List[StructField]): StructType = {
-    val temp = new Array[StructField](0)
-    StructType(fields.toArray(temp))
+    import scala.collection.JavaConverters._
+    StructType(fields.asScala)
   }
 
   protected[sql] def fromAttributes(attributes: Seq[Attribute]): StructType =

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
@@ -18,10 +18,7 @@
 package test.org.apache.spark.sql;
 
 import java.io.Serializable;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
@@ -211,8 +208,14 @@ public class JavaDataFrameSuite {
 
   @Test
   public void testCreateStructTypeFromList(){
-    StructType schema = StructType$.MODULE$.apply(Arrays.asList(createStructField("i", IntegerType, true)));
-    Assert.assertEquals(0, schema.fieldIndex("i"));
+    List<StructField> f_1 = new ArrayList<>();
+    f_1.add(new StructField("id", DataTypes.StringType, true, Metadata.empty()));
+    StructType schema1 = StructType$.MODULE$.apply(f_1);
+    Assert.assertEquals(0, schema1.fieldIndex("id"));
+
+    List<StructField> f_2 = Arrays.asList(new StructField("id", DataTypes.StringType, true, Metadata.empty()));
+    StructType schema2 = StructType$.MODULE$.apply(f_2);
+    Assert.assertEquals(0, schema2.fieldIndex("id"));
   }
 
   private static final Comparator<Row> crosstabRowComparator = new Comparator<Row>() {

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
@@ -18,7 +18,11 @@
 package test.org.apache.spark.sql;
 
 import java.io.Serializable;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.ArrayList;
 
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
@@ -208,13 +212,13 @@ public class JavaDataFrameSuite {
 
   @Test
   public void testCreateStructTypeFromList(){
-    List<StructField> f_1 = new ArrayList<>();
-    f_1.add(new StructField("id", DataTypes.StringType, true, Metadata.empty()));
-    StructType schema1 = StructType$.MODULE$.apply(f_1);
+    List<StructField> fields1 = new ArrayList<>();
+    fields1.add(new StructField("id", DataTypes.StringType, true, Metadata.empty()));
+    StructType schema1 = StructType$.MODULE$.apply(fields1);
     Assert.assertEquals(0, schema1.fieldIndex("id"));
 
-    List<StructField> f_2 = Arrays.asList(new StructField("id", DataTypes.StringType, true, Metadata.empty()));
-    StructType schema2 = StructType$.MODULE$.apply(f_2);
+    List<StructField> fields2 = Arrays.asList(new StructField("id", DataTypes.StringType, true, Metadata.empty()));
+    StructType schema2 = StructType$.MODULE$.apply(fields2);
     Assert.assertEquals(0, schema2.fieldIndex("id"));
   }
 

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
@@ -209,6 +209,12 @@ public class JavaDataFrameSuite {
     Assert.assertEquals(1, result.length);
   }
 
+  @Test
+  public void testCreateStructTypeFromList(){
+    StructType schema = StructType$.MODULE$.apply(Arrays.asList(createStructField("i", IntegerType, true)));
+    Assert.assertEquals(0, schema.fieldIndex("i"));
+  }
+
   private static final Comparator<Row> crosstabRowComparator = new Comparator<Row>() {
     @Override
     public int compare(Row row1, Row row2) {


### PR DESCRIPTION
In the previous method, fields.toArray will cast java.util.List[StructField] into Array[Object] which can not cast into Array[StructField], thus when invoking this method will throw "java.lang.ClassCastException: [Ljava.lang.Object; cannot be cast to [Lorg.apache.spark.sql.types.StructField;"
I directly cast java.util.List[StructField] into Array[StructField]  in this patch.
