### PR TITLE
[WIP][SPARK-9686][SQL] Redirect JDBC metadata calls to Spark SQL metadata Hive client

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIService.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIService.scala
@@ -40,10 +40,10 @@ private[hive] class SparkSQLCLIService(hiveServer: HiveServer2, hiveContext: Hiv
   extends CLIService(hiveServer)
   with ReflectedCompositeService {
 
+  private val sparkSqlSessionManager = new SparkSQLSessionManager(hiveServer, hiveContext)
+
   override def init(hiveConf: HiveConf) {
     setSuperField(this, "hiveConf", hiveConf)
-
-    val sparkSqlSessionManager = new SparkSQLSessionManager(hiveServer, hiveContext)
     setSuperField(this, "sessionManager", sparkSqlSessionManager)
     addService(sparkSqlSessionManager)
     var sparkServiceUGI: UserGroupInformation = null
@@ -51,7 +51,7 @@ private[hive] class SparkSQLCLIService(hiveServer: HiveServer2, hiveContext: Hiv
     if (UserGroupInformation.isSecurityEnabled) {
       try {
         HiveAuthFactory.loginFromKeytab(hiveConf)
-        sparkServiceUGI = Utils.getUGI()
+        sparkServiceUGI = Utils.getUGI
         setSuperField(this, "serviceUGI", sparkServiceUGI)
       } catch {
         case e @ (_: IOException | _: LoginException) =>
@@ -69,6 +69,77 @@ private[hive] class SparkSQLCLIService(hiveServer: HiveServer2, hiveContext: Hiv
       case GetInfoType.CLI_DBMS_VER => new GetInfoValue(hiveContext.sparkContext.version)
       case _ => super.getInfo(sessionHandle, getInfoType)
     }
+  }
+
+  private def withMetadataHive[T](sessionHandle: SessionHandle)(f: => T): T = {
+    val sessionConf = sparkSqlSessionManager.getSession(sessionHandle).getHiveConf
+    val overridenVarnames = hiveContext.overridenExecutionHiveConfiguration.keys
+    val originalConfs = for {
+      varname <- overridenVarnames
+    } yield varname -> Option(sessionConf.get(varname))
+
+    overridenVarnames.foreach { varname =>
+      val value = hiveContext.metadataHive.getConf(varname, null)
+      if (value == null) sessionConf.unset(varname) else sessionConf.set(varname, value)
+    }
+
+    try hiveContext.metadataHive.withHiveState(f) finally {
+      originalConfs.foreach {
+        case (varname, Some(value)) => sessionConf.set(varname, value)
+        case (varname, _) => sessionConf.unset(varname)
+      }
+    }
+  }
+
+  override def getCatalogs(sessionHandle: SessionHandle): OperationHandle = {
+    withMetadataHive(sessionHandle) {
+      super.getCatalogs(sessionHandle)
+    }
+  }
+
+  override def getSchemas(
+      sessionHandle: SessionHandle,
+      catalogName: String,
+      schemaName: String): OperationHandle = {
+    withMetadataHive(sessionHandle) {
+      super.getSchemas(sessionHandle, catalogName, schemaName)
+    }
+  }
+
+  override def getTables(
+      sessionHandle: SessionHandle,
+      catalogName: String,
+      schemaName: String,
+      tableName: String,
+      tableTypes: JList[String]): OperationHandle = {
+    withMetadataHive(sessionHandle) {
+      super.getTables(sessionHandle, catalogName, schemaName, tableName, tableTypes)
+    }
+  }
+
+  override def getTableTypes(sessionHandle: SessionHandle): OperationHandle = {
+    withMetadataHive(sessionHandle) {
+      super.getTableTypes(sessionHandle)
+    }
+  }
+
+  override def getColumns(
+      sessionHandle: SessionHandle,
+      catalogName: String,
+      schemaName: String,
+      tableName: String,
+      columnName: String): OperationHandle = {
+    withMetadataHive(sessionHandle) {
+      super.getColumns(sessionHandle, catalogName, schemaName, tableName, columnName)
+    }
+  }
+
+  override def getFunctions(
+      sessionHandle: SessionHandle,
+      catalogName: String,
+      schemaName: String,
+      functionName: String): OperationHandle = {
+    super.getFunctions(sessionHandle, catalogName, schemaName, functionName)
   }
 }
 

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
@@ -501,15 +501,15 @@ class HiveThriftBinaryServerSuite extends HiveThriftJdbcTest {
   }
 
   test("JDBC metadata") {
-//    withStatement { statement =>
-//      Seq(
-//        "CREATE TABLE test_table (col INT)",
-//
-//        "CREATE DATABASE test_db",
-//        "USE test_db",
-//        "CREATE TABLE test_table (col INT)"
-//      ).foreach(statement.executeUpdate)
-//    }
+    withStatement { statement =>
+      Seq(
+        "CREATE TABLE test_table (col INT)",
+
+        "CREATE DATABASE test_db",
+        "USE test_db",
+        "CREATE TABLE test_table (col INT)"
+      ).foreach(statement.executeUpdate)
+    }
 
     withConnection { connection =>
       val schemas = connection.getMetaData.getSchemas
@@ -519,13 +519,13 @@ class HiveThriftBinaryServerSuite extends HiveThriftJdbcTest {
           Row("default", null),
           Row("test_db", null)))
     }
-//
-//    withStatement { statement =>
-//      Seq(
-//        "DROP TABLE IF EXISTS test_table",
-//        "DROP DATABASE test_db"
-//      ).foreach(statement.execute)
-//    }
+
+    withStatement { statement =>
+      Seq(
+        "DROP TABLE IF EXISTS test_table",
+        "DROP DATABASE test_db"
+      ).foreach(statement.execute)
+    }
   }
 
   test("SPARK-11043 check operation log root directory") {

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/UISeleniumSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/UISeleniumSuite.scala
@@ -74,7 +74,7 @@ class UISeleniumSuite
   }
 
   ignore("thrift server ui test") {
-    withJdbcStatement { statement =>
+    withStatement { statement =>
       val baseURL = s"http://localhost:$uiPort"
 
       val queries = Seq(

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -197,6 +197,9 @@ class HiveContext private[hive](
   @transient
   protected[sql] lazy val substitutor = new VariableSubstitution()
 
+  @transient
+  protected[hive] lazy val overridenExecutionHiveConfiguration = newTemporaryConfiguration()
+
   /**
    * The copy of the hive client that is used for execution.  Currently this must always be
    * Hive 13 as this is the version of Hive that is packaged with Spark SQL.  This copy of the
@@ -212,7 +215,7 @@ class HiveContext private[hive](
     val loader = new IsolatedClientLoader(
       version = IsolatedClientLoader.hiveVersion(hiveExecutionVersion),
       execJars = Seq(),
-      config = newTemporaryConfiguration(),
+      config = overridenExecutionHiveConfiguration,
       isolationOn = false,
       baseClassLoader = Utils.getContextOrSparkClassLoader)
     loader.createClient().asInstanceOf[ClientWrapper]

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientInterface.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientInterface.scala
@@ -21,6 +21,8 @@ import java.io.PrintStream
 import java.util.{Map => JMap}
 import javax.annotation.Nullable
 
+import org.apache.hadoop.hive.ql.metadata.Hive
+
 import org.apache.spark.sql.catalyst.analysis.{NoSuchDatabaseException, NoSuchTableException}
 import org.apache.spark.sql.catalyst.expressions.Expression
 
@@ -189,4 +191,6 @@ private[hive] trait ClientInterface {
 
   /** Used for testing only.  Removes all metadata from this instance of Hive. */
   def reset(): Unit
+
+  def client: Hive
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
@@ -252,7 +252,7 @@ private[hive] class ClientWrapper(
     false
   }
 
-  def client: Hive = {
+  override def client: Hive = {
     if (clientLoader.cachedHive != null) {
       clientLoader.cachedHive.asInstanceOf[Hive]
     } else {


### PR DESCRIPTION
This PR is based on the patch @navis provided in [SPARK-9686](https://issues.apache.org/jira/browse/SPARK-9686).

Basically, it overrides all JDBC metadata related methods in `SparkSQLCLIService`, overrides session `HiveConf` with proper configurations, and wraps the original calls with `hiveContext.metadataHive.withHiveState`, so that metadata stored in the real Hive metastore can be retrieved.

Unfortunately, both @navis and I observed that this approach doesn't play well with embedded metastore, because Hive somehow tries to establish multiple connections to the local Derby metastore database while Derby doesn't support multi-connection.

I've been digging this for a while but failed to figure out a valid fix/workaround for this issue. My impression is that somehow the `HiveMetaStoreClient` belonging to the metadata Hive client gets a snapshot of the `HiveConf` of the execution Hive client, thus makes Hive try to establish a new connection instead of reusing the existing connection because this `HiveConf` is considered to be "[incompatible][1]" with the session `HiveConf`.

I'm opening this WIP one for memo and further discussion.

[1]: https://github.com/apache/hive/blob/release-1.2.1/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java#L279-L297