### PR TITLE
[SPARK-14597] [Streaming] Streaming Listener timing metrics should include time spent in JobGenerator's graph.generateJobs

### DIFF
--- a/external/kafka/src/test/scala/org/apache/spark/streaming/kafka/DirectKafkaStreamSuite.scala
+++ b/external/kafka/src/test/scala/org/apache/spark/streaming/kafka/DirectKafkaStreamSuite.scala
@@ -595,7 +595,6 @@ class LatencyListener(ssc: StreamingContext) extends StreamingListener {
         ", processing End Time," + batchInfo.processingEndTime.getOrElse(0L) +
         ", scheduling Delay," + batchInfo.schedulingDelay.getOrElse(0L) +
         ", processing Delay," + batchInfo.processingDelay.getOrElse(0L)
-
       setMap(imap)
     }
 

--- a/external/kafka/src/test/scala/org/apache/spark/streaming/kafka/DirectKafkaStreamSuite.scala
+++ b/external/kafka/src/test/scala/org/apache/spark/streaming/kafka/DirectKafkaStreamSuite.scala
@@ -483,20 +483,39 @@ object DirectKafkaWordCount {
   import org.apache.spark.streaming._
 
   def main(args: Array[String]) {
-
-    // Create context with 2 second batch interval
     val sparkConf = new SparkConf().setMaster("local[*]").setAppName("DirectKafkaWordCount")
-    val ssc = new StreamingContext(sparkConf, Seconds(6))
+
+    val ssc = new StreamingContext(sparkConf, Seconds(2))
+    //ssc.checkpoint(checkPointPath)
+
     val listener = new LatencyListener(ssc)
     ssc.addStreamingListener(listener)
+    val kafkaBrokers = "localhost"
+    val kafkaPort ="9092"
+    val topic="test"
 
-    val lines = ssc.socketTextStream("localhost", 9998)
+    val topicsSet = Set(topic)
 
-    val words = lines.flatMap(_.split(" "))
+    val brokerListString = new StringBuilder();
+
+      brokerListString.append(kafkaBrokers).append(":").append(kafkaPort)
+
+
+    val kafkaParams = Map[String, String]("metadata.broker.list" -> brokerListString.toString())
+    System.err.println(
+      "Trying to connect to Kafka at " + brokerListString.toString())
+    val messages = KafkaUtils.createDirectStream[String, String, StringDecoder, StringDecoder](
+      ssc, kafkaParams, topicsSet)
+    ssc.checkpoint("/tmp/checkPoint/")
+    // Create context with 2 second batch interval
+
+    //val lines = ssc.socketTextStream("localhost", 9998)
+
+    val words = messages.map(x => x._2).flatMap(_.split(" "))
 
     val pairs = words.map(word => (word, 1))
 
-    val wordCounts = pairs.reduceByKey(_ + _)
+    val wordCounts = pairs.reduceByKeyAndWindow(_+_, _-_, Seconds(60),Seconds(10))
 
     wordCounts.print()
 
@@ -559,7 +578,7 @@ class LatencyListener(ssc: StreamingContext) extends StreamingListener {
       setMap(imap)
     }
 
-    if (totalRecords >= 100) {
+    if (totalRecords >= 10000) {
       if (hasStarted && !thread.isAlive) {
         //not receiving any data more, finish
         endTime = System.currentTimeMillis()

--- a/external/kafka/src/test/scala/org/apache/spark/streaming/kafka/DirectKafkaStreamSuite.scala
+++ b/external/kafka/src/test/scala/org/apache/spark/streaming/kafka/DirectKafkaStreamSuite.scala
@@ -19,28 +19,26 @@ package org.apache.spark.streaming.kafka
 
 import java.io.File
 import java.util.Arrays
-import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.ConcurrentLinkedQueue
-
-import scala.collection.JavaConverters._
-import scala.concurrent.duration._
-import scala.language.postfixOps
+import java.util.concurrent.atomic.AtomicLong
 
 import kafka.common.TopicAndPartition
 import kafka.message.MessageAndMetadata
 import kafka.serializer.StringDecoder
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
-import org.scalatest.concurrent.Eventually
-
-import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
-import org.apache.spark.streaming.{Milliseconds, StreamingContext, Time}
 import org.apache.spark.streaming.dstream.DStream
-import org.apache.spark.streaming.kafka.KafkaCluster.LeaderOffset
 import org.apache.spark.streaming.scheduler._
 import org.apache.spark.streaming.scheduler.rate.RateEstimator
+import org.apache.spark.streaming.{Seconds, Milliseconds, StreamingContext, Time}
 import org.apache.spark.util.Utils
+import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
+import org.scalatest.concurrent.Eventually
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration._
+import scala.language.postfixOps
 
 class DirectKafkaStreamSuite
   extends SparkFunSuite
@@ -475,6 +473,201 @@ class DirectKafkaStreamSuite
     new DirectKafkaInputDStream[String, String, StringDecoder, StringDecoder, (String, String)](
       ssc, Map[String, String](), earliestOffsets, messageHandler) {
       override protected[streaming] val rateController = mockRateController
+    }
+  }
+}
+
+object DirectKafkaWordCountLocal {
+
+  import org.apache.spark.streaming._
+
+  case class Tick(symbol: String, price: Int, ts: Long)
+
+  def main(args: Array[String]) {
+
+    // Create context with 2 second batch interval
+    val sparkConf = new SparkConf().setMaster("local[*]").setAppName("DirectKafkaWordCount")
+    val ssc = new StreamingContext(sparkConf, Seconds(2))
+    ssc.checkpoint("/tmp/checkpoint")
+    val listener = new LatencyListener(ssc)
+    ssc.addStreamingListener(listener)
+    val lines = ssc.socketTextStream("localhost", 8888)
+
+    val words = lines.flatMap(_.split(" "))
+
+    val pairs = words.map(word => (word, 1))
+
+    val wordCounts = pairs.reduceByKeyAndWindow(_+_, _-_, Seconds(60),Seconds(10))
+
+
+    val wordCountNew = wordCounts.filter(_._1.startsWith("sac")).reduceByKeyAndWindow(_+_, _-_, Seconds(60),Seconds(10))
+    wordCountNew.print()
+
+    ssc.start()
+    ssc.awaitTermination()
+  }
+}
+object DirectKafkaWordCountKafka {
+
+  import org.apache.spark.streaming._
+
+  def main(args: Array[String]) {
+    val sparkConf = new SparkConf().setMaster("local[*]").setAppName("DirectKafkaWordCount")
+
+    val ssc = new StreamingContext(sparkConf, Seconds(2))
+    //ssc.checkpoint(checkPointPath)
+
+    val listener = new LatencyListener(ssc)
+    ssc.addStreamingListener(listener)
+    val kafkaBrokers = "localhost"
+    val kafkaPort ="9092"
+    val topic="test"
+
+    val topicsSet = Set(topic)
+
+    val brokerListString = new StringBuilder();
+
+    brokerListString.append(kafkaBrokers).append(":").append(kafkaPort)
+
+
+    val kafkaParams = Map[String, String]("metadata.broker.list" -> brokerListString.toString())
+    System.err.println(
+      "Trying to connect to Kafka at " + brokerListString.toString())
+    val messages = KafkaUtils.createDirectStream[String, String, StringDecoder, StringDecoder](
+      ssc, kafkaParams, topicsSet)
+    ssc.checkpoint("/tmp/checkPoint/")
+    // Create context with 2 second batch interval
+
+    //val lines = ssc.socketTextStream("localhost", 9998)
+
+    val words = messages.map(x => x._2).flatMap(_.split(" "))
+
+    val pairs = words.map(word => (word, 1))
+    pairs.print()
+
+    val wordCounts = pairs.reduceByKeyAndWindow(_+_, _-_, Seconds(60),Seconds(10))
+
+    wordCounts.print()
+
+    ssc.start()
+    ssc.awaitTermination()
+  }
+}
+
+
+
+class StopContextThread(ssc: StreamingContext) extends Runnable {
+  def run {
+    ssc.stop(true, true)
+  }
+}
+
+
+class LatencyListener(ssc: StreamingContext) extends StreamingListener {
+
+  var metricMap: scala.collection.mutable.Map[String, Object] = _
+  var startTime = 0L
+  var startTime1 = 0L
+  var endTime = 0L
+  var endTime1 = 0L
+  var totalDelay = 0L
+  var hasStarted = false
+  var batchCount = 0
+  var totalRecords = 0L
+  val thread: Thread = new Thread(new StopContextThread(ssc))
+
+
+  def getMap(): scala.collection.mutable.Map[String, Object] = synchronized {
+    if (metricMap == null) metricMap = scala.collection.mutable.Map()
+    metricMap
+  }
+
+  def setMap(metricMap: scala.collection.mutable.Map[String, Object]) = synchronized {
+    this.metricMap = metricMap
+  }
+
+  /** Called when processing of a job of a batch has started. */
+  override def onOutputOperationStarted(outputOperationStarted: StreamingListenerOutputOperationStarted): Unit = {
+    println("job creation delay repoted in onOutputOperationStarted ==>"+outputOperationStarted.outputOperationInfo.batchTime+"==>"+outputOperationStarted.outputOperationInfo.id+"==>"+outputOperationStarted.outputOperationInfo.jobGenTime)
+  }
+
+  val batchSize =  Seconds(2).toString
+  val recordLimitPerThread = 1000
+  val loaderThreads = 10
+
+  val recordLimit = loaderThreads * recordLimitPerThread
+
+  override def onBatchCompleted(batchCompleted: StreamingListenerBatchCompleted): Unit = {
+    val batchInfo = batchCompleted.batchInfo
+    val prevCount = totalRecords
+    var recordThisBatch = batchInfo.numRecords
+
+    println("job creation delay repoted in onBatchCompleted ==>" +batchInfo.batchTime+"==>"+batchInfo.batchJobSetCreationDelay )
+
+    if (!thread.isAlive) {
+      totalRecords += recordThisBatch
+      //      val imap = getMap
+      //      imap(batchInfo.batchTime.toString()) = "batchTime," + batchInfo.batchTime +
+      //        ", batch Count so far," + batchCount +
+      //        ", total Records so far," + totalRecords +
+      //        ", record This Batch," + recordThisBatch +
+      //        ", submission Time," + batchInfo.submissionTime +
+      //        ", processing Start Time," + batchInfo.processingStartTime.getOrElse(0L) +
+      //        ", processing End Time," + batchInfo.processingEndTime.getOrElse(0L) +
+      //        ", scheduling Delay," + batchInfo.schedulingDelay.getOrElse(0L) +
+      //        ", processing Delay," + batchInfo.processingDelay.getOrElse(0L)
+      //
+      //      setMap(imap)
+    }
+
+    if (totalRecords >= recordLimit) {
+      if (hasStarted && !thread.isAlive) {
+        //not receiving any data more, finish
+        endTime = System.currentTimeMillis()
+        endTime1 = batchInfo.processingEndTime.getOrElse(0L)
+        var warning = ""
+        val totalTime = (endTime - startTime).toDouble / 1000
+        //This is weighted avg of every batch process time. The weight is records processed int the batch
+        val avgLatency = totalDelay.toDouble / totalRecords
+        if (avgLatency > batchSize.toDouble)
+          warning = "WARNING:SPARK CLUSTER IN UNSTABLE STATE. TRY REDUCE INPUT SPEED"
+
+        val avgLatencyAdjust = avgLatency + batchSize.toDouble
+        val recordThroughput = totalRecords / totalTime
+
+        val imap = getMap
+
+        imap("Final Metric") = " Total Batch count," + batchCount +
+          ", startTime based on submissionTime," + startTime +
+          ", startTime based on System," + startTime1 +
+          ", endTime based on System," + endTime +
+          ", endTime based on processingEndTime," + endTime1 +
+          ", Total Records," + totalRecords +
+          // ", Total processing delay = " + totalDelay + " ms "+
+          ", Total Consumed time in sec," + totalTime +
+          ", Avg latency/batchInterval in ms," + avgLatencyAdjust +
+          ", Avg records/sec," + recordThroughput +
+          ", WARNING," + warning
+
+        imap.foreach { case (key, value) => println(key + "-->" + value) }
+
+        thread.start
+      }
+    } else if (!hasStarted) {
+      if (batchInfo.numRecords > 0) {
+        startTime = batchCompleted.batchInfo.submissionTime
+        startTime1 = System.currentTimeMillis()
+        hasStarted = true
+      }
+    }
+
+    if (hasStarted) {
+      //      println("This delay:"+batchCompleted.batchInfo.processingDelay+"ms")
+      batchCompleted.batchInfo.processingDelay match {
+        case Some(value) => totalDelay += value * recordThisBatch
+        case None => //Nothing
+      }
+      batchCount = batchCount + 1
     }
   }
 }

--- a/external/kafka/src/test/scala/org/apache/spark/streaming/kafka/DirectKafkaStreamSuite.scala
+++ b/external/kafka/src/test/scala/org/apache/spark/streaming/kafka/DirectKafkaStreamSuite.scala
@@ -19,28 +19,26 @@ package org.apache.spark.streaming.kafka
 
 import java.io.File
 import java.util.Arrays
-import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.ConcurrentLinkedQueue
-
-import scala.collection.JavaConverters._
-import scala.concurrent.duration._
-import scala.language.postfixOps
+import java.util.concurrent.atomic.AtomicLong
 
 import kafka.common.TopicAndPartition
 import kafka.message.MessageAndMetadata
 import kafka.serializer.StringDecoder
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
-import org.scalatest.concurrent.Eventually
-
-import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
-import org.apache.spark.streaming.{Milliseconds, StreamingContext, Time}
 import org.apache.spark.streaming.dstream.DStream
-import org.apache.spark.streaming.kafka.KafkaCluster.LeaderOffset
 import org.apache.spark.streaming.scheduler._
 import org.apache.spark.streaming.scheduler.rate.RateEstimator
+import org.apache.spark.streaming.{Milliseconds, StreamingContext, Time}
 import org.apache.spark.util.Utils
+import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
+import org.scalatest.concurrent.Eventually
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration._
+import scala.language.postfixOps
 
 class DirectKafkaStreamSuite
   extends SparkFunSuite
@@ -117,8 +115,8 @@ class DirectKafkaStreamSuite
         logInfo(s"${o.topic} ${o.partition} ${o.fromOffset} ${o.untilOffset}")
       }
       val collected = rdd.mapPartitionsWithIndex { (i, iter) =>
-      // For each partition, get size of the range in the partition,
-      // and the number of items in the partition
+        // For each partition, get size of the range in the partition,
+        // and the number of items in the partition
         val off = offsetRanges(i)
         val all = iter.toSeq
         val partSize = all.size
@@ -413,7 +411,7 @@ class DirectKafkaStreamSuite
         .fold(e => Map.empty[TopicAndPartition, Long], m => m.mapValues(lo => lo.offset))
 
       new DirectKafkaInputDStream[String, String, StringDecoder, StringDecoder, (String, String)](
-          ssc, kafkaParams, m, messageHandler) {
+        ssc, kafkaParams, m, messageHandler) {
         override protected[streaming] val rateController =
           Some(new DirectKafkaRateController(id, estimator))
       }
@@ -438,8 +436,8 @@ class DirectKafkaStreamSuite
     Seq(100, 50, 20).foreach { rate =>
       collectedData.clear()       // Empty this buffer on each pass.
       estimator.updateRate(rate)  // Set a new rate.
-      // Expect blocks of data equal to "rate", scaled by the interval length in secs.
-      val expectedSize = Math.round(rate * batchIntervalMilliseconds * 0.001)
+    // Expect blocks of data equal to "rate", scaled by the interval length in secs.
+    val expectedSize = Math.round(rate * batchIntervalMilliseconds * 0.001)
       eventually(timeout(5.seconds), interval(batchIntervalMilliseconds.milliseconds)) {
         // Assert that rate estimator values are used to determine maxMessagesPerPartition.
         // Funky "-" in message makes the complete assertion message read better.
@@ -453,7 +451,7 @@ class DirectKafkaStreamSuite
 
   /** Get the generated offset ranges from the DirectKafkaStream */
   private def getOffsetRanges[K, V](
-      kafkaStream: DStream[(K, V)]): Seq[(Time, Array[OffsetRange])] = {
+                                     kafkaStream: DStream[(K, V)]): Seq[(Time, Array[OffsetRange])] = {
     kafkaStream.generatedRDDs.mapValues { rdd =>
       rdd.asInstanceOf[KafkaRDD[K, V, _, _, (K, V)]].offsetRanges
     }.toSeq.sortBy { _._1 }
@@ -479,6 +477,133 @@ class DirectKafkaStreamSuite
   }
 }
 
+
+object DirectKafkaWordCount {
+
+  import org.apache.spark.streaming._
+
+  def main(args: Array[String]) {
+
+    // Create context with 2 second batch interval
+    val sparkConf = new SparkConf().setMaster("local[*]").setAppName("DirectKafkaWordCount")
+    val ssc = new StreamingContext(sparkConf, Seconds(6))
+    val listener = new LatencyListener(ssc)
+    ssc.addStreamingListener(listener)
+
+    val lines = ssc.socketTextStream("localhost", 9998)
+
+    val words = lines.flatMap(_.split(" "))
+
+    val pairs = words.map(word => (word, 1))
+
+    val wordCounts = pairs.reduceByKey(_ + _)
+
+    wordCounts.print()
+
+    ssc.start()
+    ssc.awaitTermination()
+  }
+}
+import org.apache.spark.streaming.StreamingContext
+import org.apache.spark.streaming.scheduler._
+
+class StopContextThread(ssc: StreamingContext) extends Runnable {
+  def run {
+    ssc.stop(true, true)
+  }
+}
+
+
+class LatencyListener(ssc: StreamingContext) extends StreamingListener {
+
+  var metricMap: scala.collection.mutable.Map[String, Object] = _
+  var startTime = 0L
+  var startTime1 = 0L
+  var endTime = 0L
+  var endTime1 = 0L
+  var totalDelay = 0L
+  var hasStarted = false
+  var batchCount = 0
+  var totalRecords = 0L
+  val thread: Thread = new Thread(new StopContextThread(ssc))
+
+
+  def getMap(): scala.collection.mutable.Map[String, Object] = synchronized {
+    if (metricMap == null) metricMap = scala.collection.mutable.Map()
+    metricMap
+  }
+
+  def setMap(metricMap: scala.collection.mutable.Map[String, Object]) = synchronized {
+    this.metricMap = metricMap
+  }
+
+  override def onBatchCompleted(batchCompleted: StreamingListenerBatchCompleted): Unit = {
+    val batchInfo = batchCompleted.batchInfo
+    println("job generate delay ="+batchCompleted.batchInfo.batchJobSetCreationDelay)
+
+    val prevCount = totalRecords
+    var recordThisBatch = batchInfo.numRecords
+    if (!thread.isAlive) {
+      totalRecords += recordThisBatch
+      val imap = getMap
+      imap(batchInfo.batchTime.toString()) = "batchTime," + batchInfo.batchTime +
+        ", batch Count so far," + batchCount +
+        ", total Records so far," + totalRecords +
+        ", record This Batch," + recordThisBatch +
+        ", submission Time," + batchInfo.submissionTime +
+        ", processing Start Time," + batchInfo.processingStartTime.getOrElse(0L) +
+        ", processing End Time," + batchInfo.processingEndTime.getOrElse(0L) +
+        ", scheduling Delay," + batchInfo.schedulingDelay.getOrElse(0L) +
+        ", processing Delay," + batchInfo.processingDelay.getOrElse(0L)
+
+      setMap(imap)
+    }
+
+    if (totalRecords >= 100) {
+      if (hasStarted && !thread.isAlive) {
+        //not receiving any data more, finish
+        endTime = System.currentTimeMillis()
+        endTime1 = batchInfo.processingEndTime.getOrElse(0L)
+        var warning=""
+        val totalTime = (endTime - startTime).toDouble / 1000
+        //This is weighted avg of every batch process time. The weight is records processed int the batch
+        val recordThroughput = totalRecords / totalTime
+
+        val imap = getMap
+
+        imap("Final Metric") = " Total Batch count," + batchCount+
+          ", startTime based on submissionTime,"+startTime +
+          ", startTime based on System,"+startTime1 +
+          ", endTime based on System,"+endTime +
+          ", endTime based on processingEndTime,"+endTime1 +
+          ", Total Records,"+totalRecords+
+          // ", Total processing delay = " + totalDelay + " ms "+
+          ", Total Consumed time in sec," + totalTime +
+          ", Avg records/sec," + recordThroughput
+
+        imap.foreach {case (key, value) => println(key + "-->" + value)}
+
+        thread.start
+      }
+    } else if (!hasStarted) {
+      if (batchInfo.numRecords>0) {
+        startTime = batchCompleted.batchInfo.submissionTime
+        startTime1 =  System.currentTimeMillis()
+        hasStarted = true
+      }
+    }
+
+    if (hasStarted) {
+      //      println("This delay:"+batchCompleted.batchInfo.processingDelay+"ms")
+      batchCompleted.batchInfo.processingDelay match {
+        case Some(value) => totalDelay += value * recordThisBatch
+        case None => //Nothing
+      }
+      batchCount = batchCount + 1
+    }
+  }
+
+}
 object DirectKafkaStreamSuite {
   val collectedData = new ConcurrentLinkedQueue[String]()
   @volatile var total = -1L
@@ -510,10 +635,10 @@ private[streaming] class ConstantEstimator(@volatile private var rate: Long)
   }
 
   def compute(
-      time: Long,
-      elements: Long,
-      processingDelay: Long,
-      schedulingDelay: Long): Option[Double] = Some(rate)
+               time: Long,
+               elements: Long,
+               processingDelay: Long,
+               schedulingDelay: Long): Option[Double] = Some(rate)
 }
 
 private[streaming] class ConstantRateController(id: Int, estimator: RateEstimator, rate: Long)

--- a/external/kafka/src/test/scala/org/apache/spark/streaming/kafka/DirectKafkaStreamSuite.scala
+++ b/external/kafka/src/test/scala/org/apache/spark/streaming/kafka/DirectKafkaStreamSuite.scala
@@ -478,7 +478,36 @@ class DirectKafkaStreamSuite
 }
 
 
-object DirectKafkaWordCount {
+object DirectKafkaWordCountLocal {
+
+  import org.apache.spark.streaming._
+
+  case class Tick(symbol: String, price: Int, ts: Long)
+
+  def main(args: Array[String]) {
+
+    // Create context with 2 second batch interval
+    val sparkConf = new SparkConf().setMaster("local[*]").setAppName("DirectKafkaWordCount")
+    val ssc = new StreamingContext(sparkConf, Seconds(2))
+    ssc.checkpoint("/tmp/checkpoint")
+    val listener = new LatencyListener(ssc)
+    ssc.addStreamingListener(listener)
+    val lines = ssc.socketTextStream("localhost", 9998)
+
+    val words = lines.flatMap(_.split(" "))
+
+    val pairs = words.map(word => (word, 1))
+
+    val wordCounts = pairs.reduceByKeyAndWindow(_+_, _-_, Seconds(60),Seconds(10))
+
+    wordCounts.print()
+
+    ssc.start()
+    ssc.awaitTermination()
+  }
+}
+
+object DirectKafkaWordCountKafka {
 
   import org.apache.spark.streaming._
 

--- a/external/kafka/src/test/scala/org/apache/spark/streaming/kafka/DirectKafkaStreamSuite.scala
+++ b/external/kafka/src/test/scala/org/apache/spark/streaming/kafka/DirectKafkaStreamSuite.scala
@@ -482,8 +482,6 @@ object DirectKafkaWordCountLocal {
 
   import org.apache.spark.streaming._
 
-  case class Tick(symbol: String, price: Int, ts: Long)
-
   def main(args: Array[String]) {
 
     // Create context with 2 second batch interval
@@ -525,10 +523,7 @@ object DirectKafkaWordCountKafka {
 
     val topicsSet = Set(topic)
 
-    val brokerListString = new StringBuilder();
-
-      brokerListString.append(kafkaBrokers).append(":").append(kafkaPort)
-
+    val brokerListString = kafkaBrokers+":"+kafkaPort
 
     val kafkaParams = Map[String, String]("metadata.broker.list" -> brokerListString.toString())
     System.err.println(
@@ -536,9 +531,6 @@ object DirectKafkaWordCountKafka {
     val messages = KafkaUtils.createDirectStream[String, String, StringDecoder, StringDecoder](
       ssc, kafkaParams, topicsSet)
     ssc.checkpoint("/tmp/checkPoint/")
-    // Create context with 2 second batch interval
-
-    //val lines = ssc.socketTextStream("localhost", 9998)
 
     val words = messages.map(x => x._2).flatMap(_.split(" "))
 

--- a/external/kafka/src/test/scala/org/apache/spark/streaming/kafka/DirectKafkaStreamSuite.scala
+++ b/external/kafka/src/test/scala/org/apache/spark/streaming/kafka/DirectKafkaStreamSuite.scala
@@ -19,26 +19,28 @@ package org.apache.spark.streaming.kafka
 
 import java.io.File
 import java.util.Arrays
-import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicLong
-
-import kafka.common.TopicAndPartition
-import kafka.message.MessageAndMetadata
-import kafka.serializer.StringDecoder
-import org.apache.spark.internal.Logging
-import org.apache.spark.rdd.RDD
-import org.apache.spark.streaming.dstream.DStream
-import org.apache.spark.streaming.scheduler._
-import org.apache.spark.streaming.scheduler.rate.RateEstimator
-import org.apache.spark.streaming.{Milliseconds, StreamingContext, Time}
-import org.apache.spark.util.Utils
-import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
-import org.scalatest.concurrent.Eventually
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
+import java.util.concurrent.ConcurrentLinkedQueue
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.language.postfixOps
+
+import kafka.common.TopicAndPartition
+import kafka.message.MessageAndMetadata
+import kafka.serializer.StringDecoder
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
+import org.scalatest.concurrent.Eventually
+
+import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
+import org.apache.spark.internal.Logging
+import org.apache.spark.rdd.RDD
+import org.apache.spark.streaming.{Milliseconds, StreamingContext, Time}
+import org.apache.spark.streaming.dstream.DStream
+import org.apache.spark.streaming.kafka.KafkaCluster.LeaderOffset
+import org.apache.spark.streaming.scheduler._
+import org.apache.spark.streaming.scheduler.rate.RateEstimator
+import org.apache.spark.util.Utils
 
 class DirectKafkaStreamSuite
   extends SparkFunSuite
@@ -115,8 +117,8 @@ class DirectKafkaStreamSuite
         logInfo(s"${o.topic} ${o.partition} ${o.fromOffset} ${o.untilOffset}")
       }
       val collected = rdd.mapPartitionsWithIndex { (i, iter) =>
-        // For each partition, get size of the range in the partition,
-        // and the number of items in the partition
+      // For each partition, get size of the range in the partition,
+      // and the number of items in the partition
         val off = offsetRanges(i)
         val all = iter.toSeq
         val partSize = all.size
@@ -411,7 +413,7 @@ class DirectKafkaStreamSuite
         .fold(e => Map.empty[TopicAndPartition, Long], m => m.mapValues(lo => lo.offset))
 
       new DirectKafkaInputDStream[String, String, StringDecoder, StringDecoder, (String, String)](
-        ssc, kafkaParams, m, messageHandler) {
+          ssc, kafkaParams, m, messageHandler) {
         override protected[streaming] val rateController =
           Some(new DirectKafkaRateController(id, estimator))
       }
@@ -436,8 +438,8 @@ class DirectKafkaStreamSuite
     Seq(100, 50, 20).foreach { rate =>
       collectedData.clear()       // Empty this buffer on each pass.
       estimator.updateRate(rate)  // Set a new rate.
-    // Expect blocks of data equal to "rate", scaled by the interval length in secs.
-    val expectedSize = Math.round(rate * batchIntervalMilliseconds * 0.001)
+      // Expect blocks of data equal to "rate", scaled by the interval length in secs.
+      val expectedSize = Math.round(rate * batchIntervalMilliseconds * 0.001)
       eventually(timeout(5.seconds), interval(batchIntervalMilliseconds.milliseconds)) {
         // Assert that rate estimator values are used to determine maxMessagesPerPartition.
         // Funky "-" in message makes the complete assertion message read better.
@@ -451,7 +453,7 @@ class DirectKafkaStreamSuite
 
   /** Get the generated offset ranges from the DirectKafkaStream */
   private def getOffsetRanges[K, V](
-                                     kafkaStream: DStream[(K, V)]): Seq[(Time, Array[OffsetRange])] = {
+      kafkaStream: DStream[(K, V)]): Seq[(Time, Array[OffsetRange])] = {
     kafkaStream.generatedRDDs.mapValues { rdd =>
       rdd.asInstanceOf[KafkaRDD[K, V, _, _, (K, V)]].offsetRanges
     }.toSeq.sortBy { _._1 }
@@ -477,172 +479,6 @@ class DirectKafkaStreamSuite
   }
 }
 
-
-object DirectKafkaWordCountLocal {
-
-  import org.apache.spark.streaming._
-
-  def main(args: Array[String]) {
-
-    // Create context with 2 second batch interval
-    val sparkConf = new SparkConf().setMaster("local[*]").setAppName("DirectKafkaWordCount")
-    val ssc = new StreamingContext(sparkConf, Seconds(2))
-    ssc.checkpoint("/tmp/checkpoint")
-    val listener = new LatencyListener(ssc)
-    ssc.addStreamingListener(listener)
-    val lines = ssc.socketTextStream("localhost", 9998)
-
-    val words = lines.flatMap(_.split(" "))
-
-    val pairs = words.map(word => (word, 1))
-
-    val wordCounts = pairs.reduceByKeyAndWindow(_+_, _-_, Seconds(60),Seconds(10))
-
-    wordCounts.print()
-
-    ssc.start()
-    ssc.awaitTermination()
-  }
-}
-
-object DirectKafkaWordCountKafka {
-
-  import org.apache.spark.streaming._
-
-  def main(args: Array[String]) {
-    val sparkConf = new SparkConf().setMaster("local[*]").setAppName("DirectKafkaWordCount")
-
-    val ssc = new StreamingContext(sparkConf, Seconds(2))
-    //ssc.checkpoint(checkPointPath)
-
-    val listener = new LatencyListener(ssc)
-    ssc.addStreamingListener(listener)
-    val kafkaBrokers = "localhost"
-    val kafkaPort ="9092"
-    val topic="test"
-
-    val topicsSet = Set(topic)
-
-    val brokerListString = kafkaBrokers+":"+kafkaPort
-
-    val kafkaParams = Map[String, String]("metadata.broker.list" -> brokerListString.toString())
-    System.err.println(
-      "Trying to connect to Kafka at " + brokerListString.toString())
-    val messages = KafkaUtils.createDirectStream[String, String, StringDecoder, StringDecoder](
-      ssc, kafkaParams, topicsSet)
-    ssc.checkpoint("/tmp/checkPoint/")
-
-    val words = messages.map(x => x._2).flatMap(_.split(" "))
-
-    val pairs = words.map(word => (word, 1))
-
-    val wordCounts = pairs.reduceByKeyAndWindow(_+_, _-_, Seconds(60),Seconds(10))
-
-    wordCounts.print()
-
-    ssc.start()
-    ssc.awaitTermination()
-  }
-}
-import org.apache.spark.streaming.StreamingContext
-import org.apache.spark.streaming.scheduler._
-
-class StopContextThread(ssc: StreamingContext) extends Runnable {
-  def run {
-    ssc.stop(true, true)
-  }
-}
-
-
-class LatencyListener(ssc: StreamingContext) extends StreamingListener {
-
-  var metricMap: scala.collection.mutable.Map[String, Object] = _
-  var startTime = 0L
-  var startTime1 = 0L
-  var endTime = 0L
-  var endTime1 = 0L
-  var totalDelay = 0L
-  var hasStarted = false
-  var batchCount = 0
-  var totalRecords = 0L
-  val thread: Thread = new Thread(new StopContextThread(ssc))
-
-
-  def getMap(): scala.collection.mutable.Map[String, Object] = synchronized {
-    if (metricMap == null) metricMap = scala.collection.mutable.Map()
-    metricMap
-  }
-
-  def setMap(metricMap: scala.collection.mutable.Map[String, Object]) = synchronized {
-    this.metricMap = metricMap
-  }
-
-  override def onBatchCompleted(batchCompleted: StreamingListenerBatchCompleted): Unit = {
-    val batchInfo = batchCompleted.batchInfo
-    println("job generate delay ="+batchCompleted.batchInfo.batchJobSetCreationDelay)
-
-    val prevCount = totalRecords
-    var recordThisBatch = batchInfo.numRecords
-    if (!thread.isAlive) {
-      totalRecords += recordThisBatch
-      val imap = getMap
-      imap(batchInfo.batchTime.toString()) = "batchTime," + batchInfo.batchTime +
-        ", batch Count so far," + batchCount +
-        ", total Records so far," + totalRecords +
-        ", record This Batch," + recordThisBatch +
-        ", submission Time," + batchInfo.submissionTime +
-        ", processing Start Time," + batchInfo.processingStartTime.getOrElse(0L) +
-        ", processing End Time," + batchInfo.processingEndTime.getOrElse(0L) +
-        ", scheduling Delay," + batchInfo.schedulingDelay.getOrElse(0L) +
-        ", processing Delay," + batchInfo.processingDelay.getOrElse(0L)
-      setMap(imap)
-    }
-
-    if (totalRecords >= 10000) {
-      if (hasStarted && !thread.isAlive) {
-        //not receiving any data more, finish
-        endTime = System.currentTimeMillis()
-        endTime1 = batchInfo.processingEndTime.getOrElse(0L)
-        var warning=""
-        val totalTime = (endTime - startTime).toDouble / 1000
-        //This is weighted avg of every batch process time. The weight is records processed int the batch
-        val recordThroughput = totalRecords / totalTime
-
-        val imap = getMap
-
-        imap("Final Metric") = " Total Batch count," + batchCount+
-          ", startTime based on submissionTime,"+startTime +
-          ", startTime based on System,"+startTime1 +
-          ", endTime based on System,"+endTime +
-          ", endTime based on processingEndTime,"+endTime1 +
-          ", Total Records,"+totalRecords+
-          // ", Total processing delay = " + totalDelay + " ms "+
-          ", Total Consumed time in sec," + totalTime +
-          ", Avg records/sec," + recordThroughput
-
-        imap.foreach {case (key, value) => println(key + "-->" + value)}
-
-        thread.start
-      }
-    } else if (!hasStarted) {
-      if (batchInfo.numRecords>0) {
-        startTime = batchCompleted.batchInfo.submissionTime
-        startTime1 =  System.currentTimeMillis()
-        hasStarted = true
-      }
-    }
-
-    if (hasStarted) {
-      //      println("This delay:"+batchCompleted.batchInfo.processingDelay+"ms")
-      batchCompleted.batchInfo.processingDelay match {
-        case Some(value) => totalDelay += value * recordThisBatch
-        case None => //Nothing
-      }
-      batchCount = batchCount + 1
-    }
-  }
-
-}
 object DirectKafkaStreamSuite {
   val collectedData = new ConcurrentLinkedQueue[String]()
   @volatile var total = -1L
@@ -674,10 +510,10 @@ private[streaming] class ConstantEstimator(@volatile private var rate: Long)
   }
 
   def compute(
-               time: Long,
-               elements: Long,
-               processingDelay: Long,
-               schedulingDelay: Long): Option[Double] = Some(rate)
+      time: Long,
+      elements: Long,
+      processingDelay: Long,
+      schedulingDelay: Long): Option[Double] = Some(rate)
 }
 
 private[streaming] class ConstantRateController(id: Int, estimator: RateEstimator, rate: Long)

--- a/external/kafka/src/test/scala/org/apache/spark/streaming/kafka/DirectKafkaStreamSuite.scala
+++ b/external/kafka/src/test/scala/org/apache/spark/streaming/kafka/DirectKafkaStreamSuite.scala
@@ -19,26 +19,28 @@ package org.apache.spark.streaming.kafka
 
 import java.io.File
 import java.util.Arrays
-import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicLong
-
-import kafka.common.TopicAndPartition
-import kafka.message.MessageAndMetadata
-import kafka.serializer.StringDecoder
-import org.apache.spark.internal.Logging
-import org.apache.spark.rdd.RDD
-import org.apache.spark.streaming.dstream.DStream
-import org.apache.spark.streaming.scheduler._
-import org.apache.spark.streaming.scheduler.rate.RateEstimator
-import org.apache.spark.streaming.{Seconds, Milliseconds, StreamingContext, Time}
-import org.apache.spark.util.Utils
-import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
-import org.scalatest.concurrent.Eventually
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
+import java.util.concurrent.ConcurrentLinkedQueue
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.language.postfixOps
+
+import kafka.common.TopicAndPartition
+import kafka.message.MessageAndMetadata
+import kafka.serializer.StringDecoder
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
+import org.scalatest.concurrent.Eventually
+
+import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
+import org.apache.spark.internal.Logging
+import org.apache.spark.rdd.RDD
+import org.apache.spark.streaming.{Milliseconds, StreamingContext, Time}
+import org.apache.spark.streaming.dstream.DStream
+import org.apache.spark.streaming.kafka.KafkaCluster.LeaderOffset
+import org.apache.spark.streaming.scheduler._
+import org.apache.spark.streaming.scheduler.rate.RateEstimator
+import org.apache.spark.util.Utils
 
 class DirectKafkaStreamSuite
   extends SparkFunSuite
@@ -473,201 +475,6 @@ class DirectKafkaStreamSuite
     new DirectKafkaInputDStream[String, String, StringDecoder, StringDecoder, (String, String)](
       ssc, Map[String, String](), earliestOffsets, messageHandler) {
       override protected[streaming] val rateController = mockRateController
-    }
-  }
-}
-
-object DirectKafkaWordCountLocal {
-
-  import org.apache.spark.streaming._
-
-  case class Tick(symbol: String, price: Int, ts: Long)
-
-  def main(args: Array[String]) {
-
-    // Create context with 2 second batch interval
-    val sparkConf = new SparkConf().setMaster("local[*]").setAppName("DirectKafkaWordCount")
-    val ssc = new StreamingContext(sparkConf, Seconds(2))
-    ssc.checkpoint("/tmp/checkpoint")
-    val listener = new LatencyListener(ssc)
-    ssc.addStreamingListener(listener)
-    val lines = ssc.socketTextStream("localhost", 8888)
-
-    val words = lines.flatMap(_.split(" "))
-
-    val pairs = words.map(word => (word, 1))
-
-    val wordCounts = pairs.reduceByKeyAndWindow(_+_, _-_, Seconds(60),Seconds(10))
-
-
-    val wordCountNew = wordCounts.filter(_._1.startsWith("sac")).reduceByKeyAndWindow(_+_, _-_, Seconds(60),Seconds(10))
-    wordCountNew.print()
-
-    ssc.start()
-    ssc.awaitTermination()
-  }
-}
-object DirectKafkaWordCountKafka {
-
-  import org.apache.spark.streaming._
-
-  def main(args: Array[String]) {
-    val sparkConf = new SparkConf().setMaster("local[*]").setAppName("DirectKafkaWordCount")
-
-    val ssc = new StreamingContext(sparkConf, Seconds(2))
-    //ssc.checkpoint(checkPointPath)
-
-    val listener = new LatencyListener(ssc)
-    ssc.addStreamingListener(listener)
-    val kafkaBrokers = "localhost"
-    val kafkaPort ="9092"
-    val topic="test"
-
-    val topicsSet = Set(topic)
-
-    val brokerListString = new StringBuilder();
-
-    brokerListString.append(kafkaBrokers).append(":").append(kafkaPort)
-
-
-    val kafkaParams = Map[String, String]("metadata.broker.list" -> brokerListString.toString())
-    System.err.println(
-      "Trying to connect to Kafka at " + brokerListString.toString())
-    val messages = KafkaUtils.createDirectStream[String, String, StringDecoder, StringDecoder](
-      ssc, kafkaParams, topicsSet)
-    ssc.checkpoint("/tmp/checkPoint/")
-    // Create context with 2 second batch interval
-
-    //val lines = ssc.socketTextStream("localhost", 9998)
-
-    val words = messages.map(x => x._2).flatMap(_.split(" "))
-
-    val pairs = words.map(word => (word, 1))
-    pairs.print()
-
-    val wordCounts = pairs.reduceByKeyAndWindow(_+_, _-_, Seconds(60),Seconds(10))
-
-    wordCounts.print()
-
-    ssc.start()
-    ssc.awaitTermination()
-  }
-}
-
-
-
-class StopContextThread(ssc: StreamingContext) extends Runnable {
-  def run {
-    ssc.stop(true, true)
-  }
-}
-
-
-class LatencyListener(ssc: StreamingContext) extends StreamingListener {
-
-  var metricMap: scala.collection.mutable.Map[String, Object] = _
-  var startTime = 0L
-  var startTime1 = 0L
-  var endTime = 0L
-  var endTime1 = 0L
-  var totalDelay = 0L
-  var hasStarted = false
-  var batchCount = 0
-  var totalRecords = 0L
-  val thread: Thread = new Thread(new StopContextThread(ssc))
-
-
-  def getMap(): scala.collection.mutable.Map[String, Object] = synchronized {
-    if (metricMap == null) metricMap = scala.collection.mutable.Map()
-    metricMap
-  }
-
-  def setMap(metricMap: scala.collection.mutable.Map[String, Object]) = synchronized {
-    this.metricMap = metricMap
-  }
-
-  /** Called when processing of a job of a batch has started. */
-  override def onOutputOperationStarted(outputOperationStarted: StreamingListenerOutputOperationStarted): Unit = {
-    println("job creation delay repoted in onOutputOperationStarted ==>"+outputOperationStarted.outputOperationInfo.batchTime+"==>"+outputOperationStarted.outputOperationInfo.id+"==>"+outputOperationStarted.outputOperationInfo.jobGenTime)
-  }
-
-  val batchSize =  Seconds(2).toString
-  val recordLimitPerThread = 1000
-  val loaderThreads = 10
-
-  val recordLimit = loaderThreads * recordLimitPerThread
-
-  override def onBatchCompleted(batchCompleted: StreamingListenerBatchCompleted): Unit = {
-    val batchInfo = batchCompleted.batchInfo
-    val prevCount = totalRecords
-    var recordThisBatch = batchInfo.numRecords
-
-    println("job creation delay repoted in onBatchCompleted ==>" +batchInfo.batchTime+"==>"+batchInfo.batchJobSetCreationDelay )
-
-    if (!thread.isAlive) {
-      totalRecords += recordThisBatch
-      //      val imap = getMap
-      //      imap(batchInfo.batchTime.toString()) = "batchTime," + batchInfo.batchTime +
-      //        ", batch Count so far," + batchCount +
-      //        ", total Records so far," + totalRecords +
-      //        ", record This Batch," + recordThisBatch +
-      //        ", submission Time," + batchInfo.submissionTime +
-      //        ", processing Start Time," + batchInfo.processingStartTime.getOrElse(0L) +
-      //        ", processing End Time," + batchInfo.processingEndTime.getOrElse(0L) +
-      //        ", scheduling Delay," + batchInfo.schedulingDelay.getOrElse(0L) +
-      //        ", processing Delay," + batchInfo.processingDelay.getOrElse(0L)
-      //
-      //      setMap(imap)
-    }
-
-    if (totalRecords >= recordLimit) {
-      if (hasStarted && !thread.isAlive) {
-        //not receiving any data more, finish
-        endTime = System.currentTimeMillis()
-        endTime1 = batchInfo.processingEndTime.getOrElse(0L)
-        var warning = ""
-        val totalTime = (endTime - startTime).toDouble / 1000
-        //This is weighted avg of every batch process time. The weight is records processed int the batch
-        val avgLatency = totalDelay.toDouble / totalRecords
-        if (avgLatency > batchSize.toDouble)
-          warning = "WARNING:SPARK CLUSTER IN UNSTABLE STATE. TRY REDUCE INPUT SPEED"
-
-        val avgLatencyAdjust = avgLatency + batchSize.toDouble
-        val recordThroughput = totalRecords / totalTime
-
-        val imap = getMap
-
-        imap("Final Metric") = " Total Batch count," + batchCount +
-          ", startTime based on submissionTime," + startTime +
-          ", startTime based on System," + startTime1 +
-          ", endTime based on System," + endTime +
-          ", endTime based on processingEndTime," + endTime1 +
-          ", Total Records," + totalRecords +
-          // ", Total processing delay = " + totalDelay + " ms "+
-          ", Total Consumed time in sec," + totalTime +
-          ", Avg latency/batchInterval in ms," + avgLatencyAdjust +
-          ", Avg records/sec," + recordThroughput +
-          ", WARNING," + warning
-
-        imap.foreach { case (key, value) => println(key + "-->" + value) }
-
-        thread.start
-      }
-    } else if (!hasStarted) {
-      if (batchInfo.numRecords > 0) {
-        startTime = batchCompleted.batchInfo.submissionTime
-        startTime1 = System.currentTimeMillis()
-        hasStarted = true
-      }
-    }
-
-    if (hasStarted) {
-      //      println("This delay:"+batchCompleted.batchInfo.processingDelay+"ms")
-      batchCompleted.batchInfo.processingDelay match {
-        case Some(value) => totalDelay += value * recordThisBatch
-        case None => //Nothing
-      }
-      batchCount = batchCount + 1
     }
   }
 }

--- a/streaming/src/main/scala/org/apache/spark/streaming/DStreamGraph.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/DStreamGraph.scala
@@ -114,8 +114,10 @@ final private[streaming] class DStreamGraph extends Serializable with Logging {
     logDebug("Generating jobs for time " + time)
     val jobs = this.synchronized {
       outputStreams.flatMap { outputStream =>
+        val genStartTime=System.currentTimeMillis()
         val jobOption = outputStream.generateJob(time)
         jobOption.foreach(_.setCallSite(outputStream.creationSite))
+        jobOption.foreach(_.setGenDelay(System.currentTimeMillis()-genStartTime))
         jobOption
       }
     }

--- a/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaStreamingListener.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaStreamingListener.scala
@@ -241,4 +241,5 @@ private[streaming] case class JavaOutputOperationInfo(
     description: String,
     startTime: Long,
     endTime: Long,
+    jobGenTime:  Long,
     failureReason: String)

--- a/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaStreamingListenerWrapper.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaStreamingListenerWrapper.scala
@@ -58,6 +58,7 @@ private[streaming] class JavaStreamingListenerWrapper(javaStreamingListener: Jav
       outputOperationInfo.description: String,
       outputOperationInfo.startTime.getOrElse(-1),
       outputOperationInfo.endTime.getOrElse(-1),
+      outputOperationInfo.jobGenTime.getOrElse(-1),
       outputOperationInfo.failureReason.orNull
     )
   }

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/BatchInfo.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/BatchInfo.scala
@@ -34,6 +34,7 @@ import org.apache.spark.streaming.Time
 @DeveloperApi
 case class BatchInfo(
     batchTime: Time,
+    jobSetCreationDelay: Option[Long],
     streamIdToInputInfo: Map[Int, StreamInputInfo],
     submissionTime: Long,
     processingStartTime: Option[Long],
@@ -41,6 +42,7 @@ case class BatchInfo(
     outputOperationInfos: Map[Int, OutputOperationInfo]
   ) {
 
+  def batchJobSetCreationDelay = jobSetCreationDelay.getOrElse(0L)
   /**
    * Time taken for the first job of this batch to start processing from the time this batch
    * was submitted to the streaming scheduler. Essentially, it is

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/Job.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/Job.scala
@@ -34,6 +34,7 @@ class Job(val time: Time, func: () => _) {
   private var _callSite: CallSite = null
   private var _startTime: Option[Long] = None
   private var _endTime: Option[Long] = None
+  private var _jobGenTime: Option[Long] = None
 
   def run() {
     _result = Try(func())
@@ -85,6 +86,14 @@ class Job(val time: Time, func: () => _) {
     _startTime = Some(startTime)
   }
 
+  def setGenDelay(jobGenTime: Long): Unit = {
+    _jobGenTime = Some(jobGenTime)
+  }
+
+  def getGenDelay(): Option[Long]  = {
+    _jobGenTime
+  }
+
   def setEndTime(endTime: Long): Unit = {
     _endTime = Some(endTime)
   }
@@ -96,7 +105,7 @@ class Job(val time: Time, func: () => _) {
       None
     }
     OutputOperationInfo(
-      time, outputOpId, callSite.shortForm, callSite.longForm, _startTime, _endTime, failureReason)
+      time, outputOpId, callSite.shortForm, callSite.longForm, _startTime, _endTime, _jobGenTime, failureReason)
   }
 
   override def toString: String = id

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobGenerator.scala
@@ -17,13 +17,14 @@
 
 package org.apache.spark.streaming.scheduler
 
+import scala.util.{Failure, Success, Try}
+
+import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
-import org.apache.spark.streaming.util.RecurringTimer
 import org.apache.spark.streaming.{Checkpoint, CheckpointWriter, Time}
+import org.apache.spark.streaming.util.RecurringTimer
 import org.apache.spark.util.{Clock, EventLoop, ManualClock, Utils}
-
-import scala.util.{Failure, Success, Try}
 
 /** Event classes for JobGenerator */
 private[scheduler] sealed trait JobGeneratorEvent

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobSet.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobSet.scala
@@ -28,6 +28,7 @@ import org.apache.spark.streaming.Time
 private[streaming]
 case class JobSet(
     time: Time,
+    jobSetCreationDelay: Option[Long],
     jobs: Seq[Job],
     streamIdToInputInfo: Map[Int, StreamInputInfo] = Map.empty) {
 
@@ -63,6 +64,7 @@ case class JobSet(
   def toBatchInfo: BatchInfo = {
     BatchInfo(
       time,
+      jobSetCreationDelay,
       streamIdToInputInfo,
       submissionTime,
       if (hasStarted) Some(processingStartTime) else None,

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/OutputOperationInfo.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/OutputOperationInfo.scala
@@ -39,6 +39,7 @@ case class OutputOperationInfo(
     description: String,
     startTime: Option[Long],
     endTime: Option[Long],
+    jobGenTime:  Option[Long],
     failureReason: Option[String]) {
 
   /**

--- a/streaming/src/main/scala/org/apache/spark/streaming/ui/BatchUIData.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/ui/BatchUIData.scala
@@ -116,6 +116,7 @@ private[ui] case class OutputOperationUIData(
     description: String,
     startTime: Option[Long],
     endTime: Option[Long],
+    jobGenTime: Option[Long],
     failureReason: Option[String]) {
 
   def duration: Option[Long] = for (s <- startTime; e <- endTime) yield e - s
@@ -130,6 +131,7 @@ private[ui] object OutputOperationUIData {
       outputOperationInfo.description,
       outputOperationInfo.startTime,
       outputOperationInfo.endTime,
+      outputOperationInfo.jobGenTime,
       outputOperationInfo.failureReason
     )
   }

--- a/streaming/src/test/java/org/apache/spark/streaming/api/java/JavaStreamingListenerWrapperSuite.scala
+++ b/streaming/src/test/java/org/apache/spark/streaming/api/java/JavaStreamingListenerWrapperSuite.scala
@@ -63,7 +63,7 @@ class JavaStreamingListenerWrapperSuite extends SparkFunSuite {
     assertReceiverInfo(listener.receiverError.receiverInfo, receiverError.receiverInfo)
 
     val batchSubmitted = StreamingListenerBatchSubmitted(BatchInfo(
-      batchTime = Time(1000L),
+      batchTime = Time(1000L), None,
       streamIdToInputInfo = Map(
         0 -> StreamInputInfo(
           inputStreamId = 0,
@@ -98,7 +98,7 @@ class JavaStreamingListenerWrapperSuite extends SparkFunSuite {
     assertBatchInfo(listener.batchSubmitted.batchInfo, batchSubmitted.batchInfo)
 
     val batchStarted = StreamingListenerBatchStarted(BatchInfo(
-      batchTime = Time(1000L),
+      batchTime = Time(1000L), None,
       streamIdToInputInfo = Map(
         0 -> StreamInputInfo(
           inputStreamId = 0,
@@ -133,7 +133,7 @@ class JavaStreamingListenerWrapperSuite extends SparkFunSuite {
     assertBatchInfo(listener.batchStarted.batchInfo, batchStarted.batchInfo)
 
     val batchCompleted = StreamingListenerBatchCompleted(BatchInfo(
-      batchTime = Time(1000L),
+      batchTime = Time(1000L), None,
       streamIdToInputInfo = Map(
         0 -> StreamInputInfo(
           inputStreamId = 0,

--- a/streaming/src/test/java/org/apache/spark/streaming/api/java/JavaStreamingListenerWrapperSuite.scala
+++ b/streaming/src/test/java/org/apache/spark/streaming/api/java/JavaStreamingListenerWrapperSuite.scala
@@ -84,6 +84,7 @@ class JavaStreamingListenerWrapperSuite extends SparkFunSuite {
           description = "operation1",
           startTime = None,
           endTime = None,
+          jobGenTime = None,
           failureReason = None),
         1 -> OutputOperationInfo(
           batchTime = Time(1000L),
@@ -92,6 +93,7 @@ class JavaStreamingListenerWrapperSuite extends SparkFunSuite {
           description = "operation2",
           startTime = None,
           endTime = None,
+          jobGenTime = None,
           failureReason = None))
     ))
     listenerWrapper.onBatchSubmitted(batchSubmitted)
@@ -119,6 +121,7 @@ class JavaStreamingListenerWrapperSuite extends SparkFunSuite {
           description = "operation1",
           startTime = Some(1003L),
           endTime = None,
+          jobGenTime = None,
           failureReason = None),
         1 -> OutputOperationInfo(
           batchTime = Time(1000L),
@@ -127,6 +130,7 @@ class JavaStreamingListenerWrapperSuite extends SparkFunSuite {
           description = "operation2",
           startTime = Some(1005L),
           endTime = None,
+          jobGenTime = None,
           failureReason = None))
     ))
     listenerWrapper.onBatchStarted(batchStarted)
@@ -154,6 +158,7 @@ class JavaStreamingListenerWrapperSuite extends SparkFunSuite {
           description = "operation1",
           startTime = Some(1003L),
           endTime = Some(1004L),
+          jobGenTime = None,
           failureReason = None),
         1 -> OutputOperationInfo(
           batchTime = Time(1000L),
@@ -162,6 +167,7 @@ class JavaStreamingListenerWrapperSuite extends SparkFunSuite {
           description = "operation2",
           startTime = Some(1005L),
           endTime = Some(1010L),
+          jobGenTime = None,
           failureReason = None))
     ))
     listenerWrapper.onBatchCompleted(batchCompleted)
@@ -174,6 +180,7 @@ class JavaStreamingListenerWrapperSuite extends SparkFunSuite {
       description = "operation1",
       startTime = Some(1003L),
       endTime = None,
+      jobGenTime = None,
       failureReason = None
     ))
     listenerWrapper.onOutputOperationStarted(outputOperationStarted)
@@ -187,6 +194,7 @@ class JavaStreamingListenerWrapperSuite extends SparkFunSuite {
       description = "operation1",
       startTime = Some(1003L),
       endTime = Some(1004L),
+      jobGenTime = None,
       failureReason = None
     ))
     listenerWrapper.onOutputOperationCompleted(outputOperationCompleted)
@@ -243,6 +251,7 @@ class JavaStreamingListenerWrapperSuite extends SparkFunSuite {
     assert(javaOutputOperationInfo.description === outputOperationInfo.description)
     assert(javaOutputOperationInfo.startTime === outputOperationInfo.startTime.getOrElse(-1))
     assert(javaOutputOperationInfo.endTime === outputOperationInfo.endTime.getOrElse(-1))
+    assert(javaOutputOperationInfo.jobGenTime === outputOperationInfo.jobGenTime.getOrElse(-1))
     assert(javaOutputOperationInfo.failureReason === outputOperationInfo.failureReason.orNull)
   }
 }

--- a/streaming/src/test/scala/org/apache/spark/streaming/ui/StreamingJobProgressListenerSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/ui/StreamingJobProgressListenerSuite.scala
@@ -63,7 +63,7 @@ class StreamingJobProgressListenerSuite extends TestSuiteBase with Matchers {
       1 -> StreamInputInfo(1, 300L, Map(StreamInputInfo.METADATA_KEY_DESCRIPTION -> "test")))
 
     // onBatchSubmitted
-    val batchInfoSubmitted = BatchInfo(Time(1000), streamIdToInputInfo, 1000, None, None, Map.empty)
+    val batchInfoSubmitted = BatchInfo(Time(1000), None, streamIdToInputInfo, 1000, None, None, Map.empty)
     listener.onBatchSubmitted(StreamingListenerBatchSubmitted(batchInfoSubmitted))
     listener.waitingBatches should be (List(BatchUIData(batchInfoSubmitted)))
     listener.runningBatches should be (Nil)
@@ -76,7 +76,7 @@ class StreamingJobProgressListenerSuite extends TestSuiteBase with Matchers {
 
     // onBatchStarted
     val batchInfoStarted =
-      BatchInfo(Time(1000), streamIdToInputInfo, 1000, Some(2000), None, Map.empty)
+      BatchInfo(Time(1000), None, streamIdToInputInfo, 1000, Some(2000), None, Map.empty)
     listener.onBatchStarted(StreamingListenerBatchStarted(batchInfoStarted))
     listener.waitingBatches should be (Nil)
     listener.runningBatches should be (List(BatchUIData(batchInfoStarted)))
@@ -118,7 +118,7 @@ class StreamingJobProgressListenerSuite extends TestSuiteBase with Matchers {
 
     // onBatchCompleted
     val batchInfoCompleted =
-      BatchInfo(Time(1000), streamIdToInputInfo, 1000, Some(2000), None, Map.empty)
+      BatchInfo(Time(1000), None, streamIdToInputInfo, 1000, Some(2000), None, Map.empty)
     listener.onBatchCompleted(StreamingListenerBatchCompleted(batchInfoCompleted))
     listener.waitingBatches should be (Nil)
     listener.runningBatches should be (Nil)
@@ -159,7 +159,7 @@ class StreamingJobProgressListenerSuite extends TestSuiteBase with Matchers {
     val streamIdToInputInfo = Map(0 -> StreamInputInfo(0, 300L), 1 -> StreamInputInfo(1, 300L))
 
     val batchInfoCompleted =
-      BatchInfo(Time(1000), streamIdToInputInfo, 1000, Some(2000), None, Map.empty)
+      BatchInfo(Time(1000), None, streamIdToInputInfo, 1000, Some(2000), None, Map.empty)
 
     for(_ <- 0 until (limit + 10)) {
       listener.onBatchCompleted(StreamingListenerBatchCompleted(batchInfoCompleted))
@@ -177,7 +177,7 @@ class StreamingJobProgressListenerSuite extends TestSuiteBase with Matchers {
     // fulfill completedBatchInfos
     for(i <- 0 until limit) {
       val batchInfoCompleted = BatchInfo(
-          Time(1000 + i * 100), Map.empty, 1000 + i * 100, Some(2000 + i * 100), None, Map.empty)
+          Time(1000 + i * 100), None, Map.empty, 1000 + i * 100, Some(2000 + i * 100), None, Map.empty)
       listener.onBatchCompleted(StreamingListenerBatchCompleted(batchInfoCompleted))
       val jobStart = createJobStart(Time(1000 + i * 100), outputOpId = 0, jobId = 1)
       listener.onJobStart(jobStart)
@@ -188,7 +188,7 @@ class StreamingJobProgressListenerSuite extends TestSuiteBase with Matchers {
     listener.onJobStart(jobStart)
 
     val batchInfoSubmitted =
-      BatchInfo(Time(1000 + limit * 100), Map.empty, (1000 + limit * 100), None, None, Map.empty)
+      BatchInfo(Time(1000 + limit * 100), None, Map.empty, (1000 + limit * 100), None, None, Map.empty)
     listener.onBatchSubmitted(StreamingListenerBatchSubmitted(batchInfoSubmitted))
 
     // We still can see the info retrieved from onJobStart
@@ -205,7 +205,7 @@ class StreamingJobProgressListenerSuite extends TestSuiteBase with Matchers {
     // A lot of "onBatchCompleted"s happen before "onJobStart"
     for(i <- limit + 1 to limit * 2) {
       val batchInfoCompleted = BatchInfo(
-          Time(1000 + i * 100), Map.empty, 1000 + i * 100, Some(2000 + i * 100), None, Map.empty)
+          Time(1000 + i * 100), None, Map.empty, 1000 + i * 100, Some(2000 + i * 100), None, Map.empty)
       listener.onBatchCompleted(StreamingListenerBatchCompleted(batchInfoCompleted))
     }
 
@@ -231,12 +231,12 @@ class StreamingJobProgressListenerSuite extends TestSuiteBase with Matchers {
 
       // onBatchSubmitted
       val batchInfoSubmitted =
-        BatchInfo(Time(1000), streamIdToInputInfo, 1000, None, None, Map.empty)
+        BatchInfo(Time(1000), None, streamIdToInputInfo, 1000, None, None, Map.empty)
       listener.onBatchSubmitted(StreamingListenerBatchSubmitted(batchInfoSubmitted))
 
       // onBatchStarted
       val batchInfoStarted =
-        BatchInfo(Time(1000), streamIdToInputInfo, 1000, Some(2000), None, Map.empty)
+        BatchInfo(Time(1000), None, streamIdToInputInfo, 1000, Some(2000), None, Map.empty)
       listener.onBatchStarted(StreamingListenerBatchStarted(batchInfoStarted))
 
       // onJobStart
@@ -254,7 +254,7 @@ class StreamingJobProgressListenerSuite extends TestSuiteBase with Matchers {
 
       // onBatchCompleted
       val batchInfoCompleted =
-        BatchInfo(Time(1000), streamIdToInputInfo, 1000, Some(2000), None, Map.empty)
+        BatchInfo(Time(1000), None, streamIdToInputInfo, 1000, Some(2000), None, Map.empty)
       listener.onBatchCompleted(StreamingListenerBatchCompleted(batchInfoCompleted))
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

I have added the complete information on the jira https://issues.apache.org/jira/browse/SPARK-14597
## How was this patch tested?

not tested yet to discuss and finalize the approach.

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
