### PR TITLE
[SPARK-12252][SPARK-12131][SQL] refactor MapObjects to make it less hacky

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/JavaTypeInference.scala
@@ -230,25 +230,23 @@ object JavaTypeInference {
         primitiveMethod.map { method =>
           Invoke(getPath, method, ObjectType(c))
         }.getOrElse {
-          val loopVar = LoopVar(inferDataType(elementType)._1)
           Invoke(
             MapObjects(
-              loopVar,
-              constructorFor(typeToken.getComponentType, Some(loopVar)),
-              getPath),
+              p => constructorFor(typeToken.getComponentType, Some(p)),
+              getPath,
+              inferDataType(elementType)._1),
             "array",
             ObjectType(c))
         }
 
       case c if listType.isAssignableFrom(typeToken) =>
         val et = elementType(typeToken)
-        val loopVar = LoopVar(inferDataType(et)._1)
         val array =
           Invoke(
             MapObjects(
-              loopVar,
-              constructorFor(et, Some(loopVar)),
-              getPath),
+              p => constructorFor(et, Some(p)),
+              getPath,
+              inferDataType(et)._1),
             "array",
             ObjectType(classOf[Array[Any]]))
 
@@ -259,23 +257,21 @@ object JavaTypeInference {
         val keyDataType = inferDataType(keyType)._1
         val valueDataType = inferDataType(valueType)._1
 
-        val keyLoopVar = LoopVar(keyDataType)
         val keyData =
           Invoke(
             MapObjects(
-              keyLoopVar,
-              constructorFor(keyType, Some(keyLoopVar)),
-              Invoke(getPath, "keyArray", ArrayType(keyDataType))),
+              p => constructorFor(keyType, Some(p)),
+              Invoke(getPath, "keyArray", ArrayType(keyDataType)),
+              keyDataType),
             "array",
             ObjectType(classOf[Array[Any]]))
 
-        val valueLoopVar = LoopVar(valueDataType)
         val valueData =
           Invoke(
             MapObjects(
-              valueLoopVar,
-              constructorFor(valueType, Some(valueLoopVar)),
-              Invoke(getPath, "valueArray", ArrayType(valueDataType))),
+              p => constructorFor(valueType, Some(p)),
+              Invoke(getPath, "valueArray", ArrayType(valueDataType)),
+              valueDataType),
             "array",
             ObjectType(classOf[Array[Any]]))
 
@@ -328,8 +324,7 @@ object JavaTypeInference {
           input :: Nil,
           dataType = ArrayType(dataType, nullable))
       } else {
-        val loopVar = LoopVar(ObjectType(elementType.getRawType))
-        MapObjects(loopVar, extractorFor(loopVar, elementType), input)
+        MapObjects(extractorFor(_, elementType), input, ObjectType(elementType.getRawType))
       }
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -264,12 +264,11 @@ object ScalaReflection extends ScalaReflection {
         }.getOrElse {
           val className = getClassNameFromType(elementType)
           val newTypePath = s"""- array element class: "$className"""" +: walkedTypePath
-          val loopVar = LoopVar(schemaFor(elementType).dataType)
           Invoke(
             MapObjects(
-              loopVar,
-              constructorFor(elementType, Some(loopVar), newTypePath),
-              getPath),
+              p => constructorFor(elementType, Some(p), newTypePath),
+              getPath,
+              schemaFor(elementType).dataType),
             "array",
             arrayClassFor(elementType))
         }
@@ -278,13 +277,12 @@ object ScalaReflection extends ScalaReflection {
         val TypeRef(_, _, Seq(elementType)) = t
         val className = getClassNameFromType(elementType)
         val newTypePath = s"""- array element class: "$className"""" +: walkedTypePath
-        val loopVar = LoopVar(schemaFor(elementType).dataType)
         val arrayData =
           Invoke(
             MapObjects(
-              loopVar,
-              constructorFor(elementType, Some(loopVar), newTypePath),
-              getPath),
+              p => constructorFor(elementType, Some(p), newTypePath),
+              getPath,
+              schemaFor(elementType).dataType),
             "array",
             ObjectType(classOf[Array[Any]]))
 
@@ -298,23 +296,21 @@ object ScalaReflection extends ScalaReflection {
         // TODO: add walked type path for map
         val TypeRef(_, _, Seq(keyType, valueType)) = t
 
-        val keyLoopVar = LoopVar(schemaFor(keyType).dataType)
         val keyData =
           Invoke(
             MapObjects(
-              keyLoopVar,
-              constructorFor(keyType, Some(keyLoopVar), walkedTypePath),
-              Invoke(getPath, "keyArray", ArrayType(schemaFor(keyType).dataType))),
+              p => constructorFor(keyType, Some(p), walkedTypePath),
+              Invoke(getPath, "keyArray", ArrayType(schemaFor(keyType).dataType)),
+              schemaFor(keyType).dataType),
             "array",
             ObjectType(classOf[Array[Any]]))
 
-        val valueLoopVar = LoopVar(schemaFor(valueType).dataType)
         val valueData =
           Invoke(
             MapObjects(
-              valueLoopVar,
-              constructorFor(valueType, Some(valueLoopVar), walkedTypePath),
-              Invoke(getPath, "valueArray", ArrayType(schemaFor(valueType).dataType))),
+              p => constructorFor(valueType, Some(p), walkedTypePath),
+              Invoke(getPath, "valueArray", ArrayType(schemaFor(valueType).dataType)),
+              schemaFor(valueType).dataType),
             "array",
             ObjectType(classOf[Array[Any]]))
 
@@ -418,8 +414,7 @@ object ScalaReflection extends ScalaReflection {
       } else {
         val clsName = getClassNameFromType(elementType)
         val newPath = s"""- array element class: "$clsName"""" +: walkedTypePath
-        val loopVar = LoopVar(externalDataType)
-        MapObjects(loopVar, extractorFor(loopVar, elementType, newPath), input)
+        MapObjects(extractorFor(_, elementType, newPath), input, externalDataType)
       }
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/RowEncoder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/RowEncoder.scala
@@ -93,7 +93,9 @@ object RowEncoder {
           classOf[GenericArrayData],
           inputObject :: Nil,
           dataType = t)
-      case _ => MapObjects(extractorsFor(_, et), inputObject, externalDataTypeFor(et))
+      case _ =>
+        val loopVar = LoopVar(externalDataTypeFor(et))
+        MapObjects(loopVar, extractorsFor(loopVar, et), inputObject)
     }
 
     case t @ MapType(kt, vt, valueNullable) =>
@@ -191,9 +193,10 @@ object RowEncoder {
       Invoke(input, "toString", ObjectType(classOf[String]))
 
     case ArrayType(et, nullable) =>
+      val loopVar = LoopVar(et)
       val arrayData =
         Invoke(
-          MapObjects(constructorFor, input, et),
+          MapObjects(loopVar, constructorFor(loopVar), input),
           "array",
           ObjectType(classOf[Array[_]]))
       StaticInvoke(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/RowEncoder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/RowEncoder.scala
@@ -93,9 +93,7 @@ object RowEncoder {
           classOf[GenericArrayData],
           inputObject :: Nil,
           dataType = t)
-      case _ =>
-        val loopVar = LoopVar(externalDataTypeFor(et))
-        MapObjects(loopVar, extractorsFor(loopVar, et), inputObject)
+      case _ => MapObjects(extractorsFor(_, et), inputObject, externalDataTypeFor(et))
     }
 
     case t @ MapType(kt, vt, valueNullable) =>
@@ -193,10 +191,9 @@ object RowEncoder {
       Invoke(input, "toString", ObjectType(classOf[String]))
 
     case ArrayType(et, nullable) =>
-      val loopVar = LoopVar(et)
       val arrayData =
         Invoke(
-          MapObjects(loopVar, constructorFor(loopVar), input),
+          MapObjects(constructorFor(_), input, et),
           "array",
           ObjectType(classOf[Array[_]]))
       StaticInvoke(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects.scala
@@ -323,22 +323,26 @@ case class WrapOption(child: Expression)
 }
 
 /**
- * A place holder for the loop variable used in [[MapObjects]].  This should never be constructed
- * manually, but will instead be passed into the provided lambda function.
+ * A place holder for the loop variable used in [[MapObjects]].
  */
-case class LambdaVariable(value: String, isNull: String, dataType: DataType) extends Expression {
+case class LoopVar(value: String, isNull: String, dataType: DataType) extends LeafExpression
+  with Unevaluable {
 
-  override def genCode(ctx: CodeGenContext, ev: GeneratedExpressionCode): String =
-    throw new UnsupportedOperationException("Only calling gen() is supported.")
+  override def nullable: Boolean = true
 
-  override def children: Seq[Expression] = Nil
-  override def gen(ctx: CodeGenContext): GeneratedExpressionCode =
+  override def gen(ctx: CodeGenContext): GeneratedExpressionCode = {
     GeneratedExpressionCode(code = "", value = value, isNull = isNull)
+  }
+}
 
-  override def nullable: Boolean = false
-  override def eval(input: InternalRow): Any =
-    throw new UnsupportedOperationException("Only code-generated evaluation is supported.")
+object LoopVar {
+  private val curId = new java.util.concurrent.atomic.AtomicInteger()
 
+  def apply(dataType: DataType): LoopVar = {
+    val loopValue = "MapObjects_loopValue" + curId.getAndIncrement()
+    val loopIsNull = "MapObjects_loopIsNull" + curId.getAndIncrement()
+    LoopVar(loopValue, loopIsNull, dataType)
+  }
 }
 
 /**
@@ -349,20 +353,16 @@ case class LambdaVariable(value: String, isNull: String, dataType: DataType) ext
  * The following collection ObjectTypes are currently supported:
  *   Seq, Array, ArrayData, java.util.List
  *
- * @param function A function that returns an expression, given an attribute that can be used
- *                 to access the current value.  This is does as a lambda function so that
- *                 a unique attribute reference can be provided for each expression (thus allowing
- *                 us to nest multiple MapObject calls).
+ * @param loopVar A place holder that used as the loop variable when iterate the collection, and
+ *                used as input for the `lambdaFunction`. It also carries the element type info.
+ * @param lambdaFunction A function that take the `loopVar` as input, and used as lambda function
+ *                       to handle collection elements.
  * @param inputData An expression that when evaluted returns a collection object.
- * @param elementType The type of element in the collection, expressed as a DataType.
  */
 case class MapObjects(
-    function: AttributeReference => Expression,
-    inputData: Expression,
-    elementType: DataType) extends Expression {
-
-  private lazy val loopAttribute = AttributeReference("loopVar", elementType)()
-  private lazy val completeFunction = function(loopAttribute)
+    loopVar: LoopVar,
+    lambdaFunction: Expression,
+    inputData: Expression) extends Expression {
 
   private def itemAccessorMethod(dataType: DataType): String => String = dataType match {
     case NullType =>
@@ -402,37 +402,23 @@ case class MapObjects(
 
   override def nullable: Boolean = true
 
-  override def children: Seq[Expression] = completeFunction :: inputData :: Nil
+  override def children: Seq[Expression] = lambdaFunction :: inputData :: Nil
 
   override def eval(input: InternalRow): Any =
     throw new UnsupportedOperationException("Only code-generated evaluation is supported")
 
-  override def dataType: DataType = ArrayType(completeFunction.dataType)
+  override def dataType: DataType = ArrayType(lambdaFunction.dataType)
 
   override def genCode(ctx: CodeGenContext, ev: GeneratedExpressionCode): String = {
     val javaType = ctx.javaType(dataType)
-    val elementJavaType = ctx.javaType(elementType)
+    val elementJavaType = ctx.javaType(loopVar.dataType)
     val genInputData = inputData.gen(ctx)
-
-    // Variables to hold the element that is currently being processed.
-    val loopValue = ctx.freshName("loopValue")
-    val loopIsNull = ctx.freshName("loopIsNull")
-
-    val loopVariable = LambdaVariable(loopValue, loopIsNull, elementType)
-    val substitutedFunction = completeFunction transform {
-      case a: AttributeReference if a == loopAttribute => loopVariable
-    }
-    // A hack to run this through the analyzer (to bind extractions).
-    val boundFunction =
-      SimpleAnalyzer.execute(Project(Alias(substitutedFunction, "")() :: Nil, LocalRelation(Nil)))
-        .expressions.head.children.head
-
-    val genFunction = boundFunction.gen(ctx)
+    val genFunction = lambdaFunction.gen(ctx)
     val dataLength = ctx.freshName("dataLength")
     val convertedArray = ctx.freshName("convertedArray")
     val loopIndex = ctx.freshName("loopIndex")
 
-    val convertedType = ctx.boxedType(boundFunction.dataType)
+    val convertedType = ctx.boxedType(lambdaFunction.dataType)
 
     // Because of the way Java defines nested arrays, we have to handle the syntax specially.
     // Specifically, we have to insert the [$dataLength] in between the type and any extra nested
@@ -446,9 +432,9 @@ case class MapObjects(
     }
 
     val loopNullCheck = if (primitiveElement) {
-      s"boolean $loopIsNull = ${genInputData.value}.isNullAt($loopIndex);"
+      s"boolean ${loopVar.isNull} = ${genInputData.value}.isNullAt($loopIndex);"
     } else {
-      s"boolean $loopIsNull = ${genInputData.isNull} || $loopValue == null;"
+      s"boolean ${loopVar.isNull} = ${genInputData.isNull} || ${loopVar.value} == null;"
     }
 
     s"""
@@ -464,11 +450,11 @@ case class MapObjects(
 
         int $loopIndex = 0;
         while ($loopIndex < $dataLength) {
-          $elementJavaType $loopValue =
+          $elementJavaType ${loopVar.value} =
             ($elementJavaType)${genInputData.value}${itemAccessor(loopIndex)};
           $loopNullCheck
 
-          if ($loopIsNull) {
+          if (${loopVar.isNull}) {
             $convertedArray[$loopIndex] = null;
           } else {
             ${genFunction.code}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
@@ -145,6 +145,7 @@ class ExpressionEncoderSuite extends SparkFunSuite {
 
   case class InnerClass(i: Int)
   productTest(InnerClass(1))
+  encodeDecodeTest(Array(InnerClass(1)), "array of inner class")
 
   productTest(PrimitiveData(1, 1, 1, 1, 1, 1, true))
 


### PR DESCRIPTION
in https://github.com/apache/spark/pull/10133 we found that, we shoud ensure the children of `TreeNode` are all accessible in the `productIterator`, or the behavior will be very confusing.

In this PR, I try to fix this problem by expsing the `loopVar`.

This also fixes SPARK-12131 which is caused by the hacky `MapObjects`.
