### PR TITLE
[SPARK-13064] Make sure attemptId not none for Rest API

### DIFF
--- a/core/src/main/scala/org/apache/spark/status/api/v1/ApplicationListResource.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/ApplicationListResource.scala
@@ -68,7 +68,10 @@ private[spark] object ApplicationsListResource {
       memoryPerExecutorMB = None,
       attempts = app.attempts.map { internalAttemptInfo =>
         new ApplicationAttemptInfo(
-          attemptId = internalAttemptInfo.attemptId,
+          attemptId = internalAttemptInfo.attemptId match {
+            case Some(str) => internalAttemptInfo.attemptId
+            case None => Some("1")
+          },
           startTime = new Date(internalAttemptInfo.startTime),
           endTime = new Date(internalAttemptInfo.endTime),
           duration =
@@ -97,7 +100,7 @@ private[spark] object ApplicationsListResource {
       coresPerExecutor = internal.desc.coresPerExecutor,
       memoryPerExecutorMB = Some(internal.desc.memoryPerExecutorMB),
       attempts = Seq(new ApplicationAttemptInfo(
-        attemptId = None,
+        attemptId = Some("1"),
         startTime = new Date(internal.startTime),
         endTime = new Date(internal.endTime),
         duration =

--- a/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/SparkUI.scala
@@ -112,7 +112,7 @@ private[spark] class SparkUI private (
       coresPerExecutor = None,
       memoryPerExecutorMB = None,
       attempts = Seq(new ApplicationAttemptInfo(
-        attemptId = None,
+        attemptId = Some("1"),
         startTime = new Date(startTime),
         endTime = new Date(-1),
         duration = 0,


### PR DESCRIPTION
## What changes were proposed in this pull request?

From the view of REST API, we prefer not to have some field occasionally empty.
For some application that does not set attemptId for their attempts, e.g., spark-shell applications, we set the default attemptId as Some("1") rather than None. 
## How was this patch tested?

Manually tested.
