### PR TITLE
[SPARK-12480][follow-up] use a single column vararg for hash

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1017,6 +1017,17 @@ def sha2(col, numBits):
     jc = sc._jvm.functions.sha2(_to_java_column(col), numBits)
     return Column(jc)
 
+@since(2.0)
+def hash(col):
+    """Calculates the hash code of given columns, and returns the result as a int column.
+
+    >>> sqlContext.createDataFrame([('ABC',)], ['a']).select(hash('a').alias('hash')).collect()
+    [Row(hash=1358996357)]
+    """
+    sc = SparkContext._active_spark_context
+    jc = sc._jvm.functions.hash(_to_java_column(col))
+    return Column(jc)
+
 
 # ---------------------- String/Binary functions ------------------------------
 

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1019,14 +1019,14 @@ def sha2(col, numBits):
 
 
 @since(2.0)
-def hash(col):
+def hash(*cols):
     """Calculates the hash code of given columns, and returns the result as a int column.
 
     >>> sqlContext.createDataFrame([('ABC',)], ['a']).select(hash('a').alias('hash')).collect()
     [Row(hash=1358996357)]
     """
     sc = SparkContext._active_spark_context
-    jc = sc._jvm.functions.hash(_to_java_column(col))
+    jc = sc._jvm.functions.hash(_to_seq(sc, cols, _to_java_column))
     return Column(jc)
 
 

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1017,6 +1017,7 @@ def sha2(col, numBits):
     jc = sc._jvm.functions.sha2(_to_java_column(col), numBits)
     return Column(jc)
 
+
 @since(2.0)
 def hash(col):
     """Calculates the hash code of given columns, and returns the result as a int column.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -200,7 +200,7 @@ case class Murmur3Hash(children: Seq[Expression], seed: Int) extends Expression 
 
   override def checkInputDataTypes(): TypeCheckResult = {
     if (children.isEmpty) {
-      TypeCheckResult.TypeCheckFailure("arguments of function hash cannot be empty")
+      TypeCheckResult.TypeCheckFailure("function hash requires at least one argument")
     } else {
       TypeCheckResult.TypeCheckSuccess
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
@@ -163,6 +163,7 @@ class ExpressionTypeCheckingSuite extends SparkFunSuite {
     assertError(Coalesce(Seq('intField, 'booleanField)),
       "input to function coalesce should all be the same type")
     assertError(Coalesce(Nil), "input to function coalesce cannot be empty")
+    assertError(new Murmur3Hash(Nil), "arguments of function hash cannot be empty")
     assertError(Explode('intField),
       "input to function explode should be array or map type")
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
@@ -163,7 +163,7 @@ class ExpressionTypeCheckingSuite extends SparkFunSuite {
     assertError(Coalesce(Seq('intField, 'booleanField)),
       "input to function coalesce should all be the same type")
     assertError(Coalesce(Nil), "input to function coalesce cannot be empty")
-    assertError(new Murmur3Hash(Nil), "arguments of function hash cannot be empty")
+    assertError(new Murmur3Hash(Nil), "function hash requires at least one argument")
     assertError(Explode('intField),
       "input to function explode should be array or map type")
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -1820,8 +1820,8 @@ object functions extends LegacyFunctions {
    * @since 2.0
    */
   @scala.annotation.varargs
-  def hash(col: Column, cols: Column*): Column = withExpr {
-    new Murmur3Hash((col +: cols).map(_.expr))
+  def hash(cols: Column*): Column = withExpr {
+    new Murmur3Hash(cols.map(_.expr))
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
address comments in #10435

This makes the API easier to use if user programmatically generate the call to hash, and they will get analysis exception if the arguments of hash is empty.
