### PR TITLE
[minor][build][test-maven] Remove invocation of dependency plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2082,23 +2082,6 @@
           <artifactId>maven-deploy-plugin</artifactId>
           <version>2.8.2</version>
         </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-dependency-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>default-cli</id>
-              <goals>
-                 <goal>build-classpath</goal>
-              </goals>
-              <configuration>
-                <!-- This includes dependencies with 'runtime' and 'compile' scopes;
-                     see the docs for includeScope for more details -->
-                <includeScope>runtime</includeScope>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
         <!-- This plugin's configuration is used to store Eclipse m2e settings only. -->
         <!-- It has no influence on the Maven build itself. -->
         <plugin>


### PR DESCRIPTION
This avoids noisy output in maven builds, where the classpath of
each module would be printed to the terminal.

This was introduced in SPARK-10359 but seems to be just for debugging,
not for any needed functionality.
