### PR TITLE
[SPARK-12270][SQL]remove empty space after getString from database

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -422,7 +422,14 @@ private[sql] class JDBCRDD(
             case IntegerConversion => mutableRow.setInt(i, rs.getInt(pos))
             case LongConversion => mutableRow.setLong(i, rs.getLong(pos))
             // TODO(davies): use getBytes for better performance, if the encoding is UTF-8
-            case StringConversion => mutableRow.update(i, UTF8String.fromString(rs.getString(pos)))
+            case StringConversion =>
+              val s = rs.getString(pos)
+              if (s != null) {
+                mutableRow.update(i, UTF8String.fromString(rs.getString(pos).trim))
+              }
+              else {
+                mutableRow.update(i, null)
+              }
             case TimestampConversion =>
               val t = rs.getTimestamp(pos)
               if (t != null) {


### PR DESCRIPTION
{code}
    conn.prepareStatement(
        "create table people (name char(32)").executeUpdate()
     conn.prepareStatement("insert into people values ('fred')").executeUpdate()
     sql(
       s"""
          |CREATE TEMPORARY TABLE foobar
          |USING org.apache.spark.sql.jdbc
          |OPTIONS (url '$url', dbtable 'PEOPLE', user 'testuser', password 'testpassword')
      """.stripMargin.replaceAll("\n", " "))
     val df = sqlContext.sql("SELECT \* FROM foobar WHERE NAME = 'fred'")
{code}
I am expecting to see one row with content 'fred' in df. However, there is no row returned. If I changed the data type to varchar (32) in the create table ddl , then I can get the row back correctly. The cause of the problem is that for data type char (num), DB2 defines it as fixed-length character strings, so if I have char (32), when doing "SELECT \* FROM foobar WHERE NAME = 'fred'", DB2 returns 'fred' padded with 28 empty space. Spark treats "fred' padded with empty space not the same as 'fred' so df doesn't have any row. If I have varchar (32), DB2 just returns 'fred' for the select statement and df has the right row. In order to make DB2 char (num) works for spark, I suggest to change spark code to trim the empty space after get the data from database.
