### PR TITLE
[SPARK-12009][Yarn]Avoid to re-allocating yarn container while driver want to stop all Executors 

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -258,9 +258,9 @@ private[spark] class ApplicationMaster(
   }
 
   private def sparkContextStopped(sc: SparkContext) = {
-    sparkContextRef.compareAndSet(sc, null)
     reporterThread.interrupt()
     reporterThread = null
+    sparkContextRef.compareAndSet(sc, null)
   }
 
   private def registerAM(

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -259,6 +259,8 @@ private[spark] class ApplicationMaster(
 
   private def sparkContextStopped(sc: SparkContext) = {
     sparkContextRef.compareAndSet(sc, null)
+    reporterThread.interrupt()
+    reporterThread = null
   }
 
   private def registerAM(
@@ -621,13 +623,9 @@ private[spark] class ApplicationMaster(
     }
 
     override def onDisconnected(remoteAddress: RpcAddress): Unit = {
-      // In cluster mode, shut down reporterThread in order to avoid to re-allocating containers
-      // and do not rely on the disassociated event to exit
+      // In cluster mode, do not rely on the disassociated event to exit
       // This avoids potentially reporting incorrect exit codes if the driver fails
-      if (isClusterMode) {
-        reporterThread.interrupt()
-        reporterThread = null
-      } else {
+      if (!isClusterMode) {
         logInfo(s"Driver terminated or disconnected! Shutting down. $remoteAddress")
         finish(FinalApplicationStatus.SUCCEEDED, ApplicationMaster.EXIT_SUCCESS)
       }


### PR DESCRIPTION
when it is yarn-cluster mode and user had called sc.stop(), but main function continue to run, need to shut down reporterThread in order to avoid to re-allocating containers. 
@suyanNone  @vanzin @andrewor14 Can you take a look at this? Thanks.
