### PR TITLE
[SPARK-13109][Build] Fix SBT publishLocal issue

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -155,7 +155,8 @@ object SparkBuild extends PomBuild {
     // Override SBT's default resolvers:
     resolvers := Seq(
       DefaultMavenRepository,
-      Resolver.mavenLocal
+      Resolver.mavenLocal,
+      Resolver.file("local", file(Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns)
     ),
     externalResolvers := resolvers.value,
     otherResolvers <<= SbtPomKeys.mvnLocalRepository(dotM2 => Seq(Resolver.file("dotM2", dotM2))),

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution.vectorized;
 import java.nio.ByteOrder;
 
 import org.apache.spark.memory.MemoryMode;
+import org.apache.spark.sql.execution.vectorized.ColumnVector.Array;
 import org.apache.spark.sql.types.BooleanType;
 import org.apache.spark.sql.types.ByteType;
 import org.apache.spark.sql.types.DataType;

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.execution.vectorized;
 
 import org.apache.spark.memory.MemoryMode;
+import org.apache.spark.sql.execution.vectorized.ColumnVector.Array;
 import org.apache.spark.sql.types.*;
 import org.apache.spark.unsafe.Platform;
 


### PR DESCRIPTION
Add local ivy repo to the SBT build file to fix this.

~~Another small issue when executing `publishLocal` to generate javadoc, it is not relevant but also should be fixed,~~

~~[error] /Users/sshao/projects/apache-spark/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java:256: not found: type Array
[error]   public final void loadBytes(Array array) {
[error]                               ^
[error] /Users/sshao/projects/apache-spark/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java:283: not found: type Array
[error]   public final void loadBytes(Array array) {
[error]~~

Scaladoc compile error is fixed.
