### PR TITLE
[SPARK-13492][MESOS] Configurable Mesos framework webui URL.

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/historypage-template.html
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage-template.html
@@ -67,7 +67,7 @@
       <td class="rowGroupColumn"><span title="{{id}}"><a href="{{url}}">{{id}}</a></span></td>
       <td class="rowGroupColumn">{{name}}</td>
       {{#attempts}}
-      <td class="attemptIDSpan"><a href="/history/{{id}}/{{attemptId}}/">{{attemptId}}</a></td>
+      <td class="attemptIDSpan"><a href="history/{{id}}/{{attemptId}}/">{{attemptId}}</a></td>
       <td>{{startTime}}</td>
       <td>{{endTime}}</td>
       <td><span title="{{duration}}" class="durationClass">{{duration}}</span></td>

--- a/core/src/main/resources/org/apache/spark/ui/static/historypage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage.js
@@ -110,7 +110,7 @@ $(document).ready(function() {
     requestedIncomplete = getParameterByName("showIncomplete", searchString);
     requestedIncomplete = (requestedIncomplete == "true" ? true : false);
 
-    $.getJSON("/api/v1/applications", function(response,status,jqXHR) {
+    $.getJSON("api/v1/applications", function(response,status,jqXHR) {
       var array = [];
       var hasMultipleAttempts = false;
       for (i in response) {
@@ -139,9 +139,9 @@ $(document).ready(function() {
 
           var url = null
           if (maxAttemptId == null) {
-            url = "/history/" + id + "/"
+            url = "history/" + id + "/"
           } else {
-            url = "/history/" + id + "/" + maxAttemptId + "/"
+            url = "history/" + id + "/" + maxAttemptId + "/"
           }
 
           var app_clone = {"id" : id, "name" : name, "url" : url, "attempts" : [attempt]};
@@ -150,7 +150,7 @@ $(document).ready(function() {
       }
 
       var data = {"applications": array}
-      $.get("/static/historypage-template.html", function(template) {
+      $.get("static/historypage-template.html", function(template) {
         historySummary.append(Mustache.render($(template).filter("#history-summary-template").html(),data));
         var selector = "#history-summary-table";
         var conf = {

--- a/core/src/main/scala/org/apache/spark/deploy/mesos/MesosClusterDispatcher.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/mesos/MesosClusterDispatcher.scala
@@ -97,9 +97,6 @@ private[mesos] object MesosClusterDispatcher extends Logging {
     val dispatcherArgs = new MesosClusterDispatcherArguments(args, conf)
     conf.setMaster(dispatcherArgs.masterUrl)
     conf.setAppName(dispatcherArgs.name)
-    dispatcherArgs.webUiUrl.foreach { url =>
-      conf.set("spark.mesos.dispatcher.webui.url", url)
-    }
     dispatcherArgs.zookeeperUrl.foreach { z =>
       conf.set("spark.deploy.recoveryMode", "ZOOKEEPER")
       conf.set("spark.deploy.zookeeper.url", z)

--- a/core/src/main/scala/org/apache/spark/deploy/mesos/MesosClusterDispatcher.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/mesos/MesosClusterDispatcher.scala
@@ -73,7 +73,7 @@ private[mesos] class MesosClusterDispatcher(
 
   def start(): Unit = {
     webUi.bind()
-    scheduler.frameworkUrl = webUi.activeWebUiUrl
+    scheduler.frameworkUrl = conf.get("spark.mesos.dispatcher.webui.url", webUi.activeWebUiUrl)
     scheduler.start()
     server.start()
   }
@@ -97,6 +97,9 @@ private[mesos] object MesosClusterDispatcher extends Logging {
     val dispatcherArgs = new MesosClusterDispatcherArguments(args, conf)
     conf.setMaster(dispatcherArgs.masterUrl)
     conf.setAppName(dispatcherArgs.name)
+    dispatcherArgs.webUiUrl.foreach { url =>
+      conf.set("spark.mesos.dispatcher.webui.url", url)
+    }
     dispatcherArgs.zookeeperUrl.foreach { z =>
       conf.set("spark.deploy.recoveryMode", "ZOOKEEPER")
       conf.set("spark.deploy.zookeeper.url", z)

--- a/core/src/main/scala/org/apache/spark/deploy/mesos/MesosClusterDispatcherArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/mesos/MesosClusterDispatcherArguments.scala
@@ -28,7 +28,6 @@ private[mesos] class MesosClusterDispatcherArguments(args: Array[String], conf: 
   var port = 7077
   var name = "Spark Cluster"
   var webUiPort = 8081
-  var webUiUrl: Option[String] = None
   var masterUrl: String = _
   var zookeeperUrl: Option[String] = None
   var propertiesFile: String = _
@@ -39,10 +38,6 @@ private[mesos] class MesosClusterDispatcherArguments(args: Array[String], conf: 
 
   @tailrec
   private def parse(args: List[String]): Unit = args match {
-    case ("--webui-url") :: value :: tail =>
-      webUiUrl = Some(value)
-      parse(tail)
-
     case ("--host" | "-h") :: value :: tail =>
       Utils.checkHost(value, "Please use hostname " + value)
       host = value
@@ -103,9 +98,6 @@ private[mesos] class MesosClusterDispatcherArguments(args: Array[String], conf: 
         "  -h HOST, --host HOST    Hostname to listen on\n" +
         "  -p PORT, --port PORT    Port to listen on (default: 7077)\n" +
         "  --webui-port WEBUI_PORT WebUI Port to listen on (default: 8081)\n" +
-        "  --webui-url  WEBUI_URL  The WebUI URL to be set in the underlying\n" +
-        "                          scheduler driver. If unset it defaults\n" +
-        "                          to the dispatcher WebUI URL.\n" +
         "  --name NAME             Framework name to show in Mesos UI\n" +
         "  -m --master MASTER      URI for connecting to Mesos master\n" +
         "  -z --zk ZOOKEEPER       Comma delimited URLs for connecting to \n" +

--- a/core/src/main/scala/org/apache/spark/deploy/mesos/MesosClusterDispatcherArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/mesos/MesosClusterDispatcherArguments.scala
@@ -28,6 +28,7 @@ private[mesos] class MesosClusterDispatcherArguments(args: Array[String], conf: 
   var port = 7077
   var name = "Spark Cluster"
   var webUiPort = 8081
+  var webUiUrl: Option[String] = None
   var masterUrl: String = _
   var zookeeperUrl: Option[String] = None
   var propertiesFile: String = _
@@ -38,6 +39,10 @@ private[mesos] class MesosClusterDispatcherArguments(args: Array[String], conf: 
 
   @tailrec
   private def parse(args: List[String]): Unit = args match {
+    case ("--webui-url") :: value :: tail =>
+      webUiUrl = Some(value)
+      parse(tail)
+
     case ("--host" | "-h") :: value :: tail =>
       Utils.checkHost(value, "Please use hostname " + value)
       host = value
@@ -47,7 +52,7 @@ private[mesos] class MesosClusterDispatcherArguments(args: Array[String], conf: 
       port = value
       parse(tail)
 
-    case ("--webui-port" | "-p") :: IntParam(value) :: tail =>
+    case ("--webui-port") :: IntParam(value) :: tail =>
       webUiPort = value
       parse(tail)
 
@@ -98,6 +103,9 @@ private[mesos] class MesosClusterDispatcherArguments(args: Array[String], conf: 
         "  -h HOST, --host HOST    Hostname to listen on\n" +
         "  -p PORT, --port PORT    Port to listen on (default: 7077)\n" +
         "  --webui-port WEBUI_PORT WebUI Port to listen on (default: 8081)\n" +
+        "  --webui-url  WEBUI_URL  The WebUI URL to be set in the underlying\n" +
+        "                          scheduler driver. If unset it defaults\n" +
+        "                          to the dispatcher WebUI URL.\n" +
         "  --name NAME             Framework name to show in Mesos UI\n" +
         "  -m --master MASTER      URI for connecting to Mesos master\n" +
         "  -z --zk ZOOKEEPER       Comma delimited URLs for connecting to \n" +

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackend.scala
@@ -149,7 +149,8 @@ private[spark] class CoarseMesosSchedulerBackend(
       sc.sparkUser,
       sc.appName,
       sc.conf,
-      sc.ui.map(_.appUIAddress))
+      sc.conf.getOption("spark.mesos.driver.webui.url").orElse(sc.ui.map(_.appUIAddress))
+    )
     startScheduler(driver)
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosSchedulerBackend.scala
@@ -78,7 +78,8 @@ private[spark] class MesosSchedulerBackend(
       sc.sparkUser,
       sc.appName,
       sc.conf,
-      sc.ui.map(_.appUIAddress))
+      sc.conf.getOption("spark.mesos.driver.webui.url").orElse(sc.ui.map(_.appUIAddress))
+    )
     startScheduler(driver)
   }
 

--- a/core/src/test/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackendSuite.scala
@@ -316,6 +316,7 @@ class CoarseMesosSchedulerBackendSuite extends SparkFunSuite
       .setMaster("local[*]")
       .setAppName("test-mesos-dynamic-alloc")
       .setSparkHome("/path")
+      .set("spark.mesos.driver.webui.url", "http://webui")
 
     if (sparkConfVars != null) {
       for (attr <- sparkConfVars) {
@@ -333,5 +334,33 @@ class CoarseMesosSchedulerBackendSuite extends SparkFunSuite
     driverEndpoint = mock[RpcEndpointRef]
 
     backend = createSchedulerBackend(taskScheduler, driver, externalShuffleClient, driverEndpoint)
+  }
+
+  test("weburi is set in created scheduler driver") {
+    val taskScheduler = mock[TaskSchedulerImpl]
+    when(taskScheduler.sc).thenReturn(sc)
+    val driver = mock[SchedulerDriver]
+    when(driver.start()).thenReturn(Protos.Status.DRIVER_RUNNING)
+    val securityManager = mock[SecurityManager]
+
+    val backend = new CoarseMesosSchedulerBackend(taskScheduler, sc, "master", securityManager) {
+      override protected def createSchedulerDriver(
+        masterUrl: String,
+        scheduler: Scheduler,
+        sparkUser: String,
+        appName: String,
+        conf: SparkConf,
+        webuiUrl: Option[String] = None,
+        checkpoint: Option[Boolean] = None,
+        failoverTimeout: Option[Double] = None,
+        frameworkId: Option[String] = None): SchedulerDriver = {
+        markRegistered()
+        assert(webuiUrl.isDefined)
+        assert(webuiUrl.get.equals("http://webui"))
+        driver
+      }
+    }
+
+    backend.start()
   }
 }

--- a/core/src/test/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/cluster/mesos/CoarseMesosSchedulerBackendSuite.scala
@@ -218,15 +218,15 @@ class CoarseMesosSchedulerBackendSuite extends SparkFunSuite
 
     val backend = new CoarseMesosSchedulerBackend(taskScheduler, sc, "master", securityManager) {
       override protected def createSchedulerDriver(
-                                                    masterUrl: String,
-                                                    scheduler: Scheduler,
-                                                    sparkUser: String,
-                                                    appName: String,
-                                                    conf: SparkConf,
-                                                    webuiUrl: Option[String] = None,
-                                                    checkpoint: Option[Boolean] = None,
-                                                    failoverTimeout: Option[Double] = None,
-                                                    frameworkId: Option[String] = None): SchedulerDriver = {
+        masterUrl: String,
+        scheduler: Scheduler,
+        sparkUser: String,
+        appName: String,
+        conf: SparkConf,
+        webuiUrl: Option[String] = None,
+        checkpoint: Option[Boolean] = None,
+        failoverTimeout: Option[Double] = None,
+        frameworkId: Option[String] = None): SchedulerDriver = {
         markRegistered()
         assert(webuiUrl.isDefined)
         assert(webuiUrl.get.equals("http://webui"))

--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -390,6 +390,22 @@ See the [configuration page](configuration.html) for information on Spark config
     </ul>
   </td>
 </tr>
+<tr>
+  <td><code>spark.mesos.driver.webui.url</code></td>
+  <td><code>(none)</code></td>
+  <td>
+    Set the Spark Mesos driver webui_url for interacting with the framework.
+    If unset it will point to Spark's internal web UI.
+  </td>
+</tr>
+<tr>
+  <td><code>spark.mesos.dispatcher.webui.url</code></td>
+  <td><code>(none)</code></td>
+  <td>
+    Set the Spark Mesos dispatcher webui_url for interacting with the framework.
+    If unset it will point to Spark's internal web UI.
+  </td>
+</tr>
 </table>
 
 # Troubleshooting and Debugging


### PR DESCRIPTION
## What changes were proposed in this pull request?

Previously the Mesos framework webui URL was being derived only from the Spark UI address leaving no possibility to configure it. This commit makes it configurable. If unset it falls back to the previous behavior.

Motivation:
This change is necessary in order to be able to install Spark on DCOS and to be able to give it a custom service link. The configured `webui_url` is configured to point to a reverse proxy in the DCOS environment.
## How was this patch tested?

Locally, using unit tests and on DCOS testing and stable revision.
