### PR TITLE
[SPARK-13437][SQL] Introduce InternalColumn and MutableColumn

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/InternalColumn.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/InternalColumn.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst
+
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.types.{DataType, StructType}
+
+/**
+ * An abstract class for column used internal in Spark SQL, which only contain the rows as
+ * internal types.
+ */
+abstract class InternalColumn extends SpecializedGetters with Serializable {
+
+  def numFields: Int
+
+  // This is only use for test and will throw a null pointer exception if the position is null.
+  def getString(ordinal: Int): String = getUTF8String(ordinal).toString
+
+  /**
+   * Make a copy of the current [[InternalColumn]] object.
+   */
+  def copy(): InternalColumn
+
+  /** Returns true if there are any NULL values in this column. */
+  def anyNull: Boolean
+
+  /* ---------------------- utility methods for Scala ---------------------- */
+
+  /**
+   * Return a Scala Seq representing the column. Elements are placed in the same order in the Seq.
+   */
+  def toSeq(fieldTypes: Seq[DataType]): Seq[Any] = {
+    val len = numFields
+    assert(len == fieldTypes.length)
+
+    val values = new Array[Any](len)
+    var i = 0
+    while (i < len) {
+      values(i) = get(i, fieldTypes(i))
+      i += 1
+    }
+    values
+  }
+
+  def toSeq(schema: StructType): Seq[Any] = toSeq(schema.map(_.dataType))
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/columns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/columns.scala
@@ -17,11 +17,8 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
-//import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalColumn
-//import org.apache.spark.sql.catalyst.util.{ArrayData, MapData}
 import org.apache.spark.sql.types._
-//import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 
 /**
  * An extended interface to [[InternalColumn]] that allows the values for each row to be updated.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/columns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/columns.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+//import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.InternalColumn
+//import org.apache.spark.sql.catalyst.util.{ArrayData, MapData}
+import org.apache.spark.sql.types._
+//import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
+
+/**
+ * An extended interface to [[InternalColumn]] that allows the values for each row to be updated.
+ * Setting a value through a primitive function implicitly marks that row as not null.
+ */
+abstract class MutableColumn extends InternalColumn {
+  def setNullAt(i: Int): Unit
+
+  def update(i: Int, value: Any)
+
+  // default implementation (slow)
+  def setBoolean(i: Int, value: Boolean): Unit = { update(i, value) }
+  def setByte(i: Int, value: Byte): Unit = { update(i, value) }
+  def setShort(i: Int, value: Short): Unit = { update(i, value) }
+  def setInt(i: Int, value: Int): Unit = { update(i, value) }
+  def setLong(i: Int, value: Long): Unit = { update(i, value) }
+  def setFloat(i: Int, value: Float): Unit = { update(i, value) }
+  def setDouble(i: Int, value: Double): Unit = { update(i, value) }
+
+  /**
+   * Update the decimal column at `i`.
+   *
+   * Note: In order to support update decimal with precision > 18 in UnsafeColumn,
+   * CAN NOT call setNullAt() for decimal column on UnsafeColumn,
+   * call setDecimal(i, null, precision).
+   */
+  def setDecimal(i: Int, value: Decimal, precision: Int) { update(i, value) }
+}

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
@@ -21,6 +21,8 @@ import java.math.BigInteger;
 
 import org.apache.spark.memory.MemoryMode;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.InternalColumn;
+import org.apache.spark.sql.catalyst.expressions.MutableColumn;
 import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.MapData;
 import org.apache.spark.sql.types.*;
@@ -54,7 +56,7 @@ import org.apache.commons.lang.NotImplementedException;
  *
  * ColumnVectors are intended to be reused.
  */
-public abstract class ColumnVector {
+public abstract class ColumnVector extends MutableColumn {
   /**
    * Allocates a column to store elements of `type` on or off heap.
    * Capacity is the initial capacity of the vector and it will grow as necessary. Capacity is
@@ -308,6 +310,72 @@ public abstract class ColumnVector {
   public abstract long nullsNativeAddress();
   public abstract long valuesNativeAddress();
 
+  // At MutableColumn
+  @Override
+  public void update(int ordinal, Object value) {
+    throw new NotImplementedException();
+  }
+
+  @Override
+  public void setNullAt(int i) {
+    throw new NotImplementedException();
+  }
+
+  // At InternalColumn
+  @Override
+  public boolean anyNull() {
+    return anyNullsSet();
+  }
+
+  @Override
+  public int numFields() {
+    throw new NotImplementedException();
+  }
+
+  @Override
+  public InternalColumn copy() {
+    throw new NotImplementedException();
+  }
+
+  // At SpecializedGetters
+  @Override
+  public boolean isNullAt(int ordinal) { return getIsNull(ordinal); }
+      
+  @Override
+  public Decimal getDecimal(int ordinal, int precision, int scale) {
+    throw new NotImplementedException();
+  }
+
+  @Override
+  public UTF8String getUTF8String(int ordinal) {
+    throw new NotImplementedException();
+  }
+
+  @Override
+  public byte[] getBinary(int ordinal) {
+    throw new NotImplementedException();
+  }
+
+  @Override
+  public CalendarInterval getInterval(int ordinal) {
+    throw new NotImplementedException();
+  }
+
+  @Override
+  public InternalRow getStruct(int ordinal, int numFields) {
+    throw new NotImplementedException();
+  }
+
+  @Override
+  public MapData getMap(int ordinal) {
+    throw new NotImplementedException();
+  }
+
+  @Override
+  public Object get(int ordinal, DataType dataType) {
+    throw new NotImplementedException();
+  }
+    
   /**
    * Sets the value at rowId to null/not null.
    */


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR introduce `InternalColumn` and `MutableColumn` to abstract a columnar storage at code generation as an analogy with `InternalRow`. This would allow us to use different implementations of column storage.
For now, `ColumnarVector` extends `InternalRow` and `MutableColumn`.
## How was the this patch tested?

Succeeded to compile
