### PR TITLE
[SPARK-12143]When cloumn type is binary, change to Array[Byte] instead of string

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
@@ -96,7 +96,9 @@ private[hive] class SparkExecuteStatementOperation(
         to += from.getAs[Date](ordinal)
       case TimestampType =>
         to +=  from.getAs[Timestamp](ordinal)
-      case BinaryType | _: ArrayType | _: StructType | _: MapType =>
+      case BinaryType =>
+        to += from.getAs[Array[Byte]](ordinal)
+      case _: ArrayType | _: StructType | _: MapType =>
         val hiveString = HiveContext.toHiveString((from.get(ordinal), dataTypes(ordinal)))
         to += hiveString
     }


### PR DESCRIPTION
In Beeline, execute below sql:
1. create table bb(bi binary);
2. load data inpath 'tmp/data' into table bb;
3.select \* from bb;
Error: java.lang.ClassCastException: java.lang.String cannot be cast to [B (state=, code=0)
