### PR TITLE
[SPARK-12905] [ML] [PySpark] PCAModel return eigenvalues for PySpark

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/PCA.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/PCA.scala
@@ -102,6 +102,8 @@ object PCA extends DefaultParamsReadable[PCA] {
  * Model fitted by [[PCA]].
  *
  * @param pc A principal components Matrix. Each column is one principal component.
+ * @param explainedVariance A vector of proportions of variance explained by
+ *                          each principal component.
  */
 @Experimental
 class PCAModel private[ml] (

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -1987,6 +1987,8 @@ class PCA(JavaEstimator, HasInputCol, HasOutputCol):
     >>> model = pca.fit(df)
     >>> model.transform(df).collect()[0].pca_features
     DenseVector([1.648..., -4.013...])
+    >>> model.explainedVariance
+    DenseVector([0.794..., 0.205...])
 
     .. versionadded:: 1.5.0
     """
@@ -2051,6 +2053,15 @@ class PCAModel(JavaModel):
         Each column is one principal component.
         """
         return self._call_java("pc")
+
+    @property
+    @since("2.0.0")
+    def explainedVariance(self):
+        """
+        Returns a vector of proportions of variance
+        explained by each principal component.
+        """
+        return self._call_java("explainedVariance")
 
 
 @inherit_doc


### PR DESCRIPTION
`PCAModel`  can output `explainedVariance` at Python side.

cc @mengxr @srowen 
