### PR TITLE
[SPARK-14103][SQL] Parse unescaped quotes in CSV data source.

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.2
+++ b/dev/deps/spark-deps-hadoop-2.2
@@ -175,7 +175,8 @@ stax-api-1.0.1.jar
 stream-2.7.0.jar
 stringtemplate-3.2.1.jar
 super-csv-2.2.0.jar
-univocity-parsers-1.5.6.jar
+univocity-parsers-2.0.2.jar
+unused-1.0.0.jar
 xbean-asm5-shaded-4.4.jar
 xmlenc-0.52.jar
 xz-1.0.jar

--- a/dev/deps/spark-deps-hadoop-2.2
+++ b/dev/deps/spark-deps-hadoop-2.2
@@ -176,7 +176,6 @@ stream-2.7.0.jar
 stringtemplate-3.2.1.jar
 super-csv-2.2.0.jar
 univocity-parsers-2.0.2.jar
-unused-1.0.0.jar
 xbean-asm5-shaded-4.4.jar
 xmlenc-0.52.jar
 xz-1.0.jar

--- a/dev/deps/spark-deps-hadoop-2.3
+++ b/dev/deps/spark-deps-hadoop-2.3
@@ -166,7 +166,8 @@ stax-api-1.0.1.jar
 stream-2.7.0.jar
 stringtemplate-3.2.1.jar
 super-csv-2.2.0.jar
-univocity-parsers-1.5.6.jar
+univocity-parsers-2.0.2.jar
+unused-1.0.0.jar
 xbean-asm5-shaded-4.4.jar
 xmlenc-0.52.jar
 xz-1.0.jar

--- a/dev/deps/spark-deps-hadoop-2.3
+++ b/dev/deps/spark-deps-hadoop-2.3
@@ -167,7 +167,6 @@ stream-2.7.0.jar
 stringtemplate-3.2.1.jar
 super-csv-2.2.0.jar
 univocity-parsers-2.0.2.jar
-unused-1.0.0.jar
 xbean-asm5-shaded-4.4.jar
 xmlenc-0.52.jar
 xz-1.0.jar

--- a/dev/deps/spark-deps-hadoop-2.4
+++ b/dev/deps/spark-deps-hadoop-2.4
@@ -168,7 +168,6 @@ stream-2.7.0.jar
 stringtemplate-3.2.1.jar
 super-csv-2.2.0.jar
 univocity-parsers-2.0.2.jar
-unused-1.0.0.jar
 xbean-asm5-shaded-4.4.jar
 xmlenc-0.52.jar
 xz-1.0.jar

--- a/dev/deps/spark-deps-hadoop-2.4
+++ b/dev/deps/spark-deps-hadoop-2.4
@@ -167,7 +167,8 @@ stax-api-1.0.1.jar
 stream-2.7.0.jar
 stringtemplate-3.2.1.jar
 super-csv-2.2.0.jar
-univocity-parsers-1.5.6.jar
+univocity-parsers-2.0.2.jar
+unused-1.0.0.jar
 xbean-asm5-shaded-4.4.jar
 xmlenc-0.52.jar
 xz-1.0.jar

--- a/dev/deps/spark-deps-hadoop-2.6
+++ b/dev/deps/spark-deps-hadoop-2.6
@@ -174,7 +174,6 @@ stream-2.7.0.jar
 stringtemplate-3.2.1.jar
 super-csv-2.2.0.jar
 univocity-parsers-2.0.2.jar
-unused-1.0.0.jar
 xbean-asm5-shaded-4.4.jar
 xercesImpl-2.9.1.jar
 xmlenc-0.52.jar

--- a/dev/deps/spark-deps-hadoop-2.6
+++ b/dev/deps/spark-deps-hadoop-2.6
@@ -173,7 +173,8 @@ stax-api-1.0.1.jar
 stream-2.7.0.jar
 stringtemplate-3.2.1.jar
 super-csv-2.2.0.jar
-univocity-parsers-1.5.6.jar
+univocity-parsers-2.0.2.jar
+unused-1.0.0.jar
 xbean-asm5-shaded-4.4.jar
 xercesImpl-2.9.1.jar
 xmlenc-0.52.jar

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -174,7 +174,8 @@ stax-api-1.0.1.jar
 stream-2.7.0.jar
 stringtemplate-3.2.1.jar
 super-csv-2.2.0.jar
-univocity-parsers-1.5.6.jar
+univocity-parsers-2.0.2.jar
+unused-1.0.0.jar
 xbean-asm5-shaded-4.4.jar
 xercesImpl-2.9.1.jar
 xmlenc-0.52.jar

--- a/dev/deps/spark-deps-hadoop-2.7
+++ b/dev/deps/spark-deps-hadoop-2.7
@@ -175,7 +175,6 @@ stream-2.7.0.jar
 stringtemplate-3.2.1.jar
 super-csv-2.2.0.jar
 univocity-parsers-2.0.2.jar
-unused-1.0.0.jar
 xbean-asm5-shaded-4.4.jar
 xercesImpl-2.9.1.jar
 xmlenc-0.52.jar

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>com.univocity</groupId>
       <artifactId>univocity-parsers</artifactId>
-      <version>1.5.6</version>
+      <version>2.0.2</version>
       <type>jar</type>
     </dependency>
     <dependency>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParser.scala
@@ -47,6 +47,7 @@ private[sql] abstract class CsvReader(params: CSVOptions, headers: Seq[String]) 
     settings.setMaxColumns(params.maxColumns)
     settings.setNullValue(params.nullValue)
     settings.setMaxCharsPerColumn(params.maxCharsPerColumn)
+    settings.setParseUnescapedQuotesUntilDelimiter(true)
     if (headers != null) settings.setHeaders(headers: _*)
 
     new CsvParser(settings)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVParser.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.datasources.csv
 import java.io.{ByteArrayOutputStream, OutputStreamWriter, StringReader}
 import java.nio.charset.StandardCharsets
 
+import com.univocity.parsers.common.TextParsingException
 import com.univocity.parsers.csv.{CsvParser, CsvParserSettings, CsvWriter, CsvWriterSettings}
 
 import org.apache.spark.internal.Logging
@@ -104,10 +105,18 @@ private[sql] class LineCsvReader(params: CSVOptions)
    * @return array of strings where each string is a field in the CSV record
    */
   def parseLine(line: String): Array[String] = {
-    parser.beginParsing(new StringReader(line))
-    val parsed = parser.parseNext()
-    parser.stopParsing()
-    parsed
+    try {
+      parser.parseLine(line)
+    } catch {
+      case e: TextParsingException =>
+        val contents = e.getParsedContent
+        val length = e.getParsedContent.length
+        val colIndex = e.getColumnIndex
+        throw new RuntimeException(s"Length of parsed input exceeds the maximum number of " +
+          s"characters defined at maxCharsPerColumn. Please increase the value " +
+          s"for maxCharsPerColumn option. Column index: [$colIndex] " +
+          s"maxCharsPerColumn value: [$length] Parsed content: [$contents]")
+    }
   }
 }
 
@@ -135,7 +144,18 @@ private[sql] class BulkCsvReader(
   override def next(): Array[String] = {
     val curRecord = nextRecord
     if(curRecord != null) {
-      nextRecord = parser.parseNext()
+      try {
+        nextRecord = parser.parseNext()
+      } catch {
+        case e: TextParsingException =>
+          val contents = e.getParsedContent
+          val length = e.getParsedContent.length
+          val colIndex = e.getColumnIndex
+          throw new RuntimeException(s"Length of parsed input exceeds the maximum number of " +
+            s"characters defined at maxCharsPerColumn. Please increase the value " +
+            s"for maxCharsPerColumn option. Column index: [$colIndex] " +
+            s"maxCharsPerColumn value: [$length] Parsed content: [$contents]")
+      }
     } else {
       throw new NoSuchElementException("next record is null")
     }

--- a/sql/core/src/test/resources/unescaped-quotes.csv
+++ b/sql/core/src/test/resources/unescaped-quotes.csv
@@ -1,0 +1,2 @@
+"a"b,ccc,ddd
+ab,cc"c,ddd"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -45,6 +45,7 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
   private val disableCommentsFile = "disable_comments.csv"
   private val boolFile = "bool.csv"
   private val simpleSparseFile = "simple_sparse.csv"
+  private val unescapedQuotesFile = "unescaped-quotes.csv"
 
   private def testFile(fileName: String): String = {
     Thread.currentThread().getContextClassLoader.getResource(fileName).toString
@@ -138,6 +139,17 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
       .load(testFile(carsAltFile))
 
     verifyCars(cars, withHeader = true)
+  }
+
+  test("parse unescaped quotes with maxCharsPerColumn") {
+    val rows = sqlContext.read
+      .format("csv")
+      .option("maxCharsPerColumn", "4")
+      .load(testFile(unescapedQuotesFile))
+
+    val expectedRows = Seq(Row("\"a\"b", "ccc", "ddd"), Row("ab", "cc\"c", "ddd\""))
+
+    checkAnswer(rows, expectedRows)
   }
 
   test("bad encoding name") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -152,19 +152,6 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
     checkAnswer(rows, expectedRows)
   }
 
-  test("throws an wrapped exception for maxCharsPerColumn") {
-    val exception = intercept[RuntimeException] {
-      val rows = sqlContext.read
-        .format("csv")
-        .option("maxCharsPerColumn", "2")
-        .load(testFile(unescapedQuotesFile))
-        .collect()
-    }
-
-    assert(exception.getMessage.contains("Length of parsed input exceeds the " +
-      "maximum number of characters defined at maxCharsPerColumn."))
-  }
-
   test("bad encoding name") {
     val exception = intercept[UnsupportedCharsetException] {
       sqlContext

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -152,6 +152,19 @@ class CSVSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
     checkAnswer(rows, expectedRows)
   }
 
+  test("throws an wrapped exception for maxCharsPerColumn") {
+    val exception = intercept[RuntimeException] {
+      val rows = sqlContext.read
+        .format("csv")
+        .option("maxCharsPerColumn", "2")
+        .load(testFile(unescapedQuotesFile))
+        .collect()
+    }
+
+    assert(exception.getMessage.contains("Length of parsed input exceeds the " +
+      "maximum number of characters defined at maxCharsPerColumn."))
+  }
+
   test("bad encoding name") {
     val exception = intercept[UnsupportedCharsetException] {
       sqlContext


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR resolves the problem during parsing unescaped quotes in input data. For example, currently the data below:

```
"a"b,ccc,ddd
e,f,g
```

produces a data below:
- **Before**

``` bash
["a"b,ccc,ddd[\n]e,f,g]  <- as a value.
```
- **After**

``` bash
["a"b], [ccc], [ddd]
[e], [f], [g]
```

This PR bumps up the Univocity parser's version. This was fixed in `2.0.2`, https://github.com/uniVocity/univocity-parsers/issues/60.
## How was this patch tested?

Unit tests in `CSVSuite` and `sbt/sbt scalastyle`.
