### PR TITLE
[SPARK-12231][SQL] Fix dropna when working with groupBy and partitionBy

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -205,8 +205,7 @@ object ColumnPruning extends Rule[LogicalPlan] {
       a.copy(child = e.copy(child = prunedChild(child, e.references ++ a.references)))
 
     // Eliminate attributes that are not needed to calculate the specified aggregates.
-    case a @ Aggregate(_, _, child)
-      if !a.references.isEmpty && (child.outputSet -- a.references).nonEmpty =>
+    case a @ Aggregate(_, _, child) if (child.outputSet -- a.references).nonEmpty =>
       a.copy(child = Project(a.references.toSeq, child))
 
     // Eliminate attributes that are not needed to calculate the Generate.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -205,7 +205,8 @@ object ColumnPruning extends Rule[LogicalPlan] {
       a.copy(child = e.copy(child = prunedChild(child, e.references ++ a.references)))
 
     // Eliminate attributes that are not needed to calculate the specified aggregates.
-    case a @ Aggregate(_, _, child) if (child.outputSet -- a.references).nonEmpty =>
+    case a @ Aggregate(_, _, child)
+      if !a.references.isEmpty && (child.outputSet -- a.references).nonEmpty =>
       a.copy(child = Project(a.references.toSeq, child))
 
     // Eliminate attributes that are not needed to calculate the Generate.

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
@@ -194,4 +194,17 @@ class DataFrameNaFunctionsSuite extends QueryTest with SharedSQLContext {
     assert(out1(4) === Row("Amy", null, null))
     assert(out1(5) === Row(null, null, null))
   }
+
+  test("dropna with partitionBy") {
+    withTempPath { dir =>
+      val df = sqlContext.range(10)
+      val df1 = df.withColumn("a", $"id".cast("int"))
+      df1.write.partitionBy("id").parquet(dir.getCanonicalPath)
+
+      val df2 = sqlContext.read.parquet(dir.getCanonicalPath)
+
+      val group = df2.na.drop().groupBy().count()
+      group.collect()
+    }
+  }
 }


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-12231

When no filters are pushed down and ColumnPruning strategy inserts an empty projection, current codes to process partitioned HadoopFsRelation will request empty columns. It causes problem in later Filter operator.
