### PR TITLE
[SPARK-13790] Speed up ColumnVector's getDecimal

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
@@ -400,7 +400,7 @@ public final class UnsafeRow extends MutableRow implements Externalizable, KryoS
       return null;
     }
     if (precision <= Decimal.MAX_LONG_DIGITS()) {
-      return Decimal.apply(getLong(ordinal), precision, scale);
+      return Decimal.createUnsafe(getLong(ordinal), precision, scale);
     } else {
       byte[] bytes = getBinary(ordinal);
       BigInteger bigInteger = new BigInteger(bytes);

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
@@ -69,6 +69,13 @@ final class Decimal extends Ordered[Decimal] with Serializable {
   }
 
   /**
+   * Just updates the underlying value to `v`, assuming precision and scale is unchanged.
+   */
+  def setInternal(v: Long): Unit = {
+    this.longVal = v
+  }
+
+  /**
    * Set this Decimal to the given unscaled Long, with a given precision and scale.
    */
   def set(unscaled: Long, precision: Int, scale: Int): Decimal = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
@@ -69,13 +69,6 @@ final class Decimal extends Ordered[Decimal] with Serializable {
   }
 
   /**
-   * Just updates the underlying value to `v`, assuming precision and scale is unchanged.
-   */
-  def setInternal(v: Long): Unit = {
-    this.longVal = v
-  }
-
-  /**
    * Set this Decimal to the given unscaled Long, with a given precision and scale.
    */
   def set(unscaled: Long, precision: Int, scale: Int): Decimal = {
@@ -382,6 +375,17 @@ object Decimal {
     new Decimal().set(unscaled, precision, scale)
 
   def apply(value: String): Decimal = new Decimal().set(BigDecimal(value))
+
+  /**
+   * Creates a decimal from unscaled, precision and scale without checking the bounds.
+   */
+  def createUnsafe(unscaled: Long, precision: Int, scale: Int): Decimal = {
+    val dec = new Decimal()
+    dec.longVal = unscaled
+    dec._precision = precision
+    dec._scale = scale
+    dec
+  }
 
   // Evidence parameters for Decimal considered either as Fractional or Integral. We provide two
   // parameters inheriting from a common trait since both traits define mkNumericOps.

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
@@ -536,9 +536,13 @@ public abstract class ColumnVector {
    */
   public final Decimal getDecimal(int rowId, int precision, int scale) {
     if (precision <= Decimal.MAX_INT_DIGITS()) {
-      return Decimal.apply(getInt(rowId), precision, scale);
+      assert(resultDecimal != null);
+      resultDecimal.setInternal(getInt(rowId));
+      return resultDecimal;
     } else if (precision <= Decimal.MAX_LONG_DIGITS()) {
-      return Decimal.apply(getLong(rowId), precision, scale);
+      assert (resultDecimal != null);
+      resultDecimal.setInternal(getLong(rowId));
+      return resultDecimal;
     } else {
       // TODO: best perf?
       byte[] bytes = getBinary(rowId);
@@ -853,6 +857,11 @@ public abstract class ColumnVector {
   protected final ColumnarBatch.Row resultStruct;
 
   /**
+   * Reusable object for getDecimal()
+   */
+  private Decimal resultDecimal;
+
+  /**
    * The Dictionary for this column.
    *
    * If it's not null, will be used to decode the value in getXXX().
@@ -926,6 +935,13 @@ public abstract class ColumnVector {
       this.childColumns = null;
       this.resultArray = null;
       this.resultStruct = null;
+    }
+
+    if (type instanceof DecimalType) {
+      DecimalType dt = (DecimalType)type;
+      if (dt.precision() <= Decimal.MAX_LONG_DIGITS()) {
+        resultDecimal = Decimal.apply(0, dt.precision(), dt.scale());
+      }
     }
   }
 }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
@@ -536,13 +536,9 @@ public abstract class ColumnVector {
    */
   public final Decimal getDecimal(int rowId, int precision, int scale) {
     if (precision <= Decimal.MAX_INT_DIGITS()) {
-      assert(resultDecimal != null);
-      resultDecimal.setInternal(getInt(rowId));
-      return resultDecimal;
+      return Decimal.createUnsafe(getInt(rowId), precision, scale);
     } else if (precision <= Decimal.MAX_LONG_DIGITS()) {
-      assert (resultDecimal != null);
-      resultDecimal.setInternal(getLong(rowId));
-      return resultDecimal;
+      return Decimal.createUnsafe(getLong(rowId), precision, scale);
     } else {
       // TODO: best perf?
       byte[] bytes = getBinary(rowId);
@@ -857,11 +853,6 @@ public abstract class ColumnVector {
   protected final ColumnarBatch.Row resultStruct;
 
   /**
-   * Reusable object for getDecimal()
-   */
-  private Decimal resultDecimal;
-
-  /**
    * The Dictionary for this column.
    *
    * If it's not null, will be used to decode the value in getXXX().
@@ -935,13 +926,6 @@ public abstract class ColumnVector {
       this.childColumns = null;
       this.resultArray = null;
       this.resultStruct = null;
-    }
-
-    if (type instanceof DecimalType) {
-      DecimalType dt = (DecimalType)type;
-      if (dt.precision() <= Decimal.MAX_LONG_DIGITS()) {
-        resultDecimal = Decimal.apply(0, dt.precision(), dt.scale());
-      }
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

We should reuse an object similar to the other non-primitive type getters. For
a query that computes averages over decimal columns, this shows a 10% speedup
on overall query times.
## How was this patch tested?

Existing tests and this benchmark

```
TPCDS Snappy:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)
--------------------------------------------------------------------------------
q27-agg (master)                       10627 / 11057         10.8          92.3
q27-agg (this patch)                     9722 / 9832         11.8          84.4
```
