### PR TITLE
[SPARK-12227][SQL] Support drop multiple columns specified by Column class in DataFrame API

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -1296,10 +1296,10 @@ class DataFrame private[sql](
   }
 
   /**
-   * Returns a new [[DataFrame]] with a column dropped.
+   * Returns a new [[DataFrame]] with columns dropped.
    * This version of drop accepts Column(s) rather than name(s).
    * This is a no-op if the DataFrame doesn't have column(s)
-   * with an equivalent expression.
+   * with equivalent expression(s).
    * @group dfops
    * @since 1.6.0
    */

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -402,6 +402,13 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     assert(df.schema.map(_.name) === Seq("value"))
   }
 
+  test("drop column using drop with column references") {
+    val src = Seq((0, 2, 3)).toDF("a", "b", "c")
+    val df = src.drop(src("a"), src("b"))
+    checkAnswer(df, Row(3))
+    assert(df.schema.map(_.name) === Seq("c"))
+  }
+
   test("drop unknown column (no-op) with column reference") {
     val col = Column("random")
     val df = testData.drop(col)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-12227

In this PR, I added the support to drop multiple columns by reference. This was only supported with the string names.

As `varargs` does not recognise the type for multuple variables, I changed `drop(colNames: String*)` to `drop(colName: String, colNames: String*)` correspondingly to `orderBy(sortCol: String, sortCols: String*)` and `sort(sortCol: String, sortCols: String*)`.

Accordingly, the call in `drop(colName: String)` was changed.
