### PR TITLE
[SPARK-12000] Fixes compilation issues with java8 and sbt.

### DIFF
--- a/network/common/src/main/java/org/apache/spark/network/client/StreamCallback.java
+++ b/network/common/src/main/java/org/apache/spark/network/client/StreamCallback.java
@@ -21,8 +21,8 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 /**
- * Callback for streaming data. Stream data will be offered to the {@link onData(ByteBuffer)}
- * method as it arrives. Once all the stream data is received, {@link onComplete()} will be
+ * Callback for streaming data. Stream data will be offered to the {@link onData(String, ByteBuffer)}
+ * method as it arrives. Once all the stream data is received, {@link onComplete(String)} will be
  * called.
  * <p>
  * The network library guarantees that a single thread will call these methods at a time, but

--- a/network/common/src/main/java/org/apache/spark/network/server/RpcHandler.java
+++ b/network/common/src/main/java/org/apache/spark/network/server/RpcHandler.java
@@ -55,7 +55,7 @@ public abstract class RpcHandler {
 
   /**
    * Receives an RPC message that does not expect a reply. The default implementation will
-   * call "{@link receive(TransportClient, byte[], RpcResponseCallback}" and log a warning if
+   * call "{@link receive(TransportClient, byte[], RpcResponseCallback)}" and log a warning if
    * any of the callback methods are called.
    *
    * @param client A channel client which enables the handler to make requests back to the sender

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -159,9 +159,9 @@ object SparkBuild extends PomBuild {
     scalacJVMVersion := "1.7",
 
     javacOptions in Compile ++= Seq(
-      "-encoding", "UTF-8",
-      "-source", javacJVMVersion.value,
-      "-target", javacJVMVersion.value
+      "-encoding", "UTF-8"
+      //"-source", javacJVMVersion.value,
+      //"-target", javacJVMVersion.value
     ),
 
     scalacOptions in Compile ++= Seq(

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -155,11 +155,13 @@ object SparkBuild extends PomBuild {
       if (major.toInt >= 1 && minor.toInt >= 8) Seq("-Xdoclint:all", "-Xdoclint:-missing") else Seq.empty
     },
 
+    // TODO(thunterdb) how to set these based on the current version of the JVM?
     javacJVMVersion := "1.7",
     scalacJVMVersion := "1.7",
 
     javacOptions in Compile ++= Seq(
       "-encoding", "UTF-8"
+      // TODO(thunterdb) make it conditional for <= "1.7"
       //"-source", javacJVMVersion.value,
       //"-target", javacJVMVersion.value
     ),


### PR DESCRIPTION
Currently, trying to publish spark locally fails when java version is >= 1.8.0:
- a javadoc option has been removed
- javadoc is stricter about its input and fails with some malformed comments

This PR fixes both issues.
