### PR TITLE
[SPARK-13166][SQL]Rename DataStreamReaderWriterSuite to DataFrameReaderWriterSuite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/DataFrameReaderWriterSuite.scala
@@ -56,7 +56,7 @@ class DefaultSource extends StreamSourceProvider with StreamSinkProvider {
   }
 }
 
-class DataStreamReaderWriterSuite extends StreamTest with SharedSQLContext {
+class DataFrameReaderWriterSuite extends StreamTest with SharedSQLContext {
   import testImplicits._
 
   test("resolve default source") {


### PR DESCRIPTION
A follow up PR for #11062 because it didn't rename the test suite.
