### PR TITLE
[SPARK-14123] [SQL] DDL: Create / Drop Function

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
@@ -446,10 +446,8 @@ case class SetDatabaseCommand(databaseName: String) extends RunnableCommand {
   * }}}
   */
 case class CreateFunction(
-                           functionName: String,
-                           alias: String,
-                           resources: Seq[(String, String)],
-                           isTemp: Boolean)(sql: String) extends RunnableCommand {
+    functionName: String, alias: String, resources: Seq[(String, String)],
+    isTemp: Boolean)(sql: String) extends RunnableCommand {
   override def run(sqlContext: SQLContext): Seq[Row] = {
     val catalog = sqlContext.sessionState.catalog
     val functionIdentifier = FunctionIdentifier(functionName, Some(catalog.getCurrentDatabase))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
@@ -22,15 +22,20 @@ import java.util.NoSuchElementException
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.catalog.CatalogFunction
-import org.apache.spark.sql.{Dataset, Row, SQLContext}
-import org.apache.spark.sql.catalyst.{CatalystTypeConverters, FunctionIdentifier, InternalRow, TableIdentifier}
 import org.apache.spark.sql.catalyst.errors.TreeNodeException
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
 import org.apache.spark.sql.catalyst.plans.logical
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.CatalystTypeConverters
+import org.apache.spark.sql.catalyst.FunctionIdentifier
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.Dataset
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.SQLContext
 
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -52,13 +52,6 @@ case class CreateDatabase(
     props: Map[String, String])(sql: String)
   extends NativeDDLCommand(sql) with Logging
 
-case class CreateFunction(
-    functionName: String,
-    alias: String,
-    resources: Seq[(String, String)],
-    isTemp: Boolean)(sql: String)
-  extends NativeDDLCommand(sql) with Logging
-
 case class AlterTableRename(
     oldName: TableIdentifier,
     newName: TableIdentifier)(sql: String)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -86,26 +86,6 @@ case class DescribeDatabase(
     extended: Boolean)(sql: String)
   extends NativeDDLCommand(sql) with Logging
 
-case class CreateFunction(
-    databaseName: Option[String],
-    functionName: String,
-    alias: String,
-    resources: Seq[(String, String)],
-    isTemp: Boolean)(sql: String)
-  extends NativeDDLCommand(sql) with Logging
-
-/**
- * The DDL command that drops a function.
- * ifExists: returns an error if the function doesn't exist, unless this is true.
- * isTemp: indicates if it is a temporary function.
- */
-case class DropFunction(
-    databaseName: Option[String],
-    functionName: String,
-    ifExists: Boolean,
-    isTemp: Boolean)(sql: String)
-  extends NativeDDLCommand(sql) with Logging
-
 case class AlterTableRename(
     oldName: TableIdentifier,
     newName: TableIdentifier)(sql: String)

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -21,10 +21,13 @@ import java.math.MathContext
 import java.sql.Timestamp
 
 import org.apache.spark.AccumulatorSuite
+import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedException
+import org.apache.spark.sql.catalyst.catalog.CatalogFunction
 import org.apache.spark.sql.catalyst.expressions.SortOrder
 import org.apache.spark.sql.catalyst.plans.logical.Aggregate
 import org.apache.spark.sql.execution.aggregate
+import org.apache.spark.sql.execution.command.CreateFunction
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoin, CartesianProduct, SortMergeJoin}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
@@ -2375,5 +2378,31 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
           Row("r2c1", "r2c2", "t1r2c3", "r2c2", "t1r2c3") ::
           Row("r3c1x", "r3c2", "t1r3c3", "r3c2", "t1r3c3") :: Nil)
     }
+  }
+
+  test("SPARK-14123") {
+    val sql1 =
+      """
+        |CREATE TEMPORARY FUNCTION helloworld1 AS
+        |'spark.example.SimpleUDFExample1' USING JAR '/path/to/jar1',
+        |JAR '/path/to/jar2'
+      """.stripMargin
+    val sql2 =
+      """
+        |CREATE FUNCTION helloworld2 AS
+        |'spark.example.SimpleUDFExample2' USING ARCHIVE '/path/to/archive',
+        |FILE '/path/to/file'
+      """.stripMargin
+    sql(sql1)
+    sql(sql2)
+
+    val catalog = sqlContext.sessionState.catalog
+    val id1 = FunctionIdentifier("helloworld1", Some(catalog.getCurrentDatabase))
+    val id2 = FunctionIdentifier("helloworld2", Some(catalog.getCurrentDatabase))
+
+    val f1 = catalog.getFunction(id1)
+    val f2 = catalog.getFunction(id2)
+    assert(f1 == CatalogFunction(id1, "spark.example.SimpleUDFExample1"))
+    assert(f2 == CatalogFunction(id2, "spark.example.SimpleUDFExample2"))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2379,30 +2379,4 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
           Row("r3c1x", "r3c2", "t1r3c3", "r3c2", "t1r3c3") :: Nil)
     }
   }
-
-  test("SPARK-14123") {
-    val sql1 =
-      """
-        |CREATE TEMPORARY FUNCTION helloworld1 AS
-        |'spark.example.SimpleUDFExample1' USING JAR '/path/to/jar1',
-        |JAR '/path/to/jar2'
-      """.stripMargin
-    val sql2 =
-      """
-        |CREATE FUNCTION helloworld2 AS
-        |'spark.example.SimpleUDFExample2' USING ARCHIVE '/path/to/archive',
-        |FILE '/path/to/file'
-      """.stripMargin
-    sql(sql1)
-    sql(sql2)
-
-    val catalog = sqlContext.sessionState.catalog
-    val id1 = FunctionIdentifier("helloworld1", Some(catalog.getCurrentDatabase))
-    val id2 = FunctionIdentifier("helloworld2", Some(catalog.getCurrentDatabase))
-
-    val f1 = catalog.getFunction(id1)
-    val f2 = catalog.getFunction(id2)
-    assert(f1 == CatalogFunction(id1, "spark.example.SimpleUDFExample1"))
-    assert(f2 == CatalogFunction(id2, "spark.example.SimpleUDFExample2"))
-  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandSuite.scala
@@ -47,13 +47,13 @@ class DDLCommandSuite extends PlanTest {
   test("create function") {
     val sql1 =
       """
-       |CREATE TEMPORARY FUNCTION helloworld as
+       |CREATE TEMPORARY FUNCTION helloworld AS
        |'com.matthewrathbone.example.SimpleUDFExample' USING JAR '/path/to/jar1',
        |JAR '/path/to/jar2'
      """.stripMargin
     val sql2 =
       """
-        |CREATE FUNCTION hello.world as
+        |CREATE FUNCTION hello.world AS
         |'com.matthewrathbone.example.SimpleUDFExample' USING ARCHIVE '/path/to/archive',
         |FILE '/path/to/file'
       """.stripMargin

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.test.SharedSQLContext
 class DDLSuite extends QueryTest with SharedSQLContext {
 
   test("SPARK-14123: Create / drop function DDL") {
+    // test the create functions
     val sql1 =
       """
         |CREATE TEMPORARY FUNCTION helloworld1 AS
@@ -49,9 +50,14 @@ class DDLSuite extends QueryTest with SharedSQLContext {
     assert(f1 == CatalogFunction(id1, "spark.example.SimpleUDFExample1"))
     assert(f2 == CatalogFunction(id2, "spark.example.SimpleUDFExample2"))
 
+    // test the drop functions
     assert(catalog.listFunctions(catalog.getCurrentDatabase, "helloworld*").size == 2)
-    catalog.dropFunction(id1)
-    catalog.dropFunction(id2)
+
+    val sql3 = "DROP TEMPORARY FUNCTION helloworld1"
+    val sql4 = "DROP FUNCTION IF EXISTS helloworld2"
+    sql(sql3)
+    sql(sql4)
+
     assert(catalog.listFunctions(catalog.getCurrentDatabase, "helloworld*").isEmpty)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.command
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.FunctionIdentifier
+import org.apache.spark.sql.catalyst.catalog.CatalogFunction
+import org.apache.spark.sql.test.SharedSQLContext
+
+class DDLSuite extends QueryTest with SharedSQLContext {
+
+  test("SPARK-14123: Create / drop function DDL") {
+    val sql1 =
+      """
+        |CREATE TEMPORARY FUNCTION helloworld1 AS
+        |'spark.example.SimpleUDFExample1' USING JAR '/path/to/jar1',
+        |JAR '/path/to/jar2'
+      """.stripMargin
+    val sql2 =
+      """
+        |CREATE FUNCTION helloworld2 AS
+        |'spark.example.SimpleUDFExample2' USING ARCHIVE '/path/to/archive',
+        |FILE '/path/to/file'
+      """.stripMargin
+    sql(sql1)
+    sql(sql2)
+
+    val catalog = sqlContext.sessionState.catalog
+    val id1 = FunctionIdentifier("helloworld1", Some(catalog.getCurrentDatabase))
+    val id2 = FunctionIdentifier("helloworld2", Some(catalog.getCurrentDatabase))
+
+    val f1 = catalog.getFunction(id1)
+    val f2 = catalog.getFunction(id2)
+    assert(f1 == CatalogFunction(id1, "spark.example.SimpleUDFExample1"))
+    assert(f2 == CatalogFunction(id2, "spark.example.SimpleUDFExample2"))
+
+    assert(catalog.listFunctions(catalog.getCurrentDatabase, "helloworld*").size == 2)
+    catalog.dropFunction(id1)
+    catalog.dropFunction(id2)
+    assert(catalog.listFunctions(catalog.getCurrentDatabase, "helloworld*").isEmpty)
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is the first step to support create / drop functions by using catalog based on @yhuai document. Instead of using NativeDDLCommand, we will call the functions in the catalog to do the jobs.
## How was this patch tested?

I've create a new test suite called DDLSuite that will test the DDL functions, eventually it will contains more DDL test cases, such as Create DB / Table, etc.
