### PR TITLE
[SPARK-13381][SQL] Support for loading CSV with a single function call

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -347,8 +347,8 @@ class DataFrameReader private[sql](sqlContext: SQLContext) extends Logging {
   /**
    * Loads a CSV file and returns the result as a [[DataFrame]].
    *
-   * This function goes through the input once to determine the input schema. If you know the
-   * schema in advance, use the version that specifies the schema to avoid the extra scan.
+   * This function goes through the input once to determine the input schema. To avoid going
+   * through the entire data once, specify the schema explicitly using [[schema]].
    *
    * @since 2.0.0
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -30,7 +30,6 @@ import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.execution.datasources.{LogicalRelation, ResolvedDataSource}
-import org.apache.spark.sql.execution.datasources.csv.CSVRelation
 import org.apache.spark.sql.execution.datasources.jdbc.{JDBCPartition, JDBCPartitioningInfo, JDBCRelation}
 import org.apache.spark.sql.execution.datasources.json.JSONRelation
 import org.apache.spark.sql.execution.datasources.parquet.ParquetRelation
@@ -353,37 +352,8 @@ class DataFrameReader private[sql](sqlContext: SQLContext) extends Logging {
    *
    * @since 2.0.0
    */
+  @scala.annotation.varargs
   def csv(paths: String*): DataFrame = format("csv").load(paths : _*)
-
-  /**
-   * Loads an `RDD[String]` storing CSV records and returns the result as a [[DataFrame]].
-   *
-   * Unless the schema is specified using [[schema]] function, this function goes through the
-   * input once to determine the input schema.
-   *
-   * @param csvRDD input RDD containing CSV records
-   * @since 2.0.0
-   */
-  def csv(csvRDD: JavaRDD[String]): DataFrame = csv(csvRDD.rdd)
-
-  /**
-   * Loads an `RDD[String]` storing CSV records and returns the result as a [[DataFrame]].
-   *
-   * Unless the schema is specified using [[schema]] function, this function goes through the
-   * input once to determine the input schema.
-   *
-   * @param csvRDD input RDD containing CSV records
-   * @since 2.0.0
-   */
-  def csv(csvRDD: RDD[String]): DataFrame = {
-    sqlContext.baseRelationToDataFrame(
-      new CSVRelation(
-        Some(csvRDD),
-        maybeDataSchema = userSpecifiedSchema,
-        userDefinedPartitionColumns = None,
-        parameters = extraOptions.toMap)(sqlContext)
-    )
-  }
 
   /**
    * Loads a Parquet file, returning the result as a [[DataFrame]]. This function returns an empty

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
@@ -37,9 +37,9 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types._
 
-private[csv] class CSVRelation(
+private[sql] class CSVRelation(
     private val inputRDD: Option[RDD[String]],
-    override val paths: Array[String],
+    override val paths: Array[String] = Array.empty[String],
     private val maybeDataSchema: Option[StructType],
     override val userDefinedPartitionColumns: Option[StructType],
     private val parameters: Map[String, String])
@@ -127,7 +127,7 @@ private[csv] class CSVRelation(
   }
 
   private def inferSchema(paths: Array[String]): StructType = {
-    val rdd = baseRdd(Array(paths.head))
+    val rdd = baseRdd(paths)
     val firstLine = findFirstLine(rdd)
     val firstRow = new LineCsvReader(params).parseLine(firstLine)
 

--- a/sql/core/src/test/java/test/org/apache/spark/sql/sources/JavaSaveLoadSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/sources/JavaSaveLoadSuite.java
@@ -59,7 +59,7 @@ public class JavaSaveLoadSuite {
 
     originalDefaultSource = sqlContext.conf().defaultDataSourceName();
     path =
-            Utils.createTempDir(System.getProperty("java.io.tmpdir"), "datasource").getCanonicalFile();
+      Utils.createTempDir(System.getProperty("java.io.tmpdir"), "datasource").getCanonicalFile();
     if (path.exists()) {
       path.delete();
     }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/sources/JavaSaveLoadSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/sources/JavaSaveLoadSuite.java
@@ -75,7 +75,7 @@ public class JavaSaveLoadSuite {
 
     List<String> csvObjects = new ArrayList<>(10);
     for (int i = 0; i < 10; i++) {
-      jsonObjects.add(i + ", " + i + ", str" );
+      csvObjects.add(i + "," + i + ",str" );
     }
     JavaRDD<String> csvRDD = sc.parallelize(csvObjects);
     csvDf = sqlContext.read().csv(csvRDD);

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -100,16 +100,6 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
     verifyCars(cars, withHeader = false, checkTypes = false)
   }
 
-  test("simple csv test with loading csv data from RDD") {
-    val csvRDD = sparkContext.textFile(testFile(carsFile))
-    val cars = sqlContext
-      .read
-      .option("header", "false")
-      .csv(csvRDD)
-
-    verifyCars(cars, withHeader = false, checkTypes = false)
-  }
-
   test("simple csv test with type inference") {
     val cars = sqlContext
       .read

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -91,6 +91,25 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
     verifyCars(cars, withHeader = false, checkTypes = false)
   }
 
+  test("simple csv test with calling another function to load") {
+    val cars = sqlContext
+      .read
+      .option("header", "false")
+      .csv(testFile(carsFile))
+
+    verifyCars(cars, withHeader = false, checkTypes = false)
+  }
+
+  test("simple csv test with loading csv data from RDD") {
+    val csvRDD = sparkContext.textFile(testFile(carsFile))
+    val cars = sqlContext
+      .read
+      .option("header", "false")
+      .csv(csvRDD)
+
+    verifyCars(cars, withHeader = false, checkTypes = false)
+  }
+
   test("simple csv test with type inference") {
     val cars = sqlContext
       .read


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-13381

This PR adds the support to load CSV data directly by a single call with given paths.

Also, I corrected this to refer all paths rather than the first path in schema inference, which JSON datasource dose.

Several unitests were added for each functionality.
