### PR TITLE
[SPARK-13997][SQL] Use Hadoop 2.0 default value for compression in data sources.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/CompressionCodecs.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/CompressionCodecs.scala
@@ -59,7 +59,7 @@ private[datasources] object CompressionCodecs {
   def setCodecConfiguration(conf: Configuration, codec: String): Unit = {
     if (codec != null) {
       conf.set("mapreduce.output.fileoutputformat.compress", "true")
-      conf.set("mapreduce.output.fileoutputformat.compress.type", CompressionType.BLOCK.toString)
+      conf.set("mapreduce.output.fileoutputformat.compress.type", CompressionType.RECORD.toString)
       conf.set("mapreduce.output.fileoutputformat.compress.codec", codec)
       conf.set("mapreduce.map.output.compress", "true")
       conf.set("mapreduce.map.output.compress.codec", codec)


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://issues.apache.org/jira/browse/SPARK-13997

Currently, JSON, TEXT and CSV data sources use `CompressionCodecs` class to set compression configurations via `option("compress", "codec")`.

I made this uses Hadoop 1.x default value (block level compression). However, the default value in Hadoop 2.x is record level compression as described in [mapred-site.xml](https://hadoop.apache.org/docs/r2.7.1/hadoop-mapreduce-client/hadoop-mapreduce-client-core/mapred-default.xml).

Since it drops Hadoop 1.x, it will make sense to use Hadoop 2.x default values.
## How was this patch tested?

Via `./dev/run_tests` and unit tests.
