### PR TITLE
[SPARK-14396] [Build] [HOT] Fix compilation against Scala 2.10

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDDLCommandSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDDLCommandSuite.scala
@@ -263,8 +263,8 @@ class HiveDDLCommandSuite extends PlanTest {
     assert(desc.tableType == CatalogTableType.VIRTUAL_VIEW)
     assert(desc.storage.locationUri.isEmpty)
     assert(desc.schema == Seq.empty[CatalogColumn])
-    assert(desc.viewText.contains("SELECT * FROM tab1"))
-    assert(desc.viewOriginalText.contains("SELECT * FROM tab1"))
+    assert(desc.viewText == Option("SELECT * FROM tab1"))
+    assert(desc.viewOriginalText == Option("SELECT * FROM tab1"))
     assert(desc.storage.serdeProperties == Map())
     assert(desc.storage.inputFormat.isEmpty)
     assert(desc.storage.outputFormat.isEmpty)
@@ -290,8 +290,8 @@ class HiveDDLCommandSuite extends PlanTest {
     assert(desc.schema ==
       CatalogColumn("col1", null, nullable = true, None) ::
         CatalogColumn("col3", null, nullable = true, None) :: Nil)
-    assert(desc.viewText.contains("SELECT * FROM tab1"))
-    assert(desc.viewOriginalText.contains("SELECT * FROM tab1"))
+    assert(desc.viewText == Option("SELECT * FROM tab1"))
+    assert(desc.viewOriginalText == Option("SELECT * FROM tab1"))
     assert(desc.storage.serdeProperties == Map())
     assert(desc.storage.inputFormat.isEmpty)
     assert(desc.storage.outputFormat.isEmpty)


### PR DESCRIPTION
#### What changes were proposed in this pull request?

This PR is to fix the compilation errors in Scala 2.10 build, as shown in the link:
https://amplab.cs.berkeley.edu/jenkins/job/spark-master-compile-maven-scala-2.10/735/console

```
[error] /home/jenkins/workspace/spark-master-compile-maven-scala-2.10/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDDLCommandSuite.scala:266: value contains is not a member of Option[String]
[error]     assert(desc.viewText.contains("SELECT * FROM tab1"))
[error]                          ^
[error] /home/jenkins/workspace/spark-master-compile-maven-scala-2.10/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDDLCommandSuite.scala:267: value contains is not a member of Option[String]
[error]     assert(desc.viewOriginalText.contains("SELECT * FROM tab1"))
[error]                                  ^
[error] /home/jenkins/workspace/spark-master-compile-maven-scala-2.10/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDDLCommandSuite.scala:293: value contains is not a member of Option[String]
[error]     assert(desc.viewText.contains("SELECT * FROM tab1"))
[error]                          ^
[error] /home/jenkins/workspace/spark-master-compile-maven-scala-2.10/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveDDLCommandSuite.scala:294: value contains is not a member of Option[String]
[error]     assert(desc.viewOriginalText.contains("SELECT * FROM tab1"))
[error]                                  ^
[error] four errors found
[error] Compile failed at Apr 5, 2016 10:59:09 PM [10.502s]
```
#### How was this patch tested?

Not sure how to trigger Scala 2.10 compilation in the test environment.
