### PR TITLE
[SPARK-14225][SQL] Cap the length of toCommentSafeString at 128 chars

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
@@ -155,10 +155,12 @@ package object util {
 
   /**
    * Returns the string representation of this expression that is safe to be put in
-   * code comments of generated code.
+   * code comments of generated code. The length is capped at 128 characters.
    */
-  def toCommentSafeString(str: String): String =
-    str.replace("*/", "\\*\\/").replace("\\u", "\\\\u")
+  def toCommentSafeString(str: String): String = {
+    val len = math.min(str.length, 128)
+    str.substring(0, len).replace("*/", "\\*\\/").replace("\\u", "\\\\u")
+  }
 
   /* FIX ME
   implicit class debugLogging(a: Any) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

I just saw a query with over 1000 fields and the generated expression comment is pages long. At that level printing them no longer gives us much benefit. We should just cap the length at some level. This patch changes it to max 128 chars.
## How was this patch tested?

Manually examined the generated code.
