### PR TITLE
[SPARK-12829] Turn Java style checker on

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -537,8 +537,7 @@ def main():
                                 or f.endswith("checkstyle.xml")
                                 or f.endswith("checkstyle-suppressions.xml")
                                 for f in changed_files):
-        # run_java_style_checks()
-        pass
+        run_java_style_checks()
     if not changed_files or any(f.endswith(".py") for f in changed_files):
         run_python_style_checks()
     if not changed_files or any(f.endswith(".R") for f in changed_files):


### PR DESCRIPTION
It was previously turned off because there was a problem with a pull request. We should turn it on now.
