### PR TITLE
[SPARK-11935][PySpark]Send the Python exceptions in TransformFunction and TransformFunctionSerializer to Java

### DIFF
--- a/python/pyspark/streaming/util.py
+++ b/python/pyspark/streaming/util.py
@@ -45,6 +45,8 @@ class TransformFunction(object):
         return self
 
     def call(self, milliseconds, jrdds):
+        # Clear the failure
+        self.failure = None
         try:
             if self.ctx is None:
                 self.ctx = SparkContext._active_spark_context
@@ -66,11 +68,8 @@ class TransformFunction(object):
         except:
             self.failure = traceback.format_exc()
 
-    def getFailure(self):
-        failure = self.failure
-        # Clear the failure
-        self.failure = None
-        return failure
+    def getLastFailure(self):
+        return self.failure
 
     def __repr__(self):
         return "TransformFunction(%s)" % self.func
@@ -98,6 +97,8 @@ class TransformFunctionSerializer(object):
         self.failure = None
 
     def dumps(self, id):
+        # Clear the failure
+        self.failure = None
         try:
             func = self.gateway.gateway_property.pool[id]
             return bytearray(self.serializer.dumps((func.func, func.deserializers)))
@@ -105,17 +106,16 @@ class TransformFunctionSerializer(object):
             self.failure = traceback.format_exc()
 
     def loads(self, data):
+        # Clear the failure
+        self.failure = None
         try:
             f, deserializers = self.serializer.loads(bytes(data))
             return TransformFunction(self.ctx, f, *deserializers)
         except:
             self.failure = traceback.format_exc()
 
-    def getFailure(self):
-        failure = self.failure
-        # Clear the failure
-        self.failure = None
-        return failure
+    def getLastFailure(self):
+        return self.failure
 
     def __repr__(self):
         return "TransformFunctionSerializer(%s)" % self.serializer

--- a/streaming/src/main/scala/org/apache/spark/streaming/api/python/PythonDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/api/python/PythonDStream.scala
@@ -21,13 +21,12 @@ import java.io.{ObjectInputStream, ObjectOutputStream}
 import java.lang.reflect.Proxy
 import java.util.{ArrayList => JArrayList, List => JList}
 
-import org.apache.spark.{SparkException, Logging}
-
 import scala.collection.JavaConverters._
 import scala.language.existentials
 
 import py4j.GatewayServer
 
+import org.apache.spark.SparkException
 import org.apache.spark.api.java._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
@@ -123,7 +122,7 @@ private[python] class TransformFunction(@transient var pfunc: PythonTransformFun
  * PythonTransformFunctionSerializer is logically a singleton that's happens to be
  * implemented as a Python object.
  */
-private[python] object PythonTransformFunctionSerializer extends Logging {
+private[python] object PythonTransformFunctionSerializer {
 
   /**
    * A serializer in Python, used to serialize PythonTransformFunction


### PR DESCRIPTION
The Python exception track in TransformFunction and TransformFunctionSerializer is not sent back to Java. Py4j just throws a very general exception, which is hard to debug.

This PRs adds `getFailure` method to get the failure message in Java side.
