### PR TITLE
[SPARK-14112] [SQL] [WIP] Unique Constraints over a Set of AttributeReferences

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -102,6 +102,11 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]] extends TreeNode[PlanT
   protected def validConstraints: Set[Expression] = Set.empty
 
   /**
+   * The set of attributes whose combination can uniquely identify a row.
+   */
+  def distinctSet: AttributeSet = AttributeSet.empty
+
+  /**
    * Returns the set of attributes that are output by this node.
    */
   def outputSet: AttributeSet = AttributeSet(output)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicOperators.scala
@@ -51,6 +51,14 @@ case class Project(projectList: Seq[NamedExpression], child: LogicalPlan) extend
     !expressions.exists(!_.resolved) && childrenResolved && !hasSpecialExpressions
   }
 
+  override def distinctSet: AttributeSet = {
+    if (child.outputSet.nonEmpty && child.outputSet.subsetOf(outputSet)) {
+      child.distinctSet
+    } else {
+      AttributeSet.empty
+    }
+  }
+
   override def validConstraints: Set[Expression] =
     child.constraints.union(getAliasedConstraints(projectList))
 }
@@ -107,6 +115,8 @@ case class Filter(condition: Expression, child: LogicalPlan)
 
   override def maxRows: Option[Long] = child.maxRows
 
+  override def distinctSet: AttributeSet = child.distinctSet
+
   override protected def validConstraints: Set[Expression] =
     child.constraints.union(splitConjunctivePredicates(condition).toSet)
 }
@@ -136,6 +146,8 @@ case class Intersect(left: LogicalPlan, right: LogicalPlan) extends SetOperation
     left.output.zip(right.output).map { case (leftAttr, rightAttr) =>
       leftAttr.withNullability(leftAttr.nullable && rightAttr.nullable)
     }
+
+  override def distinctSet: AttributeSet = left.outputSet
 
   override protected def validConstraints: Set[Expression] =
     leftConstraints.union(rightConstraints)
@@ -167,6 +179,8 @@ case class Intersect(left: LogicalPlan, right: LogicalPlan) extends SetOperation
 case class Except(left: LogicalPlan, right: LogicalPlan) extends SetOperation(left, right) {
   /** We don't use right.output because those rows get excluded from the set. */
   override def output: Seq[Attribute] = left.output
+
+  override def distinctSet: AttributeSet = left.outputSet
 
   override protected def validConstraints: Set[Expression] = leftConstraints
 
@@ -265,6 +279,9 @@ case class Join(
     }
   }
 
+  override def distinctSet: AttributeSet =
+    if (joinType == LeftSemi) left.distinctSet else AttributeSet.empty
+
   override protected def validConstraints: Set[Expression] = {
     joinType match {
       case Inner if condition.isDefined =>
@@ -312,6 +329,8 @@ case class Join(
  */
 case class BroadcastHint(child: LogicalPlan) extends UnaryNode {
   override def output: Seq[Attribute] = child.output
+
+  override def distinctSet: AttributeSet = child.distinctSet
 
   // We manually set statistics of BroadcastHint to smallest value to make sure
   // the plan wrapped by BroadcastHint will be considered to broadcast later.
@@ -367,6 +386,7 @@ case class Sort(
     child: LogicalPlan) extends UnaryNode {
   override def output: Seq[Attribute] = child.output
   override def maxRows: Option[Long] = child.maxRows
+  override def distinctSet: AttributeSet = child.distinctSet
 }
 
 /** Factory for constructing new `Range` nodes. */
@@ -422,6 +442,19 @@ case class Aggregate(
   override def output: Seq[Attribute] = aggregateExpressions.map(_.toAttribute)
   override def maxRows: Option[Long] = child.maxRows
 
+  override def distinctSet: AttributeSet = {
+    if (isForDistinct) {
+      AttributeSet(aggregateExpressions)
+    } else if (child.outputSet.nonEmpty && child.outputSet.subsetOf(outputSet)) {
+      child.distinctSet
+    } else {
+      AttributeSet.empty
+    }
+  }
+
+  def isForDistinct: Boolean =
+    groupingExpressions.nonEmpty && groupingExpressions == aggregateExpressions
+
   override def validConstraints: Set[Expression] =
     child.constraints.union(getAliasedConstraints(aggregateExpressions))
 
@@ -442,6 +475,8 @@ case class Window(
 
   override def output: Seq[Attribute] =
     child.output ++ windowExpressions.map(_.toAttribute)
+
+  override def distinctSet: AttributeSet = child.distinctSet
 
   def windowOutputSet: AttributeSet = AttributeSet(windowExpressions.map(_.toAttribute))
 }
@@ -585,6 +620,7 @@ object Limit {
 
 case class GlobalLimit(limitExpr: Expression, child: LogicalPlan) extends UnaryNode {
   override def output: Seq[Attribute] = child.output
+  override def distinctSet: AttributeSet = child.distinctSet
   override def maxRows: Option[Long] = {
     limitExpr match {
       case IntegerLiteral(limit) => Some(limit)
@@ -600,6 +636,7 @@ case class GlobalLimit(limitExpr: Expression, child: LogicalPlan) extends UnaryN
 
 case class LocalLimit(limitExpr: Expression, child: LogicalPlan) extends UnaryNode {
   override def output: Seq[Attribute] = child.output
+  override def distinctSet: AttributeSet = child.distinctSet
   override def maxRows: Option[Long] = {
     limitExpr match {
       case IntegerLiteral(limit) => Some(limit)
@@ -639,6 +676,8 @@ case class Sample(
 
   override def output: Seq[Attribute] = child.output
 
+  override def distinctSet: AttributeSet = child.distinctSet
+
   override def statistics: Statistics = {
     val ratio = upperBound - lowerBound
     // BigInt can't multiply with Double
@@ -658,6 +697,7 @@ case class Sample(
 case class Distinct(child: LogicalPlan) extends UnaryNode {
   override def maxRows: Option[Long] = child.maxRows
   override def output: Seq[Attribute] = child.output
+  override def distinctSet: AttributeSet = child.outputSet
 }
 
 /**


### PR DESCRIPTION
#### What changes were proposed in this pull request?

This PR is to introduce unique constraints over a set of `AttributeReference`s. Below are just two of use cases:
- Remove unnecessary `Distinct` from the plan, as shown in the PR: https://github.com/apache/spark/pull/11854. 
- Eliminate the no-op `Join` from the plan, as shown in the PR: 
  https://github.com/apache/spark/pull/9089

We can infer the output uniqueness of the current operator through the uniqueness of the child node's output. The bottom-up propagation rule of unique constraints is 
- `Distinct`, `Intersect`, `Except` always return distinct values. 
- `Aggregate` has three cases:
  1. When its aggregate expressions is identical to its grouping expressions, it is equivalent to `Distinct`. It can always return distinct values.
  2. When the child's `outputSet` is subset of its own `outputSet`, it keeps the unique constraints of the child.
  3. Otherwise, it does not enforce unique constraints
- UnaryNode `Filter`, `BroadcastHint`, `Sort`, `Window`, `GlobalLimit`, `LocalLimit`, `Sample` and `SubqueryAlias` still keep the unique constraints of the child.
- BinaryNode `Left-semi Join` keeps the unique constraints of the left child.
- `Project` keeps the unique constraints of the child if and only if the child's `outputSet` is subset of its own `outputSet`
#### How was this patch tested?

TODO: add a set of test cases for verifying the propagation rules
