### PR TITLE
[SPARK-6332] [MLlib] compute calibration curve for binary classifiers

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -177,6 +177,8 @@ abstract class ProbabilisticClassificationModel[
    * Predict the probability of each class given the features.
    * These predictions are also called class conditional probabilities.
    *
+   * See BinaryClassificationMetrics.calibration to assess calibration.
+   *
    * This internal method is used to implement [[transform()]] and output [[probabilityCol]].
    *
    * @return Estimated class conditional probabilities

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -177,7 +177,7 @@ abstract class ProbabilisticClassificationModel[
    * Predict the probability of each class given the features.
    * These predictions are also called class conditional probabilities.
    *
-   * See BinaryClassificationMetrics.calibration to assess calibration.
+   * See [[org.apache.spark.mllib.evaluation.BinaryClassificationMetrics.calibration]] to assess calibration.
    *
    * This internal method is used to implement [[transform()]] and output [[probabilityCol]].
    *

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -177,7 +177,8 @@ abstract class ProbabilisticClassificationModel[
    * Predict the probability of each class given the features.
    * These predictions are also called class conditional probabilities.
    *
-   * See [[org.apache.spark.mllib.evaluation.BinaryClassificationMetrics.calibration]] to assess calibration.
+   * See [[org.apache.spark.mllib.evaluation.BinaryClassificationMetrics.calibration]] to assess
+   * calibration.
    *
    * This internal method is used to implement [[transform()]] and output [[probabilityCol]].
    *

--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetrics.scala
@@ -262,7 +262,14 @@ class BinaryClassificationMetrics @Since("1.3.0") (
       } else {
         val distinctScoresCount = distinctScoresAndLabelCounts.count()
   
-        var groupCount = distinctScoresCount / numBins
+        var groupCount =
+          if (distinctScoresCount % numBins == 0) {
+            distinctScoresCount / numBins
+          } else {
+            // prevent the last bin from being very small compared to the others
+            distinctScoresCount / numBins + 1
+          }
+        
         if (groupCount < 2) {
           logInfo(s"Too few distinct scores ($distinctScoresCount) for $numBins bins to be useful")
           distinctScoresAndLabelCounts.map { pair => ((pair._1, pair._1), pair._2) }

--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetrics.scala
@@ -227,23 +227,22 @@ class BinaryClassificationMetrics @Since("1.3.0") (
   /**
    * Returns the calibration or reliability curve,
    * which is an RDD of (average score in bin, fraction of positive examples in bin).
-   * @see http://en.wikipedia.org/wiki/Calibration_%28statistics%29#In_classification
    *
-   * References:
+   * @see [[http://en.wikipedia.org/wiki/Calibration_%28statistics%29#In_classification Wikipedia article on calibration in classification]]
    *
-   * Mahdi Pakdaman Naeini, Gregory F. Cooper, Milos Hauskrecht.
+   * @see Mahdi Pakdaman Naeini, Gregory F. Cooper, Milos Hauskrecht.
    * Binary Classifier Calibration: Non-parametric approach.
-   * http://arxiv.org/abs/1401.3390
+   * [[http://arxiv.org/abs/1401.3390 Link to paper]]
    *
-   * Alexandru Niculescu-Mizil, Rich Caruana.
+   * @see Alexandru Niculescu-Mizil, Rich Caruana.
    * Predicting Good Probabilities With Supervised Learning.
    * Appearing in Proceedings of the 22nd International Conference on Machine Learning,
    * Bonn, Germany, 2005.
-   * http://www.cs.cornell.edu/~alexn/papers/calibration.icml05.crc.rev3.pdf
+   * [[http://www.cs.cornell.edu/~alexn/papers/calibration.icml05.crc.rev3.pdf Link to paper]]
    *
-   * Properties and benefits of calibrated classifiers.
+   * @see Properties and benefits of calibrated classifiers.
    * Ira Cohen, Moises Goldszmidt.
-   * http://www.hpl.hp.com/techreports/2004/HPL-2004-22R1.pdf
+   * [[http://www.hpl.hp.com/techreports/2004/HPL-2004-22R1.pdf Link to paper]]
    */
   def calibration(): RDD[((Double, Double), (Double, Long))] = {
     assessedCalibration

--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetrics.scala
@@ -247,7 +247,8 @@ class BinaryClassificationMetrics @Since("1.3.0") (
    *
    * Otherwise, the actual number of bins is equal to `numBins`.
    *
-   * @see [[http://en.wikipedia.org/wiki/Calibration_%28statistics%29#In_classification Wikipedia article on calibration in classification]]
+   * @see Wikipedia article on calibration in classification:
+   * [[http://en.wikipedia.org/wiki/Calibration_%28statistics%29#In_classification Link to article]]
    *
    * @see Mahdi Pakdaman Naeini, Gregory F. Cooper, Milos Hauskrecht.
    * Binary Classifier Calibration: Non-parametric approach.
@@ -266,20 +267,20 @@ class BinaryClassificationMetrics @Since("1.3.0") (
   def calibration(): RDD[((Double, Double), (Double, Long))] = {
     assessedCalibration
   }
-  
+
   private lazy val assessedCalibration: RDD[((Double, Double), (Double, Long))] = {
     val distinctScoresAndLabelCounts = scoreAndLabels.combineByKey(
       createCombiner = (label: Double) => new BinaryLabelCounter(0L, 0L) += label,
       mergeValue = (c: BinaryLabelCounter, label: Double) => c += label,
       mergeCombiners = (c1: BinaryLabelCounter, c2: BinaryLabelCounter) => c1 += c2
     ).sortByKey(ascending = true)
-  
+
     val binnedDistinctScoresAndLabelCounts =
       if (numBins == 0) {
         distinctScoresAndLabelCounts.map { case (score, count) => ((score, score), count) }
       } else {
         val distinctScoresCount = distinctScoresAndLabelCounts.count()
-  
+
         var groupCount =
           if (distinctScoresCount % numBins == 0) {
             distinctScoresCount / numBins
@@ -287,7 +288,7 @@ class BinaryClassificationMetrics @Since("1.3.0") (
             // prevent the last bin from being very small compared to the others
             distinctScoresCount / numBins + 1
           }
-        
+
         if (groupCount < 2) {
           logInfo(s"Too few distinct scores ($distinctScoresCount) for $numBins bins to be useful;"
             + " proceed with number of bins == number of distinct scores.")
@@ -308,7 +309,7 @@ class BinaryClassificationMetrics @Since("1.3.0") (
           })
         }
       }
-  
+
     binnedDistinctScoresAndLabelCounts.map { case (bounds, counts) =>
       val n = counts.numPositives + counts.numNegatives
       (bounds, (counts.numPositives / n.toDouble, n))

--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetrics.scala
@@ -29,14 +29,14 @@ import org.apache.spark.sql.DataFrame
  * Evaluator for binary classification.
  *
  * @param scoreAndLabels an RDD of (score, label) pairs.
- * @param numBins if greater than 0, then the curves (ROC curve, PR curve) computed internally
- *                will be down-sampled to this many "bins". If 0, no down-sampling will occur.
- *                This is useful because the curve contains a point for each distinct score
- *                in the input, and this could be as large as the input itself -- millions of
- *                points or more, when thousands may be entirely sufficient to summarize
- *                the curve. After down-sampling, the curves will instead be made of approximately
- *                `numBins` points instead. Points are made from bins of equal numbers of
- *                consecutive points. The size of each bin is
+ * @param numBins if greater than 0, then the curves (ROC curve, PR curve, calibration curve)
+ *                computed internally will be down-sampled to this many "bins". If 0, no
+ *                down-sampling will occur. This is useful because the curve contains a point for
+ *                each distinct score in the input, and this could be as large as the input itself
+ *                -- millions of points or more, when thousands may be entirely sufficient to
+ *                summarize the curve. After down-sampling, the curves will instead be made of
+ *                approximately `numBins` points instead. Points are made from bins of equal
+ *                numbers of consecutive points. The size of each bin is
  *                `floor(scoreAndLabels.count() / numBins)`, which means the resulting number
  *                of bins may not exactly equal numBins. The last bin in each partition may
  *                be smaller as a result, meaning there may be an extra sample at
@@ -225,5 +225,91 @@ class BinaryClassificationMetrics @Since("1.3.0") (
     confusions.map { case (_, c) =>
       (x(c), y(c))
     }
+  }
+
+  /**
+   * Returns the calibration or reliability curve,
+   * which is an RDD of (average score in bin, fraction of positive examples in bin).
+   * @see http://en.wikipedia.org/wiki/Calibration_%28statistics%29#In_classification
+   *
+   * References:
+   *
+   * Mahdi Pakdaman Naeini, Gregory F. Cooper, Milos Hauskrecht.
+   * Binary Classifier Calibration: Non-parametric approach.
+   * http://arxiv.org/abs/1401.3390
+   *
+   * Alexandru Niculescu-Mizil, Rich Caruana.
+   * Predicting Good Probabilities With Supervised Learning.
+   * Appearing in Proceedings of the 22nd International Conference on Machine Learning,
+   * Bonn, Germany, 2005.
+   * http://www.cs.cornell.edu/~alexn/papers/calibration.icml05.crc.rev3.pdf
+   *
+   * Properties and benefits of calibrated classifiers.
+   * Ira Cohen, Moises Goldszmidt.
+   * http://www.hpl.hp.com/techreports/2004/HPL-2004-22R1.pdf
+   */
+  def calibration(): RDD[((Double, Double), (Double, Int))] = {
+    val calibrationCurve = assessedCalibration
+    val sc = confusions.context
+    sc.makeRDD(calibrationCurve, 1)
+  }
+  
+  private lazy val assessedCalibration: Seq[((Double, Double), (Double, Int))] = {
+//  val distinctScoreAndLabels = scoreAndLabels.combineByKey(
+//    createCombiner = (label: Double) => new BinaryLabelCounter(0L, 0L) += label,
+//    mergeValue = (c: BinaryLabelCounter, label: Double) => c += label,
+//    mergeCombiners = (c1: BinaryLabelCounter, c2: BinaryLabelCounter) => c1 += c2
+//  ).sortByKey(ascending = true)
+//
+//  val binnedCounts =
+//    if (numBins == 0) {
+//      counts
+//    } else {
+//      val countsSize = counts.count()
+//
+//      var grouping = countsSize / numBins
+//      if (grouping < 2) {
+//        logInfo(s"Curve is too small ($countsSize) for $numBins bins to be useful")
+//        counts
+//      } else {
+//        if (grouping >= Int.MaxValue) {
+//          logWarning(
+//            s"Curve too large ($countsSize) for $numBins bins; capping at ${Int.MaxValue}")
+//          grouping = Int.MaxValue
+//        }
+//        counts.mapPartitions(_.grouped(grouping.toInt).map { pairs =>
+//          // The score of the combined point will be just the first one's score
+//          // I THINK WE WANT THE AVERAGE OF SCORE OVER THE BIN HERE
+//          val firstScore = pairs.head._1
+//          // The point will contain all counts in this chunk
+//          val agg = new BinaryLabelCounter()
+//          pairs.foreach(pair => agg += pair._2)
+//          (firstScore, agg)
+//        })
+//      }
+//    }
+//
+//  val agg = binnedCounts.values.mapPartitions { iter =>
+//    val agg = new BinaryLabelCounter()
+//    iter.foreach(agg += _)
+//    Iterator(agg)
+//  }.collect()
+//  val partitionwiseCumulativeCounts =
+//    agg.scanLeft(new BinaryLabelCounter())(
+//      (agg: BinaryLabelCounter, c: BinaryLabelCounter) => agg.clone() += c)
+//  val totalCount = partitionwiseCumulativeCounts.last
+//  logInfo(s"Total counts: $totalCount")
+//  // WE WANT PER-BIN COUNTS HERE, NOT CUMULATIVE
+//  val correctCounts = binnedCounts.mapPartitionsWithIndex(
+//    (index: Int, iter: Iterator[(Double, BinaryLabelCounter)]) => {
+//      val cumCount = partitionwiseCumulativeCounts(index)
+//      iter.map { case (score, c) =>
+//        cumCount += c
+//        (score, cumCount.clone())
+//      }
+//    }, preservesPartitioning = true)
+//  correctCounts.persist()
+//  correctCounts
+    Seq(((0.0, 0.0), (0.0, 0)), ((1.0, 1.0), (1.0, 0)))
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetrics.scala
@@ -248,68 +248,47 @@ class BinaryClassificationMetrics @Since("1.3.0") (
    * Ira Cohen, Moises Goldszmidt.
    * http://www.hpl.hp.com/techreports/2004/HPL-2004-22R1.pdf
    */
-  def calibration(): RDD[((Double, Double), (Double, Int))] = {
-    val calibrationCurve = assessedCalibration
-    val sc = confusions.context
-    sc.makeRDD(calibrationCurve, 1)
+  def calibration(): RDD[((Double, Double), (Double, Long))] = {
+    assessedCalibration
   }
   
-  private lazy val assessedCalibration: Seq[((Double, Double), (Double, Int))] = {
-//  val distinctScoreAndLabels = scoreAndLabels.combineByKey(
-//    createCombiner = (label: Double) => new BinaryLabelCounter(0L, 0L) += label,
-//    mergeValue = (c: BinaryLabelCounter, label: Double) => c += label,
-//    mergeCombiners = (c1: BinaryLabelCounter, c2: BinaryLabelCounter) => c1 += c2
-//  ).sortByKey(ascending = true)
-//
-//  val binnedCounts =
-//    if (numBins == 0) {
-//      counts
-//    } else {
-//      val countsSize = counts.count()
-//
-//      var grouping = countsSize / numBins
-//      if (grouping < 2) {
-//        logInfo(s"Curve is too small ($countsSize) for $numBins bins to be useful")
-//        counts
-//      } else {
-//        if (grouping >= Int.MaxValue) {
-//          logWarning(
-//            s"Curve too large ($countsSize) for $numBins bins; capping at ${Int.MaxValue}")
-//          grouping = Int.MaxValue
-//        }
-//        counts.mapPartitions(_.grouped(grouping.toInt).map { pairs =>
-//          // The score of the combined point will be just the first one's score
-//          // I THINK WE WANT THE AVERAGE OF SCORE OVER THE BIN HERE
-//          val firstScore = pairs.head._1
-//          // The point will contain all counts in this chunk
-//          val agg = new BinaryLabelCounter()
-//          pairs.foreach(pair => agg += pair._2)
-//          (firstScore, agg)
-//        })
-//      }
-//    }
-//
-//  val agg = binnedCounts.values.mapPartitions { iter =>
-//    val agg = new BinaryLabelCounter()
-//    iter.foreach(agg += _)
-//    Iterator(agg)
-//  }.collect()
-//  val partitionwiseCumulativeCounts =
-//    agg.scanLeft(new BinaryLabelCounter())(
-//      (agg: BinaryLabelCounter, c: BinaryLabelCounter) => agg.clone() += c)
-//  val totalCount = partitionwiseCumulativeCounts.last
-//  logInfo(s"Total counts: $totalCount")
-//  // WE WANT PER-BIN COUNTS HERE, NOT CUMULATIVE
-//  val correctCounts = binnedCounts.mapPartitionsWithIndex(
-//    (index: Int, iter: Iterator[(Double, BinaryLabelCounter)]) => {
-//      val cumCount = partitionwiseCumulativeCounts(index)
-//      iter.map { case (score, c) =>
-//        cumCount += c
-//        (score, cumCount.clone())
-//      }
-//    }, preservesPartitioning = true)
-//  correctCounts.persist()
-//  correctCounts
-    Seq(((0.0, 0.0), (0.0, 0)), ((1.0, 1.0), (1.0, 0)))
+  private lazy val assessedCalibration: RDD[((Double, Double), (Double, Long))] = {
+    val distinctScoresAndLabelCounts = scoreAndLabels.combineByKey(
+      createCombiner = (label: Double) => new BinaryLabelCounter(0L, 0L) += label,
+      mergeValue = (c: BinaryLabelCounter, label: Double) => c += label,
+      mergeCombiners = (c1: BinaryLabelCounter, c2: BinaryLabelCounter) => c1 += c2
+    ).sortByKey(ascending = true)
+  
+    val binnedDistinctScoresAndLabelCounts =
+      if (numBins == 0) {
+        distinctScoresAndLabelCounts.map { pair => ((pair._1, pair._1), pair._2) }
+      } else {
+        val distinctScoresCount = distinctScoresAndLabelCounts.count()
+  
+        var groupCount = distinctScoresCount / numBins
+        if (groupCount < 2) {
+          logInfo(s"Too few distinct scores ($distinctScoresCount) for $numBins bins to be useful")
+          distinctScoresAndLabelCounts.map { pair => ((pair._1, pair._1), pair._2) }
+        } else {
+          if (groupCount >= Int.MaxValue) {
+            val n = distinctScoresCount
+            logWarning(
+              s"Too many distinct scores ($n) for $numBins bins; capping at ${Int.MaxValue}")
+            groupCount = Int.MaxValue
+          }
+          distinctScoresAndLabelCounts.mapPartitions(_.grouped(groupCount.toInt).map { pairs =>
+            val firstScore = pairs.head._1
+            val lastScore = pairs.last._1
+            val agg = new BinaryLabelCounter()
+            pairs.foreach(pair => agg += pair._2)
+            ((firstScore, lastScore), agg)
+          })
+        }
+      }
+  
+    binnedDistinctScoresAndLabelCounts.map { pair =>
+      val n = pair._2.numPositives + pair._2.numNegatives
+      (pair._1, (pair._2.numPositives / n.toDouble, n))
+    }
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetrics.scala
@@ -265,7 +265,14 @@ class BinaryClassificationMetrics @Since("1.3.0") (
       } else {
         val distinctScoresCount = distinctScoresAndLabelCounts.count()
   
-        var groupCount = distinctScoresCount / numBins
+        var groupCount =
+          if (distinctScoresCount % numBins == 0) {
+            distinctScoresCount / numBins
+          } else {
+            // prevent the last bin from being very small compared to the others
+            distinctScoresCount / numBins + 1
+          }
+        
         if (groupCount < 2) {
           logInfo(s"Too few distinct scores ($distinctScoresCount) for $numBins bins to be useful")
           distinctScoresAndLabelCounts.map { pair => ((pair._1, pair._1), pair._2) }

--- a/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
@@ -86,7 +86,8 @@ object MLUtils {
         val indicesLength = indices.length
         while (i < indicesLength) {
           val current = indices(i)
-          require(current > previous, "indices should be one-based and in ascending order; found current=" + current + ", previous=" + previous + "; line=\"" + line + "\"")
+          require(current > previous, s"indices should be one-based and in ascending order;"
+            + " found current=$current, previous=$previous; line=\"$line\"")
           previous = current
           i += 1
         }

--- a/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
@@ -86,7 +86,7 @@ object MLUtils {
         val indicesLength = indices.length
         while (i < indicesLength) {
           val current = indices(i)
-          require(current > previous, "indices should be one-based and in ascending order" )
+          require(current > previous, "indices should be one-based and in ascending order; found current=" + current + ", previous=" + previous + "; line=\"" + line + "\"")
           previous = current
           i += 1
         }

--- a/mllib/src/test/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetricsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetricsSuite.scala
@@ -28,7 +28,8 @@ class BinaryClassificationMetricsSuite extends SparkFunSuite with MLlibTestSpark
   private def pairsWithinEpsilon(x: ((Double, Double), (Double, Double))): Boolean =
     (x._1._1 ~= x._2._1 absTol 1E-5) && (x._1._2 ~= x._2._2 absTol 1E-5)
 
-  private def pairPairsWithinEpsilon(x: (((Double, Double), (Double, Long)), ((Double, Double), (Double, Long)))): Boolean =
+  private def pairPairsWithinEpsilon(x: (((Double, Double), (Double, Long)), ((Double, Double),
+      (Double, Long)))): Boolean =
     (x._1._1._1 ~= x._2._1._1 absTol 1E-5) && (x._1._1._2 ~= x._2._1._2 absTol 1E-5) &&
       (x._1._2._1 ~= x._2._2._1 absTol 1E-5) && x._1._2._2 == x._2._2._2
 
@@ -91,8 +92,8 @@ class BinaryClassificationMetricsSuite extends SparkFunSuite with MLlibTestSpark
     val prCurve = Seq((0.0, 1.0)) ++ pr
     val f1 = pr.map { case (r, p) => 2.0 * (p * r) / (p + r)}
     val f2 = pr.map { case (r, p) => 5.0 * (p * r) / (4.0 * p + r)}
-    val calibration = Seq(((0.1, 0.1), (0.5, 2L)), ((0.4, 0.4), (0.0, 1L)), ((0.6, 0.6), (2/3.0, 3L)),
-      ((0.8, 0.8), (1.0, 1L)))
+    val calibration = Seq(((0.1, 0.1), (0.5, 2L)), ((0.4, 0.4), (0.0, 1L)), ((0.6, 0.6),
+                           (2/3.0, 3L)), ((0.8, 0.8), (1.0, 1L)))
 
     validateMetrics(metrics, thresholds, rocCurve, prCurve, f1, f2, precisions, recalls,
       calibration)
@@ -177,7 +178,8 @@ class BinaryClassificationMetricsSuite extends SparkFunSuite with MLlibTestSpark
       ) ==
       downsampledROC)
 
-    val calibration = Array(((0.1, 0.3), (1/3.0, 3L)), ((0.4, 0.6), (1/3.0, 3L)), ((0.7, 0.9), (2/3.0, 3L)))
+    val calibration = Array(((0.1, 0.3), (1/3.0, 3L)), ((0.4, 0.6), (1/3.0, 3L)), ((0.7, 0.9),
+                             (2/3.0, 3L)))
     assertTupleTupleSequencesMatch(calibration, downsampled.calibration().collect())
   }
 

--- a/mllib/src/test/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetricsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetricsSuite.scala
@@ -28,7 +28,7 @@ class BinaryClassificationMetricsSuite extends SparkFunSuite with MLlibTestSpark
   private def pairsWithinEpsilon(x: ((Double, Double), (Double, Double))): Boolean =
     (x._1._1 ~= x._2._1 absTol 1E-5) && (x._1._2 ~= x._2._2 absTol 1E-5)
 
-  private def pairPairsWithinEpsilon(x: (((Double, Double), (Double, Int)), ((Double, Double), (Double, Int)))): Boolean =
+  private def pairPairsWithinEpsilon(x: (((Double, Double), (Double, Long)), ((Double, Double), (Double, Long)))): Boolean =
     (x._1._1._1 ~= x._2._1._1 absTol 1E-5) && (x._1._1._2 ~= x._2._1._2 absTol 1E-5) &&
       (x._1._2._1 ~= x._2._2._1 absTol 1E-5) && x._1._2._2 == x._2._2._2
 
@@ -41,8 +41,8 @@ class BinaryClassificationMetricsSuite extends SparkFunSuite with MLlibTestSpark
     assert(left.zip(right).forall(pairsWithinEpsilon))
   }
 
-  private def assertTupleTupleSequencesMatch(left: Seq[((Double, Double), (Double, Int))],
-       right: Seq[((Double, Double), (Double, Int))]): Unit = {
+  private def assertTupleTupleSequencesMatch(left: Seq[((Double, Double), (Double, Long))],
+       right: Seq[((Double, Double), (Double, Long))]): Unit = {
     assert(left.zip(right).forall(pairPairsWithinEpsilon))
   }
 
@@ -54,7 +54,7 @@ class BinaryClassificationMetricsSuite extends SparkFunSuite with MLlibTestSpark
       expectedFmeasures2: Seq[Double],
       expectedPrecisions: Seq[Double],
       expectedRecalls: Seq[Double],
-      expectedCalibration: Seq[((Double, Double), (Double, Int))]) = {
+      expectedCalibration: Seq[((Double, Double), (Double, Long))]) = {
 
     assertSequencesMatch(metrics.thresholds().collect(), expectedThresholds)
     assertTupleSequencesMatch(metrics.roc().collect(), expectedROCCurve)
@@ -91,8 +91,8 @@ class BinaryClassificationMetricsSuite extends SparkFunSuite with MLlibTestSpark
     val prCurve = Seq((0.0, 1.0)) ++ pr
     val f1 = pr.map { case (r, p) => 2.0 * (p * r) / (p + r)}
     val f2 = pr.map { case (r, p) => 5.0 * (p * r) / (4.0 * p + r)}
-    val calibration = Seq(((0.1, 0.1), (0.5, 2)), ((0.4, 0.4), (0.0, 1)), ((0.6, 0.6), (2/3.0, 3)),
-      ((0.8, 0.8), (1.0, 1)))
+    val calibration = Seq(((0.1, 0.1), (0.5, 2L)), ((0.4, 0.4), (0.0, 1L)), ((0.6, 0.6), (2/3.0, 3L)),
+      ((0.8, 0.8), (1.0, 1L)))
 
     validateMetrics(metrics, thresholds, rocCurve, prCurve, f1, f2, precisions, recalls,
       calibration)
@@ -111,7 +111,7 @@ class BinaryClassificationMetricsSuite extends SparkFunSuite with MLlibTestSpark
     val prCurve = Seq((0.0, 1.0)) ++ pr
     val f1 = pr.map { case (r, p) => 2.0 * (p * r) / (p + r)}
     val f2 = pr.map { case (r, p) => 5.0 * (p * r) / (4.0 * p + r)}
-    val calibration = Seq(((0.5, 0.5), (1.0, 2)))
+    val calibration = Seq(((0.5, 0.5), (1.0, 2L)))
 
     validateMetrics(metrics, thresholds, rocCurve, prCurve, f1, f2, precisions, recalls,
       calibration)
@@ -137,7 +137,7 @@ class BinaryClassificationMetricsSuite extends SparkFunSuite with MLlibTestSpark
       case (r, p) => 5.0 * (p * r) / (4.0 * p + r)
     }
 
-    val calibration = Seq(((0.5, 0.5), (0.0, 2)))
+    val calibration = Seq(((0.5, 0.5), (0.0, 2L)))
 
     validateMetrics(metrics, thresholds, rocCurve, prCurve, f1, f2, precisions, recalls,
       calibration)
@@ -177,8 +177,8 @@ class BinaryClassificationMetricsSuite extends SparkFunSuite with MLlibTestSpark
       ) ==
       downsampledROC)
 
-    val calibration = Seq(((0.1, 0.2), (0.0, 2)), ((0.3, 0.4), (0.5, 2)), ((0.5, 0.6), (0.5, 2)),
-      ((0.7, 0.9), (2/3.0, 3)))
+    val calibration = Seq(((0.1, 0.2), (0.0, 2L)), ((0.3, 0.4), (0.5, 2L)), ((0.5, 0.6), (0.5, 2L)),
+      ((0.7, 0.9), (2/3.0, 3L)))
     assert(calibration == downsampled.calibration().collect())
   }
 

--- a/mllib/src/test/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetricsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetricsSuite.scala
@@ -177,9 +177,8 @@ class BinaryClassificationMetricsSuite extends SparkFunSuite with MLlibTestSpark
       ) ==
       downsampledROC)
 
-    val calibration = Seq(((0.1, 0.2), (0.0, 2L)), ((0.3, 0.4), (0.5, 2L)), ((0.5, 0.6), (0.5, 2L)),
-      ((0.7, 0.9), (2/3.0, 3L)))
-    assert(calibration == downsampled.calibration().collect())
+    val calibration = Array(((0.1, 0.3), (1/3.0, 3L)), ((0.4, 0.6), (1/3.0, 3L)), ((0.7, 0.9), (2/3.0, 3L)))
+    assertTupleTupleSequencesMatch(calibration, downsampled.calibration().collect())
   }
 
 }

--- a/mllib/src/test/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetricsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetricsSuite.scala
@@ -28,6 +28,10 @@ class BinaryClassificationMetricsSuite extends SparkFunSuite with MLlibTestSpark
   private def pairsWithinEpsilon(x: ((Double, Double), (Double, Double))): Boolean =
     (x._1._1 ~= x._2._1 absTol 1E-5) && (x._1._2 ~= x._2._2 absTol 1E-5)
 
+  private def pairPairsWithinEpsilon(x: (((Double, Double), (Double, Int)), ((Double, Double), (Double, Int)))): Boolean =
+    (x._1._1._1 ~= x._2._1._1 absTol 1E-5) && (x._1._1._2 ~= x._2._1._2 absTol 1E-5) &&
+      (x._1._2._1 ~= x._2._2._1 absTol 1E-5) && x._1._2._2 == x._2._2._2
+
   private def assertSequencesMatch(left: Seq[Double], right: Seq[Double]): Unit = {
       assert(left.zip(right).forall(areWithinEpsilon))
   }
@@ -37,6 +41,11 @@ class BinaryClassificationMetricsSuite extends SparkFunSuite with MLlibTestSpark
     assert(left.zip(right).forall(pairsWithinEpsilon))
   }
 
+  private def assertTupleTupleSequencesMatch(left: Seq[((Double, Double), (Double, Int))],
+       right: Seq[((Double, Double), (Double, Int))]): Unit = {
+    assert(left.zip(right).forall(pairPairsWithinEpsilon))
+  }
+
   private def validateMetrics(metrics: BinaryClassificationMetrics,
       expectedThresholds: Seq[Double],
       expectedROCCurve: Seq[(Double, Double)],
@@ -44,7 +53,8 @@ class BinaryClassificationMetricsSuite extends SparkFunSuite with MLlibTestSpark
       expectedFMeasures1: Seq[Double],
       expectedFmeasures2: Seq[Double],
       expectedPrecisions: Seq[Double],
-      expectedRecalls: Seq[Double]) = {
+      expectedRecalls: Seq[Double],
+      expectedCalibration: Seq[((Double, Double), (Double, Int))]) = {
 
     assertSequencesMatch(metrics.thresholds().collect(), expectedThresholds)
     assertTupleSequencesMatch(metrics.roc().collect(), expectedROCCurve)
@@ -59,6 +69,7 @@ class BinaryClassificationMetricsSuite extends SparkFunSuite with MLlibTestSpark
       expectedThresholds.zip(expectedPrecisions))
     assertTupleSequencesMatch(metrics.recallByThreshold().collect(),
       expectedThresholds.zip(expectedRecalls))
+    assertTupleTupleSequencesMatch(metrics.calibration().collect(), expectedCalibration)
   }
 
   test("binary evaluation metrics") {
@@ -80,8 +91,11 @@ class BinaryClassificationMetricsSuite extends SparkFunSuite with MLlibTestSpark
     val prCurve = Seq((0.0, 1.0)) ++ pr
     val f1 = pr.map { case (r, p) => 2.0 * (p * r) / (p + r)}
     val f2 = pr.map { case (r, p) => 5.0 * (p * r) / (4.0 * p + r)}
+    val calibration = Seq(((0.1, 0.1), (0.5, 2)), ((0.4, 0.4), (0.0, 1)), ((0.6, 0.6), (2/3.0, 3)),
+      ((0.8, 0.8), (1.0, 1)))
 
-    validateMetrics(metrics, thresholds, rocCurve, prCurve, f1, f2, precisions, recalls)
+    validateMetrics(metrics, thresholds, rocCurve, prCurve, f1, f2, precisions, recalls,
+      calibration)
   }
 
   test("binary evaluation metrics for RDD where all examples have positive label") {
@@ -97,8 +111,10 @@ class BinaryClassificationMetricsSuite extends SparkFunSuite with MLlibTestSpark
     val prCurve = Seq((0.0, 1.0)) ++ pr
     val f1 = pr.map { case (r, p) => 2.0 * (p * r) / (p + r)}
     val f2 = pr.map { case (r, p) => 5.0 * (p * r) / (4.0 * p + r)}
+    val calibration = Seq(((0.5, 0.5), (1.0, 2)))
 
-    validateMetrics(metrics, thresholds, rocCurve, prCurve, f1, f2, precisions, recalls)
+    validateMetrics(metrics, thresholds, rocCurve, prCurve, f1, f2, precisions, recalls,
+      calibration)
   }
 
   test("binary evaluation metrics for RDD where all examples have negative label") {
@@ -121,7 +137,10 @@ class BinaryClassificationMetricsSuite extends SparkFunSuite with MLlibTestSpark
       case (r, p) => 5.0 * (p * r) / (4.0 * p + r)
     }
 
-    validateMetrics(metrics, thresholds, rocCurve, prCurve, f1, f2, precisions, recalls)
+    val calibration = Seq(((0.5, 0.5), (0.0, 2)))
+
+    validateMetrics(metrics, thresholds, rocCurve, prCurve, f1, f2, precisions, recalls,
+      calibration)
   }
 
   test("binary evaluation metrics with downsampling") {
@@ -157,6 +176,10 @@ class BinaryClassificationMetricsSuite extends SparkFunSuite with MLlibTestSpark
         (1.0, 1.0), (1.0, 1.0)
       ) ==
       downsampledROC)
+
+    val calibration = Seq(((0.1, 0.2), (0.0, 2)), ((0.3, 0.4), (0.5, 2)), ((0.5, 0.6), (0.5, 2)),
+      ((0.7, 0.9), (2/3.0, 3)))
+    assert(calibration == downsampled.calibration().collect())
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1970,7 +1970,7 @@
               <include>**/*Suite.java</include>
             </includes>
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
-            <argLine>-Xmx3g -Xss4096k -XX:MaxPermSize=${MaxPermGen} -XX:ReservedCodeCacheSize=512m</argLine>
+            <argLine>-Xmx1024M -XX:MaxPermSize=1024M -Xss4M</argLine>
             <environmentVariables>
               <!--
                 Setting SPARK_DIST_CLASSPATH is a simple way to make sure any child processes
@@ -2008,7 +2008,7 @@
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
             <junitxml>.</junitxml>
             <filereports>SparkTestSuite.txt</filereports>
-            <argLine>-ea -Xmx3g -XX:MaxPermSize=${MaxPermGen} -XX:ReservedCodeCacheSize=${CodeCacheSize}</argLine>
+            <argLine>-ea -Xmx1024M -XX:MaxPermSize=1024M -Xss4M</argLine>
             <stderr/>
             <environmentVariables>
               <!--

--- a/pom.xml
+++ b/pom.xml
@@ -1970,7 +1970,7 @@
               <include>**/*Suite.java</include>
             </includes>
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
-            <argLine>-Xmx3g -XX:MaxPermSize=${MaxPermGen} -XX:ReservedCodeCacheSize=512m</argLine>
+            <argLine>-Xmx3g -Xss4096k -XX:MaxPermSize=${MaxPermGen} -XX:ReservedCodeCacheSize=512m</argLine>
             <environmentVariables>
               <!--
                 Setting SPARK_DIST_CLASSPATH is a simple way to make sure any child processes

--- a/pom.xml
+++ b/pom.xml
@@ -1970,7 +1970,7 @@
               <include>**/*Suite.java</include>
             </includes>
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
-            <argLine>-Xmx1024M -XX:MaxPermSize=1024M -Xss4M</argLine>
+            <argLine>-Xmx3g -XX:MaxPermSize=${MaxPermGen} -XX:ReservedCodeCacheSize=512m</argLine>
             <environmentVariables>
               <!--
                 Setting SPARK_DIST_CLASSPATH is a simple way to make sure any child processes
@@ -2008,7 +2008,7 @@
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
             <junitxml>.</junitxml>
             <filereports>SparkTestSuite.txt</filereports>
-            <argLine>-ea -Xmx1024M -XX:MaxPermSize=1024M -Xss4M</argLine>
+            <argLine>-ea -Xmx3g -XX:MaxPermSize=${MaxPermGen} -XX:ReservedCodeCacheSize=${CodeCacheSize}</argLine>
             <stderr/>
             <environmentVariables>
               <!--

--- a/pom.xml
+++ b/pom.xml
@@ -1889,7 +1889,7 @@
               <include>**/*Suite.java</include>
             </includes>
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
-            <argLine>-Xmx1024M -XX:MaxPermSize=1024M -Xss4M</argLine>
+            <argLine>-Xmx3g -XX:MaxPermSize=${MaxPermGen} -XX:ReservedCodeCacheSize=512m</argLine>
             <environmentVariables>
               <!--
                 Setting SPARK_DIST_CLASSPATH is a simple way to make sure any child processes
@@ -1927,7 +1927,7 @@
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
             <junitxml>.</junitxml>
             <filereports>SparkTestSuite.txt</filereports>
-            <argLine>-ea -Xmx1024M -XX:MaxPermSize=1024M -Xss4M</argLine>
+            <argLine>-ea -Xmx3g -XX:MaxPermSize=${MaxPermGen} -XX:ReservedCodeCacheSize=${CodeCacheSize}</argLine>
             <stderr/>
             <environmentVariables>
               <!--

--- a/pom.xml
+++ b/pom.xml
@@ -1889,7 +1889,7 @@
               <include>**/*Suite.java</include>
             </includes>
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
-            <argLine>-Xmx3g -Xss4096k -XX:MaxPermSize=${MaxPermGen} -XX:ReservedCodeCacheSize=512m</argLine>
+            <argLine>-Xmx1024M -XX:MaxPermSize=1024M -Xss4M</argLine>
             <environmentVariables>
               <!--
                 Setting SPARK_DIST_CLASSPATH is a simple way to make sure any child processes
@@ -1927,7 +1927,7 @@
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
             <junitxml>.</junitxml>
             <filereports>SparkTestSuite.txt</filereports>
-            <argLine>-ea -Xmx3g -XX:MaxPermSize=${MaxPermGen} -XX:ReservedCodeCacheSize=${CodeCacheSize}</argLine>
+            <argLine>-ea -Xmx1024M -XX:MaxPermSize=1024M -Xss4M</argLine>
             <stderr/>
             <environmentVariables>
               <!--

--- a/pom.xml
+++ b/pom.xml
@@ -1889,7 +1889,7 @@
               <include>**/*Suite.java</include>
             </includes>
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
-            <argLine>-Xmx3g -XX:MaxPermSize=${MaxPermGen} -XX:ReservedCodeCacheSize=512m</argLine>
+            <argLine>-Xmx3g -Xss4096k -XX:MaxPermSize=${MaxPermGen} -XX:ReservedCodeCacheSize=512m</argLine>
             <environmentVariables>
               <!--
                 Setting SPARK_DIST_CLASSPATH is a simple way to make sure any child processes


### PR DESCRIPTION
This PR is a revised, updated version of the previous ([PR #5025](https://github.com/apache/spark/pull/5025)), which was closed for lack of activity. I have now addressed the comments about coding style, so I'd like to get the ball rolling again. I am opening a new PR as that was requested when the previous PR was closed.

The corresponding issue, [SPARK-6332](https://issues.apache.org/jira/browse/SPARK-6332), is still applicable; the proposed functionality is the same as before.
