### PR TITLE
[SPARK-14174][ML][WIP] Accelerate KMeans via Mini-Batch EM

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -90,8 +90,8 @@ private[clustering] trait KMeansParams extends Params with HasMaxIter with HasFe
    * @group param
    */
   @Since("2.2.0")
-  final val miniBatchFraction = new DoubleParam(this, "k", "The fraction of the data to update" +
-    " clustering centers per iteration. Must be in (0, 1].",
+  final val miniBatchFraction = new DoubleParam(this, "miniBatchFraction", "The fraction of the" +
+    " data to update clustering centers per iteration. Must be in (0, 1].",
     ParamValidators.inRange(0, 1, lowerInclusive = false, upperInclusive = true))
 
   /** @group getParam */

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -85,13 +85,13 @@ private[clustering] trait KMeansParams extends Params with HasMaxIter with HasFe
   def getInitSteps: Int = $(initSteps)
 
   /**
-   * The fraction of the data to update centers per iteration. Must be &gt; 0 and &le; 1.
+   * The fraction of data used to update centers per iteration. Must be &gt; 0 and &le; 1.
    * Default: 1.0.
    * @group param
    */
   @Since("2.3.0")
-  final val miniBatchFraction = new DoubleParam(this, "miniBatchFraction", "The fraction of the" +
-    " data to update clustering centers per iteration. Must be in (0, 1].",
+  final val miniBatchFraction = new DoubleParam(this, "miniBatchFraction", "The fraction of" +
+    " data used to update cluster centers per iteration. Must be in (0, 1].",
     ParamValidators.inRange(0, 1, lowerInclusive = false, upperInclusive = true))
 
   /** @group getParam */

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -89,13 +89,13 @@ private[clustering] trait KMeansParams extends Params with HasMaxIter with HasFe
    * Default: 1.0.
    * @group param
    */
-  @Since("2.2.0")
+  @Since("2.3.0")
   final val miniBatchFraction = new DoubleParam(this, "miniBatchFraction", "The fraction of the" +
     " data to update clustering centers per iteration. Must be in (0, 1].",
     ParamValidators.inRange(0, 1, lowerInclusive = false, upperInclusive = true))
 
   /** @group getParam */
-  @Since("2.2.0")
+  @Since("2.3.0")
   def getMiniBatchFraction: Double = $(miniBatchFraction)
 
   /**
@@ -316,7 +316,7 @@ class KMeans @Since("1.5.0") (
   def setSeed(value: Long): this.type = set(seed, value)
 
   /** @group setParam */
-  @Since("2.2.0")
+  @Since("2.3.0")
   def setMiniBatchFraction(value: Double): this.type = set(miniBatchFraction, value)
 
   @Since("2.0.0")

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeans.scala
@@ -157,7 +157,6 @@ class KMeans private (
   /**
    * The fraction of data to be used for each EM iteration.
    */
-  @Since("2.2.0")
   private[spark] def getMiniBatchFraction: Double = miniBatchFraction
 
   /**
@@ -165,7 +164,6 @@ class KMeans private (
    * Set fraction of data to be used for each EM iteration.
    * Default 1.0
    */
-  @Since("2.2.0")
   private[spark] def setMiniBatchFraction(fraction: Double): this.type = {
     require(fraction > 0 && fraction <= 1.0,
       s"Fraction for mini-batch EM must be in range (0, 1] but got ${fraction}")

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeans.scala
@@ -45,15 +45,17 @@ class KMeans private (
     private var maxIterations: Int,
     private var initializationMode: String,
     private var initializationSteps: Int,
+    private var miniBatchFraction: Double,
     private var epsilon: Double,
     private var seed: Long) extends Serializable with Logging {
 
   /**
    * Constructs a KMeans instance with default parameters: {k: 2, maxIterations: 20,
-   * initializationMode: "k-means||", initializationSteps: 2, epsilon: 1e-4, seed: random}.
+   * initializationMode: "k-means||", initializationSteps: 2, miniBatchFraction: 1.0,
+   * epsilon: 1e-4, seed: random}.
    */
   @Since("0.8.0")
-  def this() = this(2, 20, KMeans.K_MEANS_PARALLEL, 2, 1e-4, Utils.random.nextLong())
+  def this() = this(2, 20, KMeans.K_MEANS_PARALLEL, 2, 1.0, 1e-4, Utils.random.nextLong())
 
   /**
    * Number of clusters to create (k).
@@ -148,6 +150,26 @@ class KMeans private (
     require(initializationSteps > 0,
       s"Number of initialization steps must be positive but got ${initializationSteps}")
     this.initializationSteps = initializationSteps
+    this
+  }
+
+
+  /**
+   * The fraction of data to be used for each EM iteration.
+   */
+  @Since("2.2.0")
+  private[spark] def getMiniBatchFraction: Double = miniBatchFraction
+
+  /**
+   * :: Experimental ::
+   * Set fraction of data to be used for each EM iteration.
+   * Default 1.0
+   */
+  @Since("2.2.0")
+  private[spark] def setMiniBatchFraction(fraction: Double): this.type = {
+    require(fraction > 0 && fraction <= 1.0,
+      s"Fraction for mini-batch EM must be in range (0, 1] but got ${fraction}")
+    this.miniBatchFraction = fraction
     this
   }
 
@@ -272,8 +294,14 @@ class KMeans private (
       val costAccum = sc.doubleAccumulator
       val bcCenters = sc.broadcast(centers)
 
+      val sampled = if (miniBatchFraction < 1) {
+        data.sample(false, miniBatchFraction, 42 + iteration)
+      } else {
+        data
+      }
+
       // Find the sum and count of points mapping to each center
-      val totalContribs = data.mapPartitions { points =>
+      val totalContribs = sampled.mapPartitions { points =>
         val thisCenters = bcCenters.value
         val dims = thisCenters.head.vector.size
 

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -95,6 +95,12 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext with DefaultR
     intercept[IllegalArgumentException] {
       new KMeans().setMiniBatchFraction(0)
     }
+    intercept[IllegalArgumentException] {
+      new KMeans().setMiniBatchFraction(-0.01)
+    }
+    intercept[IllegalArgumentException] {
+      new KMeans().setMiniBatchFraction(1.01)
+    }
   }
 
   test("fit, transform and summary") {

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -144,6 +144,14 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext with DefaultR
     assert(model.getPredictionCol == predictionColName)
   }
 
+  test("SPARK-14174: enable mini-batch EM") {
+    val model1 = new KMeans().setK(k).setSeed(1).fit(dataset)
+    val cost1 = model1.computeCost(dataset)
+    val model2 = new KMeans().setK(k).setMiniBatchFraction(0.9).setSeed(1).fit(dataset)
+    val cost2 = model2.computeCost(dataset)
+    require(cost1 === cost2)
+  }
+
   test("read/write") {
     def checkModelData(model: KMeansModel, model2: KMeansModel): Unit = {
       assert(model.clusterCenters === model2.clusterCenters)

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -50,6 +50,7 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext with DefaultR
     assert(kmeans.getInitMode === MLlibKMeans.K_MEANS_PARALLEL)
     assert(kmeans.getInitSteps === 2)
     assert(kmeans.getTol === 1e-4)
+    assert(kmeans.getMiniBatchFraction === 1.0)
     val model = kmeans.setMaxIter(1).fit(dataset)
 
     MLTestingUtils.checkCopyAndUids(kmeans, model)
@@ -68,6 +69,7 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext with DefaultR
       .setInitSteps(3)
       .setSeed(123)
       .setTol(1e-3)
+      .setMiniBatchFraction(0.5)
 
     assert(kmeans.getK === 9)
     assert(kmeans.getFeaturesCol === "test_feature")
@@ -77,6 +79,7 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext with DefaultR
     assert(kmeans.getInitSteps === 3)
     assert(kmeans.getSeed === 123)
     assert(kmeans.getTol === 1e-3)
+    assert(kmeans.getMiniBatchFraction === 0.5)
   }
 
   test("parameters validation") {
@@ -88,6 +91,9 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext with DefaultR
     }
     intercept[IllegalArgumentException] {
       new KMeans().setInitSteps(0)
+    }
+    intercept[IllegalArgumentException] {
+      new KMeans().setMiniBatchFraction(0)
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
1,  involve MiniBatch EM into `mllib.KMeans` and make it private in spark
2, expose `setMiniBatchFraction` method in `ml.KMeans`
3, add test in `ml.KMeansSuite`
## How was this patch tested?

existing tests and added test
