### PR TITLE
[SPARK-11755] [R] SparkR should export "predict"

### DIFF
--- a/R/pkg/R/generics.R
+++ b/R/pkg/R/generics.R
@@ -1056,7 +1056,7 @@ setGeneric("glm")
 
 #' @rdname predict
 #' @export
-setGeneric("predict", function(object, newData) { standardGeneric("predict") })
+setGeneric("predict", function(object, ...) { standardGeneric("predict") })
 
 #' @rdname rbind
 #' @export

--- a/R/pkg/R/generics.R
+++ b/R/pkg/R/generics.R
@@ -1054,6 +1054,10 @@ setGeneric("year", function(x) { standardGeneric("year") })
 #' @export
 setGeneric("glm")
 
+#' @rdname predict
+#' @export
+setGeneric("predict", function(object, newData) { standardGeneric("predict") })
+
 #' @rdname rbind
 #' @export
 setGeneric("rbind", signature = "...")


### PR DESCRIPTION
The bug described at [SPARK-11755](https://issues.apache.org/jira/browse/SPARK-11755), after exporting `predict` we can both get the help information from the SparkR and base R package like the following:

``` Java
> help(predict)
Help on topic ‘predict’ was found in the following packages:

  Package               Library
  SparkR                /Users/yanboliang/data/trunk2/spark/R/lib
  stats                 /Library/Frameworks/R.framework/Versions/3.2/Resources/library

Choose one 

1: Make predictions from a model {SparkR}
2: Model Predictions {stats}
```
