### PR TITLE
[SPARK-14545][SQL] Improve `LikeSimplification` by adding `a%b` rule

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -524,23 +524,23 @@ object LikeSimplification extends Rule[LogicalPlan] {
   private val equalTo = "([^_%]*)".r
 
   def apply(plan: LogicalPlan): LogicalPlan = plan transformAllExpressions {
-    case Like(l, Literal(utf, StringType)) =>
-      utf.toString match {
-        case startsWith(pattern) if !pattern.endsWith("\\") =>
-          StartsWith(l, Literal(pattern))
-        case endsWith(pattern) =>
-          EndsWith(l, Literal(pattern))
+    case Like(l, Literal(pattern, StringType)) =>
+      pattern.toString match {
+        case startsWith(prefix) if !prefix.endsWith("\\") =>
+          StartsWith(l, Literal(prefix))
+        case endsWith(postfix) =>
+          EndsWith(l, Literal(postfix))
         // 'a%a' pattern is basically same with 'a%' && '%a'.
         // However, the additional `Length` condition is required to prevent 'a' match 'a%a'.
         case startsAndEndsWith(prefix, postfix) if !prefix.endsWith("\\") =>
           And(GreaterThanOrEqual(Length(l), Literal(prefix.size + postfix.size)),
             And(StartsWith(l, Literal(prefix)), EndsWith(l, Literal(postfix))))
-        case contains(pattern) if !pattern.endsWith("\\") =>
-          Contains(l, Literal(pattern))
-        case equalTo(pattern) =>
-          EqualTo(l, Literal(pattern))
+        case contains(infix) if !infix.endsWith("\\") =>
+          Contains(l, Literal(infix))
+        case equalTo(str) =>
+          EqualTo(l, Literal(str))
         case _ =>
-          Like(l, Literal.create(utf, StringType))
+          Like(l, Literal.create(pattern, StringType))
       }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -530,6 +530,8 @@ object LikeSimplification extends Rule[LogicalPlan] {
           StartsWith(l, Literal(pattern))
         case endsWith(pattern) =>
           EndsWith(l, Literal(pattern))
+        // 'a%a' pattern is basically same with 'a%' && '%a'.
+        // However, the additional `Length` condition is required to prevent 'a' match 'a%a'.
         case startsAndEndsWith(prefix, postfix) if !prefix.endsWith("\\") =>
           And(GreaterThanOrEqual(Length(l), Literal(prefix.size + postfix.size)),
             And(StartsWith(l, Literal(prefix)), EndsWith(l, Literal(postfix))))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -524,23 +524,23 @@ object LikeSimplification extends Rule[LogicalPlan] {
   private val equalTo = "([^_%]*)".r
 
   def apply(plan: LogicalPlan): LogicalPlan = plan transformAllExpressions {
-    case Like(l, Literal(pattern, StringType)) =>
+    case Like(input, Literal(pattern, StringType)) =>
       pattern.toString match {
         case startsWith(prefix) if !prefix.endsWith("\\") =>
-          StartsWith(l, Literal(prefix))
+          StartsWith(input, Literal(prefix))
         case endsWith(postfix) =>
-          EndsWith(l, Literal(postfix))
+          EndsWith(input, Literal(postfix))
         // 'a%a' pattern is basically same with 'a%' && '%a'.
         // However, the additional `Length` condition is required to prevent 'a' match 'a%a'.
         case startsAndEndsWith(prefix, postfix) if !prefix.endsWith("\\") =>
-          And(GreaterThanOrEqual(Length(l), Literal(prefix.size + postfix.size)),
-            And(StartsWith(l, Literal(prefix)), EndsWith(l, Literal(postfix))))
+          And(GreaterThanOrEqual(Length(input), Literal(prefix.size + postfix.size)),
+            And(StartsWith(input, Literal(prefix)), EndsWith(input, Literal(postfix))))
         case contains(infix) if !infix.endsWith("\\") =>
-          Contains(l, Literal(infix))
+          Contains(input, Literal(infix))
         case equalTo(str) =>
-          EqualTo(l, Literal(str))
+          EqualTo(input, Literal(str))
         case _ =>
-          Like(l, Literal.create(pattern, StringType))
+          Like(input, Literal.create(pattern, StringType))
       }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LikeSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LikeSimplificationSuite.scala
@@ -61,6 +61,20 @@ class LikeSimplificationSuite extends PlanTest {
     comparePlans(optimized, correctAnswer)
   }
 
+  test("simplify Like into StartsAndEndsWith") {
+    val originalQuery =
+      testRelation
+        .where(('a like "abc\\%def") || ('a like "abc%def"))
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+    val correctAnswer = testRelation
+      .where(('a like "abc\\%def") ||
+        (Length('a) >= 6 && (StartsWith('a, "abc") && EndsWith('a, "def"))))
+      .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
   test("simplify Like into Contains") {
     val originalQuery =
       testRelation

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LikeSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LikeSimplificationSuite.scala
@@ -61,7 +61,7 @@ class LikeSimplificationSuite extends PlanTest {
     comparePlans(optimized, correctAnswer)
   }
 
-  test("simplify Like into StartsAndEndsWith") {
+  test("simplify Like into startsWith and EndsWith") {
     val originalQuery =
       testRelation
         .where(('a like "abc\\%def") || ('a like "abc%def"))


### PR DESCRIPTION
## What changes were proposed in this pull request?

Current `LikeSimplification` handles the following four rules.
- 'a%' => expr.StartsWith("a")
- '%b' => expr.EndsWith("b")
- '%a%' => expr.Contains("a")
- 'a' => EqualTo("a")

This PR adds the following rule.
- 'a%b' => expr.Length() >= 2 && expr.StartsWith("a") && expr.EndsWith("b")

Here, 2 is statically calculated from "a".size + "b".size.

**Before**

```
scala> sql("select a from (select explode(array('abc','adc')) a) T where a like 'a%c'").explain()
== Physical Plan ==
WholeStageCodegen
:  +- Filter a#5 LIKE a%c
:     +- INPUT
+- Generate explode([abc,adc]), false, false, [a#5]
   +- Scan OneRowRelation[]
```

**After**

```
scala> sql("select a from (select explode(array('abc','adc')) a) T where a like 'a%c'").explain()
== Physical Plan ==
WholeStageCodegen
:  +- Filter ((length(a#5) >= 2) && (StartsWith(a#5, a) && EndsWith(a#5, c)))
:     +- INPUT
+- Generate explode([abc,adc]), false, false, [a#5]
   +- Scan OneRowRelation[]
```
## How was this patch tested?

Pass the Jenkins tests (including new testcase).
