### PR TITLE
[SPARK-13222][Streaming][WIP]make sure latest status of stateful RDD be checkpointed on gracefulshutdown

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/DStreamGraph.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/DStreamGraph.scala
@@ -100,10 +100,8 @@ final private[streaming] class DStreamGraph extends Serializable with Logging {
 
   def getOutputStreams(): Array[DStream[_]] = this.synchronized { outputStreams.toArray }
 
-  def readyToShutdown() : Unit = this.synchronized {
-    this.synchronized {
-      outputStreams.foreach(_.readyToShutdown())
-    }
+  def readyToShutdown(): Unit = this.synchronized {
+    outputStreams.foreach(_.readyToShutdown())
     logDebug("Ready to shutdown")
   }
 
@@ -138,7 +136,7 @@ final private[streaming] class DStreamGraph extends Serializable with Logging {
     logDebug("Cleared old metadata for time " + time)
   }
 
-  def isCheckpointMissedLastTime() : Boolean = {
+  def isCheckpointMissedLastTime(): Boolean = {
     outputStreams.foldLeft(false)((value, next) => value || next.isCheckpointMissedLastTime)
   }
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
@@ -497,13 +497,14 @@ abstract class DStream[T: ClassTag] (
   private[streaming] def readyToShutdown(): Unit = {
     _readyToShutdown = true
     dependencies.foreach(_.readyToShutdown())
-    logDebug("Ready to shutdown")
+    logDebug("Ready to shutdown: " + this)  // show DStreamType@InstanceId
   }
 
   private[streaming] def isCheckpointMissedLastTime(): Boolean = {
-    val latestTime = generatedRDDs.keys.max
-    val itself = checkpointDuration!= null &&
+    val itself = if (checkpointDuration != null) {
+      val latestTime = generatedRDDs.keys.max
       !(latestTime - zeroTime).isMultipleOf(checkpointDuration)
+    } else false
     dependencies.foldLeft(itself)((value, next) => value || next.isCheckpointMissedLastTime)
   }
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
@@ -126,7 +126,10 @@ class JobGenerator(jobScheduler: JobScheduler) extends Logging {
         timedOut
       }
 
-      // generate one more bacth to make sure RDD in lastJob is checkpointed.
+      // generate one more batch to make sure RDD in lastJob is checkpointed. As an performance
+      // optimization, if the latest info has been checkpointed in last batch, there is no need
+      // to run another round. "isCheckpointMissedLastTime" method here is in charge of collect
+      // such information from every DStream recursively.
       if (!jobScheduler.receiverTracker.hasUnallocatedBlocks &&
         ssc.graph.isCheckpointMissedLastTime) {
         Thread.sleep(ssc.graph.batchDuration.milliseconds)


### PR DESCRIPTION
The CheckpointInterval of DStream could be customized to multiple of BatchInteveal. So when user call shutdown it could be in the middle of two RDD checkpoint. In case the input source is not repeatable and user don't want to enable WAL because of its extra cost, the application could be unrecoverable.

This PR is to make sure the latest status of stateful RDD could be checkpointed on graceful shutdown
