### PR TITLE
[SPARK-14262] correct app's state after master leader changed

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -333,7 +333,11 @@ private[deploy] class Master(
       idToApp.get(appId) match {
         case Some(app) =>
           logInfo("Application has been re-registered: " + appId)
-          app.state = ApplicationState.WAITING
+          if (app.coresLeft > 0) {
+            app.state = ApplicationState.WAITING
+          } else {
+            app.state = ApplicationState.RUNNING
+          }
         case None =>
           logWarning("Master change ack from unknown app: " + appId)
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Suppose master leadership changes, even if recovery is completed, those privious apps in RUNNING state are now in WAITING state from master's WebUI, although they are really at work. Now correct the state.
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
