### PR TITLE
[SPARK-14087][PySpark][ML] [WIP] PySpark JavaModel Param ownership error

### DIFF
--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -59,10 +59,14 @@ class Identifiable(object):
 
     def __init__(self):
         #: A unique id for the object.
-        self.uid = self._randomUID()
+        self.uid = self._getInitialUID()
 
     def __repr__(self):
         return self.uid
+
+    def _getInitialUID(self):
+        # Override to set a different initial UID
+        return self._randomUID()
 
     @classmethod
     def _randomUID(cls):

--- a/python/pyspark/ml/wrapper.py
+++ b/python/pyspark/ml/wrapper.py
@@ -34,6 +34,7 @@ class JavaWrapper(Params):
 
     __metaclass__ = ABCMeta
 
+
     def __init__(self):
         """
         Initialize the wrapped java object to None
@@ -195,10 +196,24 @@ class JavaModel(Model, JavaTransformer):
         these wrappers depend on pyspark.ml.util (both directly and via
         other ML classes).
         """
+
+        # Must set an initial uid before calling Params constructor
+        self.initial_uid = java_model.uid() if java_model is not None else None
+
         super(JavaModel, self).__init__()
         if java_model is not None:
             self._java_obj = java_model
-            self.uid = java_model.uid()
+
+    def _getInitialUID(self):
+        """
+        Override method in Params to set initial UID to match that of the
+        model. If the java_model was created with an overridden UID value
+        then the Python model will also use that as the initial UID.
+        """
+        if self.initial_uid is not None:
+            return self.initial_uid
+        else:
+            return super(JavaModel, self)._getInitialUID()
 
     def copy(self, extra=None):
         """

--- a/python/pyspark/ml/wrapper.py
+++ b/python/pyspark/ml/wrapper.py
@@ -34,7 +34,6 @@ class JavaWrapper(Params):
 
     __metaclass__ = ABCMeta
 
-
     def __init__(self):
         """
         Initialize the wrapped java object to None

--- a/python/pyspark/ml/wrapper.py
+++ b/python/pyspark/ml/wrapper.py
@@ -202,6 +202,7 @@ class JavaModel(Model, JavaTransformer):
         super(JavaModel, self).__init__()
         if java_model is not None:
             self._java_obj = java_model
+            self._transfer_params_from_java()
 
     def _getInitialUID(self):
         """


### PR DESCRIPTION
When a PySpark model is created after fitting data, its UID is initialized to the parent estimator's value. Before this assignment, any params defined in the model are copied from the object to the class in Params._copy_params() and assigned a different parent UID. This causes PySpark to think the params are not owned by the model and can lead to a ValueError raised from Params._shouldOwn

**\* Still thinking of a possible test for this
