### PR TITLE
[SPARK-13015][Docs] Replace example code in mllib-data-types.md using include_example

### DIFF
--- a/docs/mllib-data-types.md
+++ b/docs/mllib-data-types.md
@@ -35,16 +35,7 @@ using the factory methods implemented in
 
 Refer to the [`Vector` Scala docs](api/scala/index.html#org.apache.spark.mllib.linalg.Vector) and [`Vectors` Scala docs](api/scala/index.html#org.apache.spark.mllib.linalg.Vectors) for details on the API.
 
-{% highlight scala %}
-import org.apache.spark.mllib.linalg.{Vector, Vectors}
-
-// Create a dense vector (1.0, 0.0, 3.0).
-val dv: Vector = Vectors.dense(1.0, 0.0, 3.0)
-// Create a sparse vector (1.0, 0.0, 3.0) by specifying its indices and values corresponding to nonzero entries.
-val sv1: Vector = Vectors.sparse(3, Array(0, 2), Array(1.0, 3.0))
-// Create a sparse vector (1.0, 0.0, 3.0) by specifying its nonzero entries.
-val sv2: Vector = Vectors.sparse(3, Seq((0, 1.0), (2, 3.0)))
-{% endhighlight %}
+{% include_example scala/org/apache/spark/examples/mllib/LocalVectorExample.scala %}
 
 ***Note:***
 Scala imports `scala.collection.immutable.Vector` by default, so you have to import
@@ -63,15 +54,7 @@ using the factory methods implemented in
 
 Refer to the [`Vector` Java docs](api/java/org/apache/spark/mllib/linalg/Vector.html) and [`Vectors` Java docs](api/java/org/apache/spark/mllib/linalg/Vectors.html) for details on the API.
 
-{% highlight java %}
-import org.apache.spark.mllib.linalg.Vector;
-import org.apache.spark.mllib.linalg.Vectors;
-
-// Create a dense vector (1.0, 0.0, 3.0).
-Vector dv = Vectors.dense(1.0, 0.0, 3.0);
-// Create a sparse vector (1.0, 0.0, 3.0) by specifying its indices and values corresponding to nonzero entries.
-Vector sv = Vectors.sparse(3, new int[] {0, 2}, new double[] {1.0, 3.0});
-{% endhighlight %}
+{% include_example java/org/apache/spark/examples/mllib/JavaLocalVectorExample.java %}
 </div>
 
 <div data-lang="python" markdown="1">
@@ -92,21 +75,7 @@ in [`Vectors`](api/python/pyspark.mllib.html#pyspark.mllib.linalg.Vectors) to cr
 
 Refer to the [`Vectors` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.linalg.Vectors) for more details on the API.
 
-{% highlight python %}
-import numpy as np
-import scipy.sparse as sps
-from pyspark.mllib.linalg import Vectors
-
-# Use a NumPy array as a dense vector.
-dv1 = np.array([1.0, 0.0, 3.0])
-# Use a Python list as a dense vector.
-dv2 = [1.0, 0.0, 3.0]
-# Create a SparseVector.
-sv1 = Vectors.sparse(3, [0, 2], [1.0, 3.0])
-# Use a single-column SciPy csc_matrix as a sparse vector.
-sv2 = sps.csc_matrix((np.array([1.0, 3.0]), np.array([0, 2]), np.array([0, 2])), shape = (3, 1))
-{% endhighlight %}
-
+{% include_example python/mllib/local_vector_example.py %}
 </div>
 </div>
 
@@ -127,16 +96,7 @@ A labeled point is represented by the case class
 
 Refer to the [`LabeledPoint` Scala docs](api/scala/index.html#org.apache.spark.mllib.regression.LabeledPoint) for details on the API.
 
-{% highlight scala %}
-import org.apache.spark.mllib.linalg.Vectors
-import org.apache.spark.mllib.regression.LabeledPoint
-
-// Create a labeled point with a positive label and a dense feature vector.
-val pos = LabeledPoint(1.0, Vectors.dense(1.0, 0.0, 3.0))
-
-// Create a labeled point with a negative label and a sparse feature vector.
-val neg = LabeledPoint(0.0, Vectors.sparse(3, Array(0, 2), Array(1.0, 3.0)))
-{% endhighlight %}
+{% include_example scala/org/apache/spark/examples/mllib/LabeledPointExample.scala %}
 </div>
 
 <div data-lang="java" markdown="1">
@@ -146,16 +106,7 @@ A labeled point is represented by
 
 Refer to the [`LabeledPoint` Java docs](api/java/org/apache/spark/mllib/regression/LabeledPoint.html) for details on the API.
 
-{% highlight java %}
-import org.apache.spark.mllib.linalg.Vectors;
-import org.apache.spark.mllib.regression.LabeledPoint;
-
-// Create a labeled point with a positive label and a dense feature vector.
-LabeledPoint pos = new LabeledPoint(1.0, Vectors.dense(1.0, 0.0, 3.0));
-
-// Create a labeled point with a negative label and a sparse feature vector.
-LabeledPoint neg = new LabeledPoint(0.0, Vectors.sparse(3, new int[] {0, 2}, new double[] {1.0, 3.0}));
-{% endhighlight %}
+{% include_example java/org/apache/spark/examples/mllib/JavaLabeledPointExample.java %}
 </div>
 
 <div data-lang="python" markdown="1">
@@ -165,16 +116,7 @@ A labeled point is represented by
 
 Refer to the [`LabeledPoint` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.regression.LabeledPoint) for more details on the API.
 
-{% highlight python %}
-from pyspark.mllib.linalg import SparseVector
-from pyspark.mllib.regression import LabeledPoint
-
-# Create a labeled point with a positive label and a dense feature vector.
-pos = LabeledPoint(1.0, [1.0, 0.0, 3.0])
-
-# Create a labeled point with a negative label and a sparse feature vector.
-neg = LabeledPoint(0.0, SparseVector(3, [0, 2], [1.0, 3.0]))
-{% endhighlight %}
+{% include_example python/mllib/labeled_point_example.py %}
 </div>
 </div>
 
@@ -201,13 +143,7 @@ examples stored in LIBSVM format.
 
 Refer to the [`MLUtils` Scala docs](api/scala/index.html#org.apache.spark.mllib.util.MLUtils) for details on the API.
 
-{% highlight scala %}
-import org.apache.spark.mllib.regression.LabeledPoint
-import org.apache.spark.mllib.util.MLUtils
-import org.apache.spark.rdd.RDD
-
-val examples: RDD[LabeledPoint] = MLUtils.loadLibSVMFile(sc, "data/mllib/sample_libsvm_data.txt")
-{% endhighlight %}
+{% include_example scala/org/apache/spark/examples/mllib/LabeledPointSparseDataExample.scala %}
 </div>
 
 <div data-lang="java" markdown="1">
@@ -216,14 +152,7 @@ examples stored in LIBSVM format.
 
 Refer to the [`MLUtils` Java docs](api/java/org/apache/spark/mllib/util/MLUtils.html) for details on the API.
 
-{% highlight java %}
-import org.apache.spark.mllib.regression.LabeledPoint;
-import org.apache.spark.mllib.util.MLUtils;
-import org.apache.spark.api.java.JavaRDD;
-
-JavaRDD<LabeledPoint> examples = 
-  MLUtils.loadLibSVMFile(jsc.sc(), "data/mllib/sample_libsvm_data.txt").toJavaRDD();
-{% endhighlight %}
+{% include_example java/org/apache/spark/examples/mllib/JavaLabeledPointSparseDataExample.java %}
 </div>
 
 <div data-lang="python" markdown="1">
@@ -232,11 +161,7 @@ examples stored in LIBSVM format.
 
 Refer to the [`MLUtils` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.util.MLUtils) for more details on the API.
 
-{% highlight python %}
-from pyspark.mllib.util import MLUtils
-
-examples = MLUtils.loadLibSVMFile(sc, "data/mllib/sample_libsvm_data.txt")
-{% endhighlight %}
+{% include_example python/mllib/labeled_point_sparse_data_example.py %}
 </div>
 </div>
 
@@ -266,15 +191,7 @@ matrices. Remember, local matrices in MLlib are stored in column-major order.
 
 Refer to the [`Matrix` Scala docs](api/scala/index.html#org.apache.spark.mllib.linalg.Matrix) and [`Matrices` Scala docs](api/scala/index.html#org.apache.spark.mllib.linalg.Matrices) for details on the API.
 
-{% highlight scala %}
-import org.apache.spark.mllib.linalg.{Matrix, Matrices}
-
-// Create a dense matrix ((1.0, 2.0), (3.0, 4.0), (5.0, 6.0))
-val dm: Matrix = Matrices.dense(3, 2, Array(1.0, 3.0, 5.0, 2.0, 4.0, 6.0))
-
-// Create a sparse matrix ((9.0, 0.0), (0.0, 8.0), (0.0, 6.0))
-val sm: Matrix = Matrices.sparse(3, 2, Array(0, 1, 3), Array(0, 2, 1), Array(9, 6, 8))
-{% endhighlight %}
+{% include_example scala/org/apache/spark/examples/mllib/LocalMatrixExample.scala %}
 </div>
 
 <div data-lang="java" markdown="1">
@@ -289,16 +206,7 @@ matrices. Remember, local matrices in MLlib are stored in column-major order.
 
 Refer to the [`Matrix` Java docs](api/java/org/apache/spark/mllib/linalg/Matrix.html) and [`Matrices` Java docs](api/java/org/apache/spark/mllib/linalg/Matrices.html) for details on the API.
 
-{% highlight java %}
-import org.apache.spark.mllib.linalg.Matrix;
-import org.apache.spark.mllib.linalg.Matrices;
-
-// Create a dense matrix ((1.0, 2.0), (3.0, 4.0), (5.0, 6.0))
-Matrix dm = Matrices.dense(3, 2, new double[] {1.0, 3.0, 5.0, 2.0, 4.0, 6.0});
-
-// Create a sparse matrix ((9.0, 0.0), (0.0, 8.0), (0.0, 6.0))
-Matrix sm = Matrices.sparse(3, 2, new int[] {0, 1, 3}, new int[] {0, 2, 1}, new double[] {9, 6, 8});
-{% endhighlight %}
+{% include_example java/org/apache/spark/examples/mllib/JavaLocalMatrixExample.java %}
 </div>
 
 <div data-lang="python" markdown="1">
@@ -313,15 +221,7 @@ matrices. Remember, local matrices in MLlib are stored in column-major order.
 
 Refer to the [`Matrix` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.linalg.Matrix) and [`Matrices` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.linalg.Matrices) for more details on the API.
 
-{% highlight python %}
-import org.apache.spark.mllib.linalg.{Matrix, Matrices}
-
-// Create a dense matrix ((1.0, 2.0), (3.0, 4.0), (5.0, 6.0))
-dm2 = Matrices.dense(3, 2, [1, 2, 3, 4, 5, 6])
-
-// Create a sparse matrix ((9.0, 0.0), (0.0, 8.0), (0.0, 6.0))
-sm = Matrices.sparse(3, 2, [0, 1, 3], [0, 2, 1], [9, 6, 8])
-{% endhighlight %}
+{% include_example python/mllib/local_matrix_example.py %}
 </div>
 
 </div>
@@ -367,21 +267,7 @@ For [singular value decomposition (SVD)](https://en.wikipedia.org/wiki/Singular_
 
 Refer to the [`RowMatrix` Scala docs](api/scala/index.html#org.apache.spark.mllib.linalg.distributed.RowMatrix) for details on the API.
 
-{% highlight scala %}
-import org.apache.spark.mllib.linalg.Vector
-import org.apache.spark.mllib.linalg.distributed.RowMatrix
-
-val rows: RDD[Vector] = ... // an RDD of local vectors
-// Create a RowMatrix from an RDD[Vector].
-val mat: RowMatrix = new RowMatrix(rows)
-
-// Get its size.
-val m = mat.numRows()
-val n = mat.numCols()
-
-// QR decomposition 
-val qrResult = mat.tallSkinnyQR(true)
-{% endhighlight %}
+{% include_example scala/org/apache/spark/examples/mllib/RowMatrixExample.scala %}
 </div>
 
 <div data-lang="java" markdown="1">
@@ -391,22 +277,7 @@ created from a `JavaRDD<Vector>` instance.  Then we can compute its column summa
 
 Refer to the [`RowMatrix` Java docs](api/java/org/apache/spark/mllib/linalg/distributed/RowMatrix.html) for details on the API.
 
-{% highlight java %}
-import org.apache.spark.api.java.JavaRDD;
-import org.apache.spark.mllib.linalg.Vector;
-import org.apache.spark.mllib.linalg.distributed.RowMatrix;
-
-JavaRDD<Vector> rows = ... // a JavaRDD of local vectors
-// Create a RowMatrix from an JavaRDD<Vector>.
-RowMatrix mat = new RowMatrix(rows.rdd());
-
-// Get its size.
-long m = mat.numRows();
-long n = mat.numCols();
-
-// QR decomposition 
-QRDecomposition<RowMatrix, Matrix> result = mat.tallSkinnyQR(true);
-{% endhighlight %}
+{% include_example java/org/apache/spark/examples/mllib/JavaRowMatrixExample.java %}
 </div>
 
 <div data-lang="python" markdown="1">
@@ -416,22 +287,7 @@ created from an `RDD` of vectors.
 
 Refer to the [`RowMatrix` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.linalg.distributed.RowMatrix) for more details on the API.
 
-{% highlight python %}
-from pyspark.mllib.linalg.distributed import RowMatrix
-
-# Create an RDD of vectors.
-rows = sc.parallelize([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]])
-
-# Create a RowMatrix from an RDD of vectors.
-mat = RowMatrix(rows)
-
-# Get its size.
-m = mat.numRows()  # 4
-n = mat.numCols()  # 3
-
-# Get the rows as an RDD of vectors again.
-rowsRDD = mat.rows
-{% endhighlight %}
+{% include_example python/mllib/row_matrix_example.py %}
 </div>
 
 </div>
@@ -454,20 +310,7 @@ its row indices.
 
 Refer to the [`IndexedRowMatrix` Scala docs](api/scala/index.html#org.apache.spark.mllib.linalg.distributed.IndexedRowMatrix) for details on the API.
 
-{% highlight scala %}
-import org.apache.spark.mllib.linalg.distributed.{IndexedRow, IndexedRowMatrix, RowMatrix}
-
-val rows: RDD[IndexedRow] = ... // an RDD of indexed rows
-// Create an IndexedRowMatrix from an RDD[IndexedRow].
-val mat: IndexedRowMatrix = new IndexedRowMatrix(rows)
-
-// Get its size.
-val m = mat.numRows()
-val n = mat.numCols()
-
-// Drop its row indices.
-val rowMat: RowMatrix = mat.toRowMatrix()
-{% endhighlight %}
+{% include_example scala/org/apache/spark/examples/mllib/IndexedRowMatrixExample.scala %}
 </div>
 
 <div data-lang="java" markdown="1">
@@ -481,23 +324,7 @@ its row indices.
 
 Refer to the [`IndexedRowMatrix` Java docs](api/java/org/apache/spark/mllib/linalg/distributed/IndexedRowMatrix.html) for details on the API.
 
-{% highlight java %}
-import org.apache.spark.api.java.JavaRDD;
-import org.apache.spark.mllib.linalg.distributed.IndexedRow;
-import org.apache.spark.mllib.linalg.distributed.IndexedRowMatrix;
-import org.apache.spark.mllib.linalg.distributed.RowMatrix;
-
-JavaRDD<IndexedRow> rows = ... // a JavaRDD of indexed rows
-// Create an IndexedRowMatrix from a JavaRDD<IndexedRow>.
-IndexedRowMatrix mat = new IndexedRowMatrix(rows.rdd());
-
-// Get its size.
-long m = mat.numRows();
-long n = mat.numCols();
-
-// Drop its row indices.
-RowMatrix rowMat = mat.toRowMatrix();
-{% endhighlight %}
+{% include_example java/org/apache/spark/examples/mllib/JavaIndexedRowMatrixExample.java %}
 </div>
 
 <div data-lang="python" markdown="1">
@@ -510,38 +337,7 @@ its row indices.
 
 Refer to the [`IndexedRowMatrix` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.linalg.distributed.IndexedRowMatrix) for more details on the API.
 
-{% highlight python %}
-from pyspark.mllib.linalg.distributed import IndexedRow, IndexedRowMatrix
-
-# Create an RDD of indexed rows.
-#   - This can be done explicitly with the IndexedRow class:
-indexedRows = sc.parallelize([IndexedRow(0, [1, 2, 3]), 
-                              IndexedRow(1, [4, 5, 6]), 
-                              IndexedRow(2, [7, 8, 9]), 
-                              IndexedRow(3, [10, 11, 12])])
-#   - or by using (long, vector) tuples:
-indexedRows = sc.parallelize([(0, [1, 2, 3]), (1, [4, 5, 6]), 
-                              (2, [7, 8, 9]), (3, [10, 11, 12])])
-
-# Create an IndexedRowMatrix from an RDD of IndexedRows.
-mat = IndexedRowMatrix(indexedRows)
-
-# Get its size.
-m = mat.numRows()  # 4
-n = mat.numCols()  # 3
-
-# Get the rows as an RDD of IndexedRows.
-rowsRDD = mat.rows
-
-# Convert to a RowMatrix by dropping the row indices.
-rowMat = mat.toRowMatrix()
-
-# Convert to a CoordinateMatrix.
-coordinateMat = mat.toCoordinateMatrix()
-
-# Convert to a BlockMatrix.
-blockMat = mat.toBlockMatrix()
-{% endhighlight %}
+{% include_example python/mllib/indexed_row_matrix_example.py %}
 </div>
 
 </div>
@@ -566,20 +362,7 @@ with sparse rows by calling `toIndexedRowMatrix`.  Other computations for
 
 Refer to the [`CoordinateMatrix` Scala docs](api/scala/index.html#org.apache.spark.mllib.linalg.distributed.CoordinateMatrix) for details on the API.
 
-{% highlight scala %}
-import org.apache.spark.mllib.linalg.distributed.{CoordinateMatrix, MatrixEntry}
-
-val entries: RDD[MatrixEntry] = ... // an RDD of matrix entries
-// Create a CoordinateMatrix from an RDD[MatrixEntry].
-val mat: CoordinateMatrix = new CoordinateMatrix(entries)
-
-// Get its size.
-val m = mat.numRows()
-val n = mat.numCols()
-
-// Convert it to an IndexRowMatrix whose rows are sparse vectors.
-val indexedRowMatrix = mat.toIndexedRowMatrix()
-{% endhighlight %}
+{% include_example scala/org/apache/spark/examples/mllib/CoordinateMatrixExample.scala %}
 </div>
 
 <div data-lang="java" markdown="1">
@@ -594,23 +377,7 @@ with sparse rows by calling `toIndexedRowMatrix`. Other computations for
 
 Refer to the [`CoordinateMatrix` Java docs](api/java/org/apache/spark/mllib/linalg/distributed/CoordinateMatrix.html) for details on the API.
 
-{% highlight java %}
-import org.apache.spark.api.java.JavaRDD;
-import org.apache.spark.mllib.linalg.distributed.CoordinateMatrix;
-import org.apache.spark.mllib.linalg.distributed.IndexedRowMatrix;
-import org.apache.spark.mllib.linalg.distributed.MatrixEntry;
-
-JavaRDD<MatrixEntry> entries = ... // a JavaRDD of matrix entries
-// Create a CoordinateMatrix from a JavaRDD<MatrixEntry>.
-CoordinateMatrix mat = new CoordinateMatrix(entries.rdd());
-
-// Get its size.
-long m = mat.numRows();
-long n = mat.numCols();
-
-// Convert it to an IndexRowMatrix whose rows are sparse vectors.
-IndexedRowMatrix indexedRowMatrix = mat.toIndexedRowMatrix();
-{% endhighlight %}
+{% include_example java/org/apache/spark/examples/mllib/JavaCoordinateMatrixExample.java %}
 </div>
 
 <div data-lang="python" markdown="1">
@@ -623,34 +390,7 @@ calling `toRowMatrix`, or to an `IndexedRowMatrix` with sparse rows by calling `
 
 Refer to the [`CoordinateMatrix` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.linalg.distributed.CoordinateMatrix) for more details on the API.
 
-{% highlight python %}
-from pyspark.mllib.linalg.distributed import CoordinateMatrix, MatrixEntry
-
-# Create an RDD of coordinate entries.
-#   - This can be done explicitly with the MatrixEntry class:
-entries = sc.parallelize([MatrixEntry(0, 0, 1.2), MatrixEntry(1, 0, 2.1), MatrixEntry(6, 1, 3.7)])
-#   - or using (long, long, float) tuples:
-entries = sc.parallelize([(0, 0, 1.2), (1, 0, 2.1), (2, 1, 3.7)])
-
-# Create an CoordinateMatrix from an RDD of MatrixEntries.
-mat = CoordinateMatrix(entries)
-
-# Get its size.
-m = mat.numRows()  # 3
-n = mat.numCols()  # 2
-
-# Get the entries as an RDD of MatrixEntries.
-entriesRDD = mat.entries
-
-# Convert to a RowMatrix.
-rowMat = mat.toRowMatrix()
-
-# Convert to an IndexedRowMatrix.
-indexedRowMat = mat.toIndexedRowMatrix()
-
-# Convert to a BlockMatrix.
-blockMat = mat.toBlockMatrix()
-{% endhighlight %}
+{% include_example python/mllib/coordinate_matrix_example.py %}
 </div>
 
 </div>
@@ -674,22 +414,7 @@ Users may change the block size by supplying the values through `toBlockMatrix(r
 
 Refer to the [`BlockMatrix` Scala docs](api/scala/index.html#org.apache.spark.mllib.linalg.distributed.BlockMatrix) for details on the API.
 
-{% highlight scala %}
-import org.apache.spark.mllib.linalg.distributed.{BlockMatrix, CoordinateMatrix, MatrixEntry}
-
-val entries: RDD[MatrixEntry] = ... // an RDD of (i, j, v) matrix entries
-// Create a CoordinateMatrix from an RDD[MatrixEntry].
-val coordMat: CoordinateMatrix = new CoordinateMatrix(entries)
-// Transform the CoordinateMatrix to a BlockMatrix
-val matA: BlockMatrix = coordMat.toBlockMatrix().cache()
-
-// Validate whether the BlockMatrix is set up properly. Throws an Exception when it is not valid.
-// Nothing happens if it is valid.
-matA.validate()
-
-// Calculate A^T A.
-val ata = matA.transpose.multiply(matA)
-{% endhighlight %}
+{% include_example scala/org/apache/spark/examples/mllib/BlockMatrixExample.scala %}
 </div>
 
 <div data-lang="java" markdown="1">
@@ -701,25 +426,7 @@ Users may change the block size by supplying the values through `toBlockMatrix(r
 
 Refer to the [`BlockMatrix` Java docs](api/java/org/apache/spark/mllib/linalg/distributed/BlockMatrix.html) for details on the API.
 
-{% highlight java %}
-import org.apache.spark.api.java.JavaRDD;
-import org.apache.spark.mllib.linalg.distributed.BlockMatrix;
-import org.apache.spark.mllib.linalg.distributed.CoordinateMatrix;
-import org.apache.spark.mllib.linalg.distributed.IndexedRowMatrix;
-
-JavaRDD<MatrixEntry> entries = ... // a JavaRDD of (i, j, v) Matrix Entries
-// Create a CoordinateMatrix from a JavaRDD<MatrixEntry>.
-CoordinateMatrix coordMat = new CoordinateMatrix(entries.rdd());
-// Transform the CoordinateMatrix to a BlockMatrix
-BlockMatrix matA = coordMat.toBlockMatrix().cache();
-
-// Validate whether the BlockMatrix is set up properly. Throws an Exception when it is not valid.
-// Nothing happens if it is valid.
-matA.validate();
-
-// Calculate A^T A.
-BlockMatrix ata = matA.transpose().multiply(matA);
-{% endhighlight %}
+{% include_example java/org/apache/spark/examples/mllib/JavaBlockMatrixExample.java %}
 </div>
 
 <div data-lang="python" markdown="1">
@@ -730,32 +437,6 @@ can be created from an `RDD` of sub-matrix blocks, where a sub-matrix block is a
 
 Refer to the [`BlockMatrix` Python docs](api/python/pyspark.mllib.html#pyspark.mllib.linalg.distributed.BlockMatrix) for more details on the API.
 
-{% highlight python %}
-from pyspark.mllib.linalg import Matrices
-from pyspark.mllib.linalg.distributed import BlockMatrix
-
-# Create an RDD of sub-matrix blocks.
-blocks = sc.parallelize([((0, 0), Matrices.dense(3, 2, [1, 2, 3, 4, 5, 6])), 
-                         ((1, 0), Matrices.dense(3, 2, [7, 8, 9, 10, 11, 12]))])
-
-# Create a BlockMatrix from an RDD of sub-matrix blocks.
-mat = BlockMatrix(blocks, 3, 2)
-
-# Get its size.
-m = mat.numRows() # 6
-n = mat.numCols() # 2
-
-# Get the blocks as an RDD of sub-matrix blocks.
-blocksRDD = mat.blocks
-
-# Convert to a LocalMatrix.
-localMat = mat.toLocalMatrix()
-
-# Convert to an IndexedRowMatrix.
-indexedRowMat = mat.toIndexedRowMatrix()
-
-# Convert to a CoordinateMatrix.
-coordinateMat = mat.toCoordinateMatrix()
-{% endhighlight %}
+{% include_example python/mllib/block_matrix_example.py %}
 </div>
 </div>

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaBlockMatrixExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaBlockMatrixExample.java
@@ -17,16 +17,16 @@
 
 package org.apache.spark.examples.mllib;
 
-import java.util.Arrays;
-
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.mllib.linalg.distributed.MatrixEntry;
 // $example on$
+import java.util.Arrays;
+
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.mllib.linalg.distributed.BlockMatrix;
 import org.apache.spark.mllib.linalg.distributed.CoordinateMatrix;
 // $example off$
-import org.apache.spark.mllib.linalg.distributed.MatrixEntry;
 
 public class JavaBlockMatrixExample {
   public static void main(String[] args) {
@@ -34,11 +34,11 @@ public class JavaBlockMatrixExample {
     SparkConf conf = new SparkConf().setAppName("JavaBlockMatrixExample");
     JavaSparkContext jsc = new JavaSparkContext(conf);
 
+    // $example on$
     MatrixEntry me1 = new MatrixEntry(0, 0, 1.2);
     MatrixEntry me2 = new MatrixEntry(1, 0, 2.1);
     MatrixEntry me3 = new MatrixEntry(6, 1, 3.7);
 
-    // $example on$
     // a JavaRDD of (i, j, v) Matrix Entries
     JavaRDD<MatrixEntry> entries = jsc.parallelize(Arrays.asList(me1, me2, me3));
 

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaBlockMatrixExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaBlockMatrixExample.java
@@ -19,47 +19,43 @@ package org.apache.spark.examples.mllib;
 
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
-import org.apache.spark.mllib.linalg.Vector;
-import org.apache.spark.mllib.linalg.Vectors;
 // $example on$
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.mllib.linalg.distributed.BlockMatrix;
 import org.apache.spark.mllib.linalg.distributed.CoordinateMatrix;
-import org.apache.spark.mllib.linalg.distributed.IndexedRowMatrix;
 // $example off$
-import org.apache.spark.mllib.linalg.Matrix;
 import org.apache.spark.mllib.linalg.distributed.MatrixEntry;
 
 import java.util.Arrays;
 
 public class JavaBlockMatrixExample {
-    public static void main(String[] args) {
+  public static void main(String[] args) {
 
-        SparkConf conf = new SparkConf().setAppName("JavaBlockMatrixExample")
-                .setMaster("local[*]");
-        JavaSparkContext jsc = new JavaSparkContext(conf);
+    SparkConf conf = new SparkConf().setAppName("JavaBlockMatrixExample");
+    JavaSparkContext jsc = new JavaSparkContext(conf);
 
-        MatrixEntry me1 = new MatrixEntry(0, 0, 1.2);
-        MatrixEntry me2 = new MatrixEntry(1, 0, 2.1);
-        MatrixEntry me3 = new MatrixEntry(6, 1, 3.7);
+    MatrixEntry me1 = new MatrixEntry(0, 0, 1.2);
+    MatrixEntry me2 = new MatrixEntry(1, 0, 2.1);
+    MatrixEntry me3 = new MatrixEntry(6, 1, 3.7);
 
-        // $example on$
-        JavaRDD<MatrixEntry> entries = jsc.parallelize(Arrays.asList(me1, me2, me3)); // a JavaRDD of (i, j, v) Matrix Entries
+    // $example on$
+    // a JavaRDD of (i, j, v) Matrix Entries
+    JavaRDD<MatrixEntry> entries = jsc.parallelize(Arrays.asList(me1, me2, me3));
 
-        // Create a CoordinateMatrix from a JavaRDD<MatrixEntry>.
-        CoordinateMatrix coordMat = new CoordinateMatrix(entries.rdd());
-        // Transform the CoordinateMatrix to a BlockMatrix
-        BlockMatrix matA = coordMat.toBlockMatrix().cache();
+    // Create a CoordinateMatrix from a JavaRDD<MatrixEntry>.
+    CoordinateMatrix coordMat = new CoordinateMatrix(entries.rdd());
+    // Transform the CoordinateMatrix to a BlockMatrix
+    BlockMatrix matA = coordMat.toBlockMatrix().cache();
 
-        // Validate whether the BlockMatrix is set up properly. Throws an Exception when it is not valid.
-        // Nothing happens if it is valid.
-        matA.validate();
+    // Validate whether the BlockMatrix is set up properly. Throws an Exception when it is not valid
+    // Nothing happens if it is valid.
+    matA.validate();
 
-        // Calculate A^T A.
-        BlockMatrix ata = matA.transpose().multiply(matA);
-        // $example off$
+    // Calculate A^T A.
+    BlockMatrix ata = matA.transpose().multiply(matA);
+    // $example off$
 
-        jsc.stop();
+    jsc.stop();
 
-    }
+  }
 }

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaBlockMatrixExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaBlockMatrixExample.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.examples.mllib;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.mllib.linalg.Vector;
+import org.apache.spark.mllib.linalg.Vectors;
+// $example on$
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.mllib.linalg.distributed.BlockMatrix;
+import org.apache.spark.mllib.linalg.distributed.CoordinateMatrix;
+import org.apache.spark.mllib.linalg.distributed.IndexedRowMatrix;
+// $example off$
+import org.apache.spark.mllib.linalg.Matrix;
+import org.apache.spark.mllib.linalg.distributed.MatrixEntry;
+
+import java.util.Arrays;
+
+public class JavaBlockMatrixExample {
+    public static void main(String[] args) {
+
+        SparkConf conf = new SparkConf().setAppName("JavaIndexedRowMatrixExample")
+                .setMaster("local[*]");
+        JavaSparkContext jsc = new JavaSparkContext(conf);
+
+        MatrixEntry me1 = new MatrixEntry(0, 0, 1.2);
+        MatrixEntry me2 = new MatrixEntry(1, 0, 2.1);
+        MatrixEntry me3 = new MatrixEntry(6, 1, 3.7);
+
+        // $example on$
+        JavaRDD<MatrixEntry> entries = jsc.parallelize(Arrays.asList(me1, me2, me3)); // a JavaRDD of (i, j, v) Matrix Entries
+
+        // Create a CoordinateMatrix from a JavaRDD<MatrixEntry>.
+        CoordinateMatrix coordMat = new CoordinateMatrix(entries.rdd());
+        // Transform the CoordinateMatrix to a BlockMatrix
+        BlockMatrix matA = coordMat.toBlockMatrix().cache();
+
+        // Validate whether the BlockMatrix is set up properly. Throws an Exception when it is not valid.
+        // Nothing happens if it is valid.
+        matA.validate();
+
+        // Calculate A^T A.
+        BlockMatrix ata = matA.transpose().multiply(matA);
+        // $example off$
+
+        jsc.stop();
+
+    }
+}

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaBlockMatrixExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaBlockMatrixExample.java
@@ -35,7 +35,7 @@ import java.util.Arrays;
 public class JavaBlockMatrixExample {
     public static void main(String[] args) {
 
-        SparkConf conf = new SparkConf().setAppName("JavaIndexedRowMatrixExample")
+        SparkConf conf = new SparkConf().setAppName("JavaBlockMatrixExample")
                 .setMaster("local[*]");
         JavaSparkContext jsc = new JavaSparkContext(conf);
 

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaBlockMatrixExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaBlockMatrixExample.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.examples.mllib;
 
+import java.util.Arrays;
+
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
 // $example on$
@@ -25,8 +27,6 @@ import org.apache.spark.mllib.linalg.distributed.BlockMatrix;
 import org.apache.spark.mllib.linalg.distributed.CoordinateMatrix;
 // $example off$
 import org.apache.spark.mllib.linalg.distributed.MatrixEntry;
-
-import java.util.Arrays;
 
 public class JavaBlockMatrixExample {
   public static void main(String[] args) {

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaCoordinateMatrixExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaCoordinateMatrixExample.java
@@ -17,11 +17,11 @@
 
 package org.apache.spark.examples.mllib;
 
-import java.util.Arrays;
-
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
 // $example on$
+import java.util.Arrays;
+
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.mllib.linalg.distributed.CoordinateMatrix;
 import org.apache.spark.mllib.linalg.distributed.IndexedRowMatrix;
@@ -34,11 +34,11 @@ public class JavaCoordinateMatrixExample {
     SparkConf conf = new SparkConf().setAppName("JavaCoordinateMatrixExample");
     JavaSparkContext jsc = new JavaSparkContext(conf);
 
+    // $example on$
     MatrixEntry me1 = new MatrixEntry(0, 0, 1.2);
     MatrixEntry me2 = new MatrixEntry(1, 0, 2.1);
     MatrixEntry me3 = new MatrixEntry(6, 1, 3.7);
 
-    // $example on$
     // a JavaRDD of matrix entries
     JavaRDD<MatrixEntry> entries = jsc.parallelize(Arrays.asList(me1, me2, me3));
     // Create a CoordinateMatrix from a JavaRDD<MatrixEntry>.

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaCoordinateMatrixExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaCoordinateMatrixExample.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.examples.mllib;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.mllib.linalg.Vector;
+import org.apache.spark.mllib.linalg.Vectors;
+// $example on$
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.mllib.linalg.distributed.CoordinateMatrix;
+import org.apache.spark.mllib.linalg.distributed.IndexedRowMatrix;
+import org.apache.spark.mllib.linalg.distributed.MatrixEntry;
+// $example off$
+import org.apache.spark.mllib.linalg.Matrix;
+
+import java.util.Arrays;
+
+public class JavaCoordinateMatrixExample {
+    public static void main(String[] args) {
+
+        SparkConf conf = new SparkConf().setAppName("JavaCoordinateMatrixExample")
+                .setMaster("local[*]");
+        JavaSparkContext jsc = new JavaSparkContext(conf);
+
+        MatrixEntry me1 = new MatrixEntry(0, 0, 1.2);
+        MatrixEntry me2 = new MatrixEntry(1, 0, 2.1);
+        MatrixEntry me3 = new MatrixEntry(6, 1, 3.7);
+
+        // $example on$
+        // a JavaRDD of matrix entries
+        JavaRDD<MatrixEntry> entries = jsc.parallelize(Arrays.asList(me1, me2, me3));
+        // Create a CoordinateMatrix from a JavaRDD<MatrixEntry>.
+        CoordinateMatrix mat = new CoordinateMatrix(entries.rdd());
+
+        // Get its size.
+        long m = mat.numRows();
+        long n = mat.numCols();
+
+        // Convert it to an IndexRowMatrix whose rows are sparse vectors.
+        IndexedRowMatrix indexedRowMatrix = mat.toIndexedRowMatrix();
+        // $example off$
+
+        jsc.stop();
+
+    }
+}

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaCoordinateMatrixExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaCoordinateMatrixExample.java
@@ -19,44 +19,39 @@ package org.apache.spark.examples.mllib;
 
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
-import org.apache.spark.mllib.linalg.Vector;
-import org.apache.spark.mllib.linalg.Vectors;
 // $example on$
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.mllib.linalg.distributed.CoordinateMatrix;
 import org.apache.spark.mllib.linalg.distributed.IndexedRowMatrix;
 import org.apache.spark.mllib.linalg.distributed.MatrixEntry;
 // $example off$
-import org.apache.spark.mllib.linalg.Matrix;
-
 import java.util.Arrays;
 
 public class JavaCoordinateMatrixExample {
-    public static void main(String[] args) {
+  public static void main(String[] args) {
 
-        SparkConf conf = new SparkConf().setAppName("JavaCoordinateMatrixExample")
-                .setMaster("local[*]");
-        JavaSparkContext jsc = new JavaSparkContext(conf);
+    SparkConf conf = new SparkConf().setAppName("JavaCoordinateMatrixExample");
+    JavaSparkContext jsc = new JavaSparkContext(conf);
 
-        MatrixEntry me1 = new MatrixEntry(0, 0, 1.2);
-        MatrixEntry me2 = new MatrixEntry(1, 0, 2.1);
-        MatrixEntry me3 = new MatrixEntry(6, 1, 3.7);
+    MatrixEntry me1 = new MatrixEntry(0, 0, 1.2);
+    MatrixEntry me2 = new MatrixEntry(1, 0, 2.1);
+    MatrixEntry me3 = new MatrixEntry(6, 1, 3.7);
 
-        // $example on$
-        // a JavaRDD of matrix entries
-        JavaRDD<MatrixEntry> entries = jsc.parallelize(Arrays.asList(me1, me2, me3));
-        // Create a CoordinateMatrix from a JavaRDD<MatrixEntry>.
-        CoordinateMatrix mat = new CoordinateMatrix(entries.rdd());
+    // $example on$
+    // a JavaRDD of matrix entries
+    JavaRDD<MatrixEntry> entries = jsc.parallelize(Arrays.asList(me1, me2, me3));
+    // Create a CoordinateMatrix from a JavaRDD<MatrixEntry>.
+    CoordinateMatrix mat = new CoordinateMatrix(entries.rdd());
 
-        // Get its size.
-        long m = mat.numRows();
-        long n = mat.numCols();
+    // Get its size.
+    long m = mat.numRows();
+    long n = mat.numCols();
 
-        // Convert it to an IndexRowMatrix whose rows are sparse vectors.
-        IndexedRowMatrix indexedRowMatrix = mat.toIndexedRowMatrix();
-        // $example off$
+    // Convert it to an IndexRowMatrix whose rows are sparse vectors.
+    IndexedRowMatrix indexedRowMatrix = mat.toIndexedRowMatrix();
+    // $example off$
 
-        jsc.stop();
+    jsc.stop();
 
-    }
+  }
 }

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaCoordinateMatrixExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaCoordinateMatrixExample.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.examples.mllib;
 
+import java.util.Arrays;
+
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
 // $example on$
@@ -25,7 +27,6 @@ import org.apache.spark.mllib.linalg.distributed.CoordinateMatrix;
 import org.apache.spark.mllib.linalg.distributed.IndexedRowMatrix;
 import org.apache.spark.mllib.linalg.distributed.MatrixEntry;
 // $example off$
-import java.util.Arrays;
 
 public class JavaCoordinateMatrixExample {
   public static void main(String[] args) {
@@ -52,6 +53,5 @@ public class JavaCoordinateMatrixExample {
     // $example off$
 
     jsc.stop();
-
   }
 }

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaIndexedRowMatrixExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaIndexedRowMatrixExample.java
@@ -17,16 +17,16 @@
 
 package org.apache.spark.examples.mllib;
 
-import java.util.Arrays;
-
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
-import org.apache.spark.mllib.linalg.Vectors;
 // $example on$
+import java.util.Arrays;
+
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.mllib.linalg.distributed.IndexedRow;
 import org.apache.spark.mllib.linalg.distributed.IndexedRowMatrix;
 import org.apache.spark.mllib.linalg.distributed.RowMatrix;
+import org.apache.spark.mllib.linalg.Vectors;
 // $example off$
 
 public class JavaIndexedRowMatrixExample {
@@ -35,13 +35,14 @@ public class JavaIndexedRowMatrixExample {
     SparkConf conf = new SparkConf().setAppName("JavaIndexedRowMatrixExample");
     JavaSparkContext jsc = new JavaSparkContext(conf);
 
-    IndexedRow r1 = new IndexedRow(1, Vectors.dense(1.0, 10.0, 100.0));
-    IndexedRow r2 = new IndexedRow(2, Vectors.dense(2.0, 20.0, 200.0));
-    IndexedRow r3 = new IndexedRow(3, Vectors.dense(5.0, 33.0, 366.0));
-
     // $example on$
+    IndexedRow r0 = new IndexedRow(0, Vectors.dense(1, 2, 3));
+    IndexedRow r1 = new IndexedRow(1, Vectors.dense(4, 5, 6));
+    IndexedRow r2 = new IndexedRow(2, Vectors.dense(7, 8, 9));
+    IndexedRow r3 = new IndexedRow(3, Vectors.dense(10, 11, 12));
+
     // a JavaRDD of indexed rows
-    JavaRDD<IndexedRow> rows = jsc.parallelize(Arrays.asList(r1, r2, r3));
+    JavaRDD<IndexedRow> rows = jsc.parallelize(Arrays.asList(r0, r1, r2, r3));
 
     // Create an IndexedRowMatrix from a JavaRDD<IndexedRow>.
     IndexedRowMatrix mat = new IndexedRowMatrix(rows.rdd());

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaIndexedRowMatrixExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaIndexedRowMatrixExample.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.examples.mllib;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.mllib.linalg.Vector;
+import org.apache.spark.mllib.linalg.Vectors;
+// $example on$
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.mllib.linalg.distributed.IndexedRow;
+import org.apache.spark.mllib.linalg.distributed.IndexedRowMatrix;
+import org.apache.spark.mllib.linalg.distributed.RowMatrix;
+// $example off$
+import org.apache.spark.mllib.linalg.Matrix;
+
+import java.util.Arrays;
+
+public class JavaIndexedRowMatrixExample {
+    public static void main(String[] args) {
+
+        SparkConf conf = new SparkConf().setAppName("JavaIndexedRowMatrixExample")
+                .setMaster("local[*]");
+        JavaSparkContext jsc = new JavaSparkContext(conf);
+
+        IndexedRow r1 = new IndexedRow(1, Vectors.dense(1.0, 10.0, 100.0));
+        IndexedRow r2 = new IndexedRow(2, Vectors.dense(2.0, 20.0, 200.0));
+        IndexedRow r3 = new IndexedRow(3, Vectors.dense(5.0, 33.0, 366.0));
+
+        // $example on$
+        // a JavaRDD of indexed rows
+        JavaRDD<IndexedRow> rows = jsc.parallelize(Arrays.asList(r1, r2, r3));
+
+        // Create an IndexedRowMatrix from a JavaRDD<IndexedRow>.
+        IndexedRowMatrix mat = new IndexedRowMatrix(rows.rdd());
+
+        // Get its size.
+        long m = mat.numRows();
+        long n = mat.numCols();
+
+        // Drop its row indices.
+        RowMatrix rowMat = mat.toRowMatrix();
+
+        // $example off$
+
+        jsc.stop();
+
+    }
+}

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaIndexedRowMatrixExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaIndexedRowMatrixExample.java
@@ -52,7 +52,6 @@ public class JavaIndexedRowMatrixExample {
 
     // Drop its row indices.
     RowMatrix rowMat = mat.toRowMatrix();
-
     // $example off$
 
     jsc.stop();

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaIndexedRowMatrixExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaIndexedRowMatrixExample.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.examples.mllib;
 
+import java.util.Arrays;
+
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.mllib.linalg.Vectors;
@@ -26,8 +28,6 @@ import org.apache.spark.mllib.linalg.distributed.IndexedRow;
 import org.apache.spark.mllib.linalg.distributed.IndexedRowMatrix;
 import org.apache.spark.mllib.linalg.distributed.RowMatrix;
 // $example off$
-
-import java.util.Arrays;
 
 public class JavaIndexedRowMatrixExample {
   public static void main(String[] args) {
@@ -55,6 +55,5 @@ public class JavaIndexedRowMatrixExample {
     // $example off$
 
     jsc.stop();
-
   }
 }

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaIndexedRowMatrixExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaIndexedRowMatrixExample.java
@@ -19,7 +19,6 @@ package org.apache.spark.examples.mllib;
 
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
-import org.apache.spark.mllib.linalg.Vector;
 import org.apache.spark.mllib.linalg.Vectors;
 // $example on$
 import org.apache.spark.api.java.JavaRDD;
@@ -27,38 +26,36 @@ import org.apache.spark.mllib.linalg.distributed.IndexedRow;
 import org.apache.spark.mllib.linalg.distributed.IndexedRowMatrix;
 import org.apache.spark.mllib.linalg.distributed.RowMatrix;
 // $example off$
-import org.apache.spark.mllib.linalg.Matrix;
 
 import java.util.Arrays;
 
 public class JavaIndexedRowMatrixExample {
-    public static void main(String[] args) {
+  public static void main(String[] args) {
 
-        SparkConf conf = new SparkConf().setAppName("JavaIndexedRowMatrixExample")
-                .setMaster("local[*]");
-        JavaSparkContext jsc = new JavaSparkContext(conf);
+    SparkConf conf = new SparkConf().setAppName("JavaIndexedRowMatrixExample");
+    JavaSparkContext jsc = new JavaSparkContext(conf);
 
-        IndexedRow r1 = new IndexedRow(1, Vectors.dense(1.0, 10.0, 100.0));
-        IndexedRow r2 = new IndexedRow(2, Vectors.dense(2.0, 20.0, 200.0));
-        IndexedRow r3 = new IndexedRow(3, Vectors.dense(5.0, 33.0, 366.0));
+    IndexedRow r1 = new IndexedRow(1, Vectors.dense(1.0, 10.0, 100.0));
+    IndexedRow r2 = new IndexedRow(2, Vectors.dense(2.0, 20.0, 200.0));
+    IndexedRow r3 = new IndexedRow(3, Vectors.dense(5.0, 33.0, 366.0));
 
-        // $example on$
-        // a JavaRDD of indexed rows
-        JavaRDD<IndexedRow> rows = jsc.parallelize(Arrays.asList(r1, r2, r3));
+    // $example on$
+    // a JavaRDD of indexed rows
+    JavaRDD<IndexedRow> rows = jsc.parallelize(Arrays.asList(r1, r2, r3));
 
-        // Create an IndexedRowMatrix from a JavaRDD<IndexedRow>.
-        IndexedRowMatrix mat = new IndexedRowMatrix(rows.rdd());
+    // Create an IndexedRowMatrix from a JavaRDD<IndexedRow>.
+    IndexedRowMatrix mat = new IndexedRowMatrix(rows.rdd());
 
-        // Get its size.
-        long m = mat.numRows();
-        long n = mat.numCols();
+    // Get its size.
+    long m = mat.numRows();
+    long n = mat.numCols();
 
-        // Drop its row indices.
-        RowMatrix rowMat = mat.toRowMatrix();
+    // Drop its row indices.
+    RowMatrix rowMat = mat.toRowMatrix();
 
-        // $example off$
+    // $example off$
 
-        jsc.stop();
+    jsc.stop();
 
-    }
+  }
 }

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaLabeledPointExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaLabeledPointExample.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.examples.mllib;
+
+// $example on$
+import org.apache.spark.mllib.linalg.Vectors;
+import org.apache.spark.mllib.regression.LabeledPoint;
+// $example off$
+
+public class JavaLabeledPointExample {
+    public static void main(String[] args) {
+
+        // $example on$
+        // Create a labeled point with a positive label and a dense feature vector.
+        LabeledPoint pos = new LabeledPoint(1.0, Vectors.dense(1.0, 0.0, 3.0));
+
+        // Create a labeled point with a negative label and a sparse feature vector.
+        LabeledPoint neg = new LabeledPoint(
+                0.0, Vectors.sparse(3, new int[] {0, 2}, new double[] {1.0, 3.0}));
+
+        // $example off$
+
+    }
+}

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaLabeledPointExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaLabeledPointExample.java
@@ -30,7 +30,7 @@ public class JavaLabeledPointExample {
 
     // Create a labeled point with a negative label and a sparse feature vector.
     LabeledPoint neg = new LabeledPoint(
-            0.0, Vectors.sparse(3, new int[] {0, 2}, new double[] {1.0, 3.0}));
+      0.0, Vectors.sparse(3, new int[] {0, 2}, new double[] {1.0, 3.0}));
     // $example off$
   }
 }

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaLabeledPointExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaLabeledPointExample.java
@@ -23,17 +23,14 @@ import org.apache.spark.mllib.regression.LabeledPoint;
 // $example off$
 
 public class JavaLabeledPointExample {
-    public static void main(String[] args) {
+  public static void main(String[] args) {
+    // $example on$
+    // Create a labeled point with a positive label and a dense feature vector.
+    LabeledPoint pos = new LabeledPoint(1.0, Vectors.dense(1.0, 0.0, 3.0));
 
-        // $example on$
-        // Create a labeled point with a positive label and a dense feature vector.
-        LabeledPoint pos = new LabeledPoint(1.0, Vectors.dense(1.0, 0.0, 3.0));
-
-        // Create a labeled point with a negative label and a sparse feature vector.
-        LabeledPoint neg = new LabeledPoint(
-                0.0, Vectors.sparse(3, new int[] {0, 2}, new double[] {1.0, 3.0}));
-
-        // $example off$
-
-    }
+    // Create a labeled point with a negative label and a sparse feature vector.
+    LabeledPoint neg = new LabeledPoint(
+            0.0, Vectors.sparse(3, new int[] {0, 2}, new double[] {1.0, 3.0}));
+    // $example off$
+  }
 }

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaLabeledPointSparseDataExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaLabeledPointSparseDataExample.java
@@ -26,18 +26,17 @@ import org.apache.spark.api.java.JavaRDD;
 // $example off$
 
 public class JavaLabeledPointSparseDataExample {
-    public static void main(String[] args) {
+  public static void main(String[] args) {
 
-        SparkConf conf = new SparkConf().setAppName("JavaLabeledPointSparseDataExample")
-                .setMaster("local[*]");
-        JavaSparkContext jsc = new JavaSparkContext(conf);
+    SparkConf conf = new SparkConf().setAppName("JavaLabeledPointSparseDataExample");
+    JavaSparkContext jsc = new JavaSparkContext(conf);
 
-        // $example on$
-        JavaRDD<LabeledPoint> examples =
-                MLUtils.loadLibSVMFile(jsc.sc(), "data/mllib/sample_libsvm_data.txt").toJavaRDD();
-        // $example off$
+    // $example on$
+    JavaRDD<LabeledPoint> examples =
+            MLUtils.loadLibSVMFile(jsc.sc(), "data/mllib/sample_libsvm_data.txt").toJavaRDD();
+    // $example off$
 
-        jsc.stop();
+      jsc.stop();
 
-    }
+  }
 }

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaLabeledPointSparseDataExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaLabeledPointSparseDataExample.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.examples.mllib;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaSparkContext;
+// $example on$
+import org.apache.spark.mllib.regression.LabeledPoint;
+import org.apache.spark.mllib.util.MLUtils;
+import org.apache.spark.api.java.JavaRDD;
+// $example off$
+
+public class JavaLabeledPointSparseDataExample {
+    public static void main(String[] args) {
+
+        SparkConf conf = new SparkConf().setAppName("JavaCorrelationsExample").setMaster("local[*]");
+        JavaSparkContext jsc = new JavaSparkContext(conf);
+
+        // $example on$
+        JavaRDD<LabeledPoint> examples =
+                MLUtils.loadLibSVMFile(jsc.sc(), "data/mllib/sample_libsvm_data.txt").toJavaRDD();
+        // $example off$
+
+        jsc.stop();
+
+    }
+}

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaLabeledPointSparseDataExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaLabeledPointSparseDataExample.java
@@ -28,7 +28,8 @@ import org.apache.spark.api.java.JavaRDD;
 public class JavaLabeledPointSparseDataExample {
     public static void main(String[] args) {
 
-        SparkConf conf = new SparkConf().setAppName("JavaCorrelationsExample").setMaster("local[*]");
+        SparkConf conf = new SparkConf().setAppName("JavaLabeledPointSparseDataExample")
+                .setMaster("local[*]");
         JavaSparkContext jsc = new JavaSparkContext(conf);
 
         // $example on$

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaLabeledPointSparseDataExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaLabeledPointSparseDataExample.java
@@ -33,10 +33,9 @@ public class JavaLabeledPointSparseDataExample {
 
     // $example on$
     JavaRDD<LabeledPoint> examples =
-            MLUtils.loadLibSVMFile(jsc.sc(), "data/mllib/sample_libsvm_data.txt").toJavaRDD();
+      MLUtils.loadLibSVMFile(jsc.sc(), "data/mllib/sample_libsvm_data.txt").toJavaRDD();
     // $example off$
 
       jsc.stop();
-
   }
 }

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaLocalMatrixExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaLocalMatrixExample.java
@@ -25,10 +25,10 @@ import org.apache.spark.mllib.linalg.Matrices;
 public class JavaLocalMatrixExample {
   public static void main(String[] args) {
     // $example on$
-    // Create a dense matrix ((1.0, 2.0), (3.0, 4.0), (5.0, 6.0))
+    // Create a dense matrix
     Matrix dm = Matrices.dense(3, 2, new double[] {1.0, 3.0, 5.0, 2.0, 4.0, 6.0});
 
-    // Create a sparse matrix ((9.0, 0.0), (0.0, 8.0), (0.0, 6.0))
+    // Create a sparse matrix
     Matrix sm = Matrices.sparse(
       3, 2, new int[] {0, 1, 3}, new int[] {0, 2, 1}, new double[] {9, 6, 8});
     // $example off$

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaLocalMatrixExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaLocalMatrixExample.java
@@ -24,15 +24,13 @@ import org.apache.spark.mllib.linalg.Matrices;
 
 public class JavaLocalMatrixExample {
   public static void main(String[] args) {
-
     // $example on$
     // Create a dense matrix ((1.0, 2.0), (3.0, 4.0), (5.0, 6.0))
     Matrix dm = Matrices.dense(3, 2, new double[] {1.0, 3.0, 5.0, 2.0, 4.0, 6.0});
 
     // Create a sparse matrix ((9.0, 0.0), (0.0, 8.0), (0.0, 6.0))
     Matrix sm = Matrices.sparse(
-            3, 2, new int[] {0, 1, 3}, new int[] {0, 2, 1}, new double[] {9, 6, 8});
+      3, 2, new int[] {0, 1, 3}, new int[] {0, 2, 1}, new double[] {9, 6, 8});
     // $example off$
-
   }
 }

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaLocalMatrixExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaLocalMatrixExample.java
@@ -23,16 +23,16 @@ import org.apache.spark.mllib.linalg.Matrices;
 // $example off$
 
 public class JavaLocalMatrixExample {
-    public static void main(String[] args) {
+  public static void main(String[] args) {
 
-        // $example on$
-        // Create a dense matrix ((1.0, 2.0), (3.0, 4.0), (5.0, 6.0))
-        Matrix dm = Matrices.dense(3, 2, new double[] {1.0, 3.0, 5.0, 2.0, 4.0, 6.0});
+    // $example on$
+    // Create a dense matrix ((1.0, 2.0), (3.0, 4.0), (5.0, 6.0))
+    Matrix dm = Matrices.dense(3, 2, new double[] {1.0, 3.0, 5.0, 2.0, 4.0, 6.0});
 
-        // Create a sparse matrix ((9.0, 0.0), (0.0, 8.0), (0.0, 6.0))
-        Matrix sm = Matrices.sparse(
-                3, 2, new int[] {0, 1, 3}, new int[] {0, 2, 1}, new double[] {9, 6, 8});
-        // $example off$
+    // Create a sparse matrix ((9.0, 0.0), (0.0, 8.0), (0.0, 6.0))
+    Matrix sm = Matrices.sparse(
+            3, 2, new int[] {0, 1, 3}, new int[] {0, 2, 1}, new double[] {9, 6, 8});
+    // $example off$
 
-    }
+  }
 }

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaLocalMatrixExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaLocalMatrixExample.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.examples.mllib;
+
+// $example on$
+import org.apache.spark.mllib.linalg.Matrix;
+import org.apache.spark.mllib.linalg.Matrices;
+// $example off$
+
+public class JavaLocalMatrixExample {
+    public static void main(String[] args) {
+
+        // $example on$
+        // Create a dense matrix ((1.0, 2.0), (3.0, 4.0), (5.0, 6.0))
+        Matrix dm = Matrices.dense(3, 2, new double[] {1.0, 3.0, 5.0, 2.0, 4.0, 6.0});
+
+        // Create a sparse matrix ((9.0, 0.0), (0.0, 8.0), (0.0, 6.0))
+        Matrix sm = Matrices.sparse(
+                3, 2, new int[] {0, 1, 3}, new int[] {0, 2, 1}, new double[] {9, 6, 8});
+        // $example off$
+
+    }
+}

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaLocalVectorExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaLocalVectorExample.java
@@ -25,10 +25,10 @@ import org.apache.spark.mllib.linalg.Vectors;
 public class JavaLocalVectorExample {
   public static void main(String[] args) {
     // $example on$
-    // Create a dense vector (1.0, 0.0, 3.0).
+    // Create a dense vector
     Vector dv = Vectors.dense(1.0, 0.0, 3.0);
 
-    // Create a sparse vector (1.0, 0.0, 3.0) by specifying its indices
+    // Create a sparse vector by specifying its indices
     // and values corresponding to nonzero entries.
     Vector sv = Vectors.sparse(3, new int[] {0, 2}, new double[] {1.0, 3.0});
     // $example off$

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaLocalVectorExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaLocalVectorExample.java
@@ -23,16 +23,14 @@ import org.apache.spark.mllib.linalg.Vectors;
 // $example off$
 
 public class JavaLocalVectorExample {
-    public static void main(String[] args) {
+  public static void main(String[] args) {
+    // $example on$
+    // Create a dense vector (1.0, 0.0, 3.0).
+    Vector dv = Vectors.dense(1.0, 0.0, 3.0);
 
-        // $example on$
-        // Create a dense vector (1.0, 0.0, 3.0).
-        Vector dv = Vectors.dense(1.0, 0.0, 3.0);
-
-        // Create a sparse vector (1.0, 0.0, 3.0) by specifying its indices
-        // and values corresponding to nonzero entries.
-        Vector sv = Vectors.sparse(3, new int[] {0, 2}, new double[] {1.0, 3.0});
-        // $example off$
-
-    }
+    // Create a sparse vector (1.0, 0.0, 3.0) by specifying its indices
+    // and values corresponding to nonzero entries.
+    Vector sv = Vectors.sparse(3, new int[] {0, 2}, new double[] {1.0, 3.0});
+    // $example off$
+  }
 }

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaLocalVectorExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaLocalVectorExample.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.examples.mllib;
+
+// $example on$
+import org.apache.spark.mllib.linalg.Vector;
+import org.apache.spark.mllib.linalg.Vectors;
+// $example off$
+
+public class JavaLocalVectorExample {
+    public static void main(String[] args) {
+
+        // $example on$
+        // Create a dense vector (1.0, 0.0, 3.0).
+        Vector dv = Vectors.dense(1.0, 0.0, 3.0);
+
+        // Create a sparse vector (1.0, 0.0, 3.0) by specifying its indices
+        // and values corresponding to nonzero entries.
+        Vector sv = Vectors.sparse(3, new int[] {0, 2}, new double[] {1.0, 3.0});
+        // $example off$
+
+    }
+}

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaRowMatrixExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaRowMatrixExample.java
@@ -17,18 +17,18 @@
 
 package org.apache.spark.examples.mllib;
 
-import java.util.Arrays;
-
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
 // $example on$
+import java.util.Arrays;
+
 import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.mllib.linalg.distributed.RowMatrix;
+import org.apache.spark.mllib.linalg.Matrix;
 import org.apache.spark.mllib.linalg.QRDecomposition;
 import org.apache.spark.mllib.linalg.Vector;
 import org.apache.spark.mllib.linalg.Vectors;
-import org.apache.spark.mllib.linalg.distributed.RowMatrix;
 // $example off$
-import org.apache.spark.mllib.linalg.Matrix;
 
 public class JavaRowMatrixExample {
   public static void main(String[] args) {
@@ -38,7 +38,7 @@ public class JavaRowMatrixExample {
 
     Vector v1 = Vectors.dense(1.0, 10.0, 100.0);
     Vector v2 = Vectors.dense(2.0, 20.0, 200.0);
-    Vector v3 = Vectors.dense(5.0, 33.0, 366.0);
+    Vector v3 = Vectors.dense(3.0, 30.0, 300.0);
 
     // $example on$
     // a JavaRDD of local vectors

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaRowMatrixExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaRowMatrixExample.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.examples.mllib;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaSparkContext;
+// $example on$
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.mllib.linalg.QRDecomposition;
+import org.apache.spark.mllib.linalg.Vector;
+import org.apache.spark.mllib.linalg.Vectors;
+import org.apache.spark.mllib.linalg.distributed.RowMatrix;
+// $example off$
+import org.apache.spark.mllib.linalg.Matrix;
+
+import java.util.Arrays;
+
+public class JavaRowMatrixExample {
+    public static void main(String[] args) {
+
+        SparkConf conf = new SparkConf().setAppName("JavaRowMatrixExample").setMaster("local[*]");
+        JavaSparkContext jsc = new JavaSparkContext(conf);
+
+        Vector v1 = Vectors.dense(1.0, 10.0, 100.0);
+        Vector v2 = Vectors.dense(2.0, 20.0, 200.0);
+        Vector v3 = Vectors.dense(5.0, 33.0, 366.0);
+
+        // $example on$
+        // a JavaRDD of local vectors
+        JavaRDD<Vector> rows = jsc.parallelize(Arrays.asList(v1, v2, v3));
+
+        // Create a RowMatrix from an JavaRDD<Vector>.
+        RowMatrix mat = new RowMatrix(rows.rdd());
+
+        // Get its size.
+        long m = mat.numRows();
+        long n = mat.numCols();
+
+        // QR decomposition
+        QRDecomposition<RowMatrix, Matrix> result = mat.tallSkinnyQR(true);
+        // $example off$
+
+        jsc.stop();
+
+    }
+}

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaRowMatrixExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaRowMatrixExample.java
@@ -56,6 +56,5 @@ public class JavaRowMatrixExample {
     // $example off$
 
     jsc.stop();
-
   }
 }

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaRowMatrixExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaRowMatrixExample.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.examples.mllib;
 
+import java.util.Arrays;
+
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
 // $example on$
@@ -27,8 +29,6 @@ import org.apache.spark.mllib.linalg.Vectors;
 import org.apache.spark.mllib.linalg.distributed.RowMatrix;
 // $example off$
 import org.apache.spark.mllib.linalg.Matrix;
-
-import java.util.Arrays;
 
 public class JavaRowMatrixExample {
   public static void main(String[] args) {

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaRowMatrixExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaRowMatrixExample.java
@@ -31,31 +31,31 @@ import org.apache.spark.mllib.linalg.Matrix;
 import java.util.Arrays;
 
 public class JavaRowMatrixExample {
-    public static void main(String[] args) {
+  public static void main(String[] args) {
 
-        SparkConf conf = new SparkConf().setAppName("JavaRowMatrixExample").setMaster("local[*]");
-        JavaSparkContext jsc = new JavaSparkContext(conf);
+    SparkConf conf = new SparkConf().setAppName("JavaRowMatrixExample");
+    JavaSparkContext jsc = new JavaSparkContext(conf);
 
-        Vector v1 = Vectors.dense(1.0, 10.0, 100.0);
-        Vector v2 = Vectors.dense(2.0, 20.0, 200.0);
-        Vector v3 = Vectors.dense(5.0, 33.0, 366.0);
+    Vector v1 = Vectors.dense(1.0, 10.0, 100.0);
+    Vector v2 = Vectors.dense(2.0, 20.0, 200.0);
+    Vector v3 = Vectors.dense(5.0, 33.0, 366.0);
 
-        // $example on$
-        // a JavaRDD of local vectors
-        JavaRDD<Vector> rows = jsc.parallelize(Arrays.asList(v1, v2, v3));
+    // $example on$
+    // a JavaRDD of local vectors
+    JavaRDD<Vector> rows = jsc.parallelize(Arrays.asList(v1, v2, v3));
 
-        // Create a RowMatrix from an JavaRDD<Vector>.
-        RowMatrix mat = new RowMatrix(rows.rdd());
+    // Create a RowMatrix from an JavaRDD<Vector>.
+    RowMatrix mat = new RowMatrix(rows.rdd());
 
-        // Get its size.
-        long m = mat.numRows();
-        long n = mat.numCols();
+    // Get its size.
+    long m = mat.numRows();
+    long n = mat.numCols();
 
-        // QR decomposition
-        QRDecomposition<RowMatrix, Matrix> result = mat.tallSkinnyQR(true);
-        // $example off$
+    // QR decomposition
+    QRDecomposition<RowMatrix, Matrix> result = mat.tallSkinnyQR(true);
+    // $example off$
 
-        jsc.stop();
+    jsc.stop();
 
-    }
+  }
 }

--- a/examples/src/main/python/mllib/block_matrix_example.py
+++ b/examples/src/main/python/mllib/block_matrix_example.py
@@ -1,0 +1,55 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import print_function
+
+from pyspark import SparkContext
+# $example on$
+from pyspark.mllib.linalg import Matrices
+from pyspark.mllib.linalg.distributed import BlockMatrix
+# $example off$
+
+if __name__ == "__main__":
+
+    sc = SparkContext(appName="BlockMatrixExample") # SparkContext
+
+    # $example on$
+    # Create an RDD of sub-matrix blocks.
+    blocks = sc.parallelize([((0, 0), Matrices.dense(3, 2, [1, 2, 3, 4, 5, 6])),
+                             ((1, 0), Matrices.dense(3, 2, [7, 8, 9, 10, 11, 12]))])
+
+    # Create a BlockMatrix from an RDD of sub-matrix blocks.
+    mat = BlockMatrix(blocks, 3, 2)
+
+    # Get its size.
+    m = mat.numRows() # 6
+    n = mat.numCols() # 2
+
+    # Get the blocks as an RDD of sub-matrix blocks.
+    blocksRDD = mat.blocks
+
+    # Convert to a LocalMatrix.
+    localMat = mat.toLocalMatrix()
+
+    # Convert to an IndexedRowMatrix.
+    indexedRowMat = mat.toIndexedRowMatrix()
+
+    # Convert to a CoordinateMatrix.
+    coordinateMat = mat.toCoordinateMatrix()
+    # $example off$
+
+    sc.stop()

--- a/examples/src/main/python/mllib/block_matrix_example.py
+++ b/examples/src/main/python/mllib/block_matrix_example.py
@@ -25,7 +25,7 @@ from pyspark.mllib.linalg.distributed import BlockMatrix
 
 if __name__ == "__main__":
 
-    sc = SparkContext(appName="BlockMatrixExample") # SparkContext
+    sc = SparkContext(appName="BlockMatrixExample")  # SparkContext
 
     # $example on$
     # Create an RDD of sub-matrix blocks.
@@ -36,8 +36,8 @@ if __name__ == "__main__":
     mat = BlockMatrix(blocks, 3, 2)
 
     # Get its size.
-    m = mat.numRows() # 6
-    n = mat.numCols() # 2
+    m = mat.numRows()  # 6
+    n = mat.numCols()  # 2
 
     # Get the blocks as an RDD of sub-matrix blocks.
     blocksRDD = mat.blocks

--- a/examples/src/main/python/mllib/coordinate_matrix_example.py
+++ b/examples/src/main/python/mllib/coordinate_matrix_example.py
@@ -1,0 +1,56 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import print_function
+
+from pyspark import SparkContext
+# $example on$
+from pyspark.mllib.linalg.distributed import CoordinateMatrix, MatrixEntry
+# $example off$
+
+if __name__ == "__main__":
+
+    sc = SparkContext(appName="CoordinateMatrixExample") # SparkContext
+
+    # $example on$
+    # Create an RDD of coordinate entries.
+    #   - This can be done explicitly with the MatrixEntry class:
+    entries = sc.parallelize([MatrixEntry(0, 0, 1.2), MatrixEntry(1, 0, 2.1), MatrixEntry(6, 1, 3.7)])
+    #   - or using (long, long, float) tuples:
+    entries = sc.parallelize([(0, 0, 1.2), (1, 0, 2.1), (2, 1, 3.7)])
+
+    # Create an CoordinateMatrix from an RDD of MatrixEntries.
+    mat = CoordinateMatrix(entries)
+
+    # Get its size.
+    m = mat.numRows()  # 3
+    n = mat.numCols()  # 2
+
+    # Get the entries as an RDD of MatrixEntries.
+    entriesRDD = mat.entries
+
+    # Convert to a RowMatrix.
+    rowMat = mat.toRowMatrix()
+
+    # Convert to an IndexedRowMatrix.
+    indexedRowMat = mat.toIndexedRowMatrix()
+
+    # Convert to a BlockMatrix.
+    blockMat = mat.toBlockMatrix()
+    # $example off$
+
+    sc.stop()

--- a/examples/src/main/python/mllib/coordinate_matrix_example.py
+++ b/examples/src/main/python/mllib/coordinate_matrix_example.py
@@ -24,12 +24,13 @@ from pyspark.mllib.linalg.distributed import CoordinateMatrix, MatrixEntry
 
 if __name__ == "__main__":
 
-    sc = SparkContext(appName="CoordinateMatrixExample") # SparkContext
+    sc = SparkContext(appName="CoordinateMatrixExample")  # SparkContext
 
     # $example on$
     # Create an RDD of coordinate entries.
     #   - This can be done explicitly with the MatrixEntry class:
-    entries = sc.parallelize([MatrixEntry(0, 0, 1.2), MatrixEntry(1, 0, 2.1), MatrixEntry(6, 1, 3.7)])
+    entries = sc.parallelize(
+        [MatrixEntry(0, 0, 1.2), MatrixEntry(1, 0, 2.1), MatrixEntry(6, 1, 3.7)])
     #   - or using (long, long, float) tuples:
     entries = sc.parallelize([(0, 0, 1.2), (1, 0, 2.1), (2, 1, 3.7)])
 

--- a/examples/src/main/python/mllib/indexed_row_matrix_example.py
+++ b/examples/src/main/python/mllib/indexed_row_matrix_example.py
@@ -24,7 +24,7 @@ from pyspark.mllib.linalg.distributed import IndexedRow, IndexedRowMatrix
 
 if __name__ == "__main__":
 
-    sc = SparkContext(appName="IndexedRowMatrixExample") # SparkContext
+    sc = SparkContext(appName="IndexedRowMatrixExample")  # SparkContext
 
     # $example on$
     # Create an RDD of indexed rows.

--- a/examples/src/main/python/mllib/indexed_row_matrix_example.py
+++ b/examples/src/main/python/mllib/indexed_row_matrix_example.py
@@ -1,0 +1,60 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import print_function
+
+from pyspark import SparkContext
+# $example on$
+from pyspark.mllib.linalg.distributed import IndexedRow, IndexedRowMatrix
+# $example off$
+
+if __name__ == "__main__":
+
+    sc = SparkContext(appName="IndexedRowMatrixExample") # SparkContext
+
+    # $example on$
+    # Create an RDD of indexed rows.
+    #   - This can be done explicitly with the IndexedRow class:
+    indexedRows = sc.parallelize([IndexedRow(0, [1, 2, 3]),
+                                  IndexedRow(1, [4, 5, 6]),
+                                  IndexedRow(2, [7, 8, 9]),
+                                  IndexedRow(3, [10, 11, 12])])
+    #   - or by using (long, vector) tuples:
+    indexedRows = sc.parallelize([(0, [1, 2, 3]), (1, [4, 5, 6]),
+                                  (2, [7, 8, 9]), (3, [10, 11, 12])])
+
+    # Create an IndexedRowMatrix from an RDD of IndexedRows.
+    mat = IndexedRowMatrix(indexedRows)
+
+    # Get its size.
+    m = mat.numRows()  # 4
+    n = mat.numCols()  # 3
+
+    # Get the rows as an RDD of IndexedRows.
+    rowsRDD = mat.rows
+
+    # Convert to a RowMatrix by dropping the row indices.
+    rowMat = mat.toRowMatrix()
+
+    # Convert to a CoordinateMatrix.
+    coordinateMat = mat.toCoordinateMatrix()
+
+    # Convert to a BlockMatrix.
+    blockMat = mat.toBlockMatrix()
+    # $example off$
+
+    sc.stop()

--- a/examples/src/main/python/mllib/labeled_point_example.py
+++ b/examples/src/main/python/mllib/labeled_point_example.py
@@ -1,0 +1,33 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import print_function
+
+# $example on$
+from pyspark.mllib.linalg import SparseVector
+from pyspark.mllib.regression import LabeledPoint
+# $example off$
+
+if __name__ == "__main__":
+
+    # $example on$
+    # Create a labeled point with a positive label and a dense feature vector.
+    pos = LabeledPoint(1.0, [1.0, 0.0, 3.0])
+
+    # Create a labeled point with a negative label and a sparse feature vector.
+    neg = LabeledPoint(0.0, SparseVector(3, [0, 2], [1.0, 3.0]))
+    # $example off$

--- a/examples/src/main/python/mllib/labeled_point_sparse_data_example.py
+++ b/examples/src/main/python/mllib/labeled_point_sparse_data_example.py
@@ -24,7 +24,7 @@ from pyspark.mllib.util import MLUtils
 
 if __name__ == "__main__":
 
-    sc = SparkContext(appName="SummaryStatisticsExample") # SparkContext
+    sc = SparkContext(appName="LabeledPointSparseDataExample") # SparkContext
 
     # $example on$
     examples = MLUtils.loadLibSVMFile(sc, "data/mllib/sample_libsvm_data.txt")

--- a/examples/src/main/python/mllib/labeled_point_sparse_data_example.py
+++ b/examples/src/main/python/mllib/labeled_point_sparse_data_example.py
@@ -24,7 +24,7 @@ from pyspark.mllib.util import MLUtils
 
 if __name__ == "__main__":
 
-    sc = SparkContext(appName="LabeledPointSparseDataExample") # SparkContext
+    sc = SparkContext(appName="LabeledPointSparseDataExample")  # SparkContext
 
     # $example on$
     examples = MLUtils.loadLibSVMFile(sc, "data/mllib/sample_libsvm_data.txt")

--- a/examples/src/main/python/mllib/labeled_point_sparse_data_example.py
+++ b/examples/src/main/python/mllib/labeled_point_sparse_data_example.py
@@ -1,0 +1,31 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import print_function
+
+from pyspark import SparkContext
+# $example on$
+from pyspark.mllib.util import MLUtils
+# $example off$
+
+if __name__ == "__main__":
+
+    sc = SparkContext(appName="SummaryStatisticsExample") # SparkContext
+
+    # $example on$
+    examples = MLUtils.loadLibSVMFile(sc, "data/mllib/sample_libsvm_data.txt")
+    # $example off$

--- a/examples/src/main/python/mllib/local_matrix_example.py
+++ b/examples/src/main/python/mllib/local_matrix_example.py
@@ -24,9 +24,9 @@ from pyspark.mllib.linalg import Matrices
 if __name__ == "__main__":
 
     # $example on$
-    # Create a dense matrix ((1.0, 2.0), (3.0, 4.0), (5.0, 6.0))
+    # Create a dense matrix
     dm2 = Matrices.dense(3, 2, [1, 2, 3, 4, 5, 6])
 
-    # Create a sparse matrix ((9.0, 0.0), (0.0, 8.0), (0.0, 6.0))
+    # Create a sparse matrix
     sm = Matrices.sparse(3, 2, [0, 1, 3], [0, 2, 1], [9, 6, 8])
     # $example off$

--- a/examples/src/main/python/mllib/local_matrix_example.py
+++ b/examples/src/main/python/mllib/local_matrix_example.py
@@ -1,0 +1,32 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import print_function
+
+# $example on$
+import org.apache.spark.mllib.linalg.{Matrix, Matrices}
+# $example off$
+
+if __name__ == "__main__":
+
+    # $example on$
+    # Create a dense matrix ((1.0, 2.0), (3.0, 4.0), (5.0, 6.0))
+    dm2 = Matrices.dense(3, 2, [1, 2, 3, 4, 5, 6])
+
+    # Create a sparse matrix ((9.0, 0.0), (0.0, 8.0), (0.0, 6.0))
+    sm = Matrices.sparse(3, 2, [0, 1, 3], [0, 2, 1], [9, 6, 8])
+    # $example off$

--- a/examples/src/main/python/mllib/local_matrix_example.py
+++ b/examples/src/main/python/mllib/local_matrix_example.py
@@ -18,7 +18,8 @@
 from __future__ import print_function
 
 # $example on$
-import org.apache.spark.mllib.linalg.{Matrix, Matrices}
+import org.apache.spark.mllib.linalg.Matrices
+import org.apache.spark.mllib.linalg.Matrix
 # $example off$
 
 if __name__ == "__main__":

--- a/examples/src/main/python/mllib/local_matrix_example.py
+++ b/examples/src/main/python/mllib/local_matrix_example.py
@@ -18,8 +18,7 @@
 from __future__ import print_function
 
 # $example on$
-import org.apache.spark.mllib.linalg.Matrices
-import org.apache.spark.mllib.linalg.Matrix
+from pyspark.mllib.linalg import Matrices
 # $example off$
 
 if __name__ == "__main__":

--- a/examples/src/main/python/mllib/local_vector_example.py
+++ b/examples/src/main/python/mllib/local_vector_example.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 # $example on$
 import numpy as np
 import scipy.sparse as sps
+
 from pyspark.mllib.linalg import Vectors
 # $example off$
 

--- a/examples/src/main/python/mllib/local_vector_example.py
+++ b/examples/src/main/python/mllib/local_vector_example.py
@@ -1,0 +1,37 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import print_function
+
+# $example on$
+import numpy as np
+import scipy.sparse as sps
+from pyspark.mllib.linalg import Vectors
+# $example off$
+
+if __name__ == "__main__":
+
+    # $example on$
+    # Use a NumPy array as a dense vector.
+    dv1 = np.array([1.0, 0.0, 3.0])
+    # Use a Python list as a dense vector.
+    dv2 = [1.0, 0.0, 3.0]
+    # Create a SparseVector.
+    sv1 = Vectors.sparse(3, [0, 2], [1.0, 3.0])
+    # Use a single-column SciPy csc_matrix as a sparse vector.
+    sv2 = sps.csc_matrix((np.array([1.0, 3.0]), np.array([0, 2]), np.array([0, 2])), shape = (3, 1))
+    # $example off$

--- a/examples/src/main/python/mllib/local_vector_example.py
+++ b/examples/src/main/python/mllib/local_vector_example.py
@@ -33,5 +33,5 @@ if __name__ == "__main__":
     # Create a SparseVector.
     sv1 = Vectors.sparse(3, [0, 2], [1.0, 3.0])
     # Use a single-column SciPy csc_matrix as a sparse vector.
-    sv2 = sps.csc_matrix((np.array([1.0, 3.0]), np.array([0, 2]), np.array([0, 2])), shape = (3, 1))
+    sv2 = sps.csc_matrix((np.array([1.0, 3.0]), np.array([0, 2]), np.array([0, 2])), shape=(3, 1))
     # $example off$

--- a/examples/src/main/python/mllib/row_matrix_example.py
+++ b/examples/src/main/python/mllib/row_matrix_example.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
 
     # $example on$
     # Create an RDD of vectors.
-    rows = sc.parallelize([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]])
+    rows = sc.parallelize([[1.0, 10.0, 100.0], [2.0, 20.0, 200.0], [3.0, 30.0, 300.0]])
 
     # Create a RowMatrix from an RDD of vectors.
     mat = RowMatrix(rows)

--- a/examples/src/main/python/mllib/row_matrix_example.py
+++ b/examples/src/main/python/mllib/row_matrix_example.py
@@ -24,7 +24,7 @@ from pyspark.mllib.linalg.distributed import RowMatrix
 
 if __name__ == "__main__":
 
-    sc = SparkContext(appName="RowMatrixExample") # SparkContext
+    sc = SparkContext(appName="RowMatrixExample")  # SparkContext
 
     # $example on$
     # Create an RDD of vectors.

--- a/examples/src/main/python/mllib/row_matrix_example.py
+++ b/examples/src/main/python/mllib/row_matrix_example.py
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import print_function
+
+from pyspark import SparkContext
+# $example on$
+from pyspark.mllib.linalg.distributed import RowMatrix
+# $example off$
+
+if __name__ == "__main__":
+
+    sc = SparkContext(appName="RowMatrixExample") # SparkContext
+
+    # $example on$
+    # Create an RDD of vectors.
+    rows = sc.parallelize([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]])
+
+    # Create a RowMatrix from an RDD of vectors.
+    mat = RowMatrix(rows)
+
+    # Get its size.
+    m = mat.numRows()  # 4
+    n = mat.numCols()  # 3
+
+    # Get the rows as an RDD of vectors again.
+    rowsRDD = mat.rows
+    # $example off$
+
+    sc.stop()

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/BlockMatrixExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/BlockMatrixExample.scala
@@ -21,21 +21,21 @@ package org.apache.spark.examples.mllib
 import org.apache.spark.{SparkConf, SparkContext}
 // $example on$
 import org.apache.spark.mllib.linalg.distributed.{BlockMatrix, CoordinateMatrix, MatrixEntry}
-// $example off$
 import org.apache.spark.rdd.RDD
+// $example off$
 
 object BlockMatrixExample {
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
 
     val conf = new SparkConf().setAppName("BlockMatrixExample")
     val sc = new SparkContext(conf)
 
+    // $example on$
     val me1 = MatrixEntry(0, 0, 1.2)
     val me2 = MatrixEntry(1, 0, 2.1)
     val me3 = MatrixEntry(6, 1, 3.7)
 
-    // $example on$
     // an RDD of (i, j, v) matrix entries
     val entries: RDD[MatrixEntry] = sc.parallelize(Seq(me1, me2, me3))
     // Create a CoordinateMatrix from an RDD[MatrixEntry].

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/BlockMatrixExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/BlockMatrixExample.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// scalastyle:off println
+package org.apache.spark.examples.mllib
+
+import org.apache.spark.{SparkConf, SparkContext}
+// $example on$
+import org.apache.spark.mllib.linalg.distributed.{BlockMatrix, CoordinateMatrix, MatrixEntry}
+// $example off$
+import org.apache.spark.rdd.RDD
+
+object BlockMatrixExample {
+
+  def main(args: Array[String]) {
+
+    val conf = new SparkConf().setAppName("BlockMatrixExample").setMaster("local[*]")
+    val sc = new SparkContext(conf)
+
+    val me1 = MatrixEntry(0, 0, 1.2)
+    val me2 = MatrixEntry(1, 0, 2.1)
+    val me3 = MatrixEntry(6, 1, 3.7)
+
+    // $example on$
+    // an RDD of (i, j, v) matrix entries
+    val entries: RDD[MatrixEntry] = sc.parallelize(Seq(me1, me2, me3))
+    // Create a CoordinateMatrix from an RDD[MatrixEntry].
+    val coordMat: CoordinateMatrix = new CoordinateMatrix(entries)
+    // Transform the CoordinateMatrix to a BlockMatrix
+    val matA: BlockMatrix = coordMat.toBlockMatrix().cache()
+
+    // Validate whether the BlockMatrix is set up properly.
+    // Throws an Exception when it is not valid.
+    // Nothing happens if it is valid.
+    matA.validate()
+
+    // Calculate A^T A.
+    val ata = matA.transpose.multiply(matA)
+    // $example off$
+
+    sc.stop()
+  }
+}
+// scalastyle:on println

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/BlockMatrixExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/BlockMatrixExample.scala
@@ -28,7 +28,7 @@ object BlockMatrixExample {
 
   def main(args: Array[String]) {
 
-    val conf = new SparkConf().setAppName("BlockMatrixExample").setMaster("local[*]")
+    val conf = new SparkConf().setAppName("BlockMatrixExample")
     val sc = new SparkContext(conf)
 
     val me1 = MatrixEntry(0, 0, 1.2)

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/CoordinateMatrixExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/CoordinateMatrixExample.scala
@@ -21,22 +21,22 @@ package org.apache.spark.examples.mllib
 import org.apache.spark.{SparkConf, SparkContext}
 // $example on$
 import org.apache.spark.mllib.linalg.distributed.{CoordinateMatrix, MatrixEntry}
-// $example off$
 import org.apache.spark.rdd.RDD
+// $example off$
 
 object CoordinateMatrixExample {
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
 
     val conf = new SparkConf().setAppName("CoordinateMatrixExample")
     val sc = new SparkContext(conf)
 
+    // $example on$
     val me1 = MatrixEntry(0, 0, 1.2)
     val me2 = MatrixEntry(1, 0, 2.1)
     val me3 = MatrixEntry(6, 1, 3.7)
 
-    // $example on$
-    val entries: RDD[MatrixEntry] = sc.parallelize(Seq(me1, me2, me3)) // an RDD of matrix entries
+    val entries: RDD[MatrixEntry] = sc.parallelize(Seq(me1, me2, me3))  // an RDD of matrix entries
     // Create a CoordinateMatrix from an RDD[MatrixEntry].
     val mat: CoordinateMatrix = new CoordinateMatrix(entries)
 

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/CoordinateMatrixExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/CoordinateMatrixExample.scala
@@ -28,7 +28,7 @@ object CoordinateMatrixExample {
 
   def main(args: Array[String]) {
 
-    val conf = new SparkConf().setAppName("CoordinateMatrixExample").setMaster("local[*]")
+    val conf = new SparkConf().setAppName("CoordinateMatrixExample")
     val sc = new SparkContext(conf)
 
     val me1 = MatrixEntry(0, 0, 1.2)

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/CoordinateMatrixExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/CoordinateMatrixExample.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// scalastyle:off println
+package org.apache.spark.examples.mllib
+
+import org.apache.spark.{SparkConf, SparkContext}
+// $example on$
+import org.apache.spark.mllib.linalg.distributed.{CoordinateMatrix, MatrixEntry}
+// $example off$
+import org.apache.spark.rdd.RDD
+
+object CoordinateMatrixExample {
+
+  def main(args: Array[String]) {
+
+    val conf = new SparkConf().setAppName("CoordinateMatrixExample").setMaster("local[*]")
+    val sc = new SparkContext(conf)
+
+    val me1 = MatrixEntry(0, 0, 1.2)
+    val me2 = MatrixEntry(1, 0, 2.1)
+    val me3 = MatrixEntry(6, 1, 3.7)
+
+    // $example on$
+    val entries: RDD[MatrixEntry] = sc.parallelize(Seq(me1, me2, me3)) // an RDD of matrix entries
+    // Create a CoordinateMatrix from an RDD[MatrixEntry].
+    val mat: CoordinateMatrix = new CoordinateMatrix(entries)
+
+    // Get its size.
+    val m = mat.numRows()
+    val n = mat.numCols()
+
+    // Convert it to an IndexRowMatrix whose rows are sparse vectors.
+    val indexedRowMatrix = mat.toIndexedRowMatrix()
+    // $example off$
+
+    sc.stop()
+  }
+}
+// scalastyle:on println

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/IndexedRowMatrixExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/IndexedRowMatrixExample.scala
@@ -19,25 +19,26 @@
 package org.apache.spark.examples.mllib
 
 import org.apache.spark.{SparkConf, SparkContext}
-import org.apache.spark.mllib.linalg.Vectors
 // $example on$
 import org.apache.spark.mllib.linalg.distributed.{IndexedRow, IndexedRowMatrix, RowMatrix}
-// $example off$
+import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.rdd.RDD
+// $example off$
 
 object IndexedRowMatrixExample {
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
 
     val conf = new SparkConf().setAppName("IndexedRowMatrixExample")
     val sc = new SparkContext(conf)
 
-    val r1 = IndexedRow(1, Vectors.dense(1.0, 10.0, 100.0))
-    val r2 = IndexedRow(2, Vectors.dense(2.0, 20.0, 200.0))
-    val r3 = IndexedRow(3, Vectors.dense(3.0, 30.0, 300.0))
-
     // $example on$
-    val rows: RDD[IndexedRow] = sc.parallelize(Seq(r1, r2, r3)) // an RDD of indexed rows
+    val r0 = IndexedRow(0, Vectors.dense(1, 2, 3))
+    val r1 = IndexedRow(1, Vectors.dense(4, 5, 6))
+    val r2 = IndexedRow(2, Vectors.dense(7, 8, 9))
+    val r3 = IndexedRow(3, Vectors.dense(10, 11, 12))
+
+    val rows: RDD[IndexedRow] = sc.parallelize(Seq(r0, r1, r2, r3))  // an RDD of indexed rows
     // Create an IndexedRowMatrix from an RDD[IndexedRow].
     val mat: IndexedRowMatrix = new IndexedRowMatrix(rows)
 

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/IndexedRowMatrixExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/IndexedRowMatrixExample.scala
@@ -29,7 +29,7 @@ object IndexedRowMatrixExample {
 
   def main(args: Array[String]) {
 
-    val conf = new SparkConf().setAppName("IndexedRowMatrixExample").setMaster("local[*]")
+    val conf = new SparkConf().setAppName("IndexedRowMatrixExample")
     val sc = new SparkContext(conf)
 
     val r1 = IndexedRow(1, Vectors.dense(1.0, 10.0, 100.0))

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/IndexedRowMatrixExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/IndexedRowMatrixExample.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// scalastyle:off println
+package org.apache.spark.examples.mllib
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.mllib.linalg.Vectors
+// $example on$
+import org.apache.spark.mllib.linalg.distributed.{IndexedRow, IndexedRowMatrix, RowMatrix}
+// $example off$
+import org.apache.spark.rdd.RDD
+
+object IndexedRowMatrixExample {
+
+  def main(args: Array[String]) {
+
+    val conf = new SparkConf().setAppName("IndexedRowMatrixExample").setMaster("local[*]")
+    val sc = new SparkContext(conf)
+
+    val r1 = IndexedRow(1, Vectors.dense(1.0, 10.0, 100.0))
+    val r2 = IndexedRow(2, Vectors.dense(2.0, 20.0, 200.0))
+    val r3 = IndexedRow(3, Vectors.dense(3.0, 30.0, 300.0))
+
+    // $example on$
+    val rows: RDD[IndexedRow] = sc.parallelize(Seq(r1, r2, r3)) // an RDD of indexed rows
+    // Create an IndexedRowMatrix from an RDD[IndexedRow].
+    val mat: IndexedRowMatrix = new IndexedRowMatrix(rows)
+
+    // Get its size.
+    val m = mat.numRows()
+    val n = mat.numCols()
+
+    // Drop its row indices.
+    val rowMat: RowMatrix = mat.toRowMatrix()
+    // $example off$
+
+    sc.stop()
+  }
+}
+// scalastyle:on println

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/LabeledPointExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/LabeledPointExample.scala
@@ -25,7 +25,7 @@ import org.apache.spark.mllib.regression.LabeledPoint
 
 object LabeledPointExample {
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     // $example on$
     // Create a labeled point with a positive label and a dense feature vector.
     val pos = LabeledPoint(1.0, Vectors.dense(1.0, 0.0, 3.0))

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/LabeledPointExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/LabeledPointExample.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// scalastyle:off println
+package org.apache.spark.examples.mllib
+
+// $example on$
+import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.mllib.regression.LabeledPoint
+// $example off$
+
+object LabeledPointExample {
+
+  def main(args: Array[String]) {
+
+    // $example on$
+    // Create a labeled point with a positive label and a dense feature vector.
+    val pos = LabeledPoint(1.0, Vectors.dense(1.0, 0.0, 3.0))
+
+    // Create a labeled point with a negative label and a sparse feature vector.
+    val neg = LabeledPoint(0.0, Vectors.sparse(3, Array(0, 2), Array(1.0, 3.0)))
+
+    // $example off$
+
+  }
+}
+// scalastyle:on println

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/LabeledPointExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/LabeledPointExample.scala
@@ -26,16 +26,13 @@ import org.apache.spark.mllib.regression.LabeledPoint
 object LabeledPointExample {
 
   def main(args: Array[String]) {
-
     // $example on$
     // Create a labeled point with a positive label and a dense feature vector.
     val pos = LabeledPoint(1.0, Vectors.dense(1.0, 0.0, 3.0))
 
     // Create a labeled point with a negative label and a sparse feature vector.
     val neg = LabeledPoint(0.0, Vectors.sparse(3, Array(0, 2), Array(1.0, 3.0)))
-
     // $example off$
-
   }
 }
 // scalastyle:on println

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/LabeledPointSparseDataExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/LabeledPointSparseDataExample.scala
@@ -27,7 +27,7 @@ import org.apache.spark.rdd.RDD
 
 object LabeledPointSparseDataExample {
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
 
     val conf = new SparkConf().setAppName("LabeledPointSparseDataExample")
     val sc = new SparkContext(conf)

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/LabeledPointSparseDataExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/LabeledPointSparseDataExample.scala
@@ -29,7 +29,7 @@ object LabeledPointSparseDataExample {
 
   def main(args: Array[String]) {
 
-    val conf = new SparkConf().setAppName("CorrelationsExample").setMaster("local[*]")
+    val conf = new SparkConf().setAppName("LabeledPointSparseDataExample").setMaster("local[*]")
     val sc = new SparkContext(conf)
 
     // $example on$

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/LabeledPointSparseDataExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/LabeledPointSparseDataExample.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// scalastyle:off println
+package org.apache.spark.examples.mllib
+
+import org.apache.spark.{SparkConf, SparkContext}
+// $example on$
+import org.apache.spark.mllib.regression.LabeledPoint
+import org.apache.spark.mllib.util.MLUtils
+import org.apache.spark.rdd.RDD
+// $example off$
+
+object LabeledPointSparseDataExample {
+
+  def main(args: Array[String]) {
+
+    val conf = new SparkConf().setAppName("CorrelationsExample").setMaster("local[*]")
+    val sc = new SparkContext(conf)
+
+    // $example on$
+    val examples: RDD[LabeledPoint] = MLUtils.
+      loadLibSVMFile(sc, "data/mllib/sample_libsvm_data.txt")
+    // $example off$
+
+    sc.stop()
+  }
+}
+// scalastyle:on println

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/LabeledPointSparseDataExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/LabeledPointSparseDataExample.scala
@@ -29,7 +29,7 @@ object LabeledPointSparseDataExample {
 
   def main(args: Array[String]) {
 
-    val conf = new SparkConf().setAppName("LabeledPointSparseDataExample").setMaster("local[*]")
+    val conf = new SparkConf().setAppName("LabeledPointSparseDataExample")
     val sc = new SparkContext(conf)
 
     // $example on$

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/LocalMatrixExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/LocalMatrixExample.scala
@@ -24,13 +24,13 @@ import org.apache.spark.mllib.linalg.{Matrices, Matrix}
 
 object LocalMatrixExample {
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
 
     // $example on$
-    // Create a dense matrix ((1.0, 2.0), (3.0, 4.0), (5.0, 6.0))
+    // Create a dense matrix
     val dm: Matrix = Matrices.dense(3, 2, Array(1.0, 3.0, 5.0, 2.0, 4.0, 6.0))
 
-    // Create a sparse matrix ((9.0, 0.0), (0.0, 8.0), (0.0, 6.0))
+    // Create a sparse matrix
     val sm: Matrix = Matrices.sparse(3, 2, Array(0, 1, 3), Array(0, 2, 1), Array(9, 6, 8))
     // $example off$
   }

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/LocalMatrixExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/LocalMatrixExample.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// scalastyle:off println
+package org.apache.spark.examples.mllib
+
+// $example on$
+import org.apache.spark.mllib.linalg.{Matrices, Matrix}
+// $example off$
+
+object LocalMatrixExample {
+
+  def main(args: Array[String]) {
+
+    // $example on$
+    // Create a dense matrix ((1.0, 2.0), (3.0, 4.0), (5.0, 6.0))
+    val dm: Matrix = Matrices.dense(3, 2, Array(1.0, 3.0, 5.0, 2.0, 4.0, 6.0))
+
+    // Create a sparse matrix ((9.0, 0.0), (0.0, 8.0), (0.0, 6.0))
+    val sm: Matrix = Matrices.sparse(3, 2, Array(0, 1, 3), Array(0, 2, 1), Array(9, 6, 8))
+    // $example off$
+
+  }
+}
+// scalastyle:on println

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/LocalMatrixExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/LocalMatrixExample.scala
@@ -33,7 +33,6 @@ object LocalMatrixExample {
     // Create a sparse matrix ((9.0, 0.0), (0.0, 8.0), (0.0, 6.0))
     val sm: Matrix = Matrices.sparse(3, 2, Array(0, 1, 3), Array(0, 2, 1), Array(9, 6, 8))
     // $example off$
-
   }
 }
 // scalastyle:on println

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/LocalVectorExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/LocalVectorExample.scala
@@ -24,15 +24,15 @@ import org.apache.spark.mllib.linalg.{Vector, Vectors}
 
 object LocalVectorExample {
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
 
     // $example on$
-    // Create a dense vector (1.0, 0.0, 3.0).
+    // Create a dense vector
     val dv: Vector = Vectors.dense(1.0, 0.0, 3.0)
-    // Create a sparse vector (1.0, 0.0, 3.0)
+    // Create a sparse vector
     // by specifying its indices and values corresponding to nonzero entries.
     val sv1: Vector = Vectors.sparse(3, Array(0, 2), Array(1.0, 3.0))
-    // Create a sparse vector (1.0, 0.0, 3.0) by specifying its nonzero entries.
+    // Create a sparse vector by specifying its nonzero entries.
     val sv2: Vector = Vectors.sparse(3, Seq((0, 1.0), (2, 3.0)))
     // $example off$
   }

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/LocalVectorExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/LocalVectorExample.scala
@@ -35,7 +35,6 @@ object LocalVectorExample {
     // Create a sparse vector (1.0, 0.0, 3.0) by specifying its nonzero entries.
     val sv2: Vector = Vectors.sparse(3, Seq((0, 1.0), (2, 3.0)))
     // $example off$
-
   }
 }
 // scalastyle:on println

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/LocalVectorExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/LocalVectorExample.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// scalastyle:off println
+package org.apache.spark.examples.mllib
+
+// $example on$
+import org.apache.spark.mllib.linalg.{Vector, Vectors}
+// $example off$
+
+object LocalVectorExample {
+
+  def main(args: Array[String]) {
+
+    // $example on$
+    // Create a dense vector (1.0, 0.0, 3.0).
+    val dv: Vector = Vectors.dense(1.0, 0.0, 3.0)
+    // Create a sparse vector (1.0, 0.0, 3.0)
+    // by specifying its indices and values corresponding to nonzero entries.
+    val sv1: Vector = Vectors.sparse(3, Array(0, 2), Array(1.0, 3.0))
+    // Create a sparse vector (1.0, 0.0, 3.0) by specifying its nonzero entries.
+    val sv2: Vector = Vectors.sparse(3, Seq((0, 1.0), (2, 3.0)))
+    // $example off$
+
+  }
+}
+// scalastyle:on println

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/RowMatrixExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/RowMatrixExample.scala
@@ -22,22 +22,22 @@ import org.apache.spark.{SparkConf, SparkContext}
 // $example on$
 import org.apache.spark.mllib.linalg.{Vector, Vectors}
 import org.apache.spark.mllib.linalg.distributed.RowMatrix
-// $example off$
 import org.apache.spark.rdd.RDD
+// $example off$
 
 object RowMatrixExample {
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
 
     val conf = new SparkConf().setAppName("RowMatrixExample")
     val sc = new SparkContext(conf)
 
+    // $example on$
     val v1 = Vectors.dense(1.0, 10.0, 100.0)
     val v2 = Vectors.dense(2.0, 20.0, 200.0)
     val v3 = Vectors.dense(3.0, 30.0, 300.0)
 
-    // $example on$
-    val rows: RDD[Vector] = sc.parallelize(Seq(v1, v2, v3)) // an RDD of local vectors
+    val rows: RDD[Vector] = sc.parallelize(Seq(v1, v2, v3))  // an RDD of local vectors
     // Create a RowMatrix from an RDD[Vector].
     val mat: RowMatrix = new RowMatrix(rows)
 

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/RowMatrixExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/RowMatrixExample.scala
@@ -29,7 +29,7 @@ object RowMatrixExample {
 
   def main(args: Array[String]) {
 
-    val conf = new SparkConf().setAppName("SummaryStatisticsExample").setMaster("local[*]")
+    val conf = new SparkConf().setAppName("RowMatrixExample").setMaster("local[*]")
     val sc = new SparkContext(conf)
 
     val v1 = Vectors.dense(1.0, 10.0, 100.0)

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/RowMatrixExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/RowMatrixExample.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// scalastyle:off println
+package org.apache.spark.examples.mllib
+
+import org.apache.spark.{SparkConf, SparkContext}
+// $example on$
+import org.apache.spark.mllib.linalg.{Vector, Vectors}
+import org.apache.spark.mllib.linalg.distributed.RowMatrix
+// $example off$
+import org.apache.spark.rdd.RDD
+
+object RowMatrixExample {
+
+  def main(args: Array[String]) {
+
+    val conf = new SparkConf().setAppName("SummaryStatisticsExample").setMaster("local[*]")
+    val sc = new SparkContext(conf)
+
+    val v1 = Vectors.dense(1.0, 10.0, 100.0)
+    val v2 = Vectors.dense(2.0, 20.0, 200.0)
+    val v3 = Vectors.dense(3.0, 30.0, 300.0)
+
+    // $example on$
+    val rows: RDD[Vector] = sc.parallelize(Seq(v1, v2, v3)) // an RDD of local vectors
+    // Create a RowMatrix from an RDD[Vector].
+    val mat: RowMatrix = new RowMatrix(rows)
+
+    // Get its size.
+    val m = mat.numRows()
+    val n = mat.numCols()
+
+    // QR decomposition
+    val qrResult = mat.tallSkinnyQR(true)
+    // $example off$
+
+    sc.stop()
+  }
+}
+// scalastyle:on println

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/RowMatrixExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/RowMatrixExample.scala
@@ -29,7 +29,7 @@ object RowMatrixExample {
 
   def main(args: Array[String]) {
 
-    val conf = new SparkConf().setAppName("RowMatrixExample").setMaster("local[*]")
+    val conf = new SparkConf().setAppName("RowMatrixExample")
     val sc = new SparkContext(conf)
 
     val v1 = Vectors.dense(1.0, 10.0, 100.0)


### PR DESCRIPTION
Replace example code in mllib-data-types.md using include_example
https://issues.apache.org/jira/browse/SPARK-13015

The example code in the user guide is embedded in the markdown and hence it is not easy to test. It would be nice to automatically test them. This JIRA is to discuss options to automate example code testing and see what we can do in Spark 1.6.

Goal is to move actual example code to spark/examples and test compilation in Jenkins builds. Then in the markdown, we can reference part of the code to show in the user guide. This requires adding a Jekyll tag that is similar to https://github.com/jekyll/jekyll/blob/master/lib/jekyll/tags/include.rb, e.g., called include_example.
`{% include_example scala/org/apache/spark/examples/mllib/LocalVectorExample.scala %}`
Jekyll will find `examples/src/main/scala/org/apache/spark/examples/mllib/LocalVectorExample.scala` and pick code blocks marked "example" and replace code block in 
`{% highlight %}`
 in the markdown. 

See more sub-tasks in parent ticket: https://issues.apache.org/jira/browse/SPARK-11337
