### PR TITLE
[SPARK-11869] [ML] Clean up TempDirectory properly in ML tests

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/ml/util/TempDirectory.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/util/TempDirectory.scala
@@ -39,7 +39,7 @@ trait TempDirectory extends BeforeAndAfterAll { self: Suite =>
   }
 
   override def afterAll(): Unit = {
-    Utils.deleteRecursively(_tempDir)
+    Utils.deleteRecursively(_tempDir.getParentFile)
     super.afterAll()
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/util/TempDirectory.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/util/TempDirectory.scala
@@ -35,7 +35,7 @@ trait TempDirectory extends BeforeAndAfterAll { self: Suite =>
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    _tempDir = Utils.createTempDir(this.getClass.getName)
+    _tempDir = Utils.createTempDir(namePrefix = this.getClass.getName)
   }
 
   override def afterAll(): Unit = {

--- a/mllib/src/test/scala/org/apache/spark/ml/util/TempDirectory.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/util/TempDirectory.scala
@@ -39,7 +39,7 @@ trait TempDirectory extends BeforeAndAfterAll { self: Suite =>
   }
 
   override def afterAll(): Unit = {
-    Utils.deleteRecursively(_tempDir.getParentFile)
+    Utils.deleteRecursively(_tempDir)
     super.afterAll()
   }
 }


### PR DESCRIPTION
Need to remove parent directory (`className`) rather than just tempDir (`className/random_name`)

I tested this with IDFSuite, which has 2 read/write tests, and it fixes the problem.

CC: @mengxr  Can you confirm this is fine?  I believe it is since the same `random_name` is used for all tests in a suite; we basically have an extra unneeded level of nesting.
