### PR TITLE
[SPARK-14354][SQL] Let Expand take name expressions and infer output attributes

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1669,7 +1669,8 @@ object TimeWindowing extends Rule[LogicalPlan] {
             Literal(WINDOW_END) :: windowEnd :: Nil)
         }
 
-        val projections = windows.map(Alias(_, "window")() +: p.children.head.output)
+        val projections =
+          windows.map(Alias(_, "window")(exprId = windowAttr.exprId) +: p.children.head.output)
 
         val filterExpr =
           window.timeColumn >= windowAttr.getField(WINDOW_START) &&

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -249,7 +249,7 @@ class Analyzer(
           s"${VirtualColumn.groupingIdName} is deprecated; use grouping_id() instead")
       // Ensure all the expressions have been resolved.
       case x: GroupingSets if x.expressions.forall(_.resolved) =>
-        val gid = AttributeReference(VirtualColumn.groupingIdName, IntegerType, false)()
+        val gid = VirtualColumn.groupingIdAttribute
 
         // Expand works by setting grouping expressions to null as determined by the bitmasks. To
         // prevent these null values from being used in an aggregate instead of the original value

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1665,8 +1665,8 @@ object TimeWindowing extends Rule[LogicalPlan] {
           val windowEnd = windowStart + window.windowDuration
 
           CreateNamedStruct(
-            Literal(WINDOW_START) :: windowStart ::
-            Literal(WINDOW_END) :: windowEnd :: Nil)
+            Literal(WINDOW_START) :: TimestampFromLong(windowStart) ::
+            Literal(WINDOW_END) :: TimestampFromLong(windowEnd) :: Nil)
         }
 
         val projections =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TimeWindow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TimeWindow.scala
@@ -131,3 +131,19 @@ case class PreciseTimestamp(child: Expression) extends UnaryExpression with Expe
        """.stripMargin
   }
 }
+
+/**
+ * Expression used internally to convert a Long to TimestampType without losing
+ * precision, i.e. in microseconds. Used in time windowing.
+ */
+case class TimestampFromLong(child: Expression) extends UnaryExpression with ExpectsInputTypes {
+  override def inputTypes: Seq[AbstractDataType] = Seq(LongType)
+  override def dataType: DataType = TimestampType
+  override def genCode(ctx: CodegenContext, ev: ExprCode): String = {
+    val eval = child.gen(ctx)
+    eval.code +
+      s"""boolean ${ev.isNull} = ${eval.isNull};
+         |${ctx.javaType(dataType)} ${ev.value} = ${eval.value};
+       """.stripMargin
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -327,14 +327,14 @@ object ColumnPruning extends Rule[LogicalPlan] {
     case p @ Project(_, a: Aggregate) if (a.outputSet -- p.references).nonEmpty =>
       p.copy(
         child = a.copy(aggregateExpressions = a.aggregateExpressions.filter(p.references.contains)))
-    case a @ Project(_, e @ Expand(_, _, grandChild)) if (e.outputSet -- a.references).nonEmpty =>
+    case a @ Project(_, e @ Expand(_, grandChild)) if (e.outputSet -- a.references).nonEmpty =>
       val newOutput = e.output.filter(a.references.contains(_))
       val newProjects = e.projections.map { proj =>
         proj.zip(e.output).filter { case (e, a) =>
           newOutput.contains(a)
         }.unzip._1
       }
-      a.copy(child = Expand(newProjects, newOutput, grandChild))
+      a.copy(child = Expand(newProjects, grandChild))
 
     // Prunes the unused columns from child of MapPartitions
     case mp @ MapPartitions(_, _, _, child) if (child.outputSet -- mp.references).nonEmpty =>
@@ -343,7 +343,7 @@ object ColumnPruning extends Rule[LogicalPlan] {
     // Prunes the unused columns from child of Aggregate/Expand/Generate
     case a @ Aggregate(_, _, child) if (child.outputSet -- a.references).nonEmpty =>
       a.copy(child = prunedChild(child, a.references))
-    case e @ Expand(_, _, child) if (child.outputSet -- e.references).nonEmpty =>
+    case e @ Expand(_, child) if (child.outputSet -- e.references).nonEmpty =>
       e.copy(child = prunedChild(child, e.references))
     case g: Generate if !g.join && (g.child.outputSet -- g.references).nonEmpty =>
       g.copy(child = prunedChild(g.child, g.references))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicOperators.scala
@@ -496,7 +496,7 @@ private[sql] object Expand {
         if (nonSelectedGroupAttrSet.contains(attr)) {
           // if the input attribute in the Invalid Grouping Expression set of for this group
           // replace it with constant null
-          Alias(Literal.create(null, attr.dataType), attr.name)()
+          Alias(Literal.create(null, attr.dataType), attr.name)(exprId = attr.exprId)
         } else {
           attr
         }
@@ -524,9 +524,10 @@ case class Expand(
     // Check output consistency on remaining projections
     projections.tail.foreach { p =>
       p.zipWithIndex.foreach { case (e, index) =>
-        if (e.name != preOutput(index).name || e.dataType != preOutput(index).dataType) {
-          throw new AnalysisException(s"Projection $p is inconsistent with output $preOutput" +
-            "in Expand operator")
+        if (e.dataType != preOutput(index).dataType) {
+          throw new AnalysisException(s"Projection $p (column ${e.name}, ${e.dataType}) is " +
+            s"inconsistent with output $preOutput (column ${preOutput(index).name}, " +
+            s"${preOutput(index).dataType}) in Expand operator.")
         }
       }
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ColumnPruningSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ColumnPruningSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression,
 import org.apache.spark.sql.catalyst.plans.{Inner, PlanTest}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
-import org.apache.spark.sql.types.StringType
+import org.apache.spark.sql.types.{IntegerType, StringType}
 
 class ColumnPruningSuite extends PlanTest {
 
@@ -111,9 +111,8 @@ class ColumnPruningSuite extends PlanTest {
         Seq(sum('c).as("sum")),
         Expand(
           Seq(
-            Seq('a, 'b, 'c, Literal.create(null, StringType), 1),
-            Seq('a, 'b, 'c, 'a, 2)),
-          Seq('a, 'b, 'c, 'aa.int, 'gid.int),
+            Seq('a, 'b, 'c, Alias(Literal.create(null, IntegerType), "aa")(), Alias(1, "gid")()),
+            Seq('a, 'b, 'c, Alias('a, "aa")(), Alias(2, "gid")())),
           input)).analyze
     val optimized = Optimize.execute(query)
 
@@ -123,9 +122,8 @@ class ColumnPruningSuite extends PlanTest {
         Seq(sum('c).as("sum")),
         Expand(
           Seq(
-            Seq('c, Literal.create(null, StringType), 1),
-            Seq('c, 'a, 2)),
-          Seq('c, 'aa.int, 'gid.int),
+            Seq('c, Alias(Literal.create(null, IntegerType), "aa")(), Alias(1, "gid")()),
+            Seq('c, Alias('a, "aa")(), Alias(2, "gid")())),
           Project(Seq('a, 'c),
             input))).analyze
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/ConstraintPropagationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/ConstraintPropagationSuite.scala
@@ -106,13 +106,14 @@ class ConstraintPropagationSuite extends SparkFunSuite {
 
     val expand = Expand(
           Seq(
-            Seq('c, Literal.create(null, StringType), 1),
-            Seq('c, 'a, 2)),
-          Seq('c, 'a, 'gid.int),
-          Project(Seq('a, 'c),
-            notNullRelation))
+            Seq('c, Alias(Literal.create(null, IntegerType), "a")(), Alias(1, "gid")()),
+            Seq('c, 'a, Alias(2, "gid")())),
+            notNullRelation)
     verifyConstraints(expand.analyze.constraints,
-      ExpressionSet(Seq.empty[Expression]))
+      ExpressionSet(Seq(
+        resolveColumn(notNullRelation.analyze, "c") > 10,
+        IsNotNull(resolveColumn(notNullRelation.analyze, "c")),
+        IsNotNull(resolveColumn(expand.analyze, "gid")))))
   }
 
   test("propagating constraints in aliases") {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -366,7 +366,7 @@ private[sql] abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         execution.Project(projectList, planLater(child)) :: Nil
       case logical.Filter(condition, child) =>
         execution.Filter(condition, planLater(child)) :: Nil
-      case e @ logical.Expand(_, _, child) =>
+      case e @ logical.Expand(_, child) =>
         execution.Expand(e.projections, e.output, planLater(child)) :: Nil
       case logical.Window(windowExprs, partitionSpec, orderSpec, child) =>
         execution.Window(windowExprs, partitionSpec, orderSpec, planLater(child)) :: Nil

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/SQLBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/SQLBuilder.scala
@@ -110,7 +110,7 @@ class SQLBuilder(logicalPlan: LogicalPlan, sqlContext: SQLContext) extends Loggi
     case p: Project =>
       projectToSQL(p, isDistinct = false)
 
-    case a @ Aggregate(_, _, e @ Expand(_, _, p: Project)) if isGroupingSet(a, e, p) =>
+    case a @ Aggregate(_, _, e @ Expand(_, p: Project)) if isGroupingSet(a, e, p) =>
       groupingSetToSQL(a, e, p)
 
     case p: Aggregate =>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/SQLBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/SQLBuilder.scala
@@ -330,7 +330,7 @@ class SQLBuilder(logicalPlan: LogicalPlan, sqlContext: SQLContext) extends Loggi
     val aggExprs = agg.aggregateExpressions.map { case aggExpr =>
       val originalAggExpr = aggExpr.transformDown {
         // grouping_id() is converted to VirtualColumn.groupingIdName by Analyzer. Revert it back.
-        case ar: AttributeReference if ar == gid => GroupingID(Nil)
+        case ar: AttributeReference if ar.exprId == gid.exprId => GroupingID(Nil)
         case ar: AttributeReference if groupByAttrMap.contains(ar) => groupByAttrMap(ar)
         case a @ Cast(BitwiseAnd(
             ShiftRight(ar: AttributeReference, Literal(value: Any, IntegerType)),


### PR DESCRIPTION
## What changes were proposed in this pull request?

JIRA: https://issues.apache.org/jira/browse/SPARK-14354

Currently we create `Expand` operator by specifying projections (`Seq[Seq[Expression]]`) and its output. We allow `Expand` to reuse child operator's attributes and so make its constraints invalid when we change the corresponding values of these attributes (e.g., making them null when doing a roll up). We should let it take name expressions and infer output itself.

The problem is we re-use child's output as `Expand`s output.  We will create new attributes in `Expand` because `Expand` actually performs multiple projections. However, we let the projections in `Expand` as `Expression` instead of `NamedExpression` and re-use child output attributes. Thus there is a inconsistency between `Expand`'s output attributes and projected values.

The obvious example for this inconsistency is constraints. Previously `Expand` inherits child's constraints. As we will change child's output values by projections (e.g., set it as null), these constraints bound on child's attributes are not valid.

In previous PR we just set `Expand`s `validConstraints` to empty to avoid such inconsistency. But as the result, we don't have reliable constraints after `Expand` operator.
## How was this patch tested?

Modified `ConstraintPropagationSuite`.
