### PR TITLE
[SPARK-11319][SQL] Making StructField's nullable field documentation clearer

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructField.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructField.scala
@@ -24,7 +24,9 @@ import org.json4s.JsonDSL._
  * A field inside a StructType.
  * @param name The name of this field.
  * @param dataType The data type of this field.
- * @param nullable Indicates if values of this field can be `null` values.
+ * @param nullable Indicates if values of this field can be `null` values. Note that this ONLY A HINT to the 
+ *                 optimiser, the calling code is responsible for ensuring that there is no null. It is NOT 
+ *                 a constraint that will be checked by the engine.
  * @param metadata The metadata of this field. The metadata should be preserved during
  *                 transformation if the content of the column is not modified, e.g, in selection.
  */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructField.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructField.scala
@@ -24,7 +24,7 @@ import org.json4s.JsonDSL._
  * A field inside a StructType.
  * @param name The name of this field.
  * @param dataType The data type of this field.
- * @param nullable Indicates if values of this field can be `null` values. Note that this ONLY A HINT to the 
+ * @param nullable Indicates if values of this field can be `null` values. Note that this is ONLY A HINT to the 
  *                 optimiser, the calling code is responsible for ensuring that there is no null. It is NOT 
  *                 a constraint that will be checked by the engine.
  * @param metadata The metadata of this field. The metadata should be preserved during


### PR DESCRIPTION
## What changes were proposed in this pull request?

Be more descriptive in what the nullable field of StructField is intended for. At the moment, the description does not explain that it's only a hint to the optimizer, and many people are mistakenly thinking that this is a "NOT NULL" type constraint. Making it clear in the doc should help people understand its purpose.
## How was this patch tested?

Not tested as it's only documentation
