### PR TITLE
[SPARK-13277][BUILD] Follow-up ANTLR warnings are treated as build errors

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -433,7 +433,7 @@ object Catalyst {
       }
 
       // Generate the parser.
-      antlr.process
+      antlr.process()
       val errorState = org.antlr.tool.ErrorManager.getErrorState
       if (errorState.errors > 0) {
         sys.error("ANTLR: Caught %d build errors.".format(errorState.errors))

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -434,8 +434,11 @@ object Catalyst {
 
       // Generate the parser.
       antlr.process
-      if (antlr.getNumErrors > 0) {
-        log.error("ANTLR: Caught %d build errors.".format(antlr.getNumErrors))
+      val errorState = org.antlr.tool.ErrorManager.getErrorState
+      if (errorState.errors > 0) {
+        sys.error("ANTLR: Caught %d build errors.".format(errorState.errors))
+      } else if (errorState.warnings > 0) {
+        sys.error("ANTLR: Caught %d build warnings.".format(errorState.warnings))
       }
 
       // Return all generated java files.

--- a/sql/catalyst/src/main/antlr3/org/apache/spark/sql/catalyst/parser/SparkSqlParser.g
+++ b/sql/catalyst/src/main/antlr3/org/apache/spark/sql/catalyst/parser/SparkSqlParser.g
@@ -949,7 +949,7 @@ createTableStatement
          tablePropertiesPrefixed?
          )
       |
-         tableProvider
+         (tableProvider) => tableProvider
          tableOpts?
          (KW_AS selectStatementWithCTE)?
       -> ^(TOK_CREATETABLEUSING $name $temp? ifNotExists?

--- a/sql/catalyst/src/main/antlr3/org/apache/spark/sql/catalyst/parser/SparkSqlParser.g
+++ b/sql/catalyst/src/main/antlr3/org/apache/spark/sql/catalyst/parser/SparkSqlParser.g
@@ -949,7 +949,7 @@ createTableStatement
          tablePropertiesPrefixed?
          )
       |
-         (tableProvider) => tableProvider
+         tableProvider
          tableOpts?
          (KW_AS selectStatementWithCTE)?
       -> ^(TOK_CREATETABLEUSING $name $temp? ifNotExists?


### PR DESCRIPTION
It is possible to create faulty but legal ANTLR grammars. ANTLR will produce warnings but also a valid compileable parser. This PR makes sure we treat such warnings as build errors.

cc @rxin / @viirya 
