### PR TITLE
[Minor] Add missing interpolation in NettyRPCEnv

### DIFF
--- a/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
@@ -232,7 +232,7 @@ private[netty] class NettyRpcEnv(
     val timeoutCancelable = timeoutScheduler.schedule(new Runnable {
       override def run(): Unit = {
         promise.tryFailure(
-          new TimeoutException("Cannot receive any reply in ${timeout.duration}"))
+          new TimeoutException(s"Cannot receive any reply in ${timeout.duration}"))
       }
     }, timeout.duration.toNanos, TimeUnit.NANOSECONDS)
     promise.future.onComplete { v =>


### PR DESCRIPTION
```
Exception in thread "main" org.apache.spark.rpc.RpcTimeoutException:
Cannot receive any reply in ${timeout.duration}. This timeout is controlled by spark.rpc.askTimeout
    at org.apache.spark.rpc.RpcTimeout.org$apache$spark$rpc$RpcTimeout$$createRpcTimeoutException(RpcTimeout.scala:48)
    at org.apache.spark.rpc.RpcTimeout$$anonfun$addMessageIfTimeout$1.applyOrElse(RpcTimeout.scala:63)
    at org.apache.spark.rpc.RpcTimeout$$anonfun$addMessageIfTimeout$1.applyOrElse(RpcTimeout.scala:59)
    at scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:33)
```
