### PR TITLE
[SPARK-14392][ML]CountVectorizer Estimator should include binary toggle Param

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
@@ -202,7 +202,6 @@ object CountVectorizer extends DefaultParamsReadable[CountVectorizer] {
 /**
  * :: Experimental ::
  * Converts a text document to a sparse vector of token counts.
- *
  * @param vocabulary An Array over terms. Only the terms in the vocabulary will be counted.
  */
 @Experimental

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
@@ -113,6 +113,8 @@ private[feature] trait CountVectorizerParams extends Params with HasInputCol wit
 
   /** @group getParam */
   def getBinary: Boolean = $(binary)
+
+  setDefault(binary -> false)
 }
 
 /**
@@ -144,8 +146,6 @@ class CountVectorizer(override val uid: String)
   def setBinary(value: Boolean): this.type = set(binary, value)
 
   setDefault(vocabSize -> (1 << 18), minDF -> 1)
-
-  setDefault(binary -> false)
 
   override def fit(dataset: DataFrame): CountVectorizerModel = {
     transformSchema(dataset.schema, logging = true)
@@ -226,8 +226,6 @@ class CountVectorizerModel(override val uid: String, val vocabulary: Array[Strin
 
   /** @group setParam */
   def setBinary(value: Boolean): this.type = set(binary, value)
-
-  setDefault(binary -> false)
 
   /** Dictionary created from [[vocabulary]] and its indices, broadcast once for [[transform()]] */
   private var broadcastDict: Option[Broadcast[Map[String, Int]]] = None

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
@@ -173,11 +173,7 @@ class CountVectorizer(override val uid: String)
     }.filter { case (word, (wc, df)) =>
       df >= minDf
     }.map { case (word, (count, dfCount)) =>
-      if ($(binary)) {
-        (word, 1L)
-      } else {
-        (word, count)
-      }
+      (word, count)
     }.cache()
     val fullVocabSize = wordCounts.count()
     val vocab: Array[String] = {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
@@ -42,8 +42,8 @@ private[feature] trait CountVectorizerParams extends Params with HasInputCol wit
    * vocabSize terms ordered by term frequency across the corpus.
    *
    * Default: 2^18^
-    *
-    * @group param
+   *
+   * @group param
    */
   val vocabSize: IntParam =
     new IntParam(this, "vocabSize", "max size of the vocabulary", ParamValidators.gt(0))
@@ -113,9 +113,7 @@ private[feature] trait CountVectorizerParams extends Params with HasInputCol wit
     * @group param
     */
   val binary: BooleanParam =
-    new BooleanParam(this, "binary", "If True, all non zero counts are set to 1. " +
-      "This is useful for discrete probabilistic models that model binary events rather " +
-      "than integer counts")
+    new BooleanParam(this, "binary", "If True, all non zero counts are set to 1.")
 
   /** @group getParam */
   def getBinary: Boolean = $(binary)
@@ -208,8 +206,8 @@ object CountVectorizer extends DefaultParamsReadable[CountVectorizer] {
 /**
  * :: Experimental ::
  * Converts a text document to a sparse vector of token counts.
-  *
-  * @param vocabulary An Array over terms. Only the terms in the vocabulary will be counted.
+ *
+ * @param vocabulary An Array over terms. Only the terms in the vocabulary will be counted.
  */
 @Experimental
 class CountVectorizerModel(override val uid: String, val vocabulary: Array[String])

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
@@ -113,8 +113,6 @@ private[feature] trait CountVectorizerParams extends Params with HasInputCol wit
 
   /** @group getParam */
   def getBinary: Boolean = $(binary)
-
-  setDefault(binary -> false)
 }
 
 /**
@@ -146,6 +144,8 @@ class CountVectorizer(override val uid: String)
   def setBinary(value: Boolean): this.type = set(binary, value)
 
   setDefault(vocabSize -> (1 << 18), minDF -> 1)
+
+  setDefault(binary -> false)
 
   override def fit(dataset: DataFrame): CountVectorizerModel = {
     transformSchema(dataset.schema, logging = true)
@@ -226,6 +226,8 @@ class CountVectorizerModel(override val uid: String, val vocabulary: Array[Strin
 
   /** @group setParam */
   def setBinary(value: Boolean): this.type = set(binary, value)
+
+  setDefault(binary -> false)
 
   /** Dictionary created from [[vocabulary]] and its indices, broadcast once for [[transform()]] */
   private var broadcastDict: Option[Broadcast[Map[String, Int]]] = None

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
@@ -42,7 +42,6 @@ private[feature] trait CountVectorizerParams extends Params with HasInputCol wit
    * vocabSize terms ordered by term frequency across the corpus.
    *
    * Default: 2^18^
-   *
    * @group param
    */
   val vocabSize: IntParam =
@@ -58,8 +57,7 @@ private[feature] trait CountVectorizerParams extends Params with HasInputCol wit
    * if this is a double in [0,1), then this specifies the fraction of documents.
    *
    * Default: 1
-    *
-    * @group param
+   * @group param
    */
   val minDF: DoubleParam = new DoubleParam(this, "minDF", "Specifies the minimum number of" +
     " different documents a term must appear in to be included in the vocabulary." +
@@ -89,8 +87,7 @@ private[feature] trait CountVectorizerParams extends Params with HasInputCol wit
    * affect fitting.
    *
    * Default: 1
-    *
-    * @group param
+   * @group param
    */
   val minTF: DoubleParam = new DoubleParam(this, "minTF", "Filter to ignore rare words in" +
     " a document. For each document, terms with frequency/count less than the given threshold are" +
@@ -105,13 +102,12 @@ private[feature] trait CountVectorizerParams extends Params with HasInputCol wit
   def getMinTF: Double = $(minTF)
 
   /**
-    * Binary toggle to control the output vector values.
-    * If True, all nonzero counts (after minTF filter applied) are set to 1. This is useful for
-    * discrete probabilistic models that model binary events rather than integer counts.
-    * Default: false
-    *
-    * @group param
-    */
+   * Binary toggle to control the output vector values.
+   * If True, all nonzero counts (after minTF filter applied) are set to 1. This is useful for
+   * discrete probabilistic models that model binary events rather than integer counts.
+   * Default: false
+   * @group param
+   */
   val binary: BooleanParam =
     new BooleanParam(this, "binary", "If True, all non zero counts are set to 1.")
 

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/CountVectorizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/CountVectorizerSuite.scala
@@ -114,7 +114,7 @@ class CountVectorizerSuite extends SparkFunSuite with MLlibTestSparkContext
         assert(features ~== expected absTol 1e-14)
     }
   }
-  
+ 
   test("CountVectorizer throws exception when vocab is empty") {
     intercept[IllegalArgumentException] {
       val df = sqlContext.createDataFrame(Seq(

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/CountVectorizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/CountVectorizerSuite.scala
@@ -170,7 +170,7 @@ class CountVectorizerSuite extends SparkFunSuite with MLlibTestSparkContext
 
   test("CountVectorizerModel and CountVectorizer with binary") {
     val df = sqlContext.createDataFrame(Seq(
-      (0, split("a a a a b b b b c d"), 
+      (0, split("a a a a b b b b c d"),
       Vectors.sparse(4, Seq((0, 1.0), (1, 1.0), (2, 1.0), (3, 1.0)))),
       (1, split("c c c"), Vectors.sparse(4, Seq((2, 1.0)))),
       (2, split("a"), Vectors.sparse(4, Seq((0, 1.0))))

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/CountVectorizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/CountVectorizerSuite.scala
@@ -190,8 +190,6 @@ class CountVectorizerSuite extends SparkFunSuite with MLlibTestSparkContext
       .setOutputCol("features")
       .setBinary(true)
       .fit(df)
-    assert(cv2.vocabulary === Array("a", "b", "c", "d"))
-
     cv2.transform(df).select("features", "expected").collect().foreach {
       case Row(features: Vector, expected: Vector) =>
         assert(features ~== expected absTol 1e-14)

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/CountVectorizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/CountVectorizerSuite.scala
@@ -176,21 +176,22 @@ class CountVectorizerSuite extends SparkFunSuite with MLlibTestSparkContext
       (2, split("a"), Vectors.sparse(4, Seq((0, 1.0))))
     )).toDF("id", "words", "expected")
 
-    val cv = new CountVectorizerModel(Array("a", "b", "c", "d"))
+    // CountVectorizer test
+    val cv = new CountVectorizer()
       .setInputCol("words")
       .setOutputCol("features")
       .setBinary(true)
+      .fit(df)
     cv.transform(df).select("features", "expected").collect().foreach {
       case Row(features: Vector, expected: Vector) =>
         assert(features ~== expected absTol 1e-14)
     }
 
-    // CountVectorizer test
-    val cv2 = new CountVectorizer()
+    // CountVectorizerModel test
+    val cv2 = new CountVectorizerModel(cv.vocabulary)
       .setInputCol("words")
       .setOutputCol("features")
       .setBinary(true)
-      .fit(df)
     cv2.transform(df).select("features", "expected").collect().foreach {
       case Row(features: Vector, expected: Vector) =>
         assert(features ~== expected absTol 1e-14)

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/CountVectorizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/CountVectorizerSuite.scala
@@ -114,28 +114,7 @@ class CountVectorizerSuite extends SparkFunSuite with MLlibTestSparkContext
         assert(features ~== expected absTol 1e-14)
     }
   }
-
-  test("CountVectorizer with binary") {
-    val df = sqlContext.createDataFrame(Seq(
-      (0, split("a b c d e a b"),
-        Vectors.sparse(5, Seq((0, 1.0), (1, 1.0), (2, 1.0), (3, 1.0), (4, 1.0)))),
-      (1, split("a a a a a a"), Vectors.sparse(5, Seq((0, 1.0)))),
-      (2, split("c c"), Vectors.sparse(5, Seq((2, 1.0)))),
-      (3, split("b b b b b"), Vectors.sparse(5, Seq((1, 1.0)))))
-    ).toDF("id", "words", "expected")
-    val cv = new CountVectorizer()
-      .setInputCol("words")
-      .setOutputCol("features")
-      .setBinary(true)
-      .fit(df)
-    assert(cv.vocabulary === Array("a", "b", "c", "d", "e"))
-
-    cv.transform(df).select("features", "expected").collect().foreach {
-      case Row(features: Vector, expected: Vector) =>
-        assert(features ~== expected absTol 1e-14)
-    }
-  }
-
+  
   test("CountVectorizer throws exception when vocab is empty") {
     intercept[IllegalArgumentException] {
       val df = sqlContext.createDataFrame(Seq(
@@ -189,7 +168,7 @@ class CountVectorizerSuite extends SparkFunSuite with MLlibTestSparkContext
     }
   }
 
-  test("CountVectorizerModel with binary") {
+  test("CountVectorizerModel and CountVectorizer with binary") {
     val df = sqlContext.createDataFrame(Seq(
       (0, split("a a a b b c"), Vectors.sparse(4, Seq((0, 1.0), (1, 1.0), (2, 1.0)))),
       (1, split("c c c"), Vectors.sparse(4, Seq((2, 1.0)))),
@@ -201,6 +180,26 @@ class CountVectorizerSuite extends SparkFunSuite with MLlibTestSparkContext
       .setOutputCol("features")
       .setBinary(true)
     cv.transform(df).select("features", "expected").collect().foreach {
+      case Row(features: Vector, expected: Vector) =>
+        assert(features ~== expected absTol 1e-14)
+    }
+
+    // CountVectorizer test
+    val df2 = sqlContext.createDataFrame(Seq(
+      (0, split("a b c d e a b"),
+        Vectors.sparse(5, Seq((0, 1.0), (1, 1.0), (2, 1.0), (3, 1.0), (4, 1.0)))),
+      (1, split("a a a a a a"), Vectors.sparse(5, Seq((0, 1.0)))),
+      (2, split("c c"), Vectors.sparse(5, Seq((2, 1.0)))),
+      (3, split("b b b b b"), Vectors.sparse(5, Seq((1, 1.0)))))
+    ).toDF("id", "words", "expected")
+    val cv2 = new CountVectorizer()
+      .setInputCol("words")
+      .setOutputCol("features")
+      .setBinary(true)
+      .fit(df2)
+    assert(cv2.vocabulary === Array("a", "b", "c", "d", "e"))
+
+    cv2.transform(df2).select("features", "expected").collect().foreach {
       case Row(features: Vector, expected: Vector) =>
         assert(features ~== expected absTol 1e-14)
     }

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/CountVectorizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/CountVectorizerSuite.scala
@@ -170,7 +170,7 @@ class CountVectorizerSuite extends SparkFunSuite with MLlibTestSparkContext
 
   test("CountVectorizerModel and CountVectorizer with binary") {
     val df = sqlContext.createDataFrame(Seq(
-      (0, split("a a a b b c"), Vectors.sparse(4, Seq((0, 1.0), (1, 1.0), (2, 1.0)))),
+      (0, split("a a a a b b b b c d"), Vectors.sparse(4, Seq((0, 1.0), (1, 1.0), (2, 1.0), (3, 1.0)))),
       (1, split("c c c"), Vectors.sparse(4, Seq((2, 1.0)))),
       (2, split("a"), Vectors.sparse(4, Seq((0, 1.0))))
     )).toDF("id", "words", "expected")
@@ -185,21 +185,14 @@ class CountVectorizerSuite extends SparkFunSuite with MLlibTestSparkContext
     }
 
     // CountVectorizer test
-    val df2 = sqlContext.createDataFrame(Seq(
-      (0, split("a b c d e a b"),
-        Vectors.sparse(5, Seq((0, 1.0), (1, 1.0), (2, 1.0), (3, 1.0), (4, 1.0)))),
-      (1, split("a a a a a a"), Vectors.sparse(5, Seq((0, 1.0)))),
-      (2, split("c c"), Vectors.sparse(5, Seq((2, 1.0)))),
-      (3, split("b b b b b"), Vectors.sparse(5, Seq((1, 1.0)))))
-    ).toDF("id", "words", "expected")
     val cv2 = new CountVectorizer()
       .setInputCol("words")
       .setOutputCol("features")
       .setBinary(true)
-      .fit(df2)
-    assert(cv2.vocabulary === Array("a", "b", "c", "d", "e"))
+      .fit(df)
+    assert(cv2.vocabulary === Array("a", "b", "c", "d"))
 
-    cv2.transform(df2).select("features", "expected").collect().foreach {
+    cv2.transform(df).select("features", "expected").collect().foreach {
       case Row(features: Vector, expected: Vector) =>
         assert(features ~== expected absTol 1e-14)
     }

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/CountVectorizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/CountVectorizerSuite.scala
@@ -114,7 +114,7 @@ class CountVectorizerSuite extends SparkFunSuite with MLlibTestSparkContext
         assert(features ~== expected absTol 1e-14)
     }
   }
- 
+
   test("CountVectorizer throws exception when vocab is empty") {
     intercept[IllegalArgumentException] {
       val df = sqlContext.createDataFrame(Seq(
@@ -170,7 +170,8 @@ class CountVectorizerSuite extends SparkFunSuite with MLlibTestSparkContext
 
   test("CountVectorizerModel and CountVectorizer with binary") {
     val df = sqlContext.createDataFrame(Seq(
-      (0, split("a a a a b b b b c d"), Vectors.sparse(4, Seq((0, 1.0), (1, 1.0), (2, 1.0), (3, 1.0)))),
+      (0, split("a a a a b b b b c d"), 
+      Vectors.sparse(4, Seq((0, 1.0), (1, 1.0), (2, 1.0), (3, 1.0)))),
       (1, split("c c c"), Vectors.sparse(4, Seq((2, 1.0)))),
       (2, split("a"), Vectors.sparse(4, Seq((0, 1.0))))
     )).toDF("id", "words", "expected")


### PR DESCRIPTION
## What changes were proposed in this pull request?

CountVectorizerModel has a binary toggle param. This PR is to add binary toggle param for estimator CountVectorizer. As discussed in the JIRA, instead of adding a param into CountVerctorizer, I moved the binary param to CountVectorizerParams. Therefore, the estimator inherits the binary param.
## How was this patch tested?

Add a new test case, which fits the model with binary flag set to true and then check the trained model's all non-zero counts is set to 1.0.

All tests in CounterVectorizerSuite.scala are passed.
