### PR TITLE
[ML] testEstimatorAndModelReadWrite should call checkModelData

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/LDASuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/LDASuite.scala
@@ -52,7 +52,8 @@ object LDASuite {
     "checkpointInterval" -> 30,
     "learningOffset" -> 1023.0,
     "learningDecay" -> 0.52,
-    "subsamplingRate" -> 0.051
+    "subsamplingRate" -> 0.051,
+    "docConcentration" -> Array(2.0)
   )
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/util/DefaultReadWriteTest.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/util/DefaultReadWriteTest.scala
@@ -82,6 +82,7 @@ trait DefaultReadWriteTest extends TempDirectory { self: Suite =>
    *  - Explicitly set Params, and train model
    *  - Test save/load using [[testDefaultReadWrite()]] on Estimator and Model
    *  - Check Params on Estimator and Model
+   *  - Compare model data
    *
    * This requires that the [[Estimator]] and [[Model]] share the same set of [[Param]]s.
    * @param estimator  Estimator to test
@@ -117,6 +118,8 @@ trait DefaultReadWriteTest extends TempDirectory { self: Suite =>
       val param = model.getParam(p)
       assert(model.get(param).get === model2.get(param).get)
     }
+
+    checkModelData(model, model2)
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Although we defined `checkModelData` in [`read/write` test](https://github.com/apache/spark/blob/master/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala#L994) of ML estimators/models and pass it to `testEstimatorAndModelReadWrite`, `testEstimatorAndModelReadWrite` omits to call `checkModelData` to check the equality of model data. So actually we did not run the check of model data equality for all test cases currently, we should fix it. 
BTW, fix the bug of LDA read/write test which did not set `docConcentration`. This bug should have failed test, but it does not complain because we did not run `checkModelData` actually. 
cc @jkbradley @mengxr 
## How was this patch tested?

No new unit test, should pass the exist ones.
