### PR TITLE
[SPARK-13887][PYTHON][TRIVIAL][BUILD] Make lint-python script fail fast

### DIFF
--- a/dev/lint-python
+++ b/dev/lint-python
@@ -60,22 +60,6 @@ export "PYTHONPATH=$SPARK_ROOT_DIR/dev/pylint"
 export "PYLINT_HOME=$PYTHONPATH"
 export "PATH=$PYTHONPATH:$PATH"
 
-# if [ ! -d "$PYLINT_HOME" ]; then
-#     mkdir "$PYLINT_HOME"
-#     # Redirect the annoying pylint installation output.
-#     easy_install -d "$PYLINT_HOME" pylint==1.4.4 &>> "$PYLINT_INSTALL_INFO"
-#     easy_install_status="$?"
-#
-#     if [ "$easy_install_status" -ne 0 ]; then
-#         echo "Unable to install pylint locally in \"$PYTHONPATH\"."
-#         cat "$PYLINT_INSTALL_INFO"
-#         exit "$easy_install_status"
-#     fi
-#
-#     rm "$PYLINT_INSTALL_INFO"
-#
-# fi
-
 # There is no need to write this output to a file
 #+ first, but we do so so that the check status can
 #+ be output before the report, like with the
@@ -92,11 +76,12 @@ fi
 if [ "$lint_status" -ne 0 ]; then
     echo "PEP8 checks failed."
     cat "$PEP8_REPORT_PATH"
+    rm "$PEP8_REPORT_PATH"
+    exit "$lint_status"
 else
     echo "PEP8 checks passed."
+    rm "$PEP8_REPORT_PATH"
 fi
-
-rm "$PEP8_REPORT_PATH"
 
 # Check that the documentation builds acceptably, skip check if sphinx is not installed.
 if hash "$SPHINXBUILD" 2> /dev/null; then
@@ -110,29 +95,13 @@ if hash "$SPHINXBUILD" 2> /dev/null; then
     echo "re-running make html to print full warning list"
     make clean
     SPHINXOPTS="-a" make html
+    rm "$SPHINX_REPORT_PATH"
+    exit "$lint_status"
   else
     echo "pydoc checks passed."
+    rm "$SPHINX_REPORT_PATH"
   fi
-  rm "$SPHINX_REPORT_PATH"
   cd ../..
 else
   echo >&2 "The $SPHINXBUILD command was not found. Skipping pydoc checks for now"
 fi
-
-
-# for to_be_checked in "$PATHS_TO_CHECK"
-# do
-#     pylint --rcfile="$SPARK_ROOT_DIR/python/pylintrc" $to_be_checked >> "$PYLINT_REPORT_PATH"
-# done
-
-# if [ "${PIPESTATUS[0]}" -ne 0 ]; then
-#     lint_status=1
-#     echo "Pylint checks failed."
-#     cat "$PYLINT_REPORT_PATH"
-# else
-#     echo "Pylint checks passed."
-# fi
-
-# rm "$PYLINT_REPORT_PATH"
-
-exit "$lint_status"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change lint python script to stop on first error rather than building them up so its clearer why we failed (requested by @rxin). Also while in the file, remove the commented out code.
## How was this patch tested?

Manually ran lint-python script with & without pep8 errors locally and verified expected results.
