### PR TITLE
[SPARK-12343][YARN] Make YARN Client private

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1053,12 +1053,13 @@ private[spark] class Client(
 
 }
 
-object Client extends Logging {
+private[deploy] object Client extends Logging {
 
   def main(argStrings: Array[String]) {
     if (!sys.props.contains("SPARK_SUBMIT")) {
-      logWarning("WARNING: This client is deprecated and will be removed in a " +
-        "future version of Spark. Use ./bin/spark-submit with \"--master yarn\"")
+      logError("Error: Client main class should not be called. " +
+        "Use ./bin/spark-submit with \"--master yarn\"")
+      throw new SparkException("Client main class should not be called")
     }
 
     // Set an env variable indicating we are running in YARN mode.


### PR DESCRIPTION
It's being called in yarn-client mode so the main class cannot be removed, making private instead.
https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala#L571

Some classes are `private[spark]` it seems they could be made `private[deploy]`

cc @rxin @vanzin 
