### PR TITLE
[SPARK-14085] [SQL] Star Expansion for Hash

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -445,11 +445,6 @@ class Analyzer(
             case s: Star => s.expand(child, resolver)
             case o => o :: Nil
           })
-        case p: Concat if containsStar(p.children) =>
-          p.copy(children = p.children.flatMap {
-            case s: Star => s.expand(child, resolver)
-            case o => o :: Nil
-          })
         // count(*) has been replaced by count(1)
         case o if containsStar(o.children) =>
           failAnalysis(s"Invalid usage of '*' in expression '${o.prettyName}'")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -403,13 +403,13 @@ class Analyzer(
      */
     private def buildExpandedProjectList(
         exprs: Seq[NamedExpression],
-        plan: LogicalPlan): Seq[NamedExpression] = {
+        child: LogicalPlan): Seq[NamedExpression] = {
       exprs.flatMap {
         // Using Dataframe/Dataset API: testData2.groupBy($"a", $"b").agg($"*")
-        case s: Star => s.expand(plan, resolver)
+        case s: Star => s.expand(child, resolver)
         // Using SQL API without running ResolveAlias: SELECT * FROM testData2 group by a, b
-        case UnresolvedAlias(s: Star, _) => s.expand(plan, resolver)
-        case o if containsStar(o :: Nil) => expandStarExpression(o, plan) :: Nil
+        case UnresolvedAlias(s: Star, _) => s.expand(child, resolver)
+        case o if containsStar(o :: Nil) => expandStarExpression(o, child) :: Nil
         case o => o :: Nil
       }.map(_.asInstanceOf[NamedExpression])
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -408,7 +408,7 @@ class Analyzer(
         // Using Dataframe/Dataset API: testData2.groupBy($"a", $"b").agg($"*")
         case s: Star => s.expand(plan.child, resolver)
         // Using SQL API without running ResolveAlias: SELECT * FROM testData2 group by a, b
-        case UnresolvedAlias(s: Star, _) => expandStarExpression(s, plan.child) :: Nil
+        case UnresolvedAlias(s: Star, _) => s.expand(plan.child, resolver)
         case o if containsStar(o :: Nil) => expandStarExpression(o, plan.child) :: Nil
         case o => o :: Nil
       }.map(_.asInstanceOf[NamedExpression])

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -181,6 +181,45 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
     assert(structDf.select(array($"record.*").as("a")).first().getAs[Seq[Int]](0) === Seq(1, 1))
   }
 
+  test("Star Expansion - hash") {
+    val structDf = testData2.select("a", "b").as("record")
+    checkAnswer(
+      structDf.groupBy($"a", $"b").agg(min(hash($"a", $"*"))),
+      structDf.groupBy($"a", $"b").agg(min(hash($"a", $"a", $"b"))))
+
+    checkAnswer(
+      structDf.groupBy($"a", $"b").agg(hash($"a", $"*")),
+      structDf.groupBy($"a", $"b").agg(hash($"a", $"a", $"b")))
+
+    checkAnswer(
+      structDf.select(hash($"*")),
+      structDf.select(hash($"record.*")))
+
+    checkAnswer(
+      structDf.select(hash($"a", $"*")),
+      structDf.select(hash($"a", $"record.*")))
+  }
+
+  test("Star Expansion - concat") {
+    val structDf = testData2.select("a", "b").as("record")
+
+    checkAnswer(
+      structDf.groupBy($"a", $"b").agg(min(concat($"a", $"*"))),
+      structDf.groupBy($"a", $"b").agg(min(concat($"a", $"a", $"b"))))
+
+    checkAnswer(
+      structDf.groupBy($"a", $"b").agg(concat($"a", $"*")),
+      structDf.groupBy($"a", $"b").agg(concat($"a", $"a", $"b")))
+
+    checkAnswer(
+      structDf.select(concat($"*")),
+      structDf.select(concat($"record.*")))
+
+    checkAnswer(
+      structDf.select(concat($"a", $"*")),
+      structDf.select(concat($"a", $"record.*")))
+  }
+
   test("Star Expansion - explode should fail with a meaningful message if it takes a star") {
     val df = Seq(("1", "1,2"), ("2", "4"), ("3", "7,8,9")).toDF("prefix", "csv")
     val e = intercept[AnalysisException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -200,26 +200,6 @@ class DataFrameSuite extends QueryTest with SharedSQLContext {
       structDf.select(hash($"a", $"record.*")))
   }
 
-  test("Star Expansion - concat") {
-    val structDf = testData2.select("a", "b").as("record")
-
-    checkAnswer(
-      structDf.groupBy($"a", $"b").agg(min(concat($"a", $"*"))),
-      structDf.groupBy($"a", $"b").agg(min(concat($"a", $"a", $"b"))))
-
-    checkAnswer(
-      structDf.groupBy($"a", $"b").agg(concat($"a", $"*")),
-      structDf.groupBy($"a", $"b").agg(concat($"a", $"a", $"b")))
-
-    checkAnswer(
-      structDf.select(concat($"*")),
-      structDf.select(concat($"record.*")))
-
-    checkAnswer(
-      structDf.select(concat($"a", $"*")),
-      structDf.select(concat($"a", $"record.*")))
-  }
-
   test("Star Expansion - explode should fail with a meaningful message if it takes a star") {
     val df = Seq(("1", "1,2"), ("2", "4"), ("3", "7,8,9")).toDF("prefix", "csv")
     val e = intercept[AnalysisException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -1937,6 +1937,14 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
     }
   }
 
+  test("Star Expansion - group by") {
+    withSQLConf("spark.sql.retainGroupColumns" -> "false") {
+      checkAnswer(
+        testData2.groupBy($"a", $"b").agg($"*"),
+        sql("SELECT * FROM testData2 group by a, b"))
+    }
+  }
+
   test("Common subexpression elimination") {
     // TODO: support subexpression elimination in whole stage codegen
     withSQLConf("spark.sql.codegen.wholeStage" -> "false") {


### PR DESCRIPTION
#### What changes were proposed in this pull request?

This PR is to support star expansion in hash. For example,

``` SQL
val structDf = testData2.select("a", "b").as("record")
structDf.select(hash($"*")
```

In addition, it refactors the codes for the rule `ResolveStar` and fixes a regression for star expansion in group by when using SQL API. For example, 

``` SQL
SELECT * FROM testData2 group by a, b
```

cc @cloud-fan Now, the code for star resolution is much cleaner. The coverage is better. Could you check if this refactoring is good? Thanks!
#### How was this patch tested?

Added a few test cases to cover it. 
