### PR TITLE
[SPARK-14293] Improve shuffle load balancing and minimize network data transmission.

### DIFF
--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -430,11 +430,7 @@ private[spark] class MapOutputTrackerMaster(conf: SparkConf)
    * @param numReducers total number of reducers in the shuffle
    *
    */
-  def getLocationsWithGlobalMode(
-                                  shuffleId: Int,
-                                  numReducers: Int
-                                  )
-  : Option[Array[BlockManagerId]] = {
+  def getLocationsWithGlobalMode(shuffleId: Int, numReducers: Int): Option[Array[BlockManagerId]] = {
     val statuses = mapStatuses.get(shuffleId).orNull
     assert(statuses != null)
     val splitsByLocation = new HashMap[BlockManagerId, Array[Long]]


### PR DESCRIPTION
## What changes were proposed in this pull request?

 Based on the map output sizes and locations tracked by MapOutputTracker, we can obtain a better load balancing

This patch proposes a strategy to set preferred locations for each reduce task, which could firstly keep each executor process almost the same amount of intermediate data and secondly minimize the network data transmission. This can benefit some conditions:

1．REDUCER_PREF_LOCS_FRACTION tries to place the reduce tasks close to the largest output. If there exists data skew in the map outputs. It could cause some executors that have large of map outputs become busy. Our method could avoid this case and minimize the network data transmission.

2．When there are large of reduce tasks in the job, it helps each executor processes almost the same data and keeps load balancing.

The special steps are following.
Step 1: For each task, calculate the amount of data and their distributions.

Step 2: Divide the tasks into n groups according to the number of nodes and data size, ensuring that the data size for each group is nearly equal.

Step 3: Determine the amount of local data if the tasks of every group are executed on every node. Thus, a n × n matrix is created.

Step 4: Choose the largest value in the matrix to identify which group is allocated to which node. Mark the row and column at which the selected group is located to ensure that the group is not chosen next time. Goto Step 4 until no group is available.
## How was this patch tested?

Unit test suite
Author: Cheng Pei peicheng89@gmail.com
