### PR TITLE
fix minor tempo in 'hypot' docstring

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -142,7 +142,7 @@ _functions_1_6 = {
 _binary_mathfunctions = {
     'atan2': 'Returns the angle theta from the conversion of rectangular coordinates (x, y) to' +
              'polar coordinates (r, theta).',
-    'hypot': 'Computes `sqrt(a^2^ + b^2^)` without intermediate overflow or underflow.',
+    'hypot': 'Computes `sqrt(a^2 + b^2)` without intermediate overflow or underflow.',
     'pow': 'Returns the value of the first argument raised to the power of the second argument.',
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Minor typo:  docstring for pyspark.sql.functions: hypot has extra characters
## How was this patch tested?

N/A
