### PR TITLE
[SPARK-13154][PYTHON] Add linting for pydocs

### DIFF
--- a/dev/lint-python
+++ b/dev/lint-python
@@ -24,7 +24,7 @@ PATHS_TO_CHECK="$PATHS_TO_CHECK ./dev/run-tests.py ./python/run-tests.py ./dev/r
 PEP8_REPORT_PATH="$SPARK_ROOT_DIR/dev/pep8-report.txt"
 PYLINT_REPORT_PATH="$SPARK_ROOT_DIR/dev/pylint-report.txt"
 PYLINT_INSTALL_INFO="$SPARK_ROOT_DIR/dev/pylint-info.txt"
-SPHINXBUILD = sphinx-build
+SPHINXBUILD=${SPHINXBUILD:=sphinx-build}
 SPHINX_REPORT_PATH="$SPARK_ROOT_DIR/dev/sphinx-report.txt"
 
 cd "$SPARK_ROOT_DIR"
@@ -99,11 +99,28 @@ fi
 rm "$PEP8_REPORT_PATH"
 
 # Check that the documentation builds acceptably, skip check if sphinx is not installed.
-ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
-$(warn The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you do not have Sphinx installed, grab it from http://sphinx-doc.org/. Skipping doc checks for now)
+if hash "$SPHINXBUILD" 2> /dev/null; then
+  cd python/docs
+  make clean
+  export SPHINXOPTS=""
+  make linkcheck &>> "$SPHINX_REPORT_PATH"  || lint_status=1
+  make clean
+  export SPHINXOPTS="-a -W"
+  make html &>> "$SPHINX_REPORT_PATH" || lint_status=1
+  if [ "$lint_status" -ne 0 ]; then
+    echo "\033[0;31mpydoc checks failed.\033[0m"
+    cat "$SPHINX_REPORT_PATH"
+    echo "re-running make html to print full warning list"
+    export SPHINXOPTS="-a"
+    make clean
+    make html
+  else
+    echo "pydoc checks passed."
+  fi
+  cd ../..
 else
-# Run the doc tests
-endif
+  echo >&2 "The $SPHINXBUILD command was not found. Skipping pydoc checks for now"
+fi
 
 
 # for to_be_checked in "$PATHS_TO_CHECK"

--- a/dev/lint-python
+++ b/dev/lint-python
@@ -109,11 +109,11 @@ if hash "$SPHINXBUILD" 2> /dev/null; then
   export SPHINXOPTS="-a -W"
   make html &>> "$SPHINX_REPORT_PATH" || lint_status=1
   if [ "$lint_status" -ne 0 ]; then
-    echo "\033[0;31mpydoc checks failed.\033[0m"
+    echo "pydoc checks failed."
     cat "$SPHINX_REPORT_PATH"
     echo "re-running make html to print full warning list"
-    export SPHINXOPTS="-a"
     make clean
+    export SPHINXOPTS="-a"
     make html
   else
     echo "pydoc checks passed."

--- a/dev/lint-python
+++ b/dev/lint-python
@@ -24,6 +24,8 @@ PATHS_TO_CHECK="$PATHS_TO_CHECK ./dev/run-tests.py ./python/run-tests.py ./dev/r
 PEP8_REPORT_PATH="$SPARK_ROOT_DIR/dev/pep8-report.txt"
 PYLINT_REPORT_PATH="$SPARK_ROOT_DIR/dev/pylint-report.txt"
 PYLINT_INSTALL_INFO="$SPARK_ROOT_DIR/dev/pylint-info.txt"
+SPHINXBUILD = sphinx-build
+SPHINX_REPORT_PATH="$SPARK_ROOT_DIR/dev/sphinx-report.txt"
 
 cd "$SPARK_ROOT_DIR"
 
@@ -95,6 +97,14 @@ else
 fi
 
 rm "$PEP8_REPORT_PATH"
+
+# Check that the documentation builds acceptably, skip check if sphinx is not installed.
+ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
+$(warn The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you do not have Sphinx installed, grab it from http://sphinx-doc.org/. Skipping doc checks for now)
+else
+# Run the doc tests
+endif
+
 
 # for to_be_checked in "$PATHS_TO_CHECK"
 # do

--- a/dev/lint-python
+++ b/dev/lint-python
@@ -105,6 +105,7 @@ if hash "$SPHINXBUILD" 2> /dev/null; then
   export SPHINXOPTS=""
   make linkcheck &>> "$SPHINX_REPORT_PATH"  || lint_status=1
   make clean
+  # Treat warnings as errors so we stop correctly
   export SPHINXOPTS="-a -W"
   make html &>> "$SPHINX_REPORT_PATH" || lint_status=1
   if [ "$lint_status" -ne 0 ]; then

--- a/dev/lint-python
+++ b/dev/lint-python
@@ -102,22 +102,18 @@ rm "$PEP8_REPORT_PATH"
 if hash "$SPHINXBUILD" 2> /dev/null; then
   cd python/docs
   make clean
-  export SPHINXOPTS=""
-  make linkcheck &>> "$SPHINX_REPORT_PATH"  || lint_status=1
-  make clean
   # Treat warnings as errors so we stop correctly
-  export SPHINXOPTS="-a -W"
-  make html &>> "$SPHINX_REPORT_PATH" || lint_status=1
+  SPHINXOPTS="-a -W" make html &> "$SPHINX_REPORT_PATH" || lint_status=1
   if [ "$lint_status" -ne 0 ]; then
     echo "pydoc checks failed."
     cat "$SPHINX_REPORT_PATH"
     echo "re-running make html to print full warning list"
     make clean
-    export SPHINXOPTS="-a"
-    make html
+    SPHINXOPTS="-a" make html
   else
     echo "pydoc checks passed."
   fi
+  rm "$SPHINX_REPORT_PATH"
   cd ../..
 else
   echo >&2 "The $SPHINXBUILD command was not found. Skipping pydoc checks for now"

--- a/python/docs/Makefile
+++ b/python/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-#SPHINXOPTS    =
+SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/python/docs/Makefile
+++ b/python/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+#SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/python/docs/conf.py
+++ b/python/docs/conf.py
@@ -334,3 +334,6 @@ epub_exclude_files = ['search.html']
 
 # If false, no index is generated.
 #epub_use_index = True
+
+# Skip kinses link
+linkcheck_ignore = [r'https://kinesis.us-east-1.amazonaws.com']

--- a/python/docs/conf.py
+++ b/python/docs/conf.py
@@ -335,5 +335,5 @@ epub_exclude_files = ['search.html']
 # If false, no index is generated.
 #epub_use_index = True
 
-# Skip kinses link
+# Skip sample endpoint link (not expected to resolve)
 linkcheck_ignore = [r'https://kinesis.us-east-1.amazonaws.com']


### PR DESCRIPTION
We should have lint rules using sphinx to automatically catch the pydoc issues that are sometimes introduced.

Right now ./dev/lint-python will skip building the docs if sphinx isn't present - but it might make sense to fail hard - just a matter of if we want to insist all PySpark developers have sphinx present.
