### PR TITLE
[SPARK-12398] Smart truncation of DataFrame / Dataset toString

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -67,7 +67,7 @@ abstract class DataType extends AbstractDataType {
   def simpleString: String = typeName
 
   /** Readable string representation for the type with truncation */
-  def simpleString(maxNumberFields: Int): String = simpleString
+  private[sql] def simpleString(maxNumberFields: Int): String = simpleString
 
   /**
    * Check if `this` and `other` are the same data type when ignoring nullability

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -66,6 +66,9 @@ abstract class DataType extends AbstractDataType {
   /** Readable string representation for the type. */
   def simpleString: String = typeName
 
+  /** Readable string representation for the type with truncation */
+  def simpleString(maxNumberFields: Int): String = simpleString
+
   /**
    * Check if `this` and `other` are the same data type when ignoring nullability
    * (`StructField.nullable`, `ArrayType.containsNull`, and `MapType.valueContainsNull`).

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -278,6 +278,23 @@ case class StructType(fields: Array[StructField]) extends DataType with Seq[Stru
     s"struct<${fieldTypes.mkString(",")}>"
   }
 
+  override def simpleString(maxNumberFields: Int): String = {
+    val builder = new StringBuilder
+    val fieldTypes = fields.take(maxNumberFields).map {
+      case f => s"${f.name}: ${f.dataType.simpleString(maxNumberFields)}"
+    }
+    builder.append("struct<")
+    builder.append(fieldTypes.mkString(","))
+    if (fields.length > 2) {
+      if (fields.length - fieldTypes.size == 1) {
+        builder.append(" ... 1 more field")
+      } else {
+        builder.append(" ... " + (fields.length - 2) + " more fields")
+      }
+    }
+    builder.append(">").toString()
+  }
+
   /**
    * Merges with another schema (`StructType`).  For a struct field A from `this` and a struct field
    * B from `that`,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -278,13 +278,13 @@ case class StructType(fields: Array[StructField]) extends DataType with Seq[Stru
     s"struct<${fieldTypes.mkString(",")}>"
   }
 
-  override def simpleString(maxNumberFields: Int): String = {
+  private[sql] override def simpleString(maxNumberFields: Int): String = {
     val builder = new StringBuilder
     val fieldTypes = fields.take(maxNumberFields).map {
       case f => s"${f.name}: ${f.dataType.simpleString(maxNumberFields)}"
     }
     builder.append("struct<")
-    builder.append(fieldTypes.mkString(","))
+    builder.append(fieldTypes.mkString(", "))
     if (fields.length > 2) {
       if (fields.length - fieldTypes.size == 1) {
         builder.append(" ... 1 more field")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/Queryable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/Queryable.scala
@@ -30,7 +30,20 @@ private[sql] trait Queryable {
 
   override def toString: String = {
     try {
-      schema.map(f => s"${f.name}: ${f.dataType.simpleString}").mkString("[", ", ", "]")
+      val builder = new StringBuilder
+      val fields = schema.take(2).map {
+        case f => s"${f.name}: ${f.dataType.simpleString(2)}"
+      }
+      builder.append("[")
+      builder.append(fields.mkString(", "))
+      if (schema.length > 2) {
+        if (schema.length - fields.size == 1) {
+          builder.append(" ... 1 more field")
+        } else {
+          builder.append(" ... " + (schema.length - 2) + " more fields")
+        }
+      }
+      builder.append("]").toString()
     } catch {
       case NonFatal(e) =>
         s"Invalid tree; ${e.getMessage}:\n$queryExecution"

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -1157,52 +1157,41 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
   }
 
   test("SPARK-12398 truncated toString") {
-    val df1 = Seq((1: Long, "row1": String)).toDF("id", "name")
+    val df1 = Seq((1L, "row1")).toDF("id", "name")
     assert(df1.toString() === "[id: bigint, name: string]")
 
-    val df2 = Seq((1: Long, "c2": String, false: Boolean)).toDF("c1", "c2", "c3")
+    val df2 = Seq((1L, "c2", false)).toDF("c1", "c2", "c3")
     assert(df2.toString === "[c1: bigint, c2: string ... 1 more field]")
 
-    val df3 = Seq((1: Long, "c2": String, false: Boolean, 10: Integer)).toDF("c1", "c2", "c3", "c4")
+    val df3 = Seq((1L, "c2", false, 10)).toDF("c1", "c2", "c3", "c4")
     assert(df3.toString === "[c1: bigint, c2: string ... 2 more fields]")
 
-    val df4 = Seq((1: Long, Tuple2(1: Long, "val": String))).toDF("c1", "c2")
-    assert(df4.toString === "[c1: bigint, c2: struct<_1: bigint,_2: string>]")
+    val df4 = Seq((1L, Tuple2(1L, "val"))).toDF("c1", "c2")
+    assert(df4.toString === "[c1: bigint, c2: struct<_1: bigint, _2: string>]")
 
-    val df5 = Seq((1: Long, Tuple2(1: Long, "val": String), 20.0: Double)).toDF("c1", "c2", "c3")
-    assert(df5.toString === "[c1: bigint, c2: struct<_1: bigint,_2: string> ... 1 more field]")
+    val df5 = Seq((1L, Tuple2(1L, "val"), 20.0)).toDF("c1", "c2", "c3")
+    assert(df5.toString === "[c1: bigint, c2: struct<_1: bigint, _2: string> ... 1 more field]")
 
-    val df6 =
-      Seq((1: Long,
-        Tuple2(1: Long, "val": String),
-        20.0: Double, 1: Integer)).toDF("c1", "c2", "c3", "c4")
-    assert(df6.toString === "[c1: bigint, c2: struct<_1: bigint,_2: string> ... 2 more fields]")
+    val df6 = Seq((1L, Tuple2(1L, "val"), 20.0, 1)).toDF("c1", "c2", "c3", "c4")
+    assert(df6.toString === "[c1: bigint, c2: struct<_1: bigint, _2: string> ... 2 more fields]")
 
-    val df7 =
-      Seq((1: Long,
-        Tuple3(1: Long, "val": String, 2: Short),
-        20.0: Double, 1: Integer)).toDF("c1", "c2", "c3", "c4")
+    val df7 = Seq((1L, Tuple3(1L, "val", 2), 20.0, 1)).toDF("c1", "c2", "c3", "c4")
     assert(
       df7.toString ===
-        "[c1: bigint, c2: struct<_1: bigint,_2: string ... 1 more field> ... 2 more fields]")
+        "[c1: bigint, c2: struct<_1: bigint, _2: string ... 1 more field> ... 2 more fields]")
 
-    val df8 =
-      Seq((1: Long,
-        Tuple7(1: Long, "val": String, 2: Short, 3: Integer, 4: Integer, 5: Integer, 6: Integer ),
-        20.0: Double, 1: Integer)).toDF("c1", "c2", "c3", "c4")
+    val df8 = Seq((1L, Tuple7(1L, "val", 2, 3, 4, 5, 6), 20.0, 1)).toDF("c1", "c2", "c3", "c4")
     assert(
       df8.toString ===
-        "[c1: bigint, c2: struct<_1: bigint,_2: string ... 5 more fields> ... 2 more fields]")
+        "[c1: bigint, c2: struct<_1: bigint, _2: string ... 5 more fields> ... 2 more fields]")
 
     val df9 =
-      Seq((1: Long,
-        Tuple4(1: Long, Tuple4(1: Long, 2: Long, 3: Long, 4: Long), 2: Long, 3: Long),
-        20.0: Double, 1: Integer)).toDF("c1", "c2", "c3", "c4")
+      Seq((1L, Tuple4(1L, Tuple4(1L, 2L, 3L, 4L), 2L, 3L), 20.0, 1)).toDF("c1", "c2", "c3", "c4")
     assert(
       df9.toString ===
         "[c1: bigint, c2: struct<_1: bigint," +
-          "_2: struct<_1: bigint," +
-          "_2: bigint ... 2 more fields> ... 2 more fields> ... 2 more fields]")
+          " _2: struct<_1: bigint," +
+          " _2: bigint ... 2 more fields> ... 2 more fields> ... 2 more fields]")
 
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -1155,4 +1155,54 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     val primitiveUDF = udf((i: Int) => i * 2)
     checkAnswer(df.select(primitiveUDF($"age")), Row(44) :: Row(null) :: Nil)
   }
+
+  test("SPARK-12398 truncated toString") {
+    val df1 = Seq((1: Long, "row1": String)).toDF("id", "name")
+    assert(df1.toString() === "[id: bigint, name: string]")
+
+    val df2 = Seq((1: Long, "c2": String, false: Boolean)).toDF("c1", "c2", "c3")
+    assert(df2.toString === "[c1: bigint, c2: string ... 1 more field]")
+
+    val df3 = Seq((1: Long, "c2": String, false: Boolean, 10: Integer)).toDF("c1", "c2", "c3", "c4")
+    assert(df3.toString === "[c1: bigint, c2: string ... 2 more fields]")
+
+    val df4 = Seq((1: Long, Tuple2(1: Long, "val": String))).toDF("c1", "c2")
+    assert(df4.toString === "[c1: bigint, c2: struct<_1: bigint,_2: string>]")
+
+    val df5 = Seq((1: Long, Tuple2(1: Long, "val": String), 20.0: Double)).toDF("c1", "c2", "c3")
+    assert(df5.toString === "[c1: bigint, c2: struct<_1: bigint,_2: string> ... 1 more field]")
+
+    val df6 =
+      Seq((1: Long,
+        Tuple2(1: Long, "val": String),
+        20.0: Double, 1: Integer)).toDF("c1", "c2", "c3", "c4")
+    assert(df6.toString === "[c1: bigint, c2: struct<_1: bigint,_2: string> ... 2 more fields]")
+
+    val df7 =
+      Seq((1: Long,
+        Tuple3(1: Long, "val": String, 2: Short),
+        20.0: Double, 1: Integer)).toDF("c1", "c2", "c3", "c4")
+    assert(
+      df7.toString ===
+        "[c1: bigint, c2: struct<_1: bigint,_2: string ... 1 more field> ... 2 more fields]")
+
+    val df8 =
+      Seq((1: Long,
+        Tuple7(1: Long, "val": String, 2: Short, 3: Integer, 4: Integer, 5: Integer, 6: Integer ),
+        20.0: Double, 1: Integer)).toDF("c1", "c2", "c3", "c4")
+    assert(
+      df8.toString ===
+        "[c1: bigint, c2: struct<_1: bigint,_2: string ... 5 more fields> ... 2 more fields]")
+
+    val df9 =
+      Seq((1: Long,
+        Tuple4(1: Long, Tuple4(1: Long, 2: Long, 3: Long, 4: Long), 2: Long, 3: Long),
+        20.0: Double, 1: Integer)).toDF("c1", "c2", "c3", "c4")
+    assert(
+      df9.toString ===
+        "[c1: bigint, c2: struct<_1: bigint," +
+          "_2: struct<_1: bigint," +
+          "_2: bigint ... 2 more fields> ... 2 more fields> ... 2 more fields]")
+
+  }
 }


### PR DESCRIPTION
When a DataFrame or Dataset has a long schema, we should intelligently truncate to avoid flooding the screen with unreadable information.
// Standard output
[a: int, b: int]

// Truncate many top level fields
[a: int, b, string ... 10 more fields]

// Truncate long inner structs
[a: struct<a: Int ... 10 more fields>]
