### PR TITLE
[SPARK-11837] [EC2] python3 compatibility for launching ec2 m3 instances

### DIFF
--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -595,7 +595,7 @@ def launch_cluster(conn, opts, cluster_name):
             dev = BlockDeviceType()
             dev.ephemeral_name = 'ephemeral%d' % i
             # The first ephemeral drive is /dev/sdb.
-            name = '/dev/sd' + string.letters[i + 1]
+            name = '/dev/sd' + string.ascii_letters[i + 1]
             block_map[name] = dev
 
     # Launch slaves


### PR DESCRIPTION
this currently breaks for python3 because `string` module doesn't have `letters` anymore, instead `ascii_letters` should be used 
