### PR TITLE
[SPARK-12330] [MESOS] Fix mesos coarse mode cleanup

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -19,6 +19,7 @@ package org.apache.spark.executor
 
 import java.net.URL
 import java.nio.ByteBuffer
+import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.collection.mutable
 import scala.util.{Failure, Success}
@@ -42,6 +43,7 @@ private[spark] class CoarseGrainedExecutorBackend(
     env: SparkEnv)
   extends ThreadSafeRpcEndpoint with ExecutorBackend with Logging {
 
+  private[this] val stopping = new AtomicBoolean(false)
   var executor: Executor = null
   @volatile var driver: Option[RpcEndpointRef] = None
 
@@ -102,19 +104,23 @@ private[spark] class CoarseGrainedExecutorBackend(
       }
 
     case StopExecutor =>
+      stopping.set(true)
       logInfo("Driver commanded a shutdown")
       // Cannot shutdown here because an ack may need to be sent back to the caller. So send
       // a message to self to actually do the shutdown.
       self.send(Shutdown)
 
     case Shutdown =>
+      stopping.set(true)
       executor.stop()
       stop()
       rpcEnv.shutdown()
   }
 
   override def onDisconnected(remoteAddress: RpcAddress): Unit = {
-    if (driver.exists(_.address == remoteAddress)) {
+    if (stopping.get()) {
+      logInfo(s"Driver from $remoteAddress disconnected during shutdown")
+    } else if (driver.exists(_.address == remoteAddress)) {
       logError(s"Driver $remoteAddress disassociated! Shutting down.")
       System.exit(1)
     } else {

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
@@ -396,7 +396,7 @@ private[spark] class CoarseMesosSchedulerBackend(
       stopwatch.elapsed(TimeUnit.MILLISECONDS) < shutdownTimeoutMS) {
       Thread.sleep(100)
     }
-    if(slaveIdsWithExecutors.nonEmpty) {
+    if (slaveIdsWithExecutors.nonEmpty) {
       logWarning(s"${slaveIdsWithExecutors.size} executors still running. "
         + "Proceeding with mesos driver stop.")
     }

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
@@ -18,8 +18,8 @@
 package org.apache.spark.scheduler.cluster.mesos
 
 import java.io.File
-import java.util.concurrent.TimeUnit
 import java.util.{Collections, List => JList}
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantLock
 
 import scala.collection.JavaConverters._

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
@@ -396,6 +396,10 @@ private[spark] class CoarseMesosSchedulerBackend(
       stopwatch.elapsed(TimeUnit.MILLISECONDS) < shutdownTimeoutMS) {
       Thread.sleep(100)
     }
+    if(slaveIdsWithExecutors.nonEmpty) {
+      logWarning(s"${slaveIdsWithExecutors.size} executors still running. "
+        + "Proceeding with mesos driver stop.")
+    }
     if (mesosDriver != null) {
       mesosDriver.stop()
     }

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
@@ -18,12 +18,14 @@
 package org.apache.spark.scheduler.cluster.mesos
 
 import java.io.File
+import java.util.concurrent.TimeUnit
 import java.util.{Collections, List => JList}
 import java.util.concurrent.locks.ReentrantLock
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.{HashMap, HashSet}
 
+import com.google.common.base.Stopwatch
 import com.google.common.collect.HashBiMap
 import org.apache.mesos.{Scheduler => MScheduler, SchedulerDriver}
 import org.apache.mesos.Protos.{TaskInfo => MesosTaskInfo, _}
@@ -59,6 +61,12 @@ private[spark] class CoarseMesosSchedulerBackend(
 
   // Maximum number of cores to acquire (TODO: we'll need more flexible controls here)
   val maxCores = conf.get("spark.cores.max", Int.MaxValue.toString).toInt
+
+  private[this] val shutdownTimeoutMS = conf.getInt("spark.mesos.coarse.shutdown.ms", 10000)
+    .ensuring(_ >= 0, "spark.mesos.coarse.shutdown.ms must be >= 0")
+
+  // Synchronization protected by stateLock
+  private[this] var stopCalled: Boolean = false
 
   // If shuffle service is enabled, the Spark driver will register with the shuffle service.
   // This is for cleaning up shuffle files reliably.
@@ -245,6 +253,13 @@ private[spark] class CoarseMesosSchedulerBackend(
    */
   override def resourceOffers(d: SchedulerDriver, offers: JList[Offer]) {
     stateLock.synchronized {
+      if (stopCalled) {
+        logDebug("Ignoring offers during shutdown")
+        // Driver should simply return a stopped status on race
+        // condition between this.stop() and completing here
+        offers.asScala.map(_.getId).foreach(d.declineOffer)
+        return
+      }
       val filters = Filters.newBuilder().setRefuseSeconds(5).build()
       for (offer <- offers.asScala) {
         val offerAttributes = toAttributeMap(offer.getAttributesList)
@@ -364,7 +379,23 @@ private[spark] class CoarseMesosSchedulerBackend(
   }
 
   override def stop() {
-    super.stop()
+    // Make sure we're not launching tasks during shutdown
+    stateLock.synchronized {
+      if (stopCalled) {
+        logWarning("Stop called multiple times, ignoring")
+        return
+      }
+      stopCalled = true
+      super.stop()
+    }
+    // Wait for finish
+    val stopwatch = new Stopwatch()
+    stopwatch.start()
+    // slaveIdsWithExecutors has no memory barrier, so this is eventually consistent
+    while (slaveIdsWithExecutors.nonEmpty &&
+      stopwatch.elapsed(TimeUnit.MILLISECONDS) < shutdownTimeoutMS) {
+      Thread.sleep(100)
+    }
     if (mesosDriver != null) {
       mesosDriver.stop()
     }

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -387,6 +387,13 @@ See the [configuration page](configuration.html) for information on Spark config
     </ul>
   </td>
 </tr>
+<tr>
+  <td><code>spark.mesos.coarse.shutdown.ms</code></td>
+  <td><code>10000</code> (10 seconds)</td>
+  <td> 
+    Time (in ms) to wait for executors to report that they have exited. Setting this too low has the risk of shutting down the Mesos driver (and thereby killing the spark executors) while the executor is still in the process of exiting cleanly.
+  </td>
+</tr>
 </table>
 
 # Troubleshooting and Debugging

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -387,13 +387,6 @@ See the [configuration page](configuration.html) for information on Spark config
     </ul>
   </td>
 </tr>
-<tr>
-  <td><code>spark.mesos.coarse.shutdown.ms</code></td>
-  <td><code>10s</code></td>
-  <td> 
-    Time to wait for executors to report that they have exited. Setting this too low has the risk of shutting down the Mesos driver (and thereby killing the spark executors) while the executor is still in the process of exiting cleanly.
-  </td>
-</tr>
 </table>
 
 # Troubleshooting and Debugging

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -389,9 +389,9 @@ See the [configuration page](configuration.html) for information on Spark config
 </tr>
 <tr>
   <td><code>spark.mesos.coarse.shutdown.ms</code></td>
-  <td><code>10000</code> (10 seconds)</td>
+  <td><code>10s</code></td>
   <td> 
-    Time (in ms) to wait for executors to report that they have exited. Setting this too low has the risk of shutting down the Mesos driver (and thereby killing the spark executors) while the executor is still in the process of exiting cleanly.
+    Time to wait for executors to report that they have exited. Setting this too low has the risk of shutting down the Mesos driver (and thereby killing the spark executors) while the executor is still in the process of exiting cleanly.
   </td>
 </tr>
 </table>


### PR DESCRIPTION
In the current implementation the mesos coarse scheduler does not wait for the mesos tasks to complete before ending the driver. This causes a race where the task has to finish cleaning up before the mesos driver terminates it with a SIGINT (and SIGKILL after 3 seconds if the SIGINT doesn't work).

This PR causes the mesos coarse scheduler to wait for the mesos tasks to finish (with a timeout defined by `spark.mesos.coarse.shutdown.ms`)

This PR also fixes a regression caused by [SPARK-10987] whereby submitting a shutdown causes a race between the local shutdown procedure and the notification of the scheduler driver disconnection. If the scheduler driver disconnection wins the race, the coarse executor incorrectly exits with status 1 (instead of the proper status 0)

With this patch the mesos coarse scheduler terminates properly, the executors clean up, and the tasks are reported as `FINISHED` in the Mesos console (as opposed to `KILLED` in < 1.6 or `FAILED` in 1.6 and later)
