### PR TITLE
[SPARK-14180][Core]Fix a deadlock in CoarseGrainedExecutorBackend Shutdown

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -114,7 +114,13 @@ private[spark] class CoarseGrainedExecutorBackend(
     case Shutdown =>
       stopping.set(true)
       new Thread("CoarseGrainedExecutorBackend-stop-executor") {
-        override def run(): Unit = executor.stop()
+        override def run(): Unit = {
+          // executor.stop() will call `SparkEnv.stop()` which waits until RpcEnv stops totally.
+          // However, if `executor.stop()` runs in some thread of RpcEnv, RpcEnv won't be able to
+          // stop until `executor.stop()` returns, which becomes a dead-lock (See SPARK-14180).
+          // Therefore, we put this line in a new thread.
+          executor.stop()
+        }
       }.start()
   }
 

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -113,9 +113,9 @@ private[spark] class CoarseGrainedExecutorBackend(
 
     case Shutdown =>
       stopping.set(true)
-      executor.stop()
-      stop()
-      rpcEnv.shutdown()
+      new Thread("CoarseGrainedExecutorBackend-stop-executor") {
+        override def run(): Unit = executor.stop()
+      }.start()
   }
 
   override def onDisconnected(remoteAddress: RpcAddress): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Call `executor.stop` in a new thread to eliminate deadlock.
## How was this patch tested?

Existing unit tests
