### PR TITLE
[SPARK-14163][CORE] SumEvaluator and countApprox cannot reliably handle RDDs of size 1

### DIFF
--- a/core/src/main/scala/org/apache/spark/partial/BoundedDouble.scala
+++ b/core/src/main/scala/org/apache/spark/partial/BoundedDouble.scala
@@ -21,5 +21,20 @@ package org.apache.spark.partial
  * A Double value with error bars and associated confidence.
  */
 class BoundedDouble(val mean: Double, val confidence: Double, val low: Double, val high: Double) {
-  override def toString(): String = "[%.3f, %.3f]".format(low, high)
+  override def toString(): String = "BoundedDouble(%.3f, %.3f, %.3f, %.3f)".format(mean, confidence, low, high)
+
+  override def hashCode:Int = this.mean.hashCode ^ this.confidence.hashCode ^ this.low.hashCode ^ this.high.hashCode
+
+  override def equals(that: Any): Boolean =
+        that match {
+          case that: BoundedDouble => {
+            this.mean == that.mean &&
+            this.confidence == that.confidence &&
+            this.low == that.low &&
+            this.high == that.high
+          }
+          case _ => false
+        }
+
+
 }

--- a/core/src/main/scala/org/apache/spark/partial/BoundedDouble.scala
+++ b/core/src/main/scala/org/apache/spark/partial/BoundedDouble.scala
@@ -24,10 +24,12 @@ class BoundedDouble(val mean: Double, val confidence: Double, val low: Double, v
   override def toString(): String =
     "BoundedDouble(%.3f, %.3f, %.3f, %.3f)".format(mean, confidence, low, high)
 
-  override def hashCode:Int =
+  override def hashCode: Int =
     this.mean.hashCode ^ this.confidence.hashCode ^ this.low.hashCode ^ this.high.hashCode
 
-  /** Note that consistent with Double, any NaN value will make equality false **/
+  /**
+    * Note that consistent with Double, any NaN value will make equality false
+    */
   override def equals(that: Any): Boolean =
     that match {
       case that: BoundedDouble => {

--- a/core/src/main/scala/org/apache/spark/partial/BoundedDouble.scala
+++ b/core/src/main/scala/org/apache/spark/partial/BoundedDouble.scala
@@ -40,6 +40,4 @@ class BoundedDouble(val mean: Double, val confidence: Double, val low: Double, v
       }
       case _ => false
     }
-
-
 }

--- a/core/src/main/scala/org/apache/spark/partial/BoundedDouble.scala
+++ b/core/src/main/scala/org/apache/spark/partial/BoundedDouble.scala
@@ -21,8 +21,8 @@ package org.apache.spark.partial
  * A Double value with error bars and associated confidence.
  */
 class BoundedDouble(val mean: Double, val confidence: Double, val low: Double, val high: Double) {
-  override def toString(): String =
-    "BoundedDouble(%.3f, %.3f, %.3f, %.3f)".format(mean, confidence, low, high)
+
+  override def toString(): String = "[%.3f, %.3f]".format(low, high)
 
   override def hashCode: Int =
     this.mean.hashCode ^ this.confidence.hashCode ^ this.low.hashCode ^ this.high.hashCode

--- a/core/src/main/scala/org/apache/spark/partial/BoundedDouble.scala
+++ b/core/src/main/scala/org/apache/spark/partial/BoundedDouble.scala
@@ -21,20 +21,23 @@ package org.apache.spark.partial
  * A Double value with error bars and associated confidence.
  */
 class BoundedDouble(val mean: Double, val confidence: Double, val low: Double, val high: Double) {
-  override def toString(): String = "BoundedDouble(%.3f, %.3f, %.3f, %.3f)".format(mean, confidence, low, high)
+  override def toString(): String =
+    "BoundedDouble(%.3f, %.3f, %.3f, %.3f)".format(mean, confidence, low, high)
 
-  override def hashCode:Int = this.mean.hashCode ^ this.confidence.hashCode ^ this.low.hashCode ^ this.high.hashCode
+  override def hashCode:Int =
+    this.mean.hashCode ^ this.confidence.hashCode ^ this.low.hashCode ^ this.high.hashCode
 
+  /** Note that consistent with Double, any NaN value will make equality false **/
   override def equals(that: Any): Boolean =
-        that match {
-          case that: BoundedDouble => {
-            this.mean == that.mean &&
-            this.confidence == that.confidence &&
-            this.low == that.low &&
-            this.high == that.high
-          }
-          case _ => false
-        }
+    that match {
+      case that: BoundedDouble => {
+        this.mean == that.mean &&
+        this.confidence == that.confidence &&
+        this.low == that.low &&
+        this.high == that.high
+      }
+      case _ => false
+    }
 
 
 }

--- a/core/src/main/scala/org/apache/spark/partial/SumEvaluator.scala
+++ b/core/src/main/scala/org/apache/spark/partial/SumEvaluator.scala
@@ -64,11 +64,12 @@ private[spark] class SumEvaluator(totalOutputs: Int, confidence: Double)
         val confFactor = if (counter.count > 100) {
           new NormalDistribution().inverseCumulativeProbability(1 - (1 - confidence) / 2)
         } else {
-          // note that if this goes to 0, TDistribution will throw an exception. Hence special casing 1 above. 
+          // note that if this goes to 0, TDistribution will throw an exception.
+          // Hence special casing 1 above.
           val degreesOfFreedom = (counter.count - 1).toInt
           new TDistribution(degreesOfFreedom).inverseCumulativeProbability(1 - (1 - confidence) / 2)
         }
-        
+
         val low = sumEstimate - confFactor * sumStdev
         val high = sumEstimate + confFactor * sumStdev
         new BoundedDouble(sumEstimate, confidence, low, high)

--- a/core/src/test/scala/org/apache/spark/partial/SumEvaluatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/partial/SumEvaluatorSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.partial
 
-
 import org.apache.spark._
 import org.apache.spark.util.StatCounter
 
@@ -25,7 +24,7 @@ class SumEvaluatorSuite extends SparkFunSuite with SharedSparkContext {
 
   test("correct handling of count 1") {
 
-    //setup
+    // setup
     val counter = new StatCounter(List(2.0))
     // count of 10 because it's larger than 1,
     // and 0.95 because that's the default
@@ -33,21 +32,22 @@ class SumEvaluatorSuite extends SparkFunSuite with SharedSparkContext {
     // arbitrarily assign id 1
     evaluator.merge(1, counter)
 
-    //execute
+    // execute
     val res = evaluator.currentResult()
     // 38.0 - 7.1E-15 because that's how the maths shakes out
-    val targetMean =  38.0 - 7.1E-15
- 
-    //Sanity check that equality works on BoundedDouble
+    val targetMean = 38.0 - 7.1E-15
+
+    // Sanity check that equality works on BoundedDouble
     assert(new BoundedDouble(2.0, 0.95, 1.1, 1.2) == new BoundedDouble(2.0, 0.95, 1.1, 1.2))
 
     // actual test
-    assert(res == new BoundedDouble(targetMean, 0.950, Double.NegativeInfinity, Double.PositiveInfinity))
+    assert(res ==
+      new BoundedDouble(targetMean, 0.950, Double.NegativeInfinity, Double.PositiveInfinity))
   }
 
   test("correct handling of count 0") {
 
-    //setup
+    // setup
     val counter = new StatCounter(List())
     // count of 10 because it's larger than 0,
     // and 0.95 because that's the default
@@ -55,25 +55,25 @@ class SumEvaluatorSuite extends SparkFunSuite with SharedSparkContext {
     // arbitrarily assign id 1
     evaluator.merge(1, counter)
 
-    //execute
+    // execute
     val res = evaluator.currentResult()
-    //assert
+    // assert
     assert(res == new BoundedDouble(0, 0.0, Double.NegativeInfinity, Double.PositiveInfinity))
   }
 
   test("correct handling of NaN") {
 
-    //setup
-    val counter = new StatCounter(List(1,Double.NaN,2))
+    // setup
+    val counter = new StatCounter(List(1, Double.NaN, 2))
     // count of 10 because it's larger than 0,
     // and 0.95 because that's the default
     val evaluator = new SumEvaluator(10, 0.95)
     // arbitrarily assign id 1
     evaluator.merge(1, counter)
 
-    //execute
+    // execute
     val res = evaluator.currentResult()
-    //assert - note semantics of == in face of NaN
+    // assert - note semantics of == in face of NaN
     assert(res.mean.isNaN)
     assert(res.confidence == 0.95)
     assert(res.low == Double.NegativeInfinity)
@@ -82,23 +82,23 @@ class SumEvaluatorSuite extends SparkFunSuite with SharedSparkContext {
 
   test("correct handling of > 1 values") {
 
-    //setup
-    val counter = new StatCounter(List(1,3,2))
+    // setup
+    val counter = new StatCounter(List(1, 3, 2))
     // count of 10 because it's larger than 0,
     // and 0.95 because that's the default
     val evaluator = new SumEvaluator(10, 0.95)
     // arbitrarily assign id 1
     evaluator.merge(1, counter)
 
-    //execute
+    // execute
     val res = evaluator.currentResult()
 
     // These vals because that's how the maths shakes out
-    val targetMean =  78.0
+    val targetMean = 78.0
     val targetLow = -117.617 + 2.732357258139473E-5
     val targetHigh = 273.617 - 2.7323572624027292E-5
     val target = new BoundedDouble(targetMean, 0.95, targetLow, targetHigh)
-    
+
 
     // check that values are within expected tolerance of expectation
     assert(res == target)

--- a/core/src/test/scala/org/apache/spark/partial/SumEvaluatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/partial/SumEvaluatorSuite.scala
@@ -36,22 +36,13 @@ class SumEvaluatorSuite extends SparkFunSuite with SharedSparkContext {
     //execute
     val res = evaluator.currentResult()
     // 38.0 - 7.1E-15 because that's how the maths shakes out
-    val target_mean =  38.0 - 7.1E-15
-    // Version to test everything except mean
-    val ancillary_res = new BoundedDouble(target_mean, res.confidence, res.low, res.high)
-    // mean result to test
-    val mean_diff = (res.mean - target_mean).abs
-    
-
+    val targetMean =  38.0 - 7.1E-15
+ 
     //Sanity check that equality works on BoundedDouble
     assert(new BoundedDouble(2.0, 0.95, 1.1, 1.2) == new BoundedDouble(2.0, 0.95, 1.1, 1.2))
+
     // actual test
-
-    // Use ancillary_res as the result to check everything except the mean
-    assert(ancillary_res == new BoundedDouble(target_mean, 0.950, Double.NegativeInfinity, Double.PositiveInfinity))
-
-    // check that mean is within expected tolerance of expectation
-    assert(mean_diff < Double.MinPositiveValue)
+    assert(res == new BoundedDouble(targetMean, 0.950, Double.NegativeInfinity, Double.PositiveInfinity))
   }
 
   test("correct handling of count 0") {
@@ -82,7 +73,7 @@ class SumEvaluatorSuite extends SparkFunSuite with SharedSparkContext {
 
     //execute
     val res = evaluator.currentResult()
-    //assert
+    //assert - note semantics of == in face of NaN
     assert(res.mean.isNaN)
     assert(res.confidence == 0.95)
     assert(res.low == Double.NegativeInfinity)
@@ -103,15 +94,14 @@ class SumEvaluatorSuite extends SparkFunSuite with SharedSparkContext {
     val res = evaluator.currentResult()
 
     // These vals because that's how the maths shakes out
-    val target_mean =  78.0
-    val target_low = -117.617 + 2.732357258139473E-5
-    val target_high = 273.617 - 2.7323572624027292E-5
+    val targetMean =  78.0
+    val targetLow = -117.617 + 2.732357258139473E-5
+    val targetHigh = 273.617 - 2.7323572624027292E-5
+    val target = new BoundedDouble(targetMean, 0.95, targetLow, targetHigh)
     
 
     // check that values are within expected tolerance of expectation
-    assert((res.mean - target_mean).abs < Double.MinPositiveValue)
-    assert((res.low - target_low).abs < Double.MinPositiveValue)
-    assert((res.high - target_high).abs < Double.MinPositiveValue)
+    assert(res == target)
   }
 
 }

--- a/core/src/test/scala/org/apache/spark/partial/SumEvaluatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/partial/SumEvaluatorSuite.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.partial
+
+
+import org.apache.spark._
+import org.apache.spark.util.StatCounter
+
+class SumEvaluatorSuite extends SparkFunSuite with SharedSparkContext {
+
+  test("correct handling of count 1") {
+
+    //setup
+    val counter = new StatCounter(List(2.0))
+    // count of 10 because it's larger than 1,
+    // and 0.95 because that's the default
+    val evaluator = new SumEvaluator(10, 0.95)
+    // arbitrarily assign id 1
+    evaluator.merge(1, counter)
+
+    //execute
+    val res = evaluator.currentResult()
+    // Build version with known precisions for equality check
+    val round_res = new BoundedDouble(res.mean.round.toDouble, res.confidence, res.low, res.high)
+
+    //Sanity check that equality works on BoundedDouble
+    assert(new BoundedDouble(2.0, 0.95, 1.1, 1.2) == new BoundedDouble(2.0, 0.95, 1.1, 1.2))
+    // actual test
+    
+    // 38.0 because that's how the maths shakes out
+    assert(round_res == new BoundedDouble(38.0, 0.950, Double.NegativeInfinity, Double.PositiveInfinity))
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This special cases 0 and 1 counts to avoid passing 0 degrees of freedom. 
## How was this patch tested?

Tests run successfully. New test added. 
## Note:

This recreates #11982 which was closed to due to non-updated diff. @rxin @srowen Commented there. 
This also adds tests, reworks the code to perform the special casing (based on @srowen's comments), and adds equality machinery for BoundedDouble, as well as changing how it is transformed to string. 
