### PR TITLE
[SPARK-14369][SQL] Locality support for FileScanRDD

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
@@ -89,17 +89,6 @@ class FileScanRDD(
 
   override protected def getPreferredLocations(split: Partition): Seq[String] = {
     val files = split.asInstanceOf[FilePartition].files
-    val partitionSize = files.map(_.length).sum
-
-    // Here we only collect locations of file blocks whose size exceeds a predefined fraction
-    // of the whole partition size.
-    files
-      .filter(_.length.toDouble / partitionSize >= FileScanRDD.FILE_PARTITION_PREF_LOCS_FRAC)
-      .flatMap(_.locations)
-      .distinct
+    if (files.isEmpty) Seq.empty else files.maxBy(_.length).locations
   }
-}
-
-object FileScanRDD {
-  private val FILE_PARTITION_PREF_LOCS_FRAC = 0.1D
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
@@ -103,7 +103,7 @@ class FileScanRDD(
     // Takes the first 3 hosts with the most data to be retrieved
     hostToNumBytes.toSeq.sortBy {
       case (host, numBytes) => numBytes
-    }.take(3).map {
+    }.reverse.take(3).map {
       case (host, numBytes) => host
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
@@ -31,7 +31,8 @@ case class PartitionedFile(
     partitionValues: InternalRow,
     filePath: String,
     start: Long,
-    length: Long) {
+    length: Long,
+    locations: Array[String] = Array.empty) {
   override def toString: String = {
     s"path: $filePath, range: $start-${start + length}, partition values: $partitionValues"
   }
@@ -85,4 +86,8 @@ class FileScanRDD(
   }
 
   override protected def getPartitions: Array[Partition] = filePartitions.toArray
+
+  override protected def getPreferredLocations(split: Partition): Seq[String] = {
+    split.asInstanceOf[FilePartition].files.flatMap(_.locations).distinct
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
@@ -101,5 +101,5 @@ class FileScanRDD(
 }
 
 object FileScanRDD {
-  private val FILE_PARTITION_PREF_LOCS_FRAC = 0.2D
+  private val FILE_PARTITION_PREF_LOCS_FRAC = 0.1D
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -219,21 +219,13 @@ private[sql] object FileSourceStrategy extends Strategy with Logging {
   }
 
   private def getBlockIndex(blockLocations: Array[BlockLocation], offset: Long): Int = {
-    val index = blockLocations.indexWhere { b =>
+    blockLocations.indexWhere { b =>
       b.getOffset <= offset && offset < b.getOffset + b.getLength
     }
-
-    if (index < 0) {
-      val last = blockLocations.last
-      val totalLength = last.getOffset + last.getLength
-      throw new IllegalArgumentException(
-        s"Offset $offset is outside of file (0..$totalLength")
-    }
-
-    index
   }
 
   private def getBlockHosts(blockLocations: Array[BlockLocation], offset: Long): Array[String] = {
-    blockLocations(getBlockIndex(blockLocations, offset)).getHosts
+    val index = getBlockIndex(blockLocations, offset)
+    if (index < 0) Array.empty[String] else blockLocations(index).getHosts
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -143,7 +143,7 @@ private[sql] object FileSourceStrategy extends Strategy with Logging {
           val splitFiles = selectedPartitions.flatMap { partition =>
             partition.files.flatMap { file =>
               val blockLocations = getBlockLocations(file)
-              (0L to file.getLen by maxSplitBytes).map { offset =>
+              (0L until file.getLen by maxSplitBytes).map { offset =>
                 val remaining = file.getLen - offset
                 val size = if (remaining > maxSplitBytes) maxSplitBytes else remaining
                 val hosts = getBlockHosts(blockLocations, offset, size)

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -21,8 +21,8 @@ import scala.collection.mutable
 import scala.util.Try
 
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.s3.S3FileSystem
 import org.apache.hadoop.fs.{FileStatus, FileSystem, LocatedFileStatus, Path}
+import org.apache.hadoop.fs.s3.S3FileSystem
 import org.apache.hadoop.mapred.{FileInputFormat, JobConf}
 import org.apache.hadoop.mapreduce.{Job, TaskAttemptContext}
 
@@ -32,7 +32,7 @@ import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
-import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow, expressions}
+import org.apache.spark.sql.catalyst.{expressions, CatalystTypeConverters, InternalRow}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.execution.FileRelation
 import org.apache.spark.sql.execution.datasources._

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -31,7 +31,7 @@ import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
-import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow, expressions}
+import org.apache.spark.sql.catalyst.{expressions, CatalystTypeConverters, InternalRow}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.execution.FileRelation
 import org.apache.spark.sql.execution.datasources._

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -18,8 +18,9 @@
 package org.apache.spark.sql.execution.datasources
 
 import java.io.File
+import java.util.concurrent.atomic.AtomicInteger
 
-import org.apache.hadoop.fs.FileStatus
+import org.apache.hadoop.fs.{BlockLocation, FileStatus, RawLocalFileSystem}
 import org.apache.hadoop.mapreduce.Job
 
 import org.apache.spark.sql._
@@ -267,6 +268,80 @@ class FileSourceStrategySuite extends QueryTest with SharedSQLContext with Predi
     }
   }
 
+  test("Locality support for FileScanRDD") {
+    val partition = FilePartition(0, Seq(
+      PartitionedFile(InternalRow.empty, "fakePath0", 0, 10, Array("host0", "host1")),
+      PartitionedFile(InternalRow.empty, "fakePath0", 10, 20, Array("host1", "host2")),
+      PartitionedFile(InternalRow.empty, "fakePath1", 0, 5, Array("host3")),
+      PartitionedFile(InternalRow.empty, "fakePath2", 0, 5, Array("host4"))
+    ))
+
+    val fakeRDD = new FileScanRDD(
+      sqlContext,
+      (file: PartitionedFile) => Iterator.empty,
+      Seq(partition)
+    )
+
+    assertResult(Set("host0", "host1", "host2")) {
+      fakeRDD.preferredLocations(partition).toSet
+    }
+  }
+
+  test("Locality support for FileScanRDD - one file per partition") {
+    withHadoopConf(
+      "fs.file.impl" -> classOf[LocalityTestFileSystem].getName,
+      "fs.file.impl.disable.cache" -> "true"
+    ) {
+      withSQLConf(SQLConf.FILES_MAX_PARTITION_BYTES.key -> "10") {
+        val table =
+          createTable(files = Seq(
+            "file1" -> 10,
+            "file2" -> 10
+          ))
+
+        checkScan(table) { partitions =>
+          val Seq(p1, p2) = partitions
+          assert(p1.files.length == 1)
+          assert(p1.files.flatMap(_.locations).length == 1)
+          assert(p2.files.length == 1)
+          assert(p2.files.flatMap(_.locations).length == 1)
+
+          val fileScanRDD = getFileScanRDD(table)
+          assert(partitions.flatMap(fileScanRDD.preferredLocations).length == 2)
+        }
+      }
+    }
+  }
+
+  test("Locality support for FileScanRDD - large file") {
+    withHadoopConf(
+      "fs.file.impl" -> classOf[LocalityTestFileSystem].getName,
+      "fs.file.impl.disable.cache" -> "true"
+    ) {
+      withSQLConf(
+        SQLConf.FILES_MAX_PARTITION_BYTES.key -> "10",
+        SQLConf.FILES_OPEN_COST_IN_BYTES.key -> "0"
+      ) {
+        val table =
+          createTable(files = Seq(
+            "file1" -> 15,
+            "file2" -> 5
+          ))
+
+        checkScan(table) { partitions =>
+          val Seq(p1, p2) = partitions
+          assert(p1.files.length == 1)
+          assert(p1.files.flatMap(_.locations).length == 1)
+          assert(p2.files.length == 2)
+          assert(p2.files.flatMap(_.locations).length == 2)
+
+          val fileScanRDD = getFileScanRDD(table)
+          assert(partitions.flatMap(fileScanRDD.preferredLocations).length == 3)
+        }
+      }
+    }
+  }
+
   // Helpers for checking the arguments passed to the FileFormat.
 
   protected val checkPartitionSchema =
@@ -303,14 +378,7 @@ class FileSourceStrategySuite extends QueryTest with SharedSQLContext with Predi
 
   /** Plans the query and calls the provided validation function with the planned partitioning. */
   def checkScan(df: DataFrame)(func: Seq[FilePartition] => Unit): Unit = {
-    val fileScan = df.queryExecution.executedPlan.collect {
-      case scan: DataSourceScan if scan.rdd.isInstanceOf[FileScanRDD] =>
-        scan.rdd.asInstanceOf[FileScanRDD]
-    }.headOption.getOrElse {
-      fail(s"No FileScan in query\n${df.queryExecution}")
-    }
-
-    func(fileScan.filePartitions)
+    func(getFileScanRDD(df).filePartitions)
   }
 
   /**
@@ -346,6 +414,15 @@ class FileSourceStrategySuite extends QueryTest with SharedSQLContext with Predi
       Dataset.ofRows(sqlContext, bucketed)
     } else {
       df
+    }
+  }
+
+  def getFileScanRDD(df: DataFrame): FileScanRDD = {
+    df.queryExecution.executedPlan.collect {
+      case scan: DataSourceScan if scan.rdd.isInstanceOf[FileScanRDD] =>
+        scan.rdd.asInstanceOf[FileScanRDD]
+    }.headOption.getOrElse {
+      fail(s"No FileScan in query\n${df.queryExecution}")
     }
   }
 }
@@ -405,5 +482,15 @@ class TestFileFormat extends FileFormat {
     LastArguments.options = options
 
     (file: PartitionedFile) => { Iterator.empty }
+  }
+}
+
+class LocalityTestFileSystem extends RawLocalFileSystem {
+  private val invocations = new AtomicInteger(0)
+
+  override def getFileBlockLocations(
+      file: FileStatus, start: Long, len: Long): Array[BlockLocation] = {
+    val count = invocations.getAndAdd(1)
+    Array(new BlockLocation(Array(s"host$count:50010"), Array(s"host$count"), 0, len))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
@@ -91,6 +91,10 @@ private[sql] trait SQLTestUtils
     sparkContext.hadoopConfiguration
   }
 
+  /**
+   * Sets all Hadoop configurations specified in `pairs`, calls `f`, and then restore all Hadoop
+   * configurations.
+   */
   protected def withHadoopConf(pairs: (String, String)*)(f: => Unit): Unit = {
     val (keys, _) = pairs.unzip
     val originalValues = keys.map(key => Option(hadoopConfiguration.get(key)))

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
@@ -91,6 +91,23 @@ private[sql] trait SQLTestUtils
     sparkContext.hadoopConfiguration
   }
 
+  protected def withHadoopConf(pairs: (String, String)*)(f: => Unit): Unit = {
+    val (keys, _) = pairs.unzip
+    val originalValues = keys.map(key => Option(hadoopConfiguration.get(key)))
+
+    try {
+      pairs.foreach { case (key, value) =>
+        hadoopConfiguration.set(key, value)
+      }
+      f
+    } finally {
+      keys.zip(originalValues).foreach {
+        case (key, Some(value)) => hadoopConfiguration.set(key, value)
+        case (key, None) => hadoopConfiguration.unset(key)
+      }
+    }
+  }
+
   /**
    * Sets all SQL configurations specified in `pairs`, calls `f`, and then restore all SQL
    * configurations.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -504,11 +504,12 @@ private[hive] class HiveMetastoreCatalog(val client: HiveClient, hive: HiveConte
     }
   }
 
-  private def convertToLogicalRelation(metastoreRelation: MetastoreRelation,
-                                       options: Map[String, String],
-                                       defaultSource: FileFormat,
-                                       fileFormatClass: Class[_ <: FileFormat],
-                                       fileType: String): LogicalRelation = {
+  private def convertToLogicalRelation(
+      metastoreRelation: MetastoreRelation,
+      options: Map[String, String],
+      defaultSource: FileFormat,
+      fileFormatClass: Class[_ <: FileFormat],
+      fileType: String): LogicalRelation = {
     val metastoreSchema = StructType.fromAttributes(metastoreRelation.output)
     val tableIdentifier =
       QualifiedTableName(metastoreRelation.databaseName, metastoreRelation.tableName)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala
@@ -256,6 +256,10 @@ class BucketedReadSuite extends QueryTest with SQLTestUtils with TestHiveSinglet
         val t2 = hiveContext.table("bucketed_table2")
         val joined = t1.join(t2, joinCondition(t1, t2, joinColumns))
 
+        joined.sort("bucketed_table1.k", "bucketed_table2.k").collect()
+
+        df1.join(df2, joinCondition(df1, df2, joinColumns)).sort("df1.k", "df2.k").collect()
+
         // First check the result is corrected.
         checkAnswer(
           joined.sort("bucketed_table1.k", "bucketed_table2.k"),
@@ -301,8 +305,8 @@ class BucketedReadSuite extends QueryTest with SQLTestUtils with TestHiveSinglet
   }
 
   test("only shuffle one side when 2 bucketed tables have different bucket keys") {
-    val bucketSpec1 = Some(BucketSpec(8, Seq("i"), Nil))
-    val bucketSpec2 = Some(BucketSpec(8, Seq("j"), Nil))
+    val bucketSpec1 = Some(BucketSpec(5, Seq("i"), Nil))
+    val bucketSpec2 = Some(BucketSpec(5, Seq("j"), Nil))
     testBucketing(bucketSpec1, bucketSpec2, Seq("i"), shuffleLeft = false, shuffleRight = true)
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/ParquetHadoopFsRelationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/ParquetHadoopFsRelationSuite.scala
@@ -18,15 +18,12 @@
 package org.apache.spark.sql.sources
 
 import java.io.File
-import java.util.concurrent.atomic.AtomicInteger
 
 import com.google.common.io.Files
 import org.apache.hadoop.fs._
 
 import org.apache.spark.deploy.SparkHadoopUtil
-import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
-import org.apache.spark.sql.execution.datasources.FileScanRDD
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
@@ -228,49 +225,6 @@ class ParquetHadoopFsRelationSuite extends HadoopFsRelationTest {
           .parquet(path)
         checkAnswer(df, copyDf)
       }
-    }
-  }
-
-  test("Locality support for FileScanRDD") {
-    withHadoopConf(
-      "fs.file.impl" -> classOf[LocalityTestFileSystem].getName,
-      "fs.file.impl.disable.cache" -> "true"
-    ) {
-      withTempPath { dir =>
-        val path = "file://" + dir.getCanonicalPath
-        sqlContext.range(4).repartition(2).write.parquet(path)
-        val df = sqlContext.read.parquet(path)
-
-        val Some(fileScanRDD) = {
-          def allRDDsInDAG(rdd: RDD[_]): Seq[RDD[_]] = {
-            rdd +: rdd.dependencies.map(_.rdd).flatMap(allRDDsInDAG)
-          }
-
-          // We have to search for the `FileScanRDD` along the the RDD DAG since
-          // RDD.preferredLocations doesn't propagate along the DAG to the root RDD.
-          allRDDsInDAG(df.rdd).collectFirst {
-            case f: FileScanRDD => f
-          }
-        }
-
-        val partitions = fileScanRDD.partitions
-        val preferredLocations = partitions.flatMap(fileScanRDD.preferredLocations)
-
-        assert(preferredLocations.distinct.length == 2)
-      }
-    }
-  }
-}
-
-class LocalityTestFileSystem extends RawLocalFileSystem {
-  private val invocations = new AtomicInteger(0)
-
-  override def getFileBlockLocations(
-      file: FileStatus, start: Long, len: Long): Array[BlockLocation] = {
-    if (invocations.getAndAdd(1) % 2 == 0) {
-      Array(new BlockLocation(Array("host1:50010"), Array("host1"), 0, len))
-    } else {
-      Array(new BlockLocation(Array("host2:50010"), Array("host2"), 0, len))
     }
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/hadoopFsRelationSuites.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/hadoopFsRelationSuites.scala
@@ -29,10 +29,9 @@ import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter
 import org.apache.parquet.hadoop.ParquetOutputCommitter
 
 import org.apache.spark.deploy.SparkHadoopUtil
-import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.execution.DataSourceScan
-import org.apache.spark.sql.execution.datasources.{FileScanRDD, LogicalRelation}
+import org.apache.spark.sql.execution.datasources.{FileScanRDD, LocalityTestFileSystem, LogicalRelation}
 import org.apache.spark.sql.hive.test.TestHiveSingleton
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SQLTestUtils
@@ -724,15 +723,5 @@ class AlwaysFailParquetOutputCommitter(
 
   override def commitJob(context: JobContext): Unit = {
     sys.error("Intentional job commitment failure for testing purpose.")
-  }
-}
-
-class LocalityTestFileSystem extends RawLocalFileSystem {
-  private val invocations = new AtomicInteger(0)
-
-  override def getFileBlockLocations(
-      file: FileStatus, start: Long, len: Long): Array[BlockLocation] = {
-    val count = invocations.getAndAdd(1)
-    Array(new BlockLocation(Array(s"host$count:50010"), Array(s"host$count"), 0, len))
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/hadoopFsRelationSuites.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/hadoopFsRelationSuites.scala
@@ -680,7 +680,8 @@ abstract class HadoopFsRelationTest extends QueryTest with SQLTestUtils with Tes
       withTempPath { dir =>
         val path = "file://" + dir.getCanonicalPath
         val df1 = sqlContext.range(4)
-        df1.repartition(2).write.format(dataSourceName).save(path)
+        df1.coalesce(1).write.mode("overwrite").format(dataSourceName).save(path)
+        df1.coalesce(1).write.mode("append").format(dataSourceName).save(path)
 
         val df2 = sqlContext.read
           .format(dataSourceName)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/hadoopFsRelationSuites.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/hadoopFsRelationSuites.scala
@@ -738,10 +738,7 @@ class LocalityTestFileSystem extends RawLocalFileSystem {
 
   override def getFileBlockLocations(
       file: FileStatus, start: Long, len: Long): Array[BlockLocation] = {
-    if (invocations.getAndAdd(1) % 2 == 0) {
-      Array(new BlockLocation(Array("host1:50010"), Array("host1"), 0, len))
-    } else {
-      Array(new BlockLocation(Array("host2:50010"), Array("host2"), 0, len))
-    }
+    val count = invocations.getAndAdd(1)
+    Array(new BlockLocation(Array(s"host$count:50010"), Array(s"host$count"), 0, len))
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds preliminary locality support for `FileFormat` data sources by overriding `FileScanRDD.preferredLocations()`. The strategy can be divided into two parts:
1.  Block location lookup
   
   Unlike `HadoopRDD` or `NewHadoopRDD`, `FileScanRDD` doesn't have access to the underlying `InputFormat` or `InputSplit`, and thus can't rely on `InputSplit.getLocations()` to gather locality information. Instead, this PR queries block locations using `FileSystem.getBlockLocations()` after listing all `FileStatus`es in `HDFSFileCatalog` and convert all `FileStatus`es into `LocatedFileStatus`es.
   
   Note that although S3/S3A/S3N file systems don't provide valid locality information, their `getLocatedStatus()` implementations don't actually issue remote calls either. So there's no need to special case these file systems.
2.  Selecting preferred locations
   
   For each `FilePartition`, we pick up top 3 locations that containing the most data to be retrieved. This isn't necessarily the best algorithm out there. Further improvements may be brought up in follow-up PRs.
## How was this patch tested?

Tested by overriding default `FileSystem` implementation for `file:///` with a mocked one, which returns mocked block locations.
