### PR TITLE
[SPARK-12853][SQL] ignore bucketing information if we do not need it

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -905,6 +905,8 @@ class SQLContext private[sql](
   protected[sql] val prepareForExecution = new RuleExecutor[SparkPlan] {
     val batches = Seq(
       Batch("Add exchange", Once, EnsureRequirements(self)),
+      Batch("Apply Bucketing", FixedPoint(100), ReplacePhysicalRelation(self)),
+      Batch("Add exchange", Once, EnsureRequirements(self)),
       Batch("Whole stage codegen", Once, CollapseCodegenStages(self))
     )
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -46,7 +46,7 @@ private[sql] object DataSourceStrategy extends Strategy with Logging {
         l,
         projects,
         filters,
-        (requestedColumns, allPredicates, _) =>
+        (requestedColumns, allPredicates, _, _) =>
           toCatalystRDD(l, requestedColumns, t.buildScan(requestedColumns, allPredicates))) :: Nil
 
     case PhysicalOperation(projects, filters, l @ LogicalRelation(t: PrunedFilteredScan, _, _)) =>
@@ -54,14 +54,14 @@ private[sql] object DataSourceStrategy extends Strategy with Logging {
         l,
         projects,
         filters,
-        (a, f) => toCatalystRDD(l, a, t.buildScan(a.map(_.name).toArray, f))) :: Nil
+        (a, f, _) => toCatalystRDD(l, a, t.buildScan(a.map(_.name).toArray, f))) :: Nil
 
     case PhysicalOperation(projects, filters, l @ LogicalRelation(t: PrunedScan, _, _)) =>
       pruneFilterProject(
         l,
         projects,
         filters,
-        (a, _) => toCatalystRDD(l, a, t.buildScan(a.map(_.name).toArray))) :: Nil
+        (a, _, _) => toCatalystRDD(l, a, t.buildScan(a.map(_.name).toArray))) :: Nil
 
     // Scanning partitioned HadoopFsRelation
     case PhysicalOperation(projects, filters, l @ LogicalRelation(t: HadoopFsRelation, _, _))
@@ -128,7 +128,13 @@ private[sql] object DataSourceStrategy extends Strategy with Logging {
         l,
         projects,
         filters,
-        (a, f) => t.buildInternalScan(a.map(_.name).toArray, f, t.paths, confBroadcast)) :: Nil
+        (requiredColumns, filters, useBucketInfo) =>
+          t.buildInternalScan(
+            requiredColumns.map(_.name).toArray,
+            filters,
+            t.paths,
+            confBroadcast,
+            useBucketInfo)) :: Nil
 
     case l @ LogicalRelation(baseRelation: TableScan, _, _) =>
       execution.PhysicalRDD.createFromDataSource(
@@ -164,7 +170,7 @@ private[sql] object DataSourceStrategy extends Strategy with Logging {
     // Now, we create a scan builder, which will be used by pruneFilterProject. This scan builder
     // will union all partitions and attach partition values if needed.
     val scanBuilder = {
-      (requiredColumns: Seq[Attribute], filters: Array[Filter]) => {
+      (requiredColumns: Seq[Attribute], filters: Array[Filter], useBucketInfo: Boolean) => {
         val requiredDataColumns =
           requiredColumns.filterNot(c => partitionColumnNames.contains(c.name))
 
@@ -174,7 +180,11 @@ private[sql] object DataSourceStrategy extends Strategy with Logging {
           // assuming partition columns data stored in data files are always consistent with those
           // partition values encoded in partition directory paths.
           val dataRows = relation.buildInternalScan(
-            requiredDataColumns.map(_.name).toArray, filters, Array(dir), confBroadcast)
+            requiredDataColumns.map(_.name).toArray,
+            filters,
+            Array(dir),
+            confBroadcast,
+            useBucketInfo)
 
           // Merges data values with partition values.
           mergeWithPartitionValues(
@@ -283,17 +293,17 @@ private[sql] object DataSourceStrategy extends Strategy with Logging {
       relation: LogicalRelation,
       projects: Seq[NamedExpression],
       filterPredicates: Seq[Expression],
-      scanBuilder: (Seq[Attribute], Array[Filter]) => RDD[InternalRow]) = {
+      scanBuilder: (Seq[Attribute], Array[Filter], Boolean) => RDD[InternalRow]) = {
     pruneFilterProjectRaw(
       relation,
       projects,
       filterPredicates,
-      (requestedColumns, _, pushedFilters) => {
-        scanBuilder(requestedColumns, pushedFilters.toArray)
+      (requestedColumns, _, pushedFilters, useBucketInfo) => {
+        scanBuilder(requestedColumns, pushedFilters.toArray, useBucketInfo)
       })
   }
 
-  // Based on Catalyst expressions. The `scanBuilder` function accepts three arguments:
+  // Based on Catalyst expressions. The `scanBuilder` function accepts 4 arguments:
   //
   //  1. A `Seq[Attribute]`, containing all required column attributes. Used to handle relation
   //     traits that support column pruning (e.g. `PrunedScan` and `PrunedFilteredScan`).
@@ -306,12 +316,16 @@ private[sql] object DataSourceStrategy extends Strategy with Logging {
   //     relation traits (`CatalystScan` excluded) that support filter push-down (e.g.
   //     `PrunedFilteredScan` and `HadoopFsRelation`).
   //
+  //  4. A `boolean`, indicate if we should use bucket information of the relation. If the relation
+  //     is not under join or aggregate, i.e. bucketing optimization can't be applied, we should
+  //     ignore bucket information to avoid unnecessary coalesce.
+  //
   // Note that 2 and 3 shouldn't be used together.
   protected def pruneFilterProjectRaw(
     relation: LogicalRelation,
     projects: Seq[NamedExpression],
     filterPredicates: Seq[Expression],
-    scanBuilder: (Seq[Attribute], Seq[Expression], Seq[Filter]) => RDD[InternalRow]) = {
+    scanBuilder: (Seq[Attribute], Seq[Expression], Seq[Filter], Boolean) => RDD[InternalRow]) = {
 
     val projectSet = AttributeSet(projects.flatMap(_.references))
     val filterSet = AttributeSet(filterPredicates.flatMap(_.references))
@@ -365,20 +379,22 @@ private[sql] object DataSourceStrategy extends Strategy with Logging {
         // Don't request columns that are only referenced by pushed filters.
         .filterNot(handledSet.contains)
 
-      val scan = execution.PhysicalRDD.createFromDataSource(
+      val scan = PhysicalRelation(
         projects.map(_.toAttribute),
-        scanBuilder(requestedColumns, candidatePredicates, pushedFilters),
-        relation.relation, metadata)
+        scanBuilder(requestedColumns, candidatePredicates, pushedFilters, _),
+        relation.relation,
+        metadata)
       filterCondition.map(execution.Filter(_, scan)).getOrElse(scan)
     } else {
       // Don't request columns that are only referenced by pushed filters.
       val requestedColumns =
         (projectSet ++ filterSet -- handledSet).map(relation.attributeMap).toSeq
 
-      val scan = execution.PhysicalRDD.createFromDataSource(
+      val scan = PhysicalRelation(
         requestedColumns,
-        scanBuilder(requestedColumns, candidatePredicates, pushedFilters),
-        relation.relation, metadata)
+        scanBuilder(requestedColumns, candidatePredicates, pushedFilters, _),
+        relation.relation,
+        metadata)
       execution.Project(
         projects, filterCondition.map(execution.Filter(_, scan)).getOrElse(scan))
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PhysicalRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PhysicalRelation.scala
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{AnalysisException, SQLContext}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution._
+import org.apache.spark.sql.sources.{BaseRelation, HadoopFsRelation}
+
+/**
+ * A placeholder for [[PhysicalRDD]].  It will carry the relation information and we will decide
+ * to use bucketing or not based on the information later.
+ */
+private[sql] case class PhysicalRelation(
+    output: Seq[Attribute],
+    scanBuilder: Boolean => RDD[InternalRow],
+    relation: BaseRelation,
+    meta: Map[String, String],
+    bucketingRequired: Boolean = true) extends LeafNode {
+
+  def toPhysicalRDD: PhysicalRDD = {
+    val rdd = scanBuilder(bucketingRequired)
+    if (bucketingRequired) {
+      PhysicalRDD.createFromDataSource(output, rdd, relation, meta, outputPartitioning)
+    } else {
+      PhysicalRDD.createFromDataSource(output, rdd, relation, meta)
+    }
+  }
+
+  override protected def doExecute(): RDD[InternalRow] =
+    throw new IllegalArgumentException("We should never execute PhysicalRelation.")
+
+  override def outputPartitioning: Partitioning = {
+    val bucketSpec = relation match {
+      case r: HadoopFsRelation if bucketingRequired => r.getBucketSpec
+      case _ => None
+    }
+
+    def toAttribute(colName: String): Attribute = output.find(_.name == colName).getOrElse {
+      throw new AnalysisException(s"bucket column $colName not found in existing columns " +
+        s"(${output.map(_.name).mkString(", ")})")
+    }
+
+    bucketSpec.map { spec =>
+      val numBuckets = spec.numBuckets
+      val bucketColumns = spec.bucketColumnNames.map(toAttribute)
+      HashPartitioning(bucketColumns, numBuckets)
+    }.getOrElse {
+      super.outputPartitioning
+    }
+  }
+}
+
+/**
+ * Replaces [[PhysicalRelation]] with [[PhysicalRDD]] after decided to use bucketing information or
+ * not.
+ *
+ * Note that this rule only replaces one `PhysicalRelation` at a time, so should be put in a batch
+ * with fixed point.
+ */
+private[sql] case class ReplacePhysicalRelation(sqlContext: SQLContext) extends Rule[SparkPlan] {
+
+  /**
+   * The strategy is: picks up one `PhysicalRelation` and disable its bucketing. If we need extra
+   * shuffle because of this, it means this bucketing information is useful and we should keep it.
+   * Else, we can safely ignore the bucketing information.
+   */
+  def apply(plan: SparkPlan): SparkPlan = {
+    var stop = false
+    val bucketingDisabled = plan transform {
+      case r: PhysicalRelation if !stop =>
+        stop = true
+        r.copy(bucketingRequired = false)
+    }
+
+    if (!stop) {
+      // There is no more PhysicalRelation to replace, return the original plan.
+      plan
+    } else {
+      val bucketingRequired = numShuffle(addShuffle(bucketingDisabled)) > numShuffle(plan)
+      bucketingDisabled transform {
+        case r: PhysicalRelation if !r.bucketingRequired =>
+          r.copy(bucketingRequired = bucketingRequired).toPhysicalRDD
+      }
+    }
+  }
+
+  private def numShuffle(plan: SparkPlan): Int = {
+    plan.collect { case _: Exchange => 0 }.length
+  }
+
+  private val addShuffle = EnsureRequirements(sqlContext)
+}

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala
@@ -22,7 +22,8 @@ import java.io.File
 import org.apache.spark.sql.{Column, DataFrame, DataFrameWriter, QueryTest, SQLConf}
 import org.apache.spark.sql.catalyst.expressions.UnsafeProjection
 import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
-import org.apache.spark.sql.execution.Exchange
+import org.apache.spark.sql.execution.{Exchange, PhysicalRDD, SparkPlan}
+import org.apache.spark.sql.execution.datasources.BucketSpec
 import org.apache.spark.sql.execution.joins.SortMergeJoin
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.hive.test.TestHiveSingleton
@@ -35,26 +36,35 @@ class BucketedReadSuite extends QueryTest with SQLTestUtils with TestHiveSinglet
   test("read bucketed data") {
     val df = (0 until 50).map(i => (i % 5, i % 13, i.toString)).toDF("i", "j", "k")
     withTable("bucketed_table") {
+      val numBuckets = 8
+
       df.write
         .format("parquet")
         .partitionBy("i")
-        .bucketBy(8, "j", "k")
+        .bucketBy(numBuckets, "j", "k")
         .saveAsTable("bucketed_table")
 
       for (i <- 0 until 5) {
-        val rdd = hiveContext.table("bucketed_table").filter($"i" === i).queryExecution.toRdd
-        assert(rdd.partitions.length == 8)
-
-        val attrs = df.select("j", "k").schema.toAttributes
-        val checkBucketId = rdd.mapPartitionsWithIndex((index, rows) => {
-          val getBucketId = UnsafeProjection.create(
-            HashPartitioning(attrs, 8).partitionIdExpression :: Nil,
-            attrs)
-          rows.map(row => getBucketId(row).getInt(0) == index)
-        })
-
-        assert(checkBucketId.collect().reduce(_ && _))
+        // Add Aggregate so that bucket information will be used.
+        val agged = hiveContext.table("bucketed_table").filter($"i" === i).groupBy("j", "k").count()
+        assert(isBucketed(agged.queryExecution.executedPlan, numBuckets, Seq("j", "k")))
       }
+    }
+  }
+
+  private def isBucketed(
+      plan: SparkPlan, numBuckets: Int, bucketColumnNames: Seq[String]): Boolean = {
+    val rdd = plan.collect { case p: PhysicalRDD => p }.head.rdd
+    rdd.partitions.length == numBuckets && {
+      val attrs = bucketColumnNames.map(c => plan.output.find(_.name == c).get)
+      val checkBucketId = rdd.mapPartitionsWithIndex((index, rows) => {
+        val getBucketId = UnsafeProjection.create(
+          HashPartitioning(attrs, numBuckets).partitionIdExpression :: Nil,
+          attrs)
+        rows.map(row => getBucketId(row).getInt(0) == index)
+      })
+
+      checkBucketId.collect().reduce(_ && _)
     }
   }
 
@@ -62,14 +72,23 @@ class BucketedReadSuite extends QueryTest with SQLTestUtils with TestHiveSinglet
   private val df2 = (0 until 50).map(i => (i % 7, i % 11, i.toString)).toDF("i", "j", "k").as("df2")
 
   private def testBucketing(
-      bucketing1: DataFrameWriter => DataFrameWriter,
-      bucketing2: DataFrameWriter => DataFrameWriter,
+      bucketSpecLeft: Option[BucketSpec],
+      bucketSpecRight: Option[BucketSpec],
       joinColumns: Seq[String],
       shuffleLeft: Boolean,
       shuffleRight: Boolean): Unit = {
     withTable("bucketed_table1", "bucketed_table2") {
-      bucketing1(df1.write.format("parquet")).saveAsTable("bucketed_table1")
-      bucketing2(df2.write.format("parquet")).saveAsTable("bucketed_table2")
+      def withBucket(writer: DataFrameWriter, bucketSpec: Option[BucketSpec]): DataFrameWriter = {
+        bucketSpec.map { spec =>
+          writer.bucketBy(
+            spec.numBuckets,
+            spec.bucketColumnNames.head,
+            spec.bucketColumnNames.tail: _*)
+        }.getOrElse(writer)
+      }
+
+      withBucket(df1.write.format("parquet"), bucketSpecLeft).saveAsTable("bucketed_table1")
+      withBucket(df2.write.format("parquet"), bucketSpecRight).saveAsTable("bucketed_table2")
 
       withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "0") {
         val t1 = hiveContext.table("bucketed_table1")
@@ -84,8 +103,17 @@ class BucketedReadSuite extends QueryTest with SQLTestUtils with TestHiveSinglet
         assert(joined.queryExecution.executedPlan.isInstanceOf[SortMergeJoin])
         val joinOperator = joined.queryExecution.executedPlan.asInstanceOf[SortMergeJoin]
 
+        def checkBucket(plan: SparkPlan, bucketSpec: Option[BucketSpec], shuffle: Boolean): Unit = {
+          for (spec <- bucketSpec) {
+            assert(isBucketed(plan, spec.numBuckets, spec.bucketColumnNames) == !shuffle)
+          }
+        }
+
         assert(joinOperator.left.find(_.isInstanceOf[Exchange]).isDefined == shuffleLeft)
+        checkBucket(joinOperator.left, bucketSpecLeft, shuffleLeft)
+
         assert(joinOperator.right.find(_.isInstanceOf[Exchange]).isDefined == shuffleRight)
+        checkBucket(joinOperator.right, bucketSpecRight, shuffleRight)
       }
     }
   }
@@ -95,42 +123,42 @@ class BucketedReadSuite extends QueryTest with SQLTestUtils with TestHiveSinglet
   }
 
   test("avoid shuffle when join 2 bucketed tables") {
-    val bucketing = (writer: DataFrameWriter) => writer.bucketBy(8, "i", "j")
-    testBucketing(bucketing, bucketing, Seq("i", "j"), shuffleLeft = false, shuffleRight = false)
+    val bucketSpec = Some(BucketSpec(8, Seq("i", "j"), Nil))
+    testBucketing(bucketSpec, bucketSpec, Seq("i", "j"), shuffleLeft = false, shuffleRight = false)
   }
 
   // Enable it after fix https://issues.apache.org/jira/browse/SPARK-12704
   ignore("avoid shuffle when join keys are a super-set of bucket keys") {
-    val bucketing = (writer: DataFrameWriter) => writer.bucketBy(8, "i")
-    testBucketing(bucketing, bucketing, Seq("i", "j"), shuffleLeft = false, shuffleRight = false)
+    val bucketSpec = Some(BucketSpec(8, Seq("i"), Nil))
+    testBucketing(bucketSpec, bucketSpec, Seq("i", "j"), shuffleLeft = false, shuffleRight = false)
   }
 
   test("only shuffle one side when join bucketed table and non-bucketed table") {
-    val bucketing = (writer: DataFrameWriter) => writer.bucketBy(8, "i", "j")
-    testBucketing(bucketing, identity, Seq("i", "j"), shuffleLeft = false, shuffleRight = true)
+    val bucketSpec = Some(BucketSpec(8, Seq("i", "j"), Nil))
+    testBucketing(bucketSpec, None, Seq("i", "j"), shuffleLeft = false, shuffleRight = true)
   }
 
   test("only shuffle one side when 2 bucketed tables have different bucket number") {
-    val bucketing1 = (writer: DataFrameWriter) => writer.bucketBy(8, "i", "j")
-    val bucketing2 = (writer: DataFrameWriter) => writer.bucketBy(5, "i", "j")
-    testBucketing(bucketing1, bucketing2, Seq("i", "j"), shuffleLeft = false, shuffleRight = true)
+    val bucketSpec1 = Some(BucketSpec(8, Seq("i", "j"), Nil))
+    val bucketSpec2 = Some(BucketSpec(5, Seq("i", "j"), Nil))
+    testBucketing(bucketSpec1, bucketSpec2, Seq("i", "j"), shuffleLeft = false, shuffleRight = true)
   }
 
   test("only shuffle one side when 2 bucketed tables have different bucket keys") {
-    val bucketing1 = (writer: DataFrameWriter) => writer.bucketBy(8, "i")
-    val bucketing2 = (writer: DataFrameWriter) => writer.bucketBy(8, "j")
-    testBucketing(bucketing1, bucketing2, Seq("i"), shuffleLeft = false, shuffleRight = true)
+    val bucketSpec1 = Some(BucketSpec(8, Seq("i"), Nil))
+    val bucketSpec2 = Some(BucketSpec(8, Seq("j"), Nil))
+    testBucketing(bucketSpec1, bucketSpec2, Seq("i"), shuffleLeft = false, shuffleRight = true)
   }
 
   test("shuffle when join keys are not equal to bucket keys") {
-    val bucketing = (writer: DataFrameWriter) => writer.bucketBy(8, "i")
-    testBucketing(bucketing, bucketing, Seq("j"), shuffleLeft = true, shuffleRight = true)
+    val bucketSpec = Some(BucketSpec(8, Seq("i"), Nil))
+    testBucketing(bucketSpec, bucketSpec, Seq("j"), shuffleLeft = true, shuffleRight = true)
   }
 
   test("shuffle when join 2 bucketed tables with bucketing disabled") {
-    val bucketing = (writer: DataFrameWriter) => writer.bucketBy(8, "i", "j")
+    val bucketSpec = Some(BucketSpec(8, Seq("i", "j"), Nil))
     withSQLConf(SQLConf.BUCKETING_ENABLED.key -> "false") {
-      testBucketing(bucketing, bucketing, Seq("i", "j"), shuffleLeft = true, shuffleRight = true)
+      testBucketing(bucketSpec, bucketSpec, Seq("i", "j"), shuffleLeft = true, shuffleRight = true)
     }
   }
 


### PR DESCRIPTION
The idea is: use a place holder for `LogicalRelation` that can delay the scan and carry bucketing information, during planning. Then we add a rule to randomly pick one place holder from the physical plan, try to disable bucketing and see if we will add extra shuffle. If no extra shuffle is added, it means the bucketing for this relation is unnecessary, we can ignore it and do a normal scan. If extra shuffle is added, we do a bucket scan.
