### PR TITLE
[Minor][SPARK-13482][Configuration]Make consistency of the configuraiton named  in TransportConf.

### DIFF
--- a/network/common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/network/common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -132,7 +132,8 @@ public class TransportConf {
    * memory mapping has high overhead for blocks close to or below the page size of the OS.
    */
   public int memoryMapBytes() {
-    return conf.getInt("spark.storage.memoryMapThreshold", 2 * 1024 * 1024);
+    return Ints.checkedCast(JavaUtils.byteStringAsBytes(
+      conf.get("spark.storage.memoryMapThreshold", "2m")));
   }
 
   /**


### PR DESCRIPTION
`spark.storage.memoryMapThreshold` has two kind of the value, one is 2_1024_1024 as integer and the other one is '2m' as string.
"2m" is recommanded in document but it will go wrong if the code goes into `TransportConf#memoryMapBytes`.

[Jira](https://issues.apache.org/jira/browse/SPARK-13482)
