### PR TITLE
[SPARK-14352][SQL] approxQuantile should support multi columns

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1382,7 +1382,7 @@ class DataFrame(object):
           list, but each element in it is a list of float, i.e., the output
           is a list of list of float.
 
-        .. versionchanged:: 2.1
+        .. versionchanged:: 2.2
            Added support for multiple columns.
         """
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1377,21 +1377,23 @@ class DataFrame(object):
         :return:  the approximate quantiles at the given probabilities. If
           the input `col` is a string, the output is a list of float. If the
           input `col` is a list or tuple of strings, the output is also a
-          list, but each element in it is a list of float (list of list of
-          float).
+          list, but each element in it is a list of float, i.e., the output
+          is a list of list of float.
         """
         if not isinstance(col, (str, list, tuple)):
-            raise ValueError("col should be a string or list or tuple.")
+            raise ValueError("col should be a string, list or tuple.")
+
         isStr = False
         if isinstance(col, str):
             isStr = True
-            col = [col]
+
         if isinstance(col, tuple):
             col = list(col)
-        for c in col:
-            if not isinstance(c, str):
-                raise ValueError("columns should be strings.")
-        col = _to_list(self._sc, col)
+        if isinstance(col, list):
+            for c in col:
+                if not isinstance(c, str):
+                    raise ValueError("columns should be strings.")
+            col = _to_list(self._sc, col)
 
         if not isinstance(probabilities, (list, tuple)):
             raise ValueError("probabilities should be a list or tuple")
@@ -1406,11 +1408,11 @@ class DataFrame(object):
             raise ValueError("relativeError should be numerical (float, int, long) >= 0.")
         relativeError = float(relativeError)
 
-        jaqs = self._jdf.stat().approxQuantileMultiCols(col, probabilities, relativeError)
-        res = [list(jaq) for jaq in jaqs]
+        jaq = self._jdf.stat().approxQuantile(col, probabilities, relativeError)
         if isStr:
-            return res[0]
-        return res
+            return list(jaq)
+        else:
+            return [list(j) for j in jaq]
 
     @since(1.4)
     def corr(self, col1, col2, method=None):

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1383,9 +1383,7 @@ class DataFrame(object):
         if not isinstance(col, (str, list, tuple)):
             raise ValueError("col should be a string, list or tuple.")
 
-        isStr = False
-        if isinstance(col, str):
-            isStr = True
+        isStr = isinstance(col, str)
 
         if isinstance(col, tuple):
             col = list(col)

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1379,7 +1379,13 @@ class DataFrame(object):
           input `col` is a list or tuple of strings, the output is also a
           list, but each element in it is a list of float, i.e., the output
           is a list of list of float.
+
+        .. versionchanged:: 2.1
+           Added support for multiple columns.
         """
+
+
+
         if not isinstance(col, (str, list, tuple)):
             raise ValueError("col should be a string, list or tuple.")
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1384,8 +1384,6 @@ class DataFrame(object):
            Added support for multiple columns.
         """
 
-
-
         if not isinstance(col, (str, list, tuple)):
             raise ValueError("col should be a string, list or tuple.")
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1375,8 +1375,16 @@ class DataFrame(object):
           accepted but give the same result as 1.
         :return:  the approximate quantiles at the given probabilities
         """
-        if not isinstance(col, str):
-            raise ValueError("col should be a string.")
+        if not isinstance(col, (str, list, tuple)):
+            raise ValueError("col should be a string or list or tuple.")
+        if isinstance(col, str):
+            col = [col]
+        if isinstance(col, tuple):
+            col = list(col)
+        for c in col:
+            if not isinstance(col, str):
+                raise ValueError("columns should be strings.")
+        col = _to_list(self._sc, col)
 
         if not isinstance(probabilities, (list, tuple)):
             raise ValueError("probabilities should be a list or tuple")
@@ -1391,7 +1399,10 @@ class DataFrame(object):
             raise ValueError("relativeError should be numerical (float, int, long) >= 0.")
         relativeError = float(relativeError)
 
-        jaq = self._jdf.stat().approxQuantile(col, probabilities, relativeError)
+        jaq = self._jdf.stat().approxQuantileMultiCols(col, probabilities, relativeError)
+        jaq = list(jaq)
+        if len(jaq) == 1:
+            return list(jaq[0])
         return list(jaq)
 
     @since(1.4)

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1365,7 +1365,8 @@ class DataFrame(object):
         Space-efficient Online Computation of Quantile Summaries]]
         by Greenwald and Khanna.
 
-        :param col: the name of the numerical column
+        :param col: the name of the numerical column, or a list/tuple of
+          numerical columns.
         :param probabilities: a list of quantile probabilities
           Each number must belong to [0, 1].
           For example 0 is the minimum, 0.5 is the median, 1 is the maximum.
@@ -1399,11 +1400,13 @@ class DataFrame(object):
             raise ValueError("relativeError should be numerical (float, int, long) >= 0.")
         relativeError = float(relativeError)
 
-        jaq = self._jdf.stat().approxQuantileMultiCols(col, probabilities, relativeError)
-        jaq = list(jaq)
-        if len(jaq) == 1:
-            return list(jaq[0])
-        return list(jaq)
+        jaqs = self._jdf.stat().approxQuantileMultiCols(col, probabilities, relativeError)
+        res = []
+        for jaq in jaqs:
+            res.append(list(jaq))
+        if len(res) == 1:
+            return res[0]
+        return res
 
     @since(1.4)
     def corr(self, col1, col2, method=None):

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1365,8 +1365,8 @@ class DataFrame(object):
         Space-efficient Online Computation of Quantile Summaries]]
         by Greenwald and Khanna.
 
-        :param col: the name of the numerical column, or a list/tuple of
-          numerical columns.
+        :param col: str, list.
+          Can be a single column name, or a list of names for multiple columns.
         :param probabilities: a list of quantile probabilities
           Each number must belong to [0, 1].
           For example 0 is the minimum, 0.5 is the median, 1 is the maximum.

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1348,7 +1348,7 @@ class DataFrame(object):
     @since(2.0)
     def approxQuantile(self, col, probabilities, relativeError):
         """
-        Calculates the approximate quantiles of a numerical column of a
+        Calculates the approximate quantiles of numerical columns of a
         DataFrame.
 
         The result of this algorithm has the following deterministic bound:
@@ -1374,7 +1374,11 @@ class DataFrame(object):
           (>= 0). If set to zero, the exact quantiles are computed, which
           could be very expensive. Note that values greater than 1 are
           accepted but give the same result as 1.
-        :return:  the approximate quantiles at the given probabilities
+        :return:  the approximate quantiles at the given probabilities. If
+          the input `col` is a string, the output is a list of float. If the
+          input `col` is a list or tuple of strings, the output is also a
+          list, but each element in it is a list of float (list of list of
+          float).
         """
         if not isinstance(col, (str, list, tuple)):
             raise ValueError("col should be a string or list or tuple.")
@@ -1403,9 +1407,7 @@ class DataFrame(object):
         relativeError = float(relativeError)
 
         jaqs = self._jdf.stat().approxQuantileMultiCols(col, probabilities, relativeError)
-        res = []
-        for jaq in jaqs:
-            res.append(list(jaq))
+        res = [list(jaq) for jaq in jaqs]
         if isStr:
             return res[0]
         return res

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1378,12 +1378,14 @@ class DataFrame(object):
         """
         if not isinstance(col, (str, list, tuple)):
             raise ValueError("col should be a string or list or tuple.")
+        isStr = False
         if isinstance(col, str):
+            isStr = True
             col = [col]
         if isinstance(col, tuple):
             col = list(col)
         for c in col:
-            if not isinstance(col, str):
+            if not isinstance(c, str):
                 raise ValueError("columns should be strings.")
         col = _to_list(self._sc, col)
 
@@ -1404,7 +1406,7 @@ class DataFrame(object):
         res = []
         for jaq in jaqs:
             res.append(list(jaq))
-        if len(res) == 1:
+        if isStr:
             return res[0]
         return res
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -16,7 +16,6 @@
 #
 
 import sys
-import warnings
 import random
 
 if sys.version >= '3':
@@ -1387,7 +1386,7 @@ class DataFrame(object):
         """
 
         if not isinstance(col, (str, list, tuple)):
-            raise ValueError("col should be a string, list or tuple.")
+            raise ValueError("col should be a string, list or tuple, but got %r" % type(col))
 
         isStr = isinstance(col, str)
 
@@ -1398,7 +1397,7 @@ class DataFrame(object):
 
         for c in col:
             if not isinstance(c, str):
-                raise ValueError("columns should be strings.")
+                raise ValueError("columns should be strings, but got %r" % type(c))
         col = _to_list(self._sc, col)
 
         if not isinstance(probabilities, (list, tuple)):

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1391,11 +1391,13 @@ class DataFrame(object):
 
         if isinstance(col, tuple):
             col = list(col)
-        if isinstance(col, list):
-            for c in col:
-                if not isinstance(c, str):
-                    raise ValueError("columns should be strings.")
-            col = _to_list(self._sc, col)
+        elif isinstance(col, str):
+            col = [col]
+
+        for c in col:
+            if not isinstance(c, str):
+                raise ValueError("columns should be strings.")
+        col = _to_list(self._sc, col)
 
         if not isinstance(probabilities, (list, tuple)):
             raise ValueError("probabilities should be a list or tuple")
@@ -1412,7 +1414,7 @@ class DataFrame(object):
 
         jaq = self._jdf.stat().approxQuantile(col, probabilities, relativeError)
         if isStr:
-            return list(jaq)
+            return [list(j) for j in jaq][0]
         else:
             return [list(j) for j in jaq]
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1365,6 +1365,8 @@ class DataFrame(object):
         Space-efficient Online Computation of Quantile Summaries]]
         by Greenwald and Khanna.
 
+        Note that rows containing any null values will be removed before calculation.
+
         :param col: str, list.
           Can be a single column name, or a list of names for multiple columns.
         :param probabilities: a list of quantile probabilities
@@ -1413,10 +1415,8 @@ class DataFrame(object):
         relativeError = float(relativeError)
 
         jaq = self._jdf.stat().approxQuantile(col, probabilities, relativeError)
-        if isStr:
-            return [list(j) for j in jaq][0]
-        else:
-            return [list(j) for j in jaq]
+        jaq_list = [list(j) for j in jaq]
+        return jaq_list[0] if isStr else jaq_list
 
     @since(1.4)
     def corr(self, col1, col2, method=None):

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1376,10 +1376,10 @@ class DataFrame(object):
           could be very expensive. Note that values greater than 1 are
           accepted but give the same result as 1.
         :return:  the approximate quantiles at the given probabilities. If
-          the input `col` is a string, the output is a list of float. If the
+          the input `col` is a string, the output is a list of floats. If the
           input `col` is a list or tuple of strings, the output is also a
-          list, but each element in it is a list of float, i.e., the output
-          is a list of list of float.
+          list, but each element in it is a list of floats, i.e., the output
+          is a list of list of floats.
 
         .. versionchanged:: 2.2
            Added support for multiple columns.

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -879,8 +879,7 @@ class SQLTests(ReusedPySparkTestCase):
         self.assertTrue(isinstance(aq, list))
         self.assertEqual(len(aq), 3)
         self.assertTrue(all(isinstance(q, float) for q in aq))
-
-        aqs = df.stat.approxQuantile(["a","b"], [0.1, 0.5, 0.9], 0.1)
+        aqs = df.stat.approxQuantile(["a", "b"], [0.1, 0.5, 0.9], 0.1)
         self.assertTrue(isinstance(aqs, list))
         self.assertEqual(len(aqs), 2)
         self.assertTrue(isinstance(aqs[0], list))
@@ -889,7 +888,6 @@ class SQLTests(ReusedPySparkTestCase):
         self.assertTrue(isinstance(aqs[1], list))
         self.assertEqual(len(aqs[1]), 3)
         self.assertTrue(all(isinstance(q, float) for q in aqs[1]))
-
 
     def test_corr(self):
         import math

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -888,6 +888,18 @@ class SQLTests(ReusedPySparkTestCase):
         self.assertTrue(isinstance(aqs[1], list))
         self.assertEqual(len(aqs[1]), 3)
         self.assertTrue(all(isinstance(q, float) for q in aqs[1]))
+        aqt = df.stat.approxQuantile(("a", "b"), [0.1, 0.5, 0.9], 0.1)
+        self.assertTrue(isinstance(aqt, list))
+        self.assertEqual(len(aqt), 2)
+        self.assertTrue(isinstance(aqt[0], list))
+        self.assertEqual(len(aqt[0]), 3)
+        self.assertTrue(all(isinstance(q, float) for q in aqt[0]))
+        self.assertTrue(isinstance(aqt[1], list))
+        self.assertEqual(len(aqt[1]), 3)
+        self.assertTrue(all(isinstance(q, float) for q in aqt[1]))
+        self.assertRaises(ValueError, lambda: df.stat.approxQuantile(123, [0.1, 0.9], 0.1))
+        self.assertRaises(ValueError, lambda: df.stat.approxQuantile(("a", 123), [0.1, 0.9], 0.1))
+        self.assertRaises(ValueError, lambda: df.stat.approxQuantile(["a", 123], [0.1, 0.9], 0.1))
 
     def test_corr(self):
         import math

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -874,11 +874,22 @@ class SQLTests(ReusedPySparkTestCase):
         self.assertEqual([Row(a=None, b=1, c=None, d=98)], df3.collect())
 
     def test_approxQuantile(self):
-        df = self.sc.parallelize([Row(a=i) for i in range(10)]).toDF()
+        df = self.sc.parallelize([Row(a=i, b=i+10) for i in range(10)]).toDF()
         aq = df.stat.approxQuantile("a", [0.1, 0.5, 0.9], 0.1)
         self.assertTrue(isinstance(aq, list))
         self.assertEqual(len(aq), 3)
         self.assertTrue(all(isinstance(q, float) for q in aq))
+
+        aqs = df.stat.approxQuantile(["a","b"], [0.1, 0.5, 0.9], 0.1)
+        self.assertTrue(isinstance(aqs, list))
+        self.assertEqual(len(aqs), 2)
+        self.assertTrue(isinstance(aqs[0], list))
+        self.assertEqual(len(aqs[0]), 3)
+        self.assertTrue(all(isinstance(q, float) for q in aqs[0]))
+        self.assertTrue(isinstance(aqs[1], list))
+        self.assertEqual(len(aqs[1]), 3)
+        self.assertTrue(all(isinstance(q, float) for q in aqs[1]))
+
 
     def test_corr(self):
         import math

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -123,7 +123,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
   /**
    * Python-friendly version of [[approxQuantile()]]
    */
-  private[spark] def approxQuantileMultiCols(
+  private[spark] def approxQuantile(
       cols: List[String],
       probabilities: List[Double],
       relativeError: Double): java.util.List[java.util.List[Double]] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -93,7 +93,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    *
    * @note Rows containing any NaN values will be removed before calculation
    *
-   * @since 2.1.0
+   * @since 2.2.0
    */
   def approxQuantile(
       cols: Array[String],

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -75,6 +75,40 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
   }
 
   /**
+   * Calculates the approximate quantiles of numerical columns of a DataFrame.
+   *
+   * The result of this algorithm has the following deterministic bound:
+   * If the DataFrame has N elements and if we request the quantile at probability `p` up to error
+   * `err`, then the algorithm will return a sample `x` from the DataFrame so that the *exact* rank
+   * of `x` is close to (p * N).
+   * More precisely,
+   *
+   *   floor((p - err) * N) <= rank(x) <= ceil((p + err) * N).
+   *
+   * This method implements a variation of the Greenwald-Khanna algorithm (with some speed
+   * optimizations).
+   * The algorithm was first present in [[http://dx.doi.org/10.1145/375663.375670 Space-efficient
+   * Online Computation of Quantile Summaries]] by Greenwald and Khanna.
+   *
+   * @param cols the names of the numerical columns
+   * @param probabilities a list of quantile probabilities
+   *   Each number must belong to [0, 1].
+   *   For example 0 is the minimum, 0.5 is the median, 1 is the maximum.
+   * @param relativeError The relative target precision to achieve (>= 0).
+   *   If set to zero, the exact quantiles are computed, which could be very expensive.
+   *   Note that values greater than 1 are accepted but give the same result as 1.
+   * @return the approximate quantiles at the given probabilities
+   *
+   * @since 2.0.0
+   */
+  def approxQuantile(
+      cols: Array[String],
+      probabilities: Array[Double],
+      relativeError: Double): Array[Double] = {
+    StatFunctions.multipleApproxQuantiles(df, cols, probabilities, relativeError).head.toArray
+  }
+
+  /**
    * Python-friendly version of [[approxQuantile()]]
    */
   private[spark] def approxQuantile(

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -91,6 +91,9 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    *   Note that values greater than 1 are accepted but give the same result as 1.
    * @return the approximate quantiles at the given probabilities of each column
    *
+   * @note Rows containing any NaN values will be removed from the numerical column
+   *       before calculation
+   *
    * @since 2.1.0
    */
   def approxQuantile(

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -91,8 +91,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    *   Note that values greater than 1 are accepted but give the same result as 1.
    * @return the approximate quantiles at the given probabilities of each column
    *
-   * @note Rows containing any NaN values will be removed from the numerical column
-   *       before calculation
+   * @note Rows containing any NaN values will be removed before calculation
    *
    * @since 2.1.0
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -75,6 +75,16 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
   }
 
   /**
+   * Python-friendly version of [[approxQuantile()]]
+   */
+  private[spark] def approxQuantile(
+      col: String,
+      probabilities: List[Double],
+      relativeError: Double): java.util.List[Double] = {
+    approxQuantile(col, probabilities.toArray, relativeError).toList.asJava
+  }
+
+  /**
    * Calculates the approximate quantiles of numerical columns of a DataFrame.
    *
    * The result of this algorithm has the following deterministic bound:
@@ -109,14 +119,16 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
       .map(_.toArray).toArray
   }
 
+
   /**
    * Python-friendly version of [[approxQuantile()]]
    */
-  private[spark] def approxQuantile(
-      col: String,
+  private[spark] def approxQuantileMultiCols(
+      cols: List[String],
       probabilities: List[Double],
-      relativeError: Double): java.util.List[Double] = {
-    approxQuantile(col, probabilities.toArray, relativeError).toList.asJava
+      relativeError: Double): java.util.List[java.util.List[Double]] = {
+    approxQuantile(cols.toArray, probabilities.toArray, relativeError)
+        .map(_.toList.asJava).toList.asJava
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -109,7 +109,7 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    *   Note that values greater than 1 are accepted but give the same result as 1.
    * @return the approximate quantiles at the given probabilities of each column
    *
-   * @since 2.0.0
+   * @since 2.1.0
    */
   def approxQuantile(
       cols: Array[String],

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -75,16 +75,6 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
   }
 
   /**
-   * Python-friendly version of [[approxQuantile()]]
-   */
-  private[spark] def approxQuantile(
-      col: String,
-      probabilities: List[Double],
-      relativeError: Double): java.util.List[Double] = {
-    approxQuantile(col, probabilities.toArray, relativeError).toList.asJava
-  }
-
-  /**
    * Calculates the approximate quantiles of numerical columns of a DataFrame.
    *
    * The result of this algorithm has the following deterministic bound:

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -77,8 +77,11 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
 
   /**
    * Calculates the approximate quantiles of numerical columns of a DataFrame.
+   * @see [[DataFrameStatsFunctions.approxQuantile(col:Str* approxQuantile]] for
+   *     detailed description.
    *
-   * Note that rows containing any null values will be removed before calculation.
+   * Note that rows containing any null or NaN values values will be removed before
+   * calculation.
    * @param cols the names of the numerical columns
    * @param probabilities a list of quantile probabilities
    *   Each number must belong to [0, 1].

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -97,15 +97,16 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    * @param relativeError The relative target precision to achieve (>= 0).
    *   If set to zero, the exact quantiles are computed, which could be very expensive.
    *   Note that values greater than 1 are accepted but give the same result as 1.
-   * @return the approximate quantiles at the given probabilities
+   * @return the approximate quantiles at the given probabilities of each column
    *
    * @since 2.0.0
    */
   def approxQuantile(
       cols: Array[String],
       probabilities: Array[Double],
-      relativeError: Double): Array[Double] = {
-    StatFunctions.multipleApproxQuantiles(df, cols, probabilities, relativeError).head.toArray
+      relativeError: Double): Array[Array[Double]] = {
+    StatFunctions.multipleApproxQuantiles(df, cols, probabilities, relativeError)
+      .map(_.toArray).toArray
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
@@ -163,6 +163,12 @@ class DataFrameStatSuite extends QueryTest with SharedSQLContext {
     val dfNaN = Seq(Double.NaN, 1.0, Double.NaN, Double.NaN).toDF("input")
     val resNaN = dfNaN.stat.approxQuantile("input", Array(q1, q2), epsilons.head)
     assert(resNaN.count(_.isNaN) === 0)
+    // test approxQuantile on multi-column NaN values
+    val dfNaN2 = Seq((Double.NaN, 1.0), (1.0, 1.0), (-1.0, Double.NaN), (Double.NaN, Double.NaN))
+      .toDF("input1", "input2")
+    val resNaN2 = dfNaN2.stat.approxQuantile(Array("input1", "input2"),
+      Array(q1, q2), epsilons.head)
+    assert(resNaN2.flatten.count(_.isNaN) === 0)
   }
 
   test("crosstab") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
@@ -149,6 +149,15 @@ class DataFrameStatSuite extends QueryTest with SharedSQLContext {
       assert(math.abs(s2 - q2 * n) < error_single)
       assert(math.abs(d1 - 2 * q1 * n) < error_double)
       assert(math.abs(d2 - 2 * q2 * n) < error_double)
+
+      // Multiple columns
+      val Array(Array(ms1, ms2), Array(md1, md2)) =
+        df.stat.approxQuantile(Array("singles", "doubles"), Array(q1, q2), epsilon)
+
+      assert(math.abs(ms1 - q1 * n) < error_single)
+      assert(math.abs(ms2 - q2 * n) < error_single)
+      assert(math.abs(md1 - 2 * q1 * n) < error_double)
+      assert(math.abs(md2 - 2 * q2 * n) < error_double)
     }
     // test approxQuantile on NaN values
     val dfNaN = Seq(Double.NaN, 1.0, Double.NaN, Double.NaN).toDF("input")


### PR DESCRIPTION
## What changes were proposed in this pull request?

1, add the multi-cols support based on current private api 
2, add the multi-cols support to pyspark
## How was this patch tested?

unit tests
