### PR TITLE
[SPARK-13227] Risky apply() in OpenHashMap

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/collection/OpenHashMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/OpenHashMap.scala
@@ -28,6 +28,9 @@ import org.apache.spark.annotation.DeveloperApi
  * space overhead.
  *
  * Under the hood, it uses our OpenHashSet implementation.
+ *
+ * NOTE: when using numeric type as the value type, the user of this class should be careful to
+ * distinguish between the 0/0.0/0L and non-exist value
  */
 @DeveloperApi
 private[spark]


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-13227

It might confuse the future developers when they use OpenHashMap.apply() with a numeric value type.

null.asInstance[Int], null.asInstance[Long], null.asInstace[Float] and null.asInstance[Double] will return 0/0.0/0L, which might confuse the developer if the value set contains 0/0.0/0L with an existing key 

The current patch only adds the comments describing the issue, with the respect to apply the minimum changes to the code base 

The more direct, yet more aggressive, approach is use Option as the return type

@andrewor14  @JoshRosen  any thoughts about how to avoid the potential issue?
