### PR TITLE
[SPARK-7727] [SQL] Avoid inner classes in RuleExecutor

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -33,8 +33,8 @@ import org.apache.spark.sql.types._
   * Optimizers can override this.
   */
 abstract class Optimizer extends RuleExecutor[LogicalPlan] {
-  def batches: Seq[Batch] =
-  // SubQueries are only needed for analysis and can be removed before execution.
+  def batches: Seq[Batch] = {
+    // SubQueries are only needed for analysis and can be removed before execution.
     Batch("Remove SubQueries", FixedPoint(100),
       EliminateSubQueries) ::
     Batch("Aggregate", FixedPoint(100),
@@ -68,14 +68,16 @@ abstract class Optimizer extends RuleExecutor[LogicalPlan] {
       DecimalAggregates) ::
     Batch("LocalRelation", FixedPoint(100),
       ConvertToLocalRelation) :: Nil
+  }
 }
 
 /**
   * Non-abstract representation of the standard Spark optimizing strategies
+  *
+  * To ensure extendability, we leave the standard rules in the abstract optimizer rules, while
+  * specific rules go to the subclasses
   */
-object DefaultOptimizer extends Optimizer {
-  override def batches: Seq[Batch] = super.batches
-}
+object DefaultOptimizer extends Optimizer
 
 /**
  * Pushes operations down into a Sample.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -28,11 +28,13 @@ import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules._
 import org.apache.spark.sql.types._
 
-abstract class Optimizer extends RuleExecutor[LogicalPlan]
-
-object DefaultOptimizer extends Optimizer {
-  val batches =
-    // SubQueries are only needed for analysis and can be removed before execution.
+/**
+  * Abstract class all optimizers should inherit of, contains the standard batches (extending
+  * Optimizers can override this.
+  */
+abstract class Optimizer extends RuleExecutor[LogicalPlan] {
+  def batches: Seq[Batch] =
+  // SubQueries are only needed for analysis and can be removed before execution.
     Batch("Remove SubQueries", FixedPoint(100),
       EliminateSubQueries) ::
     Batch("Aggregate", FixedPoint(100),
@@ -66,6 +68,13 @@ object DefaultOptimizer extends Optimizer {
       DecimalAggregates) ::
     Batch("LocalRelation", FixedPoint(100),
       ConvertToLocalRelation) :: Nil
+}
+
+/**
+  * Non-abstract representation of the standard Spark optimizing strategies
+  */
+object DefaultOptimizer extends Optimizer {
+  override def batches: Seq[Batch] = super.batches
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleExecutor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleExecutor.scala
@@ -59,7 +59,7 @@ abstract class RuleExecutor[TreeType <: TreeNode[_]] extends Logging {
   protected case class Batch(name: String, strategy: Strategy, rules: Rule[TreeType]*)
 
   /** Defines a sequence of rule batches, to be overridden by the implementation. */
-  protected val batches: Seq[Batch]
+  protected def batches: Seq[Batch]
 
 
   /**

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerExtendableSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerExtendableSuite.scala
@@ -41,8 +41,12 @@ class OptimizerExtendableSuite extends SparkFunSuite {
   class ExtendedOptimizer extends Optimizer {
 
     // rules set to DummyRule, would not be executed anyways
-    val myBatches: Seq[Batch] = Batch("once", Once, DummyRule) ::
-                                Batch("fixedPoint", FixedPoint(100), DummyRule) :: Nil
+    val myBatches: Seq[Batch] = {
+      Batch("once", Once,
+        DummyRule) ::
+      Batch("fixedPoint", FixedPoint(100),
+        DummyRule) :: Nil
+    }
 
     override def batches: Seq[Batch] = super.batches ++ myBatches
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerExtendableSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerExtendableSuite.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.optimizer.Optimizer
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.Rule
+
+/**
+  * This is a test for SPARK-7727 if the Optimizer is kept being extendable
+  */
+class OptimizerExtendableSuite extends SparkFunSuite {
+
+  /**
+    * Dummy rule for test batches
+    */
+  object DummyRule extends Rule[LogicalPlan] {
+    def apply(p: LogicalPlan): LogicalPlan = p
+  }
+
+  /**
+    * This class represents a dummy extended optimizer that takes the batches of the
+    * Optimizer and adds custom ones.
+    */
+  class ExtendedOptimizer extends Optimizer {
+
+    // rules set to DummyRule, would not be executed anyways
+    val myBatches: Seq[Batch] = Batch("once", Once, DummyRule) ::
+                                Batch("fixedPoint", FixedPoint(100), DummyRule) :: Nil
+
+    override def batches: Seq[Batch] = super.batches ++ myBatches
+  }
+
+  test("Extending batches possible") {
+    // test simply instantiates the new extended optimizer
+    val extendedOptimizer = new ExtendedOptimizer()
+  }
+}


### PR DESCRIPTION
Moved (case) classes Strategy, Once, FixedPoint and Batch to the companion object. This is necessary if we want to have the Optimizer easily extendable in the following sense: Usually a user wants to add additional rules, and just take the ones that are already there. However, inner classes made that impossible since the code did not compile

This allows easy extension of existing Optimizers see the DefaultOptimizerExtendableSuite for a corresponding test case.
