### PR TITLE
[SPARK-12602] [SQL] Join Reordering: Pushing Inner Join Through Left/Right Outer Join

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -45,7 +45,7 @@ abstract class Optimizer extends RuleExecutor[LogicalPlan] {
       SetOperationPushDown,
       SamplePushDown,
       ReorderInnerJoin,
-      ReorderOuterInner,
+      ReorderOuterInnerJoins,
       PushPredicateThroughJoin,
       PushPredicateThroughProject,
       PushPredicateThroughGenerate,
@@ -771,11 +771,11 @@ object ReorderInnerJoin extends Rule[LogicalPlan] with PredicateHelper {
 
 
 /**
- * Reorder the adjacent outer and inner joins and push inner join below left/right outer join.
+ * Reorder the adjacent outer and inner joins and push inner join through left/right outer join.
  *
  * TODO: improve the checking conditions to cover out-of-order cases.
  */
-object ReorderOuterInner extends Rule[LogicalPlan] {
+object ReorderOuterInnerJoins extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan transform {
 
     case j @ Join(left @ Join(ll, lr, joinType, lCondition), right, Inner, condition) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -778,7 +778,7 @@ object ReorderInnerJoin extends Rule[LogicalPlan] with PredicateHelper {
 object ReorderOuterInnerJoins extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan transform {
 
-    case j @ Join(left @ Join(ll, lr, joinType, lCondition), right, Inner, condition) =>
+    case j @ Join(left @ Join(ll, lr, LeftOuter|RightOuter, lCond), right, Inner, condition) =>
       val leftJoinKey = j match {
         case ExtractEquiJoinKeys(_, leftKeys, _, _, _, _) => leftKeys
       }
@@ -787,15 +787,15 @@ object ReorderOuterInnerJoins extends Rule[LogicalPlan] {
           (leftKeys, rightKeys)
       }
 
-      joinType match {
+      left.joinType match {
         case LeftOuter if leftJoinKey == leftLeftJoinKey =>
-          Join(Join(ll, right, Inner, condition), lr, LeftOuter, lCondition)
+          Join(Join(ll, right, Inner, condition), lr, LeftOuter, lCond)
         case RightOuter if leftJoinKey == leftRightJoinKey =>
-          Join(ll, Join(lr, right, Inner, condition), RightOuter, lCondition)
+          Join(ll, Join(lr, right, Inner, condition), RightOuter, lCond)
         case _ => j
       }
 
-    case j @ Join(left, right @ Join(rl, rr, joinType, rCondition), Inner, condition) =>
+    case j @ Join(left, right @ Join(rl, rr, LeftOuter|RightOuter, rCond), Inner, condition) =>
       val rightJoinKey = j match {
         case ExtractEquiJoinKeys(_, _, rightKey, _, _, _) => rightKey
       }
@@ -804,11 +804,11 @@ object ReorderOuterInnerJoins extends Rule[LogicalPlan] {
           (leftKeys, rightKeys)
       }
 
-      joinType match {
+      right.joinType match {
         case LeftOuter if rightJoinKey == rightLeftJoinKey =>
-          Join(Join(rl, left, Inner, condition), rr, LeftOuter, rCondition)
+          Join(Join(rl, left, Inner, condition), rr, LeftOuter, rCond)
         case RightOuter if rightJoinKey == rightRightJoinKey =>
-          Join(rl, Join(left, rr, Inner, condition), RightOuter, rCondition)
+          Join(rl, Join(left, rr, Inner, condition), RightOuter, rCond)
         case _ => j
       }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinOrderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinOrderSuite.scala
@@ -143,8 +143,8 @@ class JoinOrderSuite extends PlanTest {
 
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer =
-      y.join(x.join(z, Inner, Some("z.c".attr === "x.c".attr)),
-        RightOuter, Some("x.a".attr === "y.a".attr)).analyze
+      x.join(z, Inner, Some("z.c".attr === "x.c".attr))
+        .join(y, LeftOuter, Some("x.a".attr === "y.a".attr)).analyze
 
     comparePlans(optimized, analysis.EliminateSubQueries(correctAnswer))
   }
@@ -161,8 +161,8 @@ class JoinOrderSuite extends PlanTest {
 
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer =
-      x.join(z.join(y, Inner, Some("z.c".attr === "y.c".attr)),
-        RightOuter, Some("x.b".attr === "y.b".attr)).analyze
+      z.join(y, Inner, Some("z.c".attr === "y.c".attr))
+        .join(x, LeftOuter, Some("x.b".attr === "y.b".attr)).analyze
 
     comparePlans(optimized, analysis.EliminateSubQueries(correctAnswer))
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinOrderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinOrderSuite.scala
@@ -38,13 +38,12 @@ class JoinOrderSuite extends PlanTest {
         CombineFilters,
         PushPredicateThroughProject,
         BooleanSimplification,
-        ReorderJoin,
+        ReorderInnerJoin,
         PushPredicateThroughJoin,
         PushPredicateThroughGenerate,
         PushPredicateThroughAggregate,
         ColumnPruning,
         ProjectCollapsing) :: Nil
-
   }
 
   val testRelation = LocalRelation('a.int, 'b.int, 'c.int)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
@@ -147,11 +147,11 @@ class DataFrameJoinSuite extends QueryTest with SharedSQLContext {
 
   test("join - left outer + inner reordering # 2") {
     val df = Seq((1, 2, "1"), (3, 4, "3")).toDF("int", "int2", "str").as("a")
-    val df2 = Seq((1, 3, "1"), (5, 6, "5")).toDF("int", "int2", "str").as("b")
+    val df2 = Seq((1, 2, "1"), (5, 6, "5")).toDF("int", "int2", "str").as("b")
     val df3 = Seq((1, 3, "1"), (3, 6, "5")).toDF("int", "int2", "str").as("c")
 
     // Left Then Inner -> Inner Then Left
-    val right = df.join(df2, $"a.int" === $"b.int", "left")
+    val right = df.join(df2, $"a.int" === $"b.int" && $"a.int2" === $"b.int2", "left")
     val leftInnerJoin = df3.join(right, $"c.int" === $"a.int", "inner")
       .select($"a.*", $"b.*", $"c.*")
 
@@ -167,7 +167,7 @@ class DataFrameJoinSuite extends QueryTest with SharedSQLContext {
 
     checkAnswer(
       leftInnerJoin,
-      Row(1, 2, "1", 1, 3, "1", 1, 3, "1") ::
+      Row(1, 2, "1", 1, 2, "1", 1, 3, "1") ::
       Row(3, 4, "3", null, null, null, 3, 6, "5") :: Nil)
   }
 
@@ -195,12 +195,12 @@ class DataFrameJoinSuite extends QueryTest with SharedSQLContext {
   }
 
   test("join - right outer + inner reordering #2") {
-    val df = Seq((1, 2, "1"), (3, 4, "3")).toDF("int", "int2", "str").as("a")
-    val df2 = Seq((1, 3, "1"), (5, 6, "5")).toDF("int", "int2", "str").as("b")
+    val df = Seq((0, 2, "1"), (3, 4, "3")).toDF("int", "int2", "str").as("a")
+    val df2 = Seq((1, 2, "1"), (5, 6, "5")).toDF("int", "int2", "str").as("b")
     val df3 = Seq((1, 9, "8"), (5, 0, "4")).toDF("int", "int2", "str").as("c")
 
     // Right Then Inner -> Inner Then Right
-    val right = df.join(df2, $"a.int" === $"b.int", "right")
+    val right = df.join(df2, $"a.int2" === $"b.int2", "right")
     val rightInnerJoin = df3.join(right, $"c.int" === $"b.int", "inner")
       .select($"a.*", $"b.*", $"c.*")
 
@@ -214,7 +214,7 @@ class DataFrameJoinSuite extends QueryTest with SharedSQLContext {
 
     checkAnswer(
       rightInnerJoin,
-      Row(1, 2, "1", 1, 3, "1", 1, 9, "8") ::
+      Row(0, 2, "1", 1, 2, "1", 1, 9, "8") ::
       Row(null, null, null, 5, 6, "5", 5, 0, "4") :: Nil)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
@@ -184,9 +184,9 @@ class DataFrameJoinSuite extends QueryTest with SharedSQLContext {
     assert(rightInnerJoin.queryExecution.analyzed.collect {
       case j @ Join(Join(_, _, RightOuter, _), _, Inner, _) => j }.size === 1)
 
-    // The order after reordering: Inner Then Right
+    // The order after reordering: Inner Then Left
     assert(rightInnerJoin.queryExecution.optimizedPlan.collect {
-      case j @ Join(_, Join(_, _, Inner, _), RightOuter, _) => j }.size === 1)
+      case j @ Join(Join(_, _, Inner, _), _, LeftOuter, _) => j }.size === 1)
 
     checkAnswer(
       rightInnerJoin,
@@ -208,9 +208,9 @@ class DataFrameJoinSuite extends QueryTest with SharedSQLContext {
     assert(rightInnerJoin.queryExecution.analyzed.collect {
       case j @ Join(_, Join(_, _, RightOuter, _), Inner, _) => j }.size === 1)
 
-    // The order after reordering: Inner Then Right
+    // The order after reordering: Inner Then Left
     assert(rightInnerJoin.queryExecution.optimizedPlan.collect {
-      case j @ Join(_, Join(_, _, Inner, _), RightOuter, _) => j }.size === 1)
+      case j @ Join(Join(_, _, Inner, _), _, LeftOuter, _) => j }.size === 1)
 
     checkAnswer(
       rightInnerJoin,


### PR DESCRIPTION
This PR is to push `Inner Join` through `Left/Right Outer Join`.

The basic idea is built on the associativity property of outer and inner joins:
- `R1 inner (R2 left R3 on p23) on p12 = (R1 inner R2 on p12) left R3 on p23`
- `R1 inner (R2 right R3 on p23) on p13 = R2 right (R1 inner R3 on p13) on p23 = (R1 inner R3 on p13) left R2 on p23`
- `(R1 left R2 on p12) inner R3 on p13 = (R1 inner R3 on p13) left R2 on p12`
- `(R1 right R2 on p12) inner R3 on p23 = R1 right (R2 inner R3 on p23) on p12 = (R2 inner R3 on p23) left R1 on p12`

In this PR, the reordering can reduce the number of processed rows since the `Inner Join` always can generate less (or equivalent) rows than `Left/Right Outer Join`. The join predicates of `Left/Right Outer Join` will not affect the number of returned rows. This PR can improve the query performance in most cases, especially when the join predicates of `Inner Join` are highly selective. 

When cost-based optimization is available, we can switch the order of tables in each join type based on their costs. The order of joined tables in the inner join does not affect the results and the right outer join can be changed to the left outer join. This part is out of scope here. 

For example, given the following eligible query:
`df.join(df2, $"a.int" === $"b.int", "right").join(df3, $"c.int" === $"b.int", "inner")`

Before the fix, the logical plan is like

```
Join Inner, Some((int#15 = int#9))
:- Join RightOuter, Some((int#3 = int#9))
:  :- LocalRelation [int#3,int2#4,str#5], [[1,2,1],[3,4,3]]
:  +- LocalRelation [int#9,int2#10,str#11], [[1,3,1],[5,6,5]]
+- LocalRelation [int#15,int2#16,str#17], [[1,9,8],[5,0,4]]
```

After the fix, the logical plan is like

```
Join LeftOuter, Some((int#3 = int#9))
:- Join Inner, Some((int#15 = int#9))
:  :- LocalRelation [int#9,int2#10,str#11], [[1,3,1],[5,6,5]]
:  +- LocalRelation [int#15,int2#16,str#17], [[1,9,8],[5,0,4]]
+- LocalRelation [int#3,int2#4,str#5], [[1,2,1],[3,4,3]]
```
