### PR TITLE
[SPARK-12329][SQL]Fix code in ClientWrapper which prints to stdout instead of stderr

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/ClientWrapper.scala
@@ -494,9 +494,9 @@ private[hive] class ClientWrapper(
           results
 
         case _ =>
-          if (state.out != null) {
+          if (state.err != null) {
             // scalastyle:off println
-            state.out.println(tokens(0) + " " + cmd_1)
+            state.err.println(tokens(0) + " " + cmd_1)
             // scalastyle:on println
           }
           Seq(proc.run(cmd_1).getResponseCode.toString)


### PR DESCRIPTION
When I run "$spark-sql -f <sqlfile>", I see that few "SET key value" messages get printed on stdout instead of stderr. These messages should go to stderr.

@marmbrus 
