### PR TITLE
[SPARK-13811][SPARK-13836] [SQL] Removed IsNotNull Constraints of Compound Expressions And Generated IsNotNull Constraints inside Not

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -606,11 +606,12 @@ object NullPropagation extends Rule[LogicalPlan] {
 object NullFiltering extends Rule[LogicalPlan] with PredicateHelper {
   def apply(plan: LogicalPlan): LogicalPlan = plan transform {
     case filter @ Filter(condition, child) =>
-      // We generate a list of additional isNotNull filters from the operator's existing constraints
-      // but remove those that are either already part of the filter condition or are part of the
-      // operator's child constraints.
-      val newIsNotNullConstraints = filter.constraints.filter(_.isInstanceOf[IsNotNull]) --
-        (child.constraints ++ splitConjunctivePredicates(condition))
+      // We generate a list of additional isNotNull filters from the operator's existing
+      // non-compound constraints but remove those that are either already part of the filter
+      // condition or are part of the operator's child constraints.
+      val newIsNotNullConstraints =
+        filter.constraints.filter(isNullFilteringForNonCompoundExpr) --
+          (child.constraints ++ splitConjunctivePredicates(condition))
       if (newIsNotNullConstraints.nonEmpty) {
         Filter(And(newIsNotNullConstraints.reduce(And), condition), child)
       } else {
@@ -619,11 +620,11 @@ object NullFiltering extends Rule[LogicalPlan] with PredicateHelper {
 
     case join @ Join(left, right, joinType, condition) =>
       val leftIsNotNullConstraints = join.constraints
-        .filter(_.isInstanceOf[IsNotNull])
+        .filter(isNullFilteringForNonCompoundExpr)
         .filter(_.references.subsetOf(left.outputSet)) -- left.constraints
       val rightIsNotNullConstraints =
         join.constraints
-          .filter(_.isInstanceOf[IsNotNull])
+          .filter(isNullFilteringForNonCompoundExpr)
           .filter(_.references.subsetOf(right.outputSet)) -- right.constraints
       val newLeftChild = if (leftIsNotNullConstraints.nonEmpty) {
         Filter(leftIsNotNullConstraints.reduce(And), left)
@@ -640,6 +641,12 @@ object NullFiltering extends Rule[LogicalPlan] with PredicateHelper {
       } else {
         join
       }
+  }
+  private def isNullFilteringForNonCompoundExpr(exp: Expression): Boolean = {
+    exp match {
+      case c: IsNotNull if c.child.isInstanceOf[AttributeReference] => true
+      case _ => false
+    }
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -613,7 +613,6 @@ object NullFiltering extends Rule[LogicalPlan] with PredicateHelper {
       // operator's child constraints.
       val newIsNotNullConstraints = filter.constraints.filter(_.isInstanceOf[IsNotNull]) --
         (child.constraints ++ splitConjunctivePredicates(condition))
-
       if (newIsNotNullConstraints.nonEmpty) {
         Filter(And(newIsNotNullConstraints.reduce(And), condition), child)
       } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -46,6 +46,8 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]] extends TreeNode[PlanT
   private def constructIsNotNullConstraints(constraints: Set[Expression]): Set[Expression] = {
     // Currently we only propagate constraints if the condition consists of equality
     // and ranges. For all other cases, we return an empty set of constraints
+    // Note: Almost all the subclasses of BinaryComparison (EqualTo, LessThan, LessThanOrEqual,
+    // GreaterThan and GreaterThanOrEqual) are NULL intolerant. The only exception is EqualNullSafe
     var isNotNullConstraints = Set.empty[Expression]
     constraints.collect {
       case b @ BinaryComparison(l, r) if !b.isInstanceOf[EqualNullSafe] =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -46,22 +46,16 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]] extends TreeNode[PlanT
   private def constructIsNotNullConstraints(constraints: Set[Expression]): Set[Expression] = {
     // Currently we only propagate constraints if the condition consists of equality
     // and ranges. For all other cases, we return an empty set of constraints
-    constraints.map {
-      case EqualTo(l, r) =>
-        Set(IsNotNull(l), IsNotNull(r))
-      case GreaterThan(l, r) =>
-        Set(IsNotNull(l), IsNotNull(r))
-      case GreaterThanOrEqual(l, r) =>
-        Set(IsNotNull(l), IsNotNull(r))
-      case LessThan(l, r) =>
-        Set(IsNotNull(l), IsNotNull(r))
-      case LessThanOrEqual(l, r) =>
-        Set(IsNotNull(l), IsNotNull(r))
-      case Not(EqualTo(l, r)) =>
-        Set(IsNotNull(l), IsNotNull(r))
-      case _ =>
-        Set.empty[Expression]
-    }.foldLeft(Set.empty[Expression])(_ union _.toSet)
+    var isNotNullConstraints = Set.empty[Expression]
+    constraints.collect {
+      case b @ BinaryComparison(l, r) if !b.isInstanceOf[EqualNullSafe] =>
+        if (l.isInstanceOf[AttributeReference]) isNotNullConstraints += IsNotNull(l)
+        if (r.isInstanceOf[AttributeReference]) isNotNullConstraints += IsNotNull(r)
+      case Not(b @ BinaryComparison(l, r)) if !b.isInstanceOf[EqualNullSafe] =>
+        if (l.isInstanceOf[AttributeReference]) isNotNullConstraints += IsNotNull(l)
+        if (r.isInstanceOf[AttributeReference]) isNotNullConstraints += IsNotNull(r)
+    }
+    isNotNullConstraints
   }
 
   /**

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/ConstraintPropagationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/ConstraintPropagationSuite.scala
@@ -217,4 +217,19 @@ class ConstraintPropagationSuite extends SparkFunSuite {
         IsNotNull(resolveColumn(tr, "a")),
         IsNotNull(resolveColumn(tr, "b")))))
   }
+
+  test("IsNotNull constraints of compound expressions in filters") {
+    val tr = LocalRelation('a.int, 'b.string, 'c.int)
+    verifyConstraints(tr
+      .where('a.attr + 'c.attr > 10).analyze.constraints,
+      ExpressionSet(Seq(resolveColumn(tr, "a") + resolveColumn(tr, "c") > 10)))
+  }
+
+  test("IsNotNull constraints of BinaryComparison in Not in filters") {
+    val tr = LocalRelation('a.int, 'b.string, 'c.int)
+    verifyConstraints(tr
+      .where(!('a.attr < 10)).analyze.constraints,
+      ExpressionSet(Seq(IsNotNull(resolveColumn(tr, "a")),
+        Not(resolveColumn(tr, "a") < 10))))
+  }
 }


### PR DESCRIPTION
#### What changes were proposed in this pull request?

We generate `IsNotNull` constraint for compound expressions. However, we should not add extra predicate conditions for these compound expressions. It will add extra costs for query processing. Normally, it will not filter out any row but requires extra processing. 

For example, 

``` SQL
testRelation.where('a + 'b === 1)
```

Without this PR, the plan will be like 

```
Filter (((a#0 + b#0) = 1) && isnotnull((a#0 + b#0)))
 +- LocalRelation [a#0,b#0,c#0]
```

After the PR, constraints-generated null filtering of compound expressions will not be added.

```
Filter ((a#0 + b#0) = 1))
 +- LocalRelation [a#0,b#0,c#0]
```

The solution is to remove the `IsNotNull` constraints for compound expressions. 

In addition, this PR can generate `IsNotNull` constraints for all the `BinaryComparison` inside `Not` except `EqualNullSafe`.

cc @sameeragarwal @nongli @marmbrus 
#### How was this patch tested?

Added a test case for Filter and another case for Join
