### PR TITLE
[SPARK-11717] Ignore R session and history files from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,7 @@ metastore/
 warehouse/
 TempStatsStore/
 sql/hive-thriftserver/test_warehouses
+
+# For R session data
+.RHistory
+.RData


### PR DESCRIPTION
see: https://issues.apache.org/jira/browse/SPARK-11717

SparkR generates R session data and history files under current directory.
It might be useful to ignore these files even running SparkR on spark directory for test or development.
