### PR TITLE
[SPARK-14399] Remove unnecessary excludes from POMs and simplify Hive POM

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -212,10 +212,6 @@
       <artifactId>netty-all</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.clearspring.analytics</groupId>
       <artifactId>stream</artifactId>
     </dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -257,12 +257,6 @@
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-java</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-      </exclusions>
       <scope>test</scope>
     </dependency>
     <!-- Added for selenium: -->

--- a/dev/deps/spark-deps-hadoop-2.2
+++ b/dev/deps/spark-deps-hadoop-2.2
@@ -27,7 +27,7 @@ commons-beanutils-core-1.8.0.jar
 commons-cli-1.2.jar
 commons-codec-1.10.jar
 commons-collections-3.2.2.jar
-commons-compiler-2.7.6.jar
+commons-compiler-2.7.8.jar
 commons-compress-1.4.1.jar
 commons-configuration-1.6.jar
 commons-dbcp-1.4.jar

--- a/dev/deps/spark-deps-hadoop-2.2
+++ b/dev/deps/spark-deps-hadoop-2.2
@@ -118,6 +118,7 @@ jettison-1.1.jar
 jetty-all-7.6.0.v20120127.jar
 jetty-util-6.1.26.jar
 jline-2.12.jar
+joda-time-2.9.jar
 jodd-core-3.5.2.jar
 jpam-1.1.jar
 json-20090211.jar

--- a/dev/deps/spark-deps-hadoop-2.2
+++ b/dev/deps/spark-deps-hadoop-2.2
@@ -78,6 +78,12 @@ hadoop-yarn-client-2.2.0.jar
 hadoop-yarn-common-2.2.0.jar
 hadoop-yarn-server-common-2.2.0.jar
 hadoop-yarn-server-web-proxy-2.2.0.jar
+hive-beeline-1.2.1.spark.jar
+hive-cli-1.2.1.spark.jar
+hive-exec-1.2.1.spark.jar
+hive-jdbc-1.2.1.spark.jar
+hive-metastore-1.2.1.spark.jar
+hive-service-1.2.1.spark.jar
 httpclient-4.3.2.jar
 httpcore-4.3.2.jar
 ivy-2.4.0.jar

--- a/dev/deps/spark-deps-hadoop-2.2
+++ b/dev/deps/spark-deps-hadoop-2.2
@@ -118,7 +118,6 @@ jettison-1.1.jar
 jetty-all-7.6.0.v20120127.jar
 jetty-util-6.1.26.jar
 jline-2.12.jar
-joda-time-2.9.jar
 jodd-core-3.5.2.jar
 jpam-1.1.jar
 json-20090211.jar

--- a/dev/deps/spark-deps-hadoop-2.3
+++ b/dev/deps/spark-deps-hadoop-2.3
@@ -29,7 +29,7 @@ commons-beanutils-core-1.8.0.jar
 commons-cli-1.2.jar
 commons-codec-1.10.jar
 commons-collections-3.2.2.jar
-commons-compiler-2.7.6.jar
+commons-compiler-2.7.8.jar
 commons-compress-1.4.1.jar
 commons-configuration-1.6.jar
 commons-dbcp-1.4.jar

--- a/dev/deps/spark-deps-hadoop-2.3
+++ b/dev/deps/spark-deps-hadoop-2.3
@@ -73,6 +73,12 @@ hadoop-yarn-client-2.3.0.jar
 hadoop-yarn-common-2.3.0.jar
 hadoop-yarn-server-common-2.3.0.jar
 hadoop-yarn-server-web-proxy-2.3.0.jar
+hive-beeline-1.2.1.spark.jar
+hive-cli-1.2.1.spark.jar
+hive-exec-1.2.1.spark.jar
+hive-jdbc-1.2.1.spark.jar
+hive-metastore-1.2.1.spark.jar
+hive-service-1.2.1.spark.jar
 httpclient-4.3.2.jar
 httpcore-4.3.2.jar
 ivy-2.4.0.jar

--- a/dev/deps/spark-deps-hadoop-2.3
+++ b/dev/deps/spark-deps-hadoop-2.3
@@ -109,6 +109,7 @@ jetty-6.1.26.jar
 jetty-all-7.6.0.v20120127.jar
 jetty-util-6.1.26.jar
 jline-2.12.jar
+joda-time-2.9.jar
 jodd-core-3.5.2.jar
 jpam-1.1.jar
 json-20090211.jar

--- a/dev/deps/spark-deps-hadoop-2.3
+++ b/dev/deps/spark-deps-hadoop-2.3
@@ -109,7 +109,6 @@ jetty-6.1.26.jar
 jetty-all-7.6.0.v20120127.jar
 jetty-util-6.1.26.jar
 jline-2.12.jar
-joda-time-2.9.jar
 jodd-core-3.5.2.jar
 jpam-1.1.jar
 json-20090211.jar

--- a/dev/deps/spark-deps-hadoop-2.4
+++ b/dev/deps/spark-deps-hadoop-2.4
@@ -110,7 +110,6 @@ jetty-6.1.26.jar
 jetty-all-7.6.0.v20120127.jar
 jetty-util-6.1.26.jar
 jline-2.12.jar
-joda-time-2.9.jar
 jodd-core-3.5.2.jar
 jpam-1.1.jar
 json-20090211.jar

--- a/dev/deps/spark-deps-hadoop-2.4
+++ b/dev/deps/spark-deps-hadoop-2.4
@@ -73,6 +73,12 @@ hadoop-yarn-client-2.4.0.jar
 hadoop-yarn-common-2.4.0.jar
 hadoop-yarn-server-common-2.4.0.jar
 hadoop-yarn-server-web-proxy-2.4.0.jar
+hive-beeline-1.2.1.spark.jar
+hive-cli-1.2.1.spark.jar
+hive-exec-1.2.1.spark.jar
+hive-jdbc-1.2.1.spark.jar
+hive-metastore-1.2.1.spark.jar
+hive-service-1.2.1.spark.jar
 httpclient-4.3.2.jar
 httpcore-4.3.2.jar
 ivy-2.4.0.jar

--- a/dev/deps/spark-deps-hadoop-2.4
+++ b/dev/deps/spark-deps-hadoop-2.4
@@ -29,7 +29,7 @@ commons-beanutils-core-1.8.0.jar
 commons-cli-1.2.jar
 commons-codec-1.10.jar
 commons-collections-3.2.2.jar
-commons-compiler-2.7.6.jar
+commons-compiler-2.7.8.jar
 commons-compress-1.4.1.jar
 commons-configuration-1.6.jar
 commons-dbcp-1.4.jar

--- a/dev/deps/spark-deps-hadoop-2.4
+++ b/dev/deps/spark-deps-hadoop-2.4
@@ -110,6 +110,7 @@ jetty-6.1.26.jar
 jetty-all-7.6.0.v20120127.jar
 jetty-util-6.1.26.jar
 jline-2.12.jar
+joda-time-2.9.jar
 jodd-core-3.5.2.jar
 jpam-1.1.jar
 json-20090211.jar

--- a/dev/deps/spark-deps-hadoop-2.6
+++ b/dev/deps/spark-deps-hadoop-2.6
@@ -78,6 +78,12 @@ hadoop-yarn-client-2.6.0.jar
 hadoop-yarn-common-2.6.0.jar
 hadoop-yarn-server-common-2.6.0.jar
 hadoop-yarn-server-web-proxy-2.6.0.jar
+hive-beeline-1.2.1.spark.jar
+hive-cli-1.2.1.spark.jar
+hive-exec-1.2.1.spark.jar
+hive-jdbc-1.2.1.spark.jar
+hive-metastore-1.2.1.spark.jar
+hive-service-1.2.1.spark.jar
 htrace-core-3.0.4.jar
 httpclient-4.3.2.jar
 httpcore-4.3.2.jar

--- a/dev/deps/spark-deps-hadoop-2.6
+++ b/dev/deps/spark-deps-hadoop-2.6
@@ -116,6 +116,7 @@ jetty-6.1.26.jar
 jetty-all-7.6.0.v20120127.jar
 jetty-util-6.1.26.jar
 jline-2.12.jar
+joda-time-2.9.jar
 jodd-core-3.5.2.jar
 jpam-1.1.jar
 json-20090211.jar

--- a/dev/deps/spark-deps-hadoop-2.6
+++ b/dev/deps/spark-deps-hadoop-2.6
@@ -116,7 +116,6 @@ jetty-6.1.26.jar
 jetty-all-7.6.0.v20120127.jar
 jetty-util-6.1.26.jar
 jline-2.12.jar
-joda-time-2.9.jar
 jodd-core-3.5.2.jar
 jpam-1.1.jar
 json-20090211.jar

--- a/dev/deps/spark-deps-hadoop-2.6
+++ b/dev/deps/spark-deps-hadoop-2.6
@@ -33,7 +33,7 @@ commons-beanutils-core-1.8.0.jar
 commons-cli-1.2.jar
 commons-codec-1.10.jar
 commons-collections-3.2.2.jar
-commons-compiler-2.7.6.jar
+commons-compiler-2.7.8.jar
 commons-compress-1.4.1.jar
 commons-configuration-1.6.jar
 commons-dbcp-1.4.jar

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -116,6 +116,7 @@ jetty-6.1.26.jar
 jetty-all-7.6.0.v20120127.jar
 jetty-util-6.1.26.jar
 jline-2.12.jar
+joda-time-2.9.jar
 jodd-core-3.5.2.jar
 jpam-1.1.jar
 json-20090211.jar

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -116,7 +116,6 @@ jetty-6.1.26.jar
 jetty-all-7.6.0.v20120127.jar
 jetty-util-6.1.26.jar
 jline-2.12.jar
-joda-time-2.9.jar
 jodd-core-3.5.2.jar
 jpam-1.1.jar
 json-20090211.jar

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -33,7 +33,7 @@ commons-beanutils-core-1.8.0.jar
 commons-cli-1.2.jar
 commons-codec-1.10.jar
 commons-collections-3.2.2.jar
-commons-compiler-2.7.6.jar
+commons-compiler-2.7.8.jar
 commons-compress-1.4.1.jar
 commons-configuration-1.6.jar
 commons-dbcp-1.4.jar

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -78,6 +78,12 @@ hadoop-yarn-client-2.7.0.jar
 hadoop-yarn-common-2.7.0.jar
 hadoop-yarn-server-common-2.7.0.jar
 hadoop-yarn-server-web-proxy-2.7.0.jar
+hive-beeline-1.2.1.spark.jar
+hive-cli-1.2.1.spark.jar
+hive-exec-1.2.1.spark.jar
+hive-jdbc-1.2.1.spark.jar
+hive-metastore-1.2.1.spark.jar
+hive-service-1.2.1.spark.jar
 htrace-core-3.1.0-incubating.jar
 httpclient-4.3.2.jar
 httpcore-4.3.2.jar

--- a/dev/test-dependencies.sh
+++ b/dev/test-dependencies.sh
@@ -81,7 +81,7 @@ for HADOOP_PROFILE in "${HADOOP_PROFILES[@]}"; do
   $MVN $HADOOP2_MODULE_PROFILES -P$HADOOP_PROFILE dependency:build-classpath -pl assembly \
     | grep "Building Spark Project Assembly" -A 5 \
     | tail -n 1 | tr ":" "\n" | rev | cut -d "/" -f 1 | rev | sort \
-    | grep -v spark > dev/pr-deps/spark-deps-$HADOOP_PROFILE
+    | grep -v ^spark > dev/pr-deps/spark-deps-$HADOOP_PROFILE
 done
 
 if [[ $@ == **replace-manifest** ]]; then

--- a/external/flume-assembly/pom.xml
+++ b/external/flume-assembly/pom.xml
@@ -96,7 +96,6 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro-mapred</artifactId>
-      <classifier>${avro.mapred.classifier}</classifier>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/external/kafka-assembly/pom.xml
+++ b/external/kafka-assembly/pom.xml
@@ -88,7 +88,6 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro-mapred</artifactId>
-      <classifier>${avro.mapred.classifier}</classifier>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/external/kinesis-asl-assembly/pom.xml
+++ b/external/kinesis-asl-assembly/pom.xml
@@ -98,7 +98,6 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro-mapred</artifactId>
-      <classifier>${avro.mapred.classifier}</classifier>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -404,12 +404,6 @@
         <artifactId>selenium-java</artifactId>
         <version>2.45.0</version> <!-- 2.46.0+ requires Jetty 9 -->
         <scope>test</scope>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <!-- Added for selenium only, and should match its dependent version: -->
       <dependency>
@@ -565,18 +559,10 @@
         <artifactId>jackson-annotations</artifactId>
         <version>${fasterxml.jackson.version}</version>
       </dependency>
-      <!-- Guava is excluded because of SPARK-6149.  The Guava version referenced in this module is
-           15.0, which causes runtime incompatibility issues. -->
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
         <version>${fasterxml.jackson.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.sun.jersey</groupId>
@@ -675,10 +661,6 @@
         <version>3.4.0</version>
         <scope>test</scope>
         <exclusions>
-          <exclusion>
-            <artifactId>guava</artifactId>
-            <groupId>com.google.guava</groupId>
-          </exclusion>
           <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
@@ -1280,10 +1262,6 @@
             <groupId>org.mortbay.jetty</groupId>
             <artifactId>servlet-api</artifactId>
           </exclusion>
-          <exclusion>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-          </exclusion>
         </exclusions>
       </dependency>
 
@@ -1367,10 +1345,6 @@
         <scope>${hive.deps.scope}</scope>
         <exclusions>
           <exclusion>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-yarn-server-resourcemanager</artifactId>
           </exclusion>
@@ -1450,10 +1424,6 @@
         <!-- Version matches Hive 1.2.1's version -->
         <version>1.2.0-incubating</version>
         <exclusions>
-          <exclusion>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-          </exclusion>
           <exclusion>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1188,10 +1188,6 @@
             <artifactId>kryo</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro-mapred</artifactId>
           </exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -1567,6 +1567,9 @@
                            in different artifacts. To avoid hard-to-debug conflicts, we choose to
                            exclude org.ow2.asm (ASM 4) in favor of asm.asm (ASM 3). -->
                       <exclude>org.ow2.asm</exclude>
+                      <!-- We don't want to depend on mockito-all, which bundles its transitive
+                           dependencies; we use the regular mockito-core dependency instead. -->
+                      <exclude>org.mockito:mockito-all</exclude>
                     </excludes>
                     <searchTransitive>true</searchTransitive>
                   </bannedDependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -562,6 +562,11 @@
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>${fasterxml.jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
         <version>${fasterxml.jackson.version}</version>
       </dependency>
@@ -1638,10 +1643,6 @@
         <artifactId>calcite-core</artifactId>
         <exclusions>
           <exclusion>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
           </exclusion>
@@ -1660,16 +1661,6 @@
           <exclusion>
             <groupId>org.pentaho</groupId>
             <artifactId>pentaho-aggdesigner-algorithm</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.calcite</groupId>
-        <artifactId>calcite-avatica</artifactId>
-        <exclusions>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,6 @@
     <oro.version>2.0.8</oro.version>
     <codahale.metrics.version>3.1.2</codahale.metrics.version>
     <avro.version>1.7.7</avro.version>
-    <avro.mapred.classifier>hadoop2</avro.mapred.classifier>
     <jets3t.version>0.7.1</jets3t.version>
     <aws.kinesis.client.version>1.6.1</aws.kinesis.client.version>
     <!-- the producer is used in tests -->
@@ -827,10 +826,7 @@
         <groupId>org.apache.avro</groupId>
         <artifactId>avro-mapred</artifactId>
         <version>${avro.version}</version>
-        <!-- use the build matching the hadoop api of avro-mapred (i.e. no classifier for hadoop 1
-             API, adoop2 classifier for hadoop 2 API. avro-mapred is a dependency of
-             org.spark-project.hive:hive-serde -->
-        <classifier>${avro.mapred.classifier}</classifier>
+        <classifier>hadoop2</classifier>
         <scope>${hive.deps.scope}</scope>
         <exclusions>
           <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,6 @@
     <commons-lang2.version>2.6</commons-lang2.version>
     <!-- org.apache.commons/commons-lang3/-->
     <commons-lang3.version>3.3.2</commons-lang3.version>
-    <datanucleus-core.version>3.2.10</datanucleus-core.version>
     <janino.version>2.7.8</janino.version>
     <jersey.version>1.9</jersey.version>
     <joda.version>2.9</joda.version>
@@ -1715,11 +1714,6 @@
         <groupId>joda-time</groupId>
         <artifactId>joda-time</artifactId>
         <version>${joda.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.datanucleus</groupId>
-        <artifactId>datanucleus-core</artifactId>
-        <version>${datanucleus-core.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.thrift</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1558,6 +1558,7 @@
                       -->
                       <exclude>org.jboss.netty</exclude>
                       <exclude>org.codehaus.groovy</exclude>
+                      <exclude>javax.servlet:servlet-api</exclude>
                       <!-- hsqldb interferes with the use of Derby as the default db
                            in Hive's use of Datanucleus. -->
                       <exclude>org.hsqldb:hsqldb</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,6 @@
     <fasterxml.jackson.version>2.5.3</fasterxml.jackson.version>
     <snappy.version>1.1.2.4</snappy.version>
     <netlib.java.version>1.1.2</netlib.java.version>
-    <calcite.version>1.2.0-incubating</calcite.version>
     <commons-codec.version>1.10</commons-codec.version>
     <!-- org.apache.commons/commons-lang/-->
     <commons-lang2.version>2.6</commons-lang2.version>
@@ -1642,7 +1641,6 @@
       <dependency>
         <groupId>org.apache.calcite</groupId>
         <artifactId>calcite-core</artifactId>
-        <version>${calcite.version}</version>
         <exclusions>
           <exclusion>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -1681,7 +1679,6 @@
       <dependency>
         <groupId>org.apache.calcite</groupId>
         <artifactId>calcite-avatica</artifactId>
-        <version>${calcite.version}</version>
         <exclusions>
           <exclusion>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -272,11 +272,7 @@
         <exclusions>
           <exclusion>
             <groupId>org.ow2.asm</groupId>
-            <artifactId>asm</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.ow2.asm</groupId>
-            <artifactId>asm-commons</artifactId>
+            <artifactId>*</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -287,11 +283,7 @@
         <exclusions>
           <exclusion>
             <groupId>org.ow2.asm</groupId>
-            <artifactId>asm</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.ow2.asm</groupId>
-            <artifactId>asm-commons</artifactId>
+            <artifactId>*</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -693,6 +685,21 @@
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
+          <!-- ASM is actually relocated inside of the docker-client JAR but is not relocated.
+               Ordinarily, this would be a problem but in our case it's fine because this package
+               is only used in a handful of unit tests which are isolated to their own Maven
+               project. For more details, see https://github.com/spotify/docker-client/pull/272.
+               We need to add these exclusions here because the 'shaded' classifier only affects
+               the JAR contents and does not impact the resolution of transitive dependencies.
+               These exclusions are here to make Maven Enforcer happy. -->
+          <exclusion>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-commons</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -751,7 +758,7 @@
           </exclusion>
           <exclusion>
             <groupId>org.ow2.asm</groupId>
-            <artifactId>asm</artifactId>
+            <artifactId>*</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.jboss.netty</groupId>
@@ -879,7 +886,7 @@
           </exclusion>
           <exclusion>
             <groupId>org.ow2.asm</groupId>
-            <artifactId>asm</artifactId>
+            <artifactId>*</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.jboss.netty</groupId>
@@ -903,7 +910,7 @@
           </exclusion>
           <exclusion>
             <groupId>org.ow2.asm</groupId>
-            <artifactId>asm</artifactId>
+            <artifactId>*</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.jboss.netty</groupId>
@@ -932,7 +939,7 @@
           </exclusion>
           <exclusion>
             <groupId>org.ow2.asm</groupId>
-            <artifactId>asm</artifactId>
+            <artifactId>*</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.jboss.netty</groupId>
@@ -1569,6 +1576,11 @@
                       <!-- hsqldb interferes with the use of Derby as the default db
                            in Hive's use of Datanucleus. -->
                       <exclude>org.hsqldb:hsqldb</exclude>
+                      <!-- Our direct ASM dependency is via a shaded JAR, but our transitive deps.
+                           depend on a mixture of ASM artifacts which publish the same classes
+                           in different artifacts. To avoid hard-to-debug conflicts, we choose to
+                           exclude org.ow2.asm (ASM 4) in favor of asm.asm (ASM 3). -->
+                      <exclude>org.ow2.asm</exclude>
                     </excludes>
                     <searchTransitive>true</searchTransitive>
                   </bannedDependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1315,10 +1315,6 @@
             <artifactId>libthrift</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>org.apache.thrift</groupId>
-            <artifactId>libfb303</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
           </exclusion>
@@ -1358,10 +1354,6 @@
           <exclusion>
             <groupId>${hive.group}</groupId>
             <artifactId>hive-shims</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.thrift</groupId>
-            <artifactId>libfb303</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.apache.thrift</groupId>
@@ -1407,10 +1399,6 @@
           <exclusion>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.thrift</groupId>
-            <artifactId>libfb303</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.slf4j</groupId>
@@ -1464,10 +1452,6 @@
           <exclusion>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-recipes</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.thrift</groupId>
-            <artifactId>libfb303</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.apache.thrift</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1175,6 +1175,12 @@
             <groupId>ant</groupId>
             <artifactId>ant</artifactId>
           </exclusion>
+          <!-- Calcite is excluded here and explicitly re-added in hive/pom.xml;
+               see comments there for full explanation. -->
+          <exclusion>
+            <groupId>org.apache.calcite</groupId>
+            <artifactId>calcite-core</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
@@ -1444,6 +1450,8 @@
       <dependency>
         <groupId>org.apache.calcite</groupId>
         <artifactId>calcite-core</artifactId>
+        <!-- Version matches Hive 1.2.1's version -->
+        <version>1.2.0-incubating</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -757,10 +757,6 @@
             <artifactId>asm</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
           </exclusion>
@@ -1643,15 +1639,7 @@
         <exclusions>
           <exclusion>
             <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
           </exclusion>
           <exclusion>
             <groupId>com.google.guava</groupId>
@@ -1681,15 +1669,7 @@
         <exclusions>
           <exclusion>
             <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1506,12 +1506,6 @@
         <groupId>org.apache.thrift</groupId>
         <artifactId>libthrift</artifactId>
         <version>${libthrift.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.thrift</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1186,9 +1186,6 @@
       <dependency>
         <groupId>${hive.group}</groupId>
         <artifactId>hive-exec</artifactId>
-<!--
-        <classifier>core</classifier>
--->
         <version>${hive.version}</version>
         <scope>${hive.deps.scope}</scope>
         <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,7 @@
     <commons-lang3.version>3.3.2</commons-lang3.version>
     <janino.version>2.7.8</janino.version>
     <jersey.version>1.9</jersey.version>
+    <joda.version>2.9</joda.version>
     <jsr305.version>1.3.9</jsr305.version>
     <libthrift.version>0.9.2</libthrift.version>
     <antlr4.version>4.5.2-1</antlr4.version>
@@ -1476,6 +1477,11 @@
         <groupId>org.codehaus.janino</groupId>
         <artifactId>commons-compiler</artifactId>
         <version>${janino.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>joda-time</groupId>
+        <artifactId>joda-time</artifactId>
+        <version>${joda.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.thrift</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1184,8 +1184,8 @@
             <artifactId>ant</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>com.esotericsoftware.kryo</groupId>
-            <artifactId>kryo</artifactId>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>*</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.apache.avro</groupId>
@@ -1206,10 +1206,6 @@
           <exclusion>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.thrift</groupId>
-            <artifactId>libfb303</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.apache.zookeeper</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1412,10 +1412,6 @@
             <artifactId>commons-codec</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
           </exclusion>
@@ -1625,10 +1621,6 @@
           <exclusion>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.codehaus.janino</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,6 @@
     <janino.version>2.7.8</janino.version>
     <jersey.version>1.9</jersey.version>
     <joda.version>2.9</joda.version>
-    <jodd.version>3.5.2</jodd.version>
     <jsr305.version>1.3.9</jsr305.version>
     <libthrift.version>0.9.2</libthrift.version>
     <antlr4.version>4.5.2-1</antlr4.version>
@@ -1716,11 +1715,6 @@
         <groupId>joda-time</groupId>
         <artifactId>joda-time</artifactId>
         <version>${joda.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jodd</groupId>
-        <artifactId>jodd-core</artifactId>
-        <version>${jodd.version}</version>
       </dependency>
       <dependency>
         <groupId>org.datanucleus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1473,6 +1473,11 @@
         <version>${janino.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.codehaus.janino</groupId>
+        <artifactId>commons-compiler</artifactId>
+        <version>${janino.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.thrift</groupId>
         <artifactId>libthrift</artifactId>
         <version>${libthrift.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -832,6 +832,9 @@
         <groupId>org.apache.avro</groupId>
         <artifactId>avro-mapred</artifactId>
         <version>${avro.version}</version>
+        <!-- use the build matching the hadoop api of avro-mapred (i.e. no classifier for hadoop 1
+             API, adoop2 classifier for hadoop 2 API. avro-mapred is a dependency of
+             org.spark-project.hive:hive-serde -->
         <classifier>${avro.mapred.classifier}</classifier>
         <scope>${hive.deps.scope}</scope>
         <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -1137,10 +1137,6 @@
             <artifactId>ant</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>org.apache.zookeeper</groupId>
-            <artifactId>zookeeper</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
@@ -1208,10 +1204,6 @@
             <artifactId>libthrift</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>org.apache.zookeeper</groupId>
-            <artifactId>zookeeper</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
@@ -1257,10 +1249,6 @@
           <exclusion>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.zookeeper</groupId>
-            <artifactId>zookeeper</artifactId>
           </exclusion>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -1404,10 +1392,6 @@
           <exclusion>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.zookeeper</groupId>
-            <artifactId>zookeeper</artifactId>
           </exclusion>
           <exclusion>
             <groupId>commons-logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1673,9 +1673,6 @@
             <groupId>org.codehaus.janino</groupId>
             <artifactId>janino</artifactId>
           </exclusion>
-          <!-- hsqldb interferes with the use of derby as the default db
-            in hive's use of datanucleus.
-          -->
           <exclusion>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
@@ -1793,6 +1790,9 @@
                       -->
                       <exclude>org.jboss.netty</exclude>
                       <exclude>org.codehaus.groovy</exclude>
+                      <!-- hsqldb interferes with the use of Derby as the default db
+                           in Hive's use of Datanucleus. -->
+                      <exclude>org.hsqldb:hsqldb</exclude>
                     </excludes>
                     <searchTransitive>true</searchTransitive>
                   </bannedDependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1187,17 +1187,11 @@
             <groupId>org.apache.avro</groupId>
             <artifactId>avro-mapred</artifactId>
           </exclusion>
+          <!-- We need to keep this exclusion here because hive-exec pulls in a dependency on the
+               curator POM -->
           <exclusion>
             <groupId>org.apache.curator</groupId>
             <artifactId>apache-curator</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.curator</groupId>
-            <artifactId>curator-client</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.curator</groupId>
-            <artifactId>curator-framework</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.apache.thrift</groupId>
@@ -1346,14 +1340,6 @@
             <artifactId>hive-shims</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>org.apache.curator</groupId>
-            <artifactId>curator-framework</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.curator</groupId>
-            <artifactId>curator-recipes</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
           </exclusion>
@@ -1384,10 +1370,6 @@
           <exclusion>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-yarn-server-resourcemanager</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.curator</groupId>
-            <artifactId>curator-framework</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.apache.thrift</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -683,7 +683,7 @@
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
-          <!-- ASM is actually relocated inside of the docker-client JAR but is not relocated.
+          <!-- ASM is actually packaged inside of the docker-client JAR but is not relocated.
                Ordinarily, this would be a problem but in our case it's fine because this package
                is only used in a handful of unit tests which are isolated to their own Maven
                project. For more details, see https://github.com/spotify/docker-client/pull/272.

--- a/pom.xml
+++ b/pom.xml
@@ -1608,10 +1608,6 @@
             <artifactId>guava</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>org.codehaus.janino</groupId>
-            <artifactId>janino</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
           </exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -1251,11 +1251,6 @@
             <groupId>org.apache.avro</groupId>
             <artifactId>avro-mapred</artifactId>
           </exclusion>
-          <!--  this is needed and must be explicitly included later-->
-          <exclusion>
-            <groupId>org.apache.calcite</groupId>
-            <artifactId>calcite-core</artifactId>
-          </exclusion>
           <exclusion>
             <groupId>org.apache.curator</groupId>
             <artifactId>apache-curator</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,6 @@
     <commons-lang3.version>3.3.2</commons-lang3.version>
     <janino.version>2.7.8</janino.version>
     <jersey.version>1.9</jersey.version>
-    <joda.version>2.9</joda.version>
     <jsr305.version>1.3.9</jsr305.version>
     <libthrift.version>0.9.2</libthrift.version>
     <antlr4.version>4.5.2-1</antlr4.version>
@@ -1698,11 +1697,6 @@
         <groupId>org.codehaus.janino</groupId>
         <artifactId>janino</artifactId>
         <version>${janino.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>joda-time</groupId>
-        <artifactId>joda-time</artifactId>
-        <version>${joda.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.thrift</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -690,18 +690,6 @@
             <groupId>com.google.guava</groupId>
           </exclusion>
           <exclusion>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>httpclient</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
@@ -1326,14 +1314,6 @@
             <artifactId>hive-shims</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-framework</artifactId>
           </exclusion>
@@ -1675,14 +1655,6 @@
         <version>${libthrift.version}</version>
         <exclusions>
           <exclusion>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
           </exclusion>
@@ -1693,14 +1665,6 @@
         <artifactId>libfb303</artifactId>
         <version>${libthrift.version}</version>
         <exclusions>
-          <exclusion>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-          </exclusion>
           <exclusion>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1073,18 +1073,6 @@
             <artifactId>libthrift</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
@@ -1129,18 +1117,6 @@
             <artifactId>libthrift</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
@@ -1163,18 +1139,6 @@
           <exclusion>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
           </exclusion>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -1256,18 +1220,6 @@
             <artifactId>zookeeper</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
@@ -1319,18 +1271,6 @@
             <artifactId>zookeeper</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
@@ -1367,14 +1307,6 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
           </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-          </exclusion>
         </exclusions>
       </dependency>
 
@@ -1399,18 +1331,6 @@
           <exclusion>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
           </exclusion>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -1496,18 +1416,6 @@
           <exclusion>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
           </exclusion>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -1621,12 +1529,6 @@
         <groupId>org.apache.thrift</groupId>
         <artifactId>libfb303</artifactId>
         <version>${libthrift.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1227,10 +1227,6 @@
             <artifactId>kryo</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>commons-httpclient</groupId>
             <artifactId>commons-httpclient</artifactId>
           </exclusion>
@@ -1408,10 +1404,6 @@
             <artifactId>hive-shims</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
           </exclusion>
@@ -1467,10 +1459,6 @@
           <exclusion>
             <groupId>${hive.group}</groupId>
             <artifactId>hive-shims</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.apache.curator</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -409,10 +409,6 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
           </exclusion>
-          <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty</artifactId>
-          </exclusion>
         </exclusions>
       </dependency>
       <!-- Added for selenium only, and should match its dependent version: -->
@@ -517,11 +513,13 @@
         <artifactId>netty-all</artifactId>
         <version>4.0.29.Final</version>
       </dependency>
+      <!-- Spark 2.x doesn't have a direct dependency on io.netty:netty, but we leave this
+           entry in order to prevent a downgrade of our transitive io.netty:netty dependency -->
       <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty</artifactId>
-        <version>3.8.0.Final</version>
-      </dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty</artifactId>
+         <version>3.8.0.Final</version>
+       </dependency>
       <dependency>
         <groupId>org.apache.derby</groupId>
         <artifactId>derby</artifactId>
@@ -799,10 +797,6 @@
         <scope>${hadoop.deps.scope}</scope>
         <exclusions>
           <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>org.mortbay.jetty</groupId>
             <artifactId>jetty</artifactId>
           </exclusion>
@@ -838,10 +832,6 @@
         <classifier>${avro.mapred.classifier}</classifier>
         <scope>${hive.deps.scope}</scope>
         <exclusions>
-          <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty</artifactId>
-          </exclusion>
           <exclusion>
             <groupId>org.mortbay.jetty</groupId>
             <artifactId>jetty</artifactId>
@@ -1464,10 +1454,6 @@
         <scope>${flume.deps.scope}</scope>
         <exclusions>
           <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>org.apache.flume</groupId>
             <artifactId>flume-ng-auth</artifactId>
           </exclusion>
@@ -1487,10 +1473,6 @@
         <version>${flume.version}</version>
         <scope>${flume.deps.scope}</scope>
         <exclusions>
-          <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty</artifactId>
-          </exclusion>
           <exclusion>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>

--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -62,48 +62,18 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-test-tags_${scala.binary.version}</artifactId>
     </dependency>
-<!--
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-      <version>${protobuf.version}</version>
-    </dependency>
--->
     <dependency>
       <groupId>${hive.group}</groupId>
       <artifactId>hive-cli</artifactId>
     </dependency>
-<!--
-    <dependency>
-      <groupId>${hive.group}</groupId>
-      <artifactId>hive-common</artifactId>
-    </dependency>
--->
     <dependency>
       <groupId>${hive.group}</groupId>
       <artifactId>hive-exec</artifactId>
-<!--
-      <classifier>core</classifier>
--->
     </dependency>
     <dependency>
       <groupId>${hive.group}</groupId>
       <artifactId>hive-metastore</artifactId>
     </dependency>
-    <!--
-        <dependency>
-          <groupId>${hive.group}</groupId>
-          <artifactId>hive-serde</artifactId>
-        </dependency>
-        <dependency>
-          <groupId>${hive.group}</groupId>
-          <artifactId>hive-shims</artifactId>
-        </dependency>
-    -->
     <!-- hive-serde already depends on avro, but this brings in customized config of avro deps from parent -->
     <dependency>
       <groupId>org.apache.avro</groupId>

--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -146,10 +146,6 @@
       <artifactId>joda-time</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jodd</groupId>
-      <artifactId>jodd-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
     </dependency>

--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -78,6 +78,15 @@
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
     </dependency>
+    <!-- This direct dependency shouldn't be strictly necessary, since Hive will transitively
+         include the required Calcite dependencies, but we need to add this explicit dependency
+         so that our dependencyManament excludes prevent pentaho-aggdesigner-algorithm from being
+         resolved: that artifact is not present in Maven Central and therefore breaks the SBT
+         build. For discussion and details, see https://github.com/apache/spark/pull/12171 -->
+    <dependency>
+      <groupId>org.apache.calcite</groupId>
+      <artifactId>calcite-core</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.apache.thrift</groupId>
       <artifactId>libthrift</artifactId>

--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -134,10 +134,6 @@
       <artifactId>commons-codec</artifactId>
     </dependency>
     <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
     </dependency>

--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -118,10 +118,6 @@
     </dependency>
     <!-- transitive dependencies of hive-exec-core doesn't declare -->
     <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.thrift</groupId>
       <artifactId>libthrift</artifactId>
     </dependency>

--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -86,14 +86,9 @@
       <artifactId>avro-mapred</artifactId>
       <classifier>${avro.mapred.classifier}</classifier>
     </dependency>
-    <!-- transitive dependencies of hive-exec-core doesn't declare -->
     <dependency>
       <groupId>org.apache.thrift</groupId>
       <artifactId>libthrift</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.thrift</groupId>
-      <artifactId>libfb303</artifactId>
     </dependency>
     <dependency>
       <groupId>org.scalacheck</groupId>

--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -121,14 +121,6 @@
       <artifactId>commons-httpclient</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.calcite</groupId>
-      <artifactId>calcite-avatica</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.calcite</groupId>
-      <artifactId>calcite-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
     </dependency>

--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -74,17 +74,9 @@
       <groupId>${hive.group}</groupId>
       <artifactId>hive-metastore</artifactId>
     </dependency>
-    <!-- hive-serde already depends on avro, but this brings in customized config of avro deps from parent -->
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
-    </dependency>
-    <!-- use the build matching the hadoop api of avro-mapred (i.e. no classifier for hadoop 1 API,
-    hadoop2 classifier for hadoop 2 API. avro-mapred is a dependency of org.spark-project.hive:hive-serde -->
-    <dependency>
-      <groupId>org.apache.avro</groupId>
-      <artifactId>avro-mapred</artifactId>
-      <classifier>${avro.mapred.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>org.apache.thrift</groupId>

--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -150,10 +150,6 @@
       <artifactId>jsr305</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.datanucleus</groupId>
-      <artifactId>datanucleus-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.thrift</groupId>
       <artifactId>libthrift</artifactId>
     </dependency>

--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -124,10 +124,6 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-    </dependency>
     <!-- transitive dependencies of hive-exec-core doesn't declare -->
     <dependency>
       <groupId>commons-codec</groupId>

--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -122,10 +122,6 @@
       <artifactId>commons-codec</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.thrift</groupId>
       <artifactId>libthrift</artifactId>
     </dependency>

--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -116,14 +116,6 @@
       <artifactId>avro-mapred</artifactId>
       <classifier>${avro.mapred.classifier}</classifier>
     </dependency>
-    <dependency>
-      <groupId>commons-httpclient</groupId>
-      <artifactId>commons-httpclient</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-    </dependency>
     <!-- transitive dependencies of hive-exec-core doesn't declare -->
     <dependency>
       <groupId>commons-codec</groupId>

--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -80,12 +80,18 @@
     </dependency>
     <!-- This direct dependency shouldn't be strictly necessary, since Hive will transitively
          include the required Calcite dependencies, but we need to add this explicit dependency
-         so that our dependencyManament excludes prevent pentaho-aggdesigner-algorithm from being
+         so that our dependencyManagement excludes prevent pentaho-aggdesigner-algorithm from being
          resolved: that artifact is not present in Maven Central and therefore breaks the SBT
          build. For discussion and details, see https://github.com/apache/spark/pull/12171 -->
     <dependency>
       <groupId>org.apache.calcite</groupId>
       <artifactId>calcite-core</artifactId>
+    </dependency>
+    <!-- Although Spark doesn't directly depend on joda-time, Hive seems to need it because removing
+         this dependency breaks the Hive tests; see https://github.com/apache/spark/pull/12171. -->
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.thrift</groupId>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -76,7 +76,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.4.1</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -71,6 +71,16 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
       </plugin>
+      <!-- This project is only used to hold the MiMa exclude generator, so we don't care
+           whether normally-banned dependencies are used here. Therefore, skpi enforcer: -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.4.1</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
This patch aims to simplify our build by removing a number of unnecessary excludes. The individual commit messages describe the changes here in more detail, but there are a few key themes:
- **Remove many excludes in the root POM:** According to the [Maven documentation](ttps://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Management), "dependency management takes precedence over dependency mediation". In many cases, we were both excluding transitive dependencies while also using those dependencies in `spark-core` and pinning those dependencies' versions in the `dependencyManagment` section of our POM.
  
  As a rough guideline, I think like we should only exclude dependencies under the following scenarios:
  - We don't want the dependency at all, in which case we should define a Maven Enforcer rule to ban it.
  - We want to include _some_ version of the dependency but don't want to explicitly specify a fixed version. For instance, imagine that libraries A and B depend on some dependency C. We might exclude C from library B so that library A's version of C becomes the final effective version.
  - We want to include the dependency only when certain profiles are enabled, so we ban it from all of our transitive dependencies and explicitly re-add it in a profile.
- **Remove explicitly-promoted transitive dependencies from Hive POM:** in an early revision of #7191, it looks like we tried to use the `core`-classified version of `hive-exec`, which is published as a thin-JAR which does not bundle third-party dependencies' classes. However, both the regular and classified versions of the dependency share the same effective POM, which, in this case, happens to be the dependency-reduced-POM produced by the Maven shade plugin. As a result, users of the `core`-classified JAR must add direct dependencies on what are logically transitive dependencies of `hive-exec`, so #7191 added several such dependencies in `hive/pom.xml`.
  
  However, by the end of #7191 we abandoned the idea of using an existing Hive JAR and chose to republish our own JAR, so this promotion of transitive dependencies is no longer necessary.  As a result, this patch was able to significantly cut down the size of the `hive` POM by removing those direct dependencies. This had the side-effect of exposing a problem where one of our Janino JARs was being pulled to a lower version as a side-effect of this unnecessary dependency promotion.
- **Use Maven's new wildcard exclude support:** Maven now supports wildcard exclusion patterns, so I used that to simplify the exclusion of `org.ow2.asm` artifacts.
- **Improve `dev/test-dependencies`:** a bad regex caused the `org.spark-project:hive` JARs to not be listed under `dev/deps`; this is now fixed.
- **Remove explicit `io.netty` dependency**: we don't seem to need this anymore. I did leave the `dependencyManagement` entry for now in order to prevent an unexpected downgrade.

/cc @srowen @steveloughran @vanzin @pwendell @rxin for review.
