### PR TITLE
[SPARK-12421][SQL] Prevent Internal/External row from exposing state.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/rows.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/rows.scala
@@ -199,9 +199,9 @@ class GenericRow(protected[sql] val values: Array[Any]) extends Row {
 
   override def get(i: Int): Any = values(i)
 
-  override def toSeq: Seq[Any] = values.toSeq
+  override def toSeq: Seq[Any] = values.clone()
 
-  override def copy(): Row = this
+  override def copy(): GenericRow = this
 }
 
 class GenericRowWithSchema(values: Array[Any], override val schema: StructType)
@@ -226,11 +226,11 @@ class GenericInternalRow(private[sql] val values: Array[Any]) extends BaseGeneri
 
   override protected def genericGet(ordinal: Int) = values(ordinal)
 
-  override def toSeq(fieldTypes: Seq[DataType]): Seq[Any] = values
+  override def toSeq(fieldTypes: Seq[DataType]): Seq[Any] = values.clone()
 
   override def numFields: Int = values.length
 
-  override def copy(): InternalRow = new GenericInternalRow(values.clone())
+  override def copy(): GenericInternalRow = this
 }
 
 /**

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/RowTest.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/RowTest.scala
@@ -104,4 +104,34 @@ class RowTest extends FunSpec with Matchers {
       internalRow shouldEqual internalRow2
     }
   }
+
+  describe("row immutability") {
+    val values = Array(1, 2, "3", "IV", 6L)
+    val externalRow = Row(values.clone(): _*)
+    val internalRow = InternalRow(values.clone(): _*)
+
+    def modifyValues(values: Seq[Any]): Seq[Any] = {
+      val array = values.toArray
+      array(2) = "42"
+      array
+    }
+
+    it("copy should return same ref for external rows") {
+      externalRow should be theSameInstanceAs externalRow.copy()
+    }
+
+    it("copy should return same ref for interal rows") {
+      internalRow should be theSameInstanceAs internalRow.copy()
+    }
+
+    it("toSeq should not expose internal state for external rows") {
+      val modifiedValues = modifyValues(externalRow.toSeq)
+      externalRow.toSeq should not equal modifiedValues
+    }
+
+    it("toSeq should not expose internal state for internal rows") {
+      val modifiedValues = modifyValues(internalRow.toSeq(Seq.empty))
+      internalRow.toSeq(Seq.empty) should not equal modifiedValues
+    }
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/RowTest.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/RowTest.scala
@@ -107,7 +107,7 @@ class RowTest extends FunSpec with Matchers {
 
   describe("row immutability") {
     val values = Seq(1, 2, "3", "IV", 6L)
-    val externalRow = Row(values)
+    val externalRow = Row.fromSeq(values)
     val internalRow = InternalRow.fromSeq(values)
 
     def modifyValues(values: Seq[Any]): Seq[Any] = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/RowTest.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/RowTest.scala
@@ -106,9 +106,9 @@ class RowTest extends FunSpec with Matchers {
   }
 
   describe("row immutability") {
-    val values = Array(1, 2, "3", "IV", 6L)
-    val externalRow = Row(values.clone(): _*)
-    val internalRow = InternalRow(values.clone(): _*)
+    val values = Seq(1, 2, "3", "IV", 6L)
+    val externalRow = Row(values)
+    val internalRow = InternalRow.fromSeq(values)
 
     def modifyValues(values: Seq[Any]): Seq[Any] = {
       val array = values.toArray


### PR DESCRIPTION
It is currently possible to change the values of the supposedly immutable `GenericRow` and `GenericInternalRow` classes. This is caused by the fact that scala's ArrayOps `toArray` (returned by calling `toSeq`) will return the backing array instead of a copy. This PR fixes this problem.

This PR was inspired by https://github.com/apache/spark/pull/10374 by @apo1.

cc @apo1 @sarutak @marmbrus @cloud-fan @nongli (everyone in the previous conversation).
