### PR TITLE
[Build][Minor] Fix SBT build error with network-yarn module

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -477,7 +477,7 @@ yarn = Module(
     ],
     sbt_test_goals=[
         "yarn/test",
-        "common/network-yarn/test",
+        "network-yarn/test",
     ],
     test_tags=[
         "org.apache.spark.tags.ExtendedYarnTest"


### PR DESCRIPTION
## What changes were proposed in this pull request?

```
error] Expected ID character
[error] Not a valid command: common (similar: completions)
[error] Expected project ID
[error] Expected configuration
[error] Expected ':' (if selecting a configuration)
[error] Expected key
[error] Not a valid key: common (similar: commands)
[error] common/network-yarn/test
```

`common/network-yarn` is not a valid sbt project, we should change to `network-yarn`.
## How was this patch tested?

Locally run the the unit-test.

CC @rxin , we should either change here, or change the sbt project name.
