### PR TITLE
[SPARK-13253] [SQL]avoid checking nullability for complex data type for typeSuffix code path

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -137,6 +137,8 @@ abstract class Expression extends TreeNode[Expression] {
    */
   def dataType: DataType
 
+  def prettyDataType: DataType = dataType
+
   /**
    * Returns true if  all the children of this expression have been resolved to a specific schema
    * and false if any still contains any unresolved placeholders.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
@@ -55,6 +55,9 @@ case class SortOrder(child: Expression, direction: SortDirection)
   }
 
   override def dataType: DataType = child.dataType
+
+  override def prettyDataType: DataType = child.prettyDataType
+
   override def nullable: Boolean = child.nullable
 
   override def toString: String = s"$child ${direction.sql}"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/First.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/First.scala
@@ -53,6 +53,8 @@ case class First(child: Expression, ignoreNullsExpr: Expression) extends Declara
   // Return data type.
   override def dataType: DataType = child.dataType
 
+  override def prettyDataType: DataType = child.prettyDataType
+
   // Expected input data type.
   override def inputTypes: Seq[AbstractDataType] = Seq(AnyDataType)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Last.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Last.scala
@@ -50,6 +50,8 @@ case class Last(child: Expression, ignoreNullsExpr: Expression) extends Declarat
   // Return data type.
   override def dataType: DataType = child.dataType
 
+  override def prettyDataType: DataType = child.prettyDataType
+
   // Expected input data type.
   override def inputTypes: Seq[AbstractDataType] = Seq(AnyDataType)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Max.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Max.scala
@@ -33,6 +33,8 @@ case class Max(child: Expression) extends DeclarativeAggregate {
   // Return data type.
   override def dataType: DataType = child.dataType
 
+  override def prettyDataType: DataType = child.prettyDataType
+
   // Expected input data type.
   override def inputTypes: Seq[AbstractDataType] = Seq(AnyDataType)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Min.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Min.scala
@@ -33,6 +33,8 @@ case class Min(child: Expression) extends DeclarativeAggregate {
   // Return data type.
   override def dataType: DataType = child.dataType
 
+  override def prettyDataType: DataType = child.prettyDataType
+
   // Expected input data type.
   override def inputTypes: Seq[AbstractDataType] = Seq(AnyDataType)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala
@@ -33,6 +33,8 @@ case class Sum(child: Expression) extends DeclarativeAggregate {
   // Return data type.
   override def dataType: DataType = resultType
 
+  override def prettyDataType: DataType = prettyResultType
+
   override def inputTypes: Seq[AbstractDataType] =
     Seq(TypeCollection(LongType, DoubleType, DecimalType))
 
@@ -43,6 +45,12 @@ case class Sum(child: Expression) extends DeclarativeAggregate {
     case DecimalType.Fixed(precision, scale) =>
       DecimalType.bounded(precision + 10, scale)
     case _ => child.dataType
+  }
+
+  private lazy val prettyResultType = child.prettyDataType match {
+    case DecimalType.Fixed(precision, scale) =>
+      DecimalType.bounded(precision + 10, scale)
+    case _ => child.prettyDataType
   }
 
   private lazy val sumDataType = resultType

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
@@ -114,6 +114,7 @@ private[sql] case class AggregateExpression(
 
   override def children: Seq[Expression] = aggregateFunction :: Nil
   override def dataType: DataType = aggregateFunction.dataType
+  override def prettyDataType: DataType = aggregateFunction.prettyDataType
   override def foldable: Boolean = false
   override def nullable: Boolean = aggregateFunction.nullable
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -32,6 +32,8 @@ case class UnaryMinus(child: Expression) extends UnaryExpression
 
   override def dataType: DataType = child.dataType
 
+  override def prettyDataType: DataType = child.prettyDataType
+
   override def toString: String = s"-$child"
 
   private lazy val numeric = TypeUtils.getNumeric(dataType)
@@ -69,6 +71,7 @@ case class UnaryPositive(child: Expression)
   override def inputTypes: Seq[AbstractDataType] = Seq(TypeCollection.NumericAndInterval)
 
   override def dataType: DataType = child.dataType
+  override def prettyDataType: DataType = child.prettyDataType
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode =
     defineCodeGen(ctx, ev, c => c)
@@ -91,6 +94,8 @@ case class Abs(child: Expression)
 
   override def dataType: DataType = child.dataType
 
+  override def prettyDataType: DataType = child.prettyDataType
+
   private lazy val numeric = TypeUtils.getNumeric(dataType)
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = dataType match {
@@ -106,6 +111,8 @@ case class Abs(child: Expression)
 abstract class BinaryArithmetic extends BinaryOperator {
 
   override def dataType: DataType = left.dataType
+
+  override def prettyDataType: DataType = left.prettyDataType
 
   override lazy val resolved = childrenResolved && checkInputDataTypes().isSuccess
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/bitwiseExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/bitwiseExpressions.scala
@@ -117,6 +117,8 @@ case class BitwiseNot(child: Expression) extends UnaryExpression with ExpectsInp
 
   override def dataType: DataType = child.dataType
 
+  override def prettyDataType: DataType = child.prettyDataType
+
   override def toString: String = s"~$child"
 
   private lazy val not: (Any) => Any = dataType match {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -60,6 +60,7 @@ case class SortArray(base: Expression, ascendingOrder: Expression)
   override def left: Expression = base
   override def right: Expression = ascendingOrder
   override def dataType: DataType = base.dataType
+  override def prettyDataType: DataType = base.prettyDataType
   override def inputTypes: Seq[AbstractDataType] = Seq(ArrayType, BooleanType)
 
   override def checkInputDataTypes(): TypeCheckResult = base.dataType match {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
@@ -107,8 +107,10 @@ case class GetStructField(child: Expression, ordinal: Int, name: Option[String] 
   extends UnaryExpression with ExtractValue {
 
   private[sql] lazy val childSchema = child.dataType.asInstanceOf[StructType]
+  private[sql] lazy val prettyChildSchema = child.prettyDataType.asInstanceOf[StructType]
 
   override def dataType: DataType = childSchema(ordinal).dataType
+  override def prettyDataType: DataType = prettyChildSchema(ordinal).dataType
   override def nullable: Boolean = child.nullable || childSchema(ordinal).nullable
 
   override def toString: String = {
@@ -229,6 +231,8 @@ case class GetArrayItem(child: Expression, ordinal: Expression)
 
   override def dataType: DataType = child.dataType.asInstanceOf[ArrayType].elementType
 
+  override def prettyDataType: DataType = child.prettyDataType.asInstanceOf[ArrayType].elementType
+
   protected override def nullSafeEval(value: Any, ordinal: Any): Any = {
     val baseValue = value.asInstanceOf[ArrayData]
     val index = ordinal.asInstanceOf[Number].intValue()
@@ -277,6 +281,8 @@ case class GetMapValue(child: Expression, key: Expression)
   override def nullable: Boolean = true
 
   override def dataType: DataType = child.dataType.asInstanceOf[MapType].valueType
+
+  override def prettyDataType: DataType = child.prettyDataType.asInstanceOf[MapType].valueType
 
   // todo: current search is O(n), improve it.
   protected override def nullSafeEval(value: Any, ordinal: Any): Any = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
@@ -104,7 +104,7 @@ abstract class CaseWhenBase(
 
   override def dataType: DataType = branches.head._2.dataType
 
-  override def prettyDataType: DataType = thenList.head.prettyDataType
+  override def prettyDataType: DataType = branches.head._2.prettyDataType
 
   override def nullable: Boolean = {
     // Result is nullable if any of the branch is nullable, or if the else value is nullable

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
@@ -47,6 +47,8 @@ case class If(predicate: Expression, trueValue: Expression, falseValue: Expressi
 
   override def dataType: DataType = trueValue.dataType
 
+  override def prettyDataType: DataType = trueValue.prettyDataType
+
   override def eval(input: InternalRow): Any = {
     if (java.lang.Boolean.TRUE.equals(predicate.eval(input))) {
       trueValue.eval(input)
@@ -101,6 +103,8 @@ abstract class CaseWhenBase(
   }
 
   override def dataType: DataType = branches.head._2.dataType
+
+  override def prettyDataType: DataType = thenList.head.prettyDataType
 
   override def nullable: Boolean = {
     // Result is nullable if any of the branch is nullable, or if the else value is nullable
@@ -307,6 +311,8 @@ case class Least(children: Seq[Expression]) extends Expression {
 
   override def dataType: DataType = children.head.dataType
 
+  override def prettyDataType: DataType = children.head.prettyDataType
+
   override def eval(input: InternalRow): Any = {
     children.foldLeft[Any](null)((r, c) => {
       val evalc = c.eval(input)
@@ -366,6 +372,8 @@ case class Greatest(children: Seq[Expression]) extends Expression {
   }
 
   override def dataType: DataType = children.head.dataType
+
+  override def prettyDataType: DataType = children.head.prettyDataType
 
   override def eval(input: InternalRow): Any = {
     children.foldLeft[Any](null)((r, c) => {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/decimalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/decimalExpressions.scala
@@ -69,6 +69,7 @@ case class MakeDecimal(child: Expression, precision: Int, scale: Int) extends Un
  */
 case class PromotePrecision(child: Expression) extends UnaryExpression {
   override def dataType: DataType = child.dataType
+  override def prettyDataType: DataType = child.prettyDataType
   override def eval(input: InternalRow): Any = child.eval(input)
   override def genCode(ctx: CodegenContext): ExprCode = child.genCode(ctx)
   override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = ev.copy("")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
@@ -86,9 +86,10 @@ trait NamedExpression extends Expression {
   /** Returns a copy of this expression with a new `exprId`. */
   def newInstance(): NamedExpression
 
+  /** avoid checking nullability for complex data type  */
   protected def typeSuffix =
     if (resolved) {
-      dataType match {
+      prettyDataType match {
         case LongType => "L"
         case _ => ""
       }
@@ -146,6 +147,7 @@ case class Alias(child: Expression, name: String)(
   override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = ev.copy("")
 
   override def dataType: DataType = child.dataType
+  override def prettyDataType: DataType = child.prettyDataType
   override def nullable: Boolean = child.nullable
   override def metadata: Metadata = {
     explicitMetadata.getOrElse {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
@@ -55,6 +55,8 @@ case class Coalesce(children: Seq[Expression]) extends Expression {
 
   override def dataType: DataType = children.head.dataType
 
+  override def prettyDataType: DataType = children.head.prettyDataType
+
   override def eval(input: InternalRow): Any = {
     var result: Any = null
     val childIterator = children.iterator
@@ -135,6 +137,8 @@ case class NaNvl(left: Expression, right: Expression)
     extends BinaryExpression with ImplicitCastInputTypes {
 
   override def dataType: DataType = left.dataType
+
+  override def prettyDataType: DataType = left.prettyDataType
 
   override def inputTypes: Seq[AbstractDataType] =
     Seq(TypeCollection(DoubleType, FloatType), TypeCollection(DoubleType, FloatType))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects.scala
@@ -444,6 +444,8 @@ case class MapObjects private(
 
   override def dataType: DataType = ArrayType(lambdaFunction.dataType)
 
+  override def prettyDataType: DataType = ArrayType(lambdaFunction.prettyDataType)
+
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     val javaType = ctx.javaType(dataType)
     val elementJavaType = ctx.javaType(loopVar.dataType)
@@ -643,6 +645,8 @@ case class InitializeJavaBean(beanInstance: Expression, setters: Map[String, Exp
   override def children: Seq[Expression] = beanInstance +: setters.values.toSeq
   override def dataType: DataType = beanInstance.dataType
 
+  override def prettyDataType: DataType = beanInstance.prettyDataType
+
   override def eval(input: InternalRow): Any =
     throw new UnsupportedOperationException("Only code-generated evaluation is supported.")
 
@@ -682,6 +686,8 @@ case class AssertNotNull(child: Expression, walkedTypePath: Seq[String])
   extends UnaryExpression with NonSQLExpression {
 
   override def dataType: DataType = child.dataType
+
+  override def prettyDataType: DataType = child.prettyDataType
 
   override def nullable: Boolean = false
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -784,6 +784,8 @@ case class Substring(str: Expression, pos: Expression, len: Expression)
 
   override def dataType: DataType = str.dataType
 
+  override def prettyDataType: DataType = str.prettyDataType
+
   override def inputTypes: Seq[AbstractDataType] =
     Seq(TypeCollection(StringType, BinaryType), IntegerType, IntegerType)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/windowExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/windowExpressions.scala
@@ -292,6 +292,7 @@ case class WindowExpression(
   override def children: Seq[Expression] = windowFunction :: windowSpec :: Nil
 
   override def dataType: DataType = windowFunction.dataType
+  override def prettyDataType: DataType = windowFunction.prettyDataType
   override def foldable: Boolean = windowFunction.foldable
   override def nullable: Boolean = windowFunction.nullable
 
@@ -365,6 +366,8 @@ abstract class OffsetWindowFunction
   }
 
   override def dataType: DataType = input.dataType
+
+  override def prettyDataType: DataType = input.prettyDataType
 
   override def inputTypes: Seq[AbstractDataType] =
     Seq(AnyDataType, IntegerType, TypeCollection(input.dataType, NullType))

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameComplexTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameComplexTypeSuite.scala
@@ -58,4 +58,15 @@ class DataFrameComplexTypeSuite extends QueryTest with SharedSQLContext {
     val nullIntRow = df.selectExpr("i[1]").collect()(0)
     assert(nullIntRow == org.apache.spark.sql.Row(null))
   }
+
+  test("SPARK-13253") {
+    val data = sparkContext.parallelize(Array.range(0, 10).map(x => (x, x + 1)))
+    val df = data.toDF("a", "b")
+    val arrayCol1 = functions.array(df("a"), df("b")).as("arrayCol1")
+    arrayCol1.toString
+
+    val arrayCol2 = functions.struct(df("a"), df("b")).as("arrayCol2")
+    arrayCol2.toString
+  }
+
 }


### PR DESCRIPTION
Hello: 

When we call the typeSuffix method, it will call the dataType and get the LongType for the suffix("L"). But in the complex data type(like CreatArray) cases, the dataType will also evaluate the children's nullability, which is not necessary for the typeSuffix. 

For the proposed fix, I will create a prettyDataType, in parallel to the dataType in the expression. At the base, it defaults to the dataType. It is only used by typeSuffix in the NameExpression for now.

So the main changes is at the typeSuffix in the NameExpression, and the complexTypeCreator. The rest of files just override the prettyDataType from the abstract class Expression when their "dataType" method relies on other expression's "dataType"

Then for those complex types, the "prettyDataType" does not try to evaluate the "nullable" but just pass a default that will not be used at all by the caller, "typeSuffix".
