### PR TITLE
[SPARK-13014][Docs] Replace example code in mllib-collaborative-filtering.md using include_example

### DIFF
--- a/docs/mllib-collaborative-filtering.md
+++ b/docs/mllib-collaborative-filtering.md
@@ -88,6 +88,15 @@ that is equivalent to the provided example in Scala is given below:
 Refer to the [`ALS` Java docs](api/java/org/apache/spark/mllib/recommendation/ALS.html) for details on the API.
 
 {% include_example java/org/apache/spark/examples/mllib/JavaRecommendationExample.java %}
+
+If the rating matrix is derived from other source of information (i.e., it is inferred from other
+signals), you can use the trainImplicit method to get better results.
+
+{% highlight java %}
+double alpha = 0.01;
+double lambda = 0.01;
+MatrixFactorizationModel model = ALS.trainImplicit(JavaRDD.toRDD(ratings), rank, numIterations, lambda, alpha);
+{% endhighlight %}
 </div>
 
 <div data-lang="python" markdown="1">


### PR DESCRIPTION
Replace example code in mllib-collaborative-filtering.md using include_example https://issues.apache.org/jira/browse/SPARK-13014

The example code in the user guide is embedded in the markdown and hence it is not easy to test. It would be nice to automatically test them. This JIRA is to discuss options to automate example code testing and see what we can do in Spark 1.6.

Goal is to move actual example code to spark/examples and test compilation in Jenkins builds. Then in the markdown, we can reference part of the code to show in the user guide. This requires adding a Jekyll tag that is similar to https://github.com/jekyll/jekyll/blob/master/lib/jekyll/tags/include.rb, e.g., called include_example.
`{% include_example scala/org/apache/spark/examples/mllib/RecommendationExample.scala %}`
Jekyll will find `examples/src/main/scala/org/apache/spark/examples/mllib/RecommendationExample.scala` and pick code blocks marked "example" and replace code block in 
`{% highlight %}`
 in the markdown. 

See more sub-tasks in parent ticket: https://issues.apache.org/jira/browse/SPARK-11337
