### PR TITLE
[SPARK-13982][SparkR] KMean's predict: Features output column name is an unclear, automatically genetared text

### DIFF
--- a/R/pkg/inst/tests/testthat/test_mllib.R
+++ b/R/pkg/inst/tests/testthat/test_mllib.R
@@ -124,7 +124,9 @@ test_that("kmeans", {
   take(training, 1)
 
   model <- kmeans(x = training, centers = 2)
-  sample <- take(select(predict(model, training), "prediction"), 1)
+  prediction <- predict(model, training)
+  expect_equal(dim(select(prediction, "features")), c(150,1))
+  sample <- take(select(prediction, "prediction"), 1)
   expect_equal(typeof(sample$prediction), "integer")
   expect_equal(sample$prediction, 1)
 

--- a/R/pkg/inst/tests/testthat/test_mllib.R
+++ b/R/pkg/inst/tests/testthat/test_mllib.R
@@ -125,7 +125,7 @@ test_that("kmeans", {
 
   model <- kmeans(x = training, centers = 2)
   prediction <- predict(model, training)
-  expect_equal(dim(select(prediction, "features")), c(150,1))
+  expect_equal(dim(select(prediction, "features")), c(150, 1))
   sample <- take(select(prediction, "prediction"), 1)
   expect_equal(typeof(sample$prediction), "integer")
   expect_equal(sample$prediction, 1)

--- a/mllib/src/main/scala/org/apache/spark/ml/r/SparkRWrappers.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/SparkRWrappers.scala
@@ -58,7 +58,7 @@ private[r] object SparkRWrappers {
       maxIter: Double,
       k: Double,
       columns: Array[String]): PipelineModel = {
-    val assembler = new VectorAssembler().setInputCols(columns)
+    val assembler = new VectorAssembler().setInputCols(columns).setOutputCol("features")
     val kMeans = new KMeans()
       .setInitMode(initMode)
       .setMaxIter(maxIter.toInt)


### PR DESCRIPTION
## What changes were proposed in this pull request?

In KMean's predict the output column name of the features was set to something like this: "vecAssembler_522ba59ea239__output", which is the default output column name of the "VectorAssembler".
I set a value "features" which is more intuitive and human readable
Before fix: 
    predict(model, training)
    DataFrame[Sepal_Length:double, Sepal_Width:double, Petal_Length:double, Petal_Width:double,    **vecAssembler_522ba59ea239__output: vector**, prediction:int]

After fix: 
    DataFrame[Sepal_Length:double, Sepal_Width:double, Petal_Length:double, Petal_Width:double,    **features:vector**, prediction:int]
## How was this patch tested?

All previous test cases pass!
