### PR TITLE
[SPARK-12313] [SQL] [RFC] use alt metastore partition pruning api when possible

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -376,20 +376,18 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
     // Hive getPartitionsByFilter() takes a string that represents partition
     // predicates like "str_key=\"value\" and int_key=1 ..."
     val filter = convertFilters(table, predicates)
-    val partitions = {
-      val r = filter match {
-        case EmptyPushdown =>
-          getAllPartitionsMethod.invoke(hive, table).asInstanceOf[JSet[Partition]]
-        case PartitionExpr(filterExpr) =>
-          logDebug(s"Hive metastore filter expression is '$filterExpr'.")
-          getPartitionsByFilterMethod.invoke(hive, table, filterExpr)
-        case PartitionSpec(filterSpec) =>
-          logDebug(s"Hive metastore partition spec is $filterSpec.")
-          getPartitionsByPartitionSpec.invoke(hive, table, filterSpec)
-      }
-      r.asInstanceOf[JArrayList[Partition]]
+    val partitions = filter match {
+      case EmptyPushdown =>
+        getAllPartitionsMethod.invoke(hive, table).asInstanceOf[JSet[Partition]]
+      case PartitionExpr(filterExpr) =>
+        logDebug(s"Hive metastore filter expression is '$filterExpr'.")
+        getPartitionsByFilterMethod.invoke(hive, table, filterExpr)
+          .asInstanceOf[JArrayList[Partition]]
+      case PartitionSpec(filterSpec) =>
+        logDebug(s"Hive metastore partition spec is $filterSpec.")
+        getPartitionsByPartitionSpec.invoke(hive, table, filterSpec)
+          .asInstanceOf[JArrayList[Partition]]
     }
-
     partitions.asScala.toSeq
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveTableScanSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveTableScanSuite.scala
@@ -46,6 +46,29 @@ class HiveTableScanSuite extends HiveComparisonTest {
       |SELECT * from part_scan_test;
     """.stripMargin)
 
+  createQueryTest("partition filtering",
+    """
+      | SET spark.sql.hive.metastorePartitionPruning = true;
+      | SELECT * FROM srcpart WHERE ds = '2008-04-08'
+    """.stripMargin
+  )
+
+  createQueryTest("partition filtering with null",
+    // this test is pretty bad right now, since there isn't actually any data with null.  right now
+    // this test will just capture basic usage errors
+    """
+      | SET spark.sql.hive.metastorePartitionPruning = true;
+      | SELECT * FROM srcpart WHERE ds IS NULL
+    """.stripMargin
+  )
+
+  createQueryTest("partition filtering with >",
+    """
+      | SET spark.sql.hive.metastorePartitionPruning = true;
+      | SELECT * FROM srcpart WHERE ds > '2008-04-08'
+    """.stripMargin
+  )
+
   // In unit test, kv1.txt is a small file and will be loaded as table src
   // Since the small file will be considered as a single split, we assume
   // Hive / SparkSQL HQL has the same output even for SORT BY


### PR DESCRIPTION
## What changes were proposed in this pull request?

Asking the metastore to filter partitions with {{getPartitionsByFilter}} can silently fail (that is, incorrectly returns no partitions, without reporting any error) when there are lots of partitions.  As a partial workaround, when the filter criteria is only equality, we can use {{getPartitions(..., partitionSpec)}} which doesn't appear to have this issue.
## How was this patch tested?

jenkins unit tests.  (Note: existing tests are insufficient at this point, needs more before merging.  Also doesn't have a repro of the original problem.)
