### PR TITLE
[SPARK-11903] Remove --skip-java-test

### DIFF
--- a/make-distribution.sh
+++ b/make-distribution.sh
@@ -69,9 +69,6 @@ while (( "$#" )); do
       echo "Error: '--with-hive' is no longer supported, use Maven options -Phive and -Phive-thriftserver"
       exit_with_usage
       ;;
-    --skip-java-test)
-      SKIP_JAVA_TEST=true
-      ;;
     --with-tachyon)
       SPARK_TACHYON=true
       ;;


### PR DESCRIPTION
Per [@pwendell's comments on SPARK-11903](https://issues.apache.org/jira/browse/SPARK-11903?focusedCommentId=15021511&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15021511) I'm removing this dead code.

If we are concerned about preserving compatibility, I can instead leave the option in and add a warning.

For example:

``` sh
echo "Warning: '--skip-java-test' is deprecated and has no effect."
;;
```

cc @pwendell, @srowen 
