### PR TITLE
[SPARK-13277][SQL] ANTLR ignores other rule using the USING keyword

### DIFF
--- a/sql/catalyst/src/main/antlr3/org/apache/spark/sql/catalyst/parser/SparkSqlParser.g
+++ b/sql/catalyst/src/main/antlr3/org/apache/spark/sql/catalyst/parser/SparkSqlParser.g
@@ -949,7 +949,7 @@ createTableStatement
          tablePropertiesPrefixed?
          )
       |
-         tableProvider
+         (tableProvider) => tableProvider
          tableOpts?
          (KW_AS selectStatementWithCTE)?
       -> ^(TOK_CREATETABLEUSING $name $temp? ifNotExists?


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-13277

There is an ANTLR warning during compilation:

```
warning(200): org/apache/spark/sql/catalyst/parser/SparkSqlParser.g:938:7: 
Decision can match input such as "KW_USING Identifier" using multiple alternatives: 2, 3

As a result, alternative(s) 3 were disabled for that input
```

This patch is to fix it.
