### PR TITLE
[minor][build][test-maven] Remove invocation of dependency plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2087,7 +2087,6 @@
           <artifactId>maven-dependency-plugin</artifactId>
           <executions>
             <execution>
-              <id>default-cli</id>
               <goals>
                  <goal>build-classpath</goal>
               </goals>


### PR DESCRIPTION
Removing the execution id prevents the goal from running unless
it's explicitly invoked from the command line.
