### PR TITLE
[SPARK-14572] [Doc] Update config docs to allow -Xms in extraJavaOptions

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -225,10 +225,9 @@ Apart from these, the following properties are also available, and may be useful
   <td>(none)</td>
   <td>
     A string of extra JVM options to pass to the driver. For instance, GC settings or other logging.
-    Note that it is illegal to set maximum heap size (-Xmx) settings with this option. However,
-    specifying an initial heap size (-Xms) is allowed. Maximum heap size settings can be set with
-    <code>spark.driver.memory</code> in the cluster mode and through the <code>--driver-memory</code>
-    command line option in the client mode.
+    Note that it is illegal to set maximum heap size (-Xmx) settings with this option. Maximum heap
+    size settings can be set with <code>spark.driver.memory</code> in the cluster mode and through
+    the <code>--driver-memory</code> command line option in the client mode.
 
     <br /><em>Note:</em> In client mode, this config must not be set through the <code>SparkConf</code>
     directly in your application, because the driver JVM has already started at that point.
@@ -274,9 +273,8 @@ Apart from these, the following properties are also available, and may be useful
   <td>
     A string of extra JVM options to pass to executors. For instance, GC settings or other logging.
     Note that it is illegal to set Spark properties or maximum heap size (-Xmx) settings with this
-    option. However, specifying an initial heap size (-Xms) is allowed. Spark properties should be
-    set using a SparkConf object or the spark-defaults.conf file used with the spark-submit script.
-    Maximum heap size settings can be set with spark.executor.memory.
+    option. Spark properties should be set using a SparkConf object or the spark-defaults.conf file
+    used with the spark-submit script. Maximum heap size settings can be set with spark.executor.memory.
   </td>
 </tr>
 <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -225,11 +225,15 @@ Apart from these, the following properties are also available, and may be useful
   <td>(none)</td>
   <td>
     A string of extra JVM options to pass to the driver. For instance, GC settings or other logging.
+    Note that it is illegal to set maximum heap size (-Xmx) settings with this option. However,
+    specifying an initial heap size (-Xms) is allowed. Maximum heap size settings can be set with
+    <code>spark.driver.memory</code> in the cluster mode and through the <code>--driver-memory</code>
+    command line option in the client mode.
 
     <br /><em>Note:</em> In client mode, this config must not be set through the <code>SparkConf</code>
     directly in your application, because the driver JVM has already started at that point.
     Instead, please set this through the <code>--driver-java-options</code> command line option or in
-    your default properties file.</td>
+    your default properties file.
   </td>
 </tr>
 <tr>
@@ -269,9 +273,10 @@ Apart from these, the following properties are also available, and may be useful
   <td>(none)</td>
   <td>
     A string of extra JVM options to pass to executors. For instance, GC settings or other logging.
-    Note that it is illegal to set Spark properties or heap size settings with this option. Spark
-    properties should be set using a SparkConf object or the spark-defaults.conf file used with the
-    spark-submit script. Heap size settings can be set with spark.executor.memory.
+    Note that it is illegal to set Spark properties or maximum heap size (-Xmx) settings with this
+    option. However, specifying an initial heap size (-Xms) is allowed. Spark properties should be
+    set using a SparkConf object or the spark-defaults.conf file used with the spark-submit script.
+    Maximum heap size settings can be set with spark.executor.memory.
   </td>
 </tr>
 <tr>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -343,8 +343,8 @@ If you need a reference to the proper location to put log files in the YARN so t
   <td>
   A string of extra JVM options to pass to the YARN Application Master in client mode.
   In cluster mode, use <code>spark.driver.extraJavaOptions</code> instead. Note that it is illegal
-  to set maximum heap size (-Xmx) settings with this option. However, specifying an initial heap
-  size (-Xms) is allowed. Maximum heap size settings can be set with <code>spark.yarn.am.memory</code>
+  to set maximum heap size (-Xmx) settings with this option. Maximum heap size settings can be set
+  with <code>spark.yarn.am.memory</code>
   </td>
 </tr>
 <tr>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -342,7 +342,9 @@ If you need a reference to the proper location to put log files in the YARN so t
   <td>(none)</td>
   <td>
   A string of extra JVM options to pass to the YARN Application Master in client mode.
-  In cluster mode, use <code>spark.driver.extraJavaOptions</code> instead.
+  In cluster mode, use <code>spark.driver.extraJavaOptions</code> instead. Note that it is illegal
+  to set maximum heap size (-Xmx) settings with this option. However, specifying an initial heap
+  size (-Xms) is allowed. Maximum heap size settings can be set with <code>spark.yarn.am.memory</code>
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The configuration docs are updated to reflect the changes introduced with [SPARK-12384](https://issues.apache.org/jira/browse/SPARK-12384). This allows the user to specify initial heap memory settings through the extraJavaOptions for executor, driver and am. 
## How was this patch tested?

The changes are tested in [SPARK-12384](https://issues.apache.org/jira/browse/SPARK-12384). This is just documenting the changes made.
