### PR TITLE
[SPARK-9372] [SQL] For joins, insert IS NOT NULL filters to children.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -389,7 +389,7 @@ class Analyzer(
         a.copy(aggregateExpressions = expanded)
 
       // Special handling for cases when self-join introduce duplicate expression ids.
-      case j @ Join(left, right, _, _) if !j.selfJoinResolved =>
+      case j @ Join(left, right, _, _, _) if !j.selfJoinResolved =>
         val conflictingAttributes = left.outputSet.intersect(right.outputSet)
         logDebug(s"Conflicting attributes ${conflictingAttributes.mkString(",")} in $j")
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateFunction, AggregateExpression}
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.types._
 
@@ -87,12 +87,12 @@ trait CheckAnalysis {
               s"filter expression '${f.condition.prettyString}' " +
                 s"of type ${f.condition.dataType.simpleString} is not a boolean.")
 
-          case j @ Join(_, _, _, Some(condition)) if condition.dataType != BooleanType =>
+          case j @ Join(_, _, _, Some(condition), _) if condition.dataType != BooleanType =>
             failAnalysis(
               s"join condition '${condition.prettyString}' " +
                 s"of type ${condition.dataType.simpleString} is not a boolean.")
 
-          case j @ Join(_, _, _, Some(condition)) =>
+          case j @ Join(_, _, _, Some(condition), _) =>
             def checkValidJoinConditionExprs(expr: Expression): Unit = expr match {
               case p: Predicate =>
                 p.asInstanceOf[Expression].children.foreach(checkValidJoinConditionExprs)
@@ -190,7 +190,7 @@ trait CheckAnalysis {
                  | ${exprs.map(_.prettyString).mkString(",")}""".stripMargin)
 
           // Special handling for cases when self-join introduce duplicate expression ids.
-          case j @ Join(left, right, _, _) if left.outputSet.intersect(right.outputSet).nonEmpty =>
+          case j @ Join(left, right, _, _, _) if left.outputSet.intersect(right.outputSet).nonEmpty =>
             val conflictingAttributes = left.outputSet.intersect(right.outputSet)
             failAnalysis(
               s"""

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -190,14 +190,15 @@ trait CheckAnalysis {
                  | ${exprs.map(_.prettyString).mkString(",")}""".stripMargin)
 
           // Special handling for cases when self-join introduce duplicate expression ids.
-          case j @ Join(left, right, _, _, _) if left.outputSet.intersect(right.outputSet).nonEmpty =>
-            val conflictingAttributes = left.outputSet.intersect(right.outputSet)
-            failAnalysis(
-              s"""
-                 |Failure when resolving conflicting references in Join:
-                 |$plan
-                 |Conflicting attributes: ${conflictingAttributes.mkString(",")}
-                 |""".stripMargin)
+          case j @ Join(left, right, _, _, _)
+            if left.outputSet.intersect(right.outputSet).nonEmpty =>
+              val conflictingAttributes = left.outputSet.intersect(right.outputSet)
+              failAnalysis(
+                s"""
+                   |Failure when resolving conflicting references in Join:
+                   |$plan
+                   |Conflicting attributes: ${conflictingAttributes.mkString(",")}
+                   |""".stripMargin)
 
           case o if !o.resolved =>
             failAnalysis(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/EquivalentExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/EquivalentExpressions.scala
@@ -88,6 +88,13 @@ class EquivalentExpressions {
   }
 
   /**
+   * Returns true if e exists.
+   */
+  def contains(e: Expression): Boolean = {
+    equivalenceMap.contains(Expr(e))
+  }
+
+  /**
    * Returns the state of the data structure as a string. If `all` is false, skips sets of
    * equivalent expressions with cardinality 1.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -203,9 +203,20 @@ object ExtractNonNullableAttributes extends Logging with PredicateHelper {
           result.add(b)
         }
       }
+      case BinaryComparison(Cast(a: Attribute, _), Cast(b: Attribute, _)) => {
+        if (!e.isInstanceOf[EqualNullSafe]) {
+          result.add(a)
+          result.add(b)
+        }
+      }
       case BinaryComparison(a: Attribute, _) => if (!e.isInstanceOf[EqualNullSafe]) result.add(a)
       case BinaryComparison(_, a: Attribute) => if (!e.isInstanceOf[EqualNullSafe]) result.add(a)
+      case BinaryComparison(Cast(a: Attribute, _), _) =>
+        if (!e.isInstanceOf[EqualNullSafe]) result.add(a)
+      case BinaryComparison(_, Cast(a: Attribute, _)) =>
+        if (!e.isInstanceOf[EqualNullSafe]) result.add(a)
       case Not(child) => extract(child)
+      case _ =>
     }
     predicates.foreach { extract(_) }
     result.toSet

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
@@ -99,6 +99,13 @@ abstract class LogicalPlan extends QueryPlan[LogicalPlan] with Logging {
    */
   lazy val resolved: Boolean = expressions.forall(_.resolved) && childrenResolved
 
+  /**
+   * Returns true if the two plans are semantically equal. This should ignore state generated
+   * during planning to help the planning process.
+   * TODO: implement this as a pass that canonicalizes the plan tree instead?
+   */
+  def semanticEquals(other: LogicalPlan): Boolean = this == other
+
   override protected def statePrefix = if (!resolved) "'" else super.statePrefix
 
   /**

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinFilterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinFilterSuite.scala
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.analysis.EliminateSubQueries
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.plans.{Inner, PlanTest}
+import org.apache.spark.sql.catalyst.rules._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.dsl.expressions._
+
+class JoinFilterSuite extends PlanTest {
+
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches =
+      Batch("Subqueries", Once,
+        EliminateSubQueries) ::
+        Batch("Filter Pushdown", Once,
+          SamplePushDown,
+          CombineFilters,
+          PushPredicateThroughProject,
+          BooleanSimplification,
+          PushPredicateThroughJoin,
+          PushPredicateThroughGenerate,
+          PushPredicateThroughAggregate,
+          ColumnPruning,
+          ProjectCollapsing,
+          AddJoinKeyNullabilityFilters) :: Nil
+  }
+
+  val testRelation = LocalRelation('a.int, 'b.int, 'c.int)
+
+  val testRelation1 = LocalRelation('d.int)
+
+  test("joins infer is NOT NULL on equijoin keys") {
+    val x = testRelation.subquery('x)
+    val y = testRelation.subquery('y)
+
+    val originalQuery = x.join(y).
+      where("x.b".attr === "y.b".attr)
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+
+    val correctAnswer =
+        Filter(IsNotNull("x.b".attr), x).join(
+        Filter(IsNotNull("y.b".attr), y), Inner, Some("x.b".attr === "y.b".attr)).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("joins infer is NOT NULL on join keys") {
+    val x = testRelation.subquery('x)
+    val y = testRelation.subquery('y)
+
+    val originalQuery = x.join(y).
+      where("x.b".attr >= "y.b".attr).where("x.b".attr < "y.b".attr)
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+
+    val correctAnswer =
+      Filter(IsNotNull("x.b".attr), x).join(
+        Filter(IsNotNull("y.b".attr), y), Inner,
+        Some(And("x.b".attr >= "y.b".attr, "x.b".attr < "y.b".attr))).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("joins infer is NOT NULL on not equal keys") {
+    val x = testRelation.subquery('x)
+    val y = testRelation.subquery('y)
+
+    val originalQuery = x.join(y).
+      where("x.b".attr !== "y.a".attr)
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+
+    val correctAnswer =
+      Filter(IsNotNull("x.b".attr), x).join(
+        Filter(IsNotNull("y.a".attr), y), Inner, Some("x.b".attr !== "y.a".attr)).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("joins infer is NOT NULL with multiple joins") {
+    val t1 = testRelation.subquery('t1)
+    val t2 = testRelation.subquery('t2)
+    val t3 = testRelation.subquery('t3)
+    val t4 = testRelation.subquery('t4)
+
+    val originalQuery = t1.join(t2).join(t3).join(t4)
+      .where("t1.b".attr === "t2.b".attr)
+      .where("t1.b".attr === "t3.b".attr)
+      .where("t1.b".attr === "t4.b".attr)
+      .where("t2.b".attr === "t3.b".attr)
+      .where("t2.b".attr === "t4.b".attr)
+      .where("t3.b".attr === "t4.b".attr)
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+    var numFilters = 0
+    optimized.foreach { p => p match {
+      case Filter(condition, _) => {
+        var containsIsNotNull = false
+        condition.foreach { c =>
+          if (c.isInstanceOf[IsNotNull]) containsIsNotNull = true
+        }
+        if (containsIsNotNull) {
+          // If the condition contained IsNotNull, then it must be generated. Verify the entire
+          // condition is IsNotNull (to verify IsNotNull is not repeated) and that we generate the
+          // expected number of filters.
+          assert(condition.isInstanceOf[IsNotNull])
+          numFilters += 1
+        }
+      }
+      case _ =>
+    }}
+    assertResult(4)(numFilters)
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/PlanTest.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/PlanTest.scala
@@ -43,7 +43,7 @@ abstract class PlanTest extends SparkFunSuite {
   protected def comparePlans(plan1: LogicalPlan, plan2: LogicalPlan) {
     val normalized1 = normalizeExprIds(plan1)
     val normalized2 = normalizeExprIds(plan2)
-    if (normalized1 != normalized2) {
+    if (!normalized1.semanticEquals(normalized2)) {
       fail(
         s"""
           |== FAIL: Plans do not match ===


### PR DESCRIPTION
Some join types and conditions imply that the join keys cannot be NULL and
can be filtered out by the children. This patch does this for inner joins
and introduces a mechanism to generate predicates. The complex part of doing
this is to make sure the transformation is stable. The problem that we want
to avoid is generating a filter in the join, having that pushed down and then
having the join regenerate the filter.

This patch solves this by having the join remember predicates that it has
generated. This mechanism should be general enough that we can infer other
predicates, for example "a join b where a.id = b.id AND a.id = 10" could
also use this mechanism to generate the predicate "b.id = 10".
