### PR TITLE
[SPARK-13923] [SQL] Implement SessionCatalog

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/TableIdentifier.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/TableIdentifier.scala
@@ -18,7 +18,8 @@
 package org.apache.spark.sql.catalyst
 
 /**
- * Identifies a `table` in `database`.  If `database` is not defined, the current database is used.
+ * Identifies a table in a database.
+ * If `database` is not defined, the current database is used.
  */
 private[sql] case class TableIdentifier(table: String, database: Option[String]) {
   def this(table: String) = this(table, None)
@@ -32,4 +33,23 @@ private[sql] case class TableIdentifier(table: String, database: Option[String])
 
 private[sql] object TableIdentifier {
   def apply(tableName: String): TableIdentifier = new TableIdentifier(tableName)
+}
+
+/**
+ * Identifies a function in a database.
+ * If `database` is not defined, the current database is used.
+ */
+// TODO: reuse some code with TableIdentifier.
+private[sql] case class FunctionIdentifier(name: String, database: Option[String]) {
+  def this(name: String) = this(name, None)
+
+  override def toString: String = quotedString
+
+  def quotedString: String = database.map(db => s"`$db`.`$name`").getOrElse(s"`$name`")
+
+  def unquotedString: String = database.map(db => s"$db.$name").getOrElse(name)
+}
+
+private[sql] object FunctionIdentifier {
+  def apply(funcName: String): FunctionIdentifier = new FunctionIdentifier(funcName)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/TableIdentifier.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/TableIdentifier.scala
@@ -40,14 +40,14 @@ private[sql] object TableIdentifier {
  * If `database` is not defined, the current database is used.
  */
 // TODO: reuse some code with TableIdentifier.
-private[sql] case class FunctionIdentifier(name: String, database: Option[String]) {
+private[sql] case class FunctionIdentifier(funcName: String, database: Option[String]) {
   def this(name: String) = this(name, None)
 
   override def toString: String = quotedString
 
-  def quotedString: String = database.map(db => s"`$db`.`$name`").getOrElse(s"`$name`")
+  def quotedString: String = database.map(db => s"`$db`.`$funcName`").getOrElse(s"`$funcName`")
 
-  def unquotedString: String = database.map(db => s"$db.$name").getOrElse(name)
+  def unquotedString: String = database.map(db => s"$db.$funcName").getOrElse(funcName)
 }
 
 private[sql] object FunctionIdentifier {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.catalog
 import scala.collection.mutable
 
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
 
 
 /**
@@ -294,10 +294,10 @@ class InMemoryCatalog extends ExternalCatalog {
 
   override def createFunction(db: String, func: CatalogFunction): Unit = synchronized {
     requireDbExists(db)
-    if (existsFunction(db, func.name)) {
+    if (existsFunction(db, func.name.funcName)) {
       throw new AnalysisException(s"Function $func already exists in $db database")
     } else {
-      catalog(db).functions.put(func.name, func)
+      catalog(db).functions.put(func.name.funcName, func)
     }
   }
 
@@ -308,14 +308,14 @@ class InMemoryCatalog extends ExternalCatalog {
 
   override def renameFunction(db: String, oldName: String, newName: String): Unit = synchronized {
     requireFunctionExists(db, oldName)
-    val newFunc = getFunction(db, oldName).copy(name = newName)
+    val newFunc = getFunction(db, oldName).copy(name = FunctionIdentifier(newName, Some(db)))
     catalog(db).functions.remove(oldName)
     catalog(db).functions.put(newName, newFunc)
   }
 
   override def alterFunction(db: String, funcDefinition: CatalogFunction): Unit = synchronized {
-    requireFunctionExists(db, funcDefinition.name)
-    catalog(db).functions.put(funcDefinition.name, funcDefinition)
+    requireFunctionExists(db, funcDefinition.name.funcName)
+    catalog(db).functions.put(funcDefinition.name.funcName, funcDefinition)
   }
 
   override def getFunction(db: String, funcName: String): CatalogFunction = synchronized {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -176,7 +176,7 @@ class InMemoryCatalog extends ExternalCatalog {
       catalog(db).tables.remove(table)
     } else {
       if (!ignoreIfNotExists) {
-        throw new AnalysisException(s"Table $table does not exist in $db database")
+        throw new AnalysisException(s"Table '$table' does not exist in database '$db'")
       }
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -69,19 +69,20 @@ class InMemoryCatalog extends ExternalCatalog {
 
   private def requireFunctionExists(db: String, funcName: String): Unit = {
     if (!existsFunction(db, funcName)) {
-      throw new AnalysisException(s"Function $funcName does not exist in $db database")
+      throw new AnalysisException(s"Function '$funcName' does not exist in database '$db'")
     }
   }
 
   private def requireTableExists(db: String, table: String): Unit = {
     if (!existsTable(db, table)) {
-      throw new AnalysisException(s"Table $table does not exist in $db database")
+      throw new AnalysisException(s"Table '$table' does not exist in database '$db'")
     }
   }
 
   private def requirePartitionExists(db: String, table: String, spec: TablePartitionSpec): Unit = {
     if (!existsPartition(db, table, spec)) {
-      throw new AnalysisException(s"Partition does not exist in database $db table $table: $spec")
+      throw new AnalysisException(
+        s"Partition does not exist in database '$db' table '$table': '$spec'")
     }
   }
 
@@ -94,7 +95,7 @@ class InMemoryCatalog extends ExternalCatalog {
       ignoreIfExists: Boolean): Unit = synchronized {
     if (catalog.contains(dbDefinition.name)) {
       if (!ignoreIfExists) {
-        throw new AnalysisException(s"Database ${dbDefinition.name} already exists.")
+        throw new AnalysisException(s"Database '${dbDefinition.name}' already exists.")
       }
     } else {
       catalog.put(dbDefinition.name, new DatabaseDesc(dbDefinition))
@@ -109,17 +110,17 @@ class InMemoryCatalog extends ExternalCatalog {
       if (!cascade) {
         // If cascade is false, make sure the database is empty.
         if (catalog(db).tables.nonEmpty) {
-          throw new AnalysisException(s"Database $db is not empty. One or more tables exist.")
+          throw new AnalysisException(s"Database '$db' is not empty. One or more tables exist.")
         }
         if (catalog(db).functions.nonEmpty) {
-          throw new AnalysisException(s"Database $db is not empty. One or more functions exist.")
+          throw new AnalysisException(s"Database '$db' is not empty. One or more functions exist.")
         }
       }
       // Remove the database.
       catalog.remove(db)
     } else {
       if (!ignoreIfNotExists) {
-        throw new AnalysisException(s"Database $db does not exist")
+        throw new AnalysisException(s"Database '$db' does not exist")
       }
     }
   }
@@ -160,7 +161,7 @@ class InMemoryCatalog extends ExternalCatalog {
     val table = tableDefinition.name.table
     if (existsTable(db, table)) {
       if (!ignoreIfExists) {
-        throw new AnalysisException(s"Table $table already exists in $db database")
+        throw new AnalysisException(s"Table '$table' already exists in database '$db'")
       }
     } else {
       catalog(db).tables.put(table, new TableDesc(tableDefinition))
@@ -224,8 +225,8 @@ class InMemoryCatalog extends ExternalCatalog {
       val dupSpecs = parts.collect { case p if existingParts.contains(p.spec) => p.spec }
       if (dupSpecs.nonEmpty) {
         val dupSpecsStr = dupSpecs.mkString("\n===\n")
-        throw new AnalysisException(
-          s"The following partitions already exist in database $db table $table:\n$dupSpecsStr")
+        throw new AnalysisException("The following partitions already exist in database " +
+          s"'$db' table '$table':\n$dupSpecsStr")
       }
     }
     parts.foreach { p => existingParts.put(p.spec, p) }
@@ -242,8 +243,8 @@ class InMemoryCatalog extends ExternalCatalog {
       val missingSpecs = partSpecs.collect { case s if !existingParts.contains(s) => s }
       if (missingSpecs.nonEmpty) {
         val missingSpecsStr = missingSpecs.mkString("\n===\n")
-        throw new AnalysisException(
-          s"The following partitions do not exist in database $db table $table:\n$missingSpecsStr")
+        throw new AnalysisException("The following partitions do not exist in database " +
+          s"'$db' table '$table':\n$missingSpecsStr")
       }
     }
     partSpecs.foreach(existingParts.remove)
@@ -295,7 +296,7 @@ class InMemoryCatalog extends ExternalCatalog {
   override def createFunction(db: String, func: CatalogFunction): Unit = synchronized {
     requireDbExists(db)
     if (existsFunction(db, func.name.funcName)) {
-      throw new AnalysisException(s"Function $func already exists in $db database")
+      throw new AnalysisException(s"Function '$func' already exists in '$db' database")
     } else {
       catalog(db).functions.put(func.name.funcName, func)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -220,13 +220,23 @@ abstract class SessionCatalog(catalog: ExternalCatalog) {
   // | Methods that interact with metastore functions only |
   // -------------------------------------------------------
 
+  /**
+   * Create a metastore function in the database specified in `funcDefinition`.
+   * If no such database is specified, create it in the current database.
+   */
   def createFunction(currentDb: String, funcDefinition: CatalogFunction): Unit
 
+  /**
+   * Drop a metastore function.
+   * If no database is specified, assume the function is in the current database.
+   */
   def dropFunction(currentDb: String, funcName: FunctionIdentifier): Unit
 
   /**
-   * Alter a function whose name that matches the one specified in `funcDefinition`,
-   * assuming the function exists.
+   * Alter a function whose name that matches the one specified in `funcDefinition`.
+   *
+   * If no database is specified in `funcDefinition`, assume the function is in the
+   * current database.
    *
    * Note: If the underlying implementation does not support altering a certain field,
    * this becomes a no-op.
@@ -237,20 +247,43 @@ abstract class SessionCatalog(catalog: ExternalCatalog) {
   // | Methods that interact with temporary and metastore functions |
   // ----------------------------------------------------------------
 
+  /**
+   * Create a temporary function.
+   * This assumes no database is specified in `funcDefinition`.
+   */
   def createTempFunction(funcDefinition: CatalogFunction): Unit
 
   // TODO: The reason that we distinguish dropFunction and dropTempFunction is that
   // Hive has DROP FUNCTION and DROP TEMPORARY FUNCTION. We may want to consolidate
   // dropFunction and dropTempFunction.
-  def dropTempFunction(funcName: String): Unit
+  def dropTempFunction(name: String): Unit
 
+  /**
+   * Rename a function.
+   *
+   * If a database is specified in `oldName`, this will rename the function in that database.
+   * If no database is specified, this will first attempt to rename a temporary function with
+   * the same name, then, if that does not exist, rename the function in the current database.
+   *
+   * This assumes the database specified in `oldName` matches the one specified in `newName`.
+   */
   def renameFunction(
       currentDb: String,
       oldName: FunctionIdentifier,
       newName: FunctionIdentifier): Unit
 
-  def getFunction(currentDb: String, funcIdentifier: FunctionIdentifier): CatalogFunction
+  /**
+   * Retrieve the metadata of an existing function.
+   *
+   * If a database is specified in `name`, this will return the function in that database.
+   * If no database is specified, this will first attempt to return a temporary function with
+   * the same name, then, if that does not exist, return the function in the current database.
+   */
+  def getFunction(currentDb: String, name: FunctionIdentifier): CatalogFunction
 
+  /**
+   * List all matching functions in the current database, including temporary functions.
+   */
   def listFunctions(currentDb: String, pattern: String): Seq[FunctionIdentifier]
 
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -64,11 +64,13 @@ abstract class SessionCatalog(catalog: ExternalCatalog) {
   // sessions as their metadata is persisted in the underlying catalog.
   // ----------------------------------------------------------------------------
 
-  // Methods that interact with metastore tables only.
+  // ----------------------------------------------------
+  // | Methods that interact with metastore tables only |
+  // ----------------------------------------------------
 
   /**
    * Create a metastore table in the database specified in `tableDefinition`.
-   * If no such table is specified, create it in the current database.
+   * If no such database is specified, create it in the current database.
    */
   def createTable(
       currentDb: String,
@@ -78,17 +80,23 @@ abstract class SessionCatalog(catalog: ExternalCatalog) {
   /**
    * Alter the metadata of an existing metastore table identified by `tableDefinition`.
    *
+   * If no database is specified in `tableDefinition`, assume the table is in the
+   * current database.
+   *
    * Note: If the underlying implementation does not support altering a certain field,
    * this becomes a no-op.
    */
-  def alterTable(tableDefinition: CatalogTable): Unit
+  def alterTable(currentDb: String, tableDefinition: CatalogTable): Unit
 
   /**
    * Retrieve the metadata of an existing metastore table.
+   * If no database is specified, assume the table is in the current database.
    */
-  def getTable(name: TableIdentifier): CatalogTable
+  def getTable(currentDb: String, name: TableIdentifier): CatalogTable
 
-  // Methods that interact with temporary tables and metastore tables.
+  // -------------------------------------------------------------
+  // | Methods that interact with temporary and metastore tables |
+  // -------------------------------------------------------------
 
   /**
    * Create a temporary table.
@@ -208,7 +216,9 @@ abstract class SessionCatalog(catalog: ExternalCatalog) {
   // their metadata is persisted in the underlying catalog.
   // ----------------------------------------------------------------------------
 
-  // Methods that interact with metastore functions only.
+  // -------------------------------------------------------
+  // | Methods that interact with metastore functions only |
+  // -------------------------------------------------------
 
   def createFunction(currentDb: String, funcDefinition: CatalogFunction): Unit
 
@@ -223,7 +233,9 @@ abstract class SessionCatalog(catalog: ExternalCatalog) {
    */
   def alterFunction(currentDb: String, funcDefinition: CatalogFunction): Unit
 
-  // Methods that interact with temporary functions and metastore functions.
+  // ----------------------------------------------------------------
+  // | Methods that interact with temporary and metastore functions |
+  // ----------------------------------------------------------------
 
   def createTempFunction(funcDefinition: CatalogFunction): Unit
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -80,6 +80,9 @@ class SessionCatalog(externalCatalog: ExternalCatalog) {
   def getCurrentDatabase: String = currentDb
 
   def setCurrentDatabase(db: String): Unit = {
+    if (!databaseExists(db)) {
+      throw new AnalysisException(s"cannot set current database to non-existent '$db'")
+    }
     currentDb = db
   }
 
@@ -223,7 +226,7 @@ class SessionCatalog(externalCatalog: ExternalCatalog) {
    */
   def listTables(db: String, pattern: String): Seq[TableIdentifier] = {
     val dbTables =
-      externalCatalog.listTables(db, pattern).map { t => TableIdentifier(t, Some(currentDb)) }
+      externalCatalog.listTables(db, pattern).map { t => TableIdentifier(t, Some(db)) }
     val regex = pattern.replaceAll("\\*", ".*").r
     val _tempTables = tempTables.keys().asScala
       .filter { t => regex.pattern.matcher(t).matches() }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -19,8 +19,11 @@ package org.apache.spark.sql.catalyst.catalog
 
 import java.util.concurrent.ConcurrentHashMap
 
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical.{SubqueryAlias, LogicalPlan}
 
 
 /**
@@ -28,7 +31,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
  * proxy to the underlying metastore (e.g. Hive Metastore) and it also manages temporary
  * tables and functions of the Spark Session that it belongs to.
  */
-abstract class SessionCatalog(catalog: ExternalCatalog) {
+class SessionCatalog(externalCatalog: ExternalCatalog) {
   import ExternalCatalog._
 
   private[this] val tempTables = new ConcurrentHashMap[String, LogicalPlan]
@@ -41,19 +44,33 @@ abstract class SessionCatalog(catalog: ExternalCatalog) {
   // All methods in this category interact directly with the underlying catalog.
   // ----------------------------------------------------------------------------
 
-  def createDatabase(dbDefinition: CatalogDatabase, ignoreIfExists: Boolean): Unit
+  def createDatabase(dbDefinition: CatalogDatabase, ignoreIfExists: Boolean): Unit = {
+    externalCatalog.createDatabase(dbDefinition, ignoreIfExists)
+  }
 
-  def dropDatabase(db: String, ignoreIfNotExists: Boolean, cascade: Boolean): Unit
+  def dropDatabase(db: String, ignoreIfNotExists: Boolean, cascade: Boolean): Unit = {
+    externalCatalog.dropDatabase(db, ignoreIfNotExists, cascade)
+  }
 
-  def alterDatabase(dbDefinition: CatalogDatabase): Unit
+  def alterDatabase(dbDefinition: CatalogDatabase): Unit = {
+    externalCatalog.alterDatabase(dbDefinition)
+  }
 
-  def getDatabase(db: String): CatalogDatabase
+  def getDatabase(db: String): CatalogDatabase = {
+    externalCatalog.getDatabase(db)
+  }
 
-  def databaseExists(db: String): Boolean
+  def databaseExists(db: String): Boolean = {
+    externalCatalog.databaseExists(db)
+  }
 
-  def listDatabases(): Seq[String]
+  def listDatabases(): Seq[String] = {
+    externalCatalog.listDatabases()
+  }
 
-  def listDatabases(pattern: String): Seq[String]
+  def listDatabases(pattern: String): Seq[String] = {
+    externalCatalog.listDatabases(pattern)
+  }
 
   // ----------------------------------------------------------------------------
   // Tables
@@ -75,7 +92,12 @@ abstract class SessionCatalog(catalog: ExternalCatalog) {
   def createTable(
       currentDb: String,
       tableDefinition: CatalogTable,
-      ignoreIfExists: Boolean): Unit
+      ignoreIfExists: Boolean): Unit = {
+    val db = tableDefinition.name.database.getOrElse(currentDb)
+    val newTableDefinition = tableDefinition.copy(
+      name = TableIdentifier(tableDefinition.name.table, Some(db)))
+    externalCatalog.createTable(db, newTableDefinition, ignoreIfExists)
+  }
 
   /**
    * Alter the metadata of an existing metastore table identified by `tableDefinition`.
@@ -86,13 +108,21 @@ abstract class SessionCatalog(catalog: ExternalCatalog) {
    * Note: If the underlying implementation does not support altering a certain field,
    * this becomes a no-op.
    */
-  def alterTable(currentDb: String, tableDefinition: CatalogTable): Unit
+  def alterTable(currentDb: String, tableDefinition: CatalogTable): Unit = {
+    val db = tableDefinition.name.database.getOrElse(currentDb)
+    val newTableDefinition = tableDefinition.copy(
+      name = TableIdentifier(tableDefinition.name.table, Some(db)))
+    externalCatalog.alterTable(db, newTableDefinition)
+  }
 
   /**
    * Retrieve the metadata of an existing metastore table.
    * If no database is specified, assume the table is in the current database.
    */
-  def getTable(currentDb: String, name: TableIdentifier): CatalogTable
+  def getTable(currentDb: String, name: TableIdentifier): CatalogTable = {
+    val db = name.database.getOrElse(currentDb)
+    externalCatalog.getTable(db, name.table)
+  }
 
   // -------------------------------------------------------------
   // | Methods that interact with temporary and metastore tables |
@@ -100,9 +130,16 @@ abstract class SessionCatalog(catalog: ExternalCatalog) {
 
   /**
    * Create a temporary table.
-   * If a temporary table with the same name already exists, this throws an exception.
    */
-  def createTempTable(name: String, tableDefinition: LogicalPlan): Unit
+  def createTempTable(
+      name: String,
+      tableDefinition: LogicalPlan,
+      ignoreIfExists: Boolean): Unit = {
+    if (tempTables.contains(name) && !ignoreIfExists) {
+      throw new AnalysisException(s"Temporary table '$name' already exists.")
+    }
+    tempTables.put(name, tableDefinition)
+  }
 
   /**
    * Rename a table.
@@ -116,7 +153,15 @@ abstract class SessionCatalog(catalog: ExternalCatalog) {
   def renameTable(
       currentDb: String,
       oldName: TableIdentifier,
-      newName: TableIdentifier): Unit
+      newName: TableIdentifier): Unit = {
+    val db = oldName.database.getOrElse(currentDb)
+    if (oldName.database.isDefined || !tempTables.contains(oldName.table)) {
+      externalCatalog.renameTable(db, oldName.table, newName.table)
+    } else {
+      val table = tempTables.remove(oldName.table)
+      tempTables.put(newName.table, table)
+    }
+  }
 
   /**
    * Drop a table.
@@ -128,7 +173,14 @@ abstract class SessionCatalog(catalog: ExternalCatalog) {
   def dropTable(
       currentDb: String,
       name: TableIdentifier,
-      ignoreIfNotExists: Boolean): Unit
+      ignoreIfNotExists: Boolean): Unit = {
+    val db = name.database.getOrElse(currentDb)
+    if (name.database.isDefined || !tempTables.contains(name.table)) {
+      externalCatalog.dropTable(db, name.table, ignoreIfNotExists)
+    } else {
+      tempTables.remove(name.table)
+    }
+  }
 
   /**
    * Return a [[LogicalPlan]] that represents the given table.
@@ -140,17 +192,42 @@ abstract class SessionCatalog(catalog: ExternalCatalog) {
   def lookupRelation(
       currentDb: String,
       name: TableIdentifier,
-      alias: Option[String] = None): LogicalPlan
+      alias: Option[String] = None): LogicalPlan = {
+    val db = name.database.getOrElse(currentDb)
+    val relation =
+      if (name.database.isDefined || !tempTables.contains(name.table)) {
+        val metadata = externalCatalog.getTable(db, name.table)
+        CatalogRelation(db, metadata, alias)
+      } else {
+        tempTables.get(name.table)
+      }
+    val tableWithQualifiers = SubqueryAlias(name.table, relation)
+    // If an alias was specified by the lookup, wrap the plan in a subquery so that
+    // attributes are properly qualified with this alias.
+    alias.map(a => SubqueryAlias(a, tableWithQualifiers)).getOrElse(tableWithQualifiers)
+  }
 
   /**
    * List all tables in the current database, including temporary tables.
    */
-  def listTables(currentDb: String): Seq[TableIdentifier]
+  def listTables(currentDb: String): Seq[TableIdentifier] = {
+    val tablesInCurrentDb = externalCatalog.listTables(currentDb).map { t =>
+      TableIdentifier(t, Some(currentDb))
+    }
+    val _tempTables = tempTables.keys().asScala.map { t => TableIdentifier(t) }
+    tablesInCurrentDb ++ _tempTables
+  }
 
   /**
    * List all matching tables in the current database, including temporary tables.
    */
-  def listTables(currentDb: String, pattern: String): Seq[TableIdentifier]
+  def listTables(currentDb: String, pattern: String): Seq[TableIdentifier] = {
+    val tablesInCurrentDb = externalCatalog.listTables(currentDb, pattern).map { t =>
+      TableIdentifier(t, Some(currentDb))
+    }
+    val _tempTables = tempTables.keys().asScala.map { t => TableIdentifier(t) }
+    tablesInCurrentDb ++ _tempTables
+  }
 
   // ----------------------------------------------------------------------------
   // Partitions
@@ -164,31 +241,52 @@ abstract class SessionCatalog(catalog: ExternalCatalog) {
   // the metastore. For now, partition values of a data source table will be
   // automatically discovered when we load the table.
 
+  /**
+   * Create partitions in an existing table, assuming it exists.
+   * If no database is specified, assume the table is in the current database.
+   */
   def createPartitions(
       currentDb: String,
       tableName: TableIdentifier,
       parts: Seq[CatalogTablePartition],
-      ignoreIfExists: Boolean): Unit
+      ignoreIfExists: Boolean): Unit = {
+    val db = tableName.database.getOrElse(currentDb)
+    externalCatalog.createPartitions(db, tableName.table, parts, ignoreIfExists)
+  }
 
+  /**
+   * Drop partitions from a table, assuming they exist.
+   * If no database is specified, assume the table is in the current database.
+   */
   def dropPartitions(
       currentDb: String,
       tableName: TableIdentifier,
       parts: Seq[TablePartitionSpec],
-      ignoreIfNotExists: Boolean): Unit
+      ignoreIfNotExists: Boolean): Unit = {
+    val db = tableName.database.getOrElse(currentDb)
+    externalCatalog.dropPartitions(db, tableName.table, parts, ignoreIfNotExists)
+  }
 
   /**
    * Override the specs of one or many existing table partitions, assuming they exist.
+   *
    * This assumes index i of `specs` corresponds to index i of `newSpecs`.
+   * If no database is specified, assume the table is in the current database.
    */
   def renamePartitions(
       currentDb: String,
       tableName: TableIdentifier,
       specs: Seq[TablePartitionSpec],
-      newSpecs: Seq[TablePartitionSpec]): Unit
+      newSpecs: Seq[TablePartitionSpec]): Unit = {
+    val db = tableName.database.getOrElse(currentDb)
+    externalCatalog.renamePartitions(db, tableName.table, specs, newSpecs)
+  }
 
   /**
    * Alter one or many table partitions whose specs that match those specified in `parts`,
    * assuming the partitions exist.
+   *
+   * If no database is specified, assume the table is in the current database.
    *
    * Note: If the underlying implementation does not support altering a certain field,
    * this becomes a no-op.
@@ -196,16 +294,33 @@ abstract class SessionCatalog(catalog: ExternalCatalog) {
   def alterPartitions(
       currentDb: String,
       tableName: TableIdentifier,
-      parts: Seq[CatalogTablePartition]): Unit
+      parts: Seq[CatalogTablePartition]): Unit = {
+    val db = tableName.database.getOrElse(currentDb)
+    externalCatalog.alterPartitions(db, tableName.table, parts)
+  }
 
+  /**
+   * Retrieve the metadata of a table partition, assuming it exists.
+   * If no database is specified, assume the table is in the current database.
+   */
   def getPartition(
       currentDb: String,
       tableName: TableIdentifier,
-      spec: TablePartitionSpec): CatalogTablePartition
+      spec: TablePartitionSpec): CatalogTablePartition = {
+    val db = tableName.database.getOrElse(currentDb)
+    externalCatalog.getPartition(db, tableName.table, spec)
+  }
 
+  /**
+   * List all partitions in a table, assuming it exists.
+   * If no database is specified, assume the table is in the current database.
+   */
   def listPartitions(
       currentDb: String,
-      tableName: TableIdentifier): Seq[CatalogTablePartition]
+      tableName: TableIdentifier): Seq[CatalogTablePartition] = {
+    val db = tableName.database.getOrElse(currentDb)
+    externalCatalog.listPartitions(db, tableName.table)
+  }
 
   // ----------------------------------------------------------------------------
   // Functions
@@ -224,16 +339,24 @@ abstract class SessionCatalog(catalog: ExternalCatalog) {
    * Create a metastore function in the database specified in `funcDefinition`.
    * If no such database is specified, create it in the current database.
    */
-  def createFunction(currentDb: String, funcDefinition: CatalogFunction): Unit
+  def createFunction(currentDb: String, funcDefinition: CatalogFunction): Unit = {
+    val db = funcDefinition.name.database.getOrElse(currentDb)
+    val newFuncDefinition = funcDefinition.copy(
+      name = FunctionIdentifier(funcDefinition.name.funcName, Some(db)))
+    externalCatalog.createFunction(db, newFuncDefinition)
+  }
 
   /**
    * Drop a metastore function.
    * If no database is specified, assume the function is in the current database.
    */
-  def dropFunction(currentDb: String, funcName: FunctionIdentifier): Unit
+  def dropFunction(currentDb: String, name: FunctionIdentifier): Unit = {
+    val db = name.database.getOrElse(currentDb)
+    externalCatalog.dropFunction(db, name.funcName)
+  }
 
   /**
-   * Alter a function whose name that matches the one specified in `funcDefinition`.
+   * Alter a metastore function whose name that matches the one specified in `funcDefinition`.
    *
    * If no database is specified in `funcDefinition`, assume the function is in the
    * current database.
@@ -241,7 +364,12 @@ abstract class SessionCatalog(catalog: ExternalCatalog) {
    * Note: If the underlying implementation does not support altering a certain field,
    * this becomes a no-op.
    */
-  def alterFunction(currentDb: String, funcDefinition: CatalogFunction): Unit
+  def alterFunction(currentDb: String, funcDefinition: CatalogFunction): Unit = {
+    val db = funcDefinition.name.database.getOrElse(currentDb)
+    val newFuncDefinition = funcDefinition.copy(
+      name = FunctionIdentifier(funcDefinition.name.funcName, Some(db)))
+    externalCatalog.alterFunction(db, newFuncDefinition)
+  }
 
   // ----------------------------------------------------------------
   // | Methods that interact with temporary and metastore functions |
@@ -251,12 +379,31 @@ abstract class SessionCatalog(catalog: ExternalCatalog) {
    * Create a temporary function.
    * This assumes no database is specified in `funcDefinition`.
    */
-  def createTempFunction(funcDefinition: CatalogFunction): Unit
+  def createTempFunction(
+      funcDefinition: CatalogFunction,
+      ignoreIfExists: Boolean): Unit = {
+    require(funcDefinition.name.database.isEmpty,
+      "attempted to create a temporary function while specifying a database")
+    val name = funcDefinition.name.funcName
+    if (tempFunctions.contains(name) && !ignoreIfExists) {
+      throw new AnalysisException(s"Temporary function '$name' already exists.")
+    }
+    tempFunctions.put(name, funcDefinition)
+  }
 
+  /**
+   * Drop a temporary function.
+   */
   // TODO: The reason that we distinguish dropFunction and dropTempFunction is that
   // Hive has DROP FUNCTION and DROP TEMPORARY FUNCTION. We may want to consolidate
   // dropFunction and dropTempFunction.
-  def dropTempFunction(name: String): Unit
+  def dropTempFunction(name: String, ignoreIfNotExists: Boolean): Unit = {
+    if (!tempFunctions.contains(name) && !ignoreIfNotExists) {
+      throw new AnalysisException(
+        s"Temporary function '$name' cannot be dropped because it does not exist!")
+    }
+    tempFunctions.remove(name)
+  }
 
   /**
    * Rename a function.
@@ -270,7 +417,16 @@ abstract class SessionCatalog(catalog: ExternalCatalog) {
   def renameFunction(
       currentDb: String,
       oldName: FunctionIdentifier,
-      newName: FunctionIdentifier): Unit
+      newName: FunctionIdentifier): Unit = {
+    val db = oldName.database.getOrElse(currentDb)
+    if (oldName.database.isDefined || !tempFunctions.contains(oldName.funcName)) {
+      externalCatalog.renameFunction(db, oldName.funcName, newName.funcName)
+    } else {
+      val func = tempFunctions.remove(oldName.funcName)
+      val newFunc = func.copy(name = func.name.copy(funcName = newName.funcName))
+      tempFunctions.put(newName.funcName, newFunc)
+    }
+  }
 
   /**
    * Retrieve the metadata of an existing function.
@@ -279,11 +435,23 @@ abstract class SessionCatalog(catalog: ExternalCatalog) {
    * If no database is specified, this will first attempt to return a temporary function with
    * the same name, then, if that does not exist, return the function in the current database.
    */
-  def getFunction(currentDb: String, name: FunctionIdentifier): CatalogFunction
+  def getFunction(currentDb: String, name: FunctionIdentifier): CatalogFunction = {
+    val db = name.database.getOrElse(currentDb)
+    if (name.database.isDefined || !tempFunctions.contains(name.funcName)) {
+      externalCatalog.getFunction(db, name.funcName)
+    } else {
+      tempFunctions.get(name.funcName)
+    }
+  }
 
   /**
    * List all matching functions in the current database, including temporary functions.
    */
-  def listFunctions(currentDb: String, pattern: String): Seq[FunctionIdentifier]
+  def listFunctions(currentDb: String, pattern: String): Seq[FunctionIdentifier] = {
+    val functionsInCurrentDb = externalCatalog.listFunctions(currentDb, pattern).map { f =>
+      FunctionIdentifier(f, Some(currentDb))
+    }
+    functionsInCurrentDb ++ tempFunctions.keys.asScala.map { f => FunctionIdentifier(f) }
+  }
 
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -23,7 +23,7 @@ import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
-import org.apache.spark.sql.catalyst.plans.logical.{SubqueryAlias, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, SubqueryAlias}
 
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -465,7 +465,18 @@ class SessionCatalog(externalCatalog: ExternalCatalog) {
     val functionsInCurrentDb = externalCatalog.listFunctions(currentDb, pattern).map { f =>
       FunctionIdentifier(f, Some(currentDb))
     }
-    functionsInCurrentDb ++ tempFunctions.keys.asScala.map { f => FunctionIdentifier(f) }
+    val regex = pattern.replaceAll("\\*", ".*").r
+    val _tempFunctions = tempFunctions.keys().asScala
+      .filter { f => regex.pattern.matcher(f).matches() }
+      .map { f => FunctionIdentifier(f) }
+    functionsInCurrentDb ++ _tempFunctions
+  }
+
+  /**
+   * Return a temporary function. For testing only.
+   */
+  private[catalog] def getTempFunction(name: String): Option[CatalogFunction] = {
+    Option(tempFunctions.get(name))
   }
 
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.catalog
+
+import java.util.concurrent.ConcurrentHashMap
+
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+
+
+/**
+ * An internal catalog that is used by a Spark Session. This internal catalog serves as a
+ * proxy to the underlying metastore (e.g. Hive Metastore) and it also manages temporary
+ * tables and functions of the Spark Session that it belongs to.
+ */
+abstract class SessionCatalog(catalog: ExternalCatalog) {
+  import ExternalCatalog._
+
+  private[this] val tempTables = new ConcurrentHashMap[String, LogicalPlan]
+
+  private[this] val tempFunctions = new ConcurrentHashMap[String, CatalogFunction]
+
+  // --------------------------------------------------------------------------
+  // Databases
+  // All methods in this category interact directly with the underlying catalog.
+  // --------------------------------------------------------------------------
+
+  def createDatabase(dbDefinition: CatalogDatabase, ignoreIfExists: Boolean): Unit
+
+  def dropDatabase(db: String, ignoreIfNotExists: Boolean, cascade: Boolean): Unit
+
+  def alterDatabase(dbDefinition: CatalogDatabase): Unit
+
+  def getDatabase(db: String): CatalogDatabase
+
+  def databaseExists(db: String): Boolean
+
+  def listDatabases(): Seq[String]
+
+  def listDatabases(pattern: String): Seq[String]
+
+  // --------------------------------------------------------------------------
+  // Tables
+  // --------------------------------------------------------------------------
+
+  // --------------------------------------------------------------------------
+  // Tables: Methods for metastore tables.
+  // Methods in this category are only used for metastore tables, which store
+  // metadata in the underlying catalog.
+  // --------------------------------------------------------------------------
+
+  def createTable(db: String, tableDefinition: CatalogTable, ignoreIfExists: Boolean): Unit
+
+  /**
+   * Alters a table whose name matches the one specified in `tableDefinition`,
+   * assuming the table exists.
+   *
+   * Note: If the underlying implementation does not support altering a certain field,
+   * this becomes a no-op.
+   */
+  def alterTable(db: String, tableDefinition: CatalogTable): Unit
+
+  /**
+   * Retrieves the metadata of a table called `table` in the database `db`.
+   */
+  def getTable(db: String, table: String): CatalogTable
+
+  // --------------------------------------------------------------------------
+  // Tables: Methods for metastore tables or temp tables.
+  // --------------------------------------------------------------------------
+
+  /**
+   * Creates a temporary table. If there is already a temporary table having the same name,
+   * the table definition of that table will be updated to the new definition.
+   */
+  // TODO: Should we automatically overwrite the existing temp table?
+  // Postgres and Hive will complain if a temp table is already defined.
+  def createTempTable(tableIdent: TableIdentifier, tableDefinition: LogicalPlan): Unit
+
+  def renameTable(
+      specifiedDB: Option[String],
+      currentDB: String,
+      oldName: String,
+      newName: String): Unit
+
+  /**
+   * Drops a table. If a database name is not provided, this method will drop the table with
+   * the given name from the temporary table name space as well as the table
+   * in the current database. If a database name is provided, this method only drops the table
+   * with the given name from the given database.
+   */
+  // TODO: When a temp table and a table in the current db have the same name, should we
+  // only drop the temp table when a database is not provided (Postgresql's semantic)?
+  def dropTable(
+      tableIdent: TableIdentifier,
+      currentDB: String,
+      ignoreIfNotExists: Boolean): Unit
+
+  /**
+   * Returns a [[LogicalPlan]] representing the requested table. This method is used
+   * when we need to create a query plan for a given table.
+   *
+   * This method is different from `getTable`, which only returns the metadata of the table
+   * in the form of [[CatalogTable]]. The [[LogicalPlan]] returned by this method contains
+   * the metadata of the table in the form of [[CatalogTable]].
+   */
+  def lookupRelation(tableIdent: TableIdentifier, alias: Option[String] = None): LogicalPlan
+
+  def listTables(specifiedDB: Option[String], currentDB: String): Seq[String]
+
+  def listTables(specifiedDB: Option[String], currentDB: String, pattern: String): Seq[String]
+
+  // --------------------------------------------------------------------------
+  // Partitions
+  // All methods in this category interact directly with the underlying catalog.
+  // --------------------------------------------------------------------------
+  // TODO: We need to figure out how these methods interact with our data source tables.
+  // For data source tables, we do not store values of partitioning columns in the metastore.
+  // For now, partition values of a data source table will be automatically discovered
+  // when we load the table.
+
+  def createPartitions(
+      db: String,
+      table: String,
+      parts: Seq[CatalogTablePartition],
+      ignoreIfExists: Boolean): Unit
+
+  def dropPartitions(
+      db: String,
+      table: String,
+      parts: Seq[TablePartitionSpec],
+      ignoreIfNotExists: Boolean): Unit
+
+  /**
+   * Override the specs of one or many existing table partitions, assuming they exist.
+   * This assumes index i of `specs` corresponds to index i of `newSpecs`.
+   */
+  def renamePartitions(
+      db: String,
+      table: String,
+      specs: Seq[TablePartitionSpec],
+      newSpecs: Seq[TablePartitionSpec]): Unit
+
+  /**
+   * Alter one or many table partitions whose specs that match those specified in `parts`,
+   * assuming the partitions exist.
+   *
+   * Note: If the underlying implementation does not support altering a certain field,
+   * this becomes a no-op.
+   */
+  def alterPartitions(
+      db: String,
+      table: String,
+      parts: Seq[CatalogTablePartition]): Unit
+
+  def getPartition(db: String, table: String, spec: TablePartitionSpec): CatalogTablePartition
+
+  def listPartitions(db: String, table: String): Seq[CatalogTablePartition]
+
+  // --------------------------------------------------------------------------
+  // Functions
+  // --------------------------------------------------------------------------
+
+  // --------------------------------------------------------------------------
+  // Functions: Methods for metastore functions (permanent UDFs).
+  // --------------------------------------------------------------------------
+
+  def createFunction(db: String, funcDefinition: CatalogFunction): Unit
+
+  /**
+   * Drops a permanent function with the given name from the given database.
+   */
+  def dropFunction(db: String, funcName: String): Unit
+
+  // --------------------------------------------------------------------------
+  // Functions: Methods for metastore functions (permanent UDFs) or temp functions.
+  // --------------------------------------------------------------------------
+
+  def createTempFunction(funcDefinition: CatalogFunction): Unit
+
+  /**
+   * Drops a temporary function with the given name.
+   */
+  // TODO: The reason that we distinguish dropFunction and dropTempFunction is that
+  // Hive has DROP FUNCTION and DROP TEMPORARY FUNCTION. We may want to consolidate
+  // dropFunction and dropTempFunction.
+  def dropTempFunction(funcName: String): Unit
+
+  def renameFunction(
+      specifiedDB: Option[String],
+      currentDB: String,
+      oldName: String,
+      newName: String): Unit
+
+  /**
+   * Alter a function whose name that matches the one specified in `funcDefinition`,
+   * assuming the function exists.
+   *
+   * Note: If the underlying implementation does not support altering a certain field,
+   * this becomes a no-op.
+   */
+  def alterFunction(
+      specifiedDB: Option[String],
+      currentDB: String,
+      funcDefinition: CatalogFunction): Unit
+
+  def getFunction(
+      specifiedDB: Option[String],
+      currentDB: String,
+      funcName: String): CatalogFunction
+
+  def listFunctions(
+      specifiedDB: Option[String],
+      currentDB: String,
+      pattern: String): Seq[String]
+
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -458,6 +458,8 @@ class SessionCatalog(externalCatalog: ExternalCatalog) {
     }
   }
 
+  // TODO: implement lookupFunction that returns something from the registry itself
+
   /**
    * List all matching functions in the current database, including temporary functions.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -167,6 +167,7 @@ abstract class ExternalCatalog {
  * @param name name of the function
  * @param className fully qualified class name, e.g. "org.apache.spark.util.MyFunc"
  */
+// TODO: use FunctionIdentifier here.
 case class CatalogFunction(name: String, className: String)
 
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -21,6 +21,8 @@ import javax.annotation.Nullable
 
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LogicalPlan}
 
 
 /**
@@ -271,4 +273,21 @@ object ExternalCatalog {
    * Specifications of a table partition. Mapping column name to column value.
    */
   type TablePartitionSpec = Map[String, String]
+}
+
+
+/**
+ * A [[LogicalPlan]] that wraps [[CatalogTable]].
+ */
+case class CatalogRelation(
+    db: String,
+    metadata: CatalogTable,
+    alias: Option[String])
+  extends LeafNode {
+
+  // TODO: implement this
+  override def output: Seq[Attribute] = Seq.empty
+
+  require(metadata.name.database == Some(db),
+    "provided database does not much the one specified in the table definition")
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -211,6 +211,7 @@ case class CatalogTablePartition(
  * future once we have a better understanding of how we want to handle skewed columns.
  */
 case class CatalogTable(
+    // TODO: just use TableIdentifier here
     specifiedDatabase: Option[String],
     name: String,
     tableType: CatalogTableType,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -212,7 +212,6 @@ case class CatalogTablePartition(
  * future once we have a better understanding of how we want to handle skewed columns.
  */
 case class CatalogTable(
-    // TODO: just use TableIdentifier here
     specifiedDatabase: Option[String],
     name: String,
     tableType: CatalogTableType,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -168,8 +168,7 @@ abstract class ExternalCatalog {
  * @param name name of the function
  * @param className fully qualified class name, e.g. "org.apache.spark.util.MyFunc"
  */
-// TODO: use FunctionIdentifier here.
-case class CatalogFunction(name: String, className: String)
+case class CatalogFunction(name: FunctionIdentifier, className: String)
 
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.catalyst.catalog
 import javax.annotation.Nullable
 
 import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
 
 
 /**
@@ -212,8 +213,7 @@ case class CatalogTablePartition(
  * future once we have a better understanding of how we want to handle skewed columns.
  */
 case class CatalogTable(
-    specifiedDatabase: Option[String],
-    name: String,
+    name: TableIdentifier,
     tableType: CatalogTableType,
     storage: CatalogStorageFormat,
     schema: Seq[CatalogColumn],
@@ -227,12 +227,12 @@ case class CatalogTable(
     viewText: Option[String] = None) {
 
   /** Return the database this table was specified to belong to, assuming it exists. */
-  def database: String = specifiedDatabase.getOrElse {
+  def database: String = name.database.getOrElse {
     throw new AnalysisException(s"table $name did not specify database")
   }
 
   /** Return the fully qualified name of this table, assuming the database was specified. */
-  def qualifiedName: String = s"$database.$name"
+  def qualifiedName: String = name.unquotedString
 
   /** Syntactic sugar to update a field in `storage`. */
   def withNewStorage(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -282,7 +282,7 @@ object ExternalCatalog {
 case class CatalogRelation(
     db: String,
     metadata: CatalogTable,
-    alias: Option[String])
+    alias: Option[String] = None)
   extends LeafNode {
 
   // TODO: implement this

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/identifiers.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/identifiers.scala
@@ -45,7 +45,7 @@ private[sql] case class TableIdentifier(
 }
 
 private[sql] object TableIdentifier {
-  def apply(tableName: String): TableIdentifier = TableIdentifier(tableName)
+  def apply(tableName: String): TableIdentifier = new TableIdentifier(tableName)
 }
 
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/identifiers.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/identifiers.scala
@@ -24,7 +24,8 @@ package org.apache.spark.sql.catalyst
  * Format (unquoted): "name" or "db.name"
  * Format (quoted): "`name`" or "`db`.`name`"
  */
-private[sql] abstract class IdentifierWithDatabase(name: String) {
+sealed trait IdentifierWithDatabase {
+  val name: String
   def database: Option[String]
   def quotedString: String = database.map(db => s"`$db`.`$name`").getOrElse(s"`$name`")
   def unquotedString: String = database.map(db => s"$db.$name").getOrElse(name)
@@ -36,15 +37,16 @@ private[sql] abstract class IdentifierWithDatabase(name: String) {
  * Identifies a table in a database.
  * If `database` is not defined, the current database is used.
  */
-private[sql] case class TableIdentifier(
-    table: String,
-    database: Option[String])
-  extends IdentifierWithDatabase(table) {
+case class TableIdentifier(table: String, database: Option[String])
+  extends IdentifierWithDatabase {
+
+  override val name: String = table
 
   def this(name: String) = this(name, None)
+
 }
 
-private[sql] object TableIdentifier {
+object TableIdentifier {
   def apply(tableName: String): TableIdentifier = new TableIdentifier(tableName)
 }
 
@@ -53,14 +55,14 @@ private[sql] object TableIdentifier {
  * Identifies a function in a database.
  * If `database` is not defined, the current database is used.
  */
-private[sql] case class FunctionIdentifier(
-    funcName: String,
-    database: Option[String])
-  extends IdentifierWithDatabase(funcName) {
+case class FunctionIdentifier(funcName: String, database: Option[String])
+  extends IdentifierWithDatabase {
+
+  override val name: String = funcName
 
   def this(name: String) = this(name, None)
 }
 
-private[sql] object FunctionIdentifier {
+object FunctionIdentifier {
   def apply(funcName: String): FunctionIdentifier = new FunctionIdentifier(funcName)
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/CatalogTestCases.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/CatalogTestCases.scala
@@ -342,7 +342,7 @@ abstract class CatalogTestCases extends SparkFunSuite with BeforeAndAfterEach {
 
   test("alter partitions") {
     val catalog = newBasicCatalog()
-    try{
+    try {
       // Note: Before altering table partitions in Hive, you *must* set the current database
       // to the one that contains the table of interest. Otherwise you will end up with the
       // most helpful error message ever: "Unable to alter partition. alter is not possible."

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/CatalogTestCases.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/CatalogTestCases.scala
@@ -22,6 +22,7 @@ import org.scalatest.BeforeAndAfterEach
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
+import org.apache.spark.util.Utils
 
 
 /**
@@ -30,23 +31,10 @@ import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
  * Implementations of the [[ExternalCatalog]] interface can create test suites by extending this.
  */
 abstract class CatalogTestCases extends SparkFunSuite with BeforeAndAfterEach {
-  private lazy val storageFormat = CatalogStorageFormat(
-    locationUri = None,
-    inputFormat = Some(tableInputFormat),
-    outputFormat = Some(tableOutputFormat),
-    serde = None,
-    serdeProperties = Map.empty)
-  private lazy val part1 = CatalogTablePartition(Map("a" -> "1", "b" -> "2"), storageFormat)
-  private lazy val part2 = CatalogTablePartition(Map("a" -> "3", "b" -> "4"), storageFormat)
-  private lazy val part3 = CatalogTablePartition(Map("a" -> "5", "b" -> "6"), storageFormat)
-  private val funcClass = "org.apache.spark.myFunc"
+  protected val utils: CatalogTestUtils
+  import utils._
 
-  // Things subclasses should override
-  protected val tableInputFormat: String = "org.apache.park.serde.MyInputFormat"
-  protected val tableOutputFormat: String = "org.apache.park.serde.MyOutputFormat"
-  protected def newUriForDatabase(): String = "uri"
   protected def resetState(): Unit = { }
-  protected def newEmptyCatalog(): ExternalCatalog
 
   // Clear all state after each test
   override def afterEach(): Unit = {
@@ -56,63 +44,6 @@ abstract class CatalogTestCases extends SparkFunSuite with BeforeAndAfterEach {
       super.afterEach()
     }
   }
-
-  /**
-   * Creates a basic catalog, with the following structure:
-   *
-   * default
-   * db1
-   * db2
-   *   - tbl1
-   *   - tbl2
-   *     - part1
-   *     - part2
-   *   - func1
-   */
-  private def newBasicCatalog(): ExternalCatalog = {
-    val catalog = newEmptyCatalog()
-    // When testing against a real catalog, the default database may already exist
-    catalog.createDatabase(newDb("default"), ignoreIfExists = true)
-    catalog.createDatabase(newDb("db1"), ignoreIfExists = false)
-    catalog.createDatabase(newDb("db2"), ignoreIfExists = false)
-    catalog.createTable("db2", newTable("tbl1", "db2"), ignoreIfExists = false)
-    catalog.createTable("db2", newTable("tbl2", "db2"), ignoreIfExists = false)
-    catalog.createPartitions("db2", "tbl2", Seq(part1, part2), ignoreIfExists = false)
-    catalog.createFunction("db2", newFunc("func1", Some("db2")))
-    catalog
-  }
-
-  private def newFunc(): CatalogFunction = newFunc("funcName")
-
-  private def newDb(name: String): CatalogDatabase = {
-    CatalogDatabase(name, name + " description", newUriForDatabase(), Map.empty)
-  }
-
-  private def newTable(name: String, db: String): CatalogTable = {
-    CatalogTable(
-      name = TableIdentifier(name, Some(db)),
-      tableType = CatalogTableType.EXTERNAL_TABLE,
-      storage = storageFormat,
-      schema = Seq(CatalogColumn("col1", "int"), CatalogColumn("col2", "string")),
-      partitionColumns = Seq(CatalogColumn("a", "int"), CatalogColumn("b", "string")))
-  }
-
-  private def newFunc(name: String, database: Option[String] = None): CatalogFunction = {
-    CatalogFunction(FunctionIdentifier(name, database), funcClass)
-  }
-
-  /**
-   * Whether the catalog's table partitions equal the ones given.
-   * Note: Hive sets some random serde things, so we just compare the specs here.
-   */
-  private def catalogPartitionsEqual(
-      catalog: ExternalCatalog,
-      db: String,
-      table: String,
-      parts: Seq[CatalogTablePartition]): Boolean = {
-    catalog.listPartitions(db, table).map(_.spec).toSet == parts.map(_.spec).toSet
-  }
-
 
   // --------------------------------------------------------------------------
   // Databases
@@ -553,6 +484,89 @@ abstract class CatalogTestCases extends SparkFunSuite with BeforeAndAfterEach {
     catalog.createFunction("db2", newFunc("not_me"))
     assert(catalog.listFunctions("db2", "*").toSet == Set("func1", "func2", "not_me"))
     assert(catalog.listFunctions("db2", "func*").toSet == Set("func1", "func2"))
+  }
+
+}
+
+
+/**
+ * A collection of utility fields and methods for tests related to the [[ExternalCatalog]].
+ */
+abstract class CatalogTestUtils {
+
+  // Unimplemented methods
+  val tableInputFormat: String
+  val tableOutputFormat: String
+  def newEmptyCatalog(): ExternalCatalog
+
+  // These fields must be lazy because they rely on fields that are not implemented yet
+  lazy val storageFormat = CatalogStorageFormat(
+    locationUri = None,
+    inputFormat = Some(tableInputFormat),
+    outputFormat = Some(tableOutputFormat),
+    serde = None,
+    serdeProperties = Map.empty)
+  lazy val part1 = CatalogTablePartition(Map("a" -> "1", "b" -> "2"), storageFormat)
+  lazy val part2 = CatalogTablePartition(Map("a" -> "3", "b" -> "4"), storageFormat)
+  lazy val part3 = CatalogTablePartition(Map("a" -> "5", "b" -> "6"), storageFormat)
+  lazy val funcClass = "org.apache.spark.myFunc"
+
+  /**
+   * Creates a basic catalog, with the following structure:
+   *
+   * default
+   * db1
+   * db2
+   *   - tbl1
+   *   - tbl2
+   *     - part1
+   *     - part2
+   *   - func1
+   */
+  def newBasicCatalog(): ExternalCatalog = {
+    val catalog = newEmptyCatalog()
+    // When testing against a real catalog, the default database may already exist
+    catalog.createDatabase(newDb("default"), ignoreIfExists = true)
+    catalog.createDatabase(newDb("db1"), ignoreIfExists = false)
+    catalog.createDatabase(newDb("db2"), ignoreIfExists = false)
+    catalog.createTable("db2", newTable("tbl1", "db2"), ignoreIfExists = false)
+    catalog.createTable("db2", newTable("tbl2", "db2"), ignoreIfExists = false)
+    catalog.createPartitions("db2", "tbl2", Seq(part1, part2), ignoreIfExists = false)
+    catalog.createFunction("db2", newFunc("func1", Some("db2")))
+    catalog
+  }
+
+  def newFunc(): CatalogFunction = newFunc("funcName")
+
+  def newUriForDatabase(): String = Utils.createTempDir().getAbsolutePath
+
+  def newDb(name: String): CatalogDatabase = {
+    CatalogDatabase(name, name + " description", newUriForDatabase(), Map.empty)
+  }
+
+  def newTable(name: String, db: String): CatalogTable = {
+    CatalogTable(
+      name = TableIdentifier(name, Some(db)),
+      tableType = CatalogTableType.EXTERNAL_TABLE,
+      storage = storageFormat,
+      schema = Seq(CatalogColumn("col1", "int"), CatalogColumn("col2", "string")),
+      partitionColumns = Seq(CatalogColumn("a", "int"), CatalogColumn("b", "string")))
+  }
+
+  def newFunc(name: String, database: Option[String] = None): CatalogFunction = {
+    CatalogFunction(FunctionIdentifier(name, database), funcClass)
+  }
+
+  /**
+   * Whether the catalog's table partitions equal the ones given.
+   * Note: Hive sets some random serde things, so we just compare the specs here.
+   */
+  def catalogPartitionsEqual(
+      catalog: ExternalCatalog,
+      db: String,
+      table: String,
+      parts: Seq[CatalogTablePartition]): Boolean = {
+    catalog.listPartitions(db, table).map(_.spec).toSet == parts.map(_.spec).toSet
   }
 
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/CatalogTestCases.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/CatalogTestCases.scala
@@ -544,9 +544,11 @@ abstract class CatalogTestUtils {
     CatalogDatabase(name, name + " description", newUriForDatabase(), Map.empty)
   }
 
-  def newTable(name: String, db: String): CatalogTable = {
+  def newTable(name: String, db: String): CatalogTable = newTable(name, Some(db))
+
+  def newTable(name: String, database: Option[String] = None): CatalogTable = {
     CatalogTable(
-      name = TableIdentifier(name, Some(db)),
+      name = TableIdentifier(name, database),
       tableType = CatalogTableType.EXTERNAL_TABLE,
       storage = storageFormat,
       schema = Seq(CatalogColumn("col1", "int"), CatalogColumn("col2", "string")),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/CatalogTestCases.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/CatalogTestCases.scala
@@ -78,7 +78,7 @@ abstract class CatalogTestCases extends SparkFunSuite with BeforeAndAfterEach {
     catalog.createTable("db2", newTable("tbl1", "db2"), ignoreIfExists = false)
     catalog.createTable("db2", newTable("tbl2", "db2"), ignoreIfExists = false)
     catalog.createPartitions("db2", "tbl2", Seq(part1, part2), ignoreIfExists = false)
-    catalog.createFunction("db2", newFunc("func1"))
+    catalog.createFunction("db2", newFunc("func1", Some("db2")))
     catalog
   }
 
@@ -97,8 +97,8 @@ abstract class CatalogTestCases extends SparkFunSuite with BeforeAndAfterEach {
       partitionColumns = Seq(CatalogColumn("a", "int"), CatalogColumn("b", "string")))
   }
 
-  private def newFunc(name: String): CatalogFunction = {
-    CatalogFunction(FunctionIdentifier(name, database = None), funcClass)
+  private def newFunc(name: String, database: Option[String] = None): CatalogFunction = {
+    CatalogFunction(FunctionIdentifier(name, database), funcClass)
   }
 
   /**

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/CatalogTestCases.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/CatalogTestCases.scala
@@ -21,6 +21,7 @@ import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.TableIdentifier
 
 
 /**
@@ -89,8 +90,7 @@ abstract class CatalogTestCases extends SparkFunSuite with BeforeAndAfterEach {
 
   private def newTable(name: String, db: String): CatalogTable = {
     CatalogTable(
-      specifiedDatabase = Some(db),
-      name = name,
+      name = TableIdentifier(name, Some(db)),
       tableType = CatalogTableType.EXTERNAL_TABLE,
       storage = storageFormat,
       schema = Seq(CatalogColumn("col1", "int"), CatalogColumn("col2", "string")),
@@ -277,7 +277,7 @@ abstract class CatalogTestCases extends SparkFunSuite with BeforeAndAfterEach {
   }
 
   test("get table") {
-    assert(newBasicCatalog().getTable("db2", "tbl1").name == "tbl1")
+    assert(newBasicCatalog().getTable("db2", "tbl1").name.table == "tbl1")
   }
 
   test("get table when database/table does not exist") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -18,12 +18,356 @@
 package org.apache.spark.sql.catalyst.catalog
 
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
+import org.apache.spark.sql.catalyst.plans.logical.{Range, SubqueryAlias}
 
 
+/**
+ * Tests for [[SessionCatalog]] that assume that [[InMemoryCatalog]] is correctly implemented.
+ *
+ * Note: many of the methods here are very similar to the ones in [[CatalogTestCases]].
+ * This is because [[SessionCatalog]] and [[ExternalCatalog]] share many similar method
+ * signatures but do not extend a common parent. This is largely by design but
+ * unfortunately leads to very similar test code in two places.
+ */
 class SessionCatalogSuite extends SparkFunSuite {
+  private val utils = new CatalogTestUtils {
+    override val tableInputFormat: String = "com.fruit.eyephone.CameraInputFormat"
+    override val tableOutputFormat: String = "com.fruit.eyephone.CameraOutputFormat"
+    override def newEmptyCatalog(): ExternalCatalog = new InMemoryCatalog
+  }
 
-  test("dummy") {
+  import utils._
 
+  // --------------------------------------------------------------------------
+  // Databases
+  // --------------------------------------------------------------------------
+
+  test("basic create and list databases") {
+    val catalog = new SessionCatalog(newEmptyCatalog())
+    catalog.createDatabase(newDb("default"), ignoreIfExists = true)
+    assert(catalog.databaseExists("default"))
+    assert(!catalog.databaseExists("testing"))
+    assert(!catalog.databaseExists("testing2"))
+    catalog.createDatabase(newDb("testing"), ignoreIfExists = false)
+    assert(catalog.databaseExists("testing"))
+    assert(catalog.listDatabases().toSet == Set("default", "testing"))
+    catalog.createDatabase(newDb("testing2"), ignoreIfExists = false)
+    assert(catalog.listDatabases().toSet == Set("default", "testing", "testing2"))
+    assert(catalog.databaseExists("testing2"))
+    assert(!catalog.databaseExists("does_not_exist"))
+  }
+
+  test("get database when a database exists") {
+    val catalog = new SessionCatalog(newBasicCatalog())
+    val db1 = catalog.getDatabase("db1")
+    assert(db1.name == "db1")
+    assert(db1.description.contains("db1"))
+  }
+
+  test("get database should throw exception when the database does not exist") {
+    val catalog = new SessionCatalog(newBasicCatalog())
+    intercept[AnalysisException] { catalog.getDatabase("db_that_does_not_exist") }
+  }
+
+  test("list databases without pattern") {
+    val catalog = new SessionCatalog(newBasicCatalog())
+    assert(catalog.listDatabases().toSet == Set("default", "db1", "db2"))
+  }
+
+  test("list databases with pattern") {
+    val catalog = new SessionCatalog(newBasicCatalog())
+    assert(catalog.listDatabases("db").toSet == Set.empty)
+    assert(catalog.listDatabases("db*").toSet == Set("db1", "db2"))
+    assert(catalog.listDatabases("*1").toSet == Set("db1"))
+    assert(catalog.listDatabases("db2").toSet == Set("db2"))
+  }
+
+  test("drop database") {
+    val catalog = new SessionCatalog(newBasicCatalog())
+    catalog.dropDatabase("db1", ignoreIfNotExists = false, cascade = false)
+    assert(catalog.listDatabases().toSet == Set("default", "db2"))
+  }
+
+  test("drop database when the database is not empty") {
+    // Throw exception if there are functions left
+    val externalCatalog1 = newBasicCatalog()
+    val sessionCatalog1 = new SessionCatalog(externalCatalog1)
+    externalCatalog1.dropTable("db2", "tbl1", ignoreIfNotExists = false)
+    externalCatalog1.dropTable("db2", "tbl2", ignoreIfNotExists = false)
+    intercept[AnalysisException] {
+      sessionCatalog1.dropDatabase("db2", ignoreIfNotExists = false, cascade = false)
+    }
+
+    // Throw exception if there are tables left
+    val externalCatalog2 = newBasicCatalog()
+    val sessionCatalog2 = new SessionCatalog(externalCatalog2)
+    externalCatalog2.dropFunction("db2", "func1")
+    intercept[AnalysisException] {
+      sessionCatalog2.dropDatabase("db2", ignoreIfNotExists = false, cascade = false)
+    }
+
+    // When cascade is true, it should drop them
+    val externalCatalog3 = newBasicCatalog()
+    val sessionCatalog3 = new SessionCatalog(externalCatalog3)
+    externalCatalog3.dropDatabase("db2", ignoreIfNotExists = false, cascade = true)
+    assert(sessionCatalog3.listDatabases().toSet == Set("default", "db1"))
+  }
+
+  test("drop database when the database does not exist") {
+    val catalog = new SessionCatalog(newBasicCatalog())
+    intercept[AnalysisException] {
+      catalog.dropDatabase("db_that_does_not_exist", ignoreIfNotExists = false, cascade = false)
+    }
+    catalog.dropDatabase("db_that_does_not_exist", ignoreIfNotExists = true, cascade = false)
+  }
+
+  test("alter database") {
+    val catalog = new SessionCatalog(newBasicCatalog())
+    val db1 = catalog.getDatabase("db1")
+    // Note: alter properties here because Hive does not support altering other fields
+    catalog.alterDatabase(db1.copy(properties = Map("k" -> "v3", "good" -> "true")))
+    val newDb1 = catalog.getDatabase("db1")
+    assert(db1.properties.isEmpty)
+    assert(newDb1.properties.size == 2)
+    assert(newDb1.properties.get("k") == Some("v3"))
+    assert(newDb1.properties.get("good") == Some("true"))
+  }
+
+  test("alter database should throw exception when the database does not exist") {
+    val catalog = new SessionCatalog(newBasicCatalog())
+    intercept[AnalysisException] {
+      catalog.alterDatabase(newDb("does_not_exist"))
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Tables
+  // --------------------------------------------------------------------------
+
+  test("create temporary table") {
+    val catalog = new SessionCatalog(newBasicCatalog())
+    val tempTable1 = Range(1, 10, 1, 10, Seq())
+    val tempTable2 = Range(1, 20, 2, 10, Seq())
+    catalog.createTempTable("tbl1", tempTable1, ignoreIfExists = false)
+    catalog.createTempTable("tbl2", tempTable2, ignoreIfExists = false)
+    assert(catalog.getTempTable("tbl1") == Some(tempTable1))
+    assert(catalog.getTempTable("tbl2") == Some(tempTable2))
+    assert(catalog.getTempTable("tbl3") == None)
+    // Temporary table already exists
+    intercept[AnalysisException] {
+      catalog.createTempTable("tbl1", tempTable1, ignoreIfExists = false)
+    }
+    // Temporary table already exists but we override it
+    catalog.createTempTable("tbl1", tempTable2, ignoreIfExists = true)
+    assert(catalog.getTempTable("tbl1") == Some(tempTable2))
+  }
+
+  test("drop table") {
+    val externalCatalog = newBasicCatalog()
+    val sessionCatalog = new SessionCatalog(externalCatalog)
+    assert(externalCatalog.listTables("db2").toSet == Set("tbl1", "tbl2"))
+    sessionCatalog.dropTable("db2", TableIdentifier("tbl1"), ignoreIfNotExists = false)
+    assert(externalCatalog.listTables("db2").toSet == Set("tbl2"))
+    sessionCatalog.dropTable(
+      "db_not_read", TableIdentifier("tbl2", Some("db2")), ignoreIfNotExists = false)
+    assert(externalCatalog.listTables("db2").isEmpty)
+  }
+
+  test("drop table when database/table does not exist") {
+    val catalog = new SessionCatalog(newBasicCatalog())
+    // Should always throw exception when the database does not exist
+    intercept[AnalysisException] {
+      catalog.dropTable("unknown_db", TableIdentifier("unknown_table"), ignoreIfNotExists = false)
+    }
+    intercept[AnalysisException] {
+      catalog.dropTable("unknown_db", TableIdentifier("unknown_table"), ignoreIfNotExists = true)
+    }
+
+    // Should throw exception when the table does not exist, if ignoreIfNotExists is false
+    intercept[AnalysisException] {
+      catalog.dropTable("db2", TableIdentifier("unknown_table"), ignoreIfNotExists = false)
+    }
+    catalog.dropTable("db2", TableIdentifier("unknown_table"), ignoreIfNotExists = true)
+  }
+
+  test("drop temp table") {
+    val externalCatalog = newBasicCatalog()
+    val sessionCatalog = new SessionCatalog(externalCatalog)
+    val tempTable = Range(1, 10, 2, 10, Seq())
+    sessionCatalog.createTempTable("tbl1", tempTable, ignoreIfExists = false)
+    assert(sessionCatalog.getTempTable("tbl1") == Some(tempTable))
+    assert(externalCatalog.listTables("db2").toSet == Set("tbl1", "tbl2"))
+    // If database is not specified, temp table should be dropped first
+    sessionCatalog.dropTable("db_not_read", TableIdentifier("tbl1"), ignoreIfNotExists = false)
+    assert(sessionCatalog.getTempTable("tbl1") == None)
+    assert(externalCatalog.listTables("db2").toSet == Set("tbl1", "tbl2"))
+    // If database is specified, temp tables are never dropped
+    sessionCatalog.createTempTable("tbl1", tempTable, ignoreIfExists = false)
+    sessionCatalog.dropTable(
+      "db_not_read", TableIdentifier("tbl1", Some("db2")), ignoreIfNotExists = false)
+    assert(sessionCatalog.getTempTable("tbl1") == Some(tempTable))
+    assert(externalCatalog.listTables("db2").toSet == Set("tbl2"))
+  }
+
+  test("rename table") {
+    val externalCatalog = newBasicCatalog()
+    val sessionCatalog = new SessionCatalog(externalCatalog)
+    assert(externalCatalog.listTables("db2").toSet == Set("tbl1", "tbl2"))
+    sessionCatalog.renameTable("db2", TableIdentifier("tbl1"), TableIdentifier("tblone"))
+    assert(externalCatalog.listTables("db2").toSet == Set("tblone", "tbl2"))
+    sessionCatalog.renameTable(
+      "db_not_read", TableIdentifier("tbl2", Some("db2")), TableIdentifier("tbltwo", Some("db2")))
+    assert(externalCatalog.listTables("db2").toSet == Set("tblone", "tbltwo"))
+  }
+
+  test("rename table when database/table does not exist") {
+    val catalog = new SessionCatalog(newBasicCatalog())
+    intercept[AnalysisException] {
+      catalog.renameTable(
+        "unknown_db", TableIdentifier("unknown_table"), TableIdentifier("unknown_table"))
+    }
+    intercept[AnalysisException] {
+      catalog.renameTable(
+        "db2", TableIdentifier("unknown_table"), TableIdentifier("unknown_table"))
+    }
+    // Renaming "db2.tblone" to "db1.tblones" should fail because databases don't match
+    intercept[AnalysisException] {
+      catalog.renameTable(
+        "db_not_read", TableIdentifier("tblone", Some("db2")), TableIdentifier("x", Some("db1")))
+    }
+  }
+
+  test("rename temp table") {
+    val externalCatalog = newBasicCatalog()
+    val sessionCatalog = new SessionCatalog(externalCatalog)
+    val tempTable = Range(1, 10, 2, 10, Seq())
+    sessionCatalog.createTempTable("tbl1", tempTable, ignoreIfExists = false)
+    assert(sessionCatalog.getTempTable("tbl1") == Some(tempTable))
+    assert(externalCatalog.listTables("db2").toSet == Set("tbl1", "tbl2"))
+    // If database is not specified, temp table should be renamed first
+    sessionCatalog.renameTable("db_not_read", TableIdentifier("tbl1"), TableIdentifier("tbl3"))
+    assert(sessionCatalog.getTempTable("tbl1") == None)
+    assert(sessionCatalog.getTempTable("tbl3") == Some(tempTable))
+    assert(externalCatalog.listTables("db2").toSet == Set("tbl1", "tbl2"))
+    // If database is specified, temp tables are never renamed
+    sessionCatalog.renameTable(
+      "db_not_read", TableIdentifier("tbl2", Some("db2")), TableIdentifier("tbl4", Some("db2")))
+    assert(sessionCatalog.getTempTable("tbl3") == Some(tempTable))
+    assert(sessionCatalog.getTempTable("tbl4") == None)
+    assert(externalCatalog.listTables("db2").toSet == Set("tbl1", "tbl4"))
+  }
+
+  test("alter table") {
+    val externalCatalog = newBasicCatalog()
+    val sessionCatalog = new SessionCatalog(externalCatalog)
+    val tbl1 = externalCatalog.getTable("db2", "tbl1")
+    sessionCatalog.alterTable("db2", tbl1.copy(properties = Map("toh" -> "frem")))
+    val newTbl1 = externalCatalog.getTable("db2", "tbl1")
+    assert(!tbl1.properties.contains("toh"))
+    assert(newTbl1.properties.size == tbl1.properties.size + 1)
+    assert(newTbl1.properties.get("toh") == Some("frem"))
+  }
+
+  test("alter table when database/table does not exist") {
+    val catalog = new SessionCatalog(newBasicCatalog())
+    intercept[AnalysisException] {
+      catalog.alterTable("unknown_db", newTable("tbl1", "unknown_db"))
+    }
+    intercept[AnalysisException] {
+      catalog.alterTable("db2", newTable("unknown_table", "db2"))
+    }
+  }
+
+  test("get table") {
+    val externalCatalog = newBasicCatalog()
+    val sessionCatalog = new SessionCatalog(externalCatalog)
+    assert(sessionCatalog.getTable("db2", TableIdentifier("tbl1"))
+      == externalCatalog.getTable("db2", "tbl1"))
+    assert(sessionCatalog.getTable("db_not_read", TableIdentifier("tbl1", Some("db2")))
+      == externalCatalog.getTable("db2", "tbl1"))
+  }
+
+  test("get table when database/table does not exist") {
+    val catalog = new SessionCatalog(newBasicCatalog())
+    intercept[AnalysisException] {
+      catalog.getTable("unknown_db", TableIdentifier("unknown_table"))
+    }
+    intercept[AnalysisException] {
+      catalog.getTable("db2", TableIdentifier("unknown_table"))
+    }
+  }
+
+  test("lookup table relation") {
+    val externalCatalog = newBasicCatalog()
+    val sessionCatalog = new SessionCatalog(externalCatalog)
+    val tempTable1 = Range(1, 10, 1, 10, Seq())
+    sessionCatalog.createTempTable("tbl1", tempTable1, ignoreIfExists = false)
+    val metastoreTable1 = externalCatalog.getTable("db2", "tbl1")
+    // If we explicitly specify the database, we'll look up the relation in that database
+    assert(sessionCatalog.lookupRelation("db_not_read", TableIdentifier("tbl1", Some("db2")))
+      == SubqueryAlias("tbl1", CatalogRelation("db2", metastoreTable1)))
+    // Otherwise, we'll first look up a temporary table with the same name
+    assert(sessionCatalog.lookupRelation("db2", TableIdentifier("tbl1"))
+      == SubqueryAlias("tbl1", tempTable1))
+    // Then, if that does not exist, look up the relation in the current database
+    sessionCatalog.dropTable("db_not_read", TableIdentifier("tbl1"), ignoreIfNotExists = false)
+    assert(sessionCatalog.lookupRelation("db2", TableIdentifier("tbl1"))
+      == SubqueryAlias("tbl1", CatalogRelation("db2", metastoreTable1)))
+  }
+
+  test("lookup table relation with alias") {
+    val externalCatalog = newBasicCatalog()
+    val sessionCatalog = new SessionCatalog(externalCatalog)
+    val alias = "monster"
+    val table1 = externalCatalog.getTable("db2", "tbl1")
+    val withoutAlias = SubqueryAlias("tbl1", CatalogRelation("db2", table1))
+    val withAlias =
+      SubqueryAlias(alias,
+        SubqueryAlias("tbl1",
+          CatalogRelation("db2", table1, Some(alias))))
+    assert(sessionCatalog.lookupRelation(
+      "db_not_read", TableIdentifier("tbl1", Some("db2")), alias = None) == withoutAlias)
+    assert(sessionCatalog.lookupRelation(
+      "db_not_read", TableIdentifier("tbl1", Some("db2")), alias = Some(alias)) == withAlias)
+  }
+
+  test("list tables without pattern") {
+    val catalog = new SessionCatalog(newBasicCatalog())
+    val tempTable = Range(1, 10, 2, 10, Seq())
+    catalog.createTempTable("tbl1", tempTable, ignoreIfExists = false)
+    catalog.createTempTable("tbl4", tempTable, ignoreIfExists = false)
+    assert(catalog.listTables("db1").toSet ==
+      Set(TableIdentifier("tbl1"), TableIdentifier("tbl4")))
+    assert(catalog.listTables("db2").toSet ==
+      Set(TableIdentifier("tbl1"),
+        TableIdentifier("tbl4"),
+        TableIdentifier("tbl1", Some("db2")),
+        TableIdentifier("tbl2", Some("db2"))))
+    intercept[AnalysisException] { catalog.listTables("unknown_db") }
+  }
+
+  test("list tables with pattern") {
+    val catalog = new SessionCatalog(newBasicCatalog())
+    val tempTable = Range(1, 10, 2, 10, Seq())
+    catalog.createTempTable("tbl1", tempTable, ignoreIfExists = false)
+    catalog.createTempTable("tbl4", tempTable, ignoreIfExists = false)
+    assert(catalog.listTables("db1", "*").toSet ==
+      Set(TableIdentifier("tbl1"), TableIdentifier("tbl4")))
+    assert(catalog.listTables("db2", "*").toSet ==
+      Set(TableIdentifier("tbl1"),
+        TableIdentifier("tbl4"),
+        TableIdentifier("tbl1", Some("db2")),
+        TableIdentifier("tbl2", Some("db2"))))
+    assert(catalog.listTables("db2", "tbl*").toSet ==
+      Set(TableIdentifier("tbl1"),
+        TableIdentifier("tbl4"),
+        TableIdentifier("tbl1", Some("db2")),
+        TableIdentifier("tbl2", Some("db2"))))
+    assert(catalog.listTables("db2", "*1").toSet ==
+      Set(TableIdentifier("tbl1"), TableIdentifier("tbl1", Some("db2"))))
+    intercept[AnalysisException] { catalog.listTables("unknown_db") }
   }
 
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -17,14 +17,13 @@
 
 package org.apache.spark.sql.catalyst.catalog
 
+import org.apache.spark.SparkFunSuite
 
-/** Test suite for the [[InMemoryCatalog]]. */
-class InMemoryCatalogSuite extends CatalogTestCases {
 
-  protected override val utils: CatalogTestUtils = new CatalogTestUtils {
-    override val tableInputFormat: String = "org.apache.park.SequenceFileInputFormat"
-    override val tableOutputFormat: String = "org.apache.park.SequenceFileOutputFormat"
-    override def newEmptyCatalog(): ExternalCatalog = new InMemoryCatalog
+class SessionCatalogSuite extends SparkFunSuite {
+
+  test("dummy") {
+
   }
 
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveCatalog.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis.NoSuchItemException
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.hive.client.HiveClient
+import org.apache.spark.sql.catalyst.TableIdentifier
 
 
 /**
@@ -73,10 +74,10 @@ private[spark] class HiveCatalog(client: HiveClient) extends ExternalCatalog wit
   }
 
   private def requireDbMatches(db: String, table: CatalogTable): Unit = {
-    if (table.specifiedDatabase != Some(db)) {
+    if (table.name.database != Some(db)) {
       throw new AnalysisException(
         s"Provided database $db does not much the one specified in the " +
-        s"table definition (${table.specifiedDatabase.getOrElse("n/a")})")
+        s"table definition (${table.name.database.getOrElse("n/a")})")
     }
   }
 
@@ -160,7 +161,7 @@ private[spark] class HiveCatalog(client: HiveClient) extends ExternalCatalog wit
   }
 
   override def renameTable(db: String, oldName: String, newName: String): Unit = withClient {
-    val newTable = client.getTable(db, oldName).copy(name = newName)
+    val newTable = client.getTable(db, oldName).copy(name = TableIdentifier(newName, Some(db)))
     client.alterTable(oldName, newTable)
   }
 
@@ -173,7 +174,7 @@ private[spark] class HiveCatalog(client: HiveClient) extends ExternalCatalog wit
    */
   override def alterTable(db: String, tableDefinition: CatalogTable): Unit = withClient {
     requireDbMatches(db, tableDefinition)
-    requireTableExists(db, tableDefinition.name)
+    requireTableExists(db, tableDefinition.name.table)
     client.alterTable(tableDefinition)
   }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveCatalog.scala
@@ -24,10 +24,10 @@ import org.apache.thrift.TException
 
 import org.apache.spark.Logging
 import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.NoSuchItemException
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.hive.client.HiveClient
-import org.apache.spark.sql.catalyst.TableIdentifier
 
 
 /**

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -118,8 +118,8 @@ private[hive] class HiveMetastoreCatalog(val client: HiveClient, hive: HiveConte
 
   private def getQualifiedTableName(t: CatalogTable): QualifiedTableName = {
     QualifiedTableName(
-      t.specifiedDatabase.getOrElse(client.currentDatabase).toLowerCase,
-      t.name.toLowerCase)
+      t.name.database.getOrElse(client.currentDatabase).toLowerCase,
+      t.name.table.toLowerCase)
   }
 
   /** A cache of Spark SQL data source tables that have been accessed. */
@@ -293,8 +293,7 @@ private[hive] class HiveMetastoreCatalog(val client: HiveClient, hive: HiveConte
 
     def newSparkSQLSpecificMetastoreTable(): CatalogTable = {
       CatalogTable(
-        specifiedDatabase = Option(dbName),
-        name = tblName,
+        name = TableIdentifier(tblName, Option(dbName)),
         tableType = tableType,
         schema = Nil,
         storage = CatalogStorageFormat(
@@ -314,8 +313,7 @@ private[hive] class HiveMetastoreCatalog(val client: HiveClient, hive: HiveConte
       assert(relation.partitionSchema.isEmpty)
 
       CatalogTable(
-        specifiedDatabase = Option(dbName),
-        name = tblName,
+        name = TableIdentifier(tblName, Option(dbName)),
         tableType = tableType,
         storage = CatalogStorageFormat(
           locationUri = Some(relation.location.paths.map(_.toUri.toString).head),
@@ -432,7 +430,7 @@ private[hive] class HiveMetastoreCatalog(val client: HiveClient, hive: HiveConte
       alias match {
         // because hive use things like `_c0` to build the expanded text
         // currently we cannot support view from "create view v1(c1) as ..."
-        case None => SubqueryAlias(table.name, hive.parseSql(viewText))
+        case None => SubqueryAlias(table.name.table, hive.parseSql(viewText))
         case Some(aliasText) => SubqueryAlias(aliasText, hive.parseSql(viewText))
       }
     } else {
@@ -618,9 +616,7 @@ private[hive] class HiveMetastoreCatalog(val client: HiveClient, hive: HiveConte
         val QualifiedTableName(dbName, tblName) = getQualifiedTableName(table)
 
         execution.CreateViewAsSelect(
-          table.copy(
-            specifiedDatabase = Some(dbName),
-            name = tblName),
+          table.copy(name = TableIdentifier(tblName, Some(dbName))),
           child,
           allowExisting,
           replace)
@@ -642,7 +638,7 @@ private[hive] class HiveMetastoreCatalog(val client: HiveClient, hive: HiveConte
         if (hive.convertCTAS && table.storage.serde.isEmpty) {
           // Do the conversion when spark.sql.hive.convertCTAS is true and the query
           // does not specify any storage format (file format and storage handler).
-          if (table.specifiedDatabase.isDefined) {
+          if (table.name.database.isDefined) {
             throw new AnalysisException(
               "Cannot specify database name in a CTAS statement " +
                 "when spark.sql.hive.convertCTAS is set to true.")
@@ -650,7 +646,7 @@ private[hive] class HiveMetastoreCatalog(val client: HiveClient, hive: HiveConte
 
           val mode = if (allowExisting) SaveMode.Ignore else SaveMode.ErrorIfExists
           CreateTableUsingAsSelect(
-            TableIdentifier(desc.name),
+            TableIdentifier(desc.name.table),
             conf.defaultDataSourceName,
             temporary = false,
             Array.empty[String],
@@ -671,9 +667,7 @@ private[hive] class HiveMetastoreCatalog(val client: HiveClient, hive: HiveConte
           val QualifiedTableName(dbName, tblName) = getQualifiedTableName(table)
 
           execution.CreateTableAsSelect(
-            desc.copy(
-              specifiedDatabase = Some(dbName),
-              name = tblName),
+            desc.copy(name = TableIdentifier(tblName, Some(dbName))),
             child,
             allowExisting)
         }
@@ -824,7 +818,7 @@ private[hive] case class MetastoreRelation(
     // We start by constructing an API table as Hive performs several important transformations
     // internally when converting an API table to a QL table.
     val tTable = new org.apache.hadoop.hive.metastore.api.Table()
-    tTable.setTableName(table.name)
+    tTable.setTableName(table.name.table)
     tTable.setDbName(table.database)
 
     val tableParameters = new java.util.HashMap[String, String]()

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
@@ -60,7 +60,7 @@ private[hive] case class CreateTableAsSelect(
 
   override def output: Seq[Attribute] = Seq.empty[Attribute]
   override lazy val resolved: Boolean =
-    tableDesc.specifiedDatabase.isDefined &&
+    tableDesc.name.database.isDefined &&
     tableDesc.schema.nonEmpty &&
     tableDesc.storage.serde.isDefined &&
     tableDesc.storage.inputFormat.isDefined &&
@@ -185,13 +185,10 @@ private[hive] class HiveQl(conf: ParserConf) extends SparkQl(conf) with Logging 
       properties: Map[String, String],
       allowExist: Boolean,
       replace: Boolean): CreateViewAsSelect = {
-    val TableIdentifier(viewName, dbName) = extractTableIdent(viewNameParts)
-
+    val tableIdentifier = extractTableIdent(viewNameParts)
     val originalText = query.source
-
     val tableDesc = CatalogTable(
-      specifiedDatabase = dbName,
-      name = viewName,
+      name = tableIdentifier,
       tableType = CatalogTableType.VIRTUAL_VIEW,
       schema = schema,
       storage = CatalogStorageFormat(
@@ -356,12 +353,11 @@ private[hive] class HiveQl(conf: ParserConf) extends SparkQl(conf) with Logging 
               "TOK_TABLELOCATION",
               "TOK_TABLEPROPERTIES"),
             children)
-        val TableIdentifier(tblName, dbName) = extractTableIdent(tableNameParts)
+        val tableIdentifier = extractTableIdent(tableNameParts)
 
         // TODO add bucket support
         var tableDesc: CatalogTable = CatalogTable(
-          specifiedDatabase = dbName,
-          name = tblName,
+          name = tableIdentifier,
           tableType =
             if (externalTable.isDefined) {
               CatalogTableType.EXTERNAL_TABLE

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
@@ -91,7 +91,7 @@ private[hive] trait HiveClient {
   def dropTable(dbName: String, tableName: String, ignoreIfNotExists: Boolean): Unit
 
   /** Alter a table whose name matches the one specified in `table`, assuming it exists. */
-  final def alterTable(table: CatalogTable): Unit = alterTable(table.name, table)
+  final def alterTable(table: CatalogTable): Unit = alterTable(table.name.table, table)
 
   /** Updates the given table with new metadata, optionally renaming the table. */
   def alterTable(tableName: String, table: CatalogTable): Unit

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -35,6 +35,7 @@ import org.apache.hadoop.hive.ql.session.SessionState
 import org.apache.hadoop.security.UserGroupInformation
 
 import org.apache.spark.{Logging, SparkConf, SparkException}
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{NoSuchDatabaseException, NoSuchPartitionException}
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.expressions.Expression
@@ -298,8 +299,7 @@ private[hive] class HiveClientImpl(
     logDebug(s"Looking up $dbName.$tableName")
     Option(client.getTable(dbName, tableName, false)).map { h =>
       CatalogTable(
-        specifiedDatabase = Option(h.getDbName),
-        name = h.getTableName,
+        name = TableIdentifier(h.getTableName, Option(h.getDbName)),
         tableType = h.getTableType match {
           case HiveTableType.EXTERNAL_TABLE => CatalogTableType.EXTERNAL_TABLE
           case HiveTableType.MANAGED_TABLE => CatalogTableType.MANAGED_TABLE
@@ -639,7 +639,7 @@ private[hive] class HiveClientImpl(
   }
 
   private def toHiveTable(table: CatalogTable): HiveTable = {
-    val hiveTable = new HiveTable(table.database, table.name)
+    val hiveTable = new HiveTable(table.database, table.name.table)
     hiveTable.setTableType(table.tableType match {
       case CatalogTableType.EXTERNAL_TABLE => HiveTableType.EXTERNAL_TABLE
       case CatalogTableType.MANAGED_TABLE => HiveTableType.MANAGED_TABLE

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/CreateTableAsSelect.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/CreateTableAsSelect.scala
@@ -38,7 +38,7 @@ case class CreateTableAsSelect(
     allowExisting: Boolean)
   extends RunnableCommand {
 
-  val tableIdentifier = TableIdentifier(tableDesc.name, Some(tableDesc.database))
+  private val tableIdentifier = tableDesc.name
 
   override def children: Seq[LogicalPlan] = Seq(query)
 
@@ -93,6 +93,6 @@ case class CreateTableAsSelect(
   }
 
   override def argString: String = {
-    s"[Database:${tableDesc.database}}, TableName: ${tableDesc.name}, InsertIntoHiveTable]"
+    s"[Database:${tableDesc.database}}, TableName: ${tableDesc.name.table}, InsertIntoHiveTable]"
   }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/CreateViewAsSelect.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/CreateViewAsSelect.scala
@@ -44,7 +44,7 @@ private[hive] case class CreateViewAsSelect(
   assert(tableDesc.schema == Nil || tableDesc.schema.length == childSchema.length)
   assert(tableDesc.viewText.isDefined)
 
-  val tableIdentifier = TableIdentifier(tableDesc.name, Some(tableDesc.database))
+  private val tableIdentifier = tableDesc.name
 
   override def run(sqlContext: SQLContext): Seq[Row] = {
     val hiveContext = sqlContext.asInstanceOf[HiveContext]
@@ -116,7 +116,7 @@ private[hive] case class CreateViewAsSelect(
     }
 
     val viewText = tableDesc.viewText.get
-    val viewName = quote(tableDesc.name)
+    val viewName = quote(tableDesc.name.table)
     s"SELECT $viewOutput FROM ($viewText) $viewName"
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveCatalogSuite.scala
@@ -36,15 +36,12 @@ class HiveCatalogSuite extends CatalogTestCases {
       sparkConf = new SparkConf()).createClient()
   }
 
-  protected override val tableInputFormat: String =
-    "org.apache.hadoop.mapred.SequenceFileInputFormat"
-  protected override val tableOutputFormat: String =
-    "org.apache.hadoop.mapred.SequenceFileOutputFormat"
-
-  protected override def newUriForDatabase(): String = Utils.createTempDir().getAbsolutePath
+  protected override val utils: CatalogTestUtils = new CatalogTestUtils {
+    override val tableInputFormat: String = "org.apache.hadoop.mapred.SequenceFileInputFormat"
+    override val tableOutputFormat: String = "org.apache.hadoop.mapred.SequenceFileOutputFormat"
+    override def newEmptyCatalog(): ExternalCatalog = new HiveCatalog(client)
+  }
 
   protected override def resetState(): Unit = client.reset()
-
-  protected override def newEmptyCatalog(): ExternalCatalog = new HiveCatalog(client)
 
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveQlSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveQlSuite.scala
@@ -54,8 +54,8 @@ class HiveQlSuite extends SparkFunSuite with BeforeAndAfterAll {
 
     val (desc, exists) = extractTableDesc(s1)
     assert(exists)
-    assert(desc.specifiedDatabase == Some("mydb"))
-    assert(desc.name == "page_view")
+    assert(desc.name.database == Some("mydb"))
+    assert(desc.name.table == "page_view")
     assert(desc.tableType == CatalogTableType.EXTERNAL_TABLE)
     assert(desc.storage.locationUri == Some("/user/external/page_view"))
     assert(desc.schema ==
@@ -100,8 +100,8 @@ class HiveQlSuite extends SparkFunSuite with BeforeAndAfterAll {
 
     val (desc, exists) = extractTableDesc(s2)
     assert(exists)
-    assert(desc.specifiedDatabase == Some("mydb"))
-    assert(desc.name == "page_view")
+    assert(desc.name.database == Some("mydb"))
+    assert(desc.name.table == "page_view")
     assert(desc.tableType == CatalogTableType.EXTERNAL_TABLE)
     assert(desc.storage.locationUri == Some("/user/external/page_view"))
     assert(desc.schema ==
@@ -127,8 +127,8 @@ class HiveQlSuite extends SparkFunSuite with BeforeAndAfterAll {
     val s3 = """CREATE TABLE page_view AS SELECT * FROM src"""
     val (desc, exists) = extractTableDesc(s3)
     assert(exists == false)
-    assert(desc.specifiedDatabase == None)
-    assert(desc.name == "page_view")
+    assert(desc.name.database == None)
+    assert(desc.name.table == "page_view")
     assert(desc.tableType == CatalogTableType.MANAGED_TABLE)
     assert(desc.storage.locationUri == None)
     assert(desc.schema == Seq.empty[CatalogColumn])
@@ -162,8 +162,8 @@ class HiveQlSuite extends SparkFunSuite with BeforeAndAfterAll {
                |   ORDER BY key, value""".stripMargin
     val (desc, exists) = extractTableDesc(s5)
     assert(exists == false)
-    assert(desc.specifiedDatabase == None)
-    assert(desc.name == "ctas2")
+    assert(desc.name.database == None)
+    assert(desc.name.table == "ctas2")
     assert(desc.tableType == CatalogTableType.MANAGED_TABLE)
     assert(desc.storage.locationUri == None)
     assert(desc.schema == Seq.empty[CatalogColumn])

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
@@ -719,8 +719,7 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with TestHiv
     withTable(tableName) {
       val schema = StructType(StructField("int", IntegerType, true) :: Nil)
       val hiveTable = CatalogTable(
-        specifiedDatabase = Some("default"),
-        name = tableName,
+        name = TableIdentifier(tableName, Some("default")),
         tableType = CatalogTableType.MANAGED_TABLE,
         schema = Seq.empty,
         storage = CatalogStorageFormat(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
@@ -22,6 +22,7 @@ import java.io.File
 import org.apache.hadoop.util.VersionInfo
 
 import org.apache.spark.{Logging, SparkConf, SparkFunSuite}
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Literal, NamedExpression}
 import org.apache.spark.sql.catalyst.util.quietly
@@ -129,8 +130,7 @@ class VersionsSuite extends SparkFunSuite with Logging {
     test(s"$version: createTable") {
       val table =
         CatalogTable(
-          specifiedDatabase = Option("default"),
-          name = "src",
+          name = TableIdentifier("src", Some("default")),
           tableType = CatalogTableType.MANAGED_TABLE,
           schema = Seq(CatalogColumn("key", "int")),
           storage = CatalogStorageFormat(


### PR DESCRIPTION
## What changes were proposed in this pull request?

As part of the effort to merge `SQLContext` and `HiveContext`, this patch implements an internal catalog called `SessionCatalog` that handles temporary functions and tables and delegates metastore operations to `ExternalCatalog`. Currently, this is still dead code, but in the future it will be part of `SessionState` and will replace `o.a.s.sql.catalyst.analysis.Catalog`.

A recent patch #11573 parses Hive commands ourselves in Spark, but still passes the entire query text to Hive. In a future patch, we will use `SessionCatalog` to implement the parsed commands.
## How was this patch tested?

800+ lines of tests in `SessionCatalogSuite`.
