### PR TITLE
[SPARK-12213] [SQL] use multiple partitions for single distinct query

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/CatalystConf.scala
@@ -19,8 +19,6 @@ package org.apache.spark.sql.catalyst
 
 private[spark] trait CatalystConf {
   def caseSensitiveAnalysis: Boolean
-
-  protected[spark] def specializeSingleDistinctAggPlanning: Boolean
 }
 
 /**
@@ -31,13 +29,8 @@ object EmptyConf extends CatalystConf {
   override def caseSensitiveAnalysis: Boolean = {
     throw new UnsupportedOperationException
   }
-
-  protected[spark] override def specializeSingleDistinctAggPlanning: Boolean = {
-    throw new UnsupportedOperationException
-  }
 }
 
 /** A CatalystConf that can be used for local testing. */
 case class SimpleCatalystConf(caseSensitiveAnalysis: Boolean) extends CatalystConf {
-  protected[spark] override def specializeSingleDistinctAggPlanning: Boolean = true
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/DistinctAggregationRewriter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/DistinctAggregationRewriter.scala
@@ -123,15 +123,8 @@ case class DistinctAggregationRewriter(conf: CatalystConf) extends Rule[LogicalP
       .filter(_.isDistinct)
       .groupBy(_.aggregateFunction.children.toSet)
 
-    val shouldRewrite = if (conf.specializeSingleDistinctAggPlanning) {
-      // When the flag is set to specialize single distinct agg planning,
-      // we will rely on our Aggregation strategy to handle queries with a single
-      // distinct column.
-      distinctAggGroups.size > 1
-    } else {
-      distinctAggGroups.size >= 1
-    }
-    if (shouldRewrite) {
+    // Aggregation strategy can handle the query with single distinct
+    if (distinctAggGroups.size > 1) {
       // Create the attributes for the grouping id and the group by clause.
       val gid = new AttributeReference("gid", IntegerType, false)()
       val groupByMap = a.groupingExpressions.collect {

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
@@ -449,18 +449,6 @@ private[spark] object SQLConf {
     doc = "When true, we could use `datasource`.`path` as table in SQL query"
   )
 
-  val SPECIALIZE_SINGLE_DISTINCT_AGG_PLANNING =
-    booleanConf("spark.sql.specializeSingleDistinctAggPlanning",
-      defaultValue = Some(false),
-      isPublic = false,
-      doc = "When true, if a query only has a single distinct column and it has " +
-        "grouping expressions, we will use our planner rule to handle this distinct " +
-        "column (other cases are handled by DistinctAggregationRewriter). " +
-        "When false, we will always use DistinctAggregationRewriter to plan " +
-        "aggregation queries with DISTINCT keyword. This is an internal flag that is " +
-        "used to benchmark the performance impact of using DistinctAggregationRewriter to " +
-        "plan aggregation queries with a single distinct column.")
-
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"
     val EXTERNAL_SORT = "spark.sql.planner.externalSort"
@@ -578,9 +566,6 @@ private[sql] class SQLConf extends Serializable with CatalystConf {
   private[spark] def dataFrameRetainGroupColumns: Boolean = getConf(DATAFRAME_RETAIN_GROUP_COLUMNS)
 
   private[spark] def runSQLOnFile: Boolean = getConf(RUN_SQL_ON_FILES)
-
-  protected[spark] override def specializeSingleDistinctAggPlanning: Boolean =
-    getConf(SPECIALIZE_SINGLE_DISTINCT_AGG_PLANNING)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggregationIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggregationIterator.scala
@@ -17,12 +17,12 @@
 
 package org.apache.spark.sql.execution.aggregate
 
+import scala.collection.mutable.ArrayBuffer
+
 import org.apache.spark.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
-
-import scala.collection.mutable.ArrayBuffer
 
 /**
  * The base class of [[SortBasedAggregationIterator]].
@@ -33,15 +33,14 @@ import scala.collection.mutable.ArrayBuffer
  *    is used to generate result.
  */
 abstract class AggregationIterator(
-    groupingKeyAttributes: Seq[Attribute],
+    groupingExpressions: Seq[NamedExpression],
     valueAttributes: Seq[Attribute],
     aggregateExpressions: Seq[AggregateExpression],
     aggregateAttributes: Seq[Attribute],
     initialInputBufferOffset: Int,
     resultExpressions: Seq[NamedExpression],
-    newMutableProjection: (Seq[Expression], Seq[Attribute]) => (() => MutableProjection),
-    outputsUnsafeRows: Boolean)
-  extends Iterator[InternalRow] with Logging {
+    newMutableProjection: (Seq[Expression], Seq[Attribute]) => (() => MutableProjection))
+  extends Iterator[UnsafeRow] with Logging {
 
   ///////////////////////////////////////////////////////////////////////////
   // Initializing functions.
@@ -53,9 +52,10 @@ abstract class AggregationIterator(
 
   // Initialize all AggregateFunctions by binding references if necessary,
   // and set inputBufferOffset and mutableBufferOffset.
-  protected val aggregateFunctions: Array[AggregateFunction] = {
+  protected def initializeAggregateFunctions(
+    startingInputBufferOffset: Int): Array[AggregateFunction] = {
     var mutableBufferOffset = 0
-    var inputBufferOffset: Int = initialInputBufferOffset
+    var inputBufferOffset: Int = startingInputBufferOffset
     val functions = new Array[AggregateFunction](aggregateExpressions.length)
     var i = 0
     while (i < aggregateExpressions.length) {
@@ -94,11 +94,14 @@ abstract class AggregationIterator(
     functions
   }
 
+  protected val aggregateFunctions: Array[AggregateFunction] =
+    initializeAggregateFunctions(initialInputBufferOffset)
+
   // Positions of those imperative aggregate functions in allAggregateFunctions.
   // For example, we have func1, func2, func3, func4 in aggregateFunctions, and
   // func2 and func3 are imperative aggregate functions.
   // ImperativeAggregateFunctionPositions will be [1, 2].
-  private[this] val allImperativeAggregateFunctionPositions: Array[Int] = {
+  protected[this] val allImperativeAggregateFunctionPositions: Array[Int] = {
     val positions = new ArrayBuffer[Int]()
     var i = 0
     while (i < aggregateFunctions.length) {
@@ -112,7 +115,7 @@ abstract class AggregationIterator(
   }
 
   // The projection used to initialize buffer values for all expression-based aggregates.
-  private[this] val expressionAggInitialProjection = {
+  protected[this] val expressionAggInitialProjection = {
     val initExpressions = aggregateFunctions.flatMap {
       case ae: DeclarativeAggregate => ae.initialValues
       // For the positions corresponding to imperative aggregate functions, we'll use special
@@ -123,7 +126,7 @@ abstract class AggregationIterator(
   }
 
   // All imperative AggregateFunctions.
-  private[this] val allImperativeAggregateFunctions: Array[ImperativeAggregate] =
+  protected[this] val allImperativeAggregateFunctions: Array[ImperativeAggregate] =
     allImperativeAggregateFunctionPositions
       .map(aggregateFunctions)
       .map(_.asInstanceOf[ImperativeAggregate])
@@ -135,17 +138,7 @@ abstract class AggregationIterator(
   // Initializing functions used to process a row.
   protected val processRow: (MutableRow, InternalRow) => Unit = {
     val joinedRow = new JoinedRow
-    val aggregationBufferSchema = aggregateFunctions.flatMap(_.aggBufferAttributes)
-    val modes = aggregateExpressions.map(_.mode).distinct
     if (aggregateExpressions.nonEmpty) {
-      val inputAggregationBufferSchema = if (initialInputBufferOffset == 0) {
-        // If initialInputBufferOffset, the input value does not contain
-        // grouping keys.
-        // This part is pretty hacky.
-        aggregateFunctions.flatMap(_.inputAggBufferAttributes).toSeq
-      } else {
-        groupingKeyAttributes ++ aggregateFunctions.flatMap(_.inputAggBufferAttributes)
-      }
       val mergeExpressions = aggregateFunctions.zipWithIndex.flatMap {
         case (ae: DeclarativeAggregate, i) =>
           aggregateExpressions(i).mode match {
@@ -164,12 +157,13 @@ abstract class AggregationIterator(
           }
       }
       // This projection is used to merge buffer values for all expression-based aggregates.
-      val expressionAggMergeProjection =
+      val aggregationBufferSchema = aggregateFunctions.flatMap(_.aggBufferAttributes)
+      val updateProjection =
         newMutableProjection(mergeExpressions, aggregationBufferSchema ++ valueAttributes)()
 
       (currentBuffer: MutableRow, row: InternalRow) => {
         // Process all expression-based aggregate functions.
-        expressionAggMergeProjection.target(currentBuffer)(joinedRow(currentBuffer, row))
+        updateProjection.target(currentBuffer)(joinedRow(currentBuffer, row))
         // Process all imperative aggregate functions.
         var i = 0
         while (i < updateFunctions.length) {
@@ -183,49 +177,29 @@ abstract class AggregationIterator(
     }
   }
 
+
+  protected val groupingKeyProjection: UnsafeProjection =
+    UnsafeProjection.create(groupingExpressions, valueAttributes)
+  protected val groupingAttributes = groupingExpressions.map(_.toAttribute)
+
   // Initializing the function used to generate the output row.
-  protected val generateOutput: (InternalRow, MutableRow) => InternalRow = {
-    val rowToBeEvaluated = new JoinedRow
-    val safeOutputRow = new SpecificMutableRow(resultExpressions.map(_.dataType))
-    val mutableOutput = if (outputsUnsafeRows) {
-      UnsafeProjection.create(resultExpressions.map(_.dataType).toArray).apply(safeOutputRow)
-    } else {
-      safeOutputRow
-    }
+  protected def generateResultProjection(): (UnsafeRow, MutableRow) => UnsafeRow = {
+    val joinedRow = new JoinedRow
     val modes = aggregateExpressions.map(_.mode).distinct
-    if (!modes.contains(Final) && !modes.contains(Complete)) {
-      // Because we cannot copy a joinedRow containing a UnsafeRow (UnsafeRow does not
-      // support generic getter), we create a mutable projection to output the
-      // JoinedRow(currentGroupingKey, currentBuffer)
-      val bufferSchema = aggregateFunctions.flatMap(_.aggBufferAttributes)
-      val resultProjection =
-        newMutableProjection(
-          groupingKeyAttributes ++ bufferSchema,
-          groupingKeyAttributes ++ bufferSchema)()
-      resultProjection.target(mutableOutput)
-      (currentGroupingKey: InternalRow, currentBuffer: MutableRow) => {
-        resultProjection(rowToBeEvaluated(currentGroupingKey, currentBuffer))
-      }
-    } else if (aggregateExpressions.nonEmpty) {
-      // Final-only, Complete-only and Final-Complete: every output row contains values representing
-      // resultExpressions.
-      val bufferSchemata = aggregateFunctions.flatMap(_.aggBufferAttributes)
+    val bufferAttributes = aggregateFunctions.flatMap(_.aggBufferAttributes)
+    if (modes.contains(Final) || modes.contains(Complete)) {
       val evalExpressions = aggregateFunctions.map {
         case ae: DeclarativeAggregate => ae.evaluateExpression
         case agg: AggregateFunction => NoOp
       }
-      val expressionAggEvalProjection = newMutableProjection(evalExpressions, bufferSchemata)()
-      val aggregateResultSchema = aggregateAttributes
-      // TODO: Use unsafe row.
-      val aggregateResult = new SpecificMutableRow(aggregateResultSchema.map(_.dataType))
+      val aggregateResult = new SpecificMutableRow(aggregateAttributes.map(_.dataType))
+      val expressionAggEvalProjection = newMutableProjection(evalExpressions, bufferAttributes)()
       expressionAggEvalProjection.target(aggregateResult)
 
       val resultProjection =
-        newMutableProjection(
-          resultExpressions, groupingKeyAttributes ++ aggregateResultSchema)()
-      resultProjection.target(mutableOutput)
+        UnsafeProjection.create(resultExpressions, groupingAttributes ++ aggregateAttributes)
 
-      (currentGroupingKey: InternalRow, currentBuffer: MutableRow) => {
+      (currentGroupingKey: UnsafeRow, currentBuffer: MutableRow) => {
         // Generate results for all expression-based aggregate functions.
         expressionAggEvalProjection(currentBuffer)
         // Generate results for all imperative aggregate functions.
@@ -236,19 +210,26 @@ abstract class AggregationIterator(
             allImperativeAggregateFunctions(i).eval(currentBuffer))
           i += 1
         }
-        resultProjection(rowToBeEvaluated(currentGroupingKey, aggregateResult))
+        resultProjection(joinedRow(currentGroupingKey, aggregateResult))
+      }
+    } else if (modes.contains(Partial) || modes.contains(PartialMerge)) {
+      val resultProjection = UnsafeProjection.create(
+        groupingAttributes ++ bufferAttributes,
+        groupingAttributes ++ bufferAttributes)
+      (currentGroupingKey: UnsafeRow, currentBuffer: MutableRow) => {
+        resultProjection(joinedRow(currentGroupingKey, currentBuffer))
       }
     } else {
       // Grouping-only: we only output values of grouping expressions.
-      val resultProjection =
-        newMutableProjection(resultExpressions, groupingKeyAttributes)()
-      resultProjection.target(mutableOutput)
-
-      (currentGroupingKey: InternalRow, currentBuffer: MutableRow) => {
+      val resultProjection = UnsafeProjection.create(resultExpressions, groupingAttributes)
+      (currentGroupingKey: UnsafeRow, currentBuffer: MutableRow) => {
         resultProjection(currentGroupingKey)
       }
     }
   }
+
+  protected val generateOutput: (UnsafeRow, MutableRow) => UnsafeRow =
+    generateResultProjection()
 
   /** Initializes buffer values for all aggregate functions. */
   protected def initializeBuffer(buffer: MutableRow): Unit = {
@@ -259,10 +240,4 @@ abstract class AggregationIterator(
       i += 1
     }
   }
-
-  /**
-   * Creates a new aggregation buffer and initializes buffer values
-   * for all aggregate functions.
-   */
-  protected def newBuffer: MutableRow
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggregationIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggregationIterator.scala
@@ -35,10 +35,8 @@ import scala.collection.mutable.ArrayBuffer
 abstract class AggregationIterator(
     groupingKeyAttributes: Seq[Attribute],
     valueAttributes: Seq[Attribute],
-    nonCompleteAggregateExpressions: Seq[AggregateExpression],
-    nonCompleteAggregateAttributes: Seq[Attribute],
-    completeAggregateExpressions: Seq[AggregateExpression],
-    completeAggregateAttributes: Seq[Attribute],
+    aggregateExpressions: Seq[AggregateExpression],
+    aggregateAttributes: Seq[Attribute],
     initialInputBufferOffset: Int,
     resultExpressions: Seq[NamedExpression],
     newMutableProjection: (Seq[Expression], Seq[Attribute]) => (() => MutableProjection),
@@ -49,41 +47,20 @@ abstract class AggregationIterator(
   // Initializing functions.
   ///////////////////////////////////////////////////////////////////////////
 
-  // An Seq of all AggregateExpressions.
-  // It is important that all AggregateExpressions with the mode Partial, PartialMerge or Final
-  // are at the beginning of the allAggregateExpressions.
-  protected val allAggregateExpressions =
-    nonCompleteAggregateExpressions ++ completeAggregateExpressions
-
   require(
-    allAggregateExpressions.map(_.mode).distinct.length <= 2,
-    s"$allAggregateExpressions are not supported becuase they have more than 2 distinct modes.")
-
-  /**
-   * The distinct modes of AggregateExpressions. Right now, we can handle the following mode:
-   *  - Partial-only: all AggregateExpressions have the mode of Partial;
-   *  - PartialMerge-only: all AggregateExpressions have the mode of PartialMerge);
-   *  - Final-only: all AggregateExpressions have the mode of Final;
-   *  - Final-Complete: some AggregateExpressions have the mode of Final and
-   *    others have the mode of Complete;
-   *  - Complete-only: nonCompleteAggregateExpressions is empty and we have AggregateExpressions
-   *    with mode Complete in completeAggregateExpressions; and
-   *  - Grouping-only: there is no AggregateExpression.
-   */
-  protected val aggregationMode: (Option[AggregateMode], Option[AggregateMode]) =
-    nonCompleteAggregateExpressions.map(_.mode).distinct.headOption ->
-      completeAggregateExpressions.map(_.mode).distinct.headOption
+    aggregateExpressions.map(_.mode).distinct.length <= 2,
+    s"$aggregateExpressions are not supported becuase they have more than 2 distinct modes.")
 
   // Initialize all AggregateFunctions by binding references if necessary,
   // and set inputBufferOffset and mutableBufferOffset.
-  protected val allAggregateFunctions: Array[AggregateFunction] = {
+  protected val aggregateFunctions: Array[AggregateFunction] = {
     var mutableBufferOffset = 0
     var inputBufferOffset: Int = initialInputBufferOffset
-    val functions = new Array[AggregateFunction](allAggregateExpressions.length)
+    val functions = new Array[AggregateFunction](aggregateExpressions.length)
     var i = 0
-    while (i < allAggregateExpressions.length) {
-      val func = allAggregateExpressions(i).aggregateFunction
-      val funcWithBoundReferences: AggregateFunction = allAggregateExpressions(i).mode match {
+    while (i < aggregateExpressions.length) {
+      val func = aggregateExpressions(i).aggregateFunction
+      val funcWithBoundReferences: AggregateFunction = aggregateExpressions(i).mode match {
         case Partial | Complete if func.isInstanceOf[ImperativeAggregate] =>
           // We need to create BoundReferences if the function is not an
           // expression-based aggregate function (it does not support code-gen) and the mode of
@@ -124,8 +101,8 @@ abstract class AggregationIterator(
   private[this] val allImperativeAggregateFunctionPositions: Array[Int] = {
     val positions = new ArrayBuffer[Int]()
     var i = 0
-    while (i < allAggregateFunctions.length) {
-      allAggregateFunctions(i) match {
+    while (i < aggregateFunctions.length) {
+      aggregateFunctions(i) match {
         case agg: DeclarativeAggregate =>
         case _ => positions += i
       }
@@ -134,17 +111,9 @@ abstract class AggregationIterator(
     positions.toArray
   }
 
-  // All AggregateFunctions functions with mode Partial, PartialMerge, or Final.
-  private[this] val nonCompleteAggregateFunctions: Array[AggregateFunction] =
-    allAggregateFunctions.take(nonCompleteAggregateExpressions.length)
-
-  // All imperative aggregate functions with mode Partial, PartialMerge, or Final.
-  private[this] val nonCompleteImperativeAggregateFunctions: Array[ImperativeAggregate] =
-    nonCompleteAggregateFunctions.collect { case func: ImperativeAggregate => func }
-
   // The projection used to initialize buffer values for all expression-based aggregates.
   private[this] val expressionAggInitialProjection = {
-    val initExpressions = allAggregateFunctions.flatMap {
+    val initExpressions = aggregateFunctions.flatMap {
       case ae: DeclarativeAggregate => ae.initialValues
       // For the positions corresponding to imperative aggregate functions, we'll use special
       // no-op expressions which are ignored during projection code-generation.
@@ -156,7 +125,7 @@ abstract class AggregationIterator(
   // All imperative AggregateFunctions.
   private[this] val allImperativeAggregateFunctions: Array[ImperativeAggregate] =
     allImperativeAggregateFunctionPositions
-      .map(allAggregateFunctions)
+      .map(aggregateFunctions)
       .map(_.asInstanceOf[ImperativeAggregate])
 
   ///////////////////////////////////////////////////////////////////////////
@@ -165,155 +134,52 @@ abstract class AggregationIterator(
 
   // Initializing functions used to process a row.
   protected val processRow: (MutableRow, InternalRow) => Unit = {
-    val rowToBeProcessed = new JoinedRow
-    val aggregationBufferSchema = allAggregateFunctions.flatMap(_.aggBufferAttributes)
-    aggregationMode match {
-      // Partial-only
-      case (Some(Partial), None) =>
-        val updateExpressions = nonCompleteAggregateFunctions.flatMap {
-          case ae: DeclarativeAggregate => ae.updateExpressions
-          case agg: AggregateFunction => Seq.fill(agg.aggBufferAttributes.length)(NoOp)
-        }
-        val expressionAggUpdateProjection =
-          newMutableProjection(updateExpressions, aggregationBufferSchema ++ valueAttributes)()
-
-        (currentBuffer: MutableRow, row: InternalRow) => {
-          expressionAggUpdateProjection.target(currentBuffer)
-          // Process all expression-based aggregate functions.
-          expressionAggUpdateProjection(rowToBeProcessed(currentBuffer, row))
-          // Process all imperative aggregate functions.
-          var i = 0
-          while (i < nonCompleteImperativeAggregateFunctions.length) {
-            nonCompleteImperativeAggregateFunctions(i).update(currentBuffer, row)
-            i += 1
+    val joinedRow = new JoinedRow
+    val aggregationBufferSchema = aggregateFunctions.flatMap(_.aggBufferAttributes)
+    val modes = aggregateExpressions.map(_.mode).distinct
+    if (aggregateExpressions.nonEmpty) {
+      val inputAggregationBufferSchema = if (initialInputBufferOffset == 0) {
+        // If initialInputBufferOffset, the input value does not contain
+        // grouping keys.
+        // This part is pretty hacky.
+        aggregateFunctions.flatMap(_.inputAggBufferAttributes).toSeq
+      } else {
+        groupingKeyAttributes ++ aggregateFunctions.flatMap(_.inputAggBufferAttributes)
+      }
+      val mergeExpressions = aggregateFunctions.zipWithIndex.flatMap {
+        case (ae: DeclarativeAggregate, i) =>
+          aggregateExpressions(i).mode match {
+            case Partial | Complete => ae.updateExpressions
+            case PartialMerge | Final => ae.mergeExpressions
           }
-        }
-
-      // PartialMerge-only or Final-only
-      case (Some(PartialMerge), None) | (Some(Final), None) =>
-        val inputAggregationBufferSchema = if (initialInputBufferOffset == 0) {
-          // If initialInputBufferOffset, the input value does not contain
-          // grouping keys.
-          // This part is pretty hacky.
-          allAggregateFunctions.flatMap(_.inputAggBufferAttributes).toSeq
-        } else {
-          groupingKeyAttributes ++ allAggregateFunctions.flatMap(_.inputAggBufferAttributes)
-        }
-        // val inputAggregationBufferSchema =
-        //  groupingKeyAttributes ++
-        //    allAggregateFunctions.flatMap(_.cloneBufferAttributes)
-        val mergeExpressions = nonCompleteAggregateFunctions.flatMap {
-          case ae: DeclarativeAggregate => ae.mergeExpressions
-          case agg: AggregateFunction => Seq.fill(agg.aggBufferAttributes.length)(NoOp)
-        }
-        // This projection is used to merge buffer values for all expression-based aggregates.
-        val expressionAggMergeProjection =
-          newMutableProjection(
-            mergeExpressions,
-            aggregationBufferSchema ++ inputAggregationBufferSchema)()
-
-        (currentBuffer: MutableRow, row: InternalRow) => {
-          // Process all expression-based aggregate functions.
-          expressionAggMergeProjection.target(currentBuffer)(rowToBeProcessed(currentBuffer, row))
-          // Process all imperative aggregate functions.
-          var i = 0
-          while (i < nonCompleteImperativeAggregateFunctions.length) {
-            nonCompleteImperativeAggregateFunctions(i).merge(currentBuffer, row)
-            i += 1
+        case (agg: AggregateFunction, _) => Seq.fill(agg.aggBufferAttributes.length)(NoOp)
+      }
+      val updateFunctions = aggregateFunctions.zipWithIndex.collect {
+        case (ae: ImperativeAggregate, i) =>
+          aggregateExpressions(i).mode match {
+            case Partial | Complete =>
+              (buffer: MutableRow, row: InternalRow) => ae.update(buffer, row)
+            case PartialMerge | Final =>
+              (buffer: MutableRow, row: InternalRow) => ae.merge(buffer, row)
           }
+      }
+      // This projection is used to merge buffer values for all expression-based aggregates.
+      val expressionAggMergeProjection =
+        newMutableProjection(mergeExpressions, aggregationBufferSchema ++ valueAttributes)()
+
+      (currentBuffer: MutableRow, row: InternalRow) => {
+        // Process all expression-based aggregate functions.
+        expressionAggMergeProjection.target(currentBuffer)(joinedRow(currentBuffer, row))
+        // Process all imperative aggregate functions.
+        var i = 0
+        while (i < updateFunctions.length) {
+          updateFunctions(i)(currentBuffer, row)
+          i += 1
         }
-
-      // Final-Complete
-      case (Some(Final), Some(Complete)) =>
-        val completeAggregateFunctions: Array[AggregateFunction] =
-          allAggregateFunctions.takeRight(completeAggregateExpressions.length)
-        // All imperative aggregate functions with mode Complete.
-        val completeImperativeAggregateFunctions: Array[ImperativeAggregate] =
-          completeAggregateFunctions.collect { case func: ImperativeAggregate => func }
-
-        // The first initialInputBufferOffset values of the input aggregation buffer is
-        // for grouping expressions and distinct columns.
-        val groupingAttributesAndDistinctColumns = valueAttributes.take(initialInputBufferOffset)
-
-        val completeOffsetExpressions =
-          Seq.fill(completeAggregateFunctions.map(_.aggBufferAttributes.length).sum)(NoOp)
-        // We do not touch buffer values of aggregate functions with the Final mode.
-        val finalOffsetExpressions =
-          Seq.fill(nonCompleteAggregateFunctions.map(_.aggBufferAttributes.length).sum)(NoOp)
-
-        val mergeInputSchema =
-          aggregationBufferSchema ++
-            groupingAttributesAndDistinctColumns ++
-            nonCompleteAggregateFunctions.flatMap(_.inputAggBufferAttributes)
-        val mergeExpressions =
-          nonCompleteAggregateFunctions.flatMap {
-            case ae: DeclarativeAggregate => ae.mergeExpressions
-            case agg: AggregateFunction => Seq.fill(agg.aggBufferAttributes.length)(NoOp)
-          } ++ completeOffsetExpressions
-        val finalExpressionAggMergeProjection =
-          newMutableProjection(mergeExpressions, mergeInputSchema)()
-
-        val updateExpressions =
-          finalOffsetExpressions ++ completeAggregateFunctions.flatMap {
-            case ae: DeclarativeAggregate => ae.updateExpressions
-            case agg: AggregateFunction => Seq.fill(agg.aggBufferAttributes.length)(NoOp)
-          }
-        val completeExpressionAggUpdateProjection =
-          newMutableProjection(updateExpressions, aggregationBufferSchema ++ valueAttributes)()
-
-        (currentBuffer: MutableRow, row: InternalRow) => {
-          val input = rowToBeProcessed(currentBuffer, row)
-          // For all aggregate functions with mode Complete, update buffers.
-          completeExpressionAggUpdateProjection.target(currentBuffer)(input)
-          var i = 0
-          while (i < completeImperativeAggregateFunctions.length) {
-            completeImperativeAggregateFunctions(i).update(currentBuffer, row)
-            i += 1
-          }
-
-          // For all aggregate functions with mode Final, merge buffers.
-          finalExpressionAggMergeProjection.target(currentBuffer)(input)
-          i = 0
-          while (i < nonCompleteImperativeAggregateFunctions.length) {
-            nonCompleteImperativeAggregateFunctions(i).merge(currentBuffer, row)
-            i += 1
-          }
-        }
-
-      // Complete-only
-      case (None, Some(Complete)) =>
-        val completeAggregateFunctions: Array[AggregateFunction] =
-          allAggregateFunctions.takeRight(completeAggregateExpressions.length)
-        // All imperative aggregate functions with mode Complete.
-        val completeImperativeAggregateFunctions: Array[ImperativeAggregate] =
-          completeAggregateFunctions.collect { case func: ImperativeAggregate => func }
-
-        val updateExpressions =
-          completeAggregateFunctions.flatMap {
-            case ae: DeclarativeAggregate => ae.updateExpressions
-            case agg: AggregateFunction => Seq.fill(agg.aggBufferAttributes.length)(NoOp)
-          }
-        val completeExpressionAggUpdateProjection =
-          newMutableProjection(updateExpressions, aggregationBufferSchema ++ valueAttributes)()
-
-        (currentBuffer: MutableRow, row: InternalRow) => {
-          val input = rowToBeProcessed(currentBuffer, row)
-          // For all aggregate functions with mode Complete, update buffers.
-          completeExpressionAggUpdateProjection.target(currentBuffer)(input)
-          var i = 0
-          while (i < completeImperativeAggregateFunctions.length) {
-            completeImperativeAggregateFunctions(i).update(currentBuffer, row)
-            i += 1
-          }
-        }
-
+      }
+    } else {
       // Grouping only.
-      case (None, None) => (currentBuffer: MutableRow, row: InternalRow) => {}
-
-      case other =>
-        sys.error(
-          s"Could not evaluate ${nonCompleteAggregateExpressions} because we do not " +
-            s"support evaluate modes $other in this iterator.")
+      (currentBuffer: MutableRow, row: InternalRow) => {}
     }
   }
 
@@ -326,73 +192,61 @@ abstract class AggregationIterator(
     } else {
       safeOutputRow
     }
-
-    aggregationMode match {
-      // Partial-only or PartialMerge-only: every output row is basically the values of
-      // the grouping expressions and the corresponding aggregation buffer.
-      case (Some(Partial), None) | (Some(PartialMerge), None) =>
-        // Because we cannot copy a joinedRow containing a UnsafeRow (UnsafeRow does not
-        // support generic getter), we create a mutable projection to output the
-        // JoinedRow(currentGroupingKey, currentBuffer)
-        val bufferSchema = nonCompleteAggregateFunctions.flatMap(_.aggBufferAttributes)
-        val resultProjection =
-          newMutableProjection(
-            groupingKeyAttributes ++ bufferSchema,
-            groupingKeyAttributes ++ bufferSchema)()
-        resultProjection.target(mutableOutput)
-
-        (currentGroupingKey: InternalRow, currentBuffer: MutableRow) => {
-          resultProjection(rowToBeEvaluated(currentGroupingKey, currentBuffer))
-          // rowToBeEvaluated(currentGroupingKey, currentBuffer)
-        }
-
+    val modes = aggregateExpressions.map(_.mode).distinct
+    if (!modes.contains(Final) && !modes.contains(Complete)) {
+      // Because we cannot copy a joinedRow containing a UnsafeRow (UnsafeRow does not
+      // support generic getter), we create a mutable projection to output the
+      // JoinedRow(currentGroupingKey, currentBuffer)
+      val bufferSchema = aggregateFunctions.flatMap(_.aggBufferAttributes)
+      val resultProjection =
+        newMutableProjection(
+          groupingKeyAttributes ++ bufferSchema,
+          groupingKeyAttributes ++ bufferSchema)()
+      resultProjection.target(mutableOutput)
+      (currentGroupingKey: InternalRow, currentBuffer: MutableRow) => {
+        resultProjection(rowToBeEvaluated(currentGroupingKey, currentBuffer))
+      }
+    } else if (aggregateExpressions.nonEmpty) {
       // Final-only, Complete-only and Final-Complete: every output row contains values representing
       // resultExpressions.
-      case (Some(Final), None) | (Some(Final) | None, Some(Complete)) =>
-        val bufferSchemata =
-          allAggregateFunctions.flatMap(_.aggBufferAttributes)
-        val evalExpressions = allAggregateFunctions.map {
-          case ae: DeclarativeAggregate => ae.evaluateExpression
-          case agg: AggregateFunction => NoOp
-        }
-        val expressionAggEvalProjection = newMutableProjection(evalExpressions, bufferSchemata)()
-        val aggregateResultSchema = nonCompleteAggregateAttributes ++ completeAggregateAttributes
-        // TODO: Use unsafe row.
-        val aggregateResult = new SpecificMutableRow(aggregateResultSchema.map(_.dataType))
-        expressionAggEvalProjection.target(aggregateResult)
-        val resultProjection =
-          newMutableProjection(
-            resultExpressions, groupingKeyAttributes ++ aggregateResultSchema)()
-        resultProjection.target(mutableOutput)
+      val bufferSchemata = aggregateFunctions.flatMap(_.aggBufferAttributes)
+      val evalExpressions = aggregateFunctions.map {
+        case ae: DeclarativeAggregate => ae.evaluateExpression
+        case agg: AggregateFunction => NoOp
+      }
+      val expressionAggEvalProjection = newMutableProjection(evalExpressions, bufferSchemata)()
+      val aggregateResultSchema = aggregateAttributes
+      // TODO: Use unsafe row.
+      val aggregateResult = new SpecificMutableRow(aggregateResultSchema.map(_.dataType))
+      expressionAggEvalProjection.target(aggregateResult)
 
-        (currentGroupingKey: InternalRow, currentBuffer: MutableRow) => {
-          // Generate results for all expression-based aggregate functions.
-          expressionAggEvalProjection(currentBuffer)
-          // Generate results for all imperative aggregate functions.
-          var i = 0
-          while (i < allImperativeAggregateFunctions.length) {
-            aggregateResult.update(
-              allImperativeAggregateFunctionPositions(i),
-              allImperativeAggregateFunctions(i).eval(currentBuffer))
-            i += 1
-          }
-          resultProjection(rowToBeEvaluated(currentGroupingKey, aggregateResult))
-        }
+      val resultProjection =
+        newMutableProjection(
+          resultExpressions, groupingKeyAttributes ++ aggregateResultSchema)()
+      resultProjection.target(mutableOutput)
 
+      (currentGroupingKey: InternalRow, currentBuffer: MutableRow) => {
+        // Generate results for all expression-based aggregate functions.
+        expressionAggEvalProjection(currentBuffer)
+        // Generate results for all imperative aggregate functions.
+        var i = 0
+        while (i < allImperativeAggregateFunctions.length) {
+          aggregateResult.update(
+            allImperativeAggregateFunctionPositions(i),
+            allImperativeAggregateFunctions(i).eval(currentBuffer))
+          i += 1
+        }
+        resultProjection(rowToBeEvaluated(currentGroupingKey, aggregateResult))
+      }
+    } else {
       // Grouping-only: we only output values of grouping expressions.
-      case (None, None) =>
-        val resultProjection =
-          newMutableProjection(resultExpressions, groupingKeyAttributes)()
-        resultProjection.target(mutableOutput)
+      val resultProjection =
+        newMutableProjection(resultExpressions, groupingKeyAttributes)()
+      resultProjection.target(mutableOutput)
 
-        (currentGroupingKey: InternalRow, currentBuffer: MutableRow) => {
-          resultProjection(currentGroupingKey)
-        }
-
-      case other =>
-        sys.error(
-          s"Could not evaluate ${nonCompleteAggregateExpressions} because we do not " +
-            s"support evaluate modes $other in this iterator.")
+      (currentGroupingKey: InternalRow, currentBuffer: MutableRow) => {
+        resultProjection(currentGroupingKey)
+      }
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggregationIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggregationIterator.scala
@@ -49,7 +49,7 @@ abstract class AggregationIterator(
 
   require(
     aggregateExpressions.map(_.mode).distinct.length <= 2,
-    s"$aggregateExpressions are not supported becuase they have more than 2 distinct modes.")
+    s"$aggregateExpressions are not supported because they have more than 2 distinct modes.")
 
   // Initialize all AggregateFunctions by binding references if necessary,
   // and set inputBufferOffset and mutableBufferOffset.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggregationIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggregationIterator.scala
@@ -46,6 +46,18 @@ abstract class AggregationIterator(
   // Initializing functions.
   ///////////////////////////////////////////////////////////////////////////
 
+  /**
+    * The following combinations of AggregationMode are supported:
+    * - Partial
+    * - PartialMerge (for single distinct)
+    * - Partial and PartialMerge (for single distinct)
+    * - Final
+    * - Complete (for SortBasedAggregate with functions that does not support Partial)
+    * - Final and Complete (currently not used)
+    *
+    * TODO: AggregateMode should have only two modes: Update and Merge, AggregateExpression
+    * could have a flag to tell it's final or not.
+    */
   {
     val modes = aggregateExpressions.map(_.mode).distinct.toSet
     require(modes.size <= 2,
@@ -57,8 +69,8 @@ abstract class AggregationIterator(
   // Initialize all AggregateFunctions by binding references if necessary,
   // and set inputBufferOffset and mutableBufferOffset.
   protected def initializeAggregateFunctions(
-    expressions: Seq[AggregateExpression],
-    startingInputBufferOffset: Int): Array[AggregateFunction] = {
+      expressions: Seq[AggregateExpression],
+      startingInputBufferOffset: Int): Array[AggregateFunction] = {
     var mutableBufferOffset = 0
     var inputBufferOffset: Int = startingInputBufferOffset
     val functions = new Array[AggregateFunction](expressions.length)
@@ -138,9 +150,9 @@ abstract class AggregationIterator(
 
   // Initializing functions used to process a row.
   protected def generateProcessRow(
-    expressions: Seq[AggregateExpression],
-    functions: Seq[AggregateFunction],
-    inputAttributes: Seq[Attribute]): (MutableRow, InternalRow) => Unit = {
+      expressions: Seq[AggregateExpression],
+      functions: Seq[AggregateFunction],
+      inputAttributes: Seq[Attribute]): (MutableRow, InternalRow) => Unit = {
     val joinedRow = new JoinedRow
     if (expressions.nonEmpty) {
       val mergeExpressions = functions.zipWithIndex.flatMap {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortBasedAggregate.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortBasedAggregate.scala
@@ -41,8 +41,8 @@ case class SortBasedAggregate(
     "numOutputRows" -> SQLMetrics.createLongMetric(sparkContext, "number of output rows"))
 
   override def outputsUnsafeRows: Boolean = true
-  override def canProcessUnsafeRows: Boolean = true
-  override def canProcessSafeRows: Boolean = false
+  override def canProcessUnsafeRows: Boolean = false
+  override def canProcessSafeRows: Boolean = true
 
   override def output: Seq[Attribute] = resultExpressions.map(_.toAttribute)
 
@@ -77,7 +77,7 @@ case class SortBasedAggregate(
         val outputIter = new SortBasedAggregationIterator(
           groupingExpressions,
           child.output,
-          iter.asInstanceOf[Iterator[UnsafeRow]],
+          iter,
           aggregateExpressions,
           aggregateAttributes,
           initialInputBufferOffset,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortBasedAggregate.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortBasedAggregate.scala
@@ -29,10 +29,8 @@ import org.apache.spark.sql.execution.metric.SQLMetrics
 case class SortBasedAggregate(
     requiredChildDistributionExpressions: Option[Seq[Expression]],
     groupingExpressions: Seq[NamedExpression],
-    nonCompleteAggregateExpressions: Seq[AggregateExpression],
-    nonCompleteAggregateAttributes: Seq[Attribute],
-    completeAggregateExpressions: Seq[AggregateExpression],
-    completeAggregateAttributes: Seq[Attribute],
+    aggregateExpressions: Seq[AggregateExpression],
+    aggregateAttributes: Seq[Attribute],
     initialInputBufferOffset: Int,
     resultExpressions: Seq[NamedExpression],
     child: SparkPlan)
@@ -86,10 +84,8 @@ case class SortBasedAggregate(
           groupingExpressions.map(_.toAttribute),
           child.output,
           iter,
-          nonCompleteAggregateExpressions,
-          nonCompleteAggregateAttributes,
-          completeAggregateExpressions,
-          completeAggregateAttributes,
+          aggregateExpressions,
+          aggregateAttributes,
           initialInputBufferOffset,
           resultExpressions,
           newMutableProjection,
@@ -109,7 +105,7 @@ case class SortBasedAggregate(
   }
 
   override def simpleString: String = {
-    val allAggregateExpressions = nonCompleteAggregateExpressions ++ completeAggregateExpressions
+    val allAggregateExpressions = aggregateExpressions
 
     val keyString = groupingExpressions.mkString("[", ",", "]")
     val functionString = allAggregateExpressions.mkString("[", ",", "]")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortBasedAggregationIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortBasedAggregationIterator.scala
@@ -31,10 +31,8 @@ class SortBasedAggregationIterator(
     groupingKeyAttributes: Seq[Attribute],
     valueAttributes: Seq[Attribute],
     inputIterator: Iterator[InternalRow],
-    nonCompleteAggregateExpressions: Seq[AggregateExpression],
-    nonCompleteAggregateAttributes: Seq[Attribute],
-    completeAggregateExpressions: Seq[AggregateExpression],
-    completeAggregateAttributes: Seq[Attribute],
+    aggregateExpressions: Seq[AggregateExpression],
+    aggregateAttributes: Seq[Attribute],
     initialInputBufferOffset: Int,
     resultExpressions: Seq[NamedExpression],
     newMutableProjection: (Seq[Expression], Seq[Attribute]) => (() => MutableProjection),
@@ -44,17 +42,15 @@ class SortBasedAggregationIterator(
   extends AggregationIterator(
     groupingKeyAttributes,
     valueAttributes,
-    nonCompleteAggregateExpressions,
-    nonCompleteAggregateAttributes,
-    completeAggregateExpressions,
-    completeAggregateAttributes,
+    aggregateExpressions,
+    aggregateAttributes,
     initialInputBufferOffset,
     resultExpressions,
     newMutableProjection,
     outputsUnsafeRows) {
 
   override protected def newBuffer: MutableRow = {
-    val bufferSchema = allAggregateFunctions.flatMap(_.aggBufferAttributes)
+    val bufferSchema = aggregateFunctions.flatMap(_.aggBufferAttributes)
     val bufferRowSize: Int = bufferSchema.length
 
     val genericMutableBuffer = new GenericMutableRow(bufferRowSize)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregationIterator.scala
@@ -127,10 +127,10 @@ class TungstenAggregationIterator(
   }
 
   // Creates a function used to generate output rows.
-  override def generateResultProjection(): (UnsafeRow, MutableRow) => UnsafeRow = {
+  override protected def generateResultProjection(): (UnsafeRow, MutableRow) => UnsafeRow = {
     val modes = aggregateExpressions.map(_.mode).distinct
     if (modes.nonEmpty && !modes.contains(Final) && !modes.contains(Complete)) {
-      // Fast path for partial aggregation
+      // Fast path for partial aggregation, UnsafeRowJoiner is usually faster than projection
       val groupingAttributes = groupingExpressions.map(_.toAttribute)
       val bufferAttributes = aggregateFunctions.flatMap(_.aggBufferAttributes)
       val groupingKeySchema = StructType.fromAttributes(groupingAttributes)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/utils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/utils.scala
@@ -209,7 +209,8 @@ object Utils {
           partialMergeAggregateExpressions.flatMap(_.aggregateFunction.inputAggBufferAttributes)
       if (usesTungstenAggregate) {
         TungstenAggregate(
-          requiredChildDistributionExpressions = Some(groupingAttributes),
+          requiredChildDistributionExpressions =
+            Some(groupingAttributes ++ distinctColumnAttributes),
           groupingExpressions = groupingAttributes ++ distinctColumnAttributes,
           nonCompleteAggregateExpressions = partialMergeAggregateExpressions,
           nonCompleteAggregateAttributes = partialMergeAggregateAttributes,
@@ -220,7 +221,8 @@ object Utils {
           child = partialAggregate)
       } else {
         SortBasedAggregate(
-          requiredChildDistributionExpressions = Some(groupingAttributes),
+          requiredChildDistributionExpressions =
+            Some(groupingAttributes ++ distinctColumnAttributes),
           groupingExpressions = groupingAttributes ++ distinctColumnAttributes,
           nonCompleteAggregateExpressions = partialMergeAggregateExpressions,
           nonCompleteAggregateAttributes = partialMergeAggregateAttributes,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/utils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/utils.scala
@@ -42,14 +42,42 @@ object Utils {
     SortBasedAggregate(
       requiredChildDistributionExpressions = Some(groupingAttributes),
       groupingExpressions = groupingAttributes,
-      nonCompleteAggregateExpressions = Nil,
-      nonCompleteAggregateAttributes = Nil,
-      completeAggregateExpressions = completeAggregateExpressions,
-      completeAggregateAttributes = completeAggregateAttributes,
+      aggregateExpressions = completeAggregateExpressions,
+      aggregateAttributes = completeAggregateAttributes,
       initialInputBufferOffset = 0,
       resultExpressions = resultExpressions,
       child = child
     ) :: Nil
+  }
+
+  private def createAggregate(
+      requiredChildDistributionExpressions: Option[Seq[Expression]] = None,
+      groupingExpressions: Seq[NamedExpression] = Nil,
+      aggregateExpressions: Seq[AggregateExpression] = Nil,
+      aggregateAttributes: Seq[Attribute] = Nil,
+      initialInputBufferOffset: Int = 0,
+      resultExpressions: Seq[NamedExpression] = Nil,
+      child: SparkPlan): SparkPlan = {
+    val usesTungstenAggregate = TungstenAggregate.supportsAggregate(aggregateAttributes)
+    if (usesTungstenAggregate) {
+      TungstenAggregate(
+        requiredChildDistributionExpressions = requiredChildDistributionExpressions,
+        groupingExpressions = groupingExpressions,
+        aggregateExpressions = aggregateExpressions,
+        aggregateAttributes = aggregateAttributes,
+        initialInputBufferOffset = initialInputBufferOffset,
+        resultExpressions = resultExpressions,
+        child = child)
+    } else {
+      SortBasedAggregate(
+        requiredChildDistributionExpressions = requiredChildDistributionExpressions,
+        groupingExpressions = groupingExpressions,
+        aggregateExpressions = aggregateExpressions,
+        aggregateAttributes = aggregateAttributes,
+        initialInputBufferOffset = initialInputBufferOffset,
+        resultExpressions = resultExpressions,
+        child = child)
+    }
   }
 
   def planAggregateWithoutDistinct(
@@ -59,9 +87,6 @@ object Utils {
       resultExpressions: Seq[NamedExpression],
       child: SparkPlan): Seq[SparkPlan] = {
     // Check if we can use TungstenAggregate.
-    val usesTungstenAggregate = TungstenAggregate.supportsAggregate(
-        groupingExpressions,
-        aggregateExpressions.flatMap(_.aggregateFunction.aggBufferAttributes))
 
     // 1. Create an Aggregate Operator for partial aggregations.
 
@@ -73,29 +98,14 @@ object Utils {
       groupingAttributes ++
         partialAggregateExpressions.flatMap(_.aggregateFunction.inputAggBufferAttributes)
 
-    val partialAggregate = if (usesTungstenAggregate) {
-      TungstenAggregate(
-        requiredChildDistributionExpressions = None: Option[Seq[Expression]],
+    val partialAggregate = createAggregate(
+        requiredChildDistributionExpressions = None,
         groupingExpressions = groupingExpressions,
-        nonCompleteAggregateExpressions = partialAggregateExpressions,
-        nonCompleteAggregateAttributes = partialAggregateAttributes,
-        completeAggregateExpressions = Nil,
-        completeAggregateAttributes = Nil,
+        aggregateExpressions = partialAggregateExpressions,
+        aggregateAttributes = partialAggregateAttributes,
         initialInputBufferOffset = 0,
         resultExpressions = partialResultExpressions,
         child = child)
-    } else {
-      SortBasedAggregate(
-        requiredChildDistributionExpressions = None: Option[Seq[Expression]],
-        groupingExpressions = groupingExpressions,
-        nonCompleteAggregateExpressions = partialAggregateExpressions,
-        nonCompleteAggregateAttributes = partialAggregateAttributes,
-        completeAggregateExpressions = Nil,
-        completeAggregateAttributes = Nil,
-        initialInputBufferOffset = 0,
-        resultExpressions = partialResultExpressions,
-        child = child)
-    }
 
     // 2. Create an Aggregate Operator for final aggregations.
     val finalAggregateExpressions = aggregateExpressions.map(_.copy(mode = Final))
@@ -105,29 +115,14 @@ object Utils {
       expr => aggregateFunctionToAttribute(expr.aggregateFunction, expr.isDistinct)
     }
 
-    val finalAggregate = if (usesTungstenAggregate) {
-      TungstenAggregate(
+    val finalAggregate = createAggregate(
         requiredChildDistributionExpressions = Some(groupingAttributes),
         groupingExpressions = groupingAttributes,
-        nonCompleteAggregateExpressions = finalAggregateExpressions,
-        nonCompleteAggregateAttributes = finalAggregateAttributes,
-        completeAggregateExpressions = Nil,
-        completeAggregateAttributes = Nil,
+        aggregateExpressions = finalAggregateExpressions,
+        aggregateAttributes = finalAggregateAttributes,
         initialInputBufferOffset = groupingExpressions.length,
         resultExpressions = resultExpressions,
         child = partialAggregate)
-    } else {
-      SortBasedAggregate(
-        requiredChildDistributionExpressions = Some(groupingAttributes),
-        groupingExpressions = groupingAttributes,
-        nonCompleteAggregateExpressions = finalAggregateExpressions,
-        nonCompleteAggregateAttributes = finalAggregateAttributes,
-        completeAggregateExpressions = Nil,
-        completeAggregateAttributes = Nil,
-        initialInputBufferOffset = groupingExpressions.length,
-        resultExpressions = resultExpressions,
-        child = partialAggregate)
-    }
 
     finalAggregate :: Nil
   }
@@ -140,101 +135,99 @@ object Utils {
       resultExpressions: Seq[NamedExpression],
       child: SparkPlan): Seq[SparkPlan] = {
 
-    val aggregateExpressions = functionsWithDistinct ++ functionsWithoutDistinct
-    val usesTungstenAggregate = TungstenAggregate.supportsAggregate(
-      groupingExpressions,
-      aggregateExpressions.flatMap(_.aggregateFunction.aggBufferAttributes))
-
     // functionsWithDistinct is guaranteed to be non-empty. Even though it may contain more than one
     // DISTINCT aggregate function, all of those functions will have the same column expressions.
     // For example, it would be valid for functionsWithDistinct to be
     // [COUNT(DISTINCT foo), MAX(DISTINCT foo)], but [COUNT(DISTINCT bar), COUNT(DISTINCT foo)] is
     // disallowed because those two distinct aggregates have different column expressions.
-    val distinctColumnExpressions = functionsWithDistinct.head.aggregateFunction.children
-    val namedDistinctColumnExpressions = distinctColumnExpressions.map {
+    val distinctExpressions = functionsWithDistinct.head.aggregateFunction.children
+    val namedDistinctExpressions = distinctExpressions.map {
       case ne: NamedExpression => ne
       case other => Alias(other, other.toString)()
     }
-    val distinctColumnAttributes = namedDistinctColumnExpressions.map(_.toAttribute)
+    val distinctAttributes = namedDistinctExpressions.map(_.toAttribute)
     val groupingAttributes = groupingExpressions.map(_.toAttribute)
 
     // 1. Create an Aggregate Operator for partial aggregations.
     val partialAggregate: SparkPlan = {
-      val partialAggregateExpressions = functionsWithoutDistinct.map(_.copy(mode = Partial))
-      val partialAggregateAttributes =
-        partialAggregateExpressions.flatMap(_.aggregateFunction.aggBufferAttributes)
+      val aggregateExpressions = functionsWithoutDistinct.map(_.copy(mode = Partial))
+      val aggregateAttributes = aggregateExpressions.map {
+        expr => aggregateFunctionToAttribute(expr.aggregateFunction, expr.isDistinct)
+      }
       // We will group by the original grouping expression, plus an additional expression for the
       // DISTINCT column. For example, for AVG(DISTINCT value) GROUP BY key, the grouping
       // expressions will be [key, value].
-      val partialAggregateGroupingExpressions =
-        groupingExpressions ++ namedDistinctColumnExpressions
-      val partialAggregateResult =
-        groupingAttributes ++
-          distinctColumnAttributes ++
-          partialAggregateExpressions.flatMap(_.aggregateFunction.inputAggBufferAttributes)
-      if (usesTungstenAggregate) {
-        TungstenAggregate(
-          requiredChildDistributionExpressions = None,
-          groupingExpressions = partialAggregateGroupingExpressions,
-          nonCompleteAggregateExpressions = partialAggregateExpressions,
-          nonCompleteAggregateAttributes = partialAggregateAttributes,
-          completeAggregateExpressions = Nil,
-          completeAggregateAttributes = Nil,
-          initialInputBufferOffset = 0,
-          resultExpressions = partialAggregateResult,
-          child = child)
-      } else {
-        SortBasedAggregate(
-          requiredChildDistributionExpressions = None,
-          groupingExpressions = partialAggregateGroupingExpressions,
-          nonCompleteAggregateExpressions = partialAggregateExpressions,
-          nonCompleteAggregateAttributes = partialAggregateAttributes,
-          completeAggregateExpressions = Nil,
-          completeAggregateAttributes = Nil,
-          initialInputBufferOffset = 0,
-          resultExpressions = partialAggregateResult,
-          child = child)
-      }
+      createAggregate(
+        groupingExpressions = groupingExpressions ++ namedDistinctExpressions,
+        aggregateExpressions = aggregateExpressions,
+        aggregateAttributes = aggregateAttributes,
+        resultExpressions = groupingAttributes ++ distinctAttributes ++
+          aggregateExpressions.flatMap(_.aggregateFunction.inputAggBufferAttributes),
+        child = child)
     }
 
     // 2. Create an Aggregate Operator for partial merge aggregations.
     val partialMergeAggregate: SparkPlan = {
-      val partialMergeAggregateExpressions =
-        functionsWithoutDistinct.map(_.copy(mode = PartialMerge))
-      val partialMergeAggregateAttributes =
-        partialMergeAggregateExpressions.flatMap(_.aggregateFunction.aggBufferAttributes)
-      val partialMergeAggregateResult =
-        groupingAttributes ++
-          distinctColumnAttributes ++
-          partialMergeAggregateExpressions.flatMap(_.aggregateFunction.inputAggBufferAttributes)
-      if (usesTungstenAggregate) {
-        TungstenAggregate(
-          requiredChildDistributionExpressions =
-            Some(groupingAttributes ++ distinctColumnAttributes),
-          groupingExpressions = groupingAttributes ++ distinctColumnAttributes,
-          nonCompleteAggregateExpressions = partialMergeAggregateExpressions,
-          nonCompleteAggregateAttributes = partialMergeAggregateAttributes,
-          completeAggregateExpressions = Nil,
-          completeAggregateAttributes = Nil,
-          initialInputBufferOffset = (groupingAttributes ++ distinctColumnAttributes).length,
-          resultExpressions = partialMergeAggregateResult,
-          child = partialAggregate)
-      } else {
-        SortBasedAggregate(
-          requiredChildDistributionExpressions =
-            Some(groupingAttributes ++ distinctColumnAttributes),
-          groupingExpressions = groupingAttributes ++ distinctColumnAttributes,
-          nonCompleteAggregateExpressions = partialMergeAggregateExpressions,
-          nonCompleteAggregateAttributes = partialMergeAggregateAttributes,
-          completeAggregateExpressions = Nil,
-          completeAggregateAttributes = Nil,
-          initialInputBufferOffset = (groupingAttributes ++ distinctColumnAttributes).length,
-          resultExpressions = partialMergeAggregateResult,
-          child = partialAggregate)
+      val aggregateExpressions = functionsWithoutDistinct.map(_.copy(mode = PartialMerge))
+      val aggregateAttributes = aggregateExpressions.map {
+        expr => aggregateFunctionToAttribute(expr.aggregateFunction, expr.isDistinct)
       }
+      createAggregate(
+        requiredChildDistributionExpressions =
+          Some(groupingAttributes ++ distinctAttributes),
+        groupingExpressions = groupingAttributes ++ distinctAttributes,
+        aggregateExpressions = aggregateExpressions,
+        aggregateAttributes = aggregateAttributes,
+        initialInputBufferOffset = (groupingAttributes ++ distinctAttributes).length,
+        resultExpressions = groupingAttributes ++ distinctAttributes ++
+          aggregateExpressions.flatMap(_.aggregateFunction.inputAggBufferAttributes),
+        child = partialAggregate)
     }
 
-    // 3. Create an Aggregate Operator for the final aggregation.
+    // 3. Create an Aggregate operator for partial aggregation (for distinct)
+    val distinctColumnAttributeLookup = distinctExpressions.zip(distinctAttributes).toMap
+    val rewrittenDistinctFunctions = functionsWithDistinct.map {
+      // Children of an AggregateFunction with DISTINCT keyword has already
+      // been evaluated. At here, we need to replace original children
+      // to AttributeReferences.
+      case agg @ AggregateExpression(aggregateFunction, mode, true) =>
+        aggregateFunction.transformDown(distinctColumnAttributeLookup)
+          .asInstanceOf[AggregateFunction]
+    }
+
+    val partialDistinctAggregate: SparkPlan = {
+      val mergeAggregateExpressions = functionsWithoutDistinct.map(_.copy(mode = PartialMerge))
+      // The attributes of the final aggregation buffer, which is presented as input to the result
+      // projection:
+      val mergeAggregateAttributes = mergeAggregateExpressions.map {
+        expr => aggregateFunctionToAttribute(expr.aggregateFunction, expr.isDistinct)
+      }
+      val (distinctAggregateExpressions, distinctAggregateAttributes) =
+        rewrittenDistinctFunctions.zipWithIndex.map { case (func, i) =>
+          // We rewrite the aggregate function to a non-distinct aggregation because
+          // its input will have distinct arguments.
+          // We just keep the isDistinct setting to true, so when users look at the query plan,
+          // they still can see distinct aggregations.
+          val expr = AggregateExpression(func, Partial, isDistinct = true)
+          // Use original AggregationFunction to lookup attributes, which is used to build
+          // aggregateFunctionToAttribute
+          val attr = aggregateFunctionToAttribute(functionsWithDistinct(i).aggregateFunction, true)
+          (expr, attr)
+      }.unzip
+
+      val partialAggregateResult = groupingAttributes ++
+          mergeAggregateExpressions.flatMap(_.aggregateFunction.inputAggBufferAttributes) ++
+          distinctAggregateExpressions.flatMap(_.aggregateFunction.inputAggBufferAttributes)
+      createAggregate(
+        groupingExpressions = groupingAttributes,
+        aggregateExpressions = mergeAggregateExpressions ++ distinctAggregateExpressions,
+        aggregateAttributes = mergeAggregateAttributes ++ distinctAggregateAttributes,
+        initialInputBufferOffset = (groupingAttributes ++ distinctAttributes).length,
+        resultExpressions = partialAggregateResult,
+        child = partialMergeAggregate)
+    }
+
+    // 4. Create an Aggregate Operator for the final aggregation.
     val finalAndCompleteAggregate: SparkPlan = {
       val finalAggregateExpressions = functionsWithoutDistinct.map(_.copy(mode = Final))
       // The attributes of the final aggregation buffer, which is presented as input to the result
@@ -243,49 +236,27 @@ object Utils {
         expr => aggregateFunctionToAttribute(expr.aggregateFunction, expr.isDistinct)
       }
 
-      val distinctColumnAttributeLookup =
-        distinctColumnExpressions.zip(distinctColumnAttributes).toMap
-      val (completeAggregateExpressions, completeAggregateAttributes) = functionsWithDistinct.map {
-        // Children of an AggregateFunction with DISTINCT keyword has already
-        // been evaluated. At here, we need to replace original children
-        // to AttributeReferences.
-        case agg @ AggregateExpression(aggregateFunction, mode, true) =>
-          val rewrittenAggregateFunction = aggregateFunction
-            .transformDown(distinctColumnAttributeLookup)
-            .asInstanceOf[AggregateFunction]
+      val (distinctAggregateExpressions, distinctAggregateAttributes) =
+        rewrittenDistinctFunctions.zipWithIndex.map { case (func, i) =>
           // We rewrite the aggregate function to a non-distinct aggregation because
           // its input will have distinct arguments.
           // We just keep the isDistinct setting to true, so when users look at the query plan,
           // they still can see distinct aggregations.
-          val rewrittenAggregateExpression =
-            AggregateExpression(rewrittenAggregateFunction, Complete, isDistinct = true)
-
-          val aggregateFunctionAttribute = aggregateFunctionToAttribute(agg.aggregateFunction, true)
-          (rewrittenAggregateExpression, aggregateFunctionAttribute)
+          val expr = AggregateExpression(func, Final, isDistinct = true)
+          // Use original AggregationFunction to lookup attributes, which is used to build
+          // aggregateFunctionToAttribute
+          val attr = aggregateFunctionToAttribute(functionsWithDistinct(i).aggregateFunction, true)
+          (expr, attr)
       }.unzip
-      if (usesTungstenAggregate) {
-        TungstenAggregate(
-          requiredChildDistributionExpressions = Some(groupingAttributes),
-          groupingExpressions = groupingAttributes,
-          nonCompleteAggregateExpressions = finalAggregateExpressions,
-          nonCompleteAggregateAttributes = finalAggregateAttributes,
-          completeAggregateExpressions = completeAggregateExpressions,
-          completeAggregateAttributes = completeAggregateAttributes,
-          initialInputBufferOffset = (groupingAttributes ++ distinctColumnAttributes).length,
-          resultExpressions = resultExpressions,
-          child = partialMergeAggregate)
-      } else {
-        SortBasedAggregate(
-          requiredChildDistributionExpressions = Some(groupingAttributes),
-          groupingExpressions = groupingAttributes,
-          nonCompleteAggregateExpressions = finalAggregateExpressions,
-          nonCompleteAggregateAttributes = finalAggregateAttributes,
-          completeAggregateExpressions = completeAggregateExpressions,
-          completeAggregateAttributes = completeAggregateAttributes,
-          initialInputBufferOffset = (groupingAttributes ++ distinctColumnAttributes).length,
-          resultExpressions = resultExpressions,
-          child = partialMergeAggregate)
-      }
+
+      createAggregate(
+        requiredChildDistributionExpressions = Some(groupingAttributes),
+        groupingExpressions = groupingAttributes,
+        aggregateExpressions = finalAggregateExpressions ++ distinctAggregateExpressions,
+        aggregateAttributes = finalAggregateAttributes ++ distinctAggregateAttributes,
+        initialInputBufferOffset = groupingAttributes.length,
+        resultExpressions = resultExpressions,
+        child = partialDistinctAggregate)
     }
 
     finalAndCompleteAggregate :: Nil

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/utils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/utils.scala
@@ -58,7 +58,8 @@ object Utils {
       initialInputBufferOffset: Int = 0,
       resultExpressions: Seq[NamedExpression] = Nil,
       child: SparkPlan): SparkPlan = {
-    val usesTungstenAggregate = TungstenAggregate.supportsAggregate(aggregateAttributes)
+    val usesTungstenAggregate = TungstenAggregate.supportsAggregate(
+      aggregateExpressions.flatMap(_.aggregateFunction.aggBufferAttributes))
     if (usesTungstenAggregate) {
       TungstenAggregate(
         requiredChildDistributionExpressions = requiredChildDistributionExpressions,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -44,10 +44,10 @@ class PlannerSuite extends SharedSQLContext {
         fail(s"Could query play aggregation query $query. Is it an aggregation query?"))
     val aggregations = planned.collect { case n if n.nodeName contains "Aggregate" => n }
 
-    // For the new aggregation code path, there will be three aggregate operator for
+    // For the new aggregation code path, there will be four aggregate operator for
     // distinct aggregations.
     assert(
-      aggregations.size == 2 || aggregations.size == 3,
+      aggregations.size == 2 || aggregations.size == 4,
       s"The plan of query $query does not have partial aggregations.")
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -44,10 +44,10 @@ class PlannerSuite extends SharedSQLContext {
         fail(s"Could query play aggregation query $query. Is it an aggregation query?"))
     val aggregations = planned.collect { case n if n.nodeName contains "Aggregate" => n }
 
-    // For the new aggregation code path, there will be four aggregate operator for
+    // For the new aggregation code path, there will be three aggregate operator for
     // distinct aggregations.
     assert(
-      aggregations.size == 2 || aggregations.size == 4,
+      aggregations.size == 2 || aggregations.size == 3,
       s"The plan of query $query does not have partial aggregations.")
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.hive.execution
 
 import scala.collection.JavaConverters._
 
-import org.apache.spark.SparkException
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 import org.apache.spark.sql.expressions.{MutableAggregationBuffer, UserDefinedAggregateFunction}
@@ -525,80 +524,73 @@ abstract class AggregationQuerySuite extends QueryTest with SQLTestUtils with Te
   }
 
   test("single distinct column set") {
-    Seq(true, false).foreach { specializeSingleDistinctAgg =>
-      val conf =
-        (SQLConf.SPECIALIZE_SINGLE_DISTINCT_AGG_PLANNING.key,
-          specializeSingleDistinctAgg.toString)
-      withSQLConf(conf) {
-        // DISTINCT is not meaningful with Max and Min, so we just ignore the DISTINCT keyword.
-        checkAnswer(
-          sqlContext.sql(
-            """
-              |SELECT
-              |  min(distinct value1),
-              |  sum(distinct value1),
-              |  avg(value1),
-              |  avg(value2),
-              |  max(distinct value1)
-              |FROM agg2
-            """.stripMargin),
-          Row(-60, 70.0, 101.0/9.0, 5.6, 100))
+    // DISTINCT is not meaningful with Max and Min, so we just ignore the DISTINCT keyword.
+    checkAnswer(
+      sqlContext.sql(
+        """
+          |SELECT
+          |  min(distinct value1),
+          |  sum(distinct value1),
+          |  avg(value1),
+          |  avg(value2),
+          |  max(distinct value1)
+          |FROM agg2
+        """.stripMargin),
+      Row(-60, 70.0, 101.0/9.0, 5.6, 100))
 
-        checkAnswer(
-          sqlContext.sql(
-            """
-              |SELECT
-              |  mydoubleavg(distinct value1),
-              |  avg(value1),
-              |  avg(value2),
-              |  key,
-              |  mydoubleavg(value1 - 1),
-              |  mydoubleavg(distinct value1) * 0.1,
-              |  avg(value1 + value2)
-              |FROM agg2
-              |GROUP BY key
-            """.stripMargin),
-          Row(120.0, 70.0/3.0, -10.0/3.0, 1, 67.0/3.0 + 100.0, 12.0, 20.0) ::
-            Row(100.0, 1.0/3.0, 1.0, 2, -2.0/3.0 + 100.0, 10.0, 2.0) ::
-            Row(null, null, 3.0, 3, null, null, null) ::
-            Row(110.0, 10.0, 20.0, null, 109.0, 11.0, 30.0) :: Nil)
+    checkAnswer(
+      sqlContext.sql(
+        """
+          |SELECT
+          |  mydoubleavg(distinct value1),
+          |  avg(value1),
+          |  avg(value2),
+          |  key,
+          |  mydoubleavg(value1 - 1),
+          |  mydoubleavg(distinct value1) * 0.1,
+          |  avg(value1 + value2)
+          |FROM agg2
+          |GROUP BY key
+        """.stripMargin),
+      Row(120.0, 70.0/3.0, -10.0/3.0, 1, 67.0/3.0 + 100.0, 12.0, 20.0) ::
+        Row(100.0, 1.0/3.0, 1.0, 2, -2.0/3.0 + 100.0, 10.0, 2.0) ::
+        Row(null, null, 3.0, 3, null, null, null) ::
+        Row(110.0, 10.0, 20.0, null, 109.0, 11.0, 30.0) :: Nil)
 
-        checkAnswer(
-          sqlContext.sql(
-            """
-              |SELECT
-              |  key,
-              |  mydoubleavg(distinct value1),
-              |  mydoublesum(value2),
-              |  mydoublesum(distinct value1),
-              |  mydoubleavg(distinct value1),
-              |  mydoubleavg(value1)
-              |FROM agg2
-              |GROUP BY key
-            """.stripMargin),
-          Row(1, 120.0, -10.0, 40.0, 120.0, 70.0/3.0 + 100.0) ::
-            Row(2, 100.0, 3.0, 0.0, 100.0, 1.0/3.0 + 100.0) ::
-            Row(3, null, 3.0, null, null, null) ::
-            Row(null, 110.0, 60.0, 30.0, 110.0, 110.0) :: Nil)
+    checkAnswer(
+      sqlContext.sql(
+        """
+          |SELECT
+          |  key,
+          |  mydoubleavg(distinct value1),
+          |  mydoublesum(value2),
+          |  mydoublesum(distinct value1),
+          |  mydoubleavg(distinct value1),
+          |  mydoubleavg(value1)
+          |FROM agg2
+          |GROUP BY key
+        """.stripMargin),
+      Row(1, 120.0, -10.0, 40.0, 120.0, 70.0/3.0 + 100.0) ::
+        Row(2, 100.0, 3.0, 0.0, 100.0, 1.0/3.0 + 100.0) ::
+        Row(3, null, 3.0, null, null, null) ::
+        Row(null, 110.0, 60.0, 30.0, 110.0, 110.0) :: Nil)
 
-        checkAnswer(
-          sqlContext.sql(
-            """
-              |SELECT
-              |  count(value1),
-              |  count(*),
-              |  count(1),
-              |  count(DISTINCT value1),
-              |  key
-              |FROM agg2
-              |GROUP BY key
-            """.stripMargin),
-          Row(3, 3, 3, 2, 1) ::
-            Row(3, 4, 4, 2, 2) ::
-            Row(0, 2, 2, 0, 3) ::
-            Row(3, 4, 4, 3, null) :: Nil)
-      }
-    }
+    checkAnswer(
+      sqlContext.sql(
+        """
+          |SELECT
+          |  count(value1),
+          |  count(*),
+          |  count(1),
+          |  count(DISTINCT value1),
+          |  key
+          |FROM agg2
+          |GROUP BY key
+        """.stripMargin),
+      Row(3, 3, 3, 2, 1) ::
+        Row(3, 4, 4, 2, 2) ::
+        Row(0, 2, 2, 0, 3) ::
+        Row(3, 4, 4, 3, null) :: Nil)
   }
 
   test("single distinct multiple columns set") {


### PR DESCRIPTION
Currently, we could generate different plans for query with single distinct (depends on spark.sql.specializeSingleDistinctAggPlanning), one works better on low cardinality columns, the other 
works better for high cardinality column (default one).

This PR change to generate a single plan (three aggregations and two exchanges), which work better in both cases, then we could safely remove the flag `spark.sql.specializeSingleDistinctAggPlanning` (introduced in 1.6).

For a query like `SELECT COUNT(DISTINCT a) FROM table` will be

```
AGG-4 (count distinct)
  Shuffle to a single reducer
    Partial-AGG-3 (count distinct, no grouping)
      Partial-AGG-2 (grouping on a)
        Shuffle by a
          Partial-AGG-1 (grouping on a)
```

This PR also includes large refactor for aggregation (reduce 500+ lines of code)

cc @yhuai @nongli @marmbrus 
