### PR TITLE
[SPARK-12745] [SQL] Hive Parser: Limit is not supported inside Set Operation

### DIFF
--- a/sql/catalyst/src/main/antlr3/org/apache/spark/sql/catalyst/parser/SparkSqlParser.g
+++ b/sql/catalyst/src/main/antlr3/org/apache/spark/sql/catalyst/parser/SparkSqlParser.g
@@ -651,7 +651,7 @@ import java.util.HashMap;
     return false;
   }
   private CommonTree throwSetOpException() throws RecognitionException {
-    throw new FailedPredicateException(input, "orderByClause clusterByClause distributeByClause sortByClause limitClause can only be applied to the whole union.", "");
+    throw new FailedPredicateException(input, "orderByClause clusterByClause distributeByClause sortByClause can only be applied to the whole union.", "");
   }
   private CommonTree throwColumnNameException() throws RecognitionException {
     throw new FailedPredicateException(input, Arrays.toString(excludedCharForColumnName) + " can not be used in column name in create table statement.", "");
@@ -2250,7 +2250,7 @@ selectStatement[boolean topLevel]
    (set=setOpSelectStatement[$selectStatement.tree, topLevel])?
    -> {set == null}?
       {$selectStatement.tree}
-   -> {o==null && c==null && d==null && sort==null && l==null}?
+   -> {o==null && c==null && d==null && sort==null}?
       {$set.tree}
    -> {throwSetOpException()}
    ;
@@ -2322,8 +2322,9 @@ simpleSelectStatement
    groupByClause?
    havingClause?
    ((window_clause) => window_clause)?
+   ((limitClause) => limitClause)?
    -> ^(TOK_QUERY fromClause? ^(TOK_INSERT ^(TOK_DESTINATION ^(TOK_DIR TOK_TMP_FILE))
-                     selectClause whereClause? groupByClause? havingClause? window_clause?))
+                     selectClause whereClause? groupByClause? havingClause? window_clause? limitClause?))
    ;
 
 selectStatementWithCTE

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystQlSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystQlSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.plans.PlanTest
-import org.apache.spark.sql.catalyst.plans.logical.{Union, Subquery, Project, Limit}
+import org.apache.spark.sql.catalyst.plans.logical.{Limit, Project, Subquery, Union}
 
 class CatalystQlSuite extends PlanTest {
   val parser = new CatalystQl()

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystQlSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystQlSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.catalyst
 
 import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.plans.logical.Limit
 
 class CatalystQlSuite extends PlanTest {
   val parser = new CatalystQl()
@@ -51,9 +52,14 @@ class CatalystQlSuite extends PlanTest {
   }
 
   test("limit clause: a support in set operation") {
-    parser.createPlan("select key from (select * from t1) x limit 1")
-    parser.createPlan("select key from (select * from t1 limit 2) x limit 1")
-    parser.createPlan("select key from ((select * from testData limit 1) " +
+    val plan1 = parser.createPlan("select key from (select * from t1) x limit 1")
+    assert(plan1.collect{ case w: Limit => w }.size === 1)
+
+    val plan2 = parser.createPlan("select key from (select * from t1 limit 2) x limit 1")
+    assert(plan2.collect{ case w: Limit => w }.size === 2)
+
+    val plan3 = parser.createPlan("select key from ((select * from testData limit 1) " +
       "union all (select * from testData limit 1)) x limit 1")
+    assert(plan3.collect{ case w: Limit => w }.size === 3)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystQlSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystQlSuite.scala
@@ -49,4 +49,11 @@ class CatalystQlSuite extends PlanTest {
     parser.createPlan("select sum(product + 1) over (partition by (product + (1)) order by 2) " +
       "from windowData")
   }
+
+  test("limit clause: a support in set operation") {
+    parser.createPlan("select key from (select * from t1) x limit 1")
+    parser.createPlan("select key from (select * from t1 limit 2) x limit 1")
+    parser.createPlan("select key from ((select * from testData limit 1) " +
+      "union all (select * from testData limit 1)) x limit 1")
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystQlSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystQlSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst
 
-import org.apache.spark.sql.catalyst.analysis.{UnresolvedStar, UnresolvedAlias, UnresolvedAttribute, UnresolvedRelation}
+import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical.{Union, Subquery, Project, Limit}


### PR DESCRIPTION
The current SQLContext allows the following query, which is copied from a test case in SQLQuerySuite:

```
     checkAnswer(sql(
       """
         |select key from ((select * from testData limit 1)
         |  union all (select * from testData limit 1)) x limit 1
       """.stripMargin),
       Row(1)
     )
```

However, it is rejected by the Hive parser. 

This PR is to make Hive parser support the Limit Clause inside Set Operator. 
