### PR TITLE
[SPARK-13464][Streaming][PySpark] Fix failed streaming in pyspark in branch 1.3

### DIFF
--- a/python/pyspark/streaming/tests.py
+++ b/python/pyspark/streaming/tests.py
@@ -423,7 +423,7 @@ class WindowFunctionTests(PySparkStreamingTestCase):
                 .reduceByKeyAndWindow(operator.add, None, 5, 1)\
                 .filter(lambda kv: kv[1] > 0).count()
 
-        expected = [[2], [4], [6], [6], [6], [6]]
+        expected = [[1], [2], [3], [4], [5], [6]]
         self._test_func(input, func, expected)
 
 


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-13464
## What changes were proposed in this pull request?

During backport a mllib feature, I found that the clearly checkouted branch-1.3 codebase would fail at the test `test_reduce_by_key_and_window_with_none_invFunc` in pyspark/streaming. We should fix it.
## How was the this patch tested?

Unit test `test_reduce_by_key_and_window_with_none_invFunc` is fixed.
