### PR TITLE
[SPARK-12366][SQL][REPL] ExecutorClassLoader should skip finding classes generated by Janino

### DIFF
--- a/repl/src/main/scala/org/apache/spark/repl/ExecutorClassLoader.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/ExecutorClassLoader.scala
@@ -70,6 +70,9 @@ class ExecutorClassLoader(
   }
 
   override def findClass(name: String): Class[_] = {
+    if (name.contains("org.apache.spark.sql.catalyst.expressions.GeneratedClass")) {
+      throw new ClassNotFoundException(name)
+    }
     userClassPathFirst match {
       case true => findClassLocally(name).getOrElse(parentLoader.loadClass(name))
       case false => {


### PR DESCRIPTION
I think, ExecutorClassLoader should not load classes generated by Janino so ExecutorClassLoader should skip to find those classes to avoid useless RPC and getting error messages. Otherwise, we can get error messages when we use REPL and generated code.
Error messages are like as follows ( @jaceklaskowski reported ).

```
scala> val df = sqlContext.read.json("examples/src/main/resources/people.json")
df: org.apache.spark.sql.DataFrame = [age: bigint, name: string]

scala> df.show
ERROR TransportRequestHandler: Error opening stream /classes/org/apache/spark/sql/catalyst/expressions/GeneratedClass.class for request from /172.20.4.141:55136
java.lang.IllegalArgumentException: requirement failed: File not found: /classes/org/apache/spark/sql/catalyst/expressions/GeneratedClass.class
    at scala.Predef$.require(Predef.scala:219)
    at org.apache.spark.rpc.netty.NettyStreamManager.openStream(NettyStreamManager.scala:60)
    at org.apache.spark.network.server.TransportRequestHandler.processStreamRequest(TransportRequestHandler.java:136)
    at org.apache.spark.network.server.TransportRequestHandler.handle(TransportRequestHandler.java:106)
    at org.apache.spark.network.server.TransportChannelHandler.channelRead0(TransportChannelHandler.java:104)
    at org.apache.spark.network.server.TransportChannelHandler.channelRead0(TransportChannelHandler.java:51)
    at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:105)
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:308)
    at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:294)
```
