### PR TITLE
[SPARK-13047][PYSPARK][ML] Pyspark Params.hasParam should not throw an error

### DIFF
--- a/python/pyspark/ml/param/__init__.py
+++ b/python/pyspark/ml/param/__init__.py
@@ -156,6 +156,10 @@ class Params(Identifiable):
         """
         Tests whether this instance contains a param with a given
         (string) name.
+
+        Note: this method is changed in Spark 2.0+ to return `False`
+              instead of raising `AttributeError` when the instance
+              does not have a parameter with `paramName`.
         """
         if isinstance(paramName, str):
             p = getattr(self, paramName, None)

--- a/python/pyspark/ml/param/__init__.py
+++ b/python/pyspark/ml/param/__init__.py
@@ -152,13 +152,17 @@ class Params(Identifiable):
         return self.isSet(param) or self.hasDefault(param)
 
     @since("1.4.0")
-    def hasParam(self, paramName):
+    def hasParam(self, param):
         """
-        Tests whether this instance contains a param with a given
-        (string) name.
+        Tests whether this instance contains a param.
         """
-        param = self._resolveParam(paramName)
-        return param in self.params
+        if isinstance(param, Param):
+            return hasattr(self, param.name)
+        elif isinstance(param, str):
+            p = getattr(self, param, None)
+            return p is not None and isinstance(p, Param)
+        else:
+            raise TypeError("hasParam(): param must be a string or Param type")
 
     @since("1.4.0")
     def getOrDefault(self, param):

--- a/python/pyspark/ml/param/__init__.py
+++ b/python/pyspark/ml/param/__init__.py
@@ -156,10 +156,6 @@ class Params(Identifiable):
         """
         Tests whether this instance contains a param with a given
         (string) name.
-
-        Note: this method is changed in Spark 2.0+ to return `False`
-              instead of raising `AttributeError` when the instance
-              does not have a parameter with `paramName`.
         """
         if isinstance(paramName, str):
             p = getattr(self, paramName, None)

--- a/python/pyspark/ml/param/__init__.py
+++ b/python/pyspark/ml/param/__init__.py
@@ -163,7 +163,7 @@ class Params(Identifiable):
         """
         if isinstance(paramName, str):
             p = getattr(self, paramName, None)
-            return p is not None and isinstance(p, Param)
+            return isinstance(p, Param)
         else:
             raise TypeError("hasParam(): paramName must be a string")
 

--- a/python/pyspark/ml/param/__init__.py
+++ b/python/pyspark/ml/param/__init__.py
@@ -152,17 +152,16 @@ class Params(Identifiable):
         return self.isSet(param) or self.hasDefault(param)
 
     @since("1.4.0")
-    def hasParam(self, param):
+    def hasParam(self, paramName):
         """
-        Tests whether this instance contains a param.
+        Tests whether this instance contains a param with a given
+        (string) name.
         """
-        if isinstance(param, Param):
-            return hasattr(self, param.name)
-        elif isinstance(param, str):
-            p = getattr(self, param, None)
+        if isinstance(paramName, str):
+            p = getattr(self, paramName, None)
             return p is not None and isinstance(p, Param)
         else:
-            raise TypeError("hasParam(): param must be a string or Param type")
+            raise TypeError("hasParam(): paramName must be a string")
 
     @since("1.4.0")
     def getOrDefault(self, param):

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -201,7 +201,7 @@ class ParamTests(PySparkTestCase):
         params = testParams.params
         self.assertEqual(params, [inputCol, maxIter, seed])
 
-        self.assertTrue(testParams.hasParam(maxIter))
+        self.assertTrue(testParams.hasParam(maxIter.name))
         self.assertTrue(testParams.hasDefault(maxIter))
         self.assertFalse(testParams.isSet(maxIter))
         self.assertTrue(testParams.isDefined(maxIter))
@@ -210,7 +210,7 @@ class ParamTests(PySparkTestCase):
         self.assertTrue(testParams.isSet(maxIter))
         self.assertEqual(testParams.getMaxIter(), 100)
 
-        self.assertTrue(testParams.hasParam(inputCol))
+        self.assertTrue(testParams.hasParam(inputCol.name))
         self.assertFalse(testParams.hasDefault(inputCol))
         self.assertFalse(testParams.isSet(inputCol))
         self.assertFalse(testParams.isDefined(inputCol))

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -192,6 +192,11 @@ class ParamTests(PySparkTestCase):
         self.assertEqual(maxIter.doc, "max number of iterations (>= 0).")
         self.assertTrue(maxIter.parent == testParams.uid)
 
+    def test_hasparam(self):
+        testParams = TestParams()
+        self.assertTrue(all([testParams.hasParam(p.name) for p in testParams.params]))
+        self.assertFalse(testParams.hasParam("notAParameter"))
+
     def test_params(self):
         testParams = TestParams()
         maxIter = testParams.maxIter


### PR DESCRIPTION
Pyspark Params class has a method `hasParam(paramName)` which returns `True` if the class has a parameter by that name, but throws an `AttributeError` otherwise. There is not currently a way of getting a Boolean to indicate if a class has a parameter. With Spark 2.0 we could modify the existing behavior of `hasParam` or add an additional method with this functionality.

In Python:

``` python
from pyspark.ml.classification import NaiveBayes
nb = NaiveBayes()
print nb.hasParam("smoothing")
print nb.hasParam("notAParam")
```

produces:

> True
> AttributeError: 'NaiveBayes' object has no attribute 'notAParam'

However, in Scala:

``` scala
import org.apache.spark.ml.classification.NaiveBayes
val nb  = new NaiveBayes()
nb.hasParam("smoothing")
nb.hasParam("notAParam")
```

produces:

> true
> false

cc @holdenk 
