### PR TITLE
[SPARK-12385] [SQL] [WIP] Push Projection into Join

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -52,6 +52,7 @@ object DefaultOptimizer extends Optimizer {
       ProjectCollapsing,
       CombineFilters,
       CombineLimits,
+      CombineProjectJoin,
       // Constant folding
       NullPropagation,
       OptimizeIn,
@@ -284,6 +285,17 @@ object ColumnPruning extends Rule[LogicalPlan] {
     } else {
       c
     }
+}
+
+/**
+ * Combines the adjacent [[Project]] and [[Join]] operators, iff their output sets are the same.
+ */
+object CombineProjectJoin extends Rule[LogicalPlan] {
+
+  def apply(plan: LogicalPlan): LogicalPlan = plan transformUp {
+    case p @ Project(_, j: Join)
+      if j.outputSet == p.outputSet => j
+  }
 }
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -168,8 +168,9 @@ class SQLMetricsSuite extends SparkFunSuite with SharedSQLContext {
       // ... -> SortMergeJoin(nodeId = 1) -> TungstenProject(nodeId = 0)
       val df = sqlContext.sql(
         "SELECT * FROM testData2 JOIN testDataForJoin ON testData2.a = testDataForJoin.a")
+      df.explain(true)
       testSparkPlanMetrics(df, 1, Map(
-        1L -> ("SortMergeJoin", Map(
+        0L -> ("SortMergeJoin", Map(
           // It's 4 because we only read 3 rows in the first partition and 1 row in the second one
           "number of left rows" -> 4L,
           "number of right rows" -> 2L,
@@ -189,7 +190,7 @@ class SQLMetricsSuite extends SparkFunSuite with SharedSQLContext {
       val df = sqlContext.sql(
         "SELECT * FROM testData2 left JOIN testDataForJoin ON testData2.a = testDataForJoin.a")
       testSparkPlanMetrics(df, 1, Map(
-        1L -> ("SortMergeOuterJoin", Map(
+        0L -> ("SortMergeOuterJoin", Map(
           // It's 4 because we only read 3 rows in the first partition and 1 row in the second one
           "number of left rows" -> 6L,
           "number of right rows" -> 2L,
@@ -199,7 +200,7 @@ class SQLMetricsSuite extends SparkFunSuite with SharedSQLContext {
       val df2 = sqlContext.sql(
         "SELECT * FROM testDataForJoin right JOIN testData2 ON testData2.a = testDataForJoin.a")
       testSparkPlanMetrics(df2, 1, Map(
-        1L -> ("SortMergeOuterJoin", Map(
+        0L -> ("SortMergeOuterJoin", Map(
           // It's 4 because we only read 3 rows in the first partition and 1 row in the second one
           "number of left rows" -> 2L,
           "number of right rows" -> 6L,
@@ -254,7 +255,7 @@ class SQLMetricsSuite extends SparkFunSuite with SharedSQLContext {
         "SELECT * FROM testData2 left JOIN testDataForJoin ON " +
           "testData2.a * testDataForJoin.a != testData2.a + testDataForJoin.a")
       testSparkPlanMetrics(df, 3, Map(
-        1L -> ("BroadcastNestedLoopJoin", Map(
+        0L -> ("BroadcastNestedLoopJoin", Map(
           "number of left rows" -> 12L, // left needs to be scanned twice
           "number of right rows" -> 2L,
           "number of output rows" -> 12L)))
@@ -315,7 +316,7 @@ class SQLMetricsSuite extends SparkFunSuite with SharedSQLContext {
       val df = sqlContext.sql(
         "SELECT * FROM testData2 JOIN testDataForJoin")
       testSparkPlanMetrics(df, 1, Map(
-        1L -> ("CartesianProduct", Map(
+        0L -> ("CartesianProduct", Map(
           "number of left rows" -> 12L, // left needs to be scanned twice
           "number of right rows" -> 4L, // right is read twice
           "number of output rows" -> 12L)))


### PR DESCRIPTION
`sql("SELECT * FROM testData JOIN testData2").explain(true)`

The current plan is like

```
== Analyzed Logical Plan ==
key: int, value: string, a: int, b: int
Project [key#2,value#3,a#4,b#5]
+- Join Inner, None
   :- Subquery testData
   :  +- LogicalRDD [key#2,value#3], MapPartitionsRDD[3] at beforeAll at BeforeAndAfterAll.scala:187
   +- Subquery testData2
      +- LogicalRDD [a#4,b#5], MapPartitionsRDD[5] at beforeAll at BeforeAndAfterAll.scala:187

== Optimized Logical Plan ==
Project [key#2,value#3,a#4,b#5]
+- Join Inner, None
   :- InMemoryRelation [key#2,value#3], true, 10000, StorageLevel(true, true, false, true, 1), ConvertToUnsafe, Some(testData)
   +- LogicalRDD [a#4,b#5], MapPartitionsRDD[5] at beforeAll at BeforeAndAfterAll.scala:187
```

After this PR, the new plan does not have the unnecessary Project. 

```
== Optimized Logical Plan ==
Join Inner, None
:- InMemoryRelation [key#2,value#3], true, 10000, StorageLevel(true, true, false, true, 1), ConvertToUnsafe, Some(testData)
+- LogicalRDD [a#4,b#5], MapPartitionsRDD[5] at beforeAll at BeforeAndAfterAll.scala:187
```

However, it loses the ordering and alias information of attributes in `Projection`. This is just a preliminary work. If their `outputSet`s do not match, we still can push it into the `Join`, since the runtime/execution of Join will do the Projection. 

**Question**: Should we follow what we did in `ConvertToLocalRelation`?

Thank you!
