### PR TITLE
[SPARK-12580][SQL] Remove string concatenations from usage and extended in @ExpressionDescription

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/MonotonicallyIncreasingID.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/MonotonicallyIncreasingID.scala
@@ -33,12 +33,12 @@ import org.apache.spark.sql.types.{LongType, DataType}
  * Since this expression is stateful, it cannot be a case object.
  */
 @ExpressionDescription(
-  usage =
-    """_FUNC_() - Returns monotonically increasing 64-bit integers.
-      The generated ID is guaranteed to be monotonically increasing and unique, but not consecutive.
-      The current implementation puts the partition ID in the upper 31 bits, and the lower 33 bits
-      represent the record number within each partition. The assumption is that the data frame has
-      less than 1 billion partitions, and each partition has less than 8 billion records.""",
+  usage = """_FUNC_() - Returns monotonically increasing 64-bit integers.
+The generated ID is guaranteed to be monotonically increasing and unique, but not
+consecutive. The current implementation puts the partition ID in the upper 31
+bits, and the lower 33 bits represent the record number within each partition.
+The assumption is that the data frame has less than 1 billion partitions,
+and each partition has less than 8 billion records.""",
   extended = "> SELECT _FUNC_();\n 0")
 private[sql] case class MonotonicallyIncreasingID() extends LeafExpression with Nondeterministic {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/MonotonicallyIncreasingID.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/MonotonicallyIncreasingID.scala
@@ -33,12 +33,12 @@ import org.apache.spark.sql.types.{LongType, DataType}
  * Since this expression is stateful, it cannot be a case object.
  */
 @ExpressionDescription(
-  usage = """_FUNC_() - Returns monotonically increasing 64-bit integers.
-The generated ID is guaranteed to be monotonically increasing and unique, but not
-consecutive. The current implementation puts the partition ID in the upper 31
-bits, and the lower 33 bits represent the record number within each partition.
-The assumption is that the data frame has less than 1 billion partitions,
-and each partition has less than 8 billion records.""",
+  usage =
+    """_FUNC_() - Returns monotonically increasing 64-bit integers.
+      The generated ID is guaranteed to be monotonically increasing and unique, but not consecutive.
+      The current implementation puts the partition ID in the upper 31 bits, and the lower 33 bits
+      represent the record number within each partition. The assumption is that the data frame has
+      less than 1 billion partitions, and each partition has less than 8 billion records.""",
   extended = "> SELECT _FUNC_();\n 0")
 private[sql] case class MonotonicallyIncreasingID() extends LeafExpression with Nondeterministic {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -57,10 +57,9 @@ case class Md5(child: Expression) extends UnaryExpression with ImplicitCastInput
  * the hash length is not one of the permitted values, the return value is NULL.
  */
 @ExpressionDescription(
-  usage =
-    """_FUNC_(input, bitLength) - Returns a checksum of SHA-2 family as a hex string of the input.
-      SHA-224, SHA-256, SHA-384, and SHA-512 are supported. Bit length of 0 is equivalent to 256."""
-  ,
+  usage = """_FUNC_(input, bitLength) - Returns a checksum of SHA-2 family as a hex string of
+the input. SHA-224, SHA-256, SHA-384, and SHA-512 are supported. Bit length of 0 is
+equivalent to 256.""",
   extended = "> SELECT _FUNC_('Spark', 0);\n " +
     "'529bc3b07127ecb7e53a4dcf1991d9152c24537d919178022b2c42657f79a26b'")
 case class Sha2(left: Expression, right: Expression)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -56,12 +56,13 @@ case class Md5(child: Expression) extends UnaryExpression with ImplicitCastInput
  * asking for an unsupported SHA function, the return value is NULL. If either argument is NULL or
  * the hash length is not one of the permitted values, the return value is NULL.
  */
+// scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = """_FUNC_(input, bitLength) - Returns a checksum of SHA-2 family as a hex string of
-the input. SHA-224, SHA-256, SHA-384, and SHA-512 are supported. Bit length of 0 is
-equivalent to 256.""",
-  extended = "> SELECT _FUNC_('Spark', 0);\n " +
-    "'529bc3b07127ecb7e53a4dcf1991d9152c24537d919178022b2c42657f79a26b'")
+  usage = """_FUNC_(input, bitLength) - Returns a checksum of SHA-2 family as a hex string of the input.
+            SHA-224, SHA-256, SHA-384, and SHA-512 are supported. Bit length of 0 is equivalent to 256.""",
+  extended = """> SELECT _FUNC_('Spark', 0);
+               '529bc3b07127ecb7e53a4dcf1991d9152c24537d919178022b2c42657f79a26b'""")
+// scalastyle:on line.size.limit
 case class Sha2(left: Expression, right: Expression)
   extends BinaryExpression with Serializable with ImplicitCastInputTypes {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/windowExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/windowExpressions.scala
@@ -366,8 +366,8 @@ abstract class OffsetWindowFunction
  * @param default to use when the input value is null or when the offset is larger than the window.
  */
 @ExpressionDescription(usage =
-  """_FUNC_(input, offset, default) - LEAD returns the value of 'x' at 'offset' rows after the
-     current row in the window""")
+  """_FUNC_(input, offset, default) - LEAD returns the value of 'x' at 'offset' rows
+     after the current row in the window""")
 case class Lead(input: Expression, offset: Expression, default: Expression)
     extends OffsetWindowFunction {
 
@@ -393,8 +393,8 @@ case class Lead(input: Expression, offset: Expression, default: Expression)
  * @param default to use when the input value is null or when the offset is smaller than the window.
  */
 @ExpressionDescription(usage =
-  """_FUNC_(input, offset, default) - LAG returns the value of 'x' at 'offset' rows before the
-     current row in the window""")
+  """_FUNC_(input, offset, default) - LAG returns the value of 'x' at 'offset' rows
+     before the current row in the window""")
 case class Lag(input: Expression, offset: Expression, default: Expression)
     extends OffsetWindowFunction {
 
@@ -446,9 +446,9 @@ object SizeBasedWindowFunction {
  * This documentation has been based upon similar documentation for the Hive and Presto projects.
  */
 @ExpressionDescription(usage =
-  """_FUNC_() - The ROW_NUMBER() function assigns a unique, sequential
-     number to each row, starting with one, according to the ordering of rows within the window
-     partition.""")
+  """_FUNC_() - The ROW_NUMBER() function assigns a unique, sequential number to
+     each row, starting with one, according to the ordering of rows within
+     the window partition.""")
 case class RowNumber() extends RowNumberLike {
   override val evaluateExpression = rowNumber
 }
@@ -462,8 +462,8 @@ case class RowNumber() extends RowNumberLike {
  * This documentation has been based upon similar documentation for the Hive and Presto projects.
  */
 @ExpressionDescription(usage =
-  """_FUNC_() - The CUME_DIST() function computes the position of a value relative to a all values
-     in the partition.""")
+  """_FUNC_() - The CUME_DIST() function computes the position of a value relative to
+     a all values in the partition.""")
 case class CumeDist() extends RowNumberLike with SizeBasedWindowFunction {
   override def dataType: DataType = DoubleType
   // The frame for CUME_DIST is Range based instead of Row based, because CUME_DIST must
@@ -494,8 +494,8 @@ case class CumeDist() extends RowNumberLike with SizeBasedWindowFunction {
  * @param buckets number of buckets to divide the rows in. Default value is 1.
  */
 @ExpressionDescription(usage =
-  """_FUNC_(x) - The NTILE(n) function divides the rows for each window partition into 'n' buckets
-     ranging from 1 to at most 'n'.""")
+  """_FUNC_(x) - The NTILE(n) function divides the rows for each window partition
+     into 'n' buckets ranging from 1 to at most 'n'.""")
 case class NTile(buckets: Expression) extends RowNumberLike with SizeBasedWindowFunction {
   def this() = this(Literal(1))
 
@@ -602,9 +602,9 @@ abstract class RankLike extends AggregateWindowFunction {
  *                 Analyser.
  */
 @ExpressionDescription(usage =
-  """_FUNC_() -  RANK() computes the rank of a value in a group of values. The result is one plus
-     the number of rows preceding or equal to the current row in the ordering of the partition. Tie
-     values will produce gaps in the sequence.""")
+  """_FUNC_() -  RANK() computes the rank of a value in a group of values. The result
+     is one plus the number of rows preceding or equal to the current row in the
+     ordering of the partition. Tie values will produce gaps in the sequence.""")
 case class Rank(children: Seq[Expression]) extends RankLike {
   def this() = this(Nil)
   override def withOrder(order: Seq[Expression]): Rank = Rank(order)
@@ -622,9 +622,9 @@ case class Rank(children: Seq[Expression]) extends RankLike {
  *                 Analyser.
  */
 @ExpressionDescription(usage =
-  """_FUNC_() - The DENSE_RANK() function computes the rank of a value in a group of values. The
-     result is one plus the previously assigned rank value. Unlike Rank, DenseRank will not produce
-     gaps in the ranking sequence.""")
+  """_FUNC_() - The DENSE_RANK() function computes the rank of a value in a group of
+     values. The result is one plus the previously assigned rank value. Unlike Rank,
+     DenseRank will not produce gaps in the ranking sequence.""")
 case class DenseRank(children: Seq[Expression]) extends RankLike {
   def this() = this(Nil)
   override def withOrder(order: Seq[Expression]): DenseRank = DenseRank(order)
@@ -649,8 +649,8 @@ case class DenseRank(children: Seq[Expression]) extends RankLike {
  *                 Analyser.
  */
 @ExpressionDescription(usage =
-  """_FUNC_() - PERCENT_RANK() The PercentRank function computes the percentage ranking of a value
-     in a group of values.""")
+  """_FUNC_() - PERCENT_RANK() The PercentRank function computes the percentage
+     ranking of a value in a group of values.""")
 case class PercentRank(children: Seq[Expression]) extends RankLike with SizeBasedWindowFunction {
   def this() = this(Nil)
   override def withOrder(order: Seq[Expression]): PercentRank = PercentRank(order)


### PR DESCRIPTION
Use multi-line string literals for @ExpressionDescription with `// scalastyle:off line.size.limit` and `// scalastyle:on line.size.limit`

The policy is here, as describe at https://github.com/apache/spark/pull/10488

Let's use multi-line string literals. If we have to have a line with more than 100 characters, let's use `// scalastyle:off line.size.limit` and `// scalastyle:on line.size.limit` to just bypass the line number requirement.
