### PR TITLE
[SPARK-12836][CORE] Fix spark enable both driver run executor & write…

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
@@ -133,7 +133,7 @@ private[spark] class CoarseMesosSchedulerBackend(
     val driver = createSchedulerDriver(
       master,
       CoarseMesosSchedulerBackend.this,
-      sc.sparkUser,
+      conf.get("spark.executor.start.user", sc.sparkUser),
       sc.appName,
       sc.conf,
       sc.ui.map(_.appUIAddress))


### PR DESCRIPTION
… to HDFS

when spark set env HADOOP_USER_NAME CoarseMesosSchedulerBackend will set sparkuser from this env, but in my cluster run spark must be root, write HDFS must set HADOOP_USER_NAME, need a configuration set run executor by root & write hdfs by another.
