### PR TITLE
[SPARK-11989][SQL] Only use commit in JDBC data source if the underlying database supports transactions

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -129,8 +129,8 @@ object JdbcUtils extends Logging {
     val supportsTransactions = try {
       conn.getMetaData().supportsDataManipulationTransactionsOnly() ||
       conn.getMetaData().supportsDataDefinitionAndDataManipulationTransactions()
-    } catch { 
-      case NonFatal(e) => 
+    } catch {
+      case NonFatal(e) =>
         logWarning("Exception while detecting transaction support", e)
         true
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -129,7 +129,7 @@ object JdbcUtils extends Logging {
       dialect: JdbcDialect): Iterator[Byte] = {
     val conn = getConnection()
     var committed = false
-    val supportsTransactions = Try( 
+    val supportsTransactions = Try(
       conn.getMetaData().supportsDataManipulationTransactionsOnly() ||
       conn.getMetaData().supportsDataDefinitionAndDataManipulationTransactions()
       ).getOrElse( true )

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -131,8 +131,9 @@ object JdbcUtils extends Logging {
     } catch { 
       case _: Exception => true
     }
+
     try {
-      if (supportsTransactions){
+      if (supportsTransactions) {
         conn.setAutoCommit(false) // Everything in the same db transaction.
       }
       val stmt = insertStatement(conn, table, rddSchema)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -48,10 +48,6 @@ object JdbcUtils extends Logging {
     // Somewhat hacky, but there isn't a good way to identify whether a table exists for all
     // SQL database systems using JDBC meta data calls, considering "table" could also include
     // the database name. Query used to find table exists can be overriden by the dialects.
-
-    System.out.println()
-    System.out.println("Query: " + dialect.getTableExistsQuery(table) )
-    System.out.println()
     Try(conn.prepareStatement(dialect.getTableExistsQuery(table)).executeQuery()).isSuccess
   }
 
@@ -129,10 +125,12 @@ object JdbcUtils extends Logging {
       dialect: JdbcDialect): Iterator[Byte] = {
     val conn = getConnection()
     var committed = false
-    val supportsTransactions = Try(
+    val supportsTransactions = try {
       conn.getMetaData().supportsDataManipulationTransactionsOnly() ||
       conn.getMetaData().supportsDataDefinitionAndDataManipulationTransactions()
-      ).getOrElse( true )
+    } catch { 
+      case _: Exception => true
+    }
     try {
       if (supportsTransactions){
         conn.setAutoCommit(false) // Everything in the same db transaction.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -129,7 +129,7 @@ object JdbcUtils extends Logging {
       conn.getMetaData().supportsDataManipulationTransactionsOnly() ||
       conn.getMetaData().supportsDataDefinitionAndDataManipulationTransactions()
     } catch { 
-      case e: Exception => logWarning("Transaction succeeded, but closing failed", e)
+      case e: Exception => logWarning("Exception while detecting transaction support", e)
                            true
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -21,6 +21,7 @@ import java.sql.{Connection, PreparedStatement}
 import java.util.Properties
 
 import scala.util.Try
+import scala.util.control.NonFatal
 
 import org.apache.spark.Logging
 import org.apache.spark.sql.jdbc.{JdbcDialect, JdbcType, JdbcDialects}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -129,8 +129,9 @@ object JdbcUtils extends Logging {
       conn.getMetaData().supportsDataManipulationTransactionsOnly() ||
       conn.getMetaData().supportsDataDefinitionAndDataManipulationTransactions()
     } catch { 
-      case e: Exception => logWarning("Exception while detecting transaction support", e)
-                           true
+      case NonFatal(e) => 
+        logWarning("Exception while detecting transaction support", e)
+        true
     }
 
     try {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -129,7 +129,8 @@ object JdbcUtils extends Logging {
       conn.getMetaData().supportsDataManipulationTransactionsOnly() ||
       conn.getMetaData().supportsDataDefinitionAndDataManipulationTransactions()
     } catch { 
-      case _: Exception => true
+      case e: Exception => logWarning("Transaction succeeded, but closing failed", e)
+                           true
     }
 
     try {


### PR DESCRIPTION
Fixes [SPARK-11989](https://issues.apache.org/jira/browse/SPARK-11989)
