### PR TITLE
[SPARK-14560] Spillables can be forced to spill after inserting all data, to avoid OOM

### DIFF
--- a/core/src/main/java/org/apache/spark/memory/MemoryConsumer.java
+++ b/core/src/main/java/org/apache/spark/memory/MemoryConsumer.java
@@ -45,7 +45,7 @@ public abstract class MemoryConsumer {
   /**
    * Returns the size of used memory in bytes.
    */
-  long getUsed() {
+  public long getUsed() {
     return used;
   }
 

--- a/core/src/main/java/org/apache/spark/memory/TaskMemoryManager.java
+++ b/core/src/main/java/org/apache/spark/memory/TaskMemoryManager.java
@@ -98,6 +98,10 @@ public class TaskMemoryManager {
 
   private final long taskAttemptId;
 
+  public long getTaskAttemptId() {
+    return taskAttemptId;
+  }
+
   /**
    * Tracks whether we're in-heap or off-heap. For off-heap, we short-circuit most of these methods
    * without doing any masking or lookups. Since this branching should be well-predicted by the JIT,

--- a/core/src/main/scala/org/apache/spark/Aggregator.scala
+++ b/core/src/main/scala/org/apache/spark/Aggregator.scala
@@ -39,6 +39,9 @@ case class Aggregator[K, V, C] (
       context: TaskContext): Iterator[(K, C)] = {
     val combiners = new ExternalAppendOnlyMap[K, V, C](createCombiner, mergeValue, mergeCombiners)
     combiners.insertAll(iter)
+    if (SparkEnv.get.conf.getBoolean("spark.shuffle.spillAfterRead", false)) {
+      combiners.spill()
+    }
     updateMetrics(context, combiners)
     combiners.iterator
   }
@@ -48,6 +51,9 @@ case class Aggregator[K, V, C] (
       context: TaskContext): Iterator[(K, C)] = {
     val combiners = new ExternalAppendOnlyMap[K, C, C](identity, mergeCombiners, mergeCombiners)
     combiners.insertAll(iter)
+    if (SparkEnv.get.conf.getBoolean("spark.shuffle.spillAfterRead", false)) {
+      combiners.spill()
+    }
     updateMetrics(context, combiners)
     combiners.iterator
   }

--- a/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
@@ -103,6 +103,9 @@ private[spark] class BlockStoreShuffleReader[K, C](
         val sorter =
           new ExternalSorter[K, C, C](context, ordering = Some(keyOrd), serializer = dep.serializer)
         sorter.insertAll(aggregatedIter)
+        if (SparkEnv.get.conf.getBoolean("spark.shuffle.spillAfterRead", false)) {
+          sorter.spill()
+        }
         context.taskMetrics().incMemoryBytesSpilled(sorter.memoryBytesSpilled)
         context.taskMetrics().incDiskBytesSpilled(sorter.diskBytesSpilled)
         context.taskMetrics().incPeakExecutionMemory(sorter.peakMemoryUsedBytes)

--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
@@ -153,13 +153,11 @@ class ExternalAppendOnlyMap[K, V, C](
 
     while (entries.hasNext) {
       curEntry = entries.next()
-      val estimatedSize = currentMap.estimateSize()
+      val estimatedSize = estimateUsedMemory
       if (estimatedSize > _peakMemoryUsedBytes) {
         _peakMemoryUsedBytes = estimatedSize
       }
-      if (maybeSpill(currentMap, estimatedSize)) {
-        currentMap = new SizeTrackingAppendOnlyMap[K, C]
-      }
+      maybeSpill(estimatedSize)
       currentMap.changeValue(curEntry._1, update)
       addElementsRead()
     }
@@ -178,10 +176,18 @@ class ExternalAppendOnlyMap[K, V, C](
     insertAll(entries.iterator)
   }
 
+  def estimateUsedMemory(): Long = {
+    currentMap.estimateSize()
+  }
+
+  protected def resetAfterSpill(): Unit = {
+    currentMap = new SizeTrackingAppendOnlyMap[K, C]
+  }
+
   /**
    * Sort the existing contents of the in-memory map and spill them to a temporary file on disk.
    */
-  override protected[this] def spill(collection: SizeTracker): Unit = {
+  override protected[this] def spillCollection(): Unit = {
     val (blockId, file) = diskBlockManager.createTempLocalBlock()
     curWriteMetrics = new ShuffleWriteMetrics()
     var writer = blockManager.getDiskWriter(blockId, file, ser, fileBufferSize, curWriteMetrics)

--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
@@ -534,6 +534,13 @@ class ExternalAppendOnlyMap[K, V, C](
 
   /** Convenience function to hash the given (K, C) pair by the key. */
   private def hashKey(kc: (K, C)): Int = ExternalAppendOnlyMap.hash(kc._1)
+
+  /**
+   * To prevent debug code from printing out the contents of the iterator, and destroying the data
+   */
+  override def toString(): String = {
+    getClass().getSimpleName + "@" + System.identityHashCode(this)
+  }
 }
 
 private[spark] object ExternalAppendOnlyMap {

--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
@@ -243,7 +243,7 @@ private[spark] class ExternalSorter[K, V, C](
    * @param collection whichever collection we're using (map or buffer)
    */
   override protected[this] def spillCollection(): Unit = {
-    if(usingMap) {
+    if (usingMap) {
       spillCollection(map)
     } else {
       spillCollection(buffer)

--- a/core/src/main/scala/org/apache/spark/util/collection/Spillable.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/Spillable.scala
@@ -37,16 +37,16 @@ private[spark] trait Spillable[C] extends Logging {
   protected def resetAfterSpill(): Unit
 
   /**
-    * return an estimate of the current memory used by the collection.
-    *
-    * Note this is *not* the same as the memory requested from the memory manager, for two reasons:
-    * (1) If we allow the collection to use some initial amount of memory that is untracked, that
-    * should still be reported here. (which would lead to this amount being larger than what is
-    * tracked by the memory manager.)
-    * (2) If we've just requested a large increase in memory from the memory manager, but aren't
-    * actually *using* that memory yet, we will not report it here (which would lead to this amount
-    * being smaller than what is tracked by the memory manager.)
-    */
+   * Return an estimate of the current memory used by the collection.
+   *
+   * Note this is *not* the same as the memory requested from the memory manager, for two reasons:
+   * (1) If we allow the collection to use some initial amount of memory that is untracked, that
+   * should still be reported here. (which would lead to this amount being larger than what is
+   * tracked by the memory manager.)
+   * (2) If we've just requested a large increase in memory from the memory manager, but aren't
+   * actually *using* that memory yet, we will not report it here (which would lead to this amount
+   * being smaller than what is tracked by the memory manager.)
+   */
   def estimateUsedMemory(): Long
 
   /**
@@ -176,12 +176,12 @@ private[spark] trait Spillable[C] extends Logging {
 }
 
 /**
-  * A light-wrapper around Spillables to implement MemoryConsumer, just so that
-  * they can be tracked and logged in TaskMemoryManager.
-  *
-  * Note that this does *not* give cooperative memory management for Spillables, its just to
-  * make debug logs clearly on memory usage.
-  */
+ * A light-wrapper around Spillables to implement MemoryConsumer, just so that
+ * they can be tracked and logged in TaskMemoryManager.
+ *
+ * Note that this does *not* give cooperative memory management for Spillables, its just to
+ * make debug logs clearly on memory usage.
+ */
 class SpillableMemoryConsumer(val sp: Spillable[_], val taskMM: TaskMemoryManager)
     extends MemoryConsumer(taskMM) with Logging {
   def spill(size: Long, trigger: MemoryConsumer): Long = {

--- a/core/src/main/scala/org/apache/spark/util/collection/Spillable.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/Spillable.scala
@@ -63,13 +63,17 @@ private[spark] trait Spillable[C] extends Logging {
   }
 
   final def spill(currentMemory: Long): Unit = {
-    _spillCount += 1
-    logSpillage(currentMemory)
-    spillCollection()
-    _elementsRead = 0
-    _memoryBytesSpilled += currentMemory
-    releaseMemory()
-    resetAfterSpill()
+    if (_elementsRead == 0) {
+      logDebug(s"Skipping spill since ${this} is empty")
+    } else {
+      _spillCount += 1
+      logSpillage(currentMemory)
+      spillCollection()
+      _elementsRead = 0
+      _memoryBytesSpilled += currentMemory
+      releaseMemory()
+      resetAfterSpill()
+    }
   }
 
   // Number of elements read from input since last spill

--- a/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
@@ -373,7 +373,7 @@ abstract class ShuffleSuite extends SparkFunSuite with Matchers with LocalSparkC
     }
 
     val reader = manager.getReader[Int, Int](shuffleHandle, 0, 1,
-      new TaskContextImpl(1, 0, 2L, 0, taskMemoryManager, new Properties, metricsSystem, false,
+      new TaskContextImpl(1, 0, 2L, 0, taskMemoryManager, new Properties, metricsSystem,
         InternalAccumulator.create(sc)))
     val readData = reader.read().toIndexedSeq
     assert(readData === data1.toIndexedSeq || readData === data2.toIndexedSeq)
@@ -389,6 +389,7 @@ abstract class ShuffleSuite extends SparkFunSuite with Matchers with LocalSparkC
       .set("spark.shuffle.sort.bypassMergeThreshold", "0")
       // for relocation, so we can use ShuffleExternalSorter
       .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+      .set("spark.shuffle.spillAfterRead", "true")
     sc = new SparkContext("local", "test", myConf)
     val N = 2e6.toInt
     val p = new org.apache.spark.HashPartitioner(10)
@@ -413,6 +414,7 @@ abstract class ShuffleSuite extends SparkFunSuite with Matchers with LocalSparkC
       // pretty small, but otherwise its too easy for the structures to claim they are using 0
       // memory in these small tests
       .set("spark.shuffle.spill.initialMemoryThreshold", "5000")
+      .set("spark.shuffle.spillAfterRead", "true")
     sc = new SparkContext("local", "test", myConf)
     val N = 2e6.toInt
     val p = new org.apache.spark.HashPartitioner(10)

--- a/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
@@ -385,7 +385,7 @@ abstract class ShuffleSuite extends SparkFunSuite with Matchers with LocalSparkC
     val myConf = conf.clone()
       .set("spark.shuffle.memoryFraction", "0.01")
       .set("spark.memory.useLegacyMode", "true")
-      .set("spark.testing.memory", "500000000") //~500MB
+      .set("spark.testing.memory", "500000000") // ~500MB
       .set("spark.shuffle.sort.bypassMergeThreshold", "0")
       // for relocation, so we can use ShuffleExternalSorter
       .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
@@ -394,8 +394,8 @@ abstract class ShuffleSuite extends SparkFunSuite with Matchers with LocalSparkC
     val N = 2e6.toInt
     val p = new org.apache.spark.HashPartitioner(10)
     val d = sc.parallelize(1 to N, 10).map { x => (x % 10000) -> x.toLong }
-    // now we use an aggregator, but that still produces enough data that we need to spill on the read-side
-    // (this one is ridiculous, we shouldn't aggregate at all, but its just an easy
+    // now we use an aggregator, but that still produces enough data that we need to spill on the
+    // read-side (this one is ridiculous, we shouldn't aggregate at all, but its just an easy
     // way to trigger lots of memory use on the shuffle-read side)
    val d2: RDD[(Int, Seq[Long])] = d.aggregateByKey(Seq[Long](), 5) (
       { case (list, next) => list :+ next },
@@ -409,7 +409,7 @@ abstract class ShuffleSuite extends SparkFunSuite with Matchers with LocalSparkC
     val myConf = conf.clone()
       .set("spark.shuffle.memoryFraction", "0.01")
       .set("spark.memory.useLegacyMode", "true")
-      .set("spark.testing.memory", "500000000") //~500MB
+      .set("spark.testing.memory", "500000000") // ~500MB
       .set("spark.shuffle.sort.bypassMergeThreshold", "0")
       // pretty small, but otherwise its too easy for the structures to claim they are using 0
       // memory in these small tests

--- a/core/src/test/scala/org/apache/spark/util/collection/ExternalAppendOnlyMapSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/ExternalAppendOnlyMapSuite.scala
@@ -418,4 +418,24 @@ class ExternalAppendOnlyMapSuite extends SparkFunSuite with LocalSparkContext {
     }
   }
 
+  test("SPARK-14560 -- force spill an empty collection") {
+    // You should be able to force-spill a collection any time -- even if there is nothing
+    // to spill (eg., nothing has been added, or it just spilled)
+    val conf = createSparkConf(loadDefaults = true)
+    sc = new SparkContext("local", "test", conf)
+    val map = createExternalMap[Int]
+    map.spill()
+    assert(map.iterator.toIndexedSeq == IndexedSeq())
+
+    val map2 = createExternalMap[Int]
+    val elements = IndexedSeq((1, 1), (2, 2), (5, 5))
+    val expected = elements.map { case (k, v) => k -> ArrayBuffer(v)}
+    map2.insertAll(elements.iterator)
+    // say the first spill is natural due to the collection being full
+    map2.spill()
+    // and then we spill again, even though we haven't added anything else, because something
+    // external requests us to free memory
+    map2.spill()
+    assert(map2.iterator.toIndexedSeq == expected)
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This adds a new configuration, `spark.shuffle.spillAfterRead`, which can be used to force `Spillable`s to spill their contents after all records have been inserted.  The default is false, to keep previous behavior and avoid a performance penalty when unnecessary.  However this needed in cases to prevent an OOM when one `Spillable` acquires all of the execution memory available for a task, thus leaving no memory available for any other operations in the same task.

This also required some small refactoring of `Spillable` to support a forced spill from an external request (as opposed to not having enough memory as records are added).

I was initially hoping to limit the places where we needed to spill -- I thought that it would only be in a `ShuffleMapTask` which also does a shuffle-read. In that case there is clearly a `Spillable` on both the shuffle-read and shuffle-write side.  However, I realized this wasn't sufficient -- there are other cases when you can have multiple `Spillable`s, eg if you use a common partitioner across several aggregations, which will get pipelined into one stage.

This also makes `Spillable`s register themselves as `MemoryConsumer`s with the `TaskMemoryManager`.  Note that this does _not_ lead to cooperative memory management for `Spillable`s -- the only reason for this is to improve the logging around memory usage.  Before this change, there would be messages like:

```
INFO memory.TaskMemoryManager: 217903352 bytes of memory were used by task 2109 but are not associated with specific consumers
```

instead, with this change the logs report the memory as being associated with the corresponing `Spillable`
## How was this patch tested?
- unit tests were added to reproduce the original problem
- jenkins unit tests
- also independently ran some large workloads which were consistently getting an OOM before this change, which now pass
