### PR TITLE
[SPARK-**][SQL][MASTER] Added-TestSuite :Spark-SQL JDBC Oracle dialect fails to map string datatypes to Oracle VARCHAR datatype

### DIFF
--- a/docker-integration-tests/pom.xml
+++ b/docker-integration-tests/pom.xml
@@ -131,6 +131,12 @@
       <artifactId>postgresql</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.oracle</groupId>
+      <artifactId>ojdbc6</artifactId>
+      <version>11.2.0.2.0</version>
+      <scope>test</scope>
+    </dependency>
     <!-- Jersey dependencies, used to override version.
      See https://github.com/apache/spark/pull/9503#issuecomment-154369560 for
      background on why we need to use a newer Jersey only in this test module;

--- a/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
+++ b/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
@@ -112,7 +112,7 @@ abstract class DockerJDBCIntegrationSuite
       // Start the container and wait until the database can accept JDBC connections:
       docker.startContainer(containerId)
       jdbcUrl = db.getJdbcUrl(dockerIp, externalPort)
-      eventually(timeout(60.seconds), interval(1.seconds)) {
+      eventually(timeout(200.seconds), interval(200.seconds)) {
         val conn = java.sql.DriverManager.getConnection(jdbcUrl)
         conn.close()
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
@@ -42,4 +42,9 @@ private case object OracleDialect extends JdbcDialect {
       None
     }
   }
+
+  override def getJDBCType(dt: DataType): Option[JdbcType] = dt match {
+      case StringType => Some(JdbcType("VARCHAR2(255)", java.sql.Types.VARCHAR))
+      case _ => None
+ }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -575,4 +575,10 @@ class JDBCSuite extends SparkFunSuite
       r => assert(!List("testPass", "testUser").exists(r.toString.contains))
     }
   }
+
+  test("SPARK 12941:test Oracle type mapping for StringType to Oracle") {
+    val oracleDialect = JdbcDialects.get("jdbc:oracle://127.0.0.1/db")
+    assert(oracleDialect.getJDBCType(StringType).
+      map(_.databaseTypeDefinition).get == "VARCHAR2(255)")
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added a test suite for the oracle type mapping corresponding to the type StringType
## How was this patch tested?

Tested manually, using the test suite

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
