### PR TITLE
[SPARK-13474][PROJECT INFRA] Update packaging scripts to push artifacts to home.apache.org

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -222,13 +222,13 @@ if [[ "$1" == "docs" ]]; then
   echo "Copying release documentation to $dest_dir"
   # Put to new directory:
   LFTP mkdir -p $dest_dir
-  LFTP mput -O $dest_dir '_site/*'
+  LFTP put -O $REMOTE_PARENT_DIR '_site' -o "${DEST_DIR_NAME}-docs"
   # Delete /latest directory and rename new upload to /latest
   LFTP "rm -r -f $REMOTE_PARENT_DIR/latest || exit 0"
   LFTP mv $dest_dir "$REMOTE_PARENT_DIR/latest"
   # Re-upload a second time and leave the files in the timestamped upload directory:
   LFTP mkdir -p $dest_dir
-  LFTP mput -O $dest_dir '_site/*'
+  LFTP put -O $REMOTE_PARENT_DIR '_site' -o "${DEST_DIR_NAME}-docs"
   cd ..
   exit 0
 fi

--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -102,7 +102,14 @@ fi
 DEST_DIR_NAME="spark-$SPARK_PACKAGE_VERSION"
 
 function LFTP {
-  COMMANDS="connect -u $ASF_USERNAME,p sftp://home.apache.org && $@"
+  SSH="ssh -o ConnectTimeout=300 -o StrictHostKeyChecking=no -i $ASF_RSA_KEY"
+  COMMANDS=$(cat <<'EOF'
+     set net:max-retries 1 &&
+     set sftp:connect-program $SSH &&
+     connect -u $ASF_USERNAME,p sftp://home.apache.org &&
+     $@
+EOF
+)
   lftp --norc -c "$COMMANDS"
 }
 export -f LFTP

--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -198,11 +198,15 @@ if [[ "$1" == "package" ]]; then
   # Copy data
   dest_dir="$REMOTE_PARENT_DIR/${DEST_DIR_NAME}-bin"
   echo "Copying release tarballs to $dest_dir"
+  # Put to new directory:
   LFTP mkdir -p $dest_dir
   LFTP mput -O $dest_dir spark-*
-  echo "Linking /latest to $dest_dir"
+  # Delete /latest directory and rename new upload to /latest
   LFTP rm -f "$REMOTE_PARENT_DIR/latest"
-  LFTP ln -s $dest_dir "$REMOTE_PARENT_DIR/latest"
+  LFTP mv $dest_dir "$REMOTE_PARENT_DIR/latest"
+  # Re-upload a second time and leave the files in the timestamped upload directory:
+  LFTP mkdir -p $dest_dir
+  LFTP mput -O $dest_dir spark-*
   exit 0
 fi
 
@@ -216,10 +220,14 @@ if [[ "$1" == "docs" ]]; then
   # TODO: Make configurable to add this: PRODUCTION=1
   PRODUCTION=1 RELEASE_VERSION="$SPARK_VERSION" jekyll build
   echo "Copying release documentation to $dest_dir"
+  # Put to new directory:
   LFTP mkdir -p $dest_dir
-  echo "Linking /latest to $dest_dir"
+  LFTP mput -O $dest_dir _site/*
+  # Delete /latest directory and rename new upload to /latest
   LFTP rm -f "$REMOTE_PARENT_DIR/latest"
-  LFTP ln -s $dest_dir "$REMOTE_PARENT_DIR/latest"
+  LFTP mv $dest_dir "$REMOTE_PARENT_DIR/latest"
+  # Re-upload a second time and leave the files in the timestamped upload directory:
+  LFTP mkdir -p $dest_dir
   LFTP mput -O $dest_dir _site/*
   cd ..
   exit 0

--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -102,7 +102,7 @@ fi
 DEST_DIR_NAME="spark-$SPARK_PACKAGE_VERSION"
 
 function LFTP {
-  COMMANDS="set sftp:auto-confirm true && connect -u $ASF_USERNAME,p sftp://home.apache.org && $@"
+  COMMANDS="connect -u $ASF_USERNAME,p sftp://home.apache.org && $@"
   lftp --norc -c "$COMMANDS"
 }
 export -f LFTP

--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -200,13 +200,13 @@ if [[ "$1" == "package" ]]; then
   echo "Copying release tarballs to $dest_dir"
   # Put to new directory:
   LFTP mkdir -p $dest_dir
-  LFTP mput -O $dest_dir spark-*
+  LFTP mput -O $dest_dir 'spark-*'
   # Delete /latest directory and rename new upload to /latest
   LFTP "rm -r -f $REMOTE_PARENT_DIR/latest && exit 0"
   LFTP mv $dest_dir "$REMOTE_PARENT_DIR/latest"
   # Re-upload a second time and leave the files in the timestamped upload directory:
   LFTP mkdir -p $dest_dir
-  LFTP mput -O $dest_dir spark-*
+  LFTP mput -O $dest_dir 'spark-*'
   exit 0
 fi
 
@@ -222,13 +222,13 @@ if [[ "$1" == "docs" ]]; then
   echo "Copying release documentation to $dest_dir"
   # Put to new directory:
   LFTP mkdir -p $dest_dir
-  LFTP mput -O $dest_dir _site/*
+  LFTP mput -O $dest_dir '_site/*'
   # Delete /latest directory and rename new upload to /latest
   LFTP "rm -r -f $REMOTE_PARENT_DIR/latest && exit 0"
   LFTP mv $dest_dir "$REMOTE_PARENT_DIR/latest"
   # Re-upload a second time and leave the files in the timestamped upload directory:
   LFTP mkdir -p $dest_dir
-  LFTP mput -O $dest_dir _site/*
+  LFTP mput -O $dest_dir '_site/*'
   cd ..
   exit 0
 fi

--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -222,13 +222,13 @@ if [[ "$1" == "docs" ]]; then
   echo "Copying release documentation to $dest_dir"
   # Put to new directory:
   LFTP mkdir -p $dest_dir
-  LFTP put -O $REMOTE_PARENT_DIR '_site' -o "${DEST_DIR_NAME}-docs"
+  LFTP mirror -R _site $dest_dir
   # Delete /latest directory and rename new upload to /latest
   LFTP "rm -r -f $REMOTE_PARENT_DIR/latest || exit 0"
   LFTP mv $dest_dir "$REMOTE_PARENT_DIR/latest"
   # Re-upload a second time and leave the files in the timestamped upload directory:
   LFTP mkdir -p $dest_dir
-  LFTP put -O $REMOTE_PARENT_DIR '_site' -o "${DEST_DIR_NAME}-docs"
+  LFTP mirror -R _site $dest_dir
   cd ..
   exit 0
 fi

--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -121,10 +121,14 @@ rm -rf .git
 cd ..
 
 if [ -n "$REMOTE_PARENT_MAX_LENGTH" ]; then
-  old_dirs=$(LFTP nlist $REMOTE_PARENT_DIR | sort | head -n +$REMOTE_PARENT_MAX_LENGTH)
+  old_dirs=$(
+    LFTP nlist $REMOTE_PARENT_DIR \
+        | grep -v "^\." \
+        | sort \
+        | tail -n +$REMOTE_PARENT_MAX_LENGTH)
   for old_dir in $old_dirs; do
     echo "Removing directory: $old_dir"
-    LFTP rm -r $REMOTE_PARENT_DIR/$old_dir
+    LFTP rm -rf $REMOTE_PARENT_DIR/$old_dir
   done
 fi
 

--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -103,7 +103,7 @@ DEST_DIR_NAME="spark-$SPARK_PACKAGE_VERSION"
 
 function LFTP {
   SSH="ssh -o ConnectTimeout=300 -o StrictHostKeyChecking=no -i $ASF_RSA_KEY"
-  COMMANDS=$(cat <<'EOF'
+  COMMANDS=$(cat <<EOF
      set net:max-retries 1 &&
      set sftp:connect-program $SSH &&
      connect -u $ASF_USERNAME,p sftp://home.apache.org &&

--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -124,7 +124,7 @@ if [ -n "$REMOTE_PARENT_MAX_LENGTH" ]; then
   old_dirs=$(
     LFTP nlist $REMOTE_PARENT_DIR \
         | grep -v "^\." \
-        | sort \
+        | sort -r \
         | tail -n +$REMOTE_PARENT_MAX_LENGTH)
   for old_dir in $old_dirs; do
     echo "Removing directory: $old_dir"

--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -23,8 +23,8 @@ usage: release-build.sh <package|docs|publish-snapshot|publish-release>
 Creates build deliverables from a Spark commit.
 
 Top level targets are
-  package: Create binary packages and copy them to people.apache
-  docs: Build docs and copy them to people.apache
+  package: Create binary packages and copy them to home.apache
+  docs: Build docs and copy them to home.apache
   publish-snapshot: Publish snapshot release to Apache snapshots
   publish-release: Publish a release to Apache release repo
 
@@ -64,13 +64,16 @@ for env in ASF_USERNAME ASF_RSA_KEY GPG_PASSPHRASE GPG_KEY; do
   fi
 done
 
+# Explicitly set locale in order to make `sort` output consistent across machines.
+# See https://stackoverflow.com/questions/28881 for more details.
+export LC_ALL=C
+
 # Commit ref to checkout when building
 GIT_REF=${GIT_REF:-master}
 
 # Destination directory parent on remote server
 REMOTE_PARENT_DIR=${REMOTE_PARENT_DIR:-/home/$ASF_USERNAME/public_html}
 
-SSH="ssh -o ConnectTimeout=300 -o StrictHostKeyChecking=no -i $ASF_RSA_KEY"
 GPG="gpg --no-tty --batch"
 NEXUS_ROOT=https://repository.apache.org/service/local/staging
 NEXUS_PROFILE=d63f592e7eac0 # Profile for Spark staging uploads
@@ -97,7 +100,13 @@ if [ -z "$SPARK_PACKAGE_VERSION" ]; then
 fi
 
 DEST_DIR_NAME="spark-$SPARK_PACKAGE_VERSION"
-USER_HOST="$ASF_USERNAME@people.apache.org"
+
+function LFTP {
+  COMMANDS="set sftp:auto-confirm true && connect -u $ASF_USERNAME,p sftp://home.apache.org && $@"
+  lftp --norc -c "$COMMANDS"
+}
+export -f LFTP
+
 
 git clean -d -f -x
 rm .gitignore
@@ -105,10 +114,10 @@ rm -rf .git
 cd ..
 
 if [ -n "$REMOTE_PARENT_MAX_LENGTH" ]; then
-  old_dirs=$($SSH $USER_HOST ls -t $REMOTE_PARENT_DIR | tail -n +$REMOTE_PARENT_MAX_LENGTH)
+  old_dirs=$(LFTP nlist $REMOTE_PARENT_DIR | sort | head -n +$REMOTE_PARENT_MAX_LENGTH)
   for old_dir in $old_dirs; do
     echo "Removing directory: $old_dir"
-    $SSH $USER_HOST rm -r $REMOTE_PARENT_DIR/$old_dir
+    LFTP rm -r $REMOTE_PARENT_DIR/$old_dir
   done
 fi
 
@@ -178,11 +187,11 @@ if [[ "$1" == "package" ]]; then
   # Copy data
   dest_dir="$REMOTE_PARENT_DIR/${DEST_DIR_NAME}-bin"
   echo "Copying release tarballs to $dest_dir"
-  $SSH $USER_HOST mkdir $dest_dir
-  rsync -e "$SSH" spark-* $USER_HOST:$dest_dir
+  LFTP mkdir -p $dest_dir
+  LFTP mput spark-* $dest_dir
   echo "Linking /latest to $dest_dir"
-  $SSH $USER_HOST rm -f "$REMOTE_PARENT_DIR/latest"
-  $SSH $USER_HOST ln -s $dest_dir "$REMOTE_PARENT_DIR/latest"
+  LFTP rm "$REMOTE_PARENT_DIR/latest"
+  LFTP ln -s $dest_dir "$REMOTE_PARENT_DIR/latest"
   exit 0
 fi
 
@@ -196,11 +205,11 @@ if [[ "$1" == "docs" ]]; then
   # TODO: Make configurable to add this: PRODUCTION=1
   PRODUCTION=1 RELEASE_VERSION="$SPARK_VERSION" jekyll build
   echo "Copying release documentation to $dest_dir"
-  $SSH $USER_HOST mkdir $dest_dir
+  LFTP mkdir -p $dest_dir
   echo "Linking /latest to $dest_dir"
-  $SSH $USER_HOST rm -f "$REMOTE_PARENT_DIR/latest"
-  $SSH $USER_HOST ln -s $dest_dir "$REMOTE_PARENT_DIR/latest"
-  rsync -e "$SSH" -r _site/* $USER_HOST:$dest_dir
+  LFTP rm "$REMOTE_PARENT_DIR/latest"
+  LFTP ln -s $dest_dir "$REMOTE_PARENT_DIR/latest"
+  LFTP mput _site/* $dest_dir
   cd ..
   exit 0
 fi

--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -128,7 +128,7 @@ if [ -n "$REMOTE_PARENT_MAX_LENGTH" ]; then
         | tail -n +$REMOTE_PARENT_MAX_LENGTH)
   for old_dir in $old_dirs; do
     echo "Removing directory: $old_dir"
-    LFTP rm -rf $REMOTE_PARENT_DIR/$old_dir
+    LFTP "rm -rf $REMOTE_PARENT_DIR/$old_dir && exit 0"
   done
 fi
 
@@ -198,17 +198,15 @@ if [[ "$1" == "package" ]]; then
   # Copy data
   dest_dir="$REMOTE_PARENT_DIR/${DEST_DIR_NAME}-bin"
   echo "Copying release tarballs to $dest_dir"
-  set -x
   # Put to new directory:
   LFTP mkdir -p $dest_dir
   LFTP mput -O $dest_dir spark-*
   # Delete /latest directory and rename new upload to /latest
-  LFTP rm -rf "$REMOTE_PARENT_DIR/latest"
+  LFTP "rm -r -f $REMOTE_PARENT_DIR/latest && exit 0"
   LFTP mv $dest_dir "$REMOTE_PARENT_DIR/latest"
   # Re-upload a second time and leave the files in the timestamped upload directory:
   LFTP mkdir -p $dest_dir
   LFTP mput -O $dest_dir spark-*
-  set +x
   exit 0
 fi
 
@@ -226,7 +224,7 @@ if [[ "$1" == "docs" ]]; then
   LFTP mkdir -p $dest_dir
   LFTP mput -O $dest_dir _site/*
   # Delete /latest directory and rename new upload to /latest
-  LFTP rm -rf "$REMOTE_PARENT_DIR/latest"
+  LFTP "rm -r -f $REMOTE_PARENT_DIR/latest && exit 0"
   LFTP mv $dest_dir "$REMOTE_PARENT_DIR/latest"
   # Re-upload a second time and leave the files in the timestamped upload directory:
   LFTP mkdir -p $dest_dir

--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -198,15 +198,17 @@ if [[ "$1" == "package" ]]; then
   # Copy data
   dest_dir="$REMOTE_PARENT_DIR/${DEST_DIR_NAME}-bin"
   echo "Copying release tarballs to $dest_dir"
+  set -x
   # Put to new directory:
   LFTP mkdir -p $dest_dir
   LFTP mput -O $dest_dir spark-*
   # Delete /latest directory and rename new upload to /latest
-  LFTP rm -f "$REMOTE_PARENT_DIR/latest"
+  LFTP rm -rf "$REMOTE_PARENT_DIR/latest"
   LFTP mv $dest_dir "$REMOTE_PARENT_DIR/latest"
   # Re-upload a second time and leave the files in the timestamped upload directory:
   LFTP mkdir -p $dest_dir
   LFTP mput -O $dest_dir spark-*
+  set +x
   exit 0
 fi
 
@@ -224,7 +226,7 @@ if [[ "$1" == "docs" ]]; then
   LFTP mkdir -p $dest_dir
   LFTP mput -O $dest_dir _site/*
   # Delete /latest directory and rename new upload to /latest
-  LFTP rm -f "$REMOTE_PARENT_DIR/latest"
+  LFTP rm -rf "$REMOTE_PARENT_DIR/latest"
   LFTP mv $dest_dir "$REMOTE_PARENT_DIR/latest"
   # Re-upload a second time and leave the files in the timestamped upload directory:
   LFTP mkdir -p $dest_dir

--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -197,7 +197,7 @@ if [[ "$1" == "package" ]]; then
   LFTP mkdir -p $dest_dir
   LFTP mput -O $dest_dir spark-*
   echo "Linking /latest to $dest_dir"
-  LFTP rm "$REMOTE_PARENT_DIR/latest"
+  LFTP rm -f "$REMOTE_PARENT_DIR/latest"
   LFTP ln -s $dest_dir "$REMOTE_PARENT_DIR/latest"
   exit 0
 fi
@@ -214,7 +214,7 @@ if [[ "$1" == "docs" ]]; then
   echo "Copying release documentation to $dest_dir"
   LFTP mkdir -p $dest_dir
   echo "Linking /latest to $dest_dir"
-  LFTP rm "$REMOTE_PARENT_DIR/latest"
+  LFTP rm -f "$REMOTE_PARENT_DIR/latest"
   LFTP ln -s $dest_dir "$REMOTE_PARENT_DIR/latest"
   LFTP mput -O $dest_dir _site/*
   cd ..

--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -202,7 +202,7 @@ if [[ "$1" == "package" ]]; then
   LFTP mkdir -p $dest_dir
   LFTP mput -O $dest_dir 'spark-*'
   # Delete /latest directory and rename new upload to /latest
-  LFTP "rm -r -f $REMOTE_PARENT_DIR/latest && exit 0"
+  LFTP "rm -r -f $REMOTE_PARENT_DIR/latest || exit 0"
   LFTP mv $dest_dir "$REMOTE_PARENT_DIR/latest"
   # Re-upload a second time and leave the files in the timestamped upload directory:
   LFTP mkdir -p $dest_dir
@@ -224,7 +224,7 @@ if [[ "$1" == "docs" ]]; then
   LFTP mkdir -p $dest_dir
   LFTP mput -O $dest_dir '_site/*'
   # Delete /latest directory and rename new upload to /latest
-  LFTP "rm -r -f $REMOTE_PARENT_DIR/latest && exit 0"
+  LFTP "rm -r -f $REMOTE_PARENT_DIR/latest || exit 0"
   LFTP mv $dest_dir "$REMOTE_PARENT_DIR/latest"
   # Re-upload a second time and leave the files in the timestamped upload directory:
   LFTP mkdir -p $dest_dir

--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -195,7 +195,7 @@ if [[ "$1" == "package" ]]; then
   dest_dir="$REMOTE_PARENT_DIR/${DEST_DIR_NAME}-bin"
   echo "Copying release tarballs to $dest_dir"
   LFTP mkdir -p $dest_dir
-  LFTP mput spark-* $dest_dir
+  LFTP mput -O $dest_dir spark-*
   echo "Linking /latest to $dest_dir"
   LFTP rm "$REMOTE_PARENT_DIR/latest"
   LFTP ln -s $dest_dir "$REMOTE_PARENT_DIR/latest"
@@ -216,7 +216,7 @@ if [[ "$1" == "docs" ]]; then
   echo "Linking /latest to $dest_dir"
   LFTP rm "$REMOTE_PARENT_DIR/latest"
   LFTP ln -s $dest_dir "$REMOTE_PARENT_DIR/latest"
-  LFTP mput _site/* $dest_dir
+  LFTP mput -O $dest_dir _site/*
   cd ..
   exit 0
 fi


### PR DESCRIPTION
Due to the people.apache.org -> home.apache.org migration, we need to update our packaging scripts to publish artifacts to the new server. Because the new server only supports sftp instead of ssh, we need to update the scripts to use lftp instead of ssh + rsync.
