### PR TITLE
[SPARK-14580][SPARK-14655][SQL] Hive IfCoercion should preserve predicate.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -328,6 +328,7 @@ object FunctionRegistry {
     expression[SortArray]("sort_array"),
 
     // misc functions
+    expression[AssertTrue]("assert_true"),
     expression[Crc32]("crc32"),
     expression[Md5]("md5"),
     expression[Murmur3Hash]("hash"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
@@ -584,6 +584,8 @@ object HiveTypeCoercion {
           val newRight = if (right.dataType == widestType) right else Cast(right, widestType)
           If(pred, newLeft, newRight)
         }.getOrElse(i)  // If there is no applicable conversion, leave expression unchanged.
+      case If(Literal(null, NullType), left, right) =>
+        If(Literal.create(null, BooleanType), left, right)
       case If(pred, left, right) if pred.dataType == NullType =>
         If(Cast(pred, BooleanType), left, right)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercion.scala
@@ -584,10 +584,8 @@ object HiveTypeCoercion {
           val newRight = if (right.dataType == widestType) right else Cast(right, widestType)
           If(pred, newLeft, newRight)
         }.getOrElse(i)  // If there is no applicable conversion, leave expression unchanged.
-      // Convert If(null literal, _, _) into boolean type.
-      // In the optimizer, we should short-circuit this directly into false value.
       case If(pred, left, right) if pred.dataType == NullType =>
-        If(Literal.create(null, BooleanType), left, right)
+        If(Cast(pred, BooleanType), left, right)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -515,7 +515,7 @@ case class AssertTrue(child: Expression) extends UnaryExpression with ImplicitCa
     ev.isNull = "true"
     ev.value = "null"
     s"""${eval.code}
-       |if (${eval.isNull} || java.lang.Boolean.FALSE.equals("${eval.value}")) {
+       |if (${eval.isNull} || !${eval.value}) {
        |  throw new RuntimeException("'${child.simpleString}' is not true.");
        |}
      """.stripMargin

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/HiveTypeCoercionSuite.scala
@@ -19,9 +19,7 @@ package org.apache.spark.sql.catalyst.analysis
 
 import java.sql.Timestamp
 
-import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -351,36 +349,21 @@ class HiveTypeCoercionSuite extends PlanTest {
   test("type coercion for If") {
     val rule = HiveTypeCoercion.IfCoercion
 
-    // SPARK-14580 Hive IfCoercion should preserve predicate
-    case class AssertTrue(condition: Boolean) extends LeafExpression {
-      def nullable: Boolean = true
-      def dataType: DataType = NullType
-      def eval(input: InternalRow = null) : Any = {
-        if (!condition) throw new Exception("SPARK-14580 TEST")
-        Literal.create(null, NullType)
-      }
-      override def genCode(ctx: CodegenContext, ev: ExprCode): String = {
-        s"""if (!$condition) throw new Exception("SPARK-14580 TEST");"""
-      }
-    }
-
     ruleTest(rule,
       If(Literal(true), Literal(1), Literal(1L)),
-      If(Literal(true), Cast(Literal(1), LongType), Literal(1L))
-    )
+      If(Literal(true), Cast(Literal(1), LongType), Literal(1L)))
 
     ruleTest(rule,
       If(Literal.create(null, NullType), Literal(1), Literal(1)),
-      If(Literal.create(null, BooleanType), Literal(1), Literal(1))
-    )
+      If(Literal.create(null, BooleanType), Literal(1), Literal(1)))
 
     ruleTest(rule,
-      If(AssertTrue(true), Literal(1), Literal(2)),
-      If(Cast(AssertTrue(true), BooleanType), Literal(1), Literal(2)))
+      If(AssertTrue(Literal.create(true, BooleanType)), Literal(1), Literal(2)),
+      If(Cast(AssertTrue(Literal.create(true, BooleanType)), BooleanType), Literal(1), Literal(2)))
 
     ruleTest(rule,
-      If(AssertTrue(false), Literal(1), Literal(2)),
-      If(Cast(AssertTrue(false), BooleanType), Literal(1), Literal(2)))
+      If(AssertTrue(Literal.create(false, BooleanType)), Literal(1), Literal(2)),
+      If(Cast(AssertTrue(Literal.create(false, BooleanType)), BooleanType), Literal(1), Literal(2)))
   }
 
   test("type coercion for CaseKeyWhen") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MiscFunctionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MiscFunctionsSuite.scala
@@ -70,13 +70,25 @@ class MiscFunctionsSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("assert_true") {
-    checkEvaluation(AssertTrue(Literal(true, BooleanType)), null)
+    // False values of assert_true: false, 0, null, ""
     intercept[RuntimeException] {
       checkEvaluation(AssertTrue(Literal(false, BooleanType)), null)
     }
     intercept[RuntimeException] {
-      checkEvaluation(AssertTrue(Literal.create(null, BinaryType)), null)
+      checkEvaluation(AssertTrue(Literal(0)), null)
     }
+    intercept[RuntimeException] {
+      checkEvaluation(AssertTrue(Literal.create(null, NullType)), null)
+    }
+    intercept[RuntimeException] {
+      checkEvaluation(AssertTrue(Literal.create(null, BooleanType)), null)
+    }
+    intercept[RuntimeException] {
+      checkEvaluation(AssertTrue(Literal("")), null)
+    }
+    checkEvaluation(AssertTrue(Literal(true, BooleanType)), null)
+    checkEvaluation(AssertTrue(Literal(1)), null)
+    checkEvaluation(AssertTrue(Literal("abc", BooleanType)), null)
   }
 
   private val structOfString = new StructType().add("str", StringType)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MiscFunctionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MiscFunctionsSuite.scala
@@ -69,6 +69,16 @@ class MiscFunctionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkConsistencyBetweenInterpretedAndCodegen(Crc32, BinaryType)
   }
 
+  test("assert_true") {
+    checkEvaluation(AssertTrue(Literal(true, BooleanType)), null)
+    intercept[RuntimeException] {
+      checkEvaluation(AssertTrue(Literal(false, BooleanType)), null)
+    }
+    intercept[RuntimeException] {
+      checkEvaluation(AssertTrue(Literal.create(null, BinaryType)), null)
+    }
+  }
+
   private val structOfString = new StructType().add("str", StringType)
   private val structOfUDT = new StructType().add("udt", new ExamplePointUDT, false)
   private val arrayOfString = ArrayType(StringType)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MiscFunctionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MiscFunctionsSuite.scala
@@ -75,7 +75,7 @@ class MiscFunctionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       checkEvaluation(AssertTrue(Literal(false, BooleanType)), null)
     }
     intercept[RuntimeException] {
-      checkEvaluation(AssertTrue(Literal(0)), null)
+      checkEvaluation(AssertTrue(Cast(Literal(0), BooleanType)), null)
     }
     intercept[RuntimeException] {
       checkEvaluation(AssertTrue(Literal.create(null, NullType)), null)
@@ -83,12 +83,8 @@ class MiscFunctionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     intercept[RuntimeException] {
       checkEvaluation(AssertTrue(Literal.create(null, BooleanType)), null)
     }
-    intercept[RuntimeException] {
-      checkEvaluation(AssertTrue(Literal("")), null)
-    }
     checkEvaluation(AssertTrue(Literal(true, BooleanType)), null)
-    checkEvaluation(AssertTrue(Literal(1)), null)
-    checkEvaluation(AssertTrue(Literal("abc", BooleanType)), null)
+    checkEvaluation(AssertTrue(Cast(Literal(1), BooleanType)), null)
   }
 
   private val structOfString = new StructType().add("str", StringType)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MiscFunctionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MiscFunctionsSuite.scala
@@ -70,7 +70,6 @@ class MiscFunctionsSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("assert_true") {
-    // False values of assert_true: false, 0, null, ""
     intercept[RuntimeException] {
       checkEvaluation(AssertTrue(Literal(false, BooleanType)), null)
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HivePlanTest.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HivePlanTest.scala
@@ -49,4 +49,12 @@ class HivePlanTest extends QueryTest with TestHiveSingleton {
     assert(plan.collect{ case w: logical.Window => w }.size === 1,
       "Should have only 1 Window operator.")
   }
+
+  test("SPARK-14580 Hive IfCoercion should preserve predicate") {
+    val plan = sql("SELECT IF(assert_true(false), 1, 2)").queryExecution.analyzed
+    val optimized = sql("SELECT IF(assert_true(false), 1, 2)").queryExecution.optimizedPlan
+    val correctAnswer = plan
+
+    comparePlans(optimized, plan)
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HivePlanTest.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HivePlanTest.scala
@@ -49,12 +49,4 @@ class HivePlanTest extends QueryTest with TestHiveSingleton {
     assert(plan.collect{ case w: logical.Window => w }.size === 1,
       "Should have only 1 Window operator.")
   }
-
-  test("SPARK-14580 Hive IfCoercion should preserve predicate") {
-    val plan = sql("SELECT IF(assert_true(false), 1, 2)").queryExecution.analyzed
-    val optimized = sql("SELECT IF(assert_true(false), 1, 2)").queryExecution.optimizedPlan
-    val correctAnswer = plan
-
-    comparePlans(optimized, plan)
-  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, `HiveTypeCoercion.IfCoercion` removes all predicates whose return-type are null. However, some UDFs need evaluations because they are designed to throw exceptions. This PR fixes that to preserve the predicates. Also, `assert_true` is implemented as Spark SQL function.

**Before**

```
scala> sql("select if(assert_true(false),2,3)").head
res2: org.apache.spark.sql.Row = [3]
```

**After**

```
scala> sql("select if(assert_true(false),2,3)").head
... ASSERT_TRUE ...
```

**Hive**

```
hive> select if(assert_true(false),2,3);
OK
Failed with exception java.io.IOException:org.apache.hadoop.hive.ql.metadata.HiveException: ASSERT_TRUE(): assertion failed.
```
## How was this patch tested?

Pass the Jenkins tests (including a new testcase in `HivePlanTest`)
