### PR TITLE
[SPARK-13372] [ML] Fix LogisticRegression when standardization = false && regParam = 0.0

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/classification/LogisticRegression.scala
@@ -444,8 +444,8 @@ class LogisticRegressionWithLBFGS
         createModel(weights, mlLogisticRegresionModel.intercept)
       }
       optimizer.getUpdater() match {
-        case x: SquaredL2Updater => runWithMlLogisitcRegression(1.0)
-        case x: L1Updater => runWithMlLogisitcRegression(0.0)
+        case x: SquaredL2Updater => runWithMlLogisitcRegression(0.0)
+        case x: L1Updater => runWithMlLogisitcRegression(1.0)
         case _ => super.run(input, initialWeights)
       }
     } else {

--- a/mllib/src/test/scala/org/apache/spark/mllib/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/classification/LogisticRegressionSuite.scala
@@ -394,6 +394,7 @@ class LogisticRegressionSuite extends SparkFunSuite with MLlibTestSparkContext w
     lrA.optimizer.setNumIterations(numIteration)
     val lrB = new LogisticRegressionWithLBFGS().setIntercept(true).setFeatureScaling(false)
     lrB.optimizer.setNumIterations(numIteration)
+    lrB.optimizer.setRegParam(0.001)
 
     val modelA1 = lrA.run(testRDD1, initialWeights)
     val modelA2 = lrA.run(testRDD2, initialWeights)


### PR DESCRIPTION
At #7080 we implemented disable feature scaling by penalizing each component differently. But if users train model without penalizing(set `regParam = 0.0`), `LogisticRegression` with `standardization = false` will run the same route as `standardization = true` which is incorrect. This PR will fix this issue.

We can check the test case `binary logistic regression without intercept without regularization`.
Before this fix, it will converged after 16 iterations  for both `standardization = true` and `standardization = false`(Because they run the same code route).
After this fix, it will converged after 16 iterations for  `standardization = true` and 14 iterations for  `standardization = false`.

`LinearRegression` may have the same issue. If this is accepted, I can send another PR to fix that.

cc @dbtsai @mengxr @holdenk 
