### PR TITLE
[SPARK-12010][SQL] Spark JDBC requires support for column-name-free INSERT syntax

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -60,17 +60,6 @@ object JdbcUtils extends Logging {
   }
 
   /**
-   * Returns a PreparedStatement that inserts a row into table via conn.
-   */
-  def insertStatement(conn: Connection,
-                      dialect: JdbcDialect,
-                      table: String,
-                      rddSchema: StructType): PreparedStatement = {
-    val sql = dialect.getInsertStatement(table, rddSchema)
-    conn.prepareStatement(sql)
-  }
-
-  /**
    * Retrieve standard jdbc types.
    * @param dt The datatype (e.g. [[org.apache.spark.sql.types.StringType]])
    * @return The default JdbcType for this DataType
@@ -136,7 +125,8 @@ object JdbcUtils extends Logging {
       if (supportsTransactions) {
         conn.setAutoCommit(false) // Everything in the same db transaction.
       }
-      val stmt = insertStatement(conn, dialect, table, rddSchema)
+      val sql = dialect.getInsertStatement(table, rddSchema)
+      val stmt = conn.prepareStatement(sql)
       try {
         var rowCount = 0
         while (iterator.hasNext) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -123,7 +123,6 @@ object JdbcUtils extends Logging {
       dialect: JdbcDialect): Iterator[Byte] = {
     val conn = getConnection()
     var committed = false
-    // Temp work-around. Not to be commited!!!!
     val supportsTransactions = try {
       conn.getMetaData().supportsDataManipulationTransactionsOnly() ||
       conn.getMetaData().supportsDataDefinitionAndDataManipulationTransactions()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -60,6 +60,17 @@ object JdbcUtils extends Logging {
   }
 
   /**
+   * Returns a PreparedStatement that inserts a row into table via conn.
+   */
+  def insertStatement(conn: Connection,
+                      table: String,
+                      rddSchema: StructType,
+                      dialect: JdbcDialect): PreparedStatement = {
+    val sql = dialect.getInsertStatement(table, rddSchema)
+    conn.prepareStatement(sql)
+  }
+
+  /**
    * Retrieve standard jdbc types.
    * @param dt The datatype (e.g. [[org.apache.spark.sql.types.StringType]])
    * @return The default JdbcType for this DataType
@@ -125,8 +136,7 @@ object JdbcUtils extends Logging {
       if (supportsTransactions) {
         conn.setAutoCommit(false) // Everything in the same db transaction.
       }
-      val sql = dialect.getInsertStatement(table, rddSchema)
-      val stmt = conn.prepareStatement(sql)
+      val stmt = insertStatement(conn, table, rddSchema, dialect)
       try {
         var rowCount = 0
         while (iterator.hasNext) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -63,10 +63,9 @@ object JdbcUtils extends Logging {
    * Returns a PreparedStatement that inserts a row into table via conn.
    */
   def insertStatement(conn: Connection, table: String, rddSchema: StructType): PreparedStatement = {
-    val sql = rddSchema.fields.map(field => field.name)
-                       .mkString(s"INSERT INTO $table ( ", ", ", " ) " ) +
-              rddSchema.fields.map(field => "?")
-                       .mkString("VALUES ( ", ", ", " )" )
+    val columns = rddSchema.fields.map(_.name).mkString(",")
+    val placeholders = rddSchema.fields.map(_ => "?").mkString(",")
+    val sql = s"INSERT INTO $table ($columns) VALUES ($placeholders)"
     conn.prepareStatement(sql)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -108,6 +108,24 @@ abstract class JdbcDialect extends Serializable {
   def beforeFetch(connection: Connection, properties: Map[String, String]): Unit = {
   }
 
+  /**
+   * Get the SQL statement that should be used to insert new records into the table.
+   * Dialects can override this method to return a statement that works best in a particular
+   * database.
+   * @param table          The name of the table.
+   * @param rddSchema      The schema of DataFrame to be inserted
+   * @param columnMapping  An optional mapping from DataFrame field names to database column
+   *                       names
+   * @return The SQL statement to use for inserting into the table.
+   */
+  def getInsertStatement(table: String,
+                         rddSchema: StructType): String = {
+    rddSchema.fields.map(field => field.name)
+      .mkString(s"INSERT INTO $table ( ", ", ", " ) " ) +
+    rddSchema.fields.map(field => "?")
+      .mkString("VALUES ( ", ", ", " )" )
+  }
+
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -108,24 +108,6 @@ abstract class JdbcDialect extends Serializable {
   def beforeFetch(connection: Connection, properties: Map[String, String]): Unit = {
   }
 
-  /**
-   * Get the SQL statement that should be used to insert new records into the table.
-   * Dialects can override this method to return a statement that works best in a particular
-   * database.
-   * @param table          The name of the table.
-   * @param rddSchema      The schema of DataFrame to be inserted
-   * @param columnMapping  An optional mapping from DataFrame field names to database column
-   *                       names
-   * @return The SQL statement to use for inserting into the table.
-   */
-  def getInsertStatement(table: String,
-                         rddSchema: StructType): String = {
-    rddSchema.fields.map(field => field.name)
-      .mkString(s"INSERT INTO $table ( ", ", ", " ) " ) +
-    rddSchema.fields.map(field => "?")
-      .mkString("VALUES ( ", ", ", " )" )
-  }
-
 }
 
 /**


### PR DESCRIPTION
In the past Spark JDBC write only worked with technologies which support the following INSERT statement syntax (JdbcUtils.scala: insertStatement()):

INSERT INTO $table VALUES ( ?, ?, ..., ? )

But some technologies require a list of column names:

INSERT INTO $table ( $colNameList ) VALUES ( ?, ?, ..., ? )

This was blocking the use of e.g. the Progress JDBC Driver for Cassandra.

Another limitation is that syntax 1 relies no the dataframe field ordering match that of the target table. This works fine, as long as the target table has been created by writer.jdbc().

If the target table contains more columns (not created by writer.jdbc()), then the insert fails due mismatch of number of columns or their data types.

This PR switches to the recommended second INSERT syntax. Column names are taken from datafram field names.
