### PR TITLE
[SPARK-13471] [SQL] WiP update hive version to 1.2.1.1.spark

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
     <curator.version>2.4.0</curator.version>
     <hive.group>org.spark-project.hive</hive.group>
     <!-- Version used in Maven Hive dependency -->
-    <hive.version>1.2.1.spark</hive.version>
+    <hive.version>1.2.1.1.spark</hive.version>
     <!-- Version used for internal directory structure -->
     <hive.version.short>1.2.1</hive.version.short>
     <derby.version>10.10.1.1</derby.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is the patch of #11346 against master; the details are covered there.

essentially: switches to a new hive 1.2.1.1.spark JAR, which declares a dependency on groovy 2.4.4, so eliminating risk from a serialization CVE
