### PR TITLE
[SPARK-12079][BUILD][SQL] Run Catalyst subproject's tests in parallel

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -250,6 +250,8 @@ object SparkBuild extends PomBuild {
   /* Spark SQL Core console settings */
   enable(SQL.settings)(sql)
 
+  enable(Catalyst.settings)(catalyst)
+
   /* Hive console settings */
   enable(Hive.settings)(hive)
 
@@ -380,6 +382,15 @@ object SQL {
         |import sqlContext._
       """.stripMargin,
     cleanupCommands in console := "sc.stop()"
+  )
+}
+
+object Catalyst {
+  lazy val settings = Seq(
+    // Catalyst's tests can run in parallel within the same JVM since they don't launch
+    // SparkContexts.
+    parallelExecution in Test := true,
+    testForkedParallel in Test := true
   )
 }
 
@@ -671,7 +682,6 @@ object TestSettings {
       }
       Seq[File]()
     },
-    concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),
     // Remove certain packages from Scaladoc
     scalacOptions in (Compile, doc) := Seq(
       "-groups",


### PR DESCRIPTION
The Catalyst tests do not launch SparkContexts and thus are easy to parallelize without introducing flakiness. This is really easy to do and can save ~2 minutes per test run.
