### PR TITLE
[BUILD][HOTFIX] Download Maven from regular mirror network rather than archive.apache.org

### DIFF
--- a/build/mvn
+++ b/build/mvn
@@ -70,7 +70,7 @@ install_app() {
 # Install maven under the build/ folder
 install_mvn() {
   local MVN_VERSION="3.3.9"
-  local APACHE_MIRROR=${APACHE_MIRROR:-https://archive.apache.org/dist}
+  local APACHE_MIRROR=${APACHE_MIRROR:-'https://www.apache.org/dyn/closer.lua?action=download&filename='}
 
   install_app \
     "${APACHE_MIRROR}/maven/maven-3/${MVN_VERSION}/binaries" \


### PR DESCRIPTION
[archive.apache.org](https://archive.apache.org/) is undergoing maintenance, breaking our `build/mvn` script:

> We are in the process of relocating this service. To save on the immense bandwidth that this service outputs, we have put it in maintenance mode, disabling all downloads for the next few days. We expect the maintenance to be complete no later than the morning of Monday the 11th of April, 2016.

This patch fixes this issue by updating the script to use the regular mirror network to download Maven.
