### PR TITLE
Branch 1.6  - Kafka receivers with white/black list topic filter

### DIFF
--- a/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaInputDStream.scala
+++ b/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaInputDStream.scala
@@ -52,15 +52,14 @@ class KafkaInputDStream[
     kafkaParams: Map[String, String],
     topics: Map[String, Int],
     useReliableReceiver: Boolean,
-    storageLevel: StorageLevel,
-    useWhiteListTopicFilter: Boolean = false
+    storageLevel: StorageLevel
   ) extends ReceiverInputDStream[(K, V)](ssc_) with Logging {
 
   def getReceiver(): Receiver[(K, V)] = {
     if (!useReliableReceiver) {
-      new KafkaReceiver[K, V, U, T](kafkaParams, topics, storageLevel, useWhiteListTopicFilter)
+      new KafkaReceiver[K, V, U, T](kafkaParams, topics, storageLevel)
     } else {
-      new ReliableKafkaReceiver[K, V, U, T](kafkaParams, topics, storageLevel, useWhiteListTopicFilter)
+      new ReliableKafkaReceiver[K, V, U, T](kafkaParams, topics, storageLevel)
     }
   }
 }

--- a/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaInputDStream.scala
+++ b/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaInputDStream.scala
@@ -50,7 +50,7 @@ class KafkaInputDStream[
   T <: Decoder[_]: ClassTag](
     ssc_ : StreamingContext,
     kafkaParams: Map[String, String],
-    topics: Map[String, Int],
+    topics: KafkaTopicFilter,
     useReliableReceiver: Boolean,
     storageLevel: StorageLevel
   ) extends ReceiverInputDStream[(K, V)](ssc_) with Logging {

--- a/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaReceiver.scala
+++ b/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaReceiver.scala
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.streaming.kafka
+
+import java.util.Properties
+import java.util.concurrent.{ConcurrentHashMap, ThreadPoolExecutor}
+
+import kafka.consumer._
+import kafka.serializer.Decoder
+import kafka.utils.{VerifiableProperties, ZKGroupTopicDirs, ZKStringSerializer, ZkUtils}
+import org.apache.spark.storage.{StorageLevel, StreamBlockId}
+import org.apache.spark.streaming.receiver.{BlockGenerator, BlockGeneratorListener, Receiver}
+import org.apache.spark.util.ThreadUtils
+import org.apache.spark.{Logging, SparkEnv}
+
+import scala.collection.{Map, mutable}
+import scala.reflect.{ClassTag, classTag}
+
+/**
+  * KafkaReceiver.
+  */
+private[streaming]
+class KafkaReceiver[
+  K: ClassTag,
+  V: ClassTag,
+  U <: Decoder[_] : ClassTag,
+  T <: Decoder[_] : ClassTag](
+     kafkaParams: Map[String, String],
+     topics: Map[String, Int],
+     storageLevel: StorageLevel,
+     useWhiteListTopicFilter: Boolean = false
+   ) extends Receiver[(K, V)](storageLevel) with Logging {
+
+  // Connection to Kafka
+  var consumerConnector: ConsumerConnector = null
+
+  def onStop() {
+    if (consumerConnector != null) {
+      consumerConnector.shutdown()
+      consumerConnector = null
+    }
+  }
+
+  def onStart() {
+
+    logInfo("Starting Kafka Consumer Stream with group: " + kafkaParams("group.id"))
+
+    // Kafka connection properties
+    val props = new Properties()
+    kafkaParams.foreach(param => props.put(param._1, param._2))
+
+    val zkConnect = kafkaParams("zookeeper.connect")
+    // Create the connection to the cluster
+    logInfo("Connecting to Zookeeper: " + zkConnect)
+    val consumerConfig = new ConsumerConfig(props)
+    consumerConnector = Consumer.create(consumerConfig)
+    logInfo("Connected to " + zkConnect)
+
+    val keyDecoder = classTag[U].runtimeClass.getConstructor(classOf[VerifiableProperties])
+      .newInstance(consumerConfig.props)
+      .asInstanceOf[Decoder[K]]
+
+    val valueDecoder = classTag[T].runtimeClass.getConstructor(classOf[VerifiableProperties])
+      .newInstance(consumerConfig.props)
+      .asInstanceOf[Decoder[V]]
+
+    val messageHandlerThreadPool =
+      ThreadUtils.newDaemonFixedThreadPool(topics.values.sum, "KafkaMessageHandler")
+
+    try {
+      createMessageHandlers(keyDecoder, valueDecoder).foreach(messageHandlerThreadPool.submit)
+    } finally {
+      // Just causes threads to terminate after work is done
+      messageHandlerThreadPool.shutdown()
+    }
+  }
+
+  private def createMessageHandlers(
+      keyDecoder: Decoder[K], valueDecoder: Decoder[V]) : Iterable[MessageHandler] = {
+    if (!useWhiteListTopicFilter) {
+      val topicMessageStreams = consumerConnector.createMessageStreams(
+        topics, keyDecoder, valueDecoder)
+
+      topicMessageStreams.values.flatten { streams =>
+        streams.map { stream =>
+          new MessageHandler(stream)
+        }
+      }
+    } else {
+      val topicsHeadOption = topics.headOption
+      assert(topicsHeadOption.isDefined)
+
+      val topicsHead = topicsHeadOption.get
+      val topicFilter = Whitelist(topicsHead._1);
+
+      val topicMessageStreams = consumerConnector.createMessageStreamsByFilter(
+        topicFilter, topicsHead._2, keyDecoder, valueDecoder)
+
+      topicMessageStreams.map { stream =>
+        new MessageHandler(stream)
+      }
+    }
+  }
+
+  // Handles Kafka messages
+  private class MessageHandler(stream: KafkaStream[K, V])
+    extends Runnable {
+    def run() {
+      logInfo("Starting MessageHandler.")
+      try {
+        val streamIterator = stream.iterator()
+        while (streamIterator.hasNext()) {
+          val msgAndMetadata = streamIterator.next()
+          store((msgAndMetadata.key, msgAndMetadata.message))
+        }
+      } catch {
+        case e: Throwable => reportError("Error handling message; exiting", e)
+      }
+    }
+  }
+
+}

--- a/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaRegexTopicFilter.scala
+++ b/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaRegexTopicFilter.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.streaming.kafka
+
+import scala.collection.immutable.HashMap
+
+class KafkaRegexTopicFilter  (
+  val regexFilter: String,
+  val numStreams: Int,
+  val blackList: Boolean
+) extends HashMap[String, Int]() {
+
+}
+
+object KafkaRegexTopicFilter {
+  def apply (
+    regexFilter: String,
+    numStreams: Int,
+    blackList: Boolean = false
+  ) = new KafkaRegexTopicFilter(regexFilter, numStreams, blackList)
+}

--- a/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaTopicFilter.scala
+++ b/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaTopicFilter.scala
@@ -17,20 +17,38 @@
 
 package org.apache.spark.streaming.kafka
 
-import scala.collection.immutable.HashMap
+import java.lang.{Integer => JInt}
+import java.util.{Map => JMap}
 
-class KafkaRegexTopicFilter  (
-  val regexFilter: String,
-  val numStreams: Int,
-  val blackList: Boolean
-) extends HashMap[String, Int]() {
+import scala.collection.JavaConverters._
 
-}
+abstract class KafkaTopicFilter extends Serializable {}
 
-object KafkaRegexTopicFilter {
+object KafkaTopicFilter {
   def apply (
     regexFilter: String,
     numStreams: Int,
     blackList: Boolean = false
-  ) = new KafkaRegexTopicFilter(regexFilter, numStreams, blackList)
+  ) : KafkaTopicFilter = new KafkaRegexTopicFilter(regexFilter, numStreams, blackList)
+
+  def apply (topics: Map[String, Int]) : KafkaTopicFilter = new KafkaPlainTopicFilter(topics)
+
+  def apply (topics: JMap[String, JInt]) : KafkaTopicFilter = new KafkaPlainTopicFilter(topics)
+}
+
+class KafkaRegexTopicFilter  (
+   val regexFilter: String,
+   val numStreams: Int,
+   val blackList: Boolean
+ ) extends KafkaTopicFilter {
+
+}
+
+class KafkaPlainTopicFilter  (
+   val topics: Map[String, Int]
+ ) extends KafkaTopicFilter {
+
+  def this(topics: JMap[String, JInt]) {
+    this(Map(topics.asScala.mapValues(_.intValue()).toSeq: _*));
+  }
 }

--- a/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/ReliableKafkaReceiver.scala
+++ b/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/ReliableKafkaReceiver.scala
@@ -54,7 +54,7 @@ class ReliableKafkaReceiver[
   U <: Decoder[_]: ClassTag,
   T <: Decoder[_]: ClassTag](
     kafkaParams: Map[String, String],
-    topics: Map[String, Int],
+    topics: KafkaTopicFilter,
     storageLevel: StorageLevel
   ) extends Receiver[(K, V)](storageLevel) with Logging {
 
@@ -147,8 +147,8 @@ class ReliableKafkaReceiver[
       case filter: KafkaRegexTopicFilter => {
         filter.numStreams
       }
-      case _ => {
-        topics.values.sum
+      case filter: KafkaPlainTopicFilter => {
+        filter.topics.values.sum
       }
     }
   }
@@ -170,9 +170,9 @@ class ReliableKafkaReceiver[
           new MessageHandler(stream)
         }
       }
-      case _ => {
+      case filter: KafkaPlainTopicFilter => {
         val topicMessageStreams = consumerConnector.createMessageStreams(
-          topics, keyDecoder, valueDecoder)
+          filter.topics, keyDecoder, valueDecoder)
 
         topicMessageStreams.values.flatten { streams =>
           streams.map { stream =>

--- a/external/kafka/src/test/scala/org/apache/spark/streaming/kafka/KafkaStreamSuite.scala
+++ b/external/kafka/src/test/scala/org/apache/spark/streaming/kafka/KafkaStreamSuite.scala
@@ -17,29 +17,55 @@
 
 package org.apache.spark.streaming.kafka
 
+import kafka.serializer.StringDecoder
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.streaming.{Milliseconds, StreamingContext}
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.scalatest.concurrent.Eventually
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
+
 import scala.collection.mutable
 import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.Random
 
-import kafka.serializer.StringDecoder
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.concurrent.Eventually
+class KafkaStreamSuite extends SparkFunSuite
+    with BeforeAndAfterAll with BeforeAndAfter with Eventually {
 
-import org.apache.spark.{SparkConf, SparkFunSuite}
-import org.apache.spark.storage.StorageLevel
-import org.apache.spark.streaming.{Milliseconds, StreamingContext}
+  private val sparkConf = new SparkConf()
+    .setMaster("local[4]")
+    .setAppName(this.getClass.getSimpleName)
+  private val data = Map("a" -> 5, "b" -> 3, "c" -> 10)
+  private val data2 = Map("d" -> 8, "e" -> 1, "f" -> 9)
 
-class KafkaStreamSuite extends SparkFunSuite with Eventually with BeforeAndAfterAll {
-  private var ssc: StreamingContext = _
   private var kafkaTestUtils: KafkaTestUtils = _
 
-  override def beforeAll(): Unit = {
-    kafkaTestUtils = new KafkaTestUtils
-    kafkaTestUtils.setup()
+  private var groupId: String = _
+  private var kafkaParams: Map[String, String] = _
+  private var ssc: StreamingContext = _
+
+  override def beforeAll() : Unit = {
+    groupId = s"test-consumer-${Random.nextInt(10000)}"
   }
 
   override def afterAll(): Unit = {
+    // Nothing to be done here
+  }
+
+  before {
+    ssc = new StreamingContext(sparkConf, Milliseconds(500))
+
+    kafkaTestUtils = new KafkaTestUtils
+    kafkaTestUtils.setup()
+
+    kafkaParams = Map(
+      "zookeeper.connect" -> kafkaTestUtils.zkAddress,
+      "group.id" -> groupId,
+      "auto.offset.reset" -> "smallest"
+    )
+  }
+
+  after {
     if (ssc != null) {
       ssc.stop()
       ssc = null
@@ -52,16 +78,9 @@ class KafkaStreamSuite extends SparkFunSuite with Eventually with BeforeAndAfter
   }
 
   test("Kafka input stream") {
-    val sparkConf = new SparkConf().setMaster("local[4]").setAppName(this.getClass.getSimpleName)
-    ssc = new StreamingContext(sparkConf, Milliseconds(500))
     val topic = "topic1"
-    val sent = Map("a" -> 5, "b" -> 3, "c" -> 10)
     kafkaTestUtils.createTopic(topic)
-    kafkaTestUtils.sendMessages(topic, sent)
-
-    val kafkaParams = Map("zookeeper.connect" -> kafkaTestUtils.zkAddress,
-      "group.id" -> s"test-consumer-${Random.nextInt(10000)}",
-      "auto.offset.reset" -> "smallest")
+    kafkaTestUtils.sendMessages(topic, data)
 
     val stream = KafkaUtils.createStream[String, String, StringDecoder, StringDecoder](
       ssc, kafkaParams, Map(topic -> 1), StorageLevel.MEMORY_ONLY)
@@ -77,7 +96,59 @@ class KafkaStreamSuite extends SparkFunSuite with Eventually with BeforeAndAfter
     ssc.start()
 
     eventually(timeout(10000 milliseconds), interval(100 milliseconds)) {
-      assert(sent === result)
+      assert(data === result)
+    }
+  }
+
+  test("Kafka input stream with WhiteList") {
+    val topic = "topic1"
+    kafkaTestUtils.createTopic(topic)
+    kafkaTestUtils.sendMessages(topic, data)
+
+    val topicFilter = KafkaRegexTopicFilter("topic1", 1, true)
+
+    val stream = KafkaUtils.createStream[String, String, StringDecoder, StringDecoder](
+      ssc, kafkaParams, topicFilter, StorageLevel.MEMORY_ONLY)
+    val result = new mutable.HashMap[String, Long]() with mutable.SynchronizedMap[String, Long]
+    stream.map(_._2).countByValue().foreachRDD { r =>
+      val ret = r.collect()
+      ret.toMap.foreach { kv =>
+        val count = result.getOrElseUpdate(kv._1, 0) + kv._2
+        result.put(kv._1, count)
+      }
+    }
+
+    ssc.start()
+
+    eventually(timeout(10000 milliseconds), interval(100 milliseconds)) {
+      assert(data === result)
+    }
+  }
+
+  test("Kafka input stream with WhiteList 2") {
+    val topics = Map("topic1" -> data, "topic2" -> data2)
+    topics.foreach { case (t, d) =>
+      kafkaTestUtils.createTopic(t)
+      kafkaTestUtils.sendMessages(t, d)
+    }
+
+    val topicFilter = KafkaRegexTopicFilter("topic1", 1, true)
+
+    val stream = KafkaUtils.createStream[String, String, StringDecoder, StringDecoder](
+      ssc, kafkaParams, topicFilter, StorageLevel.MEMORY_ONLY)
+    val result = new mutable.HashMap[String, Long]() with mutable.SynchronizedMap[String, Long]
+    stream.map(_._2).countByValue().foreachRDD { r =>
+      val ret = r.collect()
+      ret.toMap.foreach { kv =>
+        val count = result.getOrElseUpdate(kv._1, 0) + kv._2
+        result.put(kv._1, count)
+      }
+    }
+
+    ssc.start()
+
+    eventually(timeout(10000 milliseconds), interval(100 milliseconds)) {
+      assert(data === result)
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Expose Kafka consumers white/black list topic filter interface on Kafka receivers all the way up to KafkaUtils.
## How was this patch tested?

Added a couple of cases to the Java tests. Will do the same on the Scala ones once the interface changes are approved.

The existing changes are already being used on a live system.

Build/Tests with Java 8 and Scala 2.10
