### PR TITLE
[SPARK-11691][SQL] Support setting hadoop compression codecs in DataFrameWriter#option

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -60,6 +60,51 @@ private[spark] object CallSite {
   val empty = CallSite("", "")
 }
 
+/** An utility class to map short compression codec names to qualified ones. */
+private[spark] class ShortCompressionCodecNameMapper {
+
+  def get(codecName: String): Option[String] = codecName.toLowerCase match {
+    case "none" => none
+    case "uncompressed" => uncompressed
+    case "bzip2" => bzip2
+    case "deflate" => deflate
+    case "gzip" => gzip
+    case "lzo" => lzo
+    case "lz4" => lz4
+    case "lzf" => lzf
+    case "snappy" => snappy
+    case _ => None
+  }
+
+  def getAsMap: Map[String, String] = {
+    Seq(
+      ("none", none),
+      ("uncompressed", uncompressed),
+      ("bzip2", bzip2),
+      ("deflate", deflate),
+      ("gzip", gzip),
+      ("lzo", lzo),
+      ("lz4", lz4),
+      ("lzf", lzf),
+      ("snappy", snappy)
+    ).flatMap { case (shortCodecName, codecName) =>
+        if (codecName.isDefined) Some(shortCodecName, codecName.get) else None
+    }.toMap
+  }
+
+  // To support short codec names, derived classes need to override the methods below that return
+  // corresponding qualified codec names.
+  def none: Option[String] = None
+  def uncompressed: Option[String] = None
+  def bzip2: Option[String] = None
+  def deflate: Option[String] = None
+  def gzip: Option[String] = None
+  def lzo: Option[String] = None
+  def lz4: Option[String] = None
+  def lzf: Option[String] = None
+  def snappy: Option[String] = None
+}
+
 /**
  * Various utility methods used by Spark.
  */

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -21,6 +21,8 @@ import java.util.Properties
 
 import scala.collection.JavaConverters._
 
+import org.apache.hadoop.io.compress.CompressionCodec
+
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
@@ -29,6 +31,8 @@ import org.apache.spark.sql.execution.datasources.{BucketSpec, CreateTableUsingA
 import org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils
 import org.apache.spark.sql.execution.streaming.StreamExecution
 import org.apache.spark.sql.sources.HadoopFsRelation
+
+
 
 /**
  * :: Experimental ::
@@ -151,6 +155,7 @@ final class DataFrameWriter private[sql](df: DataFrame) {
   }
 
   /**
+<<<<<<< b72611f20a03c790b6fd341b6ffdb3b5437609ee
    * Buckets the output by the given columns. If specified, the output is laid out on the file
    * system similar to Hive's bucketing scheme.
    *
@@ -175,6 +180,15 @@ final class DataFrameWriter private[sql](df: DataFrame) {
   @scala.annotation.varargs
   def sortBy(colName: String, colNames: String*): DataFrameWriter = {
     this.sortColumnNames = Option(colName +: colNames)
+    this
+  }
+  /*
+   * Specify the compression codec when saving it on hdfs
+   *
+   * @since 1.7.0
+   */
+  def compress(codec: Class[_ <: CompressionCodec]): DataFrameWriter = {
+    this.extraOptions += ("compression.codec" -> codec.getCanonicalName)
     this
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -33,7 +33,6 @@ import org.apache.spark.sql.execution.streaming.StreamExecution
 import org.apache.spark.sql.sources.HadoopFsRelation
 
 
-
 /**
  * :: Experimental ::
  * Interface used to write a [[DataFrame]] to external storage systems (e.g. file systems,
@@ -185,7 +184,7 @@ final class DataFrameWriter private[sql](df: DataFrame) {
   /*
    * Specify the compression codec when saving it on hdfs
    *
-   * @since 1.7.0
+   * @since 1.6.0
    */
   def compress(codec: Class[_ <: CompressionCodec]): DataFrameWriter = {
     this.extraOptions += ("compression.codec" -> codec.getCanonicalName)

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -154,7 +154,6 @@ final class DataFrameWriter private[sql](df: DataFrame) {
   }
 
   /**
-<<<<<<< b72611f20a03c790b6fd341b6ffdb3b5437609ee
    * Buckets the output by the given columns. If specified, the output is laid out on the file
    * system similar to Hive's bucketing scheme.
    *

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -184,7 +184,7 @@ final class DataFrameWriter private[sql](df: DataFrame) {
   /*
    * Specify the compression codec when saving it on hdfs
    *
-   * @since 1.6.0
+   * @since 1.7.0
    */
   def compress(codec: Class[_ <: CompressionCodec]): DataFrameWriter = {
     this.extraOptions += ("compression.codec" -> codec.getCanonicalName)

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -32,7 +32,6 @@ import org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils
 import org.apache.spark.sql.execution.streaming.StreamExecution
 import org.apache.spark.sql.sources.HadoopFsRelation
 
-
 /**
  * :: Experimental ::
  * Interface used to write a [[DataFrame]] to external storage systems (e.g. file systems,

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -1,27 +1,25 @@
 /*
-* Licensed to the Apache Software Foundation (ASF) under one or more
-* contributor license agreements.  See the NOTICE file distributed with
-* this work for additional information regarding copyright ownership.
-* The ASF licenses this file to You under the Apache License, Version 2.0
-* (the "License"); you may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.apache.spark.sql
 
 import java.util.Properties
 
 import scala.collection.JavaConverters._
-
-import org.apache.hadoop.io.compress.CompressionCodec
 
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -177,15 +175,6 @@ final class DataFrameWriter private[sql](df: DataFrame) {
   @scala.annotation.varargs
   def sortBy(colName: String, colNames: String*): DataFrameWriter = {
     this.sortColumnNames = Option(colName +: colNames)
-    this
-  }
-  /*
-   * Specify the compression codec when saving it on hdfs.
-   *
-   * @since 2.0.0
-   */
-  def compress(codec: Class[_ <: CompressionCodec]): DataFrameWriter = {
-    this.extraOptions += ("compression.codec" -> codec.getCanonicalName)
     this
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -180,9 +180,9 @@ final class DataFrameWriter private[sql](df: DataFrame) {
     this
   }
   /*
-   * Specify the compression codec when saving it on hdfs
+   * Specify the compression codec when saving it on hdfs.
    *
-   * @since 1.7.0
+   * @since 2.0.0
    */
   def compress(codec: Class[_ <: CompressionCodec]): DataFrameWriter = {
     this.extraOptions += ("compression.codec" -> codec.getCanonicalName)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -151,7 +151,7 @@ private[sql] object DataSourceStrategy extends Strategy with Logging {
     case i @ logical.InsertIntoTable(
       l @ LogicalRelation(t: HadoopFsRelation, _, _), part, query, overwrite, false) =>
       val mode = if (overwrite) SaveMode.Overwrite else SaveMode.Append
-      execution.ExecutedCommand(InsertIntoHadoopFsRelation(t, query, mode, None)) :: Nil
+      execution.ExecutedCommand(InsertIntoHadoopFsRelation(t, query, mode)) :: Nil
 
     case _ => Nil
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -151,7 +151,7 @@ private[sql] object DataSourceStrategy extends Strategy with Logging {
     case i @ logical.InsertIntoTable(
       l @ LogicalRelation(t: HadoopFsRelation, _, _), part, query, overwrite, false) =>
       val mode = if (overwrite) SaveMode.Overwrite else SaveMode.Append
-      execution.ExecutedCommand(InsertIntoHadoopFsRelation(t, query, mode)) :: Nil
+      execution.ExecutedCommand(InsertIntoHadoopFsRelation(t, query, mode, None)) :: Nil
 
     case _ => Nil
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelation.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.execution.{RunnableCommand, SQLExecution}
 import org.apache.spark.sql.sources._
 import org.apache.spark.util.Utils
 
+
 /**
  * A command for writing data to a [[HadoopFsRelation]].  Supports both overwriting and appending.
  * Writing to dynamic partitions is also supported.  Each [[InsertIntoHadoopFsRelation]] issues a

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelation.scala
@@ -60,7 +60,7 @@ private[sql] case class InsertIntoHadoopFsRelation(
     @transient relation: HadoopFsRelation,
     @transient query: LogicalPlan,
     mode: SaveMode,
-    codec: Option[Class[_ <: CompressionCodec]] = None)
+    compressionCodec: Option[Class[_ <: CompressionCodec]] = None)
   extends RunnableCommand {
 
   override def run(sqlContext: SQLContext): Seq[Row] = {
@@ -128,7 +128,7 @@ private[sql] case class InsertIntoHadoopFsRelation(
           """.stripMargin)
 
         val writerContainer = if (partitionColumns.isEmpty && relation.maybeBucketSpec.isEmpty) {
-          new DefaultWriterContainer(relation, job, isAppend, codec)
+          new DefaultWriterContainer(relation, job, isAppend, compressionCodec)
         } else {
           val output = df.queryExecution.executedPlan.output
           val (partitionOutput, dataOutput) =
@@ -143,7 +143,7 @@ private[sql] case class InsertIntoHadoopFsRelation(
             PartitioningUtils.DEFAULT_PARTITION_NAME,
             sqlContext.conf.getConf(SQLConf.PARTITION_MAX_FILES),
             isAppend,
-            codec)
+            compressionCodec)
         }
 
         // This call shouldn't be put into the `try` block below because it only initializes and

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelation.scala
@@ -59,7 +59,7 @@ private[sql] case class InsertIntoHadoopFsRelation(
     @transient relation: HadoopFsRelation,
     @transient query: LogicalPlan,
     mode: SaveMode,
-    codec: Option[Class[_ <: CompressionCodec]])
+    codec: Option[Class[_ <: CompressionCodec]] = None)
   extends RunnableCommand {
 
   override def run(sqlContext: SQLContext): Seq[Row] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ResolvedDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ResolvedDataSource.scala
@@ -26,6 +26,7 @@ import scala.util.{Failure, Success, Try}
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.compress.{CompressionCodec, CompressionCodecFactory}
 import org.apache.hadoop.util.StringUtils
+import org.apache.hadoop.io.compress.{CompressionCodec, CompressionCodecFactory}
 
 import org.apache.spark.Logging
 import org.apache.spark.deploy.SparkHadoopUtil

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ResolvedDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ResolvedDataSource.scala
@@ -26,7 +26,6 @@ import scala.util.{Failure, Success, Try}
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.compress.{CompressionCodec, CompressionCodecFactory}
 import org.apache.hadoop.util.StringUtils
-import org.apache.hadoop.io.compress.{CompressionCodec, CompressionCodecFactory}
 
 import org.apache.spark.Logging
 import org.apache.spark.deploy.SparkHadoopUtil

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/WriterContainer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/WriterContainer.scala
@@ -212,7 +212,7 @@ private[sql] abstract class BaseWriterContainer(
     serializableConf.value.set("mapred.task.id", taskAttemptId.toString)
     serializableConf.value.setBoolean("mapred.task.is.map", true)
     serializableConf.value.setInt("mapred.task.partition", 0)
-    for (c <- codec) {
+    codec.foreach { c =>
       serializableConf.value.set("mapred.output.compress", "true")
       serializableConf.value.set("mapred.output.compression.codec", c.getCanonicalName)
       serializableConf.value.set("mapred.output.compression.type", CompressionType.BLOCK.toString)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/WriterContainer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/WriterContainer.scala
@@ -19,11 +19,8 @@ package org.apache.spark.sql.execution.datasources
 
 import java.util.{Date, UUID}
 
-import scala.collection.JavaConverters._
-
 import org.apache.hadoop.fs.Path
-import org.apache.hadoop.io.SequenceFile.CompressionType
-import org.apache.hadoop.io.compress.{CompressionCodec, SnappyCodec}
+import org.apache.hadoop.io.compress.CompressionCodec
 import org.apache.hadoop.mapreduce._
 import org.apache.hadoop.mapreduce.lib.output.{FileOutputCommitter => MapReduceFileOutputCommitter}
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
@@ -212,10 +209,10 @@ private[sql] abstract class BaseWriterContainer(
     serializableConf.value.set("mapred.task.id", taskAttemptId.toString)
     serializableConf.value.setBoolean("mapred.task.is.map", true)
     serializableConf.value.setInt("mapred.task.partition", 0)
-    codec.foreach { c =>
+    codec.map { codecClass =>
       serializableConf.value.set("mapred.output.compress", "true")
-      serializableConf.value.set("mapred.output.compression.codec", c.getCanonicalName)
-      serializableConf.value.set("mapred.output.compression.type", CompressionType.BLOCK.toString)
+      serializableConf.value.set("mapred.output.compression.codec", codecClass.getCanonicalName)
+      serializableConf.value.set("mapred.output.compression.type", "BLOCK")
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/WriterContainer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/WriterContainer.scala
@@ -44,7 +44,7 @@ private[sql] abstract class BaseWriterContainer(
     @transient val relation: HadoopFsRelation,
     @transient private val job: Job,
     isAppend: Boolean,
-    codec: Option[Class[_ <: CompressionCodec]])
+    codec: Option[Class[_ <: CompressionCodec]] = None)
   extends Logging with Serializable {
 
   protected val dataSchema = relation.dataSchema
@@ -251,8 +251,7 @@ private[sql] class DefaultWriterContainer(
     job: Job,
     isAppend: Boolean,
     codec: Option[Class[_ <: CompressionCodec]])
-  extends BaseWriterContainer(relation, job, isAppend,
-    codec: Option[Class[_ <: CompressionCodec]]) {
+  extends BaseWriterContainer(relation, job, isAppend, codec) {
 
   def writeRows(taskContext: TaskContext, iterator: Iterator[InternalRow]): Unit = {
     executorSideSetup(taskContext)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/WriterContainer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/WriterContainer.scala
@@ -41,7 +41,7 @@ private[sql] abstract class BaseWriterContainer(
     @transient val relation: HadoopFsRelation,
     @transient private val job: Job,
     isAppend: Boolean,
-    codec: Option[Class[_ <: CompressionCodec]] = None)
+    compressionCodec: Option[Class[_ <: CompressionCodec]] = None)
   extends Logging with Serializable {
 
   protected val dataSchema = relation.dataSchema
@@ -209,7 +209,7 @@ private[sql] abstract class BaseWriterContainer(
     serializableConf.value.set("mapred.task.id", taskAttemptId.toString)
     serializableConf.value.setBoolean("mapred.task.is.map", true)
     serializableConf.value.setInt("mapred.task.partition", 0)
-    codec.map { codecClass =>
+    compressionCodec.map { codecClass =>
       serializableConf.value.set("mapred.output.compress", "true")
       serializableConf.value.set("mapred.output.compression.codec", codecClass.getCanonicalName)
       serializableConf.value.set("mapred.output.compression.type", "BLOCK")
@@ -247,8 +247,8 @@ private[sql] class DefaultWriterContainer(
     relation: HadoopFsRelation,
     job: Job,
     isAppend: Boolean,
-    codec: Option[Class[_ <: CompressionCodec]])
-  extends BaseWriterContainer(relation, job, isAppend, codec) {
+    compressionCodec: Option[Class[_ <: CompressionCodec]])
+  extends BaseWriterContainer(relation, job, isAppend, compressionCodec) {
 
   def writeRows(taskContext: TaskContext, iterator: Iterator[InternalRow]): Unit = {
     executorSideSetup(taskContext)
@@ -317,8 +317,8 @@ private[sql] class DynamicPartitionWriterContainer(
     defaultPartitionName: String,
     maxOpenFiles: Int,
     isAppend: Boolean,
-    codec: Option[Class[_ <: CompressionCodec]])
-  extends BaseWriterContainer(relation, job, isAppend, codec) {
+    compressionCodec: Option[Class[_ <: CompressionCodec]])
+  extends BaseWriterContainer(relation, job, isAppend, compressionCodec) {
 
   private val bucketSpec = relation.maybeBucketSpec
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRelation.scala
@@ -49,7 +49,7 @@ import org.apache.spark.sql.catalyst.util.LegacyTypeStringParser
 import org.apache.spark.sql.execution.datasources.{PartitionSpec, _}
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.{DataType, StructType}
-import org.apache.spark.util.{SerializableConfiguration, Utils}
+import org.apache.spark.util.{SerializableConfiguration, ShortCompressionCodecNameMapper, Utils}
 
 private[sql] class DefaultSource extends BucketedHadoopFsRelationProvider with DataSourceRegister {
 
@@ -283,10 +283,8 @@ private[sql] class ParquetRelation(
     conf.set(
       ParquetOutputFormat.COMPRESSION,
       ParquetRelation
-        .shortParquetCompressionCodecNames
-        .getOrElse(
-          sqlContext.conf.parquetCompressionCodec.toUpperCase,
-          CompressionCodecName.UNCOMPRESSED).name())
+        .parquetShortCodecNameMapper.get(sqlContext.conf.parquetCompressionCodec)
+        .getOrElse(CompressionCodecName.UNCOMPRESSED.name()))
 
     new BucketedOutputWriterFactory {
       override def newInstance(
@@ -902,11 +900,12 @@ private[sql] object ParquetRelation extends Logging {
     }
   }
 
-  // The parquet compression short names
-  val shortParquetCompressionCodecNames = Map(
-    "NONE" -> CompressionCodecName.UNCOMPRESSED,
-    "UNCOMPRESSED" -> CompressionCodecName.UNCOMPRESSED,
-    "SNAPPY" -> CompressionCodecName.SNAPPY,
-    "GZIP" -> CompressionCodecName.GZIP,
-    "LZO" -> CompressionCodecName.LZO)
+  /** Maps the short versions of compression codec names to qualified compression names. */
+  val parquetShortCodecNameMapper = new ShortCompressionCodecNameMapper {
+    override def none: Option[String] = Some(CompressionCodecName.UNCOMPRESSED.name())
+    override def uncompressed: Option[String] = Some(CompressionCodecName.UNCOMPRESSED.name())
+    override def gzip: Option[String] = Some(CompressionCodecName.GZIP.name())
+    override def lzo: Option[String] = Some(CompressionCodecName.LZO.name())
+    override def snappy: Option[String] = Some(CompressionCodecName.SNAPPY.name())
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/text/TextSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/text/TextSuite.scala
@@ -63,7 +63,6 @@ class TextSuite extends QueryTest with SharedSQLContext {
   test("compression") {
     val tempDirPath = Files.createTempDir().getAbsolutePath;
     val df = sqlContext.read.text(testFile)
-    df.show()
     df.write.compress(classOf[GzipCodec]).mode(SaveMode.Overwrite).text(tempDirPath)
     verifyFrame(sqlContext.read.text(tempDirPath))
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/text/TextSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/text/TextSuite.scala
@@ -58,10 +58,12 @@ class TextSuite extends QueryTest with SharedSQLContext {
   }
 
   test("compression") {
-    val tempDirPath = Utils.createTempDir().getAbsolutePath
-    val df = sqlContext.read.text(testFile)
-    df.write.option("compressionCodec", "GzipCodec").mode(SaveMode.Overwrite).text(tempDirPath)
-    verifyFrame(sqlContext.read.text(tempDirPath))
+    Seq("bzip2", "deflate", "gzip", "snappy").map { codecName =>
+      val tempDirPath = Utils.createTempDir().getAbsolutePath
+      val df = sqlContext.read.text(testFile)
+      df.write.option("compressionCodec", codecName).mode(SaveMode.Overwrite).text(tempDirPath)
+      verifyFrame(sqlContext.read.text(tempDirPath))
+    }
   }
 
   private def testFile: String = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/text/TextSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/text/TextSuite.scala
@@ -58,7 +58,7 @@ class TextSuite extends QueryTest with SharedSQLContext {
   }
 
   test("compression") {
-    Seq("bzip2", "deflate", "gzip", "snappy").map { codecName =>
+    Seq("bzip2", "deflate", "gzip").map { codecName =>
       val tempDirPath = Utils.createTempDir().getAbsolutePath
       val df = sqlContext.read.text(testFile)
       df.write.option("compressionCodec", codecName).mode(SaveMode.Overwrite).text(tempDirPath)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/text/TextSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/text/TextSuite.scala
@@ -17,10 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.text
 
-import com.google.common.io.Files
-import org.apache.hadoop.io.compress.GzipCodec
-
-import org.apache.spark.sql._
+import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row, SaveMode}
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types.{StringType, StructType}
 import org.apache.spark.util.Utils
@@ -61,9 +58,9 @@ class TextSuite extends QueryTest with SharedSQLContext {
   }
 
   test("compression") {
-    val tempDirPath = Files.createTempDir().getAbsolutePath;
+    val tempDirPath = Utils.createTempDir().getAbsolutePath
     val df = sqlContext.read.text(testFile)
-    df.write.compress(classOf[GzipCodec]).mode(SaveMode.Overwrite).text(tempDirPath)
+    df.write.option("compressionCodec", "GzipCodec").mode(SaveMode.Overwrite).text(tempDirPath)
     verifyFrame(sqlContext.read.text(tempDirPath))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/text/TextSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/text/TextSuite.scala
@@ -17,7 +17,10 @@
 
 package org.apache.spark.sql.execution.datasources.text
 
-import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
+import com.google.common.io.Files
+import org.apache.hadoop.io.compress.GzipCodec
+
+import org.apache.spark.sql._
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.sql.types.{StringType, StructType}
 import org.apache.spark.util.Utils
@@ -55,6 +58,14 @@ class TextSuite extends QueryTest with SharedSQLContext {
     intercept[AnalysisException] {
       sqlContext.range(2).select(df("id"), df("id") + 1).write.text(tempFile.getCanonicalPath)
     }
+  }
+
+  test("compression") {
+    val tempDirPath = Files.createTempDir().getAbsolutePath;
+    val df = sqlContext.read.text(testFile)
+    df.show()
+    df.write.compress(classOf[GzipCodec]).mode(SaveMode.Overwrite).text(tempDirPath)
+    verifyFrame(sqlContext.read.text(tempDirPath))
   }
 
   private def testFile: String = {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/parquetSuites.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/parquetSuites.scala
@@ -306,7 +306,7 @@ class ParquetMetastoreSuite extends ParquetPartitioningTest {
 
       val df = sql("INSERT INTO TABLE test_insert_parquet SELECT a FROM jt")
       df.queryExecution.sparkPlan match {
-        case ExecutedCommand(InsertIntoHadoopFsRelation(_: ParquetRelation, _, _)) => // OK
+        case ExecutedCommand(InsertIntoHadoopFsRelation(_: ParquetRelation, _, _, _)) => // OK
         case o => fail("test_insert_parquet should be converted to a " +
           s"${classOf[ParquetRelation].getCanonicalName} and " +
           s"${classOf[InsertIntoDataSource].getCanonicalName} is expcted as the SparkPlan. " +
@@ -336,7 +336,7 @@ class ParquetMetastoreSuite extends ParquetPartitioningTest {
 
       val df = sql("INSERT INTO TABLE test_insert_parquet SELECT a FROM jt_array")
       df.queryExecution.sparkPlan match {
-        case ExecutedCommand(InsertIntoHadoopFsRelation(r: ParquetRelation, _, _)) => // OK
+        case ExecutedCommand(InsertIntoHadoopFsRelation(r: ParquetRelation, _, _, _)) => // OK
         case o => fail("test_insert_parquet should be converted to a " +
           s"${classOf[ParquetRelation].getCanonicalName} and " +
           s"${classOf[InsertIntoDataSource].getCanonicalName} is expcted as the SparkPlan." +


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr is to support hadoop compression codecs when saving DataFrame to disk.
This is rework from #9657 because it gets stale.

closes #9657
