### PR TITLE
[SPARK-11535][ML] handling empty string in StringIndexer

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
@@ -82,7 +82,8 @@ class StringIndexer(override val uid: String) extends Estimator[StringIndexerMod
 
 
   override def fit(dataset: DataFrame): StringIndexerModel = {
-    val counts = dataset.select(col($(inputCol)).cast(StringType))
+    val counts = dataset.select(col($(inputCol)).cast(StringType) as $(inputCol))
+      .na.replace($(inputCol) :: Nil, Map("" -> "EMPTY_STRING"))
       .rdd
       .map(_.getString(0))
       .countByValue()

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/StringIndexerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/StringIndexerSuite.scala
@@ -178,6 +178,20 @@ class StringIndexerSuite
     }
   }
 
+  test("StringIndexer on column with empty string values") {
+    val data = sc.parallelize(Seq((0, "a"), (1, ""), (2, "c"), (3, "a"), (4, "a"), (5, "c")), 2)
+    val df = sqlContext.createDataFrame(data).toDF("id", "label")
+    val indexer = new StringIndexer()
+      .setInputCol("label")
+      .setOutputCol("labelIndex")
+      .fit(df)
+
+    val transformed = indexer.transform(df)
+    val attr = Attribute.fromStructField(transformed.schema("labelIndex"))
+      .asInstanceOf[NominalAttribute]
+    assert(attr.values.get === Array("a", "c", "EMPTY_STRING"))
+  }
+
   test("StringIndexer, IndexToString are inverses") {
     val data = sc.parallelize(Seq((0, "a"), (1, "b"), (2, "c"), (3, "a"), (4, "a"), (5, "c")), 2)
     val df = sqlContext.createDataFrame(data).toDF("id", "label")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replacing "" (not null) with string "EMPTY_STRING" in StringIndexer. Another approach is to use "0" (or next available integer), but it may have performance issues when input column has integer values say (0 to 100000). We can use another string to replace "" values if "EMPTY_STRING" is commonly used.
## How was this patch tested?

unit tests
