### PR TITLE
[SPARK-14497][ML] Use top instead of sortBy() to get top N frequent words as dict in ConutVectorizer

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
@@ -153,15 +153,9 @@ class CountVectorizer(override val uid: String)
     }.cache()
     val fullVocabSize = wordCounts.count()
 
-    val wordCountOrdering = new Ordering[(String, Long)]{
-      override def compare(x: (String, Long), y: (String,Long)): Int = {
-        if (x._2 > y._2) +1 else if (x._2 < y._2) -1 else 0
-      }
-    }
-
-    val vocab: Array[String] = wordCounts
-      .top(math.min(fullVocabSize, vocSize).toInt)(wordCountOrdering)
-      .map(_._1)
+    val vocab: Array[String] = wordCounts.
+    top(math.min(fullVocabSize, vocSize).toInt)(Ordering.by(_._2))
+    .map(_._1)
 
     require(vocab.length > 0, "The vocabulary size should be > 0. Lower minDF as necessary.")
     copyValues(new CountVectorizerModel(uid, vocab).setParent(this))

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
@@ -153,9 +153,9 @@ class CountVectorizer(override val uid: String)
     }.cache()
     val fullVocabSize = wordCounts.count()
 
-    val vocab: Array[String] = wordCounts
-    .top(math.min(fullVocabSize, vocSize).toInt)(Ordering.by(_._2))
-    .map(_._1)
+    val vocab = wordCounts
+      .top(math.min(fullVocabSize, vocSize).toInt)(Ordering.by(_._2))
+      .map(_._1)
 
     require(vocab.length > 0, "The vocabulary size should be > 0. Lower minDF as necessary.")
     copyValues(new CountVectorizerModel(uid, vocab).setParent(this))

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
@@ -152,16 +152,10 @@ class CountVectorizer(override val uid: String)
       (word, count)
     }.cache()
     val fullVocabSize = wordCounts.count()
-    val vocab: Array[String] = {
-      val tmpSortedWC: Array[(String, Long)] = if (fullVocabSize <= vocSize) {
-        // Use all terms
-        wordCounts.collect().sortBy(-_._2)
-      } else {
-        // Sort terms to select vocab
-        wordCounts.sortBy(_._2, ascending = false).take(vocSize)
-      }
-      tmpSortedWC.map(_._1)
-    }
+
+    val vocab: Array[String] = wordCounts.map(_.swap)
+      .top(Math.min(fullVocabSize, vocSize).toInt)
+      .map(_._2)
 
     require(vocab.length > 0, "The vocabulary size should be > 0. Lower minDF as necessary.")
     copyValues(new CountVectorizerModel(uid, vocab).setParent(this))

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
@@ -153,8 +153,8 @@ class CountVectorizer(override val uid: String)
     }.cache()
     val fullVocabSize = wordCounts.count()
 
-    val vocab: Array[String] = wordCounts.
-    top(math.min(fullVocabSize, vocSize).toInt)(Ordering.by(_._2))
+    val vocab: Array[String] = wordCounts
+    .top(math.min(fullVocabSize, vocSize).toInt)(Ordering.by(_._2))
     .map(_._1)
 
     require(vocab.length > 0, "The vocabulary size should be > 0. Lower minDF as necessary.")

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
@@ -153,9 +153,15 @@ class CountVectorizer(override val uid: String)
     }.cache()
     val fullVocabSize = wordCounts.count()
 
-    val vocab: Array[String] = wordCounts.map(_.swap)
-      .top(Math.min(fullVocabSize, vocSize).toInt)
-      .map(_._2)
+    val wordCountOrdering = new Ordering[(String, Long)]{
+      override def compare(x: (String, Long), y: (String,Long)): Int = {
+        if (x._2 > y._2) +1 else -1
+      }
+    }
+    
+    val vocab: Array[String] = wordCounts
+      .top(math.min(fullVocabSize, vocSize).toInt)(wordCountOrdering)
+      .map(_._1)
 
     require(vocab.length > 0, "The vocabulary size should be > 0. Lower minDF as necessary.")
     copyValues(new CountVectorizerModel(uid, vocab).setParent(this))

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/CountVectorizer.scala
@@ -155,10 +155,10 @@ class CountVectorizer(override val uid: String)
 
     val wordCountOrdering = new Ordering[(String, Long)]{
       override def compare(x: (String, Long), y: (String,Long)): Int = {
-        if (x._2 > y._2) +1 else -1
+        if (x._2 > y._2) +1 else if (x._2 < y._2) -1 else 0
       }
     }
-    
+
     val vocab: Array[String] = wordCounts
       .top(math.min(fullVocabSize, vocSize).toInt)(wordCountOrdering)
       .map(_._1)

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/CountVectorizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/CountVectorizerSuite.scala
@@ -66,7 +66,7 @@ class CountVectorizerSuite extends SparkFunSuite with MLlibTestSparkContext
       .setInputCol("words")
       .setOutputCol("features")
       .fit(df)
-    assert(cv.vocabulary === Array("a", "b", "c", "e", "d"))
+    assert(cv.vocabulary === Array("a", "b", "c", "d", "e"))
 
     cv.transform(df).select("features", "expected").collect().foreach {
       case Row(features: Vector, expected: Vector) =>

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/CountVectorizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/CountVectorizerSuite.scala
@@ -66,7 +66,7 @@ class CountVectorizerSuite extends SparkFunSuite with MLlibTestSparkContext
       .setInputCol("words")
       .setOutputCol("features")
       .fit(df)
-    assert(cv.vocabulary === Array("a", "b", "c", "d", "e"))
+    assert(cv.vocabulary === Array("a", "b", "c", "e", "d"))
 
     cv.transform(df).select("features", "expected").collect().foreach {
       case Row(features: Vector, expected: Vector) =>

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/CountVectorizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/CountVectorizerSuite.scala
@@ -56,11 +56,12 @@ class CountVectorizerSuite extends SparkFunSuite with MLlibTestSparkContext
 
   test("CountVectorizer common cases") {
     val df = sqlContext.createDataFrame(Seq(
-      (0, split("a b c d d e"),
-        Vectors.sparse(5, Seq((0, 1.0), (1, 1.0), (2, 1.0), (3, 2.0), (4, 1.0)))),
+      (0, split("a b c d e"),
+        Vectors.sparse(5, Seq((0, 1.0), (1, 1.0), (2, 1.0), (3, 1.0), (4, 1.0)))),
       (1, split("a a a a a a"), Vectors.sparse(5, Seq((0, 6.0)))),
-      (2, split("c"), Vectors.sparse(5, Seq((2, 1.0)))),
-      (3, split("b b b b b"), Vectors.sparse(5, Seq((1, 5.0)))))
+      (2, split("c c"), Vectors.sparse(5, Seq((2, 2.0)))),
+      (3, split("d"), Vectors.sparse(5, Seq((3, 1.0)))),
+      (4, split("b b b b b"), Vectors.sparse(5, Seq((1, 5.0)))))
     ).toDF("id", "words", "expected")
     val cv = new CountVectorizer()
       .setInputCol("words")

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/CountVectorizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/CountVectorizerSuite.scala
@@ -56,8 +56,8 @@ class CountVectorizerSuite extends SparkFunSuite with MLlibTestSparkContext
 
   test("CountVectorizer common cases") {
     val df = sqlContext.createDataFrame(Seq(
-      (0, split("a b c d e"),
-        Vectors.sparse(5, Seq((0, 1.0), (1, 1.0), (2, 1.0), (3, 1.0), (4, 1.0)))),
+      (0, split("a b c d d e"),
+        Vectors.sparse(5, Seq((0, 1.0), (1, 1.0), (2, 1.0), (3, 2.0), (4, 1.0)))),
       (1, split("a a a a a a"), Vectors.sparse(5, Seq((0, 6.0)))),
       (2, split("c"), Vectors.sparse(5, Seq((2, 1.0)))),
       (3, split("b b b b b"), Vectors.sparse(5, Seq((1, 5.0)))))
@@ -66,7 +66,7 @@ class CountVectorizerSuite extends SparkFunSuite with MLlibTestSparkContext
       .setInputCol("words")
       .setOutputCol("features")
       .fit(df)
-    assert(cv.vocabulary === Array("a", "b", "c", "d", "e"))
+    assert(cv.vocabulary.toSet === Set("a", "b", "c", "d", "e"))
 
     cv.transform(df).select("features", "expected").collect().foreach {
       case Row(features: Vector, expected: Vector) =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace sortBy() with top() to calculate the top N frequent words as dictionary.
## How was this patch tested?

existing unit tests.  The terms with same TF would be sorted in descending order. The test would fail if hardcode the terms with same TF the dictionary like "c", "d"...
