### PR TITLE
[SPARK-11089] [SQL] Adds option for disabling multi-session in Thrift server

### DIFF
--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -2008,6 +2008,18 @@ or system properties:
   ...
 {% endhighlight %}
 
+From Spark 1.6, by default the Thrift server runs in multi-session mode.  Which means each JDBC/ODBC
+connection owns a copy of their own SQL configuration and temporary function registry.  Cached
+tables are still shared though.  If you prefer to run the Thrift server in the old single-session
+mode, please set option `spark.sql.hive.thriftServer.singleSession` to `true`.  You may either add
+this option to `spark-defaults.conf`, or pass it to `start-thriftserver.sh` via `--conf`:
+
+{% highlight bash %}
+./sbin/start-thriftserver.sh \
+  --conf spark.sql.hive.thriftServer.singleSession=true \
+  ...
+{% endhighlight %}
+
 Now you can use beeline to test the Thrift JDBC/ODBC server:
 
     ./bin/beeline

--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -2008,18 +2008,6 @@ or system properties:
   ...
 {% endhighlight %}
 
-From Spark 1.6, by default the Thrift server runs in multi-session mode.  Which means each JDBC/ODBC
-connection owns a copy of their own SQL configuration and temporary function registry.  Cached
-tables are still shared though.  If you prefer to run the Thrift server in the old single-session
-mode, please set option `spark.sql.hive.thriftServer.singleSession` to `true`.  You may either add
-this option to `spark-defaults.conf`, or pass it to `start-thriftserver.sh` via `--conf`:
-
-{% highlight bash %}
-./sbin/start-thriftserver.sh \
-  --conf spark.sql.hive.thriftServer.singleSession=true \
-  ...
-{% endhighlight %}
-
 Now you can use beeline to test the Thrift JDBC/ODBC server:
 
     ./bin/beeline
@@ -2062,6 +2050,20 @@ You may run `./bin/spark-sql --help` for a complete list of all available
 options.
 
 # Migration Guide
+
+## Upgrading From Spark SQL 1.5 to 1.6
+
+ - From Spark 1.6, by default the Thrift server runs in multi-session mode.  Which means each JDBC/ODBC
+   connection owns a copy of their own SQL configuration and temporary function registry.  Cached
+   tables are still shared though.  If you prefer to run the Thrift server in the old single-session
+   mode, please set option `spark.sql.hive.thriftServer.singleSession` to `true`.  You may either add
+   this option to `spark-defaults.conf`, or pass it to `start-thriftserver.sh` via `--conf`:
+
+   {% highlight bash %}
+   ./sbin/start-thriftserver.sh \
+     --conf spark.sql.hive.thriftServer.singleSession=true \
+     ...
+   {% endhighlight %}
 
 ## Upgrading From Spark SQL 1.4 to 1.5
 

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLSessionManager.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLSessionManager.scala
@@ -66,7 +66,11 @@ private[hive] class SparkSQLSessionManager(hiveServer: HiveServer2, hiveContext:
     val session = super.getSession(sessionHandle)
     HiveThriftServer2.listener.onSessionCreated(
       session.getIpAddress, sessionHandle.getSessionId.toString, session.getUsername)
-    val ctx = hiveContext.newSession()
+    val ctx = if (hiveContext.hiveThriftServerSingleSession) {
+      hiveContext
+    } else {
+      hiveContext.newSession()
+    }
     ctx.setConf("spark.sql.hive.version", HiveContext.hiveExecutionVersion)
     sparkSqlOperationManager.sessionToContexts += sessionHandle -> ctx
     sessionHandle

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -190,6 +190,9 @@ class HiveContext private[hive](
    */
   protected[hive] def hiveThriftServerAsync: Boolean = getConf(HIVE_THRIFT_SERVER_ASYNC)
 
+  protected[hive] def hiveThriftServerSingleSession: Boolean =
+    sc.conf.get("spark.sql.hive.thriftServer.singleSession", "false").toBoolean
+
   @transient
   protected[sql] lazy val substitutor = new VariableSubstitution()
 


### PR DESCRIPTION
This PR adds a new option `spark.sql.hive.thriftServer.singleSession` for disabling multi-session support in the Thrift server.

Note that this option is added as a Spark configuration (retrieved from `SparkConf`) rather than Spark SQL configuration (retrieved from `SQLConf`). This is because all SQL configurations are session-ized. Since multi-session support is by default on, no JDBC connection can modify global configurations like the newly added one.
