### PR TITLE
[BUILD] Runner for spark packages

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -294,7 +294,7 @@ object SparkBuild extends PomBuild {
 
     sparkPackage := {
       import complete.DefaultParsers._
-      val packages :: className :: otherArgs = spaceDelimited("<arg>").parsed.toList
+      val packages :: className :: otherArgs = spaceDelimited("<group:artifact:version> <MainClass> [args]").parsed.toList
       val scalaRun = (runner in run).value
       val classpath = (fullClasspath in Runtime).value
       val args = Seq("--packages", packages, "--class", className, (Keys.`package` in Compile in "core").value.getCanonicalPath) ++ otherArgs
@@ -307,7 +307,6 @@ object SparkBuild extends PomBuild {
     sparkSql := {
       (runMain in Compile).toTask(" org.apache.spark.sql.hive.thriftserver.SparkSQLCLIDriver").value
     }
-
   ))(assembly)
 
   enable(Seq(sparkShell := sparkShell in "assembly"))(spark)

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -274,7 +274,11 @@ object SparkBuild extends PomBuild {
    * Usage: `build/sbt sparkShell`
    */
   val sparkShell = taskKey[Unit]("start a spark-shell.")
-  val sparkPackage = inputKey[Unit]("download and run a spark package")
+  val sparkPackage = inputKey[Unit](
+    s"""
+       |Download and run a spark package.
+       |Usage `builds/sbt "sparkPackage <group:artifact:version> <MainClass> [args]
+     """.stripMargin)
   val sparkSql = taskKey[Unit]("starts the spark sql CLI.")
 
   enable(Seq(


### PR DESCRIPTION
This is a convenience method added to the SBT build for developers, though if people think its useful we could consider adding a official script that runs using the assembly instead of compiling on demand.  It simply compiles spark (without requiring an assembly), and invokes Spark Submit to download / run the package.

Example Usage:

```
$ build/sbt
> sparkPackage com.databricks:spark-sql-perf_2.10:0.2.4 com.databricks.spark.sql.perf.RunBenchmark --help
```
