### PR TITLE
[SPARK-14404][SQL][TESTS] HDFSMetadataLogSuite should recover the original FileSystem implementation after overriding it

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
@@ -91,10 +91,29 @@ private[sql] trait SQLTestUtils
   }
 
   /**
+   * Sets all Hadoop configurations specified in `pairs`, calls `f`, and then restore all Hadoop
+   * configurations.
+   */
+  protected def withHadoopConf(pairs: (String, String)*)(f: => Unit): Unit = {
+    val (keys, _) = pairs.unzip
+    val originalValues = keys.map(key => Option(hadoopConfiguration.get(key)))
+
+    try {
+      pairs.foreach { case (key, value) =>
+        hadoopConfiguration.set(key, value)
+      }
+      f
+    } finally {
+      keys.zip(originalValues).foreach {
+        case (key, Some(value)) => hadoopConfiguration.set(key, value)
+        case (key, None) => hadoopConfiguration.unset(key)
+      }
+    }
+  }
+
+  /**
    * Sets all SQL configurations specified in `pairs`, calls `f`, and then restore all SQL
    * configurations.
-   *
-   * @todo Probably this method should be moved to a more general place
    */
   protected def withSQLConf(pairs: (String, String)*)(f: => Unit): Unit = {
     val (keys, values) = pairs.unzip


### PR DESCRIPTION
## What changes were proposed in this pull request?

Test case `HDFSMetadataLog: fallback from FileContext to FileSystem` doesn't recover the original `FileSystem` implementation after overriding it with `FakeFileSystem`.

This PR fixes this issue by adding `withHadoopConf` in `SQLTestUtils` and apply it to the aforementioned test case.
## How was this patch tested?

Using existing tests.
