### PR TITLE
[SPARK-12505] [SQL] Pushdown a Limit on top of an Outer-Join

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.analysis.{CleanupAliases, EliminateSubQueri
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.planning.ExtractFiltersAndInnerJoins
-import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.catalyst.plans.{FullOuter, Inner, LeftOuter, LeftSemi, RightOuter}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules._
 import org.apache.spark.sql.types._

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -868,11 +868,15 @@ object PushLimitThroughOuterJoin extends Rule[LogicalPlan] with PredicateHelper 
     case f @ Limit(expr, Join(left, right, joinType, joinCondition)) =>
       joinType match {
         case RightOuter =>
-          Limit(expr, Join(left, Limit(expr, right), joinType, joinCondition))
+          Limit(expr, Join(left, CombineLimits(Limit(expr, right)), joinType, joinCondition))
         case LeftOuter =>
-          Limit(expr, Join(Limit(expr, left), right, joinType, joinCondition))
+          Limit(expr, Join(CombineLimits(Limit(expr, left)), right, joinType, joinCondition))
         case FullOuter =>
-          Limit(expr, Join(Limit(expr, left), Limit(expr, right), joinType, joinCondition))
+          Limit(expr,
+            Join(
+              CombineLimits(Limit(expr, left)),
+              CombineLimits(Limit(expr, right)),
+              joinType, joinCondition))
         case _ => f // DO Nothing for the other join types
       }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.catalyst.analysis
 import org.apache.spark.sql.catalyst.analysis.EliminateSubQueries
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical._
-import org.apache.spark.sql.catalyst.plans.{LeftSemi, PlanTest, LeftOuter, RightOuter}
+import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.rules._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.dsl.expressions._
@@ -41,6 +41,7 @@ class FilterPushdownSuite extends PlanTest {
         PushPredicateThroughJoin,
         PushPredicateThroughGenerate,
         PushPredicateThroughAggregate,
+        PushLimitThroughOuterJoin,
         ColumnPruning,
         ProjectCollapsing) :: Nil
   }
@@ -747,6 +748,58 @@ class FilterPushdownSuite extends PlanTest {
       .groupBy('a)('a + Rand(10) as 'aa, count('b) as 'c, Rand(11).as("rnd"))
       .where('c === 2L && 'aa + Rand(10).as("rnd") === 3 && 'rnd === 5)
       .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("limit: push down left outer join") {
+    val x = testRelation.subquery('x)
+    val y = testRelation.subquery('y)
+
+    val originalQuery = {
+      x.join(y, LeftOuter)
+        .limit(1)
+    }
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+    val left = testRelation.limit(1)
+    val correctAnswer =
+      left.join(y, LeftOuter).limit(1).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("limit: push down right outer join") {
+    val x = testRelation.subquery('x)
+    val y = testRelation.subquery('y)
+
+    val originalQuery = {
+      x.join(y, RightOuter)
+        .limit(1)
+    }
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+    val right = testRelation.limit(1)
+    val correctAnswer =
+      x.join(right, RightOuter).limit(1).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("limit: push down full outer join") {
+    val x = testRelation.subquery('x)
+    val y = testRelation.subquery('y)
+
+    val originalQuery = {
+      x.join(y, FullOuter)
+        .limit(1)
+    }
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+    val left = testRelation.limit(1)
+    val right = testRelation.limit(1)
+    val correctAnswer =
+      left.join(right, FullOuter).limit(1).analyze
 
     comparePlans(optimized, correctAnswer)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.catalyst.analysis
 import org.apache.spark.sql.catalyst.analysis.EliminateSubQueries
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical._
-import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.catalyst.plans.{FullOuter, LeftSemi, LeftOuter, PlanTest, RightOuter}
 import org.apache.spark.sql.catalyst.rules._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.dsl.expressions._

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -796,10 +796,28 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val left = testRelation.limit(1)
+    val left = testRelation
     val right = testRelation.limit(1)
     val correctAnswer =
       left.join(right, FullOuter).limit(1).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("limit: push down full outer join + project") {
+    val x = testRelation.subquery('x)
+    val y = testRelation1.subquery('y)
+
+    val originalQuery = {
+      x.join(y, FullOuter).select('a, 'b, 'd)
+        .limit(1)
+    }
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+    val left = testRelation.select('a, 'b)
+    val right = testRelation1.limit(1)
+    val correctAnswer =
+      left.join(right, FullOuter).select('a, 'b, 'd).limit(1).analyze
 
     comparePlans(optimized, correctAnswer)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeInSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeInSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.catalyst.optimizer
 
-import scala.collection.immutable.HashSet
 import org.apache.spark.sql.catalyst.analysis.{EliminateSubQueries, UnresolvedAttribute}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}


### PR DESCRIPTION
"Rule that applies to a Limit on top of an OUTER Join. The original Limit won't go away after applying this rule, but additional Limit node(s) will be created on top of the outer-side child (or children if it's a FULL OUTER Join). "
– from https://issues.apache.org/jira/browse/CALCITE-832

Also, the same topic in Hive: https://issues.apache.org/jira/browse/HIVE-11684 This has been merged to HIVE. 

This PR is for performance improvement. The idea is like predicate pushdown. It can reduce the number of rows processed by `Outer Joins`. The performance improvement is significant when the number of rows in Limit is small but the cost of `Join` is large. 

For example, 

```
    val df = Seq((1, 2, "1"), (3, 4, "3")).toDF("int", "int2", "str").as('a)
    val df2 = Seq((1, 3, "1"), (5, 6, "5")).toDF("int", "int2", "str").as('b)
    val join = df.join(df2, $"a.int" === $"a.int", "outer").limit(1)
```

After the improvement, we can see the changes in the optimized plan:

```
== Analyzed Logical Plan ==
int: int, int2: int, str: string, int: int, int2: int, str: string
Limit 1
+- Join FullOuter, Some((int#3 = int#3))
   :- Subquery a
   :  +- Project [_1#0 AS int#3,_2#1 AS int2#4,_3#2 AS str#5]
   :     +- LocalRelation [_1#0,_2#1,_3#2], [[1,2,1],[3,4,3]]
   +- Subquery b
      +- Project [_1#6 AS int#9,_2#7 AS int2#10,_3#8 AS str#11]
         +- LocalRelation [_1#6,_2#7,_3#8], [[1,3,1],[5,6,5]]

== Optimized Logical Plan ==
Limit 1
+- Join FullOuter, Some((int#3 = int#3))
   :- LocalRelation [int#3,int2#4,str#5], [[1,2,1],[3,4,3]]
   +- Limit 1  <---- extra limit is added
      +- LocalRelation [int#9,int2#10,str#11], [[1,3,1],[5,6,5]]
```
