### PR TITLE
[SPARK-11816] [ML] fix some style issue in ML/MLlib examples

### DIFF
--- a/examples/src/main/java/org/apache/spark/examples/ml/JavaKMeansExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/ml/JavaKMeansExample.java
@@ -41,7 +41,7 @@ import org.apache.spark.sql.types.StructType;
  * An example demonstrating a k-means clustering.
  * Run with
  * <pre>
- * bin/run-example ml.JavaSimpleParamsExample <file> <k>
+ * bin/run-example ml.JavaKMeansExample <file> <k>
  * </pre>
  */
 public class JavaKMeansExample {

--- a/examples/src/main/scala/org/apache/spark/examples/ml/AFTSurvivalRegressionExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/AFTSurvivalRegressionExample.scala
@@ -59,4 +59,4 @@ object AFTSurvivalRegressionExample {
     sc.stop()
   }
 }
-// scalastyle:off println
+// scalastyle:on println

--- a/examples/src/main/scala/org/apache/spark/examples/ml/DecisionTreeClassificationExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/DecisionTreeClassificationExample.scala
@@ -90,3 +90,4 @@ object DecisionTreeClassificationExample {
     // $example off$
   }
 }
+// scalastyle:on println

--- a/examples/src/main/scala/org/apache/spark/examples/ml/DecisionTreeRegressionExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/DecisionTreeRegressionExample.scala
@@ -78,3 +78,4 @@ object DecisionTreeRegressionExample {
     // $example off$
   }
 }
+// scalastyle:on println

--- a/examples/src/main/scala/org/apache/spark/examples/ml/MultilayerPerceptronClassifierExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/MultilayerPerceptronClassifierExample.scala
@@ -66,4 +66,4 @@ object MultilayerPerceptronClassifierExample {
     sc.stop()
   }
 }
-// scalastyle:off println
+// scalastyle:on println


### PR DESCRIPTION
jira: https://issues.apache.org/jira/browse/SPARK-11816
Currently I only fixed some obvious comments issue like 
// scalastyle:off println 
on the bottom.

Yet the style in examples is not quite consistent, like only half of the examples  are with 
// Example usage: ./bin/run-example mllib.FPGrowthExample \, 
