### PR TITLE
[SPARK-12904][SQL] Strength reduction for integral/decimal comparisons

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
@@ -422,21 +422,21 @@ object HiveTypeCoercion {
       // 7. decimal_literal < int_col => floor(decimal_literal) < int_col
       // 8. decimal_literal <= int_col => ceil(decimal_literal) <= int_col
       case GreaterThan(i @ IntegralType(), Literal(value: Decimal, _: DecimalType)) =>
-        GreaterThan(i, Literal.create(value.floor.toInt, IntegerType))
+        GreaterThan(i, Literal.create(value.floor.toLong, LongType))
       case GreaterThanOrEqual(i @ IntegralType(), Literal(value: Decimal, _: DecimalType)) =>
-        GreaterThanOrEqual(i, Literal.create(value.ceil.toInt, IntegerType))
+        GreaterThanOrEqual(i, Literal.create(value.ceil.toLong, LongType))
       case LessThan(i @ IntegralType(), Literal(value: Decimal, _: DecimalType)) =>
-        LessThan(i, Literal.create(value.ceil.toInt, IntegerType))
+        LessThan(i, Literal.create(value.ceil.toLong, LongType))
       case LessThanOrEqual(i @ IntegralType(), Literal(value: Decimal, _: DecimalType)) =>
-        LessThanOrEqual(i, Literal.create(value.floor.toInt, IntegerType))
+        LessThanOrEqual(i, Literal.create(value.floor.toLong, LongType))
       case GreaterThan(Literal(value: Decimal, _: DecimalType), i @ IntegralType()) =>
-        GreaterThan(Literal.create(value.ceil.toInt, IntegerType), i)
+        GreaterThan(Literal.create(value.ceil.toLong, LongType), i)
       case GreaterThanOrEqual(Literal(value: Decimal, _: DecimalType), i @ IntegralType()) =>
-        GreaterThanOrEqual(Literal.create(value.floor.toInt, IntegerType), i)
+        GreaterThanOrEqual(Literal.create(value.floor.toLong, LongType), i)
       case LessThan(Literal(value: Decimal, _: DecimalType), i @ IntegralType()) =>
-        LessThan(Literal.create(value.floor.toInt, IntegerType), i)
+        LessThan(Literal.create(value.floor.toLong, LongType), i)
       case LessThanOrEqual(Literal(value: Decimal, _: DecimalType), i @ IntegralType()) =>
-        LessThanOrEqual(Literal.create(value.ceil.toInt, IntegerType), i)
+        LessThanOrEqual(Literal.create(value.ceil.toLong, LongType), i)
 
       // Promote integers inside a binary expression with fixed-precision decimals to decimals,
       // and fixed-precision decimals in an expression with floats / doubles to doubles

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
@@ -49,7 +49,6 @@ object HiveTypeCoercion {
       InConversion ::
       WidenSetOperationTypes ::
       PromoteStrings ::
-      SimplifyIntegerDecimalComparing ::
       DecimalPrecision ::
       BooleanEquality ::
       StringToIntegralCasts ::
@@ -463,6 +462,32 @@ object HiveTypeCoercion {
           val resultType = widerDecimalType(p1, s1, p2, s2)
           b.makeCopy(Array(Cast(e1, resultType), Cast(e2, resultType)))
 
+        // Strength reduction for comparisons between an integral column and a decimal literal:
+        // 1. int_col > decimal_literal => int_col > floor(decimal_literal)
+        // 2. int_col >= decimal_literal => int_col >= ceil(decimal_literal)
+        // 3. int_col < decimal_literal => int_col < ceil(decimal_literal)
+        // 4. int_col <= decimal_literal => int_col <= floor(decimal_literal)
+        // 5. decimal_literal > int_col => ceil(decimal_literal) > int_col
+        // 6. decimal_literal >= int_col => floor(decimal_literal) >= int_col
+        // 7. decimal_literal < int_col => floor(decimal_literal) < int_col
+        // 8. decimal_literal <= int_col => ceil(decimal_literal) <= int_col
+        case GreaterThan(i @ IntegerType(), Literal(value: Decimal, _: DecimalType)) =>
+          GreaterThan(i, Literal.create(value.floor.toInt, IntegerType))
+        case GreaterThanOrEqual(i @ IntegerType(), Literal(value: Decimal, _: DecimalType)) =>
+          GreaterThanOrEqual(i, Literal.create(value.ceil.toInt, IntegerType))
+        case LessThan(i @ IntegerType(), Literal(value: Decimal, _: DecimalType)) =>
+          LessThan(i, Literal.create(value.ceil.toInt, IntegerType))
+        case LessThanOrEqual(i @ IntegerType(), Literal(value: Decimal, _: DecimalType)) =>
+          LessThanOrEqual(i, Literal.create(value.floor.toInt, IntegerType))
+        case GreaterThan(Literal(value: Decimal, _: DecimalType), i @ IntegerType()) =>
+          GreaterThan(Literal.create(value.ceil.toInt, IntegerType), i)
+        case GreaterThanOrEqual(Literal(value: Decimal, _: DecimalType), i @ IntegerType()) =>
+          GreaterThanOrEqual(Literal.create(value.floor.toInt, IntegerType), i)
+        case LessThan(Literal(value: Decimal, _: DecimalType), i @ IntegerType()) =>
+          LessThan(Literal.create(value.floor.toInt, IntegerType), i)
+        case LessThanOrEqual(Literal(value: Decimal, _: DecimalType), i @ IntegerType()) =>
+          LessThanOrEqual(Literal.create(value.ceil.toInt, IntegerType), i)
+
         // Promote integers inside a binary expression with fixed-precision decimals to decimals,
         // and fixed-precision decimals in an expression with floats / doubles to doubles
         case b @ BinaryOperator(left, right) if left.dataType != right.dataType =>
@@ -693,43 +718,6 @@ object HiveTypeCoercion {
         Cast(TimeAdd(l, r), l.dataType)
       case Subtract(l, r @ CalendarIntervalType()) if acceptedTypes.contains(l.dataType) =>
         Cast(TimeSub(l, r), l.dataType)
-    }
-  }
-
-  /**
-   * Strength reduction for comparisons between an integral column and a decimal literal:
-   *
-   * 1. int_col > decimal_literal => int_col > floor(decimal_literal)
-   * 2. int_col >= decimal_literal => int_col >= ceil(decimal_literal)
-   * 3. int_col < decimal_literal => int_col < ceil(decimal_literal)
-   * 4. int_col <= decimal_literal => int_col <= floor(decimal_literal)
-   * 5. decimal_literal > int_col => ceil(decimal_literal) > int_col
-   * 6. decimal_literal >= int_col => floor(decimal_literal) >= int_col
-   * 7. decimal_literal < int_col => floor(decimal_literal) < int_col
-   * 8. decimal_literal <= int_col => ceil(decimal_literal) <= int_col
-   *
-   */
-  object SimplifyIntegerDecimalComparing extends Rule[LogicalPlan] {
-    def apply(plan: LogicalPlan): LogicalPlan = plan resolveExpressions {
-      // Skip nodes who's children have not been resolved yet.
-      case e if !e.childrenResolved => e
-
-      case GreaterThan(i @ IntegerType(), Literal(value: Decimal, _: DecimalType)) =>
-        GreaterThan(i, Literal.create(value.floor.toInt, IntegerType))
-      case GreaterThanOrEqual(i @ IntegerType(), Literal(value: Decimal, _: DecimalType)) =>
-        GreaterThanOrEqual(i, Literal.create(value.ceil.toInt, IntegerType))
-      case LessThan(i @ IntegerType(), Literal(value: Decimal, _: DecimalType)) =>
-        LessThan(i, Literal.create(value.ceil.toInt, IntegerType))
-      case LessThanOrEqual(i @ IntegerType(), Literal(value: Decimal, _: DecimalType)) =>
-        LessThanOrEqual(i, Literal.create(value.floor.toInt, IntegerType))
-      case GreaterThan(Literal(value: Decimal, _: DecimalType), i @ IntegerType()) =>
-        GreaterThan(Literal.create(value.ceil.toInt, IntegerType), i)
-      case GreaterThanOrEqual(Literal(value: Decimal, _: DecimalType), i @ IntegerType()) =>
-        GreaterThanOrEqual(Literal.create(value.floor.toInt, IntegerType), i)
-      case LessThan(Literal(value: Decimal, _: DecimalType), i @ IntegerType()) =>
-        LessThan(Literal.create(value.floor.toInt, IntegerType), i)
-      case LessThanOrEqual(Literal(value: Decimal, _: DecimalType), i @ IntegerType()) =>
-        LessThanOrEqual(Literal.create(value.ceil.toInt, IntegerType), i)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
@@ -502,7 +502,7 @@ object HiveTypeCoercion {
         CheckOverflow(Pmod(promotePrecision(e1, widerType), promotePrecision(e2, widerType)),
           resultType)
 
-      case _ => e
+      case _ => binaryOperator(e)
     }
 
     def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
@@ -512,8 +512,7 @@ object HiveTypeCoercion {
         // Skip nodes whose children have not been resolved yet
         case e if !e.childrenResolved => e
 
-        case e: BinaryArithmetic => binaryArithmetic(e)
-        case e: BinaryOperator => binaryOperator(e)
+        case e: BinaryOperator => binaryArithmetic(e)
 
         // TODO: MaxOf, MinOf, etc might want other rules
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercionSuite.scala
@@ -524,78 +524,82 @@ class HiveTypeCoercionSuite extends PlanTest {
   test("strength reduction for integer/decimal comparisons") {
     val rule = HiveTypeCoercion.DecimalPrecision
 
-    // If a is an int.
-    // a > 4.7 => a > 4
-    // e.g., 5 > 4.7 == 5 > 4  (true)
-    //       4 > 4.7 == 4 > 4  (false)
-    ruleTest(rule,
-      GreaterThan(AttributeReference("a", IntegerType)(),
-        Literal.create(Decimal(4.7), new DecimalType())),
-      GreaterThan(AttributeReference("a", IntegerType)(),
-        Literal.create(4, IntegerType)))
+    def testRule(dt: DataType): Unit = {
+      // If a is an int.
+      // a > 4.7 => a > 4
+      // e.g., 5 > 4.7 == 5 > 4  (true)
+      //       4 > 4.7 == 4 > 4  (false)
+      ruleTest(rule,
+        GreaterThan(AttributeReference("a", dt)(),
+          Literal.create(Decimal(4.7), new DecimalType())),
+        GreaterThan(AttributeReference("a", dt)(),
+          Literal.create(4L, LongType)))
 
-    // a >= 4.7 => a >= 5
-    // e.g., 5 >= 4.7 == 5 >= 5  (true)
-    //       4 >= 4.7 == 4 >= 5  (false)
-    ruleTest(rule,
-      GreaterThanOrEqual(AttributeReference("a", IntegerType)(),
-        Literal.create(Decimal(4.7), new DecimalType())),
-      GreaterThanOrEqual(AttributeReference("a", IntegerType)(),
-        Literal.create(5, IntegerType)))
+      // a >= 4.7 => a >= 5
+      // e.g., 5 >= 4.7 == 5 >= 5  (true)
+      //       4 >= 4.7 == 4 >= 5  (false)
+      ruleTest(rule,
+        GreaterThanOrEqual(AttributeReference("a", dt)(),
+          Literal.create(Decimal(4.7), new DecimalType())),
+        GreaterThanOrEqual(AttributeReference("a", dt)(),
+          Literal.create(5L, LongType)))
 
-    // a < 4.7 => a < 5
-    // e.g., 5 < 4.7 == 5 < 5   (false)
-    //       4 < 4.7 == 4 < 5   (true)
-    ruleTest(rule,
-      LessThan(AttributeReference("a", IntegerType)(),
-        Literal.create(Decimal(4.7), new DecimalType())),
-      LessThan(AttributeReference("a", IntegerType)(),
-        Literal.create(5, IntegerType)))
+      // a < 4.7 => a < 5
+      // e.g., 5 < 4.7 == 5 < 5   (false)
+      //       4 < 4.7 == 4 < 5   (true)
+      ruleTest(rule,
+        LessThan(AttributeReference("a", dt)(),
+          Literal.create(Decimal(4.7), new DecimalType())),
+        LessThan(AttributeReference("a", dt)(),
+          Literal.create(5L, LongType)))
 
-    // a <= 4.7 => a <= 4
-    // e.g., 5 <= 4.7 == 5 <= 4  (false)
-    //       4 <= 4.7 == 4 <= 4  (true)
-    ruleTest(rule,
-      LessThanOrEqual(AttributeReference("a", IntegerType)(),
-        Literal.create(Decimal(4.7), new DecimalType())),
-      LessThanOrEqual(AttributeReference("a", IntegerType)(),
-        Literal.create(4, IntegerType)))
+      // a <= 4.7 => a <= 4
+      // e.g., 5 <= 4.7 == 5 <= 4  (false)
+      //       4 <= 4.7 == 4 <= 4  (true)
+      ruleTest(rule,
+        LessThanOrEqual(AttributeReference("a", dt)(),
+          Literal.create(Decimal(4.7), new DecimalType())),
+        LessThanOrEqual(AttributeReference("a", dt)(),
+          Literal.create(4L, LongType)))
 
-    // 4.7 > a => 5 > a
-    // e.g., 4.7 > 5 == 5 > 5   (false)
-    //       4.7 > 4 == 5 > 4   (true)
-    ruleTest(rule,
-      GreaterThan(Literal.create(Decimal(4.7), new DecimalType()),
-        AttributeReference("a", IntegerType)()),
-      GreaterThan(Literal.create(5, IntegerType),
-        AttributeReference("a", IntegerType)()))
+      // 4.7 > a => 5 > a
+      // e.g., 4.7 > 5 == 5 > 5   (false)
+      //       4.7 > 4 == 5 > 4   (true)
+      ruleTest(rule,
+        GreaterThan(Literal.create(Decimal(4.7), new DecimalType()),
+          AttributeReference("a", dt)()),
+        GreaterThan(Literal.create(5L, LongType),
+          AttributeReference("a", dt)()))
 
-    // 4.7 >= a => 4 >= a
-    // e.g., 4.7 >= 5 == 4 >= 5  (false)
-    //       4.7 >= 4 == 4 >= 4  (true)
-    ruleTest(rule,
-      GreaterThanOrEqual(Literal.create(Decimal(4.7), new DecimalType()),
-        AttributeReference("a", IntegerType)()),
-      GreaterThanOrEqual(Literal.create(4, IntegerType),
-        AttributeReference("a", IntegerType)()))
+      // 4.7 >= a => 4 >= a
+      // e.g., 4.7 >= 5 == 4 >= 5  (false)
+      //       4.7 >= 4 == 4 >= 4  (true)
+      ruleTest(rule,
+        GreaterThanOrEqual(Literal.create(Decimal(4.7), new DecimalType()),
+          AttributeReference("a", dt)()),
+        GreaterThanOrEqual(Literal.create(4L, LongType),
+          AttributeReference("a", dt)()))
 
-    // 4.7 < a => 4 < a
-    // e.g., 4.7 < 5 == 4 < 5   (true)
-    //       4.7 < 4 == 4 < 4   (false)
-    ruleTest(rule,
-      LessThan(Literal.create(Decimal(4.7), new DecimalType()),
-        AttributeReference("a", IntegerType)()),
-      LessThan(Literal.create(4, IntegerType),
-        AttributeReference("a", IntegerType)()))
+      // 4.7 < a => 4 < a
+      // e.g., 4.7 < 5 == 4 < 5   (true)
+      //       4.7 < 4 == 4 < 4   (false)
+      ruleTest(rule,
+        LessThan(Literal.create(Decimal(4.7), new DecimalType()),
+          AttributeReference("a", dt)()),
+        LessThan(Literal.create(4L, LongType),
+          AttributeReference("a", dt)()))
 
-    // 4.7 <= a => 5 <= a
-    // e.g., 4.7 <= 5 == 5 <= 5  (true)
-    //       4.7 <= 4 == 5 <= 4  (false)
-    ruleTest(rule,
-      LessThanOrEqual(Literal.create(Decimal(4.7), new DecimalType()),
-        AttributeReference("a", IntegerType)()),
-      LessThanOrEqual(Literal.create(5, IntegerType),
-        AttributeReference("a", IntegerType)()))
+      // 4.7 <= a => 5 <= a
+      // e.g., 4.7 <= 5 == 5 <= 5  (true)
+      //       4.7 <= 4 == 5 <= 4  (false)
+      ruleTest(rule,
+        LessThanOrEqual(Literal.create(Decimal(4.7), new DecimalType()),
+          AttributeReference("a", dt)()),
+        LessThanOrEqual(Literal.create(5L, LongType),
+          AttributeReference("a", dt)()))
+    }
+
+    Seq(ByteType, ShortType, IntegerType, LongType).map(testRule)
   }
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercionSuite.scala
@@ -522,7 +522,7 @@ class HiveTypeCoercionSuite extends PlanTest {
   }
 
   test("strength reduction for integer/decimal comparisons") {
-    val rule = HiveTypeCoercion.SimplifyIntegerDecimalComparing
+    val rule = HiveTypeCoercion.DecimalPrecision
 
     // If a is an int.
     // a > 4.7 => a > 4

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercionSuite.scala
@@ -520,6 +520,83 @@ class HiveTypeCoercionSuite extends PlanTest {
         Seq(Cast(Literal(1), StringType), Cast(Literal("b"), StringType)))
     )
   }
+
+  test("strength reduction for integer/decimal comparisons") {
+    val rule = HiveTypeCoercion.SimplifyIntegerDecimalComparing
+
+    // If a is an int.
+    // a > 4.7 => a > 4
+    // e.g., 5 > 4.7 == 5 > 4  (true)
+    //       4 > 4.7 == 4 > 4  (false)
+    ruleTest(rule,
+      GreaterThan(AttributeReference("a", IntegerType)(),
+        Literal.create(Decimal(4.7), new DecimalType())),
+      GreaterThan(AttributeReference("a", IntegerType)(),
+        Literal.create(4, IntegerType)))
+
+    // a >= 4.7 => a >= 5
+    // e.g., 5 >= 4.7 == 5 >= 5  (true)
+    //       4 >= 4.7 == 4 >= 5  (false)
+    ruleTest(rule,
+      GreaterThanOrEqual(AttributeReference("a", IntegerType)(),
+        Literal.create(Decimal(4.7), new DecimalType())),
+      GreaterThanOrEqual(AttributeReference("a", IntegerType)(),
+        Literal.create(5, IntegerType)))
+
+    // a < 4.7 => a < 5
+    // e.g., 5 < 4.7 == 5 < 5   (false)
+    //       4 < 4.7 == 4 < 5   (true)
+    ruleTest(rule,
+      LessThan(AttributeReference("a", IntegerType)(),
+        Literal.create(Decimal(4.7), new DecimalType())),
+      LessThan(AttributeReference("a", IntegerType)(),
+        Literal.create(5, IntegerType)))
+
+    // a <= 4.7 => a <= 4
+    // e.g., 5 <= 4.7 == 5 <= 4  (false)
+    //       4 <= 4.7 == 4 <= 4  (true)
+    ruleTest(rule,
+      LessThanOrEqual(AttributeReference("a", IntegerType)(),
+        Literal.create(Decimal(4.7), new DecimalType())),
+      LessThanOrEqual(AttributeReference("a", IntegerType)(),
+        Literal.create(4, IntegerType)))
+
+    // 4.7 > a => 5 > a
+    // e.g., 4.7 > 5 == 5 > 5   (false)
+    //       4.7 > 4 == 5 > 4   (true)
+    ruleTest(rule,
+      GreaterThan(Literal.create(Decimal(4.7), new DecimalType()),
+        AttributeReference("a", IntegerType)()),
+      GreaterThan(Literal.create(5, IntegerType),
+        AttributeReference("a", IntegerType)()))
+
+    // 4.7 >= a => 4 >= a
+    // e.g., 4.7 >= 5 == 4 >= 5  (false)
+    //       4.7 >= 4 == 4 >= 4  (true)
+    ruleTest(rule,
+      GreaterThanOrEqual(Literal.create(Decimal(4.7), new DecimalType()),
+        AttributeReference("a", IntegerType)()),
+      GreaterThanOrEqual(Literal.create(4, IntegerType),
+        AttributeReference("a", IntegerType)()))
+
+    // 4.7 < a => 4 < a
+    // e.g., 4.7 < 5 == 4 < 5   (true)
+    //       4.7 < 4 == 4 < 4   (false)
+    ruleTest(rule,
+      LessThan(Literal.create(Decimal(4.7), new DecimalType()),
+        AttributeReference("a", IntegerType)()),
+      LessThan(Literal.create(4, IntegerType),
+        AttributeReference("a", IntegerType)()))
+
+    // 4.7 <= a => 5 <= a
+    // e.g., 4.7 <= 5 == 5 <= 5  (true)
+    //       4.7 <= 4 == 5 <= 4  (false)
+    ruleTest(rule,
+      LessThanOrEqual(Literal.create(Decimal(4.7), new DecimalType()),
+        AttributeReference("a", IntegerType)()),
+      LessThanOrEqual(Literal.create(5, IntegerType),
+        AttributeReference("a", IntegerType)()))
+  }
 }
 
 


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-12904

We can do the following strength reduction for comparisons between an integral column and a decimal literal:
1. int_col > decimal_literal => int_col > floor(decimal_literal)
2. int_col >= decimal_literal => int_col >= ceil(decimal_literal)
3. int_col < decimal_literal => int_col < ceil(decimal_literal)
4. int_col <= decimal_literal => int_col <= floor(decimal_literal)
5. decimal_literal > int_col => ceil(decimal_literal) > int_col
6. decimal_literal >= int_col => floor(decimal_literal) >= int_col
7. decimal_literal < int_col => floor(decimal_literal) < int_col
8. decimal_literal <= int_col => ceil(decimal_literal) <= int_col
