### PR TITLE
[SPARK-13135][SQL] Don't print expressions recursively in generated code

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -36,11 +36,11 @@ import org.apache.spark.util.Utils
 /**
  * Java source for evaluating an [[Expression]] given a [[InternalRow]] of input.
  *
- * @param code The sequence of statements required to evaluate the expression.
- * @param isNull A term that holds a boolean value representing whether the expression evaluated
- *                 to null.
- * @param value A term for a (possibly primitive) value of the result of the evaluation. Not
- *              valid if `isNull` is set to `true`.
+ * @param code The Java source code required to evaluate the expression.
+ * @param isNull Name of the variable that holds the boolean value representing whether the
+ *               expression evaluated to null.
+ * @param value Name of the variable that holds the (possibly primitive) value of the result
+ *              of the evaluation. Not valid if `isNull` is `true`.
  */
 case class ExprCode(var code: String, var isNull: String, var value: String)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateMutableProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateMutableProjection.scala
@@ -125,6 +125,7 @@ object GenerateMutableProjection extends CodeGenerator[Seq[Expression], () => Mu
 
         public java.lang.Object apply(java.lang.Object _i) {
           InternalRow ${ctx.INPUT_ROW} = (InternalRow) _i;
+          // project list: ${expressions.map(_.toCommentSafeString).mkString(", ")}
           $evalSubexpr
           $allProjections
           // copy all the results into MutableRow

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GeneratePredicate.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GeneratePredicate.scala
@@ -56,6 +56,7 @@ object GeneratePredicate extends CodeGenerator[Expression, (InternalRow) => Bool
         }
 
         public boolean eval(InternalRow ${ctx.INPUT_ROW}) {
+          // predicate: ${predicate.toCommentSafeString}
           ${eval.code}
           return !${eval.isNull} && ${eval.value};
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateSafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateSafeProjection.scala
@@ -171,6 +171,7 @@ object GenerateSafeProjection extends CodeGenerator[Seq[Expression], Projection]
 
         public java.lang.Object apply(java.lang.Object _i) {
           InternalRow ${ctx.INPUT_ROW} = (InternalRow) _i;
+          // project list: ${expressions.map(_.toCommentSafeString).mkString(", ")}
           $allExpressions
           return mutableRow;
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
@@ -332,6 +332,7 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
 
     val code =
       s"""
+        // project list: ${expressions.map(_.toCommentSafeString).mkString("[", ", ", "]")}
         $resetBufferHolder
         $evalSubexpr
         $writeExpressions

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregate.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregate.scala
@@ -198,7 +198,8 @@ case class TungstenAggregate(
     ctx.addNewFunction(doAgg,
       s"""
          | private void $doAgg() throws java.io.IOException {
-         |   // initialize aggregation buffer
+         |   // initialize agg buffer:
+         |   // ${aggregateExpressions.map(_.toCommentSafeString).mkString("[", ", ", "]")}
          |   ${bufVars.map(_.code).mkString("\n")}
          |
          |   ${child.asInstanceOf[CodegenSupport].produce(ctx, this)}
@@ -222,7 +223,7 @@ case class TungstenAggregate(
     // only have DeclarativeAggregate
     val functions = aggregateExpressions.map(_.aggregateFunction.asInstanceOf[DeclarativeAggregate])
     val inputAttrs = functions.flatMap(_.aggBufferAttributes) ++ child.output
-    val updateExpr = aggregateExpressions.flatMap { e =>
+    val updateExpr: Seq[Expression] = aggregateExpressions.flatMap { e =>
       e.mode match {
         case Partial | Complete =>
           e.aggregateFunction.asInstanceOf[DeclarativeAggregate].updateExpressions
@@ -242,9 +243,9 @@ case class TungstenAggregate(
     }
 
     s"""
-       | // do aggregate
+       | // aggregate: ${updateExpr.map(_.toCommentSafeString).mkString("[", ", ", "]")}
        | ${aggVals.map(_.code).mkString("\n")}
-       | // update aggregation buffer
+       | // update agg buffer
        | ${updates.mkString("")}
      """.stripMargin
   }
@@ -427,7 +428,7 @@ case class TungstenAggregate(
     }
 
     s"""
-     // generate grouping key
+     // grouping key: ${groupingExpressions.map(_.toCommentSafeString).mkString("[", ", ", "]")}
      ${keyCode.code}
      UnsafeRow $buffer = $hashMapTerm.getAggregationBufferFromUnsafeRow($key);
      if ($buffer == null) {
@@ -435,9 +436,9 @@ case class TungstenAggregate(
        throw new OutOfMemoryError("No enough memory for aggregation");
      }
 
-     // evaluate aggregate function
+     // aggregate: ${updateExpr.map(_.toCommentSafeString).mkString("[", ", ", "]")}
      ${evals.map(_.code).mkString("\n")}
-     // update aggregate buffer
+     // update agg buffer
      ${updates.mkString("\n")}
      """
   }


### PR DESCRIPTION
Our code generation currently prints expressions recursively. For example, for expression "(1 + 1) + 1)", we would print the following:
"(1 + 1) + 1)"
"(1 + 1)"
"1"
"1"

This pull request changes codegen to print this only once.
