### PR TITLE
[SPARK-6624][WIP] Draft of another alternative version of CNF normalization

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -58,6 +58,7 @@ object DefaultOptimizer extends Optimizer {
       ConstantFolding,
       LikeSimplification,
       BooleanSimplification,
+      CNFNormalization,
       RemoveDispensableExpressions,
       SimplifyFilters,
       SimplifyCasts,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -583,6 +583,12 @@ object BooleanSimplification extends Rule[LogicalPlan] with PredicateHelper {
   }
 }
 
+object CNFNormalization extends Rule[LogicalPlan] {
+  override def apply(plan: LogicalPlan): LogicalPlan = plan transform {
+    case f @ Filter(condition, _) => f.copy(condition = Predicate.toCNF(condition, Some(10)))
+  }
+}
+
 /**
  * Combines two adjacent [[Filter]] operators into one, merging the
  * conditions into one conjunctive predicate.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleExecutor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleExecutor.scala
@@ -55,6 +55,10 @@ abstract class RuleExecutor[TreeType <: TreeNode[_]] extends Logging {
   /** A strategy that runs until fix point or maxIterations times, whichever comes first. */
   case class FixedPoint(maxIterations: Int) extends Strategy
 
+  object FixedPoint {
+    val Unlimited: FixedPoint = FixedPoint(-1)
+  }
+
   /** A batch of rules. */
   protected case class Batch(name: String, strategy: Strategy, rules: Rule[TreeType]*)
 
@@ -95,7 +99,7 @@ abstract class RuleExecutor[TreeType <: TreeNode[_]] extends Logging {
             result
         }
         iteration += 1
-        if (iteration > batch.strategy.maxIterations) {
+        if (batch.strategy.maxIterations > 0 && iteration > batch.strategy.maxIterations) {
           // Only log if this is a rule that is supposed to run more than once.
           if (iteration != 2) {
             logInfo(s"Max iterations (${iteration - 1}) reached for batch ${batch.name}")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -558,6 +558,8 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
     }
     case _ => JNull
   }
+
+  def size: Int = 1 + children.map(_.size).sum
 }
 
 object TreeNode {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -559,6 +559,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product {
     case _ => JNull
   }
 
+  /** Returns total number of tree nodes in this tree. */
   def size: Int = 1 + children.map(_.size).sum
 }
 


### PR DESCRIPTION
This PR is a draft version of another alternative of CNF normalization based on [comment](https://github.com/apache/spark/pull/8200/files#r48328448) in PR #8200. This PR doesn't include test cases, and is only for further discussion.

In this version, CNF normalization is implemented as a separate function `Predicate.toCNF`, which accepts an optional expansion threshold to prevent exponential explosion. The motivation behind this design is that, CNF normalization itself can be useful in other use cases (e.g., eliminating common predicate factors). It would be convenient if we can call it from anywhere without involving the optimizer.

Another consideration is that, if no expansion threshold is provided, `toCNF` should always return a predicate that is really in CNF. That's why a new `RuleExecutor` strategy `FixedPoint.Unlimited` is added.

A major compromise here is that, we may not convert all predicates to CNF, and can't guarantee that filters passed to data sources are in CNF, thus we may lose potential optimization opportunities in front of complicated filter predicates.
