### PR TITLE
[SPARK-13663] Upgrade Snappy Java to 1.1.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
     <jline.groupid>org.scala-lang</jline.groupid>
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
     <fasterxml.jackson.version>2.5.3</fasterxml.jackson.version>
-    <snappy.version>1.1.2</snappy.version>
+    <snappy.version>1.1.2.1</snappy.version>
     <netlib.java.version>1.1.2</netlib.java.version>
     <calcite.version>1.2.0-incubating</calcite.version>
     <commons-codec.version>1.10</commons-codec.version>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
@@ -75,7 +75,7 @@ import org.apache.spark.unsafe.types.UTF8String
  *       byte[]
  *       java.sql.Date
  *       java.sql.Timestamp
- *   Writables :
+ *   Writables:
  *       org.apache.hadoop.hive.serde2.io.HiveVarcharWritable
  *       org.apache.hadoop.hive.serde2.io.HiveCharWritable
  *       org.apache.hadoop.io.Text

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
@@ -75,7 +75,7 @@ import org.apache.spark.unsafe.types.UTF8String
  *       byte[]
  *       java.sql.Date
  *       java.sql.Timestamp
- *   Writables:
+ *   Writables :
  *       org.apache.hadoop.hive.serde2.io.HiveVarcharWritable
  *       org.apache.hadoop.hive.serde2.io.HiveCharWritable
  *       org.apache.hadoop.io.Text


### PR DESCRIPTION
## What changes were proposed in this pull request?

The JVM memory leaky problem reported in https://github.com/xerial/snappy-java/issues/131 has been resolved in 1.1.2.1 release.
This PR upgrades snappy-java to 1.1.2.1 release.
## How was this patch tested?

Through unit tests.
