### PR TITLE
[SPARK-14222][BUILD] Remove jackson-module-scala dependency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -240,10 +240,6 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.module</groupId>
-      <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
       <scope>test</scope>

--- a/core/src/main/scala/org/apache/spark/deploy/rest/SubmitRestProtocolMessage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/rest/SubmitRestProtocolMessage.scala
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.annotation._
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper, SerializationFeature}
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.json4s.JsonAST._
 import org.json4s.jackson.JsonMethods._
 
@@ -102,7 +101,6 @@ private[spark] object SubmitRestProtocolMessage {
   private val mapper = new ObjectMapper()
     .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     .enable(SerializationFeature.INDENT_OUTPUT)
-    .registerModule(DefaultScalaModule)
 
   /**
    * Parse the value of the action field from the given JSON.

--- a/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDDOperationScope.scala
@@ -19,10 +19,9 @@ package org.apache.spark.rdd
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import com.fasterxml.jackson.annotation.{JsonIgnore, JsonInclude, JsonPropertyOrder}
+import com.fasterxml.jackson.annotation.{JsonCreator, JsonIgnore, JsonInclude, JsonProperty, JsonPropertyOrder}
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.google.common.base.Objects
 
 import org.apache.spark.SparkContext
@@ -43,10 +42,10 @@ import org.apache.spark.internal.Logging
  */
 @JsonInclude(Include.NON_NULL)
 @JsonPropertyOrder(Array("id", "name", "parent"))
-private[spark] class RDDOperationScope(
-    val name: String,
-    val parent: Option[RDDOperationScope] = None,
-    val id: String = RDDOperationScope.nextScopeId().toString) {
+private[spark] class RDDOperationScope @JsonCreator() (
+    @JsonProperty("name") val name: String,
+    @JsonProperty("parent") val parent: Option[RDDOperationScope] = None,
+    @JsonProperty("id") val id: String = RDDOperationScope.nextScopeId().toString) {
 
   def toJson: String = {
     RDDOperationScope.jsonMapper.writeValueAsString(this)
@@ -79,7 +78,7 @@ private[spark] class RDDOperationScope(
  * An RDD scope tracks the series of operations that created a given RDD.
  */
 private[spark] object RDDOperationScope extends Logging {
-  private val jsonMapper = new ObjectMapper().registerModule(DefaultScalaModule)
+  private val jsonMapper = new ObjectMapper()
   private val scopeCounter = new AtomicInteger(0)
 
   def fromJson(s: String): RDDOperationScope = {

--- a/core/src/main/scala/org/apache/spark/status/api/v1/JacksonMessageWriter.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/JacksonMessageWriter.scala
@@ -47,7 +47,6 @@ private[v1] class JacksonMessageWriter extends MessageBodyWriter[Object]{
       super.writeValueAsString(t)
     }
   }
-  mapper.registerModule(com.fasterxml.jackson.module.scala.DefaultScalaModule)
   mapper.enable(SerializationFeature.INDENT_OUTPUT)
   mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
   mapper.setDateFormat(JacksonMessageWriter.makeISODateFormat)

--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -23,7 +23,6 @@ import scala.collection.JavaConverters._
 import scala.collection.Map
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.json4s.DefaultFormats
 import org.json4s.JsonAST._
 import org.json4s.JsonDSL._
@@ -56,7 +55,7 @@ private[spark] object JsonProtocol {
 
   private implicit val format = DefaultFormats
 
-  private val mapper = new ObjectMapper().registerModule(DefaultScalaModule)
+  private val mapper = new ObjectMapper()
 
   /** ------------------------------------------------- *
    * JSON serialization methods for SparkListenerEvents |

--- a/dev/deps/spark-deps-hadoop-2.2
+++ b/dev/deps/spark-deps-hadoop-2.2
@@ -87,7 +87,6 @@ jackson-core-asl-1.9.13.jar
 jackson-databind-2.5.3.jar
 jackson-jaxrs-1.9.13.jar
 jackson-mapper-asl-1.9.13.jar
-jackson-module-scala_2.11-2.5.3.jar
 jackson-xc-1.9.13.jar
 janino-2.7.8.jar
 javax.inject-1.jar
@@ -142,7 +141,7 @@ netty-all-4.0.29.Final.jar
 objenesis-1.2.jar
 opencsv-2.3.jar
 oro-2.0.8.jar
-paranamer-2.6.jar
+paranamer-2.3.jar
 parquet-column-1.7.0.jar
 parquet-common-1.7.0.jar
 parquet-encoding-1.7.0.jar

--- a/dev/deps/spark-deps-hadoop-2.3
+++ b/dev/deps/spark-deps-hadoop-2.3
@@ -82,7 +82,6 @@ jackson-core-asl-1.9.13.jar
 jackson-databind-2.5.3.jar
 jackson-jaxrs-1.9.13.jar
 jackson-mapper-asl-1.9.13.jar
-jackson-module-scala_2.11-2.5.3.jar
 jackson-xc-1.9.13.jar
 janino-2.7.8.jar
 java-xmlbuilder-1.0.jar
@@ -133,7 +132,7 @@ netty-all-4.0.29.Final.jar
 objenesis-1.2.jar
 opencsv-2.3.jar
 oro-2.0.8.jar
-paranamer-2.6.jar
+paranamer-2.3.jar
 parquet-column-1.7.0.jar
 parquet-common-1.7.0.jar
 parquet-encoding-1.7.0.jar

--- a/dev/deps/spark-deps-hadoop-2.4
+++ b/dev/deps/spark-deps-hadoop-2.4
@@ -82,7 +82,6 @@ jackson-core-asl-1.9.13.jar
 jackson-databind-2.5.3.jar
 jackson-jaxrs-1.9.13.jar
 jackson-mapper-asl-1.9.13.jar
-jackson-module-scala_2.11-2.5.3.jar
 jackson-xc-1.9.13.jar
 janino-2.7.8.jar
 java-xmlbuilder-1.0.jar
@@ -134,7 +133,7 @@ netty-all-4.0.29.Final.jar
 objenesis-1.2.jar
 opencsv-2.3.jar
 oro-2.0.8.jar
-paranamer-2.6.jar
+paranamer-2.3.jar
 parquet-column-1.7.0.jar
 parquet-common-1.7.0.jar
 parquet-encoding-1.7.0.jar

--- a/dev/deps/spark-deps-hadoop-2.6
+++ b/dev/deps/spark-deps-hadoop-2.6
@@ -88,7 +88,6 @@ jackson-core-asl-1.9.13.jar
 jackson-databind-2.5.3.jar
 jackson-jaxrs-1.9.13.jar
 jackson-mapper-asl-1.9.13.jar
-jackson-module-scala_2.11-2.5.3.jar
 jackson-xc-1.9.13.jar
 janino-2.7.8.jar
 java-xmlbuilder-1.0.jar
@@ -140,7 +139,7 @@ netty-all-4.0.29.Final.jar
 objenesis-1.2.jar
 opencsv-2.3.jar
 oro-2.0.8.jar
-paranamer-2.6.jar
+paranamer-2.3.jar
 parquet-column-1.7.0.jar
 parquet-common-1.7.0.jar
 parquet-encoding-1.7.0.jar

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -88,7 +88,6 @@ jackson-core-asl-1.9.13.jar
 jackson-databind-2.5.3.jar
 jackson-jaxrs-1.9.13.jar
 jackson-mapper-asl-1.9.13.jar
-jackson-module-scala_2.11-2.5.3.jar
 jackson-xc-1.9.13.jar
 janino-2.7.8.jar
 java-xmlbuilder-1.0.jar
@@ -141,7 +140,7 @@ netty-all-4.0.29.Final.jar
 objenesis-1.2.jar
 opencsv-2.3.jar
 oro-2.0.8.jar
-paranamer-2.6.jar
+paranamer-2.3.jar
 parquet-column-1.7.0.jar
 parquet-common-1.7.0.jar
 parquet-encoding-1.7.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -574,19 +574,6 @@
         <artifactId>jackson-annotations</artifactId>
         <version>${fasterxml.jackson.version}</version>
       </dependency>
-      <!-- Guava is excluded because of SPARK-6149.  The Guava version referenced in this module is
-           15.0, which causes runtime incompatibility issues. -->
-      <dependency>
-        <groupId>com.fasterxml.jackson.module</groupId>
-        <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
-        <version>${fasterxml.jackson.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
       <dependency>
         <groupId>com.sun.jersey</groupId>
         <artifactId>jersey-server</artifactId>


### PR DESCRIPTION
This patch removes our `jackson-module-scala` dependency in order to reduce the number of dependencies that we'll have to upgrade when adding experimental Scala 2.12 support. I think that our current use of this library is fairly minimal and removing the dependency seems like less work than having to help test and publish it for every Scala 2.12 milestone plus the final 2.12 release (see https://github.com/FasterXML/jackson-module-scala/issues/245).

/cc @vanzin @andrewor14
