### PR TITLE
[SPARK-12444][SQL] A lightweight Scala DSL for schema construction

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/ArrayType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/ArrayType.scala
@@ -29,6 +29,11 @@ object ArrayType extends AbstractDataType {
   /** Construct a [[ArrayType]] object with the given element type. The `containsNull` is true. */
   def apply(elementType: DataType): ArrayType = ArrayType(elementType, containsNull = true)
 
+  def apply(elementTypeSpec: (DataType, Boolean)): ArrayType = {
+    val (elementType, containsNull) = elementTypeSpec
+    ArrayType(elementType, containsNull)
+  }
+
   override private[sql] def defaultConcreteType: DataType = ArrayType(NullType, containsNull = true)
 
   override private[sql] def acceptsType(other: DataType): Boolean = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.types
 
+import scala.language.implicitConversions
 import scala.util.Try
 import scala.util.parsing.combinator.RegexParsers
 
@@ -373,4 +374,6 @@ object DataType {
       case (fromDataType, toDataType) => fromDataType == toDataType
     }
   }
+
+  implicit def dataTypeWithNullability(dataType: DataType): (DataType, Boolean) = dataType -> true
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -87,6 +87,10 @@ abstract class DataType extends AbstractDataType {
   override private[sql] def defaultConcreteType: DataType = this
 
   override private[sql] def acceptsType(other: DataType): Boolean = sameType(other)
+
+  def ! : (DataType, Boolean) = (this, false)
+
+  def ? : (DataType, Boolean) = (this, true)
 }
 
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -88,8 +88,60 @@ abstract class DataType extends AbstractDataType {
 
   override private[sql] def acceptsType(other: DataType): Boolean = sameType(other)
 
+  /**
+   * This method and [[?]] are used together with constructors of complex types ([[ArrayType]],
+   * [[MapType]], and [[StructType]]), to indicate nullability of a struct field, an array element
+   * type.
+   *
+   * Examples:
+   *
+   *  - `StructType`:
+   *
+   *    {{{
+   *      StructType(
+   *        "a" -> IntegerType.!,
+   *        "b" -> StringType.?
+   *      )
+   *    }}}
+   *    is equivalent to
+   *    {{{
+   *      StructType(Seq(
+   *        StructField("a", IntegerType, nullable = false),
+   *        StructField("b", IntegerType, nullable = true)
+   *      ))
+   *    }}}
+   *
+   *  - `ArrayType`:
+   *
+   *    {{{
+   *      ArrayType(IntegerType.!)
+   *    }}}
+   *    is equivalent to
+   *    {{{
+   *      ArrayType(IntegerType, containsNull = false)
+   *    }}}
+   *
+   *  - `MapType`:
+   *
+   *    {{{
+   *      MapType(IntegerType, StringType.?)
+   *    }}}
+   *    is equivalent to
+   *    {{{
+   *      MapType(IntegerType, StringType, valueContainsNull = true)
+   *    }}}
+   *
+   * @see [[?]]
+   */
   def ! : (DataType, Boolean) = (this, false)
 
+  /**
+   * This method and [[!]] are used together with constructors of complex types ([[ArrayType]],
+   * [[MapType]], and [[StructType]]), to indicate nullability of a struct field, an array element
+   * type.
+   *
+   * @see [[!]] for examples
+   */
   def ? : (DataType, Boolean) = (this, true)
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/MapType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/MapType.scala
@@ -87,4 +87,9 @@ object MapType extends AbstractDataType {
    */
   def apply(keyType: DataType, valueType: DataType): MapType =
     MapType(keyType: DataType, valueType: DataType, valueContainsNull = true)
+
+  def apply(keyType: DataType, valueTypeSpec: (DataType, Boolean)): MapType = {
+    val (valueType, valueContainsNull) = valueTypeSpec
+    apply(keyType, valueType, valueContainsNull)
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -332,6 +332,15 @@ object StructType extends AbstractDataType {
     StructType(fields.asScala)
   }
 
+  def apply(
+      firstField: (String, (DataType, Boolean)),
+      restFields: (String, (DataType, Boolean))*): StructType = {
+    apply((firstField +: restFields).map {
+      case (name, (dataType, nullable)) =>
+        StructField(name, dataType, nullable)
+    })
+  }
+
   protected[sql] def fromAttributes(attributes: Seq[Attribute]): StructType =
     StructType(attributes.map(a => StructField(a.name, a.dataType, a.nullable, a.metadata)))
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -64,6 +64,35 @@ class DataTypeSuite extends SparkFunSuite {
     assert(StructField("c", StringType, true) === struct("c"))
   }
 
+  test("lightweight DSL for constructing schema") {
+    val actual = StructType(
+      "f0" -> IntegerType.!,
+      "f1" -> ArrayType(IntegerType.?).!,
+      "f2" -> MapType(
+        IntegerType,
+        StructType(
+          "f20" -> DoubleType.!,
+          "f21" -> StringType.?
+        ).!
+      ).?
+    )
+
+    val expected = StructType(Seq(
+      StructField("f0", IntegerType, nullable = false),
+      StructField("f1", ArrayType(IntegerType, containsNull = true), nullable = false),
+      StructField("f2", MapType(
+        IntegerType,
+        StructType(Seq(
+          StructField("f20", DoubleType, nullable = false),
+          StructField("f21", StringType, nullable = true)
+        )),
+        valueContainsNull = false
+      ), nullable = true)
+    ))
+
+    assert(actual === expected)
+  }
+
   test("extract fields from a StructType") {
     val struct = StructType(
       StructField("a", IntegerType, true) ::

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -67,14 +67,14 @@ class DataTypeSuite extends SparkFunSuite {
   test("lightweight DSL for constructing schema") {
     val actual = StructType(
       "f0" -> IntegerType.!,
-      "f1" -> ArrayType(IntegerType.?).!,
+      "f1" -> ArrayType(IntegerType).!,
       "f2" -> MapType(
         IntegerType,
         StructType(
           "f20" -> DoubleType.!,
-          "f21" -> StringType.?
+          "f21" -> StringType
         ).!
-      ).?
+      )
     )
 
     val expected = StructType(Seq(


### PR DESCRIPTION
This PR introduces a lightweight Scala DSL for constructing complex Spark SQL schema.

Two DSL methods `!` and `?` are added to `DataType` to help indicating nullability of struct field, array element type, and map value type.
- `!` means non-nullable (or required), while
- `?` means nullable (or optional)
  
  An implicit conversion from any `DataType` `t` to `t -> true` is added, so that the `?` call can be optional in most cases.  This behavior is consistent to existing constructors of complex types, where `nullable`, `containsNull`, and `valueContainsNull` are all `true` by default.

With the help of these two methods, and three more constructors, we can now construct schema like this:

``` scala
StructType(
  "f0" -> IntegerType.!,
  "f1" -> ArrayType(IntegerType).!,
  "f2" -> MapType(
    IntegerType,
    StructType(
      "f20" -> DoubleType.!,
      "f21" -> StringType
    ).!
  )
)
```

which is conciser and arguably more readable than equivalent existing approaches:

``` scala
StructType(Seq(
  StructField("f0", IntegerType, nullable = false),
  StructField("f1", ArrayType(IntegerType), nullable = false),
  StructField("f2", MapType(
    IntegerType,
    StructType(Seq(
      StructField("f20", DoubleType, nullable = false),
      StructField("f21", StringType)
    )),
    valueContainsNull = false
  ))
))

new StructType()
  .add("f0", IntegerType, nullable = false)
  .add("f1", ArrayType(IntegerType), nullable = false)
  .add("f2", MapType(
    IntegerType,
    new StructType()
      .add("f20", DoubleType, nullable = false)
      .add("f21", StringType),
    valueContainsNull = false
  ))
```
