### PR TITLE
[SPARK-14344][SQL] Not creating meta files when summary-metadata property is false in parquet

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetRelation.scala
@@ -1,5 +1,5 @@
 /*
- * Licensid to the Apache Software Foundation (ASF) under one or more
+ * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0

--- a/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetRelation.scala
@@ -1,5 +1,5 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
+ * Licensid to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
@@ -184,9 +184,9 @@ private[sql] object ParquetRelation {
     val schema = StructType.fromAttributes(attributes).asNullable
     val newAttributes = schema.toAttributes
     if (sqlContext.sparkContext.hadoopConfiguration
-      .getBoolean(ParquetOutputFormat.ENABLE_JOB_SUMMARY, true)) {
+        .getBoolean(ParquetOutputFormat.ENABLE_JOB_SUMMARY, true)) {
       ParquetTypesConverter.writeMetaData(attributes, path, conf)
-      } else {
+    } else {
       // Create only the directory without the metafile
       val fs = path.getFileSystem(conf)
       if (fs == null) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetTableOperations.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/parquet/ParquetTableOperations.scala
@@ -652,6 +652,10 @@ private[parquet] object FileSystemHelper {
      */
   def findMaxTaskId(pathStr: String, conf: Configuration): Int = {
     val files = FileSystemHelper.listFiles(pathStr, conf)
+    // Return in case the "parquet.enable.summary-metadata" is false
+    if(files.size == 0) {
+      return 0
+    }
     // filename pattern is part-r-<int>.parquet
     val nameP = new scala.util.matching.Regex("""part-r-(\d{1,}).parquet""", "taskid")
     val hiddenFileP = new scala.util.matching.Regex("_.*")


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change fixes a bug related to the property "parquet.enable.summary-metadata". Currently, the property's value is not considered before writing the metaData (_metadata and _common-metadata files) in the "saveAsParquetFile" code-flow. Hence making this property false still created the meta files.
## How was this patch tested?

Integration tests and manual tests
