### PR TITLE
IMP add setup.py for pyspark

### DIFF
--- a/python/pyspark/__init__.py
+++ b/python/pyspark/__init__.py
@@ -36,6 +36,30 @@ Public classes:
       Finer-grained cache persistence levels.
 
 """
+import os, re
+
+
+def get_spark_version():
+    """
+    Detect version of Spark located under SPARK_HOME.
+    """
+    libs_path = os.path.join(os.environ['SPARK_HOME'], 'lib')
+    for jar_file in os.listdir(libs_path):
+        if jar_file.startswith('spark-assembly'):
+            try:
+                return re.match('^spark-assembly-(.*)-', jar_file).group(1)
+            except IndexError:
+                raise ImportError("Can't detect Spark version by the assembly file")
+
+    raise ImportError("Can't find file with Spark version")
+
+
+__version__ = '2.0.0'
+if __version__ != get_spark_version():
+    raise ImportError("Incompatible versions of PySpark ({}) and Spark ({})".format(
+        __version__, get_spark_version()
+    ))
+
 
 from pyspark.conf import SparkConf
 from pyspark.context import SparkContext

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,42 @@
+from setuptools import setup
+
+import pyspark
+
+
+setup(
+    name='pyspark',
+    version=pyspark.__version__,
+    packages=[
+        'pyspark',
+        'pyspark.mllib',
+        'pyspark.ml',
+        'pyspark.sql',
+        'pyspark.streaming',
+    ],
+    install_requires=[
+        'py4j==0.9',
+    ],
+    extras_require={
+        'ml': ['numpy>=1.7'],
+        'sql': ['pandas'],
+    },
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Topic :: Software Development',
+        'Intended Audience :: Developers',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'License :: OSI Approved :: Apache Software License',
+    ],
+    description='Apache Spark Python API',
+    keywords='spark pyspark',
+    author='Spark Developers',
+    author_email='dev@spark.apache.org',
+    url='https://github.com/apache/spark/tree/master/python',
+    license='http://www.apache.org/licenses/LICENSE-2.0',
+)


### PR DESCRIPTION
Make PySpark friendly to the Python ecosystem.
Now, we consider it as a package with dependencies on py4j.
Changes were tested manually.

Inspired by - https://github.com/apache/spark/pull/8318
