### PR TITLE
[SPARK-13211] [STREAMING] StreamingContext throws NoSuchElementException when created from non-existent checkpoint directory

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/Checkpoint.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/Checkpoint.scala
@@ -334,17 +334,13 @@ object CheckpointReader extends Logging {
       ignoreReadError: Boolean = false): Option[Checkpoint] = {
     val checkpointPath = new Path(checkpointDir)
 
-    // TODO(rxin): Why is this a def?!
-    def fs: FileSystem = checkpointPath.getFileSystem(hadoopConf)
+    val fs: FileSystem = checkpointPath.getFileSystem(hadoopConf)
 
     // Try to find the checkpoint files
     val checkpointFiles = Checkpoint.getCheckpointFiles(checkpointDir, Some(fs)).reverse
-    if (checkpointFiles.isEmpty) {
-      return None
-    }
 
     // Try to read the checkpoint files in the order
-    logInfo("Checkpoint files found: " + checkpointFiles.mkString(","))
+    logInfo("Looking for checkpoint files in: " + checkpointFiles.mkString(","))
     var readError: Exception = null
     checkpointFiles.foreach(file => {
       logInfo("Attempting to load checkpoint from file " + file)

--- a/streaming/src/test/scala/org/apache/spark/streaming/CheckpointSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/CheckpointSuite.scala
@@ -34,7 +34,7 @@ import org.mockito.Mockito.mock
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.time.SpanSugar._
 
-import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite, TestUtils}
+import org.apache.spark.{SparkConf, SparkContext, SparkException, SparkFunSuite, TestUtils}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.streaming.dstream._
 import org.apache.spark.streaming.scheduler._
@@ -226,6 +226,11 @@ class CheckpointSuite extends TestSuiteBase with DStreamCheckpointTester
     } finally {
       super.afterFunction()
     }
+  }
+
+  test("non-existent checkpoint dir") {
+    // SPARK-13211
+    intercept[SparkException](new StreamingContext("nosuchdirectory"))
   }
 
   test("basic rdd checkpoints + dstream graph checkpoint recovery") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

new StreamingContext with non-existent checkpoint dir should yield specific SparkException, not NoSuchElementException
## How was this patch tested?

Jenkins test plus new test for this case
