### PR TITLE
[SPARK-13591] [SQL] Remove Back-ticks in AttributeReference/Alias Names

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -329,7 +329,8 @@ class Analyzer(
               throw new AnalysisException(
                 s"Aggregate expression required for pivot, found '$aggregate'")
             }
-            val name = if (singleAgg) value.toString else value + "_" + aggregate.sql
+            val name =
+              if (singleAgg) value.toString else value + "_" + usePrettyExpression(aggregate).sql
             Alias(filteredAggregate, name)()
           }
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/windowExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/windowExpressions.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis.UnresolvedException
 import org.apache.spark.sql.catalyst.expressions.aggregate.{DeclarativeAggregate, NoOp}
+import org.apache.spark.sql.catalyst.util.usePrettyExpression
 import org.apache.spark.sql.types._
 
 /**
@@ -557,7 +558,7 @@ abstract class RankLike extends AggregateWindowFunction {
 
   /** Store the values of the window 'order' expressions. */
   protected val orderAttrs = children.map { expr =>
-    AttributeReference(expr.sql, expr.dataType)()
+    AttributeReference(usePrettyExpression(expr).sql, expr.dataType)()
   }
 
   /** Predicate that detects if the order attributes have changed. */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicOperators.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.catalyst.analysis.MultiInstanceRelation
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.catalyst.util.usePrettyExpression
 import org.apache.spark.sql.types._
 
 /**
@@ -596,7 +597,8 @@ case class Pivot(
   override def output: Seq[Attribute] = groupByExprs.map(_.toAttribute) ++ aggregates match {
     case agg :: Nil => pivotValues.map(value => AttributeReference(value.toString, agg.dataType)())
     case _ => pivotValues.flatMap{ value =>
-      aggregates.map(agg => AttributeReference(value + "_" + agg.sql, agg.dataType)())
+      aggregates.map(agg =>
+        AttributeReference(value + "_" + usePrettyExpression(agg).sql, agg.dataType)())
     }
   }
 }


### PR DESCRIPTION
#### What changes were proposed in this pull request?

When calling .sql, back-ticks are automatically added. When using .sql as AttributeReference/Alias names, we hit a couple of issues when doing logicalPlan to SQL. Parser is unable to recognize it.

For example, the name could be converted to 

```
`sum(`name`)`
```

This PR is to follow the same way to remove back-ticks from names as what we did in https://github.com/apache/spark/pull/10757. 

*_Question: *_ This is a common issue. I am afraid the future coders might miss that. Should we call `usePrettyExpression` every time when we creating an alias name or attributeReference name? Or add another function (e.g., .sqlToName) like `.sql`? Thanks!

@liancheng @cloud-fan 
#### How was this patch tested?

N/A
