### PR TITLE
[SPARK-11206] (Followup) Fix SQLListenerMemoryLeakSuite test error

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -241,7 +241,7 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
   private var _jars: Seq[String] = _
   private var _files: Seq[String] = _
   private var _shutdownHookRef: AnyRef = _
-  private val _stopHook = new ListBuffer[() => Unit]()
+  private val _stopHooks = new ListBuffer[() => Unit]()
 
   /* ------------------------------------------------------------------------------------- *
    | Accessors and public fields. These provide access to the internal state of the        |
@@ -1624,7 +1624,7 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
    * sparkContext is being stopped.
    */
   private[spark] def addStopHook(hook: () => Unit): Unit = {
-    _stopHook += hook
+    _stopHooks += hook
   }
 
   /**
@@ -1773,7 +1773,7 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
     // Unset YARN mode system env variable, to allow switching between cluster types.
     System.clearProperty("SPARK_YARN_MODE")
     SparkContext.clearActiveContext()
-    _stopHook.foreach(_())
+    _stopHooks.foreach(_())
     logInfo("Successfully stopped SparkContext")
   }
 

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1773,10 +1773,11 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
     // Unset YARN mode system env variable, to allow switching between cluster types.
     System.clearProperty("SPARK_YARN_MODE")
     SparkContext.clearActiveContext()
-    _stopHooks.foreach(_())
+    _stopHooks.foreach(hook => Utils.tryLogNonFatalError {
+      hook()
+    })
     logInfo("Successfully stopped SparkContext")
   }
-
 
   /**
    * Get Spark's home location from either a value set through the constructor,

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -29,7 +29,7 @@ import java.util.UUID.randomUUID
 import scala.collection.JavaConverters._
 import scala.collection.{Map, Set}
 import scala.collection.generic.Growable
-import scala.collection.mutable.HashMap
+import scala.collection.mutable.{ListBuffer, HashMap}
 import scala.reflect.{ClassTag, classTag}
 import scala.util.control.NonFatal
 
@@ -241,6 +241,7 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
   private var _jars: Seq[String] = _
   private var _files: Seq[String] = _
   private var _shutdownHookRef: AnyRef = _
+  private val _stopHook = new ListBuffer[() => Unit]()
 
   /* ------------------------------------------------------------------------------------- *
    | Accessors and public fields. These provide access to the internal state of the        |
@@ -1619,6 +1620,14 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
   }
 
   /**
+   * Adds a stop hook which can be used to clean up additional resource. This is called when the
+   * sparkContext is being stopped.
+   */
+  private[spark] def addStopHook(hook: () => Unit): Unit = {
+    _stopHook += hook
+  }
+
+  /**
    * Adds a JAR dependency for all tasks to be executed on this SparkContext in the future.
    * The `path` passed can be either a local file, a file in HDFS (or other Hadoop-supported
    * filesystems), an HTTP, HTTPS or FTP URI, or local:/path for a file on every worker node.
@@ -1764,6 +1773,7 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
     // Unset YARN mode system env variable, to allow switching between cluster types.
     System.clearProperty("SPARK_YARN_MODE")
     SparkContext.clearActiveContext()
+    _stopHook.foreach(_())
     logInfo("Successfully stopped SparkContext")
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -78,6 +78,12 @@ class SQLContext private[sql](
   }
   def this(sparkContext: JavaSparkContext) = this(sparkContext.sc)
 
+  sparkContext.addStopHook(() => {
+    SQLContext.clearInstantiatedContext()
+    SQLContext.clearActive()
+    SQLContext.clearSqlListener()
+  })
+
   // If spark.sql.allowMultipleContexts is true, we will throw an exception if a user
   // wants to create a new root SQLContext (a SLQContext that is not created by newSession).
   private val allowMultipleContexts =

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLListenerSuite.scala
@@ -343,6 +343,8 @@ class SQLListenerMemoryLeakSuite extends SparkFunSuite {
       .set("spark.sql.ui.retainedExecutions", "50") // Set it to 50 to run this test quickly
     val sc = new SparkContext(conf)
     try {
+      // Clear the sql listener created by a previous test suite.
+      SQLContext.clearSqlListener()
       val sqlContext = new SQLContext(sc)
       import sqlContext.implicits._
       // Run 100 successful executions and 100 failed executions.


### PR DESCRIPTION
A followup to #9297, fix the SQLListenerMemoryLeakSuite test error. The [failure](https://amplab.cs.berkeley.edu/jenkins/job/Spark-Master-Maven-pre-YARN/HADOOP_VERSION=2.0.0-mr1-cdh4.1.2,label=spark-test/4896/) occurs because a `sqlListener` created by a previous test suite is not cleared in the SQLListenerMemoryLeakSuite.
In the failure case, the previous test suite DateFunctionsSuite has 91 completed executions. So the error message is `91 was not less than or equal to 50.`

For test suites extends `SharedSQLContext`, the sqlListener is cleared in the method `beforeAll`. Since `SQLListenerMemoryLeakSuite` doesn't extend `SharedSQLContext`, the `sqlListener` need to be cleared manually before creating the `SQLContext`.

/cc @vanzin @JoshRosen @chenghao-intel 
