### PR TITLE
[SPARK-13145] [SQL] checkAnswer in SQL query suites should tolerate small float number error

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/MathExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MathExpressionsSuite.scala
@@ -409,4 +409,9 @@ class MathExpressionsSuite extends QueryTest with SharedSQLContext {
     checkAnswer(df.selectExpr("positive(a)"), Row(1))
     checkAnswer(df.selectExpr("positive(b)"), Row(-1))
   }
+
+  test("SPARK-13145") {
+    val df = Seq((0.1 + 0.2, 0.3)).toDF("a", "b")
+    checkAnswer(df.select("a", "b"), Row(0.3, 0.3))
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -350,6 +350,9 @@ object QueryTest {
     Row.fromSeq(row.toSeq.map {
       case null => null
       case d: java.math.BigDecimal => BigDecimal(d)
+      // Round up the values to avoid approximate error
+      case f : Float => BigDecimal(f).setScale(8, BigDecimal.RoundingMode.HALF_UP).toFloat
+      case dd : Double => BigDecimal(dd).setScale(16, BigDecimal.RoundingMode.HALF_UP).toDouble
       // Convert array to Seq for easy equality check.
       case b: Array[_] => b.toSeq
       case r: Row => prepareRow(r)


### PR DESCRIPTION
checkAnswer will report error for small difference caused by float / double numbers.
for example, in Scala, val a = 0.1 + 0.2 will result as 0.30000000000000004, and it will result in error when comparing to 0.3

the fix will use round up and difference scale to change the values while doing the row value preparation, scale 8 / 16 should be sufficient to tolerate the errors.
