### PR TITLE
[SPARK-13032] [ML] [PySpark] PySpark support model export/import and take LinearRegression as example

### DIFF
--- a/python/pyspark/ml/param/__init__.py
+++ b/python/pyspark/ml/param/__init__.py
@@ -317,7 +317,7 @@ class Params(Identifiable):
 
     def _resetUid(self, newUid):
         """
-        Changes the uid of this instance.  This updates both
+        Changes the uid of this instance. This updates both
         the stored uid and the parent uid of params and param maps.
         This is used by persistence (loading).
         :param newUid: new uid to use

--- a/python/pyspark/ml/param/__init__.py
+++ b/python/pyspark/ml/param/__init__.py
@@ -314,3 +314,27 @@ class Params(Identifiable):
             if p in paramMap and to.hasParam(p.name):
                 to._set(**{p.name: paramMap[p]})
         return to
+
+    def _resetUid(self, newUid):
+        """
+        Changes the uid of this instance.  This updates both
+        the stored uid and the parent uid of params and param maps.
+        This is used by persistence (loading).
+        :param newUid: new uid to use
+        :return: same instance, but with the uid and Param.parent values
+                 updated, including within param maps
+        """
+        self.uid = newUid
+        newDefaultParamMap = dict()
+        newParamMap = dict()
+        for param in self.params:
+            newParam = copy.copy(param)
+            newParam.parent = newUid
+            if param in self._defaultParamMap:
+                newDefaultParamMap[newParam] = self._defaultParamMap[param]
+            if param in self._paramMap:
+                newParamMap[newParam] = self._paramMap[param]
+            param.parent = newUid
+        self._defaultParamMap = newDefaultParamMap
+        self._paramMap = newParamMap
+        return self

--- a/python/pyspark/ml/regression.py
+++ b/python/pyspark/ml/regression.py
@@ -73,6 +73,8 @@ class LinearRegression(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPrediction
     >>> lr_path = path + "/lr"
     >>> lr.save(lr_path)
     >>> lr2 = LinearRegression.load(lr_path)
+    >>> lr2.getOrDefault(lr2.getParam("maxIter"))
+    5
     >>> model2 = lr2.fit(df)
     >>> abs(model.coefficients[0] - model2.coefficients[0]) < 0.001
     True

--- a/python/pyspark/ml/regression.py
+++ b/python/pyspark/ml/regression.py
@@ -73,19 +73,14 @@ class LinearRegression(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPrediction
     >>> lr_path = path + "/lr"
     >>> lr.save(lr_path)
     >>> lr2 = LinearRegression.load(lr_path)
-    >>> lr2.getOrDefault(lr2.getParam("maxIter"))
+    >>> lr2.getMaxIter()
     5
-    >>> model2 = lr2.fit(df)
-    >>> abs(model.coefficients[0] - model2.coefficients[0]) < 0.001
-    True
-    >>> abs(model.intercept - model2.intercept) < 0.001
-    True
     >>> model_path = path + "/lr_model"
     >>> model.save(model_path)
-    >>> model3 = LinearRegressionModel.load(model_path)
-    >>> model.coefficients[0] == model3.coefficients[0]
+    >>> model2 = LinearRegressionModel.load(model_path)
+    >>> model.coefficients[0] == model2.coefficients[0]
     True
-    >>> model.intercept == model3.intercept
+    >>> model.intercept == model2.intercept
     True
     >>> from shutil import rmtree
     >>> try:

--- a/python/pyspark/ml/regression.py
+++ b/python/pyspark/ml/regression.py
@@ -79,12 +79,12 @@ class LinearRegression(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPrediction
     True
     >>> abs(model.intercept - model2.intercept) < 0.001
     True
-    >>> model_path = path + "/model"
+    >>> model_path = path + "/lr_model"
     >>> model.save(model_path)
     >>> model3 = LinearRegressionModel.load(model_path)
-    >>> abs(model.coefficients[0] - model3.coefficients[0]) < 0.001
+    >>> model.coefficients[0] == model3.coefficients[0]
     True
-    >>> abs(model.intercept - model3.intercept) < 0.001
+    >>> model.intercept == model3.intercept
     True
     >>> from shutil import rmtree
     >>> try:

--- a/python/pyspark/ml/regression.py
+++ b/python/pyspark/ml/regression.py
@@ -35,8 +35,7 @@ __all__ = ['AFTSurvivalRegression', 'AFTSurvivalRegressionModel',
 @inherit_doc
 class LinearRegression(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, HasMaxIter,
                        HasRegParam, HasTol, HasElasticNetParam, HasFitIntercept,
-                       HasStandardization, HasSolver, HasWeightCol, MLWritable,
-                       EstimatorMLReadable):
+                       HasStandardization, HasSolver, HasWeightCol, MLWritable, MLReadable):
     """
     Linear regression.
 
@@ -129,7 +128,7 @@ class LinearRegression(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPrediction
         return LinearRegressionModel(java_model)
 
 
-class LinearRegressionModel(JavaModel, MLWritable, TransformerMLReadable):
+class LinearRegressionModel(JavaModel, MLWritable, MLReadable):
     """
     Model fitted by LinearRegression.
 

--- a/python/pyspark/ml/regression.py
+++ b/python/pyspark/ml/regression.py
@@ -18,9 +18,9 @@
 import warnings
 
 from pyspark import since
-from pyspark.ml.util import keyword_only
-from pyspark.ml.wrapper import JavaEstimator, JavaModel
 from pyspark.ml.param.shared import *
+from pyspark.ml.util import *
+from pyspark.ml.wrapper import JavaEstimator, JavaModel
 from pyspark.mllib.common import inherit_doc
 
 
@@ -35,7 +35,8 @@ __all__ = ['AFTSurvivalRegression', 'AFTSurvivalRegressionModel',
 @inherit_doc
 class LinearRegression(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, HasMaxIter,
                        HasRegParam, HasTol, HasElasticNetParam, HasFitIntercept,
-                       HasStandardization, HasSolver, HasWeightCol):
+                       HasStandardization, HasSolver, HasWeightCol, MLWritable,
+                       EstimatorMLReadable):
     """
     Linear regression.
 
@@ -68,6 +69,28 @@ class LinearRegression(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPrediction
     Traceback (most recent call last):
         ...
     TypeError: Method setParams forces keyword arguments.
+    >>> import os, tempfile
+    >>> path = tempfile.mkdtemp()
+    >>> lr_path = path + "/lr"
+    >>> lr.save(lr_path)
+    >>> lr2 = LinearRegression.load(lr_path)
+    >>> model2 = lr2.fit(df)
+    >>> abs(model.coefficients[0] - model2.coefficients[0]) < 0.001
+    True
+    >>> abs(model.intercept - model2.intercept) < 0.001
+    True
+    >>> model_path = path + "/model"
+    >>> model.save(model_path)
+    >>> model3 = LinearRegressionModel.load(model_path)
+    >>> abs(model.coefficients[0] - model3.coefficients[0]) < 0.001
+    True
+    >>> abs(model.intercept - model3.intercept) < 0.001
+    True
+    >>> from shutil import rmtree
+    >>> try:
+    ...     rmtree(path)
+    ... except OSError:
+    ...     pass
 
     .. versionadded:: 1.4.0
     """
@@ -106,7 +129,7 @@ class LinearRegression(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPrediction
         return LinearRegressionModel(java_model)
 
 
-class LinearRegressionModel(JavaModel):
+class LinearRegressionModel(JavaModel, MLWritable, TransformerMLReadable):
     """
     Model fitted by LinearRegression.
 
@@ -821,9 +844,10 @@ class AFTSurvivalRegressionModel(JavaModel):
 
 if __name__ == "__main__":
     import doctest
+    import pyspark.ml.regression
     from pyspark.context import SparkContext
     from pyspark.sql import SQLContext
-    globs = globals().copy()
+    globs = pyspark.ml.regression.__dict__.copy()
     # The small batch size here ensures that we see multiple batches,
     # even in these small test examples:
     sc = SparkContext("local[2]", "ml.regression tests")

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -34,18 +34,22 @@ if sys.version_info[:2] <= (2, 6):
 else:
     import unittest
 
-from pyspark.tests import ReusedPySparkTestCase as PySparkTestCase
-from pyspark.sql import DataFrame, SQLContext, Row
-from pyspark.sql.functions import rand
+from shutil import rmtree
+import tempfile
+
+from pyspark.ml import Estimator, Model, Pipeline, Transformer
 from pyspark.ml.classification import LogisticRegression
 from pyspark.ml.evaluation import RegressionEvaluator
+from pyspark.ml.feature import *
 from pyspark.ml.param import Param, Params
 from pyspark.ml.param.shared import HasMaxIter, HasInputCol, HasSeed
-from pyspark.ml.util import keyword_only
-from pyspark.ml import Estimator, Model, Pipeline, Transformer
-from pyspark.ml.feature import *
+from pyspark.ml.regression import LinearRegression
 from pyspark.ml.tuning import ParamGridBuilder, CrossValidator, CrossValidatorModel
+from pyspark.ml.util import keyword_only
 from pyspark.mllib.linalg import DenseVector
+from pyspark.sql import DataFrame, SQLContext, Row
+from pyspark.sql.functions import rand
+from pyspark.tests import ReusedPySparkTestCase as PySparkTestCase
 
 
 class MockDataset(DataFrame):
@@ -403,6 +407,29 @@ class CrossValidatorTests(PySparkTestCase):
         self.assertEqual(0.0, bestModel.getOrDefault('inducedError'),
                          "Best model should have zero induced error")
         self.assertEqual(1.0, bestModelMetric, "Best model has R-squared of 1")
+
+
+class PersistenceTest(PySparkTestCase):
+
+    def test_linear_regression(self):
+        lr = LinearRegression(maxIter = 1)
+        path = tempfile.mkdtemp()
+        lr_path = path + "/lr"
+        lr.save(lr_path)
+        lr2 = LinearRegression.load(lr_path)
+        lr2.getMaxIter()
+        print lr.uid
+        print lr2.uid
+        print lr2.maxIter.parent
+        self.assertEqual(lr2.uid, lr2.maxIter.parent,
+            "Loaded LinearRegression instance uid (%s) did not match Param's uid (%s)"
+            % (lr2.uid, lr2.maxIter.parent))
+        self.assertEqual(lr._defaultParamMap[lr.maxIter], lr2._defaultParamMap[lr2.maxIter],
+            "Loaded LinearRegression instance defaults did not match original defaults")
+        try:
+            rmtree(path)
+        except OSError:
+            pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -412,20 +412,17 @@ class CrossValidatorTests(PySparkTestCase):
 class PersistenceTest(PySparkTestCase):
 
     def test_linear_regression(self):
-        lr = LinearRegression(maxIter = 1)
+        lr = LinearRegression(maxIter=1)
         path = tempfile.mkdtemp()
         lr_path = path + "/lr"
         lr.save(lr_path)
         lr2 = LinearRegression.load(lr_path)
-        lr2.getMaxIter()
-        print lr.uid
-        print lr2.uid
-        print lr2.maxIter.parent
         self.assertEqual(lr2.uid, lr2.maxIter.parent,
-            "Loaded LinearRegression instance uid (%s) did not match Param's uid (%s)"
-            % (lr2.uid, lr2.maxIter.parent))
+                         "Loaded LinearRegression instance uid (%s) did not match Param's uid (%s)"
+                         % (lr2.uid, lr2.maxIter.parent))
         self.assertEqual(lr._defaultParamMap[lr.maxIter], lr2._defaultParamMap[lr2.maxIter],
-            "Loaded LinearRegression instance defaults did not match original defaults")
+                         "Loaded LinearRegression instance default params did not match " +
+                         "original defaults")
         try:
             rmtree(path)
         except OSError:

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -74,11 +74,11 @@ class Identifiable(object):
 
 
 @inherit_doc
-class MLWriter(object):
+class JavaMLWriter(object):
     """
     .. note:: Experimental
 
-    Utility class that can save ML instances.
+    Utility class that can save ML instances through their Scala implementation.
 
     .. versionadded:: 2.0.0
     """
@@ -87,18 +87,15 @@ class MLWriter(object):
         instance._transfer_params_to_java()
         self._jwrite = instance._java_obj.write()
 
-    @since("2.0.0")
     def save(self, path):
-        """Saves the ML instances to the input path."""
+        """Save the ML instance to the input path."""
         self._jwrite.save(path)
 
-    @since("2.0.0")
     def overwrite(self):
         """Overwrites if the output path already exists."""
         self._jwrite.overwrite()
         return self
 
-    @since("2.0.0")
     def context(self, sqlContext):
         """Sets the SQL context to use for saving."""
         self._jwrite.context(sqlContext._ssql_ctx)
@@ -110,18 +107,15 @@ class MLWritable(object):
     """
     .. note:: Experimental
 
-    Mixin for ML instances that provide MLWriter through their Scala
-    implementation.
+    Mixin for ML instances that provide JavaMLWriter.
 
     .. versionadded:: 2.0.0
     """
 
-    @since("2.0.0")
     def write(self):
-        """Returns an MLWriter instance for this ML instance."""
-        return MLWriter(self)
+        """Returns an JavaMLWriter instance for this ML instance."""
+        return JavaMLWriter(self)
 
-    @since("2.0.0")
     def save(self, path):
         """Save this ML instance to the given path, a shortcut of `write().save(path)`."""
         if not isinstance(path, basestring):
@@ -130,11 +124,11 @@ class MLWritable(object):
 
 
 @inherit_doc
-class MLReader(object):
+class JavaMLReader(object):
     """
     .. note:: Experimental
 
-    Utility class that can load ML instances.
+    Utility class that can load ML instances through their Scala implementation.
 
     .. versionadded:: 2.0.0
     """
@@ -144,16 +138,14 @@ class MLReader(object):
         self._instance._java_obj = self._load_java_obj(self._instance)
         self._jread = self._instance._java_obj.read()
 
-    @since("2.0.0")
     def load(self, path):
-        """Loads the ML component from the input path."""
+        """Load the ML instance from the input path."""
         java_obj = self._jread.load(path)
         self._instance._java_obj = java_obj
         self._instance.uid = java_obj.uid()
         self._instance._transfer_params_from_java(True)
         return self._instance
 
-    @since("2.0.0")
     def context(self, sqlContext):
         """Sets the SQL context to use for loading."""
         self._jread.context(sqlContext._ssql_ctx)
@@ -162,7 +154,7 @@ class MLReader(object):
     @classmethod
     def _java_loader_class(cls, instance):
         """
-        Returns the full class name of the Java loader. The default
+        Returns the full class name of the Java ML instance. The default
         implementation replaces "pyspark" by "org.apache.spark" in
         the Python full class name.
         """
@@ -171,7 +163,7 @@ class MLReader(object):
 
     @classmethod
     def _load_java_obj(cls, instance):
-        """Load the peer Java object."""
+        """Load the peer Java object of the ML instance."""
         java_class = cls._java_loader_class(instance)
         java_obj = _jvm()
         for name in java_class.split("."):
@@ -184,19 +176,19 @@ class MLReadable(object):
     """
     .. note:: Experimental
 
-    Mixin for objects that provide MLReader using its Scala implementation.
+    Mixin for instances that provide JavaMLReader.
 
     .. versionadded:: 2.0.0
     """
 
     @classmethod
-    @since("2.0.0")
     def read(cls):
-        """Returns an MLReader instance for this class."""
-        return MLReader(cls())
+        """Returns an JavaMLReader instance for this class."""
+        return JavaMLReader(cls())
 
     @classmethod
-    @since("2.0.0")
     def load(cls, path):
         """Reads an ML instance from the input path, a shortcut of `read().load(path)`."""
+        if not isinstance(path, basestring):
+            raise TypeError("path should be a basestring, got type %s" % type(path))
         return cls.read().load(path)

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -181,9 +181,7 @@ class MLReadable(object):
 
     @classmethod
     def _load_java_obj(cls):
-        """
-        Load the peer Java object.
-        """
+        """Load the peer Java object."""
         java_class = cls._java_loader_class()
         java_obj = _jvm()
         for name in java_class.split("."):

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -15,8 +15,27 @@
 # limitations under the License.
 #
 
-from functools import wraps
+import sys
 import uuid
+from functools import wraps
+
+if sys.version > '3':
+    basestring = str
+
+from pyspark import SparkContext, since
+from pyspark.mllib.common import inherit_doc
+
+
+def _jvm():
+    """
+    Returns the JVM view associated with SparkContext. Must be called
+    after SparkContext is initialized.
+    """
+    jvm = SparkContext._jvm
+    if jvm:
+        return jvm
+    else:
+        raise AttributeError("Cannot load _jvm from SparkContext. Is SparkContext initialized?")
 
 
 def keyword_only(func):
@@ -52,3 +71,141 @@ class Identifiable(object):
         concatenates the class name, "_", and 12 random hex chars.
         """
         return cls.__name__ + "_" + uuid.uuid4().hex[12:]
+
+
+@inherit_doc
+class MLWriter(object):
+    """
+    Abstract class for utility classes that can save ML instances.
+
+    .. versionadded:: 2.0.0
+    """
+
+    def __init__(self, instance):
+        self._jwrite = instance._java_obj.write()
+
+    @since("2.0.0")
+    def save(self, path):
+        """Saves the ML instances to the input path."""
+        self._jwrite.save(path)
+
+    @since("2.0.0")
+    def overwrite(self):
+        """Overwrites if the output path already exists."""
+        self._jwrite.overwrite()
+        return self
+
+    @since("2.0.0")
+    def context(self, sqlContext):
+        """Sets the SQL context to use for saving."""
+        self._jwrite.context(sqlContext._ssql_ctx)
+        return self
+
+
+@inherit_doc
+class MLWritable(object):
+    """
+    Mixin for ML instances that provide MLWriter through their Scala
+    implementation.
+
+    .. versionadded:: 2.0.0
+    """
+
+    @since("2.0.0")
+    def write(self):
+        """Returns an MLWriter instance for this ML instance."""
+        return MLWriter(self)
+
+    @since("2.0.0")
+    def save(self, path):
+        """Save this ML instance to the given path, a shortcut of `write().save(path)`."""
+        if not isinstance(path, basestring):
+            raise TypeError("path should be a basestring, got type %s" % type(path))
+        self._java_obj.save(path)
+
+
+@inherit_doc
+class MLReader(object):
+    """
+    Abstract class for utility classes that can load ML instances.
+
+    .. versionadded:: 2.0.0
+    """
+
+    def __init__(self, instance):
+        self._instance = instance
+        self._jread = instance._java_obj.read()
+
+    @since("2.0.0")
+    def load(self, path):
+        """Loads the ML component from the input path."""
+        self._instance.load(path)
+
+    @since("2.0.0")
+    def context(self, sqlContext):
+        """Sets the SQL context to use for loading."""
+        self._jread.context(sqlContext._ssql_ctx)
+        return self
+
+
+@inherit_doc
+class MLReadable(object):
+    """
+    Mixin for objects that provide MLReader using its Scala implementation.
+
+    .. versionadded:: 2.0.0
+    """
+
+    @classmethod
+    def _java_loader_class(cls):
+        """
+        Returns the full class name of the Java loader. The default
+        implementation replaces "pyspark" by "org.apache.spark" in
+        the Python full class name.
+        """
+        java_package = cls.__module__.replace("pyspark", "org.apache.spark")
+        return ".".join([java_package, cls.__name__])
+
+    @classmethod
+    def _load_java(cls, path):
+        """
+        Load a Java model from the given path.
+        """
+        java_class = cls._java_loader_class()
+        java_obj = _jvm()
+        for name in java_class.split("."):
+            java_obj = getattr(java_obj, name)
+        return java_obj.load(path)
+
+    @classmethod
+    @since("2.0.0")
+    def read(self):
+        """Returns an MLReader instance for this class."""
+        return MLReader(self)
+
+
+@inherit_doc
+class TransformerMLReadable(MLReadable):
+
+    @classmethod
+    @since("2.0.0")
+    def load(cls, path):
+        """Load a model from the given path."""
+        java_obj = cls._load_java(path)
+        new_instance = cls(java_obj)
+        new_instance._transfer_params_from_java()
+        return new_instance
+
+
+@inherit_doc
+class EstimatorMLReadable(MLReadable):
+
+    @classmethod
+    @since("2.0.0")
+    def load(cls, path):
+        """Load a model from the given path."""
+        java_obj = cls._load_java(path)
+        new_instance = cls()
+        new_instance._java_obj = java_obj
+        new_instance._transfer_params_from_java()
+        return new_instance

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -84,6 +84,7 @@ class MLWriter(object):
     """
 
     def __init__(self, instance):
+        instance._transfer_params_to_java()
         self._jwrite = instance._java_obj.write()
 
     @since("2.0.0")
@@ -125,7 +126,7 @@ class MLWritable(object):
         """Save this ML instance to the given path, a shortcut of `write().save(path)`."""
         if not isinstance(path, basestring):
             raise TypeError("path should be a basestring, got type %s" % type(path))
-        self._java_obj.save(path)
+        self.write().save(path)
 
 
 @inherit_doc

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -76,7 +76,9 @@ class Identifiable(object):
 @inherit_doc
 class MLWriter(object):
     """
-    Abstract class for utility classes that can save ML instances.
+    .. note:: Experimental
+
+    Utility class that can save ML instances.
 
     .. versionadded:: 2.0.0
     """
@@ -105,6 +107,8 @@ class MLWriter(object):
 @inherit_doc
 class MLWritable(object):
     """
+    .. note:: Experimental
+
     Mixin for ML instances that provide MLWriter through their Scala
     implementation.
 
@@ -127,19 +131,20 @@ class MLWritable(object):
 @inherit_doc
 class MLReader(object):
     """
-    Abstract class for utility classes that can load ML instances.
+    .. note:: Experimental
+
+    Utility class that can load ML instances.
 
     .. versionadded:: 2.0.0
     """
 
     def __init__(self, instance):
-        self._instance = instance
         self._jread = instance._java_obj.read()
 
     @since("2.0.0")
     def load(self, path):
         """Loads the ML component from the input path."""
-        self._instance.load(path)
+        self._jread.load(path)
 
     @since("2.0.0")
     def context(self, sqlContext):
@@ -151,6 +156,8 @@ class MLReader(object):
 @inherit_doc
 class MLReadable(object):
     """
+    .. note:: Experimental
+
     Mixin for objects that provide MLReader using its Scala implementation.
 
     .. versionadded:: 2.0.0

--- a/python/pyspark/ml/wrapper.py
+++ b/python/pyspark/ml/wrapper.py
@@ -175,8 +175,9 @@ class JavaModel(Model, JavaTransformer):
         if extra is None:
             extra = dict()
         that = super(JavaModel, self).copy(extra)
-        that._java_obj = self._java_obj.copy(self._empty_java_param_map())
-        that._transfer_params_to_java()
+        if self._java_obj is not None:
+            that._java_obj = self._java_obj.copy(self._empty_java_param_map())
+            that._transfer_params_to_java()
         return that
 
     def _call_java(self, name, *args):

--- a/python/pyspark/ml/wrapper.py
+++ b/python/pyspark/ml/wrapper.py
@@ -71,7 +71,7 @@ class JavaWrapper(Params):
                 pair = self._make_java_param_pair(param, paramMap[param])
                 self._java_obj.set(pair)
 
-    def _transfer_params_from_java(self, withParent=False):
+    def _transfer_params_from_java(self):
         """
         Transforms the embedded params from the companion Java object.
         """
@@ -79,8 +79,6 @@ class JavaWrapper(Params):
         parent = self._java_obj.uid()
         for param in self.params:
             if self._java_obj.hasParam(param.name):
-                if withParent:
-                    param.parent = parent
                 java_param = self._java_obj.getParam(param.name)
                 value = _java2py(sc, self._java_obj.getOrDefault(java_param))
                 self._paramMap[param] = value
@@ -156,9 +154,14 @@ class JavaModel(Model, JavaTransformer):
         Initialize this instance with a Java model object.
         Subclasses should call this constructor, initialize params,
         and then call _transformer_params_from_java.
+
         This instance can be instantiated without specifying java_model,
         it will be assigned after that, but this scenario only used by
-        :py:class:`JavaMLReader` to load models.
+        :py:class:`JavaMLReader` to load models.  This is a bit of a
+        hack, but it is easiest since a proper fix would require
+        MLReader (in pyspark.ml.util) to depend on these wrappers, but
+        these wrappers depend on pyspark.ml.util (both directly and via
+        other ML classes).
         """
         super(JavaModel, self).__init__()
         if java_model is not None:

--- a/python/pyspark/ml/wrapper.py
+++ b/python/pyspark/ml/wrapper.py
@@ -156,6 +156,9 @@ class JavaModel(Model, JavaTransformer):
         Initialize this instance with a Java model object.
         Subclasses should call this constructor, initialize params,
         and then call _transformer_params_from_java.
+        This instance can be instantiated without specifying java_model,
+        it will be assigned after that, but this scenario only used by
+        :py:class:`JavaMLReader` to load models.
         """
         super(JavaModel, self).__init__()
         if java_model is not None:

--- a/python/pyspark/ml/wrapper.py
+++ b/python/pyspark/ml/wrapper.py
@@ -21,19 +21,8 @@ from pyspark import SparkContext
 from pyspark.sql import DataFrame
 from pyspark.ml.param import Params
 from pyspark.ml.pipeline import Estimator, Transformer, Model
+from pyspark.ml.util import _jvm
 from pyspark.mllib.common import inherit_doc, _java2py, _py2java
-
-
-def _jvm():
-    """
-    Returns the JVM view associated with SparkContext. Must be called
-    after SparkContext is initialized.
-    """
-    jvm = SparkContext._jvm
-    if jvm:
-        return jvm
-    else:
-        raise AttributeError("Cannot load _jvm from SparkContext. Is SparkContext initialized?")
 
 
 @inherit_doc

--- a/python/pyspark/ml/wrapper.py
+++ b/python/pyspark/ml/wrapper.py
@@ -76,7 +76,6 @@ class JavaWrapper(Params):
         Transforms the embedded params from the companion Java object.
         """
         sc = SparkContext._active_spark_context
-        parent = self._java_obj.uid()
         for param in self.params:
             if self._java_obj.hasParam(param.name):
                 java_param = self._java_obj.getParam(param.name)


### PR DESCRIPTION
- Implement `MLWriter/MLWritable/MLReader/MLReadable` for PySpark.
- Making `LinearRegression` to support `save/load` as example. After this merged, the work for other transformers/estimators will be easy, then we can list and distribute the tasks to the community.

cc @mengxr @jkbradley 
