### PR TITLE
[SPARK-7857][MLLIB] Prevent IDFModel from returning zeros in SparseVe…

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
@@ -218,7 +218,7 @@ private object IDFModel {
           newValues(k) = values(k) * idf(indices(k))
           k += 1
         }
-        Vectors.sparse(n, indices, newValues)
+        Vectors.sparse(n, indices, newValues).toSparse
       case DenseVector(values) =>
         val newValues = new Array[Double](n)
         var j = 0

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
@@ -214,8 +214,9 @@ private object IDFModel {
     v match {
       case SparseVector(size, indices, values) =>
         val newElements = new ArrayBuffer[(Int, Double)]
+        val nnz = indices.size
         var k = 0
-        while (k < indices.size) {
+        while (k < nnz) {
           val newValue = values(k) * idf(indices(k))
           if (newValue != 0.0) {
             newElements.append((indices(k), newValue))

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/IDF.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.mllib.feature
 
+import scala.collection.mutable.ArrayBuffer
+
 import breeze.linalg.{DenseVector => BDV}
 
 import org.apache.spark.annotation.Since
@@ -211,14 +213,16 @@ private object IDFModel {
     val n = v.size
     v match {
       case SparseVector(size, indices, values) =>
-        val nnz = indices.size
-        val newValues = new Array[Double](nnz)
+        val newElements = new ArrayBuffer[(Int, Double)]
         var k = 0
-        while (k < nnz) {
-          newValues(k) = values(k) * idf(indices(k))
+        while (k < indices.size) {
+          val newValue = values(k) * idf(indices(k))
+          if (newValue != 0.0) {
+            newElements.append((indices(k), newValue))
+          }
           k += 1
         }
-        Vectors.sparse(n, indices, newValues).toSparse
+        Vectors.sparse(n, newElements.toArray)
       case DenseVector(values) =>
         val newValues = new Array[Double](n)
         var j = 0

--- a/mllib/src/test/scala/org/apache/spark/mllib/feature/IDFSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/feature/IDFSuite.scala
@@ -23,16 +23,31 @@ import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
 
 class IDFSuite extends SparkFunSuite with MLlibTestSparkContext {
+  private val n = 4
+  private val localTermFrequencies = Seq(
+    Vectors.sparse(n, Array(1, 3), Array(1.0, 2.0)),
+    Vectors.dense(0.0, 1.0, 2.0, 3.0),
+    Vectors.sparse(n, Array(1), Array(1.0))
+  )
+  private val m = localTermFrequencies.size
+  private lazy val termFrequencies = sc.parallelize(localTermFrequencies, 2)
+
+  private def assertHelper(tfidf: Array[Vector], expected: Vector) = {
+    assert(tfidf.size === 3)
+    val tfidf0 = tfidf(0).asInstanceOf[SparseVector]
+    assert(tfidf0.indices === Array(3))
+    assert(!tfidf0.values.contains(0))
+    assert(Vectors.dense(tfidf0.values) ~==
+        Vectors.dense(2.0 * expected(3)) absTol 1e-12)
+    val tfidf1 = tfidf(1).asInstanceOf[DenseVector]
+    assert(Vectors.dense(tfidf1.values) ~==
+        Vectors.dense(0.0, 1.0 * expected(1), 2.0 * expected(2), 3.0 * expected(3)) absTol 1e-12)
+    val tfidf2 = tfidf(2).asInstanceOf[SparseVector]
+    assert(tfidf2.indices === Array())
+    assert(tfidf2.values === Array())
+  }
 
   test("idf") {
-    val n = 4
-    val localTermFrequencies = Seq(
-      Vectors.sparse(n, Array(1, 3), Array(1.0, 2.0)),
-      Vectors.dense(0.0, 1.0, 2.0, 3.0),
-      Vectors.sparse(n, Array(1), Array(1.0))
-    )
-    val m = localTermFrequencies.size
-    val termFrequencies = sc.parallelize(localTermFrequencies, 2)
     val idf = new IDF
     val model = idf.fit(termFrequencies)
     val expected = Vectors.dense(Array(0, 3, 1, 2).map { x =>
@@ -40,36 +55,15 @@ class IDFSuite extends SparkFunSuite with MLlibTestSparkContext {
     })
     assert(model.idf ~== expected absTol 1e-12)
 
-    val assertHelper = (tfidf: Array[Vector]) => {
-      assert(tfidf.size === 3)
-      val tfidf0 = tfidf(0).asInstanceOf[SparseVector]
-      assert(tfidf0.indices === Array(1, 3))
-      assert(Vectors.dense(tfidf0.values) ~==
-          Vectors.dense(1.0 * expected(1), 2.0 * expected(3)) absTol 1e-12)
-      val tfidf1 = tfidf(1).asInstanceOf[DenseVector]
-      assert(Vectors.dense(tfidf1.values) ~==
-          Vectors.dense(0.0, 1.0 * expected(1), 2.0 * expected(2), 3.0 * expected(3)) absTol 1e-12)
-      val tfidf2 = tfidf(2).asInstanceOf[SparseVector]
-      assert(tfidf2.indices === Array(1))
-      assert(tfidf2.values(0) ~== (1.0 * expected(1)) absTol 1e-12)
-    }
     // Transforms a RDD
     val tfidf = model.transform(termFrequencies).collect()
-    assertHelper(tfidf)
+    assertHelper(tfidf, expected)
     // Transforms local vectors
     val localTfidf = localTermFrequencies.map(model.transform(_)).toArray
-    assertHelper(localTfidf)
+    assertHelper(localTfidf, expected)
   }
 
   test("idf minimum document frequency filtering") {
-    val n = 4
-    val localTermFrequencies = Seq(
-      Vectors.sparse(n, Array(1, 3), Array(1.0, 2.0)),
-      Vectors.dense(0.0, 1.0, 2.0, 3.0),
-      Vectors.sparse(n, Array(1), Array(1.0))
-    )
-    val m = localTermFrequencies.size
-    val termFrequencies = sc.parallelize(localTermFrequencies, 2)
     val idf = new IDF(minDocFreq = 1)
     val model = idf.fit(termFrequencies)
     val expected = Vectors.dense(Array(0, 3, 1, 2).map { x =>
@@ -81,25 +75,12 @@ class IDFSuite extends SparkFunSuite with MLlibTestSparkContext {
     })
     assert(model.idf ~== expected absTol 1e-12)
 
-    val assertHelper = (tfidf: Array[Vector]) => {
-      assert(tfidf.size === 3)
-      val tfidf0 = tfidf(0).asInstanceOf[SparseVector]
-      assert(tfidf0.indices === Array(1, 3))
-      assert(Vectors.dense(tfidf0.values) ~==
-          Vectors.dense(1.0 * expected(1), 2.0 * expected(3)) absTol 1e-12)
-      val tfidf1 = tfidf(1).asInstanceOf[DenseVector]
-      assert(Vectors.dense(tfidf1.values) ~==
-          Vectors.dense(0.0, 1.0 * expected(1), 2.0 * expected(2), 3.0 * expected(3)) absTol 1e-12)
-      val tfidf2 = tfidf(2).asInstanceOf[SparseVector]
-      assert(tfidf2.indices === Array(1))
-      assert(tfidf2.values(0) ~== (1.0 * expected(1)) absTol 1e-12)
-    }
     // Transforms a RDD
     val tfidf = model.transform(termFrequencies).collect()
-    assertHelper(tfidf)
+    assertHelper(tfidf, expected)
     // Transforms local vectors
     val localTfidf = localTermFrequencies.map(model.transform(_)).toArray
-    assertHelper(localTfidf)
+    assertHelper(localTfidf, expected)
   }
 
 }


### PR DESCRIPTION
…ctors

When the IDF model's `minDocFreq` parameter is set to a non-zero threshold, the
IDF for any feature below that threshold is set to zero. When the model is used
to transform a set of SparseVectors containing that feature, the resulting
SparseVectors contain entries whose values are explicitly zero. The zero entries
should be omitted in order to simplify downstream processing.
