### PR TITLE
[SPARK-12871][SQL] Support to specify the option for compression codec.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParameters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParameters.scala
@@ -73,7 +73,7 @@ private[sql] case class CSVParameters(parameters: Map[String, String]) extends L
 
   val nullValue = parameters.getOrElse("nullValue", "")
 
-  val codec = parameters.getOrElse("codec", null)
+  val codec = parameters.getOrElse("codec", parameters.getOrElse("compression", null))
 
   val maxColumns = 20480
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParameters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParameters.scala
@@ -136,6 +136,6 @@ private[csv] object CSVCompressionCodecs {
       case e: ClassNotFoundException => None
     }
     codecClassName.getOrElse(throw new IllegalArgumentException(s"Codec [$codecName] " +
-      s"is not available. Available codecs: ${shortCompressionCodecNames.keys.mkString(", ")}"))
+      s"is not available. Available codecs are ${shortCompressionCodecNames.keys.mkString(", ")}."))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParameters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParameters.scala
@@ -135,7 +135,7 @@ private[csv] object CSVCompressionCodecs {
     } catch {
       case e: ClassNotFoundException => None
     }
-    codecClassName.getOrElse(throw new IllegalArgumentException(s"Codec [$codecName]" +
-      s" is not available. Available codecs are ${shortCompressionCodecNames.keys.mkString(",")}."))
+    codecClassName.getOrElse(throw new IllegalArgumentException(s"Codec [$codecName] " +
+      s"is not available. Available codecs: ${shortCompressionCodecNames.keys.mkString(", ")}"))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParameters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParameters.scala
@@ -46,7 +46,7 @@ private[sql] case class CSVParameters(@transient parameters: Map[String, String]
       throw new Exception(s"$paramName flag can be true or false")
     }
   }
-  
+
   val delimiter = CSVTypeCast.toChar(
     parameters.getOrElse("sep", parameters.getOrElse("delimiter", ",")))
   val parseMode = parameters.getOrElse("mode", "PERMISSIVE")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParameters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParameters.scala
@@ -44,11 +44,9 @@ private[sql] case class CSVParameters(parameters: Map[String, String]) extends L
     }
   }
 
-  val delimiter = CSVTypeCast.toChar(
-    parameters.getOrElse("delimiter", parameters.getOrElse("sep", ",")))
+  val delimiter = CSVTypeCast.toChar(parameters.getOrElse("delimiter", ","))
   val parseMode = parameters.getOrElse("mode", "PERMISSIVE")
-  val charset = parameters.getOrElse("charset",
-    parameters.getOrElse("encoding", Charset.forName("UTF-8").name()))
+  val charset = parameters.getOrElse("charset", Charset.forName("UTF-8").name())
 
   val quote = getChar("quote", '\"')
   val escape = getChar("escape", '\\')

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParameters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParameters.scala
@@ -76,12 +76,9 @@ private[sql] case class CSVParameters(@transient parameters: Map[String, String]
 
   val nullValue = parameters.getOrElse("nullValue", "")
 
-  val compressionCodecName =
-    parameters.getOrElse("compression", parameters.getOrElse("codec", null))
-  val compressionCodec = if (compressionCodecName != null) {
-    CSVCompressionCodecs.getCodecClassName(compressionCodecName)
-  } else {
-    null
+  val compressionCodec: Option[String] = {
+    val name = parameters.get("compression").orElse(parameters.get("codec"))
+    name.map(CSVCompressionCodecs.getCodecClassName)
   }
 
   val maxColumns = 20480
@@ -119,7 +116,7 @@ private[csv] object ParseModes {
 }
 
 private[csv] object CSVCompressionCodecs {
-  val shortCompressionCodecNames = Map(
+  private val shortCompressionCodecNames = Map(
     "bzip2" -> classOf[BZip2Codec].getName,
     "gzip" -> classOf[GzipCodec].getName,
     "lz4" -> classOf[Lz4Codec].getName,
@@ -138,7 +135,7 @@ private[csv] object CSVCompressionCodecs {
     } catch {
       case e: ClassNotFoundException => None
     }
-    codecClassName.getOrElse(throw new IllegalArgumentException(s"Codec [$codecName] " +
-      s"is not available. Available codecs are ${shortCompressionCodecNames.keys.mkString(",")}."))
+    codecClassName.getOrElse(throw new IllegalArgumentException(s"Codec [$codecName]" +
+      s" is not available. Available codecs are ${shortCompressionCodecNames.keys.mkString(",")}."))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParameters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParameters.scala
@@ -44,9 +44,11 @@ private[sql] case class CSVParameters(parameters: Map[String, String]) extends L
     }
   }
 
-  val delimiter = CSVTypeCast.toChar(parameters.getOrElse("delimiter", ","))
+  val delimiter = CSVTypeCast.toChar(
+    parameters.getOrElse("delimiter", parameters.getOrElse("sep", ",")))
   val parseMode = parameters.getOrElse("mode", "PERMISSIVE")
-  val charset = parameters.getOrElse("charset", Charset.forName("UTF-8").name())
+  val charset = parameters.getOrElse("charset",
+    parameters.getOrElse("encoding", Charset.forName("UTF-8").name()))
 
   val quote = getChar("quote", '\"')
   val escape = getChar("escape", '\\')
@@ -70,6 +72,8 @@ private[sql] case class CSVParameters(parameters: Map[String, String]) extends L
   val permissive = ParseModes.isPermissiveMode(parseMode)
 
   val nullValue = parameters.getOrElse("nullValue", "")
+
+  val codec = parameters.getOrElse("codec", null)
 
   val maxColumns = 20480
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParameters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParameters.scala
@@ -128,14 +128,14 @@ private[csv] object CSVCompressionCodecs {
    */
   def getCodecClassName(name: String): String = {
     val codecName = shortCompressionCodecNames.getOrElse(name.toLowerCase, name)
-    val codecClassName = try {
+    try {
       // Validate the codec name
       Utils.classForName(codecName)
-      Some(codecName)
+      codecName
     } catch {
-      case e: ClassNotFoundException => None
+      case e: ClassNotFoundException =>
+        throw new IllegalArgumentException(s"Codec [$codecName] " +
+          s"is not available. Known codecs are ${shortCompressionCodecNames.keys.mkString(", ")}.")
     }
-    codecClassName.getOrElse(throw new IllegalArgumentException(s"Codec [$codecName] " +
-      s"is not available. Available codecs are ${shortCompressionCodecNames.keys.mkString(", ")}."))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParameters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParameters.scala
@@ -46,6 +46,7 @@ private[sql] case class CSVParameters(@transient parameters: Map[String, String]
       throw new Exception(s"$paramName flag can be true or false")
     }
   }
+  
   val delimiter = CSVTypeCast.toChar(
     parameters.getOrElse("sep", parameters.getOrElse("delimiter", ",")))
   val parseMode = parameters.getOrElse("mode", "PERMISSIVE")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParameters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParameters.scala
@@ -71,7 +71,7 @@ private[sql] case class CSVParameters(parameters: Map[String, String]) extends L
 
   val nullValue = parameters.getOrElse("nullValue", "")
 
-  val codec = parameters.getOrElse("codec", parameters.getOrElse("compression", null))
+  val codec = parameters.getOrElse("compression", parameters.getOrElse("codec", null))
 
   val maxColumns = 20480
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
@@ -101,7 +101,7 @@ private[csv] class CSVRelation(
 
   override def prepareJobForWrite(job: Job): OutputWriterFactory = {
     val conf = job.getConfiguration
-    Option(params.codec).foreach { codec =>
+    Option(params.compressionCodec).foreach { codec =>
       conf.set("mapreduce.output.fileoutputformat.compress", "true")
       conf.set("mapreduce.output.fileoutputformat.compress.type", CompressionType.BLOCK.toString)
       conf.set("mapreduce.output.fileoutputformat.compress.codec", codec)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
@@ -101,13 +101,6 @@ private[csv] class CSVRelation(
   override def prepareJobForWrite(job: Job): OutputWriterFactory = {
     val conf = job.getConfiguration
     Option(params.codec).foreach { codec =>
-      // Hadoop 1.x
-      conf.set("mapred.output.compress", "true")
-      conf.set("mapred.output.compression.codec", codec)
-      conf.set("mapred.output.compression.type", CompressionType.BLOCK.toString)
-      conf.set("mapred.compress.map.output", "true")
-      conf.set("mapred.map.output.compression.codec", codec)
-      // Hadoop 2.x
       conf.set("mapreduce.output.fileoutputformat.compress", "true")
       conf.set("mapreduce.output.fileoutputformat.compress.type", CompressionType.BLOCK.toString)
       conf.set("mapreduce.output.fileoutputformat.compress.codec", codec)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
@@ -101,7 +101,7 @@ private[csv] class CSVRelation(
 
   override def prepareJobForWrite(job: Job): OutputWriterFactory = {
     val conf = job.getConfiguration
-    Option(params.compressionCodec).foreach { codec =>
+    params.compressionCodec.foreach { codec =>
       conf.set("mapreduce.output.fileoutputformat.compress", "true")
       conf.set("mapreduce.output.fileoutputformat.compress.type", CompressionType.BLOCK.toString)
       conf.set("mapreduce.output.fileoutputformat.compress.codec", codec)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
@@ -59,10 +59,9 @@ private[csv] class CSVRelation(
     if (Charset.forName(params.charset) == Charset.forName("UTF-8")) {
       sqlContext.sparkContext.textFile(location)
     } else {
-      val charset = params.charset
       sqlContext.sparkContext.hadoopFile[LongWritable, Text, TextInputFormat](location)
         .mapPartitions { _.map { pair =>
-            new String(pair._2.getBytes, 0, pair._2.getLength, charset)
+            new String(pair._2.getBytes, 0, pair._2.getLength, params.charset)
           }
         }
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
@@ -19,15 +19,12 @@ package org.apache.spark.sql.execution.datasources.csv
 
 import java.nio.charset.Charset
 
-import org.apache.hadoop.io.SequenceFile.CompressionType
-import org.apache.hadoop.io.compress.CompressionCodec
-import org.apache.spark.util.Utils
-
 import scala.util.control.NonFatal
 
 import com.google.common.base.Objects
 import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.hadoop.io.{LongWritable, NullWritable, Text}
+import org.apache.hadoop.io.SequenceFile.CompressionType
 import org.apache.hadoop.mapred.TextInputFormat
 import org.apache.hadoop.mapreduce.{Job, TaskAttemptContext}
 import org.apache.hadoop.mapreduce.RecordWriter

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -21,8 +21,6 @@ import java.io.File
 import java.nio.charset.UnsupportedCharsetException
 import java.sql.Timestamp
 
-import org.apache.hadoop.io.compress.GzipCodec
-
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{DataFrame, QueryTest, Row}
 import org.apache.spark.sql.test.{SharedSQLContext, SQLTestUtils}
@@ -363,7 +361,7 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
       cars.coalesce(1).write
         .format("csv")
         .option("header", "true")
-        .option("compression", classOf[GzipCodec].getCanonicalName)
+        .option("compression", "gZiP")
         .save(csvDir)
 
       val compressedFiles = new File(csvDir).listFiles()


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-12871
This PR added an option to support to specify compression codec.
This adds the option `codec` as an alias `compression` as filed in [SPARK-12668 ](https://issues.apache.org/jira/browse/SPARK-12668).

Note that I did not add configurations for Hadoop 1.x as this `CsvRelation` is using Hadoop 2.x API and I guess it is going to drop Hadoop 1.x support.
