### PR TITLE
[SPARK-13910][SQL] Makes Dataset.newDataFrame public

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -48,11 +48,17 @@ import org.apache.spark.sql.types._
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util.Utils
 
-private[sql] object Dataset {
-  def apply[T: Encoder](sqlContext: SQLContext, logicalPlan: LogicalPlan): Dataset[T] = {
+object Dataset {
+  private[sql] def apply[T: Encoder](
+      sqlContext: SQLContext, logicalPlan: LogicalPlan): Dataset[T] = {
     new Dataset(sqlContext, logicalPlan, implicitly[Encoder[T]])
   }
 
+  /**
+   * Creates a [[DataFrame]] by analyzing a given logical plan.
+   *
+   * @since 2.0.0
+   */
   def newDataFrame(sqlContext: SQLContext, logicalPlan: LogicalPlan): DataFrame = {
     val qe = sqlContext.executePlan(logicalPlan)
     qe.assertAnalyzed()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Before merging DataFrame and Dataset, there is a public DataFrame constructor that accepts an unresolved logical plan. Now this constructor has gone together with class `DataFrame`. This functionality is now provided by `Dataset.newDataFrame`, but object Dataset is marked as `private[sql]`. This PR make this method public.
## How was this patch tested?

No tests since this is only an API visibility change.
