### PR TITLE
[SPARK-13934][SQL] Fixed table name parsing

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AbstractSparkSQLParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AbstractSparkSQLParser.scala
@@ -129,7 +129,7 @@ class SqlLexical extends StdLexical {
   override def identChar: Parser[Elem] = letter | elem('_')
 
   private lazy val scientificNotation: Parser[String] =
-    (elem('e') | elem('E')) ~> (elem('+') | elem('-')).? ~ rep1(digit) ^^ {
+    (elem('e') | elem('E')) ~> (elem('+') | elem('-')).? ~ rep1(digit) <~ not(rep1(identChar)) ^^ {
       case s ~ rest => "e" + s.mkString + rest.mkString
     }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/CatalystQlSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/CatalystQlSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.parser
 
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.{SqlParser, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.PlanTest
@@ -171,6 +171,7 @@ class CatalystQlSuite extends PlanTest {
   test("table identifier") {
     assert(TableIdentifier("q") === parser.parseTableIdentifier("q"))
     assert(TableIdentifier("q", Some("d")) === parser.parseTableIdentifier("d.q"))
+    assert(TableIdentifier("104e4d676bac4d9aa3856f00b5b9f51c") === parser.parseTableIdentifier("104e4d676bac4d9aa3856f00b5b9f51c"))
     intercept[AnalysisException](parser.parseTableIdentifier(""))
     intercept[AnalysisException](parser.parseTableIdentifier("d.q.g"))
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

val tableName = "1e34abcd"
hc.sql("select 123").registerTempTable(tableName)
hc.dropTempTable(tableName)
The last line will throw a RuntimeException.(java.lang.RuntimeException: [1.1] failure: identifier expected)

Fix this by changing the scientific notation parser. If a scientific notation is followed by one or more identifier char, then don't see it as a valid token.
## How was this patch tested?

unit test is added 
