### PR TITLE
[SPARK-12527] Add private val after @transient for kinesis-asl module

### DIFF
--- a/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisBackedBlockRDD.scala
+++ b/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisBackedBlockRDD.scala
@@ -73,7 +73,7 @@ class KinesisBackedBlockRDD[T: ClassTag](
     @transient private val sc: SparkContext,
     val regionName: String,
     val endpointUrl: String,
-    @transient private val blockIds: Array[BlockId],
+    @transient val blockIds: Array[BlockId],
     @transient val arrayOfseqNumberRanges: Array[SequenceNumberRanges],
     @transient private val isBlockIdValid: Array[Boolean] = Array.empty,
     val retryTimeoutMs: Int = 10000,

--- a/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisBackedBlockRDD.scala
+++ b/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisBackedBlockRDD.scala
@@ -73,7 +73,7 @@ class KinesisBackedBlockRDD[T: ClassTag](
     @transient private val sc: SparkContext,
     val regionName: String,
     val endpointUrl: String,
-    @transient val blockIds: Array[BlockId],
+    @transient override val blockIds: Array[BlockId],
     @transient val arrayOfseqNumberRanges: Array[SequenceNumberRanges],
     @transient private val isBlockIdValid: Array[Boolean] = Array.empty,
     val retryTimeoutMs: Int = 10000,

--- a/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisBackedBlockRDD.scala
+++ b/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisBackedBlockRDD.scala
@@ -70,12 +70,12 @@ class KinesisBackedBlockRDDPartition(
  */
 private[kinesis]
 class KinesisBackedBlockRDD[T: ClassTag](
-    @transient sc: SparkContext,
+    @transient private val sc: SparkContext,
     val regionName: String,
     val endpointUrl: String,
-    @transient blockIds: Array[BlockId],
+    @transient private val blockIds: Array[BlockId],
     @transient val arrayOfseqNumberRanges: Array[SequenceNumberRanges],
-    @transient isBlockIdValid: Array[Boolean] = Array.empty,
+    @transient private val isBlockIdValid: Array[Boolean] = Array.empty,
     val retryTimeoutMs: Int = 10000,
     val messageHandler: Record => T = KinesisUtils.defaultMessageHandler _,
     val awsCredentialsOption: Option[SerializableAWSCredentials] = None

--- a/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisInputDStream.scala
+++ b/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisInputDStream.scala
@@ -30,7 +30,7 @@ import org.apache.spark.streaming.scheduler.ReceivedBlockInfo
 import org.apache.spark.streaming.{Duration, StreamingContext, Time}
 
 private[kinesis] class KinesisInputDStream[T: ClassTag](
-    @transient _ssc: StreamingContext,
+    @transient private val _ssc: StreamingContext,
     streamName: String,
     endpointUrl: String,
     regionName: String,


### PR DESCRIPTION
In SBT build using Scala 2.11, the following warnings were reported which resulted in build failure:

```
[error] [warn] /dev/shm/spark-workspaces/8/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisInputDStream.scala:33: no valid targets for annotation on  value _ssc - it is discarded unused. You may specify targets with meta-annotations, e.g. @(transient @param)
[error] [warn]     @transient _ssc: StreamingContext,
[error] [warn]
[error] [warn] /dev/shm/spark-workspaces/8/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisBackedBlockRDD.scala:73: no valid targets for annotation   on value sc - it is discarded unused. You may specify targets with meta-annotations, e.g. @(transient @param)
[error] [warn]     @transient sc: SparkContext,
[error] [warn]
[error] [warn] /dev/shm/spark-workspaces/8/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisBackedBlockRDD.scala:76: no valid targets for annotation   on value blockIds - it is discarded unused. You may specify targets with meta-annotations, e.g. @(transient @param)
[error] [warn]     @transient blockIds: Array[BlockId],
[error] [warn]
[error] [warn] /dev/shm/spark-workspaces/8/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisBackedBlockRDD.scala:78: no valid targets for annotation   on value isBlockIdValid - it is discarded unused. You may specify targets with meta-annotations, e.g. @(transient @param)
[error] [warn]     @transient isBlockIdValid: Array[Boolean] = Array.empty,
```
