### PR TITLE
[SPARK-12597] [ML] Use udf to replace callUDF for ML

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/ElementwiseProduct.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/ElementwiseProduct.scala
@@ -23,6 +23,8 @@ import org.apache.spark.ml.param.{Param, ParamMap}
 import org.apache.spark.ml.util.Identifiable
 import org.apache.spark.mllib.feature
 import org.apache.spark.mllib.linalg.{Vector, VectorUDT}
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.UserDefinedFunction
 import org.apache.spark.sql.types.DataType
 
 /**
@@ -49,10 +51,12 @@ class ElementwiseProduct(override val uid: String)
   /** @group getParam */
   def getScalingVec: Vector = getOrDefault(scalingVec)
 
-  override protected def createTransformFunc: Vector => Vector = {
+  override protected def transformFunc: UserDefinedFunction = {
     require(params.contains(scalingVec), s"transformation requires a weight vector")
-    val elemScaler = new feature.ElementwiseProduct($(scalingVec))
-    elemScaler.transform
+    udf { input: Vector =>
+      val elemScaler = new feature.ElementwiseProduct($(scalingVec))
+      elemScaler.transform(input)
+    }
   }
 
   override protected def outputDataType: DataType = new VectorUDT()

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/NGram.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/NGram.scala
@@ -21,6 +21,8 @@ import org.apache.spark.annotation.{Experimental, Since}
 import org.apache.spark.ml.UnaryTransformer
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.util._
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.UserDefinedFunction
 import org.apache.spark.sql.types.{ArrayType, DataType, StringType}
 
 /**
@@ -56,8 +58,10 @@ class NGram(override val uid: String)
 
   setDefault(n -> 2)
 
-  override protected def createTransformFunc: Seq[String] => Seq[String] = {
-    _.iterator.sliding($(n)).withPartial(false).map(_.mkString(" ")).toSeq
+  override protected def transformFunc: UserDefinedFunction = {
+    udf { input: Seq[String] =>
+      input.iterator.sliding($(n)).withPartial(false).map(_.mkString(" ")).toSeq
+    }
   }
 
   override protected def validateInputType(inputType: DataType): Unit = {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Normalizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Normalizer.scala
@@ -23,6 +23,8 @@ import org.apache.spark.ml.param.{DoubleParam, ParamValidators}
 import org.apache.spark.ml.util._
 import org.apache.spark.mllib.feature
 import org.apache.spark.mllib.linalg.{Vector, VectorUDT}
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.UserDefinedFunction
 import org.apache.spark.sql.types.DataType
 
 /**
@@ -50,9 +52,11 @@ class Normalizer(override val uid: String)
   /** @group setParam */
   def setP(value: Double): this.type = set(p, value)
 
-  override protected def createTransformFunc: Vector => Vector = {
-    val normalizer = new feature.Normalizer($(p))
-    normalizer.transform
+  override protected def transformFunc: UserDefinedFunction = {
+    udf { input: Vector =>
+      val normalizer = new feature.Normalizer($(p))
+      normalizer.transform(input)
+    }
   }
 
   override protected def outputDataType: DataType = new VectorUDT()

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/PolynomialExpansion.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/PolynomialExpansion.scala
@@ -24,7 +24,9 @@ import org.apache.spark.ml.UnaryTransformer
 import org.apache.spark.ml.param.{IntParam, ParamMap, ParamValidators}
 import org.apache.spark.ml.util._
 import org.apache.spark.mllib.linalg._
+import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.UserDefinedFunction
 
 /**
  * :: Experimental ::
@@ -56,8 +58,10 @@ class PolynomialExpansion(override val uid: String)
   /** @group setParam */
   def setDegree(value: Int): this.type = set(degree, value)
 
-  override protected def createTransformFunc: Vector => Vector = { v =>
-    PolynomialExpansion.expand(v, $(degree))
+  override protected def transformFunc: UserDefinedFunction = {
+    udf { input: Vector =>
+      PolynomialExpansion.expand(input, $(degree))
+    }
   }
 
   override protected def outputDataType: DataType = new VectorUDT()


### PR DESCRIPTION
`callUDF` has been deprecated and will be removed in Spark 2.0. We should replace the use of `callUDF` with `udf` for ML.
I was trying to directly wrap `createTransformFunc` to `udf`(which was illustrated by the following code snippet) as an initial attempt, but it hits a bug of `TypeTag ... NotSerializableException` which exists at Scala 2.10.

``` Scala
abstract class UnaryTransformer[IN: TypeTag, OUT: TypeTag, T <: UnaryTransformer[IN, OUT, T]]
  extends Transformer with HasInputCol with HasOutputCol with Logging {
  ......
  override def transform(dataset: DataFrame): DataFrame = {
    transformSchema(dataset.schema, logging = true)
    val transformFunc = udf { input: IN => this.createTransformFunc(input) }
    dataset.withColumn($(outputCol), transformFunc(col($(inputCol))))
  }
  ......
}
```
