### PR TITLE
[SPARK-913] [CORE] log the size of each shuffle block in block manager

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -709,6 +709,7 @@ private[spark] class BlockManager(
       level: StorageLevel,
       tellMaster: Boolean = true): Boolean = {
     require(bytes != null, "Bytes is null")
+    logInfo(s"Putting block $blockId with the size of ${bytes.size} bytes in ${level.description}")
     doPutBytes(blockId, bytes, level, tellMaster)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added a log message which shows the size of the block.
## How was this patch tested?

Verified it manually that this log is coming in the executor log.
