### PR TITLE
[Spark-12732][ML] bug fix in linear regression train

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -248,8 +248,8 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
       } else {
         logWarning(s"The standard deviation of the label is zero. " +
           "Consider setting fitIntercept=true.")
-        // In this case, the training cannot be done in scaled space.
-        // So setting yStd=1 means that the label will not be scaled anymore and
+        // In this case, the target variable cannot be standardized.
+        // So setting yStd=1 means that the target variable will not be scaled anymore and
         // the training will continue.
         yStd = 1.0
       }

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -221,9 +221,11 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
     val yMean = ySummarizer.mean(0)
     val rawYStd = math.sqrt(ySummarizer.variance(0))
     if (rawYStd == 0.0) {
-      if ($(fitIntercept)) {
+      if ($(fitIntercept) || yMean==0.0) {
         // If the rawYStd is zero and fitIntercept=true, then the intercept is yMean with
         // zero coefficient; as a result, training is not needed.
+        // Also, if yMean==0 and rawYStd==0, all the coefficients are zero regardless of
+        // the fitIntercept
         logWarning(s"The standard deviation of the label is zero, so the coefficients will be " +
           s"zeros and the intercept will be the mean of the label; as a result, " +
           s"training is not needed.")
@@ -245,9 +247,8 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
           Array(0D))
         return copyValues(model.setSummary(trainingSummary))
       } else {
-        require(!($(regParam) > 0.0 && $(standardization)),
-          "The standard deviation of the label is zero. " +
-            "Model cannot be regularized with standardization=true")
+        require($(regParam) == 0.0, "The standard deviation of the label is zero. " +
+          "Model cannot be regularized.")
         logWarning(s"The standard deviation of the label is zero. " +
           "Consider setting fitIntercept=true.")
       }
@@ -255,7 +256,7 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
 
     // if y is constant (rawYStd is zero), then y cannot be scaled. In this case
     // setting yStd=1.0 ensures that y is not scaled anymore in l-bfgs algorithm.
-    val yStd = if (rawYStd > 0) rawYStd else 1.0
+    val yStd = if (rawYStd > 0) rawYStd else if (yMean != 0.0) math.abs(yMean) else 1.0
     val featuresMean = featuresSummarizer.mean.toArray
     val featuresStd = featuresSummarizer.variance.toArray.map(math.sqrt)
 

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -74,7 +74,8 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
   /**
    * Set the regularization parameter.
    * Default is 0.0.
-   * @group setParam
+    *
+    * @group setParam
    */
   @Since("1.3.0")
   def setRegParam(value: Double): this.type = set(regParam, value)
@@ -83,7 +84,8 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
   /**
    * Set if we should fit the intercept
    * Default is true.
-   * @group setParam
+    *
+    * @group setParam
    */
   @Since("1.5.0")
   def setFitIntercept(value: Boolean): this.type = set(fitIntercept, value)
@@ -96,7 +98,8 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
    * the models should be always converged to the same solution when no regularization
    * is applied. In R's GLMNET package, the default behavior is true as well.
    * Default is true.
-   * @group setParam
+    *
+    * @group setParam
    */
   @Since("1.5.0")
   def setStandardization(value: Boolean): this.type = set(standardization, value)
@@ -107,7 +110,8 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
    * For alpha = 0, the penalty is an L2 penalty. For alpha = 1, it is an L1 penalty.
    * For 0 < alpha < 1, the penalty is a combination of L1 and L2.
    * Default is 0.0 which is an L2 penalty.
-   * @group setParam
+    *
+    * @group setParam
    */
   @Since("1.4.0")
   def setElasticNetParam(value: Double): this.type = set(elasticNetParam, value)
@@ -116,7 +120,8 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
   /**
    * Set the maximum number of iterations.
    * Default is 100.
-   * @group setParam
+    *
+    * @group setParam
    */
   @Since("1.3.0")
   def setMaxIter(value: Int): this.type = set(maxIter, value)
@@ -126,7 +131,8 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
    * Set the convergence tolerance of iterations.
    * Smaller value will lead to higher accuracy with the cost of more iterations.
    * Default is 1E-6.
-   * @group setParam
+    *
+    * @group setParam
    */
   @Since("1.4.0")
   def setTol(value: Double): this.type = set(tol, value)
@@ -136,7 +142,8 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
    * Whether to over-/under-sample training instances according to the given weights in weightCol.
    * If empty, all instances are treated equally (weight 1.0).
    * Default is empty, so all instances have weight one.
-   * @group setParam
+    *
+    * @group setParam
    */
   @Since("1.6.0")
   def setWeightCol(value: String): this.type = set(weightCol, value)
@@ -150,7 +157,8 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
    * solution to the linear regression problem.
    * The default value is "auto" which means that the solver algorithm is
    * selected automatically.
-   * @group setParam
+    *
+    * @group setParam
    */
   @Since("1.6.0")
   def setSolver(value: String): this.type = set(solver, value)
@@ -226,9 +234,14 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
         // zero coefficient; as a result, training is not needed.
         // Also, if yMean==0 and rawYStd==0, all the coefficients are zero regardless of
         // the fitIntercept
-        logWarning(s"The standard deviation of the label is zero, so the coefficients will be " +
-          s"zeros and the intercept will be the mean of the label; as a result, " +
-          s"training is not needed.")
+        if (yMean == 0.0) {
+          logWarning(s"Mean and standard deviation of the label are zero, so the coefficients " +
+            s"and the intercept will all be zero; as a result, training is not needed.")
+        } else {
+          logWarning(s"The standard deviation of the label is zero, so the coefficients will be " +
+            s"zeros and the intercept will be the mean of the label; as a result, " +
+            s"training is not needed.")
+        }
         if (handlePersistence) instances.unpersist()
         val coefficients = Vectors.sparse(numFeatures, Seq())
         val intercept = yMean
@@ -256,7 +269,7 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
 
     // if y is constant (rawYStd is zero), then y cannot be scaled. In this case
     // setting yStd=1.0 ensures that y is not scaled anymore in l-bfgs algorithm.
-    val yStd = if (rawYStd > 0) rawYStd else if (yMean != 0.0) math.abs(yMean) else 1.0
+    val yStd = if (rawYStd > 0) rawYStd else math.abs(yMean)
     val featuresMean = featuresSummarizer.mean.toArray
     val featuresStd = featuresSummarizer.variance.toArray.map(math.sqrt)
 
@@ -409,7 +422,8 @@ class LinearRegressionModel private[ml] (
 
   /**
    * Evaluates the model on a testset.
-   * @param dataset Test dataset to evaluate model on.
+    *
+    * @param dataset Test dataset to evaluate model on.
    */
   // TODO: decide on a good name before exposing to public API
   private[regression] def evaluate(dataset: DataFrame): LinearRegressionSummary = {
@@ -507,7 +521,8 @@ object LinearRegressionModel extends MLReadable[LinearRegressionModel] {
  * :: Experimental ::
  * Linear regression training results. Currently, the training summary ignores the
  * training coefficients except for the objective trace.
- * @param predictions predictions outputted by the model's `transform` method.
+  *
+  * @param predictions predictions outputted by the model's `transform` method.
  * @param objectiveHistory objective function (scaled loss + regularization) at each iteration.
  */
 @Since("1.5.0")
@@ -531,7 +546,8 @@ class LinearRegressionTrainingSummary private[regression] (
 /**
  * :: Experimental ::
  * Linear regression results evaluated on a dataset.
- * @param predictions predictions outputted by the model's `transform` method.
+  *
+  * @param predictions predictions outputted by the model's `transform` method.
  */
 @Since("1.5.0")
 @Experimental

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -74,8 +74,7 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
   /**
    * Set the regularization parameter.
    * Default is 0.0.
-    *
-    * @group setParam
+   * @group setParam
    */
   @Since("1.3.0")
   def setRegParam(value: Double): this.type = set(regParam, value)
@@ -84,8 +83,7 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
   /**
    * Set if we should fit the intercept
    * Default is true.
-    *
-    * @group setParam
+   * @group setParam
    */
   @Since("1.5.0")
   def setFitIntercept(value: Boolean): this.type = set(fitIntercept, value)
@@ -98,8 +96,7 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
    * the models should be always converged to the same solution when no regularization
    * is applied. In R's GLMNET package, the default behavior is true as well.
    * Default is true.
-    *
-    * @group setParam
+   * @group setParam
    */
   @Since("1.5.0")
   def setStandardization(value: Boolean): this.type = set(standardization, value)
@@ -110,8 +107,7 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
    * For alpha = 0, the penalty is an L2 penalty. For alpha = 1, it is an L1 penalty.
    * For 0 < alpha < 1, the penalty is a combination of L1 and L2.
    * Default is 0.0 which is an L2 penalty.
-    *
-    * @group setParam
+   * @group setParam
    */
   @Since("1.4.0")
   def setElasticNetParam(value: Double): this.type = set(elasticNetParam, value)
@@ -120,8 +116,7 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
   /**
    * Set the maximum number of iterations.
    * Default is 100.
-    *
-    * @group setParam
+   * @group setParam
    */
   @Since("1.3.0")
   def setMaxIter(value: Int): this.type = set(maxIter, value)
@@ -131,8 +126,7 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
    * Set the convergence tolerance of iterations.
    * Smaller value will lead to higher accuracy with the cost of more iterations.
    * Default is 1E-6.
-    *
-    * @group setParam
+   * @group setParam
    */
   @Since("1.4.0")
   def setTol(value: Double): this.type = set(tol, value)
@@ -142,8 +136,7 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
    * Whether to over-/under-sample training instances according to the given weights in weightCol.
    * If empty, all instances are treated equally (weight 1.0).
    * Default is empty, so all instances have weight one.
-    *
-    * @group setParam
+   * @group setParam
    */
   @Since("1.6.0")
   def setWeightCol(value: String): this.type = set(weightCol, value)
@@ -157,8 +150,7 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
    * solution to the linear regression problem.
    * The default value is "auto" which means that the solver algorithm is
    * selected automatically.
-    *
-    * @group setParam
+   * @group setParam
    */
   @Since("1.6.0")
   def setSolver(value: String): this.type = set(solver, value)
@@ -422,8 +414,7 @@ class LinearRegressionModel private[ml] (
 
   /**
    * Evaluates the model on a testset.
-    *
-    * @param dataset Test dataset to evaluate model on.
+   * @param dataset Test dataset to evaluate model on.
    */
   // TODO: decide on a good name before exposing to public API
   private[regression] def evaluate(dataset: DataFrame): LinearRegressionSummary = {
@@ -521,8 +512,7 @@ object LinearRegressionModel extends MLReadable[LinearRegressionModel] {
  * :: Experimental ::
  * Linear regression training results. Currently, the training summary ignores the
  * training coefficients except for the objective trace.
-  *
-  * @param predictions predictions outputted by the model's `transform` method.
+ * @param predictions predictions outputted by the model's `transform` method.
  * @param objectiveHistory objective function (scaled loss + regularization) at each iteration.
  */
 @Since("1.5.0")
@@ -546,8 +536,7 @@ class LinearRegressionTrainingSummary private[regression] (
 /**
  * :: Experimental ::
  * Linear regression results evaluated on a dataset.
-  *
-  * @param predictions predictions outputted by the model's `transform` method.
+ * @param predictions predictions outputted by the model's `transform` method.
  */
 @Since("1.5.0")
 @Experimental

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
@@ -100,7 +100,7 @@ class LinearRegressionSuite
        A <- matrix(c(0, 1, 2, 3, 5, 7, 11, 13), 4, 2)
        b <- c(17, 17, 17, 17)
        w <- c(1, 2, 3, 4)
-       df <- as.data.frame(cbind(A, b))
+       df.const.label <- as.data.frame(cbind(A, b))
      */
     datasetWithWeightConstantLabel = sqlContext.createDataFrame(
       sc.parallelize(Seq(
@@ -578,10 +578,8 @@ class LinearRegressionSuite
   test("linear regression model with constant label") {
     /*
        R code:
-       # here b is constant
-       df <- as.data.frame(cbind(A, b))
        for (formula in c(b ~ . -1, b ~ .)) {
-         model <- lm(formula, data=df, weights=w)
+         model <- lm(formula, data=df.const.label, weights=w)
          print(as.vector(coef(model)))
        }
       [1] -9.221298  3.394343
@@ -593,7 +591,10 @@ class LinearRegressionSuite
 
     var idx = 0
     for (fitIntercept <- Seq(false, true)) {
-      val model = new LinearRegression().setFitIntercept(fitIntercept).setSolver("l-bfgs")
+      val model = new LinearRegression()
+        .setFitIntercept(fitIntercept)
+        .setWeightCol("weight")
+        .setSolver("l-bfgs")
         .fit(datasetWithWeightConstantLabel)
       val actual = Vectors.dense(model.intercept, model.coefficients(0), model.coefficients(1))
       assert(actual ~== expected(idx) absTol 1e-4)

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
@@ -605,13 +605,15 @@ class LinearRegressionSuite
   }
 
   test("regularized linear regression through origin with constant label") {
-    // The problem is ill-defined if fitIntercept=false, regParam is non-zero and \
+    // The problem is ill-defined if fitIntercept=false, regParam is non-zero and
     // standardization=true. An exception is thrown in this case.
     Seq("auto", "l-bfgs", "normal").foreach { solver =>
-      val model = new LinearRegression()
-        .setFitIntercept(false).setRegParam(0.1).setStandardization(true).setSolver(solver)
-      intercept[IllegalArgumentException] {
-        model.fit(datasetWithWeightConstantLabel)
+      for (standardization <- Seq(false, true)) {
+        val model = new LinearRegression().setFitIntercept(false)
+          .setRegParam(0.1).setStandardization(standardization).setSolver(solver)
+        intercept[IllegalArgumentException] {
+          model.fit(datasetWithWeightConstantLabel)
+        }
       }
     }
   }

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
@@ -38,6 +38,7 @@ class LinearRegressionSuite
   @transient var datasetWithSparseFeature: DataFrame = _
   @transient var datasetWithWeight: DataFrame = _
   @transient var datasetWithWeightConstantLabel: DataFrame = _
+  @transient var datasetWithWeightZeroLabel: DataFrame = _
 
   /*
      In `LinearRegressionSuite`, we will make sure that the model trained by SparkML
@@ -108,6 +109,13 @@ class LinearRegressionSuite
         Instance(17.0, 2.0, Vectors.dense(1.0, 7.0)),
         Instance(17.0, 3.0, Vectors.dense(2.0, 11.0)),
         Instance(17.0, 4.0, Vectors.dense(3.0, 13.0))
+      ), 2))
+    datasetWithWeightZeroLabel = sqlContext.createDataFrame(
+      sc.parallelize(Seq(
+        Instance(0.0, 1.0, Vectors.dense(0.0, 5.0).toSparse),
+        Instance(0.0, 2.0, Vectors.dense(1.0, 7.0)),
+        Instance(0.0, 3.0, Vectors.dense(2.0, 11.0)),
+        Instance(0.0, 4.0, Vectors.dense(3.0, 13.0))
       ), 2))
   }
 
@@ -592,21 +600,31 @@ class LinearRegressionSuite
     Seq("auto", "l-bfgs", "normal").foreach { solver =>
       var idx = 0
       for (fitIntercept <- Seq(false, true)) {
-        val model = new LinearRegression()
+        val model1 = new LinearRegression()
           .setFitIntercept(fitIntercept)
           .setWeightCol("weight")
           .setSolver(solver)
           .fit(datasetWithWeightConstantLabel)
-        val actual = Vectors.dense(model.intercept, model.coefficients(0), model.coefficients(1))
-        assert(actual ~== expected(idx) absTol 1e-4)
+        val actual1 = Vectors.dense(model1.intercept, model1.coefficients(0),
+            model1.coefficients(1))
+        assert(actual1 ~== expected(idx) absTol 1e-4)
+
+        val model2 = new LinearRegression()
+          .setFitIntercept(fitIntercept)
+          .setWeightCol("weight")
+          .setSolver(solver)
+          .fit(datasetWithWeightZeroLabel)
+        val actual2 = Vectors.dense(model2.intercept, model2.coefficients(0),
+            model2.coefficients(1))
+        assert(actual2 ~==  Vectors.dense(0.0, 0.0, 0.0) absTol 1e-4)
         idx += 1
       }
     }
   }
 
   test("regularized linear regression through origin with constant label") {
-    // The problem is ill-defined if fitIntercept=false, regParam is non-zero and
-    // standardization=true. An exception is thrown in this case.
+    // The problem is ill-defined if fitIntercept=false, regParam is non-zero.
+    // An exception is thrown in this case.
     Seq("auto", "l-bfgs", "normal").foreach { solver =>
       for (standardization <- Seq(false, true)) {
         val model = new LinearRegression().setFitIntercept(false)
@@ -614,6 +632,33 @@ class LinearRegressionSuite
         intercept[IllegalArgumentException] {
           model.fit(datasetWithWeightConstantLabel)
         }
+      }
+    }
+  }
+
+  test("linear regression with l-bfgs when training is not needed") {
+    // When label is constant, l-bfgs solver returns results without training.
+    // There are two possibilities: If the label is non-zero but constant,
+    // and fitIntercept is true, then the model return yMean as intercept without training.
+    // If label is all zeros, then all coefficients are zero regardless of fitIntercept, so
+    // no training is needed.
+    for (fitIntercept <- Seq(false, true)) {
+      for (standardization <- Seq(false, true)) {
+        val model1 = new LinearRegression()
+          .setFitIntercept(fitIntercept)
+          .setStandardization(standardization)
+          .setWeightCol("weight")
+          .setSolver("l-bfgs")
+          .fit(datasetWithWeightConstantLabel)
+        if (fitIntercept) {
+          assert(model1.summary.objectiveHistory(0) ~== 0.0 absTol 1e-4)
+        }
+        val model2 = new LinearRegression()
+          .setFitIntercept(fitIntercept)
+          .setWeightCol("weight")
+          .setSolver("l-bfgs")
+          .fit(datasetWithWeightZeroLabel)
+        assert(model2.summary.objectiveHistory(0) ~== 0.0 absTol 1e-4)
       }
     }
   }


### PR DESCRIPTION
Fixed the bug in linear regression train for the case when the target variable is constant. The two cases for `fitIntercept=true` or `fitIntercept=false` should be treated differently.
