### PR TITLE
[SPARK-13717][Core] Let RandomSampler can sample with Java iterator

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/random/RandomSampler.scala
+++ b/core/src/main/scala/org/apache/spark/util/random/RandomSampler.scala
@@ -19,6 +19,7 @@ package org.apache.spark.util.random
 
 import java.util.Random
 
+import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
 
@@ -40,6 +41,11 @@ trait RandomSampler[T, U] extends Pseudorandom with Cloneable with Serializable 
 
   /** take a random sample */
   def sample(items: Iterator[T]): Iterator[U]
+
+  /** take a random sample */
+  def sample(items: java.util.Iterator[T]): Iterator[U] = {
+    sample(items.asScala)
+  }
 
   /** return a copy of the RandomSampler object */
   override def clone: RandomSampler[T, U] =

--- a/core/src/test/scala/org/apache/spark/util/random/RandomSamplerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/random/RandomSamplerSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.util.random
 
 import java.util.Random
 
+import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.commons.math3.distribution.PoissonDistribution
@@ -289,10 +290,21 @@ class RandomSamplerSuite extends SparkFunSuite with Matchers {
     d = medianKSD(gaps(sampler1.sample(Iterator.from(0))), gaps(sampler2.sample(Iterator.from(0))))
     d should be (0.0)
 
+    // With Java iterator
+    d = medianKSD(gaps(sampler1.sample(Iterator.from(0).asJava)),
+      gaps(sampler2.sample(Iterator.from(0).asJava)))
+    d should be (0.0)
+
     // should be different for different seeds
     sampler1.setSeed(73)
     sampler2.setSeed(37)
     d = medianKSD(gaps(sampler1.sample(Iterator.from(0))), gaps(sampler2.sample(Iterator.from(0))))
+    d should be > 0.0
+    d should be < D
+
+    // With Java iterator
+    d = medianKSD(gaps(sampler1.sample(Iterator.from(0).asJava)),
+      gaps(sampler2.sample(Iterator.from(0).asJava)))
     d should be > 0.0
     d should be < D
 
@@ -305,10 +317,20 @@ class RandomSamplerSuite extends SparkFunSuite with Matchers {
     d = medianKSD(gaps(sampler1.sample(Iterator.from(0))), gaps(sampler2.sample(Iterator.from(0))))
     d should be (0.0)
 
+    // With Java iterator
+    d = medianKSD(gaps(sampler1.sample(Iterator.from(0).asJava)),
+      gaps(sampler2.sample(Iterator.from(0).asJava)))
+    d should be (0.0)
+
     // should be different for different seeds
     sampler1.setSeed(73)
     sampler2.setSeed(37)
     d = medianKSD(gaps(sampler1.sample(Iterator.from(0))), gaps(sampler2.sample(Iterator.from(0))))
+    d should be > 0.0
+    d should be < D
+
+    d = medianKSD(gaps(sampler1.sample(Iterator.from(0).asJava)),
+      gaps(sampler2.sample(Iterator.from(0).asJava)))
     d should be > 0.0
     d should be < D
   }
@@ -324,9 +346,19 @@ class RandomSamplerSuite extends SparkFunSuite with Matchers {
     d = medianKSD(gaps(sampler.sample(Iterator.from(0))), gaps(sampleWR(Iterator.from(0), 0.5)))
     d should be < D
 
+    // With Java iterator
+    d = medianKSD(gaps(sampler.sample(Iterator.from(0).asJava)),
+      gaps(sampleWR(Iterator.from(0), 0.5)))
+    d should be < D
+
     sampler = new PoissonSampler[Int](0.7)
     sampler.setSeed(rngSeed.nextLong)
     d = medianKSD(gaps(sampler.sample(Iterator.from(0))), gaps(sampleWR(Iterator.from(0), 0.7)))
+    d should be < D
+
+    // With Java iterator
+    d = medianKSD(gaps(sampler.sample(Iterator.from(0).asJava)),
+      gaps(sampleWR(Iterator.from(0), 0.7)))
     d should be < D
 
     sampler = new PoissonSampler[Int](0.9)
@@ -334,10 +366,20 @@ class RandomSamplerSuite extends SparkFunSuite with Matchers {
     d = medianKSD(gaps(sampler.sample(Iterator.from(0))), gaps(sampleWR(Iterator.from(0), 0.9)))
     d should be < D
 
+    // With Java iterator
+    d = medianKSD(gaps(sampler.sample(Iterator.from(0).asJava)),
+      gaps(sampleWR(Iterator.from(0), 0.9)))
+    d should be < D
+
     // sampling at different frequencies should show up as statistically different:
     sampler = new PoissonSampler[Int](0.5)
     sampler.setSeed(rngSeed.nextLong)
     d = medianKSD(gaps(sampler.sample(Iterator.from(0))), gaps(sampleWR(Iterator.from(0), 0.6)))
+    d should be > D
+
+    // With Java iterator
+    d = medianKSD(gaps(sampler.sample(Iterator.from(0).asJava)),
+      gaps(sampleWR(Iterator.from(0), 0.6)))
     d should be > D
   }
 


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-13717
## What changes were proposed in this pull request?

Currently `RandomSampler.sample` only accepts Scala iterator. We should also let it accept Java iterator for better compatibility.
## How was this patch tested?

Some tests are added into `RandomSamplerSuite`.
