### PR TITLE
[SPARK-13792][SQL] Limit logging of bad records in CSVRelation

### DIFF
--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -351,6 +351,9 @@ class DataFrameReader(object):
         :param maxCharsPerColumn: defines the maximum number of characters allowed for any given
                                   value being read. If None is set, it uses the default value,
                                   ``1000000``.
+        :param maxLogRecordsPerPartition: defines the maximum number of logs for the malformed
+                                          records that is going to be ignored. If None is set, it
+                                          uses the default value, ``1``.
         :param mode: allows a mode for dealing with corrupt records during parsing. If None is
                      set, it uses the default value, ``PERMISSIVE``.
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -394,6 +394,8 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
    * a record can have.</li>
    * <li>`maxCharsPerColumn` (default `1000000`): defines the maximum number of characters allowed
    * for any given value being read.</li>
+   * <li>`maxLogRecordsPerPartition` (default `1`): defines the maximum number of logs for the
+   * malformed records that is going to be ignored.</li>
    * <li>`mode` (default `PERMISSIVE`): allows a mode for dealing with corrupt records
    *    during parsing.</li>
    * <ul>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ParseModes.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ParseModes.scala
@@ -20,18 +20,20 @@ package org.apache.spark.sql.execution.datasources
 private[datasources] object ParseModes {
   val PERMISSIVE_MODE = "PERMISSIVE"
   val DROP_MALFORMED_MODE = "DROPMALFORMED"
+  val COUNT_MALFORMED_MODE = "COUNTMALFORMED"
   val FAIL_FAST_MODE = "FAILFAST"
 
   val DEFAULT = PERMISSIVE_MODE
 
   def isValidMode(mode: String): Boolean = {
     mode.toUpperCase match {
-      case PERMISSIVE_MODE | DROP_MALFORMED_MODE | FAIL_FAST_MODE => true
+      case PERMISSIVE_MODE | DROP_MALFORMED_MODE | COUNT_MALFORMED_MODE | FAIL_FAST_MODE => true
       case _ => false
     }
   }
 
   def isDropMalformedMode(mode: String): Boolean = mode.toUpperCase == DROP_MALFORMED_MODE
+  def isCountMalformedMode(mode: String): Boolean = mode.toUpperCase == COUNT_MALFORMED_MODE
   def isFailFastMode(mode: String): Boolean = mode.toUpperCase == FAIL_FAST_MODE
   def isPermissiveMode(mode: String): Boolean = if (isValidMode(mode))  {
     mode.toUpperCase == PERMISSIVE_MODE

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ParseModes.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ParseModes.scala
@@ -20,20 +20,18 @@ package org.apache.spark.sql.execution.datasources
 private[datasources] object ParseModes {
   val PERMISSIVE_MODE = "PERMISSIVE"
   val DROP_MALFORMED_MODE = "DROPMALFORMED"
-  val COUNT_MALFORMED_MODE = "COUNTMALFORMED"
   val FAIL_FAST_MODE = "FAILFAST"
 
   val DEFAULT = PERMISSIVE_MODE
 
   def isValidMode(mode: String): Boolean = {
     mode.toUpperCase match {
-      case PERMISSIVE_MODE | DROP_MALFORMED_MODE | COUNT_MALFORMED_MODE | FAIL_FAST_MODE => true
+      case PERMISSIVE_MODE | DROP_MALFORMED_MODE | FAIL_FAST_MODE => true
       case _ => false
     }
   }
 
   def isDropMalformedMode(mode: String): Boolean = mode.toUpperCase == DROP_MALFORMED_MODE
-  def isCountMalformedMode(mode: String): Boolean = mode.toUpperCase == COUNT_MALFORMED_MODE
   def isFailFastMode(mode: String): Boolean = mode.toUpperCase == FAIL_FAST_MODE
   def isPermissiveMode(mode: String): Boolean = if (isValidMode(mode))  {
     mode.toUpperCase == PERMISSIVE_MODE

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
@@ -28,6 +28,8 @@ import org.apache.hadoop.mapreduce._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.JoinedRow
+import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types._

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVOptions.scala
@@ -86,6 +86,7 @@ private[sql] class CSVOptions(@transient private val parameters: Map[String, Str
 
   val failFast = ParseModes.isFailFastMode(parseMode)
   val dropMalformed = ParseModes.isDropMalformedMode(parseMode)
+  val countMalformed = ParseModes.isCountMalformedMode(parseMode)
   val permissive = ParseModes.isPermissiveMode(parseMode)
 
   val nullValue = parameters.getOrElse("nullValue", "")
@@ -112,6 +113,9 @@ private[sql] class CSVOptions(@transient private val parameters: Map[String, Str
   val maxCharsPerColumn = getInt("maxCharsPerColumn", 1000000)
 
   val escapeQuotes = getBool("escapeQuotes", true)
+
+  // Only used in the `COUNTMALFORMED` mode
+  val maxStoredMalformedPerPartition = getInt("maxStoredMalformedPerPartition", 1)
 
   val inputBufferSize = 128
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVOptions.scala
@@ -86,7 +86,6 @@ private[sql] class CSVOptions(@transient private val parameters: Map[String, Str
 
   val failFast = ParseModes.isFailFastMode(parseMode)
   val dropMalformed = ParseModes.isDropMalformedMode(parseMode)
-  val countMalformed = ParseModes.isCountMalformedMode(parseMode)
   val permissive = ParseModes.isPermissiveMode(parseMode)
 
   val nullValue = parameters.getOrElse("nullValue", "")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVOptions.scala
@@ -113,8 +113,7 @@ private[sql] class CSVOptions(@transient private val parameters: Map[String, Str
 
   val escapeQuotes = getBool("escapeQuotes", true)
 
-  // Only used in the `COUNTMALFORMED` mode
-  val maxStoredMalformedPerPartition = getInt("maxStoredMalformedPerPartition", 1)
+  val maxLogRecordsPerPartition = getInt("maxLogRecordsPerPartition", 1)
 
   val inputBufferSize = 128
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
@@ -150,7 +150,7 @@ object CSVRelation extends Logging {
     }
   }
 
-  def parseCsvInRdd(
+  private[csv] def parseCsvInRdd(
       tokenizedRDD: RDD[Array[String]],
       schema: StructType,
       requiredColumns: Array[String],
@@ -167,7 +167,7 @@ object CSVRelation extends Logging {
     }
   }
 
-  def parseCsvInIterator(
+  private[csv] def parseCsvInIterator(
       tokenizedIterator: Iterator[Array[String]],
       schema: StructType,
       requiredColumns: Array[String],

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVRelation.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.execution.datasources.csv
 
-import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
 
 import org.apache.hadoop.fs.Path
@@ -35,30 +34,6 @@ import org.apache.spark.sql.execution.command.CreateDataSourceTableUtils
 import org.apache.spark.sql.execution.datasources.{OutputWriter, OutputWriterFactory, PartitionedFile}
 import org.apache.spark.sql.types._
 import org.apache.spark.util.CompletionIterator
-
-/**
- * Stores and counts malformed lines during CSV parsing.
- */
-private[csv] class MalformedLinesInfo(maxStoreMalformed: Int) extends Serializable {
-
-  var malformedLines = new ArrayBuffer[String]
-  var malformedLineNum = 0
-
-  def add(line: String): Unit = {
-    if (malformedLines.size < maxStoreMalformed) {
-      malformedLines += line
-    }
-    malformedLineNum = malformedLineNum + 1
-  }
-
-  override def toString: String =
-    s"""
-       |# of total malformed lines: ${malformedLineNum}
-       |${malformedLines.size} malformed lines extracted and listed as follows;
-       |${malformedLines.mkString("\n")}
-     """.stripMargin.trim
-}
-
 
 object CSVRelation extends Logging {
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CsvUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CsvUtils.scala
@@ -17,31 +17,23 @@
 
 package org.apache.spark.sql.execution.datasources.csv
 
-import scala.collection.mutable.ArrayBuffer
+import org.apache.spark.internal.Logging
 
 /**
- * Stores and counts malformed lines during CSV parsing.
+ * Logs and counts malformed lines during CSV parsing.
  */
-private[csv] class MalformedLinesInfo(maxStoreMalformed: Int) extends Serializable {
+private[csv] class MalformedLinesInfo(maxStoreMalformed: Int) extends Serializable with Logging {
 
-  var malformedLines = new ArrayBuffer[String]
   var malformedLineNum = 0
 
   def add(line: String): Unit = {
-    if (malformedLines.size < maxStoreMalformed) {
-      malformedLines += line
+    if (malformedLineNum < maxStoreMalformed) {
+      logWarning(s"Parse exception. Dropping malformed line: ${line}")
     }
     malformedLineNum = malformedLineNum + 1
   }
 
   override def toString: String = {
-    (s"# of total malformed lines: ${malformedLineNum}" +: {
-      if (malformedLines.size > 0) {
-        (s"${malformedLines.size} malformed lines extracted and listed as follows;" +:
-          malformedLines.toSeq).map(_.trim)
-      } else {
-        Seq.empty
-      }
-    }).mkString("\n")
+    s"# of total malformed lines: ${malformedLineNum}"
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CsvUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CsvUtils.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.csv
+
+import scala.collection.mutable.ArrayBuffer
+
+/**
+ * Stores and counts malformed lines during CSV parsing.
+ */
+private[csv] class MalformedLinesInfo(maxStoreMalformed: Int) extends Serializable {
+
+  var malformedLines = new ArrayBuffer[String]
+  var malformedLineNum = 0
+
+  def add(line: String): Unit = {
+    if (malformedLines.size < maxStoreMalformed) {
+      malformedLines += line
+    }
+    malformedLineNum = malformedLineNum + 1
+  }
+
+  override def toString: String = {
+    (s"# of total malformed lines: ${malformedLineNum}" +: {
+      if (malformedLines.size > 0) {
+        (s"${malformedLines.size} malformed lines extracted and listed as follows;" +:
+          malformedLines.toSeq).map(_.trim)
+      } else {
+        Seq.empty
+      }
+    }).mkString("\n")
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CsvUtilsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CsvUtilsSuite.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.csv
+
+import org.apache.spark.SparkFunSuite
+
+class CsvUtilsSuite extends SparkFunSuite {
+
+  test("count malformed lines") {
+    val malformedLinesInfo = new MalformedLinesInfo(3)
+    malformedLinesInfo.add("aaa, bbb, ccc")
+    malformedLinesInfo.add("ddd, eee")
+    malformedLinesInfo.add("fff, ggg, hhh, iii")
+    malformedLinesInfo.add("jjj")
+    assert(s"${malformedLinesInfo}" ===
+      s"""
+        |# of total malformed lines: 4
+        |3 malformed lines extracted and listed as follows;
+        |aaa, bbb, ccc
+        |ddd, eee
+        |fff, ggg, hhh, iii
+      """.stripMargin.trim)
+
+    val noSummaryLines = new MalformedLinesInfo(0)
+    noSummaryLines.add("kkk, lll, mmm")
+    noSummaryLines.add("nnn")
+    assert(s"${noSummaryLines}" ===
+      s"""
+        |# of total malformed lines: 2
+      """.stripMargin.trim)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CsvUtilsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CsvUtilsSuite.scala
@@ -30,18 +30,6 @@ class CsvUtilsSuite extends SparkFunSuite {
     assert(s"${malformedLinesInfo}" ===
       s"""
         |# of total malformed lines: 4
-        |3 malformed lines extracted and listed as follows;
-        |aaa, bbb, ccc
-        |ddd, eee
-        |fff, ggg, hhh, iii
-      """.stripMargin.trim)
-
-    val noSummaryLines = new MalformedLinesInfo(0)
-    noSummaryLines.add("kkk, lll, mmm")
-    noSummaryLines.add("nnn")
-    assert(s"${noSummaryLines}" ===
-      s"""
-        |# of total malformed lines: 2
       """.stripMargin.trim)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently in `PERMISSIVE` and `DROPMALFORMED` modes we log any record that is going to be ignored. This can generate a lot of logs with large datasets. This pr is to log the parts of malformed records and the number of subsequent records for each partition.
This adds two options as follows;

```
sqlContext.read
  .format("csv")
  .option("mode", "COUNTMALFORMED")
  .option("maxStoredMalformedPerPartition", 3)
  .load("test.csv").show
```

A logging message is;

```
16/04/05 16:42:12 WARN CSVRelation: # of total malformed lines: 25
3 malformed lines extracted and listed as follows;
ab ccc ddd ddd
ab ccc ddd ddd
...
```
## How was this patch tested?

Manual tests done
