### PR TITLE
[SPARK-13023][PROJECT INFRA] Fix handling of root module in modules_to_test()

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -113,15 +113,13 @@ def determine_modules_to_test(changed_modules):
     ['sql', 'hive', 'mllib', 'examples', 'hive-thriftserver', 'pyspark-sql', 'sparkr',
      'pyspark-mllib', 'pyspark-ml']
     """
-    # If we're going to have to run all of the tests, then we can just short-circuit
-    # and return 'root'. No module depends on root, so if it appears then it will be
-    # in changed_modules.
-    if modules.root in changed_modules:
-        return [modules.root]
     modules_to_test = set()
     for module in changed_modules:
         modules_to_test = modules_to_test.union(determine_modules_to_test(module.dependent_modules))
     modules_to_test = modules_to_test.union(set(changed_modules))
+    # If we need to run all of the tests, then we should short-circuit and return 'root'
+    if modules.root in modules_to_test:
+        return [modules.root]
     return toposort_flatten(
         {m: set(m.dependencies).intersection(modules_to_test) for m in modules_to_test}, sort=True)
 

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -104,6 +104,8 @@ def determine_modules_to_test(changed_modules):
 
     >>> [x.name for x in determine_modules_to_test([modules.root])]
     ['root']
+    >>> [x.name for x in determine_modules_to_test([modules.build])]
+    ['root']
     >>> [x.name for x in determine_modules_to_test([modules.graphx])]
     ['graphx', 'examples']
     >>> x = [x.name for x in determine_modules_to_test([modules.sql])]


### PR DESCRIPTION
There's a minor bug in how we handle the `root` module in the `modules_to_test()` function in `dev/run-tests.py`: since `root` now depends on `build` (since every test needs to run on any build test), we now need to check for the presence of root in `modules_to_test` instead of `changed_modules`.
