### PR TITLE
[Spark-14138][SQL] Fix generated SpecificColumnarIterator code can exceed JVM size limit for cached DataFrames

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GenerateColumnAccessor.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GenerateColumnAccessor.scala
@@ -95,14 +95,14 @@ object GenerateColumnAccessor extends CodeGenerator[Seq[DataType], ColumnarItera
 
       val createCode = dt match {
         case t if ctx.isPrimitiveType(dt) =>
-	  s"$accessorName = new $accessorCls(ByteBuffer.wrap(buffers[$index]).order(nativeOrder));"
-	case NullType | StringType | BinaryType =>
-	  s"$accessorName = new $accessorCls(ByteBuffer.wrap(buffers[$index]).order(nativeOrder));"
-	case other =>
-	  s"""$accessorName = new $accessorCls(ByteBuffer.wrap(buffers[$index]).order(nativeOrder),
+          s"$accessorName = new $accessorCls(ByteBuffer.wrap(buffers[$index]).order(nativeOrder));"
+        case NullType | StringType | BinaryType =>
+          s"$accessorName = new $accessorCls(ByteBuffer.wrap(buffers[$index]).order(nativeOrder));"
+        case other =>
+          s"""$accessorName = new $accessorCls(ByteBuffer.wrap(buffers[$index]).order(nativeOrder),
         (${dt.getClass.getName}) columnTypes[$index]);"""
       }
-		   
+
       val extract = s"$accessorName.extractTo(mutableRow, $index);"
       val patch = dt match {
         case DecimalType.Fixed(p, s) if p > Decimal.MAX_LONG_DIGITS =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GenerateColumnAccessor.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GenerateColumnAccessor.scala
@@ -137,7 +137,7 @@ object GenerateColumnAccessor extends CodeGenerator[Seq[DataType], ColumnarItera
              |  ${body.mkString("\n")}
              |}
            """.stripMargin
-	  ctx.addNewFunction(funcName, funcCode)
+          ctx.addNewFunction(funcName, funcCode)
         }
         groupedExtractorsItr.zipWithIndex.map { case (body, i) =>
           val funcName = s"extractors$i"
@@ -146,13 +146,10 @@ object GenerateColumnAccessor extends CodeGenerator[Seq[DataType], ColumnarItera
              |  ${body.mkString("\n")}
              |}
            """.stripMargin
-	  ctx.addNewFunction(funcName, funcCode)
+          ctx.addNewFunction(funcName, funcCode)
         }
         ((0 to groupedAccessorsLength - 1).map { i => s"accessors$i();" }.mkString("\n"),
          (0 to groupedAccessorsLength - 1).map { i => s"extractors$i();" }.mkString("\n"))
-        //(0 to groupedAccessorsLength - 1).map { i =>
-        //  (s"accessors$i();", s"extractors$i();")
-	//}.unzip
       }
 
     val code = s"""

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GenerateColumnAccessor.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GenerateColumnAccessor.scala
@@ -118,7 +118,7 @@ object GenerateColumnAccessor extends CodeGenerator[Seq[DataType], ColumnarItera
     }.unzip
 
     /*
-     * 200 = 6000 bytes / 30 (up to 25 bytes per one call))
+     * 200 = 6000 bytes / 30 (up to 30 bytes per one call))
      * the maximum byte code size to be compiled for HotSpot is 8000.
      * We should keep less than 8000
      */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GenerateColumnAccessor.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GenerateColumnAccessor.scala
@@ -145,7 +145,7 @@ object GenerateColumnAccessor extends CodeGenerator[Seq[DataType], ColumnarItera
     /* 4000 = 64000 bytes / 16 (up to 16 bytes per one call)) */
     val numberOfStatementsThreshold = 4000
     val (initializerAccessorFuncs, initializerAccessorCalls, extractorFuncs, extractorCalls) =
-      if (initializeAccessors.length < numberOfStatementsThreshold) {
+      if (initializeAccessors.length <= numberOfStatementsThreshold) {
         ("", initializeAccessors.mkString("\n"), "", extractors.mkString("\n"))
       } else {
         val groupedAccessorsItr = initializeAccessors.grouped(numberOfStatementsThreshold)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GenerateColumnAccessor.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GenerateColumnAccessor.scala
@@ -95,16 +95,16 @@ object GenerateColumnAccessor extends CodeGenerator[Seq[DataType], ColumnarItera
       ctx.addMutableState(accessorCls, accessorName, "")
 
       val createCode = {
-        val shortAccCls = accessorCls.substring(accessorCls.lastIndexOf(".") + 1)
+        val shortCls = accessorCls.substring(accessorCls.lastIndexOf(".") + 1)
         dt match {
           case t if ctx.isPrimitiveType(dt) =>
-            s"$accessorName = get${accessorClasses.getOrElseUpdate(accessorCls, shortAccCls)}($index);"
+            s"$accessorName = get${accessorClasses.getOrElseUpdate(accessorCls, shortCls)}($index);"
           case NullType | StringType | BinaryType =>
-            s"$accessorName = get${accessorClasses.getOrElseUpdate(accessorCls, shortAccCls)}($index);"
+            s"$accessorName = get${accessorClasses.getOrElseUpdate(accessorCls, shortCls)}($index);"
           case other =>
             val shortDTCls = dt.getClass.getName.substring(dt.getClass.getName.lastIndexOf(".") + 1)
-            accessorStructClasses.getOrElseUpdate((accessorCls, dt), (shortAccCls, shortDTCls))
-            s"$accessorName = get${shortAccCls}_${shortDTCls}($index);"
+            accessorStructClasses.getOrElseUpdate((accessorCls, dt), (shortCls, shortDTCls))
+            s"$accessorName = get${shortCls}_${shortDTCls}($index);"
         }
       }
 
@@ -160,17 +160,17 @@ object GenerateColumnAccessor extends CodeGenerator[Seq[DataType], ColumnarItera
                |}
              """.stripMargin
           }.mkString(""),
-	  (0 to groupedAccessorsLength - 1).map { i => s"accessors$i();" }.mkString("\n"),
-	  groupedExtractorsItr.zipWithIndex.map { case (body, i) =>
-	    groupedExtractorsLength += 1
-	    s"""
+          (0 to groupedAccessorsLength - 1).map { i => s"accessors$i();" }.mkString("\n"),
+          groupedExtractorsItr.zipWithIndex.map { case (body, i) =>
+            groupedExtractorsLength += 1
+            s"""
                |private void extractors$i() {
                |  ${body.mkString("\n")}
                |}
              """.stripMargin
-	  }.mkString(""),
-	  (0 to groupedExtractorsLength - 1).map { i => s"extractors$i();" }.mkString("\n")
-	)
+          }.mkString(""),
+          (0 to groupedExtractorsLength - 1).map { i => s"extractors$i();" }.mkString("\n")
+        )
       }
 
     val code = s"""

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GenerateColumnAccessor.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/GenerateColumnAccessor.scala
@@ -142,8 +142,12 @@ object GenerateColumnAccessor extends CodeGenerator[Seq[DataType], ColumnarItera
         """
     }
 
-    /* 4000 = 64000 bytes / 16 (up to 16 bytes per one call)) */
-    val numberOfStatementsThreshold = 4000
+    /*
+     * 500 = 7500 bytes / 15 (up to 15 bytes per one call))
+     * the maximum byte code size to be compiled for HotSpot is 8000.
+     * We should keep less than 8000
+     */
+    val numberOfStatementsThreshold = 500
     val (initializerAccessorFuncs, initializerAccessorCalls, extractorFuncs, extractorCalls) =
       if (initializeAccessors.length <= numberOfStatementsThreshold) {
         ("", initializeAccessors.mkString("\n"), "", extractors.mkString("\n"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
@@ -220,7 +220,7 @@ class InMemoryColumnarQuerySuite extends QueryTest with SharedSQLContext {
     assert(data.filter($"s" === "3").count() === 1)
   }
 
-  test("SPARK-14138: Generated SpecificColumnarIterator code can exceed JVM size limit for cached DataFrames") {
+  test("SPARK-14138: Generated SpecificColumnarIterator can exceed JVM size limit for cached DF") {
     val length = 10000
     val columnTypes = List.fill(length)(IntegerType)
     val columnarIterator = GenerateColumnAccessor.generate(columnTypes)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
@@ -219,4 +219,10 @@ class InMemoryColumnarQuerySuite extends QueryTest with SharedSQLContext {
     assert(data.count() === 10)
     assert(data.filter($"s" === "3").count() === 1)
   }
+
+  test("SPARK-14138: Generated SpecificColumnarIterator code can exceed JVM size limit for cached DataFrames") {
+    val length = 10000
+    val columnTypes = List.fill(length)(IntegerType)
+    val columnarIterator = GenerateColumnAccessor.generate(columnTypes)
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
@@ -221,8 +221,12 @@ class InMemoryColumnarQuerySuite extends QueryTest with SharedSQLContext {
   }
 
   test("SPARK-14138: Generated SpecificColumnarIterator can exceed JVM size limit for cached DF") {
-    val length = 10000
-    val columnTypes = List.fill(length)(IntegerType)
-    val columnarIterator = GenerateColumnAccessor.generate(columnTypes)
+    val length1 = 3999
+    val columnTypes1 = List.fill(length1)(IntegerType)
+    val columnarIterator1 = GenerateColumnAccessor.generate(columnTypes1)
+
+    val length2 = 10000
+    val columnTypes2 = List.fill(length2)(IntegerType)
+    val columnarIterator2 = GenerateColumnAccessor.generate(columnTypes2)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR reduces Java byte code size of method in `SpecificColumnarIterator` by using two approaches:
1. Generate and call `getTYPEColumnAccessor()` for each type, which is actually used, for instantiating accessors
2. Group a lot of method calls (more than 4000) into a method
## How was this patch tested?

Added a new unit test to `InMemoryColumnarQuerySuite`

Here is generate code

``` java
/* 033 */   private org.apache.spark.sql.execution.columnar.CachedBatch batch = null;
/* 034 */
/* 035 */   private org.apache.spark.sql.execution.columnar.IntColumnAccessor accessor;
/* 036 */   private org.apache.spark.sql.execution.columnar.IntColumnAccessor accessor1;
/* 037 */
/* 038 */   public SpecificColumnarIterator() {
/* 039 */     this.nativeOrder = ByteOrder.nativeOrder();
/* 030 */     this.mutableRow = new MutableUnsafeRow(rowWriter);
/* 041 */   }
/* 042 */
/* 043 */   public void initialize(Iterator input, DataType[] columnTypes, int[] columnIndexes,
/* 044 */     boolean columnNullables[]) {
/* 044 */     this.input = input;
/* 046 */     this.columnTypes = columnTypes;
/* 047 */     this.columnIndexes = columnIndexes;
/* 048 */   }
/* 049 */
/* 050 */
/* 051 */   private org.apache.spark.sql.execution.columnar.IntColumnAccessor getIntColumnAccessor(int idx) {
/* 052 */     byte[] buffer = batch.buffers()[columnIndexes[idx]];
/* 053 */     return new org.apache.spark.sql.execution.columnar.IntColumnAccessor(ByteBuffer.wrap(buffer).order(nativeOrder));
/* 054 */   }
/* 055 */
/* 056 */
/* 057 */
/* 058 */
/* 059 */
/* 060 */
/* 061 */   public boolean hasNext() {
/* 062 */     if (currentRow < numRowsInBatch) {
/* 063 */       return true;
/* 064 */     }
/* 065 */     if (!input.hasNext()) {
/* 066 */       return false;
/* 067 */     }
/* 068 */
/* 069 */     batch = (org.apache.spark.sql.execution.columnar.CachedBatch) input.next();
/* 070 */     currentRow = 0;
/* 071 */     numRowsInBatch = batch.numRows();
/* 072 */     accessor = getIntColumnAccessor(0);
/* 073 */     accessor1 = getIntColumnAccessor(1);
/* 074 */
/* 075 */     return hasNext();
/* 076 */   }
/* 077 */
/* 078 */   public InternalRow next() {
/* 079 */     currentRow += 1;
/* 080 */     bufferHolder.reset();
/* 081 */     rowWriter.zeroOutNullBytes();
/* 082 */     accessor.extractTo(mutableRow, 0);
/* 083 */     accessor1.extractTo(mutableRow, 1);
/* 084 */     unsafeRow.setTotalSize(bufferHolder.totalSize());
/* 085 */     return unsafeRow;
/* 086 */   }
```

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
