### PR TITLE
[SPARK-12409][SQL]JDBC AND operator push down

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -288,6 +288,8 @@ private[sql] class JDBCRDD(
     case GreaterThanOrEqual(attr, value) => s"$attr >= ${compileValue(value)}"
     case IsNull(attr) => s"$attr IS NULL"
     case IsNotNull(attr) => s"$attr IS NOT NULL"
+    case And(filter1, filter2) =>
+      "(" + compileFilter (filter1) + ") AND ("  + compileFilter (filter2)  + ")"
     case _ => null
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -184,6 +184,8 @@ class JDBCSuite extends SparkFunSuite with BeforeAndAfter with SharedSQLContext 
     assert(stripSparkFilter(sql("SELECT * FROM foobar WHERE NAME != 'fred'")).collect().size == 2)
     assert(stripSparkFilter(sql("SELECT * FROM nulltypes WHERE A IS NULL")).collect().size == 1)
     assert(stripSparkFilter(sql("SELECT * FROM nulltypes WHERE A IS NOT NULL")).collect().size == 0)
+    assert(stripSparkFilter(sql(
+      "SELECT * FROM foobar WHERE THEID = 1 OR NAME = 'mary' AND THEID = 2")).collect().size === 2)
   }
 
   test("SELECT * WHERE (quoted strings)") {


### PR DESCRIPTION
For simple AND such as 
select \* from test where THEID = 1 AND NAME = 'fred', 
The filters pushed down to JDBC layers are EqualTo(THEID,1), EqualTo(Name,fred). These are handled OK by the current code.
For query such as 
SELECT \* FROM foobar WHERE THEID = 1 OR NAME = 'mary' AND THEID = 2" ,
the filter is Or(EqualTo(THEID,1),And(EqualTo(NAME,mary),EqualTo(THEID,2)))
So need to add And filter in JDBC layer.
