### PR TITLE
[SPARK-13727] [SQL] SparkConf.contains does not consider deprecated keys

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -352,11 +352,8 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging {
 
   /** Does the configuration contain a given parameter? */
   def contains(key: String): Boolean = {
-    settings.containsKey(key) || {
-      // try to find the settings in the alternatives
-      val alts = configsWithAlternatives.get(key)
-      alts.isDefined && alts.get.exists { alt => contains(alt.key) }
-    }
+    settings.containsKey(key) ||
+      configsWithAlternatives.get(key).toSeq.flatten.exists { alt => contains(alt.key) }
   }
 
   /** Copy this object */

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -352,11 +352,11 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging {
 
   /** Does the configuration contain a given parameter? */
   def contains(key: String): Boolean = {
-    settings.containsKey(key) ||
+    settings.containsKey(key) || {
       // try to find the settings in the alternatives
-      configsWithAlternatives.get(key).flatMap { alts =>
-        alts.collectFirst { case alt if contains(alt.key) => true }
-      }.isDefined
+      val alts = configsWithAlternatives.get(key)
+      if (alts.isDefined) alts.get.exists { alt => contains(alt.key) } else false
+    }
   }
 
   /** Copy this object */

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -352,14 +352,11 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging {
 
   /** Does the configuration contain a given parameter? */
   def contains(key: String): Boolean = {
-    if (settings.containsKey(key)) {
-      true
-    } else {
+    settings.containsKey(key) ||
       // try to find the settings in the alternatives
       configsWithAlternatives.get(key).flatMap { alts =>
         alts.collectFirst { case alt if contains(alt.key) => true }
       }.isDefined
-    }
   }
 
   /** Copy this object */

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -355,7 +355,7 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging {
     settings.containsKey(key) || {
       // try to find the settings in the alternatives
       val alts = configsWithAlternatives.get(key)
-      if (alts.isDefined) alts.get.exists { alt => contains(alt.key) } else false
+      alts.isDefined && alts.get.exists { alt => contains(alt.key) }
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -351,7 +351,16 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging {
   def getAppId: String = get("spark.app.id")
 
   /** Does the configuration contain a given parameter? */
-  def contains(key: String): Boolean = settings.containsKey(key)
+  def contains(key: String): Boolean = {
+    if (settings.containsKey(key)) {
+      true
+    } else {
+      // try to find the settings in the alternatives
+      configsWithAlternatives.get(key).flatMap { alts =>
+        alts.collectFirst { case alt if contains(alt.key) => true }
+      }.isDefined
+    }
+  }
 
   /** Copy this object */
   override def clone: SparkConf = {

--- a/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
@@ -267,6 +267,20 @@ class SparkConfSuite extends SparkFunSuite with LocalSparkContext with ResetSyst
     conf.set("spark.akka.lookupTimeout", "4")
     assert(RpcUtils.lookupRpcTimeout(conf).duration === (4 seconds))
   }
+
+  test("SPARK-13727") {
+    val conf = new SparkConf()
+    // set the conf in the deprecated way
+    conf.set("spark.io.compression.lz4.block.size", "12345")
+    // get the conf in the recommended way
+    assert(conf.get("spark.io.compression.lz4.blockSize") === "12345")
+    // we can still get the conf in the deprecated way
+    assert(conf.get("spark.io.compression.lz4.block.size") === "12345")
+    // the contains() also works as expected
+    assert(conf.contains("spark.io.compression.lz4.block.size"))
+    assert(conf.contains("spark.io.compression.lz4.blockSize"))
+    assert(conf.contains("spark.io.unknown") === false)
+  }
 }
 
 class Class1 {}


### PR DESCRIPTION
## What changes were proposed in this pull request?

The contains() method does not return consistently with get() if the key is deprecated. For example,
import org.apache.spark.SparkConf
val conf = new SparkConf()
conf.set("spark.io.compression.lz4.block.size", "12345")  # display some deprecated warning message 
conf.get("spark.io.compression.lz4.block.size") # return 12345
conf.get("spark.io.compression.lz4.blockSize") # return 12345
conf.contains("spark.io.compression.lz4.block.size") # return true
conf.contains("spark.io.compression.lz4.blockSize") # return false

The fix will make the contains() and get() more consistent.
## How was this patch tested?

I've added a test case for this.

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
Unit tests should be sufficient.
