### PR TITLE
[SPARK-12960] [Python] Some examples are missing support for python2

### DIFF
--- a/examples/src/main/python/streaming/direct_kafka_wordcount.py
+++ b/examples/src/main/python/streaming/direct_kafka_wordcount.py
@@ -28,6 +28,7 @@
       examples/src/main/python/streaming/direct_kafka_wordcount.py \
       localhost:9092 test`
 """
+from __future__ import print_function
 
 import sys
 

--- a/extras/kinesis-asl/src/main/python/examples/streaming/kinesis_wordcount_asl.py
+++ b/extras/kinesis-asl/src/main/python/examples/streaming/kinesis_wordcount_asl.py
@@ -54,6 +54,8 @@
   See http://spark.apache.org/docs/latest/streaming-kinesis-integration.html for more details on
   the Kinesis Spark Streaming integration.
 """
+from __future__ import print_function
+
 import sys
 
 from pyspark import SparkContext


### PR DESCRIPTION
Without importing the print_function, the lines later on like `print("Usage: direct_kafka_wordcount.py <broker_list> <topic>", file=sys.stderr)` fail when using python2.*. Import fixes that problem and doesn't break anything on python3 either.
