### PR TITLE
[SPARK-13637][SQL] use more information to simplify the code in Expand builder

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -297,12 +297,10 @@ class Analyzer(
           }.asInstanceOf[NamedExpression]
         }
 
-        val child = Project(x.child.output ++ groupByAliases, x.child)
-
         Aggregate(
           groupByAttributes :+ VirtualColumn.groupingIdAttribute,
           aggregations,
-          Expand(x.bitmasks, groupByAttributes, gid, child))
+          Expand(x.bitmasks, groupByAliases, groupByAttributes, gid, x.child))
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The code in `Expand.apply` can be simplified by existing information:
- the `groupByExprs` parameter are all `Attribute`s
- the `child` parameter is a `Project` that append aliased group by expressions to its child's output
## How was this patch tested?

by existing tests.
