### PR TITLE
[SPARK-13780][sql] Add missing dependency to build.

### DIFF
--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -84,6 +84,10 @@
       <artifactId>parquet-hadoop</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${fasterxml.jackson.version}</version>


### PR DESCRIPTION
This is needed to avoid odd compiler errors when building just the
sql package with maven, because of odd interactions between scalac
and shaded classes.
