### PR TITLE
[SPARK-11997][SQL] NPE when save a DataFrame as parquet and partitioned by long column

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -606,17 +606,9 @@ abstract class HadoopFsRelation private[sql](
         // we need to cast into the data type that user specified.
         def castPartitionValuesToUserSchema(row: InternalRow) = {
           InternalRow((0 until row.numFields).map { i =>
-            row.isNullAt(i) match {
-              case true =>
-                Cast(
-                  Literal.create(null, StringType),
-                  userProvidedSchema.fields(i).dataType).eval()
-              case false =>
-                Cast(
-                  Literal.create(row.getString(i), StringType),
-                  userProvidedSchema.fields(i).dataType).eval()
-
-            }
+            Cast(
+              Literal.create(row.getUTF8String(i), StringType),
+              userProvidedSchema.fields(i).dataType).eval()
           }: _*)
         }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -606,9 +606,17 @@ abstract class HadoopFsRelation private[sql](
         // we need to cast into the data type that user specified.
         def castPartitionValuesToUserSchema(row: InternalRow) = {
           InternalRow((0 until row.numFields).map { i =>
-            Cast(
-              Literal.create(row.getString(i), StringType),
-              userProvidedSchema.fields(i).dataType).eval()
+            row.isNullAt(i) match {
+              case true =>
+                Cast(
+                  Literal.create(null, StringType),
+                  userProvidedSchema.fields(i).dataType).eval()
+              case false =>
+                Cast(
+                  Literal.create(row.getString(i), StringType),
+                  userProvidedSchema.fields(i).dataType).eval()
+
+            }
           }: _*)
         }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
@@ -252,6 +252,19 @@ class ParquetQuerySuite extends QueryTest with ParquetTest with SharedSQLContext
     }
   }
 
+  test("SPARK-11997 parquet with null partition values") {
+    withTempPath { dir =>
+      val path = dir.getCanonicalPath
+      sqlContext.range(1, 3)
+        .selectExpr("if(id % 2 = 0, null, id) AS n", "id")
+        .write.partitionBy("n").parquet(path)
+
+      checkAnswer(
+        sqlContext.read.parquet(path).filter("n is null"),
+        Row(2, null))
+    }
+  }
+
   // This test case is ignored because of parquet-mr bug PARQUET-370
   ignore("SPARK-10301 requested schema clipping - schemas with disjoint sets of fields") {
     withTempPath { dir =>


### PR DESCRIPTION
Check for partition column null-ability while building the partition spec. 
