### PR TITLE
[SPARK-12625][SPARKR][SQL] replace R usage of Spark SQL deprecated API

### DIFF
--- a/R/pkg/R/SQLContext.R
+++ b/R/pkg/R/SQLContext.R
@@ -256,9 +256,11 @@ jsonFile <- function(sqlContext, path) {
 
 # TODO: support schema
 jsonRDD <- function(sqlContext, rdd, schema = NULL, samplingRatio = 1.0) {
+  .Deprecated("read.json")
   rdd <- serializeToString(rdd)
   if (is.null(schema)) {
-    sdf <- callJMethod(sqlContext, "jsonRDD", callJMethod(getJRDD(rdd), "rdd"), samplingRatio)
+    read <- callJMethod(sqlContext, "read")
+    sdf <- callJMethod(read, "json", callJMethod(getJRDD(rdd), "rdd"), samplingRatio)
     dataFrame(sdf)
   } else {
     stop("not implemented")

--- a/R/pkg/R/SQLContext.R
+++ b/R/pkg/R/SQLContext.R
@@ -260,7 +260,8 @@ jsonRDD <- function(sqlContext, rdd, schema = NULL, samplingRatio = 1.0) {
   rdd <- serializeToString(rdd)
   if (is.null(schema)) {
     read <- callJMethod(sqlContext, "read")
-    sdf <- callJMethod(read, "json", callJMethod(getJRDD(rdd), "rdd"), samplingRatio)
+    # samplingRatio is deprecated
+    sdf <- callJMethod(read, "json", callJMethod(getJRDD(rdd), "rdd"))
     dataFrame(sdf)
   } else {
     stop("not implemented")
@@ -291,10 +292,7 @@ read.parquet <- function(sqlContext, path) {
 # TODO: Implement saveasParquetFile and write examples for both
 parquetFile <- function(sqlContext, ...) {
   .Deprecated("read.parquet")
-  # Allow the user to have a more flexible definiton of the text file path
-  paths <- lapply(list(...), function(x) suppressWarnings(normalizePath(x)))
-  sdf <- callJMethod(sqlContext, "parquetFile", paths)
-  dataFrame(sdf)
+  read.parquet(sqlContext, unlist(list(...)))
 }
 
 #' SQL Query

--- a/R/pkg/R/column.R
+++ b/R/pkg/R/column.R
@@ -209,7 +209,7 @@ setMethod("cast",
 setMethod("%in%",
           signature(x = "Column"),
           function(x, table) {
-            jc <- callJMethod(x@jc, "in", as.list(table))
+            jc <- callJMethod(x@jc, "isin", as.list(table))
             return(column(jc))
           })
 

--- a/R/pkg/R/utils.R
+++ b/R/pkg/R/utils.R
@@ -641,3 +641,12 @@ assignNewEnv <- function(data) {
 splitString <- function(input) {
   Filter(nzchar, unlist(strsplit(input, ",|\\s")))
 }
+
+convertToJSaveMode <- function(mode) {
+ allModes <- c("append", "overwrite", "error", "ignore")
+ if (!(mode %in% allModes)) {
+   stop('mode should be one of "append", "overwrite", "error", "ignore"')  # nolint
+ }
+ jmode <- callJStatic("org.apache.spark.sql.api.r.SQLUtils", "saveMode", mode)
+ jmode
+}

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -420,6 +420,18 @@ test_that("read/write json files", {
   unlink(jsonPath3)
 })
 
+test_that("jsonRDD() on a RDD with json string", {
+  rdd <- parallelize(sc, mockLines)
+  expect_equal(count(rdd), 3)
+  df <- suppressWarnings(jsonRDD(sqlContext, rdd))
+  expect_is(df, "DataFrame")
+  expect_equal(count(df), 3)
+
+  rdd2 <- flatMap(rdd, function(x) c(x, x))
+  df <- suppressWarnings(jsonRDD(sqlContext, rdd2))
+  expect_is(df, "DataFrame")
+  expect_equal(count(df), 6)
+})
 
 test_that("test cache, uncache and clearCache", {
   df <- read.json(sqlContext, jsonPath)

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -420,18 +420,19 @@ test_that("read/write json files", {
   unlink(jsonPath3)
 })
 
-test_that("jsonRDD() on a RDD with json string", {
-  rdd <- parallelize(sc, mockLines)
-  expect_equal(count(rdd), 3)
-  df <- jsonRDD(sqlContext, rdd)
-  expect_is(df, "DataFrame")
-  expect_equal(count(df), 3)
-
-  rdd2 <- flatMap(rdd, function(x) c(x, x))
-  df <- jsonRDD(sqlContext, rdd2)
-  expect_is(df, "DataFrame")
-  expect_equal(count(df), 6)
-})
+# test_that("jsonRDD() on a RDD with json string", {
+#   rdd <- parallelize(sc, mockLines)
+#   expect_equal(count(rdd), 3)
+#   # Suppress warnings because jsonRDD is deprecated
+#   df <- suppressWarnings(jsonRDD(sqlContext, rdd))
+#   expect_is(df, "DataFrame")
+#   expect_equal(count(df), 3)
+#
+#   rdd2 <- flatMap(rdd, function(x) c(x, x))
+#   df <- suppressWarnings(jsonRDD(sqlContext, rdd2))
+#   expect_is(df, "DataFrame")
+#   expect_equal(count(df), 6)
+# })
 
 test_that("test cache, uncache and clearCache", {
   df <- read.json(sqlContext, jsonPath)

--- a/R/pkg/inst/tests/testthat/test_sparkSQL.R
+++ b/R/pkg/inst/tests/testthat/test_sparkSQL.R
@@ -420,19 +420,6 @@ test_that("read/write json files", {
   unlink(jsonPath3)
 })
 
-# test_that("jsonRDD() on a RDD with json string", {
-#   rdd <- parallelize(sc, mockLines)
-#   expect_equal(count(rdd), 3)
-#   # Suppress warnings because jsonRDD is deprecated
-#   df <- suppressWarnings(jsonRDD(sqlContext, rdd))
-#   expect_is(df, "DataFrame")
-#   expect_equal(count(df), 3)
-#
-#   rdd2 <- flatMap(rdd, function(x) c(x, x))
-#   df <- suppressWarnings(jsonRDD(sqlContext, rdd2))
-#   expect_is(df, "DataFrame")
-#   expect_equal(count(df), 6)
-# })
 
 test_that("test cache, uncache and clearCache", {
   df <- read.json(sqlContext, jsonPath)

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -425,13 +425,12 @@ def run_build_tests():
 
 
 def run_sparkr_tests():
-    # set_title_and_block("Running SparkR tests", "BLOCK_SPARKR_UNIT_TESTS")
+    set_title_and_block("Running SparkR tests", "BLOCK_SPARKR_UNIT_TESTS")
 
-    # if which("R"):
-    #     run_cmd([os.path.join(SPARK_HOME, "R", "run-tests.sh")])
-    # else:
-    #     print("Ignoring SparkR tests as R was not found in PATH")
-    pass
+    if which("R"):
+        run_cmd([os.path.join(SPARK_HOME, "R", "run-tests.sh")])
+    else:
+        print("Ignoring SparkR tests as R was not found in PATH")
 
 
 def parse_opts():


### PR DESCRIPTION
@rxin @davies @shivaram 
Took save mode from my PR #10480, and move everything to writer methods. This is related to PR #10559
- [x] it seems jsonRDD() is broken, need to investigate - this is not a public API though; will look into some more tonight. (fixed)
