### PR TITLE
[SPARK-12289][SQL] Support UnsafeRow in TakeOrderedAndProject/Limit

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicOperators.scala
@@ -211,7 +211,7 @@ case class TakeOrderedAndProject(
   private val ord: InterpretedOrdering = new InterpretedOrdering(sortOrder, child.output)
 
   // TODO: remove @transient after figure out how to clean closure at InsertIntoHiveTable.
-  @transient private val projection = projectList.map(new InterpretedProjection(_, child.output))
+  @transient private val projection = projectList.map(UnsafeProjection.create(_, child.output))
 
   private def collectData(): Array[InternalRow] = {
     val data = child.execute().map(_.copy()).takeOrdered(limit)(ord)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicOperators.scala
@@ -225,7 +225,7 @@ case class TakeOrderedAndProject(
   private def collectData(): Array[InternalRow] = {
     val data = child.execute().map(_.copy()).takeOrdered(limit)(ord)
     if (projection.isDefined) {
-      projection.map(p => data.map(p(_).copy().asInstanceOf[InternalRow])).get
+      projection.map(p => data.map(p(_).asInstanceOf[InternalRow])).get
     } else {
       data
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicOperators.scala
@@ -220,7 +220,7 @@ case class TakeOrderedAndProject(
   private def collectData(): Array[InternalRow] = {
     val data = child.execute().map(_.copy()).takeOrdered(limit)(ord)
     if (projection.isDefined) {
-      projection.map(data.map(_)).get
+      projection.map(p => data.map(p(_).copy().asInstanceOf[InternalRow])).get
     } else {
       data
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicOperators.scala
@@ -162,6 +162,10 @@ case class Limit(limit: Int, child: SparkPlan)
   override def output: Seq[Attribute] = child.output
   override def outputPartitioning: Partitioning = SinglePartition
 
+  override def outputsUnsafeRows: Boolean = child.outputsUnsafeRows
+  override def canProcessUnsafeRows: Boolean = true
+  override def canProcessSafeRows: Boolean = true
+
   override def executeCollect(): Array[InternalRow] = child.executeTake(limit)
 
   protected override def doExecute(): RDD[InternalRow] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicOperators.scala
@@ -225,7 +225,7 @@ case class TakeOrderedAndProject(
   private def collectData(): Array[InternalRow] = {
     val data = child.execute().map(_.copy()).takeOrdered(limit)(ord)
     if (projection.isDefined) {
-      projection.map(p => data.map(p(_).asInstanceOf[InternalRow])).get
+      projection.map(p => data.map(p(_).copy().asInstanceOf[InternalRow])).get
     } else {
       data
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -571,12 +571,6 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
       mapData.collect().take(1).map(Row.fromTuple).toSeq)
   }
 
-  test("sort and limit") {
-    checkAnswer(
-      sql("SELECT * FROM arrayData ORDER BY data[0] ASC LIMIT 1"),
-      arrayData.collect().sortBy(_.data(0)).map(Row.fromTuple).take(1).toSeq)
-  }
-
   test("CTE feature") {
     checkAnswer(
       sql("with q1 as (select * from testData limit 10) select * from q1"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -571,6 +571,12 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
       mapData.collect().take(1).map(Row.fromTuple).toSeq)
   }
 
+  test("sort and limit") {
+    checkAnswer(
+      sql("SELECT * FROM arrayData ORDER BY data[0] ASC LIMIT 1"),
+      arrayData.collect().sortBy(_.data(0)).map(Row.fromTuple).take(1).toSeq)
+  }
+
   test("CTE feature") {
     checkAnswer(
       sql("with q1 as (select * from testData limit 10) select * from q1"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/RowFormatConvertersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/RowFormatConvertersSuite.scala
@@ -38,7 +38,7 @@ class RowFormatConvertersSuite extends SparkPlanTest with SharedSQLContext {
   private val outputsUnsafe = Sort(Nil, false, PhysicalRDD(Seq.empty, null, "name"))
   assert(outputsUnsafe.outputsUnsafeRows)
 
-  test("planner should insert unsafe->safe conversions when required") {
+  ignore("planner should insert unsafe->safe conversions when required") {
     val plan = Limit(10, outputsUnsafe)
     val preparedPlan = sqlContext.prepareForExecution.execute(plan)
     assert(preparedPlan.children.head.isInstanceOf[ConvertToSafe])

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/RowFormatConvertersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/RowFormatConvertersSuite.scala
@@ -26,6 +26,15 @@ import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types.{ArrayType, StringType}
 import org.apache.spark.unsafe.types.UTF8String
 
+case class DummySafeNode(limit: Int, child: SparkPlan) extends UnaryNode {
+  override def output: Seq[Attribute] = child.output
+  override def canProcessUnsafeRows: Boolean = false
+  override def canProcessSafeRows: Boolean = true
+
+  override def executeCollect(): Array[InternalRow] = child.executeTake(limit)
+  protected override def doExecute(): RDD[InternalRow] = child.execute()
+}
+
 class RowFormatConvertersSuite extends SparkPlanTest with SharedSQLContext {
 
   private def getConverters(plan: SparkPlan): Seq[SparkPlan] = plan.collect {
@@ -38,8 +47,8 @@ class RowFormatConvertersSuite extends SparkPlanTest with SharedSQLContext {
   private val outputsUnsafe = Sort(Nil, false, PhysicalRDD(Seq.empty, null, "name"))
   assert(outputsUnsafe.outputsUnsafeRows)
 
-  ignore("planner should insert unsafe->safe conversions when required") {
-    val plan = Limit(10, outputsUnsafe)
+  test("planner should insert unsafe->safe conversions when required") {
+    val plan = DummySafeNode(10, outputsUnsafe)
     val preparedPlan = sqlContext.prepareForExecution.execute(plan)
     assert(preparedPlan.children.head.isInstanceOf[ConvertToSafe])
   }


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-12289

This change is needed for #10283. Without this, JavaDataFrameSuite will be failed when we support UnsafeRow in LocalTableScan.

Support in Limit is added first. TakeOrderedAndProject will be added later.
