### PR TITLE
[SPARK-12560][SQL] SqlTestUtils.stripSparkFilter needs to copy utf8strings

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
@@ -189,7 +189,7 @@ private[sql] trait SQLTestUtils
       .executedPlan.asInstanceOf[org.apache.spark.sql.execution.Filter]
       .child
       .execute()
-      .map(row => Row.fromSeq(row.toSeq(schema)))
+      .map(row => Row.fromSeq(row.copy().toSeq(schema)))
 
     sqlContext.createDataFrame(childRDD, schema)
   }


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/SPARK-12560

This isn't causing any problems currently because the tests for string predicate pushdown are currently disabled.  I ran into this while trying to turn them back on with a different version of parquet.  Figure it was good to fix now in any case.
