### PR TITLE
[SPARK-13242] [SQL] Generate one method per `when` clause

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
@@ -139,54 +139,84 @@ case class CaseWhen(branches: Seq[(Expression, Expression)], elseValue: Option[E
   override def genCode(ctx: CodegenContext, ev: ExprCode): String = {
     // Generate code that looks like:
     //
-    // condA = ...
-    // if (condA) {
-    //   valueA
-    // } else {
+    // def when_0 {
+    //   condA = ...
+    //   if (condA) {
+    //     valueA
+    //     return true
+    //   }
+    //   return false
+    // }
+    //
+    // def when_1 {
     //   condB = ...
     //   if (condB) {
     //     valueB
-    //   } else {
-    //     condC = ...
-    //     if (condC) {
-    //       valueC
-    //     } else {
-    //       elseValue
-    //     }
+    //     return true
     //   }
+    //   return false
     // }
-    val cases = branches.map { case (condExpr, valueExpr) =>
+    //
+    // def when_2 {
+    //   elseValue
+    //   return true
+    // }
+    //
+    // if (when_0()) {} else { if (when_1()) {} else { if (when_2()) {} else { }}}
+
+    val isNull = ctx.freshName("isNull")
+    val value = ctx.freshName("value")
+
+    ctx.addMutableState("boolean", isNull, s"boolean ${isNull} = true;")
+    ctx.addMutableState(ctx.javaType(dataType), value,
+      s"${ctx.javaType(dataType)} ${value} = ${ctx.defaultValue(dataType)};")
+
+    def addCase(body: String) = {
+      val name = ctx.freshName("when_")
+      val code = s"""
+        public boolean ${name}(InternalRow ${ctx.INPUT_ROW}) {
+          ${body}
+        }""".stripMargin
+      ctx.addNewFunction(name, code)
+      name
+    }
+
+    val cases = branches.zipWithIndex.map { case ((condExpr, valueExpr), index) =>
       val cond = condExpr.gen(ctx)
       val res = valueExpr.gen(ctx)
       s"""
         ${cond.code}
         if (!${cond.isNull} && ${cond.value}) {
           ${res.code}
-          ${ev.isNull} = ${res.isNull};
-          ${ev.value} = ${res.value};
+          ${isNull} = ${res.isNull};
+          ${value} = ${res.value};
+          return true;
         }
+        return false;
       """
     }
 
-    var generatedCode = cases.mkString("", "\nelse {\n", "\nelse {\n")
-
-    elseValue.foreach { elseExpr =>
+    val elseCase = elseValue.map { elseExpr =>
       val res = elseExpr.gen(ctx)
-      generatedCode +=
-        s"""
-          ${res.code}
-          ${ev.isNull} = ${res.isNull};
-          ${ev.value} = ${res.value};
-        """
+      s"""
+        ${res.code}
+        ${isNull} = ${res.isNull};
+        ${value} = ${res.value};
+        return true;
+      """
     }
 
-    generatedCode += "}\n" * cases.size
+    val names = (cases ++ elseCase).map(c => addCase(c))
+    val calls = names
+        .map(fn => s"if (${fn}(${ctx.INPUT_ROW})) { } else { ").mkString("", "", "}" * names.size)
 
     s"""
-      boolean ${ev.isNull} = true;
-      ${ctx.javaType(dataType)} ${ev.value} = ${ctx.defaultValue(dataType)};
-      $generatedCode
-    """
+      ${isNull} = true;
+      ${value} = ${ctx.defaultValue(dataType)};
+      $calls
+      boolean ${ev.isNull} = ${isNull};
+      ${ctx.javaType(dataType)} ${ev.value} = ${value};
+     """
   }
 
   override def toString: String = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
@@ -176,12 +176,12 @@ case class CaseWhen(branches: Seq[(Expression, Expression)], elseValue: Option[E
       val code = s"""
         public boolean ${name}(InternalRow ${ctx.INPUT_ROW}) {
           ${body}
-        }""".stripMargin
+        }"""
       ctx.addNewFunction(name, code)
       name
     }
 
-    val cases = branches.zipWithIndex.map { case ((condExpr, valueExpr), index) =>
+    val cases = branches.map { case (condExpr, valueExpr) =>
       val cond = condExpr.gen(ctx)
       val res = valueExpr.gen(ctx)
       s"""

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
@@ -59,7 +59,7 @@ class CodeGenerationSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
 
-  test("split complex single column expressions") {
+  test("SPARK-13242: split when clauses") {
     val cases = 50
     val conditionClauses = 20
 
@@ -72,9 +72,6 @@ class CodeGenerationSuite extends SparkFunSuite with ExpressionEvalHelper {
     }
 
     val expression = CaseWhen((1 to cases).map(generateCase(_)))
-
-    // Currently this throws a java.util.concurrent.ExecutionException wrapping a
-    // org.codehaus.janino.JaninoRuntimeException: Code of method XXX of class YYY grows beyond 64 KB
     val plan = GenerateMutableProjection.generate(Seq(expression))()
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
@@ -61,11 +61,11 @@ class CodeGenerationSuite extends SparkFunSuite with ExpressionEvalHelper {
 
   test("SPARK-13242: split when clauses") {
     val cases = 50
-    val conditionClauses = 20
+    val clauses = 20
 
     // Generate an individual case
     def generateCase(n: Int): (Expression, Expression) = {
-      val condition = (1 to conditionClauses)
+      val condition = (1 to clauses)
           .map(c => EqualTo(BoundReference(0, StringType, false), Literal(s"$c:$n")))
           .reduceLeft[Expression]((l, r) => Or(l, r))
       (condition, Literal(n))
@@ -73,6 +73,10 @@ class CodeGenerationSuite extends SparkFunSuite with ExpressionEvalHelper {
 
     val expression = CaseWhen((1 to cases).map(generateCase(_)))
     val plan = GenerateMutableProjection.generate(Seq(expression))()
+    val input = new GenericMutableRow(Array[Any](UTF8String.fromString(s"${clauses}:${cases}")))
+    val actual = plan(input).toSeq(Seq(expression.dataType))
+
+    assert(actual(0) == cases)
   }
 
   test("test generated safe and unsafe projection") {


### PR DESCRIPTION
This patch modifies code generation to split `when` clauses into separate methods.

As the included test demonstrates, with the previous behaviour it was quite easy to breach the 64KB method size limit with even moderately complex `when` expressions.

This contribution is my original work and I license the work to the project under the project's open source license.
