### PR TITLE
[SPARK-12479] [SPARKR] collect on GroupedData throws R error 'missing val…

### DIFF
--- a/R/pkg/R/utils.R
+++ b/R/pkg/R/utils.R
@@ -159,6 +159,7 @@ wrapInt <- function(value) {
 # integer-overflows are handled at every step.
 mult31AndAdd <- function(val, addVal) {
   vec <- c(bitwShiftL(val, c(4,3,2,1,0)), addVal)
+  vec[is.na(vec)] <- 0
   Reduce(function(a, b) {
           wrapInt(as.numeric(a) + as.numeric(b))
          },


### PR DESCRIPTION
sparkR collect on GroupedData throws R error "missing value where TRUE/FALSE needed" see SPARK-12479 for details
