### PR TITLE
[SPARK-7799][Streaming][Document]Add the linking and deploying instructions for streaming-akka project

### DIFF
--- a/docs/streaming-custom-receivers.md
+++ b/docs/streaming-custom-receivers.md
@@ -257,12 +257,22 @@ The following table summarizes the characteristics of both types of receivers
 
 ## Implementing and Using a Custom Actor-based Receiver
 
+Custom [Akka Actors](http://doc.akka.io/docs/akka/2.3.11/scala/actors.html) can also be used to
+receive data. Here are the instructions.
+
+1. **Linking:** You need to add the following dependency to your SBT or Maven project (see [Linking section](streaming-programming-guide.html#linking) in the main programming guide for further information).
+
+		groupId = org.apache.spark
+		artifactId = spark-streaming-akka_{{site.SCALA_BINARY_VERSION}}
+		version = {{site.SPARK_VERSION_SHORT}}
+
+2. **Programming:**
+
 <div class="codetabs">
 <div data-lang="scala"  markdown="1" >
 
-Custom [Akka Actors](http://doc.akka.io/docs/akka/2.3.11/scala/actors.html) can also be used to
-receive data. Extending [`ActorReceiver`](api/scala/index.html#org.apache.spark.streaming.akka.ActorReceiver)
-allows received data to be stored in Spark using `store(...)` methods. The supervisor strategy of
+You need to extend [`ActorReceiver`](api/scala/index.html#org.apache.spark.streaming.akka.ActorReceiver)
+so as to store received data into Spark using `store(...)` methods. The supervisor strategy of
 this actor can be configured to handle failures, etc.
 
 {% highlight scala %}
@@ -283,9 +293,8 @@ See [ActorWordCount.scala](https://github.com/apache/spark/blob/master/examples/
 </div>
 <div data-lang="java" markdown="1">
 
-Custom [Akka UntypedActors](http://doc.akka.io/docs/akka/2.3.11/java/untyped-actors.html) can also be used to
-receive data. Extending [`JavaActorReceiver`](api/scala/index.html#org.apache.spark.streaming.akka.JavaActorReceiver)
-allows received data to be stored in Spark using `store(...)` methods. The supervisor strategy of
+You need to extend [`JavaActorReceiver`](api/scala/index.html#org.apache.spark.streaming.akka.JavaActorReceiver)
+so as to store received data into Spark using `store(...)` methods. The supervisor strategy of
 this actor can be configured to handle failures, etc.
 
 {% highlight java %}

--- a/docs/streaming-custom-receivers.md
+++ b/docs/streaming-custom-receivers.md
@@ -268,52 +268,50 @@ receive data. Here are the instructions.
 
 2. **Programming:**
 
-<div class="codetabs">
-<div data-lang="scala"  markdown="1" >
+	<div class="codetabs">
+	<div data-lang="scala"  markdown="1" >
 
-You need to extend [`ActorReceiver`](api/scala/index.html#org.apache.spark.streaming.akka.ActorReceiver)
-so as to store received data into Spark using `store(...)` methods. The supervisor strategy of
-this actor can be configured to handle failures, etc.
+	You need to extend [`ActorReceiver`](api/scala/index.html#org.apache.spark.streaming.akka.ActorReceiver)
+	so as to store received data into Spark using `store(...)` methods. The supervisor strategy of
+	this actor can be configured to handle failures, etc.
 
-{% highlight scala %}
+		class CustomActor extends ActorReceiver {
+		  def receive = {
+		    case data: String => store(data)
+		  }
+		}
 
-class CustomActor extends ActorReceiver {
-  def receive = {
-    case data: String => store(data)
-  }
-}
+		// A new input stream can be created with this custom actor as
+		val ssc: StreamingContext = ...
+		val lines = AkkaUtils.createStream[String](ssc, Props[CustomActor](), "CustomReceiver")
 
-// A new input stream can be created with this custom actor as
-val ssc: StreamingContext = ...
-val lines = AkkaUtils.createStream[String](ssc, Props[CustomActor](), "CustomReceiver")
+	See [ActorWordCount.scala](https://github.com/apache/spark/blob/master/examples/src/main/scala/org/apache/spark/examples/streaming/ActorWordCount.scala) for an end-to-end example.
+	</div>
+	<div data-lang="java" markdown="1">
 
-{% endhighlight %}
+	You need to extend [`JavaActorReceiver`](api/scala/index.html#org.apache.spark.streaming.akka.JavaActorReceiver)
+	so as to store received data into Spark using `store(...)` methods. The supervisor strategy of
+	this actor can be configured to handle failures, etc.
 
-See [ActorWordCount.scala](https://github.com/apache/spark/blob/master/examples/src/main/scala/org/apache/spark/examples/streaming/ActorWordCount.scala) for an end-to-end example.
-</div>
-<div data-lang="java" markdown="1">
+		class CustomActor extends JavaActorReceiver {
+		  @Override
+		  public void onReceive(Object msg) throws Exception {
+		    store((String) msg);
+		  }
+		}
 
-You need to extend [`JavaActorReceiver`](api/scala/index.html#org.apache.spark.streaming.akka.JavaActorReceiver)
-so as to store received data into Spark using `store(...)` methods. The supervisor strategy of
-this actor can be configured to handle failures, etc.
+		// A new input stream can be created with this custom actor as
+		JavaStreamingContext jssc = ...;
+		JavaDStream<String> lines = AkkaUtils.<String>createStream(jssc, Props.create(CustomActor.class), "CustomReceiver");
 
-{% highlight java %}
+	See [JavaActorWordCount.scala](https://github.com/apache/spark/blob/master/examples/src/main/scala/org/apache/spark/examples/streaming/JavaActorWordCount.scala) for an end-to-end example.
+	</div>
+	</div>
 
-class CustomActor extends JavaActorReceiver {
-  @Override
-  public void onReceive(Object msg) throws Exception {
-    store((String) msg);
-  }
-}
-
-// A new input stream can be created with this custom actor as
-JavaStreamingContext jssc = ...;
-JavaDStream<String> lines = AkkaUtils.<String>createStream(jssc, Props.create(CustomActor.class), "CustomReceiver");
-
-{% endhighlight %}
-
-See [JavaActorWordCount.scala](https://github.com/apache/spark/blob/master/examples/src/main/scala/org/apache/spark/examples/streaming/JavaActorWordCount.scala) for an end-to-end example.
-</div>
-</div>
+3. **Deploying:** As with any Spark applications, `spark-submit` is used to launch your application.
+You need to package `spark-streaming-akka_{{site.SCALA_BINARY_VERSION}}` and its dependencies into
+the application JAR. Make sure `spark-core_{{site.SCALA_BINARY_VERSION}}` and `spark-streaming_{{site.SCALA_BINARY_VERSION}}`
+are marked as `provided` dependencies as those are already present in a Spark installation. Then
+use `spark-submit` to launch your application (see [Deploying section](streaming-programming-guide.html#deploying-applications) in the main programming guide).
 
 <span class="badge" style="background-color: grey">Python API</span> Since actors are available only in the Java and Scala libraries, AkkaUtils is not available in the Python API.


### PR DESCRIPTION
Since `actorStream` is an external project, we should add the linking and deploying instructions for it.

A follow up PR of #10744
