### PR TITLE
[SPARK-13901][CORE]correct the logDebug information when jump to the next locality level

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -543,21 +543,22 @@ private[spark] class TaskSetManager(
         case TaskLocality.NO_PREF => pendingTasksWithNoPrefs.nonEmpty
         case TaskLocality.RACK_LOCAL => moreTasksToRunIn(pendingTasksForRack)
       }
+      val previousLocalityIndex = currentLocalityIndex
       if (!moreTasks) {
         // This is a performance optimization: if there are no more tasks that can
         // be scheduled at a particular locality level, there is no point in waiting
         // for the locality wait timeout (SPARK-4939).
         lastLaunchTime = curTime
-        logDebug(s"No tasks for locality level ${myLocalityLevels(currentLocalityIndex)}, " +
-          s"so moving to locality level ${myLocalityLevels(currentLocalityIndex + 1)}")
-        currentLocalityIndex += 1
+	currentLocalityIndex += 1
+        logDebug(s"No tasks for locality level ${myLocalityLevels(previousLocalityIndex)}, " +
+          s"so moving to locality level ${myLocalityLevels(currentLocalityIndex)}")
       } else if (curTime - lastLaunchTime >= localityWaits(currentLocalityIndex)) {
         // Jump to the next locality level, and reset lastLaunchTime so that the next locality
         // wait timer doesn't immediately expire
         lastLaunchTime += localityWaits(currentLocalityIndex)
         currentLocalityIndex += 1
         logDebug(s"Moving to ${myLocalityLevels(currentLocalityIndex)} after waiting for " +
-          s"${localityWaits(currentLocalityIndex - 1)}ms")
+          s"${localityWaits(previousLocalityIndex)}ms")
       } else {
         return myLocalityLevels(currentLocalityIndex)
       }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -557,7 +557,7 @@ private[spark] class TaskSetManager(
         lastLaunchTime += localityWaits(currentLocalityIndex)
         currentLocalityIndex += 1
         logDebug(s"Moving to ${myLocalityLevels(currentLocalityIndex)} after waiting for " +
-          s"${localityWaits(currentLocalityIndex)}ms")
+          s"${localityWaits(currentLocalityIndex - 1)}ms")
       } else {
         return myLocalityLevels(currentLocalityIndex)
       }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -549,7 +549,7 @@ private[spark] class TaskSetManager(
         // be scheduled at a particular locality level, there is no point in waiting
         // for the locality wait timeout (SPARK-4939).
         lastLaunchTime = curTime
-	currentLocalityIndex += 1
+        currentLocalityIndex += 1
         logDebug(s"No tasks for locality level ${myLocalityLevels(previousLocalityIndex)}, " +
           s"so moving to locality level ${myLocalityLevels(currentLocalityIndex)}")
       } else if (curTime - lastLaunchTime >= localityWaits(currentLocalityIndex)) {


### PR DESCRIPTION
JIRA Issue:https://issues.apache.org/jira/browse/SPARK-13901
In getAllowedLocalityLevel method of TaskSetManager,we get wrong logDebug information when jump to the next locality level.So we should fix it.
