### PR TITLE
[SPARK-12699][SPARKR] R driver process should start in a clean state

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/RPackageUtils.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/RPackageUtils.scala
@@ -36,7 +36,8 @@ private[deploy] object RPackageUtils extends Logging {
   private final val hasRPackage = "Spark-HasRPackage"
 
   /** Base of the shell command used in order to install R packages. */
-  private final val baseInstallCmd = Seq("R", "CMD", "INSTALL", "-l")
+  private final val baseInstallCmd = Seq("R", "--no-save", "--no-site-file", "--no-environ",
+    "--no-restore", "CMD", "INSTALL", "-l")
 
   /** R source code should exist under R/pkg in a jar. */
   private final val RJarEntries = "R/pkg"

--- a/core/src/main/scala/org/apache/spark/deploy/RRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/RRunner.scala
@@ -78,7 +78,9 @@ object RRunner {
     if (initialized.tryAcquire(backendTimeout, TimeUnit.SECONDS)) {
       // Launch R
       val returnCode = try {
-        val builder = new ProcessBuilder((Seq(rCommand, rFileNormalized) ++ otherArgs).asJava)
+        val rCommandWithArgs = Seq(rCommand, "--no-save", "--no-site-file", "--no-environ",
+          "--no-restore", rFileNormalized) ++ otherArgs
+        val builder = new ProcessBuilder(rCommandWithArgs.asJava)
         val env = builder.environment()
         env.put("EXISTING_SPARKR_BACKEND_PORT", sparkRBackendPort.toString)
         val rPackageDir = RUtils.sparkRPackagePath(isDriver = true)

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -273,8 +273,6 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
 
     List<String> args = new ArrayList<String>();
     args.add(firstNonEmpty(System.getenv("SPARKR_DRIVER_R"), "R"));
-    // Allow save/restore for SparkR shell
-    Collections.addAll(args, "--no-site-file", "--no-environ");
     return args;
   }
 

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -273,7 +273,8 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
 
     List<String> args = new ArrayList<String>();
     args.add(firstNonEmpty(System.getenv("SPARKR_DRIVER_R"), "R"));
-    Collections.addAll(args, "--no-site-file", "--no-environ", "--no-restore");
+    // Allow save/restore for SparkR shell
+    Collections.addAll(args, "--no-site-file", "--no-environ");
     return args;
   }
 

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -273,6 +273,7 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
 
     List<String> args = new ArrayList<String>();
     args.add(firstNonEmpty(System.getenv("SPARKR_DRIVER_R"), "R"));
+    Collections.addAll(args, "--no-site-file", "--no-environ", "--no-restore");
     return args;
   }
 


### PR DESCRIPTION
Currently we have R worker process launched with the --vanilla option that brings it up in a clean state (without init profile or workspace data, https://stat.ethz.ch/R-manual/R-devel/library/base/html/Startup.html). However, the R process for the Spark driver is not.

We should do that because
1. That would make driver consistent with the worker process in R - for instance, a library might be load in driver but not worker
2. Since SparkR depends on .libPath and .First() it could be broken by something in the user workspace, for example

Here are the changes proposed:
1. When starting `sparkR` shell (except: allow save/restore workspace, since the driver/shell is local)
2. When launching R driver in cluster mode
3. In cluster mode, when calling R to install shipped R package

This is discussed in PR #10171

@shivaram @sun-rui 
