### PR TITLE
[SPARK-12517] add default RDD name for one created via sc.textFile

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -885,7 +885,7 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
       classOf[Text],
       classOf[Text],
       updateConf,
-      minPartitions).setName(path).map(record => (record._1.toString, record._2.toString))
+      minPartitions).map(record => (record._1.toString, record._2.toString)).setName(path)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -836,7 +836,7 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
       minPartitions: Int = defaultMinPartitions): RDD[String] = withScope {
     assertNotStopped()
     hadoopFile(path, classOf[TextInputFormat], classOf[LongWritable], classOf[Text],
-      minPartitions).map(pair => pair._2.toString)
+      minPartitions).map(pair => pair._2.toString).setName(path)
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -274,6 +274,19 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext {
     }
   }
 
+    test("Default path for file based RDDs is properly set (SPARK-12517)") {
+      sc = new SparkContext(new SparkConf().setAppName("test").setMaster("local"))
+
+      // Test textFile, wholeTextFiles and binaryFiles for default paths
+      val mockPath = "default/path/for/wholeTextFile/"
+      assert(sc.textFile(mockPath + "textFile").name == mockPath + "textFile")
+      assert(sc.wholeTextFiles(mockPath + "wholeTextFile").name == mockPath + "wholeTextFile")
+      assert(sc.binaryFiles(mockPath + "binaryFiles").name == mockPath + "binaryFiles")
+      assert(sc.hadoopFile(mockPath + "hadoopFile").name == mockPath + "hadoopFile")
+      assert(sc.newAPIHadoopFile(mockPath + "newAPIHadoopFile").name == mockPath + "newAPIHadoopFile")
+      sc.stop()
+  }
+
   test("calling multiple sc.stop() must not throw any exception") {
     noException should be thrownBy {
       sc = new SparkContext(new SparkConf().setAppName("test").setMaster("local"))

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -277,13 +277,25 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext {
     test("Default path for file based RDDs is properly set (SPARK-12517)") {
       sc = new SparkContext(new SparkConf().setAppName("test").setMaster("local"))
 
-      // Test textFile, wholeTextFiles and binaryFiles for default paths
+      // Test  filetextFile, wholeTextFiles, binaryFiles, hadoopFile and
+      // newAPIHadoopFile for setting the default path as the RDD name
       val mockPath = "default/path/for/"
-      assert(sc.textFile(mockPath + "textFile").name == mockPath + "textFile")
-      assert(sc.wholeTextFiles(mockPath + "wholeTextFile").name == mockPath + "wholeTextFile")
-      assert(sc.binaryFiles(mockPath + "binaryFiles").name == mockPath + "binaryFiles")
-      assert(sc.hadoopFile(mockPath + "hadoopFile").name == mockPath + "hadoopFile")
-      assert(sc.newAPIHadoopFile(mockPath + "newAPIHadoopFile").name == mockPath + "newAPIHadoopFile")
+
+      var targetPath = mockPath + "textFile"
+      assert(sc.textFile(targetPath).name == targetPath")
+
+      targetPath = mockPath + "wholeTextFile"
+      assert(sc.wholeTextFile(targetPath).name == targetPath")
+
+      targetPath = mockPath + "binaryFiles"
+      assert(sc.binaryFiles(targetPath).name == targetPath")
+      
+      targetPath = mockPath + "hadoopFile"
+      assert(sc.hadoopFile(targetPath).name == targetPath")
+      
+      targetPath = mockPath + "newAPIHadoopFile"
+      assert(sc.newAPIHadoopFile(targetPath).name == targetPath")
+
       sc.stop()
   }
 

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -274,29 +274,29 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext {
     }
   }
 
-    test("Default path for file based RDDs is properly set (SPARK-12517)") {
-      sc = new SparkContext(new SparkConf().setAppName("test").setMaster("local"))
+  test("Default path for file based RDDs is properly set (SPARK-12517)") {
+    sc = new SparkContext(new SparkConf().setAppName("test").setMaster("local"))
 
-      // Test  filetextFile, wholeTextFiles, binaryFiles, hadoopFile and
-      // newAPIHadoopFile for setting the default path as the RDD name
-      val mockPath = "default/path/for/"
+    // Test filetextFile, wholeTextFiles, binaryFiles, hadoopFile and
+    // newAPIHadoopFile for setting the default path as the RDD name
+    val mockPath = "default/path/for/"
 
-      var targetPath = mockPath + "textFile"
-      assert(sc.textFile(targetPath).name == targetPath)
+    var targetPath = mockPath + "textFile"
+    assert(sc.textFile(targetPath).name === targetPath)
 
-      targetPath = mockPath + "wholeTextFiles"
-      assert(sc.wholeTextFiles(targetPath).name == targetPath)
+    targetPath = mockPath + "wholeTextFiles"
+    assert(sc.wholeTextFiles(targetPath).name === targetPath)
 
-      targetPath = mockPath + "binaryFiles"
-      assert(sc.binaryFiles(targetPath).name == targetPath)
+    targetPath = mockPath + "binaryFiles"
+    assert(sc.binaryFiles(targetPath).name === targetPath)
 
-      targetPath = mockPath + "hadoopFile"
-      assert(sc.hadoopFile(targetPath).name == targetPath)
+    targetPath = mockPath + "hadoopFile"
+    assert(sc.hadoopFile(targetPath).name === targetPath)
 
-      targetPath = mockPath + "newAPIHadoopFile"
-      assert(sc.newAPIHadoopFile(targetPath).name == targetPath)
+    targetPath = mockPath + "newAPIHadoopFile"
+    assert(sc.newAPIHadoopFile(targetPath).name === targetPath)
 
-      sc.stop()
+    sc.stop()
   }
 
   test("calling multiple sc.stop() must not throw any exception") {

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -278,7 +278,7 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext {
       sc = new SparkContext(new SparkConf().setAppName("test").setMaster("local"))
 
       // Test textFile, wholeTextFiles and binaryFiles for default paths
-      val mockPath = "default/path/for/wholeTextFile/"
+      val mockPath = "default/path/for/"
       assert(sc.textFile(mockPath + "textFile").name == mockPath + "textFile")
       assert(sc.wholeTextFiles(mockPath + "wholeTextFile").name == mockPath + "wholeTextFile")
       assert(sc.binaryFiles(mockPath + "binaryFiles").name == mockPath + "binaryFiles")

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -284,15 +284,15 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext {
       var targetPath = mockPath + "textFile"
       assert(sc.textFile(targetPath).name == targetPath)
 
-      targetPath = mockPath + "wholeTextFile"
-      assert(sc.wholeTextFile(targetPath).name == targetPath)
+      targetPath = mockPath + "wholeTextFiles"
+      assert(sc.wholeTextFiles(targetPath).name == targetPath)
 
       targetPath = mockPath + "binaryFiles"
       assert(sc.binaryFiles(targetPath).name == targetPath)
-      
+
       targetPath = mockPath + "hadoopFile"
       assert(sc.hadoopFile(targetPath).name == targetPath)
-      
+
       targetPath = mockPath + "newAPIHadoopFile"
       assert(sc.newAPIHadoopFile(targetPath).name == targetPath)
 

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -282,19 +282,19 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext {
       val mockPath = "default/path/for/"
 
       var targetPath = mockPath + "textFile"
-      assert(sc.textFile(targetPath).name == targetPath")
+      assert(sc.textFile(targetPath).name == targetPath)
 
       targetPath = mockPath + "wholeTextFile"
-      assert(sc.wholeTextFile(targetPath).name == targetPath")
+      assert(sc.wholeTextFile(targetPath).name == targetPath)
 
       targetPath = mockPath + "binaryFiles"
-      assert(sc.binaryFiles(targetPath).name == targetPath")
+      assert(sc.binaryFiles(targetPath).name == targetPath)
       
       targetPath = mockPath + "hadoopFile"
-      assert(sc.hadoopFile(targetPath).name == targetPath")
+      assert(sc.hadoopFile(targetPath).name == targetPath)
       
       targetPath = mockPath + "newAPIHadoopFile"
-      assert(sc.newAPIHadoopFile(targetPath).name == targetPath")
+      assert(sc.newAPIHadoopFile(targetPath).name == targetPath)
 
       sc.stop()
   }


### PR DESCRIPTION
The feature was first added at commit: 7b877b27053bfb7092e250e01a3b887e1b50a109 but was later removed (probably by mistake) at commit: fc8b58195afa67fbb75b4c8303e022f703cbf007. 
This change sets the default path of RDDs created via sc.textFile(...) to the path argument.

Here is the symptom:
- Using spark-1.5.2-bin-hadoop2.6:

scala> sc.textFile("/home/root/.bashrc").name
res5: String = null

scala> sc.binaryFiles("/home/root/.bashrc").name
res6: String = /home/root/.bashrc
- while using Spark 1.3.1:

scala> sc.textFile("/home/root/.bashrc").name
res0: String = /home/root/.bashrc

scala> sc.binaryFiles("/home/root/.bashrc").name
res1: String = /home/root/.bashrc
