### PR TITLE
Typo in comment: use 2 seconds instead of 1

### DIFF
--- a/examples/src/main/java/org/apache/spark/examples/streaming/JavaKafkaWordCount.java
+++ b/examples/src/main/java/org/apache/spark/examples/streaming/JavaKafkaWordCount.java
@@ -66,7 +66,7 @@ public final class JavaKafkaWordCount {
 
     StreamingExamples.setStreamingLogLevels();
     SparkConf sparkConf = new SparkConf().setAppName("JavaKafkaWordCount");
-    // Create the context with a 1 second batch size
+    // Create the context with 2 seconds batch size
     JavaStreamingContext jssc = new JavaStreamingContext(sparkConf, new Duration(2000));
 
     int numThreads = Integer.parseInt(args[3]);


### PR DESCRIPTION
Use 2 seconds batch size as duration specified in JavaStreamingContext constructor is 2000 ms
