### PR TITLE
[SPARK-12977][Streaming][WIP] Support Streaming UI in history server

### DIFF
--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -216,6 +216,10 @@ object MimaExcludes {
         // SPARK-11622 Make LibSVMRelation extends HadoopFsRelation and Add LibSVMOutputWriter
         ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.ml.source.libsvm.DefaultSource"),
         ProblemFilters.exclude[MissingMethodProblem]("org.apache.spark.ml.source.libsvm.DefaultSource.createRelation")
+      ) ++ Seq(
+        // SPARK-12977
+        ProblemFilters.exclude[MissingMethodProblem]("org.apache.spark.streaming.Time.millis$1"),
+        ProblemFilters.exclude[AbstractClassProblem]("org.apache.spark.streaming.scheduler.StreamingListenerBus")
       )
     case v if v.startsWith("1.6") =>
       Seq(

--- a/streaming/src/main/resources/META-INF/services/org.apache.spark.scheduler.SparkHistoryListenerFactory
+++ b/streaming/src/main/resources/META-INF/services/org.apache.spark.scheduler.SparkHistoryListenerFactory
@@ -1,0 +1,1 @@
+org.apache.spark.streaming.scheduler.StreamingHistoryListenerFactory

--- a/streaming/src/main/scala/org/apache/spark/streaming/Time.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/Time.scala
@@ -23,7 +23,7 @@ package org.apache.spark.streaming
  * time and midnight, January 1, 1970 UTC. This is the same format as what is returned by
  * System.currentTimeMillis.
  */
-case class Time(private val millis: Long) {
+case class Time(val millis: Long) {
 
   def milliseconds: Long = millis
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/BatchInfo.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/BatchInfo.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.streaming.scheduler
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.streaming.Time
 
@@ -34,10 +36,12 @@ import org.apache.spark.streaming.Time
 @DeveloperApi
 case class BatchInfo(
     batchTime: Time,
+    @JsonDeserialize(keyAs = classOf[java.lang.Integer])
     streamIdToInputInfo: Map[Int, StreamInputInfo],
     submissionTime: Long,
     processingStartTime: Option[Long],
     processingEndTime: Option[Long],
+    @JsonDeserialize(keyAs = classOf[java.lang.Integer])
     outputOperationInfos: Map[Int, OutputOperationInfo]
   ) {
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
@@ -27,6 +27,7 @@ import org.apache.spark.rdd.PairRDDFunctions
 import org.apache.spark.streaming._
 import org.apache.spark.streaming.ui.UIUtils
 import org.apache.spark.util.{EventLoop, ThreadUtils, Utils}
+import org.apache.spark.streaming.dstream.ReceiverInputDStream
 
 
 private[scheduler] sealed trait JobSchedulerEvent
@@ -77,6 +78,12 @@ class JobScheduler(val ssc: StreamingContext) extends Logging {
     } ssc.addStreamingListener(rateController)
 
     listenerBus.start()
+
+    ssc.graph.getInputStreams().foreach { inputStream =>
+      listenerBus.post(StreamingListenerInputStreamRegistered(
+        inputStream.id, inputStream.name, inputStream.isInstanceOf[ReceiverInputDStream[_]]))
+    }
+
     receiverTracker = new ReceiverTracker(ssc)
     inputInfoTracker = new InputInfoTracker(ssc)
     receiverTracker.start()

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
@@ -25,10 +25,9 @@ import scala.util.Failure
 import org.apache.spark.Logging
 import org.apache.spark.rdd.PairRDDFunctions
 import org.apache.spark.streaming._
-import org.apache.spark.streaming.ui.UIUtils
-import org.apache.spark.util.{EventLoop, ThreadUtils, Utils}
 import org.apache.spark.streaming.dstream.ReceiverInputDStream
-
+import org.apache.spark.streaming.ui.UIUtils
+import org.apache.spark.util.{EventLoop, ThreadUtils}
 
 private[scheduler] sealed trait JobSchedulerEvent
 private[scheduler] case class JobStarted(job: Job, startTime: Long) extends JobSchedulerEvent

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
@@ -49,7 +49,7 @@ class JobScheduler(val ssc: StreamingContext) extends Logging {
     ThreadUtils.newDaemonFixedThreadPool(numConcurrentJobs, "streaming-job-executor")
   private val jobGenerator = new JobGenerator(this)
   val clock = jobGenerator.clock
-  val listenerBus = new StreamingListenerBus(ssc.sparkContext.listenerBus)
+  val listenerBus = new LiveStreamingListenerBus(ssc.sparkContext.listenerBus)
 
   // These two are created only when scheduler starts.
   // eventLoop not being null means the scheduler has been started and not stopped

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/StreamingListener.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/StreamingListener.scala
@@ -17,11 +17,10 @@
 
 package org.apache.spark.streaming.scheduler
 
-import org.apache.spark.scheduler.SparkListenerEvent
-
 import scala.collection.mutable.Queue
 
 import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.scheduler.SparkListenerEvent
 import org.apache.spark.util.Distribution
 
 /**

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/StreamingListener.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/StreamingListener.scala
@@ -60,6 +60,10 @@ case class StreamingListenerOutputOperationCompleted(outputOperationInfo: Output
   extends StreamingListenerEvent
 
 @DeveloperApi
+case class StreamingListenerInputStreamRegistered(
+    streamId: Int, name: String, isReceiverBased: Boolean) extends StreamingListenerEvent
+
+@DeveloperApi
 case class StreamingListenerReceiverStarted(receiverInfo: ReceiverInfo)
   extends StreamingListenerEvent
 
@@ -86,6 +90,10 @@ trait StreamingListener {
   /** Called when a streaming application has been stopped */
   def onStreamingApplicationEnd(
       streamingListenerApplicationEnd: StreamingListenerApplicationEnd) { }
+
+  /** Called when an InputDStream has been registered */
+  def onInputStreamRegistered(
+      streamingListenerInputStreamRegistered: StreamingListenerInputStreamRegistered) { }
 
   /** Called when a receiver has been started */
   def onReceiverStarted(receiverStarted: StreamingListenerReceiverStarted) { }

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/StreamingListenerBus.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/StreamingListenerBus.scala
@@ -24,10 +24,10 @@ import org.apache.spark.ui.SparkUI
 import org.apache.spark.util.ListenerBus
 
 /**
- * A Streaming listener bus to forward events to StreamingListeners. This one will wrap received
- * Streaming events as WrappedStreamingListenerEvent and send them to Spark listener bus. It also
- * registers itself with Spark listener bus, so that it can receive WrappedStreamingListenerEvents,
- * unwrap them as StreamingListenerEvent and dispatch them to StreamingListeners.
+ * A Streaming listener bus to forward events to StreamingListeners. This one will forward received
+ * Streaming events as SparkListenerEvent and send them to Spark listener bus. It also
+ * registers itself with Spark listener bus, so that it can receive SparkListenerEvents,
+ * forward them as StreamingListenerEvent and dispatch them to StreamingListeners.
  */
 private[streaming] abstract class StreamingListenerBus
   extends SparkListener with ListenerBus[StreamingListener, StreamingListenerEvent] {
@@ -48,6 +48,8 @@ private[streaming] abstract class StreamingListenerBus
         listener.onStreamingApplicationStarted(applicationStarted)
       case applicationEnd: StreamingListenerApplicationEnd =>
         listener.onStreamingApplicationEnd(applicationEnd)
+      case inputStreamRegistered: StreamingListenerInputStreamRegistered =>
+        listener.onInputStreamRegistered(inputStreamRegistered)
       case receiverStarted: StreamingListenerReceiverStarted =>
         listener.onReceiverStarted(receiverStarted)
       case receiverError: StreamingListenerReceiverError =>
@@ -69,12 +71,6 @@ private[streaming] abstract class StreamingListenerBus
   }
 }
 
-/**
- * A Streaming listener bus to forward events to StreamingListeners. This one will wrap received
- * Streaming events as WrappedStreamingListenerEvent and send them to Spark listener bus. It also
- * registers itself with Spark listener bus, so that it can receive WrappedStreamingListenerEvents,
- * unwrap them as StreamingListenerEvent and dispatch them to StreamingListeners.
- */
 private[streaming] class LiveStreamingListenerBus(sparkListenerBus: LiveListenerBus)
   extends StreamingListenerBus {
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/StreamingListenerBus.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/StreamingListenerBus.scala
@@ -19,7 +19,7 @@ package org.apache.spark.streaming.scheduler
 
 import org.apache.spark.SparkConf
 import org.apache.spark.scheduler._
-import org.apache.spark.streaming.ui.{StreamingTab, StreamingJobProgressListener}
+import org.apache.spark.streaming.ui.{StreamingJobProgressListener, StreamingTab}
 import org.apache.spark.ui.SparkUI
 import org.apache.spark.util.ListenerBus
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/ui/BatchPage.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/ui/BatchPage.scala
@@ -32,7 +32,7 @@ private[ui] case class SparkJobIdWithUIData(sparkJobId: SparkJobId, jobUIData: O
 
 private[ui] class BatchPage(parent: StreamingTab) extends WebUIPage("batch") {
   private val streamingListener = parent.listener
-  private val sparkListener = parent.ssc.sc.jobProgressListener
+  private val sparkListener = parent.sparkUI.jobProgressListener
 
   private def columns: Seq[Node] = {
     <th>Output Op Id</th>

--- a/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingJobProgressListener.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingJobProgressListener.scala
@@ -63,7 +63,6 @@ private[streaming] class StreamingJobProgressListener(conf: SparkConf)
       }
     }
 
-
   @volatile var batchDuration = 0L
   @volatile var applicationStartTime = 0L
   @volatile var applicationEndTime = 0L

--- a/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingJobProgressListener.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingJobProgressListener.scala
@@ -19,12 +19,11 @@ package org.apache.spark.streaming.ui
 
 import java.util.{LinkedHashMap, Map => JMap, Properties}
 
-import org.apache.spark.SparkConf
-
 import scala.collection.mutable.{ArrayBuffer, HashMap, Queue, SynchronizedBuffer}
 
+import org.apache.spark.SparkConf
 import org.apache.spark.scheduler._
-import org.apache.spark.streaming.{StreamingContext, Time}
+import org.apache.spark.streaming.Time
 import org.apache.spark.streaming.scheduler._
 
 private[streaming] class StreamingJobProgressListener(conf: SparkConf)

--- a/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingPage.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingPage.scala
@@ -145,7 +145,7 @@ private[ui] class StreamingPage(parent: StreamingTab)
   import StreamingPage._
 
   private val listener = parent.listener
-  private val startTime = System.currentTimeMillis()
+  private lazy val startTime = listener.applicationStartTime
 
   /** Render the page */
   def render(request: HttpServletRequest): Seq[Node] = {
@@ -173,7 +173,12 @@ private[ui] class StreamingPage(parent: StreamingTab)
 
   /** Generate basic information of the streaming program */
   private def generateBasicInfo(): Seq[Node] = {
-    val timeSinceStart = System.currentTimeMillis() - startTime
+    val timeSinceStart = if (listener.applicationEndTime <= 0L) {
+      System.currentTimeMillis() - startTime
+    } else {
+      listener.applicationEndTime - startTime
+    }
+
     <div>Running batches of
       <strong>
         {SparkUIUtils.formatDurationVerbose(listener.batchDuration)}

--- a/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingTab.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingTab.scala
@@ -17,44 +17,29 @@
 
 package org.apache.spark.streaming.ui
 
-import org.apache.spark.{Logging, SparkException}
-import org.apache.spark.streaming.StreamingContext
+import org.apache.spark.Logging
 import org.apache.spark.ui.{SparkUI, SparkUITab}
 
 /**
  * Spark Web UI tab that shows statistics of a streaming job.
  * This assumes the given SparkContext has enabled its SparkUI.
  */
-private[spark] class StreamingTab(val ssc: StreamingContext)
-  extends SparkUITab(StreamingTab.getSparkUI(ssc), "streaming") with Logging {
-
-  import StreamingTab._
+private[spark] class StreamingTab(val listener: StreamingJobProgressListener, val sparkUI: SparkUI)
+  extends SparkUITab(sparkUI, "streaming") with Logging {
 
   private val STATIC_RESOURCE_DIR = "org/apache/spark/streaming/ui/static"
 
-  val parent = getSparkUI(ssc)
-  val listener = ssc.progressListener
-
-  ssc.addStreamingListener(listener)
-  ssc.sc.addSparkListener(listener)
   attachPage(new StreamingPage(this))
   attachPage(new BatchPage(this))
 
   def attach() {
-    getSparkUI(ssc).attachTab(this)
-    getSparkUI(ssc).addStaticHandler(STATIC_RESOURCE_DIR, "/static/streaming")
+    logInfo(s"Attach the streaming UI")
+    sparkUI.attachTab(this)
+    sparkUI.addStaticHandler(STATIC_RESOURCE_DIR, "/static/streaming")
   }
 
   def detach() {
-    getSparkUI(ssc).detachTab(this)
-    getSparkUI(ssc).removeStaticHandler("/static/streaming")
-  }
-}
-
-private object StreamingTab {
-  def getSparkUI(ssc: StreamingContext): SparkUI = {
-    ssc.sc.ui.getOrElse {
-      throw new SparkException("Parent SparkUI to attach this tab to not found!")
-    }
+    sparkUI.detachTab(this)
+    sparkUI.removeStaticHandler("/static/streaming")
   }
 }

--- a/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingTab.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingTab.scala
@@ -33,7 +33,6 @@ private[spark] class StreamingTab(val listener: StreamingJobProgressListener, va
   attachPage(new BatchPage(this))
 
   def attach() {
-    logInfo(s"Attach the streaming UI")
     sparkUI.attachTab(this)
     sparkUI.addStaticHandler(STATIC_RESOURCE_DIR, "/static/streaming")
   }

--- a/streaming/src/test/scala/org/apache/spark/streaming/ui/StreamingJobProgressListenerSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/ui/StreamingJobProgressListenerSuite.scala
@@ -56,7 +56,7 @@ class StreamingJobProgressListenerSuite extends TestSuiteBase with Matchers {
   test("onBatchSubmitted, onBatchStarted, onBatchCompleted, " +
     "onReceiverStarted, onReceiverError, onReceiverStopped") {
     ssc = setupStreams(input, operation)
-    val listener = new StreamingJobProgressListener(ssc)
+    val listener = new StreamingJobProgressListener(conf)
 
     val streamIdToInputInfo = Map(
       0 -> StreamInputInfo(0, 300L),
@@ -154,7 +154,7 @@ class StreamingJobProgressListenerSuite extends TestSuiteBase with Matchers {
   test("Remove the old completed batches when exceeding the limit") {
     ssc = setupStreams(input, operation)
     val limit = ssc.conf.getInt("spark.streaming.ui.retainedBatches", 1000)
-    val listener = new StreamingJobProgressListener(ssc)
+    val listener = new StreamingJobProgressListener(conf)
 
     val streamIdToInputInfo = Map(0 -> StreamInputInfo(0, 300L), 1 -> StreamInputInfo(1, 300L))
 
@@ -172,7 +172,7 @@ class StreamingJobProgressListenerSuite extends TestSuiteBase with Matchers {
   test("out-of-order onJobStart and onBatchXXX") {
     ssc = setupStreams(input, operation)
     val limit = ssc.conf.getInt("spark.streaming.ui.retainedBatches", 1000)
-    val listener = new StreamingJobProgressListener(ssc)
+    val listener = new StreamingJobProgressListener(conf)
 
     // fulfill completedBatchInfos
     for(i <- 0 until limit) {
@@ -222,7 +222,7 @@ class StreamingJobProgressListenerSuite extends TestSuiteBase with Matchers {
 
   test("detect memory leak") {
     ssc = setupStreams(input, operation)
-    val listener = new StreamingJobProgressListener(ssc)
+    val listener = new StreamingJobProgressListener(conf)
 
     val limit = ssc.conf.getInt("spark.streaming.ui.retainedBatches", 1000)
 


### PR DESCRIPTION
This patch adds the Streaming UI support in history server. Here is the screenshot of the current progress:

![screenshot-1](https://cloud.githubusercontent.com/assets/850797/12637029/16911e38-c5cd-11e5-9bd2-ec0e36e04f27.png)

There still has left some parts need to be addressed:
1. Add / fix the unit test to verify the newly added functionality, especially newly added listener events.
2. Add Python related codes for the new streaming listener events.

Posted WIP here to see if this solution is acceptable or not, please help to comment, thanks a lot.
