### PR TITLE
[SPARK-12962] [SQL] [PySpark] PySpark support covar_samp and covar_pop

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -252,11 +252,11 @@ def corr(col1, col2):
     """Returns a new :class:`Column` for the Pearson Correlation Coefficient for ``col1``
     and ``col2``.
 
-    >>> a = [x * x - 2 * x + 3.5 for x in range(20)]
-    >>> b = range(20)
-    >>> df = sqlContext.createDataFrame(zip(a, b))
-    >>> df.agg(corr(df._1, df._2))
-    DataFrame[corr(_1,_2): double]
+    >>> a = range(20)
+    >>> b = [2 * x for x in range(20)]
+    >>> df = sqlContext.createDataFrame(zip(a, b), ["a", "b"])
+    >>> df.agg(corr("a", "b")).collect()
+    [Row(corr(a,b,0,0)=1.0)]
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.corr(_to_java_column(col1), _to_java_column(col2)))
@@ -267,11 +267,11 @@ def covar_pop(col1, col2):
     """Returns a new :class:`Column` for the population covariance of ``col1``
     and ``col2``.
 
-    >>> a = [x * x - 2 * x + 3.5 for x in range(20)]
-    >>> b = range(20)
+    >>> a = [1] * 10
+    >>> b = [1] * 10
     >>> df = sqlContext.createDataFrame(zip(a, b), ["a", "b"])
-    >>> df.agg(covar_pop("a", "b"))
-    DataFrame[covar_pop(a,b): double]
+    >>> df.agg(covar_pop("a", "b")).collect()
+    [Row(covpopulation(a,b,0,0)=0.0)]
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.covar_pop(_to_java_column(col1), _to_java_column(col2)))
@@ -282,11 +282,11 @@ def covar_samp(col1, col2):
     """Returns a new :class:`Column` for the sample covariance of ``col1``
     and ``col2``.
 
-    >>> a = [x * x - 2 * x + 3.5 for x in range(20)]
-    >>> b = range(20)
+    >>> a = [1] * 10
+    >>> b = [1] * 10
     >>> df = sqlContext.createDataFrame(zip(a, b), ["a", "b"])
-    >>> df.agg(covar_samp("a", "b"))
-    DataFrame[covar_samp(a,b): double]
+    >>> df.agg(covar_samp("a", "b")).collect()
+    [Row(covsample(a,b,0,0)=0.0)]
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.covar_samp(_to_java_column(col1), _to_java_column(col2)))

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -255,8 +255,8 @@ def corr(col1, col2):
     >>> a = range(20)
     >>> b = [2 * x for x in range(20)]
     >>> df = sqlContext.createDataFrame(zip(a, b), ["a", "b"])
-    >>> df.agg(corr("a", "b")).collect()
-    [Row(corr(a,b,0,0)=1.0)]
+    >>> df.agg(corr("a", "b").alias('c')).collect()
+    [Row(c=1.0)]
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.corr(_to_java_column(col1), _to_java_column(col2)))
@@ -270,8 +270,8 @@ def covar_pop(col1, col2):
     >>> a = [1] * 10
     >>> b = [1] * 10
     >>> df = sqlContext.createDataFrame(zip(a, b), ["a", "b"])
-    >>> df.agg(covar_pop("a", "b")).collect()
-    [Row(covpopulation(a,b,0,0)=0.0)]
+    >>> df.agg(covar_pop("a", "b").alias('c')).collect()
+    [Row(c=0.0)]
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.covar_pop(_to_java_column(col1), _to_java_column(col2)))
@@ -285,8 +285,8 @@ def covar_samp(col1, col2):
     >>> a = [1] * 10
     >>> b = [1] * 10
     >>> df = sqlContext.createDataFrame(zip(a, b), ["a", "b"])
-    >>> df.agg(covar_samp("a", "b")).collect()
-    [Row(covsample(a,b,0,0)=0.0)]
+    >>> df.agg(covar_samp("a", "b").alias('c')).collect()
+    [Row(c=0.0)]
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.covar_samp(_to_java_column(col1), _to_java_column(col2)))

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -254,10 +254,8 @@ def corr(col1, col2):
 
     >>> a = [x * x - 2 * x + 3.5 for x in range(20)]
     >>> b = range(20)
-    >>> corrDf = sqlContext.createDataFrame(zip(a, b))
-    >>> corrDf = corrDf.agg(corr(corrDf._1, corrDf._2).alias('c'))
-    >>> corrDf.selectExpr('abs(c - 0.9572339139475857) < 1e-16 as t').collect()
-    [Row(t=True)]
+    >>> df = sqlContext.createDataFrame(zip(a, b))
+    >>> df.agg(corr(df._1, df._2))
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.corr(_to_java_column(col1), _to_java_column(col2)))
@@ -271,9 +269,7 @@ def covar_pop(col1, col2):
     >>> a = [x * x - 2 * x + 3.5 for x in range(20)]
     >>> b = range(20)
     >>> df = sqlContext.createDataFrame(zip(a, b), ["a", "b"])
-    >>> covDf = df.agg(covar_pop("a", "b").alias('c'))
-    >>> covDf.select("c").collect()
-    [Row(c=565.25)]
+    >>> df.agg(covar_pop("a", "b"))
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.covar_pop(_to_java_column(col1), _to_java_column(col2)))
@@ -287,9 +283,7 @@ def covar_samp(col1, col2):
     >>> a = [x * x - 2 * x + 3.5 for x in range(20)]
     >>> b = range(20)
     >>> df = sqlContext.createDataFrame(zip(a, b), ["a", "b"])
-    >>> covDf = df.agg(covar_samp("a", "b").alias('c'))
-    >>> covDf.select("c").collect()
-    [Row(c=595.0)]
+    >>> df.agg(covar_samp("a", "b"))
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.covar_samp(_to_java_column(col1), _to_java_column(col2)))

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -263,6 +263,38 @@ def corr(col1, col2):
     return Column(sc._jvm.functions.corr(_to_java_column(col1), _to_java_column(col2)))
 
 
+@since(2.0)
+def covar_pop(col1, col2):
+    """Returns a new :class:`Column` for the population covariance of ``col1``
+    and ``col2``.
+
+    >>> a = [x * x - 2 * x + 3.5 for x in range(20)]
+    >>> b = range(20)
+    >>> df = sqlContext.createDataFrame(zip(a, b), ["a", "b"])
+    >>> covDf = df.agg(covar_pop("a", "b").alias('c'))
+    >>> covDf.select("c").collect()
+    [Row(c=565.25)]
+    """
+    sc = SparkContext._active_spark_context
+    return Column(sc._jvm.functions.covar_pop(_to_java_column(col1), _to_java_column(col2)))
+
+
+@since(2.0)
+def covar_samp(col1, col2):
+    """Returns a new :class:`Column` for the sample covariance of ``col1``
+    and ``col2``.
+
+    >>> a = [x * x - 2 * x + 3.5 for x in range(20)]
+    >>> b = range(20)
+    >>> df = sqlContext.createDataFrame(zip(a, b), ["a", "b"])
+    >>> covDf = df.agg(covar_samp("a", "b").alias('c'))
+    >>> covDf.select("c").collect()
+    [Row(c=595.0)]
+    """
+    sc = SparkContext._active_spark_context
+    return Column(sc._jvm.functions.covar_samp(_to_java_column(col1), _to_java_column(col2)))
+
+
 @since(1.3)
 def countDistinct(col, *cols):
     """Returns a new :class:`Column` for distinct count of ``col`` or ``cols``.

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -256,6 +256,7 @@ def corr(col1, col2):
     >>> b = range(20)
     >>> df = sqlContext.createDataFrame(zip(a, b))
     >>> df.agg(corr(df._1, df._2))
+    DataFrame[corr(_1,_2): double]
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.corr(_to_java_column(col1), _to_java_column(col2)))
@@ -270,6 +271,7 @@ def covar_pop(col1, col2):
     >>> b = range(20)
     >>> df = sqlContext.createDataFrame(zip(a, b), ["a", "b"])
     >>> df.agg(covar_pop("a", "b"))
+    DataFrame[covar_pop(a,b): double]
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.covar_pop(_to_java_column(col1), _to_java_column(col2)))
@@ -284,6 +286,7 @@ def covar_samp(col1, col2):
     >>> b = range(20)
     >>> df = sqlContext.createDataFrame(zip(a, b), ["a", "b"])
     >>> df.agg(covar_samp("a", "b"))
+    DataFrame[covar_samp(a,b): double]
     """
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.functions.covar_samp(_to_java_column(col1), _to_java_column(col2)))


### PR DESCRIPTION
PySpark support `covar_samp` and `covar_pop`.

cc @rxin @davies @marmbrus 
