### PR TITLE
[SPARK-13369] Make number of consecutive fetch failures for a stage b…

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/ResultStage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ResultStage.scala
@@ -34,8 +34,10 @@ private[spark] class ResultStage(
     val partitions: Array[Int],
     parents: List[Stage],
     firstJobId: Int,
+    maxConsecutiveFetchFailure: Int,
     callSite: CallSite)
-  extends Stage(id, rdd, partitions.length, parents, firstJobId, callSite) {
+  extends Stage(id, rdd, partitions.length, parents, firstJobId, maxConsecutiveFetchFailure,
+    callSite) {
 
   /**
    * The active job for this result stage. Will be empty if the job has already finished

--- a/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapStage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapStage.scala
@@ -39,9 +39,10 @@ private[spark] class ShuffleMapStage(
     numTasks: Int,
     parents: List[Stage],
     firstJobId: Int,
+    maxConsecutiveFetchFailure: Int,
     callSite: CallSite,
     val shuffleDep: ShuffleDependency[_, _, _])
-  extends Stage(id, rdd, numTasks, parents, firstJobId, callSite) {
+  extends Stage(id, rdd, numTasks, parents, firstJobId, maxConsecutiveFetchFailure, callSite) {
 
   private[this] var _mapStageJobs: List[ActiveJob] = Nil
 

--- a/core/src/main/scala/org/apache/spark/scheduler/Stage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Stage.scala
@@ -58,6 +58,7 @@ private[scheduler] abstract class Stage(
     val numTasks: Int,
     val parents: List[Stage],
     val firstJobId: Int,
+    val maxConsecutiveFetchFailure: Int,
     val callSite: CallSite)
   extends Logging {
 
@@ -118,7 +119,7 @@ private[scheduler] abstract class Stage(
    */
   private[scheduler] def failedOnFetchAndShouldAbort(stageAttemptId: Int): Boolean = {
     fetchFailedAttemptIds.add(stageAttemptId)
-    fetchFailedAttemptIds.size >= Stage.MAX_CONSECUTIVE_FETCH_FAILURES
+    fetchFailedAttemptIds.size >= maxConsecutiveFetchFailure
   }
 
   /** Creates a new attempt for this stage by creating a new StageInfo with a new attempt ID. */
@@ -145,6 +146,6 @@ private[scheduler] abstract class Stage(
 }
 
 private[scheduler] object Stage {
-  // The number of consecutive failures allowed before a stage is aborted
-  val MAX_CONSECUTIVE_FETCH_FAILURES = 4
+  // The number of consecutive fetch failures allowed before a stage is aborted
+  val DEFAULT_MAX_CONSECUTIVE_FETCH_FAILURES = 4
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1157,6 +1157,13 @@ Apart from these, the following properties are also available, and may be useful
     Should be greater than or equal to 1. Number of allowed retries = this value - 1.
   </td>
 </tr>
+<tr>
+  <td><code>spark.max.fetch.failures.per.stage</code></td>
+  <td>4</td>
+  <td>
+    Number of consecutive fetch failures allowed before a stage is aborted.
+  </td>
+</tr>
 </table>
 
 #### Dynamic Allocation


### PR DESCRIPTION
## What changes were proposed in this pull request?

The previously hardcoded max 4 retries per stage is not suitable for all cluster configurations. Since spark retries a stage at the sign of the first fetch failure, you can easily end up with many stage retries to discover all the failures. In particular, two scenarios this value should change are (1) if there are more than 4 executors per node; in that case, it may take 4 retries to discover the problem with each executor on the node and (2) during cluster maintenance on large clusters, where multiple machines are serviced at once, but you also cannot afford total cluster downtime. By making this value configurable, cluster managers can tune this value to something more appropriate to their cluster configuration.


unit tests.
