### PR TITLE
[SPARK-13642][Yarn] Changed the default application exit state to failed for yarn cluster mode

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -152,13 +152,14 @@ private[spark] class ApplicationMaster(
         val isLastAttempt = client.getAttemptId().getAttemptId() >= maxAppAttempts
 
         if (!finished) {
-          // This happens when the user application calls System.exit(). We have the choice
-          // of either failing or succeeding at this point. We report success to avoid
-          // retrying applications that have succeeded (System.exit(0)), which means that
-          // applications that explicitly exit with a non-zero status will also show up as
-          // succeeded in the RM UI.
+          // The default state of ApplicationMaster is failed if it is invoked by shut down hook.
+          // This behavior is different compared to 1.x version, we guarantee user will not call
+          // System.exit() at the end of application, so state will be updated before calling
+          // into shutdown hook.
+          // If user application is exited ahead of time by calling System.exit(), here mark
+          // this application as failed with EXIT_EARLY.
           finish(finalStatus,
-            ApplicationMaster.EXIT_SUCCESS,
+            ApplicationMaster.EXIT_EARLY,
             "Shutdown hook called before final status was reported.")
         }
 
@@ -209,7 +210,7 @@ private[spark] class ApplicationMaster(
    */
   final def getDefaultFinalStatus(): FinalApplicationStatus = {
     if (isClusterMode) {
-      FinalApplicationStatus.SUCCEEDED
+      FinalApplicationStatus.FAILED
     } else {
       FinalApplicationStatus.UNDEFINED
     }
@@ -653,6 +654,7 @@ object ApplicationMaster extends Logging {
   private val EXIT_SC_NOT_INITED = 13
   private val EXIT_SECURITY = 14
   private val EXIT_EXCEPTION_USER_CLASS = 15
+  private val EXIT_EARLY = 16
 
   private var master: ApplicationMaster = _
 

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -153,11 +153,10 @@ private[spark] class ApplicationMaster(
 
         if (!finished) {
           // The default state of ApplicationMaster is failed if it is invoked by shut down hook.
-          // This behavior is different compared to 1.x version, we guarantee user will not call
-          // System.exit() at the end of application, so state will be updated before calling
-          // into shutdown hook.
-          // If user application is exited ahead of time by calling System.exit(), here mark
-          // this application as failed with EXIT_EARLY.
+          // This behavior is different compared to 1.x version.
+          // If user application is exited ahead of time by calling System.exit(N), here mark
+          // this application as failed with EXIT_EARLY. For a good shutdown, user shouldn't call
+          // System.exit(0) to terminate the application.
           finish(finalStatus,
             ApplicationMaster.EXIT_EARLY,
             "Shutdown hook called before final status was reported.")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changing the default exit state to `failed` for any application running on yarn cluster mode.
## How was this patch tested?

Unit test is done locally.

CC @tgravescs and @vanzin .
