### PR TITLE
[SPARK-14467][SQL] Interleave CPU and IO better in FileScanRDD.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
@@ -85,30 +85,23 @@ class FileScanRDD(
 
       /** Advances to the next file. Returns true if a new non-empty iterator is available. */
       private def nextIterator(): Boolean = {
-        if (asyncIO) {
-          if (nextFile == null) return false
-        } else {
-          if (!files.hasNext) return false
-        }
-
-        // Wait for the async task to complete
         val file = if (asyncIO) {
+          if (nextFile == null) return false
+          // Wait for the async task to complete
           Await.result(nextFile, Duration.Inf)
         } else {
+          if (!files.hasNext) return false
           val f = files.next()
-          val it = readFunction(f)
-          NextFile(f, it)
+          NextFile(f, readFunction(f))
         }
 
         // This is only used to evaluate the rest of the execution so we can safely set it here.
         SqlNewHadoopRDDState.setInputFileName(file.file.filePath)
         currentIterator = file.iter
 
-        if (asyncIO && files.hasNext) {
+        if (asyncIO) {
           // Asynchronously start the next file.
           nextFile = prepareNextFile()
-        } else {
-          nextFile = null
         }
 
         hasNext
@@ -119,17 +112,17 @@ class FileScanRDD(
       }
 
       def prepareNextFile() = {
-        Future {
-          if (files.hasNext) {
+        if (files.hasNext) {
+          Future {
             val file = files.next()
             val it = readFunction(file)
             // Read something from the file to trigger some initial IO.
             it.hasNext
             NextFile(file, it)
-          } else {
-            null
-          }
-        }(FileScanRDD.ioExecutionContext)
+          }(FileScanRDD.ioExecutionContext)
+        } else {
+          null
+        }
       }
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -28,7 +28,6 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
 import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.sql.catalyst.CatalystConf
-import org.apache.spark.util.Utils
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // This file defines the configuration options for Spark SQL.
@@ -417,6 +416,12 @@ object SQLConf {
     .longConf
     .createWithDefault(4 * 1024 * 1024)
 
+  val FILES_ASYNC_IO = SQLConfigBuilder("spark.sql.files.asyncIO")
+    .internal()
+    .doc("If true, attempts to asynchronously do IO when reading data.")
+    .booleanConf
+    .createWithDefault(true)
+
   val EXCHANGE_REUSE_ENABLED = SQLConfigBuilder("spark.sql.exchange.reuse")
     .internal()
     .doc("When true, the planner will try to find out duplicated exchanges and re-use them.")
@@ -478,6 +483,8 @@ private[sql] class SQLConf extends Serializable with CatalystConf with Logging {
   def filesMaxPartitionBytes: Long = getConf(FILES_MAX_PARTITION_BYTES)
 
   def filesOpenCostInBytes: Long = getConf(FILES_OPEN_COST_IN_BYTES)
+
+  def filesAsyncIO: Boolean = getConf(FILES_ASYNC_IO)
 
   def useCompression: Boolean = getConf(COMPRESS_CACHED)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -78,10 +78,14 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSQLContext {
   }
 
   test("basic data types (without binary)") {
-    val data = (1 to 4).map { i =>
-      (i % 2 == 0, i, i.toLong, i.toFloat, i.toDouble)
+    (true :: false :: Nil).foreach { v =>
+      withSQLConf(SQLConf.FILES_ASYNC_IO.key -> v.toString) {
+        val data = (1 to 4).map { i =>
+          (i % 2 == 0, i, i.toLong, i.toFloat, i.toDouble)
+        }
+        checkParquetFile(data)
+      }
     }
-    checkParquetFile(data)
   }
 
   test("raw binary") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch updates FileScanRDD to start reading from the next file while the current file
is being processed. The goal is to have better interleaving of CPU and IO. It does this
by launching a future which will asynchronously start preparing the next file to be read.
The expectation is that the async task is IO intensive and the current file (which
includes all the computation for the query plan) is CPU intensive. For some file formats,
this would just mean opening the file and the initial setup. For file formats like
parquet, this would mean doing all the IO for all the columns.
## How was this patch tested?

Good coverage from existing tests. Added a new one to test the flag. Cluster testing on tpcds queries.
