### PR TITLE
[SPARK-13163] [Web UI] Column width on new History Server DataTables not getting set correctly

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/historypage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage.js
@@ -118,6 +118,7 @@ $(document).ready(function() {
                         {name: 'seventh'},
                         {name: 'eighth'},
                     ],
+                    "autoWidth": false
         };
 
         var rowGroupConf = {


### PR DESCRIPTION
The column width for the new DataTables now adjusts for the current page rather than being hard-coded for the entire table's data.
