### PR TITLE
[SPARK-13010] [ML] [SparkR] Implement a simple wrapper of AFTSurvivalRegression in SparkR

### DIFF
--- a/R/pkg/DESCRIPTION
+++ b/R/pkg/DESCRIPTION
@@ -11,7 +11,8 @@ Depends:
     R (>= 3.0),
     methods,
 Suggests:
-    testthat
+    testthat,
+    survival
 Description: R frontend for Spark
 License: Apache License (== 2.0)
 Collate:

--- a/R/pkg/NAMESPACE
+++ b/R/pkg/NAMESPACE
@@ -15,7 +15,8 @@ exportMethods("glm",
               "predict",
               "summary",
               "kmeans",
-              "fitted")
+              "fitted",
+              "survreg")
 
 # Job group lifecycle management methods
 export("setJobGroup",

--- a/R/pkg/R/generics.R
+++ b/R/pkg/R/generics.R
@@ -1175,3 +1175,7 @@ setGeneric("kmeans")
 #' @rdname fitted
 #' @export
 setGeneric("fitted")
+
+#' @rdname survreg
+#' @export
+setGeneric("survreg", function(formula, data) { standardGeneric("survreg") })

--- a/R/pkg/R/mllib.R
+++ b/R/pkg/R/mllib.R
@@ -83,7 +83,7 @@ setMethod("glm", signature(formula = "formula", family = "ANY", data = "DataFram
 #'}
 setMethod("survreg", signature(formula = "formula", data = "DataFrame"),
           function(formula, data) {
-            formula <- paste(deparse(formula), collapse="")
+            formula <- paste(deparse(formula), collapse = "")
             model <- callJStatic("org.apache.spark.ml.api.r.SparkRWrappers",
                                  "fitAFTSurvivalRegression", formula, data@sdf)
             return(new("PipelineModel", model = model))

--- a/R/pkg/R/mllib.R
+++ b/R/pkg/R/mllib.R
@@ -61,6 +61,34 @@ setMethod("glm", signature(formula = "formula", family = "ANY", data = "DataFram
             return(new("PipelineModel", model = model))
           })
 
+#' Fit an accelerated failure time (AFT) survival regression model.
+#'
+#' Fit an accelerated failure time (AFT) survival regression model, similarly to R's survreg().
+#'
+#' @param formula A symbolic description of the model to be fitted. Currently only a few formula
+#'                operators are supported, including '~', ':', '+', and '-'.
+#' @param data DataFrame for training.
+#' @return a fitted MLlib model
+#' @rdname survreg
+#' @export
+#' @examples
+#'\dontrun{
+#' sc <- sparkR.init()
+#' sqlContext <- sparkRSQL.init(sc)
+#' library(survival)
+#' data(ovarian)
+#' df <- createDataFrame(sqlContext, ovarian)
+#' model <- survreg(Surv(futime, fustat) ~ ecog_ps + rx, df)
+#' summary(model)
+#'}
+setMethod("survreg", signature(formula = "formula", data = "DataFrame"),
+          function(formula, data) {
+            formula <- paste(deparse(formula), collapse="")
+            model <- callJStatic("org.apache.spark.ml.api.r.SparkRWrappers",
+                                 "fitAFTSurvivalRegression", formula, data@sdf)
+            return(new("PipelineModel", model = model))
+          })
+
 #' Make predictions from a model
 #'
 #' Makes predictions from a model produced by glm(), similarly to R's predict().
@@ -135,6 +163,11 @@ setMethod("summary", signature(object = "PipelineModel"),
               colnames(coefficients) <- unlist(features)
               rownames(coefficients) <- 1:k
               return(list(coefficients = coefficients, size = size, cluster = dataFrame(cluster)))
+            } else if (modelName == "AFTSurvivalRegressionModel") {
+              coefficients <- as.matrix(unlist(coefficients))
+              colnames(coefficients) <- c("Value")
+              rownames(coefficients) <- unlist(features)
+              return(list(coefficients = coefficients))
             } else {
               stop(paste("Unsupported model", modelName, sep = " "))
             }

--- a/R/pkg/inst/tests/testthat/test_mllib.R
+++ b/R/pkg/inst/tests/testthat/test_mllib.R
@@ -141,3 +141,17 @@ test_that("kmeans", {
   cluster <- summary.model$cluster
   expect_equal(sort(collect(distinct(select(cluster, "prediction")))$prediction), c(0, 1))
 })
+
+test_that("survreg vs survival::survreg", {
+  data <- list(list(4,1,0,0), list(3,1,2,0), list(1,1,1,0),
+          list(1,0,1,0), list(2,1,1,1), list(2,1,0,1), list(3,0,0,1))
+  df <- createDataFrame(sqlContext, data, c("time", "status", "x", "sex"))
+  model <- survreg(Surv(time, status) ~ x + sex, df)
+  stats <- summary(model)
+  coefs <- as.vector(stats$coefficients[,1])
+  rCoefs <- c(1.3149571, -0.1903409, -0.2532618, -1.1599802)
+  expect_true(all(abs(rCoefs - coefs) < 1e-4))
+  expect_true(all(
+    rownames(stats$coefficients) ==
+    c("(Intercept)", "x", "sex", "Log(scale)")))
+})

--- a/R/pkg/inst/tests/testthat/test_mllib.R
+++ b/R/pkg/inst/tests/testthat/test_mllib.R
@@ -143,12 +143,12 @@ test_that("kmeans", {
 })
 
 test_that("survreg vs survival::survreg", {
-  data <- list(list(4,1,0,0), list(3,1,2,0), list(1,1,1,0),
-          list(1,0,1,0), list(2,1,1,1), list(2,1,0,1), list(3,0,0,1))
+  data <- list(list(4, 1, 0, 0), list(3, 1, 2, 0), list(1, 1, 1, 0),
+          list(1, 0, 1, 0), list(2, 1, 1, 1), list(2, 1, 0, 1), list(3, 0, 0, 1))
   df <- createDataFrame(sqlContext, data, c("time", "status", "x", "sex"))
   model <- survreg(Surv(time, status) ~ x + sex, df)
   stats <- summary(model)
-  coefs <- as.vector(stats$coefficients[,1])
+  coefs <- as.vector(stats$coefficients[, 1])
   rCoefs <- c(1.3149571, -0.1903409, -0.2532618, -1.1599802)
   expect_true(all(abs(rCoefs - coefs) < 1e-4))
   expect_true(all(

--- a/mllib/src/main/scala/org/apache/spark/ml/r/SparkRWrappers.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/SparkRWrappers.scala
@@ -61,7 +61,7 @@ private[r] object SparkRWrappers {
       var rewrited: String = null
       var censorCol: String = null
 
-      val regex = "^Surv\\(([^,]*),([^,]*)\\)\\s*\\~\\s*(.*)".r
+      val regex = "^Surv\\(([^,]+),([^,]+)\\)\\s*\\~\\s*(.+)".r
       try {
         val regex(label, censor, features) = value
         // TODO: Support dot operator.

--- a/mllib/src/main/scala/org/apache/spark/ml/r/SparkRWrappers.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/SparkRWrappers.scala
@@ -61,7 +61,7 @@ private[r] object SparkRWrappers {
       var rewrited: String = null
       var censorCol: String = null
 
-      val regex = "^Surv\\(([^,]+),([^,]+)\\)\\s*\\~\\s*(.+)".r
+      val regex = "^Surv\\s*\\(([^,]+),([^,]+)\\)\\s*\\~\\s*(.+)".r
       try {
         val regex(label, censor, features) = value
         // TODO: Support dot operator.
@@ -197,7 +197,7 @@ private[r] object SparkRWrappers {
         attrs.attributes.get.map(_.name.get)
       case m: AFTSurvivalRegressionModel =>
         val attrs = AttributeGroup.fromStructField(
-          m.summary.predictions.schema(m.summary.featuresCol))
+          m.summary.predictions.schema(m.getFeaturesCol))
         if (m.getFitIntercept) {
           Array("(Intercept)") ++ attrs.attributes.get.map(_.name.get) ++ Array("Log(scale)")
         } else {

--- a/mllib/src/main/scala/org/apache/spark/ml/r/SparkRWrappers.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/SparkRWrappers.scala
@@ -17,12 +17,13 @@
 
 package org.apache.spark.ml.api.r
 
+import org.apache.spark.SparkException
 import org.apache.spark.ml.{Pipeline, PipelineModel}
 import org.apache.spark.ml.attribute._
 import org.apache.spark.ml.classification.{LogisticRegression, LogisticRegressionModel}
 import org.apache.spark.ml.clustering.{KMeans, KMeansModel}
 import org.apache.spark.ml.feature.{RFormula, VectorAssembler}
-import org.apache.spark.ml.regression.{LinearRegression, LinearRegressionModel}
+import org.apache.spark.ml.regression._
 import org.apache.spark.sql.DataFrame
 
 private[r] object SparkRWrappers {
@@ -48,6 +49,43 @@ private[r] object SparkRWrappers {
         .setFitIntercept(formula.hasIntercept)
         .setStandardization(standardize)
     }
+    val pipeline = new Pipeline().setStages(Array(formula, estimator))
+    pipeline.fit(df)
+  }
+
+  def fitAFTSurvivalRegression(
+      value: String,
+      df: DataFrame): PipelineModel = {
+
+    def formulaRewrite(value: String): (String, String) = {
+      var rewrited: String = null
+      var censorCol: String = null
+
+      val regex = "^Surv\\(([^,]*),([^,]*)\\)\\s*\\~\\s*(.*)".r
+      try {
+        val regex(label, censor, features) = value
+        // TODO: Support dot operator.
+        if (features.contains(".")) {
+          throw new UnsupportedOperationException(
+            "Terms of survreg formula can not support dot operator.")
+        }
+        rewrited = label.trim + "~" + features
+        censorCol = censor.trim
+      } catch {
+        case e: MatchError =>
+          throw new SparkException(s"Could not parse formula: $value")
+      }
+
+      (rewrited, censorCol)
+    }
+
+    val (rewritedValue, censorCol) = formulaRewrite(value)
+
+    val formula = new RFormula().setFormula(rewritedValue)
+    val estimator = new AFTSurvivalRegression()
+      .setCensorCol(censorCol)
+      .setFitIntercept(formula.hasIntercept)
+
     val pipeline = new Pipeline().setStages(Array(formula, estimator))
     pipeline.fit(df)
   }
@@ -91,6 +129,12 @@ private[r] object SparkRWrappers {
       }
       case m: KMeansModel =>
         m.clusterCenters.flatMap(_.toArray)
+      case m: AFTSurvivalRegressionModel =>
+        if (m.getFitIntercept) {
+          Array(m.intercept) ++ m.coefficients.toArray ++ Array(math.log(m.scale))
+        } else {
+          m.coefficients.toArray ++ Array(math.log(m.scale))
+        }
     }
   }
 
@@ -151,6 +195,14 @@ private[r] object SparkRWrappers {
         val attrs = AttributeGroup.fromStructField(
           m.summary.predictions.schema(m.summary.featuresCol))
         attrs.attributes.get.map(_.name.get)
+      case m: AFTSurvivalRegressionModel =>
+        val attrs = AttributeGroup.fromStructField(
+          m.summary.predictions.schema(m.summary.featuresCol))
+        if (m.getFitIntercept) {
+          Array("(Intercept)") ++ attrs.attributes.get.map(_.name.get) ++ Array("Log(scale)")
+        } else {
+          attrs.attributes.get.map(_.name.get) ++ Array("Log(scale)")
+        }
     }
   }
 
@@ -162,6 +214,8 @@ private[r] object SparkRWrappers {
         "LogisticRegressionModel"
       case m: KMeansModel =>
         "KMeansModel"
+      case m: AFTSurvivalRegressionModel =>
+        "AFTSurvivalRegressionModel"
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Implement a simple wrapper of `AFTSurvivalRegression` named `survreg` in SparkR.
cc @mengxr 
## How was this patch tested?

unit test.
Output of R:

``` R
> library(survival)
> model <- survreg(Surv(futime, fustat) ~ ecog.ps + rx, ovarian, dist="weibull")
> summary(model)
Call:
survreg(formula = Surv(futime, fustat) ~ ecog.ps + rx, data = ovarian, 
    dist = "weibull")
             Value Std. Error      z        p
(Intercept)  6.897      1.178  5.857 4.72e-09
ecog.ps     -0.385      0.527 -0.731 4.65e-01
rx           0.529      0.529  0.999 3.18e-01
Log(scale)  -0.123      0.252 -0.489 6.25e-01

Scale= 0.884 
```

Output of SparkR:

``` R
> df <- createDataFrame(sqlContext, ovarian)
> model <- survreg(Surv(futime, fustat) ~ ecog_ps + rx, df)
> summary(model)
$coefficients
                 Value
(Intercept)  6.8966932
ecog_ps     -0.3850426
rx           0.5286455
Log(scale)  -0.1234418
```
