### PR TITLE
[SPARK-5095] remove flaky test

### DIFF
--- a/core/src/test/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackendSuite.scala
@@ -300,6 +300,11 @@ class CoarseMesosSchedulerBackendSuite extends SparkFunSuite
       override protected def createDriverEndpointRef(
           properties: ArrayBuffer[(String, String)]): RpcEndpointRef = endpoint
 
+      // override to avoid race condition with the driver thread on `mesosDriver`
+      override def startScheduler(newDriver: SchedulerDriver): Unit = {
+        mesosDriver = newDriver
+      }
+
       markRegistered()
     }
     backend.start()


### PR DESCRIPTION
Overrode the start() method, which was previously starting a thread causing a race condition. I believe this should fix the flaky test.
