### PR TITLE
[SPARK-13040][Docs] Update JDBC deprecated SPARK_CLASSPATH documentation

### DIFF
--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -1869,7 +1869,7 @@ spark classpath. For example, to connect to postgres from the Spark Shell you wo
 following command:
 
 {% highlight bash %}
-SPARK_CLASSPATH=postgresql-9.3-1102-jdbc41.jar bin/spark-shell
+bin/spark-shell --conf spark.executor.extraClassPath=postgresql-9.3-1102-jdbc41.jar --driver-class-path postgresql-9.3-1102-jdbc41.jar --jars postgresql-9.3-1102-jdbc41.jar
 {% endhighlight %}
 
 Tables from the remote database can be loaded as a DataFrame or Spark SQL Temporary table using

--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -1869,7 +1869,7 @@ spark classpath. For example, to connect to postgres from the Spark Shell you wo
 following command:
 
 {% highlight bash %}
-bin/spark-shell --driver-class-path postgresql-9.3-1102-jdbc41.jar --jars postgresql-9.3-1102-jdbc41.jar
+bin/spark-shell --driver-class-path postgresql-9.4.1207.jar --jars postgresql-9.4.1207.jar
 {% endhighlight %}
 
 Tables from the remote database can be loaded as a DataFrame or Spark SQL Temporary table using

--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -1869,7 +1869,7 @@ spark classpath. For example, to connect to postgres from the Spark Shell you wo
 following command:
 
 {% highlight bash %}
-bin/spark-shell --conf spark.executor.extraClassPath=postgresql-9.3-1102-jdbc41.jar --driver-class-path postgresql-9.3-1102-jdbc41.jar --jars postgresql-9.3-1102-jdbc41.jar
+bin/spark-shell --driver-class-path postgresql-9.3-1102-jdbc41.jar --jars postgresql-9.3-1102-jdbc41.jar
 {% endhighlight %}
 
 Tables from the remote database can be loaded as a DataFrame or Spark SQL Temporary table using


### PR DESCRIPTION
Update JDBC documentation based on http://stackoverflow.com/a/30947090/219530 as SPARK_CLASSPATH is deprecated.

Also, that's how it worked, it didn't work with the SPARK_CLASSPATH or the --jars alone.

This would solve issue: https://issues.apache.org/jira/browse/SPARK-13040
