### PR TITLE
[SPARK-13533][SQL] Fix readBytes in VectorizedPlainValuesReader

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
@@ -85,7 +85,7 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
     for (int i = 0; i < total; i++) {
       // Bytes are stored as a 4-byte little endian int. Just read the first byte.
       // TODO: consider pushing this in ColumnVector by adding a readBytes with a stride.
-      c.putInt(rowId + i, buffer[offset]);
+      c.putByte(rowId + i, buffer[offset]);
       offset += 4;
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix readBytes in VectorizedPlainValuesReader. This fixes a copy and paste issue.
## How was this patch tested?

Ran ParquetHadoopFsRelationSuite which failed before this.
