### PR TITLE
[Minor] [ML] When trainingSummary is None, it should throw RuntimeException.

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -509,9 +509,7 @@ class LogisticRegressionModel private[spark] (
    */
   @Since("1.5.0")
   def summary: LogisticRegressionTrainingSummary = trainingSummary.getOrElse {
-    throw new SparkException(
-      "No training summary available for this LogisticRegressionModel",
-      new RuntimeException())
+    throw new SparkException("No training summary available for this LogisticRegressionModel")
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -508,12 +508,10 @@ class LogisticRegressionModel private[spark] (
    * thrown if `trainingSummary == None`.
    */
   @Since("1.5.0")
-  def summary: LogisticRegressionTrainingSummary = trainingSummary match {
-    case Some(summ) => summ
-    case None =>
-      throw new SparkException(
-        "No training summary available for this LogisticRegressionModel",
-        new NullPointerException())
+  def summary: LogisticRegressionTrainingSummary = trainingSummary.getOrElse {
+    throw new SparkException(
+      "No training summary available for this LogisticRegressionModel",
+      new RuntimeException())
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -148,12 +148,10 @@ class KMeansModel private[ml] (
    * thrown if `trainingSummary == None`.
    */
   @Since("2.0.0")
-  def summary: KMeansSummary = trainingSummary match {
-    case Some(summ) => summ
-    case None =>
-      throw new SparkException(
-        s"No training summary available for the ${this.getClass.getSimpleName}",
-        new NullPointerException())
+  def summary: KMeansSummary = trainingSummary.getOrElse {
+    throw new SparkException(
+      s"No training summary available for the ${this.getClass.getSimpleName}",
+      new RuntimeException())
   }
 }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -150,8 +150,7 @@ class KMeansModel private[ml] (
   @Since("2.0.0")
   def summary: KMeansSummary = trainingSummary.getOrElse {
     throw new SparkException(
-      s"No training summary available for the ${this.getClass.getSimpleName}",
-      new RuntimeException())
+      s"No training summary available for the ${this.getClass.getSimpleName}")
   }
 }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -680,8 +680,7 @@ class GeneralizedLinearRegressionModel private[ml] (
   @Since("2.0.0")
   def summary: GeneralizedLinearRegressionSummary = trainingSummary.getOrElse {
     throw new SparkException(
-      "No training summary available for this GeneralizedLinearRegressionModel",
-      new RuntimeException())
+      "No training summary available for this GeneralizedLinearRegressionModel")
   }
 
   private[regression] def setSummary(summary: GeneralizedLinearRegressionSummary): this.type = {

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -398,9 +398,7 @@ class LinearRegressionModel private[ml] (
    */
   @Since("1.5.0")
   def summary: LinearRegressionTrainingSummary = trainingSummary.getOrElse {
-    throw new SparkException(
-      "No training summary available for this LinearRegressionModel",
-      new RuntimeException())
+    throw new SparkException("No training summary available for this LinearRegressionModel")
   }
 
   private[regression] def setSummary(summary: LinearRegressionTrainingSummary): this.type = {

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/LinearRegression.scala
@@ -397,12 +397,10 @@ class LinearRegressionModel private[ml] (
    * thrown if `trainingSummary == None`.
    */
   @Since("1.5.0")
-  def summary: LinearRegressionTrainingSummary = trainingSummary match {
-    case Some(summ) => summ
-    case None =>
-      throw new SparkException(
-        "No training summary available for this LinearRegressionModel",
-        new NullPointerException())
+  def summary: LinearRegressionTrainingSummary = trainingSummary.getOrElse {
+    throw new SparkException(
+      "No training summary available for this LinearRegressionModel",
+      new RuntimeException())
   }
 
   private[regression] def setSummary(summary: LinearRegressionTrainingSummary): this.type = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When trainingSummary is None, it should throw `RuntimeException`.
cc @mengxr 
## How was this patch tested?

Existing tests.
