### PR TITLE
[SPARK-12643][Build] Set lib directory for antlr

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -443,6 +443,7 @@ object Hive {
         val relGFilePath = (gFilePath relativeTo sourceDir).get.getPath
         log.info("ANTLR: Grammar file '%s' detected.".format(relGFilePath))
         antlr.addGrammarFile(relGFilePath)
+        antlr.setLibDirectory(gFilePath.getParent)
       }
 
       // Generate the parser.

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -443,6 +443,9 @@ object Hive {
         val relGFilePath = (gFilePath relativeTo sourceDir).get.getPath
         log.info("ANTLR: Grammar file '%s' detected.".format(relGFilePath))
         antlr.addGrammarFile(relGFilePath)
+        // We will set library directory multiple times here. However, only the
+        // last one has effect. Because the grammar files are located under the same directory,
+        // We assume there is only one library directory.
         antlr.setLibDirectory(gFilePath.getParent)
       }
 


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-12643

Without setting lib directory for antlr, the updates of imported grammar files can not be detected. So SparkSqlParser.g will not be rebuilt automatically.

Since it is a minor update, no JIRA ticket is opened. Let me know if it is needed. Thanks.
