### PR TITLE
[MINOR] [Build] Ignore ensime cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ spark-tests.log
 streaming-tests.log
 dependency-reduced-pom.xml
 .ensime
+.ensime_cache/
 .ensime_lucene
 checkpoint
 derby.log


### PR DESCRIPTION
Using ENSIME, I often have `.ensime_cache` polluting my source tree. This PR simply adds the cache directory to `.gitignore`
