### PR TITLE
[SPARK-14004][follow-up] Implementations of NonSQLExpression should not override sql method

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -226,7 +226,7 @@ trait Unevaluable extends Expression {
  * `ScalaUDF`, `ScalaUDAF`, and object expressions like `MapObjects` and `Invoke`.
  */
 trait NonSQLExpression extends Expression {
-  override def sql: String = {
+  final override def sql: String = {
     transform {
       case a: Attribute => new PrettyAttribute(a)
     }.toString

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonUDF.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonUDF.scala
@@ -32,9 +32,7 @@ case class PythonUDF(
     children: Seq[Expression])
   extends Expression with Unevaluable with NonSQLExpression with Logging {
 
-  override def toString: String = s"PythonUDF#$name(${children.mkString(", ")})"
+  override def toString: String = s"$name(${children.mkString(", ")})"
 
   override def nullable: Boolean = true
-
-  override def sql: String = s"$name(${children.mkString(", ")})"
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

There is only one exception: `PythonUDF`. However, I don't think the `PythonUDF#` prefix is useful, as we can only create python udf under python context. This PR removes the `PythonUDF#` prefix from `PythonUDF.toString`, so that it doesn't need to overrde `sql`.
## How was this patch tested?

existing tests.
