### PR TITLE
[SPARK-13148] [YARN] document zero-keytab Oozie application launch; add diagnostics

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -17,10 +17,11 @@
 
 package org.apache.spark.deploy
 
-import java.io.{ByteArrayInputStream, DataInputStream}
+import java.io.{ByteArrayInputStream, DataInputStream, IOException}
 import java.lang.reflect.Method
 import java.security.PrivilegedExceptionAction
-import java.util.{Arrays, Comparator}
+import java.text.DateFormat
+import java.util.{Arrays, Comparator, Date}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
@@ -34,6 +35,8 @@ import org.apache.hadoop.fs.FileSystem.Statistics
 import org.apache.hadoop.hdfs.security.token.delegation.DelegationTokenIdentifier
 import org.apache.hadoop.mapred.JobConf
 import org.apache.hadoop.security.{Credentials, UserGroupInformation}
+import org.apache.hadoop.security.token.{Token, TokenIdentifier}
+import org.apache.hadoop.security.token.delegation.AbstractDelegationTokenIdentifier
 
 import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.annotation.DeveloperApi
@@ -356,6 +359,51 @@ class SparkHadoopUtil extends Logging {
     val confKey = s"fs.${scheme}.impl.disable.cache"
     newConf.setBoolean(confKey, true)
     newConf
+  }
+
+  /**
+    * Dump the credentials' tokens to string values.
+    *
+    * @param credentials credentials
+    * @return an iterator over the string values. If no credentials are passed in: an empty list
+    */
+  private[spark] def dumpTokens(credentials: Credentials): Iterable[String] = {
+    if (credentials != null) {
+      credentials.getAllTokens.asScala.map(tokenToString)
+    } else {
+      Seq()
+    }
+  }
+
+  /**
+    * Convert a token to a string for logging.
+    * If its an abstract delegation token, attempt to unmarshall it and then
+    * print more details, including timestamps in human-readable form.
+    *
+    * @param token token to convert to a string
+    * @return a printable string value.
+    */
+  private[spark] def tokenToString(token: Token[_ <: TokenIdentifier]): String = {
+    val df = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT)
+    val buffer = new StringBuilder(128)
+    buffer.append(token.toString)
+    try {
+      val ti = token.decodeIdentifier
+      buffer.append("; ").append(ti)
+      ti match {
+        case dt: AbstractDelegationTokenIdentifier =>
+          // include human times and the renewer, which the HDFS tokens toString omits
+          buffer.append("; Renewer: ").append(dt.getRenewer)
+          buffer.append("; Issued: ").append(df.format(new Date(dt.getIssueDate)))
+          buffer.append("; Max Date: ").append(df.format(new Date(dt.getMaxDate)))
+        case _ =>
+      }
+    } catch {
+      case e: IOException => {
+        logDebug("Failed to decode $token: $e", e)
+      }
+    }
+    buffer.toString
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -362,11 +362,11 @@ class SparkHadoopUtil extends Logging {
   }
 
   /**
-    * Dump the credentials' tokens to string values.
-    *
-    * @param credentials credentials
-    * @return an iterator over the string values. If no credentials are passed in: an empty list
-    */
+   * Dump the credentials' tokens to string values.
+   *
+   * @param credentials credentials
+   * @return an iterator over the string values. If no credentials are passed in: an empty list
+   */
   private[spark] def dumpTokens(credentials: Credentials): Iterable[String] = {
     if (credentials != null) {
       credentials.getAllTokens.asScala.map(tokenToString)
@@ -376,13 +376,13 @@ class SparkHadoopUtil extends Logging {
   }
 
   /**
-    * Convert a token to a string for logging.
-    * If its an abstract delegation token, attempt to unmarshall it and then
-    * print more details, including timestamps in human-readable form.
-    *
-    * @param token token to convert to a string
-    * @return a printable string value.
-    */
+   * Convert a token to a string for logging.
+   * If its an abstract delegation token, attempt to unmarshall it and then
+   * print more details, including timestamps in human-readable form.
+   *
+   * @param token token to convert to a string
+   * @return a printable string value.
+   */
   private[spark] def tokenToString(token: Token[_ <: TokenIdentifier]): String = {
     val df = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT)
     val buffer = new StringBuilder(128)
@@ -399,9 +399,8 @@ class SparkHadoopUtil extends Logging {
         case _ =>
       }
     } catch {
-      case e: IOException => {
+      case e: IOException =>
         logDebug("Failed to decode $token: $e", e)
-      }
     }
     buffer.toString
   }

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -492,18 +492,26 @@ using the Kerberos credentials of the user launching the application —that is,
 identity will become that of the launched Spark application.
 
 This is normally done at launch time: in a secure cluster Spark will automatically obtain a
-token for the cluster's HDFS filesystem, and, if required, HBase and Hive.
+token for the cluster's HDFS filesystem, and potentially for HBase and Hive.
+
+An HBase token will be obtained if HBase is in on classpath, the HBase configuration declares
+the application is secure (i.e. `hbase.security.authentication==kerberos`),
+and `spark.yarn.security.tokens.hbase.enabled` is not set to `false`.
+
+Similarly, a Hive token will be obtained if Hive is on the classpath, its configuration
+includes a URI of the metadata store in `"hive.metastore.uris`, and
+`spark.yarn.security.tokens.hive.enabled` is not set to `false`.
 
 If an application needs to interact with other secure HDFS clusters, then
 the tokens needed to access these clusters must be explicitly requested at
 launch time. This is done by listing them in the `spark.yarn.access.namenodes` property.
 
 ```
-spark.yarn.access.namenodes hdfs://ireland.emea.example.org:8020/,hdfs://frankfurt.emea.example.org:8020/
+spark.yarn.access.namenodes hdfs://ireland.example.org:8020/,hdfs://frankfurt.example.org:8020/
 ```
 
-Hadoop tokens expire. They can be renewed "for a while";
-However, eventually, they will stop being renewable —after which all attempts to
+Hadoop tokens expire. They can be renewed "for a while".
+Eventually, they will stop being renewable —after which all attempts to
 access secure data will fail. The only way to avoid that is for the application to be launched
 with the secrets needed to log in to Kerberos directly: a "keytab". Consult
 the [Spark Property](#Spark Properties) `spark.yarn.keytab` for the specifics.

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -480,9 +480,9 @@ If you need a reference to the proper location to put log files in the YARN so t
 # Running in a secure YARN cluster
 
 As covered in [security](security.html), Kerberos is used in a secure YARN cluster to
-authenticate principals with services —and obtain access the services and
-their data . Hadoop services issue 'hadoop tokens' to allow an authenticated
-principal's access to the service and data, tokens provided over Hadoop IPC and REST/Web APIs.
+authenticate principals with services —and so access these services and
+their data. These services issue 'hadoop tokens' to grant access to the service and data,
+tokens which are then supplied over Hadoop IPC and REST/Web APIs as proof of access rights.
 For YARN applications to interact with HDFS, HBase and Hive, the application must request tokens
 using the kerberos credentials of the user launching the cluster (the principal).
 
@@ -498,14 +498,14 @@ spark.yarn.access.namenodes hdfs://ireland.emea.example.org:8020/,hdfs://frankfu
 ```
 
 Hadoop tokens expire. They can be renewed "for a while"; the Spark Application Master will automatically
-do this. However, eventually, they will stop being renewable. After this point, all attempts to
+do this. However, eventually, they will stop being renewable —after which all attempts to
 access secure data will fail. The only way to avoid that is for the application to be launched
 with the secrets needed to log in to Kerberos directly: a keytab.
 
 ## Launching your application with Apache Oozie
 
-Apache Oozie can launch Spark. In an insecure cluster, this is straightforward.
-In a secure cluster, Spark will need the tokens needed to access the cluster's services.
+Apache Oozie can launch Spark. In a secure cluster, the launched application will need the relevant
+tokens to access the cluster's services.
 If Spark is launched with a keytab, this is automatic. However, if Spark is to be
 launched without a keytab, the responsibility for setting up security must be handed
 over to Oozie.
@@ -517,6 +517,7 @@ The Oozie workflow configuration must be set up for Oozie to request all tokens,
 - Any remote HDFS filesystems.
 - Hive.
 - HBase.
+- The YARN timeline server, if the application interacts with this.
 
 The Spark configuration must be set to *not* request Hive or HBase tokens:
 
@@ -550,4 +551,6 @@ spark.yarn.appMasterEnv.HADOOP_JAAS_DEBUG true
 spark.yarn.am.extraJavaOptions -Dsun.security.krb5.debug=true -Dsun.security.spnego.debug=true
 ```
 
+Finally, if the log level for `org.apache.spark.deploy.yarn.Client` is set to `DEBUG`, the log
+will include a list of all tokens obtained, and their expiry details
 

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -484,18 +484,19 @@ authenticate principals associated with services and clients. This allows client
 make requests of these authenticated services; the services to grant rights
 to the authenticated principals.
 
-Hadoop services issue *hadoop tokens* to grant access to the services and data,
-tokens which the client must supply over Hadoop IPC and REST/Web APIs as proof of access rights.
-For Spark applications launched in a YARN cluster to interact with HDFS, HBase and Hive,
-the application must acquire the relevant tokens
-using the Kerberos credentials of the user launching the application —that is, the principal whose
-identity will become that of the launched Spark application.
+Hadoop services issue *hadoop tokens* to grant access to the services and data.
+Clients must first acquire tokens for the services they will access and pass them along with their
+application as it is launched in the YARN cluster.
+
+For a Spark application to interact with HDFS, HBase and Hive, it must acquire the relevant tokens
+using the Kerberos credentials of the user launching the application
+—that is, the principal whose identity will become that of the launched Spark application.
 
 This is normally done at launch time: in a secure cluster Spark will automatically obtain a
 token for the cluster's HDFS filesystem, and potentially for HBase and Hive.
 
 An HBase token will be obtained if HBase is in on classpath, the HBase configuration declares
-the application is secure (i.e. `hbase.security.authentication==kerberos`),
+the application is secure (i.e. `hbase-site.xml` sets `hbase.security.authentication` to `kerberos`),
 and `spark.yarn.security.tokens.hbase.enabled` is not set to `false`.
 
 Similarly, a Hive token will be obtained if Hive is on the classpath, its configuration
@@ -509,12 +510,6 @@ launch time. This is done by listing them in the `spark.yarn.access.namenodes` p
 ```
 spark.yarn.access.namenodes hdfs://ireland.example.org:8020/,hdfs://frankfurt.example.org:8020/
 ```
-
-Hadoop tokens expire. They can be renewed "for a while".
-Eventually, they will stop being renewable —after which all attempts to
-access secure data will fail. The only way to avoid that is for the application to be launched
-with the secrets needed to log in to Kerberos directly: a "keytab". Consult
-the [Spark Property](#Spark Properties) `spark.yarn.keytab` for the specifics.
 
 ## Launching your application with Apache Oozie
 

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -504,13 +504,18 @@ with the secrets needed to log in to Kerberos directly: a keytab.
 
 ## Launching your application with Apache Oozie
 
-Apache Oozie can launch Spark. In a secure cluster, the launched application will need the relevant
+Apache Oozie can launch Spark.
+In a secure cluster, the launched application will need the relevant
 tokens to access the cluster's services.
-If Spark is launched with a keytab, this is automatic. However, if Spark is to be
-launched without a keytab, the responsibility for setting up security must be handed
+If Spark is launched with a keytab, this is automatic.
+However, if Spark is to be launched without a keytab, the responsibility for setting up security must be handed
 over to Oozie.
+
+The details of configuring Oozie for secure clusters and obtaining
+credentials for a job can be found on the [Oozie web site](http://oozie.apache.org/)
+in the "Authentication" section of the specific release's documentation.
  
-The Oozie workflow configuration must be set up for Oozie to request all tokens, including:
+For Spark applications, the Oozie workflow must be set up for Oozie to request all tokens, including:
 
 - The YARN resource manager.
 - The local HDFS filesystem.

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -480,14 +480,19 @@ If you need a reference to the proper location to put log files in the YARN so t
 # Running in a secure YARN cluster
 
 As covered in [security](security.html), Kerberos is used in a secure YARN cluster to
-authenticate principals with services —and so access these services and
-their data. These services issue 'hadoop tokens' to grant access to the service and data,
-tokens which are then supplied over Hadoop IPC and REST/Web APIs as proof of access rights.
-For YARN applications to interact with HDFS, HBase and Hive, the application must request tokens
-using the kerberos credentials of the user launching the cluster (the principal).
+authenticate principals associated with services and clients. This allows clients to
+make requests of these authenticated services; the services to grant rights
+to the authenticated principals.
 
-This is normally done at launch time: Spark will automatically obtain a token for the cluster's
-HDFS filesystem, and optionally HBase and Hive.
+Hadoop services issue *hadoop tokens* to grant access to the services and data,
+tokens which the client must supply over Hadoop IPC and REST/Web APIs as proof of access rights.
+For Spark applications launched in a YARN cluster to interact with HDFS, HBase and Hive,
+the application must acquire the relevant tokens
+using the Kerberos credentials of the user launching the application —that is, the principal whose
+identity will become that of the launched Spark application.
+
+This is normally done at launch time: in a secure cluster Spark will automatically obtain a
+token for the cluster's HDFS filesystem, and, if required, HBase and Hive.
 
 If an application needs to interact with other secure HDFS clusters, then
 the tokens needed to access these clusters must be explicitly requested at
@@ -497,19 +502,19 @@ launch time. This is done by listing them in the `spark.yarn.access.namenodes` p
 spark.yarn.access.namenodes hdfs://ireland.emea.example.org:8020/,hdfs://frankfurt.emea.example.org:8020/
 ```
 
-Hadoop tokens expire. They can be renewed "for a while"; the Spark Application Master will automatically
-do this. However, eventually, they will stop being renewable —after which all attempts to
+Hadoop tokens expire. They can be renewed "for a while";
+However, eventually, they will stop being renewable —after which all attempts to
 access secure data will fail. The only way to avoid that is for the application to be launched
-with the secrets needed to log in to Kerberos directly: a keytab.
+with the secrets needed to log in to Kerberos directly: a "keytab". Consult
+the [Spark Property](#Spark Properties) `spark.yarn.keytab` for the specifics.
 
 ## Launching your application with Apache Oozie
 
 Apache Oozie can launch Spark.
-In a secure cluster, the launched application will need the relevant
-tokens to access the cluster's services.
-If Spark is launched with a keytab, this is automatic.
-However, if Spark is to be launched without a keytab, the responsibility for setting up security must be handed
-over to Oozie.
+In a secure cluster, such an application will need the relevant tokens to access the cluster's
+services. If Spark is launched with a keytab, this is automatic.
+However, if Spark is to be launched without a keytab, the responsibility for setting up security
+must be handed over to Oozie.
 
 The details of configuring Oozie for secure clusters and obtaining
 credentials for a job can be found on the [Oozie web site](http://oozie.apache.org/)

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -370,7 +370,9 @@ private[spark] class Client(
       YarnSparkHadoopUtil.get.obtainTokenForHiveMetastore(sparkConf, hadoopConf, credentials)
       YarnSparkHadoopUtil.get.obtainTokenForHBase(sparkConf, hadoopConf, credentials)
       // list all credentials at debug; useful for diagnostics.
-      logDebug(YarnSparkHadoopUtil.get.dumpTokens(credentials).mkString("\n"))
+      if (credentials != null) {
+        logDebug(YarnSparkHadoopUtil.get.dumpTokens(credentials).mkString("\n"))
+      }
     } else {
       // credentials coming from environment variables -do not attempt to obtain any
       // more. Logging the current credentials helps identify Oozie setup problems here.

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -369,6 +369,8 @@ private[spark] class Client(
       YarnSparkHadoopUtil.get.obtainTokensForNamenodes(nns, hadoopConf, credentials)
       YarnSparkHadoopUtil.get.obtainTokenForHiveMetastore(sparkConf, hadoopConf, credentials)
       YarnSparkHadoopUtil.get.obtainTokenForHBase(sparkConf, hadoopConf, credentials)
+      // list all credentials at debug; useful for diagnostics.
+      logDebug(YarnSparkHadoopUtil.get.dumpTokens(credentials).mkString("\n"))
     } else {
       // credentials coming from environment variables -do not attempt to obtain any
       // more. Logging the current credentials helps identify Oozie setup problems here.

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -99,7 +99,6 @@ private[spark] class Client(
   private val distCacheMgr = new ClientDistributedCacheManager()
 
   private var loginFromKeytab = false
-  private var credentialsFromEnvironment = false;
   private var principal: String = null
   private var keytab: String = null
   private var credentials: Credentials = null
@@ -364,21 +363,8 @@ private[spark] class Client(
     // Upload Spark and the application JAR to the remote file system if necessary,
     // and add them as local resources to the application master.
     val fs = destDir.getFileSystem(hadoopConf)
-    if (!credentialsFromEnvironment) {
-      val nns = YarnSparkHadoopUtil.get.getNameNodesToAccess(sparkConf) + destDir
-      YarnSparkHadoopUtil.get.obtainTokensForNamenodes(nns, hadoopConf, credentials)
-      YarnSparkHadoopUtil.get.obtainTokenForHiveMetastore(sparkConf, hadoopConf, credentials)
-      YarnSparkHadoopUtil.get.obtainTokenForHBase(sparkConf, hadoopConf, credentials)
-      // list all credentials at debug; useful for diagnostics.
-      if (credentials != null) {
-        logDebug(YarnSparkHadoopUtil.get.dumpTokens(credentials).mkString("\n"))
-      }
-    } else {
-      // credentials coming from environment variables -do not attempt to obtain any
-      // more. Logging the current credentials helps identify Oozie setup problems here.
-      logInfo("Using credentials supplied in environment")
-      logInfo(YarnSparkHadoopUtil.get.dumpTokens(credentials).mkString("\n"))
-    }
+    val nns = YarnSparkHadoopUtil.get.getNameNodesToAccess(sparkConf) + destDir
+    YarnSparkHadoopUtil.get.obtainTokensForNamenodes(nns, hadoopConf, credentials)
     // Used to keep track of URIs added to the distributed cache. If the same URI is added
     // multiple times, YARN will fail to launch containers for the app with an internal
     // error.
@@ -387,6 +373,11 @@ private[spark] class Client(
     // same name but different path files are added multiple time, YARN will fail to launch
     // containers for the app with an internal error.
     val distributedNames = new HashSet[String]
+    YarnSparkHadoopUtil.get.obtainTokenForHiveMetastore(sparkConf, hadoopConf, credentials)
+    YarnSparkHadoopUtil.get.obtainTokenForHBase(sparkConf, hadoopConf, credentials)
+    if (credentials != null) {
+      logDebug(YarnSparkHadoopUtil.get.dumpTokens(credentials).mkString("\n"))
+    }
 
     val replication = sparkConf.get(STAGING_FILE_REPLICATION).map(_.toShort)
       .getOrElse(fs.getDefaultReplication(destDir))
@@ -1008,9 +999,6 @@ private[spark] class Client(
       val keytabFileName = f.getName + "-" + UUID.randomUUID().toString
       sparkConf.set(KEYTAB.key, keytabFileName)
       sparkConf.set(PRINCIPAL.key, principal)
-    } else {
-      // were the credentials from the environment?
-      credentialsFromEnvironment = YarnSparkHadoopUtil.get.environmentCredentialsFile().isDefined
     }
     credentials = UserGroupInformation.getCurrentUser.getCredentials
   }

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -17,13 +17,16 @@
 
 package org.apache.spark.deploy.yarn
 
-import java.io.File
+import java.io.{File, IOException}
 import java.lang.reflect.UndeclaredThrowableException
 import java.nio.charset.StandardCharsets.UTF_8
 import java.security.PrivilegedExceptionAction
+import java.text.DateFormat
+import java.util.Date
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
+import scala.collection.JavaConversions._
 import scala.collection.mutable.HashMap
 import scala.reflect.runtime._
 import scala.util.Try
@@ -36,6 +39,7 @@ import org.apache.hadoop.mapred.{JobConf, Master}
 import org.apache.hadoop.security.Credentials
 import org.apache.hadoop.security.UserGroupInformation
 import org.apache.hadoop.security.token.{Token, TokenIdentifier}
+import org.apache.hadoop.security.token.delegation.AbstractDelegationTokenIdentifier
 import org.apache.hadoop.yarn.api.ApplicationConstants
 import org.apache.hadoop.yarn.api.ApplicationConstants.Environment
 import org.apache.hadoop.yarn.api.records.{ApplicationAccessType, ContainerId, Priority}
@@ -326,6 +330,55 @@ class YarnSparkHadoopUtil extends SparkHadoopUtil {
     }
   }
 
+  /**
+   * Are the credentials supplied by the environment, rather than a TGT or keytab?
+   * This predicate will always return true in a YARN AM, as the relevant env var is
+   * always set (it is used to pass down the AM/RM token). In the client, if it is true
+   * it means that the application was launched in an Oozie workflow (or similar) with
+   * all tokens created in advance.
+   * @return the path to a credentials file if that is where the credentials came from
+   */
+  def environmentCredentialsFile() : Option[File] = {
+    val location = System.getenv(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION)
+    if (location != null) {
+      Some(new File(location))
+    } else {
+      None
+    }
+  }
+
+  def dumpTokens(credentials: Credentials): Iterable[String] = {
+    credentials.getAllTokens.map(tokenToString)
+  }
+
+  /**
+   * Convert a token to a string. If its an abstract delegation token
+   *
+   * @param token
+   * @return
+   */
+  def tokenToString(token: Token[_ <: TokenIdentifier]): String = {
+    val df = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT)
+    val buffer =  new StringBuilder(128)
+    buffer.append(token.toString)
+    try {
+      val ti = token.decodeIdentifier
+      buffer.append("; ").append(ti)
+      ti match {
+        case dt: AbstractDelegationTokenIdentifier =>
+          // include human times and the renewer, which the HDFS tokens toString omits
+          buffer.append(s" Renewer: ${dt.getRenewer}")
+          buffer.append(" Issued: ").append(df.format(new Date(dt.getIssueDate)))
+          buffer.append(" Max Date: ").append(df.format(new Date(dt.getMaxDate)))
+        case _ =>
+      }
+    } catch {
+      case e: IOException => {
+        logDebug("Failed to decode $token: $e", e)
+      }
+    }
+    buffer.toString
+  }
 }
 
 object YarnSparkHadoopUtil {

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -350,10 +350,14 @@ class YarnSparkHadoopUtil extends SparkHadoopUtil {
   /**
    * Dump the credentials's tokens to string values.
    * @param credentials credentials
-   * @return an iterator over the string values.
+   * @return an iterator over the string values. If no credentials are passed in: an empty list
    */
   def dumpTokens(credentials: Credentials): Iterable[String] = {
-    credentials.getAllTokens.asScala.map(tokenToString)
+    if (credentials != null) {
+      credentials.getAllTokens.asScala.map(tokenToString)
+    } else {
+      Seq()
+    }
   }
 
   /**

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -331,23 +331,6 @@ class YarnSparkHadoopUtil extends SparkHadoopUtil {
   }
 
   /**
-   * Are the credentials supplied by the environment, rather than a TGT or keytab?
-   * This predicate will always return true in a YARN AM, as the relevant env var is
-   * always set (it is used to pass down the AM/RM token). In the client, if it is true
-   * it means that the application was launched in an Oozie workflow (or similar) with
-   * all tokens created in advance.
-   * @return the path to a credentials file if that is where the credentials came from
-   */
-  def environmentCredentialsFile() : Option[File] = {
-    val location = System.getenv(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION)
-    if (location != null) {
-      Some(new File(location))
-    } else {
-      None
-    }
-  }
-
-  /**
    * Dump the credentials' tokens to string values.
    * @param credentials credentials
    * @return an iterator over the string values. If no credentials are passed in: an empty list

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -312,7 +312,6 @@ class YarnSparkHadoopUtil extends SparkHadoopUtil {
   }
 
   /**
-<<<<<<< 6c77c543addb861d7455bf3f050eb33026381cab
    * Run some code as the real logged in user (which may differ from the current user, for
    * example, when using proxying).
    */
@@ -349,7 +348,7 @@ class YarnSparkHadoopUtil extends SparkHadoopUtil {
   }
 
   /**
-   * Dump the credentials's tokens to string values.
+   * Dump the credentials' tokens to string values.
    * @param credentials credentials
    * @return an iterator over the string values. If no credentials are passed in: an empty list
    */
@@ -362,9 +361,9 @@ class YarnSparkHadoopUtil extends SparkHadoopUtil {
   }
 
   /**
-   * Convert a token to a string. If its an abstract delegation token,
-   * attempt to unmarshall it and then print more details, including
-   * timestamps in human-readable form.
+   * Convert a token to a string.
+   * If its an abstract delegation token, attempt to unmarshall it and then
+   * print more details, including timestamps in human-readable form.
    * @param token token to convert to a string
    * @return a printable string value.
    */

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -312,6 +312,7 @@ class YarnSparkHadoopUtil extends SparkHadoopUtil {
   }
 
   /**
+<<<<<<< 6c77c543addb861d7455bf3f050eb33026381cab
    * Run some code as the real logged in user (which may differ from the current user, for
    * example, when using proxying).
    */


### PR DESCRIPTION
This patch provides detail on what to do for keytabless Oozie launches of spark apps, and adds some debug-level diagnostics of what credentials have been submitted
