### PR TITLE
[SPARK-12023][BUILD] Fix warnings while packaging spark with maven.

### DIFF
--- a/assembly/src/main/assembly/assembly.xml
+++ b/assembly/src/main/assembly/assembly.xml
@@ -32,7 +32,7 @@
       <directory>
         ${project.parent.basedir}/core/src/main/resources/org/apache/spark/ui/static/
       </directory>
-      <outputDirectory>/ui-resources/org/apache/spark/ui/static</outputDirectory>
+      <outputDirectory>ui-resources/org/apache/spark/ui/static</outputDirectory>
       <includes>
         <include>**/*</include>
       </includes>
@@ -41,7 +41,7 @@
       <directory>
         ${project.parent.basedir}/sbin/
       </directory>
-      <outputDirectory>/sbin</outputDirectory>
+      <outputDirectory>sbin</outputDirectory>
       <includes>
         <include>**/*</include>
       </includes>
@@ -50,7 +50,7 @@
       <directory>
         ${project.parent.basedir}/bin/
       </directory>
-      <outputDirectory>/bin</outputDirectory>
+      <outputDirectory>bin</outputDirectory>
       <includes>
         <include>**/*</include>
       </includes>
@@ -59,7 +59,7 @@
       <directory>
         ${project.parent.basedir}/assembly/target/${spark.jar.dir}
       </directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <includes>
         <include>${spark.jar.basename}</include>
       </includes>

--- a/external/mqtt/src/main/assembly/assembly.xml
+++ b/external/mqtt/src/main/assembly/assembly.xml
@@ -24,7 +24,7 @@
   <fileSets>
     <fileSet>
       <directory>${project.build.directory}/scala-${scala.binary.version}/test-classes</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
     </fileSet>
   </fileSets>
 


### PR DESCRIPTION
this is a trivial fix, discussed [here](http://stackoverflow.com/questions/28500401/maven-assembly-plugin-warning-the-assembly-descriptor-contains-a-filesystem-roo/).
