### PR TITLE
[SPARK-13428] [SQL] Pushing Down Aggregate Expressions in Sort into Aggregate

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -607,14 +607,21 @@ class Analyzer(
     def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
       // Skip sort with aggregate. This will be handled in ResolveAggregateFunctions
       case sa @ Sort(_, _, child: Aggregate) => sa
-
+      case sa @ Sort(_, _, _)
+        if sa.order.exists(so => ResolveAggregateFunctions.containsAggregate(so.child)) => sa
       case s @ Sort(order, _, child) if !s.resolved && child.resolved =>
         try {
           val newOrder = order.map(resolveExpressionRecursively(_, child).asInstanceOf[SortOrder])
           val requiredAttrs = AttributeSet(newOrder).filter(_.resolved)
           val missingAttrs = requiredAttrs -- child.outputSet
-          if (missingAttrs.nonEmpty) {
-            // Add missing attributes and then project them away after the sort.
+          // resolve the unresolved functions for knowing if they are aggregate functions
+          val evaluatedSort =
+            ResolveFunctions.resolveFunctions(Sort(newOrder, s.global, child)).asInstanceOf[Sort]
+          if (evaluatedSort.order.exists(so =>
+              ResolveAggregateFunctions.containsAggregate(so.child))) {
+            // Skip sort with aggregate. This will be handled in ResolveAggregateFunctions
+            s.copy(order = evaluatedSort.order)
+          } else if (missingAttrs.nonEmpty) {
             Project(child.output,
               Sort(newOrder, s.global, addMissingAttr(child, missingAttrs)))
           } else if (newOrder != order) {
@@ -634,7 +641,7 @@ class Analyzer(
       * Add the missing attributes into projectList of Project/Window or aggregateExpressions of
       * Aggregate.
       */
-    private def addMissingAttr(plan: LogicalPlan, missingAttrs: AttributeSet): LogicalPlan = {
+    def addMissingAttr(plan: LogicalPlan, missingAttrs: AttributeSet): LogicalPlan = {
       if (missingAttrs.isEmpty) {
         return plan
       }
@@ -647,10 +654,12 @@ class Analyzer(
           w.copy(projectList = w.projectList ++ missingAttrs,
             child = addMissingAttr(w.child, missing))
         case a: Aggregate =>
-          // all the missing attributes should be grouping expressions
-          // TODO: push down AggregateExpression
+          // Case 1: the added missing attribute could be an alias of the existing
+          // expression in a.aggregateExpressions
+          // Case 2: the missing attribute must be from grouping expressions
           missingAttrs.foreach { attr =>
-            if (!a.groupingExpressions.exists(_.semanticEquals(attr))) {
+            if (!a.aggregateExpressions.exists(_.toAttribute.semanticEquals(attr)) &&
+              (!a.groupingExpressions.exists(_.semanticEquals(attr)))) {
               throw new AnalysisException(s"Can't add $attr to ${a.simpleString}")
             }
           }
@@ -691,28 +700,31 @@ class Analyzer(
    */
   object ResolveFunctions extends Rule[LogicalPlan] {
     def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
-      case q: LogicalPlan =>
-        q transformExpressions {
-          case u if !u.childrenResolved => u // Skip until children are resolved.
-          case u @ UnresolvedFunction(name, children, isDistinct) =>
-            withPosition(u) {
-              registry.lookupFunction(name, children) match {
-                // DISTINCT is not meaningful for a Max or a Min.
-                case max: Max if isDistinct =>
-                  AggregateExpression(max, Complete, isDistinct = false)
-                case min: Min if isDistinct =>
-                  AggregateExpression(min, Complete, isDistinct = false)
-                // AggregateWindowFunctions are AggregateFunctions that can only be evaluated within
-                // the context of a Window clause. They do not need to be wrapped in an
-                // AggregateExpression.
-                case wf: AggregateWindowFunction => wf
-                // We get an aggregate function, we need to wrap it in an AggregateExpression.
-                case agg: AggregateFunction => AggregateExpression(agg, Complete, isDistinct)
-                // This function is not an aggregate function, just return the resolved one.
-                case other => other
-              }
+      case q: LogicalPlan => resolveFunctions(q)
+    }
+
+    def resolveFunctions(plan: LogicalPlan): LogicalPlan = {
+      plan transformExpressions {
+        case u if !u.childrenResolved => u // Skip until children are resolved.
+        case u@UnresolvedFunction(name, children, isDistinct) =>
+          withPosition(u) {
+            registry.lookupFunction(name, children) match {
+              // DISTINCT is not meaningful for a Max or a Min.
+              case max: Max if isDistinct =>
+                AggregateExpression(max, Complete, isDistinct = false)
+              case min: Min if isDistinct =>
+                AggregateExpression(min, Complete, isDistinct = false)
+              // AggregateWindowFunctions are AggregateFunctions that can only be evaluated within
+              // the context of a Window clause. They do not need to be wrapped in an
+              // AggregateExpression.
+              case wf: AggregateWindowFunction => wf
+              // We get an aggregate function, we need to wrap it in an AggregateExpression.
+              case agg: AggregateFunction => AggregateExpression(agg, Complete, isDistinct)
+              // This function is not an aggregate function, just return the resolved one.
+              case other => other
             }
-        }
+          }
+      }
     }
   }
 
@@ -775,10 +787,19 @@ class Analyzer(
           filter
         }
 
-      case sort @ Sort(sortOrder, global, aggregate: Aggregate) if aggregate.resolved =>
+      case sort @ Sort(sortOrder, global, _)
+          if sort.child.resolved &&
+            (sort.order.exists(containsAggregate) || sort.child.isInstanceOf[Aggregate]) =>
+        val firstAggregate = sort.child.find(_.isInstanceOf[Aggregate])
 
+        if (firstAggregate.isEmpty) {
+          // If no Aggregate exists, we are unable to push down aggregate expressions.
+          // And thus, return the unresolved sort
+          return sort
+        }
         // Try resolving the ordering as though it is in the aggregate clause.
         try {
+          val aggregate = firstAggregate.asInstanceOf[Option[Aggregate]].get
           val unresolvedSortOrders = sortOrder.filter(s => !s.resolved || containsAggregate(s))
           val aliasedOrdering =
             unresolvedSortOrders.map(o => Alias(o.child, "aggOrder")(isGenerated = true))
@@ -825,9 +846,21 @@ class Analyzer(
           if (sortOrder == finalSortOrders) {
             sort
           } else {
-            Project(aggregate.output,
-              Sort(finalSortOrders, global,
-                aggregate.copy(aggregateExpressions = originalAggExprs ++ needsPushDown)))
+            // Add the aggregation functions into the Aggregate operator
+            val newChild = sort.child transform {
+              case a: Aggregate if a == aggregate =>
+                aggregate.copy(aggregateExpressions = originalAggExprs ++ needsPushDown)
+            }
+            if ((AttributeSet(finalSortOrders) -- newChild.outputSet).isEmpty) {
+              Project(sort.child.output,
+                Sort(finalSortOrders, global, newChild))
+            } else {
+              // Add the needsPushDown to the operators between Sort and Aggregator
+              val finalChild = ResolveSortReferences.addMissingAttr(newChild,
+                AttributeSet(needsPushDown.map(_.toAttribute)))
+              Project(sort.child.output,
+                Sort(finalSortOrders, global, finalChild))
+            }
           }
         } catch {
           // Attempting to resolve in the aggregate can result in ambiguity.  When this happens,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicOperators.scala
@@ -372,6 +372,8 @@ case class Sort(
     child: LogicalPlan) extends UnaryNode {
   override def output: Seq[Attribute] = child.output
   override def maxRows: Option[Long] = child.maxRows
+  override lazy val resolved: Boolean =
+    expressions.forall(_.resolved) && childrenResolved && missingInput.isEmpty
 }
 
 /** Factory for constructing new `Range` nodes. */

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -1021,8 +1021,7 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
       ).map(i => Row(i._1, i._2)))
   }
 
-  // todo: fix this test case by reimplementing the function ResolveAggregateFunctions
-  ignore("window function: Pushing aggregate Expressions in Sort to Aggregate") {
+  test("window function: Pushing aggregate Expressions in Sort to Aggregate") {
     val data = Seq(
       WindowData(1, "d", 10),
       WindowData(2, "a", 6),
@@ -1038,7 +1037,7 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
         """
           |select area, sum(product) over () as c from windowData
           |where product > 3 group by area, product
-          |having avg(month) > 0 order by avg(month), product
+          |having avg(month) > 0 order by area, avg(month), product
         """.stripMargin),
       Seq(
         ("a", 51),


### PR DESCRIPTION
#### What changes were proposed in this pull request?

When there exists the other operators between Sort and Aggregate, we are unable to push down the aggregate functions in `Sort` into `Aggregate`. For example, in the following query, 

``` SQL
select area, sum(product) over () as c from windowData
where product > 3 group by area, product
having avg(month) > 0 order by area, avg(month), product
```

The parsed logical plan is like

```
'Sort ['area ASC,'avg('month) ASC,'product ASC], true
+- 'Filter cast(('avg('month) > 0) as boolean)
   +- 'Aggregate ['area,'product], [unresolvedalias('area,None),unresolvedalias('sum('product) windowspecdefinition(UnspecifiedFrame) AS c#3,None)]
      +- 'Filter ('product > 3)
         +- 'UnresolvedRelation `windowData`, None
```

After having this PR, the query can be resolved and create an alias `aggOrder#12` for the aggregated function and added into `Aggregate` and all the nodes between `Sort` and `Aggregate`. The generated analyzed plan is like:

```
Project [area#1,c#3L]
+- Project [area#1,c#3L,aggOrder#12]
   +- Sort [area#1 ASC,aggOrder#12 ASC,product#2 ASC], true
      +- Project [area#1,c#3L,aggOrder#12,product#2]
         +- Project [area#1,product#2,c#3L,c#3L,aggOrder#12]
            +- Window [area#1,product#2,aggOrder#12], [(sum(cast(product#2 as bigint)),mode=Complete,isDistinct=false) windowspecdefinition(ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS c#3L]
               +- Project [area#1,product#2,aggOrder#12]
                  +- Filter havingCondition#10: boolean
                     +- Aggregate [area#1,product#2], [cast(((avg(cast(month#0 as bigint)),mode=Complete,isDistinct=false) > cast(0 as double)) as boolean) AS havingCondition#10,area#1,product#2,(avg(cast(month#0 as bigint)),mode=Complete,isDistinct=false) AS aggOrder#12]
                        +- Filter (product#2 > 3)
                           +- Subquery windowdata
                              +- LogicalRDD [month#0,area#1,product#2], MapPartitionsRDD[1] at apply at Transformer.scala:22
```
#### How was the this patch tested?

Turn on a test case that `test("window function: Pushing aggregate Expressions in Sort to Aggregate")` exposes this issue.
