### PR TITLE
[SPARK-13889][YARN] Fix integer overflow when calculating the max number of executor failure

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -73,7 +73,8 @@ private[spark] class ApplicationMaster(
       } else {
         sparkConf.get(EXECUTOR_INSTANCES).getOrElse(0)
       }
-    val defaultMaxNumExecutorFailures = math.max(3, 2 * effectiveNumExecutors)
+    val defaultMaxNumExecutorFailures = math.max(3,
+      if (effectiveNumExecutors > Int.MaxValue / 2) Int.MaxValue else (2 * effectiveNumExecutors))
 
     sparkConf.get(MAX_EXECUTOR_FAILURES).getOrElse(defaultMaxNumExecutorFailures)
   }

--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -73,6 +73,8 @@ private[spark] class ApplicationMaster(
       } else {
         sparkConf.get(EXECUTOR_INSTANCES).getOrElse(0)
       }
+    // By default, effectiveNumExecutors is Int.MaxValue if dynamic allocation is enabled. We need
+    // avoid the integer overflow here.
     val defaultMaxNumExecutorFailures = math.max(3,
       if (effectiveNumExecutors > Int.MaxValue / 2) Int.MaxValue else (2 * effectiveNumExecutors))
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The max number of executor failure before failing the application is default to twice the maximum number of executors if dynamic allocation is enabled. The default value for "spark.dynamicAllocation.maxExecutors" is Int.MaxValue. So this causes an integer overflow and a wrong result. The calculated value of the default max number of executor failure is 3. This PR adds a check to avoid the overflow.
## How was this patch tested?

It tests if the value is greater that Int.MaxValue / 2 to avoid the overflow when it multiplies 2. 
