### PR TITLE
[SPARK-13518][SQL] Enable vectorized parquet scanner by default

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -345,12 +345,9 @@ object SQLConf {
     defaultValue = Some(true),
     doc = "Enables using the custom ParquetUnsafeRowRecordReader.")
 
-  // Note: this can not be enabled all the time because the reader will not be returning UnsafeRows.
-  // Doing so is very expensive and we should remove this requirement instead of fixing it here.
-  // Initial testing seems to indicate only sort requires this.
   val PARQUET_VECTORIZED_READER_ENABLED = booleanConf(
     key = "spark.sql.parquet.enableVectorizedReader",
-    defaultValue = Some(false),
+    defaultValue = Some(true),
     doc = "Enables vectorized parquet decoding.")
 
   val ORC_FILTER_PUSHDOWN_ENABLED = booleanConf("spark.sql.orc.filterPushdown",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change the default of the flag to enable this feature now that the implementation is complete.
## How was this patch tested?

The new parquet reader should be a drop in, so will be exercised by the existing tests.
