### PR TITLE
[SPARK-12274][SQL] WrapOption should not have type constraint for child

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects.scala
@@ -296,14 +296,11 @@ case class UnwrapOption(
  * (in the case of reference types) equality with null.
  * @param child The expression to evaluate and wrap.
  */
-case class WrapOption(child: Expression)
-  extends UnaryExpression with ExpectsInputTypes {
+case class WrapOption(child: Expression) extends UnaryExpression {
 
   override def dataType: DataType = ObjectType(classOf[Option[_]])
 
   override def nullable: Boolean = true
-
-  override def inputTypes: Seq[AbstractDataType] = ObjectType :: Nil
 
   override def eval(input: InternalRow): Any =
     throw new UnsupportedOperationException("Only code-generated evaluation is supported")


### PR DESCRIPTION
I think it was a mistake, and we have not catched it so far until https://github.com/apache/spark/pull/10260 which begin to check if the `fromRowExpression` is resolved.
