### PR TITLE
[SPARK-14485][CORE] ignore task finished for executor lost and removed by driver

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -358,7 +358,7 @@ private[spark] class TaskSchedulerImpl(
               // at sometime, before executor killed  by cluster, the task of running on this
               // executor is finished and return task success state to driver. However, this kinds
               // of task should be ignored, because the task on this executor is already re-queued
-              // by driver.
+              // by driver. For more details, can check in SPARK-14485.
               if (executorId.ne(null) && !executorIdToTaskCount.contains(executorId)) {
                 taskSet.removeRunningTask(tid)
                 logWarning(

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -361,10 +361,8 @@ private[spark] class TaskSchedulerImpl(
               // by driver. For more details, can check in SPARK-14485.
               taskSet.removeRunningTask(tid)
               if (executorId != null && !executorIdToTaskCount.contains(executorId)) {
-                logInfo(
-                  ("Ignoring update with state %s for TID %s because its executor has already " +
-                    "removed by driver, and the task of this executor has re-queued")
-                    .format(state, tid))
+                logInfo(s"Ignoring update with state $state for TID $tid because its executor " +
+                  s"has already been removed by driver")
               } else {
                 taskResultGetter.enqueueSuccessfulTask(taskSet, tid, serializedData)
               }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -359,13 +359,13 @@ private[spark] class TaskSchedulerImpl(
               // executor is finished and return task success state to driver. However, this kinds
               // of task should be ignored, because the task on this executor is already re-queued
               // by driver. For more details, can check in SPARK-14485.
-              if (executorId.ne(null) && !executorIdToTaskCount.contains(executorId)) {
-                taskSet.removeRunningTask(tid)
-                logWarning(
-                  ("Ignoring update with state %s for TID %s because its executor has already removed " +
-                    "by driver, and the task of this executor has re-queued").format(state, tid))
+              taskSet.removeRunningTask(tid)
+              if (executorId != null && !executorIdToTaskCount.contains(executorId)) {
+                logInfo(
+                  ("Ignoring update with state %s for TID %s because its executor has already " +
+                    "removed by driver, and the task of this executor has re-queued")
+                    .format(state, tid))
               } else {
-                taskSet.removeRunningTask(tid)
                 taskResultGetter.enqueueSuccessfulTask(taskSet, tid, serializedData)
               }
             } else if (Set(TaskState.FAILED, TaskState.KILLED, TaskState.LOST).contains(state)) {

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -354,8 +354,8 @@ private[spark] class TaskSchedulerImpl(
               }
             }
             if (state == TaskState.FINISHED) {
-              // In some case, executor has already removed by driver for heartbeats timeout, but
-              // at sometime, before executor killed  by cluster, the task of running on this
+              // In some case, executor has already been removed by driver for heartbeats timeout,
+              // but at sometime, before executor killed by cluster, the task of running on this
               // executor is finished and return task success state to driver. However, this kinds
               // of task should be ignored, because the task on this executor is already re-queued
               // by driver. For more details, can check in SPARK-14485.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now, when executor is removed by driver with heartbeats timeout, driver will re-queue the task on this executor and send a kill command to cluster to kill this executor.
But, in a situation, the running task of this executor is finished and return result to driver before this executor killed by kill command sent by driver. At this situation, driver will accept the task finished event and ignore speculative task and re-queued task. 
But, as we know, this executor has removed by driver, the result of this finished task can not save in driver because the BlockManagerId has also removed from BlockManagerMaster by driver. So, the result data of this stage is not complete, and then, it will cause fetch failure. For more details, [link to jira issues SPARK-14485](https://issues.apache.org/jira/browse/SPARK-14485)
This PR introduce a mechanism to ignore this kind of task finished.
## How was this patch tested?

N/A
