### PR TITLE
[SPARK-13399][STREAMING] Fix checkpointsuite type erasure warnings

### DIFF
--- a/streaming/src/test/scala/org/apache/spark/streaming/CheckpointSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/CheckpointSuite.scala
@@ -138,7 +138,7 @@ trait DStreamCheckpointTester { self: SparkFunSuite =>
    */
   protected def getTestOutputStream[V: ClassTag](streams: Array[DStream[_]]):
     TestOutputStreamWithPartitions[V] = {
-    streams.collect{
+    streams.collect {
       case ds: TestOutputStreamWithPartitions[V @unchecked] => ds
     }.head
   }

--- a/streaming/src/test/scala/org/apache/spark/streaming/CheckpointSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/CheckpointSuite.scala
@@ -914,7 +914,7 @@ private object CheckpointSuite extends Serializable {
   var batchThreeShouldBlockIndefinitely: Boolean = true
 
   /**
-   * Get the first TestOutputStreamWithPartitions.
+   * Get the first TestOutputStreamWithPartitions, does not check the provided generic type.
    */
   def getTestOutputStream[V: ClassTag](streams: Array[DStream[_]]): TestOutputStreamWithPartitions[V] = {
     streams.collect{

--- a/streaming/src/test/scala/org/apache/spark/streaming/CheckpointSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/CheckpointSuite.scala
@@ -21,7 +21,7 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream, File, ObjectOutputS
 import java.util.concurrent.ConcurrentLinkedQueue
 
 import scala.collection.JavaConverters._
-import scala.reflect.{classTag, ClassTag}
+import scala.reflect.ClassTag
 
 import com.google.common.base.Charsets
 import com.google.common.io.Files
@@ -150,7 +150,7 @@ trait DStreamCheckpointTester { self: SparkFunSuite =>
       clock.setTime(targetBatchTime.milliseconds)
       logInfo("Manual clock after advancing = " + clock.getTimeMillis())
 
-      val outputStream = CheckpointSuite.getTypedStream[V](ssc.graph.getOutputStreams())
+      val outputStream = CheckpointSuite.getTestOutputStream[V](ssc.graph.getOutputStreams())
 
       eventually(timeout(10 seconds)) {
         ssc.awaitTerminationOrTimeout(10)
@@ -905,7 +905,7 @@ class CheckpointSuite extends TestSuiteBase with DStreamCheckpointTester
     logInfo("Manual clock after advancing = " + clock.getTimeMillis())
     Thread.sleep(batchDuration.milliseconds)
 
-    val outputStream = CheckpointSuite.getTypedStream[V](ssc.graph.getOutputStreams())
+    val outputStream = CheckpointSuite.getTestOutputStream[V](ssc.graph.getOutputStreams())
     outputStream.output.asScala.map(_.flatten)
   }
 }
@@ -914,11 +914,11 @@ private object CheckpointSuite extends Serializable {
   var batchThreeShouldBlockIndefinitely: Boolean = true
 
   /**
-   * Get the first output stream containing the provided type.
+   * Get the first TestOutputStreamWithPartitions.
    */
-  def getTypedStream[V: ClassTag](streams: Array[DStream[_]]): TestOutputStreamWithPartitions[V] = {
+  def getTestOutputStream[V: ClassTag](streams: Array[DStream[_]]): TestOutputStreamWithPartitions[V] = {
     streams.collect{
-      case ds: TestOutputStreamWithPartitions[V @unchecked] if ds.ct == classTag[V] => ds
+      case ds: TestOutputStreamWithPartitions[V @unchecked] => ds
     }.head
   }
 }

--- a/streaming/src/test/scala/org/apache/spark/streaming/TestSuiteBase.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/TestSuiteBase.scala
@@ -22,7 +22,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 
 import scala.collection.JavaConverters._
 import scala.language.implicitConversions
-import scala.reflect.{classTag, ClassTag}
+import scala.reflect.ClassTag
 
 import org.scalatest.BeforeAndAfter
 import org.scalatest.concurrent.Eventually.timeout
@@ -130,8 +130,6 @@ class TestOutputStreamWithPartitions[T: ClassTag](
     ois.defaultReadObject()
     output.clear()
   }
-
-  val ct = classTag[T]
 }
 
 /**

--- a/streaming/src/test/scala/org/apache/spark/streaming/TestSuiteBase.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/TestSuiteBase.scala
@@ -22,7 +22,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 
 import scala.collection.JavaConverters._
 import scala.language.implicitConversions
-import scala.reflect.ClassTag
+import scala.reflect.{classTag, ClassTag}
 
 import org.scalatest.BeforeAndAfter
 import org.scalatest.concurrent.Eventually.timeout
@@ -130,6 +130,8 @@ class TestOutputStreamWithPartitions[T: ClassTag](
     ois.defaultReadObject()
     output.clear()
   }
+
+  val ct = classTag[T]
 }
 
 /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change the checkpointsuite getting the outputstreams to explicitly be unchecked on the generic type so as to avoid the warnings. This only impacts test code.

Alternatively we could encode the type tag in the TestOutputStreamWithPartitions and filter the type tag as well - but this is unnecessary since multiple testoutputstreams are not registered and the previous code was not actually checking this type.
## How was the this patch tested?

unit tests (streaming/testOnly org.apache.spark.streaming.CheckpointSuite)
