### PR TITLE
[SPARK-13854][SQL] Add constraints to outer join

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicOperators.scala
@@ -280,24 +280,24 @@ case class Join(
         left.constraints
       case LeftOuter =>
         // For left outer join, the constraints of right side are effective if the referred
-        // outputs in right side are not null.
+        // outputs in right side are not null. Otherwise, the referred outputs are all nulls.
         val rightConstraints = right.constraints.map { constraint =>
           val relatedOuputs = constraint.references.filter(right.outputSet.contains)
-          val notNulls = relatedOuputs.map { o =>
-            IsNotNull(o)
+          val isNulls = relatedOuputs.map { o =>
+            IsNull(o)
           }.reduce(And)
-          And(notNulls, constraint)
+          Or(notNulls, constraint)
         }
         left.constraints.union(ExpressionSet(rightConstraints))
       case RightOuter =>
         // For right outer join, the constraints of left side are effective if the referred
-        // outputs in left side are not null.
+        // outputs in left side are not null. Otherwise, the referred outputs are all nulls.
         val leftConstraints = left.constraints.map { constraint =>
           val relatedOuputs = constraint.references.filter(left.outputSet.contains)
-          val notNulls = relatedOuputs.map { o =>
-            IsNotNull(o)
+          val isNulls = relatedOuputs.map { o =>
+            IsNull(o)
           }.reduce(And)
-          And(notNulls, constraint)
+          Or(notNulls, constraint)
         }
         right.constraints.union(ExpressionSet(leftConstraints))
       case FullOuter =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/ConstraintPropagationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/ConstraintPropagationSuite.scala
@@ -183,7 +183,9 @@ class ConstraintPropagationSuite extends SparkFunSuite {
       .join(tr2.where('d.attr < 100), LeftOuter, Some("tr1.a".attr === "tr2.a".attr))
       .analyze.constraints,
       ExpressionSet(Seq(tr1.resolveQuoted("a", caseInsensitiveResolution).get > 10,
-        IsNotNull(tr1.resolveQuoted("a", caseInsensitiveResolution).get))))
+        IsNotNull(tr1.resolveQuoted("a", caseInsensitiveResolution).get),
+        Or(IsNull(tr2.resolveQuoted("d", caseInsensitiveResolution).get),
+          tr2.resolveQuoted("d", caseInsensitiveResolution).get < 100))))
   }
 
   test("propagating constraints in right-outer join") {
@@ -194,15 +196,22 @@ class ConstraintPropagationSuite extends SparkFunSuite {
       .join(tr2.where('d.attr < 100), RightOuter, Some("tr1.a".attr === "tr2.a".attr))
       .analyze.constraints,
       ExpressionSet(Seq(tr2.resolveQuoted("d", caseInsensitiveResolution).get < 100,
-        IsNotNull(tr2.resolveQuoted("d", caseInsensitiveResolution).get))))
+        IsNotNull(tr2.resolveQuoted("d", caseInsensitiveResolution).get),
+        Or(IsNull(tr1.resolveQuoted("a", caseInsensitiveResolution).get),
+          tr1.resolveQuoted("a", caseInsensitiveResolution).get > 10))))
   }
 
   test("propagating constraints in full-outer join") {
     val tr1 = LocalRelation('a.int, 'b.int, 'c.int).subquery('tr1)
     val tr2 = LocalRelation('a.int, 'd.int, 'e.int).subquery('tr2)
-    assert(tr1.where('a.attr > 10)
+    verifyConstraints(tr1.where('a.attr > 10)
       .join(tr2.where('d.attr < 100), FullOuter, Some("tr1.a".attr === "tr2.a".attr))
-      .analyze.constraints.isEmpty)
+      .analyze.constraints,
+      ExpressionSet(Seq(
+        Or(IsNull(tr1.resolveQuoted("a", caseInsensitiveResolution).get),
+          tr1.resolveQuoted("a",caseInsensitiveResolution).get > 10),
+        Or(IsNull(tr2.resolveQuoted("d", caseInsensitiveResolution).get),
+          tr2.resolveQuoted("d", caseInsensitiveResolution).get < 100))))
   }
 
   test("infer additional constraints in filters") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/ConstraintPropagationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/ConstraintPropagationSuite.scala
@@ -209,7 +209,7 @@ class ConstraintPropagationSuite extends SparkFunSuite {
       .analyze.constraints,
       ExpressionSet(Seq(
         Or(IsNull(tr1.resolveQuoted("a", caseInsensitiveResolution).get),
-          tr1.resolveQuoted("a",caseInsensitiveResolution).get > 10),
+          tr1.resolveQuoted("a", caseInsensitiveResolution).get > 10),
         Or(IsNull(tr2.resolveQuoted("d", caseInsensitiveResolution).get),
           tr2.resolveQuoted("d", caseInsensitiveResolution).get < 100))))
   }


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-13854
## What changes were proposed in this pull request?

Currently, for left outer join we only keep left side constraint. For right outer join, we only keep right side constraints. For full outer join, the constraints are empty.

In fact, the constraints are less than the actual constraints for the join operator.

For example, for left outer join, besides the constraints from left side, the constraints of right side should be inherited with a bit modification.

Consider a join as following:

```
val tr1 = LocalRelation('a.int, 'b.int, 'c.int).subquery('tr1)
val tr2 = LocalRelation('a.int, 'd.int, 'e.int).subquery('tr2)

tr1.where('a.attr > 10)
  .join(tr2.where('d.attr < 100), LeftOuter, Some("tr1.a".attr === "tr2.a".attr))
```

The constraints are not only "a" > 10, "a" is not null. It should also include ("d" is null || "d" < 100).
## How was this patch tested?

Three tests in `ConstraintPropagationSuite` are modified for this PR.
