### PR TITLE
[SPARK-12000] [Build] remove scala-compiler and scalap from json4s deps

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -206,6 +206,16 @@
       <groupId>org.json4s</groupId>
       <artifactId>json4s-jackson_${scala.binary.version}</artifactId>
       <version>3.2.10</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.scala-lang</groupId>
+          <artifactId>scala-compiler</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.scala-lang</groupId>
+          <artifactId>scalap</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>

--- a/sql/catalyst/pom.xml
+++ b/sql/catalyst/pom.xml
@@ -40,6 +40,10 @@
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-reflect</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-compiler</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.spark</groupId>


### PR DESCRIPTION
This could be a fix for SPARK-12000 because json4s pulls in scala-compiler:2.10.0 and scalap, which could cause the compiler bug. See https://github.com/json4s/json4s/issues/108.

Another option is to upgrade json4s to 3.3.0, which removes scala-compiler/scalap from its runtime deps but depends on Scala 2.10.6.

cc @JoshRosen 
