### PR TITLE
[SPARK-12492] Using spark-sql commond to run query,  write the event of SparkListenerJobStart 

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -600,9 +600,9 @@ class HiveContext private[hive](
      * Returns the result as a hive compatible sequence of strings.  For native commands, the
      * execution is simply passed back to Hive.
      */
-    def stringResult(): Seq[String] = SQLExecution.withNewExecutionId(self, this) {
-      executedPlan match {
-        case ExecutedCommand(desc: DescribeHiveTableCommand) =>
+    def stringResult(): Seq[String] = executedPlan match {
+      case ExecutedCommand(desc: DescribeHiveTableCommand) =>
+        SQLExecution.withNewExecutionId(self, this) {
           // If it is a describe command for a Hive table, we want to have the output format
           // be similar with Hive.
           desc.run(self).map {
@@ -612,16 +612,20 @@ class HiveContext private[hive](
                 .map(s => String.format(s"%-20s", s))
                 .mkString("\t")
           }
-        case command: ExecutedCommand =>
+        }
+      case command: ExecutedCommand =>
+        SQLExecution.withNewExecutionId(self, this) {
           command.executeCollect().map(_.getString(0))
+        }
 
-        case other =>
+      case other => 
+        SQLExecution.withNewExecutionId(self, this) {
           val result: Seq[Seq[Any]] = other.executeCollectPublic().map(_.toSeq).toSeq
           // We need the types so we can output struct field names
           val types = analyzed.output.map(_.dataType)
           // Reformat to match hive tab delimited output.
           result.map(_.zip(types).map(HiveContext.toHiveString)).map(_.mkString("\t")).toSeq
-      }
+        }
     }
 
     override def simpleString: String =

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -618,7 +618,7 @@ class HiveContext private[hive](
           command.executeCollect().map(_.getString(0))
         }
 
-      case other => 
+      case other =>
         SQLExecution.withNewExecutionId(self, this) {
           val result: Seq[Seq[Any]] = other.executeCollectPublic().map(_.toSeq).toSeq
           // We need the types so we can output struct field names

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -615,11 +615,13 @@ class HiveContext private[hive](
         command.executeCollect().map(_.getString(0))
 
       case other =>
-        val result: Seq[Seq[Any]] = other.executeCollectPublic().map(_.toSeq).toSeq
-        // We need the types so we can output struct field names
-        val types = analyzed.output.map(_.dataType)
-        // Reformat to match hive tab delimited output.
-        result.map(_.zip(types).map(HiveContext.toHiveString)).map(_.mkString("\t")).toSeq
+        SQLExecution.withNewExecutionId(other.sqlContext, this) {
+          val result: Seq[Seq[Any]] = other.executeCollectPublic().map(_.toSeq).toSeq
+          // We need the types so we can output struct field names
+          val types = analyzed.output.map(_.dataType)
+          // Reformat to match hive tab delimited output.
+          result.map(_.zip(types).map(HiveContext.toHiveString)).map(_.mkString("\t")).toSeq
+      }
     }
 
     override def simpleString: String =


### PR DESCRIPTION
Using spark-sql commond to run query, the sqlPage is blank, e.g.
![sqlpage is blank](https://cloud.githubusercontent.com/assets/9440626/12570121/ce441cfc-c40f-11e5-88e6-618abc1ed4d9.png)

Because, running query, the event of SparkListenerJobStart  is not written. So now I change the code, when run job, the event will be written, then the sqlPage will be not blank.
