### PR TITLE
[SPARK-12003] [SQL] remove the prefix for name after expanded star

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -204,7 +204,7 @@ case class UnresolvedStar(target: Option[Seq[String]]) extends Star with Unevalu
         case s: StructType => s.zipWithIndex.map {
           case (f, i) =>
             val extract = GetStructField(attribute.get, i)
-            Alias(extract, target.get + "." + f.name)()
+            Alias(extract, f.name)()
         }
 
         case _ => {


### PR DESCRIPTION
Right now, the expended start will include the name of expression as prefix for column, that's not better than without expending, we should not have the prefix.
