### PR TITLE
[SPARK-12231][SQL]create a combineFilters' projection when we call buildPartitionedTableScan

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -86,7 +86,8 @@ private[sql] object DataSourceStrategy extends Strategy with Logging {
       }
 
       // need to add projections from combineFilters in
-      val combineProjections = projects.toSet.union(combineFilters.flatMap(_.references).toSet).toSeq
+      val combineProjections =
+        projects.toSet.union(combineFilters.flatMap(_.references).toSet).toSeq
       val scan = buildPartitionedTableScan(
         l,
         combineProjections,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -85,9 +85,11 @@ private[sql] object DataSourceStrategy extends Strategy with Logging {
         s"Selected $selected partitions out of $total, pruned $percentPruned% partitions."
       }
 
+      // need to add projections from combineFilters in
+      val combineProjections = projects.toSet.union(combineFilters.flatMap(_.references).toSet).toSeq
       val scan = buildPartitionedTableScan(
         l,
-        projects,
+        combineProjections,
         pushedFilters,
         t.partitionSpec.partitionColumns,
         selectedPartitions)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
@@ -194,4 +194,31 @@ class DataFrameNaFunctionsSuite extends QueryTest with SharedSQLContext {
     assert(out1(4) === Row("Amy", null, null))
     assert(out1(5) === Row(null, null, null))
   }
+
+  test("dropna with partitionBy and groupBy") {
+    withTempPath { dir =>
+      val df = sqlContext.range(10)
+      val df1 = df.withColumn("a", $"id".cast("int"))
+      df1.write.partitionBy("id").parquet(dir.getCanonicalPath)
+
+      val df2 = sqlContext.read.parquet(dir.getCanonicalPath)
+
+      val group = df2.na.drop().groupBy().count()
+      group.collect()
+    }
+  }
+
+  test("dropna with partitionBy") {
+    withTempPath { dir =>
+      val df = sqlContext.range(10)
+      val df1 = df.withColumn("a", $"id".cast("int"))
+      df1.write.partitionBy("id").parquet(dir.getCanonicalPath)
+
+      val df2 = sqlContext.read.parquet(dir.getCanonicalPath)
+
+      val group = df2.na.drop().count()
+
+    }
+  }
+
 }


### PR DESCRIPTION
Hello Michael & All: Here I am submitting another approach to solve this problem. Can you verify ? 

I think the problem is related to change from spark-10829,

before that PR change, the projects and filters are done inside buildPartitionedTableScan.
With that PR change, the filter expression divide to 3 parts, the filter left outside of the scan (combineFilters ) needs a different projection. 

So the fix is to create a combine projection for the outside filter and beyond. 

Thanks for your comments.  
