### PR TITLE
[SPARK-13778][Core]Set the executor state for a worker when removing it

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -763,6 +763,7 @@ private[deploy] class Master(
       logInfo("Telling app of lost executor: " + exec.id)
       exec.application.driver.send(ExecutorUpdated(
         exec.id, ExecutorState.LOST, Some("worker lost"), None))
+      exec.state = ExecutorState.LOST
       exec.application.removeExecutor(exec)
     }
     for (driver <- worker.drivers.values) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When a worker is lost, the executors on this worker are also lost. But Master's ApplicationPage still displays their states as running.

This patch just sets the executor state to `LOST` when a worker is lost.
## How was this patch tested?

manual tests
