### PR TITLE
Drop private for JobFailed

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/JobResult.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/JobResult.scala
@@ -30,4 +30,4 @@ sealed trait JobResult
 case object JobSucceeded extends JobResult
 
 @DeveloperApi
-private[spark] case class JobFailed(exception: Exception) extends JobResult
+case class JobFailed(exception: Exception) extends JobResult


### PR DESCRIPTION
In the thread, 'SparkListener - why is org.apache.spark.scheduler.JobFailed in scala private', Sumona was requesting JobFailed to be accessible by user application.

@andrewor14 
Please take a look.
