### PR TITLE
[SPARK-14218][SQL] Use encoder schema for generating dataset show output to match the column names with the data.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -235,7 +235,7 @@ class Dataset[T] private[sql](
 
     // For array values, replace Seq and Array with square brackets
     // For cells that are beyond 20 characters, replace it with the first 17 and "..."
-    val rows: Seq[Seq[String]] = schema.fieldNames.toSeq +: data.map {
+    val rows: Seq[Seq[String]] = resolvedTEncoder.schema.fieldNames.toSeq +: data.map {
       case r: Row => r
       case tuple: Product => Row.fromTuple(tuple)
       case o => Row(o)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -626,6 +626,19 @@ class DatasetSuite extends QueryTest with SharedSQLContext {
     // Make sure the generated code for this plan can compile and execute.
     wideDF.map(_.getLong(0)).collect()
   }
+
+  test("SPARK-14218: showString schema order in the output") {
+    val ds = Seq((1, "one"), (2, "two"), (3, "three")).toDF("b", "a").as[ClassData]
+    val expectedAnswer = """+-----+---+
+                           ||    a|  b|
+                           |+-----+---+
+                           ||  one|  1|
+                           ||  two|  2|
+                           ||three|  3|
+                           |+-----+---+
+                           |""".stripMargin
+    assert(ds.showString(10) === expectedAnswer)
+  }
 }
 
 case class OtherTuple(_1: String, _2: Int)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Data is displayed in the schema order of the encoder, but the column names are displayed in the order of the underlying data frame schema, this results in mismatch of column names and the data in the output. This PR modifies the schema used in the showString() method to the encoder schema. 
## How was this patch tested?

Added a new unit test case to check the output of showString when the schema orders are different. 

@liancheng
