### PR TITLE
[MLLib] Fix CholeskyDecomposition assertion's message

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/CholeskyDecomposition.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/CholeskyDecomposition.scala
@@ -37,7 +37,7 @@ private[spark] object CholeskyDecomposition {
     val info = new intW(0)
     lapack.dppsv("U", k, 1, A, bx, k, info)
     val code = info.`val`
-    assert(code == 0, s"lapack.dpotrs returned $code.")
+    assert(code == 0, s"lapack.dppsv returned $code.")
     bx
   }
 


### PR DESCRIPTION
Change assertion's message so it's consistent with the code. The old message says that the invoked method was lapack.dports, where in fact it was lapack.dppsv method.
