### PR TITLE
[SPARK-13788][MLLIB] Fix side effects in CholeskyDecomposition

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/CholeskyDecomposition.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/CholeskyDecomposition.scala
@@ -33,12 +33,14 @@ private[spark] object CholeskyDecomposition {
    * @return the solution array
    */
   def solve(A: Array[Double], bx: Array[Double]): Array[Double] = {
+    val tmpA = A.clone()
+    val tmpbx = bx.clone()
     val k = bx.length
     val info = new intW(0)
-    lapack.dppsv("U", k, 1, A, bx, k, info)
+    lapack.dppsv("U", k, 1, tmpA, tmpbx, k, info)
     val code = info.`val`
     assert(code == 0, s"lapack.dppsv returned $code.")
-    bx
+    tmpbx
   }
 
   /**
@@ -50,10 +52,11 @@ private[spark] object CholeskyDecomposition {
    * @return the upper triangle of the (symmetric) inverse of A
    */
   def inverse(UAi: Array[Double], k: Int): Array[Double] = {
+    val tmpUAi = UAi.clone()
     val info = new intW(0)
-    lapack.dpptri("U", k, UAi, info)
+    lapack.dpptri("U", k, tmpUAi, info)
     val code = info.`val`
     assert(code == 0, s"lapack.dpptri returned $code.")
-    UAi
+    tmpUAi
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Capturing CholeskyDecomposition side effects from calling lapack.dppsv and lapack.dpptri by cloning arrays.
## How was this patch tested?

Manual test as well as checking with lapack documentations: 

http://www.netlib.org/lapack/explore-html/d3/d62/dppsv_8f.html
http://www.netlib.org/lapack/explore-html/d2/de0/dpptri_8f.html
