### PR TITLE
SPARK-11741 Process doctests using TextTestRunner/XMLTestRunner

### DIFF
--- a/python/pyspark/accumulators.py
+++ b/python/pyspark/accumulators.py
@@ -25,19 +25,6 @@ else:
 import threading
 from pyspark.cloudpickle import CloudPickler
 from pyspark.serializers import read_int, PickleSerializer
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
-import doctest
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
 
 
 __all__ = ['Accumulator', 'AccumulatorParam']
@@ -275,11 +262,7 @@ def _start_update_server():
     return server
 
 if __name__ == "__main__":
-    t = doctest.DocTestSuite()
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    from pyspark.doctesthelper import run_doctests
+    result = run_doctests(__file__)
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/broadcast.py
+++ b/python/pyspark/broadcast.py
@@ -19,6 +19,18 @@ import os
 import sys
 import gc
 from tempfile import NamedTemporaryFile
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
 
 if sys.version < '3':
     import cPickle as pickle
@@ -115,6 +127,11 @@ class Broadcast(object):
 
 if __name__ == "__main__":
     import doctest
-    (failure_count, test_count) = doctest.testmod()
-    if failure_count:
+    t = doctest.DocTestSuite()
+    if xmlrunner:
+        result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                         verbosity=3).run(t)
+    else:
+        result = unittest.TextTestRunner(verbosity=3).run(t)
+    if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/broadcast.py
+++ b/python/pyspark/broadcast.py
@@ -19,18 +19,6 @@ import os
 import sys
 import gc
 from tempfile import NamedTemporaryFile
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 if sys.version < '3':
     import cPickle as pickle
@@ -126,12 +114,7 @@ class Broadcast(object):
 
 
 if __name__ == "__main__":
-    import doctest
-    t = doctest.DocTestSuite()
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    from pyspark.doctesthelper import run_doctests
+    result = run_doctests(__file__)
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/conf.py
+++ b/python/pyspark/conf.py
@@ -19,18 +19,6 @@ __all__ = ['SparkConf']
 
 import sys
 import re
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 if sys.version > '3':
     unicode = str
@@ -194,12 +182,8 @@ class SparkConf(object):
 
 def _test():
     import doctest
-    t = doctest.DocTestSuite(optionflags=doctest.ELLIPSIS)
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    from pyspark.doctesthelper import run_doctests
+    result = run_doctests(__file__, optionflags=doctest.ELLIPSIS)
     if not result.wasSuccessful():
         exit(-1)
 

--- a/python/pyspark/conf.py
+++ b/python/pyspark/conf.py
@@ -15,49 +15,22 @@
 # limitations under the License.
 #
 
-"""
->>> from pyspark.conf import SparkConf
->>> from pyspark.context import SparkContext
->>> conf = SparkConf()
->>> conf.setMaster("local").setAppName("My app")
-<pyspark.conf.SparkConf object at ...>
->>> conf.get("spark.master")
-u'local'
->>> conf.get("spark.app.name")
-u'My app'
->>> sc = SparkContext(conf=conf)
->>> sc.master
-u'local'
->>> sc.appName
-u'My app'
->>> sc.sparkHome is None
-True
-
->>> conf = SparkConf(loadDefaults=False)
->>> conf.setSparkHome("/path")
-<pyspark.conf.SparkConf object at ...>
->>> conf.get("spark.home")
-u'/path'
->>> conf.setExecutorEnv("VAR1", "value1")
-<pyspark.conf.SparkConf object at ...>
->>> conf.setExecutorEnv(pairs = [("VAR3", "value3"), ("VAR4", "value4")])
-<pyspark.conf.SparkConf object at ...>
->>> conf.get("spark.executorEnv.VAR1")
-u'value1'
->>> print(conf.toDebugString())
-spark.executorEnv.VAR1=value1
-spark.executorEnv.VAR3=value3
-spark.executorEnv.VAR4=value4
-spark.home=/path
->>> sorted(conf.getAll(), key=lambda p: p[0])
-[(u'spark.executorEnv.VAR1', u'value1'), (u'spark.executorEnv.VAR3', u'value3'), \
-(u'spark.executorEnv.VAR4', u'value4'), (u'spark.home', u'/path')]
-"""
-
 __all__ = ['SparkConf']
 
 import sys
 import re
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
 
 if sys.version > '3':
     unicode = str
@@ -84,6 +57,45 @@ class SparkConf(object):
 
     Note that once a SparkConf object is passed to Spark, it is cloned
     and can no longer be modified by the user.
+    """
+
+    """
+    >>> from pyspark.conf import SparkConf
+    >>> from pyspark.context import SparkContext
+    >>> conf = SparkConf()
+    >>> conf.setMaster("local").setAppName("My app")
+    <pyspark.conf.SparkConf object at ...>
+    >>> conf.get("spark.master")
+    u'local'
+    >>> conf.get("spark.app.name")
+    u'My app'
+    >>> sc = SparkContext(conf=conf)
+    >>> sc.master
+    u'local'
+    >>> sc.appName
+    u'My app'
+    >>> sc.sparkHome is None
+    True
+
+    >>> conf = SparkConf(loadDefaults=False)
+    >>> conf.setSparkHome("/path")
+    <pyspark.conf.SparkConf object at ...>
+    >>> conf.get("spark.home")
+    u'/path'
+    >>> conf.setExecutorEnv("VAR1", "value1")
+    <pyspark.conf.SparkConf object at ...>
+    >>> conf.setExecutorEnv(pairs = [("VAR3", "value3"), ("VAR4", "value4")])
+    <pyspark.conf.SparkConf object at ...>
+    >>> conf.get("spark.executorEnv.VAR1")
+    u'value1'
+    >>> print(conf.toDebugString())
+    spark.executorEnv.VAR1=value1
+    spark.executorEnv.VAR3=value3
+    spark.executorEnv.VAR4=value4
+    spark.home=/path
+    >>> sorted(conf.getAll(), key=lambda p: p[0])
+    [(u'spark.executorEnv.VAR1', u'value1'), (u'spark.executorEnv.VAR3', u'value3'), \
+    (u'spark.executorEnv.VAR4', u'value4'), (u'spark.home', u'/path')]
     """
 
     def __init__(self, loadDefaults=True, _jvm=None, _jconf=None):
@@ -182,8 +194,13 @@ class SparkConf(object):
 
 def _test():
     import doctest
-    (failure_count, test_count) = doctest.testmod(optionflags=doctest.ELLIPSIS)
-    if failure_count:
+    t = doctest.DocTestSuite(optionflags=doctest.ELLIPSIS)
+    if xmlrunner:
+        result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                         verbosity=3).run(t)
+    else:
+        result = unittest.TextTestRunner(verbosity=3).run(t)
+    if not result.wasSuccessful():
         exit(-1)
 
 

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -24,18 +24,6 @@ import sys
 import threading
 from threading import RLock
 from tempfile import NamedTemporaryFile
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 from pyspark import accumulators
 from pyspark.accumulators import Accumulator
@@ -963,18 +951,15 @@ class SparkContext(object):
 
 def _test():
     import atexit
+    from pyspark.doctesthelper import run_doctests
     import doctest
     import tempfile
     globs = globals().copy()
     globs['sc'] = SparkContext('local[4]', 'PythonTest')
     globs['tempdir'] = tempfile.mkdtemp()
     atexit.register(lambda: shutil.rmtree(globs['tempdir']))
-    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    result = run_doctests(__file__, globs=globs,
+                          optionflags=doctest.ELLIPSIS)
     globs['sc'].stop()
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -24,6 +24,18 @@ import sys
 import threading
 from threading import RLock
 from tempfile import NamedTemporaryFile
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
 
 from pyspark import accumulators
 from pyspark.accumulators import Accumulator
@@ -957,9 +969,14 @@ def _test():
     globs['sc'] = SparkContext('local[4]', 'PythonTest')
     globs['tempdir'] = tempfile.mkdtemp()
     atexit.register(lambda: shutil.rmtree(globs['tempdir']))
-    (failure_count, test_count) = doctest.testmod(globs=globs, optionflags=doctest.ELLIPSIS)
+    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
+    if xmlrunner:
+        result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                         verbosity=3).run(t)
+    else:
+        result = unittest.TextTestRunner(verbosity=3).run(t)
     globs['sc'].stop()
-    if failure_count:
+    if not result.wasSuccessful():
         exit(-1)
 
 

--- a/python/pyspark/doctesthelper.py
+++ b/python/pyspark/doctesthelper.py
@@ -31,7 +31,7 @@ except ImportError:
     xmlrunner = None
 
 
-def run_doctests(file_name, globs={}, optionflags=None):
+def run_doctests(file_name, globs={}, optionflags=0):
     t = doctest.DocFileSuite(file_name, module_relative=False,
                              globs=globs, optionflags=optionflags)
     if xmlrunner:

--- a/python/pyspark/doctesthelper.py
+++ b/python/pyspark/doctesthelper.py
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import sys
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
+import doctest
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+
+
+def run_doctests(file_name, globs={}, optionflags=None):
+    t = doctest.DocFileSuite(file_name, module_relative=False,
+                             globs=globs, optionflags=optionflags)
+    if xmlrunner:
+        return xmlrunner.XMLTestRunner(output='target/test-reports',
+                                       verbosity=3).run(t)
+    else:
+        return unittest.TextTestRunner(verbosity=3).run(t)

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -17,18 +17,6 @@
 
 import warnings
 import sys
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 from pyspark import since
 from pyspark.ml.util import *
@@ -891,6 +879,7 @@ class MultilayerPerceptronClassificationModel(JavaModel):
 if __name__ == "__main__":
     import doctest
     import pyspark.ml.classification
+    from pyspark.doctesthelper import run_doctests
     from pyspark.context import SparkContext
     from pyspark.sql import SQLContext
     import tempfile
@@ -904,12 +893,8 @@ if __name__ == "__main__":
     temp_path = tempfile.mkdtemp()
     globs['temp_path'] = temp_path
     try:
-        t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
-        if xmlrunner:
-            result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                             verbosity=3).run(t)
-        else:
-            result = unittest.TextTestRunner(verbosity=3).run(t)
+        result = run_doctests(__file__, globs=globs,
+                              optionflags=doctest.ELLIPSIS)
         sc.stop()
     finally:
         from shutil import rmtree

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -16,6 +16,19 @@
 #
 
 import warnings
+import sys
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
 
 from pyspark import since
 from pyspark.ml.util import *
@@ -880,6 +893,7 @@ if __name__ == "__main__":
     import pyspark.ml.classification
     from pyspark.context import SparkContext
     from pyspark.sql import SQLContext
+    import tempfile
     globs = pyspark.ml.classification.__dict__.copy()
     # The small batch size here ensures that we see multiple batches,
     # even in these small test examples:
@@ -887,11 +901,15 @@ if __name__ == "__main__":
     sqlContext = SQLContext(sc)
     globs['sc'] = sc
     globs['sqlContext'] = sqlContext
-    import tempfile
     temp_path = tempfile.mkdtemp()
     globs['temp_path'] = temp_path
     try:
-        (failure_count, test_count) = doctest.testmod(globs=globs, optionflags=doctest.ELLIPSIS)
+        t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
+        if xmlrunner:
+            result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                             verbosity=3).run(t)
+        else:
+            result = unittest.TextTestRunner(verbosity=3).run(t)
         sc.stop()
     finally:
         from shutil import rmtree
@@ -899,5 +917,5 @@ if __name__ == "__main__":
             rmtree(temp_path)
         except OSError:
             pass
-    if failure_count:
+    if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -15,19 +15,6 @@
 # limitations under the License.
 #
 
-import sys
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 from pyspark import since
 from pyspark.ml.util import *
@@ -309,6 +296,7 @@ class BisectingKMeans(JavaEstimator, HasFeaturesCol, HasPredictionCol, HasMaxIte
 if __name__ == "__main__":
     import doctest
     import pyspark.ml.clustering
+    from pyspark.doctesthelper import run_doctests
     from pyspark.context import SparkContext
     from pyspark.sql import SQLContext
     import tempfile
@@ -322,12 +310,8 @@ if __name__ == "__main__":
     temp_path = tempfile.mkdtemp()
     globs['temp_path'] = temp_path
     try:
-        t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
-        if xmlrunner:
-            result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                             verbosity=3).run(t)
-        else:
-            result = unittest.TextTestRunner(verbosity=3).run(t)
+        result = run_doctests(__file__, globs=globs,
+                              optionflags=doctest.ELLIPSIS)
         sc.stop()
     finally:
         from shutil import rmtree

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -15,6 +15,20 @@
 # limitations under the License.
 #
 
+import sys
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
+
 from pyspark import since
 from pyspark.ml.util import *
 from pyspark.ml.wrapper import JavaEstimator, JavaModel
@@ -297,6 +311,7 @@ if __name__ == "__main__":
     import pyspark.ml.clustering
     from pyspark.context import SparkContext
     from pyspark.sql import SQLContext
+    import tempfile
     globs = pyspark.ml.clustering.__dict__.copy()
     # The small batch size here ensures that we see multiple batches,
     # even in these small test examples:
@@ -304,11 +319,15 @@ if __name__ == "__main__":
     sqlContext = SQLContext(sc)
     globs['sc'] = sc
     globs['sqlContext'] = sqlContext
-    import tempfile
     temp_path = tempfile.mkdtemp()
     globs['temp_path'] = temp_path
     try:
-        (failure_count, test_count) = doctest.testmod(globs=globs, optionflags=doctest.ELLIPSIS)
+        t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
+        if xmlrunner:
+            result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                             verbosity=3).run(t)
+        else:
+            result = unittest.TextTestRunner(verbosity=3).run(t)
         sc.stop()
     finally:
         from shutil import rmtree
@@ -316,5 +335,5 @@ if __name__ == "__main__":
             rmtree(temp_path)
         except OSError:
             pass
-    if failure_count:
+    if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/ml/evaluation.py
+++ b/python/pyspark/ml/evaluation.py
@@ -16,19 +16,6 @@
 #
 
 from abc import abstractmethod, ABCMeta
-import sys
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 from pyspark import since
 from pyspark.ml.wrapper import JavaWrapper
@@ -319,6 +306,7 @@ class MulticlassClassificationEvaluator(JavaEvaluator, HasLabelCol, HasPredictio
 
 if __name__ == "__main__":
     import doctest
+    from pyspark.doctesthelper import run_doctests
     from pyspark.context import SparkContext
     from pyspark.sql import SQLContext
     globs = globals().copy()
@@ -328,12 +316,8 @@ if __name__ == "__main__":
     sqlContext = SQLContext(sc)
     globs['sc'] = sc
     globs['sqlContext'] = sqlContext
-    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    result = run_doctests(__file__, globs=globs,
+                          optionflags=doctest.ELLIPSIS)
     sc.stop()
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/ml/evaluation.py
+++ b/python/pyspark/ml/evaluation.py
@@ -16,6 +16,19 @@
 #
 
 from abc import abstractmethod, ABCMeta
+import sys
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
 
 from pyspark import since
 from pyspark.ml.wrapper import JavaWrapper
@@ -315,8 +328,12 @@ if __name__ == "__main__":
     sqlContext = SQLContext(sc)
     globs['sc'] = sc
     globs['sqlContext'] = sqlContext
-    (failure_count, test_count) = doctest.testmod(
-        globs=globs, optionflags=doctest.ELLIPSIS)
+    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
+    if xmlrunner:
+        result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                         verbosity=3).run(t)
+    else:
+        result = unittest.TextTestRunner(verbosity=3).run(t)
     sc.stop()
-    if failure_count:
+    if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -16,6 +16,18 @@
 #
 
 import sys
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
 if sys.version > '3':
     basestring = str
 
@@ -2580,7 +2592,12 @@ if __name__ == "__main__":
     temp_path = tempfile.mkdtemp()
     globs['temp_path'] = temp_path
     try:
-        (failure_count, test_count) = doctest.testmod(globs=globs, optionflags=doctest.ELLIPSIS)
+        t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
+        if xmlrunner:
+            result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                             verbosity=3).run(t)
+        else:
+            result = unittest.TextTestRunner(verbosity=3).run(t)
         sc.stop()
     finally:
         from shutil import rmtree
@@ -2588,5 +2605,5 @@ if __name__ == "__main__":
             rmtree(temp_path)
         except OSError:
             pass
-    if failure_count:
+    if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -16,18 +16,6 @@
 #
 
 import sys
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 if sys.version > '3':
     basestring = str
 
@@ -2572,6 +2560,7 @@ if __name__ == "__main__":
     import tempfile
 
     import pyspark.ml.feature
+    from pyspark.doctesthelper import run_doctests
     from pyspark.context import SparkContext
     from pyspark.sql import Row, SQLContext
 
@@ -2592,12 +2581,8 @@ if __name__ == "__main__":
     temp_path = tempfile.mkdtemp()
     globs['temp_path'] = temp_path
     try:
-        t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
-        if xmlrunner:
-            result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                             verbosity=3).run(t)
-        else:
-            result = unittest.TextTestRunner(verbosity=3).run(t)
+        result = run_doctests(__file__, globs=globs,
+                              optionflags=doctest.ELLIPSIS)
         sc.stop()
     finally:
         from shutil import rmtree

--- a/python/pyspark/ml/recommendation.py
+++ b/python/pyspark/ml/recommendation.py
@@ -15,6 +15,20 @@
 # limitations under the License.
 #
 
+import sys
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
+
 from pyspark import since
 from pyspark.ml.util import *
 from pyspark.ml.wrapper import JavaEstimator, JavaModel
@@ -326,6 +340,7 @@ if __name__ == "__main__":
     import pyspark.ml.recommendation
     from pyspark.context import SparkContext
     from pyspark.sql import SQLContext
+    import tempfile
     globs = pyspark.ml.recommendation.__dict__.copy()
     # The small batch size here ensures that we see multiple batches,
     # even in these small test examples:
@@ -333,11 +348,15 @@ if __name__ == "__main__":
     sqlContext = SQLContext(sc)
     globs['sc'] = sc
     globs['sqlContext'] = sqlContext
-    import tempfile
     temp_path = tempfile.mkdtemp()
     globs['temp_path'] = temp_path
     try:
-        (failure_count, test_count) = doctest.testmod(globs=globs, optionflags=doctest.ELLIPSIS)
+        t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
+        if xmlrunner:
+            result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                             verbosity=3).run(t)
+        else:
+            result = unittest.TextTestRunner(verbosity=3).run(t)
         sc.stop()
     finally:
         from shutil import rmtree
@@ -345,5 +364,5 @@ if __name__ == "__main__":
             rmtree(temp_path)
         except OSError:
             pass
-    if failure_count:
+    if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/ml/recommendation.py
+++ b/python/pyspark/ml/recommendation.py
@@ -15,19 +15,6 @@
 # limitations under the License.
 #
 
-import sys
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 from pyspark import since
 from pyspark.ml.util import *
@@ -338,6 +325,7 @@ class ALSModel(JavaModel, MLWritable, MLReadable):
 if __name__ == "__main__":
     import doctest
     import pyspark.ml.recommendation
+    from pyspark.doctesthelper import run_doctests
     from pyspark.context import SparkContext
     from pyspark.sql import SQLContext
     import tempfile
@@ -351,12 +339,8 @@ if __name__ == "__main__":
     temp_path = tempfile.mkdtemp()
     globs['temp_path'] = temp_path
     try:
-        t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
-        if xmlrunner:
-            result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                             verbosity=3).run(t)
-        else:
-            result = unittest.TextTestRunner(verbosity=3).run(t)
+        result = run_doctests(__file__, globs=globs,
+                              optionflags=doctest.ELLIPSIS)
         sc.stop()
     finally:
         from shutil import rmtree

--- a/python/pyspark/ml/regression.py
+++ b/python/pyspark/ml/regression.py
@@ -16,19 +16,6 @@
 #
 
 import warnings
-import sys
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 from pyspark import since
 from pyspark.ml.param.shared import *
@@ -917,6 +904,7 @@ class AFTSurvivalRegressionModel(JavaModel, MLWritable, MLReadable):
 if __name__ == "__main__":
     import doctest
     import pyspark.ml.regression
+    from pyspark.doctesthelper import run_doctests
     from pyspark.context import SparkContext
     from pyspark.sql import SQLContext
     import tempfile
@@ -930,12 +918,8 @@ if __name__ == "__main__":
     temp_path = tempfile.mkdtemp()
     globs['temp_path'] = temp_path
     try:
-        t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
-        if xmlrunner:
-            result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                             verbosity=3).run(t)
-        else:
-            result = unittest.TextTestRunner(verbosity=3).run(t)
+        result = run_doctests(__file__, globs=globs,
+                              optionflags=doctest.ELLIPSIS)
         sc.stop()
     finally:
         from shutil import rmtree

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -17,19 +17,6 @@
 
 import itertools
 import numpy as np
-import sys
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 from pyspark import since
 from pyspark.ml import Estimator, Model
@@ -494,6 +481,7 @@ class TrainValidationSplitModel(Model):
 
 if __name__ == "__main__":
     import doctest
+    from pyspark.doctesthelper import run_doctests
     from pyspark.context import SparkContext
     from pyspark.sql import SQLContext
     globs = globals().copy()
@@ -503,12 +491,8 @@ if __name__ == "__main__":
     sqlContext = SQLContext(sc)
     globs['sc'] = sc
     globs['sqlContext'] = sqlContext
-    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    result = run_doctests(__file__, globs=globs,
+                          optionflags=doctest.ELLIPSIS)
     sc.stop()
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -17,6 +17,19 @@
 
 import itertools
 import numpy as np
+import sys
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
 
 from pyspark import since
 from pyspark.ml import Estimator, Model
@@ -490,8 +503,12 @@ if __name__ == "__main__":
     sqlContext = SQLContext(sc)
     globs['sc'] = sc
     globs['sqlContext'] = sqlContext
-    (failure_count, test_count) = doctest.testmod(
-        globs=globs, optionflags=doctest.ELLIPSIS)
+    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
+    if xmlrunner:
+        result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                         verbosity=3).run(t)
+    else:
+        result = unittest.TextTestRunner(verbosity=3).run(t)
     sc.stop()
-    if failure_count:
+    if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/mllib/classification.py
+++ b/python/pyspark/mllib/classification.py
@@ -16,22 +16,9 @@
 #
 
 from math import exp
-import sys
 
 import numpy
 from numpy import array
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 from pyspark import RDD, since
 from pyspark.streaming import DStream
@@ -762,16 +749,13 @@ class StreamingLogisticRegressionWithSGD(StreamingLinearAlgorithm):
 
 def _test():
     import doctest
+    from pyspark.doctesthelper import run_doctests
     from pyspark import SparkContext
     import pyspark.mllib.classification
     globs = pyspark.mllib.classification.__dict__.copy()
     globs['sc'] = SparkContext('local[4]', 'PythonTest', batchSize=2)
-    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    result = run_doctests(__file__, globs=globs,
+                          optionflags=doctest.ELLIPSIS)
     globs['sc'].stop()
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/mllib/classification.py
+++ b/python/pyspark/mllib/classification.py
@@ -16,9 +16,22 @@
 #
 
 from math import exp
+import sys
 
 import numpy
 from numpy import array
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
 
 from pyspark import RDD, since
 from pyspark.streaming import DStream
@@ -753,9 +766,14 @@ def _test():
     import pyspark.mllib.classification
     globs = pyspark.mllib.classification.__dict__.copy()
     globs['sc'] = SparkContext('local[4]', 'PythonTest', batchSize=2)
-    (failure_count, test_count) = doctest.testmod(globs=globs, optionflags=doctest.ELLIPSIS)
+    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
+    if xmlrunner:
+        result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                         verbosity=3).run(t)
+    else:
+        result = unittest.TextTestRunner(verbosity=3).run(t)
     globs['sc'].stop()
-    if failure_count:
+    if not result.wasSuccessful():
         exit(-1)
 
 if __name__ == "__main__":

--- a/python/pyspark/mllib/clustering.py
+++ b/python/pyspark/mllib/clustering.py
@@ -18,18 +18,6 @@
 import sys
 import array as pyarray
 import warnings
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 if sys.version > '3':
     xrange = range
@@ -1072,15 +1060,12 @@ class LDA(object):
 
 def _test():
     import doctest
+    from pyspark.doctesthelper import run_doctests
     import pyspark.mllib.clustering
     globs = pyspark.mllib.clustering.__dict__.copy()
     globs['sc'] = SparkContext('local[4]', 'PythonTest', batchSize=2)
-    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    result = run_doctests(__file__, globs=globs,
+                          optionflags=doctest.ELLIPSIS)
     globs['sc'].stop()
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/mllib/clustering.py
+++ b/python/pyspark/mllib/clustering.py
@@ -18,6 +18,18 @@
 import sys
 import array as pyarray
 import warnings
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
 
 if sys.version > '3':
     xrange = range
@@ -1063,9 +1075,14 @@ def _test():
     import pyspark.mllib.clustering
     globs = pyspark.mllib.clustering.__dict__.copy()
     globs['sc'] = SparkContext('local[4]', 'PythonTest', batchSize=2)
-    (failure_count, test_count) = doctest.testmod(globs=globs, optionflags=doctest.ELLIPSIS)
+    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
+    if xmlrunner:
+        result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                         verbosity=3).run(t)
+    else:
+        result = unittest.TextTestRunner(verbosity=3).run(t)
     globs['sc'].stop()
-    if failure_count:
+    if not result.wasSuccessful():
         exit(-1)
 
 

--- a/python/pyspark/mllib/evaluation.py
+++ b/python/pyspark/mllib/evaluation.py
@@ -15,19 +15,6 @@
 # limitations under the License.
 #
 
-import sys
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 from pyspark import since
 from pyspark.mllib.common import JavaModelWrapper, callMLlibFunc
@@ -530,16 +517,13 @@ class MultilabelMetrics(JavaModelWrapper):
 
 def _test():
     import doctest
+    from pyspark.doctesthelper import run_doctests
     from pyspark import SparkContext
     import pyspark.mllib.evaluation
     globs = pyspark.mllib.evaluation.__dict__.copy()
     globs['sc'] = SparkContext('local[4]', 'PythonTest')
-    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    result = run_doctests(__file__, globs=globs,
+                          optionflags=doctest.ELLIPSIS)
     globs['sc'].stop()
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/mllib/evaluation.py
+++ b/python/pyspark/mllib/evaluation.py
@@ -15,6 +15,20 @@
 # limitations under the License.
 #
 
+import sys
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
+
 from pyspark import since
 from pyspark.mllib.common import JavaModelWrapper, callMLlibFunc
 from pyspark.sql import SQLContext
@@ -520,9 +534,14 @@ def _test():
     import pyspark.mllib.evaluation
     globs = pyspark.mllib.evaluation.__dict__.copy()
     globs['sc'] = SparkContext('local[4]', 'PythonTest')
-    (failure_count, test_count) = doctest.testmod(globs=globs, optionflags=doctest.ELLIPSIS)
+    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
+    if xmlrunner:
+        result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                         verbosity=3).run(t)
+    else:
+        result = unittest.TextTestRunner(verbosity=3).run(t)
     globs['sc'].stop()
-    if failure_count:
+    if not result.wasSuccessful():
         exit(-1)
 
 

--- a/python/pyspark/mllib/feature.py
+++ b/python/pyspark/mllib/feature.py
@@ -24,18 +24,6 @@ import sys
 import warnings
 import random
 import binascii
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 if sys.version >= '3':
     basestring = str
     unicode = str
@@ -724,15 +712,12 @@ class ElementwiseProduct(VectorTransformer):
 
 def _test():
     import doctest
+    from pyspark.doctesthelper import run_doctests
     from pyspark import SparkContext
     globs = globals().copy()
     globs['sc'] = SparkContext('local[4]', 'PythonTest', batchSize=2)
-    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    result = run_doctests(__file__, globs=globs,
+                          optionflags=doctest.ELLIPSIS)
     globs['sc'].stop()
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/mllib/feature.py
+++ b/python/pyspark/mllib/feature.py
@@ -24,6 +24,18 @@ import sys
 import warnings
 import random
 import binascii
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
 if sys.version >= '3':
     basestring = str
     unicode = str
@@ -715,9 +727,14 @@ def _test():
     from pyspark import SparkContext
     globs = globals().copy()
     globs['sc'] = SparkContext('local[4]', 'PythonTest', batchSize=2)
-    (failure_count, test_count) = doctest.testmod(globs=globs, optionflags=doctest.ELLIPSIS)
+    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
+    if xmlrunner:
+        result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                         verbosity=3).run(t)
+    else:
+        result = unittest.TextTestRunner(verbosity=3).run(t)
     globs['sc'].stop()
-    if failure_count:
+    if not result.wasSuccessful():
         exit(-1)
 
 if __name__ == "__main__":

--- a/python/pyspark/mllib/fpm.py
+++ b/python/pyspark/mllib/fpm.py
@@ -18,19 +18,6 @@
 import numpy
 from numpy import array
 from collections import namedtuple
-import sys
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 from pyspark import SparkContext, since
 from pyspark.rdd import ignore_unicode_prefix
@@ -196,6 +183,7 @@ class PrefixSpan(object):
 
 def _test():
     import doctest
+    from pyspark.doctesthelper import run_doctests
     import pyspark.mllib.fpm
     import tempfile
     globs = pyspark.mllib.fpm.__dict__.copy()
@@ -204,12 +192,8 @@ def _test():
     globs['temp_path'] = temp_path
 
     try:
-        t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
-        if xmlrunner:
-            result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                             verbosity=3).run(t)
-        else:
-            result = unittest.TextTestRunner(verbosity=3).run(t)
+        result = run_doctests(__file__, globs=globs,
+                              optionflags=doctest.ELLIPSIS)
         globs['sc'].stop()
     finally:
         from shutil import rmtree

--- a/python/pyspark/mllib/fpm.py
+++ b/python/pyspark/mllib/fpm.py
@@ -18,6 +18,19 @@
 import numpy
 from numpy import array
 from collections import namedtuple
+import sys
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
 
 from pyspark import SparkContext, since
 from pyspark.rdd import ignore_unicode_prefix
@@ -184,14 +197,19 @@ class PrefixSpan(object):
 def _test():
     import doctest
     import pyspark.mllib.fpm
+    import tempfile
     globs = pyspark.mllib.fpm.__dict__.copy()
     globs['sc'] = SparkContext('local[4]', 'PythonTest')
-    import tempfile
-
     temp_path = tempfile.mkdtemp()
     globs['temp_path'] = temp_path
+
     try:
-        (failure_count, test_count) = doctest.testmod(globs=globs, optionflags=doctest.ELLIPSIS)
+        t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
+        if xmlrunner:
+            result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                             verbosity=3).run(t)
+        else:
+            result = unittest.TextTestRunner(verbosity=3).run(t)
         globs['sc'].stop()
     finally:
         from shutil import rmtree
@@ -199,7 +217,7 @@ def _test():
             rmtree(temp_path)
         except OSError:
             pass
-    if failure_count:
+    if not result.wasSuccessful():
         exit(-1)
 
 

--- a/python/pyspark/mllib/linalg/__init__.py
+++ b/python/pyspark/mllib/linalg/__init__.py
@@ -26,6 +26,18 @@ SciPy is available in their environment.
 import sys
 import array
 import struct
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
 
 if sys.version >= '3':
     basestring = str
@@ -1237,8 +1249,13 @@ class Matrices(object):
 
 def _test():
     import doctest
-    (failure_count, test_count) = doctest.testmod(optionflags=doctest.ELLIPSIS)
-    if failure_count:
+    t = doctest.DocTestSuite(optionflags=doctest.ELLIPSIS)
+    if xmlrunner:
+        result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                         verbosity=3).run(t)
+    else:
+        result = unittest.TextTestRunner(verbosity=3).run(t)
+    if not result.wasSuccessful():
         exit(-1)
 
 if __name__ == "__main__":

--- a/python/pyspark/mllib/linalg/__init__.py
+++ b/python/pyspark/mllib/linalg/__init__.py
@@ -26,18 +26,6 @@ SciPy is available in their environment.
 import sys
 import array
 import struct
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 if sys.version >= '3':
     basestring = str
@@ -1248,13 +1236,8 @@ class Matrices(object):
 
 
 def _test():
-    import doctest
-    t = doctest.DocTestSuite(optionflags=doctest.ELLIPSIS)
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    from pyspark.doctesthelper import run_doctests
+    result = run_doctests(__file__, optionflags=doctest.ELLIPSIS)
     if not result.wasSuccessful():
         exit(-1)
 

--- a/python/pyspark/mllib/linalg/distributed.py
+++ b/python/pyspark/mllib/linalg/distributed.py
@@ -20,18 +20,6 @@ Package for distributed linear algebra.
 """
 
 import sys
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 if sys.version >= '3':
     long = int
@@ -930,6 +918,7 @@ class BlockMatrix(DistributedMatrix):
 
 def _test():
     import doctest
+    from pyspark.doctesthelper import run_doctests
     from pyspark import SparkContext
     from pyspark.sql import SQLContext
     from pyspark.mllib.linalg import Matrices
@@ -938,12 +927,8 @@ def _test():
     globs['sc'] = SparkContext('local[2]', 'PythonTest', batchSize=2)
     globs['sqlContext'] = SQLContext(globs['sc'])
     globs['Matrices'] = Matrices
-    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    result = run_doctests(__file__, globs=globs,
+                          optionflags=doctest.ELLIPSIS)
     globs['sc'].stop()
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/mllib/random.py
+++ b/python/pyspark/mllib/random.py
@@ -20,19 +20,6 @@ Python package for random data generation.
 """
 
 from functools import wraps
-import sys
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 from pyspark import since
 from pyspark.mllib.common import callMLlibFunc
@@ -422,17 +409,14 @@ class RandomRDDs(object):
 
 def _test():
     import doctest
+    from pyspark.doctesthelper import run_doctests
     from pyspark.context import SparkContext
     globs = globals().copy()
     # The small batch size here ensures that we see multiple batches,
     # even in these small test examples:
     globs['sc'] = SparkContext('local[2]', 'PythonTest', batchSize=2)
-    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    result = run_doctests(__file__, globs=globs,
+                          optionflags=doctest.ELLIPSIS)
     globs['sc'].stop()
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/mllib/random.py
+++ b/python/pyspark/mllib/random.py
@@ -20,6 +20,19 @@ Python package for random data generation.
 """
 
 from functools import wraps
+import sys
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
 
 from pyspark import since
 from pyspark.mllib.common import callMLlibFunc
@@ -414,9 +427,14 @@ def _test():
     # The small batch size here ensures that we see multiple batches,
     # even in these small test examples:
     globs['sc'] = SparkContext('local[2]', 'PythonTest', batchSize=2)
-    (failure_count, test_count) = doctest.testmod(globs=globs, optionflags=doctest.ELLIPSIS)
+    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
+    if xmlrunner:
+        result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                         verbosity=3).run(t)
+    else:
+        result = unittest.TextTestRunner(verbosity=3).run(t)
     globs['sc'].stop()
-    if failure_count:
+    if not result.wasSuccessful():
         exit(-1)
 
 

--- a/python/pyspark/mllib/recommendation.py
+++ b/python/pyspark/mllib/recommendation.py
@@ -16,20 +16,7 @@
 #
 
 import array
-import sys
 from collections import namedtuple
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 from pyspark import SparkContext, since
 from pyspark.rdd import RDD
@@ -330,18 +317,15 @@ class ALS(object):
 
 def _test():
     import doctest
+    from pyspark.doctesthelper import run_doctests
     import pyspark.mllib.recommendation
     from pyspark.sql import SQLContext
     globs = pyspark.mllib.recommendation.__dict__.copy()
     sc = SparkContext('local[4]', 'PythonTest')
     globs['sc'] = sc
     globs['sqlContext'] = SQLContext(sc)
-    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    result = run_doctests(__file__, globs=globs,
+                          optionflags=doctest.ELLIPSIS)
     globs['sc'].stop()
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/mllib/regression.py
+++ b/python/pyspark/mllib/regression.py
@@ -17,19 +17,6 @@
 
 import numpy as np
 from numpy import array
-import sys
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 from pyspark import RDD, since
 from pyspark.streaming.dstream import DStream
@@ -819,16 +806,13 @@ class StreamingLinearRegressionWithSGD(StreamingLinearAlgorithm):
 
 def _test():
     import doctest
+    from pyspark.doctesthelper import run_doctests
     from pyspark import SparkContext
     import pyspark.mllib.regression
     globs = pyspark.mllib.regression.__dict__.copy()
     globs['sc'] = SparkContext('local[2]', 'PythonTest', batchSize=2)
-    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    result = run_doctests(__file__, globs=globs,
+                          optionflags=doctest.ELLIPSIS)
     globs['sc'].stop()
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/mllib/stat/KernelDensity.py
+++ b/python/pyspark/mllib/stat/KernelDensity.py
@@ -21,18 +21,6 @@ if sys.version > '3':
     xrange = range
 
 import numpy as np
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 from pyspark.mllib.common import callMLlibFunc
 from pyspark.rdd import RDD
@@ -75,15 +63,12 @@ class KernelDensity(object):
 
 def _test():
     import doctest
+    from pyspark.doctesthelper import run_doctests
     from pyspark import SparkContext
     globs = globals().copy()
     globs['sc'] = SparkContext('local[4]', 'PythonTest', batchSize=2)
-    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    result = run_doctests(__file__, globs=globs,
+                          optionflags=doctest.ELLIPSIS)
     globs['sc'].stop()
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/mllib/stat/_statistics.py
+++ b/python/pyspark/mllib/stat/_statistics.py
@@ -18,18 +18,6 @@
 import sys
 if sys.version >= '3':
     basestring = str
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 from pyspark.rdd import RDD, ignore_unicode_prefix
 from pyspark.mllib.common import callMLlibFunc, JavaModelWrapper
@@ -318,15 +306,12 @@ class Statistics(object):
 
 def _test():
     import doctest
+    from pyspark.doctesthelper import run_doctests
     from pyspark import SparkContext
     globs = globals().copy()
     globs['sc'] = SparkContext('local[4]', 'PythonTest', batchSize=2)
-    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    result = run_doctests(__file__, globs=globs,
+                          optionflags=doctest.ELLIPSIS)
     globs['sc'].stop()
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/mllib/stat/distribution.py
+++ b/python/pyspark/mllib/stat/distribution.py
@@ -16,6 +16,19 @@
 #
 
 from collections import namedtuple
+import sys
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
 
 __all__ = ['MultivariateGaussian']
 
@@ -30,3 +43,23 @@ class MultivariateGaussian(namedtuple('MultivariateGaussian', ['mu', 'sigma'])):
     >>> (m[0], m[1])
     (DenseVector([11.0, 12.0]), array([[ 1., 5.],[ 3., 2.]]))
     """
+
+
+def _test():
+    import doctest
+    from pyspark import SparkContext
+    globs = globals().copy()
+    globs['sc'] = SparkContext('local[4]', 'PythonTest', batchSize=2)
+    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
+    if xmlrunner:
+        result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                         verbosity=3).run(t)
+    else:
+        result = unittest.TextTestRunner(verbosity=3).run(t)
+    globs['sc'].stop()
+    if not result.wasSuccessful():
+        exit(-1)
+
+
+if __name__ == "__main__":
+    _test()

--- a/python/pyspark/mllib/stat/distribution.py
+++ b/python/pyspark/mllib/stat/distribution.py
@@ -16,19 +16,6 @@
 #
 
 from collections import namedtuple
-import sys
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 __all__ = ['MultivariateGaussian']
 
@@ -47,15 +34,12 @@ class MultivariateGaussian(namedtuple('MultivariateGaussian', ['mu', 'sigma'])):
 
 def _test():
     import doctest
+    from pyspark.doctesthelper import run_doctests
     from pyspark import SparkContext
     globs = globals().copy()
     globs['sc'] = SparkContext('local[4]', 'PythonTest', batchSize=2)
-    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    result = run_doctests(__file__, globs=globs,
+                          optionflags=doctest.ELLIPSIS)
     globs['sc'].stop()
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/mllib/tree.py
+++ b/python/pyspark/mllib/tree.py
@@ -18,6 +18,19 @@
 from __future__ import absolute_import
 
 import random
+import sys
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
 
 from pyspark import SparkContext, RDD, since
 from pyspark.mllib.common import callMLlibFunc, inherit_doc, JavaModelWrapper
@@ -658,9 +671,14 @@ def _test():
     import doctest
     globs = globals().copy()
     globs['sc'] = SparkContext('local[4]', 'PythonTest', batchSize=2)
-    (failure_count, test_count) = doctest.testmod(globs=globs, optionflags=doctest.ELLIPSIS)
+    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
+    if xmlrunner:
+        result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                         verbosity=3).run(t)
+    else:
+        result = unittest.TextTestRunner(verbosity=3).run(t)
     globs['sc'].stop()
-    if failure_count:
+    if not result.wasSuccessful():
         exit(-1)
 
 if __name__ == "__main__":

--- a/python/pyspark/mllib/tree.py
+++ b/python/pyspark/mllib/tree.py
@@ -18,19 +18,6 @@
 from __future__ import absolute_import
 
 import random
-import sys
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 from pyspark import SparkContext, RDD, since
 from pyspark.mllib.common import callMLlibFunc, inherit_doc, JavaModelWrapper
@@ -669,14 +656,11 @@ class GradientBoostedTrees(object):
 
 def _test():
     import doctest
+    from pyspark.doctesthelper import run_doctests
     globs = globals().copy()
     globs['sc'] = SparkContext('local[4]', 'PythonTest', batchSize=2)
-    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    result = run_doctests(__file__, globs=globs,
+                          optionflags=doctest.ELLIPSIS)
     globs['sc'].stop()
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/mllib/util.py
+++ b/python/pyspark/mllib/util.py
@@ -18,6 +18,18 @@
 import sys
 import numpy as np
 import warnings
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
 
 if sys.version > '3':
     xrange = range
@@ -352,9 +364,14 @@ def _test():
     # The small batch size here ensures that we see multiple batches,
     # even in these small test examples:
     globs['sc'] = SparkContext('local[2]', 'PythonTest', batchSize=2)
-    (failure_count, test_count) = doctest.testmod(globs=globs, optionflags=doctest.ELLIPSIS)
+    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
+    if xmlrunner:
+        result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                         verbosity=3).run(t)
+    else:
+        result = unittest.TextTestRunner(verbosity=3).run(t)
     globs['sc'].stop()
-    if failure_count:
+    if not result.wasSuccessful():
         exit(-1)
 
 

--- a/python/pyspark/mllib/util.py
+++ b/python/pyspark/mllib/util.py
@@ -18,18 +18,6 @@
 import sys
 import numpy as np
 import warnings
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 if sys.version > '3':
     xrange = range
@@ -359,17 +347,14 @@ class LinearDataGenerator(object):
 
 def _test():
     import doctest
+    from pyspark.doctesthelper import run_doctests
     from pyspark.context import SparkContext
     globs = globals().copy()
     # The small batch size here ensures that we see multiple batches,
     # even in these small test examples:
     globs['sc'] = SparkContext('local[2]', 'PythonTest', batchSize=2)
-    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    result = run_doctests(__file__, globs=globs,
+                          optionflags=doctest.ELLIPSIS)
     globs['sc'].stop()
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/profiler.py
+++ b/python/pyspark/profiler.py
@@ -19,6 +19,19 @@ import cProfile
 import pstats
 import os
 import atexit
+import sys
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
 
 from pyspark.accumulators import AccumulatorParam
 
@@ -171,6 +184,11 @@ class BasicProfiler(Profiler):
 
 if __name__ == "__main__":
     import doctest
-    (failure_count, test_count) = doctest.testmod()
-    if failure_count:
+    t = doctest.DocTestSuite()
+    if xmlrunner:
+        result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                         verbosity=3).run(t)
+    else:
+        result = unittest.TextTestRunner(verbosity=3).run(t)
+    if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/profiler.py
+++ b/python/pyspark/profiler.py
@@ -19,19 +19,6 @@ import cProfile
 import pstats
 import os
 import atexit
-import sys
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 from pyspark.accumulators import AccumulatorParam
 
@@ -183,12 +170,7 @@ class BasicProfiler(Profiler):
 
 
 if __name__ == "__main__":
-    import doctest
-    t = doctest.DocTestSuite()
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    from pyspark.doctesthelper import run_doctests
+    result = run_doctests(__file__)
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -33,6 +33,18 @@ from collections import defaultdict
 from itertools import chain
 from functools import reduce
 from math import sqrt, log, isinf, isnan, pow, ceil
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
 
 if sys.version > '3':
     basestring = unicode = str
@@ -2426,10 +2438,14 @@ def _test():
     # The small batch size here ensures that we see multiple batches,
     # even in these small test examples:
     globs['sc'] = SparkContext('local[4]', 'PythonTest')
-    (failure_count, test_count) = doctest.testmod(
-        globs=globs, optionflags=doctest.ELLIPSIS)
+    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
+    if xmlrunner:
+        result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                         verbosity=3).run(t)
+    else:
+        result = unittest.TextTestRunner(verbosity=3).run(t)
     globs['sc'].stop()
-    if failure_count:
+    if not result.wasSuccessful():
         exit(-1)
 
 

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -33,18 +33,6 @@ from collections import defaultdict
 from itertools import chain
 from functools import reduce
 from math import sqrt, log, isinf, isnan, pow, ceil
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 if sys.version > '3':
     basestring = unicode = str
@@ -2432,18 +2420,15 @@ class PipelinedRDD(RDD):
 
 
 def _test():
+    from pyspark.doctesthelper import run_doctests
     import doctest
     from pyspark.context import SparkContext
     globs = globals().copy()
     # The small batch size here ensures that we see multiple batches,
     # even in these small test examples:
     globs['sc'] = SparkContext('local[4]', 'PythonTest')
-    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    result = run_doctests(__file__, globs=globs,
+                          optionflags=doctest.ELLIPSIS)
     globs['sc'].stop()
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -2004,20 +2004,20 @@ class RDD(object):
 
     def repartition(self, numPartitions):
         """
-         Return a new RDD that has exactly numPartitions partitions.
+        Return a new RDD that has exactly numPartitions partitions.
 
-         Can increase or decrease the level of parallelism in this RDD.
-         Internally, this uses a shuffle to redistribute data.
-         If you are decreasing the number of partitions in this RDD, consider
-         using `coalesce`, which can avoid performing a shuffle.
+        Can increase or decrease the level of parallelism in this RDD.
+        Internally, this uses a shuffle to redistribute data.
+        If you are decreasing the number of partitions in this RDD, consider
+        using `coalesce`, which can avoid performing a shuffle.
 
-         >>> rdd = sc.parallelize([1,2,3,4,5,6,7], 4)
-         >>> sorted(rdd.glom().collect())
-         [[1], [2, 3], [4, 5], [6, 7]]
-         >>> len(rdd.repartition(2).glom().collect())
-         2
-         >>> len(rdd.repartition(10).glom().collect())
-         10
+        >>> rdd = sc.parallelize([1,2,3,4,5,6,7], 4)
+        >>> sorted(rdd.glom().collect())
+        [[1], [2, 3], [4, 5], [6, 7]]
+        >>> len(rdd.repartition(2).glom().collect())
+        2
+        >>> len(rdd.repartition(10).glom().collect())
+        10
         """
         jrdd = self._jrdd.repartition(numPartitions)
         return RDD(jrdd, self.ctx, self._jrdd_deserializer)

--- a/python/pyspark/serializers.py
+++ b/python/pyspark/serializers.py
@@ -23,18 +23,6 @@ import types
 import collections
 import zlib
 import itertools
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 if sys.version < '3':
     import cPickle as pickle
@@ -568,12 +556,7 @@ def write_with_length(obj, stream):
 
 
 if __name__ == '__main__':
-    import doctest
-    t = doctest.DocTestSuite()
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    from pyspark.doctesthelper import run_doctests
+    result = run_doctests(__file__)
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/shuffle.py
+++ b/python/pyspark/shuffle.py
@@ -23,6 +23,19 @@ import gc
 import itertools
 import operator
 import random
+import sys
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
 
 import pyspark.heapq3 as heapq
 from pyspark.serializers import BatchedSerializer, PickleSerializer, FlattenedValuesSerializer, \
@@ -808,6 +821,11 @@ class ExternalGroupBy(ExternalMerger):
 
 if __name__ == "__main__":
     import doctest
-    (failure_count, test_count) = doctest.testmod()
-    if failure_count:
+    t = doctest.DocTestSuite()
+    if xmlrunner:
+        result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                         verbosity=3).run(t)
+    else:
+        result = unittest.TextTestRunner(verbosity=3).run(t)
+    if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/shuffle.py
+++ b/python/pyspark/shuffle.py
@@ -23,19 +23,6 @@ import gc
 import itertools
 import operator
 import random
-import sys
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 import pyspark.heapq3 as heapq
 from pyspark.serializers import BatchedSerializer, PickleSerializer, FlattenedValuesSerializer, \
@@ -820,12 +807,7 @@ class ExternalGroupBy(ExternalMerger):
 
 
 if __name__ == "__main__":
-    import doctest
-    t = doctest.DocTestSuite()
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    from pyspark.doctesthelper import run_doctests
+    result = run_doctests(__file__)
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -17,6 +17,18 @@
 
 import sys
 import warnings
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
 
 if sys.version >= '3':
     basestring = str
@@ -447,11 +459,16 @@ def _test():
         .toDF(StructType([StructField('age', IntegerType()),
                           StructField('name', StringType())]))
 
-    (failure_count, test_count) = doctest.testmod(
-        pyspark.sql.column, globs=globs,
-        optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE | doctest.REPORT_NDIFF)
+    t = doctest.DocTestSuite(pyspark.sql.column, globs=globs,
+                             optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE |
+                             doctest.REPORT_NDIFF)
+    if xmlrunner:
+        result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                         verbosity=3).run(t)
+    else:
+        result = unittest.TextTestRunner(verbosity=3).run(t)
     globs['sc'].stop()
-    if failure_count:
+    if not result.wasSuccessful():
         exit(-1)
 
 

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -17,18 +17,6 @@
 
 import sys
 import warnings
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 if sys.version >= '3':
     basestring = str
@@ -448,6 +436,7 @@ class Column(object):
 
 def _test():
     import doctest
+    from pyspark.doctesthelper import run_doctests
     from pyspark.context import SparkContext
     from pyspark.sql import SQLContext
     import pyspark.sql.column
@@ -459,14 +448,9 @@ def _test():
         .toDF(StructType([StructField('age', IntegerType()),
                           StructField('name', StringType())]))
 
-    t = doctest.DocTestSuite(pyspark.sql.column, globs=globs,
-                             optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE |
-                             doctest.REPORT_NDIFF)
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    result = run_doctests(__file__, globs=globs,
+                          optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE |
+                          doctest.REPORT_NDIFF)
     globs['sc'].stop()
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -20,18 +20,6 @@ import sys
 import warnings
 import json
 from functools import reduce
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 if sys.version >= '3':
     basestring = unicode = str
@@ -657,6 +645,7 @@ class UDFRegistration(object):
 def _test():
     import os
     import doctest
+    from pyspark.doctesthelper import run_doctests
     from pyspark.context import SparkContext
     from pyspark.sql import Row, SQLContext
     import pyspark.sql.context
@@ -682,13 +671,8 @@ def _test():
     ]
     globs['jsonStrings'] = jsonStrings
     globs['json'] = sc.parallelize(jsonStrings)
-    t = doctest.DocTestSuite(pyspark.sql.context, globs=globs,
-                             optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE)
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    result = run_doctests(__file__, globs=globs,
+                          optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE)
     globs['sc'].stop()
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -20,6 +20,18 @@ import sys
 import warnings
 import json
 from functools import reduce
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
 
 if sys.version >= '3':
     basestring = unicode = str
@@ -670,11 +682,15 @@ def _test():
     ]
     globs['jsonStrings'] = jsonStrings
     globs['json'] = sc.parallelize(jsonStrings)
-    (failure_count, test_count) = doctest.testmod(
-        pyspark.sql.context, globs=globs,
-        optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE)
+    t = doctest.DocTestSuite(pyspark.sql.context, globs=globs,
+                             optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE)
+    if xmlrunner:
+        result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                         verbosity=3).run(t)
+    else:
+        result = unittest.TextTestRunner(verbosity=3).run(t)
     globs['sc'].stop()
-    if failure_count:
+    if not result.wasSuccessful():
         exit(-1)
 
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -18,6 +18,18 @@
 import sys
 import warnings
 import random
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
 
 if sys.version >= '3':
     basestring = unicode = str
@@ -1467,11 +1479,16 @@ def _test():
                                   Row(name='Tom', age=None, height=None),
                                   Row(name=None, age=None, height=None)]).toDF()
 
-    (failure_count, test_count) = doctest.testmod(
-        pyspark.sql.dataframe, globs=globs,
-        optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE | doctest.REPORT_NDIFF)
+    t = doctest.DocTestSuite(pyspark.sql.dataframe, globs=globs,
+                             optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE |
+                             doctest.REPORT_NDIFF)
+    if xmlrunner:
+        result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                         verbosity=3).run(t)
+    else:
+        result = unittest.TextTestRunner(verbosity=3).run(t)
     globs['sc'].stop()
-    if failure_count:
+    if not result.wasSuccessful():
         exit(-1)
 
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -18,18 +18,6 @@
 import sys
 import warnings
 import random
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 if sys.version >= '3':
     basestring = unicode = str
@@ -1461,6 +1449,7 @@ class DataFrameStatFunctions(object):
 
 def _test():
     import doctest
+    from pyspark.doctesthelper import run_doctests
     from pyspark.context import SparkContext
     from pyspark.sql import Row, SQLContext
     import pyspark.sql.dataframe
@@ -1479,14 +1468,9 @@ def _test():
                                   Row(name='Tom', age=None, height=None),
                                   Row(name=None, age=None, height=None)]).toDF()
 
-    t = doctest.DocTestSuite(pyspark.sql.dataframe, globs=globs,
-                             optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE |
-                             doctest.REPORT_NDIFF)
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    result = run_doctests(__file__, globs=globs,
+                          optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE |
+                          doctest.REPORT_NDIFF)
     globs['sc'].stop()
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -20,18 +20,6 @@ A collections of builtin functions
 """
 import math
 import sys
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 if sys.version < "3":
     from itertools import imap as map
@@ -1697,6 +1685,7 @@ __all__.sort()
 
 def _test():
     import doctest
+    from pyspark.doctesthelper import run_doctests
     from pyspark.context import SparkContext
     from pyspark.sql import Row, SQLContext
     import pyspark.sql.functions
@@ -1705,13 +1694,8 @@ def _test():
     globs['sc'] = sc
     globs['sqlContext'] = SQLContext(sc)
     globs['df'] = sc.parallelize([Row(name='Alice', age=2), Row(name='Bob', age=5)]).toDF()
-    t = doctest.DocTestSuite(pyspark.sql.functions, globs=globs,
-                             optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE)
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    result = run_doctests(__file__, globs=globs,
+                          optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE)
     globs['sc'].stop()
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/sql/group.py
+++ b/python/pyspark/sql/group.py
@@ -15,19 +15,6 @@
 # limitations under the License.
 #
 
-import sys
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 from pyspark import since
 from pyspark.rdd import ignore_unicode_prefix
@@ -209,6 +196,7 @@ class GroupedData(object):
 
 def _test():
     import doctest
+    from pyspark.doctesthelper import run_doctests
     from pyspark.context import SparkContext
     from pyspark.sql import Row, SQLContext
     import pyspark.sql.group
@@ -227,14 +215,9 @@ def _test():
                                    Row(course="dotNET", year=2013, earnings=48000),
                                    Row(course="Java",   year=2013, earnings=30000)]).toDF()
 
-    t = doctest.DocTestSuite(pyspark.sql.group, globs=globs,
-                             optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE |
-                             doctest.REPORT_NDIFF)
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    result = run_doctests(__file__, globs=globs,
+                          optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE |
+                          doctest.REPORT_NDIFF)
     globs['sc'].stop()
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/sql/group.py
+++ b/python/pyspark/sql/group.py
@@ -15,6 +15,20 @@
 # limitations under the License.
 #
 
+import sys
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
+
 from pyspark import since
 from pyspark.rdd import ignore_unicode_prefix
 from pyspark.sql.column import Column, _to_seq, _to_java_column, _create_column_from_literal
@@ -213,11 +227,16 @@ def _test():
                                    Row(course="dotNET", year=2013, earnings=48000),
                                    Row(course="Java",   year=2013, earnings=30000)]).toDF()
 
-    (failure_count, test_count) = doctest.testmod(
-        pyspark.sql.group, globs=globs,
-        optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE | doctest.REPORT_NDIFF)
+    t = doctest.DocTestSuite(pyspark.sql.group, globs=globs,
+                             optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE |
+                             doctest.REPORT_NDIFF)
+    if xmlrunner:
+        result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                         verbosity=3).run(t)
+    else:
+        result = unittest.TextTestRunner(verbosity=3).run(t)
     globs['sc'].stop()
-    if failure_count:
+    if not result.wasSuccessful():
         exit(-1)
 
 

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -16,18 +16,6 @@
 #
 
 import sys
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 if sys.version >= '3':
     basestring = unicode = str
@@ -611,6 +599,7 @@ def _test():
     import doctest
     import os
     import tempfile
+    from pyspark.doctesthelper import run_doctests
     from pyspark.context import SparkContext
     from pyspark.sql import Row, SQLContext, HiveContext
     import pyspark.sql.readwriter
@@ -627,14 +616,9 @@ def _test():
     globs['hiveContext'] = HiveContext(sc)
     globs['df'] = globs['sqlContext'].read.parquet('python/test_support/sql/parquet_partitioned')
 
-    t = doctest.DocTestSuite(pyspark.sql.readwriter, globs=globs,
-                             optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE |
-                             doctest.REPORT_NDIFF)
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    result = run_doctests(__file__, globs=globs,
+                          optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE |
+                          doctest.REPORT_NDIFF)
     globs['sc'].stop()
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -16,6 +16,18 @@
 #
 
 import sys
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
 
 if sys.version >= '3':
     basestring = unicode = str
@@ -615,11 +627,16 @@ def _test():
     globs['hiveContext'] = HiveContext(sc)
     globs['df'] = globs['sqlContext'].read.parquet('python/test_support/sql/parquet_partitioned')
 
-    (failure_count, test_count) = doctest.testmod(
-        pyspark.sql.readwriter, globs=globs,
-        optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE | doctest.REPORT_NDIFF)
+    t = doctest.DocTestSuite(pyspark.sql.readwriter, globs=globs,
+                             optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE |
+                             doctest.REPORT_NDIFF)
+    if xmlrunner:
+        result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                         verbosity=3).run(t)
+    else:
+        result = unittest.TextTestRunner(verbosity=3).run(t)
     globs['sc'].stop()
-    if failure_count:
+    if not result.wasSuccessful():
         exit(-1)
 
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -24,18 +24,6 @@ import json
 import re
 import base64
 from array import array
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 if sys.version >= "3":
     long = int
@@ -1489,18 +1477,15 @@ register_input_converter(DateConverter())
 
 def _test():
     import doctest
+    from pyspark.doctesthelper import run_doctests
     from pyspark.context import SparkContext
     from pyspark.sql import SQLContext
     globs = globals()
     sc = SparkContext('local[4]', 'PythonTest')
     globs['sc'] = sc
     globs['sqlContext'] = SQLContext(sc)
-    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    result = run_doctests(__file__, globs=globs,
+                          optionflags=doctest.ELLIPSIS)
     globs['sc'].stop()
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -24,6 +24,18 @@ import json
 import re
 import base64
 from array import array
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
 
 if sys.version >= "3":
     long = int
@@ -1483,9 +1495,14 @@ def _test():
     sc = SparkContext('local[4]', 'PythonTest')
     globs['sc'] = sc
     globs['sqlContext'] = SQLContext(sc)
-    (failure_count, test_count) = doctest.testmod(globs=globs, optionflags=doctest.ELLIPSIS)
+    t = doctest.DocTestSuite(globs=globs, optionflags=doctest.ELLIPSIS)
+    if xmlrunner:
+        result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                         verbosity=3).run(t)
+    else:
+        result = unittest.TextTestRunner(verbosity=3).run(t)
     globs['sc'].stop()
-    if failure_count:
+    if not result.wasSuccessful():
         exit(-1)
 
 

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -15,19 +15,6 @@
 # limitations under the License.
 #
 
-import sys
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 from pyspark import since, SparkContext
 from pyspark.sql.column import _to_seq, _to_java_column
@@ -157,14 +144,9 @@ class WindowSpec(object):
 
 
 def _test():
-    import doctest
+    from pyspark.doctesthelper import run_doctests
     sc = SparkContext('local[4]', 'PythonTest')
-    t = doctest.DocTestSuite()
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    result = run_doctests(__file__)
     sc.stop()
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -16,6 +16,18 @@
 #
 
 import sys
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
 
 from pyspark import since, SparkContext
 from pyspark.sql.column import _to_seq, _to_java_column
@@ -146,9 +158,15 @@ class WindowSpec(object):
 
 def _test():
     import doctest
-    SparkContext('local[4]', 'PythonTest')
-    (failure_count, test_count) = doctest.testmod()
-    if failure_count:
+    sc = SparkContext('local[4]', 'PythonTest')
+    t = doctest.DocTestSuite()
+    if xmlrunner:
+        result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                         verbosity=3).run(t)
+    else:
+        result = unittest.TextTestRunner(verbosity=3).run(t)
+    sc.stop()
+    if not result.wasSuccessful():
         exit(-1)
 
 

--- a/python/pyspark/statcounter.py
+++ b/python/pyspark/statcounter.py
@@ -19,6 +19,19 @@
 
 import copy
 import math
+import sys
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
 
 try:
     from numpy import maximum, minimum, sqrt
@@ -156,3 +169,15 @@ class StatCounter(object):
     def __repr__(self):
         return ("(count: %s, mean: %s, stdev: %s, max: %s, min: %s)" %
                 (self.count(), self.mean(), self.stdev(), self.max(), self.min()))
+
+
+if __name__ == "__main__":
+    import doctest
+    t = doctest.DocTestSuite()
+    if xmlrunner:
+        result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                         verbosity=3).run(t)
+    else:
+        result = unittest.TextTestRunner(verbosity=3).run(t)
+    if not result.wasSuccessful():
+        exit(-1)

--- a/python/pyspark/statcounter.py
+++ b/python/pyspark/statcounter.py
@@ -19,19 +19,6 @@
 
 import copy
 import math
-import sys
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 try:
     from numpy import maximum, minimum, sqrt
@@ -172,12 +159,7 @@ class StatCounter(object):
 
 
 if __name__ == "__main__":
-    import doctest
-    t = doctest.DocTestSuite()
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    from pyspark.doctesthelper import run_doctests
+    result = run_doctests(__file__)
     if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/streaming/util.py
+++ b/python/pyspark/streaming/util.py
@@ -18,6 +18,19 @@
 import time
 from datetime import datetime
 import traceback
+import sys
+try:
+    import xmlrunner
+except ImportError:
+    xmlrunner = None
+if sys.version_info[:2] <= (2, 6):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
+        sys.exit(1)
+else:
+    import unittest
 
 from pyspark import SparkContext, RDD
 
@@ -145,6 +158,11 @@ def rddToFileName(prefix, suffix, timestamp):
 
 if __name__ == "__main__":
     import doctest
-    (failure_count, test_count) = doctest.testmod()
-    if failure_count:
+    t = doctest.DocTestSuite()
+    if xmlrunner:
+        result = xmlrunner.XMLTestRunner(output='target/test-reports',
+                                         verbosity=3).run(t)
+    else:
+        result = unittest.TextTestRunner(verbosity=3).run(t)
+    if not result.wasSuccessful():
         exit(-1)

--- a/python/pyspark/streaming/util.py
+++ b/python/pyspark/streaming/util.py
@@ -18,19 +18,6 @@
 import time
 from datetime import datetime
 import traceback
-import sys
-try:
-    import xmlrunner
-except ImportError:
-    xmlrunner = None
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        sys.stderr.write('Please install unittest2 to test with Python 2.6 or earlier')
-        sys.exit(1)
-else:
-    import unittest
 
 from pyspark import SparkContext, RDD
 
@@ -157,12 +144,7 @@ def rddToFileName(prefix, suffix, timestamp):
 
 
 if __name__ == "__main__":
-    import doctest
-    t = doctest.DocTestSuite()
-    if xmlrunner:
-        result = xmlrunner.XMLTestRunner(output='target/test-reports',
-                                         verbosity=3).run(t)
-    else:
-        result = unittest.TextTestRunner(verbosity=3).run(t)
+    from pyspark.doctesthelper import run_doctests
+    result = run_doctests(__file__)
     if not result.wasSuccessful():
         exit(-1)


### PR DESCRIPTION
SPARK-11741 Process doctests using TextTestRunner/XMLTestRunner

Doctests were moved under a class to correct processing
