### PR TITLE
[SPARK-14462] [HOTFIX] Let DummyTestingSuite inherit FunSuite 

### DIFF
--- a/mllib-local/pom.xml
+++ b/mllib-local/pom.xml
@@ -39,6 +39,11 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/mllib-local/pom.xml
+++ b/mllib-local/pom.xml
@@ -39,11 +39,6 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_${scala.binary.version}</artifactId>
-      <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/mllib-local/src/test/scala/org/apache/spark/ml/DummyTestingSuite.scala
+++ b/mllib-local/src/test/scala/org/apache/spark/ml/DummyTestingSuite.scala
@@ -17,10 +17,10 @@
 
 package org.apache.spark.ml
 
-import org.apache.spark.SparkFunSuite
+import org.scalatest.{BeforeAndAfterAll, FunSuite, Outcome}
 
 // This is testing if the new build works. To be removed soon.
-class DummyTestingSuite extends SparkFunSuite {
+class DummyTestingSuite extends FunSuite {
 
   test("This is testing if the new build works.") {
     assert(DummyTesting.add10(15) === 25)


### PR DESCRIPTION
## What changes were proposed in this pull request?

After [SPARK-14462] went in, build shows the following error:

```
[error] missing or invalid dependency detected while loading class file 'SparkFunSuite.class'.
[error] Could not access type Logging in package org.apache.spark.internal,
[error] because it (or its dependencies) are missing. Check your build definition for
[error] missing or conflicting dependencies. (Re-run with `-Ylog-classpath` to see the problematic classpath.)
[error] A full rebuild may help if 'SparkFunSuite.class' was compiled against an incompatible version of org.apache.spark.internal.
[error] one error found
[error] Compile failed at Apr 9, 2016 9:31:47 AM [0.382s]
```

This was due to missing dependency of spark-core module where Logging resides.
SparkFunSuite imports Logging.

I tried creating SparkFunNoLoggingSuite but then realized that it becomes FunSuite.

Current PR lets DummyTestingSuite inherit FunSuite so that mllib-local module doesn't depend on spark-core.
## How was this patch tested?

Gone through maven build.
