### PR TITLE
[SPARK-11818][REPL] Fix ExecutorClassLoader to lookup resources from …

### DIFF
--- a/core/src/main/scala/org/apache/spark/TestUtils.scala
+++ b/core/src/main/scala/org/apache/spark/TestUtils.scala
@@ -159,16 +159,6 @@ private[spark] object TestUtils {
     createCompiledClass(className, destDir, sourceFile, classpathUrls)
   }
 
-  def createResource(
-      resourceName: String,
-      destDir: File,
-      fileContent: String = "test"): File = {
-    val out: File = new File(destDir, resourceName)
-    Files.write(fileContent.getBytes(StandardCharsets.UTF_8), out)
-    assert(out.exists(), "Resource file is not written: " + out.getAbsolutePath())
-    out
-  }
-
   /**
    * Run some code involving jobs submitted to the given context and assert that the jobs spilled.
    */

--- a/core/src/main/scala/org/apache/spark/TestUtils.scala
+++ b/core/src/main/scala/org/apache/spark/TestUtils.scala
@@ -159,6 +159,16 @@ private[spark] object TestUtils {
     createCompiledClass(className, destDir, sourceFile, classpathUrls)
   }
 
+  def createResource(
+      resourceName: String,
+      destDir: File,
+      fileContent: String = "test"): File = {
+    val out: File = new File(destDir, resourceName)
+    Files.write(fileContent.getBytes(StandardCharsets.UTF_8), out)
+    assert(out.exists(), "Resource file is not written: " + out.getAbsolutePath())
+    out
+  }
+
   /**
    * Run some code involving jobs submitted to the given context and assert that the jobs spilled.
    */

--- a/repl/src/main/scala/org/apache/spark/repl/ExecutorClassLoader.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/ExecutorClassLoader.scala
@@ -34,7 +34,9 @@ import org.apache.spark.util.ParentClassLoader
 /**
  * A ClassLoader that reads classes from a Hadoop FileSystem or HTTP URI,
  * used to load classes defined by the interpreter when the REPL is used.
- * Allows the user to specify if user class path should be first
+ * Allows the user to specify if user class path should be first.
+ * This class loader delegates getting/finding resources to parent loader,
+ * which makes sense until REPL never provide resource dynamically.
  */
 class ExecutorClassLoader(conf: SparkConf, classUri: String, parent: ClassLoader,
     userClassPathFirst: Boolean) extends ClassLoader with Logging {
@@ -53,6 +55,14 @@ class ExecutorClassLoader(conf: SparkConf, classUri: String, parent: ClassLoader
     } else {
       FileSystem.get(uri, SparkHadoopUtil.get.newConfiguration(conf))
     }
+  }
+
+  override def getResource(name: String): URL = {
+    parentLoader.getResource(name)
+  }
+
+  override def getResources(name: String): java.util.Enumeration[URL] = {
+    parentLoader.getResources(name)
   }
 
   override def findClass(name: String): Class[_] = {

--- a/repl/src/test/scala/org/apache/spark/repl/ExecutorClassLoaderSuite.scala
+++ b/repl/src/test/scala/org/apache/spark/repl/ExecutorClassLoaderSuite.scala
@@ -19,7 +19,10 @@ package org.apache.spark.repl
 
 import java.io.File
 import java.net.{URL, URLClassLoader}
+import java.nio.charset.StandardCharsets
 import java.util
+
+import com.google.common.io.Files
 
 import scala.concurrent.duration._
 import scala.io.Source
@@ -57,7 +60,8 @@ class ExecutorClassLoaderSuite
     url1 = "file://" + tempDir1
     urls2 = List(tempDir2.toURI.toURL).toArray
     childClassNames.foreach(TestUtils.createCompiledClass(_, tempDir1, "1"))
-    parentResourceNames.foreach(TestUtils.createResource(_, tempDir2, "resource"))
+    parentResourceNames.foreach(x =>
+      Files.write("resource".getBytes(StandardCharsets.UTF_8), new File(tempDir2, x)))
     parentClassNames.foreach(TestUtils.createCompiledClass(_, tempDir2, "2"))
   }
 


### PR DESCRIPTION
…parent class loader

Without patch, two additional tests of ExecutorClassLoaderSuite fails.
- "resource from parent"
- "resources from parent"

Detailed explanation is here, https://issues.apache.org/jira/browse/SPARK-11818?focusedCommentId=15011202&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15011202
