### PR TITLE
[SPARK-12604] [CORE] Addendum - use casting vs mapValues for countBy{Key,Value}

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/java/JavaPairRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaPairRDD.scala
@@ -296,7 +296,7 @@ class JavaPairRDD[K, V](val rdd: RDD[(K, V)])
 
   /** Count the number of elements for each key, and return the result to the master as a Map. */
   def countByKey(): java.util.Map[K, jl.Long] =
-    mapAsSerializableJavaMap(rdd.countByKey().mapValues(jl.Long.valueOf))
+    mapAsSerializableJavaMap(rdd.countByKey()).asInstanceOf[java.util.Map[K, jl.Long]]
 
   /**
    * Approximate version of countByKey that can return a partial result if it does

--- a/core/src/main/scala/org/apache/spark/api/java/JavaRDDLike.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaRDDLike.scala
@@ -448,7 +448,7 @@ trait JavaRDDLike[T, This <: JavaRDDLike[T, This]] extends Serializable {
    * combine step happens locally on the master, equivalent to running a single reduce task.
    */
   def countByValue(): java.util.Map[T, jl.Long] =
-    mapAsSerializableJavaMap(rdd.countByValue().mapValues(jl.Long.valueOf))
+    mapAsSerializableJavaMap(rdd.countByValue()).asInstanceOf[java.util.Map[T, jl.Long]]
 
   /**
    * (Experimental) Approximate version of countByValue().


### PR DESCRIPTION
Per @rxin, let's use the casting for countByKey and countByValue as well. Let's see if this passes.
