### PR TITLE
[SPARK-12065] Upgrade Tachyon from 0.8.1 to 0.8.2

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -270,7 +270,7 @@
     <dependency>
       <groupId>org.tachyonproject</groupId>
       <artifactId>tachyon-client</artifactId>
-      <version>0.8.1</version>
+      <version>0.8.2</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.hadoop</groupId>

--- a/make-distribution.sh
+++ b/make-distribution.sh
@@ -33,7 +33,7 @@ SPARK_HOME="$(cd "`dirname "$0"`"; pwd)"
 DISTDIR="$SPARK_HOME/dist"
 
 SPARK_TACHYON=false
-TACHYON_VERSION="0.8.1"
+TACHYON_VERSION="0.8.2"
 TACHYON_TGZ="tachyon-${TACHYON_VERSION}-bin.tar.gz"
 TACHYON_URL="http://tachyon-project.org/downloads/files/${TACHYON_VERSION}/${TACHYON_TGZ}"
 


### PR DESCRIPTION
This commit upgrades the Tachyon dependency from 0.8.1 to 0.8.2.
