### PR TITLE
[SPARK-13484][SQL] Prevent illegal NULL propagation when filtering outer-join results

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1473,7 +1473,7 @@ class Analyzer(
         q.transform {
           case f @ Filter(filterCondition, j @ Join(_, _, _, _)) =>
             val joinOutput = new ArrayBuffer[(Attribute, Attribute)]
-            j.output.map {
+            j.output.foreach {
               case a: AttributeReference => joinOutput += ((a, a))
             }
             val joinOutputMap = AttributeMap(joinOutput)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -631,6 +631,10 @@ class Analyzer(
             ExtractValue(child, fieldExpr, resolver)
         }
 
+        // Replaces attribute references in a filter if it has a join as a child and it references
+        // some columns on the base relations of the join. This is because outer joins change
+        // nullability on columns and this could cause wrong NULL propagation in Optimizer.
+        // See SPARK-13484 for the concrete query of this case.
         resolvedPlan.transform {
           case f @ Filter(filterCondition, j @ Join(_, _, _, _)) =>
             val joinOutput = new ArrayBuffer[(Attribute, Attribute)]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -181,6 +181,23 @@ object ExtractFiltersAndInnerJoins extends PredicateHelper {
   }
 }
 
+/**
+ * An extractor for join output attributes directly under a given operator.
+ */
+object ExtractJoinOutputAttributes {
+
+  def unapply(plan: LogicalPlan): Option[(Join, AttributeMap[Attribute])] = {
+    plan.collectFirst {
+      case j: Join => j
+    }.map { join =>
+      val joinOutput = new mutable.ArrayBuffer[(Attribute, Attribute)]
+      join.output.foreach {
+        case a: AttributeReference => joinOutput += ((a, a))
+      }
+      (join, AttributeMap(joinOutput))
+    }
+  }
+}
 
 /**
  * A pattern that collects all adjacent unions and returns their children as a Seq.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveNaturalJoinSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveNaturalJoinSuite.scala
@@ -100,7 +100,7 @@ class ResolveNaturalJoinSuite extends AnalysisTest {
     val naturalPlan = r3.join(r4, NaturalJoin(FullOuter), None)
     val usingPlan = r3.join(r4, UsingJoin(FullOuter, Seq(UnresolvedAttribute("b"))), None)
     val expected = r3.join(r4, FullOuter, Some(EqualTo(bNotNull, bNotNull))).select(
-      Alias(Coalesce(Seq(bNotNull, bNotNull)), "b")(), a, c)
+      Alias(Coalesce(Seq(b, b)), "b")(), a, c)
     checkAnalysis(naturalPlan, expected)
     checkAnalysis(usingPlan, expected)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
@@ -205,7 +205,8 @@ class DataFrameJoinSuite extends QueryTest with SharedSQLContext {
       Row(1, 2, "1", 1, 3, "1") :: Nil)
   }
 
-  test("filter outer join results using a non-nullable column from a right table") {
+  test("process outer join results using the non-nullable columns in the join input") {
+    // Filter data using a non-nullable column from a right table
     val df1 = Seq((0, 0), (1, 0), (2, 0), (3, 0), (4, 0)).toDF("id", "count")
     val df2 = Seq(Tuple1(0), Tuple1(1)).toDF("id").groupBy("id").count
     checkAnswer(
@@ -213,6 +214,15 @@ class DataFrameJoinSuite extends QueryTest with SharedSQLContext {
       Row(2, 0, null, null) ::
       Row(3, 0, null, null) ::
       Row(4, 0, null, null) :: Nil
+    )
+
+    // Coalesce data using non-nullable columns in input tables
+    val df3 = Seq((1, 1)).toDF("a", "b")
+    val df4 = Seq((2, 2)).toDF("a", "b")
+    checkAnswer(
+      df3.join(df4, df3("a") === df4("a"), "outer")
+        .select(coalesce(df3("a"), df3("b")), coalesce(df4("a"), df4("b"))),
+      Row(1, null) :: Row(null, 2) :: Nil
     )
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
@@ -204,4 +204,15 @@ class DataFrameJoinSuite extends QueryTest with SharedSQLContext {
       leftJoin2Inner,
       Row(1, 2, "1", 1, 3, "1") :: Nil)
   }
+
+  test("filter outer join results using a non-nullable column from a right table") {
+    val df1 = Seq((0, 0), (1, 0), (2, 0), (3, 0), (4, 0)).toDF("id", "count")
+    val df2 = Seq(Tuple1(0), Tuple1(1)).toDF("id").groupBy("id").count
+    checkAnswer(
+      df1.join(df2, df1("id") === df2("id"), "left_outer").filter(df2("count").isNull),
+      Row(2, 0, null, null) ::
+      Row(3, 0, null, null) ::
+      Row(4, 0, null, null) :: Nil
+    )
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr is to prevent illegal NULL propagation in the query below;

```
val a = sqlContext.range(10).select(col("id"), lit(0).as("count"))
val b = sqlContext.range(10).select((col("id") % 3).as("id")).groupBy("id").count()
a.join(b, a("id") === b("id"), "left_outer").filter(b("count").isNull)
```

It returns nothing because `b("count")` is not nullable and the filter condition is always false by `Optimizer`.
## How was this patch tested?

Added a test for the query above in `DataFrameJoinSuite`.
