### PR TITLE
[SPARK-13018][Docs] Replace example code in mllib-pmml-model-export.md using include_example

### DIFF
--- a/docs/mllib-pmml-model-export.md
+++ b/docs/mllib-pmml-model-export.md
@@ -45,26 +45,12 @@ The table below outlines the `spark.mllib` models that can be exported to PMML a
 <div data-lang="scala" markdown="1">
 To export a supported `model` (see table above) to PMML, simply call `model.toPMML`.
 
+As well as exporting the PMML model to a String (`model.toPMML` as in the example above), you can export the PMML model to other formats.
+
 Refer to the [`KMeans` Scala docs](api/scala/index.html#org.apache.spark.mllib.clustering.KMeans) and [`Vectors` Scala docs](api/scala/index.html#org.apache.spark.mllib.linalg.Vectors) for details on the API.
 
 Here a complete example of building a KMeansModel and print it out in PMML format:
 {% include_example scala/org/apache/spark/examples/mllib/PMMLModelExportExample.scala %}
-
-As well as exporting the PMML model to a String (`model.toPMML` as in the example above), you can export the PMML model to other formats:
-
-{% highlight scala %}
-// Export the model to a String in PMML format
-clusters.toPMML
-
-// Export the model to a local file in PMML format
-clusters.toPMML("/tmp/kmeans.xml")
-
-// Export the model to a directory on a distributed file system in PMML format
-clusters.toPMML(sc,"/tmp/kmeans")
-
-// Export the model to the OutputStream in PMML format
-clusters.toPMML(System.out)
-{% endhighlight %}
 
 For unsupported models, either you will not find a `.toPMML` method or an `IllegalArgumentException` will be thrown.
 

--- a/docs/mllib-pmml-model-export.md
+++ b/docs/mllib-pmml-model-export.md
@@ -48,22 +48,7 @@ To export a supported `model` (see table above) to PMML, simply call `model.toPM
 Refer to the [`KMeans` Scala docs](api/scala/index.html#org.apache.spark.mllib.clustering.KMeans) and [`Vectors` Scala docs](api/scala/index.html#org.apache.spark.mllib.linalg.Vectors) for details on the API.
 
 Here a complete example of building a KMeansModel and print it out in PMML format:
-{% highlight scala %}
-import org.apache.spark.mllib.clustering.KMeans
-import org.apache.spark.mllib.linalg.Vectors
-
-// Load and parse the data
-val data = sc.textFile("data/mllib/kmeans_data.txt")
-val parsedData = data.map(s => Vectors.dense(s.split(' ').map(_.toDouble))).cache()
-
-// Cluster the data into two classes using KMeans
-val numClusters = 2
-val numIterations = 20
-val clusters = KMeans.train(parsedData, numClusters, numIterations)
-
-// Export to PMML
-println("PMML Model:\n" + clusters.toPMML)
-{% endhighlight %}
+{% include_example scala/org/apache/spark/examples/mllib/PMMLModelExportExample.scala %}
 
 As well as exporting the PMML model to a String (`model.toPMML` as in the example above), you can export the PMML model to other formats:
 

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/PMMLModelExportExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/PMMLModelExportExample.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// scalastyle:off println
+package org.apache.spark.examples.mllib
+
+import org.apache.spark.{SparkConf, SparkContext}
+// $example on$
+import org.apache.spark.mllib.clustering.KMeans
+import org.apache.spark.mllib.linalg.Vectors
+// $example off$
+
+object PMMLModelExportExample {
+
+  def main(args: Array[String]) {
+
+    val conf = new SparkConf().setAppName("PMMLModelExportExample").setMaster("local[*]")
+    val sc = new SparkContext(conf)
+
+    // $example on$
+    // Load and parse the data
+    val data = sc.textFile("data/mllib/kmeans_data.txt")
+    val parsedData = data.map(s => Vectors.dense(s.split(' ').map(_.toDouble))).cache()
+
+    // Cluster the data into two classes using KMeans
+    val numClusters = 2
+    val numIterations = 20
+    val clusters = KMeans.train(parsedData, numClusters, numIterations)
+
+    // Export to PMML
+    println("PMML Model:\n" + clusters.toPMML)
+    // $example off$
+
+    sc.stop()
+  }
+}
+// scalastyle:on println

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/PMMLModelExportExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/PMMLModelExportExample.scala
@@ -26,9 +26,8 @@ import org.apache.spark.mllib.linalg.Vectors
 
 object PMMLModelExportExample {
 
-  def main(args: Array[String]) {
-
-    val conf = new SparkConf().setAppName("PMMLModelExportExample").setMaster("local[*]")
+  def main(args: Array[String]): Unit = {
+    val conf = new SparkConf().setAppName("PMMLModelExportExample")
     val sc = new SparkContext(conf)
 
     // $example on$

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/PMMLModelExportExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/PMMLModelExportExample.scala
@@ -47,7 +47,7 @@ object PMMLModelExportExample {
     clusters.toPMML("/tmp/kmeans.xml")
 
     // Export the model to a directory on a distributed file system in PMML format
-    clusters.toPMML(sc,"/tmp/kmeans")
+    clusters.toPMML(sc, "/tmp/kmeans")
 
     // Export the model to the OutputStream in PMML format
     clusters.toPMML(System.out)

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/PMMLModelExportExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/PMMLModelExportExample.scala
@@ -40,8 +40,17 @@ object PMMLModelExportExample {
     val numIterations = 20
     val clusters = KMeans.train(parsedData, numClusters, numIterations)
 
-    // Export to PMML
+    // Export to PMML to a String in PMML format
     println("PMML Model:\n" + clusters.toPMML)
+
+    // Export the model to a local file in PMML format
+    clusters.toPMML("/tmp/kmeans.xml")
+
+    // Export the model to a directory on a distributed file system in PMML format
+    clusters.toPMML(sc,"/tmp/kmeans")
+
+    // Export the model to the OutputStream in PMML format
+    clusters.toPMML(System.out)
     // $example off$
 
     sc.stop()


### PR DESCRIPTION
Replace example code in mllib-pmml-model-export.md using include_example
https://issues.apache.org/jira/browse/SPARK-13018

The example code in the user guide is embedded in the markdown and hence it is not easy to test. It would be nice to automatically test them. This JIRA is to discuss options to automate example code testing and see what we can do in Spark 1.6.

Goal is to move actual example code to spark/examples and test compilation in Jenkins builds. Then in the markdown, we can reference part of the code to show in the user guide. This requires adding a Jekyll tag that is similar to https://github.com/jekyll/jekyll/blob/master/lib/jekyll/tags/include.rb, e.g., called include_example.
`{% include_example scala/org/apache/spark/examples/mllib/PMMLModelExportExample.scala %}`
Jekyll will find `examples/src/main/scala/org/apache/spark/examples/mllib/PMMLModelExportExample.scala` and pick code blocks marked "example" and replace code block in 
`{% highlight %}`
 in the markdown. 

See more sub-tasks in parent ticket: https://issues.apache.org/jira/browse/SPARK-11337
