### PR TITLE
[SPARK-13536] [SQL] Stop Resolving Missing Sort Attributes in Transform Clauses

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -679,7 +679,7 @@ class Analyzer(
 
     /**
       * Resolve the expression on a specified logical plan and it's child (recursively), until
-      * the expression is resolved or meet a non-unary node or Subquery.
+      * the expression is resolved or meet a non-unary node, SubqueryAlias or ScriptTransformation.
       */
     private def resolveExpressionRecursively(expr: Expression, plan: LogicalPlan): Expression = {
       val resolved = resolveExpression(expr, plan)
@@ -687,7 +687,8 @@ class Analyzer(
         resolved
       } else {
         plan match {
-          case u: UnaryNode if !u.isInstanceOf[SubqueryAlias] =>
+          case u: UnaryNode
+              if !u.isInstanceOf[SubqueryAlias] && !u.isInstanceOf[ScriptTransformation] =>
             resolveExpressionRecursively(resolved, u.child)
           case other => resolved
         }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -710,6 +710,15 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
       .queryExecution.analyzed
   }
 
+  test("missing sort attribute in script transform") {
+    val data = (1 to 10).map { i => (i, i, i) }
+    data.toDF("d1", "d2", "d3").registerTempTable("script_trans")
+    val e = intercept[AnalysisException] {
+      sql("SELECT TRANSFORM (d1, d2) USING 'cat' AS (a,b) FROM script_trans order by d3")
+    }
+    assert(e.getMessage.contains("cannot resolve '`d3`' given input columns: [a, b]"))
+  }
+
   test("test script transform for stdout") {
     val data = (1 to 100000).map { i => (i, i, i) }
     data.toDF("d1", "d2", "d3").registerTempTable("script_trans")


### PR DESCRIPTION
#### What changes were proposed in this pull request?

When missing sort attributes are not in the output of `Transform`, we should not bypass it and check its child nodes. Like `subquery`, we should not continue finding the missing attributes in its child nodes.
#### How was this patch tested?

This is an internal code bug. So far, unable to trigger the external behavior difference. The newly added code is just for covering and verifying it.
