### PR TITLE
[SPARK-13834] Update sbt for 2.x.

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-sbt.version=0.13.9
+sbt.version=0.13.11


### PR DESCRIPTION
## What changes were proposed in this pull request?

For 2.0.0, we had better bump `sbt`, too. SBT 0.13.11 fixes wrong warnings and improve incremental compilation.

```
-sbt.version=0.13.9
+sbt.version=0.13.11
```

**REFERENCE**
https://github.com/sbt/sbt/releases/tag/v0.13.11
## How was this patch tested?

Pass the existing build and test.
