### PR TITLE
[SPARK-14320][SQL] Make ColumnarBatch.Row mutable

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVector.java
@@ -566,6 +566,18 @@ public abstract class ColumnVector {
     }
   }
 
+
+  public final void putDecimal(int rowId, Decimal value, int precision) {
+    if (precision <= Decimal.MAX_INT_DIGITS()) {
+      putInt(rowId, value.toInt());
+    } else if (precision <= Decimal.MAX_LONG_DIGITS()) {
+      putLong(rowId, value.toLong());
+    } else {
+      BigInteger bigInteger = value.toJavaBigDecimal().unscaledValue();
+      putByteArray(rowId, bigInteger.toByteArray());
+    }
+  }
+
   /**
    * Returns the UTF8String for rowId.
    */

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnarBatch.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnarBatch.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang.NotImplementedException;
 import org.apache.spark.memory.MemoryMode;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericMutableRow;
+import org.apache.spark.sql.catalyst.expressions.MutableRow;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
 import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.MapData;
@@ -91,7 +92,7 @@ public final class ColumnarBatch {
    * Adapter class to interop with existing components that expect internal row. A lot of
    * performance is lost with this translation.
    */
-  public static final class Row extends InternalRow {
+  public static final class Row extends MutableRow {
     protected int rowId;
     private final ColumnarBatch parent;
     private final int fixedLenRowSize;
@@ -230,6 +231,56 @@ public final class ColumnarBatch {
 
     @Override
     public Object get(int ordinal, DataType dataType) {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public void setNullAt(int ordinal) {
+      columns[ordinal].putNull(rowId);
+    }
+
+    @Override
+    public void update(int ordinal, Object value) {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public void setBoolean(int ordinal, boolean value) {
+      columns[ordinal].putBoolean(rowId, value);
+    }
+
+    @Override
+    public void setByte(int ordinal, byte value) {
+      columns[ordinal].putByte(rowId, value);
+    }
+
+    @Override
+    public void setShort(int ordinal, short value) {
+      columns[ordinal].putShort(rowId, value);
+    }
+
+    @Override
+    public void setInt(int ordinal, int value) {
+      columns[ordinal].putInt(rowId, value);
+    }
+
+    @Override
+    public void setLong(int ordinal, long value) {
+      columns[ordinal].putLong(rowId, value);
+    }
+
+    @Override
+    public void setFloat(int ordinal, float value) {
+      columns[ordinal].putFloat(rowId, value);
+    }
+
+    @Override
+    public void setDouble(int ordinal, double value) {
+      columns[ordinal].putDouble(rowId, value);
+    }
+
+    @Override
+    public void setDecimal(int ordinal, Decimal value, int precision) {
       throw new NotImplementedException();
     }
   }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnarBatch.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnarBatch.java
@@ -16,6 +16,7 @@
  */
 package org.apache.spark.sql.execution.vectorized;
 
+import java.math.BigDecimal;
 import java.util.*;
 
 import org.apache.commons.lang.NotImplementedException;
@@ -235,53 +236,93 @@ public final class ColumnarBatch {
     }
 
     @Override
+    public void update(int ordinal, Object value) {
+      if (value == null) {
+        setNullAt(ordinal);
+      } else {
+        DataType dt = columns[ordinal].dataType();
+        if (dt instanceof BooleanType) {
+          setBoolean(ordinal, (boolean) value);
+        } else if (dt instanceof IntegerType) {
+          setInt(ordinal, (int) value);
+        } else if (dt instanceof ShortType) {
+          setShort(ordinal, (short) value);
+        } else if (dt instanceof LongType) {
+          setLong(ordinal, (long) value);
+        } else if (dt instanceof FloatType) {
+          setFloat(ordinal, (float) value);
+        } else if (dt instanceof DoubleType) {
+          setDouble(ordinal, (double) value);
+        } else if (dt instanceof DecimalType) {
+          DecimalType t = (DecimalType) dt;
+          setDecimal(ordinal, Decimal.apply((BigDecimal) value, t.precision(), t.scale()),
+              t.precision());
+        } else {
+          throw new NotImplementedException("Datatype not supported " + dt);
+        }
+      }
+    }
+
+    @Override
     public void setNullAt(int ordinal) {
+      assert (!columns[ordinal].isConstant);
       columns[ordinal].putNull(rowId);
     }
 
     @Override
-    public void update(int ordinal, Object value) {
-      throw new NotImplementedException();
-    }
-
-    @Override
     public void setBoolean(int ordinal, boolean value) {
+      assert (!columns[ordinal].isConstant);
+      columns[ordinal].putNotNull(rowId);
       columns[ordinal].putBoolean(rowId, value);
     }
 
     @Override
     public void setByte(int ordinal, byte value) {
+      assert (!columns[ordinal].isConstant);
+      columns[ordinal].putNotNull(rowId);
       columns[ordinal].putByte(rowId, value);
     }
 
     @Override
     public void setShort(int ordinal, short value) {
+      assert (!columns[ordinal].isConstant);
+      columns[ordinal].putNotNull(rowId);
       columns[ordinal].putShort(rowId, value);
     }
 
     @Override
     public void setInt(int ordinal, int value) {
+      assert (!columns[ordinal].isConstant);
+      columns[ordinal].putNotNull(rowId);
       columns[ordinal].putInt(rowId, value);
     }
 
     @Override
     public void setLong(int ordinal, long value) {
+      assert (!columns[ordinal].isConstant);
+      columns[ordinal].putNotNull(rowId);
       columns[ordinal].putLong(rowId, value);
     }
 
     @Override
     public void setFloat(int ordinal, float value) {
+      assert (!columns[ordinal].isConstant);
+      columns[ordinal].putNotNull(rowId);
       columns[ordinal].putFloat(rowId, value);
     }
 
     @Override
     public void setDouble(int ordinal, double value) {
+      assert (!columns[ordinal].isConstant);
+      columns[ordinal].putNotNull(rowId);
       columns[ordinal].putDouble(rowId, value);
     }
 
     @Override
     public void setDecimal(int ordinal, Decimal value, int precision) {
-      throw new NotImplementedException();
+      assert (!columns[ordinal].isConstant);
+      columns[ordinal].putNotNull(rowId);
+      columns[ordinal].putDecimal(rowId, value, precision);
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/BenchmarkWholeStageCodegen.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/BenchmarkWholeStageCodegen.scala
@@ -473,7 +473,7 @@ class BenchmarkWholeStageCodegen extends SparkFunSuite {
       val map = new AggregateHashMap(schema)
       while (i < numKeys) {
         val row = map.findOrInsert(i.toLong)
-        row.setLong(1, row.getLong(1))
+        row.setLong(1, row.getLong(1) +  1)
         i += 1
       }
       var s = 0

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/BenchmarkWholeStageCodegen.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/BenchmarkWholeStageCodegen.scala
@@ -472,9 +472,8 @@ class BenchmarkWholeStageCodegen extends SparkFunSuite {
         .add("value", LongType)
       val map = new AggregateHashMap(schema)
       while (i < numKeys) {
-        val idx = map.findOrInsert(i.toLong)
-        map.batch.column(1).putLong(map.buckets(idx),
-          map.batch.column(1).getLong(map.buckets(idx)) + 1)
+        val row = map.findOrInsert(i.toLong)
+        row.setLong(1, row.getLong(1))
         i += 1
       }
       var s = 0

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -756,4 +756,33 @@ class ColumnarBatchSuite extends SparkFunSuite {
       }}
     }
   }
+
+  test("mutable ColumnarBatch rows") {
+    (MemoryMode.ON_HEAP :: MemoryMode.OFF_HEAP :: Nil).foreach { memMode => {
+      val rows = Row(1, 2L, 1.2, 'b'.toByte, true, 1.2f, '1'.toShort, "hello") :: Nil
+      val schema = new StructType()
+        .add("int", IntegerType)
+        .add("long", LongType)
+        .add("double", DoubleType)
+        .add("byte", ByteType)
+        .add("boolean", BooleanType)
+        .add("float", FloatType)
+        .add("short", ShortType)
+        .add("string", StringType)
+
+      val batch = ColumnVectorUtils.toBatch(schema, memMode, rows.iterator.asJava)
+      val columnarBatchRow = batch.getRow(0)
+      columnarBatchRow.setInt(0, 2)
+      columnarBatchRow.setLong(1, 5L)
+      columnarBatchRow.setDouble(2, 1.9)
+      columnarBatchRow.setByte(3, 'c'.toByte)
+      columnarBatchRow.setBoolean(4, false)
+      columnarBatchRow.setFloat(5, 1.9f)
+      columnarBatchRow.setShort(6, '2'.toShort)
+      columnarBatchRow.setNullAt(7)
+      compareStruct(schema, columnarBatchRow,
+        Row(2, 5L, 1.9, 'c'.toByte, false, 1.9f, '2'.toShort, null), 0)
+      batch.close()
+    }}
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In order to leverage a data structure like `AggregateHashMap` (https://github.com/apache/spark/pull/12055) to speed up aggregates with keys, we need to make `ColumnarBatch.Row` mutable.
## How was this patch tested?

Unit test in `ColumnarBatchSuite`. Also, tested via `BenchmarkWholeStageCodegen`.
