### PR TITLE
[Spark-12260][wip][Streaming]Graceful Shutdown with In-Memory State

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DSteamDumpFormat.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DSteamDumpFormat.scala
@@ -26,7 +26,7 @@ import org.apache.spark.SparkContext
 /**
  * User can customize DumpFormat by extends this abstract class.
  */
-abstract class DSteamDumpFormat[K, S] extends Serializable{
+abstract class DSteamDumpFormat[K, S] extends Serializable {
   // Identity have to be provided here for every DumpableDStream instance. Otherwise it's not able
   // to recognize each other during loading.
   val identity : String
@@ -47,7 +47,8 @@ class CheckpointDumpFormat[K: ClassTag, S: ClassTag](val identity: String)
   private[streaming] def dump(rdd : RDD[(K, S)], path: String): Unit = {
     val broadcastedConf = rdd.context.broadcast(
         new SerializableConfiguration(rdd.context.hadoopConfiguration))
-    val dumpFunc = ReliableCheckpointRDD.writeCheckpointFile[(K, S)](path, broadcastedConf)_
+    val dumpFunc = ReliableCheckpointRDD.writePartitionToCheckpointFile[(K, S)](
+        path, broadcastedConf)_
 
     rdd.context.runJob(rdd, dumpFunc)
   }

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DSteamDumpFormat.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DSteamDumpFormat.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.streaming.dstream
+
+import scala.reflect.ClassTag
+import org.apache.spark.rdd.RDD
+import org.apache.spark.util.SerializableConfiguration
+import org.apache.spark.rdd.ReliableCheckpointRDD
+import org.apache.spark.SparkContext
+
+/**
+ * User can customize DumpFormat by extends this abstract class.
+ */
+abstract class DSteamDumpFormat[K, S] extends Serializable{
+  // Identity have to be provided here for every DumpableDStream instance. Otherwise it's not able
+  // to recognize each other during loading.
+  val identity : String
+
+  // user can customize how to dump state information
+  private[streaming] def dump(rdd : RDD[(K, S)], path: String): Unit
+
+  // user can customize how to load state information
+  def load(sc: SparkContext, path: String): RDD[(K, S)]
+}
+
+/**
+ * Dump RDD to HDFS which reuse the same code path as doing checkpoint
+ */
+class CheckpointDumpFormat[K: ClassTag, S: ClassTag](val identity: String)
+  extends DSteamDumpFormat[K, S] {
+
+  private[streaming] def dump(rdd : RDD[(K, S)], path: String): Unit = {
+    val broadcastedConf = rdd.context.broadcast(
+        new SerializableConfiguration(rdd.context.hadoopConfiguration))
+    val dumpFunc = ReliableCheckpointRDD.writeCheckpointFile[(K, S)](path, broadcastedConf)_
+
+    rdd.context.runJob(rdd, dumpFunc)
+  }
+
+  def load(sc: SparkContext, path: String): RDD[(K, S)] = {
+    new ReliableCheckpointRDD[(K, S)](sc , path)
+  }
+}

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
@@ -330,6 +330,20 @@ abstract class DStream[T: ClassTag] (
   }
 
   /**
+   * compute the last valid time till input time
+   * (validTime = zeroTime + N * slideDuration)
+   */
+  private[streaming] def lastValidTime(time: Time): Time = {
+    if (time < zeroTime) {
+      throw new IllegalArgumentException(
+          s"Input(${time}) must bigger then zeroTime($zeroTime)")
+    }
+
+    val multi: Int = ((time - zeroTime) / slideDuration).floor.toInt
+    zeroTime + (slideDuration * multi)
+  }
+
+  /**
    * Get the RDD corresponding to the given time; either retrieve it from cache
    * or compute-and-cache it.
    */

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DumpableDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DumpableDStream.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.streaming.dstream
+
+import org.apache.spark.streaming.Time
+import org.apache.spark.streaming.StreamingContext
+
+import scala.reflect.ClassTag
+
+/**
+ * A common trait for all DStream which would like to make data persistence
+ *
+ * @tparam K Class of data key
+ * @tparam S Class of data value
+ */
+abstract class DumpableDStream[K: ClassTag, S: ClassTag](ssc: StreamingContext)
+  extends DStream[(K, S)](ssc) {
+  // A reference to dumpFormat. default value is None, so nothing will be dumpped. User need to
+  // specify DumpFormat instance, if he/she want to dump data during process shutdown.
+  var _dumpFormat: Option[DSteamDumpFormat[K, S]] = None
+
+  def setDumpFormat(df: DSteamDumpFormat[K, S]): Unit = {
+    _dumpFormat = Some(df)
+  }
+
+  // dump data on given time to given path
+  def dump(time: Time, path: String): Unit = _dumpFormat match {
+    case None =>
+      log.debug("DumpFormat is not set, nothing will be dumped for this DStream")
+    case Some(df) =>
+      log.info(s"DumpFormat is set as ${df.getClass}, start dumping ${df.identity}")
+
+      // "identity" in DumpFormat will be used as file name
+      val dumpPath = path + "/" + df.identity
+      val validTime = lastValidTime(time)
+      log.info(s"convent ${time} to valid time ${validTime}")
+
+      getOrCompute(validTime) match {
+        case Some(rdd) =>
+          df.dump(rdd, dumpPath) // delegate to DumpFormat.dump
+          log.info(s"Finish dumping ${df.identity} into path ${dumpPath}")
+        case None =>
+          log.info(s"There is no RDD on ${validTime}, nothing will be dumped for this DStream")
+      }
+  }
+}

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/PairDStreamFunctions.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/PairDStreamFunctions.scala
@@ -499,7 +499,7 @@ class PairDStreamFunctions[K, V](self: DStream[(K, V)])
       partitioner: Partitioner,
       rememberPartitioner: Boolean,
       initialRDD: RDD[(K, S)]
-    ): DStream[(K, S)] = ssc.withScope {
+    ): DumpableDStream[K, S] = ssc.withScope {
      new StateDStream(self, ssc.sc.clean(updateFunc), partitioner,
        rememberPartitioner, Some(initialRDD))
   }

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/StateDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/StateDStream.scala
@@ -22,8 +22,10 @@ import org.apache.spark.Partitioner
 import org.apache.spark.SparkContext._
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming.{Duration, Time}
-
 import scala.reflect.ClassTag
+import org.apache.spark.rdd.ReliableRDDCheckpointData
+import org.apache.spark.rdd.ReliableCheckpointRDD
+import org.apache.spark.util.SerializableConfiguration
 
 private[streaming]
 class StateDStream[K: ClassTag, V: ClassTag, S: ClassTag](
@@ -32,7 +34,7 @@ class StateDStream[K: ClassTag, V: ClassTag, S: ClassTag](
     partitioner: Partitioner,
     preservePartitioning: Boolean,
     initialRDD : Option[RDD[(K, S)]]
-  ) extends DStream[(K, S)](parent.ssc) {
+  ) extends DumpableDStream[K, S](parent.ssc) {
 
   super.persist(StorageLevel.MEMORY_ONLY_SER)
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
@@ -112,6 +112,12 @@ class JobScheduler(val ssc: StreamingContext) extends Logging {
     }
     logDebug("Stopped job executor")
 
+    // For all DumpableDStream, persist data to checkpoint directory, so that when process
+    // restarted, user is able to load these data back.
+    if (processAllReceivedData) {
+      ssc.graph.dump(Time(clock.getTimeMillis()), ssc.checkpointDir)
+    }
+
     // Stop everything else
     listenerBus.stop()
     eventLoop.stop()

--- a/streaming/src/test/scala/org/apache/spark/streaming/Demo.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/Demo.scala
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.streaming
+
+import java.util.concurrent.TimeUnit
+import org.apache.spark.HashPartitioner
+import org.apache.spark.LocalSparkContext
+import org.apache.spark.SparkConf
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.streaming.dstream.DStream.toPairDStreamFunctions
+import org.apache.spark.util.ThreadUtils
+import java.io.FileInputStream
+import org.apache.spark.serializer.JavaSerializer
+import org.apache.spark.rdd.RDD
+import org.apache.spark.rdd.MapPartitionsRDD
+import org.apache.spark.streaming.dstream.StateDStream
+import org.apache.spark.serializer.Serializer
+import org.apache.spark.rdd.ReliableCheckpointRDD
+import org.apache.spark.streaming.dstream.CheckpointDumpFormat
+
+/**
+ * This is to demonstrate usage. Do NOT merge it to main branch!!!
+ *
+ * In this demo, we save latest status of StateDStream when process shutdown.
+ * During restarting, we load it back and recover status.
+ */
+object Demo extends App {
+  // define update method
+  val updateFunc = (values: Seq[Int], state: Option[Int]) => {
+    val currentCount = values.sum
+    val previousCount = state.getOrElse(0)
+    Some(currentCount + previousCount)
+  }
+
+  val newUpdateFunc = (iterator: Iterator[(String, Seq[Int], Option[Int])]) => {
+    iterator.flatMap(t => updateFunc(t._2, t._3).map { s => (t._1, s) })
+  }
+
+  val checkpointDir = "/home/maowei/checkpoint"
+
+  // prepare StreamingContext
+  val conf = new SparkConf()
+    .setAppName("test")
+    .setMaster("local")
+    .set("spark.ui.enabled", "false")
+  val ssc = new StreamingContext(conf, Seconds(1))
+  ssc.checkpoint(checkpointDir)
+
+  // new a DumpFormat instance
+  val df = new CheckpointDumpFormat[String, Int]("WordCount")
+
+  // read dumpped RDD back
+  val initialRDD = df.load(ssc.sc , checkpointDir + "/WordCount")
+  // val initialRDD = ssc.sc.parallelize(Seq(("hello", 1), ("world", 1)), 1)
+
+  // define transformation and action
+  val lines = ssc.textFileStream("/home/maowei/tmp")
+  val wordDstream = lines.flatMap(_.split(" ")).map { x => (x, 1) }
+  val stateDstream = wordDstream.updateStateByKey[Int](newUpdateFunc,
+    new HashPartitioner(ssc.sparkContext.defaultParallelism), true, initialRDD)
+
+  // set DumpFormat for StateDStream instance
+  stateDstream.setDumpFormat(df)
+
+  stateDstream.print()
+
+  // create another thread to stop ssc
+  val thread = ThreadUtils.newDaemonSingleThreadScheduledExecutor("stop-streamiing-thread")
+  val scheduleTask = new Runnable() {
+    override def run(): Unit = {
+      ssc.stop(true, true)
+    }
+  }
+  thread.schedule(scheduleTask, 5, TimeUnit.SECONDS)
+
+  // start streaming context
+  ssc.start()
+  ssc.awaitTermination()
+}


### PR DESCRIPTION
[View Detail Design DOC](https://docs.google.com/document/d/1JS9W370hNTUCtwHLa8WiKRuOuIbo8A-UwYBdbK7WGg8/edit?usp=sharing)

**Motivation:**
Users often stop and restart their streaming jobs for tasks such as maintenance, software upgrades or even application logic updates. When a job re-starts it should pick up where it left off i.e. any state information that existed when the job stopped should be used as the initial state when the job restarts.

**Proposal:**
I  create an abstract class called `DumpableDStream` which extends `DStream`, and make stateful `DStreams` entend it, for instance, `MapWithStateDStream`, `StateDStream`. So that these stateful `DSteams` will have common ancestor.

`DumpFormat` is also an abstract class, looks like following:

``` scala
abstract class DSteamDumpFormat[K, S] extends Serializable{
     val identity : String
     private[streaming] def dump(rdd : RDD[(K, S)], path: String): Unit
     def load(sc: SparkContext, path: String): RDD[(K, S)]
}
```

User can customize his own `DumpFormat` by extending this abstract class. There are three interfaces in it. “identity” is used to recognize dumped RDD during loading it back, it have to be provided for every DumpableDStream instance. “dump” method is designed to dump inputted DRR to given path, this method will be called by `DumpableDStream.dump` method. “load” method is designed to load RDD back from given path, user need to call it expilicatly.  

When an application performs graceful shutdown via invoking `StreamingContext.stop(…)`, it invoke a method `ssc.graph.dump` that will traverse current `DStreamGraph` to find all `DumpableDStream` and perform `DumpableDStream.dump()`

**Usage:**
From user perspective, first he/she need to create a new DumpFormat instance:

``` scala
val df = new CheckpointDumpFormat[String, Int]("WordCount")
```

Then set this `DumpFormat` instance into `stateDStream` reference”. That’s all.

``` scala
    val stateDstream = wordDstream.updateStateByKey[Int](newUpdateFunc,
    new HashPartitioner(ssc.sparkContext.defaultParallelism), true, initialRDD)
    stateDstream.setDumpFormat(df)
```

Once `StreamingContext.stop()` is invoked with `stopGracefully = true`, the state of WordCount will be automatically saved into HDFS and user can easily load it back when restarting the process by following code:

``` scala
    val initialRDD = df.load(ssc.sc , checkpointDir+"/WordCount")
```

For advance usage, user can create his own `DumpFormat` type to specify serializer or save in-memory state into Datadase, etc.
