### PR TITLE
[SPARK-11775][PYSPARK][SQL] Allow PySpark to register Java UDF

### DIFF
--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -202,6 +202,11 @@ class SQLContext(object):
         """
         self.sparkSession.catalog.registerFunction(name, f, returnType)
 
+    def registerJavaFunction(self, name, javaClassName, returnType):
+        jdt = self._ssql_ctx.parseDataType(returnType.json())
+        self._ssql_ctx.udf().registerJava(name, javaClassName, jdt)
+
+
     # TODO(andrew): delete this once we refactor things to take in SparkSession
     def _inferSchema(self, rdd, samplingRatio=None):
         """

--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -206,7 +206,6 @@ class SQLContext(object):
         jdt = self._ssql_ctx.parseDataType(returnType.json())
         self._ssql_ctx.udf().registerJava(name, javaClassName, jdt)
 
-
     # TODO(andrew): delete this once we refactor things to take in SparkSession
     def _inferSchema(self, rdd, samplingRatio=None):
         """

--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -208,17 +208,17 @@ class SQLContext(object):
         """Register a java UDF so it can be used in SQL statements.
 
         In addition to a name and the function itself, the return type can be optionally specified.
-        When the return type is not given it would infer the returnType via reflection.
+        When the return type is not specified we would infer it via reflection.
         :param name:  name of the UDF
         :param javaClassName: fully qualified name of java class
         :param returnType: a :class:`pyspark.sql.types.DataType` object
 
         >>> sqlContext.registerJavaFunction("javaStringLength",
-        ...   "org.apache.spark.sql.test.JavaStringLength", IntegerType())
+        ...   "test.org.apache.spark.sql.JavaStringLength", IntegerType())
         >>> sqlContext.sql("SELECT javaStringLength('test')").collect()
         [Row(UDF(test)=4)]
         >>> sqlContext.registerJavaFunction("javaStringLength2",
-        ...   "org.apache.spark.sql.test.JavaStringLength")
+        ...   "test.org.apache.spark.sql.JavaStringLength")
         >>> sqlContext.sql("SELECT javaStringLength2('test')").collect()
         [Row(UDF(test)=4)]
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
@@ -59,7 +59,7 @@ object JavaTypeInference {
    * @param typeToken Java type
    * @return (SQL data type, nullable)
    */
-  private def inferDataType(typeToken: TypeToken[_]): (DataType, Boolean) = {
+  private[sql] def inferDataType(typeToken: TypeToken[_]): (DataType, Boolean) = {
     typeToken.getRawType match {
       case c: Class[_] if c.isAnnotationPresent(classOf[SQLUserDefinedType]) =>
         (c.getAnnotation(classOf[SQLUserDefinedType]).udt().newInstance(), true)

--- a/sql/core/src/main/java/org/apache/spark/sql/test/JavaStringLength.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/test/JavaStringLength.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.test;
+
+import org.apache.spark.sql.api.java.UDF1;
+
+/**
+ * It is used for register Java UDF from PySpark
+ */
+public class JavaStringLength implements UDF1<String, Integer> {
+  @Override
+  public Integer call(String str) throws Exception {
+    return new Integer(str.length());
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/UDFRegistration.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/UDFRegistration.scala
@@ -28,6 +28,7 @@ import org.apache.spark.annotation.InterfaceStability
 import org.apache.spark.internal.Logging
 import sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl
 
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.api.java._
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
 import org.apache.spark.sql.catalyst.ScalaReflection

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaStringLength.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaStringLength.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.test;
+package test.org.apache.spark.sql;
 
 import org.apache.spark.sql.api.java.UDF1;
 

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaUDFSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaUDFSuite.java
@@ -87,4 +87,20 @@ public class JavaUDFSuite implements Serializable {
     Row result = spark.sql("SELECT stringLengthTest('test', 'test2')").head();
     Assert.assertEquals(9, result.getInt(0));
   }
+
+  public static class StringLengthTest implements UDF2<String, String, Integer> {
+    @Override
+    public Integer call(String str1, String str2) throws Exception {
+      return new Integer(str1.length() + str2.length());
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void udf3Test() {
+    spark.udf().registerJava("stringLengthTest", StringLengthTest.class.getName(),
+            DataTypes.IntegerType);
+    Row result = spark.sql("SELECT stringLengthTest('test', 'test2')").head();
+    Assert.assertEquals(9, result.getInt(0));
+  }
 }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaUDFSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaUDFSuite.java
@@ -99,8 +99,13 @@ public class JavaUDFSuite implements Serializable {
   @Test
   public void udf3Test() {
     spark.udf().registerJava("stringLengthTest", StringLengthTest.class.getName(),
-            DataTypes.IntegerType);
+        DataTypes.IntegerType);
     Row result = spark.sql("SELECT stringLengthTest('test', 'test2')").head();
+    Assert.assertEquals(9, result.getInt(0));
+
+    // returnType is not provided
+    spark.udf().registerJava("stringLengthTest2", StringLengthTest.class.getName(), null);
+    result = spark.sql("SELECT stringLengthTest('test', 'test2')").head();
     Assert.assertEquals(9, result.getInt(0));
   }
 }


### PR DESCRIPTION
Currently pyspark can only call the builtin java UDF, but can not call custom java UDF. It would be better to allow that. 2 benefits:
- Leverage the power of rich third party java library
- Improve the performance. Because if we use python UDF, python daemons will be started on worker which will affect the performance.
