### PR TITLE
[SPARK-11778] [SQL]:parse table name before it is passed to lookupRelation

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -313,7 +313,7 @@ class DataFrameReader private[sql](sqlContext: SQLContext) extends Logging {
    * @since 1.4.0
    */
   def table(tableName: String): DataFrame = {
-    DataFrame(sqlContext, sqlContext.catalog.lookupRelation(TableIdentifier(tableName)))
+    DataFrame(sqlContext, sqlContext.catalog.lookupRelation(SqlParser.parseTableIdentifier(tableName)))
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -313,7 +313,8 @@ class DataFrameReader private[sql](sqlContext: SQLContext) extends Logging {
    * @since 1.4.0
    */
   def table(tableName: String): DataFrame = {
-    DataFrame(sqlContext, sqlContext.catalog.lookupRelation(SqlParser.parseTableIdentifier(tableName)))
+    DataFrame(sqlContext,
+      sqlContext.catalog.lookupRelation(SqlParser.parseTableIdentifier(tableName)))
   }
 
   /**

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDataFrameAnalyticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDataFrameAnalyticsSuite.scala
@@ -34,10 +34,14 @@ class HiveDataFrameAnalyticsSuite extends QueryTest with TestHiveSingleton with 
   override def beforeAll() {
     testData = Seq((1, 2), (2, 2), (3, 4)).toDF("a", "b")
     hiveContext.registerDataFrameAsTable(testData, "mytable")
+    hiveContext.sql("create schema usrdb")
+    hiveContext.sql("create table usrdb.test(c1 int)")
   }
 
   override def afterAll(): Unit = {
     hiveContext.dropTempTable("mytable")
+    hiveContext.sql("drop table usrdb.test")
+    hiveContext.sql("drop schema usrdb")
   }
 
   test("rollup") {
@@ -73,5 +77,11 @@ class HiveDataFrameAnalyticsSuite extends QueryTest with TestHiveSingleton with 
       testData.cube("a", "b").agg(sum("b")),
       sql("select a, b, sum(b) from mytable group by a, b with cube").collect()
     )
+  }
+
+  //There was a bug in DataFrameFrameReader.table and it has problem for table with schema name,
+  // Before fix, it throw Exceptionorg.apache.spark.sql.catalyst.analysis.NoSuchTableException
+  test("table name with schema") {
+    hiveContext.read.table("usrdb.test")
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDataFrameAnalyticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDataFrameAnalyticsSuite.scala
@@ -79,7 +79,7 @@ class HiveDataFrameAnalyticsSuite extends QueryTest with TestHiveSingleton with 
     )
   }
 
-  //There was a bug in DataFrameFrameReader.table and it has problem for table with schema name,
+  // There was a bug in DataFrameFrameReader.table and it has problem for table with schema name,
   // Before fix, it throw Exceptionorg.apache.spark.sql.catalyst.analysis.NoSuchTableException
   test("table name with schema") {
     hiveContext.read.table("usrdb.test")


### PR DESCRIPTION
Fix a bug in DataFrameReader.table (table with schema name such as "db_name.table" doesn't work)
Use SqlParser.parseTableIdentifier to parse the table name before lookupRelation. 
