### PR TITLE
Modified NAMESPACE to allow user to access lapply and map actions on …

### DIFF
--- a/R/pkg/NAMESPACE
+++ b/R/pkg/NAMESPACE
@@ -105,6 +105,9 @@ exportMethods("arrange",
               "write.parquet",
               "write.text")
 
+exportMethods("lapply","lapplyPartition", "map","reduce")
+
+
 exportClasses("Column")
 
 exportMethods("%in%",


### PR DESCRIPTION
## What changes were proposed in this pull request?

I made lapply, lapplyParition, map and reduce available as methods that operate on Spark DataFrame. This is needed for common operations, such as calculating statistic over columns of DataFrame
## How was this patch tested?

No specific unit test needed. run-test.sh positive
