### PR TITLE
[SPARK-12719][SQL] [WIP] SQL generation support for generators, including UDTF

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -253,10 +253,6 @@ case class MultiAlias(child: Expression, names: Seq[String])
 
   override def toString: String = s"$child AS $names"
 
-  override def sql: String = {
-    val aliasNames = names.map(quoteIdentifier(_)).mkString(",")
-    s"${child.sql} AS ($aliasNames)"
-  }
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -253,6 +253,10 @@ case class MultiAlias(child: Expression, names: Seq[String])
 
   override def toString: String = s"$child AS $names"
 
+  override def sql: String = {
+    val aliasNames = names.map(quoteIdentifier(_)).mkString(",")
+    s"${child.sql} AS ($aliasNames)"
+  }
 }
 
 /**

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/SQLBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/SQLBuilder.scala
@@ -334,7 +334,7 @@ class SQLBuilder(logicalPlan: LogicalPlan, sqlContext: SQLContext) extends Loggi
 
   /* This function handles the SQL generation when generators are specified in the
    * LATERAL VIEW clause. SQL generation of generators specified in projection lists
-   * are handled in projectToSQL.
+   * is handled in projectToSQL.
    * sample plan :
    *   +- Project [mycol2#192]
    *     +- Generate explode(myCol#191), true, false, Some(mytable2), [mycol2#192]
@@ -348,7 +348,7 @@ class SQLBuilder(logicalPlan: LogicalPlan, sqlContext: SQLContext) extends Loggi
     val outerClause = if (plan.outer) "OUTER" else ""
     build(
       toSQL(plan.child),
-      "LATERAL VIEW ",
+      "LATERAL VIEW",
       outerClause,
       plan.generator.sql,
       quoteIdentifier(generatorAlias),

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/SQLBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/SQLBuilder.scala
@@ -326,7 +326,12 @@ class SQLBuilder(logicalPlan: LogicalPlan, sqlContext: SQLContext) extends Loggi
     val generatorAlias = if (plan.qualifier.isEmpty) "" else plan.qualifier.get
     val outerClause = if (plan.outer) "OUTER" else ""
     build(
-      if (plan.child == OneRowRelation) s"(SELECT 1) ${SQLBuilder.newSubqueryName}" else toSQL(plan.child),
+      if (plan.child == OneRowRelation) {
+        s"(SELECT 1) ${SQLBuilder.newSubqueryName}"
+      }
+      else {
+        toSQL(plan.child)
+      },
       "LATERAL VIEW",
       outerClause,
       plan.generator.sql,
@@ -350,7 +355,7 @@ class SQLBuilder(logicalPlan: LogicalPlan, sqlContext: SQLContext) extends Loggi
       case o => o
     }
 
-    //If Generate is missing the qualifier (its in projection list) , add one here.
+    // If Generate is missing the qualifier (its in projection list) , add one here.
     val planToProcess =
       if (generate.qualifier.isEmpty) {
         generate.copy(qualifier = Some(generatorAlias))

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/LogicalPlanToSQLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/LogicalPlanToSQLSuite.scala
@@ -588,23 +588,28 @@ class LogicalPlanToSQLSuite extends SQLBuilderTest with SQLTestUtils {
   test("SQL generation for lateral views") {
     // Filter and OUTER clause
     checkHiveQl(
-      """SELECT key, value
-        |FROM t1 LATERAL VIEW OUTER explode(value) gentab as gencol
+      """
+        |SELECT key, value
+        |FROM t1
+        |LATERAL VIEW OUTER explode(value) gentab as gencol
         |WHERE key = 1
       """.stripMargin
     )
 
     // single lateral view
     checkHiveQl(
-      """SELECT *
-        |FROM t1 LATERAL VIEW explode(array(1,2,3)) gentab AS gencol
+      """
+        |SELECT *
+        |FROM t1
+        |LATERAL VIEW explode(array(1,2,3)) gentab AS gencol
         |SORT BY key ASC, gencol ASC LIMIT 1
       """.stripMargin
     )
 
     // multiple lateral views
     checkHiveQl(
-      """SELECT gentab2.*
+      """
+        |SELECT gentab2.*
         |FROM t1
         |LATERAL VIEW explode(array(array(1,2,3))) gentab1 AS gencol1
         |LATERAL VIEW explode(gentab1.gencol1) gentab2 AS gencol2 LIMIT 3
@@ -614,8 +619,8 @@ class LogicalPlanToSQLSuite extends SQLBuilderTest with SQLTestUtils {
     // No generated column aliases
     checkHiveQl(
       """SELECT gentab.*
-        |FROM
-        |t1 LATERAL VIEW explode(map('key1', 100, 'key2', 200)) gentab limit 2
+        |FROM t1
+        |LATERAL VIEW explode(map('key1', 100, 'key2', 200)) gentab limit 2
       """.stripMargin
     )
   }
@@ -623,13 +628,15 @@ class LogicalPlanToSQLSuite extends SQLBuilderTest with SQLTestUtils {
   test("SQL generation for lateral views in subquery") {
     // Subquries in FROM clause using Generate
     checkHiveQl(
-      """SELECT subq.gencol
+      """
+        |SELECT subq.gencol
         |FROM
         |(SELECT * from t1 LATERAL VIEW explode(value) gentab AS gencol) subq
       """.stripMargin)
 
     checkHiveQl(
-      """SELECT subq.key
+      """
+        |SELECT subq.key
         |FROM
         |(SELECT key, value from t1 LATERAL VIEW explode(value) gentab AS gencol) subq
       """.stripMargin

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/LogicalPlanToSQLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/LogicalPlanToSQLSuite.scala
@@ -585,6 +585,15 @@ class LogicalPlanToSQLSuite extends SQLBuilderTest with SQLTestUtils {
     checkHiveQl("SELECT key, json_tuple(jstring, 'f1', 'f2', 'f3', 'f4', 'f5') FROM parquet_t3")
   }
 
+  test("Lateral view with join") {
+    checkHiveQl(
+      """
+      |SELECT gencol, explode(array(1,2,3)), x1.key
+      |FROM (t1 LATERAL VIEW OUTER explode(value) gentab as gencol), t1 as x1
+      """.stripMargin
+    )
+  }
+
   test("SQL generation for lateral views") {
     // Filter and OUTER clause
     checkHiveQl(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/LogicalPlanToSQLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/LogicalPlanToSQLSuite.scala
@@ -30,6 +30,17 @@ class LogicalPlanToSQLSuite extends SQLBuilderTest with SQLTestUtils {
     sql("DROP TABLE IF EXISTS parquet_t1")
     sql("DROP TABLE IF EXISTS parquet_t2")
     sql("DROP TABLE IF EXISTS t0")
+    sql("DROP TABLE IF EXISTS t3")
+    sql("DROP TABLE IF EXISTS t4")
+
+    val tuples: Seq[(String, String)] =
+      ("1", """{"f1": "value1", "f2": "value2", "f3": 3, "f5": 5.23}""") ::
+        ("2", """{"f1": "value12", "f3": "value3", "f2": 2, "f4": 4.01}""") ::
+        ("3", """{"f1": "value13", "f4": "value44", "f3": "value33", "f2": 2, "f5": 5.01}""") ::
+        ("4", null) ::
+        ("5", """{"f1": "", "f5": null}""") ::
+        ("6", "[invalid JSON string]") ::
+        Nil
 
     sqlContext.range(10).write.saveAsTable("parquet_t0")
     sql("CREATE TABLE t0 AS SELECT * FROM parquet_t0")
@@ -45,6 +56,11 @@ class LogicalPlanToSQLSuite extends SQLBuilderTest with SQLTestUtils {
       .select('id as 'a, 'id as 'b, 'id as 'c, 'id as 'd)
       .write
       .saveAsTable("parquet_t2")
+
+    sqlContext.range(10).select('id as 'a, 'id as 'b, 'id as 'c, 'id as 'd).write.saveAsTable("t2")
+
+    tuples.toDF("key", "jstring").write.saveAsTable("t3")
+    sql("CREATE TABLE t4 as select key, array(value) as value from parquet_t1 limit 20")
   }
 
   override protected def afterAll(): Unit = {
@@ -52,6 +68,8 @@ class LogicalPlanToSQLSuite extends SQLBuilderTest with SQLTestUtils {
     sql("DROP TABLE IF EXISTS parquet_t1")
     sql("DROP TABLE IF EXISTS parquet_t2")
     sql("DROP TABLE IF EXISTS t0")
+    sql("DROP TABLE IF EXISTS t3")
+    sql("DROP TABLE IF EXISTS t4")
   }
 
   private def checkHiveQl(hiveQl: String): Unit = {
@@ -549,5 +567,87 @@ class LogicalPlanToSQLSuite extends SQLBuilderTest with SQLTestUtils {
         |FROM parquet_t1
         |WINDOW w AS (PARTITION BY key % 5 ORDER BY key)
       """.stripMargin)
+  }
+
+  test("SQL generation for generate") {
+    sql(s"ADD JAR ${hiveContext.getHiveFile("TestUDTF.jar").getCanonicalPath()}")
+    // The function source code can be found at:
+    // https://cwiki.apache.org/confluence/display/Hive/DeveloperGuide+UDTF
+    sql(
+      """
+        |CREATE TEMPORARY FUNCTION udtf_count2
+        |AS 'org.apache.spark.sql.hive.execution.GenericUDTFCount2'
+      """.stripMargin)
+
+    // Basic Explode
+    checkHiveQl("SELECT explode(array(1,2,3)) FROM src")
+
+    // Explode with Alias
+    checkHiveQl("SELECT explode(array(1,2,3)) as value FROM src")
+
+    // Explode without FROM
+    checkHiveQl("select explode(array(1,2,3)) AS gencol")
+
+    // Explode with columns other than generated columns in projection list
+    checkHiveQl("SELECT key as c1, explode(array(1,2,3)) as c2, value as c3 FROM t4")
+
+    // Explode with a column reference as input to generator
+    checkHiveQl("SELECT key, value from t4 LATERAL VIEW explode(value) gentab")
+
+    // json_tuple
+    checkHiveQl("SELECT key, json_tuple(jstring, 'f1', 'f2', 'f3', 'f4', 'f5') FROM t3")
+
+    // udtf
+    checkHiveQl("SELECT key, gencol FROM t4 LATERAL VIEW udtf_count2(value) gentab AS gencol")
+
+    // udtf
+    checkHiveQl("SELECT udtf_count2(c1) FROM (SELECT 1 AS c1 FROM t4 LIMIT 3) g1")
+
+    // Filter and OUTER clause
+    checkHiveQl(
+      """SELECT key, value
+        |FROM t4 LATERAL VIEW OUTER explode(value) gentab as gencol
+        |WHERE key = 1
+      """.stripMargin
+    )
+
+    // single lateral view
+    checkHiveQl(
+      """SELECT *
+        |FROM t4 LATERAL VIEW explode(array(1,2,3)) gentab AS gencol
+        |SORT BY key ASC, gencol ASC LIMIT 1
+      """.stripMargin
+    )
+
+    // multiple lateral views
+    checkHiveQl(
+      """SELECT gentab2.*
+        |FROM t4
+        |LATERAL VIEW explode(array(array(1,2,3))) gentab1 AS gencol1
+        |LATERAL VIEW explode(gentab1.gencol1) gentab2 AS gencol2 LIMIT 3
+      """.stripMargin
+    )
+
+    // Subquries in FROM clause using Generate
+    checkHiveQl(
+      """SELECT subq.gencol
+        |FROM
+        |(SELECT * from t4 LATERAL VIEW explode(value) gentab AS gencol) subq
+      """.stripMargin)
+
+    checkHiveQl(
+      """SELECT subq.key
+        |FROM
+        |(SELECT key, value from t4 LATERAL VIEW explode(value) gentab AS gencol) subq
+      """.stripMargin
+    )
+
+    checkHiveQl(
+      """SELECT gentab.*
+        |FROM
+        |t4 LATERAL VIEW explode(map('key1', 100, 'key2', 200)) gentab limit 2
+      """.stripMargin
+    )
+    sql("DROP TEMPORARY FUNCTION udtf_count2")
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a alternate way to convert SQL from analyzed logical plans containing Generate operator.
In this PR , generators in projection list are expressed as LATERAL VIEW.

Sample Plan :

```
GlobalLimit 3
+- LocalLimit 3
   +- Project [gencol2#204]
      +- Generate explode(gencol1#203), true, false, Some(gentab2), [gencol2#204]
         +- Generate explode(array(array(1, 2, 3))), true, false, Some(gentab1), [gencol1#203]
            +- MetastoreRelation default, t4, None
```

Generated Query:

```
SELECT `gentab2`.`gencol2` FROM `default`.`t4` LATERAL VIEW explode(array(array(1, 2, 3))) `gentab1` AS `gencol1` LATERAL VIEW explode(`gentab1`.`gencol1`) `gentab2` AS `gencol2` LIMIT 3
```
## How was this patch tested?

Tests added to LogicalPlanToSQLSuite

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
