### PR TITLE
[SPARK-11699] TrackStateRDDSuite fails on Jenkins builds

### DIFF
--- a/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleManager.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleManager.scala
@@ -88,7 +88,8 @@ private[spark] class SortShuffleManager(conf: SparkConf) extends ShuffleManager 
       shuffleId: Int,
       numMaps: Int,
       dependency: ShuffleDependency[K, V, C]): ShuffleHandle = {
-    if (SortShuffleWriter.shouldBypassMergeSort(SparkEnv.get.conf, dependency)) {
+    if (SparkEnv.get != null &&
+      SortShuffleWriter.shouldBypassMergeSort(SparkEnv.get.conf, dependency)) {
       // If there are fewer than spark.shuffle.sort.bypassMergeThreshold partitions and we don't
       // need map-side aggregation, then write numPartitions files directly and just concatenate
       // them at the end. This avoids doing serialization and deserialization twice to merge


### PR DESCRIPTION
Here is the stack trace:

```
java.lang.NullPointerException
      at org.apache.spark.shuffle.sort.SortShuffleManager.registerShuffle(SortShuffleManager.scala:91)
      at org.apache.spark.ShuffleDependency.<init>(Dependency.scala:90)
      at org.apache.spark.rdd.ShuffledRDD.getDependencies(ShuffledRDD.scala:80)
      at org.apache.spark.rdd.RDD$$anonfun$dependencies$2.apply(RDD.scala:226)
      at org.apache.spark.rdd.RDD$$anonfun$dependencies$2.apply(RDD.scala:224)
      at scala.Option.getOrElse(Option.scala:120)
      at org.apache.spark.rdd.RDD.dependencies(RDD.scala:224)
      at org.apache.spark.scheduler.DAGScheduler.visit$1(DAGScheduler.scala:386)
      at org.apache.spark.scheduler.DAGScheduler.getParentStages(DAGScheduler.scala:398)
      at org.apache.spark.scheduler.DAGScheduler.getParentStagesAndId(DAGScheduler.scala:299)
      at org.apache.spark.scheduler.DAGScheduler.newResultStage(DAGScheduler.scala:334)
      at org.apache.spark.scheduler.DAGScheduler.handleJobSubmitted(DAGScheduler.scala:836)
      at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.doOnReceive(DAGScheduler.scala:1607)
      at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:1599)
      at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:1588)
```
