### PR TITLE
Update StructType.scala

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -40,7 +40,7 @@ import org.apache.spark.sql.catalyst.util.DataTypeParser
  * Example:
  * {{{
  * import org.apache.spark.sql._
- *
+ * import org.apache.spark.sql.types._
  * val struct =
  *   StructType(
  *     StructField("a", IntegerType, true) ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -41,6 +41,7 @@ import org.apache.spark.sql.catalyst.util.DataTypeParser
  * {{{
  * import org.apache.spark.sql._
  * import org.apache.spark.sql.types._
+ * 
  * val struct =
  *   StructType(
  *     StructField("a", IntegerType, true) ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -41,7 +41,7 @@ import org.apache.spark.sql.catalyst.util.DataTypeParser
  * {{{
  * import org.apache.spark.sql._
  * import org.apache.spark.sql.types._
- * 
+ *
  * val struct =
  *   StructType(
  *     StructField("a", IntegerType, true) ::


### PR DESCRIPTION
The example will throw error like 
<console>:20: error: not found: value StructType

Need to add this line:
import org.apache.spark.sql.types._
