### PR TITLE
[SPARK-12187] *MemoryPool classes should not be fully public

### DIFF
--- a/core/src/main/scala/org/apache/spark/memory/ExecutionMemoryPool.scala
+++ b/core/src/main/scala/org/apache/spark/memory/ExecutionMemoryPool.scala
@@ -39,7 +39,7 @@ import org.apache.spark.Logging
  * @param lock a [[MemoryManager]] instance to synchronize on
  * @param poolName a human-readable name for this pool, for use in log messages
  */
-class ExecutionMemoryPool(
+private[memory] class ExecutionMemoryPool(
     lock: Object,
     poolName: String
   ) extends MemoryPool(lock) with Logging {

--- a/core/src/main/scala/org/apache/spark/memory/MemoryPool.scala
+++ b/core/src/main/scala/org/apache/spark/memory/MemoryPool.scala
@@ -27,7 +27,7 @@ import javax.annotation.concurrent.GuardedBy
  *             to `Object` to avoid programming errors, since this object should only be used for
  *             synchronization purposes.
  */
-abstract class MemoryPool(lock: Object) {
+private[memory] abstract class MemoryPool(lock: Object) {
 
   @GuardedBy("lock")
   private[this] var _poolSize: Long = 0

--- a/core/src/main/scala/org/apache/spark/memory/StorageMemoryPool.scala
+++ b/core/src/main/scala/org/apache/spark/memory/StorageMemoryPool.scala
@@ -31,7 +31,7 @@ import org.apache.spark.storage.{MemoryStore, BlockStatus, BlockId}
  *
  * @param lock a [[MemoryManager]] instance to synchronize on
  */
-class StorageMemoryPool(lock: Object) extends MemoryPool(lock) with Logging {
+private[memory] class StorageMemoryPool(lock: Object) extends MemoryPool(lock) with Logging {
 
   @GuardedBy("lock")
   private[this] var _memoryUsed: Long = 0L

--- a/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
+++ b/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
@@ -49,7 +49,7 @@ import org.apache.spark.storage.{BlockStatus, BlockId}
 private[spark] class UnifiedMemoryManager private[memory] (
     conf: SparkConf,
     val maxMemory: Long,
-    private val storageRegionSize: Long,
+    storageRegionSize: Long,
     numCores: Int)
   extends MemoryManager(
     conf,


### PR DESCRIPTION
This patch tightens them to `private[memory]`.
