### PR TITLE
SPARK-12948. [SQL]. Consider reducing size of broadcasts in OrcRelation

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -967,6 +967,29 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
     new HadoopRDD(this, conf, inputFormatClass, keyClass, valueClass, minPartitions)
   }
 
+  /**
+    * Get an RDD for a Hadoop-readable dataset from the Hadoop JobConf.
+    *
+    * @param broadcastedConf A general Hadoop Configuration, or a subclass of it.
+    * @param initLocalJobConfFuncOpt Optional closure used to initialize any JobConf
+    *                                that HadoopRDD creates.
+    * @param inputFormatClass Class of the InputFormat
+    * @param keyClass Class of the keys
+    * @param valueClass Class of the values
+    * @param minPartitions Minimum number of Hadoop Splits to generate.
+    */
+  def hadoopRDD[K, V](
+      broadcastedConf: Broadcast[SerializableConfiguration],
+      initLocalJobConfFuncOpt: Option[JobConf => Unit],
+      inputFormatClass: Class[_ <: InputFormat[K, V]],
+      keyClass: Class[K],
+      valueClass: Class[V],
+      minPartitions: Int = defaultMinPartitions): RDD[(K, V)] = withScope {
+    assertNotStopped()
+    new HadoopRDD(this, broadcastedConf, initLocalJobConfFuncOpt,
+      inputFormatClass, keyClass, valueClass, minPartitions)
+  }
+
   /** Get an RDD for a Hadoop file with an arbitrary InputFormat
    *
    * '''Note:''' Because Hadoop's RecordReader class re-uses the same Writable object for each

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1006,7 +1006,7 @@ class DAGScheduler(
         case stage: ResultStage =>
           JavaUtils.bufferToArray(closureSerializer.serialize((stage.rdd, stage.func): AnyRef))
       }
-
+      logDebug(s"Size of broadcasted task binary: ${taskBinaryBytes.length}")
       taskBinary = sc.broadcast(taskBinaryBytes)
     } catch {
       // In the case of a failure during serialization, abort the stage.


### PR DESCRIPTION
Size of broadcasted data in OrcRelation was significantly higher when running query with large number of partitions (e.g TPC-DS). And it has an impact on the job runtime. This would be more evident when there is large number of partitions/splits. Profiler snapshot is attached in SPARK-12948 (https://issues.apache.org/jira/secure/attachment/12783513/SPARK-12948_cpuProf.png). 
