### PR TITLE
[SPARK-14074][SPARKR] Specify commit sha1 ID when using install_github to install intr package.

### DIFF
--- a/dev/lint-r.R
+++ b/dev/lint-r.R
@@ -27,7 +27,7 @@ if (! library(SparkR, lib.loc = LOCAL_LIB_LOC, logical.return = TRUE)) {
 # Installs lintr from Github in a local directory.
 # NOTE: The CRAN's version is too old to adapt to our rules.
 if ("lintr" %in% row.names(installed.packages())  == FALSE) {
-  devtools::install_github("jimhester/lintr")
+  devtools::install_github("jimhester/lintr@a769c0b")
 }
 
 library(lintr)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a backport of https://github.com/apache/spark/pull/11913 to branch 1.6.

In dev/lint-r.R, install_github makes our builds depend on a unstable source. This may cause un-expected test failures and then build break. This PR adds a specified commit sha1 ID to install_github to get a stable source.
## How was this patch tested?

dev/lint-r
