### PR TITLE
[pyspark] adding disjunction and difference functions for rdds

### DIFF
--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -1926,6 +1926,36 @@ class RDD(object):
         """
         return python_cogroup((self, other), numPartitions)
 
+    def disjunction(self, other, numPartitions=None):
+      """
+      For each key-value pair in C{self} and C{other}, return a resulting RDD that
+      contains the values which are not both in C{self} and C{other}.
+
+      >>> x = sc.parallelize([("a", 1), ("b", 4)])
+      >>> y = sc.parallelize([("a", 2), ("d", 5)])
+      >>> x.disjunction(y).collect()
+      [('b', 4), ('d', 5)]
+      """
+      return self.map(lambda v: (v, None)) \
+          .cogroup(other.map(lambda v: (v, None))) \
+          .filter(lambda k_vs: not all(k_vs[1])) \
+          .keys()
+
+    def difference(self, other, numPartitions=None):
+      """
+      For each key-value pair in C{self}, return a resulting RDD that
+      contains all key-value pairs for which the key does not exist in C{other}.
+
+      >>> x = sc.parallelize([("a", 1), ("b", 4)])
+      >>> y = sc.parallelize([("a", 2)])
+      >>> x.difference(y).collect()
+      [('a', 1)]
+      """
+      return self.map(lambda v: (v, None)) \
+          .cogroup(other.map(lambda v: (v, None))) \
+          .filter(lambda k_vs: not len(k_vs[1][1])) \
+          .keys()
+
     def sampleByKey(self, withReplacement, fractions, seed=None):
         """
         Return a subset of this RDD sampled by key (via stratified sampling).

--- a/python/pyspark/streaming/dstream.py
+++ b/python/pyspark/streaming/dstream.py
@@ -349,6 +349,24 @@ class DStream(object):
             numPartitions = self._sc.defaultParallelism
         return self.transformWith(lambda a, b: a.cogroup(b, numPartitions), other)
 
+    def disjunction(self, other, numPartitions=None):
+        """
+        Returns a new DStream by applying 'disjunction' between RDDs of this
+        DStream and `other` DStream.
+        """
+        if numPartitions is None:
+            numPartitions = self._sc.defaultParallelism
+        return self.transformWith(lambda a, b: a.disjunction(b, numPartitions), other)
+
+    def difference(self, other, numPartitions=None):
+        """
+        Returns a new DStream by applying 'difference' between RDDs of this
+        DStream and `other` DStream.
+        """
+        if numPartitions is None:
+            numPartitions = self._sc.defaultParallelism
+        return self.transformWith(lambda a, b: a.difference(b, numPartitions), other)
+
     def join(self, other, numPartitions=None):
         """
         Return a new DStream by applying 'join' between RDDs of this DStream and

--- a/python/pyspark/streaming/tests.py
+++ b/python/pyspark/streaming/tests.py
@@ -348,6 +348,26 @@ class BasicOperationTests(PySparkStreamingTestCase):
                     [("a", ([1, 1], [1, 1])), ("b", ([1], [1])), ("", ([1, 1], [1, 2]))]]
         self._test_func(input, func, expected, sort=True, input2=input2)
 
+    def test_disjunction(self):
+        input = [[(1, 1), (2, 1), (3, 1)]]
+        input2 = [[(1, 1), (3, 1), (4, 1)]]
+
+        def func(d1, d2):
+            return d1.disjunction(d2)
+
+        expected = [[(2, 1), (4, 1)]]
+        self._test_func(input, func, expected, True, input2)
+
+    def test_difference(self):
+        input = [[(1, 1), (2, 1), (3, 1)]]
+        input2 = [[(1, 1), (3, 1), (4, 1)]]
+
+        def func(d1, d2):
+            return d1.difference(d2)
+
+        expected = [[(2, 1)]]
+        self._test_func(input, func, expected, True, input2)
+
     def test_join(self):
         input = [[('a', 1), ('b', 2)]]
         input2 = [[('b', 3), ('c', 4)]]


### PR DESCRIPTION
I was looking for a way to perform disjunction and difference operations, in other words:
- disjunction: find all elements NOT in A and B 
- difference: find all elements in A but NOT in B

If there are better names for these functions, I'd be happy to change them.  I am a pyspark user so they are only in the python code.  I would love having them in Scala and Java too.
