### PR TITLE
[SPARK-13842][PYSPARK] pyspark.sql.types.StructType accessor enhancements

### DIFF
--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -823,6 +823,9 @@ class SQLTests(ReusedPySparkTestCase):
         with self.assertRaises(TypeError):
             not_a_field = struct1[9.9]
 
+        struct1 = StructType().add("f1", StringType(), True).add("f2", StringType(), True, None)
+        self.assertEqual(struct1.names, ["f1", "f2"])
+
     def test_metadata_null(self):
         from pyspark.sql.types import StructType, StringType, StructField
         schema = StructType([StructField("f1", StringType(), True, None),

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -815,7 +815,7 @@ class SQLTests(ReusedPySparkTestCase):
         struct1 = StructType().add("f1", StringType(), True).add("f2", StringType(), True, None)
         self.assertIs(struct1["f1"], struct1.fields[0])
         self.assertIs(struct1[0], struct1.fields[0])
-        self.assertEqual(struct1[0:1], struct1.fields[0:1])
+        self.assertEqual(struct1[0:1], StructType(struct1.fields[0:1]))
         with self.assertRaises(KeyError):
             not_a_field = struct1["f9"]
         with self.assertRaises(IndexError):

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -823,9 +823,6 @@ class SQLTests(ReusedPySparkTestCase):
         with self.assertRaises(TypeError):
             not_a_field = struct1[9.9]
 
-        struct1 = StructType().add("f1", StringType(), True).add("f2", StringType(), True, None)
-        self.assertEqual(struct1.names, ["f1", "f2"])
-
     def test_metadata_null(self):
         from pyspark.sql.types import StructType, StringType, StructField
         schema = StructType([StructField("f1", StringType(), True, None),

--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -802,11 +802,26 @@ class SQLTests(ReusedPySparkTestCase):
         self.assertNotEqual(struct1, struct2)
 
         # Catch exception raised during improper construction
-        try:
+        with self.assertRaises(ValueError):
             struct1 = StructType().add("name")
-            self.assertEqual(1, 0)
-        except ValueError:
-            self.assertEqual(1, 1)
+
+        struct1 = StructType().add("f1", StringType(), True).add("f2", StringType(), True, None)
+        for field in struct1:
+            self.assertIsInstance(field, StructField)
+
+        struct1 = StructType().add("f1", StringType(), True).add("f2", StringType(), True, None)
+        self.assertEqual(len(struct1), 2)
+
+        struct1 = StructType().add("f1", StringType(), True).add("f2", StringType(), True, None)
+        self.assertIs(struct1["f1"], struct1.fields[0])
+        self.assertIs(struct1[0], struct1.fields[0])
+        self.assertEqual(struct1[0:1], struct1.fields[0:1])
+        with self.assertRaises(KeyError):
+            not_a_field = struct1["f9"]
+        with self.assertRaises(IndexError):
+            not_a_field = struct1[9]
+        with self.assertRaises(TypeError):
+            not_a_field = struct1[9.9]
 
     def test_metadata_null(self):
         from pyspark.sql.types import StructType, StringType, StructField

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -457,13 +457,10 @@ class StructType(DataType):
         """
         if not fields:
             self.fields = []
-            self.names = []
         else:
             self.fields = fields
-            self.names = [f.name for f in fields]
             assert all(isinstance(f, StructField) for f in fields),\
                 "fields should be a list of StructField"
-        self._needSerializeAnyField = any(f.needConversion() for f in self)
 
     def add(self, field, data_type=None, nullable=True, metadata=None):
         """
@@ -497,7 +494,6 @@ class StructType(DataType):
         """
         if isinstance(field, StructField):
             self.fields.append(field)
-            self.names.append(field.name)
         else:
             if isinstance(field, str) and data_type is None:
                 raise ValueError("Must specify DataType if passing name of struct_field to create.")
@@ -507,9 +503,17 @@ class StructType(DataType):
             else:
                 data_type_f = data_type
             self.fields.append(StructField(field, data_type_f, nullable, metadata))
-            self.names.append(field)
-        self._needSerializeAnyField = any(f.needConversion() for f in self)
         return self
+
+    @property
+    def names(self):
+        """Return a list of the field names"""
+        return [field.name for field in self]
+
+    @property
+    def _needSerializeAnyField(self):
+        """Determine if any field needs conversion"""
+        return any(field.needConversion() for field in self)
 
     def __iter__(self):
         """Iterate the fields"""

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -463,7 +463,7 @@ class StructType(DataType):
             self.names = [f.name for f in fields]
             assert all(isinstance(f, StructField) for f in fields),\
                 "fields should be a list of StructField"
-        self._needSerializeAnyField = any(f.needConversion() for f in self.fields)
+        self._needSerializeAnyField = any(f.needConversion() for f in self)
 
     def add(self, field, data_type=None, nullable=True, metadata=None):
         """
@@ -508,7 +508,7 @@ class StructType(DataType):
                 data_type_f = data_type
             self.fields.append(StructField(field, data_type_f, nullable, metadata))
             self.names.append(field)
-        self._needSerializeAnyField = any(f.needConversion() for f in self.fields)
+        self._needSerializeAnyField = any(f.needConversion() for f in self)
         return self
 
     def __iter__(self):
@@ -536,15 +536,15 @@ class StructType(DataType):
             raise TypeError('StructType keys should be strings, integers or slices')
 
     def simpleString(self):
-        return 'struct<%s>' % (','.join(f.simpleString() for f in self.fields))
+        return 'struct<%s>' % (','.join(f.simpleString() for f in self))
 
     def __repr__(self):
         return ("StructType(List(%s))" %
-                ",".join(str(field) for field in self.fields))
+                ",".join(str(field) for field in self))
 
     def jsonValue(self):
         return {"type": self.typeName(),
-                "fields": [f.jsonValue() for f in self.fields]}
+                "fields": [f.jsonValue() for f in self]}
 
     @classmethod
     def fromJson(cls, json):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -511,6 +511,30 @@ class StructType(DataType):
         self._needSerializeAnyField = any(f.needConversion() for f in self.fields)
         return self
 
+    def __iter__(self):
+        """Iterate the fields"""
+        return iter(self.fields)
+
+    def __len__(self):
+        """Return the number of fields."""
+        return len(self.fields)
+
+    def __getitem__(self, key):
+        """Access fields by name or slice."""
+        if isinstance(key, str):
+            _dict_fields = {field.name: field for field in self}
+            try:
+                return _dict_fields[key]
+            except KeyError:
+                raise KeyError('No StructField named {}'.format(key))
+        elif isinstance(key, (int, slice)):
+            try:
+                return self.fields[key]
+            except IndexError:
+                raise IndexError('StructType index out of range')
+        else:
+            raise TypeError('StructType keys should be strings, integers or slices')
+
     def simpleString(self):
         return 'struct<%s>' % (','.join(f.simpleString() for f in self.fields))
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -466,10 +466,13 @@ class StructType(DataType):
         """
         if not fields:
             self.fields = []
+            self.names = []
         else:
             self.fields = fields
+            self.names = [f.name for f in fields]
             assert all(isinstance(f, StructField) for f in fields),\
                 "fields should be a list of StructField"
+        self._needSerializeAnyField = any(f.needConversion() for f in self)
 
     def add(self, field, data_type=None, nullable=True, metadata=None):
         """
@@ -503,6 +506,7 @@ class StructType(DataType):
         """
         if isinstance(field, StructField):
             self.fields.append(field)
+            self.names.append(field.name)
         else:
             if isinstance(field, str) and data_type is None:
                 raise ValueError("Must specify DataType if passing name of struct_field to create.")
@@ -512,17 +516,9 @@ class StructType(DataType):
             else:
                 data_type_f = data_type
             self.fields.append(StructField(field, data_type_f, nullable, metadata))
+            self.names.append(field)
+        self._needSerializeAnyField = any(f.needConversion() for f in self)
         return self
-
-    @property
-    def names(self):
-        """Return a list of the field names"""
-        return [field.name for field in self]
-
-    @property
-    def _needSerializeAnyField(self):
-        """Determine if any field needs conversion"""
-        return any(field.needConversion() for field in self)
 
     def __iter__(self):
         """Iterate the fields"""

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -531,11 +531,13 @@ class StructType(DataType):
     def __getitem__(self, key):
         """Access fields by name or slice."""
         if isinstance(key, str):
-            _dict_fields = {field.name: field for field in self}
+            _dict_fields = {}
+            for field in self:
+                _dict_fields[field.name] = field
             try:
                 return _dict_fields[key]
             except KeyError:
-                raise KeyError('No StructField named {}'.format(key))
+                raise KeyError('No StructField named {0}'.format(key))
         elif isinstance(key, int):
             try:
                 return self.fields[key]

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -442,6 +442,15 @@ class StructType(DataType):
     """Struct type, consisting of a list of :class:`StructField`.
 
     This is the data type representing a :class:`Row`.
+
+    Iterating a :class:`StructType` will iterate its :class:`StructField`s.
+    A contained :class:`StructField` can be accessed by name or position.
+
+    >>> struct1 = StructType([StructField("f1", StringType(), True)])
+    >>> struct1["f1"]
+    StructField(f1,StringType,true)
+    >>> struct1[0]
+    StructField(f1,StringType,true)
     """
     def __init__(self, fields=None):
         """

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -531,13 +531,10 @@ class StructType(DataType):
     def __getitem__(self, key):
         """Access fields by name or slice."""
         if isinstance(key, str):
-            _dict_fields = {}
             for field in self:
-                _dict_fields[field.name] = field
-            try:
-                return _dict_fields[key]
-            except KeyError:
-                raise KeyError('No StructField named {0}'.format(key))
+                if field.name == key:
+                    return field
+            raise KeyError('No StructField named {0}'.format(key))
         elif isinstance(key, int):
             try:
                 return self.fields[key]

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -540,11 +540,13 @@ class StructType(DataType):
                 return _dict_fields[key]
             except KeyError:
                 raise KeyError('No StructField named {}'.format(key))
-        elif isinstance(key, (int, slice)):
+        elif isinstance(key, int):
             try:
                 return self.fields[key]
             except IndexError:
                 raise IndexError('StructType index out of range')
+        elif isinstance(key, slice):
+            return StructType(self.fields[key])
         else:
             raise TypeError('StructType keys should be strings, integers or slices')
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Expand the possible ways to interact with the contents of a `pyspark.sql.types.StructType` instance.
- Iterating a `StructType` will iterate its fields
  - `[field.name for field in my_structtype]`
- Indexing with a string will return a field by name
  - `my_structtype['my_field_name']`
- Indexing with an integer will return a field by position
  - `my_structtype[0]`
- Indexing with a slice will return a new `StructType` with just the chosen fields:
  - `my_structtype[1:3]`
- The length is the number of fields (should also provide "truthiness" for free)
  - `len(my_structtype) == 2`
## How was this patch tested?

Extended the unit test coverage in the accompanying `tests.py`.
