### PR TITLE
[SPARK-14170] [infra] Simplify the PR template and remove it when merging.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,7 +1,7 @@
-### Please provide the following information about your PR below:
-### - What changes were proposed in this pull request?
-### - How was this patch tested?
-### - If this patch involves UI changes, please attach a screenshot
-###
-### If you haven't done so, please also check the following wiki page:
-###   https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark
+> Please provide the following information about your PR:
+> - What changes are proposed in this pull request?
+> - How was this patch tested?
+> - If this patch involves UI changes, please attach a screenshot.
+>
+> If you haven't done so, please also check the following wiki page:
+>   https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -2,6 +2,3 @@
 > - What changes are proposed in this pull request?
 > - How was this patch tested?
 > - If this patch involves UI changes, please attach a screenshot.
->
-> If you haven't done so, please also check the following wiki page:
->   https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,12 +1,7 @@
-## What changes were proposed in this pull request?
-
-(Please fill in changes proposed in this fix)
-
-
-## How was this patch tested?
-
-(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
-
-
-(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
-
+### Please provide the following information about your PR below:
+### - What changes were proposed in this pull request?
+### - How was this patch tested?
+### - If this patch involves UI changes, please attach a screenshot
+###
+### If you haven't done so, please also check the following wiki page:
+###   https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark

--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -399,7 +399,13 @@ def main():
     else:
         title = pr["title"]
 
-    body = pr["body"]
+    # Remove all leading lines that start with '###', and any empty lines before actual content
+    # starts, so that we remove the PR template from commit messages.
+    body = pr["body"].split("\n")
+    while body and (body[0].startswith("###") or not body[0].strip()):
+      del body[0]
+    body = "\n".join(body)
+
     target_ref = pr["base"]["ref"]
     user_login = pr["user"]["login"]
     base_ref = pr["head"]["ref"]

--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -402,7 +402,7 @@ def main():
     # Remove all leading lines that start with '###', and any empty lines before actual content
     # starts, so that we remove the PR template from commit messages.
     body = pr["body"].split("\n")
-    while body and (body[0].startswith("###") or not body[0].strip()):
+    while body and (body[0].startswith(">") or not body[0].strip()):
       del body[0]
     body = "\n".join(body)
 


### PR DESCRIPTION
This change modifies the template so that all instructions are together at
the top, which makes it easy to remove the template in the merge script,
just in case people forget. It's also less intrusive since it doesn't
require contributors to write their commit message in the middle of the
template.
