### PR TITLE
[SPARK-12088][SQL]check connection.isClosed before calling connection…

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -498,7 +498,7 @@ private[sql] class JDBCRDD(
       }
       try {
         if (null != conn) {
-          if (!conn.getAutoCommit && !conn.isClosed) {
+          if (!conn.isClosed && !conn.getAutoCommit) {
             try {
               conn.commit()
             } catch {


### PR DESCRIPTION
In Java Spec java.sql.Connection, it has 
boolean getAutoCommit() throws SQLException
Throws:
SQLException - if a database access error occurs or this method is called on a closed connection

So if conn.getAutoCommit is called on a closed connection, a SQLException will be thrown. Even though the code catch the SQLException and program can continue, I think we should check conn.isClosed before calling conn.getAutoCommit to avoid the unnecessary SQLException.
