### PR TITLE
[SPARK-12265][Mesos] Spark calls System.exit inside driver instead of throwing exception

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
@@ -361,6 +361,7 @@ private[spark] class CoarseMesosSchedulerBackend(
   override def error(d: SchedulerDriver, message: String) {
     logError(s"Mesos error: $message")
     scheduler.error(message)
+    markErr()
   }
 
   override def stop() {

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
@@ -360,8 +360,8 @@ private[spark] class CoarseMesosSchedulerBackend(
 
   override def error(d: SchedulerDriver, message: String) {
     logError(s"Mesos error: $message")
-    scheduler.error(message)
     markErr()
+    scheduler.error(message)
   }
 
   override def stop() {

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
@@ -360,7 +360,6 @@ private[spark] class CoarseMesosSchedulerBackend(
 
   override def error(d: SchedulerDriver, message: String) {
     logError(s"Mesos error: $message")
-    markErr()
     scheduler.error(message)
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosClusterScheduler.scala
@@ -573,6 +573,7 @@ private[spark] class MesosClusterScheduler(
   override def slaveLost(driver: SchedulerDriver, slaveId: SlaveID): Unit = {}
   override def error(driver: SchedulerDriver, error: String): Unit = {
     logError("Error received: " + error)
+    markErr()
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
@@ -376,6 +376,7 @@ private[spark] class MesosSchedulerBackend(
     inClassLoader() {
       logError("Mesos error: " + message)
       scheduler.error(message)
+      markErr()
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
@@ -375,8 +375,8 @@ private[spark] class MesosSchedulerBackend(
   override def error(d: SchedulerDriver, message: String) {
     inClassLoader() {
       logError("Mesos error: " + message)
-      scheduler.error(message)
       markErr()
+      scheduler.error(message)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtils.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtils.scala
@@ -109,20 +109,17 @@ private[mesos] trait MesosSchedulerUtils extends Logging {
 
       new Thread(Utils.getFormattedClassName(this) + "-mesos-driver") {
         setDaemon(true)
+        setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler {
+          override def uncaughtException(t: Thread, e: Throwable): Unit =
+            logError("Error starting driver", e)
+        })
 
         override def run() {
           mesosDriver = newDriver
-          try {
-            val ret = mesosDriver.run()
-            logInfo("driver.run() returned with code " + ret)
-            if (ret != null && ret.equals(Status.DRIVER_ABORTED)) {
-              System.exit(1)
-            }
-          } catch {
-            case e: Exception => {
-              logError("driver.run() failed", e)
-              System.exit(1)
-            }
+          val ret = mesosDriver.run()
+          logInfo("driver.run() returned with code " + ret)
+          if (ret != null && ret.equals(Status.DRIVER_ABORTED)) {
+            throw new SparkException("Error starting driver, DRIVER_ABORTED")
           }
         }
       }.start()
@@ -141,6 +138,10 @@ private[mesos] trait MesosSchedulerUtils extends Logging {
   }
 
   protected def markRegistered(): Unit = {
+    registerLatch.countDown()
+  }
+
+  protected def markErr(): Unit = {
     registerLatch.countDown()
   }
 


### PR DESCRIPTION
This takes over #10729 and makes sure that `spark-shell` fails with a proper error message. There is a slight behavioral change: before this change `spark-shell` would exit, while now the REPL is still there, but `sc` and `sqlContext` are not defined and the error is visible to the user.
