### PR TITLE
[SPARK-13438][STREAMING] Remove by default dash from filename

### DIFF
--- a/docs/streaming-programming-guide.md
+++ b/docs/streaming-programming-guide.md
@@ -1237,13 +1237,13 @@ Currently, the following output operations are defined:
 <tr>
   <td> <b>saveAsTextFiles</b>(<i>prefix</i>, [<i>suffix</i>]) </td>
   <td> Save this DStream's contents as text files. The file name at each batch interval is
-  generated based on <i>prefix</i> and <i>suffix</i>: <i>"prefix-TIME_IN_MS[.suffix]"</i>. </td>
+  generated based on <i>prefix</i> and <i>suffix</i>: <i>"<prefix>TIME_IN_MS[.suffix]"</i>. </td>
 </tr>
 <tr>
   <td> <b>saveAsObjectFiles</b>(<i>prefix</i>, [<i>suffix</i>]) </td>
   <td> Save this DStream's contents as <code>SequenceFiles</code> of serialized Java objects. The file
   name at each batch interval is generated based on <i>prefix</i> and
-  <i>suffix</i>: <i>"prefix-TIME_IN_MS[.suffix]"</i>.
+  <i>suffix</i>: <i>"<prefix>TIME_IN_MS[.suffix]"</i>.
   <br/>
   <span class="badge" style="background-color: grey">Python API</span> This is not available in
   the Python API.
@@ -1252,7 +1252,7 @@ Currently, the following output operations are defined:
 <tr>
   <td> <b>saveAsHadoopFiles</b>(<i>prefix</i>, [<i>suffix</i>]) </td>
   <td> Save this DStream's contents as Hadoop files. The file name at each batch interval is
-  generated based on <i>prefix</i> and <i>suffix</i>: <i>"prefix-TIME_IN_MS[.suffix]"</i>.
+  generated based on <i>prefix</i> and <i>suffix</i>: <i>"<prefix>TIME_IN_MS[.suffix]"</i>.
   <br>
   <span class="badge" style="background-color: grey">Python API</span> This is not available in
   the Python API.

--- a/python/pyspark/streaming/util.py
+++ b/python/pyspark/streaming/util.py
@@ -127,20 +127,20 @@ class TransformFunctionSerializer(object):
 
 def rddToFileName(prefix, suffix, timestamp):
     """
-    Return string prefix-time(.suffix)
+    Return string <prefix>time[.suffix]
 
-    >>> rddToFileName("spark", None, 12345678910)
+    >>> rddToFileName("spark-", None, 12345678910)
     'spark-12345678910'
-    >>> rddToFileName("spark", "tmp", 12345678910)
+    >>> rddToFileName("spark-", "tmp", 12345678910)
     'spark-12345678910.tmp'
     """
     if isinstance(timestamp, datetime):
         seconds = time.mktime(timestamp.timetuple())
         timestamp = int(seconds * 1000) + timestamp.microsecond // 1000
     if suffix is None:
-        return prefix + "-" + str(timestamp)
+        return prefix + str(timestamp)
     else:
-        return prefix + "-" + str(timestamp) + "." + suffix
+        return prefix + str(timestamp) + "." + suffix
 
 
 if __name__ == "__main__":

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -843,7 +843,7 @@ object StreamingContext extends Logging {
   private[streaming] def rddToFileName[T](prefix: String, suffix: String, time: Time): String = {
     var result = time.milliseconds.toString
     if (prefix != null && prefix.length > 0) {
-      result = s"$prefix-$result"
+      result = s"$prefix$result"
     }
     if (suffix != null && suffix.length > 0) {
       result = s"$result.$suffix"


### PR DESCRIPTION
Spark generates the following schema with prefix = `/data/timestamp=`

```
/data/timestamp=-1455894364000/_SUCCESS
/data/timestamp=-1455894364000/part-00000
```

The above behaviour forces our hands when we would like to write to a schema with partitions.

This change removes the by default dash from the schema.
