### PR TITLE
[SPARK-14071][PySpark][ML]Change MLWritable.write to be a property

### DIFF
--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -655,6 +655,7 @@ class PersistenceTest(PySparkTestCase):
                 rmtree(temp_path)
             except OSError:
                 pass
+            
     def test_write_property(self):
         wrt = MLWritable()
         self.assertEqual(isinstance(type(wrt).write, property), True)

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -655,7 +655,7 @@ class PersistenceTest(PySparkTestCase):
                 rmtree(temp_path)
             except OSError:
                 pass
-            
+
     def test_write_property(self):
         wrt = MLWritable()
         self.assertEqual(isinstance(type(wrt).write, property), True)

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -51,7 +51,7 @@ from pyspark.ml.param.shared import HasMaxIter, HasInputCol, HasSeed
 from pyspark.ml.regression import LinearRegression, DecisionTreeRegressor
 from pyspark.ml.tuning import *
 from pyspark.ml.util import keyword_only
-from pyspark.ml.util import MLWritable
+from pyspark.ml.util import MLWritable, MLWriter
 from pyspark.ml.wrapper import JavaWrapper
 from pyspark.mllib.linalg import DenseVector, SparseVector
 from pyspark.sql import DataFrame, SQLContext, Row
@@ -658,17 +658,7 @@ class PersistenceTest(PySparkTestCase):
 
     def test_write_property(self):
         lr = LinearRegression(maxIter=1)
-        path = tempfile.mkdtemp()
-        lr_path = path + "/lr"
-        lr.write.save(lr_path)
-        lr2 = LinearRegression.load(lr_path)
-        self.assertEqual(lr._defaultParamMap[lr.maxIter], lr2._defaultParamMap[lr2.maxIter],
-                         "Loaded LinearRegression instance default params did not match " +
-                         "original defaults")
-        try:
-            rmtree(path)
-        except OSError:
-            pass
+        self.assertTrue(isinstance(lr.write, MLWriter))
 
     def test_decisiontree_classifier(self):
         dt = DecisionTreeClassifier(maxDepth=1)

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -51,6 +51,7 @@ from pyspark.ml.param.shared import HasMaxIter, HasInputCol, HasSeed
 from pyspark.ml.regression import LinearRegression, DecisionTreeRegressor
 from pyspark.ml.tuning import *
 from pyspark.ml.util import keyword_only
+from pyspark.ml.util import MLWritable
 from pyspark.ml.wrapper import JavaWrapper
 from pyspark.mllib.linalg import DenseVector, SparseVector
 from pyspark.sql import DataFrame, SQLContext, Row
@@ -654,6 +655,9 @@ class PersistenceTest(PySparkTestCase):
                 rmtree(temp_path)
             except OSError:
                 pass
+    def test_write_property(self):
+        wrt = MLWritable()
+        self.assertEqual(isinstance(type(wrt).write, property), True)
 
     def test_decisiontree_classifier(self):
         dt = DecisionTreeClassifier(maxDepth=1)

--- a/python/pyspark/ml/tests.py
+++ b/python/pyspark/ml/tests.py
@@ -657,8 +657,18 @@ class PersistenceTest(PySparkTestCase):
                 pass
 
     def test_write_property(self):
-        wrt = MLWritable()
-        self.assertEqual(isinstance(type(wrt).write, property), True)
+        lr = LinearRegression(maxIter=1)
+        path = tempfile.mkdtemp()
+        lr_path = path + "/lr"
+        lr.write.save(lr_path)
+        lr2 = LinearRegression.load(lr_path)
+        self.assertEqual(lr._defaultParamMap[lr.maxIter], lr2._defaultParamMap[lr2.maxIter],
+                         "Loaded LinearRegression instance default params did not match " +
+                         "original defaults")
+        try:
+            rmtree(path)
+        except OSError:
+            pass
 
     def test_decisiontree_classifier(self):
         dt = DecisionTreeClassifier(maxDepth=1)

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -135,7 +135,6 @@ class MLWritable(object):
     """
 
     @property
-    @since(2.0)
     def write(self):
         """Returns an JavaMLWriter instance for this ML instance."""
         raise NotImplementedError("MLWritable is not yet implemented for type: %r" % type(self))
@@ -152,7 +151,6 @@ class JavaMLWritable(MLWritable):
     """
 
     @property
-    @since(2.0)
     def write(self):
         """Returns an JavaMLWriter instance for this ML instance."""
         return JavaMLWriter(self)

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -133,7 +133,8 @@ class MLWritable(object):
 
     .. versionadded:: 2.0.0
     """
-
+    @property
+    @since(2.0)
     def write(self):
         """Returns an JavaMLWriter instance for this ML instance."""
         raise NotImplementedError("MLWritable is not yet implemented for type: %r" % type(self))

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -142,7 +142,7 @@ class MLWritable(object):
 
     def save(self, path):
         """Save this ML instance to the given path, a shortcut of `write().save(path)`."""
-        self.write().save(path)
+        self.write.save(path)
 
 
 @inherit_doc
@@ -151,6 +151,8 @@ class JavaMLWritable(MLWritable):
     (Private) Mixin for ML instances that provide :py:class:`JavaMLWriter`.
     """
 
+    @property
+    @since(2.0)
     def write(self):
         """Returns an JavaMLWriter instance for this ML instance."""
         return JavaMLWriter(self)

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -133,6 +133,7 @@ class MLWritable(object):
 
     .. versionadded:: 2.0.0
     """
+
     @property
     @since(2.0)
     def write(self):


### PR DESCRIPTION
Add property to MLWritable.write method, so we can use .write instead of .write()

Add a new test to ml/test.py to check whether the write is a property. 
./python/run-tests --python-executables=python2.7 --modules=pyspark-ml

Will test against the following Python executables: ['python2.7']
Will test the following Python modules: ['pyspark-ml']
Finished test(python2.7): pyspark.ml.evaluation (11s)
Finished test(python2.7): pyspark.ml.clustering (16s)
Finished test(python2.7): pyspark.ml.classification (24s)
Finished test(python2.7): pyspark.ml.recommendation (24s)
Finished test(python2.7): pyspark.ml.feature (39s)
Finished test(python2.7): pyspark.ml.regression (26s)
Finished test(python2.7): pyspark.ml.tuning (15s)
Finished test(python2.7): pyspark.ml.tests (30s)
Tests passed in 55 seconds
