### PR TITLE
[SPARK-3724][ML] RandomForest: More options for feature subset size.

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/DecisionTreeMetadata.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/DecisionTreeMetadata.scala
@@ -191,7 +191,7 @@ private[spark] object DecisionTreeMetadata extends Logging {
       case "sqrt" => math.sqrt(numFeatures).ceil.toInt
       case "log2" => math.max(1, (math.log(numFeatures) / math.log(2)).ceil.toInt)
       case "onethird" => (numFeatures / 3.0).ceil.toInt
-      case isIntRegex(number) => if (number.toInt > numFeatures) numFeatures else number.toInt
+      case isIntRegex(number) => if (BigInt(number) > numFeatures) numFeatures else number.toInt
       case isFractionRegex(fraction) => (fraction.toDouble * numFeatures).ceil.toInt
     }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/DecisionTreeMetadata.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/DecisionTreeMetadata.scala
@@ -185,7 +185,7 @@ private[spark] object DecisionTreeMetadata extends Logging {
     }
 
     val isIntRegex = "^([1-9]\\d*)$".r
-    val isFractionRegex = "^(0\\.\\d*[1-9]\\d*\\d*|1\\.0+)$".r
+    val isFractionRegex = "^(0?\\.\\d*[1-9]\\d*|1\\.0+)$".r
     val numFeaturesPerNode: Int = _featureSubsetStrategy match {
       case "all" => numFeatures
       case "sqrt" => math.sqrt(numFeatures).ceil.toInt

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/impl/DecisionTreeMetadata.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/impl/DecisionTreeMetadata.scala
@@ -184,39 +184,15 @@ private[spark] object DecisionTreeMetadata extends Logging {
       case _ => featureSubsetStrategy
     }
 
-    object featureSubsetNumber {
-      def unapply(strategy: String): Option[Int] = try {
-        val number = strategy.toInt
-        if (0 < number) {
-          Some(number)
-        } else {
-          None
-        }
-      } catch {
-        case _ : java.lang.NumberFormatException => None
-      }
-    }
-
-    object featureSubsetFraction {
-      def unapply(strategy: String): Option[Double] = try {
-        val fraction = strategy.toDouble
-        if (0.0 < fraction && fraction <= 1.0) {
-          Some(fraction)
-        } else {
-          None
-        }
-      } catch {
-        case _ : java.lang.NumberFormatException => None
-      }
-    }
-
+    val isIntRegex = "^([1-9]\\d*)$".r
+    val isFractionRegex = "^(0\\.\\d*[1-9]\\d*\\d*|1\\.0+)$".r
     val numFeaturesPerNode: Int = _featureSubsetStrategy match {
       case "all" => numFeatures
       case "sqrt" => math.sqrt(numFeatures).ceil.toInt
       case "log2" => math.max(1, (math.log(numFeatures) / math.log(2)).ceil.toInt)
       case "onethird" => (numFeatures / 3.0).ceil.toInt
-      case featureSubsetNumber(number) => if (number > numFeatures) numFeatures else number
-      case featureSubsetFraction(fraction) => (fraction * numFeatures).ceil.toInt
+      case isIntRegex(number) => if (number.toInt > numFeatures) numFeatures else number.toInt
+      case isFractionRegex(fraction) => (fraction.toDouble * numFeatures).ceil.toInt
     }
 
     new DecisionTreeMetadata(numFeatures, numExamples, numClasses, numBins.max,

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
@@ -329,8 +329,8 @@ private[ml] trait HasFeatureSubsetStrategy extends Params {
    *  - "onethird": use 1/3 of the features
    *  - "sqrt": use sqrt(number of features)
    *  - "log2": use log2(number of features)
-   *  - "(0.0-1.0]": use the specified fraction of features
-   *  - "n": use n features, for integer 0 < n <= (number of features)
+   *  - "n": when n is in the range (0, 1.0], use n * number of features. When n
+   *         is in the range (1, number of features), use n features.
    * (default = "auto")
    *
    * These various settings are based on the following references:

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
@@ -329,6 +329,8 @@ private[ml] trait HasFeatureSubsetStrategy extends Params {
    *  - "onethird": use 1/3 of the features
    *  - "sqrt": use sqrt(number of features)
    *  - "log2": use log2(number of features)
+   *  - "(0.0-1.0]": use the specified fraction of features
+   *  - "[1-n]": use the specified number of features
    * (default = "auto")
    *
    * These various settings are based on the following references:
@@ -346,7 +348,9 @@ private[ml] trait HasFeatureSubsetStrategy extends Params {
     "The number of features to consider for splits at each tree node." +
       s" Supported options: ${RandomForestParams.supportedFeatureSubsetStrategies.mkString(", ")}",
     (value: String) =>
-      RandomForestParams.supportedFeatureSubsetStrategies.contains(value.toLowerCase))
+      RandomForestParams.supportedFeatureSubsetStrategies.contains(value.toLowerCase)
+      || (try { value.toInt > 0 } catch { case _ : Throwable => false })
+      || (try { value.toDouble > 0.0 || value.toDouble <= 1.0} catch { case _ : Throwable => false }))
 
   setDefault(featureSubsetStrategy -> "auto")
 

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
@@ -330,7 +330,7 @@ private[ml] trait HasFeatureSubsetStrategy extends Params {
    *  - "sqrt": use sqrt(number of features)
    *  - "log2": use log2(number of features)
    *  - "(0.0-1.0]": use the specified fraction of features
-   *  - "[1-n]": use the specified number of features
+   *  - "n": use n features, for integer 0 < n <= (number of features)
    * (default = "auto")
    *
    * These various settings are based on the following references:
@@ -349,7 +349,7 @@ private[ml] trait HasFeatureSubsetStrategy extends Params {
       s" Supported options: ${RandomForestParams.supportedFeatureSubsetStrategies.mkString(", ")}",
     (value: String) =>
       RandomForestParams.supportedFeatureSubsetStrategies.contains(value.toLowerCase)
-      || value.matches("^(?:[1-9]\\d*|0\\.\\d*[1-9]\\d*\\d*|1\\.0+)$"))
+      || value.matches(RandomForestParams.supportedFeatureSubsetStrategiesRegex))
 
   setDefault(featureSubsetStrategy -> "auto")
 
@@ -396,6 +396,9 @@ private[spark] object RandomForestParams {
   // These options should be lowercase.
   final val supportedFeatureSubsetStrategies: Array[String] =
     Array("auto", "all", "onethird", "sqrt", "log2").map(_.toLowerCase)
+
+  // The regex to capture "(0.0-1.0]", and "n" for integer 0 < n <= (number of features)
+  final val supportedFeatureSubsetStrategiesRegex = "^(?:[1-9]\\d*|0?\\.\\d*[1-9]\\d*|1\\.0+)$"
 }
 
 private[ml] trait RandomForestClassifierParams

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeParams.scala
@@ -349,8 +349,7 @@ private[ml] trait HasFeatureSubsetStrategy extends Params {
       s" Supported options: ${RandomForestParams.supportedFeatureSubsetStrategies.mkString(", ")}",
     (value: String) =>
       RandomForestParams.supportedFeatureSubsetStrategies.contains(value.toLowerCase)
-      || (try { value.toInt > 0 } catch { case _ : Throwable => false })
-      || (try { value.toDouble > 0.0 || value.toDouble <= 1.0} catch { case _ : Throwable => false }))
+      || value.matches("^(?:[1-9]\\d*|0\\.\\d*[1-9]\\d*\\d*|1\\.0+)$"))
 
   setDefault(featureSubsetStrategy -> "auto")
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/RandomForest.scala
@@ -76,10 +76,10 @@ private class RandomForest (
   strategy.assertValid()
   require(numTrees > 0, s"RandomForest requires numTrees > 0, but was given numTrees = $numTrees.")
   require(RandomForest.supportedFeatureSubsetStrategies.contains(featureSubsetStrategy)
-    || (try { featureSubsetStrategy.toInt > 0 } catch { case _ : Throwable => false })
-    || (try { featureSubsetStrategy.toDouble > 0.0 || featureSubsetStrategy.toDouble <= 1.0} catch { case _ : Throwable => false }),
+    || featureSubsetStrategy.matches("^(?:[1-9]\\d*|0\\.\\d*[1-9]\\d*\\d*|1\\.0+)$"),
     s"RandomForest given invalid featureSubsetStrategy: $featureSubsetStrategy." +
-    s" Supported values: ${RandomForest.supportedFeatureSubsetStrategies.mkString(", ")}, (0.0-1.0], [1-n].")
+    s" Supported values: ${RandomForest.supportedFeatureSubsetStrategies.mkString(", ")}," +
+    s" (0.0-1.0], [1-n].")
 
   /**
    * Method to train a decision tree model over an RDD

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/RandomForest.scala
@@ -60,11 +60,10 @@ import org.apache.spark.util.Utils
  *                                if numTrees == 1, set to "all";
  *                                if numTrees > 1 (forest) set to "sqrt" for classification and
  *                                  to "onethird" for regression.
- *                              If a real value "(0.0-1.0]" is set, this parameter specifies
- *                                the fraction of features in each subset.
- *                              If an integer value "n" is set, this parameter specifies
- *                                the number of features used in each subset,
- *                                for integer 0 < n <= (number of features).
+ *                              If a real value "n" in the range (0, 1.0] is set,
+ *                                use n * number of features.
+ *                              If an integer value "n" in the range (1, num features) is set,
+ *                                use n features.
  * @param seed Random seed for bootstrapping and choosing feature subsets.
  */
 private class RandomForest (

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/RandomForest.scala
@@ -61,9 +61,10 @@ import org.apache.spark.util.Utils
  *                                if numTrees > 1 (forest) set to "sqrt" for classification and
  *                                  to "onethird" for regression.
  *                              If a real value "(0.0-1.0]" is set, this parameter specifies
- *                              the fraction of features in each subset.
- *                              If an integer value "[1-n]" is set, this parameter specifies
- *                              the number of features in each subset.
+ *                                the fraction of features in each subset.
+ *                              If an integer value "n" is set, this parameter specifies
+ *                                the number of features used in each subset,
+ *                                for integer 0 < n <= (number of features).
  * @param seed Random seed for bootstrapping and choosing feature subsets.
  */
 private class RandomForest (
@@ -76,7 +77,7 @@ private class RandomForest (
   strategy.assertValid()
   require(numTrees > 0, s"RandomForest requires numTrees > 0, but was given numTrees = $numTrees.")
   require(RandomForest.supportedFeatureSubsetStrategies.contains(featureSubsetStrategy)
-    || featureSubsetStrategy.matches("^(?:[1-9]\\d*|0\\.\\d*[1-9]\\d*\\d*|1\\.0+)$"),
+    || featureSubsetStrategy.matches(NewRFParams.supportedFeatureSubsetStrategiesRegex),
     s"RandomForest given invalid featureSubsetStrategy: $featureSubsetStrategy." +
     s" Supported values: ${RandomForest.supportedFeatureSubsetStrategies.mkString(", ")}," +
     s" (0.0-1.0], [1-n].")

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/RandomForest.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/RandomForest.scala
@@ -79,7 +79,7 @@ private class RandomForest (
     || (try { featureSubsetStrategy.toInt > 0 } catch { case _ : Throwable => false })
     || (try { featureSubsetStrategy.toDouble > 0.0 || featureSubsetStrategy.toDouble <= 1.0} catch { case _ : Throwable => false }),
     s"RandomForest given invalid featureSubsetStrategy: $featureSubsetStrategy." +
-    s" Supported values: ${RandomForest.supportedFeatureSubsetStrategies.mkString(", ")}, [0.0-1.0], [1-n].")
+    s" Supported values: ${RandomForest.supportedFeatureSubsetStrategies.mkString(", ")}, (0.0-1.0], [1-n].")
 
   /**
    * Method to train a decision tree model over an RDD

--- a/mllib/src/test/java/org/apache/spark/ml/classification/JavaRandomForestClassifierSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/classification/JavaRandomForestClassifierSuite.java
@@ -80,15 +80,14 @@ public class JavaRandomForestClassifierSuite implements Serializable {
     for (String featureSubsetStrategy: RandomForestClassifier.supportedFeatureSubsetStrategies()) {
       rf.setFeatureSubsetStrategy(featureSubsetStrategy);
     }
-    rf.setFeatureSubsetStrategy(".1");
-    rf.setFeatureSubsetStrategy(".10");
-    rf.setFeatureSubsetStrategy("0.10");
-    rf.setFeatureSubsetStrategy("0.1");
-    rf.setFeatureSubsetStrategy("0.9");
-    rf.setFeatureSubsetStrategy("1.0");
-    rf.setFeatureSubsetStrategy("1");
-    rf.setFeatureSubsetStrategy("100");
-    rf.setFeatureSubsetStrategy("1000");
+    String realStrategies[] = {".1", ".10", "0.10", "0.1", "0.9", "1.0"};
+    for (String strategy: realStrategies) {
+      rf.setFeatureSubsetStrategy(strategy);
+    }
+    String integerStrategies[] = {"1", "10", "100", "1000", "10000"};
+    for (String strategy: integerStrategies) {
+      rf.setFeatureSubsetStrategy(strategy);
+    }
     RandomForestClassificationModel model = rf.fit(dataFrame);
 
     model.transform(dataFrame);

--- a/mllib/src/test/java/org/apache/spark/ml/classification/JavaRandomForestClassifierSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/classification/JavaRandomForestClassifierSuite.java
@@ -80,6 +80,12 @@ public class JavaRandomForestClassifierSuite implements Serializable {
     for (String featureSubsetStrategy: RandomForestClassifier.supportedFeatureSubsetStrategies()) {
       rf.setFeatureSubsetStrategy(featureSubsetStrategy);
     }
+    for (double featureSubsetFraction = 0.1; featureSubsetFraction <= 1.0; featureSubsetFraction++) {
+      rf.setFeatureSubsetStrategy(Double.toString(featureSubsetFraction));
+    }
+    for (int featureSubsetNumber = 1; featureSubsetNumber <= 100; featureSubsetNumber++) {
+      rf.setFeatureSubsetStrategy(Integer.toString(featureSubsetNumber));
+    }
     RandomForestClassificationModel model = rf.fit(dataFrame);
 
     model.transform(dataFrame);

--- a/mllib/src/test/java/org/apache/spark/ml/classification/JavaRandomForestClassifierSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/classification/JavaRandomForestClassifierSuite.java
@@ -80,6 +80,9 @@ public class JavaRandomForestClassifierSuite implements Serializable {
     for (String featureSubsetStrategy: RandomForestClassifier.supportedFeatureSubsetStrategies()) {
       rf.setFeatureSubsetStrategy(featureSubsetStrategy);
     }
+    rf.setFeatureSubsetStrategy(".1");
+    rf.setFeatureSubsetStrategy(".10");
+    rf.setFeatureSubsetStrategy("0.10");
     rf.setFeatureSubsetStrategy("0.1");
     rf.setFeatureSubsetStrategy("0.9");
     rf.setFeatureSubsetStrategy("1.0");

--- a/mllib/src/test/java/org/apache/spark/ml/classification/JavaRandomForestClassifierSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/classification/JavaRandomForestClassifierSuite.java
@@ -80,7 +80,7 @@ public class JavaRandomForestClassifierSuite implements Serializable {
     for (String featureSubsetStrategy: RandomForestClassifier.supportedFeatureSubsetStrategies()) {
       rf.setFeatureSubsetStrategy(featureSubsetStrategy);
     }
-    for (double featureSubsetFraction = 0.1; featureSubsetFraction <= 1.0; featureSubsetFraction++) {
+    for (double featureSubsetFraction = 0.1; featureSubsetFraction <= 1.0; featureSubsetFraction += 0.1) {
       rf.setFeatureSubsetStrategy(Double.toString(featureSubsetFraction));
     }
     for (int featureSubsetNumber = 1; featureSubsetNumber <= 100; featureSubsetNumber++) {

--- a/mllib/src/test/java/org/apache/spark/ml/classification/JavaRandomForestClassifierSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/classification/JavaRandomForestClassifierSuite.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -88,6 +89,16 @@ public class JavaRandomForestClassifierSuite implements Serializable {
     for (String strategy: integerStrategies) {
       rf.setFeatureSubsetStrategy(strategy);
     }
+    String invalidStrategies[] = {"-.1", "-.10", "-0.10", ".0", "0.0", "1.1", "0"};
+    for (String strategy: invalidStrategies) {
+      try {
+        rf.setFeatureSubsetStrategy(strategy);
+        Assert.fail("Expected exception to be thrown for invalid strategies");
+      } catch (Exception e) {
+        Assert.assertTrue(e instanceof IllegalArgumentException);
+      }
+    }
+
     RandomForestClassificationModel model = rf.fit(dataFrame);
 
     model.transform(dataFrame);

--- a/mllib/src/test/java/org/apache/spark/ml/classification/JavaRandomForestClassifierSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/classification/JavaRandomForestClassifierSuite.java
@@ -80,9 +80,9 @@ public class JavaRandomForestClassifierSuite implements Serializable {
     for (String featureSubsetStrategy: RandomForestClassifier.supportedFeatureSubsetStrategies()) {
       rf.setFeatureSubsetStrategy(featureSubsetStrategy);
     }
-    for (double featureSubsetFraction = 0.1; featureSubsetFraction <= 1.0; featureSubsetFraction += 0.1) {
-      rf.setFeatureSubsetStrategy(Double.toString(featureSubsetFraction));
-    }
+    rf.setFeatureSubsetStrategy("0.1");
+    rf.setFeatureSubsetStrategy("0.9");
+    rf.setFeatureSubsetStrategy("1.0");
     rf.setFeatureSubsetStrategy("1");
     rf.setFeatureSubsetStrategy("100");
     rf.setFeatureSubsetStrategy("1000");

--- a/mllib/src/test/java/org/apache/spark/ml/classification/JavaRandomForestClassifierSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/classification/JavaRandomForestClassifierSuite.java
@@ -83,9 +83,9 @@ public class JavaRandomForestClassifierSuite implements Serializable {
     for (double featureSubsetFraction = 0.1; featureSubsetFraction <= 1.0; featureSubsetFraction += 0.1) {
       rf.setFeatureSubsetStrategy(Double.toString(featureSubsetFraction));
     }
-    for (int featureSubsetNumber = 1; featureSubsetNumber <= 100; featureSubsetNumber++) {
-      rf.setFeatureSubsetStrategy(Integer.toString(featureSubsetNumber));
-    }
+    rf.setFeatureSubsetStrategy("1");
+    rf.setFeatureSubsetStrategy("100");
+    rf.setFeatureSubsetStrategy("1000");
     RandomForestClassificationModel model = rf.fit(dataFrame);
 
     model.transform(dataFrame);

--- a/mllib/src/test/java/org/apache/spark/ml/regression/JavaRandomForestRegressorSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/regression/JavaRandomForestRegressorSuite.java
@@ -80,6 +80,12 @@ public class JavaRandomForestRegressorSuite implements Serializable {
     for (String featureSubsetStrategy: RandomForestRegressor.supportedFeatureSubsetStrategies()) {
       rf.setFeatureSubsetStrategy(featureSubsetStrategy);
     }
+    for (double featureSubsetFraction = 0.1; featureSubsetFraction <= 1.0; featureSubsetFraction++) {
+      rf.setFeatureSubsetStrategy(Double.toString(featureSubsetFraction));
+    }
+    for (int featureSubsetNumber = 1; featureSubsetNumber <= 100; featureSubsetNumber++) {
+      rf.setFeatureSubsetStrategy(Integer.toString(featureSubsetNumber));
+    }
     RandomForestRegressionModel model = rf.fit(dataFrame);
 
     model.transform(dataFrame);

--- a/mllib/src/test/java/org/apache/spark/ml/regression/JavaRandomForestRegressorSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/regression/JavaRandomForestRegressorSuite.java
@@ -83,9 +83,9 @@ public class JavaRandomForestRegressorSuite implements Serializable {
     for (double featureSubsetFraction = 0.1; featureSubsetFraction <= 1.0; featureSubsetFraction += 0.1) {
       rf.setFeatureSubsetStrategy(Double.toString(featureSubsetFraction));
     }
-    for (int featureSubsetNumber = 1; featureSubsetNumber <= 100; featureSubsetNumber++) {
-      rf.setFeatureSubsetStrategy(Integer.toString(featureSubsetNumber));
-    }
+    rf.setFeatureSubsetStrategy("1");
+    rf.setFeatureSubsetStrategy("100");
+    rf.setFeatureSubsetStrategy("1000");
     RandomForestRegressionModel model = rf.fit(dataFrame);
 
     model.transform(dataFrame);

--- a/mllib/src/test/java/org/apache/spark/ml/regression/JavaRandomForestRegressorSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/regression/JavaRandomForestRegressorSuite.java
@@ -80,9 +80,9 @@ public class JavaRandomForestRegressorSuite implements Serializable {
     for (String featureSubsetStrategy: RandomForestRegressor.supportedFeatureSubsetStrategies()) {
       rf.setFeatureSubsetStrategy(featureSubsetStrategy);
     }
-    for (double featureSubsetFraction = 0.1; featureSubsetFraction <= 1.0; featureSubsetFraction += 0.1) {
-      rf.setFeatureSubsetStrategy(Double.toString(featureSubsetFraction));
-    }
+    rf.setFeatureSubsetStrategy("0.1");
+    rf.setFeatureSubsetStrategy("0.9");
+    rf.setFeatureSubsetStrategy("1.0");
     rf.setFeatureSubsetStrategy("1");
     rf.setFeatureSubsetStrategy("100");
     rf.setFeatureSubsetStrategy("1000");

--- a/mllib/src/test/java/org/apache/spark/ml/regression/JavaRandomForestRegressorSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/regression/JavaRandomForestRegressorSuite.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -88,6 +89,16 @@ public class JavaRandomForestRegressorSuite implements Serializable {
     for (String strategy: integerStrategies) {
       rf.setFeatureSubsetStrategy(strategy);
     }
+    String invalidStrategies[] = {"-.1", "-.10", "-0.10", ".0", "0.0", "1.1", "0"};
+    for (String strategy: invalidStrategies) {
+      try {
+        rf.setFeatureSubsetStrategy(strategy);
+        Assert.fail("Expected exception to be thrown for invalid strategies");
+      } catch (Exception e) {
+        Assert.assertTrue(e instanceof IllegalArgumentException);
+      }
+    }
+
     RandomForestRegressionModel model = rf.fit(dataFrame);
 
     model.transform(dataFrame);

--- a/mllib/src/test/java/org/apache/spark/ml/regression/JavaRandomForestRegressorSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/regression/JavaRandomForestRegressorSuite.java
@@ -80,6 +80,9 @@ public class JavaRandomForestRegressorSuite implements Serializable {
     for (String featureSubsetStrategy: RandomForestRegressor.supportedFeatureSubsetStrategies()) {
       rf.setFeatureSubsetStrategy(featureSubsetStrategy);
     }
+    rf.setFeatureSubsetStrategy(".1");
+    rf.setFeatureSubsetStrategy(".10");
+    rf.setFeatureSubsetStrategy("0.10");
     rf.setFeatureSubsetStrategy("0.1");
     rf.setFeatureSubsetStrategy("0.9");
     rf.setFeatureSubsetStrategy("1.0");

--- a/mllib/src/test/java/org/apache/spark/ml/regression/JavaRandomForestRegressorSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/regression/JavaRandomForestRegressorSuite.java
@@ -80,15 +80,14 @@ public class JavaRandomForestRegressorSuite implements Serializable {
     for (String featureSubsetStrategy: RandomForestRegressor.supportedFeatureSubsetStrategies()) {
       rf.setFeatureSubsetStrategy(featureSubsetStrategy);
     }
-    rf.setFeatureSubsetStrategy(".1");
-    rf.setFeatureSubsetStrategy(".10");
-    rf.setFeatureSubsetStrategy("0.10");
-    rf.setFeatureSubsetStrategy("0.1");
-    rf.setFeatureSubsetStrategy("0.9");
-    rf.setFeatureSubsetStrategy("1.0");
-    rf.setFeatureSubsetStrategy("1");
-    rf.setFeatureSubsetStrategy("100");
-    rf.setFeatureSubsetStrategy("1000");
+    String realStrategies[] = {".1", ".10", "0.10", "0.1", "0.9", "1.0"};
+    for (String strategy: realStrategies) {
+      rf.setFeatureSubsetStrategy(strategy);
+    }
+    String integerStrategies[] = {"1", "10", "100", "1000", "10000"};
+    for (String strategy: integerStrategies) {
+      rf.setFeatureSubsetStrategy(strategy);
+    }
     RandomForestRegressionModel model = rf.fit(dataFrame);
 
     model.transform(dataFrame);

--- a/mllib/src/test/java/org/apache/spark/ml/regression/JavaRandomForestRegressorSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/regression/JavaRandomForestRegressorSuite.java
@@ -80,7 +80,7 @@ public class JavaRandomForestRegressorSuite implements Serializable {
     for (String featureSubsetStrategy: RandomForestRegressor.supportedFeatureSubsetStrategies()) {
       rf.setFeatureSubsetStrategy(featureSubsetStrategy);
     }
-    for (double featureSubsetFraction = 0.1; featureSubsetFraction <= 1.0; featureSubsetFraction++) {
+    for (double featureSubsetFraction = 0.1; featureSubsetFraction <= 1.0; featureSubsetFraction += 0.1) {
       rf.setFeatureSubsetStrategy(Double.toString(featureSubsetFraction));
     }
     for (int featureSubsetNumber = 1; featureSubsetNumber <= 100; featureSubsetNumber++) {

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
@@ -27,7 +27,6 @@ import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.tree.{DecisionTreeSuite => OldDTSuite, EnsembleTestHelper}
 import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo, QuantileStrategy, Strategy => OldStrategy}
 import org.apache.spark.mllib.tree.impurity.{Entropy, Gini, GiniCalculator}
-import org.apache.spark.mllib.tree.model.RandomForestModel
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
 import org.apache.spark.util.collection.OpenHashMap

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
@@ -423,6 +423,13 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
     checkFeatureSubsetStrategy(numTrees = 1, "log2",
       (math.log(numFeatures) / math.log(2)).ceil.toInt)
     checkFeatureSubsetStrategy(numTrees = 1, "onethird", (numFeatures / 3.0).ceil.toInt)
+    checkFeatureSubsetStrategy(numTrees = 1, "0.1", (0.1 * numFeatures).ceil.toInt)
+    checkFeatureSubsetStrategy(numTrees = 1, "0.5", (0.5 * numFeatures).ceil.toInt)
+    checkFeatureSubsetStrategy(numTrees = 1, "1.0", (1.0 * numFeatures).ceil.toInt)
+    checkFeatureSubsetStrategy(numTrees = 1, "1", 1)
+    checkFeatureSubsetStrategy(numTrees = 1, "2", 2)
+    checkFeatureSubsetStrategy(numTrees = 1, numFeatures.toString, numFeatures)
+    checkFeatureSubsetStrategy(numTrees = 1, (numFeatures * 2).toString, numFeatures)
 
     checkFeatureSubsetStrategy(numTrees = 2, "all", numFeatures)
     checkFeatureSubsetStrategy(numTrees = 2, "auto", math.sqrt(numFeatures).ceil.toInt)
@@ -430,6 +437,13 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
     checkFeatureSubsetStrategy(numTrees = 2, "log2",
       (math.log(numFeatures) / math.log(2)).ceil.toInt)
     checkFeatureSubsetStrategy(numTrees = 2, "onethird", (numFeatures / 3.0).ceil.toInt)
+    checkFeatureSubsetStrategy(numTrees = 2, "0.1", (0.1 * numFeatures).ceil.toInt)
+    checkFeatureSubsetStrategy(numTrees = 2, "0.5", (0.5 * numFeatures).ceil.toInt)
+    checkFeatureSubsetStrategy(numTrees = 2, "1.0", (1.0 * numFeatures).ceil.toInt)
+    checkFeatureSubsetStrategy(numTrees = 2, "1", 1)
+    checkFeatureSubsetStrategy(numTrees = 2, "2", 2)
+    checkFeatureSubsetStrategy(numTrees = 2, numFeatures.toString, numFeatures)
+    checkFeatureSubsetStrategy(numTrees = 2, (numFeatures * 2).toString, numFeatures)
   }
 
   test("Binary classification with continuous features: subsampling features") {
@@ -507,25 +521,6 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
     TreeEnsembleModel.normalizeMapValues(map)
     val expected = Map(0 -> 1.0 / 3.0, 2 -> 2.0 / 3.0)
     assert(mapToVec(map.toMap) ~== mapToVec(expected) relTol 0.01)
-  }
-
-  test("options for feature subset size in RandomForest - SPARK-3724") {
-    val arr = EnsembleTestHelper.generateOrderedLabeledPoints(numFeatures = 50, 1000)
-    val rdd = sc.parallelize(arr)
-    val numTrees = 1
-
-    val strategy = new OldStrategy(algo = OldAlgo.Classification, impurity = Gini, maxDepth = 2,
-      numClasses = 2, categoricalFeaturesInfo = Map.empty[Int, Int],
-      useNodeIdCache = true)
-
-    // Both options should be the same as 17 == 50 * 0.34
-    val rf1 = RandomForest.run(rdd, strategy, numTrees = numTrees,
-      featureSubsetStrategy = "17", seed = 123)
-    val rf2 = RandomForest.run(rdd, strategy, numTrees = numTrees,
-      featureSubsetStrategy = "0.34", seed = 123)
-    val model1 = new RandomForestModel(strategy.algo, rf1.map(_.toOld))
-    val model2 = new RandomForestModel(strategy.algo, rf2.map(_.toOld))
-    assert(model1.toDebugString == model2.toDebugString)
   }
 
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
@@ -422,13 +422,18 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
     checkFeatureSubsetStrategy(numTrees = 1, "log2",
       (math.log(numFeatures) / math.log(2)).ceil.toInt)
     checkFeatureSubsetStrategy(numTrees = 1, "onethird", (numFeatures / 3.0).ceil.toInt)
-    checkFeatureSubsetStrategy(numTrees = 1, "0.1", (0.1 * numFeatures).ceil.toInt)
-    checkFeatureSubsetStrategy(numTrees = 1, "0.5", (0.5 * numFeatures).ceil.toInt)
-    checkFeatureSubsetStrategy(numTrees = 1, "1.0", (1.0 * numFeatures).ceil.toInt)
-    checkFeatureSubsetStrategy(numTrees = 1, "1", 1)
-    checkFeatureSubsetStrategy(numTrees = 1, "2", 2)
-    checkFeatureSubsetStrategy(numTrees = 1, numFeatures.toString, numFeatures)
-    checkFeatureSubsetStrategy(numTrees = 1, (numFeatures * 2).toString, numFeatures)
+
+    val realStrategies = Array(".1", ".10", "0.10", "0.1", "0.9", "1.0")
+    for (strategy <- realStrategies) {
+      val expected = (strategy.toDouble * numFeatures).ceil.toInt
+      checkFeatureSubsetStrategy(numTrees = 1, strategy, expected)
+    }
+
+    val integerStrategies = Array("1", "10", "100", "1000", "10000")
+    for (strategy <- integerStrategies) {
+      val expected = if (strategy.toInt < numFeatures) strategy.toInt else numFeatures
+      checkFeatureSubsetStrategy(numTrees = 1, strategy, expected)
+    }
 
     checkFeatureSubsetStrategy(numTrees = 2, "all", numFeatures)
     checkFeatureSubsetStrategy(numTrees = 2, "auto", math.sqrt(numFeatures).ceil.toInt)
@@ -436,13 +441,16 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
     checkFeatureSubsetStrategy(numTrees = 2, "log2",
       (math.log(numFeatures) / math.log(2)).ceil.toInt)
     checkFeatureSubsetStrategy(numTrees = 2, "onethird", (numFeatures / 3.0).ceil.toInt)
-    checkFeatureSubsetStrategy(numTrees = 2, "0.1", (0.1 * numFeatures).ceil.toInt)
-    checkFeatureSubsetStrategy(numTrees = 2, "0.5", (0.5 * numFeatures).ceil.toInt)
-    checkFeatureSubsetStrategy(numTrees = 2, "1.0", (1.0 * numFeatures).ceil.toInt)
-    checkFeatureSubsetStrategy(numTrees = 2, "1", 1)
-    checkFeatureSubsetStrategy(numTrees = 2, "2", 2)
-    checkFeatureSubsetStrategy(numTrees = 2, numFeatures.toString, numFeatures)
-    checkFeatureSubsetStrategy(numTrees = 2, (numFeatures * 2).toString, numFeatures)
+
+    for (strategy <- realStrategies) {
+      val expected = (strategy.toDouble * numFeatures).ceil.toInt
+      checkFeatureSubsetStrategy(numTrees = 2, strategy, expected)
+    }
+
+    for (strategy <- integerStrategies) {
+      val expected = if (strategy.toInt < numFeatures) strategy.toInt else numFeatures
+      checkFeatureSubsetStrategy(numTrees = 2, strategy, expected)
+    }
   }
 
   test("Binary classification with continuous features: subsampling features") {

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
@@ -435,6 +435,14 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
       checkFeatureSubsetStrategy(numTrees = 1, strategy, expected)
     }
 
+    val invalidStrategies = Array("-.1", "-.10", "-0.10", ".0", "0.0", "1.1", "0")
+    for (invalidStrategy <- invalidStrategies) {
+      intercept[MatchError]{
+        val metadata =
+          DecisionTreeMetadata.buildMetadata(rdd, strategy, numTrees = 1, invalidStrategy)
+      }
+    }
+
     checkFeatureSubsetStrategy(numTrees = 2, "all", numFeatures)
     checkFeatureSubsetStrategy(numTrees = 2, "auto", math.sqrt(numFeatures).ceil.toInt)
     checkFeatureSubsetStrategy(numTrees = 2, "sqrt", math.sqrt(numFeatures).ceil.toInt)
@@ -450,6 +458,12 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
     for (strategy <- integerStrategies) {
       val expected = if (strategy.toInt < numFeatures) strategy.toInt else numFeatures
       checkFeatureSubsetStrategy(numTrees = 2, strategy, expected)
+    }
+    for (invalidStrategy <- invalidStrategies) {
+      intercept[MatchError]{
+        val metadata =
+          DecisionTreeMetadata.buildMetadata(rdd, strategy, numTrees = 2, invalidStrategy)
+      }
     }
   }
 

--- a/mllib/src/test/scala/org/apache/spark/mllib/tree/RandomForestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/tree/RandomForestSuite.scala
@@ -135,6 +135,23 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(rf1.toDebugString != rf2.toDebugString)
   }
 
+  test("options for feature subset size in RandomForest - SPARK-3724") {
+    val arr = EnsembleTestHelper.generateOrderedLabeledPoints(numFeatures = 50, 1000)
+    val rdd = sc.parallelize(arr)
+    val numTrees = 1
+
+    val strategy = new Strategy(algo = Classification, impurity = Gini, maxDepth = 2,
+      numClasses = 2, categoricalFeaturesInfo = Map.empty[Int, Int],
+      useNodeIdCache = true)
+
+    // Both options should be the same as 17 == 50 * 0.34
+    val rf1 = RandomForest.trainClassifier(rdd, strategy, numTrees = numTrees,
+      featureSubsetStrategy = "17", seed = 123)
+    val rf2 = RandomForest.trainClassifier(rdd, strategy, numTrees = numTrees,
+      featureSubsetStrategy = "0.34", seed = 123)
+    assert(rf1.toDebugString == rf2.toDebugString)
+  }
+
   test("model save/load") {
     val tempDir = Utils.createTempDir()
     val path = tempDir.toURI.toString

--- a/mllib/src/test/scala/org/apache/spark/mllib/tree/RandomForestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/tree/RandomForestSuite.scala
@@ -135,23 +135,6 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(rf1.toDebugString != rf2.toDebugString)
   }
 
-  test("options for feature subset size in RandomForest - SPARK-3724") {
-    val arr = EnsembleTestHelper.generateOrderedLabeledPoints(numFeatures = 50, 1000)
-    val rdd = sc.parallelize(arr)
-    val numTrees = 1
-
-    val strategy = new Strategy(algo = Classification, impurity = Gini, maxDepth = 2,
-      numClasses = 2, categoricalFeaturesInfo = Map.empty[Int, Int],
-      useNodeIdCache = true)
-
-    // Both options should be the same as 17 == 50 * 0.34
-    val rf1 = RandomForest.trainClassifier(rdd, strategy, numTrees = numTrees,
-      featureSubsetStrategy = "17", seed = 123)
-    val rf2 = RandomForest.trainClassifier(rdd, strategy, numTrees = numTrees,
-      featureSubsetStrategy = "0.34", seed = 123)
-    assert(rf1.toDebugString == rf2.toDebugString)
-  }
-
   test("model save/load") {
     val tempDir = Utils.createTempDir()
     val path = tempDir.toURI.toString


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR tries to support more options for feature subset size in RandomForest implementation. Previously, RandomForest only support "auto", "all", "sort", "log2", "onethird". This PR tries to support any given value to allow model search.

In this PR, `featureSubsetStrategy` could be passed with:
a) a real number in the range of `(0.0-1.0]` that represents the fraction of the number of features in each subset,
b)  an integer number (`>0`) that represents the number of features in each subset.
## How was this patch tested?

Two tests `JavaRandomForestClassifierSuite` and `JavaRandomForestRegressorSuite` have been updated to check the additional options for params in this PR.
An additional test has been added to `org.apache.spark.mllib.tree.RandomForestSuite` to cover the cases in this PR.
