### PR TITLE
[HOTFIX][SQL]Add a timeout for 'cq.stop'

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/StreamTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StreamTest.scala
@@ -28,6 +28,7 @@ import scala.util.control.NonFatal
 
 import org.scalatest.Assertions
 import org.scalatest.concurrent.{Eventually, Timeouts}
+import org.scalatest.concurrent.Eventually.timeout
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.exceptions.TestFailedDueToTimeoutException
 import org.scalatest.time.Span
@@ -67,7 +68,14 @@ trait StreamTest extends QueryTest with Timeouts {
 
   implicit class RichContinuousQuery(cq: ContinuousQuery) {
     def stopQuietly(): Unit = quietly {
-      cq.stop()
+      try {
+        failAfter(10.seconds) {
+          cq.stop()
+        }
+      } catch {
+        case e: TestFailedDueToTimeoutException =>
+          logError(e.getMessage(), e)
+      }
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix an issue that DataFrameReaderWriterSuite may hang forever.
## How was this patch tested?

Existing tests.
