### PR TITLE
[SPARK-12534][DOC] update documentation to list command line equivalent to properties

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,7 +120,8 @@ of the most common options to set are:
   <td><code>spark.driver.cores</code></td>
   <td>1</td>
   <td>
-    Number of cores to use for the driver process, only in cluster mode.
+    Number of cores to use for the driver process, only in cluster mode. This can be set through
+    <code>--driver-cores</code> command line option.
   </td>
 </tr>
   <td><code>spark.driver.maxResultSize</code></td>
@@ -151,7 +152,8 @@ of the most common options to set are:
   <td><code>spark.executor.memory</code></td>
   <td>1g</td>
   <td>
-    Amount of memory to use per executor process (e.g. <code>2g</code>, <code>8g</code>).
+    Amount of memory to use per executor process (e.g. <code>2g</code>, <code>8g</code>). This can
+    be set through the <code>--executor-memory</code> command line option.
   </td>
 </tr>
 <tr>
@@ -173,7 +175,7 @@ of the most common options to set are:
     stored on disk. This should be on a fast, local disk in your system. It can also be a
     comma-separated list of multiple directories on different disks.
 
-    NOTE: In Spark 1.0 and later this will be overriden by SPARK_LOCAL_DIRS (Standalone, Mesos) or
+    NOTE: In Spark 1.0 and later this will be overridden by SPARK_LOCAL_DIRS (Standalone, Mesos) or
     LOCAL_DIRS (YARN) environment variables set by the cluster manager.
   </td>
 </tr>
@@ -687,10 +689,10 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.rdd.compress</code></td>
   <td>false</td>
   <td>
-    Whether to compress serialized RDD partitions (e.g. for 
-    <code>StorageLevel.MEMORY_ONLY_SER</code> in Java 
-    and Scala or <code>StorageLevel.MEMORY_ONLY</code> in Python). 
-    Can save substantial space at the cost of some extra CPU time. 
+    Whether to compress serialized RDD partitions (e.g. for
+    <code>StorageLevel.MEMORY_ONLY_SER</code> in Java
+    and Scala or <code>StorageLevel.MEMORY_ONLY</code> in Python).
+    Can save substantial space at the cost of some extra CPU time.
   </td>
 </tr>
 <tr>
@@ -850,6 +852,8 @@ Apart from these, the following properties are also available, and may be useful
     In standalone mode, setting this parameter allows an application to run multiple executors on
     the same worker, provided that there are enough cores on that worker. Otherwise, only one
     executor per application will run on each worker.
+
+    This can be set through <code>--executor-cores</code> in the command line.
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,8 +120,7 @@ of the most common options to set are:
   <td><code>spark.driver.cores</code></td>
   <td>1</td>
   <td>
-    Number of cores to use for the driver process, only in cluster mode. This can be set through
-    <code>--driver-cores</code> command line option.
+    Number of cores to use for the driver process, only in cluster mode.
   </td>
 </tr>
   <td><code>spark.driver.maxResultSize</code></td>
@@ -152,8 +151,7 @@ of the most common options to set are:
   <td><code>spark.executor.memory</code></td>
   <td>1g</td>
   <td>
-    Amount of memory to use per executor process (e.g. <code>2g</code>, <code>8g</code>). This can
-    be set through the <code>--executor-memory</code> command line option.
+    Amount of memory to use per executor process (e.g. <code>2g</code>, <code>8g</code>).
   </td>
 </tr>
 <tr>
@@ -852,8 +850,6 @@ Apart from these, the following properties are also available, and may be useful
     In standalone mode, setting this parameter allows an application to run multiple executors on
     the same worker, provided that there are enough cores on that worker. Otherwise, only one
     executor per application will run on each worker.
-
-    This can be set through <code>--executor-cores</code> in the command line.
   </td>
 </tr>
 <tr>

--- a/docs/job-scheduling.md
+++ b/docs/job-scheduling.md
@@ -39,7 +39,10 @@ Resource allocation can be configured as follows, based on the cluster type:
   and optionally set `spark.cores.max` to limit each application's resource share as in the standalone mode.
   You should also set `spark.executor.memory` to control the executor memory.
 * **YARN:** The `--num-executors` option to the Spark YARN client controls how many executors it will allocate
-  on the cluster, while `--executor-memory` and `--executor-cores` control the resources per executor.
+  on the cluster (`spark.executor.instances` as configuration property), while `--executor-memory`
+  (`spark.executor.memory` configuration property) and `--executor-cores` (`spark.executor.cores`) configuration
+  property) control the resources per executor. For more information, see the
+  [YARN Spark Properties](running-on-yarn.html).
 
 A second option available on Mesos is _dynamic sharing_ of CPU cores. In this mode, each Spark application
 still has a fixed and independent memory allocation (set by `spark.executor.memory`), but when the

--- a/docs/job-scheduling.md
+++ b/docs/job-scheduling.md
@@ -40,7 +40,7 @@ Resource allocation can be configured as follows, based on the cluster type:
   You should also set `spark.executor.memory` to control the executor memory.
 * **YARN:** The `--num-executors` option to the Spark YARN client controls how many executors it will allocate
   on the cluster (`spark.executor.instances` as configuration property), while `--executor-memory`
-  (`spark.executor.memory` configuration property) and `--executor-cores` (`spark.executor.cores`) configuration
+  (`spark.executor.memory` configuration property) and `--executor-cores` (`spark.executor.cores` configuration
   property) control the resources per executor. For more information, see the
   [YARN Spark Properties](running-on-yarn.html).
 

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -120,6 +120,7 @@ If you need a reference to the proper location to put log files in the YARN so t
     Number of cores used by the driver in YARN cluster mode.
     Since the driver is run in the same JVM as the YARN Application Master in cluster mode, this also controls the cores used by the YARN Application Master.
     In client mode, use <code>spark.yarn.am.cores</code> to control the number of cores used by the YARN Application Master instead.
+    This can be set through <code>--driver-cores</code> command line option.
   </td>
 </tr>
 <tr>
@@ -204,11 +205,32 @@ If you need a reference to the proper location to put log files in the YARN so t
   </td>
 </tr>
 <tr>
+  <td><code>spark.executor.cores</code></td>
+  <td>1 in YARN mode, all the available cores on the worker in standalone mode.</td>
+  <td>
+    The number of cores to use on each executor. For YARN and standalone mode only.
+
+    In standalone mode, setting this parameter allows an application to run multiple executors on
+    the same worker, provided that there are enough cores on that worker. Otherwise, only one
+    executor per application will run on each worker.
+
+    This can be set through <code>--executor-cores</code> in the command line.
+  </td>
+</tr>
+<tr>
  <td><code>spark.executor.instances</code></td>
   <td><code>2</code></td>
   <td>
     The number of executors. Note that this property is incompatible with <code>spark.dynamicAllocation.enabled</code>. If both <code>spark.dynamicAllocation.enabled</code> and <code>spark.executor.instances</code> are specified, dynamic allocation is turned off and the specified number of <code>spark.executor.instances</code> is used.
     This can be set through <code>--num-executors</code> command line option.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.executor.memory</code></td>
+  <td>1g</td>
+  <td>
+    Amount of memory to use per executor process (e.g. <code>2g</code>, <code>8g</code>). This can
+    be set through the <code>--executor-memory</code> command line option.
   </td>
 </tr>
 <tr>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -193,6 +193,7 @@ If you need a reference to the proper location to put log files in the YARN so t
   <td>(none)</td>
   <td>
     Comma separated list of archives to be extracted into the working directory of each executor.
+    This can be set through <code>--archives</code> command line option.
   </td>
 </tr>
 <tr>
@@ -207,6 +208,7 @@ If you need a reference to the proper location to put log files in the YARN so t
   <td><code>2</code></td>
   <td>
     The number of executors. Note that this property is incompatible with <code>spark.dynamicAllocation.enabled</code>. If both <code>spark.dynamicAllocation.enabled</code> and <code>spark.executor.instances</code> are specified, dynamic allocation is turned off and the specified number of <code>spark.executor.instances</code> is used.
+    This can be set through <code>--num-executors</code> command line option.
   </td>
 </tr>
 <tr>
@@ -241,7 +243,8 @@ If you need a reference to the proper location to put log files in the YARN so t
   <td><code>spark.yarn.queue</code></td>
   <td><code>default</code></td>
   <td>
-    The name of the YARN queue to which the application is submitted.
+    The name of the YARN queue to which the application is submitted. This can be set through
+    <code>--queue</code> command line option.
   </td>
 </tr>
 <tr>
@@ -359,6 +362,7 @@ If you need a reference to the proper location to put log files in the YARN so t
   The full path to the file that contains the keytab for the principal specified above.
   This keytab will be copied to the node running the YARN Application Master via the Secure Distributed Cache,
   for renewing the login tickets and the delegation tokens periodically. (Works also with the "local" master)
+  This can be set through <code>--keytab</code> command line option.
   </td>
 </tr>
 <tr>
@@ -366,6 +370,7 @@ If you need a reference to the proper location to put log files in the YARN so t
   <td>(none)</td>
   <td>
   Principal to be used to login to KDC, while running on secure HDFS. (Works also with the "local" master)
+  This can be set through <code>--principal</code> command line option.
   </td>
 </tr>
 <tr>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -114,6 +114,19 @@ If you need a reference to the proper location to put log files in the YARN so t
   </td>
 </tr>
 <tr>
+  <td><code>spark.driver.memory</code></td>
+  <td>1g</td>
+  <td>
+    Amount of memory to use for the driver process, i.e. where SparkContext is initialized.
+    (e.g. <code>1g</code>, <code>2g</code>).
+
+    <br /><em>Note:</em> In client mode, this config must not be set through the <code>SparkConf</code>
+    directly in your application, because the driver JVM has already started at that point.
+    Instead, please set this through the <code>--driver-memory</code> command line option
+    or in your default properties file.
+  </td>
+</tr>
+<tr>
   <td><code>spark.driver.cores</code></td>
   <td><code>1</code></td>
   <td>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -207,10 +207,6 @@ If you need a reference to the proper location to put log files in the YARN so t
   <td>1 in YARN mode, all the available cores on the worker in standalone mode.</td>
   <td>
     The number of cores to use on each executor. For YARN and standalone mode only.
-
-    In standalone mode, setting this parameter allows an application to run multiple executors on
-    the same worker, provided that there are enough cores on that worker. Otherwise, only one
-    executor per application will run on each worker.
   </td>
 </tr>
 <tr>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -120,7 +120,6 @@ If you need a reference to the proper location to put log files in the YARN so t
     Number of cores used by the driver in YARN cluster mode.
     Since the driver is run in the same JVM as the YARN Application Master in cluster mode, this also controls the cores used by the YARN Application Master.
     In client mode, use <code>spark.yarn.am.cores</code> to control the number of cores used by the YARN Application Master instead.
-    This can be set through <code>--driver-cores</code> command line option.
   </td>
 </tr>
 <tr>
@@ -194,7 +193,6 @@ If you need a reference to the proper location to put log files in the YARN so t
   <td>(none)</td>
   <td>
     Comma separated list of archives to be extracted into the working directory of each executor.
-    This can be set through <code>--archives</code> command line option.
   </td>
 </tr>
 <tr>
@@ -213,8 +211,6 @@ If you need a reference to the proper location to put log files in the YARN so t
     In standalone mode, setting this parameter allows an application to run multiple executors on
     the same worker, provided that there are enough cores on that worker. Otherwise, only one
     executor per application will run on each worker.
-
-    This can be set through <code>--executor-cores</code> in the command line.
   </td>
 </tr>
 <tr>
@@ -222,15 +218,13 @@ If you need a reference to the proper location to put log files in the YARN so t
   <td><code>2</code></td>
   <td>
     The number of executors. Note that this property is incompatible with <code>spark.dynamicAllocation.enabled</code>. If both <code>spark.dynamicAllocation.enabled</code> and <code>spark.executor.instances</code> are specified, dynamic allocation is turned off and the specified number of <code>spark.executor.instances</code> is used.
-    This can be set through <code>--num-executors</code> command line option.
   </td>
 </tr>
 <tr>
   <td><code>spark.executor.memory</code></td>
   <td>1g</td>
   <td>
-    Amount of memory to use per executor process (e.g. <code>2g</code>, <code>8g</code>). This can
-    be set through the <code>--executor-memory</code> command line option.
+    Amount of memory to use per executor process (e.g. <code>2g</code>, <code>8g</code>).
   </td>
 </tr>
 <tr>
@@ -265,8 +259,7 @@ If you need a reference to the proper location to put log files in the YARN so t
   <td><code>spark.yarn.queue</code></td>
   <td><code>default</code></td>
   <td>
-    The name of the YARN queue to which the application is submitted. This can be set through
-    <code>--queue</code> command line option.
+    The name of the YARN queue to which the application is submitted.
   </td>
 </tr>
 <tr>
@@ -384,7 +377,6 @@ If you need a reference to the proper location to put log files in the YARN so t
   The full path to the file that contains the keytab for the principal specified above.
   This keytab will be copied to the node running the YARN Application Master via the Secure Distributed Cache,
   for renewing the login tickets and the delegation tokens periodically. (Works also with the "local" master)
-  This can be set through <code>--keytab</code> command line option.
   </td>
 </tr>
 <tr>
@@ -392,7 +384,6 @@ If you need a reference to the proper location to put log files in the YARN so t
   <td>(none)</td>
   <td>
   Principal to be used to login to KDC, while running on secure HDFS. (Works also with the "local" master)
-  This can be set through <code>--principal</code> command line option.
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
Several Spark properties equivalent to Spark submit command line options are missing.
