### PR TITLE
[Minor][DOC] Fix nits in JavaStreamingTestExample

### DIFF
--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaStreamingTestExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaStreamingTestExample.java
@@ -56,6 +56,9 @@ import org.apache.spark.util.Utils;
  * batches processed exceeds `numBatchesTimeout`.
  */
 public class JavaStreamingTestExample {
+
+  private static int timeoutCounter = 0;
+
   public static void main(String[] args) {
     if (args.length != 3) {
       System.err.println("Usage: JavaStreamingTestExample " +
@@ -94,22 +97,21 @@ public class JavaStreamingTestExample {
     // $example off$
 
     // Stop processing if test becomes significant or we time out
-    final Accumulator<Integer> timeoutCounter =
-      ssc.sparkContext().accumulator(numBatchesTimeout);
+    timeoutCounter = numBatchesTimeout;
 
     out.foreachRDD(new VoidFunction<JavaRDD<StreamingTestResult>>() {
       @Override
       public void call(JavaRDD<StreamingTestResult> rdd) throws Exception {
-        timeoutCounter.add(-1);
+        timeoutCounter -= 1;
 
-        long cntSignificant = rdd.filter(new Function<StreamingTestResult, Boolean>() {
+        boolean anySignificant = ! rdd.filter(new Function<StreamingTestResult, Boolean>() {
           @Override
           public Boolean call(StreamingTestResult v) throws Exception {
             return v.pValue() < 0.05;
           }
-        }).count();
+        }).isEmpty();
 
-        if (timeoutCounter.value() <= 0 || cntSignificant > 0) {
+        if (timeoutCounter <= 0 || anySignificant) {
           rdd.context().stop();
         }
       }

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaStreamingTestExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaStreamingTestExample.java
@@ -79,7 +79,7 @@ public class JavaStreamingTestExample {
     JavaDStream<BinarySample> data = ssc.textFileStream(dataDir).map(
       new Function<String, BinarySample>() {
         @Override
-        public BinarySample call(String line) throws Exception {
+        public BinarySample call(String line) {
           String[] ts = line.split(",");
           boolean label = Boolean.valueOf(ts[0]);
           double value = Double.valueOf(ts[1]);
@@ -101,12 +101,12 @@ public class JavaStreamingTestExample {
 
     out.foreachRDD(new VoidFunction<JavaRDD<StreamingTestResult>>() {
       @Override
-      public void call(JavaRDD<StreamingTestResult> rdd) throws Exception {
+      public void call(JavaRDD<StreamingTestResult> rdd) {
         timeoutCounter -= 1;
 
         boolean anySignificant = ! rdd.filter(new Function<StreamingTestResult, Boolean>() {
           @Override
-          public Boolean call(StreamingTestResult v) throws Exception {
+          public Boolean call(StreamingTestResult v) {
             return v.pValue() < 0.05;
           }
         }).isEmpty();

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaStreamingTestExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaStreamingTestExample.java
@@ -104,7 +104,7 @@ public class JavaStreamingTestExample {
       public void call(JavaRDD<StreamingTestResult> rdd) {
         timeoutCounter -= 1;
 
-        boolean anySignificant = ! rdd.filter(new Function<StreamingTestResult, Boolean>() {
+        boolean anySignificant = !rdd.filter(new Function<StreamingTestResult, Boolean>() {
           @Override
           public Boolean call(StreamingTestResult v) {
             return v.pValue() < 0.05;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix some nits discussed in https://github.com/apache/spark/pull/11776#issuecomment-198207419
use !rdd.isEmpty instead of rdd.count > 0
use static instead of AtomicInteger
remove unneeded "throws Exception" 
## How was this patch tested?

manual tests
