### PR TITLE
[SPARK-10086] [MLlib] [Streaming] [PySpark] ignore StreamingKMeans test in PySpark for now

### DIFF
--- a/python/pyspark/mllib/tests.py
+++ b/python/pyspark/mllib/tests.py
@@ -1189,6 +1189,7 @@ class StreamingKMeansTest(MLLibStreamingTestCase):
 
         self._eventually(condition, catch_assertions=True)
 
+    @unittest.skip("SPARK-10086: Flaky StreamingKMeans test in PySpark")
     def test_trainOn_predictOn(self):
         """Test that prediction happens on the updated model."""
         stkm = StreamingKMeans(decayFactor=0.0, k=2)


### PR DESCRIPTION
I saw several failures from recent PR builds, e.g., https://amplab.cs.berkeley.edu/jenkins/job/SparkPullRequestBuilder/50015/consoleFull. This PR marks the test as ignored and we will fix the flakyness in SPARK-10086.

@gliptak Do you know why the test failure didn't show up in the Jenkins "Test Result"?

cc: @jkbradley 
