### PR TITLE
[SPARK-12230][ML] WeightedLeastSquares.fit() should handle division by zero properly if standard deviation of target variable is zero.

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/optim/WeightedLeastSquares.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/WeightedLeastSquares.scala
@@ -93,12 +93,12 @@ private[ml] class WeightedLeastSquares(
           s"training is not needed.")
         val coefficients = new DenseVector(Array.ofDim(k-1))
         val intercept = bBar
-        val diagInvAtWA = new DenseVector(Array.ofDim(k))
+        val diagInvAtWA = new DenseVector(Array(0D))
         return new WeightedLeastSquaresModel(coefficients, intercept, diagInvAtWA)
       }
       else {
       logWarning(s"The standard deviation of the label is zero. " +
-        "Consider setting FitIntercept=true.")
+        "Consider setting fitIntercept=true.")
       }
     }
 
@@ -111,7 +111,6 @@ private[ml] class WeightedLeastSquares(
         lambda *= aVar(j - 2)
       }
       if (standardizeLabel && bStd != 0) {
-        // TODO: handle the case when bStd = 0
         lambda /= bStd
       }
       aaValues(i) += lambda

--- a/mllib/src/main/scala/org/apache/spark/ml/optim/WeightedLeastSquares.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/WeightedLeastSquares.scala
@@ -86,6 +86,22 @@ private[ml] class WeightedLeastSquares(
     val aaBar = summary.aaBar
     val aaValues = aaBar.values
 
+    if (bStd == 0) {
+      if (fitIntercept) {
+        logWarning(s"The standard deviation of the label is zero, so the coefficients will be " +
+          s"zeros and the intercept will be the mean of the label; as a result, " +
+          s"training is not needed.")
+        val coefficients = new DenseVector(Array.ofDim(k-1))
+        val intercept = bBar
+        val diagInvAtWA = new DenseVector(Array.ofDim(k))
+        return new WeightedLeastSquaresModel(coefficients, intercept, diagInvAtWA)
+      }
+      else {
+      logWarning(s"The standard deviation of the label is zero. " +
+        "Consider setting FitIntercept=true.")
+      }
+    }
+
     // add regularization to diagonals
     var i = 0
     var j = 2
@@ -94,7 +110,7 @@ private[ml] class WeightedLeastSquares(
       if (standardizeFeatures) {
         lambda *= aVar(j - 2)
       }
-      if (standardizeLabel) {
+      if (standardizeLabel && bStd != 0) {
         // TODO: handle the case when bStd = 0
         lambda /= bStd
       }

--- a/mllib/src/main/scala/org/apache/spark/ml/optim/WeightedLeastSquares.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/WeightedLeastSquares.scala
@@ -95,8 +95,7 @@ private[ml] class WeightedLeastSquares(
         val intercept = bBar
         val diagInvAtWA = new DenseVector(Array(0D))
         return new WeightedLeastSquaresModel(coefficients, intercept, diagInvAtWA)
-      }
-      else {
+      } else {
       logWarning(s"The standard deviation of the label is zero. " +
         "Consider setting fitIntercept=true.")
       }

--- a/mllib/src/main/scala/org/apache/spark/ml/optim/WeightedLeastSquares.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/WeightedLeastSquares.scala
@@ -96,8 +96,11 @@ private[ml] class WeightedLeastSquares(
         val diagInvAtWA = new DenseVector(Array(0D))
         return new WeightedLeastSquaresModel(coefficients, intercept, diagInvAtWA)
       } else {
-      logWarning(s"The standard deviation of the label is zero. " +
-        "Consider setting fitIntercept=true.")
+        require(!(regParam > 0.0 && standardizeLabel),
+          "The standard deviation of the label is zero. " +
+            "Model cannot be regularized with standardization=true")
+        logWarning(s"The standard deviation of the label is zero. " +
+          "Consider setting fitIntercept=true.")
       }
     }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/optim/WeightedLeastSquaresSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/optim/WeightedLeastSquaresSuite.scala
@@ -47,8 +47,10 @@ class WeightedLeastSquaresSuite extends SparkFunSuite with MLlibTestSparkContext
 
     /*
        R code:
-       same as above except make the label constant
+
+       A <- matrix(c(0, 1, 2, 3, 5, 7, 11, 13), 4, 2)
        b <- c(17, 17, 17, 17)
+       w <- c(1, 2, 3, 4)
      */
     instancesConstLabel = sc.parallelize(Seq(
       Instance(17.0, 1.0, Vectors.dense(0.0, 5.0).toSparse),


### PR DESCRIPTION
This fixes the behavior of WeightedLeastSquars.fit() when the standard deviation of the target variable is zero. If the fitIntercept is true, there is no need to train.
