### PR TITLE
[SPARK-13540][SQL] Supports using nested classes within Scala objects as Dataset element type

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
+import java.lang.reflect.Modifier
+
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.AnalysisException
@@ -559,7 +561,10 @@ class Analyzer(
       }
 
       resolveExpression(unbound, LocalRelation(attributes), throws = true) transform {
-        case n: NewInstance if n.outerPointer.isEmpty && n.cls.isMemberClass =>
+        case n: NewInstance
+          if n.outerPointer.isEmpty &&
+             n.cls.isMemberClass &&
+             !Modifier.isStatic(n.cls.getModifiers) =>
           val outer = OuterScopes.outerScopes.get(n.cls.getDeclaringClass.getName)
           if (outer == null) {
             throw new AnalysisException(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -562,6 +562,9 @@ class Analyzer(
 
       resolveExpression(unbound, LocalRelation(attributes), throws = true) transform {
         case n: NewInstance
+          // If this is an inner class of another class, register the outer object in `OuterScopes`.
+          // Note that static inner classes (e.g., inner classes within Scala objects) don't need
+          // outer pointer registration.
           if n.outerPointer.isEmpty &&
              n.cls.isMemberClass &&
              !Modifier.isStatic(n.cls.getModifiers) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/OuterScopes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/OuterScopes.scala
@@ -37,6 +37,6 @@ object OuterScopes {
    * given wrapper class.
    */
   def addOuterScope(outer: AnyRef): Unit = {
-    outerScopes.putIfAbsent(outer.getClass.getName, outer)
+    outerScopes.putIfAbsent(outer.getClass.getName.stripSuffix("$"), outer)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/OuterScopes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/OuterScopes.scala
@@ -37,6 +37,6 @@ object OuterScopes {
    * given wrapper class.
    */
   def addOuterScope(outer: AnyRef): Unit = {
-    outerScopes.putIfAbsent(outer.getClass.getName.stripSuffix("$"), outer)
+    outerScopes.putIfAbsent(outer.getClass.getName, outer)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -622,8 +622,7 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
       Some(1), Some(2), Some(3))
   }
 
-  test("SPARK-13540 add Scala object to OuterScopes") {
-    OuterScopes.addOuterScope(OuterObject)
+  test("SPARK-13540 Dataset of nested class defined in Scala object") {
     checkAnswer(
       Seq(OuterObject.InnerClass("foo")).toDS(),
       OuterObject.InnerClass("foo"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -624,7 +624,9 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
 
   test("SPARK-13540 add Scala object to OuterScopes") {
     OuterScopes.addOuterScope(OuterObject)
-    Seq(OuterObject.InnerClass("foo")).toDS()
+    checkAnswer(
+      Seq(OuterObject.InnerClass("foo")).toDS(),
+      OuterObject.InnerClass("foo"))
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -621,9 +621,18 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
       ds.filter(_ => true),
       Some(1), Some(2), Some(3))
   }
+
+  test("SPARK-13540 add Scala object to OuterScopes") {
+    OuterScopes.addOuterScope(OuterObject)
+    Seq(OuterObject.InnerClass("foo")).toDS()
+  }
 }
 
 class OuterClass extends Serializable {
+  case class InnerClass(a: String)
+}
+
+object OuterObject {
   case class InnerClass(a: String)
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Nested classes defined within Scala objects are translated into Java static nested classes. Unlike inner classes, they don't need outer scopes. But the analyzer still thinks that an outer scope is required.

This PR fixes this issue simply by checking whether a nested class is static before looking up its outer scope.
## How was this patch tested?

A test case is added to `DatasetSuite`. It checks contents of a Dataset whose element type is a nested class declared in a Scala object.
