### PR TITLE
[SPARK-12687][SQL] Support from clause surrounded by `()`.

### DIFF
--- a/sql/catalyst/src/main/antlr3/org/apache/spark/sql/catalyst/parser/FromClauseParser.g
+++ b/sql/catalyst/src/main/antlr3/org/apache/spark/sql/catalyst/parser/FromClauseParser.g
@@ -151,8 +151,8 @@ fromSource
 @after { gParent.popMsg(state); }
     :
     (LPAREN KW_VALUES) => fromSource0
-    | (LPAREN) => LPAREN joinSource RPAREN -> joinSource
     | fromSource0
+    | (LPAREN joinSource) => LPAREN joinSource RPAREN -> joinSource
     ;
 
 

--- a/sql/catalyst/src/main/antlr3/org/apache/spark/sql/catalyst/parser/SparkSqlParser.g
+++ b/sql/catalyst/src/main/antlr3/org/apache/spark/sql/catalyst/parser/SparkSqlParser.g
@@ -2216,6 +2216,8 @@ regularBody[boolean topLevel]
 selectStatement[boolean topLevel]
    :
    (
+   (
+   LPAREN
    s=selectClause
    f=fromClause?
    w=whereClause?
@@ -2227,6 +2229,20 @@ selectStatement[boolean topLevel]
    sort=sortByClause?
    win=window_clause?
    l=limitClause?
+   RPAREN
+   |
+   s=selectClause
+   f=fromClause?
+   w=whereClause?
+   g=groupByClause?
+   h=havingClause?
+   o=orderByClause?
+   c=clusterByClause?
+   d=distributeByClause?
+   sort=sortByClause?
+   win=window_clause?
+   l=limitClause?
+   )
    -> ^(TOK_QUERY $f? ^(TOK_INSERT ^(TOK_DESTINATION ^(TOK_DIR TOK_TMP_FILE))
                      $s $w? $g? $h? $o? $c?
                      $d? $sort? $win? $l?))
@@ -2241,7 +2257,10 @@ selectStatement[boolean topLevel]
 
 setOpSelectStatement[CommonTree t, boolean topLevel]
    :
-   (u=setOperator b=simpleSelectStatement
+   ((
+    u=setOperator LPAREN b=simpleSelectStatement RPAREN
+    |
+    u=setOperator b=simpleSelectStatement)
    -> {$setOpSelectStatement.tree != null && $u.tree.getType()==SparkSqlParser.TOK_UNIONDISTINCT}?
       ^(TOK_QUERY
           ^(TOK_FROM

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystQlSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystQlSuite.scala
@@ -28,5 +28,9 @@ class CatalystQlSuite extends PlanTest {
     paresr.createPlan("select * from t1 union select * from t2")
     paresr.createPlan("select * from t1 except select * from t2")
     paresr.createPlan("select * from t1 intersect select * from t2")
+    paresr.createPlan("(select * from t1) union all (select * from t2)")
+    paresr.createPlan("(select * from t1) union distinct (select * from t2)")
+    paresr.createPlan("(select * from t1) union (select * from t2)")
+    paresr.createPlan("select * from ((select * from t1) union (select * from t2)) t")
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -803,21 +803,6 @@ class HiveQuerySuite extends HiveComparisonTest with BeforeAndAfter {
     assertResult(Array(Row(1))) {
       sql("select 1 as a intersect select 1 as a").collect()
     }
-    assertResult(Array(Row(1))) {
-      sql("(select 1 as a) intersect (select 1 as a)").collect()
-    }
-    assertResult(Array(Row(1), Row(1))) {
-      sql("(select 1 as a) union all (select 1 as a)").collect()
-    }
-    assertResult(Array(Row(1))) {
-      sql("(select 1 as a) union distinct (select 1 as a)").collect()
-    }
-    assertResult(Array(Row(1))) {
-      sql("(select 1 as a) union (select 1 as a)").collect()
-    }
-    assertResult(Array(Row(1))) {
-      sql("select * from ((select 1 as a) union (select 1 as a)) t").collect()
-    }
   }
 
   test("SPARK-5383 alias for udfs with multi output columns") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -803,6 +803,21 @@ class HiveQuerySuite extends HiveComparisonTest with BeforeAndAfter {
     assertResult(Array(Row(1))) {
       sql("select 1 as a intersect select 1 as a").collect()
     }
+    assertResult(Array(Row(1))) {
+      sql("(select 1 as a) intersect (select 1 as a)").collect()
+    }
+    assertResult(Array(Row(1), Row(1))) {
+      sql("(select 1 as a) union all (select 1 as a)").collect()
+    }
+    assertResult(Array(Row(1))) {
+      sql("(select 1 as a) union distinct (select 1 as a)").collect()
+    }
+    assertResult(Array(Row(1))) {
+      sql("(select 1 as a) union (select 1 as a)").collect()
+    }
+    assertResult(Array(Row(1))) {
+      sql("select * from ((select 1 as a) union (select 1 as a)) t").collect()
+    }
   }
 
   test("SPARK-5383 alias for udfs with multi output columns") {


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-12687

Some queries such as `(select 1 as a) union (select 2 as a)` can't work. This patch fixes it.
