### PR TITLE
[SPARK-13793] [CORE] PipedRDD doesn't propagate exceptions while reading parent RDD

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/PipedRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PipedRDD.scala
@@ -170,7 +170,7 @@ private[spark] class PipedRDD[T: ClassTag](
 
       private def propagateChildThreadException(): Unit = {
         if (childThreadException.get() != null) {
-          proc.destroyForcibly()
+          proc.destroy()
           throw childThreadException.get()
         }
       }

--- a/core/src/main/scala/org/apache/spark/rdd/PipedRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PipedRDD.scala
@@ -166,7 +166,10 @@ private[spark] class PipedRDD[T: ClassTag](
     // Return an iterator that read lines from the process's stdout
     val lines = Source.fromInputStream(proc.getInputStream).getLines()
     new Iterator[String] {
-      def next(): String = lines.next()
+      def next(): String = {
+        propagateChildThreadException()
+        lines.next()
+      }
 
       private def propagateChildThreadException(): Unit = {
         if (childThreadException.get() != null) {

--- a/core/src/test/scala/org/apache/spark/rdd/PipedRDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/PipedRDDSuite.scala
@@ -50,6 +50,29 @@ class PipedRDDSuite extends SparkFunSuite with SharedSparkContext {
     }
   }
 
+  test("failure in iterating over pipe input") {
+    if (testCommandAvailable("cat")) {
+      val nums =
+        sc.makeRDD(Array(1, 2, 3, 4), 2)
+          .mapPartitionsWithIndex((index, iterator) => {
+            new Iterator[Int] {
+              def hasNext = true
+              def next() = {
+                throw new SparkException("Exception to simulate bad scenario")
+              }
+            }
+          })
+
+      val piped = nums.pipe(Seq("cat"))
+
+      intercept[SparkException] {
+        piped.collect()
+      }
+    } else {
+      assert(true)
+    }
+  }
+
   test("advanced pipe") {
     if (testCommandAvailable("cat")) {
       val nums = sc.makeRDD(Array(1, 2, 3, 4), 2)

--- a/core/src/test/scala/org/apache/spark/rdd/PipedRDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/PipedRDDSuite.scala
@@ -68,8 +68,6 @@ class PipedRDDSuite extends SparkFunSuite with SharedSparkContext {
       intercept[SparkException] {
         piped.collect()
       }
-    } else {
-      assert(true)
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

PipedRDD creates a child thread to read output of the parent stage and feed it to the pipe process. Used a variable to save the exception thrown in the child thread and then propagating the exception in the main thread if the variable was set.
## How was this patch tested?
- Added a unit test
- Ran all the existing tests in PipedRDDSuite and they all pass with the change
- Tested the patch with a real pipe() job, bounced the executor node which ran the parent stage to simulate a fetch failure and observed that the parent stage was re-ran.
