### PR TITLE
[SPARK-14201][SQL] handle empty file for new data source strategy

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -138,7 +138,6 @@ private[sql] object FileSourceStrategy extends Strategy with Logging {
 
           val splitFiles = selectedPartitions.flatMap { partition =>
             partition.files.flatMap { file =>
-              assert(file.getLen != 0, file.toString)
               (0L to file.getLen by maxSplitBytes).map { offset =>
                 val remaining = file.getLen - offset
                 val size = if (remaining > maxSplitBytes) maxSplitBytes else remaining

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -549,18 +549,15 @@ class HDFSFileCatalog(
 
   refresh()
 
-  private def isInvalidFile(f: FileStatus): Boolean =
-    f.getPath.getName.startsWith("_") || f.getLen == 0
-
   override def listFiles(filters: Seq[Expression]): Seq[Partition] = {
     if (partitionSpec().partitionColumns.isEmpty) {
-      Partition(InternalRow.empty, allFiles().filterNot(isInvalidFile)) :: Nil
+      Partition(InternalRow.empty, allFiles().filterNot(_.getPath.getName startsWith "_")) :: Nil
     } else {
       prunePartitions(filters, partitionSpec()).map {
         case PartitionDirectory(values, path) =>
           Partition(
             values,
-            getStatus(path).filterNot(isInvalidFile))
+            getStatus(path).filterNot(_.getPath.getName startsWith "_"))
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -549,15 +549,18 @@ class HDFSFileCatalog(
 
   refresh()
 
+  private def isInvalidFile(f: FileStatus): Boolean =
+    f.getPath.getName.startsWith("_") || f.getLen == 0
+
   override def listFiles(filters: Seq[Expression]): Seq[Partition] = {
     if (partitionSpec().partitionColumns.isEmpty) {
-      Partition(InternalRow.empty, allFiles().filterNot(_.getPath.getName startsWith "_")) :: Nil
+      Partition(InternalRow.empty, allFiles().filterNot(isInvalidFile)) :: Nil
     } else {
       prunePartitions(filters, partitionSpec()).map {
         case PartitionDirectory(values, path) =>
           Partition(
             values,
-            getStatus(path).filterNot(_.getPath.getName startsWith "_"))
+            getStatus(path).filterNot(isInvalidFile))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -40,22 +40,12 @@ import org.apache.spark.util.collection.BitSet
 class FileSourceStrategySuite extends QueryTest with SharedSQLContext with PredicateHelper {
   import testImplicits._
 
-  test("empty table") {
-    val table = createTable(Seq("file1" -> 0, "file2" -> 0))
-    checkScan(table.select('c1)) { partitions =>
-      assert(partitions.size == 0, "when checking partitions")
-    }
-  }
-
-  test("non-empty table with empty file") {
-    val table = createTable(Seq("file1" -> 1, "file2" -> 0))
+  test("empty files") {
+    val table = createTable(Seq("file1" -> 1, "file2" -> 0, "file3" -> 0))
     checkScan(table.select('c1)) { partitions =>
       assert(partitions.size == 1, "when checking partitions")
-      // The empty file should be ignored.
-      assert(partitions.head.files.size == 1, "when checking partition 1")
-      // 1 byte files are too small to split so we should read the whole thing.
-      assert(partitions.head.files.head.start == 0)
-      assert(partitions.head.files.head.length == 1)
+      // We should pass empty files to FileFormat
+      assert(partitions.head.files.size == 3, "when checking partition 1")
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

It's possible that users will write empty files to data dir. For example, write data to JSON data source with one line string, and default parallelism is 2, we will write an empty file and a file with all data. The new data source should be able to handle it.
## How was this patch tested?

new tests in `FileSourceStrategySuite`
