### PR TITLE
[SPARK-12376][TESTS] Spark Streaming Java8APISuite fails in assertOrderInvariantEquals method

### DIFF
--- a/extras/java8-tests/src/test/java/org/apache/spark/streaming/Java8APISuite.java
+++ b/extras/java8-tests/src/test/java/org/apache/spark/streaming/Java8APISuite.java
@@ -25,6 +25,7 @@ import scala.Tuple2;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.google.common.collect.Ordering;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -440,8 +441,13 @@ public class Java8APISuite extends LocalJavaStreamingContext implements Serializ
   public static <T extends Comparable<T>> void assertOrderInvariantEquals(
     List<List<T>> expected, List<List<T>> actual) {
     expected.forEach((List<T> list) -> Collections.sort(list));
-    actual.forEach((List<T> list) -> Collections.sort(list));
-    Assert.assertEquals(expected, actual);
+    ArrayList<ArrayList<T>> sortedActual = new ArrayList<ArrayList<T>>();
+    actual.forEach((List<T> list) -> {
+        ArrayList<T> sortedList = new ArrayList<T>(list);
+        Collections.sort(sortedList);
+        sortedActual.add(sortedList);
+    });
+    Assert.assertEquals(expected, sortedActual);
   }
 
   @Test

--- a/extras/java8-tests/src/test/java/org/apache/spark/streaming/Java8APISuite.java
+++ b/extras/java8-tests/src/test/java/org/apache/spark/streaming/Java8APISuite.java
@@ -25,7 +25,6 @@ import scala.Tuple2;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import com.google.common.collect.Ordering;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -440,9 +439,9 @@ public class Java8APISuite extends LocalJavaStreamingContext implements Serializ
    */
   public static <T extends Comparable<T>> void assertOrderInvariantEquals(
     List<List<T>> expected, List<List<T>> actual) {
-    expected.forEach((List<T> list) -> Collections.sort(list));
+    expected.forEach(list -> Collections.sort(list));
     List<List<T>> sortedActual = new ArrayList<>();
-    actual.forEach((List<T> list) -> {
+    actual.forEach(list -> {
         List<T> sortedList = new ArrayList<>(list);
         Collections.sort(sortedList);
         sortedActual.add(sortedList);

--- a/extras/java8-tests/src/test/java/org/apache/spark/streaming/Java8APISuite.java
+++ b/extras/java8-tests/src/test/java/org/apache/spark/streaming/Java8APISuite.java
@@ -441,9 +441,9 @@ public class Java8APISuite extends LocalJavaStreamingContext implements Serializ
   public static <T extends Comparable<T>> void assertOrderInvariantEquals(
     List<List<T>> expected, List<List<T>> actual) {
     expected.forEach((List<T> list) -> Collections.sort(list));
-    ArrayList<ArrayList<T>> sortedActual = new ArrayList<ArrayList<T>>();
+    List<List<T>> sortedActual = new ArrayList<>();
     actual.forEach((List<T> list) -> {
-        ArrayList<T> sortedList = new ArrayList<T>(list);
+        List<T> sortedList = new ArrayList<>(list);
         Collections.sort(sortedList);
         sortedActual.add(sortedList);
     });


### PR DESCRIPTION
org.apache.spark.streaming.Java8APISuite.java is failing due to trying to sort immutable list in assertOrderInvariantEquals method.
