### PR TITLE
[SPARK-12477][SQL] - Tungsten projection fails for null values in array fields

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
@@ -227,7 +227,7 @@ case class GetArrayItem(child: Expression, ordinal: Expression)
     nullSafeCodeGen(ctx, ev, (eval1, eval2) => {
       s"""
         final int index = (int) $eval2;
-        if (index >= $eval1.numElements() || index < 0) {
+        if (index >= $eval1.numElements() || index < 0 || $eval1.isNullAt(index)) {
           ${ev.isNull} = true;
         } else {
           ${ev.value} = ${ctx.getValue(eval1, dataType, "index")};

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameComplexTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameComplexTypeSuite.scala
@@ -44,8 +44,9 @@ class DataFrameComplexTypeSuite extends QueryTest with SharedSQLContext {
     df.select(array($"a").as("s")).select(f(expr("s[0]"))).collect()
   }
 
-    val df = sc.parallelize(Seq((Seq("val1",null,"val2"),Seq(Some(1),None,Some(2))))).toDF("s","i")
   test("SPARK-12477 accessing null element in array field") {
+    val df = sc.parallelize(Seq((Seq("val1", null, "val2"),
+      Seq(Some(1), None, Some(2))))).toDF("s", "i")
     val nullStringRow = df.selectExpr("s[1]").collect()(0)
     assert(nullStringRow == org.apache.spark.sql.Row(null))
     val nullIntRow = df.selectExpr("i[1]").collect()(0)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameComplexTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameComplexTypeSuite.scala
@@ -43,4 +43,12 @@ class DataFrameComplexTypeSuite extends QueryTest with SharedSQLContext {
     val df = sparkContext.parallelize(Seq((1, 1))).toDF("a", "b")
     df.select(array($"a").as("s")).select(f(expr("s[0]"))).collect()
   }
+
+  test("Accessing null element in array field") {
+    val df = sc.parallelize(Seq((Seq("val1",null,"val2"),Seq(Some(1),None,Some(2))))).toDF("s","i")
+    val nullStringRow = df.selectExpr("s[1]").collect()(0)
+    assert(nullStringRow == org.apache.spark.sql.Row(null))
+    val nullIntRow = df.selectExpr("i[1]").collect()(0)
+    assert(nullIntRow == org.apache.spark.sql.Row(null))
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameComplexTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameComplexTypeSuite.scala
@@ -44,8 +44,8 @@ class DataFrameComplexTypeSuite extends QueryTest with SharedSQLContext {
     df.select(array($"a").as("s")).select(f(expr("s[0]"))).collect()
   }
 
-  test("Accessing null element in array field") {
     val df = sc.parallelize(Seq((Seq("val1",null,"val2"),Seq(Some(1),None,Some(2))))).toDF("s","i")
+  test("SPARK-12477 accessing null element in array field") {
     val nullStringRow = df.selectExpr("s[1]").collect()(0)
     assert(nullStringRow == org.apache.spark.sql.Row(null))
     val nullIntRow = df.selectExpr("i[1]").collect()(0)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameComplexTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameComplexTypeSuite.scala
@@ -45,7 +45,7 @@ class DataFrameComplexTypeSuite extends QueryTest with SharedSQLContext {
   }
 
   test("SPARK-12477 accessing null element in array field") {
-    val df = sc.parallelize(Seq((Seq("val1", null, "val2"),
+    val df = sparkContext.parallelize(Seq((Seq("val1", null, "val2"),
       Seq(Some(1), None, Some(2))))).toDF("s", "i")
     val nullStringRow = df.selectExpr("s[1]").collect()(0)
     assert(nullStringRow == org.apache.spark.sql.Row(null))


### PR DESCRIPTION
Accessing null elements in an array field fails when tungsten is enabled.
It works in Spark 1.3.1, and in Spark > 1.5 with Tungsten disabled.

This PR solves this by checking if the accessed element in the array field is null, in the generated code.

Example:

```
// Array of String
case class AS( as: Seq[String] )
val dfAS = sc.parallelize( Seq( AS ( Seq("a",null,"b") ) ) ).toDF
dfAS.registerTempTable("T_AS")
for (i <- 0 to 2) { println(i + " = " + sqlContext.sql(s"select as[$i] from T_AS").collect.mkString(","))}
```

With Tungsten disabled:

```
0 = [a]
1 = [null]
2 = [b]
```

With Tungsten enabled:

```
0 = [a]
15/12/22 09:32:50 ERROR Executor: Exception in task 7.0 in stage 1.0 (TID 15)
java.lang.NullPointerException
    at org.apache.spark.sql.catalyst.expressions.UnsafeRowWriters$UTF8StringWriter.getSize(UnsafeRowWriters.java:90)
    at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.apply(Unknown Source)
    at org.apache.spark.sql.execution.TungstenProject$$anonfun$3$$anonfun$apply$3.apply(basicOperators.scala:90)
    at org.apache.spark.sql.execution.TungstenProject$$anonfun$3$$anonfun$apply$3.apply(basicOperators.scala:88)
    at scala.collection.Iterator$$anon$11.next(Iterator.scala:328)
    at scala.collection.Iterator$$anon$11.next(Iterator.scala:328)
    at scala.collection.Iterator$class.foreach(Iterator.scala:727)
    at scala.collection.AbstractIterator.foreach(Iterator.scala:1157)
```
