### PR TITLE
[SPARK-12682][SQL] Add support for (optionally) not storing tables in hive metadata format

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -323,13 +323,12 @@ private[hive] class HiveMetastoreCatalog(val client: ClientInterface, hive: Hive
 
     // TODO: Support persisting partitioned data source relations in Hive compatible format
     val qualifiedTableName = tableIdent.quotedString
-    val skipHiveMetadata = options.getOrElse("skip_hive_metadata", "false").toBoolean
+    val skipHiveMetadata = options.getOrElse("skipHiveMetadata", "false").toBoolean
     val (hiveCompatibleTable, logMessage) = (maybeSerDe, dataSource.relation) match {
-      case (Some(serde), relation: HadoopFsRelation) if skipHiveMetadata =>
+      case _ if skipHiveMetadata =>
         val message =
           s"Persisting partitioned data source relation $qualifiedTableName into " +
-            "Hive metastore in Spark SQL specific format, which is NOT compatible with Hive. " +
-            "Input path(s): " + relation.paths.mkString("\n", "\n", "")
+            "Hive metastore in Spark SQL specific format, which is NOT compatible with Hive."
         (None, message)
 
       case (Some(serde), relation: HadoopFsRelation)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
@@ -857,9 +857,11 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with TestHiv
       partitionColumns = Array.empty[String],
       bucketSpec = None,
       provider = "parquet",
-      options = Map("path" -> "just a dummy path", "skip_hive_metadata" -> "false"),
+      options = Map("path" -> "just a dummy path", "skipHiveMetadata" -> "false"),
       isExternal = false)
 
+    // As a proxy for verifying that the table was stored in Hive compatible format, we verify that
+    // each column of the table is of native type StringType.
     assert(catalog.client.getTable("default", "not_skip_hive_metadata").schema
       .forall(column => HiveMetastoreTypes.toDataType(column.hiveType) == StringType))
 
@@ -869,9 +871,11 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with TestHiv
       partitionColumns = Array.empty[String],
       bucketSpec = None,
       provider = "parquet",
-      options = Map("path" -> "just a dummy path", "skip_hive_metadata" -> "true"),
+      options = Map("path" -> "just a dummy path", "skipHiveMetadata" -> "true"),
       isExternal = false)
 
+    // As a proxy for verifying that the table was stored in SparkSQL format, we verify that
+    // the table has a column type as array of StringType.
     assert(catalog.client.getTable("default", "skip_hive_metadata").schema
       .forall(column => HiveMetastoreTypes.toDataType(column.hiveType) == ArrayType(StringType)))
   }


### PR DESCRIPTION
This PR adds a new table option (`skip_hive_metadata`) that'd allow the user to skip storing the table metadata in hive metadata format. While this could be useful in general, the specific use-case for this change is that Hive doesn't handle wide schemas well (see https://issues.apache.org/jira/browse/SPARK-12682 and https://issues.apache.org/jira/browse/SPARK-6024) which in turn prevents such tables from being queried in SparkSQL.
