### PR TITLE
[SPARK-11290][STREAMING][test-maven] Fix the test for maven build

### DIFF
--- a/streaming/src/test/scala/org/apache/spark/streaming/rdd/TrackStateRDDSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/rdd/TrackStateRDDSuite.scala
@@ -28,11 +28,17 @@ import org.apache.spark.{HashPartitioner, SparkConf, SparkContext, SparkFunSuite
 
 class TrackStateRDDSuite extends SparkFunSuite with BeforeAndAfterAll {
 
-  private var sc = new SparkContext(
-    new SparkConf().setMaster("local").setAppName("TrackStateRDDSuite"))
+  private var sc: SparkContext = null
+
+  override def beforeAll(): Unit = {
+    sc = new SparkContext(
+      new SparkConf().setMaster("local").setAppName("TrackStateRDDSuite"))
+  }
 
   override def afterAll(): Unit = {
-    sc.stop()
+    if (sc != null) {
+      sc.stop()
+    }
   }
 
   test("creation from pair RDD") {


### PR DESCRIPTION
Should not create SparkContext in the constructor of `TrackStateRDDSuite`. This is a follow up PR for #9256 to fix the test for maven build. 
