### PR TITLE
[SPARK-7889] [Core] WiP History Caching: xu tingjun's patch against master

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
@@ -73,4 +73,6 @@ private[history] abstract class ApplicationHistoryProvider {
   @throws(classOf[SparkException])
   def writeEventLogs(appId: String, attemptId: Option[String], zipStream: ZipOutputStream): Unit
 
+  def getAppStatus(appid: String): Boolean
+
 }

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
@@ -73,6 +73,7 @@ private[history] abstract class ApplicationHistoryProvider {
   @throws(classOf[SparkException])
   def writeEventLogs(appId: String, attemptId: Option[String], zipStream: ZipOutputStream): Unit
 
-  def getAppStatus(appid: String): Boolean
+  @throws(classOf[NoSuchElementException])
+  def isCompleted(appId: String, attemptId: Option[String]): Boolean
 
 }

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -89,6 +89,8 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
   // List of application logs to be deleted by event log cleaner.
   private var attemptsToClean = new mutable.ListBuffer[FsApplicationAttemptInfo]
 
+  private val isAppCompleted = new mutable.HashMap[String, Boolean]()
+
   /**
    * Return a runnable that performs the given operation on the event logs.
    * This operation is expected to be executed periodically.
@@ -537,7 +539,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
       val appCompleted = isApplicationCompleted(eventLog)
       bus.addListener(appListener)
       bus.replay(logInput, logPath.toString, !appCompleted)
-      appStatus.put(logPath.getName(), appCompleted)
+      isAppCompleted.put(logPath.getName(), appCompleted)
 
       // Without an app ID, new logs will render incorrectly in the listing page, so do not list or
       // try to show their UI. Some old versions of Spark generate logs without an app ID, so let
@@ -679,17 +681,15 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
     method.invoke(dfs, action).asInstanceOf[Boolean]
   }
 
-   def getAppStatus(appid: String): Boolean = {
-     if (appStatus.keySet.contains(appid)) {
-       return true
-     }
-     else if (appStatus.contains(appid + EventLoggingListener.IN_PROGRESS)) {
-       return false
-     }
-    else {
-       val e = new NoSuchElementException(s"no app with key $appid.")
-       e.initCause(new NoSuchElementException)
-       throw e
+  def isCompleted(appId: String, attemptId: Option[String]): Boolean = {
+
+    val name = appId + attemptId.map { id => s"_$id" }.getOrElse("")
+    if (isAppCompleted.keySet.contains(name)) {
+      true
+    } else if (isAppCompleted.contains(name + EventLoggingListener.IN_PROGRESS)) {
+      false
+    } else {
+      throw new NoSuchElementException(s"no app with key $appId/$attemptId.")
     }
   }
 
@@ -697,8 +697,6 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
 
 private[history] object FsHistoryProvider {
   val DEFAULT_LOG_DIR = "file:/tmp/spark-events"
-
-  private val appStatus = new mutable.HashMap[String, Boolean]()
 
   // Constants used to parse Spark 1.0.0 log directories.
   val LOG_PREFIX = "EVENT_LOG_"

--- a/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
@@ -66,7 +66,11 @@ private[spark] class SparkUI private (
     attachTab(new EnvironmentTab(this))
     attachTab(new ExecutorsTab(this))
     attachHandler(createStaticHandler(SparkUI.STATIC_RESOURCE_DIR, "/static"))
-    attachHandler(createRedirectHandler("/", "/jobs/", basePath = basePath))
+    if (sc.isDefined) {
+      attachHandler(createRedirectHandler("/", "/jobs", basePath = basePath))
+    } else {
+      attachHandler(createRedirectHandler("/ui", "/jobs", basePath = basePath))
+    }
     attachHandler(ApiRootResource.getServletHandler(this))
     // This should be POST only, but, the YARN AM proxy won't proxy POSTs
     attachHandler(createRedirectHandler(


### PR DESCRIPTION
This is @XuTingjun's patch (#6545) reapplied to trunk with a bit of cleanup (the probe in the history provider is now `isComplete(String appId, Option[String] attemptId`; the conditions around its use and is internals slightly tweaked.

Looking at this code now, I do agree the history provider should have a say in the state of the attempts, I'm not sure if this is the right approach. Having 3x different maps to track app state (including two that never get cleaned up) isn't ideal, and if it were to be so, then the two new ones would have to be thread safe, so as to handle the scenario of "multiple requests coming in at the same time"

I'd rather retain the history server's information alongside the cached app, (as my patch does), though that still leaves the question of how to probe for a updated version and then reload it, especially in a way that is thread safe.

Oh, and testing, obviously.

(once this PR has been tested I'm going to close it; it's here as reference)
