### PR TITLE
[SPARK-14533] [MLLIB] RowMatrix.computeCovariance inaccurate when values are very large

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/RowMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/RowMatrix.scala
@@ -328,43 +328,43 @@ class RowMatrix @Since("1.0.0") (
     val n = numCols().toInt
     checkNumColumns(n)
 
-    val (m, mean) = rows.treeAggregate[(Long, BDV[Double])]((0L, BDV.zeros[Double](n)))(
-      seqOp = (s: (Long, BDV[Double]), v: Vector) => (s._1 + 1L, s._2 += v.toBreeze),
-      combOp = (s1: (Long, BDV[Double]), s2: (Long, BDV[Double])) =>
-        (s1._1 + s2._1, s1._2 += s2._2)
-    )
+    val summary = computeColumnSummaryStatistics()
+    val m = summary.count
+    require(m > 1, s"RowMatrix.computeCovariance called on matrix with only $m rows." +
+      "  Cannot compute the covariance of a RowMatrix with <= 1 row.")
+    val mean = summary.mean.toBreeze
 
-    if (m <= 1) {
-      sys.error(s"RowMatrix.computeCovariance called on matrix with only $m rows." +
-        "  Cannot compute the covariance of a RowMatrix with <= 1 row.")
+    rows.first() match {
+      case _: SparseVector =>
+        // We use the formula Cov(X, Y) = E[X * Y] - E[X] E[Y], which is not accurate if E[X * Y] is
+        // large but Cov(X, Y) is small, but it is good for sparse computation.
+        // TODO: find a fast and stable way for sparse data.
+        val G = computeGramianMatrix().toBreeze
+        var i = 0
+        var j = 0
+        val m1 = m - 1.0
+        var alpha = 0.0
+        while (i < n) {
+          alpha = m / m1 * mean(i)
+          j = i
+          while (j < n) {
+            val Gij = G(i, j) / m1 - alpha * mean(j)
+            G(i, j) = Gij
+            G(j, i) = Gij
+            j += 1
+          }
+          i += 1
+        }
+        Matrices.fromBreeze(G)
+
+      case _: DenseVector =>
+        // For dense, go ahead and subtract off mean to avoid round-off problem above
+        val centeredRows = rows.map(row => Vectors.fromBreeze(row.toBreeze - mean))
+        // Then all that's needed is to divide the Gramian by m-1
+        new RowMatrix(centeredRows, nRows, nCols).computeGramianMatrix().map(_ / (m - 1.0))
+
+      case _ => throw new IllegalArgumentException("Unsupported vector type")
     }
-    updateNumRows(m)
-
-    mean :/= m.toDouble
-
-    // We use the formula Cov(X, Y) = E[X * Y] - E[X] E[Y], which is not accurate if E[X * Y] is
-    // large but Cov(X, Y) is small, but it is good for sparse computation.
-    // TODO: find a fast and stable way for sparse data.
-
-    val G = computeGramianMatrix().toBreeze.asInstanceOf[BDM[Double]]
-
-    var i = 0
-    var j = 0
-    val m1 = m - 1.0
-    var alpha = 0.0
-    while (i < n) {
-      alpha = m / m1 * mean(i)
-      j = i
-      while (j < n) {
-        val Gij = G(i, j) / m1 - alpha * mean(j)
-        G(i, j) = Gij
-        G(j, i) = Gij
-        j += 1
-      }
-      i += 1
-    }
-
-    Matrices.fromBreeze(G)
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/stat/correlation/PearsonCorrelation.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/stat/correlation/PearsonCorrelation.scala
@@ -52,7 +52,7 @@ private[stat] object PearsonCorrelation extends Correlation with Logging {
 
   /**
    * Compute the Pearson correlation matrix from the covariance matrix.
-   * 0 covariance results in a correlation value of Double.NaN.
+   * 0 variance results in a correlation value of Double.NaN.
    */
   def computeCorrelationMatrixFromCovariance(covarianceMatrix: Matrix): Matrix = {
     val cov = covarianceMatrix.toBreeze.asInstanceOf[BDM[Double]]

--- a/mllib/src/test/scala/org/apache/spark/mllib/stat/CorrelationSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/stat/CorrelationSuite.scala
@@ -22,6 +22,7 @@ import breeze.linalg.{DenseMatrix => BDM, Matrix => BM}
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.internal.Logging
 import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.mllib.random.RandomRDDs
 import org.apache.spark.mllib.stat.correlation.{Correlations, PearsonCorrelation,
   SpearmanCorrelation}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
@@ -42,10 +43,10 @@ class CorrelationSuite extends SparkFunSuite with MLlibTestSparkContext with Log
   test("corr(x, y) pearson, 1 value in data") {
     val x = sc.parallelize(Array(1.0))
     val y = sc.parallelize(Array(4.0))
-    intercept[RuntimeException] {
+    intercept[IllegalArgumentException] {
       Statistics.corr(x, y, "pearson")
     }
-    intercept[RuntimeException] {
+    intercept[IllegalArgumentException] {
       Statistics.corr(x, y, "spearman")
     }
   }
@@ -127,13 +128,20 @@ class CorrelationSuite extends SparkFunSuite with MLlibTestSparkContext with Log
     assert(Correlations.getCorrelationFromName("pearson") === pearson)
     assert(Correlations.getCorrelationFromName("spearman") === spearman)
 
-    // Should throw IllegalArgumentException
-    try {
+    intercept[IllegalArgumentException] {
       Correlations.getCorrelationFromName("kendall")
-      assert(false)
-    } catch {
-      case ie: IllegalArgumentException =>
     }
+  }
+
+  test("Pearson correlation of very large uncorrelated values") {
+    // The two RDDs should have 0 correlation because they're random;
+    // this should stay the same after shifting them by any amount
+    // In practice a large shift produces very large values which can reveal
+    // round-off problems
+    val a = RandomRDDs.normalRDD(sc, 100000, 10).map(_ + 1000000000.0)
+    val b = RandomRDDs.normalRDD(sc, 100000, 10).map(_ + 1000000000.0)
+    val p = Statistics.corr(a, b, method = "pearson")
+    assert(approxEqual(p, 0.0, 0.01))
   }
 
   def approxEqual(v1: Double, v2: Double, threshold: Double = 1e-6): Boolean = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

For dense rows, compute covariance more accurately by centering in computeCovariance (sparse case remains untouched). Also compute column means more accurately with computeColumnSummaryStatistics

CC @mengxr -- am I missing anything here? seems OK for the dense case.
I'd like to back-port to 1.6 or even 1.5 if this looks OK.
## How was this patch tested?

Jenkins test, including new test mentioned in the JIRA.
