### PR TITLE
[SPARK-13025] Allow users to set initial model in logistic regression

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -250,7 +250,7 @@ class LogisticRegression @Since("1.2.0") (
   private var optInitialModel: Option[LogisticRegressionModel] = None
 
   /** @group setParam */
-  private[spark] def setInitialModel(model: LogisticRegressionModel): this.type = {
+  def setInitialModel(model: LogisticRegressionModel): this.type = {
     this.optInitialModel = Some(model)
     this
   }


### PR DESCRIPTION
JIRA : [SPARK - 13025](https://issues.apache.org/jira/browse/SPARK-13025?jql=project%20%3D%20SPARK%20AND%20status%20%3D%20Open%20AND%20component%20in%20%28ML%2C%20MLlib%2C%20SparkR%29%20AND%20created%20%3E%3D%20-12w%20ORDER%20BY%20priority%20ASC%2C%20created%20ASC)

Modified access specifier to default(Public) to allow users to set initial model in logistic regression
