### PR TITLE
[SPARK-12537] [SQL] Add option to accept quoting of all character backslash quoting mechanism

### DIFF
--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -160,6 +160,8 @@ class DataFrameReader(object):
                 quotes
             * ``allowNumericLeadingZeros`` (default ``false``): allows leading zeros in numbers \
                 (e.g. 00012)
+            * ``allowBackslashEscapingAnyCharacter`` (default ``false``): allows accepting quoting \
+                of all character using backslash quoting mechanism \
 
         >>> df1 = sqlContext.read.json('python/test_support/sql/people.json')
         >>> df1.dtypes

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -257,6 +257,8 @@ class DataFrameReader private[sql](sqlContext: SQLContext) extends Logging {
    * </li>
    * <li>`allowNumericLeadingZeros` (default `false`): allows leading zeros in numbers
    * (e.g. 00012)</li>
+   * <li>`allowBackslashEscapingAnyCharacter` (default `false`): allows accepting quoting of all
+   * character using backslash quoting mechanism</li>
    *
    * @since 1.6.0
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JSONOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JSONOptions.scala
@@ -31,7 +31,8 @@ case class JSONOptions(
     allowUnquotedFieldNames: Boolean = false,
     allowSingleQuotes: Boolean = true,
     allowNumericLeadingZeros: Boolean = false,
-    allowNonNumericNumbers: Boolean = false) {
+    allowNonNumericNumbers: Boolean = false,
+    allowBackslashEscapingAnyCharacter: Boolean = false) {
 
   /** Sets config options on a Jackson [[JsonFactory]]. */
   def setJacksonOptions(factory: JsonFactory): Unit = {
@@ -40,6 +41,8 @@ case class JSONOptions(
     factory.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, allowSingleQuotes)
     factory.configure(JsonParser.Feature.ALLOW_NUMERIC_LEADING_ZEROS, allowNumericLeadingZeros)
     factory.configure(JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS, allowNonNumericNumbers)
+    factory.configure(JsonParser.Feature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER,
+      allowBackslashEscapingAnyCharacter)
   }
 }
 
@@ -59,6 +62,8 @@ object JSONOptions {
     allowNumericLeadingZeros =
       parameters.get("allowNumericLeadingZeros").map(_.toBoolean).getOrElse(false),
     allowNonNumericNumbers =
-      parameters.get("allowNonNumericNumbers").map(_.toBoolean).getOrElse(true)
+      parameters.get("allowNonNumericNumbers").map(_.toBoolean).getOrElse(true),
+    allowBackslashEscapingAnyCharacter =
+      parameters.get("allowBackslashEscapingAnyCharacter").map(_.toBoolean).getOrElse(false)
   )
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonParsingOptionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonParsingOptionsSuite.scala
@@ -126,6 +126,6 @@ class JsonParsingOptionsSuite extends QueryTest with SharedSQLContext {
     val df = sqlContext.read.option("allowBackslashEscapingAnyCharacter", "true").json(rdd)
 
     assert(df.schema.head.name == "name")
-    assert(df.schema.head.name == "Cazen Lee")
+    assert(df.first().getString(0) == "Cazen Lee")
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonParsingOptionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonParsingOptionsSuite.scala
@@ -112,7 +112,7 @@ class JsonParsingOptionsSuite extends QueryTest with SharedSQLContext {
     assert(df.first().getDouble(0).isNaN)
   }
 
-  ignore("allowBackslashEscapingAnyCharacter off") {
+  test("allowBackslashEscapingAnyCharacter off") {
     val str = """{"name": "Cazen Lee"}"""
     val rdd = sqlContext.sparkContext.parallelize(Seq(str))
     val df = sqlContext.read.option("allowBackslashEscapingAnyCharacter", "false").json(rdd)
@@ -120,7 +120,7 @@ class JsonParsingOptionsSuite extends QueryTest with SharedSQLContext {
     assert(df.schema.head.name == "null")
   }
 
-  ignore("allowBackslashEscapingAnyCharacter on") {
+  test("allowBackslashEscapingAnyCharacter on") {
     val str = """{"name": "Cazen Lee"}"""
     val rdd = sqlContext.sparkContext.parallelize(Seq(str))
     val df = sqlContext.read.option("allowBackslashEscapingAnyCharacter", "true").json(rdd)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonParsingOptionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonParsingOptionsSuite.scala
@@ -118,7 +118,6 @@ class JsonParsingOptionsSuite extends QueryTest with SharedSQLContext {
     val df = sqlContext.read.option("allowBackslashEscapingAnyCharacter", "false").json(rdd)
 
     assert(df.schema.head.name == "_corrupt_record")
-    assert(df.first().getString(0) == "null")
   }
 
   test("allowBackslashEscapingAnyCharacter on") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonParsingOptionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonParsingOptionsSuite.scala
@@ -111,4 +111,21 @@ class JsonParsingOptionsSuite extends QueryTest with SharedSQLContext {
     assert(df.schema.head.name == "age")
     assert(df.first().getDouble(0).isNaN)
   }
+
+  ignore("allowBackslashEscapingAnyCharacter off") {
+    val str = """{"name": "Cazen Lee"}"""
+    val rdd = sqlContext.sparkContext.parallelize(Seq(str))
+    val df = sqlContext.read.option("allowBackslashEscapingAnyCharacter", "false").json(rdd)
+
+    assert(df.schema.head.name == "null")
+  }
+
+  ignore("allowBackslashEscapingAnyCharacter on") {
+    val str = """{"name": "Cazen Lee"}"""
+    val rdd = sqlContext.sparkContext.parallelize(Seq(str))
+    val df = sqlContext.read.option("allowBackslashEscapingAnyCharacter", "true").json(rdd)
+
+    assert(df.schema.head.name == "name")
+    assert(df.schema.head.name == "Cazen Lee")
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonParsingOptionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonParsingOptionsSuite.scala
@@ -113,7 +113,7 @@ class JsonParsingOptionsSuite extends QueryTest with SharedSQLContext {
   }
 
   test("allowBackslashEscapingAnyCharacter off") {
-    val str = """{"name": "Cazen Lee"}"""
+    val str = """{"name": "Cazen Lee", "price": "\$10"}"""
     val rdd = sqlContext.sparkContext.parallelize(Seq(str))
     val df = sqlContext.read.option("allowBackslashEscapingAnyCharacter", "false").json(rdd)
 
@@ -122,7 +122,7 @@ class JsonParsingOptionsSuite extends QueryTest with SharedSQLContext {
   }
 
   test("allowBackslashEscapingAnyCharacter on") {
-    val str = """{"name": "Cazen Lee"}"""
+    val str = """{"name": "Cazen Lee", "price": "\$10"}"""
     val rdd = sqlContext.sparkContext.parallelize(Seq(str))
     val df = sqlContext.read.option("allowBackslashEscapingAnyCharacter", "true").json(rdd)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonParsingOptionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonParsingOptionsSuite.scala
@@ -117,7 +117,8 @@ class JsonParsingOptionsSuite extends QueryTest with SharedSQLContext {
     val rdd = sqlContext.sparkContext.parallelize(Seq(str))
     val df = sqlContext.read.option("allowBackslashEscapingAnyCharacter", "false").json(rdd)
 
-    assert(df.schema.head.name == "null")
+    assert(df.schema.head.name == "name")
+    assert(df.first().getString(0) == "null")
   }
 
   test("allowBackslashEscapingAnyCharacter on") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonParsingOptionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonParsingOptionsSuite.scala
@@ -117,7 +117,7 @@ class JsonParsingOptionsSuite extends QueryTest with SharedSQLContext {
     val rdd = sqlContext.sparkContext.parallelize(Seq(str))
     val df = sqlContext.read.option("allowBackslashEscapingAnyCharacter", "false").json(rdd)
 
-    assert(df.schema.head.name == "name")
+    assert(df.schema.head.name == "_corrupt_record")
     assert(df.first().getString(0) == "null")
   }
 


### PR DESCRIPTION
We can provides the option to choose JSON parser can be enabled to accept quoting of all character or not.
