### PR TITLE
[SPARK-13635][SQL] Enable LimitPushdown optimizer rule because we have whole-stage codegen for Limit

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -67,7 +67,7 @@ abstract class Optimizer extends RuleExecutor[LogicalPlan] {
       PushPredicateThroughProject,
       PushPredicateThroughGenerate,
       PushPredicateThroughAggregate,
-      // LimitPushDown, // Disabled until we have whole-stage codegen for limit
+      LimitPushDown,
       ColumnPruning,
       // Operator combine
       CollapseRepartition,


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-13635
## What changes were proposed in this pull request?

LimitPushdown optimizer rule has been disabled due to no whole-stage codegen for Limit. As we have whole-stage codegen for Limit now, we should enable it.
## How was this patch tested?

As we only re-enable LimitPushdown optimizer rule, no need to add new tests for it.
