### PR TITLE
[HOT] [TEST] Disable a Test that Requires Nested Union Support.

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/LogicalPlanToSQLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/LogicalPlanToSQLSuite.scala
@@ -130,7 +130,7 @@ class LogicalPlanToSQLSuite extends SQLBuilderTest with SQLTestUtils {
   // FROM (((SELECT  `t0`.`id` FROM `default`.`t0`)
   // UNION ALL (SELECT  `t0`.`id` FROM `default`.`t0`))
   // UNION ALL (SELECT  `t0`.`id` FROM `default`.`t0`)) AS u_1
-  test("three-child union") {
+  ignore("three-child union") {
     checkHiveQl(
       """
         |SELECT id FROM parquet_t0


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since "[SPARK-13321][SQL] Support nested UNION in parser" is reverted, we need to disable the test case that requires this PR. Thanks!

@rxin @yhuai @marmbrus 
## How was this patch tested?

N/A
