### PR TITLE
SPARK-12778 Use of Java Unsafe should take endianness into account

### DIFF
--- a/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
+++ b/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
@@ -18,6 +18,7 @@
 package org.apache.spark.unsafe;
 
 import java.lang.reflect.Field;
+import java.nio.ByteOrder;
 
 import sun.misc.Unsafe;
 
@@ -33,11 +34,21 @@ public final class Platform {
 
   public static final int DOUBLE_ARRAY_OFFSET;
 
+  static final boolean littleEndian = ByteOrder.nativeOrder()
+      .equals(ByteOrder.LITTLE_ENDIAN);
+
+
   public static int getInt(Object object, long offset) {
+    if (littleEndian) {
+      return Integer.reverseBytes(_UNSAFE.getInt(object, offset));
+    }
     return _UNSAFE.getInt(object, offset);
   }
 
   public static void putInt(Object object, long offset, int value) {
+    if (littleEndian) {
+      value = Integer.reverseBytes(value);
+    }
     _UNSAFE.putInt(object, offset, value);
   }
 
@@ -58,18 +69,30 @@ public final class Platform {
   }
 
   public static short getShort(Object object, long offset) {
+    if (littleEndian) {
+      return Short.reverseBytes(_UNSAFE.getShort(object, offset));
+    }
     return _UNSAFE.getShort(object, offset);
   }
 
   public static void putShort(Object object, long offset, short value) {
+    if (littleEndian) {
+      value = Short.reverseBytes(value);
+    }
     _UNSAFE.putShort(object, offset, value);
   }
 
   public static long getLong(Object object, long offset) {
+    if (littleEndian) {
+      return Long.reverseBytes(_UNSAFE.getLong(object, offset));
+    }
     return _UNSAFE.getLong(object, offset);
   }
 
   public static void putLong(Object object, long offset, long value) {
+    if (littleEndian) {
+      value = Long.reverseBytes(value);
+    }
     _UNSAFE.putLong(object, offset, value);
   }
 


### PR DESCRIPTION
In Platform.java, methods of Java Unsafe are called directly without considering endianness.

In thread, 'Tungsten in a mixed endian environment', Adam Roberts reported data corruption when "spark.sql.tungsten.enabled" is enabled in mixed endian environment.

Platform.java should take endianness into account.

Here is link to the thread:
http://search-hadoop.com/m/q3RTtT49Gb28IS4c1
