### PR TITLE
[SPARK-12375] [ML] add handleinvalid for vectorindexer

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/VectorIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/VectorIndexer.scala
@@ -37,7 +37,8 @@ import org.apache.spark.sql.types.{StructField, StructType}
 import org.apache.spark.util.collection.OpenHashSet
 
 /** Private trait for params for VectorIndexer and VectorIndexerModel */
-private[ml] trait VectorIndexerParams extends Params with HasInputCol with HasOutputCol {
+private[ml] trait VectorIndexerParams extends Params with HasInputCol with HasOutputCol
+    with HasHandleInvalid {
 
   /**
    * Threshold for the number of values a categorical feature can take.
@@ -98,6 +99,10 @@ class VectorIndexer(override val uid: String) extends Estimator[VectorIndexerMod
   with VectorIndexerParams with DefaultParamsWritable {
 
   def this() = this(Identifiable.randomUID("vecIdx"))
+
+  /** @group setParam */
+  def setHandleInvalid(value: String): this.type = set(handleInvalid, value)
+  setDefault(handleInvalid, "error")
 
   /** @group setParam */
   def setMaxCategories(value: Int): this.type = set(maxCategories, value)
@@ -345,12 +350,27 @@ class VectorIndexerModel private[ml] (
   /** @group setParam */
   def setOutputCol(value: String): this.type = set(outputCol, value)
 
+  /** @group setParam */
+  def setHandleInvalid(value: String): this.type = set(handleInvalid, value)
+  setDefault(handleInvalid, "error")
+
   override def transform(dataset: DataFrame): DataFrame = {
     transformSchema(dataset.schema, logging = true)
     val newField = prepOutputField(dataset.schema)
+
+    val filteredDataset = (getHandleInvalid) match {
+      case "skip" => {
+        val filterer = udf { label: Vector =>
+          categoryMaps.forall { case (index, categoryMap) => categoryMap.contains(label(index)) }
+        }
+        dataset.where(filterer(dataset($(inputCol))))
+      }
+      case _ => dataset
+    }
+
     val transformUDF = udf { (vector: Vector) => transformFunc(vector) }
-    val newCol = transformUDF(dataset($(inputCol)))
-    dataset.withColumn($(outputCol), newCol, newField.metadata)
+    val newCol = transformUDF(filteredDataset($(inputCol)))
+    filteredDataset.withColumn($(outputCol), newCol, newField.metadata)
   }
 
   override def transformSchema(schema: StructType): StructType = {


### PR DESCRIPTION
jira: https://issues.apache.org/jira/browse/SPARK-12375

> "Add option for allowing unknown categories, probably via a parameter like "allowUnknownCategories."
> If true, then handle unknown categories during transform by assigning them to an extra category index.
> 
> The API should resemble the API used for StringIndexer."

The PR simply follows the current behavior of StringIndexer, which does not yet support extra category for unseen labels.

I would propose to extend the `HasHandleInvalid`  with more options in this or other PR, like,
1. adding option "allow" and categorize all unseen labels to -1. (for customization, we need introduce another parameter).
2. just encourage users to use `handleInvalid` to specify the category value for unseen labels. Yet this may be out of expectation for some users.
