### PR TITLE
SPARK-12637 Print stage info of finished stages properly

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala
@@ -266,7 +266,7 @@ class StatsReportListener extends SparkListener with Logging {
 
   override def onStageCompleted(stageCompleted: SparkListenerStageCompleted) {
     implicit val sc = stageCompleted
-    this.logInfo("Finished stage: " + stageCompleted.stageInfo)
+    this.logInfo("Finished stage: " + getStatusDetail(stageCompleted.stageInfo))
     showMillisDistribution("task runtime:", (info, _) => Some(info.duration), taskInfoMetrics)
 
     // Shuffle write
@@ -293,6 +293,15 @@ class StatsReportListener extends SparkListener with Logging {
     taskInfoMetrics.clear()
   }
 
+  private[spark] def getStatusDetail(stageInfo: StageInfo): String = {
+    "Stage(%d, %d); Name: \"%s\"; Status: %s%s; numTasks: %d; Took: %s msec".format(
+      stageInfo.stageId, stageInfo.attemptId, stageInfo.name, stageInfo.getStatusString,
+      stageInfo.failureReason.map(x => "(" + x + ")").getOrElse(""),
+      stageInfo.numTasks,
+      stageInfo.submissionTime.map(
+        x => stageInfo.completionTime.getOrElse(System.currentTimeMillis()) - x).getOrElse("-")
+    )
+  }
 }
 
 private[spark] object StatsReportListener extends Logging {


### PR DESCRIPTION
Currently it prints hashcode of stage info, which seemed not that useful.

```
INFO scheduler.StatsReportListener: Finished stage: org.apache.spark.scheduler.StageInfo@2eb47d79
```
