### PR TITLE
[SPARK-13205] [SQL] SQL Generation Support for Self Join

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/LogicalRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/LogicalRelation.scala
@@ -76,7 +76,11 @@ case class LogicalRelation(
   /** Used to lookup original attribute capitalization */
   val attributeMap: AttributeMap[AttributeReference] = AttributeMap(output.map(o => (o, o)))
 
-  def newInstance(): this.type = LogicalRelation(relation).asInstanceOf[this.type]
+  def newInstance(): this.type =
+    LogicalRelation(
+      relation,
+      expectedOutputAttributes,
+      metastoreTableIdentifier).asInstanceOf[this.type]
 
   override def simpleString: String = s"Relation[${output.mkString(",")}] $relation"
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/SQLBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/SQLBuilder.scala
@@ -142,7 +142,15 @@ class SQLBuilder(logicalPlan: LogicalPlan, sqlContext: SQLContext) extends Loggi
       Some(s"`$database`.`$table`")
 
     case Subquery(alias, child) =>
-      toSQL(child).map(childSQL => s"($childSQL) AS $alias")
+      toSQL(child).map( childSQL =>
+        child match {
+          // Parentheses is not used for persisted data source relations
+          // e.g., select x.c1 from (t1) as x inner join (t1) as y on x.c1 = y.c1
+          case Subquery(_, l: LogicalRelation) =>
+            s"$childSQL AS $alias"
+          case _ =>
+            s"($childSQL) AS $alias"
+        })
 
     case Join(left, right, joinType, condition) =>
       for {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/SQLBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/SQLBuilder.scala
@@ -146,7 +146,7 @@ class SQLBuilder(logicalPlan: LogicalPlan, sqlContext: SQLContext) extends Loggi
         child match {
           // Parentheses is not used for persisted data source relations
           // e.g., select x.c1 from (t1) as x inner join (t1) as y on x.c1 = y.c1
-          case Subquery(_, l: LogicalRelation) =>
+          case Subquery(_, _: LogicalRelation | _: MetastoreRelation) =>
             s"$childSQL AS $alias"
           case _ =>
             s"($childSQL) AS $alias"

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/LogicalPlanToSQLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/LogicalPlanToSQLSuite.scala
@@ -105,6 +105,14 @@ class LogicalPlanToSQLSuite extends SQLBuilderTest with SQLTestUtils {
     checkHiveQl("SELECT id FROM t0 UNION ALL SELECT CAST(id AS INT) AS id FROM t0")
   }
 
+  test("self join") {
+    checkHiveQl("SELECT x.key FROM t1 x JOIN t1 y ON x.key = y.key")
+  }
+
+  test("self join with group by") {
+    checkHiveQl("SELECT x.key, COUNT(*) FROM t1 x JOIN t1 y ON x.key = y.key group by x.key")
+  }
+
   test("three-child union") {
     checkHiveQl("SELECT id FROM t0 UNION ALL SELECT id FROM t0 UNION ALL SELECT id FROM t0")
   }


### PR DESCRIPTION
This PR addresses two issues:
- Self join does not work in SQL Generation
- When creating new instances for `LogicalRelation`, `metastoreTableIdentifier` is lost.

@liancheng Could you please review the code changes? Thank you!
