### PR TITLE
[SPARK-13267] [Web UI] document the ?param arguments of the REST API; lift the…

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -230,15 +230,17 @@ for a running application, at `http://localhost:4040/api/v1`.
   </tr>
   <tr>
      <td></td>
-     <td><code>?status=[completed|running]</code> list only applications in the state</td>
+     <td><code>?status=[completed|running]</code> list only applications in the chosen state</td>
   </tr>
   <tr>
      <td></td>
-     <td><code>?minDate=[date]</code> earliest date to list. e.g <code>?minDate=2015-02-10</code></td>
+     <td><code>?minDate=[date]</code> earliest date/time to list. Examples:
+     <br><code>?minDate=2015-02-10</code>
+     <br><code>?minDate=2015-02-03T16:42:40.000GMT</code></td>
   </tr>
   <tr>
      <td></td>
-     <td><code>?maxDate=[date]</code> latest date to list. e.g <code>?maxDate=2015-02-03T16:42:40.000GMT</code></td>
+     <td><code>?maxDate=[date]</code> latest date/time to list; uses same format as <code>minDate</code></td>
   </tr>
   <tr>
     <td><code>/applications/[app-id]/jobs</code></td>
@@ -275,7 +277,7 @@ for a running application, at `http://localhost:4040/api/v1`.
   <tr>
      <td></td>
      <td><code>?quantiles</code> summarize the metrics with the given quantiles.
-     e.g. <code>?quantiles=0.01,0.5,0.99</code></td>
+     Example: <br><code>?quantiles=0.01,0.5,0.99</code></td>
   </tr>
   <tr>
     <td><code>/applications/[app-id]/stages/[stage-id]/[stage-attempt-id]/taskList</code></td>
@@ -284,7 +286,7 @@ for a running application, at `http://localhost:4040/api/v1`.
   <tr>
      <td></td>
      <td><code>?offset=[offset]&amp;length=[len]</code> list only tasks in the range.
-      e.g. <code>?offset=10&amp;length=50</code></td>
+      Example: <br> <code>?offset=10&amp;length=50</code></td>
   </tr>
   <tr>
      <td></td>

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -230,22 +230,15 @@ where `[base-app-id]` is the YARN application ID.
 <table class="table">
   <tr><th>Endpoint</th><th>Meaning</th></tr>
   <tr>
-    <td><code>/applications</code></td>
-    <td>A list of all applications</td>
-  </tr>
-  <tr>
-    <td></td>
-    <td><code>?status=[completed|running]</code> list only applications in the chosen state</td>
-  </tr>
-  <tr>
-    <td></td>
-    <td><code>?minDate=[date]</code> earliest date/time to list. Examples:
+    <td ><code>/applications</code></td>
+    <td>A list of all applications
+    <br>
+    <code>?status=[completed|running]</code> list only applications in the chosen state
+    <br>
+    <code>?minDate=[date]</code> earliest date/time to list. Examples:
     <br><code>?minDate=2015-02-10</code>
-    <br><code>?minDate=2015-02-03T16:42:40.000GMT</code></td>
-  </tr>
-  <tr>
-    <td></td>
-    <td><code>?maxDate=[date]</code> latest date/time to list; uses same format as <code>minDate</code></td>
+    <br><code>?minDate=2015-02-03T16:42:40.000GMT</code>
+    <br><code>?maxDate=[date]</code> latest date/time to list; uses same format as <code>minDate</code></td>
   </tr>
   <tr>
     <td><code>/applications/[app-id]/jobs</code></td>
@@ -311,12 +304,13 @@ where `[base-app-id]` is the YARN application ID.
   </tr>
   <tr>
     <td><code>/applications/[base-app-id]/logs</code></td>
-    <td>Download the event logs for all attempts of the given application as a zip file.
+    <td>Download the event logs for all attempts of the given application as files within
+    a zip file.
     </td>
   </tr>
   <tr>
     <td><code>/applications/[base-app-id]/[attempt-id]/logs</code></td>
-    <td>Download the event logs for a specific application as a zip file</td>
+    <td>Download the event logs for a specific application as a zip file.</td>
   </tr>
 </table>
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -230,39 +230,38 @@ where `[base-app-id]` is the YARN application ID.
 <table class="table">
   <tr><th>Endpoint</th><th>Meaning</th></tr>
   <tr>
-    <td ><code>/applications</code></td>
-    <td>A list of all applications
+    <td><code>/applications</code></td>
+    <td>A list of all applications.
     <br>
-    <code>?status=[completed|running]</code> list only applications in the chosen state
+    <code>?status=[completed|running]</code> list only applications in the chosen state.
     <br>
-    <code>?minDate=[date]</code> earliest date/time to list. Examples:
+    <code>?minDate=[date]</code> earliest date/time to list.
+    <br>Examples:
     <br><code>?minDate=2015-02-10</code>
     <br><code>?minDate=2015-02-03T16:42:40.000GMT</code>
-    <br><code>?maxDate=[date]</code> latest date/time to list; uses same format as <code>minDate</code></td>
+    <br><code>?maxDate=[date]</code> latest date/time to list; uses same format as <code>minDate</code>.</td>
   </tr>
   <tr>
     <td><code>/applications/[app-id]/jobs</code></td>
-    <td>A list of all jobs for a given application</td>
-  </tr>
-  <tr>
-    <td></td>
-    <td><code>?status=[complete|succeeded|failed]</code> list only jobs in the state</td>
+    <td>
+      A list of all jobs for a given application.
+      <br><code>?status=[complete|succeeded|failed]</code> list only jobs in the specific state.
+    </td>
   </tr>
   <tr>
     <td><code>/applications/[app-id]/jobs/[job-id]</code></td>
-    <td>Details for the given job</td>
+    <td>Details for the given job.</td>
   </tr>
   <tr>
     <td><code>/applications/[app-id]/stages</code></td>
-    <td>A list of all stages for a given application</td>
+    <td>A list of all stages for a given application.</td>
   </tr>
   <tr>
     <td><code>/applications/[app-id]/stages/[stage-id]</code></td>
-    <td>A list of all attempts for the given stage</td>
-  </tr>
-  <tr>
-    <td></td>
-    <td><code>?status=[active|complete|pending|failed]</code> list only stages in the state</td>
+    <td>
+      A list of all attempts for the given stage.
+      <br><code>?status=[active|complete|pending|failed]</code> list only stages in the state.
+    </td>
   </tr>
   <tr>
     <td><code>/applications/[app-id]/stages/[stage-id]/[stage-attempt-id]</code></td>
@@ -270,37 +269,32 @@ where `[base-app-id]` is the YARN application ID.
   </tr>
   <tr>
     <td><code>/applications/[app-id]/stages/[stage-id]/[stage-attempt-id]/taskSummary</code></td>
-    <td>Summary metrics of all tasks in the given stage attempt</td>
-  </tr>
-  <tr>
-    <td></td>
-    <td><code>?quantiles</code> summarize the metrics with the given quantiles.
-    Example: <br><code>?quantiles=0.01,0.5,0.99</code></td>
+    <td>
+      Summary metrics of all tasks in the given stage attempt.
+      <br><code>?quantiles</code> summarize the metrics with the given quantiles.
+      <br>Example: <code>?quantiles=0.01,0.5,0.99</code>
+    </td>
   </tr>
   <tr>
     <td><code>/applications/[app-id]/stages/[stage-id]/[stage-attempt-id]/taskList</code></td>
-    <td>A list of all tasks for the given stage attempt</td>
-  </tr>
-  <tr>
-    <td></td>
-    <td><code>?offset=[offset]&amp;length=[len]</code> list only tasks in the range.
-    Example: <br> <code>?offset=10&amp;length=50</code></td>
-  </tr>
-  <tr>
-    <td></td>
-    <td><code>?sortBy=[runtime|-runtime]</code> sort the tasks</td>
+    <td>
+       A list of all tasks for the given stage attempt.
+      <br><code>?offset=[offset]&amp;length=[len]</code> list tasks in the given range.
+      <br><code>?sortBy=[runtime|-runtime]</code> sort the tasks.
+      <br>Example: <code>?offset=10&amp;length=50&amp;sortBy=runtime</code>
+    </td>
   </tr>
   <tr>
     <td><code>/applications/[app-id]/executors</code></td>
-    <td>A list of all executors for the given application</td>
+    <td>A list of all executors for the given application.</td>
   </tr>
   <tr>
     <td><code>/applications/[app-id]/storage/rdd</code></td>
-    <td>A list of stored RDDs for the given application</td>
+    <td>A list of stored RDDs for the given application.</td>
   </tr>
   <tr>
     <td><code>/applications/[app-id]/storage/rdd/[rdd-id]</code></td>
-    <td>Details for the storage status of a given RDD</td>
+    <td>Details for the storage status of a given RDD.</td>
   </tr>
   <tr>
     <td><code>/applications/[base-app-id]/logs</code></td>
@@ -310,14 +304,14 @@ where `[base-app-id]` is the YARN application ID.
   </tr>
   <tr>
     <td><code>/applications/[base-app-id]/[attempt-id]/logs</code></td>
-    <td>Download the event logs for a specific application as a zip file.</td>
+    <td>Download the event logs for a specific application attempt as a zip file.</td>
   </tr>
 </table>
 
-The number of jobs and stages which can retrieved is constrained by the same garbage
-collection mechanism of the standalone Spark UI; `"spark.ui.retainedJobs"` defines the threshold
+The number of jobs and stages which can retrieved is constrained by the same retention
+mechanism of the standalone Spark UI; `"spark.ui.retainedJobs"` defines the threshold
 value triggering garbage collection on jobs, and `spark.ui.retainedStages` that for stages.
-Note that the garbage collection takes place on playback: it is actually possible to retrieve
+Note that the garbage collection takes place on playback: it is possible to retrieve
 more entries by increasing these values and restarting the history server.
 
 ### API Versioning Policy

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -309,8 +309,8 @@ for a running application, at `http://localhost:4040/api/v1`.
     <td>Download the event logs for all attempts of the given application as a zip file</td>
   </tr>
   <tr>
-    <td><code>/applications/[app-id]/[attempt-id]/logs</code></td>
-    <td>Download the event logs for the specified attempt of the given application as a zip file</td>
+    <td><code>/applications/[app-id]/logs</code></td>
+    <td>Download the event logs for the application as a zip file</td>
   </tr>
 </table>
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -229,8 +229,24 @@ for a running application, at `http://localhost:4040/api/v1`.
     <td>A list of all applications</td>
   </tr>
   <tr>
+     <td></td>
+     <td><code>?status=[completed|running]</code> list only applications in the state</td>
+  </tr>
+  <tr>
+     <td></td>
+     <td><code>?minDate=[date]</code> earliest date to list. e.g <code>?minDate=2015-02-10</code></td>
+  </tr>
+  <tr>
+     <td></td>
+     <td><code>?maxDate=[date]</code> latest date to list. e.g <code>?maxDate=2015-02-03T16:42:40.000GMT</code></td>
+  </tr>
+  <tr>
     <td><code>/applications/[app-id]/jobs</code></td>
     <td>A list of all jobs for a given application</td>
+  </tr>
+  <tr>
+     <td></td>
+     <td><code>?status=[complete|succeeded|failed]</code> list only jobs in the state</td>
   </tr>
   <tr>
     <td><code>/applications/[app-id]/jobs/[job-id]</code></td>
@@ -245,6 +261,10 @@ for a running application, at `http://localhost:4040/api/v1`.
     <td>A list of all attempts for the given stage</td>
   </tr>
   <tr>
+     <td></td>
+     <td><code>?status=[active|complete|pending|failed]</code> list only stages in the state</td>
+  </tr>
+  <tr>
     <td><code>/applications/[app-id]/stages/[stage-id]/[stage-attempt-id]</code></td>
     <td>Details for the given stage attempt</td>
   </tr>
@@ -253,8 +273,22 @@ for a running application, at `http://localhost:4040/api/v1`.
     <td>Summary metrics of all tasks in the given stage attempt</td>
   </tr>
   <tr>
+     <td></td>
+     <td><code>?quantiles</code> summarize the metrics with the given quantiles.
+     e.g. <code>?quantiles=0.01,0.5,0.99</code></td>
+  </tr>
+  <tr>
     <td><code>/applications/[app-id]/stages/[stage-id]/[stage-attempt-id]/taskList</code></td>
     <td>A list of all tasks for the given stage attempt</td>
+  </tr>
+  <tr>
+     <td></td>
+     <td><code>?offset=[offset]&amp;length=[len]</code> list only tasks in the range.
+      e.g. <code>?offset=10&amp;length=50</code></td>
+  </tr>
+  <tr>
+     <td></td>
+     <td><code>?sortBy=[runtime|-runtime]</code> sort the tasks</td>
   </tr>
   <tr>
     <td><code>/applications/[app-id]/executors</code></td>

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -222,6 +222,11 @@ both running applications, and in the history server.  The endpoints are mounted
 for the history server, they would typically be accessible at `http://<server-url>:18080/api/v1`, and
 for a running application, at `http://localhost:4040/api/v1`.
 
+In the API, an application is referenced by its application ID, `[app-id]`.
+When running on YARN, each application may have multiple attempts; each identified by their `[attempt-id]`.
+In the API listed below, `[app-id]` will actually be `[base-app-id]/[attempt-id]`,
+where `[base-app-id]` is the YARN application ID.
+
 <table class="table">
   <tr><th>Endpoint</th><th>Meaning</th></tr>
   <tr>
@@ -229,26 +234,26 @@ for a running application, at `http://localhost:4040/api/v1`.
     <td>A list of all applications</td>
   </tr>
   <tr>
-     <td></td>
-     <td><code>?status=[completed|running]</code> list only applications in the chosen state</td>
+    <td></td>
+    <td><code>?status=[completed|running]</code> list only applications in the chosen state</td>
   </tr>
   <tr>
-     <td></td>
-     <td><code>?minDate=[date]</code> earliest date/time to list. Examples:
-     <br><code>?minDate=2015-02-10</code>
-     <br><code>?minDate=2015-02-03T16:42:40.000GMT</code></td>
+    <td></td>
+    <td><code>?minDate=[date]</code> earliest date/time to list. Examples:
+    <br><code>?minDate=2015-02-10</code>
+    <br><code>?minDate=2015-02-03T16:42:40.000GMT</code></td>
   </tr>
   <tr>
-     <td></td>
-     <td><code>?maxDate=[date]</code> latest date/time to list; uses same format as <code>minDate</code></td>
+    <td></td>
+    <td><code>?maxDate=[date]</code> latest date/time to list; uses same format as <code>minDate</code></td>
   </tr>
   <tr>
     <td><code>/applications/[app-id]/jobs</code></td>
     <td>A list of all jobs for a given application</td>
   </tr>
   <tr>
-     <td></td>
-     <td><code>?status=[complete|succeeded|failed]</code> list only jobs in the state</td>
+    <td></td>
+    <td><code>?status=[complete|succeeded|failed]</code> list only jobs in the state</td>
   </tr>
   <tr>
     <td><code>/applications/[app-id]/jobs/[job-id]</code></td>
@@ -263,8 +268,8 @@ for a running application, at `http://localhost:4040/api/v1`.
     <td>A list of all attempts for the given stage</td>
   </tr>
   <tr>
-     <td></td>
-     <td><code>?status=[active|complete|pending|failed]</code> list only stages in the state</td>
+    <td></td>
+    <td><code>?status=[active|complete|pending|failed]</code> list only stages in the state</td>
   </tr>
   <tr>
     <td><code>/applications/[app-id]/stages/[stage-id]/[stage-attempt-id]</code></td>
@@ -275,22 +280,22 @@ for a running application, at `http://localhost:4040/api/v1`.
     <td>Summary metrics of all tasks in the given stage attempt</td>
   </tr>
   <tr>
-     <td></td>
-     <td><code>?quantiles</code> summarize the metrics with the given quantiles.
-     Example: <br><code>?quantiles=0.01,0.5,0.99</code></td>
+    <td></td>
+    <td><code>?quantiles</code> summarize the metrics with the given quantiles.
+    Example: <br><code>?quantiles=0.01,0.5,0.99</code></td>
   </tr>
   <tr>
     <td><code>/applications/[app-id]/stages/[stage-id]/[stage-attempt-id]/taskList</code></td>
     <td>A list of all tasks for the given stage attempt</td>
   </tr>
   <tr>
-     <td></td>
-     <td><code>?offset=[offset]&amp;length=[len]</code> list only tasks in the range.
-      Example: <br> <code>?offset=10&amp;length=50</code></td>
+    <td></td>
+    <td><code>?offset=[offset]&amp;length=[len]</code> list only tasks in the range.
+    Example: <br> <code>?offset=10&amp;length=50</code></td>
   </tr>
   <tr>
-     <td></td>
-     <td><code>?sortBy=[runtime|-runtime]</code> sort the tasks</td>
+    <td></td>
+    <td><code>?sortBy=[runtime|-runtime]</code> sort the tasks</td>
   </tr>
   <tr>
     <td><code>/applications/[app-id]/executors</code></td>
@@ -305,17 +310,23 @@ for a running application, at `http://localhost:4040/api/v1`.
     <td>Details for the storage status of a given RDD</td>
   </tr>
   <tr>
-    <td><code>/applications/[app-id]/logs</code></td>
-    <td>Download the event logs for all attempts of the given application as a zip file</td>
+    <td><code>/applications/[base-app-id]/logs</code></td>
+    <td>Download the event logs for all attempts of the given application as a zip file.
+    </td>
   </tr>
   <tr>
-    <td><code>/applications/[app-id]/logs</code></td>
-    <td>Download the event logs for the application as a zip file</td>
+    <td><code>/applications/[base-app-id]/[attempt-id]/logs</code></td>
+    <td>Download the event logs for a specific application as a zip file</td>
   </tr>
 </table>
 
-When running on Yarn, each application has multiple attempts, so `[app-id]` is actually
-`[app-id]/[attempt-id]` in all cases.
+The number of jobs and stages which can retrieved is constrained by the same garbage
+collection mechanism of the standalone Spark UI; `"spark.ui.retainedJobs"` defines the threshold
+value triggering garbage collection on jobs, and `spark.ui.retainedStages` that for stages.
+Note that the garbage collection takes place on playback: it is actually possible to retrieve
+more entries by increasing these values and restarting the history server.
+
+### API Versioning Policy
 
 These endpoints have been strongly versioned to make it easier to develop applications on top.
  In particular, Spark guarantees:


### PR DESCRIPTION
Add to the REST API details on the ? args and examples from the test suite.

I've used the existing table, adding all the fields to the second table.

see [in the pr](https://github.com/steveloughran/spark/blob/history/SPARK-13267-doc-params/docs/monitoring.md).

There's a slightly more sophisticated option: make the table 3 columns wide, and for all existing entries, have the initial `td` span 2 columns. The new entries would then have an empty 1st column, param in 2nd and text in 3rd, with any examples after a `br` entry.
