### PR TITLE
[SPARK-13316][Streaming]add check to avoid registering new DStream when recovering from CP

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -156,6 +156,7 @@ class StreamingContext private[streaming] (
     if (isCheckpointPresent) {
       _cp.graph.setContext(this)
       _cp.graph.restoreCheckpointData()
+      _cp.graph.recoveredFromCheckpoint = true
       _cp.graph
     } else {
       require(_batchDur != null, "Batch duration for StreamingContext cannot be null")


### PR DESCRIPTION
When creating a recoverable streaming job, it must be no new DStream registered after a StreamingContext has been recreated from checkpoint. Or you will see following exception:

```
org.apache.spark.SparkException: org.apache.spark.streaming.dstream.ConstantInputDStream@724797ab has not been initialized
      at org.apache.spark.streaming.dstream.DStream.isTimeValid(DStream.scala:311)
      at org.apache.spark.streaming.dstream.InputDStream.isTimeValid(InputDStream.scala:89)
      at org.apache.spark.streaming.dstream.DStream$$anonfun$getOrCompute$1.apply(DStream.scala:332)
      at org.apache.spark.streaming.dstream.DStream$$anonfun$getOrCompute$1.apply(DStream.scala:332)
      at scala.Option.orElse(Option.scala:289)
      at org.apache.spark.streaming.dstream.DStream.getOrCompute(DStream.scala:329)
      at org.apache.spark.streaming.dstream.ForEachDStream.generateJob(ForEachDStream.scala:48)
      at org.apache.spark.streaming.DStreamGraph$$anonfun$1.apply(DStreamGraph.scala:117)
      at org.apache.spark.streaming.DStreamGraph$$anonfun$1.apply(DStreamGraph.scala:116)
```

This PR is to add meaningful error message to make it obvious at first. 

I manually tested the PR with following repo code

``` scala
def createStreamingContext(): StreamingContext = {
    val ssc = new StreamingContext(sparkConf, Duration(1000))
    ssc.checkpoint(checkpointDir)
    ssc
}
val ssc = StreamingContext.getOrCreate(checkpointDir), createStreamingContext)

val socketStream = ssc.socketTextStream(...)
socketStream.checkpoint(Seconds(1))
socketStream.foreachRDD(...)
```
