### PR TITLE
[SPARK-13211][STREAMING] Deprecate certain constructors of StreamingContext's

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -109,7 +109,7 @@ class StreamingContext private[streaming] (
               "http://spark.apache.org/docs/latest/streaming-programming-guide.html#checkpointing",
               "2.0.0")
   def this(path: String, hadoopConf: Configuration) =
-    this(null, CheckpointReader.read(path, new SparkConf(), hadoopConf).getOrElse(null), null)
+    this(null, CheckpointReader.read(path, new SparkConf(), hadoopConf).get, null)
 
   /**
    * Recreate a StreamingContext from a checkpoint file.
@@ -131,8 +131,7 @@ class StreamingContext private[streaming] (
   def this(path: String, sparkContext: SparkContext) = {
     this(
       sparkContext,
-      CheckpointReader.read(path, sparkContext.conf, sparkContext.hadoopConfiguration)
-        .getOrElse(null),
+      CheckpointReader.read(path, sparkContext.conf, sparkContext.hadoopConfiguration).get,
       null)
   }
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -106,7 +106,7 @@ class StreamingContext private[streaming] (
    *                   HDFS compatible filesystems
    */
   def this(path: String, hadoopConf: Configuration) =
-    this(null, CheckpointReader.read(path, new SparkConf(), hadoopConf).get, null)
+    this(null, CheckpointReader.read(path, new SparkConf(), hadoopConf).getOrElse(null), null)
 
   /**
    * Recreate a StreamingContext from a checkpoint file.
@@ -122,7 +122,8 @@ class StreamingContext private[streaming] (
   def this(path: String, sparkContext: SparkContext) = {
     this(
       sparkContext,
-      CheckpointReader.read(path, sparkContext.conf, sparkContext.hadoopConfiguration).get,
+      CheckpointReader.read(path, sparkContext.conf, sparkContext.hadoopConfiguration)
+        .getOrElse(null),
       null)
   }
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -105,6 +105,9 @@ class StreamingContext private[streaming] (
    * @param hadoopConf Optional, configuration object if necessary for reading from
    *                   HDFS compatible filesystems
    */
+  @deprecated("Will be removed in 2.1.0. Use StreamingContext.getOrCreate() instead; see " +
+              "http://spark.apache.org/docs/latest/streaming-programming-guide.html#checkpointing",
+              "2.0.0")
   def this(path: String, hadoopConf: Configuration) =
     this(null, CheckpointReader.read(path, new SparkConf(), hadoopConf).getOrElse(null), null)
 
@@ -112,6 +115,9 @@ class StreamingContext private[streaming] (
    * Recreate a StreamingContext from a checkpoint file.
    * @param path Path to the directory that was specified as the checkpoint directory
    */
+  @deprecated("Will be removed in 2.1.0. Use StreamingContext.getOrCreate() instead; see " +
+              "http://spark.apache.org/docs/latest/streaming-programming-guide.html#checkpointing",
+              "2.0.0")
   def this(path: String) = this(path, SparkHadoopUtil.get.conf)
 
   /**
@@ -119,6 +125,9 @@ class StreamingContext private[streaming] (
    * @param path Path to the directory that was specified as the checkpoint directory
    * @param sparkContext Existing SparkContext
    */
+  @deprecated("Will be removed in 2.1.0. Use StreamingContext.getOrCreate() instead; see " +
+              "http://spark.apache.org/docs/latest/streaming-programming-guide.html#checkpointing",
+              "2.0.0")
   def this(path: String, sparkContext: SparkContext) = {
     this(
       sparkContext,

--- a/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaStreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaStreamingContext.scala
@@ -141,6 +141,9 @@ class JavaStreamingContext(val ssc: StreamingContext) extends Closeable {
    * Recreate a JavaStreamingContext from a checkpoint file.
    * @param path Path to the directory that was specified as the checkpoint directory
    */
+  @deprecated("Will be removed in 2.1.0. Use JavaStreamingContext.getOrCreate() instead; see " +
+              "http://spark.apache.org/docs/latest/streaming-programming-guide.html#checkpointing",
+              "2.0.0")
   def this(path: String) = this(new StreamingContext(path, SparkHadoopUtil.get.conf))
 
   /**
@@ -148,6 +151,9 @@ class JavaStreamingContext(val ssc: StreamingContext) extends Closeable {
    * @param path Path to the directory that was specified as the checkpoint directory
    *
    */
+  @deprecated("Will be removed in 2.1.0. Use JavaStreamingContext.getOrCreate() instead; see " +
+              "http://spark.apache.org/docs/latest/streaming-programming-guide.html#checkpointing",
+              "2.0.0")
   def this(path: String, hadoopConf: Configuration) = this(new StreamingContext(path, hadoopConf))
 
   /** The underlying SparkContext */


### PR DESCRIPTION
## What changes were proposed in this pull request?

These constructors, each of which takes a checkpoint path parameter, are deprecated by this PR:
- `StreamingContext`'s
  - `this(path: String, hadoopConf: Configuration)`
  - `this(path: String)`
  - `this(path: String, sparkContext: SparkContext)`
- `JavaStreamingContext`'s
  - `this(path: String)`
  - `this(path: String, hadoopConf: Configuration)`
## How was this patch tested?

Existing test suits.
