### PR TITLE
[SPARK-13471] [SQL]: WiP update hive version to 1.2.1.1.spark

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <curator.version>2.4.0</curator.version>
     <hive.group>org.spark-project.hive</hive.group>
     <!-- Version used in Maven Hive dependency -->
-    <hive.version>1.2.1.spark</hive.version>
+    <hive.version>1.2.1.1.spark</hive.version>
     <!-- Version used for internal directory structure -->
     <hive.version.short>1.2.1</hive.version.short>
     <derby.version>10.10.1.1</derby.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This updates the hive dependency from 1.2.1.spark to 1.2.1.1.spark, an update which does nothing but
1. Update the POM
2. Update groovy to 2.4.4

In doing so it ensures that CVE-2015-3253 is not passed on to applications pulling in spark-hive via POM dependencies.
## How was this patch tested?

Full tests ongoing; basic build & hive tests seemed happy. This only works with a local build of `org.spark-project.hive` of 1.2.1.1.spark with the modified groovy dependency; Jenkins will fail to build until the artifact is actually published. ( see [https://github.com/pwendell/hive/pull/1] 

audit of maven dependencies shows that later groovy version is picked up

```
[INFO] +- org.spark-project.hive:hive-exec:jar:1.2.1.1.spark:compile
[INFO] |  +- (com.twitter:parquet-hadoop-bundle:jar:1.6.0:compile - omitted for duplicate)
[INFO] |  +- commons-io:commons-io:jar:2.4:compile
[INFO] |  +- (org.apache.commons:commons-lang3:jar:3.3.2:compile - version managed from 3.1; omitted for duplicate)
[INFO] |  +- (commons-lang:commons-lang:jar:2.6:compile - version managed from 2.4; omitted for duplicate)
[INFO] |  +- javolution:javolution:jar:5.5.1:compile
[INFO] |  +- log4j:apache-log4j-extras:jar:1.2.17:compile
[INFO] |  +- org.antlr:antlr-runtime:jar:3.4:compile
[INFO] |  |  +- org.antlr:stringtemplate:jar:3.2.1:compile
[INFO] |  |  |  \- (antlr:antlr:jar:2.7.7:compile - omitted for duplicate)
[INFO] |  |  \- antlr:antlr:jar:2.7.7:compile
[INFO] |  +- org.antlr:ST4:jar:4.0.4:compile
[INFO] |  |  \- (org.antlr:antlr-runtime:jar:3.3:compile - omitted for conflict with 3.4)
[INFO] |  +- (org.apache.avro:avro:jar:1.7.7:compile - version managed from 1.7.5; omitted for duplicate)
[INFO] |  +- org.apache.commons:commons-compress:jar:1.4.1:compile
[INFO] |  |  \- org.tukaani:xz:jar:1.0:compile
[INFO] |  +- (org.apache.ivy:ivy:jar:2.4.0:compile - omitted for duplicate)
[INFO] |  +- org.codehaus.groovy:groovy-all:jar:2.4.4:compile
[INFO] |  +- org.codehaus.jackson:jackson-core-asl:jar:1.9.13:compile
[INFO] |  +- (org.jodd:jodd-core:jar:3.5.2:compile - omitted for duplicate)
[INFO] |  +- (org.codehaus.jackson:jackson-mapper-asl:jar:1.9.13:compile - version managed from 1.9.2; omitted for duplicate)
[INFO] |  +- (org.datanucleus:datanucleus-core:jar:3.2.10:compile - omitted for duplicate)
[INFO] |  +- (org.apache.calcite:calcite-avatica:jar:1.2.0-incubating:compile - omitted for duplicate)
[INFO] |  +- com.google.guava:guava:jar:14.0.1:provided
[INFO] |  +- com.googlecode.javaewah:JavaEWAH:jar:0.3.2:compile
[INFO] |  +- org.iq80.snappy:snappy:jar:0.2:compile
[INFO] |  +- org.json:json:jar:20090211:compile
[INFO] |  +- stax:stax-api:jar:1.0.1:compile
[INFO] |  +- net.sf.opencsv:opencsv:jar:2.3:compile
[INFO] |  \- (jline:jline:jar:2.12:compile - omitted for duplicate)
```
