### PR TITLE
[SPARK-12941][SQL][MASTER] Spark-SQL JDBC Oracle dialect fails to map string datatypes to Oracle VARCHAR datatype

### DIFF
--- a/docker-integration-tests/pom.xml
+++ b/docker-integration-tests/pom.xml
@@ -131,12 +131,14 @@
       <artifactId>postgresql</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.oracle</groupId>
-      <artifactId>ojdbc6</artifactId>
-      <version>11.2.0.2.0</version>
-      <scope>test</scope>
-    </dependency>
+    <!--
+      <dependency>
+        <groupId>com.oracle</groupId>
+        <artifactId>ojdbc6</artifactId>
+        <version>11.2.0.2.0</version>
+        <scope>test</scope>
+      </dependency>
+    -->
     <!-- Jersey dependencies, used to override version.
      See https://github.com/apache/spark/pull/9503#issuecomment-154369560 for
      background on why we need to use a newer Jersey only in this test module;

--- a/docker-integration-tests/pom.xml
+++ b/docker-integration-tests/pom.xml
@@ -131,6 +131,11 @@
       <artifactId>postgresql</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- Oracle ojdbc jar, used for oracle  integration suite for docker testing.
+     See https://github.com/apache/spark/pull/11306 for background on why we need
+     to use a an ojdbc jar for the testcase. The maven dependency here is commented
+     because currently the maven repository does not contain the ojdbc jar mentioned.
+     Once the jar is available in maven, this could be uncommented. -->
     <!--
       <dependency>
         <groupId>com.oracle</groupId>

--- a/docker-integration-tests/pom.xml
+++ b/docker-integration-tests/pom.xml
@@ -131,6 +131,12 @@
       <artifactId>postgresql</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.oracle</groupId>
+      <artifactId>ojdbc6</artifactId>
+      <version>11.2.0.2.0</version>
+      <scope>test</scope>
+    </dependency>
     <!-- Jersey dependencies, used to override version.
      See https://github.com/apache/spark/pull/9503#issuecomment-154369560 for
      background on why we need to use a newer Jersey only in this test module;

--- a/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
+++ b/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
@@ -112,7 +112,7 @@ abstract class DockerJDBCIntegrationSuite
       // Start the container and wait until the database can accept JDBC connections:
       docker.startContainer(containerId)
       jdbcUrl = db.getJdbcUrl(dockerIp, externalPort)
-      eventually(timeout(200.seconds), interval(200.seconds)) {
+      eventually(timeout(60.seconds), interval(1.seconds)) {
         val conn = java.sql.DriverManager.getConnection(jdbcUrl)
         conn.close()
       }

--- a/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
+++ b/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
@@ -112,7 +112,7 @@ abstract class DockerJDBCIntegrationSuite
       // Start the container and wait until the database can accept JDBC connections:
       docker.startContainer(containerId)
       jdbcUrl = db.getJdbcUrl(dockerIp, externalPort)
-      eventually(timeout(60.seconds), interval(1.seconds)) {
+      eventually(timeout(200.seconds), interval(200.seconds)) {
         val conn = java.sql.DriverManager.getConnection(jdbcUrl)
         conn.close()
       }

--- a/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
+++ b/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.tags.DockerTest
  * is already tested with the branch 1.4
  *
  * This patch was tested using the Oracle docker.Created this integration suite for the same.
- * The ojdbc6.jar was to be downloaded from the maven repository.Since there was 
+ * The ojdbc6-11.2.0.2.0.jar was to be downloaded from the maven repository.Since there was 
  * no jdbc jar available in the maven repository, the jar was downloaded from oracle site 
  * manually and installed in the local; thus tested. So, for SparkQA test case run, the
  * ojdbc jar might be manually placed in the local maven repository(com/oracle/ojdbc6/11.2.0.2.0)

--- a/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
+++ b/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
@@ -24,18 +24,14 @@ import java.util.Properties
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.DockerTest
+
 /**
- * This integration suite is created as part of Pull request(11306) and is used for the fix
- * SPARK-12941, creating a data type mapping to Oracle for the corresponding data type
- * "Stringtype" from dataframe. This PR is for the master branch fix, where as another PR
- * is already tested with the branch 1.4
- *
- * This patch was tested using the Oracle docker.Created this integration suite for the same.
- * The ojdbc6-11.2.0.2.0.jar was to be downloaded from the maven repository.Since there was
+ * This patch was tested using the Oracle docker. Created this integration suite for the same.
+ * The ojdbc6-11.2.0.2.0.jar was to be downloaded from the maven repository. Since there was
  * no jdbc jar available in the maven repository, the jar was downloaded from oracle site
  * manually and installed in the local; thus tested. So, for SparkQA test case run, the
  * ojdbc jar might be manually placed in the local maven repository(com/oracle/ojdbc6/11.2.0.2.0)
- * while Spark QA test run
+ * while Spark QA test run.
  *
  * The following would be the steps to test this
  * 1. Pull oracle 11g image - docker pull wnameless/oracle-xe-11g
@@ -44,6 +40,8 @@ import org.apache.spark.tags.DockerTest
  *    (com/oracle/ojdbc6/11.2.0.2.0/ojdbc6-11.2.0.2.0.jar)
  * 4. Run spark test - ./build/sbt "test-only org.apache.spark.sql.jdbc.OracleIntegrationSuite"
  *
+ * All tests in this suite are ignored because of the dependency with the oracle jar from maven
+ * repository.
  */
 @DockerTest
 class OracleIntegrationSuite extends DockerJDBCIntegrationSuite with SharedSQLContext {
@@ -62,13 +60,6 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationSuite with SharedSQLCo
   override def dataPreparation(conn: Connection): Unit = {
   }
 
-  /**
-   * For SparkQA test case run, the ojdbc6-11.2.0.2.0.jar would be required to be manually
-   * placed in the local maven repository(com/oracle/ojdbc6/11.2.0.2.0) while Spark QA test
-   * run.Because, the maven repository for oracle mentioned in the pom file
-   * (commented already) does not contain the ojdbc jar.So, this test case is ignored for
-   * the temporary purpose.This testcase has been tested locally and verified.
-   */
   ignore("SPARK-12941: String datatypes to be mapped to Varchar in Oracle") {
     // create a sample dataframe with string type
     val df1 = sparkContext.parallelize(Seq(("foo"))).toDF("x")

--- a/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
+++ b/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
@@ -21,8 +21,8 @@ import java.math.BigDecimal
 import java.sql.{Connection, Date, Timestamp}
 import java.util.Properties
 
-import org.apache.spark.sql.types._
 import org.apache.spark.sql.test.SharedSQLContext
+import org.apache.spark.sql.types._
 import org.apache.spark.tags.DockerTest
 
 @DockerTest

--- a/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
+++ b/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
@@ -38,7 +38,9 @@ import org.apache.spark.tags.DockerTest
  * 2. Start docker - sudo service docker start
  * 3. Download oracle 11g driver jar and put it in maven local repo:
  *    (com/oracle/ojdbc6/11.2.0.2.0/ojdbc6-11.2.0.2.0.jar)
- * 4. Run spark test - ./build/sbt "test-only org.apache.spark.sql.jdbc.OracleIntegrationSuite"
+ * 4. The timeout and interval parameter to be increased from 60,1 to a high value for oracle test
+ *    in DockerJDBCIntegrationSuite.scala (Locally tested with 200,200 and executed successfully).
+ * 5. Run spark test - ./build/sbt "test-only org.apache.spark.sql.jdbc.OracleIntegrationSuite"
  *
  * All tests in this suite are ignored because of the dependency with the oracle jar from maven
  * repository.

--- a/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
+++ b/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
@@ -25,7 +25,6 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.tags.DockerTest
 
-
 @DockerTest
 class OracleIntegrationSuite extends DockerJDBCIntegrationSuite with SharedSQLContext {
   import testImplicits._

--- a/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
+++ b/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
@@ -25,22 +25,22 @@ import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.DockerTest
 /**
- * This integration suite is created as part of Pull request(11306) and is used for the fix 
+ * This integration suite is created as part of Pull request(11306) and is used for the fix
  * SPARK-12941, creating a data type mapping to Oracle for the corresponding data type
- * "Stringtype" from dataframe. This PR is for the master branch fix, where as another PR 
+ * "Stringtype" from dataframe. This PR is for the master branch fix, where as another PR
  * is already tested with the branch 1.4
  *
  * This patch was tested using the Oracle docker.Created this integration suite for the same.
- * The ojdbc6-11.2.0.2.0.jar was to be downloaded from the maven repository.Since there was 
- * no jdbc jar available in the maven repository, the jar was downloaded from oracle site 
+ * The ojdbc6-11.2.0.2.0.jar was to be downloaded from the maven repository.Since there was
+ * no jdbc jar available in the maven repository, the jar was downloaded from oracle site
  * manually and installed in the local; thus tested. So, for SparkQA test case run, the
  * ojdbc jar might be manually placed in the local maven repository(com/oracle/ojdbc6/11.2.0.2.0)
  * while Spark QA test run
- * 
+ *
  * The following would be the steps to test this
  * 1. Pull oracle 11g image - docker pull wnameless/oracle-xe-11g
  * 2. Start docker - sudo service docker start
- * 3. Download oracle 11g driver jar and put it in maven local repo: 
+ * 3. Download oracle 11g driver jar and put it in maven local repo:
  *    (com/oracle/ojdbc6/11.2.0.2.0/ojdbc6-11.2.0.2.0.jar)
  * 4. Run spark test - ./build/sbt "test-only org.apache.spark.sql.jdbc.OracleIntegrationSuite"
  *
@@ -61,7 +61,7 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationSuite with SharedSQLCo
 
   override def dataPreparation(conn: Connection): Unit = {
   }
-  
+
   /**
    * For SparkQA test case run, the ojdbc6-11.2.0.2.0.jar would be required to be manually
    * placed in the local maven repository(com/oracle/ojdbc6/11.2.0.2.0) while Spark QA test

--- a/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
+++ b/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
@@ -24,7 +24,27 @@ import java.util.Properties
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.DockerTest
-
+/**
+ * This integration suite is created as part of Pull request(11306) and is used for the fix 
+ * SPARK-12941, creating a data type mapping to Oracle for the corresponding data type
+ * "Stringtype" from dataframe. This PR is for the master branch fix, where as another PR 
+ * is already tested with the branch 1.4
+ *
+ * This patch was tested using the Oracle docker.Created this integration suite for the same.
+ * The ojdbc6.jar was to be downloaded from the maven repository.Since there was 
+ * no jdbc jar available in the maven repository, the jar was downloaded from oracle site 
+ * manually and installed in the local; thus tested. So, for SparkQA test case run, the
+ * ojdbc jar might be manually placed in the local maven repository(com/oracle/ojdbc6/11.2.0.2.0)
+ * while Spark QA test run
+ * 
+ * The following would be the steps to test this
+ * 1. Pull oracle 11g image - docker pull wnameless/oracle-xe-11g
+ * 2. Start docker - sudo service docker start
+ * 3. Download oracle 11g driver jar and put it in maven local repo: 
+ *    (com/oracle/ojdbc6/11.2.0.2.0/ojdbc6-11.2.0.2.0.jar)
+ * 4. Run spark test - ./build/sbt "test-only org.apache.spark.sql.jdbc.OracleIntegrationSuite"
+ *
+ */
 @DockerTest
 class OracleIntegrationSuite extends DockerJDBCIntegrationSuite with SharedSQLContext {
   import testImplicits._
@@ -39,6 +59,16 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationSuite with SharedSQLCo
       s"jdbc:oracle:thin:system/oracle@//$ip:$port/xe"
   }
 
+  override def dataPreparation(conn: Connection): Unit = {
+  }
+  
+  /**
+   * For SparkQA test case run, the ojdbc6-11.2.0.2.0.jar would be required to be manually
+   * placed in the local maven repository(com/oracle/ojdbc6/11.2.0.2.0) while Spark QA test
+   * run.Because, the maven repository for oracle mentioned in the pom file
+   * (commented already) does not contain the ojdbc jar.So, this test case is ignored for
+   * the temporary purpose.This testcase has been tested locally and verified.
+   */
   ignore("SPARK-12941: String datatypes to be mapped to Varchar in Oracle") {
     // create a sample dataframe with string type
     val df1 = sparkContext.parallelize(Seq(("foo"))).toDF("x")

--- a/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
+++ b/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.jdbc
 import java.math.BigDecimal
 import java.sql.{Connection, Date, Timestamp}
 import java.util.Properties
+
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.tags.DockerTest
@@ -39,7 +40,7 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationSuite with SharedSQLCo
       s"jdbc:oracle:thin:system/oracle@//$ip:$port/xe"
   }
 
-  test("SPARK-12941: String datatypes to be mapped to Varchar in Oracle") {
+  ignore("SPARK-12941: String datatypes to be mapped to Varchar in Oracle") {
     // create a sample dataframe with string type
     val df1 = sparkContext.parallelize(Seq(("foo"))).toDF("x")
     // write the dataframe to the oracle table tbl

--- a/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
+++ b/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
@@ -28,8 +28,8 @@ import org.apache.spark.tags.DockerTest
 @DockerTest
 class OracleIntegrationSuite extends DockerJDBCIntegrationSuite with SharedSQLContext {
   import testImplicits._
- 
- override val db = new DatabaseOnDocker {
+
+  override val db = new DatabaseOnDocker {
     override val imageName = "wnameless/oracle-xe-11g:latest"
     override val env = Map(
       "ORACLE_ROOT_PASSWORD" -> "oracle"

--- a/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
+++ b/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.jdbc
+
+import java.math.BigDecimal
+import java.sql.{Connection, Date, Timestamp}
+import java.util.Properties
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.test.SharedSQLContext
+import org.apache.spark.tags.DockerTest
+
+
+@DockerTest
+class OracleIntegrationSuite extends DockerJDBCIntegrationSuite with SharedSQLContext {
+  import testImplicits._
+ 
+ override val db = new DatabaseOnDocker {
+    override val imageName = "wnameless/oracle-xe-11g:latest"
+    override val env = Map(
+      "ORACLE_ROOT_PASSWORD" -> "oracle"
+    )
+    override val jdbcPort: Int = 1521
+    override def getJdbcUrl(ip: String, port: Int): String =
+      s"jdbc:oracle:thin:system/oracle@//$ip:$port/xe"
+  }
+
+  test("SPARK-12941: String datatypes to be mapped to Varchar in Oracle") {
+    // create a sample dataframe with string type
+    val df1 = sparkContext.parallelize(Seq(("foo"))).toDF("x")
+    // write the dataframe to the oracle table tbl
+    df1.write.jdbc(jdbcUrl, "tbl2", new Properties)
+    // read the table from the oracle
+    val dfRead = sqlContext.read.jdbc(jdbcUrl, "tbl2", new Properties)
+    // get the rows
+    val rows = dfRead.collect()
+    // verify the data type is inserted
+    val types = rows(0).toSeq.map(x => x.getClass.toString)
+    assert(types(0).equals("class java.lang.String"))
+    // verify the value is the inserted correct or not
+    assert(rows(0).getString(0).equals("foo"))
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
@@ -42,4 +42,9 @@ private case object OracleDialect extends JdbcDialect {
       None
     }
   }
+
+  override def getJDBCType(dt: DataType): Option[JdbcType] = dt match {
+    case StringType => Some(JdbcType("VARCHAR2(255)", java.sql.Types.VARCHAR))
+    case _ => None
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This Pull request is used for the fix SPARK-12941, creating a data type mapping to Oracle for the corresponding data type"Stringtype" from dataframe. This PR is for the master branch fix, where as another PR is already tested with the branch 1.4
## How was the this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
This patch was tested using the Oracle docker .Created a new integration suite for the same.The oracle.jdbc jar was to be downloaded from the maven repository.Since there was no jdbc jar available in the maven repository, the jar was downloaded from oracle site manually and installed in the local; thus tested. So, for SparkQA test case run, the ojdbc jar might be manually placed in the local maven repository(com/oracle/ojdbc6/11.2.0.2.0) while Spark QA test run.
