### PR TITLE
[SPARK-13936] [SQL] Avoid Predicate Pushdown Using Constraints in PushPredicateThroughProject

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -895,11 +895,6 @@ object PushPredicateThroughProject extends Rule[LogicalPlan] with PredicateHelpe
       // condition without nondeterministic expressions.
       val andConditions = splitConjunctivePredicates(condition)
 
-      val temp = andConditions.map{
-        _.collect {
-          case a: Attribute if aliasMap.contains(a) => aliasMap(a)
-        }
-      }
       val (deterministic, nondeterministic) = andConditions.partition(_.collect {
         case a: Attribute if aliasMap.contains(a) => aliasMap(a)
       }.forall(_.deterministic))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferredFiltersPushDownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferredFiltersPushDownSuite.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules._
+
+class InferredFiltersPushDownSuite  extends PlanTest {
+
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches =
+      Batch("NullFiltering", FixedPoint(15),
+        SetOperationPushDown,
+        PushPredicateThroughJoin,
+        PushPredicateThroughProject,
+        PushPredicateThroughGenerate,
+        PushPredicateThroughAggregate,
+        NullFiltering,
+        CollapseProject,
+        PruneFilters,
+        CombineFilters) :: Nil
+  }
+
+  val testRelation1 = LocalRelation('a.string, 'b.int, 'c.int)
+  val testRelation2 = LocalRelation('a.string, 'b.int, 'c.int)
+
+  test("filter: do not push predicates") {
+    val x2 = testRelation1.select("tst1".as("key"), 'b)
+    val x1 = testRelation1.groupBy('a)('a.as("x2a"), 'b + 1)
+    val y = testRelation1
+    val union1 = x1.unionAll(x2)
+
+    val originalQuery = union1.join(y, condition = Some('x2a === 'a)).analyze
+
+    val x1Optimized =
+      testRelation1.select("tst1".as("key"), 'b).where(IsNotNull('key))
+    val x2Optimized = testRelation1.where(IsNotNull('a)).groupBy('a)('a.as("x2a"), 'b + 1)
+    val unionOptimized = x2Optimized.unionAll(x1Optimized)
+    val correctAnswer =
+      unionOptimized.join(y.where(IsNotNull('a)), condition = Some('x2a === 'a)).analyze
+    val optimized = Optimize.execute(originalQuery)
+    comparePlans(optimized, correctAnswer)
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PruneFiltersSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PruneFiltersSuite.scala
@@ -130,7 +130,6 @@ class PruneFiltersSuite extends PlanTest {
   test("Nondeterministic predicate is not pruned") {
     val originalQuery = testRelation.where(Rand(10) > 5).select('a).where(Rand(10) > 5).analyze
     val optimized = Optimize.execute(originalQuery)
-    val correctAnswer = testRelation.where(Rand(10) > 5).where(Rand(10) > 5).select('a).analyze
-    comparePlans(optimized, correctAnswer)
+    comparePlans(optimized, originalQuery)
   }
 }


### PR DESCRIPTION
#### What changes were proposed in this pull request?

In the query, Optimizer keeps adding duplicate constraints in Filter constraints by applying the rule PushPredicateThroughProject.

``` SQL
SELECT unionsrc1.key, unionsrc1.value, unionsrc2.key, unionsrc2.value FROM (select 'tst1' as key, cast(count(1) as string) as value from parquet_t1 s1 UNION ALL select s2.key as key, s2.value as value from parquet_t1 s2 where s2.key < 10) unionsrc1 JOIN (select 'tst1' as key, cast(count(1) as string) as value from parquet_t1 s3 UNION  ALL select s4.key as key, s4.value as value from parquet_t1 s4 where s4.key < 10) unionsrc2 ON (unionsrc1.key = unionsrc2.key)
```

The generated optimized plan is like

```
Join Inner, Some((key#30 = key#34))
:- Filter isnotnull(key#30)
:  +- Union
:     :- Aggregate [tst1 AS key#30,cast((count(1),mode=Complete,isDistinct=false) as string) AS value#31]
:     :  +- Project
:     :     +- Relation[key#38L,value#39] ParquetFormat part: struct<>, data: struct<key:bigint,value:string>
:     +- Project [cast(key#38L as string) AS key#46,value#39 AS value#33]
:        +- Filter ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((isnotnull(key#38L) && (key#38L < 10)) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string)))
:           +- Relation[key#38L,value#39] ParquetFormat part: struct<>, data: struct<key:bigint,value:string>
+- Filter isnotnull(key#34)
   +- Union
      :- Aggregate [tst1 AS key#34,cast((count(1),mode=Complete,isDistinct=false) as string) AS value#35]
      :  +- Project
      :     +- Relation[key#38L,value#39] ParquetFormat part: struct<>, data: struct<key:bigint,value:string>
      +- Project [cast(key#38L as string) AS key#47,value#39 AS value#37]
         +- Filter ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((isnotnull(key#38L) && (key#38L < 10)) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string))) && isnotnull(cast(key#38L as string)))
            +- Relation[key#38L,value#39] ParquetFormat part: struct<>, data: struct<key:bigint,value:string>
```

Due to this issue, it also hits the max iteration, as shown in the log output https://amplab.cs.berkeley.edu/jenkins/job/SparkPullRequestBuilder/53176/consoleFull. 

This PR uses the constraints to avoid pushing any predicate that already exists in its child's Constraints. Also, it will not pushing any predicate that does not contain any reference, since it could introduce the same issue.

Will introduce the same idea in the similar rules:
-       PushPredicateThroughJoin,
-       PushPredicateThroughGenerate,
-       PushPredicateThroughAggregate,
-       SetOperationPushDown

Should I do it in the same PR? or different PRs? @marmbrus 
#### How was this patch tested?

Added a test case and also manually tested the case that causes the exception in https://github.com/apache/spark/pull/11714
