### PR TITLE
[SPARK-10086] [PySpark] [MLlib] [Streaming] [Tests] Fix flaky StreamingKMeans PySpark test 

### DIFF
--- a/python/pyspark/mllib/tests.py
+++ b/python/pyspark/mllib/tests.py
@@ -1174,7 +1174,7 @@ class StreamingKMeansTest(MLLibStreamingTestCase):
         # proving that the model is updated.
         batches = [[[-0.5], [0.6], [0.8]], [[0.2], [-0.1], [0.3]]]
         batches = [sc.parallelize(batch) for batch in batches]
-        input_stream = self.ssc.queueStream(batches)
+        input_stream = self.ssc.queueStream(batches, default=batches[1])
         predict_results = []
 
         def collect(rdd):
@@ -1189,7 +1189,9 @@ class StreamingKMeansTest(MLLibStreamingTestCase):
         self.ssc.start()
 
         def condition():
-            self.assertEqual(predict_results, [[0, 1, 1], [1, 0, 1]])
+            self.assertTrue(predict_results)
+            self.assertEqual(predict_results[0], [0, 1, 1])
+            self.assertEqual(predict_results[-1], [1, 0, 1])
             return True
 
         self._eventually(condition, catch_assertions=True)


### PR DESCRIPTION
The test sometimes fails because `predictOn` would occur before `trainOn` with the input stream.  This test is testing that the model gets updated and is able to predict correctly with the updated model.  This fix allows more flexibility about when the update happens by repeating the final batch as the default RDD in the queueStream and checking that the last result matches the expected prediction of the updated model, within a timeout.
