### PR TITLE
[SPARK-12063][SQL] Use number in group by clause to refer to columns

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -70,7 +70,7 @@ class Analyzer(
     Batch("Resolution", fixedPoint,
       ResolveRelations ::
       ResolveReferences ::
-      ResolveGroupByReferences ::
+      ResolveNumericReferences ::
       ResolveGroupingAnalytics ::
       ResolvePivot ::
       ResolveSortReferences ::
@@ -180,23 +180,42 @@ class Analyzer(
   }
 
   /**
-   * Replaces queries of the form "SELECT expr FROM A GROUP BY 1"
-   * with a query of the form "SELECT expr FROM A GROUP BY expr"
+   * Replaces queries of the form "SELECT expr FROM A GROUP BY 1 ORDER BY 1"
+   * with a query of the form "SELECT expr FROM A GROUP BY expr ORDER BY expr"
    */
-  object ResolveGroupByReferences extends Rule[LogicalPlan] {
+  object ResolveNumericReferences extends Rule[LogicalPlan] {
 
     def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
       case Aggregate(groups, aggs, child) =>
-        Aggregate(groups.map(group => group match {
-          case g if g.prettyString forall Character.isDigit =>
-            aggs(g.prettyString.toInt - 1) match {
-              case u : UnresolvedAlias =>
-                u.child
-              case a : Alias =>
-                a.child
+        val newGroups = groups.map {
+          case group if group.isInstanceOf[Literal] && group.dataType.isInstanceOf[IntegralType] =>
+            aggs(group.toString.toInt - 1) match {
+              case u: UnresolvedAlias =>
+                u.child match {
+                  case UnresolvedStar(_) => // Can't replace literal with column yet
+                    group
+                  case _ => u.child
+                }
+              case a: Alias => a.child
+              case a: AttributeReference => a
             }
-          case _ => group
-        }), aggs, child)
+          case group => group
+        }
+        Aggregate(newGroups, aggs, child)
+      case Sort(ordering, global, child) =>
+        val newOrdering = ordering.map {
+          case o if o.child.isInstanceOf[Literal] && o.dataType.isInstanceOf[IntegralType] =>
+            val newExpr = child.asInstanceOf[Project].projectList(o.child.toString.toInt - 1)
+                match {
+                  case u: UnresolvedAlias =>
+                    u.child
+                  case a: Alias =>
+                    a.child
+                }
+            SortOrder(newExpr, o.direction)
+          case other => other
+        }
+       Sort(newOrdering, global, child)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -187,20 +187,16 @@ class Analyzer(
 
     def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
       case Aggregate(groups, aggs, child) =>
-        var newGroups = Seq[Expression]()
-        groups.foreach(group =>
-          newGroups = newGroups :+ (group match {
-            case clauseName if clauseName.prettyString forall Character.isDigit =>
-                aggs(group.prettyString.toInt - 1) match {
-                case u : UnresolvedAlias =>
-                  u.child
-                case a : Alias =>
-                  a.child
-              }
-            case _ => group
-          }))
-        Aggregate(newGroups, aggs, child)
-
+        Aggregate(groups.map(group => group match {
+          case g if g.prettyString forall Character.isDigit =>
+            aggs(g.prettyString.toInt - 1) match {
+              case u : UnresolvedAlias =>
+                u.child
+              case a : Alias =>
+                a.child
+            }
+          case _ => group
+        }), aggs, child)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -146,6 +146,12 @@ trait CheckAnalysis {
                     s"data type.")
               }
 
+              if (expr.isInstanceOf[AggregateExpression] || expr.isInstanceOf[AggregateFunction]) {
+                // Aggregate function in group by clause; this fails to execute
+                failAnalysis(s"aggregate expression ${expr.prettyString} should not " +
+                  s"appear in grouping expression.")
+              }
+
               if (!expr.deterministic) {
                 // This is just a sanity check, our analysis rule PullOutNondeterministic should
                 // already pull out those nondeterministic expressions and evaluate them in

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2033,7 +2033,7 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
       sql("SELECT a, SUM(b) FROM testData2 GROUP BY 1"),
       Seq(Row(1, 3), Row(2, 3), Row(3, 3)))
   }
-  
+
   test("SPARK-12063: Order by Column Number") {
     Seq(("one", 1), ("two", 2), ("three", 3), ("one", 5)).toDF("k", "v").registerTempTable("ord")
     checkAnswer(

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2028,4 +2028,10 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
       Row(false) :: Row(true) :: Nil)
   }
 
+  test("SPARK-12063: Group by Column Number identifier") {
+    checkAnswer(
+      sql("SELECT a, SUM(b) FROM testData2 GROUP BY 1"),
+      Seq(Row(1, 3), Row(2, 3), Row(3, 3)))
+  }
+
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -472,25 +472,6 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
       Seq(Row(1, 3), Row(2, 3), Row(3, 3)))
   }
 
-  test("literal in agg grouping expressions") {
-    checkAnswer(
-      sql("SELECT a, count(1) FROM testData2 GROUP BY a, 1"),
-      Seq(Row(1, 2), Row(2, 2), Row(3, 2)))
-    checkAnswer(
-      sql("SELECT a, count(2) FROM testData2 GROUP BY a, 2"),
-      Seq(Row(1, 2), Row(2, 2), Row(3, 2)))
-
-    checkAnswer(
-      sql("SELECT a, 1, sum(b) FROM testData2 GROUP BY a, 1"),
-      sql("SELECT a, 1, sum(b) FROM testData2 GROUP BY a"))
-    checkAnswer(
-      sql("SELECT a, 1, sum(b) FROM testData2 GROUP BY a, 1 + 2"),
-      sql("SELECT a, 1, sum(b) FROM testData2 GROUP BY a"))
-    checkAnswer(
-      sql("SELECT 1, 2, sum(b) FROM testData2 GROUP BY 1, 2"),
-      sql("SELECT 1, 2, sum(b) FROM testData2"))
-  }
-
   test("aggregates with nulls") {
     checkAnswer(
       sql("SELECT SKEWNESS(a), KURTOSIS(a), MIN(a), MAX(a)," +

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2028,10 +2028,17 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
       Row(false) :: Row(true) :: Nil)
   }
 
-  test("SPARK-12063: Group by Column Number identifier") {
+  test("SPARK-12063: Group by Columns Number") {
     checkAnswer(
       sql("SELECT a, SUM(b) FROM testData2 GROUP BY 1"),
       Seq(Row(1, 3), Row(2, 3), Row(3, 3)))
+  }
+  
+  test("SPARK-12063: Order by Column Number") {
+    Seq(("one", 1), ("two", 2), ("three", 3), ("one", 5)).toDF("k", "v").registerTempTable("ord")
+    checkAnswer(
+      sql("SELECT v from ord order by 1 desc"),
+      Row(5) :: Row(3) :: Row(2) :: Row(1) :: Nil)
   }
 
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
@@ -1103,16 +1103,7 @@ https://cwiki.apache.org/confluence/display/Hive/Enhanced+Aggregation%2C+Cube%2C
             groupByClause.map(e => e match {
               case Token("TOK_GROUPBY", children) =>
                 // Not a transformation so must be either project or aggregation.
-                var newChildren = Seq[ASTNode]()
-                children.foreach(child =>
-                  newChildren = newChildren :+ (child.getText match {
-                    case clauseName if clauseName forall Character.isDigit =>
-                      val Token("TOK_SELEXPR", columns) = selectClause.get.getChildren
-                        .get(clauseName.toInt - 1)
-                      columns(0)
-                    case _ => child
-                  }))
-                Aggregate(newChildren.map(nodeToExpr), selectExpressions, withLateralView)
+                Aggregate(children.map(nodeToExpr), selectExpressions, withLateralView)
               case _ => sys.error("Expect GROUP BY")
             }),
             groupingSetsClause.map(e => e match {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
@@ -1103,7 +1103,16 @@ https://cwiki.apache.org/confluence/display/Hive/Enhanced+Aggregation%2C+Cube%2C
             groupByClause.map(e => e match {
               case Token("TOK_GROUPBY", children) =>
                 // Not a transformation so must be either project or aggregation.
-                Aggregate(children.map(nodeToExpr), selectExpressions, withLateralView)
+                var newChildren = Seq[ASTNode]()
+                children.foreach(child =>
+                  newChildren = newChildren :+ (child.getText match {
+                    case clauseName if clauseName forall Character.isDigit =>
+                      val Token("TOK_SELEXPR", columns) = selectClause.get.getChildren
+                        .get(clauseName.toInt - 1)
+                      columns(0)
+                    case _ => child
+                  }))
+                Aggregate(newChildren.map(nodeToExpr), selectExpressions, withLateralView)
               case _ => sys.error("Expect GROUP BY")
             }),
             groupingSetsClause.map(e => e match {


### PR DESCRIPTION
If there is a number n in a group by clause, the nth column in the select clause is used to modify the group by clause to refer to this column instead of the number.

eg.
select a,b from c group by 1,2
becomes
select a,b from c group by a,b
