### PR TITLE
Fixing the type of the sentiment happiness value

### DIFF
--- a/examples/src/main/scala/org/apache/spark/examples/streaming/TwitterHashTagJoinSentiments.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/streaming/TwitterHashTagJoinSentiments.scala
@@ -57,7 +57,7 @@ object TwitterHashTagJoinSentiments {
     val wordSentiments = ssc.sparkContext.textFile(wordSentimentFilePath).map { line =>
       val Array(word, happinessValue) = line.split("\t")
       (word, happinessValue.toInt)
-    } cache()
+    }.cache()
 
     // Determine the hash tags with the highest sentiment values by joining the streaming RDD
     // with the static RDD inside the transform() method and then multiplying

--- a/examples/src/main/scala/org/apache/spark/examples/streaming/TwitterHashTagJoinSentiments.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/streaming/TwitterHashTagJoinSentiments.scala
@@ -56,7 +56,7 @@ object TwitterHashTagJoinSentiments {
     val wordSentimentFilePath = "data/streaming/AFINN-111.txt"
     val wordSentiments = ssc.sparkContext.textFile(wordSentimentFilePath).map { line =>
       val Array(word, happinessValue) = line.split("\t")
-      (word, happinessValue)
+      (word, happinessValue.toInt)
     } cache()
 
     // Determine the hash tags with the highest sentiment values by joining the streaming RDD


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added the conversion to int for the 'happiness value' read from the file. Otherwise, later on line 75 the multiplication will multiply a string by a number, yielding values like "-2-2" instead of -4.
## How was this patch tested?

Tested manually.
