### PR TITLE
[SPARK-13838][SQL] Clear variable code to prevent it to be re-evaluated in BoundAttribute

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/BoundAttribute.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/BoundAttribute.scala
@@ -65,7 +65,9 @@ case class BoundReference(ordinal: Int, dataType: DataType, nullable: Boolean)
       val oev = ctx.currentVars(ordinal)
       ev.isNull = oev.isNull
       ev.value = oev.value
-      oev.code
+      val code = oev.code
+      oev.code = ""
+      code
     } else if (nullable) {
       s"""
         boolean ${ev.isNull} = ${ctx.INPUT_ROW}.isNullAt($ordinal);


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-13838
## What changes were proposed in this pull request?

We should also clear the variable code in `BoundReference.genCode` to prevent it  to be evaluated twice, as we did in `evaluateVariables`.
## How was this patch tested?

Existing tests.
