### PR TITLE
RoutingTablePartition code comment errors(Previous PR cannot be merged)

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/impl/RoutingTablePartition.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/impl/RoutingTablePartition.scala
@@ -34,7 +34,7 @@ object RoutingTablePartition {
   /**
    * A message from an edge partition to a vertex specifying the position in which the edge
    * partition references the vertex (src, dst, or both). The edge partition is encoded in the lower
-   * 30 bytes of the Int, and the position is encoded in the upper 2 bytes of the Int.
+   * 30 bits of the Int, and the position is encoded in the upper 2 bits of the Int.
    */
   type RoutingTableMessage = (VertexId, Int)
 


### PR DESCRIPTION
There is an error in description of RoutingTablePartition object. The edge partition is encoded in the lower 30 bits of the Int, not 30 bytes of the Int. And the same mistake is made in position is encoded in the upper 2 bytes of the Int.
