### PR TITLE
[SPARK-13592][Windows] fix path of spark-submit2.cmd in spark-submit.cmd

### DIFF
--- a/bin/spark-submit.cmd
+++ b/bin/spark-submit.cmd
@@ -20,4 +20,4 @@ rem
 rem This is the entry point for running Spark submit. To avoid polluting the
 rem environment, it just launches a new cmd to do the real work.
 
-cmd /V /E /C spark-submit2.cmd %*
+cmd /V /E /C "%~dp0spark-submit2.cmd" %*


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch fixes the problem that pyspark fails on Windows because pyspark can't find `spark-submit2.cmd`.
## How was this patch tested?

manual tests:
  I ran `bin\pyspark.cmd` and checked if pyspark is launched correctly after this patch is applyed.
