### PR TITLE
[SPARK-13853][SQL] QueryPlan sub-classes should override producedAttributes to fix missingInput

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -110,7 +110,7 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]] extends TreeNode[PlanT
    * All Attributes that appear in expressions from this operator.  Note that this set does not
    * include attributes that are implicitly referenced by being passed through to the output tuple.
    */
-  def references: AttributeSet = AttributeSet(expressions.flatMap(_.references))
+  final def references: AttributeSet = AttributeSet(expressions.flatMap(_.references))
 
   /**
    * The set of all attributes that are input to this operator by its children.
@@ -128,7 +128,7 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]] extends TreeNode[PlanT
    * Subclasses should override this method if they produce attributes internally as it is used by
    * assertions designed to prevent the construction of invalid plans.
    */
-  def missingInput: AttributeSet = references -- inputSet -- producedAttributes
+  final def missingInput: AttributeSet = references -- inputSet -- producedAttributes
 
   /**
    * Runs [[transform]] with `rule` on all expressions present in this query operator.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ScriptTransformation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ScriptTransformation.scala
@@ -33,7 +33,7 @@ case class ScriptTransformation(
     output: Seq[Attribute],
     child: LogicalPlan,
     ioschema: ScriptInputOutputSchema) extends UnaryNode {
-  override def references: AttributeSet = AttributeSet(input.flatMap(_.references))
+  override def producedAttributes: AttributeSet = AttributeSet(output)
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicOperators.scala
@@ -519,8 +519,7 @@ case class Expand(
     output: Seq[Attribute],
     child: LogicalPlan) extends UnaryNode {
 
-  override def references: AttributeSet =
-    AttributeSet(projections.flatten.flatMap(_.references))
+  override def producedAttributes: AttributeSet = AttributeSet(output)
 
   override def statistics: Statistics = {
     val sizeInBytes = super.statistics.sizeInBytes * projections.length

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/Expand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/Expand.scala
@@ -46,8 +46,7 @@ case class Expand(
   // as UNKNOWN partitioning
   override def outputPartitioning: Partitioning = UnknownPartitioning(0)
 
-  override def references: AttributeSet =
-    AttributeSet(projections.flatten.flatMap(_.references))
+  override def producedAttributes: AttributeSet = AttributeSet(output)
 
   private[this] val projection =
     (exprs: Seq[Expression]) => UnsafeProjection.create(exprs, child.output)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/EvaluatePython.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/EvaluatePython.scala
@@ -45,8 +45,7 @@ case class EvaluatePython(
 
   def output: Seq[Attribute] = child.output :+ resultAttribute
 
-  // References should not include the produced attribute.
-  override def references: AttributeSet = udf.references
+  override def producedAttributes: AttributeSet = AttributeSet(resultAttribute)
 }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some operators will produce new attributes as output(e.g. most leaf nodes and Generate), and we should exclude them when calculating missing input. Nowadays subclasses can override `producedAttributes` to fix this issue, which is the recommended way. However, they can also override `reference` or `missingInput`, we should stop doing this and mark these 2 methods as `final` to force subclasses to override `producedAttributes` only.

Except `producedAttributes`, sub-classes can also produce new attributes by `Alias`. This approach is better but can't fit in all situations, e.g. `Generate`, `Expand`, `ScriptTransform`, etc. These operators have nothing to alias and behave like a leaf node. But `EvaluatePython` operator can produce new attribute by alias, so this PR also changes `EveluatePython` to use the alias approach.
## How was this patch tested?

existing tests.
