### PR TITLE
[SQL][HOTFIX] Fix flakiness in StateStoreRDDSuite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreCoordinatorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreCoordinatorSuite.scala
@@ -71,7 +71,6 @@ class StateStoreCoordinatorSuite extends SparkFunSuite with SharedSparkContext {
         assert(coordinatorRef.verifyIfInstanceActive(id1, exec) === true)
         assert(coordinatorRef.verifyIfInstanceActive(id2, exec) === true)
         assert(coordinatorRef.verifyIfInstanceActive(id3, exec) === true)
-
       }
 
       coordinatorRef.deactivateInstances("x")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDDSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDDSuite.scala
@@ -26,7 +26,6 @@ import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.time.SpanSugar._
 
-
 import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
 import org.apache.spark.LocalSparkContext._
 import org.apache.spark.rdd.RDD


### PR DESCRIPTION
## What changes were proposed in this pull request?

StateStoreCoordinator.reportActiveInstance is async, so subsequence state checks must be in eventually.
## How was this patch tested?

Jenkins tests
