### PR TITLE
Revert "[SPARK-13616][SQL] Let SQLBuilder convert logical plan without a project on top of it"

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/SQLBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/SQLBuilder.scala
@@ -65,7 +65,7 @@ class SQLBuilder(logicalPlan: LogicalPlan, sqlContext: SQLContext) extends Loggi
         case e => e
       }
 
-      val generatedSQL = toSQL(replaced, true)
+      val generatedSQL = toSQL(replaced)
       logDebug(
         s"""Built SQL query string successfully from given logical plan:
            |
@@ -87,27 +87,6 @@ class SQLBuilder(logicalPlan: LogicalPlan, sqlContext: SQLContext) extends Loggi
            |${canonicalizedPlan.treeString}
          """.stripMargin)
       throw e
-    }
-  }
-
-  private def toSQL(node: LogicalPlan, topNode: Boolean): String = {
-    if (topNode) {
-      node match {
-        case d: Distinct => toSQL(node)
-        case p: Project => toSQL(node)
-        case a: Aggregate => toSQL(node)
-        case s: Sort => toSQL(node)
-        case r: RepartitionByExpression => toSQL(node)
-        case _ =>
-          build(
-            "SELECT",
-            node.output.map(_.sql).mkString(", "),
-            "FROM",
-            toSQL(node)
-          )
-      }
-    } else {
-      toSQL(node)
     }
   }
 


### PR DESCRIPTION
This reverts commit f87ce0504ea0697969ac3e67690c78697b76e94a.

According to discussion in #11466, let's revert PR #11466 for safe.
