### PR TITLE
[SPARK-14263][SQL] Benchmark Vectorized HashMap for GroupBy Aggregates

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/AggregateHashMap.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/AggregateHashMap.java
@@ -45,9 +45,9 @@ public class AggregateHashMap {
   private int numRows = 0;
   private int maxSteps = 3;
 
-  private static int DEFAULT_NUM_BUCKETS = 65536 * 4;
+  private static int DEFAULT_CAPACITY = 1 << 16;
   private static double DEFAULT_LOAD_FACTOR = 0.25;
-  private static int MAX_STEPS = 3;
+  private static int DEFAULT_MAX_STEPS = 3;
 
   public AggregateHashMap(StructType schema, int capacity, double loadFactor, int maxSteps) {
 
@@ -59,14 +59,14 @@ public class AggregateHashMap {
     assert (capacity > 0 && ((capacity & (capacity - 1)) == 0));
 
     this.maxSteps = maxSteps;
-    numBuckets = capacity;
-    batch = ColumnarBatch.allocate(schema, MemoryMode.ON_HEAP, (int) (numBuckets * loadFactor));
+    numBuckets = (int) (capacity / loadFactor);
+    batch = ColumnarBatch.allocate(schema, MemoryMode.ON_HEAP, capacity);
     buckets = new int[numBuckets];
     Arrays.fill(buckets, -1);
   }
 
   public AggregateHashMap(StructType schema) {
-    this(schema, DEFAULT_NUM_BUCKETS, DEFAULT_LOAD_FACTOR, MAX_STEPS);
+    this(schema, DEFAULT_CAPACITY, DEFAULT_LOAD_FACTOR, DEFAULT_MAX_STEPS);
   }
 
   public int findOrInsert(long key) {

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/VectorizedHashMap.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/VectorizedHashMap.java
@@ -1,0 +1,62 @@
+package org.apache.spark.sql.execution.vectorized;
+
+import java.util.Arrays;
+
+import org.apache.spark.memory.MemoryMode;
+import org.apache.spark.sql.types.StructType;
+
+import static org.apache.spark.sql.types.DataTypes.LongType;
+
+/**
+ * This is an illustrative implementation of a single-key/single value vectorized hash map that can
+ * be potentially 'codegened' in TungstenAggregate to speed up aggregate w/ key
+ */
+public class VectorizedHashMap {
+  public ColumnarBatch batch;
+  public int[] buckets;
+  private int numBuckets;
+  private int numRows = 0;
+  private int maxSteps = 3;
+
+  public VectorizedHashMap(int capacity, double loadFactor, int maxSteps) {
+    StructType schema = new StructType()
+        .add("key", LongType)
+        .add("value", LongType);
+    this.maxSteps = maxSteps;
+    numBuckets = capacity;
+    batch = ColumnarBatch.allocate(schema, MemoryMode.ON_HEAP, (int) (numBuckets * loadFactor));
+    buckets = new int[numBuckets];
+    Arrays.fill(buckets, -1);
+  }
+
+  public int findOrInsert(long key) {
+    int idx = find(key);
+    if (idx != -1 && buckets[idx] == -1) {
+      batch.column(0).putLong(numRows, key);
+      batch.column(1).putLong(numRows, 0);
+      buckets[idx] = numRows++;
+    }
+    return idx;
+  }
+
+  public int find(long key) {
+    long h = hash(key);
+    int step = 0;
+    int idx = (int) h & (numBuckets - 1);
+    while (step < maxSteps) {
+      if ((buckets[idx] == -1) || (buckets[idx] != -1 && equals(idx, key))) return idx;
+      idx = (idx + 1) & (numBuckets - 1);
+      step++;
+    }
+    // Didn't find it
+    return -1;
+  }
+
+  private long hash(long key) {
+    return key;
+  }
+
+  private boolean equals(int idx, long key1) {
+    return batch.column(0).getLong(buckets[idx]) == key1;
+  }
+}

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/VectorizedHashMap.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/VectorizedHashMap.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.sql.execution.vectorized;
 
 import java.util.Arrays;


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes a new data-structure based on a vectorized hashmap that can be potentially _codegened_ in `TungstenAggregate` to speed up aggregates with group by. Micro-benchmarks show a 10x improvement over the current `BytesToBytes` aggregation map.
## How was this patch tested?

```
Intel(R) Core(TM) i7-4960HQ CPU @ 2.60GHz
BytesToBytesMap:                    Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------
hash                                      108 /  119         96.9          10.3       1.0X
fast hash                                  63 /   70        166.2           6.0       1.7X
arrayEqual                                 70 /   73        150.8           6.6       1.6X
Java HashMap (Long)                       141 /  200         74.3          13.5       0.8X
Java HashMap (two ints)                   145 /  185         72.3          13.8       0.7X
Java HashMap (UnsafeRow)                  499 /  524         21.0          47.6       0.2X
BytesToBytesMap (off Heap)                483 /  548         21.7          46.0       0.2X
BytesToBytesMap (on Heap)                 485 /  562         21.6          46.2       0.2X
Vectorized Hashmap                         54 /   60        193.7           5.2       2.0X
```
