### PR TITLE
SPARK-14421 : Upgrade Kinesis Client Library (KCL) to 1.6.2, fixes support for de-aggregation.

### DIFF
--- a/extras/kinesis-asl-assembly/pom.xml
+++ b/extras/kinesis-asl-assembly/pom.xml
@@ -60,13 +60,16 @@
       <artifactId>commons-lang</artifactId>
       <scope>provided</scope>
     </dependency>
-<!--
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <scope>provided</scope>
+      <version>2.6.1</version>
+      <!-- 
+         We are being explicit about version here and overriding the 
+         spark default of 2.5.0 because KCL appears to have introduced 
+         a dependency on protobuf 2.6.1 somewhere between KCL 1.4.0 and 1.6.1.
+       -->
     </dependency>
--->
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-server</artifactId>

--- a/extras/kinesis-asl-assembly/pom.xml
+++ b/extras/kinesis-asl-assembly/pom.xml
@@ -148,13 +148,13 @@
           </includes>
         </artifactSet>
         <relocations>
-            <relocation>
-              <pattern>com.google.protobuf</pattern>
-              <shadedPattern>kinesis.protobuf</shadedPattern>
-              <includes>
-                <include>com.google.protobuf.**</include>
-              </includes>
-            </relocation>
+          <relocation>
+            <pattern>com.google.protobuf</pattern>
+            <shadedPattern>kinesis.protobuf</shadedPattern>
+            <includes>
+              <include>com.google.protobuf.**</include>
+            </includes>
+          </relocation>
         </relocations>
         <filters>
           <filter>

--- a/extras/kinesis-asl-assembly/pom.xml
+++ b/extras/kinesis-asl-assembly/pom.xml
@@ -150,7 +150,7 @@
         <relocations>
             <relocation>
               <pattern>com.google.protobuf</pattern>
-              <shadedPattern>kcl.protobuf</shadedPattern>
+              <shadedPattern>kinesis.protobuf</shadedPattern>
               <includes>
                 <include>com.google.protobuf.**</include>
               </includes>

--- a/extras/kinesis-asl-assembly/pom.xml
+++ b/extras/kinesis-asl-assembly/pom.xml
@@ -147,6 +147,15 @@
             <include>*:*</include>
           </includes>
         </artifactSet>
+        <relocations>
+            <relocation>
+              <pattern>com.google.protobuf</pattern>
+              <shadedPattern>kcl.protobuf</shadedPattern>
+              <includes>
+                <include>com.google.protobuf</include>
+              </includes>
+            </relocation>
+        </relocations>
         <filters>
           <filter>
             <artifact>*:*</artifact>

--- a/extras/kinesis-asl-assembly/pom.xml
+++ b/extras/kinesis-asl-assembly/pom.xml
@@ -152,7 +152,7 @@
               <pattern>com.google.protobuf</pattern>
               <shadedPattern>kcl.protobuf</shadedPattern>
               <includes>
-                <include>com.google.protobuf</include>
+                <include>com.google.protobuf.**</include>
               </includes>
             </relocation>
         </relocations>

--- a/extras/kinesis-asl-assembly/pom.xml
+++ b/extras/kinesis-asl-assembly/pom.xml
@@ -60,11 +60,13 @@
       <artifactId>commons-lang</artifactId>
       <scope>provided</scope>
     </dependency>
+<!--
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
       <scope>provided</scope>
     </dependency>
+-->
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-server</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <slf4j.version>1.7.10</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
     <hadoop.version>2.2.0</hadoop.version>
-    <protobuf.version>2.5.0</protobuf.version>
+    <protobuf.version>2.6.1</protobuf.version>
     <yarn.version>${hadoop.version}</yarn.version>
     <hbase.version>0.98.7-hadoop2</hbase.version>
     <hbase.artifact>hbase</hbase.artifact>
@@ -153,7 +153,7 @@
     <avro.version>1.7.7</avro.version>
     <avro.mapred.classifier>hadoop2</avro.mapred.classifier>
     <jets3t.version>0.7.1</jets3t.version>
-    <aws.kinesis.client.version>1.4.0</aws.kinesis.client.version>
+    <aws.kinesis.client.version>1.6.2</aws.kinesis.client.version>
     <!-- the producer is used in tests -->
     <aws.kinesis.producer.version>0.10.1</aws.kinesis.producer.version>
     <!--  org.apache.httpcomponents/httpclient-->

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <slf4j.version>1.7.10</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
     <hadoop.version>2.2.0</hadoop.version>
-    <protobuf.version>2.6.1</protobuf.version>
+    <protobuf.version>2.5.0</protobuf.version>
     <yarn.version>${hadoop.version}</yarn.version>
     <hbase.version>0.98.7-hadoop2</hbase.version>
     <hbase.artifact>hbase</hbase.artifact>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrades KCL dependency, backported to 1.6.1.
## How was this patch tested?

Used kinesis word count example against a stream containing aggregated data.

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

See: SPARK-14421
