### PR TITLE
[MINOR][TEST][SQL] Remove wrong "expected" parameter in checkNaNWithoutCodegen

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MathFunctionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MathFunctionsSuite.scala
@@ -122,7 +122,6 @@ class MathFunctionsSuite extends SparkFunSuite with ExpressionEvalHelper {
 
   private def checkNaNWithoutCodegen(
     expression: Expression,
-    expected: Any,
     inputRow: InternalRow = EmptyRow): Unit = {
     val actual = try evaluate(expression, inputRow) catch {
       case e: Exception => fail(s"Exception evaluating $expression", e)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove the wrong "expected" parameter in MathFunctionsSuite.scala's checkNaNWithoutCodegen.
This function is to check NaN value, so the "expected" parameter is useless. The Callers do not pass "expected" value and the similar function like checkNaNWithGeneratedProjection and checkNaNWithOptimization do not use it also.
