### PR TITLE
[SPARK-14323] [SQL] fix the show functions by using catalog listFunctions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -48,7 +48,7 @@ class InMemoryCatalog extends ExternalCatalog {
   private val catalog = new scala.collection.mutable.HashMap[String, DatabaseDesc]
 
   private def filterPattern(names: Seq[String], pattern: String): Seq[String] = {
-    val regex = pattern.replaceAll(".\\*", "\\*").replaceAll("\\*", ".*").r
+    val regex = pattern.replaceAll("\\.\\*", "\\*").replaceAll("\\*", "\\.\\*").r
     names.filter { funcName => regex.pattern.matcher(funcName).matches() }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -48,7 +48,7 @@ class InMemoryCatalog extends ExternalCatalog {
   private val catalog = new scala.collection.mutable.HashMap[String, DatabaseDesc]
 
   private def filterPattern(names: Seq[String], pattern: String): Seq[String] = {
-    val regex = pattern.replaceAll("\\*", ".*").r
+    val regex = pattern.replaceAll(".\\*", "\\*").replaceAll("\\*", ".*").r
     names.filter { funcName => regex.pattern.matcher(funcName).matches() }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -533,7 +533,7 @@ class SessionCatalog(
   def listFunctions(db: String, pattern: String): Seq[FunctionIdentifier] = {
     val dbFunctions =
       externalCatalog.listFunctions(db, pattern).map { f => FunctionIdentifier(f, Some(db)) }
-    val regex = pattern.replaceAll("\\*", ".*").r
+    val regex = pattern.replaceAll(".\\*", "\\*").replaceAll("\\*", ".*").r
     val _tempFunctions = functionRegistry.listFunction()
       .filter { f => regex.pattern.matcher(f).matches() }
       .map { f => FunctionIdentifier(f) }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -282,7 +282,7 @@ class SessionCatalog(
   def listTables(db: String, pattern: String): Seq[TableIdentifier] = {
     val dbTables =
       externalCatalog.listTables(db, pattern).map { t => TableIdentifier(t, Some(db)) }
-    val regex = pattern.replaceAll(".\\*", "\\*").replaceAll("\\*", ".*").r
+    val regex = pattern.replaceAll("\\.\\*", "\\*").replaceAll("\\*", "\\.\\*").r
     val _tempTables = tempTables.keys.toSeq
       .filter { t => regex.pattern.matcher(t).matches() }
       .map { t => TableIdentifier(t) }
@@ -533,7 +533,7 @@ class SessionCatalog(
   def listFunctions(db: String, pattern: String): Seq[FunctionIdentifier] = {
     val dbFunctions =
       externalCatalog.listFunctions(db, pattern).map { f => FunctionIdentifier(f, Some(db)) }
-    val regex = pattern.replaceAll(".\\*", "\\*").replaceAll("\\*", ".*").r
+    val regex = pattern.replaceAll("\\.\\*", "\\*").replaceAll("\\*", "\\.\\*").r
     val _tempFunctions = functionRegistry.listFunction()
       .filter { f => regex.pattern.matcher(f).matches() }
       .map { f => FunctionIdentifier(f) }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -282,7 +282,7 @@ class SessionCatalog(
   def listTables(db: String, pattern: String): Seq[TableIdentifier] = {
     val dbTables =
       externalCatalog.listTables(db, pattern).map { t => TableIdentifier(t, Some(db)) }
-    val regex = pattern.replaceAll("\\*", ".*").r
+    val regex = pattern.replaceAll(".\\*", "\\*").replaceAll("\\*", ".*").r
     val _tempTables = tempTables.keys.toSeq
       .filter { t => regex.pattern.matcher(t).matches() }
       .map { t => TableIdentifier(t) }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
@@ -370,13 +370,13 @@ case class ShowFunctions(db: Option[String], pattern: Option[String]) extends Ru
     pattern match {
       case Some(p) =>
         try {
-          catalog.listFunctions(database, p).map{f: FunctionIdentifier => Row(f.name)}
+          catalog.listFunctions(database, p).map { f => Row(f.name) }
         } catch {
           // probably will failed in the regex that user provided, then returns empty row.
           case _: Throwable => Seq.empty[Row]
         }
       case None =>
-        catalog.listFunctions(database, ".*").map{f: FunctionIdentifier => Row(f.name)}
+        catalog.listFunctions(database, ".*").map { f => Row(f.name) }
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
@@ -353,9 +353,8 @@ case class ShowTablesCommand(databaseName: Option[String]) extends RunnableComma
  * A command for users to list all of the registered functions.
  * The syntax of using this command in SQL is:
  * {{{
- *    SHOW FUNCTIONS
+ *    SHOW FUNCTIONS (LIKE? (qualifiedName | pattern))?
  * }}}
- * TODO currently we are simply ignore the db
  */
 case class ShowFunctions(db: Option[String], pattern: Option[String]) extends RunnableCommand {
   override val output: Seq[Attribute] = {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -1811,4 +1811,11 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
       }
     }
   }
+
+  test("show functions properly") {
+    sql("CREATE FUNCTION f1 AS 'org.apache.hadoop.hive.ql.udf.generic.GenericUDFUpper'")
+    sql("CREATE TEMPORARY FUNCTION f2 AS 'org.apache.hadoop.hive.ql.udf.generic.GenericUDFUpper'")
+    checkExistence(sql("SHOW FUNCTIONS LIKE '*f*'"), true, "default.f1", "f2")
+    checkExistence(sql("SHOW FUNCTIONS"), true, "default.f1", "f2")
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The syntax of "SHOW FUNCTIONS" can be found here:
[https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-ShowFunctions](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-ShowFunctions)

By leveraging catalog.listFunctions(), we can get the proper list of functions with proper regex. 

Please check listFunctions() in SessionCatalog.scala to see how "*" get escaped. 

If we do not escape "*", for pattern "*f*", it will cause exception (PatternSyntaxException, Dangling meta character) and thus return empty result.

The original approach is to replace "*" with ".*" to make regex work, but it will fail on the following case:
Suppose functions: sha, sha1, sha2; Query string "sha.*" (sha will not be shown because query becomes "sha..*" - notice 2 dots) 
## How was this patch tested?

I have added test cases for this issue and also verified that it has the consistent result from Hive.
