### PR TITLE
[SPARK-13056][SQL] map column would throw NPE if value is null

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
@@ -278,7 +278,7 @@ case class GetMapValue(child: Expression, key: Expression)
       }
     }
 
-    if (!found) {
+    if (!found || map.valueArray().isNullAt(i)) {
       null
     } else {
       map.valueArray().get(i, dataType)
@@ -307,7 +307,7 @@ case class GetMapValue(child: Expression, key: Expression)
           }
         }
 
-        if ($found) {
+        if ($found && !$eval1.valueArray().isNullAt($index)) {
           ${ev.value} = ${ctx.getValue(eval1 + ".valueArray()", dataType, index)};
         } else {
           ${ev.isNull} = true;

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
@@ -218,7 +218,7 @@ case class GetArrayItem(child: Expression, ordinal: Expression)
   protected override def nullSafeEval(value: Any, ordinal: Any): Any = {
     val baseValue = value.asInstanceOf[ArrayData]
     val index = ordinal.asInstanceOf[Number].intValue()
-    if (index >= baseValue.numElements() || index < 0) {
+    if (index >= baseValue.numElements() || index < 0 || baseValue.isNullAt(index)) {
       null
     } else {
       baseValue.get(index, dataType)
@@ -267,6 +267,7 @@ case class GetMapValue(child: Expression, key: Expression)
     val map = value.asInstanceOf[MapData]
     val length = map.numElements()
     val keys = map.keyArray()
+    val values = map.valueArray()
 
     var i = 0
     var found = false
@@ -278,10 +279,10 @@ case class GetMapValue(child: Expression, key: Expression)
       }
     }
 
-    if (!found || map.valueArray().isNullAt(i)) {
+    if (!found || values.isNullAt(i)) {
       null
     } else {
-      map.valueArray().get(i, dataType)
+      values.get(i, dataType)
     }
   }
 
@@ -291,10 +292,12 @@ case class GetMapValue(child: Expression, key: Expression)
     val keys = ctx.freshName("keys")
     val found = ctx.freshName("found")
     val key = ctx.freshName("key")
+    val values = ctx.freshName("values")
     nullSafeCodeGen(ctx, ev, (eval1, eval2) => {
       s"""
         final int $length = $eval1.numElements();
         final ArrayData $keys = $eval1.keyArray();
+        final ArrayData $values = $eval1.valueArray();
 
         int $index = 0;
         boolean $found = false;
@@ -307,8 +310,8 @@ case class GetMapValue(child: Expression, key: Expression)
           }
         }
 
-        if ($found && !$eval1.valueArray().isNullAt($index)) {
-          ${ev.value} = ${ctx.getValue(eval1 + ".valueArray()", dataType, index)};
+        if ($found && !$values.isNullAt($index)) {
+          ${ev.value} = ${ctx.getValue(values, dataType, index)};
         } else {
           ${ev.isNull} = true;
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
@@ -310,10 +310,10 @@ case class GetMapValue(child: Expression, key: Expression)
           }
         }
 
-        if ($found && !$values.isNullAt($index)) {
-          ${ev.value} = ${ctx.getValue(values, dataType, index)};
-        } else {
+        if (!$found || $values.isNullAt($index)) {
           ${ev.isNull} = true;
+        } else {
+          ${ev.value} = ${ctx.getValue(values, dataType, index)};
         }
       """
     })

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2046,6 +2046,15 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
     )
   }
 
+  test("SPARK-13056: Null in map value causes NPE") {
+    val df = Seq(1 -> Map("abc" -> "somestring", "cba" -> null)).toDF("key", "value")
+    withTempTable("maptest") {
+      df.registerTempTable("maptest")
+      checkAnswer(sql("SELECT value['abc'] FROM maptest"), Row("somestring"))
+      checkAnswer(sql("SELECT value['cba'] FROM maptest"), Row(null))
+    }
+  }
+
   test("hash function") {
     val df = Seq(1 -> "a", 2 -> "b").toDF("i", "j")
     withTempTable("tbl") {
@@ -2055,12 +2064,5 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
         sql("SELECT hash(i, j) from tbl")
       )
     }
-  }
-
-  test("SPARK-13056: Null in map value causes NPE") {
-    val df = Seq(1 -> Map("abc" -> "somestring", "cba" -> null)).toDF("key", "value")
-    df.registerTempTable("maptest")
-    checkAnswer(sql("SELECT value['abc'] FROM maptest"), Row("somestring"))
-    checkAnswer(sql("SELECT value['cba'] FROM maptest"), Row(null))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2050,8 +2050,8 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
     val df = Seq(1 -> Map("abc" -> "somestring", "cba" -> null)).toDF("key", "value")
     withTempTable("maptest") {
       df.registerTempTable("maptest")
-      checkAnswer(sql("SELECT value['abc'] FROM maptest"), Row("somestring"))
-      checkAnswer(sql("SELECT value['cba'] FROM maptest"), Row(null))
+      checkAnswer(sql("SELECT value['abc'] FROM maptest where key = 1"), Row("somestring"))
+      checkAnswer(sql("SELECT value['cba'] FROM maptest where key = 1"), Row(null))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2050,6 +2050,7 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
     val df = Seq(1 -> Map("abc" -> "somestring", "cba" -> null)).toDF("key", "value")
     withTempTable("maptest") {
       df.registerTempTable("maptest")
+      // local optimization will by pass codegen code, so we should keep the filter `key=1`
       checkAnswer(sql("SELECT value['abc'] FROM maptest where key = 1"), Row("somestring"))
       checkAnswer(sql("SELECT value['cba'] FROM maptest where key = 1"), Row(null))
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2056,4 +2056,11 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
       )
     }
   }
+
+  test("SPARK-13056: Null in map value causes NPE") {
+    val df = Seq(1 -> Map("abc" -> "somestring", "cba" -> null)).toDF("key", "value")
+    df.registerTempTable("maptest")
+    checkAnswer(sql("SELECT value['abc'] FROM maptest"), Row("somestring"))
+    checkAnswer(sql("SELECT value['cba'] FROM maptest"), Row(null))
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -1463,11 +1463,4 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
         |FROM (SELECT '{"f1": "value1", "f2": 12}' json, 'hello' as str) test
       """.stripMargin), Row("value1", "12", BigDecimal("3.14"), "hello"))
   }
-
-  test("SPARK-13056: Null in map value causes NPE") {
-    val df = Seq(1 -> Map("abc" -> "somestring", "cba" -> null)).toDF("key", "value")
-    df.registerTempTable("maptest")
-    checkAnswer(sql("SELECT value['abc'] FROM maptest"), Row("somestring"))
-    checkAnswer(sql("SELECT value['cba'] FROM maptest"), Row(null))
-  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -1463,4 +1463,11 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
         |FROM (SELECT '{"f1": "value1", "f2": 12}' json, 'hello' as str) test
       """.stripMargin), Row("value1", "12", BigDecimal("3.14"), "hello"))
   }
+
+  test("SPARK-13056: Null in map value causes NPE") {
+    Seq((1, "abc=somestring,cba")).toDF("key", "value").registerTempTable("mapsrc")
+    sql("""CREATE TABLE maptest AS SELECT str_to_map(value, ",", "=") as col1 FROM mapsrc""")
+    checkAnswer(sql("SELECT col1['abc'] FROM maptest"), Row("somestring"))
+    checkAnswer(sql("SELECT col1['cba'] FROM maptest"), Row(null))
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -1465,9 +1465,9 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
   }
 
   test("SPARK-13056: Null in map value causes NPE") {
-    Seq((1, "abc=somestring,cba")).toDF("key", "value").registerTempTable("mapsrc")
-    sql("""CREATE TABLE maptest AS SELECT str_to_map(value, ",", "=") as col1 FROM mapsrc""")
-    checkAnswer(sql("SELECT col1['abc'] FROM maptest"), Row("somestring"))
-    checkAnswer(sql("SELECT col1['cba'] FROM maptest"), Row(null))
+    val df = Seq(1 -> Map("abc" -> "somestring", "cba" -> null)).toDF("key", "value")
+    df.registerTempTable("maptest")
+    checkAnswer(sql("SELECT value['abc'] FROM maptest"), Row("somestring"))
+    checkAnswer(sql("SELECT value['cba'] FROM maptest"), Row(null))
   }
 }


### PR DESCRIPTION
Jira:
https://issues.apache.org/jira/browse/SPARK-13056

Create a map like
{ "a": "somestring", "b": null}
Query like
SELECT col["b"] FROM t1;
NPE would be thrown.
