### PR TITLE
[WebUI][SPARK-7889] HistoryServer updates UI for incomplete apps

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
@@ -51,7 +51,8 @@ import org.apache.spark.util.Clock
  * @param retainedApplications number of retained applications
  * @param clock time source
  */
-private[history] class ApplicationCache(val operations: ApplicationCacheOperations,
+private[history] class ApplicationCache(
+    val operations: ApplicationCacheOperations,
     val refreshInterval: Long,
     val retainedApplications: Int,
     val clock: Clock) extends Logging {
@@ -90,10 +91,12 @@ private[history] class ApplicationCache(val operations: ApplicationCacheOperatio
    *
    * Tagged as `protected` so as to allow subclasses in tests to accesss it directly
    */
-  protected val appCache: LoadingCache[CacheKey, CacheEntry] = CacheBuilder.newBuilder()
-      .maximumSize(retainedApplications)
-      .removalListener(removalListener)
-      .build(appLoader)
+  protected val appCache: LoadingCache[CacheKey, CacheEntry] = {
+    CacheBuilder.newBuilder()
+        .maximumSize(retainedApplications)
+        .removalListener(removalListener)
+        .build(appLoader)
+  }
 
   /**
    * The metrics which are updated as the cache is used
@@ -396,7 +399,7 @@ private[history] class CacheMetrics(prefix: String) extends Source {
    */
   override val sourceName = "ApplicationCache"
 
-  override def metricRegistry: MetricRegistry = new MetricRegistry
+  override val metricRegistry: MetricRegistry = new MetricRegistry
 
   /**
    * Startup actions.

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.deploy.history
 
 import java.util.NoSuchElementException
-
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 import javax.servlet.{DispatcherType, Filter, FilterChain, FilterConfig, ServletException, ServletRequest, ServletResponse}
 
@@ -354,15 +353,6 @@ private[history] final class CacheEntry(
  * @param attemptId attempt ID
  */
 private[history] final case class CacheKey(appId: String, attemptId: Option[String]) {
-
-  override def hashCode(): Int = {
-    appId.hashCode() + attemptId.map(_.hashCode).getOrElse(0)
-  }
-
-  override def equals(obj: Any): Boolean = {
-    val that = obj.asInstanceOf[CacheKey]
-    that.appId == appId && that.attemptId == attemptId
-  }
 
   override def toString: String = {
     appId + attemptId.map { id => s"/$id" }.getOrElse("")

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
@@ -123,11 +123,11 @@ private[history] class ApplicationCache(operations: ApplicationCacheOperations,
       metricRegistry.register(MetricRegistry.name("history.cache", e._1), e._2))
   }
 
-
   /**
-   * Get the entry. Cache fetch/refresh will have taken place by
+   * Get an entry. Cache fetch/refresh will have taken place by
    * the time this method returns.
-   * @param appAndAttempt application to look up
+   * @param appAndAttempt application to look up in the format needed by the history server web UI,
+   *                      `appId/attemptId` or `appId`.
    * @return the entry
    */
   def get(appAndAttempt: String): SparkUI = {

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
@@ -19,8 +19,8 @@ package org.apache.spark.deploy.history
 
 import java.util.NoSuchElementException
 
-import javax.servlet.http.{HttpServletResponse, HttpServletRequest}
-import javax.servlet.{DispatcherType, ServletException, FilterConfig, FilterChain, ServletResponse, ServletRequest, Filter}
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
+import javax.servlet.{DispatcherType, Filter, FilterChain, FilterConfig, ServletException, ServletRequest, ServletResponse}
 
 import scala.collection.JavaConverters._
 

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
@@ -165,7 +165,6 @@ private[history] class ApplicationCache(val operations: ApplicationCacheOperatio
 
   def size(): Long = appCache.size()
 
-
   /**
    * Time a closure, returning its output.
    * @param t timer
@@ -373,7 +372,7 @@ private[history] trait ApplicationCacheOperations {
   def attachSparkUI(appId: String, attemptId: Option[String], ui: SparkUI, completed: Boolean): Unit
 
   /**
-   *  Detach a Spark UI.
+   * Detach a Spark UI.
    *
    * @param ui Spark UI
    */

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
@@ -554,7 +554,7 @@ private[history] object ApplicationCacheCheckFilterRelay extends Logging {
    * @param attemptId attempt ID
    */
   def registerFilter(ui: SparkUI,
-      appId: String, attemptId: Option[String] ) = {
+      appId: String, attemptId: Option[String] ): Unit = {
     require(ui != null)
     val enumDispatcher = java.util.EnumSet.of(DispatcherType.ASYNC, DispatcherType.REQUEST)
     val holder = new FilterHolder()

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
@@ -59,7 +59,8 @@ private[history] class ApplicationCache(operations: ApplicationCacheOperations,
     val appId = parts(0)
     val attemptId = if (parts.length > 1) Some(parts(1)) else None
     operations.getAppUI(appId, attemptId) match {
-      case Some((ui, completed)) =>
+      case Some(ui) =>
+        val completed = ui.getApplicationInfoList.exists(_.attempts.last.completed)
         // attach the spark UI
         operations.attachSparkUI(ui, completed)
         // build the cache entry
@@ -134,9 +135,9 @@ private[history] trait ApplicationCacheOperations {
    * Get the application UI
    * @param appId application ID
    * @param attemptId attempt ID
-   * @return (the Spark UI, completed flag)
+   * @return The Spark UI
    */
-  def getAppUI(appId: String, attemptId: Option[String]): Option[(SparkUI, Boolean)]
+  def getAppUI(appId: String, attemptId: Option[String]): Option[SparkUI]
 
   /** Attach a reconstructed UI  */
   def attachSparkUI(ui: SparkUI, completed: Boolean): Unit;

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
@@ -18,8 +18,8 @@
 package org.apache.spark.deploy.history
 
 import java.util.NoSuchElementException
-import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 import javax.servlet.{DispatcherType, Filter, FilterChain, FilterConfig, ServletException, ServletRequest, ServletResponse}
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
 import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
@@ -62,7 +62,7 @@ private[history] class ApplicationCache(
    */
   private val appLoader = new CacheLoader[CacheKey, CacheEntry] {
 
-    /** the cache key doesn't match an cached entry ... attempt to load it  */
+    /** the cache key doesn't match a cached entry, or the entry is out-of-date, so load it. */
     override def load(key: CacheKey): CacheEntry = {
       loadApplicationEntry(key.appId, key.attemptId)
     }

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
@@ -551,7 +551,8 @@ private[history] class ApplicationCacheCheckFilter() extends Filter with Logging
       // send a redirect back to the same location. This will be routed
       // to the *new* UI
       logInfo(s"Application Attempt $appId/$attemptId updated; refreshing")
-      val redirectUrl = httpResponse.encodeRedirectURL(requestURI)
+      val queryStr = Option(httpRequest.getQueryString).map("?" + _).getOrElse("")
+      val redirectUrl = httpResponse.encodeRedirectURL(requestURI + queryStr)
       httpResponse.sendRedirect(redirectUrl)
     } else {
       chain.doFilter(request, response)

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
@@ -99,7 +99,7 @@ private[history] class ApplicationCache(
   }
 
   /**
-   * The metrics which are updated as the cache is used
+   * The metrics which are updated as the cache is used.
    */
   val metrics = new CacheMetrics("history.cache")
 
@@ -124,8 +124,9 @@ private[history] class ApplicationCache(
   }
 
   /**
-   * Get an entry. Cache fetch/refresh will have taken place by
-   * the time this method returns.
+   * Get an entry.
+   *
+   * Cache fetch/refresh will have taken place by the time this method returns.
    * @param appAndAttempt application to look up in the format needed by the history server web UI,
    *                      `appId/attemptId` or `appId`.
    * @return the entry
@@ -155,8 +156,9 @@ private[history] class ApplicationCache(
   }
 
   /**
-   * Get the associated spark UI. Cache fetch/refresh will have taken place by
-   * the time this method returns.
+   * Get the associated spark UI.
+   *
+   * Cache fetch/refresh will have taken place by the time this method returns.
    * @param appId application ID
    * @param attemptId optional attempt ID
    * @return the entry
@@ -205,7 +207,9 @@ private[history] class ApplicationCache(
   }
 
   /**
-   * This method is visible for testing. It looks up the cached entry *and returns a clone of it*.
+   * This method is visible for testing.
+   *
+   * It looks up the cached entry *and returns a clone of it*.
    * This ensures that the cached entries never leak
    * @param appId application ID
    * @param attemptId optional attempt ID
@@ -217,7 +221,7 @@ private[history] class ApplicationCache(
   }
 
   /**
-   * Probe for an application being updated
+   * Probe for an application being updated.
    * @param appId application ID
    * @param attemptId attempt ID
    * @return true if an update has been triggered
@@ -228,13 +232,13 @@ private[history] class ApplicationCache(
   }
 
   /**
-   * Size probe, primarily for testing
+   * Size probe, primarily for testing.
    * @return size
    */
   def size(): Long = appCache.size()
 
   /**
-   * Emptiness predicate, primarily for testing
+   * Emptiness predicate, primarily for testing.
    * @return true if the cache is empty
    */
   def isEmpty: Boolean = appCache.size() == 0
@@ -258,6 +262,7 @@ private[history] class ApplicationCache(
   /**
    * Load the Spark UI via [[ApplicationCacheOperations.getAppUI()]],
    * then attach it to the web UI via [[ApplicationCacheOperations.attachSparkUI()]].
+   *
    * If the application is incomplete, it has the [[ApplicationCacheCheckFilter]]
    * added as a filter to the HTTP requests, so that queries on the UI will trigger
    * update checks.
@@ -317,8 +322,9 @@ private[history] class ApplicationCache(
   }
 
   /**
-   * Merge an appId and optional attempt Id into a key of the form `applicationId/attemptId`
-   * if there is an `attemptId`; `applicationId` if not.
+   * Merge an appId and optional attempt Id into a key of the form `applicationId/attemptId`.
+   *
+   * If there is an `attemptId`; `applicationId` if not.
    * @param appId application ID
    * @param attemptId optional attempt ID
    * @return a unified string

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.history
+
+import java.util.NoSuchElementException
+
+import scala.util.control.NonFatal
+
+import com.google.common.base.Ticker
+import com.google.common.cache.{CacheBuilder, RemovalListener, RemovalNotification, CacheLoader}
+
+import org.apache.spark.Logging
+import org.apache.spark.ui.SparkUI
+
+/**
+ * Cache for applications.
+ * Completed applications are cached for as long as there is capacity for them.
+ * Incompleted applications have their update time checked on every
+ * retrieval; if the cached entry is out of date, it is refreshed.
+ * @param refreshInterval interval between refreshes in nanoseconds.
+ * @param retainedApplications number of retained applications
+ */
+private[history] class ApplicationCache(operations: ApplicationCacheOperations,
+    refreshInterval: Long,
+    retainedApplications: Int,
+    time: Ticker)
+    extends RemovalListener[String, CacheEntry] with Logging {
+
+  private val appLoader = new CacheLoader[String, CacheEntry] {
+    override def load(key: String): CacheEntry = {
+      loadEntry(key)
+    }
+  }
+
+  private val appCache = CacheBuilder.newBuilder()
+      .maximumSize(retainedApplications)
+      .removalListener(this)
+      .build(appLoader)
+
+
+  def loadEntry(key: String): CacheEntry = {
+    val parts = key.split("/")
+    require(parts.length == 1 || parts.length == 2, s"Invalid app key $key")
+    val appId = parts(0)
+    val attemptId = if (parts.length > 1) Some(parts(1)) else None
+    operations.getAppUI(appId, attemptId) match {
+      case Some((ui, completed)) =>
+        // attach the spark UI
+        operations.attachSparkUI(ui, completed)
+        // build the cache entry
+        CacheEntry(ui, completed, time.read())
+      case None =>
+        throw new NoSuchElementException(s"no app with key $key")
+    }
+  }
+
+  /**
+   * Get the entry. Cache fetch/refresh will have taken place by
+   * the time this method returns
+   * @param key key to retrieve
+   * @return the entry
+   */
+  def get(key: String): Option[CacheEntry] = {
+    try {
+      val entry = appCache.get(key)
+      if (!entry.completed &&
+          (time.read() - entry.timestamp) > refreshInterval) {
+        // trigger refresh
+        logDebug(s"refreshing $key")
+        operations.detachSparkUI(entry.ui, true)
+        appCache.invalidate(key)
+        get(key)
+      }
+      Some(entry)
+    } catch {
+      case NonFatal(e) => e.getCause() match {
+        case nsee: NoSuchElementException =>
+          None
+
+        case cause: Exception => throw cause
+      }
+    }
+  }
+
+  /**
+   * Removal event notifies the provider to detach the UI
+   * @param rm removal notification
+   */
+  override def onRemoval(rm: RemovalNotification[String, CacheEntry]): Unit = {
+    operations.detachSparkUI(rm.getValue().ui, false)
+  }
+}
+
+/**
+ * An entry in the cache
+ * @param ui Spark UI
+ * @param completed: flag to indicated that the application has completed (and so
+ *                 does not need refreshing)
+ * @param timestamp timestamp in nanos
+ */
+case class CacheEntry(ui: SparkUI, completed: Boolean, timestamp: Long);
+
+/**
+ * Callbacks for cache events
+ */
+private[history] trait ApplicationCacheOperations {
+
+  /**
+   * Get the application UI
+   * @param appId application ID
+   * @param attemptId attempt ID
+   * @return (the Spark UI, completed flag)
+   */
+  def getAppUI(appId: String, attemptId: Option[String]): Option[(SparkUI, Boolean)]
+
+  /** Attach a reconstructed UI  */
+  def attachSparkUI(ui: SparkUI, completed: Boolean): Unit;
+
+
+  /**
+   *  Detach a reconstructed UI
+   *
+   * @param ui Spark UI
+   * @param refreshInProgress flag to indicate this was triggered by a refresh of an
+   *                          incomplete application
+   */
+  def detachSparkUI(ui: SparkUI, refreshInProgress: Boolean): Unit;
+
+
+}

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
@@ -430,14 +430,15 @@ private[history] class CacheMetrics(prefix: String) extends Source {
    * This includes registering metrics with [[metricRegistry]]
    */
   private def init(): Unit = {
-    allMetrics.foreach(e =>
-      metricRegistry.register(MetricRegistry.name(prefix, e._1), e._2))
+    allMetrics.foreach { case (name, metric) =>
+      metricRegistry.register(MetricRegistry.name(prefix, name), metric)
+    }
   }
 
   override def toString: String = {
     val sb = new StringBuilder()
-    counters.foreach { e =>
-      sb.append(e._1).append(" = ").append(e._2.getCount).append('\n')
+    counters.foreach { case (name, counter) =>
+      sb.append(name).append(" = ").append(counter.getCount).append('\n')
     }
     sb.toString()
   }
@@ -605,7 +606,7 @@ private[history] object ApplicationCacheCheckFilterRelay extends Logging {
    * @param cache new cache
    */
   def setApplicationCache(cache: ApplicationCache): Unit = {
-    applicationCache.foreach( c => logDebug(s"Overwriting application cache $c"))
+    applicationCache.foreach( c => logWarning(s"Overwriting application cache $c"))
     applicationCache = Some(cache)
   }
 

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
@@ -35,6 +35,12 @@ private[spark] case class ApplicationHistoryInfo(
     name: String,
     attempts: List[ApplicationAttemptInfo])
 
+private[spark] case class LiveApplicationAttemptUI(
+  id: String,
+  name: String,
+  attempts: List[ApplicationAttemptInfo])
+
+
 private[history] abstract class ApplicationHistoryProvider {
 
   /**

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
@@ -21,7 +21,6 @@ import java.util.zip.ZipOutputStream
 
 import org.apache.spark.SparkException
 import org.apache.spark.ui.SparkUI
-import org.apache.spark.util.Clock
 
 private[spark] case class ApplicationAttemptInfo(
     attemptId: Option[String],

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
@@ -33,7 +33,12 @@ private[spark] case class ApplicationAttemptInfo(
 private[spark] case class ApplicationHistoryInfo(
     id: String,
     name: String,
-    attempts: List[ApplicationAttemptInfo])
+    attempts: List[ApplicationAttemptInfo]) {
+
+  def completed: Boolean = {
+    attempts.nonEmpty && attempts.head.completed
+  }
+}
 
 private[history] abstract class ApplicationHistoryProvider {
 
@@ -87,7 +92,7 @@ private[history] abstract class ApplicationHistoryProvider {
   def isCompleted(appId: String,
     attemptId: Option[String],
     applicationHistoryInfo: ApplicationHistoryInfo): Boolean = {
-    applicationHistoryInfo.attempts.nonEmpty && applicationHistoryInfo.attempts.head.completed
+    applicationHistoryInfo.completed
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
@@ -56,7 +56,7 @@ private[history] abstract class ApplicationHistoryProvider {
    * @param attemptId The application attempt ID (or None if there is no attempt ID).
    * @return The application's UI, or None if application is not found.
    */
-  def getAppUI(appId: String, attemptId: Option[String]): Option[SparkUI]
+  def getAppUI(appId: String, attemptId: Option[String]): Option[(SparkUI, Option[Any])]
 
   /**
    * Called when the server is shutting down.
@@ -100,11 +100,12 @@ private[history] abstract class ApplicationHistoryProvider {
    * @param appId application ID
    * @param attemptId optional attempt ID
    * @param updateTimeMillis time in milliseconds to use as the threshold for an update.
+   * @param data any other data the operations implementation can use to determine age
    * @return true if the application was updated since `updateTimeMillis`
    */
-  def isUpdated(appId: String, attemptId: Option[String], updateTimeMillis: Long): Boolean = {
+  def isUpdated(appId: String, attemptId: Option[String], updateTimeMillis: Long,
+      data: Option[Any]): Boolean = {
     false
   }
-
 
 }

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
@@ -56,7 +56,7 @@ private[history] abstract class ApplicationHistoryProvider {
    * @param attemptId The application attempt ID (or None if there is no attempt ID).
    * @return The application's UI, or None if application is not found.
    */
-  def getAppUI(appId: String, attemptId: Option[String]): Option[(SparkUI, Option[Any])]
+  def getAppUI(appId: String, attemptId: Option[String]): Option[(SparkUI, Long, Option[Any])]
 
   /**
    * Called when the server is shutting down.

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
@@ -54,13 +54,13 @@ private[spark] case class ApplicationHistoryInfo(
 private[history] case class HistoryProviderUpdateState()
 
 /**
- * All the information returned from a call to getAppUI
+ * All the information returned from a call to `getAppUI()`: the new UI
+ * and any required update state.
  * @param ui Spark UI
- * @param timestamp timestamp of the loaded data
  * @param updateState any provider-specific update state
  */
-private[history] case class LoadedAppUI(ui: SparkUI,
-    timestamp: Long,
+private[history] case class LoadedAppUI(
+    ui: SparkUI,
     updateState: Option[HistoryProviderUpdateState])
 
 private[history] abstract class ApplicationHistoryProvider {
@@ -77,7 +77,8 @@ private[history] abstract class ApplicationHistoryProvider {
    *
    * @param appId The application ID.
    * @param attemptId The application attempt ID (or None if there is no attempt ID).
-   * @return The application's UI, or None if application is not found.
+   * @return a [[LoadedAppUI]] instance containing the application's UI and any state information
+   *         for update probes, or `None` if the application/attempt is not found.
    */
   def getAppUI(appId: String, attemptId: Option[String]): Option[LoadedAppUI]
 
@@ -105,12 +106,13 @@ private[history] abstract class ApplicationHistoryProvider {
    * Probe for an update to an (incompleted) application
    * @param appId application ID
    * @param attemptId optional attempt ID
-   * @param updateTimeMillis time in milliseconds to use as the threshold for an update.
-   * @param data any other data the operations implementation can use to determine age
-   * @return true if the application was updated since `updateTimeMillis`
+   * @param updateState state information needed by the provider to determine age
+   * @return true if the application has been updated
    */
-  def isUpdated(appId: String, attemptId: Option[String], updateTimeMillis: Long,
-      data: Option[HistoryProviderUpdateState]): Boolean = {
+  def isUpdated(
+      appId: String,
+      attemptId: Option[String],
+      updateState: Option[HistoryProviderUpdateState]): Boolean = {
     false
   }
 

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationHistoryProvider.scala
@@ -68,7 +68,7 @@ private[history] abstract class HistoryUpdateProbe {
  */
 private[history] case class LoadedAppUI(
     ui: SparkUI,
-    updateProbe: HistoryUpdateProbe)
+    updateProbe: () => Boolean)
 
 private[history] abstract class ApplicationHistoryProvider {
 

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -19,7 +19,8 @@ package org.apache.spark.deploy.history
 
 import java.io.{BufferedInputStream, FileNotFoundException, InputStream, IOException, OutputStream}
 import java.util.UUID
-import java.util.concurrent.{Executors, ExecutorService, TimeUnit}
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.{ExecutorService, Executors, TimeUnit}
 import java.util.zip.{ZipEntry, ZipOutputStream}
 
 import scala.collection.mutable
@@ -81,6 +82,10 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
   // to ignore logs that are older during subsequent scans, to avoid processing data that
   // is already known.
   private var lastScanTime = -1L
+
+  // a counter for attempts, to ensure that whenever an attempt is created or updated,
+  // it can have a time
+  private val attemptCounter = new AtomicLong(0)
 
   // Mapping of application IDs to their metadata, in descending end time order. Apps are inserted
   // into the map in order, so the LinkedHashMap maintains the correct ordering.
@@ -227,8 +232,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
             ui.getSecurityManager.setAdminAcls(appListener.adminAcls.getOrElse(""))
             ui.getSecurityManager.setViewAcls(attempt.sparkUser,
               appListener.viewAcls.getOrElse(""))
-            (ui, Math.max(attempt.fileSizeUpdateTime, status.getModificationTime),
-                Some(status.getLen))
+            (ui, Math.max(attempt.instance, status.getModificationTime), Some(attempt.instance))
           }
         }
       }
@@ -482,7 +486,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
                 logDebug(s"Attempt ${attempt.name}/${attempt.appId} size => $size")
                 Some(new FsApplicationAttemptInfo(attempt.logPath, attempt.name, attempt.appId,
                   attempt.attemptId, attempt.startTime, attempt.endTime, attempt.lastUpdated,
-                  attempt.sparkUser, attempt.completed, size, now))
+                  attempt.sparkUser, attempt.completed, size, attemptCounter.incrementAndGet()))
               } else {
                 None
               }
@@ -702,15 +706,13 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
    */
   override def isUpdated(appId: String, attemptId: Option[String], updateTimeMillis: Long,
       data: Option[Any]): Boolean = {
-    val oldSize = data.getOrElse(-1L).asInstanceOf[Long]
+    val instance = data.getOrElse(-1L).asInstanceOf[Long]
     lookup(appId, attemptId) match {
       case None =>
         logDebug(s"Application Attempt $appId/$attemptId not found")
         false
       case Some(attempt) =>
-        attempt.lastUpdated > updateTimeMillis ||
-            (oldSize >= 0 && attempt.fileSize > oldSize)
-      //      attempt.fileSizeUpdateTime > updateTimeMillis
+        instance < attempt.instance
     }
   }
 }
@@ -730,12 +732,12 @@ private class FsApplicationAttemptInfo(
     sparkUser: String,
     completed: Boolean = true,
     val fileSize: Long = -1,
-    val fileSizeUpdateTime: Long = -1)
+    val instance: Long = -1)
   extends ApplicationAttemptInfo(attemptId, startTime, endTime,
     lastUpdated, sparkUser, completed) {
   override def toString: String = {
     s"FsApplicationAttemptInfo($logPath, $name, $appId," +
-      s" ${super.toString}, $fileSize, $fileSizeUpdateTime"
+      s" ${super.toString}, $fileSize, $instance"
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -19,7 +19,6 @@ package org.apache.spark.deploy.history
 
 import java.io.{BufferedInputStream, FileNotFoundException, InputStream, IOException, OutputStream}
 import java.util.UUID
-import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.{ExecutorService, Executors, TimeUnit}
 import java.util.zip.{ZipEntry, ZipOutputStream}
 
@@ -111,14 +110,6 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
   // to ignore logs that are older during subsequent scans, to avoid processing data that
   // is already known.
   private var lastScanTime = -1L
-
-  // a counter for attempts, used when creating an [[FsApplicationAttemptInfo]] instance
-  // to guarantee that the instance will have a higher attempt count than any instance
-  // describing the same attempt. To determine if an attempt is out of date, the two
-  // instance's counter fields can be checked. And, as the current attempt's counter
-  // value is included in the [[FsHistoryProviderUpdateState]], the version of the cached
-  // value can be be checked.
-  private val attemptCounter = new AtomicLong(0)
 
   // Mapping of application IDs to their metadata, in descending end time order. Apps are inserted
   // into the map in order, so the LinkedHashMap maintains the correct ordering.
@@ -263,7 +254,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
             ui.getSecurityManager.setAdminAcls(appListener.adminAcls.getOrElse(""))
             ui.getSecurityManager.setViewAcls(attempt.sparkUser,
               appListener.viewAcls.getOrElse(""))
-            LoadedAppUI(ui, new UpdateProbe(appId, attemptId, attempt.version))
+            LoadedAppUI(ui, new UpdateProbe(appId, attemptId, attempt.fileSize))
           }
         }
       }
@@ -418,7 +409,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
         res match {
           case Some(r) => logDebug(s"Application log ${r.logPath} loaded successfully: $r")
           case None => logWarning(s"Failed to load application log ${fileStatus.getPath}. " +
-              "The application may have not started.")
+            "The application may have not started.")
         }
         res
       } catch {
@@ -439,8 +430,8 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
    * be lost.
    * @param newAttempts a possibly empty list of new attempts
    */
-  private def updateApplicationsWithNewAttempts(newAttempts: Iterable[FsApplicationAttemptInfo])
-    : Unit = {
+  private def updateApplicationsWithNewAttempts(
+      newAttempts: Iterable[FsApplicationAttemptInfo]): Unit = {
     if (newAttempts.nonEmpty) {
       applications = mergeAttempts(newAttempts, applications)
     }
@@ -505,7 +496,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
 
 
   /**
-   * Scan through all known incomplete applications, and check for any that have been updated.
+   * Build list of incomplete apps that have been updated since they were last examined.
    *
    * After the scan, if there were any updated attempts, [[applications]] is updated
    * with the new values.
@@ -514,6 +505,8 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
    * 2. As this overwrites [[applications]] with a new value, it must not run concurrently
    * with the main scan for new applications. That is: it must be in the [[checkForLogs()]]
    * operation.
+   * 3. If an attempt's files are no longer present, the existing attempt is not considered
+   * out of date or otherwise modified.
    */
   private[history] def scanAndUpdateIncompleteAttemptInfo(): Unit = {
     val newAttempts: Iterable[FsApplicationAttemptInfo] = applications
@@ -530,7 +523,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
                 logDebug(s"Attempt ${prevInfo.name}/${prevInfo.appId} size => $size")
                 Some(new FsApplicationAttemptInfo(prevInfo.logPath, prevInfo.name, prevInfo.appId,
                   prevInfo.attemptId, prevInfo.startTime, prevInfo.endTime, prevInfo.lastUpdated,
-                  prevInfo.sparkUser, prevInfo.completed, size, attemptCounter.incrementAndGet()))
+                  prevInfo.sparkUser, prevInfo.completed, size))
               } else {
                 None
               }
@@ -663,8 +656,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
           eventLog.getModificationTime(),
           appListener.sparkUser.getOrElse(NOT_STARTED),
           appCompleted,
-          getLogSize(eventLog).getOrElse(0),
-          eventLog.getModificationTime()))
+          getLogSize(eventLog).getOrElse(0)))
       } else {
         None
       }
@@ -727,18 +719,18 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
 
   /**
    * The update probe of the is the generational counter of attempts:
-   * if the counter is less than that of the attempt's current value, it is out of date.
+   * if the filesize is less than that of the latest attempt's size, it is out of date.
    * @param appId application to probe
    * @param attemptId attempt to probe
-   * @param version the version value of the last attempt.
+   * @param fileSize the file size of the last attempt's logs
    */
   private class UpdateProbe(
       appId: String,
       attemptId: Option[String],
-      version: Long) extends HistoryUpdateProbe {
+      fileSize: Long) extends HistoryUpdateProbe {
 
     override def toString: String = {
-      s"UpdateProbe($appId/$attemptId @$version)"
+      s"UpdateProbe($appId/$attemptId @$fileSize)"
     }
 
     override def isUpdated(): Boolean = {
@@ -747,7 +739,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
           logDebug(s"Application Attempt $appId/$attemptId not found")
           false
         case Some(latest) =>
-          version < latest.version
+          fileSize < latest.fileSize
       }
     }
   }
@@ -771,8 +763,6 @@ private[history] object FsHistoryProvider {
  * @param sparkUser user running the application
  * @param completed predicate to indicate whether or not the application has completed.
  * @param fileSize the size of the log file the last time the file was scanned for changes
- * @param version a version counter incremented whenever a new attempt with a longer filesize
- *                is created.
  */
 private class FsApplicationAttemptInfo(
     val logPath: String,
@@ -784,15 +774,14 @@ private class FsApplicationAttemptInfo(
     lastUpdated: Long,
     sparkUser: String,
     completed: Boolean,
-    val fileSize: Long,
-    val version: Long)
+    val fileSize: Long)
   extends ApplicationAttemptInfo(attemptId, startTime, endTime,
     lastUpdated, sparkUser, completed) {
 
   /** extend the superclass string value with the extra attributes of this class */
   override def toString: String = {
     s"FsApplicationAttemptInfo($logPath, $name, $appId," +
-      s" ${super.toString}, $fileSize, $version"
+      s" ${super.toString}, $fileSize"
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -597,8 +597,6 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
    *
    * Note that DistributedFileSystem is a `@LimitedPrivate` class, which for all practical reasons
    * makes it more public than not.
-   * HADOOP-12614 proposes adding a public version of this probe, one which other filesystems could
-   * implement.
    */
   private[history] def isFsInSafeMode(): Boolean = fs match {
     case dfs: DistributedFileSystem =>

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -549,10 +549,8 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
     // and when we read the file here.  That is OK -- it may result in an unnecessary refresh
     // when there is no update, but will not result in missing an update.  We *must* prevent
     // an error the other way -- if we report a size bigger (ie later) than the file that is
-    // actually read, we may never refresh the app
-    // we expect FileStatus to return the file size when it was initially created, but the api
-    // is not explicit about this so lets be extra-safe.
-    val eventLogLength = eventLog.getLen()
+    // actually read, we may never refresh the app.  FileStatus is guaranteed to be static
+    // after it's created, so we get a file size that is no bigger than what is actually read.
     val logInput = EventLoggingListener.openEventLog(logPath, fs)
     try {
       val appListener = new ApplicationEventListener
@@ -573,7 +571,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
           eventLog.getModificationTime(),
           appListener.sparkUser.getOrElse(NOT_STARTED),
           appCompleted,
-          eventLogLength
+          eventLog.getLen()
         )
         fileToAppInfo(logPath) = attemptInfo
         Some(attemptInfo)

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -190,7 +190,20 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
 
   override def getListing(): Iterable[FsApplicationHistoryInfo] = applications.values
 
-  override def getAppUI(appId: String, attemptId: Option[String]): Option[SparkUI] = {
+  /**
+   * Look up an application attempt
+   * @param appId application ID
+   * @param attemptId Attempt ID, if set
+   * @return the matching attempt, if found
+   */
+  def lookup(appId: String, attemptId: Option[String]): Option[FsApplicationAttemptInfo] = {
+    applications.get(appId).flatMap { appInfo =>
+      appInfo.attempts.find(_.attemptId == attemptId)
+    }
+  }
+
+  override def getAppUI(appId: String, attemptId: Option[String])
+      : Option[(SparkUI, Option[Any])] = {
     try {
       applications.get(appId).flatMap { appInfo =>
         appInfo.attempts.find(_.attemptId == attemptId).flatMap { attempt =>
@@ -213,7 +226,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
             ui.getSecurityManager.setAdminAcls(appListener.adminAcls.getOrElse(""))
             ui.getSecurityManager.setViewAcls(attempt.sparkUser,
               appListener.viewAcls.getOrElse(""))
-            ui
+            (ui, None)
           }
         }
       }
@@ -272,7 +285,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
           entry1.getModificationTime() >= entry2.getModificationTime()
       }
 
-      logDebug(s"New attempts found: ${logInfos.size} ${logInfos.map(_.getPath)}")
+      logDebug(s"New/updated attempts found: ${logInfos.size} ${logInfos.map(_.getPath)}")
       logInfos.grouped(20)
         .map { batch =>
           replayExecutor.submit(new Runnable {
@@ -369,7 +382,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
         val bus = new ReplayListenerBus()
         val res = replay(fileStatus, bus)
         res match {
-          case Some(r) => logDebug(s"Application log ${r.logPath} loaded successfully.")
+          case Some(r) => logDebug(s"Application log ${r.logPath} loaded successfully: $r")
           case None => logWarning(s"Failed to load application log ${fileStatus.getPath}. " +
               "The application may have not started.")
         }
@@ -656,13 +669,20 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
   }
 */
 
+  /**
+   * String description for diagnostics
+   * @return a summary of the component staet
+   */
   override def toString: String = {
-    s"""
+    val header = s"""
       | FsHistoryProvider: logdir=$logDir,
-      | last scan time =$lastScanTime,
-      | applications=$applications,
-      | polling thread=$initThread,
+      | last scan time=$lastScanTime
+      | Cached application count =${applications.size}}
+      |
     """.stripMargin
+    val sb = new StringBuilder(header)
+    applications.foreach(entry => sb.append(entry._2).append("\n"))
+    sb.toString
   }
 
   /**
@@ -671,14 +691,14 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
    * @param appId application ID
    * @param attemptId optional attempt ID
    * @param updateTimeMillis time in milliseconds to use as the threshold for an update.
+   * @param data a long containing the file size at the time of the last check
    * @return true if the application was updated since `updateTimeMillis`
    */
-  override def isUpdated(appId: String, attemptId: Option[String], updateTimeMillis: Long)
-    : Boolean = {
-
-    applications.get(appId).exists {
-      _.attempts.find(_.attemptId == attemptId)
-        .exists(_.fileSizeUpdateTime > updateTimeMillis)
+  override def isUpdated(appId: String, attemptId: Option[String], updateTimeMillis: Long,
+      data: Option[Any]): Boolean = {
+    lookup(appId, attemptId).exists { attempt =>
+        attempt.lastUpdated > updateTimeMillis ||
+      attempt.fileSizeUpdateTime > updateTimeMillis
     }
   }
 }
@@ -699,12 +719,21 @@ private class FsApplicationAttemptInfo(
     completed: Boolean = true,
     val fileSize: Long = -1,
     val fileSizeUpdateTime: Long = -1)
-  extends ApplicationAttemptInfo(
-      attemptId, startTime, endTime, lastUpdated, sparkUser, completed)
+  extends ApplicationAttemptInfo(attemptId, startTime, endTime,
+    lastUpdated, sparkUser, completed) {
+  override def toString: String = {
+    s"FsApplicationAttemptInfo($logPath, $name, $appId," +
+      s" ${super.toString}, $fileSize, $fileSizeUpdateTime"
+  }
+}
 
 private class FsApplicationHistoryInfo(
     id: String,
     override val name: String,
     override val attempts: List[FsApplicationAttemptInfo],
     val lastUpdated: Long)
-  extends ApplicationHistoryInfo(id, name, attempts)
+  extends ApplicationHistoryInfo(id, name, attempts) {
+  override def toString: String = {
+    s"FsApplicationHistoryInfo(lastUpdated = $lastUpdated, ${super.toString}"
+  }
+}

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -42,7 +42,7 @@ import org.apache.spark.util.{Clock, SystemClock, ThreadUtils, Utils}
  * This provider checks for new finished applications in the background periodically and
  * renders the history application UI by parsing the associated event logs.
  *
- * ==How new and updated attempts are detected==
+ * == How new and updated attempts are detected ==
  *
  * - New attempts are detected in [[checkForLogs]]: the log dir is scanned, and any
  * entries in the log dir whose modification time is greater than the last scan time
@@ -488,6 +488,8 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
     }
     newIterator.foreach(addIfAbsent)
     oldIterator.foreach(addIfAbsent)
+    logDebug(s" completed apps=${mergedApps.count(_._2.completed)}")
+    logDebug(s" incomplete apps=${mergedApps.count(!_._2.completed)}")
     mergedApps
   }
 
@@ -741,7 +743,7 @@ private[history] object FsHistoryProvider {
  * @param lastUpdated the modification time of the log file when this entry was built by replaying
  *                    the history.
  * @param sparkUser user running the application
- * @param completed predicate to indicate whether or not the application has completed.
+ * @param completed flag to indicate whether or not the application has completed.
  * @param fileSize the size of the log file the last time the file was scanned for changes
  */
 private class FsApplicationAttemptInfo(
@@ -760,8 +762,8 @@ private class FsApplicationAttemptInfo(
 
   /** extend the superclass string value with the extra attributes of this class */
   override def toString: String = {
-    s"FsApplicationAttemptInfo($logPath, $name, $appId," +
-      s" ${super.toString}, $fileSize"
+    s"FsApplicationAttemptInfo($name, $appId," +
+      s" ${super.toString}, source=$logPath, size=$fileSize"
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -566,6 +566,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
     dfs.setSafeMode(HdfsConstants.SafeModeAction.SAFEMODE_GET)
   }
 
+
 /*
   def isCompleted(appId: String, attemptId: Option[String]): Boolean = {
 
@@ -580,19 +581,13 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
   }
 */
 
-  /**
-   * Has an application attempt completed?
-   *
-   * The default returns the completed state of the history info
-   * @param appId application ID
-   * @param attemptId optional attempt ID
-   * @param applicationHistoryInfo the application being probed.
-   * @return true if the application is considered to have completed
-   */
-  override def isCompleted(appId: String,
-    attemptId: Option[String],
-    applicationHistoryInfo: ApplicationHistoryInfo): Boolean = {
-    super.isCompleted(appId, attemptId, applicationHistoryInfo)
+  override def toString: String = {
+    s"""
+      | FsHistoryProvider: logdir=$logDir,
+      | last scan time =$lastScanTime,
+      | applications=$applications,
+      | polling thread=$initThread,
+    """.stripMargin
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -664,21 +664,6 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
     dfs.setSafeMode(HdfsConstants.SafeModeAction.SAFEMODE_GET)
   }
 
-
-/*
-  def isCompleted(appId: String, attemptId: Option[String]): Boolean = {
-
-    val name = appId + attemptId.map { id => s"_$id" }.getOrElse("")
-    if (isAppCompleted.keySet.contains(name)) {
-      true
-    } else if (isAppCompleted.contains(name + EventLoggingListener.IN_PROGRESS)) {
-      false
-    } else {
-      throw new NoSuchElementException(s"no app with key $appId/$attemptId.")
-    }
-  }
-*/
-
   /**
    * String description for diagnostics
    * @return a summary of the component staet

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -619,6 +619,18 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
   }
 
   /**
+   * Look up an application attempt
+   * @param appId application ID
+   * @param attemptId Attempt ID, if set
+   * @return the matching attempt, if found
+   */
+  def lookup(appId: String, attemptId: Option[String]): Option[FsApplicationAttemptInfo] = {
+    applications.get(appId).flatMap { appInfo =>
+      appInfo.attempts.find(_.attemptId == attemptId)
+    }
+  }
+
+  /**
    * The update probe of the is the generational counter of attempts:
    * if the filesize is less than that of the latest attempt's size, it is out of date.
    * @param appId application to probe
@@ -626,9 +638,9 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
    * @param fileSize the file size of the last attempt's logs
    */
   private def updateProbe(
-    appId: String,
-    attemptId: Option[String],
-    fileSize: Long)(): Boolean = {
+      appId: String,
+      attemptId: Option[String],
+      fileSize: Long)(): Boolean = {
     lookup(appId, attemptId) match {
       case None =>
         logDebug(s"Application Attempt $appId/$attemptId not found")

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -509,13 +509,15 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
 
 
   /**
-   * Scan through all incomplete applications, and check for any that have changed.
+   * Scan through all known incomplete applications, and check for any that have been updated.
    *
    * After the scan, if there were any updated attempts, [[applications]] is updated
    * with the new values.
    *
    * 1. No attempt to replay the application is made; this scan is a low cost operation.
    * 2. As this overwrites [[applications]] with a new value, it must not run concurrently
+   * with the main scan for new applications. That is: it must be in the [[checkForLogs()]]
+   * operation.
    */
   private[history] def scanAndUpdateIncompleteAttemptInfo(): Unit = {
     val now = System.currentTimeMillis();

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryPage.scala
@@ -30,7 +30,7 @@ private[history] class HistoryPage(parent: HistoryServer) extends WebUIPage("") 
       Option(request.getParameter("showIncomplete")).getOrElse("false").toBoolean
 
     val allApps = parent.getApplicationList()
-      .filter(_.attempts.head.completed != requestedIncomplete)
+      .filter(_.completed != requestedIncomplete)
     val allAppsSize = allApps.size
 
     val providerConfig = parent.getProviderConfig()

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -31,7 +31,7 @@ import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.status.api.v1.{ApiRootResource, ApplicationInfo, ApplicationsListResource, UIRoot}
 import org.apache.spark.ui.{SparkUI, UIUtils, WebUI}
 import org.apache.spark.ui.JettyUtils._
-import org.apache.spark.util.{ShutdownHookManager, Utils}
+import org.apache.spark.util.{ShutdownHookManager, SystemClock, Utils}
 
 /**
  * A web server that renders SparkUIs of completed applications.
@@ -61,7 +61,7 @@ class HistoryServer(
 
 
   private val appCache = new ApplicationCache(this,
-      incompleteApplicationRefreshInterval, retainedApplications, Ticker.systemTicker())
+      incompleteApplicationRefreshInterval, retainedApplications, new SystemClock())
 
   private val loaderServlet = new HttpServlet {
     protected override def doGet(req: HttpServletRequest, res: HttpServletResponse): Unit = {
@@ -153,16 +153,6 @@ class HistoryServer(
   }
 
   /**
-   * Notification of a refresh. This will be followed by the normal
-   * detach/attach operations
-   * @param key
-   * @param ui
-   */
-  override def refreshTriggered(key: String, ui: SparkUI): Unit = {
-    logDebug(s"Refreshing app $key")
-  }
-
-  /**
    * Get the application UI and whether or not it is completed
    * @param appId application ID
    * @param attemptId attempt ID
@@ -170,6 +160,11 @@ class HistoryServer(
    */
   override def getAppUI(appId: String, attemptId: Option[String]): Option[SparkUI] = {
     provider.getAppUI(appId, attemptId)
+  }
+
+  override def isUpdated(appId: String, attemptId: Option[String],
+      updateTimeMillis: Long): Boolean = {
+    provider.isUpdated(appId, attemptId, updateTimeMillis)
   }
 
   /**
@@ -201,7 +196,7 @@ class HistoryServer(
 
   private def loadAppUi(appId: String, attemptId: Option[String]): Boolean = {
     try {
-      appCache.get(appId + attemptId.map { id => s"/$id" }.getOrElse(""))
+      appCache.get(appId, attemptId)
       true
     } catch {
       case NonFatal(e) => e.getCause() match {

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -57,7 +57,7 @@ class HistoryServer(
 
   // configuration interval is in seconds; internally in nanoseconds
   private val incompleteApplicationRefreshInterval =
-    conf.getLong("spark.history.refresh.interval", 30)* 1000000000
+    conf.getLong("spark.history.cache.interval", 60)* 1000000000
 
 
   private val appCache = new ApplicationCache(this,

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -140,6 +140,7 @@ class HistoryServer(
   override def stop() {
     super.stop()
     provider.stop()
+    appCache.stop()
   }
 
   /** Attach a reconstructed UI to this server. Only valid after bind(). */
@@ -212,6 +213,13 @@ class HistoryServer(
     }
   }
 
+  override def toString: String = {
+    s"""
+      | History Server;
+      | provider = $provider
+      | cache = $appCache
+    """.stripMargin
+  }
 }
 
 /**

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -147,9 +147,19 @@ class HistoryServer(
   }
 
   /** Detach a reconstructed UI from this server. Only valid after bind(). */
-  override def detachSparkUI(ui: SparkUI, refreshInProgress: Boolean) {
+  override def detachSparkUI(ui: SparkUI) {
     assert(serverInfo.isDefined, "HistoryServer must be bound before detaching SparkUIs")
     ui.getHandlers.foreach(detachHandler)
+  }
+
+  /**
+   * Notification of a refresh. This will be followed by the normal
+   * detach/attach operations
+   * @param key
+   * @param ui
+   */
+  override def refreshTriggered(key: String, ui: SparkUI): Unit = {
+    logDebug(s"Refreshing app $key")
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -165,19 +165,11 @@ class HistoryServer(
   /**
    * Get the application UI and whether or not it is completed
    * @param appId application ID
-   * @param attemptId attemptd ID
+   * @param attemptId attempt ID
    * @return (the Spark UI, completed flag)
    */
-  override def getAppUI(appId: String, attemptId: Option[String]): Option[(SparkUI, Boolean)] = {
-    provider.getAppUI(appId,attemptId) match {
-      case Some(ui) =>
-        // look up the listing to see if it is listed as complete
-        val completed = provider.getListing().exists(
-          (info) => info.name == appId && info.attempts.last.completed)
-        Some(ui, completed)
-      case None =>
-        None
-    }
+  override def getAppUI(appId: String, attemptId: Option[String]): Option[SparkUI] = {
+    provider.getAppUI(appId, attemptId)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -161,15 +161,16 @@ class HistoryServer(
    * Get the application UI and whether or not it is completed
    * @param appId application ID
    * @param attemptId attempt ID
-   * @return (the Spark UI, completed flag)
+   * @return If found, the Spark UI and any history information to be used in the cache
    */
-  override def getAppUI(appId: String, attemptId: Option[String]): Option[SparkUI] = {
+  override def getAppUI(appId: String, attemptId: Option[String])
+      : Option[(SparkUI, Option[Any])] = {
     provider.getAppUI(appId, attemptId)
   }
 
   override def isUpdated(appId: String, attemptId: Option[String],
-      updateTimeMillis: Long): Boolean = {
-    provider.isUpdated(appId, attemptId, updateTimeMillis)
+      updateTimeMillis: Long, data: Option[Any]): Boolean = {
+    provider.isUpdated(appId, attemptId, updateTimeMillis, data)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -23,7 +23,6 @@ import javax.servlet.http.{HttpServlet, HttpServletRequest, HttpServletResponse}
 
 import scala.util.control.NonFatal
 
-import com.google.common.base.Ticker
 import org.eclipse.jetty.servlet.{ServletContextHandler, ServletHolder}
 
 import org.apache.spark.{Logging, SecurityManager, SparkConf}
@@ -107,7 +106,7 @@ class HistoryServer(
   }
 
   def getSparkUI(appKey: String): Option[SparkUI] = {
-    Option(appCache.get(appKey))
+    appCache.getSparkUI(appKey)
   }
 
   initialize()

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -164,7 +164,7 @@ class HistoryServer(
    * @return If found, the Spark UI and any history information to be used in the cache
    */
   override def getAppUI(appId: String, attemptId: Option[String])
-      : Option[(SparkUI, Option[Any])] = {
+      : Option[(SparkUI, Long, Option[Any])] = {
     provider.getAppUI(appId, attemptId)
   }
 

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -171,20 +171,6 @@ class HistoryServer(
   }
 
   /**
-   * Relay checks for the update to the history provider, passing down the update state
-   * returned by the provider's `getAppUI` call previously.
-   * @param appId application ID
-   * @param attemptId optional attempt ID
-   * @param updateState state information needed by the provider to determine age
-   * @return true if the application was updated
-   */
-  override def isUpdated(appId: String,
-      attemptId: Option[String],
-      updateState: Option[HistoryProviderUpdateState]): Boolean = {
-    provider.isUpdated(appId, attemptId, updateState)
-  }
-
-  /**
    * Returns a list of available applications, in descending order according to their end time.
    *
    * @return List of all known applications.

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -54,13 +54,8 @@ class HistoryServer(
   // How many applications to retain
   private val retainedApplications = conf.getInt("spark.history.retainedApplications", 50)
 
-  // configuration interval is in seconds; internally in milliseconds
-  private val incompleteApplicationRefreshInterval =
-    conf.getTimeAsMs("spark.history.cache.window", "60s")
-
   // application
-  private val appCache = new ApplicationCache(this,
-      incompleteApplicationRefreshInterval, retainedApplications, new SystemClock())
+  private val appCache = new ApplicationCache(this, retainedApplications, new SystemClock())
 
   // and its metrics, for testing as well as monitoring
   val cacheMetrics = appCache.metrics

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -144,7 +144,8 @@ class HistoryServer(
   }
 
   /** Attach a reconstructed UI to this server. Only valid after bind(). */
-  override def attachSparkUI(appId: String,
+  override def attachSparkUI(
+      appId: String,
       attemptId: Option[String],
       ui: SparkUI,
       completed: Boolean) {
@@ -170,18 +171,17 @@ class HistoryServer(
   }
 
   /**
-   * Relay checks for the update to the history provider.
+   * Relay checks for the update to the history provider, passing down the update state
+   * returned by the provider's `getAppUI` call previously.
    * @param appId application ID
    * @param attemptId optional attempt ID
-   * @param updateTimeMillis time in milliseconds to use as the threshold for an update.
-   * @param data any other data the operations implementation can use to determine age
-   * @return true if the application was updated since `updateTimeMillis`
+   * @param updateState state information needed by the provider to determine age
+   * @return true if the application was updated
    */
   override def isUpdated(appId: String,
       attemptId: Option[String],
-      updateTimeMillis: Long,
-      data: Option[HistoryProviderUpdateState]): Boolean = {
-    provider.isUpdated(appId, attemptId, updateTimeMillis, data)
+      updateState: Option[HistoryProviderUpdateState]): Boolean = {
+    provider.isUpdated(appId, attemptId, updateState)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -55,10 +55,9 @@ class HistoryServer(
   // How many applications to retain
   private val retainedApplications = conf.getInt("spark.history.retainedApplications", 50)
 
-  // configuration interval is in seconds; internally in milli
+  // configuration interval is in seconds; internally in milliseconds
   private val incompleteApplicationRefreshInterval =
-    conf.getTimeAsMs("spark.history.cache.interval", "60 s")
-
+    conf.getTimeAsMs("spark.history.cache.window", "60s")
 
   private val appCache = new ApplicationCache(this,
       incompleteApplicationRefreshInterval, retainedApplications, new SystemClock())
@@ -140,7 +139,8 @@ class HistoryServer(
   }
 
   /** Attach a reconstructed UI to this server. Only valid after bind(). */
-  override def attachSparkUI(appId: String, attemptId: Option[String],ui: SparkUI, completed: Boolean) {
+  override def attachSparkUI(appId: String, attemptId: Option[String],
+      ui: SparkUI, completed: Boolean) {
     assert(serverInfo.isDefined, "HistoryServer must be bound before attaching SparkUIs")
     ui.getHandlers.foreach(attachHandler)
     addFilters(ui.getHandlers, conf)

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -59,8 +59,12 @@ class HistoryServer(
   private val incompleteApplicationRefreshInterval =
     conf.getTimeAsMs("spark.history.cache.window", "60s")
 
+  // application
   private val appCache = new ApplicationCache(this,
       incompleteApplicationRefreshInterval, retainedApplications, new SystemClock())
+
+  // and its metrics, for testing as well as monitoring
+  val cacheMetrics = appCache.metrics
 
   private val loaderServlet = new HttpServlet {
     protected override def doGet(req: HttpServletRequest, res: HttpServletResponse): Unit = {

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -224,6 +224,13 @@ private[spark] class EventLoggingListener(
       }
     }
     fileSystem.rename(new Path(logPath + IN_PROGRESS), target)
+    // touch file to ensure modtime is current across those filesystems where rename()
+    // does not set it, -and which support setTimes(); it's a no-op on most object stores
+    try {
+      fileSystem.setTimes(target, System.currentTimeMillis(), -1)
+    } catch {
+      case e: Exception => logDebug(s"failed to set time of $target", e)
+    }
   }
 
 }

--- a/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
@@ -1,13 +1,12 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.spark.deploy.history
 
 import java.util.{Date, NoSuchElementException}

--- a/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
@@ -27,8 +27,8 @@ import com.codahale.metrics.Counter
 import com.google.common.cache.LoadingCache
 import com.google.common.util.concurrent.UncheckedExecutionException
 import org.mockito.Mockito._
-import org.scalatest.mock.MockitoSugar
 import org.scalatest.Matchers
+import org.scalatest.mock.MockitoSugar
 
 import org.apache.spark.status.api.v1.{ApplicationAttemptInfo => AttemptInfo, ApplicationInfo}
 import org.apache.spark.ui.SparkUI
@@ -379,7 +379,7 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
     // build a list of applications
     val count = 100
     for (i <- 1 to count ) {
-      val appId =  f"app-$i%04d"
+      val appId = f"app-$i%04d"
       ids += appId
       clock.advance(10)
       val t = clock.getTimeMillis()
@@ -394,10 +394,7 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
 
     assertMetric("loadCount", metrics.loadCount, count)
     assertMetric("evictionCount", metrics.evictionCount, count - size)
-
-
-  }
-
+}
 
   test("AttemptsAreEvicted") {
     val operations = new StubCacheOperations()

--- a/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
@@ -57,14 +57,14 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
     }
 
     /** Attach a reconstructed UI  */
-    override def attachSparkUI(ui: SparkUI, completed: Boolean): Unit  = {
+    override def attachSparkUI(ui: SparkUI, completed: Boolean): Unit = {
       attachCount += 1
       val name = ui.getAppName
       assert(name != null, s"no name for spark UI $ui")
       attached += (name -> ui)
     }
 
-    def create(name: String, completed: Boolean): SparkUI  = {
+    def create(name: String, completed: Boolean): SparkUI = {
       val ui = newUI(name, completed)
       instances += (name -> ui)
       ui
@@ -97,11 +97,9 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
    */
   class FakeTicker(var now: Long) extends Ticker {
 
-    override def read(): Long = {
-      now
-    }
+    override def read(): Long =  now
 
-    def tick(): Unit =  {
+    def tick(): Unit = {
       now += 1
     }
 
@@ -110,7 +108,7 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
     }
   }
 
-  def newUI(name: String, completed: Boolean) : SparkUI =  {
+  def newUI(name: String, completed: Boolean): SparkUI =  {
     val date = new Date(0)
     val info = new ApplicationInfo(name, name,
       Some(1), Some(1), Some(1), Some(64),
@@ -171,7 +169,7 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
     // and in the map of attached
     assert(None !== operations.attached.get("1"), s"attached entry '1' from $cache")
 
-    //go forward in time
+    // go forward in time
     ticker.set(10)
     val cacheEntry2 = cache.get("1")
     // no more refresh as this is a completed app
@@ -186,7 +184,7 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
 
     // there should have been a detachment here
     assert(1 === operations.detachCount, s"detach count from $cache")
-    /// and entry "1" no longer attached
+    // and entry "1" no longer attached
     assert(None === operations.attached.get("1"), s"get(1) in $cache")
 
   }
@@ -198,7 +196,6 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
     val operations = new StubCacheOperations()
     val ticker = new FakeTicker(1)
     val cache = new ApplicationCache(operations, 5, 10, ticker)
-    //operations.instances += ("1" ->(newUI("1"), true))
     // add the incomplete app
     operations.instances += ("inc" ->(newUI("inc", false)))
     val entry = cache.get("inc")
@@ -215,7 +212,7 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
     assert((ticker.read() - entry.timestamp) > cache.refreshInterval)
     val entry3 = cache.get("inc")
     assert(entry !== entry3, s"updated entry test from $cache")
-    assert(1 === operations.refreshCount,  s"refresh count in $cache")
+    assert(1 === operations.refreshCount, s"refresh count in $cache")
     assert(1 === operations.detachCount, s"detach count in $cache")
     assert(None !== operations.attached.get("inc"), s"attached['inc'] in $cache")
     assert(entry3.timestamp === 15)

--- a/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.deploy.history
 
 import java.util.{Date, NoSuchElementException}
-
 import javax.servlet.Filter
 
 import scala.collection.mutable
@@ -264,10 +263,7 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
     assertNotFound(appId, None)
   }
 
-  /**
-   * Test that if an attempt ID is is set, it must be used in lookups
-   */
-  test("Naming") {
+  test("Test that if an attempt ID is is set, it must be used in lookups") {
     val operations = new StubCacheOperations()
     val clock = new ManualClock(1)
     implicit val cache = new ApplicationCache(operations,
@@ -359,8 +355,11 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
    * @param expected expected value.
    * @param cache cache
    */
-  def assertMetric(name: String, counter: Counter, expected: Long)(implicit cache: ApplicationCache)
-  : Unit = {
+  def assertMetric(
+      name: String,
+      counter: Counter,
+      expected: Long)
+      (implicit cache: ApplicationCache): Unit = {
     val actual = counter.getCount
     if (actual != expected) {
       // this is here because Scalatest loses stack depth
@@ -377,8 +376,11 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
    * @param expected expected value
    * @param cache app cache
    */
-  def assertCacheEntryEquals(appId: String, attemptId: Option[String],
-      expected: CacheEntry)(implicit cache: ApplicationCache): Unit = {
+  def assertCacheEntryEquals(
+      appId: String,
+      attemptId: Option[String],
+      expected: CacheEntry)
+      (implicit cache: ApplicationCache): Unit = {
     val actual = cache.lookupCacheEntry(appId, attemptId)
     val errorText = s"Expected get($appId, $attemptId) -> $expected, but got $actual from $cache"
     assert(expected.ui === actual.ui, errorText + " SparkUI reference")
@@ -394,7 +396,9 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
    * @param attemptId attempt ID
    * @param cache app cache
    */
-  def assertNotFound(appId: String, attemptId: Option[String])
+  def assertNotFound(
+      appId: String,
+      attemptId: Option[String])
       (implicit cache: ApplicationCache): Unit = {
     val ex = intercept[UncheckedExecutionException] {
       cache.get(appId, attemptId)
@@ -416,7 +420,7 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
 
     val attempt1 = Some("01")
 
-    var ids = new ListBuffer[String]()
+    val ids = new ListBuffer[String]()
     // build a list of applications
     val count = 100
     for (i <- 1 to count ) {
@@ -437,9 +441,8 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
     assertMetric("evictionCount", metrics.evictionCount, count - size)
 }
 
-  test("AttemptsAreEvicted") {
+  test("Attempts are Evicted") {
     val operations = new StubCacheOperations()
-    // only two entries are retained, so we expect evictions to occurr on lookups
     implicit val cache: ApplicationCache = new TestApplicationCache(operations,
       retainedApplications = 4, refreshInterval = 2)
     val metrics = cache.metrics

--- a/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
@@ -78,10 +78,10 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
      * @return If found, the Spark UI and any history information to be used in the cache
      */
     override def getAppUI(appId: String, attemptId: Option[String])
-        : Option[(SparkUI, Option[Any])] = {
+        : Option[(SparkUI, Long, Option[Any])] = {
       logDebug(s"getAppUI($appId, $attemptId)")
       getAppUICount += 1
-      instances.get(CacheKey(appId, attemptId)).map( e => (e.ui, None))
+      instances.get(CacheKey(appId, attemptId)).map( e => (e.ui, 0L, None))
     }
 
     override def attachSparkUI(appId: String, attemptId: Option[String], ui: SparkUI,

--- a/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
@@ -17,25 +17,27 @@
  */
 package org.apache.spark.deploy.history
 
-import java.util.NoSuchElementException
+import java.util.{Date, NoSuchElementException}
 
 import com.google.common.base.Ticker
 import com.google.common.util.concurrent.UncheckedExecutionException
+import org.mockito.Mockito._
+import org.scalatest.mock.MockitoSugar
 
-import org.apache.spark.scheduler.ReplayListenerBus
+import org.apache.spark.status.api.v1.{ApplicationAttemptInfo => AttemptInfo, ApplicationInfo}
 import org.apache.spark.ui.SparkUI
-import org.apache.spark.{SparkConf, Logging, SparkFunSuite}
+import org.apache.spark.{Logging, SparkFunSuite}
 
-class ApplicationCacheSuite extends SparkFunSuite with Logging {
+class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar {
 
   /**
    * cache operations
    */
   class StubCacheOperations extends ApplicationCacheOperations {
 
-    var instances = scala.collection.mutable.HashMap.empty[String, (SparkUI, Boolean)]
+    var instances = scala.collection.mutable.HashMap.empty[String, SparkUI]
 
-    var attached = scala.collection.mutable.HashMap.empty[String, (SparkUI, Boolean)]
+    var attached = scala.collection.mutable.HashMap.empty[String, SparkUI]
 
     var getCount = 0L
     var attachCount = 0L
@@ -49,7 +51,7 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging {
      * @return (the Spark UI, completed flag)
      */
     override def getAppUI(appId: String,
-        attemptId: Option[String]): Option[(SparkUI, Boolean)] = {
+        attemptId: Option[String]): Option[SparkUI] = {
       getCount +=1
       instances.get(appId)
     }
@@ -57,13 +59,15 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging {
     /** Attach a reconstructed UI  */
     override def attachSparkUI(ui: SparkUI, completed: Boolean): Unit  = {
       attachCount += 1
-      attached += (ui.appName -> (ui, completed))
+      val name = ui.getAppName
+      assert(name != null, s"no name for spark UI $ui")
+      attached += (name -> ui)
     }
 
 
     def create(name: String, completed: Boolean): SparkUI  = {
-      val ui = newUI(name)
-      instances += (name -> (ui, completed))
+      val ui = newUI(name, completed)
+      instances += (name -> ui)
       ui
     }
 
@@ -71,12 +75,10 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging {
      * Detach a reconstructed UI
      *
      * @param ui Spark UI
-     * @param refreshInProgress flag to indicate this was triggered by a refresh of an
-     *                          incomplete application
      */
     override def detachSparkUI(ui: SparkUI): Unit = {
       detachCount += 1
-      attached -= ui.appName
+      attached -= ui.getAppName
     }
 
     /**
@@ -110,9 +112,15 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging {
   }
 
 
-  def newUI(name: String) : SparkUI =  {
-    SparkUI.createHistoryUI(new SparkConf(),
-      new ReplayListenerBus(),null, name, "", 0)
+  def newUI(name: String, completed: Boolean) : SparkUI =  {
+    val date = new Date(0)
+    val info = new ApplicationInfo(name, name,
+      Seq(new AttemptInfo(None, date, date, "user", completed)))
+    val ui = mock[SparkUI]
+    when(ui.getApplicationInfoList).thenReturn(List(info).iterator)
+    when(ui.getAppName).thenReturn(name)
+    when(ui.appName).thenReturn(name)
+    ui
   }
 
   /**
@@ -148,7 +156,7 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging {
     assert(0 == operations.attachCount)
 
     // add the entry
-    operations.instances += ("1" -> (newUI("1"), true))
+    operations.instances += ("1" -> (newUI("1", true)))
     operations.create("1", true)
 
     // now expect it to be found
@@ -159,7 +167,7 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging {
     assert(1 == operations.attachCount)
 
     // and in the map of attached
-    assert(None !== operations.attached.get("1"))
+    assert(None !== operations.attached.get("1"), s"attached entry '1' from $cache")
 
     //go forward in time
     ticker.set(10)
@@ -175,9 +183,9 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging {
     cache.get("3")
 
     // there should have been a detachment here
-    assert(1 === operations.detachCount)
+    assert(1 === operations.detachCount, s"detach count from $cache")
     /// and entry "1" no longer attached
-    assert(None === operations.attached.get("1"))
+    assert(None === operations.attached.get("1"), s"get(1) in $cache")
 
   }
 
@@ -190,7 +198,7 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging {
     val cache = new ApplicationCache(operations, 5, 10, ticker)
     //operations.instances += ("1" ->(newUI("1"), true))
     // add the incomplete app
-    operations.instances += ("inc" ->(newUI("inc"), false))
+    operations.instances += ("inc" ->(newUI("inc", false)))
     val entry = cache.get("inc")
     assert(1 === entry.timestamp)
     assert(!entry.completed)
@@ -207,7 +215,7 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging {
     assert(entry !== entry3, s"updated entry test from $cache")
     assert(1 === operations.refreshCount,  s"refresh count in $cache")
     assert(1 === operations.detachCount, s"detach count in $cache")
-    assert(None !== operations.attached.get("inc"))
+    assert(None !== operations.attached.get("inc"), s"attached['inc'] in $cache")
     assert(entry3.timestamp === 15)
 
     // go a little bit forward again
@@ -218,7 +226,7 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging {
     // and a short time later, and again the entry can be updated.
     // here with a now complete entry
     ticker.set(30)
-    operations.instances += ("inc" ->(newUI("inc"), true))
+    operations.instances += ("inc" ->(newUI("inc", true)))
     val entry5 = cache.get("inc")
     assert(entry5.completed)
 

--- a/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
@@ -19,6 +19,8 @@ package org.apache.spark.deploy.history
 
 import java.util.{Date, NoSuchElementException}
 
+import scala.collection.mutable
+
 import com.google.common.base.Ticker
 import com.google.common.util.concurrent.UncheckedExecutionException
 import org.mockito.Mockito._
@@ -35,9 +37,9 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
    */
   class StubCacheOperations extends ApplicationCacheOperations {
 
-    var instances = scala.collection.mutable.HashMap.empty[String, SparkUI]
+    val instances = mutable.HashMap.empty[String, SparkUI]
 
-    var attached = scala.collection.mutable.HashMap.empty[String, SparkUI]
+    val attached = mutable.HashMap.empty[String, SparkUI]
 
     var getCount = 0L
     var attachCount = 0L
@@ -110,8 +112,7 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
 
   def newUI(name: String, completed: Boolean): SparkUI =  {
     val date = new Date(0)
-    val info = new ApplicationInfo(name, name,
-      Some(1), Some(1), Some(1), Some(64),
+    val info = new ApplicationInfo(name, name, Some(1), Some(1), Some(1), Some(64),
       Seq(new AttemptInfo(None, date, date, "user", completed)))
     val ui = mock[SparkUI]
     when(ui.getApplicationInfoList).thenReturn(List(info).iterator)
@@ -133,7 +134,7 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
     }
     var cause = ex.getCause
     assert(cause !== null)
-    if(!cause.isInstanceOf[NoSuchElementException]) {
+    if (!cause.isInstanceOf[NoSuchElementException]) {
       throw cause;
     }
   }

--- a/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
@@ -19,6 +19,8 @@ package org.apache.spark.deploy.history
 
 import java.util.{Date, NoSuchElementException}
 
+import javax.servlet.Filter
+
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.language.postfixOps
@@ -26,6 +28,7 @@ import scala.language.postfixOps
 import com.codahale.metrics.Counter
 import com.google.common.cache.LoadingCache
 import com.google.common.util.concurrent.UncheckedExecutionException
+import org.eclipse.jetty.servlet.ServletContextHandler
 import org.mockito.Mockito._
 import org.scalatest.Matchers
 import org.scalatest.mock.MockitoSugar
@@ -154,6 +157,8 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
     when(ui.getApplicationInfoList).thenReturn(List(info).iterator)
     when(ui.getAppName).thenReturn(name)
     when(ui.appName).thenReturn(name)
+    val handler = new ServletContextHandler()
+    when(ui.getHandlers).thenReturn(Seq(handler))
     ui
   }
 
@@ -442,4 +447,12 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
     expectLoadAndEvictionCounts(5, 1)
 
   }
+
+  test("Instantiate Filter") {
+    // this is a regression test on the filter being constructable
+    val clazz = Class.forName(ApplicationCacheCheckFilterRelay.FILTER_NAME)
+    val instance = clazz.newInstance()
+    instance shouldBe a [Filter]
+  }
+
 }

--- a/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
@@ -77,11 +77,10 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
      * @param attemptId attempt ID
      * @return If found, the Spark UI and any history information to be used in the cache
      */
-    override def getAppUI(appId: String, attemptId: Option[String])
-        : Option[(SparkUI, Long, Option[Any])] = {
+    override def getAppUI(appId: String, attemptId: Option[String]): Option[LoadedAppUI] = {
       logDebug(s"getAppUI($appId, $attemptId)")
       getAppUICount += 1
-      instances.get(CacheKey(appId, attemptId)).map( e => (e.ui, 0L, None))
+      instances.get(CacheKey(appId, attemptId)).map( e => LoadedAppUI(e.ui, 0L, None))
     }
 
     override def attachSparkUI(appId: String, attemptId: Option[String], ui: SparkUI,
@@ -121,7 +120,7 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
       detachCount += 1
       var name = ui.getAppName
       val key = CacheKey(appId, attemptId)
-      attached.getOrElse(key, {throw new scala.NoSuchElementException()})
+      attached.getOrElse(key, { throw new java.util.NoSuchElementException() })
       attached -= key
     }
 
@@ -129,7 +128,7 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
      * @return true if the timestamp on a cached instance is greater than `updateTimeMillis`.
      */
     override def isUpdated(appId: String, attemptId: Option[String], updateTimeMillis: Long,
-        data: Option[Any]): Boolean = {
+        data: Option[HistoryProviderUpdateState]): Boolean = {
       updateProbeCount += 1
       logDebug(s"isUpdated($appId, $attemptId, $updateTimeMillis)")
       val entry = instances.get(CacheKey(appId, attemptId)).get

--- a/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
@@ -64,7 +64,6 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
       attached += (name -> ui)
     }
 
-
     def create(name: String, completed: Boolean): SparkUI  = {
       val ui = newUI(name, completed)
       instances += (name -> ui)
@@ -111,10 +110,10 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
     }
   }
 
-
   def newUI(name: String, completed: Boolean) : SparkUI =  {
     val date = new Date(0)
     val info = new ApplicationInfo(name, name,
+      Some(1), Some(1), Some(1), Some(64),
       Seq(new AttemptInfo(None, date, date, "user", completed)))
     val ui = mock[SparkUI]
     when(ui.getApplicationInfoList).thenReturn(List(info).iterator)
@@ -134,8 +133,11 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
     val ex = intercept[UncheckedExecutionException] {
       cache.get("key")
     }
-    assert(ex.getCause !== null)
-    ex.getCause.asInstanceOf[NoSuchElementException]
+    var cause = ex.getCause
+    assert(cause !== null)
+    if(!cause.isInstanceOf[NoSuchElementException]) {
+      throw cause;
+    }
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.history
+
+import java.util.NoSuchElementException
+
+import com.google.common.base.Ticker
+import com.google.common.util.concurrent.UncheckedExecutionException
+
+import org.apache.spark.scheduler.ReplayListenerBus
+import org.apache.spark.ui.SparkUI
+import org.apache.spark.{SparkConf, Logging, SparkFunSuite}
+
+class ApplicationCacheSuite extends SparkFunSuite with Logging {
+
+  /**
+   * cache operations
+   */
+  class StubCacheOperations extends ApplicationCacheOperations {
+
+    var instances = scala.collection.mutable.HashMap.empty[String, (SparkUI, Boolean)]
+
+    var attached = scala.collection.mutable.HashMap.empty[String, (SparkUI, Boolean)]
+
+    var getCount = 0L
+    var attachCount = 0L
+    var detachCount = 0L
+    var refreshCount = 0L
+
+    /**
+     * Get the application UI
+     * @param appId application ID
+     * @param attemptId attempt ID
+     * @return (the Spark UI, completed flag)
+     */
+    override def getAppUI(appId: String,
+        attemptId: Option[String]): Option[(SparkUI, Boolean)] = {
+      getCount +=1
+      instances.get(appId)
+    }
+
+    /** Attach a reconstructed UI  */
+    override def attachSparkUI(ui: SparkUI, completed: Boolean): Unit  = {
+      attachCount += 1
+      attached += (ui.appName -> (ui, completed))
+    }
+
+
+    def create(name: String, completed: Boolean): SparkUI  = {
+      val ui = newUI(name)
+      instances += (name -> (ui, completed))
+      ui
+    }
+
+    /**
+     * Detach a reconstructed UI
+     *
+     * @param ui Spark UI
+     * @param refreshInProgress flag to indicate this was triggered by a refresh of an
+     *                          incomplete application
+     */
+    override def detachSparkUI(ui: SparkUI, refreshInProgress: Boolean): Unit = {
+      detachCount += 1
+      if (refreshInProgress) {
+        refreshCount += 1
+      }
+      attached -= ui.appName
+    }
+  }
+
+  /**
+   * Ticker class for testing
+   * @param now initial time
+   */
+  class FakeTicker(var now: Long) extends Ticker {
+
+    override def read(): Long = {
+      now
+    }
+
+    def tick(): Unit =  {
+      now += 1
+    }
+
+    def set(l: Long): Unit = {
+      now = l;
+    }
+  }
+
+
+  def newUI(name: String) : SparkUI =  {
+    SparkUI.createHistoryUI(new SparkConf(),
+      new ReplayListenerBus(),null, name, "", 0)
+  }
+
+  /**
+   * Assert that a key wasn't found in cache or loaded.
+   * <p>
+   * Looks for the specific nested exception raised by [[ApplicationCache]]
+   * @param cache
+   * @param key
+   */
+  def assertNotLoaded(cache: ApplicationCache, key: String) {
+    val ex = intercept[UncheckedExecutionException] {
+      cache.get("key")
+    }
+    assert(ex.getCause !== null)
+    ex.getCause.asInstanceOf[NoSuchElementException]
+  }
+
+  /**
+   * Test operations on completed UIs: they are loaded on demand, entries
+   * are removed on overload
+   */
+  test("Completed UI get") {
+    val operations = new StubCacheOperations()
+    val ticker = new FakeTicker(0)
+    val cache = new ApplicationCache(operations, 5, 2, ticker)
+    // cache misses
+    assertNotLoaded(cache, "1")
+    assert(1 == operations.getCount)
+    assertNotLoaded(cache, "1")
+    assert(2 == operations.getCount)
+    assert(0 == operations.attachCount)
+
+    // add the entry
+    operations.instances += ("1" -> (newUI("1"), true))
+    operations.create("1", true)
+
+    // now expect it to be found
+    val cacheEntry = cache.get("1")
+    assert(3 == operations.getCount)
+    assert(1 == operations.attachCount)
+
+    // and in the cache of attached
+    assert(None !== operations.attached.get("1"))
+
+    //go forward in time
+    ticker.set(10)
+    val cacheEntry2 = cache.get("1")
+    // no more refresh as this is a completed app
+    assert(3 == operations.getCount)
+    assert(0 == operations.detachCount)
+
+    // evict the entry
+    operations.create("2", true)
+    operations.create("3", true)
+    cache.get("2")
+    cache.get("3")
+
+    // there should have been a detachment here
+    assert(1 === operations.detachCount)
+    /// and entry "1" no longer attached
+    assert(None === operations.attached.get("1"))
+
+  }
+
+}

--- a/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
@@ -35,7 +35,7 @@ import org.scalatest.mock.MockitoSugar
 
 import org.apache.spark.status.api.v1.{ApplicationAttemptInfo => AttemptInfo, ApplicationInfo}
 import org.apache.spark.ui.SparkUI
-import org.apache.spark.util.{Clock, ManualClock}
+import org.apache.spark.util.{Clock, ManualClock, Utils}
 import org.apache.spark.{Logging, SparkFunSuite}
 
 class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar with Matchers {
@@ -450,7 +450,7 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
 
   test("Instantiate Filter") {
     // this is a regression test on the filter being constructable
-    val clazz = Class.forName(ApplicationCacheCheckFilterRelay.FILTER_NAME)
+    val clazz = Utils.classForName(ApplicationCacheCheckFilterRelay.FILTER_NAME)
     val instance = clazz.newInstance()
     instance shouldBe a [Filter]
   }

--- a/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
@@ -74,7 +74,7 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
       attachSparkUI(appId, attemptId, ui, completed)
       ui
     }
-    
+
     def putAppUI(appId: String, attemptId: Option[String], completed: Boolean, started: Long,
         ended: Long, timestamp: Long): SparkUI = {
       val ui = newUI(appId, attemptId, completed, started, ended)
@@ -128,7 +128,7 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
    * `org.apache.spark.status.api.v1`, not the near-equivalents from the history package
    */
   def newUI(name: String, attemptId: Option[String], completed: Boolean, started: Long,
-      ended: Long): SparkUI =  {
+      ended: Long): SparkUI = {
     val info = new ApplicationInfo(name, name, Some(1), Some(1), Some(1), Some(64),
       Seq(new AttemptInfo(attemptId, new Date(started), new Date(ended), "user", completed)))
     val ui = mock[SparkUI]
@@ -212,7 +212,7 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
     val cache = new ApplicationCache(operations, 5, 10, clock)
     val appId = "app1"
     val attemptId = Some("_01")
-    operations.putAppUI(appId, attemptId, false,  clock.getTimeMillis(), 0, 0)
+    operations.putAppUI(appId, attemptId, false, clock.getTimeMillis(), 0, 0)
     assertNotFound(cache, appId, None)
   }
 
@@ -289,11 +289,12 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
    * @param counter counter
    * @param expected expected value.
    */
-  def assertCounter(cache: ApplicationCache, name: String, counter: Counter, expected: Long): Unit = {
+  def assertCounter(cache: ApplicationCache, name: String, counter: Counter, expected: Long)
+      : Unit = {
     val actual = counter.getCount
     if (actual != expected) {
       // this is here because Scalatest loses stack depth
-      throw new Exception(s"Wrong $name value - expected $expected but got $actual in $cache");
+      throw new Exception(s"Wrong $name value - expected $expected but got $actual in $cache")
     }
   }
 
@@ -306,7 +307,6 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
       expected: CacheEntry): Unit = {
     val actual = cache.lookupCacheEntry(appId, attemptId)
     val errorText = s"Expected get($appId, $attemptId) -> $expected, but got $actual from $cache"
-    // here for failures where scalatest hides the stack logDebug(errorText, new Exception(errorText))
     assert(expected.ui === actual.ui, errorText + " SparkUI reference")
     assert(expected.completed === actual.completed, errorText + " -completed flag")
     assert(expected.timestamp === actual.timestamp, errorText + " -timestamp")
@@ -326,7 +326,7 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
     var cause = ex.getCause
     assert(cause !== null)
     if (!cause.isInstanceOf[NoSuchElementException]) {
-      throw cause;
+      throw cause
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.deploy.history
 
 import java.util.{Date, NoSuchElementException}
 import javax.servlet.Filter
-import javax.servlet.http.{HttpServletResponse, HttpServletRequest}
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
@@ -29,17 +29,17 @@ import com.codahale.metrics.Counter
 import com.google.common.cache.LoadingCache
 import com.google.common.util.concurrent.UncheckedExecutionException
 import org.eclipse.jetty.servlet.ServletContextHandler
-import org.mockito.Mockito._
 import org.mockito.Matchers._
+import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatest.Matchers
 import org.scalatest.mock.MockitoSugar
 
+import org.apache.spark.{Logging, SparkFunSuite}
 import org.apache.spark.status.api.v1.{ApplicationAttemptInfo => AttemptInfo, ApplicationInfo}
 import org.apache.spark.ui.SparkUI
 import org.apache.spark.util.{Clock, ManualClock, Utils}
-import org.apache.spark.{Logging, SparkFunSuite}
 
 class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar with Matchers {
 

--- a/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
@@ -174,7 +174,8 @@ class ApplicationCacheSuite extends SparkFunSuite with Logging with MockitoSugar
       started: Long,
       ended: Long): SparkUI = {
     val info = new ApplicationInfo(name, name, Some(1), Some(1), Some(1), Some(64),
-      Seq(new AttemptInfo(attemptId, new Date(started), new Date(ended), "user", completed)))
+      Seq(new AttemptInfo(attemptId, new Date(started), new Date(ended),
+        new Date(ended), ended - started, "user", completed)))
     val ui = mock[SparkUI]
     when(ui.getApplicationInfoList).thenReturn(List(info).iterator)
     when(ui.getAppName).thenReturn(name)

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -38,6 +38,7 @@ import org.scalatest.selenium.WebBrowser
 import org.scalatest.{BeforeAndAfter, Matchers}
 import org.scalatest.mock.MockitoSugar
 
+import org.apache.spark.ui.jobs.UIData.JobUIData
 import org.apache.spark.ui.{SparkUI, UIUtils}
 import org.apache.spark.util.ResetSystemProperties
 import org.apache.spark._
@@ -291,7 +292,7 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
     server.bind()
     val port = server.boundPort
     val metrics = server.cacheMetrics
-    def assertMetric(name: String, counter: Counter, expected: Long) = {
+    def assertMetric(name: String, counter: Counter, expected: Long): Unit = {
       val actual = counter.getCount
       if (actual != expected) {
         // this is here because Scalatest loses stack depth
@@ -317,10 +318,10 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
         go to (s"http://localhost:$port/history/$appId$suffix")
         findAll(cssSelector("tbody tr")).toIndexedSeq.size
       }
-      def completedJobs() = {
+      def completedJobs(): Seq[JobUIData] = {
         getAppUI.jobProgressListener.completedJobs
       }
-      def activeJobs() = {
+      def activeJobs(): Seq[JobUIData] = {
         getAppUI.jobProgressListener.activeJobs.values.toSeq
       }
 

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -29,7 +29,6 @@ import com.google.common.base.Charsets
 import com.google.common.io.{ByteStreams, Files}
 import org.apache.commons.io.{FileUtils, IOUtils}
 import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
-import org.json4s._
 import org.json4s.JsonAST._
 import org.json4s.jackson.JsonMethods
 import org.json4s.jackson.JsonMethods._
@@ -447,7 +446,6 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
       getNumJobsRestful() should be(2)
     }
 
-    // and again, without any intermediate sleep, so relying on size changes rather than modtime
     d.count()
     d.count()
     eventually(stdTimeout, stdInterval) {

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -69,7 +69,7 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
   def init(): Unit = {
     val conf = new SparkConf()
       .set("spark.history.fs.logDirectory", logDir.getAbsolutePath)
-      .set("spark.history.fs.updateInterval", "0")
+      .set("spark.history.fs.update.interval", "0")
       .set("spark.testing", "true")
     provider = new FsHistoryProvider(conf)
     provider.checkForLogs()
@@ -320,6 +320,7 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
       val port = server.boundPort
       val metrics = server.cacheMetrics
 
+      // assert that a metric has a value; if not dump the whole metrics instance
       def assertMetric(name: String, counter: Counter, expected: Long): Unit = {
         val actual = counter.getCount
         if (actual != expected) {
@@ -329,6 +330,7 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
         }
       }
 
+      // build a URL for an app or app/attempt plus a page underneath
       def buildURL(appId: String, suffix: String): URL = {
         new URL(s"http://localhost:$port/history/$appId$suffix")
       }
@@ -363,7 +365,7 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
       rootAppPage should not be empty
 
       def getAppUI: SparkUI = {
-        provider.getAppUI(appId, None).get._1
+        provider.getAppUI(appId, None).get.ui
       }
 
       // selenium isn't that useful on failures...add our own reporting
@@ -373,11 +375,9 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
         try {
           go to target.toExternalForm
           findAll(cssSelector("tbody tr")).toIndexedSeq.size
-        }
-        catch {
+        } catch {
           case ex: Exception =>
-            logError(s"Against $target\n$targetBody", ex)
-            throw ex
+            throw new Exception(s"Against $target\n$targetBody", ex)
         }
       }
       def completedJobs(): Seq[JobUIData] = {
@@ -392,6 +392,9 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
       getNumJobs("") should be(1)
       getNumJobs("/jobs") should be(1)
       assert(metrics.lookupCount.getCount > 1, s"lookup count too low in $metrics")
+
+      // dump state before the next bit of test, which is where update
+      // checking really gets stressed
       dumpLogDir("filesystem before executing second job")
       logDebug(s"History Server: $server")
 
@@ -404,11 +407,10 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
       dumpLogDir("After second job")
 
 
-      val stdTimeout = timeout(20 seconds)
+      val stdTimeout = timeout(10 seconds)
 
       logDebug("waiting for UI to update")
       eventually(stdTimeout, stdInterval) {
-        val finalFileStatus = fs.getFileStatus(logDirPath)
         assert(2 === getNumJobs(""),
           s"jobs not updated, server=$server\n dir = ${listDir(logDirPath)}")
         assert(2 === getNumJobs("/jobs"),
@@ -443,16 +445,17 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
         assert(provider.getListing().head.completed,
           s"application never completed, server=$server\n")
       }
-      assert(endcount === getNumJobs("/jobs"))
 
-      // which lists as incomplete
+      // verify the root page picks up the application, even without any GETs to the loaded
+      // incomplete UI
       eventually(stdTimeout, stdInterval) {
         assertUrlContains(historyServerRoot, appId)
       }
-      assert(!HistoryServerSuite.getUrl(historyServerIncompleted).contains(appId))
-
-
       // the root UI must pick this up too
+      HistoryServerSuite.getUrl(historyServerIncompleted) should not contain (appId)
+
+      assert(endcount === getNumJobs("/jobs"))
+
     } finally {
       sc.stop()
     }

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -31,22 +31,19 @@ import org.apache.commons.io.{FileUtils, IOUtils}
 import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
 import org.json4s._
 import org.json4s.JsonAST._
-import org.json4s.JsonAST.JNothing
 import org.json4s.jackson.JsonMethods
 import org.json4s.jackson.JsonMethods._
-import org.mockito.Mockito.when
-import org.openqa.selenium.htmlunit.HtmlUnitDriver
 import org.openqa.selenium.WebDriver
-import org.scalatest.concurrent.Eventually
-import org.scalatest.selenium.WebBrowser
+import org.openqa.selenium.htmlunit.HtmlUnitDriver
 import org.scalatest.{BeforeAndAfter, Matchers}
+import org.scalatest.concurrent.Eventually
 import org.scalatest.mock.MockitoSugar
+import org.scalatest.selenium.WebBrowser
 
+import org.apache.spark._
 import org.apache.spark.ui.SparkUI
 import org.apache.spark.ui.jobs.UIData.JobUIData
-import org.apache.spark.util.ResetSystemProperties
-import org.apache.spark._
-import org.apache.spark.util.Utils
+import org.apache.spark.util.{ResetSystemProperties, Utils}
 
 /**
  * A collection of tests against the historyserver, including comparing responses from the json
@@ -60,7 +57,8 @@ import org.apache.spark.util.Utils
  * are considered part of Spark's public api.
  */
 class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers with MockitoSugar
-  with JsonTestUtils with Eventually with WebBrowser with LocalSparkContext with ResetSystemProperties {
+  with JsonTestUtils with Eventually with WebBrowser with LocalSparkContext
+  with ResetSystemProperties {
 
   private val logDir = new File("src/test/resources/spark-events")
   private val expRoot = new File("src/test/resources/HistoryServerExpectations/")

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -340,14 +340,6 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
     }
 
     val historyServerRoot = new URL(s"http://localhost:$port/")
-    val historyServerIncompleted = new URL(historyServerRoot, "?page=1&showIncomplete=true")
-
-    // assert the body of a URL contains a string; return that body
-    def assertUrlContains(url: URL, str: String): String = {
-      val body = HistoryServerSuite.getUrl(url)
-      assert(body.contains(str), s"did not find $str at $url : $body")
-      body
-    }
 
     // start initial job
     val d = sc.parallelize(1 to 10)
@@ -359,9 +351,6 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
       apps should have size 1
       (apps.head \ "id").extract[String]
     }
-
-    // which lists as incomplete
-//    assertUrlContains(historyServerIncompleted, appId)
 
     val appIdRoot = buildURL(appId, "")
     val rootAppPage = HistoryServerSuite.getUrl(appIdRoot)

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -376,9 +376,10 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
       activeJobs() should have size 0
       completedJobs() should have size 1
       getNumJobs("") should be(1)
+      getNumJobs("/jobs") should be(1)
       assert(metrics.lookupCount.getCount > 1, s"lookup count too low in $metrics")
       dumpLogDir("filesystem before executing second job")
-      logDebug(s"History provider: $provider")
+      logDebug(s"History Server: $server")
 
       // second job needs a delay to ensure timestamps are different
       Thread.sleep(10)
@@ -390,8 +391,8 @@ class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with Matchers
 
 
       val stdTimeout = timeout(20 seconds)
-      logDebug(s"Explicitly reloading app UI for updated job information")
 /*
+      logDebug(s"Explicitly reloading app UI for updated job information")
       eventually(stdTimeout, stdInterval) {
         // verifies that a reload picks up the change
         completedJobs() should have size 2

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -38,11 +38,25 @@ You can start the history server by executing:
 
     ./sbin/start-history-server.sh
 
-When using the file-system provider class (see spark.history.provider below), the base logging
-directory must be supplied in the <code>spark.history.fs.logDirectory</code> configuration option,
-and should contain sub-directories that each represents an application's event logs. This creates a
-web interface at `http://<server-url>:18080` by default. The history server can be configured as
-follows:
+This creates a web interface at `http://<server-url>:18080` by default, listing incomplete
+and completed applications and attempts, and allowing them to be viewed
+
+When using the file-system provider class (see `spark.history.provider` below), the base logging
+directory must be supplied in the `spark.history.fs.logDirectory` configuration option,
+and should contain sub-directories that each represents an application's event logs.
+ 
+The spark jobs themselves must be configured to log events, and to log them to the same shared,
+writeable directory. For example, if the server was configured with a log directory of
+`hdfs://namenode/shared/spark-logs`, then the client-side options would be:
+
+```
+spark.eventLog.enabled true
+spark.eventLog.dir hdfs://namenode/shared/spark-logs
+```
+ 
+The history server can be configured as follows:
+
+### Environment Variables
 
 <table class="table">
   <tr><th style="width:21%">Environment Variable</th><th>Meaning</th></tr>
@@ -69,29 +83,16 @@ follows:
   </tr>
 </table>
 
+### Spark configuration options
+
 <table class="table">
   <tr><th>Property Name</th><th>Default</th><th>Meaning</th></tr>
   <tr>
     <td>spark.history.provider</td>
-    <td>org.apache.spark.deploy.history.FsHistoryProvider</td>
+    <td><code>org.apache.spark.deploy.history.FsHistoryProvider</code></td>
     <td>Name of the class implementing the application history backend. Currently there is only
     one implementation, provided by Spark, which looks for application logs stored in the
     file system.</td>
-  </tr>
-  <tr>
-    <td>spark.history.fs.logDirectory</td>
-    <td>file:/tmp/spark-events</td>
-    <td>
-     Directory that contains application event logs to be loaded by the history server
-    </td>
-  </tr>
-  <tr>
-    <td>spark.history.fs.update.interval</td>
-    <td>10s</td>
-    <td>
-      The period at which information displayed by this history server is updated.
-      Each update checks for any changes made to the event logs in persisted storage.
-    </td>
   </tr>
   <tr>
     <td>spark.history.retainedApplications</td>
@@ -102,10 +103,33 @@ follows:
     </td>
   </tr>
   <tr>
-    <td>spark.history.cache.window</td>
-    <td>60</td>
+    <td>spark.history.fs.logDirectory</td>
+    <td>file:/tmp/spark-events</td>
     <td>
-      Time in seconds between checks for changes in the history of incomplete applications. 
+    For the filesystem history provider, the URL to the directory containing application event
+    logs to load. This can be a local <code>file://</code> path,
+    an HDFS path <code>hdfs://namenode/shared/spark-logs</code>
+    or that of an alternative filesystem supported by the Hadoop APIs.
+    </td>
+  </tr>
+  <tr>
+    <td>spark.history.fs.update.interval</td>
+    <td>10s</td>
+    <td>
+      The period at which the the filesystem history provider checks for new or
+      updated logs in the log directory. A shorter interval detects new applications faster,
+      at the expense of more server load re-reading updated applications.
+      As soon as an update has completed, listings of the completed and incomplete applications
+      will reflect the changes. For performance reasons, the UIs of web applications are
+      only updated at a slower interval, that defined in <code>spark.history.cache.window</code> 
+    </td>
+  </tr>
+  <tr>
+    <td>spark.history.cache.window</td>
+    <td>60s</td>
+    <td>
+      Minimum time between checks for updates to incomplete web applications whose web
+      views have been loaded into the history server.
     </td>
   </tr>
   <tr>
@@ -119,7 +143,7 @@ follows:
     <td>spark.history.kerberos.enabled</td>
     <td>false</td>
     <td>
-      Indicates whether the history server should use kerberos to login. This is useful
+      Indicates whether the history server should use kerberos to login. This is required
       if the history server is accessing HDFS files on a secure Hadoop cluster. If this is 
       true, it uses the configs <code>spark.history.kerberos.principal</code> and
       <code>spark.history.kerberos.keytab</code>. 
@@ -163,15 +187,15 @@ follows:
     <td>spark.history.fs.cleaner.interval</td>
     <td>1d</td>
     <td>
-      How often the job history cleaner checks for files to delete.
-      Files are only deleted if they are older than spark.history.fs.cleaner.maxAge.
+      How often the filesystem job history cleaner checks for files to delete.
+      Files are only deleted if they are older than <code>spark.history.fs.cleaner.maxAge</code>
     </td>
   </tr>
   <tr>
     <td>spark.history.fs.cleaner.maxAge</td>
     <td>7d</td>
     <td>
-      Job history files older than this will be deleted when the history cleaner runs.
+      Job history files older than this will be deleted when the filesystem history cleaner runs.
     </td>
   </tr>
 </table>
@@ -179,7 +203,26 @@ follows:
 Note that in all of these UIs, the tables are sortable by clicking their headers,
 making it easy to identify slow tasks, data skew, etc.
 
-Note that the history server only displays completed Spark jobs. One way to signal the completion of a Spark job is to stop the Spark Context explicitly (`sc.stop()`), or in Python using the `with SparkContext() as sc:` to handle the Spark Context setup and tear down, and still show the job history on the UI.
+Note
+
+1. The history server displays both completed and incomplete Spark jobs. If an application makes
+multiple attempts after failures, the failed attempts will be displayed, as well as any ongoing
+incomplete attempt or the final successful attempt.
+
+2. Incomplete applications are only updated intermittently. The time between updates is defined
+by both the interval between checks for changed files (`spark.history.fs.update.interval`)
+and the window between checks for updated loaded applications (`spark.history.cache.window`).
+On larger clusters the update interval and the cache window may be set to large values.
+The way to view a running application is actually to view its own web UI.
+
+3. Applications which exited without registering themselves as completed will be listed
+as incomplete —even though they are no longer running. This can happen if an application
+crashes.
+
+2. One way to signal the completion of a Spark job is to stop the Spark Context
+explicitly (`sc.stop()`), or in Python using the `with SparkContext() as sc:` construct
+to handle the Spark Context setup and tear down.
+
 
 ## REST API
 
@@ -256,7 +299,7 @@ These endpoints have been strongly versioned to make it easier to develop applic
 * New endpoints may be added
 * New fields may be added to existing endpoints
 * New versions of the api may be added in the future at a separate endpoint (eg., `api/v2`).  New versions are *not* required to be backwards compatible.
-* Api versions may be dropped, but only after at least one minor release of co-existing with a new api version
+* Api versions may be dropped, but only after at least one minor release of co-existing with a new api version.
 
 Note that even when examining the UI of a running applications, the `applications/[app-id]` portion is
 still required, though there is only one application available.  Eg. to see the list of jobs for the

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -95,14 +95,6 @@ The history server can be configured as follows:
     file system.</td>
   </tr>
   <tr>
-    <td>spark.history.retainedApplications</td>
-    <td>50</td>
-    <td>
-      The number of application UIs to retain. If this cap is exceeded, then the oldest
-      applications will be removed.
-    </td>
-  </tr>
-  <tr>
     <td>spark.history.fs.logDirectory</td>
     <td>file:/tmp/spark-events</td>
     <td>
@@ -122,6 +114,14 @@ The history server can be configured as follows:
       As soon as an update has completed, listings of the completed and incomplete applications
       will reflect the changes. For performance reasons, the UIs of web applications are
       only updated at a slower interval, that defined in <code>spark.history.cache.window</code> 
+    </td>
+  </tr>
+  <tr>
+    <td>spark.history.retainedApplications</td>
+    <td>50</td>
+    <td>
+      The number of application UIs to retain. If this cap is exceeded, then the oldest
+      applications will be removed.
     </td>
   </tr>
   <tr>

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -102,6 +102,13 @@ follows:
     </td>
   </tr>
   <tr>
+    <td>spark.history.cache.interval</td>
+    <td>60</td>
+    <td>
+      Time in seconds between checks for changes in the history of incomplete applications. 
+    </td>
+  </tr>
+  <tr>
     <td>spark.history.ui.port</td>
     <td>18080</td>
     <td>

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -102,7 +102,7 @@ follows:
     </td>
   </tr>
   <tr>
-    <td>spark.history.cache.interval</td>
+    <td>spark.history.cache.window</td>
     <td>60</td>
     <td>
       Time in seconds between checks for changes in the history of incomplete applications. 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -112,8 +112,7 @@ The history server can be configured as follows:
       updated logs in the log directory. A shorter interval detects new applications faster,
       at the expense of more server load re-reading updated applications.
       As soon as an update has completed, listings of the completed and incomplete applications
-      will reflect the changes. For performance reasons, the UIs of web applications are
-      only updated at a slower interval, that defined in <code>spark.history.cache.window</code> 
+      will reflect the changes.
     </td>
   </tr>
   <tr>
@@ -122,14 +121,6 @@ The history server can be configured as follows:
     <td>
       The number of application UIs to retain. If this cap is exceeded, then the oldest
       applications will be removed.
-    </td>
-  </tr>
-  <tr>
-    <td>spark.history.cache.window</td>
-    <td>60s</td>
-    <td>
-      Minimum time between checks for updates to incomplete web applications whose web
-      views have been loaded into the history server.
     </td>
   </tr>
   <tr>
@@ -210,9 +201,8 @@ multiple attempts after failures, the failed attempts will be displayed, as well
 incomplete attempt or the final successful attempt.
 
 2. Incomplete applications are only updated intermittently. The time between updates is defined
-by both the interval between checks for changed files (`spark.history.fs.update.interval`)
-and the window between checks for updated loaded applications (`spark.history.cache.window`).
-On larger clusters the update interval and the cache window may be set to large values.
+by the interval between checks for changed files (`spark.history.fs.update.interval`).
+On larger clusters the update interval may be set to large values.
 The way to view a running application is actually to view its own web UI.
 
 3. Applications which exited without registering themselves as completed will be listed

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -231,6 +231,9 @@ object MimaExcludes {
         ProblemFilters.exclude[MissingMethodProblem]("org.apache.spark.SparkContext.metadataCleaner"),
         ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.scheduler.cluster.YarnSchedulerBackend$YarnDriverEndpoint"),
         ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.scheduler.cluster.YarnSchedulerBackend$YarnSchedulerEndpoint")
+      ) ++ Seq(
+        // SPARK-7889
+        ProblemFilters.exclude[MissingMethodProblem]("org.apache.spark.deploy.history.HistoryServer.org$apache$spark$deploy$history$HistoryServer$@tachSparkUI")
       )
     case v if v.startsWith("1.6") =>
       Seq(


### PR DESCRIPTION
When the HistoryServer is showing an incomplete app, it needs to check if there is a newer version of the app available.  It does this by checking if a version of the app has been loaded with a larger _filesize_.  If so, it detaches the current UI, attaches the new one, and redirects back to the same URL to show the new UI.

https://issues.apache.org/jira/browse/SPARK-7889
