### PR TITLE
[CORE][SPARK-14178]DAGScheduler should get map output statuses directly.

### DIFF
--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -429,7 +429,7 @@ private[spark] class MapOutputTrackerMaster(conf: SparkConf)
   }
 
   def getMapOutputStatuses(shuffleId: Int): Array[MapStatus] = epochLock.synchronized {
-    mapStatuses.getOrElse(shuffleId, Array[MapStatus]())
+    Array[MapStatus]() ++ mapStatuses.getOrElse(shuffleId, Array[MapStatus]())
   }
 
   def getSerializedMapOutputStatuses(shuffleId: Int): Array[Byte] = {

--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -428,6 +428,10 @@ private[spark] class MapOutputTrackerMaster(conf: SparkConf)
     }
   }
 
+  def getMapOutputStatuses(shuffleId: Int): Array[MapStatus] = epochLock.synchronized {
+    mapStatuses.getOrElse(shuffleId, Array[MapStatus]())
+  }
+
   def getSerializedMapOutputStatuses(shuffleId: Int): Array[Byte] = {
     var statuses: Array[MapStatus] = null
     var epochGotten: Long = -1

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -354,9 +354,8 @@ class DAGScheduler(
     val numTasks = rdd.partitions.length
     val stage = newShuffleMapStage(rdd, numTasks, shuffleDep, firstJobId, rdd.creationSite)
     if (mapOutputTracker.containsShuffle(shuffleDep.shuffleId)) {
-      val serLocs = mapOutputTracker.getSerializedMapOutputStatuses(shuffleDep.shuffleId)
-      val locs = MapOutputTracker.deserializeMapStatuses(serLocs)
-      (0 until locs.length).foreach { i =>
+      val locs = mapOutputTracker.getMapOutputStatuses(shuffleDep.shuffleId)
+      locs.indices.foreach { i =>
         if (locs(i) ne null) {
           // locs(i) will be null if missing
           stage.addOutputLoc(i, locs(i))


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a new method to `MapOutputTracker` class

``` scala
  def getMapOutputStatuses(shuffleId: Int): Array[MapStatus] = epochLock.synchronized {
    Array[MapStatus]() ++ mapStatuses.getOrElse(shuffleId, Array[MapStatus]())
  }
```

DAG uses  `getMapOutputStatuses` rather than the `getSerializedMapOutputStatuses`
## How was this patch tested?

Tests run successfully.
