### PR TITLE
[SPARK-11949][SQL] Check bitmasks to set nullable property

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -223,8 +223,10 @@ class Analyzer(
           case other => Alias(other, other.toString)()
         }
 
+        val nonNullBitmask = x.bitmasks.reduce(_ & _)
+
         val attributeMap = groupByAliases.zipWithIndex.map { case (a, idx) =>
-          if (x.bitmasks.exists(bitmask => (bitmask & 1 << idx) == 0)) {
+          if ((nonNullBitmask & 1 << idx) == 0) {
             (a -> a.toAttribute.withNullability(true))
           } else {
             (a -> a.toAttribute)


### PR DESCRIPTION
Following up #10038.

We can use bitmasks to determine which grouping expressions need to be set as nullable.

cc @yhuai 
