### PR TITLE
[MINOR][COMMON] Fix copy-paste oversight in variable naming

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/util/JavaUtils.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/JavaUtils.java
@@ -236,11 +236,11 @@ public class JavaUtils {
       }
 
     } catch (NumberFormatException e) {
-      String timeError = "Size must be specified as bytes (b), " +
+      String byteError = "Size must be specified as bytes (b), " +
         "kibibytes (k), mebibytes (m), gibibytes (g), tebibytes (t), or pebibytes(p). " +
         "E.g. 50b, 100k, or 250m.";
 
-      throw new NumberFormatException(timeError + "\n" + e.getMessage());
+      throw new NumberFormatException(byteError + "\n" + e.getMessage());
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

JavaUtils.java has methods to convert time and byte strings for internal use, this change renames a variable used in byteStringAs(), from timeError to byteError.
