### PR TITLE
[SPARK-12125][SQL] pull out nondeterministic expressions from Join

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1046,27 +1046,75 @@ class Analyzer(
    * put them into an inner Project and finally project them away at the outer Project.
    */
   object PullOutNondeterministic extends Rule[LogicalPlan] {
+    /**
+     * split the expression by given logicalPlan
+     */
+    private def split(expressions: Seq[Expression], left: LogicalPlan, right: LogicalPlan) = {
+      //split the expressions to otherExpressions and restExpressions
+      //because otherExpression is not AttributeReference
+      val (otherExpressions, restExpressions) =
+        expressions.partition(_.references.size == 0)
+      val (leftEvaluateExpressions, rest) =
+        restExpressions.partition(_.references subsetOf left.outputSet)
+      val (rightEvaluateExpressions, other) =
+        rest.partition(_.references subsetOf right.outputSet)
+
+      (leftEvaluateExpressions, rightEvaluateExpressions, otherExpressions ++ other)
+    }
+
+    private def splitByPredicates(expressions: Expression): Seq[Expression] = {
+      expressions match {
+        case And(cond1, cond2) =>
+          splitByPredicates(cond1) ++ splitByPredicates(cond2)
+        case EqualTo(cond1, cond2) =>
+          splitByPredicates(cond1) ++ splitByPredicates(cond2)
+        case other => other :: Nil
+      }
+    }
+
+    private def getNondeterministicMap(
+        expressions: Seq[Expression]): Map[TreeNodeRef, NamedExpression] = {
+      expressions.filterNot(_.deterministic).flatMap { expr =>
+        val leafNondeterministic = expr.collect {
+          case n: Nondeterministic => n
+        }
+        leafNondeterministic.map { e =>
+          val ne = e match {
+            case n: NamedExpression => n
+            case _ => Alias(e, "_nondeterministic")()
+          }
+          new TreeNodeRef(e) -> ne
+        }
+      }.toMap
+    }
+
     override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
       case p if !p.resolved => p // Skip unresolved nodes.
       case p: Project => p
       case f: Filter => f
+      case j: Join if j.expressions.exists(!_.deterministic) =>
+
+        // For now, not pull out nondeterministic from `otherExpressions`
+        // which references do not in the left child or right child
+        val (leftExpression, rightExpression, otherExpression) =
+          split(j.expressions.flatMap(splitByPredicates), j.left, j.right)
+
+        val leftNondeterministic = getNondeterministicMap(leftExpression)
+        val rightNondeterministic = getNondeterministicMap(rightExpression)
+        val nondeterministicExprs = leftNondeterministic ++ rightNondeterministic
+
+        val newJoinPlan = j.transformExpressions { case e =>
+          nondeterministicExprs.get(new TreeNodeRef(e)).map(_.toAttribute).getOrElse(e)
+        }
+        val newLeftChild = Project(j.left.output ++ leftNondeterministic.values, j.left)
+        val newRightChild = Project(j.right.output ++ rightNondeterministic.values, j.right)
+        Project(newJoinPlan.output, newJoinPlan.withNewChildren(List(newLeftChild, newRightChild)))
 
       // todo: It's hard to write a general rule to pull out nondeterministic expressions
       // from LogicalPlan, currently we only do it for UnaryNode which has same output
       // schema with its child.
       case p: UnaryNode if p.output == p.child.output && p.expressions.exists(!_.deterministic) =>
-        val nondeterministicExprs = p.expressions.filterNot(_.deterministic).flatMap { expr =>
-          val leafNondeterministic = expr.collect {
-            case n: Nondeterministic => n
-          }
-          leafNondeterministic.map { e =>
-            val ne = e match {
-              case n: NamedExpression => n
-              case _ => Alias(e, "_nondeterministic")()
-            }
-            new TreeNodeRef(e) -> ne
-          }
-        }.toMap
+        val nondeterministicExprs = getNondeterministicMap(p.expressions)
         val newPlan = p.transformExpressions { case e =>
           nondeterministicExprs.get(new TreeNodeRef(e)).map(_.toAttribute).getOrElse(e)
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1050,8 +1050,8 @@ class Analyzer(
      * split the expression by given logicalPlan
      */
     private def split(expressions: Seq[Expression], left: LogicalPlan, right: LogicalPlan) = {
-      //split the expressions to otherExpressions and restExpressions
-      //because otherExpression is not AttributeReference
+      // split the expressions to otherExpressions and restExpressions
+      // because otherExpression is not AttributeReference
       val (otherExpressions, restExpressions) =
         expressions.partition(_.references.size == 0)
       val (leftEvaluateExpressions, rest) =

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -142,7 +142,7 @@ class AnalysisSuite extends AnalysisTest {
       Project(testRelation.output ++ testRelation2.output,
         Join(Project(testRelation.output, testRelation),
           Project(testRelation2.output :+ projected, testRelation2), Inner,
-          Some(And(EqualTo(a, Cast(e, IntegerType)), EqualTo(projected.toAttribute * c, c)))))
+            Some(And(EqualTo(a, Cast(e, IntegerType)), EqualTo(projected.toAttribute * c, c)))))
     checkAnalysis(plan, expected)
   }
 


### PR DESCRIPTION
Currently,`nondeterministic expressions` are only allowed in `Project` or `Filter`,And only when we use nondeterministic expressions in `UnaryNode` can be pulled out.

But,Sometime in many case,we will use nondeterministic expressions to process `join keys` avoiding data skew.for example:

```
select * 
from tableA a 
join 
(select * from tableB) b 
on upper((case when (a.brand_code is null or a.brand_code = '' ) then cast( (-rand() * 10000000 ) as string ) else a.brand_code end ))  = b.brand_code

```

This PR introduce a mechanism to pull out nondeterministic expressions from `Join`,so we can use nondeterministic expression in `Join` appropriately.
