### PR TITLE
[SPARK-13367]  [Streaming] Refactor KinesusUtils to specify more KCL options

### DIFF
--- a/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisBackedBlockRDD.scala
+++ b/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisBackedBlockRDD.scala
@@ -132,8 +132,6 @@ class KinesisSequenceRangeIterator(
   private var lastSeqNumber: String = null
   private var internalIterator: Iterator[Record] = null
 
-  client.setEndpoint(config.endpointUrl)
-
   override protected def getNext(): Record = {
     var nextRecord: Record = null
     if (toSeqNumberReceived) {

--- a/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisBackedBlockRDD.scala
+++ b/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisBackedBlockRDD.scala
@@ -21,8 +21,6 @@ import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 
-import com.amazonaws.auth.{AWSCredentials, DefaultAWSCredentialsProviderChain}
-import com.amazonaws.services.kinesis.AmazonKinesisClient
 import com.amazonaws.services.kinesis.clientlibrary.types.UserRecord
 import com.amazonaws.services.kinesis.model._
 
@@ -71,14 +69,12 @@ class KinesisBackedBlockRDDPartition(
 private[kinesis]
 class KinesisBackedBlockRDD[T: ClassTag](
     sc: SparkContext,
-    val regionName: String,
-    val endpointUrl: String,
+    val config: KinesisConfig,
     @transient private val _blockIds: Array[BlockId],
     @transient val arrayOfseqNumberRanges: Array[SequenceNumberRanges],
     @transient private val isBlockIdValid: Array[Boolean] = Array.empty,
     val retryTimeoutMs: Int = 10000,
-    val messageHandler: Record => T = KinesisUtils.defaultMessageHandler _,
-    val awsCredentialsOption: Option[SerializableAWSCredentials] = None
+    val messageHandler: Record => T = KinesisUtils.defaultMessageHandler _
   ) extends BlockRDD[T](sc, _blockIds) {
 
   require(_blockIds.length == arrayOfseqNumberRanges.length,
@@ -104,12 +100,8 @@ class KinesisBackedBlockRDD[T: ClassTag](
     }
 
     def getBlockFromKinesis(): Iterator[T] = {
-      val credentials = awsCredentialsOption.getOrElse {
-        new DefaultAWSCredentialsProviderChain().getCredentials()
-      }
       partition.seqNumberRanges.ranges.iterator.flatMap { range =>
-        new KinesisSequenceRangeIterator(credentials, endpointUrl, regionName,
-          range, retryTimeoutMs).map(messageHandler)
+        new KinesisSequenceRangeIterator(config, range, retryTimeoutMs).map(messageHandler)
       }
     }
     if (partition.isBlockIdValid) {
@@ -128,13 +120,11 @@ class KinesisBackedBlockRDD[T: ClassTag](
  */
 private[kinesis]
 class KinesisSequenceRangeIterator(
-    credentials: AWSCredentials,
-    endpointUrl: String,
-    regionId: String,
+    config: KinesisConfig,
     range: SequenceNumberRange,
     retryTimeoutMs: Int) extends NextIterator[Record] with Logging {
 
-  private val client = new AmazonKinesisClient(credentials)
+  private val client = config.buildKinesisClient()
   private val streamName = range.streamName
   private val shardId = range.shardId
 
@@ -142,7 +132,7 @@ class KinesisSequenceRangeIterator(
   private var lastSeqNumber: String = null
   private var internalIterator: Iterator[Record] = null
 
-  client.setEndpoint(endpointUrl, "kinesis", regionId)
+  client.setEndpoint(config.endpointUrl)
 
   override protected def getNext(): Record = {
     var nextRecord: Record = null
@@ -205,7 +195,7 @@ class KinesisSequenceRangeIterator(
   private def getRecordsAndNextKinesisIterator(
       shardIterator: String): (Iterator[Record], String) = {
     val getRecordsRequest = new GetRecordsRequest
-    getRecordsRequest.setRequestCredentials(credentials)
+    getRecordsRequest.setRequestCredentials(config.awsCreds)
     getRecordsRequest.setShardIterator(shardIterator)
     val getRecordsResult = retryOrTimeout[GetRecordsResult](
       s"getting records using shard iterator") {
@@ -225,7 +215,7 @@ class KinesisSequenceRangeIterator(
       iteratorType: ShardIteratorType,
       sequenceNumber: String): String = {
     val getShardIteratorRequest = new GetShardIteratorRequest
-    getShardIteratorRequest.setRequestCredentials(credentials)
+    getShardIteratorRequest.setRequestCredentials(config.awsCreds)
     getShardIteratorRequest.setStreamName(streamName)
     getShardIteratorRequest.setShardId(shardId)
     getShardIteratorRequest.setShardIteratorType(iteratorType.toString)

--- a/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisBackedBlockRDD.scala
+++ b/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisBackedBlockRDD.scala
@@ -195,7 +195,7 @@ class KinesisSequenceRangeIterator(
   private def getRecordsAndNextKinesisIterator(
       shardIterator: String): (Iterator[Record], String) = {
     val getRecordsRequest = new GetRecordsRequest
-    getRecordsRequest.setRequestCredentials(config.awsCreds)
+    getRecordsRequest.setRequestCredentials(config.awsCredentials)
     getRecordsRequest.setShardIterator(shardIterator)
     val getRecordsResult = retryOrTimeout[GetRecordsResult](
       s"getting records using shard iterator") {
@@ -215,7 +215,7 @@ class KinesisSequenceRangeIterator(
       iteratorType: ShardIteratorType,
       sequenceNumber: String): String = {
     val getShardIteratorRequest = new GetShardIteratorRequest
-    getShardIteratorRequest.setRequestCredentials(config.awsCreds)
+    getShardIteratorRequest.setRequestCredentials(config.awsCredentials)
     getShardIteratorRequest.setStreamName(streamName)
     getShardIteratorRequest.setShardId(shardId)
     getShardIteratorRequest.setShardIteratorType(iteratorType.toString)

--- a/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisConfig.scala
+++ b/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisConfig.scala
@@ -64,7 +64,7 @@ case class KinesisConfig(
     awsCredentialsOption: Option[SerializableAWSCredentials] = None,
     dynamoEndpointUrl: Option[String] = None,
     dynamoCredentials: Option[SerializableAWSCredentials] = None
-    ) {
+    ) extends Serializable {
 
   /**
    * Builds a KinesisClientLibConfiguration object, which contains all the configuration options
@@ -86,7 +86,6 @@ case class KinesisConfig(
       .withKinesisEndpoint(endpointUrl)
       .withInitialPositionInStream(initialPositionInStream)
       .withTaskBackoffTimeMillis(500)
-      .withRegionName(regionName)
     return kinesisClientLibConfiguration
 
   }
@@ -101,11 +100,12 @@ case class KinesisConfig(
     } else {
       new AmazonDynamoDBClient(resolveAWSCredentialsProvider())
     }
-    client.setRegion(region)
+
     if (dynamoEndpointUrl.isDefined) {
-      client.setEndpoint(dynamoEndpointUrl.get)
+      client.withEndpoint(dynamoEndpointUrl.get)
+    } else {
+      client.withRegion(region)
     }
-    client
   }
 
   /**
@@ -113,9 +113,7 @@ case class KinesisConfig(
    */
   def buildKinesisClient(): AmazonKinesisClient = {
     val client = new AmazonKinesisClient(resolveAWSCredentialsProvider())
-    client.setRegion(region)
-    client.setEndpoint(endpointUrl)
-    client
+    client.withEndpoint(endpointUrl)
 
   }
 
@@ -124,9 +122,7 @@ case class KinesisConfig(
    */
   def buildCloudwatchClient(): AmazonCloudWatchClient = {
     val client = new AmazonCloudWatchClient(resolveAWSCredentialsProvider())
-    client.setRegion(region)
-    client
-
+    client.withRegion(region)
   }
 
   /**

--- a/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisConfig.scala
+++ b/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisConfig.scala
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.streaming.kinesis
+
+import scala.reflect.ClassTag
+
+
+import com.amazonaws.auth.{AWSCredentials, AWSCredentialsProvider, DefaultAWSCredentialsProviderChain}
+import com.amazonaws.regions.{RegionUtils, Region}
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.{InitialPositionInStream, KinesisClientLibConfiguration}
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
+import com.amazonaws.services.kinesis.AmazonKinesisClient
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient
+
+
+case class KinesisConfig(
+    kinesisAppName: String,
+    streamName: String,
+    endpointUrl: String,
+    regionName: String,
+    initialPositionInStream: InitialPositionInStream = InitialPositionInStream.TRIM_HORIZON,
+    awsCredentialsOption: Option[SerializableAWSCredentials] = None,
+    dynamoEndpointUrl: Option[String] = None,
+    dynamoCredentials: Option[SerializableAWSCredentials] = None
+    ) {
+
+  def buildKCLConfig(workerId: String): KinesisClientLibConfiguration = {
+    // KCL config instance
+    val kinesisClientLibConfiguration =
+      new KinesisClientLibConfiguration(kinesisAppName, streamName, resolveAWSCredentialsProvider(), workerId)
+      .withKinesisEndpoint(endpointUrl)
+      .withInitialPositionInStream(initialPositionInStream)
+      .withTaskBackoffTimeMillis(500)
+      .withRegionName(regionName)
+    return kinesisClientLibConfiguration
+
+  }
+
+  def region: Region = {
+    RegionUtils.getRegion(regionName)
+  }
+
+  def buildDynamoClient(): AmazonDynamoDBClient = {
+    val client = if (dynamoCredentials.isDefined) new AmazonDynamoDBClient(resolveAWSCredentialsProvider(dynamoCredentials)) else new AmazonDynamoDBClient(resolveAWSCredentialsProvider())
+    client.setRegion(region)
+    if (dynamoEndpointUrl.isDefined) {
+      client.setEndpoint(dynamoEndpointUrl.get)
+    }
+    client
+  }
+
+  def buildKinesisClient(): AmazonKinesisClient = {
+    val client = new AmazonKinesisClient(resolveAWSCredentialsProvider())
+    client.setRegion(region)
+    client.setEndpoint(endpointUrl)
+    client
+
+  }
+
+  def buildCloudwatchClient(): AmazonCloudWatchClient = {
+    val client = new AmazonCloudWatchClient(resolveAWSCredentialsProvider())
+    client.setRegion(region)
+    client
+
+  }
+
+  def awsCreds: AWSCredentials = {
+    awsCredentialsOption.getOrElse(new DefaultAWSCredentialsProviderChain().getCredentials())
+
+  }
+
+
+  /**
+   * If AWS credential is provided, return a AWSCredentialProvider returning that credential.
+   * Otherwise, return the DefaultAWSCredentialsProviderChain.
+   */
+  private def resolveAWSCredentialsProvider(awsCredOpt: Option[SerializableAWSCredentials] = awsCredentialsOption): AWSCredentialsProvider = {
+    awsCredOpt match {
+      case Some(awsCredentials) =>
+        new AWSCredentialsProvider {
+          override def getCredentials: AWSCredentials = awsCredentials
+          override def refresh(): Unit = { }
+        }
+      case None =>
+        new DefaultAWSCredentialsProviderChain()
+    }
+  }
+
+}
+
+case class SerializableAWSCredentials(accessKeyId: String, secretKey: String)
+  extends AWSCredentials {
+  override def getAWSAccessKeyId: String = accessKeyId
+  override def getAWSSecretKey: String = secretKey
+}
+
+private object KinesisConfig {
+
+
+  /*
+   * @param kinesisAppName  Kinesis application name used by the Kinesis Client Library
+   *                        (KCL) to update DynamoDB
+   * @param streamName   Kinesis stream name
+   * @param endpointUrl  Url of Kinesis service (e.g., https://kinesis.us-east-1.amazonaws.com)
+   * @param regionName   Name of region used by the Kinesis Client Library (KCL) to update
+   *                     DynamoDB (lease coordination and checkpointing) and CloudWatch (metrics)
+   * @param initialPositionInStream  In the absence of Kinesis checkpoint info, this is the
+   *                                 worker's initial starting position in the stream.
+   *                                 The values are either the beginning of the stream
+   *                                 per Kinesis' limit of 24 hours
+   *                                 (InitialPositionInStream.TRIM_HORIZON) or
+   *                                 the tip of the stream (InitialPositionInStream.LATEST).
+   *
+   */
+  def buildConfig(
+    kinesisAppName: String,
+    streamName: String,
+    endpointUrl: String,
+    regionName: String,
+    initialPositionInStream: InitialPositionInStream = InitialPositionInStream.TRIM_HORIZON,
+    awsCredentialsOption: Option[SerializableAWSCredentials] = None): KinesisConfig = {
+    new KinesisConfig(kinesisAppName, streamName, endpointUrl,
+        regionName, initialPositionInStream, awsCredentialsOption)
+  }
+
+}

--- a/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisReceiver.scala
+++ b/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisReceiver.scala
@@ -23,9 +23,8 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.util.control.NonFatal
 
-import com.amazonaws.auth.{AWSCredentials, AWSCredentialsProvider, DefaultAWSCredentialsProviderChain}
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.{IRecordProcessor, IRecordProcessorCheckpointer, IRecordProcessorFactory}
-import com.amazonaws.services.kinesis.clientlibrary.lib.worker.{InitialPositionInStream, KinesisClientLibConfiguration, Worker}
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.Worker
 import com.amazonaws.services.kinesis.model.Record
 
 import org.apache.spark.storage.{StorageLevel, StreamBlockId}
@@ -34,12 +33,6 @@ import org.apache.spark.streaming.receiver.{BlockGenerator, BlockGeneratorListen
 import org.apache.spark.util.Utils
 import org.apache.spark.Logging
 
-private[kinesis]
-case class SerializableAWSCredentials(accessKeyId: String, secretKey: String)
-  extends AWSCredentials {
-  override def getAWSAccessKeyId: String = accessKeyId
-  override def getAWSSecretKey: String = secretKey
-}
 
 /**
  * Custom AWS Kinesis-specific implementation of Spark Streaming's Receiver.
@@ -60,37 +53,17 @@ case class SerializableAWSCredentials(accessKeyId: String, secretKey: String)
  *  - Periodically, each KinesisRecordProcessor checkpoints the latest successfully stored sequence
  *    number for it own shard.
  *
- * @param streamName   Kinesis stream name
- * @param endpointUrl  Url of Kinesis service (e.g., https://kinesis.us-east-1.amazonaws.com)
- * @param regionName  Region name used by the Kinesis Client Library for
- *                    DynamoDB (lease coordination and checkpointing) and CloudWatch (metrics)
- * @param initialPositionInStream  In the absence of Kinesis checkpoint info, this is the
- *                                 worker's initial starting position in the stream.
- *                                 The values are either the beginning of the stream
- *                                 per Kinesis' limit of 24 hours
- *                                 (InitialPositionInStream.TRIM_HORIZON) or
- *                                 the tip of the stream (InitialPositionInStream.LATEST).
- * @param checkpointAppName  Kinesis application name. Kinesis Apps are mapped to Kinesis Streams
- *                 by the Kinesis Client Library.  If you change the App name or Stream name,
- *                 the KCL will throw errors.  This usually requires deleting the backing
- *                 DynamoDB table with the same name this Kinesis application.
+ * @param config SparkKinesisConfig object,
  * @param checkpointInterval  Checkpoint interval for Kinesis checkpointing.
  *                            See the Kinesis Spark Streaming documentation for more
  *                            details on the different types of checkpoints.
  * @param storageLevel Storage level to use for storing the received objects
- * @param awsCredentialsOption Optional AWS credentials, used when user directly specifies
- *                             the credentials
  */
 private[kinesis] class KinesisReceiver[T](
-    val streamName: String,
-    endpointUrl: String,
-    regionName: String,
-    initialPositionInStream: InitialPositionInStream,
-    checkpointAppName: String,
+    config: KinesisConfig,
     checkpointInterval: Duration,
     storageLevel: StorageLevel,
-    messageHandler: Record => T,
-    awsCredentialsOption: Option[SerializableAWSCredentials])
+    messageHandler: Record => T)
   extends Receiver[T](storageLevel) with Logging { receiver =>
 
   /*
@@ -147,14 +120,6 @@ private[kinesis] class KinesisReceiver[T](
     workerId = Utils.localHostName() + ":" + UUID.randomUUID()
 
     kinesisCheckpointer = new KinesisCheckpointer(receiver, checkpointInterval, workerId)
-    // KCL config instance
-    val awsCredProvider = resolveAWSCredentialsProvider()
-    val kinesisClientLibConfiguration =
-      new KinesisClientLibConfiguration(checkpointAppName, streamName, awsCredProvider, workerId)
-      .withKinesisEndpoint(endpointUrl)
-      .withInitialPositionInStream(initialPositionInStream)
-      .withTaskBackoffTimeMillis(500)
-      .withRegionName(regionName)
 
    /*
     *  RecordProcessorFactory creates impls of IRecordProcessor.
@@ -167,7 +132,8 @@ private[kinesis] class KinesisReceiver[T](
         new KinesisRecordProcessor(receiver, workerId)
     }
 
-    worker = new Worker(recordProcessorFactory, kinesisClientLibConfiguration)
+    worker = new Worker(recordProcessorFactory, config.buildKCLConfig(workerId),
+        config.buildKinesisClient(), config.buildDynamoClient(), config.buildCloudwatchClient())
     workerThread = new Thread() {
       override def run(): Unit = {
         try {
@@ -215,7 +181,7 @@ private[kinesis] class KinesisReceiver[T](
   private[kinesis] def addRecords(shardId: String, records: java.util.List[Record]): Unit = {
     if (records.size > 0) {
       val dataIterator = records.iterator().asScala.map(messageHandler)
-      val metadata = SequenceNumberRange(streamName, shardId,
+      val metadata = SequenceNumberRange(config.streamName, shardId,
         records.get(0).getSequenceNumber(), records.get(records.size() - 1).getSequenceNumber())
       blockGenerator.addMultipleDataWithCallback(dataIterator, metadata)
     }
@@ -296,24 +262,6 @@ private[kinesis] class KinesisReceiver[T](
     // is assumed to be
     rangesToReport.ranges.foreach { range =>
       shardIdToLatestStoredSeqNum.put(range.shardId, range.toSeqNumber)
-    }
-  }
-
-  /**
-   * If AWS credential is provided, return a AWSCredentialProvider returning that credential.
-   * Otherwise, return the DefaultAWSCredentialsProviderChain.
-   */
-  private def resolveAWSCredentialsProvider(): AWSCredentialsProvider = {
-    awsCredentialsOption match {
-      case Some(awsCredentials) =>
-        logInfo("Using provided AWS credentials")
-        new AWSCredentialsProvider {
-          override def getCredentials: AWSCredentials = awsCredentials
-          override def refresh(): Unit = { }
-        }
-      case None =>
-        logInfo("Using DefaultAWSCredentialsProviderChain")
-        new DefaultAWSCredentialsProviderChain()
     }
   }
 

--- a/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisTestUtils.scala
+++ b/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisTestUtils.scala
@@ -26,6 +26,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.util.{Failure, Random, Success, Try}
 
 import com.amazonaws.auth.{AWSCredentials, DefaultAWSCredentialsProviderChain}
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.InitialPositionInStream
 import com.amazonaws.regions.RegionUtils
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
 import com.amazonaws.services.dynamodbv2.document.DynamoDB
@@ -66,6 +67,10 @@ private[kinesis] class KinesisTestUtils extends Logging {
     new DynamoDB(dynamoDBClient)
   }
 
+  lazy val sparkKinesisConfig: KinesisConfig = {
+    KinesisConfig.buildConfig("kinesis-asl-unit-test", _streamName, endpointUrl, regionName, InitialPositionInStream.TRIM_HORIZON)
+  }
+
   protected def getProducer(aggregate: Boolean): KinesisDataGenerator = {
     if (!aggregate) {
       new SimpleDataGenerator(kinesisClient)
@@ -74,10 +79,12 @@ private[kinesis] class KinesisTestUtils extends Logging {
     }
   }
 
+
   def streamName: String = {
     require(streamCreated, "Stream not yet created, call createStream() to create one")
     _streamName
   }
+
 
   def createStream(): Unit = {
     require(!streamCreated, "Stream already created")
@@ -228,6 +235,7 @@ private[kinesis] object KinesisTestUtils {
            """.stripMargin)
     }
   }
+
 }
 
 /** A wrapper interface that will allow us to consolidate the code for synthetic data generation. */

--- a/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisTestUtils.scala
+++ b/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisTestUtils.scala
@@ -26,10 +26,10 @@ import scala.collection.mutable.ArrayBuffer
 import scala.util.{Failure, Random, Success, Try}
 
 import com.amazonaws.auth.{AWSCredentials, DefaultAWSCredentialsProviderChain}
-import com.amazonaws.services.kinesis.clientlibrary.lib.worker.InitialPositionInStream
 import com.amazonaws.regions.RegionUtils
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
 import com.amazonaws.services.dynamodbv2.document.DynamoDB
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.InitialPositionInStream
 import com.amazonaws.services.kinesis.AmazonKinesisClient
 import com.amazonaws.services.kinesis.model._
 
@@ -68,7 +68,12 @@ private[kinesis] class KinesisTestUtils extends Logging {
   }
 
   lazy val sparkKinesisConfig: KinesisConfig = {
-    KinesisConfig.buildConfig("kinesis-asl-unit-test", _streamName, endpointUrl, regionName, InitialPositionInStream.TRIM_HORIZON)
+    KinesisConfig.buildConfig(
+        "kinesis-asl-unit-test",
+        _streamName,
+        endpointUrl,
+        regionName,
+        InitialPositionInStream.TRIM_HORIZON)
   }
 
   protected def getProducer(aggregate: Boolean): KinesisDataGenerator = {

--- a/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisUtils.scala
+++ b/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisUtils.scala
@@ -156,7 +156,8 @@ object KinesisUtils {
     // scalastyle:on
     val cleanedHandler = ssc.sc.clean(messageHandler)
     val kinesisClientConfig = KinesisConfig.buildConfig(kinesisAppName, streamName,
-      endpointUrl, validateRegion(regionName), initialPositionInStream, Some(SerializableAWSCredentials(awsAccessKeyId, awsSecretKey)))
+      endpointUrl, validateRegion(regionName), initialPositionInStream,
+      Some(SerializableAWSCredentials(awsAccessKeyId, awsSecretKey)))
     ssc.withNamedScope("kinesis stream") {
       new KinesisInputDStream[T](ssc, kinesisClientConfig,
         checkpointInterval, storageLevel, cleanedHandler)
@@ -184,7 +185,8 @@ object KinesisUtils {
       storageLevel: StorageLevel): ReceiverInputDStream[Array[Byte]] = {
     // Setting scope to override receiver stream's scope of "receiver stream"
     ssc.withNamedScope("kinesis stream") {
-      new KinesisInputDStream[Array[Byte]](ssc, config, checkpointInterval, storageLevel, defaultMessageHandler)
+      new KinesisInputDStream[Array[Byte]](ssc, config, checkpointInterval,
+          storageLevel, defaultMessageHandler)
     }
   }
 
@@ -274,7 +276,8 @@ object KinesisUtils {
       awsAccessKeyId: String,
       awsSecretKey: String): ReceiverInputDStream[Array[Byte]] = {
     val kinesisClientConfig = KinesisConfig.buildConfig(kinesisAppName, streamName,
-      endpointUrl, validateRegion(regionName), initialPositionInStream, Some(SerializableAWSCredentials(awsAccessKeyId, awsSecretKey)))
+      endpointUrl, validateRegion(regionName), initialPositionInStream,
+      Some(SerializableAWSCredentials(awsAccessKeyId, awsSecretKey)))
     ssc.withNamedScope("kinesis stream") {
       new KinesisInputDStream[Array[Byte]](ssc, kinesisClientConfig,
         checkpointInterval, storageLevel, defaultMessageHandler)

--- a/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisUtils.scala
+++ b/extras/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisUtils.scala
@@ -27,8 +27,38 @@ import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming.{Duration, StreamingContext}
 import org.apache.spark.streaming.api.java.{JavaReceiverInputDStream, JavaStreamingContext}
 import org.apache.spark.streaming.dstream.ReceiverInputDStream
+import org.apache.spark.util.Utils
 
 object KinesisUtils {
+  /**
+   * Create an input stream that pulls messages from a Kinesis stream.
+   * This uses the Kinesis Client Library (KCL) to pull messages from Kinesis.
+   *
+   * Note: the
+   *
+   * @param ssc StreamingContext object
+   * @param config SparkKinesisConfig object,
+   * @param checkpointInterval  Checkpoint interval for Kinesis checkpointing.
+   *                            See the Kinesis Spark Streaming documentation for more
+   *                            details on the different types of checkpoints.
+   * @param storageLevel Storage level to use for storing the received objects.
+   *                     StorageLevel.MEMORY_AND_DISK_2 is recommended.
+   * @param messageHandler A custom message handler that can generate a generic output from a
+   *                       Kinesis `Record`, which contains both message data, and metadata.
+   */
+  def createStream[T: ClassTag](
+      ssc: StreamingContext,
+      config: KinesisConfig,
+      checkpointInterval: Duration,
+      storageLevel: StorageLevel,
+      messageHandler: Record => T): ReceiverInputDStream[T] = {
+    val cleanedHandler = ssc.sc.clean(messageHandler)
+    // Setting scope to override receiver stream's scope of "receiver stream"
+    ssc.withNamedScope("kinesis stream") {
+      new KinesisInputDStream[T](ssc, config, checkpointInterval, storageLevel, cleanedHandler)
+    }
+  }
+
   /**
    * Create an input stream that pulls messages from a Kinesis stream.
    * This uses the Kinesis Client Library (KCL) to pull messages from Kinesis.
@@ -70,12 +100,14 @@ object KinesisUtils {
       messageHandler: Record => T): ReceiverInputDStream[T] = {
     val cleanedHandler = ssc.sc.clean(messageHandler)
     // Setting scope to override receiver stream's scope of "receiver stream"
+    val kinesisClientConfig = KinesisConfig.buildConfig(kinesisAppName, streamName,
+      endpointUrl, validateRegion(regionName), initialPositionInStream, None)
     ssc.withNamedScope("kinesis stream") {
-      new KinesisInputDStream[T](ssc, streamName, endpointUrl, validateRegion(regionName),
-        initialPositionInStream, kinesisAppName, checkpointInterval, storageLevel,
-        cleanedHandler, None)
+      new KinesisInputDStream[T](ssc, kinesisClientConfig,
+        checkpointInterval, storageLevel, cleanedHandler)
     }
   }
+
 
   /**
    * Create an input stream that pulls messages from a Kinesis stream.
@@ -123,10 +155,36 @@ object KinesisUtils {
       awsSecretKey: String): ReceiverInputDStream[T] = {
     // scalastyle:on
     val cleanedHandler = ssc.sc.clean(messageHandler)
+    val kinesisClientConfig = KinesisConfig.buildConfig(kinesisAppName, streamName,
+      endpointUrl, validateRegion(regionName), initialPositionInStream, Some(SerializableAWSCredentials(awsAccessKeyId, awsSecretKey)))
     ssc.withNamedScope("kinesis stream") {
-      new KinesisInputDStream[T](ssc, streamName, endpointUrl, validateRegion(regionName),
-        initialPositionInStream, kinesisAppName, checkpointInterval, storageLevel,
-        cleanedHandler, Some(SerializableAWSCredentials(awsAccessKeyId, awsSecretKey)))
+      new KinesisInputDStream[T](ssc, kinesisClientConfig,
+        checkpointInterval, storageLevel, cleanedHandler)
+    }
+  }
+
+  /**
+   * Create an input stream that pulls messages from a Kinesis stream.
+   * This uses the Kinesis Client Library (KCL) to pull messages from Kinesis.
+   *
+   * Note: the
+   *
+   * @param ssc StreamingContext object
+   * @param config SparkKinesisConfig object,
+   * @param checkpointInterval  Checkpoint interval for Kinesis checkpointing.
+   *                            See the Kinesis Spark Streaming documentation for more
+   *                            details on the different types of checkpoints.
+   * @param storageLevel Storage level to use for storing the received objects.
+   *                     StorageLevel.MEMORY_AND_DISK_2 is recommended.
+   */
+  def createStream(
+      ssc: StreamingContext,
+      config: KinesisConfig,
+      checkpointInterval: Duration,
+      storageLevel: StorageLevel): ReceiverInputDStream[Array[Byte]] = {
+    // Setting scope to override receiver stream's scope of "receiver stream"
+    ssc.withNamedScope("kinesis stream") {
+      new KinesisInputDStream[Array[Byte]](ssc, config, checkpointInterval, storageLevel, defaultMessageHandler)
     }
   }
 
@@ -167,10 +225,11 @@ object KinesisUtils {
       checkpointInterval: Duration,
       storageLevel: StorageLevel): ReceiverInputDStream[Array[Byte]] = {
     // Setting scope to override receiver stream's scope of "receiver stream"
+    val kinesisClientConfig = KinesisConfig.buildConfig(kinesisAppName, streamName,
+      endpointUrl, validateRegion(regionName), initialPositionInStream, None)
     ssc.withNamedScope("kinesis stream") {
-      new KinesisInputDStream[Array[Byte]](ssc, streamName, endpointUrl, validateRegion(regionName),
-        initialPositionInStream, kinesisAppName, checkpointInterval, storageLevel,
-        defaultMessageHandler, None)
+      new KinesisInputDStream[Array[Byte]](ssc, kinesisClientConfig,
+        checkpointInterval, storageLevel, defaultMessageHandler)
     }
   }
 
@@ -214,10 +273,11 @@ object KinesisUtils {
       storageLevel: StorageLevel,
       awsAccessKeyId: String,
       awsSecretKey: String): ReceiverInputDStream[Array[Byte]] = {
+    val kinesisClientConfig = KinesisConfig.buildConfig(kinesisAppName, streamName,
+      endpointUrl, validateRegion(regionName), initialPositionInStream, Some(SerializableAWSCredentials(awsAccessKeyId, awsSecretKey)))
     ssc.withNamedScope("kinesis stream") {
-      new KinesisInputDStream[Array[Byte]](ssc, streamName, endpointUrl, validateRegion(regionName),
-        initialPositionInStream, kinesisAppName, checkpointInterval, storageLevel,
-        defaultMessageHandler, Some(SerializableAWSCredentials(awsAccessKeyId, awsSecretKey)))
+      new KinesisInputDStream[Array[Byte]](ssc, kinesisClientConfig,
+        checkpointInterval, storageLevel, defaultMessageHandler)
     }
   }
 
@@ -259,10 +319,11 @@ object KinesisUtils {
       initialPositionInStream: InitialPositionInStream,
       storageLevel: StorageLevel
     ): ReceiverInputDStream[Array[Byte]] = {
+    val kinesisClientConfig = KinesisConfig.buildConfig(ssc.sc.appName, streamName,
+      endpointUrl, getRegionByEndpoint(endpointUrl), initialPositionInStream)
     ssc.withNamedScope("kinesis stream") {
-      new KinesisInputDStream[Array[Byte]](ssc, streamName, endpointUrl,
-        getRegionByEndpoint(endpointUrl), initialPositionInStream, ssc.sc.appName,
-        checkpointInterval, storageLevel, defaultMessageHandler, None)
+      new KinesisInputDStream[Array[Byte]](ssc, kinesisClientConfig,
+        checkpointInterval, storageLevel, defaultMessageHandler)
     }
   }
 
@@ -558,3 +619,5 @@ private class KinesisUtilsPythonHelper {
   }
 
 }
+
+

--- a/extras/kinesis-asl/src/test/java/org/apache/spark/streaming/kinesis/JavaKinesisStreamSuite.java
+++ b/extras/kinesis-asl/src/test/java/org/apache/spark/streaming/kinesis/JavaKinesisStreamSuite.java
@@ -28,8 +28,6 @@ import org.apache.spark.streaming.api.java.JavaDStream;
 
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.InitialPositionInStream;
 
-import java.nio.ByteBuffer;
-
 /**
  * Demonstrate the use of the KinesisUtils Java API
  */

--- a/extras/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisConfigSuite.scala
+++ b/extras/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisConfigSuite.scala
@@ -44,7 +44,6 @@ class KinesisConfigSuite extends KinesisFunSuite {
     assert(kclConfig.getStreamName() == kinesisStreamName)
     assert(kclConfig.getInitialPositionInStream() == streamPosition)
     assert(kclConfig.getApplicationName() == kinesisAppName)
-    assert(kclConfig.getRegionName() == regionName)
     assert(kclConfig.getKinesisEndpoint() == endpointUrl)
   }
 

--- a/extras/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisConfigSuite.scala
+++ b/extras/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisConfigSuite.scala
@@ -38,7 +38,7 @@ class KinesisConfigSuite extends KinesisFunSuite {
 
 
   test("builds a KinesisClientLibConfiguration with defaults set") {
-    val kinesisConfig = new KinesisConfig(kinesisAppName, kinesisStreamName, regionName, endpointUrl, streamPosition)
+    val kinesisConfig = new KinesisConfig(kinesisAppName, kinesisStreamName, endpointUrl, regionName, streamPosition)
     val kclConfig = kinesisConfig.buildKCLConfig(workerId)
     assert(kclConfig.getApplicationName() == kinesisAppName)
     assert(kclConfig.getStreamName() == kinesisStreamName)

--- a/extras/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisConfigSuite.scala
+++ b/extras/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisConfigSuite.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.streaming.kinesis
+
+import scala.language.postfixOps
+
+
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.{InitialPositionInStream, KinesisClientLibConfiguration}
+
+class KinesisConfigSuite extends KinesisFunSuite {
+
+  private val workerId = "dummyWorkerId"
+  private val kinesisAppName = "testApp"
+  private val kinesisStreamName = "testStream"
+  private val regionName = "us-east-1"
+  private val endpointUrl = "https://testendpoint.local"
+  private val streamPosition = InitialPositionInStream.TRIM_HORIZON
+
+  private val awsAccessKey = "accessKey"
+  private val awsSecretKey = "secretKey"
+  private val awsCreds = new SerializableAWSCredentials(awsAccessKey, awsSecretKey)
+
+
+
+  test("builds a KinesisClientLibConfiguration with defaults set") {
+    val kinesisConfig = new KinesisConfig(kinesisAppName, kinesisStreamName, regionName, endpointUrl, streamPosition)
+    val kclConfig = kinesisConfig.buildKCLConfig(workerId)
+    assert(kclConfig.getApplicationName() == kinesisAppName)
+    assert(kclConfig.getStreamName() == kinesisStreamName)
+    assert(kclConfig.getInitialPositionInStream() == streamPosition)
+    assert(kclConfig.getApplicationName() == kinesisAppName)
+    assert(kclConfig.getRegionName() == regionName)
+    assert(kclConfig.getKinesisEndpoint() == endpointUrl)
+  }
+
+  test("returns given creds if creds are specified") {
+    val kinesisConfig = new KinesisConfig(kinesisAppName, kinesisStreamName, regionName, endpointUrl, streamPosition, Some(awsCreds))
+    assert(kinesisConfig.awsCredentials == awsCreds)
+  }
+
+}

--- a/extras/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisStreamSuite.scala
+++ b/extras/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisStreamSuite.scala
@@ -142,9 +142,9 @@ abstract class KinesisStreamTests(aggregateTestData: Boolean) extends KinesisFun
     assert(kinesisRDD.config.regionName === dummyRegionName)
     assert(kinesisRDD.config.endpointUrl === dummyEndpointUrl)
     assert(kinesisRDD.retryTimeoutMs === batchDuration.milliseconds)
-    assert(kinesisRDD.config.awsCreds.getAWSAccessKeyId() ===
+    assert(kinesisRDD.config.awsCredentials.getAWSAccessKeyId() ===
       dummyAWSAccessKey)
-    assert(kinesisRDD.config.awsCreds.getAWSSecretKey() ===
+    assert(kinesisRDD.config.awsCredentials.getAWSSecretKey() ===
       dummyAWSSecretKey)
     assert(nonEmptyRDD.partitions.size === blockInfos.size)
     nonEmptyRDD.partitions.foreach { _ shouldBe a [KinesisBackedBlockRDDPartition] }

--- a/extras/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisStreamSuite.scala
+++ b/extras/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisStreamSuite.scala
@@ -139,11 +139,13 @@ abstract class KinesisStreamTests(aggregateTestData: Boolean) extends KinesisFun
     val nonEmptyRDD = kinesisStream.createBlockRDD(time, blockInfos)
     nonEmptyRDD shouldBe a [KinesisBackedBlockRDD[_]]
     val kinesisRDD = nonEmptyRDD.asInstanceOf[KinesisBackedBlockRDD[_]]
-    assert(kinesisRDD.regionName === dummyRegionName)
-    assert(kinesisRDD.endpointUrl === dummyEndpointUrl)
+    assert(kinesisRDD.config.regionName === dummyRegionName)
+    assert(kinesisRDD.config.endpointUrl === dummyEndpointUrl)
     assert(kinesisRDD.retryTimeoutMs === batchDuration.milliseconds)
-    assert(kinesisRDD.awsCredentialsOption ===
-      Some(SerializableAWSCredentials(dummyAWSAccessKey, dummyAWSSecretKey)))
+    assert(kinesisRDD.config.awsCreds.getAWSAccessKeyId() ===
+      dummyAWSAccessKey)
+    assert(kinesisRDD.config.awsCreds.getAWSSecretKey() ===
+      dummyAWSSecretKey)
     assert(nonEmptyRDD.partitions.size === blockInfos.size)
     nonEmptyRDD.partitions.foreach { _ shouldBe a [KinesisBackedBlockRDDPartition] }
     val partitions = nonEmptyRDD.partitions.map {
@@ -154,7 +156,7 @@ abstract class KinesisStreamTests(aggregateTestData: Boolean) extends KinesisFun
 
     // Verify that KinesisBackedBlockRDD is generated even when there are no blocks
     val emptyRDD = kinesisStream.createBlockRDD(time, Seq.empty)
-    emptyRDD shouldBe a [KinesisBackedBlockRDD[Array[Byte]]]
+    emptyRDD shouldBe a [KinesisBackedBlockRDD[_]]
     emptyRDD.partitions shouldBe empty
 
     // Verify that the KinesisBackedBlockRDD has isBlockValid = false when blocks are invalid


### PR DESCRIPTION
This patch refactors the KinesisUtils and adds new APIs such that it is
easy to pass more configuration options into the KCL, such as using a
different DynamoDBClient with a different endpoint.

The core of this refactoring/change is to introduce the `KinesisConfig`
class which is intended to encapsulate all configuration concerns.
Currently, it doesn't do much more than allow for setting the DynamoDB
endpoint, but it is a good place for where other options could be
contained without changing underlying APIs. It could also be inherited
to override behavior for more options without requiring any API changes
(such as overriding `buildKCLConfig` ti allow for more configuration
changes)

This also introduce a new external API for creating a KinesisRDD, which
takes a `KinesisConfig` object which may be a more manageable API going
forward.

Docs are still lacking for the new class as well as some basic unit
specs
