### PR TITLE
[SPARK-12131][SQL] Fixes ExpressionEncoder for arrays of nested classes

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
@@ -234,7 +234,7 @@ object JavaTypeInference {
             MapObjects(
               p => constructorFor(typeToken.getComponentType, Some(p)),
               getPath,
-              inferDataType(elementType)._1),
+              inferDataType(elementType)._1)(),
             "array",
             ObjectType(c))
         }
@@ -246,7 +246,7 @@ object JavaTypeInference {
             MapObjects(
               p => constructorFor(et, Some(p)),
               getPath,
-              inferDataType(et)._1),
+              inferDataType(et)._1)(),
             "array",
             ObjectType(classOf[Array[Any]]))
 
@@ -262,7 +262,7 @@ object JavaTypeInference {
             MapObjects(
               p => constructorFor(keyType, Some(p)),
               Invoke(getPath, "keyArray", ArrayType(keyDataType)),
-              keyDataType),
+              keyDataType)(),
             "array",
             ObjectType(classOf[Array[Any]]))
 
@@ -271,7 +271,7 @@ object JavaTypeInference {
             MapObjects(
               p => constructorFor(valueType, Some(p)),
               Invoke(getPath, "valueArray", ArrayType(valueDataType)),
-              valueDataType),
+              valueDataType)(),
             "array",
             ObjectType(classOf[Array[Any]]))
 
@@ -324,7 +324,7 @@ object JavaTypeInference {
           input :: Nil,
           dataType = ArrayType(dataType, nullable))
       } else {
-        MapObjects(extractorFor(_, elementType), input, ObjectType(elementType.getRawType))
+        MapObjects(extractorFor(_, elementType), input, ObjectType(elementType.getRawType))()
       }
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -268,7 +268,7 @@ object ScalaReflection extends ScalaReflection {
             MapObjects(
               p => constructorFor(elementType, Some(p), newTypePath),
               getPath,
-              schemaFor(elementType).dataType),
+              schemaFor(elementType).dataType)(),
             "array",
             arrayClassFor(elementType))
         }
@@ -282,7 +282,7 @@ object ScalaReflection extends ScalaReflection {
             MapObjects(
               p => constructorFor(elementType, Some(p), newTypePath),
               getPath,
-              schemaFor(elementType).dataType),
+              schemaFor(elementType).dataType)(),
             "array",
             ObjectType(classOf[Array[Any]]))
 
@@ -301,7 +301,7 @@ object ScalaReflection extends ScalaReflection {
             MapObjects(
               p => constructorFor(keyType, Some(p), walkedTypePath),
               Invoke(getPath, "keyArray", ArrayType(schemaFor(keyType).dataType)),
-              schemaFor(keyType).dataType),
+              schemaFor(keyType).dataType)(),
             "array",
             ObjectType(classOf[Array[Any]]))
 
@@ -310,7 +310,7 @@ object ScalaReflection extends ScalaReflection {
             MapObjects(
               p => constructorFor(valueType, Some(p), walkedTypePath),
               Invoke(getPath, "valueArray", ArrayType(schemaFor(valueType).dataType)),
-              schemaFor(valueType).dataType),
+              schemaFor(valueType).dataType)(),
             "array",
             ObjectType(classOf[Array[Any]]))
 
@@ -418,7 +418,7 @@ object ScalaReflection extends ScalaReflection {
         // to trigger the type check.
         extractorFor(inputObject, elementType, newPath)
 
-        MapObjects(extractorFor(_, elementType, newPath), input, externalDataType)
+        MapObjects(extractorFor(_, elementType, newPath), input, externalDataType)()
       }
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/OuterScopes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/OuterScopes.scala
@@ -28,7 +28,7 @@ object OuterScopes {
 
   /**
    * Adds a new outer scope to this context that can be used when instantiating an `inner class`
-   * during deserialialization. Inner classes are created when a case class is defined in the
+   * during deserialization. Inner classes are created when a case class is defined in the
    * Spark REPL and registering the outer scope that this class was defined in allows us to create
    * new instances on the spark executors.  In normal use, users should not need to call this
    * function.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/RowEncoder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/RowEncoder.scala
@@ -93,7 +93,7 @@ object RowEncoder {
           classOf[GenericArrayData],
           inputObject :: Nil,
           dataType = t)
-      case _ => MapObjects(extractorsFor(_, et), inputObject, externalDataTypeFor(et))
+      case _ => MapObjects(extractorsFor(_, et), inputObject, externalDataTypeFor(et))()
     }
 
     case t @ MapType(kt, vt, valueNullable) =>
@@ -193,7 +193,7 @@ object RowEncoder {
     case ArrayType(et, nullable) =>
       val arrayData =
         Invoke(
-          MapObjects(constructorFor, input, et),
+          MapObjects(constructorFor, input, et)(),
           "array",
           ObjectType(classOf[Array[_]]))
       StaticInvoke(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects.scala
@@ -366,9 +366,9 @@ case class MapObjects(
     function(AttributeReference("loopVar", elementType)())
   }
 
-  lazy val loopAttribute = completeFunction.collectFirst {
+  lazy val loopAttribute = completeFunction.collect {
     case a: AttributeReference if a.name == "loopVar" => a
-  }.get
+  }.last
 
   override protected def otherCopyArgs: Seq[AnyRef] = completeFunctionCopy :: Nil
 


### PR DESCRIPTION
`ExpressionEncoder` uses `MapObjects` to extract Scala objects from `InternalRow`s. During the process, `MapObjects.completeFunction` plays the role of a lambda function within the SQL space.  However, there lies an contradiction:
1.  `completeFunction` is not a constructor argument of `MapObjects`. This stops `ExpressionEncoder.resolve` to transform inner `NewInstance` expressions within `completeFunction` to fill in outer pointers for nested classes.
2.  On the other hand, once we make `completeFunction` a constructor arguments, it will be eagerly resolved by the analyzer. But this "lambda" function should only be resolved while being "applied" within the generated code.

This PR tries to fix this issue by specializing `MapObjects` in `ExpressionEncoder.resolve`, and adding an extra argument list to the constructor to pass in an optional copy of the transformed `completeFunction`.
