### PR TITLE
[SPARK-7424] [ML] ML ClassificationModel should add metadata to output column

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/Classifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/Classifier.scala
@@ -19,8 +19,8 @@ package org.apache.spark.ml.classification
 
 import org.apache.spark.SparkException
 import org.apache.spark.annotation.DeveloperApi
-import org.apache.spark.ml.attribute._
 import org.apache.spark.ml.{PredictionModel, Predictor, PredictorParams}
+import org.apache.spark.ml.attribute._
 import org.apache.spark.ml.param.shared.HasRawPredictionCol
 import org.apache.spark.ml.util.{MetadataUtils, SchemaUtils}
 import org.apache.spark.mllib.linalg.{Vector, VectorUDT}

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/Classifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/Classifier.scala
@@ -180,16 +180,22 @@ abstract class ClassificationModel[FeaturesType, M <: ClassificationModel[Featur
         }
         predictUDF(col(getFeaturesCol))
       }
-      // determine number of classes either from metadata if provided.
-      val labelSchema = dataset.schema($(labelCol))
-      // extract label metadata from label column if present, or create a nominal attribute
-      // to output the number of labels
-      val labelAttribute = Attribute.fromStructField(labelSchema) match {
-        case _: NumericAttribute | UnresolvedAttribute =>
-          NominalAttribute.defaultAttr.withName("label").withNumValues(numClasses)
-        case attr: Attribute => attr
+      // The label column for base binary classifier of OneVsRest will not be retained during
+      // model transformation, so we should not handle label column metadata as well.
+      if (dataset.schema.fieldNames.contains($(labelCol))) {
+        // determine number of classes either from metadata if provided.
+        val labelSchema = dataset.schema($(labelCol))
+        // extract label metadata from label column if present, or create a nominal attribute
+        // to output the number of labels
+        val labelAttribute = Attribute.fromStructField(labelSchema) match {
+          case _: NumericAttribute | UnresolvedAttribute =>
+            NominalAttribute.defaultAttr.withName("label").withNumValues(numClasses)
+          case attr: Attribute => attr
+        }
+        outputData = outputData.withColumn(getPredictionCol, predUDF, labelAttribute.toMetadata)
+      } else {
+        outputData = outputData.withColumn(getPredictionCol, predUDF)
       }
-      outputData = outputData.withColumn(getPredictionCol, predUDF, labelAttribute.toMetadata)
       numColsOutput += 1
     }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/Classifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/Classifier.scala
@@ -45,9 +45,9 @@ private[spark] trait ClassifierParams
     if (fitting) {
       SchemaUtils.checkNumericType(schema, $(labelCol))
     }
-    SchemaUtils.appendColumn(schema, $(predictionCol), DoubleType,
+    val newSchema = SchemaUtils.appendColumn(schema, $(predictionCol), DoubleType,
       nullable = false, generatePredictionMetadata(schema))
-    SchemaUtils.appendColumn(schema, $(rawPredictionCol), new VectorUDT)
+    SchemaUtils.appendColumn(newSchema, $(rawPredictionCol), new VectorUDT)
   }
 
   protected def generatePredictionMetadata(schema: StructType): Metadata = {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -31,11 +31,13 @@ import org.apache.spark.sql.types.{DataType, StructType}
  */
 private[classification] trait ProbabilisticClassifierParams
   extends ClassifierParams with HasProbabilityCol with HasThresholds {
-  override protected def validateAndTransformSchema(
+  override def validateAndTransformSchema(
       schema: StructType,
       fitting: Boolean,
-      featuresDataType: DataType): StructType = {
-    val parentSchema = super.validateAndTransformSchema(schema, fitting, featuresDataType)
+      featuresDataType: DataType,
+      numClasses: Option[Int]): StructType = {
+    val parentSchema = super.validateAndTransformSchema(schema,
+      fitting, featuresDataType, numClasses)
     SchemaUtils.appendColumn(parentSchema, $(probabilityCol), new VectorUDT)
   }
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -138,7 +138,7 @@ abstract class ProbabilisticClassificationModel[
         }
         predictUDF(col($(featuresCol)))
       }
-      outputData = outputData.withColumn(getPredictionCol, predUDF, predictionMetadata)
+      outputData = outputData.withColumn($(predictionCol), predUDF, predictionMetadata)
       numColsOutput += 1
     }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/ProbabilisticClassifier.scala
@@ -138,22 +138,7 @@ abstract class ProbabilisticClassificationModel[
         }
         predictUDF(col($(featuresCol)))
       }
-      // The label column for base binary classifier of OneVsRest will not be retained during
-      // model transformation, so we should not handle label column metadata as well.
-      if (dataset.schema.fieldNames.contains($(labelCol))) {
-        // determine number of classes either from metadata if provided.
-        val labelSchema = dataset.schema($(labelCol))
-        // extract label metadata from label column if present, or create a nominal attribute
-        // to output the number of labels
-        val labelAttribute = Attribute.fromStructField(labelSchema) match {
-          case _: NumericAttribute | UnresolvedAttribute =>
-            NominalAttribute.defaultAttr.withName("label").withNumValues(numClasses)
-          case attr: Attribute => attr
-        }
-        outputData = outputData.withColumn(getPredictionCol, predUDF, labelAttribute.toMetadata)
-      } else {
-        outputData = outputData.withColumn(getPredictionCol, predUDF)
-      }
+      outputData = outputData.withColumn(getPredictionCol, predUDF, predictionMetadata)
       numColsOutput += 1
     }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/util/SchemaUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/SchemaUtils.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.ml.util
 
-import org.apache.spark.sql.types.{DataType, NumericType, StructField, StructType}
+import org.apache.spark.sql.types._
 
 
 /**
@@ -89,6 +89,28 @@ private[spark] object SchemaUtils {
       nullable: Boolean = false): StructType = {
     if (colName.isEmpty) return schema
     appendColumn(schema, StructField(colName, dataType, nullable))
+  }
+
+  /**
+   * Appends a new column to the input schema. This fails if the given output column already exists.
+   * @param schema input schema
+   * @param colName new column name. If this column name is an empty string "", this method returns
+   *                the input schema unchanged. This allows users to disable output columns.
+   * @param dataType new column data type
+   * @param nullable Indicates if values of this field can be `null` values.
+   * @param metadata The metadata of this field. The metadata should be preserved during
+   *                 transformation if the content of the column is not modified.
+   * @return new schema with the input column appended
+   */
+  def appendColumn(
+      schema: StructType,
+      colName: String,
+      dataType: DataType,
+      nullable: Boolean,
+      metadata: Metadata
+      ): StructType = {
+    if (colName.isEmpty) return schema
+    appendColumn(schema, StructField(colName, dataType, nullable, metadata))
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/ml/util/SchemaUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/SchemaUtils.scala
@@ -80,23 +80,6 @@ private[spark] object SchemaUtils {
    * @param colName new column name. If this column name is an empty string "", this method returns
    *                the input schema unchanged. This allows users to disable output columns.
    * @param dataType new column data type
-   * @return new schema with the input column appended
-   */
-  def appendColumn(
-      schema: StructType,
-      colName: String,
-      dataType: DataType,
-      nullable: Boolean = false): StructType = {
-    if (colName.isEmpty) return schema
-    appendColumn(schema, StructField(colName, dataType, nullable))
-  }
-
-  /**
-   * Appends a new column to the input schema. This fails if the given output column already exists.
-   * @param schema input schema
-   * @param colName new column name. If this column name is an empty string "", this method returns
-   *                the input schema unchanged. This allows users to disable output columns.
-   * @param dataType new column data type
    * @param nullable Indicates if values of this field can be `null` values.
    * @param metadata The metadata of this field. The metadata should be preserved during
    *                 transformation if the content of the column is not modified.
@@ -106,9 +89,8 @@ private[spark] object SchemaUtils {
       schema: StructType,
       colName: String,
       dataType: DataType,
-      nullable: Boolean,
-      metadata: Metadata
-      ): StructType = {
+      nullable: Boolean = false,
+      metadata: Metadata = Metadata.empty): StructType = {
     if (colName.isEmpty) return schema
     appendColumn(schema, StructField(colName, dataType, nullable, metadata))
   }

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/NaiveBayesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/NaiveBayesSuite.scala
@@ -199,25 +199,26 @@ class NaiveBayesSuite extends SparkFunSuite with MLlibTestSparkContext with Defa
   test("copy label column metadata to prediction column") {
     val data = sc.parallelize(Seq((Vectors.dense(0.0), "a"), (Vectors.dense(1.0), "b"),
       (Vectors.dense(2.0), "c"), (Vectors.dense(3.0), "a"), (Vectors.dense(4.0), "a")), 2)
-    var df = sqlContext.createDataFrame(data).toDF("features", "label")
+    val df1 = sqlContext.createDataFrame(data).toDF("features", "label")
 
     val indexer = new StringIndexer()
       .setInputCol("label")
       .setOutputCol("labelIndex")
-      .fit(df)
-    df = indexer.transform(df)
+      .fit(df1)
+    val df2 = indexer.transform(df1)
 
     val naiveBayes = new NaiveBayes().setLabelCol("labelIndex")
-    val naiveBayesModel = naiveBayes.fit(df)
-    df = naiveBayesModel.transform(df)
+    val naiveBayesModel = naiveBayes.fit(df2)
+    val df3 = naiveBayesModel.transform(df2)
 
-    val schema = df.schema
+    val schema = df3.schema
     val labelAttr = Attribute.fromStructField(schema(naiveBayesModel.getLabelCol))
       .asInstanceOf[NominalAttribute]
     val predictionAttr = Attribute.fromStructField(schema(naiveBayesModel.getPredictionCol))
       .asInstanceOf[NominalAttribute]
     assert(labelAttr.attrType === predictionAttr.attrType)
     assert(labelAttr.values.get === predictionAttr.values.get)
+    assert(predictionAttr.name.get === naiveBayesModel.getPredictionCol)
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

ML `ClassificationModel` should add metadata to output column from label column if present, or create a nominal attribute to output the number of labels.
## How was this patch tested?

Will add test case soon.

cc @jkbradley @mengxr 
