### PR TITLE
[SPARK-12132] [PYSPARK] raise KeyboardInterrupt inside SIGINT handler

### DIFF
--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -222,6 +222,7 @@ class SparkContext(object):
         # create a signal handler which would be invoked on receiving SIGINT
         def signal_handler(signal, frame):
             self.cancelAllJobs()
+            raise KeyboardInterrupt()
 
         # see http://stackoverflow.com/questions/23206787/
         if isinstance(threading.current_thread(), threading._MainThread):


### PR DESCRIPTION
Currently, the current line is not cleared by Cltr-C

After this patch

```
>>> asdfasdf^C
Traceback (most recent call last):
  File "~/spark/python/pyspark/context.py", line 225, in signal_handler
    raise KeyboardInterrupt()
KeyboardInterrupt
```

It's still worse than 1.5 (and before).
