### PR TITLE
[SPARK-13642][Yarn][1.6-backport] Properly handle signal kill in ApplicationMaster

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -127,7 +127,7 @@ private[spark] class ApplicationMaster(
     val signalHandler = new SignalHandler() {
       override def handle(sig: Signal): Unit = {
 
-        logInfo(s"received signal: ${sig.getName}")
+        logInfo(s"RECEIVED SIGNAL ${sig.getNumber}: SIG${sig.getName}")
         finish(FinalApplicationStatus.FAILED, ApplicationMaster.EXIT_SIGNAL)
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch is fixing the race condition in ApplicationMaster when receiving a signal. In the current implementation, if signal is received and with no any exception, this application will be finished with successful state in Yarn, and there's no another attempt. Actually the application is killed by signal in the runtime, so another attempt is expected.

This patch adds a signal handler to handle the signal things, if signal is received, marking this application finished with failure, rather than success.
## How was this patch tested?

This patch is tested with following situations:

Application is finished normally.
Application is finished by calling System.exit(n).
Application is killed by yarn command.
ApplicationMaster is killed by "SIGTERM" send by kill pid command.
ApplicationMaster is killed by NM with "SIGTERM" in case of NM failure.
