### PR TITLE
[SPARK-12926][SQL] SQLContext to display warning message when non-sql configs are being set

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
@@ -19,13 +19,12 @@ package org.apache.spark.sql
 
 import java.util.Properties
 
-import org.apache.spark.Logging
-
 import scala.collection.immutable
 import scala.collection.JavaConverters._
 
 import org.apache.parquet.hadoop.ParquetOutputCommitter
 
+import org.apache.spark.Logging
 import org.apache.spark.sql.catalyst.CatalystConf
 import org.apache.spark.sql.catalyst.parser.ParserConf
 import org.apache.spark.util.Utils

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql
 
 import java.util.Properties
 
-import org.apache.spark.SparkException
+import org.apache.spark.Logging
 
 import scala.collection.immutable
 import scala.collection.JavaConverters._
@@ -513,7 +513,7 @@ private[spark] object SQLConf {
  *
  * SQLConf is thread-safe (internally synchronized, so safe to be used in multiple threads).
  */
-private[sql] class SQLConf extends Serializable with CatalystConf with ParserConf {
+private[sql] class SQLConf extends Serializable with CatalystConf with ParserConf with Logging {
   import SQLConf._
 
   /** Only low degree of contention is expected for conf, thus NOT using ConcurrentHashMap. */
@@ -693,8 +693,7 @@ private[sql] class SQLConf extends Serializable with CatalystConf with ParserCon
 
   private def setConfWithCheck(key: String, value: String): Unit = {
     if (key.startsWith("spark.") && !key.startsWith("spark.sql.")) {
-      throw new SparkException(
-        s"Attempt to set non-Spark SQL config in SQLConf: key = $key, value = $value")
+      logWarning(s"Attempt to set non-Spark SQL config in SQLConf: key = $key, value = $value")
     }
     settings.put(key, value)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLConfSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql
 
+import org.apache.spark.SparkException
 import org.apache.spark.sql.test.{SharedSQLContext, TestSQLContext}
 
 class SQLConfSuite extends QueryTest with SharedSQLContext {
@@ -91,6 +92,16 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
       sql(s"set ${SQLConf.CASE_SENSITIVE.key}=10")
     }
     assert(e.getMessage === s"${SQLConf.CASE_SENSITIVE.key} should be boolean, but was 10")
+  }
+
+  test("passing Spark config other than Spark SQL ones") {
+    sqlContext.conf.clear()
+    val key = "spark.some.config"
+    val value = "foo"
+    val e = intercept[SparkException] {
+      sql(s"set $key=$value")
+    }
+    assert(e.getMessage === s"Attempt to set non-Spark SQL config in SQLConf: key = $key, value = $value")
   }
 
   test("Test SHUFFLE_TARGET_POSTSHUFFLE_INPUT_SIZE's method") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLConfSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql
 
-import org.apache.spark.SparkException
 import org.apache.spark.sql.test.{SharedSQLContext, TestSQLContext}
 
 class SQLConfSuite extends QueryTest with SharedSQLContext {
@@ -92,16 +91,6 @@ class SQLConfSuite extends QueryTest with SharedSQLContext {
       sql(s"set ${SQLConf.CASE_SENSITIVE.key}=10")
     }
     assert(e.getMessage === s"${SQLConf.CASE_SENSITIVE.key} should be boolean, but was 10")
-  }
-
-  test("passing Spark config other than Spark SQL ones") {
-    sqlContext.conf.clear()
-    val key = "spark.some.config"
-    val value = "foo"
-    val e = intercept[SparkException] {
-      sql(s"set $key=$value")
-    }
-    assert(e.getMessage === s"Attempt to set non-Spark SQL config in SQLConf: key = $key, value = $value")
   }
 
   test("Test SHUFFLE_TARGET_POSTSHUFFLE_INPUT_SIZE's method") {


### PR DESCRIPTION
Users unknowingly try to set core Spark configs in SQLContext but later realise that it didn't work. eg. sqlContext.sql("SET spark.shuffle.memoryFraction=0.4"). This PR adds a warning message when such operations are done.
