### PR TITLE
[SPARK-12203][STREAMING] Add KafkaDirectInputDStream

### DIFF
--- a/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaDirectInputDStream.scala
+++ b/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaDirectInputDStream.scala
@@ -195,12 +195,12 @@ class KafkaDirectReceiver[
       s"Beginning offset ${fromOffset} is after the ending offset ${untilOffset} " +
         s"for topic ${part.topic} partition ${part.partition}. " +
         "You either provided an invalid fromOffset, or the Kafka topic has been damaged"
-    
+
     private def errRanOutBeforeEnd(): String =
       s"Ran out of messages before reaching ending offset ${untilOffset} " +
       s"for topic ${part.topic} partition ${part.partition} start ${fromOffset}." +
       " This should not happen, and indicates that messages may have been lost"
-    
+
     private def errOvershotEnd(itemOffset: Long): String =
       s"Got ${itemOffset} > ending offset ${untilOffset} " +
       s"for topic ${part.topic} partition ${part.partition} start ${fromOffset}." +
@@ -247,7 +247,7 @@ class KafkaDirectReceiver[
         }
       }
     }
-  } 
+  }
 
   // Handles Kafka messages
   private class MessageHandler(partition: TopicAndPartition, fromOffset: Long)

--- a/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaDirectInputDStream.scala
+++ b/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaDirectInputDStream.scala
@@ -259,7 +259,8 @@ class KafkaDirectReceiver[
 
       while(true) {
         try {
-          val untilOffsets = clamp(currentOffset, latestLeaderOffsets(kc, Set(partition), maxRetries))
+          val untilOffsets =
+            clamp(currentOffset, latestLeaderOffsets(kc, Set(partition), maxRetries))
           if (currentOffset != untilOffsets(partition).offset) {
             val iter =
               new KafkaDirectIterator(kc, partition, currentOffset, untilOffsets(partition).offset)

--- a/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaDirectInputDStream.scala
+++ b/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaDirectInputDStream.scala
@@ -1,0 +1,281 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.streaming.kafka
+
+import java.util.Properties
+
+import scala.reflect.{classTag, ClassTag}
+
+import kafka.api.{FetchRequestBuilder, FetchResponse}
+import kafka.common.{ErrorMapping, TopicAndPartition}
+import kafka.consumer.{KafkaStream, Consumer, ConsumerConfig, ConsumerConnector, SimpleConsumer}
+import kafka.message.{MessageAndMetadata, MessageAndOffset}
+import kafka.serializer.Decoder
+import kafka.utils.VerifiableProperties
+
+import org.apache.spark.{Logging, SparkConf, SparkException}
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.streaming.{Duration, DStreamGraph, StreamingContext}
+import org.apache.spark.streaming.dstream._
+import org.apache.spark.streaming.kafka.KafkaCluster.LeaderOffset
+import org.apache.spark.streaming.receiver.Receiver
+import org.apache.spark.streaming.scheduler.{RateController, StreamInputInfo}
+import org.apache.spark.streaming.scheduler.rate.RateEstimator
+import org.apache.spark.util.{NextIterator, ThreadUtils}
+
+
+/**
+ * Input stream that pulls messages from a Kafka Broker.
+ *
+ * @param kafkaParams Map of kafka configuration parameters.
+ *                    See: http://kafka.apache.org/configuration.html
+ *   Requires "metadata.broker.list" or "bootstrap.servers" to be set with Kafka broker(s),
+ *   NOT zookeeper servers, specified in host1:port1,host2:port2 form.
+ * @param fromOffsets per-topic/partition Kafka offsets defining the (inclusive)
+ *  starting point of the stream
+ * @param storageLevel RDD storage level.
+ */
+private[streaming]
+class KafkaDirectInputDStream[
+  K: ClassTag,
+  V: ClassTag,
+  U <: Decoder[_]: ClassTag,
+  T <: Decoder[_]: ClassTag](
+    ssc_ : StreamingContext,
+    kafkaParams: Map[String, String],
+    val fromOffsets: Map[TopicAndPartition, Long],
+    storageLevel: StorageLevel
+  ) extends ReceiverInputDStream[(K, V)](ssc_) with Logging {
+
+  // Keep this consistent with how other streams are named (e.g. "Flume polling stream [2]")
+  private[streaming] override def name: String = s"Kafka direct receiver stream [$id]"
+
+  def getReceiver(): Receiver[(K, V)] = {
+    new KafkaDirectReceiver[K, V, U, T](ssc_.conf, context.graph.batchDuration, kafkaParams,
+      fromOffsets, storageLevel)
+  }
+}
+
+private[streaming]
+class KafkaDirectReceiver[
+  K: ClassTag,
+  V: ClassTag,
+  U <: Decoder[_]: ClassTag,
+  T <: Decoder[_]: ClassTag](
+    conf: SparkConf,
+    duration: Duration,
+    kafkaParams: Map[String, String],
+    val fromOffsets: Map[TopicAndPartition, Long],
+    storageLevel: StorageLevel
+  ) extends Receiver[(K, V)](storageLevel) with Logging {
+
+  val maxRetries = conf.getInt(
+    "spark.streaming.kafka.maxRetries", 1)
+
+  private val maxRateLimitPerPartition: Int = conf.getInt(
+      "spark.streaming.kafka.maxRatePerPartition", 0)
+
+  private def maxMessagesPerPartition: Option[Long] = {
+    val numPartitions = fromOffsets.keys.size
+
+    val effectiveRateLimitPerPartition =
+      Math.max(0, maxRateLimitPerPartition)
+
+    if (effectiveRateLimitPerPartition > 0 && duration != null) {
+      val secsPerBatch = duration.milliseconds.toDouble / 1000
+      Some((secsPerBatch * effectiveRateLimitPerPartition).toLong)
+    } else {
+      None
+    }
+  }
+
+  protected final def latestLeaderOffsets(
+      kc: KafkaCluster,
+      topicAndPartition: Set[TopicAndPartition],
+      retries: Int): Map[TopicAndPartition, LeaderOffset] = {
+    val o = kc.getLatestLeaderOffsets(topicAndPartition)
+    // Either.fold would confuse @tailrec, do it manually
+    if (o.isLeft) {
+      val err = o.left.get.toString
+      if (retries <= 0) {
+        throw new SparkException(err)
+      } else {
+        log.error(err)
+        Thread.sleep(kc.config.refreshLeaderBackoffMs)
+        latestLeaderOffsets(kc, topicAndPartition, retries - 1)
+      }
+    } else {
+      o.right.get
+    }
+  }
+
+  // limits the maximum number of messages per partition
+  protected def clamp(
+    currentOffset: Long,
+    leaderOffsets: Map[TopicAndPartition, LeaderOffset]): Map[TopicAndPartition, LeaderOffset] = {
+    maxMessagesPerPartition.map { mmp =>
+      leaderOffsets.map { case (tp, lo) =>
+        tp -> lo.copy(offset = Math.min(currentOffset + mmp, lo.offset))
+      }
+    }.getOrElse(leaderOffsets)
+  }
+
+  def onStop() {
+  }
+
+  def onStart() {
+    logInfo("Starting Kafka Consumer Direct Stream")
+
+    val executorPool =
+      ThreadUtils.newDaemonFixedThreadPool(fromOffsets.keys.size, "KafkaMessageHandler")
+    try {
+      // Start the messages handler
+      fromOffsets.keys.foreach { partition =>
+        executorPool.submit(new MessageHandler(partition, fromOffsets(partition)))
+      }
+    } finally {
+      executorPool.shutdown() // Just causes thread to terminate after work is done
+    }
+  }
+
+  private class KafkaDirectIterator(
+      kc: KafkaCluster,
+      part: TopicAndPartition,
+      fromOffset: Long,
+      untilOffset: Long) extends NextIterator[MessageAndMetadata[K, V]] {
+    val keyDecoder = classTag[U].runtimeClass.getConstructor(classOf[VerifiableProperties])
+      .newInstance(kc.config.props)
+      .asInstanceOf[Decoder[K]]
+    val valueDecoder = classTag[T].runtimeClass.getConstructor(classOf[VerifiableProperties])
+      .newInstance(kc.config.props)
+      .asInstanceOf[Decoder[V]]
+    val consumer = connectLeader
+    var requestOffset = fromOffset
+    var iter: Iterator[MessageAndOffset] = null
+
+    private def connectLeader: SimpleConsumer = {
+      kc.connectLeader(part.topic, part.partition).fold(
+        errs => throw new SparkException(
+          s"Couldn't connect to leader for topic ${part.topic} ${part.partition}: " +
+            errs.mkString("\n")),
+        consumer => consumer
+      )
+    }
+
+    private def handleFetchErr(resp: FetchResponse) {
+      if (resp.hasError) {
+        val err = resp.errorCode(part.topic, part.partition)
+        if (err == ErrorMapping.LeaderNotAvailableCode ||
+          err == ErrorMapping.NotLeaderForPartitionCode) {
+          log.error(s"Lost leader for topic ${part.topic} partition ${part.partition}, " +
+            s" sleeping for ${kc.config.refreshLeaderBackoffMs}ms")
+          Thread.sleep(kc.config.refreshLeaderBackoffMs)
+        }
+        // Let normal rdd retry sort out reconnect attempts
+        throw ErrorMapping.exceptionFor(err)
+      }
+    }
+
+    private def errBeginAfterEnd(): String =
+      s"Beginning offset ${fromOffset} is after the ending offset ${untilOffset} " +
+        s"for topic ${part.topic} partition ${part.partition}. " +
+        "You either provided an invalid fromOffset, or the Kafka topic has been damaged"
+    
+    private def errRanOutBeforeEnd(): String =
+      s"Ran out of messages before reaching ending offset ${untilOffset} " +
+      s"for topic ${part.topic} partition ${part.partition} start ${fromOffset}." +
+      " This should not happen, and indicates that messages may have been lost"
+    
+    private def errOvershotEnd(itemOffset: Long): String =
+      s"Got ${itemOffset} > ending offset ${untilOffset} " +
+      s"for topic ${part.topic} partition ${part.partition} start ${fromOffset}." +
+      " This should not happen, and indicates a message may have been skipped"
+
+    private def fetchBatch: Iterator[MessageAndOffset] = {
+      val req = new FetchRequestBuilder()
+        .addFetch(part.topic, part.partition, requestOffset, kc.config.fetchMessageMaxBytes)
+        .build()
+      val resp = consumer.fetch(req)
+      handleFetchErr(resp)
+      // kafka may return a batch that starts before the requested offset
+      resp.messageSet(part.topic, part.partition)
+        .iterator
+        .dropWhile(_.offset < requestOffset)
+    }
+
+    override def close(): Unit = {
+      if (consumer != null) {
+        consumer.close()
+      }
+    }
+
+    override def getNext(): MessageAndMetadata[K, V] = {
+      assert(fromOffset <= untilOffset, errBeginAfterEnd())
+      if (iter == null || !iter.hasNext) {
+        iter = fetchBatch
+      }
+      if (!iter.hasNext) {
+        assert(requestOffset == untilOffset, errRanOutBeforeEnd())
+        finished = true
+        null.asInstanceOf[MessageAndMetadata[K, V]]
+      } else {
+        val item = iter.next()
+        if (item.offset >= untilOffset) {
+          assert(item.offset == untilOffset, errOvershotEnd(item.offset))
+          errOvershotEnd(item.offset)
+          finished = true
+          null.asInstanceOf[MessageAndMetadata[K, V]]
+        } else {
+          requestOffset = item.nextOffset
+          new MessageAndMetadata(
+            part.topic, part.partition, item.message, item.offset, keyDecoder, valueDecoder)
+        }
+      }
+    }
+  } 
+
+  // Handles Kafka messages
+  private class MessageHandler(partition: TopicAndPartition, fromOffset: Long)
+    extends Runnable {
+    val kc = new KafkaCluster(kafkaParams)
+    var currentOffset: Long = fromOffset
+    def run() {
+      logInfo("Starting MessageHandler.")
+
+      while(true) {
+        try {
+          val untilOffsets = clamp(currentOffset, latestLeaderOffsets(kc, Set(partition), maxRetries))
+          if (currentOffset != untilOffsets(partition).offset) {
+            val iter =
+              new KafkaDirectIterator(kc, partition, currentOffset, untilOffsets(partition).offset)
+
+            var next: MessageAndMetadata[K, V] = iter.getNext()
+            while (next != null) {
+              store((next.key, next.message))
+              next = iter.getNext()
+            }
+            currentOffset = untilOffsets(partition).offset
+          }
+        } catch {
+          case e: Throwable =>
+            reportError("Error handling message; exiting", e)
+        }
+      }
+    }
+  }
+}

--- a/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaRDDIterator.scala
+++ b/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaRDDIterator.scala
@@ -105,7 +105,7 @@ private[streaming] class KafkaRDDIterator[
     }
   }
 }
- 
+
 private[streaming] class KafkaIterator[
   K: ClassTag,
   V: ClassTag,
@@ -118,7 +118,7 @@ private[streaming] class KafkaIterator[
     partition: Int,
     fromOffset: Long,
     untilOffset: Long) extends NextIterator[MessageAndMetadata[K, V]] with Logging {
- 
+
   log.info(s"Computing topic ${topic}, partition ${partition} " +
     s"offsets ${fromOffset} -> ${untilOffset}")
 

--- a/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaRDDIterator.scala
+++ b/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaRDDIterator.scala
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.streaming.kafka
+
+import scala.collection.mutable.ArrayBuffer
+import scala.reflect.{classTag, ClassTag}
+
+import org.apache.spark.{Logging, Partition, SparkContext, SparkException, TaskContext}
+import org.apache.spark.partial.{PartialResult, BoundedDouble}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.util.NextIterator
+
+import kafka.api.{FetchRequestBuilder, FetchResponse}
+import kafka.common.ErrorMapping
+import kafka.consumer.SimpleConsumer
+import kafka.message.{MessageAndMetadata, MessageAndOffset}
+import kafka.serializer.Decoder
+import kafka.utils.VerifiableProperties
+
+private[streaming] object KafkaIteratorError {
+  def errBeginAfterEnd(
+      topic: String,
+      partition: Int,
+      fromOffset: Long,
+      untilOffset: Long): String =
+    s"Beginning offset ${fromOffset} is after the ending offset ${untilOffset} " +
+      s"for topic ${topic} partition ${partition}. " +
+      "You either provided an invalid fromOffset, or the Kafka topic has been damaged"
+
+  def errRanOutBeforeEnd(
+      topic: String,
+      partition: Int,
+      fromOffset: Long,
+      untilOffset: Long): String =
+    s"Ran out of messages before reaching ending offset ${untilOffset} " +
+    s"for topic ${topic} partition ${partition} start ${fromOffset}." +
+    " This should not happen, and indicates that messages may have been lost"
+
+  def errOvershotEnd(
+      itemOffset: Long,
+      topic: String,
+      partition: Int,
+      fromOffset: Long,
+      untilOffset: Long): String =
+    s"Got ${itemOffset} > ending offset ${untilOffset} " +
+    s"for topic ${topic} partition ${partition} start ${fromOffset}." +
+    " This should not happen, and indicates a message may have been skipped"
+}
+
+private[streaming] class KafkaRDDIterator[
+  K: ClassTag,
+  V: ClassTag,
+  U <: Decoder[_]: ClassTag,
+  T <: Decoder[_]: ClassTag,
+  R: ClassTag](
+    kafkaParams: Map[String, String],
+    part: KafkaRDDPartition,
+    context: TaskContext,
+    messageHandler: MessageAndMetadata[K, V] => R)
+    extends NextIterator[R] {
+
+  context.addTaskCompletionListener{ context => closeIfNeeded() }
+
+  val kc = new KafkaCluster(kafkaParams)
+
+  val (preferredHost, preferredPort) = if (context.attemptNumber > 0) {
+    (Some(part.host), Some(part.port))
+  } else {
+    (None, None)
+  }
+
+  val iter = new KafkaIterator[K, V, U, T](
+    kc,
+    preferredHost,
+    preferredPort,
+    part.topic,
+    part.partition,
+    part.fromOffset,
+    part.untilOffset)
+
+  override def close(): Unit = iter.close()
+
+  override def getNext(): R = {
+    val nextItem = iter.getNext()
+    if (nextItem == null) {
+      finished = true
+      nextItem.asInstanceOf[R]
+    } else {
+      messageHandler(nextItem)
+    }
+  }
+}
+ 
+private[streaming] class KafkaIterator[
+  K: ClassTag,
+  V: ClassTag,
+  U <: Decoder[_]: ClassTag,
+  T <: Decoder[_]: ClassTag](
+    kc: KafkaCluster,
+    host: Option[String],
+    port: Option[Int],
+    topic: String,
+    partition: Int,
+    fromOffset: Long,
+    untilOffset: Long) extends NextIterator[MessageAndMetadata[K, V]] with Logging {
+ 
+  log.info(s"Computing topic ${topic}, partition ${partition} " +
+    s"offsets ${fromOffset} -> ${untilOffset}")
+
+  val keyDecoder = classTag[U].runtimeClass.getConstructor(classOf[VerifiableProperties])
+    .newInstance(kc.config.props)
+    .asInstanceOf[Decoder[K]]
+  val valueDecoder = classTag[T].runtimeClass.getConstructor(classOf[VerifiableProperties])
+    .newInstance(kc.config.props)
+    .asInstanceOf[Decoder[V]]
+  val consumer = connectLeader
+  var requestOffset = fromOffset
+  var iter: Iterator[MessageAndOffset] = null
+
+  // The idea is to use the provided preferred host, if given
+  // ,except on task retry atttempts,
+  // to minimize number of kafka metadata requests
+  private def connectLeader: SimpleConsumer = {
+    if (host.isDefined && port.isDefined) {
+      kc.connect(host.get, port.get)
+    } else {
+      kc.connectLeader(topic, partition).fold(
+        errs => throw new SparkException(
+          s"Couldn't connect to leader for topic ${topic} ${partition}: " +
+            errs.mkString("\n")),
+        consumer => consumer
+      )
+    }
+  }
+
+  private def handleFetchErr(resp: FetchResponse) {
+    if (resp.hasError) {
+      val err = resp.errorCode(topic, partition)
+      if (err == ErrorMapping.LeaderNotAvailableCode ||
+        err == ErrorMapping.NotLeaderForPartitionCode) {
+        log.error(s"Lost leader for topic ${topic} partition ${partition}, " +
+          s" sleeping for ${kc.config.refreshLeaderBackoffMs}ms")
+        Thread.sleep(kc.config.refreshLeaderBackoffMs)
+      }
+      // Let normal rdd retry sort out reconnect attempts
+      throw ErrorMapping.exceptionFor(err)
+    }
+  }
+
+  private def fetchBatch: Iterator[MessageAndOffset] = {
+    val req = new FetchRequestBuilder()
+      .addFetch(topic, partition, requestOffset, kc.config.fetchMessageMaxBytes)
+      .build()
+    val resp = consumer.fetch(req)
+    handleFetchErr(resp)
+    // kafka may return a batch that starts before the requested offset
+    resp.messageSet(topic, partition)
+      .iterator
+      .dropWhile(_.offset < requestOffset)
+  }
+
+  override def close(): Unit = {
+    if (consumer != null) {
+      consumer.close()
+    }
+  }
+
+  override def getNext(): MessageAndMetadata[K, V] = {
+    if (iter == null || !iter.hasNext) {
+      iter = fetchBatch
+    }
+    if (!iter.hasNext) {
+      assert(requestOffset == untilOffset,
+        KafkaIteratorError.errRanOutBeforeEnd(topic, partition, fromOffset, untilOffset))
+      finished = true
+      null.asInstanceOf[MessageAndMetadata[K, V]]
+    } else {
+      val item = iter.next()
+      if (item.offset >= untilOffset) {
+        assert(item.offset == untilOffset,
+          KafkaIteratorError.errOvershotEnd(item.offset, topic, partition, fromOffset, untilOffset))
+        finished = true
+        null.asInstanceOf[MessageAndMetadata[K, V]]
+      } else {
+        requestOffset = item.nextOffset
+        new MessageAndMetadata(
+          topic, partition, item.message, item.offset, keyDecoder, valueDecoder)
+      }
+    }
+  }
+}

--- a/external/kafka/src/test/scala/org/apache/spark/streaming/kafka/KafkaDirectStreamSuite.scala
+++ b/external/kafka/src/test/scala/org/apache/spark/streaming/kafka/KafkaDirectStreamSuite.scala
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.streaming.kafka
+
+import scala.collection.mutable
+import scala.concurrent.duration._
+import scala.language.postfixOps
+import scala.util.Random
+
+import kafka.serializer.StringDecoder
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.Eventually
+
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.streaming.{Milliseconds, StreamingContext}
+
+class KafkaDirectStreamSuite extends SparkFunSuite with Eventually with BeforeAndAfterAll {
+  private var ssc: StreamingContext = _
+  private var kafkaTestUtils: KafkaTestUtils = _
+
+  override def beforeAll(): Unit = {
+    kafkaTestUtils = new KafkaTestUtils
+    kafkaTestUtils.setup()
+  }
+
+  override def afterAll(): Unit = {
+    if (ssc != null) {
+      ssc.stop()
+      ssc = null
+    }
+
+    if (kafkaTestUtils != null) {
+      kafkaTestUtils.teardown()
+      kafkaTestUtils = null
+    }
+  }
+
+  test("Kafka direct input stream") {
+    val sparkConf = new SparkConf().setMaster("local[4]").setAppName(this.getClass.getSimpleName)
+    ssc = new StreamingContext(sparkConf, Milliseconds(500))
+
+    val sent = Map("a" -> 14, "b" -> 18, "c" -> 10)
+    val topics = Set("basic1", "basic2")
+    val data = Map("a" -> 7, "b" -> 9, "c" -> 5)
+    topics.foreach { t =>
+      kafkaTestUtils.createTopic(t)
+      kafkaTestUtils.sendMessages(t, data)
+    }
+
+    val kafkaParams = Map(
+      "metadata.broker.list" -> kafkaTestUtils.brokerAddress,
+      "auto.offset.reset" -> "smallest")
+
+    val stream =
+      KafkaUtils.createDirectReceiverStream[String, String, StringDecoder, StringDecoder](
+        ssc, kafkaParams, topics)
+
+    val result = new mutable.HashMap[String, Long]() with mutable.SynchronizedMap[String, Long]
+    stream.map(_._2).countByValue().foreachRDD { r =>
+      val ret = r.collect()
+      ret.toMap.foreach { kv =>
+        val count = result.getOrElseUpdate(kv._1, 0) + kv._2
+        result.put(kv._1, count)
+      }
+    }
+
+    ssc.start()
+
+    eventually(timeout(10000 milliseconds), interval(100 milliseconds)) {
+      assert(sent === result)
+    }
+  }
+}

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -163,6 +163,22 @@ object MimaExcludes {
       // SPARK-11314: YARN backend moved to yarn sub-module and MiMA complains even though it's a
       // private class.
       MimaBuild.excludeSparkClass("scheduler.cluster.YarnSchedulerBackend$YarnSchedulerEndpoint")
+      ++ Seq(
+        ProblemFilters.exclude[MissingMethodProblem](
+          "org.apache.spark.streaming.kafka.KafkaRDD.org$apache$spark$streaming$kafka$KafkaRDD$$errRanOutBeforeEnd"),
+        ProblemFilters.exclude[MissingMethodProblem](
+          "org.apache.spark.streaming.kafka.KafkaRDD.org$apache$spark$streaming$kafka$KafkaRDD$$errBeginAfterEnd"),
+        ProblemFilters.exclude[MissingMethodProblem](
+          "org.apache.spark.streaming.kafka.KafkaRDD.org$apache$spark$streaming$kafka$KafkaRDD$$errOvershotEnd"),
+        ProblemFilters.exclude[MissingClassProblem](
+          "org.apache.spark.streaming.kafka.KafkaRDD$KafkaRDDIterator"),
+        ProblemFilters.exclude[MissingMethodProblem](
+          "org.apache.spark.streaming.kafka.DirectKafkaInputDStream.latestLeaderOffsets"),
+        ProblemFilters.exclude[MissingMethodProblem](
+          "org.apache.spark.streaming.kafka.DirectKafkaInputDStream.org$apache$spark$streaming$kafka$DirectKafkaInputDStream$$maxRateLimitPerPartition"),
+        ProblemFilters.exclude[MissingMethodProblem](
+          "org.apache.spark.streaming.kafka.DirectKafkaInputDStream.clamp")
+      )
     case v if v.startsWith("1.5") =>
       Seq(
         MimaBuild.excludeSparkPackage("network"),

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -162,8 +162,8 @@ object MimaExcludes {
       ) ++
       // SPARK-11314: YARN backend moved to yarn sub-module and MiMA complains even though it's a
       // private class.
-      MimaBuild.excludeSparkClass("scheduler.cluster.YarnSchedulerBackend$YarnSchedulerEndpoint")
-      ++ Seq(
+      MimaBuild.excludeSparkClass("scheduler.cluster.YarnSchedulerBackend$YarnSchedulerEndpoint") ++
+      Seq(
         ProblemFilters.exclude[MissingMethodProblem](
           "org.apache.spark.streaming.kafka.KafkaRDD.org$apache$spark$streaming$kafka$KafkaRDD$$errRanOutBeforeEnd"),
         ProblemFilters.exclude[MissingMethodProblem](


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-12203

Currently, we have DirectKafkaInputDStream, which directly pulls messages from Kafka Brokers without any receivers, and KafkaInputDStream, which pulls messages from a Kafka Broker using receivers with zookeeper.

As we observed, because DirectKafkaInputDStream retrieves messages from Kafka after each batch finishes, it posts a latency compared with KafkaInputDStream that continues to pull messages during each batch window.

So we try to add KafkaDirectInputDStream that directly pulls messages from Kafka Brokers as DirectKafkaInputDStream, but it uses receivers as KafkaInputDStream and pulls messages as blocks during each batch window.
