### PR TITLE
SPARK-14091 [core] Consider improving performance of SparkContext.get…

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1745,10 +1745,11 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
    * has overridden the call site using `setCallSite()`, this will return the user's version.
    */
   private[spark] def getCallSite(): CallSite = {
-    val callSite = Utils.getCallSite()
     CallSite(
-      Option(getLocalProperty(CallSite.SHORT_FORM)).getOrElse(callSite.shortForm),
-      Option(getLocalProperty(CallSite.LONG_FORM)).getOrElse(callSite.longForm)
+      Option(getLocalProperty(CallSite.SHORT_FORM))
+        .getOrElse(Utils.getCallSite().shortForm),
+      Option(getLocalProperty(CallSite.LONG_FORM))
+        .getOrElse(Utils.getCallSite().shortForm)
     )
   }
 

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1745,12 +1745,16 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
    * has overridden the call site using `setCallSite()`, this will return the user's version.
    */
   private[spark] def getCallSite(): CallSite = {
-    CallSite(
-      Option(getLocalProperty(CallSite.SHORT_FORM))
-        .getOrElse(Utils.getCallSite().shortForm),
-      Option(getLocalProperty(CallSite.LONG_FORM))
-        .getOrElse(Utils.getCallSite().shortForm)
-    )
+    var (shortForm, longForm) = (getLocalProperty(CallSite.SHORT_FORM),
+      getLocalProperty(CallSite.LONG_FORM))
+
+    if (shortForm == null || longForm == null) {
+      val callSite = Utils.getCallSite()
+      shortForm = callSite.shortForm
+      longForm = callSite.longForm
+    }
+
+    CallSite(shortForm, longForm)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1745,16 +1745,11 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
    * has overridden the call site using `setCallSite()`, this will return the user's version.
    */
   private[spark] def getCallSite(): CallSite = {
-    var (shortForm, longForm) = (getLocalProperty(CallSite.SHORT_FORM),
-      getLocalProperty(CallSite.LONG_FORM))
-
-    if (shortForm == null || longForm == null) {
-      val callSite = Utils.getCallSite()
-      shortForm = Option(shortForm).getOrElse(callSite.shortForm)
-      longForm = Option(longForm).getOrElse(callSite.longForm)
-    }
-
-    CallSite(shortForm, longForm)
+    lazy val callSite = Utils.getCallSite()
+    CallSite(
+      Option(getLocalProperty(CallSite.SHORT_FORM)).getOrElse(callSite.shortForm),
+      Option(getLocalProperty(CallSite.LONG_FORM)).getOrElse(callSite.longForm)
+    )
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1750,8 +1750,8 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
 
     if (shortForm == null || longForm == null) {
       val callSite = Utils.getCallSite()
-      shortForm = callSite.shortForm
-      longForm = callSite.longForm
+      shortForm = Option(shortForm).getOrElse(callSite.shortForm)
+      longForm = Option(longForm).getOrElse(callSite.longForm)
     }
 
     CallSite(shortForm, longForm)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently SparkContext.getCallSite() makes a call to Utils.getCallSite().

```
 private[spark] def getCallSite(): CallSite = {
    val callSite = Utils.getCallSite()
    CallSite(
      Option(getLocalProperty(CallSite.SHORT_FORM)).getOrElse(callSite.shortForm),
      Option(getLocalProperty(CallSite.LONG_FORM)).getOrElse(callSite.longForm)
    )
  }
```

However, in some places utils.withDummyCallSite(sc) is invoked to avoid expensive threaddumps within getCallSite(). But Utils.getCallSite() is evaluated earlier causing threaddumps to be computed. 

This can have severe impact on smaller queries (that finish in 10-20 seconds) having large number of RDDs.

Creating this patch for lazy evaluation of  getCallSite.
## How was this patch tested?

No new test cases are added. Following standalone test was tried out manually. Also, built entire spark binary and tried with few SQL queries in TPC-DS  and TPC-H in multi node cluster

```
def run(): Unit = {
    val conf = new SparkConf()
    val sc = new SparkContext("local[1]", "test-context", conf)
    val start: Long = System.currentTimeMillis();
    val confBroadcast = sc.broadcast(new SerializableConfiguration(new Configuration()))
    Utils.withDummyCallSite(sc) {
      //Large tables end up creating 5500 RDDs
      for(i <- 1 to 5000) {
       //ignore nulls in RDD as its mainly for testing callSite
        val testRDD = new HadoopRDD(sc, confBroadcast, None, null,
          classOf[NullWritable], classOf[Writable], 10)
      }
    }
    val end: Long = System.currentTimeMillis();
    println("Time taken : " + (end - start))
  }

def main(args: Array[String]): Unit = {
    run
  }
```

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

…CallSite() (rbalamohan)
