### PR TITLE
[HOTFIX] Fix `optional` to `createOptional`.

### DIFF
--- a/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
+++ b/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
@@ -111,7 +111,7 @@ package object config {
   private[spark] val STAGING_DIR = ConfigBuilder("spark.yarn.stagingDir")
     .doc("Staging directory used while submitting applications.")
     .stringConf
-    .optional
+    .createOptional
 
   /* Cluster-mode launcher configuration. */
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fixes the following line.

```
   private[spark] val STAGING_DIR = ConfigBuilder("spark.yarn.stagingDir")
     .doc("Staging directory used while submitting applications.")
     .stringConf
-    .optional
+    .createOptional
```
## How was this patch tested?

Pass the build.
