### PR TITLE
[SPARK-13038][SPARK-13388][PySpark] Add load/save to pipeline and change it to use the Scala implementation

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -429,6 +429,7 @@ pyspark_ml = Module(
         "pyspark.ml.feature",
         "pyspark.ml.classification",
         "pyspark.ml.clustering",
+        "pyspark.ml.pipeline",
         "pyspark.ml.recommendation",
         "pyspark.ml.regression",
         "pyspark.ml.tuning",

--- a/python/pyspark/ml/__init__.py
+++ b/python/pyspark/ml/__init__.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
-from pyspark.ml.pipeline import Transformer, Estimator, Model, Pipeline, PipelineModel
+from pyspark.ml.base import Estimator, Model, Transformer
+from pyspark.ml.pipeline import Pipeline, PipelineModel
 
 __all__ = ["Transformer", "Estimator", "Model", "Pipeline", "PipelineModel"]

--- a/python/pyspark/ml/base.py
+++ b/python/pyspark/ml/base.py
@@ -1,0 +1,126 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from abc import ABCMeta, abstractmethod
+
+from pyspark import since
+from pyspark.ml.param import Params
+from pyspark.mllib.common import inherit_doc
+
+
+@inherit_doc
+class Estimator(Params):
+    """
+    Abstract class for estimators that fit models to data.
+
+    .. versionadded:: 1.3.0
+    """
+
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def _fit(self, dataset):
+        """
+        Fits a model to the input dataset. This is called by the
+        default implementation of fit.
+
+        :param dataset: input dataset, which is an instance of
+                        :py:class:`pyspark.sql.DataFrame`
+        :returns: fitted model
+        """
+        raise NotImplementedError()
+
+    @since("1.3.0")
+    def fit(self, dataset, params=None):
+        """
+        Fits a model to the input dataset with optional parameters.
+
+        :param dataset: input dataset, which is an instance of
+                        :py:class:`pyspark.sql.DataFrame`
+        :param params: an optional param map that overrides embedded
+                       params. If a list/tuple of param maps is given,
+                       this calls fit on each param map and returns a
+                       list of models.
+        :returns: fitted model(s)
+        """
+        if params is None:
+            params = dict()
+        if isinstance(params, (list, tuple)):
+            return [self.fit(dataset, paramMap) for paramMap in params]
+        elif isinstance(params, dict):
+            if params:
+                return self.copy(params)._fit(dataset)
+            else:
+                return self._fit(dataset)
+        else:
+            raise ValueError("Params must be either a param map or a list/tuple of param maps, "
+                             "but got %s." % type(params))
+
+
+@inherit_doc
+class Transformer(Params):
+    """
+    Abstract class for transformers that transform one dataset into
+    another.
+
+    .. versionadded:: 1.3.0
+    """
+
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def _transform(self, dataset):
+        """
+        Transforms the input dataset.
+
+        :param dataset: input dataset, which is an instance of
+                        :py:class:`pyspark.sql.DataFrame`
+        :returns: transformed dataset
+        """
+        raise NotImplementedError()
+
+    @since("1.3.0")
+    def transform(self, dataset, params=None):
+        """
+        Transforms the input dataset with optional parameters.
+
+        :param dataset: input dataset, which is an instance of
+                        :py:class:`pyspark.sql.DataFrame`
+        :param params: an optional param map that overrides embedded
+                       params.
+        :returns: transformed dataset
+        """
+        if params is None:
+            params = dict()
+        if isinstance(params, dict):
+            if params:
+                return self.copy(params,)._transform(dataset)
+            else:
+                return self._transform(dataset)
+        else:
+            raise ValueError("Params must be either a param map but got %s." % type(params))
+
+
+@inherit_doc
+class Model(Transformer):
+    """
+    Abstract class for models that are fitted by estimators.
+
+    .. versionadded:: 1.4.0
+    """
+
+    __metaclass__ = ABCMeta

--- a/python/pyspark/ml/pipeline.py
+++ b/python/pyspark/ml/pipeline.py
@@ -15,120 +15,16 @@
 # limitations under the License.
 #
 
-from abc import ABCMeta, abstractmethod
-
 from pyspark import since
+from pyspark.ml.base import Estimator, Model, Transformer
 from pyspark.ml.param import Param, Params
-from pyspark.ml.util import keyword_only
+from pyspark.ml.util import keyword_only, MLReadable, MLWritable
+from pyspark.ml.wrapper import JavaWrapper
 from pyspark.mllib.common import inherit_doc
 
 
 @inherit_doc
-class Estimator(Params):
-    """
-    Abstract class for estimators that fit models to data.
-
-    .. versionadded:: 1.3.0
-    """
-
-    __metaclass__ = ABCMeta
-
-    @abstractmethod
-    def _fit(self, dataset):
-        """
-        Fits a model to the input dataset. This is called by the
-        default implementation of fit.
-
-        :param dataset: input dataset, which is an instance of
-                        :py:class:`pyspark.sql.DataFrame`
-        :returns: fitted model
-        """
-        raise NotImplementedError()
-
-    @since("1.3.0")
-    def fit(self, dataset, params=None):
-        """
-        Fits a model to the input dataset with optional parameters.
-
-        :param dataset: input dataset, which is an instance of
-                        :py:class:`pyspark.sql.DataFrame`
-        :param params: an optional param map that overrides embedded
-                       params. If a list/tuple of param maps is given,
-                       this calls fit on each param map and returns a
-                       list of models.
-        :returns: fitted model(s)
-        """
-        if params is None:
-            params = dict()
-        if isinstance(params, (list, tuple)):
-            return [self.fit(dataset, paramMap) for paramMap in params]
-        elif isinstance(params, dict):
-            if params:
-                return self.copy(params)._fit(dataset)
-            else:
-                return self._fit(dataset)
-        else:
-            raise ValueError("Params must be either a param map or a list/tuple of param maps, "
-                             "but got %s." % type(params))
-
-
-@inherit_doc
-class Transformer(Params):
-    """
-    Abstract class for transformers that transform one dataset into
-    another.
-
-    .. versionadded:: 1.3.0
-    """
-
-    __metaclass__ = ABCMeta
-
-    @abstractmethod
-    def _transform(self, dataset):
-        """
-        Transforms the input dataset.
-
-        :param dataset: input dataset, which is an instance of
-                        :py:class:`pyspark.sql.DataFrame`
-        :returns: transformed dataset
-        """
-        raise NotImplementedError()
-
-    @since("1.3.0")
-    def transform(self, dataset, params=None):
-        """
-        Transforms the input dataset with optional parameters.
-
-        :param dataset: input dataset, which is an instance of
-                        :py:class:`pyspark.sql.DataFrame`
-        :param params: an optional param map that overrides embedded
-                       params.
-        :returns: transformed dataset
-        """
-        if params is None:
-            params = dict()
-        if isinstance(params, dict):
-            if params:
-                return self.copy(params,)._transform(dataset)
-            else:
-                return self._transform(dataset)
-        else:
-            raise ValueError("Params must be either a param map but got %s." % type(params))
-
-
-@inherit_doc
-class Model(Transformer):
-    """
-    Abstract class for models that are fitted by estimators.
-
-    .. versionadded:: 1.4.0
-    """
-
-    __metaclass__ = ABCMeta
-
-
-@inherit_doc
-class Pipeline(Estimator):
+class Pipeline(Estimator, JavaWrapper, MLReadable, MLWritable):
     """
     A simple pipeline, which acts as an estimator. A Pipeline consists
     of a sequence of stages, each of which is either an
@@ -234,7 +130,7 @@ class Pipeline(Estimator):
 
 
 @inherit_doc
-class PipelineModel(Model):
+class PipelineModel(Model, JavaWrapper, MLReadable, MLWritable):
     """
     Represents a compiled pipeline with transformers and fitted models.
 

--- a/python/pyspark/ml/pipeline.py
+++ b/python/pyspark/ml/pipeline.py
@@ -15,16 +15,16 @@
 # limitations under the License.
 #
 
+from pyspark import SparkContext
 from pyspark import since
-from pyspark.ml.base import Estimator, Model, Transformer
 from pyspark.ml.param import Param, Params
 from pyspark.ml.util import keyword_only, MLReadable, MLWritable
-from pyspark.ml.wrapper import JavaWrapper
-from pyspark.mllib.common import inherit_doc
+from pyspark.ml.wrapper import JavaEstimator, JavaModel
+from pyspark.mllib.common import inherit_doc, _py2java, _java2py
 
 
 @inherit_doc
-class Pipeline(Estimator, JavaWrapper, MLReadable, MLWritable):
+class Pipeline(JavaEstimator, MLReadable, MLWritable):
     """
     A simple pipeline, which acts as an estimator. A Pipeline consists
     of a sequence of stages, each of which is either an
@@ -42,6 +42,49 @@ class Pipeline(Estimator, JavaWrapper, MLReadable, MLWritable):
     pipeline stages. If there are no stages, the pipeline acts as an
     identity transformer.
 
+    >>> from pyspark.ml.feature import HashingTF
+    >>> from pyspark.ml.feature import PCA
+    >>> df = sqlContext.createDataFrame([(["a", "b", "c"],), (["c", "d", "e"],)], ["words"])
+    >>> hashingTF = HashingTF(numFeatures=10, inputCol="words", outputCol="features")
+    >>> pca = PCA(k=2, inputCol="features", outputCol="pca_features")
+    >>> pl = Pipeline(stages=[hashingTF, pca])
+    >>> model = pl.fit(df)
+    >>> transformed = model.transform(df)
+    >>> transformed.head().words == ["a", "b", "c"]
+    True
+    >>> transformed.head().features
+    SparseVector(10, {7: 1.0, 8: 1.0, 9: 1.0})
+    >>> transformed.head().pca_features
+    DenseVector([1.0, 0.5774])
+    >>> import tempfile
+    >>> path = tempfile.mkdtemp()
+    >>> featurePath = path + "/feature-transformer"
+    >>> pl.save(featurePath)
+    >>> loadedPipeline = Pipeline.load(featurePath)
+    >>> loadedPipeline.uid == pl.uid
+    True
+    >>> len(loadedPipeline.getStages())
+    2
+    >>> [loadedHT, loadedPCA] = loadedPipeline.getStages()
+    >>> type(loadedHT)
+    <class 'pyspark.ml.feature.HashingTF'>
+    >>> type(loadedPCA)
+    <class 'pyspark.ml.feature.PCA'>
+    >>> loadedHT.uid == hashingTF.uid
+    True
+    >>> param = loadedHT.getParam("numFeatures")
+    >>> loadedHT.getOrDefault(param) == hashingTF.getOrDefault(param)
+    True
+    >>> loadedPCA.uid == pca.uid
+    True
+    >>> loadedPCA.getK() == pca.getK()
+    True
+    >>> from shutil import rmtree
+    >>> try:
+    ...     rmtree(path)
+    ... except OSError:
+    ...     pass
+
     .. versionadded:: 1.3.0
     """
 
@@ -52,11 +95,22 @@ class Pipeline(Estimator, JavaWrapper, MLReadable, MLWritable):
         """
         __init__(self, stages=None)
         """
-        if stages is None:
-            stages = []
         super(Pipeline, self).__init__()
+        self._java_obj = self._new_java_obj("org.apache.spark.ml.Pipeline", self.uid)
         kwargs = self.__init__._input_kwargs
         self.setParams(**kwargs)
+
+    @keyword_only
+    @since("1.3.0")
+    def setParams(self, stages=None):
+        """
+        setParams(self, stages=None)
+        Sets params for Pipeline.
+        """
+        if stages is None:
+            stages = []
+        kwargs = self.setParams._input_kwargs
+        return self._set(**kwargs)
 
     @since("1.3.0")
     def setStages(self, value):
@@ -77,84 +131,107 @@ class Pipeline(Estimator, JavaWrapper, MLReadable, MLWritable):
         if self.stages in self._paramMap:
             return self._paramMap[self.stages]
 
-    @keyword_only
-    @since("1.3.0")
-    def setParams(self, stages=None):
+    def _transfer_stages_to_java(self):
         """
-        setParams(self, stages=None)
-        Sets params for Pipeline.
+        Transforms the parameter stages to a list of Java stages.
         """
-        if stages is None:
-            stages = []
-        kwargs = self.setParams._input_kwargs
-        return self._set(**kwargs)
 
-    def _fit(self, dataset):
-        stages = self.getStages()
-        for stage in stages:
-            if not (isinstance(stage, Estimator) or isinstance(stage, Transformer)):
-                raise TypeError(
-                    "Cannot recognize a pipeline stage of type %s." % type(stage))
-        indexOfLastEstimator = -1
-        for i, stage in enumerate(stages):
-            if isinstance(stage, Estimator):
-                indexOfLastEstimator = i
-        transformers = []
-        for i, stage in enumerate(stages):
-            if i <= indexOfLastEstimator:
-                if isinstance(stage, Transformer):
-                    transformers.append(stage)
-                    dataset = stage.transform(dataset)
-                else:  # must be an Estimator
-                    model = stage.fit(dataset)
-                    transformers.append(model)
-                    if i < indexOfLastEstimator:
-                        dataset = model.transform(dataset)
-            else:
-                transformers.append(stage)
-        return PipelineModel(transformers)
+        def __transfer_stage_to_java(stage):
+            stage._transfer_params_to_java()
+            return stage._java_obj
 
-    @since("1.4.0")
-    def copy(self, extra=None):
-        """
-        Creates a copy of this instance.
+        return [__transfer_stage_to_java(stage) for stage in self.getStages()]
 
-        :param extra: extra parameters
-        :returns: new instance
+    def _transfer_params_to_java(self):
         """
-        if extra is None:
-            extra = dict()
-        that = Params.copy(self, extra)
-        stages = [stage.copy(extra) for stage in that.getStages()]
-        return that.setStages(stages)
+        Transforms the parameter stages to Java stages.
+        """
+        paramMap = self.extractParamMap()
+        assert self.stages in paramMap
+        param = self.stages
+        value = paramMap[param]
+
+        sc = SparkContext._active_spark_context
+        param = self._resolveParam(param)
+        java_param = self._java_obj.getParam(param.name)
+        gateway = SparkContext._gateway
+        jvm = SparkContext._jvm
+        stageArray = gateway.new_array(jvm.org.apache.spark.ml.PipelineStage, len(value))
+
+        for idx, java_stage in enumerate(self._transfer_stages_to_java()):
+            stageArray[idx] = java_stage
+
+        java_value = _py2java(sc, stageArray)
+        self._java_obj.set(java_param.w(java_value))
+
+    @staticmethod
+    def __get_class(clazz):
+        """
+        Loads class from its name.
+        """
+        parts = clazz.split('.')
+        module = ".".join(parts[:-1])
+        m = __import__( module )
+        for comp in parts[1:]:
+            m = getattr(m, comp)
+        return m
+
+    def _transfer_stages_from_java(self, java_sc, java_stages):
+        """
+        Transforms the parameter stages from a list of Java stages.
+        """
+
+        def __transfer_stage_from_java(java_stage):
+            stage_name = java_stage.getClass().getName().replace("org.apache.spark", "pyspark")
+            py_stage = self.__get_class(stage_name)()
+            py_stage._java_obj = java_stage
+            py_stage._resetUid(_java2py(java_sc, java_stage.uid()))
+            py_stage._transfer_params_from_java()
+            return py_stage
+
+        return [__transfer_stage_from_java(stage) for stage in java_stages]
+
+    def _transfer_params_from_java(self):
+        """
+        Transforms the embedded params from the companion Java object.
+        """
+        sc = SparkContext._active_spark_context
+        assert self._java_obj.hasParam(self.stages.name)
+        java_param = self._java_obj.getParam(self.stages.name)
+        if self._java_obj.isDefined(java_param):
+            java_stages = _java2py(sc, self._java_obj.getOrDefault(java_param))
+            self._paramMap[self.stages] = self._transfer_stages_from_java(sc, java_stages)
+        else:
+            self._paramMap[self.stages] = []
+
+    def _create_model(self, java_model):
+        return PipelineModel(java_model)
 
 
 @inherit_doc
-class PipelineModel(Model, JavaWrapper, MLReadable, MLWritable):
+class PipelineModel(JavaModel, MLReadable, MLWritable):
     """
     Represents a compiled pipeline with transformers and fitted models.
 
     .. versionadded:: 1.3.0
     """
 
-    def __init__(self, stages):
-        super(PipelineModel, self).__init__()
-        self.stages = stages
 
-    def _transform(self, dataset):
-        for t in self.stages:
-            dataset = t.transform(dataset)
-        return dataset
-
-    @since("1.4.0")
-    def copy(self, extra=None):
-        """
-        Creates a copy of this instance.
-
-        :param extra: extra parameters
-        :returns: new instance
-        """
-        if extra is None:
-            extra = dict()
-        stages = [stage.copy(extra) for stage in self.stages]
-        return PipelineModel(stages)
+if __name__ == "__main__":
+    import doctest
+    import pyspark.ml
+    import pyspark.ml.feature
+    from pyspark.sql import SQLContext
+    globs = pyspark.ml.__dict__.copy()
+    globs_feature = pyspark.ml.feature.__dict__.copy()
+    globs.update(globs_feature)
+    # The small batch size here ensures that we see multiple batches,
+    # even in these small test examples:
+    sc = SparkContext("local[2]", "ml.pipeline tests")
+    sqlContext = SQLContext(sc)
+    globs['sc'] = sc
+    globs['sqlContext'] = sqlContext
+    (failure_count, test_count) = doctest.testmod(globs=globs, optionflags=doctest.ELLIPSIS)
+    sc.stop()
+    if failure_count:
+        exit(-1)

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -37,7 +37,7 @@ else:
 from shutil import rmtree
 import tempfile
 
-from pyspark.ml import Estimator, Model, Pipeline, Transformer
+from pyspark.ml import Estimator, Model, Pipeline, PipelineModel, Transformer
 from pyspark.ml.classification import LogisticRegression
 from pyspark.ml.clustering import KMeans
 from pyspark.ml.evaluation import RegressionEvaluator
@@ -144,6 +144,25 @@ class PipelineTests(PySparkTestCase):
         self.assertEqual(4, model2.dataset_index)
         self.assertEqual(5, transformer3.dataset_index)
         self.assertEqual(6, dataset.index)
+
+        # Test pipeline save/load
+        path = tempfile.mkdtemp()
+        pipeline_path = path + "/pipeline"
+        pipeline.save(pipeline_path)
+        loaded_pipeline = Pipeline.load(pipeline_path)
+        self.assertEqual(pipeline.getStages().size, loaded_pipeline.getStages().size)
+        for p, loaded_p in zip(pipeline.getStages(), loaded_pipeline.getStages()):
+            self.assertEqual(type(p), type(loaded_p))
+            self.assertEqual(p.dataset_index, loaded_p.dataset_index)
+            self.assertEqual(p.getFake(), loaded_p.getFake)
+        model_path = path + "/model"
+        pipeline_model.save(model_path)
+        loaded_model = PipelineModel.load(model_path)
+        self.assertEqual(pipeline_model.stages.size, loaded_pipeline.stages.size)
+        for p, loaded_p in zip(pipeline_model.stages, loaded_model.stages):
+            self.assertEqual(type(p), type(loaded_p))
+            self.assertEqual(p.dataset_index, loaded_p.dataset_index)
+            self.assertEqual(p.getFake(), loaded_p.getFake)
 
 
 class TestParams(HasMaxIter, HasInputCol, HasSeed):

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -161,6 +161,8 @@ class JavaMLReader(object):
         the Python full class name.
         """
         java_package = clazz.__module__.replace("pyspark", "org.apache.spark")
+        if clazz.__name__ == "Pipeline":
+            java_package = "org.apache.spark.ml"
         return ".".join([java_package, clazz.__name__])
 
     @classmethod

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -161,8 +161,9 @@ class JavaMLReader(object):
         the Python full class name.
         """
         java_package = clazz.__module__.replace("pyspark", "org.apache.spark")
-        if clazz.__name__ == "Pipeline":
-            java_package = "org.apache.spark.ml"
+        if clazz.__name__ == "Pipeline" or "PipelineModel":
+            # Remove the last package name "pipeline" for Pipeline and PipelineModel.
+            java_package = ".".join(java_package.split(".")[0:-1])
         return ".".join([java_package, clazz.__name__])
 
     @classmethod

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -161,7 +161,7 @@ class JavaMLReader(object):
         the Python full class name.
         """
         java_package = clazz.__module__.replace("pyspark", "org.apache.spark")
-        if clazz.__name__ == "Pipeline" or "PipelineModel":
+        if clazz.__name__ in ("Pipeline", "PipelineModel"):
             # Remove the last package name "pipeline" for Pipeline and PipelineModel.
             java_package = ".".join(java_package.split(".")[0:-1])
         return ".".join([java_package, clazz.__name__])

--- a/python/pyspark/ml/wrapper.py
+++ b/python/pyspark/ml/wrapper.py
@@ -19,8 +19,8 @@ from abc import ABCMeta, abstractmethod
 
 from pyspark import SparkContext
 from pyspark.sql import DataFrame
+from pyspark.ml.base import Estimator, Transformer, Model
 from pyspark.ml.param import Params
-from pyspark.ml.pipeline import Estimator, Transformer, Model
 from pyspark.ml.util import _jvm
 from pyspark.mllib.common import inherit_doc, _java2py, _py2java
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

JIRA issues:
- https://issues.apache.org/jira/browse/SPARK-13038
- https://issues.apache.org/jira/browse/SPARK-13388
## How was the patch tested?

The patch is tested with Python doctest. I remove the original unit test for Pipeline and PipelineModel since the `MockEstimator` and `MockTransformer` are not suitable to use in Pipeline now because they have no Java Object.
