### PR TITLE
[SPARK-14147] [ML] [SparkR] SparkR predict should not output feature column

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/r/AFTSurvivalRegressionWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/AFTSurvivalRegressionWrapper.scala
@@ -44,7 +44,7 @@ private[r] class AFTSurvivalRegressionWrapper private (
   }
 
   def transform(dataset: Dataset[_]): DataFrame = {
-    pipeline.transform(dataset)
+    pipeline.transform(dataset).drop(aftModel.getFeaturesCol)
   }
 }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/r/NaiveBayesWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/NaiveBayesWrapper.scala
@@ -37,7 +37,9 @@ private[r] class NaiveBayesWrapper private (
   lazy val tables: Array[Double] = naiveBayesModel.theta.toArray.map(math.exp)
 
   def transform(dataset: Dataset[_]): DataFrame = {
-    pipeline.transform(dataset).drop(PREDICTED_LABEL_INDEX_COL)
+    pipeline.transform(dataset)
+      .drop(PREDICTED_LABEL_INDEX_COL)
+      .drop(naiveBayesModel.getFeaturesCol)
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

SparkR does not support type of vector which is the default type of feature column in ML. R predict also does not output intermediate feature column. So SparkR `predict` should not output feature column. In this PR, I only fix this issue for `naiveBayes` and `survreg`. `kmeans` has the right code route already and  `glm` will be fixed at SparkRWrapper refactor(#12294).
## How was this patch tested?

No new tests.

cc @mengxr @shivaram 
