### PR TITLE
[SPARK-13010] [ML] [SparkR] Implement a simple wrapper of AFTSurvivalRegression in SparkR

### DIFF
--- a/R/pkg/DESCRIPTION
+++ b/R/pkg/DESCRIPTION
@@ -12,7 +12,8 @@ Depends:
     methods,
 Suggests:
     testthat,
-    e1071
+    e1071,
+    survival
 Description: R frontend for Spark
 License: Apache License (== 2.0)
 Collate:
@@ -37,4 +38,4 @@ Collate:
     'stats.R'
     'types.R'
     'utils.R'
-RoxygenNote: 5.0.1
+RoxygenNote: 5.0.0

--- a/R/pkg/DESCRIPTION
+++ b/R/pkg/DESCRIPTION
@@ -38,4 +38,4 @@ Collate:
     'stats.R'
     'types.R'
     'utils.R'
-RoxygenNote: 5.0.0
+RoxygenNote: 5.0.1

--- a/R/pkg/NAMESPACE
+++ b/R/pkg/NAMESPACE
@@ -16,7 +16,8 @@ exportMethods("glm",
               "summary",
               "kmeans",
               "fitted",
-              "naiveBayes")
+              "naiveBayes",
+              "survreg")
 
 # Job group lifecycle management methods
 export("setJobGroup",

--- a/R/pkg/R/generics.R
+++ b/R/pkg/R/generics.R
@@ -1179,3 +1179,7 @@ setGeneric("fitted")
 #' @rdname naiveBayes
 #' @export
 setGeneric("naiveBayes", function(formula, data, ...) { standardGeneric("naiveBayes") })
+
+#' @rdname survreg
+#' @export
+setGeneric("survreg", function(formula, data, ...) { standardGeneric("survreg") })

--- a/R/pkg/R/mllib.R
+++ b/R/pkg/R/mllib.R
@@ -285,6 +285,7 @@ setMethod("naiveBayes", signature(formula = "formula", data = "DataFrame"),
 #'
 #' @param formula A symbolic description of the model to be fitted. Currently only a few formula
 #'                operators are supported, including '~', ':', '+', and '-'.
+#'                Note that operator '.' is not supported currently.
 #' @param data DataFrame for training.
 #' @return a fitted AFT survival regression model
 #' @rdname survreg

--- a/R/pkg/inst/tests/testthat/test_mllib.R
+++ b/R/pkg/inst/tests/testthat/test_mllib.R
@@ -265,7 +265,7 @@ test_that("survreg2", {
   rScale <- rModel$scale
 
   expect_equal(coefs, rCoefs, tolerance = 1e-4)
-  expect_equal(scale, rScale, tolerance = 1e-4)
+  expect_true(abs(scale - rScale) < 1e-4)
   expect_true(all(
     rownames(stats$coefficients) ==
     c("(Intercept)", "ecog_ps", "rx", "Log(scale)")))

--- a/R/pkg/inst/tests/testthat/test_mllib.R
+++ b/R/pkg/inst/tests/testthat/test_mllib.R
@@ -249,24 +249,3 @@ test_that("survreg", {
     expect_equal(predict(model, rData)[[1]], 3.724591, tolerance = 1e-4)
   }
 })
-
-test_that("survreg2", {
-  library(survival)
-  data(ovarian)
-  df <- suppressWarnings(createDataFrame(sqlContext, ovarian))
-
-  model <- SparkR::survreg(Surv(futime, fustat) ~ ecog_ps + rx, df)
-  stats <- summary(model)
-  coefs <- as.vector(stats$coefficients[, 1][1:3])
-  scale <- exp(stats$coefficients[, 1][4])
-
-  rModel <- survival::survreg(Surv(futime, fustat) ~ ecog.ps + rx, ovarian)
-  rCoefs <- as.vector(coef(rModel))
-  rScale <- rModel$scale
-
-  expect_equal(coefs, rCoefs, tolerance = 1e-4)
-  expect_true(abs(scale - rScale) < 1e-4)
-  expect_true(all(
-    rownames(stats$coefficients) ==
-    c("(Intercept)", "ecog_ps", "rx", "Log(scale)")))
-})

--- a/R/pkg/inst/tests/testthat/test_mllib.R
+++ b/R/pkg/inst/tests/testthat/test_mllib.R
@@ -213,20 +213,11 @@ test_that("survreg", {
   #
   # -- output of 'summary(model)'
   #
-  # survreg(formula = Surv(time, status) ~ x + sex, data = data)
   #              Value Std. Error     z        p
   # (Intercept)  1.315      0.270  4.88 1.07e-06
   # x           -0.190      0.173 -1.10 2.72e-01
   # sex         -0.253      0.329 -0.77 4.42e-01
   # Log(scale)  -1.160      0.396 -2.93 3.41e-03
-  #
-  # Scale= 0.313
-  #
-  # Weibull distribution
-  # Loglik(model)= -7.7   Loglik(intercept only)= -8.2
-  #     Chisq= 1.16 on 2 degrees of freedom, p= 0.56
-  # Number of Newton-Raphson Iterations: 8
-  # n= 7
   #
   # -- output of 'predict(model, data)'
   #
@@ -274,7 +265,7 @@ test_that("survreg2", {
   rScale <- rModel$scale
 
   expect_equal(coefs, rCoefs, tolerance = 1e-4)
-  expect_true(abs(rScale - scale) < 1e-4)
+  expect_equal(scale, rScale, tolerance = 1e-4)
   expect_true(all(
     rownames(stats$coefficients) ==
     c("(Intercept)", "ecog_ps", "rx", "Log(scale)")))

--- a/mllib/src/main/scala/org/apache/spark/ml/r/AFTSurvivalRegressionWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/AFTSurvivalRegressionWrapper.scala
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.r
+
+import org.apache.spark.SparkException
+import org.apache.spark.ml.attribute.AttributeGroup
+import org.apache.spark.ml.{Pipeline, PipelineModel}
+import org.apache.spark.ml.feature.RFormula
+import org.apache.spark.ml.regression.{AFTSurvivalRegressionModel, AFTSurvivalRegression}
+import org.apache.spark.sql.DataFrame
+
+private[r] class AFTSurvivalRegressionWrapper private (
+    pipeline: PipelineModel,
+    features: Array[String]) {
+
+  private val aftModel: AFTSurvivalRegressionModel =
+    pipeline.stages(1).asInstanceOf[AFTSurvivalRegressionModel]
+
+  lazy val rCoefficients: Array[Double] = if (aftModel.getFitIntercept) {
+    Array(aftModel.intercept) ++ aftModel.coefficients.toArray ++ Array(math.log(aftModel.scale))
+  } else {
+    aftModel.coefficients.toArray ++ Array(math.log(aftModel.scale))
+  }
+
+  lazy val rFeatures: Array[String] = if (aftModel.getFitIntercept) {
+    Array("(Intercept)") ++ features ++ Array("Log(scale)")
+  } else {
+    features ++ Array("Log(scale)")
+  }
+
+  def transform(dataset: DataFrame): DataFrame = {
+    pipeline.transform(dataset)
+  }
+}
+
+private[r] object AFTSurvivalRegressionWrapper {
+
+  private def formulaRewrite(formula: String): (String, String) = {
+    var rewritedFormula: String = null
+    var censorCol: String = null
+
+    val regex = """Surv\(([^,]+), ([^,]+)\) ~ (.+)""".r
+    try {
+      val regex(label, censor, features) = formula
+      // TODO: Support dot operator.
+      if (features.contains(".")) {
+        throw new UnsupportedOperationException(
+          "Terms of survreg formula can not support dot operator.")
+      }
+      rewritedFormula = label.trim + "~" + features.trim
+      censorCol = censor.trim
+    } catch {
+      case e: MatchError =>
+        throw new SparkException(s"Could not parse formula: $formula")
+    }
+
+    (rewritedFormula, censorCol)
+  }
+
+
+  def fit(formula: String, data: DataFrame): AFTSurvivalRegressionWrapper = {
+
+    val (rewritedFormula, censorCol) = formulaRewrite(formula)
+
+    val rFormula = new RFormula().setFormula(rewritedFormula)
+    val rFormulaModel = rFormula.fit(data)
+
+    // get feature names from output schema
+    val schema = rFormulaModel.transform(data).schema
+    val featureAttrs = AttributeGroup.fromStructField(schema(rFormula.getFeaturesCol))
+      .attributes.get
+    val features = featureAttrs.map(_.name.get)
+
+    val aft = new AFTSurvivalRegression()
+      .setCensorCol(censorCol)
+      .setFitIntercept(rFormula.hasIntercept)
+
+    val pipeline = new Pipeline()
+      .setStages(Array(rFormulaModel, aft))
+      .fit(data)
+
+    new AFTSurvivalRegressionWrapper(pipeline, features)
+  }
+}

--- a/mllib/src/main/scala/org/apache/spark/ml/r/AFTSurvivalRegressionWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/AFTSurvivalRegressionWrapper.scala
@@ -18,10 +18,10 @@
 package org.apache.spark.ml.r
 
 import org.apache.spark.SparkException
-import org.apache.spark.ml.attribute.AttributeGroup
 import org.apache.spark.ml.{Pipeline, PipelineModel}
+import org.apache.spark.ml.attribute.AttributeGroup
 import org.apache.spark.ml.feature.RFormula
-import org.apache.spark.ml.regression.{AFTSurvivalRegressionModel, AFTSurvivalRegression}
+import org.apache.spark.ml.regression.{AFTSurvivalRegression, AFTSurvivalRegressionModel}
 import org.apache.spark.sql.DataFrame
 
 private[r] class AFTSurvivalRegressionWrapper private (


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR continues the work in #11447, we implemented the wrapper of `AFTSurvivalRegression` named `survreg` in SparkR.
## How was this patch tested?

Test against output from R package survival's survreg.

cc @mengxr @felixcheung 

Close #11447 
