### PR TITLE
[SPARK-12498][SQL][MINOR] BooleanSimplication simplification

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -27,9 +27,9 @@ import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types._
 
 object Literal {
-  val True: Literal = Literal(true, BooleanType)
+  val TrueLiteral: Literal = Literal(true, BooleanType)
 
-  val False: Literal = Literal(false, BooleanType)
+  val FalseLiteral: Literal = Literal(false, BooleanType)
 
   def apply(v: Any): Literal = v match {
     case i: Int => Literal(i, IntegerType)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -27,6 +27,10 @@ import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types._
 
 object Literal {
+  val True: Literal = Literal(true, BooleanType)
+
+  val False: Literal = Literal(false, BooleanType)
+
   def apply(v: Any): Literal = v match {
     case i: Int => Literal(i, IntegerType)
     case l: Long => Literal(l, LongType)


### PR DESCRIPTION
Scala syntax allows binary case classes to be used as infix operator in pattern matching. This PR makes use of this syntax sugar to make `BooleanSimplification` more readable.
