### PR TITLE
[SPARK-12181] Check Cached unaligned-access capability before using Unsafe

### DIFF
--- a/core/src/main/scala/org/apache/spark/memory/MemoryManager.scala
+++ b/core/src/main/scala/org/apache/spark/memory/MemoryManager.scala
@@ -25,6 +25,7 @@ import org.apache.spark.{SparkConf, Logging}
 import org.apache.spark.storage.{BlockId, BlockStatus, MemoryStore}
 import org.apache.spark.unsafe.array.ByteArrayMethods
 import org.apache.spark.unsafe.memory.MemoryAllocator
+import org.apache.spark.unsafe.Platform
 
 /**
  * An abstract memory manager that enforces how memory is shared between execution and storage.
@@ -189,7 +190,14 @@ private[spark] abstract class MemoryManager(
    * sun.misc.Unsafe.
    */
   final val tungstenMemoryMode: MemoryMode = {
-    if (conf.getBoolean("spark.unsafe.offHeap", false)) MemoryMode.OFF_HEAP else MemoryMode.ON_HEAP
+    if (conf.getBoolean("spark.unsafe.offHeap", false)) {
+      if (!Platform.unaligned()) {
+        throw new IllegalArgumentException(s"No support for unaligned Unsafe")
+      }
+      MemoryMode.OFF_HEAP
+    } else {
+      MemoryMode.ON_HEAP
+    }
   }
 
   /**

--- a/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
+++ b/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
@@ -18,7 +18,7 @@
 package org.apache.spark.unsafe;
 
 import java.lang.reflect.Field;
-import java.security.AccessController;
+import java.nio.Bits;
 
 import sun.misc.Unsafe;
 
@@ -36,11 +36,13 @@ public final class Platform {
   
   private static final boolean unaligned;
   static {
-    // Copied from java.nio.Bits.java#unaligned
-    String arch = AccessController
-        .doPrivileged(new sun.security.action.GetPropertyAction("os.arch"));
-    unaligned = arch.equals("i386") || arch.equals("x86") || arch.equals("amd64")
-        || arch.equals("x86_64");
+    // use reflection to access unaligned field
+    try {
+      Field unalignedField = Bits.class.getDeclaredField("unaligned");
+      unalignedField.setAccessible(true);
+      unaligned = (boolean) unalignedField.get(null);
+    } catch (Throwable t) {
+    }
   }
 
   /**

--- a/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
+++ b/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
@@ -42,7 +42,7 @@ public final class Platform {
       unalignedField.setAccessible(true);
       unaligned = (boolean) unalignedField.get(null);
     } catch (Throwable t) {
-      unaligned = false
+      unaligned = false;
     }
   }
 

--- a/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
+++ b/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
@@ -18,6 +18,7 @@
 package org.apache.spark.unsafe;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 
 import sun.misc.Unsafe;
 

--- a/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
+++ b/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
@@ -36,6 +36,7 @@ public final class Platform {
   
   private static final boolean unaligned;
   static {
+    boolean _unaligned;
     // use reflection to access unaligned field
     try {
       Class<?> clazz = Class.forName("java.nio.Bits");
@@ -45,6 +46,7 @@ public final class Platform {
     } catch (Throwable t) {
       unaligned = false;
     }
+    unaligned = _unaligned;
   }
 
   /**

--- a/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
+++ b/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
@@ -18,6 +18,7 @@
 package org.apache.spark.unsafe;
 
 import java.lang.reflect.Field;
+import java.security.AccessController;
 
 import sun.misc.Unsafe;
 
@@ -32,6 +33,23 @@ public final class Platform {
   public static final int LONG_ARRAY_OFFSET;
 
   public static final int DOUBLE_ARRAY_OFFSET;
+  
+  private static final boolean unaligned;
+  static {
+    // Copied from java.nio.Bits.java#unaligned
+    String arch = AccessController
+        .doPrivileged(new sun.security.action.GetPropertyAction("os.arch"));
+    unaligned = arch.equals("i386") || arch.equals("x86") || arch.equals("amd64")
+        || arch.equals("x86_64");
+  }
+
+  /**
+   * @return true when running JVM is having sun's Unsafe package available in it and underlying
+   *         system having unaligned-access capability.
+   */
+  public static boolean unaligned() {
+    return unaligned;
+  }
 
   public static int getInt(Object object, long offset) {
     return _UNSAFE.getInt(object, offset);

--- a/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
+++ b/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
@@ -38,9 +38,9 @@ public final class Platform {
     // use reflection to access unaligned field
     try {
       Class<?> clazz = Class.forName("java.nio.Bits");
-      Field unalignedField = clazz.getDeclaredField("unaligned");
-      unalignedField.setAccessible(true);
-      unaligned = (boolean) unalignedField.get(null);
+      Method m = clazz.getDeclaredMethod("unaligned");
+      m.setAccessible(true);
+      unaligned = (boolean) m.invoke(null);
     } catch (Throwable t) {
       unaligned = false;
     }

--- a/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
+++ b/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
@@ -18,7 +18,6 @@
 package org.apache.spark.unsafe;
 
 import java.lang.reflect.Field;
-import java.nio.Bits;
 
 import sun.misc.Unsafe;
 
@@ -38,7 +37,8 @@ public final class Platform {
   static {
     // use reflection to access unaligned field
     try {
-      Field unalignedField = Bits.class.getDeclaredField("unaligned");
+      Class<?> clazz = Class.forName("java.nio.Bits");
+      Field unalignedField = clazz.getDeclaredField("unaligned");
       unalignedField.setAccessible(true);
       unaligned = (boolean) unalignedField.get(null);
     } catch (Throwable t) {

--- a/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
+++ b/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
@@ -42,9 +42,9 @@ public final class Platform {
       Class<?> clazz = Class.forName("java.nio.Bits");
       Method m = clazz.getDeclaredMethod("unaligned");
       m.setAccessible(true);
-      unaligned = (boolean) m.invoke(null);
+      _unaligned = (boolean) m.invoke(null);
     } catch (Throwable t) {
-      unaligned = false;
+      _unaligned = false;
     }
     unaligned = _unaligned;
   }

--- a/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
+++ b/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
@@ -42,6 +42,7 @@ public final class Platform {
       unalignedField.setAccessible(true);
       unaligned = (boolean) unalignedField.get(null);
     } catch (Throwable t) {
+      unaligned = false
     }
   }
 


### PR DESCRIPTION
For MemoryMode.OFF_HEAP, Unsafe.getInt etc. are used with no restriction.

However, the Oracle implementation uses these methods only if the class variable unaligned (commented as "Cached unaligned-access capability") is true, which seems to be calculated whether the architecture is i386, x86, amd64, or x86_64.

I think we should perform similar check for the use of Unsafe.
