### PR TITLE
[SPARK-13276] Catch bad characters at the end of a Table Identifier/Expression string

### DIFF
--- a/sql/catalyst/src/main/antlr3/org/apache/spark/sql/catalyst/parser/SparkSqlParser.g
+++ b/sql/catalyst/src/main/antlr3/org/apache/spark/sql/catalyst/parser/SparkSqlParser.g
@@ -722,6 +722,18 @@ statement
     | (KW_SET)=> KW_SET -> ^(TOK_SETCONFIG)
 	;
 
+// Rule for expression parsing
+singleNamedExpression
+    :
+    namedExpression EOF
+    ;
+
+// Rule for table name parsing
+singleTableName
+    :
+    tableName EOF
+    ;
+
 explainStatement
 @init { pushMsg("explain statement", state); }
 @after { popMsg(state); }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
@@ -35,12 +35,12 @@ object ParseDriver extends Logging {
 
   /** Create an Expression ASTNode from a SQL command. */
   def parseExpression(command: String, conf: ParserConf): ASTNode = parse(command, conf) { parser =>
-    parser.namedExpression().getTree
+    parser.singleNamedExpression().getTree
   }
 
   /** Create an TableIdentifier ASTNode from a SQL command. */
   def parseTableName(command: String, conf: ParserConf): ASTNode = parse(command, conf) { parser =>
-    parser.tableName().getTree
+    parser.singleTableName().getTree
   }
 
   private def parse(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystQlSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/CatalystQlSuite.scala
@@ -134,14 +134,15 @@ class CatalystQlSuite extends PlanTest {
           Literal("o") ::
           UnresolvedFunction("o", UnresolvedAttribute("bar") :: Nil, false) ::
           Nil, false)))
+
+    intercept[AnalysisException](parser.parseExpression("1 - f('o', o(bar)) hello * world"))
   }
 
   test("table identifier") {
     assert(TableIdentifier("q") === parser.parseTableIdentifier("q"))
     assert(TableIdentifier("q", Some("d")) === parser.parseTableIdentifier("d.q"))
     intercept[AnalysisException](parser.parseTableIdentifier(""))
-    // TODO parser swallows third identifier.
-    // intercept[AnalysisException](parser.parseTableIdentifier("d.q.g"))
+    intercept[AnalysisException](parser.parseTableIdentifier("d.q.g"))
   }
 
   test("parse union/except/intersect") {


### PR DESCRIPTION
The parser currently parses the following strings without a hitch:
- Table Identifier:
  - `a.b.c` should fail, but results in the following table identifier `a.b`
  - `table!#` should fail, but results in the following table identifier `table`
- Expression
  - `1+2 r+e` should fail, but results in the following expression `1 + 2`

This PR fixes this by adding terminated rules for both expression parsing and table identifier parsing.

cc @cloud-fan (we discussed this in https://github.com/apache/spark/pull/10649) @jayadevanmurali (this causes your PR https://github.com/apache/spark/pull/11051 to fail)
