### PR TITLE
[SPARK-14168] Warn instead of Error on Managed Memory leak detection.

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -239,11 +239,12 @@ private[spark] class Executor(
           val freedMemory = taskMemoryManager.cleanUpAllAllocatedMemory()
 
           if (freedMemory > 0) {
-            val errMsg = s"Managed memory leak detected; size = $freedMemory bytes, TID = $taskId"
+            val errMsg = s"Potential managed memory leak detected; " +
+              s"size = $freedMemory bytes, TID = $taskId.  See SPARK-14168."
             if (conf.getBoolean("spark.unsafe.exceptionOnMemoryLeak", false) && !threwException) {
               throw new SparkException(errMsg)
             } else {
-              logError(errMsg)
+              logWarning(errMsg)
             }
           }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The leak detection can be misleading, either when an iterator is not
read completely (eg. rdd.take()) or if there is a task failure.
Downgrade from error to warn, and reword slightly
## How was this patch tested?

Jenkins unit tests
