### PR TITLE
[SPARK-6847][Core][Streaming]Fix stack overflow issue when updateStateByKey is followed by a checkpointed dstream

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1540,7 +1540,7 @@ abstract class RDD[T: ClassTag](
   // less data but is not safe for all workloads. E.g. in streaming we may checkpoint both
   // an RDD and its parent in every batch, in which case the parent may never be checkpointed
   // and its lineage never truncated, leading to OOMs in the long run (SPARK-6847).
-  private val checkpointAllMarked =
+  private val checkpointAllMarkedAncestors =
     Option(sc.getLocalProperty(RDD.CHECKPOINT_ALL_MARKED_ANCESTORS))
       .map(_.toBoolean).getOrElse(false)
 
@@ -1587,7 +1587,7 @@ abstract class RDD[T: ClassTag](
       if (!doCheckpointCalled) {
         doCheckpointCalled = true
         if (checkpointData.isDefined) {
-          if (checkpointAllMarked) {
+          if (checkpointAllMarkedAncestors) {
             // TODO We can collect all the RDDs that needs to be checkpointed, and then checkpoint
             // them in parallel.
             // Checkpoint parents first because our lineage will be truncated after we

--- a/core/src/test/scala/org/apache/spark/CheckpointSuite.scala
+++ b/core/src/test/scala/org/apache/spark/CheckpointSuite.scala
@@ -512,6 +512,21 @@ class CheckpointSuite extends SparkFunSuite with RDDCheckpointTester with LocalS
     assert(rdd.isCheckpointedAndMaterialized === true)
     assert(rdd.partitions.size === 0)
   }
+
+  runTest("recursive RDD checkpoint") { reliableCheckpoint: Boolean =>
+    sc.setLocalProperty("spark.checkpoint.recursive", "true")
+    try {
+      val rdd1 = sc.parallelize(1 to 10)
+      checkpoint(rdd1, reliableCheckpoint)
+      val rdd2 = rdd1.map(_ + 1)
+      checkpoint(rdd2, reliableCheckpoint)
+      rdd2.count()
+      assert(rdd1.isCheckpointed === true)
+      assert(rdd2.isCheckpointed === true)
+    } finally {
+      sc.setLocalProperty("spark.checkpoint.recursive", null)
+    }
+  }
 }
 
 /** RDD partition that has large serialized size. */

--- a/core/src/test/scala/org/apache/spark/CheckpointSuite.scala
+++ b/core/src/test/scala/org/apache/spark/CheckpointSuite.scala
@@ -513,8 +513,8 @@ class CheckpointSuite extends SparkFunSuite with RDDCheckpointTester with LocalS
     assert(rdd.partitions.size === 0)
   }
 
-  runTest("recursive RDD checkpoint") { reliableCheckpoint: Boolean =>
-    sc.setLocalProperty("spark.checkpoint.recursive", "true")
+  runTest("checkpoint all marked RDDs") { reliableCheckpoint: Boolean =>
+    sc.setLocalProperty(RDD.CHECKPOINT_ALL_MARKED, "true")
     try {
       val rdd1 = sc.parallelize(1 to 10)
       checkpoint(rdd1, reliableCheckpoint)
@@ -524,7 +524,7 @@ class CheckpointSuite extends SparkFunSuite with RDDCheckpointTester with LocalS
       assert(rdd1.isCheckpointed === true)
       assert(rdd2.isCheckpointed === true)
     } finally {
-      sc.setLocalProperty("spark.checkpoint.recursive", null)
+      sc.setLocalProperty(RDD.CHECKPOINT_ALL_MARKED, null)
     }
   }
 }

--- a/core/src/test/scala/org/apache/spark/CheckpointSuite.scala
+++ b/core/src/test/scala/org/apache/spark/CheckpointSuite.scala
@@ -513,18 +513,24 @@ class CheckpointSuite extends SparkFunSuite with RDDCheckpointTester with LocalS
     assert(rdd.partitions.size === 0)
   }
 
-  runTest("checkpoint all marked RDDs") { reliableCheckpoint: Boolean =>
-    sc.setLocalProperty(RDD.CHECKPOINT_ALL_MARKED, "true")
+  runTest("checkpointAllMarkedAncestors") { reliableCheckpoint: Boolean =>
+    testCheckpointAllMarkedAncestors(reliableCheckpoint, checkpointAllMarkedAncestors = true)
+    testCheckpointAllMarkedAncestors(reliableCheckpoint, checkpointAllMarkedAncestors = false)
+  }
+
+  private def testCheckpointAllMarkedAncestors(
+      reliableCheckpoint: Boolean, checkpointAllMarkedAncestors: Boolean): Unit = {
+    sc.setLocalProperty(RDD.CHECKPOINT_ALL_MARKED_ANCESTORS, checkpointAllMarkedAncestors.toString)
     try {
       val rdd1 = sc.parallelize(1 to 10)
       checkpoint(rdd1, reliableCheckpoint)
       val rdd2 = rdd1.map(_ + 1)
       checkpoint(rdd2, reliableCheckpoint)
       rdd2.count()
-      assert(rdd1.isCheckpointed === true)
+      assert(rdd1.isCheckpointed === checkpointAllMarkedAncestors)
       assert(rdd2.isCheckpointed === true)
     } finally {
-      sc.setLocalProperty(RDD.CHECKPOINT_ALL_MARKED, null)
+      sc.setLocalProperty(RDD.CHECKPOINT_ALL_MARKED_ANCESTORS, null)
     }
   }
 }

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
@@ -243,6 +243,10 @@ class JobGenerator(jobScheduler: JobScheduler) extends Logging {
     // Example: BlockRDDs are created in this thread, and it needs to access BlockManager
     // Update: This is probably redundant after threadlocal stuff in SparkEnv has been removed.
     SparkEnv.set(ssc.env)
+
+    // Enable "spark.checkpoint.recursive" to make sure that all RDDs marked with the checkpoint
+    // flag are all checkpointed to avoid the stack overflow issue. See SPARK-6847
+    ssc.sparkContext.setLocalProperty("spark.checkpoint.recursive", "true")
     Try {
       jobScheduler.receiverTracker.allocateBlocksToBatch(time) // allocate received blocks to batch
       graph.generateJobs(time) // generate jobs using allocated block

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
@@ -20,6 +20,7 @@ package org.apache.spark.streaming.scheduler
 import scala.util.{Failure, Success, Try}
 
 import org.apache.spark.{Logging, SparkEnv}
+import org.apache.spark.rdd.RDD
 import org.apache.spark.streaming.{Checkpoint, CheckpointWriter, Time}
 import org.apache.spark.streaming.util.RecurringTimer
 import org.apache.spark.util.{Clock, EventLoop, ManualClock, Utils}
@@ -244,9 +245,9 @@ class JobGenerator(jobScheduler: JobScheduler) extends Logging {
     // Update: This is probably redundant after threadlocal stuff in SparkEnv has been removed.
     SparkEnv.set(ssc.env)
 
-    // Enable "spark.checkpoint.recursive" to make sure that all RDDs marked with the checkpoint
-    // flag are all checkpointed to avoid the stack overflow issue. See SPARK-6847
-    ssc.sparkContext.setLocalProperty("spark.checkpoint.recursive", "true")
+    // Enable "spark.checkpoint.checkpointAllMarked" to make sure that all RDDs marked with the
+    // checkpoint flag are all checkpointed to avoid the stack overflow issue. See SPARK-6847
+    ssc.sparkContext.setLocalProperty(RDD.CHECKPOINT_ALL_MARKED, "true")
     Try {
       jobScheduler.receiverTracker.allocateBlocksToBatch(time) // allocate received blocks to batch
       graph.generateJobs(time) // generate jobs using allocated block

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
@@ -245,9 +245,9 @@ class JobGenerator(jobScheduler: JobScheduler) extends Logging {
     // Update: This is probably redundant after threadlocal stuff in SparkEnv has been removed.
     SparkEnv.set(ssc.env)
 
-    // Enable "spark.checkpoint.checkpointAllMarked" to make sure that all RDDs marked with the
-    // checkpoint flag are all checkpointed to avoid the stack overflow issue. See SPARK-6847
-    ssc.sparkContext.setLocalProperty(RDD.CHECKPOINT_ALL_MARKED, "true")
+    // Checkpoint all RDDs marked for checkpointing to ensure their lineages are
+    // truncated periodically. Otherwise, we may run into stack overflows (SPARK-6847).
+    ssc.sparkContext.setLocalProperty(RDD.CHECKPOINT_ALL_MARKED_ANCESTORS, "true")
     Try {
       jobScheduler.receiverTracker.allocateBlocksToBatch(time) // allocate received blocks to batch
       graph.generateJobs(time) // generate jobs using allocated block

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
@@ -210,9 +210,9 @@ class JobScheduler(val ssc: StreamingContext) extends Logging {
           s"""Streaming job from <a href="$batchUrl">$batchLinkText</a>""")
         ssc.sc.setLocalProperty(BATCH_TIME_PROPERTY_KEY, job.time.milliseconds.toString)
         ssc.sc.setLocalProperty(OUTPUT_OP_ID_PROPERTY_KEY, job.outputOpId.toString)
-        // Enable "spark.checkpoint.checkpointAllMarked" to make sure that all RDDs marked with the
-        // checkpoint flag are all checkpointed to avoid the stack overflow issue. See SPARK-6847
-        ssc.sparkContext.setLocalProperty(RDD.CHECKPOINT_ALL_MARKED, "true")
+        // Checkpoint all RDDs marked for checkpointing to ensure their lineages are
+        // truncated periodically. Otherwise, we may run into stack overflows (SPARK-6847).
+        ssc.sparkContext.setLocalProperty(RDD.CHECKPOINT_ALL_MARKED_ANCESTORS, "true")
 
         // We need to assign `eventLoop` to a temp variable. Otherwise, because
         // `JobScheduler.stop(false)` may set `eventLoop` to null when this method is running, then

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
@@ -23,10 +23,10 @@ import scala.collection.JavaConverters._
 import scala.util.Failure
 
 import org.apache.spark.Logging
-import org.apache.spark.rdd.PairRDDFunctions
+import org.apache.spark.rdd.{PairRDDFunctions, RDD}
 import org.apache.spark.streaming._
 import org.apache.spark.streaming.ui.UIUtils
-import org.apache.spark.util.{EventLoop, ThreadUtils, Utils}
+import org.apache.spark.util.{EventLoop, ThreadUtils}
 
 
 private[scheduler] sealed trait JobSchedulerEvent
@@ -210,6 +210,9 @@ class JobScheduler(val ssc: StreamingContext) extends Logging {
           s"""Streaming job from <a href="$batchUrl">$batchLinkText</a>""")
         ssc.sc.setLocalProperty(BATCH_TIME_PROPERTY_KEY, job.time.milliseconds.toString)
         ssc.sc.setLocalProperty(OUTPUT_OP_ID_PROPERTY_KEY, job.outputOpId.toString)
+        // Enable "spark.checkpoint.checkpointAllMarked" to make sure that all RDDs marked with the
+        // checkpoint flag are all checkpointed to avoid the stack overflow issue. See SPARK-6847
+        ssc.sparkContext.setLocalProperty(RDD.CHECKPOINT_ALL_MARKED, "true")
 
         // We need to assign `eventLoop` to a temp variable. Otherwise, because
         // `JobScheduler.stop(false)` may set `eventLoop` to null when this method is running, then

--- a/streaming/src/test/scala/org/apache/spark/streaming/CheckpointSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/CheckpointSuite.scala
@@ -880,10 +880,10 @@ class CheckpointSuite extends TestSuiteBase with DStreamCheckpointTester
             map(_.toBoolean).getOrElse(false)
 
         val stateRDDs = findAllMarkedRDDs(rdd)
-          rdd.count()
-          // Check the two state RDDs are both checkpointed
-          rddsCheckpointed = stateRDDs.size == 2 && stateRDDs.forall(_.isCheckpointed)
-        }
+        rdd.count()
+        // Check the two state RDDs are both checkpointed
+        rddsCheckpointed = stateRDDs.size == 2 && stateRDDs.forall(_.isCheckpointed)
+      }
     ssc.start()
     batchCounter.waitUntilBatchesCompleted(1, 10000)
     assert(shouldCheckpointAllMarkedRDDs === true)


### PR DESCRIPTION
Add a local property to indicate if checkpointing all RDDs that are marked with the checkpoint flag, and enable it in Streaming
