### PR TITLE
[SPARK-12324][MLLIB][DOC] Fixes the sidebar in the ML documentation

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -607,3 +607,10 @@ Vis.js uses and redistributes the following third-party libraries:
 - keycharm
   https://github.com/AlexDM0/keycharm
   The MIT License
+
+===============================================================================
+
+The CSS style for the navigation sidebar of the documentation was originally 
+submitted by Óscar Nájera for the scikit-learn project. The scikit-learn project
+is distributed under the 3-Clause BSD license.
+===============================================================================

--- a/docs/_layouts/global.html
+++ b/docs/_layouts/global.html
@@ -128,19 +128,31 @@
 
             {% if page.url contains "/ml" %}
               {% include nav-left-wrapper-ml.html nav-mllib=site.data.menu-mllib nav-ml=site.data.menu-ml %}
+              <input id="nav-trigger" class="nav-trigger" checked="" type="checkbox">
+              <label for="nav-trigger"></label>
+                <div class="content-with-sidebar" id="content">
+                  {% if page.displayTitle %}
+                    <h1 class="title">{{ page.displayTitle }}</h1>
+                  {% else %}
+                    <h1 class="title">{{ page.title }}</h1>
+                  {% endif %}
+
+                  {{ content }}
+
+                </div> <!-- /container -->
+            {% else %}
+                <div class="content" id="content">
+                      {% if page.displayTitle %}
+                        <h1 class="title">{{ page.displayTitle }}</h1>
+                      {% else %}
+                        <h1 class="title">{{ page.title }}</h1>
+                      {% endif %}
+
+                      {{ content }}
+
+                </div> <!-- /container -->
             {% endif %}
 
-
-            <div class="container" id="content">
-              {% if page.displayTitle %}
-                <h1 class="title">{{ page.displayTitle }}</h1>
-              {% else %}
-                <h1 class="title">{{ page.title }}</h1>
-              {% endif %}
-
-              {{ content }}
-
-            </div> <!-- /container -->
         </div>
 
         <script src="js/vendor/jquery-1.8.0.min.js"></script>

--- a/docs/_layouts/global.html
+++ b/docs/_layouts/global.html
@@ -1,3 +1,4 @@
+
 <!DOCTYPE html>
 <!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
 <!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
@@ -127,32 +128,32 @@
         <div class="container-wrapper">
 
             {% if page.url contains "/ml" %}
-              {% include nav-left-wrapper-ml.html nav-mllib=site.data.menu-mllib nav-ml=site.data.menu-ml %}
-              <input id="nav-trigger" class="nav-trigger" checked="" type="checkbox">
-              <label for="nav-trigger"></label>
+                {% include nav-left-wrapper-ml.html nav-mllib=site.data.menu-mllib nav-ml=site.data.menu-ml %}
+                <input id="nav-trigger" class="nav-trigger" checked type="checkbox">
+                <label for="nav-trigger"></label>
                 <div class="content-with-sidebar" id="content">
-                  {% if page.displayTitle %}
-                    <h1 class="title">{{ page.displayTitle }}</h1>
-                  {% else %}
-                    <h1 class="title">{{ page.title }}</h1>
-                  {% endif %}
+                    {% if page.displayTitle %}
+                        <h1 class="title">{{ page.displayTitle }}</h1>
+                    {% else %}
+                        <h1 class="title">{{ page.title }}</h1>
+                    {% endif %}
 
-                  {{ content }}
+                    {{ content }}
 
-                </div> <!-- /container -->
+                </div>
             {% else %}
                 <div class="content" id="content">
-                      {% if page.displayTitle %}
+                    {% if page.displayTitle %}
                         <h1 class="title">{{ page.displayTitle }}</h1>
-                      {% else %}
+                    {% else %}
                         <h1 class="title">{{ page.title }}</h1>
-                      {% endif %}
+                    {% endif %}
 
-                      {{ content }}
+                    {{ content }}
 
-                </div> <!-- /container -->
+                </div>
             {% endif %}
-
+             <!-- /container -->
         </div>
 
         <script src="js/vendor/jquery-1.8.0.min.js"></script>

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -39,13 +39,26 @@
   margin-left: 10px;
 }
 
+/*
 body .container-wrapper {
   position: absolute;
   width: 100%;
   display: flex;
 }
+*/
 
-body #content {
+body .container-wrapper {
+  background-color: #FFF;
+  color: #1D1F22;
+  max-width: 1024px;
+  margin-top: 10px;
+  margin-left: auto;
+  margin-right: auto;
+  border-radius: 15px;
+  position: relative;
+}
+
+body #contentREMOVE {
   position: relative;
 
   line-height: 1.6; /* Inspired by Github's wiki style */
@@ -99,6 +112,24 @@ a:hover code {
 
 .container {
   max-width: 914px;
+}
+
+.content {
+  z-index: 1;
+  position: relative;
+  background-color: #FFF;
+  padding-left: 15px;
+  max-width: 914px;
+  line-height: 1.6; /* Inspired by Github's wiki style */
+  background-color: white;
+}
+
+.content-with-sidebar {
+  z-index: 1;
+  position: relative;
+  background-color: #FFF;
+  padding-left: 15px;
+  max-width: 914px;  
 }
 
 .dropdown-menu {
@@ -171,15 +202,28 @@ a.anchorjs-link:hover { text-decoration: none; }
  * The left navigation bar.
  */
 .left-menu-wrapper {
+margin-left: 0px;
+margin-right: 0px;
+background-color: inherit;
+border-top-left-radius: 15px;
+border-top-width: 0px;
+border-left-width: 0px;
+border-bottom-width: 0px;
+margin-top: 0px;
+width: 210px;
+float: left;
+position: absolute;
+/*
   position: absolute;
   height: 100%;
 
   width: 256px;
   margin-top: -20px;
   padding-top: 20px;
-  background-color: #F0F8FC;
+  background-color: #F0F8FC;*/
 }
 
+/*
 .left-menu {
   position: fixed;
   max-width: 350px;
@@ -187,8 +231,94 @@ a.anchorjs-link:hover { text-decoration: none; }
   padding-right: 10px;
   width: 256px;
 }
+*/
+
+.left-menu {
+padding: 0px;
+width: 199px;
+}
 
 .left-menu h3 {
   margin-left: 10px;
   line-height: 30px;
+}
+
+/**
+ * The collapsing button for the navigation bar.
+ */
+.nav-trigger {
+    position: fixed;
+    clip: rect(0, 0, 0, 0);
+}
+
+.nav-trigger + label:after {
+    content: '»';
+}
+
+label {
+  z-index: 10;
+}
+
+label[for="nav-trigger"] {
+    position: fixed;
+    margin-left: 0px;
+    padding-top: 100px;s
+    z-index: 10;
+    width: 15px;
+    height: 80%;
+    cursor: pointer;
+    background-size: contain;
+    background-color: #F6F6F6;
+    border-radius: 10px 0px 0px 10px;
+}
+
+label[for="nav-trigger"]:hover {
+    background-color: #D0D0D0;
+}
+
+.nav-trigger:checked + label {
+    margin-left: 200px;
+}
+
+.nav-trigger:checked + label:after {
+    content: '«';
+}
+
+.nav-trigger:checked ~ div.content-with-sidebar {
+    margin-left: 200px;
+}
+.nav-trigger + label, div.content-with-sidebar {
+    transition: left 0.4s;
+}
+
+/**
+ * Rules to collapse the menu automatically when the screen becomes too thin.
+ */
+
+@media all and (max-width: 780px) {
+
+  div.content-with-sidebar {
+    margin-left: 200px;
+  }
+  .nav-trigger + label:after {
+    content: '«';
+  }
+  label[for="nav-trigger"] {
+    margin-left: 200px;
+  }
+
+  .nav-trigger:checked + label {
+    margin-left: 0px;
+  }
+  .nav-trigger:checked + label:after {
+    content: '»';
+  }
+  .nav-trigger:checked ~ div.content-with-sidebar {
+    margin-left: 0px;
+  }
+
+  div.container-index {
+    margin-left: -215px;
+  }
+
 }

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -102,18 +102,20 @@ a:hover code {
   z-index: 1;
   position: relative;
   background-color: #FFF;
-  padding-left: 15px;
   max-width: 914px;
   line-height: 1.6; /* Inspired by Github's wiki style */
   background-color: white;
+  padding-left: 15px;
 }
 
 .content-with-sidebar {
   z-index: 1;
   position: relative;
   background-color: #FFF;
+  max-width: 914px;
+  line-height: 1.6; /* Inspired by Github's wiki style */
+  background-color: white;
   padding-left: 30px;
-  max-width: 914px;  
 }
 
 .dropdown-menu {

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -104,7 +104,6 @@ a:hover code {
   background-color: #FFF;
   max-width: 914px;
   line-height: 1.6; /* Inspired by Github's wiki style */
-  background-color: white;
   padding-left: 15px;
 }
 
@@ -114,7 +113,6 @@ a:hover code {
   background-color: #FFF;
   max-width: 914px;
   line-height: 1.6; /* Inspired by Github's wiki style */
-  background-color: white;
   padding-left: 30px;
 }
 

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -128,7 +128,7 @@ a:hover code {
   z-index: 1;
   position: relative;
   background-color: #FFF;
-  padding-left: 15px;
+  padding-left: 30px;
   max-width: 914px;  
 }
 
@@ -202,40 +202,21 @@ a.anchorjs-link:hover { text-decoration: none; }
  * The left navigation bar.
  */
 .left-menu-wrapper {
-margin-left: 0px;
-margin-right: 0px;
-background-color: inherit;
-border-top-left-radius: 15px;
-border-top-width: 0px;
-border-left-width: 0px;
-border-bottom-width: 0px;
-margin-top: 0px;
-width: 210px;
-float: left;
-position: absolute;
-/*
+  margin-left: 0px;
+  margin-right: 0px;
+  background-color: #F0F8FC;
+  border-top-width: 0px;
+  border-left-width: 0px;
+  border-bottom-width: 0px;
+  margin-top: 0px;
+  width: 210px;
+  float: left;
   position: absolute;
-  height: 100%;
-
-  width: 256px;
-  margin-top: -20px;
-  padding-top: 20px;
-  background-color: #F0F8FC;*/
 }
 
-/*
 .left-menu {
-  position: fixed;
-  max-width: 350px;
-
-  padding-right: 10px;
-  width: 256px;
-}
-*/
-
-.left-menu {
-padding: 0px;
-width: 199px;
+  padding: 0px;
+  width: 199px;
 }
 
 .left-menu h3 {
@@ -262,18 +243,18 @@ label {
 label[for="nav-trigger"] {
     position: fixed;
     margin-left: 0px;
-    padding-top: 100px;s
-    z-index: 10;
-    width: 15px;
+    padding-top: 100px;
+    padding-left: 5px;
+    width: 10px;
     height: 80%;
     cursor: pointer;
     background-size: contain;
-    background-color: #F6F6F6;
+    background-color: #D4F0FF;
     border-radius: 10px 0px 0px 10px;
 }
 
 label[for="nav-trigger"]:hover {
-    background-color: #D0D0D0;
+    background-color: #BEE9FF;
 }
 
 .nav-trigger:checked + label {

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -39,14 +39,6 @@
   margin-left: 10px;
 }
 
-/*
-body .container-wrapper {
-  position: absolute;
-  width: 100%;
-  display: flex;
-}
-*/
-
 body .container-wrapper {
   background-color: #FFF;
   color: #1D1F22;
@@ -56,14 +48,6 @@ body .container-wrapper {
   margin-right: auto;
   border-radius: 15px;
   position: relative;
-}
-
-body #contentREMOVE {
-  position: relative;
-
-  line-height: 1.6; /* Inspired by Github's wiki style */
-  background-color: white;
-  padding-left: 15px;
 }
 
 .title {
@@ -228,12 +212,12 @@ a.anchorjs-link:hover { text-decoration: none; }
  * The collapsing button for the navigation bar.
  */
 .nav-trigger {
-    position: fixed;
-    clip: rect(0, 0, 0, 0);
+  position: fixed;
+  clip: rect(0, 0, 0, 0);
 }
 
 .nav-trigger + label:after {
-    content: '»';
+  content: '»';
 }
 
 label {
@@ -241,35 +225,35 @@ label {
 }
 
 label[for="nav-trigger"] {
-    position: fixed;
-    margin-left: 0px;
-    padding-top: 100px;
-    padding-left: 5px;
-    width: 10px;
-    height: 80%;
-    cursor: pointer;
-    background-size: contain;
-    background-color: #D4F0FF;
-    border-radius: 10px 0px 0px 10px;
+  position: fixed;
+  margin-left: 0px;
+  padding-top: 100px;
+  padding-left: 5px;
+  width: 10px;
+  height: 80%;
+  cursor: pointer;
+  background-size: contain;
+  background-color: #D4F0FF;
 }
 
 label[for="nav-trigger"]:hover {
-    background-color: #BEE9FF;
+  background-color: #BEE9FF;
 }
 
 .nav-trigger:checked + label {
-    margin-left: 200px;
+  margin-left: 200px;
 }
 
 .nav-trigger:checked + label:after {
-    content: '«';
+  content: '«';
 }
 
 .nav-trigger:checked ~ div.content-with-sidebar {
-    margin-left: 200px;
+  margin-left: 200px;
 }
+
 .nav-trigger + label, div.content-with-sidebar {
-    transition: left 0.4s;
+  transition: left 0.4s;
 }
 
 /**

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -83,7 +83,7 @@ $(function() {
   // Display anchor links when hovering over headers. For documentation of the
   // configuration options, see the AnchorJS documentation.
   anchors.options = {
-    placement: 'left'
+    placement: 'right'
   };
   anchors.add();
 


### PR DESCRIPTION
This fixes the sidebar, using a pure CSS mechanism to hide it when the browser's viewport is too narrow.
Credit goes to the original author @Titan-C (mentioned in the NOTICE).

Note that I am not a CSS expert, so I can only address comments up to some extent.

Default view:
<img width="936" alt="screen shot 2015-12-14 at 12 46 39 pm" src="https://cloud.githubusercontent.com/assets/7594753/11793597/6d1d6eda-a261-11e5-836b-6eb2054e9054.png">

When collapsed manually by the user:
<img width="1004" alt="screen shot 2015-12-14 at 12 54 02 pm" src="https://cloud.githubusercontent.com/assets/7594753/11793669/c991989e-a261-11e5-8bf6-aecf3bdb6319.png">

Disappears when column is too narrow:
<img width="697" alt="screen shot 2015-12-14 at 12 47 22 pm" src="https://cloud.githubusercontent.com/assets/7594753/11793607/7754dbcc-a261-11e5-8b15-e0d074b0e47c.png">

Can still be opened by the user if necessary:
<img width="651" alt="screen shot 2015-12-14 at 12 51 15 pm" src="https://cloud.githubusercontent.com/assets/7594753/11793612/7bf82968-a261-11e5-9cc3-e827a7a6b2b0.png">
