### PR TITLE
[SPARK-13314][SQL] Fixes malformed WholeStageCodegen tree string

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegen.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegen.scala
@@ -329,7 +329,7 @@ case class WholeStageCodegen(plan: CodegenSupport, children: Seq[SparkPlan])
     builder.append(simpleString)
     builder.append("\n")
 
-    plan.generateTreeString(depth + 2, lastChildren :+ false :+ true, builder)
+    plan.generateTreeString(depth + 2, lastChildren :+ children.isEmpty :+ true, builder)
     if (children.nonEmpty) {
       children.init.foreach(_.generateTreeString(depth + 1, lastChildren :+ false, builder))
       children.last.generateTreeString(depth + 1, lastChildren :+ true, builder)


### PR DESCRIPTION
When the query plan contains binary operator(s), `WholeStageCodegen` tree string can be malformed. This PR fixes this issue.

Before:

```
val a = sqlContext range 5
val b = sqlContext range 2
a select ('id as 'a) unionAll (b select ('id as 'a)) explain true
...
== Physical Plan ==
Union
:- WholeStageCodegen
:  :  +- Project [id#3L AS a#6L]
:  :     +- Range 0, 1, 8, 5, [id#3L]
+- WholeStageCodegen
   :  +- Project [id#4L AS a#7L]
   :     +- Range 0, 1, 8, 2, [id#4L]
```

After:

```
== Physical Plan ==
Union
:- WholeStageCodegen
:     +- Project [id#0L AS a#2L]
:        +- Range 0, 1, 8, 5, [id#0L]
+- WholeStageCodegen
      +- Project [id#1L AS a#3L]
         +- Range 0, 1, 8, 2, [id#1L]
```
