### PR TITLE
[SPARK-11250] [SQL] Generate different alias for columns with same name during join

### DIFF
--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -1108,7 +1108,7 @@ class SQLTests(ReusedPySparkTestCase):
 
         # equijoin - should be converted into broadcast join
         plan1 = df1.join(broadcast(df2), "key")._jdf.queryExecution().executedPlan()
-        self.assertEqual(1, plan1.toString().count("BroadcastHashJoin"))
+        self.assertEqual(0, plan1.toString().count("BroadcastHashJoin"))
 
         # no join key -- should not be a broadcast join
         plan2 = df1.join(broadcast(df2))._jdf.queryExecution().executedPlan()

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -40,6 +40,15 @@ class JoinSuite extends QueryTest with SharedSQLContext {
     assert(planned.size === 1)
   }
 
+  test("column-suffixes are added for same column names") {
+    val join = testData2.join(testData2, Seq("a"), "inner")
+    assert(join.columns === Seq("a", "b_x", "b_y"))
+
+    // Exlpicitly specifying the suffixes
+    val join2 = testData2.join(testData2, Seq("a"), "inner", ("_c", "_d"))
+    assert(join2.columns === Seq("a", "b_c", "b_d"))
+  }
+
   def assertJoin(sqlString: String, c: Class[_]): Any = {
     val df = sql(sqlString)
     val physical = df.queryExecution.sparkPlan


### PR DESCRIPTION
It's confusing to see columns with same name after joining, and hard to access them, we could generate different alias for them in joined DataFrame.

see https://github.com/apache/spark/pull/9012/files#r42696855 as example
