### PR TITLE
[SPARK-12821][BUILD]Style checker should run when some configuration files for style are modified but any source files are not.

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -529,9 +529,14 @@ def main():
     run_apache_rat_checks()
 
     # style checks
-    if not changed_files or any(f.endswith(".scala") for f in changed_files):
+    if not changed_files or any(f.endswith(".scala")
+                                or f.endswith("scalastyle-config.xml")
+                                for f in changed_files):
         run_scala_style_checks()
-    if not changed_files or any(f.endswith(".java") for f in changed_files):
+    if not changed_files or any(f.endswith(".java")
+                                or f.endswith("checkstyle.xml")
+                                or f.endswith("checkstyle-suppressions.xml")
+                                for f in changed_files):
         # run_java_style_checks()
         pass
     if not changed_files or any(f.endswith(".py") for f in changed_files):


### PR DESCRIPTION
When running the `run-tests` script, style checkers run only when any source files are modified but they should run when configuration files related to style are modified.
