### PR TITLE
[SPARK-14105][STREAMING] Deep copy each kafka message for serialization

### DIFF
--- a/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaRDD.scala
+++ b/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaRDD.scala
@@ -212,8 +212,7 @@ class KafkaRDD[
 
           val copiedBuffer = ByteBuffer.wrap(deepCopy)
           val copiedMessage = new Message(copiedBuffer)
-          MessageAndOffset(copiedMessage, m.offset)
-        }
+          MessageAndOffset(copiedMessage, m.offset)}
         }
       } else {
         it

--- a/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaRDD.scala
+++ b/external/kafka/src/main/scala/org/apache/spark/streaming/kafka/KafkaRDD.scala
@@ -208,7 +208,7 @@ class KafkaRDD[
           val deepCopy = Arrays.copyOfRange(
             messageByteBuffer.array(),
             messageByteBuffer.arrayOffset(),
-            messageByteBuffer.capacity())
+            messageByteBuffer.arrayOffset() + messageByteBuffer.capacity())
 
           val copiedBuffer = ByteBuffer.wrap(deepCopy)
           val copiedMessage = new Message(copiedBuffer)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Due to serialization issue described in SPARK-14105, this PR is to deep copy each Kafka message if the storage is not None. The new iterator won't reference to the underlying ByteBuffer in ByteBufferMessageSet. Therefore, serializer won't serialize the entire byte[] of FetchResponse for each message.
## How was this patch tested?

Tested with the real job and verified the serialization issue is fixed.
