### PR TITLE
[SPARK-12630][PYSPARK] [DOC] PySpark classification parameter desc to consistent format

### DIFF
--- a/python/pyspark/mllib/classification.py
+++ b/python/pyspark/mllib/classification.py
@@ -94,16 +94,18 @@ class LogisticRegressionModel(LinearClassificationModel):
     Classification model trained using Multinomial/Binary Logistic
     Regression.
 
-    :param weights: Weights computed for every feature.
-    :param intercept: Intercept computed for this model. (Only used
-            in Binary Logistic Regression. In Multinomial Logistic
-            Regression, the intercepts will not be a single value,
-            so the intercepts will be part of the weights.)
-    :param numFeatures: the dimension of the features.
-    :param numClasses: the number of possible outcomes for k classes
-            classification problem in Multinomial Logistic Regression.
-            By default, it is binary logistic regression so numClasses
-            will be set to 2.
+    :param weights:
+      Weights computed for every feature.
+    :param intercept:
+      Intercept computed for this model. (Only used in Binary Logistic
+      Regression. In Multinomial Logistic Regression, the intercepts will not
+      be a single value, so the intercepts will be part of the weights.)
+    :param numFeatures:
+      the dimension of the features.
+    :param numClasses:
+      the number of possible outcomes for k classes classification problem in
+      Multinomial Logistic Regression. By default, it is binary logistic
+      regression so numClasses will be set to 2.
 
     >>> data = [
     ...     LabeledPoint(0.0, [0.0, 1.0]),
@@ -272,37 +274,42 @@ class LogisticRegressionWithSGD(object):
         """
         Train a logistic regression model on the given data.
 
-        :param data:              The training data, an RDD of
-                                  LabeledPoint.
-        :param iterations:        The number of iterations
-                                  (default: 100).
-        :param step:              The step parameter used in SGD
-                                  (default: 1.0).
-        :param miniBatchFraction: Fraction of data to be used for each
-                                  SGD iteration (default: 1.0).
-        :param initialWeights:    The initial weights (default: None).
-        :param regParam:          The regularizer parameter
-                                  (default: 0.01).
-        :param regType:           The type of regularizer used for
-                                  training our model.
-
-                                  :Allowed values:
-                                     - "l1" for using L1 regularization
-                                     - "l2" for using L2 regularization
-                                     - None for no regularization
-
-                                     (default: "l2")
-
-        :param intercept:         Boolean parameter which indicates the
-                                  use or not of the augmented representation
-                                  for training data (i.e. whether bias
-                                  features are activated or not,
-                                  default: False).
-        :param validateData:      Boolean parameter which indicates if
-                                  the algorithm should validate data
-                                  before training. (default: True)
-        :param convergenceTol:    A condition which decides iteration termination.
-                                  (default: 0.001)
+        :param data:
+          The training data, an RDD of LabeledPoint.
+        :param iterations:
+          The number of iterations.
+          (default: 100)
+        :param step:
+          The step parameter used in SGD.
+          (default: 1.0)
+        :param miniBatchFraction:
+          Fraction of data to be used for each SGD iteration.
+          (default: 1.0)
+        :param initialWeights:
+          The initial weights.
+          (default: None)
+        :param regParam:
+          The regularizer parameter.
+          (default: 0.01)
+        :param regType:
+          The type of regularizer used for training our model.
+          :Allowed values:
+            - "l1" for using L1 regularization
+            - "l2" for using L2 regularization
+            - None for no regularization
+          (default: "l2")
+        :param intercept:
+          Boolean parameter which indicates the use or not of the augmented
+          representation for training data (i.e. whether bias features are
+          activated or not).
+          (default: False)
+        :param validateData:
+          Boolean parameter which indicates if the algorithm should validate
+          data before training.
+          (default: True)
+        :param convergenceTol:
+          A condition which decides iteration termination.
+          (default: 0.001)
         """
         def train(rdd, i):
             return callMLlibFunc("trainLogisticRegressionModelWithSGD", rdd, int(iterations),
@@ -323,38 +330,45 @@ class LogisticRegressionWithLBFGS(object):
         """
         Train a logistic regression model on the given data.
 
-        :param data:           The training data, an RDD of
-                               LabeledPoint.
-        :param iterations:     The number of iterations
-                               (default: 100).
-        :param initialWeights: The initial weights (default: None).
-        :param regParam:       The regularizer parameter
-                               (default: 0.01).
-        :param regType:        The type of regularizer used for
-                               training our model.
+        :param data:
+          The training data, an RDD of LabeledPoint.
+        :param iterations:
+          The number of iterations
+          (default: 100).
+        :param initialWeights:
+          The initial weights
+          (default: None).
+        :param regParam:
+          The regularizer parameter
+          (default: 0.01).
+        :param regType:
+          The type of regularizer used for training our model.
 
-                               :Allowed values:
-                                 - "l1" for using L1 regularization
-                                 - "l2" for using L2 regularization
-                                 - None for no regularization
+          :Allowed values:
+            - "l1" for using L1 regularization
+            - "l2" for using L2 regularization
+            - None for no regularization
+          (default: "l2")
 
-                                 (default: "l2")
-
-        :param intercept:      Boolean parameter which indicates the
-                               use or not of the augmented representation
-                               for training data (i.e. whether bias
-                               features are activated or not,
-                               default: False).
-        :param corrections:    The number of corrections used in the
-                               LBFGS update (default: 10).
-        :param tolerance:      The convergence tolerance of iterations
-                               for L-BFGS (default: 1e-4).
-        :param validateData:   Boolean parameter which indicates if the
-                               algorithm should validate data before
-                               training. (default: True)
-        :param numClasses:     The number of classes (i.e., outcomes) a
-                               label can take in Multinomial Logistic
-                               Regression (default: 2).
+        :param intercept:
+          Boolean parameter which indicates the use or not of the augmented
+          representation for training data (i.e. whether bias features are
+          activated or not)
+         (default: False)
+        :param corrections:
+           The number of corrections used in the LBFGS update.
+          (default: 10)
+        :param tolerance:
+          The convergence tolerance of iterations for L-BFGS.
+          (default: 1e-4)
+        :param validateData:
+          Boolean parameter which indicates if the algorithm should validate
+          data before training.
+          (default: True)
+        :param numClasses:
+          The number of classes (i.e., outcomes) a label can take in Multinomial
+          Logistic Regression
+          (default: 2).
 
         >>> data = [
         ...     LabeledPoint(0.0, [0.0, 1.0]),
@@ -387,8 +401,10 @@ class SVMModel(LinearClassificationModel):
     """
     Model for Support Vector Machines (SVMs).
 
-    :param weights: Weights computed for every feature.
-    :param intercept: Intercept computed for this model.
+    :param weights:
+      Weights computed for every feature.
+    :param intercept:
+      Intercept computed for this model.
 
     >>> data = [
     ...     LabeledPoint(0.0, [0.0]),
@@ -490,37 +506,45 @@ class SVMWithSGD(object):
         """
         Train a support vector machine on the given data.
 
-        :param data:              The training data, an RDD of
-                                  LabeledPoint.
-        :param iterations:        The number of iterations
-                                  (default: 100).
-        :param step:              The step parameter used in SGD
-                                  (default: 1.0).
-        :param regParam:          The regularizer parameter
-                                  (default: 0.01).
-        :param miniBatchFraction: Fraction of data to be used for each
-                                  SGD iteration (default: 1.0).
-        :param initialWeights:    The initial weights (default: None).
-        :param regType:           The type of regularizer used for
-                                  training our model.
+        :param data:
+          The training data, an RDD of LabeledPoint.
+        :param iterations:
+          The number of iterations.
+          (default: 100)
+        :param step:
+          The step parameter used in SGD.
+          (default: 1.0)
+        :param regParam:
+          The regularizer parameter.
+          (default: 0.01)
+        :param miniBatchFraction:
+          Fraction of data to be used for each SGD iteration.
+          (default: 1.0)
+        :param initialWeights:
+          The initial weights.
+          (default: None)
+        :param regType:
+          The type of regularizer used for training our model.
 
-                                  :Allowed values:
-                                     - "l1" for using L1 regularization
-                                     - "l2" for using L2 regularization
-                                     - None for no regularization
+          :Allowed values:
+            - "l1" for using L1 regularization
+            - "l2" for using L2 regularization
+            - None for no regularization
 
-                                     (default: "l2")
+          (default: "l2")
 
-        :param intercept:         Boolean parameter which indicates the
-                                  use or not of the augmented representation
-                                  for training data (i.e. whether bias
-                                  features are activated or not,
-                                  default: False).
-        :param validateData:      Boolean parameter which indicates if
-                                  the algorithm should validate data
-                                  before training. (default: True)
-        :param convergenceTol:    A condition which decides iteration termination.
-                                  (default: 0.001)
+        :param intercept:
+          Boolean parameter which indicates the use or not of the augmented
+          representation for training data (i.e. whether bias features are
+          activated or not).
+          (default: False)
+        :param validateData:
+          Boolean parameter which indicates if the algorithm should validate
+          data before training.
+          (default: True)
+        :param convergenceTol:
+          A condition which decides iteration termination.
+          (default: 0.001)
         """
         def train(rdd, i):
             return callMLlibFunc("trainSVMModelWithSGD", rdd, int(iterations), float(step),
@@ -536,11 +560,13 @@ class NaiveBayesModel(Saveable, Loader):
     """
     Model for Naive Bayes classifiers.
 
-    :param labels: list of labels.
-    :param pi: log of class priors, whose dimension is C,
-            number of labels.
-    :param theta: log of class conditional probabilities, whose
-            dimension is C-by-D, where D is number of features.
+    :param labels:
+      list of labels.
+    :param pi:
+      log of class priors, whose dimension is C, number of labels.
+    :param theta:
+      log of class conditional probabilities, whose dimension is C-by-D,
+      where D is number of features.
 
     >>> data = [
     ...     LabeledPoint(0.0, [0.0, 0.0]),
@@ -639,8 +665,11 @@ class NaiveBayes(object):
         it can also be used as Bernoulli NB (U{http://tinyurl.com/p7c96j6}).
         The input feature values must be nonnegative.
 
-        :param data: RDD of LabeledPoint.
-        :param lambda_: The smoothing parameter (default: 1.0).
+        :param data:
+          RDD of LabeledPoint.
+        :param lambda_:
+          The smoothing parameter.
+          (default: 1.0)
         """
         first = data.first()
         if not isinstance(first, LabeledPoint):

--- a/python/pyspark/mllib/classification.py
+++ b/python/pyspark/mllib/classification.py
@@ -91,21 +91,19 @@ class LinearClassificationModel(LinearModel):
 class LogisticRegressionModel(LinearClassificationModel):
 
     """
-    Classification model trained using Multinomial/Binary Logistic
-    Regression.
+    Classification model trained using Multinomial/Binary Logistic Regression.
 
     :param weights:
       Weights computed for every feature.
     :param intercept:
-      Intercept computed for this model. (Only used in Binary Logistic
-      Regression. In Multinomial Logistic Regression, the intercepts will not
-      be a single value, so the intercepts will be part of the weights.)
+      Intercept computed for this model. (Only used in Binary Logistic Regression. In  Multinomial
+      Logistic Regression, the intercepts will not be a single value, so the intercepts will be part
+      of the weights.)
     :param numFeatures:
-      the dimension of the features.
+      The dimension of the features.
     :param numClasses:
-      the number of possible outcomes for k classes classification problem in
-      Multinomial Logistic Regression. By default, it is binary logistic
-      regression so numClasses will be set to 2.
+      The number of possible outcomes for k classes classification problem in Multinomial Logistic
+      Regression. By default, it is binary logistic regression so numClasses will be set to 2.
 
     >>> data = [
     ...     LabeledPoint(0.0, [0.0, 1.0]),
@@ -299,13 +297,11 @@ class LogisticRegressionWithSGD(object):
             - None for no regularization
           (default: "l2")
         :param intercept:
-          Boolean parameter which indicates the use or not of the augmented
-          representation for training data (i.e. whether bias features are
-          activated or not).
+          Boolean parameter which indicates the use or not of the augmented representation for
+          training data (i.e., whether bias features are activated or not).
           (default: False)
         :param validateData:
-          Boolean parameter which indicates if the algorithm should validate
-          data before training.
+          Boolean parameter which indicates if the algorithm should validate data before training.
           (default: True)
         :param convergenceTol:
           A condition which decides iteration termination.
@@ -333,42 +329,37 @@ class LogisticRegressionWithLBFGS(object):
         :param data:
           The training data, an RDD of LabeledPoint.
         :param iterations:
-          The number of iterations
-          (default: 100).
+          The number of iterations.
+          (default: 100)
         :param initialWeights:
-          The initial weights
-          (default: None).
+          The initial weights.
+          (default: None)
         :param regParam:
-          The regularizer parameter
-          (default: 0.01).
+          The regularizer parameter.
+          (default: 0.01)
         :param regType:
           The type of regularizer used for training our model.
-
           :Allowed values:
             - "l1" for using L1 regularization
             - "l2" for using L2 regularization
             - None for no regularization
           (default: "l2")
-
         :param intercept:
-          Boolean parameter which indicates the use or not of the augmented
-          representation for training data (i.e. whether bias features are
-          activated or not)
-         (default: False)
+          Boolean parameter which indicates the use or not of the augmented representation for
+          training data (i.e., whether bias features are activated or not).
+          (default: False)
         :param corrections:
-           The number of corrections used in the LBFGS update.
+          The number of corrections used in the LBFGS update.
           (default: 10)
         :param tolerance:
           The convergence tolerance of iterations for L-BFGS.
           (default: 1e-4)
         :param validateData:
-          Boolean parameter which indicates if the algorithm should validate
-          data before training.
+          Boolean parameter which indicates if the algorithm should validate data before training.
           (default: True)
         :param numClasses:
-          The number of classes (i.e., outcomes) a label can take in Multinomial
-          Logistic Regression
-          (default: 2).
+          The number of classes (i.e., outcomes) a label can take in Multinomial Logistic Regression.
+          (default: 2)
 
         >>> data = [
         ...     LabeledPoint(0.0, [0.0, 1.0]),
@@ -525,22 +516,17 @@ class SVMWithSGD(object):
           (default: None)
         :param regType:
           The type of regularizer used for training our model.
-
           :Allowed values:
             - "l1" for using L1 regularization
             - "l2" for using L2 regularization
             - None for no regularization
-
           (default: "l2")
-
         :param intercept:
-          Boolean parameter which indicates the use or not of the augmented
-          representation for training data (i.e. whether bias features are
-          activated or not).
+          Boolean parameter which indicates the use or not of the augmented representation for
+          training data (i.e. whether bias features are activated or not).
           (default: False)
         :param validateData:
-          Boolean parameter which indicates if the algorithm should validate
-          data before training.
+          Boolean parameter which indicates if the algorithm should validate data before training.
           (default: True)
         :param convergenceTol:
           A condition which decides iteration termination.
@@ -561,12 +547,11 @@ class NaiveBayesModel(Saveable, Loader):
     Model for Naive Bayes classifiers.
 
     :param labels:
-      list of labels.
+      List of labels.
     :param pi:
-      log of class priors, whose dimension is C, number of labels.
+      Log of class priors, whose dimension is C, number of labels.
     :param theta:
-      log of class conditional probabilities, whose dimension is C-by-D,
-      where D is number of features.
+      Log of class conditional probabilities, whose dimension is C-by-D, where D is number of features.
 
     >>> data = [
     ...     LabeledPoint(0.0, [0.0, 0.0]),

--- a/python/pyspark/mllib/classification.py
+++ b/python/pyspark/mllib/classification.py
@@ -96,14 +96,16 @@ class LogisticRegressionModel(LinearClassificationModel):
     :param weights:
       Weights computed for every feature.
     :param intercept:
-      Intercept computed for this model. (Only used in Binary Logistic Regression. In  Multinomial
-      Logistic Regression, the intercepts will not be a single value, so the intercepts will be part
-      of the weights.)
+      Intercept computed for this model. (Only used in Binary Logistic
+      Regression. In Multinomial Logistic Regression, the intercepts will
+      not bea single value, so the intercepts will be part of the
+      weights.)
     :param numFeatures:
       The dimension of the features.
     :param numClasses:
-      The number of possible outcomes for k classes classification problem in Multinomial Logistic
-      Regression. By default, it is binary logistic regression so numClasses will be set to 2.
+      The number of possible outcomes for k classes classification problem
+      in Multinomial Logistic Regression. By default, it is binary
+      logistic regression so numClasses will be set to 2.
 
     >>> data = [
     ...     LabeledPoint(0.0, [0.0, 1.0]),
@@ -297,11 +299,13 @@ class LogisticRegressionWithSGD(object):
             - None for no regularization
           (default: "l2")
         :param intercept:
-          Boolean parameter which indicates the use or not of the augmented representation for
-          training data (i.e., whether bias features are activated or not).
+          Boolean parameter which indicates the use or not of the
+          augmented representation for training data (i.e., whether bias
+          features are activated or not).
           (default: False)
         :param validateData:
-          Boolean parameter which indicates if the algorithm should validate data before training.
+          Boolean parameter which indicates if the algorithm should
+          validate data before training.
           (default: True)
         :param convergenceTol:
           A condition which decides iteration termination.
@@ -345,8 +349,9 @@ class LogisticRegressionWithLBFGS(object):
             - None for no regularization
           (default: "l2")
         :param intercept:
-          Boolean parameter which indicates the use or not of the augmented representation for
-          training data (i.e., whether bias features are activated or not).
+          Boolean parameter which indicates the use or not of the
+          augmented representation for training data (i.e., whether bias
+          features are activated or not).
           (default: False)
         :param corrections:
           The number of corrections used in the LBFGS update.
@@ -355,10 +360,12 @@ class LogisticRegressionWithLBFGS(object):
           The convergence tolerance of iterations for L-BFGS.
           (default: 1e-4)
         :param validateData:
-          Boolean parameter which indicates if the algorithm should validate data before training.
+          Boolean parameter which indicates if the algorithm should
+          validate data before training.
           (default: True)
         :param numClasses:
-          The number of classes (i.e., outcomes) a label can take in Multinomial Logistic Regression.
+          The number of classes (i.e., outcomes) a label can take in
+          Multinomial Logistic Regression.
           (default: 2)
 
         >>> data = [
@@ -522,11 +529,13 @@ class SVMWithSGD(object):
             - None for no regularization
           (default: "l2")
         :param intercept:
-          Boolean parameter which indicates the use or not of the augmented representation for
-          training data (i.e. whether bias features are activated or not).
+          Boolean parameter which indicates the use or not of the
+          augmented representation for training data (i.e. whether bias
+          features are activated or not).
           (default: False)
         :param validateData:
-          Boolean parameter which indicates if the algorithm should validate data before training.
+          Boolean parameter which indicates if the algorithm should
+          validate data before training.
           (default: True)
         :param convergenceTol:
           A condition which decides iteration termination.
@@ -551,7 +560,8 @@ class NaiveBayesModel(Saveable, Loader):
     :param pi:
       Log of class priors, whose dimension is C, number of labels.
     :param theta:
-      Log of class conditional probabilities, whose dimension is C-by-D, where D is number of features.
+      Log of class conditional probabilities, whose dimension is C-by-D,
+      where D is number of features.
 
     >>> data = [
     ...     LabeledPoint(0.0, [0.0, 0.0]),
@@ -666,9 +676,9 @@ class NaiveBayes(object):
 @inherit_doc
 class StreamingLogisticRegressionWithSGD(StreamingLinearAlgorithm):
     """
-    Train or predict a logistic regression model on streaming data. Training uses
-    Stochastic Gradient Descent to update the model based on each new batch of
-    incoming data from a DStream.
+    Train or predict a logistic regression model on streaming data.
+    Training uses Stochastic Gradient Descent to update the model based on
+    each new batch of incoming data from a DStream.
 
     Each batch of data is assumed to be an RDD of LabeledPoints.
     The number of data points per batch can vary, but the number

--- a/python/pyspark/mllib/classification.py
+++ b/python/pyspark/mllib/classification.py
@@ -91,7 +91,8 @@ class LinearClassificationModel(LinearModel):
 class LogisticRegressionModel(LinearClassificationModel):
 
     """
-    Classification model trained using Multinomial/Binary Logistic Regression.
+    Classification model trained using Multinomial/Binary Logistic
+    Regression.
 
     :param weights:
       Weights computed for every feature.
@@ -191,8 +192,8 @@ class LogisticRegressionModel(LinearClassificationModel):
     @since('1.4.0')
     def numClasses(self):
         """
-        Number of possible outcomes for k classes classification problem in Multinomial
-        Logistic Regression.
+        Number of possible outcomes for k classes classification problem
+        in Multinomial Logistic Regression.
         """
         return self._numClasses
 

--- a/python/pyspark/mllib/classification.py
+++ b/python/pyspark/mllib/classification.py
@@ -294,11 +294,11 @@ class LogisticRegressionWithSGD(object):
           (default: 0.01)
         :param regType:
           The type of regularizer used for training our model.
-          :Allowed values:
+          Allowed values:
+
             - "l1" for using L1 regularization
-            - "l2" for using L2 regularization
+            - "l2" for using L2 regularization (default)
             - None for no regularization
-          (default: "l2")
         :param intercept:
           Boolean parameter which indicates the use or not of the
           augmented representation for training data (i.e., whether bias
@@ -344,11 +344,11 @@ class LogisticRegressionWithLBFGS(object):
           (default: 0.01)
         :param regType:
           The type of regularizer used for training our model.
-          :Allowed values:
+          Allowed values:
+
             - "l1" for using L1 regularization
-            - "l2" for using L2 regularization
+            - "l2" for using L2 regularization (default)
             - None for no regularization
-          (default: "l2")
         :param intercept:
           Boolean parameter which indicates the use or not of the
           augmented representation for training data (i.e., whether bias
@@ -524,11 +524,11 @@ class SVMWithSGD(object):
           (default: None)
         :param regType:
           The type of regularizer used for training our model.
-          :Allowed values:
+          Allowed values:
+
             - "l1" for using L1 regularization
-            - "l2" for using L2 regularization
+            - "l2" for using L2 regularization (default)
             - None for no regularization
-          (default: "l2")
         :param intercept:
           Boolean parameter which indicates the use or not of the
           augmented representation for training data (i.e. whether bias


### PR DESCRIPTION
Part of task for [SPARK-11219](https://issues.apache.org/jira/browse/SPARK-11219) to make PySpark MLlib parameter description formatting consistent. This is for the classification module.
