### PR TITLE
https://issues.apache.org/jira/browse/SPARK-12838

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -276,6 +276,7 @@ private[spark] class PythonRunner(
         // Serialized command:
         dataOut.writeInt(command.length)
         dataOut.write(command)
+		dataOut.flush()
         // Data values
         PythonRDD.writeIteratorToStream(inputIterator, dataOut)
         dataOut.writeInt(SpecialLengths.END_OF_DATA_SECTION)


### PR DESCRIPTION
there is a bug in PythonRDD.scala to cause a  time  gap betweeen  worker.py and PythonRdd.scala because the socket can't send the command's length and command in time.  if modified, the gap disappears and I did some experiments to validate it .
