### PR TITLE
[CORE] Refactoring: Use pattern matching and dedicated method

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -349,12 +349,14 @@ private[spark] class TaskSchedulerImpl(
                 }
               }
             }
-            if (state == TaskState.FINISHED) {
-              taskSet.removeRunningTask(tid)
-              taskResultGetter.enqueueSuccessfulTask(taskSet, tid, serializedData)
-            } else if (Set(TaskState.FAILED, TaskState.KILLED, TaskState.LOST).contains(state)) {
-              taskSet.removeRunningTask(tid)
-              taskResultGetter.enqueueFailedTask(taskSet, tid, state, serializedData)
+            state match {
+              case TaskState.FINISHED =>
+                taskSet.removeRunningTask(tid)
+                taskResultGetter.enqueueSuccessfulTask(taskSet, tid, serializedData)
+              case s if TaskState.isFinished(s) =>
+                taskSet.removeRunningTask(tid)
+                taskResultGetter.enqueueFailedTask(taskSet, tid, state, serializedData)
+              case ignored =>
             }
           case None =>
             logError(


### PR DESCRIPTION
It should be slightly easier to see what really happens (without questions like what other state a task can be here).

BTW, I was thinking about introducing `TaskState.isFailed` or similar method so it's even clearer that the order of cases in the pattern match matters as the only case left out in `TaskState.isFinished` is `FINISHED`. With such a method, `TaskState.isFinished` would be `TaskState.isFailed` + `FINISHED` state. Perhaps, `TaskState.isCompleted` would be more appropriate.
