### PR TITLE
[SPARK-14502][SQL] Add optimization for Binary Comparison Simplification

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NonNullableBinaryComparisonSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NonNullableBinaryComparisonSimplificationSuite.scala
@@ -41,12 +41,8 @@ class NonNullableBinaryComparisonSimplificationSuite extends PlanTest with Predi
         PruneFilters) :: Nil
   }
 
-  val nullableRelation = LocalRelation.fromExternalRows(
-    Seq('a.int.withNullability(true)),
-    Seq(null, null, null, null).map(x => Row(x)))
-  val nonNullableRelation = LocalRelation.fromExternalRows(
-    Seq('a.int.withNullability(false)),
-    Seq(1, 2, 3, 4).map(x => Row(x)))
+  val nullableRelation = LocalRelation('a.int.withNullability(true))
+  val nonNullableRelation = LocalRelation('a.int.withNullability(false))
 
   test("Preserve nullable or non-deterministic exprs") {
     for (e <- Seq('a === 'a, Rand(0) === Rand(0))) {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NonNullableBinaryComparisonSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NonNullableBinaryComparisonSimplificationSuite.scala
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.analysis._
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.Literal.{FalseLiteral, TrueLiteral}
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules._
+
+class NonNullableBinaryComparisonSimplificationSuite extends PlanTest with PredicateHelper {
+
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches =
+      Batch("AnalysisNodes", Once,
+        EliminateSubqueryAliases) ::
+      Batch("Constant Folding", FixedPoint(50),
+        NullPropagation,
+        ConstantFolding,
+        BooleanSimplification,
+        NonNullableBinaryComparisonSimplification,
+        PruneFilters) :: Nil
+  }
+
+  val nullableRelation = LocalRelation.fromExternalRows(
+    Seq('a.int.withNullability(true)),
+    Seq(null, null, null, null).map(x => Row(x)))
+  val nonNullableRelation = LocalRelation.fromExternalRows(
+    Seq('a.int.withNullability(false)),
+    Seq(1, 2, 3, 4).map(x => Row(x)))
+
+  test("Preserve nullable or non-deterministic exprs") {
+    for (e <- Seq('a === 'a, Rand(0) === Rand(0))) {
+      val plan = nullableRelation.where('a === 'a).analyze
+      val actual = Optimize.execute(plan)
+      val correctAnswer = plan
+      comparePlans(actual, correctAnswer)
+    }
+  }
+
+  test("Non-Nullable Simplification Primitive") {
+    val plan = nonNullableRelation
+      .select('a === 'a, 'a <=> 'a, 'a <= 'a, 'a >= 'a, 'a < 'a, 'a > 'a).analyze
+    val actual = Optimize.execute(plan)
+    val correctAnswer = nonNullableRelation
+      .select(
+        Alias(TrueLiteral, "(a = a)")(),
+        Alias(TrueLiteral, "(a <=> a)")(),
+        Alias(TrueLiteral, "(a <= a)")(),
+        Alias(TrueLiteral, "(a >= a)")(),
+        Alias(FalseLiteral, "(a < a)")(),
+        Alias(FalseLiteral, "(a > a)")())
+      .analyze
+    comparePlans(actual, correctAnswer)
+  }
+
+  test("TRUE Filter") {
+    val plan = nonNullableRelation.where('a === 'a && 'a <=> 'a && 'a <= 'a && 'a >= 'a).analyze
+    val actual = Optimize.execute(plan)
+    val correctAnswer = nonNullableRelation.analyze
+    comparePlans(actual, correctAnswer)
+  }
+
+  test("FALSE Filter") {
+    val plan = nonNullableRelation.where('a < 'a || 'a > 'a).analyze
+    val actual = Optimize.execute(plan)
+    val correctAnswer = LocalRelation(Seq('a.int.withNullability(false)), Seq.empty)
+    comparePlans(actual, correctAnswer)
+  }
+
+  test("Expression Normalization") {
+    val plan = nonNullableRelation.where(
+      'a * Literal(100) + Pi() === Pi() + Literal(100) * 'a ||
+      DateAdd(CurrentDate(), 'a + Literal(2)) <= DateAdd(CurrentDate(), Literal(2) + 'a))
+      .analyze
+    val actual = Optimize.execute(plan)
+    val correctAnswer = nonNullableRelation.analyze
+    comparePlans(actual, correctAnswer)
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NonNullableBinaryComparisonSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NonNullableBinaryComparisonSimplificationSuite.scala
@@ -89,7 +89,7 @@ class NonNullableBinaryComparisonSimplificationSuite extends PlanTest with Predi
 
   test("Expression Normalization") {
     val plan = nonNullableRelation.where(
-      'a * Literal(100) + Pi() === Pi() + Literal(100) * 'a ||
+      'a * Literal(100) + Pi() === Pi() + Literal(100) * 'a &&
       DateAdd(CurrentDate(), 'a + Literal(2)) <= DateAdd(CurrentDate(), Literal(2) + 'a))
       .analyze
     val actual = Optimize.execute(plan)


### PR DESCRIPTION
## What changes were proposed in this pull request?

We can simplifies binary comparisons with semantically-equal operands:
1. Replace '<=>' with 'true' literal.
2. Replace '=', '<=', and '>=' with 'true' literal if both operands are non-nullable.
3. Replace '<' and '>' with 'false' literal if both operands are non-nullable.

For example, the following example plan

```
scala> sql("SELECT * FROM (SELECT explode(array(1,2,3)) a) T WHERE a BETWEEN a AND a+7").explain()
...
:  +- Filter ((a#59 >= a#59) && (a#59 <= (a#59 + 7)))
...
```

will be optimized into the following.

```
:  +- Filter (a#47 <= (a#47 + 7))
```
## How was this patch tested?

Pass the Jenkins tests including new `BinaryComparisonSimplificationSuite`.
