### PR TITLE
[SPARK-13678][SQL] transformExpressions should only apply on QueryPlan.expressions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -510,17 +510,6 @@ class Analyzer(
           ordering.map(order => resolveExpression(order, child).asInstanceOf[SortOrder])
         Sort(newOrdering, global, child)
 
-      // A special case for Generate, because the output of Generate should not be resolved by
-      // ResolveReferences. Attributes in the output will be resolved by ResolveGenerate.
-      case g @ Generate(generator, join, outer, qualifier, output, child)
-        if child.resolved && !generator.resolved =>
-        val newG = resolveExpression(generator, child, throws = true)
-        if (newG.fastEquals(generator)) {
-          g
-        } else {
-          Generate(newG.asInstanceOf[Generator], join, outer, qualifier, output, child)
-        }
-
       // A special case for ObjectOperator, because the deserializer expressions in ObjectOperator
       // should be resolved by their corresponding attributes instead of children's output.
       case o: ObjectOperator if containsUnresolvedDeserializer(o.deserializers.map(_._1)) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.plans
 
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.trees.{TreeNodeRef, TreeNode}
+import org.apache.spark.sql.catalyst.trees.{TreeNode, TreeNodeRef}
 import org.apache.spark.sql.types.{DataType, StructType}
 
 abstract class QueryPlan[PlanType <: TreeNode[PlanType]] extends TreeNode[PlanType] {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.plans
 
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.trees.TreeNode
+import org.apache.spark.sql.catalyst.trees.{TreeNodeRef, TreeNode}
 import org.apache.spark.sql.types.{DataType, StructType}
 
 abstract class QueryPlan[PlanType <: TreeNode[PlanType]] extends TreeNode[PlanType] {
@@ -107,8 +107,14 @@ abstract class QueryPlan[PlanType <: TreeNode[PlanType]] extends TreeNode[PlanTy
    */
   def missingInput: AttributeSet = references -- inputSet -- producedAttributes
 
+  private lazy val expressionRefs = expressions.map(new TreeNodeRef(_)).toSet
+
+  protected def isOneOfExpressions(e: Expression): Boolean = {
+    expressionRefs.contains(new TreeNodeRef(e))
+  }
+
   /**
-   * Runs [[transform]] with `rule` on all expressions present in this query operator.
+   * Runs [[transform]] with `rule` on all expressions returned by [[expressions]] of this plan.
    * Users should not expect a specific directionality. If a specific directionality is needed,
    * transformExpressionsDown or transformExpressionsUp should be used.
    *
@@ -137,8 +143,8 @@ abstract class QueryPlan[PlanType <: TreeNode[PlanType]] extends TreeNode[PlanTy
     }
 
     def recursiveTransform(arg: Any): AnyRef = arg match {
-      case e: Expression => transformExpressionDown(e)
-      case Some(e: Expression) => Some(transformExpressionDown(e))
+      case e: Expression if isOneOfExpressions(e) => transformExpressionDown(e)
+      case Some(e: Expression) if isOneOfExpressions(e) => Some(transformExpressionDown(e))
       case m: Map[_, _] => m
       case d: DataType => d // Avoid unpacking Structs
       case seq: Traversable[_] => seq.map(recursiveTransform)
@@ -171,8 +177,8 @@ abstract class QueryPlan[PlanType <: TreeNode[PlanType]] extends TreeNode[PlanTy
     }
 
     def recursiveTransform(arg: Any): AnyRef = arg match {
-      case e: Expression => transformExpressionUp(e)
-      case Some(e: Expression) => Some(transformExpressionUp(e))
+      case e: Expression if isOneOfExpressions(e) => transformExpressionUp(e)
+      case Some(e: Expression) if isOneOfExpressions(e) => Some(transformExpressionUp(e))
       case m: Map[_, _] => m
       case d: DataType => d // Avoid unpacking Structs
       case seq: Traversable[_] => seq.map(recursiveTransform)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
@@ -155,7 +155,7 @@ abstract class LogicalPlan extends QueryPlan[LogicalPlan] with Logging {
 
     productIterator.map {
       // Children are checked using sameResult above.
-      case tn: TreeNode[_] if containsChild(tn) => null
+      case tn: TreeNode[_] if isOneOfChildren(tn) => null
       case e: Expression => cleanExpression(e)
       case s: Option[_] => s.map {
         case e: Expression => cleanExpression(e)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/PlanTest.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/PlanTest.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.catalyst.plans
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.plans.logical.{Generate, Filter, LogicalPlan, OneRowRelation}
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, Generate, LogicalPlan, OneRowRelation}
 import org.apache.spark.sql.catalyst.util._
 
 /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Similar to `TreeNode.transform`, which only apply the rule on its children, `QueryPlan.transformExpressions` should also only apply the rule on its expressions(i.e. returned by `Query.expressions`). I think it's more intuitive to exclude the expressions that are not defined as this plan's expressions, for example, `Generate.generatorOutput` should not be touched by `transformExpressions`.

This PR also did some renaming in `TreeNode` to make the code more readable, and removed the analyzer trick for `Generate`.
## How was this patch tested?

existing tests.
