### PR TITLE
[SPARK-12440][Core] - Avoid setCheckpoint warning when directory is not local

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -2073,8 +2073,8 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
     // its own local file system, which is incorrect because the checkpoint files
     // are actually on the executor machines.
     if (!isLocal && Utils.nonLocalPaths(directory).isEmpty) {
-      logWarning(s"Spark is not running in local mode, therefore the checkpoint directory " +
-        "must not be on the local filesystem. Directory '$directory' " +
+      logWarning("Spark is not running in local mode, therefore the checkpoint directory " +
+        s"must not be on the local filesystem. Directory '$directory' " +
         "appears to be on the local filesystem.")
     }
 

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -2073,8 +2073,8 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
     // its own local file system, which is incorrect because the checkpoint files
     // are actually on the executor machines.
     if (!isLocal && Utils.nonLocalPaths(directory).isEmpty) {
-      logWarning(s"Spark is not running in local mode, therefore the checkpoint directory "+
-        "must not be on the local filesystem. Directory '$directory' "+
+      logWarning(s"Spark is not running in local mode, therefore the checkpoint directory " +
+        "must not be on the local filesystem. Directory '$directory' " +
         "appears to be on the local filesystem.")
     }
 

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -2066,7 +2066,8 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
    * Set the directory under which RDDs are going to be checkpointed. The directory must
    * be a HDFS path if running on a cluster.
    */
-  def setCheckpointDir(dir
+  def setCheckpointDir(directory: String) {
+
     // If we are running on a cluster, log a warning if the directory is local.
     // Otherwise, the driver may attempt to reconstruct the checkpointed RDD from
     // its own local file system, which is incorrect because the checkpoint files

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -2066,24 +2066,24 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
    * Set the directory under which RDDs are going to be checkpointed. The directory must
    * be a HDFS path if running on a cluster.
    */
-  def setCheckpointDir(directory: String) {
-
+  def setCheckpointDir(dir
     // If we are running on a cluster, log a warning if the directory is local.
     // Otherwise, the driver may attempt to reconstruct the checkpointed RDD from
     // its own local file system, which is incorrect because the checkpoint files
     // are actually on the executor machines.
-    val path = new Path(directory, UUID.randomUUID().toString)
-    val fs = path.getFileSystem(hadoopConfiguration)
-    val isDirLocal = fs.isInstanceOf[LocalFileSystem]
-    if (!isLocal && Utils.nonLocalPaths(directory).isEmpty && !isDirLocal) {
-      logWarning("Checkpoint directory must be non-local " +
-        "if Spark is running on a cluster: " + directory)
+    if (!isLocal && Utils.nonLocalPaths(directory).isEmpty) {
+      logWarning(s"Spark is not running in local mode, therefore the checkpoint directory "+
+        "must not be on the local filesystem. Directory '$directory' "+
+        "appears to be on the local filesystem.")
     }
 
     checkpointDir = Option(directory).map { dir =>
+      val path = new Path(dir, UUID.randomUUID().toString)
+      val fs = path.getFileSystem(hadoopConfiguration)
       fs.mkdirs(path)
       fs.getFileStatus(path).getPath.toString
     }
+
   }
 
   def getCheckpointDir: Option[String] = checkpointDir

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -35,7 +35,7 @@ import scala.util.control.NonFatal
 
 import org.apache.commons.lang.SerializationUtils
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{Path,LocalFileSystem}
+import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.{ArrayWritable, BooleanWritable, BytesWritable, DoubleWritable,
   FloatWritable, IntWritable, LongWritable, NullWritable, Text, Writable}
 import org.apache.hadoop.mapred.{FileInputFormat, InputFormat, JobConf, SequenceFileInputFormat,
@@ -2084,7 +2084,6 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
       fs.mkdirs(path)
       fs.getFileStatus(path).getPath.toString
     }
-
   }
 
   def getCheckpointDir: Option[String] = checkpointDir


### PR DESCRIPTION
In SparkContext method `setCheckpointDir`, a warning is issued when spark master is not local and the passed directory for the checkpoint dir appears to be local.

In practice, when relying on HDFS configuration file and using a relative path for the checkpoint directory (using an incomplete URI without HDFS scheme, ...), this warning should not be issued and might be confusing.
In fact, in this case, the checkpoint directory is successfully created, and the checkpointing mechanism works as expected.

This PR uses the `FileSystem` instance created with the given directory, and checks whether it is local or not.
(The rationale is that since this same `FileSystem` instance is used to create the checkpoint dir anyway and can therefore be reliably used to determine if it is local or not).

The warning is only issued if the directory is not local, on top of the existing conditions.
