### PR TITLE
[SPARK-12692][BUILD] Scala style: check no white space before comma and colon

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -218,6 +218,12 @@ This file is divided into 3 sections:
     </parameters>
   </check>
 
+  <!-- Should turn this on, but we have a few places that need to be fixed first -->
+  <check level="warning" class="org.scalastyle.scalariform.DisallowSpaceBeforeTokenChecker" enabled="true">
+    <parameters>
+      <parameter name="tokens">COLON, COMMA</parameter>
+    </parameters>
+  </check>
 
   <!-- ================================================================================ -->
   <!--                               rules we don't want                                -->


### PR DESCRIPTION
We should not put a white space before `,` and `:` so let's check it.
Because there are lots of style violations, first, I'd like to add a checker, enable and let the level `warning`.
Then, I'd like to fix the style step by step.
