### PR TITLE
[SPARK-12361][PYSPARK][TESTS] Should set PYSPARK_DRIVER_PYTHON before…

### DIFF
--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -56,7 +56,8 @@ LOGGER = logging.getLogger()
 
 def run_individual_python_test(test_name, pyspark_python):
     env = dict(os.environ)
-    env.update({'SPARK_TESTING': '1', 'PYSPARK_PYTHON': which(pyspark_python)})
+    env.update({'SPARK_TESTING': '1', 'PYSPARK_PYTHON': which(pyspark_python),
+                'PYSPARK_DRIVER_PYTHON': which(pyspark_python)})
     LOGGER.debug("Starting test(%s): %s", pyspark_python, test_name)
     start_time = time.time()
     try:


### PR DESCRIPTION
… python test

Although this patch still doesn't solve the issue why the return code is 0 (see jira description), it resolves the issue of python version mismatch. 

@JoshRosen  Could you help review it ? Thanks
