### PR TITLE
[SPARK-12834] Change ser/de of JavaArray and JavaList

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/api/python/PythonMLLibAPI.scala
@@ -1473,7 +1473,11 @@ private[spark] object SerDe extends Serializable {
   initialize()
 
   def dumps(obj: AnyRef): Array[Byte] = {
-    new Pickler().dumps(obj)
+    obj match {
+      // Pickler in Python side cannot deserialize Scala Array normally. See SPARK-12834.
+      case array: Array[_] => new Pickler().dumps(array.toSeq.asJava)
+      case _ => new Pickler().dumps(obj)
+    }
   }
 
   def loads(bytes: Array[Byte]): AnyRef = {

--- a/python/pyspark/mllib/common.py
+++ b/python/pyspark/mllib/common.py
@@ -107,10 +107,7 @@ def _java2py(sc, r, encoding="bytes"):
         if clsName in _picklable_classes:
             r = sc._jvm.SerDe.dumps(r)
         elif isinstance(r, (JavaArray, JavaList)):
-            try:
-                r = sc._jvm.SerDe.dumps(r)
-            except Py4JJavaError:
-                pass  # not pickable
+            r = list(r)
 
     if isinstance(r, (bytearray, bytes)):
         r = PickleSerializer().loads(bytes(r), encoding=encoding)

--- a/python/pyspark/mllib/common.py
+++ b/python/pyspark/mllib/common.py
@@ -107,7 +107,10 @@ def _java2py(sc, r, encoding="bytes"):
         if clsName in _picklable_classes:
             r = sc._jvm.SerDe.dumps(r)
         elif isinstance(r, (JavaArray, JavaList)):
-            r = list(r)
+            try:
+                r = sc._jvm.SerDe.dumps(r)
+            except Py4JJavaError:
+                pass  # not pickable
 
     if isinstance(r, (bytearray, bytes)):
         r = PickleSerializer().loads(bytes(r), encoding=encoding)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-12834

We use `SerDe.dumps()` to serialize `JavaArray` and `JavaList` in `PythonMLLibAPI`, then deserialize them with `PickleSerializer` in Python side. However, there is no need to transform them in such an inefficient way. Instead of it, we can use type conversion to convert them, e.g. `list(JavaArray)` or `list(JavaList)`. What's more, there is an issue to Ser/De Scala Array as I said in https://issues.apache.org/jira/browse/SPARK-12780
