### PR TITLE
[SPARKR][DOC] minor doc update for version in migration guide

### DIFF
--- a/docs/sparkr.md
+++ b/docs/sparkr.md
@@ -385,12 +385,12 @@ The following functions are masked by the SparkR package:
 </table>
 
 Since part of SparkR is modeled on the `dplyr` package, certain functions in SparkR share the same names with those in `dplyr`. Depending on the load order of the two packages, some functions from the package loaded first are masked by those in the package loaded after. In such case, prefix such calls with the package name, for instance, `SparkR::cume_dist(x)` or `dplyr::cume_dist(x)`.
-  
+
 You can inspect the search path in R with [`search()`](https://stat.ethz.ch/R-manual/R-devel/library/base/html/search.html)
 
 
 # Migration Guide
 
-## Upgrading From SparkR 1.6 to 1.7
+## Upgrading From SparkR 1.5.x to 1.6
 
- - Until Spark 1.6, the default mode for writes was `append`. It was changed in Spark 1.7 to `error` to match the Scala API.
+ - Before Spark 1.6, the default mode for writes was `append`. It was changed in Spark 1.6.0 to `error` to match the Scala API.


### PR DESCRIPTION
checked that the change is in Spark 1.6.0.
@shivaram 
