### PR TITLE
[SPARK-12860][SQL] speed up safe projection for primitive types

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -495,7 +495,6 @@ abstract class GeneratedClass {
 abstract class CodeGenerator[InType <: AnyRef, OutType <: AnyRef] extends Logging {
 
   protected val genericMutableRowType: String = classOf[GenericMutableRow].getName
-  protected val specificMutableRowType: String = classOf[SpecificMutableRow].getName
 
   /**
    * Generates a class for a given input expression.  Called when there is not cached code

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -475,6 +475,7 @@ abstract class GeneratedClass {
 abstract class CodeGenerator[InType <: AnyRef, OutType <: AnyRef] extends Logging {
 
   protected val genericMutableRowType: String = classOf[GenericMutableRow].getName
+  protected val specificMutableRowType: String = classOf[SpecificMutableRow].getName
 
   protected def declareMutableStates(ctx: CodegenContext): String = {
     ctx.mutableStates.map { case (javaType, variableName, _) =>


### PR DESCRIPTION
The idea is simple, use `SpecificMutableRow` instead of `GenericMutableRow` as result row for safe projection.

A simple benchmark shows about 1.5x speed up for primitive types, code: https://gist.github.com/cloud-fan/fa77713ccebf0823b2ab#file-safeprojectionbenchmark-scala
