### PR TITLE
[SPARK-12048][SQL] Part 2 Prevent to close JDBC resources twice

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/JdbcRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/JdbcRDD.scala
@@ -73,6 +73,7 @@ class JdbcRDD[T: ClassTag](
 
   override def compute(thePart: Partition, context: TaskContext): Iterator[T] = new NextIterator[T]
   {
+    var closed = false
     context.addTaskCompletionListener{ context => closeIfNeeded() }
     val part = thePart.asInstanceOf[JdbcPartition]
     val conn = getConnection()
@@ -100,6 +101,7 @@ class JdbcRDD[T: ClassTag](
     }
 
     override def close() {
+      if (closed) return
       try {
         if (null != rs) {
           rs.close()
@@ -122,6 +124,7 @@ class JdbcRDD[T: ClassTag](
       } catch {
         case e: Exception => logWarning("Exception closing connection", e)
       }
+      closed = true
     }
   }
 }


### PR DESCRIPTION
PR #10101 dealt with sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala

This PR applies the same technique on JdbcRDD.scala
