### PR TITLE
[SPARK-10359][PROJECT-INFRA] Multiple fixes to dev/test-dependencies.sh script

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -402,7 +402,8 @@ build = Module(
     source_file_regexes=[
         ".*pom.xml",
         "dev/test-dependencies.sh",
-    ]
+    ],
+    should_run_build_tests=True
 )
 
 ec2 = Module(

--- a/dev/test-dependencies.sh
+++ b/dev/test-dependencies.sh
@@ -77,7 +77,7 @@ for HADOOP_PROFILE in "${HADOOP_PROFILES[@]}"; do
     | rev \
     | cut -d "/" -f 1 \
     | rev \
-    | sort \
+    | LC_ALL=C sort `# The LC_ALL here is necessary for portability` \
     | grep -v spark > dev/pr-deps/spark-deps-$HADOOP_PROFILE
 done
 

--- a/dev/test-dependencies.sh
+++ b/dev/test-dependencies.sh
@@ -72,7 +72,12 @@ for HADOOP_PROFILE in "${HADOOP_PROFILES[@]}"; do
   mkdir -p dev/pr-deps
   $MVN $HADOOP2_MODULE_PROFILES -P$HADOOP_PROFILE dependency:build-classpath -pl assembly \
     | grep "Building Spark Project Assembly" -A 5 \
-    | tail -n 1 | tr ":" "\n" | rev | cut -d "/" -f 1 | rev | sort \
+    | tail -n 1 \
+    | tr ":" "\n" \
+    | rev \
+    | cut -d "/" -f 1 \
+    | rev \
+    | sort \
     | grep -v spark > dev/pr-deps/spark-deps-$HADOOP_PROFILE
 done
 

--- a/dev/test-dependencies.sh
+++ b/dev/test-dependencies.sh
@@ -72,12 +72,7 @@ for HADOOP_PROFILE in "${HADOOP_PROFILES[@]}"; do
   mkdir -p dev/pr-deps
   $MVN $HADOOP2_MODULE_PROFILES -P$HADOOP_PROFILE dependency:build-classpath -pl assembly \
     | grep "Building Spark Project Assembly" -A 5 \
-    | tail -n 1 \
-    | tr ":" "\n" \
-    | rev \
-    | cut -d "/" -f 1 \
-    | rev \
-    | sort \
+    | tail -n 1 | tr ":" "\n" | rev | cut -d "/" -f 1 | rev | sort \
     | grep -v spark > dev/pr-deps/spark-deps-$HADOOP_PROFILE
 done
 

--- a/dev/test-dependencies.sh
+++ b/dev/test-dependencies.sh
@@ -22,6 +22,10 @@ set -e
 FWDIR="$(cd "`dirname $0`"/..; pwd)"
 cd "$FWDIR"
 
+# Explicitly set locale in order to make `sort` output consistent across machines.
+# See https://stackoverflow.com/questions/28881 for more details.
+export LC_ALL=C
+
 # TODO: This would be much nicer to do in SBT, once SBT supports Maven-style resolution.
 
 # NOTE: These should match those in the release publishing script

--- a/dev/test-dependencies.sh
+++ b/dev/test-dependencies.sh
@@ -37,7 +37,7 @@ HADOOP_PROFILES=(
 # resolve Spark's internal submodule dependencies.
 
 # See http://stackoverflow.com/a/3545363 for an explanation of this one-liner:
-OLD_VERSION=$(mvn help:evaluate -Dexpression=project.version|grep -Ev '(^\[|Download\w+:)')
+OLD_VERSION=$($MVN help:evaluate -Dexpression=project.version|grep -Ev '(^\[|Download\w+:)')
 TEMP_VERSION="spark-$(date +%s | tail -c6)"
 
 function reset_version {

--- a/dev/test-dependencies.sh
+++ b/dev/test-dependencies.sh
@@ -77,7 +77,7 @@ for HADOOP_PROFILE in "${HADOOP_PROFILES[@]}"; do
     | rev \
     | cut -d "/" -f 1 \
     | rev \
-    | LC_ALL=C sort `# The LC_ALL here is necessary for portability` \
+    | sort \
     | grep -v spark > dev/pr-deps/spark-deps-$HADOOP_PROFILE
 done
 

--- a/dev/test-dependencies.sh
+++ b/dev/test-dependencies.sh
@@ -100,3 +100,5 @@ for HADOOP_PROFILE in "${HADOOP_PROFILES[@]}"; do
     exit 1
   fi
 done
+
+exit 0


### PR DESCRIPTION
This patch includes multiple fixes for the `dev/test-dependencies.sh` script (which was introduced in #10461):
- Use `build/mvn --force` instead of `mvn` in one additional place.
- Explicitly set a zero exit code on success.
- Set `LC_ALL=C` to make `sort` results agree across machines (see https://stackoverflow.com/questions/28881/).
- Set `should_run_build_tests=True` for `build` module (this somehow got lost).
