### PR TITLE
[SPARK-13149][SQL][FOLLOWUP]Make FileStreamSource thread-safe and atomic

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.streaming
 
 import java.io._
-import javax.annotation.concurrent.{GuardedBy, ThreadSafe}
+import javax.annotation.concurrent.GuardedBy
 
 import scala.collection.mutable.HashMap
 import scala.io.Codec
@@ -32,11 +32,12 @@ import org.apache.spark.sql.types.{StringType, StructType}
 import org.apache.spark.util.collection.OpenHashSet
 
 /**
- * A very simple source that reads text files from the given directory as they appear.
+ * A very simple source that reads text files from the given directory as they appear. This class is
+ * thread-safe and can be called in multiple threads from different
+ * [[org.apache.spark.sql.ContinuousQuery ContinuousQuery]].
  *
  * TODO Clean up the metadata files periodically
  */
-@ThreadSafe
 class FileStreamSource(
     sqlContext: SQLContext,
     metadataPath: String,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/Source.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/Source.scala
@@ -17,16 +17,16 @@
 
 package org.apache.spark.sql.execution.streaming
 
-import javax.annotation.concurrent.ThreadSafe
-
 import org.apache.spark.sql.types.StructType
 
 /**
  * A source of continually arriving data for a streaming query. A [[Source]] must have a
  * monotonically increasing notion of progress that can be represented as an [[Offset]]. Spark
  * will regularly query each [[Source]] to see if any more data is available.
+ *
+ * The implementation should be thread-safe because it can be called in multiple threads from
+ * different [[org.apache.spark.sql.ContinuousQuery ContinuousQuery]].
  */
-@ThreadSafe
 trait Source  {
 
   /** Returns the schema of the data from this source */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/Source.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/Source.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.execution.streaming
 
+import javax.annotation.concurrent.ThreadSafe
+
 import org.apache.spark.sql.types.StructType
 
 /**
@@ -24,6 +26,7 @@ import org.apache.spark.sql.types.StructType
  * monotonically increasing notion of progress that can be represented as an [[Offset]]. Spark
  * will regularly query each [[Source]] to see if any more data is available.
  */
+@ThreadSafe
 trait Source  {
 
   /** Returns the schema of the data from this source */

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types.{StringType, StructType}
 import org.apache.spark.util.Utils
 
-class FileStreamSourceTest extends StreamTest with SharedSQLContext {
+abstract class FileStreamSourceTest extends StreamTest with SharedSQLContext {
 
   import testImplicits._
 


### PR DESCRIPTION
- Make FileStreamSource thread-safe to use FileStreamSource in multiple queries.
- Only update FileStreamSource's status before returning to make it atomic.
