### PR TITLE
[SPARK-14445][SQL] Support native execution of SHOW COLUMNS and SHOW PARTITIONS

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -106,6 +106,9 @@ statement
     | SHOW DATABASES (LIKE pattern=STRING)?                            #showDatabases
     | SHOW TBLPROPERTIES table=tableIdentifier
         ('(' key=tablePropertyKey ')')?                                #showTblProperties
+    | SHOW COLUMNS (FROM | IN) tableIdentifier
+        ((FROM | IN) db=identifier)?                                   #showColumns
+    | SHOW PARTITIONS tableIdentifier partitionSpec?                   #showPartitions
     | SHOW FUNCTIONS (LIKE? (qualifiedName | pattern=STRING))?         #showFunctions
     | (DESC | DESCRIBE) FUNCTION EXTENDED? describeFuncName            #describeFunction
     | (DESC | DESCRIBE) option=(EXTENDED | FORMATTED)?
@@ -128,7 +131,6 @@ hiveNativeCommands
     : DELETE FROM tableIdentifier (WHERE booleanExpression)?
     | TRUNCATE TABLE tableIdentifier partitionSpec?
         (COLUMNS identifierList)?
-    | SHOW COLUMNS (FROM | IN) tableIdentifier ((FROM|IN) identifier)?
     | START TRANSACTION (transactionMode (',' transactionMode)*)?
     | COMMIT WORK?
     | ROLLBACK WORK?

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -299,29 +299,17 @@ class InMemoryCatalog extends ExternalCatalog {
   }
 
   /**
-   * Returns the partition names from catalog for a given table in a database.
-   * Currently returns empty sequence for [[InMemoryCatalog]].
+   * List the metadata of all partitions that belong to the specified table, assuming it exists.
+   *
+   * A partial partition spec may optionally be provided to filter the partitions returned.
+   * For instance, if there exist partitions (a='1', b='2'), (a='1', b='3') and (a='2', b='4'),
+   * then a partial spec of (a='1') will return the first two only.
+   * TODO: Currently partialSpec is not used for memory catalog and it returns all the partitions.
    */
-  def getPartitionNames(db: String, table: String, range: Short): Seq[String] = {
-    Seq.empty[String]
-  }
-
-  /**
-   * Returns the partition names that matche the partition spec for a given table in a database.
-   * When no match is found, an empty Sequence is returned.
-   * Currently returns empty sequence for [[InMemoryCatalog]]
-   */
-  def getPartitionNames(
-      db: String,
-      table: String,
-      spec: TablePartitionSpec,
-      range: Short): Seq[String] = {
-    Seq.empty[String]
-  }
-
   override def listPartitions(
       db: String,
-      table: String): Seq[CatalogTablePartition] = synchronized {
+      table: String,
+      partialSpec: Option[TablePartitionSpec] = None): Seq[CatalogTablePartition] = synchronized {
     requireTableExists(db, table)
     catalog(db).tables(table).partitions.values.toSeq
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -298,6 +298,27 @@ class InMemoryCatalog extends ExternalCatalog {
     catalog(db).tables(table).partitions(spec)
   }
 
+  /**
+   * Returns the partition names from catalog for a given table in a database.
+   * Currently returns empty sequence for [[InMemoryCatalog]].
+   */
+  def getPartitionNames(db: String, table: String, range: Short): Seq[String] = {
+    Seq.empty[String]
+  }
+
+  /**
+   * Returns the partition names that matche the partition spec for a given table in a database.
+   * When no match is found, an empty Sequence is returned.
+   * Currently returns empty sequence for [[InMemoryCatalog]]
+   */
+  def getPartitionNames(
+      db: String,
+      table: String,
+      spec: TablePartitionSpec,
+      range: Short): Seq[String] = {
+    Seq.empty[String]
+  }
+
   override def listPartitions(
       db: String,
       table: String): Seq[CatalogTablePartition] = synchronized {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -298,19 +298,15 @@ class InMemoryCatalog extends ExternalCatalog {
     catalog(db).tables(table).partitions(spec)
   }
 
-  /**
-   * List the metadata of all partitions that belong to the specified table, assuming it exists.
-   *
-   * A partial partition spec may optionally be provided to filter the partitions returned.
-   * For instance, if there exist partitions (a='1', b='2'), (a='1', b='3') and (a='2', b='4'),
-   * then a partial spec of (a='1') will return the first two only.
-   * TODO: Currently partialSpec is not used for memory catalog and it returns all the partitions.
-   */
   override def listPartitions(
       db: String,
       table: String,
       partialSpec: Option[TablePartitionSpec] = None): Seq[CatalogTablePartition] = synchronized {
     requireTableExists(db, table)
+    if (partialSpec.nonEmpty) {
+      throw new AnalysisException("listPartition does not support partition spec in " +
+        "InMemoryCatalog.")
+    }
     catalog(db).tables(table).partitions.values.toSeq
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -471,32 +471,18 @@ class SessionCatalog(
   }
 
   /**
-   * Returns the partition names from catalog for a given table in a database.
+   * List the metadata of all partitions that belong to the specified table, assuming it exists.
+   *
+   * A partial partition spec may optionally be provided to filter the partitions returned.
+   * For instance, if there exist partitions (a='1', b='2'), (a='1', b='3') and (a='2', b='4'),
+   * then a partial spec of (a='1') will return the first two only.
    */
-  def getPartitionNames(db: String, table: String, range: Short): Seq[String] = {
-    externalCatalog.getPartitionNames(db, table, range)
-  }
-
-  /**
-   * Returns the partition names that matche the partition spec for a given table in a database.
-   * When no match is found, an empty Sequence is returned.
-   */
-  def getPartitionNames(
-      db: String,
-      table: String,
-      spec: TablePartitionSpec,
-      range: Short): Seq[String] = {
-    externalCatalog.getPartitionNames(db, table, spec, range)
-  }
-
-  /**
-   * List all partitions in a table, assuming it exists.
-   * If no database is specified, assume the table is in the current database.
-   */
-  def listPartitions(tableName: TableIdentifier): Seq[CatalogTablePartition] = {
+  def listPartitions(
+      tableName: TableIdentifier,
+      partialSpec: Option[TablePartitionSpec] = None): Seq[CatalogTablePartition] = {
     val db = tableName.database.getOrElse(currentDb)
     val table = formatTableName(tableName.table)
-    externalCatalog.listPartitions(db, table)
+    externalCatalog.listPartitions(db, table, partialSpec)
   }
 
   // ----------------------------------------------------------------------------

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -471,6 +471,25 @@ class SessionCatalog(
   }
 
   /**
+   * Returns the partition names from catalog for a given table in a database.
+   */
+  def getPartitionNames(db: String, table: String, range: Short): Seq[String] = {
+    externalCatalog.getPartitionNames(db, table, range)
+  }
+
+  /**
+   * Returns the partition names that matche the partition spec for a given table in a database.
+   * When no match is found, an empty Sequence is returned.
+   */
+  def getPartitionNames(
+      db: String,
+      table: String,
+      spec: TablePartitionSpec,
+      range: Short): Seq[String] = {
+    externalCatalog.getPartitionNames(db, table, spec, range)
+  }
+
+  /**
    * List all partitions in a table, assuming it exists.
    * If no database is specified, assume the table is in the current database.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -158,33 +158,19 @@ abstract class ExternalCatalog {
   def getPartition(db: String, table: String, spec: TablePartitionSpec): CatalogTablePartition
 
   /**
-   * Returns the partition names from catalog for a given table in a database.
+   * List the metadata of all partitions that belong to the specified table, assuming it exists.
    *
+   * A partial partition spec may optionally be provided to filter the partitions returned.
+   * For instance, if there exist partitions (a='1', b='2'), (a='1', b='3') and (a='2', b='4'),
+   * then a partial spec of (a='1') will return the first two only.
    * @param db database name
    * @param table table name
-   * @param range maximum number of partition names to return. When value of -1 is specified, all
-   *              the partitions are returned.
+   * @param partialSpec  partition spec
    */
-  def getPartitionNames(db: String, table: String, range: Short): Seq[String]
-
-  /**
-   * Returns the partition names that matches the partition spec for a given table in a database.
-   * When no match is found, an empty Sequence is returned.
-   *
-   * @param db database name
-   * @param table table name
-   * @param spec  partition spec
-   * @param range maximum number of partition names to return. When value of -1 is specified, all
-   *              the partitions that match the spec are returned.
-   */
-  def getPartitionNames(
+  def listPartitions(
       db: String,
       table: String,
-      spec: TablePartitionSpec,
-      range: Short): Seq[String]
-
-  // TODO: support listing by pattern
-  def listPartitions(db: String, table: String): Seq[CatalogTablePartition]
+      partialSpec: Option[TablePartitionSpec] = None): Seq[CatalogTablePartition]
 
   // --------------------------------------------------------------------------
   // Functions

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -157,6 +157,32 @@ abstract class ExternalCatalog {
 
   def getPartition(db: String, table: String, spec: TablePartitionSpec): CatalogTablePartition
 
+  /**
+   * Returns the partition names from catalog for a given table in a database.
+   *
+   * @param db database name
+   * @param table table name
+   * @param range maximum number of partition names to return. When value of -1 is specified, all
+   *              the partitions are returned.
+   */
+  def getPartitionNames(db: String, table: String, range: Short): Seq[String]
+
+  /**
+   * Returns the partition names that matches the partition spec for a given table in a database.
+   * When no match is found, an empty Sequence is returned.
+   *
+   * @param db database name
+   * @param table table name
+   * @param spec  partition spec
+   * @param range maximum number of partition names to return. When value of -1 is specified, all
+   *              the partitions that match the spec are returned.
+   */
+  def getPartitionNames(
+      db: String,
+      table: String,
+      spec: TablePartitionSpec,
+      range: Short): Seq[String]
+
   // TODO: support listing by pattern
   def listPartitions(db: String, table: String): Seq[CatalogTablePartition]
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
@@ -20,12 +20,14 @@ package org.apache.spark.sql.execution.command
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Dataset, Row, SQLContext}
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow, TableIdentifier}
-import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
+import org.apache.spark.sql.catalyst.catalog.CatalogTableType
+import org.apache.spark.sql.catalyst.catalog.ExternalCatalog.TablePartitionSpec
 import org.apache.spark.sql.catalyst.errors.TreeNodeException
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
 import org.apache.spark.sql.catalyst.plans.logical
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.datasources.PartitioningUtils
 import org.apache.spark.sql.execution.debug._
 import org.apache.spark.sql.types._
 
@@ -130,9 +132,8 @@ case class ShowColumnsCommand(table: TableIdentifier) extends RunnableCommand {
   }
 
   override def run(sqlContext: SQLContext): Seq[Row] = {
-    val relation = sqlContext.sessionState.catalog.lookupRelation(table, None)
-    relation.schema.fields.map { field =>
-      Row(field.name)
+    sqlContext.sessionState.catalog.getTableMetadata(table).schema.map { c =>
+      Row(c.name)
     }
   }
 }
@@ -154,55 +155,58 @@ case class ShowColumnsCommand(table: TableIdentifier) extends RunnableCommand {
  */
 case class ShowPartitionsCommand(
     table: TableIdentifier,
-    partitionSpec: Option[Map[String, String]]) extends RunnableCommand {
+    spec: Option[TablePartitionSpec]) extends RunnableCommand {
   // The result of SHOW PARTITIONS has one column called 'result'
   override val output: Seq[Attribute] = {
     AttributeReference("result", StringType, nullable = false)() :: Nil
   }
 
-  /**
-   * This function validates the partitioning spec by making sure all the referenced columns are
-   * defined as partitioning columns in table definition. An AnalysisException exception is
-   * thrown if the partitioning spec is invalid.
-   */
-  private def validatePartitionSpec(table: CatalogTable, spec: Map[String, String]): Unit = {
-    if (!spec.keySet.forall(table.partitionColumns.map(_.name).contains)) {
-      throw new AnalysisException(s"Partition spec ${spec.mkString("(", ", ", ")")} contains " +
-        s"non-partition columns")
-    }
+  def getPartName(spec: TablePartitionSpec): String = {
+    spec.map {s =>
+      PartitioningUtils.escapePathName(s._1) + "=" + PartitioningUtils.escapePathName(s._2)
+    }.mkString("/")
   }
-
-  /**
-   * Validates and throws an [[AnalysisException]] exception under the following conditions:
-   * 1. If the table is not partitioned.
-   * 2. If it is a datasource table.
-   * 3. If it is a view or index table.
-   */
-  private def checkRequirements(table: CatalogTable): Unit = {
-    if (table.tableType == CatalogTableType.VIRTUAL_VIEW ||
-      table.tableType == CatalogTableType.INDEX_TABLE) {
-      throw new AnalysisException("Operation not allowed: view or index table")
-    } else if (!DDLUtils.isTablePartitioned(table)) {
-      throw new AnalysisException(s"Table ${table.qualifiedName} is not a partitioned table")
-    } else if (DDLUtils.isDatasourceTable(table)) {
-      throw new AnalysisException("Operation not allowed: datasource table")
-    }
-  }
-
   override def run(sqlContext: SQLContext): Seq[Row] = {
     val catalog = sqlContext.sessionState.catalog
     val db = table.database.getOrElse(catalog.getCurrentDatabase)
     if (catalog.isTemporaryTable(table)) {
-      Seq.empty[Row]
+      throw new AnalysisException("SHOW PARTITIONS is not allowed on a temporary table: " +
+          s"${table.unquotedString}")
     } else {
-      val tab = catalog.getTable(table)
-      checkRequirements(tab)
-      val partNames = partitionSpec match {
-        case None => catalog.getPartitionNames(db, table.identifier, -1.asInstanceOf[Short])
-        case Some(spec) =>
-          validatePartitionSpec(tab, spec)
-          catalog.getPartitionNames(db, table.identifier, spec, -1.asInstanceOf[Short])
+      val tab = catalog.getTableMetadata(table)
+      /**
+       * Validate and throws an [[AnalysisException]] exception under the following conditions:
+       * 1. If the table is not partitioned.
+       * 2. If it is a datasource table.
+       * 3. If it is a view or index table.
+       */
+      if (tab.tableType == CatalogTableType.VIRTUAL_VIEW ||
+        tab.tableType == CatalogTableType.INDEX_TABLE) {
+        throw new AnalysisException("SHOW PARTITIONS is not allowed on a view or index table: " +
+          s"${tab.qualifiedName}")
       }
+      if (!DDLUtils.isTablePartitioned(tab)) {
+        throw new AnalysisException("SHOW PARTITIONS is not allowed on a table that is not " +
+          s"partitioned: ${tab.qualifiedName}")
+      }
+      if (DDLUtils.isDatasourceTable(tab)) {
+        throw new AnalysisException("SHOW PARTITIONS is not allowed on a datasource table: " +
+          s"${tab.qualifiedName}")
+      }
+      /**
+       * Validate the partitioning spec by making sure all the referenced columns are
+       * defined as partitioning columns in table definition. An AnalysisException exception is
+       * thrown if the partitioning spec is invalid.
+       */
+      if (spec.isDefined) {
+        val badColumns = spec.get.keySet.filterNot(tab.partitionColumns.map(_.name).contains)
+        if (badColumns.nonEmpty) {
+          throw new AnalysisException(
+            s"Non-partitioned column(s) [${badColumns.mkString(", ")}] are " +
+              s"specified for SHOW PARTITIONS")
+        }
+      }
+      val partNames = catalog.listPartitions(table, spec).map(p => getPartName(p.spec))
       partNames.map { p => Row(p) }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
@@ -17,6 +17,10 @@
 
 package org.apache.spark.sql.execution.command
 
+import java.io.File
+import java.util.NoSuchElementException
+
+import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Dataset, Row, SQLContext}
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow, TableIdentifier}
@@ -164,7 +168,7 @@ case class ShowPartitionsCommand(
   def getPartName(spec: TablePartitionSpec): String = {
     spec.map {s =>
       PartitioningUtils.escapePathName(s._1) + "=" + PartitioningUtils.escapePathName(s._2)
-    }.mkString("/")
+    }.mkString(File.separator)
   }
   override def run(sqlContext: SQLContext): Seq[Row] = {
     val catalog = sqlContext.sessionState.catalog

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/commands.scala
@@ -18,8 +18,9 @@
 package org.apache.spark.sql.execution.command
 
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{Row, SparkSession}
-import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
+import org.apache.spark.sql.{Dataset, Row, SQLContext}
+import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow, TableIdentifier}
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
 import org.apache.spark.sql.catalyst.errors.TreeNodeException
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
 import org.apache.spark.sql.catalyst.plans.logical
@@ -110,5 +111,99 @@ case class ExplainCommand(
     Seq(Row(outputString))
   } catch { case cause: TreeNodeException[_] =>
     ("Error occurred during query planning: \n" + cause.getMessage).split("\n").map(Row(_))
+  }
+}
+
+/**
+ * A command for users to list the column names for a table. This function creates a
+ * [[ShowColumnsCommand]] logical plan.
+ *
+ * The syntax of using this command in SQL is:
+ * {{{
+ *   SHOW COLUMNS (FROM | IN) table_identifier [(FROM | IN) database];
+ * }}}
+ */
+case class ShowColumnsCommand(table: TableIdentifier) extends RunnableCommand {
+  // The result of SHOW COLUMNS has one column called 'result'
+  override val output: Seq[Attribute] = {
+    AttributeReference("result", StringType, nullable = false)() :: Nil
+  }
+
+  override def run(sqlContext: SQLContext): Seq[Row] = {
+    val relation = sqlContext.sessionState.catalog.lookupRelation(table, None)
+    relation.schema.fields.map { field =>
+      Row(field.name)
+    }
+  }
+}
+
+/**
+ * A command for users to list the partition names of a table. If the partition spec is specified,
+ * partitions that match the spec are returned. [[AnalysisException]] exception is thrown under
+ * the following conditions:
+ *
+ * 1. If the command is called for a non partitioned table.
+ * 2. If the partition spec refers to the columns that are not defined as partitioning columns.
+ *
+ * This function creates a [[ShowPartitionsCommand]] logical plan
+ *
+ * The syntax of using this command in SQL is:
+ * {{{
+ *   SHOW PARTITIONS [db_name.]table_name [PARTITION(partition_spec)]
+ * }}}
+ */
+case class ShowPartitionsCommand(
+    table: TableIdentifier,
+    partitionSpec: Option[Map[String, String]]) extends RunnableCommand {
+  // The result of SHOW PARTITIONS has one column called 'result'
+  override val output: Seq[Attribute] = {
+    AttributeReference("result", StringType, nullable = false)() :: Nil
+  }
+
+  /**
+   * This function validates the partitioning spec by making sure all the referenced columns are
+   * defined as partitioning columns in table definition. An AnalysisException exception is
+   * thrown if the partitioning spec is invalid.
+   */
+  private def validatePartitionSpec(table: CatalogTable, spec: Map[String, String]): Unit = {
+    if (!spec.keySet.forall(table.partitionColumns.map(_.name).contains)) {
+      throw new AnalysisException(s"Partition spec ${spec.mkString("(", ", ", ")")} contains " +
+        s"non-partition columns")
+    }
+  }
+
+  /**
+   * Validates and throws an [[AnalysisException]] exception under the following conditions:
+   * 1. If the table is not partitioned.
+   * 2. If it is a datasource table.
+   * 3. If it is a view or index table.
+   */
+  private def checkRequirements(table: CatalogTable): Unit = {
+    if (table.tableType == CatalogTableType.VIRTUAL_VIEW ||
+      table.tableType == CatalogTableType.INDEX_TABLE) {
+      throw new AnalysisException("Operation not allowed: view or index table")
+    } else if (!DDLUtils.isTablePartitioned(table)) {
+      throw new AnalysisException(s"Table ${table.qualifiedName} is not a partitioned table")
+    } else if (DDLUtils.isDatasourceTable(table)) {
+      throw new AnalysisException("Operation not allowed: datasource table")
+    }
+  }
+
+  override def run(sqlContext: SQLContext): Seq[Row] = {
+    val catalog = sqlContext.sessionState.catalog
+    val db = table.database.getOrElse(catalog.getCurrentDatabase)
+    if (catalog.isTemporaryTable(table)) {
+      Seq.empty[Row]
+    } else {
+      val tab = catalog.getTable(table)
+      checkRequirements(tab)
+      val partNames = partitionSpec match {
+        case None => catalog.getPartitionNames(db, table.identifier, -1.asInstanceOf[Short])
+        case Some(spec) =>
+          validatePartitionSpec(tab, spec)
+          catalog.getPartitionNames(db, table.identifier, spec, -1.asInstanceOf[Short])
+      }
+      partNames.map { p => Row(p) }
+    }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -536,5 +536,9 @@ private[sql] object DDLUtils {
       case _ =>
     })
   }
+  def isTablePartitioned(table: CatalogTable): Boolean = {
+    table.partitionColumns.size > 0 ||
+      table.properties.contains("spark.sql.sources.schema.numPartCols")
+  }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -424,7 +424,7 @@ private[sql] object PartitioningUtils {
     path.foreach { c =>
       if (needsEscaping(c)) {
         builder.append('%')
-        builder.append(f"${c.asInstanceOf[Int]}%02x")
+        builder.append(f"${c.asInstanceOf[Int]}%02X")
       } else {
         builder.append(c)
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandSuite.scala
@@ -678,7 +678,7 @@ class DDLCommandSuite extends PlanTest {
     comparePlans(parsed3, expected3)
     comparePlans(parsed4, expected4)
   }
-  
+
   test("show columns") {
     val sql1 = "SHOW COLUMNS FROM t1"
     val sql2 = "SHOW COLUMNS IN db1.t1"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandSuite.scala
@@ -624,7 +624,7 @@ class DDLCommandSuite extends PlanTest {
     comparePlans(parsed1, expected1)
     comparePlans(parsed2, expected2)
   }
-
+  
   test("SPARK-14383: DISTRIBUTE and UNSET as non-keywords") {
     val sql = "SELECT distribute, unset FROM x"
     val parsed = parser.parsePlan(sql)
@@ -677,5 +677,45 @@ class DDLCommandSuite extends PlanTest {
     comparePlans(parsed2, expected2)
     comparePlans(parsed3, expected3)
     comparePlans(parsed4, expected4)
+  }
+  
+  test("show columns") {
+    val sql1 = "SHOW COLUMNS FROM t1"
+    val sql2 = "SHOW COLUMNS IN db1.t1"
+    val sql3 = "SHOW COLUMNS FROM t1 IN db1"
+    val sql4 = "SHOW COLUMNS FROM db1.t1 IN db2"
+
+    val parsed1 = parser.parsePlan(sql1)
+    val expected1 = ShowColumnsCommand(TableIdentifier("t1", None))
+    val parsed2 = parser.parsePlan(sql2)
+    val expected2 = ShowColumnsCommand(TableIdentifier("t1", Some("db1")))
+    val parsed3 = parser.parsePlan(sql3)
+    comparePlans(parsed1, expected1)
+    comparePlans(parsed2, expected2)
+    comparePlans(parsed3, expected2)
+    val message = intercept[ParseException] {
+      parser.parsePlan(sql4)
+    }.getMessage
+    assert(message.contains("Duplicates the declaration for database"))
+  }
+
+  test("show partitions") {
+    val sql1 = "SHOW PARTITIONS t1"
+    val sql2 = "SHOW PARTITIONS db1.t1"
+    val sql3 = "SHOW PARTITIONS t1 PARTITION(partcol1='partvalue', partcol2='partvalue')"
+
+    val parsed1 = parser.parsePlan(sql1)
+    val expected1 =
+      ShowPartitionsCommand(TableIdentifier("t1", None), None)
+    val parsed2 = parser.parsePlan(sql2)
+    val expected2 =
+      ShowPartitionsCommand(TableIdentifier("t1", Some("db1")), None)
+    val expected3 =
+      ShowPartitionsCommand(TableIdentifier("t1", None),
+        Some(Map("partcol1" -> "partvalue", "partcol2" -> "partvalue")))
+    val parsed3 = parser.parsePlan(sql3)
+    comparePlans(parsed1, expected1)
+    comparePlans(parsed2, expected2)
+    comparePlans(parsed3, expected3)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandSuite.scala
@@ -624,7 +624,7 @@ class DDLCommandSuite extends PlanTest {
     comparePlans(parsed1, expected1)
     comparePlans(parsed2, expected2)
   }
-  
+
   test("SPARK-14383: DISTRIBUTE and UNSET as non-keywords") {
     val sql = "SELECT distribute, unset FROM x"
     val parsed = parser.parsePlan(sql)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -283,10 +283,35 @@ private[spark] class HiveExternalCatalog(client: HiveClient) extends ExternalCat
     client.getPartition(db, table, spec)
   }
 
+  /**
+   * Returns the partition names from hive metastore for a given table in a database.
+   */
   override def listPartitions(
       db: String,
       table: String): Seq[CatalogTablePartition] = withClient {
     client.getAllPartitions(db, table)
+  }
+
+  /**
+   * Returns the partition names from hive metastore for a given table in a database.
+   */
+  override def getPartitionNames(
+      db: String,
+      table: String,
+      range: Short): Seq[String] = withClient {
+    client.getPartitionNames(db, table, range)
+  }
+
+  /**
+   * Returns the partition names that matches the partition spec for a given table in a database.
+   * When no match is found, an empty Sequence is returned.
+   */
+  override def getPartitionNames(
+      db: String,
+      table: String,
+      spec: TablePartitionSpec,
+      range: Short): Seq[String] = withClient {
+    client.getPartitionNames(db, table, spec, range)
   }
 
   // --------------------------------------------------------------------------

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -288,30 +288,9 @@ private[spark] class HiveExternalCatalog(client: HiveClient) extends ExternalCat
    */
   override def listPartitions(
       db: String,
-      table: String): Seq[CatalogTablePartition] = withClient {
-    client.getAllPartitions(db, table)
-  }
-
-  /**
-   * Returns the partition names from hive metastore for a given table in a database.
-   */
-  override def getPartitionNames(
-      db: String,
       table: String,
-      range: Short): Seq[String] = withClient {
-    client.getPartitionNames(db, table, range)
-  }
-
-  /**
-   * Returns the partition names that matches the partition spec for a given table in a database.
-   * When no match is found, an empty Sequence is returned.
-   */
-  override def getPartitionNames(
-      db: String,
-      table: String,
-      spec: TablePartitionSpec,
-      range: Short): Seq[String] = withClient {
-    client.getPartitionNames(db, table, spec, range)
+      partialSpec: Option[TablePartitionSpec] = None): Seq[CatalogTablePartition] = withClient {
+    client.getPartitions(db, table, partialSpec)
   }
 
   // --------------------------------------------------------------------------

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/MetastoreRelation.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/MetastoreRelation.scala
@@ -130,7 +130,7 @@ private[hive] case class MetastoreRelation(
 
   // When metastore partition pruning is turned off, we cache the list of all partitions to
   // mimic the behavior of Spark < 1.5
-  private lazy val allPartitions: Seq[CatalogTablePartition] = client.getAllPartitions(catalogTable)
+  private lazy val allPartitions: Seq[CatalogTablePartition] = client.getPartitions(catalogTable)
 
   def getHiveQlPartitions(predicates: Seq[Expression] = Nil): Seq[Partition] = {
     val rawPartitions = if (sparkSession.sessionState.conf.metastorePartitionPruning) {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
@@ -150,21 +150,6 @@ private[hive] trait HiveClient {
     }
   }
 
-  /**
-   * Returns the partition names from hive metastore for a given table in a database.
-   */
-  def getPartitionNames(db: String, table: String, range: Short): Seq[String]
-
-  /**
-   * Returns the partition names that matches the partition spec for a given table in a database.
-   * When no match is found, an empty Sequence is returned.
-   */
-  def getPartitionNames(
-      db: String,
-      table: String,
-      spec: ExternalCatalog.TablePartitionSpec,
-      range: Short): Seq[String]
-
   /** Returns the specified partition or None if it does not exist. */
   final def getPartitionOption(
       db: String,
@@ -178,13 +163,24 @@ private[hive] trait HiveClient {
       table: CatalogTable,
       spec: ExternalCatalog.TablePartitionSpec): Option[CatalogTablePartition]
 
-  /** Returns all partitions for the given table. */
-  final def getAllPartitions(db: String, table: String): Seq[CatalogTablePartition] = {
-    getAllPartitions(getTable(db, table))
+  /**
+   * Returns the partitions for the given table that match the supplied partition spec.
+   * If no partition spec is specified, all partitions are returned.
+   */
+  final def getPartitions(
+      db: String,
+      table: String,
+      partialSpec: Option[ExternalCatalog.TablePartitionSpec]): Seq[CatalogTablePartition] = {
+    getPartitions(getTable(db, table), partialSpec)
   }
 
-  /** Returns all partitions for the given table. */
-  def getAllPartitions(table: CatalogTable): Seq[CatalogTablePartition]
+  /**
+   * Returns the partitions for the given table that match the supplied partition spec.
+   * If no partition spec is specified, all partitions are returned.
+   */
+  def getPartitions(
+      table: CatalogTable,
+      partialSpec: Option[ExternalCatalog.TablePartitionSpec] = None): Seq[CatalogTablePartition]
 
   /** Returns partitions filtered by predicates for the given table. */
   def getPartitionsByFilter(

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
@@ -150,6 +150,21 @@ private[hive] trait HiveClient {
     }
   }
 
+  /**
+   * Returns the partition names from hive metastore for a given table in a database.
+   */
+  def getPartitionNames(db: String, table: String, range: Short): Seq[String]
+
+  /**
+   * Returns the partition names that matches the partition spec for a given table in a database.
+   * When no match is found, an empty Sequence is returned.
+   */
+  def getPartitionNames(
+      db: String,
+      table: String,
+      spec: ExternalCatalog.TablePartitionSpec,
+      range: Short): Seq[String]
+
   /** Returns the specified partition or None if it does not exist. */
   final def getPartitionOption(
       db: String,

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -428,6 +428,28 @@ private[hive] class HiveClientImpl(
     Option(hivePartition).map(fromHivePartition)
   }
 
+  /**
+   * Returns the partition names from hive metastore for a given table in a database.
+   */
+  override def getPartitionNames(
+      db: String,
+      table: String,
+      range: Short): Seq[String] = withHiveState {
+    client.getPartitionNames(db, table, -1).asScala
+  }
+
+  /**
+   * Returns the partition names that matches the partition spec for a given table in a database.
+   * When no match is found, an empty Sequence is returned.
+   */
+  override def getPartitionNames(
+      db: String,
+      table: String,
+      spec: ExternalCatalog.TablePartitionSpec,
+      range: Short): Seq[String] = withHiveState {
+    client.getPartitionNames(db, table, spec.asJava, -1).asScala
+  }
+
   override def getAllPartitions(table: CatalogTable): Seq[CatalogTablePartition] = withHiveState {
     val hiveTable = toHiveTable(table)
     shim.getAllPartitions(client, hiveTable).map(fromHivePartition)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -28,8 +28,7 @@ import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.metastore.{PartitionDropOptions, TableType => HiveTableType}
 import org.apache.hadoop.hive.metastore.api.{Database => HiveDatabase, FieldSchema, Function => HiveFunction, FunctionType, PrincipalType, ResourceType, ResourceUri}
 import org.apache.hadoop.hive.ql.Driver
-import org.apache.hadoop.hive.ql.metadata.{Partition => HivePartition, Table => HiveTable}
-import org.apache.hadoop.hive.ql.metadata.{Hive, HiveException}
+import org.apache.hadoop.hive.ql.metadata.{Hive, HiveException, Partition => HivePartition, Table => HiveTable}
 import org.apache.hadoop.hive.ql.plan.AddPartitionDesc
 import org.apache.hadoop.hive.ql.processors._
 import org.apache.hadoop.hive.ql.session.SessionState
@@ -41,6 +40,7 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.{NoSuchDatabaseException, NoSuchPartitionException}
 import org.apache.spark.sql.catalyst.catalog._
+import org.apache.spark.sql.catalyst.catalog.ExternalCatalog.TablePartitionSpec
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.execution.QueryExecutionException
 import org.apache.spark.util.{CircularBuffer, Utils}
@@ -422,37 +422,24 @@ private[hive] class HiveClientImpl(
 
   override def getPartitionOption(
       table: CatalogTable,
-      spec: ExternalCatalog.TablePartitionSpec): Option[CatalogTablePartition] = withHiveState {
+      spec: TablePartitionSpec): Option[CatalogTablePartition] = withHiveState {
     val hiveTable = toHiveTable(table)
     val hivePartition = client.getPartition(hiveTable, spec.asJava, false)
     Option(hivePartition).map(fromHivePartition)
   }
 
   /**
-   * Returns the partition names from hive metastore for a given table in a database.
+   * Returns the partitions for the given table that match the supplied partition spec.
+   * If no partition spec is specified, all partitions are returned.
    */
-  override def getPartitionNames(
-      db: String,
-      table: String,
-      range: Short): Seq[String] = withHiveState {
-    client.getPartitionNames(db, table, -1).asScala
-  }
-
-  /**
-   * Returns the partition names that matches the partition spec for a given table in a database.
-   * When no match is found, an empty Sequence is returned.
-   */
-  override def getPartitionNames(
-      db: String,
-      table: String,
-      spec: ExternalCatalog.TablePartitionSpec,
-      range: Short): Seq[String] = withHiveState {
-    client.getPartitionNames(db, table, spec.asJava, -1).asScala
-  }
-
-  override def getAllPartitions(table: CatalogTable): Seq[CatalogTablePartition] = withHiveState {
+  override def getPartitions(
+      table: CatalogTable,
+      spec: Option[TablePartitionSpec]): Seq[CatalogTablePartition] = withHiveState {
     val hiveTable = toHiveTable(table)
-    shim.getAllPartitions(client, hiveTable).map(fromHivePartition)
+    spec match {
+      case None => shim.getAllPartitions(client, hiveTable).map(fromHivePartition)
+      case Some(s) => client.getPartitions(hiveTable, s.asJava).asScala.map(fromHivePartition)
+    }
   }
 
   override def getPartitionsByFilter(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
@@ -189,7 +189,7 @@ class VersionsSuite extends SparkFunSuite with Logging {
     }
 
     test(s"$version: getPartitions") {
-      client.getAllPartitions(client.getTable("default", "src_part"))
+      client.getPartitions(client.getTable("default", "src_part"))
     }
 
     test(s"$version: getPartitionsByFilter") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
@@ -17,7 +17,8 @@
 
 package org.apache.spark.sql.hive.execution
 
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, QueryTest, Row, SaveMode}
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 import org.apache.spark.sql.hive.test.TestHiveSingleton
 import org.apache.spark.sql.test.SQLTestUtils
 
@@ -36,12 +37,22 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
         |STORED AS PARQUET
         |TBLPROPERTIES('prop1Key'="prop1Val", '`prop2Key`'="prop2Val")
       """.stripMargin)
+     sql("CREATE TABLE parquet_tab3(col1 int, `col 2` int)")
+     sql("CREATE TABLE parquet_tab4 (price int, qty int) partitioned by (year int, month int)")
+     sql("INSERT INTO parquet_tab4 PARTITION(year = 2015, month=1) SELECT 1,1")
+     sql("INSERT INTO parquet_tab4 PARTITION(year = 2015, month=2) SELECT 2,2")
+     sql("INSERT INTO parquet_tab4 PARTITION(year = 2016, month=2) SELECT 3,3")
+     sql("INSERT INTO parquet_tab4 PARTITION(year = 2016, month=3) SELECT 3,3")
+     sql("CREATE VIEW parquet_view1 as select * from parquet_tab4")
   }
 
   override protected def afterAll(): Unit = {
     try {
       sql("DROP TABLE IF EXISTS parquet_tab1")
       sql("DROP TABLE IF EXISTS parquet_tab2")
+      sql("DROP TABLE IF EXISTS parquet_tab3")
+      sql("DROP TABLE IF EXISTS parquet_tab4")
+      sql("DROP VIEW IF EXISTS parquet_view1")
     } finally {
       super.afterAll()
     }
@@ -245,6 +256,105 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
         sql(s"""LOAD DATA INPATH "$testData" INTO TABLE non_part_table""")
       }
       hiveContext.sessionState.hadoopConf.set("fs.default.name", originalFsName)
+    }
+  }
+  
+    test("show columns") {
+    checkAnswer(
+      sql("SHOW COLUMNS IN parquet_tab3"),
+      Row("col1") :: Row("col 2") :: Nil)
+
+    checkAnswer(
+      sql("SHOW COLUMNS IN default.parquet_tab3"),
+      Row("col1") :: Row("col 2") :: Nil)
+
+    checkAnswer(
+      sql("SHOW COLUMNS IN parquet_tab3 FROM default"),
+      Row("col1") :: Row("col 2") :: Nil)
+
+    checkAnswer(
+      sql("SHOW COLUMNS IN parquet_tab4 IN default"),
+      Row("price") :: Row("qty") :: Row("year") :: Row("month") :: Nil)
+
+    val message = intercept[NoSuchTableException] {
+      sql("SHOW COLUMNS IN badtable FROM default")
+    }.getMessage
+    assert(message.contains("Table badtable not found in database"))
+  }
+
+  test("show partitions - show everything") {
+    checkAnswer(
+      sql("show partitions parquet_tab4"),
+      Row("year=2015/month=1") ::
+        Row("year=2015/month=2") ::
+        Row("year=2016/month=2") ::
+        Row("year=2016/month=3") :: Nil)
+
+    checkAnswer(
+      sql("show partitions default.parquet_tab4"),
+      Row("year=2015/month=1") ::
+        Row("year=2015/month=2") ::
+        Row("year=2016/month=2") ::
+        Row("year=2016/month=3") :: Nil)
+  }
+
+  test("show partitions - filter") {
+    checkAnswer(
+      sql("show partitions default.parquet_tab4 PARTITION(year=2015)"),
+      Row("year=2015/month=1") ::
+        Row("year=2015/month=2") :: Nil)
+
+    checkAnswer(
+      sql("show partitions default.parquet_tab4 PARTITION(year=2015, month=1)"),
+      Row("year=2015/month=1") :: Nil)
+
+    checkAnswer(
+      sql("show partitions default.parquet_tab4 PARTITION(month=2)"),
+      Row("year=2015/month=2") ::
+        Row("year=2016/month=2") :: Nil)
+  }
+
+  test("show partitions - empty row") {
+    withTempTable("parquet_temp") {
+      sql(
+        """
+          |CREATE TEMPORARY TABLE parquet_temp (c1 INT, c2 STRING)
+          |USING org.apache.spark.sql.parquet.DefaultSource
+        """.stripMargin)
+      // An empty sequence of row is returned for session temporary table.
+      checkAnswer(sql("SHOW PARTITIONS parquet_temp"), Nil)
+      val message1 = intercept[AnalysisException] {
+        sql("SHOW PARTITIONS parquet_tab3")
+      }.getMessage
+      assert(message1.contains("is not a partitioned table"))
+
+      val message2 = intercept[AnalysisException] {
+        sql("SHOW PARTITIONS parquet_tab4 PARTITION(abcd=2015, xyz=1)")
+      }.getMessage
+      assert(message2.contains("Partition spec (abcd -> 2015, xyz -> 1) contains " +
+        "non-partition columns"))
+
+      val message3 = intercept[AnalysisException] {
+        sql("SHOW PARTITIONS parquet_view1")
+      }.getMessage
+      assert(message3.contains("Operation not allowed: view or index table"))
+    }
+  }
+
+  test("show partitions - datasource") {
+    import sqlContext.implicits._
+    withTable("part_datasrc") {
+      val df = (1 to 3).map(i => (i, s"val_$i", i * 2)).toDF("a", "b", "c")
+      df.write
+        .partitionBy("a")
+        .format("parquet")
+        .mode(SaveMode.Overwrite)
+        .saveAsTable("part_datasrc")
+
+      val message1 = intercept[AnalysisException] {
+        sql("SHOW PARTITIONS part_datasrc")
+      }.getMessage
+      assert(message1.contains("Operation not allowed: datasource table"))
     }
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
@@ -52,8 +52,8 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
       sql("DROP TABLE IF EXISTS parquet_tab1")
       sql("DROP TABLE IF EXISTS parquet_tab2")
       sql("DROP TABLE IF EXISTS parquet_tab3")
-      sql("DROP TABLE IF EXISTS parquet_tab4")
       sql("DROP VIEW IF EXISTS parquet_view1")
+      sql("DROP TABLE IF EXISTS parquet_tab4")
     } finally {
       super.afterAll()
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveComparisonTest.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveComparisonTest.scala
@@ -175,7 +175,7 @@ abstract class HiveComparisonTest
           .filterNot(_ == "")
       case _: HiveNativeCommand => answer.filterNot(nonDeterministicLine).filterNot(_ == "")
       case _: ExplainCommand => answer
-      case _: DescribeTableCommand =>
+      case _: DescribeTableCommand | ShowColumnsCommand(_) =>
         // Filter out non-deterministic lines and lines which do not have actual results but
         // can introduce problems because of the way Hive formats these lines.
         // Then, remove empty lines. Do not sort the results.

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveComparisonTest.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveComparisonTest.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.catalyst.SQLBuilder
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.util._
-import org.apache.spark.sql.execution.command.{DescribeTableCommand, ExplainCommand, HiveNativeCommand, SetCommand}
+import org.apache.spark.sql.execution.command.{DescribeTableCommand, ExplainCommand, HiveNativeCommand, SetCommand, ShowColumnsCommand}
 import org.apache.spark.sql.hive.{InsertIntoHiveTable => LogicalInsertIntoHiveTable}
 import org.apache.spark.sql.hive.test.{TestHive, TestHiveQueryExecution}
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds Native execution of SHOW COLUMNS and SHOW PARTITION commands.

Command Syntax:

``` SQL
SHOW COLUMNS (FROM | IN) table_identifier [(FROM | IN) database]
```

``` SQL
SHOW PARTITIONS [db_name.]table_name [PARTITION(partition_spec)]
```
## How was this patch tested?

Added test cases in HiveCommandSuite to verify execution and DDLCommandSuite
to verify plans.
