### PR TITLE
[Docs] Fix the jar location of datanucleus in sql-programming-guid.md

### DIFF
--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -1695,7 +1695,7 @@ on all of the worker nodes, as they will need access to the Hive serialization a
 
 Configuration of Hive is done by placing your `hive-site.xml`, `core-site.xml` (for security configuration),
  `hdfs-site.xml` (for HDFS configuration) file in `conf/`. Please note when running
-the query on a YARN cluster (`cluster` mode), the `datanucleus` jars under the `lib_managed/jars` directory
+the query on a YARN cluster (`cluster` mode), the `datanucleus` jars under the `lib` directory
 and `hive-site.xml` under `conf/` directory need to be available on the driver and all executors launched by the
 YARN cluster. The convenient way to do this is adding them through the `--jars` option and `--file` option of the
 `spark-submit` command.


### PR DESCRIPTION
ISTM `lib` is better because `datanucleus` jars are located in `lib` for release builds.
