### PR TITLE
[SPARK-11880][Windows][Spark Submit] bin/load-spark-env.cmd loads spark-env.cmd from wrong directory

### DIFF
--- a/bin/load-spark-env.cmd
+++ b/bin/load-spark-env.cmd
@@ -27,7 +27,7 @@ if [%SPARK_ENV_LOADED%] == [] (
   if not [%SPARK_CONF_DIR%] == [] (
     set user_conf_dir=%SPARK_CONF_DIR%
   ) else (
-    set user_conf_dir=%~dp0..\..\conf
+    set user_conf_dir=%~dp0..\conf
   )
 
   call :LoadSparkEnv


### PR DESCRIPTION
- On windows the `bin/load-spark-env.cmd` tries to load `spark-env.cmd` from `%~dp0..\..\conf`, where `~dp0` points to `bin` and `conf` is only one level up.
- Updated `bin/load-spark-env.cmd` to load `spark-env.cmd` from `%~dp0..\conf`, instead of `%~dp0..\..\conf`
