### PR TITLE
[SPARK-12349] [ML] Fix typo in Spark version regex introduced in SPARK-12349 / PR 10327

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/PCA.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/PCA.scala
@@ -180,7 +180,7 @@ object PCAModel extends MLReadable[PCAModel] {
       val metadata = DefaultParamsReader.loadMetadata(path, sc, className)
 
       // explainedVariance field is not present in Spark <= 1.6
-      val versionRegex = "([0-9]+)\\.([0-9])+.*".r
+      val versionRegex = "([0-9]+)\\.([0-9]+).*".r
       val hasExplainedVariance = metadata.sparkVersion match {
         case versionRegex(major, minor) =>
           (major.toInt >= 2 || (major.toInt == 1 && minor.toInt > 6))


### PR DESCRIPTION
Sorry @jkbradley 
Ref: https://github.com/apache/spark/pull/10327#discussion_r48502942
