### PR TITLE
[SPARK-13571] [SQL] Track current database in SQLContext

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Catalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Catalog.scala
@@ -37,9 +37,9 @@ trait Catalog {
 
   def lookupRelation(tableIdent: TableIdentifier, alias: Option[String] = None): LogicalPlan
 
-  def setCurrentDatabase(databaseName: String): Unit = {
-    throw new UnsupportedOperationException
-  }
+  def getCurrentDatabase: String
+
+  def setCurrentDatabase(databaseName: String): Unit
 
   /**
    * Returns tuples of (tableName, isTemporary) for all tables in the given database.
@@ -76,6 +76,15 @@ trait Catalog {
 
 class SimpleCatalog(val conf: CatalystConf) extends Catalog {
   private[this] val tables = new ConcurrentHashMap[String, LogicalPlan]
+
+  // TODO: just call catalog.InMemoryCatalog instead of keeping track of this ourselves
+  private[this] var currentDatabase = "default"
+
+  override def getCurrentDatabase: String = currentDatabase
+
+  override def setCurrentDatabase(databaseName: String): Unit = {
+    currentDatabase = databaseName
+  }
 
   override def registerTable(tableIdent: TableIdentifier, plan: LogicalPlan): Unit = {
     tables.put(getTableName(tableIdent), plan)
@@ -193,6 +202,14 @@ object EmptyCatalog extends Catalog {
   override def lookupRelation(
       tableIdent: TableIdentifier,
       alias: Option[String] = None): LogicalPlan = {
+    throw new UnsupportedOperationException
+  }
+
+  override def getCurrentDatabase: String = {
+    throw new UnsupportedOperationException
+  }
+
+  override def setCurrentDatabase(databaseName: String): Unit = {
     throw new UnsupportedOperationException
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -42,6 +42,9 @@ class InMemoryCatalog extends Catalog {
   // Database name -> description
   private val catalog = new scala.collection.mutable.HashMap[String, DatabaseDesc]
 
+  // Name of current database
+  private var currentDatabase: String = "default"
+
   private def filterPattern(names: Seq[String], pattern: String): Seq[String] = {
     val regex = pattern.replaceAll("\\*", ".*").r
     names.filter { funcName => regex.pattern.matcher(funcName).matches() }
@@ -141,7 +144,14 @@ class InMemoryCatalog extends Catalog {
     filterPattern(listDatabases(), pattern)
   }
 
-  override def setCurrentDatabase(db: String): Unit = { /* no-op */ }
+  override def getCurrentDatabase: String = synchronized {
+    currentDatabase
+  }
+
+  override def setCurrentDatabase(db: String): Unit = synchronized {
+    requireDbExists(db)
+    currentDatabase = db
+  }
 
   // --------------------------------------------------------------------------
   // Tables

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -64,6 +64,8 @@ abstract class Catalog {
 
   def listDatabases(pattern: String): Seq[String]
 
+  def getCurrentDatabase: String
+
   def setCurrentDatabase(db: String): Unit
 
   // --------------------------------------------------------------------------

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/CatalogTestCases.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/CatalogTestCases.scala
@@ -212,6 +212,18 @@ abstract class CatalogTestCases extends SparkFunSuite with BeforeAndAfterEach {
     }
   }
 
+  test("get/set current database") {
+    val catalog = newBasicCatalog()
+    assert(catalog.getCurrentDatabase === "default")
+    catalog.setCurrentDatabase("db1")
+    assert(catalog.getCurrentDatabase === "db1")
+    catalog.setCurrentDatabase("db2")
+    assert(catalog.getCurrentDatabase === "db2")
+    intercept[AnalysisException] {
+      catalog.setCurrentDatabase("does_not_exist")
+    }
+  }
+
   // --------------------------------------------------------------------------
   // Tables
   // --------------------------------------------------------------------------

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveCatalog.scala
@@ -134,6 +134,10 @@ private[spark] class HiveCatalog(client: HiveClient) extends Catalog with Loggin
     client.listDatabases(pattern)
   }
 
+  override def getCurrentDatabase: String = withClient {
+    client.currentDatabase
+  }
+
   override def setCurrentDatabase(db: String): Unit = withClient {
     client.setCurrentDatabase(db)
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -715,6 +715,10 @@ private[hive] class HiveMetastoreCatalog(val client: HiveClient, hive: HiveConte
 
   override def unregisterAllTables(): Unit = {}
 
+  override def getCurrentDatabase: String = {
+    client.currentDatabase
+  }
+
   override def setCurrentDatabase(databaseName: String): Unit = {
     client.setCurrentDatabase(databaseName)
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `get/setCurrentDatabase` methods to the internal catalog used by `SQLContext`. This was already available in `HiveContext`, so we should add it to `SQLContext` too to facilitate the merging of the two contexts.

Note: there are two catalogs, `analysis.Catalog` and `catalog.Catalog`. The former is used currently in the contexts and the latter is not used yet. I added this functionality to both catalogs for now, but in the future one catalog will call the other so we don't have to duplicate functionality.

All API changes in this PR are internal.
## How was this patch tested?

Existing Jenkins tests + new test in `CatalogTestCases`
