### PR TITLE
[SPARK-13310] [SQL] Resolve Missing Sorting Columns in Generate

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -645,6 +645,17 @@ class Analyzer(
           }
           val newAggregateExpressions = a.aggregateExpressions ++ missingAttrs
           a.copy(aggregateExpressions = newAggregateExpressions)
+        case g: Generate =>
+          if (g.outer && !g.join) {
+            // For Generate, the missing sort-by attributes are not resolvable
+            // when the outer is true but join is false because it might add extra NULL.
+            throw new AnalysisException(s"Can't add $missingAttrs to $g")
+          } else {
+            // If join is false, we will convert it to true for getting from the child the missing
+            // attributes that its child might have or could have.
+            val missing = missingAttrs -- g.child.outputSet
+            g.copy(join = true, child = addMissingAttr(g.child, missing))
+          }
         case u: UnaryNode =>
           u.withNewChildren(addMissingAttr(u.child, missingAttrs) :: Nil)
         case other =>
@@ -662,8 +673,6 @@ class Analyzer(
         resolved
       } else {
         plan match {
-          case g: Generate =>
-            if (g.join) resolveExpressionRecursively(resolved, g.child) else resolved
           case u: UnaryNode if !u.isInstanceOf[Subquery] =>
             resolveExpressionRecursively(resolved, u.child)
           case other => resolved

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -655,9 +655,9 @@ class Analyzer(
         resolved
       } else {
         plan match {
-          case g: Generate if g.join =>
-            resolveExpressionRecursively(resolved, g.child)
-          case u: UnaryNode if !u.isInstanceOf[Subquery] && !u.isInstanceOf[Generate] =>
+          case g: Generate =>
+            if (g.join) resolveExpressionRecursively(resolved, g.child) else resolved
+          case u: UnaryNode if !u.isInstanceOf[Subquery] =>
             resolveExpressionRecursively(resolved, u.child)
           case other => resolved
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -598,17 +598,24 @@ class Analyzer(
       case sa @ Sort(_, _, child: Aggregate) => sa
 
       case s @ Sort(order, _, child) if !s.resolved && child.resolved =>
-        val newOrder = order.map(resolveExpressionRecursively(_, child).asInstanceOf[SortOrder])
-        val requiredAttrs = AttributeSet(newOrder).filter(_.resolved)
-        val missingAttrs = requiredAttrs -- child.outputSet
-        if (missingAttrs.nonEmpty) {
-          // Add missing attributes and then project them away after the sort.
-          Project(child.output,
-            Sort(newOrder, s.global, addMissingAttr(child, missingAttrs)))
-        } else if (newOrder != order) {
-          s.copy(order = newOrder)
-        } else {
-          s
+        try {
+          val newOrder = order.map(resolveExpressionRecursively(_, child).asInstanceOf[SortOrder])
+          val requiredAttrs = AttributeSet(newOrder).filter(_.resolved)
+          val missingAttrs = requiredAttrs -- child.outputSet
+          if (missingAttrs.nonEmpty) {
+            // Add missing attributes and then project them away after the sort.
+            Project(child.output,
+              Sort(newOrder, s.global, addMissingAttr(child, missingAttrs)))
+          } else if (newOrder != order) {
+            s.copy(order = newOrder)
+          } else {
+            s
+          }
+        } catch {
+          // Attempting to resolve it might fail. When this happens, return the original plan.
+          // Users will see an AnalysisException for resolution failure of missing attributes
+          // in Sort
+          case ae: AnalysisException => s
         }
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -646,16 +646,10 @@ class Analyzer(
           val newAggregateExpressions = a.aggregateExpressions ++ missingAttrs
           a.copy(aggregateExpressions = newAggregateExpressions)
         case g: Generate =>
-          if (g.outer && !g.join) {
-            // For Generate, the missing sort-by attributes are not resolvable
-            // when the outer is true but join is false because it might add extra NULL.
-            throw new AnalysisException(s"Can't add $missingAttrs to $g")
-          } else {
-            // If join is false, we will convert it to true for getting from the child the missing
-            // attributes that its child might have or could have.
-            val missing = missingAttrs -- g.child.outputSet
-            g.copy(join = true, child = addMissingAttr(g.child, missing))
-          }
+          // If join is false, we will convert it to true for getting from the child the missing
+          // attributes that its child might have or could have.
+          val missing = missingAttrs -- g.child.outputSet
+          g.copy(join = true, child = addMissingAttr(g.child, missing))
         case u: UnaryNode =>
           u.withNewChildren(addMissingAttr(u.child, missingAttrs) :: Nil)
         case other =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -655,7 +655,9 @@ class Analyzer(
         resolved
       } else {
         plan match {
-          case u: UnaryNode if !u.isInstanceOf[Subquery] =>
+          case g: Generate if g.join =>
+            resolveExpressionRecursively(resolved, g.child)
+          case u: UnaryNode if !u.isInstanceOf[Subquery] && !u.isInstanceOf[Generate] =>
             resolveExpressionRecursively(resolved, u.child)
           case other => resolved
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -249,7 +249,7 @@ object ColumnPruning extends Rule[LogicalPlan] {
       g.copy(child = Project(g.references.toSeq, g.child))
 
     case p @ Project(_, g: Generate) if g.join && p.references.subsetOf(g.generatedSet) =>
-      p.copy(child = g.copy(join = false))
+      p.copy(child = g.copy(join = false, outer = false))
 
     case p @ Project(projectList, g: Generate) if g.join =>
       val neededChildOutput = p.references -- g.generatorOutput ++ g.references

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -249,7 +249,7 @@ object ColumnPruning extends Rule[LogicalPlan] {
       g.copy(child = Project(g.references.toSeq, g.child))
 
     case p @ Project(_, g: Generate) if g.join && p.references.subsetOf(g.generatedSet) =>
-      p.copy(child = g.copy(join = false, outer = false))
+      p.copy(child = g.copy(join = false))
 
     case p @ Project(projectList, g: Generate) if g.join =>
       val neededChildOutput = p.references -- g.generatorOutput ++ g.references

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -194,6 +194,11 @@ class AnalysisErrorSuite extends AnalysisTest {
     "sort" :: "type" :: "map<int,int>" :: Nil)
 
   errorTest(
+    "sorting by attributes are not from grouping expressions",
+    testRelation2.groupBy('a, 'c)('a, 'c, count('a).as("a3")).orderBy('b.asc),
+    "cannot resolve" :: "'b'" :: "given input columns" :: "[a, c, a3]" :: Nil)
+
+  errorTest(
     "non-boolean filters",
     testRelation.where(Literal(1)),
     "filter" :: "'1'" :: "not a boolean" :: Literal(1).dataType.simpleString :: Nil)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -24,11 +24,10 @@ import scala.collection.JavaConverters._
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{EliminateSubQueries, FunctionRegistry}
-import org.apache.spark.sql.catalyst.parser.ParserConf
-import org.apache.spark.sql.execution.SparkQl
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.execution.datasources.parquet.ParquetRelation
-import org.apache.spark.sql.hive.{HiveContext, HiveQl, MetastoreRelation}
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.hive.{HiveContext, MetastoreRelation}
 import org.apache.spark.sql.hive.test.TestHiveSingleton
 import org.apache.spark.sql.test.SQLTestUtils
 import org.apache.spark.sql.types._
@@ -929,19 +928,19 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
 
   test("Sorting columns are not in Generate") {
     withTempTable("data") {
-      val rdd = sparkContext.makeRDD((1 to 5)
-        .map(i => s"""{"a":[$i, ${i + 1}], "b":"$i", "c":"${10 - i}", "d":[$i, ${i + 5}]}"""))
-      read.json(rdd).registerTempTable("data")
+      sqlContext.range(1, 5)
+        .select(array($"id", $"id" + 1).as("a"), $"id".as("b"), (lit(10) - $"id").as("c"))
+        .registerTempTable("data")
 
       // case 1: missing sort columns are resolvable if join is true
       checkAnswer(
         sql("SELECT explode(a) AS val, b FROM data WHERE b < 2 order by val, c"),
-        Row(1, "1") :: Row(2, "1") :: Nil)
+        Row(1, 1) :: Row(2, 1) :: Nil)
 
       // case 2: missing sort columns are resolvable if join is false
       checkAnswer(
         sql("SELECT explode(a) AS val FROM data order by val, c"),
-        Seq(1, 2, 2, 3, 3, 4, 4, 5, 5, 6).map(i => Row(i)))
+        Seq(1, 2, 2, 3, 3, 4, 4, 5).map(i => Row(i)))
 
       // case 3: missing sort columns are resolvable if join is true and outer is true
       checkAnswer(
@@ -950,7 +949,7 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
             |SELECT C.val, b FROM data LATERAL VIEW OUTER explode(a) C as val
             |where b < 2 order by c, val, b
           """.stripMargin),
-        Row(1, "1") :: Row(2, "1") :: Nil)
+        Row(1, 1) :: Row(2, 1) :: Nil)
     }
   }
 


### PR DESCRIPTION
``` scala
// case 1: missing sort columns are resolvable if join is true
sql("SELECT explode(a) AS val, b FROM data WHERE b < 2 order by val, c")
// case 2: missing sort columns are not resolvable if join is false. Thus, issue an error message in this case
sql("SELECT explode(a) AS val FROM data order by val, c")
```

When sort columns are not in `Generate`, we can resolve them when `join` is equal to `true`. Still trying to add more test cases for the other `UnaryNode` types.

Could you review the changes? @davies @cloud-fan Thanks!
