### PR TITLE
[SPARK-14321][SQL] Reduce date format cost and string-to-date cost in date functions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -423,11 +423,9 @@ abstract class UnixTime extends BinaryExpression with ExpectsInputTypes {
         }
       case StringType =>
         val sdf = classOf[SimpleDateFormat].getName
-        val formatter = ctx.freshName("sdf")
-        ctx.addMutableState(sdf, formatter, s"""$formatter = null;""")
         nullSafeCodeGen(ctx, ev, (string, format) => {
           s"""
-	    try {
+            try {
               ${ev.value} =
                 (new $sdf($format.toString())).parse($string.toString()).getTime() / 1000L;
             } catch (java.lang.Throwable e) {
@@ -546,11 +544,9 @@ case class FromUnixTime(sec: Expression, format: Expression)
         """
       }
     } else {
-      val sdfTerm = ctx.freshName("sdf")
-      ctx.addMutableState(sdf, sdfTerm, s"""$sdfTerm = null;""")
       nullSafeCodeGen(ctx, ev, (seconds, f) => {
         s"""
-	try {
+        try {
           ${ev.value} = UTF8String.fromString((new $sdf($f.toString())).format(
             new java.util.Date($seconds * 1000L)));
         } catch (java.lang.Throwable e) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -59,6 +59,8 @@ object DateTimeUtils {
   final val toYearZero = to2001 + 7304850
   final val TimeZoneGMT = TimeZone.getTimeZone("GMT")
 
+  lazy val c = Calendar.getInstance(TimeZone.getTimeZone("GMT"))
+
   @transient lazy val defaultTimeZone = TimeZone.getDefault
 
   // Reuse the Calendar object in each thread as it is expensive to create in each method call.
@@ -418,7 +420,6 @@ object DateTimeUtils {
         segments(2) < 1 || segments(2) > 31) {
       return None
     }
-    val c = threadLocalGmtCalendar.get()
     c.clear()
     c.set(segments(0), segments(1) - 1, segments(2), 0, 0, 0)
     c.set(Calendar.MILLISECOND, 0)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -59,8 +59,6 @@ object DateTimeUtils {
   final val toYearZero = to2001 + 7304850
   final val TimeZoneGMT = TimeZone.getTimeZone("GMT")
 
-  lazy val c = Calendar.getInstance(TimeZone.getTimeZone("GMT"))
-
   @transient lazy val defaultTimeZone = TimeZone.getDefault
 
   // Reuse the Calendar object in each thread as it is expensive to create in each method call.
@@ -420,6 +418,7 @@ object DateTimeUtils {
         segments(2) < 1 || segments(2) > 31) {
       return None
     }
+    val c = threadLocalGmtCalendar.get()
     c.clear()
     c.set(segments(0), segments(1) - 1, segments(2), 0, 0, 0)
     c.set(Calendar.MILLISECOND, 0)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Here is the generated code snippet when executing date functions. SimpleDateFormat is fairly expensive and can show up bottleneck when processing millions of records. It would be better to instantiate it once.

```
/* 066 */     UTF8String primitive5 = null;
/* 067 */     if (!isNull4) {
/* 068 */       try {
/* 069 */         primitive5 = UTF8String.fromString(new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(
/* 070 */             new java.util.Date(primitive7 * 1000L)));
/* 071 */       } catch (java.lang.Throwable e) {
/* 072 */         isNull4 = true;
/* 073 */       }
/* 074 */     }
```

With modified code, here is the generated code

```
/* 010 */   private java.text.SimpleDateFormat sdf2;
/* 011 */   private UnsafeRow result13;
/* 012 */   private org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder bufferHolder14;
/* 013 */   private org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter rowWriter15;
/* 014 */
...
...
/* 065 */     boolean isNull0 = isNull3;
/* 066 */     UTF8String primitive1 = null;
/* 067 */     if (!isNull0) {
/* 068 */       try {
/* 069 */         if (sdf2 == null) {
/* 070 */           sdf2 = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
/* 071 */         }
/* 072 */         primitive1 = UTF8String.fromString(sdf2.format(
/* 073 */             new java.util.Date(primitive4 * 1000L)));
/* 074 */       } catch (java.lang.Throwable e) {
/* 075 */         isNull0 = true;
/* 076 */       }
/* 077 */     }
```

Similarly Calendar.getInstance was used in DateTimeUtils which can be lazily inited.
## How was this patch tested?

org.apache.spark.sql.catalyst.expressions.DateExpressionsSuite,org.apache.spark.sql.catalyst.util.DateTimeUtilsSuite
Also tried with couple of sample SQL queries with single executor (6GB) which showed good improvement with the fix.
