### PR TITLE
[SPARK-14058][PYTHON]  Incorrect docstring in Window.order

### DIFF
--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -60,7 +60,7 @@ class Window(object):
     @since(1.4)
     def orderBy(*cols):
         """
-        Creates a :class:`WindowSpec` with the partitioning defined.
+        Creates a :class:`WindowSpec` with the ordering defined.
         """
         sc = SparkContext._active_spark_context
         jspec = sc._jvm.org.apache.spark.sql.expressions.Window.orderBy(_to_java_cols(cols))


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replaces current docstring ("Creates a :class:`WindowSpec` with the partitioning defined.") with "Creates a :class:`WindowSpec` with the ordering defined."
## How was this patch tested?

PySpark unit tests (no regression introduced). No changes to the code.  
