### PR TITLE
[SPARK-10380] Confusing examples in pyspark SQL docs

### DIFF
--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -320,11 +320,12 @@ class Column(object):
     def cast(self, dataType):
         """ Convert the column into type ``dataType``.
 
+        :func:`cast` is an alias for :func:`astype`.
+
         >>> df.select(df.age.cast("string").alias('ages')).collect()
         [Row(ages=u'2'), Row(ages=u'5')]
         >>> df.select(df.age.cast(StringType()).alias('ages')).collect()
         [Row(ages=u'2'), Row(ages=u'5')]
-        :func:`cast` is an alias for :func:`astype`.
         """
         if isinstance(dataType, basestring):
             jc = self._jc.cast(dataType)

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -324,6 +324,8 @@ class Column(object):
         [Row(ages=u'2'), Row(ages=u'5')]
         >>> df.select(df.age.cast(StringType()).alias('ages')).collect()
         [Row(ages=u'2'), Row(ages=u'5')]
+
+        :func:`cast` is an alias for :func:`astype`.
         """
         if isinstance(dataType, basestring):
             jc = self._jc.cast(dataType)
@@ -337,7 +339,12 @@ class Column(object):
             raise TypeError("unexpected type: %s" % type(dataType))
         return Column(jc)
 
-    astype = cast
+    @ignore_unicode_prefix
+    @since(1.3)
+    def astype(self, dataType):
+        """
+        :func:`astype` is an alias for :func:`cast`.
+        """
 
     @since(1.3)
     def between(self, lowerBound, upperBound):

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -324,7 +324,6 @@ class Column(object):
         [Row(ages=u'2'), Row(ages=u'5')]
         >>> df.select(df.age.cast(StringType()).alias('ages')).collect()
         [Row(ages=u'2'), Row(ages=u'5')]
-
         :func:`cast` is an alias for :func:`astype`.
         """
         if isinstance(dataType, basestring):

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -974,6 +974,11 @@ class DataFrame(object):
             jdf = self._jdf.dropDuplicates(self._jseq(subset))
         return DataFrame(jdf, self.sql_ctx)
 
+    def dropDuplicates(self, subset=None):
+        """
+        :func:`drop_duplicates` is an alias for :func:`dropDuplicates`.
+        """
+
     @since("1.3.1")
     def dropna(self, how='any', thresh=None, subset=None):
         """Returns a new :class:`DataFrame` omitting rows with null values.
@@ -1363,7 +1368,6 @@ class DataFrame(object):
     ##########################################################################################
 
     groupby = groupBy
-    drop_duplicates = dropDuplicates
 
 
 def _to_scala_map(sc, jm):


### PR DESCRIPTION
#8647

JIRA : https://issues.apache.org/jira/browse/SPARK-10380

Fixed confusing pyspark examples in SQL docs
