### PR TITLE
[SPARK-11810][SQL] Java-based encoder for opaque types in Datasets.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoder.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql
 import scala.reflect.{ClassTag, classTag}
 
 import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, encoderFor}
-import org.apache.spark.sql.catalyst.expressions.{DeserializeWithKryo, BoundReference, SerializeWithKryo}
+import org.apache.spark.sql.catalyst.expressions.{DecodeUsingSerializer, BoundReference, EncodeUsingSerializer}
 import org.apache.spark.sql.types._
 
 /**
@@ -43,27 +43,47 @@ trait Encoder[T] extends Serializable {
  */
 object Encoders {
 
+  private def genericSerializer[T: ClassTag](useKryo: Boolean): Encoder[T] = {
+    ExpressionEncoder[T](
+      schema = new StructType().add("value", BinaryType),
+      flat = true,
+      toRowExpressions = Seq(
+        EncodeUsingSerializer(
+          BoundReference(0, ObjectType(classOf[AnyRef]), nullable = true), kryo = useKryo)),
+      fromRowExpression =
+        DecodeUsingSerializer[T](
+          BoundReference(0, BinaryType, nullable = true), classTag[T], kryo = useKryo),
+      clsTag = classTag[T]
+    )
+  }
+
   /**
    * (Scala-specific) Creates an encoder that serializes objects of type T using Kryo.
    * This encoder maps T into a single byte array (binary) field.
    */
-  def kryo[T: ClassTag]: Encoder[T] = {
-    val ser = SerializeWithKryo(BoundReference(0, ObjectType(classOf[AnyRef]), nullable = true))
-    val deser = DeserializeWithKryo[T](BoundReference(0, BinaryType, nullable = true), classTag[T])
-    ExpressionEncoder[T](
-      schema = new StructType().add("value", BinaryType),
-      flat = true,
-      toRowExpressions = Seq(ser),
-      fromRowExpression = deser,
-      clsTag = classTag[T]
-    )
-  }
+  def kryo[T: ClassTag]: Encoder[T] = genericSerializer(useKryo = true)
 
   /**
    * Creates an encoder that serializes objects of type T using Kryo.
    * This encoder maps T into a single byte array (binary) field.
    */
   def kryo[T](clazz: Class[T]): Encoder[T] = kryo(ClassTag[T](clazz))
+
+  /**
+   * (Scala-specific) Creates an encoder that serializes objects of type T using generic Java
+   * serialization. This encoder maps T into a single byte array (binary) field.
+   *
+   * Note that this is extremely inefficient and should only be used as the last resort.
+   */
+  def genericJava[T: ClassTag]: Encoder[T] = genericSerializer(useKryo = false)
+
+  /**
+   * Creates an encoder that serializes objects of type T using generic Java serialization.
+   * This encoder maps T into a single byte array (binary) field.
+   *
+   * Note that this is extremely inefficient and should only be used as the last resort.
+   */
+  def genericJava[T](clazz: Class[T]): Encoder[T] = genericJava(ClassTag[T](clazz))
 
   def BOOLEAN: Encoder[java.lang.Boolean] = ExpressionEncoder(flat = true)
   def BYTE: Encoder[java.lang.Byte] = ExpressionEncoder(flat = true)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoder.scala
@@ -43,6 +43,7 @@ trait Encoder[T] extends Serializable {
  */
 object Encoders {
 
+  /** A way to construct encoders using generic serializers. */
   private def genericSerializer[T: ClassTag](useKryo: Boolean): Encoder[T] = {
     ExpressionEncoder[T](
       schema = new StructType().add("value", BinaryType),
@@ -75,7 +76,7 @@ object Encoders {
    *
    * Note that this is extremely inefficient and should only be used as the last resort.
    */
-  def genericJava[T: ClassTag]: Encoder[T] = genericSerializer(useKryo = false)
+  def javaSerialization[T: ClassTag]: Encoder[T] = genericSerializer(useKryo = false)
 
   /**
    * Creates an encoder that serializes objects of type T using generic Java serialization.
@@ -83,7 +84,7 @@ object Encoders {
    *
    * Note that this is extremely inefficient and should only be used as the last resort.
    */
-  def genericJava[T](clazz: Class[T]): Encoder[T] = genericJava(ClassTag[T](clazz))
+  def javaSerialization[T](clazz: Class[T]): Encoder[T] = javaSerialization(ClassTag[T](clazz))
 
   def BOOLEAN: Encoder[java.lang.Boolean] = ExpressionEncoder(flat = true)
   def BYTE: Encoder[java.lang.Byte] = ExpressionEncoder(flat = true)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/FlatEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/FlatEncoderSuite.scala
@@ -82,11 +82,28 @@ class FlatEncoderSuite extends ExpressionEncoderSuite {
     new NotJavaSerializable(15),
     Encoders.kryo[NotJavaSerializable].asInstanceOf[ExpressionEncoder[NotJavaSerializable]],
     "kryo object serialization")
+
+  // Java encoders
+  encodeDecodeTest(
+    "hello",
+    Encoders.genericJava[String].asInstanceOf[ExpressionEncoder[String]],
+    "java string")
+  encodeDecodeTest(
+    new JavaSerializable(15),
+    Encoders.genericJava[JavaSerializable].asInstanceOf[ExpressionEncoder[JavaSerializable]],
+    "java object serialization")
 }
 
 
 class NotJavaSerializable(val value: Int) {
   override def equals(other: Any): Boolean = {
     this.value == other.asInstanceOf[NotJavaSerializable].value
+  }
+}
+
+
+class JavaSerializable(val value: Int) extends Serializable {
+  override def equals(other: Any): Boolean = {
+    this.value == other.asInstanceOf[JavaSerializable].value
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/FlatEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/FlatEncoderSuite.scala
@@ -79,8 +79,8 @@ class FlatEncoderSuite extends ExpressionEncoderSuite {
     encoderFor(Encoders.kryo[String]),
     "kryo string")
   encodeDecodeTest(
-    new NotJavaSerializable(15),
-    encoderFor(Encoders.kryo[NotJavaSerializable]),
+    new KryoSerializable(15),
+    encoderFor(Encoders.kryo[KryoSerializable]),
     "kryo object serialization")
 
   // Java encoders
@@ -94,14 +94,14 @@ class FlatEncoderSuite extends ExpressionEncoderSuite {
     "java object serialization")
 }
 
-
-class NotJavaSerializable(val value: Int) {
+/** For testing Kryo serialization based encoder. */
+class KryoSerializable(val value: Int) {
   override def equals(other: Any): Boolean = {
-    this.value == other.asInstanceOf[NotJavaSerializable].value
+    this.value == other.asInstanceOf[KryoSerializable].value
   }
 }
 
-
+/** For testing Java serialization based encoder. */
 class JavaSerializable(val value: Int) extends Serializable {
   override def equals(other: Any): Boolean = {
     this.value == other.asInstanceOf[JavaSerializable].value

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/FlatEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/FlatEncoderSuite.scala
@@ -76,21 +76,21 @@ class FlatEncoderSuite extends ExpressionEncoderSuite {
   // Kryo encoders
   encodeDecodeTest(
     "hello",
-    Encoders.kryo[String].asInstanceOf[ExpressionEncoder[String]],
+    encoderFor(Encoders.kryo[String]),
     "kryo string")
   encodeDecodeTest(
     new NotJavaSerializable(15),
-    Encoders.kryo[NotJavaSerializable].asInstanceOf[ExpressionEncoder[NotJavaSerializable]],
+    encoderFor(Encoders.kryo[NotJavaSerializable]),
     "kryo object serialization")
 
   // Java encoders
   encodeDecodeTest(
     "hello",
-    Encoders.genericJava[String].asInstanceOf[ExpressionEncoder[String]],
+    encoderFor(Encoders.javaSerialization[String]),
     "java string")
   encodeDecodeTest(
     new JavaSerializable(15),
-    Encoders.genericJava[JavaSerializable].asInstanceOf[ExpressionEncoder[JavaSerializable]],
+    encoderFor(Encoders.javaSerialization[JavaSerializable]),
     "java object serialization")
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -377,7 +377,7 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
   }
 
   test("Java encoder") {
-    implicit val kryoEncoder = Encoders.genericJava[JavaData]
+    implicit val kryoEncoder = Encoders.javaSerialization[JavaData]
     val ds = Seq(JavaData(1), JavaData(2)).toDS()
 
     assert(ds.groupBy(p => p).count().collect().toSeq ==
@@ -385,7 +385,7 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
   }
 
   ignore("Java encoder self join") {
-    implicit val kryoEncoder = Encoders.genericJava[JavaData]
+    implicit val kryoEncoder = Encoders.javaSerialization[JavaData]
     val ds = Seq(JavaData(1), JavaData(2)).toDS()
     assert(ds.joinWith(ds, lit(true)).collect().toSet ==
       Set(

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -357,7 +357,7 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
     assert(ds.toString == "[_1: int, _2: int]")
   }
 
-  test("kryo encoder") {
+  test("Kryo encoder") {
     implicit val kryoEncoder = Encoders.kryo[KryoData]
     val ds = Seq(KryoData(1), KryoData(2)).toDS()
 
@@ -365,7 +365,7 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
       Seq((KryoData(1), 1L), (KryoData(2), 1L)))
   }
 
-  test("kryo encoder self join") {
+  test("Kryo encoder self join") {
     implicit val kryoEncoder = Encoders.kryo[KryoData]
     val ds = Seq(KryoData(1), KryoData(2)).toDS()
     assert(ds.joinWith(ds, lit(true)).collect().toSet ==
@@ -374,6 +374,25 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
         (KryoData(1), KryoData(2)),
         (KryoData(2), KryoData(1)),
         (KryoData(2), KryoData(2))))
+  }
+
+  test("Java encoder") {
+    implicit val kryoEncoder = Encoders.genericJava[JavaData]
+    val ds = Seq(JavaData(1), JavaData(2)).toDS()
+
+    assert(ds.groupBy(p => p).count().collect().toSeq ==
+      Seq((JavaData(1), 1L), (JavaData(2), 1L)))
+  }
+
+  ignore("Java encoder self join") {
+    implicit val kryoEncoder = Encoders.genericJava[JavaData]
+    val ds = Seq(JavaData(1), JavaData(2)).toDS()
+    assert(ds.joinWith(ds, lit(true)).collect().toSet ==
+      Set(
+        (JavaData(1), JavaData(1)),
+        (JavaData(1), JavaData(2)),
+        (JavaData(2), JavaData(1)),
+        (JavaData(2), JavaData(2))))
   }
 }
 
@@ -405,4 +424,17 @@ class KryoData(val a: Int) {
 
 object KryoData {
   def apply(a: Int): KryoData = new KryoData(a)
+}
+
+/** Used to test Java encoder. */
+class JavaData(val a: Int) extends Serializable {
+  override def equals(other: Any): Boolean = {
+    a == other.asInstanceOf[JavaData].a
+  }
+  override def hashCode: Int = a
+  override def toString: String = s"JavaData($a)"
+}
+
+object JavaData {
+  def apply(a: Int): JavaData = new JavaData(a)
 }


### PR DESCRIPTION
This patch refactors the existing Kryo encoder expressions and adds support for Java serialization.
