### PR TITLE
[SPARK-11884] Drop multiple columns in the DataFrame API

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -1252,11 +1252,11 @@ class DataFrame private[sql](
    */
   @scala.annotation.varargs
   def drop(colNames: String*): DataFrame = {
-    val remainingCols = df.schema.filter(f => colNames.contains(f.name)).map(f => Column(f.name))
-    if (remainingCols.size == df.schema.size) {
+    val remainingCols = this.schema.filter(f => colNames.contains(f.name)).map(f => Column(f.name))
+    if (remainingCols.size == this.schema.size) {
       this
     } else {
-      df.select(remainingCols: _*)
+      this.select(remainingCols: _*)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -1241,7 +1241,7 @@ class DataFrame private[sql](
    * @since 1.4.0
    */
   def drop(colName: String): DataFrame = {
-    drop(Seq(colName))
+    drop(Seq(colName) : _*)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -1252,7 +1252,7 @@ class DataFrame private[sql](
    */
   @scala.annotation.varargs
   def drop(colNames: String*): DataFrame = {
-    val remainingCols = df.schema.filter(f => colNames.contains(f.name)).map(f=>Column(f.name))
+    val remainingCols = df.schema.filter(f => colNames.contains(f.name)).map(f => Column(f.name))
   	if (remainingCols.size == df.schema.size) {
       this
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -1252,21 +1252,12 @@ class DataFrame private[sql](
    */
   @scala.annotation.varargs
   def drop(colNames: String*): DataFrame = {
-    val resolver = sqlContext.analyzer.resolver
-    val iter = colNames.iterator
-    var df = this
-    while (iter.hasNext) {
-      val colName = iter.next()
-      val shouldDrop = df.schema.exists(f => resolver(f.name, colName))
-      if (shouldDrop) {
-        val colsAfterDrop = df.schema.filter { field =>
-          val name = field.name
-          !resolver(name, colName)
-        }.map(f => Column(f.name))
-        df = df.select(colsAfterDrop : _*)
-      }
+    val remainingColumns = df.schema.filter(f => colNames.contains(f.name)).map(f=>Column(f.name))
+		if (remainingColumns.size == df.schema.size) {
+      this
+    } else {
+      df.select(remainingColumns: _*)
     }
-    df
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -1254,7 +1254,7 @@ class DataFrame private[sql](
   def drop(colNames: String*): DataFrame = {
     val resolver = sqlContext.analyzer.resolver
     val remainingCols =
-      schema.filter(f => colNames.forall(n => !resolver(f.name))).map(f => Column(f.name))
+      schema.filter(f => colNames.forall(n => !resolver(f.name, n))).map(f => Column(f.name))
     if (remainingCols.size == this.schema.size) {
       this
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -1252,11 +1252,11 @@ class DataFrame private[sql](
    */
   @scala.annotation.varargs
   def drop(colNames: String*): DataFrame = {
-    val remainingColumns = df.schema.filter(f => colNames.contains(f.name)).map(f=>Column(f.name))
-		if (remainingColumns.size == df.schema.size) {
+    val remainingCols = df.schema.filter(f => colNames.contains(f.name)).map(f=>Column(f.name))
+  	if (remainingCols.size == df.schema.size) {
       this
     } else {
-      df.select(remainingColumns: _*)
+      df.select(remainingCols: _*)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -1241,17 +1241,7 @@ class DataFrame private[sql](
    * @since 1.4.0
    */
   def drop(colName: String): DataFrame = {
-    val resolver = sqlContext.analyzer.resolver
-    val shouldDrop = schema.exists(f => resolver(f.name, colName))
-    if (shouldDrop) {
-      val colsAfterDrop = schema.filter { field =>
-        val name = field.name
-        !resolver(name, colName)
-      }.map(f => Column(f.name))
-      select(colsAfterDrop : _*)
-    } else {
-      this
-    }
+    drop(colName.toSeq)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -1253,7 +1253,7 @@ class DataFrame private[sql](
   @scala.annotation.varargs
   def drop(colNames: String*): DataFrame = {
     val remainingCols = df.schema.filter(f => colNames.contains(f.name)).map(f => Column(f.name))
-  	if (remainingCols.size == df.schema.size) {
+    if (remainingCols.size == df.schema.size) {
       this
     } else {
       df.select(remainingCols: _*)

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -1252,7 +1252,9 @@ class DataFrame private[sql](
    */
   @scala.annotation.varargs
   def drop(colNames: String*): DataFrame = {
-    val remainingCols = this.schema.filter(f => colNames.contains(f.name)).map(f => Column(f.name))
+    val resolver = sqlContext.analyzer.resolver
+    val remainingCols =
+      schema.filter(f => colNames.forall(n => !resolver(f.name))).map(f => Column(f.name))
     if (remainingCols.size == this.schema.size) {
       this
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -1260,6 +1260,7 @@ class DataFrame private[sql](
    * @group dfops
    * @since 1.6.0
    */
+  @scala.annotation.varargs
   def drop(colNames: String*): DataFrame = {
     val resolver = sqlContext.analyzer.resolver
     val iter = colNames.iterator

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -1241,7 +1241,7 @@ class DataFrame private[sql](
    * @since 1.4.0
    */
   def drop(colName: String): DataFrame = {
-    drop(colName.toSeq)
+    drop(Seq(colName))
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -379,7 +379,7 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
   }
 
   test("drop columns using drop") {
-    val src = Seq((1, 2, 3)).toDF("a", "b", "c")
+    val src = Seq((0, 2, 3)).toDF("a", "b", "c")
     val df = src.drop("a", "b")
     checkAnswer(
       df, src.collect().map(x => Row(x.getInt(2))).toSeq)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -381,8 +381,7 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
   test("drop columns using drop") {
     val src = Seq((0, 2, 3)).toDF("a", "b", "c")
     val df = src.drop("a", "b")
-    checkAnswer(
-      df, src.collect().map(x => Row(x.getInt(2))).toSeq)
+    checkAnswer(df, Row(3))
     assert(df.schema.map(_.name) === Seq("c"))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -378,6 +378,15 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     assert(df.schema.map(_.name) === Seq("value"))
   }
 
+  test("drop columns using drop") {
+    val src = Seq((1,2,3)).toDF("a", "b", "c")
+    val df = src.drop("a", "b")
+    checkAnswer(
+      df,
+      src.collect().map(x => Row(x.getInt(2))).toSeq)
+    assert(df.schema.map(_.name) === Seq("c"))
+  }
+
   test("drop unknown column (no-op)") {
     val df = testData.drop("random")
     checkAnswer(

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -382,8 +382,7 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     val src = Seq((1,2,3)).toDF("a", "b", "c")
     val df = src.drop("a", "b")
     checkAnswer(
-      df,
-      src.collect().map(x => Row(x.getInt(2))).toSeq)
+      df, src.collect().map(x => Row(x.getInt(2))).toSeq)
     assert(df.schema.map(_.name) === Seq("c"))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -379,7 +379,7 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
   }
 
   test("drop columns using drop") {
-    val src = Seq((1,2,3)).toDF("a", "b", "c")
+    val src = Seq((1, 2, 3)).toDF("a", "b", "c")
     val df = src.drop("a", "b")
     checkAnswer(
       df, src.collect().map(x => Row(x.getInt(2))).toSeq)


### PR DESCRIPTION
See the thread Ben started:
http://search-hadoop.com/m/q3RTtveEuhjsr7g/

This PR adds drop() method to DataFrame which accepts multiple column names
