### PR TITLE
[SPARK-14520][SQL] Use correct return type in VectorizedParquetInputFormat

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRelation.scala
@@ -476,8 +476,8 @@ private[sql] class DefaultSource
 final class VectorizedParquetInputFormat extends ParquetInputFormat[InternalRow] {
   override def createRecordReader(
     inputSplit: InputSplit,
-    taskAttemptContext: TaskAttemptContext): ParquetRecordReader[InternalRow] = {
-    new VectorizedParquetRecordReader().asInstanceOf[ParquetRecordReader[InternalRow]]
+    taskAttemptContext: TaskAttemptContext): RecordReader[Void, InternalRow] = {
+    new VectorizedParquetRecordReader().asInstanceOf[RecordReader[Void, InternalRow]]
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

JIRA: https://issues.apache.org/jira/browse/SPARK-14520

`VectorizedParquetInputFormat` inherits `ParquetInputFormat` and overrides `createRecordReader`. However, its overridden `createRecordReader` returns a `ParquetRecordReader`. It should return a `RecordReader`. Otherwise, `ClassCastException` will be thrown.
## How was this patch tested?

Existing tests.
