### PR TITLE
[SPARK-14627][SQL] Avoid shilfting encoder when delta is zero

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoder.scala
@@ -339,9 +339,13 @@ case class ExpressionEncoder[T](
    * Returns a new encoder with input columns shifted by `delta` ordinals
    */
   def shift(delta: Int): ExpressionEncoder[T] = {
-    copy(deserializer = deserializer transform {
-      case r: BoundReference => r.copy(ordinal = r.ordinal + delta)
-    })
+    if (delta == 0) {
+      this
+    } else {
+      copy(deserializer = deserializer transform {
+        case r: BoundReference => r.copy(ordinal = r.ordinal + delta)
+      })
+    }
   }
 
   protected val attrs = serializer.flatMap(_.collect {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TypedAggregateExpression.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TypedAggregateExpression.scala
@@ -85,9 +85,6 @@ case class TypedAggregateExpression(
     .resolve(aggBufferAttributes, OuterScopes.outerScopes)
     .bind(aggBufferAttributes)
 
-  val bEncoderForMutableAggBuffer = bEncoder.shift(mutableAggBufferOffset)
-  val bEncoderForInputAggBuffer = bEncoder.shift(inputAggBufferOffset)
-
   // Note: although this simply copies aggBufferAttributes, this common code can not be placed
   // in the superclass because that will lead to initialization ordering issues.
   override val inputAggBufferAttributes: Seq[AttributeReference] =
@@ -121,7 +118,7 @@ case class TypedAggregateExpression(
 
   override def update(buffer: MutableRow, input: InternalRow): Unit = {
     val inputA = boundA.fromRow(input)
-    val currentB = bEncoderForMutableAggBuffer.fromRow(buffer)
+    val currentB = bEncoder.shift(mutableAggBufferOffset).fromRow(buffer)
     val merged = aggregator.reduce(currentB, inputA)
     val returned = bEncoder.toRow(merged)
 
@@ -129,8 +126,8 @@ case class TypedAggregateExpression(
   }
 
   override def merge(buffer1: MutableRow, buffer2: InternalRow): Unit = {
-    val b1 = bEncoderForMutableAggBuffer.fromRow(buffer1)
-    val b2 = bEncoderForInputAggBuffer.fromRow(buffer2)
+    val b1 = bEncoder.shift(mutableAggBufferOffset).fromRow(buffer1)
+    val b2 = bEncoder.shift(inputAggBufferOffset).fromRow(buffer2)
     val merged = aggregator.merge(b1, b2)
     val returned = bEncoder.toRow(merged)
 
@@ -138,7 +135,7 @@ case class TypedAggregateExpression(
   }
 
   override def eval(buffer: InternalRow): Any = {
-    val b = bEncoderForMutableAggBuffer.fromRow(buffer)
+    val b = bEncoder.shift(mutableAggBufferOffset).fromRow(buffer)
     val result = cEncoder.toRow(aggregator.finish(b))
     dataType match {
       case _: StructType => result


### PR DESCRIPTION
## What changes were proposed in this pull request?

JIRA: https://issues.apache.org/jira/browse/SPARK-14627

Every time we call `TypedAggregateExpression.update` method, we call encoder's `shift` method. As shift method will copy encoder and underlying `BoundReference`, we should prepare the shifted encoder in advance, instead of calling `shift` method every time.

BTW, we can also slightly improve encoder's `shift` method to return itself when shift delta is zero.
## How was this patch tested?

Existing tests.
