### PR TITLE
[SPARK-7425] [ML] spark.ml Predictor should support other numeric types for label

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
@@ -26,7 +26,7 @@ import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types.{DataType, DoubleType, StructType}
+import org.apache.spark.sql.types.{DataType, DoubleType, NumericType, StructType}
 
 /**
  * (private[ml])  Trait for parameters for prediction (regression and classification).
@@ -36,7 +36,8 @@ private[ml] trait PredictorParams extends Params
 
   /**
    * Validates and transforms the input schema with the provided param map.
-   * @param schema input schema
+    *
+    * @param schema input schema
    * @param fitting whether this is in fitting
    * @param featuresDataType  SQL DataType for FeaturesType.
    *                          E.g., [[org.apache.spark.mllib.linalg.VectorUDT]] for vector features.
@@ -49,8 +50,9 @@ private[ml] trait PredictorParams extends Params
     // TODO: Support casting Array[Double] and Array[Float] to Vector when FeaturesType = Vector
     SchemaUtils.checkColumnType(schema, $(featuresCol), featuresDataType)
     if (fitting) {
-      // TODO: Allow other numeric types
-      SchemaUtils.checkColumnType(schema, $(labelCol), DoubleType)
+      val actualDataType = schema($(labelCol)).dataType
+      require(actualDataType.isInstanceOf[NumericType],
+        s"Column $labelCol must be of type NumericType but was actually $actualDataType")
     }
     SchemaUtils.appendColumn(schema, $(predictionCol), DoubleType)
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
@@ -52,8 +52,8 @@ private[ml] trait PredictorParams extends Params
     if (fitting) {
       val actualDataType = schema($(labelCol)).dataType
       val labelColName = $(labelCol)
-      require(actualDataType.isInstanceOf[NumericType],
-        s"Column $labelColName must be of type NumericType but was actually of type $actualDataType")
+      require(actualDataType.isInstanceOf[NumericType], s"Column $labelColName must be of type " +
+        "NumericType but was actually of type $actualDataType")
     }
     SchemaUtils.appendColumn(schema, $(predictionCol), DoubleType)
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
@@ -124,8 +124,10 @@ abstract class Predictor[
    */
   protected def extractLabeledPoints(dataset: DataFrame): RDD[LabeledPoint] = {
     dataset.select($(labelCol), $(featuresCol)).rdd.map {
-      case Row(label: Double, features: Vector) =>
-        LabeledPoint(label, features)
+      case Row(label: Double, features: Vector) => LabeledPoint(label, features)
+      case Row(label: Float, features: Vector) => LabeledPoint(label, features)
+      case Row(label: Long, features: Vector) => LabeledPoint(label, features)
+      case Row(label: Int, features: Vector) => LabeledPoint(label, features)
     }
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
@@ -36,8 +36,8 @@ private[ml] trait PredictorParams extends Params
 
   /**
    * Validates and transforms the input schema with the provided param map.
-    *
-    * @param schema input schema
+   *
+   * @param schema input schema
    * @param fitting whether this is in fitting
    * @param featuresDataType  SQL DataType for FeaturesType.
    *                          E.g., [[org.apache.spark.mllib.linalg.VectorUDT]] for vector features.

--- a/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
@@ -53,7 +53,7 @@ private[ml] trait PredictorParams extends Params
       val actualDataType = schema($(labelCol)).dataType
       val labelColName = $(labelCol)
       require(actualDataType.isInstanceOf[NumericType], s"Column $labelColName must be of type " +
-        "NumericType but was actually of type $actualDataType")
+        s"NumericType but was actually of type $actualDataType")
     }
     SchemaUtils.appendColumn(schema, $(predictionCol), DoubleType)
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
@@ -51,8 +51,9 @@ private[ml] trait PredictorParams extends Params
     SchemaUtils.checkColumnType(schema, $(featuresCol), featuresDataType)
     if (fitting) {
       val actualDataType = schema($(labelCol)).dataType
+      val labelColName = $(labelCol)
       require(actualDataType.isInstanceOf[NumericType],
-        s"Column $labelCol must be of type NumericType but was actually $actualDataType")
+        s"Column $labelColName must be of type NumericType but was actually of type $actualDataType")
     }
     SchemaUtils.appendColumn(schema, $(predictionCol), DoubleType)
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
@@ -49,7 +49,9 @@ private[ml] trait PredictorParams extends Params
       featuresDataType: DataType): StructType = {
     // TODO: Support casting Array[Double] and Array[Float] to Vector when FeaturesType = Vector
     SchemaUtils.checkColumnType(schema, $(featuresCol), featuresDataType)
-    if (fitting) SchemaUtils.checkNumericType(schema, $(labelCol))
+    if (fitting) {
+      SchemaUtils.checkNumericType(schema, $(labelCol))
+    }
     SchemaUtils.appendColumn(schema, $(predictionCol), DoubleType)
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
@@ -123,11 +123,8 @@ abstract class Predictor[
    * and put it in an RDD with strong types.
    */
   protected def extractLabeledPoints(dataset: DataFrame): RDD[LabeledPoint] = {
-    dataset.select($(labelCol), $(featuresCol)).rdd.map {
+    dataset.select(col($(labelCol)).cast(DoubleType), col($(featuresCol))).rdd.map {
       case Row(label: Double, features: Vector) => LabeledPoint(label, features)
-      case Row(label: Float, features: Vector) => LabeledPoint(label, features)
-      case Row(label: Long, features: Vector) => LabeledPoint(label, features)
-      case Row(label: Int, features: Vector) => LabeledPoint(label, features)
     }
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
@@ -49,12 +49,7 @@ private[ml] trait PredictorParams extends Params
       featuresDataType: DataType): StructType = {
     // TODO: Support casting Array[Double] and Array[Float] to Vector when FeaturesType = Vector
     SchemaUtils.checkColumnType(schema, $(featuresCol), featuresDataType)
-    if (fitting) {
-      val actualDataType = schema($(labelCol)).dataType
-      val labelColName = $(labelCol)
-      require(actualDataType.isInstanceOf[NumericType], s"Column $labelColName must be of type " +
-        s"NumericType but was actually of type $actualDataType")
-    }
+    if (fitting) SchemaUtils.checkNumericType(schema, $(labelCol))
     SchemaUtils.appendColumn(schema, $(predictionCol), DoubleType)
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/Predictor.scala
@@ -26,7 +26,7 @@ import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types.{DataType, DoubleType, NumericType, StructType}
+import org.apache.spark.sql.types.{DataType, DoubleType, StructType}
 
 /**
  * (private[ml])  Trait for parameters for prediction (regression and classification).

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.ml.classification
 
-import org.apache.spark.sql.types.DoubleType
-
 import scala.collection.mutable
 
 import breeze.linalg.{DenseVector => BDV}
@@ -40,6 +38,7 @@ import org.apache.spark.mllib.util.MLUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.functions.{col, lit}
+import org.apache.spark.sql.types.DoubleType
 import org.apache.spark.storage.StorageLevel
 
 /**

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.ml.classification
 
+import org.apache.spark.sql.types.DoubleType
+
 import scala.collection.mutable
 
 import breeze.linalg.{DenseVector => BDV}
@@ -265,7 +267,7 @@ class LogisticRegression @Since("1.2.0") (
       LogisticRegressionModel = {
     val w = if ($(weightCol).isEmpty) lit(1.0) else col($(weightCol))
     val instances: RDD[Instance] =
-      dataset.select(col($(labelCol)), w, col($(featuresCol))).rdd.map {
+      dataset.select(col($(labelCol)).cast(DoubleType), w, col($(featuresCol))).rdd.map {
         case Row(label: Double, weight: Double, features: Vector) =>
           Instance(label, weight, features)
       }
@@ -361,7 +363,7 @@ class LogisticRegression @Since("1.2.0") (
         if (optInitialModel.isDefined && optInitialModel.get.coefficients.size != numFeatures) {
           val vec = optInitialModel.get.coefficients
           logWarning(
-            s"Initial coefficients provided ${vec} did not match the expected size ${numFeatures}")
+            s"Initial coefficients provided $vec did not match the expected size $numFeatures")
         }
 
         if (optInitialModel.isDefined && optInitialModel.get.coefficients.size == numFeatures) {
@@ -522,7 +524,7 @@ class LogisticRegressionModel private[spark] (
       (LogisticRegressionModel, String) = {
     $(probabilityCol) match {
       case "" =>
-        val probabilityColName = "probability_" + java.util.UUID.randomUUID.toString()
+        val probabilityColName = "probability_" + java.util.UUID.randomUUID.toString
         (copy(ParamMap.empty).setProbabilityCol(probabilityColName), probabilityColName)
       case p => (this, p)
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
@@ -295,6 +295,8 @@ final class OneVsRest @Since("1.4.0") (
 
   @Since("1.4.0")
   override def fit(dataset: DataFrame): OneVsRestModel = {
+    transformSchema(dataset.schema)
+    
     // determine number of classes either from metadata if provided, or via computation.
     val labelSchema = dataset.schema($(labelCol))
     val computeNumClasses: () => Int = () => {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
@@ -296,7 +296,7 @@ final class OneVsRest @Since("1.4.0") (
   @Since("1.4.0")
   override def fit(dataset: DataFrame): OneVsRestModel = {
     transformSchema(dataset.schema)
-    
+  
     // determine number of classes either from metadata if provided, or via computation.
     val labelSchema = dataset.schema($(labelCol))
     val computeNumClasses: () => Int = () => {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
@@ -296,7 +296,7 @@ final class OneVsRest @Since("1.4.0") (
   @Since("1.4.0")
   override def fit(dataset: DataFrame): OneVsRestModel = {
     transformSchema(dataset.schema)
-  
+
     // determine number of classes either from metadata if provided, or via computation.
     val labelSchema = dataset.schema($(labelCol))
     val computeNumClasses: () => Int = () => {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/OneVsRest.scala
@@ -298,7 +298,7 @@ final class OneVsRest @Since("1.4.0") (
     // determine number of classes either from metadata if provided, or via computation.
     val labelSchema = dataset.schema($(labelCol))
     val computeNumClasses: () => Int = () => {
-      val Row(maxLabelIndex: Double) = dataset.agg(max($(labelCol))).head()
+      val Row(maxLabelIndex: Double) = dataset.agg(max(col($(labelCol)).cast(DoubleType))).head()
       // classes are assumed to be numbered from 0,...,maxLabelIndex
       maxLabelIndex.toInt + 1
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
@@ -48,8 +48,7 @@ private[regression] trait AFTSurvivalRegressionParams extends Params
    * Param for censor column name.
    * The value of this column could be 0 or 1.
    * If the value is 1, it means the event has occurred i.e. uncensored; otherwise censored.
-    *
-    * @group param
+   * @group param
    */
   @Since("1.6.0")
   final val censorCol: Param[String] = new Param(this, "censorCol", "censor column name")
@@ -63,8 +62,7 @@ private[regression] trait AFTSurvivalRegressionParams extends Params
    * Param for quantile probabilities array.
    * Values of the quantile probabilities array should be in the range (0, 1)
    * and the array should be non-empty.
-    *
-    * @group param
+   * @group param
    */
   @Since("1.6.0")
   final val quantileProbabilities: DoubleArrayParam = new DoubleArrayParam(this,
@@ -79,8 +77,7 @@ private[regression] trait AFTSurvivalRegressionParams extends Params
   /**
    * Param for quantiles column name.
    * This column will output quantiles of corresponding quantileProbabilities if it is set.
-    *
-    * @group param
+   * @group param
    */
   @Since("1.6.0")
   final val quantilesCol: Param[String] = new Param(this, "quantilesCol", "quantiles column name")
@@ -96,8 +93,7 @@ private[regression] trait AFTSurvivalRegressionParams extends Params
 
   /**
    * Validates and transforms the input schema with the provided param map.
-    *
-    * @param schema input schema
+   * @param schema input schema
    * @param fitting whether this is in fitting or prediction
    * @return output schema
    */
@@ -158,8 +154,7 @@ class AFTSurvivalRegression @Since("1.6.0") (@Since("1.6.0") override val uid: S
   /**
    * Set if we should fit the intercept
    * Default is true.
-    *
-    * @group setParam
+   * @group setParam
    */
   @Since("1.6.0")
   def setFitIntercept(value: Boolean): this.type = set(fitIntercept, value)
@@ -168,8 +163,7 @@ class AFTSurvivalRegression @Since("1.6.0") (@Since("1.6.0") override val uid: S
   /**
    * Set the maximum number of iterations.
    * Default is 100.
-    *
-    * @group setParam
+   * @group setParam
    */
   @Since("1.6.0")
   def setMaxIter(value: Int): this.type = set(maxIter, value)
@@ -179,8 +173,7 @@ class AFTSurvivalRegression @Since("1.6.0") (@Since("1.6.0") override val uid: S
    * Set the convergence tolerance of iterations.
    * Smaller value will lead to higher accuracy with the cost of more iterations.
    * Default is 1E-6.
-    *
-    * @group setParam
+   * @group setParam
    */
   @Since("1.6.0")
   def setTol(value: Double): this.type = set(tol, value)
@@ -438,8 +431,7 @@ object AFTSurvivalRegressionModel extends MLReadable[AFTSurvivalRegressionModel]
  *   \frac{\partial (-\iota)}{\partial (\log\sigma)}=
  *   \sum_{i=1}^{n}[\delta_{i}+(\delta_{i}-e^{\epsilon_{i}})\epsilon_{i}]
  * }}}
-  *
-  * @param parameters including three part: The log of scale parameter, the intercept and
+ * @param parameters including three part: The log of scale parameter, the intercept and
  *                regression coefficients corresponding to the features.
  * @param fitIntercept Whether to fit an intercept term.
  */

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
@@ -48,7 +48,8 @@ private[regression] trait AFTSurvivalRegressionParams extends Params
    * Param for censor column name.
    * The value of this column could be 0 or 1.
    * If the value is 1, it means the event has occurred i.e. uncensored; otherwise censored.
-   * @group param
+    *
+    * @group param
    */
   @Since("1.6.0")
   final val censorCol: Param[String] = new Param(this, "censorCol", "censor column name")
@@ -62,7 +63,8 @@ private[regression] trait AFTSurvivalRegressionParams extends Params
    * Param for quantile probabilities array.
    * Values of the quantile probabilities array should be in the range (0, 1)
    * and the array should be non-empty.
-   * @group param
+    *
+    * @group param
    */
   @Since("1.6.0")
   final val quantileProbabilities: DoubleArrayParam = new DoubleArrayParam(this,
@@ -77,7 +79,8 @@ private[regression] trait AFTSurvivalRegressionParams extends Params
   /**
    * Param for quantiles column name.
    * This column will output quantiles of corresponding quantileProbabilities if it is set.
-   * @group param
+    *
+    * @group param
    */
   @Since("1.6.0")
   final val quantilesCol: Param[String] = new Param(this, "quantilesCol", "quantiles column name")
@@ -93,7 +96,8 @@ private[regression] trait AFTSurvivalRegressionParams extends Params
 
   /**
    * Validates and transforms the input schema with the provided param map.
-   * @param schema input schema
+    *
+    * @param schema input schema
    * @param fitting whether this is in fitting or prediction
    * @return output schema
    */
@@ -154,7 +158,8 @@ class AFTSurvivalRegression @Since("1.6.0") (@Since("1.6.0") override val uid: S
   /**
    * Set if we should fit the intercept
    * Default is true.
-   * @group setParam
+    *
+    * @group setParam
    */
   @Since("1.6.0")
   def setFitIntercept(value: Boolean): this.type = set(fitIntercept, value)
@@ -163,7 +168,8 @@ class AFTSurvivalRegression @Since("1.6.0") (@Since("1.6.0") override val uid: S
   /**
    * Set the maximum number of iterations.
    * Default is 100.
-   * @group setParam
+    *
+    * @group setParam
    */
   @Since("1.6.0")
   def setMaxIter(value: Int): this.type = set(maxIter, value)
@@ -173,7 +179,8 @@ class AFTSurvivalRegression @Since("1.6.0") (@Since("1.6.0") override val uid: S
    * Set the convergence tolerance of iterations.
    * Smaller value will lead to higher accuracy with the cost of more iterations.
    * Default is 1E-6.
-   * @group setParam
+    *
+    * @group setParam
    */
   @Since("1.6.0")
   def setTol(value: Double): this.type = set(tol, value)
@@ -183,12 +190,13 @@ class AFTSurvivalRegression @Since("1.6.0") (@Since("1.6.0") override val uid: S
    * Extract [[featuresCol]], [[labelCol]] and [[censorCol]] from input dataset,
    * and put it in an RDD with strong types.
    */
-  protected[ml] def extractAFTPoints(dataset: DataFrame): RDD[AFTPoint] =
+  protected[ml] def extractAFTPoints(dataset: DataFrame): RDD[AFTPoint] = {
     dataset.select(col($(featuresCol)), col($(labelCol)).cast(DoubleType), col($(censorCol)))
       .rdd.map {
         case Row(features: Vector, label: Double, censor: Double) =>
           AFTPoint(features, label, censor)
       }
+  }
 
   @Since("1.6.0")
   override def fit(dataset: DataFrame): AFTSurvivalRegressionModel = {
@@ -430,7 +438,8 @@ object AFTSurvivalRegressionModel extends MLReadable[AFTSurvivalRegressionModel]
  *   \frac{\partial (-\iota)}{\partial (\log\sigma)}=
  *   \sum_{i=1}^{n}[\delta_{i}+(\delta_{i}-e^{\epsilon_{i}})\epsilon_{i}]
  * }}}
- * @param parameters including three part: The log of scale parameter, the intercept and
+  *
+  * @param parameters including three part: The log of scale parameter, the intercept and
  *                regression coefficients corresponding to the features.
  * @param fitIntercept Whether to fit an intercept term.
  */

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/AFTSurvivalRegression.scala
@@ -103,7 +103,7 @@ private[regression] trait AFTSurvivalRegressionParams extends Params
     SchemaUtils.checkColumnType(schema, $(featuresCol), new VectorUDT)
     if (fitting) {
       SchemaUtils.checkColumnType(schema, $(censorCol), DoubleType)
-      SchemaUtils.checkColumnType(schema, $(labelCol), DoubleType)
+      SchemaUtils.checkNumericType(schema, $(labelCol))
     }
     if (hasQuantilesCol) {
       SchemaUtils.appendColumn(schema, $(quantilesCol), new VectorUDT)
@@ -183,12 +183,12 @@ class AFTSurvivalRegression @Since("1.6.0") (@Since("1.6.0") override val uid: S
    * Extract [[featuresCol]], [[labelCol]] and [[censorCol]] from input dataset,
    * and put it in an RDD with strong types.
    */
-  protected[ml] def extractAFTPoints(dataset: DataFrame): RDD[AFTPoint] = {
-    dataset.select($(featuresCol), $(labelCol), $(censorCol)).rdd.map {
-      case Row(features: Vector, label: Double, censor: Double) =>
-        AFTPoint(features, label, censor)
-    }
-  }
+  protected[ml] def extractAFTPoints(dataset: DataFrame): RDD[AFTPoint] =
+    dataset.select(col($(featuresCol)), col($(labelCol)).cast(DoubleType), col($(censorCol)))
+      .rdd.map {
+        case Row(features: Vector, label: Double, censor: Double) =>
+          AFTPoint(features, label, censor)
+      }
 
   @Since("1.6.0")
   override def fit(dataset: DataFrame): AFTSurvivalRegressionModel = {

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -125,7 +125,6 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
   /**
    * Sets the value of param [[family]].
    * Default is "gaussian".
-   *
    * @group setParam
    */
   @Since("2.0.0")
@@ -134,7 +133,6 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
 
   /**
    * Sets the value of param [[link]].
-   *
    * @group setParam
    */
   @Since("2.0.0")
@@ -143,7 +141,6 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
   /**
    * Sets if we should fit the intercept.
    * Default is true.
-   *
    * @group setParam
    */
   @Since("2.0.0")
@@ -152,7 +149,6 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
   /**
    * Sets the maximum number of iterations.
    * Default is 25 if the solver algorithm is "irls".
-   *
    * @group setParam
    */
   @Since("2.0.0")
@@ -162,7 +158,6 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
    * Sets the convergence tolerance of iterations.
    * Smaller value will lead to higher accuracy with the cost of more iterations.
    * Default is 1E-6.
-   *
    * @group setParam
    */
   @Since("2.0.0")
@@ -172,7 +167,6 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
   /**
    * Sets the regularization parameter.
    * Default is 0.0.
-   *
    * @group setParam
    */
   @Since("2.0.0")
@@ -183,7 +177,6 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
    * Sets the value of param [[weightCol]].
    * If this is not set or empty, we treat all instance weights as 1.0.
    * Default is empty, so all instances have weight one.
-   *
    * @group setParam
    */
   @Since("2.0.0")
@@ -193,7 +186,6 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
   /**
    * Sets the solver algorithm used for optimization.
    * Currently only support "irls" which is also the default solver.
-   *
    * @group setParam
    */
   @Since("2.0.0")
@@ -339,7 +331,6 @@ object GeneralizedLinearRegression extends DefaultParamsReadable[GeneralizedLine
 
   /**
    * A description of the error distribution to be used in the model.
-   *
    * @param name the name of the family.
    */
   private[ml] abstract class Family(val name: String) extends Serializable {
@@ -377,7 +368,6 @@ object GeneralizedLinearRegression extends DefaultParamsReadable[GeneralizedLine
 
     /**
      * Gets the [[Family]] object from its name.
-     *
      * @param name family name: "gaussian", "binomial", "poisson" or "gamma".
      */
     def fromName(name: String): Family = {
@@ -557,7 +547,6 @@ object GeneralizedLinearRegression extends DefaultParamsReadable[GeneralizedLine
    * A description of the link function to be used in the model.
    * The link function provides the relationship between the linear predictor
    * and the mean of the distribution function.
-   *
    * @param name the name of link function.
    */
   private[ml] abstract class Link(val name: String) extends Serializable {
@@ -576,7 +565,6 @@ object GeneralizedLinearRegression extends DefaultParamsReadable[GeneralizedLine
 
     /**
      * Gets the [[Link]] object from its name.
-     *
      * @param name link name: "identity", "logit", "log",
      *             "inverse", "probit", "cloglog" or "sqrt".
      */

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -47,7 +47,7 @@ private[regression] trait GeneralizedLinearRegressionBase extends PredictorParam
    * to be used in the model.
    * Supported options: "gaussian", "binomial", "poisson" and "gamma".
    * Default is "gaussian".
- *
+   *
    * @group param
    */
   @Since("2.0.0")
@@ -64,7 +64,7 @@ private[regression] trait GeneralizedLinearRegressionBase extends PredictorParam
    * Param for the name of link function which provides the relationship
    * between the linear predictor and the mean of the distribution function.
    * Supported options: "identity", "log", "inverse", "logit", "probit", "cloglog" and "sqrt".
- *
+   *
    * @group param
    */
   @Since("2.0.0")
@@ -125,7 +125,7 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
   /**
    * Sets the value of param [[family]].
    * Default is "gaussian".
- *
+   *
    * @group setParam
    */
   @Since("2.0.0")
@@ -134,7 +134,7 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
 
   /**
    * Sets the value of param [[link]].
- *
+   *
    * @group setParam
    */
   @Since("2.0.0")
@@ -143,7 +143,7 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
   /**
    * Sets if we should fit the intercept.
    * Default is true.
- *
+   *
    * @group setParam
    */
   @Since("2.0.0")
@@ -152,7 +152,7 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
   /**
    * Sets the maximum number of iterations.
    * Default is 25 if the solver algorithm is "irls".
- *
+   *
    * @group setParam
    */
   @Since("2.0.0")
@@ -162,7 +162,7 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
    * Sets the convergence tolerance of iterations.
    * Smaller value will lead to higher accuracy with the cost of more iterations.
    * Default is 1E-6.
- *
+   *
    * @group setParam
    */
   @Since("2.0.0")
@@ -172,7 +172,7 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
   /**
    * Sets the regularization parameter.
    * Default is 0.0.
- *
+   *
    * @group setParam
    */
   @Since("2.0.0")
@@ -183,7 +183,7 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
    * Sets the value of param [[weightCol]].
    * If this is not set or empty, we treat all instance weights as 1.0.
    * Default is empty, so all instances have weight one.
- *
+   *
    * @group setParam
    */
   @Since("2.0.0")
@@ -193,7 +193,7 @@ class GeneralizedLinearRegression @Since("2.0.0") (@Since("2.0.0") override val 
   /**
    * Sets the solver algorithm used for optimization.
    * Currently only support "irls" which is also the default solver.
- *
+   *
    * @group setParam
    */
   @Since("2.0.0")
@@ -339,7 +339,7 @@ object GeneralizedLinearRegression extends DefaultParamsReadable[GeneralizedLine
 
   /**
    * A description of the error distribution to be used in the model.
- *
+   *
    * @param name the name of the family.
    */
   private[ml] abstract class Family(val name: String) extends Serializable {
@@ -377,7 +377,7 @@ object GeneralizedLinearRegression extends DefaultParamsReadable[GeneralizedLine
 
     /**
      * Gets the [[Family]] object from its name.
- *
+     *
      * @param name family name: "gaussian", "binomial", "poisson" or "gamma".
      */
     def fromName(name: String): Family = {
@@ -557,7 +557,7 @@ object GeneralizedLinearRegression extends DefaultParamsReadable[GeneralizedLine
    * A description of the link function to be used in the model.
    * The link function provides the relationship between the linear predictor
    * and the mean of the distribution function.
- *
+   *
    * @param name the name of link function.
    */
   private[ml] abstract class Link(val name: String) extends Serializable {
@@ -576,7 +576,7 @@ object GeneralizedLinearRegression extends DefaultParamsReadable[GeneralizedLine
 
     /**
      * Gets the [[Link]] object from its name.
- *
+     *
      * @param name link name: "identity", "logit", "log",
      *             "inverse", "probit", "cloglog" or "sqrt".
      */

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/IsotonicRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/IsotonicRegression.scala
@@ -90,7 +90,7 @@ private[regression] trait IsotonicRegressionBase extends Params with HasFeatures
     } else {
       lit(1.0)
     }
-    dataset.select(col($(labelCol)), f, w).rdd.map {
+    dataset.select(col($(labelCol)).cast(DoubleType), f, w).rdd.map {
       case Row(label: Double, feature: Double, weight: Double) =>
         (label, feature, weight)
     }
@@ -106,7 +106,7 @@ private[regression] trait IsotonicRegressionBase extends Params with HasFeatures
       schema: StructType,
       fitting: Boolean): StructType = {
     if (fitting) {
-      SchemaUtils.checkColumnType(schema, $(labelCol), DoubleType)
+      SchemaUtils.checkNumericType(schema, $(labelCol))
       if (hasWeightCol) {
         SchemaUtils.checkColumnType(schema, $(weightCol), DoubleType)
       } else {

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.ml.regression
 
-import org.apache.spark.sql.types.DoubleType
-
 import scala.collection.mutable
 
 import breeze.linalg.{DenseVector => BDV}
@@ -42,6 +40,7 @@ import org.apache.spark.mllib.stat.MultivariateOnlineSummarizer
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.DoubleType
 import org.apache.spark.storage.StorageLevel
 
 /**

--- a/mllib/src/main/scala/org/apache/spark/ml/util/SchemaUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/SchemaUtils.scala
@@ -44,10 +44,10 @@ private[spark] object SchemaUtils {
   }
 
   /**
-    * Check whether the given schema contains a column of one of the require data types.
-    * @param colName  column name
-    * @param dataTypes  required column data types
-    */
+   * Check whether the given schema contains a column of one of the require data types.
+   * @param colName  column name
+   * @param dataTypes  required column data types
+   */
   def checkColumnTypes(
       schema: StructType,
       colName: String,
@@ -61,9 +61,9 @@ private[spark] object SchemaUtils {
   }
 
   /**
-    * Check whether the given schema contains a column of the numeric data type.
-    * @param colName  column name
-    */
+   * Check whether the given schema contains a column of the numeric data type.
+   * @param colName  column name
+   */
   def checkNumericType(
       schema: StructType,
       colName: String,

--- a/mllib/src/main/scala/org/apache/spark/ml/util/SchemaUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/SchemaUtils.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.ml.util
 
-import org.apache.spark.sql.types.{DataType, StructField, StructType}
+import org.apache.spark.sql.types.{DataType, NumericType, StructField, StructType}
 
 
 /**
@@ -58,6 +58,20 @@ private[spark] object SchemaUtils {
     require(dataTypes.exists(actualDataType.equals),
       s"Column $colName must be of type equal to one of the following types: " +
         s"${dataTypes.mkString("[", ", ", "]")} but was actually of type $actualDataType.$message")
+  }
+
+  /**
+    * Check whether the given schema contains a column of the numeric data type.
+    * @param colName  column name
+    */
+  def checkNumericType(
+      schema: StructType,
+      colName: String,
+      msg: String = ""): Unit = {
+    val actualDataType = schema(colName).dataType
+    val message = if (msg != null && msg.trim.length > 0) " " + msg else ""
+    require(actualDataType.isInstanceOf[NumericType], s"Column $colName must be of type " +
+      s"NumericType but was actually of type $actualDataType.$message")
   }
 
   /**

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -336,10 +336,10 @@ class DecisionTreeClassifierSuite
 
   test("should support all NumericType labels and not support other types") {
     val dt = new DecisionTreeClassifier()
-    MLTestingUtils.checkPredictorAcceptAllNumericTypes[
-        DecisionTreeClassificationModel, DecisionTreeClassifier](
-      dt, sqlContext)((expected, actual) => TreeTests.checkEqual(expected, actual))
-    MLTestingUtils.checkPredictorRejectNotNumericTypes(dt, sqlContext)
+    MLTestingUtils.checkNumericTypes[DecisionTreeClassificationModel, DecisionTreeClassifier](
+      dt, isClassification = true, sqlContext) { (expected, actual) =>
+        TreeTests.checkEqual(expected, actual)
+      }
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -334,7 +334,7 @@ class DecisionTreeClassifierSuite
     assert(importances.toArray.forall(_ >= 0.0))
   }
 
-  test("DecisionTree should support other NumericType labels") {
+  test("DecisionTree should support all NumericType labels") {
     val dfWithIntLabels = TreeTests.setMetadata(sqlContext.createDataFrame(Seq(
       (0, Vectors.dense(0, 2, 3)),
       (1, Vectors.dense(0, 3, 1)),

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -27,8 +27,8 @@ import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.tree.{DecisionTree => OldDecisionTree, DecisionTreeSuite => OldDecisionTreeSuite}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.types.DoubleType
 import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.types.DoubleType
 
 class DecisionTreeClassifierSuite
   extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -27,8 +27,8 @@ import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.tree.{DecisionTree => OldDecisionTree, DecisionTreeSuite => OldDecisionTreeSuite}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.types._
 
 class DecisionTreeClassifierSuite
   extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -335,7 +335,7 @@ class DecisionTreeClassifierSuite
   }
 
   test("should support all NumericType labels and not support other types") {
-    val dt = new DecisionTreeClassifier()
+    val dt = new DecisionTreeClassifier().setMaxDepth(1)
     MLTestingUtils.checkNumericTypes[DecisionTreeClassificationModel, DecisionTreeClassifier](
       dt, isClassification = true, sqlContext) { (expected, actual) =>
         TreeTests.checkEqual(expected, actual)

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -335,8 +335,6 @@ class DecisionTreeClassifierSuite
   }
 
   test("DecisionTree should support other NumericType labels") {
-    val sqlContext = new SQLContext(sc)
-
     val dfWithIntLabels = TreeTests.setMetadata(sqlContext.createDataFrame(Seq(
       (0, Vectors.dense(0, 2, 3)),
       (1, Vectors.dense(0, 3, 1)),

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -352,11 +352,11 @@ class DecisionTreeClassifierSuite
 
     val dt = new DecisionTreeClassifier().setFeaturesCol("features")
 
-    val refModel = dt.setLabelCol(DoubleType.toString)
+    val expected = dt.setLabelCol(DoubleType.toString)
       .fit(TreeTests.setMetadata(dfWithTypes, 2, DoubleType.toString))
     types.filter(_ != DoubleType).foreach { t =>
-      TreeTests.checkEqual(refModel, dt.setLabelCol(t.toString)
-        .fit(TreeTests.setMetadata(dfWithTypes, 2, t.toString)))
+      TreeTests.checkEqual(expected,
+        dt.setLabelCol(t.toString).fit(TreeTests.setMetadata(dfWithTypes, 2, t.toString)))
     }
   }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -28,7 +28,6 @@ import org.apache.spark.mllib.tree.{DecisionTree => OldDecisionTree, DecisionTre
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Row}
-import org.apache.spark.sql.types.DoubleType
 
 class DecisionTreeClassifierSuite
   extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {
@@ -335,32 +334,12 @@ class DecisionTreeClassifierSuite
     assert(importances.toArray.forall(_ >= 0.0))
   }
 
-  test("should support all NumericType labels") {
-    val dfs = MLTestingUtils.genClassifDFWithNumericLabelCol(sqlContext, "label", "features")
-
-    val dt = new DecisionTreeClassifier().setFeaturesCol("features")
-
-    val expected = dt.setLabelCol("label")
-        .fit(TreeTests.setMetadata(dfs(DoubleType), 2, "label"))
-    dfs.keys.filter(_ != DoubleType).foreach { t =>
-      TreeTests.checkEqual(expected,
-        dt.setLabelCol("label").fit(TreeTests.setMetadata(dfs(t), 2, "label")))
-    }
-  }
-
-  test("shouldn't support non NumericType labels") {
-    val dfWithStringLabels = TreeTests.setMetadata(
-      MLTestingUtils.generateDFWithStringLabelCol(sqlContext, "label", "features"), 2, "label")
-
+  test("should support all NumericType labels and not support other types") {
     val dt = new DecisionTreeClassifier()
-      .setLabelCol("label")
-      .setFeaturesCol("features")
-
-    val thrown = intercept[IllegalArgumentException] {
-      dt.fit(dfWithStringLabels)
-    }
-    assert(thrown.getMessage contains
-      "Column label must be of type NumericType but was actually of type StringType")
+    MLTestingUtils.checkPredictorAcceptAllNumericTypes[
+        DecisionTreeClassificationModel, DecisionTreeClassifier](
+      dt, sqlContext)((expected, actual) => TreeTests.checkEqual(expected, actual))
+    MLTestingUtils.checkPredictorRejectNotNumericTypes(dt, sqlContext)
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.tree.{DecisionTree => OldDecisionTree, DecisionTreeSuite => OldDecisionTreeSuite}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{DataFrame, Row, SQLContext}
+import org.apache.spark.sql.{DataFrame, Row}
 
 class DecisionTreeClassifierSuite
   extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -336,38 +336,21 @@ class DecisionTreeClassifierSuite
   }
 
   test("should support all NumericType labels") {
-    val df = sqlContext.createDataFrame(Seq(
-      (0, Vectors.dense(0, 2, 3)),
-      (1, Vectors.dense(0, 3, 1)),
-      (0, Vectors.dense(0, 2, 2)),
-      (1, Vectors.dense(0, 3, 9)),
-      (0, Vectors.dense(0, 2, 6))
-    )).toDF("label", "features")
-
-    val types =
-      Seq(ShortType, LongType, IntegerType, FloatType, ByteType, DoubleType, DecimalType(10, 0))
-
-    var dfWithTypes = df
-    types.foreach(t => dfWithTypes = dfWithTypes.withColumn(t.toString, df("label").cast(t)))
+    val dfs = MLTestingUtils.generateDFWithNumericLabelCol(sqlContext, "label", "features")
 
     val dt = new DecisionTreeClassifier().setFeaturesCol("features")
 
-    val expected = dt.setLabelCol(DoubleType.toString)
-      .fit(TreeTests.setMetadata(dfWithTypes, 2, DoubleType.toString))
-    types.filter(_ != DoubleType).foreach { t =>
+    val expected = dt.setLabelCol("label")
+        .fit(TreeTests.setMetadata(dfs(DoubleType), 2, "label"))
+    dfs.keys.filter(_ != DoubleType).foreach { t =>
       TreeTests.checkEqual(expected,
-        dt.setLabelCol(t.toString).fit(TreeTests.setMetadata(dfWithTypes, 2, t.toString)))
+        dt.setLabelCol("label").fit(TreeTests.setMetadata(dfs(t), 2, "label")))
     }
   }
 
   test("shouldn't support non NumericType labels") {
-    val dfWithStringLabels = TreeTests.setMetadata(sqlContext.createDataFrame(Seq(
-      ("0", Vectors.dense(0, 2, 3)),
-      ("1", Vectors.dense(0, 3, 1)),
-      ("0", Vectors.dense(0, 2, 2)),
-      ("1", Vectors.dense(0, 3, 9)),
-      ("0", Vectors.dense(0, 2, 6))
-    )).toDF("label", "features"), 2, "label")
+    val dfWithStringLabels = TreeTests.setMetadata(
+      MLTestingUtils.generateDFWithStringLabelCol(sqlContext, "label", "features"), 2, "label")
 
     val dt = new DecisionTreeClassifier()
       .setLabelCol("label")

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -350,8 +350,7 @@ class DecisionTreeClassifierSuite
     var dfWithTypes = df
     types.foreach(t => dfWithTypes = dfWithTypes.withColumn(t.toString, df("label").cast(t)))
 
-    val dt = new DecisionTreeClassifier()
-      .setFeaturesCol("features")
+    val dt = new DecisionTreeClassifier().setFeaturesCol("features")
 
     val refModel = dt.setLabelCol(DoubleType.toString)
       .fit(TreeTests.setMetadata(dfWithTypes, 2, DoubleType.toString))

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -336,7 +336,7 @@ class DecisionTreeClassifierSuite
   }
 
   test("should support all NumericType labels") {
-    val dfs = MLTestingUtils.generateDFWithNumericLabelCol(sqlContext, "label", "features")
+    val dfs = MLTestingUtils.genClassifDFWithNumericLabelCol(sqlContext, "label", "features")
 
     val dt = new DecisionTreeClassifier().setFeaturesCol("features")
 

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -27,8 +27,8 @@ import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.tree.{DecisionTree => OldDecisionTree, DecisionTreeSuite => OldDecisionTreeSuite}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.types.DoubleType
 import org.apache.spark.sql.{DataFrame, Row}
-import org.apache.spark.sql.types._
 
 class DecisionTreeClassifierSuite
   extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -334,7 +334,7 @@ class DecisionTreeClassifierSuite
     assert(importances.toArray.forall(_ >= 0.0))
   }
 
-  test("DecisionTree should support all NumericType labels") {
+  test("should support all NumericType labels") {
     val dfWithIntLabels = TreeTests.setMetadata(sqlContext.createDataFrame(Seq(
       (0, Vectors.dense(0, 2, 3)),
       (1, Vectors.dense(0, 3, 1)),
@@ -366,6 +366,26 @@ class DecisionTreeClassifierSuite
     dt.fit(dfWithIntLabels)
     dt.fit(dfWithFloatLabels)
     dt.fit(dfWithLongLabels)
+  }
+
+  test("shouldn't support non NumericType labels") {
+    val dfWithStringLabels = TreeTests.setMetadata(sqlContext.createDataFrame(Seq(
+      ("0", Vectors.dense(0, 2, 3)),
+      ("1", Vectors.dense(0, 3, 1)),
+      ("0", Vectors.dense(0, 2, 2)),
+      ("1", Vectors.dense(0, 3, 9)),
+      ("0", Vectors.dense(0, 2, 6))
+    )).toDF("label", "features"), 2)
+
+    val dt = new DecisionTreeClassifier()
+      .setLabelCol("label")
+      .setFeaturesCol("features")
+
+    val thrown = intercept[IllegalArgumentException] {
+      dt.fit(dfWithStringLabels)
+    }
+    assert(thrown.getMessage contains
+      "Column label must be of type NumericType but was actually of type StringType")
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
@@ -103,9 +103,10 @@ class GBTClassifierSuite extends SparkFunSuite with MLlibTestSparkContext {
 
   test("should support all NumericType labels and not support other types") {
     val gbt = new GBTClassifier()
-    MLTestingUtils.checkPredictorAcceptAllNumericTypes[GBTClassificationModel, GBTClassifier](
-      gbt, sqlContext)((expected, actual) => TreeTests.checkEqual(expected, actual))
-    MLTestingUtils.checkPredictorRejectNotNumericTypes(gbt, sqlContext)
+    MLTestingUtils.checkNumericTypes[GBTClassificationModel, GBTClassifier](
+      gbt, isClassification = true, sqlContext) { (expected, actual) =>
+        TreeTests.checkEqual(expected, actual)
+      }
   }
 
   // TODO: Reinstate test once runWithValidation is implemented   SPARK-7132

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
@@ -29,7 +29,6 @@ import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.types.DoubleType
 import org.apache.spark.util.Utils
 
 /**
@@ -102,32 +101,11 @@ class GBTClassifierSuite extends SparkFunSuite with MLlibTestSparkContext {
     Utils.deleteRecursively(tempDir)
   }
 
-  test("should support all NumericType labels") {
-    val dfs = MLTestingUtils.genClassifDFWithNumericLabelCol(sqlContext, "label", "features")
-
-    val gbt = new GBTClassifier().setFeaturesCol("features")
-
-    val expected = gbt.setLabelCol("label")
-      .fit(TreeTests.setMetadata(dfs(DoubleType), 2, "label"))
-    dfs.keys.filter(_ != DoubleType).foreach { t =>
-      TreeTests.checkEqual(expected,
-        gbt.setLabelCol("label").fit(TreeTests.setMetadata(dfs(t), 2, "label")))
-    }
-  }
-
-  test("shouldn't support non NumericType labels") {
-    val dfWithStringLabels = TreeTests.setMetadata(
-      MLTestingUtils.generateDFWithStringLabelCol(sqlContext, "label", "features"), 2, "label")
-
+  test("should support all NumericType labels and not support other types") {
     val gbt = new GBTClassifier()
-      .setLabelCol("label")
-      .setFeaturesCol("features")
-
-    val thrown = intercept[IllegalArgumentException] {
-      gbt.fit(dfWithStringLabels)
-    }
-    assert(thrown.getMessage contains
-      "Column label must be of type NumericType but was actually of type StringType")
+    MLTestingUtils.checkPredictorAcceptAllNumericTypes[GBTClassificationModel, GBTClassifier](
+      gbt, sqlContext)((expected, actual) => TreeTests.checkEqual(expected, actual))
+    MLTestingUtils.checkPredictorRejectNotNumericTypes(gbt, sqlContext)
   }
 
   // TODO: Reinstate test once runWithValidation is implemented   SPARK-7132

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
@@ -119,8 +119,7 @@ class GBTClassifierSuite extends SparkFunSuite with MLlibTestSparkContext {
     var dfWithTypes = df
     types.foreach(t => dfWithTypes = dfWithTypes.withColumn(t.toString, df("label").cast(t)))
 
-    val gbt = new GBTClassifier()
-      .setFeaturesCol("features")
+    val gbt = new GBTClassifier().setFeaturesCol("features")
 
     val refModel = gbt.setLabelCol(DoubleType.toString)
       .fit(TreeTests.setMetadata(dfWithTypes, 2, DoubleType.toString))

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
@@ -23,16 +23,14 @@ import org.apache.spark.ml.regression.DecisionTreeRegressionModel
 import org.apache.spark.ml.tree.LeafNode
 import org.apache.spark.ml.tree.impl.TreeTests
 import org.apache.spark.ml.util.MLTestingUtils
-import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.tree.{EnsembleTestHelper, GradientBoostedTrees => OldGBT}
 import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.DoubleType
 import org.apache.spark.util.Utils
-
 
 /**
  * Test suite for [[GBTClassifier]].

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
@@ -102,7 +102,7 @@ class GBTClassifierSuite extends SparkFunSuite with MLlibTestSparkContext {
   }
 
   test("should support all NumericType labels and not support other types") {
-    val gbt = new GBTClassifier()
+    val gbt = new GBTClassifier().setMaxDepth(1)
     MLTestingUtils.checkNumericTypes[GBTClassificationModel, GBTClassifier](
       gbt, isClassification = true, sqlContext) { (expected, actual) =>
         TreeTests.checkEqual(expected, actual)

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
@@ -105,38 +105,21 @@ class GBTClassifierSuite extends SparkFunSuite with MLlibTestSparkContext {
   }
 
   test("should support all NumericType labels") {
-    val df = sqlContext.createDataFrame(Seq(
-      (0, Vectors.dense(0, 2, 3)),
-      (1, Vectors.dense(0, 3, 1)),
-      (0, Vectors.dense(0, 2, 2)),
-      (1, Vectors.dense(0, 3, 9)),
-      (0, Vectors.dense(0, 2, 6))
-    )).toDF("label", "features")
-
-    val types =
-      Seq(ShortType, LongType, IntegerType, FloatType, ByteType, DoubleType, DecimalType(10, 0))
-
-    var dfWithTypes = df
-    types.foreach(t => dfWithTypes = dfWithTypes.withColumn(t.toString, df("label").cast(t)))
+    val dfs = MLTestingUtils.generateDFWithNumericLabelCol(sqlContext, "label", "features")
 
     val gbt = new GBTClassifier().setFeaturesCol("features")
 
-    val expected = gbt.setLabelCol(DoubleType.toString)
-      .fit(TreeTests.setMetadata(dfWithTypes, 2, DoubleType.toString))
-    types.filter(_ != DoubleType).foreach { t =>
+    val expected = gbt.setLabelCol("label")
+      .fit(TreeTests.setMetadata(dfs(DoubleType), 2, "label"))
+    dfs.keys.filter(_ != DoubleType).foreach { t =>
       TreeTests.checkEqual(expected,
-        gbt.setLabelCol(t.toString).fit(TreeTests.setMetadata(dfWithTypes, 2, t.toString)))
+        gbt.setLabelCol("label").fit(TreeTests.setMetadata(dfs(t), 2, "label")))
     }
   }
 
   test("shouldn't support non NumericType labels") {
-    val dfWithStringLabels = TreeTests.setMetadata(sqlContext.createDataFrame(Seq(
-      ("0", Vectors.dense(0, 2, 3)),
-      ("1", Vectors.dense(0, 3, 1)),
-      ("0", Vectors.dense(0, 2, 2)),
-      ("1", Vectors.dense(0, 3, 9)),
-      ("0", Vectors.dense(0, 2, 6))
-    )).toDF("label", "features"), 2, "label")
+    val dfWithStringLabels = TreeTests.setMetadata(
+      MLTestingUtils.generateDFWithStringLabelCol(sqlContext, "label", "features"), 2, "label")
 
     val gbt = new GBTClassifier()
       .setLabelCol("label")

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
@@ -121,11 +121,11 @@ class GBTClassifierSuite extends SparkFunSuite with MLlibTestSparkContext {
 
     val gbt = new GBTClassifier().setFeaturesCol("features")
 
-    val refModel = gbt.setLabelCol(DoubleType.toString)
+    val expected = gbt.setLabelCol(DoubleType.toString)
       .fit(TreeTests.setMetadata(dfWithTypes, 2, DoubleType.toString))
     types.filter(_ != DoubleType).foreach { t =>
-      TreeTests.checkEqual(refModel, gbt.setLabelCol(t.toString)
-        .fit(TreeTests.setMetadata(dfWithTypes, 2, t.toString)))
+      TreeTests.checkEqual(expected,
+        gbt.setLabelCol(t.toString).fit(TreeTests.setMetadata(dfWithTypes, 2, t.toString)))
     }
   }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
@@ -103,7 +103,7 @@ class GBTClassifierSuite extends SparkFunSuite with MLlibTestSparkContext {
   }
 
   test("should support all NumericType labels") {
-    val dfs = MLTestingUtils.generateDFWithNumericLabelCol(sqlContext, "label", "features")
+    val dfs = MLTestingUtils.genClassifDFWithNumericLabelCol(sqlContext, "label", "features")
 
     val gbt = new GBTClassifier().setFeaturesCol("features")
 

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -936,7 +936,7 @@ class LogisticRegressionSuite
   }
 
   test("should support all NumericType labels and not support other types") {
-    val lr = new LogisticRegression()
+    val lr = new LogisticRegression().setMaxIter(1)
     MLTestingUtils.checkNumericTypes[LogisticRegressionModel, LogisticRegression](
       lr, isClassification = true, sqlContext) { (expected, actual) =>
         assert(expected.intercept === actual.intercept)

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -937,7 +937,7 @@ class LogisticRegressionSuite
   }
 
   test("should support all NumericType labels") {
-    val dfs = MLTestingUtils.generateDFWithNumericLabelCol(sqlContext, "label", "features")
+    val dfs = MLTestingUtils.genClassifDFWithNumericLabelCol(sqlContext, "label", "features")
 
     val lr = new LogisticRegression().setFeaturesCol("features")
 

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -952,17 +952,15 @@ class LogisticRegressionSuite
     var dfWithTypes = df
     types.foreach(t => dfWithTypes = dfWithTypes.withColumn(t.toString, df("label").cast(t)))
 
-    val lr = new LogisticRegression()
-      .setFeaturesCol("features")
+    val lr = new LogisticRegression().setFeaturesCol("features")
 
-    val refModel = lr.setLabelCol(DoubleType.toString)
-      .fit(dfWithTypes)
+    val expected = lr.setLabelCol(DoubleType.toString).fit(dfWithTypes)
     types.filter(_ != DoubleType).foreach { t =>
-      val actualModel = lr.setLabelCol(t.toString).fit(dfWithTypes)
-      assert(refModel.intercept === actualModel.intercept)
-      assert(refModel.coefficients.toArray === actualModel.coefficients.toArray)
-      assert(refModel.numClasses === actualModel.numClasses)
-      assert(refModel.numFeatures === actualModel.numFeatures)
+      val actual = lr.setLabelCol(t.toString).fit(dfWithTypes)
+      assert(expected.intercept === actual.intercept)
+      assert(expected.coefficients.toArray === actual.coefficients.toArray)
+      assert(expected.numClasses === actual.numClasses)
+      assert(expected.numFeatures === actual.numFeatures)
     }
   }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -959,12 +959,10 @@ class LogisticRegressionSuite
       val actual = lr.setLabelCol(t.toString).fit(dfWithTypes)
       assert(expected.intercept === actual.intercept)
       assert(expected.coefficients.toArray === actual.coefficients.toArray)
-      assert(expected.numClasses === actual.numClasses)
-      assert(expected.numFeatures === actual.numFeatures)
     }
   }
 
-  test("shouldnt support non NumericType labels") {
+  test("shouldn't support non NumericType labels") {
     val dfWithStringLabels = sqlContext.createDataFrame(Seq(
       ("0", Vectors.dense(0, 2, 3)),
       ("1", Vectors.dense(0, 3, 1)),

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.functions.lit
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.DoubleType
 
 class LogisticRegressionSuite
   extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -937,12 +937,11 @@ class LogisticRegressionSuite
 
   test("should support all NumericType labels and not support other types") {
     val lr = new LogisticRegression()
-    MLTestingUtils.checkPredictorAcceptAllNumericTypes[LogisticRegressionModel, LogisticRegression](
-      lr, sqlContext) { (expected, actual) =>
+    MLTestingUtils.checkNumericTypes[LogisticRegressionModel, LogisticRegression](
+      lr, isClassification = true, sqlContext) { (expected, actual) =>
         assert(expected.intercept === actual.intercept)
         assert(expected.coefficients.toArray === actual.coefficients.toArray)
       }
-    MLTestingUtils.checkPredictorRejectNotNumericTypes(lr, sqlContext)
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.ml.classification
 
-import org.apache.spark.sql.types._
-
 import scala.language.existentials
 import scala.util.Random
 
@@ -31,6 +29,7 @@ import org.apache.spark.mllib.linalg.{Vector, Vectors}
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
+import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.functions.lit
 

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -29,9 +29,9 @@ import org.apache.spark.mllib.linalg.{Vector, Vectors}
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
-import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.functions.lit
+import org.apache.spark.sql.types._
 
 class LogisticRegressionSuite
   extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifierSuite.scala
@@ -167,12 +167,11 @@ class MultilayerPerceptronClassifierSuite
   test("should support all NumericType labels and not support other types") {
     val layers = Array(3, 2)
     val mpc = new MultilayerPerceptronClassifier().setLayers(layers)
-    MLTestingUtils.checkPredictorAcceptAllNumericTypes[
+    MLTestingUtils.checkNumericTypes[
         MultilayerPerceptronClassificationModel, MultilayerPerceptronClassifier](
-      mpc, sqlContext) { (expected, actual) =>
+      mpc, isClassification = true, sqlContext) { (expected, actual) =>
         assert(expected.layers === actual.layers)
         assert(expected.weights === actual.weights)
       }
-    MLTestingUtils.checkPredictorRejectNotNumericTypes(mpc, sqlContext)
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifierSuite.scala
@@ -163,7 +163,7 @@ class MultilayerPerceptronClassifierSuite
     assert(newMlpModel.layers === mlpModel.layers)
     assert(newMlpModel.weights === mlpModel.weights)
   }
-  
+
   test("should support all NumericType labels and not support other types") {
     val layers = Array(3, 2)
     val mpc = new MultilayerPerceptronClassifier().setLayers(layers)

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifierSuite.scala
@@ -166,7 +166,7 @@ class MultilayerPerceptronClassifierSuite
   }
   
   test("should support all NumericType labels") {
-    val dfs = MLTestingUtils.generateDFWithNumericLabelCol(sqlContext, "label", "features")
+    val dfs = MLTestingUtils.genClassifDFWithNumericLabelCol(sqlContext, "label", "features")
 
     val layers = Array(3, 2)
     val mpc = new MultilayerPerceptronClassifier()

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifierSuite.scala
@@ -166,7 +166,7 @@ class MultilayerPerceptronClassifierSuite
 
   test("should support all NumericType labels and not support other types") {
     val layers = Array(3, 2)
-    val mpc = new MultilayerPerceptronClassifier().setLayers(layers)
+    val mpc = new MultilayerPerceptronClassifier().setLayers(layers).setMaxIter(1)
     MLTestingUtils.checkNumericTypes[
         MultilayerPerceptronClassificationModel, MultilayerPerceptronClassifier](
       mpc, isClassification = true, sqlContext) { (expected, actual) =>

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifierSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.ml.classification
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.util.DefaultReadWriteTest
+import org.apache.spark.ml.util.MLTestingUtils
 import org.apache.spark.mllib.classification.LogisticRegressionSuite._
 import org.apache.spark.mllib.classification.LogisticRegressionWithLBFGS
 import org.apache.spark.mllib.evaluation.MulticlassMetrics
@@ -165,28 +166,16 @@ class MultilayerPerceptronClassifierSuite
   }
   
   test("should support all NumericType labels") {
-    val df = sqlContext.createDataFrame(Seq(
-      (0, Vectors.dense(0, 2, 3)),
-      (1, Vectors.dense(0, 3, 1)),
-      (0, Vectors.dense(0, 2, 2)),
-      (1, Vectors.dense(0, 3, 9)),
-      (0, Vectors.dense(0, 2, 6))
-    )).toDF("label", "features")
-
-    val types =
-      Seq(ShortType, LongType, IntegerType, FloatType, ByteType, DoubleType, DecimalType(10, 0))
-
-    var dfWithTypes = df
-    types.foreach(t => dfWithTypes = dfWithTypes.withColumn(t.toString, df("label").cast(t)))
+    val dfs = MLTestingUtils.generateDFWithNumericLabelCol(sqlContext, "label", "features")
 
     val layers = Array(3, 2)
     val mpc = new MultilayerPerceptronClassifier()
       .setFeaturesCol("features")
       .setLayers(layers)
 
-    val expected = mpc.setLabelCol(DoubleType.toString).fit(dfWithTypes)
-    types.filter(_ != DoubleType).foreach { t =>
-      val actual = mpc.setLabelCol(t.toString).fit(dfWithTypes)
+    val expected = mpc.setLabelCol("label").fit(dfs(DoubleType))
+    dfs.keys.filter(_ != DoubleType).foreach { t =>
+      val actual = mpc.setLabelCol("label").fit(dfs(t))
       assert(expected.layers === actual.layers)
       assert(expected.weights === actual.weights)
       assert(expected.numFeatures === actual.numFeatures)
@@ -194,13 +183,8 @@ class MultilayerPerceptronClassifierSuite
   }
 
   test("shouldn't support non NumericType labels") {
-    val dfWithStringLabels = sqlContext.createDataFrame(Seq(
-      ("0", Vectors.dense(0, 2, 3)),
-      ("1", Vectors.dense(0, 3, 1)),
-      ("0", Vectors.dense(0, 2, 2)),
-      ("1", Vectors.dense(0, 3, 9)),
-      ("0", Vectors.dense(0, 2, 6))
-    )).toDF("label", "features")
+    val dfWithStringLabels =
+      MLTestingUtils.generateDFWithStringLabelCol(sqlContext, "label", "features")
 
     val mpc = new MultilayerPerceptronClassifier()
       .setLabelCol("label")

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifierSuite.scala
@@ -26,6 +26,7 @@ import org.apache.spark.mllib.linalg.{Vector, Vectors}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
 import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.types._
 
 class MultilayerPerceptronClassifierSuite
   extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {
@@ -161,5 +162,54 @@ class MultilayerPerceptronClassifierSuite
     val newMlpModel = testDefaultReadWrite(mlpModel, testParams = true)
     assert(newMlpModel.layers === mlpModel.layers)
     assert(newMlpModel.weights === mlpModel.weights)
+  }
+  
+  test("should support all NumericType labels") {
+    val df = sqlContext.createDataFrame(Seq(
+      (0, Vectors.dense(0, 2, 3)),
+      (1, Vectors.dense(0, 3, 1)),
+      (0, Vectors.dense(0, 2, 2)),
+      (1, Vectors.dense(0, 3, 9)),
+      (0, Vectors.dense(0, 2, 6))
+    )).toDF("label", "features")
+
+    val types =
+      Seq(ShortType, LongType, IntegerType, FloatType, ByteType, DoubleType, DecimalType(10, 0))
+
+    var dfWithTypes = df
+    types.foreach(t => dfWithTypes = dfWithTypes.withColumn(t.toString, df("label").cast(t)))
+
+    val layers = Array(3, 2)
+    val mpc = new MultilayerPerceptronClassifier()
+      .setFeaturesCol("features")
+      .setLayers(layers)
+
+    val expected = mpc.setLabelCol(DoubleType.toString).fit(dfWithTypes)
+    types.filter(_ != DoubleType).foreach { t =>
+      val actual = mpc.setLabelCol(t.toString).fit(dfWithTypes)
+      assert(expected.layers === actual.layers)
+      assert(expected.weights === actual.weights)
+      assert(expected.numFeatures === actual.numFeatures)
+    }
+  }
+
+  test("shouldn't support non NumericType labels") {
+    val dfWithStringLabels = sqlContext.createDataFrame(Seq(
+      ("0", Vectors.dense(0, 2, 3)),
+      ("1", Vectors.dense(0, 3, 1)),
+      ("0", Vectors.dense(0, 2, 2)),
+      ("1", Vectors.dense(0, 3, 9)),
+      ("0", Vectors.dense(0, 2, 6))
+    )).toDF("label", "features")
+
+    val mpc = new MultilayerPerceptronClassifier()
+      .setLabelCol("label")
+      .setFeaturesCol("features")
+
+    val thrown = intercept[IllegalArgumentException] {
+      mpc.fit(dfWithStringLabels)
+    }
+    assert(thrown.getMessage contains
+      "Column label must be of type NumericType but was actually of type StringType")
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifierSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.mllib.linalg.{Vector, Vectors}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
 import org.apache.spark.sql.{DataFrame, Row}
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.DoubleType
 
 class MultilayerPerceptronClassifierSuite
   extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/NaiveBayesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/NaiveBayesSuite.scala
@@ -187,12 +187,11 @@ class NaiveBayesSuite extends SparkFunSuite with MLlibTestSparkContext with Defa
 
   test("should support all NumericType labels and not support other types") {
     val nb = new NaiveBayes()
-    MLTestingUtils.checkPredictorAcceptAllNumericTypes[NaiveBayesModel, NaiveBayes](
-      nb, sqlContext) { (expected, actual) =>
+    MLTestingUtils.checkNumericTypes[NaiveBayesModel, NaiveBayes](
+      nb, isClassification = true, sqlContext) { (expected, actual) =>
         assert(expected.pi === actual.pi)
         assert(expected.theta === actual.theta)
       }
-    MLTestingUtils.checkPredictorRejectNotNumericTypes(nb, sqlContext)
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/NaiveBayesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/NaiveBayesSuite.scala
@@ -187,7 +187,7 @@ class NaiveBayesSuite extends SparkFunSuite with MLlibTestSparkContext with Defa
   }
 
   test("should support all NumericType labels") {
-    val dfs = MLTestingUtils.generateDFWithNumericLabelCol(sqlContext, "label", "features")
+    val dfs = MLTestingUtils.genClassifDFWithNumericLabelCol(sqlContext, "label", "features")
 
     val nb = new NaiveBayes().setFeaturesCol("features")
 

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/NaiveBayesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/NaiveBayesSuite.scala
@@ -27,8 +27,8 @@ import org.apache.spark.mllib.classification.NaiveBayesSuite._
 import org.apache.spark.mllib.linalg._
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
-import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.types._
 
 class NaiveBayesSuite extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {
 

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/NaiveBayesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/NaiveBayesSuite.scala
@@ -21,14 +21,14 @@ import breeze.linalg.{Vector => BV}
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.param.ParamsSuite
-import org.apache.spark.ml.util.{MLTestingUtils, DefaultReadWriteTest}
+import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTestingUtils}
 import org.apache.spark.mllib.classification.NaiveBayes.{Bernoulli, Multinomial}
 import org.apache.spark.mllib.classification.NaiveBayesSuite._
 import org.apache.spark.mllib.linalg._
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
 import org.apache.spark.sql.{DataFrame, Row}
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.DoubleType
 
 class NaiveBayesSuite extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {
 
@@ -87,7 +87,7 @@ class NaiveBayesSuite extends SparkFunSuite with MLlibTestSparkContext with Defa
       model: NaiveBayesModel,
       modelType: String): Unit = {
     featureAndProbabilities.collect().foreach {
-      case Row(features: Vector, probability: Vector) => {
+      case Row(features: Vector, probability: Vector) =>
         assert(probability.toArray.sum ~== 1.0 relTol 1.0e-10)
         val expected = modelType match {
           case Multinomial =>
@@ -98,7 +98,6 @@ class NaiveBayesSuite extends SparkFunSuite with MLlibTestSparkContext with Defa
             throw new UnknownError(s"Invalid modelType: $modelType.")
         }
         assert(probability ~== expected relTol 1.0e-10)
-      }
     }
   }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/NaiveBayesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/NaiveBayesSuite.scala
@@ -21,7 +21,7 @@ import breeze.linalg.{Vector => BV}
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.param.ParamsSuite
-import org.apache.spark.ml.util.DefaultReadWriteTest
+import org.apache.spark.ml.util.{MLTestingUtils, DefaultReadWriteTest}
 import org.apache.spark.mllib.classification.NaiveBayes.{Bernoulli, Multinomial}
 import org.apache.spark.mllib.classification.NaiveBayesSuite._
 import org.apache.spark.mllib.linalg._
@@ -188,38 +188,21 @@ class NaiveBayesSuite extends SparkFunSuite with MLlibTestSparkContext with Defa
   }
 
   test("should support all NumericType labels") {
-    val df = sqlContext.createDataFrame(Seq(
-      (0, Vectors.dense(0, 2, 3)),
-      (1, Vectors.dense(0, 3, 1)),
-      (0, Vectors.dense(0, 2, 2)),
-      (1, Vectors.dense(0, 3, 9)),
-      (0, Vectors.dense(0, 2, 6))
-    )).toDF("label", "features")
-
-    val types =
-      Seq(ShortType, LongType, IntegerType, FloatType, ByteType, DoubleType, DecimalType(10, 0))
-
-    var dfWithTypes = df
-    types.foreach(t => dfWithTypes = dfWithTypes.withColumn(t.toString, df("label").cast(t)))
+    val dfs = MLTestingUtils.generateDFWithNumericLabelCol(sqlContext, "label", "features")
 
     val nb = new NaiveBayes().setFeaturesCol("features")
 
-    val expected = nb.setLabelCol(DoubleType.toString).fit(dfWithTypes)
-    types.filter(_ != DoubleType).foreach { t =>
-      val actual = nb.setLabelCol(t.toString).fit(dfWithTypes)
+    val expected = nb.setLabelCol("label").fit(dfs(DoubleType))
+    dfs.keys.filter(_ != DoubleType).foreach { t =>
+      val actual = nb.setLabelCol("label").fit(dfs(t))
       assert(expected.pi === actual.pi)
       assert(expected.theta === actual.theta)
     }
   }
 
   test("shouldn't support non NumericType labels") {
-    val dfWithStringLabels = sqlContext.createDataFrame(Seq(
-      ("0", Vectors.dense(0, 2, 3)),
-      ("1", Vectors.dense(0, 3, 1)),
-      ("0", Vectors.dense(0, 2, 2)),
-      ("1", Vectors.dense(0, 3, 9)),
-      ("0", Vectors.dense(0, 2, 6))
-    )).toDF("label", "features")
+    val dfWithStringLabels =
+      MLTestingUtils.generateDFWithStringLabelCol(sqlContext, "label", "features")
 
     val nb = new NaiveBayes()
       .setLabelCol("label")

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
@@ -226,7 +226,7 @@ class OneVsRestSuite extends SparkFunSuite with MLlibTestSparkContext with Defau
   }
 
   test("should support all NumericType labels") {
-    val dfs = MLTestingUtils.generateDFWithNumericLabelCol(sqlContext, "label", "features")
+    val dfs = MLTestingUtils.genClassifDFWithNumericLabelCol(sqlContext, "label", "features")
 
     val ovr = new OneVsRest()
       .setClassifier(new LogisticRegression)

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
@@ -225,10 +225,10 @@ class OneVsRestSuite extends SparkFunSuite with MLlibTestSparkContext with Defau
     checkModelData(ovaModel, newOvaModel)
   }
 
-  test("should support all NumericType labels") {
+  test("should support all NumericType labels and not support other types") {
     val ovr = new OneVsRest().setClassifier(new LogisticRegression)
-    MLTestingUtils.checkEstimatorAcceptAllNumericTypes[OneVsRestModel, OneVsRest](
-      ovr, sqlContext) { (expected, actual) =>
+    MLTestingUtils.checkNumericTypes[OneVsRestModel, OneVsRest](
+      ovr, isClassification = true, sqlContext) { (expected, actual) =>
         val expectedModels = expected.models.map(m => m.asInstanceOf[LogisticRegressionModel])
         val actualModels = actual.models.map(m => m.asInstanceOf[LogisticRegressionModel])
         assert(expectedModels.length === actualModels.length)
@@ -237,16 +237,6 @@ class OneVsRestSuite extends SparkFunSuite with MLlibTestSparkContext with Defau
           assert(e.coefficients.toArray === a.coefficients.toArray)
         }
       }
-  }
-
-  test("shouldn't support non NumericType labels") {
-    val dfWithStringLabels = MLTestingUtils.generateDFWithStringLabelCol(sqlContext)
-    val ovr = new OneVsRest().setClassifier(new LogisticRegression)
-    // thrown by AttributeFactory#fromStructField and not by Predictor#validateAndTransformSchema
-    // because OneVsRest reimplements the fit method
-    intercept[IllegalArgumentException] {
-      ovr.fit(dfWithStringLabels)
-    }
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
@@ -226,7 +226,7 @@ class OneVsRestSuite extends SparkFunSuite with MLlibTestSparkContext with Defau
   }
 
   test("should support all NumericType labels and not support other types") {
-    val ovr = new OneVsRest().setClassifier(new LogisticRegression)
+    val ovr = new OneVsRest().setClassifier(new LogisticRegression().setMaxIter(1))
     MLTestingUtils.checkNumericTypes[OneVsRestModel, OneVsRest](
       ovr, isClassification = true, sqlContext) { (expected, actual) =>
         val expectedModels = expected.models.map(m => m.asInstanceOf[LogisticRegressionModel])

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.{DoubleType, Metadata}
 
 class OneVsRestSuite extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {
 

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/OneVsRestSuite.scala
@@ -74,7 +74,7 @@ class OneVsRestSuite extends SparkFunSuite with MLlibTestSparkContext with Defau
     // copied model must have the same parent.
     MLTestingUtils.checkCopy(ovaModel)
 
-    assert(ovaModel.models.size === numClasses)
+    assert(ovaModel.models.length === numClasses)
     val transformedDataset = ovaModel.transform(dataset)
 
     // check for label metadata in prediction col

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
@@ -180,7 +180,7 @@ class RandomForestClassifierSuite extends SparkFunSuite with MLlibTestSparkConte
   }
 
   test("should support all NumericType labels") {
-    val dfs = MLTestingUtils.generateDFWithNumericLabelCol(sqlContext, "label", "features")
+    val dfs = MLTestingUtils.genClassifDFWithNumericLabelCol(sqlContext, "label", "features")
 
     val rf = new RandomForestClassifier().setFeaturesCol("features")
 

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
@@ -29,8 +29,8 @@ import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.types.DoubleType
 import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.types.DoubleType
 
 /**
  * Test suite for [[RandomForestClassifier]].

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
@@ -180,10 +180,10 @@ class RandomForestClassifierSuite extends SparkFunSuite with MLlibTestSparkConte
 
   test("should support all NumericType labels and not support other types") {
     val rf = new RandomForestClassifier()
-    MLTestingUtils.checkPredictorAcceptAllNumericTypes[
-        RandomForestClassificationModel, RandomForestClassifier](
-      rf, sqlContext)((expected, actual) => TreeTests.checkEqual(expected, actual))
-    MLTestingUtils.checkPredictorRejectNotNumericTypes(rf, sqlContext)
+    MLTestingUtils.checkNumericTypes[RandomForestClassificationModel, RandomForestClassifier](
+      rf, isClassification = true, sqlContext) { (expected, actual) =>
+        TreeTests.checkEqual(expected, actual)
+      }
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
@@ -29,8 +29,8 @@ import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
 import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.types.DoubleType
 import org.apache.spark.sql.{DataFrame, Row}
-import org.apache.spark.sql.types._
 
 /**
  * Test suite for [[RandomForestClassifier]].

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
@@ -29,8 +29,8 @@ import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.types._
 
 /**
  * Test suite for [[RandomForestClassifier]].

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
@@ -179,7 +179,7 @@ class RandomForestClassifierSuite extends SparkFunSuite with MLlibTestSparkConte
   }
 
   test("should support all NumericType labels and not support other types") {
-    val rf = new RandomForestClassifier()
+    val rf = new RandomForestClassifier().setMaxDepth(1)
     MLTestingUtils.checkNumericTypes[RandomForestClassificationModel, RandomForestClassifier](
       rf, isClassification = true, sqlContext) { (expected, actual) =>
         TreeTests.checkEqual(expected, actual)

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
@@ -29,6 +29,7 @@ import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
 import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, Row}
 
 /**
@@ -176,6 +177,51 @@ class RandomForestClassifierSuite extends SparkFunSuite with MLlibTestSparkConte
     assert(mostImportantFeature === 1)
     assert(importances.toArray.sum === 1.0)
     assert(importances.toArray.forall(_ >= 0.0))
+  }
+
+  test("should support all NumericType labels") {
+    val df = sqlContext.createDataFrame(Seq(
+      (0, Vectors.dense(0, 2, 3)),
+      (1, Vectors.dense(0, 3, 1)),
+      (0, Vectors.dense(0, 2, 2)),
+      (1, Vectors.dense(0, 3, 9)),
+      (0, Vectors.dense(0, 2, 6))
+    )).toDF("label", "features")
+
+    val types =
+      Seq(ShortType, LongType, IntegerType, FloatType, ByteType, DoubleType, DecimalType(10, 0))
+
+    var dfWithTypes = df
+    types.foreach(t => dfWithTypes = dfWithTypes.withColumn(t.toString, df("label").cast(t)))
+
+    val rf = new RandomForestClassifier().setFeaturesCol("features")
+
+    val expected = rf.setLabelCol(DoubleType.toString)
+      .fit(TreeTests.setMetadata(dfWithTypes, 2, DoubleType.toString))
+    types.filter(_ != DoubleType).foreach { t =>
+      TreeTests.checkEqual(expected,
+        rf.setLabelCol(t.toString).fit(TreeTests.setMetadata(dfWithTypes, 2, t.toString)))
+    }
+  }
+
+  test("shouldn't support non NumericType labels") {
+    val dfWithStringLabels = TreeTests.setMetadata(sqlContext.createDataFrame(Seq(
+      ("0", Vectors.dense(0, 2, 3)),
+      ("1", Vectors.dense(0, 3, 1)),
+      ("0", Vectors.dense(0, 2, 2)),
+      ("1", Vectors.dense(0, 3, 9)),
+      ("0", Vectors.dense(0, 2, 6))
+    )).toDF("label", "features"), 2, "label")
+
+    val rb = new RandomForestClassifier()
+      .setLabelCol("label")
+      .setFeaturesCol("features")
+
+    val thrown = intercept[IllegalArgumentException] {
+      rb.fit(dfWithStringLabels)
+    }
+    assert(thrown.getMessage contains
+      "Column label must be of type NumericType but was actually of type StringType")
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/AFTSurvivalRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/AFTSurvivalRegressionSuite.scala
@@ -349,7 +349,7 @@ class AFTSurvivalRegressionSuite
 
   test("should support all NumericType labels") {
     val aft = new AFTSurvivalRegression()
-    MLTestingUtils.checkEstimatorAcceptAllNumericTypes[
+    MLTestingUtils.checkNumericTypes[
         AFTSurvivalRegressionModel, AFTSurvivalRegression](
       aft, sqlContext) { (expected, actual) =>
         assert(expected.intercept === actual.intercept)

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/AFTSurvivalRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/AFTSurvivalRegressionSuite.scala
@@ -351,7 +351,9 @@ class AFTSurvivalRegressionSuite
   test("should support all NumericType labels") {
     val dfs = MLTestingUtils.genRegressionDFWithNumericLabelCol(sqlContext, "label", "features")
 
-    val aft = new AFTSurvivalRegression().setFeaturesCol("features")
+    val aft = new AFTSurvivalRegression()
+      .setFeaturesCol("features")
+      .setCensorCol("censor")
 
     val expected = aft.setLabelCol("label").fit(dfs(DoubleType))
     dfs.keys.filter(_ != DoubleType).foreach { t =>
@@ -368,6 +370,7 @@ class AFTSurvivalRegressionSuite
     val aft = new AFTSurvivalRegression()
       .setLabelCol("label")
       .setFeaturesCol("features")
+      .setCensorCol("censor")
 
     val thrown = intercept[IllegalArgumentException] {
       aft.fit(dfWithStringLabels)

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/AFTSurvivalRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/AFTSurvivalRegressionSuite.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.ml.regression
 
-import org.apache.spark.sql.types.DoubleType
-
 import scala.util.Random
 
 import org.apache.spark.SparkFunSuite
@@ -29,6 +27,7 @@ import org.apache.spark.mllib.random.{ExponentialGenerator, WeibullGenerator}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
 import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.types.DoubleType
 
 class AFTSurvivalRegressionSuite
   extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/AFTSurvivalRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/AFTSurvivalRegressionSuite.scala
@@ -349,13 +349,11 @@ class AFTSurvivalRegressionSuite
 
   test("should support all NumericType labels") {
     val aft = new AFTSurvivalRegression()
-    MLTestingUtils.checkNumericTypes[
-        AFTSurvivalRegressionModel, AFTSurvivalRegression](
-      aft, sqlContext) { (expected, actual) =>
+    MLTestingUtils.checkNumericTypes[AFTSurvivalRegressionModel, AFTSurvivalRegression](
+      aft, isClassification = false, sqlContext) { (expected, actual) =>
         assert(expected.intercept === actual.intercept)
         assert(expected.coefficients === actual.coefficients)
       }
-    MLTestingUtils.checkEstimatorRejectNotNumericTypes(aft, sqlContext)
   }
 
   test("read/write") {

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/AFTSurvivalRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/AFTSurvivalRegressionSuite.scala
@@ -348,7 +348,7 @@ class AFTSurvivalRegressionSuite
   }
 
   test("should support all NumericType labels") {
-    val aft = new AFTSurvivalRegression()
+    val aft = new AFTSurvivalRegression().setMaxIter(1)
     MLTestingUtils.checkNumericTypes[AFTSurvivalRegressionModel, AFTSurvivalRegression](
       aft, isClassification = false, sqlContext) { (expected, actual) =>
         assert(expected.intercept === actual.intercept)

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
@@ -119,7 +119,7 @@ class DecisionTreeRegressorSuite
   }
 
   test("should support all NumericType labels") {
-    val dfs = MLTestingUtils.generateDFWithNumericLabelCol(sqlContext, "label", "features")
+    val dfs = MLTestingUtils.genRegressionDFWithNumericLabelCol(sqlContext, "label", "features")
 
     val dt = new DecisionTreeRegressor().setFeaturesCol("features")
 

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
@@ -21,14 +21,13 @@ import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.tree.impl.TreeTests
 import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTestingUtils}
 import org.apache.spark.mllib.linalg.Vector
-import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.tree.{DecisionTree => OldDecisionTree,
   DecisionTreeSuite => OldDecisionTreeSuite}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Row}
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.DoubleType
 
 class DecisionTreeRegressorSuite
   extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
@@ -118,7 +118,7 @@ class DecisionTreeRegressorSuite
   }
 
   test("should support all NumericType labels and not support other types") {
-    val dt = new DecisionTreeRegressor()
+    val dt = new DecisionTreeRegressor().setMaxDepth(1)
     MLTestingUtils.checkNumericTypes[DecisionTreeRegressionModel, DecisionTreeRegressor](
       dt, isClassification = false, sqlContext) { (expected, actual) =>
         TreeTests.checkEqual(expected, actual)

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
@@ -120,38 +120,21 @@ class DecisionTreeRegressorSuite
   }
 
   test("should support all NumericType labels") {
-    val df = sqlContext.createDataFrame(Seq(
-      (0, Vectors.dense(0, 2, 3)),
-      (1, Vectors.dense(0, 3, 1)),
-      (0, Vectors.dense(0, 2, 2)),
-      (1, Vectors.dense(0, 3, 9)),
-      (0, Vectors.dense(0, 2, 6))
-    )).toDF("label", "features")
-
-    val types =
-      Seq(ShortType, LongType, IntegerType, FloatType, ByteType, DoubleType, DecimalType(10, 0))
-
-    var dfWithTypes = df
-    types.foreach(t => dfWithTypes = dfWithTypes.withColumn(t.toString, df("label").cast(t)))
+    val dfs = MLTestingUtils.generateDFWithNumericLabelCol(sqlContext, "label", "features")
 
     val dt = new DecisionTreeRegressor().setFeaturesCol("features")
 
-    val expected = dt.setLabelCol(DoubleType.toString)
-      .fit(TreeTests.setMetadata(dfWithTypes, 2, DoubleType.toString))
-    types.filter(_ != DoubleType).foreach { t =>
+    val expected = dt.setLabelCol("label")
+      .fit(TreeTests.setMetadata(dfs(DoubleType), 2, "label"))
+    dfs.keys.filter(_ != DoubleType).foreach { t =>
       TreeTests.checkEqual(expected,
-        dt.setLabelCol(t.toString).fit(TreeTests.setMetadata(dfWithTypes, 2, t.toString)))
+        dt.setLabelCol("label").fit(TreeTests.setMetadata(dfs(t), 2, "label")))
     }
   }
 
   test("shouldn't support non NumericType labels") {
-    val dfWithStringLabels = TreeTests.setMetadata(sqlContext.createDataFrame(Seq(
-      ("0", Vectors.dense(0, 2, 3)),
-      ("1", Vectors.dense(0, 3, 1)),
-      ("0", Vectors.dense(0, 2, 2)),
-      ("1", Vectors.dense(0, 3, 9)),
-      ("0", Vectors.dense(0, 2, 6))
-    )).toDF("label", "features"), 2, "label")
+    val dfWithStringLabels =
+      MLTestingUtils.generateDFWithStringLabelCol(sqlContext, "label", "features")
 
     val dt = new DecisionTreeRegressor()
       .setLabelCol("label")

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
@@ -99,7 +99,6 @@ class DecisionTreeRegressorSuite
     }
   }
 
-<<<<<<< cfc6f97eab35c60fec15accaab25e6e1a236da37
   test("Feature importance with toy data") {
     val dt = new DecisionTreeRegressor()
       .setImpurity("variance")
@@ -118,7 +117,8 @@ class DecisionTreeRegressorSuite
     assert(mostImportantFeature === 1)
     assert(importances.toArray.sum === 1.0)
     assert(importances.toArray.forall(_ >= 0.0))
-=======
+  }
+
   test("should support all NumericType labels") {
     val df = sqlContext.createDataFrame(Seq(
       (0, Vectors.dense(0, 2, 3)),
@@ -162,7 +162,6 @@ class DecisionTreeRegressorSuite
     }
     assert(thrown.getMessage contains
       "Column label must be of type NumericType but was actually of type StringType")
->>>>>>> uts for the decision tree regressor
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
@@ -21,12 +21,14 @@ import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.tree.impl.TreeTests
 import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTestingUtils}
 import org.apache.spark.mllib.linalg.Vector
+import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.tree.{DecisionTree => OldDecisionTree,
   DecisionTreeSuite => OldDecisionTreeSuite}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.types._
 
 class DecisionTreeRegressorSuite
   extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {
@@ -97,6 +99,7 @@ class DecisionTreeRegressorSuite
     }
   }
 
+<<<<<<< cfc6f97eab35c60fec15accaab25e6e1a236da37
   test("Feature importance with toy data") {
     val dt = new DecisionTreeRegressor()
       .setImpurity("variance")
@@ -115,6 +118,51 @@ class DecisionTreeRegressorSuite
     assert(mostImportantFeature === 1)
     assert(importances.toArray.sum === 1.0)
     assert(importances.toArray.forall(_ >= 0.0))
+=======
+  test("should support all NumericType labels") {
+    val df = sqlContext.createDataFrame(Seq(
+      (0, Vectors.dense(0, 2, 3)),
+      (1, Vectors.dense(0, 3, 1)),
+      (0, Vectors.dense(0, 2, 2)),
+      (1, Vectors.dense(0, 3, 9)),
+      (0, Vectors.dense(0, 2, 6))
+    )).toDF("label", "features")
+
+    val types =
+      Seq(ShortType, LongType, IntegerType, FloatType, ByteType, DoubleType, DecimalType(10, 0))
+
+    var dfWithTypes = df
+    types.foreach(t => dfWithTypes = dfWithTypes.withColumn(t.toString, df("label").cast(t)))
+
+    val dt = new DecisionTreeRegressor().setFeaturesCol("features")
+
+    val expected = dt.setLabelCol(DoubleType.toString)
+      .fit(TreeTests.setMetadata(dfWithTypes, 2, DoubleType.toString))
+    types.filter(_ != DoubleType).foreach { t =>
+      TreeTests.checkEqual(expected,
+        dt.setLabelCol(t.toString).fit(TreeTests.setMetadata(dfWithTypes, 2, t.toString)))
+    }
+  }
+
+  test("shouldn't support non NumericType labels") {
+    val dfWithStringLabels = TreeTests.setMetadata(sqlContext.createDataFrame(Seq(
+      ("0", Vectors.dense(0, 2, 3)),
+      ("1", Vectors.dense(0, 3, 1)),
+      ("0", Vectors.dense(0, 2, 2)),
+      ("1", Vectors.dense(0, 3, 9)),
+      ("0", Vectors.dense(0, 2, 6))
+    )).toDF("label", "features"), 2, "label")
+
+    val dt = new DecisionTreeRegressor()
+      .setLabelCol("label")
+      .setFeaturesCol("features")
+
+    val thrown = intercept[IllegalArgumentException] {
+      dt.fit(dfWithStringLabels)
+    }
+    assert(thrown.getMessage contains
+      "Column label must be of type NumericType but was actually of type StringType")
+>>>>>>> uts for the decision tree regressor
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/DecisionTreeRegressorSuite.scala
@@ -119,10 +119,10 @@ class DecisionTreeRegressorSuite
 
   test("should support all NumericType labels and not support other types") {
     val dt = new DecisionTreeRegressor()
-    MLTestingUtils.checkPredictorAcceptAllNumericTypes[
-        DecisionTreeRegressionModel, DecisionTreeRegressor](
-      dt, sqlContext)((expected, actual) => TreeTests.checkEqual(expected, actual))
-    MLTestingUtils.checkPredictorRejectNotNumericTypes(dt, sqlContext)
+    MLTestingUtils.checkNumericTypes[DecisionTreeRegressionModel, DecisionTreeRegressor](
+      dt, isClassification = false, sqlContext) { (expected, actual) =>
+        TreeTests.checkEqual(expected, actual)
+      }
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GBTRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GBTRegressorSuite.scala
@@ -113,9 +113,10 @@ class GBTRegressorSuite extends SparkFunSuite with MLlibTestSparkContext {
 
   test("should support all NumericType labels and not support other types") {
     val gbt = new GBTRegressor()
-    MLTestingUtils.checkPredictorAcceptAllNumericTypes[GBTRegressionModel, GBTRegressor](
-      gbt, sqlContext)((expected, actual) => TreeTests.checkEqual(expected, actual))
-    MLTestingUtils.checkPredictorRejectNotNumericTypes(gbt, sqlContext)
+    MLTestingUtils.checkNumericTypes[GBTRegressionModel, GBTRegressor](
+      gbt, isClassification = false, sqlContext) { (expected, actual) =>
+        TreeTests.checkEqual(expected, actual)
+      }
   }
 
   // TODO: Reinstate test once runWithValidation is implemented  SPARK-7132

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GBTRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GBTRegressorSuite.scala
@@ -114,38 +114,21 @@ class GBTRegressorSuite extends SparkFunSuite with MLlibTestSparkContext {
   }
 
   test("should support all NumericType labels") {
-    val df = sqlContext.createDataFrame(Seq(
-      (0, Vectors.dense(0, 2, 3)),
-      (1, Vectors.dense(0, 3, 1)),
-      (0, Vectors.dense(0, 2, 2)),
-      (1, Vectors.dense(0, 3, 9)),
-      (0, Vectors.dense(0, 2, 6))
-    )).toDF("label", "features")
-
-    val types =
-      Seq(ShortType, LongType, IntegerType, FloatType, ByteType, DoubleType, DecimalType(10, 0))
-
-    var dfWithTypes = df
-    types.foreach(t => dfWithTypes = dfWithTypes.withColumn(t.toString, df("label").cast(t)))
+    val dfs = MLTestingUtils.generateDFWithNumericLabelCol(sqlContext, "label", "features")
 
     val gbt = new GBTRegressor().setFeaturesCol("features")
 
-    val expected = gbt.setLabelCol(DoubleType.toString)
-      .fit(TreeTests.setMetadata(dfWithTypes, 2, DoubleType.toString))
-    types.filter(_ != DoubleType).foreach { t =>
+    val expected = gbt.setLabelCol("label")
+      .fit(TreeTests.setMetadata(dfs(DoubleType), 2, "label"))
+    dfs.keys.filter(_ != DoubleType).foreach { t =>
       TreeTests.checkEqual(expected,
-        gbt.setLabelCol(t.toString).fit(TreeTests.setMetadata(dfWithTypes, 2, t.toString)))
+        gbt.setLabelCol("label").fit(TreeTests.setMetadata(dfs(t), 2, "label")))
     }
   }
 
   test("shouldn't support non NumericType labels") {
-    val dfWithStringLabels = TreeTests.setMetadata(sqlContext.createDataFrame(Seq(
-      ("0", Vectors.dense(0, 2, 3)),
-      ("1", Vectors.dense(0, 3, 1)),
-      ("0", Vectors.dense(0, 2, 2)),
-      ("1", Vectors.dense(0, 3, 9)),
-      ("0", Vectors.dense(0, 2, 6))
-    )).toDF("label", "features"), 2, "label")
+    val dfWithStringLabels =
+      MLTestingUtils.generateDFWithStringLabelCol(sqlContext, "label", "features")
 
     val gbt = new GBTRegressor()
       .setLabelCol("label")

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GBTRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GBTRegressorSuite.scala
@@ -112,7 +112,7 @@ class GBTRegressorSuite extends SparkFunSuite with MLlibTestSparkContext {
   }
 
   test("should support all NumericType labels and not support other types") {
-    val gbt = new GBTRegressor()
+    val gbt = new GBTRegressor().setMaxDepth(1)
     MLTestingUtils.checkNumericTypes[GBTRegressionModel, GBTRegressor](
       gbt, isClassification = false, sqlContext) { (expected, actual) =>
         TreeTests.checkEqual(expected, actual)

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GBTRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GBTRegressorSuite.scala
@@ -27,9 +27,8 @@ import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.DoubleType
 import org.apache.spark.util.Utils
-
 
 /**
  * Test suite for [[GBTRegressor]].

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GBTRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GBTRegressorSuite.scala
@@ -113,7 +113,7 @@ class GBTRegressorSuite extends SparkFunSuite with MLlibTestSparkContext {
   }
 
   test("should support all NumericType labels") {
-    val dfs = MLTestingUtils.generateDFWithNumericLabelCol(sqlContext, "label", "features")
+    val dfs = MLTestingUtils.genRegressionDFWithNumericLabelCol(sqlContext, "label", "features")
 
     val gbt = new GBTRegressor().setFeaturesCol("features")
 

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -984,7 +984,7 @@ class GeneralizedLinearRegressionSuite
   }
 
   test("should support all NumericType labels and not support other types") {
-    val glr = new GeneralizedLinearRegression()
+    val glr = new GeneralizedLinearRegression().setMaxIter(1)
     MLTestingUtils.checkNumericTypes[
         GeneralizedLinearRegressionModel, GeneralizedLinearRegression](
       glr, isClassification = false, sqlContext) { (expected, actual) =>

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -1001,12 +1001,12 @@ class GeneralizedLinearRegressionSuite
     val dfWithStringLabels =
       MLTestingUtils.generateDFWithStringLabelCol(sqlContext, "label", "features")
 
-    val lr = new LinearRegression()
+    val glr = new GeneralizedLinearRegression()
       .setLabelCol("label")
       .setFeaturesCol("features")
 
     val thrown = intercept[IllegalArgumentException] {
-      lr.fit(dfWithStringLabels)
+      glr.fit(dfWithStringLabels)
     }
     assert(thrown.getMessage contains
       "Column label must be of type NumericType but was actually of type StringType")

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -31,7 +31,6 @@ import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types.DoubleType
 
 class GeneralizedLinearRegressionSuite
   extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {
@@ -983,33 +982,16 @@ class GeneralizedLinearRegressionSuite
     testEstimatorAndModelReadWrite(glr, datasetPoissonLog,
       GeneralizedLinearRegressionSuite.allParamSettings, checkModelData)
   }
-
-  test("should support all NumericType labels") {
-    val dfs = MLTestingUtils.genRegressionDFWithNumericLabelCol(sqlContext, "label", "features")
-
-    val glr = new GeneralizedLinearRegression().setFeaturesCol("features")
-
-    val expected = glr.setLabelCol("label").fit(dfs(DoubleType))
-    dfs.keys.filter(_ != DoubleType).foreach { t =>
-      val actual = glr.setLabelCol("label").fit(dfs(t))
-      assert(expected.intercept === actual.intercept)
-      assert(expected.coefficients === actual.coefficients)
-    }
-  }
-
-  test("shouldn't support non NumericType labels") {
-    val dfWithStringLabels =
-      MLTestingUtils.generateDFWithStringLabelCol(sqlContext, "label", "features")
-
+  
+  test("should support all NumericType labels and not support other types") {
     val glr = new GeneralizedLinearRegression()
-      .setLabelCol("label")
-      .setFeaturesCol("features")
-
-    val thrown = intercept[IllegalArgumentException] {
-      glr.fit(dfWithStringLabels)
-    }
-    assert(thrown.getMessage contains
-      "Column label must be of type NumericType but was actually of type StringType")
+    MLTestingUtils.checkPredictorAcceptAllNumericTypes[
+        GeneralizedLinearRegressionModel, GeneralizedLinearRegression](
+      glr, sqlContext) { (expected, actual) =>
+        assert(expected.intercept === actual.intercept)
+        assert(expected.coefficients === actual.coefficients)
+      }
+    MLTestingUtils.checkPredictorRejectNotNumericTypes(glr, sqlContext)
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -1023,7 +1023,7 @@ object GeneralizedLinearRegressionSuite {
     generator.setSeed(seed)
 
     (0 until nPoints).map { _ =>
-      val features = Vectors.dense(coefficients.indices.map { rndElement(_) }.toArray)
+      val features = Vectors.dense(coefficients.indices.map(rndElement).toArray)
       val eta = BLAS.dot(Vectors.dense(coefficients), features) + intercept
       val mu = link match {
         case "identity" => eta

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -982,7 +982,7 @@ class GeneralizedLinearRegressionSuite
     testEstimatorAndModelReadWrite(glr, datasetPoissonLog,
       GeneralizedLinearRegressionSuite.allParamSettings, checkModelData)
   }
-  
+
   test("should support all NumericType labels and not support other types") {
     val glr = new GeneralizedLinearRegression()
     MLTestingUtils.checkPredictorAcceptAllNumericTypes[

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -985,13 +985,12 @@ class GeneralizedLinearRegressionSuite
 
   test("should support all NumericType labels and not support other types") {
     val glr = new GeneralizedLinearRegression()
-    MLTestingUtils.checkPredictorAcceptAllNumericTypes[
+    MLTestingUtils.checkNumericTypes[
         GeneralizedLinearRegressionModel, GeneralizedLinearRegression](
-      glr, sqlContext) { (expected, actual) =>
+      glr, isClassification = false, sqlContext) { (expected, actual) =>
         assert(expected.intercept === actual.intercept)
         assert(expected.coefficients === actual.coefficients)
       }
-    MLTestingUtils.checkPredictorRejectNotNumericTypes(glr, sqlContext)
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/IsotonicRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/IsotonicRegressionSuite.scala
@@ -184,11 +184,10 @@ class IsotonicRegressionSuite
   test("should support all NumericType labels and not support other types") {
     val ir = new IsotonicRegression()
     MLTestingUtils.checkNumericTypes[IsotonicRegressionModel, IsotonicRegression](
-      ir, sqlContext) { (expected, actual) =>
+      ir, isClassification = false, sqlContext) { (expected, actual) =>
         assert(expected.boundaries === actual.boundaries)
         assert(expected.predictions === actual.predictions)
       }
-    MLTestingUtils.checkEstimatorRejectNotNumericTypes(ir, sqlContext)
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/IsotonicRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/IsotonicRegressionSuite.scala
@@ -183,7 +183,7 @@ class IsotonicRegressionSuite
 
   test("should support all NumericType labels and not support other types") {
     val ir = new IsotonicRegression()
-    MLTestingUtils.checkEstimatorAcceptAllNumericTypes[IsotonicRegressionModel, IsotonicRegression](
+    MLTestingUtils.checkNumericTypes[IsotonicRegressionModel, IsotonicRegression](
       ir, sqlContext) { (expected, actual) =>
         assert(expected.boundaries === actual.boundaries)
         assert(expected.predictions === actual.predictions)

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.ml.regression
 
-import org.apache.spark.sql.types._
-
 import scala.util.Random
 
 import org.apache.spark.SparkFunSuite
@@ -29,6 +27,7 @@ import org.apache.spark.mllib.linalg.{DenseVector, Vector, Vectors}
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.util.{LinearDataGenerator, MLlibTestSparkContext}
 import org.apache.spark.mllib.util.TestingUtils._
+import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, Row}
 
 class LinearRegressionSuite

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
@@ -1009,12 +1009,11 @@ class LinearRegressionSuite
 
   test("should support all NumericType labels and not support other types") {
     val lr = new LinearRegression()
-    MLTestingUtils.checkPredictorAcceptAllNumericTypes[LinearRegressionModel, LinearRegression](
-      lr, sqlContext) { (expected, actual) =>
+    MLTestingUtils.checkNumericTypes[LinearRegressionModel, LinearRegression](
+      lr, isClassification = false, sqlContext) { (expected, actual) =>
         assert(expected.intercept === actual.intercept)
         assert(expected.coefficients === actual.coefficients)
       }
-    MLTestingUtils.checkPredictorRejectNotNumericTypes(lr, sqlContext)
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
@@ -1009,7 +1009,7 @@ class LinearRegressionSuite
   }
 
   test("should support all NumericType labels") {
-    val dfs = MLTestingUtils.generateDFWithNumericLabelCol(sqlContext, "label", "features")
+    val dfs = MLTestingUtils.genRegressionDFWithNumericLabelCol(sqlContext, "label", "features")
 
     val lr = new LinearRegression().setFeaturesCol("features")
 

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
@@ -27,8 +27,8 @@ import org.apache.spark.mllib.linalg.{DenseVector, Vector, Vectors}
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.util.{LinearDataGenerator, MLlibTestSparkContext}
 import org.apache.spark.mllib.util.TestingUtils._
-import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.types._
 
 class LinearRegressionSuite
   extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
@@ -1009,12 +1009,12 @@ class LinearRegressionSuite
 
   test("should support all NumericType labels and not support other types") {
     val lr = new LinearRegression()
-    MLTestingUtils.checkAcceptAllNumericTypes[LinearRegressionModel, LinearRegression](
+    MLTestingUtils.checkPredictorAcceptAllNumericTypes[LinearRegressionModel, LinearRegression](
       lr, sqlContext) { (expected, actual) =>
         assert(expected.intercept === actual.intercept)
         assert(expected.coefficients === actual.coefficients)
       }
-    MLTestingUtils.checkRejectNotNumericTypes(lr, sqlContext)
+    MLTestingUtils.checkPredictorRejectNotNumericTypes(lr, sqlContext)
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
@@ -61,9 +61,9 @@ class LinearRegressionSuite
     val featureSize = 4100
     datasetWithSparseFeature = sqlContext.createDataFrame(
       sc.parallelize(LinearDataGenerator.generateLinearInput(
-        intercept = 0.0, weights = Seq.fill(featureSize)(r.nextDouble).toArray,
-        xMean = Seq.fill(featureSize)(r.nextDouble).toArray,
-        xVariance = Seq.fill(featureSize)(r.nextDouble).toArray, nPoints = 200,
+        intercept = 0.0, weights = Seq.fill(featureSize)(r.nextDouble()).toArray,
+        xMean = Seq.fill(featureSize)(r.nextDouble()).toArray,
+        xVariance = Seq.fill(featureSize)(r.nextDouble()).toArray, nPoints = 200,
         seed, eps = 0.1, sparsity = 0.7), 2))
 
     /*

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.util.{LinearDataGenerator, MLlibTestSparkContext}
 import org.apache.spark.mllib.util.TestingUtils._
 import org.apache.spark.sql.{DataFrame, Row}
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.DoubleType
 
 class LinearRegressionSuite
   extends SparkFunSuite with MLlibTestSparkContext with DefaultReadWriteTest {

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
@@ -1008,7 +1008,7 @@ class LinearRegressionSuite
   }
 
   test("should support all NumericType labels and not support other types") {
-    val lr = new LinearRegression()
+    val lr = new LinearRegression().setMaxIter(1)
     MLTestingUtils.checkNumericTypes[LinearRegressionModel, LinearRegression](
       lr, isClassification = false, sqlContext) { (expected, actual) =>
         assert(expected.intercept === actual.intercept)

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/RandomForestRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/RandomForestRegressorSuite.scala
@@ -95,7 +95,7 @@ class RandomForestRegressorSuite extends SparkFunSuite with MLlibTestSparkContex
   }
 
   test("should support all NumericType labels and not support other types") {
-    val rf = new RandomForestRegressor()
+    val rf = new RandomForestRegressor().setMaxDepth(1)
     MLTestingUtils.checkNumericTypes[RandomForestRegressionModel, RandomForestRegressor](
       rf, isClassification = false, sqlContext) { (expected, actual) =>
         TreeTests.checkEqual(expected, actual)

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/RandomForestRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/RandomForestRegressorSuite.scala
@@ -96,7 +96,7 @@ class RandomForestRegressorSuite extends SparkFunSuite with MLlibTestSparkContex
   }
 
   test("should support all NumericType labels") {
-    val dfs = MLTestingUtils.generateDFWithNumericLabelCol(sqlContext, "label", "features")
+    val dfs = MLTestingUtils.genRegressionDFWithNumericLabelCol(sqlContext, "label", "features")
 
     val rf = new RandomForestRegressor().setFeaturesCol("features")
 

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/RandomForestRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/RandomForestRegressorSuite.scala
@@ -96,10 +96,10 @@ class RandomForestRegressorSuite extends SparkFunSuite with MLlibTestSparkContex
 
   test("should support all NumericType labels and not support other types") {
     val rf = new RandomForestRegressor()
-    MLTestingUtils.checkPredictorAcceptAllNumericTypes[
-        RandomForestRegressionModel, RandomForestRegressor](
-      rf, sqlContext)((expected, actual) => TreeTests.checkEqual(expected, actual))
-    MLTestingUtils.checkPredictorRejectNotNumericTypes(rf, sqlContext)
+    MLTestingUtils.checkNumericTypes[RandomForestRegressionModel, RandomForestRegressor](
+      rf, isClassification = false, sqlContext) { (expected, actual) =>
+        TreeTests.checkEqual(expected, actual)
+      }
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/RandomForestRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/RandomForestRegressorSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.DoubleType
 
 /**
  * Test suite for [[RandomForestRegressor]].

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/RandomForestRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/RandomForestRegressorSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.ml.regression
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.tree.impl.TreeTests
-import org.apache.spark.ml.util.MLTestingUtils
+import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.tree.{EnsembleTestHelper, RandomForest => OldRandomForest}
 import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo}

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/RandomForestRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/RandomForestRegressorSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.ml.regression
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.tree.impl.TreeTests
-import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.ml.util.MLTestingUtils
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.tree.{EnsembleTestHelper, RandomForest => OldRandomForest}
 import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo}
@@ -96,38 +96,21 @@ class RandomForestRegressorSuite extends SparkFunSuite with MLlibTestSparkContex
   }
 
   test("should support all NumericType labels") {
-    val df = sqlContext.createDataFrame(Seq(
-      (0, Vectors.dense(0, 2, 3)),
-      (1, Vectors.dense(0, 3, 1)),
-      (0, Vectors.dense(0, 2, 2)),
-      (1, Vectors.dense(0, 3, 9)),
-      (0, Vectors.dense(0, 2, 6))
-    )).toDF("label", "features")
-
-    val types =
-      Seq(ShortType, LongType, IntegerType, FloatType, ByteType, DoubleType, DecimalType(10, 0))
-
-    var dfWithTypes = df
-    types.foreach(t => dfWithTypes = dfWithTypes.withColumn(t.toString, df("label").cast(t)))
+    val dfs = MLTestingUtils.generateDFWithNumericLabelCol(sqlContext, "label", "features")
 
     val rf = new RandomForestRegressor().setFeaturesCol("features")
 
-    val expected = rf.setLabelCol(DoubleType.toString)
-      .fit(TreeTests.setMetadata(dfWithTypes, 2, DoubleType.toString))
-    types.filter(_ != DoubleType).foreach { t =>
+    val expected = rf.setLabelCol("label")
+      .fit(TreeTests.setMetadata(dfs(DoubleType), 2, "label"))
+    dfs.keys.filter(_ != DoubleType).foreach { t =>
       TreeTests.checkEqual(expected,
-        rf.setLabelCol(t.toString).fit(TreeTests.setMetadata(dfWithTypes, 2, t.toString)))
+        rf.setLabelCol("label").fit(TreeTests.setMetadata(dfs(t), 2, "label")))
     }
   }
 
   test("shouldn't support non NumericType labels") {
-    val dfWithStringLabels = TreeTests.setMetadata(sqlContext.createDataFrame(Seq(
-      ("0", Vectors.dense(0, 2, 3)),
-      ("1", Vectors.dense(0, 3, 1)),
-      ("0", Vectors.dense(0, 2, 2)),
-      ("1", Vectors.dense(0, 3, 9)),
-      ("0", Vectors.dense(0, 2, 6))
-    )).toDF("label", "features"), 2, "label")
+    val dfWithStringLabels =
+      MLTestingUtils.generateDFWithStringLabelCol(sqlContext, "label", "features")
 
     val rf = new RandomForestRegressor()
       .setLabelCol("label")

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/TreeTests.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/TreeTests.scala
@@ -78,16 +78,17 @@ private[ml] object TreeTests extends SparkFunSuite {
    * @param data  Dataset.  Categorical features and labels must already have 0-based indices.
    *              This must be non-empty.
    * @param numClasses  Number of classes label can take. If 0, mark as continuous.
+   * @param labelColName  Name of the label column on which to set the metadata.
    * @return DataFrame with metadata
    */
-  def setMetadata(data: DataFrame, numClasses: Int): DataFrame = {
+  def setMetadata(data: DataFrame, numClasses: Int, labelColName: String): DataFrame = {
     val labelAttribute = if (numClasses == 0) {
-      NumericAttribute.defaultAttr.withName("label")
+      NumericAttribute.defaultAttr.withName(labelColName)
     } else {
-      NominalAttribute.defaultAttr.withName("label").withNumValues(numClasses)
+      NominalAttribute.defaultAttr.withName(labelColName).withNumValues(numClasses)
     }
     val labelMetadata = labelAttribute.toMetadata()
-    data.select(data("features"), data("label").as("label", labelMetadata))
+    data.select(data("features"), data(labelColName).as(labelColName, labelMetadata))
   }
 
   /**

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/TreeTests.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/TreeTests.scala
@@ -74,6 +74,23 @@ private[ml] object TreeTests extends SparkFunSuite {
   }
 
   /**
+   * Set label metadata (particularly the number of classes) on a DataFrame.
+   * @param data  Dataset.  Categorical features and labels must already have 0-based indices.
+   *              This must be non-empty.
+   * @param numClasses  Number of classes label can take. If 0, mark as continuous.
+   * @return DataFrame with metadata
+   */
+  def setMetadata(data: DataFrame, numClasses: Int): DataFrame = {
+    val labelAttribute = if (numClasses == 0) {
+      NumericAttribute.defaultAttr.withName("label")
+    } else {
+      NominalAttribute.defaultAttr.withName("label").withNumValues(numClasses)
+    }
+    val labelMetadata = labelAttribute.toMetadata()
+    data.select(data("features"), data("label").as("label", labelMetadata))
+  }
+
+  /**
    * Check if the two trees are exactly the same.
    * Note: I hesitate to override Node.equals since it could cause problems if users
    *       make mistakes such as creating loops of Nodes.

--- a/mllib/src/test/scala/org/apache/spark/ml/util/MLTestingUtils.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/util/MLTestingUtils.scala
@@ -47,7 +47,7 @@ object MLTestingUtils extends SparkFunSuite {
     val expected = estimator.fit(dfs(DoubleType))
     val actuals = dfs.keys.filter(_ != DoubleType).map(t => estimator.fit(dfs(t)))
     actuals.foreach(actual => check(expected, actual))
-    
+
     val dfWithStringLabels = generateDFWithStringLabelCol(sqlContext)
     val thrown = intercept[IllegalArgumentException] {
       estimator.fit(dfWithStringLabels)

--- a/mllib/src/test/scala/org/apache/spark/ml/util/MLTestingUtils.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/util/MLTestingUtils.scala
@@ -53,31 +53,34 @@ object MLTestingUtils {
   def genRegressionDFWithNumericLabelCol(
     sqlContext: SQLContext,
     labelColName: String,
-    featuresColName: String
+    featuresColName: String,
+    censorColName: String = "censor"
   ): Map[NumericType, DataFrame] = {
     val df = sqlContext.createDataFrame(Seq(
-      (0, Vectors.dense(0)),
-      (1, Vectors.dense(1)),
-      (2, Vectors.dense(2)),
-      (3, Vectors.dense(3)),
-      (4, Vectors.dense(4))
-    )).toDF(labelColName, featuresColName)
+      (0, Vectors.dense(0), 0.0),
+      (1, Vectors.dense(1), 1.0),
+      (2, Vectors.dense(2), 0.0),
+      (3, Vectors.dense(3), 1.0),
+      (4, Vectors.dense(4), 0.0)
+    )).toDF(labelColName, featuresColName, censorColName)
 
     val types =
       Seq(ShortType, LongType, IntegerType, FloatType, ByteType, DoubleType, DecimalType(10, 0))
-    types.map(t => t -> df.select(col(labelColName).cast(t), col(featuresColName))).toMap
+    types.map(t =>
+      t -> df.select(col(labelColName).cast(t), col(featuresColName), col(censorColName))).toMap
   }
 
   def generateDFWithStringLabelCol(
     sqlContext: SQLContext,
     labelColName: String,
-    featuresColName: String
+    featuresColName: String,
+    censorColName: String = "censor"
   ): DataFrame =
     sqlContext.createDataFrame(Seq(
-      ("0", Vectors.dense(0, 2, 3)),
-      ("1", Vectors.dense(0, 3, 1)),
-      ("0", Vectors.dense(0, 2, 2)),
-      ("1", Vectors.dense(0, 3, 9)),
-      ("0", Vectors.dense(0, 2, 6))
-    )).toDF(labelColName, featuresColName)
+      ("0", Vectors.dense(0, 2, 3), 0.0),
+      ("1", Vectors.dense(0, 3, 1), 1.0),
+      ("0", Vectors.dense(0, 2, 2), 0.0),
+      ("1", Vectors.dense(0, 3, 9), 1.0),
+      ("0", Vectors.dense(0, 2, 6), 0.0)
+    )).toDF(labelColName, featuresColName, censorColName)
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/util/MLTestingUtils.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/util/MLTestingUtils.scala
@@ -17,14 +17,17 @@
 
 package org.apache.spark.ml.util
 
-import org.apache.spark.ml.Model
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.ml.{Model, Predictor}
+import org.apache.spark.ml.classification.{ClassificationModel, Classifier}
 import org.apache.spark.ml.param.ParamMap
+import org.apache.spark.ml.regression.{RegressionModel, Regressor}
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.sql.{DataFrame, SQLContext}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 
-object MLTestingUtils {
+object MLTestingUtils extends SparkFunSuite {
   def checkCopy(model: Model[_]): Unit = {
     val copied = model.copy(ParamMap.empty)
       .asInstanceOf[Model[_]]
@@ -32,11 +35,35 @@ object MLTestingUtils {
     assert(copied.parent == model.parent)
   }
 
+  def checkAcceptAllNumericTypes[M <: RegressionModel[_, M], T <: Regressor[_, _, M]](
+      regressor: T, sqlContext: SQLContext)(check: (M, M) => Unit): Unit = {
+    val dfs = genRegressionDFWithNumericLabelCol(sqlContext, "label", "features")
+    val expected = regressor.fit(dfs(DoubleType))
+    val actuals = dfs.keys.filter(_ != DoubleType).map(t => regressor.fit(dfs(t)))
+    actuals.foreach(actual => check(expected, actual))
+  }
+
+  def checkAcceptAllNumericTypes[M <: ClassificationModel[_, M], T <: Classifier[_, _, M]](
+      classifier: T, sqlContext: SQLContext)(check: (M, M) => Unit): Unit = {
+    val dfs = genClassifDFWithNumericLabelCol(sqlContext, "label", "features")
+    val expected = classifier.fit(dfs(DoubleType))
+    val actuals = dfs.keys.filter(_ != DoubleType).map(t => classifier.fit(dfs(t)))
+    actuals.foreach(actual => check(expected, actual))
+  }
+  def checkRejectNotNumericTypes(predictor: Predictor[_, _, _], sqlContext: SQLContext): Unit = {
+    val dfWithStringLabels =
+      MLTestingUtils.generateDFWithStringLabelCol(sqlContext, "label", "features")
+    val thrown = intercept[IllegalArgumentException] {
+      predictor.fit(dfWithStringLabels)
+    }
+    assert(thrown.getMessage contains
+      "Column label must be of type NumericType but was actually of type StringType")
+  }
+
   def genClassifDFWithNumericLabelCol(
-    sqlContext: SQLContext,
-    labelColName: String,
-    featuresColName: String
-  ): Map[NumericType, DataFrame] = {
+      sqlContext: SQLContext,
+      labelColName: String,
+      featuresColName: String): Map[NumericType, DataFrame] = {
     val df = sqlContext.createDataFrame(Seq(
       (0, Vectors.dense(0, 2, 3)),
       (1, Vectors.dense(0, 3, 1)),
@@ -51,11 +78,10 @@ object MLTestingUtils {
   }
 
   def genRegressionDFWithNumericLabelCol(
-    sqlContext: SQLContext,
-    labelColName: String,
-    featuresColName: String,
-    censorColName: String = "censor"
-  ): Map[NumericType, DataFrame] = {
+      sqlContext: SQLContext,
+      labelColName: String,
+      featuresColName: String,
+      censorColName: String = "censor"): Map[NumericType, DataFrame] = {
     val df = sqlContext.createDataFrame(Seq(
       (0, Vectors.dense(0), 0.0),
       (1, Vectors.dense(1), 1.0),
@@ -71,11 +97,10 @@ object MLTestingUtils {
   }
 
   def generateDFWithStringLabelCol(
-    sqlContext: SQLContext,
-    labelColName: String,
-    featuresColName: String,
-    censorColName: String = "censor"
-  ): DataFrame =
+      sqlContext: SQLContext,
+      labelColName: String,
+      featuresColName: String,
+      censorColName: String = "censor"): DataFrame =
     sqlContext.createDataFrame(Seq(
       ("0", Vectors.dense(0, 2, 3), 0.0),
       ("1", Vectors.dense(0, 3, 1), 1.0),

--- a/mllib/src/test/scala/org/apache/spark/ml/util/MLTestingUtils.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/util/MLTestingUtils.scala
@@ -20,7 +20,6 @@ package org.apache.spark.ml.util
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.{Estimator, Model}
 import org.apache.spark.ml.param.ParamMap
-import org.apache.spark.ml.regression.Regressor
 import org.apache.spark.ml.tree.impl.TreeTests
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.sql.{DataFrame, SQLContext}
@@ -39,10 +38,10 @@ object MLTestingUtils extends SparkFunSuite {
       estimator: T,
       isClassification: Boolean,
       sqlContext: SQLContext)(check: (M, M) => Unit): Unit = {
-    val dfs = if (estimator.isInstanceOf[Regressor[_, _, _]]) {
-      genRegressionDFWithNumericLabelCol(sqlContext)
-    } else {
+    val dfs = if (isClassification) {
       genClassifDFWithNumericLabelCol(sqlContext)
+    } else {
+      genRegressionDFWithNumericLabelCol(sqlContext)
     }
     val expected = estimator.fit(dfs(DoubleType))
     val actuals = dfs.keys.filter(_ != DoubleType).map(t => estimator.fit(dfs(t)))
@@ -93,7 +92,7 @@ object MLTestingUtils extends SparkFunSuite {
     types
       .map(t => t -> df.select(col(labelColName).cast(t), col(featuresColName)))
       .map { case (t, d) =>
-        t -> TreeTests.setMetadata(d, 2, labelColName).withColumn(censorColName, lit(0.0))
+        t -> TreeTests.setMetadata(d, 0, labelColName).withColumn(censorColName, lit(0.0))
       }
       .toMap
   }

--- a/mllib/src/test/scala/org/apache/spark/ml/util/MLTestingUtils.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/util/MLTestingUtils.scala
@@ -32,7 +32,7 @@ object MLTestingUtils {
     assert(copied.parent == model.parent)
   }
 
-  def generateDFWithNumericLabelCol(
+  def genClassifDFWithNumericLabelCol(
     sqlContext: SQLContext,
     labelColName: String,
     featuresColName: String
@@ -43,6 +43,24 @@ object MLTestingUtils {
       (0, Vectors.dense(0, 2, 2)),
       (1, Vectors.dense(0, 3, 9)),
       (0, Vectors.dense(0, 2, 6))
+    )).toDF(labelColName, featuresColName)
+
+    val types =
+      Seq(ShortType, LongType, IntegerType, FloatType, ByteType, DoubleType, DecimalType(10, 0))
+    types.map(t => t -> df.select(col(labelColName).cast(t), col(featuresColName))).toMap
+  }
+
+  def genRegressionDFWithNumericLabelCol(
+    sqlContext: SQLContext,
+    labelColName: String,
+    featuresColName: String
+  ): Map[NumericType, DataFrame] = {
+    val df = sqlContext.createDataFrame(Seq(
+      (0, Vectors.dense(0)),
+      (1, Vectors.dense(1)),
+      (2, Vectors.dense(2)),
+      (3, Vectors.dense(3)),
+      (4, Vectors.dense(4))
     )).toDF(labelColName, featuresColName)
 
     val types =

--- a/mllib/src/test/scala/org/apache/spark/ml/util/MLTestingUtils.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/util/MLTestingUtils.scala
@@ -18,10 +18,10 @@
 package org.apache.spark.ml.util
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.ml.tree.impl.TreeTests
 import org.apache.spark.ml.{Estimator, Model, PredictionModel, Predictor}
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.regression.Regressor
+import org.apache.spark.ml.tree.impl.TreeTests
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.sql.{DataFrame, SQLContext}
 import org.apache.spark.sql.functions._
@@ -56,7 +56,7 @@ object MLTestingUtils extends SparkFunSuite {
     assert(thrown.getMessage contains
       "Column label must be of type NumericType but was actually of type StringType")
   }
-  
+
   def checkEstimatorAcceptAllNumericTypes[M <: Model[M], T <: Estimator[M]](
       estimator: T, sqlContext: SQLContext)(check: (M, M) => Unit): Unit = {
     val dfs = genRegressionDFWithNumericLabelCol(sqlContext)

--- a/mllib/src/test/scala/org/apache/spark/ml/util/MLTestingUtils.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/util/MLTestingUtils.scala
@@ -19,6 +19,10 @@ package org.apache.spark.ml.util
 
 import org.apache.spark.ml.Model
 import org.apache.spark.ml.param.ParamMap
+import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.sql.{DataFrame, SQLContext}
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types._
 
 object MLTestingUtils {
   def checkCopy(model: Model[_]): Unit = {
@@ -27,4 +31,35 @@ object MLTestingUtils {
     assert(copied.parent.uid == model.parent.uid)
     assert(copied.parent == model.parent)
   }
+
+  def generateDFWithNumericLabelCol(
+    sqlContext: SQLContext,
+    labelColName: String,
+    featuresColName: String
+  ): Map[NumericType, DataFrame] = {
+    val df = sqlContext.createDataFrame(Seq(
+      (0, Vectors.dense(0, 2, 3)),
+      (1, Vectors.dense(0, 3, 1)),
+      (0, Vectors.dense(0, 2, 2)),
+      (1, Vectors.dense(0, 3, 9)),
+      (0, Vectors.dense(0, 2, 6))
+    )).toDF(labelColName, featuresColName)
+
+    val types =
+      Seq(ShortType, LongType, IntegerType, FloatType, ByteType, DoubleType, DecimalType(10, 0))
+    types.map(t => t -> df.select(col(labelColName).cast(t), col(featuresColName))).toMap
+  }
+
+  def generateDFWithStringLabelCol(
+    sqlContext: SQLContext,
+    labelColName: String,
+    featuresColName: String
+  ): DataFrame =
+    sqlContext.createDataFrame(Seq(
+      ("0", Vectors.dense(0, 2, 3)),
+      ("1", Vectors.dense(0, 3, 1)),
+      ("0", Vectors.dense(0, 2, 2)),
+      ("1", Vectors.dense(0, 3, 9)),
+      ("0", Vectors.dense(0, 2, 6))
+    )).toDF(labelColName, featuresColName)
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/util/MLTestingUtils.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/util/MLTestingUtils.scala
@@ -90,7 +90,7 @@ object MLTestingUtils extends SparkFunSuite {
     val types =
       Seq(ShortType, LongType, IntegerType, FloatType, ByteType, DoubleType, DecimalType(10, 0))
     types.map(t => t -> df.select(col(labelColName).cast(t), col(featuresColName)))
-      .map { case (t, d) => t -> TreeTests.setMetadata(d, 2, "label") }
+      .map { case (t, d) => t -> TreeTests.setMetadata(d, 2, labelColName) }
       .toMap
   }
 
@@ -100,18 +100,20 @@ object MLTestingUtils extends SparkFunSuite {
       featuresColName: String = "features",
       censorColName: String = "censor"): Map[NumericType, DataFrame] = {
     val df = sqlContext.createDataFrame(Seq(
-      (0, Vectors.dense(0), 0.0),
-      (1, Vectors.dense(1), 1.0),
-      (2, Vectors.dense(2), 0.0),
-      (3, Vectors.dense(3), 1.0),
-      (4, Vectors.dense(4), 0.0)
-    )).toDF(labelColName, featuresColName, censorColName)
+      (0, Vectors.dense(0)),
+      (1, Vectors.dense(1)),
+      (2, Vectors.dense(2)),
+      (3, Vectors.dense(3)),
+      (4, Vectors.dense(4))
+    )).toDF(labelColName, featuresColName)
 
     val types =
       Seq(ShortType, LongType, IntegerType, FloatType, ByteType, DoubleType, DecimalType(10, 0))
     types
-      .map(t => t -> df.select(col(labelColName).cast(t), col(featuresColName), col(censorColName)))
-      .map { case (t, d) => t -> TreeTests.setMetadata(d, 2, "label") }
+      .map(t => t -> df.select(col(labelColName).cast(t), col(featuresColName)))
+      .map { case (t, d) =>
+        t -> TreeTests.setMetadata(d, 2, labelColName).withColumn(censorColName, lit(0.0))
+      }
       .toMap
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/AbstractDataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/AbstractDataType.scala
@@ -27,7 +27,7 @@ import org.apache.spark.util.Utils
 /**
  * A non-concrete data type, reserved for internal uses.
  */
-private[spark] abstract class AbstractDataType {
+private[sql] abstract class AbstractDataType {
   /**
    * The default concrete type to use if we want to cast a null literal into this type.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/AbstractDataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/AbstractDataType.scala
@@ -151,7 +151,7 @@ abstract class NumericType extends AtomicType {
 }
 
 
-private[spark] object NumericType extends AbstractDataType {
+private[sql] object NumericType extends AbstractDataType {
   /**
    * Enables matching against NumericType for expressions:
    * {{{

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/AbstractDataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/AbstractDataType.scala
@@ -27,7 +27,7 @@ import org.apache.spark.util.Utils
 /**
  * A non-concrete data type, reserved for internal uses.
  */
-private[sql] abstract class AbstractDataType {
+private[spark] abstract class AbstractDataType {
   /**
    * The default concrete type to use if we want to cast a null literal into this type.
    */
@@ -151,7 +151,7 @@ abstract class NumericType extends AtomicType {
 }
 
 
-private[sql] object NumericType extends AbstractDataType {
+private[spark] object NumericType extends AbstractDataType {
   /**
    * Enables matching against NumericType for expressions:
    * {{{


### PR DESCRIPTION
Currently, the Predictor abstraction expects the input labelCol type to be DoubleType, but we should support other numeric types. This will involve updating the PredictorParams.validateAndTransformSchema method.
