### PR TITLE
[SPARK-13710] [Shell] [Windows] Fix jline dependency on Windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -822,6 +822,10 @@
             <groupId>org.jboss.netty</groupId>
             <artifactId>netty</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>jline</groupId>
+            <artifactId>jline</artifactId>
+          </exclusion>          
         </exclusions>
       </dependency>
       <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Exclude jline from curator-recipes since it conflicts with scala 2.11 when running spark-shell.  Should not affect scala 2.10 since it is builtin.
## How was this patch tested?

Ran spark-shell manually.
