### PR TITLE
[SPARK-13839][SQL] Defer input evaluation and fix Cast issue in IsNotNull filtering for Filter codegen

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -202,3 +202,21 @@ object Unions {
     }
   }
 }
+
+/**
+ * A pattern that finds the original expression from a sequence of casts.
+ */
+object Casts {
+  def unapply(expr: Expression): Option[Expression] = expr match {
+    case c: Cast => Some(collectCasts(expr))
+    case _ => None
+  }
+
+  private def collectCasts(e: Expression): Expression = {
+    if (e.isInstanceOf[Cast]) {
+      collectCasts(e.children(0))
+    } else {
+      e
+    }
+  }
+}


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-13839
## What changes were proposed in this pull request?

This PR improves Filter codegen by:
1. After #11585, we filter out the rows early if it have null value. So we can only evaluate the inputs used in these filtering before this plan. The evaluation of other inputs can be deferred after the filtering done.
2. Currently we check `IsNotNull(a)` to find the attributes needed to filter out null values. However, the expression `IsNotNull(Cast(a, dt))` will not be checked by this. We should add pattern to find this.
## How was this patch tested?

Existing tests.
