### PR TITLE
[SPARK-13304] [SQL] Fix worst case of broadcast join of two ints

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/BenchmarkWholeStageCodegen.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/BenchmarkWholeStageCodegen.scala
@@ -24,7 +24,7 @@ import org.apache.spark.memory.{StaticMemoryManager, TaskMemoryManager}
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types.IntegerType
+import org.apache.spark.sql.types.{StringType, IntegerType}
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.unsafe.hash.Murmur3_x86_32
 import org.apache.spark.unsafe.map.BytesToBytesMap


### PR DESCRIPTION
If the two join columns have the same value, the hash code of them will be (a ^ b), which is 0, then the HashMap will be very very slow.

This PR will rotate the second int to avoid this case. In theory, it's still have the possibility that has lots of collisions, the pattern will be (1, 131072), (2, 131073) ... (n, n + 131072).

This PR also added some micro benchmark, and updated the results for broadcast hash joins.
