### PR TITLE
[SPARK-13618][STREAMING][WEB-UI] Make Streaming web UI page display rate-limit lines on statistics graph - Part 1

### DIFF
--- a/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/ReliableKafkaReceiver.scala
+++ b/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/ReliableKafkaReceiver.scala
@@ -289,7 +289,8 @@ class ReliableKafkaReceiver[
       rememberBlockOffsets(blockId)
     }
 
-    def onPushBlock(blockId: StreamBlockId, arrayBuffer: mutable.ArrayBuffer[_]): Unit = {
+    def onPushBlock(blockId: StreamBlockId, arrayBuffer: mutable.ArrayBuffer[_],
+        numRecordsLimit: Long): Unit = {
       // Store block and commit the blocks offset
       storeBlockAndCommitOffset(blockId, arrayBuffer)
     }

--- a/external/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisReceiver.scala
+++ b/external/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisReceiver.scala
@@ -348,7 +348,8 @@ private[kinesis] class KinesisReceiver[T](
     }
 
     /** Callback method called when a block is ready to be pushed / stored. */
-    def onPushBlock(blockId: StreamBlockId, arrayBuffer: mutable.ArrayBuffer[_]): Unit = {
+    def onPushBlock(blockId: StreamBlockId, arrayBuffer: mutable.ArrayBuffer[_],
+        numRecordsLimit: Long): Unit = {
       storeBlockWithRanges(blockId,
         arrayBuffer.asInstanceOf[mutable.ArrayBuffer[T]])
     }

--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/RateLimiter.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/RateLimiter.scala
@@ -17,9 +17,13 @@
 
 package org.apache.spark.streaming.receiver
 
+import scala.collection.mutable.ArrayBuffer
+
 import com.google.common.util.concurrent.{RateLimiter => GuavaRateLimiter}
 
 import org.apache.spark.{Logging, SparkConf}
+import org.apache.spark.util.Clock
+
 
 /** Provides waitToPush() method to limit the rate at which receivers consume data.
   *
@@ -32,7 +36,7 @@ import org.apache.spark.{Logging, SparkConf}
   *
   * @param conf spark configuration
   */
-private[receiver] abstract class RateLimiter(conf: SparkConf) extends Logging {
+private[receiver] abstract class RateLimiter(conf: SparkConf, clock: Clock) extends Logging {
 
   // treated as an upper limit
   private val maxRateLimit = conf.getLong("spark.streaming.receiver.maxRate", Long.MaxValue)
@@ -57,8 +61,10 @@ private[receiver] abstract class RateLimiter(conf: SparkConf) extends Logging {
     if (newRate > 0) {
       if (maxRateLimit > 0) {
         rateLimiter.setRate(newRate.min(maxRateLimit))
+        appendLimitToHistory(newRate.min(maxRateLimit))
       } else {
         rateLimiter.setRate(newRate)
+        appendLimitToHistory(newRate)
       }
     }
 
@@ -67,5 +73,58 @@ private[receiver] abstract class RateLimiter(conf: SparkConf) extends Logging {
    */
   private def getInitialRateLimit(): Long = {
     math.min(conf.getLong("spark.streaming.backpressure.initialRate", maxRateLimit), maxRateLimit)
+  }
+
+  private[receiver] case class RateLimitSnapshot(limit: Double, ts: Long)
+
+  private[receiver] val rateLimitHistory: ArrayBuffer[RateLimitSnapshot] =
+    ArrayBuffer(RateLimitSnapshot(getInitialRateLimit().toDouble, -1L))
+
+  /**
+   * Logs the rateLimit change history, so that we can do a sum later.
+   *
+   * @param rate the new rate
+   * @param ts at which time the rate changed
+   */
+  private[receiver] def appendLimitToHistory(rate: Double, ts: Long = clock.getTimeMillis()) {
+    rateLimitHistory.synchronized {
+      rateLimitHistory += RateLimitSnapshot(rate, ts)
+    }
+  }
+
+  private val blockIntervalMs = conf.getTimeAsMs("spark.streaming.blockInterval", "200ms")
+  require(blockIntervalMs > 0, s"'spark.streaming.blockInterval' should be a positive value")
+
+  /**
+   * Calculate the upper bound of how many events can be received in a block interval.
+   * Note this should be called for each block interval once and only once.
+   *
+   * @param ts the ending timestamp of a block interval
+   * @return the upper bound of how many events can be received in a block interval
+   */
+  private[receiver]  def sumHistoryThenTrim(ts: Long = clock.getTimeMillis()): Long = {
+    var sum: Double = 0
+    rateLimitHistory.synchronized {
+      // first add a RateLimitSnapshot
+      // this RateLimitSnapshot will be used as the ending of this block interval and the beginning
+      // of the next block interval
+      rateLimitHistory += RateLimitSnapshot(rateLimitHistory.last.limit, ts)
+
+      // then do a sum
+      for (idx <- 0 until rateLimitHistory.length - 1) {
+        val duration = rateLimitHistory(idx + 1).ts - (if (rateLimitHistory(idx).ts < 0) {
+          rateLimitHistory.last.ts - blockIntervalMs
+        }
+        else {
+          rateLimitHistory(idx).ts
+        })
+        sum += rateLimitHistory(idx).limit * duration
+      }
+
+      // trim the history to the last one
+      rateLimitHistory.trimStart(rateLimitHistory.length - 1)
+    }
+
+    (sum / 1000).ceil.toLong
   }
 }

--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/Receiver.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/Receiver.scala
@@ -121,7 +121,7 @@ abstract class Receiver[T](val storageLevel: StorageLevel) extends Serializable 
 
   /** Store an ArrayBuffer of received data as a data block into Spark's memory. */
   def store(dataBuffer: ArrayBuffer[T]) {
-    supervisor.pushArrayBuffer(dataBuffer, None, None)
+    supervisor.pushArrayBuffer(dataBuffer, None, None, None)
   }
 
   /**
@@ -130,12 +130,12 @@ abstract class Receiver[T](val storageLevel: StorageLevel) extends Serializable 
    * for being used in the corresponding InputDStream.
    */
   def store(dataBuffer: ArrayBuffer[T], metadata: Any) {
-    supervisor.pushArrayBuffer(dataBuffer, Some(metadata), None)
+    supervisor.pushArrayBuffer(dataBuffer, Some(metadata), None, None)
   }
 
   /** Store an iterator of received data as a data block into Spark's memory. */
   def store(dataIterator: Iterator[T]) {
-    supervisor.pushIterator(dataIterator, None, None)
+    supervisor.pushIterator(dataIterator, None, None, None)
   }
 
   /**
@@ -144,12 +144,12 @@ abstract class Receiver[T](val storageLevel: StorageLevel) extends Serializable 
    * for being used in the corresponding InputDStream.
    */
   def store(dataIterator: java.util.Iterator[T], metadata: Any) {
-    supervisor.pushIterator(dataIterator.asScala, Some(metadata), None)
+    supervisor.pushIterator(dataIterator.asScala, Some(metadata), None, None)
   }
 
   /** Store an iterator of received data as a data block into Spark's memory. */
   def store(dataIterator: java.util.Iterator[T]) {
-    supervisor.pushIterator(dataIterator.asScala, None, None)
+    supervisor.pushIterator(dataIterator.asScala, None, None, None)
   }
 
   /**
@@ -158,7 +158,7 @@ abstract class Receiver[T](val storageLevel: StorageLevel) extends Serializable 
    * for being used in the corresponding InputDStream.
    */
   def store(dataIterator: Iterator[T], metadata: Any) {
-    supervisor.pushIterator(dataIterator, Some(metadata), None)
+    supervisor.pushIterator(dataIterator, Some(metadata), None, None)
   }
 
   /**
@@ -167,7 +167,7 @@ abstract class Receiver[T](val storageLevel: StorageLevel) extends Serializable 
    * that Spark is configured to use.
    */
   def store(bytes: ByteBuffer) {
-    supervisor.pushBytes(bytes, None, None)
+    supervisor.pushBytes(bytes, None, None, None)
   }
 
   /**
@@ -176,7 +176,7 @@ abstract class Receiver[T](val storageLevel: StorageLevel) extends Serializable 
    * for being used in the corresponding InputDStream.
    */
   def store(bytes: ByteBuffer, metadata: Any) {
-    supervisor.pushBytes(bytes, Some(metadata), None)
+    supervisor.pushBytes(bytes, Some(metadata), None, None)
   }
 
   /** Report exceptions in receiving data. */

--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/ReceiverSupervisor.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/ReceiverSupervisor.scala
@@ -74,22 +74,25 @@ private[streaming] abstract class ReceiverSupervisor(
   /** Store the bytes of received data as a data block into Spark's memory. */
   def pushBytes(
       bytes: ByteBuffer,
-      optionalMetadata: Option[Any],
-      optionalBlockId: Option[StreamBlockId]
+      metadataOption: Option[Any],
+      blockIdOption: Option[StreamBlockId],
+      numRecordsLimitOption: Option[Long]
     )
 
   /** Store a iterator of received data as a data block into Spark's memory. */
   def pushIterator(
       iterator: Iterator[_],
-      optionalMetadata: Option[Any],
-      optionalBlockId: Option[StreamBlockId]
+      metadataOption: Option[Any],
+      BlockIdOption: Option[StreamBlockId],
+      numRecordsLimitOption: Option[Long]
     )
 
   /** Store an ArrayBuffer of received data as a data block into Spark's memory. */
   def pushArrayBuffer(
       arrayBuffer: ArrayBuffer[_],
-      optionalMetadata: Option[Any],
-      optionalBlockId: Option[StreamBlockId]
+      metadataOption: Option[Any],
+      blockIdOption: Option[StreamBlockId],
+      numRecordsLimitOption: Option[Long]
     )
 
   /**

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceivedBlockInfo.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceivedBlockInfo.scala
@@ -25,11 +25,15 @@ import org.apache.spark.streaming.util.WriteAheadLogRecordHandle
 private[streaming] case class ReceivedBlockInfo(
     streamId: Int,
     numRecords: Option[Long],
+    numRecordsLimitOption: Option[Long],
     metadataOption: Option[Any],
     blockStoreResult: ReceivedBlockStoreResult
   ) {
 
-  require(numRecords.isEmpty || numRecords.get >= 0, "numRecords must not be negative")
+  require(numRecords.isEmpty || numRecords.get >= 0,
+          "numRecordsOption must not be negative")
+  require(numRecordsLimitOption.isEmpty || numRecordsLimitOption.get >= 0,
+          "numRecordsLimitOption must not be negative")
 
   @volatile private var _isBlockIdValid = true
 

--- a/streaming/src/test/scala/org/apache/spark/streaming/ReceivedBlockTrackerSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/ReceivedBlockTrackerSuite.scala
@@ -293,7 +293,7 @@ class ReceivedBlockTrackerSuite
 
   /** Generate blocks infos using random ids */
   def generateBlockInfos(): Seq[ReceivedBlockInfo] = {
-    List.fill(5)(ReceivedBlockInfo(streamId, Some(0L), None,
+    List.fill(5)(ReceivedBlockInfo(streamId, Some(0L), None, None,
       BlockManagerBasedStoreResult(StreamBlockId(streamId, math.abs(Random.nextInt)), Some(0L))))
   }
 

--- a/streaming/src/test/scala/org/apache/spark/streaming/ReceiverInputDStreamSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/ReceiverInputDStreamSuite.scala
@@ -155,6 +155,6 @@ class ReceiverInputDStreamSuite extends TestSuiteBase with BeforeAndAfterAll {
     } else {
       new BlockManagerBasedStoreResult(blockId, None)
     }
-    new ReceivedBlockInfo(0, None, None, storeResult)
+    new ReceivedBlockInfo(0, None, None, None, storeResult)
   }
 }

--- a/streaming/src/test/scala/org/apache/spark/streaming/ReceiverSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/ReceiverSuite.scala
@@ -298,22 +298,25 @@ class ReceiverSuite extends TestSuiteBase with Timeouts with Serializable {
 
     def pushBytes(
         bytes: ByteBuffer,
-        optionalMetadata: Option[Any],
-        optionalBlockId: Option[StreamBlockId]) {
+        metadataOption: Option[Any],
+        blockIdOption: Option[StreamBlockId],
+        numRecordsLimitOption: Option[Long]) {
       byteBuffers += bytes
     }
 
     def pushIterator(
         iterator: Iterator[_],
-        optionalMetadata: Option[Any],
-        optionalBlockId: Option[StreamBlockId]) {
+        metadataOption: Option[Any],
+        blockIdOption: Option[StreamBlockId],
+        numRecordsLimitOption: Option[Long]) {
       iterators += iterator
     }
 
     def pushArrayBuffer(
         arrayBuffer: ArrayBuffer[_],
-        optionalMetadata: Option[Any],
-        optionalBlockId: Option[StreamBlockId]) {
+        metadataOption: Option[Any],
+        blockIdOption: Option[StreamBlockId],
+        numRecordsLimitOption: Option[Long]) {
       arrayBuffers +=  arrayBuffer
     }
 
@@ -341,7 +344,7 @@ class ReceiverSuite extends TestSuiteBase with Timeouts with Serializable {
 
     def onGenerateBlock(blockId: StreamBlockId) { }
 
-    def onPushBlock(blockId: StreamBlockId, arrayBuffer: ArrayBuffer[_]) {
+    def onPushBlock(blockId: StreamBlockId, arrayBuffer: ArrayBuffer[_], numRecordsLimit: Long) {
       val bufferOfInts = arrayBuffer.map(_.asInstanceOf[Int])
       arrayBuffers += bufferOfInts
       Thread.sleep(0)

--- a/streaming/src/test/scala/org/apache/spark/streaming/receiver/BlockGeneratorSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/receiver/BlockGeneratorSuite.scala
@@ -203,8 +203,8 @@ class BlockGeneratorSuite extends SparkFunSuite with BeforeAndAfter {
   test("block push errors are reported") {
     val listener = new TestBlockGeneratorListener {
       @volatile var errorReported = false
-      override def onPushBlock(
-          blockId: StreamBlockId, arrayBuffer: mutable.ArrayBuffer[_]): Unit = {
+      override def onPushBlock(blockId: StreamBlockId, arrayBuffer: mutable.ArrayBuffer[_],
+                               numRecordsLimit: Long): Unit = {
         throw new SparkException("test")
       }
       override def onError(message: String, throwable: Throwable): Unit = {
@@ -244,7 +244,8 @@ class BlockGeneratorSuite extends SparkFunSuite with BeforeAndAfter {
     @volatile var onAddDataCalled = false
     @volatile var onPushBlockCalled = false
 
-    override def onPushBlock(blockId: StreamBlockId, arrayBuffer: mutable.ArrayBuffer[_]): Unit = {
+    override def onPushBlock(blockId: StreamBlockId, arrayBuffer: mutable.ArrayBuffer[_],
+                             numRecordsLimit: Long): Unit = {
       pushedData.addAll(arrayBuffer.asJava)
       onPushBlockCalled = true
     }

--- a/streaming/src/test/scala/org/apache/spark/streaming/receiver/RateLimiterSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/receiver/RateLimiterSuite.scala
@@ -17,30 +17,86 @@
 
 package org.apache.spark.streaming.receiver
 
-import org.apache.spark.SparkConf
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.util.SystemClock
 
 /** Testsuite for testing the network receiver behavior */
 class RateLimiterSuite extends SparkFunSuite {
 
   test("rate limiter initializes even without a maxRate set") {
     val conf = new SparkConf()
-    val rateLimiter = new RateLimiter(conf) {}
+    val rateLimiter = new RateLimiter(conf, new SystemClock) {}
     rateLimiter.updateRate(105)
     assert(rateLimiter.getCurrentLimit == 105)
   }
 
   test("rate limiter updates when below maxRate") {
     val conf = new SparkConf().set("spark.streaming.receiver.maxRate", "110")
-    val rateLimiter = new RateLimiter(conf) {}
+    val rateLimiter = new RateLimiter(conf, new SystemClock) {}
     rateLimiter.updateRate(105)
     assert(rateLimiter.getCurrentLimit == 105)
   }
 
   test("rate limiter stays below maxRate despite large updates") {
     val conf = new SparkConf().set("spark.streaming.receiver.maxRate", "100")
-    val rateLimiter = new RateLimiter(conf) {}
+    val rateLimiter = new RateLimiter(conf, new SystemClock) {}
     rateLimiter.updateRate(105)
     assert(rateLimiter.getCurrentLimit === 100)
   }
+
+  test("historySumThenTrim() returns expected numRecordsLimit") {
+    val conf = new SparkConf().set("spark.streaming.receiver.maxRate", "100")
+                              .set("spark.streaming.blockInterval", "500ms")
+    val rateLimiter = new RateLimiter(conf, new SystemClock) {}
+
+    // Make sure that rateLimitHistory starts with a special initial snapshot
+    assert(rateLimiter.rateLimitHistory(0).limit == 100)
+    assert(rateLimiter.rateLimitHistory(0).ts == -1)
+
+    // Test if sumHistoryThenTrim() works well with the first batch which
+    // contains a special initial snapshot
+    {
+      rateLimiter.appendLimitToHistory(10, 1100)
+      rateLimiter.appendLimitToHistory(20, 1200)
+      rateLimiter.appendLimitToHistory(30, 1300)
+      rateLimiter.appendLimitToHistory(40, 1400)
+      val sum = rateLimiter.sumHistoryThenTrim(1500)
+      val expectedInMillis = 100 * (1100 - (1500 - 500)) +
+                              10 * (1200 - 1100) +
+                              20 * (1300 - 1200) +
+                              30 * (1400 - 1300) +
+                              40 * (1500 - 1400)
+      val expected = expectedInMillis / 1000
+      assert(sum == expected)
+    }
+
+    assert(rateLimiter.rateLimitHistory.length == 1)
+    assert(rateLimiter.rateLimitHistory(0).limit == 40)
+    assert(rateLimiter.rateLimitHistory(0).ts == 1500)
+
+    {
+      val sum = rateLimiter.sumHistoryThenTrim(2000)
+      val expectedInMillis = 40 * (2000 - 1500)
+      val expected = expectedInMillis / 1000
+      assert(sum == expected)
+    }
+
+    assert(rateLimiter.rateLimitHistory.length == 1)
+    assert(rateLimiter.rateLimitHistory(0).limit == 40)
+    assert(rateLimiter.rateLimitHistory(0).ts == 2000)
+
+    {
+      rateLimiter.appendLimitToHistory(50, 2100)
+      val sum = rateLimiter.sumHistoryThenTrim(2500)
+      val expectedInMillis = 40 * (2100 - 2000) +
+                             50 * (2500 - 2100)
+      val expected = expectedInMillis / 1000
+      assert(sum == expected)
+    }
+
+    assert(rateLimiter.rateLimitHistory.length == 1)
+    assert(rateLimiter.rateLimitHistory(0).limit == 50)
+    assert(rateLimiter.rateLimitHistory(0).ts == 2500)
+  }
+
 }

--- a/streaming/src/test/scala/org/apache/spark/streaming/scheduler/ReceiverTrackerSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/scheduler/ReceiverTrackerSuite.scala
@@ -128,7 +128,9 @@ private[streaming] class RateTestReceiver(receiverId: Int, host: Option[String] 
 
   private lazy val customBlockGenerator = supervisor.createBlockGenerator(
     new BlockGeneratorListener {
-      override def onPushBlock(blockId: StreamBlockId, arrayBuffer: ArrayBuffer[_]): Unit = {}
+      override def onPushBlock(blockId: StreamBlockId,
+                               arrayBuffer: ArrayBuffer[_],
+                               numRecordsLimit: Long): Unit = {}
       override def onError(message: String, throwable: Throwable): Unit = {}
       override def onGenerateBlock(blockId: StreamBlockId): Unit = {}
       override def onAddData(data: Any, metadata: Any): Unit = {}

--- a/streaming/src/test/scala/org/apache/spark/streaming/util/WriteAheadLogSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/util/WriteAheadLogSuite.scala
@@ -453,7 +453,7 @@ class BatchedWriteAheadLogSuite extends CommonWriteAheadLogTests(
 
   test("BatchedWriteAheadLog - serializing and deserializing batched records") {
     val events = Seq(
-      BlockAdditionEvent(ReceivedBlockInfo(0, None, None, null)),
+      BlockAdditionEvent(ReceivedBlockInfo(0, None, None, None, null)),
       BatchAllocationEvent(null, null),
       BatchCleanupEvent(Nil)
     )


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR makes Streaming web UI display rate-limit lines in the statistics graph.

Design doc: https://docs.google.com/document/d/1kGXQEcToNglDK-AbyEJGoYX9wwODimUVf0PetoxuU5M/edit#

Part 1 (this PR):
1. adds in `RateLimiter` a data structure keeping history of rate limit changes, so that calculating the upper bound of how many records we can receive in a block interval is possible;
2. adds  the `numRecordsLimit` information into the path from `BlockGenerator` generates a `Block` to the `ReceivedBlockInfo`;

Part 2: [PR #11633](https://github.com/apache/spark/pull/11633)
Part 3: [PR #11643](https://github.com/apache/spark/pull/11643)
## How was this patch tested?
- units tests 
- manually checked UI(see below)
## Screenshots
### without back pressure

![](https://cloud.githubusercontent.com/assets/15843379/13664195/d2264c48-e6e0-11e5-85e6-f13187d4cbde.png)
### with back pressure

![](https://cloud.githubusercontent.com/assets/15843379/13664196/d2549c7e-e6e0-11e5-9f62-d7f1458f1c27.png)
