### PR TITLE
[SPARK-14597] [Streaming] Streaming Listener timing metrics should include time spent in JobGenerator's graph.generateJobs

### DIFF
--- a/external/kafka/src/test/scala/org/apache/spark/streaming/kafka/DirectKafkaStreamSuite.scala
+++ b/external/kafka/src/test/scala/org/apache/spark/streaming/kafka/DirectKafkaStreamSuite.scala
@@ -577,18 +577,29 @@ class LatencyListener(ssc: StreamingContext) extends StreamingListener {
     this.metricMap = metricMap
   }
 
-  var start:Long=0L;
+  var generateStart:Long=0L;
   /** Called when a batch generate has been started */
   override def onBatchGenerateStarted(batchGenerateStarted: StreamingListenerBatchGenerateStarted): Unit = {
-    start=batchGenerateStarted.time
+    generateStart=batchGenerateStarted.time
   }
 
-  var finish =0L;
+  var generateFinish =0L;
   /** Called when a batch generate has been done */
   override def onBatchGenerateCompleted(batchGenerateCompleted: StreamingListenerBatchGenerateCompleted): Unit = {
-    finish=batchGenerateCompleted.time
-    println("job creation delay="+(finish-start))
+    generateFinish=batchGenerateCompleted.time
+    println("job creation delay="+(generateFinish-generateStart))
   }
+  var checkPointingStart:Long=0L;
+  val checkPointingFinish=0L;
+  override def onCheckPointingStarted(checkpointingStarted: StreamingListenerCheckPointingStarted): Unit = {
+    checkPointingStart=checkpointingStarted.time
+  }
+
+  override def onCheckPointingCompleted(checkPointingCompleted: StreamingListenerCheckPointingCompleted): Unit = {
+    val checkPointingFinish = checkPointingCompleted.time
+    println("time consumed by checkPoining=" + (checkPointingFinish - checkPointingStart))
+  }
+
   override def onBatchCompleted(batchCompleted: StreamingListenerBatchCompleted): Unit = {
     val batchInfo = batchCompleted.batchInfo
     //println("completed systemTime="+batchCompleted.batchInfo.batchTime)

--- a/external/kafka/src/test/scala/org/apache/spark/streaming/kafka/DirectKafkaStreamSuite.scala
+++ b/external/kafka/src/test/scala/org/apache/spark/streaming/kafka/DirectKafkaStreamSuite.scala
@@ -19,28 +19,26 @@ package org.apache.spark.streaming.kafka
 
 import java.io.File
 import java.util.Arrays
-import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.ConcurrentLinkedQueue
-
-import scala.collection.JavaConverters._
-import scala.concurrent.duration._
-import scala.language.postfixOps
+import java.util.concurrent.atomic.AtomicLong
 
 import kafka.common.TopicAndPartition
 import kafka.message.MessageAndMetadata
 import kafka.serializer.StringDecoder
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
-import org.scalatest.concurrent.Eventually
-
-import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
-import org.apache.spark.streaming.{Milliseconds, StreamingContext, Time}
 import org.apache.spark.streaming.dstream.DStream
-import org.apache.spark.streaming.kafka.KafkaCluster.LeaderOffset
 import org.apache.spark.streaming.scheduler._
 import org.apache.spark.streaming.scheduler.rate.RateEstimator
+import org.apache.spark.streaming.{Milliseconds, StreamingContext, Time}
 import org.apache.spark.util.Utils
+import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
+import org.scalatest.concurrent.Eventually
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration._
+import scala.language.postfixOps
 
 class DirectKafkaStreamSuite
   extends SparkFunSuite
@@ -479,6 +477,145 @@ class DirectKafkaStreamSuite
   }
 }
 
+
+object DirectKafkaWordCount {
+
+  import org.apache.spark.streaming._
+
+  case class Tick(symbol: String, price: Int, ts: Long)
+
+  def main(args: Array[String]) {
+
+    // Create context with 2 second batch interval
+    val sparkConf = new SparkConf().setMaster("local[*]").setAppName("DirectKafkaWordCount")
+    val ssc = new StreamingContext(sparkConf, Seconds(6))
+    val listener = new LatencyListener(ssc)
+    ssc.addStreamingListener(listener)
+
+    val lines = ssc.socketTextStream("localhost", 9998)
+
+    val words = lines.flatMap(_.split(" "))
+
+    val pairs = words.map(word => (word, 1))
+
+    val wordCounts = pairs.reduceByKey(_ + _)
+
+    wordCounts.print()
+
+    ssc.start()
+    ssc.awaitTermination()
+  }
+}
+import org.apache.spark.streaming.StreamingContext
+import org.apache.spark.streaming.scheduler._
+
+class StopContextThread(ssc: StreamingContext) extends Runnable {
+  def run {
+    ssc.stop(true, true)
+  }
+}
+
+
+class LatencyListener(ssc: StreamingContext) extends StreamingListener {
+
+  var metricMap: scala.collection.mutable.Map[String, Object] = _
+  var startTime = 0L
+  var startTime1 = 0L
+  var endTime = 0L
+  var endTime1 = 0L
+  var totalDelay = 0L
+  var hasStarted = false
+  var batchCount = 0
+  var totalRecords = 0L
+  val thread: Thread = new Thread(new StopContextThread(ssc))
+
+
+  def getMap(): scala.collection.mutable.Map[String, Object] = synchronized {
+    if (metricMap == null) metricMap = scala.collection.mutable.Map()
+    metricMap
+  }
+
+  def setMap(metricMap: scala.collection.mutable.Map[String, Object]) = synchronized {
+    this.metricMap = metricMap
+  }
+
+  /** Called when a batch generate has been started */
+  override def onBatchGenerateStarted(batchGenerateStarted: StreamingListenerBatchGenerateStarted): Unit = {
+    println("started systemTime="+batchGenerateStarted.time)
+  }
+
+
+  /** Called when a batch generate has been done */
+  override def onBatchGenerateCompleted(batchGenerateCompleted: StreamingListenerBatchGenerateCompleted): Unit = {
+    println("completed systemTime="+batchGenerateCompleted.time)
+  }
+  override def onBatchCompleted(batchCompleted: StreamingListenerBatchCompleted): Unit = {
+    val batchInfo = batchCompleted.batchInfo
+    //println("completed systemTime="+batchCompleted.batchInfo.batchTime)
+
+    val prevCount = totalRecords
+    var recordThisBatch = batchInfo.numRecords
+    if (!thread.isAlive) {
+      totalRecords += recordThisBatch
+      val imap = getMap
+      imap(batchInfo.batchTime.toString()) = "batchTime," + batchInfo.batchTime +
+        ", batch Count so far," + batchCount +
+        ", total Records so far," + totalRecords +
+        ", record This Batch," + recordThisBatch +
+        ", submission Time," + batchInfo.submissionTime +
+        ", processing Start Time," + batchInfo.processingStartTime.getOrElse(0L) +
+        ", processing End Time," + batchInfo.processingEndTime.getOrElse(0L) +
+        ", scheduling Delay," + batchInfo.schedulingDelay.getOrElse(0L) +
+        ", processing Delay," + batchInfo.processingDelay.getOrElse(0L)
+
+      setMap(imap)
+    }
+
+    if (totalRecords >= 100) {
+      if (hasStarted && !thread.isAlive) {
+        //not receiving any data more, finish
+        endTime = System.currentTimeMillis()
+        endTime1 = batchInfo.processingEndTime.getOrElse(0L)
+        var warning=""
+        val totalTime = (endTime - startTime).toDouble / 1000
+        //This is weighted avg of every batch process time. The weight is records processed int the batch
+        val recordThroughput = totalRecords / totalTime
+
+        val imap = getMap
+
+        imap("Final Metric") = " Total Batch count," + batchCount+
+          ", startTime based on submissionTime,"+startTime +
+          ", startTime based on System,"+startTime1 +
+          ", endTime based on System,"+endTime +
+          ", endTime based on processingEndTime,"+endTime1 +
+          ", Total Records,"+totalRecords+
+          // ", Total processing delay = " + totalDelay + " ms "+
+          ", Total Consumed time in sec," + totalTime +
+          ", Avg records/sec," + recordThroughput
+
+        imap.foreach {case (key, value) => println(key + "-->" + value)}
+
+        thread.start
+      }
+    } else if (!hasStarted) {
+      if (batchInfo.numRecords>0) {
+        startTime = batchCompleted.batchInfo.submissionTime
+        startTime1 =  System.currentTimeMillis()
+        hasStarted = true
+      }
+    }
+
+    if (hasStarted) {
+      //      println("This delay:"+batchCompleted.batchInfo.processingDelay+"ms")
+      batchCompleted.batchInfo.processingDelay match {
+        case Some(value) => totalDelay += value * recordThisBatch
+        case None => //Nothing
+      }
+      batchCount = batchCount + 1
+    }
+  }
+
+}
 object DirectKafkaStreamSuite {
   val collectedData = new ConcurrentLinkedQueue[String]()
   @volatile var total = -1L

--- a/external/kafka/src/test/scala/org/apache/spark/streaming/kafka/DirectKafkaStreamSuite.scala
+++ b/external/kafka/src/test/scala/org/apache/spark/streaming/kafka/DirectKafkaStreamSuite.scala
@@ -539,15 +539,17 @@ class LatencyListener(ssc: StreamingContext) extends StreamingListener {
     this.metricMap = metricMap
   }
 
+  var start:Long=0L;
   /** Called when a batch generate has been started */
   override def onBatchGenerateStarted(batchGenerateStarted: StreamingListenerBatchGenerateStarted): Unit = {
-    println("started systemTime="+batchGenerateStarted.time)
+    start=batchGenerateStarted.time
   }
 
-
+  var finish =0L;
   /** Called when a batch generate has been done */
   override def onBatchGenerateCompleted(batchGenerateCompleted: StreamingListenerBatchGenerateCompleted): Unit = {
-    println("completed systemTime="+batchGenerateCompleted.time)
+    finish=batchGenerateCompleted.time
+    println("job creation delay="+(finish-start))
   }
   override def onBatchCompleted(batchCompleted: StreamingListenerBatchCompleted): Unit = {
     val batchInfo = batchCompleted.batchInfo

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
@@ -299,9 +299,11 @@ class JobGenerator(jobScheduler: JobScheduler) extends Logging {
   /** Perform checkpoint for the give `time`. */
   private def doCheckpoint(time: Time, clearCheckpointDataLater: Boolean) {
     if (shouldCheckpoint && (time - graph.zeroTime).isMultipleOf(ssc.checkpointDuration)) {
+      listenerBus.post(StreamingListenerCheckPointingStarted(clock.getTimeMillis()))
       logInfo("Checkpointing graph for time " + time)
       ssc.graph.updateCheckpointData(time)
       checkpointWriter.write(new Checkpoint(ssc, time), clearCheckpointDataLater)
+      listenerBus.post(StreamingListenerCheckPointingCompleted(clock.getTimeMillis()))
     }
   }
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/StreamingListener.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/StreamingListener.scala
@@ -53,6 +53,12 @@ case class StreamingListenerOutputOperationCompleted(outputOperationInfo: Output
   extends StreamingListenerEvent
 
 @DeveloperApi
+case class StreamingListenerCheckPointingStarted(time: Long) extends StreamingListenerEvent
+
+@DeveloperApi
+case class StreamingListenerCheckPointingCompleted(time: Long) extends StreamingListenerEvent
+
+@DeveloperApi
 case class StreamingListenerReceiverStarted(receiverInfo: ReceiverInfo)
   extends StreamingListenerEvent
 
@@ -72,14 +78,20 @@ case class StreamingListenerReceiverStopped(receiverInfo: ReceiverInfo)
 @DeveloperApi
 trait StreamingListener {
 
-  /** Called when a receiver has been started */
-  def onReceiverStarted(receiverStarted: StreamingListenerReceiverStarted) { }
-
   /** Called when a batch generate has been started */
   def onBatchGenerateStarted(batchGenerateStarted: StreamingListenerBatchGenerateStarted) { }
 
   /** Called when a batch generate has been completed */
   def onBatchGenerateCompleted(batchGenerateCompleted: StreamingListenerBatchGenerateCompleted) { }
+
+  /** Called when a checkpointing operation been started */
+  def onCheckPointingStarted(checkpointingStarted: StreamingListenerCheckPointingStarted) { }
+
+  /** Called when a checkpointing operation has been completed */
+  def onCheckPointingCompleted(checkPointingCompleted: StreamingListenerCheckPointingCompleted) { }
+
+  /** Called when a receiver has been started */
+  def onReceiverStarted(receiverStarted: StreamingListenerReceiverStarted) { }
 
   /** Called when a receiver has reported an error */
   def onReceiverError(receiverError: StreamingListenerReceiverError) { }

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/StreamingListener.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/StreamingListener.scala
@@ -30,6 +30,12 @@ import org.apache.spark.util.Distribution
 sealed trait StreamingListenerEvent
 
 @DeveloperApi
+case class StreamingListenerBatchGenerateStarted(time: Long) extends StreamingListenerEvent
+
+@DeveloperApi
+case class StreamingListenerBatchGenerateCompleted(time: Long) extends StreamingListenerEvent
+
+@DeveloperApi
 case class StreamingListenerBatchSubmitted(batchInfo: BatchInfo) extends StreamingListenerEvent
 
 @DeveloperApi
@@ -68,6 +74,12 @@ trait StreamingListener {
 
   /** Called when a receiver has been started */
   def onReceiverStarted(receiverStarted: StreamingListenerReceiverStarted) { }
+
+  /** Called when a batch generate has been started */
+  def onBatchGenerateStarted(batchGenerateStarted: StreamingListenerBatchGenerateStarted) { }
+
+  /** Called when a batch generate has been completed */
+  def onBatchGenerateCompleted(batchGenerateCompleted: StreamingListenerBatchGenerateCompleted) { }
 
   /** Called when a receiver has reported an error */
   def onReceiverError(receiverError: StreamingListenerReceiverError) { }

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/StreamingListenerBus.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/StreamingListenerBus.scala
@@ -49,6 +49,10 @@ private[streaming] class StreamingListenerBus(sparkListenerBus: LiveListenerBus)
       listener: StreamingListener,
       event: StreamingListenerEvent): Unit = {
     event match {
+      case batchGenerateStarted:StreamingListenerBatchGenerateStarted =>
+        listener.onBatchGenerateStarted(batchGenerateStarted)
+      case batchGenerateCompleted: StreamingListenerBatchGenerateCompleted =>
+        listener.onBatchGenerateCompleted(batchGenerateCompleted)
       case receiverStarted: StreamingListenerReceiverStarted =>
         listener.onReceiverStarted(receiverStarted)
       case receiverError: StreamingListenerReceiverError =>

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/StreamingListenerBus.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/StreamingListenerBus.scala
@@ -69,6 +69,10 @@ private[streaming] class StreamingListenerBus(sparkListenerBus: LiveListenerBus)
         listener.onOutputOperationStarted(outputOperationStarted)
       case outputOperationCompleted: StreamingListenerOutputOperationCompleted =>
         listener.onOutputOperationCompleted(outputOperationCompleted)
+      case checkpointingStarted:StreamingListenerCheckPointingStarted =>
+        listener.onCheckPointingStarted(checkpointingStarted)
+      case checkPointingCompleted: StreamingListenerCheckPointingCompleted =>
+        listener.onCheckPointingCompleted(checkPointingCompleted)
       case _ =>
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

I have added the complete information on the jira https://issues.apache.org/jira/browse/SPARK-14597
## How was this patch tested?

not tested yet to discuss and finalize the approach.

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
