### PR TITLE
[SPARK-12490][Core]Limit the css style scope to fix the Streaming UI

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/webui.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/webui.css
@@ -227,7 +227,7 @@ a.expandbutton {
   cursor:pointer;
 }
 
-th a, th a:hover {
+.table-head-clickable th a, .table-head-clickable th a:hover {
   /* Make the entire header clickable, not just the text label */
   display: block;
   width: 100%;

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -1233,7 +1233,8 @@ private[ui] class TaskPagedTable(
 
   override def tableId: String = "task-table"
 
-  override def tableCssClass: String = "table table-bordered table-condensed table-striped"
+  override def tableCssClass: String =
+    "table table-bordered table-condensed table-striped table-head-clickable"
 
   override def pageSizeFormField: String = "task.pageSize"
 

--- a/core/src/main/scala/org/apache/spark/ui/storage/RDDPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/storage/RDDPage.scala
@@ -237,7 +237,8 @@ private[ui] class BlockPagedTable(
 
   override def tableId: String = "rdd-storage-by-block-table"
 
-  override def tableCssClass: String = "table table-bordered table-condensed table-striped"
+  override def tableCssClass: String =
+    "table table-bordered table-condensed table-striped table-head-clickable"
 
   override def pageSizeFormField: String = "block.pageSize"
 


### PR DESCRIPTION
#10441 broke the Streaming UI because of the new CSS style.

<img width="503" alt="screen shot 2015-12-29 at 4 49 04 pm" src="https://cloud.githubusercontent.com/assets/1000778/12044763/1efce0fe-ae4c-11e5-9f8b-39df08426bf8.png">

This PR just added a class for the new style and only applied them to the paged tables. 
