### PR TITLE
[SPARK-13737][SQL][wip]Add getOrCreate method for HiveContext

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -21,6 +21,7 @@ import java.io.File
 import java.net.{URL, URLClassLoader}
 import java.sql.Timestamp
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 import java.util.regex.Pattern
 
 import scala.collection.JavaConverters._
@@ -637,10 +638,46 @@ class HiveContext private[hive](
     Thread.currentThread().setContextClassLoader(executionHive.clientLoader.classLoader)
     super.addJar(path)
   }
+
+  HiveContext.setLastInstantiatedContext(self)
 }
 
 
-private[hive] object HiveContext {
+object HiveContext {
+  /**
+    * Reference to the last created SQLContext.
+    */
+  @transient private val instantiatedContext = new AtomicReference[HiveContext]()
+
+  /**
+    * Get the singleton SQLContext if it exists or create a new one using the given configuration.
+    * This function can be used to create a singleton SQLContext object that can be shared across
+    * the JVM.
+    */
+  def getOrCreate(sparkContext: SparkContext): HiveContext = synchronized {
+    val ctx = instantiatedContext.get()
+    if (ctx == null || ctx.sparkContext.isStopped) {
+      new HiveContext(sparkContext)
+    } else {
+      ctx
+    }
+  }
+
+  private[hive] def getInstantiatedContextOption(): Option[HiveContext] = synchronized {
+    Option(instantiatedContext.get())
+  }
+
+  private[hive] def clearLastInstantiatedContext(): Unit = synchronized {
+    instantiatedContext.set(null)
+  }
+
+  private[hive] def setLastInstantiatedContext(hiveContext: HiveContext): Unit = synchronized {
+    val ctx = instantiatedContext.get()
+    if (ctx == null || ctx.sparkContext.isStopped) {
+      instantiatedContext.set(hiveContext)
+    }
+  }
+
   /** The version of hive used internally by Spark SQL. */
   val hiveExecutionVersion: String = "1.2.1"
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveContextSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveContextSuite.scala
@@ -1,0 +1,34 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.apache.spark.sql.hive
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.hive.test.TestHive
+
+class HiveContextSuite extends SparkFunSuite {
+
+  private val testHiveContext = TestHive
+  private val testSparkContext = TestHive.sparkContext
+
+  test("getOrCreate instantiates HiveContext") {
+    val hiveContext = HiveContext.getOrCreate(testSparkContext)
+    assert(hiveContext != null, "HiveContext.getOrCreate returned null")
+    assert(HiveContext.getOrCreate(testSparkContext).eq(hiveContext),
+      "HiveContext created by HiveContext.getOrCreate not returned by HiveContext.getOrCreate")
+  }
+}


### PR DESCRIPTION
There is a "getOrCreate" method in SQLContext, which is useful to recoverable streaming application with SQL operation. 
https://spark.apache.org/docs/latest/streaming-programming-guide.html#dataframe-and-sql-operations
But the corresponding method is missing in HiveContext.
