### PR TITLE
[SPARK-12292] [SQL] Support UnsafeRow in Generator.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/Generate.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/Generate.scala
@@ -56,6 +56,10 @@ case class Generate(
 
   val boundGenerator = BindReferences.bindReference(generator, child.output)
 
+  override def outputsUnsafeRows: Boolean = child.outputsUnsafeRows
+  override def canProcessUnsafeRows: Boolean = true
+  override def canProcessSafeRows: Boolean = true
+
   protected override def doExecute(): RDD[InternalRow] = {
     // boundGenerator.terminate() should be triggered after all of the rows in the partition
     if (join) {


### PR DESCRIPTION
After the fix, unsafe->safe convertors are not inserted between Generate and its Child.
