### PR TITLE
[SPARK-14576] [Web UI] Spark console should display Web UI url

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -280,6 +280,8 @@ class SparkContext(config: SparkConf) extends Logging with ExecutorAllocationCli
 
   private[spark] def ui: Option[SparkUI] = _ui
 
+  def uiWebUrl: Option[String] = _ui.map(_.webUrl)
+
   /**
    * A default Hadoop Configuration for the Hadoop code (e.g. file systems) that we reuse.
    *

--- a/core/src/main/scala/org/apache/spark/ui/WebUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/WebUI.scala
@@ -133,20 +133,20 @@ private[spark] abstract class WebUI(
 
   /** Bind to the HTTP server behind this web interface. */
   def bind() {
-    assert(!serverInfo.isDefined, "Attempted to bind %s more than once!".format(className))
+    assert(!serverInfo.isDefined, s"Attempted to bind $className more than once!")
     try {
       val host = Option(conf.getenv("SPARK_LOCAL_IP")).getOrElse("0.0.0.0")
       serverInfo = Some(startJettyServer(host, port, sslOptions, handlers, conf, name))
-      logInfo("Bound %s to %s, and started at %s".format(className, host, webUrl))
+      logInfo(s"Bound $className to $host, and started at $webUrl")
     } catch {
       case e: Exception =>
-        logError("Failed to bind %s".format(className), e)
+        logError(s"Failed to bind $className", e)
         System.exit(1)
     }
   }
 
   /** Return the url of web interface. Only valid after bind(). */
-  def webUrl: String = "http://%s:%d".format(publicHostName, boundPort)
+  def webUrl: String = s"http://$publicHostName:$boundPort"
 
   /** Return the actual port to which this server is bound. Only valid after bind(). */
   def boundPort: Int = serverInfo.map(_.boundPort).getOrElse(-1)
@@ -154,7 +154,7 @@ private[spark] abstract class WebUI(
   /** Stop the server behind this web interface. Only valid after bind(). */
   def stop() {
     assert(serverInfo.isDefined,
-      "Attempted to stop %s before binding to a server!".format(className))
+      s"Attempted to stop $className before binding to a server!")
     serverInfo.get.stop()
   }
 }

--- a/core/src/main/scala/org/apache/spark/ui/WebUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/WebUI.scala
@@ -135,16 +135,18 @@ private[spark] abstract class WebUI(
   def bind() {
     assert(!serverInfo.isDefined, "Attempted to bind %s more than once!".format(className))
     try {
-      var host = Option(conf.getenv("SPARK_LOCAL_IP")).getOrElse("0.0.0.0")
+      val host = Option(conf.getenv("SPARK_LOCAL_IP")).getOrElse("0.0.0.0")
       serverInfo = Some(startJettyServer(host, port, sslOptions, handlers, conf, name))
-      logInfo("Bound %s to %s, and started at http://%s:%d".format(className, host,
-        publicHostName, boundPort))
+      logInfo("Bound %s to %s, and started at %s".format(className, host, webUrl))
     } catch {
       case e: Exception =>
         logError("Failed to bind %s".format(className), e)
         System.exit(1)
     }
   }
+
+  /** Return the url of web interface. Only valid after bind(). */
+  def webUrl: String = "http://%s:%d".format(publicHostName, boundPort)
 
   /** Return the actual port to which this server is bound. Only valid after bind(). */
   def boundPort: Int = serverInfo.map(_.boundPort).getOrElse(-1)

--- a/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoopInit.scala
+++ b/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoopInit.scala
@@ -125,6 +125,9 @@ private[repl] trait SparkILoopInit {
       command("""
         @transient val sc = {
           val _sc = org.apache.spark.repl.Main.interp.createSparkContext()
+          _sc.uiWebUrl.map { webUrl =>
+            println(s"Spark context Web UI available at ${webUrl}")
+          }
           println("Spark context available as 'sc' " +
             s"(master = ${_sc.master}, app id = ${_sc.applicationId}).")
           _sc

--- a/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoopInit.scala
+++ b/repl/scala-2.10/src/main/scala/org/apache/spark/repl/SparkILoopInit.scala
@@ -125,9 +125,7 @@ private[repl] trait SparkILoopInit {
       command("""
         @transient val sc = {
           val _sc = org.apache.spark.repl.Main.interp.createSparkContext()
-          _sc.uiWebUrl.map { webUrl =>
-            println(s"Spark context Web UI available at ${webUrl}")
-          }
+          _sc.uiWebUrl.foreach(webUrl => println(s"Spark context Web UI available at ${webUrl}"))
           println("Spark context available as 'sc' " +
             s"(master = ${_sc.master}, app id = ${_sc.applicationId}).")
           _sc

--- a/repl/scala-2.11/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -38,9 +38,7 @@ class SparkILoop(in0: Option[BufferedReader], out: JPrintWriter)
       processLine("""
         @transient val sc = {
           val _sc = org.apache.spark.repl.Main.createSparkContext()
-          _sc.uiWebUrl.map { webUrl =>
-            println(s"Spark context Web UI available at ${webUrl}")
-          }
+          _sc.uiWebUrl.foreach(webUrl => println(s"Spark context Web UI available at ${webUrl}"))
           println("Spark context available as 'sc' " +
             s"(master = ${_sc.master}, app id = ${_sc.applicationId}).")
           _sc

--- a/repl/scala-2.11/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/scala-2.11/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -38,6 +38,9 @@ class SparkILoop(in0: Option[BufferedReader], out: JPrintWriter)
       processLine("""
         @transient val sc = {
           val _sc = org.apache.spark.repl.Main.createSparkContext()
+          _sc.uiWebUrl.map { webUrl =>
+            println(s"Spark context Web UI available at ${webUrl}")
+          }
           println("Spark context available as 'sc' " +
             s"(master = ${_sc.master}, app id = ${_sc.applicationId}).")
           _sc


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a proposal to print the Spark Driver UI link when spark-shell is launched.
## How was this patch tested?

Launched spark-shell in local mode and cluster mode. Spark-shell console output included following line:
"Spark context Web UI available at <Spark web url>"
