### PR TITLE
[SPARK-12988][SQL] Can't drop columns that contain dots

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -1270,4 +1270,29 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
       Seq(1 -> "a").toDF("i", "j").filter($"i".cast(StringType) === "1"),
       Row(1, "a"))
   }
+
+  test("SPARK-12988: drop columns with ` in column name") {
+    val src = Seq((1, 2, 3)).toDF("a_b", "a.b", "a.c")
+    val df = src.drop("a_b")
+    checkAnswer(df, Row(2, 3))
+    assert(df.schema.map(_.name) === Seq("a.b", "a.c"))
+    val df1 = src.drop("a.b")
+    checkAnswer(df1, Row(1, 3))
+    assert(df1.schema.map(_.name) === Seq("a_b", "a.c"))
+    val df2 = src.drop("`a.c`")
+    checkAnswer(df2, Row(1, 2))
+    assert(df2.schema.map(_.name) === Seq("a_b", "a.b"))
+    val col1 = new Column("a_b")
+    val df4 = src.drop(col1)
+    checkAnswer(df4, Row(2, 3))
+    assert(df4.schema.map(_.name) === Seq("a.b", "a.c"))
+    val col2 = new Column("a.b")
+    val df5 = src.drop(col2)
+    checkAnswer(df5, Row(1, 3))
+    assert(df5.schema.map(_.name) === Seq("a_b", "a.c"))
+    val col3 = new Column("`a.c`")
+    val df6 = src.drop(col3)
+    checkAnswer(df6, Row(1, 2))
+    assert(df6.schema.map(_.name) === Seq("a_b", "a.b"))
+  }
 }


### PR DESCRIPTION
Neither of theses works:
val df = Seq((1, 1)).toDF("a_b", "a.c")
df.drop("a.c").collect()

df: org.apache.spark.sql.DataFrame = [a_b: int, a.c: int]
val df = Seq((1, 1)).toDF("a_b", "a.c")
df.drop("`a.c`").collect()

df: org.apache.spark.sql.DataFrame = [a_b: int, a.c: int]
Given that you can't use drop to drop subfields, it seems to me that we should treat the column name literally (i.e. as though it is wrapped in back ticks)
