### PR TITLE
[SPARK-13120] [test-maven] Shade protobuf-java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2177,6 +2177,7 @@
               <include>org.eclipse.jetty:jetty-util</include>
               <include>org.eclipse.jetty:jetty-server</include>
               <include>com.google.guava:guava</include>
+              <include>com.google.protobuf:protobuf-java</include>
             </includes>
           </artifactSet>
           <relocations>
@@ -2190,6 +2191,10 @@
             <relocation>
               <pattern>com.google.common</pattern>
               <shadedPattern>org.spark-project.guava</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.google.protobuf</pattern>
+              <shadedPattern>org.spark-project.protobuf</shadedPattern>
             </relocation>
           </relocations>
         </configuration>


### PR DESCRIPTION
https://groups.google.com/forum/#!topic/protobuf/wAqvtPLBsE8

PB2 and PB3 are wire compatible, but, protobuf-java is not compatible so dependency will be a problem.
Shading protobuf-java would provide better experience for downstream projects.

This PR shades com.google.protobuf:protobuf-java as org.spark-project.protobuf
