### PR TITLE
[SPARK-13586][STREAMING]add config to skip generate down time batch when restart StreamingContext

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
@@ -221,8 +221,12 @@ class JobGenerator(jobScheduler: JobScheduler) extends Logging {
     logInfo("Batches pending processing (" + pendingTimes.size + " batches): " +
       pendingTimes.mkString(", "))
     // Reschedule jobs for these times
-    val timesToReschedule = (pendingTimes ++ downTimes).filter { _ < restartTime }
-      .distinct.sorted(Time.ordering)
+    val skipDownTime = conf.getBoolean("spark.streaming.skipDownTimeBatch", false)
+    val timesToReschedule = if (skipDownTime) {
+      pendingTimes
+    } else {
+      (pendingTimes ++ downTimes).distinct.sorted(Time.ordering)
+    }
     logInfo("Batches to reschedule (" + timesToReschedule.size + " batches): " +
       timesToReschedule.mkString(", "))
     timesToReschedule.foreach { time =>

--- a/streaming/src/test/scala/org/apache/spark/streaming/scheduler/JobGeneratorSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/scheduler/JobGeneratorSuite.scala
@@ -127,7 +127,7 @@ class JobGeneratorSuite extends TestSuiteBase {
     }
   }
 
-  test("do no generate down time batch when recovering from checkpoint") {
+  test("SPARK-13586: do no generate down time batch when recovering from checkpoint") {
 
     val checkpointDir = Utils.createTempDir()
     val testConf = conf


### PR DESCRIPTION
## What changes were proposed in this pull request?

The patch try to add a config `spark.streaming.skipDownTimeBatch` to control whether generate the down time batches when restarting StreamingContext. By default, it will be set to false.
## How was this patch tested?

unit test: test("SPARK-13586: do no generate down time batch when recovering from checkpoint") 
