### PR TITLE
[SPARK-13034] Add export/import for all estimators and transformers(w…

### DIFF
--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -38,7 +38,7 @@ __all__ = ['LogisticRegression', 'LogisticRegressionModel',
 class LogisticRegression(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, HasMaxIter,
                          HasRegParam, HasTol, HasProbabilityCol, HasRawPredictionCol,
                          HasElasticNetParam, HasFitIntercept, HasStandardization, HasThresholds,
-                         HasWeightCol):
+                         HasWeightCol, MLReadable, MLWritable):
     """
     Logistic regression.
     Currently, this class only supports binary classification.
@@ -69,8 +69,19 @@ class LogisticRegression(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredicti
     Traceback (most recent call last):
         ...
     TypeError: Method setParams forces keyword arguments.
+    >>> lr_path = temp_path + "/lr"
+    >>> lr.save(lr_path)
+    >>> lr2 = LogisticRegression.load(lr_path)
+    >>> lr2.getMaxIter()
 
-    .. versionadded:: 1.3.0
+    >>> model_path = temp_path + "/lr_model"
+    >>> model.save(model_path)
+    >>> model2 = LogisticRegressionModel.load(model_path)
+    >>> model.coefficients[0] == model2.coefficients[0]
+
+    >>> model.intercept == model2.intercept
+
+    .. versionadded:: 1.6.0
     """
 
     threshold = Param(Params._dummy(), "threshold",
@@ -186,7 +197,7 @@ class LogisticRegression(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredicti
                                  " threshold (%g) and thresholds (equivalent to %g)" % (t2, t))
 
 
-class LogisticRegressionModel(JavaModel):
+class LogisticRegressionModel(JavaModel, MLWritable, MLReadable):
     """
     Model fitted by LogisticRegression.
 
@@ -545,7 +556,7 @@ class GBTClassificationModel(TreeEnsembleModels):
 
 @inherit_doc
 class NaiveBayes(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, HasProbabilityCol,
-                 HasRawPredictionCol):
+                 HasRawPredictionCol, MLWritable, MLReadable):
     """
     Naive Bayes Classifiers.
     It supports both Multinomial and Bernoulli NB. Multinomial NB
@@ -579,6 +590,16 @@ class NaiveBayes(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, H
     >>> test1 = sc.parallelize([Row(features=Vectors.sparse(2, [0], [1.0]))]).toDF()
     >>> model.transform(test1).head().prediction
     1.0
+    >>> nb_path = temp_path + "/nb"
+    >>> nb.save(nb_path)
+    >>> nb2 = NaiveBayes.load(nb_path)
+    >>> nb2.getSmoothing()
+
+    >>> model_path = temp_path + "/nb_model"
+    >>> model.save(model_path)
+    >>> model2 = NaiveBayesModel.load(model_path)
+    >>> model.pi == model2.pi
+    >>> model.theta == model2.theta
 
     .. versionadded:: 1.5.0
     """
@@ -652,7 +673,7 @@ class NaiveBayes(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, H
         return self.getOrDefault(self.modelType)
 
 
-class NaiveBayesModel(JavaModel):
+class NaiveBayesModel(JavaModel, MLWritable, MLReadable):
     """
     Model fitted by NaiveBayes.
 
@@ -678,7 +699,7 @@ class NaiveBayesModel(JavaModel):
 
 @inherit_doc
 class MultilayerPerceptronClassifier(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol,
-                                     HasMaxIter, HasTol, HasSeed):
+                                     HasMaxIter, HasTol, HasSeed, MLWritable, MLReadable):
     """
     Classifier trainer based on the Multilayer Perceptron.
     Each layer has sigmoid activation function, output layer has softmax.
@@ -708,6 +729,16 @@ class MultilayerPerceptronClassifier(JavaEstimator, HasFeaturesCol, HasLabelCol,
     |[0.0,0.0]|       0.0|
     +---------+----------+
     ...
+    >>> mlp_path = temp_path + "/mlp"
+    >>> mlp.save(aftsr_path)
+    >>> mlp2 = MultilayerPerceptronClassifier.load(mlp_path)
+    >>> mlp2.getMaxIter()
+
+    >>> model_path = temp_path + "/mlp_model"
+    >>> model.save(model_path)
+    >>> model2 = MultilayerPerceptronClassificationModel.load(model_path)
+    >>> model.weights == model2.weights
+    >>> model.layers == model2.layers
 
     .. versionadded:: 1.6.0
     """
@@ -783,7 +814,7 @@ class MultilayerPerceptronClassifier(JavaEstimator, HasFeaturesCol, HasLabelCol,
         return self.getOrDefault(self.blockSize)
 
 
-class MultilayerPerceptronClassificationModel(JavaModel):
+class MultilayerPerceptronClassificationModel(JavaModel, MLWritable, MLReadable):
     """
     Model fitted by MultilayerPerceptronClassifier.
 
@@ -811,15 +842,25 @@ if __name__ == "__main__":
     import doctest
     from pyspark.context import SparkContext
     from pyspark.sql import SQLContext
-    globs = globals().copy()
+    globs = pyspark.ml.classification.__dict__.copy()
     # The small batch size here ensures that we see multiple batches,
     # even in these small test examples:
     sc = SparkContext("local[2]", "ml.classification tests")
     sqlContext = SQLContext(sc)
     globs['sc'] = sc
     globs['sqlContext'] = sqlContext
-    (failure_count, test_count) = doctest.testmod(
-        globs=globs, optionflags=doctest.ELLIPSIS)
-    sc.stop()
+    import tempfile
+    temp_path = tempfile.mkdtemp()
+    globs['temp_path'] = temp_path
+    try:
+        (failure_count, test_count) = doctest.testmod(globs=globs, optionflags=doctest.ELLIPSIS)
+        sc.stop()
+    finally:
+        from shutil import rmtree
+        try:
+            rmtree(temp_path)
+        except OSError:
+            pass
     if failure_count:
         exit(-1)
+

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -493,6 +493,57 @@ class PersistenceTest(PySparkTestCase):
         except OSError:
             pass
 
+    def test_logistic_regression(self):
+        lr = LogisticRegression(maxIter=1)
+        path = tempfile.mkdtemp()
+        lr_path = path + "/lr"
+        lr.save(lr_path)
+        lr2 = LogisticRegression.load(lr_path)
+        self.assertEqual(lr2.uid, lr2.maxIter.parent,
+                         "Loaded LogisticRegression instance uid (%s) did not match Param's uid (%s)"
+                         % (lr2.uid, lr2.maxIter.parent))
+        self.assertEqual(lr._defaultParamMap[lr.maxIter], lr2._defaultParamMap[lr2.maxIter],
+                         "Loaded LogisticRegression instance default params did not match " +
+                         "original defaults")
+        try:
+            rmtree(path)
+        except OSError:
+            pass
+
+    def test_naive_bayes(self):
+        nb = NaiveBayes(smoothing=1)
+        path = tempfile.mkdtemp()
+        nb_path = path + "/nb"
+        nb.save(nb_path)
+        nb2 = NaiveBayes.load(nb_path)
+        self.assertEqual(nb2.uid, nb2.maxIter.parent,
+                         "Loaded NaiveBayes instance uid (%s) did not match Param's uid (%s)"
+                         % (nb2.uid, nb2.smoothing.parent))
+        self.assertEqual(nb._defaultParamMap[nb.smoothing], nb2._defaultParamMap[nb2.smoothing],
+                         "Loaded NaiveBayes instance default params did not match " +
+                         "original defaults")
+        try:
+            rmtree(path)
+        except OSError:
+            pass
+
+    def test_multi_layer_perceptron(self):
+        mlp = MultilayerPerceptronClassifier(maxIter=1)
+        path = tempfile.mkdtemp()
+        mlp_path = path + "/mlp"
+        mlp.save(mlp_path)
+        mlp2 = MultilayerPerceptronClassifier.load(mlp_path)
+        self.assertEqual(mlp2.uid, mlp2.maxIter.parent,
+                         "Loaded MultilayerPerceptronClassifier instance uid (%s) did not match Param's uid (%s)"
+                         % (mlp2.uid, mlp2.smoothing.parent))
+        self.assertEqual(mlp._defaultParamMap[mlp.smoothing], mlp2._defaultParamMap[mlp2.smoothing],
+                         "Loaded MultilayerPerceptronClassifier instance default params did not match " +
+                         "original defaults")
+        try:
+            rmtree(path)
+        except OSError:
+            pass
+
 
 if __name__ == "__main__":
     from pyspark.ml.tests import *


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add export/import for all estimators and transformers(which have Scala implementation) under pyspark/ml/classification.py.

JIRA : https://issues.apache.org/jira/browse/SPARK-13034
## How was this patch tested?

Unit tests added to tests.py

…hich have Scala implementation) under pyspark/ml/classification.py
