### PR TITLE
[SPARK-12921] Fix another non-reflective TaskAttemptContext access in SpecificParquetRecordReaderBase

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/SpecificParquetRecordReaderBase.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/SpecificParquetRecordReaderBase.java
@@ -133,7 +133,7 @@ public abstract class SpecificParquetRecordReaderBase<T> extends RecordReader<Vo
     this.readSupport = getReadSupportInstance(
         (Class<? extends ReadSupport<T>>) getReadSupportClass(configuration));
     ReadSupport.ReadContext readContext = readSupport.init(new InitContext(
-        taskAttemptContext.getConfiguration(), toSetMultiMap(fileMetadata), fileSchema));
+        configuration, toSetMultiMap(fileMetadata), fileSchema));
     this.requestedSchema = readContext.getRequestedSchema();
     this.fileSchema = fileSchema;
     this.reader = new ParquetFileReader(configuration, file, blocks, requestedSchema.getColumns());


### PR DESCRIPTION
This is a minor followup to #10843 to fix one remaining place where we forgot to use reflective access of TaskAttemptContext methods.
