### PR TITLE
[Spark-10625] [SQL] Spark SQL JDBC read/write is unable to handle JDBC Drivers that adds unserializable objects into connection properties

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/DriverRegistry.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/DriverRegistry.scala
@@ -57,4 +57,3 @@ object DriverRegistry extends Logging {
     case driver => driver.getClass.getCanonicalName
   }
 }
-

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -187,7 +187,7 @@ private[sql] object JDBCRDD extends Logging {
         case e: ClassNotFoundException =>
           logWarning(s"Couldn't find class $driver", e)
       }
-      DriverManager.getConnection(url, properties)
+      DriverManager.getConnection(url, JDBCRelation.getEffectiveProperties(properties))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -21,13 +21,12 @@ import java.math.BigDecimal
 import java.sql.DriverManager
 import java.util.{Calendar, GregorianCalendar, Properties}
 
-import org.h2.jdbc.JdbcSQLException
-import org.scalatest.BeforeAndAfter
-
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
+import org.h2.jdbc.JdbcSQLException
+import org.scalatest.BeforeAndAfter
 
 class JDBCSuite extends SparkFunSuite with BeforeAndAfter with SharedSQLContext {
   import testImplicits._
@@ -467,6 +466,13 @@ class JDBCSuite extends SparkFunSuite with BeforeAndAfter with SharedSQLContext 
     assert(derbyDialect.getJDBCType(StringType).map(_.databaseTypeDefinition).get == "CLOB")
     assert(derbyDialect.getJDBCType(ByteType).map(_.databaseTypeDefinition).get == "SMALLINT")
     assert(derbyDialect.getJDBCType(BooleanType).map(_.databaseTypeDefinition).get == "BOOLEAN")
+  }
+
+  test("Basic API with Unserializable Driver Properties") {
+    UnserializableDriverHelper.replaceDriverDuring {
+      assert(sqlContext.read.jdbc(
+        urlWithUserAndPass, "TEST.PEOPLE", new Properties).collect().length === 3)
+    }
   }
 
   test("table exists query by jdbc dialect") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCWriteSuite.scala
@@ -20,12 +20,11 @@ package org.apache.spark.sql.jdbc
 import java.sql.DriverManager
 import java.util.Properties
 
-import org.scalatest.BeforeAndAfter
-
-import org.apache.spark.sql.{Row, SaveMode}
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.{Row, SaveMode}
 import org.apache.spark.util.Utils
+import org.scalatest.BeforeAndAfter
 
 class JDBCWriteSuite extends SharedSQLContext with BeforeAndAfter {
 
@@ -150,5 +149,13 @@ class JDBCWriteSuite extends SharedSQLContext with BeforeAndAfter {
     sql("INSERT OVERWRITE TABLE PEOPLE1 SELECT * FROM PEOPLE")
     assert(2 === sqlContext.read.jdbc(url1, "TEST.PEOPLE1", properties).count)
     assert(2 === sqlContext.read.jdbc(url1, "TEST.PEOPLE1", properties).collect()(0).length)
+  }
+
+  test("INSERT to JDBC Datasource with Unserializable Driver Properties") {
+    UnserializableDriverHelper.replaceDriverDuring {
+      sql("INSERT INTO TABLE PEOPLE1 SELECT * FROM PEOPLE")
+      assert(2 === sqlContext.read.jdbc(url1, "TEST.PEOPLE1", properties).count)
+      assert(2 === sqlContext.read.jdbc(url1, "TEST.PEOPLE1", properties).collect()(0).length)
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/UnserializableDriverHelper.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/UnserializableDriverHelper.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.jdbc
+
+import java.sql.{DriverManager, Connection}
+import java.util.Properties
+import java.util.logging.Logger
+
+object UnserializableDriverHelper {
+
+  def replaceDriverDuring[T](f: => T): T = {
+    import scala.collection.JavaConverters._
+
+    object UnserializableH2Driver extends org.h2.Driver {
+
+      override def connect(url: String, info: Properties): Connection = {
+
+        val result = super.connect(url, info)
+        info.put("unserializableDriver", this)
+        result
+      }
+
+      override def getParentLogger: Logger = null
+    }
+
+    val oldDrivers = DriverManager.getDrivers.asScala.filter(_.acceptsURL("jdbc:h2:")).toSeq
+    oldDrivers.foreach{
+      DriverManager.deregisterDriver
+    }
+    DriverManager.registerDriver(UnserializableH2Driver)
+
+    val result = try {
+      f
+    }
+    finally {
+      DriverManager.deregisterDriver(UnserializableH2Driver)
+      oldDrivers.foreach{
+        DriverManager.registerDriver
+      }
+    }
+    result
+  }
+}


### PR DESCRIPTION
this pull request has several commits squashed together
