### PR TITLE
[SPARK-13775] History page sorted by completed time desc by default.

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/historypage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage.js
@@ -165,7 +165,7 @@ $(document).ready(function() {
                         {name: 'eighth'},
                     ],
                     "autoWidth": false,
-                    "order": [[ 0, "desc" ]]
+                    "order": [[ 4, "desc" ]]
         };
 
         var rowGroupConf = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Originally the page is sorted by AppID by default. 
After tests with users' feedback, we think it might be best to sort by completed time (desc).
## How was this patch tested?

Manually test, with screenshot as follows.
![sorted-by-complete-time-desc](https://cloud.githubusercontent.com/assets/11683054/13647686/d6dea924-e5fa-11e5-8fc5-68e039b74b6f.png)
