### PR TITLE
[SPARK-12581][SQL] Support case-sensitive table names in postgresql

### DIFF
--- a/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
+++ b/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
@@ -37,8 +37,8 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationSuite {
   }
 
   override def dataPreparation(conn: Connection): Unit = {
-    conn.prepareStatement("CREATE DATABASE foo").executeUpdate()
-    conn.setCatalog("foo")
+    conn.prepareStatement("CREATE DATABASE pgtest").executeUpdate()
+    conn.setCatalog("pgtest")
     conn.prepareStatement("CREATE TABLE bar (c0 text, c1 integer, c2 double precision, c3 bigint, "
       + "c4 bit(1), c5 bit(10), c6 bytea, c7 boolean, c8 inet, c9 cidr, "
       + "c10 integer[], c11 text[])").executeUpdate()
@@ -49,8 +49,8 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationSuite {
     conn.prepareStatement("CREATE TABLE foo (c0 text, c1 integer)").executeUpdate()
     conn.prepareStatement("INSERT INTO foo VALUES ('abc', 0)").executeUpdate()
     conn.prepareStatement("INSERT INTO foo VALUES ('def', 1)").executeUpdate()
-    conn.prepareStatement("CREATE TABLE FOO (c0 text, c1 integer)").executeUpdate()
-    conn.prepareStatement("INSERT INTO FOO VALUES ('ghi', 2)").executeUpdate()
+    conn.prepareStatement("""CREATE TABLE "FOO" (c0 text, c1 integer)""").executeUpdate()
+    conn.prepareStatement("""INSERT INTO "FOO" VALUES ('ghi', 2)""").executeUpdate()
   }
 
   test("Type mapping for various types") {

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -57,8 +57,7 @@ object MimaExcludes {
       ) ++ Seq(
         ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.spark.SparkContext.emptyRDD"),
         ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.broadcast.HttpBroadcastFactory")
-        ) ++
-      Seq(
+      ) ++ Seq(
         // SPARK-12481 Remove Hadoop 1.x
         ProblemFilters.exclude[IncompatibleTemplateDefProblem]("org.apache.spark.mapred.SparkHadoopMapRedUtil"),
         // SPARK-12615 Remove deprecated APIs in core
@@ -119,7 +118,12 @@ object MimaExcludes {
         ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.util.Vector"),
         ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.util.Vector$Multiplier"),
         ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.util.Vector$")
+      ) ++ Seq(
+        // SPARK-12581 Support case-sensitive table names in postgresql
+        ProblemFilters.exclude[MissingMethodProblem]("org.apache.spark.sql.jdbc.JdbcDialect.quoteIdentifier"),
+        ProblemFilters.exclude[MissingMethodProblem]("org.apache.spark.sql.jdbc.MySQLDialect.quoteIdentifier")
       )
+
     case v if v.startsWith("1.6") =>
       Seq(
         MimaBuild.excludeSparkPackage("deploy"),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -253,12 +253,13 @@ private[sql] object JDBCRDD extends Logging {
       filters: Array[Filter],
       parts: Array[Partition]): RDD[InternalRow] = {
     val dialect = JdbcDialects.get(url)
-    val quotedColumns = requiredColumns.map(colName => dialect.quoteIdentifier(colName))
+    val quotedTable = dialect.quoteTableName(fqTable)
+    val quotedColumns = requiredColumns.map(colName => dialect.quoteColumnName(colName))
     new JDBCRDD(
       sc,
       JdbcUtils.createConnectionFactory(url, properties),
       pruneSchema(schema, requiredColumns),
-      fqTable,
+      quotedTable,
       quotedColumns,
       filters,
       parts,

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -82,10 +82,15 @@ abstract class JdbcDialect extends Serializable {
   def getJDBCType(dt: DataType): Option[JdbcType] = None
 
   /**
-   * Quotes the identifier. This is used to put quotes around the identifier in case the column
-   * name is a reserved keyword, or in case it contains characters that require quotes (e.g. space).
+   * Quotes the table name. This is used to put quotes around the table name in case it is
+   * a reserved keyword, or in case it contains characters that require quotes (e.g. space).
    */
-  def quoteIdentifier(colName: String): String = {
+  def quoteTableName(tableName: String): String = tableName
+
+  /**
+   * Quotes the column name. This is used for the same purpose as [[quoteTableName]].
+   */
+  def quoteColumnName(colName: String): String = {
     s""""$colName""""
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -37,7 +37,7 @@ private case object MySQLDialect extends JdbcDialect {
     } else None
   }
 
-  override def quoteIdentifier(colName: String): String = {
+  override def quoteColumnName(colName: String): String = {
     s"`$colName`"
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -68,6 +68,10 @@ private object PostgresDialect extends JdbcDialect {
     case _ => None
   }
 
+  override def quoteTableName(tableName: String): String = {
+    s""""$tableName""""
+  }
+
   override def getTableExistsQuery(table: String): String = {
     s"SELECT 1 FROM $table LIMIT 1"
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -447,9 +447,9 @@ class JDBCSuite extends SparkFunSuite
     val Derby = JdbcDialects.get("jdbc:derby:db")
 
     val columns = Seq("abc", "key")
-    val MySQLColumns = columns.map(MySQL.quoteIdentifier(_))
-    val PostgresColumns = columns.map(Postgres.quoteIdentifier(_))
-    val DerbyColumns = columns.map(Derby.quoteIdentifier(_))
+    val MySQLColumns = columns.map(MySQL.quoteColumnName(_))
+    val PostgresColumns = columns.map(Postgres.quoteColumnName(_))
+    val DerbyColumns = columns.map(Derby.quoteColumnName(_))
     assert(MySQLColumns === Seq("`abc`", "`key`"))
     assert(PostgresColumns === Seq(""""abc"""", """"key""""))
     assert(DerbyColumns === Seq(""""abc"""", """"key""""))


### PR DESCRIPTION
Table names in postgresql is originally case-insensitive.
To support case-sensitive table names, we need to wrap names in double quotes.
