### PR TITLE
[MINOR][SQL] Replace DataFrameWriter.stream() with startStream() in comments.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/util/ContinuousQueryListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/util/ContinuousQueryListener.scala
@@ -32,9 +32,9 @@ abstract class ContinuousQueryListener {
   /**
    * Called when a query is started.
    * @note This is called synchronously with
-   *       [[org.apache.spark.sql.DataFrameWriter `DataFrameWriter.stream()`]],
-   *       that is, `onQueryStart` will be called on all listeners before `DataFrameWriter.stream()`
-   *       returns the corresponding [[ContinuousQuery]].
+   *       [[org.apache.spark.sql.DataFrameWriter `DataFrameWriter.startStream()`]],
+   *       that is, `onQueryStart` will be called on all listeners before
+   *       `DataFrameWriter.startStream()` returns the corresponding [[ContinuousQuery]].
    */
   def onQueryStarted(queryStarted: QueryStarted)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

According to #11627 , this PR replace `DataFrameWriter.stream()` with `startStream()` in comments of `ContinuousQueryListener.java`.
## How was this patch tested?

Manual. (It changes on comments.)
