### PR TITLE
[SPARK-12639][SQL] Improve Explain for Datasources with Handled Predicates

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExistingRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExistingRDD.scala
@@ -114,6 +114,7 @@ private[sql] object PhysicalRDD {
   // Metadata keys
   val INPUT_PATHS = "InputPaths"
   val PUSHED_FILTERS = "PushedFilters"
+  val HANDLED_FILTERS = "HandledFilters"
 
   def createFromDataSource(
       output: Seq[Attribute],

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExistingRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExistingRDD.scala
@@ -113,7 +113,6 @@ private[sql] case class PhysicalRDD(
 private[sql] object PhysicalRDD {
   // Metadata keys
   val INPUT_PATHS = "InputPaths"
-  val PUSHED_FILTERS = "PushedFilters"
   val HANDLED_FILTERS = "HandledFilters"
 
   def createFromDataSource(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow, expressions}
-import org.apache.spark.sql.execution.PhysicalRDD.{INPUT_PATHS, HANDLED_FILTERS}
+import org.apache.spark.sql.execution.PhysicalRDD.{HANDLED_FILTERS, INPUT_PATHS}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.{StringType, StructType}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -160,7 +160,7 @@ class PlannerSuite extends SharedSQLContext {
     }
   }
 
-  test("SPARK-11390 explain should print PushedFilters of PhysicalRDD") {
+  test("SPARK-11390 explain should print HandledFilters of PhysicalRDD") {
     withTempPath { file =>
       val path = file.getCanonicalPath
       testData.write.parquet(path)
@@ -169,7 +169,7 @@ class PlannerSuite extends SharedSQLContext {
 
       withTempTable("testPushed") {
         val exp = sql("select * from testPushed where key = 15").queryExecution.executedPlan
-        assert(exp.toString.contains("PushedFilters: [EqualTo(key,15)]"))
+        assert(exp.toString.contains("HandledFilters: [EqualTo(key,15)]"))
       }
     }
   }


### PR DESCRIPTION
SPARK-11661 Makes all predicates pushed down to underlying Datasources
regardless of whether the source can handle them or not. This makes the
explain command slightly confusing as it will always list all filters
whether or not the underlying source can actually use them. Instead
now we should only list those filters which are expressly handled by the
underlying source.

All predicates are pushed down so there really isn't any value in listing them.

In the following example `plate_number` is a predicate which can be pushed to the underlying source and handled at the source level. `mileage` and `acc` cannot be handled in any way by the underlying source.

Previously 

``` scala
scala> df.filter("""plate_number = "OUTTATIME" and mileage > 100""").explain
16/01/08 09:20:05 INFO CassandraSourceRelation: filters: EqualTo(plate_number,OUTTATIME), GreaterThan(mileage,100.0)
16/01/08 09:20:05 INFO CassandraSourceRelation: pushdown filters: ArrayBuffer(EqualTo(plate_number,OUTTATIME))
== Physical Plan ==
Filter (mileage#5 > 100.0)
+- Scan org.apache.spark.sql.cassandra.CassandraSourceRelation@7b1d3a05[plate_number#0,time#1,acc#2,lat#3,lng#4,mileage#5]  PushedFilters: [EqualTo(plate_number,OUTTATIME), GreaterThan(mileage,100.0)]

scala> df.filter("""mileage > 100 and acc = 1000""").explain
16/01/08 09:23:39 INFO CassandraSourceRelation: filters: GreaterThan(mileage,100.0)
16/01/08 09:23:39 INFO CassandraSourceRelation: pushdown filters: ArrayBuffer()
== Physical Plan ==
Filter (if (isnull(acc#2)) null else CASE 1000 WHEN 1 THEN acc#2 WHEN 0 THEN NOT acc#2 ELSE false && (mileage#5 > 100.0))
+- Scan org.apache.spark.sql.cassandra.CassandraSourceRelation@7b1d3a05[plate_number#0,time#1,acc#2,lat#3,lng#4,mileage#5] PushedFilters: [GreaterThan(mileage,100.0)]
```

With this patch

``` scala
scala> df.filter("""plate_number = "OUTTATIME" and mileage > 100""").explain
16/01/08 09:20:05 INFO CassandraSourceRelation: filters: EqualTo(plate_number,OUTTATIME), GreaterThan(mileage,100.0)
16/01/08 09:20:05 INFO CassandraSourceRelation: pushdown filters: ArrayBuffer(EqualTo(plate_number,OUTTATIME))
== Physical Plan ==
Filter (mileage#5 > 100.0)
+- Scan org.apache.spark.sql.cassandra.CassandraSourceRelation@7b1d3a05[plate_number#0,time#1,acc#2,lat#3,lng#4,mileage#5] HandledFilters: [(plate_number#0 = OUTTATIME)]

scala> df.filter("""mileage > 100 and acc = 1000""").explain
16/01/08 09:23:39 INFO CassandraSourceRelation: filters: GreaterThan(mileage,100.0)
16/01/08 09:23:39 INFO CassandraSourceRelation: pushdown filters: ArrayBuffer()
== Physical Plan ==
Filter (if (isnull(acc#2)) null else CASE 1000 WHEN 1 THEN acc#2 WHEN 0 THEN NOT acc#2 ELSE false && (mileage#5 > 100.0))
+- Scan org.apache.spark.sql.cassandra.CassandraSourceRelation@7b1d3a05[plate_number#0,time#1,acc#2,lat#3,lng#4,mileage#5]
```

TLDR;
CassandraSource

```
OLD
org.apache.spark.sql.cassandra.CassandraSourceRelation@7b1d3a05[plate_number#0,time#1,acc#2,lat#3,lng#4,mileage#5]  PushedFilters: [EqualTo(plate_number,OUTTATIME), GreaterThan(mileage,100.0)]

NEW
org.apache.spark.sql.cassandra.CassandraSourceRelation@7b1d3a05[plate_number#0,time#1,acc#2,lat#3,lng#4,mileage#5] HandledFilters: [(plate_number#0 = OUTTATIME)]
```

Parquet

```
val df = sqlContext.read.load("examples/src/main/resources/users.parquet")
df.filter("age > 5").explain
```

```
OLD
== Physical Plan ==
Filter (age#0L > 5)
+- Scan JSONRelation[age#0L,name#1] InputPaths: people.json, PushedFilters: [GreaterThan(age,5)]

NEW
== Physical Plan ==
Filter (age#6L > 5)
+- Scan JSONRelation[age#6L,name#7] InputPaths: people.json
```

Orc

```
case class Contact(name: String, phone: String)
case class Person(name: String, age: Int, contacts: Seq[Contact])
val records = (1 to 100).map { i =>;
   Person(s"name_$i", i, (0 to 1).map { m => Contact(s"contact_$m", s"phone_$m") })
}
sc.parallelize(records).toDF().write.format("orc").save("people")
val people = sqlContext.read.format("orc").load("people")
people.filter("age > 10").explain
```

```
OLD
== Physical Plan ==
Filter (age#10 > 10)
+- Scan OrcRelation[name#9,age#10,contacts#11] InputPaths: people, PushedFilters: [GreaterThan(age,10)]

NEW
== Physical Plan ==
Filter (age#7 > 10)
+- Scan OrcRelation[name#6,age#7,contacts#8] InputPaths: people
```
