### PR TITLE
[SPARK-12987][SQL]Fixing the name resolution in drop column

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -1256,9 +1256,12 @@ class DataFrame private[sql](
   @scala.annotation.varargs
   def drop(colNames: String*): DataFrame = {
     val resolver = sqlContext.analyzer.resolver
+
     val remainingCols =
       schema.filter(f => colNames.forall(n => !resolver(f.name, n)))
-        .map(f => Column(UnresolvedAttribute(Seq(f.name))))
+        .map(f => Column(UnresolvedAttribute.quoted(f.name)))
+
+
     if (remainingCols.size == this.schema.size) {
       this
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -1257,7 +1257,8 @@ class DataFrame private[sql](
   def drop(colNames: String*): DataFrame = {
     val resolver = sqlContext.analyzer.resolver
     val remainingCols =
-      schema.filter(f => colNames.forall(n => !resolver(f.name, n))).map(f => Column(f.name))
+      schema.filter(f => colNames.forall(n => !resolver(f.name, n)))
+        .map(f => Column(UnresolvedAttribute(Seq(f.name))))
     if (remainingCols.size == this.schema.size) {
       this
     } else {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -36,11 +36,6 @@ import org.apache.spark.sql.types._
 class DataFrameSuite extends QueryTest with SharedSQLContext {
   import testImplicits._
 
-  test("SPARK-12987") {
-    val df = Seq((1, 1)).toDF("a_b", "a.c")
-    val df1 = df.drop("a_b")
-    assert(df1.toString() === "[a.c: int]")
-    }
 
   test("analysis error should be eagerly reported") {
     // Eager analysis.
@@ -1296,5 +1291,12 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     checkAnswer(
       Seq(1 -> "a").toDF("i", "j").filter($"i".cast(StringType) === "1"),
       Row(1, "a"))
+  }
+
+  test("SPARK-12987: drop column ") {
+    val df = Seq((1, 2)).toDF("a_b", "a.c")
+    val df1 = df.drop("a_b")
+    checkAnswer(df1, Row(2))
+    assert(df1.schema.map(_.name) === Seq("a.c"))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -36,6 +36,12 @@ import org.apache.spark.sql.types._
 class DataFrameSuite extends QueryTest with SharedSQLContext {
   import testImplicits._
 
+  test("SPARK-12987") {
+    val df = Seq((1, 1)).toDF("a_b", "a.c")
+    val df1 = df.drop("a_b")
+    assert(df1.toString() === "[a.c: int]")
+    }
+
   test("analysis error should be eagerly reported") {
     // Eager analysis.
     withSQLConf(SQLConf.DATAFRAME_EAGER_ANALYSIS.key -> "true") {


### PR DESCRIPTION
@marmbrus @cloud-fan @thomas @jayadevan : Hello All: Can you help review this code fix? 

This problem is coming from drop column, after we drop off the old column, construct the new dataframe from the remaining columns. 

the new dataframe is using the Schema information to construct the column name, in this case, the name is string ‘a.c’. Since it is from Schema, we should take the name as it is, we should not do any parsing on the name. 
