### PR TITLE
[SPARK-13093][SQL] improve null check in nullSafeCodeGen for unary, binary and ternary expression

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -355,15 +355,34 @@ class CodegenContext {
   }
 
   /**
-    * Generates code for greater of two expressions.
-    *
-    * @param dataType data type of the expressions
-    * @param c1 name of the variable of expression 1's output
-    * @param c2 name of the variable of expression 2's output
-    */
+   * Generates code for greater of two expressions.
+   *
+   * @param dataType data type of the expressions
+   * @param c1 name of the variable of expression 1's output
+   * @param c2 name of the variable of expression 2's output
+   */
   def genGreater(dataType: DataType, c1: String, c2: String): String = javaType(dataType) match {
     case JAVA_BYTE | JAVA_SHORT | JAVA_INT | JAVA_LONG => s"$c1 > $c2"
     case _ => s"(${genComp(dataType, c1, c2)}) > 0"
+  }
+
+  /**
+   * Generates code for adding null check if necessary.
+   *
+   * @param nullable we can avoid null check if it's false.
+   * @param isNull the code to check null.
+   * @param execution the code to run execution.
+   */
+  def genNullCheck(nullable: Boolean, isNull: String)(execution: String): String = {
+    if (nullable) {
+      s"""
+        if (!$isNull) {
+          $execution
+        }
+      """
+    } else {
+      "\n" + execution
+    }
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -367,21 +367,22 @@ class CodegenContext {
   }
 
   /**
-   * Generates code for adding null check if necessary.
+   * Generates code to do null safe execution, i.e. only execute the code when the input is not
+   * null by adding null check if necessary.
    *
-   * @param nullable we can avoid null check if it's false.
-   * @param isNull the code to check null.
-   * @param execution the code to run execution.
+   * @param nullable used to decide whether we should add null check or not.
+   * @param isNull the code to check if the input is null.
+   * @param execute the code that should only be executed when the input is not null.
    */
-  def genNullCheck(nullable: Boolean, isNull: String)(execution: String): String = {
+  def nullSafeExec(nullable: Boolean, isNull: String)(execute: String): String = {
     if (nullable) {
       s"""
         if (!$isNull) {
-          $execution
+          $execute
         }
       """
     } else {
-      "\n" + execution
+      "\n" + execute
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -327,7 +327,7 @@ case class Murmur3Hash(children: Seq[Expression], seed: Int) extends Expression 
     ev.isNull = "false"
     val childrenHash = children.map { child =>
       val childGen = child.gen(ctx)
-      childGen.code + generateNullCheck(child.nullable, childGen.isNull) {
+      childGen.code + ctx.genNullCheck(child.nullable, childGen.isNull) {
         computeHash(childGen.value, child.dataType, ev.value, ctx)
       }
     }.mkString("\n")
@@ -336,18 +336,6 @@ case class Murmur3Hash(children: Seq[Expression], seed: Int) extends Expression 
       int ${ev.value} = $seed;
       $childrenHash
     """
-  }
-
-  private def generateNullCheck(nullable: Boolean, isNull: String)(execution: String): String = {
-    if (nullable) {
-      s"""
-        if (!$isNull) {
-          $execution
-        }
-      """
-    } else {
-      "\n" + execution
-    }
   }
 
   private def nullSafeElementHash(
@@ -359,7 +347,7 @@ case class Murmur3Hash(children: Seq[Expression], seed: Int) extends Expression 
       ctx: CodegenContext): String = {
     val element = ctx.freshName("element")
 
-    generateNullCheck(nullable, s"$input.isNullAt($index)") {
+    ctx.genNullCheck(nullable, s"$input.isNullAt($index)") {
       s"""
         final ${ctx.javaType(elementType)} $element = ${ctx.getValue(input, elementType, index)};
         ${computeHash(element, elementType, result, ctx)}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -327,7 +327,7 @@ case class Murmur3Hash(children: Seq[Expression], seed: Int) extends Expression 
     ev.isNull = "false"
     val childrenHash = children.map { child =>
       val childGen = child.gen(ctx)
-      childGen.code + ctx.genNullCheck(child.nullable, childGen.isNull) {
+      childGen.code + ctx.nullSafeExec(child.nullable, childGen.isNull) {
         computeHash(childGen.value, child.dataType, ev.value, ctx)
       }
     }.mkString("\n")
@@ -347,7 +347,7 @@ case class Murmur3Hash(children: Seq[Expression], seed: Int) extends Expression 
       ctx: CodegenContext): String = {
     val element = ctx.freshName("element")
 
-    ctx.genNullCheck(nullable, s"$input.isNullAt($index)") {
+    ctx.nullSafeExec(nullable, s"$input.isNullAt($index)") {
       s"""
         final ${ctx.javaType(elementType)} $element = ${ctx.getValue(input, elementType, index)};
         ${computeHash(element, elementType, result, ctx)}


### PR DESCRIPTION
The current implementation is sub-optimal:
- If an expression is always nullable, e.g. `Unhex`, we can still remove null check for children if they are not nullable.
- If an expression has some non-nullable children, we can still remove null check for these children and keep null check for others.

This PR improves this by making the null check elimination more fine-grained. 
