### PR TITLE
[SPARK-13698][SQL] Fix Analysis Exceptions when Using Backticks in Generate

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/CatalystQl.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/CatalystQl.scala
@@ -999,10 +999,16 @@ https://cwiki.apache.org/confluence/display/Hive/Enhanced+Aggregation%2C+Cube%2C
     }
 
     val attributes = clauses.collect {
-      case Token(a, Nil) => UnresolvedAttribute(a.toLowerCase)
+      case Token(a, Nil) => UnresolvedAttribute(cleanIdentifier(a.toLowerCase))
     }
 
-    Generate(generator, join = true, outer = outer, Some(alias.toLowerCase), attributes, child)
+    Generate(
+      generator,
+      join = true,
+      outer = outer,
+      Some(cleanIdentifier(alias.toLowerCase)),
+      attributes,
+      child)
   }
 
   protected def nodeToGenerator(node: ASTNode): Generator = noParseRule("Generator", node)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveQlSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveQlSuite.scala
@@ -208,4 +208,13 @@ class HiveQlSuite extends SparkFunSuite with BeforeAndAfterAll {
         |USING 'cat' AS (`thing1` int, `thing2` string) FROM `default`.`parquet_t1`) AS t
       """.stripMargin)
   }
+
+  test("use backticks in output of Generator") {
+    val plan = parser.parsePlan(
+      """SELECT `gentab2`.`gencol2`
+        |FROM `default`.`src`
+        |LATERAL VIEW explode(array(array(1, 2, 3))) `gentab1` AS `gencol1`
+        |LATERAL VIEW explode(`gentab1`.`gencol1`) `gentab2` AS `gencol2`
+      """.stripMargin)
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveQlSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveQlSuite.scala
@@ -211,7 +211,8 @@ class HiveQlSuite extends SparkFunSuite with BeforeAndAfterAll {
 
   test("use backticks in output of Generator") {
     val plan = parser.parsePlan(
-      """SELECT `gentab2`.`gencol2`
+      """
+        |SELECT `gentab2`.`gencol2`
         |FROM `default`.`src`
         |LATERAL VIEW explode(array(array(1, 2, 3))) `gentab1` AS `gencol1`
         |LATERAL VIEW explode(`gentab1`.`gencol1`) `gentab2` AS `gencol2`
@@ -220,9 +221,10 @@ class HiveQlSuite extends SparkFunSuite with BeforeAndAfterAll {
 
   test("use escaped backticks in output of Generator") {
     val plan = parser.parsePlan(
-      """SELECT `gen``tab2`.`gen``col2`
+      """
+        |SELECT `gen``tab2`.`gen``col2`
         |FROM `default`.`src`
-        |LATERAL VIEW explode(array(array(1, 2, 3))) `gen``tab1` AS `gen``col1`
+        |LATERAL VIEW explode(array(array(1, 2,  3))) `gen``tab1` AS `gen``col1`
         |LATERAL VIEW explode(`gen``tab1`.`gen``col1`) `gen``tab2` AS `gen``col2`
       """.stripMargin)
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveQlSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveQlSuite.scala
@@ -217,4 +217,13 @@ class HiveQlSuite extends SparkFunSuite with BeforeAndAfterAll {
         |LATERAL VIEW explode(`gentab1`.`gencol1`) `gentab2` AS `gencol2`
       """.stripMargin)
   }
+
+  test("use escaped backticks in output of Generator") {
+    val plan = parser.parsePlan(
+      """SELECT `gen``tab2`.`gen``col2`
+        |FROM `default`.`src`
+        |LATERAL VIEW explode(array(array(1, 2, 3))) `gen``tab1` AS `gen``col1`
+        |LATERAL VIEW explode(`gen``tab1`.`gen``col1`) `gen``tab2` AS `gen``col2`
+      """.stripMargin)
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -265,8 +265,10 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
 
     checkAnswer(
       sql(
-        """SELECT `weird``tab`.`weird``col`
-          |FROM nestedArray LATERAL VIEW explode(a.b) `weird``tab` AS `weird``col`
+        """
+          |SELECT `weird``tab`.`weird``col`
+          |FROM nestedArray
+          |LATERAL VIEW explode(a.b) `weird``tab` AS `weird``col`
         """.stripMargin),
       Row(1) :: Row(2) :: Row(3) :: Nil)
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -262,6 +262,10 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
     checkAnswer(
       sql("SELECT `a`.`ints` FROM nestedArray LATERAL VIEW explode(a.b) `a` AS `ints`"),
       Row(1) :: Row(2) :: Row(3) :: Nil)
+
+    checkAnswer(
+      sql("SELECT `weird``tab`.`weird``col` FROM nestedArray LATERAL VIEW explode(a.b) `weird``tab` AS `weird``col`"),
+      Row(1) :: Row(2) :: Row(3) :: Nil)
   }
 
   test("SPARK-4512 Fix attribute reference resolution error when using SORT BY") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -254,6 +254,14 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
     checkAnswer(
       sql("SELECT ints FROM nestedArray LATERAL VIEW explode(a.b) a AS ints"),
       Row(1) :: Row(2) :: Row(3) :: Nil)
+
+    checkAnswer(
+      sql("SELECT `ints` FROM nestedArray LATERAL VIEW explode(a.b) `a` AS `ints`"),
+      Row(1) :: Row(2) :: Row(3) :: Nil)
+
+    checkAnswer(
+      sql("SELECT `a`.`ints` FROM nestedArray LATERAL VIEW explode(a.b) `a` AS `ints`"),
+      Row(1) :: Row(2) :: Row(3) :: Nil)
   }
 
   test("SPARK-4512 Fix attribute reference resolution error when using SORT BY") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -264,7 +264,10 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
       Row(1) :: Row(2) :: Row(3) :: Nil)
 
     checkAnswer(
-      sql("SELECT `weird``tab`.`weird``col` FROM nestedArray LATERAL VIEW explode(a.b) `weird``tab` AS `weird``col`"),
+      sql(
+        """SELECT `weird``tab`.`weird``col`
+          |FROM nestedArray LATERAL VIEW explode(a.b) `weird``tab` AS `weird``col`
+        """.stripMargin),
       Row(1) :: Row(2) :: Row(3) :: Nil)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Analysis exception occurs while running the following query.

```
SELECT ints FROM nestedArray LATERAL VIEW explode(a.b) `a` AS `ints`
```

```
Failed to analyze query: org.apache.spark.sql.AnalysisException: cannot resolve '`ints`' given input columns: [a, `ints`]; line 1 pos 7
'Project ['ints]
+- Generate explode(a#0.b), true, false, Some(a), [`ints`#8]
   +- SubqueryAlias nestedarray
      +- LocalRelation [a#0], [[[[1,2,3]]]]
```
## How was this patch tested?

Added new unit tests in SQLQuerySuite and HiveQlSuite
