### PR TITLE
[SPARK-13242] [SQL] Fall back to interpreting complex `when` expressions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
@@ -86,7 +86,7 @@ case class If(predicate: Expression, trueValue: Expression, falseValue: Expressi
  * @param elseValue optional value for the else branch
  */
 case class CaseWhen(branches: Seq[(Expression, Expression)], elseValue: Option[Expression] = None)
-  extends Expression {
+  extends Expression with CodegenFallback {
 
   override def children: Seq[Expression] = branches.flatMap(b => b._1 :: b._2 :: Nil) ++ elseValue
 
@@ -155,6 +155,7 @@ case class CaseWhen(branches: Seq[(Expression, Expression)], elseValue: Option[E
     //     }
     //   }
     // }
+
     val cases = branches.map { case (condExpr, valueExpr) =>
       val cond = condExpr.gen(ctx)
       val res = valueExpr.gen(ctx)
@@ -182,11 +183,16 @@ case class CaseWhen(branches: Seq[(Expression, Expression)], elseValue: Option[E
 
     generatedCode += "}\n" * cases.size
 
-    s"""
+    if (generatedCode.size > 64 * 1000) {
+      super.genCode(ctx, ev)
+    }
+    else {
+      s"""
       boolean ${ev.isNull} = true;
       ${ctx.javaType(dataType)} ${ev.value} = ${ctx.defaultValue(dataType)};
       $generatedCode
-    """
+      """
+    }
   }
 
   override def toString: String = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
@@ -184,7 +184,7 @@ case class CaseWhen(branches: Seq[(Expression, Expression)], elseValue: Option[E
     generatedCode += "}\n" * cases.size
 
     // Methods that are too long cannot be compiled, so fall back to interpreting
-    if (generatedCode.length > 10 * 1000) {
+    if (generatedCode.length > 1000) {
       super.genCode(ctx, ev)
     } else {
       s"""

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
@@ -184,7 +184,7 @@ case class CaseWhen(branches: Seq[(Expression, Expression)], elseValue: Option[E
     generatedCode += "}\n" * cases.size
 
     // Methods that are too long cannot be compiled, so fall back to interpreting
-    if (generatedCode.length > 64 * 1000) {
+    if (generatedCode.length > 10 * 1000) {
       super.genCode(ctx, ev)
     } else {
       s"""

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
@@ -183,7 +183,8 @@ case class CaseWhen(branches: Seq[(Expression, Expression)], elseValue: Option[E
 
     generatedCode += "}\n" * cases.size
 
-    if (generatedCode.size > 64 * 1000) {
+    // Methods that are too long cannot be compiled, so fall back to interpreting
+    if (generatedCode.length > 64 * 1000) {
       super.genCode(ctx, ev)
     }
     else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
@@ -186,8 +186,7 @@ case class CaseWhen(branches: Seq[(Expression, Expression)], elseValue: Option[E
     // Methods that are too long cannot be compiled, so fall back to interpreting
     if (generatedCode.length > 64 * 1000) {
       super.genCode(ctx, ev)
-    }
-    else {
+    } else {
       s"""
       boolean ${ev.isNull} = true;
       ${ctx.javaType(dataType)} ${ev.value} = ${ctx.defaultValue(dataType)};

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGenerationSuite.scala
@@ -58,6 +58,28 @@ class CodeGenerationSuite extends SparkFunSuite with ExpressionEvalHelper {
     }
   }
 
+
+  test("SPARK-13242: complicated when expressions") {
+    val cases = 50
+    val clauses = 20
+
+    // Generate an individual case
+    def generateCase(n: Int): (Expression, Expression) = {
+      val condition = (1 to clauses)
+          .map(c => EqualTo(BoundReference(0, StringType, false), Literal(s"$c:$n")))
+          .reduceLeft[Expression]((l, r) => Or(l, r))
+      (condition, Literal(n))
+    }
+
+    val expression = CaseWhen((1 to cases).map(generateCase(_)))
+
+    val plan = GenerateMutableProjection.generate(Seq(expression))()
+    val input = new GenericMutableRow(Array[Any](UTF8String.fromString(s"${clauses}:${cases}")))
+    val actual = plan(input).toSeq(Seq(expression.dataType))
+
+    assert(actual(0) == cases)
+  }
+
   test("test generated safe and unsafe projection") {
     val schema = new StructType(Array(
       StructField("a", StringType, true),


### PR DESCRIPTION
This follows @davies suggestion over on https://github.com/apache/spark/pull/11221 but rather than hard coding a limit on the number of branches, it does a heuristic check on the generated source code size. 

This isn't ideal, but will work well in practice and mirrors the approach in https://github.com/apache/spark/pull/7076 
