### PR TITLE
[SPARK-12044] [SparkR] Fix usage of isnan, isNaN

### DIFF
--- a/R/pkg/R/column.R
+++ b/R/pkg/R/column.R
@@ -56,7 +56,7 @@ operators <- list(
   "&" = "and", "|" = "or", #, "!" = "unary_$bang"
   "^" = "pow"
 )
-column_functions1 <- c("asc", "desc", "isNull", "isNotNull")
+column_functions1 <- c("asc", "desc", "isNaN", "isNull", "isNotNull")
 column_functions2 <- c("like", "rlike", "startsWith", "endsWith", "getField", "getItem", "contains")
 
 createOperator <- function(op) {

--- a/R/pkg/R/functions.R
+++ b/R/pkg/R/functions.R
@@ -488,15 +488,27 @@ setMethod("initcap",
             column(jc)
           })
 
-#' isnan
+#' is.nan
 #'
-#' Return true if the column is NaN.
+#' Return true if the column is NaN, alias for \link{isnan}
 #'
-#' @rdname isnan
-#' @name isnan
+#' @rdname is.nan
+#' @name is.nan
 #' @family normal_funcs
 #' @export
-#' @examples \dontrun{isnan(df$c)}
+#' @examples
+#' \dontrun{
+#' is.nan(df$c)
+#' isnan(df$c)
+#' }
+setMethod("is.nan",
+          signature(x = "Column"),
+          function(x) {
+            isnan(x)
+          })
+
+#' @rdname is.nan
+#' @name isnan
 setMethod("isnan",
           signature(x = "Column"),
           function(x) {

--- a/R/pkg/R/functions.R
+++ b/R/pkg/R/functions.R
@@ -516,22 +516,6 @@ setMethod("isnan",
             column(jc)
           })
 
-#' isnull
-#'
-#' Return true if the column is NULL.
-#'
-#' @rdname isnull
-#' @name isnull
-#' @family normal_funcs
-#' @export
-#' @examples \dontrun{isnull(df$c)}
-setMethod("isnull",
-          signature(x = "Column"),
-          function(x) {
-            jc <- callJStatic("org.apache.spark.sql.functions", "isnull", x@jc)
-            column(jc)
-          })
-
 #' kurtosis
 #'
 #' Aggregate function: returns the kurtosis of the values in a group.

--- a/R/pkg/R/functions.R
+++ b/R/pkg/R/functions.R
@@ -488,19 +488,35 @@ setMethod("initcap",
             column(jc)
           })
 
-#' isNaN
+#' isnan
 #'
-#' Return true iff the column is NaN.
+#' Return true if the column is NaN.
 #'
-#' @rdname isNaN
-#' @name isNaN
+#' @rdname isnan
+#' @name isnan
 #' @family normal_funcs
 #' @export
-#' @examples \dontrun{isNaN(df$c)}
-setMethod("isNaN",
+#' @examples \dontrun{isnan(df$c)}
+setMethod("isnan",
           signature(x = "Column"),
           function(x) {
-            jc <- callJStatic("org.apache.spark.sql.functions", "isNaN", x@jc)
+            jc <- callJStatic("org.apache.spark.sql.functions", "isnan", x@jc)
+            column(jc)
+          })
+
+#' isnull
+#'
+#' Return true if the column is NULL.
+#'
+#' @rdname isnull
+#' @name isnull
+#' @family normal_funcs
+#' @export
+#' @examples \dontrun{isnull(df$c)}
+setMethod("isnull",
+          signature(x = "Column"),
+          function(x) {
+            jc <- callJStatic("org.apache.spark.sql.functions", "isnull", x@jc)
             column(jc)
           })
 

--- a/R/pkg/R/generics.R
+++ b/R/pkg/R/generics.R
@@ -802,15 +802,7 @@ setGeneric("instr", function(y, x) { standardGeneric("instr") })
 
 #' @rdname is.nan
 #' @export
-setGeneric("is.nan")
-
-#' @rdname is.nan
-#' @export
 setGeneric("isnan", function(x) { standardGeneric("isnan") })
-
-#' @rdname isnull
-#' @export
-setGeneric("isnull", function(x) { standardGeneric("isnull") })
 
 #' @rdname kurtosis
 #' @export

--- a/R/pkg/R/generics.R
+++ b/R/pkg/R/generics.R
@@ -800,7 +800,11 @@ setGeneric("initcap", function(x) { standardGeneric("initcap") })
 #' @export
 setGeneric("instr", function(y, x) { standardGeneric("instr") })
 
-#' @rdname isnan
+#' @rdname is.nan
+#' @export
+setGeneric("is.nan")
+
+#' @rdname is.nan
 #' @export
 setGeneric("isnan", function(x) { standardGeneric("isnan") })
 

--- a/R/pkg/R/generics.R
+++ b/R/pkg/R/generics.R
@@ -623,6 +623,10 @@ setGeneric("getItem", function(x, ...) { standardGeneric("getItem") })
 
 #' @rdname column
 #' @export
+setGeneric("isNaN", function(x) { standardGeneric("isNaN") })
+
+#' @rdname column
+#' @export
 setGeneric("isNull", function(x) { standardGeneric("isNull") })
 
 #' @rdname column
@@ -796,9 +800,13 @@ setGeneric("initcap", function(x) { standardGeneric("initcap") })
 #' @export
 setGeneric("instr", function(y, x) { standardGeneric("instr") })
 
-#' @rdname isNaN
+#' @rdname isnan
 #' @export
-setGeneric("isNaN", function(x) { standardGeneric("isNaN") })
+setGeneric("isnan", function(x) { standardGeneric("isnan") })
+
+#' @rdname isnull
+#' @export
+setGeneric("isnull", function(x) { standardGeneric("isnull") })
 
 #' @rdname kurtosis
 #' @export

--- a/R/pkg/inst/tests/test_sparkSQL.R
+++ b/R/pkg/inst/tests/test_sparkSQL.R
@@ -878,7 +878,7 @@ test_that("column functions", {
   c2 <- avg(c) + base64(c) + bin(c) + bitwiseNOT(c) + cbrt(c) + ceil(c) + cos(c)
   c3 <- cosh(c) + count(c) + crc32(c) + exp(c)
   c4 <- explode(c) + expm1(c) + factorial(c) + first(c) + floor(c) + hex(c)
-  c5 <- hour(c) + initcap(c) + isnan(c) + isnull(c) + last(c) + last_day(c) + length(c)
+  c5 <- hour(c) + initcap(c) + last(c) + last_day(c) + length(c)
   c6 <- log(c) + (c) + log1p(c) + log2(c) + lower(c) + ltrim(c) + max(c) + md5(c)
   c7 <- mean(c) + min(c) + month(c) + negate(c) + quarter(c)
   c8 <- reverse(c) + rint(c) + round(c) + rtrim(c) + sha1(c)
@@ -889,6 +889,7 @@ test_that("column functions", {
   c13 <- lead("col", 1) + lead(c, 1) + lag("col", 1) + lag(c, 1)
   c14 <- cume_dist() + ntile(1)
   c15 <- dense_rank() + percent_rank() + rank() + row_number()
+  c16 <- isnan(c) + isNaN(c) + isnull(c) + isNull(c) + isNotNull(c)
 
   # Test if base::rank() is exposed
   expect_equal(class(rank())[[1]], "Column")

--- a/R/pkg/inst/tests/test_sparkSQL.R
+++ b/R/pkg/inst/tests/test_sparkSQL.R
@@ -892,7 +892,7 @@ test_that("column functions", {
   c16 <- is.nan(c) + isnan(c) + isNaN(c)
 
   # Test if base::is.nan() is exposed
-  expect_equal(is.nan(c(0/0, 1/0 - 1/0)), c(TRUE, TRUE))
+  expect_equal(is.nan(c("a", "b")), c(FALSE, FALSE))
 
   # Test if base::rank() is exposed
   expect_equal(class(rank())[[1]], "Column")

--- a/R/pkg/inst/tests/test_sparkSQL.R
+++ b/R/pkg/inst/tests/test_sparkSQL.R
@@ -889,7 +889,7 @@ test_that("column functions", {
   c13 <- lead("col", 1) + lead(c, 1) + lag("col", 1) + lag(c, 1)
   c14 <- cume_dist() + ntile(1)
   c15 <- dense_rank() + percent_rank() + rank() + row_number()
-  c16 <- isnan(c) + isNaN(c) + isnull(c) + isNull(c) + isNotNull(c)
+  c16 <- is.nan(c) + isnan(c) + isnull(c) + isNaN(c) + isNull(c) + isNotNull(c)
 
   # Test if base::rank() is exposed
   expect_equal(class(rank())[[1]], "Column")

--- a/R/pkg/inst/tests/test_sparkSQL.R
+++ b/R/pkg/inst/tests/test_sparkSQL.R
@@ -889,7 +889,10 @@ test_that("column functions", {
   c13 <- lead("col", 1) + lead(c, 1) + lag("col", 1) + lag(c, 1)
   c14 <- cume_dist() + ntile(1)
   c15 <- dense_rank() + percent_rank() + rank() + row_number()
-  c16 <- is.nan(c) + isnan(c) + isnull(c) + isNaN(c) + isNull(c) + isNotNull(c)
+  c16 <- is.nan(c) + isnan(c) + isNaN(c)
+
+  # Test if base::is.nan() is exposed
+  expect_equal(is.nan(c(0/0, 1/0 - 1/0)), c(TRUE, TRUE))
 
   # Test if base::rank() is exposed
   expect_equal(class(rank())[[1]], "Column")

--- a/R/pkg/inst/tests/test_sparkSQL.R
+++ b/R/pkg/inst/tests/test_sparkSQL.R
@@ -878,7 +878,7 @@ test_that("column functions", {
   c2 <- avg(c) + base64(c) + bin(c) + bitwiseNOT(c) + cbrt(c) + ceil(c) + cos(c)
   c3 <- cosh(c) + count(c) + crc32(c) + exp(c)
   c4 <- explode(c) + expm1(c) + factorial(c) + first(c) + floor(c) + hex(c)
-  c5 <- hour(c) + initcap(c) + isNaN(c) + last(c) + last_day(c) + length(c)
+  c5 <- hour(c) + initcap(c) + isnan(c) + isnull(c) + last(c) + last_day(c) + length(c)
   c6 <- log(c) + (c) + log1p(c) + log2(c) + lower(c) + ltrim(c) + max(c) + md5(c)
   c7 <- mean(c) + min(c) + month(c) + negate(c) + quarter(c)
   c8 <- reverse(c) + rint(c) + round(c) + rtrim(c) + sha1(c)


### PR DESCRIPTION
1, Add `isNaN` to `Column` for SparkR. `Column` should has three related variable functions: `isNaN, isNull, isNotNull`.
2, Replace `DataFrame.isNaN` with `DataFrame.isnan` at SparkR side. Because `DataFrame.isNaN` has been deprecated and will be removed at Spark 2.0.
<del>3, Add `isnull` to `DataFrame` for SparkR. `DataFrame` should has two related functions: `isnan, isnull`.<del>

cc @shivaram @sun-rui @felixcheung 
