### PR TITLE
[SPARK-14163][CORE] SumEvaluator and countApprox cannot reliably handle RDDs of size 1.

### DIFF
--- a/core/src/main/scala/org/apache/spark/partial/SumEvaluator.scala
+++ b/core/src/main/scala/org/apache/spark/partial/SumEvaluator.scala
@@ -42,6 +42,14 @@ private[spark] class SumEvaluator(totalOutputs: Int, confidence: Double)
       new BoundedDouble(counter.sum, 1.0, counter.sum, counter.sum)
     } else if (outputsMerged == 0) {
       new BoundedDouble(0, 0.0, Double.NegativeInfinity, Double.PositiveInfinity)
+    } else if (counter.count == 0) {
+      new BoundedDouble(0, 0.0, Double.NegativeInfinity, Double.PositiveInfinity)
+    } else if (counter.count == 1) {
+      val p = outputsMerged.toDouble / totalOutputs
+      val meanEstimate = counter.mean
+      val countEstimate = (counter.count + 1 - p) / p
+      val sumEstimate = meanEstimate * countEstimate
+      new BoundedDouble(sumEstimate, 0.0, Double.NegativeInfinity, Double.PositiveInfinity)
     } else {
       val p = outputsMerged.toDouble / totalOutputs
       val meanEstimate = counter.mean

--- a/core/src/main/scala/org/apache/spark/partial/SumEvaluator.scala
+++ b/core/src/main/scala/org/apache/spark/partial/SumEvaluator.scala
@@ -40,9 +40,7 @@ private[spark] class SumEvaluator(totalOutputs: Int, confidence: Double)
   override def currentResult(): BoundedDouble = {
     if (outputsMerged == totalOutputs) {
       new BoundedDouble(counter.sum, 1.0, counter.sum, counter.sum)
-    } else if (outputsMerged == 0) {
-      new BoundedDouble(0, 0.0, Double.NegativeInfinity, Double.PositiveInfinity)
-    } else if (counter.count == 0) {
+    } else if (outputsMerged == 0 || counter.count == 0) {
       new BoundedDouble(0, 0.0, Double.NegativeInfinity, Double.PositiveInfinity)
     } else if (counter.count == 1) {
       val p = outputsMerged.toDouble / totalOutputs


### PR DESCRIPTION
## What changes were proposed in this pull request?

This fix fixes issues in SPARK-14163 where SumEvaluator could not handle `counter.count <=` 1 as `degreesOfFreedom` requires `counter.count > 1`.
In this fix, `counter.count <= 1` is handled separately.
## How was this patch tested?

A manual test was done to make sure that no Exception is thrown for `degreesOfFreedom`.
