### PR TITLE
[SPARK-13450][SQL] External spilling when join a lot of rows with the same key

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyArrayBuffer.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyArrayBuffer.scala
@@ -1,0 +1,344 @@
+package org.apache.spark.util.collection
+
+import java.io._
+import java.util.Comparator
+
+import scala.collection.BufferedIterator
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+import scala.reflect.ClassTag
+
+import com.google.common.io.ByteStreams
+
+import org.apache.spark.{Logging, SparkEnv, TaskContext}
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.memory.TaskMemoryManager
+import org.apache.spark.serializer.{DeserializationStream, Serializer}
+import org.apache.spark.storage.{BlockId, BlockManager}
+import org.apache.spark.util.CompletionIterator
+import org.apache.spark.util.collection.ExternalAppendOnlyMap.HashComparator
+import org.apache.spark.executor.ShuffleWriteMetrics
+
+class ExternalAppendOnlyArrayBuffer[T: ClassTag](
+    serializer: Serializer = SparkEnv.get.serializer,
+    blockManager: BlockManager = SparkEnv.get.blockManager,
+    context: TaskContext = TaskContext.get())
+  extends Iterable[T]
+  with Serializable
+  with Logging
+  with Spillable[SizeTracker] {
+  if (context == null) {
+    throw new IllegalStateException(
+      "Spillable collections should not be instantiated outside of tasks")
+  }
+
+  private var currentArray = new SizeTrackingVector[T]
+  private var spilledArrays = new ArrayBuffer[DiskArrayIterator]
+  private val arrayBuffered: ArrayBuffer[T] = new ArrayBuffer[T]
+  private val sparkConf = SparkEnv.get.conf
+  private val diskBlockManager = blockManager.diskBlockManager
+
+  private val serializerBatchSize = sparkConf.getLong("spark.shuffle.spill.batchSize", 10000)
+  private val cacheSizeInArrayBuffer = sparkConf.getInt("spark.cache.array.size", 10000)
+
+  // Number of bytes spilled in total
+  private var _diskBytesSpilled = 0L
+  def diskBytesSpilled: Long = _diskBytesSpilled
+
+  // Write metrics for current spill
+  private var curWriteMetrics: ShuffleWriteMetrics = _
+  private var _size: Int = 0
+  private var _getsize: Int = 0
+
+  // Use getSizeAsKb (not bytes) to maintain backwards compatibility if no units are provided
+  private val fileBufferSize =
+    sparkConf.getSizeAsKb("spark.shuffle.file.buffer", "32k").toInt * 1024
+
+  private val ser = serializer.newInstance()
+
+  def length: Int = _size
+
+  override def reset(): Unit = {
+    logDebug("Reset:" + spilledArrays.length + " currentArray.size:" + currentArray.size)
+    super.reset()
+    if (spilledArrays.length > 0) {
+      _diskBytesSpilled = 0
+      spilledArrays.map(iter => iter.deleteTmpFile)
+      spilledArrays = new ArrayBuffer[DiskArrayIterator]
+    }
+    if (currentArray.size > 0) {
+      currentArray = new SizeTrackingVector[T]
+    }
+    _size = 0
+    arrayBuffered.clear
+    releaseMemory()
+  }
+
+  override protected[this] def taskMemoryManager: TaskMemoryManager = context.taskMemoryManager()
+
+  def +=(elem: T): Unit = {
+    _size += 1
+    addElementsRead()
+    if (_size < cacheSizeInArrayBuffer) {
+      arrayBuffered += elem
+      return
+    }
+    if (arrayBuffered.length > 0) {
+      val iter = arrayBuffered.iterator
+      while(iter.hasNext) {
+        currentArray += iter.next
+      }
+      arrayBuffered.clear
+    }
+    if(currentArray.length % 100000 == 0) {
+      logInfo("currentArray.len:" + currentArray.length)
+    }
+    val estimatedSize = currentArray.estimateSize()
+    if (maybeSpill(currentArray, estimatedSize)) {
+      currentArray = new SizeTrackingVector[T]
+    }
+    currentArray += elem
+  }
+
+  override protected[this] def spill(collection: SizeTracker): Unit = {
+    val (blockId, file) = diskBlockManager.createTempLocalBlock()
+    logInfo("Spill len:" + currentArray.length + " file:" + file)
+    curWriteMetrics = new ShuffleWriteMetrics()
+    var writer = blockManager.getDiskWriter(blockId, file, ser, fileBufferSize, curWriteMetrics)
+    var objectsWritten = 0
+
+    val batchSizes = new ArrayBuffer[Long]
+
+    // Flush the disk writer's contents to disk, and update relevant variables
+    def flush(): Unit = {
+      val w = writer
+      writer = null
+      w.commitAndClose()
+      _diskBytesSpilled += curWriteMetrics.shuffleBytesWritten
+      batchSizes.append(curWriteMetrics.shuffleBytesWritten)
+      objectsWritten = 0
+    }
+
+    var success = false
+    try {
+      val it = currentArray.iterator
+      while (it.hasNext) {
+        val elem = it.next()
+        writer.write(null, elem)
+        objectsWritten += 1
+
+        if (objectsWritten == serializerBatchSize) {
+          flush()
+          curWriteMetrics = new ShuffleWriteMetrics()
+          writer = blockManager.getDiskWriter(blockId, file, ser, fileBufferSize, curWriteMetrics)
+        }
+      }
+      if (objectsWritten > 0) {
+        flush()
+      } else if (writer != null) {
+        val w = writer
+        writer = null
+        w.revertPartialWritesAndClose()
+      }
+      success = true
+    } finally {
+      if (!success) {
+        // This code path only happens if an exception was thrown above before we set success;
+        // close our stuff and let the exception be thrown further
+        if (writer != null) {
+          writer.revertPartialWritesAndClose()
+        }
+        if (file.exists()) {
+          if (!file.delete()) {
+            logWarning(s"Error deleting ${file}")
+          }
+        }
+      }
+    }
+    spilledArrays.append(new DiskArrayIterator(file, blockId, batchSizes))
+  }
+
+  override def iterator: Iterator[T] = {
+    logInfo("Match size:" + _size)
+    if (_size < cacheSizeInArrayBuffer) {
+      arrayBuffered.iterator
+    } else if (0 == spilledArrays.length) {
+      currentArray.iterator
+    } else {
+      new ExternalIterator()
+    }
+  }
+
+  private class ExternalIterator extends Iterator[T] {
+
+    var currentIndex = 0
+    var currentIter = spilledArrays(currentIndex)
+    val arrayIter = currentArray.iterator
+    override def hasNext: Boolean = {
+      if (currentIter.hasNext) {
+        return true
+      } else if (currentIndex < spilledArrays.length - 1) {
+        currentIndex += 1
+        currentIter = spilledArrays(currentIndex)
+        return true
+      } else {
+        arrayIter.hasNext
+      }
+    }
+
+    override def next(): T = {
+      _getsize += 1
+      if (currentIter.hasNext) {
+        val tmp: T = currentIter.next
+        if (_getsize % 100000 == 0) {
+          logInfo("Getsize" + currentIndex + ":" + _getsize)
+        }
+        tmp
+      } else if (currentIndex < spilledArrays.length - 1) {
+        currentIndex += 1
+        currentIter = spilledArrays(currentIndex)
+        _getsize = 0
+        val tmp: T = currentIter.next
+        if (_getsize % 100000 == 0) {
+          logInfo("Getsize" + currentIndex + ":" + _getsize)
+        }
+        tmp
+      } else {
+        val tmp: T = arrayIter.next
+        if (_getsize % 100000 == 0) {
+          logInfo("Getsize array:" + _getsize)
+        }
+        tmp
+      }
+    }
+  }
+
+  private class DiskArrayIterator(file: File, blockId: BlockId, batchSizes: ArrayBuffer[Long])
+    extends Iterator[T] {
+
+    private val batchOffsets = batchSizes.scanLeft(0L)(_ + _)  // Size will be batchSize.length + 1
+    logDebug("BatchOffsets:" + batchOffsets.length + " file.length():" + file.length()
+        + " batchOffsets.last:" + batchOffsets.last)
+    assert(file.length() == batchOffsets.last,
+      "File length is not equal to the last batch offset:\n" +
+      s"    file length = ${file.length}\n" +
+      s"    last batch offset = ${batchOffsets.last}\n" +
+      s"    all batch offsets = ${batchOffsets.mkString(",")}"
+    )
+
+    private var batchIndex = 0  // Which batch we're in
+    private var fileStream: FileInputStream = null
+
+    // An intermediate stream that reads from exactly one batch
+    // This guards against pre-fetching and other arbitrary behavior of higher level streams
+    private var deserializeStream = nextBatchStream()
+    private var itemIsNull = true
+    private var nextItem: T = _
+    private var objectsRead = 0
+
+    /**
+     * Construct a stream that reads only from the next batch.
+     */
+    private def nextBatchStream(): DeserializationStream = {
+      // Note that batchOffsets.length = numBatches + 1 since we did a scan above; check whether
+      // we're still in a valid batch.
+      if (batchIndex < batchOffsets.length - 1) {
+        if (deserializeStream != null) {
+          deserializeStream.close()
+          fileStream.close()
+          deserializeStream = null
+          fileStream = null
+        }
+
+        val start = batchOffsets(batchIndex)
+        fileStream = new FileInputStream(file)
+        fileStream.getChannel.position(start)
+        batchIndex += 1
+
+        val end = batchOffsets(batchIndex)
+
+        assert(end >= start, "start = " + start + ", end = " + end +
+          ", batchOffsets = " + batchOffsets.mkString("[", ", ", "]"))
+
+        val bufferedStream = new BufferedInputStream(ByteStreams.limit(fileStream, end - start))
+        val compressedStream = blockManager.wrapForCompression(blockId, bufferedStream)
+        ser.deserializeStream(compressedStream)
+      } else {
+        // No more batches left
+        cleanup(false)
+        null
+      }
+    }
+
+    /**
+     * Return the next T pair from the deserialization stream.
+     *
+     * If the current batch is drained, construct a stream for the next batch and read from it.
+     * If no more element are left, return null.
+     */
+    private def readNextItem(): T = {
+      try {
+        val k = deserializeStream.readKey()
+        val c = deserializeStream.readValue().asInstanceOf[T]
+        objectsRead += 1
+        if (objectsRead == serializerBatchSize) {
+          objectsRead = 0
+          deserializeStream = nextBatchStream()
+        }
+        itemIsNull = false
+        c
+      } catch {
+        case e: EOFException =>
+          e.printStackTrace()
+          cleanup(false)
+          itemIsNull = true
+          nextItem
+      }
+    }
+
+    override def hasNext: Boolean = {
+      if (itemIsNull) {
+        if (deserializeStream == null) {
+          return false
+        }
+        nextItem = readNextItem()
+      }
+      !itemIsNull
+    }
+
+    override def next(): T = {
+      val item = if (itemIsNull) readNextItem() else nextItem
+      if (itemIsNull) {
+        throw new NoSuchElementException
+      }
+      itemIsNull = true
+      item
+    }
+
+    private def cleanup(deleteFile: Boolean) {
+      batchIndex = batchOffsets.length  // Prevent reading any other batch
+      val ds = deserializeStream
+      if (ds != null) {
+        ds.close()
+        deserializeStream = null
+      }
+      if (fileStream != null) {
+        fileStream.close()
+        fileStream = null
+      }
+      if (deleteFile) {
+        deleteTmpFile
+      }
+    }
+
+    def deleteTmpFile() {
+      if (file.exists()) {
+        if (!file.delete()) {
+          logWarning(s"Error deleting ${file}")
+        }
+      }
+    }
+
+    context.addTaskCompletionListener(context => cleanup(true))
+  }
+}

--- a/core/src/main/scala/org/apache/spark/util/collection/Spillable.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/Spillable.scala
@@ -65,6 +65,14 @@ private[spark] trait Spillable[C] extends Logging {
   // Number of spills
   private[this] var _spillCount = 0
 
+  protected def reset(): Unit = {
+    releaseMemory()
+    //myMemoryThreshold = initialMemoryThreshold
+    _elementsRead = 0
+    _memoryBytesSpilled = 0L
+    _spillCount = 0
+  }
+
   /**
    * Spills the current in-memory collection to disk if needed. Attempts to acquire more
    * memory before spilling.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoin.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCo
 import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.execution.{BinaryNode, CodegenSupport, RowIterator, SparkPlan}
 import org.apache.spark.sql.execution.metric.SQLMetrics
+import org.apache.spark.util.collection.ExternalAppendOnlyArrayBuffer
 
 /**
  * Performs an sort merge join of two child relations.
@@ -79,7 +80,7 @@ case class SortMergeJoin(
         // An ordering that can be used to compare keys from both sides.
         private[this] val keyOrdering = newNaturalAscendingOrdering(leftKeys.map(_.dataType))
         private[this] var currentLeftRow: InternalRow = _
-        private[this] var currentRightMatches: ArrayBuffer[InternalRow] = _
+        private[this] var currentRightMatchesIter: Iterator[InternalRow] = _
         private[this] var currentMatchIdx: Int = -1
         private[this] val smjScanner = new SortMergeJoinScanner(
           leftKeyGenerator,
@@ -88,6 +89,8 @@ case class SortMergeJoin(
           RowIterator.fromScala(leftIter),
           RowIterator.fromScala(rightIter)
         )
+        private[this] var currentRightMatches: ExternalAppendOnlyArrayBuffer[InternalRow] =
+          smjScanner.getBufferedMatches
         private[this] val joinRow = new JoinedRow
         private[this] val resultProjection: (InternalRow) => InternalRow =
           UnsafeProjection.create(schema)
@@ -103,6 +106,7 @@ case class SortMergeJoin(
             if (currentMatchIdx == currentRightMatches.length) {
               if (smjScanner.findNextInnerJoinRows()) {
                 currentRightMatches = smjScanner.getBufferedMatches
+                currentRightMatchesIter = currentRightMatches.iterator
                 currentLeftRow = smjScanner.getStreamedRow
                 currentMatchIdx = 0
               } else {
@@ -112,7 +116,7 @@ case class SortMergeJoin(
                 return false
               }
             }
-            joinRow(currentLeftRow, currentRightMatches(currentMatchIdx))
+            joinRow(currentLeftRow, currentRightMatchesIter.next)
             currentMatchIdx += 1
             if (boundCondition(joinRow)) {
               numOutputRows += 1
@@ -403,7 +407,8 @@ private[joins] class SortMergeJoinScanner(
    */
   private[this] var matchJoinKey: InternalRow = _
   /** Buffered rows from the buffered side of the join. This is empty if there are no matches. */
-  private[this] val bufferedMatches: ArrayBuffer[InternalRow] = new ArrayBuffer[InternalRow]
+  private[this] val bufferedMatches: ExternalAppendOnlyArrayBuffer[InternalRow] =
+    new ExternalAppendOnlyArrayBuffer[InternalRow]
 
   // Initialization (note: do _not_ want to advance streamed here).
   advancedBufferedToRowWithNullFreeJoinKey()
@@ -412,7 +417,7 @@ private[joins] class SortMergeJoinScanner(
 
   def getStreamedRow: InternalRow = streamedRow
 
-  def getBufferedMatches: ArrayBuffer[InternalRow] = bufferedMatches
+  def getBufferedMatches: ExternalAppendOnlyArrayBuffer[InternalRow] = bufferedMatches
 
   /**
    * Advances both input iterators, stopping when we have found rows with matching join keys.
@@ -428,7 +433,7 @@ private[joins] class SortMergeJoinScanner(
     if (streamedRow == null) {
       // We have consumed the entire streamed iterator, so there can be no more matches.
       matchJoinKey = null
-      bufferedMatches.clear()
+      bufferedMatches.reset()
       false
     } else if (matchJoinKey != null && keyOrdering.compare(streamedRowKey, matchJoinKey) == 0) {
       // The new streamed row has the same join key as the previous row, so return the same matches.
@@ -437,7 +442,7 @@ private[joins] class SortMergeJoinScanner(
       // The streamed row's join key does not match the current batch of buffered rows and there are
       // no more rows to read from the buffered iterator, so there can be no more matches.
       matchJoinKey = null
-      bufferedMatches.clear()
+      bufferedMatches.reset()
       false
     } else {
       // Advance both the streamed and buffered iterators to find the next pair of matching rows.
@@ -455,7 +460,7 @@ private[joins] class SortMergeJoinScanner(
       if (streamedRow == null || bufferedRow == null) {
         // We have either hit the end of one of the iterators, so there can be no more matches.
         matchJoinKey = null
-        bufferedMatches.clear()
+        bufferedMatches.reset()
         false
       } else {
         // The streamed row's join key matches the current buffered row's join, so walk through the
@@ -478,7 +483,7 @@ private[joins] class SortMergeJoinScanner(
     if (!advancedStreamed()) {
       // We have consumed the entire streamed iterator, so there can be no more matches.
       matchJoinKey = null
-      bufferedMatches.clear()
+      bufferedMatches.reset()
       false
     } else {
       if (matchJoinKey != null && keyOrdering.compare(streamedRowKey, matchJoinKey) == 0) {
@@ -486,7 +491,7 @@ private[joins] class SortMergeJoinScanner(
       } else {
         // The streamed row does not match the current group.
         matchJoinKey = null
-        bufferedMatches.clear()
+        bufferedMatches.reset()
         if (bufferedRow != null && !streamedRowKey.anyNull) {
           // The buffered iterator could still contain matching rows, so we'll need to walk through
           // it until we either find matches or pass where they would be found.
@@ -556,7 +561,7 @@ private[joins] class SortMergeJoinScanner(
     assert(keyOrdering.compare(streamedRowKey, bufferedRowKey) == 0)
     // This join key may have been produced by a mutable projection, so we need to make a copy:
     matchJoinKey = streamedRowKey.copy()
-    bufferedMatches.clear()
+    bufferedMatches.reset()
     do {
       bufferedMatches += bufferedRow.copy() // need to copy mutable rows before buffering them
       advancedBufferedToRowWithNullFreeJoinKey()


### PR DESCRIPTION
  SortMergeJoin use a ArrayBuffer[InternalRow] to store bufferedMatches, if the join have a lot of rows with the same key, it will throw OutOfMemoryError.
  Add a ExternalAppendOnlyArrayBuffer to store bufferedMatches instand of ArrayBuffer.
