### PR TITLE
[SPARK-13847][SQL] Defer the variable evaluation for Limit codegen

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
@@ -65,6 +65,8 @@ trait BaseLimit extends UnaryNode with CodegenSupport {
     child.asInstanceOf[CodegenSupport].produce(ctx, this)
   }
 
+  override def usedInputs: AttributeSet = AttributeSet.empty
+
   override def doConsume(ctx: CodegenContext, input: Seq[ExprCode], row: String): String = {
     val stopEarly = ctx.freshName("stopEarly")
     ctx.addMutableState("boolean", stopEarly, s"$stopEarly = false;")


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-13847
## What changes were proposed in this pull request?

We can defer the variable evaluation for Limit codegen as we did in Project.
## How was this patch tested?

Existing tests.
