### PR TITLE
[SPARK-14163][CORE] SumEvaluator and countApprox cannot reliably handle RDDs of size 1

### DIFF
--- a/core/src/main/scala/org/apache/spark/partial/SumEvaluator.scala
+++ b/core/src/main/scala/org/apache/spark/partial/SumEvaluator.scala
@@ -60,8 +60,8 @@ private[spark] class SumEvaluator(totalOutputs: Int, confidence: Double)
           val degreesOfFreedom = (counter.count - 1).toInt
           new TDistribution(degreesOfFreedom).inverseCumulativeProbability(1 - (1 - confidence) / 2)
         } else {
-          // this may not be statistically meaningful
-          confidence
+          // No way to meaningfully estimate confidence, so we signal no particular confidence interval
+          Double.PositiveInfinity
         }
       }
       val low = sumEstimate - confFactor * sumStdev


### PR DESCRIPTION
## What changes were proposed in this pull request?

This special cases 0 and 1 counts to avoid passing 0 degrees of freedom. 
## How was this patch tested?

Tests run successfully. 
