### PR TITLE
[SPARK-12668][SQL] Providing aliases for CSV options to be similar to Pandas and R

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.execution
 
-import org.apache.spark.sql.execution.joins.{BuildLeft, BuildRight}
 import org.apache.spark.sql.{execution, Strategy}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
@@ -29,6 +28,7 @@ import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.execution.{DescribeCommand => RunnableDescribeCommand}
 import org.apache.spark.sql.execution.columnar.{InMemoryColumnarTableScan, InMemoryRelation}
 import org.apache.spark.sql.execution.datasources.{CreateTableUsing, CreateTempTableUsing, DescribeCommand => LogicalDescribeCommand, _}
+import org.apache.spark.sql.execution.joins.{BuildLeft, BuildRight}
 
 private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
   self: SparkPlanner =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParameters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParameters.scala
@@ -44,9 +44,9 @@ private[sql] case class CSVParameters(parameters: Map[String, String]) extends L
     }
   }
 
-  val delimiter = CSVTypeCast.toChar(parameters.getOrElse("delimiter", ","))
+  val seq = CSVTypeCast.toChar(parameters.getOrElse("seq", ","))
   val parseMode = parameters.getOrElse("mode", "PERMISSIVE")
-  val charset = parameters.getOrElse("charset", Charset.forName("UTF-8").name())
+  val encoding = parameters.getOrElse("encoding", Charset.forName("UTF-8").name())
 
   val quote = getChar("quote", '\"')
   val escape = getChar("escape", '\\')

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParameters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParameters.scala
@@ -21,7 +21,7 @@ import java.nio.charset.Charset
 
 import org.apache.spark.Logging
 
-private[sql] case class CSVParameters(parameters: Map[String, String]) extends Logging {
+private[sql] case class CSVParameters(@transient parameters: Map[String, String]) extends Logging {
 
   private def getChar(paramName: String, default: Char): Char = {
     val paramValue = parameters.get(paramName)
@@ -45,10 +45,10 @@ private[sql] case class CSVParameters(parameters: Map[String, String]) extends L
   }
 
   val delimiter = CSVTypeCast.toChar(
-    parameters.getOrElse("delimiter", parameters.getOrElse("sep", ",")))
+    parameters.getOrElse("sep", parameters.getOrElse("delimiter", ",")))
   val parseMode = parameters.getOrElse("mode", "PERMISSIVE")
-  val charset = parameters.getOrElse("charset",
-    parameters.getOrElse("encoding", Charset.forName("UTF-8").name()))
+  val charset = parameters.getOrElse("encoding",
+    parameters.getOrElse("charset", Charset.forName("UTF-8").name()))
 
   val quote = getChar("quote", '\"')
   val escape = getChar("escape", '\\')

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParameters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParameters.scala
@@ -44,9 +44,11 @@ private[sql] case class CSVParameters(parameters: Map[String, String]) extends L
     }
   }
 
-  val seq = CSVTypeCast.toChar(parameters.getOrElse("seq", ","))
+  val delimiter = CSVTypeCast.toChar(
+    parameters.getOrElse("delimiter", parameters.getOrElse("sep", ",")))
   val parseMode = parameters.getOrElse("mode", "PERMISSIVE")
-  val encoding = parameters.getOrElse("encoding", Charset.forName("UTF-8").name())
+  val charset = parameters.getOrElse("charset",
+    parameters.getOrElse("encoding", Charset.forName("UTF-8").name()))
 
   val quote = getChar("quote", '\"')
   val escape = getChar("escape", '\\')

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParser.scala
@@ -34,7 +34,7 @@ private[sql] abstract class CsvReader(params: CSVParameters, headers: Seq[String
   protected lazy val parser: CsvParser = {
     val settings = new CsvParserSettings()
     val format = settings.getFormat
-    format.setDelimiter(params.delimiter)
+    format.setDelimiter(params.seq)
     format.setLineSeparator(params.rowSeparator)
     format.setQuote(params.quote)
     format.setQuoteEscape(params.escape)
@@ -62,7 +62,7 @@ private[sql] class LineCsvWriter(params: CSVParameters, headers: Seq[String]) ex
   private val writerSettings = new CsvWriterSettings
   private val format = writerSettings.getFormat
 
-  format.setDelimiter(params.delimiter)
+  format.setDelimiter(params.seq)
   format.setLineSeparator(params.rowSeparator)
   format.setQuote(params.quote)
   format.setQuoteEscape(params.escape)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParser.scala
@@ -34,7 +34,7 @@ private[sql] abstract class CsvReader(params: CSVParameters, headers: Seq[String
   protected lazy val parser: CsvParser = {
     val settings = new CsvParserSettings()
     val format = settings.getFormat
-    format.setDelimiter(params.seq)
+    format.setDelimiter(params.delimiter)
     format.setLineSeparator(params.rowSeparator)
     format.setQuote(params.quote)
     format.setQuoteEscape(params.escape)
@@ -62,7 +62,7 @@ private[sql] class LineCsvWriter(params: CSVParameters, headers: Seq[String]) ex
   private val writerSettings = new CsvWriterSettings
   private val format = writerSettings.getFormat
 
-  format.setDelimiter(params.seq)
+  format.setDelimiter(params.delimiter)
   format.setLineSeparator(params.rowSeparator)
   format.setQuote(params.quote)
   format.setQuoteEscape(params.escape)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
@@ -58,9 +58,10 @@ private[csv] class CSVRelation(
     if (Charset.forName(params.charset) == Charset.forName("UTF-8")) {
       sqlContext.sparkContext.textFile(location)
     } else {
+      val charset = params.charset
       sqlContext.sparkContext.hadoopFile[LongWritable, Text, TextInputFormat](location)
         .mapPartitions { _.map { pair =>
-            new String(pair._2.getBytes, 0, pair._2.getLength, params.charset)
+            new String(pair._2.getBytes, 0, pair._2.getLength, charset)
           }
         }
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
@@ -55,12 +55,12 @@ private[csv] class CSVRelation(
   private var cachedRDD: Option[RDD[String]] = None
 
   private def readText(location: String): RDD[String] = {
-    if (Charset.forName(params.charset) == Charset.forName("UTF-8")) {
+    if (Charset.forName(params.encoding) == Charset.forName("UTF-8")) {
       sqlContext.sparkContext.textFile(location)
     } else {
       sqlContext.sparkContext.hadoopFile[LongWritable, Text, TextInputFormat](location)
         .mapPartitions { _.map { pair =>
-            new String(pair._2.getBytes, 0, pair._2.getLength, params.charset)
+            new String(pair._2.getBytes, 0, pair._2.getLength, params.encoding)
           }
         }
     }
@@ -199,11 +199,11 @@ object CSVRelation extends Logging {
       val requiredSize = requiredFields.length
       tokenizedRDD.flatMap { tokens =>
         if (params.dropMalformed && schemaFields.length != tokens.size) {
-          logWarning(s"Dropping malformed line: ${tokens.mkString(params.delimiter.toString)}")
+          logWarning(s"Dropping malformed line: ${tokens.mkString(params.seq.toString)}")
           None
         } else if (params.failFast && schemaFields.length != tokens.size) {
           throw new RuntimeException(s"Malformed line in FAILFAST mode: " +
-            s"${tokens.mkString(params.delimiter.toString)}")
+            s"${tokens.mkString(params.seq.toString)}")
         } else {
           val indexSafeTokens = if (params.permissive && schemaFields.length > tokens.size) {
             tokens ++ new Array[String](schemaFields.length - tokens.size)
@@ -229,7 +229,7 @@ object CSVRelation extends Logging {
           } catch {
             case NonFatal(e) if params.dropMalformed =>
               logWarning("Parse exception. " +
-                s"Dropping malformed line: ${tokens.mkString(params.delimiter.toString)}")
+                s"Dropping malformed line: ${tokens.mkString(params.seq.toString)}")
               None
           }
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -101,10 +101,10 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
     verifyCars(cars, withHeader = true, checkTypes = true)
   }
 
-  test("test with alternative delimiter and quote") {
+  test("test with alternative seq and quote") {
     val cars = sqlContext.read
       .format("csv")
-      .options(Map("quote" -> "\'", "delimiter" -> "|", "header" -> "true"))
+      .options(Map("quote" -> "\'", "seq" -> "|", "header" -> "true"))
       .load(testFile(carsAltFile))
 
     verifyCars(cars, withHeader = true)
@@ -115,7 +115,7 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
       sqlContext
         .read
         .format("csv")
-        .option("charset", "1-9588-osi")
+        .option("encoding", "1-9588-osi")
         .load(testFile(carsFile8859))
     }
 
@@ -128,7 +128,7 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
       s"""
          |CREATE TEMPORARY TABLE carsTable USING csv
          |OPTIONS (path "${testFile(carsFile8859)}", header "true",
-         |charset "iso-8859-1", delimiter "þ")
+         |encoding "iso-8859-1", seq "þ")
       """.stripMargin.replaceAll("\n", " "))
     //scalstyle:on
 
@@ -139,7 +139,7 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
     sqlContext.sql(
       s"""
          |CREATE TEMPORARY TABLE carsTable USING csv
-         |OPTIONS (path "${testFile(carsTsvFile)}", header "true", delimiter "\t")
+         |OPTIONS (path "${testFile(carsTsvFile)}", header "true", seq "\t")
       """.stripMargin.replaceAll("\n", " "))
 
     verifyCars(sqlContext.table("carsTable"), numFields = 6, withHeader = true, checkHeader = false)
@@ -152,7 +152,7 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
          |(yearMade double, makeName string, modelName string, priceTag decimal,
          | comments string, grp string)
          |USING csv
-         |OPTIONS (path "${testFile(carsTsvFile)}", header "true", delimiter "\t")
+         |OPTIONS (path "${testFile(carsTsvFile)}", header "true", seq "\t")
       """.stripMargin.replaceAll("\n", " "))
 
     assert(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -122,7 +122,7 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
     assert(exception.getMessage.contains("1-9588-osi"))
   }
 
-  ignore("test different encoding") {
+  test("test different encoding") {
     // scalastyle:off
     sqlContext.sql(
       s"""
@@ -136,15 +136,15 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
   }
 
   test("test aliases sep and encoding for delimiter and charset") {
-    sqlContext
+    val cars = sqlContext
       .read
       .format("csv")
+      .option("header", "true")
       .option("encoding", "iso-8859-1")
       .option("sep", "þ")
       .load(testFile(carsFile8859))
-      .registerTempTable("carsTable")
 
-    verifyCars(sqlContext.table("carsTable"), withHeader = true)
+    verifyCars(cars, withHeader = true)
   }
 
   test("DDL test with tab separated file") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -101,10 +101,10 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
     verifyCars(cars, withHeader = true, checkTypes = true)
   }
 
-  test("test with alternative seq and quote") {
+  test("test with alternative delimiter and quote") {
     val cars = sqlContext.read
       .format("csv")
-      .options(Map("quote" -> "\'", "seq" -> "|", "header" -> "true"))
+      .options(Map("quote" -> "\'", "delimiter" -> "|", "header" -> "true"))
       .load(testFile(carsAltFile))
 
     verifyCars(cars, withHeader = true)
@@ -115,7 +115,7 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
       sqlContext
         .read
         .format("csv")
-        .option("encoding", "1-9588-osi")
+        .option("charset", "1-9588-osi")
         .load(testFile(carsFile8859))
     }
 
@@ -128,9 +128,21 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
       s"""
          |CREATE TEMPORARY TABLE carsTable USING csv
          |OPTIONS (path "${testFile(carsFile8859)}", header "true",
-         |encoding "iso-8859-1", seq "þ")
+         |charset "iso-8859-1", delimiter "þ")
       """.stripMargin.replaceAll("\n", " "))
     //scalstyle:on
+
+    verifyCars(sqlContext.table("carsTable"), withHeader = true)
+  }
+
+  test("test aliases sep and encoding for delimiter and charset") {
+    sqlContext
+      .read
+      .format("csv")
+      .option("encoding", "iso-8859-1")
+      .option("sep", "þ")
+      .load(testFile(carsFile8859))
+      .registerTempTable("carsTable")
 
     verifyCars(sqlContext.table("carsTable"), withHeader = true)
   }
@@ -139,7 +151,7 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
     sqlContext.sql(
       s"""
          |CREATE TEMPORARY TABLE carsTable USING csv
-         |OPTIONS (path "${testFile(carsTsvFile)}", header "true", seq "\t")
+         |OPTIONS (path "${testFile(carsTsvFile)}", header "true", delimiter "\t")
       """.stripMargin.replaceAll("\n", " "))
 
     verifyCars(sqlContext.table("carsTable"), numFields = 6, withHeader = true, checkHeader = false)
@@ -152,7 +164,7 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
          |(yearMade double, makeName string, modelName string, priceTag decimal,
          | comments string, grp string)
          |USING csv
-         |OPTIONS (path "${testFile(carsTsvFile)}", header "true", seq "\t")
+         |OPTIONS (path "${testFile(carsTsvFile)}", header "true", delimiter "\t")
       """.stripMargin.replaceAll("\n", " "))
 
     assert(
@@ -337,5 +349,4 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
     assert(results(0).toSeq === Array(2012, "Tesla", "S", "null", "null"))
     assert(results(2).toSeq === Array(null, "Chevy", "Volt", null, null))
   }
-
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/InnerJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/InnerJoinSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.joins
 
+import org.apache.spark.sql.{DataFrame, Row, SQLConf}
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.planning.ExtractEquiJoinKeys
 import org.apache.spark.sql.catalyst.plans.Inner
@@ -24,7 +25,6 @@ import org.apache.spark.sql.catalyst.plans.logical.Join
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
-import org.apache.spark.sql.{DataFrame, Row, SQLConf}
 
 class InnerJoinSuite extends SparkPlanTest with SharedSQLContext {
   import testImplicits.localSeqToDataFrameHolder


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-12668

Spark CSV datasource has been being merged (filed in [SPARK-12420](https://issues.apache.org/jira/browse/SPARK-12420)). This is a quicky PR that simply renames several CSV options to  similar Pandas and R.
- Alias for delimiter ­-> sep
- charset -­> encoding
