### PR TITLE
[SPARK-12067] [SQL] Fix usage of isnan, isnull, isnotnull of Column and DataFrame

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
@@ -467,28 +467,55 @@ class Column(protected[sql] val expr: Expression) extends Logging {
   }
 
   /**
+   * @group expr_ops
+   * @deprecated As of 1.6.0, replaced by `isnan`. This will be removed in Spark 2.0.
+   */
+  @deprecated("Use isnan. This will be removed in Spark 2.0.", "1.6.0")
+  def isNaN: Column = isnan
+
+  /**
    * True if the current expression is NaN.
    *
    * @group expr_ops
-   * @since 1.5.0
+   * @since 1.6.0
    */
-  def isNaN: Column = withExpr { IsNaN(expr) }
+  def isnan: Column = withExpr { IsNaN(expr) }
+
+  /**
+   * @group expr_ops
+   * @deprecated As of 1.6.0, replaced by `isnull`. This will be removed in Spark 2.0.
+   */
+  def isNull: Column = isnull
 
   /**
    * True if the current expression is null.
    *
    * @group expr_ops
-   * @since 1.3.0
+   * @since 1.6.0
    */
-  def isNull: Column = withExpr { IsNull(expr) }
+  def isnull: Column = withExpr { IsNull(expr) }
+
+  /**
+   * @group expr_ops
+   * @deprecated As of 1.6.0, replaced by `isnotnull`. This will be removed in Spark 2.0.
+   */
+  def isNotNull: Column = isnotnull
 
   /**
    * True if the current expression is NOT null.
    *
    * @group expr_ops
-   * @since 1.3.0
+   * @since 1.6.0
    */
-  def isNotNull: Column = withExpr { IsNotNull(expr) }
+  def isnotnull: Column = withExpr { IsNotNull(expr) }
+
+  /**
+   * True if the current expression is NOT null.
+   *
+   * @group expr_ops
+   * @since 1.6.0
+   */
+  def notnull: Column = isnotnull
 
   /**
    * Boolean OR.

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -866,6 +866,22 @@ object functions extends LegacyFunctions {
   def isnull(e: Column): Column = withExpr { IsNull(e.expr) }
 
   /**
+   * Return true iff the column is NOT null.
+   *
+   * @group normal_funcs
+   * @since 1.6.0
+   */
+  def isnotnull(e: Column): Column = withExpr { IsNotNull(e.expr) }
+
+  /**
+   * Return true iff the column is NOT null.
+   *
+   * @group normal_funcs
+   * @since 1.6.0
+   */
+  def notnull(e: Column): Column = isnotnull(e)
+
+  /**
    * A column expression that generates monotonically increasing 64-bit integers.
    *
    * The generated ID is guaranteed to be monotonically increasing and unique, but not consecutive.

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -265,9 +265,9 @@ class ColumnExpressionSuite extends QueryTest with SharedSQLContext {
       complexData.collect().toSeq.map(r => Row(!r.getBoolean(3))))
   }
 
-  test("isNull") {
+  test("isnull") {
     checkAnswer(
-      nullStrings.toDF.where($"s".isNull),
+      nullStrings.toDF.where($"s".isnull),
       nullStrings.collect().toSeq.filter(r => r.getString(1) eq null))
 
     checkAnswer(
@@ -275,9 +275,9 @@ class ColumnExpressionSuite extends QueryTest with SharedSQLContext {
       Row(true, false))
   }
 
-  test("isNotNull") {
+  test("isnotnull") {
     checkAnswer(
-      nullStrings.toDF.where($"s".isNotNull),
+      nullStrings.toDF.where($"s".isnotnull),
       nullStrings.collect().toSeq.filter(r => r.getString(1) ne null))
 
     checkAnswer(
@@ -285,7 +285,7 @@ class ColumnExpressionSuite extends QueryTest with SharedSQLContext {
       Row(false, true))
   }
 
-  test("isNaN") {
+  test("isnan") {
     val testData = sqlContext.createDataFrame(sparkContext.parallelize(
       Row(Double.NaN, Float.NaN) ::
       Row(math.log(-1), math.log(-3).toFloat) ::
@@ -294,11 +294,11 @@ class ColumnExpressionSuite extends QueryTest with SharedSQLContext {
       StructType(Seq(StructField("a", DoubleType), StructField("b", FloatType))))
 
     checkAnswer(
-      testData.select($"a".isNaN, $"b".isNaN),
+      testData.select($"a".isnan, $"b".isnan),
       Row(true, true) :: Row(true, true) :: Row(false, false) :: Row(false, false) :: Nil)
 
     checkAnswer(
-      testData.select(isNaN($"a"), isNaN($"b")),
+      testData.select(isnan($"a"), isnan($"b")),
       Row(true, true) :: Row(true, true) :: Row(false, false) :: Row(false, false) :: Nil)
 
     checkAnswer(


### PR DESCRIPTION
This PR including the following changes:
- #9930 has deprecated `DataFrame.isNaN, DataFrame.isNull` and replaced by `DataFrame.isnan, DataFrame.isnull`, in this PR we changed `Column.isNaN` to `Column.isnan`, `Column.isNull` to `Column.isnull`, `Column.isNotNull` to `Column.isnotnull`.
- Add `Column.notnull` as alias of `Column.isnotnull` following the [pandas](http://pandas.pydata.org/pandas-docs/version/0.17.1/generated/pandas.notnull.html) naming convention. 
- Add `DataFrame.isnotnull` and `DataFrame.notnull`.

Todo:
If this PR has been accepted, I can do the peer renaming for Python and R in a follow-up PR.

cc @rxin @marmbrus @davies 
