### PR TITLE
[SPARK-13616][SQL] Let SQLBuilder convert logical plan without a project on top of it

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/SQLBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/SQLBuilder.scala
@@ -88,11 +88,11 @@ class SQLBuilder(logicalPlan: LogicalPlan, sqlContext: SQLContext) extends Loggi
         case r: RepartitionByExpression => toSQL(node)
         case _ =>
           build(
-          "SELECT",
-          node.output.map(_.sql).mkString(", "),
-          "FROM",
-          toSQL(node)
-        )
+            "SELECT",
+            node.output.map(_.sql).mkString(", "),
+            "FROM",
+            toSQL(node)
+          )
       }
     } else {
       toSQL(node)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/SQLBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/SQLBuilder.scala
@@ -53,7 +53,7 @@ class SQLBuilder(logicalPlan: LogicalPlan, sqlContext: SQLContext) extends Loggi
         case e => e
       }
 
-      val generatedSQL = toSQL(canonicalizedPlan)
+      val generatedSQL = toSQL(canonicalizedPlan, true)
       logDebug(
         s"""Built SQL query string successfully from given logical plan:
            |
@@ -75,6 +75,27 @@ class SQLBuilder(logicalPlan: LogicalPlan, sqlContext: SQLContext) extends Loggi
            |${canonicalizedPlan.treeString}
          """.stripMargin)
       throw e
+    }
+  }
+
+  private def toSQL(node: LogicalPlan, topNode: Boolean): String = {
+    if (topNode) {
+      node match {
+        case d: Distinct => toSQL(node)
+        case p: Project => toSQL(node)
+        case a: Aggregate => toSQL(node)
+        case s: Sort => toSQL(node)
+        case r: RepartitionByExpression => toSQL(node)
+        case _ =>
+          build(
+          "SELECT",
+          node.output.map(_.sql).mkString(", "),
+          "FROM",
+          toSQL(node)
+        )
+      }
+    } else {
+      toSQL(node)
     }
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/LogicalPlanToSQLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/LogicalPlanToSQLSuite.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.hive
 
 import scala.util.control.NonFatal
 
+import org.apache.spark.sql.{DataFrame, SQLContext}
+import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SQLTestUtils
 
@@ -52,6 +54,33 @@ class LogicalPlanToSQLSuite extends SQLBuilderTest with SQLTestUtils {
     sql("DROP TABLE IF EXISTS parquet_t1")
     sql("DROP TABLE IF EXISTS parquet_t2")
     sql("DROP TABLE IF EXISTS t0")
+  }
+
+  private def checkPlan(plan: LogicalPlan, sqlContext: SQLContext, expected: String): Unit = {
+    val convertedSQL = try new SQLBuilder(plan, sqlContext).toSQL catch {
+      case NonFatal(e) =>
+        fail(
+          s"""Cannot convert the following logical query plan back to SQL query string:
+             |
+             |# Original logical query plan:
+             |${plan.treeString}
+           """.stripMargin, e)
+    }
+
+    try {
+      checkAnswer(sql(convertedSQL), DataFrame(sqlContext, plan))
+    } catch { case cause: Throwable =>
+      fail(
+        s"""Failed to execute converted SQL string or got wrong answer:
+           |
+           |# Converted SQL query string:
+           |$convertedSQL
+           |
+           |# Original logical query plan:
+           |${plan.treeString}
+         """.stripMargin,
+        cause)
+    }
   }
 
   private def checkHiveQl(hiveQl: String): Unit = {
@@ -155,6 +184,16 @@ class LogicalPlanToSQLSuite extends SQLBuilderTest with SQLTestUtils {
   test("self join with group by") {
     checkHiveQl(
       "SELECT x.key, COUNT(*) FROM parquet_t1 x JOIN parquet_t1 y ON x.key = y.key group by x.key")
+  }
+
+  test("join plan") {
+    val originalSql = "SELECT x.key FROM parquet_t1 x JOIN parquet_t1 y ON x.key = y.key"
+    val plan = sql(originalSql).queryExecution.analyzed
+    val joinPlan = plan.children.collect {
+      case j: Join => j
+    }
+    assert(joinPlan.nonEmpty)
+    checkPlan(joinPlan.head, sqlContext, originalSql)
   }
 
   test("case") {


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-13616
## What changes were proposed in this pull request?

It is possibly that a logical plan has been removed `Project` from the top of it. Or the plan doesn't has a top `Project` from the beginning because it is not necessary. Currently the `SQLBuilder` can't convert such plans back to SQL. This change is to add this feature.
## How was this patch tested?

A test is added to `LogicalPlanToSQLSuite`.
