### PR TITLE
[SPARK-13197][SQL] When trying to select from the data frame which contains the columns with . in it, it is throwing exception.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -718,7 +718,11 @@ class DataFrame private[sql](
    * @since 1.3.0
    */
   @scala.annotation.varargs
-  def select(col: String, cols: String*): DataFrame = select((col +: cols).map(Column(_)) : _*)
+  def select(col: String, cols: String*): DataFrame = {
+    val output = queryExecution.analyzed.output
+    val resolver = sqlContext.analyzer.resolver
+    select(output.filter(x=>(col +: cols).exists(y=>resolver(x.name,y))).map(Column(_)) : _*)
+  }
 
   /**
    * Selects a set of SQL expressions. This is a variant of `select` that accepts

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -1297,4 +1297,10 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
       Seq(1 -> "a").toDF("i", "j").filter($"i".cast(StringType) === "1"),
       Row(1, "a"))
   }
+  
+  test("SPARK-13197: Support select from the table with dot character in column name") {
+    val df = Seq((50, 100)).toDF("a_b", "a.c")
+    checkAnswer(df.select("a_b"),Row(50))
+    checkAnswer(df.select("a.c"),Row(100))
+  }
 }


### PR DESCRIPTION
When trying to select from the data frame which contains the columns with . in it, it is throwing exception.
Added the fix in the select method to incorporate the selection of columns containing . in it
