### PR TITLE
[SPARK-11791] Fix flaky test in BatchedWriteAheadLogSuite

### DIFF
--- a/streaming/src/test/scala/org/apache/spark/streaming/util/WriteAheadLogSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/util/WriteAheadLogSuite.scala
@@ -756,7 +756,7 @@ object WriteAheadLogSuite {
 
     override def write(record: ByteBuffer, time: Long): WriteAheadLogRecordHandle = {
       isWriteCalled = true
-      eventually(Eventually.timeout(4 second)) {
+      eventually(Eventually.timeout(2 second)) {
         assert(!blockWrite)
       }
       wal.write(record, time)

--- a/streaming/src/test/scala/org/apache/spark/streaming/util/WriteAheadLogSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/util/WriteAheadLogSuite.scala
@@ -518,9 +518,7 @@ class BatchedWriteAheadLogSuite extends CommonWriteAheadLogTests(
       // in order of timestamp, and we need the last element.
       val buffer = ArgumentCaptor.forClass(classOf[ByteBuffer])
       verify(wal, times(1)).write(buffer.capture(), meq(10L))
-      val records = Utils.deserialize[Array[Array[Byte]]](buffer.getValue.array()).map { bytes =>
-        Utils.deserialize[String](bytes)
-      }
+      val records = BatchedWriteAheadLog.deaggregate(buffer.getValue).map(byteBufferToString)
       assert(records.toSet === buffer2)
     }
   }

--- a/streaming/src/test/scala/org/apache/spark/streaming/util/WriteAheadLogSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/util/WriteAheadLogSuite.scala
@@ -502,6 +502,10 @@ class BatchedWriteAheadLogSuite extends CommonWriteAheadLogTests(
     writeAsync(batchedWal, event3, 8L)
     writeAsync(batchedWal, event4, 12L)
     writeAsync(batchedWal, event5, 10L)
+    eventually(timeout(1 second)) {
+      assert(walBatchingThreadPool.getActiveCount === 5)
+      assert(batchedWal.invokePrivate(queueLength()) === 4)
+    }
     blockingWal.allowWrite()
 
     val buffer1 = wrapArrayArrayByte(Array(event1))


### PR DESCRIPTION
stack trace of failure:

```
org.scalatest.exceptions.TestFailedDueToTimeoutException: The code passed to eventually never returned normally. Attempted 62 times over 1.006322071 seconds. Last failure message: 
Argument(s) are different! Wanted:
writeAheadLog.write(
    java.nio.HeapByteBuffer[pos=0 lim=124 cap=124],
    10
);
-> at org.apache.spark.streaming.util.BatchedWriteAheadLogSuite$$anonfun$23$$anonfun$apply$mcV$sp$15.apply(WriteAheadLogSuite.scala:518)
Actual invocation has different arguments:
writeAheadLog.write(
    java.nio.HeapByteBuffer[pos=0 lim=124 cap=124],
    10
);
-> at org.apache.spark.streaming.util.WriteAheadLogSuite$BlockingWriteAheadLog.write(WriteAheadLogSuite.scala:756)
```

I believe the issue was that due to a race condition, the ordering of the events could be messed up in the final ByteBuffer, therefore the comparison fails.

By adding eventually between the requests, we make sure the ordering is preserved. Note that in real life situations, the ordering across threads will not matter.

Another solution would be to implement a custom mockito matcher that sorts and then compares the results, but that kind of sounds like overkill to me. Let me know what you think @tdas @zsxwing 
