### PR TITLE
[SPARK-11832] [Core] Process arguments in spark-shell for Scala 2.11

### DIFF
--- a/repl/scala-2.11/src/test/scala/org/apache/spark/repl/ReplSuite.scala
+++ b/repl/scala-2.11/src/test/scala/org/apache/spark/repl/ReplSuite.scala
@@ -54,8 +54,7 @@ class ReplSuite extends SparkFunSuite {
       new SparkILoop(in, new PrintWriter(out))
     }
     org.apache.spark.repl.Main.interp = interp
-    Main.s.processArguments(List("-classpath", classpath), true)
-    Main.main(Array()) // call main
+    Main.main(Array("-classpath", classpath)) // call main
     org.apache.spark.repl.Main.interp = null
 
     if (oldExecutorClasspath != null) {


### PR DESCRIPTION
Process arguments passed to the spark-shell. Fixes running the spark-shell from within a build environment.
