### PR TITLE
[SPARK-12231][SQL]create a combineFilters' projection when we call buildPartitionedTableScan

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -77,7 +77,8 @@ private[sql] object DataSourceStrategy extends Strategy with Logging {
       val pushedFilters = filters.filter(_.references.intersect(partitionColumns).isEmpty)
 
       // Predicates with both partition keys and attributes
-      val partitionAndNormalColumnFilters = filters.toSet -- partitionFilters.toSet -- pushedFilters.toSet
+      val partitionAndNormalColumnFilters =
+        filters.toSet -- partitionFilters.toSet -- pushedFilters.toSet
 
       val selectedPartitions = prunePartitions(partitionFilters, t.partitionSpec).toArray
 
@@ -88,7 +89,7 @@ private[sql] object DataSourceStrategy extends Strategy with Logging {
         s"Selected $selected partitions out of $total, pruned $percentPruned% partitions."
       }
 
-      // need to add projections from combineFilters in
+      // need to add projections from "partitionAndNormalColumnAttrs" in if it is not empty
       val partitionAndNormalColumnAttrs = AttributeSet(partitionAndNormalColumnFilters)
       val partitionAndNormalColumnProjs = if (partitionAndNormalColumnAttrs.isEmpty) {
         projects
@@ -104,8 +105,8 @@ private[sql] object DataSourceStrategy extends Strategy with Logging {
         selectedPartitions)
 
       // Add a Projection to guarantee the original projection:
-      // this is because "partitionAndNormalColumnAttrs" may be different from the original "projects",
-      // in elements or their ordering
+      // this is because "partitionAndNormalColumnAttrs" may be different
+      // from the original "projects", in elements or their ordering
 
       partitionAndNormalColumnFilters.reduceLeftOption(expressions.And).map(cf =>
         if (projects.isEmpty || projects == partitionAndNormalColumnProjs) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -100,8 +100,8 @@ private[sql] object DataSourceStrategy extends Strategy with Logging {
         selectedPartitions)
 
       // Add a Projection to guarantee the original projection:
-      // this is because "projs" may be different from the original "projects",
-      // in elements or their ordering
+      // this is because "combinedProjects" may be different from the
+      // original "projects", in elements or their ordering
       combineFilter.map(cf => if (projects.isEmpty || combinedProjects.size < 2) {
         // If the original projection is empty or the scan's projection
         // has 0 or one element, then no need for an extra Project

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -88,16 +88,27 @@ private[sql] object DataSourceStrategy extends Strategy with Logging {
         s"Selected $selected partitions out of $total, pruned $percentPruned% partitions."
       }
 
+      // need to add projections from combineFilters in
+      val combineFilter = combineFilters.reduceLeftOption(expressions.And)
+      val combinedProjects = combineFilter.map(_.references.toSet.union(projects.toSet).toSeq)
+        .getOrElse(projects)
       val scan = buildPartitionedTableScan(
         l,
-        projects,
+        combinedProjects,
         pushedFilters,
         t.partitionSpec.partitionColumns,
         selectedPartitions)
 
-      combineFilters
-        .reduceLeftOption(expressions.And)
-        .map(execution.Filter(_, scan)).getOrElse(scan) :: Nil
+      // Add a Projection to guarantee the original projection:
+      // this is because "projs" may be different from the original "projects",
+      // in elements or their ordering
+      combineFilter.map(cf => if (projects.isEmpty || combinedProjects.size < 2) {
+        // If the original projection is empty or the scan's projection
+        // has 0 or one element, then no need for an extra Project
+        execution.Filter(cf, scan)
+      } else {
+        execution.Project(projects, execution.Filter(cf, scan))
+      }).getOrElse(scan) :: Nil
 
     // Scanning non-partitioned HadoopFsRelation
     case PhysicalOperation(projects, filters, l @ LogicalRelation(t: HadoopFsRelation, _)) =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
@@ -194,45 +194,4 @@ class DataFrameNaFunctionsSuite extends QueryTest with SharedSQLContext {
     assert(out1(4) === Row("Amy", null, null))
     assert(out1(5) === Row(null, null, null))
   }
-
-  test("Spark-12231: dropna with partitionBy and groupBy") {
-    withTempPath { dir =>
-      val df = sqlContext.range(10)
-      val df1 = df.withColumn("a", $"id".cast("int"))
-      df1.write.partitionBy("id").parquet(dir.getCanonicalPath)
-      val df2 = sqlContext.read.parquet(dir.getCanonicalPath)
-      val group = df2.na.drop().groupBy().count().collect()
-      assert(group(0).get(0) == 10)
-    }
-  }
-
-  test("Spark-12231: dropna with partitionBy") {
-    withTempPath { dir =>
-      val df = sqlContext.range(10)
-      val df1 = df.withColumn("a", $"id".cast("int"))
-      df1.write.partitionBy("id").parquet(dir.getCanonicalPath)
-      val df2 = sqlContext.read.parquet(dir.getCanonicalPath)
-      val group = df2.na.drop().count()
-      assert(group === 10L)
-    }
-  }
-
-  test("Spark-12231: dropna with sizable projection") {
-    // use a large projection to (almost) ensure that the projection ordering is respected
-    withTempPath { dir =>
-      val df = sqlContext.range(10)
-      val df1 = df.withColumn("a", $"id".cast("int"))
-        .withColumn("b", $"id".cast("int") + 1)
-        .withColumn("c", $"id".cast("int") + 2)
-        .withColumn("d", $"id".cast("int") + 3)
-
-      df1.write.partitionBy("id").parquet(dir.getCanonicalPath)
-
-      val df2 = sqlContext.read.parquet(dir.getCanonicalPath)
-
-      val group = df2.na.drop().orderBy("a").select("a", "b", "c", "d")
-      val result = group.collect()
-      assert(result(0) === Row(0, 1, 2, 3))
-    }
-  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -323,24 +323,45 @@ class ParquetFilterSuite extends QueryTest with ParquetTest with SharedSQLContex
     }
   }
 
-  test("SPARK-112231: Filter combine partition key and projects doesn't work in DataSource scan") {
+  test("SPARK-12231: test the filter and empty project in partitioned DataSource scan") {
     import testImplicits._
 
     withSQLConf(SQLConf.PARQUET_FILTER_PUSHDOWN_ENABLED.key -> "true") {
       withTempPath { dir =>
-        val path = s"${dir.getCanonicalPath}/part=1"
-        (1 to 3).map(i => (i, i + 1, i + 2, i + 3)).toDF("a", "b", "c", "d").write.parquet(path)
+        val path = s"${dir.getCanonicalPath}"
+        (1 to 3).map(i => (i, i + 1, i + 2, i + 3)).toDF("a", "b", "c", "d").
+          write.partitionBy("a").parquet(path)
 
-        // If the "part = 1" filter gets pushed down, this query will throw an exception since
-        // "part" is not a valid column in the actual Parquet file
-        checkAnswer(
-          sqlContext.read.parquet(dir.getCanonicalPath).filter("a > 1").orderBy("a")
-            selectExpr("a", "b", "c", "d"),
-          (2 to 3).map(i => Row(i, i + 1, i + 2, i + 3, 1)))
+        // The filter "a > 1 or b < 2" will not get pushed down, and the projection is empty,
+        // this query will throw an exception since the project from combinedFilter expect
+        // two projection while the
+        val df1 = sqlContext.read.parquet(dir.getCanonicalPath)
+
+        assert(df1.filter("a > 1 or b < 2").count() == 2)
       }
     }
   }
 
+  test("SPARK-12231: test the new projection in partitioned DataSource scan") {
+    import testImplicits._
+
+    withSQLConf(SQLConf.PARQUET_FILTER_PUSHDOWN_ENABLED.key -> "true") {
+      withTempPath { dir =>
+        val path = s"${dir.getCanonicalPath}"
+        (1 to 3).map(i => (i, i + 1, i + 2, i + 3)).toDF("a", "b", "c", "d").
+          write.partitionBy("a").parquet(path)
+
+        // test the generate new projection case
+        // when projects != partitionAndNormalColumnProjs
+
+        val df1 = sqlContext.read.parquet(dir.getCanonicalPath)
+
+        checkAnswer(
+          df1.filter("a > 1 or b > 2").orderBy("a").selectExpr("a", "b", "c", "d"),
+          (2 to 3).map(i => Row(i, i + 1, i + 2, i + 3)))
+      }
+    }
+  }
 
 
   test("SPARK-11103: Filter applied on merged Parquet schema with new column fails") {


### PR DESCRIPTION
Hello Michael & All: 

We have some issues to submit the new codes in the other PR(#10299), so we closed that PR and open this one with the fix. 

The reason for the previous failure is that the projection for the scan when there is a filter that is not pushed down (the "left-over" filter) could be different, in elements or ordering, from the original projection.

With this new codes, the approach to solve this problem is:

Insert a new Project if the "left-over" filter is nonempty and (the original projection is not empty and the projection for the scan has more than one elements which could otherwise cause different ordering in projection).

We create 3 test cases to cover the otherwise failure cases.
