### PR TITLE
[SPARK-13618][STREAMING][WEB-UI] Make Streaming web UI page display rate-limit lines on statistics graph - Part 2

### DIFF
--- a/external/flume/src/main/scala/org/apache/spark/streaming/flume/FlumeInputDStream.scala
+++ b/external/flume/src/main/scala/org/apache/spark/streaming/flume/FlumeInputDStream.scala
@@ -48,6 +48,9 @@ class FlumeInputDStream[T: ClassTag](
   enableDecompression: Boolean
 ) extends ReceiverInputDStream[SparkFlumeEvent](_ssc) {
 
+  /* This FlumeInputDStream would be under rate control if its rateController is defined. */
+  override protected[streaming] lazy val underRateControl = rateController.isDefined
+
   override def getReceiver(): Receiver[SparkFlumeEvent] = {
     new FlumeReceiver(host, port, storageLevel, enableDecompression)
   }

--- a/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/DirectKafkaInputDStream.scala
+++ b/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/DirectKafkaInputDStream.scala
@@ -85,6 +85,9 @@ class DirectKafkaInputDStream[
     }
   }
 
+  /* This DirectKafkaInputDStream would be under rate control if its rateController is defined. */
+  override protected[streaming] lazy val underRateControl = rateController.isDefined
+
   protected val kc = new KafkaCluster(kafkaParams)
 
   private val maxRateLimitPerPartition: Int = context.sparkContext.getConf.getInt(

--- a/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaInputDStream.scala
+++ b/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaInputDStream.scala
@@ -55,6 +55,11 @@ class KafkaInputDStream[
     storageLevel: StorageLevel
   ) extends ReceiverInputDStream[(K, V)](_ssc) with Logging {
 
+  /* KafkaReceiver uses store(dataItem) so it may be underRateControl */
+  /* ReliableKafkaReceiver uses store(ArrayBuffer) so it is NOT underRateControl */
+  override protected[streaming] lazy val underRateControl = !useReliableReceiver &&
+                                                            rateController.isDefined
+
   def getReceiver(): Receiver[(K, V)] = {
     if (!useReliableReceiver) {
       new KafkaReceiver[K, V, U, T](kafkaParams, topics, storageLevel)

--- a/external/mqtt/src/main/scala/org/apache/spark/streaming/mqtt/MQTTInputDStream.scala
+++ b/external/mqtt/src/main/scala/org/apache/spark/streaming/mqtt/MQTTInputDStream.scala
@@ -46,6 +46,9 @@ class MQTTInputDStream(
 
   private[streaming] override def name: String = s"MQTT stream [$id]"
 
+  /* This MQTTInputDStream would be under rate control if its rateController is defined. */
+  override protected[streaming] lazy val underRateControl = rateController.isDefined
+
   def getReceiver(): Receiver[String] = {
     new MQTTReceiver(brokerUrl, topic, storageLevel)
   }

--- a/external/twitter/src/main/scala/org/apache/spark/streaming/twitter/TwitterInputDStream.scala
+++ b/external/twitter/src/main/scala/org/apache/spark/streaming/twitter/TwitterInputDStream.scala
@@ -45,6 +45,9 @@ class TwitterInputDStream(
     storageLevel: StorageLevel
   ) extends ReceiverInputDStream[Status](_ssc)  {
 
+  /* This TwitterInputDStream would be under rate control if its rateController is defined. */
+  override protected[streaming] lazy val underRateControl = rateController.isDefined
+
   private def createOAuthAuthorization(): Authorization = {
     new OAuthAuthorization(new ConfigurationBuilder().build())
   }

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/InputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/InputDStream.scala
@@ -52,6 +52,16 @@ abstract class InputDStream[T: ClassTag] (_ssc: StreamingContext)
   // Keep track of the freshest rate for this stream using the rateEstimator
   protected[streaming] val rateController: Option[RateController] = None
 
+  /** Is this InputDStream under rate control.
+   *
+   * A InputDStream is under rate control when:
+   * - its rateController is defined and,
+   * - for a ReceiverInputDStream, it stores data via store(dataItem), rather than other store()
+   *   methods such as store(ByteBuffer), store(ArrayBuffer), store(Iterator).
+   * See SPARK-13618 for details.
+   */
+  protected[streaming] lazy val underRateControl: Boolean = false
+
   /** A human-readable name of this InputDStream */
   private[streaming] def name: String = {
     // e.g. FlumePollingDStream -> "Flume polling stream"

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/PluggableInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/PluggableInputDStream.scala
@@ -27,6 +27,9 @@ class PluggableInputDStream[T: ClassTag](
   _ssc: StreamingContext,
   receiver: Receiver[T]) extends ReceiverInputDStream[T](_ssc) {
 
+  /* This PluggableInputDStream would be under rate control if its rateController is defined. */
+  override protected[streaming] lazy val underRateControl = rateController.isDefined
+
   def getReceiver(): Receiver[T] = {
     receiver
   }

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/SocketInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/SocketInputDStream.scala
@@ -38,6 +38,9 @@ class SocketInputDStream[T: ClassTag](
     storageLevel: StorageLevel
   ) extends ReceiverInputDStream[T](_ssc) {
 
+  /* This SocketInputDStream would be under rate control if its rateController is defined. */
+  override protected[streaming] lazy val underRateControl = rateController.isDefined
+
   def getReceiver(): Receiver[T] = {
     new SocketReceiver(host, port, bytesToObjects, storageLevel)
   }

--- a/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingJobProgressListener.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingJobProgressListener.scala
@@ -196,6 +196,17 @@ private[streaming] class StreamingJobProgressListener(ssc: StreamingContext)
     ssc.graph.getInputStreamName(streamId)
   }
 
+  lazy val allStreamsUnderRateControl = ssc.graph.getInputStreams().forall(_.underRateControl)
+
+  def streamUnderRateControl(streamId: Int): Option[Boolean] = {
+    if (allStreamsUnderRateControl) {
+      Some(true)
+    }
+    else {
+      ssc.graph.getInputStreams().filter(_.id == streamId).headOption.map(_.underRateControl)
+    }
+  }
+
   /**
    * Return all InputDStream Ids
    */


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR makes Streaming web UI display rate-limit lines in the statistics graph.

Design doc: https://docs.google.com/document/d/1kGXQEcToNglDK-AbyEJGoYX9wwODimUVf0PetoxuU5M/edit#

Part 2 (this PR):
- adds in InputDStream an underRateControl field, to indicate whether an InputDStream instance is under rate control.

Part 1: [PR #11470](https://github.com/apache/spark/pull/11470)
Part 3: [PR #11643](https://github.com/apache/spark/pull/11643)
## Screenshots
### without back pressure

![](https://cloud.githubusercontent.com/assets/15843379/13664195/d2264c48-e6e0-11e5-85e6-f13187d4cbde.png)
### with back pressure

![](https://cloud.githubusercontent.com/assets/15843379/13664196/d2549c7e-e6e0-11e5-9f62-d7f1458f1c27.png)
