### PR TITLE
Adding zipPartitions to PySpark

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -27,7 +27,7 @@ import akka.actor.ActorSystem
 import com.google.common.collect.MapMaker
 
 import org.apache.spark.annotation.DeveloperApi
-import org.apache.spark.api.python.PythonWorkerFactory
+import org.apache.spark.api.python.{SocketPair, PythonWorkerFactory}
 import org.apache.spark.broadcast.BroadcastManager
 import org.apache.spark.metrics.MetricsSystem
 import org.apache.spark.memory.{MemoryManager, StaticMemoryManager, UnifiedMemoryManager}
@@ -128,7 +128,7 @@ class SparkEnv (
   }
 
   private[spark]
-  def createPythonWorker(pythonExec: String, envVars: Map[String, String]): java.net.Socket = {
+  def createPythonWorker(pythonExec: String, envVars: Map[String, String]): SocketPair = {
     synchronized {
       val key = (pythonExec, envVars)
       pythonWorkers.getOrElseUpdate(key, new PythonWorkerFactory(pythonExec, envVars)).create()
@@ -136,7 +136,7 @@ class SparkEnv (
   }
 
   private[spark]
-  def destroyPythonWorker(pythonExec: String, envVars: Map[String, String], worker: Socket) {
+  def destroyPythonWorker(pythonExec: String, envVars: Map[String, String], worker: SocketPair) {
     synchronized {
       val key = (pythonExec, envVars)
       pythonWorkers.get(key).foreach(_.stopWorker(worker))
@@ -144,7 +144,7 @@ class SparkEnv (
   }
 
   private[spark]
-  def releasePythonWorker(pythonExec: String, envVars: Map[String, String], worker: Socket) {
+  def releasePythonWorker(pythonExec: String, envVars: Map[String, String], worker: SocketPair) {
     synchronized {
       val key = (pythonExec, envVars)
       pythonWorkers.get(key).foreach(_.releaseWorker(worker))

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -341,8 +341,7 @@ class RDD(object):
 
         >>> rddA = sc.parallelize(range(10), 4)
         >>> rddB = rddA.map(lambda a: str(a))
-        >>> import itertools
-        >>> def f(iterA, iterB): return itertools.izip(iterA, iterB)
+        >>> def f(iterA, iterB): return ((a, iterB.next()) for a in iterA)
         >>> zippedRDD = rddA.zipPartitions(rddB, f)
         >>> result = zippedRDD.collect()
 
@@ -364,8 +363,7 @@ class RDD(object):
 
         >>> rddA = sc.parallelize(range(10), 4)
         >>> rddB = rddA.map(lambda a: str(a))
-        >>> import itertools
-        >>> def f(index, iterA, iterB): return itertools.izip(iterA, iterB)
+        >>> def f(index, iterA, iterB): return ((a, iterB.next()) for a in iterA)
         >>> zippedRDD = rddA.zipPartitionsWithIndex(rddB, f)
         >>> result = zippedRDD.collect()
 

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -341,7 +341,7 @@ class RDD(object):
 
         >>> rddA = sc.parallelize(range(10), 4)
         >>> rddB = rddA.map(lambda a: str(a))
-        >>> def f(iterA, iterB): return ((a, iterB.next()) for a in iterA)
+        >>> def f(iterA, iterB): return ((a, next(iterB)) for a in iterA)
         >>> zippedRDD = rddA.zipPartitions(rddB, f)
         >>> result = zippedRDD.collect()
 
@@ -363,7 +363,7 @@ class RDD(object):
 
         >>> rddA = sc.parallelize(range(10), 4)
         >>> rddB = rddA.map(lambda a: str(a))
-        >>> def f(index, iterA, iterB): return ((a, iterB.next()) for a in iterA)
+        >>> def f(index, iterA, iterB): return ((a, next(iterB)) for a in iterA)
         >>> zippedRDD = rddA.zipPartitionsWithIndex(rddB, f)
         >>> result = zippedRDD.collect()
 

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -329,6 +329,49 @@ class RDD(object):
         """
         return PipelinedRDD(self, f, preservesPartitioning)
 
+    def zipPartitions(self, other, f, preservesPartitioning=False):
+        """
+        Return a new RDD by zipping the partitions of this and the other RDD,
+        and then applying the user defined function.
+
+        The user defined function f takes two iterators one for this and the
+        other RDD respectively and returns a new iterator.
+
+        Note both RDDs must have the same number of partitions.
+
+        >>> rddA = sc.parallelize(range(10), 4)
+        >>> rddB = rddA.map(lambda a: str(a))
+        >>> import itertools
+        >>> def f(iterA, iterB): return itertools.izip(iterA, iterB)
+        >>> zippedRDD = rddA.zipPartitions(rddB, f)
+        >>> result = zippedRDD.collect()
+
+        """
+        def func(ind, iter1, iter2):
+            return f(iter1, iter2)
+        return ZippedRDD(self, other, func, preservesPartitioning)
+
+    def zipPartitionsWithIndex(self, other, f, preservesPartitioning=False):
+        """
+        Return a new RDD by zipping the partitions of this and the other RDD,
+        and then applying the user defined function.
+
+        The user defined function f takes the partition index as well as
+        two iterators one for this and the other RDD respectively and
+        returns a new iterator.
+
+        Note both RDDs must have the same number of partitions.
+
+        >>> rddA = sc.parallelize(range(10), 4)
+        >>> rddB = rddA.map(lambda a: str(a))
+        >>> import itertools
+        >>> def f(index, iterA, iterB): return itertools.izip(iterA, iterB)
+        >>> zippedRDD = rddA.zipPartitionsWithIndex(rddB, f)
+        >>> result = zippedRDD.collect()
+
+        """
+        return ZippedRDD(self, other, f, preservesPartitioning)
+
     def mapPartitionsWithSplit(self, f, preservesPartitioning=False):
         """
         Deprecated: use mapPartitionsWithIndex instead.
@@ -2374,7 +2417,7 @@ class PipelinedRDD(RDD):
         else:
             profiler = None
 
-        command = (self.func, profiler, self._prev_jrdd_deserializer,
+        command = (self.func, profiler, [self._prev_jrdd_deserializer],
                    self._jrdd_deserializer)
         pickled_cmd, bvars, env, includes = _prepare_for_python_RDD(self.ctx, command, self)
         python_rdd = self.ctx._jvm.PythonRDD(self._prev_jrdd.rdd(),
@@ -2396,6 +2439,58 @@ class PipelinedRDD(RDD):
 
     def _is_pipelinable(self):
         return not (self.is_cached or self.is_checkpointed)
+
+
+class ZippedRDD(RDD):
+
+    def __init__(self, prev1, prev2, func, preservesPartitioning=False):
+        self.func = func
+        self.preservesPartitioning = preservesPartitioning
+        self._prevs = [prev1, prev2]
+        self._prev_jrdds = [p._jrdd for p in self._prevs]
+        self._prev_jrdd_deserializers = [p._jrdd_deserializer for p in self._prevs]
+        self.is_cached = False
+        self.is_checkpointed = False
+        self.ctx = prev1.ctx
+        assert prev1.ctx == prev2.ctx
+        self._jrdd_val = None
+        self._id = None
+        self._jrdd_deserializer = self.ctx.serializer
+        self._bypass_serializer = False
+        self.partitioner = prev.partitioner if self.preservesPartitioning else None
+
+    def getNumPartitions(self):
+        return self._prev_jrdds[0].partitions().size()
+
+    @property
+    def _jrdd(self):
+        if self._jrdd_val:
+            return self._jrdd_val
+        if self.ctx.profiler_collector:
+            profiler = self.ctx.profiler_collector.new_profiler(self.ctx)
+        else:
+            profiler = None
+
+        command = (self.func, profiler, self._prev_jrdd_deserializers,
+                   self._jrdd_deserializer)
+        pickled_cmd, bvars, env, includes = _prepare_for_python_RDD(self.ctx, command, self)
+        python_rdd = self.ctx._jvm.PythonZippedRDD(self._prev_jrdds[0].rdd(),
+                                                   self._prev_jrdds[1].rdd(),
+                                                   bytearray(pickled_cmd),
+                                                   env, includes, self.preservesPartitioning,
+                                                   self.ctx.pythonExec, self.ctx.pythonVer,
+                                                   bvars, self.ctx._javaAccumulator)
+        self._jrdd_val = python_rdd.asJavaRDD()
+
+        if profiler:
+            self._id = self._jrdd_val.id()
+            self.ctx.profiler_collector.add_profiler(self._id, profiler)
+        return self._jrdd_val
+
+    def id(self):
+        if self._id is None:
+            self._id = self._jrdd.id()
+        return self._id
 
 
 def _test():

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -137,8 +137,11 @@ def main(infile, infile2, outfile):
     for (aid, accum) in _accumulatorRegistry.items():
         pickleSer._write_with_length((aid, accum._value), outfile)
 
-    # check end of stream
-    if read_int(infile) == SpecialLengths.END_OF_STREAM:
+    # check end of stream(s)
+    end_of_infile = read_int(infile) == SpecialLengths.END_OF_STREAM
+    if (len(deserializers) == 1 and end_of_infile) or \
+        (len(deserializers) == 2 and end_of_infile and
+            read_int(infile2) == SpecialLengths.END_OF_STREAM):
         write_int(SpecialLengths.END_OF_STREAM, outfile)
     else:
         # write a different value to tell JVM to not reuse this worker

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python.scala
@@ -395,7 +395,7 @@ case class BatchPythonEvaluation(udf: PythonUDF, output: Seq[Attribute], child: 
         udf.accumulator,
         bufferSize,
         reuseWorker
-      ).compute(inputIterator, context.partitionId(), context)
+      ).compute(inputIterator, inputIterator2 = null, context.partitionId(), context)
 
       val unpickle = new Unpickler
       val row = new GenericMutableRow(1)


### PR DESCRIPTION
The following adds support for `zipPartitions` to PySpark.  This is accomplished by modifying the PySpark `worker` (in both daemon and non-deamon mode) to open a second socket back to the Spark process.  The second socket is used to send tuple from the second iterator in `zipPartitions` enabling the user defined function to pull tuples from both iterators at different rates without requiring a back-and-forth protocol over the primary socket.  The single socket protocol design was considered but creates issues with the built-in serializers and would require much larger changes.  The second socket is always created at the launch of the worker process and is simply ignored if it is not needed.  
