### PR TITLE
[SPARK-13808][test-maven] Don't build assembly in dev/run-tests

### DIFF
--- a/bin/spark-class
+++ b/bin/spark-class
@@ -43,13 +43,13 @@ else
   SPARK_JARS_DIR="${SPARK_HOME}/assembly/target/scala-$SPARK_SCALA_VERSION"
 fi
 
-if [ ! -d "$SPARK_JARS_DIR" ]; then
+if [ ! -d "$SPARK_JARS_DIR" ] && [ -z "$SPARK_TESTING" ]; then
   echo "Failed to find Spark jars directory ($SPARK_JARS_DIR)." 1>&2
   echo "You need to build Spark before running this program." 1>&2
   exit 1
+else
+  LAUNCH_CLASSPATH="$SPARK_JARS_DIR/*"
 fi
-
-LAUNCH_CLASSPATH="$SPARK_JARS_DIR/*"
 
 # Add the launcher build dir to the classpath if requested.
 if [ -n "$SPARK_PREPEND_CLASSES" ]; then

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -323,7 +323,7 @@ def get_hadoop_profiles(hadoop_version):
 def build_spark_maven(hadoop_version):
     # Enable all of the profiles for the build:
     build_profiles = get_hadoop_profiles(hadoop_version) + modules.root.build_profile_flags
-    mvn_goals = ["clean", "package", "-DskipTests", "-pl", "!assembly"]
+    mvn_goals = ["clean", "package", "-DskipTests"]
     profiles_and_goals = build_profiles + mvn_goals
 
     print("[info] Building Spark (w/Hive 1.2.1) using Maven with these arguments: ",

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -323,7 +323,7 @@ def get_hadoop_profiles(hadoop_version):
 def build_spark_maven(hadoop_version):
     # Enable all of the profiles for the build:
     build_profiles = get_hadoop_profiles(hadoop_version) + modules.root.build_profile_flags
-    mvn_goals = ["clean", "package", "-DskipTests"]
+    mvn_goals = ["clean", "package", "-DskipTests", "-pl", "!assembly"]
     profiles_and_goals = build_profiles + mvn_goals
 
     print("[info] Building Spark (w/Hive 1.2.1) using Maven with these arguments: ",
@@ -346,16 +346,6 @@ def build_spark_sbt(hadoop_version):
     print("[info] Building Spark (w/Hive 1.2.1) using SBT with these arguments: ",
           " ".join(profiles_and_goals))
 
-    exec_sbt(profiles_and_goals)
-
-
-def build_spark_assembly_sbt(hadoop_version):
-    # Enable all of the profiles for the build:
-    build_profiles = get_hadoop_profiles(hadoop_version) + modules.root.build_profile_flags
-    sbt_goals = ["assembly/assembly"]
-    profiles_and_goals = build_profiles + sbt_goals
-    print("[info] Building Spark assembly (w/Hive 1.2.1) using SBT with these arguments: ",
-          " ".join(profiles_and_goals))
     exec_sbt(profiles_and_goals)
 
 
@@ -574,9 +564,6 @@ def main():
     if build_tool == "sbt":
         # Note: compatibility tests only supported in sbt for now
         detect_binary_inop_with_mima()
-        # Since we did not build assembly/assembly before running dev/mima, we need to
-        # do it here because the tests still rely on it; see SPARK-13294 for details.
-        build_spark_assembly_sbt(hadoop_version)
 
     # run the test suites
     run_scala_tests(build_tool, hadoop_version, test_modules, excluded_tags)

--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -144,7 +144,6 @@ abstract class AbstractCommandBuilder {
     boolean isTesting = "1".equals(getenv("SPARK_TESTING"));
     if (prependClasses || isTesting) {
       String scala = getScalaVersion();
-      // All projects except assemblies:
       List<String> projects = Arrays.asList(
         "common/network-common",
         "common/network-shuffle",
@@ -154,16 +153,6 @@ abstract class AbstractCommandBuilder {
         "common/unsafe",
         "core",
         "examples",
-        "external/akka",
-        "external/docker-integration-tests",
-        "external/flume",
-        "external/flume-sink",
-        "external/kafka",
-        "external/kinesis-asl",
-        "external/mqtt",
-        "external/spark-ganglia-lgpl",
-        "external/twitter",
-        "external/zeromq",
         "graphx",
         "launcher",
         "mllib",

--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -144,10 +144,38 @@ abstract class AbstractCommandBuilder {
     boolean isTesting = "1".equals(getenv("SPARK_TESTING"));
     if (prependClasses || isTesting) {
       String scala = getScalaVersion();
-      List<String> projects = Arrays.asList("core", "repl", "mllib", "graphx",
-        "streaming", "tools", "sql/catalyst", "sql/core", "sql/hive", "sql/hive-thriftserver",
-        "yarn", "launcher",
-        "common/network-common", "common/network-shuffle", "common/network-yarn");
+      // All projects except assemblies:
+      List<String> projects = Arrays.asList(
+        "common/network-common",
+        "common/network-shuffle",
+        "common/network-yarn",
+        "common/sketch",
+        "common/tags",
+        "common/unsafe",
+        "core",
+        "examples",
+        "external/akka",
+        "external/docker-integration-tests",
+        "external/flume",
+        "external/flume-sink",
+        "external/kafka",
+        "external/kinesis-asl",
+        "external/mqtt",
+        "external/spark-ganglia-lgpl",
+        "external/twitter",
+        "external/zeromq",
+        "graphx",
+        "launcher",
+        "mllib",
+        "repl",
+        "sql/catalyst",
+        "sql/core",
+        "sql/hive",
+        "sql/hive-thriftserver",
+        "streaming",
+        "tools",
+        "yarn"
+      );
       if (prependClasses) {
         if (!isTesting) {
           System.err.println(

--- a/python/pyspark/streaming/tests.py
+++ b/python/pyspark/streaming/tests.py
@@ -1636,7 +1636,13 @@ if __name__ == "__main__":
         jars = "%s,%s,%s,%s,%s" % (kafka_assembly_jar, flume_assembly_jar, mqtt_assembly_jar,
                                    mqtt_test_jar, kinesis_asl_assembly_jar)
 
-    os.environ["PYSPARK_SUBMIT_ARGS"] = "--jars %s pyspark-shell" % jars
+    # We need to set userClassPathFirst here because the streaming data source classes are also
+    # loadable from the root classloader (because of SPARK_PREPEND_CLASSES) but their dependencies
+    # are only present in the data source assembly JARs.
+    os.environ["PYSPARK_SUBMIT_ARGS"] = " ".join([
+        "--conf spark.driver.userClassPathFirst=true",
+        "--jars %s pyspark-shell" % jars,
+    ])
     testcases = [BasicOperationTests, WindowFunctionTests, StreamingContextTests, CheckpointTests,
                  KafkaStreamTests, FlumeStreamTests, FlumePollingStreamTests, MQTTStreamTests,
                  StreamingListenerTests]

--- a/python/pyspark/streaming/tests.py
+++ b/python/pyspark/streaming/tests.py
@@ -1636,13 +1636,7 @@ if __name__ == "__main__":
         jars = "%s,%s,%s,%s,%s" % (kafka_assembly_jar, flume_assembly_jar, mqtt_assembly_jar,
                                    mqtt_test_jar, kinesis_asl_assembly_jar)
 
-    # We need to set userClassPathFirst here because the streaming data source classes are also
-    # loadable from the root classloader (because of SPARK_PREPEND_CLASSES) but their dependencies
-    # are only present in the data source assembly JARs.
-    os.environ["PYSPARK_SUBMIT_ARGS"] = " ".join([
-        "--conf spark.driver.userClassPathFirst=true",
-        "--jars %s pyspark-shell" % jars,
-    ])
+    os.environ["PYSPARK_SUBMIT_ARGS"] = "--jars %s pyspark-shell" % jars
     testcases = [BasicOperationTests, WindowFunctionTests, StreamingContextTests, CheckpointTests,
                  KafkaStreamTests, FlumeStreamTests, FlumePollingStreamTests, MQTTStreamTests,
                  StreamingListenerTests]

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -58,7 +58,7 @@ def get_spark_dist_classpath():
     original_working_dir = os.getcwd()
     os.chdir(SPARK_HOME)
     cp = subprocess_check_output(
-        ["./build/sbt", "export assembly/managedClasspath"], universal_newlines=True)
+        ["./build/sbt", "-Phive", "export assembly/managedClasspath"], universal_newlines=True)
     cp = cp.strip().split("\n")[-1]
     os.chdir(original_working_dir)
     return cp

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -54,10 +54,27 @@ FAILURE_REPORTING_LOCK = Lock()
 LOGGER = logging.getLogger()
 
 
-def run_individual_python_test(test_name, pyspark_python):
+def get_spark_dist_classpath():
+    original_working_dir = os.getcwd()
+    os.chdir(SPARK_HOME)
+    cp = subprocess_check_output(
+        ["./build/sbt", "export assembly/managedClasspath"], universal_newlines=True)
+    cp = cp.strip().split("\n")[-1]
+    os.chdir(original_working_dir)
+    return cp
+
+
+def run_individual_python_test(test_name, pyspark_python, spark_dist_classpath):
     env = dict(os.environ)
-    env.update({'SPARK_TESTING': '1', 'PYSPARK_PYTHON': which(pyspark_python),
-                'PYSPARK_DRIVER_PYTHON': which(pyspark_python)})
+    env.update({
+        # Setting SPARK_DIST_CLASSPATH is a simple way to make sure that any child processes
+        # launched by the tests have access to the correct test-time classpath.
+        'SPARK_DIST_CLASSPATH': spark_dist_classpath,
+        'SPARK_TESTING': '1',
+        'SPARK_PREPEND_CLASSES': '1',
+        'PYSPARK_PYTHON': which(pyspark_python),
+        'PYSPARK_DRIVER_PYTHON': which(pyspark_python),
+    })
     LOGGER.debug("Starting test(%s): %s", pyspark_python, test_name)
     start_time = time.time()
     try:
@@ -175,6 +192,8 @@ def main():
                         priority = 100
                     task_queue.put((priority, (python_exec, test_goal)))
 
+    spark_dist_classpath = get_spark_dist_classpath()
+
     def process_queue(task_queue):
         while True:
             try:
@@ -182,7 +201,7 @@ def main():
             except Queue.Empty:
                 break
             try:
-                run_individual_python_test(test_goal, python_exec)
+                run_individual_python_test(test_goal, python_exec, spark_dist_classpath)
             finally:
                 task_queue.task_done()
 


### PR DESCRIPTION
As of SPARK-9284 we should no longer need to build the full Spark assembly JAR in order to run tests. Therefore, we should remove the assembly step from dev/run-tests in order to reduce build + test time.

Most of the changes in this PR were originally part of #11178.
