### PR TITLE
[branch-1.5][SPARK-11821] Propagate Kerberos keytab for all environments

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -520,20 +520,22 @@ object SparkSubmit {
       if (args.isPython) {
         sysProps.put("spark.yarn.isPython", "true")
       }
-      if (args.principal != null) {
-        require(args.keytab != null, "Keytab must be specified when principal is specified")
-        if (!new File(args.keytab).exists()) {
-          throw new SparkException(s"Keytab file: ${args.keytab} does not exist")
-        } else {
-          // Add keytab and principal configurations in sysProps to make them available
-          // for later use; e.g. in spark sql, the isolated class loader used to talk
-          // to HiveMetastore will use these settings. They will be set as Java system
-          // properties and then loaded by SparkConf
-          sysProps.put("spark.yarn.keytab", args.keytab)
-          sysProps.put("spark.yarn.principal", args.principal)
+    }
 
-          UserGroupInformation.loginUserFromKeytab(args.principal, args.keytab)
-        }
+    // assure a keytab is available from any place in a JVM
+    if (args.principal != null) {
+      require(args.keytab != null, "Keytab must be specified when principal is specified")
+      if (!new File(args.keytab).exists()) {
+        throw new SparkException(s"Keytab file: ${args.keytab} does not exist")
+      } else {
+        // Add keytab and principal configurations in sysProps to make them available
+        // for later use; e.g. in spark sql, the isolated class loader used to talk
+        // to HiveMetastore will use these settings. They will be set as Java system
+        // properties and then loaded by SparkConf
+        sysProps.put("spark.yarn.keytab", args.keytab)
+        sysProps.put("spark.yarn.principal", args.principal)
+
+        UserGroupInformation.loginUserFromKeytab(args.principal, args.keytab)
       }
     }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
@@ -21,10 +21,12 @@ import java.io.{File, PrintStream}
 import java.util.{Map => JMap}
 import javax.annotation.concurrent.GuardedBy
 
+import org.apache.hadoop.conf.Configuration
+
 import scala.collection.JavaConversions._
 import scala.language.reflectiveCalls
 
-import org.apache.hadoop.fs.Path
+import org.apache.hadoop.fs.{CommonConfigurationKeysPublic, Path}
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.metastore.api.{Database, FieldSchema}
 import org.apache.hadoop.hive.metastore.{TableType => HTableType}
@@ -166,7 +168,11 @@ private[hive] class ClientWrapper(
           " specified in spark.yarn.keytab does not exist")
       } else {
         logInfo("Attempting to login to Kerberos" +
-          s" using principal: ${principalName} and keytab: ${keytabFileName}")
+        s" using principal: ${principalName} and keytab: ${keytabFileName}")
+        val hadoopConfiguration = new Configuration()
+        hadoopConfiguration.set(CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHENTICATION,
+          "kerberos")
+        UserGroupInformation.setConfiguration(hadoopConfiguration)
         UserGroupInformation.loginUserFromKeytab(principalName, keytabFileName)
       }
     }


### PR DESCRIPTION
I prepared a patch for recent bugfix. The scope of the previous bugfix is too narrow- it works only on YARN. I need it on local mode and I think the other modes also need the information (because reflection works the same for each environment having JVM).
