### PR TITLE
[SPARK-14531][STREAMING] Flume streaming should respect maxRate

### DIFF
--- a/external/flume/src/main/scala/org/apache/spark/streaming/flume/FlumeUtils.scala
+++ b/external/flume/src/main/scala/org/apache/spark/streaming/flume/FlumeUtils.scala
@@ -147,7 +147,8 @@ object FlumeUtils {
       storageLevel: StorageLevel
     ): ReceiverInputDStream[SparkFlumeEvent] = {
     createPollingStream(ssc, addresses, storageLevel,
-      DEFAULT_POLLING_BATCH_SIZE, DEFAULT_POLLING_PARALLELISM)
+      ssc.conf.getInt("spark.streaming.receiver.maxRate", DEFAULT_POLLING_BATCH_SIZE),
+      DEFAULT_POLLING_PARALLELISM)
   }
 
   /**
@@ -217,7 +218,8 @@ object FlumeUtils {
       storageLevel: StorageLevel
     ): JavaReceiverInputDStream[SparkFlumeEvent] = {
     createPollingStream(jssc, addresses, storageLevel,
-      DEFAULT_POLLING_BATCH_SIZE, DEFAULT_POLLING_PARALLELISM)
+      jssc.ssc.conf.getInt("spark.streaming.receiver.maxRate", DEFAULT_POLLING_BATCH_SIZE),
+      DEFAULT_POLLING_PARALLELISM)
   }
 
   /**

--- a/external/flume/src/test/scala/org/apache/spark/streaming/flume/FlumeStreamSuite.scala
+++ b/external/flume/src/test/scala/org/apache/spark/streaming/flume/FlumeStreamSuite.scala
@@ -48,6 +48,23 @@ class FlumeStreamSuite extends SparkFunSuite with BeforeAndAfter with Matchers w
     testFlumeStream(testCompression = true)
   }
 
+  test("flume input with maxBatchSize - SPARK-14531") {
+    val utils = new FlumeTestUtils
+    try {
+      conf.set("spark.streaming.receiver.maxRate", "500")
+      ssc = new StreamingContext(conf, Milliseconds(200))
+      val flumePollingStream1 = FlumeUtils.createPollingStream(
+        ssc, "localhost", utils.getTestPort())
+      assert(flumePollingStream1.getReceiver().asInstanceOf[FlumePollingReceiver]
+        .getMaxBatchSize == 500)
+    } finally {
+      if (ssc != null) {
+        ssc.stop()
+      }
+      utils.close()
+    }
+  }
+
   /** Run test on flume stream */
   private def testFlumeStream(testCompression: Boolean): Unit = {
     val input = (1 to 100).map { _.toString }


### PR DESCRIPTION
## What changes were proposed in this pull request?

At the moment Flume streaming set the default polling max batch size as DEFAULT_POLLING_BATCH_SIZE (1000) even if an option "spark.streaming.receiver.maxRate" is passed. This patch tries to address this issue by respecting the option "spark.streaming.receiver.maxRate" in FlumeUtils.scala.
## How was this patch tested?

A test case is added to cover the this change.
