### PR TITLE
[SPARK-13185][SQL] Improve the performance of DateTimeUtils by reusing TimeZone and Calendar objects

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -60,7 +60,7 @@ object DateTimeUtils {
   @transient lazy val defaultTimeZone = TimeZone.getDefault
 
   // Reuse the TimeZone object as it is expensive to create in each method call.
-  final val timeZones = new ConcurrentHashMap[String, TimeZone]
+  @transient private final val timeZones = new ConcurrentHashMap[String, TimeZone]
 
   // Reuse the Calendar object in each thread as it is expensive to create in each method call.
   private val threadLocalCalendar = new ThreadLocal[Calendar] {
@@ -90,7 +90,7 @@ object DateTimeUtils {
     }
   }
 
-  def getTimeZone(id: String): TimeZone = {
+  private def getTimeZone(id: String): TimeZone = {
     if (!timeZones.containsKey(id)) {
       timeZones.put(id, TimeZone.getTimeZone(id))
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -19,8 +19,8 @@ package org.apache.spark.sql.catalyst.util
 
 import java.sql.{Date, Timestamp}
 import java.text.{DateFormat, SimpleDateFormat}
-import java.util.concurrent.ConcurrentHashMap
 import java.util.{Calendar, TimeZone}
+import java.util.concurrent.ConcurrentHashMap
 import javax.xml.bind.DatatypeConverter
 
 import org.apache.spark.unsafe.types.UTF8String

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -320,6 +320,15 @@ class DateTimeUtilsSuite extends SparkFunSuite {
       UTF8String.fromString("18:12:15.12312+7:30")).get ===
       c.getTimeInMillis * 1000 + 120)
 
+    c = Calendar.getInstance(TimeZone.getTimeZone("GMT-08:00"))
+    c.set(Calendar.HOUR_OF_DAY, 18)
+    c.set(Calendar.MINUTE, 12)
+    c.set(Calendar.SECOND, 15)
+    c.set(Calendar.MILLISECOND, 123)
+    assert(stringToTimestamp(
+      UTF8String.fromString("T18:12:15.12312-8:00")).get ===
+      c.getTimeInMillis * 1000 + 120)
+
     c = Calendar.getInstance()
     c.set(2011, 4, 6, 7, 8, 9)
     c.set(Calendar.MILLISECOND, 100)


### PR DESCRIPTION
It is expensive to create java TimeZone and Calendar objects in each method of DateTimeUtils. We can reuse the objects to improve the performance. In one of my Sql queries which calls StringToDate many times, the duration of the stage improved from 1.6 minutes to 1.2 minutes.
