### PR TITLE
[SPARK-12921] Use SparkHadoopUtil reflection in SpecificParquetRecordReaderBase

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/SpecificParquetRecordReaderBase.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/SpecificParquetRecordReaderBase.java
@@ -57,6 +57,8 @@ import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.hadoop.util.ConfigurationUtil;
 import org.apache.parquet.schema.MessageType;
 
+import org.apache.spark.deploy.SparkHadoopUtil;
+
 /**
  * Base class for custom RecordReaaders for Parquet that directly materialize to `T`.
  * This class handles computing row groups, filtering on them, setting up the column readers,
@@ -81,7 +83,8 @@ public abstract class SpecificParquetRecordReaderBase<T> extends RecordReader<Vo
 
   public void initialize(InputSplit inputSplit, TaskAttemptContext taskAttemptContext)
       throws IOException, InterruptedException {
-    Configuration configuration = taskAttemptContext.getConfiguration();
+    Configuration configuration =
+      SparkHadoopUtil.get.getConfigurationFromJobContext(taskAttemptContext);
     ParquetInputSplit split = (ParquetInputSplit)inputSplit;
     this.file = split.getPath();
     long[] rowGroupOffsets = split.getRowGroupOffsets();

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/SpecificParquetRecordReaderBase.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/SpecificParquetRecordReaderBase.java
@@ -84,7 +84,7 @@ public abstract class SpecificParquetRecordReaderBase<T> extends RecordReader<Vo
   public void initialize(InputSplit inputSplit, TaskAttemptContext taskAttemptContext)
       throws IOException, InterruptedException {
     Configuration configuration =
-      SparkHadoopUtil.get.getConfigurationFromJobContext(taskAttemptContext);
+      SparkHadoopUtil.get().getConfigurationFromJobContext(taskAttemptContext);
     ParquetInputSplit split = (ParquetInputSplit)inputSplit;
     this.file = split.getPath();
     long[] rowGroupOffsets = split.getRowGroupOffsets();


### PR DESCRIPTION
It looks like there's one place left in the codebase, SpecificParquetRecordReaderBase, where we didn't use SparkHadoopUtil's reflective accesses of TaskAttemptContext methods, which could create problems when using a single Spark artifact with both Hadoop 1.x and 2.x.
