### PR TITLE
[MINOR][SQL] Fix modifier order.

### DIFF
--- a/common/sketch/src/main/java/org/apache/spark/util/sketch/CountMinSketch.java
+++ b/common/sketch/src/main/java/org/apache/spark/util/sketch/CountMinSketch.java
@@ -50,7 +50,7 @@ import java.io.OutputStream;
  *
  * This implementation is largely based on the {@code CountMinSketch} class from stream-lib.
  */
-abstract public class CountMinSketch {
+public abstract class CountMinSketch {
 
   public enum Version {
     /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fixes the order of modifier from `abstract public` into `public abstract`.
Currently, when we run `./dev/lint-java`, it shows the error.

```
Checkstyle checks failed at following occurrences:
[ERROR] src/main/java/org/apache/spark/util/sketch/CountMinSketch.java:[53,10] (modifier) ModifierOrder: 'public' modifier out of order with the JLS suggestions.
```
## How was this patch tested?

```
$ ./dev/lint-java
Checkstyle checks passed.
```
