### PR TITLE
[SPARK-12818][SQL] Specializes integral and string types for Count-min Sketch

### DIFF
--- a/common/sketch/src/main/java/org/apache/spark/util/sketch/CountMinSketch.java
+++ b/common/sketch/src/main/java/org/apache/spark/util/sketch/CountMinSketch.java
@@ -124,6 +124,18 @@ abstract public class CountMinSketch {
    */
   public abstract void add(Object item, long count);
 
+  public abstract void addLong(long item);
+
+  public abstract void addLong(long item, long count);
+
+  public abstract void addString(String item);
+
+  public abstract void addString(String item, long count);
+
+  public abstract void addBinary(byte[] item);
+
+  public abstract void addBinary(byte[] item, long count);
+
   /**
    * Returns the estimated frequency of {@code item}.
    */

--- a/common/sketch/src/main/java/org/apache/spark/util/sketch/CountMinSketch.java
+++ b/common/sketch/src/main/java/org/apache/spark/util/sketch/CountMinSketch.java
@@ -115,25 +115,43 @@ abstract public class CountMinSketch {
   public abstract long totalCount();
 
   /**
-   * Adds 1 to {@code item}.
+   * Increments {@code item}'s count by one.
    */
   public abstract void add(Object item);
 
   /**
-   * Adds {@code count} to {@code item}.
+   * Increments {@code item}'s count by {@code count}.
    */
   public abstract void add(Object item, long count);
 
+  /**
+   * Increments {@code item}'s count by one.
+   */
   public abstract void addLong(long item);
 
+  /**
+   * Increments {@code item}'s count by {@code count}.
+   */
   public abstract void addLong(long item, long count);
 
+  /**
+   * Increments {@code item}'s count by one.
+   */
   public abstract void addString(String item);
 
+  /**
+   * Increments {@code item}'s count by {@code count}.
+   */
   public abstract void addString(String item, long count);
 
+  /**
+   * Increments {@code item}'s count by one.
+   */
   public abstract void addBinary(byte[] item);
 
+  /**
+   * Increments {@code item}'s count by {@code count}.
+   */
   public abstract void addBinary(byte[] item, long count);
 
   /**

--- a/common/sketch/src/main/java/org/apache/spark/util/sketch/CountMinSketchImpl.java
+++ b/common/sketch/src/main/java/org/apache/spark/util/sketch/CountMinSketchImpl.java
@@ -25,7 +25,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
-import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.Random;
 
@@ -146,7 +145,41 @@ class CountMinSketchImpl extends CountMinSketch implements Serializable {
     }
   }
 
-  private void addString(String item, long count) {
+  @Override
+  public void addString(String item) {
+    addString(item, 1);
+  }
+
+  @Override
+  public void addString(String item, long count) {
+    addBinary(Utils.getBytesFromUTF8String(item), count);
+  }
+
+  @Override
+  public void addLong(long item) {
+    addLong(item, 1);
+  }
+
+  @Override
+  public void addLong(long item, long count) {
+    if (count < 0) {
+      throw new IllegalArgumentException("Negative increments not implemented");
+    }
+
+    for (int i = 0; i < depth; ++i) {
+      table[i][hash(item, i)] += count;
+    }
+
+    totalCount += count;
+  }
+
+  @Override
+  public void addBinary(byte[] item) {
+    addBinary(item, 1);
+  }
+
+  @Override
+  public void addBinary(byte[] item, long count) {
     if (count < 0) {
       throw new IllegalArgumentException("Negative increments not implemented");
     }
@@ -155,18 +188,6 @@ class CountMinSketchImpl extends CountMinSketch implements Serializable {
 
     for (int i = 0; i < depth; ++i) {
       table[i][buckets[i]] += count;
-    }
-
-    totalCount += count;
-  }
-
-  private void addLong(long item, long count) {
-    if (count < 0) {
-      throw new IllegalArgumentException("Negative increments not implemented");
-    }
-
-    for (int i = 0; i < depth; ++i) {
-      table[i][hash(item, i)] += count;
     }
 
     totalCount += count;

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -38,7 +38,6 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
 
   /**
    * Calculate the sample covariance of two numerical columns of a DataFrame.
-   *
    * @param col1 the name of the first column
    * @param col2 the name of the second column
    * @return the covariance of the two columns.
@@ -49,6 +48,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    *    df.stat.cov("rand1", "rand2")
    *    res1: Double = 0.065...
    * }}}
+   *
    * @since 1.4.0
    */
   def cov(col1: String, col2: String): Double = {
@@ -70,6 +70,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    *    df.stat.corr("rand1", "rand2")
    *    res1: Double = 0.613...
    * }}}
+   *
    * @since 1.4.0
    */
   def corr(col1: String, col2: String, method: String): Double = {
@@ -91,6 +92,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    *    df.stat.corr("rand1", "rand2", "pearson")
    *    res1: Double = 0.613...
    * }}}
+   *
    * @since 1.4.0
    */
   def corr(col1: String, col2: String): Double = {
@@ -126,6 +128,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    *    |        3|  0|  1|  1|
    *    +---------+---+---+---+
    * }}}
+   *
    * @since 1.4.0
    */
   def crosstab(col1: String, col2: String): DataFrame = {
@@ -171,6 +174,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    *    |   ...    |
    *    +----------+
    * }}}
+   *
    * @since 1.4.0
    */
   def freqItems(cols: Array[String], support: Double): DataFrame = {
@@ -188,6 +192,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    *
    * @param cols the names of the columns to search frequent items in.
    * @return A Local DataFrame with the Array of frequent items for each column.
+   *
    * @since 1.4.0
    */
   def freqItems(cols: Array[String]): DataFrame = {
@@ -230,6 +235,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    *    |   ...    |
    *    +----------+
    * }}}
+   *
    * @since 1.4.0
    */
   def freqItems(cols: Seq[String], support: Double): DataFrame = {
@@ -247,6 +253,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    *
    * @param cols the names of the columns to search frequent items in.
    * @return A Local DataFrame with the Array of frequent items for each column.
+   *
    * @since 1.4.0
    */
   def freqItems(cols: Seq[String]): DataFrame = {
@@ -255,7 +262,6 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
 
   /**
    * Returns a stratified sample without replacement based on the fraction given on each stratum.
-   *
    * @param col column that defines strata
    * @param fractions sampling fraction for each stratum. If a stratum is not specified, we treat
    *                  its fraction as zero.
@@ -276,6 +282,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    *    |  3|    2|
    *    +---+-----+
    * }}}
+   *
    * @since 1.5.0
    */
   def sampleBy[T](col: String, fractions: Map[T, Double], seed: Long): DataFrame = {
@@ -292,13 +299,13 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
 
   /**
    * Returns a stratified sample without replacement based on the fraction given on each stratum.
-   *
    * @param col column that defines strata
    * @param fractions sampling fraction for each stratum. If a stratum is not specified, we treat
    *                  its fraction as zero.
    * @param seed random seed
    * @tparam T stratum type
    * @return a new [[DataFrame]] that represents the stratified sample
+   *
    * @since 1.5.0
    */
   def sampleBy[T](col: String, fractions: ju.Map[T, jl.Double], seed: Long): DataFrame = {
@@ -386,7 +393,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
         updater(sketch, row)
         sketch
       },
-      _ mergeInPlace _
+      (sketch1, sketch2) => sketch1.mergeInPlace(sketch2)
     )
   }
 
@@ -465,7 +472,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
         updater(filter, row)
         filter
       },
-      _ mergeInPlace _
+      (filter1, filter2) => filter1.mergeInPlace(filter2)
     )
   }
 }


### PR DESCRIPTION
This PR is a follow-up of #10911. It adds specialized update methods for `CountMinSketch` so that we can avoid doing internal/external row format conversion in `DataFrame.countMinSketch()`.
