### PR TITLE
[SPARK-14474][SQL]Move FileSource offset log into checkpointLocation

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/ContinuousQueryManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/ContinuousQueryManager.scala
@@ -182,7 +182,8 @@ class ContinuousQueryManager(sqlContext: SQLContext) {
       val logicalPlan = df.logicalPlan.transform {
         case StreamingRelation(dataSource, _, output) =>
           // Materialize source to avoid creating it in every batch
-          val source = dataSource.createSource(nextSourceId, checkpointLocation)
+          val metadataPath = s"$checkpointLocation/sources/$nextSourceId"
+          val source = dataSource.createSource(metadataPath)
           nextSourceId += 1
           // We still need to use the previous `output` instead of `source.schema` as attributes in
           // "df.logicalPlan" has already used attributes of the previous `output`.

--- a/sql/core/src/main/scala/org/apache/spark/sql/ContinuousQueryManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/ContinuousQueryManager.scala
@@ -178,10 +178,12 @@ class ContinuousQueryManager(sqlContext: SQLContext) {
         throw new IllegalArgumentException(
           s"Cannot start query with name $name as a query with that name is already active")
       }
+      var nextSourceId = 0L
       val logicalPlan = df.logicalPlan.transform {
         case StreamingRelation(dataSource, _, output) =>
           // Materialize source to avoid creating it in every batch
-          val source = dataSource.createSource()
+          val source = dataSource.createSource(Some(nextSourceId), Some(checkpointLocation))
+          nextSourceId += 1
           // We still need to use the previous `output` instead of `source.schema` as attributes in
           // "df.logicalPlan" has already used attributes of the previous `output`.
           StreamingExecutionRelation(source, output)

--- a/sql/core/src/main/scala/org/apache/spark/sql/ContinuousQueryManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/ContinuousQueryManager.scala
@@ -182,7 +182,7 @@ class ContinuousQueryManager(sqlContext: SQLContext) {
       val logicalPlan = df.logicalPlan.transform {
         case StreamingRelation(dataSource, _, output) =>
           // Materialize source to avoid creating it in every batch
-          val source = dataSource.createSource(Some(nextSourceId), Some(checkpointLocation))
+          val source = dataSource.createSource(nextSourceId, checkpointLocation)
           nextSourceId += 1
           // We still need to use the previous `output` instead of `source.schema` as attributes in
           // "df.logicalPlan" has already used attributes of the previous `output`.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -163,10 +163,10 @@ case class DataSource(
   }
 
   /** Returns a source that can be used to continually read data. */
-  def createSource(sourceId: Long, checkpointLocation: String): Source = {
+  def createSource(metadataPath: String): Source = {
     providingClass.newInstance() match {
       case s: StreamSourceProvider =>
-        s.createSource(sqlContext, sourceId, userSpecifiedSchema, className, options)
+        s.createSource(sqlContext, metadataPath, userSpecifiedSchema, className, options)
 
       case format: FileFormat =>
         val caseInsensitiveOptions = new CaseInsensitiveMap(options)
@@ -174,7 +174,6 @@ case class DataSource(
           throw new IllegalArgumentException("'path' is not specified")
         })
 
-        val metadataPath = s"$checkpointLocation/sources/$sourceId"
         val dataSchema = inferFileFormatSchema(format)
 
         def dataFrameBuilder(files: Array[String]): DataFrame = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
@@ -33,7 +33,7 @@ import org.apache.spark.util.collection.OpenHashSet
  */
 class FileStreamSource(
     sqlContext: SQLContext,
-    private[sql] val metadataPath: String,
+    metadataPath: String,
     path: String,
     dataSchema: Option[StructType],
     providerName: String,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
@@ -33,7 +33,7 @@ import org.apache.spark.util.collection.OpenHashSet
  */
 class FileStreamSource(
     sqlContext: SQLContext,
-    metadataPath: String,
+    private[sql] val metadataPath: String,
     path: String,
     dataSchema: Option[StructType],
     providerName: String,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
@@ -33,20 +33,15 @@ import org.apache.spark.util.collection.OpenHashSet
  */
 class FileStreamSource(
     sqlContext: SQLContext,
-    metadataPath: String,
     path: String,
     dataSchema: Option[StructType],
     providerName: String,
     dataFrameBuilder: Array[String] => DataFrame) extends Source with Logging {
 
   private val fs = FileSystem.get(sqlContext.sparkContext.hadoopConfiguration)
-  private val metadataLog = new HDFSMetadataLog[Seq[String]](sqlContext, metadataPath)
-  private var maxBatchId = metadataLog.getLatest().map(_._1).getOrElse(-1L)
-
+  private var metadataLog: MetadataLog[Seq[String]] = _
+  private var maxBatchId: Long = _
   private val seenFiles = new OpenHashSet[String]
-  metadataLog.get(None, Some(maxBatchId)).foreach { case (batchId, files) =>
-    files.foreach(seenFiles.add)
-  }
 
   /** Returns the schema of the data from this source */
   override lazy val schema: StructType = {
@@ -67,12 +62,33 @@ class FileStreamSource(
   }
 
   /**
+   * Set the metadata path. This method should be called before using [[FileStreamSource]].
+   */
+  def setMetadataPath(metadataPath: String): Unit = {
+    if (metadataLog != null) {
+      throw new IllegalStateException("metadataPath has already been set")
+    }
+    metadataLog = new HDFSMetadataLog[Seq[String]](sqlContext, metadataPath)
+    maxBatchId = metadataLog.getLatest().map(_._1).getOrElse(-1L)
+    metadataLog.get(None, Some(maxBatchId)).foreach { case (batchId, files) =>
+      files.foreach(seenFiles.add)
+    }
+  }
+
+  private def assertMetadataPath(): Unit = {
+    if (metadataLog == null) {
+      throw new IllegalStateException("metadataPath has not been set yet")
+    }
+  }
+
+  /**
    * Returns the maximum offset that can be retrieved from the source.
    *
    * `synchronized` on this method is for solving race conditions in tests. In the normal usage,
    * there is no race here, so the cost of `synchronized` should be rare.
    */
   private def fetchMaxOffset(): LongOffset = synchronized {
+    assertMetadataPath()
     val filesPresent = fetchAllFiles()
     val newFiles = new ArrayBuffer[String]()
     filesPresent.foreach { file =>
@@ -103,6 +119,7 @@ class FileStreamSource(
 
   /** Return the latest offset in the source */
   def currentOffset: LongOffset = synchronized {
+    assertMetadataPath()
     new LongOffset(maxBatchId)
   }
 
@@ -110,6 +127,7 @@ class FileStreamSource(
    * Returns the next batch of data that is available after `start`, if any is available.
    */
   override def getBatch(start: Option[Offset], end: Offset): DataFrame = {
+    assertMetadataPath()
     val startId = start.map(_.asInstanceOf[LongOffset].offset).getOrElse(-1L)
     val endId = end.asInstanceOf[LongOffset].offset
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingRelation.scala
@@ -23,8 +23,8 @@ import org.apache.spark.sql.execution.datasources.DataSource
 
 object StreamingRelation {
   def apply(dataSource: DataSource): StreamingRelation = {
-    val source = dataSource.createSource()
-    StreamingRelation(dataSource, source.toString, source.schema.toAttributes)
+    val (name, schema) = dataSource.sourceSchema()
+    StreamingRelation(dataSource, name, schema.toAttributes)
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -129,8 +129,16 @@ trait SchemaRelationProvider {
  * Implemented by objects that can produce a streaming [[Source]] for a specific format or system.
  */
 trait StreamSourceProvider {
+
+  def sourceSchema(
+      sqlContext: SQLContext,
+      schema: Option[StructType],
+      providerName: String,
+      parameters: Map[String, String]): (String, StructType)
+
   def createSource(
       sqlContext: SQLContext,
+      sourceId: Long,
       schema: Option[StructType],
       providerName: String,
       parameters: Map[String, String]): Source

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -130,6 +130,7 @@ trait SchemaRelationProvider {
  */
 trait StreamSourceProvider {
 
+  /** Returns the name and schema of the source that can be used to continually read data. */
   def sourceSchema(
       sqlContext: SQLContext,
       schema: Option[StructType],

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -139,7 +139,7 @@ trait StreamSourceProvider {
 
   def createSource(
       sqlContext: SQLContext,
-      sourceId: Long,
+      metadataPath: String,
       schema: Option[StructType],
       providerName: String,
       parameters: Map[String, String]): Source

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/DataFrameReaderWriterSuite.scala
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit
 
 import scala.concurrent.duration._
 
+import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.sql._
@@ -31,22 +32,53 @@ import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 import org.apache.spark.util.Utils
 
 object LastOptions {
+
+  var mockStreamSourceProvider = mock(classOf[StreamSourceProvider])
+  var mockStreamSinkProvider = mock(classOf[StreamSinkProvider])
+  var sourceId: Long = -1
   var parameters: Map[String, String] = null
   var schema: Option[StructType] = null
   var partitionColumns: Seq[String] = Nil
+
+  def clear(): Unit = {
+    sourceId = -1
+    parameters = null
+    schema = null
+    partitionColumns = null
+    reset(mockStreamSourceProvider)
+    reset(mockStreamSinkProvider)
+  }
 }
 
 /** Dummy provider: returns no-op source/sink and records options in [[LastOptions]]. */
 class DefaultSource extends StreamSourceProvider with StreamSinkProvider {
-  override def createSource(
+
+  private val fakeSchema = StructType(StructField("a", IntegerType) :: Nil)
+
+  override def sourceSchema(
       sqlContext: SQLContext,
       schema: Option[StructType],
       providerName: String,
-      parameters: Map[String, String]): Source = {
+      parameters: Map[String, String]): (String, StructType) = {
     LastOptions.parameters = parameters
     LastOptions.schema = schema
+    LastOptions.mockStreamSourceProvider.sourceSchema(sqlContext, schema, providerName, parameters)
+    ("dummySource", fakeSchema)
+  }
+
+  override def createSource(
+      sqlContext: SQLContext,
+      sourceId: Long,
+      schema: Option[StructType],
+      providerName: String,
+      parameters: Map[String, String]): Source = {
+    LastOptions.sourceId = sourceId
+    LastOptions.parameters = parameters
+    LastOptions.schema = schema
+    LastOptions.mockStreamSourceProvider.createSource(
+      sqlContext, sourceId, schema, providerName, parameters)
     new Source {
-      override def schema: StructType = StructType(StructField("a", IntegerType) :: Nil)
+      override def schema: StructType = fakeSchema
 
       override def getOffset: Option[Offset] = Some(new LongOffset(0))
 
@@ -64,6 +96,7 @@ class DefaultSource extends StreamSourceProvider with StreamSinkProvider {
       partitionColumns: Seq[String]): Sink = {
     LastOptions.parameters = parameters
     LastOptions.partitionColumns = partitionColumns
+    LastOptions.mockStreamSinkProvider.createSink(sqlContext, parameters, partitionColumns)
     new Sink {
       override def addBatch(batchId: Long, data: DataFrame): Unit = {}
     }
@@ -117,7 +150,7 @@ class DataFrameReaderWriterSuite extends StreamTest with SharedSQLContext with B
     assert(LastOptions.parameters("opt2") == "2")
     assert(LastOptions.parameters("opt3") == "3")
 
-    LastOptions.parameters = null
+    LastOptions.clear()
 
     df.write
       .format("org.apache.spark.sql.streaming.test")
@@ -181,7 +214,7 @@ class DataFrameReaderWriterSuite extends StreamTest with SharedSQLContext with B
 
     assert(LastOptions.parameters("path") == "/test")
 
-    LastOptions.parameters = null
+    LastOptions.clear()
 
     df.write
       .format("org.apache.spark.sql.streaming.test")
@@ -204,7 +237,7 @@ class DataFrameReaderWriterSuite extends StreamTest with SharedSQLContext with B
     assert(LastOptions.parameters("boolOpt") == "false")
     assert(LastOptions.parameters("doubleOpt") == "6.7")
 
-    LastOptions.parameters = null
+    LastOptions.clear()
     df.write
       .format("org.apache.spark.sql.streaming.test")
       .option("intOpt", 56)
@@ -302,5 +335,29 @@ class DataFrameReaderWriterSuite extends StreamTest with SharedSQLContext with B
     q.stop()
 
     assert(q.asInstanceOf[StreamExecution].trigger == ProcessingTime(100000))
+  }
+
+  test("sourceId") {
+    LastOptions.clear()
+
+    val df1 = sqlContext.read
+      .format("org.apache.spark.sql.streaming.test")
+      .stream()
+
+    val df2 = sqlContext.read
+      .format("org.apache.spark.sql.streaming.test")
+      .stream()
+
+    val q = df1.union(df2).write
+      .format("org.apache.spark.sql.streaming.test")
+      .option("checkpointLocation", newMetadataDir)
+      .trigger(ProcessingTime(10.seconds))
+      .startStream()
+    q.stop()
+
+    verify(LastOptions.mockStreamSourceProvider)
+      .createSource(sqlContext, 0L, None, "org.apache.spark.sql.streaming.test", Map.empty)
+    verify(LastOptions.mockStreamSourceProvider)
+      .createSource(sqlContext, 1L, None, "org.apache.spark.sql.streaming.test", Map.empty)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/DataFrameReaderWriterSuite.scala
@@ -35,13 +35,11 @@ object LastOptions {
 
   var mockStreamSourceProvider = mock(classOf[StreamSourceProvider])
   var mockStreamSinkProvider = mock(classOf[StreamSinkProvider])
-  var sourceId: Long = -1
   var parameters: Map[String, String] = null
   var schema: Option[StructType] = null
   var partitionColumns: Seq[String] = Nil
 
   def clear(): Unit = {
-    sourceId = -1
     parameters = null
     schema = null
     partitionColumns = null
@@ -68,15 +66,14 @@ class DefaultSource extends StreamSourceProvider with StreamSinkProvider {
 
   override def createSource(
       sqlContext: SQLContext,
-      sourceId: Long,
+      metadataPath: String,
       schema: Option[StructType],
       providerName: String,
       parameters: Map[String, String]): Source = {
-    LastOptions.sourceId = sourceId
     LastOptions.parameters = parameters
     LastOptions.schema = schema
     LastOptions.mockStreamSourceProvider.createSource(
-      sqlContext, sourceId, schema, providerName, parameters)
+      sqlContext, metadataPath, schema, providerName, parameters)
     new Source {
       override def schema: StructType = fakeSchema
 
@@ -337,8 +334,10 @@ class DataFrameReaderWriterSuite extends StreamTest with SharedSQLContext with B
     assert(q.asInstanceOf[StreamExecution].trigger == ProcessingTime(100000))
   }
 
-  test("sourceId") {
+  test("source metadataPath") {
     LastOptions.clear()
+
+    val checkpointLocation = newMetadataDir
 
     val df1 = sqlContext.read
       .format("org.apache.spark.sql.streaming.test")
@@ -350,14 +349,23 @@ class DataFrameReaderWriterSuite extends StreamTest with SharedSQLContext with B
 
     val q = df1.union(df2).write
       .format("org.apache.spark.sql.streaming.test")
-      .option("checkpointLocation", newMetadataDir)
+      .option("checkpointLocation", checkpointLocation)
       .trigger(ProcessingTime(10.seconds))
       .startStream()
     q.stop()
 
-    verify(LastOptions.mockStreamSourceProvider)
-      .createSource(sqlContext, 0L, None, "org.apache.spark.sql.streaming.test", Map.empty)
-    verify(LastOptions.mockStreamSourceProvider)
-      .createSource(sqlContext, 1L, None, "org.apache.spark.sql.streaming.test", Map.empty)
+    verify(LastOptions.mockStreamSourceProvider).createSource(
+      sqlContext,
+      checkpointLocation + "/sources/0",
+      None,
+      "org.apache.spark.sql.streaming.test",
+      Map.empty)
+
+    verify(LastOptions.mockStreamSourceProvider).createSource(
+      sqlContext,
+      checkpointLocation + "/sources/1",
+      None,
+      "org.apache.spark.sql.streaming.test",
+      Map.empty)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -73,8 +73,8 @@ class FileStreamSourceTest extends StreamTest with SharedSQLContext {
     reader.stream(path)
       .queryExecution.analyzed
       .collect { case StreamingRelation(dataSource, _, _) =>
-        // There is only one source in our tests so just set sourceId to 1
-        dataSource.createSource(0, checkpointLocation).asInstanceOf[FileStreamSource]
+        // There is only one source in our tests so just set sourceId to 0
+        dataSource.createSource(s"$checkpointLocation/sources/0").asInstanceOf[FileStreamSource]
       }.head
   }
 
@@ -340,27 +340,6 @@ class FileStreamSourceSuite extends FileStreamSourceTest with SharedSQLContext {
 
     Utils.deleteRecursively(src)
     Utils.deleteRecursively(tmp)
-  }
-
-  test("metadataPath should be in checkpointLocation") {
-    val src = Utils.createTempDir(namePrefix = "streaming.src")
-    val location = Utils.createTempDir(namePrefix = "steaming.checkpoint")
-
-    val query = sqlContext.read.format("text").stream(src.getCanonicalPath).write
-      .format("memory")
-      .queryName("memStream")
-      .option("checkpointLocation", location.getCanonicalPath)
-      .startStream()
-
-    val source = query.asInstanceOf[StreamExecution].logicalPlan.collect {
-      case StreamingExecutionRelation(source, _) => source.asInstanceOf[FileStreamSource]
-    }.head
-    val expectedPath = s"$location/sources/0"
-    assert(expectedPath === source.metadataPath)
-
-    query.stop()
-    Utils.deleteRecursively(location)
-    Utils.deleteRecursively(src)
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -77,7 +77,7 @@ class FileStreamSourceTest extends StreamTest with SharedSQLContext {
       .queryExecution.analyzed
       .collect { case StreamingRelation(dataSource, _, _) =>
         // There is only one source in our tests so just set sourceId to 1
-        dataSource.createSource(Some(0), Some(checkpointLocation)).asInstanceOf[FileStreamSource]
+        dataSource.createSource(0, checkpointLocation).asInstanceOf[FileStreamSource]
       }.head
   }
 
@@ -104,9 +104,8 @@ class FileStreamSourceSuite extends FileStreamSourceTest with SharedSQLContext
       }
     df.queryExecution.analyzed
       .collect { case StreamingRelation(dataSource, _, _) =>
-        dataSource.createSource().asInstanceOf[FileStreamSource]
-      }.head
-      .schema
+        dataSource.sourceSchema()
+      }.head._2
   }
 
   test("FileStreamSource schema: no path") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/MemorySinkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/MemorySinkSuite.scala
@@ -59,7 +59,7 @@ class MemorySinkSuite extends StreamTest with SharedSQLContext {
   }
 
   test("error if attempting to resume specific checkpoint") {
-    val location = Utils.createTempDir("steaming.checkpoint").getCanonicalPath
+    val location = Utils.createTempDir(namePrefix = "steaming.checkpoint").getCanonicalPath
 
     val input = MemoryStream[Int]
     val query = input.toDF().write

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -125,7 +125,7 @@ class FakeDefaultSource extends StreamSourceProvider {
 
   override def createSource(
       sqlContext: SQLContext,
-      sourceId: Long,
+      metadataPath: String,
       schema: Option[StructType],
       providerName: String,
       parameters: Map[String, String]): Source = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -115,8 +115,17 @@ class StreamSuite extends StreamTest with SharedSQLContext {
  */
 class FakeDefaultSource extends StreamSourceProvider {
 
+  private val fakeSchema = StructType(StructField("a", IntegerType) :: Nil)
+
+  override def sourceSchema(
+      sqlContext: SQLContext,
+      schema: Option[StructType],
+      providerName: String,
+      parameters: Map[String, String]): (String, StructType) = ("fakeSource", fakeSchema)
+
   override def createSource(
       sqlContext: SQLContext,
+      sourceId: Long,
       schema: Option[StructType],
       providerName: String,
       parameters: Map[String, String]): Source = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now that we have a single location for storing checkpointed state. This PR just propagates the checkpoint location into FileStreamSource so that we don't have one random log off on its own.
## How was this patch tested?

test("metadataPath should be in checkpointLocation")
