### PR TITLE
[SPARK-11097][Core]Add channelActive callback to RpcHandler to monitor the new connections

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/mesos/MesosExternalShuffleService.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/mesos/MesosExternalShuffleService.scala
@@ -65,7 +65,7 @@ private[mesos] class MesosExternalShuffleBlockHandler(transportConf: TransportCo
   /**
    * On connection termination, clean up shuffle files written by the associated application.
    */
-  override def connectionTerminated(client: TransportClient): Unit = {
+  override def channelInactive(client: TransportClient): Unit = {
     val address = client.getSocketAddress
     if (connectedApps.contains(address)) {
       val appId = connectedApps(address)

--- a/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
@@ -607,14 +607,14 @@ private[netty] class NettyRpcHandler(
     }
   }
 
-  override def connectionEstablished(client: TransportClient): Unit = {
+  override def channelActive(client: TransportClient): Unit = {
     val addr = client.getChannel().remoteAddress().asInstanceOf[InetSocketAddress]
     assert(addr != null)
     val clientAddr = RpcAddress(addr.getHostName, addr.getPort)
     dispatcher.postToAll(RemoteProcessConnected(clientAddr))
   }
 
-  override def connectionTerminated(client: TransportClient): Unit = {
+  override def channelInactive(client: TransportClient): Unit = {
     val addr = client.getChannel.remoteAddress().asInstanceOf[InetSocketAddress]
     if (addr != null) {
       val clientAddr = RpcAddress(addr.getHostName, addr.getPort)

--- a/core/src/test/scala/org/apache/spark/rpc/RpcEnvSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rpc/RpcEnvSuite.scala
@@ -484,10 +484,16 @@ abstract class RpcEnvSuite extends SparkFunSuite with BeforeAndAfterAll {
     }
   }
 
-  test("network events") {
+  /**
+   * Setup an [[RpcEndpoint]] to collect all network events.
+   * @return the [[RpcEndpointRef]] and an `Seq` that contains network events.
+   */
+  private def setupNetworkEndpoint(
+      _env: RpcEnv,
+      name: String): (RpcEndpointRef, Seq[(Any, Any)]) = {
     val events = new mutable.ArrayBuffer[(Any, Any)] with mutable.SynchronizedBuffer[(Any, Any)]
-    env.setupEndpoint("network-events", new ThreadSafeRpcEndpoint {
-      override val rpcEnv = env
+    val ref = _env.setupEndpoint("network-events-non-client", new ThreadSafeRpcEndpoint {
+      override val rpcEnv = _env
 
       override def receive: PartialFunction[Any, Unit] = {
         case "hello" =>
@@ -507,83 +513,97 @@ abstract class RpcEnvSuite extends SparkFunSuite with BeforeAndAfterAll {
       }
 
     })
+    (ref, events)
+  }
 
-    val anotherEnv = createRpcEnv(new SparkConf(), "remote", 0, clientMode = true)
-    // Use anotherEnv to find out the RpcEndpointRef
-    val rpcEndpointRef = anotherEnv.setupEndpointRef(
-      "local", env.address, "network-events")
-    val remoteAddress = anotherEnv.address
-    rpcEndpointRef.send("hello")
-    eventually(timeout(5 seconds), interval(5 millis)) {
-      // anotherEnv is connected in client mode, so the remote address may be unknown depending on
-      // the implementation. Account for that when doing checks.
-      if (remoteAddress != null) {
-        assert(events === List(("onConnected", remoteAddress)))
-      } else {
-        assert(events.size === 1)
-        assert(events(0)._1 === "onConnected")
-      }
-    }
+  test("network events in sever RpcEnv when another RpcEnv is in server mode") {
+    val serverEnv1 = createRpcEnv(new SparkConf(), "server1", 0, clientMode = false)
+    val serverEnv2 = createRpcEnv(new SparkConf(), "server2", 0, clientMode = false)
+    val (_, events) = setupNetworkEndpoint(serverEnv1, "network-events")
+    val (serverRef2, _) = setupNetworkEndpoint(serverEnv2, "network-events")
+    try {
+      val serverRefInServer2 =
+        serverEnv1.setupEndpointRef("server2", serverRef2.address, serverRef2.name)
+      // Send a message to set up the connection
+      serverRefInServer2.send("hello")
 
-    anotherEnv.shutdown()
-    anotherEnv.awaitTermination()
-    eventually(timeout(5 seconds), interval(5 millis)) {
-      // Account for anotherEnv not having an address due to running in client mode.
-      if (remoteAddress != null) {
-        assert(events === List(
-          ("onConnected", remoteAddress),
-          ("onNetworkError", remoteAddress),
-          ("onDisconnected", remoteAddress)) ||
-          events === List(
-          ("onConnected", remoteAddress),
-          ("onDisconnected", remoteAddress)))
-      } else {
-        val eventNames = events.map(_._1)
-        assert(eventNames === List("onConnected", "onNetworkError", "onDisconnected") ||
-          eventNames === List("onConnected", "onDisconnected"))
+      eventually(timeout(5 seconds), interval(5 millis)) {
+        assert(events.contains(("onConnected", serverEnv2.address)))
       }
+
+      serverEnv2.shutdown()
+      serverEnv2.awaitTermination()
+
+      eventually(timeout(5 seconds), interval(5 millis)) {
+        assert(events.contains(("onConnected", serverEnv2.address)))
+        assert(events.contains(("onDisconnected", serverEnv2.address)))
+      }
+    } finally {
+      serverEnv1.shutdown()
+      serverEnv2.shutdown()
+      serverEnv1.awaitTermination()
+      serverEnv2.awaitTermination()
     }
   }
 
-  test("network events between non-client-mode RpcEnvs") {
-    val events = new mutable.ArrayBuffer[(Any, Any)] with mutable.SynchronizedBuffer[(Any, Any)]
-    env.setupEndpoint("network-events-non-client", new ThreadSafeRpcEndpoint {
-      override val rpcEnv = env
+  test("network events in sever RpcEnv when another RpcEnv is in client mode") {
+    val serverEnv = createRpcEnv(new SparkConf(), "server", 0, clientMode = false)
+    val (serverRef, events) = setupNetworkEndpoint(serverEnv, "network-events")
+    val clientEnv = createRpcEnv(new SparkConf(), "client", 0, clientMode = true)
+    try {
+      val serverRefInClient =
+        clientEnv.setupEndpointRef("server", serverRef.address, serverRef.name)
+      // Send a message to set up the connection
+      serverRefInClient.send("hello")
 
-      override def receive: PartialFunction[Any, Unit] = {
-        case "hello" =>
-        case m => events += "receive" -> m
+      eventually(timeout(5 seconds), interval(5 millis)) {
+        // We don't know the exact client address but at least we can verify the message type
+        assert(events.map(_._1).contains("onConnected"))
       }
 
-      override def onConnected(remoteAddress: RpcAddress): Unit = {
-        events += "onConnected" -> remoteAddress
+      clientEnv.shutdown()
+      clientEnv.awaitTermination()
+
+      eventually(timeout(5 seconds), interval(5 millis)) {
+        // We don't know the exact client address but at least we can verify the message type
+        assert(events.map(_._1).contains("onConnected"))
+        assert(events.map(_._1).contains("onDisconnected"))
       }
-
-      override def onDisconnected(remoteAddress: RpcAddress): Unit = {
-        events += "onDisconnected" -> remoteAddress
-      }
-
-      override def onNetworkError(cause: Throwable, remoteAddress: RpcAddress): Unit = {
-        events += "onNetworkError" -> remoteAddress
-      }
-
-    })
-
-    val anotherEnv = createRpcEnv(new SparkConf(), "remote", 0, clientMode = false)
-    // Use anotherEnv to find out the RpcEndpointRef
-    val rpcEndpointRef = anotherEnv.setupEndpointRef(
-      "local", env.address, "network-events-non-client")
-    val remoteAddress = anotherEnv.address
-    rpcEndpointRef.send("hello")
-    eventually(timeout(5 seconds), interval(5 millis)) {
-      assert(events.contains(("onConnected", remoteAddress)))
+    } finally {
+      clientEnv.shutdown()
+      serverEnv.shutdown()
+      clientEnv.awaitTermination()
+      serverEnv.awaitTermination()
     }
+  }
 
-    anotherEnv.shutdown()
-    anotherEnv.awaitTermination()
-    eventually(timeout(5 seconds), interval(5 millis)) {
-      assert(events.contains(("onConnected", remoteAddress)))
-      assert(events.contains(("onDisconnected", remoteAddress)))
+  test("network events in client RpcEnv when another RpcEnv is in server mode") {
+    val clientEnv = createRpcEnv(new SparkConf(), "client", 0, clientMode = true)
+    val serverEnv = createRpcEnv(new SparkConf(), "server", 0, clientMode = false)
+    val (_, events) = setupNetworkEndpoint(clientEnv, "network-events")
+    val (serverRef, _) = setupNetworkEndpoint(serverEnv, "network-events")
+    try {
+      val serverRefInClient =
+        clientEnv.setupEndpointRef("server", serverRef.address, serverRef.name)
+      // Send a message to set up the connection
+      serverRefInClient.send("hello")
+
+      eventually(timeout(5 seconds), interval(5 millis)) {
+        assert(events.contains(("onConnected", serverEnv.address)))
+      }
+
+      serverEnv.shutdown()
+      serverEnv.awaitTermination()
+
+      eventually(timeout(5 seconds), interval(5 millis)) {
+        assert(events.contains(("onConnected", serverEnv.address)))
+        assert(events.contains(("onDisconnected", serverEnv.address)))
+      }
+    } finally {
+      clientEnv.shutdown()
+      serverEnv.shutdown()
+      clientEnv.awaitTermination()
+      serverEnv.awaitTermination()
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/rpc/netty/NettyRpcHandlerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rpc/netty/NettyRpcHandlerSuite.scala
@@ -43,7 +43,7 @@ class NettyRpcHandlerSuite extends SparkFunSuite {
     val channel = mock(classOf[Channel])
     val client = new TransportClient(channel, mock(classOf[TransportResponseHandler]))
     when(channel.remoteAddress()).thenReturn(new InetSocketAddress("localhost", 40000))
-    nettyRpcHandler.receive(client, null, null)
+    nettyRpcHandler.connectionEstablished(client)
 
     verify(dispatcher, times(1)).postToAll(RemoteProcessConnected(RpcAddress("localhost", 40000)))
   }
@@ -55,7 +55,7 @@ class NettyRpcHandlerSuite extends SparkFunSuite {
     val channel = mock(classOf[Channel])
     val client = new TransportClient(channel, mock(classOf[TransportResponseHandler]))
     when(channel.remoteAddress()).thenReturn(new InetSocketAddress("localhost", 40000))
-    nettyRpcHandler.receive(client, null, null)
+    nettyRpcHandler.connectionEstablished(client)
 
     when(channel.remoteAddress()).thenReturn(new InetSocketAddress("localhost", 40000))
     nettyRpcHandler.connectionTerminated(client)

--- a/core/src/test/scala/org/apache/spark/rpc/netty/NettyRpcHandlerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rpc/netty/NettyRpcHandlerSuite.scala
@@ -43,7 +43,7 @@ class NettyRpcHandlerSuite extends SparkFunSuite {
     val channel = mock(classOf[Channel])
     val client = new TransportClient(channel, mock(classOf[TransportResponseHandler]))
     when(channel.remoteAddress()).thenReturn(new InetSocketAddress("localhost", 40000))
-    nettyRpcHandler.connectionEstablished(client)
+    nettyRpcHandler.channelActive(client)
 
     verify(dispatcher, times(1)).postToAll(RemoteProcessConnected(RpcAddress("localhost", 40000)))
   }
@@ -55,10 +55,10 @@ class NettyRpcHandlerSuite extends SparkFunSuite {
     val channel = mock(classOf[Channel])
     val client = new TransportClient(channel, mock(classOf[TransportResponseHandler]))
     when(channel.remoteAddress()).thenReturn(new InetSocketAddress("localhost", 40000))
-    nettyRpcHandler.connectionEstablished(client)
+    nettyRpcHandler.channelActive(client)
 
     when(channel.remoteAddress()).thenReturn(new InetSocketAddress("localhost", 40000))
-    nettyRpcHandler.connectionTerminated(client)
+    nettyRpcHandler.channelInactive(client)
 
     verify(dispatcher, times(1)).postToAll(RemoteProcessConnected(RpcAddress("localhost", 40000)))
     verify(dispatcher, times(1)).postToAll(

--- a/network/common/src/main/java/org/apache/spark/network/client/TransportResponseHandler.java
+++ b/network/common/src/main/java/org/apache/spark/network/client/TransportResponseHandler.java
@@ -116,6 +116,10 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
   }
 
   @Override
+  public void channelActive() {
+  }
+
+  @Override
   public void channelUnregistered() {
     if (numOutstandingRequests() > 0) {
       String remoteAddress = NettyUtils.getRemoteAddress(channel);

--- a/network/common/src/main/java/org/apache/spark/network/client/TransportResponseHandler.java
+++ b/network/common/src/main/java/org/apache/spark/network/client/TransportResponseHandler.java
@@ -120,7 +120,7 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
   }
 
   @Override
-  public void channelUnregistered() {
+  public void channelInactive() {
     if (numOutstandingRequests() > 0) {
       String remoteAddress = NettyUtils.getRemoteAddress(channel);
       logger.error("Still have {} requests outstanding when connection from {} is closed",

--- a/network/common/src/main/java/org/apache/spark/network/sasl/SaslRpcHandler.java
+++ b/network/common/src/main/java/org/apache/spark/network/sasl/SaslRpcHandler.java
@@ -135,14 +135,14 @@ class SaslRpcHandler extends RpcHandler {
   }
 
   @Override
-  public void connectionEstablished(TransportClient client) {
-    delegate.connectionEstablished(client);
+  public void channelActive(TransportClient client) {
+    delegate.channelActive(client);
   }
 
   @Override
-  public void connectionTerminated(TransportClient client) {
+  public void channelInactive(TransportClient client) {
     try {
-      delegate.connectionTerminated(client);
+      delegate.channelInactive(client);
     } finally {
       if (saslServer != null) {
         saslServer.dispose();

--- a/network/common/src/main/java/org/apache/spark/network/sasl/SaslRpcHandler.java
+++ b/network/common/src/main/java/org/apache/spark/network/sasl/SaslRpcHandler.java
@@ -135,6 +135,11 @@ class SaslRpcHandler extends RpcHandler {
   }
 
   @Override
+  public void connectionEstablished(TransportClient client) {
+    delegate.connectionEstablished(client);
+  }
+
+  @Override
   public void connectionTerminated(TransportClient client) {
     try {
       delegate.connectionTerminated(client);

--- a/network/common/src/main/java/org/apache/spark/network/server/MessageHandler.java
+++ b/network/common/src/main/java/org/apache/spark/network/server/MessageHandler.java
@@ -34,6 +34,6 @@ public abstract class MessageHandler<T extends Message> {
   /** Invoked when an exception was caught on the Channel. */
   public abstract void exceptionCaught(Throwable cause);
 
-  /** Invoked when the channel this MessageHandler is on has been unregistered. */
-  public abstract void channelUnregistered();
+  /** Invoked when the channel this MessageHandler is on is inactive. */
+  public abstract void channelInactive();
 }

--- a/network/common/src/main/java/org/apache/spark/network/server/MessageHandler.java
+++ b/network/common/src/main/java/org/apache/spark/network/server/MessageHandler.java
@@ -28,6 +28,9 @@ public abstract class MessageHandler<T extends Message> {
   /** Handles the receipt of a single message. */
   public abstract void handle(T message) throws Exception;
 
+  /** Invoked when the channel this MessageHandler is on is active. */
+  public abstract void channelActive();
+
   /** Invoked when an exception was caught on the Channel. */
   public abstract void exceptionCaught(Throwable cause);
 

--- a/network/common/src/main/java/org/apache/spark/network/server/RpcHandler.java
+++ b/network/common/src/main/java/org/apache/spark/network/server/RpcHandler.java
@@ -69,6 +69,11 @@ public abstract class RpcHandler {
   }
 
   /**
+   * Invoked when the connection associated with the given client has been established.
+   */
+  public void connectionEstablished(TransportClient client) { }
+
+  /**
    * Invoked when the connection associated with the given client has been invalidated.
    * No further requests will come from this client.
    */

--- a/network/common/src/main/java/org/apache/spark/network/server/RpcHandler.java
+++ b/network/common/src/main/java/org/apache/spark/network/server/RpcHandler.java
@@ -69,15 +69,15 @@ public abstract class RpcHandler {
   }
 
   /**
-   * Invoked when the connection associated with the given client has been established.
+   * Invoked when the channel associated with the given client is active.
    */
-  public void connectionEstablished(TransportClient client) { }
+  public void channelActive(TransportClient client) { }
 
   /**
-   * Invoked when the connection associated with the given client has been invalidated.
+   * Invoked when the channel associated with the given client is inactive.
    * No further requests will come from this client.
    */
-  public void connectionTerminated(TransportClient client) { }
+  public void channelInactive(TransportClient client) { }
 
   public void exceptionCaught(Throwable cause, TransportClient client) { }
 

--- a/network/common/src/main/java/org/apache/spark/network/server/TransportChannelHandler.java
+++ b/network/common/src/main/java/org/apache/spark/network/server/TransportChannelHandler.java
@@ -84,6 +84,22 @@ public class TransportChannelHandler extends SimpleChannelInboundHandler<Message
   }
 
   @Override
+  public void channelActive(ChannelHandlerContext ctx) throws Exception {
+    try {
+      requestHandler.channelActive();
+    } catch (RuntimeException e) {
+      logger.error("Exception from request handler while registering channel", e);
+    }
+    try {
+      responseHandler.channelActive();
+    } catch (RuntimeException e) {
+      logger.error("Exception from response handler while registering channel", e);
+    }
+    super.channelRegistered(ctx);
+  }
+
+
+  @Override
   public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
     try {
       requestHandler.channelUnregistered();

--- a/network/common/src/main/java/org/apache/spark/network/server/TransportChannelHandler.java
+++ b/network/common/src/main/java/org/apache/spark/network/server/TransportChannelHandler.java
@@ -98,16 +98,15 @@ public class TransportChannelHandler extends SimpleChannelInboundHandler<Message
     super.channelRegistered(ctx);
   }
 
-
   @Override
-  public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
+  public void channelInactive(ChannelHandlerContext ctx) throws Exception {
     try {
-      requestHandler.channelUnregistered();
+      requestHandler.channelInactive();
     } catch (RuntimeException e) {
       logger.error("Exception from request handler while unregistering channel", e);
     }
     try {
-      responseHandler.channelUnregistered();
+      responseHandler.channelInactive();
     } catch (RuntimeException e) {
       logger.error("Exception from response handler while unregistering channel", e);
     }

--- a/network/common/src/main/java/org/apache/spark/network/server/TransportRequestHandler.java
+++ b/network/common/src/main/java/org/apache/spark/network/server/TransportRequestHandler.java
@@ -84,11 +84,11 @@ public class TransportRequestHandler extends MessageHandler<RequestMessage> {
 
   @Override
   public void channelActive() {
-    rpcHandler.connectionEstablished(reverseClient);
+    rpcHandler.channelActive(reverseClient);
   }
 
   @Override
-  public void channelUnregistered() {
+  public void channelInactive() {
     if (streamManager != null) {
       try {
         streamManager.connectionTerminated(channel);
@@ -96,7 +96,7 @@ public class TransportRequestHandler extends MessageHandler<RequestMessage> {
         logger.error("StreamManager connectionTerminated() callback failed.", e);
       }
     }
-    rpcHandler.connectionTerminated(reverseClient);
+    rpcHandler.channelInactive(reverseClient);
   }
 
   @Override

--- a/network/common/src/main/java/org/apache/spark/network/server/TransportRequestHandler.java
+++ b/network/common/src/main/java/org/apache/spark/network/server/TransportRequestHandler.java
@@ -83,6 +83,11 @@ public class TransportRequestHandler extends MessageHandler<RequestMessage> {
   }
 
   @Override
+  public void channelActive() {
+    rpcHandler.connectionEstablished(reverseClient);
+  }
+
+  @Override
   public void channelUnregistered() {
     if (streamManager != null) {
       try {

--- a/network/common/src/test/java/org/apache/spark/network/sasl/SparkSaslSuite.java
+++ b/network/common/src/test/java/org/apache/spark/network/sasl/SparkSaslSuite.java
@@ -160,7 +160,7 @@ public class SparkSaslSuite {
       long deadline = System.nanoTime() + TimeUnit.NANOSECONDS.convert(10, TimeUnit.SECONDS);
       while (deadline > System.nanoTime()) {
         try {
-          verify(rpcHandler, times(2)).connectionTerminated(any(TransportClient.class));
+          verify(rpcHandler, times(2)).channelInactive(any(TransportClient.class));
           error = null;
           break;
         } catch (Throwable t) {
@@ -362,8 +362,8 @@ public class SparkSaslSuite {
     saslHandler.getStreamManager();
     verify(handler).getStreamManager();
 
-    saslHandler.connectionTerminated(null);
-    verify(handler).connectionTerminated(any(TransportClient.class));
+    saslHandler.channelInactive(null);
+    verify(handler).channelInactive(any(TransportClient.class));
 
     saslHandler.exceptionCaught(null, null);
     verify(handler).exceptionCaught(any(Throwable.class), any(TransportClient.class));


### PR DESCRIPTION
Added `channelActive` to `RpcHandler` so that `NettyRpcHandler` doesn't need `clients` any more.
