### PR TITLE
[SPARK-14051][SQL] Implement `Double.NaN==Float.NaN` for consistency.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/Row.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/Row.scala
@@ -402,11 +402,13 @@ trait Row extends Serializable {
               return false
             }
           case f1: Float if java.lang.Float.isNaN(f1) =>
-            if (!o2.isInstanceOf[Float] || ! java.lang.Float.isNaN(o2.asInstanceOf[Float])) {
+            if (!(o2.isInstanceOf[Float] && java.lang.Float.isNaN(o2.asInstanceOf[Float]) ||
+              o2.isInstanceOf[Double] && java.lang.Double.isNaN(o2.asInstanceOf[Double]))) {
               return false
             }
           case d1: Double if java.lang.Double.isNaN(d1) =>
-            if (!o2.isInstanceOf[Double] || ! java.lang.Double.isNaN(o2.asInstanceOf[Double])) {
+            if (!(o2.isInstanceOf[Float] && java.lang.Float.isNaN(o2.asInstanceOf[Float]) ||
+              o2.isInstanceOf[Double] && java.lang.Double.isNaN(o2.asInstanceOf[Double]))) {
               return false
             }
           case d1: java.math.BigDecimal if o2.isInstanceOf[java.math.BigDecimal] =>
@@ -429,7 +431,12 @@ trait Row extends Serializable {
     var h = MurmurHash3.seqSeed
     val len = length
     while (n < len) {
-      h = MurmurHash3.mix(h, apply(n).##)
+      val v = apply(n)
+      if (v.isInstanceOf[Float] && java.lang.Float.isNaN(v.asInstanceOf[Float])) {
+        h = MurmurHash3.mix(h, Double.NaN.##)
+      } else {
+        h = MurmurHash3.mix(h, v.##)
+      }
       n += 1
     }
     MurmurHash3.finalizeHash(h, n)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/rows.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/rows.scala
@@ -109,11 +109,13 @@ trait BaseGenericInternalRow extends InternalRow {
               return false
             }
           case f1: Float if java.lang.Float.isNaN(f1) =>
-            if (!o2.isInstanceOf[Float] || ! java.lang.Float.isNaN(o2.asInstanceOf[Float])) {
+            if (!(o2.isInstanceOf[Float] && java.lang.Float.isNaN(o2.asInstanceOf[Float]) ||
+              o2.isInstanceOf[Double] && java.lang.Double.isNaN(o2.asInstanceOf[Double]))) {
               return false
             }
           case d1: Double if java.lang.Double.isNaN(d1) =>
-            if (!o2.isInstanceOf[Double] || ! java.lang.Double.isNaN(o2.asInstanceOf[Double])) {
+            if (!(o2.isInstanceOf[Float] && java.lang.Float.isNaN(o2.asInstanceOf[Float]) ||
+              o2.isInstanceOf[Double] && java.lang.Double.isNaN(o2.asInstanceOf[Double]))) {
               return false
             }
           case _ => if (o1 != o2) {
@@ -142,7 +144,13 @@ trait BaseGenericInternalRow extends InternalRow {
             case s: Short => s.toInt
             case i: Int => i
             case l: Long => (l ^ (l >>> 32)).toInt
-            case f: Float => java.lang.Float.floatToIntBits(f)
+            case f: Float =>
+              if (f.isInstanceOf[Float] && java.lang.Float.isNaN(f.asInstanceOf[Float])) {
+                val b = java.lang.Double.doubleToLongBits(Double.NaN)
+                (b ^ (b >>> 32)).toInt
+              } else {
+                java.lang.Float.floatToIntBits(f)
+              }
             case d: Double =>
               val b = java.lang.Double.doubleToLongBits(d)
               (b ^ (b >>> 32)).toInt

--- a/sql/core/src/test/scala/org/apache/spark/sql/RowSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/RowSuite.scala
@@ -93,5 +93,11 @@ class RowSuite extends SparkFunSuite with SharedSQLContext {
     assert(r1.hashCode() === r2.hashCode())
     val r3 = Row("World")
     assert(r3.hashCode() != r1.hashCode())
+
+    val r4 = Row(Float.NaN)
+    val r5 = Row(Double.NaN)
+    assert(r4 === r5)
+    assert(r5 === r4)
+    assert(r4.hashCode() === r5.hashCode())
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since [SPARK-9079](https://issues.apache.org/jira/browse/SPARK-9079) and [SPARK-9145](https://issues.apache.org/jira/browse/SPARK-9145), `NaN = NaN` returns true and works well. The only exception case is direct comparison between `Row(Float.NaN)` and `Row(Double.NaN)`. The following is the example: the last two expressions had better be **`true`** and **`List([NaN])`** for consistency.

``` scala
scala> Seq((1d,1f),(Double.NaN,Float.NaN)).toDF("a","b").registerTempTable("tmp")
scala> sql("select a,b,a=b from tmp").collect()
res1: Array[org.apache.spark.sql.Row] = Array([1.0,1.0,true], [NaN,NaN,true])
scala> val row_a = sql("select a from tmp").collect()
row_a: Array[org.apache.spark.sql.Row] = Array([1.0], [NaN])
scala> val row_b = sql("select b from tmp").collect()
row_b: Array[org.apache.spark.sql.Row] = Array([1.0], [NaN])
scala> row_a(0) == row_b(0)
res2: Boolean = true
scala> List(row_a(0),row_b(0)).distinct
res3: List[org.apache.spark.sql.Row] = List([1.0])
scala> row_a(1) == row_b(1)
res4: Boolean = false
scala> List(row_a(1),row_b(1)).distinct
res5: List[org.apache.spark.sql.Row] = List([NaN], [NaN])
```

Please note that the following background truths as of today (before this PR).
- Double.NaN != Double.NaN (Scala/Java/IEEE Standard)
- Float.NaN != Float.NaN (Scala/Java/IEEE Standard)
- Double.NaN != Float.NaN (Scala/Java/IEEE Standard)
- Row(Double.NaN) == Row(Double.NaN)
- Row(Float.NaN) == Row(Float.NaN)
- **Row(Double.NaN) != Row(Float.NaN) <== The problem of this PR**
## How was this patch tested?

Pass the Jenkins tests including new testcases.
