### PR TITLE
[SPARK-13073] [MLib] [WIP] creating R like summary for logistic Regression in Spark - Scala

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.ml.classification
 
+import scala.StringBuilder
 import scala.collection.mutable
 
 import breeze.linalg.{DenseVector => BDV}
@@ -911,6 +912,53 @@ class BinaryLogisticRegressionSummary private[classification] (
   @Since("1.5.0")
   @transient lazy val recallByThreshold: DataFrame = {
     binaryMetrics.recallByThreshold().toDF("threshold", "recall")
+  }
+  /**
+   * Returns a string representation for the fields : [[roc]] , [[pr]]
+   * and [[fMeasureByThreshold]]
+   */
+  @Since("1.6.0")
+  override def toString : String = {
+    val newLine = sys.props("line.separator")
+
+    def dataFrameToString(dataFrameName : String,dataFrame:DataFrame,sep:String) : String ={
+      val dataFrameStringBuilder = new StringBuilder()
+      val rowStringBuilder = new StringBuilder
+
+      //Append data frame name
+      dataFrameStringBuilder.append(dataFrameName+":")
+      dataFrameStringBuilder.append(newLine)
+      //create header of string representation
+      dataFrameStringBuilder.append(dataFrame.columns.mkString(sep))
+      dataFrameStringBuilder.append(newLine)
+
+      //create data string representation
+      dataFrame.collect().map(row=> {
+        rowStringBuilder.clear
+        row.toSeq.map(s => {
+          if(s.isInstanceOf[Double])
+            rowStringBuilder.append(f"${s.asInstanceOf[Double]}%1.2f")
+          else
+            rowStringBuilder.append(s.toString)
+          rowStringBuilder.append(sep)
+          rowStringBuilder.toString()
+        })
+        dataFrameStringBuilder.append(rowStringBuilder.toString.trim)
+        dataFrameStringBuilder.append(newLine)
+      })
+      dataFrameStringBuilder.toString
+    }
+    val summaryStringBuilder = new StringBuilder()
+
+    val colSep = "\t"
+    //Building roc string
+    summaryStringBuilder.append(dataFrameToString("ROC",roc,colSep))
+    summaryStringBuilder.append(newLine)
+    summaryStringBuilder.append(dataFrameToString("Precesion",pr,colSep))
+    summaryStringBuilder.append(newLine)
+    summaryStringBuilder.append(dataFrameToString("F-Measure by threshold",fMeasureByThreshold,colSep))
+    summaryStringBuilder.append(newLine)
+    summaryStringBuilder.toString
   }
 }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -915,6 +915,7 @@ class BinaryLogisticRegressionSummary private[classification] (
   /**
    * Returns a string representation for the fields : [[roc]] , [[pr]]
    * and [[fMeasureByThreshold]]
+   * //TODO add more fields in toString method
    */
   @Since("1.6.0")
   override def toString: String = {
@@ -943,15 +944,15 @@ class BinaryLogisticRegressionSummary private[classification] (
           }
 
           rowStringBuilder.append(sep)
-          rowStringBuilder.toString()
+          rowStringBuilder.toString
         })
         dataFrameStringBuilder.append(rowStringBuilder.toString.trim)
         dataFrameStringBuilder.append(newLine)
       })
       dataFrameStringBuilder.toString
     }
-    val summaryStringBuilder = new StringBuilder()
-
+    val summaryStringBuilder = new StringBuilder
+    //TODO Dynamic adjustment for separator based on col width (if needed)
     val colSep = "\t"
     summaryStringBuilder.append(dataFrameToString("ROC", roc, colSep))
     summaryStringBuilder.append(newLine)

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -952,7 +952,7 @@ class BinaryLogisticRegressionSummary private[classification] (
       dataFrameStringBuilder.toString
     }
     val summaryStringBuilder = new StringBuilder
-    //TODO Dynamic adjustment for separator based on col width (if needed)
+    // TODO Dynamic adjustment for separator based on col width (if needed)
     val colSep = "\t"
     summaryStringBuilder.append(dataFrameToString("ROC", roc, colSep))
     summaryStringBuilder.append(newLine)

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -954,7 +954,7 @@ class BinaryLogisticRegressionSummary private[classification] (
     //Building roc string
     summaryStringBuilder.append(dataFrameToString("ROC",roc,colSep))
     summaryStringBuilder.append(newLine)
-    summaryStringBuilder.append(dataFrameToString("Precesion",pr,colSep))
+    summaryStringBuilder.append(dataFrameToString("Precision",pr,colSep))
     summaryStringBuilder.append(newLine)
     summaryStringBuilder.append(dataFrameToString("F-Measure by threshold",fMeasureByThreshold,colSep))
     summaryStringBuilder.append(newLine)

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.ml.classification
 
-import scala.StringBuilder
 import scala.collection.mutable
 
 import breeze.linalg.{DenseVector => BDV}
@@ -918,28 +917,31 @@ class BinaryLogisticRegressionSummary private[classification] (
    * and [[fMeasureByThreshold]]
    */
   @Since("1.6.0")
-  override def toString : String = {
+  override def toString: String = {
     val newLine = sys.props("line.separator")
 
-    def dataFrameToString(dataFrameName : String,dataFrame:DataFrame,sep:String) : String ={
+    def dataFrameToString(dataFrameName: String, dataFrame: DataFrame, sep: String): String = {
       val dataFrameStringBuilder = new StringBuilder()
       val rowStringBuilder = new StringBuilder
 
-      //Append data frame name
-      dataFrameStringBuilder.append(dataFrameName+":")
+      // Append data frame name
+      dataFrameStringBuilder.append(dataFrameName + ":")
       dataFrameStringBuilder.append(newLine)
-      //create header of string representation
+      // create header of string representation
       dataFrameStringBuilder.append(dataFrame.columns.mkString(sep))
       dataFrameStringBuilder.append(newLine)
 
-      //create data string representation
-      dataFrame.collect().map(row=> {
+      // create data string representation
+      dataFrame.collect().map(row => {
         rowStringBuilder.clear
         row.toSeq.map(s => {
-          if(s.isInstanceOf[Double])
+          if (s.isInstanceOf[Double]) {
             rowStringBuilder.append(f"${s.asInstanceOf[Double]}%1.2f")
-          else
+          }
+          else {
             rowStringBuilder.append(s.toString)
+          }
+
           rowStringBuilder.append(sep)
           rowStringBuilder.toString()
         })
@@ -951,12 +953,12 @@ class BinaryLogisticRegressionSummary private[classification] (
     val summaryStringBuilder = new StringBuilder()
 
     val colSep = "\t"
-    //Building roc string
-    summaryStringBuilder.append(dataFrameToString("ROC",roc,colSep))
+    summaryStringBuilder.append(dataFrameToString("ROC", roc, colSep))
     summaryStringBuilder.append(newLine)
-    summaryStringBuilder.append(dataFrameToString("Precision",pr,colSep))
+    summaryStringBuilder.append(dataFrameToString("Precision", pr, colSep))
     summaryStringBuilder.append(newLine)
-    summaryStringBuilder.append(dataFrameToString("F-Measure by threshold",fMeasureByThreshold,colSep))
+    summaryStringBuilder.append(dataFrameToString("F-Measure by threshold", fMeasureByThreshold,
+      colSep))
     summaryStringBuilder.append(newLine)
     summaryStringBuilder.toString
   }

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -952,6 +952,7 @@ class LogisticRegressionSuite
     assert(strSummary.contains("ROC"))
     assert(strSummary.contains("Precision"))
     assert(strSummary.contains("F-Measure"))
+    // TODO add checking with regex
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -946,8 +946,9 @@ class LogisticRegressionSuite
     val summary = model.summary.asInstanceOf[BinaryLogisticRegressionSummary]
 
     val strSummary = summary.toString
-    assert(strSummary.isInstanceOf[String])
-    assert(strSummary.length >0)
+    assert(strSummary.isInstanceOf[String]) // Check type of return
+    assert(strSummary.length >0) // Check non-empty return string
+    // Check whether return string return expected column headers
     assert(strSummary.contains("ROC"))
     assert(strSummary.contains("Precision"))
     assert(strSummary.contains("F-Measure"))

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -798,7 +798,6 @@ class LogisticRegressionSuite
       .setThreshold(0.6)
     val model = lr.fit(dataset)
     val summary = model.summary.asInstanceOf[BinaryLogisticRegressionSummary]
-
     val sameSummary = model.evaluate(dataset).asInstanceOf[BinaryLogisticRegressionSummary]
     assert(summary.areaUnderROC === sameSummary.areaUnderROC)
     assert(summary.roc.collect() === sameSummary.roc.collect())
@@ -936,6 +935,18 @@ class LogisticRegressionSuite
     val lr = new LogisticRegression()
     testEstimatorAndModelReadWrite(lr, dataset, LogisticRegressionSuite.allParamSettings,
       checkModelData)
+  }
+
+  test("BinaryLogisticRegressionSummary toString") {
+    val lr = new LogisticRegression()
+      .setMaxIter(10)
+      .setRegParam(1.0)
+      .setThreshold(0.6)
+    val model = lr.fit(dataset)
+    val summary = model.summary.asInstanceOf[BinaryLogisticRegressionSummary]
+
+    val strSummary = summary.toString
+    print(strSummary)
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -946,7 +946,10 @@ class LogisticRegressionSuite
     val summary = model.summary.asInstanceOf[BinaryLogisticRegressionSummary]
 
     val strSummary = summary.toString
-    print(strSummary)
+    assert(strSummary.isInstanceOf[String])
+    assert(strSummary.contains("ROC"))
+    assert(strSummary.contains("Precision"))
+    assert(strSummary.contains("F-Measure"))
   }
 }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -947,6 +947,7 @@ class LogisticRegressionSuite
 
     val strSummary = summary.toString
     assert(strSummary.isInstanceOf[String])
+    assert(strSummary.length >0)
     assert(strSummary.contains("ROC"))
     assert(strSummary.contains("Precision"))
     assert(strSummary.contains("F-Measure"))


### PR DESCRIPTION
## What changes were proposed in this pull request?

Implemented initial version of toString method for BinaryLogisticRegressionSummary that converts ROC , Precision , F-Measure data frame members into tabular string representation
## How was this patch tested?

-Unit testing 
-Manual

Author : Mohamed Baddar ( mbaddar2@gmail dot com )

@mengxr Can you help in reviewing this PR
