### PR TITLE
[SPARK-12530][Build] Fix build break at Spark-Master-Maven-Snapshots from #1293

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -57,9 +57,10 @@ case class Md5(child: Expression) extends UnaryExpression with ImplicitCastInput
  * the hash length is not one of the permitted values, the return value is NULL.
  */
 @ExpressionDescription(
-  usage = "_FUNC_(input, bitLength) - Returns a checksum of SHA-2 family as a hex string of the " +
-    "input. SHA-224, SHA-256, SHA-384, and SHA-512 are supported. Bit length of 0 is equivalent " +
-    "to 256",
+  usage =
+    """_FUNC_(input, bitLength) - Returns a checksum of SHA-2 family as a hex string of the input.
+      SHA-224, SHA-256, SHA-384, and SHA-512 are supported. Bit length of 0 is equivalent to 256."""
+  ,
   extended = "> SELECT _FUNC_('Spark', 0);\n " +
     "'529bc3b07127ecb7e53a4dcf1991d9152c24537d919178022b2c42657f79a26b'")
 case class Sha2(left: Expression, right: Expression)


### PR DESCRIPTION
Compilation error caused due to string concatenations that are not a constant
Use raw string literal to avoid string concatenations

https://amplab.cs.berkeley.edu/jenkins/view/Spark-Packaging/job/Spark-Master-Maven-Snapshots/1293/
