### PR TITLE
[SPARK-12387][SQL]JDBC IN operator push down

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -269,6 +269,13 @@ private[sql] class JDBCRDD(
     case stringValue: String => s"'${escapeSql(stringValue)}'"
     case timestampValue: Timestamp => "'" + timestampValue + "'"
     case dateValue: Date => "'" + dateValue + "'"
+    case objectValue: Array[Object] => {
+      val str = objectValue.map {
+        case string: String => "'" + string + "'"
+        case other => other.toString
+      }
+      str.mkString(",")
+    }
     case _ => value
   }
 
@@ -288,6 +295,8 @@ private[sql] class JDBCRDD(
     case GreaterThanOrEqual(attr, value) => s"$attr >= ${compileValue(value)}"
     case IsNull(attr) => s"$attr IS NULL"
     case IsNotNull(attr) => s"$attr IS NOT NULL"
+    case In(attr, value) => s"$attr IN (${compileValue(value)})"
+    case Not(In(attr, value)) => s"$attr NOT IN (${compileValue(value)})"
     case _ => null
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -184,6 +184,10 @@ class JDBCSuite extends SparkFunSuite with BeforeAndAfter with SharedSQLContext 
     assert(stripSparkFilter(sql("SELECT * FROM foobar WHERE NAME != 'fred'")).collect().size == 2)
     assert(stripSparkFilter(sql("SELECT * FROM nulltypes WHERE A IS NULL")).collect().size == 1)
     assert(stripSparkFilter(sql("SELECT * FROM nulltypes WHERE A IS NOT NULL")).collect().size == 0)
+    assert(stripSparkFilter(sql("SELECT * FROM foobar WHERE NAME IN ('mary', 'fred')")).collect().size === 2)
+    assert(stripSparkFilter(sql("SELECT * FROM foobar WHERE NAME NOT IN ('mary', 'fred')")).collect().size === 1)
+    assert(stripSparkFilter(sql("SELECT * FROM foobar WHERE THEID IN (1,3)")).collect().size === 2)
+    assert(stripSparkFilter(sql("SELECT * FROM foobar WHERE THEID NOT IN (1,3)")).collect().size === 1)
   }
 
   test("SELECT * WHERE (quoted strings)") {


### PR DESCRIPTION
Will push down SQL  IN operator such as the following to JDBC datasource

SELECT column_name(s)
FROM table_name
WHERE column_name IN (value1,value2,...)
