### PR TITLE
[SPARK-11801][CORE] Notify driver when OOM is thrown before executor …

### DIFF
--- a/core/src/main/scala/org/apache/spark/TaskEndReason.scala
+++ b/core/src/main/scala/org/apache/spark/TaskEndReason.scala
@@ -200,6 +200,15 @@ case object TaskKilled extends TaskFailedReason {
 
 /**
  * :: DeveloperApi ::
+ * Task caught OOM exception and needs to be rescheduled.
+ */
+@DeveloperApi
+case object TaskOutOfMemory extends TaskFailedReason {
+  override def toErrorString: String = "TaskOutOfMemory (task caught OutOfMemoryError)"
+}
+
+/**
+ * :: DeveloperApi ::
  * Task requested the driver to commit, but was denied.
  */
 @DeveloperApi

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -24,6 +24,7 @@ import java.nio.ByteBuffer
 import java.util.concurrent.{ConcurrentHashMap, TimeUnit}
 
 import scala.collection.JavaConverters._
+import scala.collection.JavaConversions._
 import scala.collection.mutable.{ArrayBuffer, HashMap}
 import scala.util.control.NonFatal
 
@@ -113,7 +114,11 @@ private[spark] class Executor(
   // Executor for the heartbeat task.
   private val heartbeater = ThreadUtils.newDaemonSingleThreadScheduledExecutor("driver-heartbeater")
 
+  private val shutdownHookLock = new Object()
+
   startDriverHeartbeater()
+
+  addShutdownHook()
 
   def launchTask(
       context: ExecutorBackend,
@@ -143,6 +148,24 @@ private[spark] class Executor(
     if (!isLocal) {
       env.stop()
     }
+  }
+
+  private def addShutdownHook(): AnyRef = {
+    ShutdownHookManager.addShutdownHook(ShutdownHookManager.EXECUTOR_SHUTDOWN_PRIORITY) { () =>
+      // Synchronized with the OOM task handler, which is sending its status update to driver.
+      // Please note that the assumption here is that OOM thread is still running and will gets
+      // the lock prior to this.
+      shutdownHookLock.synchronized {
+        // Cleanup all the tasks which are currently running, so that they would not through
+        // undesirable error messages during shutdown. Please note that kill interrupts all
+        // the running threads and tasks will be killed when interrupts are actually handled.
+        runningTasks.values.foreach(t => t.kill(true))
+      }
+      logInfo("shutdown hook called")
+
+      // Sleep to make sure that status update from OOM handle is flushed to driver.
+      Thread.sleep(conf.getInt("spark.executor.shutdownHookDelay", 300))
+   }
   }
 
   /** Returns the total amount of time this JVM process has spent in garbage collection. */
@@ -290,6 +313,12 @@ private[spark] class Executor(
         case cDE: CommitDeniedException =>
           val reason = cDE.toTaskEndReason
           execBackend.statusUpdate(taskId, TaskState.FAILED, ser.serialize(reason))
+
+        case oom: OutOfMemoryError =>
+          shutdownHookLock.synchronized {
+            logError("Out of memory exception in " + Thread.currentThread(), oom)
+            execBackend.statusUpdate(taskId, TaskState.FAILED, ser.serialize(TaskOutOfMemory))
+          }
 
         case t: Throwable =>
           // Attempt to exit cleanly by informing the driver of our failure.

--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
@@ -144,10 +144,11 @@ private[spark] class DiskBlockManager(blockManager: BlockManager, conf: SparkCon
   }
 
   private def addShutdownHook(): AnyRef = {
-    ShutdownHookManager.addShutdownHook(ShutdownHookManager.TEMP_DIR_SHUTDOWN_PRIORITY + 1) { () =>
-      logInfo("Shutdown hook called")
-      DiskBlockManager.this.doStop()
-    }
+    ShutdownHookManager.addShutdownHook(
+      ShutdownHookManager.DISK_BLOCK_MANAGER_SHUTDOWN_PRIORITY) { () =>
+        logInfo("Shutdown hook called")
+        DiskBlockManager.this.doStop()
+      }
   }
 
   /** Cleanup local dirs and stop shuffle sender. */

--- a/core/src/main/scala/org/apache/spark/util/ShutdownHookManager.scala
+++ b/core/src/main/scala/org/apache/spark/util/ShutdownHookManager.scala
@@ -45,6 +45,18 @@ private[spark] object ShutdownHookManager extends Logging {
    */
   val TEMP_DIR_SHUTDOWN_PRIORITY = 25
 
+  /**
+   * The shutdown priority of disk block manager should be higher than temp directory.
+   */
+  val DISK_BLOCK_MANAGER_SHUTDOWN_PRIORITY = 26
+
+  /**
+   * The shutdown priority of Executor to do the cleanup of the current running tasks. Its
+   * priority should be higher than DiskBlockManager shutdown priority as the tasks may throw
+   * unhandled exceptions if temp directory cleanup is happening in parallel.
+   */
+  val EXECUTOR_SHUTDOWN_PRIORITY = 27
+
   private lazy val shutdownHooks = {
     val manager = new SparkShutdownHookManager()
     manager.install()


### PR DESCRIPTION
…JVM is killed

This fix try to make sure that task which caught OOM will update its status to driver so that driver logs will have enough information why the tasks are lost or executor is lost. This fix does the following 

1) Registers a shutdown hook for executor which does the following 
         a) Synchronizes with OOM handler thread (Assumption is that OOM thread is still running and gets the lock prior to the shutdown hook thread. I thought of introducing some delay, but my runs with fix several times didn't get to that situation.)
         b) Kill all the remaining tasks running in the current container( I thought it would be good to clean the task properly, so that they wont do any job which might throw unwanted error/exceptions)
        c) Sleeps some time so that OOM handler status is flushed to driver(No sleeping causes the status message lost)

2) Separate handler for OOM, so that we can send proper message to driver.
