### PR TITLE
[SPARK-14193][SQL] Skip unnecessary sorts if input data have been already ordered in InMemoryRelation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -652,7 +652,7 @@ class Analyzer(
       case s @ Sort(orders, global, child)
           if conf.orderByOrdinal && orders.exists(o => IntegerIndex.unapply(o.child).nonEmpty) =>
         val newOrders = orders map {
-          case s @ SortOrder(IntegerIndex(index), direction) =>
+          case s @ SortOrder(IntegerIndex(index), direction, _) =>
             if (index > 0 && index <= child.output.size) {
               SortOrder(child.output(index - 1), direction)
             } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
@@ -63,6 +63,19 @@ case class SortOrder(child: Expression, direction: SortDirection)
   def isAscending: Boolean = direction == Ascending
 }
 
+object SortOrder {
+  /**
+   * Returns true iff the `output` orders are sufficient to satisfy the `required` orders.
+   */
+  def satisfies(output: Seq[SortOrder], required: Seq[SortOrder]): Boolean = {
+    required.forall { requiredOrder =>
+      output.exists { case outputOrder =>
+        requiredOrder.child == outputOrder.child && requiredOrder.direction == outputOrder.direction
+      }
+    }
+  }
+}
+
 /**
  * An expression to generate a 64-bit long prefix used in sorting.
  */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
@@ -40,7 +40,7 @@ case object Descending extends SortDirection {
  * An expression that can be used to sort a tuple.  This class extends expression primarily so that
  * transformations over expression will descend into its child.
  */
-case class SortOrder(child: Expression, direction: SortDirection)
+case class SortOrder(child: Expression, direction: SortDirection, global: Boolean = false)
   extends UnaryExpression with Unevaluable {
 
   /** Sort order is not foldable because we don't have an eval for it. */
@@ -61,19 +61,6 @@ case class SortOrder(child: Expression, direction: SortDirection)
   override def sql: String = child.sql + " " + direction.sql
 
   def isAscending: Boolean = direction == Ascending
-}
-
-object SortOrder {
-  /**
-   * Returns true iff the `output` orders are sufficient to satisfy the `required` orders.
-   */
-  def satisfies(output: Seq[SortOrder], required: Seq[SortOrder]): Boolean = {
-    required.forall { requiredOrder =>
-      output.exists { case outputOrder =>
-        requiredOrder.child == outputOrder.child && requiredOrder.direction == outputOrder.direction
-      }
-    }
-  }
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/Sort.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/Sort.scala
@@ -43,7 +43,7 @@ case class Sort(
 
   override def output: Seq[Attribute] = child.output
 
-  override def outputOrdering: Seq[SortOrder] = sortOrder
+  override def outputOrdering: Seq[SortOrder] = sortOrder.map(d => d.copy(global = global))
 
   override def requiredChildDistribution: Seq[Distribution] =
     if (global) OrderedDistribution(sortOrder) :: Nil else UnspecifiedDistribution :: Nil

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -104,7 +104,7 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
   def requiredChildDistribution: Seq[Distribution] =
     Seq.fill(children.size)(UnspecifiedDistribution)
 
-  /** Specifies how data is ordered in each partition. */
+  /** Specifies how data is ordered in partitions. */
   def outputOrdering: Seq[SortOrder] = Nil
 
   /** Specifies sort order for each partition requirements on the input data for this operator. */


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr is to skip unnecessary sorts if input data have been already ordered in InMemoryRelation.
Let's say we have a cached table with column 'a' sorted;

```
val df1 = Seq((1, 0), (3, 0), (2, 0), (1, 0)).toDF("a", "b")
val df2 = df1.sort("a").cache
df2.show // just cache data
```

If you say `df2.sort("a")`, the current spark generates a plan like;

```
== Physical Plan ==
Sort [a#13 ASC], true, 0
+- InMemoryColumnarTableScan [a#13,b#14], InMemoryRelation [a#13,b#14], true, 10000, StorageLevel(true, true, false, true, 1), Sort [a#13 ASC], true, 0, None
```

This pr removes this unnecessary sort.
## How was this patch tested?

Add tests to check this kind of sort operators is removed in an optimizer.
