### PR TITLE
[SPARK-12633][Python][MLlib][DOC] Update param descriptions in regression.py

### DIFF
--- a/python/pyspark/mllib/regression.py
+++ b/python/pyspark/mllib/regression.py
@@ -37,10 +37,11 @@ class LabeledPoint(object):
     """
     Class that represents the features and labels of a data point.
 
-    :param label: Label for this data point.
-    :param features: Vector of features for this point (NumPy array,
-            list, pyspark.mllib.linalg.SparseVector, or scipy.sparse
-            column matrix)
+    :param label:
+      Label for this data point.
+    :param features:
+      Vector of features for this point (NumPy array, list,
+      pyspark.mllib.linalg.SparseVector, or scipy.sparse column matrix)
 
     Note: 'label' and 'features' are accessible as class attributes.
 
@@ -66,8 +67,10 @@ class LinearModel(object):
     """
     A linear model that has a vector of coefficients and an intercept.
 
-    :param weights: Weights computed for every feature.
-    :param intercept: Intercept computed for this model.
+    :param weights:
+      Weights computed for every feature.
+    :param intercept:
+      Intercept computed for this model.
 
     .. versionadded:: 0.9.0
     """
@@ -245,37 +248,45 @@ class LinearRegressionWithSGD(object):
         set of rows of A, each with its corresponding right hand side
         label y. See also the documentation for the precise formulation.
 
-        :param data:              The training data, an RDD of
-                                  LabeledPoint.
-        :param iterations:        The number of iterations
-                                  (default: 100).
-        :param step:              The step parameter used in SGD
-                                  (default: 1.0).
-        :param miniBatchFraction: Fraction of data to be used for each
-                                  SGD iteration (default: 1.0).
-        :param initialWeights:    The initial weights (default: None).
-        :param regParam:          The regularizer parameter
-                                  (default: 0.0).
-        :param regType:           The type of regularizer used for
-                                  training our model.
+        :param data:
+          The training data, an RDD of LabeledPoint.
+        :param iterations:
+          The number of iterations.
+          (default: 100)
+        :param step:
+          The step parameter used in SGD.
+          (default: 1.0)
+        :param miniBatchFraction:
+          Fraction of data to be used for each SGD iteration.
+          (default: 1.0)
+        :param initialWeights:
+          The initial weights.
+          (default: None)
+        :param regParam:
+          The regularizer parameter.
+          (default: 0.0)
+        :param regType:
+          The type of regularizer used for training our model.
 
-                                  :Allowed values:
-                                     - "l1" for using L1 regularization (lasso),
-                                     - "l2" for using L2 regularization (ridge),
-                                     - None for no regularization
+          :Allowed values:
+          - "l1" for using L1 regularization (lasso),
+          - "l2" for using L2 regularization (ridge),
+          - None for no regularization
 
-                                     (default: None)
+          (default: None)
 
-        :param intercept:         Boolean parameter which indicates the
-                                  use or not of the augmented representation
-                                  for training data (i.e. whether bias
-                                  features are activated or not,
-                                  default: False).
-        :param validateData:      Boolean parameter which indicates if
-                                  the algorithm should validate data
-                                  before training. (default: True)
-        :param convergenceTol:    A condition which decides iteration termination.
-                                  (default: 0.001)
+        :param intercept:
+          Boolean parameter which indicates the use or not of the augmented
+          representation for training data (i.e., whether bias features are
+          activated or not).
+          (default: False)
+        :param validateData:
+          Boolean parameter which indicates if the algorithm should validate data
+          before training.
+          (default: True)
+        :param convergenceTol:
+          A condition which decides iteration termination.
+          (default: 0.001)
         """
         def train(rdd, i):
             return callMLlibFunc("trainLinearRegressionModelWithSGD", rdd, int(iterations),
@@ -393,27 +404,35 @@ class LassoWithSGD(object):
         set of rows of A, each with its corresponding right hand side
         label y. See also the documentation for the precise formulation.
 
-        :param data:              The training data, an RDD of
-                                  LabeledPoint.
-        :param iterations:        The number of iterations
-                                  (default: 100).
-        :param step:              The step parameter used in SGD
-                                  (default: 1.0).
-        :param regParam:          The regularizer parameter
-                                  (default: 0.01).
-        :param miniBatchFraction: Fraction of data to be used for each
-                                  SGD iteration (default: 1.0).
-        :param initialWeights:    The initial weights (default: None).
-        :param intercept:         Boolean parameter which indicates the
-                                  use or not of the augmented representation
-                                  for training data (i.e. whether bias
-                                  features are activated or not,
-                                  default: False).
-        :param validateData:      Boolean parameter which indicates if
-                                  the algorithm should validate data
-                                  before training. (default: True)
-        :param convergenceTol:    A condition which decides iteration termination.
-                                  (default: 0.001)
+        :param data:
+          The training data, an RDD of LabeledPoint.
+        :param iterations:
+          The number of iterations.
+          (default: 100)
+        :param step:
+          The step parameter used in SGD.
+          (default: 1.0)
+        :param regParam:
+          The regularizer parameter.
+          (default: 0.01)
+        :param miniBatchFraction:
+          Fraction of data to be used for each SGD iteration.
+          (default: 1.0)
+        :param initialWeights:
+          The initial weights.
+          (default: None)
+        :param intercept:
+          Boolean parameter which indicates the use or not of the augmented
+          representation for training data (i.e. whether bias features are
+          activated or not).
+         (default: False)
+        :param validateData:
+          Boolean parameter which indicates if the algorithm should validate
+          data before training.
+          (default: True)
+        :param convergenceTol:
+          A condition which decides iteration termination.
+          (default: 0.001)
         """
         def train(rdd, i):
             return callMLlibFunc("trainLassoModelWithSGD", rdd, int(iterations), float(step),
@@ -531,27 +550,35 @@ class RidgeRegressionWithSGD(object):
         set of rows of A, each with its corresponding right hand side
         label y. See also the documentation for the precise formulation.
 
-        :param data:              The training data, an RDD of
-                                  LabeledPoint.
-        :param iterations:        The number of iterations
-                                  (default: 100).
-        :param step:              The step parameter used in SGD
-                                  (default: 1.0).
-        :param regParam:          The regularizer parameter
-                                  (default: 0.01).
-        :param miniBatchFraction: Fraction of data to be used for each
-                                  SGD iteration (default: 1.0).
-        :param initialWeights:    The initial weights (default: None).
-        :param intercept:         Boolean parameter which indicates the
-                                  use or not of the augmented representation
-                                  for training data (i.e. whether bias
-                                  features are activated or not,
-                                  default: False).
-        :param validateData:      Boolean parameter which indicates if
-                                  the algorithm should validate data
-                                  before training. (default: True)
-        :param convergenceTol:    A condition which decides iteration termination.
-                                  (default: 0.001)
+        :param data:
+          The training data, an RDD of LabeledPoint.
+        :param iterations:
+          The number of iterations.
+          (default: 100)
+        :param step:
+          The step parameter used in SGD.
+          (default: 1.0)
+        :param regParam:
+          The regularizer parameter.
+          (default: 0.01)
+        :param miniBatchFraction:
+          Fraction of data to be used for each SGD iteration.
+          (default: 1.0)
+        :param initialWeights:
+          The initial weights.
+          (default: None)
+        :param intercept:
+          Boolean parameter which indicates the use or not of the augmented
+          representation for training data (i.e. whether bias features are
+          activated or not).
+          (default: False)
+        :param validateData:
+          Boolean parameter which indicates if the algorithm should validate
+          data before training.
+          (default: True)
+        :param convergenceTol:
+          A condition which decides iteration termination.
+          (default: 0.001)
         """
         def train(rdd, i):
             return callMLlibFunc("trainRidgeModelWithSGD", rdd, int(iterations), float(step),
@@ -566,12 +593,14 @@ class IsotonicRegressionModel(Saveable, Loader):
     """
     Regression model for isotonic regression.
 
-    :param boundaries: Array of boundaries for which predictions are
-            known. Boundaries must be sorted in increasing order.
-    :param predictions: Array of predictions associated to the
-            boundaries at the same index. Results of isotonic
-            regression and therefore monotone.
-    :param isotonic: indicates whether this is isotonic or antitonic.
+    :param boundaries:
+      Array of boundaries for which predictions are known. Boundaries must be
+      sorted in increasing order.
+    :param predictions:
+      Array of predictions associated to the boundaries at the same index.
+      Results of isotonic regression and therefore monotone.
+    :param isotonic:
+      Indicates whether this is isotonic or antitonic.
 
     >>> data = [(1, 0, 1), (2, 1, 1), (3, 2, 1), (1, 3, 1), (6, 4, 1), (17, 5, 1), (16, 6, 1)]
     >>> irm = IsotonicRegression.train(sc.parallelize(data))
@@ -622,7 +651,8 @@ class IsotonicRegressionModel(Saveable, Loader):
         values with the same boundary then the same rules as in 2)
         are used.
 
-        :param x: Feature or RDD of Features to be labeled.
+        :param x:
+          Feature or RDD of Features to be labeled.
         """
         if isinstance(x, RDD):
             return x.map(lambda v: self.predict(v))
@@ -676,8 +706,11 @@ class IsotonicRegression(object):
         """
         Train a isotonic regression model on the given data.
 
-        :param data: RDD of (label, feature, weight) tuples.
-        :param isotonic: Whether this is isotonic or antitonic.
+        :param data:
+          RDD of (label, feature, weight) tuples.
+        :param isotonic:
+          Whether this is isotonic (which is default) or antitonic.
+          (default: True)
         """
         boundaries, predictions = callMLlibFunc("trainIsotonicRegressionModel",
                                                 data.map(_convert_to_vector), bool(isotonic))

--- a/python/pyspark/mllib/regression.py
+++ b/python/pyspark/mllib/regression.py
@@ -40,8 +40,8 @@ class LabeledPoint(object):
     :param label:
       Label for this data point.
     :param features:
-      Vector of features for this point (NumPy array, list,
-      pyspark.mllib.linalg.SparseVector, or scipy.sparse column matrix)
+      Vector of features for this point (NumPy array, list, pyspark.mllib.linalg.SparseVector, or
+      scipy.sparse column matrix)
 
     Note: 'label' and 'features' are accessible as class attributes.
 
@@ -267,22 +267,17 @@ class LinearRegressionWithSGD(object):
           (default: 0.0)
         :param regType:
           The type of regularizer used for training our model.
-
           :Allowed values:
           - "l1" for using L1 regularization (lasso),
           - "l2" for using L2 regularization (ridge),
           - None for no regularization
-
           (default: None)
-
         :param intercept:
-          Boolean parameter which indicates the use or not of the augmented
-          representation for training data (i.e., whether bias features are
-          activated or not).
+          Boolean parameter which indicates the use or not of the augmented representation for
+          training data (i.e., whether bias features are activated or not).
           (default: False)
         :param validateData:
-          Boolean parameter which indicates if the algorithm should validate data
-          before training.
+          Boolean parameter which indicates if the algorithm should validate data before training.
           (default: True)
         :param convergenceTol:
           A condition which decides iteration termination.
@@ -422,13 +417,11 @@ class LassoWithSGD(object):
           The initial weights.
           (default: None)
         :param intercept:
-          Boolean parameter which indicates the use or not of the augmented
-          representation for training data (i.e. whether bias features are
-          activated or not).
+          Boolean parameter which indicates the use or not of the augmented representation for
+          training data (i.e. whether bias features are activated or not).
          (default: False)
         :param validateData:
-          Boolean parameter which indicates if the algorithm should validate
-          data before training.
+          Boolean parameter which indicates if the algorithm should validate data before training.
           (default: True)
         :param convergenceTol:
           A condition which decides iteration termination.
@@ -568,13 +561,11 @@ class RidgeRegressionWithSGD(object):
           The initial weights.
           (default: None)
         :param intercept:
-          Boolean parameter which indicates the use or not of the augmented
-          representation for training data (i.e. whether bias features are
-          activated or not).
+          Boolean parameter which indicates the use or not of the augmented representation for
+          training data (i.e. whether bias features are activated or not).
           (default: False)
         :param validateData:
-          Boolean parameter which indicates if the algorithm should validate
-          data before training.
+          Boolean parameter which indicates if the algorithm should validate data before training.
           (default: True)
         :param convergenceTol:
           A condition which decides iteration termination.
@@ -594,11 +585,11 @@ class IsotonicRegressionModel(Saveable, Loader):
     Regression model for isotonic regression.
 
     :param boundaries:
-      Array of boundaries for which predictions are known. Boundaries must be
-      sorted in increasing order.
+      Array of boundaries for which predictions are known. Boundaries must be sorted in increasing
+      order.
     :param predictions:
-      Array of predictions associated to the boundaries at the same index.
-      Results of isotonic regression and therefore monotone.
+      Array of predictions associated to the boundaries at the same index. Results of isotonic
+      regression and therefore monotone.
     :param isotonic:
       Indicates whether this is isotonic or antitonic.
 

--- a/python/pyspark/mllib/regression.py
+++ b/python/pyspark/mllib/regression.py
@@ -41,7 +41,7 @@ class LabeledPoint(object):
       Label for this data point.
     :param features:
       Vector of features for this point (NumPy array, list,
-      pyspark.mllib.linalg.SparseVector, or scipy.sparse column matrix)
+      pyspark.mllib.linalg.SparseVector, or scipy.sparse column matrix).
 
     Note: 'label' and 'features' are accessible as class attributes.
 
@@ -422,7 +422,7 @@ class LassoWithSGD(object):
           Boolean parameter which indicates the use or not of the
           augmented representation for training data (i.e. whether bias
           features are activated or not).
-         (default: False)
+          (default: False)
         :param validateData:
           Boolean parameter which indicates if the algorithm should
           validate data before training.

--- a/python/pyspark/mllib/regression.py
+++ b/python/pyspark/mllib/regression.py
@@ -40,8 +40,8 @@ class LabeledPoint(object):
     :param label:
       Label for this data point.
     :param features:
-      Vector of features for this point (NumPy array, list, pyspark.mllib.linalg.SparseVector, or
-      scipy.sparse column matrix)
+      Vector of features for this point (NumPy array, list,
+      pyspark.mllib.linalg.SparseVector, or scipy.sparse column matrix)
 
     Note: 'label' and 'features' are accessible as class attributes.
 
@@ -273,11 +273,13 @@ class LinearRegressionWithSGD(object):
           - None for no regularization
           (default: None)
         :param intercept:
-          Boolean parameter which indicates the use or not of the augmented representation for
-          training data (i.e., whether bias features are activated or not).
+          Boolean parameter which indicates the use or not of the
+          augmented representation for training data (i.e., whether bias
+          features are activated or not).
           (default: False)
         :param validateData:
-          Boolean parameter which indicates if the algorithm should validate data before training.
+          Boolean parameter which indicates if the algorithm should
+          validate data before training.
           (default: True)
         :param convergenceTol:
           A condition which decides iteration termination.
@@ -417,11 +419,13 @@ class LassoWithSGD(object):
           The initial weights.
           (default: None)
         :param intercept:
-          Boolean parameter which indicates the use or not of the augmented representation for
-          training data (i.e. whether bias features are activated or not).
+          Boolean parameter which indicates the use or not of the
+          augmented representation for training data (i.e. whether bias
+          features are activated or not).
          (default: False)
         :param validateData:
-          Boolean parameter which indicates if the algorithm should validate data before training.
+          Boolean parameter which indicates if the algorithm should
+          validate data before training.
           (default: True)
         :param convergenceTol:
           A condition which decides iteration termination.
@@ -561,11 +565,13 @@ class RidgeRegressionWithSGD(object):
           The initial weights.
           (default: None)
         :param intercept:
-          Boolean parameter which indicates the use or not of the augmented representation for
-          training data (i.e. whether bias features are activated or not).
+          Boolean parameter which indicates the use or not of the
+          augmented representation for training data (i.e. whether bias
+          features are activated or not).
           (default: False)
         :param validateData:
-          Boolean parameter which indicates if the algorithm should validate data before training.
+          Boolean parameter which indicates if the algorithm should
+          validate data before training.
           (default: True)
         :param convergenceTol:
           A condition which decides iteration termination.
@@ -585,11 +591,11 @@ class IsotonicRegressionModel(Saveable, Loader):
     Regression model for isotonic regression.
 
     :param boundaries:
-      Array of boundaries for which predictions are known. Boundaries must be sorted in increasing
-      order.
+      Array of boundaries for which predictions are known. Boundaries must
+      be sorted in increasing order.
     :param predictions:
-      Array of predictions associated to the boundaries at the same index. Results of isotonic
-      regression and therefore monotone.
+      Array of predictions associated to the boundaries at the same index.
+      Results of isotonic regression and therefore monotone.
     :param isotonic:
       Indicates whether this is isotonic or antitonic.
 


### PR DESCRIPTION
Updates the param, in python mllib's regression.py, descriptions to be consistent. See [SPARK-11219] for
more details.
