### PR TITLE
[SPARK-14364] HeartbeatReceiver object should be private[spark]

### DIFF
--- a/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
@@ -220,6 +220,7 @@ private[spark] class HeartbeatReceiver(sc: SparkContext, clock: Clock)
   }
 }
 
-object HeartbeatReceiver {
+
+private[spark] object HeartbeatReceiver {
   val ENDPOINT_NAME = "HeartbeatReceiver"
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

It's a mistake that HeartbeatReceiver object was made public in Spark 1.x.
## How was this patch tested?

N/A
