### PR TITLE
SPARK-13688: Add spark.dynamicAllocation.overrideNumInstances.

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -26,7 +26,7 @@ import com.codahale.metrics.{Gauge, MetricRegistry}
 
 import org.apache.spark.metrics.source.Source
 import org.apache.spark.scheduler._
-import org.apache.spark.util.{Clock, SystemClock, ThreadUtils}
+import org.apache.spark.util.{Utils, Clock, SystemClock, ThreadUtils}
 
 /**
  * An agent that dynamically allocates and removes executors based on the workload.
@@ -86,9 +86,8 @@ private[spark] class ExecutorAllocationManager(
   import ExecutorAllocationManager._
 
   // Lower and upper bounds on the number of executors.
-  private val minNumExecutors = conf.getInt("spark.dynamicAllocation.minExecutors", 0)
-  private val maxNumExecutors = conf.getInt("spark.dynamicAllocation.maxExecutors",
-    Integer.MAX_VALUE)
+  private val minNumExecutors = Utils.getDynamicAllocationMinExecutors(conf)
+  private val maxNumExecutors = Utils.getDynamicAllocationMaxExecutors(conf)
   private val initialNumExecutors = conf.getInt("spark.dynamicAllocation.initialExecutors",
     minNumExecutors)
 

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2253,11 +2253,36 @@ private[spark] object Utils extends Logging {
   def isDynamicAllocationEnabled(conf: SparkConf): Boolean = {
     val numExecutor = conf.getInt("spark.executor.instances", 0)
     val dynamicAllocationEnabled = conf.getBoolean("spark.dynamicAllocation.enabled", false)
+    val overrideExecutors = conf.getBoolean("spark.dynamicAllocation.overrideNumInstances", false)
     if (numExecutor != 0 && dynamicAllocationEnabled) {
-      logWarning("Dynamic Allocation and num executors both set, thus dynamic allocation disabled.")
+      if (overrideExecutors) {
+        logWarning(
+          "Dynamic Allocation and num executors both set, spark.executor.instances will override " +
+          "spark.dynamicAllocation.minExecutors.")
+      } else {
+        logWarning(
+          "Dynamic Allocation and num executors both set, thus dynamic allocation disabled.")
+      }
     }
-    numExecutor == 0 && dynamicAllocationEnabled &&
+    dynamicAllocationEnabled && (numExecutor == 0 || overrideExecutors) &&
       (!isLocalMaster(conf) || conf.getBoolean("spark.dynamicAllocation.testing", false))
+  }
+
+  /**
+   * Return the minimum number of executors for dynamic allocation.
+   *
+   * If spark.executor.instances is set and larger than spark.dynamicAllocation.minExecutors, the
+   * it will be returned as the dynamic allocation minimum. This assumes that it was overridden by
+   * spark.dynamicAllocation.overrideNumInstances (or else this method would not be called).
+   */
+  def getDynamicAllocationMinExecutors(conf: SparkConf): Int = {
+    math.max(
+      conf.getInt("spark.dynamicAllocation.minExecutors", 0),
+      conf.getInt("spark.executor.instances", 0))
+  }
+
+  def getDynamicAllocationMaxExecutors(conf: SparkConf): Int = {
+    conf.getInt("spark.dynamicAllocation.maxExecutors", Integer.MAX_VALUE)
   }
 
   def tryWithResource[R <: Closeable, T](createResource: => R)(f: R => T): T = {

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -732,8 +732,34 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
       conf.set("spark.executor.instances", "1")) === false)
     assert(Utils.isDynamicAllocationEnabled(
       conf.set("spark.executor.instances", "0")) === true)
+    assert(Utils.isDynamicAllocationEnabled(conf.set("spark.executor.instances", "1")
+      .set("spark.dynamicAllocation.overrideNumInstances", "true")) === true)
+    assert(Utils.isDynamicAllocationEnabled(conf.set("spark.executor.instances", "0")
+      .set("spark.dynamicAllocation.overrideNumInstances", "true")) === true)
+    assert(Utils.isDynamicAllocationEnabled(conf.set("spark.executor.instances", "1")
+      .set("spark.dynamicAllocation.overrideNumInstances", "false")) === false)
+    assert(Utils.isDynamicAllocationEnabled(conf.set("spark.executor.instances", "0")
+      .set("spark.dynamicAllocation.overrideNumInstances", "false")) === true)
     assert(Utils.isDynamicAllocationEnabled(conf.set("spark.master", "local")) === false)
     assert(Utils.isDynamicAllocationEnabled(conf.set("spark.dynamicAllocation.testing", "true")))
+  }
+
+  test("getDynamicAllocationMinExecutors") {
+    val conf = new SparkConf()
+    assert(Utils.getDynamicAllocationMinExecutors(conf) === 0)
+    assert(Utils.getDynamicAllocationMinExecutors(
+      conf.set("spark.dynamicAllocation.minExecutors", "3")) === 3)
+    assert(Utils.getDynamicAllocationMinExecutors( // should use minExecutors
+      conf.set("spark.executor.instances", "2")) === 3)
+    assert(Utils.getDynamicAllocationMinExecutors( // should use executor.instances
+      conf.set("spark.executor.instances", "4")) === 4)
+  }
+
+  test("getDynamicAllocationMaxExecutors") {
+    val conf = new SparkConf()
+    assert(Utils.getDynamicAllocationMaxExecutors(conf) === Integer.MAX_VALUE)
+    assert(Utils.getDynamicAllocationMaxExecutors(
+      conf.set("spark.dynamicAllocation.maxExecutors", "500")) === 500)
   }
 
   test("encodeFileNameToURIRawPath") {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1164,11 +1164,23 @@ Apart from these, the following properties are also available, and may be useful
     For more detail, see the description
     <a href="job-scheduling.html#dynamic-resource-allocation">here</a>.
     <br><br>
+    This property is incompatible with <code>spark.executor.instances</code>, which statically sets
+    the number of executors. When both properties are set, static resource allocation will be used.
+    To change the default behavior, use <code>spark.dynamicAllocation.overrideNumInstances</code>.
+    <br><br>
     This requires <code>spark.shuffle.service.enabled</code> to be set.
     The following configurations are also relevant:
     <code>spark.dynamicAllocation.minExecutors</code>,
     <code>spark.dynamicAllocation.maxExecutors</code>, and
     <code>spark.dynamicAllocation.initialExecutors</code>
+  </td>
+</tr>
+<tr>
+  <td><code>spark.dynamicAllocation.overrideNumInstances</code></td>
+  <td>
+    Whether to use dynamic resource allocation when dynamic allocation is enabled, but a static
+    number of executor instances, <code>spark.executor.instances</code>, is set. By default, a
+    statically configured number of executor instances will turn off dynamic resource allocation.
   </td>
 </tr>
 <tr>

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtil.scala
@@ -509,10 +509,10 @@ object YarnSparkHadoopUtil {
       conf: SparkConf,
       numExecutors: Int = DEFAULT_NUMBER_EXECUTORS): Int = {
     if (Utils.isDynamicAllocationEnabled(conf)) {
-      val minNumExecutors = conf.getInt("spark.dynamicAllocation.minExecutors", 0)
+      val minNumExecutors = Utils.getDynamicAllocationMinExecutors(conf)
       val initialNumExecutors =
         conf.getInt("spark.dynamicAllocation.initialExecutors", minNumExecutors)
-      val maxNumExecutors = conf.getInt("spark.dynamicAllocation.maxExecutors", Int.MaxValue)
+      val maxNumExecutors = Utils.getDynamicAllocationMaxExecutors(conf)
       require(initialNumExecutors >= minNumExecutors && initialNumExecutors <= maxNumExecutors,
         s"initial executor number $initialNumExecutors must between min executor number" +
           s"$minNumExecutors and max executor number $maxNumExecutors")


### PR DESCRIPTION
When both the number of executor instances and dynamic allocation are configured, dynamic allocation is ignored and the number of executors is statically set. This introduces a configuration property to change this behavior so that cluster administrators can make dynamic allocation the default when users set `--num-executors` instead of `spark.dynamicAllocation.minExecutors` and unintentionally disable dynamic allocation for a job.

This includes unit tests for the new cases and updates to documentation.
