### PR TITLE
[SPARK-13213][SQL] Use CartisianProduct instead of BroacastNestedLoopJoin if possibly

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -380,7 +380,12 @@ object ColumnPruning extends Rule[LogicalPlan] {
   /** Applies a projection only when the child is producing unnecessary attributes */
   private def prunedChild(c: LogicalPlan, allReferences: AttributeSet) =
     if ((c.outputSet -- allReferences.filter(c.outputSet.contains)).nonEmpty) {
-      Project(allReferences.filter(c.outputSet.contains).toSeq, c)
+      c match {
+        case BroadcastHint(p) =>
+          BroadcastHint(Project(allReferences.filter(c.outputSet.contains).toSeq, p))
+        case _ =>
+          Project(allReferences.filter(c.outputSet.contains).toSeq, c)
+      }
     } else {
       c
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -87,6 +87,21 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
     }
   }
 
+  object SmallerThanBroadcastThreshold {
+    def unapply(plan: LogicalPlan): Option[LogicalPlan] = plan match {
+      case p if sqlContext.conf.autoBroadcastJoinThreshold > 0 &&
+        p.statistics.sizeInBytes <= sqlContext.conf.autoBroadcastJoinThreshold => Some(p)
+      case _ => None
+    }
+  }
+
+  object ShouldBroadcast {
+    def unapply(plan: LogicalPlan): Option[LogicalPlan] = plan match {
+      case BroadcastHint(p) => Some(p)
+      case _ => None
+    }
+  }
+
   /**
    * Uses the [[ExtractEquiJoinKeys]] pattern to find joins where at least some of the predicates
    * can be evaluated by matching join keys.
@@ -248,12 +263,26 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
 
   object BroadcastNestedLoop extends Strategy {
     def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
+      // If joinType is Inner or condition is None, we will not use BroadcastNestedLoop
+      // but faster CartesianProduct
       case logical.Join(
-             CanBroadcast(left), right, joinType, condition) if joinType != LeftSemi =>
+             SmallerThanBroadcastThreshold(left), right, joinType, condition)
+             if joinType != LeftSemi && joinType != Inner && condition != None =>
         execution.joins.BroadcastNestedLoopJoin(
           planLater(left), planLater(right), joins.BuildLeft, joinType, condition) :: Nil
       case logical.Join(
-             left, CanBroadcast(right), joinType, condition) if joinType != LeftSemi =>
+             ShouldBroadcast(left), right, joinType, condition)
+             if joinType != LeftSemi =>
+        execution.joins.BroadcastNestedLoopJoin(
+          planLater(left), planLater(right), joins.BuildLeft, joinType, condition) :: Nil
+      case logical.Join(
+             left, SmallerThanBroadcastThreshold(right), joinType, condition)
+             if joinType != LeftSemi && joinType != Inner && condition != None =>
+        execution.joins.BroadcastNestedLoopJoin(
+          planLater(left), planLater(right), joins.BuildRight, joinType, condition) :: Nil
+      case logical.Join(
+             left, ShouldBroadcast(right), joinType, condition)
+             if joinType != LeftSemi =>
         execution.joins.BroadcastNestedLoopJoin(
           planLater(left), planLater(right), joins.BuildRight, joinType, condition) :: Nil
       case _ => Nil

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -440,7 +440,7 @@ class JoinSuite extends QueryTest with SharedSQLContext {
     sql("UNCACHE TABLE testData")
   }
 
-  test("cross join with broadcast") {
+  test("cross join with cartisian product") {
     sql("CACHE TABLE testData")
 
     val sizeInByteOfTestData = statisticSizeInByte(sqlContext.table("testData"))
@@ -461,31 +461,31 @@ class JoinSuite extends QueryTest with SharedSQLContext {
         ("SELECT * FROM testData LEFT SEMI JOIN testData2",
           classOf[LeftSemiJoinBNL]),
         ("SELECT * FROM testData JOIN testData2",
-          classOf[BroadcastNestedLoopJoin]),
+          classOf[CartesianProduct]),
         ("SELECT * FROM testData JOIN testData2 WHERE key = 2",
-          classOf[BroadcastNestedLoopJoin]),
+          classOf[CartesianProduct]),
         ("SELECT * FROM testData LEFT JOIN testData2",
-          classOf[BroadcastNestedLoopJoin]),
+          classOf[CartesianProduct]),
         ("SELECT * FROM testData RIGHT JOIN testData2",
-          classOf[BroadcastNestedLoopJoin]),
+          classOf[CartesianProduct]),
         ("SELECT * FROM testData FULL OUTER JOIN testData2",
-          classOf[BroadcastNestedLoopJoin]),
+          classOf[CartesianProduct]),
         ("SELECT * FROM testData LEFT JOIN testData2 WHERE key = 2",
-          classOf[BroadcastNestedLoopJoin]),
+          classOf[CartesianProduct]),
         ("SELECT * FROM testData RIGHT JOIN testData2 WHERE key = 2",
-          classOf[BroadcastNestedLoopJoin]),
+          classOf[CartesianProduct]),
         ("SELECT * FROM testData FULL OUTER JOIN testData2 WHERE key = 2",
-          classOf[BroadcastNestedLoopJoin]),
+          classOf[CartesianProduct]),
         ("SELECT * FROM testData JOIN testData2 WHERE key > a",
-          classOf[BroadcastNestedLoopJoin]),
+          classOf[CartesianProduct]),
         ("SELECT * FROM testData FULL OUTER JOIN testData2 WHERE key > a",
-          classOf[BroadcastNestedLoopJoin]),
+          classOf[CartesianProduct]),
         ("SELECT * FROM testData left JOIN testData2 WHERE (key * a != key + a)",
-          classOf[BroadcastNestedLoopJoin]),
+          classOf[CartesianProduct]),
         ("SELECT * FROM testData right JOIN testData2 WHERE (key * a != key + a)",
-          classOf[BroadcastNestedLoopJoin]),
+          classOf[CartesianProduct]),
         ("SELECT * FROM testData full JOIN testData2 WHERE (key * a != key + a)",
-          classOf[BroadcastNestedLoopJoin])
+          classOf[CartesianProduct])
       ).foreach { case (query, joinClass) => assertJoin(query, joinClass) }
 
       checkAnswer(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/BenchmarkWholeStageCodegen.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/BenchmarkWholeStageCodegen.scala
@@ -122,6 +122,33 @@ class BenchmarkWholeStageCodegen extends SparkFunSuite {
     */
   }
 
+  ignore("broadcast hash join vs. cartisian product") {
+    val N = 1 << 10
+    val benchmark = new Benchmark("BroadcastHashJoin vs. CartisianProduct", N)
+
+    val broadcastedDim =
+      broadcast(sqlContext.range(1 << 10).selectExpr("id as k", "cast(id as string) as v"))
+    val dim = sqlContext.range(1 << 10).selectExpr("id as k", "cast(id as string) as v")
+
+    benchmark.addCase("Join w long with broadcast hash") { iter =>
+      sqlContext.range(N).join(broadcastedDim).count()
+    }
+
+    benchmark.addCase("Join w long with cartisian product") { iter =>
+      sqlContext.range(N).join(dim).count()
+    }
+
+    benchmark.run()
+
+    /*
+    model name      : Westmere E56xx/L56xx/X56xx (Nehalem-C)
+    BroadcastHashJoin vs. CartisianProduct: Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+    -------------------------------------------------------------------------------------------
+    Join w long with broadcast hash           325 /  442          0.0      316962.6       1.0X
+    Join w long with cartisian product        270 /  302          0.0      263644.3       1.2X
+    */
+  }
+
   ignore("broadcast hash join") {
     val N = 100 << 20
     val dim = broadcast(sqlContext.range(1 << 16).selectExpr("id as k", "cast(id as string) as v"))

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
 import org.apache.spark.sql.catalyst.analysis.NoSuchDatabaseException
 import org.apache.spark.sql.catalyst.expressions.Cast
 import org.apache.spark.sql.catalyst.plans.logical.Project
+import org.apache.spark.sql.functions._
 import org.apache.spark.sql.execution.joins.BroadcastNestedLoopJoin
 import org.apache.spark.sql.hive._
 import org.apache.spark.sql.hive.test.{TestHive, TestHiveContext}
@@ -111,8 +112,21 @@ class HiveQuerySuite extends HiveComparisonTest with BeforeAndAfter {
     spark_10484_4)
 
   test("SPARK-10484 Optimize the Cartesian (Cross) Join with broadcast based JOIN") {
-    def assertBroadcastNestedLoopJoin(sqlText: String): Unit = {
-      assert(sql(sqlText).queryExecution.sparkPlan.collect {
+    val df = sql("SELECT * FROM src").toDF()
+    val srcDF = df.as("a")
+    val broadcastedSrc = broadcast(df.as("b"))
+
+    val spark_10484_1 = srcDF.join(broadcastedSrc, $"a.key" > ($"b.key" + 300), "left_outer")
+      .select($"a.key", $"b.key")
+    val spark_10484_2 = srcDF.join(broadcastedSrc, $"a.key" > ($"b.key" + 300), "right_outer")
+      .select($"a.key", $"b.key")
+    val spark_10484_3 =
+      srcDF.join(broadcastedSrc, $"a.key" > ($"b.key" + 300), "outer").select($"a.key", $"b.key")
+    val spark_10484_4 =
+      srcDF.join(broadcastedSrc, $"a.key" > ($"b.key" + 300), "inner").select($"a.key", $"b.key")
+
+    def assertBroadcastNestedLoopJoin(df: DataFrame): Unit = {
+      assert(df.queryExecution.sparkPlan.collect {
         case _: BroadcastNestedLoopJoin => 1
       }.nonEmpty)
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -31,8 +31,8 @@ import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
 import org.apache.spark.sql.catalyst.analysis.NoSuchDatabaseException
 import org.apache.spark.sql.catalyst.expressions.Cast
 import org.apache.spark.sql.catalyst.plans.logical.Project
-import org.apache.spark.sql.functions._
 import org.apache.spark.sql.execution.joins.BroadcastNestedLoopJoin
+import org.apache.spark.sql.functions._
 import org.apache.spark.sql.hive._
 import org.apache.spark.sql.hive.test.{TestHive, TestHiveContext}
 import org.apache.spark.sql.hive.test.TestHive._


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-13213
## What changes were proposed in this pull request?

This patch uses `CartisianProduct` instead of `BroacastNestedLoopJoin` for a logical.join if possibly, as the performance of `CartisianProduct` is improved recently.
## How was the this patch tested?

A benchmark test and its result are added into `BenchmarkWholeStageCodegen`.
