### PR TITLE
[SPARK-13179] [Python] Fix PySpark Row name collision 'count'

### DIFF
--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1291,6 +1291,11 @@ class Row(tuple):
         else:
             return "<Row(%s)>" % ", ".join(self)
 
+    @property
+    def count(self):
+        """Overrides inherited count method to avoid column name collision."""
+        return self.__getattr__('count')
+
 
 class DateConverter(object):
     def can_convert(self, obj):


### PR DESCRIPTION
Override PySpark Row inherited count method to instead get "count" column name.
