### PR TITLE
[SPARK-14202][PYTHON] Use generator expression instead of list comp in python_full_outer_jo…

### DIFF
--- a/python/pyspark/join.py
+++ b/python/pyspark/join.py
@@ -93,7 +93,7 @@ def python_full_outer_join(rdd, other, numPartitions):
             vbuf.append(None)
         if not wbuf:
             wbuf.append(None)
-        return [(v, w) for v in vbuf for w in wbuf]
+        return ((v, w) for v in vbuf for w in wbuf)
     return _do_python_join(rdd, other, numPartitions, dispatch)
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR replaces list comprehension in python_full_outer_join.dispatch with a generator expression.
## How was this patch tested?

PySpark-Core, PySpark-MLlib test suites against Python 2.7, 3.5.
