### PR TITLE
[SPARK-14131][SQL]Add a workaround for HADOOP-10622 to fix DataFrameReaderWriterSuite

### DIFF
--- a/dev/run-tests
+++ b/dev/run-tests
@@ -20,4 +20,8 @@
 FWDIR="$(cd "`dirname $0`"/..; pwd)"
 cd "$FWDIR"
 
-exec python -u ./dev/run-tests.py "$@"
+set -e
+for i in `seq 1 300`; do
+    build/sbt -Pyarn -Phadoop-2.4 -Dhadoop.version=2.4.0 "project sql" test
+done
+# exec python -u ./dev/run-tests.py "$@"

--- a/dev/run-tests
+++ b/dev/run-tests
@@ -20,8 +20,4 @@
 FWDIR="$(cd "`dirname $0`"/..; pwd)"
 cd "$FWDIR"
 
-set -e
-for i in `seq 1 300`; do
-    build/sbt -Pyarn -Phadoop-2.4 -Dhadoop.version=2.4.0 "project sql" test
-done
-# exec python -u ./dev/run-tests.py "$@"
+exec python -u ./dev/run-tests.py "$@"

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -122,7 +122,7 @@ class StreamExecution(
 
   /**
    * Interrupt "microBatchThread" if possible. If "microBatchThread" is in the uninterruptible
-   * status. "microBatchThread" won't be interrupted until it enters into the interruptible status.
+   * status, "microBatchThread" won't be interrupted until it enters into the interruptible status.
    */
   private def interruptMicroBatchThreadSafely(): Unit = {
     uninterruptibleLock.synchronized {
@@ -287,6 +287,12 @@ class StreamExecution(
     // Update committed offsets.
     committedOffsets ++= availableOffsets
 
+    // There is a potential dead-lock in Hadoop "Shell.runCommand" before 2.5.0 (HADOOP-10622).
+    // If we interrupt some thread running Shell.runCommand, we may hit this issue.
+    // As "FileStreamSource.getOffset" will create a file using HDFS API and call "Shell.runCommand"
+    // to set the file permission, we should not interrupt "microBatchThread" when running this
+    // method. See SPARK-14131.
+    //
     // Check to see what new data is available.
     val newData = runUninterruptiblyInMicroBatchThread {
       uniqueSources.flatMap(s => s.getOffset.map(o => s -> o))
@@ -294,6 +300,11 @@ class StreamExecution(
     availableOffsets ++= newData
 
     if (dataAvailable) {
+      // There is a potential dead-lock in Hadoop "Shell.runCommand" before 2.5.0 (HADOOP-10622).
+      // If we interrupt some thread running Shell.runCommand, we may hit this issue.
+      // As "offsetLog.add" will create a file using HDFS API and call "Shell.runCommand" to set
+      // the file permission, we should not interrupt "microBatchThread" when running this method.
+      // See SPARK-14131.
       runUninterruptiblyInMicroBatchThread {
         assert(
           offsetLog.add(currentBatchId, availableOffsets.toCompositeOffset(sources)),


### PR DESCRIPTION
## What changes were proposed in this pull request?

There is a potential dead-lock in Hadoop Shell.runCommand before 2.5.0 ([HADOOP-10622](https://issues.apache.org/jira/browse/HADOOP-10622)). If we interrupt some thread running Shell.runCommand, we may hit this issue.

This PR adds some protecion to prevent from interrupting the microBatchThread when we may run into Shell.runCommand. There are two places will call Shell.runCommand now:
- offsetLog.add
- FileStreamSource.getOffset

They will create a file using HDFS API and call Shell.runCommand to set the file permission.
## How was this patch tested?

Existing unit tests.
