### PR TITLE
[SPARK-13045][SQL] Remove ColumnVector.Struct in favor of ColumnarBatch.Row

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
@@ -211,104 +211,6 @@ public abstract class ColumnVector {
   }
 
   /**
-   * Holder object to return a struct. This object is intended to be reused.
-   */
-  public static final class Struct extends InternalRow {
-    // The fields that make up this struct. For example, if the struct had 2 int fields, the access
-    // to it would be:
-    //   int f1 = fields[0].getInt[rowId]
-    //   int f2 = fields[1].getInt[rowId]
-    public final ColumnVector[] fields;
-
-    @Override
-    public boolean isNullAt(int fieldIdx) { return fields[fieldIdx].getIsNull(rowId); }
-
-    @Override
-    public boolean getBoolean(int ordinal) {
-      throw new NotImplementedException();
-    }
-
-    public byte getByte(int fieldIdx) { return fields[fieldIdx].getByte(rowId); }
-
-    @Override
-    public short getShort(int ordinal) {
-      throw new NotImplementedException();
-    }
-
-    public int getInt(int fieldIdx) { return fields[fieldIdx].getInt(rowId); }
-    public long getLong(int fieldIdx) { return fields[fieldIdx].getLong(rowId); }
-
-    @Override
-    public float getFloat(int ordinal) {
-      throw new NotImplementedException();
-    }
-
-    public double getDouble(int fieldIdx) { return fields[fieldIdx].getDouble(rowId); }
-
-    @Override
-    public Decimal getDecimal(int ordinal, int precision, int scale) {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public UTF8String getUTF8String(int ordinal) {
-      Array a = getByteArray(ordinal);
-      return UTF8String.fromBytes(a.byteArray, a.byteArrayOffset, a.length);
-    }
-
-    @Override
-    public byte[] getBinary(int ordinal) {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public CalendarInterval getInterval(int ordinal) {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public InternalRow getStruct(int ordinal, int numFields) {
-      return fields[ordinal].getStruct(rowId);
-    }
-
-    public Array getArray(int fieldIdx) { return fields[fieldIdx].getArray(rowId); }
-
-    @Override
-    public MapData getMap(int ordinal) {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public Object get(int ordinal, DataType dataType) {
-      throw new NotImplementedException();
-    }
-
-    public Array getByteArray(int fieldIdx) { return fields[fieldIdx].getByteArray(rowId); }
-    public Struct getStruct(int fieldIdx) { return fields[fieldIdx].getStruct(rowId); }
-
-    @Override
-    public final int numFields() {
-      return fields.length;
-    }
-
-    @Override
-    public InternalRow copy() {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public boolean anyNull() {
-      throw new NotImplementedException();
-    }
-
-    protected int rowId;
-
-    protected Struct(ColumnVector[] fields) {
-      this.fields = fields;
-    }
-  }
-
-  /**
    * Returns the data type of this column.
    */
   public final DataType dataType() { return type; }
@@ -494,7 +396,7 @@ public abstract class ColumnVector {
   /**
    * Returns a utility object to get structs.
    */
-  public Struct getStruct(int rowId) {
+  public ColumnarBatch.Row getStruct(int rowId) {
     resultStruct.rowId = rowId;
     return resultStruct;
   }
@@ -749,7 +651,7 @@ public abstract class ColumnVector {
   /**
    * Reusable Struct holder for getStruct().
    */
-  protected final Struct resultStruct;
+  protected final ColumnarBatch.Row resultStruct;
 
   /**
    * Sets up the common state and also handles creating the child columns if this is a nested
@@ -779,7 +681,7 @@ public abstract class ColumnVector {
         this.childColumns[i] = ColumnVector.allocate(capacity, st.fields()[i].dataType(), memMode);
       }
       this.resultArray = null;
-      this.resultStruct = new Struct(this.childColumns);
+      this.resultStruct = new ColumnarBatch.Row(this.childColumns);
     } else {
       this.childColumns = null;
       this.resultArray = null;

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -439,10 +439,10 @@ class ColumnarBatchSuite extends SparkFunSuite {
       c2.putDouble(1, 5.67)
 
       val s = column.getStruct(0)
-      assert(s.fields(0).getInt(0) == 123)
-      assert(s.fields(0).getInt(1) == 456)
-      assert(s.fields(1).getDouble(0) == 3.45)
-      assert(s.fields(1).getDouble(1) == 5.67)
+      assert(s.columns()(0).getInt(0) == 123)
+      assert(s.columns()(0).getInt(1) == 456)
+      assert(s.columns()(1).getDouble(0) == 3.45)
+      assert(s.columns()(1).getDouble(1) == 5.67)
 
       assert(s.getInt(0) == 123)
       assert(s.getDouble(1) == 3.45)


### PR DESCRIPTION
These two classes became identical as the implementation progressed.
