### PR TITLE
[SPARK-13397] Cleanup transient annotations which aren't being applied

### DIFF
--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.scheduler
 
 import java.util.Properties
 
+import scala.annotation.meta.param
 import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet, Map}
 import scala.language.reflectiveCalls
 import scala.util.control.NonFatal
@@ -67,7 +68,7 @@ class MyRDD(
     numPartitions: Int,
     dependencies: List[Dependency[_]],
     locations: Seq[Seq[String]] = Nil,
-    @transient tracker: MapOutputTrackerMaster = null)
+    @(transient @param) tracker: MapOutputTrackerMaster = null)
   extends RDD[(Int, Int)](sc, dependencies) with Serializable {
 
   override def compute(split: Partition, context: TaskContext): Iterator[(Int, Int)] =

--- a/core/src/test/scala/org/apache/spark/serializer/SerializationDebuggerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/SerializationDebuggerSuite.scala
@@ -19,6 +19,8 @@ package org.apache.spark.serializer
 
 import java.io._
 
+import scala.annotation.meta.param
+
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.SparkFunSuite
@@ -219,7 +221,7 @@ class SerializableClassWithWriteObject(val objectField: Object) extends Serializ
 }
 
 
-class SerializableClassWithWriteReplace(@transient replacementFieldObject: Object)
+class SerializableClassWithWriteReplace(@(transient @param)replacementFieldObject: Object)
   extends Serializable {
   private def writeReplace(): Object = {
     replacementFieldObject

--- a/streaming/src/test/scala/org/apache/spark/streaming/scheduler/ReceiverTrackerSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/scheduler/ReceiverTrackerSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.streaming.scheduler
 
+import scala.annotation.meta.param
 import scala.collection.mutable.ArrayBuffer
 
 import org.scalatest.concurrent.Eventually._
@@ -105,7 +106,7 @@ class ReceiverTrackerSuite extends TestSuiteBase {
 }
 
 /** An input DStream with for testing rate controlling */
-private[streaming] class RateTestInputDStream(@transient _ssc: StreamingContext)
+private[streaming] class RateTestInputDStream(@(transient @param) _ssc: StreamingContext)
   extends ReceiverInputDStream[Int](_ssc) {
 
   override def getReceiver(): Receiver[Int] = new RateTestReceiver(id)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This cleanup the transient annotations which aren't being applied. The followings are the warnings
GSchedulerSuite.scala:70: no valid targets for annotation on value tracker - it is discarded unused. You may specify targets with meta-annotations, e.g. @(transient @param)
     @transient tracker: MapOutputTrackerMaster = null)
SerializationDebuggerSuite.scala:222: no valid targets for annotation on value replacementFieldObject - it is discarded unused. You may specify targets with meta-annotations, e.g. @(transient @param)
     class SerializableClassWithWriteReplace(@transient replacementFieldObject: Object)
ReceiverTrackerSuite.scala:108: no valid targets for annotation on value _ssc - it is discarded unused. You may specify targets with meta-annotations, e.g. @(transient @param)
     class RateTestInputDStream(@transient _ssc: StreamingContext)
## How was this patch tested?

Manual.
During building, there should be no warning on transient annotation unused.
