### PR TITLE
[SPARK-13663] [CORE] Upgrade Snappy Java to 1.1.2.1

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.2
+++ b/dev/deps/spark-deps-hadoop-2.2
@@ -166,7 +166,7 @@ servlet-api-2.5.jar
 slf4j-api-1.7.16.jar
 slf4j-log4j12-1.7.16.jar
 snappy-0.2.jar
-snappy-java-1.1.2.jar
+snappy-java-1.1.2.1.jar
 spire-macros_2.11-0.7.4.jar
 spire_2.11-0.7.4.jar
 stax-api-1.0-2.jar

--- a/dev/deps/spark-deps-hadoop-2.3
+++ b/dev/deps/spark-deps-hadoop-2.3
@@ -157,7 +157,7 @@ servlet-api-2.5.jar
 slf4j-api-1.7.16.jar
 slf4j-log4j12-1.7.16.jar
 snappy-0.2.jar
-snappy-java-1.1.2.jar
+snappy-java-1.1.2.1.jar
 spire-macros_2.11-0.7.4.jar
 spire_2.11-0.7.4.jar
 stax-api-1.0-2.jar

--- a/dev/deps/spark-deps-hadoop-2.4
+++ b/dev/deps/spark-deps-hadoop-2.4
@@ -158,7 +158,7 @@ servlet-api-2.5.jar
 slf4j-api-1.7.16.jar
 slf4j-log4j12-1.7.16.jar
 snappy-0.2.jar
-snappy-java-1.1.2.jar
+snappy-java-1.1.2.1.jar
 spire-macros_2.11-0.7.4.jar
 spire_2.11-0.7.4.jar
 stax-api-1.0-2.jar

--- a/dev/deps/spark-deps-hadoop-2.6
+++ b/dev/deps/spark-deps-hadoop-2.6
@@ -164,7 +164,7 @@ servlet-api-2.5.jar
 slf4j-api-1.7.16.jar
 slf4j-log4j12-1.7.16.jar
 snappy-0.2.jar
-snappy-java-1.1.2.jar
+snappy-java-1.1.2.1.jar
 spire-macros_2.11-0.7.4.jar
 spire_2.11-0.7.4.jar
 stax-api-1.0-2.jar

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -165,7 +165,7 @@ servlet-api-2.5.jar
 slf4j-api-1.7.16.jar
 slf4j-log4j12-1.7.16.jar
 snappy-0.2.jar
-snappy-java-1.1.2.jar
+snappy-java-1.1.2.1.jar
 spire-macros_2.11-0.7.4.jar
 spire_2.11-0.7.4.jar
 stax-api-1.0-2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
     <jline.groupid>org.scala-lang</jline.groupid>
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
     <fasterxml.jackson.version>2.5.3</fasterxml.jackson.version>
-    <snappy.version>1.1.2</snappy.version>
+    <snappy.version>1.1.2.1</snappy.version>
     <netlib.java.version>1.1.2</netlib.java.version>
     <calcite.version>1.2.0-incubating</calcite.version>
     <commons-codec.version>1.10</commons-codec.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update snappy to 1.1.2.1 to pull in a single fix -- the OOM fix we already worked around.
Supersedes https://github.com/apache/spark/pull/11524
## How was this patch tested?

Jenkins tests.
