### PR TITLE
[SPARK-12990][BUILD] Fix fatal warnings due to @unnecessary transient annotations

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVOptions.scala
@@ -23,7 +23,7 @@ import org.apache.spark.Logging
 import org.apache.spark.sql.execution.datasources.CompressionCodecs
 
 private[sql] class CSVOptions(
-    @transient parameters: Map[String, String])
+    @transient private val parameters: Map[String, String])
   extends Logging with Serializable {
 
   private def getChar(paramName: String, default: Char): Char = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JSONOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/json/JSONOptions.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.execution.datasources.CompressionCodecs
  * Most of these map directly to Jackson's internal options, specified in [[JsonParser.Feature]].
  */
 private[sql] class JSONOptions(
-    @transient parameters: Map[String, String])
+    @transient private val parameters: Map[String, String])
   extends Serializable  {
 
   val samplingRatio =


### PR DESCRIPTION
A recent merge reintroduced some unnecessary @transient annotations, thus generating fatal warnings in the Scala 2.11 build.
This is a tiny PR, just transforming said parameters into transient private vals.
