### PR TITLE
[SPARK-13356][Streaming]WebUI missing input informations when recovering from dirver failure

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -155,7 +155,6 @@ class StreamingContext private[streaming] (
   private[streaming] val graph: DStreamGraph = {
     if (isCheckpointPresent) {
       _cp.graph.setContext(this)
-      _cp.graph.restoreCheckpointData()
       _cp.graph
     } else {
       require(_batchDur != null, "Batch duration for StreamingContext cannot be null")
@@ -181,6 +180,11 @@ class StreamingContext private[streaming] (
   }
 
   private[streaming] val scheduler = new JobScheduler(this)
+  // restore data has to report info to inputInfoTracker,
+  // so it need to be initialzed after JobScheduler
+  if (isCheckpointPresent) {
+    graph.restoreCheckpointData()
+  }
 
   private[streaming] val waiter = new ContextWaiter
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
@@ -345,6 +345,11 @@ class FileInputDStream[K, V, F <: NewInputFormat[K, V]](
             f.mkString("[", ", ", "]") )
           batchTimeToSelectedFiles.synchronized { batchTimeToSelectedFiles += ((t, f)) }
           recentlySelectedFiles ++= f
+          val metadata = Map(
+            "files" -> f.toList,
+            StreamInputInfo.METADATA_KEY_DESCRIPTION -> f.mkString("\n"))
+          val inputInfo = StreamInputInfo(id, 0, metadata)
+          ssc.scheduler.inputInfoTracker.reportInfo(t, inputInfo)
           generatedRDDs += ((t, filesToRDD(f)))
       }
     }

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
@@ -59,7 +59,7 @@ class JobScheduler(val ssc: StreamingContext) extends Logging {
   // eventLoop not being null means the scheduler has been started and not stopped
   var receiverTracker: ReceiverTracker = null
   // A tracker to track all the input stream information as well as processed record number
-  var inputInfoTracker: InputInfoTracker = null
+  var inputInfoTracker: InputInfoTracker = new InputInfoTracker(ssc)
 
   private var executorAllocationManager: Option[ExecutorAllocationManager] = None
 
@@ -84,7 +84,6 @@ class JobScheduler(val ssc: StreamingContext) extends Logging {
 
     listenerBus.start()
     receiverTracker = new ReceiverTracker(ssc)
-    inputInfoTracker = new InputInfoTracker(ssc)
 
     val executorAllocClient: ExecutorAllocationClient = ssc.sparkContext.schedulerBackend match {
       case b: ExecutorAllocationClient => b.asInstanceOf[ExecutorAllocationClient]


### PR DESCRIPTION
WebUI missing some input information when streaming recover from checkpoint, it may confuse people the data lost when restarting streaming context.For example:
![directkafkascreenshot](https://cloud.githubusercontent.com/assets/3426093/13099119/29d099e0-d56a-11e5-9830-25512fc7bc2c.jpg)

To address this issue, i try to:
-  Invoke `reportInfo` when restarting streaming context before generating rdd, 
-  Invoke the `generateJobs` using the info of `inputInfoTracker` to submit the job when restarting the `JobGenerator`. 

more detail:[SPARK-13356](https://issues.apache.org/jira/browse/SPARK-13356)
