### PR TITLE
[SPARK-11783][SQL] Fixes execution Hive client when using remote Hive metastore

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -492,7 +492,7 @@ class HiveContext private[hive](
     //
     // Here we enumerate all time `ConfVar`s and convert their values to numeric strings according
     // to their output time units.
-    Seq(
+    val timeConfVars = Seq(
       ConfVars.METASTORE_CLIENT_CONNECT_RETRY_DELAY -> TimeUnit.SECONDS,
       ConfVars.METASTORE_CLIENT_SOCKET_TIMEOUT -> TimeUnit.SECONDS,
       ConfVars.METASTORE_CLIENT_SOCKET_LIFETIME -> TimeUnit.SECONDS,
@@ -535,6 +535,14 @@ class HiveContext private[hive](
     ).map { case (confVar, unit) =>
       confVar.varname -> hiveconf.getTimeVar(confVar, unit).toString
     }.toMap
+
+    // SPARK-11783 When "hive.metastore.uris" is set, it overrides "javax.jdo.option.ConnectionURL",
+    // thus the execution Hive client connects to the actual remote Hive metastore instead of the
+    // Derby metastore created in the temporary directory.  Cleaning this configuration for
+    // the execution Hive client fixes this issue.
+    timeConfVars ++ Seq(
+      ConfVars.METASTOREURIS.varname -> ""
+    )
   }
 
   /**

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -492,7 +492,7 @@ class HiveContext private[hive](
     //
     // Here we enumerate all time `ConfVar`s and convert their values to numeric strings according
     // to their output time units.
-    val timeConfVars = Seq(
+    Seq(
       ConfVars.METASTORE_CLIENT_CONNECT_RETRY_DELAY -> TimeUnit.SECONDS,
       ConfVars.METASTORE_CLIENT_SOCKET_TIMEOUT -> TimeUnit.SECONDS,
       ConfVars.METASTORE_CLIENT_SOCKET_LIFETIME -> TimeUnit.SECONDS,
@@ -535,14 +535,6 @@ class HiveContext private[hive](
     ).map { case (confVar, unit) =>
       confVar.varname -> hiveconf.getTimeVar(confVar, unit).toString
     }.toMap
-
-    // SPARK-11783 When "hive.metastore.uris" is set, it overrides "javax.jdo.option.ConnectionURL",
-    // thus the execution Hive client connects to the actual remote Hive metastore instead of the
-    // Derby metastore created in the temporary directory.  Cleaning this configuration for
-    // the execution Hive client fixes this issue.
-    timeConfVars ++ Seq(
-      ConfVars.METASTOREURIS.varname -> ""
-    )
   }
 
   /**
@@ -744,6 +736,13 @@ private[hive] object HiveContext {
       s"jdbc:derby:;databaseName=${localMetastore.getAbsolutePath};create=true")
     propMap.put("datanucleus.rdbms.datastoreAdapterClassName",
       "org.datanucleus.store.rdbms.adapter.DerbyAdapter")
+
+    // SPARK-11783 When "hive.metastore.uris" is set, it overrides "javax.jdo.option.ConnectionURL",
+    // thus the execution Hive client connects to the actual remote Hive metastore instead of the
+    // Derby metastore created in the temporary directory.  Cleaning this configuration for
+    // the execution Hive client fixes this issue.
+    propMap.put(ConfVars.METASTOREURIS.varname, "")
+
     propMap.toMap
   }
 


### PR DESCRIPTION
When using remote Hive metastore, `hive.metastore.uris` is set to the metastore URI.  However, it overrides `javax.jdo.option.ConnectionURL` unexpectedly, thus the execution Hive client connects to the actual remote Hive metastore instead of the Derby metastore created in the temporary directory.  Cleaning this configuration for the execution Hive client fixes this issue.
