### PR TITLE
[SPARK-13618][STREAMING][WEB-UI] Make Streaming web UI page display rate-limit lines on statistics graph - Part 3

### DIFF
--- a/external/flume/src/main/scala/org/apache/spark/streaming/flume/FlumeInputDStream.scala
+++ b/external/flume/src/main/scala/org/apache/spark/streaming/flume/FlumeInputDStream.scala
@@ -48,6 +48,9 @@ class FlumeInputDStream[T: ClassTag](
   enableDecompression: Boolean
 ) extends ReceiverInputDStream[SparkFlumeEvent](_ssc) {
 
+  /* This FlumeInputDStream would be under rate control if its rateController is defined. */
+  override protected[streaming] lazy val underRateControl = rateController.isDefined
+
   override def getReceiver(): Receiver[SparkFlumeEvent] = {
     new FlumeReceiver(host, port, storageLevel, enableDecompression)
   }

--- a/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/DirectKafkaInputDStream.scala
+++ b/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/DirectKafkaInputDStream.scala
@@ -177,7 +177,7 @@ class DirectKafkaInputDStream[
     val metadata = Map(
       "offsets" -> offsetRanges.toList,
       StreamInputInfo.METADATA_KEY_DESCRIPTION -> description)
-    val inputInfo = StreamInputInfo(id, rdd.count, metadata)
+    val inputInfo = StreamInputInfo(id, rdd.count, None, metadata)
     ssc.scheduler.inputInfoTracker.reportInfo(validTime, inputInfo)
 
     currentOffsets = untilOffsets.map(kv => kv._1 -> kv._2.offset)

--- a/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/DirectKafkaInputDStream.scala
+++ b/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/DirectKafkaInputDStream.scala
@@ -85,6 +85,9 @@ class DirectKafkaInputDStream[
     }
   }
 
+  /* This DirectKafkaInputDStream would be under rate control if its rateController is defined. */
+  override protected[streaming] lazy val underRateControl = rateController.isDefined
+
   protected val kc = new KafkaCluster(kafkaParams)
 
   private val maxRateLimitPerPartition: Int = context.sparkContext.getConf.getInt(

--- a/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaInputDStream.scala
+++ b/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaInputDStream.scala
@@ -55,6 +55,11 @@ class KafkaInputDStream[
     storageLevel: StorageLevel
   ) extends ReceiverInputDStream[(K, V)](_ssc) with Logging {
 
+  /* KafkaReceiver uses store(dataItem) so it may be underRateControl */
+  /* ReliableKafkaReceiver uses store(ArrayBuffer) so it is NOT underRateControl */
+  override protected[streaming] lazy val underRateControl = !useReliableReceiver &&
+                                                            rateController.isDefined
+
   def getReceiver(): Receiver[(K, V)] = {
     if (!useReliableReceiver) {
       new KafkaReceiver[K, V, U, T](kafkaParams, topics, storageLevel)

--- a/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/ReliableKafkaReceiver.scala
+++ b/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/ReliableKafkaReceiver.scala
@@ -289,7 +289,8 @@ class ReliableKafkaReceiver[
       rememberBlockOffsets(blockId)
     }
 
-    def onPushBlock(blockId: StreamBlockId, arrayBuffer: mutable.ArrayBuffer[_]): Unit = {
+    def onPushBlock(blockId: StreamBlockId, arrayBuffer: mutable.ArrayBuffer[_],
+        numRecordsLimit: Long): Unit = {
       // Store block and commit the blocks offset
       storeBlockAndCommitOffset(blockId, arrayBuffer)
     }

--- a/external/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisReceiver.scala
+++ b/external/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisReceiver.scala
@@ -348,7 +348,8 @@ private[kinesis] class KinesisReceiver[T](
     }
 
     /** Callback method called when a block is ready to be pushed / stored. */
-    def onPushBlock(blockId: StreamBlockId, arrayBuffer: mutable.ArrayBuffer[_]): Unit = {
+    def onPushBlock(blockId: StreamBlockId, arrayBuffer: mutable.ArrayBuffer[_],
+        numRecordsLimit: Long): Unit = {
       storeBlockWithRanges(blockId,
         arrayBuffer.asInstanceOf[mutable.ArrayBuffer[T]])
     }

--- a/external/mqtt/src/main/scala/org/apache/spark/streaming/mqtt/MQTTInputDStream.scala
+++ b/external/mqtt/src/main/scala/org/apache/spark/streaming/mqtt/MQTTInputDStream.scala
@@ -46,6 +46,9 @@ class MQTTInputDStream(
 
   private[streaming] override def name: String = s"MQTT stream [$id]"
 
+  /* This MQTTInputDStream would be under rate control if its rateController is defined. */
+  override protected[streaming] lazy val underRateControl = rateController.isDefined
+
   def getReceiver(): Receiver[String] = {
     new MQTTReceiver(brokerUrl, topic, storageLevel)
   }

--- a/external/twitter/src/main/scala/org/apache/spark/streaming/twitter/TwitterInputDStream.scala
+++ b/external/twitter/src/main/scala/org/apache/spark/streaming/twitter/TwitterInputDStream.scala
@@ -45,6 +45,9 @@ class TwitterInputDStream(
     storageLevel: StorageLevel
   ) extends ReceiverInputDStream[Status](_ssc)  {
 
+  /* This TwitterInputDStream would be under rate control if its rateController is defined. */
+  override protected[streaming] lazy val underRateControl = rateController.isDefined
+
   private def createOAuthAuthorization(): Authorization = {
     new OAuthAuthorization(new ConfigurationBuilder().build())
   }

--- a/streaming/src/main/resources/org/apache/spark/streaming/ui/static/streaming-page.css
+++ b/streaming/src/main/resources/org/apache/spark/streaming/ui/static/streaming-page.css
@@ -40,6 +40,17 @@
   stroke-width: 1.5px;
 }
 
+/* Currently used for the rate limit line */
+.rate_limit_line_solid {
+  stroke: #ffa1b0;
+}
+
+/* Currently used for the rate limit line */
+.rate_limit_line_dashed {
+  stroke: #ffa1b0;
+  stroke-dasharray: 5,5
+}
+
 .bar rect {
   fill: #0088cc;
   shape-rendering: crispEdges;

--- a/streaming/src/main/resources/org/apache/spark/streaming/ui/static/streaming-page.js
+++ b/streaming/src/main/resources/org/apache/spark/streaming/ui/static/streaming-page.js
@@ -87,7 +87,7 @@ function drawLine(svg, xFunc, yFunc, x1, y1, x2, y2) {
  * @param unitY the unit of Y axis
  * @param batchInterval if "batchInterval" is specified, we will draw a line for "batchInterval" in the graph
  */
-function drawTimeline(id, data, minX, maxX, minY, maxY, unitY, batchInterval) {
+function drawTimeline(id, dataSets, minX, maxX, minY, maxY, unitY, batchInterval) {
     // Hide the right border of "<td>". We cannot use "css" directly, or "sorttable.js" will override them.
     d3.select(d3.select(id).node().parentNode)
         .style("padding", "8px 0 8px 8px")
@@ -143,10 +143,17 @@ function drawTimeline(id, data, minX, maxX, minY, maxY, unitY, batchInterval) {
         drawLine(svg, x, y, minX, batchInterval, maxX, batchInterval);
     }
 
-    svg.append("path")
-        .datum(data)
-        .attr("class", "line")
-        .attr("d", line);
+    for (var dataSetIdx = 0; dataSetIdx < dataSets.length; dataSetIdx ++) {
+      svg.append("path")
+         .datum(dataSets[dataSetIdx])
+         // 0th line is the event rate line
+         // 1st, 3rd, 5th... lines are the *dashed* rate limit lines
+         // 2nd, 4th, 6th... lines are the *solid* rate limit lines
+         .attr("class", dataSetIdx == 0 ? "line" : (dataSetIdx % 2 == 1 ?
+                                                    "line rate_limit_line_dashed" :
+                                                    "line rate_limit_line_solid"))
+         .attr("d", line);
+    }
 
     // If the user click one point in the graphs, jump to the batch row and highlight it. And
     // recovery the batch row after 3 seconds if necessary.
@@ -161,7 +168,8 @@ function drawTimeline(id, data, minX, maxX, minY, maxY, unitY, batchInterval) {
     // Add points to the line. However, we make it invisible at first. But when the user moves mouse
     // over a point, it will be displayed with its detail.
     svg.selectAll(".point")
-        .data(data)
+        // Only add points of the 0th line, i.e., the event rate line
+        .data(dataSets[0])
         .enter().append("circle")
             .attr("stroke", function(d) { return isFailedBatch(d.x) ? "red" : "white";}) // white and opacity = 0 make it invisible
             .attr("fill", function(d) { return isFailedBatch(d.x) ? "red" : "white";})

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
@@ -157,7 +157,7 @@ class FileInputDStream[K, V, F <: NewInputFormat[K, V]](
     val metadata = Map(
       "files" -> newFiles.toList,
       StreamInputInfo.METADATA_KEY_DESCRIPTION -> newFiles.mkString("\n"))
-    val inputInfo = StreamInputInfo(id, 0, metadata)
+    val inputInfo = StreamInputInfo(id, 0, None, metadata)
     ssc.scheduler.inputInfoTracker.reportInfo(validTime, inputInfo)
     rdds
   }

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/InputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/InputDStream.scala
@@ -52,6 +52,16 @@ abstract class InputDStream[T: ClassTag] (_ssc: StreamingContext)
   // Keep track of the freshest rate for this stream using the rateEstimator
   protected[streaming] val rateController: Option[RateController] = None
 
+  /** Is this InputDStream under rate control.
+   *
+   * A InputDStream is under rate control when:
+   * - its rateController is defined and,
+   * - for a ReceiverInputDStream, it stores data via store(dataItem), rather than other store()
+   *   methods such as store(ByteBuffer), store(ArrayBuffer), store(Iterator).
+   * See SPARK-13618 for details.
+   */
+  protected[streaming] lazy val underRateControl: Boolean = false
+
   /** A human-readable name of this InputDStream */
   private[streaming] def name: String = {
     // e.g. FlumePollingDStream -> "Flume polling stream"

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/PluggableInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/PluggableInputDStream.scala
@@ -27,6 +27,9 @@ class PluggableInputDStream[T: ClassTag](
   _ssc: StreamingContext,
   receiver: Receiver[T]) extends ReceiverInputDStream[T](_ssc) {
 
+  /* This PluggableInputDStream would be under rate control if its rateController is defined. */
+  override protected[streaming] lazy val underRateControl = rateController.isDefined
+
   def getReceiver(): Receiver[T] = {
     receiver
   }

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/SocketInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/SocketInputDStream.scala
@@ -38,6 +38,9 @@ class SocketInputDStream[T: ClassTag](
     storageLevel: StorageLevel
   ) extends ReceiverInputDStream[T](_ssc) {
 
+  /* This SocketInputDStream would be under rate control if its rateController is defined. */
+  override protected[streaming] lazy val underRateControl = rateController.isDefined
+
   def getReceiver(): Receiver[T] = {
     new SocketReceiver(host, port, bytesToObjects, storageLevel)
   }

--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/RateLimiter.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/RateLimiter.scala
@@ -17,9 +17,13 @@
 
 package org.apache.spark.streaming.receiver
 
+import scala.collection.mutable.ArrayBuffer
+
 import com.google.common.util.concurrent.{RateLimiter => GuavaRateLimiter}
 
 import org.apache.spark.{Logging, SparkConf}
+import org.apache.spark.util.Clock
+
 
 /** Provides waitToPush() method to limit the rate at which receivers consume data.
   *
@@ -32,7 +36,7 @@ import org.apache.spark.{Logging, SparkConf}
   *
   * @param conf spark configuration
   */
-private[receiver] abstract class RateLimiter(conf: SparkConf) extends Logging {
+private[receiver] abstract class RateLimiter(conf: SparkConf, clock: Clock) extends Logging {
 
   // treated as an upper limit
   private val maxRateLimit = conf.getLong("spark.streaming.receiver.maxRate", Long.MaxValue)
@@ -57,8 +61,10 @@ private[receiver] abstract class RateLimiter(conf: SparkConf) extends Logging {
     if (newRate > 0) {
       if (maxRateLimit > 0) {
         rateLimiter.setRate(newRate.min(maxRateLimit))
+        appendLimitToHistory(newRate.min(maxRateLimit))
       } else {
         rateLimiter.setRate(newRate)
+        appendLimitToHistory(newRate)
       }
     }
 
@@ -67,5 +73,58 @@ private[receiver] abstract class RateLimiter(conf: SparkConf) extends Logging {
    */
   private def getInitialRateLimit(): Long = {
     math.min(conf.getLong("spark.streaming.backpressure.initialRate", maxRateLimit), maxRateLimit)
+  }
+
+  private[receiver] case class RateLimitSnapshot(limit: Double, ts: Long)
+
+  private[receiver] val rateLimitHistory: ArrayBuffer[RateLimitSnapshot] =
+    ArrayBuffer(RateLimitSnapshot(getInitialRateLimit().toDouble, -1L))
+
+  /**
+   * Logs the rateLimit change history, so that we can do a sum later.
+   *
+   * @param rate the new rate
+   * @param ts at which time the rate changed
+   */
+  private[receiver] def appendLimitToHistory(rate: Double, ts: Long = clock.getTimeMillis()) {
+    rateLimitHistory.synchronized {
+      rateLimitHistory += RateLimitSnapshot(rate, ts)
+    }
+  }
+
+  private val blockIntervalMs = conf.getTimeAsMs("spark.streaming.blockInterval", "200ms")
+  require(blockIntervalMs > 0, s"'spark.streaming.blockInterval' should be a positive value")
+
+  /**
+   * Calculate the upper bound of how many events can be received in a block interval.
+   * Note this should be called for each block interval once and only once.
+   *
+   * @param ts the ending timestamp of a block interval
+   * @return the upper bound of how many events can be received in a block interval
+   */
+  private[receiver]  def sumHistoryThenTrim(ts: Long = clock.getTimeMillis()): Long = {
+    var sum: Double = 0
+    rateLimitHistory.synchronized {
+      // first add a RateLimitSnapshot
+      // this RateLimitSnapshot will be used as the ending of this block interval and the beginning
+      // of the next block interval
+      rateLimitHistory += RateLimitSnapshot(rateLimitHistory.last.limit, ts)
+
+      // then do a sum
+      for (idx <- 0 until rateLimitHistory.length - 1) {
+        val duration = rateLimitHistory(idx + 1).ts - (if (rateLimitHistory(idx).ts < 0) {
+          rateLimitHistory.last.ts - blockIntervalMs
+        }
+        else {
+          rateLimitHistory(idx).ts
+        })
+        sum += rateLimitHistory(idx).limit * duration
+      }
+
+      // trim the history to the last one
+      rateLimitHistory.trimStart(rateLimitHistory.length - 1)
+    }
+
+    (sum / 1000).ceil.toLong
   }
 }

--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/RateLimiter.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/RateLimiter.scala
@@ -128,3 +128,24 @@ private[receiver] abstract class RateLimiter(conf: SparkConf, clock: Clock) exte
     (sum / 1000).ceil.toLong
   }
 }
+
+private[streaming] object RateLimiterHelper {
+
+  def sumRateLimits(rateLimits: Seq[Option[Long]]): Option[Long] = {
+    if (rateLimits.length == 0 || rateLimits.count(_.isEmpty) > 0) {
+      None
+    }
+    else {
+      val sum = rateLimits.map(_.get).foldLeft(0L) { (x, y) =>
+        val z = x + y
+        // deals with overflow carefully
+        if (z < 0) {
+          Long.MaxValue
+        } else {
+          z
+        }
+      }
+      Some(sum)
+    }
+  }
+}

--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/Receiver.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/Receiver.scala
@@ -121,7 +121,7 @@ abstract class Receiver[T](val storageLevel: StorageLevel) extends Serializable 
 
   /** Store an ArrayBuffer of received data as a data block into Spark's memory. */
   def store(dataBuffer: ArrayBuffer[T]) {
-    supervisor.pushArrayBuffer(dataBuffer, None, None)
+    supervisor.pushArrayBuffer(dataBuffer, None, None, None)
   }
 
   /**
@@ -130,12 +130,12 @@ abstract class Receiver[T](val storageLevel: StorageLevel) extends Serializable 
    * for being used in the corresponding InputDStream.
    */
   def store(dataBuffer: ArrayBuffer[T], metadata: Any) {
-    supervisor.pushArrayBuffer(dataBuffer, Some(metadata), None)
+    supervisor.pushArrayBuffer(dataBuffer, Some(metadata), None, None)
   }
 
   /** Store an iterator of received data as a data block into Spark's memory. */
   def store(dataIterator: Iterator[T]) {
-    supervisor.pushIterator(dataIterator, None, None)
+    supervisor.pushIterator(dataIterator, None, None, None)
   }
 
   /**
@@ -144,12 +144,12 @@ abstract class Receiver[T](val storageLevel: StorageLevel) extends Serializable 
    * for being used in the corresponding InputDStream.
    */
   def store(dataIterator: java.util.Iterator[T], metadata: Any) {
-    supervisor.pushIterator(dataIterator.asScala, Some(metadata), None)
+    supervisor.pushIterator(dataIterator.asScala, Some(metadata), None, None)
   }
 
   /** Store an iterator of received data as a data block into Spark's memory. */
   def store(dataIterator: java.util.Iterator[T]) {
-    supervisor.pushIterator(dataIterator.asScala, None, None)
+    supervisor.pushIterator(dataIterator.asScala, None, None, None)
   }
 
   /**
@@ -158,7 +158,7 @@ abstract class Receiver[T](val storageLevel: StorageLevel) extends Serializable 
    * for being used in the corresponding InputDStream.
    */
   def store(dataIterator: Iterator[T], metadata: Any) {
-    supervisor.pushIterator(dataIterator, Some(metadata), None)
+    supervisor.pushIterator(dataIterator, Some(metadata), None, None)
   }
 
   /**
@@ -167,7 +167,7 @@ abstract class Receiver[T](val storageLevel: StorageLevel) extends Serializable 
    * that Spark is configured to use.
    */
   def store(bytes: ByteBuffer) {
-    supervisor.pushBytes(bytes, None, None)
+    supervisor.pushBytes(bytes, None, None, None)
   }
 
   /**
@@ -176,7 +176,7 @@ abstract class Receiver[T](val storageLevel: StorageLevel) extends Serializable 
    * for being used in the corresponding InputDStream.
    */
   def store(bytes: ByteBuffer, metadata: Any) {
-    supervisor.pushBytes(bytes, Some(metadata), None)
+    supervisor.pushBytes(bytes, Some(metadata), None, None)
   }
 
   /** Report exceptions in receiving data. */

--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/ReceiverSupervisor.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/ReceiverSupervisor.scala
@@ -74,22 +74,25 @@ private[streaming] abstract class ReceiverSupervisor(
   /** Store the bytes of received data as a data block into Spark's memory. */
   def pushBytes(
       bytes: ByteBuffer,
-      optionalMetadata: Option[Any],
-      optionalBlockId: Option[StreamBlockId]
+      metadataOption: Option[Any],
+      blockIdOption: Option[StreamBlockId],
+      numRecordsLimitOption: Option[Long]
     )
 
   /** Store a iterator of received data as a data block into Spark's memory. */
   def pushIterator(
       iterator: Iterator[_],
-      optionalMetadata: Option[Any],
-      optionalBlockId: Option[StreamBlockId]
+      metadataOption: Option[Any],
+      BlockIdOption: Option[StreamBlockId],
+      numRecordsLimitOption: Option[Long]
     )
 
   /** Store an ArrayBuffer of received data as a data block into Spark's memory. */
   def pushArrayBuffer(
       arrayBuffer: ArrayBuffer[_],
-      optionalMetadata: Option[Any],
-      optionalBlockId: Option[StreamBlockId]
+      metadataOption: Option[Any],
+      blockIdOption: Option[StreamBlockId],
+      numRecordsLimitOption: Option[Long]
     )
 
   /**

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/InputInfoTracker.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/InputInfoTracker.scala
@@ -29,13 +29,18 @@ import org.apache.spark.streaming.{StreamingContext, Time}
  *
  * @param inputStreamId the input stream id
  * @param numRecords the number of records in a batch
+ * @param numRecordsLimitOption (if exist) the upper bound of number of records in a batch
  * @param metadata metadata for this batch. It should contain at least one standard field named
  *                 "Description" which maps to the content that will be shown in the UI.
  */
 @DeveloperApi
-case class StreamInputInfo(
-    inputStreamId: Int, numRecords: Long, metadata: Map[String, Any] = Map.empty) {
+case class StreamInputInfo(inputStreamId: Int,
+                           numRecords: Long,
+                           numRecordsLimitOption: Option[Long] = None,
+                           metadata: Map[String, Any] = Map.empty) {
   require(numRecords >= 0, "numRecords must not be negative")
+  require(numRecordsLimitOption.isEmpty || numRecordsLimitOption.get >= 0,
+          "numRecordsLimitOption must not be negative")
 
   def metadataDescription: Option[String] =
     metadata.get(StreamInputInfo.METADATA_KEY_DESCRIPTION).map(_.toString)

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceivedBlockInfo.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceivedBlockInfo.scala
@@ -24,13 +24,13 @@ import org.apache.spark.streaming.util.WriteAheadLogRecordHandle
 /** Information about blocks received by the receiver */
 private[streaming] case class ReceivedBlockInfo(
     streamId: Int,
-    numRecords: Option[Long],
+    numRecordsOption: Option[Long],
     numRecordsLimitOption: Option[Long],
     metadataOption: Option[Any],
     blockStoreResult: ReceivedBlockStoreResult
   ) {
 
-  require(numRecords.isEmpty || numRecords.get >= 0,
+  require(numRecordsOption.isEmpty || numRecordsOption.get >= 0,
           "numRecordsOption must not be negative")
   require(numRecordsLimitOption.isEmpty || numRecordsLimitOption.get >= 0,
           "numRecordsLimitOption must not be negative")

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceivedBlockInfo.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceivedBlockInfo.scala
@@ -25,11 +25,15 @@ import org.apache.spark.streaming.util.WriteAheadLogRecordHandle
 private[streaming] case class ReceivedBlockInfo(
     streamId: Int,
     numRecords: Option[Long],
+    numRecordsLimitOption: Option[Long],
     metadataOption: Option[Any],
     blockStoreResult: ReceivedBlockStoreResult
   ) {
 
-  require(numRecords.isEmpty || numRecords.get >= 0, "numRecords must not be negative")
+  require(numRecords.isEmpty || numRecords.get >= 0,
+          "numRecordsOption must not be negative")
+  require(numRecordsLimitOption.isEmpty || numRecordsLimitOption.get >= 0,
+          "numRecordsLimitOption must not be negative")
 
   @volatile private var _isBlockIdValid = true
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/ui/AllBatchesTable.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/ui/AllBatchesTable.scala
@@ -21,11 +21,24 @@ import scala.xml.Node
 
 import org.apache.spark.ui.{UIUtils => SparkUIUtils}
 
-private[ui] abstract class BatchTableBase(tableId: String, batchInterval: Long) {
-
+private[ui] abstract class BatchTableBase(
+    tableId: String,
+    batchInterval: Long,
+    underRateLimit: Boolean) {
   protected def columns: Seq[Node] = {
     <th>Batch Time</th>
-      <th>Input Size</th>
+      <th>Input Size</th> ++ {
+        if (underRateLimit) {
+          <th>Input Size Limit
+            {SparkUIUtils.tooltip("The upper bound of possible input size of a batch, determined by"
+               + " spark.streaming.receiver.maxRate and the adaptive back pressure mechanism",
+               "top")}
+          </th>
+        }
+        else {
+          Nil
+        }
+      } ++
       <th>Scheduling Delay
         {SparkUIUtils.tooltip("Time taken by Streaming scheduler to submit jobs of a batch", "top")}
       </th>
@@ -53,6 +66,7 @@ private[ui] abstract class BatchTableBase(tableId: String, batchInterval: Long) 
     val batchTime = batch.batchTime.milliseconds
     val formattedBatchTime = UIUtils.formatBatchTime(batchTime, batchInterval)
     val eventCount = batch.numRecords
+    val eventCountLimitOption = batch.numRecordsLimitOption
     val schedulingDelay = batch.schedulingDelay
     val formattedSchedulingDelay = schedulingDelay.map(SparkUIUtils.formatDuration).getOrElse("-")
     val processingTime = batch.processingDelay
@@ -65,7 +79,20 @@ private[ui] abstract class BatchTableBase(tableId: String, batchInterval: Long) 
         {formattedBatchTime}
       </a>
     </td>
-      <td sorttable_customkey={eventCount.toString}>{eventCount.toString} events</td>
+      <td sorttable_customkey={eventCount.toString}>{eventCount.toString} events</td> ++ {
+        if (underRateLimit) {
+          <td sorttable_customkey={eventCountLimitOption.getOrElse("-").toString}> {
+          if (eventCountLimitOption.isDefined) {
+            eventCountLimitOption.get.toString + " events"
+          }
+          else {
+            "-"
+          }}
+          </td>
+        } else {
+          Nil
+        }
+      } ++
       <td sorttable_customkey={schedulingDelay.getOrElse(Long.MaxValue).toString}>
         {formattedSchedulingDelay}
       </td>
@@ -111,7 +138,9 @@ private[ui] abstract class BatchTableBase(tableId: String, batchInterval: Long) 
 private[ui] class ActiveBatchTable(
     runningBatches: Seq[BatchUIData],
     waitingBatches: Seq[BatchUIData],
-    batchInterval: Long) extends BatchTableBase("active-batches-table", batchInterval) {
+    batchInterval: Long,
+    underRateControl: Boolean)
+  extends BatchTableBase("active-batches-table", batchInterval, underRateControl) {
 
   private val firstFailureReason = getFirstFailureReason(runningBatches)
 
@@ -155,8 +184,9 @@ private[ui] class ActiveBatchTable(
   }
 }
 
-private[ui] class CompletedBatchTable(batches: Seq[BatchUIData], batchInterval: Long)
-  extends BatchTableBase("completed-batches-table", batchInterval) {
+private[ui] class CompletedBatchTable(
+    batches: Seq[BatchUIData], batchInterval: Long, underRateControl: Boolean)
+  extends BatchTableBase("completed-batches-table", batchInterval, underRateControl) {
 
   private val firstFailureReason = getFirstFailureReason(batches)
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingJobProgressListener.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingJobProgressListener.scala
@@ -196,6 +196,17 @@ private[streaming] class StreamingJobProgressListener(ssc: StreamingContext)
     ssc.graph.getInputStreamName(streamId)
   }
 
+  lazy val allStreamsUnderRateControl = ssc.graph.getInputStreams().forall(_.underRateControl)
+
+  def streamUnderRateControl(streamId: Int): Option[Boolean] = {
+    if (allStreamsUnderRateControl) {
+      Some(true)
+    }
+    else {
+      ssc.graph.getInputStreams().filter(_.id == streamId).headOption.map(_.underRateControl)
+    }
+  }
+
   /**
    * Return all InputDStream Ids
    */

--- a/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingJobProgressListener.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/ui/StreamingJobProgressListener.scala
@@ -216,20 +216,32 @@ private[streaming] class StreamingJobProgressListener(ssc: StreamingContext)
    * Return all of the event rates for each InputDStream in each batch. The key of the return value
    * is the stream id, and the value is a sequence of batch time with its event rate.
    */
-  def receivedEventRateWithBatchTime: Map[Int, Seq[(Long, Double)]] = synchronized {
-    val _retainedBatches = retainedBatches
-    val latestBatches = _retainedBatches.map { batchUIData =>
-      (batchUIData.batchTime.milliseconds, batchUIData.streamIdToInputInfo.mapValues(_.numRecords))
-    }
-    streamIds.map { streamId =>
-      val eventRates = latestBatches.map {
-        case (batchTime, streamIdToNumRecords) =>
-          val numRecords = streamIdToNumRecords.getOrElse(streamId, 0L)
-          (batchTime, numRecords * 1000.0 / batchDuration)
+  def receivedEventRateAndLimitRateWithBatchTime: Map[Int, Seq[(Long, Double, Option[Double])]] =
+    synchronized {
+      val _retainedBatches = retainedBatches
+      val latestBatches = _retainedBatches.map { batchUIData =>
+        (batchUIData.batchTime.milliseconds,
+         batchUIData.streamIdToInputInfo.mapValues(_.numRecords),
+         batchUIData.streamIdToInputInfo.mapValues(_.numRecordsLimitOption))
       }
-      (streamId, eventRates)
-    }.toMap
-  }
+      streamIds.map { streamId =>
+        val evenRatesAndLimitRates = latestBatches.map {
+          case (batchTime, streamIdToNumRecords, streamIdToNumRecordsLimitOption) =>
+            val numRecords = streamIdToNumRecords.getOrElse(streamId, 0L)
+            val numRecordsLimitOption =
+                  streamIdToNumRecordsLimitOption.get(streamId).getOrElse(None)
+            val eventRate = numRecords * 1000.0 / batchDuration
+            val limitRateOption = if (numRecordsLimitOption.isDefined) {
+              Some(numRecordsLimitOption.get * 1000.0 / batchDuration)
+            }
+            else {
+              None
+            }
+            (batchTime, eventRate, limitRateOption)
+        }
+        (streamId, evenRatesAndLimitRates)
+      }.toMap
+    }
 
   def lastReceivedBatchRecords: Map[Int, Long] = synchronized {
     val lastReceivedBlockInfoOption =

--- a/streaming/src/test/scala/org/apache/spark/streaming/ReceivedBlockTrackerSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/ReceivedBlockTrackerSuite.scala
@@ -293,7 +293,7 @@ class ReceivedBlockTrackerSuite
 
   /** Generate blocks infos using random ids */
   def generateBlockInfos(): Seq[ReceivedBlockInfo] = {
-    List.fill(5)(ReceivedBlockInfo(streamId, Some(0L), None,
+    List.fill(5)(ReceivedBlockInfo(streamId, Some(0L), None, None,
       BlockManagerBasedStoreResult(StreamBlockId(streamId, math.abs(Random.nextInt)), Some(0L))))
   }
 

--- a/streaming/src/test/scala/org/apache/spark/streaming/ReceiverInputDStreamSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/ReceiverInputDStreamSuite.scala
@@ -155,6 +155,6 @@ class ReceiverInputDStreamSuite extends TestSuiteBase with BeforeAndAfterAll {
     } else {
       new BlockManagerBasedStoreResult(blockId, None)
     }
-    new ReceivedBlockInfo(0, None, None, storeResult)
+    new ReceivedBlockInfo(0, None, None, None, storeResult)
   }
 }

--- a/streaming/src/test/scala/org/apache/spark/streaming/ReceiverSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/ReceiverSuite.scala
@@ -298,22 +298,25 @@ class ReceiverSuite extends TestSuiteBase with Timeouts with Serializable {
 
     def pushBytes(
         bytes: ByteBuffer,
-        optionalMetadata: Option[Any],
-        optionalBlockId: Option[StreamBlockId]) {
+        metadataOption: Option[Any],
+        blockIdOption: Option[StreamBlockId],
+        numRecordsLimitOption: Option[Long]) {
       byteBuffers += bytes
     }
 
     def pushIterator(
         iterator: Iterator[_],
-        optionalMetadata: Option[Any],
-        optionalBlockId: Option[StreamBlockId]) {
+        metadataOption: Option[Any],
+        blockIdOption: Option[StreamBlockId],
+        numRecordsLimitOption: Option[Long]) {
       iterators += iterator
     }
 
     def pushArrayBuffer(
         arrayBuffer: ArrayBuffer[_],
-        optionalMetadata: Option[Any],
-        optionalBlockId: Option[StreamBlockId]) {
+        metadataOption: Option[Any],
+        blockIdOption: Option[StreamBlockId],
+        numRecordsLimitOption: Option[Long]) {
       arrayBuffers +=  arrayBuffer
     }
 
@@ -341,7 +344,7 @@ class ReceiverSuite extends TestSuiteBase with Timeouts with Serializable {
 
     def onGenerateBlock(blockId: StreamBlockId) { }
 
-    def onPushBlock(blockId: StreamBlockId, arrayBuffer: ArrayBuffer[_]) {
+    def onPushBlock(blockId: StreamBlockId, arrayBuffer: ArrayBuffer[_], numRecordsLimit: Long) {
       val bufferOfInts = arrayBuffer.map(_.asInstanceOf[Int])
       arrayBuffers += bufferOfInts
       Thread.sleep(0)

--- a/streaming/src/test/scala/org/apache/spark/streaming/receiver/BlockGeneratorSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/receiver/BlockGeneratorSuite.scala
@@ -203,8 +203,8 @@ class BlockGeneratorSuite extends SparkFunSuite with BeforeAndAfter {
   test("block push errors are reported") {
     val listener = new TestBlockGeneratorListener {
       @volatile var errorReported = false
-      override def onPushBlock(
-          blockId: StreamBlockId, arrayBuffer: mutable.ArrayBuffer[_]): Unit = {
+      override def onPushBlock(blockId: StreamBlockId, arrayBuffer: mutable.ArrayBuffer[_],
+                               numRecordsLimit: Long): Unit = {
         throw new SparkException("test")
       }
       override def onError(message: String, throwable: Throwable): Unit = {
@@ -244,7 +244,8 @@ class BlockGeneratorSuite extends SparkFunSuite with BeforeAndAfter {
     @volatile var onAddDataCalled = false
     @volatile var onPushBlockCalled = false
 
-    override def onPushBlock(blockId: StreamBlockId, arrayBuffer: mutable.ArrayBuffer[_]): Unit = {
+    override def onPushBlock(blockId: StreamBlockId, arrayBuffer: mutable.ArrayBuffer[_],
+                             numRecordsLimit: Long): Unit = {
       pushedData.addAll(arrayBuffer.asJava)
       onPushBlockCalled = true
     }

--- a/streaming/src/test/scala/org/apache/spark/streaming/receiver/RateLimiterSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/receiver/RateLimiterSuite.scala
@@ -99,4 +99,32 @@ class RateLimiterSuite extends SparkFunSuite {
     assert(rateLimiter.rateLimitHistory(0).ts == 2500)
   }
 
+  test("sumRateLimits() works good for normal cases") {
+    // if rateLimits contains some None, then sumRateLimits() should return None
+    var rateLimits: Seq[Option[Long]] = Seq(Some(1L), None)
+    assert(RateLimiterHelper.sumRateLimits(rateLimits) == None)
+
+    // normal case
+    rateLimits = Seq(Some(10L))
+    var sum: Option[Long] = RateLimiterHelper.sumRateLimits(rateLimits)
+    assert(sum.isDefined && sum.get == 10L)
+    
+    // another normal case
+    rateLimits = Seq(Some(10L), Some(20L), Some(30L), Some(40L))
+    sum = RateLimiterHelper.sumRateLimits(rateLimits)
+    assert(sum.isDefined && sum.get == 100L)
+  }
+
+  test("sumRateLimits() works good for overflow cases") {
+    // overflow case
+    var rateLimits: Seq[Option[Long]] = Seq(Some(Long.MaxValue), Some(1L))
+    var sum = RateLimiterHelper.sumRateLimits(rateLimits)
+    assert(sum.isDefined && sum.get == Long.MaxValue)
+
+    // another overflow case
+    rateLimits = Seq(Some(Long.MaxValue), Some(Long.MaxValue), Some(Long.MaxValue))
+    sum = RateLimiterHelper.sumRateLimits(rateLimits)
+    assert(sum.isDefined && sum.get == Long.MaxValue)
+  }
+
 }

--- a/streaming/src/test/scala/org/apache/spark/streaming/receiver/RateLimiterSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/receiver/RateLimiterSuite.scala
@@ -17,30 +17,86 @@
 
 package org.apache.spark.streaming.receiver
 
-import org.apache.spark.SparkConf
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.util.SystemClock
 
 /** Testsuite for testing the network receiver behavior */
 class RateLimiterSuite extends SparkFunSuite {
 
   test("rate limiter initializes even without a maxRate set") {
     val conf = new SparkConf()
-    val rateLimiter = new RateLimiter(conf){}
+    val rateLimiter = new RateLimiter(conf, new SystemClock){}
     rateLimiter.updateRate(105)
     assert(rateLimiter.getCurrentLimit == 105)
   }
 
   test("rate limiter updates when below maxRate") {
     val conf = new SparkConf().set("spark.streaming.receiver.maxRate", "110")
-    val rateLimiter = new RateLimiter(conf){}
+    val rateLimiter = new RateLimiter(conf, new SystemClock){}
     rateLimiter.updateRate(105)
     assert(rateLimiter.getCurrentLimit == 105)
   }
 
   test("rate limiter stays below maxRate despite large updates") {
     val conf = new SparkConf().set("spark.streaming.receiver.maxRate", "100")
-    val rateLimiter = new RateLimiter(conf){}
+    val rateLimiter = new RateLimiter(conf, new SystemClock){}
     rateLimiter.updateRate(105)
     assert(rateLimiter.getCurrentLimit === 100)
   }
+
+  test("historySumThenTrim() returns expected numRecordsLimit") {
+    val conf = new SparkConf().set("spark.streaming.receiver.maxRate", "100")
+                              .set("spark.streaming.blockInterval", "500ms")
+    val rateLimiter = new RateLimiter(conf, new SystemClock){}
+
+    // Make sure that rateLimitHistory starts with a special initial snapshot
+    assert(rateLimiter.rateLimitHistory(0).limit == 100)
+    assert(rateLimiter.rateLimitHistory(0).ts == -1)
+
+    // Test if sumHistoryThenTrim() works well with the first batch which
+    // contains a special initial snapshot
+    {
+      rateLimiter.appendLimitToHistory(10, 1100)
+      rateLimiter.appendLimitToHistory(20, 1200)
+      rateLimiter.appendLimitToHistory(30, 1300)
+      rateLimiter.appendLimitToHistory(40, 1400)
+      val sum = rateLimiter.sumHistoryThenTrim(1500)
+      val expectedInMillis = 100 * (1100 - (1500 - 500)) +
+                              10 * (1200 - 1100) +
+                              20 * (1300 - 1200) +
+                              30 * (1400 - 1300) +
+                              40 * (1500 - 1400)
+      val expected = expectedInMillis / 1000
+      assert(sum == expected)
+    }
+
+    assert(rateLimiter.rateLimitHistory.length == 1)
+    assert(rateLimiter.rateLimitHistory(0).limit == 40)
+    assert(rateLimiter.rateLimitHistory(0).ts == 1500)
+
+    {
+      val sum = rateLimiter.sumHistoryThenTrim(2000)
+      val expectedInMillis = 40 * (2000 - 1500)
+      val expected = expectedInMillis / 1000
+      assert(sum == expected)
+    }
+
+    assert(rateLimiter.rateLimitHistory.length == 1)
+    assert(rateLimiter.rateLimitHistory(0).limit == 40)
+    assert(rateLimiter.rateLimitHistory(0).ts == 2000)
+
+    {
+      rateLimiter.appendLimitToHistory(50, 2100)
+      val sum = rateLimiter.sumHistoryThenTrim(2500)
+      val expectedInMillis = 40 * (2100 - 2000) +
+                             50 * (2500 - 2100)
+      val expected = expectedInMillis / 1000
+      assert(sum == expected)
+    }
+
+    assert(rateLimiter.rateLimitHistory.length == 1)
+    assert(rateLimiter.rateLimitHistory(0).limit == 50)
+    assert(rateLimiter.rateLimitHistory(0).ts == 2500)
+  }
+
 }

--- a/streaming/src/test/scala/org/apache/spark/streaming/receiver/RateLimiterSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/receiver/RateLimiterSuite.scala
@@ -17,30 +17,86 @@
 
 package org.apache.spark.streaming.receiver
 
-import org.apache.spark.SparkConf
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.util.SystemClock
 
 /** Testsuite for testing the network receiver behavior */
 class RateLimiterSuite extends SparkFunSuite {
 
   test("rate limiter initializes even without a maxRate set") {
     val conf = new SparkConf()
-    val rateLimiter = new RateLimiter(conf) {}
+    val rateLimiter = new RateLimiter(conf, new SystemClock) {}
     rateLimiter.updateRate(105)
     assert(rateLimiter.getCurrentLimit == 105)
   }
 
   test("rate limiter updates when below maxRate") {
     val conf = new SparkConf().set("spark.streaming.receiver.maxRate", "110")
-    val rateLimiter = new RateLimiter(conf) {}
+    val rateLimiter = new RateLimiter(conf, new SystemClock) {}
     rateLimiter.updateRate(105)
     assert(rateLimiter.getCurrentLimit == 105)
   }
 
   test("rate limiter stays below maxRate despite large updates") {
     val conf = new SparkConf().set("spark.streaming.receiver.maxRate", "100")
-    val rateLimiter = new RateLimiter(conf) {}
+    val rateLimiter = new RateLimiter(conf, new SystemClock) {}
     rateLimiter.updateRate(105)
     assert(rateLimiter.getCurrentLimit === 100)
   }
+
+  test("historySumThenTrim() returns expected numRecordsLimit") {
+    val conf = new SparkConf().set("spark.streaming.receiver.maxRate", "100")
+                              .set("spark.streaming.blockInterval", "500ms")
+    val rateLimiter = new RateLimiter(conf, new SystemClock) {}
+
+    // Make sure that rateLimitHistory starts with a special initial snapshot
+    assert(rateLimiter.rateLimitHistory(0).limit == 100)
+    assert(rateLimiter.rateLimitHistory(0).ts == -1)
+
+    // Test if sumHistoryThenTrim() works well with the first batch which
+    // contains a special initial snapshot
+    {
+      rateLimiter.appendLimitToHistory(10, 1100)
+      rateLimiter.appendLimitToHistory(20, 1200)
+      rateLimiter.appendLimitToHistory(30, 1300)
+      rateLimiter.appendLimitToHistory(40, 1400)
+      val sum = rateLimiter.sumHistoryThenTrim(1500)
+      val expectedInMillis = 100 * (1100 - (1500 - 500)) +
+                              10 * (1200 - 1100) +
+                              20 * (1300 - 1200) +
+                              30 * (1400 - 1300) +
+                              40 * (1500 - 1400)
+      val expected = expectedInMillis / 1000
+      assert(sum == expected)
+    }
+
+    assert(rateLimiter.rateLimitHistory.length == 1)
+    assert(rateLimiter.rateLimitHistory(0).limit == 40)
+    assert(rateLimiter.rateLimitHistory(0).ts == 1500)
+
+    {
+      val sum = rateLimiter.sumHistoryThenTrim(2000)
+      val expectedInMillis = 40 * (2000 - 1500)
+      val expected = expectedInMillis / 1000
+      assert(sum == expected)
+    }
+
+    assert(rateLimiter.rateLimitHistory.length == 1)
+    assert(rateLimiter.rateLimitHistory(0).limit == 40)
+    assert(rateLimiter.rateLimitHistory(0).ts == 2000)
+
+    {
+      rateLimiter.appendLimitToHistory(50, 2100)
+      val sum = rateLimiter.sumHistoryThenTrim(2500)
+      val expectedInMillis = 40 * (2100 - 2000) +
+                             50 * (2500 - 2100)
+      val expected = expectedInMillis / 1000
+      assert(sum == expected)
+    }
+
+    assert(rateLimiter.rateLimitHistory.length == 1)
+    assert(rateLimiter.rateLimitHistory(0).limit == 50)
+    assert(rateLimiter.rateLimitHistory(0).ts == 2500)
+  }
+
 }

--- a/streaming/src/test/scala/org/apache/spark/streaming/scheduler/ReceiverTrackerSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/scheduler/ReceiverTrackerSuite.scala
@@ -128,7 +128,9 @@ private[streaming] class RateTestReceiver(receiverId: Int, host: Option[String] 
 
   private lazy val customBlockGenerator = supervisor.createBlockGenerator(
     new BlockGeneratorListener {
-      override def onPushBlock(blockId: StreamBlockId, arrayBuffer: ArrayBuffer[_]): Unit = {}
+      override def onPushBlock(blockId: StreamBlockId,
+                               arrayBuffer: ArrayBuffer[_],
+                               numRecordsLimit: Long): Unit = {}
       override def onError(message: String, throwable: Throwable): Unit = {}
       override def onGenerateBlock(blockId: StreamBlockId): Unit = {}
       override def onAddData(data: Any, metadata: Any): Unit = {}

--- a/streaming/src/test/scala/org/apache/spark/streaming/ui/StreamingJobProgressListenerSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/ui/StreamingJobProgressListenerSuite.scala
@@ -60,7 +60,7 @@ class StreamingJobProgressListenerSuite extends TestSuiteBase with Matchers {
 
     val streamIdToInputInfo = Map(
       0 -> StreamInputInfo(0, 300L),
-      1 -> StreamInputInfo(1, 300L, Map(StreamInputInfo.METADATA_KEY_DESCRIPTION -> "test")))
+      1 -> StreamInputInfo(1, 300L, None, Map(StreamInputInfo.METADATA_KEY_DESCRIPTION -> "test")))
 
     // onBatchSubmitted
     val batchInfoSubmitted = BatchInfo(Time(1000), streamIdToInputInfo, 1000, None, None, Map.empty)
@@ -108,7 +108,7 @@ class StreamingJobProgressListenerSuite extends TestSuiteBase with Matchers {
     batchUIData.get.totalDelay should be (batchInfoStarted.totalDelay)
     batchUIData.get.streamIdToInputInfo should be (Map(
       0 -> StreamInputInfo(0, 300L),
-      1 -> StreamInputInfo(1, 300L, Map(StreamInputInfo.METADATA_KEY_DESCRIPTION -> "test"))))
+      1 -> StreamInputInfo(1, 300L, None, Map(StreamInputInfo.METADATA_KEY_DESCRIPTION -> "test"))))
     batchUIData.get.numRecords should be(600)
     batchUIData.get.outputOpIdSparkJobIdPairs should be
       Seq(OutputOpIdAndSparkJobId(0, 0),

--- a/streaming/src/test/scala/org/apache/spark/streaming/util/WriteAheadLogSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/util/WriteAheadLogSuite.scala
@@ -453,7 +453,7 @@ class BatchedWriteAheadLogSuite extends CommonWriteAheadLogTests(
 
   test("BatchedWriteAheadLog - serializing and deserializing batched records") {
     val events = Seq(
-      BlockAdditionEvent(ReceivedBlockInfo(0, None, None, null)),
+      BlockAdditionEvent(ReceivedBlockInfo(0, None, None, None, null)),
       BatchAllocationEvent(null, null),
       BatchCleanupEvent(Nil)
     )


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR makes Streaming web UI display rate-limit lines in the statistics graph.

Design doc: https://docs.google.com/document/d/1kGXQEcToNglDK-AbyEJGoYX9wwODimUVf0PetoxuU5M/edit#

Part 3 (this PR):
- makes changes in `StreamingJobProgressListener` and related places, so that the aggregated `numRecordsLimit` information for every batch can be calculated;
- makes changes in `StreamingPage` and related places, so two or more lines can be drawn on a single statistics graph.

Part 1: [PR #11470](https://github.com/apache/spark/pull/11470)
Part 2: [PR #11633](https://github.com/apache/spark/pull/11633)
## Screenshots
### without back pressure

![](https://cloud.githubusercontent.com/assets/15843379/13664195/d2264c48-e6e0-11e5-85e6-f13187d4cbde.png)
### with back pressure

![](https://cloud.githubusercontent.com/assets/15843379/13664196/d2549c7e-e6e0-11e5-9f62-d7f1458f1c27.png)
