### PR TITLE
[PYSPARK] Pyspark typo & Add missing abstractmethod annotation

### DIFF
--- a/python/pyspark/ml/pipeline.py
+++ b/python/pyspark/ml/pipeline.py
@@ -86,7 +86,7 @@ class Transformer(Params):
     @abstractmethod
     def _transform(self, dataset):
         """
-        Transforms the input dataset with optional parameters.
+        Transforms the input dataset.
 
         :param dataset: input dataset, which is an instance of
                         :py:class:`pyspark.sql.DataFrame`

--- a/python/pyspark/ml/wrapper.py
+++ b/python/pyspark/ml/wrapper.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from abc import ABCMeta
+from abc import ABCMeta, abstractmethod
 
 from pyspark import SparkContext
 from pyspark.sql import DataFrame
@@ -110,6 +110,7 @@ class JavaEstimator(Estimator, JavaWrapper):
 
     __metaclass__ = ABCMeta
 
+    @abstractmethod
     def _create_model(self, java_model):
         """
         Creates a model from the input Java model reference.


### PR DESCRIPTION
No jira is created since this is a trivial change.

@davies  Please help review it
