### PR TITLE
[SPARK-13755] Escape quotes in SQL plan visualization node labels

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
@@ -21,6 +21,8 @@ import java.util.concurrent.atomic.AtomicLong
 
 import scala.collection.mutable
 
+import org.apache.commons.lang3.StringEscapeUtils
+
 import org.apache.spark.sql.execution.SparkPlanInfo
 import org.apache.spark.sql.execution.metric.SQLMetrics
 
@@ -54,8 +56,6 @@ private[ui] case class SparkPlanGraph(
 }
 
 private[sql] object SparkPlanGraph {
-
-  def escapeQuotes(str: String): String = str.replace("\"", "\\\"")
 
   /**
    * Build a SparkPlanGraph from the root of a SparkPlan tree.
@@ -147,7 +147,7 @@ private[ui] class SparkPlanGraphNode(
       builder ++= values.mkString("\\n")
     }
 
-    s"""  $id [label="${SparkPlanGraph.escapeQuotes(builder.toString())}"];"""
+    s"""  $id [label="${StringEscapeUtils.escapeJava(builder.toString())}"];"""
   }
 }
 
@@ -164,7 +164,7 @@ private[ui] class SparkPlanGraphCluster(
   override def makeDotNode(metricsValue: Map[Long, String]): String = {
     s"""
        |  subgraph cluster${id} {
-       |    label="${SparkPlanGraph.escapeQuotes(name)}";
+       |    label="${StringEscapeUtils.escapeJava(name)}";
        |    ${nodes.map(_.makeDotNode(metricsValue)).mkString("    \n")}
        |  }
      """.stripMargin

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
@@ -55,6 +55,8 @@ private[ui] case class SparkPlanGraph(
 
 private[sql] object SparkPlanGraph {
 
+  def escapeQuotes(str: String): String = str.replace("\"", "\\\"")
+
   /**
    * Build a SparkPlanGraph from the root of a SparkPlan tree.
    */
@@ -145,7 +147,7 @@ private[ui] class SparkPlanGraphNode(
       builder ++= values.mkString("\\n")
     }
 
-    s"""  $id [label="${builder.toString()}"];"""
+    s"""  $id [label="${SparkPlanGraph.escapeQuotes(builder.toString())}"];"""
   }
 }
 
@@ -162,7 +164,7 @@ private[ui] class SparkPlanGraphCluster(
   override def makeDotNode(metricsValue: Map[Long, String]): String = {
     s"""
        |  subgraph cluster${id} {
-       |    label=${name};
+       |    label="${SparkPlanGraph.escapeQuotes(name)}";
        |    ${nodes.map(_.makeDotNode(metricsValue)).mkString("    \n")}
        |  }
      """.stripMargin

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
@@ -138,13 +138,11 @@ private[ui] class SparkPlanGraphNode(
     }
 
     if (values.nonEmpty) {
-      // If there are metrics, display each entry in a separate line. We should use an escaped
-      // "\n" here to follow the dot syntax.
-      //
+      // If there are metrics, display each entry in a separate line.
       // Note: whitespace between two "\n"s is to create an empty line between the name of
       // SparkPlan and metrics. If removing it, it won't display the empty line in UI.
-      builder ++= "\\n \\n"
-      builder ++= values.mkString("\\n")
+      builder ++= "\n \n"
+      builder ++= values.mkString("\n")
     }
 
     s"""  $id [label="${StringEscapeUtils.escapeJava(builder.toString())}"];"""


### PR DESCRIPTION
When generating Graphviz DOT files in the SQL query visualization we need to escape double-quotes inside node labels. This is a followup to #11309, which fixed a similar graph in Spark Core's DAG visualization.
