### PR TITLE
[SPARK-13593][SQL] improve the `createDataFrame` to accept data type string and verify the data

### DIFF
--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -59,7 +59,11 @@ def _monkey_patch_RDD(sqlContext):
         its only field, and the field name will be "value", each record will also be wrapped into a
         tuple, which can be converted to row later.
 
-        :param schema: a :class:`DataType` or a datatype string or list of names of columns
+        :param schema: a :class:`DataType` or a datatype string or list of names of columns.
+                       The data type string format equals to `DataType.simpleString`, except that
+                       top level struct type can omit the `struct<>` and numeric types use
+                       `typeName()` as their format, e.g. use `byte` instead of `tinyint` for
+                       ByteType. We can also use `int` as a short name for IntegerType.
         :param samplingRatio: the sample ratio of rows used for inferring
         :return: a DataFrame
 
@@ -67,13 +71,13 @@ def _monkey_patch_RDD(sqlContext):
            The schema parameter can be a DataType or a datatype string after 2.0. If it's not a
            StructType, it will be wrapped into a StructType and each record will also be wrapped
            into a tuple.
-           The data type string format equals to `DataType.simpleString`, except that top level
-           struct type can omit the `struct<>` and numeric types use `typeName()` as their format,
-           e.g. use `byte` instead of `tinyint` for ByteType. We can also use `int` as a short name
-           for IntegerType.
 
-        >>> rdd.toDF().collect()
+        >>> rdd.toDF().collect()      # will scan the data and infer the real schema.
         [Row(name=u'Alice', age=1)]
+        >>> rdd.toDF(["name", "age"]) # will scan the data and infer the real schema.
+        [Row(name=u'Alice', age=1)]
+        >>> rdd.toDF(["a", "b"])      # will scan the data and infer the real schema.
+        [Row(a=u'Alice', b=1)]
         >>> rdd.toDF("a: string, b: int").collect()
         [Row(a=u'Alice', b=1)]
         >>> rdd.map(lambda row: row.age).toDF("int").collect()

--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -67,6 +67,10 @@ def _monkey_patch_RDD(sqlContext):
            The schema parameter can be a DataType or a datatype string after 2.0. If it's not a
            StructType, it will be wrapped into a StructType and each record will also be wrapped
            into a tuple.
+           The data type string format equals to `DataType.simpleString`, except that top level
+           struct type can omit the `struct<>` and numeric types use `typeName()` as their format,
+           e.g. use `byte` instead of `tinyint` for ByteType. We can also use `int` as a short name
+           for IntegerType.
 
         >>> rdd.toDF().collect()
         [Row(name=u'Alice', age=1)]
@@ -84,7 +88,7 @@ def _monkey_patch_RDD(sqlContext):
 
         if not isinstance(schema, DataType):
             raise TypeError("schema should be DataType or string or list or tuple, " +
-                "but got: %s" % schema)
+                            "but got: %s" % schema)
         else:
             def verify(obj):
                 _verify_type(obj, schema)

--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -95,7 +95,7 @@ def _monkey_patch_RDD(sqlContext):
                 return obj
             rdd = self.map(verify)
 
-            if isinstance(datatype, StructType):
+            if isinstance(schema, StructType):
                 return sqlContext.createDataFrame(rdd, schema)
             else:
                 return sqlContext.createDataFrame(rdd.map(lambda obj: (obj, )),

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -369,9 +369,7 @@ class SQLTests(ReusedPySparkTestCase):
         rdd = self.sc.parallelize(range(3)).map(lambda i: Row(a=i))
         schema = StructType([StructField("a", IntegerType()), StructField("b", StringType())])
         df = self.sqlCtx.createDataFrame(rdd, schema)
-        message = ".*Input row doesn't have expected number of values required by the schema.*"
-        with self.assertRaisesRegexp(Exception, message):
-            df.show()
+        self.assertRaises(Exception, lambda: df.show())
 
     def test_serialize_nested_array_and_map(self):
         d = [Row(l=[Row(a=1, b='s')], d={"key": Row(c=1.0, d="2")})]
@@ -1178,7 +1176,7 @@ class SQLTests(ReusedPySparkTestCase):
         # planner should not crash without a join
         broadcast(df1)._jdf.queryExecution().executedPlan()
 
-    def test_apply_schema(self):
+    def test_toDF_with_schema_string(self):
         data = [Row(key=i, value=str(i)) for i in range(100)]
         rdd = self.sc.parallelize(data, 5)
 

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -1182,35 +1182,35 @@ class SQLTests(ReusedPySparkTestCase):
         data = [Row(key=i, value=str(i)) for i in range(100)]
         rdd = self.sc.parallelize(data, 5)
 
-        df = rdd.schema("key: int, value: string")
+        df = rdd.toDF("key: int, value: string")
         self.assertEqual(df.schema.simpleString(), "struct<key:int,value:string>")
         self.assertEqual(df.collect(), data)
 
         # different but compatible field types can be used.
-        df = rdd.schema("key: string, value: string")
+        df = rdd.toDF("key: string, value: string")
         self.assertEqual(df.schema.simpleString(), "struct<key:string,value:string>")
         self.assertEqual(df.collect(), [Row(key=str(i), value=str(i)) for i in range(100)])
 
         # field names can differ.
-        df = rdd.schema(" a: int, b: string ")
+        df = rdd.toDF(" a: int, b: string ")
         self.assertEqual(df.schema.simpleString(), "struct<a:int,b:string>")
         self.assertEqual(df.collect(), data)
 
         # number of fields must match.
         self.assertRaisesRegexp(Exception, "Length of object",
-                                lambda: rdd.schema("key: int").collect())
+                                lambda: rdd.toDF("key: int").collect())
 
         # field types mismatch will cause exception at runtime.
         self.assertRaisesRegexp(Exception, "FloatType can not accept",
-                                lambda: rdd.schema("key: float, value: string").collect())
+                                lambda: rdd.toDF("key: float, value: string").collect())
 
         # flat schema values will be wrapped into row.
-        df = rdd.map(lambda row: row.key).schema("int")
+        df = rdd.map(lambda row: row.key).toDF("int")
         self.assertEqual(df.schema.simpleString(), "struct<value:int>")
         self.assertEqual(df.collect(), [Row(key=i) for i in range(100)])
 
         # users can use DataType directly instead of data type string.
-        df = rdd.map(lambda row: row.key).schema(IntegerType())
+        df = rdd.map(lambda row: row.key).toDF(IntegerType())
         self.assertEqual(df.schema.simpleString(), "struct<value:int>")
         self.assertEqual(df.collect(), [Row(key=i) for i in range(100)])
 

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -1207,12 +1207,12 @@ class SQLTests(ReusedPySparkTestCase):
         # flat schema values will be wrapped into row.
         df = rdd.map(lambda row: row.key).schema("int")
         self.assertEqual(df.schema.simpleString(), "struct<value:int>")
-        self.assertEqual(df.collect(), map(lambda row: Row(value=row.key), data))
+        self.assertEqual(df.collect(), [Row(key=i) for i in range(100)])
 
         # users can use DataType directly instead of data type string.
         df = rdd.map(lambda row: row.key).schema(IntegerType())
         self.assertEqual(df.schema.simpleString(), "struct<value:int>")
-        self.assertEqual(df.collect(), map(lambda row: Row(value=row.key), data))
+        self.assertEqual(df.collect(), [Row(key=i) for i in range(100)])
 
 
 class HiveContextSQLTests(ReusedPySparkTestCase):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -749,7 +749,7 @@ def _parse_datatype_string(s):
     """
     Parses the given data type string to a :class:`DataType`. The data type string format equals
     to `DataType.simpleString`, except that top level struct type can omit the `struct<>` and
-    numeric types use `typeName()` as their format, e.g. use `byte` instead of `tinyint` for
+    atomic types use `typeName()` as their format, e.g. use `byte` instead of `tinyint` for
     ByteType. We can also use `int` as a short name for IntegerType.
 
     >>> _parse_datatype_string("int ")

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -731,7 +731,7 @@ def _ignore_brackets_split(s, separator):
     return parts
 
 
-def _parse_struct_type_string(s):
+def _parse_struct_fields_string(s):
     parts = _ignore_brackets_split(s, ",")
     fields = []
     for part in parts:
@@ -797,9 +797,9 @@ def _parse_datatype_string(s):
     elif s.startswith("struct<"):
         if s[-1] != ">":
             raise ValueError("'>' should be the last char, but got: %s" % s)
-        return _parse_struct_type_string(s[7:-1])
+        return _parse_struct_fields_string(s[7:-1])
     elif ":" in s:
-        return _parse_struct_type_string(s)
+        return _parse_struct_fields_string(s)
     else:
         return _parse_basic_datatype_string(s)
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -714,7 +714,7 @@ def _ignore_brackets_split(s, separator):
             buf += c
         elif c in _BRACKETS.values():
             if level == 0:
-                raise ValueError("Cannot parse datatype string: %s" % s)
+                raise ValueError("Brackets are not correctly paired: %s" % s)
             level -= 1
             buf += c
         elif c == separator and level > 0:
@@ -726,7 +726,7 @@ def _ignore_brackets_split(s, separator):
             buf += c
 
     if len(buf) == 0:
-        raise ValueError("Cannot parse datatype string: %s" % s)
+        raise ValueError("The %s cannot be the last char: %s" % (seperator, s))
     parts.append(buf)
     return parts
 
@@ -737,7 +737,8 @@ def _parse_struct_type_string(s):
     for part in parts:
         name_and_type = _ignore_brackets_split(part, ":")
         if len(name_and_type) != 2:
-            raise ValueError("Cannot parse datatype string: %s" % s)
+            raise ValueError("The strcut field string format is: 'field_name:field_type', " +
+                             "but got: %s" % part)
         field_name = name_and_type[0].strip()
         field_type = _parse_datatype_string(name_and_type[1])
         fields.append(StructField(field_name, field_type))
@@ -781,20 +782,21 @@ def _parse_datatype_string(s):
     s = s.strip()
     if s.startswith("array<"):
         if s[-1] != ">":
-            raise ValueError("Cannot parse datatype string: %s" % s)
+            raise ValueError("'>' should be the last char, but got: %s" % s)
         return ArrayType(_parse_datatype_string(s[6:-1]))
     elif s.startswith("map<"):
         if s[-1] != ">":
-            raise ValueError("Cannot parse datatype string: %s" % s)
+            raise ValueError("'>' should be the last char, but got: %s" % s)
         parts = _ignore_brackets_split(s[4:-1], ",")
         if len(parts) != 2:
-            raise ValueError("Cannot parse datatype string: %s" % s)
+            raise ValueError("The map type string format is: 'map<key_type,value_type>', " +
+                             "but got: %s" % s)
         kt = _parse_datatype_string(parts[0])
         vt = _parse_datatype_string(parts[1])
         return MapType(kt, vt)
     elif s.startswith("struct<"):
         if s[-1] != ">":
-            raise ValueError("Cannot parse datatype string: %s" % s)
+            raise ValueError("'>' should be the last char, but got: %s" % s)
         return _parse_struct_type_string(s[7:-1])
     elif ":" in s:
         return _parse_struct_type_string(s)

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -726,7 +726,7 @@ def _ignore_brackets_split(s, separator):
             buf += c
 
     if len(buf) == 0:
-        raise ValueError("The %s cannot be the last char: %s" % (seperator, s))
+        raise ValueError("The %s cannot be the last char: %s" % (separator, s))
     parts.append(buf)
     return parts
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR improves the `createDataFrame` method to make it also accept datatype string, then users can convert python RDD to DataFrame easily, for example, `df = rdd.toDF("a: int, b: string")`.
It also supports flat schema so users can convert an RDD of int to DataFrame directly, we will automatically wrap int to row for users.
If schema is given, now we checks if the real data matches the given schema, and throw error if it doesn't.
## How was this patch tested?

new tests in `test.py` and doc test in `types.py`
