### PR TITLE
[SPARK-12877] [ML] Add train-validation-split to pyspark

### DIFF
--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -34,18 +34,23 @@ if sys.version_info[:2] <= (2, 6):
 else:
     import unittest
 
-from pyspark.tests import ReusedPySparkTestCase as PySparkTestCase
-from pyspark.sql import DataFrame, SQLContext, Row
-from pyspark.sql.functions import rand
+from shutil import rmtree
+import tempfile
+
+from pyspark.ml import Estimator, Model, Pipeline, Transformer
 from pyspark.ml.classification import LogisticRegression
+from pyspark.ml.clustering import KMeans
 from pyspark.ml.evaluation import RegressionEvaluator
+from pyspark.ml.feature import *
 from pyspark.ml.param import Param, Params
 from pyspark.ml.param.shared import HasMaxIter, HasInputCol, HasSeed
-from pyspark.ml.util import keyword_only
-from pyspark.ml import Estimator, Model, Pipeline, Transformer
-from pyspark.ml.feature import *
+from pyspark.ml.regression import LinearRegression
 from pyspark.ml.tuning import *
+from pyspark.ml.util import keyword_only
 from pyspark.mllib.linalg import DenseVector
+from pyspark.sql import DataFrame, SQLContext, Row
+from pyspark.sql.functions import rand
+from pyspark.tests import ReusedPySparkTestCase as PySparkTestCase
 
 
 class MockDataset(DataFrame):

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -209,6 +209,11 @@ class ParamTests(PySparkTestCase):
         self.assertEqual(maxIter.doc, "max number of iterations (>= 0).")
         self.assertTrue(maxIter.parent == testParams.uid)
 
+    def test_hasparam(self):
+        testParams = TestParams()
+        self.assertTrue(all([testParams.hasParam(p.name) for p in testParams.params]))
+        self.assertFalse(testParams.hasParam("notAParameter"))
+
     def test_params(self):
         testParams = TestParams()
         maxIter = testParams.maxIter
@@ -218,7 +223,7 @@ class ParamTests(PySparkTestCase):
         params = testParams.params
         self.assertEqual(params, [inputCol, maxIter, seed])
 
-        self.assertTrue(testParams.hasParam(maxIter))
+        self.assertTrue(testParams.hasParam(maxIter.name))
         self.assertTrue(testParams.hasDefault(maxIter))
         self.assertFalse(testParams.isSet(maxIter))
         self.assertTrue(testParams.isDefined(maxIter))
@@ -227,7 +232,7 @@ class ParamTests(PySparkTestCase):
         self.assertTrue(testParams.isSet(maxIter))
         self.assertEqual(testParams.getMaxIter(), 100)
 
-        self.assertTrue(testParams.hasParam(inputCol))
+        self.assertTrue(testParams.hasParam(inputCol.name))
         self.assertFalse(testParams.hasDefault(inputCol))
         self.assertFalse(testParams.isSet(inputCol))
         self.assertFalse(testParams.isDefined(inputCol))
@@ -244,10 +249,18 @@ class ParamTests(PySparkTestCase):
                        "maxIter: max number of iterations (>= 0). (default: 10, current: 100)",
                        "seed: random seed. (default: 41, current: 43)"]))
 
+    def test_kmeans_param(self):
+        algo = KMeans()
+        self.assertEqual(algo.getInitMode(), "k-means||")
+        algo.setK(10)
+        self.assertEqual(algo.getK(), 10)
+        algo.setInitSteps(10)
+        self.assertEqual(algo.getInitSteps(), 10)
+
     def test_hasseed(self):
         noSeedSpecd = TestParams()
         withSeedSpecd = TestParams(seed=42)
-        other = OtherTestParams() 
+        other = OtherTestParams()
         # Check that we no longer use 42 as the magic number
         self.assertNotEqual(noSeedSpecd.getSeed(), 42)
         origSeed = noSeedSpecd.getSeed()

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -44,7 +44,7 @@ from pyspark.ml.param.shared import HasMaxIter, HasInputCol, HasSeed
 from pyspark.ml.util import keyword_only
 from pyspark.ml import Estimator, Model, Pipeline, Transformer
 from pyspark.ml.feature import *
-from pyspark.ml.tuning import ParamGridBuilder, CrossValidator, CrossValidatorModel
+from pyspark.ml.tuning import *
 from pyspark.mllib.linalg import DenseVector
 
 
@@ -242,7 +242,7 @@ class ParamTests(PySparkTestCase):
     def test_hasseed(self):
         noSeedSpecd = TestParams()
         withSeedSpecd = TestParams(seed=42)
-        other = OtherTestParams()
+        other = OtherTestParams() 
         # Check that we no longer use 42 as the magic number
         self.assertNotEqual(noSeedSpecd.getSeed(), 42)
         origSeed = noSeedSpecd.getSeed()

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -494,26 +494,6 @@ class PersistenceTest(PySparkTestCase):
             pass
 
 
-class PersistenceTest(PySparkTestCase):
-
-    def test_linear_regression(self):
-        lr = LinearRegression(maxIter=1)
-        path = tempfile.mkdtemp()
-        lr_path = path + "/lr"
-        lr.save(lr_path)
-        lr2 = LinearRegression.load(lr_path)
-        self.assertEqual(lr2.uid, lr2.maxIter.parent,
-                         "Loaded LinearRegression instance uid (%s) did not match Param's uid (%s)"
-                         % (lr2.uid, lr2.maxIter.parent))
-        self.assertEqual(lr._defaultParamMap[lr.maxIter], lr2._defaultParamMap[lr2.maxIter],
-                         "Loaded LinearRegression instance default params did not match " +
-                         "original defaults")
-        try:
-            rmtree(path)
-        except OSError:
-            pass
-
-
 if __name__ == "__main__":
     from pyspark.ml.tests import *
     if xmlrunner:

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -34,23 +34,18 @@ if sys.version_info[:2] <= (2, 6):
 else:
     import unittest
 
-from shutil import rmtree
-import tempfile
-
-from pyspark.ml import Estimator, Model, Pipeline, Transformer
-from pyspark.ml.classification import LogisticRegression
-from pyspark.ml.clustering import KMeans
-from pyspark.ml.evaluation import RegressionEvaluator
-from pyspark.ml.feature import *
-from pyspark.ml.param import Param, Params
-from pyspark.ml.param.shared import HasMaxIter, HasInputCol, HasSeed
-from pyspark.ml.regression import LinearRegression
-from pyspark.ml.tuning import *
-from pyspark.ml.util import keyword_only
-from pyspark.mllib.linalg import DenseVector
+from pyspark.tests import ReusedPySparkTestCase as PySparkTestCase
 from pyspark.sql import DataFrame, SQLContext, Row
 from pyspark.sql.functions import rand
-from pyspark.tests import ReusedPySparkTestCase as PySparkTestCase
+from pyspark.ml.classification import LogisticRegression
+from pyspark.ml.evaluation import RegressionEvaluator
+from pyspark.ml.param import Param, Params
+from pyspark.ml.param.shared import HasMaxIter, HasInputCol, HasSeed
+from pyspark.ml.util import keyword_only
+from pyspark.ml import Estimator, Model, Pipeline, Transformer
+from pyspark.ml.feature import *
+from pyspark.ml.tuning import ParamGridBuilder, CrossValidator, CrossValidatorModel
+from pyspark.mllib.linalg import DenseVector
 
 
 class MockDataset(DataFrame):
@@ -209,11 +204,6 @@ class ParamTests(PySparkTestCase):
         self.assertEqual(maxIter.doc, "max number of iterations (>= 0).")
         self.assertTrue(maxIter.parent == testParams.uid)
 
-    def test_hasparam(self):
-        testParams = TestParams()
-        self.assertTrue(all([testParams.hasParam(p.name) for p in testParams.params]))
-        self.assertFalse(testParams.hasParam("notAParameter"))
-
     def test_params(self):
         testParams = TestParams()
         maxIter = testParams.maxIter
@@ -223,7 +213,7 @@ class ParamTests(PySparkTestCase):
         params = testParams.params
         self.assertEqual(params, [inputCol, maxIter, seed])
 
-        self.assertTrue(testParams.hasParam(maxIter.name))
+        self.assertTrue(testParams.hasParam(maxIter))
         self.assertTrue(testParams.hasDefault(maxIter))
         self.assertFalse(testParams.isSet(maxIter))
         self.assertTrue(testParams.isDefined(maxIter))
@@ -232,7 +222,7 @@ class ParamTests(PySparkTestCase):
         self.assertTrue(testParams.isSet(maxIter))
         self.assertEqual(testParams.getMaxIter(), 100)
 
-        self.assertTrue(testParams.hasParam(inputCol.name))
+        self.assertTrue(testParams.hasParam(inputCol))
         self.assertFalse(testParams.hasDefault(inputCol))
         self.assertFalse(testParams.isSet(inputCol))
         self.assertFalse(testParams.isDefined(inputCol))
@@ -248,14 +238,6 @@ class ParamTests(PySparkTestCase):
             "\n".join(["inputCol: input column name. (undefined)",
                        "maxIter: max number of iterations (>= 0). (default: 10, current: 100)",
                        "seed: random seed. (default: 41, current: 43)"]))
-
-    def test_kmeans_param(self):
-        algo = KMeans()
-        self.assertEqual(algo.getInitMode(), "k-means||")
-        algo.setK(10)
-        self.assertEqual(algo.getK(), 10)
-        algo.setInitSteps(10)
-        self.assertEqual(algo.getInitSteps(), 10)
 
     def test_hasseed(self):
         noSeedSpecd = TestParams()

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -422,6 +422,7 @@ class CrossValidatorTests(PySparkTestCase):
                          "Best model should have zero induced error")
         self.assertEqual(1.0, bestModelMetric, "Best model has R-squared of 1")
 
+
 class TrainValidationSplitTests(PySparkTestCase):
 
     def test_fit_minimize_metric(self):

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -30,7 +30,7 @@ __all__ = ['ParamGridBuilder', 'CrossValidator', 'CrossValidatorModel', 'TrainVa
 
 
 class ParamGridBuilder(object):
-    """
+    r"""
     Builder for a param grid used in grid search-based model selection.
 
     >>> from pyspark.ml.classification import LogisticRegression
@@ -298,7 +298,6 @@ class TrainValidationSplit(Estimator, HasSeed):
         "evaluator used to select hyper-parameters that maximize the metric")
     trainRatio = Param(Params._dummy(), "trainRatio", "proportion for train-validation ratio")
 
-    @since("2.0.0")
     @keyword_only
     def __init__(self, estimator=None, estimatorParamMaps=None, evaluator=None, trainRatio=0.75,
                  seed=None):
@@ -383,7 +382,6 @@ class TrainValidationSplit(Estimator, HasSeed):
         """
         return self.getOrDefault(self.trainRatio)
 
-    @since("2.0.0")
     def _fit(self, dataset):
         est = self.getOrDefault(self.estimator)
         epm = self.getOrDefault(self.estimatorParamMaps)
@@ -434,13 +432,11 @@ class TrainValidationSplitModel(Model):
     Model from train validation split.
     """
 
-    @since("2.0.0")
     def __init__(self, bestModel):
         super(TrainValidationSplitModel, self).__init__()
         #: best model from cross validation
         self.bestModel = bestModel
 
-    @since("2.0.0")
     def _transform(self, dataset):
         return self.bestModel.transform(dataset)
 

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -308,7 +308,7 @@ class TrainValidationSplit(Estimator, HasSeed):
     >>> tvs = TrainValidationSplit(estimator=lr, estimatorParamMaps=grid, evaluator=evaluator)
     >>> tvsModel = tvs.fit(dataset)
     >>> evaluator.evaluate(tvsModel.transform(dataset))
-    0.8333...
+    0.83333333333333326
     .. versionadded:: 2.0.0
     """
 

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -290,6 +290,27 @@ class CrossValidatorModel(Model):
 
 
 class TrainValidationSplit(Estimator, HasSeed):
+    """
+    Train-Validation-Split.
+    >>> from pyspark.ml.classification import LogisticRegression
+    >>> from pyspark.ml.evaluation import BinaryClassificationEvaluator
+    >>> from pyspark.mllib.linalg import Vectors
+    >>> dataset = sqlContext.createDataFrame(
+    ...     [(Vectors.dense([0.0]), 0.0),
+    ...      (Vectors.dense([0.4]), 1.0),
+    ...      (Vectors.dense([0.5]), 0.0),
+    ...      (Vectors.dense([0.6]), 1.0),
+    ...      (Vectors.dense([1.0]), 1.0)] * 10,
+    ...     ["features", "label"])
+    >>> lr = LogisticRegression()
+    >>> grid = ParamGridBuilder().addGrid(lr.maxIter, [0, 1]).build()
+    >>> evaluator = BinaryClassificationEvaluator()
+    >>> tvs = TrainValidationSplit(estimator=lr, estimatorParamMaps=grid, evaluator=evaluator)
+    >>> tvsModel = tvs.fit(dataset)
+    >>> evaluator.evaluate(tvsModel.transform(dataset))
+    0.8333...
+    .. versionadded:: 2.0.0
+    """
 
     estimator = Param(Params._dummy(), "estimator", "estimator to be tested")
     estimatorParamMaps = Param(Params._dummy(), "estimatorParamMaps", "estimator param maps")

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -290,7 +290,6 @@ class CrossValidatorModel(Model):
 
 
 class TrainValidationSplit(Estimator, HasSeed):
-    # TODO: add since keyword to functions
 
     estimator = Param(Params._dummy(), "estimator", "estimator to be tested")
     estimatorParamMaps = Param(Params._dummy(), "estimatorParamMaps", "estimator param maps")
@@ -299,6 +298,7 @@ class TrainValidationSplit(Estimator, HasSeed):
         "evaluator used to select hyper-parameters that maximize the metric")
     trainRatio = Param(Params._dummy(), "trainRatio", "proportion for train-validation ratio")
 
+    @since("2.0.0")
     @keyword_only
     def __init__(self, estimator=None, estimatorParamMaps=None, evaluator=None, trainRatio=0.75,
                  seed=None):
@@ -311,6 +311,7 @@ class TrainValidationSplit(Estimator, HasSeed):
         kwargs = self.__init__._input_kwargs
         self._set(**kwargs)
 
+    @since("2.0.0")
     @keyword_only
     def setParams(self, estimator=None, estimatorParamMaps=None, evaluator=None, trainRatio=0.75,
                   seed=None):
@@ -322,6 +323,7 @@ class TrainValidationSplit(Estimator, HasSeed):
         kwargs = self.setParams._input_kwargs
         return self._set(**kwargs)
 
+    @since("2.0.0")
     def setEstimator(self, value):
         """
         Sets the value of :py:attr:`estimator`.
@@ -329,12 +331,14 @@ class TrainValidationSplit(Estimator, HasSeed):
         self._paramMap[self.estimator] = value
         return self
 
+    @since("2.0.0")
     def getEstimator(self):
         """
         Gets the value of estimator or its default value.
         """
         return self.getOrDefault(self.estimator)
 
+    @since("2.0.0")
     def setEstimatorParamMaps(self, value):
         """
         Sets the value of :py:attr:`estimatorParamMaps`.
@@ -342,12 +346,14 @@ class TrainValidationSplit(Estimator, HasSeed):
         self._paramMap[self.estimatorParamMaps] = value
         return self
 
+    @since("2.0.0")
     def getEstimatorParamMaps(self):
         """
         Gets the value of estimatorParamMaps or its default value.
         """
         return self.getOrDefault(self.estimatorParamMaps)
 
+    @since("2.0.0")
     def setEvaluator(self, value):
         """
         Sets the value of :py:attr:`evaluator`.
@@ -355,12 +361,14 @@ class TrainValidationSplit(Estimator, HasSeed):
         self._paramMap[self.evaluator] = value
         return self
 
+    @since("2.0.0")
     def getEvaluator(self):
         """
         Gets the value of evaluator or its default value.
         """
         return self.getOrDefault(self.evaluator)
 
+    @since("2.0.0")
     def setTrainRatio(self, value):
         """
         Sets the value of :py:attr:`trainRatio`.
@@ -368,13 +376,14 @@ class TrainValidationSplit(Estimator, HasSeed):
         self._paramMap[self.trainRatio] = value
         return self
 
-    @since("1.4.0")
+    @since("2.0.0")
     def getTrainRatio(self):
         """
         Gets the value of trainRatio or its default value.
         """
         return self.getOrDefault(self.trainRatio)
 
+    @since("2.0.0")
     def _fit(self, dataset):
         est = self.getOrDefault(self.estimator)
         epm = self.getOrDefault(self.estimatorParamMaps)
@@ -399,7 +408,7 @@ class TrainValidationSplit(Estimator, HasSeed):
         bestModel = est.fit(dataset, epm[bestIndex])
         return TrainValidationSplitModel(bestModel)
 
-    @since("1.4.0")
+    @since("2.0.0")
     def copy(self, extra=None):
         """
         Creates a copy of this instance with a randomly generated uid
@@ -425,14 +434,17 @@ class TrainValidationSplitModel(Model):
     Model from train validation split.
     """
 
+    @since("2.0.0")
     def __init__(self, bestModel):
         super(TrainValidationSplitModel, self).__init__()
         #: best model from cross validation
         self.bestModel = bestModel
 
+    @since("2.0.0")
     def _transform(self, dataset):
         return self.bestModel.transform(dataset)
 
+    @since("2.0.0")
     def copy(self, extra=None):
         """
         Creates a copy of this instance with a randomly generated uid

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -292,7 +292,7 @@ class CrossValidatorModel(Model):
 class TrainValidationSplit(Estimator, HasSeed):
     """
     Train-Validation-Split.
-    
+
     >>> from pyspark.ml.classification import LogisticRegression
     >>> from pyspark.ml.evaluation import BinaryClassificationEvaluator
     >>> from pyspark.mllib.linalg import Vectors
@@ -339,7 +339,7 @@ class TrainValidationSplit(Estimator, HasSeed):
     def setParams(self, estimator=None, estimatorParamMaps=None, evaluator=None, trainRatio=0.75,
                   seed=None):
         """
-        setParams(self, estimator=None, estimatorParamMaps=None, evaluator=None, trainRatio= 0.75,\
+        setParams(self, estimator=None, estimatorParamMaps=None, evaluator=None, trainRatio=0.75,\
                   seed=None):
         Sets params for the train validation split.
         """

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -290,36 +290,14 @@ class CrossValidatorModel(Model):
 
 
 class TrainValidationSplit(Estimator, HasSeed):
-    """
-    Train-Validation-Split.
-
-    >>> from pyspark.ml.classification import LogisticRegression
-    >>> from pyspark.ml.evaluation import BinaryClassificationEvaluator
-    >>> from pyspark.mllib.linalg import Vectors
-    >>> dataset = sqlContext.createDataFrame(
-    ...     [(Vectors.dense([0.0]), 0.0),
-    ...      (Vectors.dense([0.4]), 1.0),
-    ...      (Vectors.dense([0.5]), 0.0),
-    ...      (Vectors.dense([0.6]), 1.0),
-    ...      (Vectors.dense([1.0]), 1.0)] * 10,
-    ...     ["features", "label"])
-    >>> lr = LogisticRegression()
-    >>> grid = ParamGridBuilder().addGrid(lr.maxIter, [0, 1]).build()
-    >>> evaluator = BinaryClassificationEvaluator()
-    >>> tvs = TrainValidationSplit(estimator=lr, estimatorParamMaps=grid, evaluator=evaluator)
-    >>> tvsModel = tvs.fit(dataset)
-    >>> evaluator.evaluate(tvsModel.transform(dataset))
-    0.8333...
-
-    .. versionadded:: 2.0.0
-    """
 
     estimator = Param(Params._dummy(), "estimator", "estimator to be tested")
     estimatorParamMaps = Param(Params._dummy(), "estimatorParamMaps", "estimator param maps")
     evaluator = Param(
         Params._dummy(), "evaluator",
-        "evaluator used to select hyper-parameters that maximize the metric")
-    trainRatio = Param(Params._dummy(), "trainRatio", "Param for ratio between train and validation data. Must be between 0 and 1.")
+        "evaluator used to select hyper-parameters that maximize the validated metric")
+    trainRatio = Param(Params._dummy(), "trainRatio", "Param for ratio between train and\
+     validation data. Must be between 0 and 1.")
 
     @keyword_only
     def __init__(self, estimator=None, estimatorParamMaps=None, evaluator=None, trainRatio=0.75,

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -308,7 +308,8 @@ class TrainValidationSplit(Estimator, HasSeed):
     >>> tvs = TrainValidationSplit(estimator=lr, estimatorParamMaps=grid, evaluator=evaluator)
     >>> tvsModel = tvs.fit(dataset)
     >>> evaluator.evaluate(tvsModel.transform(dataset))
-    0.83333333333333326
+    0.8333...
+
     .. versionadded:: 2.0.0
     """
 

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -290,13 +290,36 @@ class CrossValidatorModel(Model):
 
 
 class TrainValidationSplit(Estimator, HasSeed):
+    """
+    Train-Validation-Split.
+
+    >>> from pyspark.ml.classification import LogisticRegression
+    >>> from pyspark.ml.evaluation import BinaryClassificationEvaluator
+    >>> from pyspark.mllib.linalg import Vectors
+    >>> dataset = sqlContext.createDataFrame(
+    ...     [(Vectors.dense([0.0]), 0.0),
+    ...      (Vectors.dense([0.4]), 1.0),
+    ...      (Vectors.dense([0.5]), 0.0),
+    ...      (Vectors.dense([0.6]), 1.0),
+    ...      (Vectors.dense([1.0]), 1.0)] * 10,
+    ...     ["features", "label"])
+    >>> lr = LogisticRegression()
+    >>> grid = ParamGridBuilder().addGrid(lr.maxIter, [0, 1]).build()
+    >>> evaluator = BinaryClassificationEvaluator()
+    >>> tvs = TrainValidationSplit(estimator=lr, estimatorParamMaps=grid, evaluator=evaluator)
+    >>> tvsModel = tvs.fit(dataset)
+    >>> evaluator.evaluate(tvsModel.transform(dataset))
+    0.8333...
+
+    .. versionadded:: 2.0.0
+    """
 
     estimator = Param(Params._dummy(), "estimator", "estimator to be tested")
     estimatorParamMaps = Param(Params._dummy(), "estimatorParamMaps", "estimator param maps")
     evaluator = Param(
         Params._dummy(), "evaluator",
         "evaluator used to select hyper-parameters that maximize the metric")
-    trainRatio = Param(Params._dummy(), "trainRatio", "proportion for train-validation ratio")
+    trainRatio = Param(Params._dummy(), "trainRatio", "Param for ratio between train and validation data. Must be between 0 and 1.")
 
     @keyword_only
     def __init__(self, estimator=None, estimatorParamMaps=None, evaluator=None, trainRatio=0.75,
@@ -418,13 +441,13 @@ class TrainValidationSplit(Estimator, HasSeed):
         """
         if extra is None:
             extra = dict()
-        newCV = Params.copy(self, extra)
+        newTVS = Params.copy(self, extra)
         if self.isSet(self.estimator):
-            newCV.setEstimator(self.getEstimator().copy(extra))
+            newTVS.setEstimator(self.getEstimator().copy(extra))
         # estimatorParamMaps remain the same
         if self.isSet(self.evaluator):
-            newCV.setEvaluator(self.getEvaluator().copy(extra))
-        return newCV
+            newTVS.setEvaluator(self.getEvaluator().copy(extra))
+        return newTVS
 
 
 class TrainValidationSplitModel(Model):

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -292,6 +292,7 @@ class CrossValidatorModel(Model):
 class TrainValidationSplit(Estimator, HasSeed):
     """
     Train-Validation-Split.
+    
     >>> from pyspark.ml.classification import LogisticRegression
     >>> from pyspark.ml.evaluation import BinaryClassificationEvaluator
     >>> from pyspark.mllib.linalg import Vectors

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -25,7 +25,8 @@ from pyspark.ml.param.shared import HasSeed
 from pyspark.ml.util import keyword_only
 from pyspark.sql.functions import rand
 
-__all__ = ['ParamGridBuilder', 'CrossValidator', 'CrossValidatorModel', 'TrainValidationSplit', 'TrainValidationSplitModel']
+__all__ = ['ParamGridBuilder', 'CrossValidator', 'CrossValidatorModel', 'TrainValidationSplit',
+           'TrainValidationSplitModel']
 
 
 class ParamGridBuilder(object):
@@ -291,7 +292,6 @@ class CrossValidatorModel(Model):
 class TrainValidationSplit(Estimator, HasSeed):
     # TODO: add since keyword to functions
 
-
     estimator = Param(Params._dummy(), "estimator", "estimator to be tested")
     estimatorParamMaps = Param(Params._dummy(), "estimatorParamMaps", "estimator param maps")
     evaluator = Param(
@@ -300,19 +300,19 @@ class TrainValidationSplit(Estimator, HasSeed):
     trainRatio = Param(Params._dummy(), "trainRatio", "proportion for train-validation ratio")
 
     @keyword_only
-    def __init__(self, estimator=None, estimatorParamMaps=None, evaluator=None, trainRatio= 0.75,
+    def __init__(self, estimator=None, estimatorParamMaps=None, evaluator=None, trainRatio=0.75,
                  seed=None):
         """
-        __init__(self, estimator=None, estimatorParamMaps=None, evaluator=None, trainRatio= 0.75,\
+        __init__(self, estimator=None, estimatorParamMaps=None, evaluator=None, trainRatio=0.75,\
                  seed=None)
         """
         super(TrainValidationSplit, self).__init__()
-        self._setDefault(trainRatio= 0.75)
+        self._setDefault(trainRatio=0.75)
         kwargs = self.__init__._input_kwargs
         self._set(**kwargs)
 
     @keyword_only
-    def setParams(self, estimator=None, estimatorParamMaps=None, evaluator=None, trainRatio= 0.75,
+    def setParams(self, estimator=None, estimatorParamMaps=None, evaluator=None, trainRatio=0.75,
                   seed=None):
         """
         setParams(self, estimator=None, estimatorParamMaps=None, evaluator=None, trainRatio= 0.75,\
@@ -415,7 +415,6 @@ class TrainValidationSplit(Estimator, HasSeed):
         if self.isSet(self.estimator):
             newCV.setEstimator(self.getEstimator().copy(extra))
         # estimatorParamMaps remain the same
-        
         if self.isSet(self.evaluator):
             newCV.setEvaluator(self.getEvaluator().copy(extra))
         return newCV
@@ -430,7 +429,6 @@ class TrainValidationSplitModel(Model):
         super(TrainValidationSplitModel, self).__init__()
         #: best model from cross validation
         self.bestModel = bestModel
-        
 
     def _transform(self, dataset):
         return self.bestModel.transform(dataset)
@@ -447,7 +445,7 @@ class TrainValidationSplitModel(Model):
         """
         if extra is None:
             extra = dict()
-        return TrainValidationSplitModel(self. .copy(extra))
+        return TrainValidationSplitModel(self.bestModel.copy(extra))
 
 if __name__ == "__main__":
     import doctest


### PR DESCRIPTION
## What changes were proposed in this pull request?

The changes proposed were to add train-validation-split to pyspark.ml.tuning.
## How was the this patch tested?

This patch was tested through unit tests located in pyspark/ml/test.py.

This is my original work and I license it to Spark.
