### PR TITLE
[SPARK-12139][SQL] REGEX Column Specification for Hive Queries

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
@@ -1493,7 +1493,11 @@ https://cwiki.apache.org/confluence/display/Hive/Enhanced+Aggregation%2C+Cube%2C
     /* Attribute References */
     case Token("TOK_TABLE_OR_COL",
            Token(name, Nil) :: Nil) =>
-      UnresolvedAttribute.quoted(cleanIdentifier(name))
+      name match {
+        // If the columns is wrapped in backticks, treat it as a regular expression
+        case escapedIdentifier(i) => UnresolvedRegex(i, None)
+        case _ => UnresolvedAttribute.quoted(name)
+      }
     case Token(".", qualifier :: Token(attr, Nil) :: Nil) =>
       nodeToExpr(qualifier) match {
         case UnresolvedAttribute(nameParts) =>


### PR DESCRIPTION
When executing a query of the form
Select `(a)?.` from A,
Hive interprets this query as a regular expression, which can be supported in the hive parser for spark

If a columns is specified in backticks (eg. (ds)?+.+), the hive parser will treat that as a regular expression and 'expand' the columns similar to a *, on columns that match the regex.
