### PR TITLE
[SPARK-12522] [SQL] [MINOR] Add the missing document strings for the SQL configuration

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
@@ -334,7 +334,8 @@ private[spark] object SQLConf {
 
   val HIVE_VERIFY_PARTITION_PATH = booleanConf("spark.sql.hive.verifyPartitionPath",
     defaultValue = Some(false),
-    doc = "<TODO>")
+    doc = "When true, check all the partition paths under the table\'s root directory " +
+          "when reading data stored in HDFS.")
 
   val HIVE_METASTORE_PARTITION_PRUNING = booleanConf("spark.sql.hive.metastorePartitionPruning",
     defaultValue = Some(false),
@@ -352,7 +353,7 @@ private[spark] object SQLConf {
 
   val COLUMN_NAME_OF_CORRUPT_RECORD = stringConf("spark.sql.columnNameOfCorruptRecord",
     defaultValue = Some("_corrupt_record"),
-    doc = "<TODO>")
+    doc = "The name of internal column for storing raw/un-parsed JSON records that fail to parse.")
 
   val BROADCAST_TIMEOUT = intConf("spark.sql.broadcastTimeout",
     defaultValue = Some(5 * 60),
@@ -413,7 +414,8 @@ private[spark] object SQLConf {
   val PARALLEL_PARTITION_DISCOVERY_THRESHOLD = intConf(
     key = "spark.sql.sources.parallelPartitionDiscovery.threshold",
     defaultValue = Some(32),
-    doc = "<TODO>")
+    doc = "The degree of parallelism for schema merging and partition discovery of " +
+      "Parquet data sources.")
 
   // Whether to perform eager analysis when constructing a dataframe.
   // Set to false when debugging requires the ability to look at invalid query plans.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
@@ -102,6 +102,7 @@ case class SetCommand(kv: Option[(String, Option[String])]) extends RunnableComm
       }
       (keyValueOutput, runFunc)
 
+    // Configures the deprecated "spark.sql.planner.externalSort" property.
     case Some((SQLConf.Deprecated.EXTERNAL_SORT, Some(value))) =>
       val runFunc = (sqlContext: SQLContext) => {
         logWarning(
@@ -111,6 +112,7 @@ case class SetCommand(kv: Option[(String, Option[String])]) extends RunnableComm
       }
       (keyValueOutput, runFunc)
 
+    // Configures the deprecated "spark.sql.useAggregate2" property.
     case Some((SQLConf.Deprecated.USE_SQL_AGGREGATE2, Some(value))) =>
       val runFunc = (sqlContext: SQLContext) => {
         logWarning(
@@ -121,6 +123,7 @@ case class SetCommand(kv: Option[(String, Option[String])]) extends RunnableComm
       }
       (keyValueOutput, runFunc)
 
+    // Configures the deprecated "spark.sql.tungsten.enabled" property.
     case Some((SQLConf.Deprecated.TUNGSTEN_ENABLED, Some(value))) =>
       val runFunc = (sqlContext: SQLContext) => {
         logWarning(
@@ -130,6 +133,7 @@ case class SetCommand(kv: Option[(String, Option[String])]) extends RunnableComm
       }
       (keyValueOutput, runFunc)
 
+    // Configures the deprecated "spark.sql.codegen" property.
     case Some((SQLConf.Deprecated.CODEGEN_ENABLED, Some(value))) =>
       val runFunc = (sqlContext: SQLContext) => {
         logWarning(
@@ -139,6 +143,7 @@ case class SetCommand(kv: Option[(String, Option[String])]) extends RunnableComm
       }
       (keyValueOutput, runFunc)
 
+    // Configures the deprecated "spark.sql.unsafe.enabled" property.
     case Some((SQLConf.Deprecated.UNSAFE_ENABLED, Some(value))) =>
       val runFunc = (sqlContext: SQLContext) => {
         logWarning(
@@ -148,8 +153,7 @@ case class SetCommand(kv: Option[(String, Option[String])]) extends RunnableComm
       }
       (keyValueOutput, runFunc)
 
-      (keyValueOutput, runFunc)
-
+    // Configures the deprecated "spark.sql.planner.sortMergeJoin" property.
     case Some((SQLConf.Deprecated.SORTMERGE_JOIN, Some(value))) =>
       val runFunc = (sqlContext: SQLContext) => {
         logWarning(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/commands.scala
@@ -102,7 +102,6 @@ case class SetCommand(kv: Option[(String, Option[String])]) extends RunnableComm
       }
       (keyValueOutput, runFunc)
 
-    // Configures the deprecated "spark.sql.planner.externalSort" property.
     case Some((SQLConf.Deprecated.EXTERNAL_SORT, Some(value))) =>
       val runFunc = (sqlContext: SQLContext) => {
         logWarning(
@@ -112,7 +111,6 @@ case class SetCommand(kv: Option[(String, Option[String])]) extends RunnableComm
       }
       (keyValueOutput, runFunc)
 
-    // Configures the deprecated "spark.sql.useAggregate2" property.
     case Some((SQLConf.Deprecated.USE_SQL_AGGREGATE2, Some(value))) =>
       val runFunc = (sqlContext: SQLContext) => {
         logWarning(
@@ -123,7 +121,6 @@ case class SetCommand(kv: Option[(String, Option[String])]) extends RunnableComm
       }
       (keyValueOutput, runFunc)
 
-    // Configures the deprecated "spark.sql.tungsten.enabled" property.
     case Some((SQLConf.Deprecated.TUNGSTEN_ENABLED, Some(value))) =>
       val runFunc = (sqlContext: SQLContext) => {
         logWarning(
@@ -133,7 +130,6 @@ case class SetCommand(kv: Option[(String, Option[String])]) extends RunnableComm
       }
       (keyValueOutput, runFunc)
 
-    // Configures the deprecated "spark.sql.codegen" property.
     case Some((SQLConf.Deprecated.CODEGEN_ENABLED, Some(value))) =>
       val runFunc = (sqlContext: SQLContext) => {
         logWarning(
@@ -143,7 +139,6 @@ case class SetCommand(kv: Option[(String, Option[String])]) extends RunnableComm
       }
       (keyValueOutput, runFunc)
 
-    // Configures the deprecated "spark.sql.unsafe.enabled" property.
     case Some((SQLConf.Deprecated.UNSAFE_ENABLED, Some(value))) =>
       val runFunc = (sqlContext: SQLContext) => {
         logWarning(
@@ -153,7 +148,6 @@ case class SetCommand(kv: Option[(String, Option[String])]) extends RunnableComm
       }
       (keyValueOutput, runFunc)
 
-    // Configures the deprecated "spark.sql.planner.sortMergeJoin" property.
     case Some((SQLConf.Deprecated.SORTMERGE_JOIN, Some(value))) =>
       val runFunc = (sqlContext: SQLContext) => {
         logWarning(

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -692,11 +692,14 @@ private[hive] object HiveContext {
   val CONVERT_METASTORE_PARQUET_WITH_SCHEMA_MERGING = booleanConf(
     "spark.sql.hive.convertMetastoreParquet.mergeSchema",
     defaultValue = Some(false),
-    doc = "TODO")
+    doc = "When true, also tries to merge possibly different but compatible Parquet schemas in " +
+      "different Parquet data files. This configuration is only effective " +
+      "when \"spark.sql.hive.convertMetastoreParquet\" is true.")
 
   val CONVERT_CTAS = booleanConf("spark.sql.hive.convertCTAS",
     defaultValue = Some(false),
-    doc = "TODO")
+    doc = "When true, a table created by a Hive CTAS statement (no USING clause) will be " +
+      "converted to a data source table, using the data source set by spark.sql.sources.default.")
 
   val HIVE_METASTORE_SHARED_PREFIXES = stringSeqConf("spark.sql.hive.metastore.sharedPrefixes",
     defaultValue = Some(jdbcPrefixes),
@@ -717,7 +720,7 @@ private[hive] object HiveContext {
 
   val HIVE_THRIFT_SERVER_ASYNC = booleanConf("spark.sql.hive.thriftServer.async",
     defaultValue = Some(true),
-    doc = "TODO")
+    doc = "When set to true, Hive Thrift server executes SQL queries in an asynchronous way.")
 
   /** Constructs a configuration for hive, where the metastore is located in a temp directory. */
   def newTemporaryConfiguration(useInMemoryDerby: Boolean): Map[String, String] = {


### PR DESCRIPTION
Fixing the missing the document for the configuration. We can see the missing messages "TODO" when issuing the command "SET -V".

```
spark.sql.columnNameOfCorruptRecord
spark.sql.hive.verifyPartitionPath
spark.sql.sources.parallelPartitionDiscovery.threshold
spark.sql.hive.convertMetastoreParquet.mergeSchema
spark.sql.hive.convertCTAS
spark.sql.hive.thriftServer.async
```
