### PR TITLE
[SPARK-13255][SQL] Integrate vectorized parquet scanner with whole stage codegen.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/BufferedRowIterator.java
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/BufferedRowIterator.java
@@ -25,6 +25,7 @@ import scala.collection.Iterator;
 import org.apache.spark.TaskContext;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
+import org.apache.spark.sql.execution.vectorized.ColumnarBatch;
 
 /**
  * An iterator interface used to pull the output from generated function for multiple operators
@@ -35,6 +36,7 @@ import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
 public class BufferedRowIterator {
   protected LinkedList<InternalRow> currentRows = new LinkedList<>();
   protected Iterator<InternalRow> input;
+  protected Iterator<ColumnarBatch> inputBatches;
   // used when there is no column in output
   protected UnsafeRow unsafeRow = new UnsafeRow(0);
 
@@ -52,6 +54,7 @@ public class BufferedRowIterator {
   public void setInput(Iterator<InternalRow> iter) {
     input = iter;
   }
+  public void setInputBatch(Iterator<ColumnarBatch> iter) { inputBatches = iter; }
 
   /**
    * Returns whether `processNext()` should stop processing next row from `input` or not.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregate.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregate.scala
@@ -124,8 +124,8 @@ case class TungstenAggregate(
     !aggregateExpressions.exists(_.aggregateFunction.isInstanceOf[ImperativeAggregate])
   }
 
-  override def upstream(): RDD[InternalRow] = {
-    child.asInstanceOf[CodegenSupport].upstream()
+  override def pipelineStart(): CodegenSupport = {
+    child.asInstanceOf[CodegenSupport].pipelineStart()
   }
 
   protected override def doProduce(ctx: CodegenContext): String = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicOperators.scala
@@ -34,8 +34,8 @@ case class Project(projectList: Seq[NamedExpression], child: SparkPlan)
 
   override def output: Seq[Attribute] = projectList.map(_.toAttribute)
 
-  override def upstream(): RDD[InternalRow] = {
-    child.asInstanceOf[CodegenSupport].upstream()
+  override def pipelineStart(): CodegenSupport = {
+    child.asInstanceOf[CodegenSupport].pipelineStart()
   }
 
   protected override def doProduce(ctx: CodegenContext): String = {
@@ -77,8 +77,8 @@ case class Filter(condition: Expression, child: SparkPlan) extends UnaryNode wit
     "numInputRows" -> SQLMetrics.createLongMetric(sparkContext, "number of input rows"),
     "numOutputRows" -> SQLMetrics.createLongMetric(sparkContext, "number of output rows"))
 
-  override def upstream(): RDD[InternalRow] = {
-    child.asInstanceOf[CodegenSupport].upstream()
+  override def pipelineStart(): CodegenSupport = {
+    child.asInstanceOf[CodegenSupport].pipelineStart()
   }
 
   protected override def doProduce(ctx: CodegenContext): String = {
@@ -163,7 +163,9 @@ case class Range(
     output: Seq[Attribute])
   extends LeafNode with CodegenSupport {
 
-  override def upstream(): RDD[InternalRow] = {
+  override  def pipelineStart(): CodegenSupport = this
+
+  override def startPipeline(): RDD[InternalRow] = {
     sqlContext.sparkContext.parallelize(0 until numSlices, numSlices).map(i => InternalRow(i))
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoin.scala
@@ -127,8 +127,8 @@ case class BroadcastHashJoin(
   // the term for hash relation
   private var relationTerm: String = _
 
-  override def upstream(): RDD[InternalRow] = {
-    streamedPlan.asInstanceOf[CodegenSupport].upstream()
+  override def pipelineStart(): CodegenSupport = {
+    streamedPlan.asInstanceOf[CodegenSupport].pipelineStart()
   }
 
   override def doProduce(ctx: CodegenContext): String = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -81,6 +81,10 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSQLContext {
       (i % 2 == 0, i, i.toLong, i.toFloat, i.toDouble)
     }
     checkParquetFile(data)
+
+    withParquetDataFrame(data) { df =>
+      assert(df.filter("_1 = true").agg("_2" -> "sum").collect().head.getLong(0) == 6)
+    }
   }
 
   test("raw binary") {


### PR DESCRIPTION
This patch integrates these two so that the codegen'ed function is run over
batches of rows. This removes all of the per row iterator calls for the
code paths that support this. Unfortunately, this patch combines a few different
things.
1. Refactor some of SqlNewHadoopRDD/ParquetRelation to produce RDD's of ColumnarBatch
   in addition to RDD's of InternalRow. This adds a new level of class hierarchy to minimize
   code duplication. This could use further refactoring to not require the low level
   components to return RDD's.
2. Minor refactoring of WholeStageCodegen to handle leaf operators that produce batches.
