### PR TITLE
[SPARK-13986][CORE][MLLIB] Remove `DeveloperApi`-annotations for non-publics

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/JobResult.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/JobResult.scala
@@ -30,4 +30,4 @@ sealed trait JobResult
 case object JobSucceeded extends JobResult
 
 @DeveloperApi
-private[spark] case class JobFailed(exception: Exception) extends JobResult
+case class JobFailed(exception: Exception) extends JobResult

--- a/core/src/main/scala/org/apache/spark/scheduler/JobResult.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/JobResult.scala
@@ -29,5 +29,4 @@ sealed trait JobResult
 @DeveloperApi
 case object JobSucceeded extends JobResult
 
-@DeveloperApi
-case class JobFailed(exception: Exception) extends JobResult
+private[spark] case class JobFailed(exception: Exception) extends JobResult

--- a/core/src/main/scala/org/apache/spark/util/collection/OpenHashMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/OpenHashMap.scala
@@ -19,17 +19,14 @@ package org.apache.spark.util.collection
 
 import scala.reflect.ClassTag
 
-import org.apache.spark.annotation.DeveloperApi
-
 /**
- * :: DeveloperApi ::
  * A fast hash map implementation for nullable keys. This hash map supports insertions and updates,
  * but not deletions. This map is about 5X faster than java.util.HashMap, while using much less
  * space overhead.
  *
  * Under the hood, it uses our OpenHashSet implementation.
  */
-@DeveloperApi
+private[spark]
 class OpenHashMap[K : ClassTag, @specialized(Long, Int, Double) V: ClassTag](
     initialCapacity: Int)
   extends Iterable[(K, V)]

--- a/core/src/main/scala/org/apache/spark/util/collection/OpenHashMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/OpenHashMap.scala
@@ -30,7 +30,6 @@ import org.apache.spark.annotation.DeveloperApi
  * Under the hood, it uses our OpenHashSet implementation.
  */
 @DeveloperApi
-private[spark]
 class OpenHashMap[K : ClassTag, @specialized(Long, Int, Double) V: ClassTag](
     initialCapacity: Int)
   extends Iterable[(K, V)]

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/Regressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/Regressor.scala
@@ -22,16 +22,13 @@ import org.apache.spark.ml.{PredictionModel, Predictor, PredictorParams}
 
 
 /**
- * :: DeveloperApi ::
- *
  * Single-label regression
  *
  * @tparam FeaturesType  Type of input features.  E.g., [[org.apache.spark.mllib.linalg.Vector]]
  * @tparam Learner  Concrete Estimator type
  * @tparam M  Concrete Model type
  */
-@DeveloperApi
-abstract class Regressor[
+private[spark] abstract class Regressor[
     FeaturesType,
     Learner <: Regressor[FeaturesType, Learner, M],
     M <: RegressionModel[FeaturesType, M]]

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/Regressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/Regressor.scala
@@ -31,7 +31,7 @@ import org.apache.spark.ml.{PredictionModel, Predictor, PredictorParams}
  * @tparam M  Concrete Model type
  */
 @DeveloperApi
-private[spark] abstract class Regressor[
+abstract class Regressor[
     FeaturesType,
     Learner <: Regressor[FeaturesType, Learner, M],
     M <: RegressionModel[FeaturesType, M]]

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/NodeIdCache.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/NodeIdCache.scala
@@ -172,7 +172,7 @@ private[spark] class NodeIdCache(
 }
 
 @DeveloperApi
-private[spark] object NodeIdCache {
+object NodeIdCache {
   /**
    * Initialize the node Id cache with initial node Id values.
    * @param data The RDD of training rows.

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/NodeIdCache.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/NodeIdCache.scala
@@ -171,8 +171,7 @@ private[spark] class NodeIdCache(
   }
 }
 
-@DeveloperApi
-object NodeIdCache {
+private[spark] object NodeIdCache {
   /**
    * Initialize the node Id cache with initial node Id values.
    * @param data The RDD of training rows.

--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/ValidatorParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/ValidatorParams.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.types.StructType
  * Common params for [[TrainValidationSplitParams]] and [[CrossValidatorParams]].
  */
 @DeveloperApi
-private[ml] trait ValidatorParams extends Params {
+trait ValidatorParams extends Params {
 
   /**
    * param for the estimator to be validated

--- a/mllib/src/main/scala/org/apache/spark/ml/tuning/ValidatorParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tuning/ValidatorParams.scala
@@ -17,18 +17,15 @@
 
 package org.apache.spark.ml.tuning
 
-import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.ml.Estimator
 import org.apache.spark.ml.evaluation.Evaluator
 import org.apache.spark.ml.param.{Param, ParamMap, Params}
 import org.apache.spark.sql.types.StructType
 
 /**
- * :: DeveloperApi ::
  * Common params for [[TrainValidationSplitParams]] and [[CrossValidatorParams]].
  */
-@DeveloperApi
-trait ValidatorParams extends Params {
+private[ml] trait ValidatorParams extends Params {
 
   /**
    * param for the estimator to be validated

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
@@ -156,8 +156,7 @@ sealed trait Matrix extends Serializable {
   def numActives: Int
 }
 
-@DeveloperApi
-class MatrixUDT extends UserDefinedType[Matrix] {
+private[spark] class MatrixUDT extends UserDefinedType[Matrix] {
 
   override def sqlType: StructType = {
     // type: 0 = sparse, 1 = dense

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Matrices.scala
@@ -157,7 +157,7 @@ sealed trait Matrix extends Serializable {
 }
 
 @DeveloperApi
-private[spark] class MatrixUDT extends UserDefinedType[Matrix] {
+class MatrixUDT extends UserDefinedType[Matrix] {
 
   override def sqlType: StructType = {
     // type: 0 = sparse, 1 = dense

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/impl/NodeIdCache.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/impl/NodeIdCache.scala
@@ -34,7 +34,7 @@ import org.apache.spark.storage.StorageLevel
  * @param nodeIndex The current node index of a data point that this will update.
  */
 @DeveloperApi
-case class NodeIndexUpdater(
+private[tree] case class NodeIndexUpdater(
     split: Split,
     nodeIndex: Int) {
   /**
@@ -75,7 +75,7 @@ case class NodeIndexUpdater(
  *                           (how often should the cache be checkpointed.).
  */
 @DeveloperApi
-class NodeIdCache(
+private[spark] class NodeIdCache(
   var nodeIdsForInstances: RDD[Array[Int]],
   val checkpointInterval: Int) {
 
@@ -173,9 +173,7 @@ class NodeIdCache(
   }
 }
 
-
-@DeveloperApi
-object NodeIdCache {
+private[spark] object NodeIdCache {
   /**
    * Initialize the node Id cache with initial node Id values.
    * @param data The RDD of training rows.

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/impl/NodeIdCache.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/impl/NodeIdCache.scala
@@ -34,7 +34,7 @@ import org.apache.spark.storage.StorageLevel
  * @param nodeIndex The current node index of a data point that this will update.
  */
 @DeveloperApi
-private[tree] case class NodeIndexUpdater(
+case class NodeIndexUpdater(
     split: Split,
     nodeIndex: Int) {
   /**
@@ -75,7 +75,7 @@ private[tree] case class NodeIndexUpdater(
  *                           (how often should the cache be checkpointed.).
  */
 @DeveloperApi
-private[spark] class NodeIdCache(
+class NodeIdCache(
   var nodeIdsForInstances: RDD[Array[Int]],
   val checkpointInterval: Int) {
 
@@ -173,8 +173,9 @@ private[spark] class NodeIdCache(
   }
 }
 
+
 @DeveloperApi
-private[spark] object NodeIdCache {
+object NodeIdCache {
   /**
    * Initialize the node Id cache with initial node Id values.
    * @param data The RDD of training rows.

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/InformationGainStats.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/InformationGainStats.scala
@@ -79,7 +79,6 @@ private[spark] object InformationGainStats {
 }
 
 /**
- * :: DeveloperApi ::
  * Impurity statistics for each split
  * @param gain information gain value
  * @param impurity current node impurity
@@ -89,8 +88,7 @@ private[spark] object InformationGainStats {
  * @param valid whether the current split satisfies minimum info gain or
  *              minimum number of instances per node
  */
-@DeveloperApi
-class ImpurityStats(
+private[spark] class ImpurityStats(
     val gain: Double,
     val impurity: Double,
     val impurityCalculator: ImpurityCalculator,

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/InformationGainStats.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/InformationGainStats.scala
@@ -90,7 +90,7 @@ private[spark] object InformationGainStats {
  *              minimum number of instances per node
  */
 @DeveloperApi
-private[spark] class ImpurityStats(
+class ImpurityStats(
     val gain: Double,
     val impurity: Double,
     val impurityCalculator: ImpurityCalculator,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Spark uses `@DeveloperApi` annotation, but sometimes it seems to conflict with visibility. This PR tries to fix those conflict by removing annotations for non-publics. The following is the example.

**JobResult.scala**

``` scala
@DeveloperApi
sealed trait JobResult

@DeveloperApi
case object JobSucceeded extends JobResult

-@DeveloperApi
private[spark] case class JobFailed(exception: Exception) extends JobResult
```
## How was this patch tested?

Pass the existing Jenkins test.
