### PR TITLE
[SPARK-12711][ML] ML StopWordsRemover does not protect itself from column name duplication

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StopWordsRemover.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StopWordsRemover.scala
@@ -149,9 +149,7 @@ class StopWordsRemover(override val uid: String)
     val inputType = schema($(inputCol)).dataType
     require(inputType.sameType(ArrayType(StringType)),
       s"Input type must be ArrayType(StringType) but got $inputType.")
-    val outputFields = schema.fields :+
-      StructField($(outputCol), inputType, schema($(inputCol)).nullable)
-    StructType(outputFields)
+    SchemaUtils.appendColumn(schema, $(outputCol), inputType, schema($(inputCol)).nullable)
   }
 
   override def copy(extra: ParamMap): StopWordsRemover = defaultCopy(extra)

--- a/mllib/src/main/scala/org/apache/spark/ml/util/SchemaUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/SchemaUtils.scala
@@ -54,12 +54,10 @@ private[spark] object SchemaUtils {
   def appendColumn(
       schema: StructType,
       colName: String,
-      dataType: DataType): StructType = {
+      dataType: DataType,
+      nullable: Boolean = false): StructType = {
     if (colName.isEmpty) return schema
-    val fieldNames = schema.fieldNames
-    require(!fieldNames.contains(colName), s"Column $colName already exists.")
-    val outputFields = schema.fields :+ StructField(colName, dataType, nullable = false)
-    StructType(outputFields)
+    appendColumn(schema, StructField(colName, dataType, nullable))
   }
 
   /**

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/StopWordsRemoverSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/StopWordsRemoverSuite.scala
@@ -91,20 +91,18 @@ class StopWordsRemoverSuite
   }
 
   test("StopWordsRemover output column already exists") {
-    val outpuCol = "expected"
+    val outputCol = "expected"
     val remover = new StopWordsRemover()
       .setInputCol("raw")
-      .setOutputCol(outpuCol)
-      .setCaseSensitive(true)
+      .setOutputCol(outputCol)
     val dataSet = sqlContext.createDataFrame(Seq(
-      (Seq("A"), Seq("A")),
-      (Seq("The", "the"), Seq("The"))
-    )).toDF("raw", outpuCol)
+      (Seq("A"), Seq()),
+      (Seq("The", "the"), Seq())
+    )).toDF("raw", outputCol)
 
     val thrown = intercept[IllegalArgumentException] {
       testStopWordsRemover(remover, dataSet)
     }
-    assert(thrown.getClass === classOf[IllegalArgumentException])
-    assert(thrown.getMessage == s"requirement failed: Column ${outpuCol} already exists.")
+    assert(thrown.getMessage == s"requirement failed: Column $outputCol already exists.")
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/StopWordsRemoverSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/StopWordsRemoverSuite.scala
@@ -89,4 +89,22 @@ class StopWordsRemoverSuite
       .setCaseSensitive(true)
     testDefaultReadWrite(t)
   }
+
+  test("StopWordsRemover output column already exists") {
+    val outpuCol = "expected"
+    val remover = new StopWordsRemover()
+      .setInputCol("raw")
+      .setOutputCol(outpuCol)
+      .setCaseSensitive(true)
+    val dataSet = sqlContext.createDataFrame(Seq(
+      (Seq("A"), Seq("A")),
+      (Seq("The", "the"), Seq("The"))
+    )).toDF("raw", outpuCol)
+
+    val thrown = intercept[IllegalArgumentException] {
+      testStopWordsRemover(remover, dataSet)
+    }
+    assert(thrown.getClass === classOf[IllegalArgumentException])
+    assert(thrown.getMessage == s"requirement failed: Column ${outpuCol} already exists.")
+  }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/StopWordsRemoverSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/StopWordsRemoverSuite.scala
@@ -96,8 +96,7 @@ class StopWordsRemoverSuite
       .setInputCol("raw")
       .setOutputCol(outputCol)
     val dataSet = sqlContext.createDataFrame(Seq(
-      (Seq("A"), Seq()),
-      (Seq("The", "the"), Seq())
+      (Seq("The", "the", "swift"), Seq("swift"))
     )).toDF("raw", outputCol)
 
     val thrown = intercept[IllegalArgumentException] {


### PR DESCRIPTION
Fixes problem and verifies fix by test suite.
Also - adds optional parameter: nullable (Boolean) to: SchemaUtils.appendColumn
and deduplicates SchemaUtils.appendColumn functions.
