### PR TITLE
SPARK-13335 Use declarative aggregate for collect_list

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/CollectList.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/CollectList.scala
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions.aggregate
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.catalyst.expressions.{Cast, Literal, AttributeReference, Expression}
+import org.apache.spark.sql.catalyst.util.{GenericArrayData, ArrayData, TypeUtils}
+import org.apache.spark.sql.types.{AbstractDataType, AnyDataType, DataType, DataTypes, NullType}
+
+case class CollectList(child: Expression) extends DeclarativeAggregate {
+
+  override def children: scala.Seq[Expression] = child :: Nil
+
+  override def nullable: Boolean = false
+
+  override def dataType: DataType = DataTypes.createArrayType(child.dataType)
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(AnyDataType)
+
+  // Don't do partial aggregation for CollectList, similarly to RDD.groupBy().
+  override def supportsPartial: Boolean = false
+
+  private lazy val list = AttributeReference("list", DataTypes.createArrayType(child.dataType))()
+
+  override lazy val aggBufferAttributes = list :: Nil
+
+  override lazy val initialValues = Seq(Literal.default(DataTypes.createArrayType(child.dataType)))
+
+  override lazy val updateExpressions = Seq(UpdateList(Seq(list, child)))
+
+  override lazy val mergeExpressions = Seq(MergeList(Seq(list.left, list.right)))
+
+  override lazy val evaluateExpression = Cast(list, dataType)
+
+  override def defaultResult: Option[Literal] = Option(Literal(Array()))
+
+}
+
+// TODO proper code generation for this
+private[sql] case class MergeList(children: Seq[Expression]) extends Expression with CodegenFallback {
+
+  override def nullable: Boolean = children.forall(_.nullable)
+  override def foldable: Boolean = children.forall(_.foldable)
+
+  override def checkInputDataTypes(): TypeCheckResult = {
+    if (children.length != 2) {
+      TypeCheckResult.TypeCheckFailure(s"MERGELIST requires 2 arguments")
+    } else if (children.map(_.dataType).distinct.count(_ != NullType) > 1) {
+      TypeCheckResult.TypeCheckFailure(
+        s"The expressions should all have the same type," +
+          s" got MERGELIST (${children.map(_.dataType)}).")
+    } else {
+      TypeUtils.checkForOrderingExpr(dataType, "function " + prettyName)
+    }
+  }
+
+  override def dataType: DataType = children.head.dataType
+
+  override def eval(input: InternalRow): Any = {
+    val left = children(0).eval(input).asInstanceOf[ArrayData];
+    val right = children(1).eval(input).asInstanceOf[ArrayData];
+
+    new GenericArrayData(left.array ++ right.array)
+  }
+}
+
+// TODO proper code generation for this
+private[sql] case class UpdateList(children: Seq[Expression]) extends Expression with CodegenFallback {
+
+  override def nullable: Boolean = children.forall(_.nullable)
+  override def foldable: Boolean = children.forall(_.foldable)
+
+  override def checkInputDataTypes(): TypeCheckResult = {
+    if (children.length != 2) {
+      TypeCheckResult.TypeCheckFailure(s"UPDATELIST requires 2 arguments")
+    } else {
+      TypeUtils.checkForOrderingExpr(dataType, "function " + prettyName)
+    }
+  }
+
+  override def dataType: DataType = children.head.dataType
+
+  override def eval(input: InternalRow): Any = {
+    val left = children(0).eval(input).asInstanceOf[ArrayData];
+    val right = children(1).eval(input);
+
+    new GenericArrayData(left.array :+ right)
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/CollectList.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/CollectList.scala
@@ -19,9 +19,9 @@ package org.apache.spark.sql.catalyst.expressions.aggregate
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Cast, Expression, Literal}
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
-import org.apache.spark.sql.catalyst.expressions.{Cast, Literal, AttributeReference, Expression}
-import org.apache.spark.sql.catalyst.util.{GenericArrayData, ArrayData, TypeUtils}
+import org.apache.spark.sql.catalyst.util.{ArrayData, GenericArrayData, TypeUtils}
 import org.apache.spark.sql.types.{AbstractDataType, AnyDataType, DataType, DataTypes, NullType}
 
 case class CollectList(child: Expression) extends DeclarativeAggregate {
@@ -54,7 +54,8 @@ case class CollectList(child: Expression) extends DeclarativeAggregate {
 }
 
 // TODO proper code generation for this
-private[sql] case class MergeList(children: Seq[Expression]) extends Expression with CodegenFallback {
+private[sql] case class MergeList(children: Seq[Expression])
+    extends Expression with CodegenFallback {
 
   override def nullable: Boolean = children.forall(_.nullable)
   override def foldable: Boolean = children.forall(_.foldable)
@@ -82,7 +83,8 @@ private[sql] case class MergeList(children: Seq[Expression]) extends Expression 
 }
 
 // TODO proper code generation for this
-private[sql] case class UpdateList(children: Seq[Expression]) extends Expression with CodegenFallback {
+private[sql] case class UpdateList(children: Seq[Expression])
+    extends Expression with CodegenFallback {
 
   override def nullable: Boolean = children.forall(_.nullable)
   override def foldable: Boolean = children.forall(_.foldable)

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -214,7 +214,7 @@ object functions extends LegacyFunctions {
    * @group agg_funcs
    * @since 1.6.0
    */
-  def collect_list(e: Column): Column = callUDF("collect_list", e)
+  def collect_list(e: Column): Column = withAggregateFunction { CollectList(e.expr) }
 
   /**
    * Aggregate function: returns a list of objects with duplicates.

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -406,4 +406,33 @@ class DataFrameAggregateSuite extends QueryTest with SharedSQLContext {
         expr("kurtosis(a)")),
       Row(null, null, null, null, null))
   }
+
+  test("collect list") {
+    checkAnswer(
+      testData2.groupBy("a").agg(collect_list("b")),
+      Seq(
+        Row(1, Seq(1, 2)),
+        Row(2, Seq(1, 2)),
+        Row(3, Seq(1, 2))
+      )
+    )
+
+    val testDataWithVariedGroups = Seq(
+      ("group1", "b", "c"),
+      ("group1", "c", "d"),
+      ("group2", "m", "n"),
+      ("group1", "p", "e"),
+      ("group3", "x", "y"),
+      ("group2", "e", null.asInstanceOf[String])
+    ).toDF("group", "other", "toList")
+
+    checkAnswer(
+      testDataWithVariedGroups.groupBy("group").agg(collect_list("toList")),
+      Seq(
+        Row("group1", Seq("c", "d", "e")),
+        Row("group2", Seq("n", null.asInstanceOf[String])),
+        Row("group3", Seq("y"))
+      )
+    )
+  }
 }


### PR DESCRIPTION
The current implementation of collect_list uses the Hive UDAF, which is ill-performant especially considering the need for ImperativeAggregate to convert between Catalyst types and Scala types.

In the case of collect_list, we can bypass converting the elements of the groups and just combine the encompassing arrays.

I added a new unit test in DataFrameAggregateSuite to exercise this code path. I don't have a formal comparison between the Hive UDAF and this, unfortunately - I did write an imperative aggregate implementation of collect_list and found the declarative variant to be significantly faster. More specific numbers should be recorded here when we get the chance.

Some things to think about:
- Code generation for the expressions - I'm not too familiar with writing code generation pieces, so it would be good to fill this in.
- I wonder if we can do better for the memory allocation in the expressions. Right now every updateList() call calls Array.:+ which isn't the most efficient.
