### PR TITLE
[SPARK-11852] [ML] StandardScaler minor refactor

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
@@ -42,7 +42,8 @@ private[feature] trait StandardScalerParams extends Params with HasInputCol with
    * Default: false
    * @group param
    */
-  val withMean: BooleanParam = new BooleanParam(this, "withMean", "Whether to center data with mean")
+  val withMean: BooleanParam = new BooleanParam(this, "withMean",
+    "Whether to center data with mean")
 
   /** @group getParam */
   def getWithMean: Boolean = $(withMean)

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
@@ -189,7 +189,6 @@ object StandardScalerModel extends MLReadable[StandardScalerModel] {
         sqlContext.read.parquet(dataPath)
           .select("std", "mean", "withStd", "withMean")
           .head()
-      // This is very likely to change in the future because withStd and withMean should be params.
       val oldModel = new feature.StandardScalerModel(std, mean, withStd, withMean)
       val model = new StandardScalerModel(metadata.uid, oldModel)
       DefaultParamsReader.getAndSetParams(model, metadata)

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StandardScaler.scala
@@ -36,20 +36,29 @@ import org.apache.spark.sql.types.{StructField, StructType}
 private[feature] trait StandardScalerParams extends Params with HasInputCol with HasOutputCol {
 
   /**
-   * Centers the data with mean before scaling.
+   * Whether to center the data with mean before scaling.
    * It will build a dense output, so this does not work on sparse input
    * and will raise an exception.
    * Default: false
    * @group param
    */
-  val withMean: BooleanParam = new BooleanParam(this, "withMean", "Center data with mean")
+  val withMean: BooleanParam = new BooleanParam(this, "withMean", "Whether to center data with mean")
+
+  /** @group getParam */
+  def getWithMean: Boolean = $(withMean)
 
   /**
-   * Scales the data to unit standard deviation.
+   * Whether to scale the data to unit standard deviation.
    * Default: true
    * @group param
    */
-  val withStd: BooleanParam = new BooleanParam(this, "withStd", "Scale to unit standard deviation")
+  val withStd: BooleanParam = new BooleanParam(this, "withStd",
+    "Whether to scale the data to unit standard deviation")
+
+  /** @group getParam */
+  def getWithStd: Boolean = $(withStd)
+
+  setDefault(withMean -> false, withStd -> true)
 }
 
 /**
@@ -62,8 +71,6 @@ class StandardScaler(override val uid: String) extends Estimator[StandardScalerM
   with StandardScalerParams with DefaultParamsWritable {
 
   def this() = this(Identifiable.randomUID("stdScal"))
-
-  setDefault(withMean -> false, withStd -> true)
 
   /** @group setParam */
   def setInputCol(value: String): this.type = set(inputCol, value)
@@ -122,14 +129,6 @@ class StandardScalerModel private[ml] (
 
   /** Mean of the StandardScalerModel */
   val mean: Vector = scaler.mean
-
-  /** Whether to scale to unit standard deviation. */
-  @Since("1.6.0")
-  def getWithStd: Boolean = scaler.withStd
-
-  /** Whether to center data with mean. */
-  @Since("1.6.0")
-  def getWithMean: Boolean = scaler.withMean
 
   /** @group setParam */
   def setInputCol(value: String): this.type = set(inputCol, value)

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/StandardScalerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/StandardScalerSuite.scala
@@ -132,7 +132,5 @@ class StandardScalerSuite extends SparkFunSuite with MLlibTestSparkContext
     val newInstance = testDefaultReadWrite(instance)
     assert(newInstance.std === instance.std)
     assert(newInstance.mean === instance.mean)
-    assert(newInstance.getWithStd === instance.getWithStd)
-    assert(newInstance.getWithMean === instance.getWithMean)
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/StandardScalerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/StandardScalerSuite.scala
@@ -120,14 +120,14 @@ class StandardScalerSuite extends SparkFunSuite with MLlibTestSparkContext
     val t = new StandardScaler()
       .setInputCol("myInputCol")
       .setOutputCol("myOutputCol")
+      .setWithStd(false)
       .setWithMean(true)
-      .setWithStd(true)
     testDefaultReadWrite(t)
   }
 
   test("StandardScalerModel read/write") {
     val instance = new StandardScalerModel("myStandardScalerModel",
-      Vectors.dense(0.5, 1.2), Vectors.dense(1.0, 10.0))
+      Vectors.dense(1.0, 2.0), Vectors.dense(3.0, 4.0))
     val newInstance = testDefaultReadWrite(instance)
     assert(newInstance.std === instance.std)
     assert(newInstance.mean === instance.mean)

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/StandardScalerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/StandardScalerSuite.scala
@@ -70,8 +70,8 @@ class StandardScalerSuite extends SparkFunSuite with MLlibTestSparkContext
 
   test("params") {
     ParamsSuite.checkParams(new StandardScaler)
-    val oldModel = new feature.StandardScalerModel(Vectors.dense(1.0), Vectors.dense(2.0))
-    ParamsSuite.checkParams(new StandardScalerModel("empty", oldModel))
+    ParamsSuite.checkParams(new StandardScalerModel("empty",
+      Vectors.dense(1.0), Vectors.dense(2.0)))
   }
 
   test("Standardization with default parameter") {
@@ -116,19 +116,20 @@ class StandardScalerSuite extends SparkFunSuite with MLlibTestSparkContext
     assertResult(standardScaler3.transform(df3))
   }
 
-  test("read/write") {
-    def checkModelData(model1: StandardScalerModel, model2: StandardScalerModel): Unit = {
-      assert(model1.mean === model2.mean)
-      assert(model1.std === model2.std)
-    }
-    val allParams: Map[String, Any] = Map(
-      "inputCol" -> "features",
-      "outputCol" -> "standardized_features",
-      "withMean" -> true,
-      "withStd" -> true
-    )
-    val df = sqlContext.createDataFrame(data.zip(resWithBoth)).toDF("features", "expected")
-    val standardScaler = new StandardScaler()
-    testEstimatorAndModelReadWrite(standardScaler, df, allParams, checkModelData)
+  test("StandardScaler read/write") {
+    val t = new StandardScaler()
+      .setInputCol("myInputCol")
+      .setOutputCol("myOutputCol")
+      .setWithMean(true)
+      .setWithStd(true)
+    testDefaultReadWrite(t)
+  }
+
+  test("StandardScalerModel read/write") {
+    val instance = new StandardScalerModel("myStandardScalerModel",
+      Vectors.dense(0.5, 1.2), Vectors.dense(1.0, 10.0))
+    val newInstance = testDefaultReadWrite(instance)
+    assert(newInstance.std === instance.std)
+    assert(newInstance.mean === instance.mean)
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/StandardScalerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/StandardScalerSuite.scala
@@ -116,21 +116,19 @@ class StandardScalerSuite extends SparkFunSuite with MLlibTestSparkContext
     assertResult(standardScaler3.transform(df3))
   }
 
-  test("StandardScaler read/write") {
-    val t = new StandardScaler()
-      .setInputCol("myInputCol")
-      .setOutputCol("myOutputCol")
-      .setWithStd(false)
-      .setWithMean(true)
-    testDefaultReadWrite(t)
-  }
-
-  test("StandardScalerModel read/write") {
-    val oldModel = new feature.StandardScalerModel(
-      Vectors.dense(1.0, 2.0), Vectors.dense(3.0, 4.0), false, true)
-    val instance = new StandardScalerModel("myStandardScalerModel", oldModel)
-    val newInstance = testDefaultReadWrite(instance)
-    assert(newInstance.std === instance.std)
-    assert(newInstance.mean === instance.mean)
+  test("read/write") {
+    def checkModelData(model1: StandardScalerModel, model2: StandardScalerModel): Unit = {
+      assert(model1.mean === model2.mean)
+      assert(model1.std === model2.std)
+    }
+    val allParams: Map[String, Any] = Map(
+      "inputCol" -> "features",
+      "outputCol" -> "standardized_features",
+      "withMean" -> true,
+      "withStd" -> true
+    )
+    val df = sqlContext.createDataFrame(data.zip(resWithBoth)).toDF("features", "expected")
+    val standardScaler = new StandardScaler()
+    testEstimatorAndModelReadWrite(standardScaler, df, allParams, checkModelData)
   }
 }


### PR DESCRIPTION
`withStd` and `withMean` should be params of `StandardScaler` and `StandardScalerModel`.
