### PR TITLE
[SPARK-13490] [ML] ML LinearRegression should cache standardization param value

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -277,8 +277,9 @@ class LinearRegression @Since("1.3.0") (@Since("1.3.0") override val uid: String
     val optimizer = if ($(elasticNetParam) == 0.0 || effectiveRegParam == 0.0) {
       new BreezeLBFGS[BDV[Double]]($(maxIter), 10, $(tol))
     } else {
+      val standardizationParam = $(standardization)
       def effectiveL1RegFun = (index: Int) => {
-        if ($(standardization)) {
+        if (standardizationParam) {
           effectiveL1RegParam
         } else {
           // If `standardization` is false, we still standardize the data


### PR DESCRIPTION
## What changes were proposed in this pull request?

Like #11027 for `LogisticRegression`, `LinearRegression` with L1 regularization should also cache the value of the `standardization` rather than re-fetching it from the `ParamMap` for every OWLQN iteration.
cc @srowen 
## How was this patch tested?

No extra tests are added. It should pass all existing tests. 
