### PR TITLE
[SPARK-12975] [SQL] Throwing Exception when Bucketing Columns are part of Partitioning Columns

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -21,7 +21,6 @@ import java.util.Properties
 
 import scala.collection.JavaConverters._
 
-import org.apache.spark.Logging
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.sql.catalyst.{CatalystQl, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
@@ -38,7 +37,7 @@ import org.apache.spark.sql.sources.HadoopFsRelation
  * @since 1.4.0
  */
 @Experimental
-final class DataFrameWriter private[sql](df: DataFrame) extends Logging  {
+final class DataFrameWriter private[sql](df: DataFrame) {
 
   /**
    * Specifies the behavior when data or table already exists. Options include:

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -242,7 +242,7 @@ final class DataFrameWriter private[sql](df: DataFrame) extends Logging  {
     } yield {
       require(n > 0 && n < 100000, "Bucket number must be greater than 0 and less than 100000.")
 
-      // partitionBy columns cannot be used in blockedBy
+      // partitionBy columns cannot be used in bucketBy
       if (normalizedParCols.nonEmpty &&
         normalizedBucketColNames.get.toSet.intersect(normalizedParCols.get.toSet).nonEmpty) {
           throw new AnalysisException(

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -233,8 +233,6 @@ final class DataFrameWriter private[sql](df: DataFrame) extends Logging  {
   }
 
   private def getBucketSpec: Option[BucketSpec] = {
-
-
     if (sortColumnNames.isDefined) {
       require(numBuckets.isDefined, "sortBy must be used together with bucketBy")
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -256,15 +256,15 @@ final class DataFrameWriter private[sql](df: DataFrame) extends Logging  {
           if (bucketColumns.length != normalizedBucketColNames.get.length) {
             val removedColumns: Seq[String] =
               normalizedBucketColNames.get.filter(normalizedParCols.get.contains)
-            logInfo(s"BucketBy columns is changed to '${bucketColumnNames.mkString(", ")}' after " +
-              s"removing the columns '${removedColumns.mkString(", ")}' that are part of " +
-              s"PartitionBy columns '${partitioningColumns.mkString(", ")}'")
+            logInfo(s"bucketBy columns is changed to '${bucketColumnNames.get.mkString(", ")}' " +
+              s"after removing the columns '${removedColumns.mkString(", ")}' that are part of " +
+              s"partitionBy columns '${partitioningColumns.get.mkString(", ")}'")
           }
           BucketSpec(n, bucketColumns, normalizedSortColNames.getOrElse(Nil))
         } else {
-          throw new AnalysisException(s"BucketBy columns (${bucketColumnNames.mkString(", ")}) " +
-            "should not be the subset of PartitionBy columns " +
-            s"'${partitioningColumns.mkString(", ")}'")
+          throw new AnalysisException(
+            s"bucketBy columns '${bucketColumnNames.get.mkString(", ")}' should not be the " +
+            s"subset of partitionBy columns '${partitioningColumns.get.mkString(", ")}'")
         }
       }
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
@@ -788,7 +788,7 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with TestHiv
         .saveAsTable(tableName)
       invalidateTable(tableName)
       val metastoreTable = catalog.client.getTable("default", tableName)
-      val expectedBlockByColumns = StructType(df.schema("d") :: df.schema("b") :: Nil)
+      val expectedBucketByColumns = StructType(df.schema("d") :: df.schema("b") :: Nil)
       val expectedSortByColumns = StructType(df.schema("c") :: Nil)
 
       val numBuckets = metastoreTable.properties("spark.sql.sources.schema.numBuckets").toInt
@@ -800,16 +800,16 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with TestHiv
       val numSortCols = metastoreTable.properties("spark.sql.sources.schema.numSortCols").toInt
       assert(numSortCols == 1)
 
-      val actualBlockByColumns =
+      val actualBucketByColumns =
         StructType(
           (0 until numBucketCols).map { index =>
             df.schema(metastoreTable.properties(s"spark.sql.sources.schema.bucketCol.$index"))
           })
-      // Make sure blockBy columns are correctly stored in metastore.
+      // Make sure bucketBy columns are correctly stored in metastore.
       assert(
-        expectedBlockByColumns.sameType(actualBlockByColumns),
-        s"Partitions columns stored in metastore $actualBlockByColumns is not the " +
-          s"partition columns defined by the saveAsTable operation $expectedBlockByColumns.")
+        expectedBucketByColumns.sameType(actualBucketByColumns),
+        s"Partitions columns stored in metastore $actualBucketByColumns is not the " +
+          s"partition columns defined by the saveAsTable operation $expectedBucketByColumns.")
 
       val actualSortByColumns =
         StructType(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
@@ -778,7 +778,7 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with TestHiv
 
   test("Saving information for sortBy and bucketBy columns") {
     val df = (1 to 10).map(i => (i, i + 1, s"str$i", s"str${i + 1}")).toDF("a", "b", "c", "d")
-    val tableName = s"partitionInfo_${System.currentTimeMillis()}"
+    val tableName = s"bucketingInfo_${System.currentTimeMillis()}"
 
     withTable(tableName) {
       df.write

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/BucketedWriteSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/BucketedWriteSuite.scala
@@ -158,6 +158,23 @@ class BucketedWriteSuite extends QueryTest with SQLTestUtils with TestHiveSingle
     }
   }
 
+  test("write bucketed data with the overlapping blockBy and partitionBy columns") {
+    for (source <- Seq("parquet", "json", "orc")) {
+      withTable("bucketed_table") {
+        df.write
+          .format(source)
+          .partitionBy("i")
+          .bucketBy(8, "i", "k")
+          .sortBy("k")
+          .saveAsTable("bucketed_table")
+
+        for (i <- 0 until 5) {
+          testBucketing(new File(tableDir, s"i=$i"), source, 8, Seq("k"), Seq("k"))
+        }
+      }
+    }
+  }
+
   test("write bucketed data without partitionBy") {
     for (source <- Seq("parquet", "json", "orc")) {
       withTable("bucketed_table") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/BucketedWriteSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/BucketedWriteSuite.scala
@@ -163,8 +163,8 @@ class BucketedWriteSuite extends QueryTest with SQLTestUtils with TestHiveSingle
 
   test("write bucketed data with the overlapping bucketBy and partitionBy columns") {
     intercept[AnalysisException](df.write
-      .partitionBy("i")
-      .bucketBy(8, "i", "k")
+      .partitionBy("i", "j")
+      .bucketBy(8, "j", "k")
       .sortBy("k")
       .saveAsTable("bucketed_table"))
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/BucketedWriteSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/BucketedWriteSuite.scala
@@ -162,34 +162,18 @@ class BucketedWriteSuite extends QueryTest with SQLTestUtils with TestHiveSingle
   }
 
   test("write bucketed data with the overlapping blockBy and partitionBy columns") {
-    for (source <- Seq("parquet", "json", "orc")) {
-      withTable("bucketed_table") {
-        df.write
-          .format(source)
-          .partitionBy("i")
-          .bucketBy(8, "i", "k")
-          .sortBy("k")
-          .saveAsTable("bucketed_table")
-
-        for (i <- 0 until 5) {
-          // After column pruning, the actual bucketBy columns only contain `k`, which
-          // is identical to the sortBy column.
-          testBucketing(new File(tableDir, s"i=$i"), source, 8, Seq("k"), Seq("k"))
-        }
-      }
-    }
+    intercept[AnalysisException](df.write
+      .partitionBy("i")
+      .bucketBy(8, "i", "k")
+      .sortBy("k")
+      .saveAsTable("bucketed_table"))
   }
 
   test("write bucketed data with the identical blockBy and partitionBy columns") {
-    for (source <- Seq("parquet", "json", "orc")) {
-      withTable("bucketed_table") {
-        intercept[AnalysisException](df.write
-          .format(source)
-          .partitionBy("i")
-          .bucketBy(8, "i")
-          .saveAsTable("bucketed_table"))
-      }
-    }
+    intercept[AnalysisException](df.write
+      .partitionBy("i")
+      .bucketBy(8, "i")
+      .saveAsTable("bucketed_table"))
   }
 
   test("write bucketed data without partitionBy") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/BucketedWriteSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/BucketedWriteSuite.scala
@@ -161,7 +161,7 @@ class BucketedWriteSuite extends QueryTest with SQLTestUtils with TestHiveSingle
     }
   }
 
-  test("write bucketed data with the overlapping blockBy and partitionBy columns") {
+  test("write bucketed data with the overlapping bucketBy and partitionBy columns") {
     intercept[AnalysisException](df.write
       .partitionBy("i")
       .bucketBy(8, "i", "k")
@@ -169,7 +169,7 @@ class BucketedWriteSuite extends QueryTest with SQLTestUtils with TestHiveSingle
       .saveAsTable("bucketed_table"))
   }
 
-  test("write bucketed data with the identical blockBy and partitionBy columns") {
+  test("write bucketed data with the identical bucketBy and partitionBy columns") {
     intercept[AnalysisException](df.write
       .partitionBy("i")
       .bucketBy(8, "i")


### PR DESCRIPTION
When users are using `partitionBy` and `bucketBy` at the same time, some bucketing columns might be part of partitioning columns. For example, 

```
        df.write
          .format(source)
          .partitionBy("i")
          .bucketBy(8, "i", "k")
          .saveAsTable("bucketed_table")
```

However, in the above case, adding column `i` into `bucketBy` is useless. It is just wasting extra CPU when reading or writing bucket tables. Thus, like Hive, we can issue an exception and let users do the change. 

Also added a test case for checking if the information of `sortBy` and `bucketBy` columns are correctly saved in the metastore table. 

Could you check if my understanding is correct? @cloud-fan @rxin @marmbrus Thanks!
