### PR TITLE
[SPARK-12935][SQL] DataFrame API for Count-Min Sketch

### DIFF
--- a/common/sketch/src/main/java/org/apache/spark/util/sketch/BloomFilter.java
+++ b/common/sketch/src/main/java/org/apache/spark/util/sketch/BloomFilter.java
@@ -47,11 +47,12 @@ public abstract class BloomFilter {
   public enum Version {
     /**
      * {@code BloomFilter} binary format version 1 (all values written in big-endian order):
-     *
-     *  - Version number, always 1 (32 bit)
-     *  - Total number of words of the underlying bit array (32 bit)
-     *  - The words/longs (numWords * 64 bit)
-     *  - Number of hash functions (32 bit)
+     * <ul>
+     *   <li>Version number, always 1 (32 bit)</li>
+     *   <li>Total number of words of the underlying bit array (32 bit)</li>
+     *   <li>The words/longs (numWords * 64 bit)</li>
+     *   <li>Number of hash functions (32 bit)</li>
+     * </ul>
      */
     V1(1);
 

--- a/common/sketch/src/main/java/org/apache/spark/util/sketch/BloomFilter.java
+++ b/common/sketch/src/main/java/org/apache/spark/util/sketch/BloomFilter.java
@@ -47,10 +47,11 @@ public abstract class BloomFilter {
   public enum Version {
     /**
      * {@code BloomFilter} binary format version 1 (all values written in big-endian order):
-     * - Version number, always 1 (32 bit)
-     * - Total number of words of the underlying bit array (32 bit)
-     * - The words/longs (numWords * 64 bit)
-     * - Number of hash functions (32 bit)
+     *
+     *  - Version number, always 1 (32 bit)
+     *  - Total number of words of the underlying bit array (32 bit)
+     *  - The words/longs (numWords * 64 bit)
+     *  - Number of hash functions (32 bit)
      */
     V1(1);
 

--- a/common/sketch/src/main/java/org/apache/spark/util/sketch/CountMinSketch.java
+++ b/common/sketch/src/main/java/org/apache/spark/util/sketch/CountMinSketch.java
@@ -59,17 +59,22 @@ abstract public class CountMinSketch {
   public enum Version {
     /**
      * {@code CountMinSketch} binary format version 1 (all values written in big-endian order):
-     *
-     *  - Version number, always 1 (32 bit)
-     *  - Total count of added items (64 bit)
-     *  - Depth (32 bit)
-     *  - Width (32 bit)
-     *  - Hash functions (depth * 64 bit)
-     *  - Count table
-     *    - Row 0 (width * 64 bit)
-     *    - Row 1 (width * 64 bit)
-     *    - ...
-     *    - Row depth - 1 (width * 64 bit)
+     * <ul>
+     *   <li>Version number, always 1 (32 bit)</li>
+     *   <li>Total count of added items (64 bit)</li>
+     *   <li>Depth (32 bit)</li>
+     *   <li>Width (32 bit)</li>
+     *   <li>Hash functions (depth * 64 bit)</li>
+     *   <li>
+     *     Count table
+     *     <ul>
+     *       <li>Row 0 (width * 64 bit)</li>
+     *       <li>Row 1 (width * 64 bit)</li>
+     *       <li>...</li>
+     *       <li>Row {@code depth - 1} (width * 64 bit)</li>
+     *     </ul>
+     *   </li>
+     * </ul>
      */
     V1(1);
 

--- a/common/sketch/src/main/java/org/apache/spark/util/sketch/CountMinSketch.java
+++ b/common/sketch/src/main/java/org/apache/spark/util/sketch/CountMinSketch.java
@@ -59,16 +59,17 @@ abstract public class CountMinSketch {
   public enum Version {
     /**
      * {@code CountMinSketch} binary format version 1 (all values written in big-endian order):
-     * - Version number, always 1 (32 bit)
-     * - Total count of added items (64 bit)
-     * - Depth (32 bit)
-     * - Width (32 bit)
-     * - Hash functions (depth * 64 bit)
-     * - Count table
-     *   - Row 0 (width * 64 bit)
-     *   - Row 1 (width * 64 bit)
-     *   - ...
-     *   - Row depth - 1 (width * 64 bit)
+     *
+     *  - Version number, always 1 (32 bit)
+     *  - Total count of added items (64 bit)
+     *  - Depth (32 bit)
+     *  - Width (32 bit)
+     *  - Hash functions (depth * 64 bit)
+     *  - Count table
+     *    - Row 0 (width * 64 bit)
+     *    - Row 1 (width * 64 bit)
+     *    - ...
+     *    - Row depth - 1 (width * 64 bit)
      */
     V1(1);
 

--- a/common/sketch/src/main/java/org/apache/spark/util/sketch/CountMinSketchImpl.java
+++ b/common/sketch/src/main/java/org/apache/spark/util/sketch/CountMinSketchImpl.java
@@ -377,28 +377,27 @@ class CountMinSketchImpl extends CountMinSketch implements Externalizable {
 
   @Override
   public void writeExternal(ObjectOutput out) throws IOException {
-    ByteArrayOutputStream bos = new ByteArrayOutputStream();
-    this.writeTo(bos);
-
-    byte[] bytes = bos.toByteArray();
-    out.writeObject(bytes);
-    bos.close();
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+      this.writeTo(bos);
+      byte[] bytes = bos.toByteArray();
+      out.writeObject(bytes);
+    }
   }
 
   @Override
   public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
     byte[] bytes = (byte[]) in.readObject();
 
-    ByteArrayInputStream bis = new ByteArrayInputStream(bytes);
-    CountMinSketchImpl sketch = CountMinSketchImpl.readFrom(bis);
-    bis.close();
+    try (ByteArrayInputStream bis = new ByteArrayInputStream(bytes)) {
+      CountMinSketchImpl sketch = CountMinSketchImpl.readFrom(bis);
 
-    this.depth = sketch.depth;
-    this.width = sketch.width;
-    this.eps = sketch.eps;
-    this.confidence = sketch.confidence;
-    this.totalCount = sketch.totalCount;
-    this.hashA = sketch.hashA;
-    this.table = sketch.table;
+      this.depth = sketch.depth;
+      this.width = sketch.width;
+      this.eps = sketch.eps;
+      this.confidence = sketch.confidence;
+      this.totalCount = sketch.totalCount;
+      this.hashA = sketch.hashA;
+      this.table = sketch.table;
+    }
   }
 }

--- a/common/sketch/src/main/java/org/apache/spark/util/sketch/CountMinSketchImpl.java
+++ b/common/sketch/src/main/java/org/apache/spark/util/sketch/CountMinSketchImpl.java
@@ -47,7 +47,7 @@ import java.util.Random;
  *   - Row depth - 1 (width * 64 bit)
  */
 class CountMinSketchImpl extends CountMinSketch implements Externalizable {
-  public static final long PRIME_MODULUS = (1L << 31) - 1;
+  private static final long PRIME_MODULUS = (1L << 31) - 1;
 
   private int depth;
   private int width;
@@ -353,7 +353,7 @@ class CountMinSketchImpl extends CountMinSketch implements Externalizable {
 
     int version = dis.readInt();
     if (version != Version.V1.getVersionNumber()) {
-      throw new IOException("Unexpected Count-Min Sketch version number " + version);
+      throw new IOException("Unexpected Count-Min Sketch version number (" + version + ")");
     }
 
     long totalCount = dis.readLong();
@@ -382,13 +382,17 @@ class CountMinSketchImpl extends CountMinSketch implements Externalizable {
 
     byte[] bytes = bos.toByteArray();
     out.writeObject(bytes);
+    bos.close();
   }
 
   @Override
   public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
     byte[] bytes = (byte[]) in.readObject();
 
-    CountMinSketchImpl sketch = CountMinSketchImpl.readFrom(new ByteArrayInputStream(bytes));
+    ByteArrayInputStream bis = new ByteArrayInputStream(bytes);
+    CountMinSketchImpl sketch = CountMinSketchImpl.readFrom(bis);
+    bis.close();
+
     this.depth = sketch.depth;
     this.width = sketch.width;
     this.eps = sketch.eps;

--- a/common/sketch/src/main/java/org/apache/spark/util/sketch/CountMinSketchImpl.java
+++ b/common/sketch/src/main/java/org/apache/spark/util/sketch/CountMinSketchImpl.java
@@ -31,21 +31,6 @@ import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.Random;
 
-/*
- * Binary format of a serialized CountMinSketchImpl, version 1 (all values written in big-endian
- * order):
- *
- * - Version number, always 1 (32 bit)
- * - Total count of added items (64 bit)
- * - Depth (32 bit)
- * - Width (32 bit)
- * - Hash functions (depth * 64 bit)
- * - Count table
- *   - Row 0 (width * 64 bit)
- *   - Row 1 (width * 64 bit)
- *   - ...
- *   - Row depth - 1 (width * 64 bit)
- */
 class CountMinSketchImpl extends CountMinSketch implements Externalizable {
   private static final long PRIME_MODULUS = (1L << 31) - 1;
 

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -44,6 +44,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sketch_2.10</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -313,14 +313,13 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
   }
 
   /**
-   * Builds a Count-Min sketch over a specified column.
+   * Builds a Count-min Sketch over a specified column.
    *
    * @param colName name of the column over which the sketch is built
    * @param depth depth of the sketch
    * @param width width of the sketch
    * @param seed random seed
    * @return a [[CountMinSketch]] over column `colName`
-   * @see [[http://www.eecs.harvard.edu/~michaelm/CS222/countmin.pdf]]
    * @since 2.0.0
    */
   def countMinSketch(colName: String, depth: Int, width: Int, seed: Int): CountMinSketch = {
@@ -328,14 +327,13 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
   }
 
   /**
-   * Builds a Count-Min sketch over a specified column.
+   * Builds a Count-min Sketch over a specified column.
    *
    * @param colName name of the column over which the sketch is built
    * @param eps relative error of the sketch
    * @param confidence confidence of the sketch
    * @param seed random seed
    * @return a [[CountMinSketch]] over column `colName`
-   * @see [[http://www.eecs.harvard.edu/~michaelm/CS222/countmin.pdf]]
    * @since 2.0.0
    */
   def countMinSketch(
@@ -344,14 +342,13 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
   }
 
   /**
-   * Builds a Count-Min sketch over a specified column.
+   * Builds a Count-min Sketch over a specified column.
    *
    * @param col the column over which the sketch is built
    * @param depth depth of the sketch
    * @param width width of the sketch
    * @param seed random seed
    * @return a [[CountMinSketch]] over column `colName`
-   * @see [[http://www.eecs.harvard.edu/~michaelm/CS222/countmin.pdf]]
    * @since 2.0.0
    */
   def countMinSketch(col: Column, depth: Int, width: Int, seed: Int): CountMinSketch = {
@@ -359,14 +356,13 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
   }
 
   /**
-   * Builds a Count-Min sketch over a specified column.
+   * Builds a Count-min Sketch over a specified column.
    *
    * @param col the column over which the sketch is built
    * @param eps relative error of the sketch
    * @param confidence confidence of the sketch
    * @param seed random seed
    * @return a [[CountMinSketch]] over column `colName`
-   * @see [[http://www.eecs.harvard.edu/~michaelm/CS222/countmin.pdf]]
    * @since 2.0.0
    */
   def countMinSketch(col: Column, eps: Double, confidence: Double, seed: Int): CountMinSketch = {
@@ -376,13 +372,13 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
   private def countMinSketch(col: Column, zero: CountMinSketch): CountMinSketch = {
     val singleCol = df.select(col)
     val colType = singleCol.schema.head.dataType
+    val supportedTypes: Set[DataType] = Set(ByteType, ShortType, IntegerType, LongType, StringType)
 
-    require({
-      val supportedTypes: Set[DataType] =
-        Set(ByteType, ShortType, IntegerType, LongType, StringType)
-      supportedTypes.contains(colType)
-    }, s"Count-Min Sketch doesn't support data type $colType yet.")
-
+    require(
+      supportedTypes.contains(colType),
+      s"Count-min Sketch only supports string type and integral types, " +
+        s"and does not support type $colType."
+    )
 
     singleCol.rdd.aggregate(zero)(
       (sketch: CountMinSketch, row: Row) => {

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -23,6 +23,8 @@ import scala.collection.JavaConverters._
 
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.sql.execution.stat._
+import org.apache.spark.sql.types._
+import org.apache.spark.util.sketch.CountMinSketch
 
 /**
  * :: Experimental ::
@@ -308,5 +310,89 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    */
   def sampleBy[T](col: String, fractions: ju.Map[T, jl.Double], seed: Long): DataFrame = {
     sampleBy(col, fractions.asScala.toMap.asInstanceOf[Map[T, Double]], seed)
+  }
+
+  /**
+   * Builds a Count-Min sketch over a specified column.
+   *
+   * @param colName name of the column over which the sketch is built
+   * @param depth depth of the sketch
+   * @param width width of the sketch
+   * @param seed random seed
+   * @return a [[CountMinSketch]] over column `colName`
+   * @see [[http://www.eecs.harvard.edu/~michaelm/CS222/countmin.pdf]]
+   * @since 2.0.0
+   */
+  def countMinSketch(colName: String, depth: Int, width: Int, seed: Int): CountMinSketch = {
+    countMinSketch(Column(colName), depth, width, seed)
+  }
+
+  /**
+   * Builds a Count-Min sketch over a specified column.
+   *
+   * @param colName name of the column over which the sketch is built
+   * @param eps relative error of the sketch
+   * @param confidence confidence of the sketch
+   * @param seed random seed
+   * @return a [[CountMinSketch]] over column `colName`
+   * @see [[http://www.eecs.harvard.edu/~michaelm/CS222/countmin.pdf]]
+   * @since 2.0.0
+   */
+  def countMinSketch(
+      colName: String, eps: Double, confidence: Double, seed: Int): CountMinSketch = {
+    countMinSketch(Column(colName), eps, confidence, seed)
+  }
+
+  /**
+   * Builds a Count-Min sketch over a specified column.
+   *
+   * @param col the column over which the sketch is built
+   * @param depth depth of the sketch
+   * @param width width of the sketch
+   * @param seed random seed
+   * @return a [[CountMinSketch]] over column `colName`
+   * @see [[http://www.eecs.harvard.edu/~michaelm/CS222/countmin.pdf]]
+   * @since 2.0.0
+   */
+  def countMinSketch(col: Column, depth: Int, width: Int, seed: Int): CountMinSketch = {
+    countMinSketch(col, CountMinSketch.create(depth, width, seed))
+  }
+
+  /**
+   * Builds a Count-Min sketch over a specified column.
+   *
+   * @param col the column over which the sketch is built
+   * @param eps relative error of the sketch
+   * @param confidence confidence of the sketch
+   * @param seed random seed
+   * @return a [[CountMinSketch]] over column `colName`
+   * @see [[http://www.eecs.harvard.edu/~michaelm/CS222/countmin.pdf]]
+   * @since 2.0.0
+   */
+  def countMinSketch(col: Column, eps: Double, confidence: Double, seed: Int): CountMinSketch = {
+    countMinSketch(col, CountMinSketch.create(eps, confidence, seed))
+  }
+
+  private def countMinSketch(col: Column, zero: CountMinSketch): CountMinSketch = {
+    val singleCol = df.select(col)
+    val colType = singleCol.schema.head.dataType
+
+    require({
+      val supportedTypes: Set[DataType] =
+        Set(ByteType, ShortType, IntegerType, LongType, StringType)
+      supportedTypes.contains(colType)
+    }, s"Count-Min Sketch doesn't support data type $colType yet.")
+
+
+    singleCol.rdd.aggregate(zero)(
+      (sketch: CountMinSketch, row: Row) => {
+        sketch.add(row.get(0))
+        sketch
+      },
+
+      (sketch1: CountMinSketch, sketch2: CountMinSketch) => {
+        sketch1.mergeInPlace(sketch2)
+      }
+    )
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -372,10 +372,9 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
   private def countMinSketch(col: Column, zero: CountMinSketch): CountMinSketch = {
     val singleCol = df.select(col)
     val colType = singleCol.schema.head.dataType
-    val supportedTypes: Set[DataType] = Set(ByteType, ShortType, IntegerType, LongType, StringType)
 
     require(
-      supportedTypes.contains(colType),
+      colType == StringType || colType.isInstanceOf[IntegralType],
       s"Count-min Sketch only supports string type and integral types, " +
         s"and does not support type $colType."
     )

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
@@ -19,8 +19,11 @@ package org.apache.spark.sql
 
 import java.util.Random
 
+import org.scalatest.Matchers._
+
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.test.SharedSQLContext
+import org.apache.spark.sql.types.DoubleType
 
 class DataFrameStatSuite extends QueryTest with SharedSQLContext {
   import testImplicits._
@@ -209,5 +212,38 @@ class DataFrameStatSuite extends QueryTest with SharedSQLContext {
     checkAnswer(
       sampled.groupBy("key").count().orderBy("key"),
       Seq(Row(0, 6), Row(1, 11)))
+  }
+
+  // This test case only verifies that `DataFrame.countMinSketch()` methods do return
+  // `CountMinSketch`es that meet required specs.  Test cases for `CountMinSketch` can be found in
+  // `CountMinSketchSuite` in project spark-sketch.
+  test("countMinSketch") {
+    val df = sqlContext.range(1000)
+
+    val sketch1 = df.stat.countMinSketch("id", depth = 10, width = 20, seed = 42)
+    assert(sketch1.totalCount() === 1000)
+    assert(sketch1.depth() === 10)
+    assert(sketch1.width() === 20)
+
+    val sketch2 = df.stat.countMinSketch($"id", depth = 10, width = 20, seed = 42)
+    assert(sketch2.totalCount() === 1000)
+    assert(sketch2.depth() === 10)
+    assert(sketch2.width() === 20)
+
+    val sketch3 = df.stat.countMinSketch("id", eps = 0.001, confidence = 0.99, seed = 42)
+    assert(sketch3.totalCount() === 1000)
+    assert(sketch3.relativeError() === 0.001)
+    assert(sketch3.confidence() === 0.99 +- 5e-3)
+
+    val sketch4 = df.stat.countMinSketch($"id", eps = 0.001, confidence = 0.99, seed = 42)
+    assert(sketch4.totalCount() === 1000)
+    assert(sketch4.relativeError() === 0.001 +- 1e04)
+    assert(sketch4.confidence() === 0.99 +- 5e-3)
+
+    intercept[IllegalArgumentException] {
+      df.select('id cast DoubleType as 'id)
+        .stat
+        .countMinSketch('id, depth = 10, width = 20, seed = 42)
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -1270,37 +1270,4 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
       Seq(1 -> "a").toDF("i", "j").filter($"i".cast(StringType) === "1"),
       Row(1, "a"))
   }
-
-  // This test case only verifies that `DataFrame.countMinSketch()` methods do return
-  // `CountMinSketch`es that meed required specs.  Test cases for `CountMinSketch` can be found in
-  // `CountMinSketchSuite` in project spark-sketch.
-  test("countMinSketch") {
-    val df = sqlContext.range(1000)
-
-    val sketch1 = df.stat.countMinSketch("id", depth = 10, width = 20, seed = 42)
-    assert(sketch1.totalCount() === 1000)
-    assert(sketch1.depth() === 10)
-    assert(sketch1.width() === 20)
-
-    val sketch2 = df.stat.countMinSketch($"id", depth = 10, width = 20, seed = 42)
-    assert(sketch2.totalCount() === 1000)
-    assert(sketch2.depth() === 10)
-    assert(sketch2.width() === 20)
-
-    val sketch3 = df.stat.countMinSketch("id", eps = 0.001, confidence = 0.99, seed = 42)
-    assert(sketch3.totalCount() === 1000)
-    assert(sketch3.relativeError() === 0.001)
-    assert(sketch3.confidence() === 0.99 +- 5e-3)
-
-    val sketch4 = df.stat.countMinSketch($"id", eps = 0.001, confidence = 0.99, seed = 42)
-    assert(sketch4.totalCount() === 1000)
-    assert(sketch4.relativeError() === 0.001 +- 1e04)
-    assert(sketch4.confidence() === 0.99 +- 5e-3)
-
-    intercept[IllegalArgumentException] {
-      df.select('id cast DoubleType as 'id)
-        .stat
-        .countMinSketch('id, depth = 10, width = 20, seed = 42)
-    }
-  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -1270,4 +1270,37 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
       Seq(1 -> "a").toDF("i", "j").filter($"i".cast(StringType) === "1"),
       Row(1, "a"))
   }
+
+  // This test case only verifies that `DataFrame.countMinSketch()` methods do return
+  // `CountMinSketch`es that meed required specs.  Test cases for `CountMinSketch` can be found in
+  // `CountMinSketchSuite` in project spark-sketch.
+  test("countMinSketch") {
+    val df = sqlContext.range(1000)
+
+    val sketch1 = df.stat.countMinSketch("id", depth = 10, width = 20, seed = 42)
+    assert(sketch1.totalCount() === 1000)
+    assert(sketch1.depth() === 10)
+    assert(sketch1.width() === 20)
+
+    val sketch2 = df.stat.countMinSketch($"id", depth = 10, width = 20, seed = 42)
+    assert(sketch2.totalCount() === 1000)
+    assert(sketch2.depth() === 10)
+    assert(sketch2.width() === 20)
+
+    val sketch3 = df.stat.countMinSketch("id", eps = 0.001, confidence = 0.99, seed = 42)
+    assert(sketch3.totalCount() === 1000)
+    assert(sketch3.relativeError() === 0.001)
+    assert(sketch3.confidence() === 0.99 +- 5e-3)
+
+    val sketch4 = df.stat.countMinSketch($"id", eps = 0.001, confidence = 0.99, seed = 42)
+    assert(sketch4.totalCount() === 1000)
+    assert(sketch4.relativeError() === 0.001 +- 1e04)
+    assert(sketch4.confidence() === 0.99 +- 5e-3)
+
+    intercept[IllegalArgumentException] {
+      df.select('id cast DoubleType as 'id)
+        .stat
+        .countMinSketch('id, depth = 10, width = 20, seed = 42)
+    }
+  }
 }


### PR DESCRIPTION
This PR integrates Count-Min Sketch from spark-sketch into DataFrame. This version resorts to `RDD.aggregate` for building the sketch. A more performant UDAF version can be built in future follow-up PRs.
