### PR TITLE
[SPARK-12859] [Streaming] [Web UI] Names of input streams with receivers don't fit in Streaming page

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingPage.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingPage.scala
@@ -466,7 +466,7 @@ private[ui] class StreamingPage(parent: StreamingTab)
     <tr>
       <td rowspan="2" style="vertical-align: middle; width: 151px;">
         <div style="width: 151px;">
-          <div><strong>{receiverName}</strong></div>
+          <div style="word-wrap: break-word;"><strong>{receiverName}</strong></div>
           <div>Avg: {receivedRecords.formattedAvg} events/sec</div>
         </div>
       </td>


### PR DESCRIPTION
Added CSS style to force names of input streams with receivers to wrap
