### PR TITLE
[SPARK-13472][SparkR] Fix unstable Kmeans test in R

### DIFF
--- a/R/pkg/inst/tests/testthat/test_mllib.R
+++ b/R/pkg/inst/tests/testthat/test_mllib.R
@@ -130,7 +130,7 @@ test_that("kmeans", {
 
   # Test stats::kmeans is working
   statsModel <- kmeans(x = newIris, centers = 2)
-  expect_equal(unique(statsModel$cluster), c(1, 2))
+  expect_equal(sort(unique(statsModel$cluster)), c(1, 2))
 
   # Test fitted works on KMeans
   fitted.model <- fitted(model)


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-13472
## What changes were proposed in this pull request?

One Kmeans test in R is unstable and sometimes fails. We should fix it.
## How was this patch tested?

Unit test is modified in this PR.
