### PR TITLE
[SPARK-12424][ML] The implementation of ParamMap#filter is wrong.

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
@@ -863,10 +863,7 @@ final class ParamMap private[ml] (private val map: mutable.Map[Param[Any], Any])
     // returns the instance of collections.Map, not mutable.Map.
     // Otherwise, we get ClassCastException.
     // Not using filterKeys also avoid SI-6654
-    val filtered = map.filter {
-      case (k, _) =>
-        k.parent == parent.uid
-    }
+    val filtered = map.filter { case (k, _) => k.parent == parent.uid }
     new ParamMap(filtered)
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
@@ -865,7 +865,7 @@ final class ParamMap private[ml] (private val map: mutable.Map[Param[Any], Any])
     // Not using filterKeys also avoid SI-6654
     val filtered = map.filter {
       case (k, _) =>
-      k.parent == parent.uid
+        k.parent == parent.uid
     }
     new ParamMap(filtered)
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/param/params.scala
@@ -859,8 +859,15 @@ final class ParamMap private[ml] (private val map: mutable.Map[Param[Any], Any])
    * Filters this param map for the given parent.
    */
   def filter(parent: Params): ParamMap = {
-    val filtered = map.filterKeys(_.parent == parent)
-    new ParamMap(filtered.asInstanceOf[mutable.Map[Param[Any], Any]])
+    // Don't use filterKeys because mutable.Map#filterKeys
+    // returns the instance of collections.Map, not mutable.Map.
+    // Otherwise, we get ClassCastException.
+    // Not using filterKeys also avoid SI-6654
+    val filtered = map.filter {
+      case (k, _) =>
+      k.parent == parent.uid
+    }
+    new ParamMap(filtered)
   }
 
   /**

--- a/mllib/src/test/scala/org/apache/spark/ml/param/ParamsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/param/ParamsSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.ml.param
 
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.ml.util.MyParams
 import org.apache.spark.mllib.linalg.{Vector, Vectors}
 
 class ParamsSuite extends SparkFunSuite {
@@ -348,6 +349,26 @@ class ParamsSuite extends SparkFunSuite {
     assert(!t2.isSet(t2.maxIter))
     val t3 = t.copy(ParamMap(t.maxIter -> 20))
     assert(t3.isSet(t3.maxIter))
+  }
+
+  test("Filtering ParamMap") {
+    val params1 = new MyParams("my_params1")
+    val params2 = new MyParams("my_params2")
+    val paramMap = ParamMap(
+      params1.intParam -> 1,
+      params2.intParam -> 1,
+      params1.doubleParam -> 0.2,
+      params2.doubleParam -> 0.2)
+    val filteredParamMap = paramMap.filter(params1)
+
+    assert(filteredParamMap.size === 2)
+    filteredParamMap.toSeq.foreach {
+      case ParamPair(p, _) =>
+        assert(p.parent === params1.uid)
+    }
+
+    // Following assertion is to avoid SI-6654
+    assert(filteredParamMap.isInstanceOf[Serializable])
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/param/ParamsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/param/ParamsSuite.scala
@@ -375,17 +375,7 @@ class ParamsSuite extends SparkFunSuite {
     // Now mutable.Map#filter is used instead of filterKeys and the return type is serializable.
     // So let's ensure serializability.
     val objOut = new ObjectOutputStream(new ByteArrayOutputStream())
-    try {
-      objOut.writeObject(filteredParamMap)
-    } catch {
-      case _: NotSerializableException =>
-        fail("The field of ParamMap 'map' may not be serializable. " +
-          "See SI-6654 and the implementation of ParamMap#filter")
-      case e: Exception =>
-        fail(s"Exception was thrown unexpectedly during the serializability test: ${e.getMessage}")
-    } finally {
-      objOut.close()
-    }
+    objOut.writeObject(filteredParamMap)
   }
 }
 


### PR DESCRIPTION
ParamMap#filter uses `mutable.Map#filterKeys`. The return type of `filterKey` is collection.Map, not mutable.Map but the result is casted to mutable.Map using `asInstanceOf` so we get `ClassCastException`.
Also, the return type of Map#filterKeys is not Serializable. It's the issue of Scala (https://issues.scala-lang.org/browse/SI-6654).
