### PR TITLE
[SPARK-12010][SQL] Add columnMapping support

### DIFF
--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -520,7 +520,7 @@ class DataFrameWriter(object):
         for k in properties:
             jprop.setProperty(k, properties[k])
         if columnMapping is None:
-        	  columnMapping = dict()
+            columnMapping = dict()
         jcolumnMapping = JavaClass("java.util.HashMap", self._sqlContext._sc._gateway._gateway_client)()
         for k in columnMapping:
             jcolumnMapping.put(k, columnMapping[k])

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -494,7 +494,7 @@ class DataFrameWriter(object):
         self._jwrite.orc(path)
 
     @since(1.4)
-    def jdbc(self, url, table, mode=None, properties=None):
+    def jdbc(self, url, table, mode=None, properties=None, columnMapping=None):
         """Saves the content of the :class:`DataFrame` to a external database table via JDBC.
 
         .. note:: Don't create too many partitions in parallel on a large cluster;\
@@ -511,13 +511,20 @@ class DataFrameWriter(object):
         :param properties: JDBC database connection arguments, a list of
                            arbitrary string tag/value. Normally at least a
                            "user" and "password" property should be included.
+        :param columnMapping: optional column name mapping from DF field names to 
+                              JDBC table column names.
         """
         if properties is None:
             properties = dict()
         jprop = JavaClass("java.util.Properties", self._sqlContext._sc._gateway._gateway_client)()
         for k in properties:
             jprop.setProperty(k, properties[k])
-        self._jwrite.mode(mode).jdbc(url, table, jprop)
+        if columnMapping is None:
+        	  columnMapping = dict()
+        jcolumnMapping = JavaClass("java.util.HashMap", self._sqlContext._sc._gateway._gateway_client)()
+        for k in columnMapping:
+            jcolumnMapping.put(k, columnMapping[k])
+        self._jwrite.mode(mode).jdbc(url, table, jprop, jcolumnMapping)
 
 
 def _test():

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -253,7 +253,6 @@ final class DataFrameWriter private[sql](df: DataFrame) {
   }
 
   /**
-   * (scala-specific)
    * Saves the content of the [[DataFrame]] to a external database table via JDBC. In the case the
    * table already exists in the external database, behavior of this function depends on the
    * save mode, specified by the `mode` function (default to throwing an exception).
@@ -267,21 +266,21 @@ final class DataFrameWriter private[sql](df: DataFrame) {
    *                             tag/value. Normally at least a "user" and "password" property
    *                             should be included.
    * @param columnMapping Maps DataFrame column names to target table column names.
-   *                           This parameter can be omitted if the target table has/will be
-   *                           created in this method and therefore the target table structure
-   *                           matches the DF structure.
-   *                           This parameter is stongly recommended, if target table already
-   *                           exists and has been created outside of this method.
-   *                           If omitted, the SQL insert statement will not include column names,
-   *                           which means that the field ordering of the DataFrame must match
-   *                           the target table column ordering.
+   *                      This parameter can be omitted if the target table has/will be
+   *                      created in this method and therefore the target table structure
+   *                      matches the DF structure.
+   *                      This parameter is stongly recommended, if target table already
+   *                      exists and has been created outside of this method.
+   *                      If omitted, the SQL insert statement will not include column names,
+   *                      which means that the field ordering of the DataFrame must match
+   *                      the target table column ordering.
    *
    * @since 1.4.0
    */
   def jdbc(url: String,
            table: String,
            connectionProperties: Properties,
-           columnMapping: scala.collection.immutable.Map[String, String]): Unit = {
+           columnMapping: scala.collection.Map[String, String]): Unit = {
     val props = new Properties()
     extraOptions.foreach { case (key, value) =>
       props.put(key, value)
@@ -320,28 +319,30 @@ final class DataFrameWriter private[sql](df: DataFrame) {
   }
 
   /**
-   * (java-specific) version of jdbc method
+   * (java-friendly) version of
+   * [[DataFrameWriter.jdbc(String,String,Properties,scala.collection.Map[String,String]):]]
    */
-   def jdbc(url: String,
+  def jdbc(url: String,
            table: String,
            connectionProperties: Properties,
            columnMapping: java.util.Map[String, String]): Unit = {
-    // Convert java Map into immutable scala Map
-    var sColumnMapping: scala.collection.immutable.Map[String, String] = null
+    // Convert java Map into scala Map
+    var sColumnMapping: scala.collection.Map[String, String] = null
     if (columnMapping!=null) {
-        sColumnMapping = collection.immutable.Map(columnMapping.asScala.toList: _*)
+        sColumnMapping = columnMapping.asScala
     }
-    jdbc( url, table, connectionProperties, sColumnMapping )
+    jdbc(url, table, connectionProperties, sColumnMapping)
   }
 
   /**
-   * legacy three parameter version of jdbc method
+   * Three parameter version of
+   * [[DataFrameWriter.jdbc(String,String,Properties,scala.collection.Map[String,String]):]]
    */
   def jdbc(url: String,
            table: String,
            connectionProperties: Properties): Unit = {
-    val columnMapping: scala.collection.immutable.Map[String, String] = null
-    jdbc( url, table, connectionProperties, columnMapping )
+    val columnMapping: scala.collection.Map[String, String] = null
+    jdbc(url, table, connectionProperties, columnMapping)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -341,8 +341,7 @@ final class DataFrameWriter private[sql](df: DataFrame) {
   def jdbc(url: String,
            table: String,
            connectionProperties: Properties): Unit = {
-    val columnMapping: scala.collection.Map[String, String] = null
-    jdbc(url, table, connectionProperties, columnMapping)
+    jdbc(url, table, connectionProperties, null.asInstanceOf[Map[String, String]])
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -61,16 +61,16 @@ object JdbcUtils extends Logging {
 
   /**
    * Returns a PreparedStatement that inserts a row into table via conn.
+   * If a columnMapping is provided, it will be used to translate rdd
+   * column names into table column names.
    */
-  def insertStatement(conn: Connection, table: String, rddSchema: StructType): PreparedStatement = {
-    val sql = new StringBuilder(s"INSERT INTO $table VALUES (")
-    var fieldsLeft = rddSchema.fields.length
-    while (fieldsLeft > 0) {
-      sql.append("?")
-      if (fieldsLeft > 1) sql.append(", ") else sql.append(")")
-      fieldsLeft = fieldsLeft - 1
-    }
-    conn.prepareStatement(sql.toString())
+  def insertStatement(conn: Connection,
+                      dialect: JdbcDialect,
+                      table: String,
+                      rddSchema: StructType,
+                      columnMapping: Map[String, String]): PreparedStatement = {
+    val sql = dialect.getInsertStatement(table, rddSchema, columnMapping)
+    conn.prepareStatement(sql)
   }
 
   /**
@@ -122,6 +122,7 @@ object JdbcUtils extends Logging {
       iterator: Iterator[Row],
       rddSchema: StructType,
       nullTypes: Array[Int],
+      columnMapping: Map[String, String] = null,
       batchSize: Int,
       dialect: JdbcDialect): Iterator[Byte] = {
     val conn = getConnection()
@@ -139,7 +140,7 @@ object JdbcUtils extends Logging {
       if (supportsTransactions) {
         conn.setAutoCommit(false) // Everything in the same db transaction.
       }
-      val stmt = insertStatement(conn, table, rddSchema)
+      val stmt = insertStatement(conn, dialect, table, rddSchema, columnMapping)
       try {
         var rowCount = 0
         while (iterator.hasNext) {
@@ -234,7 +235,8 @@ object JdbcUtils extends Logging {
       df: DataFrame,
       url: String,
       table: String,
-      properties: Properties = new Properties()) {
+      properties: Properties = new Properties(),
+      columnMapping: Map[String, String] = null) {
     val dialect = JdbcDialects.get(url)
     val nullTypes: Array[Int] = df.schema.fields.map { field =>
       getJdbcType(field.dataType, dialect).jdbcNullType
@@ -245,7 +247,8 @@ object JdbcUtils extends Logging {
     val getConnection: () => Connection = JDBCRDD.getConnector(driver, url, properties)
     val batchSize = properties.getProperty("batchsize", "1000").toInt
     df.foreachPartition { iterator =>
-      savePartition(getConnection, table, iterator, rddSchema, nullTypes, batchSize, dialect)
+      savePartition(getConnection, table, iterator, rddSchema, nullTypes,
+                    columnMapping, batchSize, dialect)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -61,14 +61,14 @@ object JdbcUtils extends Logging {
 
   /**
    * Returns a PreparedStatement that inserts a row into table via conn.
-   * If a columnMapping is provided, it will be used to translate rdd
+   * If a columnMapping is provided, it will be used to translate RDD
    * column names into table column names.
    */
   def insertStatement(conn: Connection,
                       dialect: JdbcDialect,
                       table: String,
                       rddSchema: StructType,
-                      columnMapping: Map[String, String]): PreparedStatement = {
+                      columnMapping: scala.collection.Map[String, String]): PreparedStatement = {
     val sql = dialect.getInsertStatement(table, rddSchema, columnMapping)
     conn.prepareStatement(sql)
   }
@@ -122,7 +122,7 @@ object JdbcUtils extends Logging {
       iterator: Iterator[Row],
       rddSchema: StructType,
       nullTypes: Array[Int],
-      columnMapping: Map[String, String] = null,
+      columnMapping: scala.collection.Map[String, String] = null,
       batchSize: Int,
       dialect: JdbcDialect): Iterator[Byte] = {
     val conn = getConnection()
@@ -236,7 +236,7 @@ object JdbcUtils extends Logging {
       url: String,
       table: String,
       properties: Properties = new Properties(),
-      columnMapping: Map[String, String] = null) {
+      columnMapping: scala.collection.Map[String, String] = null) {
     val dialect = JdbcDialects.get(url)
     val nullTypes: Array[Int] = df.schema.fields.map { field =>
       getJdbcType(field.dataType, dialect).jdbcNullType

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -122,16 +122,13 @@ abstract class JdbcDialect extends Serializable {
                          rddSchema: StructType,
                          columnMapping: scala.collection.Map[String, String] = null): String = {
     if (columnMapping == null) {
-      rddSchema.fields.map(field => "?")
-      .mkString( s"INSERT INTO $table VALUES (", ", ", " ) ")
+      rddSchema.fields.map(_ => "?")
+      .mkString(s"INSERT INTO $table VALUES (", ", ", " ) ")
     } else {
       rddSchema.fields.map(
-        field => columnMapping.get(field.name) match {
-          case Some(name) => name
-          case None => field.name
-        }
-      ).mkString( s"INSERT INTO $table ( ", ", ", " ) " ) +
-      rddSchema.fields.map(field => "?").mkString( "VALUES ( ", ", ", " )" )
+        field => columnMapping.getOrElse(field.name, field.name)
+      ).mkString(s"INSERT INTO $table ( ", ", ", " ) " ) +
+      rddSchema.fields.map(field => "?").mkString("VALUES ( ", ", ", " )" )
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -120,19 +120,18 @@ abstract class JdbcDialect extends Serializable {
    */
   def getInsertStatement(table: String,
                          rddSchema: StructType,
-                         columnMapping: Map[String, String] = null): String = {
+                         columnMapping: scala.collection.Map[String, String] = null): String = {
     if (columnMapping == null) {
-      return rddSchema.fields.map(field => "?")
-             .mkString( s"INSERT INTO $table VALUES (", ", ", " ) ")
+      rddSchema.fields.map(field => "?")
+      .mkString( s"INSERT INTO $table VALUES (", ", ", " ) ")
     } else {
-      return rddSchema.fields.map(
-               field => columnMapping.get(field.name) match {
-                 case Some(name) => name
-                 case None => s"<JdbcDialect.getInsertStatement: No entry " +
-                              s"found in columnMapping for field '${field.name}'>"
-               }
-             ).mkString( s"INSERT INTO $table ( ", ", ", " ) " ) +
-             rddSchema.fields.map(field => "?").mkString( "VALUES ( ", ", ", " )" )
+      rddSchema.fields.map(
+        field => columnMapping.get(field.name) match {
+          case Some(name) => name
+          case None => field.name
+        }
+      ).mkString( s"INSERT INTO $table ( ", ", ", " ) " ) +
+      rddSchema.fields.map(field => "?").mkString( "VALUES ( ", ", ", " )" )
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCWriteSuite.scala
@@ -93,7 +93,7 @@ class JDBCWriteSuite extends SharedSQLContext with BeforeAndAfter {
     df.write.jdbc(url, "TEST.BASICCREATETEST", new Properties)
     assert(2 === sqlContext.read.jdbc(url, "TEST.BASICCREATETEST", new Properties).count)
     assert(
-      2 === sqlContext.read.jdbc(url, "TEST.BASICCREATETEST", new Properties).collect()(0).length)
+      2 === sqlContext.read.jdbc(url, "TEST.BASICCREATETEST", new Properties()).collect()(0).length)
   }
 
   test("Basic CREATE with columnMapping") {
@@ -101,7 +101,7 @@ class JDBCWriteSuite extends SharedSQLContext with BeforeAndAfter {
 
     val columnMapping = Map("name" -> "name", "id" -> "id")
     df.write.jdbc(url, "TEST.BASICCREATETEST", new Properties, columnMapping)
-    assert(2 === sqlContext.read.jdbc(url, "TEST.BASICCREATETEST", new Properties).count)
+    assert(2 === sqlContext.read.jdbc(url, "TEST.BASICCREATETEST", new Properties()).count)
     assert(
       2 === sqlContext.read.jdbc(url, "TEST.BASICCREATETEST", new Properties).collect()(0).length)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCWriteSuite.scala
@@ -96,6 +96,16 @@ class JDBCWriteSuite extends SharedSQLContext with BeforeAndAfter {
       2 === sqlContext.read.jdbc(url, "TEST.BASICCREATETEST", new Properties).collect()(0).length)
   }
 
+  test("Basic CREATE with columnMapping") {
+    val df = sqlContext.createDataFrame(sparkContext.parallelize(arr2x2), schema2)
+
+    val columnMapping = Map("name" -> "name", "id" -> "id")
+    df.write.jdbc(url, "TEST.BASICCREATETEST", new Properties, columnMapping)
+    assert(2 === sqlContext.read.jdbc(url, "TEST.BASICCREATETEST", new Properties).count)
+    assert(
+      2 === sqlContext.read.jdbc(url, "TEST.BASICCREATETEST", new Properties).collect()(0).length)
+  }
+
   test("CREATE with overwrite") {
     val df = sqlContext.createDataFrame(sparkContext.parallelize(arr2x3), schema3)
     val df2 = sqlContext.createDataFrame(sparkContext.parallelize(arr1x2), schema2)


### PR DESCRIPTION
In the past Spark JDBC write only worked with technologies which support the following INSERT statement syntax (JdbcUtils.scala: insertStatement()):

INSERT INTO $table VALUES ( ?, ?, ..., ? )

But some technologies require a list of column names:

INSERT INTO $table ( $colNameList ) VALUES ( ?, ?, ..., ? )

This was blocking the use of e.g. the Progress JDBC Driver for Cassandra.

Another limitation is that syntax 1 relies no the dataframe field ordering match that of the target table. This works fine, as long as the target table has been created by writer.jdbc().

If the target table contains more columns (not created by writer.jdbc()), then the insert fails due mismatch of number of columns or their data types.

This PR adds an extra columnMapping parameter to write.jdbc(). This optional parameter allows the user to specify how dataframe field names are mapping to target table column names.
