### PR TITLE
[SPARK-13607][SQL] Improve compression performance for integer-typed values on cache

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/compression/CompressionScheme.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/compression/CompressionScheme.scala
@@ -64,7 +64,8 @@ private[columnar] trait AllCompressionSchemes extends WithCompressionSchemes {
 
 private[columnar] object CompressionScheme {
   val all: Seq[CompressionScheme] =
-    Seq(PassThrough, RunLengthEncoding, DictionaryEncoding, BooleanBitSet, IntDelta, LongDelta)
+    Seq(PassThrough, RunLengthEncoding, DictionaryEncoding, BooleanBitSet, IntDelta,
+      IntDeltaBinaryPacking, LongDelta)
 
   private val typeIdToScheme = all.map(scheme => scheme.typeId -> scheme).toMap
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/compression/compressionSchemes.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/compression/compressionSchemes.scala
@@ -17,15 +17,17 @@
 
 package org.apache.spark.sql.execution.columnar.compression
 
-import java.nio.ByteBuffer
+import java.nio.{ByteBuffer, ByteOrder}
 
 import scala.collection.mutable
+
+import org.apache.parquet.column.values.bitpacking.Packer
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{MutableRow, SpecificMutableRow}
 import org.apache.spark.sql.execution.columnar._
 import org.apache.spark.sql.types._
-
+import org.apache.spark.unsafe.Platform
 
 private[columnar] case object PassThrough extends CompressionScheme {
   override val typeId = 0
@@ -527,6 +529,286 @@ private[columnar] case object LongDelta extends CompressionScheme {
       val delta = buffer.get()
       prev = if (delta > Byte.MinValue) prev + delta else ByteBufferHelper.getLong(buffer)
       row.setLong(ordinal, prev)
+    }
+  }
+}
+
+/**
+ * Writes integral-type values with delta encoding and binary packing.
+ * The format is as follows:
+ *
+ *  delta-binary-packing := <header> <block>*
+ *  header := <type id> <total value count>
+ *  block := <base value> <min delta> <list of bit widths of miniblocks> <miniblocks>
+ *
+ *  In miniblocks, deltas are written with the fixed bit width that the maximum value has in each
+ *  miniblock. If there are values 3, 1, 5, 2, and 3, this encoding writes delta values with
+ *  3-bit widths in a miniblock.
+ */
+private[columnar] object DeltaBinaryPacking {
+
+  val NUM_VALUES_IN_BLOCK: Int = 1024
+  val NUM_VALUES_IN_MINIBLOCK: Int = 64
+  val NUM_MINIBLOCKS_IN_BLOCK: Int = numMiniBlocks(NUM_VALUES_IN_BLOCK)
+
+  def numMiniBlocks(n: Int): Int = {
+    (n + NUM_VALUES_IN_MINIBLOCK - 1) / NUM_VALUES_IN_MINIBLOCK
+  }
+}
+
+private[columnar] case object IntDeltaBinaryPacking extends CompressionScheme {
+  import DeltaBinaryPacking._
+
+  private val nativeOrderPacker = if (ByteOrder.nativeOrder.equals(ByteOrder.BIG_ENDIAN)) {
+    Packer.BIG_ENDIAN
+  } else {
+    Packer.LITTLE_ENDIAN
+  }
+
+  override def typeId: Int = 6
+
+  override def decoder[T <: AtomicType](buffer: ByteBuffer, columnType: NativeColumnType[T])
+    : compression.Decoder[T] = {
+    new Decoder(buffer, INT).asInstanceOf[compression.Decoder[T]]
+  }
+
+  override def encoder[T <: AtomicType](columnType: NativeColumnType[T]): compression.Encoder[T] = {
+    (new Encoder).asInstanceOf[compression.Encoder[T]]
+  }
+
+  override def supports(columnType: ColumnType[_]): Boolean = columnType == INT
+
+  class Encoder extends compression.Encoder[IntegerType.type] {
+    override def compressedSize: Int = {
+      if (compressInProgress) {
+        totalBlocksSize += calculateSizeForBufferingValues()
+        compressInProgress = false
+      }
+      totalBlocksSize
+    }
+
+    override def uncompressedSize: Int = totalValueCount * 4
+
+    private var compressInProgress: Boolean = false
+    private var totalValueCount: Int = 0
+    private var totalBlocksSize: Int = 4 // Initially includes header size
+    private var baseValue: Int = _
+    private var prevValue: Int = _
+    private var minDeltaInCurrentBlock: Int = Integer.MAX_VALUE
+    private var deltaValuesToFlush: Int = 0
+    private val deltaValuesBuffer = new Array[Int](NUM_VALUES_IN_BLOCK)
+    // Uses this buffer to pack 8 values simultaneously in a miniblock.
+    // Since a maximum bit width is 32, the buffer size requires 32 bytes = 4 bytes multiplied by 8.
+    private val miniBlockBufferInByte = new Array[Byte](32)
+    private val bitWidths = new Array[Int](NUM_MINIBLOCKS_IN_BLOCK)
+
+    override def gatherCompressibilityStats(row: InternalRow, ordinal: Int): Unit = {
+      val value = row.getInt(ordinal)
+
+      totalValueCount += 1
+
+      if (!compressInProgress) {
+        prevValue = value
+        compressInProgress = true
+        return
+      }
+
+      val delta = value - prevValue
+      deltaValuesBuffer(deltaValuesToFlush) = delta
+      deltaValuesToFlush += 1
+
+      if (delta < minDeltaInCurrentBlock) {
+        minDeltaInCurrentBlock = delta
+      }
+
+      if (NUM_VALUES_IN_BLOCK == deltaValuesToFlush) {
+        totalBlocksSize += calculateSizeForBufferingValues()
+        minDeltaInCurrentBlock = Integer.MAX_VALUE
+        deltaValuesToFlush = 0
+        compressInProgress = false
+      } else {
+        prevValue = value
+      }
+    }
+
+    override def compress(from: ByteBuffer, to: ByteBuffer): ByteBuffer = {
+      // First, writes data in a header
+      to.putInt(typeId)
+      to.putInt(totalValueCount)
+
+      minDeltaInCurrentBlock = Integer.MAX_VALUE
+      deltaValuesToFlush = 0
+      compressInProgress = false
+
+      while (from.hasRemaining) {
+        val value = INT.extract(from)
+
+        if (!compressInProgress) {
+          prevValue = value
+          baseValue = value
+          compressInProgress = true
+        } else {
+          val delta = value - prevValue
+          deltaValuesBuffer(deltaValuesToFlush) = delta
+          deltaValuesToFlush += 1
+
+          if (delta < minDeltaInCurrentBlock) {
+            minDeltaInCurrentBlock = delta
+          }
+
+          if (NUM_VALUES_IN_BLOCK == deltaValuesToFlush) {
+            flushBuffer(to)
+            minDeltaInCurrentBlock = Integer.MAX_VALUE
+            deltaValuesToFlush = 0
+            compressInProgress = false
+          } else {
+            prevValue = value
+          }
+        }
+      }
+
+      // If data left in buffer, flushes them
+      if (compressInProgress) {
+        flushBuffer(to)
+      }
+
+      assert(!to.hasRemaining)
+
+      to.rewind().asInstanceOf[ByteBuffer]
+    }
+
+    private[this] def calculateSizeForBufferingValues(): Int = {
+      if (compressInProgress) {
+        var totalSizeInBytes = 8
+
+        // Calculates and writes bit widths for each miniblock
+        val miniBlocksToFlush = numMiniBlocks(deltaValuesToFlush)
+        for (i <- 0 until miniBlocksToFlush) {
+          val miniStart = i * NUM_VALUES_IN_MINIBLOCK
+          val miniEnd = Math.min((i + 1) * NUM_VALUES_IN_MINIBLOCK, deltaValuesToFlush)
+          var mask = 0
+          for (j <- miniStart until miniEnd) {
+            mask |= (deltaValuesBuffer(j) - minDeltaInCurrentBlock)
+          }
+
+          val bitWidth = 32 - Integer.numberOfLeadingZeros(mask)
+          totalSizeInBytes += bitWidth * (NUM_VALUES_IN_MINIBLOCK / 8)
+          totalSizeInBytes += 1
+        }
+
+        totalSizeInBytes
+      } else {
+        0
+      }
+    }
+
+    private[this] def flushBuffer(out: ByteBuffer): Unit = {
+      var writePos = out.position()
+
+      // Converts delta values to be the difference to min delta and all positive
+      for (i <- 0 until deltaValuesToFlush) {
+        deltaValuesBuffer(i) -= minDeltaInCurrentBlock
+      }
+
+      // Writes data in a block header
+      Platform.putInt(out.array(), Platform.BYTE_ARRAY_OFFSET + writePos, baseValue)
+      Platform.putInt(out.array(), Platform.BYTE_ARRAY_OFFSET + writePos + 4,
+        minDeltaInCurrentBlock)
+      writePos += 8
+
+      // Calculates and writes bit widths for each miniblock
+      val miniBlocksToFlush = numMiniBlocks(deltaValuesToFlush)
+      for (i <- 0 until miniBlocksToFlush) {
+        val miniStart = i * NUM_VALUES_IN_MINIBLOCK
+        val miniEnd = Math.min((i + 1) * NUM_VALUES_IN_MINIBLOCK, deltaValuesToFlush)
+        var mask = 0
+        for (j <- miniStart until miniEnd) {
+          mask |= deltaValuesBuffer(j)
+        }
+
+        bitWidths(i) = 32 - Integer.numberOfLeadingZeros(mask)
+        Platform.putByte(out.array(), Platform.BYTE_ARRAY_OFFSET + writePos,
+          bitWidths(i).asInstanceOf[Byte])
+        writePos += 1
+      }
+
+      // Finally, writes data in miniblocks
+      for (i <- 0 until miniBlocksToFlush) {
+        val currentBitWidth = bitWidths(i)
+        val packer = nativeOrderPacker.newBytePacker(currentBitWidth)
+        val miniStart = i * NUM_VALUES_IN_MINIBLOCK
+        val miniEnd = (i + 1) * NUM_VALUES_IN_MINIBLOCK
+
+        val prevWritePos = writePos
+        for (j <- miniStart until miniEnd by 8) {
+          // Packs integer-typed 8 deltas simultaneously and convert them into a byte array by
+          // using the packer implemented in parquet.
+          //
+          // TODO: To support encoding LONG-typed columns, we need to implement a packer for
+          // long-typed deltas by ourselves because parquet has no packer for long-typed ones.
+          packer.pack8Values(deltaValuesBuffer, j, miniBlockBufferInByte, 0)
+          Platform.copyMemory(miniBlockBufferInByte, Platform.BYTE_ARRAY_OFFSET, out.array,
+            Platform.BYTE_ARRAY_OFFSET + writePos, currentBitWidth)
+          writePos += currentBitWidth
+        }
+      }
+
+      out.position(writePos)
+    }
+  }
+
+  class Decoder(buffer: ByteBuffer, columnType: NativeColumnType[IntegerType.type])
+    extends compression.Decoder[IntegerType.type] {
+
+    private var currentPos: Int = 0
+    private var totalValueCount = buffer.getInt
+    // Buffer for one base value and delta values
+    private val valuesBuffer = new Array[Int](NUM_VALUES_IN_BLOCK + 1)
+    private val deltaBuffer = new Array[Int](NUM_VALUES_IN_BLOCK)
+    private val miniBlockBufferInByte = new Array[Byte](32)
+    private val bitWidths = new Array[Int](NUM_MINIBLOCKS_IN_BLOCK)
+
+    if (hasNext) loadNextBatch()
+
+    override def hasNext: Boolean = totalValueCount > 0
+
+    override def next(row: MutableRow, ordinal: Int): Unit = {
+      if (currentPos == valuesBuffer.length) {
+        loadNextBatch()
+        currentPos = 0
+      }
+      val value = valuesBuffer(currentPos)
+      currentPos += 1
+      totalValueCount -= 1
+      row.setInt(ordinal, value)
+    }
+
+    private[this] def loadNextBatch(): Unit = {
+      val baseValue = buffer.getInt()
+      val minDeltaInCurrentBlock = buffer.getInt()
+      val miniBlocksToRead = Math.min(NUM_MINIBLOCKS_IN_BLOCK, numMiniBlocks(totalValueCount - 1))
+
+      for (i <- 0 until miniBlocksToRead) {
+        bitWidths(i) = buffer.get().asInstanceOf[Int]
+        assert(bitWidths(i) <= 32)
+      }
+
+      var writePos = 0
+      for (i <- 0 until miniBlocksToRead) {
+        val currentBitWidth = bitWidths(i)
+        val packer = nativeOrderPacker.newBytePacker(currentBitWidth)
+
+        for (j <- 0 until NUM_VALUES_IN_MINIBLOCK / 8) {
+          buffer.get(miniBlockBufferInByte, 0, currentBitWidth)
+          packer.unpack8Values(miniBlockBufferInByte, 0, deltaBuffer, writePos)
+          writePos += 8
+        }
+      }
+
+      valuesBuffer(0) = baseValue
+      for (i <- 1 to NUM_VALUES_IN_BLOCK) {
+        valuesBuffer(i) = valuesBuffer(i - 1) + deltaBuffer(i - 1) + minDeltaInCurrentBlock
+      }
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/compression/CompressionSchemeBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/compression/CompressionSchemeBenchmark.scala
@@ -211,19 +211,21 @@ object CompressionSchemeBenchmark extends AllCompressionSchemes {
     // Intel(R) Core(TM) i7-4578U CPU @ 3.00GHz
     // INT Encode (Lower Skew):            Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     // -------------------------------------------------------------------------------------------
-    // PassThrough(1.000)                         18 /   19       3716.4           0.3       1.0X
-    // RunLengthEncoding(1.001)                 1992 / 2056         33.7          29.7       0.0X
-    // DictionaryEncoding(0.500)                 723 /  739         92.8          10.8       0.0X
-    // IntDelta(0.250)                           368 /  377        182.2           5.5       0.0X
+    // PassThrough(1.000)                         17 /   18       3947.0           0.3       1.0X
+    // RunLengthEncoding(0.994)                 1865 / 1883         36.0          27.8       0.0X
+    // DictionaryEncoding(0.500)                 720 /  728         93.2          10.7       0.0X
+    // IntDelta(0.250)                           397 /  404        169.0           5.9       0.0X
+    // IntDeltaBinaryPacking(0.068)              822 /  838         81.7          12.2       0.0X
     runEncodeBenchmark("INT Encode (Lower Skew)", iters, count, INT, testData)
 
     // Intel(R) Core(TM) i7-4578U CPU @ 3.00GHz
     // INT Decode (Lower Skew):            Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     // -------------------------------------------------------------------------------------------
-    // PassThrough                               821 /  845         81.8          12.2       1.0X
-    // RunLengthEncoding                        1246 / 1256         53.9          18.6       0.7X
-    // DictionaryEncoding                        757 /  766         88.6          11.3       1.1X
-    // IntDelta                                  680 /  689         98.7          10.1       1.2X
+    // PassThrough                               808 /  856         83.1          12.0       1.0X
+    // RunLengthEncoding                        1264 / 1288         53.1          18.8       0.6X
+    // DictionaryEncoding                        747 /  755         89.8          11.1       1.1X
+    // IntDelta                                  674 /  677         99.6          10.0       1.2X
+    // IntDeltaBinaryPacking                     798 /  806         84.1          11.9       1.0X
     runDecodeBenchmark("INT Decode (Lower Skew)", iters, count, INT, testData)
 
     val g2 = genHigherSkewData()
@@ -234,19 +236,21 @@ object CompressionSchemeBenchmark extends AllCompressionSchemes {
     // Intel(R) Core(TM) i7-4578U CPU @ 3.00GHz
     // INT Encode (Higher Skew):           Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     // -------------------------------------------------------------------------------------------
-    // PassThrough(1.000)                         17 /   19       3888.4           0.3       1.0X
-    // RunLengthEncoding(1.339)                 2127 / 2148         31.5          31.7       0.0X
-    // DictionaryEncoding(0.501)                 960 /  972         69.9          14.3       0.0X
-    // IntDelta(0.250)                           362 /  366        185.5           5.4       0.0X
+    // PassThrough(1.000)                         16 /   19       4084.1           0.2       1.0X
+    // RunLengthEncoding(1.328)                 2013 / 2079         33.3          30.0       0.0X
+    // DictionaryEncoding(0.501)                 811 /  814         82.8          12.1       0.0X
+    // IntDelta(0.250)                           399 /  403        168.3           5.9       0.0X
+    // IntDeltaBinaryPacking(0.180)              860 /  866         78.1          12.8       0.0X
     runEncodeBenchmark("INT Encode (Higher Skew)", iters, count, INT, testData)
 
     // Intel(R) Core(TM) i7-4578U CPU @ 3.00GHz
     // INT Decode (Higher Skew):           Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
     // -------------------------------------------------------------------------------------------
-    // PassThrough                               838 /  884         80.1          12.5       1.0X
-    // RunLengthEncoding                        1287 / 1311         52.1          19.2       0.7X
-    // DictionaryEncoding                        844 /  859         79.5          12.6       1.0X
-    // IntDelta                                  764 /  784         87.8          11.4       1.1X
+    // PassThrough                               822 /  833         81.6          12.3       1.0X
+    // RunLengthEncoding                        1302 / 1368         51.6          19.4       0.6X
+    // DictionaryEncoding                        848 /  861         79.1          12.6       1.0X
+    // IntDelta                                  769 /  775         87.3          11.5       1.1X
+    // IntDeltaBinaryPacking                     878 /  888         76.4          13.1       0.9X
     runDecodeBenchmark("INT Decode (Higher Skew)", iters, count, INT, testData)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/compression/DeltaBinaryPackingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/compression/DeltaBinaryPackingSuite.scala
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.columnar.compression
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.expressions.GenericMutableRow
+import org.apache.spark.sql.execution.columnar._
+import org.apache.spark.sql.execution.columnar.ColumnarTestUtils._
+import org.apache.spark.sql.types.IntegralType
+
+class DeltaBinaryPackingSuite extends SparkFunSuite {
+  import DeltaBinaryPacking._
+
+  testDeltaBinaryPacking(new IntColumnStats, INT, IntDeltaBinaryPacking)
+
+  def testDeltaBinaryPacking[I <: IntegralType](
+      columnStats: ColumnStats,
+      columnType: NativeColumnType[I],
+      scheme: CompressionScheme) {
+
+    def skeleton(input: Seq[I#InternalType]) {
+      // -------------
+      // Tests encoder
+      // -------------
+
+      val builder = TestCompressibleColumnBuilder(columnStats, columnType, scheme)
+      input.map { value =>
+        val row = new GenericMutableRow(1)
+        columnType.setField(row, 0, value)
+        builder.appendFrom(row, 0)
+      }
+
+      val buffer = builder.build()
+
+      // -------------
+      // Tests decoder
+      // -------------
+
+      // Column type ID + null count + null positions
+      val headerSize = CompressionScheme.columnHeaderSize(buffer)
+
+      // Rewinds, skips column header and 4 more bytes for compression scheme ID
+      buffer.rewind().position(headerSize + 4)
+
+      val decoder = scheme.decoder(buffer, columnType)
+      val mutableRow = new GenericMutableRow(1)
+
+      if (input.nonEmpty) {
+        input.zipWithIndex.foreach { case (value, index) =>
+          assert(decoder.hasNext)
+          assertResult(value, s"Wrong ${index}-th decoded value") {
+            decoder.next(mutableRow, 0)
+            columnType.getField(mutableRow, 0)
+          }
+        }
+      }
+      assert(!decoder.hasNext)
+    }
+
+    test(s"$scheme: empty column") {
+      skeleton(Seq.empty)
+    }
+
+    test(s"$scheme: write data when data aligned with blocks") {
+      val input = Array.fill[Any](5 * NUM_VALUES_IN_BLOCK)(makeRandomValue(columnType))
+      skeleton(input.map(_.asInstanceOf[I#InternalType]))
+    }
+
+    test(s"$scheme: write data when blocks not fully written") {
+      val input = Array.fill[Any](3 * NUM_VALUES_IN_BLOCK - 3)(makeRandomValue(columnType))
+      skeleton(input.map(_.asInstanceOf[I#InternalType]))
+    }
+
+    test(s"$scheme: write data when mini blocks not fully written") {
+      val input = Array.fill[Any](3 * NUM_VALUES_IN_MINIBLOCK - 3)(makeRandomValue(columnType))
+      skeleton(input.map(_.asInstanceOf[I#InternalType]))
+    }
+
+    test(s"$scheme: write negative deltas") {
+      val input = Array.fill[Any](3 * NUM_VALUES_IN_BLOCK)(makeRandomValue(INT))
+        .zipWithIndex.map {
+          case (value: Int, index: Int) =>
+            (10 - (index * 32 - value % 6)).asInstanceOf[I#InternalType]
+        }
+      skeleton(input)
+    }
+
+    test(s"$scheme: write same deltas") {
+      val input = (0 until 3 * NUM_VALUES_IN_BLOCK).zipWithIndex.map {
+        case (value, index) => (32 * index).asInstanceOf[I#InternalType]
+      }
+      skeleton(input)
+    }
+
+    test(s"$scheme: write same values") {
+      skeleton((0 until 3 * NUM_VALUES_IN_BLOCK).map(_ => 32.asInstanceOf[I#InternalType]))
+    }
+
+    test(s"$scheme: write data when deltas having 0") {
+      val input = (0 until 3 * NUM_VALUES_IN_BLOCK).zipWithIndex.map {
+        case (value, index) => (index / 15).asInstanceOf[I#InternalType]
+      }
+      skeleton(input)
+    }
+
+    test(s"$scheme: write min and max data") {
+      val input = (0 until 3 * NUM_VALUES_IN_BLOCK).zipWithIndex.map {
+        case (value, index) if columnType == INT =>
+          (if (index % 2 == 0) Int.MinValue else Int.MaxValue).asInstanceOf[I#InternalType]
+      }
+      skeleton(input)
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr improves compression performance for integer-typed values on cache to reduce GC pressure.
A goal of this activity is to make in-memory cache size approaching to parquet formatted data size on disk. Since spark uses simpler compression algorithms than parquet does in `compressionSchemes`,
the size of in-memory columnar cache is much bigger than parquet data on disk. In one use-case (See https://www.mail-archive.com/user@spark.apache.org/msg45241.html), 24.59GB of parquet data on disk becomes 41.7GB on cache. This pr uses bit packers implemented in parquet-column that spark already has as a package dependency.
## How was this patch tested?

Add `DeltaBinaryPackingSuite` that uses  various input patterns for compression.
