### PR TITLE
[SPARK-11316] setupGroups in coalescedRDD causes super long delay.

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/CoalescedRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/CoalescedRDD.scala
@@ -273,7 +273,8 @@ private class PartitionCoalescer(maxPartitions: Int, prev: RDD[_], balanceSlack:
       groupArr += pgroup
       groupHash.getOrElseUpdate(nxt_replica, ArrayBuffer()) += pgroup
       var tries = 0
-      while (!addPartToPGroup(nxt_part, pgroup) && tries < targetLen) { // ensure at least one part
+      // ensure at least one part
+      while (pgroup.arr.size <= 0 && !addPartToPGroup(nxt_part, pgroup) && tries < targetLen) {
         nxt_part = rotIt.next()._2
         tries += 1
       }

--- a/core/src/main/scala/org/apache/spark/rdd/CoalescedRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/CoalescedRDD.scala
@@ -274,7 +274,7 @@ private class PartitionCoalescer(maxPartitions: Int, prev: RDD[_], balanceSlack:
       groupHash.getOrElseUpdate(nxt_replica, ArrayBuffer()) += pgroup
       var tries = 0
       // ensure at least one part
-      while (pgroup.arr.size <= 0 && !addPartToPGroup(nxt_part, pgroup) && tries < targetLen) {
+      while (pgroup.arr.isEmpty && !addPartToPGroup(nxt_part, pgroup) && tries < targetLen) {
         nxt_part = rotIt.next()._2
         tries += 1
       }


### PR DESCRIPTION
In coalescedRDD, the setupGroups causes super long delay due to the O(n^2) loop in the second while. That while is used to make sure that each PartitionGroup contains at least one partition. In some cases, this while will take O(n^2) to complete. If number of partitions is very large, this would take tens of minutes or even hours to complete.
