### PR TITLE
Added transitive closure transformation to Catalyst

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/TransitiveClosureSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/TransitiveClosureSuite.scala
@@ -1,0 +1,179 @@
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.analysis.EliminateSubQueries
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.catalyst.rules._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.dsl.expressions._
+
+class TransitiveClosureSuite extends PlanTest {
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches =
+      Batch("Subqueries", Once,
+        EliminateSubQueries) ::
+      Batch("Filter Pushdown", FixedPoint(4),
+        SamplePushDown,
+        CombineFilters,
+        PushPredicateThroughProject,
+        BooleanSimplification,
+        TransitiveClosure,
+        PushPredicateThroughJoin,
+        PushPredicateThroughGenerate,
+        ColumnPruning,
+        ProjectCollapsing) :: Nil
+  }
+
+  val testRelation = LocalRelation('a.int, 'b.int, 'c.int)
+
+  val testRelation1 = LocalRelation('d.int)
+
+  test("Binary comparison in where clause together with join condition") {
+    val x = testRelation.subquery('x)
+    val y = testRelation1.subquery('y)
+
+    val originalQuery = {
+      x.join(y)
+        .where("x.a".attr === "y.d".attr && "x.a".attr >= 1)
+    }
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+    val left = testRelation.where('a >= 1)
+    val right = testRelation1.where('d >= 1)
+    val correctAnswer =
+      left.join(right, condition = Some("a".attr === "d".attr)).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("Not and mixed join condition with where clause filter") {
+    val x = testRelation.subquery('x)
+    val y = testRelation1.subquery('y)
+
+    val originalQuery = {
+      x.join(y, condition = Option("x.a".attr === "y.d".attr))
+        .where("x.a".attr !== 1)
+    }
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+    val left = testRelation.where('a !== 1)
+    val right = testRelation1.where('d !== 1)
+    val correctAnswer =
+      left.join(right, condition = Some("a".attr === "d".attr)).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("In and all conditions are join conditions") {
+    val x = testRelation.subquery('x)
+    val y = testRelation1.subquery('y)
+
+    val originalQuery = {
+      x.join(y, condition = Option("x.a".attr === "y.d".attr && ("x.a".attr in (1, 2))))
+    }
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+    val left = testRelation.where('a in (1, 2))
+    val right = testRelation1.where('d in (1, 2))
+    val correctAnswer =
+      left.join(right, condition = Some("a".attr === "d".attr)).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("Or condition") {
+    val x = testRelation.subquery('x)
+    val y = testRelation1.subquery('y)
+
+    val originalQuery = {
+      x.join(y, condition = Option("x.a".attr === "y.d".attr))
+        .where("x.a".attr === 1 || "x.a".attr === 2)
+    }
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+    val left = testRelation.where('a === 1 || 'a === 2)
+    val right = testRelation1.where('d === 1 || 'd === 2)
+    val correctAnswer =
+      left.join(right, condition = Some("a".attr === "d".attr)).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("Mixed join and where clause conditions") {
+    val x = testRelation.subquery('x)
+    val y = testRelation1.subquery('y)
+
+    val originalQuery = {
+      x.join(y, condition = Option("x.a".attr === "y.d".attr && "y.d".attr === 2))
+        .where("x.a".attr === 1)
+    }
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+    val left = testRelation.where('a === 1 && 'a === 2)
+    val right = testRelation1.where('d === 1 && 'd === 2)
+    val correctAnswer =
+      left.join(right, condition = Some("a".attr === "d".attr)).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("Left join works one way") {
+    val x = testRelation.subquery('x)
+    val y = testRelation1.subquery('y)
+
+    val originalQuery = {
+      x.join(y, LeftOuter, Option("x.a".attr === "y.d".attr))
+        .where("x.a".attr === 1 && "y.d".attr === 2)
+    }
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+    val left = testRelation.where('a === 1)
+    val right = testRelation1
+    val correctAnswer =
+      left.join(right, LeftOuter, Some("a".attr === "d".attr))
+        .where("d".attr === 1 && "d".attr === 2)
+        .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("Right join works one way") {
+    val x = testRelation.subquery('x)
+    val y = testRelation1.subquery('y)
+
+    val originalQuery = {
+      x.join(y, RightOuter, Option("x.a".attr === "y.d".attr))
+        .where("y.d".attr === 2 && "x.a".attr === 1)
+    }
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+    val left = testRelation
+    val right = testRelation1.where('d === 2)
+    val correctAnswer =
+      left.join(right, RightOuter, Some("a".attr === "d".attr))
+        .where("a".attr === 2 && "a".attr === 1)
+        .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("Full join does not do anything") {
+    val x = testRelation.subquery('x)
+    val y = testRelation1.subquery('y)
+
+    val originalQuery = {
+      x.join(y, FullOuter, Option("x.a".attr === "y.d".attr && "y.d".attr === 2))
+        .where("x.a".attr === 1)
+    }
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+    val left = testRelation
+    val right = testRelation1
+    val correctAnswer =
+      left.join(right, FullOuter, Some("a".attr === "d".attr && "d".attr === 2))
+        .where("a".attr === 1).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

A relatively simple transformation is missing from Catalyst's arsenal - generation of transitive predicates. For instance, if you have got the following query:
`select * 
from   table1 t1
join   table2 t2
on     t1.a = t2.b
where  t1.a = 42`
then it is a fair assumption that t2.b also equals 42 hence an additional predicate could be generated. The additional predicate could in turn be pushed down through the join and improve performance of the whole query by filtering out the data before joining it.
Such a transformation exists in Oracle DB.
Please note, in this PR a transitive predicate would be created for the following operations: 
- a BinaryComparison (=, >=, etc.) to a foldable
- in (1, 2, 3) where all the values in the sequence are foldable
- Not of any of the above
- Or of any of the above
## How was this patch tested?

I've added a new TransitiveClosureSuite with a series of unit tests
