### PR TITLE
[SPARK-14298] [ML] [MLlib] Add unit test for EM LDA disable checkpointing

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/LDASuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/LDASuite.scala
@@ -292,7 +292,8 @@ class LDASuite extends SparkFunSuite with MLlibTestSparkContext with DefaultRead
 
   test("EM LDA disable checkpointing") {
     // Checkpoint dir is set by MLlibTestSparkContext
-    val lda = new LDA().setK(2).setSeed(1).setOptimizer("em").setMaxIter(3).setCheckpointInterval(-1)
+    val lda = new LDA().setK(2).setSeed(1).setOptimizer("em").setMaxIter(3)
+      .setCheckpointInterval(-1)
     val model_ = lda.fit(dataset)
     assert(model_.isInstanceOf[DistributedLDAModel])
     val model = model_.asInstanceOf[DistributedLDAModel]

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/LDASuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/LDASuite.scala
@@ -289,4 +289,14 @@ class LDASuite extends SparkFunSuite with MLlibTestSparkContext with DefaultRead
 
     assert(model.getCheckpointFiles.isEmpty)
   }
+
+  test("EM LDA disable checkpointing") {
+    // Checkpoint dir is set by MLlibTestSparkContext
+    val lda = new LDA().setK(2).setSeed(1).setOptimizer("em").setMaxIter(3).setCheckpointInterval(-1)
+    val model_ = lda.fit(dataset)
+    assert(model_.isInstanceOf[DistributedLDAModel])
+    val model = model_.asInstanceOf[DistributedLDAModel]
+
+    assert(model.getCheckpointFiles.isEmpty)
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is follow up for #12089, add unit test for EM LDA which test disable checkpointing when set `checkpointInterval = -1`.
## How was this patch tested?

unit test.

cc @jkbradley 
