### PR TITLE
[SPARK-14038][SQL] enable native view by default

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -365,7 +365,7 @@ object SQLConf {
           "unmatching partitions can be eliminated earlier.")
 
   val NATIVE_VIEW = booleanConf("spark.sql.nativeView",
-    defaultValue = Some(false),
+    defaultValue = Some(true),
     doc = "When true, CREATE VIEW will be handled by Spark SQL instead of Hive native commands.  " +
           "Note that this function is experimental and should ony be used when you are using " +
           "non-hive-compatible tables written by Spark SQL.  The SQL string used to create " +

--- a/sql/hive/compatibility/src/test/scala/org/apache/spark/sql/hive/execution/HiveCompatibilitySuite.scala
+++ b/sql/hive/compatibility/src/test/scala/org/apache/spark/sql/hive/execution/HiveCompatibilitySuite.scala
@@ -336,7 +336,12 @@ class HiveCompatibilitySuite extends HiveQueryFileTest with BeforeAndAfter {
     "udf_format_number",
     "udf_round",
     "udf_round_3",
-    "view_cast"
+    "view_cast",
+
+    // These tests check the VIEW table definition, but Spark handles CREATE VIEW itself and
+    // generates different View Expanded Text.
+    "alter_view_as_select",
+    "show_create_table_view"
   )
 
   /**
@@ -361,7 +366,6 @@ class HiveCompatibilitySuite extends HiveQueryFileTest with BeforeAndAfter {
     "alter_table_serde",
     "alter_varchar1",
     "alter_varchar2",
-    "alter_view_as_select",
     "ambiguous_col",
     "annotate_stats_join",
     "annotate_stats_limit",
@@ -833,7 +837,6 @@ class HiveCompatibilitySuite extends HiveQueryFileTest with BeforeAndAfter {
     "show_create_table_index",
     "show_create_table_partitioned",
     "show_create_table_serde",
-    "show_create_table_view",
     "show_describe_func_quotes",
     "show_functions",
     "show_partitions",


### PR DESCRIPTION
## What changes were proposed in this pull request?

As we have completed the `SQLBuilder`, we can safely turn on native view by default.
## How was this patch tested?

existing tests.
