### PR TITLE
[SPARK-13963][ML] Adding binary toggle param to HashingTF

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
@@ -79,7 +79,7 @@ class HashingTF(override val uid: String)
 
   override def transform(dataset: DataFrame): DataFrame = {
     val outputSchema = transformSchema(dataset.schema)
-    val hashingTF = new feature.HashingTF($(numFeatures), $(binary))
+    val hashingTF = new feature.HashingTF($(numFeatures)).setBinary($(binary))
     val t = udf { terms: Seq[_] => hashingTF.transform(terms) }
     val metadata = outputSchema($(outputCol)).metadata
     dataset.select(col("*"), t(col($(inputCol))).as($(outputCol), metadata))

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
@@ -20,7 +20,7 @@ package org.apache.spark.ml.feature
 import org.apache.spark.annotation.{Experimental, Since}
 import org.apache.spark.ml.Transformer
 import org.apache.spark.ml.attribute.AttributeGroup
-import org.apache.spark.ml.param.{IntParam, ParamMap, ParamValidators}
+import org.apache.spark.ml.param.{BooleanParam, IntParam, ParamMap, ParamValidators}
 import org.apache.spark.ml.param.shared.{HasInputCol, HasOutputCol}
 import org.apache.spark.ml.util._
 import org.apache.spark.mllib.feature
@@ -52,7 +52,14 @@ class HashingTF(override val uid: String)
   val numFeatures = new IntParam(this, "numFeatures", "number of features (> 0)",
     ParamValidators.gt(0))
 
-  setDefault(numFeatures -> (1 << 18))
+  /**
+   * Binary toggle ****
+   */
+  val binary = new BooleanParam(this, "binary", "If true, all non zero counts are set to 1. " +
+    "This is useful for discrete probabilistic models that model binary events rather " +
+    "than integer counts")
+
+  setDefault(numFeatures -> (1 << 18), binary -> false)
 
   /** @group getParam */
   def getNumFeatures: Int = $(numFeatures)
@@ -60,9 +67,15 @@ class HashingTF(override val uid: String)
   /** @group setParam */
   def setNumFeatures(value: Int): this.type = set(numFeatures, value)
 
+  /** @group getParam */
+  def getBinary: Boolean = $(binary)
+
+  /** @group setParam */
+  def setBinary(value: Boolean): this.type = set(binary, value)
+
   override def transform(dataset: DataFrame): DataFrame = {
     val outputSchema = transformSchema(dataset.schema)
-    val hashingTF = new feature.HashingTF($(numFeatures))
+    val hashingTF = new feature.HashingTF($(numFeatures), $(binary))
     val t = udf { terms: Seq[_] => hashingTF.transform(terms) }
     val metadata = outputSchema($(outputCol)).metadata
     dataset.select(col("*"), t(col($(inputCol))).as($(outputCol), metadata))

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/HashingTF.scala
@@ -53,7 +53,11 @@ class HashingTF(override val uid: String)
     ParamValidators.gt(0))
 
   /**
-   * Binary toggle ****
+   * Binary toggle to control term frequency counts.
+   * If true, all non-zero counts are set to 1.  This is useful for discrete probabilistic
+   * models that model binary events rather than integer counts.
+   * (default = false)
+   * @group param
    */
   val binary = new BooleanParam(this, "binary", "If true, all non zero counts are set to 1. " +
     "This is useful for discrete probabilistic models that model binary events rather " +

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/HashingTF.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/HashingTF.scala
@@ -32,16 +32,26 @@ import org.apache.spark.util.Utils
  * Maps a sequence of terms to their term frequencies using the hashing trick.
  *
  * @param numFeatures number of features (default: 2^20^)
- * @param binary If true, term frequency vector will be binary such that non-zero term counts
- *               will be set to 1 (default: false)
  */
 @Since("1.1.0")
-class HashingTF(val numFeatures: Int, val binary: Boolean) extends Serializable {
+class HashingTF(val numFeatures: Int) extends Serializable {
+
+  private var binary = false
 
   /**
    */
   @Since("1.1.0")
-  def this() = this(1 << 20, false)
+  def this() = this(1 << 20)
+
+  /**
+   * Sets the binary toggle param. If true, term frequency vector will be binary such that non-zero
+   * term counts will be set to 1 (default: false)
+   */
+  @Since("2.0.0")
+  def setBinary(value: Boolean): this.type = {
+    binary = value
+    this
+  }
 
   /**
    * Returns the index of the input term.

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/HashingTF.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/HashingTF.scala
@@ -44,8 +44,8 @@ class HashingTF(val numFeatures: Int) extends Serializable {
   def this() = this(1 << 20)
 
   /**
-   * Sets the binary toggle param. If true, term frequency vector will be binary such that non-zero
-   * term counts will be set to 1 (default: false)
+   * If true, term frequency vector will be binary such that non-zero term counts will be set to 1
+   * (default: false)
    */
   @Since("2.0.0")
   def setBinary(value: Boolean): this.type = {

--- a/mllib/src/main/scala/org/apache/spark/mllib/feature/HashingTF.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/feature/HashingTF.scala
@@ -32,14 +32,16 @@ import org.apache.spark.util.Utils
  * Maps a sequence of terms to their term frequencies using the hashing trick.
  *
  * @param numFeatures number of features (default: 2^20^)
+ * @param binary If true, term frequency vector will be binary such that non-zero term counts
+ *               will be set to 1 (default: false)
  */
 @Since("1.1.0")
-class HashingTF(val numFeatures: Int) extends Serializable {
+class HashingTF(val numFeatures: Int, val binary: Boolean) extends Serializable {
 
   /**
    */
   @Since("1.1.0")
-  def this() = this(1 << 20)
+  def this() = this(1 << 20, false)
 
   /**
    * Returns the index of the input term.
@@ -53,9 +55,10 @@ class HashingTF(val numFeatures: Int) extends Serializable {
   @Since("1.1.0")
   def transform(document: Iterable[_]): Vector = {
     val termFrequencies = mutable.HashMap.empty[Int, Double]
+    val setTF = if (binary) (i: Int) => 1.0 else (i: Int) => termFrequencies.getOrElse(i, 0.0) + 1.0
     document.foreach { term =>
       val i = indexOf(term)
-      termFrequencies.put(i, termFrequencies.getOrElse(i, 0.0) + 1.0)
+      termFrequencies.put(i, setTF(i))
     }
     Vectors.sparse(numFeatures, termFrequencies.toSeq)
   }

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/HashingTFSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/HashingTFSuite.scala
@@ -46,7 +46,7 @@ class HashingTFSuite extends SparkFunSuite with MLlibTestSparkContext with Defau
     require(attrGroup.numAttributes === Some(n))
     val features = output.select("features").first().getAs[Vector](0)
     // Assume perfect hash on "a", "b", "c", and "d".
-    def idx(any: Any): Int = Utils.nonNegativeMod(any.##, n)
+    def idx: Any => Int = featureIdx(n)
     val expected = Vectors.sparse(n,
       Seq((idx("a"), 2.0), (idx("b"), 2.0), (idx("c"), 1.0), (idx("d"), 1.0)))
     assert(features ~== expected absTol 1e-14)
@@ -63,11 +63,8 @@ class HashingTFSuite extends SparkFunSuite with MLlibTestSparkContext with Defau
         .setNumFeatures(n)
         .setBinary(true)
     val output = hashingTF.transform(df)
-    val attrGroup = AttributeGroup.fromStructField(output.schema("features"))
-    require(attrGroup.numAttributes === Some(n))
     val features = output.select("features").first().getAs[Vector](0)
-    // Assume perfect hash on "a", "b", "c".
-    def idx(any: Any): Int = Utils.nonNegativeMod(any.##, n)
+    def idx: Any => Int = featureIdx(n)  // Assume perfect hash on input features
     val expected = Vectors.sparse(n,
       Seq((idx("a"), 1.0), (idx("b"), 1.0), (idx("c"), 1.0)))
     assert(features ~== expected absTol 1e-14)
@@ -79,5 +76,9 @@ class HashingTFSuite extends SparkFunSuite with MLlibTestSparkContext with Defau
       .setOutputCol("myOutputCol")
       .setNumFeatures(10)
     testDefaultReadWrite(t)
+  }
+
+  private def featureIdx(numFeatures: Int)(term: Any): Int = {
+    Utils.nonNegativeMod(term.##, numFeatures)
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/mllib/feature/HashingTFSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/feature/HashingTFSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.mllib.util.TestingUtils._
 class HashingTFSuite extends SparkFunSuite with MLlibTestSparkContext {
 
   test("hashing tf on a single doc") {
-    val hashingTF = new HashingTF(1000, false)
+    val hashingTF = new HashingTF(1000)
     val doc = "a a b b c d".split(" ")
     val n = hashingTF.numFeatures
     val termFreqs = Seq(
@@ -51,7 +51,7 @@ class HashingTFSuite extends SparkFunSuite with MLlibTestSparkContext {
   }
 
   test("applying binary term freqs") {
-    val hashingTF = new HashingTF(100, true)
+    val hashingTF = new HashingTF(100).setBinary(true)
     val doc = "a a b c c c".split(" ")
     val n = hashingTF.numFeatures
     val expected = Vectors.sparse(n, Seq(

--- a/mllib/src/test/scala/org/apache/spark/mllib/feature/HashingTFSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/feature/HashingTFSuite.scala
@@ -20,11 +20,12 @@ package org.apache.spark.mllib.feature
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.util.MLlibTestSparkContext
+import org.apache.spark.mllib.util.TestingUtils._
 
 class HashingTFSuite extends SparkFunSuite with MLlibTestSparkContext {
 
   test("hashing tf on a single doc") {
-    val hashingTF = new HashingTF(1000)
+    val hashingTF = new HashingTF(1000, false)
     val doc = "a a b b c d".split(" ")
     val n = hashingTF.numFeatures
     val termFreqs = Seq(
@@ -47,5 +48,16 @@ class HashingTFSuite extends SparkFunSuite with MLlibTestSparkContext {
       "c b a c b a a".split(" "))
     val docs = sc.parallelize(localDocs, 2)
     assert(hashingTF.transform(docs).collect().toSet === localDocs.map(hashingTF.transform).toSet)
+  }
+
+  test("applying binary term freqs") {
+    val hashingTF = new HashingTF(100, true)
+    val doc = "a a b c c c".split(" ")
+    val n = hashingTF.numFeatures
+    val expected = Vectors.sparse(n, Seq(
+      (hashingTF.indexOf("a"), 1.0),
+      (hashingTF.indexOf("b"), 1.0),
+      (hashingTF.indexOf("c"), 1.0)))
+    assert(hashingTF.transform(doc) ~== expected absTol 1e-14)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding binary toggle parameter to ml.feature.HashingTF, as well as mllib.feature.HashingTF since the former wraps this functionality.  This parameter, if true, will set non-zero valued term counts to 1 to transform term count features to binary values that are well suited for discrete probability models.
## How was this patch tested?

Added unit tests for ML and MLlib
