### PR TITLE
[SPARK-13852][YARN]handle the InterruptedException caused by YARN HA switch

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -976,6 +976,11 @@ private[spark] class Client(
             logError(s"Application $appId not found.")
             return (YarnApplicationState.KILLED, FinalApplicationStatus.KILLED)
           case NonFatal(e) =>
+            if (e.isInstanceOf[InterruptedException]
+              || e.getCause.isInstanceOf[InterruptedException]) {
+              logInfo("The reporter thread is interrupted, we assume app is finished.")
+              return (YarnApplicationState.FINISHED, FinalApplicationStatus.SUCCEEDED)
+            }
             logError(s"Failed to contact YARN for application $appId.", e)
             return (YarnApplicationState.FAILED, FinalApplicationStatus.FAILED)
         }


### PR DESCRIPTION
when sc stops, it will interrupt thread using to monitor app status.
the thread will throw an InterruptedException if YARN is switch as there is a sleep method in retry logic.
If YARN is switch between active and standby, sc.stop will return YarnApplicationState.FAILED as the InterruptedException is not caught.
