### PR TITLE
[SPARK-13196] [MLlib] Optimize the iterator in Word2Vec to reduce the max memory consumption

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/Word2Vec.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/Word2Vec.scala
@@ -388,19 +388,21 @@ class Word2Vec extends Serializable with Logging {
         val syn0Local = model._1
         val syn1Local = model._2
         // Only output modified vectors.
-        Iterator.tabulate(vocabSize) { index =>
+        val modifiedSize = syn0Modify.count(_ > 0) + syn1Modify.count(_ > 0)
+        val modified = new Array[(Int, Array[Float])](modifiedSize)
+        var mi = 0
+        (0 until vocabSize).foreach { index =>
           if (syn0Modify(index) > 0) {
-            Some((index, syn0Local.slice(index * vectorSize, (index + 1) * vectorSize)))
-          } else {
-            None
+            modified(mi) = (index, syn0Local.slice(index * vectorSize, (index + 1) * vectorSize))
+            mi += 1
           }
-        }.flatten ++ Iterator.tabulate(vocabSize) { index =>
           if (syn1Modify(index) > 0) {
-            Some((index + vocabSize, syn1Local.slice(index * vectorSize, (index + 1) * vectorSize)))
-          } else {
-            None
+            modified(mi) =
+              (index + vocabSize, syn1Local.slice(index * vectorSize, (index + 1) * vectorSize))
+            mi += 1
           }
-        }.flatten
+        }
+        modified.iterator
       }
       val synAgg = partial.reduceByKey { case (v1, v2) =>
           blas.saxpy(vectorSize, 1.0f, v2, 1, v1, 1)


### PR DESCRIPTION
jira: https://issues.apache.org/jira/browse/SPARK-13196

code optimization.
1. remove the unnecessary Option and flatten.
2. avoid the extra space caused by the ++ operation.

This would reduce the maximum memory word2vec requires, thus to support larger dataset or vocabulary for limited memory.
