### PR TITLE
[MINOR][SQL] Fix typos by replacing 'much' with 'match'.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -291,5 +291,5 @@ case class CatalogRelation(
   override def output: Seq[Attribute] = Seq.empty
 
   require(metadata.identifier.database == Some(db),
-    "provided database does not much the one specified in the table definition")
+    "provided database does not match the one specified in the table definition")
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -76,7 +76,7 @@ private[spark] class HiveExternalCatalog(client: HiveClient) extends ExternalCat
   private def requireDbMatches(db: String, table: CatalogTable): Unit = {
     if (table.identifier.database != Some(db)) {
       throw new AnalysisException(
-        s"Provided database $db does not much the one specified in the " +
+        s"Provided database $db does not match the one specified in the " +
         s"table definition (${table.identifier.database.getOrElse("n/a")})")
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fixes two trivial typos: 'does not **much**' --> 'does not **match**'.
## How was this patch tested?

Manual.
