### PR TITLE
[SPARK-4628][BUILD] Add a resolver to MiMaBuild.scala for mqttv3(1.0.1).

### DIFF
--- a/project/MimaBuild.scala
+++ b/project/MimaBuild.scala
@@ -99,8 +99,8 @@ object MimaBuild {
     mimaDefaultSettings ++
     Seq(previousArtifact := Some(organization % fullId % previousSparkVersion),
       binaryIssueFilters ++= ignoredABIProblems(sparkHome, version.value),
-      sbt.Keys.resolvers :=
-        Seq("MQTT Repository" at "https://repo.eclipse.org/content/repositories/paho-releases"))
+      sbt.Keys.resolvers +=
+        "MQTT Repository" at "https://repo.eclipse.org/content/repositories/paho-releases")
   }
 
 }

--- a/project/MimaBuild.scala
+++ b/project/MimaBuild.scala
@@ -91,11 +91,16 @@ object MimaBuild {
 
   def mimaSettings(sparkHome: File, projectRef: ProjectRef) = {
     val organization = "org.apache.spark"
+    // The resolvers setting for MQTT Repository is needed for mqttv3(1.0.1)
+    // because spark-streaming-mqtt(1.6.0) depends on it.
+    // Remove the setting on updating previousSparkVersion.
     val previousSparkVersion = "1.6.0"
     val fullId = "spark-" + projectRef.project + "_2.10"
     mimaDefaultSettings ++
     Seq(previousArtifact := Some(organization % fullId % previousSparkVersion),
-      binaryIssueFilters ++= ignoredABIProblems(sparkHome, version.value))
+      binaryIssueFilters ++= ignoredABIProblems(sparkHome, version.value),
+      sbt.Keys.resolvers :=
+        Seq("MQTT Repository" at "https://repo.eclipse.org/content/repositories/paho-releases"))
   }
 
 }


### PR DESCRIPTION
#10659 removed the repository `https://repo.eclipse.org/content/repositories/paho-releases` but it's needed by MiMa because `spark-streaming-mqtt(1.6.0)` depends on `mqttv3(1.0.1)` and it is provided by the removed repository and maven-central provide only `mqttv3(1.0.2)` for now.

Otherwise, if `mqttv3(1.0.1)` is absent from the local repository, dev/mima should fail.

@JoshRosen Do you have any other better idea?
