### PR TITLE
[SPARK-13137][SQL] NullPoingException in schema inference for CSV when the first line is empty

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVOptions.scala
@@ -62,9 +62,6 @@ private[sql] class CSVOptions(
   val ignoreLeadingWhiteSpaceFlag = getBool("ignoreLeadingWhiteSpace")
   val ignoreTrailingWhiteSpaceFlag = getBool("ignoreTrailingWhiteSpace")
 
-  // Limit the number of lines we'll search for a header row that isn't comment-prefixed
-  val MAX_COMMENT_LINES_IN_HEADER = 10
-
   // Parse mode flags
   if (!ParseModes.isValidMode(parseMode)) {
     logWarning(s"$parseMode is not a valid parse mode. Using ${ParseModes.DEFAULT}.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
@@ -154,12 +154,14 @@ private[csv] class CSVRelation(
     */
   private def findFirstLine(rdd: RDD[String]): String = {
     if (params.isCommentSet) {
-      rdd.take(params.MAX_COMMENT_LINES_IN_HEADER)
-        .find(!_.startsWith(params.comment.toString))
-        .getOrElse(sys.error(s"No uncommented header line in " +
-          s"first ${params.MAX_COMMENT_LINES_IN_HEADER} lines"))
+      val comment = params.comment.toString
+      rdd.filter { line =>
+        line.trim.nonEmpty && !line.startsWith(comment)
+      }.first()
     } else {
-      rdd.first()
+      rdd.filter { line =>
+        line.trim.nonEmpty
+      }.first()
     }
   }
 }

--- a/sql/core/src/test/resources/cars.csv
+++ b/sql/core/src/test/resources/cars.csv
@@ -1,3 +1,4 @@
+
 year,make,model,comment,blank
 "2012","Tesla","S","No comment",
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-13137

This PR adds a filter in schema inference so that it does not emit NullPointException.

Also, I removed `MAX_COMMENT_LINES_IN_HEADER`but instead used a monad chaining with `filter()` and `first()`.

Lastly, I simply added a newline rather than adding a new file for this so that this is covered with the original tests.
