### PR TITLE
[SPARK-12638] [API DOC] Parameter explanation not very accurate for rdd function "aggregate"

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1071,6 +1071,13 @@ abstract class RDD[T: ClassTag](
    * apply the fold to each element sequentially in some defined ordering. For functions
    * that are not commutative, the result may differ from that of a fold applied to a
    * non-distributed collection.
+   *
+   * @param zeroValue the initial value for the accumulated result of each partition for the op operator,
+   *                  and also the initial value for the combine results from different partitions for the op,
+   *                  operator also - this will typically be the neutral element.
+   *                  (e.g. Nil for list concatenation or 0 for summation)
+   * @param op an operator used to both accumulate results within a partition and combine results
+   *                  from different partitions.
    */
   def fold(zeroValue: T)(op: (T, T) => T): T = withScope {
     // Clone the zero value since we will also be serializing it as part of tasks
@@ -1090,12 +1097,12 @@ abstract class RDD[T: ClassTag](
    * allowed to modify and return their first argument instead of creating a new U to avoid memory
    * allocation.
    * 
-   * @param zeroValue the initial value for the accumulated result of each partition for the seqOp operator, 
-   *                  and also the initial value for the combine results from different partitions for the 
-   *                  conbOp operator,  - this will typically be the neutral element  
+   * @param zeroValue the initial value for the accumulated result of each partition for the seqOp operator,
+   *                  and also the initial value for the combine results from different partitions for the
+   *                  conbOp operator,  - this will typically be the neutral element.
    *                  (e.g. Nil for list concatenation or 0 for summation)
    * @param seqOp an operator used to accumulate results within a partition
-   * @param combOp an associative operator used to combine results from different partitions   
+   * @param combOp an associative operator used to combine results from different partitions
    */
   def aggregate[U: ClassTag](zeroValue: U)(seqOp: (U, T) => U, combOp: (U, U) => U): U = withScope {
     // Clone the zero value since we will also be serializing it as part of tasks

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1073,8 +1073,8 @@ abstract class RDD[T: ClassTag](
    * non-distributed collection.
    *
    * @param zeroValue the initial value for the accumulated result of each partition for the op operator,
-   *                  and also the initial value for the combine results from different partitions for the op,
-   *                  operator also - this will typically be the neutral element.
+   *                  and also the initial value for the combine results from different partitions for the op
+   *                  operator also, - this will typically be the neutral element.
    *                  (e.g. Nil for list concatenation or 0 for summation)
    * @param op an operator used to both accumulate results within a partition and combine results
    *                  from different partitions.

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1072,9 +1072,10 @@ abstract class RDD[T: ClassTag](
    * that are not commutative, the result may differ from that of a fold applied to a
    * non-distributed collection.
    *
-   * @param zeroValue the initial value for the accumulated result of each partition for the op operator,
-   *                  and also the initial value for the combine results from different partitions for the op
-   *                  operator also, - this will typically be the neutral element.
+   * @param zeroValue the initial value for the accumulated result of each partition for the op
+   *                  operator, and also the initial value for the combine results from different
+   *                  partitions for the op operator also. 
+   *                  - this will typically be the neutral element.
    *                  (e.g. Nil for list concatenation or 0 for summation)
    * @param op an operator used to both accumulate results within a partition and combine results
    *                  from different partitions.
@@ -1097,9 +1098,10 @@ abstract class RDD[T: ClassTag](
    * allowed to modify and return their first argument instead of creating a new U to avoid memory
    * allocation.
    * 
-   * @param zeroValue the initial value for the accumulated result of each partition for the seqOp operator,
-   *                  and also the initial value for the combine results from different partitions for the
-   *                  conbOp operator,  - this will typically be the neutral element.
+   * @param zeroValue the initial value for the accumulated result of each partition for the seqOp
+   *                  operator, and also the initial value for the combine results from different
+   *                  partitions for the conbOp operator,  
+   *                  - this will typically be the neutral element.
    *                  (e.g. Nil for list concatenation or 0 for summation)
    * @param seqOp an operator used to accumulate results within a partition
    * @param combOp an associative operator used to combine results from different partitions

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1089,6 +1089,13 @@ abstract class RDD[T: ClassTag](
    * and one operation for merging two U's, as in scala.TraversableOnce. Both of these functions are
    * allowed to modify and return their first argument instead of creating a new U to avoid memory
    * allocation.
+   * 
+   * @param zeroValue the initial value for the accumulated result of each partition for the seqOp operator, 
+   *                  and also the initial value for the combine results from different partitions for the 
+   *                  conbOp operator,  - this will typically be the neutral element  
+   *                  (e.g. Nil for list concatenation or 0 for summation)
+   * @param seqOp an operator used to accumulate results within a partition
+   * @param combOp an associative operator used to combine results from different partitions   
    */
   def aggregate[U: ClassTag](zeroValue: U)(seqOp: (U, T) => U, combOp: (U, U) => U): U = withScope {
     // Clone the zero value since we will also be serializing it as part of tasks

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1074,7 +1074,7 @@ abstract class RDD[T: ClassTag](
    *
    * @param zeroValue the initial value for the accumulated result of each partition for the op
    *                  operator, and also the initial value for the combine results from different
-   *                  partitions for the op operator also. 
+   *                  partitions for the op operator also.
    *                  - this will typically be the neutral element.
    *                  (e.g. Nil for list concatenation or 0 for summation)
    * @param op an operator used to both accumulate results within a partition and combine results
@@ -1097,10 +1097,10 @@ abstract class RDD[T: ClassTag](
    * and one operation for merging two U's, as in scala.TraversableOnce. Both of these functions are
    * allowed to modify and return their first argument instead of creating a new U to avoid memory
    * allocation.
-   * 
+   *
    * @param zeroValue the initial value for the accumulated result of each partition for the seqOp
    *                  operator, and also the initial value for the combine results from different
-   *                  partitions for the conbOp operator,  
+   *                  partitions for the conbOp operator.
    *                  - this will typically be the neutral element.
    *                  (e.g. Nil for list concatenation or 0 for summation)
    * @param seqOp an operator used to accumulate results within a partition

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1072,13 +1072,12 @@ abstract class RDD[T: ClassTag](
    * that are not commutative, the result may differ from that of a fold applied to a
    * non-distributed collection.
    *
-   * @param zeroValue the initial value for the accumulated result of each partition for the op
+   * @param zeroValue the initial value for the accumulated result of each partition for the `op`
    *                  operator, and also the initial value for the combine results from different
-   *                  partitions for the op operator also.
-   *                  - this will typically be the neutral element.
-   *                  (e.g. Nil for list concatenation or 0 for summation)
+   *                  partitions for the `op` operator - this will typically be the neutral
+   *                  element (e.g. `Nil` for list concatenation or `0` for summation)
    * @param op an operator used to both accumulate results within a partition and combine results
-   *                  from different partitions.
+   *                  from different partitions
    */
   def fold(zeroValue: T)(op: (T, T) => T): T = withScope {
     // Clone the zero value since we will also be serializing it as part of tasks
@@ -1098,11 +1097,10 @@ abstract class RDD[T: ClassTag](
    * allowed to modify and return their first argument instead of creating a new U to avoid memory
    * allocation.
    *
-   * @param zeroValue the initial value for the accumulated result of each partition for the seqOp
-   *                  operator, and also the initial value for the combine results from different
-   *                  partitions for the conbOp operator.
-   *                  - this will typically be the neutral element.
-   *                  (e.g. Nil for list concatenation or 0 for summation)
+   * @param zeroValue the initial value for the accumulated result of each partition for the
+   *                  `seqOp` operator, and also the initial value for the combine results from
+   *                  different partitions for the `combOp` operator - this will typically be the
+   *                  neutral element (e.g. `Nil` for list concatenation or `0` for summation)
    * @param seqOp an operator used to accumulate results within a partition
    * @param combOp an associative operator used to combine results from different partitions
    */


### PR DESCRIPTION
Currently, RDD function aggregate's parameter doesn't explain well, especially parameter "zeroValue".
It's helpful to let junior scala user know that "zeroValue" attend both "seqOp" and "combOp" phase.
