### PR TITLE
Added omitted word in error message

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/Pregel.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/Pregel.scala
@@ -119,7 +119,7 @@ object Pregel extends Logging {
       mergeMsg: (A, A) => A)
     : Graph[VD, ED] =
   {
-    require(maxIterations > 0, s"Maximum of iterations must be greater than 0," +
+    require(maxIterations > 0, s"Maximum number of iterations must be greater than 0," +
       s" but got ${maxIterations}")
 
     var g = graph.mapVertices((vid, vdata) => vprog(vid, vdata, initialMsg)).cache()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added an omitted word in the error message displayed by the Graphx Pregel API when `maxIterations <= 0`
## How was this patch tested?

Manual test
