### PR TITLE
[SPARK-14400] [SQL] ScriptTransformation does not fail the job for bad user command

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanTest.scala
@@ -231,7 +231,12 @@ object SparkPlanTest {
     }
   }
 
-  private def executePlan(outputPlan: SparkPlan, spark: SQLContext): Seq[Row] = {
+  /**
+   * Runs the plan
+   * @param outputPlan SparkPlan to be executed
+   * @param spark SqlContext used for execution of the plan
+   */
+  def executePlan(outputPlan: SparkPlan, spark: SQLContext): Seq[Row] = {
     val execution = new QueryExecution(spark.sparkSession, null) {
       override lazy val sparkPlan: SparkPlan = outputPlan transform {
         case plan: SparkPlan =>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/ScriptTransformation.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/ScriptTransformation.scala
@@ -134,7 +134,7 @@ case class ScriptTransformation(
 
           // Checks if the proc is still alive (incase the command ran was bad)
           // The ideal way to do this is to use Java 8's Process#isAlive()
-          // Unfortunately, Jenkins builds for Spark run with Java 7 so that cannot be used
+          // but it cannot be used because Spark still supports Java 7.
           // Following is a workaround used to check if a process is alive in Java 7
           // TODO: Once builds are switched to Java 8, this can be changed
           try {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/ScriptTransformation.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/ScriptTransformation.scala
@@ -157,12 +157,8 @@ case class ScriptTransformation(
                 curLine = reader.readLine()
                 if (curLine == null) {
                   checkFailureAndPropagate()
-                  false
-                } else {
-                  true
+                  return false
                 }
-              } else {
-                true
               }
             } else if (scriptOutputWritable == null) {
               scriptOutputWritable = reusedWritableObject
@@ -170,14 +166,11 @@ case class ScriptTransformation(
               if (scriptOutputReader != null) {
                 if (scriptOutputReader.next(scriptOutputWritable) <= 0) {
                   checkFailureAndPropagate()
-                  false
-                } else {
-                  true
+                  return false
                 }
               } else {
                 try {
                   scriptOutputWritable.readFields(scriptOutputStream)
-                  true
                 } catch {
                   case _: EOFException =>
                     // This means that the stdout of `proc` (ie. TRANSFORM process) has exhausted.
@@ -186,12 +179,12 @@ case class ScriptTransformation(
                     // being terminated. So explicitly waiting for the process to be done.
                     proc.waitFor()
                     checkFailureAndPropagate()
-                    false
+                    return false
                 }
               }
-            } else {
-              true
             }
+
+            true
           } catch {
             case NonFatal(e) =>
               // If this exception is due to abrupt / unclean termination of `proc`,

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/ScriptTransformationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/ScriptTransformationSuite.scala
@@ -113,7 +113,7 @@ class ScriptTransformationSuite extends SparkPlanTest with TestHiveSingleton {
   test("SPARK-14400 script transformation should fail for bad script command") {
     val rowsDf = Seq("a", "b", "c").map(Tuple1.apply).toDF("a")
 
-    val e = intercept[Exception] {
+    val e = intercept[SparkException] {
       val plan =
         new ScriptTransformation(
           input = Seq(rowsDf.col("a").expr),

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/ScriptTransformationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/ScriptTransformationSuite.scala
@@ -113,7 +113,7 @@ class ScriptTransformationSuite extends SparkPlanTest with TestHiveSingleton {
   test("SPARK-14400 script transformation should fail for bad script command") {
     val rowsDf = Seq("a", "b", "c").map(Tuple1.apply).toDF("a")
 
-    val e = intercept[SparkException] {
+    val e = intercept[Exception] {
       val plan =
         new ScriptTransformation(
           input = Seq(rowsDf.col("a").expr),

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/ScriptTransformationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/ScriptTransformationSuite.scala
@@ -110,7 +110,7 @@ class ScriptTransformationSuite extends SparkPlanTest with TestHiveSingleton {
     assert(e.getMessage().contains("intentional exception"))
   }
 
-  test("script transformation should fail when user specifies a bad script command") {
+  test("SPARK-14400 script transformation should fail for bad script command") {
     val rowsDf = Seq("a", "b", "c").map(Tuple1.apply).toDF("a")
 
     val e = intercept[SparkException] {
@@ -120,8 +120,7 @@ class ScriptTransformationSuite extends SparkPlanTest with TestHiveSingleton {
           script = "some_non_existent_command",
           output = Seq(AttributeReference("a", StringType)()),
           child = rowsDf.queryExecution.sparkPlan,
-          ioschema = serdeIOSchema
-        )(hiveContext)
+          ioschema = serdeIOSchema)
       SparkPlanTest.executePlan(plan, hiveContext)
     }
     assert(e.getMessage.contains("Subprocess exited with status"))

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/ScriptTransformationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/ScriptTransformationSuite.scala
@@ -109,6 +109,22 @@ class ScriptTransformationSuite extends SparkPlanTest with TestHiveSingleton {
     }
     assert(e.getMessage().contains("intentional exception"))
   }
+
+  test("some_non_existent_command") {
+    val rowsDf = Seq("a", "b", "c").map(Tuple1.apply).toDF("a")
+    intercept[TestFailedException] {
+      checkAnswer(
+        rowsDf,
+        (child: SparkPlan) => new ScriptTransformation(
+          input = Seq(rowsDf.col("a").expr),
+          script = "some_non_existent_command",
+          output = Seq(AttributeReference("a", StringType)()),
+          child = child,
+          ioschema = serdeIOSchema
+        )(hiveContext),
+        rowsDf.collect())
+    }
+  }
 }
 
 private case class ExceptionInjectingOperator(child: SparkPlan) extends UnaryExecNode {


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Refer to the Jira for the problem: jira : https://issues.apache.org/jira/browse/SPARK-14400
- The fix is to check if the process has exited with a non-zero exit code in `hasNext()`. I have moved this and checking of writer thread exception to a separate method.
## How was this patch tested?
- Ran a job which had incorrect transform script command and saw that the job fails
- Existing unit tests for `ScriptTransformationSuite`. Added a new unit test
