### PR TITLE
[SPARK-13660][SQL][Tests] ContinuousQuerySuite floods the logs with garbage

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/ContinuousQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/ContinuousQuerySuite.scala
@@ -27,7 +27,7 @@ class ContinuousQuerySuite extends StreamTest with SharedSQLContext {
   import AwaitTerminationTester._
   import testImplicits._
 
-  test("lifecycle states and awaitTermination") {
+  testQuietly("lifecycle states and awaitTermination") {
     val inputData = MemoryStream[Int]
     val mapped = inputData.toDS().map { 6 / _}
 
@@ -59,7 +59,7 @@ class ContinuousQuerySuite extends StreamTest with SharedSQLContext {
     )
   }
 
-  test("source and sink statuses") {
+  testQuietly("source and sink statuses") {
     val inputData = MemoryStream[Int]
     val mapped = inputData.toDS().map(6 / _)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use method 'testQuietly' to avoid ContinuousQuerySuite flooding the console logs with garbage 

Make ContinuousQuerySuite not output logs to the console. The logs will still output to unit-tests.log.
## How was this patch tested?

Just check Jenkins output.
