### PR TITLE
[SPARK-13934][SQL] fixed table identifier

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/AbstractSparkSQLParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/AbstractSparkSQLParser.scala
@@ -129,7 +129,7 @@ class SqlLexical extends StdLexical {
   override def identChar: Parser[Elem] = letter | elem('_')
 
   private lazy val scientificNotation: Parser[String] =
-    (elem('e') | elem('E')) ~> (elem('+') | elem('-')).? ~ rep1(digit) ^^ {
+    (elem('e') | elem('E')) ~> (elem('+') | elem('-')).? ~ rep1(digit) <~ not(rep1(identChar)) ^^ {
       case s ~ rest => "e" + s.mkString + rest.mkString
     }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/SqlParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/SqlParserSuite.scala
@@ -147,4 +147,8 @@ class SqlParserSuite extends PlanTest {
 
     intercept[RuntimeException](SqlParser.parse("SELECT .e3"))
   }
+
+  test("test special table identifier SPARK-13934") {
+    assert(TableIdentifier("104e4d676bac4d9aa3856f00b5b9f51c") === SqlParser.parseTableIdentifier("104e4d676bac4d9aa3856f00b5b9f51c"))
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Table identifier that starts in a form of scientific notation (like 1e34) will throw an exception.
val tableName = "1e34abcd"
hc.sql("select 123").registerTempTable(tableName)
hc.dropTempTable(tableName)
The last line will throw a RuntimeException.(java.lang.RuntimeException: [1.1] failure: identifier expected)

Fix this by changing the scientific notation parser. If a scientific notation is followed by one or more identifier char, then don't see it as a valid token.
## How was this patch tested?

Unit test is added.
