### PR TITLE
[SPARK-11973] [SQL] push filter through aggregation with alias and literals

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -65,6 +65,15 @@ trait PredicateHelper {
     }
   }
 
+  // Substitute any known alias from a map.
+  protected def replaceAlias(
+      condition: Expression,
+      aliases: AttributeMap[Expression]): Expression = {
+    condition.transform {
+      case a: Attribute => aliases.getOrElse(a, a)
+    }
+  }
+
   /**
    * Returns true if `expr` can be evaluated using only the output of `plan`.  This method
    * can be used to determine when it is acceptable to move expression evaluation within a query

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -702,15 +702,15 @@ class FilterPushdownSuite extends PlanTest {
     val originalQuery = testRelation
       .select('a, 'b)
       .groupBy('a)(('a + 1) as 'aa, count('b) as 'c)
-      .where('c === 2L && 'aa === 3)
+      .where(('c === 2L || 'aa > 4) && 'aa < 3)
 
     val optimized = Optimize.execute(originalQuery.analyze)
 
     val correctAnswer = testRelation
       .select('a, 'b)
-      .where('a + 1 === 3)
+      .where('a + 1 < 3)
       .groupBy('a)(('a + 1) as 'aa, count('b) as 'c)
-      .where('c === 2L)
+      .where('c === 2L || 'aa > 4)
       .analyze
 
     comparePlans(optimized, correctAnswer)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -697,4 +697,57 @@ class FilterPushdownSuite extends PlanTest {
 
     comparePlans(optimized, correctAnswer)
   }
+
+  test("aggregate: push down filters with alias") {
+    val originalQuery = testRelation
+      .select('a, 'b)
+      .groupBy('a)(('a + 1) as 'aa, count('b) as 'c)
+      .where('c === 2L && 'aa === 3)
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+
+    val correctAnswer = testRelation
+      .select('a, 'b)
+      .where('a + 1 === 3)
+      .groupBy('a)(('a + 1) as 'aa, count('b) as 'c)
+      .where('c === 2L)
+      .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("aggregate: push down filters with literal") {
+    val originalQuery = testRelation
+      .select('a, 'b)
+      .groupBy('a)('a, count('b) as 'c, "s" as 'd)
+      .where('c === 2L && 'd === "s")
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+
+    val correctAnswer = testRelation
+      .select('a, 'b)
+      .where("s" === "s")
+      .groupBy('a)('a, count('b) as 'c, "s" as 'd)
+      .where('c === 2L)
+      .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("aggregate: don't push down filters which is nondeterministic") {
+    val originalQuery = testRelation
+      .select('a, 'b)
+      .groupBy('a)('a + Rand(10) as 'aa, count('b) as 'c, Rand(11).as("rnd"))
+      .where('c === 2L && 'aa + Rand(10).as("rnd") === 3 && 'rnd === 5)
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+
+    val correctAnswer = testRelation
+      .select('a, 'b)
+      .groupBy('a)('a + Rand(10) as 'aa, count('b) as 'c, Rand(11).as("rnd"))
+      .where('c === 2L && 'aa + Rand(10).as("rnd") === 3 && 'rnd === 5)
+      .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2034,13 +2034,13 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
       val q1 = sql(
         """
           | SELECT k, v from (
-          |   SELECT key k, sum(value) v, 3 c FROM src GROUP BY key
-          | ) t WHERE k = 1 and v > 0 and c = 3
+          |   SELECT key + 1 AS k, sum(value) + 2 AS v, 3 c FROM src GROUP BY key
+          | ) t WHERE k = 0 and v > 0 and c = 3
         """.stripMargin)
       val q2 = sql(
         """
           | SELECT k, v from (
-          |   SELECT key k, sum(value) v, 3 c FROM src WHERE key = 1 GROUP BY key
+          |   SELECT key + 1 AS k, sum(value) + 2 AS v, 3 c FROM src WHERE key + 1 = 0 GROUP BY key
           | ) t WHERE v > 0
         """.stripMargin)
       comparePlans(q1.queryExecution.optimizedPlan, q2.queryExecution.optimizedPlan)

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2028,25 +2028,4 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
       Row(false) :: Row(true) :: Nil)
   }
 
-  test("push filter through aggregation with alias and literals") {
-    withTempTable("src") {
-      Seq((1, 1), (-1, 1)).toDF("key", "value").registerTempTable("src")
-      val q1 = sql(
-        """
-          | SELECT k, v from (
-          |   SELECT key + 1 AS k, sum(value) + 2 AS v, 3 c FROM src GROUP BY key
-          | ) t WHERE k = 0 and v > 0 and c = 3
-        """.stripMargin)
-      val q2 = sql(
-        """
-          | SELECT k, v from (
-          |   SELECT key + 1 AS k, sum(value) + 2 AS v, 3 c FROM src WHERE key + 1 = 0 GROUP BY key
-          | ) t WHERE v > 0
-        """.stripMargin)
-      comparePlans(q1.queryExecution.optimizedPlan, q2.queryExecution.optimizedPlan)
-      checkAnswer(q1, q2)
-    }
-
-  }
-
 }


### PR DESCRIPTION
Currently, filter can't be pushed through aggregation with alias or literals, this patch fix that.

After this patch, the time of TPC-DS query 4 go down to 13 seconds from 141 seconds (10x improvements).

cc @nongli  @yhuai 
