### PR TITLE
[SPARK-12296][PYSPARK][MLLIB] Feature parity for pyspark mllib standard scaler model

### DIFF
--- a/python/pyspark/mllib/feature.py
+++ b/python/pyspark/mllib/feature.py
@@ -175,7 +175,7 @@ class StandardScalerModel(JavaVectorTransformer):
         return self
 
     @property
-    @since('1.6.0')
+    @since('2.0.0')
     def withStd(self):
         """
         Returns if the model scales the data to unit standard deviation.
@@ -183,7 +183,7 @@ class StandardScalerModel(JavaVectorTransformer):
         return self.call("withStd")
 
     @property
-    @since('1.6.0')
+    @since('2.0.0')
     def withMean(self):
         """
         Returns if the model centers the data before scaling.
@@ -191,7 +191,7 @@ class StandardScalerModel(JavaVectorTransformer):
         return self.call("withMean")
 
     @property
-    @since('1.6.0')
+    @since('2.0.0')
     def std(self):
         """
         Return the column standard deviation values. Only set if model was trained withStd.
@@ -199,12 +199,13 @@ class StandardScalerModel(JavaVectorTransformer):
         return self.call("std")
 
     @property
-    @since('1.6.0')
+    @since('2.0.0')
     def mean(self):
         """
         Return the column mean values. Only set if model was trained withMean.
         """
         return self.call("mean")
+
 
 class StandardScaler(object):
     """

--- a/python/pyspark/mllib/feature.py
+++ b/python/pyspark/mllib/feature.py
@@ -194,7 +194,7 @@ class StandardScalerModel(JavaVectorTransformer):
     @since('2.0.0')
     def std(self):
         """
-        Return the column standard deviation values. Only set if model was trained withStd.
+        Return the column standard deviation values.
         """
         return self.call("std")
 
@@ -202,7 +202,7 @@ class StandardScalerModel(JavaVectorTransformer):
     @since('2.0.0')
     def mean(self):
         """
-        Return the column mean values. Only set if model was trained withMean.
+        Return the column mean values.
         """
         return self.call("mean")
 

--- a/python/pyspark/mllib/feature.py
+++ b/python/pyspark/mllib/feature.py
@@ -174,6 +174,21 @@ class StandardScalerModel(JavaVectorTransformer):
         self.call("setWithStd", withStd)
         return self
 
+    @property
+    @since('1.6.0')
+    def std(self):
+        """
+        Return the column standard deviation values. Only set if model was trained withStd.
+        """
+        return self.call("std")
+
+    @property
+    @since('1.6.0')
+    def mean(self):
+        """
+        Return the column mean values. Only set if model was trained withMean.
+        """
+        return self.call("mean")
 
 class StandardScaler(object):
     """
@@ -198,6 +213,10 @@ class StandardScaler(object):
     >>> for r in result.collect(): r
     DenseVector([-0.7071, 0.7071, -0.7071])
     DenseVector([0.7071, -0.7071, 0.7071])
+    >>> int(model.std[0])
+    4
+    >>> int(model.mean[0]*10)
+    9
 
     .. versionadded:: 1.2.0
     """

--- a/python/pyspark/mllib/feature.py
+++ b/python/pyspark/mllib/feature.py
@@ -176,6 +176,22 @@ class StandardScalerModel(JavaVectorTransformer):
 
     @property
     @since('1.6.0')
+    def withStd(self):
+        """
+        Returns if the model scales the data to unit standard deviation.
+        """
+        return self.call("withStd")
+
+    @property
+    @since('1.6.0')
+    def withMean(self):
+        """
+        Returns if the model centers the data before scaling.
+        """
+        return self.call("withMean")
+
+    @property
+    @since('1.6.0')
     def std(self):
         """
         Return the column standard deviation values. Only set if model was trained withStd.
@@ -217,6 +233,10 @@ class StandardScaler(object):
     4
     >>> int(model.mean[0]*10)
     9
+    >>> model.withStd
+    True
+    >>> model.withMean
+    True
 
     .. versionadded:: 1.2.0
     """


### PR DESCRIPTION
Some methods are missing, such as ways to access the std, mean, etc. This PR is for feature parity for pyspark.mllib.feature.StandardScaler & StandardScalerModel.
