### PR TITLE
[SPARK-11780][SQL] Add type aliases backwards compatibility.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystTypeConverters.scala
@@ -28,7 +28,7 @@ import scala.language.existentials
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.util._
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.{ArrayBasedMapData => _, _}
 import org.apache.spark.unsafe.types.UTF8String
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/SqlParser.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.util.DataTypeParser
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.{DataTypeParser => _, _}
 import org.apache.spark.unsafe.types.CalendarInterval
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/ArrayType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/ArrayType.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.types
 
-import org.apache.spark.sql.catalyst.util.ArrayData
+import org.apache.spark.sql.catalyst.util
 import org.json4s.JsonDSL._
 
 import org.apache.spark.annotation.DeveloperApi
@@ -86,7 +86,7 @@ case class ArrayType(elementType: DataType, containsNull: Boolean) extends DataT
   }
 
   @transient
-  private[sql] lazy val interpretedOrdering: Ordering[ArrayData] = new Ordering[ArrayData] {
+  private[sql] lazy val interpretedOrdering: Ordering[util.ArrayData] = new Ordering[util.ArrayData] {
     private[this] val elementOrdering: Ordering[Any] = elementType match {
       case dt: AtomicType => dt.ordering.asInstanceOf[Ordering[Any]]
       case a : ArrayType => a.interpretedOrdering.asInstanceOf[Ordering[Any]]
@@ -95,7 +95,7 @@ case class ArrayType(elementType: DataType, containsNull: Boolean) extends DataT
         throw new IllegalArgumentException(s"Type $other does not support ordered operations")
     }
 
-    def compare(x: ArrayData, y: ArrayData): Int = {
+    def compare(x: util.ArrayData, y: util.ArrayData): Int = {
       val leftArray = x
       val rightArray = y
       val minLength = scala.math.min(leftArray.numElements(), rightArray.numElements())

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/package.scala
@@ -21,4 +21,24 @@ package org.apache.spark.sql
  * Contains a type system for attributes produced by relations, including complex types like
  * structs, arrays and maps.
  */
-package object types
+package object types {
+
+  /* Aliases for backwards compatibility. See SPARK-11780. */
+  @deprecated("Moved to org.apache.spark.sql.catalyst.util.ArrayBasedMapData", since = "1.6.0")
+  type ArrayBasedMapData = org.apache.spark.sql.catalyst.util.ArrayBasedMapData
+  @deprecated("Moved to org.apache.spark.sql.catalyst.util.ArrayBasedMapData", since = "1.6.0")
+  val ArrayBasedMapData = org.apache.spark.sql.catalyst.util.ArrayBasedMapData
+  @deprecated("Moved to org.apache.spark.sql.catalyst.util.ArrayData", since = "1.6.0")
+  type ArrayData = org.apache.spark.sql.catalyst.util.ArrayData
+  @deprecated("Moved to org.apache.spark.sql.catalyst.util.DataTypeException", since = "1.6.0")
+  type DataTypeException = org.apache.spark.sql.catalyst.util.DataTypeException
+  @deprecated("Moved to org.apache.spark.sql.catalyst.util.DataTypeParser", since = "1.6.0")
+  type DataTypeParser = org.apache.spark.sql.catalyst.util.DataTypeParser
+  @deprecated("Moved to org.apache.spark.sql.catalyst.util.DataTypeParser", since = "1.6.0")
+  val DataTypeParser = org.apache.spark.sql.catalyst.util.DataTypeParser
+  @deprecated("Moved to org.apache.spark.sql.catalyst.util.GenericArrayData", since = "1.6.0")
+  type GenericArrayData = org.apache.spark.sql.catalyst.util.GenericArrayData
+  @deprecated("Moved to org.apache.spark.sql.catalyst.util.MapData", since = "1.6.0")
+  type MapData = org.apache.spark.sql.catalyst.util.MapData
+
+}


### PR DESCRIPTION
Added type aliases in org.apache.spark.sql.types for classes
moved to org.apache.spark.sql.catalyst.util.
