### PR TITLE
[SPARK-11735] [SQL] Add a check in the constructor of SQLContext to make sure its SparkContext is not stopped

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -94,7 +94,7 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
 
   private[spark] val stopped: AtomicBoolean = new AtomicBoolean(false)
 
-  private def assertNotStopped(): Unit = {
+  private[spark] def assertNotStopped(): Unit = {
     if (stopped.get()) {
       val activeContext = SparkContext.activeContext.get()
       val activeCreationSite =

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -105,6 +105,8 @@ object MimaExcludes {
       ) ++ Seq(
         ProblemFilters.exclude[MissingMethodProblem](
           "org.apache.spark.SparkContext.preferredNodeLocationData_="),
+        ProblemFilters.exclude[MissingMethodProblem](
+          "org.apache.spark.SparkContext.org$apache$spark$SparkContext$$assertNotStopped"),
         ProblemFilters.exclude[MissingClassProblem](
           "org.apache.spark.rdd.MapPartitionsWithPreparationRDD"),
         ProblemFilters.exclude[MissingClassProblem](

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -78,6 +78,9 @@ class SQLContext private[sql](
   }
   def this(sparkContext: JavaSparkContext) = this(sparkContext.sc)
 
+  // Make sure the sparkContext we have at here is not stopped.
+  sparkContext.assertNotStopped()
+
   // If spark.sql.allowMultipleContexts is true, we will throw an exception if a user
   // wants to create a new root SQLContext (a SLQContext that is not created by newSession).
   private val allowMultipleContexts =


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-11735
