### PR TITLE
[SPARK-13001] [CORE] [MESOS] Prevent getting offers when reached max cores

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
@@ -341,7 +341,21 @@ private[spark] class CoarseMesosSchedulerBackend(
           Collections.singleton(offer.getId),
           offerTasks.asJava)
       } else if (totalCoresAcquired >= maxCores) {
-        declineOffer(d, offer, Some("reached max cores"),
+        // We already acquired the maximum number of cores so we don't need to get new offers
+        // unless an executor goes down. Setting a high "refuse seconds" filter is especially
+        // important when running a lot of frameworks in the same Mesos cluster to avoid resource
+        // starvation. One such case of starvation happens when running many small Spark apps
+        // (e.g. small Spark streaming jobs) then a new big Spark app would get offered only a
+        // fraction of the cores available in the cluster and Mesos would then stop sending it
+        // offers. That's because the small apps have a much smaller "max share" so they get the
+        // offers first. With a low number of apps it's okay because with the default
+        // refuse_seconds value of 5 seconds it's enough time for Mesos to cycle through every
+        // app and send offers to each of them. But as the number of apps increases it becomes
+        // more and more problematic, to the point where Mesos stops sending offers to the apps
+        // ranked the lowest by DRF, i.e. the big apps. We mitigate this problem by declining
+        // the offers for a long period of time when we know that we don't need offers anymore
+        // because the app already acquired all the cores it needs.
+        declineOffer(d, offer, Some("reached spark.cores.max"),
           Some(rejectOfferDurationForReachedMaxCores))
       } else {
         declineOffer(d, offer)

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
@@ -289,7 +289,10 @@ private[spark] class CoarseMesosSchedulerBackend(
     }
   }
 
-  private def declineOffer(d: SchedulerDriver, offer: Offer, reason: Option[String] = None,
+  private def declineOffer(
+      d: SchedulerDriver,
+      offer: Offer,
+      reason: Option[String] = None,
       refuseSeconds: Option[Long] = None): Unit = {
 
     val id = offer.getId.getValue
@@ -297,8 +300,9 @@ private[spark] class CoarseMesosSchedulerBackend(
     val mem = getResource(offer.getResourcesList, "mem")
     val cpus = getResource(offer.getResourcesList, "cpus")
 
-    logDebug(s"Declining offer: $id with attributes: $offerAttributes mem: $mem"
-      + s" cpu: $cpus for $refuseSeconds seconds" + reason.fold("")(r => s" (reason: $r)"))
+    logDebug(s"Declining offer: $id with attributes: $offerAttributes mem: $mem" +
+      s" cpu: $cpus for $refuseSeconds seconds" +
+      reason.map(r => s" (reason: $r)").getOrElse(""))
 
     refuseSeconds match {
       case Some(seconds) =>

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtils.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerUtils.scala
@@ -352,4 +352,8 @@ private[mesos] trait MesosSchedulerUtils extends Logging {
     sc.conf.getTimeAsSeconds("spark.mesos.rejectOfferDurationForUnmetConstraints", "120s")
   }
 
+  protected def getRejectOfferDurationForReachedMaxCores(sc: SparkContext): Long = {
+    sc.conf.getTimeAsSeconds("spark.mesos.rejectOfferDurationForReachedMaxCores", "120s")
+  }
+
 }

--- a/core/src/test/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackendSuite.scala
@@ -147,7 +147,7 @@ class CoarseMesosSchedulerBackendSuite extends SparkFunSuite
     verifyDeclinedOffer(driver, createOfferId("o1"), true)
   }
 
-  test("mesos declines offers for a long time when reached spark.cores.max") {
+  test("mesos declines offers with a filter when reached spark.cores.max") {
     val maxCores = 3
     setBackend(Map("spark.cores.max" -> maxCores.toString))
 

--- a/core/src/test/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackendSuite.scala
@@ -147,6 +147,19 @@ class CoarseMesosSchedulerBackendSuite extends SparkFunSuite
     verifyDeclinedOffer(driver, createOfferId("o1"), true)
   }
 
+  test("mesos declines offers for a long time when reached spark.cores.max") {
+    val maxCores = 3
+    setBackend(Map("spark.cores.max" -> maxCores.toString))
+
+    val executorMemory = backend.executorMemory(sc)
+    offerResources(List(
+      (executorMemory, maxCores + 1),
+      (executorMemory, maxCores + 1)))
+
+    verifyTaskLaunched("o1")
+    verifyDeclinedOffer(driver, createOfferId("o2"), true)
+  }
+
   test("mesos assigns tasks round-robin on offers") {
     val executorCores = 4
     val maxCores = executorCores * 2

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -406,6 +406,20 @@ See the [configuration page](configuration.html) for information on Spark config
     If unset it will point to Spark's internal web UI.
   </td>
 </tr>
+<tr>
+  <td><code>spark.mesos.rejectOfferDurationForUnmetConstraints</code></td>
+  <td><code>120s</code></td>
+  <td>
+    Set the amount of time for which offers are rejected when constraints are unmet. See <code>spark.mesos.constraints</code>.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.mesos.rejectOfferDurationForReachedMaxCores</code></td>
+  <td><code>120s</code></td>
+  <td>
+    Set the amount of time for which offers are rejected when the app already acquired <code>spark.cores.max</code> cores.
+  </td>
+</tr>
 </table>
 
 # Troubleshooting and Debugging

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -411,6 +411,7 @@ See the [configuration page](configuration.html) for information on Spark config
   <td><code>120s</code></td>
   <td>
     Set the amount of time for which offers are rejected when constraints are unmet. See <code>spark.mesos.constraints</code>.
+    This is used to prevent starvation of other frameworks.
   </td>
 </tr>
 <tr>
@@ -418,6 +419,7 @@ See the [configuration page](configuration.html) for information on Spark config
   <td><code>120s</code></td>
   <td>
     Set the amount of time for which offers are rejected when the app already acquired <code>spark.cores.max</code> cores.
+    This is used to prevent starvation of other frameworks.
   </td>
 </tr>
 </table>

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -406,22 +406,6 @@ See the [configuration page](configuration.html) for information on Spark config
     If unset it will point to Spark's internal web UI.
   </td>
 </tr>
-<tr>
-  <td><code>spark.mesos.rejectOfferDurationForUnmetConstraints</code></td>
-  <td><code>120s</code></td>
-  <td>
-    Set the amount of time for which offers are rejected when constraints are unmet. See <code>spark.mesos.constraints</code>.
-    This is used to prevent starvation of other frameworks.
-  </td>
-</tr>
-<tr>
-  <td><code>spark.mesos.rejectOfferDurationForReachedMaxCores</code></td>
-  <td><code>120s</code></td>
-  <td>
-    Set the amount of time for which offers are rejected when the app already acquired <code>spark.cores.max</code> cores.
-    This is used to prevent starvation of other frameworks.
-  </td>
-</tr>
 </table>
 
 # Troubleshooting and Debugging


### PR DESCRIPTION
Similar to https://github.com/apache/spark/pull/8639

This change rejects offers for 120s when reached `spark.cores.max` in coarse-grained mode to mitigate offer starvation. This prevents Mesos to send us offers again and again, starving other frameworks. This is especially problematic when running many small frameworks on the same Mesos cluster, e.g. many small Sparks streaming jobs, and cause the bigger spark jobs to stop receiving offers. By rejecting the offers for a long period of time, they become available to those other frameworks.
