### PR TITLE
[SPARK-12924][SQL] Make Token pattern matching in the parser case insensitive

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ASTNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ASTNode.scala
@@ -30,7 +30,7 @@ case class ASTNode(
   val numChildren = children.size
 
   /** tuple used in pattern matching. */
-  val pattern = Some((token.getText, children))
+  val pattern = Some((token.getText.toUpperCase, children))
 
   /** Line in which the ASTNode starts. */
   lazy val line: Int = {


### PR DESCRIPTION
In addition, I also moved the regular expressions into the companion object, so we don't need to recompile the regexes for every new instance of CatalystQl.
