### PR TITLE
[SQL] Minor Scaladoc format fix

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
@@ -200,7 +200,7 @@ abstract class ImperativeAggregate extends AggregateFunction with CodegenFallbac
    * For example, we have two aggregate functions `avg(x)` and `avg(y)`, which share the same
    * aggregation buffer. In this shared buffer, the position of the first buffer value of `avg(x)`
    * will be 0 and the position of the first buffer value of `avg(y)` will be 2:
-   *
+   * {{{
    *          avg(x) mutableAggBufferOffset = 0
    *                  |
    *                  v
@@ -210,7 +210,7 @@ abstract class ImperativeAggregate extends AggregateFunction with CodegenFallbac
    *                                    ^
    *                                    |
    *                     avg(y) mutableAggBufferOffset = 2
-   *
+   * }}}
    */
   protected val mutableAggBufferOffset: Int
 
@@ -233,7 +233,7 @@ abstract class ImperativeAggregate extends AggregateFunction with CodegenFallbac
    * `avg(x)` and `avg(y)`. In the shared input aggregation buffer, the position of the first
    * buffer value of `avg(x)` will be 1 and the position of the first buffer value of `avg(y)`
    * will be 3 (position 0 is used for the value of `key`):
-   *
+   * {{{
    *          avg(x) inputAggBufferOffset = 1
    *                   |
    *                   v
@@ -243,7 +243,7 @@ abstract class ImperativeAggregate extends AggregateFunction with CodegenFallbac
    *                                     ^
    *                                     |
    *                       avg(y) inputAggBufferOffset = 3
-   *
+   * }}}
    */
   protected val inputAggBufferOffset: Int
 


### PR DESCRIPTION
Otherwise the `^` character is always marked as error in IntelliJ since it represents an unclosed superscript markup tag.
