### PR TITLE
[CORE][TESTS] minor fix of JavaSerializerSuite

### DIFF
--- a/core/src/test/scala/org/apache/spark/serializer/JavaSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/JavaSerializerSuite.scala
@@ -23,13 +23,17 @@ class JavaSerializerSuite extends SparkFunSuite {
   test("JavaSerializer instances are serializable") {
     val serializer = new JavaSerializer(new SparkConf())
     val instance = serializer.newInstance()
-    instance.deserialize[JavaSerializer](instance.serialize(serializer))
+    val obj = instance.deserialize[JavaSerializer](instance.serialize(serializer))
+    // enforce class cast
+    obj.getClass
   }
 
   test("Deserialize object containing a primitive Class as attribute") {
     val serializer = new JavaSerializer(new SparkConf())
     val instance = serializer.newInstance()
-    instance.deserialize[JavaSerializer](instance.serialize(new ContainsPrimitiveClass()))
+    val obj = instance.deserialize[ContainsPrimitiveClass](instance.serialize(new ContainsPrimitiveClass()))
+    // enforce class cast
+    obj.getClass
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/serializer/JavaSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/JavaSerializerSuite.scala
@@ -31,7 +31,8 @@ class JavaSerializerSuite extends SparkFunSuite {
   test("Deserialize object containing a primitive Class as attribute") {
     val serializer = new JavaSerializer(new SparkConf())
     val instance = serializer.newInstance()
-    val obj = instance.deserialize[ContainsPrimitiveClass](instance.serialize(new ContainsPrimitiveClass()))
+    val obj = instance.deserialize[ContainsPrimitiveClass](instance.serialize(
+      new ContainsPrimitiveClass()))
     // enforce class cast
     obj.getClass
   }


### PR DESCRIPTION
Not jira is created. 
The original test is passed because the class cast is lazy (only when the object's method is invoked).
