### PR TITLE
[SPARK-13858] [SQL] fix the data type cast issue

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/DecimalPrecision.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/DecimalPrecision.scala
@@ -61,10 +61,6 @@ import org.apache.spark.sql.types._
 object DecimalPrecision extends Rule[LogicalPlan] {
   import scala.math.{max, min}
 
-  private def isNumericType(t: DataType): Boolean =
-    t == FloatType || t == DoubleType || t == ByteType ||
-      t == IntegerType || t == ShortType || t == LongType
-
   // Returns the wider decimal type that's wider than both of them
   def widerDecimalType(d1: DecimalType, d2: DecimalType): DecimalType = {
     widerDecimalType(d1.precision, d1.scale, d2.precision, d2.scale)
@@ -242,16 +238,47 @@ object DecimalPrecision extends Rule[LogicalPlan] {
    * side is a decimal.
    */
   private val nondecimalAndDecimal: PartialFunction[Expression, Expression] = {
-    // Promote different data types inside a binary expression
-    // with fixed-precision decimals to decimals
+    // Promote integers inside a binary expression with fixed-precision decimals to decimals,
+    // and fixed-precision decimals in an expression with floats / doubles to floats / doubles
     case b @ BinaryOperator(left, right) if left.dataType != right.dataType =>
       (left.dataType, right.dataType) match {
-        case (t: NumericType, DecimalType.Fixed(p, s)) if isNumericType(t) =>
+        case (t: IntegralType, DecimalType.Fixed(p, s)) =>
           b.makeCopy(Array(Cast(left, DecimalType.forType(t)), right))
-        case (DecimalType.Fixed(p, s), t: NumericType) if isNumericType(t) =>
+        case (DecimalType.Fixed(p, s), t: IntegralType) =>
           b.makeCopy(Array(left, Cast(right, DecimalType.forType(t))))
-        case _ =>
-          b
+
+        case (t, DecimalType.Fixed(p, s)) if t == FloatType =>
+          right match {
+            case l: Literal => {
+              val value = l.value.asInstanceOf[Decimal].toDouble
+              if (value > Float.MaxValue || value < Float.MinValue) {
+                b.makeCopy(Array(left, Cast(right, DoubleType)))
+              } else {
+                b.makeCopy(Array(left, Cast(right, FloatType)))
+              }
+            }
+            case _ => b.makeCopy(Array(left, Cast(right, DoubleType)))
+          }
+
+        case (DecimalType.Fixed(p, s), t) if t == FloatType =>
+          left match {
+            case l: Literal => {
+              val value = l.value.asInstanceOf[Decimal].toDouble
+              if (value > Float.MaxValue || value < Float.MinValue) {
+                b.makeCopy(Array(Cast(left, DoubleType), right))
+              } else {
+                b.makeCopy(Array(Cast(left, FloatType), right))
+              }
+            }
+            case _ => b.makeCopy(Array(Cast(left, DoubleType), right))
+          }
+
+        case (t, DecimalType.Fixed(p, s)) if t == DoubleType =>
+          b.makeCopy(Array(left, Cast(right, DoubleType)))
+        case (DecimalType.Fixed(p, s), t) if t == DoubleType =>
+          b.makeCopy(Array(Cast(left, DoubleType), right))
+
+        case _ => b
       }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/DecimalPrecision.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/DecimalPrecision.scala
@@ -242,8 +242,8 @@ object DecimalPrecision extends Rule[LogicalPlan] {
    * side is a decimal.
    */
   private val nondecimalAndDecimal: PartialFunction[Expression, Expression] = {
-    // Promote integers inside a binary expression with fixed-precision decimals to decimals,
-    // and fixed-precision decimals in an expression with floats / doubles to doubles
+    // Promote different data types inside a binary expression
+    // with fixed-precision decimals to decimals
     case b @ BinaryOperator(left, right) if left.dataType != right.dataType =>
       (left.dataType, right.dataType) match {
         case (t: NumericType, DecimalType.Fixed(p, s)) if isNumericType(t) =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/DecimalPrecisionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/DecimalPrecisionSuite.scala
@@ -101,7 +101,7 @@ class DecimalPrecisionSuite extends PlanTest with BeforeAndAfter {
     checkComparison(LessThan(i, d1), DecimalType(11, 1))
     checkComparison(LessThanOrEqual(d1, d2), DecimalType(5, 2))
     checkComparison(GreaterThan(d2, u), DecimalType.SYSTEM_DEFAULT)
-    checkComparison(GreaterThanOrEqual(d1, f), DecimalType(14, 7))
+    checkComparison(GreaterThanOrEqual(d1, f), DoubleType)
     checkComparison(GreaterThan(d2, d2), DecimalType(5, 2))
   }
 
@@ -120,13 +120,13 @@ class DecimalPrecisionSuite extends PlanTest with BeforeAndAfter {
 
   test("bringing in primitive types") {
     checkType(Add(d1, i), DecimalType(12, 1))
-    checkType(Add(d1, f), DecimalType(15, 7))
+    checkType(Add(d1, f), DoubleType)
     checkType(Add(i, d1), DecimalType(12, 1))
-    checkType(Add(f, d1), DecimalType(15, 7))
+    checkType(Add(f, d1), DoubleType)
     checkType(Add(d1, Cast(i, LongType)), DecimalType(22, 1))
     checkType(Add(d1, Cast(i, ShortType)), DecimalType(7, 1))
     checkType(Add(d1, Cast(i, ByteType)), DecimalType(5, 1))
-    checkType(Add(d1, Cast(i, DoubleType)), DecimalType(31, 15))
+    checkType(Add(d1, Cast(i, DoubleType)), DoubleType)
   }
 
   test("maximum decimals") {
@@ -150,17 +150,13 @@ class DecimalPrecisionSuite extends PlanTest with BeforeAndAfter {
     checkType(Remainder(i, u), DecimalType(28, 18))
     checkType(Remainder(u, u), DecimalType.SYSTEM_DEFAULT)
 
-    checkType(Add(f, u), DecimalType(38, 18))
-    checkType(Subtract(f, u), DecimalType(38, 18))
-    checkType(Multiply(f, u), DecimalType(38, 25))
-    checkType(Divide(f, u), DecimalType(38, 25))
-    checkType(Remainder(f, u), DecimalType(25, 18))
-
-    checkType(Add(b, u), DecimalType(38, 18))
-    checkType(Subtract(b, u), DecimalType(38, 18))
-    checkType(Multiply(b, u), DecimalType(38, 33))
-    checkType(Divide(b, u), DecimalType(38, 21))
-    checkType(Remainder(b, u), DecimalType(33, 18))
+    for (expr <- Seq(f, b)) {
+      checkType(Add(expr, u), DoubleType)
+      checkType(Subtract(expr, u), DoubleType)
+      checkType(Multiply(expr, u), DoubleType)
+      checkType(Divide(expr, u), DoubleType)
+      checkType(Remainder(expr, u), DoubleType)
+    }
   }
 
   test("DecimalType.isWiderThan") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/DecimalPrecisionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/DecimalPrecisionSuite.scala
@@ -101,7 +101,7 @@ class DecimalPrecisionSuite extends PlanTest with BeforeAndAfter {
     checkComparison(LessThan(i, d1), DecimalType(11, 1))
     checkComparison(LessThanOrEqual(d1, d2), DecimalType(5, 2))
     checkComparison(GreaterThan(d2, u), DecimalType.SYSTEM_DEFAULT)
-    checkComparison(GreaterThanOrEqual(d1, f), DoubleType)
+    checkComparison(GreaterThanOrEqual(d1, f), DecimalType(14, 7))
     checkComparison(GreaterThan(d2, d2), DecimalType(5, 2))
   }
 
@@ -120,13 +120,13 @@ class DecimalPrecisionSuite extends PlanTest with BeforeAndAfter {
 
   test("bringing in primitive types") {
     checkType(Add(d1, i), DecimalType(12, 1))
-    checkType(Add(d1, f), DoubleType)
+    checkType(Add(d1, f), DecimalType(15, 7))
     checkType(Add(i, d1), DecimalType(12, 1))
-    checkType(Add(f, d1), DoubleType)
+    checkType(Add(f, d1), DecimalType(15, 7))
     checkType(Add(d1, Cast(i, LongType)), DecimalType(22, 1))
     checkType(Add(d1, Cast(i, ShortType)), DecimalType(7, 1))
     checkType(Add(d1, Cast(i, ByteType)), DecimalType(5, 1))
-    checkType(Add(d1, Cast(i, DoubleType)), DoubleType)
+    checkType(Add(d1, Cast(i, DoubleType)), DecimalType(31, 15))
   }
 
   test("maximum decimals") {
@@ -150,13 +150,17 @@ class DecimalPrecisionSuite extends PlanTest with BeforeAndAfter {
     checkType(Remainder(i, u), DecimalType(28, 18))
     checkType(Remainder(u, u), DecimalType.SYSTEM_DEFAULT)
 
-    for (expr <- Seq(f, b)) {
-      checkType(Add(expr, u), DoubleType)
-      checkType(Subtract(expr, u), DoubleType)
-      checkType(Multiply(expr, u), DoubleType)
-      checkType(Divide(expr, u), DoubleType)
-      checkType(Remainder(expr, u), DoubleType)
-    }
+    checkType(Add(f, u), DecimalType(38, 18))
+    checkType(Subtract(f, u), DecimalType(38, 18))
+    checkType(Multiply(f, u), DecimalType(38, 25))
+    checkType(Divide(f, u), DecimalType(38, 25))
+    checkType(Remainder(f, u), DecimalType(25, 18))
+
+    checkType(Add(b, u), DecimalType(38, 18))
+    checkType(Subtract(b, u), DecimalType(38, 18))
+    checkType(Multiply(b, u), DecimalType(38, 33))
+    checkType(Divide(b, u), DecimalType(38, 21))
+    checkType(Remainder(b, u), DecimalType(33, 18))
   }
 
   test("DecimalType.isWiderThan") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -1383,8 +1383,8 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     val df = sqlContext.createDataFrame(rowRDD, schema)
     df.registerTempTable("table")
 
-//    val query1 = sql("select count(*) from table where col between 0 and 1.49")
-//    checkAnswer(query1, Row(1) :: Nil)
+    val query1 = sql("select count(*) from table where col between 0 and 1.49")
+    checkAnswer(query1, Row(1) :: Nil)
 
     val query2 = sql("select count(*) from table where col = 1.49")
     checkAnswer(query2, Row(1) :: Nil)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -1376,4 +1376,17 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
 
     assert(e.getStackTrace.head.getClassName != classOf[QueryExecution].getName)
   }
+
+  test("SPARK-13858/13861") {
+    val rowRDD = sparkContext.parallelize(Seq(Row(1.49f)))
+    val schema = StructType(StructField("col", FloatType) :: Nil)
+    val df = sqlContext.createDataFrame(rowRDD, schema)
+    df.registerTempTable("table")
+
+//    val query1 = sql("select count(*) from table where col between 0 and 1.49")
+//    checkAnswer(query1, Row(1) :: Nil)
+
+    val query2 = sql("select count(*) from table where col = 1.49")
+    checkAnswer(query2, Row(1) :: Nil)
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

I believe this is a critical bug in the Spark related to cast, which is found by running the TPC tests.
Use case:
User table (T) has one column (COL) which is FLOAT data type, it has tuple as (1.49f). the query is:

```
select COL from T where COL = 1.49, or
select COL from T where COL between 0 and 1.49
```

Spark will return nothing. Here is the reason in Scala (try to use Scala shell to test):

```
val a = 1.49f  #a: Float = 1.49
val b = 1.49  #b: Double = 1.49
val c = a == b #c: Boolean = false
val d = a <= b #d: Boolean = false
```

From above, we can see that casting a FLOAT to DOUBLE will not guarantee the comparison is still correct. There are many use cases that user will use =, <=, between in the queries, so it will affect the accuracy quite a lot.

The solution is to use FLOAT type if the column type is FLOAT and value is within the FLOAT range, else we will still use DOUBLE.

1.49 is the number I found with this cast issue, there may be more.
## How was this patch tested?

I did a full test for SQL, updated the expected results for a test suite, and also add a new test case for this scenario.

All tests are passed for now.
