### PR TITLE
[SPARK-14021][SQL] custom context support for SparkSQLEnv

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnv.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnv.scala
@@ -36,7 +36,7 @@ private[hive] object SparkSQLEnv extends Logging {
 
   private def readContextClassFromConf(sparkConf: SparkConf): Class[_ <: HiveContext] = {
     val className =
-      sparkConf.get("spark.sql.context.class", "org.apache.spark.sql.hive.HiveContext")
+      sparkConf.get("spark.sql.context.class", classOf[HiveContext].getName)
     val configuredContextClass = Utils.classForName(className)
     val defaultContextClass = classOf[HiveContext]
     if (defaultContextClass.isAssignableFrom(configuredContextClass)) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is to create a custom context for command `bin/spark-sql` and `sbin/start-thriftserver`. Any context that is derived from `HiveContext` is acceptable. User need to configure the class name of custom context in a config of `spark.sql.context.class`, and make sure the class in classpath. This is to provide a more elegant way for custom configurations and changes for infrastructure team.
## How was this patch tested?

Added a unit test in `CliSuite` to track this.

cc @chenghao-intel 
