### PR TITLE
[SPARK-11583] [Core]MapStatus Using RoaringBitmap More Properly

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -174,6 +174,11 @@
       <artifactId>lz4</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.roaringbitmap</groupId>
+      <artifactId>RoaringBitmap</artifactId>
+      <version>0.4.5</version>
+    </dependency>
+    <dependency>
       <groupId>commons-net</groupId>
       <artifactId>commons-net</artifactId>
     </dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -176,7 +176,6 @@
     <dependency>
       <groupId>org.roaringbitmap</groupId>
       <artifactId>RoaringBitmap</artifactId>
-      <version>0.4.5</version>
     </dependency>
     <dependency>
       <groupId>commons-net</groupId>

--- a/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/MapStatus.scala
@@ -175,7 +175,6 @@ private[spark] object HighlyCompressedMapStatus {
     var i = 0
     var numNonEmptyBlocks: Int = 0
     var totalSize: Long = 0
-
     val emptyBlocks = new RoaringBitmap()
     val nonEmptyBlocks = new RoaringBitmap()
     val totalNumBlocks = uncompressedSizes.length
@@ -196,14 +195,15 @@ private[spark] object HighlyCompressedMapStatus {
       0
     }
     if (numNonEmptyBlocks < totalNumBlocks / 2) {
-      // If non-empty blocks are sparse, we track non-empty blocks and set `isSparse` to true.
+      // If non-empty blocks are sparse, we track non-empty blocks and set `isSparse` true.
       nonEmptyBlocks.runOptimize()
+      nonEmptyBlocks.trim()
       new HighlyCompressedMapStatus(loc, numNonEmptyBlocks, nonEmptyBlocks, avgSize, isSparse = true)
     } else {
-      // If non-empty blocks are dense, we track empty blocks and set `isSparse` to false.
+      // If non-empty blocks are dense, we track empty blocks and set `isSparse` false.
       emptyBlocks.runOptimize()
+      emptyBlocks.trim()
       new HighlyCompressedMapStatus(loc, numNonEmptyBlocks, emptyBlocks, avgSize, isSparse = false)
     }
-
   }
 }

--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -21,26 +21,24 @@ import java.io.{EOFException, IOException, InputStream, OutputStream}
 import java.nio.ByteBuffer
 import javax.annotation.Nullable
 
-import org.roaringbitmap.{BitmapContainer, RoaringBitmap, RoaringArray, ArrayContainer}
-
-import scala.collection.JavaConverters._
-import scala.collection.mutable.ArrayBuffer
-import scala.reflect.ClassTag
-
-import com.esotericsoftware.kryo.{Kryo, KryoException}
 import com.esotericsoftware.kryo.io.{Input => KryoInput, Output => KryoOutput}
 import com.esotericsoftware.kryo.serializers.{JavaSerializer => KryoJavaSerializer}
+import com.esotericsoftware.kryo.{Kryo, KryoException}
 import com.twitter.chill.{AllScalaRegistrar, EmptyScalaKryoInstantiator}
 import org.apache.avro.generic.{GenericData, GenericRecord}
-
 import org.apache.spark._
 import org.apache.spark.api.python.PythonBroadcast
 import org.apache.spark.broadcast.HttpBroadcast
 import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.scheduler.{CompressedMapStatus, HighlyCompressedMapStatus}
 import org.apache.spark.storage._
-import org.apache.spark.util.{Utils, BoundedPriorityQueue, SerializableConfiguration, SerializableJobConf}
 import org.apache.spark.util.collection.{BitSet, CompactBuffer}
+import org.apache.spark.util.{BoundedPriorityQueue, SerializableConfiguration, SerializableJobConf, Utils}
+import org.roaringbitmap.RoaringBitmap
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
+import scala.reflect.ClassTag
 
 /**
  * A Spark serializer that uses the [[https://code.google.com/p/kryo/ Kryo serialization library]].
@@ -365,11 +363,6 @@ private[serializer] object KryoSerializer {
     classOf[CompressedMapStatus],
     classOf[HighlyCompressedMapStatus],
     classOf[RoaringBitmap],
-    classOf[RoaringArray],
-    classOf[RoaringArray.Element],
-    classOf[Array[RoaringArray.Element]],
-    classOf[ArrayContainer],
-    classOf[BitmapContainer],
     classOf[BitSet],
     classOf[CompactBuffer[_]],
     classOf[BlockManagerId],

--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -34,7 +34,7 @@ import org.apache.spark.scheduler.{CompressedMapStatus, HighlyCompressedMapStatu
 import org.apache.spark.storage._
 import org.apache.spark.util.collection.{BitSet, CompactBuffer}
 import org.apache.spark.util.{BoundedPriorityQueue, SerializableConfiguration, SerializableJobConf, Utils}
-import org.roaringbitmap.RoaringBitmap
+import org.roaringbitmap._
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
@@ -363,6 +363,11 @@ private[serializer] object KryoSerializer {
     classOf[CompressedMapStatus],
     classOf[HighlyCompressedMapStatus],
     classOf[RoaringBitmap],
+    classOf[RoaringArray],
+    classOf[Array[Container]],
+    classOf[ArrayContainer],
+    classOf[BitmapContainer],
+    classOf[RunContainer],
     classOf[BitSet],
     classOf[CompactBuffer[_]],
     classOf[BlockManagerId],

--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -21,6 +21,8 @@ import java.io.{EOFException, IOException, InputStream, OutputStream}
 import java.nio.ByteBuffer
 import javax.annotation.Nullable
 
+import org.roaringbitmap.{BitmapContainer, RoaringBitmap, RoaringArray, ArrayContainer}
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
@@ -362,6 +364,12 @@ private[serializer] object KryoSerializer {
     classOf[StorageLevel],
     classOf[CompressedMapStatus],
     classOf[HighlyCompressedMapStatus],
+    classOf[RoaringBitmap],
+    classOf[RoaringArray],
+    classOf[RoaringArray.Element],
+    classOf[Array[RoaringArray.Element]],
+    classOf[ArrayContainer],
+    classOf[BitmapContainer],
     classOf[BitSet],
     classOf[CompactBuffer[_]],
     classOf[BlockManagerId],

--- a/core/src/test/scala/org/apache/spark/scheduler/MapStatusSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/MapStatusSuite.scala
@@ -101,10 +101,11 @@ class MapStatusSuite extends SparkFunSuite {
 
   test("RoaringBitmap: runOptimize succeeded") {
     val r = new RoaringBitmap
-    for (i <- 1 to 200000) {
-      if(i % 200 != 0)
+    (1 to 200000).foreach(i =>
+      if (i % 200 != 0) {
         r.add(i)
-    }
+      }
+    )
     val size1 = r.getSizeInBytes
     val success = r.runOptimize()
     r.trim()
@@ -115,10 +116,11 @@ class MapStatusSuite extends SparkFunSuite {
 
   test("RoaringBitmap: runOptimize failed") {
     val r = new RoaringBitmap
-    for (i <- 1 to 200000) {
-      if(i % 200 == 0)
+    (1 to 200000).foreach(i =>
+      if (i % 200 == 0) {
         r.add(i)
-    }
+      }
+    )
     val size1 = r.getSizeInBytes
     val success = r.runOptimize()
     r.trim()

--- a/core/src/test/scala/org/apache/spark/scheduler/MapStatusSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/MapStatusSuite.scala
@@ -21,6 +21,7 @@ import org.apache.spark.storage.BlockManagerId
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.serializer.JavaSerializer
+import org.roaringbitmap.RoaringBitmap
 
 import scala.util.Random
 
@@ -96,5 +97,33 @@ class MapStatusSuite extends SparkFunSuite {
     val ser = new JavaSerializer(new SparkConf)
     val buf = ser.newInstance().serialize(status)
     ser.newInstance().deserialize[MapStatus](buf)
+  }
+
+  test("RoaringBitmap: runOptimize succeeded") {
+    val r = new RoaringBitmap
+    for (i <- 1 to 200000) {
+      if(i % 200 != 0)
+        r.add(i)
+    }
+    val size1 = r.getSizeInBytes
+    val success = r.runOptimize()
+    r.trim()
+    val size2 = r.getSizeInBytes
+    assert(size1 > size2)
+    assert(success)
+  }
+
+  test("RoaringBitmap: runOptimize failed") {
+    val r = new RoaringBitmap
+    for (i <- 1 to 200000) {
+      if(i % 200 == 0)
+        r.add(i)
+    }
+    val size1 = r.getSizeInBytes
+    val success = r.runOptimize()
+    r.trim()
+    val size2 = r.getSizeInBytes
+    assert(size1 === size2)
+    assert(!success)
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -624,6 +624,11 @@
         </exclusions>
       </dependency>
       <dependency>
+        <groupId>org.roaringbitmap</groupId>
+        <artifactId>RoaringBitmap</artifactId>
+        <version>0.4.5</version>
+      </dependency>
+      <dependency>
         <groupId>commons-net</groupId>
         <artifactId>commons-net</artifactId>
         <version>2.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -626,7 +626,7 @@
       <dependency>
         <groupId>org.roaringbitmap</groupId>
         <artifactId>RoaringBitmap</artifactId>
-        <version>0.4.5</version>
+        <version>0.5.10</version>
       </dependency>
       <dependency>
         <groupId>commons-net</groupId>


### PR DESCRIPTION
# ---------------Part I----------------
## test cases BitSet v.s. RoaringBitmap
#### sparse case: for each task 10 blocks contains data, others dont

``` scala
sc.makeRDD(1 to 40950, 4095).groupBy(x=>x).top(5)
```
#### dense case: for each task most block contains data, few dont

``` scala
sc.makeRDD(1 to 16769025, 4095).groupBy(x=>x).top(5)
sc.makeRDD(1 to 16380000, 4095).groupBy(x=>x).top(5)
```
#### test tool

``` shell
jmap -dump:format=b,file=heap.bin <pid>
```
#### test branches:

 branch-1.5, master
## memory usage

2.1 RoaringBitmap--sparse
Class Name                                                                        | Objects | Shallow Heap | Retained Heap

org.apache.spark.scheduler.HighlyCompressedMapStatus| 4,095    |  131,040          | >= 34,135,920

my explaination: 4095 \* short[4095-10] =4095 \* 16 \* 4085 / 8 ≈ 34,135,920

2.2.1 RoaringBitmap--full

org.apache.spark.scheduler.HighlyCompressedMapStatus| 4,095     | 131,040           | >= 360,360 

my explaination：RoaringBitmap(0)

2.2.2 RoaringBitmap--very dense

org.apache.spark.scheduler.HighlyCompressedMapStatus| 4,095      | 131,040           | >= 1,441,440

my explaination：4095 \* short[95] = 4095 \* 16 \* 95 / 8 = 778, 050 (+ others = 1441440)

2.3 BitSet--sparse

org.apache.spark.scheduler.HighlyCompressedMapStatus| 4,095       | 131,040          | >= 2,391,480

my explaination：4095 \* 4095 =16,769,025 + (others = 2,391,480)

2.4 BitSet--full

org.apache.spark.scheduler.HighlyCompressedMapStatus| 4,095       | 131,040         | >= 2,391,480

my explaination：same as the above
## conclusion

memory usage:( Retained Heap)
RoaringBitmap--full < RoaringBitmap--very dense < BitSet---full = BitSet--sparse < RoaringBitmap--sparse

In this specific case, for  RoaringBitmap--sparse, use RoaringBitmap to mark non-empty blocks instead of empty ones. In this way, memory usage can stay low in all cases.
# ---------------Part II----------------
## test cases

sparse case: 4085 empty ---    _S_

``` scala
sc.makeRDD(1 to 40950, 4095).groupBy(x=>x).top(5)
```

dense case: 95 empty   ----    _D_

``` scala
sc.makeRDD(1 to 16380000, 4095).groupBy(x=>x).top(5)
```
## test result
#### 1 without `runOptimize` or `trim`

| case | Class Name | Objects | Shallow Heap | Retained Heap |
| --- | --- | --- | --- | --- |
| _S_ | HighlyCompressedMapStatus | 4,095 | 131,040 | >= 34,135,920 |
| _D_ | HighlyCompressedMapStatus | 4,095 | 131,040 | >= 1,441,440 |
#### 2 with `runOptimze` and `trim`

| case | Class Name | Objects | Shallow Heap | Retained Heap |
| --- | --- | --- | --- | --- |
| _S_ | HighlyCompressedMapStatus | 4,095 | 131,040 | >= 687,960 |
| _D_ | HighlyCompressedMapStatus | 4,095 | 131,040 | >= 687,960 |
#### 3 with `runOptinize` and `trim`, also `isSparse`

| case | Class Name | Objects | Shallow Heap | Retained Heap |
| --- | --- | --- | --- | --- |
| _S_ | HighlyCompressedMapStatus | 4,095 | 131,040 | >= 687,960 |
| _D_ | HighlyCompressedMapStatus | 4,095 | 131,040 | >= 687,960 |
## conclusion
1. with `runOptimize`,  roaing saves a lot, especially in  _S_
2. after `runOptimize`,  separating sparse case seems not necessary in this 4095bit test
3. what if 100k, 200k bits? Is runOptimize OK? Or use my `separating sparse case` idea?
      ---- i don't have an env for such large tasks   (HELP!)
# ---------------Part III----------------

For my questions in my last comment
### continuous

``` scala
scala> import org.roaringbitmap._
import org.roaringbitmap._

scala> val r = new RoaringBitmap()
r: org.roaringbitmap.RoaringBitmap = {}

scala> for (i <- 1 to 2000000)  r.add(i)

scala> r.runOptimize
res1: Boolean = true

scala> r.contains(2000000)
res2: Boolean = true
```

| bits | original size | opitimized size |
| --- | --- | --- |
| 200K | 33,056 | 328 |
| 2M | 255,472 | 1,768 |
### uncontinuous

``` scala
scala> import org.roaringbitmap._
import org.roaringbitmap._

scala> val r = new RoaringBitmap()
r: org.roaringbitmap.RoaringBitmap = {}

scala> for (i <- 1 to 2000000) if(i%10==0) r.add(i)

scala> r.runOptimize
res1: Boolean = false

scala> r.trim

scala> r.contains(2000000)
res2: Boolean = true
```

| bits | original size | opitimized size | trimed size |
| --- | --- | --- | --- |
| 200K | 255,472 | 255,472 | 254,072 |
| 2M | 2,516,688 | 2,516,688 | 2,516,272 |
### conclusion

In `uncontinuous`, `runOptimize` failed and the size after `r.trim` neither became smaller as  in `continuous`
