### PR TITLE
[SPARK-13642][Yarn] Properly handle signal kill in ApplicationMaster

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -24,10 +24,12 @@ import java.util.concurrent.atomic.AtomicReference
 
 import scala.util.control.NonFatal
 
+import org.apache.commons.lang3.SystemUtils
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.yarn.api._
 import org.apache.hadoop.yarn.api.records._
 import org.apache.hadoop.yarn.conf.YarnConfiguration
+import sun.misc.{Signal, SignalHandler}
 
 import org.apache.spark._
 import org.apache.spark.deploy.SparkHadoopUtil
@@ -115,6 +117,21 @@ private[spark] class ApplicationMaster(
   private val sparkContextRef = new AtomicReference[SparkContext](null)
 
   private var delegationTokenRenewerOption: Option[AMDelegationTokenRenewer] = None
+
+  if (SystemUtils.IS_OS_UNIX) {
+    // Register signal handler for signal "TERM", "INT" and "HUP". For the cases where AM receive a
+    // signal and stop, from RM's aspect this application needs to be reattempted, rather than mark
+    // as success.
+    // Replace this signal handler with SignalLogger in AM side.
+    val signalHandler = new SignalHandler() {
+      override def handle(sig: Signal): Unit = {
+
+        logInfo(s"received signal: ${sig.getName}")
+        finish(FinalApplicationStatus.FAILED, ApplicationMaster.EXIT_SIGNAL)
+      }
+    }
+    Seq("TERM", "INT", "HUP").foreach { sig => Signal.handle(new Signal(sig), signalHandler) }
+  }
 
   def getAttemptId(): ApplicationAttemptId = {
     client.getAttemptId()
@@ -653,11 +670,11 @@ object ApplicationMaster extends Logging {
   private val EXIT_SC_NOT_INITED = 13
   private val EXIT_SECURITY = 14
   private val EXIT_EXCEPTION_USER_CLASS = 15
+  private val EXIT_SIGNAL = 16
 
   private var master: ApplicationMaster = _
 
   def main(args: Array[String]): Unit = {
-    SignalLogger.register(log)
     val amArgs = new ApplicationMasterArguments(args)
     SparkHadoopUtil.get.runAsSparkUser { () =>
       master = new ApplicationMaster(amArgs, new YarnRMClient(amArgs))


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch is fixing the race condition in ApplicationMaster when receiving a signal. In the current implementation, if signal is received and with no any exception, this application will be finished with successful state in Yarn, and there's no another attempt. Actually the application is killed by signal in the runtime, so another attempt is expected.

This patch adds a signal handler to handle the signal things, if signal is received, marking this application finished with failure, rather than success.
## How was this patch tested?

This patch is tested with following situations:
1. Application is finished normally.
2. Application is finished by calling `System.exit(n)`.
3. Application is killed by yarn command.
4. ApplicationMaster is killed by "SIGTERM" send by `kill pid` command.
5. ApplicationMaster is killed by NM with "SIGTERM" in case of NM failure.

All the scenarios return the expected states.

CC @tgravescs , please help to review this fix, thanks a lot.
