### PR TITLE
[SPARK-12377][Python][Wrong implementation for Row.__call__ in pyspark]

### DIFF
--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1243,7 +1243,7 @@ class Row(tuple):
     # let object acts like class
     def __call__(self, *args):
         """create new Row object"""
-        return _create_row(self, args)
+        return create_row(self.fields_, args)
 
     def __getitem__(self, item):
         if isinstance(item, (int, slice)):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1240,10 +1240,13 @@ class Row(tuple):
         else:
             return dict(zip(self.__fields__, self))
 
-    # let object acts like class
+	# let object acts like class
     def __call__(self, *args):
-        """create new Row object"""
-        return create_row(self.fields_, args)
+        if args:
+            """create new Row object"""
+            return create_row(self.fields_, args)
+        else:
+            raise ValueError("No args")	
 
     def __getitem__(self, item):
         if isinstance(item, (int, slice)):


### PR DESCRIPTION
Made chnages in types.py file to change "return _create_row(self, args)" to return create_row(self.fields_, args) 
